### PR TITLE
feat(cli): show 'starting … / ready' feedback during boot

### DIFF
--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -229,12 +229,14 @@ async function startFolderMode(opts: {
   const projectName = basename(resolve(workspaceRoot)) || "workspace"
   const modelCount = await checkAuth()
 
+  const url = `http://localhost:${opts.port}`
   console.log(`\n${projectName}`)
   console.log(`  workspace  ${workspaceRoot}`)
   console.log(`  mode       ${opts.cliMode}`)
   console.log(`  port       ${opts.port}`)
   console.log(`  host       ${opts.host}`)
   if (modelCount === 0) console.log(AUTH_GUIDE)
+  console.log(`\n  starting ${url} …`)
 
   const runtimeProvisioning = await provisionCliWorkspaceRuntime({
     workspaceRoot,
@@ -258,8 +260,8 @@ async function startFolderMode(opts: {
 
   await registerStatic(app as FastifyInstance, opts.publicDir)
   await app.listen({ port: opts.port, host: opts.host })
-  console.log(`\n  http://localhost:${opts.port}\n`)
-  openBrowser(`http://localhost:${opts.port}`)
+  console.log(`  ${url}  ready\n`)
+  openBrowser(url)
 }
 
 async function startWorkspacesMode(opts: {
@@ -269,6 +271,12 @@ async function startWorkspacesMode(opts: {
   cliMode: CliMode
   mode: RuntimeMode
 }) {
+  console.log(`\nBoring UI`)
+  console.log(`  mode       ${opts.cliMode}`)
+  console.log(`  port       ${opts.port}`)
+  console.log(`  host       ${opts.host}`)
+  console.log(`\n  starting http://localhost:${opts.port} …`)
+
   const [workspaceAppServer, workspaceServer, agentServer, fastifyModule] = await Promise.all([
     import("@hachej/boring-workspace/app/server"),
     import("@hachej/boring-workspace/server"),
@@ -376,12 +384,8 @@ async function startWorkspacesMode(opts: {
     ? `http://localhost:${opts.port}/workspace/${encodeURIComponent(initialWorkspace.id)}`
     : `http://localhost:${opts.port}`
 
-  console.log(`\nBoring UI`)
   console.log(`  workspaces ${registry.path}`)
-  console.log(`  mode       ${opts.cliMode}`)
-  console.log(`  port       ${opts.port}`)
-  console.log(`  host       ${opts.host}`)
-  console.log(`\n  ${initialUrl}\n`)
+  console.log(`  ${initialUrl}  ready\n`)
   if ((await checkAuth()) === 0) console.log(AUTH_GUIDE)
   openBrowser(initialUrl)
 }


### PR DESCRIPTION
## Summary
After printing the banner, the CLI runs through runtime provisioning and server startup before the URL line appears (5–30s on a cold workspace). During that stretch the terminal is silent and the user can't tell whether the CLI is doing work or stuck.

- Folder mode: print `starting http://localhost:PORT …` right after the banner; flip the URL line to `http://localhost:PORT  ready` once `app.listen` resolves.
- Workspaces mode: move the banner above the slow dynamic imports + `app.listen` so the same `starting …` indicator surfaces before provisioning.

No behavior change beyond stdout.

## Before / after (folder mode)
```
skilledin
  workspace  /home/ubuntu/projects/skilledin
  mode       local-sandbox
  port       5224
  host       0.0.0.0

  starting http://localhost:5224 …
  http://localhost:5224  ready
```

## Test plan
- [x] `pnpm --filter @hachej/boring-ui-cli typecheck`
- [x] `pnpm --filter @hachej/boring-ui-cli test` (45/45)
- [ ] Manual smoke: `npx @hachej/boring-ui-cli --port 5224` shows the new lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)