### PR TITLE
feat(workspace): make the chat panel collapsible

### DIFF
--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import type { DockviewApi } from "dockview-react"
-import { ChevronRight, FolderTree } from "lucide-react"
+import { FolderTree, PanelRightClose } from "lucide-react"
 import { Button, IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import { ArtifactSurfacePane } from "./ArtifactSurfacePane"
@@ -712,7 +712,7 @@ function WorkbenchCloseAction({ onClose }: { onClose: () => void }) {
       aria-label="Close workbench"
       title="Close workbench (⌘2)"
     >
-      <ChevronRight className="h-4 w-4" strokeWidth={1.75} />
+      <PanelRightClose className="h-4 w-4" strokeWidth={1.75} />
     </IconButton>
   )
 }

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import type { DockviewApi } from "dockview-react"
-import { FolderTree, PanelRightClose } from "lucide-react"
+import { ChevronRight, FolderTree } from "lucide-react"
 import { Button, IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import { ArtifactSurfacePane } from "./ArtifactSurfacePane"
@@ -712,7 +712,7 @@ function WorkbenchCloseAction({ onClose }: { onClose: () => void }) {
       aria-label="Close workbench"
       title="Close workbench (⌘2)"
     >
-      <PanelRightClose className="h-4 w-4" strokeWidth={1.75} />
+      <ChevronRight className="h-4 w-4" strokeWidth={1.75} />
     </IconButton>
   )
 }

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -318,13 +318,9 @@ export function ChatLayout(props: ChatLayoutProps) {
         ) : null}
       </aside>
 
-      <main
-        data-boring-workspace-part="chat-stage"
-        aria-label="Chat stage"
-        className="relative flex h-full min-h-0 min-w-0 flex-1 overflow-hidden bg-background"
-      >
-        <section
-          data-boring-workspace-part="chat-panel"
+      <div className="relative flex h-full min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+        <main
+          data-boring-workspace-part="chat-stage"
           data-boring-state={chatCollapsed ? "collapsed" : "expanded"}
           aria-label={chatCollapsed ? "Collapsed chat" : "Chat"}
           aria-hidden={chatCollapsed}
@@ -352,94 +348,100 @@ export function ChatLayout(props: ChatLayoutProps) {
               </IconButton>
             </>
           ) : null}
-        </section>
-        <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
-          {!navOpen && props.onOpenNav ? (
-            <FloatingEdgeButton
-              side="left"
-              icon="sessions"
-              onClick={props.onOpenNav}
-              label="Sessions"
-              hint="⌘1"
-            />
-          ) : null}
-          {chatCollapsed ? (
-            <FloatingEdgeButton
-              side="left"
-              icon="chat"
-              onClick={toggleChatCollapsed}
-              label="Expand chat"
-              hint="⌘\\"
-              stackIndex={!navOpen && props.onOpenNav ? 1 : 0}
-              pulse={chatRailPulse || blockers.length > 0}
-            />
-          ) : null}
-          {!surfaceOpen && props.onOpenSurface ? (
-            <FloatingEdgeButton
-              side="right"
-              icon="workbench"
-              onClick={props.onOpenSurface}
-              label="Workbench"
-              hint="⌘2"
-              bottomOffset={props.surfaceButtonBottomOffset}
-            />
-          ) : null}
-        </div>
-      </main>
+        </main>
 
