### PR TITLE
docs: plan CLI/local runtime plugin MVP

### DIFF
--- a/docs/plans/runtime-plugin-cli-local/00-vision-taxonomy.md
+++ b/docs/plans/runtime-plugin-cli-local/00-vision-taxonomy.md
@@ -1,0 +1,99 @@
+# 00 — Vision and plugin taxonomy
+
+## Thesis
+
+Boring uses plugin APIs as a composition primitive, but not all plugin code has the same trust or lifecycle.
+
+```txt
+Internal plugins extend the app.
+External plugins extend the workspace runtime.
+```
+
+## Internal/app plugins
+
+Internal plugins are app-owned, trusted modules shipped with the app.
+
+Examples:
+
+- first-party app plugins;
+- app-owned data/catalog plugins;
+- admin/domain integrations;
+- Macro-style domain APIs.
+
+Allowed:
+
+- native host React UI;
+- `boring.server`;
+- boot-time Fastify routes;
+- host agent tools;
+- app DB/auth/service access when app owner coded it.
+
+Lifecycle:
+
+```txt
+server/routes/tools: boot-time only, restart/redeploy required
+front/Pi in dev: may hot reload through current asset paths
+```
+
+## External CLI/local plugins
+
+External plugins are installed or generated after the CLI workspace exists.
+
+Examples:
+
+- `.pi/extensions/csv-viewer`;
+- npm/git Boring plugin package installed as a Pi package source with `boring-ui-plugin install`;
+- agent-authored local plugin.
+
+CLI/local trust model mirrors Pi:
+
+```txt
+boring-ui-plugin install <source> = trusted local code, enabled by default
+```
+
+Allowed in CLI/local MVP:
+
+- native frontend panels/commands/surface resolvers;
+- Pi extensions/skills/system prompts;
+- runtime backend handlers through a Boring-owned gateway;
+- npm/git/local package installs like Pi.
+
+Not allowed:
+
+- raw Fastify hot registration;
+- host app DB/auth internals by default;
+- changing internal/app server routes without restart;
+- remote sandbox/cloud assumptions.
+
+## Remote sandbox/cloud external plugins
+
+Deferred.
+
+Do not design CLI/local implementation around remote hot reload. Remote external install likely needs host/control-plane mediation and sandbox restart/reprovision. That is a later plan.
+
+## Backend distinction
+
+```txt
+boring.server
+  internal/app trusted server plugin at boot, or external CLI/local runtime backend through the constrained runtime-server contract
+  raw Fastify routes OK only for internal/app trusted server plugins
+  external CLI/local handlers are loaded with shared jiti helper
+  external CLI/local handlers are mounted through /api/v1/plugins/:pluginId/* gateway
+  /reload swaps external handler registry
+```
+
+## CLI MVP product wording
+
+When CLI starts:
+
+```txt
+Local plugin mode enabled: installed Boring plugins run as trusted local code.
+Backend handlers are exposed only under /api/v1/plugins/:pluginId/*.
+Use -l/--local on install to scope a plugin to one workspace.
+```
+
+When installing third-party source:
+
+```txt
+Security: Boring plugins run as trusted local code in CLI mode. Review third-party source before installing.
+```

--- a/docs/plans/runtime-plugin-cli-local/01-current-state-and-pr-delta.md
+++ b/docs/plans/runtime-plugin-cli-local/01-current-state-and-pr-delta.md
@@ -1,0 +1,148 @@
+# 01 — Current state and PR delta
+
+## Current plugin system
+
+### Front plugin API
+
+Current front plugins use:
+
+```ts
+import { definePlugin } from "@hachej/boring-workspace/plugin"
+```
+
+Supported front outputs:
+
+- panels;
+- commands;
+- left tabs;
+- catalogs;
+- surface resolvers;
+- providers/bindings for static composition.
+
+Hot-loaded runtime fronts:
+
+- load via `/api/v1/agent-plugins/events` SSE;
+- dynamic import with revision/cache-bust;
+- atomically replace plugin-owned panels/commands/catalogs/resolvers;
+- preserve prior working UI if import/register fails;
+- do not dynamically mount providers/bindings.
+
+### Server plugin API
+
+Internal trusted server plugins use:
+
+```ts
+import { defineServerPlugin } from "@hachej/boring-workspace/server"
+```
+
+They can contribute:
+
+- `routes`;
+- `agentTools`;
+- `systemPrompt`;
+- `piPackages`;
+- `extensionPaths`;
+- `skills`;
+- `provisioning`.
+
+These are boot-composed. Server route/tool changes require restart.
+
+### Runtime discovery
+
+Runtime plugin discovery currently scans:
+
+```txt
+<workspace>/.pi/extensions/
+~/.pi/agent/extensions/
+app/default plugin package dirs
+additional plugin dirs
+```
+
+`BoringPluginAssetManager` owns:
+
+- manifest scan/validation;
+- signatures/revisions;
+- load/unload/error events;
+- plugin list/error routes;
+- dynamic Pi snapshot from `package.json#pi`.
+
+It must **not** own executable backend handler tables.
+
+### Existing jiti behavior
+
+Already implemented:
+
+- `pluginEntryResolver.ts` uses `createJiti(import.meta.url, { moduleCache: false })` for dir-source `boring.server` entries with `hotReload: true`.
+- `rebuildServerPlugins.ts` re-resolves those entries on `/reload`.
+
+Important limitation:
+
+```txt
+current: jiti import -> validate -> diagnostics only
+needed:  jiti import -> capture handlers -> atomic registry swap -> gateway dispatch
+```
+
+## PR #157 — File records data access
+
+Adds:
+
+- `GET /api/v1/files/records`;
+- JSON array / NDJSON / CSV reader;
+- bounded pagination/search;
+- `readFileRecords()` front helper;
+- runtime singleton export.
+
+Value:
+
+- plugin UIs can read file-backed tabular data without bundling huge JSON;
+- avoids premature generic DB/RPC system.
+
+Limitations:
+
+- read-only;
+- no SQL/DuckDB/SQLite/parquet;
+- no structured filters/facets/sorts.
+
+## PR #158 — WorkspaceLink
+
+Adds:
+
+- `WorkspaceLink`;
+- `workspaceLinkCommand()`;
+- `workspaceLinkHref()`;
+- open file/surface/panel/expand targets.
+
+Value:
+
+- plugin UIs can navigate the workspace through `postUiCommand`;
+- avoids backend route hacks for UI control.
+
+## PR #159 — Runtime plugin self-test
+
+Adds:
+
+- `boring-ui test-plugin <name>`;
+- Playwright reload/render smoke test;
+- browser errors, console errors, failed requests;
+- deterministic panel/error/fallback DOM markers.
+
+Value:
+
+- agents can verify plugin UI without human eyeballs;
+- should become post-install smoke check for `boring-ui-plugin install` / `boring-ui plugin install`.
+
+## Combined PR result
+
+After #157/#158/#159, runtime plugins can:
+
+```txt
+scaffold -> verify -> /reload -> read file records -> navigate workspace -> self-test UI
+```
+
+Still missing:
+
+- Pi-style install/list/remove/update;
+- runtime backend gateway;
+- source provenance/gating;
+- unified reload coordinator;
+- backend health/self-test integration.

--- a/docs/plans/runtime-plugin-cli-local/02-runtime-backend-gateway.md
+++ b/docs/plans/runtime-plugin-cli-local/02-runtime-backend-gateway.md
@@ -1,0 +1,188 @@
+# 02 — Runtime backend gateway
+
+## Goal
+
+Allow CLI/local external plugins to expose hot-reloadable backend handlers without mutating Fastify routes at runtime.
+
+## Non-goals
+
+- No raw `app.get()` / `app.post()` from runtime plugins.
+- No dynamic host `agentTools` rewiring in this phase.
+- No remote sandbox backend support.
+- No bwrap worker/proxy in MVP.
+- No app/internal route migration.
+
+## Manifest field
+
+Use the single plugin-facing server field:
+
+```jsonc
+{
+  "name": "email-client",
+  "boring": {
+    "front": "front/index.tsx",
+    "server": "server/index.ts"
+  }
+}
+```
+
+Rules:
+
+- `boring.server` is boot-time/raw Fastify only for internal/app trusted plugins.
+- `boring.server` is CLI/local external runtime backend when discovered from external Pi package sources.
+- External runtime backend modules use the constrained runtime-server contract; raw Fastify is not allowed.
+- Server path must be safe and contained in plugin root.
+- Runtime server module never declares identity; loader supplies `pluginId` from manifest/source metadata.
+
+## Public API
+
+Subpath:
+
+```txt
+@hachej/boring-workspace/runtime-server
+```
+
+Example:
+
+```ts
+import { defineRuntimeServerPlugin } from "@hachej/boring-workspace/runtime-server"
+
+export default defineRuntimeServerPlugin({
+  routes(router) {
+    router.get("/messages", async (ctx) => ({ messages: [] }))
+    router.post("/send", async (ctx) => {
+      const body = await ctx.json()
+      return { ok: true }
+    })
+  },
+  async dispose() {
+    // cleanup timers/watchers/resources
+  },
+})
+```
+
+The runtime module must not include `id`. Reject or ignore `id`; prefer reject to keep API clean.
+
+## Handler context MVP
+
+```ts
+type RuntimePluginContext = {
+  pluginId: string
+  method: string
+  path: string
+  query: URLSearchParams
+  headers: ReadonlyHeaders
+  signal: AbortSignal
+  json<T = unknown>(): Promise<T>
+  text(): Promise<string>
+  logger: PluginLogger
+}
+```
+
+No `workspace` in MVP. Add a future facade only after exact methods are defined. Never expose `workspace.root` or raw host paths.
+
+## Gateway endpoint
+
+Plugin-owned gateway space:
+
+```txt
+/api/v1/plugins/:pluginId/*
+```
+
+Host management/health must not live under this same wildcard. Use existing management namespace:
+
+```txt
+/api/v1/agent-plugins
+/api/v1/agent-plugins/:pluginId/health
+```
+
+If a plugin registers `/health`, it is plugin-owned under:
+
+```txt
+/api/v1/plugins/:pluginId/health
+```
+
+Self-test may call plugin `/health`; host health must use `/api/v1/agent-plugins/:pluginId/health`.
+
+## Router MVP
+
+Exact-match only.
+
+```txt
+key = METHOD + normalizedPath
+```
+
+No params, wildcards, route order, or custom mini-router in MVP. If params become necessary later, use a real router/matcher dependency.
+
+## Modules
+
+```txt
+packages/workspace/src/server/pluginImports/
+  importServerModule.ts
+
+packages/workspace/src/server/runtimeBackend/
+  defineRuntimeServerPlugin.ts
+  routerCapture.ts
+  runtimeServerLoader.ts
+  runtimeBackendRegistry.ts
+  runtimeBackendGateway.ts
+  runtimeBackendResponse.ts
+  runtimeBackendHealth.ts
+  index.ts
+```
+
+`importServerModule.ts` should extract the existing jiti/native import helper from `pluginEntryResolver.ts`. Existing internal `boring.server` diagnostics and external runtime `boring.server` loading use it.
+
+## Response contract
+
+Avoid magical ambiguous return types.
+
+Use either plain JSON values or explicit response objects:
+
+```ts
+type RuntimePluginResult =
+  | null
+  | undefined
+  | string
+  | Uint8Array
+  | JsonValue
+  | { kind: "response"; status?: number; headers?: Record<string, string>; body?: RuntimePluginResultBody }
+```
+
+A plain object with `status` is still JSON unless `kind: "response"` is present.
+
+Stable errors:
+
+```txt
+RUNTIME_PLUGIN_NOT_FOUND
+RUNTIME_PLUGIN_ROUTE_NOT_FOUND
+RUNTIME_PLUGIN_HANDLER_FAILED
+RUNTIME_PLUGIN_LOAD_FAILED
+RUNTIME_PLUGIN_RESPONSE_UNSUPPORTED
+```
+
+Use canonical error-code enum/import path. No raw string codes.
+
+## Registry invariants
+
+- `reloadFromLoadedPlugins()` is serialized/single-flight.
+- Replacement installs next table before disposing previous.
+- Failed load keeps previous table live.
+- First failed load leaves backend disabled.
+- Dispose errors become diagnostics/health entries, never full reload aborts.
+- App close disposes all active backends exactly once.
+
+## Tests
+
+Required:
+
+- jiti module cache false sees source edits;
+- runtime module with `id` is rejected;
+- exact-match route dispatch;
+- unsafe route paths rejected;
+- duplicate method/path rejected;
+- syntax error keeps previous handler live;
+- remove/unload disposes handlers;
+- app close disposes handlers;
+- host health path does not conflict with plugin gateway path;
+- workspaces mode rejects cross-workspace gateway calls.

--- a/docs/plans/runtime-plugin-cli-local/03-pi-style-install.md
+++ b/docs/plans/runtime-plugin-cli-local/03-pi-style-install.md
@@ -1,0 +1,167 @@
+# 03 — Pi package-source install/list/remove/update
+
+## Goal
+
+Add external plugin installation using the same package-source model as Pi.
+
+A boring plugin package is a Pi package: boring reads `package.json#boring`, Pi reads `package.json#pi`, and Pi no-ops when a package has no `pi` resources.
+
+```txt
+boring-ui-plugin install <source> = trusted local code, enabled by default
+```
+
+No permission prompts/grants in CLI/local MVP.
+
+## Commands
+
+Mirror Pi package-source commands. Implementation lives in `boring-ui-plugin`; top-level `boring-ui plugin ...` may call the same handlers.
+
+```bash
+boring-ui-plugin install npm:@boring-plugins/email-client
+boring-ui-plugin install git:github.com/user/email-client@v1
+boring-ui-plugin install https://github.com/user/email-client
+boring-ui-plugin install ./plugins/email-client
+boring-ui-plugin install /absolute/path/to/email-client
+
+boring-ui-plugin remove npm:@boring-plugins/email-client
+boring-ui-plugin list [--json]
+
+boring-ui plugin install ./plugins/email-client   # facade/reuse, if exposed
+```
+
+## Scope
+
+Mirror Pi scope:
+
+```bash
+boring-ui-plugin install <source>       # global/user install by default
+boring-ui-plugin install -l <source>    # workspace-local/project install
+boring-ui-plugin install --local <source>
+```
+
+Install output must say scope clearly.
+
+Global example:
+
+```txt
+Installed globally: ~/.pi/agent/npm/@boring-plugins/email-client
+This plugin will load in all boring-ui CLI workspaces.
+Run with -l/--local to install only in the current workspace.
+```
+
+Local example:
+
+```txt
+Installed for this workspace: <workspace>/.pi/npm/@boring-plugins/email-client
+```
+
+## Roots
+
+Global/user:
+
+```txt
+~/.pi/agent/npm/
+~/.pi/agent/git/
+~/.pi/agent/extensions/
+```
+
+Workspace-local/project:
+
+```txt
+<workspace>/.pi/npm/
+<workspace>/.pi/git/
+<workspace>/.pi/extensions/
+```
+
+## Collision rule
+
+```txt
+workspace-local plugin wins over global plugin with same id
+```
+
+This must be explicit in discovery/source ordering and tested.
+
+## Source behavior
+
+### npm
+
+- Install into scope-specific npm root.
+- Delegate to configured package manager like Pi where possible.
+- Dependencies install through package manager.
+- Versioned specs are pinned.
+
+### git / URL
+
+- Clone into scope-specific git root.
+- Support refs (`@v1`, tag, commit).
+- Run dependency install if `package.json` exists, like Pi.
+- Pinned refs should not silently move on update.
+
+### local path
+
+Mirror Pi first:
+
+- local path is referenced, not copied;
+- relative path resolves against settings/scope file;
+- no dependency install unless user already did it;
+- copy/link modes can come later if needed.
+
+## Boring activation
+
+After install:
+
+1. resolve package root;
+2. read `package.json`;
+3. validate Boring manifest;
+4. derive plugin id from package name;
+5. write/update the Pi package source entry for the selected scope;
+6. make boring discovery read the same Pi package source roots and scan `package.json#boring`;
+7. make Pi resource loading read `package.json#pi` from the same package roots;
+8. run `verify-plugin` if applicable;
+9. run `test-plugin` if UI URL is known and user asks/flag is set;
+10. tell user to run `/reload` or trigger reload when safe.
+
+No separate `.pi/boring-plugin-sources.json` registry. Do not duplicate local plugin source trees into `.pi/extensions`; local paths remain editable source roots.
+
+MVP can keep reload user-driven to match current plugin workflow.
+
+## Security wording
+
+For npm/git/URL:
+
+```txt
+Security: Boring plugins run as trusted local code in CLI mode. Review third-party source before installing.
+```
+
+No permission grants in CLI/local MVP. Hosted/cloud policy can add grants later.
+
+## Workspaces mode
+
+Global plugin:
+
+- visible to all CLI workspaces;
+- must not bypass workspace request scoping.
+
+Workspace-local plugin:
+
+- visible only for that workspace;
+- must not activate in another workspace.
+
+Gateway calls in workspaces mode must check workspace id/header using the same policy as adjacent workspace APIs.
+
+## Tests
+
+Required:
+
+- global install appears in two workspaces;
+- local install appears only in that workspace;
+- local shadows global same-id plugin;
+- list shows scope/source/id;
+- remove global does not remove local;
+- remove local does not remove global;
+- npm/git/local source parsing matches Pi-style examples;
+- third-party warning prints for npm/git/URL;
+- install validates Boring manifest before activation;
+- a package with only `package.json#boring` and no `package.json#pi` is valid and causes Pi to no-op;
+- installed package source appears in boring `/api/v1/agent-plugins` after `/reload`;
+- no custom boring source registry is created.

