### PR TITLE
feat(workspace): compose plugin fragments

### DIFF
--- a/apps/boring-macro-v2/src/plugins/macro/catalogs.ts
+++ b/apps/boring-macro-v2/src/plugins/macro/catalogs.ts
@@ -1,4 +1,4 @@
-import type { CreateDataCatalogOutputsOptions, ExplorerRow } from "@boring/workspace"
+import type { CreateExplorerPluginOptions, ExplorerRow } from "@boring/workspace"
 import { createMacroSeriesAdapter } from "./data/macroSeriesAdapter"
 import { FREQ_LABELS } from "./data/macroSeriesUi"
 
@@ -19,21 +19,18 @@ export const MACRO_FACETS = [
   },
 ]
 
-export function createMacroSeriesDataCatalogOptions(
+export function createMacroSeriesExplorerOptions(
   onSelect: (row: ExplorerRow) => void,
-): CreateDataCatalogOutputsOptions {
+): CreateExplorerPluginOptions {
   return {
     id: "macro-series",
     label: "Data",
     adapter: macroAdapter,
     facets: MACRO_FACETS,
     groupBy: "frequency",
-    onSelect,
-    leftTabId: "macro-series",
-    leftTabTitle: "Data",
-    catalogId: "macro-series",
-    catalogLabel: "Macro Series",
-    includeVisualizationPanel: false,
+    onActivate: onSelect,
+    leftTab: { id: "macro-series", title: "Data" },
+    catalog: { id: "macro-series", label: "Macro Series" },
     emptyState: "No series match",
     searchPlaceholder: "Search...",
     getDragPayload: (row) => ({ mimeType: "text/series-id", value: row.id }),

--- a/apps/boring-macro-v2/src/plugins/macro/index.tsx
+++ b/apps/boring-macro-v2/src/plugins/macro/index.tsx
@@ -1,14 +1,15 @@
 "use client"
 import type { ComponentType } from "react"
 import {
-  appendDataCatalogOutputs,
+  composePlugins,
+  createExplorerPlugin,
   defineFrontPlugin,
   type ExplorerRow,
   type WorkspaceFrontPlugin,
 } from "@boring/workspace"
 import { LineChart, Search, TrendingUp, Presentation } from "lucide-react"
 import { chartCanvasPanel, deckPanel } from "./panels"
-import { createMacroSeriesDataCatalogOptions } from "./catalogs"
+import { createMacroSeriesExplorerOptions } from "./catalogs"
 import { macroSurfaceOutputs } from "./surfaceResolver"
 import { MACRO_PLUGIN_ID } from "./constants"
 import { openSeriesPane } from "./data/macroSeriesUi"
@@ -70,17 +71,28 @@ export const macroShellOptions = {
 export function makeMacroClientPlugin(
   onSeriesSelect: (row: ExplorerRow) => void = (row) => openSeriesPane(row.id),
 ): WorkspaceFrontPlugin {
-  const plugin = defineFrontPlugin({
-    id: MACRO_PLUGIN_ID,
-    label: "Macro",
+  const macroPanelsPlugin = defineFrontPlugin({
+    id: `${MACRO_PLUGIN_ID}:panels`,
     outputs: [
       { type: "panel", panel: chartCanvasPanel },
       { type: "panel", panel: deckPanel },
-      ...macroSurfaceOutputs,
     ],
   })
 
-  return appendDataCatalogOutputs(plugin, createMacroSeriesDataCatalogOptions(onSeriesSelect))
+  const macroSurfacesPlugin = defineFrontPlugin({
+    id: `${MACRO_PLUGIN_ID}:surfaces`,
+    outputs: macroSurfaceOutputs,
+  })
+
+  const macroSeriesCatalogPlugin = createExplorerPlugin(
+    createMacroSeriesExplorerOptions(onSeriesSelect),
+  )
+
+  return composePlugins({
+    id: MACRO_PLUGIN_ID,
+    label: "Macro",
+    plugins: [macroPanelsPlugin, macroSurfacesPlugin, macroSeriesCatalogPlugin],
+  })
 }
 
 export const macroPlugin = makeMacroClientPlugin()

--- a/packages/workspace/src/__tests__/public-api.test.ts
+++ b/packages/workspace/src/__tests__/public-api.test.ts
@@ -35,6 +35,13 @@ describe("@boring/workspace public API", () => {
   })
 
   describe("plugins", () => {
+    it("exports explorer plugin factories", () => {
+      expect(api.createExplorerPlugin).toBeDefined()
+      expect(api.createExplorerOutputs).toBeDefined()
+      expect(api.ExplorerView).toBeDefined()
+      expect(api.EXPLORER_PLUGIN_ID).toBe("explorer")
+    })
+
     it("exports data catalog plugin factories", () => {
       expect(api.createDataCatalogPlugin).toBeDefined()
       expect(api.createDataCatalogOutputs).toBeDefined()
@@ -67,6 +74,7 @@ describe("@boring/workspace public API", () => {
       expect(api.CommandRegistry).toBeDefined()
       expect(api.CatalogRegistry).toBeDefined()
       expect(api.bootstrap).toBeDefined()
+      expect(api.composePlugins).toBeDefined()
     })
 
     it("exports registry hooks and provider", () => {

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -7,11 +7,13 @@
 
 // Plugin model
 export {
+  composePlugins,
   defineFrontPlugin,
   bootstrap,
   PluginError,
 } from "./shared/plugins"
 export type {
+  ComposePluginsOptions,
   PluginErrorKind,
   BootstrapOptions,
   BootstrapResult,
@@ -52,13 +54,37 @@ export {
   PluginErrorProvider,
   usePluginErrors,
 } from "./front/plugin"
-export type { CatalogRegistryOptions, PluginError as PluginContributionError } from "./front/plugin"
+export type {
+  CatalogRegistryOptions,
+  PluginError as PluginContributionError,
+} from "./front/plugin"
 export {
   filesystemPlugin,
   emitFilesystemAgentFileChange,
   useAutoOpenAgentFiles,
 } from "./plugins/filesystemPlugin"
 export type { UseAutoOpenAgentFilesOptions } from "./plugins/filesystemPlugin"
+export {
+  createExplorerPlugin,
+  createExplorerOutputs,
+  ExplorerView,
+  EXPLORER_PLUGIN_ID,
+} from "./plugins/explorerPlugin"
+export type {
+  CreateExplorerOutputsOptions,
+  CreateExplorerPluginOptions,
+  ExplorerCatalogConfig,
+  ExplorerContributionConfig,
+  ExplorerMode,
+  ExplorerSection,
+  ExplorerSectionFilter,
+  ExplorerViewProps,
+  SectionedExplorerAdapter,
+  SectionedExplorerFacetArgs,
+  SectionedExplorerProps,
+  SectionedExplorerSearchArgs,
+  SectionedExplorerSectionsArgs,
+} from "./plugins/explorerPlugin"
 export {
   appendDataCatalogOutputs,
   createDataCatalogOpenHandler,
@@ -185,8 +211,14 @@ export { EmptyPane } from "./front/chrome/empty-pane/EmptyPane"
 export type { EmptyPaneProps } from "./front/chrome/empty-pane/EmptyPane"
 export { CodeEditorPane } from "./plugins/filesystemPlugin/code-editor/CodeEditorPane"
 export type { CodeEditorPaneProps } from "./plugins/filesystemPlugin/code-editor/CodeEditorPane"
-export { FileTreePane, FileTreeView } from "./plugins/filesystemPlugin/file-tree/FileTreeView"
-export type { FileTreePaneProps, FileTreeViewProps } from "./plugins/filesystemPlugin/file-tree/FileTreeView"
+export {
+  FileTreePane,
+  FileTreeView,
+} from "./plugins/filesystemPlugin/file-tree/FileTreeView"
+export type {
+  FileTreePaneProps,
+  FileTreeViewProps,
+} from "./plugins/filesystemPlugin/file-tree/FileTreeView"
 export { MarkdownEditorPane } from "./plugins/filesystemPlugin/markdown-editor/MarkdownEditorPane"
 export type { MarkdownEditorPaneProps } from "./plugins/filesystemPlugin/markdown-editor/MarkdownEditorPane"
 export { definePanel } from "./front/registry/types"
@@ -226,7 +258,11 @@ export type {
 export { createBridge } from "./front/bridge"
 export { createBridgeClient } from "./front/bridge"
 export { postUiCommand } from "./front/bridge"
-export type { BridgeClient, BridgeClientOptions, UIStatePut } from "./front/bridge"
+export type {
+  BridgeClient,
+  BridgeClientOptions,
+  UIStatePut,
+} from "./front/bridge"
 export type {
   DispatchContext,
   UiCommand,
@@ -258,10 +294,16 @@ export type { PanelErrorBoundaryProps } from "./front/components/PanelErrorBound
 export { CodeEditor } from "./plugins/filesystemPlugin/code-editor/CodeEditor"
 export type { CodeEditorProps } from "./plugins/filesystemPlugin/code-editor/CodeEditor"
 export { FileTree } from "./plugins/filesystemPlugin/file-tree/FileTree"
-export type { FileTreeProps, FileTreeNode } from "./plugins/filesystemPlugin/file-tree/FileTree"
+export type {
+  FileTreeProps,
+  FileTreeNode,
+} from "./plugins/filesystemPlugin/file-tree/FileTree"
 export { MarkdownEditor } from "./plugins/filesystemPlugin/markdown-editor/MarkdownEditor"
 export type { MarkdownEditorProps } from "./plugins/filesystemPlugin/markdown-editor/MarkdownEditor"
-export { DataExplorer, useExplorerState } from "./front/components/DataExplorer"
+export {
+  DataExplorer,
+  useExplorerState,
+} from "./front/components/DataExplorer"
 export type {
   DataExplorerProps,
   UseExplorerStateOptions,
@@ -278,7 +320,10 @@ export type {
   DragPayload,
 } from "./front/components/DataExplorer"
 export { SessionList } from "./front/components/SessionList"
-export type { SessionListProps, SessionItem } from "./front/components/SessionList"
+export type {
+  SessionListProps,
+  SessionItem,
+} from "./front/components/SessionList"
 
 // Declarative chat/workbench chrome
 export { SessionBrowser } from "./front/chrome/session-list/SessionBrowser"

--- a/packages/workspace/src/plugins/explorerPlugin/__tests__/explorerPlugin.test.tsx
+++ b/packages/workspace/src/plugins/explorerPlugin/__tests__/explorerPlugin.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import {
+  createExplorerOutputs,
+  createExplorerPlugin,
+  ExplorerView,
+  type SectionedExplorerAdapter,
+} from "../index"
+import type { ExplorerAdapter, ExplorerRow } from "../../../front/components/DataExplorer"
+
+const rows: ExplorerRow[] = [
+  { id: "GDPC1", title: "Real GDP", group: "Q", leading: { code: "Q" } },
+]
+
+const adapter: ExplorerAdapter = {
+  async search() {
+    return { items: rows, total: rows.length, hasMore: false }
+  },
+  async fetchFacets() {
+    return { frequency: [{ value: "Q", count: 1 }] }
+  },
+}
+
+describe("explorerPlugin", () => {
+  it("creates left-tab and catalog outputs for grouped explorer usage", () => {
+    const onSelect = vi.fn()
+    const outputs = createExplorerOutputs({
+      id: "macro-series",
+      label: "Data",
+      mode: "grouped",
+      adapter,
+      groupBy: "frequency",
+      facets: [{ key: "frequency", label: "Frequency" }],
+      leftTab: { id: "macro-series", title: "Data" },
+      catalog: { id: "macro-series", label: "Macro Series", onSelect },
+    })
+
+    expect(outputs.map((output) => output.type)).toEqual(["left-tab", "catalog"])
+    expect(outputs[0]).toEqual(expect.objectContaining({ type: "left-tab", id: "macro-series", title: "Data" }))
+    expect(outputs[1]).toEqual(
+      expect.objectContaining({
+        type: "catalog",
+        catalog: expect.objectContaining({ id: "macro-series", label: "Macro Series" }),
+      }),
+    )
+  })
+
+  it("creates a plugin from explorer outputs", () => {
+    const plugin = createExplorerPlugin({
+      id: "macro-series",
+      label: "Data",
+      adapter,
+      catalog: { id: "macro-series", label: "Macro Series" },
+    })
+
+    expect(plugin.id).toBe("macro-series")
+    expect(plugin.outputs?.map((output) => output.type)).toEqual(["left-tab", "catalog"])
+  })
+
+  it("passes scoped section filters to sectioned adapters", async () => {
+    const searchSection = vi.fn(async (_sectionId, args) => ({
+      items: args.filters.status?.includes("pending")
+        ? [{ id: "doc-1", title: "Pending doc" }]
+        : [{ id: "doc-2", title: "Any doc" }],
+      total: 1,
+      hasMore: false,
+    }))
+    const sections = vi.fn(async () => [
+      {
+        id: "sources",
+        title: "Sources",
+        defaultExpanded: true,
+        filters: [
+          {
+            key: "status",
+            label: "Status",
+            values: [{ value: "pending", count: 1 }],
+          },
+        ],
+      },
+    ])
+    const sectionedAdapter: SectionedExplorerAdapter = {
+      sections,
+      searchSection,
+    }
+
+    render(<ExplorerView mode="sectioned" sectionedAdapter={sectionedAdapter} />)
+
+    expect(await screen.findByText("Any doc")).toBeInTheDocument()
+    fireEvent.click(screen.getByText("pending"))
+
+    await waitFor(() => expect(screen.getByText("Pending doc")).toBeInTheDocument())
+    expect(searchSection).toHaveBeenLastCalledWith(
+      "sources",
+      expect.objectContaining({ filters: { status: ["pending"] } }),
+    )
+    expect(sections).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/workspace/src/plugins/explorerPlugin/index.tsx
+++ b/packages/workspace/src/plugins/explorerPlugin/index.tsx
@@ -1,0 +1,683 @@
+"use client"
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type DragEvent,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react"
+import { ChevronDownIcon, ChevronRightIcon } from "lucide-react"
+import { DataExplorer } from "../../front/components/DataExplorer"
+import type {
+  Badge,
+  DataExplorerProps,
+  DragPayload,
+  ExplorerAdapter,
+  ExplorerRow,
+  FacetConfig,
+  FacetValue,
+  Facets,
+  SearchResult,
+} from "../../front/components/DataExplorer"
+import { cn } from "../../front/lib/utils"
+import { Input } from "../../front/components/ui/input"
+import { definePanel } from "../../front/registry/types"
+import type { PaneProps, PanelConfig } from "../../front/registry/types"
+import { defineFrontPlugin } from "../../shared/plugins/defineFrontPlugin"
+import type { CatalogConfig, LeftTabParams, PluginOutput } from "../../shared/plugins/types"
+import type { WorkspaceFrontPlugin } from "../../shared/plugins/defineFrontPlugin"
+
+export const EXPLORER_PLUGIN_ID = "explorer"
+
+export type ExplorerMode = "flat" | "grouped" | "sectioned"
+
+export interface ExplorerSectionFilter extends FacetConfig {
+  values?: FacetValue[]
+}
+
+export interface ExplorerSection {
+  id: string
+  title: string
+  subtitle?: string
+  count?: number
+  filters?: ExplorerSectionFilter[]
+  defaultExpanded?: boolean
+}
+
+export interface SectionedExplorerSectionsArgs {
+  query: string
+  globalFilters: Record<string, string[]>
+  signal?: AbortSignal
+}
+
+export interface SectionedExplorerSearchArgs {
+  query: string
+  globalFilters: Record<string, string[]>
+  filters: Record<string, string[]>
+  limit: number
+  offset: number
+  signal?: AbortSignal
+}
+
+export interface SectionedExplorerFacetArgs {
+  query: string
+  globalFilters: Record<string, string[]>
+  filters: Record<string, string[]>
+  signal?: AbortSignal
+}
+
+export interface SectionedExplorerAdapter {
+  sections(args: SectionedExplorerSectionsArgs): Promise<ExplorerSection[]>
+  searchSection(sectionId: string, args: SectionedExplorerSearchArgs): Promise<SearchResult>
+  fetchSectionFacets?(sectionId: string, args: SectionedExplorerFacetArgs): Promise<Facets>
+}
+
+export interface SectionedExplorerProps {
+  adapter: SectionedExplorerAdapter
+  onActivate?: (row: ExplorerRow) => void
+  getDragPayload?: (row: ExplorerRow) => DragPayload | null | undefined
+  emptyState?: ReactNode
+  searchPlaceholder?: string
+  searchable?: boolean
+  query?: string
+  pageSize?: number
+  className?: string
+}
+
+export type ExplorerViewProps =
+  | (Omit<DataExplorerProps, "groupBy"> & {
+      mode?: "flat"
+      groupBy?: never
+      sectionedAdapter?: never
+    })
+  | (DataExplorerProps & {
+      mode: "grouped"
+      groupBy: string
+      sectionedAdapter?: never
+    })
+  | (Omit<SectionedExplorerProps, "adapter"> & {
+      mode: "sectioned"
+      adapter?: never
+      sectionedAdapter: SectionedExplorerAdapter
+      facets?: never
+      groupBy?: never
+    })
+
+export interface ExplorerContributionConfig {
+  id?: string
+  title?: string
+  label?: string
+  icon?: PanelConfig["icon"]
+}
+
+export interface ExplorerCatalogConfig {
+  id?: string
+  label?: string
+  onSelect?: (row: ExplorerRow) => void
+}
+
+export interface CreateExplorerOutputsOptions {
+  id: string
+  label?: string
+  mode?: ExplorerMode
+  adapter?: ExplorerAdapter
+  sectionedAdapter?: SectionedExplorerAdapter
+  facets?: FacetConfig[]
+  groupBy?: string
+  onActivate?: (row: ExplorerRow) => void
+  getDragPayload?: (row: ExplorerRow) => DragPayload | null | undefined
+  emptyState?: ReactNode
+  searchPlaceholder?: string
+  searchable?: boolean
+  query?: string
+  pageSize?: number
+  debounceMs?: number
+  className?: string
+  leftTab?: false | ExplorerContributionConfig
+  panel?: false | ExplorerContributionConfig
+  catalog?: false | ExplorerCatalogConfig
+  source?: PanelConfig["source"]
+}
+
+export interface CreateExplorerPluginOptions extends CreateExplorerOutputsOptions {
+  pluginId?: string
+}
+
+function resolveMode(options: CreateExplorerOutputsOptions): ExplorerMode {
+  if (options.mode) return options.mode
+  return options.sectionedAdapter ? "sectioned" : options.groupBy ? "grouped" : "flat"
+}
+
+function explorerViewProps(options: CreateExplorerOutputsOptions): ExplorerViewProps {
+  const mode = resolveMode(options)
+  if (mode === "sectioned") {
+    if (!options.sectionedAdapter) {
+      throw new Error(`explorer "${options.id}" requires sectionedAdapter for sectioned mode`)
+    }
+    return {
+      mode,
+      sectionedAdapter: options.sectionedAdapter,
+      onActivate: options.onActivate,
+      getDragPayload: options.getDragPayload,
+      emptyState: options.emptyState,
+      searchPlaceholder: options.searchPlaceholder,
+      searchable: options.searchable,
+      query: options.query,
+      pageSize: options.pageSize,
+      className: options.className,
+    }
+  }
+
+  if (!options.adapter) {
+    throw new Error(`explorer "${options.id}" requires adapter for ${mode} mode`)
+  }
+  if (mode === "grouped" && !options.groupBy) {
+    throw new Error(`explorer "${options.id}" requires groupBy for grouped mode`)
+  }
+
+  return {
+    mode,
+    adapter: options.adapter,
+    facets: options.facets,
+    groupBy: mode === "grouped" ? options.groupBy : undefined,
+    onActivate: options.onActivate,
+    getDragPayload: options.getDragPayload,
+    emptyState: options.emptyState,
+    searchPlaceholder: options.searchPlaceholder,
+    searchable: options.searchable,
+    query: options.query,
+    pageSize: options.pageSize,
+    debounceMs: options.debounceMs,
+    className: options.className,
+  } as ExplorerViewProps
+}
+
+export function ExplorerView(props: ExplorerViewProps) {
+  if (props.mode === "sectioned") {
+    const {
+      sectionedAdapter,
+      mode: _mode,
+      adapter: _adapter,
+      facets: _facets,
+      groupBy: _groupBy,
+      ...rest
+    } = props
+    return <SectionedExplorer adapter={sectionedAdapter} {...rest} />
+  }
+
+  const { mode: _mode, sectionedAdapter: _sectionedAdapter, ...rest } = props
+  return <DataExplorer {...rest} />
+}
+
+export function createExplorerOutputs(options: CreateExplorerOutputsOptions): PluginOutput[] {
+  const outputs: PluginOutput[] = []
+  const label = options.label ?? "Explorer"
+  const viewProps = explorerViewProps(options)
+  const source = options.source ?? "app"
+
+  function ExplorerLeftTab({ params, className }: PaneProps<LeftTabParams>) {
+    return (
+      <ExplorerView
+        {...viewProps}
+        query={params?.searchQuery ?? params?.query ?? viewProps.query}
+        className={className ?? viewProps.className ?? "h-full"}
+      />
+    )
+  }
+
+  function ExplorerPanel({ className }: PaneProps) {
+    return <ExplorerView {...viewProps} className={className ?? viewProps.className ?? "h-full"} />
+  }
+
+  if (options.leftTab !== false) {
+    const leftTab = options.leftTab ?? {}
+    outputs.push({
+      type: "left-tab",
+      id: leftTab.id ?? options.id,
+      title: leftTab.title ?? leftTab.label ?? label,
+      icon: leftTab.icon,
+      component: ExplorerLeftTab,
+      source,
+      chromeless: true,
+    })
+  }
+
+  if (options.panel) {
+    const panel = definePanel({
+      id: options.panel.id ?? `${options.id}-panel`,
+      title: options.panel.title ?? options.panel.label ?? label,
+      icon: options.panel.icon,
+      component: ExplorerPanel,
+      placement: "center",
+      source,
+    })
+    outputs.push({ type: "panel", panel })
+  }
+
+  if (options.catalog) {
+    if (!options.adapter) {
+      throw new Error(`explorer "${options.id}" catalog requires a flat/grouped adapter`)
+    }
+    const catalog: CatalogConfig = {
+      id: options.catalog.id ?? options.id,
+      label: options.catalog.label ?? label,
+      adapter: options.adapter,
+      onSelect: options.catalog.onSelect ?? options.onActivate ?? (() => {}),
+    }
+    outputs.push({ type: "catalog", catalog })
+  }
+
+  return outputs
+}
+
+export function createExplorerPlugin(options: CreateExplorerPluginOptions): WorkspaceFrontPlugin {
+  return defineFrontPlugin({
+    id: options.pluginId ?? options.id,
+    label: options.label ?? "Explorer",
+    outputs: createExplorerOutputs(options),
+  })
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === "AbortError"
+}
+
+function SectionedExplorer({
+  adapter,
+  onActivate,
+  getDragPayload,
+  emptyState = "No results",
+  searchPlaceholder = "Search…",
+  searchable = true,
+  query: controlledQuery,
+  pageSize = 50,
+  className,
+}: SectionedExplorerProps) {
+  const isControlled = controlledQuery !== undefined
+  const [query, setQuery] = useState(controlledQuery ?? "")
+  const [sections, setSections] = useState<ExplorerSection[]>([])
+  const [sectionItems, setSectionItems] = useState<Record<string, ExplorerRow[]>>({})
+  const [sectionTotals, setSectionTotals] = useState<Record<string, number>>({})
+  const [sectionHasMore, setSectionHasMore] = useState<Record<string, boolean>>({})
+  const [loadingSections, setLoadingSections] = useState(false)
+  const [loadingItems, setLoadingItems] = useState<Record<string, boolean>>({})
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({})
+  const [scopedFilters, setScopedFilters] = useState<Record<string, Record<string, string[]>>>({})
+  const [sectionFacets, setSectionFacets] = useState<Record<string, Facets>>({})
+  const sectionsController = useRef<AbortController | null>(null)
+  const itemControllers = useRef(new Map<string, AbortController>())
+
+  const effectiveQuery = controlledQuery ?? query
+
+  const sectionItemsRef = useRef(sectionItems)
+  sectionItemsRef.current = sectionItems
+  const expandedRef = useRef(expanded)
+  expandedRef.current = expanded
+
+  const loadSectionItems = useCallback(
+    async (sectionId: string, offset: number, append: boolean) => {
+      itemControllers.current.get(sectionId)?.abort()
+      const ctrl = new AbortController()
+      itemControllers.current.set(sectionId, ctrl)
+      setLoadingItems((prev) => ({ ...prev, [sectionId]: true }))
+      try {
+        const filters = scopedFilters[sectionId] ?? {}
+        const result = await adapter.searchSection(sectionId, {
+          query: effectiveQuery,
+          globalFilters: {},
+          filters,
+          limit: pageSize,
+          offset,
+          signal: ctrl.signal,
+        })
+        if (ctrl.signal.aborted) return
+        setSectionItems((prev) => ({
+          ...prev,
+          [sectionId]: append ? [...(prev[sectionId] ?? []), ...result.items] : result.items,
+        }))
+        setSectionTotals((prev) => ({ ...prev, [sectionId]: result.total }))
+        setSectionHasMore((prev) => ({ ...prev, [sectionId]: result.hasMore }))
+      } catch (error) {
+        if (!isAbortError(error)) console.error("Explorer: section search failed", error)
+      } finally {
+        if (itemControllers.current.get(sectionId) === ctrl) {
+          setLoadingItems((prev) => ({ ...prev, [sectionId]: false }))
+        }
+      }
+    },
+    [adapter, effectiveQuery, pageSize, scopedFilters],
+  )
+
+  const loadSectionFacets = useCallback(
+    async (sectionId: string) => {
+      if (!adapter.fetchSectionFacets) return
+      try {
+        const facets = await adapter.fetchSectionFacets(sectionId, {
+          query: effectiveQuery,
+          globalFilters: {},
+          filters: scopedFilters[sectionId] ?? {},
+        })
+        setSectionFacets((prev) => ({ ...prev, [sectionId]: facets }))
+      } catch (error) {
+        if (!isAbortError(error)) console.error("Explorer: section facets failed", error)
+      }
+    },
+    [adapter, effectiveQuery, scopedFilters],
+  )
+
+  const loadSectionItemsRef = useRef(loadSectionItems)
+  const loadSectionFacetsRef = useRef(loadSectionFacets)
+  loadSectionItemsRef.current = loadSectionItems
+  loadSectionFacetsRef.current = loadSectionFacets
+
+  useEffect(() => {
+    sectionsController.current?.abort()
+    const ctrl = new AbortController()
+    sectionsController.current = ctrl
+    setLoadingSections(true)
+    void adapter
+      .sections({ query: effectiveQuery, globalFilters: {}, signal: ctrl.signal })
+      .then((nextSections) => {
+        if (ctrl.signal.aborted) return
+        setSections(nextSections)
+        const defaults: Record<string, boolean> = {}
+        for (const section of nextSections) defaults[section.id] = !!section.defaultExpanded
+        setExpanded(defaults)
+        setSectionItems({})
+        setSectionHasMore({})
+        setSectionTotals({})
+        for (const section of nextSections) {
+          if (section.defaultExpanded) {
+            void loadSectionFacetsRef.current(section.id)
+            void loadSectionItemsRef.current(section.id, 0, false)
+          }
+        }
+      })
+      .catch((error) => {
+        if (!isAbortError(error)) console.error("Explorer: sections failed", error)
+      })
+      .finally(() => {
+        if (sectionsController.current === ctrl) setLoadingSections(false)
+      })
+    return () => ctrl.abort()
+  }, [adapter, effectiveQuery])
+
+  const toggleSection = useCallback(
+    (sectionId: string) => {
+      setExpanded((prev) => {
+        const next = !prev[sectionId]
+        if (next && !(sectionId in sectionItemsRef.current)) {
+          void loadSectionFacets(sectionId)
+          void loadSectionItems(sectionId, 0, false)
+        }
+        return { ...prev, [sectionId]: next }
+      })
+    },
+    [loadSectionFacets, loadSectionItems],
+  )
+
+  const toggleScopedFilter = useCallback(
+    (sectionId: string, key: string, value: string) => {
+      setScopedFilters((prev) => {
+        const sectionFilters = prev[sectionId] ?? {}
+        const current = sectionFilters[key] ?? []
+        const nextValues = current.includes(value)
+          ? current.filter((item) => item !== value)
+          : [...current, value]
+        const nextSectionFilters = { ...sectionFilters }
+        if (nextValues.length) nextSectionFilters[key] = nextValues
+        else delete nextSectionFilters[key]
+        return { ...prev, [sectionId]: nextSectionFilters }
+      })
+      setSectionItems((prev) => ({ ...prev, [sectionId]: [] }))
+    },
+    [],
+  )
+
+  useEffect(() => {
+    for (const sectionId of Object.keys(scopedFilters)) {
+      if (expandedRef.current[sectionId]) {
+        void loadSectionFacets(sectionId)
+        void loadSectionItems(sectionId, 0, false)
+      }
+    }
+  }, [scopedFilters, loadSectionFacets, loadSectionItems])
+
+  const showEmpty = !loadingSections && sections.length === 0
+
+  return (
+    <div className={cn("flex h-full flex-col", className)} data-slot="sectioned-explorer">
+      {searchable && !isControlled ? (
+        <div className="border-b border-border/60 px-2 py-1.5">
+          <Input
+            aria-label="Search"
+            placeholder={searchPlaceholder}
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            className="h-7 rounded-sm border-transparent bg-muted/40 px-2 text-[12.5px] shadow-none focus-visible:bg-background focus-visible:ring-1"
+          />
+        </div>
+      ) : null}
+      <div className="flex-1 overflow-y-auto" data-slot="sectioned-explorer-list">
+        {showEmpty ? (
+          <div className="flex h-full items-center justify-center px-4 py-8 text-[12px] text-muted-foreground">
+            {emptyState}
+          </div>
+        ) : (
+          <ul className="flex flex-col py-1">
+            {sections.map((section) => {
+              const isExpanded = !!expanded[section.id]
+              const items = sectionItems[section.id] ?? []
+              const staticFacets = Object.fromEntries(
+                (section.filters ?? []).map((filter) => [filter.key, filter.values ?? []]),
+              ) as Facets
+              const facets = sectionFacets[section.id] ?? staticFacets
+              const filters = scopedFilters[section.id] ?? {}
+              return (
+                <li key={section.id}>
+                  <button
+                    type="button"
+                    aria-expanded={isExpanded}
+                    onClick={() => toggleSection(section.id)}
+                    className={cn(
+                      "group mx-1 flex w-[calc(100%-0.5rem)] items-center gap-1.5 rounded-md px-1.5 py-1 text-left",
+                      "transition-colors duration-120 ease-[cubic-bezier(0.22,1,0.36,1)] hover:bg-muted/40",
+                    )}
+                  >
+                    {isExpanded ? <ChevronDownIcon size={11} /> : <ChevronRightIcon size={11} />}
+                    <span className="min-w-0 flex-1 truncate text-[12.5px] font-medium text-foreground">
+                      {section.title}
+                    </span>
+                    <span className="font-mono text-[10.5px] text-muted-foreground/80">
+                      {(sectionTotals[section.id] ?? section.count ?? 0).toLocaleString()}
+                    </span>
+                  </button>
+                  {isExpanded ? (
+                    <div>
+                      <SectionFilters
+                        configs={section.filters ?? []}
+                        facets={facets}
+                        selected={filters}
+                        onToggle={(key, value) => toggleScopedFilter(section.id, key, value)}
+                      />
+                      <ul className="flex flex-col">
+                        {items.map((row) => (
+                          <ExplorerRowItem
+                            key={row.id}
+                            row={row}
+                            indent
+                            onActivate={onActivate}
+                            getDragPayload={getDragPayload}
+                          />
+                        ))}
+                        {loadingItems[section.id] && items.length === 0 ? (
+                          <li className="py-1.5 pl-7 pr-3 text-[11px] text-muted-foreground/80">
+                            Loading…
+                          </li>
+                        ) : null}
+                        {sectionHasMore[section.id] ? (
+                          <li className="py-1 pl-7 pr-3">
+                            <button
+                              type="button"
+                              onClick={() => loadSectionItems(section.id, items.length, true)}
+                              disabled={loadingItems[section.id]}
+                              className="text-[11px] text-muted-foreground hover:text-foreground disabled:opacity-60"
+                            >
+                              {loadingItems[section.id] ? "Loading…" : "Load more"}
+                            </button>
+                          </li>
+                        ) : null}
+                      </ul>
+                    </div>
+                  ) : null}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function SectionFilters({
+  configs,
+  facets,
+  selected,
+  onToggle,
+}: {
+  configs: ExplorerSectionFilter[]
+  facets: Facets
+  selected: Record<string, string[]>
+  onToggle: (key: string, value: string) => void
+}) {
+  if (!configs.length) return null
+  return (
+    <div className="space-y-1 px-7 py-1">
+      {configs.map((config) => {
+        const values = facets[config.key] ?? config.values ?? []
+        if (!values.length) return null
+        return (
+          <div key={config.key} className="flex flex-wrap gap-1">
+            {values.map((value) => {
+              const active = selected[config.key]?.includes(value.value) ?? false
+              const label = config.formatValue ? config.formatValue(value.value) : value.value
+              return (
+                <button
+                  key={value.value}
+                  type="button"
+                  onClick={() => onToggle(config.key, value.value)}
+                  className={cn(
+                    "rounded border px-1.5 py-0.5 text-[10.5px] transition-colors",
+                    active
+                      ? "border-foreground/30 bg-foreground/10 text-foreground"
+                      : "border-border/70 text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {label}
+                  <span className="ml-1 font-mono opacity-70">{value.count}</span>
+                </button>
+              )
+            })}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function ExplorerRowItem({
+  row,
+  indent,
+  onActivate,
+  getDragPayload,
+}: {
+  row: ExplorerRow
+  indent?: boolean
+  onActivate?: (row: ExplorerRow) => void
+  getDragPayload?: (row: ExplorerRow) => DragPayload | null | undefined
+}) {
+  const interactive = !!onActivate
+  const payload = getDragPayload?.(row)
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!interactive) return
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault()
+      onActivate?.(row)
+    }
+  }
+
+  const handleDragStart = (event: DragEvent<HTMLLIElement>) => {
+    if (!payload) return
+    event.dataTransfer.setData(payload.mimeType, payload.value)
+    event.dataTransfer.setData("text/plain", payload.value)
+    event.dataTransfer.effectAllowed = "copy"
+  }
+
+  return (
+    <li
+      {...(interactive
+        ? { role: "button", tabIndex: 0, onClick: () => onActivate?.(row), onKeyDown: handleKeyDown }
+        : {})}
+      {...(payload ? { draggable: true, onDragStart: handleDragStart } : {})}
+      className={cn(
+        "group mx-1 flex items-start gap-2 rounded-md px-1.5 py-1",
+        "transition-colors duration-120 ease-[cubic-bezier(0.22,1,0.36,1)]",
+        interactive && "cursor-pointer hover:bg-foreground/5",
+        indent && "pl-7",
+      )}
+      title={row.title}
+    >
+      {row.leading ? <ExplorerChip badge={row.leading} /> : null}
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-[12.5px] font-medium leading-tight text-foreground">
+          {row.title}
+        </span>
+        {row.subtitle ? (
+          <span className="truncate text-[11.5px] leading-snug text-muted-foreground/85">
+            {row.subtitle}
+          </span>
+        ) : null}
+      </span>
+      {row.trailing?.length ? (
+        <span className="flex shrink-0 items-center gap-1">
+          {row.trailing.map((badge, index) => (
+            <ExplorerChip key={index} badge={badge} />
+          ))}
+        </span>
+      ) : null}
+      {row.meta ? (
+        <span className="shrink-0 self-center font-mono text-[10.5px] text-muted-foreground/80">
+          {row.meta}
+        </span>
+      ) : null}
+    </li>
+  )
+}
+
+function ExplorerChip({ badge }: { badge: Badge }) {
+  return (
+    <span
+      aria-hidden="true"
+      title={badge.tooltip}
+      className="mt-[1px] inline-flex h-[16px] min-w-[24px] shrink-0 items-center justify-center rounded-[3px] bg-muted/60 px-1 font-mono text-[9.5px] font-medium uppercase tracking-[0.06em] text-muted-foreground group-hover:text-foreground"
+    >
+      {badge.code}
+    </span>
+  )
+}
+
+export type {
+  DataExplorerProps,
+  DragPayload,
+  ExplorerAdapter,
+  ExplorerRow,
+  FacetConfig,
+  FacetValue,
+  Facets,
+  SearchResult,
+}

--- a/packages/workspace/src/shared/plugins/__tests__/composePlugins.test.ts
+++ b/packages/workspace/src/shared/plugins/__tests__/composePlugins.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it, vi } from "vitest"
+import { CommandRegistry } from "../../../front/registry/CommandRegistry"
+import { PanelRegistry } from "../../../front/registry/PanelRegistry"
+import { SurfaceResolverRegistry } from "../../../front/registry/SurfaceResolverRegistry"
+import { CatalogRegistry } from "../../../front/plugin/CatalogRegistry"
+import type { CatalogConfig } from "../types"
+import { bootstrap } from "../bootstrap"
+import { composePlugins } from "../composePlugins"
+import { PluginError } from "../defineFrontPlugin"
+
+const DummyPanel = () => null
+const DummyChatPanel = () => null
+
+function makeRegistries() {
+  return {
+    panels: new PanelRegistry(),
+    commands: new CommandRegistry(),
+    catalogs: new CatalogRegistry({ warnOnDuplicate: false }),
+    surfaceResolvers: new SurfaceResolverRegistry(),
+  }
+}
+
+function makeCatalog(id: string): CatalogConfig {
+  return {
+    id,
+    label: id,
+    adapter: { search: async () => ({ items: [], total: 0, hasMore: false }) },
+    onSelect: vi.fn(),
+  }
+}
+
+describe("composePlugins", () => {
+  it("flattens child plugin contributions in order before parent outputs", () => {
+    const plugin = composePlugins({
+      id: "macro",
+      label: "Macro",
+      plugins: [
+        {
+          id: "panels",
+          panels: [{ id: "chart", title: "Chart", component: DummyPanel }],
+        },
+        {
+          id: "catalog",
+          catalogs: [makeCatalog("series")],
+        },
+      ],
+      outputs: [
+        {
+          type: "left-tab",
+          id: "extra",
+          title: "Extra",
+          component: DummyPanel,
+        },
+      ],
+    })
+
+    expect(plugin.id).toBe("macro")
+    expect(plugin.label).toBe("Macro")
+    expect(plugin.panels).toBeUndefined()
+    expect(plugin.catalogs).toBeUndefined()
+    expect(plugin.outputs?.map((output) => output.type)).toEqual([
+      "panel",
+      "catalog",
+      "left-tab",
+    ])
+  })
+
+  it("adopts child output ownership to the parent plugin by default", () => {
+    const registries = makeRegistries()
+    const plugin = composePlugins({
+      id: "macro",
+      plugins: [
+        {
+          id: "catalog-child",
+          catalogs: [makeCatalog("series")],
+          outputs: [
+            {
+              type: "left-tab",
+              id: "data",
+              title: "Data",
+              component: DummyPanel,
+            },
+          ],
+        },
+      ],
+    })
+
+    bootstrap({
+      chatPanel: DummyChatPanel,
+      plugins: [plugin],
+      defaults: [],
+      registries,
+    })
+
+    expect(registries.catalogs.get("series")).toEqual(
+      expect.objectContaining({ pluginId: "macro" }),
+    )
+    expect(registries.panels.get("data")).toEqual(
+      expect.objectContaining({ pluginId: "macro" }),
+    )
+  })
+
+  it("can preserve child plugin ownership when adoptOutputs is false", () => {
+    const registries = makeRegistries()
+    const plugin = composePlugins({
+      id: "macro",
+      adoptOutputs: false,
+      plugins: [
+        {
+          id: "catalog-child",
+          catalogs: [makeCatalog("series")],
+          outputs: [
+            {
+              type: "left-tab",
+              id: "data",
+              title: "Data",
+              component: DummyPanel,
+            },
+          ],
+        },
+      ],
+    })
+
+    bootstrap({
+      chatPanel: DummyChatPanel,
+      plugins: [plugin],
+      defaults: [],
+      registries,
+    })
+
+    expect(registries.catalogs.get("series")).toEqual(
+      expect.objectContaining({ pluginId: "catalog-child" }),
+    )
+    expect(registries.panels.get("data")).toEqual(
+      expect.objectContaining({ pluginId: "catalog-child" }),
+    )
+  })
+
+  it("adopting parent strips existing child ownership from nested composition", () => {
+    const registries = makeRegistries()
+    const inner = composePlugins({
+      id: "inner",
+      adoptOutputs: false,
+      plugins: [
+        {
+          id: "leaf",
+          outputs: [{ type: "left-tab", id: "data", title: "Data", component: DummyPanel }],
+        },
+      ],
+    })
+    const outer = composePlugins({ id: "outer", plugins: [inner] })
+
+    bootstrap({
+      chatPanel: DummyChatPanel,
+      plugins: [outer],
+      defaults: [],
+      registries,
+    })
+
+    expect(registries.panels.get("data")).toEqual(
+      expect.objectContaining({ pluginId: "outer" }),
+    )
+  })
+
+  it("preserves child ownership for surface resolvers and agent tools", () => {
+    const registries = makeRegistries()
+    const agentTools = { register: vi.fn() }
+    const tool = {
+      name: "tool",
+      description: "Tool",
+      parameters: { type: "object", properties: {} },
+      execute: vi.fn(async () => ({ content: [{ type: "text" as const, text: "ok" }] })),
+    }
+    const plugin = composePlugins({
+      id: "macro",
+      adoptOutputs: false,
+      plugins: [
+        {
+          id: "surfaces",
+          outputs: [
+            {
+              type: "surface-resolver",
+              resolver: { id: "surface", resolve: () => ({ component: "chart" }) },
+            },
+            { type: "agent-tool", id: tool.name, tool },
+          ],
+        },
+      ],
+    })
+
+    bootstrap({
+      chatPanel: DummyChatPanel,
+      plugins: [plugin],
+      defaults: [],
+      registries: { ...registries, agentTools },
+    })
+
+    expect(registries.surfaceResolvers.get("surface")).toEqual(
+      expect.objectContaining({ pluginId: "surfaces" }),
+    )
+    expect(agentTools.register).toHaveBeenCalledWith(tool, "surfaces")
+  })
+
+  it("creates a valid empty composed plugin", () => {
+    expect(composePlugins({ id: "empty", plugins: [] })).toEqual({
+      id: "empty",
+      label: undefined,
+      outputs: [],
+      systemPrompt: undefined,
+    })
+  })
+
+  it("combines child and parent system prompts", () => {
+    const plugin = composePlugins({
+      id: "macro",
+      systemPrompt: "Parent prompt",
+      plugins: [
+        { id: "a", systemPrompt: "Child A" },
+        { id: "b", systemPrompt: "Child B" },
+      ],
+    })
+
+    expect(plugin.systemPrompt).toBe("Child A\n\nChild B\n\nParent prompt")
+  })
+
+  it("rejects duplicate contribution ids after flattening", () => {
+    expect(() =>
+      composePlugins({
+        id: "macro",
+        plugins: [
+          {
+            id: "a",
+            panels: [{ id: "chart", title: "Chart", component: DummyPanel }],
+          },
+          {
+            id: "b",
+            panels: [{ id: "chart", title: "Chart", component: DummyPanel }],
+          },
+        ],
+      }),
+    ).toThrow(PluginError)
+  })
+})

--- a/packages/workspace/src/shared/plugins/bootstrap.ts
+++ b/packages/workspace/src/shared/plugins/bootstrap.ts
@@ -52,34 +52,48 @@ function registerOutput(
   plugin: WorkspaceFrontPlugin,
   registries: BootstrapOptions["registries"],
 ): void {
+  const ownedOutput = output as PluginOutput & { pluginId?: string }
+  const ownerPluginId = ownedOutput.pluginId ?? plugin.id
   switch (output.type) {
     case "left-tab": {
-      const { type: _type, id, ...registration } = output
+      const ownedLeftTab = output as Extract<PluginOutput, { type: "left-tab" }> & {
+        pluginId?: string
+      }
+      const { type: _type, id, pluginId: _pluginId, ...registration } = ownedLeftTab
       registries.panels.register(id, {
         ...registration,
         placement: "left-tab",
-        pluginId: plugin.id,
+        pluginId: ownerPluginId,
       })
       return
     }
     case "panel": {
       const { id, ...registration } = output.panel
-      registries.panels.register(id, { ...registration, pluginId: plugin.id })
+      registries.panels.register(id, {
+        ...registration,
+        pluginId: ownerPluginId,
+      })
       return
     }
     case "command":
-      registries.commands.registerCommand({ ...output.command, pluginId: plugin.id })
+      registries.commands.registerCommand({
+        ...output.command,
+        pluginId: ownerPluginId,
+      })
       return
     case "catalog":
-      registries.catalogs.register(output.catalog, plugin.id)
+      registries.catalogs.register(output.catalog, ownerPluginId)
       return
     case "surface-resolver": {
       const { id, ...registration } = output.resolver
-      registries.surfaceResolvers?.register(id, { ...registration, pluginId: plugin.id })
+      registries.surfaceResolvers?.register(id, {
+        ...registration,
+        pluginId: ownerPluginId,
+      })
       return
     }
     case "agent-tool":
-      registries.agentTools?.register(output.tool, plugin.id)
+      registries.agentTools?.register(output.tool, ownerPluginId)
       return
     case "binding":
     case "provider":
@@ -94,14 +108,19 @@ export function bootstrap(options: BootstrapOptions): BootstrapResult {
 
   const excludedDefaults = new Set(options.excludeDefaults ?? [])
   const finalPlugins = [
-    ...(options.defaults ?? []).filter((plugin) => !excludedDefaults.has(plugin.id)),
+    ...(options.defaults ?? []).filter(
+      (plugin) => !excludedDefaults.has(plugin.id),
+    ),
     ...(options.plugins ?? []),
   ]
 
   const seenPluginIds = new Set<string>()
   for (const plugin of finalPlugins) {
     if (seenPluginIds.has(plugin.id)) {
-      throw new PluginError("duplicate-id", `plugin "${plugin.id}" registered twice`)
+      throw new PluginError(
+        "duplicate-id",
+        `plugin "${plugin.id}" registered twice`,
+      )
     }
     seenPluginIds.add(plugin.id)
   }
@@ -109,10 +128,16 @@ export function bootstrap(options: BootstrapOptions): BootstrapResult {
   for (const plugin of finalPlugins) {
     for (const panel of plugin.panels ?? []) {
       const { id, ...registration } = panel
-      options.registries.panels.register(id, { ...registration, pluginId: plugin.id })
+      options.registries.panels.register(id, {
+        ...registration,
+        pluginId: plugin.id,
+      })
     }
     for (const command of plugin.commands ?? []) {
-      options.registries.commands.registerCommand({ ...command, pluginId: plugin.id })
+      options.registries.commands.registerCommand({
+        ...command,
+        pluginId: plugin.id,
+      })
     }
     for (const catalog of plugin.catalogs ?? []) {
       options.registries.catalogs.register(catalog, plugin.id)
@@ -132,5 +157,8 @@ export function bootstrap(options: BootstrapOptions): BootstrapResult {
     .map((p) => p.systemPrompt!.trim())
     .join("\n\n")
 
-  return { registered: finalPlugins.map((plugin) => plugin.id), systemPromptAppend }
+  return {
+    registered: finalPlugins.map((plugin) => plugin.id),
+    systemPromptAppend,
+  }
 }

--- a/packages/workspace/src/shared/plugins/composePlugins.ts
+++ b/packages/workspace/src/shared/plugins/composePlugins.ts
@@ -1,0 +1,102 @@
+import { defineFrontPlugin } from "./defineFrontPlugin"
+import type { WorkspaceFrontPlugin } from "./defineFrontPlugin"
+import type { PluginOutput } from "./types"
+
+type OwnedPluginOutput = PluginOutput & { pluginId?: string }
+
+export interface ComposePluginsOptions {
+  id: string
+  label?: string
+  plugins: WorkspaceFrontPlugin[]
+  outputs?: PluginOutput[]
+  panels?: WorkspaceFrontPlugin["panels"]
+  commands?: WorkspaceFrontPlugin["commands"]
+  catalogs?: WorkspaceFrontPlugin["catalogs"]
+  agentTools?: WorkspaceFrontPlugin["agentTools"]
+  systemPrompt?: string
+  /**
+   * When true (default), child contributions are registered as owned by the
+   * composed parent plugin. When false, output contributions carry the child
+   * plugin id so bootstrap can preserve child ownership in registries.
+   */
+  adoptOutputs?: boolean
+}
+
+function withOwner<T extends PluginOutput>(
+  output: T,
+  pluginId: string | undefined,
+): T {
+  const { pluginId: _oldOwner, ...cleanOutput } = output as OwnedPluginOutput
+  if (!pluginId) return cleanOutput as unknown as T
+  return { ...cleanOutput, pluginId } as unknown as T
+}
+
+function pluginToOutputs(
+  plugin: WorkspaceFrontPlugin,
+  ownerPluginId: string | undefined,
+): PluginOutput[] {
+  const outputs: PluginOutput[] = []
+
+  for (const panel of plugin.panels ?? []) {
+    outputs.push(withOwner({ type: "panel", panel }, ownerPluginId))
+  }
+  for (const command of plugin.commands ?? []) {
+    outputs.push(withOwner({ type: "command", command }, ownerPluginId))
+  }
+  for (const catalog of plugin.catalogs ?? []) {
+    outputs.push(withOwner({ type: "catalog", catalog }, ownerPluginId))
+  }
+  for (const tool of plugin.agentTools ?? []) {
+    outputs.push(
+      withOwner({ type: "agent-tool", id: tool.name, tool }, ownerPluginId),
+    )
+  }
+  for (const output of plugin.outputs ?? []) {
+    outputs.push(withOwner(output, ownerPluginId))
+  }
+
+  return outputs
+}
+
+function compactPrompts(
+  prompts: Array<string | undefined>,
+): string | undefined {
+  const text = prompts
+    .map((prompt) => prompt?.trim())
+    .filter((prompt): prompt is string => Boolean(prompt))
+    .join("\n\n")
+  return text || undefined
+}
+
+/**
+ * Compose a parent plugin from smaller child plugins without introducing a new
+ * enhancer/mixin lifecycle. Contributions are flattened into PluginOutput
+ * values so normal plugin bootstrap remains the single registration path.
+ */
+export function composePlugins(options: ComposePluginsOptions): WorkspaceFrontPlugin {
+  const adoptOutputs = options.adoptOutputs !== false
+  const childOutputs = options.plugins.flatMap((plugin) =>
+    pluginToOutputs(plugin, adoptOutputs ? undefined : plugin.id),
+  )
+  const parentOutputs = pluginToOutputs(
+    {
+      id: options.id,
+      panels: options.panels,
+      commands: options.commands,
+      catalogs: options.catalogs,
+      agentTools: options.agentTools,
+      outputs: options.outputs,
+    },
+    undefined,
+  )
+
+  return defineFrontPlugin({
+    id: options.id,
+    label: options.label,
+    systemPrompt: compactPrompts([
+      ...options.plugins.map((plugin) => plugin.systemPrompt),
+      options.systemPrompt,
+    ]),
+    outputs: [...childOutputs, ...parentOutputs],
+  })
+}

--- a/packages/workspace/src/shared/plugins/index.ts
+++ b/packages/workspace/src/shared/plugins/index.ts
@@ -1,3 +1,5 @@
+export { composePlugins } from "./composePlugins"
+export type { ComposePluginsOptions } from "./composePlugins"
 export { defineFrontPlugin, PluginError } from "./defineFrontPlugin"
 export type { PluginErrorKind, WorkspaceFrontPlugin } from "./defineFrontPlugin"
 export type {

--- a/packages/workspace/src/shared/plugins/types.ts
+++ b/packages/workspace/src/shared/plugins/types.ts
@@ -1,10 +1,20 @@
 import type { ComponentType, ReactNode } from "react"
-import type { AgentTool, JSONSchema, ToolExecContext, ToolResult } from "../types/agent-tool"
+import type {
+  AgentTool,
+  JSONSchema,
+  ToolExecContext,
+  ToolResult,
+} from "../types/agent-tool"
 import type { ExplorerAdapter, ExplorerRow } from "../types/explorer"
 import type { CommandConfig, PaneProps, PanelConfig } from "../types/panel"
 import type { SurfaceResolverConfig } from "../types/surface"
 
-export type { AgentTool, JSONSchema, ToolExecContext, ToolResult } from "../types/agent-tool"
+export type {
+  AgentTool,
+  JSONSchema,
+  ToolExecContext,
+  ToolResult,
+} from "../types/agent-tool"
 
 export type PluginBinding = ComponentType<unknown>
 


### PR DESCRIPTION
## Summary
- add composePlugins for composing child plugin fragments with optional ownership preservation
- add generic explorerPlugin with flat/grouped/sectioned explorer outputs and scoped section filters
- migrate boring-macro client plugin to compose panels, surfaces, and macro series explorer plugin
- document macro generic helper extraction plan

## Tests
- pnpm --filter @boring/workspace exec vitest run src/plugins/explorerPlugin/__tests__/explorerPlugin.test.tsx src/shared/plugins/__tests__/composePlugins.test.ts src/__tests__/public-api.test.ts
- pnpm --filter @boring/macro exec vitest run src/plugin/__tests__/macroPlugin.test.ts

## Notes
- workspace typecheck still hits pre-existing WorkspaceCoreEventMap / WorkspacePluginEventMap export mismatch on this worktree base.