### PR TITLE
ci: pin GitHub Actions to commit SHAs + add regression guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm
@@ -46,15 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm
@@ -73,13 +73,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm
@@ -100,15 +100,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm
@@ -160,13 +160,13 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm
@@ -201,13 +201,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm
@@ -226,13 +226,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm
@@ -241,7 +241,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -264,13 +264,13 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm
@@ -312,7 +312,7 @@ jobs:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: superfly/flyctl-actions/setup-flyctl@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1
 

--- a/.github/workflows/invariants.yml
+++ b/.github/workflows/invariants.yml
@@ -14,13 +14,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Assert workflow actions are pinned to commit SHAs
+        run: bash scripts/check-action-pins.sh
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -34,13 +34,13 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -34,13 +34,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22.19.0
           cache: pnpm
@@ -49,7 +49,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload visual artifacts
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: visual-regression-artifacts
           path: |

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "audit:publish-manifests": "node scripts/audit-publish-manifests.mjs",
     "check:generated-artifacts": "pnpm tsx scripts/check-generated-artifacts.ts",
     "check:agent-isolation": "pnpm --filter @hachej/boring-agent run check:isolation",
+    "check:action-pins": "bash scripts/check-action-pins.sh",
     "check:bundle-size": "pnpm --filter @hachej/boring-workspace run check:bundle-size",
     "check:core-bundle-size": "pnpm --filter @hachej/boring-core run check:bundle-size",
     "ci:bundle-size": "pnpm --filter @hachej/boring-workspace... --workspace-concurrency=4 run build && pnpm check:bundle-size",

--- a/scripts/check-action-pins.sh
+++ b/scripts/check-action-pins.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Invariant: every third-party GitHub Action referenced in a workflow must be
+# pinned to a full 40-char commit SHA (not a moving tag like @v6 or @main).
+# Rationale: a tag can be re-pointed at malicious code by a compromised
+# maintainer, turning CI into a secret-exfiltration surface. A SHA cannot.
+# See the supply-chain incident write-up that motivated this guard.
+
+PREFIX="[action-pins]"
+WORKFLOW_DIR="${1:-.github/workflows}"
+
+if [[ ! -d "$WORKFLOW_DIR" ]]; then
+  echo "$PREFIX ERR workflow dir not found: $WORKFLOW_DIR"
+  exit 2
+fi
+
+failures=0
+sha_re='^[0-9a-f]{40}$'
+
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  file="${line%%:*}"
+  rest="${line#*:}"
+  lineno="${rest%%:*}"
+
+  # Extract the `uses:` value: strip everything up to and including "uses:",
+  # then drop any trailing inline comment and surrounding whitespace/quotes.
+  ref_line="${rest#*uses:}"
+  ref_line="${ref_line%%#*}"
+  ref_line="$(printf '%s' "$ref_line" | tr -d '[:space:]' | tr -d '"'\''')"
+
+  # Local (./...) and Docker (docker://...) actions are not tag-pinnable; skip.
+  [[ "$ref_line" == ./* || "$ref_line" == docker://* ]] && continue
+  # No version ref at all (bare local path) — skip.
+  [[ "$ref_line" != *@* ]] && continue
+
+  pin="${ref_line##*@}"
+  if [[ ! "$pin" =~ $sha_re ]]; then
+    failures=1
+    echo "$PREFIX ERR $file:$lineno uses unpinned ref '$ref_line'"
+  fi
+done < <(grep -rEn '^\s*-?\s*uses:' "$WORKFLOW_DIR")
+
+if [[ "$failures" -ne 0 ]]; then
+  echo "$PREFIX FAIL one or more actions are not pinned to a commit SHA"
+  echo "  Fix: replace '@vX'/'@branch' with the full commit SHA, e.g."
+  echo "       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2"
+  echo "  Resolve a tag's SHA with: gh api repos/<owner>/<repo>/commits/<tag> --jq .sha"
+  exit 1
+fi
+
+echo "$PREFIX OK all workflow actions are pinned to commit SHAs"


### PR DESCRIPTION
## Why

Prompted by the [blef.fr supply-chain write-up](https://www.blef.fr/someone-tried-to-hack-us). Our CI was **not** vulnerable to that specific attack (no `pull_request_target`, read-only `GITHUB_TOKEN`, secrets gated to push-to-main, no per-PR deploy). This PR closes the one remaining supply-chain gap: third-party actions referenced by **moving tags** (`@v6`, `@v5`…), which a compromised maintainer could re-point at malicious code.

## What

- **Pin every third-party action to a full commit SHA** across all 5 workflows, each with a `# vX.Y.Z` comment for readability:
  - `actions/checkout` → `de0fac2…` (v6.0.2)
  - `actions/setup-node` → `48b55a0…` (v6.4.0)
  - `actions/cache` → `27d5ce7…` (v5.0.5)
  - `actions/upload-artifact` → `043fb46…` (v7.0.1)
  - `pnpm/action-setup` → `d15e628…` (v6.0.8)
  - `superfly/flyctl-actions/setup-flyctl` was already SHA-pinned.
- **Add `scripts/check-action-pins.sh`** — fails if any workflow `uses:` a non-SHA ref. Skips local (`./…`) and `docker://` actions. Exposed as `pnpm check:action-pins`.
- **Wire the guard into `invariants.yml`** right after checkout, run via plain `bash` (no toolchain needed) so it fails fast on every PR and push to main.

> Note: `pnpm/action-setup`'s moving `v6` tag pointed at an *untagged* commit, so it's pinned to the latest release `v6.0.8` rather than that floating SHA.

## Test

- Guard passes on the pinned tree.
- Negative-tested: correctly flags `@v6` / `@main`, passes SHA-pinned and local-path refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)