--- a/docs/plans/runtime-plugin-cli-local/04-reload-source-health.md
+++ b/docs/plans/runtime-plugin-cli-local/04-reload-source-health.md
@@ -1,0 +1,184 @@
+# 04 — Source provenance, reload coordinator, and health
+
+## Goal
+
+Prevent runtime plugin work from becoming reload/source/lifecycle spaghetti.
+
+## Ownership table
+
+| Component | Owns | Must not own |
+| --- | --- | --- |
+| `BoringPluginAssetManager` | scan, manifest validation, signatures, revisions, SSE scan events | executable route tables, install policy, health aggregation |
+| Pi package source collector | Pi package source settings, scope, provenance, source ordering | route dispatch, Fastify handlers, boring-only registry files |
+| Runtime backend registry | executable handler tables, atomic swap, dispose, backend health | manifest scanning, npm/git install |
+| Reload coordinator | sequencing reload work and merging diagnostics | individual scan/import/dispatch internals |
+| Health aggregator | front/Pi/backend/self-test summary | source install or route dispatch |
+| CLI commands | install/list/remove/update UX | reload internals |
+
+## First-class package source metadata
+
+Do not pass bare path strings when trust/scope matters. The source of truth is Pi package source settings/roots; boring annotates resolved package roots with source metadata while scanning `package.json#boring`.
+
+No `.pi/boring-plugin-sources.json` or duplicate boring-owned registry.
+
+Use resolved source metadata like:
+
+```ts
+type BoringPluginSource = {
+  root: string
+  kind: "workspace-extension" | "global-extension" | "default-package" | "additional-dir" | "npm-package" | "git-package" | "local-path"
+  scope: "workspace" | "global" | "app"
+  workspaceId?: string
+}
+```
+
+Runtime backend permission is derived from source kind/scope in one place, not stored as a drift-prone boolean on every record.
+
+Rename planning concept:
+
+```txt
+collectBoringPluginDirs -> collectBoringPluginPackageSources
+```
+
+Scanner/load results must preserve source metadata:
+
+```ts
+type LoadedBoringPlugin = {
+  id: string
+  revision: number
+  rootDir: string
+  runtimeServerPath?: string
+  source: BoringPluginSource
+}
+```
+
+Runtime backend registry must receive a source-aware load decision from the collector/loader; it must not infer trust from paths.
+
+## Source activation rules
+
+MVP:
+
+```txt
+workspace/global external package sources can activate `boring.server`
+app/default-package sources cannot, unless explicit later opt-in
+```
+
+Workspace-local source must match current workspace id in workspaces mode.
+
+## Reload coordinator
+
+Before adding backend reload, extract existing reload sequence unchanged.
+
+New file:
+
+```txt
+packages/workspace/src/app/server/workspacePluginReload.ts
+```
+
+Two-step PR:
+
+```txt
+PR C0: extract current reload flow into workspacePluginReload.ts with no behavior change
+PR C1: add runtimeBackendRegistry.reloadFromLoadedPlugins(...) to coordinator
+```
+
+Coordinator sequence:
+
+```txt
+assetManager.load()
+  ↓
+runtimeBackendRegistry.reloadFromLoadedPlugins(loaded)
+  ↓
+rebuildServerPlugins() diagnostic-only for boring.server
+  ↓
+runRuntimeProvisioning()
+  ↓
+opts.beforeReload()
+  ↓
+merge diagnostics/restart_warnings/backend health
+```
+
+Both reload entrypoints use same coordinator closure:
+
+- chat/agent reload: `/api/v1/agent/reload` via `createAgentApp.beforeReload`;
+- developer reload endpoint: `/api/boring.reload`.
+
+Do not duplicate sequencing in both places.
+
+## Caller hook behavior
+
+`opts.beforeReload` runs after Boring-owned scan/backend/provisioning work.
+
+It must be wrapped so a caller hook failure becomes diagnostics unless the caller explicitly wants to abort. Do not let one caller hook failure mask plugin diagnostics.
+
+## Health namespaces
+
+Avoid path conflict.
+
+Plugin gateway owns:
+
+```txt
+/api/v1/plugins/:pluginId/*
+```
+
+Host management/health owns:
+
+```txt
+/api/v1/agent-plugins
+/api/v1/agent-plugins/:pluginId/health
+```
+
+Do not put host health under `/api/v1/plugins/:pluginId/health`; that path belongs to plugin gateway.
+
+## Health aggregation
+
+Health should summarize, not own underlying state:
+
+```ts
+type PluginHealth = {
+  pluginId: string
+  scope: "workspace" | "global" | "app"
+  sourceKind: string
+  revision: number
+  front?: { status: "ok" | "error" | "disabled"; message?: string }
+  pi?: { status: "ok" | "error" | "disabled"; message?: string }
+  backend?: { status: "ok" | "error" | "disabled"; message?: string }
+  selfTest?: { lastRunAt?: string; ok?: boolean; message?: string }
+}
+```
+
+## Self-test integration
+
+PR #159 gives UI self-test.
+
+Extend later:
+
+- if plugin manifest declares backend health path, call gateway path;
+- include backend status in `test-plugin` JSON/text output;
+- store last self-test result in health aggregator.
+
+Backend health declaration example:
+
+```jsonc
+{
+  "boring": {
+    "runtimeServer": "server/index.ts",
+    "health": { "path": "/health" }
+  }
+}
+```
+
+This is plugin-owned `/health` under gateway, not host metadata path.
+
+## Tests
+
+Required:
+
+- Pi package source metadata preserved through scan/load result;
+- package with `package.json#boring` but no `package.json#pi` loads in boring and no-ops in Pi;
+- runtime backend refuses default-package source;
+- workspace-local source refuses wrong workspace;
+- both reload endpoints use same coordinator behavior;
+- coordinator handles scan error + backend error + caller hook diagnostic together;
+- host health path does not conflict with gateway path;
+- self-test can report backend health separately from front health.

--- a/docs/plans/runtime-plugin-cli-local/05-implementation-tickets.md
+++ b/docs/plans/runtime-plugin-cli-local/05-implementation-tickets.md
@@ -1,0 +1,244 @@
+# 05 — Implementation ticket split
+
+Do not implement this as one giant PR.
+
+## Ticket 1 — Taxonomy docs + manifest/source metadata
+
+Goal: make the data model explicit.
+
+Allowed files/modules:
+
+- plugin docs/skills;
+- manifest validation/types;
+- source metadata types;
+- Pi package source collector naming/design.
+
+Tasks:
+
+- document internal vs external vs remote-deferred;
+- keep one `boring.server` manifest field and document its source-dependent semantics;
+- add package source metadata type proposal;
+- ensure scanner can preserve Pi package source metadata in load result;
+- decide package export names.
+
+Non-goals:
+
+- no gateway;
+- no install command;
+- no runtime backend execution.
+
+Acceptance:
+
+- docs no longer say runtime plugins are absolutely route-free;
+- docs say raw Fastify is still forbidden for external runtime plugins;
+- manifest has clear `boring.server` semantics: internal/app raw Fastify at boot, external CLI/local constrained runtime backend through gateway.
+
+## Ticket 2 — Reload coordinator extraction
+
+Goal: code-judo before new behavior.
+
+Allowed files/modules:
+
+- `createWorkspaceAgentServer.ts` only to remove inline orchestration and call coordinator;
+- new `workspacePluginReload.ts`;
+- reload tests.
+
+Tasks:
+
+- extract existing reload flow unchanged;
+- make `/api/v1/agent/reload` and `/api/boring.reload` share coordinator closure;
+- preserve existing diagnostics/restart warnings exactly.
+
+Non-goals:
+
+- no runtime backend;
+- no source install;
+- no behavior change.
+
+Acceptance:
+
+- existing tests pass;
+- new tests prove both reload endpoints share same behavior;
+- `createWorkspaceAgentServer.ts` gets smaller or at least does not grow.
+
+## Ticket 3 — Shared jiti import helper
+
+Goal: reuse existing jiti behavior cleanly.
+
+Allowed files/modules:
+
+- new `server/pluginImports/importServerModule.ts`;
+- `pluginEntryResolver.ts`;
+- tests for jiti/native import behavior.
+
+Tasks:
+
+- extract `createJiti(..., { moduleCache: false })` helper;
+- keep fallback warning behavior;
+- make existing `boring.server` diagnostic import use helper.
+
+Non-goals:
+
+- no gateway;
+- no install command.
+
+Acceptance:
+
+- source edits are visible with hotReload true;
+- native import fallback behavior unchanged;
+- no duplicated jiti helper remains.
+
+## Ticket 4 — Runtime backend API + exact router capture
+
+Goal: define runtime backend plugin authoring boundary.
+
+Allowed files/modules:
+
+- `server/runtimeBackend/defineRuntimeServerPlugin.ts`;
+- `server/runtimeBackend/routerCapture.ts`;
+- package export for `runtime-server`.
+
+Tasks:
+
+- add `defineRuntimeServerPlugin`;
+- reject runtime module identity/id fields;
+- exact-match route capture;
+- unsafe path and duplicate route validation;
+- build/export tests.
+
+Non-goals:
+
+- no Fastify gateway yet;
+- no jiti loader yet.
+
+Acceptance:
+
+- external module can import `@hachej/boring-workspace/runtime-server`;
+- subpath import does not pull app/server orchestration;
+- exact router tests pass.
+
+## Ticket 5 — Runtime backend loader + registry
+
+Goal: turn jiti import into captured handler state.
+
+Allowed files/modules:
+
+- `runtimeServerLoader.ts`;
+- `runtimeBackendRegistry.ts`;
+- `runtimeBackendResponse.ts`;
+- `runtimeBackendHealth.ts`.
+
+Tasks:
+
+- load external `boring.server` runtime backend with shared jiti helper;
+- capture handler table;
+- atomic replace;
+- failed load preserves previous table;
+- dispose on replace/unload/close;
+- stable error codes.
+
+Non-goals:
+
+- no install command;
+- no bwrap worker;
+- no route params.
+
+Acceptance:
+
+- syntax error keeps old backend live;
+- dispose invariants tested;
+- concurrent reload serialization tested.
+
+## Ticket 6 — Gateway + reload integration
+
+Goal: expose runtime backend handlers through stable gateway.
+
+Allowed files/modules:
+
+- `runtimeBackendGateway.ts`;
+- `workspacePluginReload.ts`;
+- app/server route registration wiring.
+
+Tasks:
+
+- register `ALL /api/v1/plugins/:pluginId/*` once;
+- dispatch to runtime backend registry;
+- enforce workspace scoping in workspaces mode;
+- wire registry reload into coordinator;
+- add host health endpoint under `/api/v1/agent-plugins/:pluginId/health`.
+
+Non-goals:
+
+- no install command;
+- no remote sandbox;
+- no permission prompts.
+
+Acceptance:
+
+- backend handler responds after `/reload`;
+- source edit + `/reload` changes response without restart;
+- wrong workspace gateway call rejected;
+- host health path does not conflict with plugin-owned `/health`.
+
+## Ticket 7 — Pi package-source install/list/remove/update
+
+Goal: make external boring plugin package install first-class without creating a boring-only registry.
+
+Allowed files/modules:
+
+- CLI command parser;
+- Pi package source manager/facade;
+- package source collector;
+- install tests.
+
+Tasks:
+
+- add `boring-ui-plugin install/list/remove`, plus optional `boring-ui plugin ...` facade/reuse;
+- npm/git/local source parsing;
+- global default scope;
+- `-l/--local` workspace scope;
+- Pi package source settings/roots;
+- boring discovery scans Pi package roots for `package.json#boring`;
+- Pi resource loading can consume `package.json#pi` and no-op when absent;
+- security warning;
+- verify/test hook where possible.
+
+Non-goals:
+
+- no hosted permission grants;
+- no bwrap worker;
+- no marketplace UI.
+
+Acceptance:
+
+- npm/git/local install works globally;
+- local install works workspace-only;
+- workspace-local shadows global;
+- list shows scope/source/id;
+- remove respects scope;
+- no `.pi/boring-plugin-sources.json` or copied local source tree is created.
+
+## Ticket 8 — Self-test backend extension
+
+Goal: extend PR #159 self-test to backend health.
+
+Tasks:
+
+- support backend health declaration;
+- call plugin-owned gateway `/health` if declared;
+- include backend status in output;
+- record last self-test in health aggregator.
+
+Acceptance:
+
+- `test-plugin` reports front and backend separately;
+- backend failure does not falsely mark front import as failed.
+
+## Deferred tickets
+
+- bwrap/local-sandbox worker/proxy;
+- hosted/cloud external plugins;
+- permission grants/marketplace policy;
+- dynamic provider/binding hot mount;
+- route params/wildcards;
+- rich workspace facade for backend handlers.

--- a/docs/plans/runtime-plugin-cli-local/context.md
+++ b/docs/plans/runtime-plugin-cli-local/context.md
@@ -1,0 +1,197 @@
+# CLI/local runtime plugins — context
+
+Status: canonical context for the CLI/local runtime plugin implementation plan.
+
+Scope: local `boring-ui` CLI. Remote sandbox/cloud external plugin install and hot reload are deferred.
+
+## One-line thesis
+
+```txt
+Internal plugins extend the app.
+External CLI plugins extend the local workspace runtime.
+```
+
+CLI/local external plugins use the **Pi trust model**:
+
+```txt
+boring-ui install <source> = trusted local code, enabled by default
+```
+
+No permission prompts/grants in the CLI MVP. Hosted/cloud/marketplace can add permission policy later.
+
+## Plugin classes
+
+### Internal/app plugin
+
+Trusted app-owned code shipped with the app.
+
+Uses:
+
+- app-owned domain APIs;
+- first-party integrations;
+- admin tools;
+- DB/auth/service-backed behavior.
+
+Allowed:
+
+- native host React UI;
+- `boring.server`;
+- boot-time Fastify routes;
+- host agent tools;
+- app DB/auth/service access when app owner coded it.
+
+Lifecycle:
+
+```txt
+server/routes/tools: boot-time only, restart/redeploy required
+front/Pi in dev: may hot reload through existing asset paths
+```
+
+### External CLI/local plugin
+
+User/agent/npm/git installed plugin active in a local CLI workspace.
+
+Allowed:
+
+- native frontend panels/commands/surface resolvers;
+- plugin-local frontend deps installed in the plugin folder, with React/workspace/ui-kit kept host-provided;
+- Pi extensions/skills/system prompts;
+- runtime backend handlers through Boring gateway;
+- npm/git/local package installs like Pi.
+
+Not allowed:
+
+- raw Fastify hot registration;
+- app DB/auth internals by default;
+- changing internal/app server routes without restart;
+- remote sandbox assumptions.
+
+### Remote sandbox/cloud external plugin
+
+Deferred. Do not design this phase around remote install/hot reload.
+
+## Current system summary
+
+### Front runtime hot reload
+
+Runtime fronts under plugin roots are scanned by `BoringPluginAssetManager`, announced over `/api/v1/agent-plugins/events`, imported by the browser with revision/cache-bust params, and atomically replace plugin-owned panels/commands/catalogs/surface resolvers.
+
+Current hot-loaded fronts:
+
+- preserve previous UI on import/register failure;
+- do not dynamically mount providers/bindings;
+- use CLI front runtime singletons to avoid dual React.
+
+### Internal server plugins
+
+Internal plugins are fixed/boot-time. Their `boring.server` entries resolve to:
+
+```ts
+defineServerPlugin({ routes, agentTools, systemPrompt, ... })
+```
+
+These are boot-composed. Route/tool changes require restart. The plugin-facing manifest field stays `boring.server`; source classification decides behavior: internal plugins are fixed/boot-time, external plugins are hot-reloaded through the gateway.
+
+### Existing jiti behavior
+
+Already implemented:
+
+- `pluginEntryResolver.ts` uses `createJiti(import.meta.url, { moduleCache: false })` for dir-source `boring.server` entries with `hotReload: true`.
+- `rebuildServerPlugins.ts` re-resolves those entries on `/reload`.
+
+Important limitation:
+
+```txt
+current: jiti import -> validate -> diagnostics only
+needed:  jiti import -> capture handlers -> atomic registry swap -> gateway dispatch
+```
+
+## Related PR delta
+
+### PR #166 — Plugin-local deps and ui-kit scaffolds
+
+Adds/establishes:
+
+- runtime plugin fronts resolve non-host bare imports from the plugin's own `node_modules`;
+- `react`, `react-dom`, `@hachej/boring-workspace*`, and `@hachej/boring-ui-kit` are host-provided/singleton imports;
+- plugin authors install extra frontend deps inside `.pi/extensions/<plugin>/`, not workspace root;
+- `/reload` never installs missing packages;
+- `boring-ui-plugin verify` reports missing plugin-local deps and forbidden host-provided deps;
+- scaffolded runtime plugins use `@hachej/boring-ui-kit` by default.
+
+Impact on this plan:
+
+- keep Pi-style plugin-local dependency behavior;
+- do not make `boring-ui install` a hidden dependency installer for existing `.pi/extensions` authoring;
+- avoid requiring runtime backend modules to import a host package just to be loadable.
+
+### PR #157 — File records data access
+
+Adds `GET /api/v1/files/records` and `readFileRecords()` so plugin UIs can read bounded JSON/NDJSON/CSV record pages without bundling data into front code.
+
+### PR #158 — WorkspaceLink
+
+Adds `WorkspaceLink`, `workspaceLinkCommand()`, and `workspaceLinkHref()` so plugin UIs can open files/surfaces/panels through the existing UI command bus instead of custom routes.
+
+### PR #159 — Runtime plugin self-test
+
+Adds `boring-ui test-plugin <name>` with Playwright reload/render diagnostics. This should become post-install/post-reload smoke testing for runtime plugins.
+
+## Key implementation guardrails
+
+- Do not dynamically register/unregister raw Fastify routes. Hot-reload backend behavior by pre-registering one stable gateway route and swapping plugin handler tables behind it.
+- Keep one plugin-facing server field: `boring.server`. Internal plugins are fixed/boot-time; external CLI/local plugins are hot-reloaded through the gateway.
+- Do not grow `createWorkspaceAgentServer.ts` with new reload logic; extract a focused reload helper only when it deletes complexity instead of adding abstraction.
+- Do not put executable backend handler tables in `BoringPluginAssetManager`.
+- Do not infer trust from path strings and do not store drift-prone `runtimeBackendAllowed` booleans; preserve explicit internal/external source records.
+- Do not expose `workspace.root` or raw host paths to runtime backend handlers.
+- Use exact-match backend route dispatch in MVP. No custom mini-router.
+- Keep host health metadata outside plugin-owned gateway paths.
+- Workspace-local plugin wins over global plugin with same id.
+
+## Namespaces
+
+Plugin-owned backend gateway:
+
+```txt
+/api/v1/plugins/:pluginId/*
+```
+
+Host plugin metadata/health:
+
+```txt
+/api/v1/agent-plugins
+/api/v1/agent-plugins/:pluginId/health
+```
+
+## Install model
+
+Target model mirrors Pi. Implementation can ship install/list/remove first and add update later. This is package/source installation: npm/git installs should leave declared dependencies present inside the installed/cloned plugin package dir, while local-path installs reference the local package without auto-installing deps. Never install deps in workspace/app root. That is separate from `/reload` or verify fixing dependencies for already-authored plugins:
+
+```bash
+boring-ui install npm:@boring-plugins/email-client
+boring-ui install git:github.com/user/email-client@v1
+boring-ui install https://github.com/user/email-client
+boring-ui install ./plugins/email-client
+boring-ui install -l ./plugins/email-client   # workspace-local
+
+boring-ui remove <source-or-id>
+boring-ui list
+boring-ui update [source-or-id]
+```
+
+Scopes:
+
+```txt
+Global/user default:
+  ~/.pi/agent/npm
+  ~/.pi/agent/git
+  ~/.pi/agent/extensions
+
+Workspace-local with -l/--local:
+  <workspace>/.pi/npm
+  <workspace>/.pi/git
+  <workspace>/.pi/extensions
+```
+
+Install output must clearly state whether plugin is global or workspace-local.

--- a/docs/plans/runtime-plugin-cli-local/context.md
+++ b/docs/plans/runtime-plugin-cli-local/context.md
@@ -14,7 +14,7 @@ External CLI plugins extend the local workspace runtime.
 CLI/local external plugins use the **Pi trust model**:
 
 ```txt
-boring-ui install <source> = trusted local code, enabled by default
+boring-ui-plugin install <source> = trusted local code, enabled by default
 ```
 
 No permission prompts/grants in the CLI MVP. Hosted/cloud/marketplace can add permission policy later.
@@ -122,7 +122,7 @@ Adds/establishes:
 Impact on this plan:
 
 - keep Pi-style plugin-local dependency behavior;
-- do not make `boring-ui install` a hidden dependency installer for existing `.pi/extensions` authoring;
+- do not make `boring-ui-plugin install` / `boring-ui plugin install` a hidden dependency installer for existing `.pi/extensions` authoring;
 - avoid requiring runtime backend modules to import a host package just to be loadable.
 
 ### PR #157 — File records data access
@@ -143,7 +143,7 @@ Adds `boring-ui test-plugin <name>` with Playwright reload/render diagnostics. T
 - Keep one plugin-facing server field: `boring.server`. Internal plugins are fixed/boot-time; external CLI/local plugins are hot-reloaded through the gateway.
 - Do not grow `createWorkspaceAgentServer.ts` with new reload logic; extract a focused reload helper only when it deletes complexity instead of adding abstraction.
 - Do not put executable backend handler tables in `BoringPluginAssetManager`.
-- Do not infer trust from path strings and do not store drift-prone `runtimeBackendAllowed` booleans; preserve explicit internal/external source records.
+- Do not infer trust from path strings and do not store drift-prone `runtimeBackendAllowed` booleans; preserve explicit internal/external source metadata from the package source collector.
 - Do not expose `workspace.root` or raw host paths to runtime backend handlers.
 - Use exact-match backend route dispatch in MVP. No custom mini-router.
 - Keep host health metadata outside plugin-owned gateway paths.
@@ -166,18 +166,30 @@ Host plugin metadata/health:
 
 ## Install model
 
