### PR TITLE
test(ask-user): wait for runtime waiter in bridge tests

### DIFF
--- a/plugins/ask-user/src/server/__tests__/askUserServerPlugin.test.ts
+++ b/plugins/ask-user/src/server/__tests__/askUserServerPlugin.test.ts
@@ -35,6 +35,12 @@ async function fixture() {
   return { store, runtime }
 }
 
+async function waitForRuntimeWaiter(runtime: AskUserRuntime, questionId: string) {
+  await vi.waitFor(() => {
+    expect(runtime.coordinator.hasWaiter(questionId)).toBe(true)
+  }, pendingWait)
+}
+
 describe("ask-user Pi tool", () => {
   it("registers one ask_user tool and rejects invalid input immediately", async () => {
     const { runtime } = await fixture()
@@ -73,6 +79,7 @@ describe("ask-user Pi tool", () => {
       pending = await store.getPending("chat-session")
       expect(pending).toMatchObject({ status: "ready", title: "Need input" })
     }, pendingWait)
+    await waitForRuntimeWaiter(runtime, pending!.questionId)
     await runtime.submitAnswer(pending!.questionId, "chat-session", { answer: "ok" })
     await expect(pendingResult).resolves.toMatchObject({ details: { status: "answered" } })
     await expect(store.getPending("fallback")).resolves.toBeNull()
@@ -87,10 +94,9 @@ describe("ask-user Pi tool", () => {
       pending = await store.getPending("s1")
       expect(pending).toMatchObject({ status: "ready", title: "Need input" })
     }, pendingWait)
-    await vi.waitFor(async () => {
-      await runtime.submitAnswer(pending!.questionId, "s1", { answer: "ok" })
-      await expect(pendingResult).resolves.toMatchObject({ details: { status: "answered" } })
-    })
+    await waitForRuntimeWaiter(runtime, pending!.questionId)
+    await runtime.submitAnswer(pending!.questionId, "s1", { answer: "ok" })
+    await expect(pendingResult).resolves.toMatchObject({ details: { status: "answered" } })
   })
 })
 

--- a/plugins/ask-user/src/server/__tests__/questionsBridge.test.ts
+++ b/plugins/ask-user/src/server/__tests__/questionsBridge.test.ts
@@ -28,6 +28,9 @@ async function fixture() {
     expect(pending).not.toBeNull()
     return pending!
   }, { timeout: 5_000 })
+  await vi.waitFor(() => {
+    expect(runtime.coordinator.hasWaiter(question.questionId)).toBe(true)
+  }, { timeout: 5_000 })
   return { store, runtime, question, result }
 }
 


### PR DESCRIPTION
Fixes the remaining ask-user unit-test race seen on main run 26540315466.\n\nThe tests could observe a persisted pending question before AskUserRuntime had registered its in-process waiter. Submitting in that window makes the restarted/missing-waiter path run and leaves the test's pending result unresolved until Vitest's 5s timeout.\n\nThis patch waits for runtime.coordinator.hasWaiter(questionId) before submitting in the bridge/tool tests.\n\nVerification:\n- pnpm --filter @hachej/boring-ask-user run test