### PR TITLE
fix(core): raise full-app Docker build heap

### DIFF
--- a/apps/full-app/Dockerfile
+++ b/apps/full-app/Dockerfile
@@ -12,6 +12,7 @@ COPY apps/full-app/package.json apps/full-app/package.json
 RUN pnpm install --frozen-lockfile
 
 FROM deps AS build
+ENV NODE_OPTIONS=--max-old-space-size=4096
 COPY packages/ packages/
 COPY apps/full-app/ apps/full-app/
 


### PR DESCRIPTION
Fixes the main deploy job OOM in run 26537555251.\n\nThe Fly remote Docker build was failing during the workspace Vite build with:\n\n`FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory`\n\nSet `NODE_OPTIONS=--max-old-space-size=4096` in the Docker build stage so package/front builds have the same heap headroom as CI publish builds.