-Target model mirrors Pi. Implementation can ship install/list/remove first and add update later. This is package/source installation: npm/git installs should leave declared dependencies present inside the installed/cloned plugin package dir, while local-path installs reference the local package without auto-installing deps. Never install deps in workspace/app root. That is separate from `/reload` or verify fixing dependencies for already-authored plugins:
+Target model mirrors Pi package sources. Implementation can ship install/list/remove first and add update later. This is package-source installation: npm/git installs should leave declared dependencies present inside the installed/cloned plugin package dir, while local-path installs reference the local package without auto-installing deps. Never install deps in workspace/app root. That is separate from `/reload` or verify fixing dependencies for already-authored plugins.
+
+Boring plugin packages use normal package metadata:
+
+```txt
+package.json#boring  -> boring UI/runtime-server surfaces
+package.json#pi      -> Pi resources, if any
+```
+
+A package with `boring` but no `pi` resources is valid: Pi resource loading no-ops, and boring still scans the package root. Do not add a second boring-owned package source registry such as `.pi/boring-plugin-sources.json`.
+
+Implementation ownership:
 
 ```bash
-boring-ui install npm:@boring-plugins/email-client
-boring-ui install git:github.com/user/email-client@v1
-boring-ui install https://github.com/user/email-client
-boring-ui install ./plugins/email-client
-boring-ui install -l ./plugins/email-client   # workspace-local
+boring-ui-plugin install npm:@boring-plugins/email-client
+boring-ui-plugin install git:github.com/user/email-client@v1
+boring-ui-plugin install https://github.com/user/email-client
+boring-ui-plugin install ./plugins/email-client
+boring-ui-plugin install -l ./plugins/email-client   # workspace-local
 
-boring-ui remove <source-or-id>
-boring-ui list
-boring-ui update [source-or-id]
+boring-ui-plugin remove <source-or-id>
+boring-ui-plugin list
+
+boring-ui plugin install ./plugins/email-client      # optional top-level facade/reuse
 ```
 
 Scopes:

--- a/docs/plans/runtime-plugin-cli-local/implementation-plan.md
+++ b/docs/plans/runtime-plugin-cli-local/implementation-plan.md
@@ -1,0 +1,95 @@
+# CLI/local runtime plugins — implementation plan
+
+Read first: [context.md](./context.md).
+
+This plan is intentionally reduced to **three PRs**. Each PR has a dedicated detailed plan under [prs/](./prs/).
+
+## PR 01 — Foundation
+
+Detailed plan: [prs/01-foundation.md](./prs/01-foundation.md)
+
+Goal: prepare the codebase without executing runtime backend handlers.
+
+Includes:
+
+- one plugin-facing `boring.server` manifest field;
+- first-class internal/external plugin source metadata;
+- obsolete `/api/boring.reload` removal;
+- shared jiti fresh-import helper.
+
+Acceptance:
+
+- internal vs external classification is explicit, not path-inferred;
+- obsolete `/api/boring.reload` route is removed;
+- existing jiti behavior is reused through one helper;
+- no runtime backend handlers execute yet.
+
+## PR 02 — Server runtime backend MVP
+
+Detailed plan: [prs/02-server-runtime-mvp.md](./prs/02-server-runtime-mvp.md)
+
+Goal: make external CLI/local `boring.server` entries work from existing plugin roots like `.pi/extensions`.
+
+Pipeline:
+
+```txt
+jiti import -> capture exact routes -> atomic registry swap -> gateway dispatch
+```
+
+Includes:
+
+- plain default-export runtime server module contract;
+- optional `@hachej/boring-workspace/runtime-server` helper/types for package authors;
+- exact-match router capture;
+- runtime backend loader and registry;
+- stable gateway at `/api/v1/plugins/:pluginId/*`;
+- backend reload integration;
+- backend diagnostics in reload responses.
+
+Non-goals:
+
+- no install command;
+- no npm/git/local package management;
+- no permission prompts;
+- no bwrap/remote sandbox;
+- no route params/wildcards.
+
+Acceptance:
+
+- existing `.pi/extensions/<id>` plugin with `boring.server` can hot-reload backend handlers in CLI/local mode.
+
+## PR 03 — Pi-style install/list/remove MVP
+
+Detailed plan: [prs/03-cli-install-and-verification.md](./prs/03-cli-install-and-verification.md)
+
+Goal: add user-facing install/list/remove after server MVP works.
+
+Includes:
+
+- package/source install flow matching Pi: npm/git install deps in installed/cloned plugin dirs, local paths are referenced without auto-installing deps, and `/reload` stays dependency-free;
+- `boring-ui install <source>` global by default;
+- `boring-ui install -l/--local <source>` workspace-local;
+- npm/git/URL/local path sources;
+- `list` and `remove`;
+- manifest validation before activation;
+- security warning for third-party sources.
+
+Acceptance:
+
+- user can install, list, and remove external plugins like Pi;
+- workspace-local shadows global same-id plugin;
+- installed plugin can use PR 02 server runtime after `/reload`.
+
+Follow-up:
+
+- `update`;
+- backend health support in `test-plugin`.
+
+## Deferred
+
+- hosted/cloud plugin support;
+- permission grants/marketplace policy;
+- bwrap/local-sandbox backend workers;
+- dynamic provider/binding hot mount;
+- route params/wildcards;
+- rich workspace facade for backend handlers.

--- a/docs/plans/runtime-plugin-cli-local/implementation-plan.md
+++ b/docs/plans/runtime-plugin-cli-local/implementation-plan.md
@@ -58,7 +58,7 @@ Acceptance:
 
 - existing `.pi/extensions/<id>` plugin with `boring.server` can hot-reload backend handlers in CLI/local mode.
 
-## PR 03 — Pi-style install/list/remove MVP
+## PR 03 — Pi package-source install/list/remove MVP
 
 Detailed plan: [prs/03-cli-install-and-verification.md](./prs/03-cli-install-and-verification.md)
 
@@ -66,18 +66,23 @@ Goal: add user-facing install/list/remove after server MVP works.
 
 Includes:
 
-- package/source install flow matching Pi: npm/git install deps in installed/cloned plugin dirs, local paths are referenced without auto-installing deps, and `/reload` stays dependency-free;
-- `boring-ui install <source>` global by default;
-- `boring-ui install -l/--local <source>` workspace-local;
+- package-source install flow matching Pi: npm/git install deps in installed/cloned plugin dirs, local paths are referenced without auto-installing deps, and `/reload` stays dependency-free;
+- `boring-ui-plugin install <source>` implementation, with optional `boring-ui plugin ...` facade/reuse;
+- global/user scope and `-l/--local` workspace scope using Pi package source settings;
 - npm/git/URL/local path sources;
 - `list` and `remove`;
 - manifest validation before activation;
+- boring discovery scans the same Pi package roots for `package.json#boring`;
+- Pi scans the same package roots for `package.json#pi` and no-ops when absent;
+- no separate `.pi/boring-plugin-sources.json` registry;
 - security warning for third-party sources.
 
 Acceptance:
 
-- user can install, list, and remove external plugins like Pi;
+- user can install, list, and remove external boring plugins as Pi package sources;
 - workspace-local shadows global same-id plugin;
+- installed package appears in `/api/v1/agent-plugins` after `/reload`;
+- package with no `pi` resources does not break Pi resource loading;
 - installed plugin can use PR 02 server runtime after `/reload`.
 
 Follow-up:

--- a/docs/plans/runtime-plugin-cli-local/index.md
+++ b/docs/plans/runtime-plugin-cli-local/index.md
@@ -1,0 +1,57 @@
+# CLI/local runtime plugin plan
+
+Canonical docs:
+
+1. [context.md](./context.md) — decisions, current state, terminology, guardrails.
+2. [implementation-plan.md](./implementation-plan.md) — compact overview.
+3. [prs/](./prs/) — one markdown plan per PR.
+
+## Scope
+
+Local `boring-ui` CLI only. Remote sandbox/cloud external plugin install and hot reload are deferred.
+
+## Canonical PR split
+
+Use these three PR-sized plans:
+
+| PR | Plan | Purpose |
+| --- | --- | --- |
+| 01 | [prs/01-foundation.md](./prs/01-foundation.md) | Source metadata, remove old reload route, and shared jiti helper. No backend execution. |
+| 02 | [prs/02-server-runtime-mvp.md](./prs/02-server-runtime-mvp.md) | Hot runtime behavior for external `boring.server` entries: plain module contract, route capture, registry, gateway, reload diagnostics. No install or host health route. |
+| 03 | [prs/03-cli-install-and-verification.md](./prs/03-cli-install-and-verification.md) | Pi-style install/list/remove MVP, aligned with PR #166 plugin-local dependency installs. `update` and backend self-test are follow-ups. |
+
+## Core decisions
+
+- CLI/local uses Pi trust semantics:
+
+  ```txt
+  boring-ui install <source> = trusted local code, enabled by default
+  ```
+
+- Plugin authors use one manifest field: `boring.server`.
+- Internal plugins are fixed/boot-time and use the existing `WorkspaceServerPlugin` path.
+- External CLI/local plugins are hot-reloaded through the gateway.
+- PR #166's plugin-local dependency model remains intact: `/reload` never installs missing packages.
+- `/api/v1/agent/reload` is the only reload endpoint; remove the older `/api/boring.reload` developer route in PR 01.
+- Boring already has jiti fresh import for diagnostic `boring.server` reload; missing piece is source-aware gateway/registry commit:
+
+  ```txt
+  jiti import -> capture handlers -> atomic registry swap -> gateway dispatch
+  ```
+
+## Guardrails
+
+- Do not dynamically register/unregister raw Fastify routes. Hot-reload backend behavior by pre-registering one stable gateway route and swapping plugin handler tables behind it.
+- Do not put backend handler tables in `BoringPluginAssetManager`.
+- Keep one canonical reload endpoint (`/api/v1/agent/reload`). Extract a reload helper only if backend reload integration would otherwise bloat `createWorkspaceAgentServer.ts`.
+- Preserve explicit internal/external source metadata; do not infer activation from path strings or store drift-prone backend-allowed booleans.
+- Do not expose raw workspace roots to runtime backend handlers.
+- Use exact-match route dispatch in MVP.
+- Keep host health under `/api/v1/agent-plugins/:pluginId/health`, not plugin gateway space.
+
+## Reviews
+
+- [reviews/nuclear-simplicity-robustness-pass2.md](./reviews/nuclear-simplicity-robustness-pass2.md)
+- [reviews/latest-main-reassessment.md](./reviews/latest-main-reassessment.md)
+- [reviews/pr166-reassessment.md](./reviews/pr166-reassessment.md)
+- [reviews/reload-endpoint-removal-inventory.md](./reviews/reload-endpoint-removal-inventory.md)

--- a/docs/plans/runtime-plugin-cli-local/index.md
+++ b/docs/plans/runtime-plugin-cli-local/index.md
@@ -18,20 +18,22 @@ Use these three PR-sized plans:
 | --- | --- | --- |
 | 01 | [prs/01-foundation.md](./prs/01-foundation.md) | Source metadata, remove old reload route, and shared jiti helper. No backend execution. |
 | 02 | [prs/02-server-runtime-mvp.md](./prs/02-server-runtime-mvp.md) | Hot runtime behavior for external `boring.server` entries: plain module contract, route capture, registry, gateway, reload diagnostics. No install or host health route. |
-| 03 | [prs/03-cli-install-and-verification.md](./prs/03-cli-install-and-verification.md) | Pi-style install/list/remove MVP, aligned with PR #166 plugin-local dependency installs. `update` and backend self-test are follow-ups. |
+| 03 | [prs/03-cli-install-and-verification.md](./prs/03-cli-install-and-verification.md) | Pi package-source install/list/remove MVP, aligned with PR #166 plugin-local dependency installs. `update` and backend self-test are follow-ups. |
 
 ## Core decisions
 
 - CLI/local uses Pi trust semantics:
 
   ```txt
-  boring-ui install <source> = trusted local code, enabled by default
+  boring-ui-plugin install <source> = trusted local code, enabled by default
   ```
 
 - Plugin authors use one manifest field: `boring.server`.
 - Internal plugins are fixed/boot-time and use the existing `WorkspaceServerPlugin` path.
 - External CLI/local plugins are hot-reloaded through the gateway.
 - PR #166's plugin-local dependency model remains intact: `/reload` never installs missing packages.
+- Boring plugin packages are Pi packages: Pi consumes `package.json#pi`, boring consumes `package.json#boring`, and packages with no `pi` resources are valid no-ops for Pi.
+- Install/list/remove should use Pi package source settings/roots, not a separate `.pi/boring-plugin-sources.json` registry.
 - `/api/v1/agent/reload` is the only reload endpoint; remove the older `/api/boring.reload` developer route in PR 01.
 - Boring already has jiti fresh import for diagnostic `boring.server` reload; missing piece is source-aware gateway/registry commit:
 

--- a/docs/plans/runtime-plugin-cli-local/prs/01-foundation.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/01-foundation.md
@@ -15,6 +15,7 @@ This PR combines the setup work that is too small/noisy as separate PRs:
 3. Add minimal source classification: internal plugins are fixed/boot-time; external plugins are hot-reloaded through the gateway.
 4. Remove the obsolete `/api/boring.reload` endpoint so there is one reload path.
 5. Extract the existing jiti fresh-import helper.
+6. Treat merged-main plugin-local dependency support from PR #166 as baseline: plugin folders own `package.json`/`node_modules`, host singletons stay host-provided, and `/reload` never installs packages.
 
 ## Why this PR exists
 
@@ -25,6 +26,8 @@ explicit source trust -> one reload endpoint -> canonical fresh import
 ```
 
 Without this, the implementation risks path-based trust inference, duplicated reload semantics, and another ad-hoc jiti loader.
+
+Latest `main` already includes PR #166's frontend runtime plugin dependency cleanup. PR 01 must not reopen that problem. Treat `rootDir` as the plugin package root used by existing front-runtime verification/resolution, but do not add install metadata, dependency policy, scaffold changes, or package-manager work in this foundation PR.
 
 ## Tasks
 
@@ -42,7 +45,7 @@ Source shape for this PR:
 
 ```ts
 type BoringPluginSource = {
-  rootDir: string // absolute normalized host path
+  rootDir: string // absolute normalized plugin package root on the host
   kind: "internal" | "external"
   workspaceId?: string
 }
@@ -62,6 +65,14 @@ Ignore advanced host escape hatches for MVP. If a host uses extra scan dirs, the
 
 This is not a new plugin API. Plugin authors still use `boring.server`. The host only records whether the source is internal or external so activation logic is not inferred from paths at random callsites.
 
+Merged-main dependency cleanup constraints for this source metadata:
+
+- `rootDir` is also the package root where authored runtime plugins keep `package.json` and plugin-local `node_modules`.
+- Do not add dependency/install fields to `BoringPluginSource` in PR 01.
+- Do not infer source kind from whether `node_modules` exists, whether `@hachej/boring-ui-kit` is imported, or whether a scaffold template was used.
+- Do not mutate `package.json`, lockfiles, or `node_modules` during scan/load/reload.
+- Keep host-provided frontend singleton policy (`react`, `react-dom`, `@hachej/boring-workspace*`, `@hachej/boring-ui-kit`) in the existing front-runtime/verifier path; source classification is only for `boring.server` activation.
+
 Loaded plugin records should carry:
 
 ```ts
@@ -74,7 +85,7 @@ type LoadedBoringPlugin = {
 }
 ```
 
-`npm` / `git` / `local-path` install details are PR 03 metadata. They are not needed in the server foundation.
+`npm` / `git` / `local-path` install details are PR 03 metadata. They are not needed in the server foundation. PR 01 should only preserve enough source/package-root identity for later PRs to make those decisions explicitly.
 
 ### 2. Remove obsolete reload endpoint
 
@@ -98,6 +109,8 @@ Why two endpoints exist today:
 - `/api/boring.reload` is a workspace/plugin developer endpoint from earlier plugin asset-manager work. It scans plugin assets and reports restart warnings without doing the full agent/session reload.
 
 Do not grow two reload systems. PR 01 should remove `/api/boring.reload` and route all reload tooling through `/api/v1/agent/reload`.
+
+Keep the merged-main reload rule from PR #166: canonical reload refreshes plugin resources and diagnostics, but it must not install missing plugin dependencies or modify any plugin package folder.
 
 There is no developer reload compatibility route after PR 01.
 
@@ -140,6 +153,8 @@ Extract existing behavior from `pluginEntryResolver.ts`:
 - fallback warning behavior remains unchanged.
 - existing `boring.server` diagnostics use the helper.
 
+Keep this backend import helper separate from the merged frontend Vite import policy. Do not add backend aliases for host-provided frontend packages in PR 01; PR 02's runtime backend contract can use plain default exports without requiring local plugins to import workspace helper packages.
+
 ## Non-goals
 
 - No runtime backend API.
@@ -149,22 +164,26 @@ Extract existing behavior from `pluginEntryResolver.ts`:
 - No behavior change to canonical `/api/v1/agent/reload` flow.
 - Remove obsolete `/api/boring.reload` flow.
 - No reload helper abstraction unless it deletes more code than it adds.
+- No plugin dependency install/resolution work; latest `main` already owns plugin-local frontend deps and PR 03 owns install/list/remove.
+- No scaffold or ui-kit template work; latest `main` already made generated fronts use host-provided `@hachej/boring-ui-kit`.
 
 ## Tests
 
 - Manifest keeps accepting safe `boring.server` paths.
 - Unsafe `boring.server` path is rejected.
 - Source metadata survives scan/load without changing existing list/event response shapes.
+- Source `rootDir` remains the plugin package root used by current plugin-local dependency verification/resolution.
 - Internal sources are boot-time/fixed.
 - External sources are hot-reloaded through the gateway.
 - `POST /api/boring.reload` returns 404/not registered after PR 01.
-- Existing canonical reload behavior and diagnostics remain unchanged.
+- Existing canonical reload behavior and diagnostics remain unchanged, including no package install during reload.
 - `hotReload: true` jiti import sees source edits.
 - Native import/fallback warning behavior is unchanged.
 
 ## Acceptance
 
-- Internal vs external source classification is explicit, not path-inferred and not stored as a drift-prone backend-allowed boolean.
+- Internal vs external source classification is explicit, not path-inferred, not dependency-inferred, and not stored as a drift-prone backend-allowed boolean.
+- Merged-main dependency/import cleanup is preserved: package-local deps stay package-local, host singletons stay host-provided, and PR 01 does not add another dependency system.
 - There is only one reload endpoint; no new reload abstraction is introduced unless it materially reduces code.
 - There is one canonical jiti server module import helper.
 - No runtime backend handlers execute yet.

