### PR TITLE
fix(workspace): remove duplicate theme toggle in full app

### DIFF
--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Navigate, Route, useLocation, useParams } from 'react-router-dom'
 import {
   CoreFront,
-  ThemeToggle,
   UserMenu,
   WorkspaceSwitcher,
   useCurrentWorkspace,
@@ -50,12 +49,9 @@ export interface CoreWorkspaceAgentFrontProps<
 }
 
 function DefaultTopBarRight() {
-  return (
-    <div className="flex items-center gap-2">
-      <ThemeToggle />
-      <UserMenu />
-    </div>
-  )
+  // Theme switching lives in the UserMenu for the full app, so no separate
+  // top-bar toggle here (that's only for standalone hosts like the playground).
+  return <UserMenu />
 }
 
 function WorkspaceLoadingPage({
@@ -266,6 +262,7 @@ function WorkspaceRoute<
       bootPreloadPaths={bootPreloadPaths}
       frontPluginHotReload={false}
       hotReloadEnabled={false}
+      showThemeToggle={false}
     />
   )
 }

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -69,6 +69,13 @@ export interface WorkspaceAgentFrontProps<
   surfaceInitialPanels?: SurfaceShellProps["initialPanels"]
   topBarLeft?: ReactNode
   topBarRight?: ReactNode
+  /**
+   * Show the built-in top-bar theme toggle. Defaults to true for standalone
+   * hosts (e.g. the workspace playground) that have no other theme control.
+   * Full apps that already expose theme switching elsewhere (e.g. the core
+   * UserMenu) should set this to false to avoid a duplicate control.
+   */
+  showThemeToggle?: boolean
   sessions?: Array<{ id: string; title?: string | null; updatedAt?: string | number }>
   activeSessionId?: string | null
   onSwitchSession?: (id: string) => void
@@ -275,6 +282,7 @@ export function WorkspaceAgentFront<
   surfaceInitialPanels,
   topBarLeft,
   topBarRight,
+  showThemeToggle = true,
   chatParams,
   hotReloadEnabled,
   frontPluginHotReload,
@@ -680,7 +688,7 @@ export function WorkspaceAgentFront<
             topBarLeft={topBarLeft}
             topBarRight={
               <>
-                <ThemeToggle />
+                {showThemeToggle ? <ThemeToggle /> : null}
                 {topBarRight}
               </>
             }


### PR DESCRIPTION
The top-bar theme toggle added in #39/#142 was meant for the standalone workspace playground (which has no UserMenu). In the full app, theme switching is already in the **UserMenu**, so the top-bar toggle is redundant (and `DefaultTopBarRight` + `WorkspaceAgentFront` were both injecting one).

**Fix:** `WorkspaceAgentFront` gains `showThemeToggle` (default `true` → playground keeps it); `CoreWorkspaceAgentFront` passes `showThemeToggle={false}` and `DefaultTopBarRight` is just `<UserMenu />`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)