### PR TITLE
feat(cli): default to direct mode on every platform; bwrap only when asked

### DIFF
--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -1029,17 +1029,13 @@ export async function runCli(options: RunCliOptions): Promise<void> {
     cliMode = rawMode as CliMode
     mode = MODE_MAP[cliMode]
   } else {
-    // Auto-detect: use autoDetectMode() from @hachej/boring-agent/server.
-    // On Linux with bwrap → local-sandbox (bwrap); everywhere else → local (direct).
-    const agent = await import("@hachej/boring-agent/server")
-    const detected = agent.autoDetectMode()
-    if (detected === "local") {
-      cliMode = "local-sandbox"
-      mode = "local"
-    } else {
-      cliMode = "local"
-      mode = "direct"
-    }
+    // Default to direct (no sandbox) on every platform — including Linux with
+    // bwrap available. Direct mode boots ~instantly (no pack/extract, no
+    // sandbox spin-up); bwrap isolation is opt-in via `--mode local-sandbox`,
+    // since its per-workspace first-boot provisioning cost should only be paid
+    // when the caller explicitly wants the isolation (and accepts the wait).
+    cliMode = "local"
+    mode = "direct"
   }
 
   const base = {


### PR DESCRIPTION
## What
When `--mode` is omitted, the CLI now defaults to **`direct`** mode on every platform — including Linux with bwrap available. bwrap isolation is **opt-in** via `--mode local-sandbox`.

## Why
Previously the default auto-detected: on Linux+bwrap it chose `local-sandbox` (bwrap), so the **first** load of each workspace paid a ~45s pack + in-sandbox `npm install` before the UI was interactive. Direct mode boots **~instantly** (a `file:` symlink — no pack/extract, no sandbox spin-up).

## Behavior

| `--mode` | Agent mode | First workspace load |
|---|---|---|
| *(omitted)* — **was** | `local-sandbox`→bwrap on Linux | ~45s |
| *(omitted)* — **now** | **`direct`** everywhere | **~1.2s** |
| `local` | direct | ~1.2s |
| `local-sandbox` | bwrap | ~45s (opt-in) |

## Trade-off
The default now runs the agent with **full host + network access (no OS sandbox)**. That fits local single-user dev. Multi-tenant / hosted deployments that need isolation pass `--mode local-sandbox` explicitly.

## Verified
On this Linux+bwrap host: `boring-ui workspaces` (no `--mode`) cold-loads a fresh workspace in **~1.2s** (direct, symlinked), vs ~45s under the prior bwrap default.

Diff is a single block in `packages/cli/src/server/cli.ts` (the default-mode resolution): drop the `autoDetectMode()` branch, hardcode `direct`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)