--- a/docs/plans/runtime-plugin-cli-local/prs/01-foundation.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/01-foundation.md
@@ -1,0 +1,170 @@
+# PR 01 — Foundation: source metadata, remove old reload route, jiti helper
+
+## Goal
+
+Prepare the codebase for CLI/local runtime backends with the smallest safe foundation PR.
+
+No backend execution yet.
+
+## Scope
+
+This PR combines the setup work that is too small/noisy as separate PRs:
+
+1. Keep one plugin-facing manifest field: `boring.server`.
+2. Preserve minimal plugin source metadata through discovery/load.
+3. Add minimal source classification: internal plugins are fixed/boot-time; external plugins are hot-reloaded through the gateway.
+4. Remove the obsolete `/api/boring.reload` endpoint so there is one reload path.
+5. Extract the existing jiti fresh-import helper.
+
+## Why this PR exists
+
+Runtime backend reload needs three foundations before it is safe:
+
+```txt
+explicit source trust -> one reload endpoint -> canonical fresh import
+```
+
+Without this, the implementation risks path-based trust inference, duplicated reload semantics, and another ad-hoc jiti loader.
+
+## Tasks
+
+### 1. Manifest/source metadata
+
+- Do not add `boring.runtimeServer`.
+- Keep one plugin-facing manifest field: `boring.server`.
+- A plugin declares that it has a server entry; internal/external source classification decides how that server entry is activated.
+- Internal/app sources can activate `boring.server` as the existing boot-time `WorkspaceServerPlugin` path.
+- External CLI/local sources can activate `boring.server` as the hot gateway runtime backend contract.
+- Preserve minimal source metadata in loaded plugin records.
+- Do **not** store `runtimeBackendAllowed` on source records. That boolean is too easy to set incorrectly at callsites.
+
+Source shape for this PR:
+
+```ts
+type BoringPluginSource = {
+  rootDir: string // absolute normalized host path
+  kind: "internal" | "external"
+  workspaceId?: string
+}
+```
+
+Meaning:
+
+- `"internal"` — app/default/static plugin source. `boring.server` is activated at boot through the existing `WorkspaceServerPlugin` path.
+- `"external"` — workspace/global CLI plugin source. `boring.server` is hot-reloaded behind `/api/v1/plugins/:pluginId/*`.
+
+Initial source assignment:
+
+- `defaultPluginPackages` / app-composed plugin entries => `internal`.
+- workspace `.pi/extensions` and global `~/.pi/agent/extensions` => `external`.
+
+Ignore advanced host escape hatches for MVP. If a host uses extra scan dirs, they should not automatically become external hot-server sources unless the host deliberately installs/registers them as external later.
+
+This is not a new plugin API. Plugin authors still use `boring.server`. The host only records whether the source is internal or external so activation logic is not inferred from paths at random callsites.
+
+Loaded plugin records should carry:
+
+```ts
+type LoadedBoringPlugin = {
+  id: string
+  revision: number
+  rootDir: string
+  serverPath?: string
+  source: BoringPluginSource
+}
+```
+
+`npm` / `git` / `local-path` install details are PR 03 metadata. They are not needed in the server foundation.
+
+### 2. Remove obsolete reload endpoint
+
+Make `/api/v1/agent/reload` the only reload endpoint.
+
+Do **not** introduce a reload helper/module in PR 01 unless it clearly shrinks `createWorkspaceAgentServer.ts`. With one endpoint, a helper is not required just to remove the old route.
+
+Keep the canonical `/api/v1/agent/reload` support sequence behavior unchanged in place:
+
+```txt
+assetManager.load()
+rebuildServerPlugins() diagnostic-only
+runRuntimeProvisioning()
+opts.beforeReload()
+merge diagnostics/restart_warnings
+```
+
+Why two endpoints exist today:
+
+- `/api/v1/agent/reload` belongs to the agent/session layer. It refreshes Pi/session resources and runs workspace `beforeReload` hooks. This is what chat, plugin self-test, and workspace-mode tooling already use.
+- `/api/boring.reload` is a workspace/plugin developer endpoint from earlier plugin asset-manager work. It scans plugin assets and reports restart warnings without doing the full agent/session reload.
+
+Do not grow two reload systems. PR 01 should remove `/api/boring.reload` and route all reload tooling through `/api/v1/agent/reload`.
+
+There is no developer reload compatibility route after PR 01.
+
+### Remove old reload endpoint plumbing
+
+Remove from code:
+
+- `POST /api/boring.reload` registration in `packages/workspace/src/server/agentPlugins/routes.ts`.
+- `BoringPluginRoutesOptions.rebuildPlugins` if only used for `/api/boring.reload`.
+- `BoringPluginRoutesOptions.enableReloadRoute` if only used to toggle `/api/boring.reload`.
+- `PluginReloadRebuild` type if it only supports the old route.
+- `app.register(boringPluginRoutes, { rebuildPlugins, enableReloadRoute })` arguments in `createWorkspaceAgentServer.ts`.
+- Comments/docs claiming `pluginHotReload=false` omits `/api/boring.reload`.
+
+Keep/move:
+
+- `collectRestartWarnings()` and `PluginRestartWarning`, because canonical `/api/v1/agent/reload` still uses restart warnings.
+- `rebuildServerPlugins()`, because canonical reload still needs dir-source diagnostic re-imports.
+- `/api/v1/agent-plugins`, `/api/v1/agent-plugins/:id/error`, and `/api/v1/agent-plugins/events`.
+
+Update tests/callers:
+
+- Replace tests that inject `POST /api/boring.reload` with canonical `POST /api/v1/agent/reload` when they are testing reload behavior.
+- Delete route-level tests whose only purpose was `/api/boring.reload` response shape.
+- Update `hotReloadDiscovery` expectations: `pluginHotReload=false` disables hot reload behavior, not an obsolete route.
+- Update eval/plugin-creation tests to call `/api/v1/agent/reload`.
+- Update docs and changelog references that tell users to call `/api/boring.reload`.
+
+### 3. Shared jiti helper
+
+Create:
+
+```txt
+packages/workspace/src/server/pluginImports/importServerModule.ts
+```
+
+Extract existing behavior from `pluginEntryResolver.ts`:
+
+- `hotReload: true` uses `createJiti(..., { moduleCache: false })`.
+- fallback warning behavior remains unchanged.
+- existing `boring.server` diagnostics use the helper.
+
+## Non-goals
+
+- No runtime backend API.
+- No route capture.
+- No HTTP gateway.
+- No install command.
+- No behavior change to canonical `/api/v1/agent/reload` flow.
+- Remove obsolete `/api/boring.reload` flow.
+- No reload helper abstraction unless it deletes more code than it adds.
+
+## Tests
+
+- Manifest keeps accepting safe `boring.server` paths.
+- Unsafe `boring.server` path is rejected.
+- Source metadata survives scan/load without changing existing list/event response shapes.
+- Internal sources are boot-time/fixed.
+- External sources are hot-reloaded through the gateway.
+- `POST /api/boring.reload` returns 404/not registered after PR 01.
+- Existing canonical reload behavior and diagnostics remain unchanged.
+- `hotReload: true` jiti import sees source edits.
+- Native import/fallback warning behavior is unchanged.
+
+## Acceptance
+
+- Internal vs external source classification is explicit, not path-inferred and not stored as a drift-prone backend-allowed boolean.
+- There is only one reload endpoint; no new reload abstraction is introduced unless it materially reduces code.
+- There is one canonical jiti server module import helper.
+- No runtime backend handlers execute yet.

--- a/docs/plans/runtime-plugin-cli-local/prs/02-server-runtime-mvp.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/02-server-runtime-mvp.md
@@ -1,0 +1,242 @@
+# PR 02 — Server runtime backend MVP
+
+## Goal
+
+Make external CLI/local `boring.server` entries work through the hot gateway, without adding install commands yet.
+
+A plugin in `.pi/extensions/<id>` can expose backend handlers via `boring.server`, reload them with `/reload`, and serve them through the stable gateway. Whether `boring.server` is activated as boot-time internal code or hot gateway code is decided by internal/external source classification, not a separate plugin manifest field.
+
+## Scope
+
+This PR is the server MVP:
+
+```txt
+jiti import -> capture exact routes -> atomic registry swap -> gateway dispatch
+```
+
+## Public API
+
+Runtime server modules must be loadable without a package-local dependency on `@hachej/boring-workspace`.
+
+Canonical `.pi/extensions` shape is a plain validated default export:
+
+```ts
+export default {
+  routes(router) {
+    router.get("/messages", async (ctx) => ({ messages: [] }))
+    router.post("/send", async (ctx) => {
+      const body = ctx.body
+      return { ok: true, body }
+    })
+  },
+  async dispose() {},
+}
+```
+
+A public helper/type subpath may still exist for publishable/build-based packages:
+
+```txt
+@hachej/boring-workspace/runtime-server
+```
+
+But the loader must validate plain objects and must not require plugins to import the helper. This follows PR #166's lesson: host-provided imports are useful, but local runtime plugins should not need to install or resolve workspace packages just to load.
+
+Rules:
+
+- Runtime module must not declare `id`.
+- Loader supplies plugin id from manifest/source record.
+- `defineRuntimeServerPlugin()` is optional convenience, not an activation requirement. Loader validation is authoritative.
+- Exact-match route paths only.
+- No params/wildcards/order.
+- No raw Fastify request/reply.
+- No `workspace` facade in MVP context.
+- No raw workspace root exposure.
+
+## Modules
+
+Keep module count small. Start with four files plus an export barrel:
+
+```txt
+packages/workspace/src/server/runtimeBackend/
+  defineRuntimeServerPlugin.ts  # optional public helper/types + validation utilities
+  routerCapture.ts             # exact route capture + path validation
+  runtimeBackendRegistry.ts    # jiti load, per-plugin snapshot, dispatch, dispose, diagnostics
+  runtimeBackendGateway.ts     # Fastify adapter only
+  index.ts
+```
+
+Do not create `runtimeBackendHealth.ts` or `runtimeBackendResponse.ts` unless the code becomes too large to read. In MVP, health is a projection of registry state and response coercion can stay as a small pure helper in the registry/gateway layer.
+
+## Handler context MVP
+
+Keep request body support JSON-only in MVP.
+
+```ts
+type RuntimePluginContext = {
+  pluginId: string
+  method: string
+  path: string
+  query: URLSearchParams
+  headers: ReadonlyHeaders
+  signal: AbortSignal
+  body: unknown
+  logger: PluginLogger
+}
+```
+
+No `text()` / raw-body helpers in MVP. Add them later only when a real plugin needs non-JSON payloads.
+
+## Gateway
+
+Plugin-owned endpoint:
+
+```txt
+ALL /api/v1/plugins/:pluginId/*
+```
+
+Host metadata/health namespace stays outside gateway, but a new host health route is deferred unless it is almost free to expose from existing diagnostics:
+
+```txt
+future: GET /api/v1/agent-plugins/:pluginId/health
+```
+
+## Registry invariants
+
+Use the simplest robust policy: **per-plugin prepare, then commit**.
+
+For each runtime-capable plugin:
+
+```txt
+load next module + capture routes without mutating current state
+if load succeeds: swap this plugin's snapshot, then dispose old instance
+if load fails and old snapshot exists: keep old snapshot live and record diagnostic
+if load fails and no old snapshot exists: plugin backend stays disabled
+```
+
+For removed plugins:
+
+```txt
+remove snapshot, then dispose old instance
+```
+
+Other invariants:
+
+- one reload at a time;
+- one plugin failure must not break other plugins;
+- dispose failures become diagnostics, not reload aborts.
+
+This avoids global two-phase complexity while still prevents half-written per-plugin state.
+
+## Reload integration
+
+Add runtime backend reload into the only reload endpoint:
+
+```txt
+/api/v1/agent/reload
+```
+
+It should run:
+
+```txt
+assetManager.load()
+runtimeBackendRegistry.reloadFromLoadedPlugins(loaded inspection records)
+rebuildServerPlugins() diagnostic-only for boring.server
+collect restart warnings + backend diagnostics
+runRuntimeProvisioning()
+opts.beforeReload()
+merge diagnostics/restart_warnings
+```
+
+Do not reintroduce `/api/boring.reload` or any second reload endpoint.
+
+If this makes `createWorkspaceAgentServer.ts` grow materially, extract the reload body into a focused helper such as `reloadWorkspacePlugins(...)` in this PR. Do not add that helper earlier just for abstraction symmetry.
+
+## Source gating
+
+During reload, only external sources participate in the gateway registry:
+
+```ts
+if (plugin.source.kind !== "external") skipGatewayReload(plugin)
+```
+
+Policy for MVP:
+
+- internal sources activate `boring.server` through the existing boot-time `WorkspaceServerPlugin` path;
+- external sources activate `boring.server` through the hot gateway contract;
+- workspace-local source must match current workspace in workspaces mode if `workspaceId` is present.
+
+Gateway dispatches only against the registry snapshot. Gateway must not re-evaluate source classification.
+
+## Gateway normalization
+
+Exact routing stays simple, but normalization must be explicit:
+
+- validate `pluginId` before dispatch;
+- route key is uppercase HTTP method + normalized tail path;
+- query string is not part of route key;
+- empty tail becomes `/`;
+- duplicate slashes are not normalized magically; they must match exactly after Fastify decoding;
+- reject paths containing `..` segments or backslashes.
+
+## Request body
+
+MVP accepts JSON request bodies only through `ctx.body`.
+
+Reuse existing Fastify/body-size behavior. Do not add a second raw-body reader, text parser, or body limit in this layer.
+
+## Response/error contract
+
+Keep MVP response contract small:
+
+- `undefined` / `null` => 204;
+- JSON-serializable values => JSON;
+- explicit response metadata requires `{ kind: "response", ... }`.
+
+No automatic text or byte response coercion in MVP. Plugins that need those can use explicit response metadata with headers/body.
+
+Stable errors must come from canonical error enum/import path, never raw strings:
+
+```txt
+RUNTIME_PLUGIN_NOT_FOUND
+RUNTIME_PLUGIN_ROUTE_NOT_FOUND
+RUNTIME_PLUGIN_HANDLER_FAILED
+RUNTIME_PLUGIN_LOAD_FAILED
+RUNTIME_PLUGIN_RESPONSE_UNSUPPORTED
+```
+
+## Non-goals
+
+- No `boring-ui install`.
+- No npm/git/local package manager.
+- No bwrap worker.
+- No permission prompts/grants.
+- No route params/wildcards.
+- No hosted/cloud plugin support.
+
+## Tests
+
+- Plain default-export object runtime module loads without importing `@hachej/boring-workspace`.
+- Optional `runtime-server` subpath import works for build-based/package authors.
+- Runtime module with `id` is rejected.
+- Unsafe route paths rejected.
+- Duplicate method/path rejected.
+- Exact route table dispatch works.
+- jiti-loaded runtime server captures handlers.
+- Plugin backend responds after `/reload`.
+- Source edit + `/reload` changes response without restart.
+- Syntax error keeps previous response live.
+- Removed plugin unloads gateway handlers.
+- Dispose called on replace/unload/close.
+- Concurrent reloads serialize.
+- Wrong workspace gateway call rejected.
+- `boring-ui-plugin verify` explains `boring.server` activation by source: app/internal sources are boot-time, workspace/global CLI sources are hot gateway.
+- Backend diagnostics are included in reload output.
+- Plugin-owned `/health` route, if registered by a plugin, stays under gateway and does not conflict with deferred host health namespace.
+- `/api/v1/agent/reload` includes backend diagnostics.
+- `/api/boring.reload` remains removed/not registered.
+
+## Acceptance
+
+- Existing `.pi/extensions/<id>` plugin with `boring.server` can hot-reload JSON backend handlers in CLI/local mode.
+- Backend diagnostics are visible in reload responses.
+- No install command, backend host-import aliasing, or host health route is required to prove the server MVP.

--- a/docs/plans/runtime-plugin-cli-local/prs/03-cli-install-and-verification.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/03-cli-install-and-verification.md
@@ -1,0 +1,219 @@
+# PR 03 — Pi-style install/list/remove MVP
+
+## Goal
+
+After the server MVP works from existing plugin roots, add the smallest useful user-facing install flow.
+
+## Scope
+
+Add Pi-style install, list, and remove commands for the human/host-facing `boring-ui` CLI.
+
+Do not conflate this with:
+
+- the agent-facing `boring-ui-plugin` authoring CLI provisioned by `installPluginAuthoring` in latest main;
+- `/reload` or `verify` trying to repair missing dependencies for an already-authored plugin.
+
+`boring-ui-plugin` remains the slim scaffold/verify/test tool available inside agent workspaces. `boring-ui install` is the package/source install manager.
+
+Dependency install rule mirrors Pi:
+
+```txt
+npm/git installs install package dependencies in the installed/cloned package dir.
+local-path installs reference the local package and do not auto-install dependencies.
+Never install dependencies in the workspace root or app root.
+```
+
+Internal/app plugins are different: they are composed by the app and their dependencies are owned by the app/monorepo package manager, not by `boring-ui install`.
+
+`update` and backend self-test are follow-ups unless implementation turns out trivial and does not expand the PR.
+
+## Commands
+
+Required:
+
+```bash
+boring-ui install npm:@boring-plugins/email-client
+boring-ui install git:github.com/user/email-client@v1
+boring-ui install https://github.com/user/email-client
+boring-ui install ./local-plugin
+boring-ui install -l ./local-plugin
+
+boring-ui list [--json]
+boring-ui remove <source-or-id>
+```
+
+Deferred/stretch:
+
+```bash
+boring-ui update [source-or-id]
+```
+
+## Trust model
+
+CLI/local install mirrors Pi:
+
+```txt
+boring-ui install <source> = trusted local code, enabled by default
+```
+
+No permission prompts/grants in this PR.
+
+Print warning for npm/git/URL sources:
+
+```txt
+Security: Boring plugins run as trusted local code in CLI mode. Review third-party source before installing.
+```
+
+## Scope behavior
+
+Default is global/user install.
+
+```bash
+boring-ui install <source>
+```
+
+Workspace-local install:
+
+```bash
+boring-ui install -l <source>
+boring-ui install --local <source>
+```
+
+Roots mirror Pi:
+
+```txt
+Global:
+  ~/.pi/agent/npm
+  ~/.pi/agent/git
+  ~/.pi/agent/extensions
+
+Workspace:
+  <workspace>/.pi/npm
+  <workspace>/.pi/git
+  <workspace>/.pi/extensions
+```
+
+Collision rule:
+
+```txt
+workspace-local plugin wins over global plugin with same id
+```
+
+## Source behavior
+
+### npm
+
+- Install into scope-specific package root.
+- Use package manager behavior close to Pi.
+- Dependencies are installed in the installed package directory/package-manager root for that plugin source, never workspace/app root.
+- Validate Boring manifest before activation.
+- `/reload` must never install missing packages.
+
+### git / URL
+
+- Clone into scope-specific git root.
+- Support refs/tags/commits where practical.
+- Run dependency install in the cloned plugin package directory if `package.json` exists, like Pi.
+- Validate Boring manifest before activation after dependencies are present enough for verification.
+- Pinned refs should not silently move on future update.
+
+### local path
+
+Mirror Pi strictly and align with PR #166:
+
+- reference local path;
+- do not copy;
+- do not auto-install dependencies;
+- run verification against that plugin directory;
+- if dependencies are missing, print the exact command to run in the plugin directory.
+
+Example diagnostic:
+
+```txt
+Missing dependency: recharts
+Run: cd ./local-plugin && npm install
+```
+
+Important distinction: local-path install records/references the plugin source. It does not mutate that source's dependencies. Dependency install must not happen implicitly during `/reload` or normal verification either.
+
+## Verification
+
+After install:
+
+1. resolve package root;
+2. read `package.json`;
+3. validate Boring manifest;
+4. derive plugin id from package name;
+5. add source record for selected scope;
+6. run `verify-plugin` when applicable;
+7. tell user to run `/reload` or trigger reload only when safe.
+
+Do not require Playwright `test-plugin` in this PR. It can remain a manual command or follow-up integration.
+
+Dependency install is allowed during `boring-ui install npm:<pkg>` and `boring-ui install git:<repo>` for the installed/cloned package. Local-path install does not auto-install dependencies. Do not add dependency-install behavior to `/reload`; PR #166 intentionally keeps reload as reload-only.
+
+## Follow-ups
+
+### Update command
+
+Add after install/list/remove works:
+
+```bash
+boring-ui update [source-or-id]
+```
+
+### Backend self-test polish
+
+Support optional backend health declaration later:
+
+```jsonc
+{
+  "boring": {
+    "server": "server/index.ts",
+    "health": { "path": "/health" }
+  }
+}
+```
+
+`test-plugin` can later call plugin-owned gateway path:
+
+```txt
+/api/v1/plugins/:pluginId/health
+```
+
+Host metadata health remains separate if/when added:
+
+```txt
+/api/v1/agent-plugins/:pluginId/health
+```
+
+## Non-goals
+
+- No `update` unless trivial.
+- No backend self-test integration.
+- No hosted/cloud permission system.
+- No marketplace UI.
+- No bwrap worker.
+- No generic endpoint crawler.
+- No deep backend interaction testing.
+
+## Tests
+
+- npm/git/local install works globally.
+- `-l/--local` install works workspace-only.
+- Workspace-local shadows global same-id plugin.
+- `list` shows scope/source/id.
+- `remove` respects scope.
+- Third-party warning prints for npm/git/URL.
+- Manifest validation happens before activation.
+- npm/git/URL installs leave declared package dependencies present.
+- Local-path install references the local package without auto-installing dependencies and prints clear install hints if dependencies are missing.
+- Any dependency install that does happen runs in the installed/cloned plugin package directory, never workspace/app root.
+- Missing plugin-local deps are never installed during reload.
+- Installed plugin can use PR 02 runtime backend after `/reload`.
+
+## Acceptance
+
+- User can install, list, and remove external plugins like Pi.
+- Installed plugin can be verified and, after reload, use the server MVP from PR 02.
+- `update` and backend self-test are not required for this PR to ship.

