### PR TITLE
fix(agent): stop self-symlinking workspace root + reprovisioning on venv interpreter

### DIFF
--- a/packages/agent/src/server/runtime/modes/__tests__/vercel-sandbox.test.ts
+++ b/packages/agent/src/server/runtime/modes/__tests__/vercel-sandbox.test.ts
@@ -1,4 +1,5 @@
-import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { execFileSync } from 'node:child_process'
+import { lstat, mkdir, mkdtemp, readlink, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, expect, test, vi } from 'vitest'
@@ -16,7 +17,7 @@ import {
 import type { PeriodicSnapshotScheduler } from '../../../sandbox/vercel-sandbox/periodicSnapshot'
 import { createMockVercelSandboxHarness } from '../../../workspace/__tests__/helpers/mockVercelSandbox'
 import { getBoringAgentRuntimePaths } from '../../../workspace/runtimeLayout'
-import { createVercelSandboxModeAdapter } from '../vercel-sandbox'
+import { buildWorkspaceRootSetupScript, createVercelSandboxModeAdapter } from '../vercel-sandbox'
 
 const decoder = new TextDecoder()
 
@@ -503,4 +504,40 @@ test('mode seeds template files into an existing persistent sandbox', async () =
   } finally {
     await harness.cleanup()
   }
+})
+
+test('buildWorkspaceRootSetupScript leaves the root a real dir when remote and workspace paths match', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'boring-ws-root-'))
+  const root = join(base, 'workspace')
+
+  execFileSync('sh', ['-c', buildWorkspaceRootSetupScript(root, root)])
+
+  // No self-referential symlink: the root is a plain directory.
+  expect((await lstat(root)).isDirectory()).toBe(true)
+  expect((await lstat(root)).isSymbolicLink()).toBe(false)
+})
+
+test('buildWorkspaceRootSetupScript clears a stale self-symlink and recreates a real dir', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'boring-ws-root-'))
+  const remote = join(base, 'remote')
+  const root = join(base, 'workspace')
+  // Simulate the broken state left by the old command: a symlink at the root.
+  await mkdir(remote, { recursive: true })
+  await symlink(remote, root)
+
+  execFileSync('sh', ['-c', buildWorkspaceRootSetupScript(root, root)])
+
+  expect((await lstat(root)).isSymbolicLink()).toBe(false)
+  expect((await lstat(root)).isDirectory()).toBe(true)
+})
+
+test('buildWorkspaceRootSetupScript symlinks the workspace to a distinct remote root', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'boring-ws-root-'))
+  const remote = join(base, 'remote')
+  const root = join(base, 'workspace')
+
+  execFileSync('sh', ['-c', buildWorkspaceRootSetupScript(remote, root)])
+
+  expect((await lstat(root)).isSymbolicLink()).toBe(true)
+  expect(await readlink(root)).toBe(remote)
 })

--- a/packages/agent/src/server/runtime/modes/vercel-sandbox.ts
+++ b/packages/agent/src/server/runtime/modes/vercel-sandbox.ts
@@ -174,6 +174,23 @@ type VercelSandboxWithRunCommand = VercelSandbox & {
   runCommand?: (params: { cmd: string; args?: string[] }) => Promise<{ exitCode?: number }>
 }
 
