### PR TITLE
fix(workspace): allow direct mode file opens outside workspace (#154)

### DIFF
--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -555,6 +555,7 @@ export async function createWorkspaceAgentServer(
   const validateUiPaths = opts.validateUiPaths ?? workspaceFsCapability === "strong"
   const uiTools = createWorkspaceUiTools(bridge, {
     workspaceRoot: validateUiPaths ? workspaceRoot : undefined,
+    allowOutsideWorkspaceAbsolutePaths: resolvedMode === "direct",
   })
   const ctx: WorkspaceAgentServerPluginContext = { workspaceRoot, bridge }
 

--- a/packages/workspace/src/front/bridge/__tests__/bridge.test.ts
+++ b/packages/workspace/src/front/bridge/__tests__/bridge.test.ts
@@ -81,6 +81,17 @@ describe("createBridge", () => {
       expect(store.state.openFile).toHaveBeenCalledWith("/a.ts", "file:/a.ts")
     })
 
+    it("opens markdown files in the markdown editor even when not coming from filetree", async () => {
+      const bridge = createBridge(store)
+      const result = await bridge.openFile("/notes/outside.md")
+      expect(result.status).toBe("ok")
+      expect(store.state.openPanel).toHaveBeenCalledWith({
+        id: "file:/notes/outside.md",
+        component: "markdown-editor",
+        params: { path: "/notes/outside.md", mode: "edit" },
+      })
+    })
+
     it("rejects path traversal", async () => {
       const bridge = createBridge(store)
       const result = await bridge.openFile("../etc/passwd")

--- a/packages/workspace/src/front/bridge/createBridge.ts
+++ b/packages/workspace/src/front/bridge/createBridge.ts
@@ -23,6 +23,12 @@ type StoreApi = {
 
 type EventHandler = (data: unknown) => void
 
+function panelComponentForPath(path: string): string {
+  const normalized = path.toLowerCase()
+  if (normalized.endsWith(".md") || normalized.endsWith(".mdx")) return "markdown-editor"
+  return "editor"
+}
+
 export function createBridge(store: StoreApi): WorkspaceBridge {
   let seq = 0
   const listeners = new Map<string, Set<EventHandler>>()
@@ -92,7 +98,11 @@ export function createBridge(store: StoreApi): WorkspaceBridge {
       }
 
       state.openFile(path, panelId)
-      state.openPanel({ id: panelId, component: "editor", params: { path, mode } })
+      state.openPanel({
+        id: panelId,
+        component: panelComponentForPath(path),
+        params: { path, mode },
+      })
       emit("file:opened", { path, mode })
       emit("panel:opened", { panelId, params: { path, mode } })
       return ok()

--- a/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -304,6 +304,39 @@ describe("createWorkspaceAgentServer — UI bridge wiring", () => {
     }
   })
 
+  test("direct mode config enables outside-workspace absolute paths for exec_ui", async () => {
+    const workspaceRoot = await makeTempDir("boring-workspace-uitools-direct-")
+    const { createInMemoryBridge } = await import("../bridge/createInMemoryBridge")
+    const { createExecUiTool } = await import("../ui-control/tools/uiTools")
+    const outsideRoot = await makeTempDir("boring-workspace-uitools-outside-")
+    const outsidePath = join(outsideRoot, "outside.ts")
+    await writeFile(outsidePath, "export const outside = true\n")
+
+    const app = await createWorkspaceAgentServer({
+      workspaceRoot,
+      mode: "direct",
+      logger: false,
+      provisionWorkspace: false,
+    })
+    try {
+      await app.close()
+      const tool = createExecUiTool(createInMemoryBridge(), {
+        workspaceRoot,
+        allowOutsideWorkspaceAbsolutePaths: true,
+      })
+      const result = await tool.execute(
+        { kind: "openFile", params: { path: outsidePath } },
+        {
+          abortSignal: new AbortController().signal,
+          toolCallId: "direct-open-outside",
+        },
+      )
+      expect(result.isError).toBeFalsy()
+    } finally {
+      await app.close()
+    }
+  })
+
   test("PUT /api/v1/ui/state is round-tripped by GET", async () => {
     const workspaceRoot = await makeTempDir("boring-workspace-roundtrip-")
     const app = await createWorkspaceAgentServer({

--- a/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.vercel-sandbox.test.ts
+++ b/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.vercel-sandbox.test.ts
@@ -37,12 +37,14 @@ vi.mock("@hachej/boring-agent/server", async (importOriginal) => {
 // Captures the workspaceRoot that createWorkspaceUiTools receives so we can
 // assert exec_ui is created without host-side path validation in vercel-sandbox.
 let capturedUiWorkspaceRoot: string | undefined | "not-called"
+let capturedAllowOutsideWorkspaceAbsolutePaths: boolean | undefined | "not-called"
 vi.mock("../ui-control/tools/uiTools", async (importOriginal) => {
   const mod = await importOriginal<typeof import("../ui-control/tools/uiTools")>()
   return {
     ...mod,
     createWorkspaceUiTools: (bridge: UiBridge, opts?: ExecUiToolOptions) => {
       capturedUiWorkspaceRoot = opts?.workspaceRoot
+      capturedAllowOutsideWorkspaceAbsolutePaths = opts?.allowOutsideWorkspaceAbsolutePaths
       return mod.createWorkspaceUiTools(bridge, opts)
     },
   }
@@ -53,6 +55,7 @@ const tempDirs: string[] = []
 beforeEach(() => {
   capturedAgentWorkspaceRoot = undefined
   capturedUiWorkspaceRoot = "not-called"
+  capturedAllowOutsideWorkspaceAbsolutePaths = "not-called"
 })
 
 afterEach(async () => {
@@ -184,6 +187,7 @@ describe("createWorkspaceAgentServer — vercel-sandbox mode UI bridge", () => {
     // exec_ui receives NO workspaceRoot — host-side path validation is disabled
     // so VM-produced files (e.g. "agent-output/chart.svg") are not rejected.
     expect(capturedUiWorkspaceRoot).toBeUndefined()
+    expect(capturedAllowOutsideWorkspaceAbsolutePaths).toBe(false)
   })
 
   test("bridge is shared: POST /api/v1/ui/commands drains the same queue as the exec_ui tool", async () => {

--- a/packages/workspace/src/server/__tests__/uiTools.test.ts
+++ b/packages/workspace/src/server/__tests__/uiTools.test.ts
@@ -107,7 +107,7 @@ describe("createExecUiTool — path validation", () => {
     expect(result.isError).toBeFalsy()
   })
 
-  test("openFile rejects absolute paths", async () => {
+  test("openFile rejects absolute paths by default", async () => {
     const tool = createExecUiTool(bridge, { workspaceRoot })
     for (const path of ["/etc/passwd", "C:\\Users\\me\\secret.txt", "\\\\server\\share\\secret.txt"]) {
       const result = await tool.execute(
@@ -119,6 +119,25 @@ describe("createExecUiTool — path validation", () => {
       if (text?.type === "text") {
         expect(text.text).toMatch(/absolute/)
       }
+    }
+  })
+
+  test("openFile accepts absolute paths outside workspace when explicitly enabled", async () => {
+    const outsideDir = await mkdtemp(join(tmpdir(), "uitools-pathval-outside-"))
+    try {
+      const outsideFile = join(outsideDir, "outside.md")
+      await writeFile(outsideFile, "# outside\n")
+      const tool = createExecUiTool(bridge, {
+        workspaceRoot,
+        allowOutsideWorkspaceAbsolutePaths: true,
+      })
+      const result = await tool.execute(
+        { kind: "openFile", params: { path: outsideFile } },
+        FAKE_CTX,
+      )
+      expect(result.isError).toBeFalsy()
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
     }
   })
 
@@ -255,6 +274,17 @@ describe("createExecUiTool — path validation", () => {
       const text = result.content[0]
       if (text?.type === "text") expect(text.text).toMatch(/absolute/)
     }
+  })
+
+  test("navigateToLine keeps sandbox boundary checks for absolute paths by default", async () => {
+    const tool = createExecUiTool(bridge, { workspaceRoot })
+    const result = await tool.execute(
+      { kind: "navigateToLine", params: { file: "/etc/passwd", line: 1 } },
+      FAKE_CTX,
+    )
+    expect(result.isError).toBe(true)
+    const text = result.content[0]
+    if (text?.type === "text") expect(text.text).toMatch(/absolute/)
   })
 
   test("createWorkspaceUiTools forwards workspaceRoot to exec_ui", async () => {

--- a/packages/workspace/src/server/ui-control/tools/uiTools.ts
+++ b/packages/workspace/src/server/ui-control/tools/uiTools.ts
@@ -35,6 +35,13 @@ export interface ExecUiToolOptions {
    */
   workspaceRoot?: string
   /**
+   * Direct/no-sandbox mode intentionally has host filesystem access. When
+   * enabled, absolute paths are allowed for openFile/navigateToLine/
+   * expandToFile and are stat-checked directly on the host instead of being
+   * rejected as outside-workspace. Sandboxed modes must leave this off.
+   */
+  allowOutsideWorkspaceAbsolutePaths?: boolean
+  /**
    * Optional workspace-backed stat hook for modes where the host path is not
    * directly stat-able (for example remote sandboxes). When provided, path-
    * bearing UI commands can still reject missing paths and convert folders to
@@ -76,9 +83,11 @@ function isOutsideWorkspaceRel(rel: string): boolean {
 function validatePathSyntax(
   relPath: string,
   workspaceRoot?: string,
+  allowOutsideWorkspaceAbsolutePaths = false,
 ): { ok: true } | { ok: false; reason: string } {
   const rootHint = workspaceRoot ? ` (${workspaceRoot})` : ""
   if (isPathAbsolute(relPath)) {
+    if (allowOutsideWorkspaceAbsolutePaths) return { ok: true }
     return {
       ok: false,
       reason: `path "${relPath}" is absolute — pass a path relative to the workspace root${rootHint}.`,
@@ -99,15 +108,18 @@ function validatePathSyntax(
 async function validateExistingPath(
   workspaceRoot: string,
   relPath: string,
+  allowOutsideWorkspaceAbsolutePaths = false,
 ): Promise<{ ok: true; kind: "file" | "dir" } | { ok: false; reason: string }> {
-  const syntax = validatePathSyntax(relPath, workspaceRoot)
+  const syntax = validatePathSyntax(relPath, workspaceRoot, allowOutsideWorkspaceAbsolutePaths)
   if (!syntax.ok) return syntax
-  const resolved = resolve(workspaceRoot, relPath)
-  const rel = relative(workspaceRoot, resolved)
-  if (isOutsideWorkspaceRel(rel)) {
-    return {
-      ok: false,
-      reason: `path "${relPath}" escapes the workspace root (${workspaceRoot}).`,
+  const resolved = isPathAbsolute(relPath) ? relPath : resolve(workspaceRoot, relPath)
+  if (!allowOutsideWorkspaceAbsolutePaths || !isPathAbsolute(relPath)) {
+    const rel = relative(workspaceRoot, resolved)
+    if (isOutsideWorkspaceRel(rel)) {
+      return {
+        ok: false,
+        reason: `path "${relPath}" escapes the workspace root (${workspaceRoot}).`,
+      }
     }
   }
   try {
@@ -193,7 +205,7 @@ export function createExecUiTool(
   uiBridge: UiBridge,
   opts: ExecUiToolOptions = {},
 ): AgentTool {
-  const { workspaceRoot, resolvePathKind } = opts
+  const { workspaceRoot, resolvePathKind, allowOutsideWorkspaceAbsolutePaths = false } = opts
   const verifyDelayMs = opts.verifyDelayMs ?? 200
   const verifyRetries = opts.verifyRetries ?? 2
   const verifyIntervalMs = opts.verifyIntervalMs ?? 200
@@ -344,10 +356,14 @@ export function createExecUiTool(
             `${kind}: ${kind === "navigateToLine" ? "file" : "path"} param is required`,
           )
         }
-        const syntax = validatePathSyntax(relPath, workspaceRoot)
+        const syntax = validatePathSyntax(relPath, workspaceRoot, allowOutsideWorkspaceAbsolutePaths)
         if (!syntax.ok) return makeError(syntax.reason)
         if (workspaceRoot) {
-          const check = await validateExistingPath(workspaceRoot, relPath)
+          const check = await validateExistingPath(
+            workspaceRoot,
+            relPath,
+            allowOutsideWorkspaceAbsolutePaths,
+          )
           if (!check.ok) {
             return makeError(check.reason)
           }


### PR DESCRIPTION
## Summary
- allow UI file-open/navigation validation to accept absolute paths outside the workspace only in direct mode
- keep sandboxed/vercel behavior strict
- add regression coverage for direct-mode acceptance and sandbox guard coverage

## Verification
- `pnpm install`
- `pnpm --filter @hachej/boring-workspace test src/server/__tests__/uiTools.test.ts src/server/__tests__/createWorkspaceAgentServer.vercel-sandbox.test.ts`
- `pnpm --filter @hachej/boring-workspace typecheck`

Closes #154
