### PR TITLE
fix(agent): show full transcript on reload, not just compacted tail

### DIFF
--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/sessions.load.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/sessions.load.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const mockedBuildSessionContext = vi.hoisted(() => vi.fn(() => ({
+  messages: [
+    { role: "assistant", content: [{ type: "text", text: "[summary] compacted tail only" }] },
+  ],
+})));
+
+vi.mock("@mariozechner/pi-coding-agent", async () => {
+  const actual = await vi.importActual<typeof import("@mariozechner/pi-coding-agent")>("@mariozechner/pi-coding-agent");
+  return {
+    ...actual,
+    buildSessionContext: mockedBuildSessionContext,
+  };
+});
+
+import { PiSessionStore } from "../sessions.js";
+
+describe("PiSessionStore.load fallback transcript reconstruction", () => {
+  const ctx = { workspaceId: "test-ws" };
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), "pi-session-load-"));
+    mockedBuildSessionContext.mockClear();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("rebuilds the full transcript from message entries when no ui snapshot exists", async () => {
+    const sessionId = "sess-compacted-no-snapshot";
+    const filepath = join(tmpDir, `${sessionId}.jsonl`);
+    const lines = [
+      {
+        type: "session",
+        version: 1,
+        id: sessionId,
+        timestamp: "2026-05-01T00:00:00.000Z",
+        cwd: "/workspace",
+      },
+      {
+        type: "session_info",
+        id: "info-1",
+        parentId: null,
+        timestamp: "2026-05-01T00:00:00.000Z",
+        name: "Compacted session",
+      },
+      {
+        type: "message",
+        id: "m-user-1",
+        parentId: null,
+        timestamp: "2026-05-01T00:00:01.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "first question" }],
+        },
+      },
+      {
+        type: "message",
+        id: "m-assistant-1",
+        parentId: "m-user-1",
+        timestamp: "2026-05-01T00:00:02.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "first answer" }],
+        },
+      },
+      {
+        type: "compaction",
+        id: "compact-1",
+        parentId: "m-assistant-1",
+        timestamp: "2026-05-01T00:01:00.000Z",
+        summary: "summary that should not replace transcript on reload",
+        firstKeptEntryId: "m-user-2",
+        tokensBefore: 1234,
+      },
+      {
+        type: "message",
+        id: "m-user-2",
+        parentId: "compact-1",
+        timestamp: "2026-05-01T00:01:01.000Z",
+        message: {
+          role: "user",
+          content: [{ type: "text", text: "second question" }],
+        },
+      },
+      {
+        type: "message",
+        id: "m-assistant-2",
+        parentId: "m-user-2",
+        timestamp: "2026-05-01T00:01:02.000Z",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "second answer" }],
+        },
+      },
+    ];
+
+    await writeFile(filepath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf-8");
+
+    const store = new PiSessionStore("/workspace", tmpDir);
+    const detail = await store.load(ctx, sessionId);
+
+    expect(mockedBuildSessionContext).not.toHaveBeenCalled();
+    expect(detail.title).toBe("Compacted session");
+    expect(detail.turnCount).toBe(2);
+    expect(detail.messages.map((message) => ({
+      role: message.role,
+      text: message.parts
+        .filter((part: any) => part.type === "text")
+        .map((part: any) => part.text)
+        .join(" "),
+    }))).toEqual([
+      { role: "user", text: "first question" },
+      { role: "assistant", text: "first answer" },
+      { role: "user", text: "second question" },
+      { role: "assistant", text: "second answer" },
+    ]);
+  });
+});

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -14,7 +14,6 @@ import { join, basename } from "node:path";
 import { homedir } from "node:os";
 import {
   parseSessionEntries,
-  buildSessionContext,
   type SessionEntry,
   type SessionHeader,
   type SessionMessageEntry,
@@ -145,12 +144,14 @@ export class PiSessionStore implements SessionStore {
     const fileStat = await fsStat(filepath);
 
     // Prefer a persisted UI snapshot if available — these are written by
-    // the client after each turn and survive server restarts. Fall back to
-    // reconstructing from pi's native message format (which is empty when
-    // SessionManager.inMemory() is used, so the fallback is mostly a no-op).
+    // the client after each turn and survive server restarts. When no
+    // snapshot exists, rebuild the UI transcript from every persisted message
+    // entry in file order rather than pi's compacted LLM working context.
     const uiSnapshot = extractLatestUiSnapshot(fileEntries);
     const messages = uiSnapshot ?? piMessagesToUIMessages(
-      buildSessionContext(sessionEntries).messages,
+      sessionEntries
+        .filter((entry): entry is SessionMessageEntry => entry.type === "message")
+        .map((entry) => entry.message),
     );
 
     const title = extractTitle(sessionEntries) ?? "New session";


### PR DESCRIPTION
Closes #132.

Implemented by the bclaw gh-picker (gpt-5.5) in an isolated worktree, then pushed for review.

---
Implemented in isolated worktree.

- worktree: `/home/ubuntu/projects/boring-ui-v2-issue-132`
- branch: `bclaw/issue-132-reload-full-transcript`
- commit: `dd92601b8a87c47d027bab00da0c9dd2a0afed0d`

What changed:
- `PiSessionStore.load()` now uses the latest `ui_snapshot` when present, but when no snapshot exists it rebuilds the UI transcript from **all persisted `message` entries in file order** instead of `buildSessionContext(sessionEntries).messages`.
- This avoids the compacted-tail fallback that was dropping pre-compaction transcript history on reload.
- Added a focused regression test for the no-snapshot + compaction case.

Verification:
- `cd packages/agent && pnpm test src/server/harness/pi-coding-agent/__tests__/sessions.load.test.ts src/server/harness/pi-coding-agent/__tests__/sessionMapping.conformance.test.ts` ✅ (7 tests passed)

Notes / caveat:
- This fix is intentionally localized to reload behavior. It does **not** change snapshot-writing behavior for long headless/factory runs.
- Branching caveat remains: the fallback now shows all persisted message entries in file order rather than the root→leaf compacted working context. For linear sessions this is the desired full transcript behavior; for branched sessions it may show branch history more explicitly, which is still preferable to silently dropping ~80% of the transcript on reload.

---
🤖 Auto-generated by bclaw gh-picker; opened via Claude Code. Review before merge.