--- a/docs/plans/runtime-plugin-cli-local/prs/03-cli-install-and-verification.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/03-cli-install-and-verification.md
@@ -1,19 +1,22 @@
-# PR 03 — Pi-style install/list/remove MVP
+# PR 03 — Pi-package install/list/remove MVP
 
 ## Goal
 
 After the server MVP works from existing plugin roots, add the smallest useful user-facing install flow.
 
+Design update after PR 02/03 playground validation: a boring plugin package is also a Pi package. Install/list/remove must manage Pi package sources and boring must discover `package.json#boring` from those same package roots. Do **not** create a parallel boring-only source registry.
+
 ## Scope
 
-Add Pi-style install, list, and remove commands for the human/host-facing `boring-ui` CLI.
+Add Pi-style package source install, list, and remove commands for boring plugin packages.
 
-Do not conflate this with:
+Ownership split:
 
-- the agent-facing `boring-ui-plugin` authoring CLI provisioned by `installPluginAuthoring` in latest main;
-- `/reload` or `verify` trying to repair missing dependencies for an already-authored plugin.
+- `boring-ui-plugin` owns the implementation because it is the slim workspace/agent-facing plugin CLI already provisioned into editable workspaces.
+- top-level `boring-ui plugin ...` may expose/reuse the same handlers/options as a human-facing facade.
+- `/reload` and `verify` must never repair/install missing dependencies for an already-authored plugin.
 
-`boring-ui-plugin` remains the slim scaffold/verify/test tool available inside agent workspaces. `boring-ui install` is the package/source install manager.
+Installed sources are Pi package sources. Boring consumes the same package roots by reading `package.json#boring`; Pi consumes `package.json#pi`. If a package has no `pi` resources, Pi no-ops (verified with `DefaultResourceLoader`: zero extensions, no prompt append).
 
 Dependency install rule mirrors Pi:
 
@@ -23,7 +26,7 @@ local-path installs reference the local package and do not auto-install dependen
 Never install dependencies in the workspace root or app root.
 ```
 
-Internal/app plugins are different: they are composed by the app and their dependencies are owned by the app/monorepo package manager, not by `boring-ui install`.
+Internal/app plugins are different: they are composed by the app and their dependencies are owned by the app/monorepo package manager, not by `boring-ui-plugin install`.
 
 `update` and backend self-test are follow-ups unless implementation turns out trivial and does not expand the PR.
 
@@ -32,20 +35,22 @@ Internal/app plugins are different: they are composed by the app and their depen
 Required:
 
 ```bash
-boring-ui install npm:@boring-plugins/email-client
-boring-ui install git:github.com/user/email-client@v1
-boring-ui install https://github.com/user/email-client
-boring-ui install ./local-plugin
-boring-ui install -l ./local-plugin
+boring-ui-plugin install npm:@boring-plugins/email-client
+boring-ui-plugin install git:github.com/user/email-client@v1
+boring-ui-plugin install https://github.com/user/email-client
+boring-ui-plugin install ./local-plugin
+boring-ui-plugin install -l ./local-plugin
 
-boring-ui list [--json]
-boring-ui remove <source-or-id>
+boring-ui-plugin list [--json]
+boring-ui-plugin remove <source-or-id>
+
+boring-ui plugin install ./local-plugin   # facade/reuse, if exposed
 ```
 
 Deferred/stretch:
 
 ```bash
-boring-ui update [source-or-id]
+boring-ui-plugin update [source-or-id]
 ```
 
 ## Trust model
@@ -53,7 +58,7 @@ boring-ui update [source-or-id]
 CLI/local install mirrors Pi:
 
 ```txt
-boring-ui install <source> = trusted local code, enabled by default
+boring-ui-plugin install <source> = trusted local code, enabled by default
 ```
 
 No permission prompts/grants in this PR.
@@ -69,14 +74,14 @@ Security: Boring plugins run as trusted local code in CLI mode. Review third-par
 Default is global/user install.
 
 ```bash
-boring-ui install <source>
+boring-ui-plugin install <source>
 ```
 
 Workspace-local install:
 
 ```bash
-boring-ui install -l <source>
-boring-ui install --local <source>
+boring-ui-plugin install -l <source>
+boring-ui-plugin install --local <source>
 ```
 
 Roots mirror Pi:
@@ -144,13 +149,14 @@ After install:
 2. read `package.json`;
 3. validate Boring manifest;
 4. derive plugin id from package name;
-5. add source record for selected scope;
-6. run `verify-plugin` when applicable;
-7. tell user to run `/reload` or trigger reload only when safe.
+5. add package source to Pi's selected scope/package source settings;
+6. make boring discovery read those same Pi package roots for `package.json#boring`;
+7. run `verify-plugin` when applicable;
+8. tell user to run `/reload` or trigger reload only when safe.
 
 Do not require Playwright `test-plugin` in this PR. It can remain a manual command or follow-up integration.
 
-Dependency install is allowed during `boring-ui install npm:<pkg>` and `boring-ui install git:<repo>` for the installed/cloned package. Local-path install does not auto-install dependencies. Do not add dependency-install behavior to `/reload`; PR #166 intentionally keeps reload as reload-only.
+Dependency install is allowed during `boring-ui-plugin install npm:<pkg>` and `boring-ui-plugin install git:<repo>` for the installed/cloned package. Local-path install does not auto-install dependencies. Do not add dependency-install behavior to `/reload`; PR #166 intentionally keeps reload as reload-only.
 
 ## Follow-ups
 
@@ -159,7 +165,7 @@ Dependency install is allowed during `boring-ui install npm:<pkg>` and `boring-u
 Add after install/list/remove works:
 
 ```bash
-boring-ui update [source-or-id]
+boring-ui-plugin update [source-or-id]
 ```
 
 ### Backend self-test polish
@@ -207,13 +213,17 @@ Host metadata health remains separate if/when added:
 - Third-party warning prints for npm/git/URL.
 - Manifest validation happens before activation.
 - npm/git/URL installs leave declared package dependencies present.
-- Local-path install references the local package without auto-installing dependencies and prints clear install hints if dependencies are missing.
+- Local-path install references the local package through Pi package source settings without auto-installing dependencies and prints clear install hints if dependencies are missing.
 - Any dependency install that does happen runs in the installed/cloned plugin package directory, never workspace/app root.
 - Missing plugin-local deps are never installed during reload.
+- No `.pi/boring-plugin-sources.json` or other bespoke boring registry is introduced; the package source registry is Pi-owned/compatible.
+- Installed plugin with only `package.json#boring` and no `package.json#pi` is valid: Pi no-ops and boring loads the UI/backend surfaces.
 - Installed plugin can use PR 02 runtime backend after `/reload`.
 
 ## Acceptance
 
-- User can install, list, and remove external plugins like Pi.
+- User can install, list, and remove external boring plugins as Pi package sources.
+- Boring discovers installed Pi package sources and loads their `package.json#boring` surfaces after `/reload`.
+- Pi consumes any `package.json#pi` resources from the same packages and no-ops for packages without `pi`.
 - Installed plugin can be verified and, after reload, use the server MVP from PR 02.
 - `update` and backend self-test are not required for this PR to ship.

--- a/docs/plans/runtime-plugin-cli-local/prs/pr-01-taxonomy-source-metadata.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/pr-01-taxonomy-source-metadata.md
@@ -1,0 +1,52 @@
+# PR 01 — Taxonomy docs + plugin source metadata
+
+## Goal
+
+Prepare the model for CLI/local runtime backends without executing anything yet.
+
+## Scope
+
+- Document single-field `boring.server` semantics by source kind.
+- Preserve manifest/schema support for safe `boring.server` paths.
+- Introduce first-class plugin source metadata so later code does not infer trust from path strings.
+
+## Proposed files
+
+- `packages/workspace/src/shared/plugins/manifest.ts`
+- `packages/workspace/src/server/agentPlugins/types.ts`
+- `packages/workspace/src/server/agentPlugins/scan.ts`
+- `packages/workspace/src/app/server/createWorkspaceAgentServer.ts` only if needed to pass source metadata through
+- plugin docs/skills
+
+## Source model
+
+```ts
+type BoringPluginSource = {
+  root: string
+  kind: "workspace-extension" | "global-extension" | "default-package" | "additional-dir" | "npm-package" | "git-package" | "local-path"
+  scope: "workspace" | "global" | "app"
+  workspaceId?: string
+}
+```
+
+Loaded plugin records should preserve source metadata and optionally expose the validated `boring.server` path.
+
+## Non-goals
+
+- No gateway.
+- No jiti runtime backend loader.
+- No install command.
+- No backend execution behavior yet.
+
+## Tests
+
+- Manifest accepts safe `boring.server` path.
+- Unsafe `boring.server` path is rejected.
+- Source metadata survives scan/load result.
+- Workspace/global external sources are identifiable.
+- Default package/app sources are identifiable separately.
+
+## Acceptance
+
+- Docs clearly say external CLI backends use `boring.server` through the constrained runtime-server gateway, while internal/app plugins use boot-time server wiring.
+- Runtime backend trust/activation is derived explicitly from source metadata in one place.

--- a/docs/plans/runtime-plugin-cli-local/prs/pr-02-reload-coordinator-extraction.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/pr-02-reload-coordinator-extraction.md
@@ -1,0 +1,52 @@
+# PR 02 — Reload coordinator extraction
+
+## Goal
+
+Extract existing plugin reload sequencing before adding runtime backend reload.
+
+This is a behavior-preserving refactor.
+
+## Scope
+
+Create one reload coordinator used by both reload entrypoints:
+
+- `/api/v1/agent/reload` through `createAgentApp.beforeReload`
+- `/api/boring.reload`
+
+## Proposed files
+
+- `packages/workspace/src/app/server/workspacePluginReload.ts` new
+- `packages/workspace/src/app/server/createWorkspaceAgentServer.ts` wiring only
+- `packages/workspace/src/server/agentPlugins/routes.ts` should call the same coordinator closure, not duplicate sequencing
+- reload tests
+
+## Coordinator responsibilities
+
+Current behavior only:
+
+```txt
+assetManager.load()
+rebuildServerPlugins() diagnostic-only
+runRuntimeProvisioning()
+opts.beforeReload()
+merge diagnostics/restart_warnings
+```
+
+## Non-goals
+
+- No runtime backend registry.
+- No gateway.
+- No source install.
+- No behavior change.
+
+## Tests
+
+- Existing reload tests pass unchanged.
+- `/api/v1/agent/reload` and `/api/boring.reload` surface same scan/rebuild diagnostics.
+- Caller `opts.beforeReload` diagnostics are merged with Boring diagnostics.
+- Per-plugin failures do not abort unrelated reload work.
+
+## Acceptance
+
+- `createWorkspaceAgentServer.ts` does not grow.
+- Reload sequence exists in one place.

--- a/docs/plans/runtime-plugin-cli-local/prs/pr-03-shared-jiti-import-helper.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/pr-03-shared-jiti-import-helper.md
@@ -1,0 +1,38 @@
+# PR 03 — Shared jiti import helper
+
+## Goal
+
+Extract the existing jiti fresh-import behavior into a canonical helper.
+
+## Scope
+
+Current jiti behavior exists in `pluginEntryResolver.ts`. Move it below `app/server` so both internal `boring.server` diagnostics and external runtime `boring.server` loader can use it.
+
+## Proposed files
+
+- `packages/workspace/src/server/pluginImports/importServerModule.ts` new
+- `packages/workspace/src/app/server/pluginEntryResolver.ts`
+- tests for import helper behavior
+
+## Helper behavior
+
+- `hotReload: true` uses `createJiti(import.meta.url, { moduleCache: false }).import(path)`.
+- Fallback to native `import()` when jiti unavailable, preserving existing warning.
+- `hotReload: false` uses native import.
+
+## Non-goals
+
+- No runtime backend API.
+- No gateway.
+- No install command.
+
+## Tests
+
+- `hotReload: true` sees edited TypeScript source.
+- `hotReload: false` preserves native import behavior.
+- Missing jiti fallback warning is unchanged.
+- `pluginEntryResolver.ts` still handles existing dir-source `boring.server` entries.
+
+## Acceptance
+
+- There is exactly one jiti import helper for workspace server plugin code.

--- a/docs/plans/runtime-plugin-cli-local/prs/pr-04-runtime-backend-api-router.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/pr-04-runtime-backend-api-router.md
@@ -1,0 +1,59 @@
+# PR 04 — Runtime backend API + exact route capture
+
+## Goal
+
+Add the public runtime backend authoring API and exact-match route capture.
+
+## Scope
+
+Add `@hachej/boring-workspace/runtime-server` for external CLI runtime backend modules.
+
+## Proposed files
+
+- `packages/workspace/src/server/runtimeBackend/defineRuntimeServerPlugin.ts`
+- `packages/workspace/src/server/runtimeBackend/routerCapture.ts`
+- `packages/workspace/src/server/runtimeBackend/index.ts`
+- `packages/workspace/package.json` exports
+- build/tsup config if needed
+- tests
+
+## API
+
+```ts
+import { defineRuntimeServerPlugin } from "@hachej/boring-workspace/runtime-server"
+
+export default defineRuntimeServerPlugin({
+  routes(router) {
+    router.get("/messages", async (ctx) => ({ messages: [] }))
+  },
+  async dispose() {},
+})
+```
+
+Rules:
+
+- Runtime module must not declare `id`.
+- Loader supplies plugin id from manifest/source record later.
+- Exact-match route paths only.
+- No params/wildcards/order.
+- No raw Fastify request/reply.
+- No `workspace` facade in MVP context.
+
+## Non-goals
+
+- No jiti loader for runtime backend yet.
+- No Fastify gateway yet.
+- No reload integration.
+
+## Tests
+
+- Subpath import works.
+- Importing subpath does not pull app/server orchestration.
+- Module with `id` is rejected.
+- Unsafe route paths rejected.
+- Duplicate method/path rejected.
+- Exact route table produced.
+
+## Acceptance
+
+- Runtime backend modules can be authored and route-captured in isolation.

--- a/docs/plans/runtime-plugin-cli-local/prs/pr-05-runtime-backend-loader-registry.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/pr-05-runtime-backend-loader-registry.md
@@ -1,0 +1,66 @@
+# PR 05 — Runtime backend loader + registry
+
+## Goal
+
+Load external-source `boring.server` runtime modules with the shared jiti helper and atomically manage executable handler tables.
+
+## Scope
+
+No HTTP gateway yet; this PR makes backend state loadable/testable in isolation.
+
+## Proposed files
+
+- `packages/workspace/src/server/runtimeBackend/runtimeServerLoader.ts`
+- `packages/workspace/src/server/runtimeBackend/runtimeBackendRegistry.ts`
+- `packages/workspace/src/server/runtimeBackend/runtimeBackendResponse.ts`
+- `packages/workspace/src/server/runtimeBackend/runtimeBackendHealth.ts`
+- tests
+
+## Registry invariants
+
+- Serialized/single-flight reload.
+- Atomic replace by plugin id.
+- Failed load preserves previous table.
+- First failed load leaves backend disabled.
+- Dispose old instance on replace/unload/close.
+- Dispose failures become diagnostics/health, not full reload aborts.
+
+## Response/error contract
+
+Stable errors via canonical error enum:
+
+```txt
+RUNTIME_PLUGIN_NOT_FOUND
+RUNTIME_PLUGIN_ROUTE_NOT_FOUND
+RUNTIME_PLUGIN_HANDLER_FAILED
+RUNTIME_PLUGIN_LOAD_FAILED
+RUNTIME_PLUGIN_RESPONSE_UNSUPPORTED
+```
+
+Response metadata object must be discriminated:
+
+```ts
+{ kind: "response", status?: number, headers?: Record<string, string>, body?: unknown }
+```
+
+Plain object with `status` remains JSON.
+
+## Non-goals
+
+- No Fastify gateway.
+- No install command.
+- No bwrap worker.
+- No route params.
+
+## Tests
+
+- jiti-loaded runtime server captures handlers.
+- Syntax error keeps previous backend live.
+- Dispose called on replace/unload/close.
+- Dispose error surfaces as diagnostic.
+- Concurrent reloads serialize.
+- Unsupported response value returns stable error.
+
+## Acceptance
+
+- Runtime backend registry can load, dispatch internally, reload, fail safely, and dispose.

--- a/docs/plans/runtime-plugin-cli-local/prs/pr-06-gateway-reload-integration.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/pr-06-gateway-reload-integration.md
@@ -1,0 +1,71 @@
+# PR 06 — Gateway + reload integration
+
+## Goal
+
+Expose runtime backend handlers through the stable HTTP gateway and wire backend reload into the shared coordinator.
+
+## Scope
+
+This is the first PR where external-source `boring.server` runtime modules become live over HTTP through the constrained gateway.
+
+## Proposed files
+
+- `packages/workspace/src/server/runtimeBackend/runtimeBackendGateway.ts`
+- `packages/workspace/src/app/server/workspacePluginReload.ts`
+- app/server route registration wiring
+- health route wiring
+- integration tests
+
+## Gateway
+
+Plugin-owned space:
+
+```txt
+ALL /api/v1/plugins/:pluginId/*
+```
+
+Host management/health stays outside gateway:
+
+```txt
+GET /api/v1/agent-plugins/:pluginId/health
+```
+
+## Reload integration
+
+Coordinator sequence becomes:
+
+```txt
+assetManager.load()
+runtimeBackendRegistry.reloadFromLoadedPlugins(loaded)
+rebuildServerPlugins() diagnostic-only for boring.server
+runRuntimeProvisioning()
+opts.beforeReload()
+merge diagnostics/restart_warnings/backend health
+```
+
+## Source gating
+
+- Workspace/global external sources may activate `boring.server` through the runtime backend gateway.
+- Default-package/app sources do not activate through the gateway in MVP.
+- Workspace-local source must match current workspace in workspaces mode.
+
+## Non-goals
+
+- No install command.
+- No remote sandbox.
+- No permission prompts.
+- No route params.
+
+## Tests
+
+- Plugin backend responds after `/reload`.
+- Source edit + `/reload` changes response without restart.
+- Syntax error keeps previous response live.
+- Removed plugin unloads gateway handlers.
+- Wrong workspace gateway call rejected.
+- Host health path does not conflict with plugin `/health`.
+- Both reload endpoints surface same backend diagnostics.
+
+## Acceptance
+
+- Existing `.pi/extensions/<id>` plugin with `boring.server` can hot-reload constrained backend handlers in CLI/local mode.

--- a/docs/plans/runtime-plugin-cli-local/prs/pr-07-pi-style-install.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/pr-07-pi-style-install.md
@@ -1,0 +1,78 @@
+# PR 07 — Pi package-source install/list/remove/update
+
+## Goal
+
+Add external package installation UX after runtime backend MVP works with existing plugin roots.
+
+Boring plugin packages are Pi packages: boring reads `package.json#boring`, Pi reads `package.json#pi`, and Pi no-ops for packages with no `pi` resources.
+
+## Scope
+
+`boring-ui-plugin` implementation, optional top-level `boring-ui plugin ...` facade, Pi-style trust and scopes.
+
+## Commands
+
+```bash
+boring-ui-plugin install npm:@boring-plugins/email-client
+boring-ui-plugin install git:github.com/user/email-client@v1
+boring-ui-plugin install https://github.com/user/email-client
+boring-ui-plugin install ./local-plugin
+boring-ui-plugin install -l ./local-plugin
+
+boring-ui-plugin list [--json]
+boring-ui-plugin remove <source-or-id>
+
+boring-ui plugin install ./local-plugin   # facade/reuse, if exposed
+```
+
+## Scope
+
+- Default: global/user install.
+- `-l` / `--local`: workspace-local install.
+
+Roots mirror Pi:
+
+```txt
+Global:
+  ~/.pi/agent/npm
+  ~/.pi/agent/git
+  ~/.pi/agent/extensions
+
+Workspace:
+  <workspace>/.pi/npm
+  <workspace>/.pi/git
+  <workspace>/.pi/extensions
+```
+
+## Behavior
+
+- Install = trusted + enabled.
+- No permission prompts/grants in CLI MVP.
+- Print security warning for npm/git/URL sources.
+- Validate Boring manifest before activation.
+- Write/update Pi package source settings; do not create `.pi/boring-plugin-sources.json`.
+- Reference local paths; do not copy/symlink local source into `.pi/extensions`.
+- Run `verify-plugin` when applicable.
+- Optionally run `test-plugin` when UI URL known.
+
+## Non-goals
+
+- No hosted/cloud permission system.
+- No marketplace UI.
+- No bwrap worker.
+
+## Tests
+
+- npm/git/local install works globally.
+- `-l/--local` install works workspace-only.
+- Workspace-local shadows global same-id plugin.
+- `list` shows scope/source/id.
+- `remove` respects scope.
+- Third-party warning prints for npm/git/URL.
+- Package with `boring` but no `pi` resources is valid.
+- Installed package appears in `/api/v1/agent-plugins` after `/reload`.
+- No custom boring source registry is created.
+
+## Acceptance
+
+- User can install external boring plugin packages as Pi package sources, globally or per workspace.