-      {surfaceConfigured ? (
-        <aside
-          data-boring-workspace-part="workbench"
-          data-boring-state={surfaceOpen ? "expanded" : "collapsed"}
-          aria-label={surfaceOpen ? "Surface" : undefined}
-          aria-hidden={!surfaceOpen}
-          className={cn(
-            "relative h-full min-h-0 shrink-0 overflow-hidden bg-background",
-            "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
-            surfaceOpen && "border-l border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
-          )}
-          style={{
-            width: surfaceOpen ? effectiveSurfaceWidth : 0,
-            minWidth: surfaceOpen ? effectiveSurfaceWidth : 0,
-            maxWidth: surfaceOpen ? effectiveSurfaceWidth : 0,
-            willChange: "width",
-          }}
-        >
-          <div
+        {surfaceConfigured ? (
+          <aside
+            data-boring-workspace-part="workbench"
+            data-boring-state={surfaceOpen ? "expanded" : "collapsed"}
+            aria-label={surfaceOpen ? "Surface" : undefined}
+            aria-hidden={!surfaceOpen}
             className={cn(
-              "h-full min-h-0 overflow-hidden",
-              "transition-opacity duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
-              surfaceOpen ? "opacity-100" : "opacity-0",
+              "relative h-full min-h-0 overflow-hidden bg-background",
+              // When chat is collapsed the workbench grows to fill the freed
+              // space (full width); otherwise it's a fixed-width side panel.
+              chatCollapsed && surfaceOpen ? "min-w-0 flex-1" : "shrink-0",
+              "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+              surfaceOpen && "border-l border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
             )}
+            style={
+              chatCollapsed && surfaceOpen
+                ? { willChange: "width" }
+                : {
+                    width: surfaceOpen ? effectiveSurfaceWidth : 0,
+                    minWidth: surfaceOpen ? effectiveSurfaceWidth : 0,
+                    maxWidth: surfaceOpen ? effectiveSurfaceWidth : 0,
+                    willChange: "width",
+                  }
+            }
           >
-            {props.surfaceOverlay ? (
-              <div className="relative h-full min-h-0">
-                {props.surfaceOverlay}
-                {closeSurface ? (
-                  <IconButton
-                    type="button"
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={closeSurface}
-                    className="absolute right-3 top-3 z-20 rounded-full bg-background/80 text-muted-foreground shadow-sm backdrop-blur hover:bg-muted hover:text-foreground"
-                    aria-label="Close workbench"
-                    title="Close workbench (⌘2)"
-                  >
-                    <span aria-hidden="true">›</span>
-                  </IconButton>
-                ) : null}
-              </div>
-            ) : <PanelSlot id={surfaceId} params={props.surfaceParams} />}
-          </div>
-          {surfaceOpen ? (
-            <ResizeHandle
-              side="surface-left"
-              ariaLabel="Resize workbench"
-              onResize={(delta) => setSurfaceWidth((w) => clamp(w - delta, 480, surfaceMax))}
-            />
-          ) : null}
-        </aside>
-      ) : null}
+            <div
+              className={cn(
+                "h-full min-h-0 overflow-hidden",
+                "transition-opacity duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+                surfaceOpen ? "opacity-100" : "opacity-0",
+              )}
+            >
+              {props.surfaceOverlay ? (
+                <div className="relative h-full min-h-0">
+                  {props.surfaceOverlay}
+                  {closeSurface ? (
+                    <IconButton
+                      type="button"
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={closeSurface}
+                      className="absolute right-3 top-3 z-20 rounded-full bg-background/80 text-muted-foreground shadow-sm backdrop-blur hover:bg-muted hover:text-foreground"
+                      aria-label="Close workbench"
+                      title="Close workbench (⌘2)"
+                    >
+                      <span aria-hidden="true">›</span>
+                    </IconButton>
+                  ) : null}
+                </div>
+              ) : <PanelSlot id={surfaceId} params={props.surfaceParams} />}
+            </div>
+            {surfaceOpen && !chatCollapsed ? (
+              <ResizeHandle
+                side="surface-left"
+                ariaLabel="Resize workbench"
+                onResize={(delta) => setSurfaceWidth((w) => clamp(w - delta, 480, surfaceMax))}
+              />
+            ) : null}
+          </aside>
+        ) : null}
+
+        {!navOpen && props.onOpenNav ? (
+          <FloatingEdgeButton
+            side="left"
+            icon="sessions"
+            onClick={props.onOpenNav}
+            label="Sessions"
+            hint="⌘1"
+          />
+        ) : null}
+        {chatCollapsed ? (
+          <FloatingEdgeButton
+            side="left"
+            icon="chat"
+            onClick={toggleChatCollapsed}
+            label="Expand chat"
+            hint="⌘\\"
+            stackIndex={!navOpen && props.onOpenNav ? 1 : 0}
+            pulse={chatRailPulse || blockers.length > 0}
+          />
+        ) : null}
+        {!surfaceOpen && props.onOpenSurface ? (
+          <FloatingEdgeButton
+            side="right"
+            icon="workbench"
+            onClick={props.onOpenSurface}
+            label="Workbench"
+            hint="⌘2"
+            bottomOffset={props.surfaceButtonBottomOffset}
+          />
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,8 +1,9 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
+import { ChevronLeft, ChevronRight, MessageSquare } from "lucide-react"
 import { cn } from "../lib/utils"
 import { dispatchUiCommand, type DispatchContext } from "../bridge"
-import { events, workspaceEvents } from "../events"
+import { events, useEvent, workspaceEvents } from "../events"
 import { useKeyboardShortcuts, type ShortcutBinding } from "../hooks/useKeyboardShortcuts"
 import type { SurfaceShellApi } from "../chrome/artifact-surface/SurfaceShell"
 import type { LayoutConfig, GroupConfig } from "../dock"
@@ -10,7 +11,7 @@ import { useCommandRegistry, useRegistry } from "../registry"
 import type { PaneProps } from "../registry/types"
 import { readStoredNumber, writeStoredNumber } from "../store/localStorageValues"
 import type { ChatLayoutProps } from "./types"
-import { useWorkspaceContext } from "../provider"
+import { useWorkspaceAttention, useWorkspaceContext } from "../provider"
 
 export function buildChatLayout(props: ChatLayoutProps = {}): LayoutConfig {
   const {
@@ -43,6 +44,8 @@ export function buildChatLayout(props: ChatLayoutProps = {}): LayoutConfig {
     panel: center,
     params: centerParams,
     hideHeader: true,
+    collapsible: true,
+    collapsedWidth: 40,
   })
 
   if (sidebar) {
@@ -89,6 +92,12 @@ export function ChatLayout(props: ChatLayoutProps) {
     props.storageKey ? `${props.storageKey}:surfaceWidth` : undefined,
     680,
   )
+  const [chatCollapsed, setChatCollapsed] = useStoredBooleanState(
+    props.storageKey ? `${props.storageKey}:chatCollapsed` : undefined,
+    false,
+  )
+  const [chatRailPulse, setChatRailPulse] = useState(false)
+  const { blockers } = useWorkspaceAttention()
   const commandRegistry = useCommandRegistry()
   const effectiveNavWidth = clamp(navWidth, 200, 360)
   const surfaceMax = Math.max(480, Math.floor(viewport * 0.72))
@@ -128,11 +137,17 @@ export function ChatLayout(props: ChatLayoutProps) {
     props.onOpenSidebar?.()
   }, [closeSidebar, props.onOpenSidebar, sidebarOpen])
   const focusChat = useCallback(() => {
+    if (chatCollapsed) setChatCollapsed(false)
     if (navOpen) closeNav?.()
     if (surfaceOpen) closeSurface?.()
     focusAgentComposer()
     scheduleComposerFocus()
-  }, [closeNav, closeSurface, navOpen, surfaceOpen])
+  }, [chatCollapsed, closeNav, closeSurface, navOpen, setChatCollapsed, surfaceOpen])
+
+  const toggleChatCollapsed = useCallback(() => {
+    setChatCollapsed((current) => !current)
+    setChatRailPulse(false)
+  }, [setChatCollapsed])
 
   useKeyboardShortcuts({
     shortcuts: useMemo(() => {
@@ -148,9 +163,10 @@ export function ChatLayout(props: ChatLayoutProps) {
       }
       if (centerId === "chat") {
         shortcuts.push({ key: "Escape", allowInEditable: true, handler: focusChat })
+        shortcuts.push({ key: "\\", mod: true, allowInEditable: true, handler: toggleChatCollapsed })
       }
       return shortcuts
-    }, [canControlNav, canControlSidebar, canControlSurface, centerId, focusChat, toggleNav, toggleSidebar, toggleSurface]),
+    }, [canControlNav, canControlSidebar, canControlSurface, centerId, focusChat, toggleChatCollapsed, toggleNav, toggleSidebar, toggleSurface]),
   })
 
   useEffect(() => {
@@ -247,6 +263,22 @@ export function ChatLayout(props: ChatLayoutProps) {
     })
   }, [uiSurface, uiIsWorkbenchOpen, uiOpenWorkbench, uiOpenWorkbenchSources, uiCloseWorkbench])
 
