### PR TITLE
Stabilize ask-user server plugin waiter tests

### DIFF
--- a/plugins/ask-user/src/server/__tests__/askUserServerPlugin.test.ts
+++ b/plugins/ask-user/src/server/__tests__/askUserServerPlugin.test.ts
@@ -83,7 +83,7 @@ describe("ask-user Pi tool", () => {
     await runtime.submitAnswer(pending!.questionId, "chat-session", { answer: "ok" })
     await expect(pendingResult).resolves.toMatchObject({ details: { status: "answered" } })
     await expect(store.getPending("fallback")).resolves.toBeNull()
-  })
+  }, 10_000)
 
   it("valid input creates pending question and waits for runtime answer", async () => {
     const { store, runtime } = await fixture()
@@ -97,7 +97,7 @@ describe("ask-user Pi tool", () => {
     await waitForRuntimeWaiter(runtime, pending!.questionId)
     await runtime.submitAnswer(pending!.questionId, "s1", { answer: "ok" })
     await expect(pendingResult).resolves.toMatchObject({ details: { status: "answered" } })
-  })
+  }, 10_000)
 })
 
 describe("createAskUserServerPlugin", () => {


### PR DESCRIPTION
## Summary
- give ask-user waiter tests a 10s Vitest timeout so their 5s waiter deadline does not race the default test timeout on slow CI

## Verification
- pnpm --filter @hachej/boring-ask-user run test -- src/server/__tests__/askUserServerPlugin.test.ts