### PR TITLE
Add slash command menu and Boring chart style premises

### DIFF
--- a/apps/boring-macro-v2/src/plugins/macro/panels/ChartCanvasPane.tsx
+++ b/apps/boring-macro-v2/src/plugins/macro/panels/ChartCanvasPane.tsx
@@ -11,13 +11,22 @@ import {
   XAxis,
   YAxis,
 } from "recharts"
+import {
+  BoringTooltip,
+  boringCartesianAxisProps,
+  boringCartesianGridProps,
+  boringLegendProps,
+  boringLineProps,
+  boringReferenceAreaProps,
+  getBoringChartColor,
+} from "@boring/workspace/charts"
 import type {
   Observation,
   SeriesMetadata,
   SeriesPayload,
 } from "../data/macroSeriesTypes"
 import { fetchMacroSeries } from "../data/macroSeriesData"
-import { SERIES_COLORS, formatSeriesValue, openSeriesPane } from "../data/macroSeriesUi"
+import { formatSeriesValue, openSeriesPane } from "../data/macroSeriesUi"
 
 interface ChartParams {
   seriesId?: string
@@ -39,7 +48,6 @@ function normalizeChartParams(value: unknown): ChartParams {
   return {}
 }
 
-const COLORS = SERIES_COLORS
 
 type TabId = "chart" | "table" | "metadata" | "lineage"
 
@@ -261,7 +269,7 @@ export function ChartCanvasPane({ params: initial, api }: ChartCanvasPaneProps) 
   }
 
   const allIds = [seriesId, ...overlays.map((o) => o.id)]
-  const colorFor = (id: string) => COLORS[allIds.indexOf(id) % COLORS.length]
+  const colorFor = (id: string) => getBoringChartColor(Math.max(0, allIds.indexOf(id)))
 
   // Map each series id to its yAxisId for dual-axis mode.
   const axisIdFor = (id: string): string | undefined => {
@@ -377,36 +385,33 @@ export function ChartCanvasPane({ params: initial, api }: ChartCanvasPaneProps) 
                   setZoomEnd(null)
                 }}
               >
-                <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-                <XAxis dataKey="date" tick={{ fontSize: 10 }} />
+                <CartesianGrid {...boringCartesianGridProps} />
+                <XAxis dataKey="date" {...boringCartesianAxisProps} />
                 {axisStrategy.mode === "dual" ? (
                   <>
-                    <YAxis yAxisId="left" tick={{ fontSize: 10 }} tickFormatter={formatValue} />
-                    <YAxis yAxisId="right" orientation="right" tick={{ fontSize: 10 }} tickFormatter={formatValue} />
+                    <YAxis yAxisId="left" {...boringCartesianAxisProps} tickFormatter={formatValue} />
+                    <YAxis yAxisId="right" orientation="right" {...boringCartesianAxisProps} tickFormatter={formatValue} />
                   </>
                 ) : (
-                  <YAxis tick={{ fontSize: 10 }} tickFormatter={formatValue} />
+                  <YAxis {...boringCartesianAxisProps} tickFormatter={formatValue} />
                 )}
-                <Tooltip formatter={(v) => formatValue(Number(v))} />
-                {allIds.length > 1 && <Legend wrapperStyle={{ fontSize: 11 }} />}
+                <Tooltip content={<BoringTooltip valueFormatter={(v) => formatValue(Number(v))} />} />
+                {allIds.length > 1 && <Legend {...boringLegendProps} />}
                 {allIds.map((id) => {
                   const axisId = axisIdFor(id)
                   const axisProps = axisId ? { yAxisId: axisId } : {}
                   return (
                     <Line
                       key={id}
-                      type="monotone"
+                      {...boringLineProps}
                       dataKey={id}
                       stroke={colorFor(id)}
                       {...axisProps}
-                      dot={false}
-                      isAnimationActive={false}
-                      connectNulls
                     />
                   )
                 })}
                 {zoomStart && zoomEnd && zoomStart !== zoomEnd && (
-                  <ReferenceArea x1={zoomStart} x2={zoomEnd} fill="#ff660033" />
+                  <ReferenceArea x1={zoomStart} x2={zoomEnd} {...boringReferenceAreaProps} />
                 )}
               </LineChart>
             </ResponsiveContainer>

--- a/apps/boring-macro-v2/src/plugins/macro/panels/DeckPane.tsx
+++ b/apps/boring-macro-v2/src/plugins/macro/panels/DeckPane.tsx
@@ -10,6 +10,11 @@ import {
   XAxis,
   YAxis,
 } from "recharts"