--- a/docs/plans/runtime-plugin-cli-local/prs/pr-08-self-test-backend.md
+++ b/docs/plans/runtime-plugin-cli-local/prs/pr-08-self-test-backend.md
@@ -1,0 +1,56 @@
+# PR 08 — Extend plugin self-test to backend health
+
+## Goal
+
+Extend PR #159 self-test so runtime backend handlers are verified alongside frontend loading/rendering.
+
+## Scope
+
+`boring-ui test-plugin` backend health support.
+
+## Manifest health declaration
+
+```jsonc
+{
+  "boring": {
+    "runtimeServer": "server/index.ts",
+    "health": { "path": "/health" }
+  }
+}
+```
+
+This is plugin-owned `/health` under the gateway:
+
+```txt
+/api/v1/plugins/:pluginId/health
+```
+
+Host metadata health remains:
+
+```txt
+/api/v1/agent-plugins/:pluginId/health
+```
+
+## Tasks
+
+1. Parse optional backend health declaration.
+2. `test-plugin` calls gateway health path when present.
+3. Include backend status in JSON/text output.
+4. Record last self-test result in health aggregator if available.
+
+## Non-goals
+
+- No generic endpoint crawler.
+- No deep backend interaction testing.
+- No remote sandbox support.
+
+## Tests
+
+- Healthy backend appears as backend ok.
+- Backend failure appears separately from front failure.
+- Missing backend health declaration does not fail self-test.
+- Host health path and plugin health path are not confused.
+
+## Acceptance
+
+- `boring-ui test-plugin <id>` reports front and backend separately.

--- a/docs/plans/runtime-plugin-cli-local/reviews/latest-main-reassessment.md
+++ b/docs/plans/runtime-plugin-cli-local/reviews/latest-main-reassessment.md
@@ -1,0 +1,155 @@
+# Latest-main reassessment — CLI/local runtime plugin plan
+
+Date: 2026-06-03
+
+Branch reviewed after rebasing onto latest `origin/main`:
+
+```txt
+plan/runtime-plugin-cli-local
+```
+
+Latest-main code touchpoints inspected:
+
+- `packages/workspace/src/app/server/createWorkspaceAgentServer.ts`
+- `packages/workspace/src/app/server/pluginEntryResolver.ts`
+- `packages/workspace/src/app/server/rebuildServerPlugins.ts`
+- `packages/workspace/src/server/agentPlugins/scan.ts`
+- `packages/workspace/src/server/agentPlugins/manager.ts`
+- `packages/workspace/src/server/agentPlugins/routes.ts`
+- `packages/workspace/src/shared/plugins/manifest.ts`
+- `packages/workspace/package.json`
+
+## Verdict
+
+Plan remains valid, but latest main adds two important constraints:
+
+1. `/api/v1/agent/reload` and `/api/boring.reload` do **not** currently have identical behavior; after reconsideration, PR 01 should remove `/api/boring.reload` instead of preserving a second reload path.
+2. `installPluginAuthoring` / `boring-ui-plugin` is now an explicit agent-authoring path and must stay separate from future `boring-ui install`.
+
+Canonical PR docs were updated to reflect both.
+
+## Finding 1 — remove the old reload endpoint instead of coordinating two paths
+
+Latest main behavior:
+
+- Agent reload (`createAgentApp.beforeReload`) does:
+  - asset manager scan;
+  - server rebuild diagnostics;
+  - runtime provisioning;
+  - caller `opts.beforeReload` merge;
+  - merged diagnostics/restart warnings.
+
+- Developer reload route (`POST /api/boring.reload`) does:
+  - asset manager scan;
+  - server rebuild diagnostics;
+  - restart warnings;
+  - no runtime provisioning;
+  - no caller `opts.beforeReload` merge.
+
+So PR 01 cannot truthfully be both:
+
+```txt
+behavior-preserving extraction
+```
+
+and
+
+```txt
+make both reload endpoints identical
+```
+
+## Plan adjustment made
+
+PR 01 now says `/api/v1/agent/reload` is the only reload endpoint and `/api/boring.reload` should be removed. It does not require a new helper abstraction unless that clearly shrinks `createWorkspaceAgentServer.ts`.
+
+PR 02 now says runtime backend reload is added only to the canonical agent reload path and must not reintroduce `/api/boring.reload`. A focused helper can be extracted in PR 02 if backend reload would otherwise bloat the app-server composition file.
+
+## Finding 2 — source metadata must not leak into public list/event responses by accident
+
+Current `BoringPluginAssetManager` returns list/event payloads shaped for the frontend. These do not include root/source metadata.
+
+Runtime backend needs source metadata internally, but front list/event payloads should not start exposing host paths or source policy details.
+
+## Reassessment
+
+PR 01 acceptance now explicitly says source metadata survives scan/load **without changing existing list/event response shapes**.
+
+Implementation implication:
+
+- source metadata can live on internal scan/inspection records;
+- `BoringPluginListEntry` should remain public/UI-safe;
+- do not leak `rootDir` into SSE/list payloads.
+
+## Finding 3 — current duplicate-id scan behavior conflicts with future workspace-local shadowing
+
+Current `scanBoringPlugins(pluginDirs: string[])` treats duplicate plugin ids as invalid and removes the earlier plugin.
+
+Future PR 03 says:
+
+```txt
+workspace-local plugin wins over global same-id plugin
+```
+
+That cannot be implemented by simply appending roots to the current string-dir scanner. It will need a source-aware ordering/shadowing rule.
+
+## Reassessment
+
+This does not block PR 01/02 if install remains deferred. It is a PR 03 implementation concern.
+
+When PR 03 starts, it should avoid broad rewrites by introducing source-aware collection/selection before calling scan/load, or by making scan accept source records with explicit duplicate policy.
+
+Do not hide workspace-local shadowing inside incidental array order.
+
+## Finding 4 — latest main has explicit agent-authoring CLI separation
+
+`createWorkspaceAgentServer.ts` now has `installPluginAuthoring` and provisions `boring-ui-plugin` as the slim setup/scaffold/verify CLI inside agent workspaces.
+
+This matters because PR 03 proposes top-level `boring-ui install`.
+
+## Plan adjustment made
+
+PR 03 now states:
+
+- `boring-ui-plugin` remains the agent-facing scaffold/verify tool;
+- `boring-ui install` is the human/host-facing package/source install manager;
+- do not route agent plugin authoring through the full human CLI.
+
+## Finding 5 — jiti helper extraction still matches latest main
+
+`pluginEntryResolver.ts` still owns:
+
+```ts
+createJiti(import.meta.url, { moduleCache: false }).import(serverPath)
+```
+
+PR 01 shared import helper remains appropriate.
+
+## Finding 6 — `runtime-server` export still needs build/export wiring
+
+`packages/workspace/package.json` has exports for root, app/server, server, plugin, etc. No `./runtime-server` export exists.
+
+PR 02 correctly includes adding the subpath. Implementation must update:
+
+- package exports;
+- tsup entry points;
+- public API tests/build artifact assertions if present.
+
+## Final reassessment
+
+The three-PR plan is still the right shape:
+
+```txt
+PR 01 — foundation
+PR 02 — server runtime MVP
+PR 03 — install/list/remove MVP
+```
+
+But the implementation should obey these latest-main constraints:
+
+1. Reload logic has one canonical endpoint, `/api/v1/agent/reload`; the old `/api/boring.reload` route is removed, not preserved. A helper is optional, not required.
+2. Source metadata stays internal and does not leak in list/SSE payloads.
+3. Workspace-local shadowing is a PR 03 source-selection rule, not implicit scan array luck.
+4. `boring-ui install` stays separate from agent-facing `boring-ui-plugin`.
+5. PR 02 must wire a real `./runtime-server` package export/build entry.
+
+No major plan reset needed.

--- a/docs/plans/runtime-plugin-cli-local/reviews/nuclear-pr-01-foundation.md
+++ b/docs/plans/runtime-plugin-cli-local/reviews/nuclear-pr-01-foundation.md
@@ -1,0 +1,116 @@
+# Nuclear review — PR 01 foundation plan
+
+Plan reviewed: `prs/01-foundation.md`
+
+Verdict: **revise before implementation**
+
+The PR is directionally right, but the plan still leaves too much room for spaghetti in the actual implementation. The biggest risk is turning “source metadata” into a half-explicit, half-inferred trust model scattered across scan, asset manager, reload, and future install code.
+
+## Blockers
+
+### 1. `runtimeBackendAllowed: boolean` is a drift-prone policy leak
+
+The plan says not to infer trust from paths, good. But storing `runtimeBackendAllowed` directly on every source record creates another failure mode: every caller now has to set the boolean correctly. That becomes the same bug class as path inference, just one layer later.
+
+Better shape:
+
+```ts
+type BoringPluginSource = {
+  rootDir: string
+  origin: "workspace" | "global" | "app" | "additional"
+  installKind?: "extension" | "npm" | "git" | "local-path"
+  workspaceId?: string
+}
+
+function canActivateRuntimeBackend(source: BoringPluginSource, ctx: WorkspacePluginPolicyContext): boolean
+```
+
+If you really want a stored capability, make it produced by exactly one source-normalization function, not passed around as arbitrary caller input.
+
+Required plan change: define a **single policy function / normalizer** as owner of backend activation, not an ad-hoc boolean set at callsites.
+
+### 2. The source enum is prematurely polluted by install concepts
+
+PR 01 does not implement install, but the source model already includes `npm-package`, `git-package`, and `local-path`. That invites code branches for install kinds before install exists.
+
+Code-judo move: split provenance from install mechanism:
+
+```ts
+origin: "workspace" | "global" | "app" | "additional"
+installKind?: "extension" | "npm" | "git" | "local-path"
+```
+
+Then PR 01 can use only origins that exist today. PR 03 can populate `installKind`.
+
+Required plan change: avoid future-only enum values in PR 01 execution path unless tests prove they are inert metadata only.
+
+### 3. “No behavior change” conflicts with `opts.beforeReload` error wrapping
+
+The plan says reload coordinator extraction is behavior-preserving, but also says to wrap caller `opts.beforeReload` failures into diagnostics. If current behavior aborts or throws differently, that is a behavior change and should not be inside the extraction PR.
+
+Required plan change: choose one:
+
+- strict extraction: preserve caller hook failure behavior exactly; or
+- behavior change: explicitly include it, test it, and stop calling the PR behavior-preserving.
+
+I recommend strict extraction in PR 01. Move caller-hook diagnostic changes to PR 02 with backend diagnostics.
+
+### 4. Source records need canonical path normalization rules
+
+The plan uses `root: string`, but does not say whether it is absolute, realpathed, symlink-preserving, workspace-relative, or display-only. This is security-sensitive because later gateway policy depends on it.
+
+Required plan change:
+
+- rename to `rootDir`;
+- require absolute normalized path;
+- define whether realpath is used for containment checks;
+- keep a separate display/source string if needed for CLI output.
+
+### 5. Asset manager ownership boundary is not explicit enough
+
+PR 01 touches metadata that likely flows through `BoringPluginAssetManager`, which is already 488 lines and owns too much scan/signature/event state. The plan must prevent adding policy logic there.
+
+Required plan change: explicitly state:
+
+- asset manager may carry source metadata through loaded/list/inspect records;
+- asset manager must not decide backend activation policy;
+- asset manager must not import runtime backend modules;
+- asset manager must not grow install/source ordering logic.
+
+## Strong recommendations
+
+### A. Add one type boundary file instead of sprinkling types
+
+Create one source metadata module, e.g.:
+
+```txt
+packages/workspace/src/server/agentPlugins/pluginSources.ts
+```
+
+Own there:
+
+- source record type;
+- normalizer;
+- ordering/shadowing helper if needed;
+- runtime backend policy function.
+
+Do not define source records in multiple files.
+
+### B. Keep reload coordinator extraction tiny
+
+`createWorkspaceAgentServer.ts` is already ~801 lines. This PR should shrink it or keep it flat. If the PR adds more inline conditionals there, reject it.
+
+Coordinator should be called through one clear function, not several optional callback branches.
+
+### C. Tests need “same observable behavior” snapshots
+
+The test list is good but missing a key guard: before/after reload endpoint output should remain byte/shape-compatible for existing callers. Add snapshot/shape tests for current reload response.
+
+## Suggested revised acceptance
+
+- Source metadata has one canonical module and one policy function.
+- `rootDir` is absolute and path-normalization rules are documented/tested.
+- `BoringPluginAssetManager` only carries source metadata; it does not own backend activation policy.
+- Reload coordinator extraction preserves caller-hook error behavior exactly.
+- `createWorkspaceAgentServer.ts` does not grow and preferably shrinks.
+- Jiti helper extraction has no behavior change for current `boring.server` diagnostics.

--- a/docs/plans/runtime-plugin-cli-local/reviews/nuclear-pr-02-server-runtime-mvp.md
+++ b/docs/plans/runtime-plugin-cli-local/reviews/nuclear-pr-02-server-runtime-mvp.md
@@ -1,0 +1,155 @@
+# Nuclear review — PR 02 server runtime MVP plan
+
+Plan reviewed: `prs/02-server-runtime-mvp.md`
+
+Verdict: **revise before implementation**
+
+The MVP boundary is mostly right: no install, no bwrap, no permissions, no params. But the plan still underspecifies the hardest parts: atomic commit semantics, request/body normalization, and Fastify/gateway boundaries. If implemented as written, this can easily become a set of ad-hoc route and reload branches.
+
+## Blockers
+
+### 1. Atomic registry semantics are not precise enough
+
+“Atomic replace by plugin id” is not enough. Reload touches multiple plugins. A naïve implementation can leave the registry half-updated across plugins, or dispose old handlers before all new handlers are known to be loadable.
+
+Required plan change: specify a two-phase commit:
+
+```txt
+prepare next records for all loaded runtime-capable plugins
+  -> collect diagnostics without mutating current registry
+  -> commit a new registry snapshot atomically
+  -> dispose replaced/removed old instances after commit
+```
+
+Then decide failure policy explicitly:
+
+- per-plugin fallback: failed plugin keeps its previous handler while other plugins update; or
+- all-or-nothing global reload.
+
+I recommend per-plugin fallback, but it must be stated and tested.
+
+### 2. Gateway path normalization is underdefined
+
+`ALL /api/v1/plugins/:pluginId/*` is not enough. Bugs will hide in slash handling and encoded paths.
+
+Required plan change: define:
+
+- plugin id validation before dispatch;
+- decoded vs raw path behavior;
+- trailing slash normalization;
+- duplicate slash handling;
+- query string exclusion from route key;
+- method normalization;
+- behavior for `/api/v1/plugins/:pluginId` with no tail;
+- rejection of `..`, encoded slash/backslash escape vectors if relevant.
+
+Exact-match routing only works if normalization is exact and tested.
+
+### 3. Request body helpers can become a hidden footgun
+
+Context exposes both `json()` and `text()`, but Fastify request bodies are not always safely re-readable. If each helper reads the raw stream independently, handlers become order-dependent and flaky.
+
+Required plan change: define a cached body accessor:
+
+```ts
+type RuntimeBodyReader = {
+  text(): Promise<string>
+  json<T = unknown>(): Promise<T>
+}
+```
+
+Both helpers read from the same cached raw body. Define body size/error behavior by reusing existing Fastify/body limits, not inventing a new limit in this layer.
+
+### 4. The API wrapper risks becoming a thin identity abstraction
+
+`defineRuntimeServerPlugin()` is justified only if it actively owns validation/branding/type boundary. If it is just `return plugin`, it is unearned indirection.
+
+Required plan change: state what the helper buys:
+
+- rejects `id`;
+- validates `routes` shape;
+- brands runtime plugin object so loader can distinguish it from random default exports;
+- keeps the public import type-stable.
+
+If not doing those, delete the wrapper and import a typed object directly.
+
+### 5. `runtimeBackendHealth.ts` may be premature in server MVP
+
+The plan includes `runtimeBackendHealth.ts` and host health endpoint. That can be useful, but it risks another parallel state store duplicating registry diagnostics.
+
+Code-judo move: make health a projection of the registry snapshot, not its own owner.
+
+Required plan change: health module can format/project state, but registry remains source of truth for:
+
+- active/inactive;
+- last load error;
+- revision;
+- dispose error;
+- source scope/kind.
+
+No independent health cache in PR 02.
+
+### 6. Source gating needs one canonical policy call
+
+The plan correctly says workspace/global sources may activate and default/app sources may not. But if this check appears in loader, registry, gateway, and coordinator, it becomes spaghetti.
+
+Required plan change: PR 02 must call the PR 01 policy function once during reload preparation. Gateway should dispatch only against registry snapshot; it should not re-evaluate source trust.
+
+### 7. Error code ownership is vague
+
+The plan says stable errors via canonical enum, but does not identify where new codes are added or how they are serialized. This is how raw string codes creep in.
+
+Required plan change:
+
+- name the canonical error-code file/import path;
+- include tests that response bodies use enum values, not local string literals;
+- ensure loader diagnostics and HTTP errors use the same code source.
+
+## Strong recommendations
+
+### A. Keep gateway as an adapter only
+
+`runtimeBackendGateway.ts` should do only:
+
+```txt
+Fastify request -> normalized dispatch request -> registry.dispatch() -> Fastify reply
+```
+
+It must not know jiti, source policy, load diagnostics, or plugin manifests.
+
+### B. Split registry internals into pure functions
+
+Avoid one giant `RuntimeBackendRegistry` class doing everything. Keep pure pieces:
+
+- `captureRoutes()`;
+- `normalizeGatewayPath()`;
+- `coerceRuntimePluginResult()`;
+- `prepareRuntimeBackendSnapshot()`.
+
+The class, if any, should own current snapshot and lifecycle only.
+
+### C. Add a “bad plugin cannot poison server” integration test
+
+One malformed plugin should not break:
+
+- other plugins;
+- host health endpoint;
+- front runtime plugin events;
+- future reloads.
+
+This test is more important than several happy-path tests.
+
+### D. Watch file-size thresholds
+
+`createWorkspaceAgentServer.ts` is already ~801 lines and `BoringPluginAssetManager` is ~488 lines. PR 02 must not push large runtime backend logic into either. If `createWorkspaceAgentServer.ts` approaches 900+ lines, the PR is structurally suspect.
+
+## Suggested revised acceptance
+
+- Runtime backend reload uses two-phase prepare/commit/dispose semantics.
+- Per-plugin failure policy is explicit and tested.
+- Gateway normalization is fully specified and covered by tests.
+- Request body helpers use one cached body read.
+- `defineRuntimeServerPlugin()` earns its existence through validation/branding or is removed.
+- Health is a projection of registry state, not a second source of truth.
+- Source gating happens through one canonical policy call during reload preparation.
+- Gateway is a thin adapter over `registry.dispatch()`.

