### PR TITLE
fix: show file tree empty state for zero filter matches (#128)

### DIFF
--- a/packages/agent/src/front/pi/__tests__/piNativeFollowUpQueue.test.ts
+++ b/packages/agent/src/front/pi/__tests__/piNativeFollowUpQueue.test.ts
@@ -5,6 +5,10 @@ import { usePiNativeFollowUpQueue } from '../piNativeFollowUpQueue'
 
 const stop = vi.fn()
 
+async function flushPromises(iterations = 4): Promise<void> {
+  for (let index = 0; index < iterations; index += 1) await Promise.resolve()
+}
+
 function installStorage(): void {
   const store = new Map<string, string>()
   Object.defineProperty(globalThis, 'localStorage', {
@@ -27,6 +31,250 @@ describe('usePiNativeFollowUpQueue', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('restores a queued follow-up for the same session after remount', async () => {
+    const first = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-remount',
+      status: 'streaming',
+      stop,
+    }))
+
+    act(() => {
+      first.result.current.queueFollowUp({
+        text: 'keep this queued message',
+        files: [],
+        serverMessage: 'keep this queued message',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-remount/followup',
+        expect.objectContaining({ method: 'POST' }),
+      )
+      expect(first.result.current.pendingMessages[0]?.posted).toBe(true)
+    })
+
+    vi.mocked(fetch).mockClear()
+    first.unmount()
+
+    const second = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-remount',
+      status: 'streaming',
+      stop,
+    }))
+
+    expect(second.result.current.pendingMessages).toHaveLength(1)
+    expect(second.result.current.pendingMessages[0]?.text).toBe('keep this queued message')
+    expect(second.result.current.projectedTailMessages).toHaveLength(1)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not erase another session queued follow-up when switching sessions', async () => {
+    const { result, rerender } = renderHook(
+      ({ sessionId }) => usePiNativeFollowUpQueue({ sessionId, status: 'streaming', stop }),
+      { initialProps: { sessionId: 'sess-a' } },
+    )
+
+    act(() => {
+      result.current.queueFollowUp({
+        text: 'queued on a',
+        files: [],
+        serverMessage: 'queued on a',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-a/followup',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    rerender({ sessionId: 'sess-b' })
+    expect(result.current.pendingMessages).toHaveLength(0)
+
+    rerender({ sessionId: 'sess-a' })
+    expect(result.current.pendingMessages).toHaveLength(1)
+    expect(result.current.projectedTailMessages).toHaveLength(1)
+  })
+
+  it('keeps queued follow-ups isolated between workspaces sharing a session id', async () => {
+    const { result, rerender } = renderHook(
+      ({ workspaceId }) => usePiNativeFollowUpQueue({
+        sessionId: 'sess-shared',
+        status: 'streaming',
+        requestHeaders: { 'x-boring-workspace-id': workspaceId },
+        stop,
+      }),
+      { initialProps: { workspaceId: 'workspace-a' } },
+    )
+
+    act(() => {
+      result.current.queueFollowUp({
+        text: 'queued in workspace a',
+        files: [],
+        serverMessage: 'queued in workspace a',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-shared/followup',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'x-boring-workspace-id': 'workspace-a' }),
+        }),
+      )
+    })
+
+    rerender({ workspaceId: 'workspace-b' })
+    expect(result.current.pendingMessages).toHaveLength(0)
+    expect(result.current.projectedTailMessages).toHaveLength(0)
+
+    act(() => {
+      result.current.queueFollowUp({
+        text: 'queued in workspace b',
+        files: [],
+        serverMessage: 'queued in workspace b',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-shared/followup',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'x-boring-workspace-id': 'workspace-b' }),
+        }),
+      )
+    })
+
+    expect(result.current.pendingMessages[0]?.text).toBe('queued in workspace b')
+
+    rerender({ workspaceId: 'workspace-a' })
+    expect(result.current.pendingMessages).toHaveLength(1)
+    expect(result.current.pendingMessages[0]?.text).toBe('queued in workspace a')
+    expect(result.current.projectedTailMessages).toHaveLength(1)
+  })
+
+  it('reposts a restored unposted follow-up while streaming', async () => {
+    localStorage.setItem('boring-agent:followup-queue:global:sess-unposted', JSON.stringify([{
+      id: 'pending-unposted',
+      sessionId: 'sess-unposted',
+      text: 'restore and send me',
+      files: [],
+      serverMessage: 'restore and send me',
+      attachments: [],
+      posted: false,
+      consumed: false,
+      clientNonce: 'nonce-unposted',
+      clientSeq: 1,
+      postAttempts: 0,
+    }]))
+
+    const { result } = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-unposted',
+      status: 'streaming',
+      stop,
+    }))
+
+    expect(result.current.pendingMessages).toHaveLength(1)
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-unposted/followup',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('nonce-unposted'),
+        }),
+      )
+      expect(result.current.pendingMessages[0]?.posted).toBe(true)
+    })
+  })
+
+  it('preserves a queued follow-up when posting fails after switching sessions', async () => {
+    let rejectPost: ((reason?: unknown) => void) | undefined
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => new Promise((_, reject) => {
+      rejectPost = reject
+    })))
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }) => usePiNativeFollowUpQueue({ sessionId, status: 'streaming', stop }),
+      { initialProps: { sessionId: 'sess-a-fail' } },
+    )
+
+    act(() => {
+      result.current.queueFollowUp({
+        text: 'queued before failed post',
+        files: [],
+        serverMessage: 'queued before failed post',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => expect(rejectPost).toBeDefined())
+
+    rerender({ sessionId: 'sess-b-fail' })
+    expect(result.current.pendingMessages).toHaveLength(0)
+
+    await act(async () => {
+      rejectPost?.(new Error('offline'))
+      await flushPromises()
+    })
+
+    rerender({ sessionId: 'sess-a-fail' })
+    expect(result.current.pendingMessages).toHaveLength(1)
+    expect(result.current.pendingMessages[0]).toEqual(expect.objectContaining({
+      text: 'queued before failed post',
+      posted: false,
+    }))
+  })
+
+  it('does not replay a consumed follow-up after remount', async () => {
+    const first = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-consumed',
+      status: 'streaming',
+      stop,
+    }))
+
+    act(() => {
+      first.result.current.queueFollowUp({
+        text: 'consumed follow-up',
+        files: [],
+        serverMessage: 'consumed follow-up',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-consumed/followup',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    act(() => {
+      first.result.current.handleData({
+        type: 'data-followup-consumed',
+        data: { text: 'consumed follow-up' },
+      })
+    })
+
+    first.unmount()
+
+    const second = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-consumed',
+      status: 'streaming',
+      stop,
+    }))
+
+    expect(second.result.current.pendingMessages).toHaveLength(0)
+    expect(second.result.current.projectedTailMessages).toHaveLength(0)
   })
 
   it('deletes one queued follow-up locally and asks the server to drop the matching nonce', async () => {

--- a/packages/agent/src/front/pi/piNativeFollowUpQueue.ts
+++ b/packages/agent/src/front/pi/piNativeFollowUpQueue.ts
@@ -2,10 +2,19 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { FileUIPart, UIMessage } from 'ai'
 
 const STORAGE_FOLLOWUP_SEQ_PREFIX = 'boring-agent:followup-seq:'
+const STORAGE_FOLLOWUP_QUEUE_PREFIX = 'boring-agent:followup-queue:'
 const MAX_FOLLOWUP_POST_ATTEMPTS = 5
 
-function nextStoredFollowUpSeq(sessionId: string): number {
-  const key = `${STORAGE_FOLLOWUP_SEQ_PREFIX}${sessionId}`
+function workspaceScopeFromHeaders(headers?: Record<string, string>): string {
+  return headers?.['x-boring-workspace-id'] ?? headers?.['X-Boring-Workspace-Id'] ?? 'global'
+}
+
+function scopedStorageKey(prefix: string, storageScope: string, sessionId: string): string {
+  return `${prefix}${encodeURIComponent(storageScope)}:${encodeURIComponent(sessionId)}`
+}
+
+function nextStoredFollowUpSeq(storageScope: string, sessionId: string): number {
+  const key = scopedStorageKey(STORAGE_FOLLOWUP_SEQ_PREFIX, storageScope, sessionId)
   try {
     const current = Number(globalThis.localStorage?.getItem(key) ?? '0')
     const next = Number.isFinite(current) ? current + 1 : 1
@@ -38,6 +47,61 @@ export type ProjectedFollowUpMessage = {
   status: 'queued' | 'streaming' | 'done'
 }
 
+function followUpQueueStorageKey(storageScope: string, sessionId: string): string {
+  return scopedStorageKey(STORAGE_FOLLOWUP_QUEUE_PREFIX, storageScope, sessionId)
+}
+
+function isPendingFollowUp(value: unknown, sessionId: string): value is PendingFollowUp {
+  const item = value as PendingFollowUp
+  return Boolean(
+    item &&
+    item.sessionId === sessionId &&
+    typeof item.id === 'string' &&
+    typeof item.text === 'string' &&
+    typeof item.serverMessage === 'string' &&
+    typeof item.clientNonce === 'string' &&
+    typeof item.clientSeq === 'number' &&
+    typeof item.postAttempts === 'number' &&
+    Array.isArray(item.files) &&
+    Array.isArray(item.attachments) &&
+    typeof item.posted === 'boolean' &&
+    typeof item.consumed === 'boolean',
+  )
+}
+
+function pendingToProjected(item: PendingFollowUp): ProjectedFollowUpMessage {
+  return {
+    id: item.id,
+    role: 'user',
+    text: item.text,
+    files: item.files,
+    status: item.consumed ? 'done' : 'queued',
+  }
+}
+
+function readStoredFollowUps(storageScope: string, sessionId: string): PendingFollowUp[] {
+  try {
+    const raw = globalThis.localStorage?.getItem(followUpQueueStorageKey(storageScope, sessionId))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((item): item is PendingFollowUp => isPendingFollowUp(item, sessionId))
+  } catch {
+    return []
+  }
+}
+
+function writeStoredFollowUps(storageScope: string, sessionId: string, items: PendingFollowUp[]): void {
+  try {
+    const scoped = items.filter((item) => item.sessionId === sessionId && !item.consumed)
+    const storage = globalThis.localStorage
+    if (!storage) return
+    const key = followUpQueueStorageKey(storageScope, sessionId)
+    if (scoped.length === 0) storage.removeItem(key)
+    else storage.setItem(key, JSON.stringify(scoped))
+  } catch { /* quota exceeded / storage unavailable: keep in-memory only */ }
+}
+
 export function usePiNativeFollowUpQueue({
   sessionId,
   status,
@@ -49,22 +113,26 @@ export function usePiNativeFollowUpQueue({
   requestHeaders?: Record<string, string>
   stop: () => void
 }) {
-  const [pendingMessages, setPendingMessages] = useState<PendingFollowUp[]>([])
-  const pendingMessagesRef = useRef<PendingFollowUp[]>([])
-  const [projectedFollowUps, setProjectedFollowUps] = useState<ProjectedFollowUpMessage[]>([])
-  const projectedFollowUpsRef = useRef<ProjectedFollowUpMessage[]>([])
+  const storageScope = workspaceScopeFromHeaders(requestHeaders)
+  const [pendingMessages, setPendingMessages] = useState<PendingFollowUp[]>(() => readStoredFollowUps(storageScope, sessionId))
+  const pendingMessagesRef = useRef<PendingFollowUp[]>(pendingMessages)
+  const [projectedFollowUps, setProjectedFollowUps] = useState<ProjectedFollowUpMessage[]>(() => pendingMessages.map(pendingToProjected))
+  const projectedFollowUpsRef = useRef<ProjectedFollowUpMessage[]>(projectedFollowUps)
   const activeProjectedAssistantRef = useRef<string | null>(null)
   const lastConsumedProjectedUserRef = useRef<string | null>(null)
   const followUpPostTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const followUpPostInFlightRef = useRef(false)
   const postPendingFollowUpsRef = useRef<() => void>(() => {})
   const consumedFollowUpRef = useRef<{ text: string; files: FileUIPart[] } | null>(null)
+  const activeStorageRef = useRef({ storageScope, sessionId })
+  activeStorageRef.current = { storageScope, sessionId }
 
   const updatePendingMessages = useCallback((updater: (items: PendingFollowUp[]) => PendingFollowUp[]) => {
     const next = updater(pendingMessagesRef.current)
     pendingMessagesRef.current = next
+    writeStoredFollowUps(storageScope, sessionId, next)
     setPendingMessages(next)
-  }, [])
+  }, [storageScope, sessionId])
 
   const updateProjectedFollowUps = useCallback((updater: (items: ProjectedFollowUpMessage[]) => ProjectedFollowUpMessage[]) => {
     const next = updater(projectedFollowUpsRef.current)
@@ -72,25 +140,40 @@ export function usePiNativeFollowUpQueue({
     setProjectedFollowUps(next)
   }, [])
 
-  const clearLocal = useCallback(() => {
+  const clearRuntimeState = useCallback(() => {
     consumedFollowUpRef.current = null
-    pendingMessagesRef.current = []
-    projectedFollowUpsRef.current = []
     activeProjectedAssistantRef.current = null
     lastConsumedProjectedUserRef.current = null
     if (followUpPostTimerRef.current) clearTimeout(followUpPostTimerRef.current)
     followUpPostTimerRef.current = null
     followUpPostInFlightRef.current = false
-    setPendingMessages([])
-    setProjectedFollowUps([])
   }, [])
 
-  const previousSessionIdRef = useRef(sessionId)
+  const loadLocalForScope = useCallback((nextStorageScope: string, nextSessionId: string) => {
+    clearRuntimeState()
+    const restored = readStoredFollowUps(nextStorageScope, nextSessionId)
+    const projected = restored.map(pendingToProjected)
+    pendingMessagesRef.current = restored
+    projectedFollowUpsRef.current = projected
+    setPendingMessages(restored)
+    setProjectedFollowUps(projected)
+  }, [clearRuntimeState])
+
+  const clearLocal = useCallback(() => {
+    clearRuntimeState()
+    pendingMessagesRef.current = []
+    projectedFollowUpsRef.current = []
+    writeStoredFollowUps(storageScope, sessionId, [])
+    setPendingMessages([])
+    setProjectedFollowUps([])
+  }, [clearRuntimeState, storageScope, sessionId])
+
+  const previousStorageRef = useRef({ storageScope, sessionId })
   useEffect(() => {
-    if (previousSessionIdRef.current === sessionId) return
-    previousSessionIdRef.current = sessionId
-    clearLocal()
-  }, [sessionId, clearLocal])
+    if (previousStorageRef.current.storageScope === storageScope && previousStorageRef.current.sessionId === sessionId) return
+    previousStorageRef.current = { storageScope, sessionId }
+    loadLocalForScope(storageScope, sessionId)
+  }, [storageScope, sessionId, loadLocalForScope])
 
   // Clean up timers on unmount to prevent stale retries after component
   // unmounts (e.g. when switching sessions).
@@ -105,16 +188,20 @@ export function usePiNativeFollowUpQueue({
 
   const postPendingFollowUps = useCallback(() => {
     if (followUpPostInFlightRef.current) return
+    const postStorageScope = storageScope
+    const postSessionId = sessionId
+    const isActiveScope = () => activeStorageRef.current.storageScope === postStorageScope && activeStorageRef.current.sessionId === postSessionId
+    if (!isActiveScope()) return
     followUpPostInFlightRef.current = true
     void (async () => {
       let shouldContinue = true
       try {
         while (true) {
-          const pending = pendingMessagesRef.current.find((item) => item.sessionId === sessionId && !item.posted)
+          if (!isActiveScope()) return
+          const pending = pendingMessagesRef.current.find((item) => item.sessionId === postSessionId && !item.posted)
           if (!pending) return
-          updatePendingMessages((items) => items.map((item) => item.id === pending.id ? { ...item, posted: true } : item))
           try {
-            const res = await fetch(`/api/v1/agent/chat/${encodeURIComponent(sessionId)}/followup`, {
+            const res = await fetch(`/api/v1/agent/chat/${encodeURIComponent(postSessionId)}/followup`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
@@ -129,8 +216,11 @@ export function usePiNativeFollowUpQueue({
               }),
             })
             if (!res.ok) throw new Error(`follow-up rejected: ${res.status}`)
+            if (!isActiveScope()) return
+            updatePendingMessages((items) => items.map((item) => item.id === pending.id ? { ...item, posted: true } : item))
           } catch {
             shouldContinue = false
+            if (!isActiveScope()) return
             const nextAttempts = pending.postAttempts + 1
             updatePendingMessages((items) => items.map((item) => item.id === pending.id ? { ...item, posted: false, postAttempts: nextAttempts } : item))
             if (nextAttempts < MAX_FOLLOWUP_POST_ATTEMPTS) {
@@ -144,13 +234,15 @@ export function usePiNativeFollowUpQueue({
           }
         }
       } finally {
-        followUpPostInFlightRef.current = false
-        if (shouldContinue && pendingMessagesRef.current.some((item) => item.sessionId === sessionId && !item.posted)) {
-          postPendingFollowUps()
+        if (isActiveScope()) {
+          followUpPostInFlightRef.current = false
+          if (shouldContinue && pendingMessagesRef.current.some((item) => item.sessionId === postSessionId && !item.posted)) {
+            postPendingFollowUps()
+          }
         }
       }
     })()
-  }, [sessionId, requestHeaders, updatePendingMessages])
+  }, [storageScope, sessionId, requestHeaders, updatePendingMessages])
   postPendingFollowUpsRef.current = postPendingFollowUps
 
   const queueFollowUp = useCallback((input: {
@@ -169,7 +261,7 @@ export function usePiNativeFollowUpQueue({
       posted: false,
       consumed: false,
       clientNonce: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}-nonce`,
-      clientSeq: nextStoredFollowUpSeq(sessionId),
+      clientSeq: nextStoredFollowUpSeq(storageScope, sessionId),
       postAttempts: 0,
     }
     updatePendingMessages((items) => [...items, nextPending])
@@ -188,7 +280,7 @@ export function usePiNativeFollowUpQueue({
         postPendingFollowUps()
       }, 1000)
     }
-  }, [sessionId, status, postPendingFollowUps, updatePendingMessages, updateProjectedFollowUps])
+  }, [storageScope, sessionId, status, postPendingFollowUps, updatePendingMessages, updateProjectedFollowUps])
 
   const handleData = useCallback((part: unknown) => {
     const typed = part as { type?: string; data?: Record<string, unknown> }

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/followup.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/followup.test.ts
@@ -107,6 +107,74 @@ describe("native pi follow-up integration", () => {
     await reader.return?.();
   });
 
+  it("dedupes repeated queued follow-up posts with the same nonce", async () => {
+    const harness = createPiCodingAgentHarness({ tools: [], cwd: "/tmp/test-followup" });
+    const iter = harness.sendMessage({ sessionId: "sess-dedupe", message: "first" }, makeCtx());
+    const reader = iter[Symbol.asyncIterator]();
+
+    const boot = reader.next();
+    await new Promise((r) => setTimeout(r, 5));
+    emit({ type: "message_start", message: { id: "a1", role: "assistant" } });
+    await boot;
+
+    await harness.followUp!("sess-dedupe", "same nonce", undefined, "same nonce", { clientNonce: "nonce-dedupe", clientSeq: 1 });
+    await harness.followUp!("sess-dedupe", "same nonce", undefined, "same nonce", { clientNonce: "nonce-dedupe", clientSeq: 1 });
+
+    expect(promptCalls.map((c) => c.message)).toEqual(["first", "same nonce"]);
+    expect(mockSessions[0].agent.followUpQueue.messages.map((msg: any) => msg.content[0].text)).toEqual(["same nonce"]);
+
+    promptHandle.resolve?.();
+    await reader.return?.();
+  });
+
+  it("does not dedupe distinct nonces that reuse a client sequence", async () => {
+    const harness = createPiCodingAgentHarness({ tools: [], cwd: "/tmp/test-followup" });
+    const iter = harness.sendMessage({ sessionId: "sess-seq-reuse", message: "first" }, makeCtx());
+    const reader = iter[Symbol.asyncIterator]();
+
+    const boot = reader.next();
+    await new Promise((r) => setTimeout(r, 5));
+    emit({ type: "message_start", message: { id: "a1", role: "assistant" } });
+    await boot;
+
+    await harness.followUp!("sess-seq-reuse", "first seq", undefined, "first seq", { clientNonce: "nonce-seq-a", clientSeq: 1 });
+    await harness.followUp!("sess-seq-reuse", "second seq", undefined, "second seq", { clientNonce: "nonce-seq-b", clientSeq: 1 });
+
+    expect(promptCalls.map((c) => c.message)).toEqual(["first", "first seq", "second seq"]);
+    expect(mockSessions[0].agent.followUpQueue.messages.map((msg: any) => msg.content[0].text)).toEqual(["first seq", "second seq"]);
+
+    promptHandle.resolve?.();
+    await reader.return?.();
+  });
+
+  it("dedupes a repeated follow-up post after pi consumes the first copy", async () => {
+    const harness = createPiCodingAgentHarness({ tools: [], cwd: "/tmp/test-followup" });
+    const iter = harness.sendMessage({ sessionId: "sess-consumed-dedupe", message: "first" }, makeCtx());
+    const reader = iter[Symbol.asyncIterator]();
+
+    const boot = reader.next();
+    await new Promise((r) => setTimeout(r, 5));
+    emit({ type: "message_start", message: { id: "a1", role: "assistant" } });
+    await boot;
+
+    await harness.followUp!("sess-consumed-dedupe", "same consumed nonce", undefined, "same consumed nonce", { clientNonce: "nonce-consumed", clientSeq: 1 });
+
+    const consumed = reader.next();
+    emit({
+      type: "message_start",
+      message: { id: "u2", role: "user", content: [{ type: "text", text: "same consumed nonce" }] },
+    });
+    await consumed;
+
+    await harness.followUp!("sess-consumed-dedupe", "same consumed nonce", undefined, "same consumed nonce", { clientNonce: "nonce-consumed", clientSeq: 1 });
+
+    expect(promptCalls.map((c) => c.message)).toEqual(["first", "same consumed nonce"]);
+    expect(mockSessions[0].agent.followUpQueue.messages.map((msg: any) => msg.content[0].text)).toEqual(["same consumed nonce"]);
+
+    promptHandle.resolve?.();
+    await reader.return?.();
+  });
+
   it("can delete a queued follow-up before pi drains it", async () => {
     const harness = createPiCodingAgentHarness({ tools: [], cwd: "/tmp/test-followup" });
     const iter = harness.sendMessage({ sessionId: "sess-delete", message: "first" }, makeCtx());

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -552,6 +552,7 @@ export function createPiCodingAgentHarness(opts: {
     handle.piSession.dispose();
     piSessions.delete(sessionId);
     clearNativeFollowUpWork(sessionId);
+    consumedNativeFollowUpKeys.delete(sessionId);
   }
 
   const originalDelete = sessionStore.delete.bind(sessionStore);
@@ -562,6 +563,7 @@ export function createPiCodingAgentHarness(opts: {
 
   const nativeFollowUpPending = new Set<string>();
   const nativeFollowUpQueues = new Map<string, NativeFollowUpRequest[]>();
+  const consumedNativeFollowUpKeys = new Map<string, Set<string>>();
 
   function clearNativeFollowUpWork(sessionId: string): void {
     nativeFollowUpPending.delete(sessionId);
@@ -611,14 +613,43 @@ export function createPiCodingAgentHarness(opts: {
     session._emitQueueUpdate?.();
   }
 
+  function followUpDedupeKeys(options?: FollowUpOptions | NativeFollowUpRequest): string[] {
+    const keys: string[] = [];
+    if (options?.clientNonce) keys.push(`nonce:${options.clientNonce}`);
+    if (options?.clientSeq !== undefined) keys.push(`seq:${options.clientSeq}`);
+    return keys;
+  }
+
   function hasFollowUpSelector(options?: FollowUpOptions): boolean {
-    return Boolean(options?.clientNonce) || options?.clientSeq !== undefined;
+    return followUpDedupeKeys(options).length > 0;
   }
 
   function matchesFollowUpSelector(item: NativeFollowUpRequest, options?: FollowUpOptions): boolean {
     if (!hasFollowUpSelector(options)) return true;
-    return Boolean(options?.clientNonce && item.clientNonce === options.clientNonce)
-      || (options?.clientSeq !== undefined && item.clientSeq === options.clientSeq);
+    const optionKeys = new Set(followUpDedupeKeys(options));
+    return followUpDedupeKeys(item).some((key) => optionKeys.has(key));
+  }
+
+  function rememberConsumedNativeFollowUp(sessionId: string, request: NativeFollowUpRequest | undefined): void {
+    const keys = followUpDedupeKeys(request);
+    if (keys.length === 0) return;
+    const consumed = consumedNativeFollowUpKeys.get(sessionId) ?? new Set<string>();
+    for (const key of keys) consumed.add(key);
+    consumedNativeFollowUpKeys.set(sessionId, consumed);
+  }
+
+  function followUpPostDedupeKeys(options?: FollowUpOptions | NativeFollowUpRequest): string[] {
+    if (options?.clientNonce) return [`nonce:${options.clientNonce}`];
+    if (options?.clientSeq !== undefined) return [`seq:${options.clientSeq}`];
+    return [];
+  }
+
+  function hasQueuedOrConsumedNativeFollowUp(sessionId: string, options?: FollowUpOptions): boolean {
+    const optionKeys = new Set(followUpPostDedupeKeys(options));
+    if (optionKeys.size === 0) return false;
+    const consumed = consumedNativeFollowUpKeys.get(sessionId);
+    if (consumed && [...optionKeys].some((key) => consumed.has(key))) return true;
+    return (nativeFollowUpQueues.get(sessionId) ?? []).some((request) => followUpPostDedupeKeys(request).some((key) => optionKeys.has(key)));
   }
 
   function removeNativeFollowUp(sessionId: string, options?: FollowUpOptions): NativeFollowUpRemoval[] {
@@ -651,6 +682,7 @@ export function createPiCodingAgentHarness(opts: {
     async followUp(sessionId: string, text: string, _attachments?: MessageAttachment[], displayText = text, options?: FollowUpOptions): Promise<void> {
       const handle = piSessions.get(sessionId);
       if (!handle) throw new Error("followup_session_not_ready");
+      if (hasQueuedOrConsumedNativeFollowUp(sessionId, options)) return;
       const queue = nativeFollowUpQueues.get(sessionId) ?? [];
       queue.push({
         text,
@@ -983,8 +1015,8 @@ export function createPiCodingAgentHarness(opts: {
             const queue = nativeFollowUpQueues.get(input.sessionId);
             if (queue?.length) {
               const index = queue.findIndex((item) => item.text === text || item.displayText === text);
-              if (index >= 0) queue.splice(index, 1);
-              else queue.shift();
+              const consumed = index >= 0 ? queue.splice(index, 1)[0] : queue.shift();
+              rememberConsumedNativeFollowUp(input.sessionId, consumed);
               if (queue.length > 0) nativeFollowUpQueues.set(input.sessionId, queue);
               else clearNativeFollowUpWork(input.sessionId);
             } else {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTree.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTree.tsx
@@ -16,7 +16,7 @@ import {
   Loader2Icon,
 } from "lucide-react"
 import { getFileIcon } from "../../../../front/registry/getFileIcon"
-import { Input } from "@hachej/boring-ui-kit"
+import { EmptyState, Input } from "@hachej/boring-ui-kit"
 import { cn } from "../../../../front/lib/utils"
 import { getFileTreeDndManager } from "./dndManager"
 
@@ -149,6 +149,28 @@ function InlineEditInput({
       className="h-5 min-w-0 flex-1 rounded-sm border-[color:var(--accent)]/60 px-1 text-[13px] leading-[1.2] focus-visible:ring-[color:var(--accent)]"
     />
   )
+}
+
+function countVisibleNodes(
+  nodes: FileTreeNode[],
+  searchQuery: string | undefined,
+): number {
+  if (!searchQuery?.trim()) return nodes.length
+
+  const term = searchQuery.trim().toLowerCase()
+  const countMatches = (entries: FileTreeNode[]): number => {
+    let count = 0
+    for (const entry of entries) {
+      const selfMatches = entry.name.toLowerCase().includes(term)
+      const childCount = entry.children?.length ? countMatches(entry.children) : 0
+      if (selfMatches || childCount > 0) {
+        count += 1
+      }
+    }
+    return count
+  }
+
+  return countMatches(nodes)
 }
 
 function Node({ node, style, dragHandle }: NodeRendererProps<FileTreeNode>) {
@@ -377,6 +399,11 @@ export function FileTree({
     [onContextMenu, editing, pendingPaths, onSubmitEdit, onCancelEdit],
   )
 
+  const visibleNodeCount = useMemo(
+    () => countVisibleNodes(files, searchQuery),
+    [files, searchQuery],
+  )
+
   if (files.length === 0) {
     return (
       <div
@@ -386,6 +413,20 @@ export function FileTree({
         )}
       >
         No files
+      </div>
+    )
+  }
+
+  if (visibleNodeCount === 0) {
+    return (
+      <div className={cn("flex h-full items-center justify-center p-6", className)}>
+        <EmptyState
+          className="min-h-0 border-0"
+          title="No matching files"
+          description={searchQuery?.trim()
+            ? `No files match “${searchQuery.trim()}”.`
+            : "No files match the current filter."}
+        />
       </div>
     )
   }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTree.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTree.test.tsx
@@ -136,6 +136,29 @@ describe("FileTree", () => {
     expect(screen.getByText("package.json")).toBeInTheDocument()
   })
 
+  it("renders a filter-specific empty state when searchQuery matches no files", () => {
+    render(
+      <FileTree files={sampleFiles} searchQuery="does-not-exist" height={300} />,
+    )
+
+    expect(screen.getByText("No matching files")).toBeInTheDocument()
+    expect(screen.getByText("No files match “does-not-exist”.")).toBeInTheDocument()
+    expect(screen.queryByText("No files")).not.toBeInTheDocument()
+  })
+
+  it("shows files again after clearing the searchQuery", () => {
+    const { rerender } = render(
+      <FileTree files={sampleFiles} searchQuery="does-not-exist" height={300} />,
+    )
+
+    expect(screen.getByText("No matching files")).toBeInTheDocument()
+
+    rerender(<FileTree files={sampleFiles} searchQuery="" height={300} />)
+
+    expect(screen.queryByText("No matching files")).not.toBeInTheDocument()
+    expect(screen.getByText("package.json")).toBeInTheDocument()
+  })
+
   it("renders 1000+ files without crashing", () => {
     const manyFiles: FileTreeNode[] = Array.from({ length: 1000 }, (_, i) => ({
       name: `file-${i}.ts`,


### PR DESCRIPTION
## Summary
- show a dedicated empty state when the file tree filter returns zero visible rows
- keep the existing `No files` state for truly empty workspaces/directories
- add focused tests for no-match filtering and clearing the query

## Verification
- `pnpm --dir /home/ubuntu/projects/boring-ui-v2 --filter @hachej/boring-workspace test src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTree.test.tsx`
- `pnpm --dir /home/ubuntu/projects/boring-ui-v2 --filter @hachej/boring-workspace typecheck`

Closes #128.