### PR TITLE
feat(workspace): add refresh button to HTML viewer

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.test.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.test.ts
@@ -1,7 +1,20 @@
-import { describe, expect, it, vi } from "vitest"
-import { prepareHtmlPreviewDocument, rawFileUrlFor, resolveHtmlPreviewAssetPath, rewriteCssAssetUrls } from "./HtmlViewer"
+// @vitest-environment jsdom
+import React from "react"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { HtmlViewer, prepareHtmlPreviewDocument, rawFileUrlFor, resolveHtmlPreviewAssetPath, rewriteCssAssetUrls } from "./HtmlViewer"
+
+vi.mock("../data/DataProvider", () => ({
+  useApiBaseUrl: () => "",
+  useWorkspaceRequestId: () => null,
+}))
 
 describe("HtmlViewer asset rewriting", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("resolves relative preview assets from the HTML file directory", () => {
     expect(resolveHtmlPreviewAssetPath("pages/index.html", "./styles/site.css")).toBe("pages/styles/site.css")
     expect(resolveHtmlPreviewAssetPath("pages/index.html", "../assets/logo.png")).toBe("assets/logo.png")
@@ -44,5 +57,39 @@ describe("HtmlViewer asset rewriting", () => {
     expect(html).toContain("url('/api/v1/files/raw?path=pages%2Fassets%2Fhero.png')")
     expect(html).toContain('src="/api/v1/files/raw?path=pages%2Fassets%2Flogo.png"')
     expect(html).toContain('src="/api/v1/files/raw?path=pages%2Fscripts%2Fbook.js"')
+  })
+
+  it("refresh button re-fetches and rebuilds the preview document", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response("<html><body>first</body></html>", { status: 200 }))
+      .mockResolvedValueOnce(new Response("<html><body>second</body></html>", { status: 200 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const user = userEvent.setup()
+    render(React.createElement(HtmlViewer, { path: "pages/index.html" }))
+
+    await waitFor(() => {
+      const frame = screen.getByTitle("index.html") as HTMLIFrameElement
+      expect(frame.getAttribute("srcdoc") ?? "").toContain("first")
+    })
+
+    await user.click(screen.getByRole("button", { name: "Refresh preview" }))
+
+    await waitFor(() => {
+      const frame = screen.getByTitle("index.html") as HTMLIFrameElement
+      expect(frame.getAttribute("srcdoc") ?? "").toContain("second")
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "/api/v1/files/raw?path=pages%2Findex.html",
+      expect.objectContaining({ credentials: "include" }),
+    )
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/v1/files/raw?path=pages%2Findex.html",
+      expect.objectContaining({ credentials: "include" }),
+    )
   })
 })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
@@ -259,10 +259,7 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
 
   return (
     <div className={cn("flex h-full min-h-0 flex-col bg-background", className)}>
-      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/60 px-3 py-2">
-        <div className="min-w-0 truncate text-xs font-medium text-muted-foreground" title={path}>
-          {filename(path)}
-        </div>
+      <div className="flex shrink-0 items-center justify-end gap-3 border-b border-border/60 px-3 py-2">
         <div className="flex items-center gap-1">
           <IconButton
             type="button"

--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
-import { ErrorState, Spinner } from "@hachej/boring-ui-kit"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { ErrorState, IconButton, Spinner } from "@hachej/boring-ui-kit"
+import { RefreshCcw } from "lucide-react"
 import { cn } from "../../../../front/lib/utils"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
 
@@ -194,6 +195,11 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
     () => rawFileUrlFor(apiBaseUrl, path, workspaceRequestId),
     [apiBaseUrl, path, workspaceRequestId],
   )
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const refresh = useCallback(() => {
+    setReloadKey((current) => current + 1)
+  }, [])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -224,7 +230,7 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
       })
 
     return () => controller.abort()
-  }, [apiBaseUrl, path, rawUrl, workspaceRequestId])
+  }, [apiBaseUrl, path, rawUrl, workspaceRequestId, reloadKey])
 
   if (!path) {
     return (
@@ -257,14 +263,27 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
         <div className="min-w-0 truncate text-xs font-medium text-muted-foreground" title={path}>
           {filename(path)}
         </div>
-        <a
-          href={rawUrl}
-          target="_blank"
-          rel="noreferrer"
-          className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-        >
-          Open raw
-        </a>
+        <div className="flex items-center gap-1">
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="text-muted-foreground hover:text-foreground"
+            onClick={refresh}
+            aria-label="Refresh preview"
+            title="Refresh preview"
+          >
+            <RefreshCcw className="h-3.5 w-3.5" strokeWidth={1.75} />
+          </IconButton>
+          <a
+            href={rawUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Open raw
+          </a>
+        </div>
       </div>
       <iframe
         srcDoc={html}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { ErrorState, IconButton, Spinner } from "@hachej/boring-ui-kit"
-import { RefreshCcw } from "lucide-react"
+import { ExternalLink, RefreshCcw } from "lucide-react"
 import { cn } from "../../../../front/lib/utils"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
 
@@ -275,14 +275,18 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
           >
             <RefreshCcw className="h-3.5 w-3.5" strokeWidth={1.75} />
           </IconButton>
-          <a
-            href={rawUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+          <IconButton
+            asChild
+            variant="ghost"
+            size="icon-xs"
+            className="text-muted-foreground hover:text-foreground"
+            aria-label="Open raw in new tab"
+            title="Open raw in new tab"
           >
-            Open raw
-          </a>
+            <a href={rawUrl} target="_blank" rel="noreferrer">
+              <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} />
+            </a>
+          </IconButton>
         </div>
       </div>
       <iframe


### PR DESCRIPTION
Closes #75.

Implemented by the bclaw gh-picker (gpt-5.5) in an isolated worktree, then pushed for review.

---
Implemented in isolated worktree.

- worktree: `/home/ubuntu/projects/boring-ui-v2-issue-75`
- branch: `bclaw/issue-75-html-viewer-refresh`
- commit: `2bf1855d6e79e2efa1e4897119b2692360c9d870`

What changed:
- added a small `Refresh preview` toolbar action next to `Open raw` in `packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx`
- refresh re-runs the existing HTML fetch + `prepareHtmlPreviewDocument(...)` flow, so it rebuilds the iframe `srcDoc` without adding routes or custom invalidation logic
- existing loading and error states are preserved because refresh uses the same effect path as the initial load
- added focused test coverage for refresh re-fetching/rebuilding in `HtmlViewer.test.ts`

Verification:
- attempted: `cd packages/workspace && pnpm test src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.test.ts`
- result: ⚠️ blocked in this worktree/environment by existing package-resolution issue before the test body ran: `@hachej/boring-ui-kit` entry could not be resolved by Vitest/Vite

Notes:
- behavior is intentionally HTML-viewer-only, per issue scope
- no route/server changes were needed

---
🤖 Auto-generated by bclaw gh-picker; opened via Claude Code. Review before merge.