### PR TITLE
feat(core): customize chat-first public shell

### DIFF
--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -15,7 +15,7 @@ import {
   type WorkspaceAgentSession,
 } from '@hachej/boring-workspace/app/front'
 import { ChatFirstAuthenticatedShell } from './chatFirst/ChatFirstAuthenticatedShell.js'
-import { ChatFirstPublicShell } from './chatFirst/ChatFirstPublicShell.js'
+import { ChatFirstPublicShell, type ChatFirstPublicShellOptions } from './chatFirst/ChatFirstPublicShell.js'
 import {
   clearPendingChatEntry,
   DEFAULT_CHAT_FIRST_PENDING_WORKSPACE_ID,
@@ -37,6 +37,7 @@ export interface CoreWorkspaceAgentFrontProps<
   /** Core consumes plugins statically for now; app-level hot reload is explicitly unsupported. */
   hotReload?: false
   chatEntryMode?: ChatEntryMode
+  chatFirstPublicShell?: ChatFirstPublicShellOptions
   authPages?: CoreFrontAuthPagesOverride
   cspNonce?: string
   children?: ReactNode
@@ -113,12 +114,14 @@ function HomeRedirect<TSession extends WorkspaceAgentSession = WorkspaceAgentSes
   chatEntryMode,
   appTitle,
   workspaceProps,
+  chatFirstPublicShell,
 }: {
   loadingFallback: ReactNode
   workspaceHref: (workspaceId: string) => string
   chatEntryMode: ChatEntryMode
   appTitle: string
   workspaceProps: Omit<WorkspaceAgentFrontProps<TSession>, 'workspaceId' | 'frontPluginHotReload' | 'hotReloadEnabled'>
+  chatFirstPublicShell?: ChatFirstPublicShellOptions
 }) {
   const location = useLocation()
   const session = useSession()
@@ -130,7 +133,7 @@ function HomeRedirect<TSession extends WorkspaceAgentSession = WorkspaceAgentSes
     location.search,
     location.hash,
   )
-  if (!session.data?.user && chatEntryMode === 'chat-first') return <ChatFirstPublicShell appTitle={appTitle} workspaceProps={workspaceProps} />
+  if (!session.data?.user && chatEntryMode === 'chat-first') return <ChatFirstPublicShell appTitle={appTitle} publicShell={chatFirstPublicShell} workspaceProps={workspaceProps} />
   if (!workspace && chatEntryMode === 'chat-first' && session.data?.user && restorePendingDraft) {
     return (
       <ChatFirstAuthenticatedShell
@@ -171,6 +174,7 @@ function WorkspaceRoute<
   chatEntryMode,
   appTitle,
   workspaceRoute,
+  chatFirstPublicShell,
 }: {
   workspaceIdParam: string
   loadingFallback: ReactNode
@@ -179,6 +183,7 @@ function WorkspaceRoute<
   chatEntryMode: ChatEntryMode
   appTitle: string
   workspaceRoute: string
+  chatFirstPublicShell?: ChatFirstPublicShellOptions
 }) {
   const params = useParams()
   const location = useLocation()
@@ -211,7 +216,7 @@ function WorkspaceRoute<
   if (!workspaceId) return <>{loadingFallback}</>
 
   if (!session.data?.user && chatEntryMode === 'chat-first') {
-    return <ChatFirstPublicShell appTitle={appTitle} intendedWorkspaceId={workspaceId} workspaceProps={workspaceProps} />
+    return <ChatFirstPublicShell appTitle={appTitle} intendedWorkspaceId={workspaceId} publicShell={chatFirstPublicShell} workspaceProps={workspaceProps} />
   }
 
   if (routeStatus.status === 'not-found' || routeStatus.status === 'forbidden' || routeStatus.status === 'switch-failed') {
@@ -280,6 +285,7 @@ export function CoreWorkspaceAgentFront<
   bridgeEndpoint = '/api/v1/ui',
   hotReload = false,
   chatEntryMode = 'auth-first',
+  chatFirstPublicShell,
   ...workspaceProps
 }: CoreWorkspaceAgentFrontProps<TSession>) {
   if ((hotReload as unknown) !== false) {
@@ -320,6 +326,7 @@ export function CoreWorkspaceAgentFront<
             chatEntryMode={chatEntryMode}
             appTitle={appTitle}
             workspaceProps={resolvedWorkspaceProps}
+            chatFirstPublicShell={chatFirstPublicShell}
           />
         }
       />
@@ -334,6 +341,7 @@ export function CoreWorkspaceAgentFront<
             chatEntryMode={chatEntryMode}
             appTitle={appTitle}
             workspaceRoute={workspaceRoute}
+            chatFirstPublicShell={chatFirstPublicShell}
           />
         }
       />

