### PR TITLE
feat(core): add Google signup for child apps

### DIFF
--- a/.agents/skills/boring-google-signup-setup/SKILL.md
+++ b/.agents/skills/boring-google-signup-setup/SKILL.md
@@ -10,6 +10,10 @@ description: Teach a boring-ui child app how to enable Google signup with @hache
 
 ## Goal
 
+When using this skill, default to giving the user a short manual **to-do list** for the Google-side setup plus the exact app config/env changes they must make.
+
+Do **not** imply that normal Google Sign-In web OAuth client creation is cleanly supported by `gcloud`/Terraform here. Treat Google-side client creation as a manual Console task unless the user explicitly asks for a brittle browser-automation workaround.
+
 Turn on Google signup/signin for a child app with:
 
 1. Google OAuth credentials
@@ -46,6 +50,8 @@ That keeps the first pass easy to teach and hard to break.
 ## Quick path
 
 ### 1. Create Google OAuth credentials
+
+This step is currently a **manual Google Cloud Console to-do**, not a normal `gcloud` automation step for this skill.
 
 In Google Cloud Console:
 
@@ -139,6 +145,30 @@ export function MySignInPage() {
 Rule: child apps should consume core's auth helper, not rebuild `signIn.social({ provider: 'google' })` in every app.
 
 If the app does nothing special with auth pages, it should keep using the stock core pages.
+
+## What to print to the user
+
+Default output shape for this skill:
+
+1. **Google Console to-do list**
+   - create/select project
+   - configure consent screen
+   - create Web application OAuth client
+   - add local + production redirect URIs
+   - copy client ID + client secret
+2. **Child-app config to-do list**
+   - set `GOOGLE_CLIENT_ID`
+   - set `GOOGLE_CLIENT_SECRET`
+   - set `BETTER_AUTH_URL`
+   - set `CORS_ORIGINS`
+   - set `features.google_oauth = true`
+3. **Verification to-do list**
+   - check `/auth/signin`
+   - check `/auth/signup`
+   - check invite signup stays email-only
+   - test one negative case by removing one required setting
+
+Only go beyond that if the user asks for deeper implementation help.
 
 ## Verify locally
 

--- a/.agents/skills/boring-google-signup-setup/SKILL.md
+++ b/.agents/skills/boring-google-signup-setup/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: boring-google-signup-setup
+description: Teach a boring-ui child app how to enable Google signup with @hachej/boring-core. Use when the user asks for Google auth, Google OAuth, social signup, or how to turn on Google sign-in/sign-up in a child app.
+---
+
+# Boring Google Signup Setup
+
+> This skill is the child-app setup contract for the plan in `docs/plans/google-signup-child-app-plan.md`.
+> Use it to teach or verify the shipped child-app setup shape for Google signup.
+
+## Goal
+
+Turn on Google signup/signin for a child app with:
+
+1. Google OAuth credentials
+2. the existing better-auth core envs: `BETTER_AUTH_SECRET`, `BETTER_AUTH_URL`, `CORS_ORIGINS`
+3. two Google env vars: `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`
+4. one feature flag: `features.google_oauth = true`
+5. no auth-page fork unless the app wants custom branding
+
+## Assumed child-app contract
+
+Core auth already runs on better-auth. Google is one provider inside that existing core auth stack, not a second auth system.
+
+Core exposes Google signup when all of these are true:
+
+- `GOOGLE_CLIENT_ID` is set
+- `GOOGLE_CLIENT_SECRET` is set
+- `features.google_oauth = true` in `boring.app.toml`
+
+If any one is missing, the app still boots and the Google button stays hidden.
+
+There is no `GOOGLE_OAUTH` env flag in this first pass.
+
+## Why this setup is simple
+
+This feature is intentionally narrow:
+
+- Google is enabled by one app-level TOML flag plus credentials
+- stock core auth pages gain the button automatically
+- invite signup stays on the existing email-only path
+- branded child apps reuse `GoogleAuthButton`
+
+That keeps the first pass easy to teach and hard to break.
+
+## Quick path
+
+### 1. Create Google OAuth credentials
+
+In Google Cloud Console:
+
+- create/select a project
+- enable Google Identity / OAuth consent screen
+- create an OAuth client ID for **Web application**
+- add redirect URIs:
+  - local: `http://localhost:3000/auth/callback/google`
+  - prod: `https://<your-domain>/auth/callback/google`
+
+Copy:
+- client ID
+- client secret
+
+### 2. Set child-app env vars
+
+```bash
+BETTER_AUTH_SECRET=<32-byte random hex>
+BETTER_AUTH_URL=http://localhost:3000
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173
+GOOGLE_CLIENT_ID=your-google-client-id
+GOOGLE_CLIENT_SECRET=your-google-client-secret
+```
+
+Notes:
+
+- `BETTER_AUTH_SECRET` is still required because Google uses the same better-auth session/callback flow as email auth.
+- `BETTER_AUTH_URL` must match the deployed app origin that owns `/auth/callback/google`.
+- `CORS_ORIGINS` must include every browser origin that can start auth.
+
+For production, use the real deployed origin, for example:
+
+```bash
+BETTER_AUTH_URL=https://app.example.com
+CORS_ORIGINS=https://app.example.com
+```
+
+### 3. Enable the feature in `boring.app.toml` (create it if missing)
+
+```toml
+[features]
+google_oauth = true
+```
+
+`boring.app.toml` is optional. If the child app does not already have one, create it at the repo root and add the `[features]` block above.
+
+Rule:
+- env vars provide credentials
+- TOML expresses app intent
+- both are required
+- missing credentials should disable Google cleanly, not break app boot
+- do not invent a separate `GOOGLE_OAUTH` env flag
+
+### 4. Boot the app
+
+```bash
+pnpm dev
+```
+
+Expected result:
+- `/auth/signin` shows **Continue with Google**
+- `/auth/signup` shows **Continue with Google** for normal signup flow
+- `/auth/signup?invite_token=...` stays email-only in this first pass
+- email/password still works
+
+## Default child-app path
+
+If the child app uses the stock core auth pages, nothing else is needed.
+
+That is the whole point of this setup: **do not fork the auth pages just to add Google**. Core already wires Google through better-auth and shows the button automatically when the contract above is satisfied.
+
+## Branded child-app path
+
+If the child app already overrides core auth pages, reuse core's exported Google auth primitive instead of calling Better Auth directly everywhere. Ship the specific `GoogleAuthButton`; do not promise or build a generic provider picker for this first pass.
+
+Usage shape:
+
+```tsx
+import { GoogleAuthButton } from '@hachej/boring-core/front'
+
+export function MySignInPage() {
+  return (
+    <div>
+      <GoogleAuthButton />
+      {/* app-specific email form */}
+    </div>
+  )
+}
+```
+
+Rule: child apps should consume core's auth helper, not rebuild `signIn.social({ provider: 'google' })` in every app.
+
+If the app does nothing special with auth pages, it should keep using the stock core pages.
+
+## Verify locally
+
+### Browser checks
+
+- open `/auth/signin`
+- confirm the Google button is visible
+- click it
+- confirm browser redirects to Google
+- finish login
+- confirm you land back in the app authenticated
+- open `/auth/signup`
+- confirm the Google button is visible there too
+- open `/auth/signup?invite_token=test`
+- confirm the page stays email-only in this first pass
+
+### Negative checks
+
+Temporarily remove one setting and restart:
+
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `features.google_oauth`
+
+Expected result: button disappears cleanly; email auth still works.
+
+## Deploy checks
+
+For production verify all of these match exactly:
+
+- `BETTER_AUTH_URL=https://your-real-domain`
+- `CORS_ORIGINS=https://your-real-domain`
+- Google redirect URI is `https://your-real-domain/auth/callback/google`
+- browser origin matches `BETTER_AUTH_URL`
+
+If callback/origin values drift, Google auth usually fails with redirect mismatch symptoms.
+
+## Troubleshooting
+
+### Button not showing
+
+Check first:
+
+- `GOOGLE_CLIENT_ID` present
+- `GOOGLE_CLIENT_SECRET` present
+- `google_oauth = true` in TOML
+- `boring.app.toml` exists in the app root if you expect that flag to load
+- app restarted after config change
+
+### Redirect mismatch
+
+Usually one of these is wrong:
+
+- `BETTER_AUTH_URL`
+- `CORS_ORIGINS`
+- Google Cloud redirect URI
+- deployed hostname/protocol
+
+All of them must agree exactly.
+
+### App uses custom auth pages and still has no Google button
+
+The app is probably bypassing core's default auth UI. Import `GoogleAuthButton` into the override instead of expecting it to appear automatically.
+
+## Scope boundaries
+
+This skill is for **web Google signup/signin in child apps**.
+
+Not in scope:
+
+- Google One Tap
+- native mobile token flows
+- generic multi-provider architecture or provider-picker UI
+- invite-token carry through OAuth redirects
+- billing / tenant-specific auth policy
+
+## References
+
+- `docs/plans/google-signup-child-app-plan.md`
+- `packages/core/docs/CORE.md`
+- `packages/core/src/server/auth/createAuth.ts`
+- `packages/core/src/front/auth/SignInPage.tsx`
+- `packages/core/src/front/auth/SignUpPage.tsx`

--- a/apps/full-app/e2e/collaboration.spec.ts
+++ b/apps/full-app/e2e/collaboration.spec.ts
@@ -56,6 +56,7 @@ const CONFIG = {
   apiBase: '',
   features: {
     githubOauth: false,
+    googleOauth: false,
     invitesEnabled: true,
     sendWelcomeEmail: false,
   },

--- a/apps/full-app/e2e/google-auth-webserver.sh
+++ b/apps/full-app/e2e/google-auth-webserver.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+APP_DIR=$(cd "$SCRIPT_DIR/.." && pwd)
+CONFIG_DIR=$(mktemp -d)
+CONFIG_PATH="$CONFIG_DIR/boring.app.toml"
+
+cleanup() {
+  rm -rf "$CONFIG_DIR"
+}
+trap cleanup EXIT
+
+printf '[features]\ngoogle_oauth = true\n' > "$CONFIG_PATH"
+
+cd "$APP_DIR"
+pnpm --filter @hachej/boring-core exec tsup --no-dts
+pnpm --filter @hachej/boring-core exec sh -c "cp src/front/theme.css dist/front/theme.css"
+pnpm migrate
+pnpm build
+cd "$CONFIG_DIR"
+exec env NODE_ENV=production node "$APP_DIR/dist/server/main.js"

--- a/apps/full-app/e2e/google-signup.spec.ts
+++ b/apps/full-app/e2e/google-signup.spec.ts
@@ -1,0 +1,213 @@
+import { expect, test, type Page } from '@playwright/test'
+
+const BEAD = 'boring-ui-v2-reorg-2omj'
+const GOOGLE_BUTTON_NAME = 'Continue with Google'
+const CALLBACK_PATH = '/auth/callback/google?code=mock-google-code&state=mock-google-state'
+
+function log(event: string, fields: Record<string, unknown> = {}): void {
+  console.info(JSON.stringify({ level: 'info', bead: BEAD, event, ...fields }))
+}
+
+function json(body: unknown, status = 200) {
+  return {
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  }
+}
+
+async function installGoogleAuthSmokeMocks(page: Page, baseURL: string | undefined) {
+  page.on('framenavigated', (frame) => {
+    if (frame !== page.mainFrame()) return
+    log('google-signup.route.visited', { url: frame.url() })
+  })
+
+  page.on('pageerror', (error) => {
+    log('google-signup.pageerror', {
+      name: error.name,
+      message: error.message,
+    })
+  })
+
+  page.on('console', (msg) => {
+    if (msg.type() !== 'error') return
+    log('google-signup.console.error', { text: msg.text() })
+  })
+
+  await page.route('https://accounts.google.com/**', async (route) => {
+    log('google-signup.external-google-redirect', {
+      url: route.request().url(),
+      method: route.request().method(),
+    })
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html; charset=utf-8',
+      body: '<!doctype html><html><body>mock google oauth boundary</body></html>',
+    })
+  })
+
+  await page.route('**/*', async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+    if (baseURL && url.origin !== new URL(baseURL).origin) {
+      return route.continue()
+    }
+
+    const path = url.pathname
+
+    if (path === '/api/v1/config') {
+      const response = await route.fetch()
+      const payload = await response.json()
+      const googleOauth = (payload as { features?: { googleOauth?: boolean } }).features?.googleOauth ?? null
+      log('google-signup.runtime-config', {
+        path,
+        googleOauth,
+      })
+      return route.fulfill({ response })
+    }
+
+    if (path === '/auth/get-session') {
+      return route.fulfill(json(null))
+    }
+
+    if (path === '/api/v1/workspaces' && request.method() === 'GET') {
+      return route.fulfill(json({ workspaces: [] }))
+    }
+
+    return route.continue()
+  })
+}
+
+async function visit(page: Page, route: string) {
+  log('google-signup.visit.start', { route })
+  const response = await page.goto(route, { waitUntil: 'domcontentloaded' })
+  log('google-signup.visit.complete', {
+    route,
+    status: response?.status() ?? null,
+    finalUrl: page.url(),
+  })
+  return response
+}
+
+async function readGoogleButtonState(page: Page, route: string) {
+  const button = page.getByRole('button', { name: GOOGLE_BUTTON_NAME })
+  const count = await button.count()
+  const visible = count > 0
+    ? await button.first().isVisible().catch(() => false)
+    : false
+
+  log('google-signup.button-state', {
+    route,
+    rendered: count > 0,
+    visible,
+    count,
+  })
+
+  return { button, count, visible }
+}
+
+test.describe('google signup smoke', () => {
+  test('stock sign-in shows Google and real social-init redirects toward Google', async ({ page, baseURL }) => {
+    await installGoogleAuthSmokeMocks(page, baseURL)
+
+    await test.step('stock sign-in shows Google button when enabled by real runtime config', async () => {
+      const response = await visit(page, '/auth/signin')
+      expect(response?.status(), 'expected /auth/signin to be served by the app shell').toBe(200)
+      await expect(page.getByLabel('Email')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByLabel('Password')).toBeVisible()
+
+      const { button, visible } = await readGoogleButtonState(page, '/auth/signin')
+      expect(
+        visible,
+        'expected stock sign-in to render Continue with Google when the live runtime config exposes features.googleOauth=true',
+      ).toBe(true)
+      await expect(button).toBeVisible()
+    })
+
+    await test.step('clicking Google uses the real auth route and redirects toward Google', async () => {
+      const responsePromise = page.waitForResponse((response) => {
+        const url = new URL(response.url())
+        return url.pathname === '/auth/sign-in/social'
+      })
+
+      await page.getByRole('button', { name: GOOGLE_BUTTON_NAME }).click()
+      const socialInit = await responsePromise
+      const socialInitUrl = new URL(socialInit.url())
+
+      log('google-signup.social-init.response', {
+        path: socialInitUrl.pathname,
+        status: socialInit.status(),
+      })
+
+      expect(socialInit.status(), 'expected real /auth/sign-in/social request to succeed').toBe(200)
+      await page.waitForURL(/accounts\.google\.com/, { timeout: 15_000 })
+
+      log('google-signup.social-init.boundary', {
+        finalUrl: page.url(),
+        manualBoundary: 'Live Google auth completion still requires a real provider redirect + valid callback exchange.',
+      })
+    })
+  })
+
+  test('stock sign-up shows Google, invite-token sign-up hides it, and callback path is real', async ({ page, baseURL }) => {
+    await installGoogleAuthSmokeMocks(page, baseURL)
+
+    await test.step('normal stock sign-up shows Google button', async () => {
+      const response = await visit(page, '/auth/signup')
+      expect(response?.status(), 'expected /auth/signup to be served by the app shell').toBe(200)
+      await expect(page.getByLabel('Name')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByLabel('Email')).toBeVisible()
+      await expect(page.getByLabel('Password')).toBeVisible()
+
+      const { button, visible } = await readGoogleButtonState(page, '/auth/signup')
+      expect(
+        visible,
+        'expected stock sign-up to render Continue with Google when the live runtime config exposes features.googleOauth=true',
+      ).toBe(true)
+      await expect(button).toBeVisible()
+    })
+
+    await test.step('invite-token sign-up hides Google button and keeps email fields', async () => {
+      const inviteRoute = '/auth/signup?invite_token=invite-smoke-token'
+      const response = await visit(page, inviteRoute)
+      expect(response?.status(), 'expected invite-token sign-up route to be served by the app shell').toBe(200)
+      await expect(page.getByLabel('Name')).toBeVisible({ timeout: 10_000 })
+      await expect(page.getByLabel('Email')).toBeVisible()
+      await expect(page.getByLabel('Password')).toBeVisible()
+
+      const { count, visible } = await readGoogleButtonState(page, inviteRoute)
+      expect(
+        count,
+        'expected invite-token sign-up to stay email-only and hide Continue with Google',
+      ).toBe(0)
+      expect(visible).toBe(false)
+    })
+
+    await test.step('callback path is reachable through the real auth stack', async () => {
+      const callbackResponse = await page.request.get(CALLBACK_PATH, {
+        headers: { accept: 'text/html' },
+        failOnStatusCode: false,
+        maxRedirects: 0,
+      })
+      const redirectLocation = callbackResponse.headers()['location'] ?? null
+
+      log('google-signup.callback.reached', {
+        route: CALLBACK_PATH,
+        status: callbackResponse.status(),
+        location: redirectLocation,
+      })
+
+      expect(
+        [302, 400, 401],
+        'expected /auth/callback/google to be mounted and handled by the real auth stack; bad state should still produce an auth response instead of 404/500',
+      ).toContain(callbackResponse.status())
+
+      if (callbackResponse.status() === 302 && redirectLocation) {
+        const redirectUrl = new URL(redirectLocation, baseURL)
+        await visit(page, `${redirectUrl.pathname}${redirectUrl.search}`)
+        await expect(page.getByText('Authentication error')).toBeVisible({ timeout: 10_000 })
+      }
+    })
+  })
+})

