### PR TITLE
test(ask-user): give state-publisher waiters more CI headroom

### DIFF
--- a/plugins/ask-user/src/server/__tests__/askUserStatePublisher.test.ts
+++ b/plugins/ask-user/src/server/__tests__/askUserStatePublisher.test.ts
@@ -32,7 +32,7 @@ async function waitForPending(store: FileAskUserStore, sessionId: string) {
     const pending = await store.getPending(sessionId)
     expect(pending).not.toBeNull()
     return pending!
-  }, { timeout: 5_000 })
+  }, { timeout: 10_000 })
 }
 
 describe("AskUserStatePublisher", () => {
@@ -65,7 +65,7 @@ describe("AskUserStatePublisher", () => {
     abandonedController.abort()
     await expect(abandonedPending).resolves.toMatchObject({ status: "cancelled" })
     await vi.waitFor(async () => expect((await ui.getState())?.[ASK_USER_UI_STATE_SLOTS.PENDING]).toEqual({ question: null }))
-  })
+  }, 15_000)
 })
 
 describe("ask-user UI open", () => {
@@ -79,7 +79,7 @@ describe("ask-user UI open", () => {
     await expect(store.getPending("s1")).resolves.not.toBeNull()
     await runtime.submitAnswer(question!.questionId, "s1", { answer: "ok" })
     await expect(pending).resolves.toMatchObject({ status: "answered" })
-  })
+  }, 15_000)
 
   it("returns abort without waiting for openSurface acknowledgement", async () => {
     const store = await makeStore()
@@ -101,5 +101,5 @@ describe("ask-user UI open", () => {
     const question = await waitForPending(store, "s1")
     await runtime.submitAnswer(question!.questionId, "s1", { answer: "ok" })
     await expect(pending).resolves.toMatchObject({ status: "answered" })
-  })
+  }, 15_000)
 })


### PR DESCRIPTION
## Summary
- The v0.1.25 Release run failed on `askUserStatePublisher.test.ts > keeps pending question alive when openSurface is not acknowledged` with `Test timed out in 5000ms.` under CI load.
- Bump the internal `waitForPending` waiter from 5s → 10s and give the three state-publisher tests that use it an explicit 15s per-test budget so the outer test timer doesn't fire before the inner waiter has a chance.
- No production code changes — flaky-test mitigation only.

## Test plan
- [x] `pnpm --filter @hachej/boring-ask-user test` (57 passed, 1 skipped)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)