### PR TITLE
fix(cli): auto-detect runtime mode when --mode is unset

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-ui-cli",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "description": "Turn an agent into an app",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -186,7 +186,7 @@ const HELP_TEXT = [
   "Options:",
   "  -p, --port <port>       HTTP port (default: 5200)",
   "      --host <host>       Listen host (default: 0.0.0.0)",
-  "  -m, --mode <mode>       local-sandbox or local (default: local-sandbox)",
+  "  -m, --mode <mode>       local-sandbox or local (default: local)",
   "  -h, --help              Show this help",
 ].join("\n")
 
@@ -581,12 +581,28 @@ export async function runCli(options: RunCliOptions): Promise<void> {
 
   const port = Number(args.port ?? process.env.PORT) || 5200
   const host = (args.host as string | undefined) ?? process.env.HOST ?? "0.0.0.0"
-  const rawMode = (args.mode as string | undefined) ?? process.env.BORING_MODE ?? "local-sandbox"
-  if (!(rawMode in MODE_MAP)) {
-    throw new Error(`invalid --mode "${rawMode}". Valid options: ${Object.keys(MODE_MAP).join(", ")}`)
+  const rawMode = (args.mode as string | undefined) ?? process.env.BORING_MODE
+  let cliMode: CliMode
+  let mode: RuntimeMode
+  if (rawMode) {
+    if (!(rawMode in MODE_MAP)) {
+      throw new Error(`invalid --mode "${rawMode}". Valid options: ${Object.keys(MODE_MAP).join(", ")}`)
+    }
+    cliMode = rawMode as CliMode
+    mode = MODE_MAP[cliMode]
+  } else {
+    // Auto-detect: use autoDetectMode() from @hachej/boring-agent/server.
+    // On Linux with bwrap → local-sandbox (bwrap); everywhere else → local (direct).
+    const agent = await import("@hachej/boring-agent/server")
+    const detected = agent.autoDetectMode()
+    if (detected === "local") {
+      cliMode = "local-sandbox"
+      mode = "local"
+    } else {
+      cliMode = "local"
+      mode = "direct"
+    }
   }
-  const cliMode = rawMode as CliMode
-  const mode = MODE_MAP[cliMode]
 
   const base = {
     publicDir: options.publicDir,


### PR DESCRIPTION
## Summary
- Default CLI runtime mode is now derived from `autoDetectMode()` in `@hachej/boring-agent/server` when neither `--mode` nor `BORING_MODE` is set — Linux+bwrap picks `local-sandbox`/`local`, everywhere else falls back to `local`/`direct`.
- Help text default updated from `local-sandbox` to `local`.
- Bumps `@hachej/boring-ui-cli` to 0.1.25.

## Test plan
- [x] `pnpm --filter @hachej/boring-ui-cli typecheck`
- [x] `pnpm --filter @hachej/boring-ui-cli test` (45/45)
- [ ] Smoke-test on a non-Linux host to confirm `direct` fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)