### PR TITLE
test(ask-user): make missing waiter runtime test deterministic

### DIFF
--- a/plugins/ask-user/src/server/__tests__/askUserRuntime.test.ts
+++ b/plugins/ask-user/src/server/__tests__/askUserRuntime.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { describe, expect, it, vi } from "vitest"
 import { ASK_USER_ERROR_CODES } from "../../shared/error-codes"
-import type { AskUserFormSchema } from "../../shared/types"
+import type { AskUserFormSchema, AskUserQuestion } from "../../shared/types"
 import { FileAskUserStore } from "../askUserStore"
 import { AskUserRuntime, InProcessAskUserCoordinator, requireAskUserRuntime } from "../askUserRuntime"
 
@@ -20,6 +20,21 @@ async function pendingQuestion(store: FileAskUserStore, sessionId: string) {
     expect(question).not.toBeNull()
     return question!
   }, { timeout: 5_000 })
+}
+
+function makeQuestion(overrides: Partial<AskUserQuestion> = {}): AskUserQuestion {
+  const now = new Date().toISOString()
+  return {
+    questionId: "q1",
+    sessionId: "s1",
+    ownerPrincipalId: "anonymous",
+    status: "ready",
+    schema,
+    answerToken: "token",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  }
 }
 
 describe("InProcessAskUserCoordinator", () => {
@@ -96,9 +111,9 @@ describe("AskUserRuntime", () => {
 
   it("abandons if submit/cancel discovers a missing waiter", async () => {
     const store = await makeStore()
-    const runtime = new AskUserRuntime({ store })
-    void runtime.ask({ sessionId: "s1", schema })
-    const question = await pendingQuestion(store, "s1")
+    const question = makeQuestion()
+    await store.createPending(question)
+
     const restarted = new AskUserRuntime({ store })
     await restarted.submitAnswer(question.questionId, "s1", {})
     await expect(store.getByQuestionId(question.questionId)).resolves.toMatchObject({ status: "abandoned" })


### PR DESCRIPTION
Fixes the main CI unit-test flake seen in run 26536438938.\n\nThe failing test started an ask_user runtime and intentionally never settled its waiter, then used a restarted runtime to simulate a missing waiter. Under CI load this could hang until Vitest's 5s timeout.\n\nThis patch creates the orphaned pending question directly in the store, so the missing-waiter path is tested without leaving an unresolved runtime ask promise.\n\nVerification:\n- pnpm --filter @hachej/boring-ask-user run test -- src/server/__tests__/askUserRuntime.test.ts\n- pnpm --filter @hachej/boring-ask-user run test