--- a/docs/plans/runtime-plugin-cli-local/reviews/nuclear-simplicity-robustness-pass2.md
+++ b/docs/plans/runtime-plugin-cli-local/reviews/nuclear-simplicity-robustness-pass2.md
@@ -1,0 +1,168 @@
+# Thermo-nuclear review pass 2 — simplicity + robustness
+
+Reviewed after simplification edits:
+
+- `context.md`
+- `implementation-plan.md`
+- `prs/01-foundation.md`
+- `prs/02-server-runtime-mvp.md`
+- `prs/03-cli-install-and-verification.md`
+
+Verdict: **ship the plan with minor clarifications**
+
+The plan now has the right simplicity/robustness balance. The big complexity traps were removed:
+
+- no `runtimeBackendAllowed` boolean;
+- no automatic string/bytes response coercion;
+- no raw/text body helpers;
+- no PR 02 host health route requirement;
+- no required PR 03 update/self-test work;
+- install is separated from server MVP.
+
+This is now a realistic implementation sequence rather than a framework design.
+
+## What is now right
+
+### 1. PR split is correct
+
+```txt
+PR 01 — foundation only
+PR 02 — server runtime MVP only
+PR 03 — install/list/remove only
+```
+
+This is the right granularity. Fewer PRs would mix concerns. More PRs would create orchestration overhead.
+
+### 2. Source policy is simple and robust
+
+Good:
+
+```ts
+type BoringPluginSource = {
+  rootDir: string
+  kind: "internal" | "external"
+  workspaceId?: string
+}
+```
+
+This is much better than `runtimeBackendAllowed` and reflects the simple model: internal plugins are fixed/boot-time; external plugins are hot-reloaded through the gateway.
+
+The classification is visible, testable, and hard to accidentally drift.
+
+### 3. PR 02 is no longer trying to become an HTTP framework
+
+Good MVP contract:
+
+```txt
+JSON body only
+JSON return only
+explicit response escape hatch
+exact path only
+```
+
+This gives plugins enough power without creating body/response machinery before it is needed.
+
+### 4. Host health route is correctly deferred
+
+Reload diagnostics are enough for the server MVP. A host health route can be added later from registry diagnostics if actual UX needs it.
+
+### 5. PR 03 is now a proper CLI install MVP
+
+Install/list/remove is enough. Update and backend self-test would have made the PR too wide.
+
+## Minor clarifications before implementation
+
+These are not blockers, but they should be added or kept in mind during implementation.
+
+### A. Keep internal vs external source assignment boring
+
+Current simplified policy says:
+
+```txt
+internal => fixed/boot-time
+external => hot gateway
+```
+
+Good. Keep the MVP mapping small:
+
+- app/default/composed sources are internal;
+- workspace/global `.pi` installed roots are external.
+
+Do not let advanced host escape hatches automatically become external because of array order or path shape.
+
+### B. Define `rootDir` normalization once
+
+PR 01 says absolute normalized host path. Implementation should choose one exact rule:
+
+```txt
+rootDir = path.resolve(input)
+containment checks use realpath when needed
+```
+
+Avoid mixing display paths, resolved paths, and realpaths in one field.
+
+If display path is needed later, add separate `displaySource`.
+
+### C. Keep reload extraction genuinely behavior-preserving
+
+Do not sneak diagnostics behavior changes into PR 01. If current `opts.beforeReload` throws, preserve that exact behavior in PR 01.
+
+PR 02 can add backend diagnostics after there is only one canonical reload endpoint. Extract a helper only if it reduces complexity.
+
+### D. Loader should validate even if helper validates
+
+`defineRuntimeServerPlugin()` can validate for good author UX, but loader must still validate the default export. Third-party code can bypass helper.
+
+### E. Gateway path normalization tests matter more than code volume
+
+Keep exact-match routing, but test the ugly cases:
+
+- empty tail path;
+- trailing slash;
+- duplicate slashes;
+- encoded `..` if Fastify decodes it;
+- backslash;
+- invalid plugin id.
+
+This is robustness, not over-engineering.
+
+## Non-negotiable implementation guardrails
+
+If implementation violates these, stop and simplify:
+
+1. `createWorkspaceAgentServer.ts` must not grow materially. It is already large.
+2. `BoringPluginAssetManager` must not own runtime backend execution or policy.
+3. Gateway must not know jiti, manifests, source classification, or install.
+4. Registry must keep old plugin handler live on failed reload.
+5. Response/body support must stay JSON-first until a real plugin proves need.
+6. No route params/wildcards in PR 02.
+7. No install/update/self-test leakage into PR 02.
+
+## Final verdict
+
+Plan is now strong enough to execute.
+
+Recommended final implementation target:
+
+```txt
+PR 01:
+  source origin model
+  internal/external source classification
+  remove old reload route
+  shared jiti helper
+
+PR 02:
+  runtime-server API
+  exact route capture
+  registry snapshot with per-plugin safe reload
+  thin Fastify gateway
+  reload diagnostics
+
+PR 03:
+  install/list/remove
+  global default + local flag
+  manifest validation
+  security warning
+```
+
+This is simple enough to build and robust enough not to collapse on first bad plugin.

--- a/docs/plans/runtime-plugin-cli-local/reviews/nuclear-simplicity-robustness-review.md
+++ b/docs/plans/runtime-plugin-cli-local/reviews/nuclear-simplicity-robustness-review.md
@@ -1,0 +1,292 @@
+# Thermo-nuclear review — simplicity + robustness
+
+Reviewed canonical docs:
+
+- `context.md`
+- `implementation-plan.md`
+- `prs/01-foundation.md`
+- `prs/02-server-runtime-mvp.md`
+- `prs/03-cli-install-and-verification.md`
+
+Verdict: **close, but revise PR 02 and PR 03 before implementation**
+
+The plan is now much healthier: three PRs is the right scale, `runtimeBackendAllowed` is gone, install is separated from server MVP, and PR 02 avoids raw Fastify hot registration. The remaining risk is not “too ambitious” anymore; it is **accidentally re-growing complexity through response/body/health/install polish**.
+
+## Executive recommendation
+
+Use this as the final implementation shape:
+
+```txt
+PR 01 — Foundation
+  source origin model
+  one canActivateRuntimeBackend() policy
+  reload coordinator extraction
+  jiti helper extraction
+
+PR 02 — Server MVP
+  runtime-server authoring API
+  exact route capture
+  registry snapshot
+  stable gateway
+  reload integration
+  minimal diagnostics
+
+PR 03 — Install MVP
+  install/list/remove only first
+  update and backend self-test can be follow-up if they expand scope
+```
+
+The biggest simplification is: **PR 02 should not try to be an HTTP framework.** It should be a tiny gateway from Fastify to exact handlers.
+
+## Blocker 1 — PR 02 still has too much response machinery for MVP
+
+Current PR 02 supports:
+
+- `undefined` / `null` => 204;
+- string => text;
+- `Uint8Array` => bytes;
+- plain objects/arrays/primitives => JSON;
+- explicit `{ kind: "response" }`.
+
+This is probably more than needed for the first server MVP. It creates response coercion complexity, content-type choices, error branches, and tests before there is evidence plugins need all of it.
+
+### Simpler robust version
+
+For MVP, support only:
+
+```txt
+plain JSON return value -> JSON response
+{ kind: "response", status?, headers?, body? } -> explicit response
+undefined/null -> 204
+```
+
+Defer string/bytes special casing. If a plugin needs text/bytes, it can use explicit response metadata:
+
+```ts
+return {
+  kind: "response",
+  headers: { "content-type": "text/plain" },
+  body: "ok",
+}
+```
+
+### Required plan change
+
+Cut automatic string and `Uint8Array` response branches from MVP. Keep JSON + explicit response only.
+
+This deletes ambiguous coercion while preserving escape hatch.
+
+## Blocker 2 — `defineRuntimeServerPlugin()` branding may be over-engineering
+
+The plan says the helper must validate/brand or be removed. Good instinct. But branding can become type ceremony that does not improve runtime safety.
+
+### Simpler robust version
+
+Make `defineRuntimeServerPlugin()` a tiny validation helper only:
+
+- reject unknown top-level keys like `id`;
+- require `routes` function if present;
+- return a plain object.
+
+Do not add hidden symbols/brands unless loader actually needs them.
+
+Runtime validation in loader should validate the default export shape anyway, because third-party modules can bypass TypeScript/helper.
+
+### Required plan change
+
+Replace “validate/brand” with “validate at helper and loader boundary; no private branding unless needed.”
+
+## Blocker 3 — Cached body helpers may be unnecessary in first MVP
+
+`json()` and `text()` are convenient, but body parsing is a rich source of edge cases. The plan says cached raw body, which is robust, but implementation can get messy depending on Fastify setup.
+
+### Simpler robust version
+
+If Fastify already gives parsed `request.body`, expose only:
+
+```ts
+body: unknown
+```
+
+or:
+
+```ts
+json<T = unknown>(): T | Promise<T>
+```
+
+Do not expose both `json()` and `text()` unless text bodies are required immediately.
+
+If keeping both, make one rule explicit:
+
+```txt
+MVP accepts JSON request bodies only. text() is deferred.
+```
+
+### Required plan change
+
+Choose one:
+
+1. JSON-only MVP: `body: unknown` or `json()` only; or
+2. cached raw body with both helpers, but this is knowingly more work.
+
+I recommend JSON-only MVP. External plugins mostly need app-like JSON endpoints.
+
+## Blocker 4 — Host health endpoint is still probably too much for PR 02
+
+PR 02 includes:
+
+```txt
+GET /api/v1/agent-plugins/:pluginId/health
+```
+
+This is useful, but not necessary to prove server runtime MVP. It risks adding a second mini-product: health output shape, status aggregation, frontend display, self-test integration.
+
+### Simpler robust version
+
+PR 02 registry exposes diagnostics internally and reload response includes them. No new host health route yet.
+
+Then PR 03 or follow-up adds host health if needed for install/test UX.
+
+### Required plan change
+
+Move host health endpoint out of PR 02 unless an existing route already has a natural place to expose registry diagnostics with almost no code.
+
+Keep the namespace decision in context, but defer route implementation.
+
+## Blocker 5 — PR 03 mixes install MVP with update and backend self-test polish
+
+PR 03 includes install/list/remove/update and backend self-test. That is likely too much for one PR after PR 02.
+
+The robust/simple thing is:
+
+```txt
+PR 03a — install/list/remove
+PR 03b — update
+PR 03c — backend self-test
+```
+
+But if you want only three canonical PRs, make PR 03 acceptance focus on install/list/remove and mark update/self-test as optional/stretch.
+
+### Required plan change
+
+In PR 03:
+
+- make `update` optional or follow-up;
+- make backend self-test optional or follow-up;
+- make acceptance only require install/list/remove + reload works.
+
+This avoids a PR that touches package manager, source registry, Playwright/self-test, and backend diagnostics at once.
+
+## Strong keepers — do not simplify these away
+
+These are the robustness minimum. Keep them.
+
+### Keep one source policy helper
+
+Good:
+
+```ts
+function canActivateRuntimeBackend(source: BoringPluginSource): boolean
+```
+
+Do not reintroduce `runtimeBackendAllowed`.
+
+### Keep reload coordinator extraction first
+
+This is code-judo. It prevents PR 02 from growing `createWorkspaceAgentServer.ts`, already ~801 lines.
+
+### Keep exact-match routing only
+
+No params/wildcards/custom router. Correct.
+
+### Keep old handler live on failed reload
+
+This is essential robustness. Do not simplify it away.
+
+### Keep gateway as adapter only
+
+Correct boundary:
+
+```txt
+Fastify request -> normalized dispatch request -> registry.dispatch() -> reply
+```
+
+Gateway must not know jiti, manifests, source policy, install, or scan internals.
+
+## Best final simplified PR 02 shape
+
+Recommended PR 02 after cuts:
+
+```txt
+Files:
+  defineRuntimeServerPlugin.ts
+  routerCapture.ts
+  runtimeBackendRegistry.ts
+  runtimeBackendGateway.ts
+  index.ts
+
+Supports:
+  JSON request body only
+  JSON return values
+  explicit response object escape hatch
+  exact paths only
+  per-plugin safe reload
+  diagnostics in reload response
+
+Defers:
+  text()/raw body helpers
+  automatic string/bytes responses
+  host health route
+  backend test-plugin integration
+  route params
+```
+
+This is the right simplicity/robustness level.
+
+## Suggested plan edits
+
+### PR 02
+
+Replace response section with:
+
+```txt
+MVP response contract:
+- undefined/null => 204
+- JSON-serializable value => JSON
+- { kind: "response", status?, headers?, body? } => explicit response
+
+No automatic text/bytes coercion in MVP.
+```
+
+Replace body section with:
+
+```txt
+MVP request body:
+- JSON body only through ctx.body or ctx.json()
+- text/raw helpers deferred
+```
+
+Move host health route to deferred/follow-up.
+
+### PR 03
+
+Rename to:
+
+```txt
+PR 03 — Pi-style install/list/remove MVP
+```
+
+Move `update` and backend self-test to stretch/follow-up unless implementation is tiny.
+
+## Final verdict
+
+The architecture is now basically right. The plan needs one more simplification pass:
+
+```txt
+cut response magic
+cut raw/text body handling
+cut PR02 host health route
+cut PR03 update/self-test from required acceptance
+```
+
+After those cuts, implementation should be robust without becoming a framework.

--- a/docs/plans/runtime-plugin-cli-local/reviews/pr166-reassessment.md
+++ b/docs/plans/runtime-plugin-cli-local/reviews/pr166-reassessment.md
@@ -1,0 +1,161 @@
+# PR #166 reassessment — plugin-local deps + ui-kit scaffold impact
+
+Assumption: user request “PR 66” refers to open PR #166:
+
+```txt
+feat(cli): support plugin-local deps and ui-kit scaffolds
+branch: plan/plugin-local-deps
+```
+
+PR #166 inspected:
+
+- `docs/plans/runtime-plugin-local-dev-and-rpc/04-dependency-import.md`
+- `docs/plans/runtime-plugin-local-dev-and-rpc/06-generated-plugin-design-system.md`
+- `packages/cli/src/server/pluginFrontRuntime.ts`
+- `packages/plugin-cli/src/server/verifyPlugin.ts`
+- `packages/plugin-cli/templates/front-canonical.tsx`
+- `packages/pi/skills/boring-plugin-authoring/SKILL.md`
+
+## Verdict
+
+The current CLI/local runtime backend plan remains valid, but PR #166 changes the correct simplification boundary.
+
+The plan must not build another dependency/install system around `/reload`. PR #166 already establishes the right local model:
+
+```txt
+plugin folder owns its deps
+user/agent runs install in plugin folder
+/reload never installs packages
+verify reports missing deps clearly
+host provides React/workspace/ui-kit singletons
+```
+
+## Impact 1 — Match Pi dependency behavior by source kind
+
+PR #166 teaches agents to do this for authored `.pi/extensions` plugins:
+
+```bash
+cd .pi/extensions/my-plugin
+npm install recharts
+boring-ui-plugin verify my-plugin <workspace-root>
+```
+
+That does **not** mean `boring-ui install <source>` should ignore dependencies. When the user explicitly asks to install a package/source, the installer should perform normal package-manager work for that source.
+
+Correct boundary:
+
+- `boring-ui install npm:<pkg>` installs the package and its declared dependencies in the plugin install/package root.
+- `boring-ui install git:<repo>` clones and runs dependency install in the cloned plugin package directory when `package.json` exists, like Pi.
+- `boring-ui install ./local-plugin` references the local path without copying and without auto-installing dependencies, matching Pi local-path behavior.
+- For local paths, missing dependencies are surfaced as install hints, e.g. `cd ./local-plugin && npm install`.
+- Dependency installs never run in the workspace root or app root.
+- `/reload` never installs anything.
+- `verify` reports missing deps and install hints; it does not mutate dependencies by itself.
+
+Plan updated accordingly.
+
+## Impact 2 — Runtime backend modules should not require workspace package imports
+
+PR #166 solves frontend host imports with a Vite runtime import policy. Runtime backend modules are loaded by server-side jiti, not the browser Vite runtime.
+
+If PR 02 required every `.pi/extensions` backend module to write:
+
+```ts
+import { defineRuntimeServerPlugin } from "@hachej/boring-workspace/runtime-server"
+```
+
+then plain local plugins would need either:
+
+1. package-local `@hachej/boring-workspace` dependency, which PR #166 discourages for host-provided packages; or
+2. a new jiti/backend import alias system, which is unnecessary complexity.
+
+Code-judo simplification:
+
+```ts
+export default {
+  routes(router) {
+    router.get("/messages", async () => ({ messages: [] }))
+  },
+}
+```
+
+Loader validates the plain object. Optional helper/types can exist for build-based package authors, but local runtime backend activation must not depend on importing them.
+
+Plan updated accordingly.
+
+## Impact 3 — PR #166 strengthens PR 02 verifier requirements
+
+`boring-ui-plugin verify` currently warns that `boring.server` is boot-time/static and not activated by `/reload`.
+
+After PR 02, verifier/docs need a source-aware explanation:
+
+```txt
+boring.server in app/internal sources       -> boot-time/static composition
+boring.server in workspace/global CLI roots -> hot gateway backend
+```
+
+The plugin-facing field stays the same. Internal/external source classification decides activation behavior.
+
+## Impact 4 — Host-provided modules list may need no backend equivalent
+
+Frontend runtime has explicit host-provided imports:
+
+```txt
+react
+react-dom
+@hachej/boring-workspace*
+@hachej/boring-ui-kit
+```
+
+Do not reflexively build the same host-provided import layer for backend jiti. For the MVP, plain object exports avoid that need.
+
+If backend modules later need host SDK imports, add them deliberately as a follow-up with tests. Do not include that in server MVP.
+
+## Impact 5 — PR 03 can be narrower than before
+
+Because PR #166 already improves local plugin authoring DX, PR 03 should stay focused on source/package management:
+
+```txt
+install/list/remove plugin packages/sources
+not dependency install during reload
+not scaffold UI improvements
+not frontend dep resolution
+not backend self-test
+```
+
+This makes PR 03 smaller and avoids stepping on PR #166.
+
+## Required plan changes applied
+
+- Context now calls out PR #166 decisions.
+- PR 02 now uses `boring.server` plus a plain default-export runtime server module as canonical `.pi/extensions` shape.
+- `@hachej/boring-workspace/runtime-server` is optional helper/types, not required for activation.
+- PR 03 now says npm/git installs leave declared deps present, local-path installs do not auto-install deps, and reload never installs deps.
+- Index/implementation overview now mention PR #166 dependency boundary.
+
+## Final revised target
+
+```txt
+PR 01 — foundation
+  source origin model
+  internal/external source classification
+  remove old reload route
+  jiti helper
+
+PR 02 — server runtime MVP
+  one boring.server manifest field
+  plain object backend module contract
+  exact route capture
+  registry/gateway/reload diagnostics
+  verifier explains source-based boring.server activation
+
+PR 03 — install/list/remove MVP
+  source/package install manager
+  global default + -l/--local
+  npm/git install deps in installed/cloned plugin dirs
+  local paths reference only and print dep install hints
+  no dependency install during reload
+  verify tells user what to install inside plugin folder
+```
+
+This aligns with PR #166 and keeps the backend plan simple.

--- a/docs/plans/runtime-plugin-cli-local/reviews/pr166-reassessment.md
+++ b/docs/plans/runtime-plugin-cli-local/reviews/pr166-reassessment.md
@@ -1,13 +1,14 @@
-# PR #166 reassessment — plugin-local deps + ui-kit scaffold impact
+# Merged PR #166 reassessment — plugin-local deps + ui-kit scaffold impact
 
-Assumption: user request “PR 66” refers to open PR #166:
+PR #166 is now merged into `main`:
 
 ```txt
-feat(cli): support plugin-local deps and ui-kit scaffolds
+feat(cli): support plugin-local deps and ui-kit scaffolds (#166)
 branch: plan/plugin-local-deps
+merged into: origin/main
 ```
 
-PR #166 inspected:
+Merged PR #166 changes inspected:
 
 - `docs/plans/runtime-plugin-local-dev-and-rpc/04-dependency-import.md`
 - `docs/plans/runtime-plugin-local-dev-and-rpc/06-generated-plugin-design-system.md`
@@ -18,9 +19,9 @@ PR #166 inspected:
 
 ## Verdict
 
-The current CLI/local runtime backend plan remains valid, but PR #166 changes the correct simplification boundary.
+The current CLI/local runtime backend plan remains valid, but merged main has a new simplification boundary.
 