+  useEvent(workspaceEvents.agentData, () => {
+    if (chatCollapsed) setChatRailPulse(true)
+  })
+
+  useEffect(() => {
+    if (!chatCollapsed) {
+      setChatRailPulse(false)
+      return
+    }
+    if (blockers.length > 0) {
+      setChatCollapsed(false)
+      setChatRailPulse(false)
+      scheduleComposerFocus()
+    }
+  }, [blockers.length, chatCollapsed, setChatCollapsed])
+
   return (
     <div
       data-boring-workspace=""
@@ -291,28 +323,77 @@ export function ChatLayout(props: ChatLayoutProps) {
       <main
         data-boring-workspace-part="chat-stage"
         aria-label="Chat stage"
-        className="relative h-full min-h-0 min-w-0 flex-1 overflow-hidden bg-background"
+        className="relative flex h-full min-h-0 min-w-0 flex-1 overflow-hidden bg-background"
       >
-        <PanelSlot id={centerId} params={props.centerParams} />
-        {!navOpen && props.onOpenNav ? (
-          <FloatingEdgeButton
-            side="left"
-            icon="sessions"
-            onClick={props.onOpenNav}
-            label="Sessions"
-            hint="⌘1"
-          />
-        ) : null}
-        {!surfaceOpen && props.onOpenSurface ? (
-          <FloatingEdgeButton
-            side="right"
-            icon="workbench"
-            onClick={props.onOpenSurface}
-            label="Workbench"
-            hint="⌘2"
-            bottomOffset={props.surfaceButtonBottomOffset}
-          />
-        ) : null}
+        <section
+          data-boring-workspace-part="chat-panel"
+          data-boring-state={chatCollapsed ? "collapsed" : "expanded"}
+          aria-label={chatCollapsed ? "Collapsed chat" : "Chat"}
+          className={cn(
+            "relative h-full min-h-0 shrink-0 overflow-hidden bg-background",
+            "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+            !chatCollapsed && "border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
+          )}
+          style={{
+            width: chatCollapsed ? 40 : undefined,
+            minWidth: chatCollapsed ? 40 : undefined,
+            maxWidth: chatCollapsed ? 40 : undefined,
+          }}
+        >
+          {!chatCollapsed ? (
+            <>
+              <PanelSlot id={centerId} params={props.centerParams} />
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={toggleChatCollapsed}
+                className="absolute right-2 top-2 z-20"
+                aria-label="Collapse chat"
+                title="Collapse chat (⌘\\)"
+              >
+                <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
+              </IconButton>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={toggleChatCollapsed}
+              className="flex h-full w-full flex-col items-center justify-start gap-2 border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)] bg-background px-1 py-2 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+              aria-label="Expand chat"
+              title="Expand chat (⌘\\)"
+            >
+              <ChevronRight className="h-4 w-4" strokeWidth={1.75} />
+              <div className="relative flex items-center justify-center">
+                <MessageSquare className="h-4 w-4" strokeWidth={1.75} />
+                {(chatRailPulse || blockers.length > 0) ? (
+                  <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-[color:var(--accent)]" aria-hidden="true" />
+                ) : null}
+              </div>
+            </button>
+          )}
+        </section>
+        <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
+          {!navOpen && props.onOpenNav ? (
+            <FloatingEdgeButton
+              side="left"
+              icon="sessions"
+              onClick={props.onOpenNav}
+              label="Sessions"
+              hint="⌘1"
+            />
+          ) : null}
+          {!surfaceOpen && props.onOpenSurface ? (
+            <FloatingEdgeButton
+              side="right"
+              icon="workbench"
+              onClick={props.onOpenSurface}
+              label="Workbench"
+              hint="⌘2"
+              bottomOffset={props.surfaceButtonBottomOffset}
+            />
+          ) : null}
+        </div>
       </main>
 
       {surfaceConfigured ? (
@@ -377,6 +458,7 @@ function clamp(n: number, min: number, max: number): number {
 }
 
 type StoredNumberUpdate = number | ((previous: number) => number)
+type StoredBooleanUpdate = boolean | ((previous: boolean) => boolean)
 
 function useStoredNumberState(
   key: string | undefined,
@@ -395,6 +477,40 @@ function useStoredNumberState(
       setValue((previous) => {
         const resolved = typeof next === "function" ? next(previous) : next
         if (key) writeStoredNumber(key, resolved)
+        return resolved
+      })
+    },
+    [key],
+  )
+
+  return [value, setStoredValue]
+}
+
+function useStoredBooleanState(
+  key: string | undefined,
+  fallback: boolean,
+): [boolean, (next: StoredBooleanUpdate) => void] {
+  const [value, setValue] = useState(() => {
+    if (!key || typeof window === "undefined") return fallback
+    return window.localStorage.getItem(key) === "1"
+  })
+
+  useEffect(() => {
+    if (!key || typeof window === "undefined") {
+      setValue(fallback)
+      return
+    }
+    const stored = window.localStorage.getItem(key)
+    setValue(stored == null ? fallback : stored === "1")
+  }, [key, fallback])
+
+  const setStoredValue = useCallback(
+    (next: StoredBooleanUpdate) => {
+      setValue((previous) => {
+        const resolved = typeof next === "function" ? next(previous) : next
+        if (key && typeof window !== "undefined") {
+          window.localStorage.setItem(key, resolved ? "1" : "0")
+        }
         return resolved
       })
     },

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
-import { MessageSquare, PanelLeftClose } from "lucide-react"
+import { ChevronLeft, MessageSquare } from "lucide-react"
 import { cn } from "../lib/utils"
 import { dispatchUiCommand, type DispatchContext } from "../bridge"
 import { events, useEvent, workspaceEvents } from "../events"
@@ -361,7 +361,7 @@ export function ChatLayout(props: ChatLayoutProps) {
             // like the fixed-width nav/workbench panes instead of snapping.
             "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
             chatCollapsed
-              ? "w-0 min-w-0 flex-[0_0_0px]"
+              ? "min-w-0 flex-[0_0_0px]"
               : "flex-1 border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
           )}
         >
@@ -384,7 +384,7 @@ export function ChatLayout(props: ChatLayoutProps) {
               aria-label="Collapse chat"
               title="Collapse chat (⌘\\)"
             >
-              <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
+              <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
             </IconButton>
           ) : null}
         </main>

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -143,9 +143,15 @@ export function ChatLayout(props: ChatLayoutProps) {
   }, [chatCollapsed, closeNav, closeSurface, navOpen, setChatCollapsed, surfaceOpen])
 
   const toggleChatCollapsed = useCallback(() => {
-    setChatCollapsed((current) => !current)
+    setChatCollapsed((current) => {
+      const next = !current
+      // Collapsing the chat opens the workbench so the freed space is filled
+      // instead of leaving an empty canvas.
+      if (next && !surfaceOpen) props.onOpenSurface?.()
+      return next
+    })
     setChatRailPulse(false)
-  }, [setChatCollapsed])
+  }, [setChatCollapsed, surfaceOpen, props.onOpenSurface])
 
   useKeyboardShortcuts({
     shortcuts: useMemo(() => {
@@ -430,39 +436,41 @@ export function ChatLayout(props: ChatLayoutProps) {
           </aside>
         ) : null}
 
-        {!navOpen && props.onOpenNav ? (
-          <FloatingEdgeButton
-            side="left"
-            icon="sessions"
-            onClick={props.onOpenNav}
-            label="Sessions"
-            hint="⌘1"
-          />
-        ) : null}
-        {chatCollapsed ? (
-          <FloatingEdgeButton
-            side="left"
-            icon="chat"
-            onClick={toggleChatCollapsed}
-            label="Expand chat"
-            hint="⌘\\"
-            // Fixed slot above the Sessions button so it doesn't shift when the
-            // session drawer opens/closes (the Sessions button comes/goes).
-            stackIndex={1}
-            pulse={chatRailPulse || blockers.length > 0}
-          />
-        ) : null}
-        {!surfaceOpen && props.onOpenSurface ? (
-          <FloatingEdgeButton
-            side="right"
-            icon="workbench"
-            onClick={props.onOpenSurface}
-            label="Workbench"
-            hint="⌘2"
-            bottomOffset={props.surfaceButtonBottomOffset}
-          />
-        ) : null}
       </div>
+
+      {!navOpen && props.onOpenNav ? (
+        <FloatingEdgeButton
+          side="left"
+          icon="sessions"
+          onClick={props.onOpenNav}
+          label="Sessions"
+          hint="⌘1"
+        />
+      ) : null}
+      {chatCollapsed ? (
+        <FloatingEdgeButton
+          side="left"
+          icon="chat"
+          onClick={toggleChatCollapsed}
+          label="Expand chat"
+          hint="⌘\\"
+          // Anchored to the shell's left edge (not the content region) so it
+          // stays pinned to the left even when the session drawer is open and
+          // pushes the content rightward.
+          stackIndex={1}
+          pulse={chatRailPulse || blockers.length > 0}
+        />
+      ) : null}
+      {!surfaceOpen && props.onOpenSurface ? (
+        <FloatingEdgeButton
+          side="right"
+          icon="workbench"
+          onClick={props.onOpenSurface}
+          label="Workbench"
+          hint="⌘2"
+          bottomOffset={props.surfaceButtonBottomOffset}
+        />
+      ) : null}
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -277,6 +277,19 @@ export function ChatLayout(props: ChatLayoutProps) {
     }
   }, [blockers.length, chatCollapsed, setChatCollapsed])
 
+  // Switching to a different session re-opens the chat if it was collapsed, so
+  // the newly selected conversation is visible. Skips the initial mount (only
+  // reacts to an actual change of the active session id).
+  const activeSessionId = props.centerParams?.sessionId as string | undefined
+  const prevSessionIdRef = useRef(activeSessionId)
+  useEffect(() => {
+    const prev = prevSessionIdRef.current
+    prevSessionIdRef.current = activeSessionId
+    if (prev !== undefined && activeSessionId !== undefined && activeSessionId !== prev && chatCollapsed) {
+      setChatCollapsed(false)
+    }
+  }, [activeSessionId, chatCollapsed, setChatCollapsed])
+
   return (
     <div
       data-boring-workspace=""
@@ -332,21 +345,27 @@ export function ChatLayout(props: ChatLayoutProps) {
               : "flex-1 border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
           )}
         >
+          <div
+            className={cn(
+              "h-full min-h-0 overflow-hidden",
+              "transition-opacity duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+              chatCollapsed ? "opacity-0" : "opacity-100",
+            )}
+          >
+            <PanelSlot id={centerId} params={props.centerParams} />
+          </div>
           {!chatCollapsed ? (
-            <>
-              <PanelSlot id={centerId} params={props.centerParams} />
-              <IconButton
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                onClick={toggleChatCollapsed}
-                className="absolute right-2 top-2 z-20"
-                aria-label="Collapse chat"
-                title="Collapse chat (⌘\\)"
-              >
-                <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
-              </IconButton>
-            </>
+            <IconButton
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={toggleChatCollapsed}
+              className="absolute right-2 top-2 z-20"
+              aria-label="Collapse chat"
+              title="Collapse chat (⌘\\)"
+            >
+              <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
+            </IconButton>
           ) : null}
         </main>
 
@@ -427,7 +446,9 @@ export function ChatLayout(props: ChatLayoutProps) {
             onClick={toggleChatCollapsed}
             label="Expand chat"
             hint="⌘\\"
-            stackIndex={!navOpen && props.onOpenNav ? 1 : 0}
+            // Fixed slot above the Sessions button so it doesn't shift when the
+            // session drawer opens/closes (the Sessions button comes/goes).
+            stackIndex={1}
             pulse={chatRailPulse || blockers.length > 0}
           />
         ) : null}

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
-import { ChevronLeft, ChevronRight, MessageSquare } from "lucide-react"
+import { ChevronLeft, MessageSquare } from "lucide-react"
 import { cn } from "../lib/utils"
 import { dispatchUiCommand, type DispatchContext } from "../bridge"
 import { events, useEvent, workspaceEvents } from "../events"
