### PR TITLE
perf(workspace): skip plugin-authoring runtime install on remote sandboxes

### DIFF
--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -172,7 +172,7 @@ describe("default boring-ui CLI provisioning", () => {
   })
 
   test.each(["direct", "local", "vercel-sandbox"] as const)(
-    "mode %s receives the default CLI provisioning and prompt commands",
+    "mode %s provisions plugin-authoring tooling only for local runtimes (remote sandboxes skip it)",
     async (mode) => {
       const workspaceRoot = await makeTempDir(`boring-cli-${mode}-`)
       let capturedPrompt: string | undefined
@@ -207,13 +207,21 @@ describe("default boring-ui CLI provisioning", () => {
         { plugins: Array<{ id: string; provisioning?: { nodePackages?: unknown[] } }> },
       ]
       const cli = findBoringUiCliContribution(provisionOpts.plugins)
-      expect(cli?.provisioning?.nodePackages).toContainEqual(expect.objectContaining({
-        id: "boring-ui-cli",
-        packageName: "@hachej/boring-ui-cli",
-        expectedBins: ["boring-ui"],
-      }))
-      expect(capturedPrompt).toContain("boring-ui scaffold-plugin")
-      expect(capturedPrompt).toContain("boring-ui verify-plugin")
+      if (mode === "vercel-sandbox") {
+        // Remote sandboxes don't author plugins → no CLI/workspace install and
+        // no `boring-ui scaffold-plugin` guidance.
+        expect(cli).toBeUndefined()
+        expect(capturedPrompt ?? "").not.toContain("boring-ui scaffold-plugin")
+        expect(capturedPrompt ?? "").not.toContain("boring-ui verify-plugin")
+      } else {
+        expect(cli?.provisioning?.nodePackages).toContainEqual(expect.objectContaining({
+          id: "boring-ui-cli",
+          packageName: "@hachej/boring-ui-cli",
+          expectedBins: ["boring-ui"],
+        }))
+        expect(capturedPrompt).toContain("boring-ui scaffold-plugin")
+        expect(capturedPrompt).toContain("boring-ui verify-plugin")
+      }
     },
   )
 

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -357,6 +357,15 @@ export interface CollectWorkspaceAgentServerPluginsOptions
   workspaceRoot?: string
   systemPromptAppend?: string
   pi?: WorkspaceAgentPiOptions
+  /**
+   * Whether to provision the boring plugin-authoring runtime
+   * (`@hachej/boring-ui-cli` + `@hachej/boring-workspace` + `@hachej/boring-pi`)
+   * into the workspace. Plugin creation is a local-dev feature, so this is
+   * turned OFF for remote-sandbox runtimes (e.g. vercel-sandbox) — installing
+   * the CLI's full dependency tree (~hundreds of MB) into a remote sandbox that
+   * never authors plugins is pure cold-start cost. Defaults to true.
+   */
+  installPluginAuthoring?: boolean
 }
 
 export function buildWorkspaceContextPrompt(): string {
@@ -383,11 +392,18 @@ export function collectWorkspaceAgentServerPlugins(
   const callerPiPackages = opts.pi?.packages ?? []
   const callerExtensionPaths = opts.pi?.extensionPaths ?? []
 
-  const builtinProvisioningContributions = [
-    createWorkspacePackageProvisioningContribution(),
-    createBoringPiPackageProvisioningContribution(),
-    createBoringUiCliPackageProvisioningContribution(),
-  ].filter((entry): entry is WorkspaceProvisioningContribution => Boolean(entry))
+  // Plugin-authoring runtime (CLI + workspace validator + pi authoring skill)
+  // is only provisioned for local runtimes. Remote sandboxes don't author
+  // plugins, so they skip these installs entirely — avoiding the CLI's full
+  // ~hundreds-of-MB dependency tree on every cold workspace boot.
+  const builtinProvisioningContributions = (opts.installPluginAuthoring === false
+    ? []
+    : [
+        createWorkspacePackageProvisioningContribution(),
+        createBoringPiPackageProvisioningContribution(),
+        createBoringUiCliPackageProvisioningContribution(),
+      ]
+  ).filter((entry): entry is WorkspaceProvisioningContribution => Boolean(entry))
 
   return {
     provisioningContributions: [
@@ -586,9 +602,13 @@ export async function createWorkspaceAgentServer(
   const resolvedPlugins = await Promise.all(
     allPluginEntries.map((entry) => resolveOnePluginEntry<WorkspaceServerPlugin>(entry, ctx)),
   )
+  // Remote-sandbox runtimes (vercel-sandbox → "best-effort") don't author
+  // plugins; only local runtimes ("strong") get the plugin-authoring tooling.
+  const installPluginAuthoring = workspaceFsCapability === "strong"
   const pluginCollection = collectWorkspaceAgentServerPlugins({
     ...opts,
     plugins: resolvedPlugins,
+    installPluginAuthoring,
   })
 
   // Note: defaultPluginPackagePaths land in `boringPluginDirs` below.
@@ -602,9 +622,11 @@ export async function createWorkspaceAgentServer(
   // discovered/default plugin packages is snapped once at boot and merged
   // here so production/static hosts keep the same app-default agent context
   // without a dynamic refresh hook.
-  const workspacePackagePiPackage = createBoringPiPackageSource(workspaceRoot)
+  const workspacePackagePiPackage = installPluginAuthoring
+    ? createBoringPiPackageSource(workspaceRoot)
+    : undefined
   const baseStaticPiSkillPaths = [
-    ...resolveBoringPiSkillPaths(workspaceRoot),
+    ...(installPluginAuthoring ? resolveBoringPiSkillPaths(workspaceRoot) : []),
     ...(pluginCollection.agentOptions.pi?.additionalSkillPaths ?? []),
   ]
   const baseStaticPiPackages = [
@@ -707,15 +729,20 @@ export async function createWorkspaceAgentServer(
       // `npx @hachej/boring-ui-cli` here — that would pull the
       // published version, which lags the locally-installed CLI when
       // the agent is iterating in a monorepo. Keep the bin name short.
-      buildBoringSystemPrompt({
-        scaffoldCommand: "boring-ui scaffold-plugin",
-        verifyCommand: "boring-ui verify-plugin",
-        boringPiRootOverride: boringPiRootVisibleToAgentTools(
-          workspaceRoot,
-          resolvedMode,
-          opts.provisionWorkspace !== false,
-        ),
-      }),
+      // Plugin-authoring guidance only when the tooling is actually installed
+      // (local runtimes). Remote sandboxes don't author plugins, so we don't
+      // tell the agent to run `boring-ui scaffold-plugin` (the bin isn't there).
+      installPluginAuthoring
+        ? buildBoringSystemPrompt({
+            scaffoldCommand: "boring-ui scaffold-plugin",
+            verifyCommand: "boring-ui verify-plugin",
+            boringPiRootOverride: boringPiRootVisibleToAgentTools(
+              workspaceRoot,
+              resolvedMode,
+              opts.provisionWorkspace !== false,
+            ),
+          })
+        : undefined,
       pluginCollection.agentOptions.systemPromptAppend,
       staticPluginPackagePiSnapshot.systemPromptAppend,
     ].filter(Boolean).join("\n\n") || undefined,

--- a/packages/workspace/src/server/__tests__/workspaceContextPrompt.test.ts
+++ b/packages/workspace/src/server/__tests__/workspaceContextPrompt.test.ts
@@ -179,7 +179,7 @@ describe("createWorkspaceAgentServer — workspace context injection", () => {
     expect(contextIdx).toBeLessThan(pluginIdx)
   })
 
-  test("vercel-sandbox omits workspace context even with default app prompts", async () => {
+  test("vercel-sandbox omits workspace context and plugin-authoring guidance", async () => {
     const workspaceRoot = await makeTempDir("boring-wcp-vs-undef-")
     const app = await createWorkspaceAgentServer({
       workspaceRoot,
@@ -188,7 +188,10 @@ describe("createWorkspaceAgentServer — workspace context injection", () => {
       provisionWorkspace: false,
     })
     await app.close()
-    expect(capturedSystemPromptAppend).toBeDefined()
-    expect(capturedSystemPromptAppend).not.toContain(buildWorkspaceContextPrompt())
+    // Remote sandboxes get neither the local workspace context prompt nor the
+    // plugin-authoring guidance (no plugin creation there), so with no app
+    // plugins the workspace appendix is empty.
+    expect(capturedSystemPromptAppend ?? "").not.toContain(buildWorkspaceContextPrompt())
+    expect(capturedSystemPromptAppend ?? "").not.toContain("boring-ui scaffold-plugin")
   })
 })


### PR DESCRIPTION
## Problem
Provisioning a workspace on a **remote sandbox** (vercel-sandbox, hosted full app) was multi-minute because `createWorkspaceAgentServer` installed the **plugin-authoring runtime** into *every* workspace — `@hachej/boring-ui-cli` + `@hachej/boring-workspace` + the `@hachej/boring-pi` authoring skill — which pulls the CLI's **full dependency tree (~hundreds of MB)** via `npm install` inside the sandbox. But **plugin creation is a local-dev feature**; the hosted agent never runs `boring-ui scaffold-plugin`.

(Verified live: the full app in `vercel-sandbox` mode created a real sandbox fine, but the cold provision dragged on the ~493 MB remote install.)

## Fix
Gate the plugin-authoring tooling on the runtime being **local** — `workspaceFsCapability === "strong"` (direct / local-bwrap), which the code already uses to distinguish local from remote:

| mode | fs capability | authoring runtime + `scaffold-plugin` prompt |
|---|---|---|
| direct, local (bwrap) | `strong` | **installed** (unchanged) |
| vercel-sandbox (+ future remote) | `best-effort` | **skipped** — no install, no pi skill, no prompt |

Remote sandboxes now provision in **seconds** (the ~hundreds-of-MB install is simply not done), and the agent isn't told to use a `boring-ui` bin that isn't there. Local plugin authoring is unchanged.

## Scope note
This is the smaller, surgical win that came out of investigating the slim-runtime plan: since remote sandboxes don't author plugins, we don't need to *slim* the CLI there — we just don't install it. A bundled `@hachej/boring-plugin-tools` for the local-bwrap case remains a possible future optimization (lower priority — the default local mode is `direct`, which symlinks instantly).

## Tests
- `createWorkspaceAgentServer.test.ts`: the `test.each(["direct","local","vercel-sandbox"])` now asserts per-mode — local provisions the CLI + emits the prompt; vercel does neither.
- `workspaceContextPrompt.test.ts`: vercel test updated — the workspace appendix is now empty (no context, no authoring guidance).
- Typecheck clean; the change is behavior-only behind a new optional `installPluginAuthoring` flag (default true, backward-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)