### PR TITLE
Fix plugin publish dependency metadata

### DIFF
--- a/plugins/ask-user/package.json
+++ b/plugins/ask-user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-ask-user",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "private": false,
   "description": "Ask-user plugin for Boring workspace — surfaces agent questions to the user and streams answers back.",
@@ -45,12 +45,12 @@
   },
   "peerDependencies": {
     "@hachej/boring-workspace": "workspace:*",
+    "fastify": "^5.3.3",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "@hachej/boring-ui-kit": "workspace:*",
-    "fastify": "^5.3.3",
     "lucide-react": "^1.8.0",
     "zod": "^3.23.0"
   },
@@ -62,11 +62,17 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",
+    "fastify": "^5.3.3",
     "jsdom": "^29.0.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tsup": "^8.4.0",
     "typescript": "~5.9.3",
     "vitest": "^3.1.3"
+  },
+  "peerDependenciesMeta": {
+    "fastify": {
+      "optional": true
+    }
   }
 }

--- a/plugins/data-catalog/package.json
+++ b/plugins/data-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-data-catalog",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/data-explorer/package.json
+++ b/plugins/data-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-data-explorer",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/deck/package.json
+++ b/plugins/deck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-deck",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "type": "module",
   "license": "MIT",
   "description": "Front-only markdown deck plugin scaffold for Boring workspace.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -869,9 +869,6 @@ importers:
       '@hachej/boring-ui-kit':
         specifier: workspace:*
         version: link:../../packages/ui
-      fastify:
-        specifier: ^5.3.3
-        version: 5.8.5
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
@@ -900,6 +897,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      fastify:
+        specifier: ^5.3.3
+        version: 5.8.5
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2(@noble/hashes@2.2.0)


### PR DESCRIPTION
## Summary
- bump plugin patch versions for clean npm metadata republish
- move ask-user Fastify from runtime dependency to optional peer/dev dependency
- keep pnpm-packed plugin manifests free of workspace protocol ranges

## Verification
- pnpm --filter @hachej/boring-deck build
- pnpm --filter @hachej/boring-ask-user build
- pnpm --filter @hachej/boring-data-explorer build
- pnpm --filter @hachej/boring-data-catalog build
- pnpm --filter @hachej/boring-deck test
- pnpm --filter @hachej/boring-ask-user test
- pnpm --filter @hachej/boring-data-explorer test
- TMPDIR=/home/ubuntu/tmp/vitest pnpm --filter @hachej/boring-data-catalog test
- pnpm --filter @hachej/boring-ask-user typecheck
- pnpm lint:invariants
- inspected pnpm pack manifests for all four plugins