### PR TITLE
Audit packed publish manifests before npm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
           pnpm --filter @hachej/boring-ask-user build
           pnpm --filter @hachej/boring-data-explorer build
           pnpm --filter @hachej/boring-data-catalog build
+      - name: Audit publish manifests
+        run: pnpm audit:publish-manifests
       - name: Publish
         run: |
           for pkg in packages/ui packages/agent packages/workspace packages/core packages/cli plugins/deck plugins/ask-user plugins/data-explorer plugins/data-catalog; do

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:invariants": "pnpm --dir packages/agent run lint:invariants && pnpm lint:workspace-plugin-invariants",
     "lint:workspace-plugin-invariants": "pnpm --filter @hachej/boring-workspace run lint:plugin-invariants",
     "audit:imports": "pnpm tsx scripts/audit-imports.ts",
+    "audit:publish-manifests": "node scripts/audit-publish-manifests.mjs",
     "check:generated-artifacts": "pnpm tsx scripts/check-generated-artifacts.ts",
     "check:agent-isolation": "pnpm --filter @hachej/boring-agent run check:isolation",
     "check:bundle-size": "pnpm --filter @hachej/boring-workspace run check:bundle-size",

--- a/scripts/audit-publish-manifests.mjs
+++ b/scripts/audit-publish-manifests.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * Audit the manifests that npm will actually receive.
+ *
+ * pnpm rewrites workspace:* ranges during packing. This script verifies the
+ * packed package.json files, not the repo-local manifests, so release failures
+ * catch the same metadata users/npm will see.
+ */
+import { execFileSync } from "node:child_process"
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, isAbsolute, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = resolve(__dirname, "..")
+
+const PUBLISHABLE_PACKAGES = [
+  "packages/ui",
+  "packages/agent",
+  "packages/workspace",
+  "packages/core",
+  "packages/cli",
+  "plugins/deck",
+  "plugins/ask-user",
+  "plugins/data-explorer",
+  "plugins/data-catalog",
+]
+
+const DEP_SECTIONS = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+  "devDependencies",
+]
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+function fail(message) {
+  throw new Error(message)
+}
+
+function formatPackage(pkg) {
+  return `${pkg.name}@${pkg.version}`
+}
+
+function assertRepository(pkg, packagePath) {
+  const repository = pkg.repository
+  const url = typeof repository === "string" ? repository : repository?.url
+  if (!url) {
+    fail(`${formatPackage(pkg)} (${packagePath}) must set repository.url for npm provenance`)
+  }
+  if (!url.includes("github.com/hachej/boring-ui")) {
+    fail(`${formatPackage(pkg)} (${packagePath}) repository.url must point at hachej/boring-ui; got ${url}`)
+  }
+}
+
+function npmHasVersion(name, range) {
+  try {
+    execFileSync("npm", ["view", `${name}@${range}`, "version", "--json"], {
+      cwd: root,
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+    })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function packManifest(packagePath, tempRoot) {
+  const packageDir = resolve(root, packagePath)
+  const packDir = join(tempRoot, packagePath.replaceAll("/", "__"))
+  mkdirSync(packDir, { recursive: true })
+  const output = execFileSync("pnpm", ["pack", "--pack-destination", packDir], {
+    cwd: packageDir,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  })
+  const lastLine = output.trim().split(/\r?\n/).filter(Boolean).at(-1)
+  if (!lastLine) fail(`pnpm pack produced no tarball path for ${packagePath}`)
+
+  const tarball = isAbsolute(lastLine) ? lastLine : resolve(packDir, lastLine)
+  if (!existsSync(tarball)) fail(`pnpm pack tarball not found for ${packagePath}: ${tarball}`)
+
+  const extractDir = join(packDir, "extract")
+  mkdirSync(extractDir, { recursive: true })
+  execFileSync("tar", ["-xzf", tarball, "-C", extractDir, "package/package.json"], {
+    cwd: root,
+    stdio: ["ignore", "pipe", "pipe"],
+  })
+  return readJson(join(extractDir, "package/package.json"))
+}
+
+function collectDependencyEntries(pkg) {
+  const entries = []
+  for (const section of DEP_SECTIONS) {
+    for (const [name, spec] of Object.entries(pkg[section] ?? {})) {
+      entries.push({ section, name, spec: String(spec) })
+    }
+  }
+  return entries
+}
+
+function main() {
+  const sourcePackages = PUBLISHABLE_PACKAGES.map((packagePath, index) => {
+    const pkg = readJson(resolve(root, packagePath, "package.json"))
+    return { ...pkg, packagePath, index }
+  })
+  const releasePlan = new Map(sourcePackages.map((pkg) => [pkg.name, pkg]))
+
+  const tempRoot = mkdtempSync(join(tmpdir(), "boring-publish-manifest-audit-"))
+  const errors = []
+
+  try {
+    for (const sourcePkg of sourcePackages) {
+      try {
+        assertRepository(sourcePkg, sourcePkg.packagePath)
+        const packedPkg = packManifest(sourcePkg.packagePath, tempRoot)
+        assertRepository(packedPkg, sourcePkg.packagePath)
+
+        for (const { section, name, spec } of collectDependencyEntries(packedPkg)) {
+          if (spec.startsWith("workspace:")) {
+            fail(`${formatPackage(packedPkg)} ${section}.${name} leaked ${spec} into packed manifest`)
+          }
+          if (name.startsWith("@hachej/") && /^(file|link|workspace):/.test(spec)) {
+            fail(`${formatPackage(packedPkg)} ${section}.${name} uses non-registry spec ${spec}`)
+          }
+          if (!name.startsWith("@hachej/")) continue
+
+          if (npmHasVersion(name, spec)) continue
+
+          const planned = releasePlan.get(name)
+          const isEarlierInRelease = planned && planned.version === spec && planned.index < sourcePkg.index
+          if (isEarlierInRelease) continue
+
+          if (planned && planned.version === spec) {
+            fail(
+              `${formatPackage(packedPkg)} ${section}.${name}@${spec} is not published yet and appears later/same in release order`,
+            )
+          }
+          fail(`${formatPackage(packedPkg)} ${section}.${name}@${spec} is not published on npm`)
+        }
+
+        console.log(`✓ ${formatPackage(packedPkg)} manifest ok`)
+      } catch (error) {
+        errors.push(error instanceof Error ? error.message : String(error))
+      }
+    }
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+
+  if (errors.length > 0) {
+    console.error("\nPublish manifest audit failed:")
+    for (const error of errors) console.error(`- ${error}`)
+    process.exit(1)
+  }
+
+  console.log("\nAll publish manifests are safe to publish.")
+}
+
+main()

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -16,6 +16,10 @@ const PUBLISHABLE = [
   "packages/agent",
   "packages/ui",
   "packages/cli", // @hachej/boring-ui-cli
+  "plugins/deck",
+  "plugins/ask-user",
+  "plugins/data-explorer",
+  "plugins/data-catalog",
 ]
 
 function readJson(path) {


### PR DESCRIPTION
## Summary
- add `pnpm audit:publish-manifests` to inspect the package.json files produced by `pnpm pack`
- fail releases if packed manifests leak `workspace:*`, lack provenance repository metadata, or point internal `@hachej/*` deps at versions that are neither published nor earlier in the same release order
- run the audit in `release.yml` after builds and before `npm publish`
- include plugin packages in `scripts/version.mjs`

## Verification
- `pnpm audit:publish-manifests`
- `pnpm lint`
