### PR TITLE
fix(workspace): autoreview post-merge fixes

### DIFF
--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -183,7 +183,6 @@ function createAgentRuntimeNotReadyError(workspaceId: string): Error {
 
 function createRuntimeProvisioningFailedError(workspaceId: string, cause: unknown): Error {
   const causeCode = (cause as { code?: unknown } | null)?.code
-  const details = (cause as { details?: unknown } | null)?.details
   return createHttpError(
     ErrorCode.enum.RUNTIME_PROVISIONING_FAILED,
     'Agent runtime provisioning failed. Reload the workspace and try again.',
@@ -191,7 +190,6 @@ function createRuntimeProvisioningFailedError(workspaceId: string, cause: unknow
       workspaceId,
       retryable: true,
       ...(typeof causeCode === 'string' ? { causeCode } : {}),
-      ...(details && typeof details === 'object' ? { causeDetails: details } : {}),
     },
   )
 }
@@ -506,14 +504,16 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       if (options.failIfPending && existing.state === 'pending') {
         throw createAgentRuntimeNotReadyError(workspaceId)
       }
-      if (options.failIfPending && existing.state === 'failed') {
-        throw createRuntimeProvisioningFailedError(workspaceId, existing.error)
+      if (existing.state === 'failed') {
+        if (options.failIfPending) throw createRuntimeProvisioningFailedError(workspaceId, existing.error)
+        runtimeBindings.delete(scope.key)
+      } else {
+        return await ensureRuntimeBindingReady(
+          workspaceId,
+          scope,
+          await existing.promise,
+        )
       }
-      return await ensureRuntimeBindingReady(
-        workspaceId,
-        scope,
-        await existing.promise,
-      )
     }
 
     const created = createRuntimeBindingEntry(workspaceId, scope, request)

--- a/packages/agent/src/server/tools/harness/index.ts
+++ b/packages/agent/src/server/tools/harness/index.ts
@@ -7,7 +7,7 @@ import {
 
 import type { Sandbox } from '../../../shared/sandbox'
 import type { AgentTool, ToolResult } from '../../../shared/tool'
-import type { RuntimeBundle } from '../../runtime/mode'
+import { getRuntimeBundleStorageRoot, type RuntimeBundle } from '../../runtime/mode'
 import { buildBwrapArgs } from '../../sandbox/bwrap/buildBwrapArgs'
 import { withWorkspacePythonEnv } from '../../sandbox/workspacePythonEnv'
 import { vercelBashOps } from '../operations/vercel'
@@ -91,7 +91,7 @@ function bashOptionsForMode(
     case 'bwrap':
       return {
         operations: createLocalBashOperations(),
-        spawnHook: bwrapSpawnHook(bundle.workspace.root, runtime),
+        spawnHook: bwrapSpawnHook(getRuntimeBundleStorageRoot(bundle), runtime),
       }
     default:
       return {

--- a/packages/core/src/server/routes/__tests__/workspaces.test.ts
+++ b/packages/core/src/server/routes/__tests__/workspaces.test.ts
@@ -216,6 +216,20 @@ describe('GET /api/v1/workspaces', () => {
     expect(second.json().workspaces[0].id).toBe(first.json().workspaces[0].id)
   })
 
+  it('default workspace creation on list is concurrency-safe', async () => {
+    const [first, second] = await Promise.all([
+      inject('GET', '/api/v1/workspaces', OWNER_ID),
+      inject('GET', '/api/v1/workspaces', OWNER_ID),
+    ])
+
+    expect(first.statusCode).toBe(200)
+    expect(second.statusCode).toBe(200)
+    expect(first.json().workspaces).toHaveLength(1)
+    expect(second.json().workspaces).toHaveLength(1)
+    expect(first.json().workspaces[0].id).toBe(second.json().workspaces[0].id)
+    expect([...workspaces.values()].filter((workspace) => workspace.createdBy === OWNER_ID)).toHaveLength(1)
+  })
+
   it('excludes workspaces where caller is not a member and creates caller default', async () => {
     seedWorkspaceWithMembers('Private', EDITOR_ID)
 

--- a/packages/core/src/server/routes/__tests__/workspaces.test.ts
+++ b/packages/core/src/server/routes/__tests__/workspaces.test.ts
@@ -470,6 +470,19 @@ describe('Provisioner integration', () => {
       expect(runtime?.volumePath).toBe('/volumes/ws-default')
     })
 
+    it('provision failure while auto-creating default workspace returns HTTP 500', async () => {
+      provisionFn.mockRejectedValue(new Error('disk full'))
+
+      const res = await provInject('GET', '/api/v1/workspaces', OWNER_ID)
+      expect(res.statusCode).toBe(500)
+      expect(res.json().code).toBe('provision_failed')
+
+      const runtime = runtimes.get('ws-1')
+      expect(runtime?.state).toBe('error')
+      expect(runtime?.lastError).toBe('disk full')
+      expect(runtime?.lastErrorOp).toBe('provision')
+    })
+
     it('provisions an existing signup-created default workspace with missing runtime', async () => {
       provisionFn.mockResolvedValue({ volumePath: '/volumes/signup-default' })
       const workspace = provSeedWorkspace('My Workspace', OWNER_ID, { isDefault: true })

--- a/packages/core/src/server/routes/workspaces.ts
+++ b/packages/core/src/server/routes/workspaces.ts
@@ -9,6 +9,7 @@ const DEFAULT_WORKSPACE_NAME = 'My Workspace'
 const workspaceRoutesPlugin: FastifyPluginAsync = async (app) => {
   const store = app.workspaceStore
   const provisioner = app.provisioner
+  const defaultWorkspaceCreates = new Map<string, Promise<Awaited<ReturnType<typeof store.list>>>>()
 
   async function provisionWorkspace(workspace: Awaited<ReturnType<typeof store.create>>, ownerId: string, request: FastifyRequest) {
     if (!provisioner) return
@@ -60,8 +61,27 @@ const workspaceRoutesPlugin: FastifyPluginAsync = async (app) => {
       await Promise.all(existing.map((workspace) => ensureDefaultWorkspaceProvisioned(workspace, request)))
       return existing
     }
-    const created = await createWorkspaceForUser(userId, DEFAULT_WORKSPACE_NAME, true, request)
-    return [created]
+
+    const createKey = `${app.config.appId}:${userId}`
+    const inFlight = defaultWorkspaceCreates.get(createKey)
+    if (inFlight) return await inFlight
+
+    const createPromise = (async () => {
+      try {
+        const created = await createWorkspaceForUser(userId, DEFAULT_WORKSPACE_NAME, true, request)
+        return [created]
+      } catch (error) {
+        const racedExisting = await store.list(userId, app.config.appId)
+        if (racedExisting.length > 0) return racedExisting
+        throw error
+      }
+    })()
+    defaultWorkspaceCreates.set(createKey, createPromise)
+    try {
+      return await createPromise
+    } finally {
+      if (defaultWorkspaceCreates.get(createKey) === createPromise) defaultWorkspaceCreates.delete(createKey)
+    }
   }
 
   app.post('/api/v1/workspaces', async (request, reply) => {

--- a/packages/core/src/server/routes/workspaces.ts
+++ b/packages/core/src/server/routes/workspaces.ts
@@ -71,6 +71,7 @@ const workspaceRoutesPlugin: FastifyPluginAsync = async (app) => {
         const created = await createWorkspaceForUser(userId, DEFAULT_WORKSPACE_NAME, true, request)
         return [created]
       } catch (error) {
+        if (error instanceof HttpError) throw error
         const racedExisting = await store.list(userId, app.config.appId)
         if (racedExisting.length > 0) return racedExisting
         throw error

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -297,8 +297,8 @@ export function WorkspaceAgentFront<
     [requestHeaders, workspaceId],
   )
   const resolvedAuthHeaders = useMemo(
-    () => workspaceRequestHeaders(workspaceId, authHeaders ?? EMPTY_HEADERS),
-    [authHeaders, workspaceId],
+    () => workspaceRequestHeaders(workspaceId, { ...(requestHeaders ?? EMPTY_HEADERS), ...(authHeaders ?? EMPTY_HEADERS) }),
+    [authHeaders, requestHeaders, workspaceId],
   )
   const localSessionStore = useMemo(
     () => createLocalStorageSessions({ storageKey: resolvedSessionStorageKey }),

--- a/packages/workspace/src/app/front/WorkspaceBackgroundBoot.tsx
+++ b/packages/workspace/src/app/front/WorkspaceBackgroundBoot.tsx
@@ -13,6 +13,8 @@ import {
   type WorkspaceWarmupStatus,
 } from "./workspacePreload"
 
+const PREPARING_RETRY_DELAY_MS = 500
+
 export interface WorkspaceBackgroundBootProps {
   workspaceId: string
   requestHeaders?: Record<string, string>
@@ -20,6 +22,29 @@ export interface WorkspaceBackgroundBootProps {
   preloadPaths?: string[]
   provisionWorkspace?: boolean
   onStatusChange?: (status: WorkspaceWarmupStatus) => void
+}
+
+function sleepUntilRetry(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let timeout: ReturnType<typeof globalThis.setTimeout> | undefined
+    const cleanup = () => {
+      if (timeout) globalThis.clearTimeout(timeout)
+      signal.removeEventListener("abort", onAbort)
+    }
+    const onAbort = () => {
+      cleanup()
+      reject(new DOMException("Warmup aborted", "AbortError"))
+    }
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+    timeout = globalThis.setTimeout(() => {
+      cleanup()
+      resolve()
+    }, PREPARING_RETRY_DELAY_MS)
+    signal.addEventListener("abort", onAbort, { once: true })
+  })
 }
 
 async function fetchWarmupPath({
@@ -81,7 +106,7 @@ export function WorkspaceBackgroundBoot({
         let results = await Promise.all(paths.map(async (path) => ({ path, result: await warmupPath(path) })))
         if (stale || controller.signal.aborted) return
         let preparingItems = results.filter((item) => item.result.status === "preparing")
-        if (preparingItems.length > 0) {
+        while (preparingItems.length > 0) {
           let requirement: "workspace-fs" | "sandbox-exec" | "ui-bridge" | undefined
           for (const item of preparingItems) {
             if (item.result.status === "preparing" && item.result.requirement) {
@@ -90,12 +115,11 @@ export function WorkspaceBackgroundBoot({
             }
           }
           onStatusChange?.({ status: "preparing", message: "Workspace is still preparing", ...(requirement ? { requirement } : {}) })
-          if (paths.some(isReadyStatusPath)) {
-            results = await Promise.all(preparingItems.map(async (item) => ({ path: item.path, result: await warmupPath(item.path) })))
-            if (stale || controller.signal.aborted) return
-            preparingItems = results.filter((item) => item.result.status === "preparing")
-          }
-          if (preparingItems.length > 0) return
+          await sleepUntilRetry(controller.signal)
+          if (stale || controller.signal.aborted) return
+          results = await Promise.all(preparingItems.map(async (item) => ({ path: item.path, result: await warmupPath(item.path) })))
+          if (stale || controller.signal.aborted) return
+          preparingItems = results.filter((item) => item.result.status === "preparing")
         }
         onStatusChange?.({ status: "ready" })
       } catch (error) {

--- a/packages/workspace/src/app/front/WorkspaceBootGate.tsx
+++ b/packages/workspace/src/app/front/WorkspaceBootGate.tsx
@@ -25,10 +25,35 @@ export interface WorkspaceBootGateProps {
   children: ReactNode
 }
 
+const PREPARING_RETRY_DELAY_MS = 500
+
 type WorkspaceBootState =
   | { status: "loading"; label: string }
   | { status: "ready" }
   | { status: "error"; message: string }
+
+function sleepUntilRetry(signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let timeout: ReturnType<typeof globalThis.setTimeout> | undefined
+    const cleanup = () => {
+      if (timeout) globalThis.clearTimeout(timeout)
+      signal.removeEventListener("abort", onAbort)
+    }
+    const onAbort = () => {
+      cleanup()
+      reject(new DOMException("Workspace boot aborted", "AbortError"))
+    }
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+    timeout = globalThis.setTimeout(() => {
+      cleanup()
+      resolve()
+    }, PREPARING_RETRY_DELAY_MS)
+    signal.addEventListener("abort", onAbort, { once: true })
+  })
+}
 
 export function WorkspaceBootGate({
   workspaceId,
@@ -78,13 +103,12 @@ export function WorkspaceBootGate({
         const paths = resolveBootPreloadPaths(preloadPaths, provisionWorkspace)
         let results = await Promise.all(paths.map(async (path) => ({ path, status: await fetchOk(path) })))
         let preparingPaths = results.filter((result) => result.status === "preparing").map((result) => result.path)
-        if (preparingPaths.length > 0 && paths.some(isReadyStatusPath)) {
+        while (preparingPaths.length > 0) {
+          setState({ status: "loading", label: "Workspace is still preparing" })
+          await sleepUntilRetry(controller.signal)
+          if (controller.signal.aborted) return
           results = await Promise.all(preparingPaths.map(async (path) => ({ path, status: await fetchOk(path) })))
           preparingPaths = results.filter((result) => result.status === "preparing").map((result) => result.path)
-        }
-        if (preparingPaths.length > 0) {
-          setState({ status: "loading", label: "Workspace is still preparing" })
-          return
         }
         if (!controller.signal.aborted) setState({ status: "ready" })
       } catch (error) {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -526,14 +526,14 @@ describe("WorkspaceAgentFront", () => {
       <WorkspaceAgentFront
         workspaceId="provider-headers"
         chatPanel={ChatPanel}
-        requestHeaders={{ "x-boring-workspace-id": "provider-headers" }}
+        requestHeaders={{ "x-boring-workspace-id": "stale", authorization: "Bearer request-token" }}
         plugins={[probePlugin]}
         persistenceEnabled={false}
       />,
     )
 
     await waitFor(() => {
-      expect(observed).toContainEqual({ "x-boring-workspace-id": "provider-headers" })
+      expect(observed).toContainEqual({ "x-boring-workspace-id": "provider-headers", authorization: "Bearer request-token" })
     })
   })
 

--- a/packages/workspace/src/app/front/__tests__/WorkspaceBackgroundBoot.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceBackgroundBoot.test.tsx
@@ -101,14 +101,14 @@ it("keeps retryable AGENT_RUNTIME_NOT_READY as preparing", async () => {
   })
 })
 
-it("retries transient runtime-preparing warmup after ready-status completes", async () => {
+it("keeps polling transient runtime-preparing warmup after ready-status completes", async () => {
   const onStatusChange = vi.fn()
   let sessionCalls = 0
   vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input)
     if (url.includes("/api/v1/agent/sessions")) {
       sessionCalls += 1
-      if (sessionCalls === 1) {
+      if (sessionCalls <= 2) {
         return json({
           error: {
             code: "AGENT_RUNTIME_NOT_READY",
@@ -130,8 +130,8 @@ it("retries transient runtime-preparing warmup after ready-status completes", as
     />,
   )
 
-  await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith({ status: "ready" }))
-  expect(sessionCalls).toBe(2)
+  await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith({ status: "ready" }), { timeout: 2_500 })
+  expect(sessionCalls).toBe(3)
 })
 
 it("reports degraded ready-status SSE as failed", async () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceBootGate.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceBootGate.test.tsx
@@ -55,11 +55,15 @@ describe("WorkspaceBootGate", () => {
     expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/api/v1/ready-status"))).toBe(false)
   })
 
-  it("refetches retryable preparing paths after ready status completes", async () => {
+  it("keeps refetching retryable preparing paths after ready status completes", async () => {
+    let sessionCalls = 0
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
-      if (url.includes("/api/v1/agent/sessions") && fetchMock.mock.calls.filter(([callInput]) => String(callInput).includes("/api/v1/agent/sessions")).length === 1) {
-        return new Response(JSON.stringify({ error: { code: "AGENT_RUNTIME_NOT_READY", retryable: true } }), { status: 503 })
+      if (url.includes("/api/v1/agent/sessions")) {
+        sessionCalls += 1
+        if (sessionCalls <= 2) {
+          return new Response(JSON.stringify({ error: { code: "AGENT_RUNTIME_NOT_READY", retryable: true } }), { status: 503 })
+        }
       }
       if (url.includes("/api/v1/ready-status")) {
         return new Response('data: {"state":"ready"}\n\n', { status: 200 })
@@ -76,9 +80,9 @@ describe("WorkspaceBootGate", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Workspace ready")).toBeInTheDocument()
-    })
+    }, { timeout: 2_500 })
 
-    expect(fetchMock.mock.calls.filter(([input]) => String(input).includes("/api/v1/agent/sessions"))).toHaveLength(2)
+    expect(sessionCalls).toBe(3)
   })
 
   it("renders an error fallback when preload fails", async () => {


### PR DESCRIPTION
Cherry-picks 4 commits from `work/chat-first-auth-workspace-boot` that address coding-autoreview findings after the squash-merge of PR #70.

## Changes

- **WorkspaceBackgroundBoot**: polls retryable preparing responses until ready (was stopping after 1 retry, blocking long Vercel provisioning)
- **WorkspaceBootGate**: same polling behavior for blocking gate callers
- **Runtime binding failures**: failed request-scoped bindings kept visible to warmup routes → surface as `RUNTIME_PROVISIONING_FAILED` instead of silently looping
- **Provisioning details**: host paths redacted from `RUNTIME_PROVISIONING_FAILED` responses before serializing to clients
- **Default workspace auto-create**: serialized with in-flight map to prevent concurrent race; provisioning failures now propagate correctly
- **Bwrap bash bindings**: uses `getRuntimeBundleStorageRoot()` so local bash binds the real host path instead of `/workspace`
- **Provider auth headers**: `requestHeaders` merged into `resolvedAuthHeaders` so workspace plugin providers receive Authorization

## Testing
- All unit tests pass (agent, workspace, core non-DB)
- Invariant checks clean
- Autoreview: clean, one out-of-scope finding about bwrap DNS on systemd hosts