### PR TITLE
fix(workspace): restore tab copy path fallback

### DIFF
--- a/packages/workspace/src/front/dock/ShadcnTab.tsx
+++ b/packages/workspace/src/front/dock/ShadcnTab.tsx
@@ -6,6 +6,7 @@ import { getFileIcon } from "../registry/getFileIcon"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../lib/utils"
 import { useEvent, workspaceEvents } from "../events"
+import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../shared/types/surface"
 
 type ClosablePanelApi = {
   id?: string
@@ -43,6 +44,20 @@ function readStringParam(params: unknown, key: string): string | null {
   if (!params || typeof params !== "object") return null
   const value = (params as Record<string, unknown>)[key]
   return typeof value === "string" && value.length > 0 ? value : null
+}
+
+function readPathFromPanelId(id: string | undefined): string | null {
+  if (!id) return null
+  if (id.startsWith("file:")) {
+    const path = id.slice("file:".length)
+    return path.length > 0 ? path : null
+  }
+  const surfacePrefix = `surface:${WORKSPACE_OPEN_PATH_SURFACE_KIND}:`
+  if (id.startsWith(surfacePrefix)) {
+    const path = id.slice(surfacePrefix.length)
+    return path.length > 0 ? path : null
+  }
+  return null
 }
 
 async function copyText(text: string): Promise<void> {
@@ -99,7 +114,7 @@ export function ShadcnTab(props: IDockviewPanelHeaderProps) {
   const isDirty = title.endsWith(" ●")
   const displayTitle = isDirty ? title.slice(0, -2) : title
   const Icon = getFileIcon(displayTitle)
-  const filePath = readStringParam(props.params, "path")
+  const filePath = readStringParam(props.params, "path") ?? readPathFromPanelId(api.id)
   const otherTabs = siblingPanels(props)
     .map(panelSnapshot)
     .filter((sibling) => sibling.id !== api.id && sibling.close)

--- a/packages/workspace/src/front/dock/__tests__/dock.test.tsx
+++ b/packages/workspace/src/front/dock/__tests__/dock.test.tsx
@@ -498,6 +498,56 @@ describe("ShadcnTab", () => {
     expect(writeText).toHaveBeenCalledWith("src/App.tsx")
   })
 
+  it("copies path from file-backed panel id when tab params are missing", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    })
+    const currentApi = { title: "App.tsx", id: "file:src/App.tsx", close: vi.fn() }
+
+    render(
+      <ShadcnTab
+        api={currentApi as any}
+        containerApi={{ panels: [{ api: currentApi }] } as any}
+        params={{}}
+        tabLocation={"header" as any}
+      />,
+    )
+
+    fireEvent.contextMenu(screen.getByTitle("App.tsx"))
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy path" }))
+
+    expect(writeText).toHaveBeenCalledWith("src/App.tsx")
+  })
+
+  it("copies path from workspace surface panel id when tab params are missing", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    })
+    const currentApi = {
+      title: "App.tsx",
+      id: "surface:workspace.open.path:src/App.tsx",
+      close: vi.fn(),
+    }
+
+    render(
+      <ShadcnTab
+        api={currentApi as any}
+        containerApi={{ panels: [{ api: currentApi }] } as any}
+        params={{}}
+        tabLocation={"header" as any}
+      />,
+    )
+
+    fireEvent.contextMenu(screen.getByTitle("App.tsx"))
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy path" }))
+
+    expect(writeText).toHaveBeenCalledWith("src/App.tsx")
+  })
+
   it("falls back to legacy clipboard copy when writeText rejects", async () => {
     const writeText = vi.fn().mockRejectedValue(new Error("not focused"))
     const execCommand = vi.fn().mockReturnValue(true)


### PR DESCRIPTION
## Summary
- derive Copy path from file-backed panel ids when tab params are missing
- keep existing params.path behavior as first priority
- add tests for file: and workspace surface panel ids

## Verification
- pnpm --filter @hachej/boring-workspace run test src/front/dock/__tests__/dock.test.tsx
- pnpm --filter @hachej/boring-workspace run typecheck