### PR TITLE
refactor(agent): one shared artifact-resolution algorithm for both sandbox adapters

### DIFF
--- a/packages/agent/src/server/runtime/modes/__tests__/provisioningAdapter.test.ts
+++ b/packages/agent/src/server/runtime/modes/__tests__/provisioningAdapter.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, stat, symlink, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { expect, test } from 'vitest'
@@ -103,7 +103,7 @@ test('direct adapter resolveInstallSource returns runtime-visible local paths an
   expect(adapter.getRuntimeCacheRoot()).toBe(paths.cache)
 })
 
-test('local adapter maps workspace-contained package roots to /workspace and copies external roots into writable workspace tmp', async () => {
+test('local adapter maps workspace-contained package roots to /workspace and packs external roots into an in-workspace tarball', async () => {
   const workspaceRoot = await tempRoot('boring-local-workspace-')
   const externalRoot = await tempRoot('boring-local-external-')
   await mkdir(join(workspaceRoot, 'packages', 'plugin'), { recursive: true })
@@ -114,18 +114,26 @@ test('local adapter maps workspace-contained package roots to /workspace and cop
     return { stdout: 'local ok\n' }
   })
 
+  // A package root already inside the workspace is visible in the bwrap mount,
+  // so it maps straight to its /workspace path (no packing needed).
   await expect(adapter.resolveInstallSource(join(workspaceRoot, 'packages', 'plugin'), {
     kind: 'node',
     id: 'plugin',
     fingerprint: 'sha256:111',
   })).resolves.toBe('/workspace/packages/plugin')
 
+  // An EXTERNAL root is packed to a self-contained tarball inside the
+  // workspace — the same process the vercel-sandbox adapter uses — so
+  // `uv pip install <.tar.gz>` extracts a real copy with no escaping symlink.
   const externalInstallSource = await adapter.resolveInstallSource(externalRoot, {
     kind: 'python',
     id: 'macro sdk',
     fingerprint: 'sha256:abcdef',
   })
-  expect(externalInstallSource).toBe('/workspace/.boring-agent/tmp/python-macro-sdk-abcdef-source')
+  expect(externalInstallSource).toBe('/workspace/.boring-agent/tmp/macro-sdk-v1-abcdef.tar.gz')
+  // The tarball was actually produced inside the workspace (no symlink hop).
+  const tarballStat = await stat(join(workspaceRoot, '.boring-agent', 'tmp', 'macro-sdk-v1-abcdef.tar.gz'))
+  expect(tarballStat.isFile()).toBe(true)
 
   const execResult = await adapter.exec(join(paths.venvBin, 'python'), ['-c', 'print("hello world")', 'arg with spaces', paths.venv], {
     env: { VIRTUAL_ENV: paths.venv },
@@ -135,7 +143,6 @@ test('local adapter maps workspace-contained package roots to /workspace and cop
 
   expect(calls).toHaveLength(1)
   expect(calls[0].command).toBe('bwrap')
-  await expect(readFile(join(workspaceRoot, '.boring-agent', 'tmp', 'python-macro-sdk-abcdef-source'), 'utf8')).rejects.toThrow()
   expect(calls[0].args).not.toContain(externalRoot)
   expect(calls[0].args.slice(-5)).toEqual([
     '/workspace/.boring-agent/venv/bin/python',
@@ -145,4 +152,28 @@ test('local adapter maps workspace-contained package roots to /workspace and cop
     '/workspace/.boring-agent/venv',
   ])
   expect(calls[0].env.VIRTUAL_ENV).toBe('/workspace/.boring-agent/venv')
+})
+
+test('local adapter packs an external NODE source to an in-workspace .tgz so npm extracts a copy (no escaping symlink)', async () => {
+  // The CLI's global install dir is external to the workspace. Packing it to a
+  // tarball means `npm install <.tgz>` extracts a real copy into
+  // .boring-agent/node rather than symlinking out to the host's npm-global —
+  // which is exactly what tripped the realpath guard in bwrap mode.
+  const workspaceRoot = await tempRoot('boring-local-nodepack-ws-')
+  const externalCli = await tempRoot('boring-local-nodepack-cli-')
+  await writeFile(
+    join(externalCli, 'package.json'),
+    `${JSON.stringify({ name: 'fake-cli', version: '1.0.0', bin: { 'fake-cli': 'index.js' } })}\n`,
+  )
+  await writeFile(join(externalCli, 'index.js'), 'module.exports = {}\n')
+  const adapter = createLocalProvisioningAdapter(getBoringAgentRuntimePaths(workspaceRoot))
+
+  const installSource = await adapter.resolveInstallSource(externalCli, {
+    kind: 'node',
+    id: 'fake-cli',
+    fingerprint: 'sha256:deadbeef',
+  })
+  expect(installSource).toBe('/workspace/.boring-agent/tmp/fake-cli-pnpm-pack-v2-deadbeef.tgz')
+  const tarballStat = await stat(join(workspaceRoot, '.boring-agent', 'tmp', 'fake-cli-pnpm-pack-v2-deadbeef.tgz'))
+  expect(tarballStat.isFile()).toBe(true)
 })

--- a/packages/agent/src/server/runtime/modes/provisioningAdapter.ts
+++ b/packages/agent/src/server/runtime/modes/provisioningAdapter.ts
@@ -9,6 +9,10 @@ import {
   assertRealPathWithinWorkspace,
   validatePath,
 } from '../../workspace/paths'
+import {
+  packProvisioningArtifact,
+  provisioningArtifactName,
+} from '../../workspace/provisioning/packArtifact'
 import { buildBwrapArgs } from '../../sandbox/bwrap/buildBwrapArgs'
 
 const LOCAL_SANDBOX_WORKSPACE_ROOT = '/workspace'
@@ -148,28 +152,34 @@ function mapEnvToLocalSandbox(paths: BoringAgentRuntimePaths, env: Record<string
   )
 }
 
-function sanitizeInstallSourcePart(value: string): string {
-  const sanitized = value.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '')
-  return sanitized.length > 0 ? sanitized : 'source'
+async function pathExists(absPath: string): Promise<boolean> {
+  try {
+    await stat(absPath)
+    return true
+  } catch {
+    return false
+  }
 }
 
-async function copyExternalSourceIntoWorkspace(
+async function packExternalSourceIntoWorkspace(
   paths: BoringAgentRuntimePaths,
   sourcePath: string,
-  opts: { kind: string; id: string; fingerprint: string },
+  opts: { kind: 'node' | 'python'; id: string; fingerprint: string },
 ): Promise<string> {
-  const fingerprint = opts.fingerprint.replace(/^sha256:/, '')
-  const relTarget = `.boring-agent/tmp/${sanitizeInstallSourcePart(opts.kind)}-${sanitizeInstallSourcePart(opts.id)}-${sanitizeInstallSourcePart(fingerprint)}-source`
+  // Materialize an external install source as a self-contained tarball inside
+  // the workspace — the SAME process the vercel-sandbox adapter uses. `npm
+  // install <.tgz>` / `uv pip install <.tar.gz>` then EXTRACT a real copy into
+  // .boring-agent/node|venv, so the install leaves no directory symlink that
+  // escapes the workspace root (and would be invisible inside the bwrap mount).
+  const relTarget = `.boring-agent/tmp/${provisioningArtifactName(opts.kind, opts.id, opts.fingerprint)}`
   const absTarget = validatePath(paths.workspaceRoot, relTarget)
-  await rm(absTarget, { recursive: true, force: true })
   await mkdir(dirname(absTarget), { recursive: true })
   await assertRealPathWithinWorkspace(paths.workspaceRoot, dirname(absTarget))
-  const sourceStat = await stat(sourcePath)
-  await cp(sourcePath, absTarget, {
-    recursive: sourceStat.isDirectory(),
-    force: false,
-    errorOnExist: true,
-  })
+  // The artifact name is content-addressed by fingerprint, so an existing
+  // tarball already holds the right bytes — reuse it across reruns.
+  if (!(await pathExists(absTarget))) {
+    await packProvisioningArtifact({ kind: opts.kind, source: sourcePath, outputPath: absTarget })
+  }
   return `${LOCAL_SANDBOX_WORKSPACE_ROOT}/${relTarget}`
 }
 
@@ -275,7 +285,7 @@ export function createLocalProvisioningAdapter(
         return `${LOCAL_SANDBOX_WORKSPACE_ROOT}/${relPath.split(sep).join('/')}`
       }
 
-      return await copyExternalSourceIntoWorkspace(paths, realSource, opts)
+      return await packExternalSourceIntoWorkspace(paths, realSource, opts)
     },
     workspaceFs: createWorkspaceFs(paths.workspaceRoot, { enforceSymlinkBoundary: true }),
     getRuntimeCacheRoot() {

--- a/packages/agent/src/server/runtime/modes/provisioningAdapter.ts
+++ b/packages/agent/src/server/runtime/modes/provisioningAdapter.ts
@@ -11,7 +11,7 @@ import {
 } from '../../workspace/paths'
 import {
   packProvisioningArtifact,
-  provisioningArtifactName,
+  resolveArtifactInstallSource,
 } from '../../workspace/provisioning/packArtifact'
 import { buildBwrapArgs } from '../../sandbox/bwrap/buildBwrapArgs'
 
@@ -152,37 +152,6 @@ function mapEnvToLocalSandbox(paths: BoringAgentRuntimePaths, env: Record<string
   )
 }
 
-async function pathExists(absPath: string): Promise<boolean> {
-  try {
-    await stat(absPath)
-    return true
-  } catch {
-    return false
-  }
-}
-
-async function packExternalSourceIntoWorkspace(
-  paths: BoringAgentRuntimePaths,
-  sourcePath: string,
-  opts: { kind: 'node' | 'python'; id: string; fingerprint: string },
-): Promise<string> {
-  // Materialize an external install source as a self-contained tarball inside
-  // the workspace — the SAME process the vercel-sandbox adapter uses. `npm
-  // install <.tgz>` / `uv pip install <.tar.gz>` then EXTRACT a real copy into
-  // .boring-agent/node|venv, so the install leaves no directory symlink that
-  // escapes the workspace root (and would be invisible inside the bwrap mount).
-  const relTarget = `.boring-agent/tmp/${provisioningArtifactName(opts.kind, opts.id, opts.fingerprint)}`
-  const absTarget = validatePath(paths.workspaceRoot, relTarget)
-  await mkdir(dirname(absTarget), { recursive: true })
-  await assertRealPathWithinWorkspace(paths.workspaceRoot, dirname(absTarget))
-  // The artifact name is content-addressed by fingerprint, so an existing
-  // tarball already holds the right bytes — reuse it across reruns.
-  if (!(await pathExists(absTarget))) {
-    await packProvisioningArtifact({ kind: opts.kind, source: sourcePath, outputPath: absTarget })
-  }
-  return `${LOCAL_SANDBOX_WORKSPACE_ROOT}/${relTarget}`
-}
-
 function createWorkspaceFs(
   workspaceRoot: string,
   opts: { enforceSymlinkBoundary: boolean },
@@ -253,6 +222,7 @@ export function createLocalProvisioningAdapter(
   runner: CommandRunner = spawnCommand,
 ): WorkspaceProvisioningAdapter {
   const sourceMounts = new Map<string, string>()
+  const workspaceFs = createWorkspaceFs(paths.workspaceRoot, { enforceSymlinkBoundary: true })
 
   return {
     mode: 'local',
@@ -285,9 +255,19 @@ export function createLocalProvisioningAdapter(
         return `${LOCAL_SANDBOX_WORKSPACE_ROOT}/${relPath.split(sep).join('/')}`
       }
 
-      return await packExternalSourceIntoWorkspace(paths, realSource, opts)
+      // External source: pack it into a self-contained in-workspace tarball via
+      // the SAME path the vercel-sandbox mode uses, so `npm install <.tgz>` /
+      // `uv pip install <.tar.gz>` extract a real copy and leave no directory
+      // symlink escaping the workspace (and invisible inside the bwrap mount).
+      return await resolveArtifactInstallSource({
+        workspaceFs,
+        prepareArtifact: packProvisioningArtifact,
+        runtimeTmpDir: `${LOCAL_SANDBOX_WORKSPACE_ROOT}/.boring-agent/tmp`,
+        source: realSource,
+        opts,
+      })
     },
-    workspaceFs: createWorkspaceFs(paths.workspaceRoot, { enforceSymlinkBoundary: true }),
+    workspaceFs,
     getRuntimeCacheRoot() {
       return paths.cache
     },

--- a/packages/agent/src/server/runtime/modes/vercel-sandbox.ts
+++ b/packages/agent/src/server/runtime/modes/vercel-sandbox.ts
@@ -1,9 +1,7 @@
-import { execFile } from 'node:child_process'
-import { mkdtemp, mkdir, readFile, readdir, rename, stat } from 'node:fs/promises'
-import { dirname, isAbsolute, join } from 'node:path'
+import { mkdtemp, mkdir, readFile, readdir, stat } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
-import { promisify } from 'node:util'
 
 import { Sandbox as VercelSandbox } from '@vercel/sandbox'
 
@@ -12,6 +10,7 @@ import { safeCapture, type TelemetrySink } from '../../../shared/telemetry'
 import { getEnv, setEnvDefault } from '../../config/env'
 import { createVercelSandboxExec } from '../../sandbox/vercel-sandbox/createVercelSandboxExec'
 import { createVercelProvisioningAdapter } from '../../sandbox/vercel-sandbox/provisioningAdapter'
+import { packProvisioningArtifact } from '../../workspace/provisioning/packArtifact'
 import { isNodeFamilyRuntime, uvSetupCommandsForRuntime, VERCEL_UV_BIN } from '../../sandbox/snapshots/deploymentSnapshot'
 import { FileHandleStore } from '../../sandbox/vercel-sandbox/FileHandleStore'
 import {
@@ -46,7 +45,6 @@ const ORPHAN_GUARD_MAX_IDLE_MS = 24 * 60 * 60 * 1000
 const VERCEL_SANDBOX_TIMEOUT_MS_ENV = 'BORING_AGENT_VERCEL_SANDBOX_TIMEOUT_MS'
 const VERCEL_SANDBOX_RUNTIME_ENV = 'BORING_AGENT_VERCEL_SANDBOX_RUNTIME'
 const DEFAULT_VERCEL_SANDBOX_RUNTIME = 'node24'
-const execFileAsync = promisify(execFile)
 
 export interface VercelSandboxModeAdapterOptions {
   store?: SandboxHandleStore
@@ -269,34 +267,6 @@ async function seedTemplateIntoVercelWorkspace(
 
 function provisioningSourceToPath(source: string | URL): string {
   return source instanceof URL ? fileURLToPath(source) : source
-}
-
-async function prepareVercelProvisioningArtifact(request: {
-  kind: 'node' | 'python'
-  source: string | URL
-  outputPath: string
-}): Promise<void> {
-  const sourcePath = provisioningSourceToPath(request.source)
-  await mkdir(dirname(request.outputPath), { recursive: true })
-
-  if (request.kind === 'node') {
-    const { stdout } = await execFileAsync('pnpm', [
-      '--dir',
-      sourcePath,
-      'pack',
-      '--pack-destination',
-      dirname(request.outputPath),
-    ], { maxBuffer: 1024 * 1024 * 20 })
-    const packedName = stdout.trim().split(/\r?\n/).filter(Boolean).at(-1)
-    if (!packedName) throw new Error(`pnpm pack produced no artifact for ${sourcePath}`)
-    const packedPath = isAbsolute(packedName) ? packedName : join(dirname(request.outputPath), packedName)
-    await rename(packedPath, request.outputPath)
-    return
-  }
-
-  await execFileAsync('tar', ['-czf', request.outputPath, '-C', sourcePath, '.'], {
-    maxBuffer: 1024 * 1024 * 20,
-  })
 }
 
 function shellSingleQuote(value: string): string {
@@ -575,7 +545,7 @@ export function createVercelSandboxModeAdapter(
           }
           return { stdout, stderr }
         },
-        prepareArtifact: prepareVercelProvisioningArtifact,
+        prepareArtifact: packProvisioningArtifact,
       })
     },
     async create(ctx) {

--- a/packages/agent/src/server/sandbox/vercel-sandbox/__tests__/provisioningAdapter.test.ts
+++ b/packages/agent/src/server/sandbox/vercel-sandbox/__tests__/provisioningAdapter.test.ts
@@ -164,7 +164,7 @@ test('artifact preparation receives non-source temp output path for useful failu
     fingerprint: 'sha256:feedface',
   })
 
-  expect(outputPath).toContain('boring-agent-vercel-artifact-')
+  expect(outputPath).toContain('boring-agent-artifact-')
   expect(outputPath).not.toContain(sourceRoot)
   await expect(stat(dirname(outputPath))).resolves.toBeTruthy()
 })

--- a/packages/agent/src/server/sandbox/vercel-sandbox/provisioningAdapter.ts
+++ b/packages/agent/src/server/sandbox/vercel-sandbox/provisioningAdapter.ts
@@ -1,24 +1,17 @@
-import { mkdtemp } from 'node:fs/promises'
-import { join } from 'node:path'
-import { tmpdir } from 'node:os'
-
 import type { BoringAgentRuntimePaths } from '../../workspace/runtimeLayout'
-import { ErrorCode, toProvisioningError } from '../../workspace/provisioning/errors'
 import type {
   WorkspaceProvisioningAdapter,
   WorkspaceProvisioningExecResult,
 } from '../../workspace/provisioning'
-import { provisioningArtifactName } from '../../workspace/provisioning/packArtifact'
+import {
+  type ProvisioningArtifactRequest,
+  resolveArtifactInstallSource,
+} from '../../workspace/provisioning/packArtifact'
 
 export const VERCEL_PROVISIONING_CACHE_ROOT = '/tmp/boring-agent-cache'
 
-export interface VercelProvisioningArtifactRequest {
-  kind: 'node' | 'python'
-  id: string
-  fingerprint: string
-  source: string | URL
-  outputPath: string
-}
+/** @deprecated Use {@link ProvisioningArtifactRequest}. Retained for the public export surface. */
+export type VercelProvisioningArtifactRequest = ProvisioningArtifactRequest
 
 export interface CreateVercelProvisioningAdapterOptions {
   runtimeLayout: BoringAgentRuntimePaths
@@ -28,7 +21,7 @@ export interface CreateVercelProvisioningAdapterOptions {
     env?: Record<string, string>
     timeoutMs?: number
   }): Promise<WorkspaceProvisioningExecResult | void>
-  prepareArtifact(request: VercelProvisioningArtifactRequest): Promise<void>
+  prepareArtifact(request: ProvisioningArtifactRequest): Promise<void>
   cacheRoot?: string
 }
 
@@ -45,33 +38,13 @@ export function createVercelProvisioningAdapter(
       })
     },
     async resolveInstallSource(source, opts) {
-      const name = provisioningArtifactName(opts.kind, opts.id, opts.fingerprint)
-      const workspaceRel = `.boring-agent/tmp/${name}`
-      const runtimePath = `${options.runtimeLayout.tmp}/${name}`
-
-      if (!(await options.workspaceFs.exists(workspaceRel))) {
-        const artifactDir = await mkdtemp(join(tmpdir(), 'boring-agent-vercel-artifact-'))
-        const outputPath = join(artifactDir, name)
-        try {
-          await options.prepareArtifact({
-            kind: opts.kind,
-            id: opts.id,
-            fingerprint: opts.fingerprint,
-            source,
-            outputPath,
-          })
-          await options.workspaceFs.copyFromHost(outputPath, workspaceRel)
-        } catch (error) {
-          throw toProvisioningError(
-            ErrorCode.enum.PROVISIONING_ARTIFACT_FAILED,
-            'adapter-artifact',
-            error,
-            { runtime: opts.kind, id: opts.id, artifact: workspaceRel },
-          )
-        }
-      }
-
-      return runtimePath
+      return await resolveArtifactInstallSource({
+        workspaceFs: options.workspaceFs,
+        prepareArtifact: options.prepareArtifact,
+        runtimeTmpDir: options.runtimeLayout.tmp,
+        source,
+        opts,
+      })
     },
     workspaceFs: options.workspaceFs,
     getRuntimeCacheRoot() {

--- a/packages/agent/src/server/sandbox/vercel-sandbox/provisioningAdapter.ts
+++ b/packages/agent/src/server/sandbox/vercel-sandbox/provisioningAdapter.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceProvisioningAdapter,
   WorkspaceProvisioningExecResult,
 } from '../../workspace/provisioning'
+import { provisioningArtifactName } from '../../workspace/provisioning/packArtifact'
 
 export const VERCEL_PROVISIONING_CACHE_ROOT = '/tmp/boring-agent-cache'
 
@@ -31,17 +32,6 @@ export interface CreateVercelProvisioningAdapterOptions {
   cacheRoot?: string
 }
 
-function artifactExtension(kind: 'node' | 'python'): '.tgz' | '.tar.gz' {
-  return kind === 'node' ? '.tgz' : '.tar.gz'
-}
-
-function artifactName(kind: 'node' | 'python', id: string, fingerprint: string): string {
-  const safeId = id.replace(/[^A-Za-z0-9._-]/g, '-')
-  const safeFingerprint = fingerprint.replace(/^sha256:/, '')
-  const formatVersion = kind === 'node' ? 'pnpm-pack-v2' : 'v1'
-  return `${safeId}-${formatVersion}-${safeFingerprint}${artifactExtension(kind)}`
-}
-
 export function createVercelProvisioningAdapter(
   options: CreateVercelProvisioningAdapterOptions,
 ): WorkspaceProvisioningAdapter {
@@ -55,7 +45,7 @@ export function createVercelProvisioningAdapter(
       })
     },
     async resolveInstallSource(source, opts) {
-      const name = artifactName(opts.kind, opts.id, opts.fingerprint)
+      const name = provisioningArtifactName(opts.kind, opts.id, opts.fingerprint)
       const workspaceRel = `.boring-agent/tmp/${name}`
       const runtimePath = `${options.runtimeLayout.tmp}/${name}`
 

--- a/packages/agent/src/server/workspace/provisioning/packArtifact.ts
+++ b/packages/agent/src/server/workspace/provisioning/packArtifact.ts
@@ -1,0 +1,67 @@
+import { execFile } from 'node:child_process'
+import { mkdir, rename } from 'node:fs/promises'
+import { dirname, isAbsolute, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+export type ProvisioningArtifactKind = 'node' | 'python'
+
+/**
+ * Provider-neutral materialization of an external install source into a
+ * self-contained tarball. Both the `vercel-sandbox` and `local` (bwrap) modes
+ * use this so that `npm install <.tgz>` / `uv pip install <.tar.gz>` extract a
+ * real copy into the workspace instead of leaving a directory symlink that
+ * escapes the workspace root (and is invisible inside a sandbox mount).
+ *
+ * - node: `pnpm pack` (honors the package's `files`/`bin`) → `.tgz`
+ * - python: `tar -czf` of the source tree → `.tar.gz`
+ */
+export async function packProvisioningArtifact(request: {
+  kind: ProvisioningArtifactKind
+  source: string | URL
+  outputPath: string
+}): Promise<void> {
+  const sourcePath = request.source instanceof URL ? fileURLToPath(request.source) : request.source
+  await mkdir(dirname(request.outputPath), { recursive: true })
+
+  if (request.kind === 'node') {
+    const { stdout } = await execFileAsync('pnpm', [
+      '--dir',
+      sourcePath,
+      'pack',
+      '--pack-destination',
+      dirname(request.outputPath),
+    ], { maxBuffer: 1024 * 1024 * 20 })
+    const packedName = stdout.trim().split(/\r?\n/).filter(Boolean).at(-1)
+    if (!packedName) throw new Error(`pnpm pack produced no artifact for ${sourcePath}`)
+    const packedPath = isAbsolute(packedName) ? packedName : join(dirname(request.outputPath), packedName)
+    await rename(packedPath, request.outputPath)
+    return
+  }
+
+  await execFileAsync('tar', ['-czf', request.outputPath, '-C', sourcePath, '.'], {
+    maxBuffer: 1024 * 1024 * 20,
+  })
+}
+
+function artifactExtension(kind: ProvisioningArtifactKind): '.tgz' | '.tar.gz' {
+  return kind === 'node' ? '.tgz' : '.tar.gz'
+}
+
+/**
+ * Stable, content-addressed file name for a packed install source. Shared by
+ * every mode so the same source produces the same artifact name regardless of
+ * provider.
+ */
+export function provisioningArtifactName(
+  kind: ProvisioningArtifactKind,
+  id: string,
+  fingerprint: string,
+): string {
+  const safeId = id.replace(/[^A-Za-z0-9._-]/g, '-')
+  const safeFingerprint = fingerprint.replace(/^sha256:/, '')
+  const formatVersion = kind === 'node' ? 'pnpm-pack-v2' : 'v1'
+  return `${safeId}-${formatVersion}-${safeFingerprint}${artifactExtension(kind)}`
+}

--- a/packages/agent/src/server/workspace/provisioning/packArtifact.ts
+++ b/packages/agent/src/server/workspace/provisioning/packArtifact.ts
@@ -1,12 +1,24 @@
 import { execFile } from 'node:child_process'
-import { mkdir, rename } from 'node:fs/promises'
+import { mkdir, mkdtemp, rename } from 'node:fs/promises'
 import { dirname, isAbsolute, join } from 'node:path'
+import { tmpdir } from 'node:os'
 import { fileURLToPath } from 'node:url'
 import { promisify } from 'node:util'
+
+import { ErrorCode, toProvisioningError } from './errors'
+import type { WorkspaceProvisioningAdapter } from './types'
 
 const execFileAsync = promisify(execFile)
 
 export type ProvisioningArtifactKind = 'node' | 'python'
+
+export interface ProvisioningArtifactRequest {
+  kind: ProvisioningArtifactKind
+  id: string
+  fingerprint: string
+  source: string | URL
+  outputPath: string
+}
 
 /**
  * Provider-neutral materialization of an external install source into a
@@ -64,4 +76,43 @@ export function provisioningArtifactName(
   const safeFingerprint = fingerprint.replace(/^sha256:/, '')
   const formatVersion = kind === 'node' ? 'pnpm-pack-v2' : 'v1'
   return `${safeId}-${formatVersion}-${safeFingerprint}${artifactExtension(kind)}`
+}
+
+/**
+ * The single materialization algorithm shared by every sandboxed mode (local
+ * bwrap, vercel-sandbox): ensure the content-addressed artifact exists under
+ * `.boring-agent/tmp/` in the workspace — packing it from `source` into a host
+ * temp dir and copying it in only when absent — then return the runtime-visible
+ * path. `prepareArtifact` is injected so each mode supplies its own packer (and
+ * tests can stub it); `runtimeTmpDir` is the only per-mode value (the sandbox's
+ * view of `.boring-agent/tmp`).
+ */
+export async function resolveArtifactInstallSource(args: {
+  workspaceFs: Pick<WorkspaceProvisioningAdapter['workspaceFs'], 'exists' | 'copyFromHost'>
+  prepareArtifact: (request: ProvisioningArtifactRequest) => Promise<void>
+  runtimeTmpDir: string
+  source: string | URL
+  opts: { kind: ProvisioningArtifactKind; id: string; fingerprint: string }
+}): Promise<string> {
+  const { kind, id, fingerprint } = args.opts
+  const name = provisioningArtifactName(kind, id, fingerprint)
+  const workspaceRel = `.boring-agent/tmp/${name}`
+
+  if (!(await args.workspaceFs.exists(workspaceRel))) {
+    const artifactDir = await mkdtemp(join(tmpdir(), 'boring-agent-artifact-'))
+    const outputPath = join(artifactDir, name)
+    try {
+      await args.prepareArtifact({ kind, id, fingerprint, source: args.source, outputPath })
+      await args.workspaceFs.copyFromHost(outputPath, workspaceRel)
+    } catch (error) {
+      throw toProvisioningError(
+        ErrorCode.enum.PROVISIONING_ARTIFACT_FAILED,
+        'adapter-artifact',
+        error,
+        { runtime: kind, id, artifact: workspaceRel },
+      )
+    }
+  }
+
+  return `${args.runtimeTmpDir}/${name}`
 }


### PR DESCRIPTION
Thermo-nuclear code-quality review follow-up to #136, stacked on it.

## The finding

After #136 unified both sandbox modes on pack→extract, the **local** and **vercel** adapters still carried the *same algorithm* in their `resolveInstallSource`:

> name the artifact → if it already exists in the workspace, skip → else pack to a host temp + `copyFromHost` into the workspace → return `${tmpDir}/${name}`

That's duplicated **control flow**, not just a duplicated pack step. #136 only shared the leaf (`packProvisioningArtifact`); the orchestration around it was copy-pasted across two files with subtly different existence checks and error handling.

## The move

Extract one `resolveArtifactInstallSource()` into the provider-neutral `packArtifact` module. Both adapters delegate to it. The only per-mode inputs are:
- the injected `prepareArtifact` packer,
- the mode's `workspaceFs`,
- the sandbox-visible `.boring-agent/tmp` prefix (`runtimeLayout.tmp` vs `/workspace/.boring-agent/tmp`).

Everything else — naming, the exists-skip, temp pack, copy-in, error wrapping — is now **one implementation**.

### What this deletes / fixes
- **Deletes** the bespoke local `packExternalSourceIntoWorkspace` **and** its one-off `pathExists` helper.
- **Shrinks** vercel's `resolveInstallSource` from a 25-line body to a 6-line delegation.
- **Removes a boundary inconsistency**: local now materializes through `workspaceFs.copyFromHost` (the canonical fs boundary) instead of re-implementing `assertRealPathWithinWorkspace` inline, and inherits the same `PROVISIONING_ARTIFACT_FAILED` error taxonomy vercel already had (local previously threw raw errors).
- `VercelProvisioningArtifactRequest` (a public export in `index.ts`) is preserved as a `@deprecated` alias of the canonical `ProvisioningArtifactRequest`.

## Before / after — vercel `resolveInstallSource`

```ts
// before: 25 lines duplicating the local adapter's algorithm
const name = provisioningArtifactName(...)
const workspaceRel = `.boring-agent/tmp/${name}`
if (!(await options.workspaceFs.exists(workspaceRel))) {
  const artifactDir = await mkdtemp(...)
  try { await options.prepareArtifact({...}); await options.workspaceFs.copyFromHost(...) }
  catch (error) { throw toProvisioningError(...) }
}
return `${options.runtimeLayout.tmp}/${name}`

// after
return await resolveArtifactInstallSource({
  workspaceFs: options.workspaceFs,
  prepareArtifact: options.prepareArtifact,
  runtimeTmpDir: options.runtimeLayout.tmp,
  source, opts,
})
```

## Verification
Behavior-preserving. Full agent suite green: **1046 server + 250 front**, typecheck clean, invariants pass. The vercel adapter's caching / `prepareArtifact`-injection / temp-path tests pass unchanged (only the internal `mkdtemp` prefix is now mode-neutral).

> Base is `feat/unify-bwrap-vercel-runtime` (#136); collapses once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)