### PR TITLE
fix: stabilize main test/build gates

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "boring-ui-v2",
   "type": "module",
   "scripts": {
-    "build": "pnpm -r run build",
+    "build": "pnpm -r --workspace-concurrency=1 run build",
     "dev": "pnpm -r run dev",
     "storybook": "pnpm --filter @hachej/boring-ui-kit build && storybook dev -p 6006",
     "storybook:build": "pnpm --filter @hachej/boring-ui-kit build && storybook build",

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -82,7 +82,7 @@ test('registerAgentRoutes provisions embedded runtime plugins before host app ro
   } finally {
     await app.close()
   }
-})
+}, 15_000)
 
 test('registerAgentRoutes provisions the resolved request workspace, not the host base root', async () => {
   const baseRoot = await makeTempDir('boring-agent-embed-base-root-')
@@ -129,7 +129,7 @@ test('registerAgentRoutes provisions the resolved request workspace, not the hos
   } finally {
     await app.close()
   }
-})
+}, 15_000)
 
 test('registerAgentRoutes reload reruns provisioning and refreshes skills scope', async () => {
   const workspaceRoot = await makeTempDir('boring-agent-embed-reload-provision-')

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/heartbeat.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/heartbeat.test.ts
@@ -108,7 +108,7 @@ describe("heartbeat during tool execution", () => {
     for (const hb of heartbeats) {
       expect(hb.data.elapsedMs).toBeGreaterThan(0);
     }
-  });
+  }, 15_000);
 
   it("stops heartbeat when tool ends", async () => {
     const harness = createPiCodingAgentHarness({
@@ -138,6 +138,11 @@ describe("heartbeat during tool execution", () => {
     emit({ type: "tool_execution_start", toolCallId: "tc-2", toolName: "bash", args: {} } as AgentSessionEvent);
     await vi.advanceTimersByTimeAsync(2000);
 
+    const heartbeatCountBeforeEnd = collected.filter(
+      (c: any) => c.type === "data-status" && c.data?.toolCallId === "tc-2",
+    ).length;
+    expect(heartbeatCountBeforeEnd).toBeGreaterThanOrEqual(1);
+
     emit({
       type: "tool_execution_end",
       toolCallId: "tc-2",
@@ -157,7 +162,7 @@ describe("heartbeat during tool execution", () => {
     const heartbeats = collected.filter(
       (c: any) => c.type === "data-status" && c.data?.toolCallId === "tc-2",
     );
-    expect(heartbeats.length).toBe(1);
+    expect(heartbeats.length).toBe(heartbeatCountBeforeEnd);
   });
 
   it("stops heartbeat on abort", async () => {

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/pluginExtensionSmoke.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/pluginExtensionSmoke.test.ts
@@ -165,5 +165,5 @@ describe("Plugin extension smoke test", () => {
     expect(toolResult.content[0]?.text).toBe(
       "Hello, Ada! (from synthetic extension)",
     );
-  });
+  }, 15_000);
 });

--- a/packages/core/src/server/db/__tests__/workspaceMembers.schema.test.ts
+++ b/packages/core/src/server/db/__tests__/workspaceMembers.schema.test.ts
@@ -28,10 +28,14 @@ const BASE_CONFIG: CoreConfig = {
   features: { githubOauth: false, invitesEnabled: true, sendWelcomeEmail: true, inviteTtlDays: 7 },
 }
 
+const runId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+const ownerEmail = `members-owner-${runId}@example.com`
+const memberEmail = `members-user-${runId}@example.com`
+
 let sql: postgres.Sql
-let ownerId: string
-let memberId: string
-let workspaceId: string
+let ownerId: string | undefined
+let memberId: string | undefined
+let workspaceId: string | undefined
 
 beforeAll(async () => {
   await runMigrations(BASE_CONFIG)
@@ -39,21 +43,21 @@ beforeAll(async () => {
 
   const [owner] = await sql`
     INSERT INTO users (name, email, email_verified)
-    VALUES ('Members Owner', 'members-owner@example.com', true)
+    VALUES ('Members Owner', ${ownerEmail}, true)
     RETURNING id
   `
   ownerId = owner.id
 
   const [member] = await sql`
     INSERT INTO users (name, email, email_verified)
-    VALUES ('Members User', 'members-user@example.com', true)
+    VALUES ('Members User', ${memberEmail}, true)
     RETURNING id
   `
   memberId = member.id
 
   const [workspace] = await sql`
     INSERT INTO workspaces (app_id, name, created_by)
-    VALUES ('members-app', 'Members Test Workspace', ${ownerId})
+    VALUES ('members-app', 'Members Test Workspace', ${ownerId!})
     RETURNING id
   `
   workspaceId = workspace.id
@@ -61,9 +65,17 @@ beforeAll(async () => {
 
 afterAll(async () => {
   if (!sql) return
-  await sql`DELETE FROM workspace_members WHERE workspace_id = ${workspaceId}`
-  await sql`DELETE FROM workspaces WHERE id = ${workspaceId}`
-  await sql`DELETE FROM users WHERE id IN (${ownerId}, ${memberId})`
+  if (workspaceId) {
+    const currentWorkspaceId = workspaceId
+    await sql`DELETE FROM workspace_members WHERE workspace_id = ${currentWorkspaceId}`
+    await sql`DELETE FROM workspaces WHERE id = ${currentWorkspaceId}`
+  }
+  if (ownerId || memberId) {
+    const userIds = [ownerId, memberId].filter((value): value is string => Boolean(value))
+    if (userIds.length > 0) {
+      await sql`DELETE FROM users WHERE id IN ${sql(userIds)}`
+    }
+  }
   await sql.end()
 })
 
@@ -71,21 +83,21 @@ describe('workspace_members schema', () => {
   it('RESTRICT FK blocks deleting a user with active memberships', async () => {
     await sql`
       INSERT INTO workspace_members (workspace_id, user_id, role)
-      VALUES (${workspaceId}, ${memberId}, 'editor')
+      VALUES (${workspaceId!}, ${memberId!}, 'editor')
     `
 
     await expect(
-      sql`DELETE FROM users WHERE id = ${memberId}`,
+      sql`DELETE FROM users WHERE id = ${memberId!}`,
     ).rejects.toThrow(/foreign key|violates/)
 
-    await sql`DELETE FROM workspace_members WHERE workspace_id = ${workspaceId} AND user_id = ${memberId}`
+    await sql`DELETE FROM workspace_members WHERE workspace_id = ${workspaceId!} AND user_id = ${memberId!}`
   })
 
   it('role CHECK rejects invalid role values', async () => {
     await expect(
       sql`
         INSERT INTO workspace_members (workspace_id, user_id, role)
-        VALUES (${workspaceId}, ${memberId}, 'admin')
+        VALUES (${workspaceId!}, ${memberId!}, 'admin')
       `,
     ).rejects.toThrow(/check|violates/)
   })

--- a/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -82,7 +82,7 @@ describe("createWorkspaceAgentServer — runtime provisioning reload", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 })
 
 describe("createWorkspaceAgentServer — plugin wiring", () => {
@@ -354,7 +354,7 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 
   /**
    * Simulates the CLI scenario: a globally-installed boring-ui binary runs
@@ -391,7 +391,7 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 
   test("CLI-like boot in fresh workspace auto-discovers boring-plugin-authoring skill via /api/v1/agent/skills", async () => {
     const workspaceRoot = await makeTempDir("boring-cli-skill-discovery-")
@@ -410,7 +410,7 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 
   test("collects plugin provisioning declarations and asks agent to seed workspace", async () => {
     const workspaceRoot = await makeTempDir("boring-workspace-provisioned-")
@@ -448,7 +448,7 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 
   test("POST /api/v1/agent/reload reloads boring plugin assets before pi reload", async () => {
     const workspaceRoot = await makeTempDir("boring-workspace-agent-reload-assets-")
@@ -481,7 +481,7 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 
   test("POST /api/v1/agent/reload tolerates per-plugin failures (PLUGIN_SYSTEM.md §4.5)", async () => {
     // beforeReload no longer throws on per-plugin scan/rebuild errors.
@@ -510,7 +510,7 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 
   test("can skip plugin provisioning when the host opts out", async () => {
     const workspaceRoot = await makeTempDir("boring-workspace-provision-skip-")
@@ -565,7 +565,7 @@ describe("createWorkspaceAgentServer — plugin model (j9p7.11)", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 
   test("plugin agentTools appear in the tool catalog", async () => {
     const workspaceRoot = await makeTempDir("boring-workspace-plugins-")
@@ -594,7 +594,7 @@ describe("createWorkspaceAgentServer — plugin model (j9p7.11)", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 
   test("plugin agentTools preserve tool metadata in the catalog", async () => {
     const workspaceRoot = await makeTempDir("boring-workspace-plugin-tool-metadata-")
@@ -621,7 +621,7 @@ describe("createWorkspaceAgentServer — plugin model (j9p7.11)", () => {
     } finally {
       await app.close()
     }
-  })
+  }, 15_000)
 
   test("excludeDefaults does not remove harness file tools", async () => {
     const workspaceRoot = await makeTempDir("boring-workspace-exclude-")


### PR DESCRIPTION
## Summary
- serialize the root `pnpm build` to avoid recursive workspace build races
- make the core workspace-members schema test use unique fixture data and safe cleanup
- relax a few slow/flaky integration test expectations/timeouts in agent and workspace suites

## Verification
- `pnpm lint`
- `pnpm test`
- `pnpm build`