--- a/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
+++ b/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
@@ -180,6 +180,42 @@ describe('CoreWorkspaceAgentFront', () => {
     expect(workspaceAgentProps?.chatParams).toMatchObject({ serverResourcesEnabled: false, hydrateMessages: false })
   })
 
+  it('allows apps to customize the public chat-first shell copy', async () => {
+    const { CoreWorkspaceAgentFront } = await importSubject()
+    sessionState = { data: null, isPending: false }
+    currentWorkspaceId = null
+    routePath = '/'
+
+    render(
+      <CoreWorkspaceAgentFront
+        chatEntryMode="chat-first"
+        chatFirstPublicShell={{
+          composerPlaceholder: 'Ask about macro data…',
+          emptyState: {
+            eyebrow: 'Macro analyst',
+            title: 'What macro signal should we inspect?',
+            description: 'Search FRED, plot indicators, or draft a deck.',
+          },
+          suggestions: [
+            { label: 'Search series', hint: 'Find FRED data', prompt: 'Find CPI and unemployment series.' },
+          ],
+        }}
+      />,
+    )
+
+    expect(workspaceAgentProps?.chatParams).toMatchObject({
+      composerPlaceholder: 'Ask about macro data…',
+      emptyState: {
+        eyebrow: 'Macro analyst',
+        title: 'What macro signal should we inspect?',
+        description: 'Search FRED, plot indicators, or draft a deck.',
+      },
+      suggestions: [
+        { label: 'Search series', hint: 'Find FRED data', prompt: 'Find CPI and unemployment series.' },
+      ],
+    })
+  })
+
   it('signs in from the chat-first auth overlay without a hard browser reload', async () => {
     const { CoreWorkspaceAgentFront } = await importSubject()
     sessionState = { data: null, isPending: false }

--- a/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
+++ b/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useLocation } from 'react-router-dom'
+import type { ChatSuggestion } from '@hachej/boring-agent/front'
 import type {
   WorkspaceAgentFrontProps,
   WorkspaceAgentSession,
@@ -8,6 +9,29 @@ import { AuthCard } from './AuthCard.js'
 import { AuthModal } from './AuthModal.js'
 import { ChatFirstAuthenticatedShell } from './ChatFirstAuthenticatedShell.js'
 import { safeReturnTo, writePendingChatEntry } from './pendingChatEntry.js'
+
+export interface ChatFirstPublicShellOptions {
+  composerPlaceholder?: string
+  emptyState?: {
+    eyebrow?: string
+    title?: string
+    description?: string
+  }
+  suggestions?: ChatSuggestion[]
+}
+
+const defaultPublicEmptyState = {
+  eyebrow: 'Start here',
+  title: 'What do you want to build?',
+  description: 'Type a prompt or pick an example. Sign in on send to unlock your private workspace.',
+}
+
+const defaultPublicSuggestions: ChatSuggestion[] = [
+  { label: 'Build an app from scratch', hint: 'Creates files, installs deps, opens a preview', prompt: 'Build a full-stack app with auth, a dashboard, and sample data.' },
+  { label: 'Understand a codebase', hint: 'Maps the repo and explains where to start', prompt: 'Explain this codebase, map the architecture, and suggest first improvements.' },
+  { label: 'Fix a bug safely', hint: 'Finds the cause, edits files, runs tests', prompt: 'Trace a bug, edit the right files, update tests, and summarize the diff.' },
+  { label: 'Prototype an interface', hint: 'Turns an idea into an interactive UI', prompt: 'Build an interactive prototype and open it in the workspace.' },
+]
 
 function readComposerDraftFromDom(): string {
   if (typeof document === 'undefined') return ''
@@ -20,10 +44,12 @@ export function ChatFirstPublicShell<
 >({
   appTitle,
   intendedWorkspaceId,
+  publicShell,
   workspaceProps,
 }: {
   appTitle: string
   intendedWorkspaceId?: string
+  publicShell?: ChatFirstPublicShellOptions
   workspaceProps: Omit<WorkspaceAgentFrontProps<TSession>, 'workspaceId' | 'frontPluginHotReload' | 'hotReloadEnabled'>
 }) {
   const location = useLocation()
@@ -48,18 +74,12 @@ export function ChatFirstPublicShell<
           chatParams: {
             ...workspaceProps.chatParams,
             emptyPlacement: 'hero',
-            composerPlaceholder: 'Describe the app, bug, or repo task you want help with…',
+            composerPlaceholder: publicShell?.composerPlaceholder ?? 'Describe the app, bug, or repo task you want help with…',
             emptyState: {
-              eyebrow: 'Start here',
-              title: 'What do you want to build?',
-              description: 'Type a prompt or pick an example. Sign in on send to unlock your private workspace.',
+              ...defaultPublicEmptyState,
+              ...publicShell?.emptyState,
             },
-            suggestions: [
-              { label: 'Build an app from scratch', hint: 'Creates files, installs deps, opens a preview', prompt: 'Build a full-stack app with auth, a dashboard, and sample data.' },
-              { label: 'Understand a codebase', hint: 'Maps the repo and explains where to start', prompt: 'Explain this codebase, map the architecture, and suggest first improvements.' },
-              { label: 'Fix a bug safely', hint: 'Finds the cause, edits files, runs tests', prompt: 'Trace a bug, edit the right files, update tests, and summarize the diff.' },
-              { label: 'Prototype an interface', hint: 'Turns an idea into an interactive UI', prompt: 'Build an interactive prototype and open it in the workspace.' },
-            ],
+            suggestions: publicShell?.suggestions ?? defaultPublicSuggestions,
             onBeforeSubmit: (draft: string) => {
               openAuth(draft)
               return false as const

--- a/packages/core/src/app/front/index.ts
+++ b/packages/core/src/app/front/index.ts
@@ -1,2 +1,3 @@
 export { CoreWorkspaceAgentFront } from './CoreWorkspaceAgentFront.js'
 export type { CoreWorkspaceAgentFrontProps } from './CoreWorkspaceAgentFront.js'
+export type { ChatFirstPublicShellOptions } from './chatFirst/ChatFirstPublicShell.js'

--- a/packages/workspace/scripts/assert-build-artifacts.mjs
+++ b/packages/workspace/scripts/assert-build-artifacts.mjs
@@ -58,6 +58,18 @@ async function assertConsumerSafeCss(rel) {
   }
 }
 
+async function assertNoDockviewCssSideEffect(rel) {
+  const sourceText = await readFile(path.resolve(packageRoot, rel), "utf8")
+  const pattern = /dockview-react\/dist\/styles\/dockview\.css/
+  if (pattern.test(sourceText)) {
+    console.error(
+      `assert-build-artifacts: ${rel} imports dockview's raw CSS. ` +
+        "dist/workspace.css already bundles it; JS side effects break SSR consumers.",
+    )
+    process.exit(1)
+  }
+}
+
 if (missing.length > 0) {
   console.error(
     `assert-build-artifacts: missing ${missing.length} required artifact(s):`,
@@ -71,6 +83,7 @@ if (missing.length > 0) {
 }
 
 await assertConsumerSafeCss("dist/workspace.css")
+await assertNoDockviewCssSideEffect("dist/workspace.js")
 
 console.log(
   `assert-build-artifacts: all ${requiredFiles.length} artifacts present`,

--- a/packages/workspace/src/front/dock/DockviewShell.tsx
+++ b/packages/workspace/src/front/dock/DockviewShell.tsx
@@ -16,7 +16,6 @@ import {
   type IDockviewPanelHeaderProps,
   type IDockviewPanelProps,
 } from "dockview-react"
-import "dockview-react/dist/styles/dockview.css"
 import "./dockview-overrides.css"
 import { useRegistry } from "../registry"
 import { useHydrationComplete } from "../store/selectors"


### PR DESCRIPTION
## Summary

- Add `chatFirstPublicShell` to `CoreWorkspaceAgentFront` so apps can override unauthenticated chat-first composer placeholder, empty-state copy, and suggestions.
- Export `ChatFirstPublicShellOptions` from `@hachej/boring-core/app/front` for app typing.
- Remove the raw `dockview-react/dist/styles/dockview.css` side-effect import from workspace JS; `dist/workspace.css` already bundles dockview base CSS plus overrides.
- Add a workspace build assertion to prevent reintroducing that SSR-hostile dockview CSS JS import.

## Validation

- `pnpm install`
- `pnpm --filter @hachej/boring-ui-kit --filter @hachej/boring-agent --filter @hachej/boring-workspace --workspace-concurrency=3 run build`
- `pnpm --filter @hachej/boring-core run build`
- `pnpm --filter @hachej/boring-core run typecheck`
- `cd packages/core && pnpm exec vitest run --no-file-parallelism src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx`
- `pnpm --filter @hachej/boring-workspace run build`