### PR TITLE
chore(ci): harden repository workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 env:
   CI: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -292,7 +295,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
 
       - name: Deploy boring-full-app
         run: flyctl deploy --remote-only --app boring-full-app --config apps/full-app/fly.toml

--- a/.github/workflows/invariants.yml
+++ b/.github/workflows/invariants.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint-invariants:
     runs-on: ubuntu-latest

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -21,6 +21,9 @@ on:
 env:
   CI: true
 
+permissions:
+  contents: read
+
 concurrency:
   group: visual-regression-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- pin the Fly deploy setup action to an immutable commit SHA
- declare read-only workflow permissions for CI, invariants, and visual regression
- add Dependabot config for npm/pnpm dependencies and GitHub Actions

## GitHub settings already applied
- release environment now requires review, disables admin bypass, and restricts deployment branches/patterns
- main branch protection now requires strict CI checks, stale-review dismissal, last-push approval, conversation resolution, linear history, and admin enforcement
- secret scanning, push protection, Dependabot alerts, and automated security fixes enabled where available

## Verification
- YAML parsed successfully with Python/PyYAML
- git diff --check passed
