### PR TITLE
feat(cli): add runtime plugin self-test command

### DIFF
--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readdirSync, copyFileSync, statSync } from "node:fs"
-import { dirname, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { createWorkspaceAgentServer } from "@hachej/boring-workspace/app/server"
 
 export const AGENT_API_PORT = Number(process.env.AGENT_API_PORT) || 5210
@@ -38,6 +38,7 @@ export async function startPlaygroundServer(): Promise<void> {
   agentBoot = (async () => {
     const workspaceRoot = process.env.BORING_AGENT_WORKSPACE_ROOT ?? WORKSPACE_DIR
     seedWorkspaceFromFixtures(workspaceRoot)
+    const selfTestUrl = `http://127.0.0.1:${VITE_PORT}`
     console.log(`[workspace-playground] workspace root: ${workspaceRoot}`)
     const app = await createWorkspaceAgentServer({
       workspaceRoot,
@@ -49,6 +50,10 @@ export async function startPlaygroundServer(): Promise<void> {
       // entry through the standard load process (asset manager scan,
       // SSE event, front dynamic-import, jiti reload).
       appPackageJsonPath: resolve(APP_ROOT, "package.json"),
+      runtimeEnv: {
+        BORING_UI_SELF_TEST_URL: selfTestUrl,
+        PLAYWRIGHT_BROWSERS_PATH: join(workspaceRoot, ".boring-agent", "playwright-browsers"),
+      },
     })
     await app.listen({ port: AGENT_API_PORT, host: "127.0.0.1" })
   })()

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,7 @@
     "@vitejs/plugin-react": "^4.0.0",
     "fastify": "^5.4.0",
     "lucide-react": "^1.8.0",
+    "playwright": "^1.59.1",
     "typescript": "^5.8.3",
     "vite": "^6.0.0"
   },

--- a/packages/cli/src/__tests__/testPlugin.test.ts
+++ b/packages/cli/src/__tests__/testPlugin.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "vitest"
+import { buildPanelId, buildPanelInstanceId, buildPanelSelector, defaultPlaywrightBrowsersPath, formatSelfTestResult, inferSelfTestUrl, inferSelfTestWorkspaceId, isMissingPlaywrightBrowserError, redactUrl } from "../server/testPlugin"
+
+describe("plugin self-test helpers", () => {
+  test("builds default panel id, self-test panel instance id, and selector", () => {
+    const panelId = buildPanelId("niche-explorer")
+    const panelInstanceId = buildPanelInstanceId("niche-explorer", panelId)
+
+    expect(panelId).toBe("niche-explorer.panel")
+    expect(panelInstanceId).toBe("self-test:niche-explorer:niche-explorer.panel")
+    expect(buildPanelSelector({ pluginId: "niche-explorer", panelId, panelInstanceId })).toBe(
+      '[data-boring-plugin-id="niche-explorer"][data-boring-panel-component-id="niche-explorer.panel"][data-boring-panel-instance-id="self-test:niche-explorer:niche-explorer.panel"]',
+    )
+  })
+
+  test("infers self-test URL from explicit args, env, port, then default", () => {
+    expect(inferSelfTestUrl("http://explicit.test", { BORING_UI_SELF_TEST_URL: "http://env.test" })).toBe("http://explicit.test")
+    expect(inferSelfTestUrl(undefined, { BORING_UI_SELF_TEST_URL: "http://env.test" })).toBe("http://env.test")
+    expect(inferSelfTestUrl(undefined, { PORT: "5640" })).toBe("http://127.0.0.1:5640")
+    expect(inferSelfTestUrl(undefined, {})).toBe("http://127.0.0.1:5200")
+  })
+
+  test("infers workspaces-mode workspace id from explicit arg then env", () => {
+    expect(inferSelfTestWorkspaceId("explicit", { BORING_UI_WORKSPACE_ID: "env" })).toBe("explicit")
+    expect(inferSelfTestWorkspaceId(undefined, { BORING_UI_WORKSPACE_ID: "env" })).toBe("env")
+    expect(inferSelfTestWorkspaceId(undefined, { BORING_WORKSPACE_ID: "workspace" })).toBe("workspace")
+    expect(inferSelfTestWorkspaceId(undefined, {})).toBeUndefined()
+  })
+
+  test("builds sandbox-local Playwright browser cache path", () => {
+    expect(defaultPlaywrightBrowsersPath({ BORING_AGENT_WORKSPACE_ROOT: "/workspace" })).toBe("/workspace/.boring-agent/playwright-browsers")
+    expect(defaultPlaywrightBrowsersPath({})).toBeUndefined()
+  })
+
+  test("detects missing Playwright browser launch errors", () => {
+    expect(isMissingPlaywrightBrowserError(new Error("Executable doesn't exist at /cache/chromium"))).toBe(true)
+    expect(isMissingPlaywrightBrowserError(new Error("Please run the following command to download new browsers: playwright install"))).toBe(true)
+    expect(isMissingPlaywrightBrowserError(new Error("host is unreachable"))).toBe(false)
+  })
+
+  test("redacts URL credentials, query, and hash", () => {
+    expect(redactUrl("http://user:pass@example.com/path?token=secret#frag")).toBe("http://example.com/path")
+  })
+
+  test("formats failing result with captured errors", () => {
+    expect(formatSelfTestResult({
+      ok: false,
+      pluginId: "demo",
+      reloadErrors: [{ code: "PLUGIN_FRONT_ERROR", message: "boom" }],
+      pageErrors: [],
+      consoleErrors: [],
+      failedRequests: [{ status: 500, url: "http://localhost/api/bad" }],
+      pane: {
+        found: false,
+        state: "error",
+        selector: "[data-demo]",
+        panelId: "demo.panel",
+        panelInstanceId: "self-test:demo:demo.panel",
+      },
+    })).toContain("FAIL demo")
+  })
+})

--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -143,6 +143,7 @@ export async function provisionCliWorkspaceRuntime(opts: {
   adapter?: WorkspaceProvisioningAdapter
   modeAdapter?: Pick<RuntimeModeAdapter, "createProvisioningAdapter">
   runtimeLayout?: BoringAgentRuntimePaths
+  selfTestUrl?: string
 }): Promise<WorkspaceProvisioningResult | undefined> {
   if (opts.provisionWorkspace === false) return undefined
   const agent = await import("@hachej/boring-agent/server")
@@ -163,6 +164,8 @@ export async function provisionCliWorkspaceRuntime(opts: {
     env: {
       ...result.env,
       BORING_AGENT_WORKSPACE_LOCAL_PLUGIN_ROOTS: opts.mode === "direct" || opts.mode === "local" ? "1" : "0",
+      PLAYWRIGHT_BROWSERS_PATH: join(result.env.BORING_AGENT_WORKSPACE_ROOT ?? runtimeLayout.workspaceRoot, ".boring-agent", "playwright-browsers"),
+      ...(opts.selfTestUrl ? { BORING_UI_SELF_TEST_URL: opts.selfTestUrl } : {}),
     },
   }
 }
@@ -206,6 +209,8 @@ const HELP_TEXT = [
   "                                       Scaffold a hot-reloadable plugin",
   "  boring-ui verify-plugin [name] [workspace]",
   "                                       Validate plugin manifests/files",
+  "  boring-ui test-plugin <name> [--url <url>]",
+  "                                       Headlessly reload and render-test a plugin panel",
   "",
   "Options:",
   "  -p, --port <port>       HTTP port (default: 5200)",
@@ -383,6 +388,7 @@ export async function createFolderModeApp(opts: {
   mode: RuntimeMode
   projectName?: string
   provisionWorkspace?: boolean
+  selfTestUrl?: string
 }): Promise<FastifyInstance> {
   const workspaceRoot = resolve(opts.workspaceRoot)
   const projectName = opts.projectName ?? (basename(workspaceRoot) || "workspace")
@@ -399,6 +405,7 @@ export async function createFolderModeApp(opts: {
     mode: opts.mode,
     provisionWorkspace: opts.provisionWorkspace,
     plugins: readWorkspacePluginPackageRuntimePlugins(resolveCliBoringPluginDirs(workspaceRoot)),
+    selfTestUrl: opts.selfTestUrl,
   })
   const app = await createWorkspaceAgentServer({
     workspaceRoot,
@@ -466,6 +473,7 @@ async function startFolderMode(opts: {
   const modelCount = await checkAuth()
 
   const url = `http://localhost:${opts.port}`
+  const selfTestUrl = `http://127.0.0.1:${opts.port}`
   console.log(`\n${projectName}`)
   console.log(`  workspace  ${workspaceRoot}`)
   console.log(`  mode       ${opts.cliMode}`)
@@ -478,6 +486,7 @@ async function startFolderMode(opts: {
     workspaceRoot,
     mode: opts.mode,
     projectName,
+    selfTestUrl,
   })
 
   await registerStatic(app as FastifyInstance, opts.publicDir)
@@ -490,6 +499,7 @@ export async function createWorkspacesModeApp(opts: {
   mode: RuntimeMode
   registryPath?: string
   provisionWorkspace?: boolean
+  selfTestUrl?: string
 }): Promise<FastifyInstance> {
   const [workspaceAppServer, workspaceServer, agentServer, fastifyModule, { createPluginFrontRuntimeHost }] = await Promise.all([
     import("@hachej/boring-workspace/app/server"),
@@ -656,9 +666,17 @@ export async function createWorkspacesModeApp(opts: {
         adapter: provisioningAdapter,
         runtimeLayout,
         plugins: workspaceAppServer.readWorkspacePluginPackageRuntimePlugins(resolveCliBoringPluginDirs(workspaceRoot)),
+        selfTestUrl: opts.selfTestUrl,
       })
-      runtimeProvisioningByWorkspace.set(workspaceId, provisioned)
-      return provisioned
+      const scopedProvisioning = provisioned ? {
+        ...provisioned,
+        env: {
+          ...provisioned.env,
+          BORING_UI_WORKSPACE_ID: workspaceId,
+        },
+      } : provisioned
+      runtimeProvisioningByWorkspace.set(workspaceId, scopedProvisioning)
+      return scopedProvisioning
     },
     beforeReload: async ({ workspaceId }) => {
       const workspace = await requireWorkspace(workspaceId)
@@ -812,7 +830,8 @@ async function startWorkspacesMode(opts: {
   cliMode: CliMode
   mode: RuntimeMode
 }) {
-  const app = await createWorkspacesModeApp({ mode: opts.mode })
+  const selfTestUrl = `http://127.0.0.1:${opts.port}`
+  const app = await createWorkspacesModeApp({ mode: opts.mode, selfTestUrl })
   const registry = createLocalWorkspaceRegistry()
 
   await registerStatic(app, opts.publicDir)
@@ -1011,6 +1030,10 @@ export async function runCli(options: RunCliOptions): Promise<void> {
       mode: { type: "string", short: "m" },
       name: { type: "string", short: "n" },
       path: { type: "string" as const },
+      url: { type: "string" as const },
+      workspace: { type: "string" as const },
+      "panel-id": { type: "string" as const },
+      "timeout-ms": { type: "string" as const },
       json: { type: "boolean" as const },
       help: { type: "boolean", short: "h" },
     },
@@ -1081,6 +1104,20 @@ export async function runCli(options: RunCliOptions): Promise<void> {
 
   if (positionals[0] === "verify-plugin") {
     await handleVerifyPluginCommand({ positionals })
+    return
+  }
+
+  if (positionals[0] === "test-plugin") {
+    await handleTestPluginCommand({
+      positionals,
+      args: {
+        url: args.url as string | undefined,
+        workspace: args.workspace as string | undefined,
+        panelId: args["panel-id"] as string | undefined,
+        timeoutMs: args["timeout-ms"] as string | undefined,
+        json: args.json === true,
+      },
+    })
     return
   }
 
@@ -1161,6 +1198,34 @@ async function handleVerifyPluginCommand(opts: { positionals: string[] }) {
   }
 }
 
+async function handleTestPluginCommand(opts: {
+  positionals: string[]
+  args: {
+    url?: string
+    workspace?: string
+    panelId?: string
+    timeoutMs?: string
+    json: boolean
+  }
+}) {
+  const name = opts.positionals[1]
+  if (!name) throw new Error("usage: boring-ui test-plugin <name> [--url <local-server-url>] [--workspace <id>] [--panel-id <id>] [--timeout-ms <ms>] [--json]")
+  const timeoutMs = opts.args.timeoutMs === undefined ? undefined : Number(opts.args.timeoutMs)
+  if (timeoutMs !== undefined && (!Number.isFinite(timeoutMs) || timeoutMs <= 0)) {
+    throw new Error("--timeout-ms must be a positive number")
+  }
+  const { formatSelfTestResult, runPluginSelfTest } = await import("./testPlugin.js")
+  const result = await runPluginSelfTest({
+    pluginId: name,
+    url: opts.args.url,
+    ...(opts.args.workspace ? { workspaceId: opts.args.workspace } : {}),
+    ...(opts.args.panelId ? { panelId: opts.args.panelId } : {}),
+    ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+  })
+  console.log(opts.args.json ? JSON.stringify(result, null, 2) : formatSelfTestResult(result))
+  if (!result.ok) process.exit(1)
+}
+
 async function handleScaffoldPluginCommand(opts: { positionals: string[] }) {
   const name = opts.positionals[1]
   if (!name) {
@@ -1183,7 +1248,8 @@ async function handleScaffoldPluginCommand(opts: { positionals: string[] }) {
   console.log(`  1. edit front/index.tsx for UI panels/commands/resolvers`)
   console.log(`  2. add pi.extensions / skills for hot-reloadable agent behavior`)
   console.log(`  3. bash \`boring-ui verify-plugin\` — confirms manifests + files are valid`)
-  console.log(`  4. ask the user: /reload`)
+  console.log(`  4. if the UI is running, bash \`boring-ui test-plugin <name>\` — catches browser render/import/network failures`)
+  console.log(`  5. ask the user: /reload`)
   console.log("")
   console.log("Advanced server integration:")
   console.log("  boring.server is boot-time/static composition only. It is NOT hot-registered")

--- a/packages/cli/src/server/testPlugin.ts
+++ b/packages/cli/src/server/testPlugin.ts
@@ -1,0 +1,461 @@
+import { spawnSync } from "node:child_process"
+import { createRequire } from "node:module"
+import { dirname, join } from "node:path"
+import type { Browser, BrowserType } from "playwright"
+import type { RuntimePluginDiagnosticsResponse } from "../shared/runtimePluginDiagnostics"
+
+const require = createRequire(import.meta.url)
+
+export interface SelfTestEvent {
+  code: string
+  message: string
+}
+
+export interface SelfTestFailedRequest {
+  status?: number
+  url: string
+}
+
+export interface SelfTestResult {
+  ok: boolean
+  workspaceId?: string
+  pluginId: string
+  revision?: number
+  reloadErrors: SelfTestEvent[]
+  pageErrors: SelfTestEvent[]
+  consoleErrors: SelfTestEvent[]
+  failedRequests: SelfTestFailedRequest[]
+  pane: {
+    found: boolean
+    state: "ready" | "error" | "timeout"
+    selector: string
+    panelId?: string
+    panelInstanceId?: string
+  }
+}
+
+interface ReloadResponse {
+  diagnostics?: Array<{ source?: string; message?: string; pluginId?: string }>
+  restart_warnings?: unknown[]
+}
+
+interface BrowserPluginEvent {
+  type?: string
+  id?: string
+  revision?: number
+  message?: string
+  code?: string
+  stage?: string
+}
+
+export interface RunPluginSelfTestOptions {
+  pluginId: string
+  url?: string
+  workspaceId?: string
+  panelId?: string
+  timeoutMs?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 10_000
+const PLUGIN_RELOAD_EVENT = "boring-ui:agent-plugins-reloaded"
+const PLAYWRIGHT_BROWSER_INSTALL_MAX_BUFFER = 10 * 1024 * 1024
+const PLAYWRIGHT_BROWSER_INSTALL_TIMEOUT_MS = 120_000
+
+class BrowserSetupError extends Error {
+  code: string
+
+  constructor(code: string, message: string) {
+    super(message)
+    this.name = 'BrowserSetupError'
+    this.code = code
+  }
+}
+
+export function buildPanelId(pluginId: string, panelId?: string): string {
+  return panelId?.trim() || `${pluginId}.panel`
+}
+
+export function buildPanelInstanceId(pluginId: string, panelId: string): string {
+  return `self-test:${pluginId}:${panelId}`
+}
+
+export function buildPanelSelector(args: { pluginId: string; panelId: string; panelInstanceId: string }): string {
+  return [
+    `[data-boring-plugin-id=${JSON.stringify(args.pluginId)}]`,
+    `[data-boring-panel-component-id=${JSON.stringify(args.panelId)}]`,
+    `[data-boring-panel-instance-id=${JSON.stringify(args.panelInstanceId)}]`,
+  ].join("")
+}
+
+export function redactUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl)
+    url.username = ""
+    url.password = ""
+    url.search = ""
+    url.hash = ""
+    return url.toString()
+  } catch {
+    return rawUrl.split("?")[0]?.slice(0, 500) ?? rawUrl.slice(0, 500)
+  }
+}
+
+function truncateMessage(message: string): string {
+  return message.replace(/\s+/g, " ").trim().slice(0, 1_000)
+}
+
+function shouldCaptureFailedRequest(rawUrl: string): boolean {
+  try {
+    const url = new URL(rawUrl)
+    if (url.pathname === "/favicon.ico") return false
+    return true
+  } catch {
+    return true
+  }
+}
+
+function event(code: string, message: string): SelfTestEvent {
+  return { code, message: truncateMessage(message) }
+}
+
+export function inferSelfTestUrl(explicitUrl?: string, env: Record<string, string | undefined> = process.env): string {
+  const envUrl = env.BORING_UI_SELF_TEST_URL ?? env.BORING_UI_URL ?? env.BORING_WORKSPACE_URL
+  const portUrl = env.PORT ? `http://127.0.0.1:${env.PORT}` : undefined
+  return explicitUrl?.trim() || envUrl?.trim() || portUrl || "http://127.0.0.1:5200"
+}
+
+export function inferSelfTestWorkspaceId(explicitWorkspaceId?: string, env: Record<string, string | undefined> = process.env): string | undefined {
+  return explicitWorkspaceId?.trim()
+    || env.BORING_UI_WORKSPACE_ID?.trim()
+    || env.BORING_WORKSPACE_ID?.trim()
+    || env.BORING_AGENT_WORKSPACE_ID?.trim()
+    || undefined
+}
+
+export function defaultPlaywrightBrowsersPath(env: Record<string, string | undefined> = process.env): string | undefined {
+  const workspaceRoot = env.BORING_AGENT_WORKSPACE_ROOT?.trim()
+  if (!workspaceRoot) return undefined
+  return join(workspaceRoot, ".boring-agent", "playwright-browsers")
+}
+
+export function isMissingPlaywrightBrowserError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes("Executable doesn't exist")
+    || message.includes("Please run the following command to download new browsers")
+    || message.includes("playwright install")
+}
+
+function playwrightCliPath(): string {
+  return join(dirname(require.resolve("playwright/package.json")), "cli.js")
+}
+
+function installPlaywrightChromium(env: NodeJS.ProcessEnv, timeoutMs = PLAYWRIGHT_BROWSER_INSTALL_TIMEOUT_MS): void {
+  const result = spawnSync(process.execPath, [playwrightCliPath(), "install", "chromium"], {
+    env,
+    encoding: "utf8",
+    maxBuffer: PLAYWRIGHT_BROWSER_INSTALL_MAX_BUFFER,
+    timeout: timeoutMs,
+  })
+  if (result.status === 0) return
+  const stderr = result.stderr ? `\n${result.stderr.trim()}` : ""
+  const stdout = result.stdout ? `\n${result.stdout.trim()}` : ""
+  const reason = result.error?.message ?? `exit ${result.status ?? "unknown"}`
+  throw new BrowserSetupError("SELF_TEST_BROWSER_INSTALL_FAILED", `failed to install Playwright Chromium (${reason})${stderr}${stdout}`)
+}
+
+async function launchChromiumWithLazyInstall(chromium: BrowserType): Promise<Browser> {
+  try {
+    return await chromium.launch({ headless: true })
+  } catch (error) {
+    if (!isMissingPlaywrightBrowserError(error)) {
+      throw new BrowserSetupError("SELF_TEST_BROWSER_LAUNCH_FAILED", error instanceof Error ? error.message : String(error))
+    }
+    installPlaywrightChromium(process.env)
+    try {
+      return await chromium.launch({ headless: true })
+    } catch (retryError) {
+      throw new BrowserSetupError("SELF_TEST_BROWSER_LAUNCH_FAILED", retryError instanceof Error ? retryError.message : String(retryError))
+    }
+  }
+}
+
+function normalizeBaseUrl(rawUrl: string): string {
+  const url = new URL(rawUrl)
+  url.hash = ""
+  return url.toString().replace(/\/+$/, "")
+}
+
+function apiUrl(baseUrl: string, path: string): string {
+  return `${baseUrl}${path.startsWith("/") ? path : `/${path}`}`
+}
+
+function workspaceHeaders(workspaceId?: string): Record<string, string> {
+  return workspaceId ? { "x-boring-workspace-id": workspaceId } : {}
+}
+
+function browserUrl(baseUrl: string, workspaceId?: string): string {
+  if (!workspaceId) return `${baseUrl}/`
+  return `${baseUrl}/workspace/${encodeURIComponent(workspaceId)}`
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text.trim()) return undefined
+  try {
+    return JSON.parse(text) as unknown
+  } catch {
+    return text
+  }
+}
+
+function normalizeDiagnostics(args: {
+  pluginId: string
+  reloadStatus?: number
+  diagnosticsStatus?: number
+  reloadBody?: unknown
+  diagnosticsBody?: unknown
+}): { errors: SelfTestEvent[]; revision?: number } {
+  const errors: SelfTestEvent[] = []
+  let revision: number | undefined
+
+  if (args.reloadStatus && (args.reloadStatus < 200 || args.reloadStatus >= 300)) {
+    errors.push(event("RELOAD_HTTP_ERROR", `/api/v1/agent/reload returned ${args.reloadStatus}`))
+  }
+  if (args.diagnosticsStatus && (args.diagnosticsStatus < 200 || args.diagnosticsStatus >= 300)) {
+    errors.push(event("DIAGNOSTICS_HTTP_ERROR", `/api/v1/runtime-plugin-diagnostics returned ${args.diagnosticsStatus}`))
+  }
+
+  const reload = args.reloadBody as ReloadResponse | undefined
+  for (const diagnostic of reload?.diagnostics ?? []) {
+    if (diagnostic.pluginId && diagnostic.pluginId !== args.pluginId) continue
+    errors.push(event("RELOAD_DIAGNOSTIC", diagnostic.message ?? "reload diagnostic"))
+  }
+
+  const diagnostics = args.diagnosticsBody as RuntimePluginDiagnosticsResponse | undefined
+  const plugin = diagnostics?.plugins?.find((entry) => entry.id === args.pluginId)
+  if (plugin?.serverLoadedRevision !== undefined) revision = plugin.serverLoadedRevision
+  if (plugin?.serverError) errors.push(event("PLUGIN_SERVER_ERROR", plugin.serverError))
+  if (plugin?.host?.revision !== undefined) revision = plugin.host.revision
+  if (plugin?.host?.lastErrorCode || plugin?.host?.lastErrorMessage) {
+    errors.push(event(
+      plugin.host.lastErrorCode ?? "PLUGIN_RUNTIME_HOST_ERROR",
+      plugin.host.lastErrorMessage ?? plugin.host.lastErrorStage ?? "runtime plugin host error",
+    ))
+  }
+
+  return { errors, revision }
+}
+
+async function fetchJson(args: { url: string; method?: string; headers?: Record<string, string>; body?: unknown }): Promise<{ status: number; body: unknown }> {
+  const response = await fetch(args.url, {
+    method: args.method ?? "GET",
+    headers: {
+      ...(args.body === undefined ? {} : { "content-type": "application/json" }),
+      ...(args.headers ?? {}),
+    },
+    ...(args.body === undefined ? {} : { body: JSON.stringify(args.body) }),
+  })
+  return { status: response.status, body: await readJson(response) }
+}
+
+export async function runPluginSelfTest(options: RunPluginSelfTestOptions): Promise<SelfTestResult> {
+  const pluginId = options.pluginId.trim()
+  if (!pluginId) throw new Error("plugin id is required")
+  const workspaceId = inferSelfTestWorkspaceId(options.workspaceId)
+  const baseUrl = normalizeBaseUrl(inferSelfTestUrl(options.url))
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const panelId = buildPanelId(pluginId, options.panelId)
+  const panelInstanceId = buildPanelInstanceId(pluginId, panelId)
+  const selector = buildPanelSelector({ pluginId, panelId, panelInstanceId })
+  const headers = workspaceHeaders(workspaceId)
+
+  const pageErrors: SelfTestEvent[] = []
+  const consoleErrors: SelfTestEvent[] = []
+  const failedRequests: SelfTestFailedRequest[] = []
+  const browserEvents: BrowserPluginEvent[] = []
+
+  let browser: Browser
+  try {
+    const { chromium } = await import("playwright")
+    browser = await launchChromiumWithLazyInstall(chromium)
+  } catch (error) {
+    const setupError = error instanceof BrowserSetupError
+      ? error
+      : new BrowserSetupError("SELF_TEST_BROWSER_LAUNCH_FAILED", error instanceof Error ? error.message : String(error))
+    return {
+      ok: false,
+      ...(workspaceId ? { workspaceId } : {}),
+      pluginId,
+      reloadErrors: [event(setupError.code, setupError.message)],
+      pageErrors,
+      consoleErrors,
+      failedRequests,
+      pane: {
+        found: false,
+        state: "timeout",
+        selector,
+        panelId,
+        panelInstanceId,
+      },
+    }
+  }
+  const page = await browser.newPage()
+
+  page.on("pageerror", (err) => {
+    pageErrors.push(event("PAGE_ERROR", err.message))
+  })
+  page.on("console", (msg) => {
+    if (msg.type() !== "error") return
+    consoleErrors.push(event("CONSOLE_ERROR", msg.text()))
+  })
+  page.on("requestfailed", (request) => {
+    if (!shouldCaptureFailedRequest(request.url())) return
+    failedRequests.push({ url: redactUrl(request.url()) })
+  })
+  page.on("response", (response) => {
+    const status = response.status()
+    if (status < 400 || !shouldCaptureFailedRequest(response.url())) return
+    failedRequests.push({ status, url: redactUrl(response.url()) })
+  })
+
+  await page.addInitScript((eventName: string) => {
+    const key = "__boringPluginSelfTestEvents"
+    ;(window as unknown as Record<string, unknown>)[key] = []
+    window.addEventListener(eventName, (rawEvent) => {
+      const detail = (rawEvent as CustomEvent).detail
+      ;((window as unknown as Record<string, unknown>)[key] as unknown[]).push(detail)
+    })
+  }, PLUGIN_RELOAD_EVENT)
+
+  try {
+    const reload = await fetchJson({
+      url: apiUrl(baseUrl, "/api/v1/agent/reload"),
+      method: "POST",
+      headers,
+      body: {},
+    })
+    const diagnostics = await fetchJson({
+      url: apiUrl(baseUrl, "/api/v1/runtime-plugin-diagnostics"),
+      headers,
+    })
+    const normalized = normalizeDiagnostics({
+      pluginId,
+      reloadStatus: reload.status,
+      diagnosticsStatus: diagnostics.status,
+      reloadBody: reload.body,
+      diagnosticsBody: diagnostics.body,
+    })
+    const reloadErrors = [...normalized.errors]
+    let revision = normalized.revision
+
+    await page.goto(browserUrl(baseUrl, workspaceId), { waitUntil: "domcontentloaded", timeout: timeoutMs })
+
+    let frontEvent: BrowserPluginEvent | undefined
+    try {
+      const handle = await page.waitForFunction(
+        ({ id }: { id: string }) => {
+          const events = ((window as unknown as Record<string, unknown>).__boringPluginSelfTestEvents as Array<{ id?: string; type?: string }> | undefined) ?? []
+          return events.find((entry) => entry?.id === id && (
+            entry.type === "boring.plugin.load"
+            || entry.type === "boring.plugin.front-error"
+            || entry.type === "boring.plugin.error"
+          )) ?? null
+        },
+        { id: pluginId },
+        { timeout: timeoutMs },
+      )
+      frontEvent = await handle.jsonValue() as BrowserPluginEvent | undefined
+      if (frontEvent) browserEvents.push(frontEvent)
+      if (frontEvent?.revision !== undefined) revision = frontEvent.revision
+      if (frontEvent?.type === "boring.plugin.front-error" || frontEvent?.type === "boring.plugin.error") {
+        reloadErrors.push(event(frontEvent.code ?? "PLUGIN_FRONT_ERROR", frontEvent.message ?? "plugin front failed to load"))
+      }
+    } catch {
+      reloadErrors.push(event("PLUGIN_FRONT_REGISTRATION_TIMEOUT", `timed out waiting for browser registration event for ${pluginId}`))
+    }
+
+    let paneFound = false
+    let paneState: SelfTestResult["pane"]["state"] = "timeout"
+    if (frontEvent?.type === "boring.plugin.load") {
+      const openPanel = await fetchJson({
+        url: apiUrl(baseUrl, "/api/v1/ui/commands"),
+        method: "POST",
+        headers,
+        body: {
+          kind: "openPanel",
+          params: {
+            id: panelInstanceId,
+            component: panelId,
+            title: `Self-test: ${pluginId}`,
+          },
+        },
+      })
+      if (openPanel.status < 200 || openPanel.status >= 300) {
+        reloadErrors.push(event("OPEN_PANEL_HTTP_ERROR", `/api/v1/ui/commands returned ${openPanel.status}`))
+      }
+      try {
+        const locator = page.locator(selector)
+        await locator.waitFor({ state: "attached", timeout: timeoutMs })
+        paneFound = true
+        const fallback = locator.locator("[data-boring-plugin-suspense-fallback='true']")
+        if (await fallback.count() > 0) {
+          await fallback.waitFor({ state: "detached", timeout: timeoutMs })
+        }
+        // Give mounted panels one short tick to run initial effects so failed
+        // fetches and immediate render follow-up errors are captured before ok.
+        await page.waitForTimeout(Math.min(1_000, Math.max(250, Math.floor(timeoutMs / 10))))
+        const errorBoundary = await locator.locator("[data-boring-plugin-error-boundary='true']").count()
+        const stillLoading = await fallback.count()
+        paneState = stillLoading > 0 ? "timeout" : errorBoundary > 0 ? "error" : "ready"
+      } catch {
+        paneState = "timeout"
+      }
+    } else if (reloadErrors.length > 0) {
+      paneState = "error"
+    }
+
+    const result: SelfTestResult = {
+      ok: reloadErrors.length === 0
+        && pageErrors.length === 0
+        && consoleErrors.length === 0
+        && failedRequests.length === 0
+        && paneState === "ready",
+      ...(workspaceId ? { workspaceId } : {}),
+      pluginId,
+      ...(revision !== undefined ? { revision } : {}),
+      reloadErrors,
+      pageErrors,
+      consoleErrors,
+      failedRequests,
+      pane: {
+        found: paneFound,
+        state: paneState,
+        selector,
+        panelId,
+        panelInstanceId,
+      },
+    }
+    return result
+  } finally {
+    await browser.close()
+  }
+}
+
+export function formatSelfTestResult(result: SelfTestResult): string {
+  const lines = [
+    result.ok ? `OK ${result.pluginId}` : `FAIL ${result.pluginId}`,
+    `  pane     ${result.pane.state}${result.pane.found ? "" : " (not found)"}`,
+  ]
+  if (result.revision !== undefined) lines.push(`  revision ${result.revision}`)
+  for (const [label, events] of [
+    ["reload", result.reloadErrors],
+    ["page", result.pageErrors],
+    ["console", result.consoleErrors],
+  ] as const) {
+    for (const item of events) lines.push(`  ${label}   ${item.code}: ${item.message}`)
+  }
+  for (const item of result.failedRequests) {
+    lines.push(`  request  ${item.status ?? "failed"}: ${item.url}`)
+  }
+  return lines.join("\n")
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     "src/server/pluginDiscovery.ts",
     "src/server/pluginFrontRuntime.ts",
     "src/server/scaffoldPlugin.ts",
+    "src/server/testPlugin.ts",
     "src/server/verifyPlugin.ts",
   ],
   format: ["esm"],

--- a/packages/pi/skills/boring-plugin-authoring/SKILL.md
+++ b/packages/pi/skills/boring-plugin-authoring/SKILL.md
@@ -57,7 +57,8 @@ Hot-reloadable agent behavior belongs in `pi.extensions` / `pi.skills` / `pi.sys
 3. Read the generated files with the read tool.
 4. Edit them in place with the edit tool — do **NOT** rewrite from scratch.
 5. Run `boring-ui verify-plugin <kebab-name> "$BORING_AGENT_WORKSPACE_ROOT"` via bash. Fix anything it reports and re-run until it returns `OK`.
-6. Tell the user to run `/reload` for front/Pi asset changes. If you added `boring.server`, tell the user the workspace process must be statically composed with that package and restarted.
+6. If the workspace UI is already running, run `boring-ui test-plugin <kebab-name>` via bash. It infers the URL from `BORING_UI_SELF_TEST_URL`, `BORING_UI_URL`, `BORING_WORKSPACE_URL`, `PORT`, then `http://127.0.0.1:5200`; it infers workspaces-mode scope from `BORING_UI_WORKSPACE_ID`, `BORING_WORKSPACE_ID`, or `BORING_AGENT_WORKSPACE_ID`. Pass `--url <url>` / `--workspace <id>` only when inference is wrong. Add `--panel-id <id>` if the plugin's main panel is not `<kebab-name>.panel`. On first run, it may lazily install Playwright Chromium into `.boring-agent/playwright-browsers`. Fix render/import/network failures and re-run until it returns `OK`.
+7. Tell the user to run `/reload` for front/Pi asset changes. If you added `boring.server`, tell the user the workspace process must be statically composed with that package and restarted.
 
 If the scaffold says the plugin already exists, you can read the existing
 files directly and skip the scaffold step.

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -142,6 +142,8 @@ export interface CreateWorkspaceAgentServerOptions
   additionalBoringPluginDirs?: string[]
   /** Optional host-owned front-target override for boring plugin list/event payloads. */
   boringPluginFrontTargetResolver?: BoringPluginFrontTargetResolver
+  /** Extra host-provided env vars for provisioned agent/runtime commands. */
+  runtimeEnv?: Record<string, string>
   /** Preserve legacy `/@fs/...` frontUrl payloads alongside frontTarget. Defaults to true. */
   boringPluginIncludeLegacyFrontUrl?: boolean
 }
@@ -159,7 +161,25 @@ function boringPiRootVisibleToAgentTools(workspaceRoot: string, resolvedMode: st
   return "/workspace/.boring-agent/node/node_modules/@hachej/boring-pi"
 }
 
+const RESERVED_RUNTIME_ENV_KEYS = new Set([
+  "BORING_AGENT_WORKSPACE_ROOT",
+  "VIRTUAL_ENV",
+  "HOME",
+  "PYTHONHOME",
+  "PATH",
+  "UV_CACHE_DIR",
+  "PIP_CACHE_DIR",
+  "npm_config_cache",
+])
 
+function validateRuntimeEnv(env: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!env) return undefined
+  const reserved = Object.keys(env).filter((key) => RESERVED_RUNTIME_ENV_KEYS.has(key))
+  if (reserved.length > 0) {
+    throw new Error(`runtimeEnv cannot override reserved runtime keys: ${reserved.join(", ")}`)
+  }
+  return env
+}
 
 function resolveWorkspacePackageRoot(): string {
   const candidates = [
@@ -679,6 +699,7 @@ export async function createWorkspaceAgentServer(
       env: {
         ...provisioned.env,
         BORING_AGENT_WORKSPACE_LOCAL_PLUGIN_ROOTS: workspaceFsCapability === "strong" ? "1" : "0",
+        ...(validateRuntimeEnv(opts.runtimeEnv) ?? {}),
       },
     } : currentRuntimeProvisioning
     return currentRuntimeProvisioning

--- a/packages/workspace/src/front/agentPlugins/registerAgentPlugin.tsx
+++ b/packages/workspace/src/front/agentPlugins/registerAgentPlugin.tsx
@@ -159,6 +159,7 @@ async function captureFrontFactory(pluginId: string, frontUrl: string, revision:
  */
 function buildRegistryPayloads(
   pluginId: string,
+  revision: number,
   captured: CapturedBoringFrontRegistrations,
 ): {
   panels: PanelConfig[]
@@ -175,6 +176,7 @@ function buildRegistryPayloads(
       placement: panel.placement ?? "center",
       source: panel.source ?? "plugin",
       pluginId,
+      pluginRevision: revision,
       ...(panel.icon ? { icon: panel.icon } : {}),
       ...(panel.requiresCapabilities ? { requiresCapabilities: panel.requiresCapabilities } : {}),
       ...(panel.essential !== undefined ? { essential: panel.essential } : {}),
@@ -190,6 +192,7 @@ function buildRegistryPayloads(
       placement: "left-tab",
       source: tab.source ?? "plugin",
       pluginId,
+      pluginRevision: revision,
       ...(tab.icon ? { icon: tab.icon } : {}),
       ...(tab.requiresCapabilities ? { requiresCapabilities: tab.requiresCapabilities } : {}),
       ...(tab.lazy !== undefined ? { lazy: tab.lazy } : {}),
@@ -291,6 +294,7 @@ function assertNoOutputCollisions(
 
 function commitCapturedFrontFactory(
   pluginId: string,
+  revision: number,
   captured: CapturedBoringFrontRegistrations,
   registries: ReturnType<typeof getRegistries>,
 ): void {
@@ -301,7 +305,7 @@ function commitCapturedFrontFactory(
     // existing static or previously-loaded registrations.
     throw new Error(`PLUGIN_UNSUPPORTED_DYNAMIC_CONTRIBUTIONS: plugin "${pluginId}" registered provider/binding outputs that require an app restart`)
   }
-  const payloads = buildRegistryPayloads(pluginId, captured)
+  const payloads = buildRegistryPayloads(pluginId, revision, captured)
   assertNoOutputCollisions(pluginId, payloads, registries)
   registries.panels.replaceByPluginId(pluginId, payloads.panels)
   registries.commands.replaceByPluginId(pluginId, payloads.commands)
@@ -389,7 +393,7 @@ export function useAgentPluginHotReload(options: RegisterAgentPluginOptions): vo
           // Subscribers (including DockView) see exactly one
           // transition — never an intermediate empty state.
           try {
-            commitCapturedFrontFactory(event.id, captured, registries)
+            commitCapturedFrontFactory(event.id, event.revision, captured, registries)
           } catch (error) {
             throw {
               stage: "register",

--- a/packages/workspace/src/front/plugin/PluginErrorBoundary.tsx
+++ b/packages/workspace/src/front/plugin/PluginErrorBoundary.tsx
@@ -40,11 +40,18 @@ export class PluginErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.error) {
       return (
-        <ErrorChip
-          pluginId={this.props.pluginId}
-          message={this.state.error.message}
-          kind={this.props.contributionKind}
-        />
+        <div
+          data-boring-plugin-error-boundary="true"
+          data-boring-plugin-id={this.props.pluginId}
+          data-boring-contribution-kind={this.props.contributionKind}
+          data-boring-contribution-id={this.props.contributionId}
+        >
+          <ErrorChip
+            pluginId={this.props.pluginId}
+            message={this.state.error.message}
+            kind={this.props.contributionKind}
+          />
+        </div>
       )
     }
     return this.props.children

--- a/packages/workspace/src/front/registry/PanelRegistry.ts
+++ b/packages/workspace/src/front/registry/PanelRegistry.ts
@@ -2,6 +2,20 @@ import { Suspense, createElement, lazy, useMemo, useSyncExternalStore, type Comp
 import type { PanelConfig, PanelRegistration } from "./types"
 import { PluginErrorBoundary } from "../plugin/PluginErrorBoundary"
 
+export function panelSelfTestAttributes(args: {
+  pluginId: string
+  panelId: string
+  panelInstanceId?: string
+  pluginRevision?: number
+}): Record<string, string> {
+  return {
+    "data-boring-plugin-id": args.pluginId,
+    "data-boring-panel-component-id": args.panelId,
+    ...(args.panelInstanceId ? { "data-boring-panel-instance-id": args.panelInstanceId } : {}),
+    ...(args.pluginRevision !== undefined ? { "data-boring-plugin-revision": String(args.pluginRevision) } : {}),
+  }
+}
+
 export class PanelRegistry {
   private panels = new Map<string, PanelConfig>()
   private registrationOrder: string[] = []
@@ -155,24 +169,36 @@ export class PanelRegistry {
         return current.component as ComponentType<any>
       }, [current?.component, current?.lazy, current?.requiresCapabilities, gen])
       const pluginId = current?.pluginId ?? current?.id ?? panelId
+      const pluginRevision = current?.pluginRevision
+      const panelInstanceId = typeof props?.api?.id === "string" ? props.api.id : undefined
       return createElement(
-        PluginErrorBoundary,
+        "div",
         {
-          pluginId,
-          contributionKind: "panel" as const,
-          contributionId: panelId,
-          children: createElement(
-            Suspense,
-            {
-              fallback: createElement(
-                "div",
-                { className: "flex h-full items-center justify-center text-sm text-muted-foreground" },
-                "Loading…",
-              ),
-              children: createElement(Inner, props),
-            },
-          ),
+          className: "h-full min-h-0",
+          ...panelSelfTestAttributes({ pluginId, panelId, panelInstanceId, pluginRevision }),
         },
+        createElement(
+          PluginErrorBoundary,
+          {
+            pluginId,
+            contributionKind: "panel" as const,
+            contributionId: panelId,
+            children: createElement(
+              Suspense,
+              {
+                fallback: createElement(
+                  "div",
+                  {
+                    className: "flex h-full items-center justify-center text-sm text-muted-foreground",
+                    "data-boring-plugin-suspense-fallback": "true",
+                  },
+                  "Loading…",
+                ),
+                children: createElement(Inner, props),
+              },
+            ),
+          },
+        ),
       )
     }
     this.wrapperComponentCache.set(panelId, WrappedPanel)

--- a/packages/workspace/src/front/registry/__tests__/panelSelfTestAttributes.test.ts
+++ b/packages/workspace/src/front/registry/__tests__/panelSelfTestAttributes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest"
+import { panelSelfTestAttributes } from "../PanelRegistry"
+
+describe("panelSelfTestAttributes", () => {
+  test("builds deterministic plugin panel markers", () => {
+    expect(panelSelfTestAttributes({
+      pluginId: "demo",
+      panelId: "demo.panel",
+      panelInstanceId: "self-test:demo:demo.panel",
+      pluginRevision: 7,
+    })).toEqual({
+      "data-boring-plugin-id": "demo",
+      "data-boring-panel-component-id": "demo.panel",
+      "data-boring-panel-instance-id": "self-test:demo:demo.panel",
+      "data-boring-plugin-revision": "7",
+    })
+  })
+
+  test("omits optional panel instance and revision markers", () => {
+    expect(panelSelfTestAttributes({ pluginId: "static", panelId: "static.panel" })).toEqual({
+      "data-boring-plugin-id": "static",
+      "data-boring-panel-component-id": "static.panel",
+    })
+  })
+})

--- a/packages/workspace/src/shared/types/panel.ts
+++ b/packages/workspace/src/shared/types/panel.ts
@@ -48,6 +48,8 @@ export interface PanelConfig<T = any> {
   /** Source: "builtin" | "app" */
   source?: string
   pluginId?: string
+  /** Runtime plugin revision for hot-loaded plugin panels. Static panels omit it. */
+  pluginRevision?: number
   /**
    * Whether to wrap the component with React.lazy + Suspense. Omit to let
    * the registry auto-detect: zero-arg functions (factories) are treated as

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -399,6 +399,9 @@ importers:
       lucide-react:
         specifier: ^1.8.0
         version: 1.8.0(react@19.2.5)
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       typescript:
         specifier: ^5.8.3
         version: 5.9.3


### PR DESCRIPTION
## Summary\n- add `boring-ui test-plugin <name> --url <url>` for headless runtime-plugin checks\n- capture reload diagnostics, browser registration errors, page errors, console errors, failed requests, and panel render/error-boundary state\n- add deterministic panel/fallback/error DOM markers and carry runtime plugin revisions into panel config\n- update plugin authoring skill/scaffold guidance to run `test-plugin` when a UI server is available\n\n## Validation\n- pnpm --filter @hachej/boring-workspace run test src/front/registry/__tests__/panelSelfTestAttributes.test.ts\n- pnpm --filter @hachej/boring-ui-cli run test src/__tests__/testPlugin.test.ts\n- pnpm --filter @hachej/boring-workspace run typecheck\n- pnpm --filter @hachej/boring-ui-cli run typecheck\n- pnpm --filter @hachej/boring-ui-cli run build\n\n## Review\n- subagent reviewer verdict: ship