--- a/apps/full-app/e2e/playwright.config.ts
+++ b/apps/full-app/e2e/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test'
+import { fileURLToPath } from 'node:url'
 
 const apiPort = Number(process.env.FULL_APP_E2E_PORT ?? 3900)
 const apiOrigin = `http://127.0.0.1:${apiPort}`
@@ -6,23 +7,39 @@ const baseURL = process.env.FULL_APP_E2E_BASE_URL ?? apiOrigin
 const isCI = process.env.CI === 'true' || process.env.CI === '1'
 const authSecret = process.env.BETTER_AUTH_SECRET ?? 'a'.repeat(64)
 const settingsKey = process.env.WORKSPACE_SETTINGS_ENCRYPTION_KEY ?? 'b'.repeat(64)
+const providedDatabaseUrl = process.env.FULL_APP_E2E_DATABASE_URL ?? process.env.DATABASE_URL
+
+if (isCI && !providedDatabaseUrl) {
+  throw new Error('FULL_APP_E2E_DATABASE_URL or DATABASE_URL is required for full-app Playwright runs in CI')
+}
+
 const databaseUrl =
-  process.env.DATABASE_URL ??
-  'postgres://placeholder:placeholder@127.0.0.1:5432/placeholder'
-const sharedEnv = [
-  `DATABASE_URL=${databaseUrl}`,
-  `BETTER_AUTH_SECRET=${authSecret}`,
-  `WORKSPACE_SETTINGS_ENCRYPTION_KEY=${settingsKey}`,
-  `BETTER_AUTH_URL=${apiOrigin}`,
-  'MAIL_FROM=noreply@test.local',
-  'MAIL_TRANSPORT_URL=smtp://test:test@127.0.0.1:2525',
-  `PORT=${apiPort}`,
-  'CSP_ENABLED=true',
-].join(' ')
+  providedDatabaseUrl ??
+  // Requires the standard local boring-ui-v2 test Postgres used elsewhere on this VM.
+  'postgres://ubuntu:test@127.0.0.1/boring_ui_test'
+const googleClientId = process.env.FULL_APP_E2E_GOOGLE_CLIENT_ID ?? 'test-google-client-id'
+const googleClientSecret = process.env.FULL_APP_E2E_GOOGLE_CLIENT_SECRET ?? 'test-google-client-secret'
+const mailTransportUrl = process.env.FULL_APP_E2E_MAIL_TRANSPORT_URL ?? 'smtp://test:test@127.0.0.1:2525'
+const webServerScript = fileURLToPath(new URL('./google-auth-webserver.sh', import.meta.url))
+const webServerEnv = Object.fromEntries(
+  Object.entries({
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+    BETTER_AUTH_SECRET: authSecret,
+    WORKSPACE_SETTINGS_ENCRYPTION_KEY: settingsKey,
+    BETTER_AUTH_URL: apiOrigin,
+    GOOGLE_CLIENT_ID: googleClientId,
+    GOOGLE_CLIENT_SECRET: googleClientSecret,
+    MAIL_FROM: 'noreply@test.local',
+    MAIL_TRANSPORT_URL: mailTransportUrl,
+    PORT: String(apiPort),
+    CSP_ENABLED: 'true',
+  }).filter((entry): entry is [string, string] => typeof entry[1] === 'string'),
+)
 
 export default defineConfig({
   testDir: '.',
-  testMatch: ['smoke.spec.ts', 'csp.spec.ts', 'workspace-lifecycle.spec.ts'],
+  testMatch: ['smoke.spec.ts', 'csp.spec.ts', 'workspace-lifecycle.spec.ts', 'google-signup.spec.ts'],
   fullyParallel: false,
   workers: 1,
   retries: isCI ? 1 : 0,
@@ -36,7 +53,8 @@ export default defineConfig({
     video: 'off',
   },
   webServer: {
-    command: `pnpm --filter @hachej/boring-core exec tsup --no-dts && pnpm --filter @hachej/boring-core exec sh -c "cp src/front/theme.css dist/front/theme.css" && ${sharedEnv} pnpm build && NODE_ENV=production ${sharedEnv} pnpm start`,
+    command: webServerScript,
+    env: webServerEnv,
     url: apiOrigin,
     timeout: 360_000,
     reuseExistingServer: false,

--- a/apps/full-app/e2e/smoke.spec.ts
+++ b/apps/full-app/e2e/smoke.spec.ts
@@ -74,6 +74,7 @@ test('smoke: sign in and land on /workspace/:id', async ({ page, baseURL }) => {
         apiBase: baseURL,
         features: {
           githubOauth: false,
+          googleOauth: false,
           invitesEnabled: true,
           sendWelcomeEmail: false,
         },

--- a/apps/full-app/e2e/workspace-lifecycle.spec.ts
+++ b/apps/full-app/e2e/workspace-lifecycle.spec.ts
@@ -17,6 +17,7 @@ const CONFIG = {
   apiBase: '',
   features: {
     githubOauth: false,
+    googleOauth: false,
     invitesEnabled: true,
     sendWelcomeEmail: false,
   },

--- a/docs/plans/google-signup-child-app-plan.html
+++ b/docs/plans/google-signup-child-app-plan.html
@@ -1,0 +1,443 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Google Signup Child App Plan</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b1020;
+      --panel: #121a2b;
+      --panel-2: #0f1727;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --line: #283548;
+      --accent: #7dd3fc;
+      --accent-2: #86efac;
+      --warn: #fbbf24;
+      --danger: #fca5a5;
+      --code: #111827;
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font: 16px/1.65 ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background: linear-gradient(180deg, #0b1020, #111827 320px, #0b1020);
+      color: var(--text);
+    }
+    a { color: inherit; }
+    code {
+      background: var(--code);
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: .12rem .35rem;
+      font: .92em ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      color: #bae6fd;
+    }
+    pre {
+      margin: 0;
+      overflow: auto;
+      background: #0a1220;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 18px;
+      box-shadow: 0 12px 36px rgba(0,0,0,.18);
+    }
+    pre code { background: transparent; border: 0; padding: 0; }
+    main {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 40px 24px 96px;
+      display: grid;
+      grid-template-columns: 280px minmax(0, 1fr);
+      gap: 28px;
+    }
+    nav {
+      position: sticky;
+      top: 18px;
+      align-self: start;
+      background: rgba(15,23,39,.9);
+      border: 1px solid var(--line);
+      border-radius: 20px;
+      padding: 18px;
+      backdrop-filter: blur(10px);
+    }
+    nav h2 {
+      margin: 0 0 10px;
+      font-size: .95rem;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      color: var(--accent);
+    }
+    nav ol { margin: 0; padding-left: 1.2rem; }
+    nav li { margin: .35rem 0; color: var(--muted); }
+    nav a { text-decoration: none; }
+    article { min-width: 0; }
+    .eyebrow {
+      color: var(--accent);
+      font-weight: 700;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+      font-size: .78rem;
+      margin-bottom: 14px;
+    }
+    h1 {
+      margin: 0 0 14px;
+      font-size: clamp(2.2rem, 5vw, 4.4rem);
+      line-height: .95;
+      letter-spacing: -.06em;
+    }
+    h2 {
+      margin-top: 54px;
+      padding-top: 18px;
+      border-top: 1px solid var(--line);
+      font-size: 1.7rem;
+      letter-spacing: -.03em;
+    }
+    h3 { margin-top: 28px; font-size: 1.18rem; }
+    p, li { color: #d9dee8; }
+    ul, ol { padding-left: 1.35rem; }
+    li { margin: .28rem 0; }
+    .meta { color: var(--muted); margin-bottom: 28px; }
+    .card, .callout {
+      background: rgba(18,26,43,.78);
+      border: 1px solid var(--line);
+      border-radius: 20px;
+      padding: 20px;
+      margin: 20px 0;
+    }
+    .summary-grid, .review-grid, .decision-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 14px;
+      margin: 18px 0;
+    }
+    .mini {
+      background: rgba(15,23,39,.92);
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      padding: 16px;
+    }
+    .mini h4 {
+      margin: 0 0 8px;
+      font-size: .95rem;
+      color: var(--accent);
+      letter-spacing: .02em;
+    }
+    .badge {
+      display: inline-block;
+      padding: 6px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--line);
+      color: var(--muted);
+      font-size: .85rem;
+      margin-right: 8px;
+      margin-bottom: 8px;
+      background: rgba(15,23,39,.9);
+    }
+    .good { color: var(--accent-2); }
+    .warn { color: var(--warn); }
+    .danger { color: var(--danger); }
+    .checklist li { margin: .55rem 0; }
+    .section-note {
+      color: var(--muted);
+      font-size: .98rem;
+      margin-top: -6px;
+    }
+    .footer {
+      margin-top: 56px;
+      color: var(--muted);
+      font-size: .95rem;
+    }
+    @media (max-width: 960px) {
+      main { grid-template-columns: 1fr; }
+      nav { position: static; }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <nav>
+      <h2>Review map</h2>
+      <ol>
+        <li><a href="#summary">Executive summary</a></li>
+        <li><a href="#core-idea">Core idea</a></li>
+        <li><a href="#locked">Locked decisions</a></li>
+        <li><a href="#workflows">User workflows</a></li>
+        <li><a href="#implementation">Implementation</a></li>
+        <li><a href="#exact">Exact implementation</a></li>
+        <li><a href="#tasks">Task groups</a></li>
+        <li><a href="#acceptance">Acceptance</a></li>
+        <li><a href="#risks">Risks</a></li>
+        <li><a href="#review-questions">Review questions</a></li>
+      </ol>
+    </nav>
+
+    <article>
+      <div class="eyebrow">Boring UI auth plan</div>
+      <h1>Google Signup for Any Child App</h1>
+      <p class="meta">
+        Status: <code>review ready</code> · Scope: <code>@hachej/boring-core</code> + child-app docs/skill ·
+        Source: <code>docs/plans/google-signup-child-app-plan.md</code>
+      </p>
+
+      <section id="summary">
+        <div class="card"><strong>Goal:</strong> make Google signup/signin a near-zero-code opt-in for child apps using the existing core auth stack.</div>
+        <div class="summary-grid">
+          <div class="mini"><h4>What this is</h4><ul><li>better-auth already powers core auth</li><li>Google is one better-auth social provider</li><li>core remains the auth owner</li></ul></div>
+          <div class="mini"><h4>What ships</h4><ul><li>Google config in core</li><li><code>features.google_oauth = true</code></li><li><code>socialProviders.google</code></li><li><code>GoogleAuthButton</code></li><li>Google callback route</li></ul></div>
+          <div class="mini"><h4>What stays small</h4><ul><li>no second auth system</li><li>no <code>GOOGLE_OAUTH</code> env flag</li><li>no generic provider UI</li><li>no invite OAuth state carry</li></ul></div>
+        </div>
+      </section>
+
+      <section id="core-idea">
+        <h2>Core idea</h2>
+        <p><code>@hachej/boring-core</code> already owns auth.</p>
+        <p>Google should be added as <strong>one social provider inside the existing better-auth provider</strong>, not as a second provider system.</p>
+        <ul>
+          <li>no separate auth architecture</li>
+          <li>no custom token/session model</li>
+          <li>no app-specific Google wiring in each child app</li>
+          <li>no forked auth pages required for normal usage</li>
+        </ul>
+      </section>
+
+      <section id="goal">
+        <h2>Goal</h2>
+        <p>A stock child app should only need:</p>
+        <ul>
+          <li><code>GOOGLE_CLIENT_ID</code></li>
+          <li><code>GOOGLE_CLIENT_SECRET</code></li>
+          <li><code>features.google_oauth = true</code></li>
+        </ul>
+        <p>Then core should provide Google on stock sign-in, Google on normal stock sign-up, callback handling through the existing auth stack, and one reusable <code>GoogleAuthButton</code> for branded child apps.</p>
+      </section>
+
+      <section id="why">
+        <h2>Why this matters</h2>
+        <ul>
+          <li>child apps can enable Google with a tiny config delta</li>
+          <li>core remains the canonical auth owner</li>
+          <li>branded child apps reuse one small primitive instead of re-learning better-auth</li>
+          <li>we avoid auth drift across child apps</li>
+        </ul>
+      </section>
+
+      <section id="workflows">
+        <h2>User workflows</h2>
+        <h3>Workflow A — stock child app</h3>
+        <ol>
+          <li>operator sets <code>GOOGLE_CLIENT_ID</code> and <code>GOOGLE_CLIENT_SECRET</code></li>
+          <li>operator sets <code>features.google_oauth = true</code></li>
+          <li>user visits <code>/auth/signin</code></li>
+          <li>user sees <strong>Continue with Google</strong></li>
+          <li>user signs in and lands back in the app authenticated</li>
+        </ol>
+
+        <h3>Workflow B — stock signup page</h3>
+        <ol>
+          <li>user visits <code>/auth/signup</code></li>
+          <li>user sees Google plus the existing email form</li>
+          <li>user can choose Google or email signup</li>
+          <li>existing email signup behavior stays unchanged</li>
+        </ol>
+
+        <h3>Workflow C — invite signup</h3>
+        <ol>
+          <li>invited user lands on <code>/auth/signup?invite_token=...</code></li>
+          <li>user sees the existing email signup flow only</li>
+          <li>user completes the existing invite-aware email path</li>
+        </ol>
+        <div class="callout"><strong>First-pass simplification:</strong> choose correctness over OAuth state-carry complexity.</div>
+
+        <h3>Workflow D — branded child app</h3>
+        <ol>
+          <li>child app overrides core auth pages</li>
+          <li>child app imports <code>GoogleAuthButton</code> from core</li>
+          <li>child app keeps its own branding/layout while reusing core OAuth behavior</li>
+        </ol>
+      </section>
+
+      <section id="non-goals">
+        <h2>Non-goals for this first pass</h2>
+        <div>
+          <span class="badge">no generic social-provider registry</span>
+          <span class="badge">no second auth provider abstraction</span>
+          <span class="badge">no invite-token carry across OAuth redirects</span>
+          <span class="badge">no Google One Tap</span>
+          <span class="badge">no provider-specific landing-page config</span>
+          <span class="badge">no auth override API redesign</span>
+        </div>
+      </section>
+
+      <section id="locked">
+        <h2>Locked decisions in this draft</h2>
+        <p class="section-note">These are the simplifications this plan asks the reviewer to approve.</p>
+        <div class="decision-grid">
+          <div class="mini"><h4>Provider model</h4><p>Google comes through better-auth inside the existing core auth stack. No separate auth system.</p></div>
+          <div class="mini"><h4>Config shape</h4><p>No <code>GOOGLE_OAUTH</code> env flag. One app-level TOML flag plus credentials.</p></div>
+          <div class="mini"><h4>Invite flow</h4><p>Invite signup stays email-only. No OAuth invite-token carry in v1.</p></div>
+          <div class="mini"><h4>Front-end seam</h4><p>Ship <code>GoogleAuthButton</code>, not a generic provider UI.</p></div>
+          <div class="mini"><h4>Routing scope</h4><p>Add an explicit Google callback route. No callback-routing refactor.</p></div>
+          <div class="mini"><h4>Failure mode</h4><p>Missing credentials disable Google cleanly. App still boots.</p></div>
+        </div>
+      </section>
+
+      <section id="implementation">
+        <h2>Proposed implementation</h2>
+
+        <h3>1. Config surface</h3>
+        <ul>
+          <li>env: <code>GOOGLE_CLIENT_ID</code>, <code>GOOGLE_CLIENT_SECRET</code></li>
+          <li>TOML: <code>features.google_oauth = true</code></li>
+          <li>types: add <code>auth.google</code>, <code>features.googleOauth</code>, runtime/capability fields</li>
+        </ul>
+        <div class="callout"><strong>Rule:</strong> Google resolves on only when the TOML flag is true and both credentials exist.</div>
+
+        <h3>2. better-auth wiring</h3>
+        <pre><code>socialProviders: {
+  ...(config.auth.github ? { github: {...} } : {}),
+  ...(config.auth.google ? { google: {...} } : {}),
+}</code></pre>
+        <p>Do not add provider-specific custom logic beyond the minimum better-auth config needed for Google.</p>
+
+        <h3>3. Front-end auth UX</h3>
+        <ul>
+          <li>ship one helper: <code>GoogleAuthButton</code></li>
+          <li>visibility driven by <code>useConfig()</code></li>
+          <li>internally calls <code>authClient.signIn.social({ provider: 'google', callbackURL: '/' })</code></li>
+          <li>optional <code>callbackURL</code> prop is acceptable; default stays <code>'/'</code></li>
+          <li>show on stock sign-in and normal stock sign-up</li>
+          <li>hide on sign-up pages with <code>invite_token</code></li>
+        </ul>
+
+        <h3>4. Callback-route audit</h3>
+        <ul>
+          <li>audit route map / front utils</li>
+          <li>audit <code>CoreFront</code> route registration</li>
+          <li>audit server-side auth-page allowlist/public-page handling</li>
+          <li>audit the SPA-shell auth-page allowlist in <code>createCoreWorkspaceAgentServer.ts</code></li>
+          <li>add route tests for <code>/auth/callback/google</code></li>
+        </ul>
+        <div class="callout"><strong>Important:</strong> core's better-auth base path is <code>/auth</code>, not <code>/api/auth</code>. So <code>/auth/callback/google</code> is a real auth callback path in this app.</div>
+        <div class="callout"><strong>Scope rule:</strong> add the explicit Google callback path everywhere needed. Do not generalize callback routing yet.</div>
+
+        <h3>5. Child-app override seam</h3>
+        <p>Export <code>GoogleAuthButton</code> from <code>@hachej/boring-core/front</code>. Do not ship a generic provider UI in v1.</p>
+
+        <h3>6. Docs + skill</h3>
+        <ul>
+          <li>update core docs with Google signup env + redirect URI setup</li>
+          <li>update child-app setup skill</li>
+          <li>document callback URLs:</li>
+        </ul>
+        <pre><code>local: http://localhost:3000/auth/callback/google
+prod:  https://&lt;app-domain&gt;/auth/callback/google</code></pre>
+      </section>
+
+      <section id="exact">
+        <h2>What exactly must be implemented</h2>
+        <ol class="checklist">
+          <li><strong>Core config</strong> — add <code>GOOGLE_CLIENT_ID</code>, <code>GOOGLE_CLIENT_SECRET</code>, <code>features.google_oauth = true</code>, and teach <code>TomlAppConfig.features</code> to read <code>google_oauth</code>.</li>
+          <li><strong>better-auth wiring</strong> — pass <code>socialProviders.google</code> into the existing core auth setup.</li>
+          <li><strong>Capabilities/runtime flags</strong> — expose <code>features.googleOauth</code> and <code>core.auth.google</code>, and update <code>buildRuntimeConfigPayload()</code> so the frontend actually receives the flag.</li>
+          <li><strong>Reusable front-end primitive</strong> — add <code>GoogleAuthButton</code> that calls <code>authClient.signIn.social({ provider: 'google', callbackURL: '/' })</code>.</li>
+          <li><strong>Stock auth pages</strong> — use it on stock sign-in and normal stock sign-up; hide it for invite-token signup.</li>
+          <li><strong>Callback route</strong> — add <code>/auth/callback/google</code>, treat it like a public auth callback route, and update the SPA-shell auth-page allowlist in <code>createCoreWorkspaceAgentServer.ts</code>.</li>
+          <li><strong>Docs + skill</strong> — update <code>CORE.md</code> and the child-app setup skill; document <code>BETTER_AUTH_URL</code>, <code>CORS_ORIGINS</code>, and callback URLs.</li>
+          <li><strong>Tests</strong> — config, auth wiring, callback route, visible/hidden button behavior, and existing email auth still passing.</li>
+        </ol>
+      </section>
+
+      <section id="tasks">
+        <h2>Implementation task groups</h2>
+        <div class="review-grid">
+          <div class="mini"><h4>1. Config + shared types</h4><p>Add <code>auth.google</code>, <code>features.googleOauth</code>, capability fields, <code>TomlAppConfig.features.google_oauth</code>, and update <code>buildRuntimeConfigPayload()</code>.</p><p><strong>Verify:</strong> config tests cover enabled + disabled cases.</p></div>
+          <div class="mini"><h4>2. Server auth wiring</h4><p>Extend <code>createAuth()</code>; update capabilities so Google means usable now.</p><p><strong>Verify:</strong> auth creation + capabilities tests.</p></div>
+          <div class="mini"><h4>3. Callback-route audit</h4><p>Add <code>/auth/callback/google</code>; update <code>createCoreWorkspaceAgentServer.ts</code>; ensure it is mounted/public where needed.</p><p><strong>Verify:</strong> route tests for callback path.</p></div>
+          <div class="mini"><h4>4. Front-end auth UX</h4><p>Add <code>GoogleAuthButton</code>; use it on stock pages; hide it for invite signup.</p><p><strong>Verify:</strong> visible/hidden states + click behavior.</p></div>
+          <div class="mini"><h4>5. Docs + child-app teaching</h4><p>Update <code>CORE.md</code> and setup skill; include <code>BETTER_AUTH_URL</code> + <code>CORS_ORIGINS</code> callouts.</p><p><strong>Verify:</strong> docs match shipped names and API.</p></div>
+        </div>
+      </section>
+
+      <section id="acceptance">
+        <h2>Acceptance criteria</h2>
+        <h3>Product</h3>
+        <ul class="checklist">
+          <li>child app can enable Google signup without forking core auth pages</li>
+          <li>default sign-in shows Google when enabled</li>
+          <li>default sign-up shows Google for normal signup flow</li>
+          <li>invite-token sign-up stays email-only</li>
+          <li>Google is absent when feature/credentials are missing</li>
+          <li>custom child-app auth pages can import <code>GoogleAuthButton</code></li>
+        </ul>
+
+        <h3>Technical</h3>
+        <ul class="checklist">
+          <li>config validation covers Google env + flag resolution</li>
+          <li>better-auth receives Google provider config only when valid</li>
+          <li><code>/api/v1/config</code> exposes <code>features.googleOauth</code></li>
+          <li><code>/api/v1/capabilities</code> exposes Google auth availability</li>
+          <li><code>core.auth.google</code> means usable now, not merely configured</li>
+          <li><code>/auth/callback/google</code> is mounted and public as an auth callback route</li>
+          <li>existing GitHub behavior keeps working</li>
+        </ul>
+
+        <h3>Tests</h3>
+        <ol class="checklist">
+          <li><code>loadConfig</code> resolves <code>googleOauth</code> when TOML flag + creds are present</li>
+          <li><code>loadConfig</code> keeps <code>googleOauth=false</code> when creds are incomplete</li>
+          <li><code>createAuth</code> includes Google provider when configured</li>
+          <li><code>CoreFront</code> mounts <code>/auth/callback/google</code></li>
+          <li><code>SignInPage</code> renders Google only when enabled</li>
+          <li><code>SignUpPage</code> renders Google only for normal signup flow</li>
+          <li><code>SignUpPage</code> hides Google when <code>invite_token</code> is present</li>
+          <li>clicking Google calls <code>signIn.social({ provider: 'google' ... })</code></li>
+          <li>existing email sign-in/sign-up tests still pass</li>
+        </ol>
+      </section>
+
+      <section id="risks">
+        <h2>Risks / watchouts</h2>
+        <ul>
+          <li><span class="warn"><strong>Docs drift:</strong></span> docs still describe social auth as deferred / GitHub-specific in several places</li>
+          <li><span class="danger"><strong>Callback mismatch:</strong></span> Google will fail if <code>BETTER_AUTH_URL</code> is wrong</li>
+          <li><span class="warn"><strong>Invite flow complexity:</strong></span> do not invent OAuth state carry in this first pass</li>
+          <li><span class="warn"><strong>Capability ambiguity:</strong></span> define <code>core.auth.google</code> as usable now</li>
+          <li><span class="good"><strong>Over-design guardrail:</strong></span> do not build a generic provider framework yet</li>
+        </ul>
+      </section>
+
+      <section id="review-questions">
+        <h2>Review questions</h2>
+        <div class="card">
+          <ol class="checklist">
+            <li><strong>Provider model:</strong> approve treating Google as one better-auth social provider inside the existing core auth stack?</li>
+            <li><strong>Config shape:</strong> approve TOML flag + credentials, with no separate <code>GOOGLE_OAUTH</code> env flag?</li>
+            <li><strong>Invite behavior:</strong> approve hiding Google on invite-token signup instead of solving OAuth state carry now?</li>
+            <li><strong>Front-end seam:</strong> approve shipping only <code>GoogleAuthButton</code> in v1?</li>
+            <li><strong>Routing scope:</strong> approve adding an explicit Google callback path instead of generalizing callback routing now?</li>
+            <li><strong>Redirect default:</strong> approve defaulting the Google button callback to <code>'/'</code> for the first pass?</li>
+          </ol>
+          <p><strong>If the answer to all six is yes, this plan is ready to implement.</strong></p>
+        </div>
+      </section>
+
+      <section id="later">
+        <h2>Nice-to-have later, not in this first pass</h2>
+        <ul>
+          <li>generic <code>socialProviders</code> runtime type</li>
+          <li>GitHub + Google unified provider list</li>
+          <li>Google One Tap</li>
+          <li>provider icons/theme slots</li>
+          <li>provider-specific callback / landing route config</li>
+        </ul>
+      </section>
+
+      <p class="footer">Generated as a review-friendly HTML companion to the markdown plan.</p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/plans/google-signup-child-app-plan.md
+++ b/docs/plans/google-signup-child-app-plan.md
@@ -1,0 +1,476 @@
+# Google signup for any child app — plan
+
+**Status:** review ready
+**Scope:** `@hachej/boring-core` + child-app docs/skill
+**Worktree:** `.worktrees/google-signup-child-app-auth`
+
+## Executive summary
+
+This plan keeps Google signup small.
+
+We already use **better-auth** as the core auth provider. better-auth already knows how to do Google OAuth. So this is **not** a new auth system and **not** a custom Google integration from scratch.
+
+This plan only does five things:
+
+1. expose Google credentials in core config
+2. gate Google with one app-level feature flag: `features.google_oauth = true`
+3. wire `socialProviders.google` into the existing better-auth setup
+4. add one reusable front-end primitive: `GoogleAuthButton`
+5. mount the Google callback route in the same auth system
+
+If a child app uses the stock `@hachej/boring-core` auth stack, Google should work **out of the box** once the app sets credentials and enables the feature.
+
+## Core idea
+
+`@hachej/boring-core` already owns auth.
+
+Today that auth stack is:
+
+- core config
+- core auth routes
+- better-auth session/cookie/user handling
+- core stock auth pages
+
+Google should be added as **one social provider inside the existing better-auth provider**, not as a second provider system.
+
+That means:
+
+- no separate auth architecture
+- no custom token/session model
+- no app-specific Google wiring in each child app
+- no forked auth pages required for normal usage
+
+## Goal
+
+Make Google signup/signin a near-zero-code opt-in for any child app built on `@hachej/boring-core`.
+
+A stock child app should only need:
+
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `features.google_oauth = true`
+
+Implementation note:
+
+- `boring.app.toml` is optional today in this repo
+- child apps that want Google and do not already have a `boring.app.toml` file will need to add one
+
+Then core should provide:
+
+- Google on stock sign-in
+- Google on normal stock sign-up
+- Google callback handling through the existing auth stack
+- one reusable `GoogleAuthButton` for branded child apps
+
+## Why this matters
+
+Child apps should not need to fork core auth pages just to add one mainstream social provider.
+
+The value of this feature is:
+
+- child apps can enable Google with a tiny config delta
+- core remains the canonical auth owner
+- branded child apps can reuse one small primitive instead of re-learning better-auth
+- we avoid auth drift across child apps
+
+This should feel boring in a good way: obvious to enable, hard to misconfigure, and narrow in scope.
+
+## User workflows
+
+### Workflow A — stock child app
+
+1. app operator sets `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`
+2. app operator sets `features.google_oauth = true`
+3. user visits `/auth/signin`
+4. user sees **Continue with Google**
+5. user signs in through Google and lands back in the app authenticated
+
+### Workflow B — stock signup page
+
+1. user visits `/auth/signup`
+2. user sees **Continue with Google** and the existing email form
+3. user can choose Google or email signup
+4. existing email signup behavior stays unchanged
+
+### Workflow C — invite signup
+
+1. invited user lands on `/auth/signup?invite_token=...`
+2. user sees the existing email signup flow only
+3. user completes the existing invite-aware email signup path
+
+This is an intentional first-pass simplification. We choose correctness over OAuth state-carry complexity.
+
+### Workflow D — branded child app
+
+1. child app overrides core auth pages
+2. child app imports `GoogleAuthButton` from core
+3. child app keeps its own branding/layout while reusing core OAuth behavior
+
+## Non-goals for this first pass
+
+- generic social-provider registry
+- a second auth provider abstraction
+- invite-token carry across OAuth redirects
+- Google One Tap
+- provider-specific landing-page config
+- redesigning core auth override APIs
+- adding more providers in the same change
+
+## Locked decisions in this draft
+
+These are the intentional simplifications this plan asks you to approve:
+
+- **Google comes through better-auth.** No separate auth system.
+- **No `GOOGLE_OAUTH` env flag.** First pass uses one app-level TOML flag plus credentials.
+- **Invite signup stays email-only.** No OAuth invite-token carry in v1.
+- **One shared front-end primitive only.** Ship `GoogleAuthButton`, not a generic provider UI.
+- **Explicit Google callback route.** No generalized callback-routing refactor in this change.
+- **Missing credentials disable Google cleanly.** App should still boot.
+
+## Current state
+
+### What already exists
+
+- `packages/core/src/server/auth/createAuth.ts` already uses better-auth `socialProviders`
+- the current better-auth wiring already supports GitHub in the same config shape
+- `packages/core/src/server/config/loadConfig.ts` already handles provider-specific auth config
+- core already owns auth routes, cookies, sessions, and stock auth pages
+- child apps can already override auth pages through `<BoringApp authPages={...} />`
+
+### What is missing
+
+- no Google config surface in core
+- no Google runtime/capability flag
+- stock sign-in/sign-up pages are still email-only
+- no shared Google auth button for child-app overrides
+- callback routing/public-page handling is still GitHub-specific in places
+- invite-aware social signup semantics are not defined
+- docs still describe social auth as deferred / GitHub-specific
+
+## Target child-app experience
+
+```bash
+# .env
+BETTER_AUTH_URL=http://localhost:3000
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+```
+
+```toml
+# boring.app.toml
+[features]
+google_oauth = true
+```
+
+If the child app does not already have a `boring.app.toml`, create one with at least that `features` block.
+
+Then the child app gets:
+
+- Google button on core `SignInPage`
+- Google button on core `SignUpPage` for normal signup flow
+- better-auth Google callback flow handled by the existing core auth system
+- optional reusable `GoogleAuthButton` for branded auth-page overrides
+
+First-pass scope rule for robustness:
+
+- if the signup page has an `invite_token`, keep that page email-only and hide the Google button
+- invited users keep using the existing email signup path in v1
+- social signup + invite-token state carry can come later if a real user needs it
+
+## Proposed implementation
+
+### 1. Config surface
+
+Add Google alongside the existing GitHub shape.
+
+**Server env:**
+
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+
+**TOML:**
+
+- `features.google_oauth = true`
+
+**Types to update:**
+
+- `CoreConfig.auth.google?: { clientId: string; clientSecret: string }`
+- `CoreConfig.features.googleOauth: boolean`
+- `RuntimeConfig.features.googleOauth: boolean`
+- `CoreCapabilities.features.googleOauth: boolean`
+- `CoreCapabilities.auth.google: boolean`
+
+**Rules:**
+
+- `googleOauth` resolves `true` only when `features.google_oauth = true` and both credentials exist
+- if the flag is on but credentials are missing, the app still boots; Google simply resolves off
+- keep existing GitHub behavior unchanged in this pass
+- do not introduce provider arrays or a generic provider model yet
+
+### 2. better-auth wiring
+
+In `createAuth()`:
+
+- extend `socialProviders` to include `google` when `config.auth.google` exists
+- keep existing GitHub handling intact
+- do not add provider-specific custom logic beyond the minimum better-auth config needed for Google
+
+Expected shape:
+
+```ts
+socialProviders: {
+  ...(config.auth.github ? { github: {...} } : {}),
+  ...(config.auth.google ? { google: {...} } : {}),
+}
+```
+
+### 3. Front-end auth UX
+
+Add one small shared helper in core front auth.
+
+Shipped piece:
+
+- `GoogleAuthButton`
+- visibility driven by `useConfig()`
+- internally calls `authClient.signIn.social({ provider: 'google', callbackURL: '/' })`
+- optional `callbackURL` prop is acceptable for branded child apps; default stays `'/'`
+
+Use it in:
+
+- `packages/core/src/front/auth/SignInPage.tsx`
+- `packages/core/src/front/auth/SignUpPage.tsx`
+
+UX rules:
+
+- show Google button above email form
+- show divider like “or continue with email”
+- hide button unless `features.googleOauth === true`
+- on sign-up pages with `invite_token`, hide the Google button and keep the current email flow unchanged
+- preserve current email/password flow exactly
+
+### 4. Callback-route audit
+
+Do not treat this as a button-only change.
+
+Google support must also audit every place that currently assumes GitHub callback routing:
+
+- route map / front utils
+- `CoreFront` route registration
+- any server-side auth-page allowlist/public-page handling
+- the frontend-auth SPA shell allowlist in `createCoreWorkspaceAgentServer.ts`
+- route tests for `/auth/callback/google`
+
+Important implementation note:
+
+- core's better-auth base path is `/auth`, not `/api/auth`
+- that means `/auth/callback/google` is a real auth callback path in this app
+- do not drop this route work based on better-auth defaults from other setups
+
+Keep this simple in the first pass:
+
+- add the explicit Google callback route everywhere needed
+- do **not** generalize callback routing yet
+
+### 5. Child-app override seam
+
+For child apps with branded auth pages, expose a reusable surface instead of forcing every app to rediscover better-auth client calls.
+
+Shipped seam:
+
+- export `GoogleAuthButton` from `@hachej/boring-core/front`
+
+Rule: do **not** redesign the whole auth-page override API for this.
+
+### 6. Docs + skill
+
+Create/update:
+
+- core docs section for Google signup env + redirect URI setup
+- child-app setup skill with exact steps
+- required callback URL notes:
+  - local: `http://localhost:3000/auth/callback/google`
+  - prod: `https://<app-domain>/auth/callback/google`
+
+## What exactly must be implemented
+
+This feature is small. The implementation breaks into eight concrete pieces:
+
+1. **Core config**
+  - add `GOOGLE_CLIENT_ID`
+  - add `GOOGLE_CLIENT_SECRET`
+  - add `features.google_oauth = true`
+  - teach `TomlAppConfig.features` to read `google_oauth`
+2. **better-auth wiring**
+  - extend the existing core auth setup so `socialProviders.google` is passed into better-auth
+3. **Capabilities/runtime flags**
+  - expose `features.googleOauth`
+  - expose `core.auth.google`
+  - update `buildRuntimeConfigPayload()` so the frontend actually receives `features.googleOauth`
+4. **Reusable front-end primitive**
+  - add `GoogleAuthButton`
+  - have it call `authClient.signIn.social({ provider: 'google', callbackURL: '/' })`
+5. **Stock auth pages**
+  - use `GoogleAuthButton` on stock sign-in
+  - use it on normal stock sign-up
+  - hide it for invite-token signup
+6. **Callback route**
+  - add `/auth/callback/google`
+  - make sure it is mounted and treated like a public auth callback route
+  - update the frontend-auth SPA shell allowlist in `createCoreWorkspaceAgentServer.ts`
+7. **Docs + skill**
+  - update `CORE.md`
+  - update the child-app setup skill
+  - document `BETTER_AUTH_URL`, `CORS_ORIGINS`, and callback URLs
+8. **Tests**
+  - config tests
+  - auth wiring tests
+  - callback-route tests
+  - button visible/hidden tests
+  - existing email auth tests still passing
+
+If these eight things land cleanly, the feature is done.
+
+## File map
+
+### Core server
+
+- `packages/core/src/server/config/loadConfig.ts`
+- `packages/core/src/server/config/schema.ts`
+- `packages/core/src/shared/types.ts`
+- `packages/core/src/server/app/capabilities.ts`
+- `packages/core/src/server/auth/createAuth.ts`
+- `packages/core/src/app/server/createCoreWorkspaceAgentServer.ts`
+- config tests + auth tests
+
+### Core front
+
+- `packages/core/src/front/auth/SignInPage.tsx`
+- `packages/core/src/front/auth/SignUpPage.tsx`
+- `packages/core/src/front/auth/index.ts`
+- `packages/core/src/front/utils.ts`
+- `packages/core/src/front/CoreFront.tsx`
+- maybe new helper file under `packages/core/src/front/auth/`
+- front tests
+
+### Docs / teaching
+
+- `packages/core/docs/CORE.md`
+- `.agents/skills/boring-google-signup-setup/SKILL.md`
+
+## Implementation task groups
+
+### Task group 1 — config + shared types
+
+- add `auth.google` to core config
+- add `features.googleOauth` to runtime/shared types
+- add Google capability fields
+- update `TomlAppConfig.features` for `google_oauth`
+- update `buildRuntimeConfigPayload()` so the frontend receives `features.googleOauth`
+- keep the activation rule simple: TOML flag + credentials
+
+**Verify:** config tests cover enabled and disabled cases.
+
+### Task group 2 — server auth wiring
+
+- extend `createAuth()` with Google provider wiring
+- update capabilities so Google reports as usable when enabled/configured
+
+**Verify:** auth creation tests and capabilities tests.
+
+### Task group 3 — callback-route audit
+
+- add `/auth/callback/google` to route helpers
+- mount that route in `CoreFront`
+- update `createCoreWorkspaceAgentServer.ts` SPA-shell auth-page allowlist
+- ensure auth callback routes are treated as public where needed
+
+**Verify:** route tests for the mounted Google callback path.
+
+### Task group 4 — front-end auth UX
+
+- add `GoogleAuthButton`
+- use it in stock sign-in page
+- use it in stock sign-up page
+- hide it for invite-token signup
+
+**Verify:** auth-page tests for visible/hidden states and click behavior.
+
+### Task group 5 — docs + child-app teaching
+
+- update `CORE.md`
+- update/add the child-app setup skill
+- include local + prod callback URIs
+- include `BETTER_AUTH_URL` and `CORS_ORIGINS` callouts in setup docs
+
+**Verify:** docs match the actual shipped env names and exported front-end primitive.
+
+## Acceptance criteria
+
+### Product
+
+- a child app can enable Google signup without forking core auth pages
+- default sign-in page shows Google when enabled
+- default sign-up page shows Google when enabled for normal signup flow
+- default sign-up page stays email-only when `invite_token` is present
+- Google button is absent when feature/credentials are missing
+- custom child-app auth pages can import `GoogleAuthButton` from core
+
+### Technical
+
+- config validation covers Google env + flag resolution
+- better-auth receives the Google provider config only when valid
+- `/api/v1/config` exposes `features.googleOauth`
+- `/api/v1/capabilities` exposes Google auth availability
+- `core.auth.google` means the user can use Google auth right now, not just that some config exists
+- `/auth/callback/google` is mounted and treated as a public auth callback route
+- existing GitHub behavior keeps working
+
+### Tests
+
+1. `loadConfig` resolves `googleOauth` correctly when TOML flag + creds are present
+2. `loadConfig` keeps `googleOauth=false` when creds are incomplete
+3. `createAuth` includes Google provider when configured
+4. `CoreFront` mounts `/auth/callback/google`
+5. `SignInPage` renders Google button only when enabled
+6. `SignUpPage` renders Google button only when enabled for normal signup flow
+7. `SignUpPage` hides Google when `invite_token` is present
+8. clicking Google calls `signIn.social({ provider: 'google' ... })`
+9. existing email sign-in/sign-up tests still pass
+
+## Dependencies / rollout order
+
+1. **Config + types** → frontend/runtime/server all depend on this
+2. **better-auth server wiring** → no useful UI without real provider wiring
+3. **Callback-route audit** → keeps OAuth return path from becoming a hidden bug
+4. **Front-end button/helper** → only after config + callback path exist
+5. **Docs + child-app skill** → only after exported names and env contract are final
+
+## Risks / watchouts
+
+- **Docs drift:** repo docs still mention social auth as deferred / GitHub-specific in several places; do a focused doc sweep, not just one line edit
+- **Callback mismatch:** Google will fail if `BETTER_AUTH_URL` is wrong; docs must be explicit
+- **Invite flow complexity:** do not invent OAuth state-carry for invites in this first pass; hide Google on invite signup instead
+- **Capability ambiguity:** define `core.auth.google` as “usable now” in this first pass, not just “configured somewhere”
+- **Over-design risk:** do not build a generic provider framework yet
+- **Redirect choice:** if `/` is not a safe post-login route for every child app, keep `GoogleAuthButton` small and add one optional `callbackURL` prop later instead of inventing a config tree now
+
+## Review questions
+
+Please review this draft against these decisions:
+
+1. **Provider model:** approve treating Google as one better-auth social provider inside the existing core auth stack?
+2. **Config shape:** approve TOML flag + credentials, with no separate `GOOGLE_OAUTH` env flag?
+3. **Invite behavior:** approve hiding Google on invite-token signup instead of solving OAuth state carry now?
+4. **Front-end seam:** approve shipping only `GoogleAuthButton` in v1?
+5. **Routing scope:** approve adding an explicit Google callback path instead of generalizing callback routing now?
+6. **Redirect default:** approve defaulting the Google button callback to `'/'` for the first pass?
+
+If the answer to all six is yes, this plan is ready to implement.
+
+## Nice-to-have later, not in this first pass
+
+- generic `socialProviders` runtime type
+- GitHub + Google unified provider list
+- Google One Tap
+- provider icons/theme slots
+- provider-specific callback/landing route config

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -82,7 +82,7 @@ test('registerAgentRoutes provisions embedded runtime plugins before host app ro
   } finally {
     await app.close()
   }
-})
+}, 15_000)
 
 test('registerAgentRoutes provisions the resolved request workspace, not the host base root', async () => {
   const baseRoot = await makeTempDir('boring-agent-embed-base-root-')

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/pluginExtensionSmoke.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/pluginExtensionSmoke.test.ts
@@ -165,5 +165,5 @@ describe("Plugin extension smoke test", () => {
     expect(toolResult.content[0]?.text).toBe(
       "Hello, Ada! (from synthetic extension)",
     );
-  });
+  }, 15_000);
 });

--- a/packages/core/docs/CORE.md
+++ b/packages/core/docs/CORE.md
@@ -64,9 +64,9 @@ import { Route } from 'react-router-dom'
 |---|---|
 | Package shape | **One combined package** (`@boring/core`) — no separate `@boring/cloud`. Local and real providers coexist behind interfaces. |
 | DB stack | **Drizzle + Postgres (Neon)**. SQLite fallback is a v1.x concern. |
-| Auth | **better-auth** with email/password + email verification + password reset + magic links. Drizzle adapter against the same Postgres. `AuthProvider` interface kept as a partial swap seam. **GitHub OAuth deferred to v1.x** (bundled with agent's GitHub App install — both ship together so users do "Connect GitHub" once, not twice). |
+| Auth | **better-auth** already backs core auth: email/password + email verification + password reset + magic links, with Google available as one better-auth social provider when a child app sets `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `features.google_oauth = true`. Drizzle adapter against the same Postgres. `AuthProvider` interface kept as a partial swap seam. **GitHub OAuth deferred to v1.x** (bundled with agent's GitHub App install — both ship together so users do "Connect GitHub" once, not twice). |
 | Tenancy | Port v1: **workspaces + members + invites** with owner/editor/viewer roles. Matches agent's `workspaceId` per instance. |
-| Frontend shell | `<BoringApp>` mounts **react-router v6** with a route slot. Default routes: `/auth/signin`, `/auth/signup`, `/auth/callback/github`, `/auth/verify-email`, `/auth/forgot-password`, `/auth/reset-password`, `/me`. |
+| Frontend shell | `<BoringApp>` mounts **react-router v6** with a route slot. Default user-facing routes: `/auth/signin`, `/auth/signup`, `/auth/verify-email`, `/auth/forgot-password`, `/auth/reset-password`, `/me`. Provider callback handling still lives under better-auth's backend `/auth/callback/:provider` paths; core also mounts placeholder frontend callback routes for provider flows, but those are not the main child-app-facing route contract. |
 | UI primitives | Stay in **`@boring/ui`**. Core depends on workspace for UI. |
 | Full-app wrapping | Server factory + frontend shell + config bridge + user/workspace management + auth — all four in-scope for v1. |
 
@@ -97,7 +97,7 @@ v1 had `core ← workspace ← agent`. v2 fully inverts the chain:
 ## Non-goals
 
 - SQLite / libsql support. Postgres-only in v1.
-- Social login beyond GitHub. Google/Apple/Discord are v1.x.
+- Social providers beyond the current Google child-app flow. GitHub App-linked OAuth, Apple, Discord, and any generic provider-picker UI are v1.x.
 - Billing / Stripe integration.
 - Server-side rendering. `<BoringApp>` is client-rendered only.
 - GitHub App install flow — deferred to `@boring/agent` in v1.x, when agent grows a git tool.
@@ -113,7 +113,7 @@ v1 had `core ← workspace ← agent`. v2 fully inverts the chain:
 
 ### What you get
 
-A new app depending on `@boring/core` boots with Postgres + Drizzle, better-auth (email/pw + verification + reset + magic links), session cookies, sign-in/up pages, user + workspace CRUD, `/api/v1/me`, `/api/v1/workspaces`, `/api/v1/capabilities`. (GitHub OAuth deferred to v1.x.)
+A new app depending on `@boring/core` boots with Postgres + Drizzle, better-auth (email/pw + verification + reset + magic links), session cookies, sign-in/up pages, user + workspace CRUD, `/api/v1/me`, `/api/v1/workspaces`, `/api/v1/capabilities`, and optional Google sign-in/sign-up when the child app opts in with Google credentials plus `features.google_oauth = true`. (GitHub OAuth remains deferred to v1.x.)
 
 ### 1. Install
 
@@ -131,11 +131,12 @@ pnpm add @boring/core @boring/workspace fastify react react-dom react-router-dom
 DATABASE_URL=postgres://user:pass@localhost:5432/myapp
 BETTER_AUTH_SECRET=<32-byte random hex>
 BETTER_AUTH_URL=http://localhost:3000
+CORS_ORIGINS=http://localhost:3000,http://localhost:5173
 WORKSPACE_SETTINGS_ENCRYPTION_KEY=<32-byte hex>
 MAIL_FROM=noreply@myapp.dev
 MAIL_TRANSPORT_URL=resend://re_xxxxxxxxxxxxxxxxxxxxxxxx   # default; any scheme above works
-GITHUB_CLIENT_ID=<from github oauth app>
-GITHUB_CLIENT_SECRET=<from github oauth app>
+GOOGLE_CLIENT_ID=<from google oauth web app>
+GOOGLE_CLIENT_SECRET=<from google oauth web app>
 ```
 
 `boring.app.toml`:
@@ -147,7 +148,12 @@ id = "my-app"
 [frontend.branding]
 name = "My App"
 logo = "/logo.svg"
+
+[features]
+google_oauth = true
 ```
+
+`boring.app.toml` is optional. If your child app does not already have one, create it at the repo root and add the `[features]` block there.
 
 ### 3. Migrate the DB
 
@@ -297,24 +303,26 @@ favicon = "/favicon.ico"
 default = "system"          # "light" | "dark" | "system"
 
 [features]
-github_oauth = false   # v1: deferred to v1.x
+google_oauth = false         # set true only when GOOGLE_CLIENT_ID + GOOGLE_CLIENT_SECRET are configured
 invites_enabled = true
 invite_ttl_days = 7
 ```
 
-`invite_ttl_days` lives in `boring.app.toml`. `sendWelcomeEmail` is env-only (`SEND_WELCOME_EMAIL=false`) but still lands under `CoreConfig.features` after config load so feature flags stay grouped in one object.
+`boring.app.toml` is optional; if a child app does not have one yet, create it at the repo root. `invite_ttl_days` lives in this file. `sendWelcomeEmail` is env-only (`SEND_WELCOME_EMAIL=false`) but still lands under `CoreConfig.features` after config load so feature flags stay grouped in one object.
 
 ### Environment variables
 
 | Var | Required | Description |
 |---|---|---|
 | `DATABASE_URL` | yes (prod) | Postgres connection string. |
-| `BETTER_AUTH_SECRET` | yes | 32-byte hex. Signs session cookies. |
-| `BETTER_AUTH_URL` | yes | Public URL of the deployment (used for OAuth callbacks). |
+| `BETTER_AUTH_SECRET` | yes | 32-byte hex. better-auth secret for the shared core auth stack; signs session cookies for email auth and Google auth alike. |
+| `BETTER_AUTH_URL` | yes | Public URL of the deployment. better-auth uses it as the base URL, and Google callback URLs must live under this exact origin. |
 | `WORKSPACE_SETTINGS_ENCRYPTION_KEY` | yes (prod) | 32-byte hex. pgcrypto key for `workspace_settings.value`. Rotating it without re-encrypting rows breaks typed decrypts of existing values, though metadata reads still succeed; see [V7 surface area](#v7-surface-area). |
 | `SEND_WELCOME_EMAIL` | no | Defaults to `true`. Set to `false` to suppress the post-signup welcome email for non-invite signups. |
 | `MAIL_FROM` | yes (prod) | Sender address for verification / reset / magic-link emails. Without it those flows are disabled. |
 | `MAIL_TRANSPORT_URL` | yes (prod) | URL scheme dispatched by core's transport parser. **Recommended default: `resend://<api-key>`** (Resend REST — no dependency on the resend npm package; core just hits `https://api.resend.com/emails`). Also supported: `smtp://user:pass@host:port`, `smtps://user:pass@host:port`, `console://` (dev-only — logs to stdout). Unknown scheme = boot-time `ConfigValidationError`. |
+| `GOOGLE_CLIENT_ID` | no | Google OAuth web client ID. Used only when `features.google_oauth = true`; otherwise Google stays hidden. |
+| `GOOGLE_CLIENT_SECRET` | no | Google OAuth web client secret. Used only when `features.google_oauth = true`; otherwise Google stays hidden. |
 | `GITHUB_CLIENT_ID` | **v1.x — not used in v1** | Reserved for when GitHub OAuth ships in v1.x alongside GitHub App install. Set if `features.github_oauth = true`. |
 | `GITHUB_CLIENT_SECRET` | **v1.x — not used in v1** | Same. |
 | `PORT` | no | Fastify port (default 3000). |
@@ -322,11 +330,35 @@ invite_ttl_days = 7
 | `STATIC_DIR` | no | Directory served at `/`. |
 | `CORE_STORES` | no | `postgres` (default) or `local`. |
 | `LOG_LEVEL` | no | pino level (default `info`). |
-| `CORS_ORIGINS` | yes (prod) | Comma-separated allowlist of origins for CORS (e.g. `https://app.example.com,https://admin.example.com`). Empty in dev = localhost auto-allow. |
+| `CORS_ORIGINS` | yes (prod) | Comma-separated allowlist of origins for CORS (e.g. `https://app.example.com,https://admin.example.com`). Core also passes these through to better-auth `trustedOrigins`, so include every browser origin that can start auth. Empty in dev = localhost auto-allow. |
 | `BODY_LIMIT_BYTES` | no | Override Fastify body limit (default `16777216` / 16MB). |
 | `SESSION_TTL_SECONDS` | no | Session cookie max-age (default `60*60*24*30` / 30 days, matches v1). |
 | `SESSION_COOKIE_SECURE` | no | Force `Secure` cookie flag (default `true` when `BETTER_AUTH_URL` is https). |
 | `BORING_TELEMETRY_ENABLED` | no | Explicit opt-in for core DB telemetry. Must be `true`; unset/`false` means no-op telemetry. |
+
+### Google signup in child apps (first pass)
+
+Core auth already runs on better-auth. Google is one provider inside that existing stack, not a second auth system.
+
+Child-app setup contract:
+
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `features.google_oauth = true` in `boring.app.toml`
+
+Notes:
+
+- `boring.app.toml` is optional. If the app does not have one yet, create it and add a `[features]` block.
+- There is **no** `GOOGLE_OAUTH` env flag.
+- `BETTER_AUTH_SECRET` stays required because Google uses the same better-auth session/callback stack as email auth.
+- `BETTER_AUTH_URL` must exactly match the public app origin that owns `/auth/callback/google` (`http://localhost:3000` locally, `https://app.example.com` in prod).
+- `CORS_ORIGINS` must include the same browser origin(s) that can start auth.
+- Register these Google callback URLs exactly:
+  - local: `http://localhost:3000/auth/callback/google`
+  - prod: `https://app.example.com/auth/callback/google`
+- If the TOML flag or either Google credential is missing, core still boots and the stock auth pages simply hide the Google button.
+- Deliberate first-pass invite behavior: `/auth/signup?invite_token=...` stays email-only. Core does **not** carry invite tokens through OAuth yet.
+- Stock core auth pages pick up the Google button automatically. Branded child apps can reuse `GoogleAuthButton` from `@hachej/boring-core/front`; core does not promise a generic provider-picker UI.
 
 ### Core DB telemetry (v1)
 
@@ -418,6 +450,7 @@ export interface CoreConfig {
     secret: string
     url: string
     github?: { clientId: string; clientSecret: string }
+    google?: { clientId: string; clientSecret: string }
     mail?: { from: string; transportUrl: string }
     sessionTtlSeconds: number    // default 60*60*24*30 (30 days, matches v1)
     sessionCookieSecure: boolean // derived from auth.url unless overridden
@@ -425,6 +458,7 @@ export interface CoreConfig {
 
   features: {
     githubOauth: boolean
+    googleOauth: boolean
     invitesEnabled: boolean
     sendWelcomeEmail: boolean   // default true; disables the post-signup welcome email when false
     inviteTtlDays: number       // default 7, validated to 1..30
@@ -442,7 +476,7 @@ export interface RuntimeConfig {
   appName: string
   appLogo: string | null
   apiBase: string
-  features: { githubOauth: boolean; invitesEnabled: boolean; sendWelcomeEmail: boolean }
+  features: { githubOauth: boolean; googleOauth: boolean; invitesEnabled: boolean; sendWelcomeEmail: boolean }
 }
 ```
 
@@ -621,6 +655,7 @@ export function SignUpPage(): JSX.Element
 export function ForgotPasswordPage(): JSX.Element
 export function ResetPasswordPage(): JSX.Element
 export function VerifyEmailPage(): JSX.Element
+export function GoogleAuthButton(props?: { callbackURL?: string }): JSX.Element
 export function UserMenu(): JSX.Element
 export function WorkspaceSwitcher(): JSX.Element
 export function ThemeToggle(): JSX.Element
@@ -727,11 +762,13 @@ export type CoreCapabilities = {
   features: {
     invitesEnabled: boolean    // from CoreConfig.features.invitesEnabled
     githubOauth: boolean       // from CoreConfig.features.githubOauth (and config.auth.github presence)
+    googleOauth: boolean       // from CoreConfig.features.googleOauth
     emailFlows: boolean        // DERIVED — true iff config.auth.mail is set (not a separate CoreConfig field)
   }
   auth: {
     emailPassword: boolean     // always true in v1
     github: boolean
+    google: boolean
     emailVerification: boolean
     passwordReset: boolean
     magicLink: boolean
@@ -825,7 +862,7 @@ Every `/api/v1/workspaces/:id/**` handler wears `requireWorkspaceMember(role?)`.
 
 ### v1 shape
 
-- **[better-auth](https://www.better-auth.com)** — email/password + email verification + password reset + magic links. (GitHub OAuth deferred to v1.x.)
+- **[better-auth](https://www.better-auth.com)** — email/password + email verification + password reset + magic links, plus Google when a child app sets `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `features.google_oauth = true`. (GitHub OAuth deferred to v1.x.)
 - **Drizzle adapter** against the same Postgres instance core uses.
 - Tables owned by better-auth: `users`, `sessions`, `accounts`, `verification_tokens`.
 - Session = signed cookie with explicit flags (match v1 contract): `HttpOnly; SameSite=Lax; Path=/; Max-Age=<SESSION_TTL_SECONDS>; Secure` (when `BETTER_AUTH_URL` is https). Auto-rotated by better-auth.
@@ -884,9 +921,14 @@ export function createAuth(config: CoreConfig, db: Database) {
       ? { sendOnSignUp: true, sendVerificationEmail: (...args) => sendVerificationEmail(mail, ...args) }
       : undefined,
     plugins: mail ? [magicLink({ sendMagicLink: (...args) => sendMagicLinkEmail(mail, ...args) })] : [],
-    socialProviders: config.auth.github
-      ? { github: { clientId: config.auth.github.clientId, clientSecret: config.auth.github.clientSecret } }
-      : {},
+    socialProviders: {
+      ...(config.auth.github
+        ? { github: { clientId: config.auth.github.clientId, clientSecret: config.auth.github.clientSecret } }
+        : {}),
+      ...(config.features.googleOauth && config.auth.google
+        ? { google: { clientId: config.auth.google.clientId, clientSecret: config.auth.google.clientSecret } }
+        : {}),
+    },
   })
 }
 ```
@@ -1048,14 +1090,14 @@ export interface BoringAppAuthPagesOverride {
 }
 ```
 
-Overridden components receive `{ onSubmit, oauthProviders, error, isPending, inviteToken? }` props (via React context); omitted overrides fall back to core's defaults.
+`authPages` overrides are plain `React.FC` route components. Core does not inject a generic `oauthProviders` prop. If a branded child app wants the shipped Google flow, import `GoogleAuthButton` from `@hachej/boring-core/front`; omitted overrides fall back to core's defaults.
 
 **Split of responsibility:** better-auth owns the **backend** for every flow below. Core ships the **UI form** that calls better-auth's client methods. Nothing in core re-implements tokens, expiry, or email sending.
 
 | Page | UX core owns | better-auth client call |
 |---|---|---|
-| `<SignInPage>` | Email/password form + "Sign in with GitHub" button + error state + "Forgot password?" link | `authClient.signIn.email()` / `authClient.signIn.social({ provider: 'github' })` |
-| `<SignUpPage>` | Email/password/name form + client-side password strength hint + post-signup "check your email" message | `authClient.signUp.email()` |
+| `<SignInPage>` | Email/password form + optional **Continue with Google** button + error state + "Forgot password?" link | `authClient.signIn.email()` / `GoogleAuthButton` → `authClient.signIn.social({ provider: 'google' })` |
+| `<SignUpPage>` | Email/password/name form + optional Google button on the normal signup path + post-signup "check your email" message. Invite-token signup stays email-only in this first pass. | `authClient.signUp.email()` / `GoogleAuthButton` → `authClient.signIn.social({ provider: 'google' })` |
 | `<VerifyEmailPage>` | Reads `?token=` from URL, calls verify, shows success/expired/invalid state, **resend-verification button with 60s cooldown** | `authClient.verifyEmail({ token })` + `authClient.sendVerificationEmail({ email })` |
 | `<ForgotPasswordPage>` | Email input form + success state ("check your inbox") + rate-limit-hit state | `authClient.forgetPassword({ email, redirectTo: '/auth/reset-password' })` |
 | `<ResetPasswordPage>` | Reads `?token=` from URL, **two password fields with client-side match check**, submit → redirect to `/auth/signin` with toast | `authClient.resetPassword({ token, newPassword })` |
@@ -1073,6 +1115,7 @@ Override via:
 ### In v1
 
 - Email + password.
+- Google OAuth on stock sign-in and normal stock sign-up when `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, and `features.google_oauth = true` are set.
 - ~~GitHub OAuth.~~ Deferred to v1.x (bundled with agent's GitHub App install — see §Open questions deferred).
 - Email verification (better-auth `emailVerification: { sendOnSignUp: true }`).
 - Password reset (better-auth `emailAndPassword: { sendResetPassword }`).
@@ -1082,7 +1125,7 @@ All three email flows require a mail transport. Without `MAIL_FROM` + `MAIL_TRAN
 
 ### Not in v1
 
-- Google / Apple / Discord / other OAuth providers (one-line adds in `createAuth`, unshipped).
+- Apple / Discord / other OAuth providers, plus any `GOOGLE_OAUTH`-style env flag or generic provider-picker UI.
 - 2FA / TOTP (better-auth plugin; deferred).
 - Session revocation UI (`DELETE /api/v1/me/sessions/:id`).
 - API keys (per-workspace tokens for headless access) — v1.x.

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
@@ -270,6 +270,66 @@ describe('createCoreWorkspaceAgentServer telemetry wiring', () => {
     }
   })
 
+  it('lets auth callback routes hit the auth proxy even for browser GET requests', async () => {
+    const app = await createCoreWorkspaceAgentServer({
+      appRoot: await createBuiltFrontendRoot(),
+      serveFrontend: true,
+      telemetry: { capture: vi.fn() },
+    })
+    const handler = vi.fn(async () => new Response('handled-by-auth-proxy', {
+      status: 200,
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    }))
+    app.auth.handler = handler as typeof app.auth.handler
+
+    try {
+      for (const url of ['/auth/callback/github', '/auth/callback/google']) {
+        const res = await app.inject({
+          method: 'GET',
+          url,
+          headers: { accept: 'text/html' },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(res.body).toContain('handled-by-auth-proxy')
+      }
+
+      expect(handler).toHaveBeenCalledTimes(2)
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('serves SPA-only auth pages through the frontend shell for browser GET requests', async () => {
+    const app = await createCoreWorkspaceAgentServer({
+      appRoot: await createBuiltFrontendRoot(),
+      serveFrontend: true,
+      telemetry: { capture: vi.fn() },
+    })
+    const handler = vi.fn(async () => new Response('handled-by-auth-proxy', {
+      status: 200,
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    }))
+    app.auth.handler = handler as typeof app.auth.handler
+
+    try {
+      for (const url of ['/auth/verify-email', '/auth/error?error=please_restart_the_process']) {
+        const res = await app.inject({
+          method: 'GET',
+          url,
+          headers: { accept: 'text/html' },
+        })
+
+        expect(res.statusCode).toBe(200)
+        expect(res.body).toContain('<!doctype html>')
+      }
+
+      expect(handler).not.toHaveBeenCalled()
+    } finally {
+      await app.close()
+    }
+  })
+
   it('keeps serving the shell when telemetry capture fails', async () => {
     const app = await createCoreWorkspaceAgentServer({
       appRoot: await createBuiltFrontendRoot(),

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -82,20 +82,24 @@ const AUTH_PROXY_BLOCKED_RESPONSE_HEADERS = new Set([
 
 // Pages that are served as the SPA shell (catch-all) AND get explicit GET routes
 // so the browser can navigate directly to them without hitting the auth proxy.
-// /auth/verify-email is intentionally excluded: the auth proxy's text/html guard
-// already falls through to the catch-all for browser navigation, and the explicit
-// route would shadow the proxy for API calls (breaking headless token redemption).
 const FRONTEND_AUTH_PAGES = new Set([
   '/auth/signin',
   '/auth/signup',
   '/auth/forgot-password',
   '/auth/reset-password',
-  '/auth/callback/github',
 ])
 
-// Pages served as SPA but NOT needing an explicit GET route (auth proxy handles them).
+// Pages that still belong to the SPA for browser navigation, but must NOT get
+// explicit GET shell routes because doing so would shadow real auth proxy GETs.
+// /auth/verify-email, /auth/error, and social callback routes are in this bucket:
+// browser GETs with Accept: text/html should fall through to the catch-all shell
+// when that is the intended UX, but the proxy must still be able to handle real
+// auth GETs.
 const FRONTEND_AUTH_PAGES_SPA_ONLY = new Set([
   '/auth/verify-email',
+  '/auth/error',
+  '/auth/callback/github',
+  '/auth/callback/google',
 ])
 
 export type CoreWorkspaceAgentServer = FastifyInstance & {
@@ -360,10 +364,44 @@ function shouldServeFrontend(pathname: string): boolean {
   return true
 }
 
-async function registerAuthProxy(app: CoreWorkspaceAgentServer) {
+async function serveFrontendShell(
+  request: { id: string; cspNonce?: string },
+  reply: { status: (code: number) => unknown; type: (value: string) => unknown; send: (body: unknown) => unknown },
+  indexPath: string,
+  telemetry: TelemetrySink,
+) {
+  if (!(await pathExists(indexPath))) {
+    reply.status(503)
+    return {
+      error: 'frontend_not_built',
+      message: 'Build the frontend before starting in production mode.',
+    }
+  }
+
+  const html = await readFile(indexPath, 'utf-8')
+  captureAppOpened(telemetry, request.id)
+  reply.type('text/html; charset=utf-8')
+  return reply.send(injectCspNonceIntoHtml(html, request.cspNonce))
+}
+
+async function registerAuthProxy(
+  app: CoreWorkspaceAgentServer,
+  options?: { serveSpaShell?: (request: any, reply: any) => Promise<unknown> },
+) {
   app.all('/auth/*', async (request, reply) => {
     const accept = String(request.headers?.accept ?? '')
-    if (request.method === 'GET' && accept.includes('text/html')) {
+    const pathname = request.url.split('?')[0] ?? '/'
+    const isSpaOnlyAuthPage = FRONTEND_AUTH_PAGES_SPA_ONLY.has(pathname)
+    const isExplicitShellAuthPage = FRONTEND_AUTH_PAGES.has(pathname)
+
+    if (
+      request.method === 'GET'
+      && accept.includes('text/html')
+      && (isExplicitShellAuthPage || (isSpaOnlyAuthPage && pathname !== '/auth/callback/github' && pathname !== '/auth/callback/google'))
+    ) {
+      if (options?.serveSpaShell) {
+        return options.serveSpaShell(request, reply)
+      }
       return reply.callNotFound()
     }
 
@@ -426,19 +464,7 @@ async function registerFrontendAuthPages(
   const indexPath = path.resolve(frontDistDir, 'index.html')
 
   for (const pagePath of FRONTEND_AUTH_PAGES) {
-    app.get(pagePath, async (request, reply) => {
-      if (!(await pathExists(indexPath))) {
-        reply.status(503)
-        return {
-          error: 'frontend_not_built',
-          message: 'Build the frontend before starting in production mode.',
-        }
-      }
-      const html = await readFile(indexPath, 'utf-8')
-      captureAppOpened(telemetry, request.id)
-      reply.type('text/html; charset=utf-8')
-      return reply.send(injectCspNonceIntoHtml(html, request.cspNonce))
-    })
+    app.get(pagePath, async (request, reply) => serveFrontendShell(request, reply, indexPath, telemetry))
   }
 }
 
@@ -450,20 +476,7 @@ async function registerFrontendFallback(
   const frontDistDir = path.resolve(appRoot, 'dist/front')
   const indexPath = path.resolve(frontDistDir, 'index.html')
 
-  app.get('/', async (request, reply) => {
-    if (!(await pathExists(indexPath))) {
-      reply.status(503)
-      return {
-        error: 'frontend_not_built',
-        message: 'Build the frontend before starting in production mode.',
-      }
-    }
-
-    const html = await readFile(indexPath, 'utf-8')
-    captureAppOpened(telemetry, request.id)
-    reply.type('text/html; charset=utf-8')
-    return reply.send(injectCspNonceIntoHtml(html, request.cspNonce))
-  })
+  app.get('/', async (request, reply) => serveFrontendShell(request, reply, indexPath, telemetry))
 
   app.get('/*', async (request, reply) => {
     const pathname = request.url.split('?')[0] ?? '/'
@@ -483,18 +496,7 @@ async function registerFrontendFallback(
       return reply.send(createReadStream(candidate))
     }
 
-    if (!(await pathExists(indexPath))) {
-      reply.status(503)
-      return {
-        error: 'frontend_not_built',
-        message: 'Build the frontend before starting in production mode.',
-      }
-    }
-
-    const html = await readFile(indexPath, 'utf-8')
-    captureAppOpened(telemetry, request.id)
-    reply.type('text/html; charset=utf-8')
-    return reply.send(injectCspNonceIntoHtml(html, request.cspNonce))
+    return serveFrontendShell(request, reply, indexPath, telemetry)
   })
 }
 
@@ -597,7 +599,12 @@ export async function createCoreWorkspaceAgentServer(
     await registerFrontendAuthPages(app, appRoot, telemetry)
   }
 
-  await registerAuthProxy(app)
+  await registerAuthProxy(app, serveFrontend && appRoot
+    ? {
+        serveSpaShell: (request, reply) =>
+          serveFrontendShell(request, reply, path.resolve(appRoot, 'dist/front/index.html'), telemetry),
+      }
+    : undefined)
 
   const defaultPluginPackagePaths = resolveDefaultWorkspacePluginPackagePaths({
     workspaceRoot,

--- a/packages/core/src/front/ConfigProvider.tsx
+++ b/packages/core/src/front/ConfigProvider.tsx
@@ -86,6 +86,10 @@ export function useConfig(): RuntimeConfig {
   return ctx
 }
 
+export function useOptionalConfig(): RuntimeConfig | null {
+  return useContext(ConfigContext)
+}
+
 export function useConfigLoaded(): boolean {
   return useContext(ConfigContext) !== null
 }

--- a/packages/core/src/front/CoreFront.tsx
+++ b/packages/core/src/front/CoreFront.tsx
@@ -17,6 +17,7 @@ import { SignUpPage as DefaultSignUpPage } from './auth/SignUpPage.js'
 import { ForgotPasswordPage as DefaultForgotPasswordPage } from './auth/ForgotPasswordPage.js'
 import { ResetPasswordPage as DefaultResetPasswordPage } from './auth/ResetPasswordPage.js'
 import { VerifyEmailPage as DefaultVerifyEmailPage } from './auth/VerifyEmailPage.js'
+import { AuthErrorPage as DefaultAuthErrorPage } from './auth/AuthErrorPage.js'
 import { UserSettingsPage as DefaultUserSettingsPage } from './auth/UserSettingsPage.js'
 import { InvitesPage } from './workspace/InvitesPage.js'
 import { MembersPage } from './workspace/MembersPage.js'
@@ -30,6 +31,7 @@ export interface CoreFrontAuthPagesOverride {
   forgotPassword?: React.FC
   resetPassword?: React.FC
   verifyEmail?: React.FC
+  authError?: React.FC
   userSettings?: React.FC
 }
 
@@ -75,6 +77,7 @@ export function CoreFront({ children, authPages, cspNonce }: CoreFrontProps) {
   const ForgotPasswordPage = authPages?.forgotPassword ?? DefaultForgotPasswordPage
   const ResetPasswordPage = authPages?.resetPassword ?? DefaultResetPasswordPage
   const VerifyEmailPage = authPages?.verifyEmail ?? DefaultVerifyEmailPage
+  const AuthErrorPage = authPages?.authError ?? DefaultAuthErrorPage
   const UserSettingsPage = authPages?.userSettings ?? DefaultUserSettingsPage
 
   return (
@@ -110,7 +113,9 @@ export function CoreFront({ children, authPages, cspNonce }: CoreFrontProps) {
                               <Route path={routes.forgotPassword} element={<ForgotPasswordPage />} />
                               <Route path={routes.resetPassword} element={<ResetPasswordPage />} />
                               <Route path={routes.verifyEmail} element={<VerifyEmailPage />} />
+                              <Route path={routes.authError} element={<AuthErrorPage />} />
                               <Route path={routes.callbackGithub} element={<PlaceholderPage name="github-callback" />} />
+                              <Route path={routes.callbackGoogle} element={<PlaceholderPage name="google-callback" />} />
                               <Route path={routes.me} element={<UserSettingsPage />} />
                               <Route path={routes.workspaceMembers} element={<MembersPage />} />
                               <Route path="/workspace/:id/members" element={<MembersPage />} />

--- a/packages/core/src/front/__tests__/ConfigProvider.test.tsx
+++ b/packages/core/src/front/__tests__/ConfigProvider.test.tsx
@@ -22,7 +22,7 @@ const VALID_CONFIG: RuntimeConfig = {
   appName: 'Test App',
   appLogo: null,
   apiBase: 'http://localhost:3000',
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true },
 }
 
 const FAST_BACKOFF = [0, 0, 0]

--- a/packages/core/src/front/__tests__/CoreFront.test.tsx
+++ b/packages/core/src/front/__tests__/CoreFront.test.tsx
@@ -50,7 +50,7 @@ function mockConfigEndpoint() {
     appName: 'Test App',
     appLogo: null,
     apiBase: '',
-    features: { githubOauth: false, invitesEnabled: false, sendWelcomeEmail: false },
+    features: { githubOauth: false, googleOauth: false, invitesEnabled: false, sendWelcomeEmail: false },
   }
   useMswHandler(async (input) => {
     const url =
@@ -209,7 +209,9 @@ describe('CoreFront', () => {
         { path: '/auth/forgot-password', marker: 'Forgot password' },
         { path: '/auth/reset-password', marker: 'Link expired' },
         { path: '/auth/verify-email', marker: 'Invalid verification link' },
+        { path: '/auth/error?error=please_restart_the_process', marker: 'Authentication error' },
         { path: '/auth/callback/github', marker: 'placeholder-github-callback' },
+        { path: '/auth/callback/google', marker: 'placeholder-google-callback' },
         { path: '/me', marker: 'Account settings' },
       ]
 

--- a/packages/core/src/front/__tests__/SignInPage.test.tsx
+++ b/packages/core/src/front/__tests__/SignInPage.test.tsx
@@ -4,7 +4,12 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 
+const { mockUseOptionalConfig } = vi.hoisted(() => ({
+  mockUseOptionalConfig: vi.fn(),
+}))
+
 const mockSignInEmail = vi.fn()
+const mockSignInSocial = vi.fn()
 const mockUseSession = vi.fn()
 const mockSignOut = vi.fn()
 
@@ -12,7 +17,7 @@ vi.mock('better-auth/react', () => ({
   createAuthClient: () => ({
     useSession: mockUseSession,
     signOut: mockSignOut,
-    signIn: { email: mockSignInEmail, social: vi.fn() },
+    signIn: { email: mockSignInEmail, social: mockSignInSocial },
     signUp: { email: vi.fn() },
   }),
 }))
@@ -21,11 +26,16 @@ vi.mock('better-auth/client/plugins', () => ({
   magicLinkClient: () => ({ id: 'magic-link' }),
 }))
 
+vi.mock('../ConfigProvider.js', () => ({
+  useOptionalConfig: mockUseOptionalConfig,
+}))
+
 import { withBeadId } from '../../server/__tests__/_setup'
 import { AuthProvider } from '../auth/AuthProvider'
 import { SignInPage } from '../auth/SignInPage'
 
 const BEAD_ID = 'boring-ui-v2-1pas'
+const GOOGLE_BEAD_ID = 'boring-ui-v2-reorg-mip7'
 
 function Wrapper({ children }: { children: ReactNode }) {
   return <AuthProvider>{children}</AuthProvider>
@@ -34,11 +44,13 @@ function Wrapper({ children }: { children: ReactNode }) {
 beforeEach(() => {
   vi.clearAllMocks()
   mockUseSession.mockReturnValue({ data: null, isPending: false, error: null })
+  mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: false } })
   mockSignOut.mockResolvedValue(undefined)
 })
 
 afterEach(() => {
   vi.restoreAllMocks()
+  window.history.pushState({}, '', '/')
 })
 
 describe('SignInPage', () => {
@@ -104,6 +116,59 @@ describe('SignInPage', () => {
   )
 
   it(
+    'shows Google sign-in only when enabled and clicks through social sign-in',
+    withBeadId(GOOGLE_BEAD_ID, async ({ assertionPassed }) => {
+      mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: true } })
+      mockSignInSocial.mockResolvedValue({ data: null, error: null })
+
+      render(<SignInPage />, { wrapper: Wrapper })
+
+      const user = userEvent.setup()
+      await user.click(screen.getByRole('button', { name: /continue with google/i }))
+
+      await waitFor(() =>
+        expect(mockSignInSocial).toHaveBeenCalledWith({
+          provider: 'google',
+          callbackURL: '/',
+          errorCallbackURL: '/auth/signin',
+        }),
+      )
+      assertionPassed('signin-google-social')
+    }),
+  )
+
+  it(
+    'shows an inline error when Google sign-in initiation fails before redirect',
+    withBeadId(GOOGLE_BEAD_ID, async ({ assertionPassed }) => {
+      mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: true } })
+      mockSignInSocial.mockResolvedValue({
+        data: null,
+        error: { message: 'Could not reach Google' },
+      })
+
+      render(<SignInPage />, { wrapper: Wrapper })
+
+      const user = userEvent.setup()
+      await user.click(screen.getByRole('button', { name: /continue with google/i }))
+
+      await waitFor(() =>
+        expect(screen.getByRole('alert').textContent).toBe('Could not reach Google'),
+      )
+      assertionPassed('signin-google-init-error')
+    }),
+  )
+
+  it(
+    'hides Google sign-in when google OAuth is disabled',
+    withBeadId(GOOGLE_BEAD_ID, async ({ assertionPassed }) => {
+      render(<SignInPage />, { wrapper: Wrapper })
+
+      expect(screen.queryByRole('button', { name: /continue with google/i })).toBeNull()
+      assertionPassed('signin-google-hidden')
+    }),
+  )
+
+  it(
     'does NOT render a GitHub sign-in button',
     withBeadId(BEAD_ID, async ({ assertionPassed }) => {
       render(<SignInPage />, { wrapper: Wrapper })
@@ -126,6 +191,20 @@ describe('SignInPage', () => {
         '/auth/signup',
       )
       assertionPassed('signin-links')
+    }),
+  )
+
+  it(
+    'shows a helpful error when Google redirects back with an OAuth error',
+    withBeadId(GOOGLE_BEAD_ID, async ({ assertionPassed }) => {
+      window.history.pushState({}, '', '/auth/signin?error=access_denied&error_description=cancelled')
+
+      render(<SignInPage />, { wrapper: Wrapper })
+
+      expect(screen.getByRole('button', { name: /^sign in$/i })).toBeTruthy()
+      expect(screen.getByLabelText(/email/i)).toBeTruthy()
+      expect(screen.getByRole('alert').textContent).toMatch(/could not complete google sign in/i)
+      assertionPassed('signin-oauth-error-query')
     }),
   )
 })

--- a/packages/core/src/front/__tests__/SignUpPage.test.tsx
+++ b/packages/core/src/front/__tests__/SignUpPage.test.tsx
@@ -4,6 +4,11 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
 
+const { mockUseOptionalConfig } = vi.hoisted(() => ({
+  mockUseOptionalConfig: vi.fn(),
+}))
+
+const mockSignInSocial = vi.fn()
 const mockSignUpEmail = vi.fn()
 const mockUseSession = vi.fn()
 const mockSignOut = vi.fn()
@@ -12,7 +17,7 @@ vi.mock('better-auth/react', () => ({
   createAuthClient: () => ({
     useSession: mockUseSession,
     signOut: mockSignOut,
-    signIn: { email: vi.fn(), social: vi.fn() },
+    signIn: { email: vi.fn(), social: mockSignInSocial },
     signUp: { email: mockSignUpEmail },
   }),
 }))
@@ -21,11 +26,16 @@ vi.mock('better-auth/client/plugins', () => ({
   magicLinkClient: () => ({ id: 'magic-link' }),
 }))
 
+vi.mock('../ConfigProvider.js', () => ({
+  useOptionalConfig: mockUseOptionalConfig,
+}))
+
 import { withBeadId } from '../../server/__tests__/_setup'
 import { AuthProvider } from '../auth/AuthProvider'
 import { SignUpPage } from '../auth/SignUpPage'
 
 const BEAD_ID = 'boring-ui-v2-1pas'
+const GOOGLE_BEAD_ID = 'boring-ui-v2-reorg-mip7'
 
 function Wrapper({ children }: { children: ReactNode }) {
   return <AuthProvider>{children}</AuthProvider>
@@ -34,6 +44,7 @@ function Wrapper({ children }: { children: ReactNode }) {
 beforeEach(() => {
   vi.clearAllMocks()
   mockUseSession.mockReturnValue({ data: null, isPending: false, error: null })
+  mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: false } })
   mockSignOut.mockResolvedValue(undefined)
 })
 
@@ -87,12 +98,49 @@ describe('SignUpPage', () => {
   )
 
   it(
-    'forwards invite_token as x-invite-token header',
-    withBeadId(BEAD_ID, async ({ assertionPassed }) => {
+    'shows Google sign-up on the normal signup flow when enabled',
+    withBeadId(GOOGLE_BEAD_ID, async ({ assertionPassed }) => {
+      mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: true } })
+
+      render(<SignUpPage />, { wrapper: Wrapper })
+
+      expect(screen.getByRole('button', { name: /continue with google/i })).toBeTruthy()
+      assertionPassed('signup-google-visible')
+    }),
+  )
+
+  it(
+    'passes the signup route as the Google OAuth error callback URL',
+    withBeadId(GOOGLE_BEAD_ID, async ({ assertionPassed }) => {
+      mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: true } })
+      mockSignInSocial.mockResolvedValue({ data: null, error: null })
+
+      render(<SignUpPage />, { wrapper: Wrapper })
+
+      const user = userEvent.setup()
+      await user.click(screen.getByRole('button', { name: /continue with google/i }))
+
+      await waitFor(() =>
+        expect(mockSignInSocial).toHaveBeenCalledWith({
+          provider: 'google',
+          callbackURL: '/',
+          errorCallbackURL: '/auth/signup',
+        }),
+      )
+      assertionPassed('signup-google-error-callback')
+    }),
+  )
+
+  it(
+    'forwards invite_token as x-invite-token header and hides Google sign-up',
+    withBeadId(GOOGLE_BEAD_ID, async ({ assertionPassed }) => {
+      mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: true } })
       mockSignUpEmail.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
       window.history.pushState({}, '', '/auth/signup?invite_token=test-token-abc')
 
       render(<SignUpPage />, { wrapper: Wrapper })
+
+      expect(screen.queryByRole('button', { name: /continue with google/i })).toBeNull()
 
       const user = userEvent.setup()
       await user.type(screen.getByLabelText(/name/i), 'Invited')
@@ -152,12 +200,36 @@ describe('SignUpPage', () => {
   )
 
   it(
+    'hides Google sign-up when google OAuth is disabled',
+    withBeadId(GOOGLE_BEAD_ID, async ({ assertionPassed }) => {
+      render(<SignUpPage />, { wrapper: Wrapper })
+
+      expect(screen.queryByRole('button', { name: /continue with google/i })).toBeNull()
+      assertionPassed('signup-google-hidden')
+    }),
+  )
+
+  it(
     'does NOT render a GitHub sign-up button',
     withBeadId(BEAD_ID, async ({ assertionPassed }) => {
       render(<SignUpPage />, { wrapper: Wrapper })
 
       expect(screen.queryByText(/github/i)).toBeNull()
       assertionPassed('signup-no-github')
+    }),
+  )
+
+  it(
+    'shows a helpful error when Google redirects back with an OAuth error',
+    withBeadId(GOOGLE_BEAD_ID, async ({ assertionPassed }) => {
+      window.history.pushState({}, '', '/auth/signup?error=access_denied&error_description=cancelled')
+
+      render(<SignUpPage />, { wrapper: Wrapper })
+
+      expect(screen.getByRole('button', { name: /^sign up$/i })).toBeTruthy()
+      expect(screen.getByLabelText(/email/i)).toBeTruthy()
+      expect(screen.getByRole('alert').textContent).toMatch(/could not complete google sign up/i)
+      assertionPassed('signup-oauth-error-query')
     }),
   )
 })

--- a/packages/core/src/front/__tests__/useCapabilities.hook.test.tsx
+++ b/packages/core/src/front/__tests__/useCapabilities.hook.test.tsx
@@ -65,11 +65,13 @@ describe('useCapabilities hook', () => {
           features: {
             invitesEnabled: true,
             githubOauth: false,
+            googleOauth: false,
             emailFlows: true,
           },
           auth: {
             emailPassword: true,
             github: false,
+            google: false,
             emailVerification: true,
             passwordReset: true,
             magicLink: true,

--- a/packages/core/src/front/__tests__/utils.test.ts
+++ b/packages/core/src/front/__tests__/utils.test.ts
@@ -203,11 +203,16 @@ describe('routes + routeHref', () => {
     expect(routes.forgotPassword).toBe('/auth/forgot-password')
     expect(routes.resetPassword).toBe('/auth/reset-password')
     expect(routes.verifyEmail).toBe('/auth/verify-email')
+    expect(routes.authError).toBe('/auth/error')
+    expect(routes.callbackGithub).toBe('/auth/callback/github')
+    expect(routes.callbackGoogle).toBe('/auth/callback/google')
     expect(routes.me).toBe('/me')
   })
 
   it('routeHref returns route path', () => {
     expect(routeHref('signin')).toBe('/auth/signin')
+    expect(routeHref('authError')).toBe('/auth/error')
+    expect(routeHref('callbackGoogle')).toBe('/auth/callback/google')
   })
 
   it('routeHref substitutes params', () => {

--- a/packages/core/src/front/auth/AuthErrorPage.tsx
+++ b/packages/core/src/front/auth/AuthErrorPage.tsx
@@ -1,0 +1,37 @@
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@hachej/boring-ui-kit'
+import { routes } from '../utils.js'
+
+function readAuthErrorCode(): string | null {
+  if (typeof window === 'undefined') return null
+  return new URLSearchParams(window.location.search).get('error')
+}
+
+export function AuthErrorPage() {
+  const errorCode = readAuthErrorCode()
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>Authentication error</CardTitle>
+          <CardDescription>
+            We could not complete that authentication flow. Please try again.
+          </CardDescription>
+        </CardHeader>
+        {errorCode && (
+          <CardContent>
+            <p className="text-sm text-muted-foreground break-all">Error: {errorCode}</p>
+          </CardContent>
+        )}
+        <CardFooter className="flex justify-between gap-4 text-sm">
+          <a href={routes.signin} className="text-muted-foreground hover:underline">
+            Back to sign in
+          </a>
+          <a href={routes.signup} className="text-muted-foreground hover:underline">
+            Create account
+          </a>
+        </CardFooter>
+      </Card>
+    </div>
+  )
+}

--- a/packages/core/src/front/auth/GoogleAuthButton.tsx
+++ b/packages/core/src/front/auth/GoogleAuthButton.tsx
@@ -1,0 +1,44 @@
+import { useState } from 'react'
+import { Button } from '@hachej/boring-ui-kit'
+import { useSignIn } from './AuthProvider.js'
+
+export interface GoogleAuthButtonProps {
+  callbackURL?: string
+  errorCallbackURL?: string
+  onError?: (message?: string) => void
+}
+
+export function GoogleAuthButton({
+  callbackURL = '/',
+  errorCallbackURL = callbackURL,
+  onError,
+}: GoogleAuthButtonProps) {
+  const signIn = useSignIn()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function handleClick() {
+    setIsSubmitting(true)
+    try {
+      const result = await signIn.social({ provider: 'google', callbackURL, errorCallbackURL })
+      if (result?.error) {
+        onError?.(result.error.message)
+      }
+    } catch (error) {
+      onError?.(error instanceof Error ? error.message : undefined)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      className="w-full"
+      disabled={isSubmitting}
+      onClick={() => void handleClick()}
+    >
+      {isSubmitting ? 'Redirecting…' : 'Continue with Google'}
+    </Button>
+  )
+}

--- a/packages/core/src/front/auth/SignInPage.tsx
+++ b/packages/core/src/front/auth/SignInPage.tsx
@@ -4,6 +4,8 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, Input, Label } from '@hachej/boring-ui-kit'
 import { useSignIn } from './AuthProvider.js'
+import { GoogleAuthButton } from './GoogleAuthButton.js'
+import { useOptionalConfig } from '../ConfigProvider.js'
 import { routes } from '../utils.js'
 
 const signInSchema = z.object({
@@ -13,10 +15,21 @@ const signInSchema = z.object({
 
 type SignInFormData = z.infer<typeof signInSchema>
 
+const DEFAULT_GOOGLE_SIGNIN_ERROR = 'We could not complete Google sign in. Please try again or continue with email.'
+
+function readGoogleAuthError(): string | null {
+  if (typeof window === 'undefined') return null
+  const error = new URLSearchParams(window.location.search).get('error')
+  return error ? DEFAULT_GOOGLE_SIGNIN_ERROR : null
+}
+
 export function SignInPage() {
   const signIn = useSignIn()
+  const config = useOptionalConfig()
   const [serverError, setServerError] = useState<string | null>(null)
+  const [oauthError, setOauthError] = useState<string | null>(() => readGoogleAuthError())
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const showGoogleAuth = config?.features.googleOauth === true
 
   const {
     register,
@@ -28,6 +41,7 @@ export function SignInPage() {
 
   async function onSubmit(data: SignInFormData) {
     setServerError(null)
+    setOauthError(null)
     setIsSubmitting(true)
     try {
       const result = await signIn.email({
@@ -53,9 +67,25 @@ export function SignInPage() {
         </CardHeader>
         <form onSubmit={handleSubmit(onSubmit)} noValidate>
           <CardContent className="space-y-4">
-            {serverError && (
+            {showGoogleAuth && (
+              <>
+                <GoogleAuthButton
+                  errorCallbackURL={routes.signin}
+                  onError={(message) => setOauthError(message || DEFAULT_GOOGLE_SIGNIN_ERROR)}
+                />
+                <div className="relative">
+                  <div className="absolute inset-0 flex items-center">
+                    <span className="w-full border-t" />
+                  </div>
+                  <div className="relative flex justify-center text-xs uppercase">
+                    <span className="bg-card px-2 text-muted-foreground">Or continue with email</span>
+                  </div>
+                </div>
+              </>
+            )}
+            {(serverError ?? oauthError) && (
               <div role="alert" className="text-sm text-destructive">
-                {serverError}
+                {serverError ?? oauthError}
               </div>
             )}
             <div className="space-y-2">

--- a/packages/core/src/front/auth/SignUpPage.tsx
+++ b/packages/core/src/front/auth/SignUpPage.tsx
@@ -4,6 +4,8 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, Input, Label } from '@hachej/boring-ui-kit'
 import { useSignUp } from './AuthProvider.js'
+import { GoogleAuthButton } from './GoogleAuthButton.js'
+import { useOptionalConfig } from '../ConfigProvider.js'
 import { routes } from '../utils.js'
 
 const signUpSchema = z.object({
@@ -14,15 +16,26 @@ const signUpSchema = z.object({
 
 type SignUpFormData = z.infer<typeof signUpSchema>
 
+const DEFAULT_GOOGLE_SIGNUP_ERROR = 'We could not complete Google sign up. Please try again or continue with email.'
+
+function readGoogleAuthError(): string | null {
+  if (typeof window === 'undefined') return null
+  const error = new URLSearchParams(window.location.search).get('error')
+  return error ? DEFAULT_GOOGLE_SIGNUP_ERROR : null
+}
+
 export function SignUpPage() {
   const signUp = useSignUp()
+  const config = useOptionalConfig()
   const [serverError, setServerError] = useState<string | null>(null)
+  const [oauthError, setOauthError] = useState<string | null>(() => readGoogleAuthError())
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [success, setSuccess] = useState(false)
 
   const inviteToken = typeof window !== 'undefined'
     ? new URLSearchParams(window.location.search).get('invite_token')
     : null
+  const showGoogleAuth = config?.features.googleOauth === true && !inviteToken
 
   const {
     register,
@@ -34,6 +47,7 @@ export function SignUpPage() {
 
   async function onSubmit(data: SignUpFormData) {
     setServerError(null)
+    setOauthError(null)
     setIsSubmitting(true)
     try {
       const fetchOptions = inviteToken
@@ -85,9 +99,25 @@ export function SignUpPage() {
         </CardHeader>
         <form onSubmit={handleSubmit(onSubmit)} noValidate>
           <CardContent className="space-y-4">
-            {serverError && (
+            {showGoogleAuth && (
+              <>
+                <GoogleAuthButton
+                  errorCallbackURL={routes.signup}
+                  onError={(message) => setOauthError(message || DEFAULT_GOOGLE_SIGNUP_ERROR)}
+                />
+                <div className="relative">
+                  <div className="absolute inset-0 flex items-center">
+                    <span className="w-full border-t" />
+                  </div>
+                  <div className="relative flex justify-center text-xs uppercase">
+                    <span className="bg-card px-2 text-muted-foreground">Or continue with email</span>
+                  </div>
+                </div>
+              </>
+            )}
+            {(serverError ?? oauthError) && (
               <div role="alert" className="text-sm text-destructive">
-                {serverError}
+                {serverError ?? oauthError}
               </div>
             )}
             <div className="space-y-2">

--- a/packages/core/src/front/auth/index.ts
+++ b/packages/core/src/front/auth/index.ts
@@ -7,6 +7,8 @@ export type { UserIdentity, UserIdentityProviderProps } from './UserIdentityProv
 export { getAuthClient } from './authClient.js'
 export type { AuthClient } from './authClient.js'
 
+export { GoogleAuthButton } from './GoogleAuthButton.js'
+export type { GoogleAuthButtonProps } from './GoogleAuthButton.js'
 export { SignInPage } from './SignInPage.js'
 export { SignUpPage } from './SignUpPage.js'
 export { ForgotPasswordPage } from './ForgotPasswordPage.js'

--- a/packages/core/src/front/index.ts
+++ b/packages/core/src/front/index.ts
@@ -33,6 +33,7 @@ export {
   UserIdentityProvider,
   useUser,
   getAuthClient,
+  GoogleAuthButton,
   SignInPage,
   SignUpPage,
   ForgotPasswordPage,
@@ -46,6 +47,7 @@ export type {
   UserIdentity,
   UserIdentityProviderProps,
   AuthClient,
+  GoogleAuthButtonProps,
 } from './auth/index.js'
 
 export {

--- a/packages/core/src/front/utils.ts
+++ b/packages/core/src/front/utils.ts
@@ -118,7 +118,9 @@ export type RouteMap = {
   forgotPassword: '/auth/forgot-password'
   resetPassword: '/auth/reset-password'
   verifyEmail: '/auth/verify-email'
+  authError: '/auth/error'
   callbackGithub: '/auth/callback/github'
+  callbackGoogle: '/auth/callback/google'
   me: '/me'
   workspaceMembers: '/w/:id/members'
   workspaceInvites: '/w/:id/invites'
@@ -132,7 +134,9 @@ export const routes: RouteMap = {
   forgotPassword: '/auth/forgot-password',
   resetPassword: '/auth/reset-password',
   verifyEmail: '/auth/verify-email',
+  authError: '/auth/error',
   callbackGithub: '/auth/callback/github',
+  callbackGoogle: '/auth/callback/google',
   me: '/me',
   workspaceMembers: '/w/:id/members',
   workspaceInvites: '/w/:id/invites',

--- a/packages/core/src/server/__tests__/createTestApp.ts
+++ b/packages/core/src/server/__tests__/createTestApp.ts
@@ -51,6 +51,7 @@ export function createTestCoreConfig(
     },
     features: {
       githubOauth: false,
+      googleOauth: false,
       invitesEnabled: true,
       sendWelcomeEmail: true,
       inviteTtlDays: 7,

--- a/packages/core/src/server/__tests__/raceConditions.test.ts
+++ b/packages/core/src/server/__tests__/raceConditions.test.ts
@@ -42,7 +42,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 interface SessionUser {

--- a/packages/core/src/server/app/__tests__/capabilities.test.ts
+++ b/packages/core/src/server/app/__tests__/capabilities.test.ts
@@ -30,7 +30,7 @@ const TEST_CONFIG: CoreConfig = {
     sessionCookieSecure: false,
     mail: { from: 'noreply@test.dev', transportUrl: 'console://' },
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let app: Awaited<ReturnType<typeof createCoreApp>> | null = null
@@ -55,10 +55,11 @@ describe('capabilities contributor API', () => {
     expect(body.core.version).toBe(CORE_PACKAGE_VERSION.version)
     expect(body.core.features.invitesEnabled).toBe(true)
     expect(body.core.features.githubOauth).toBe(false)
+    expect(body.core.features.googleOauth).toBe(false)
     expect(body.core.features.emailFlows).toBe(true)
   })
 
-  it('core.auth.github is false in v1', async () => {
+  it('keeps github false and defaults google auth availability to false', async () => {
     app = await createCoreApp(TEST_CONFIG, { manageShutdown: false })
     await app.ready()
 
@@ -66,10 +67,75 @@ describe('capabilities contributor API', () => {
     const body = JSON.parse(res.body)
 
     expect(body.core.auth.github).toBe(false)
+    expect(body.core.auth.google).toBe(false)
     expect(body.core.auth.emailPassword).toBe(true)
     expect(body.core.auth.emailVerification).toBe(true)
     expect(body.core.auth.passwordReset).toBe(true)
     expect(body.core.auth.magicLink).toBe(true)
+  })
+
+  it('keeps core.auth.google false when Google credentials exist but the feature is off', async () => {
+    const configuredGoogle: CoreConfig = {
+      ...TEST_CONFIG,
+      auth: {
+        ...TEST_CONFIG.auth,
+        google: {
+          clientId: 'google-client-id',
+          clientSecret: 'google-client-secret',
+        },
+      },
+    }
+    app = await createCoreApp(configuredGoogle, { manageShutdown: false })
+    await app.ready()
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/capabilities' })
+    const body = JSON.parse(res.body)
+
+    expect(body.core.features.googleOauth).toBe(false)
+    expect(body.core.auth.google).toBe(false)
+  })
+
+  it('keeps Google unavailable when the feature is on but credentials are missing', async () => {
+    const enabledGoogleWithoutCreds: CoreConfig = {
+      ...TEST_CONFIG,
+      features: {
+        ...TEST_CONFIG.features,
+        googleOauth: true,
+      },
+    }
+    app = await createCoreApp(enabledGoogleWithoutCreds, { manageShutdown: false })
+    await app.ready()
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/capabilities' })
+    const body = JSON.parse(res.body)
+
+    expect(body.core.features.googleOauth).toBe(false)
+    expect(body.core.auth.google).toBe(false)
+  })
+
+  it('reports core.auth.google true when Google auth is usable now', async () => {
+    const enabledGoogle: CoreConfig = {
+      ...TEST_CONFIG,
+      auth: {
+        ...TEST_CONFIG.auth,
+        google: {
+          clientId: 'google-client-id',
+          clientSecret: 'google-client-secret',
+        },
+      },
+      features: {
+        ...TEST_CONFIG.features,
+        googleOauth: true,
+      },
+    }
+    app = await createCoreApp(enabledGoogle, { manageShutdown: false })
+    await app.ready()
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/capabilities' })
+    const body = JSON.parse(res.body)
+
+    expect(body.core.features.googleOauth).toBe(true)
+    expect(body.core.auth.google).toBe(true)
   })
 
   it('emailFlows and auth booleans are false when mail not configured', async () => {

--- a/packages/core/src/server/app/__tests__/createCoreApp.test.ts
+++ b/packages/core/src/server/app/__tests__/createCoreApp.test.ts
@@ -29,7 +29,7 @@ const TEST_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let app: Awaited<ReturnType<typeof createCoreApp>> | null = null

--- a/packages/core/src/server/app/__tests__/errorHandler.test.ts
+++ b/packages/core/src/server/app/__tests__/errorHandler.test.ts
@@ -23,7 +23,7 @@ const TEST_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let app: Awaited<ReturnType<typeof createCoreApp>> | null = null

--- a/packages/core/src/server/app/__tests__/fixtures/shutdownHarness.ts
+++ b/packages/core/src/server/app/__tests__/fixtures/shutdownHarness.ts
@@ -26,7 +26,7 @@ const TEST_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 const app = await createCoreApp(TEST_CONFIG)

--- a/packages/core/src/server/app/__tests__/routes.test.ts
+++ b/packages/core/src/server/app/__tests__/routes.test.ts
@@ -40,7 +40,7 @@ function makeConfig(): CoreConfig {
         transportUrl: `console-capture://${MAIL_CAPTURE_PATH}`,
       },
     },
-    features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+    features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
   }
 }
 
@@ -287,7 +287,7 @@ describe('GET /api/v1/config', () => {
       appName: 'Test App',
       appLogo: null,
       apiBase: 'http://localhost:3000',
-      features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true },
+      features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true },
     })
     expect(body.auth).toBeUndefined()
     expect(body.databaseUrl).toBeUndefined()

--- a/packages/core/src/server/app/capabilities.ts
+++ b/packages/core/src/server/app/capabilities.ts
@@ -4,6 +4,7 @@ import type { CapabilitiesContributor } from './types.js'
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isGoogleOauthUsable } from '../config/loadConfig.js'
 
 let cachedVersion: string | undefined
 
@@ -54,16 +55,19 @@ export function registerCapabilities(app: FastifyInstance) {
   const hasMail = !!app.config.auth.mail
 
   app.registerCapabilitiesContributor('core', () => {
+    const googleOauth = isGoogleOauthUsable(app.config)
     const core: CoreCapabilities = {
       version: getCoreVersion(),
       features: {
         invitesEnabled: app.config.features.invitesEnabled,
         githubOauth: app.config.features.githubOauth,
+        googleOauth,
         emailFlows: hasMail,
       },
       auth: {
         emailPassword: true,
         github: false,
+        google: googleOauth,
         emailVerification: hasMail,
         passwordReset: hasMail,
         magicLink: hasMail,

--- a/packages/core/src/server/auth/__tests__/authHook.test.ts
+++ b/packages/core/src/server/auth/__tests__/authHook.test.ts
@@ -37,7 +37,7 @@ function makeConfig(): CoreConfig {
         transportUrl: `console-capture://${MAIL_CAPTURE_PATH}`,
       },
     },
-    features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+    features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
   }
 }
 

--- a/packages/core/src/server/auth/__tests__/createAuth.providers.test.ts
+++ b/packages/core/src/server/auth/__tests__/createAuth.providers.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CoreConfig } from '../../../shared/types'
+
+const { betterAuthMock, drizzleAdapterMock } = vi.hoisted(() => ({
+  betterAuthMock: vi.fn((options: Record<string, unknown>) => ({
+    handler: vi.fn(),
+    options,
+  })),
+  drizzleAdapterMock: vi.fn(() => ({ mocked: true })),
+}))
+
+vi.mock('better-auth', () => ({
+  betterAuth: betterAuthMock,
+  APIError: { from: vi.fn() },
+}))
+
+vi.mock('better-auth/adapters/drizzle', () => ({
+  drizzleAdapter: drizzleAdapterMock,
+}))
+
+import { createAuth } from '../createAuth'
+
+function makeConfig(overrides?: Partial<CoreConfig>): CoreConfig {
+  return {
+    appId: 'test-app',
+    appName: 'Test App',
+    appLogo: null,
+    port: 0,
+    host: '127.0.0.1',
+    staticDir: null,
+    databaseUrl: null,
+    stores: 'local',
+    cors: { origins: ['http://localhost:3000'], credentials: true },
+    bodyLimit: 16 * 1024 * 1024,
+    logLevel: 'silent' as CoreConfig['logLevel'],
+    encryption: { workspaceSettingsKey: 'a'.repeat(64) },
+    auth: {
+      secret: 's'.repeat(64),
+      url: 'http://localhost:3000',
+      sessionTtlSeconds: 3600,
+      sessionCookieSecure: false,
+    },
+    features: {
+      githubOauth: false,
+      googleOauth: false,
+      invitesEnabled: true,
+      sendWelcomeEmail: true,
+      inviteTtlDays: 7,
+    },
+    ...overrides,
+  }
+}
+
+function getSocialProviders() {
+  expect(betterAuthMock).toHaveBeenCalled()
+  const options = betterAuthMock.mock.calls.at(-1)?.[0] as {
+    socialProviders: Record<string, unknown>
+  }
+  return options.socialProviders
+}
+
+describe('createAuth social providers', () => {
+  beforeEach(() => {
+    betterAuthMock.mockClear()
+    drizzleAdapterMock.mockClear()
+  })
+
+  it('passes a Google provider block when Google config is present and the feature is enabled', () => {
+    createAuth(
+      makeConfig({
+        auth: {
+          ...makeConfig().auth,
+          google: {
+            clientId: 'google-client-id',
+            clientSecret: 'google-client-secret',
+          },
+        },
+        features: {
+          ...makeConfig().features,
+          googleOauth: true,
+        },
+      }),
+      {} as never,
+    )
+
+    expect(getSocialProviders()).toEqual({
+      google: {
+        clientId: 'google-client-id',
+        clientSecret: 'google-client-secret',
+      },
+    })
+  })
+
+  it('omits the Google provider block when Google config is absent', () => {
+    createAuth(makeConfig(), {} as never)
+
+    expect(getSocialProviders()).toEqual({})
+  })
+
+  it('omits the Google provider block when credentials exist but the feature is off', () => {
+    createAuth(
+      makeConfig({
+        auth: {
+          ...makeConfig().auth,
+          google: {
+            clientId: 'google-client-id',
+            clientSecret: 'google-client-secret',
+          },
+        },
+      }),
+      {} as never,
+    )
+
+    expect(getSocialProviders()).toEqual({})
+  })
+
+  it('keeps existing GitHub handling intact when Google is also configured', () => {
+    createAuth(
+      makeConfig({
+        auth: {
+          ...makeConfig().auth,
+          github: {
+            clientId: 'github-client-id',
+            clientSecret: 'github-client-secret',
+          },
+          google: {
+            clientId: 'google-client-id',
+            clientSecret: 'google-client-secret',
+          },
+        },
+        features: {
+          ...makeConfig().features,
+          googleOauth: true,
+        },
+      }),
+      {} as never,
+    )
+
+    expect(getSocialProviders()).toEqual({
+      github: {
+        clientId: 'github-client-id',
+        clientSecret: 'github-client-secret',
+      },
+      google: {
+        clientId: 'google-client-id',
+        clientSecret: 'google-client-secret',
+      },
+    })
+  })
+})

--- a/packages/core/src/server/auth/__tests__/createAuth.test.ts
+++ b/packages/core/src/server/auth/__tests__/createAuth.test.ts
@@ -35,7 +35,7 @@ function makeConfig(overrides?: Partial<CoreConfig>): CoreConfig {
         transportUrl: `console-capture://${MAIL_CAPTURE_PATH}`,
       },
     },
-    features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+    features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
     ...overrides,
   }
 }

--- a/packages/core/src/server/auth/__tests__/deleteUserCompletely.test.ts
+++ b/packages/core/src/server/auth/__tests__/deleteUserCompletely.test.ts
@@ -32,7 +32,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let sqlClient: postgres.Sql

--- a/packages/core/src/server/auth/__tests__/postSignupHook.test.ts
+++ b/packages/core/src/server/auth/__tests__/postSignupHook.test.ts
@@ -38,7 +38,7 @@ function makeConfig(overrides?: Partial<CoreConfig>): CoreConfig {
         transportUrl: `console-capture://${MAIL_CAPTURE_PATH}`,
       },
     },
-    features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+    features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
     ...overrides,
   }
 }

--- a/packages/core/src/server/auth/createAuth.ts
+++ b/packages/core/src/server/auth/createAuth.ts
@@ -115,6 +115,25 @@ export function createAuth(config: CoreConfig, db: Database, opts?: CreateAuthOp
       })
     : undefined
 
+  const socialProviders = {
+    ...(config.auth.github
+      ? {
+          github: {
+            clientId: config.auth.github.clientId,
+            clientSecret: config.auth.github.clientSecret,
+          },
+        }
+      : {}),
+    ...(config.features.googleOauth && config.auth.google
+      ? {
+          google: {
+            clientId: config.auth.google.clientId,
+            clientSecret: config.auth.google.clientSecret,
+          },
+        }
+      : {}),
+  }
+
   return betterAuth({
     database: drizzleAdapter(db, { provider: 'pg', schema }),
     secret: config.auth.secret,
@@ -197,9 +216,7 @@ export function createAuth(config: CoreConfig, db: Database, opts?: CreateAuthOp
       },
     },
     emailVerification: emailVerificationConfig,
-    socialProviders: config.auth.github
-      ? { github: { clientId: config.auth.github.clientId, clientSecret: config.auth.github.clientSecret } }
-      : {},
+    socialProviders,
     plugins,
   })
 }

--- a/packages/core/src/server/config/__tests__/inviteTtl.test.ts
+++ b/packages/core/src/server/config/__tests__/inviteTtl.test.ts
@@ -29,6 +29,7 @@ function buildValidConfig(overrides: Record<string, unknown> = {}) {
     },
     features: {
       githubOauth: false,
+      googleOauth: false,
       invitesEnabled: true,
       sendWelcomeEmail: false,
       ...overrides,

--- a/packages/core/src/server/config/__tests__/loadConfig.test.ts
+++ b/packages/core/src/server/config/__tests__/loadConfig.test.ts
@@ -25,6 +25,7 @@ logo = "/logo.svg"
 
 [features]
 github_oauth = false
+google_oauth = false
 invites_enabled = true
 `
 
@@ -60,6 +61,7 @@ describe('loadConfig', () => {
     expect(config.auth.sessionTtlSeconds).toBe(60 * 60 * 24 * 30)
     expect(config.auth.sessionCookieSecure).toBe(false)
     expect(config.features.githubOauth).toBe(false)
+    expect(config.features.googleOauth).toBe(false)
     expect(config.features.invitesEnabled).toBe(true)
     expect(config.bodyLimit).toBe(16 * 1024 * 1024)
     expect(config.cors.credentials).toBe(true)
@@ -236,6 +238,74 @@ describe('loadConfig', () => {
     })
   })
 
+  it('wires Google config when both GOOGLE_CLIENT_* are set', async () => {
+    const config = await loadConfig({
+      tomlPath: TOML_PATH,
+      env: {
+        ...VALID_ENV,
+        GOOGLE_CLIENT_ID: 'google-id',
+        GOOGLE_CLIENT_SECRET: 'google-secret',
+      },
+    })
+
+    expect(config.auth.google).toEqual({
+      clientId: 'google-id',
+      clientSecret: 'google-secret',
+    })
+    expect(config.features.googleOauth).toBe(false)
+  })
+
+  it('enables Google OAuth only when the TOML flag is on and both creds exist', async () => {
+    writeToml(`
+[features]
+google_oauth = true
+`)
+
+    const config = await loadConfig({
+      tomlPath: TOML_PATH,
+      env: {
+        ...VALID_ENV,
+        GOOGLE_CLIENT_ID: 'google-id',
+        GOOGLE_CLIENT_SECRET: 'google-secret',
+      },
+    })
+
+    expect(config.features.googleOauth).toBe(true)
+  })
+
+  it('keeps Google OAuth off when the TOML flag is on but creds are missing', async () => {
+    writeToml(`
+[features]
+google_oauth = true
+`)
+
+    const config = await loadConfig({
+      tomlPath: TOML_PATH,
+      env: VALID_ENV,
+    })
+
+    expect(config.auth.google).toBeUndefined()
+    expect(config.features.googleOauth).toBe(false)
+  })
+
+  it('keeps Google OAuth off when only one Google credential is present', async () => {
+    writeToml(`
+[features]
+google_oauth = true
+`)
+
+    const config = await loadConfig({
+      tomlPath: TOML_PATH,
+      env: {
+        ...VALID_ENV,
+        GOOGLE_CLIENT_ID: 'google-id',
+      },
+    })
+
+    expect(config.auth.google).toBeUndefined()
+    expect(config.features.googleOauth).toBe(false)
+  })
+
   it('uses custom PORT and HOST', async () => {
     const config = await loadConfig({
       tomlPath: TOML_PATH,
@@ -289,7 +359,7 @@ describe('validateConfig', () => {
           sessionTtlSeconds: 3600,
           sessionCookieSecure: false,
         },
-        features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+        features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
       }),
     ).toThrow(ConfigValidationError)
   })
@@ -316,7 +386,7 @@ describe('validateConfig', () => {
           sessionTtlSeconds: 3600,
           sessionCookieSecure: false,
         },
-        features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+        features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
       }),
     ).toThrow(ConfigValidationError)
   })
@@ -344,6 +414,7 @@ describe('buildRuntimeConfigPayload', () => {
         apiBase: 'http://localhost:3000',
         features: {
           githubOauth: false,
+          googleOauth: false,
           invitesEnabled: true,
           sendWelcomeEmail: true,
         },
@@ -355,5 +426,40 @@ describe('buildRuntimeConfigPayload', () => {
     } finally {
       rmSync(FIXTURES_DIR, { recursive: true, force: true })
     }
+  })
+
+  it('keeps googleOauth false when a manual config enables the flag without credentials', () => {
+    const runtime = buildRuntimeConfigPayload({
+      appId: 'test-app',
+      appName: 'Test App',
+      appLogo: null,
+      port: 3000,
+      host: '127.0.0.1',
+      staticDir: null,
+      databaseUrl: null,
+      stores: 'local',
+      cors: {
+        origins: ['http://localhost:3000'],
+        credentials: true,
+      },
+      bodyLimit: 1024,
+      logLevel: 'info',
+      encryption: { workspaceSettingsKey: 'a'.repeat(64) },
+      auth: {
+        secret: 's'.repeat(64),
+        url: 'http://localhost:3000',
+        sessionTtlSeconds: 3600,
+        sessionCookieSecure: false,
+      },
+      features: {
+        githubOauth: false,
+        googleOauth: true,
+        invitesEnabled: true,
+        sendWelcomeEmail: true,
+        inviteTtlDays: 7,
+      },
+    })
+
+    expect(runtime.features.googleOauth).toBe(false)
   })
 })

--- a/packages/core/src/server/config/loadConfig.ts
+++ b/packages/core/src/server/config/loadConfig.ts
@@ -26,7 +26,12 @@ interface TomlAppConfig {
     branding?: { name?: string; logo?: string; favicon?: string }
     theme?: { default?: string }
   }
-  features?: { github_oauth?: boolean; invites_enabled?: boolean; invite_ttl_days?: number }
+  features?: {
+    github_oauth?: boolean
+    google_oauth?: boolean
+    invites_enabled?: boolean
+    invite_ttl_days?: number
+  }
 }
 
 function parseRateLimitOverrides(
@@ -131,6 +136,15 @@ export async function loadConfig(
         }
       : undefined
 
+  const googleOauth = toml.features?.google_oauth === true
+  const google =
+    env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET
+      ? {
+          clientId: env.GOOGLE_CLIENT_ID,
+          clientSecret: env.GOOGLE_CLIENT_SECRET,
+        }
+      : undefined
+
   const mailFrom = env.MAIL_FROM
   const mailTransportUrl = env.MAIL_TRANSPORT_URL
   const mail =
@@ -173,6 +187,7 @@ export async function loadConfig(
       secret: authSecret,
       url: authUrl,
       github,
+      google,
       mail,
       sessionTtlSeconds: parseInt(
         env.SESSION_TTL_SECONDS ?? String(THIRTY_DAYS_SECONDS),
@@ -183,6 +198,7 @@ export async function loadConfig(
 
     features: {
       githubOauth: githubOauth && github !== undefined,
+      googleOauth: googleOauth && google !== undefined,
       invitesEnabled: toml.features?.invites_enabled ?? true,
       sendWelcomeEmail: env.SEND_WELCOME_EMAIL !== 'false',
       ...(toml.features?.invite_ttl_days != null && { inviteTtlDays: toml.features.invite_ttl_days }),
@@ -205,6 +221,10 @@ export function validateConfig(raw: unknown): CoreConfig {
   return result.data as CoreConfig
 }
 
+export function isGoogleOauthUsable(config: Pick<CoreConfig, 'features' | 'auth'>): boolean {
+  return config.features.googleOauth && config.auth.google !== undefined
+}
+
 export function buildRuntimeConfigPayload(config: CoreConfig): RuntimeConfig {
   return {
     appId: config.appId,
@@ -213,6 +233,7 @@ export function buildRuntimeConfigPayload(config: CoreConfig): RuntimeConfig {
     apiBase: config.auth.url,
     features: {
       githubOauth: config.features.githubOauth,
+      googleOauth: isGoogleOauthUsable(config),
       invitesEnabled: config.features.invitesEnabled,
       sendWelcomeEmail: config.features.sendWelcomeEmail,
     },

--- a/packages/core/src/server/config/schema.ts
+++ b/packages/core/src/server/config/schema.ts
@@ -65,6 +65,12 @@ export const coreConfigSchema = z.object({
         clientSecret: z.string().min(1),
       })
       .optional(),
+    google: z
+      .object({
+        clientId: z.string().min(1),
+        clientSecret: z.string().min(1),
+      })
+      .optional(),
     mail: z
       .object({
         from: z.string().min(1),
@@ -77,6 +83,7 @@ export const coreConfigSchema = z.object({
 
   features: z.object({
     githubOauth: z.boolean(),
+    googleOauth: z.boolean(),
     invitesEnabled: z.boolean(),
     sendWelcomeEmail: z.boolean(),
     inviteTtlDays: z.number().int().min(1).max(30).default(7),

--- a/packages/core/src/server/db/__tests__/connection.test.ts
+++ b/packages/core/src/server/db/__tests__/connection.test.ts
@@ -21,7 +21,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 describe('createDatabase', () => {

--- a/packages/core/src/server/db/__tests__/migrate.test.ts
+++ b/packages/core/src/server/db/__tests__/migrate.test.ts
@@ -24,7 +24,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let adminSql: postgres.Sql

--- a/packages/core/src/server/db/__tests__/userSettings.schema.test.ts
+++ b/packages/core/src/server/db/__tests__/userSettings.schema.test.ts
@@ -24,7 +24,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let sql: postgres.Sql

--- a/packages/core/src/server/db/__tests__/workspaceInvites.schema.test.ts
+++ b/packages/core/src/server/db/__tests__/workspaceInvites.schema.test.ts
@@ -24,7 +24,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let sql: postgres.Sql

--- a/packages/core/src/server/db/__tests__/workspaceMembers.schema.test.ts
+++ b/packages/core/src/server/db/__tests__/workspaceMembers.schema.test.ts
@@ -25,7 +25,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let sql: postgres.Sql

--- a/packages/core/src/server/db/__tests__/workspaceRuntimes.schema.test.ts
+++ b/packages/core/src/server/db/__tests__/workspaceRuntimes.schema.test.ts
@@ -25,7 +25,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 const OWNER_ID = '22000000-0000-0000-0000-000000000001'

--- a/packages/core/src/server/db/__tests__/workspaceSettings.schema.test.ts
+++ b/packages/core/src/server/db/__tests__/workspaceSettings.schema.test.ts
@@ -25,7 +25,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 const ENCRYPTION_KEY_A = 'a'.repeat(64)

--- a/packages/core/src/server/db/__tests__/workspaces.schema.test.ts
+++ b/packages/core/src/server/db/__tests__/workspaces.schema.test.ts
@@ -24,7 +24,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let sql: postgres.Sql

--- a/packages/core/src/server/db/stores/__tests__/PostgresUserStore.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/PostgresUserStore.test.ts
@@ -27,7 +27,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let sqlClient: postgres.Sql

--- a/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.invites.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.invites.test.ts
@@ -30,7 +30,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 const OWNER_ID = '41000000-0000-0000-0000-000000000001'

--- a/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
@@ -33,7 +33,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let sqlClient: postgres.Sql

--- a/packages/core/src/server/db/stores/__tests__/workspaceSettingsCrypto.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/workspaceSettingsCrypto.test.ts
@@ -34,7 +34,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 let sqlClient: postgres.Sql

--- a/packages/core/src/server/security/__tests__/rateLimit.test.ts
+++ b/packages/core/src/server/security/__tests__/rateLimit.test.ts
@@ -26,7 +26,7 @@ const BASE_CONFIG: CoreConfig = {
     sessionTtlSeconds: 3600,
     sessionCookieSecure: false,
   },
-  features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
 const RATE_LIMITED_ENDPOINTS = DEFAULT_RATE_LIMIT_RULES.map((rule) => ({

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -165,6 +165,7 @@ export interface CoreConfig {
     secret: string
     url: string
     github?: { clientId: string; clientSecret: string }
+    google?: { clientId: string; clientSecret: string }
     mail?: { from: string; transportUrl: string }
     sessionTtlSeconds: number
     sessionCookieSecure: boolean
@@ -172,6 +173,7 @@ export interface CoreConfig {
 
   features: {
     githubOauth: boolean
+    googleOauth: boolean
     invitesEnabled: boolean
     sendWelcomeEmail: boolean
     inviteTtlDays: number
@@ -183,7 +185,12 @@ export interface RuntimeConfig {
   appName: string
   appLogo: string | null
   apiBase: string
-  features: { githubOauth: boolean; invitesEnabled: boolean; sendWelcomeEmail: boolean }
+  features: {
+    githubOauth: boolean
+    googleOauth: boolean
+    invitesEnabled: boolean
+    sendWelcomeEmail: boolean
+  }
 }
 
 export type JsonValue =
@@ -199,11 +206,13 @@ export type CoreCapabilities = {
   features: {
     invitesEnabled: boolean
     githubOauth: boolean
+    googleOauth: boolean
     emailFlows: boolean
   }
   auth: {
     emailPassword: boolean
     github: boolean
+    google: boolean
     emailVerification: boolean
     passwordReset: boolean
     magicLink: boolean

--- a/packages/core/stories/auth-decorators.tsx
+++ b/packages/core/stories/auth-decorators.tsx
@@ -55,7 +55,7 @@ function makeMockFetch(originalFetch: typeof fetch): typeof fetch {
         appName: "Storybook App",
         appLogo: null,
         apiBase: "",
-        features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: false },
+        features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: false },
       })
     }
     if (url.endsWith("/api/v1/workspaces")) {


### PR DESCRIPTION
## Summary
- add Google OAuth config/runtime/auth wiring for child apps using boring core
- add stock Google auth UI, callback/error handling, docs, and child-app setup skill
- add focused unit/server coverage plus full-app Playwright smoke coverage

## Validation
- pnpm --filter @hachej/boring-core run typecheck
- pnpm exec vitest run src/front/__tests__/SignInPage.test.tsx src/front/__tests__/SignUpPage.test.tsx src/front/__tests__/CoreFront.test.tsx src/front/__tests__/utils.test.ts src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts --no-file-parallelism
- pnpm exec playwright test e2e/google-signup.spec.ts --config e2e/playwright.config.ts --reporter=list

## Notes
- supersedes #78, which was opened from a stale/diverged base branch
- intentionally leaves stray local untracked boring.app.toml temp files untouched