-The plan must not build another dependency/install system around `/reload`. PR #166 already establishes the right local model:
+The plan must not build another dependency/install system around `/reload`. Main now establishes the right local model:
 
 ```txt
 plugin folder owns its deps
@@ -32,7 +33,7 @@ host provides React/workspace/ui-kit singletons
 
 ## Impact 1 — Match Pi dependency behavior by source kind
 
-PR #166 teaches agents to do this for authored `.pi/extensions` plugins:
+Merged main teaches agents to do this for authored `.pi/extensions` plugins:
 
 ```bash
 cd .pi/extensions/my-plugin
@@ -40,13 +41,13 @@ npm install recharts
 boring-ui-plugin verify my-plugin <workspace-root>
 ```
 
-That does **not** mean `boring-ui install <source>` should ignore dependencies. When the user explicitly asks to install a package/source, the installer should perform normal package-manager work for that source.
+That does **not** mean `boring-ui-plugin install <source>` should ignore dependencies. When the user explicitly asks to install a package/source, the installer should perform normal package-manager work for that source.
 
 Correct boundary:
 
-- `boring-ui install npm:<pkg>` installs the package and its declared dependencies in the plugin install/package root.
-- `boring-ui install git:<repo>` clones and runs dependency install in the cloned plugin package directory when `package.json` exists, like Pi.
-- `boring-ui install ./local-plugin` references the local path without copying and without auto-installing dependencies, matching Pi local-path behavior.
+- `boring-ui-plugin install npm:<pkg>` installs the package and its declared dependencies in the plugin install/package root.
+- `boring-ui-plugin install git:<repo>` clones and runs dependency install in the cloned plugin package directory when `package.json` exists, like Pi.
+- `boring-ui-plugin install ./local-plugin` references the local path without copying and without auto-installing dependencies, matching Pi local-path behavior.
 - For local paths, missing dependencies are surfaced as install hints, e.g. `cd ./local-plugin && npm install`.
 - Dependency installs never run in the workspace root or app root.
 - `/reload` never installs anything.
@@ -56,7 +57,7 @@ Plan updated accordingly.
 
 ## Impact 2 — Runtime backend modules should not require workspace package imports
 
-PR #166 solves frontend host imports with a Vite runtime import policy. Runtime backend modules are loaded by server-side jiti, not the browser Vite runtime.
+Merged main solves frontend host imports with a Vite runtime import policy. Runtime backend modules are loaded by server-side jiti, not the browser Vite runtime.
 
 If PR 02 required every `.pi/extensions` backend module to write:
 
@@ -113,7 +114,7 @@ If backend modules later need host SDK imports, add them deliberately as a follo
 
 ## Impact 5 — PR 03 can be narrower than before
 
-Because PR #166 already improves local plugin authoring DX, PR 03 should stay focused on source/package management:
+Because main already improves local plugin authoring DX, PR 03 should stay focused on source/package management:
 
 ```txt
 install/list/remove plugin packages/sources
@@ -123,11 +124,11 @@ not frontend dep resolution
 not backend self-test
 ```
 
-This makes PR 03 smaller and avoids stepping on PR #166.
+This makes PR 03 smaller and avoids stepping on merged-main behavior.
 
 ## Required plan changes applied
 
-- Context now calls out PR #166 decisions.
+- Context now calls out merged PR #166 decisions.
 - PR 02 now uses `boring.server` plus a plain default-export runtime server module as canonical `.pi/extensions` shape.
 - `@hachej/boring-workspace/runtime-server` is optional helper/types, not required for activation.
 - PR 03 now says npm/git installs leave declared deps present, local-path installs do not auto-install deps, and reload never installs deps.
@@ -158,4 +159,4 @@ PR 03 — install/list/remove MVP
   verify tells user what to install inside plugin folder
 ```
 
-This aligns with PR #166 and keeps the backend plan simple.
+This aligns with current `main` and keeps the backend plan simple.

--- a/docs/plans/runtime-plugin-cli-local/reviews/reload-endpoint-removal-inventory.md
+++ b/docs/plans/runtime-plugin-cli-local/reviews/reload-endpoint-removal-inventory.md
@@ -1,0 +1,95 @@
+# Reload endpoint removal inventory
+
+Decision: PR 01 should remove the old workspace developer reload endpoint and keep one canonical reload path.
+
+Canonical:
+
+```txt
+POST /api/v1/agent/reload
+```
+
+Remove:
+
+```txt
+POST /api/boring.reload
+```
+
+## Why remove it
+
+Two reload endpoints now mean two subtly different reload semantics:
+
+- `/api/v1/agent/reload` refreshes the agent/session layer, runtime provisioning, hot Pi resources, workspace `beforeReload`, plugin scan/rebuild diagnostics, and restart warnings.
+- `/api/boring.reload` is an older asset-manager developer endpoint that scans plugin assets and rebuild diagnostics only.
+
+For runtime backend hot reload, keeping both would force every future reload feature to answer: “which endpoint is real?” That is unnecessary complexity.
+
+## Code to remove/change
+
+### `packages/workspace/src/server/agentPlugins/routes.ts`
+
+Remove:
+
+- `app.post("/api/boring.reload", ...)`.
+- `BoringPluginRoutesOptions.rebuildPlugins` if it only exists for that route.
+- `BoringPluginRoutesOptions.enableReloadRoute` if it only toggles that route.
+- `PluginReloadRebuild` if no remaining consumer needs it.
+
+Keep:
+
+- `GET /api/v1/agent-plugins`.
+- `GET /api/v1/agent-plugins/:id/error`.
+- `GET /api/v1/agent-plugins/events`.
+- `collectRestartWarnings()` and `PluginRestartWarning`, but consider moving them out of `routes.ts` if `routes.ts` no longer owns reload formatting.
+
+### `packages/workspace/src/app/server/createWorkspaceAgentServer.ts`
+
+Change:
+
+- stop passing `rebuildPlugins` and `enableReloadRoute` into `boringPluginRoutes`;
+- update comments that say `pluginHotReload=false` disables `/api/boring.reload`;
+- keep `beforeReload` as the canonical reload integration point;
+- optionally extract a focused `reloadWorkspacePlugins()` helper only if it shrinks the canonical reload path; do not add it just for abstraction symmetry.
+
+### Tests
+
+Replace or remove tests that directly call `/api/boring.reload`:
+
+- `packages/workspace/src/server/__tests__/agentPlugins.test.ts`
+  - remove old route response-shape tests;
+  - keep `collectRestartWarnings()` pure tests;
+  - move scan/rebuild/restart-warning behavior tests to `/api/v1/agent/reload` integration tests, or to a reload helper only if such helper exists.
+- `packages/workspace/src/app/server/__tests__/hotReloadDiscovery.test.ts`
+  - update `pluginHotReload=false` expectation; it should not assert old route absence as the primary behavior.
+- `packages/workspace/src/eval/__tests__/plugin-creation.test.ts`
+  - replace `/api/boring.reload` calls with `/api/v1/agent/reload`.
+
+### CLI/test harnesses
+
+Check harnesses that register `boringPluginRoutes` with `enableReloadRoute`:
+
+- `packages/cli/src/__tests__/localRuntimePluginHarness.ts`
+
+Remove `enableReloadRoute` usage and route reload tests through the canonical agent reload path.
+
+### Docs/changelog
+
+Update/remove references:
+
+- `packages/workspace/docs/PLUGIN_SYSTEM.md` mention that `pluginHotReload=true` registers `/api/boring.reload`.
+- `packages/workspace/CHANGELOG.md` historical note can stay if desired, but current docs must not tell users to call it.
+- runtime plugin plan drafts that still mention `/api/boring.reload` should be treated as stale/non-canonical.
+
+## What not to remove
+
+- `rebuildServerPlugins()` — canonical reload still needs dir-source diagnostic re-imports.
+- `collectRestartWarnings()` — canonical reload still surfaces restart warnings.
+- `/api/v1/agent-plugins` list/error/events routes — these are plugin state/event routes, not reload endpoints.
+- `pluginHotReload` option — still controls dynamic plugin scan/resource refresh behavior.
+
+## Acceptance for PR 01
+
+- `POST /api/v1/agent/reload` remains green and includes plugin scan/rebuild diagnostics + restart warnings.
+- `POST /api/boring.reload` is not registered.
+- No production code path calls `/api/boring.reload`.
+- No tests rely on `/api/boring.reload` response shape.
+- Docs point reload users/tools to `/api/v1/agent/reload`.

--- a/docs/plans/runtime-plugin-cli-local/reviews/thermo-pass1.md
+++ b/docs/plans/runtime-plugin-cli-local/reviews/thermo-pass1.md
@@ -1,0 +1,198 @@
+# Runtime/plugin planning thermo review — pass 1/3
+
+Reviewed:
+
+- `docs/plans/cli-external-plugin-system-vision-gap-plan.md`
+- `docs/plans/runtime-backend-gateway-jiti-hot-reload-plan.md`
+
+Verdict: **revise before these become implementation tickets.** The gateway/registry direction is right, but the docs still leave too many ownership seams ambiguous. If implemented as written, this can easily turn into more conditional reload spaghetti in `createWorkspaceAgentServer.ts`, source-kind guessing inside `BoringPluginAssetManager`, and conflicting public API contracts.
+
+## P0 blockers
+
+### 1. The runtime server API contradicts itself about plugin ids
+
+Both docs still show `id` inside `defineRuntimeServerPlugin(...)` even though they later say the id must come only from the manifest.
+
+- Vision doc: example repeats `id: "email-client"` at lines 121-124, but line 605 says the runtime module must not repeat the plugin id.
+- Gateway doc: target example repeats `id: "email-client"` at lines 91-93, but line 248 says do **not** repeat `id`.
+
+This is not a nit. If a ticket contains both shapes, implementation will grow a mismatch branch: manifest id vs module id, conflict diagnostics, fallback behavior, and tests. Delete that complexity now.
+
+Concrete edits:
+
+- Remove `id` from every `defineRuntimeServerPlugin` example.
+- Add one explicit contract sentence: `Runtime server modules never declare identity; the loader supplies pluginId from the validated manifest/source record.`
+- Add a test requirement: a module export with an `id` field is ignored or rejected consistently. Prefer reject at validation so the API stays clean.
+
+### 2. The vision doc is too broad to become a ticket; split it into implementation-sized plans
+
+`cli-external-plugin-system-vision-gap-plan.md` is a 1k+ line roadmap covering PR merges, docs taxonomy, install/update/remove/list, dependency installation, backend gateway, lifecycle/health, bwrap workers, and self-test. As an implementation ticket, that is an invitation to touch every layer at once.
+
+The plan needs a code-judo cut: keep this as a vision/roadmap, then make smaller tickets with hard ownership boundaries.
+
+Concrete edits:
+
+- Rename its implementation section to `Roadmap, not one ticket`.
+- Split the implementation work into separate ticket docs:
+  1. taxonomy + manifest/source metadata;
+  2. runtime backend gateway MVP using existing `.pi/extensions` roots;
+  3. Pi-style install/list/remove/update;
+  4. unified health API;
+  5. dependency import/install policy;
+  6. bwrap worker/proxy.
+- Make each ticket list allowed files/modules and explicit non-goals.
+- Do not let one worker implement Phase 2 + Phase 3 together unless there is a compelling reason.
+
+### 3. Source ownership must be modeled at discovery boundaries, not inferred later
+
+The docs correctly say runtime backend activation needs source-kind gating, but the proposed model is too thin:
+
+```ts
+type BoringPluginSourceKind = "workspace-extension" | "global-extension" | "default-package" | "additional-dir"
+```
+
+That is not enough unless source provenance enters the system before scanning. Today the server builds plain plugin dirs, then `BoringPluginAssetManager` scans them. If runtime backend gating is added after that, someone will infer trust from path strings or bolt special cases into the asset manager/gateway.
+
+Concrete edits:
+
+- Replace planned `pluginDirs: string[]` usage with a first-class source record in the docs:
+
+```ts
+type BoringPluginSource = {
+  root: string
+  kind: "workspace-extension" | "global-extension" | "default-package" | "additional-dir"
+  scope: "workspace" | "global" | "app"
+  workspaceId?: string
+  runtimeBackendAllowed: boolean
+}
+```
+
+- Rename the planned collector from `collectBoringPluginDirs` to `collectBoringPluginSources` in the plan.
+- Require `BoringPluginAssetManager.load()` to return loaded plugin records with source metadata preserved.
+- State that `runtimeBackendRegistry` must not infer trust from paths. It receives `LoadedPlugin.source.runtimeBackendAllowed` or an equivalent explicit flag.
+- Add tests for each source kind, including `additional-dir`, default package roots, and workspace-local roots in workspaces mode.
+
+### 4. Extract reload orchestration before adding backend reload
+
+`createWorkspaceAgentServer.ts` is already 801 lines. The gateway plan correctly says not to grow it, but the PR split still allows the riskiest work (`PR C: reload integration`) to touch the existing reload body and add more branches.
+
+This needs a stronger gate. The code-judo move is: first extract the existing reload flow unchanged, then add runtime backend reload to the extracted coordinator.
+
+Concrete edits:
+
+- Change the PR split to:
+  - `PR C0: extract current plugin reload flow into workspacePluginReload.ts with no behavior change`;
+  - `PR C1: add runtimeBackendManager.reloadFromLoadedPlugins(...) to that coordinator`.
+- Define the coordinator input/output types in the plan. It should receive the asset manager, rebuild function, provisioning callback, optional caller hook, and runtime backend manager; it should return merged diagnostics/restart warnings/health.
+- Replace vague `caller beforeReload()` wording with the actual owner: `opts.beforeReload` runs after Boring scan/rebuild/provisioning and must be wrapped so it cannot abort unrelated plugin reloads.
+- Update `boringPluginRoutes` planning to call the same coordinator closure, not a separate `rebuildPlugins` path.
+
+## P1 high-priority structural issues
+
+### 5. Host health endpoints conflict with the plugin gateway namespace
+
+The vision doc proposes host management endpoints like:
+
+```txt
+GET /api/v1/plugins/:pluginId/health
+```
+
+But the gateway itself is:
+
+```txt
+/api/v1/plugins/:pluginId/*
+```
+
+That means `/api/v1/plugins/email-client/health` is ambiguous: is it host health metadata or a plugin-owned `/health` handler? The Phase 3 acceptance even says `GET /api/v1/plugins/<id>/health` can dispatch to a plugin handler. This conflict will produce route-order special cases.
+
+Concrete edits:
+
+- Keep `/api/v1/plugins/:pluginId/*` exclusively plugin-owned gateway space.
+- Put host metadata under the existing management shape, e.g.:
+  - `GET /api/v1/agent-plugins`
+  - `GET /api/v1/agent-plugins/:pluginId`
+  - `GET /api/v1/agent-plugins/:pluginId/health`
+- If a plugin wants its own health check, it may register `/health` under the gateway. The self-test can call that, but host health must not live in the same path.
+
+### 6. `RuntimeWorkspaceFacade` is still a boundary leak waiting to happen
+
+The gateway doc says `workspace: RuntimeWorkspaceFacade` is in V1 context, then immediately says to omit it if no safe facade exists. The vision doc makes it optional and adds a logger. This is exactly how broad host access sneaks into a hot-loaded plugin API.
+
+Concrete edits:
+
+- For MVP, remove `workspace` from `RuntimePluginContext` entirely.
+- Add a future ticket: `RuntimeWorkspaceFacade` with explicit operations only, no root path, no raw adapter escape hatch.
+- If the team insists on including it now, define the exact method list in this plan and require tests proving no raw root/path escape is exposed.
+
+### 7. Install and dependency policy are duplicated and out of phase
+
+The vision doc says Phase 2 implements npm/git/local install, then Phase 6 again says to add package install flow for npm/git packages. The gateway doc says arbitrary npm dependency installation is a non-goal for the gateway MVP. These statements can all be reasonable, but not as one ticket sequence.
+
+Concrete edits:
+
+- Make the gateway MVP depend only on already-discovered `.pi/extensions` / explicit plugin source records.
+- Move npm/git/local package install and dependency installation into a separate Pi-style install plan.
+- In the vision roadmap, make Phase 2 own all source install mechanics and Phase 6 only own front/runtime dependency resolution after install. Do not repeat package install in both phases.
+
+### 8. Workspace scoping / same-origin checks must be in gateway MVP, not a later banner phase
+
+The vision doc delays CSRF/localhost/workspaces-mode considerations to Phase 4. That is too late. The gateway exposes trusted local code over HTTP; even in the Pi-style trust model, request routing must not cross workspace boundaries or accept unintended origins.
+
+Concrete edits:
+
+- Move these requirements into the runtime backend gateway MVP acceptance criteria:
+  - same-origin/localhost policy matches existing API policy;
+  - workspaces mode requires the same workspace identity check as adjacent workspace APIs;
+  - workspace-local plugin sources cannot serve another workspace;
+  - tests cover cross-workspace rejection.
+- Keep permission prompts out of MVP, but do not defer route boundary checks.
+
+## P2 maintainability/clarity improvements
+
+### 9. Response/result types are too magical
+
+The proposed result union allows `Response`, `{ status?, headers?, body? }`, `Record<string, unknown>`, `string`, `Uint8Array`, `null`, and `undefined`. That is convenient, but it is also ambiguous: a normal JSON object with `status` or `headers` keys can look like response metadata.
+
+Concrete edits:
+
+- Make the response object shape discriminated or require `body` for response-init objects.
+- Define a readonly headers facade instead of exposing mutable `Headers` in context.
+- Add response-normalization tests for arrays, plain objects containing `status`, unsupported values, `Uint8Array`, and thrown errors.
+
+### 10. Protect `BoringPluginAssetManager` from becoming the lifecycle dumping ground
+
+The runtime plan says not to put route tables in the asset manager. Good. The vision doc, however, puts scan state, errors, lifecycle, health, source/provenance, install state, and self-test state near the same conceptual area. That will make `BoringPluginAssetManager` absorb unrelated responsibilities.
+
+Concrete edits:
+
+- Add an explicit ownership table:
+  - asset manager: scan, manifest validation, signatures, revisions, SSE scan events;
+  - source registry/install store: installed source records and scope;
+  - runtime backend registry: executable handler tables and dispose;
+  - health aggregator: front/Pi/backend/self-test summary;
+  - CLI commands: install/list/remove/update UX.
+- Require any new asset-manager code to be scan/provenance only, not lifecycle policy or executable runtime state.
+
+### 11. The public `runtime-server` export needs a hard dependency boundary
+
+The new subpath should be importable by external plugin server modules without dragging in app/server orchestration or Fastify implementation details.
+
+Concrete edits:
+
+- State that `@hachej/boring-workspace/runtime-server` may export only types and `defineRuntimeServerPlugin`; no Fastify, no app server, no asset manager imports.
+- Add an invariant/test that importing the subpath does not register routes or touch workspace/server state.
+
+## Concrete edit checklist
+
+Before converting these docs into tickets, make these edits:
+
+1. Remove `id` from all runtime server plugin examples.
+2. Split the 1k-line vision doc into roadmap + small ticket docs.
+3. Add `BoringPluginSource` / source provenance as a first-class discovery input/output.
+4. Add a behavior-preserving reload-coordinator extraction PR before backend integration.
+5. Move host health endpoints out of `/api/v1/plugins/:pluginId/*`.
+6. Omit `workspace` from V1 runtime handler context unless the exact safe facade is specified now.
+7. Align install/dependency phases so npm/git install is not both Phase 2 and Phase 6.
+8. Move same-origin/workspace scoping checks into gateway MVP.
+9. Tighten `RuntimePluginResult` and headers types.
+10. Add an ownership table that keeps `createWorkspaceAgentServer.ts` and `BoringPluginAssetManager` from absorbing this feature.


### PR DESCRIPTION
## Summary

Adds a dedicated planning doc set for CLI/local runtime plugins:

- context doc for trust model, current state, and guardrails
- compact implementation overview
- three PR-sized plans:
  1. foundation: source origin model, reload coordinator, jiti helper
  2. server runtime MVP: runtime-server API, exact route registry, gateway, reload diagnostics
  3. install/list/remove MVP: Pi-style CLI install flow
- pass-2 thermo-nuclear review focused on simplicity and robustness

## Notes

This is docs-only. The plan intentionally defers update, backend self-test, host health routes, raw/text body helpers, route params, bwrap, and hosted/cloud plugin support.

## Validation

- git diff --cached --check