+import {
+  boringCartesianAxisProps,
+  boringLineProps,
+  getBoringChartColor,
+} from "@boring/workspace/charts"
 import { Button, Separator } from "@boring/workspace"
 import { ChevronLeft, ChevronRight, ExternalLink, Maximize2, Minimize2 } from "lucide-react"
 
@@ -18,7 +23,7 @@ const MarkdownEditor = lazy(() =>
 )
 import type { Observation, SeriesPayload } from "../data/macroSeriesTypes"
 import { fetchMacroSeries } from "../data/macroSeriesData"
-import { SERIES_COLORS, formatSeriesValue, openSeriesPane } from "../data/macroSeriesUi"
+import { formatSeriesValue, openSeriesPane } from "../data/macroSeriesUi"
 
 interface DeckParams {
   path?: string
@@ -30,7 +35,6 @@ interface DeckPaneProps {
   containerApi?: PaneProps<DeckParams | undefined>["containerApi"]
 }
 
-const COLORS = SERIES_COLORS.slice(0, 5)
 
 const fmtNumber = (v: number | null | undefined): string =>
   formatSeriesValue(v, { emptyLabel: "—" })
@@ -123,7 +127,7 @@ function MiniTimeSeries({
           {series.map((s, i) => {
             const id = ids[i]
             const c = changeBadge(s.observations)
-            const color = COLORS[i % COLORS.length]
+            const color = getBoringChartColor(i)
             const positive = c?.pct != null && c.pct >= 0
             return (
               <button
@@ -170,18 +174,17 @@ function MiniTimeSeries({
           <LineChart data={merged} margin={{ top: 8, right: 12, bottom: 0, left: -12 }}>
             <CartesianGrid
               vertical={false}
-              stroke="oklch(from var(--foreground) l c h / 0.08)"
+              stroke="oklch(from var(--border) l c h / 0.48)"
               strokeDasharray="2 4"
             />
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 10, fill: "oklch(from var(--muted-foreground) l c h / 0.85)" }}
+              {...boringCartesianAxisProps}
               tickLine={false}
-              axisLine={{ stroke: "oklch(from var(--border) l c h / 0.6)" }}
               minTickGap={32}
             />
             <YAxis
-              tick={{ fontSize: 10, fill: "oklch(from var(--muted-foreground) l c h / 0.85)" }}
+              {...boringCartesianAxisProps}
               tickLine={false}
               axisLine={false}
               width={48}
@@ -189,13 +192,10 @@ function MiniTimeSeries({
             {ids.map((id, i) => (
               <Line
                 key={id}
-                type="monotone"
+                {...boringLineProps}
                 dataKey={id}
-                stroke={COLORS[i % COLORS.length]}
+                stroke={getBoringChartColor(i)}
                 strokeWidth={1.75}
-                dot={false}
-                isAnimationActive={false}
-                connectNulls
               />
             ))}
           </LineChart>

--- a/packages/agent/src/front/ChatPanel.tsx
+++ b/packages/agent/src/front/ChatPanel.tsx
@@ -23,6 +23,7 @@ import { useAgentChat } from './hooks/useAgentChat'
 import { DebugDrawer } from './DebugDrawer'
 import { builtinCommands } from './slashCommands/builtins'
 import { parseSlashCommand } from './slashCommands/parser'
+import { filterSlashCommandSuggestions } from './slashCommands/suggestions'
 import { createCommandRegistry, type SlashCommand, type SlashCommandContext } from './slashCommands/registry'
 import { isModelId, type ModelId } from './components/ModelPicker'
 import {
@@ -409,6 +410,50 @@ export function ChatPanel(props: ChatPanelProps) {
     return () => clearTimeout(timer)
   }, [attachmentNotice])
   const [availableModels, setAvailableModels] = useState<AvailableModel[]>([])
+  const [composerText, setComposerText] = useState('')
+  const [activeSlashIndex, setActiveSlashIndex] = useState(0)
+  const [dismissedSlashText, setDismissedSlashText] = useState<string | null>(null)
+  const composerRootRef = useRef<HTMLDivElement>(null)
+  const slashSuggestions = useMemo(
+    () => filterSlashCommandSuggestions(registry.list(), composerText),
+    [registry, composerText],
+  )
+  const slashMenuOpen = slashSuggestions.length > 0 && dismissedSlashText !== composerText
+
+  useEffect(() => {
+    setActiveSlashIndex(0)
+  }, [composerText])
+
+  useEffect(() => {
+    setActiveSlashIndex((index) => {
+      if (slashSuggestions.length === 0) return 0
+      return Math.min(index, slashSuggestions.length - 1)
+    })
+  }, [slashSuggestions.length])
+
+  const setTextareaValue = useCallback((next: string, textarea?: HTMLTextAreaElement | null) => {
+    const target = textarea ?? composerRootRef.current?.querySelector('textarea')
+    if (!target) return
+    const valueSetter = Object.getOwnPropertyDescriptor(
+      HTMLTextAreaElement.prototype,
+      'value',
+    )?.set
+    if (valueSetter) valueSetter.call(target, next)
+    else target.value = next
+    target.dispatchEvent(new Event('input', { bubbles: true }))
+  }, [])
+
+  const selectSlashCommand = useCallback((command: SlashCommand, textarea?: HTMLTextAreaElement | null) => {
+    const next = `/${command.name} `
+    const target = textarea ?? composerRootRef.current?.querySelector('textarea')
+    setTextareaValue(next, target)
+    if (target) {
+      target.focus()
+      target.setSelectionRange(next.length, next.length)
+    }
+    setComposerText(next)
+    setDismissedSlashText(null)
+  }, [setTextareaValue])
 
   useEffect(() => {
     if (!userSelectedModel) return
@@ -491,6 +536,8 @@ export function ChatPanel(props: ChatPanelProps) {
           listCommands: () => registry.list(),
         }
         const result = cmd.handler(parsed.args, ctx)
+        setComposerText('')
+        setTextareaValue('')
         if (typeof result === 'string') {
           setMessages((prev) => [
             ...prev,
@@ -532,6 +579,8 @@ export function ChatPanel(props: ChatPanelProps) {
     // composer chips would linger for the entire duration of the server
     // stream. The send still runs (and errors still surface via useChat's
     // `error` state rendered above).
+    setComposerText('')
+    setTextareaValue('')
     void sendMessage(
       {
         // Rendered bubble: unchanged user text + file chips via files parts.
@@ -881,8 +930,9 @@ export function ChatPanel(props: ChatPanelProps) {
           </div>
         )}
         <div
+          ref={composerRootRef}
           className={cn(
-            "relative mx-auto w-full overflow-hidden",
+            "relative mx-auto w-full overflow-visible",
             chrome ? "max-w-3xl" : "max-w-[680px]",
             // Workspace-aligned composer surface: a flat card with an
             // inset 1px border at rest, then a focus-within swap that
@@ -907,6 +957,46 @@ export function ChatPanel(props: ChatPanelProps) {
             "[&_[data-slot=input-group]]:has-[:focus]:!ring-0",
           )}
         >
+          {slashMenuOpen && (
+            <div
+              className="absolute bottom-full left-2 right-2 z-30 mb-2 overflow-hidden rounded-xl border border-border/70 bg-popover/95 text-popover-foreground shadow-2xl backdrop-blur"
+              role="listbox"
+              aria-label="Slash commands"
+            >
+              <div className="border-b border-border/50 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+                Commands
+              </div>
+              <div className="max-h-56 overflow-auto p-1.5">
+                {slashSuggestions.map((command, index) => {
+                  const active = index === activeSlashIndex
+                  return (
+                    <button
+                      key={command.name}
+                      type="button"
+                      role="option"
+                      aria-selected={active}
+                      onMouseEnter={() => setActiveSlashIndex(index)}
+                      onMouseDown={(event) => {
+                        event.preventDefault()
+                        selectSlashCommand(command)
+                      }}
+                      className={cn(
+                        "flex w-full items-start gap-3 rounded-lg px-3 py-2 text-left transition-colors",
+                        active ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/70 hover:text-foreground",
+                      )}
+                    >
+                      <span className="shrink-0 font-mono text-[12px] font-semibold text-foreground">
+                        /{command.name}
+                      </span>
+                      <span className="min-w-0 flex-1 text-[12px] leading-relaxed">
+                        {command.description}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
           <PromptInput
             data-boring-state={status}
             onSubmit={handleSubmit}
@@ -934,6 +1024,32 @@ export function ChatPanel(props: ChatPanelProps) {
             <AttachmentsList />
             <PromptInputTextarea
               placeholder="Ask anything…"
+              onChange={(event) => {
+                setComposerText(event.currentTarget.value)
+                setDismissedSlashText(null)
+              }}
+              onKeyDown={(event) => {
+                if (!slashMenuOpen) return
+                if (event.key === 'ArrowDown') {
+                  event.preventDefault()
+                  setActiveSlashIndex((index) => (index + 1) % slashSuggestions.length)
+                  return
+                }
+                if (event.key === 'ArrowUp') {
+                  event.preventDefault()
+                  setActiveSlashIndex((index) => (index - 1 + slashSuggestions.length) % slashSuggestions.length)
+                  return
+                }
+                if (event.key === 'Tab' || event.key === 'Enter') {
+                  event.preventDefault()
+                  selectSlashCommand(slashSuggestions[activeSlashIndex] ?? slashSuggestions[0], event.currentTarget)
+                  return
+                }
+                if (event.key === 'Escape') {
+                  event.preventDefault()
+                  setDismissedSlashText(composerText)
+                }
+              }}
               className={cn(
                 "min-h-[52px] resize-none border-0 bg-transparent shadow-none",
                 "px-5 pt-3.5 pb-1 text-[13px] leading-[1.55] placeholder:text-muted-foreground/60",

--- a/packages/agent/src/front/slashCommands/__tests__/parser.test.ts
+++ b/packages/agent/src/front/slashCommands/__tests__/parser.test.ts
@@ -10,6 +10,10 @@ describe('parseSlashCommand', () => {
     expect(parseSlashCommand('/model sonnet')).toEqual({ name: 'model', args: 'sonnet' })
   })
 
+  test('parses hyphenated command names', () => {
+    expect(parseSlashCommand('/open-chart GDPC1')).toEqual({ name: 'open-chart', args: 'GDPC1' })
+  })
+
   test('trims whitespace from args', () => {
     expect(parseSlashCommand('/model   haiku  ')).toEqual({ name: 'model', args: 'haiku' })
   })

--- a/packages/agent/src/front/slashCommands/__tests__/suggestions.test.ts
+++ b/packages/agent/src/front/slashCommands/__tests__/suggestions.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest'
+import { filterSlashCommandSuggestions, getSlashCommandQuery } from '../suggestions'
+import type { SlashCommand } from '../registry'
+
+function cmd(name: string): SlashCommand {
+  return { name, description: `${name} command`, handler: () => undefined }
+}
+
+describe('slash command suggestions', () => {
+  test('extracts query only while typing a leading command token', () => {
+    expect(getSlashCommandQuery('/')).toBe('')
+    expect(getSlashCommandQuery('/mo')).toBe('mo')
+    expect(getSlashCommandQuery('/model')).toBe('model')
+    expect(getSlashCommandQuery('/open-chart')).toBe('open-chart')
+    expect(getSlashCommandQuery('/model sonnet')).toBeNull()
+    expect(getSlashCommandQuery(' /model')).toBeNull()
+    expect(getSlashCommandQuery('try /model')).toBeNull()
+  })
+
+  test('filters commands by name and caps results', () => {
+    const commands = [cmd('reset'), cmd('model'), cmd('cost'), cmd('clear'), cmd('clone')]
+    expect(filterSlashCommandSuggestions(commands, '/c').map((c) => c.name)).toEqual([
+      'clear',
+      'clone',
+      'cost',
+    ])
+    expect(filterSlashCommandSuggestions(commands, '/', 2)).toHaveLength(2)
+  })
+})

--- a/packages/agent/src/front/slashCommands/index.ts
+++ b/packages/agent/src/front/slashCommands/index.ts
@@ -7,3 +7,4 @@ export {
   type SlashCommandHandler,
 } from './registry'
 export { builtinCommands } from './builtins'
+export { filterSlashCommandSuggestions, getSlashCommandQuery } from './suggestions'

--- a/packages/agent/src/front/slashCommands/parser.ts
+++ b/packages/agent/src/front/slashCommands/parser.ts
@@ -4,7 +4,7 @@ export interface ParsedCommand {
 }
 
 export function parseSlashCommand(text: string): ParsedCommand | null {
-  const match = text.match(/^\/(\w+)(?:\s+(.*))?$/s)
+  const match = text.match(/^\/([\w-]+)(?:\s+(.*))?$/s)
   if (!match) return null
   return { name: match[1], args: match[2]?.trim() ?? '' }
 }

--- a/packages/agent/src/front/slashCommands/suggestions.ts
+++ b/packages/agent/src/front/slashCommands/suggestions.ts
@@ -1,0 +1,27 @@
+import type { SlashCommand } from './registry'
+
+const COMMAND_TOKEN = /^\/([a-zA-Z0-9_-]*)$/
+
+export function getSlashCommandQuery(text: string): string | null {
+  const match = COMMAND_TOKEN.exec(text)
+  return match ? match[1].toLowerCase() : null
+}
+
+export function filterSlashCommandSuggestions(
+  commands: SlashCommand[],
+  text: string,
+  limit = 6,
+): SlashCommand[] {
+  const query = getSlashCommandQuery(text)
+  if (query == null) return []
+  const normalized = commands
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  const matches = normalized.filter((command) => {
+    const name = command.name.toLowerCase()
+    return name.startsWith(query) || name.includes(query)
+  })
+
+  return matches.slice(0, Math.max(0, limit))
+}

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -23,6 +23,10 @@
       "types": "./dist/ui-shadcn.d.ts",
       "import": "./dist/ui-shadcn.js"
     },
+    "./charts": {
+      "types": "./dist/charts.d.ts",
+      "import": "./dist/charts.js"
+    },
     "./shared": {
       "types": "./dist/shared.d.ts",
       "import": "./dist/shared.js"
@@ -62,7 +66,8 @@
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react-dom": "^18.0.0 || ^19.0.0",
+    "recharts": "^2.15.0"
   },
   "peerDependenciesMeta": {
     "@codemirror/state": {
@@ -75,6 +80,9 @@
       "optional": true
     },
     "@tiptap/starter-kit": {
+      "optional": true
+    },
+    "recharts": {
       "optional": true
     }
   },
@@ -127,7 +135,6 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.0.0",
-    "postcss": "^8.5.13",
     "@tailwindcss/vite": "^4.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -139,8 +146,10 @@
     "@vitejs/plugin-react": "^4.0.0",
     "fast-check": "^4.7.0",
     "jsdom": "^29.0.2",
+    "postcss": "^8.5.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "recharts": "^2.15.4",
     "tailwindcss": "^4.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",

--- a/packages/workspace/scripts/assert-build-artifacts.mjs
+++ b/packages/workspace/scripts/assert-build-artifacts.mjs
@@ -18,6 +18,8 @@ const requiredFiles = [
   "dist/testing.d.ts",
   "dist/ui-shadcn.js",
   "dist/ui-shadcn.d.ts",
+  "dist/charts.js",
+  "dist/charts.d.ts",
   "dist/app-front.js",
   "dist/app-front.d.ts",
   "dist/app-server.js",
@@ -65,7 +67,7 @@ if (missing.length > 0) {
   for (const m of missing) console.error(`  - ${m}`)
   console.error(
     "\nFix: ensure tsup.config.ts emits server + shared, and " +
-      "vite.config.ts emits workspace + testing + ui-shadcn.",
+      "vite.config.ts emits workspace + testing + ui-shadcn + charts.",
   )
   process.exit(1)
 }

--- a/packages/workspace/src/front/charts/__tests__/charts.test.tsx
+++ b/packages/workspace/src/front/charts/__tests__/charts.test.tsx
@@ -20,6 +20,7 @@ describe("workspace charts", () => {
     expect(boringChartTheme.border).toBe("var(--border)")
     expect(getBoringChartColor(0)).toContain("var(--chart-1")
     expect(getBoringChartColor(9)).toBe(getBoringChartColor(1))
+    expect(getBoringChartColor(-1)).toBe(getBoringChartColor(7))
     expect(getBoringChartColor(0, { ...boringChartTheme, palette: [] })).toBe("var(--accent)")
   })
 

--- a/packages/workspace/src/front/charts/__tests__/charts.test.tsx
+++ b/packages/workspace/src/front/charts/__tests__/charts.test.tsx
@@ -46,7 +46,7 @@ describe("workspace charts", () => {
         payload={[
           { dataKey: "value", name: "Value", value: 1, color: "red" },
           { dataKey: "value", name: "Value", value: 2, color: "blue" },
-        ] as any}
+        ]}
       />,
     )
 

--- a/packages/workspace/src/front/charts/__tests__/charts.test.tsx
+++ b/packages/workspace/src/front/charts/__tests__/charts.test.tsx
@@ -1,0 +1,64 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it } from "vitest"
+import {
+  BoringChartFrame,
+  BoringTooltip,
+  boringBarProps,
+  boringCartesianAxisProps,
+  boringCartesianGridProps,
+  boringChartTheme,
+  boringLegendProps,
+  boringLineProps,
+  boringReferenceAreaProps,
+  getBoringChartColor,
+} from "../index"
+
+describe("workspace charts", () => {
+  it("uses boring design-system CSS variables for chart theme tokens", () => {
+    expect(boringChartTheme.background).toBe("var(--background)")
+    expect(boringChartTheme.foreground).toBe("var(--foreground)")
+    expect(boringChartTheme.border).toBe("var(--border)")
+    expect(getBoringChartColor(0)).toContain("var(--chart-1")
+    expect(getBoringChartColor(9)).toBe(getBoringChartColor(1))
+    expect(getBoringChartColor(0, { ...boringChartTheme, palette: [] })).toBe("var(--accent)")
+  })
+
+  it("renders the standard chart frame chrome", () => {
+    const html = renderToStaticMarkup(
+      <BoringChartFrame title="Revenue" subtitle="Monthly" source="Internal">
+        <div>chart body</div>
+      </BoringChartFrame>,
+    )
+
+    expect(html).toContain("Revenue")
+    expect(html).toContain("Monthly")
+    expect(html).toContain("Internal")
+    expect(html).toContain("chart body")
+    expect(html).toContain("var(--border)")
+  })
+
+  it("renders duplicate tooltip payload entries without key collisions", () => {
+    const html = renderToStaticMarkup(
+      <BoringTooltip
+        active
+        label="Jan"
+        payload={[
+          { dataKey: "value", name: "Value", value: 1, color: "red" },
+          { dataKey: "value", name: "Value", value: 2, color: "blue" },
+        ] as any}
+      />,
+    )
+
+    expect(html).toContain("Jan")
+    expect(html.match(/Value/g)).toHaveLength(2)
+  })
+
+  it("exposes Recharts styling premises without chart wrappers", () => {
+    expect(boringCartesianAxisProps.tick.fill).toBe("var(--muted-foreground)")
+    expect(boringCartesianGridProps.stroke).toContain("var(--border)")
+    expect(boringLegendProps.wrapperStyle.fontSize).toBe(12)
+    expect(boringLineProps.connectNulls).toBe(true)
+    expect(boringBarProps.radius).toEqual([6, 6, 2, 2])
+    expect(boringReferenceAreaProps.fill).toContain("var(--accent)")
+  })
+})

--- a/packages/workspace/src/front/charts/index.tsx
+++ b/packages/workspace/src/front/charts/index.tsx
@@ -1,0 +1,188 @@
+import type { ReactNode } from "react"
+import type { TooltipProps } from "recharts"
+import { cn } from "../lib/utils"
+
+export interface BoringChartTheme {
+  background: string
+  foreground: string
+  mutedForeground: string
+  border: string
+  grid: string
+  tooltipBackground: string
+  tooltipBorder: string
+  tooltipForeground: string
+  palette: string[]
+}
+
+export const boringChartPalette = [
+  "var(--chart-1, var(--accent))",
+  "var(--chart-2, #60a5fa)",
+  "var(--chart-3, #34d399)",
+  "var(--chart-4, #f59e0b)",
+  "var(--chart-5, #f472b6)",
+  "var(--chart-6, #a78bfa)",
+  "var(--chart-7, #22d3ee)",
+  "var(--chart-8, #fb7185)",
+]
+
+export const boringChartTheme: BoringChartTheme = {
+  background: "var(--background)",
+  foreground: "var(--foreground)",
+  mutedForeground: "var(--muted-foreground)",
+  border: "var(--border)",
+  grid: "oklch(from var(--border) l c h / 0.48)",
+  tooltipBackground: "var(--popover, var(--background))",
+  tooltipBorder: "var(--border)",
+  tooltipForeground: "var(--popover-foreground, var(--foreground))",
+  palette: boringChartPalette,
+}
+
+export function getBoringChartColor(index: number, theme: BoringChartTheme = boringChartTheme): string {
+  if (theme.palette.length === 0) return "var(--accent)"
+  const normalizedIndex = Number.isFinite(index) ? Math.abs(Math.trunc(index)) : 0
+  return theme.palette[normalizedIndex % theme.palette.length] ?? theme.palette[0] ?? "var(--accent)"
+}
+
+export function defaultBoringChartValueFormatter(value: unknown): string {
+  if (typeof value === "number") {
+    return new Intl.NumberFormat(undefined, { maximumFractionDigits: 2 }).format(value)
+  }
+  return value == null ? "—" : String(value)
+}
+
+export type BoringChartValueFormatter = (value: unknown) => string
+
+export function BoringTooltip({
+  active,
+  payload,
+  label,
+  valueFormatter = defaultBoringChartValueFormatter,
+}: TooltipProps<number | string, string> & { valueFormatter?: BoringChartValueFormatter }) {
+  if (!active || !payload || payload.length === 0) return null
+  return (
+    <div
+      className="min-w-32 rounded-md border px-2.5 py-2 text-xs shadow-xl"
+      style={{
+        background: boringChartTheme.tooltipBackground,
+        borderColor: boringChartTheme.tooltipBorder,
+        color: boringChartTheme.tooltipForeground,
+      }}
+    >
+      {label != null && (
+        <div className="mb-1.5 font-medium" style={{ color: boringChartTheme.foreground }}>
+          {String(label)}
+        </div>
+      )}
+      <div className="space-y-1">
+        {payload.map((item, index) => (
+          <div key={`${item.dataKey ?? item.name ?? "series"}:${index}`} className="flex items-center justify-between gap-4">
+            <span className="inline-flex items-center gap-1.5" style={{ color: boringChartTheme.mutedForeground }}>
+              <span
+                aria-hidden="true"
+                className="size-2 rounded-full"
+                style={{ background: item.color }}
+              />
+              {item.name ?? item.dataKey}
+            </span>
+            <span className="font-mono tabular-nums" style={{ color: boringChartTheme.foreground }}>
+              {valueFormatter(item.value)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export interface BoringChartFrameProps {
+  title?: string
+  subtitle?: string
+  source?: string
+  height?: number | string
+  className?: string
+  children: ReactNode
+}
+
+export function BoringChartFrame({
+  title,
+  subtitle,
+  source,
+  height = 320,
+  className,
+  children,
+}: BoringChartFrameProps) {
+  return (
+    <figure
+      className={cn(
+        "flex min-h-0 w-full flex-col rounded-xl border bg-card/60 text-card-foreground",
+        "shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_12px_32px_-22px_oklch(0_0_0/0.28)]",
+        className,
+      )}
+      style={{ borderColor: boringChartTheme.border }}
+    >
+      {(title || subtitle) && (
+        <figcaption className="border-b px-3 py-2" style={{ borderColor: boringChartTheme.border }}>
+          {title && <div className="text-sm font-semibold tracking-[-0.01em]">{title}</div>}
+          {subtitle && <div className="mt-0.5 text-xs text-muted-foreground">{subtitle}</div>}
+        </figcaption>
+      )}
+      <div className="min-h-0 flex-1 p-3" style={{ height }}>
+        {children}
+      </div>
+      {source && (
+        <div className="border-t px-3 py-1.5 text-[11px] text-muted-foreground" style={{ borderColor: boringChartTheme.border }}>
+          {source}
+        </div>
+      )}
+    </figure>
+  )
+}
+
+export const boringCartesianAxisProps = {
+  tick: { fill: boringChartTheme.mutedForeground, fontSize: 11 },
+  axisLine: { stroke: boringChartTheme.border },
+  tickLine: { stroke: boringChartTheme.border },
+} as const
+
+export const boringCartesianGridProps = {
+  stroke: boringChartTheme.grid,
+  strokeDasharray: "3 3",
+  vertical: false,
+} as const
+
+export const boringLegendProps = {
+  wrapperStyle: { color: boringChartTheme.mutedForeground, fontSize: 12 },
+} as const
+
+export const boringLineProps = {
+  type: "monotone",
+  strokeWidth: 2,
+  dot: false,
+  activeDot: { r: 4 },
+  connectNulls: true,
+  isAnimationActive: false,
+} as const
+
+export const boringAreaProps = {
+  type: "monotone",
+  strokeWidth: 2,
+  dot: false,
+  connectNulls: true,
+  isAnimationActive: false,
+} as const
+
+export const boringBarProps = {
+  radius: [6, 6, 2, 2] as [number, number, number, number],
+  isAnimationActive: false,
+} as const
+
+export const boringPieProps = {
+  innerRadius: "58%",
+  outerRadius: "82%",
+  paddingAngle: 2,
+  isAnimationActive: false,
+} as const
+
+export const boringReferenceAreaProps = {
+  fill: "oklch(from var(--accent) l c h / 0.20)",
+} as const

--- a/packages/workspace/src/front/charts/index.tsx
+++ b/packages/workspace/src/front/charts/index.tsx
@@ -11,10 +11,10 @@ export interface BoringChartTheme {
   tooltipBackground: string
   tooltipBorder: string
   tooltipForeground: string
-  palette: string[]
+  palette: readonly string[]
 }
 
-export const boringChartPalette = [
+export const boringChartPalette: readonly string[] = [
   "var(--chart-1, var(--accent))",
   "var(--chart-2, #60a5fa)",
   "var(--chart-3, #34d399)",
@@ -39,8 +39,9 @@ export const boringChartTheme: BoringChartTheme = {
 
 export function getBoringChartColor(index: number, theme: BoringChartTheme = boringChartTheme): string {
   if (theme.palette.length === 0) return "var(--accent)"
-  const normalizedIndex = Number.isFinite(index) ? Math.abs(Math.trunc(index)) : 0
-  return theme.palette[normalizedIndex % theme.palette.length] ?? theme.palette[0] ?? "var(--accent)"
+  const integerIndex = Number.isFinite(index) ? Math.trunc(index) : 0
+  const paletteIndex = ((integerIndex % theme.palette.length) + theme.palette.length) % theme.palette.length
+  return theme.palette[paletteIndex] ?? theme.palette[0] ?? "var(--accent)"
 }
 
 export function defaultBoringChartValueFormatter(value: unknown): string {
@@ -82,7 +83,7 @@ export function BoringTooltip({
                 className="size-2 rounded-full"
                 style={{ background: item.color }}
               />
-              {item.name ?? item.dataKey}
+              {String(item.name ?? item.dataKey ?? "Series")}
             </span>
             <span className="font-mono tabular-nums" style={{ color: boringChartTheme.foreground }}>
               {valueFormatter(item.value)}

--- a/packages/workspace/src/front/charts/index.tsx
+++ b/packages/workspace/src/front/charts/index.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react"
-import type { TooltipProps } from "recharts"
 import { cn } from "../lib/utils"
 
 export interface BoringChartTheme {
@@ -53,12 +52,26 @@ export function defaultBoringChartValueFormatter(value: unknown): string {
 
 export type BoringChartValueFormatter = (value: unknown) => string
 
+export interface BoringTooltipPayloadItem {
+  color?: string
+  dataKey?: string | number
+  name?: string | number
+  value?: unknown
+}
+
+export interface BoringTooltipProps {
+  active?: boolean
+  payload?: BoringTooltipPayloadItem[]
+  label?: unknown
+  valueFormatter?: BoringChartValueFormatter
+}
+
 export function BoringTooltip({
   active,
   payload,
   label,
   valueFormatter = defaultBoringChartValueFormatter,
-}: TooltipProps<number | string, string> & { valueFormatter?: BoringChartValueFormatter }) {
+}: BoringTooltipProps) {
   if (!active || !payload || payload.length === 0) return null
   return (
     <div
@@ -81,7 +94,7 @@ export function BoringTooltip({
               <span
                 aria-hidden="true"
                 className="size-2 rounded-full"
-                style={{ background: item.color }}
+                style={{ background: item.color ?? getBoringChartColor(index) }}
               />
               {String(item.name ?? item.dataKey ?? "Series")}
             </span>

--- a/packages/workspace/vite.config.ts
+++ b/packages/workspace/vite.config.ts
@@ -50,6 +50,7 @@ export default defineConfig({
         testing: resolve(__dirname, "src/front/testing/index.ts"),
         "testing-e2e": resolve(__dirname, "src/front/testing/e2e.ts"),
         "ui-shadcn": resolve(__dirname, "src/front/components/ui/index.ts"),
+        charts: resolve(__dirname, "src/front/charts/index.tsx"),
         "app-front": resolve(__dirname, "src/app/front/index.ts"),
       },
       formats: ["es"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -735,6 +735,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
+      recharts:
+        specifier: ^2.15.4
+        version: 2.15.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.4


### PR DESCRIPTION
## Summary
- add visible slash-command autocomplete for agent chat, including hyphenated command parsing and suggestion helpers
- add @boring/workspace/charts as Recharts-oriented Boring style premises without raw Recharts re-exports
- migrate macro chart panes to shared chart defaults and harden chart helper edge cases

## Validation
- pnpm --filter @boring/agent exec vitest run src/front/slashCommands/__tests__/parser.test.ts src/front/slashCommands/__tests__/suggestions.test.ts src/front/__tests__/ChatPanel.test.tsx
- pnpm --filter @boring/agent exec tsc --noEmit
- pnpm --filter @boring/workspace exec vitest run src/front/charts/__tests__/charts.test.tsx
- pnpm --filter @boring/workspace exec tsc --noEmit -p tsconfig.front.json
- pnpm --filter @boring/workspace build
- pnpm --filter @boring/macro exec tsc --noEmit

## Review
- Codex reviewed final full diff: ship, no blocking issues.