+/**
+ * Build the shell snippet that ensures the workspace root exists in the sandbox.
+ *
+ * When `remoteRoot` and `workspaceRoot` are the same path (the default), linking
+ * one to the other would create a self-referential symlink (or a nested
+ * `workspace/workspace`), so the symlink is only created when they differ. Any
+ * stale symlink left at the workspace root by an earlier buggy run is cleared
+ * first so the root is always a real directory.
+ */
+export function buildWorkspaceRootSetupScript(remoteRoot: string, workspaceRoot: string): string {
+  return [
+    `if [ -L ${workspaceRoot} ]; then rm -f ${workspaceRoot}; fi`,
+    `mkdir -p ${remoteRoot}`,
+    `if [ ${remoteRoot} != ${workspaceRoot} ]; then ln -sfn ${remoteRoot} ${workspaceRoot} 2>/dev/null || true; fi`,
+  ].join('; ')
+}
+
 async function ensureVercelWorkspaceRoot(sandbox: VercelSandboxWithRunCommand): Promise<void> {
   let rootCreated = false
   if (sandbox.fs?.mkdir) {
@@ -193,7 +210,7 @@ async function ensureVercelWorkspaceRoot(sandbox: VercelSandboxWithRunCommand): 
   }
   const result = await sandbox.runCommand({
     cmd: 'sh',
-    args: ['-c', `mkdir -p ${VERCEL_SANDBOX_REMOTE_ROOT} && (ln -sfn ${VERCEL_SANDBOX_REMOTE_ROOT} ${VERCEL_SANDBOX_WORKSPACE_ROOT} 2>/dev/null || true)`],
+    args: ['-c', buildWorkspaceRootSetupScript(VERCEL_SANDBOX_REMOTE_ROOT, VERCEL_SANDBOX_WORKSPACE_ROOT)],
   })
   if ((result.exitCode ?? 1) !== 0) {
     throw new Error(`failed to initialize ${VERCEL_SANDBOX_REMOTE_ROOT} (exit ${result.exitCode ?? 'unknown'})`)

--- a/packages/agent/src/server/workspace/provisioning/__tests__/python.test.ts
+++ b/packages/agent/src/server/workspace/provisioning/__tests__/python.test.ts
@@ -205,6 +205,26 @@ test('skips install when composite fingerprint matches and bm exists', async () 
   expect(state.commands.filter((cmd) => cmd.args[0] === 'pip')).toHaveLength(1)
 })
 
+test('does not reinstall when only the venv interpreter symlink is unreadable (direct-mode escape)', async () => {
+  const workspaceRoot = await tempWorkspace()
+  const paths = getBoringAgentRuntimePaths(workspaceRoot)
+  const { pyproject } = await fakePyprojectRoot()
+  const state: FakeAdapterState = { commands: [], resolved: [], systemUv: true }
+  const packages = [{ id: 'macro-sdk', packageName: 'boring-macro-sdk', projectFile: pyproject, expectedBins: ['bm'] }]
+  const adapter = createFakeAdapter(workspaceRoot, state)
+
+  const first = await ensurePythonRuntime({ adapter, runtimeLayout: paths, packages })
+  // Simulate direct-mode's filesystem rejecting bin/python: it is a symlink to
+  // the system interpreter that resolves outside the workspace, so exists()
+  // reports it missing even though the venv and its package bins are intact.
+  await rm(paths.venvPython, { force: true })
+  const second = await ensurePythonRuntime({ adapter, runtimeLayout: paths, packages })
+
+  expect(first.changed).toBe(true)
+  expect(second.changed).toBe(false)
+  expect(state.commands.filter((cmd) => cmd.args[0] === 'pip')).toHaveLength(1)
+})
+
 test('missing bin or changed extraLibs causes reinstall', async () => {
   const workspaceRoot = await tempWorkspace()
   const paths = getBoringAgentRuntimePaths(workspaceRoot)

--- a/packages/agent/src/server/workspace/provisioning/python.ts
+++ b/packages/agent/src/server/workspace/provisioning/python.ts
@@ -163,6 +163,13 @@ async function shouldInstallPythonRuntime(options: {
   }
 
   for (const output of options.expectedOutputs) {
+    // The venv interpreter (`bin/python`) is a symlink to the system Python,
+    // which resolves outside the workspace. Direct-mode's workspace filesystem
+    // intentionally rejects out-of-workspace symlinks, so probing it with
+    // exists() reports every previously-created venv as missing and forces a
+    // needless reinstall. The fingerprint plus the package bin checks already
+    // tell us whether the runtime is usable, so skip the interpreter symlink.
+    if (output === options.runtimeLayout.venvPython) continue
     if (!(await options.adapter.workspaceFs.exists(toWorkspaceRel(options.runtimeLayout, output)))) return true
   }
   return false


### PR DESCRIPTION
## What

Fixes two Vercel-sandbox provisioning bugs that the **boring-macro** product currently has to monkey-patch at install time (`scripts/patch-boring-agent.mjs`). Landing them here lets boring-macro delete that vendor shim.

### 1. Self-symlinked workspace root
`ensureVercelWorkspaceRoot` ran:
```sh
mkdir -p $REMOTE_ROOT && (ln -sfn $REMOTE_ROOT $WORKSPACE_ROOT 2>/dev/null || true)
```
But `VERCEL_SANDBOX_REMOTE_ROOT === VERCEL_SANDBOX_WORKSPACE_ROOT === /workspace`, so this links `/workspace` to itself (or creates a nested `/workspace/workspace`).

The shell logic is now extracted into an exported, unit-tested `buildWorkspaceRootSetupScript(remoteRoot, workspaceRoot)` that:
- only creates the symlink when the two paths actually differ,
- clears any stale symlink left at the workspace root by an earlier buggy run (self-heals resumed sandboxes), and
- always leaves the root as a real directory.

### 2. Reprovisioning on the venv interpreter symlink
`shouldInstallPythonRuntime` probed `venvPython` (`.boring-agent/venv/bin/python`) via `workspaceFs.exists`. That path is a symlink to the **system** interpreter, which resolves outside the workspace. Direct-mode's workspace filesystem intentionally rejects out-of-workspace symlinks, so the probe reported every existing venv as missing and forced a full reinstall on every boot. The probe now skips the interpreter symlink — the fingerprint + package-bin checks already establish usability.

## Tests
- `vercel-sandbox.test.ts`: real `sh -c` execution of `buildWorkspaceRootSetupScript` for equal roots (no self-symlink), differing roots (symlink created), and stale-symlink cleanup.
- `python.test.ts`: an unreadable interpreter symlink no longer triggers a reinstall.

All agent-package `lint` (typecheck + invariants) and the two affected test files pass (21 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)