@@ -44,8 +44,6 @@ export function buildChatLayout(props: ChatLayoutProps = {}): LayoutConfig {
     panel: center,
     params: centerParams,
     hideHeader: true,
-    collapsible: true,
-    collapsedWidth: 40,
   })
 
   if (sidebar) {
@@ -329,16 +327,14 @@ export function ChatLayout(props: ChatLayoutProps) {
           data-boring-workspace-part="chat-panel"
           data-boring-state={chatCollapsed ? "collapsed" : "expanded"}
           aria-label={chatCollapsed ? "Collapsed chat" : "Chat"}
+          aria-hidden={chatCollapsed}
           className={cn(
-            "relative h-full min-h-0 shrink-0 overflow-hidden bg-background",
-            "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
-            !chatCollapsed && "border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
+            "relative h-full min-h-0 min-w-0 overflow-hidden bg-background",
+            "transition-[width,min-width,max-width,flex-basis] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+            chatCollapsed
+              ? "w-0 min-w-0 flex-[0_0_0px]"
+              : "flex-1 border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
           )}
-          style={{
-            width: chatCollapsed ? 40 : undefined,
-            minWidth: chatCollapsed ? 40 : undefined,
-            maxWidth: chatCollapsed ? 40 : undefined,
-          }}
         >
           {!chatCollapsed ? (
             <>
@@ -355,23 +351,7 @@ export function ChatLayout(props: ChatLayoutProps) {
                 <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
               </IconButton>
             </>
-          ) : (
-            <button
-              type="button"
-              onClick={toggleChatCollapsed}
-              className="flex h-full w-full flex-col items-center justify-start gap-2 border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)] bg-background px-1 py-2 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
-              aria-label="Expand chat"
-              title="Expand chat (⌘\\)"
-            >
-              <ChevronRight className="h-4 w-4" strokeWidth={1.75} />
-              <div className="relative flex items-center justify-center">
-                <MessageSquare className="h-4 w-4" strokeWidth={1.75} />
-                {(chatRailPulse || blockers.length > 0) ? (
-                  <span className="absolute -right-1 -top-1 h-2 w-2 rounded-full bg-[color:var(--accent)]" aria-hidden="true" />
-                ) : null}
-              </div>
-            </button>
-          )}
+          ) : null}
         </section>
         <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden bg-background">
           {!navOpen && props.onOpenNav ? (
@@ -381,6 +361,17 @@ export function ChatLayout(props: ChatLayoutProps) {
               onClick={props.onOpenNav}
               label="Sessions"
               hint="⌘1"
+            />
+          ) : null}
+          {chatCollapsed ? (
+            <FloatingEdgeButton
+              side="left"
+              icon="chat"
+              onClick={toggleChatCollapsed}
+              label="Expand chat"
+              hint="⌘\\"
+              stackIndex={!navOpen && props.onOpenNav ? 1 : 0}
+              pulse={chatRailPulse || blockers.length > 0}
             />
           ) : null}
           {!surfaceOpen && props.onOpenSurface ? (
@@ -661,15 +652,23 @@ function FloatingEdgeButton({
   label,
   hint,
   bottomOffset,
+  stackIndex = 0,
+  pulse = false,
 }: {
   side: "left" | "right"
-  icon: "sessions" | "workbench"
+  icon: "sessions" | "workbench" | "chat"
   onClick: () => void
   label: string
   hint?: string
   bottomOffset?: number
+  // Stack offset for multiple buttons sharing the same vertical edge anchor.
+  // Each step lifts the button by one button-height + gap above the previous.
+  stackIndex?: number
+  pulse?: boolean
 }) {
   const dockToBottom = side === "right" && bottomOffset !== undefined
+  // Buttons are h-9 (36px); stack them with a 8px gap so they never overlap.
+  const stackOffset = stackIndex * 44
   return (
     <IconButton
       type="button"
@@ -681,18 +680,29 @@ function FloatingEdgeButton({
       className={cn(
         "absolute z-30 h-9 w-9 gap-0.5 rounded-lg bg-background text-muted-foreground",
         side === "left" ? "left-2" : "right-2",
-        dockToBottom ? "hover:-translate-y-0.5" : "top-1/2 -translate-y-1/2 hover:-translate-y-[calc(50%+1px)]",
+        dockToBottom ? "hover:-translate-y-0.5" : "top-1/2 hover:-translate-y-[1px]",
         "shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_8px_-4px_oklch(0_0_0/0.10),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.7)]",
         "hover:bg-muted/60 hover:text-foreground hover:shadow-[0_2px_4px_-1px_oklch(0_0_0/0.08),0_4px_12px_-4px_oklch(0_0_0/0.10),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.9)]",
         "focus-visible:ring-ring/40",
       )}
-      style={dockToBottom ? { bottom: bottomOffset } : undefined}
+      style={
+        dockToBottom
+          ? { bottom: bottomOffset }
+          : { transform: `translateY(calc(-50% - ${stackOffset}px))` }
+      }
     >
       {icon === "sessions" ? (
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
           <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.8" />
           <path d="M12 7v5l3.2 2" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
         </svg>
+      ) : icon === "chat" ? (
+        <span className="relative flex items-center justify-center">
+          <MessageSquare className="h-[15px] w-[15px]" strokeWidth={1.8} aria-hidden="true" />
+          {pulse ? (
+            <span className="absolute -right-1.5 -top-1.5 h-2 w-2 rounded-full bg-[color:var(--accent)]" aria-hidden="true" />
+          ) : null}
+        </span>
       ) : (
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
           <path d="M3 7.5 A1.5 1.5 0 0 1 4.5 6 h4 l2 2 h9 A1.5 1.5 0 0 1 21 9.5 V17.5 A1.5 1.5 0 0 1 19.5 19 H4.5 A1.5 1.5 0 0 1 3 17.5 Z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -296,6 +296,18 @@ export function ChatLayout(props: ChatLayoutProps) {
     }
   }, [activeSessionId, chatCollapsed, setChatCollapsed])
 
+  // Never leave a blank middle: if the workbench is closed while the chat is
+  // collapsed, re-open the chat. Mirror of "collapsing the chat opens the
+  // workbench" so at least one of the two is always visible.
+  const prevSurfaceOpenRef = useRef(surfaceOpen)
+  useEffect(() => {
+    const prevOpen = prevSurfaceOpenRef.current
+    prevSurfaceOpenRef.current = surfaceOpen
+    if (prevOpen && !surfaceOpen && chatCollapsed) {
+      setChatCollapsed(false)
+    }
+  }, [surfaceOpen, chatCollapsed, setChatCollapsed])
+
   return (
     <div
       data-boring-workspace=""

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -415,8 +415,12 @@ export function ChatLayout(props: ChatLayoutProps) {
             <div
               className={cn(
                 "h-full min-h-0 overflow-hidden",
-                "transition-opacity duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+                "transition-[opacity,padding] duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
                 surfaceOpen ? "opacity-100" : "opacity-0",
+                // When the chat is collapsed the workbench fills the full width
+                // and the left-edge "expand chat" float button would sit on top
+                // of the filetree — inset the content to leave a clear gutter.
+                chatCollapsed && surfaceOpen && !navOpen && "pl-14",
               )}
             >
               {props.surfaceOverlay ? (

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
-import { ChevronLeft, MessageSquare } from "lucide-react"
+import { MessageSquare, PanelLeftClose } from "lucide-react"
 import { cn } from "../lib/utils"
 import { dispatchUiCommand, type DispatchContext } from "../bridge"
 import { events, useEvent, workspaceEvents } from "../events"
@@ -357,7 +357,9 @@ export function ChatLayout(props: ChatLayoutProps) {
           aria-hidden={chatCollapsed}
           className={cn(
             "relative h-full min-h-0 min-w-0 overflow-hidden bg-background",
-            "transition-[width,min-width,max-width,flex-basis] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+            // Animate flex-grow (not just width) so the chat slides open/closed
+            // like the fixed-width nav/workbench panes instead of snapping.
+            "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
             chatCollapsed
               ? "w-0 min-w-0 flex-[0_0_0px]"
               : "flex-1 border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
@@ -382,7 +384,7 @@ export function ChatLayout(props: ChatLayoutProps) {
               aria-label="Collapse chat"
               title="Collapse chat (⌘\\)"
             >
-              <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
+              <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
             </IconButton>
           ) : null}
         </main>
@@ -398,7 +400,7 @@ export function ChatLayout(props: ChatLayoutProps) {
               // When chat is collapsed the workbench grows to fill the freed
               // space (full width); otherwise it's a fixed-width side panel.
               chatCollapsed && surfaceOpen ? "min-w-0 flex-1" : "shrink-0",
-              "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+              "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
               surfaceOpen && "border-l border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
             )}
             style={

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -10,7 +10,7 @@ import { PanelRegistry } from "../../registry/PanelRegistry"
 import { CommandRegistry } from "../../../shared/plugins/CommandRegistry"
 import { bindStore } from "../../store/selectors"
 import { createWorkspaceStore } from "../../store"
-import { WorkspaceProvider } from "../../provider"
+import { WorkspaceProvider, useWorkspaceAttention } from "../../provider"
 import type { SurfaceShellApi } from "../../chrome/artifact-surface/SurfaceShell"
 
 // Verify barrel exports work
@@ -538,10 +538,10 @@ describe("ChatLayout component", () => {
     const chatPanel = screen.getByLabelText("Chat")
     expect(chatPanel).toHaveAttribute("data-boring-state", "expanded")
 
-    fireShortcut("\\", { metaKey: true })
+    act(() => fireShortcut("\\", { metaKey: true }))
     expect(screen.getByLabelText("Collapsed chat")).toHaveAttribute("data-boring-state", "collapsed")
 
-    fireShortcut("\\", { metaKey: true })
+    act(() => fireShortcut("\\", { metaKey: true }))
     expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded")
   })
 
@@ -551,19 +551,19 @@ describe("ChatLayout component", () => {
       ["chat", "session-list"],
     )
 
-    fireShortcut("\\", { metaKey: true })
+    act(() => fireShortcut("\\", { metaKey: true }))
     expect(screen.getByRole("button", { name: "Expand chat" })).toBeInTheDocument()
   })
 
-  it("auto-expands the chat panel when a blocker appears while collapsed", () => {
+  it("auto-expands the chat panel when a blocker appears while collapsed", async () => {
     function Host() {
-      const { addBlocker } = require("../../provider").useWorkspaceAttention()
+      const { addBlocker } = useWorkspaceAttention()
       return (
         <>
           <ChatLayout center="chat" storageKey="chat-layout-blocker" />
           <button
             type="button"
-            onClick={() => addBlocker({ id: "b1", label: "Approve", kind: "prompt" })}
+            onClick={() => addBlocker({ id: "b1", reason: "Approve", label: "Approve" })}
           >
             Add blocker
           </button>
@@ -574,11 +574,13 @@ describe("ChatLayout component", () => {
     const user = userEvent.setup()
     renderWithRegistry(<Host />, ["chat", "session-list"])
 
-    fireShortcut("\\", { metaKey: true })
+    act(() => fireShortcut("\\", { metaKey: true }))
     expect(screen.getByLabelText("Collapsed chat")).toHaveAttribute("data-boring-state", "collapsed")
 
-    user.click(screen.getByRole("button", { name: "Add blocker" }))
-    expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded")
+    await user.click(screen.getByRole("button", { name: "Add blocker" }))
+    await waitFor(() =>
+      expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded"),
+    )
   })
 
   it("dispatches plugin UI commands through the workbench contract", () => {

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -166,8 +166,9 @@ describe("buildChatLayout", () => {
     expect(center.position).toBe("center")
     expect(center.panel).toBe("chat")
     expect(center.hideHeader).toBe(true)
-    expect(center.collapsible).toBe(true)
-    expect(center.collapsedWidth).toBe(40)
+    // Collapse is handled by the live flex ChatLayout component, not dock config.
+    expect(center.collapsible).toBeUndefined()
+    expect(center.collapsedWidth).toBeUndefined()
   })
 
   it("passes panel params through to layout groups", () => {
@@ -545,14 +546,43 @@ describe("ChatLayout component", () => {
     expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded")
   })
 
-  it("shows a collapsed chat rail affordance", () => {
+  it("collapses the chat to zero width and shows a floating expand button", () => {
     renderWithRegistry(
       <ChatLayout center="chat" storageKey="chat-layout-rail" />,
       ["chat", "session-list"],
     )
 
+    expect(screen.queryByRole("button", { name: "Expand chat" })).not.toBeInTheDocument()
+
     act(() => fireShortcut("\\", { metaKey: true }))
+
+    // The chat panel collapses to zero width (no 40px rail) ...
+    const collapsed = screen.getByLabelText("Collapsed chat")
+    expect(collapsed).toHaveAttribute("data-boring-state", "collapsed")
+    expect(collapsed).toHaveAttribute("aria-hidden", "true")
+    // ... and re-opening is a floating left-edge button.
     expect(screen.getByRole("button", { name: "Expand chat" })).toBeInTheDocument()
+
+    act(() => fireShortcut("\\", { metaKey: true }))
+    expect(screen.queryByRole("button", { name: "Expand chat" })).not.toBeInTheDocument()
+    expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded")
+  })
+
+  it("stacks the floating expand-chat button above the sessions button on the left edge", () => {
+    renderWithRegistry(
+      <ChatLayout center="chat" nav={null} onOpenNav={vi.fn()} storageKey="chat-layout-stack" />,
+      ["chat", "session-list"],
+    )
+
+    act(() => fireShortcut("\\", { metaKey: true }))
+
+    const sessionsButton = screen.getByRole("button", { name: "Sessions" })
+    const chatButton = screen.getByRole("button", { name: "Expand chat" })
+    // Both anchor to the left edge and are vertically offset so they never overlap.
+    expect(sessionsButton.className).toContain("left-2")
+    expect(chatButton.className).toContain("left-2")
+    expect(sessionsButton.style.transform).toContain("translateY(calc(-50% - 0px))")
+    expect(chatButton.style.transform).toContain("translateY(calc(-50% - 44px))")
   })
 
   it("auto-expands the chat panel when a blocker appears while collapsed", async () => {

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -166,6 +166,8 @@ describe("buildChatLayout", () => {
     expect(center.position).toBe("center")
     expect(center.panel).toBe("chat")
     expect(center.hideHeader).toBe(true)
+    expect(center.collapsible).toBe(true)
+    expect(center.collapsedWidth).toBe(40)
   })
 
   it("passes panel params through to layout groups", () => {
@@ -525,6 +527,58 @@ describe("ChatLayout component", () => {
 
     expect(openNav).toHaveBeenCalledOnce()
     expect(openSurface).toHaveBeenCalledOnce()
+  })
+
+  it("collapses and re-expands the chat panel with the keyboard shortcut", () => {
+    renderWithRegistry(
+      <ChatLayout center="chat" storageKey="chat-layout-test" />,
+      ["chat", "session-list"],
+    )
+
+    const chatPanel = screen.getByLabelText("Chat")
+    expect(chatPanel).toHaveAttribute("data-boring-state", "expanded")
+
+    fireShortcut("\\", { metaKey: true })
+    expect(screen.getByLabelText("Collapsed chat")).toHaveAttribute("data-boring-state", "collapsed")
+
+    fireShortcut("\\", { metaKey: true })
+    expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded")
+  })
+
+  it("shows a collapsed chat rail affordance", () => {
+    renderWithRegistry(
+      <ChatLayout center="chat" storageKey="chat-layout-rail" />,
+      ["chat", "session-list"],
+    )
+
+    fireShortcut("\\", { metaKey: true })
+    expect(screen.getByRole("button", { name: "Expand chat" })).toBeInTheDocument()
+  })
+
+  it("auto-expands the chat panel when a blocker appears while collapsed", () => {
+    function Host() {
+      const { addBlocker } = require("../../provider").useWorkspaceAttention()
+      return (
+        <>
+          <ChatLayout center="chat" storageKey="chat-layout-blocker" />
+          <button
+            type="button"
+            onClick={() => addBlocker({ id: "b1", label: "Approve", kind: "prompt" })}
+          >
+            Add blocker
+          </button>
+        </>
+      )
+    }
+
+    const user = userEvent.setup()
+    renderWithRegistry(<Host />, ["chat", "session-list"])
+
+    fireShortcut("\\", { metaKey: true })
+    expect(screen.getByLabelText("Collapsed chat")).toHaveAttribute("data-boring-state", "collapsed")
+
+    user.click(screen.getByRole("button", { name: "Add blocker" }))
+    expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded")
   })
 
   it("dispatches plugin UI commands through the workbench contract", () => {


### PR DESCRIPTION
Closes #54.

Implemented by the bclaw gh-picker (gpt-5.5) in an isolated worktree, then pushed for review.

---
Implemented in isolated worktree.

- worktree: `/home/ubuntu/projects/boring-ui-v2-issue-54`
- branch: `bclaw/issue-54-collapsible-chat-panel`
- commit: `1ad0e61e586ad94573e5b494308f180cd4aa8729`

What changed:
- marked the center chat group in `buildChatLayout()` as `collapsible: true` with `collapsedWidth: 40`
- added persisted collapsed state in `ChatLayout` using the same local-storage pattern as width persistence (`${storageKey}:chatCollapsed`)
- added a collapse chevron on the chat panel itself
- when collapsed, chat becomes a thin vertical rail with expand affordance + chat icon
- added a lightweight rail indicator that lights up when agent data arrives while chat is collapsed
- added `Cmd/Ctrl+\` shortcut to collapse/expand the chat panel
- auto-expands the chat again when workspace attention blockers appear while collapsed (blocking prompt path)
- added focused `ChatLayout` test coverage for config + keyboard collapse/expand + collapsed rail + blocker-driven re-expand

Verification:
- attempted: `cd packages/workspace && pnpm test src/front/layout/__tests__/presets.test.tsx`
- result: ⚠️ blocked in this worktree/environment by existing package-resolution issue before the test body ran: `@hachej/boring-ui-kit` entry could not be resolved by Vitest/Vite

Notes / caveats:
- This keeps scope in the workspace layout layer; it does not detach/remove chat, only collapse-to-rail.
- The collapsed rail uses an indicator pulse on incoming agent-data events and auto-expands only for blocker states, matching the issue’s recommended behavior more closely than always auto-expanding on any message.

---
🤖 Auto-generated by bclaw gh-picker; opened via Claude Code. Review before merge.