### PR TITLE
Reload PDF and image panes on file changes (#35)

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
+import { RefreshCw } from "lucide-react"
 import { ErrorState, Spinner } from "@hachej/boring-ui-kit"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
 import { cn } from "../../../../front/lib/utils"
@@ -8,6 +9,8 @@ import { cn } from "../../../../front/lib/utils"
 export interface MediaViewerProps {
   path: string
   kind: "image" | "pdf"
+  reloadKey?: number
+  onReload?: () => void
   className?: string
 }
 
@@ -20,17 +23,18 @@ function filename(path: string): string {
   return path.split("/").pop() ?? path
 }
 
-export function MediaViewer({ path, kind, className }: MediaViewerProps) {
+export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: MediaViewerProps) {
   const apiBaseUrl = useApiBaseUrl()
   const workspaceRequestId = useWorkspaceRequestId()
   const [objectUrl, setObjectUrl] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
-  const rawUrl = useMemo(
-    () => apiUrl(apiBaseUrl, `/api/v1/files/raw?path=${encodeURIComponent(path)}`),
-    [apiBaseUrl, path],
-  )
+  const rawUrl = useMemo(() => {
+    const query = new URLSearchParams({ path })
+    if (reloadKey > 0) query.set("reload", String(reloadKey))
+    return apiUrl(apiBaseUrl, `/api/v1/files/raw?${query.toString()}`)
+  }, [apiBaseUrl, path, reloadKey])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -98,13 +102,25 @@ export function MediaViewer({ path, kind, className }: MediaViewerProps) {
         <div className="min-w-0 truncate text-xs font-medium text-muted-foreground" title={path}>
           {filename(path)}
         </div>
-        <a
-          href={objectUrl}
-          download={filename(path)}
-          className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
-        >
-          Download
-        </a>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={onReload}
+            className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={`Reload ${filename(path)}`}
+            title="Reload preview"
+          >
+            <RefreshCw className="size-3.5" />
+            <span>Reload</span>
+          </button>
+          <a
+            href={objectUrl}
+            download={filename(path)}
+            className="rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Download
+          </a>
+        </div>
       </div>
       <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto p-4">
         {kind === "image" ? (

--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewerPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewerPane.tsx
@@ -2,6 +2,7 @@
 
 import type { PaneProps } from "../../../../shared/types/panel"
 import { MediaViewer } from "./MediaViewer"
+import { useMediaViewerReload } from "./useMediaViewerReload"
 
 export type MediaViewerPaneProps = PaneProps<{ path?: string; kind?: "image" | "pdf" }>
 
@@ -12,5 +13,15 @@ function inferKind(path: string, explicit?: "image" | "pdf"): "image" | "pdf" {
 
 export function MediaViewerPane({ params, className }: MediaViewerPaneProps) {
   const path = params?.path ?? ""
-  return <MediaViewer path={path} kind={inferKind(path, params?.kind)} className={className} />
+  const { reloadKey, reload } = useMediaViewerReload({ path })
+
+  return (
+    <MediaViewer
+      path={path}
+      kind={inferKind(path, params?.kind)}
+      reloadKey={reloadKey}
+      onReload={reload}
+      className={className}
+    />
+  )
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/useMediaViewerReload.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/useMediaViewerReload.test.tsx
@@ -1,0 +1,40 @@
+import { renderHook, act } from "@testing-library/react"
+import { beforeEach, describe, expect, it } from "vitest"
+import { events } from "../../../../front/events"
+import { filesystemEvents } from "../../shared/events"
+import { useMediaViewerReload } from "./useMediaViewerReload"
+
+describe("useMediaViewerReload", () => {
+  beforeEach(() => {
+    events._reset()
+  })
+
+  it("increments reloadKey for matching filesystem change events and manual reloads", () => {
+    const { result } = renderHook(() => useMediaViewerReload({ path: "docs/report.pdf" }))
+
+    expect(result.current.reloadKey).toBe(0)
+
+    act(() => {
+      events.emit(filesystemEvents.changed, {
+        cause: "remote",
+        ts: Date.now(),
+        path: "docs/other.pdf",
+      })
+    })
+    expect(result.current.reloadKey).toBe(0)
+
+    act(() => {
+      events.emit(filesystemEvents.changed, {
+        cause: "remote",
+        ts: Date.now(),
+        path: "docs/report.pdf",
+      })
+    })
+    expect(result.current.reloadKey).toBe(1)
+
+    act(() => {
+      result.current.reload()
+    })
+    expect(result.current.reloadKey).toBe(2)
+  })
+})

--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/useMediaViewerReload.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/useMediaViewerReload.ts
@@ -1,0 +1,32 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { onFilesystemChanged } from "../agentFileBridge"
+
+export interface UseMediaViewerReloadOptions {
+  path: string
+}
+
+export interface UseMediaViewerReloadReturn {
+  reloadKey: number
+  reload: () => void
+}
+
+export function useMediaViewerReload({ path }: UseMediaViewerReloadOptions): UseMediaViewerReloadReturn {
+  const [reloadKey, setReloadKey] = useState(0)
+
+  const reload = useCallback(() => {
+    setReloadKey((value) => value + 1)
+  }, [])
+
+  useEffect(() => {
+    if (!path) return
+
+    return onFilesystemChanged((event) => {
+      if (event.path !== path) return
+      reload()
+    })
+  }, [path, reload])
+
+  return { reloadKey, reload }
+}


### PR DESCRIPTION
## Summary\n- add a lightweight reload path for image/PDF panes\n- auto-reload matching media panes on filesystem change events\n- add a visible Reload button and deterministic cache-busting query param\n- add focused reload hook test coverage\n\n## Verification\n- 
> @hachej/boring-workspace@0.1.31 test /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-35/packages/workspace
> vitest run src/plugins/filesystemPlugin/front/media-viewer/useMediaViewerReload.test.tsx


 RUN  v2.1.9 /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-35/packages/workspace

 ✓ src/plugins/filesystemPlugin/front/media-viewer/useMediaViewerReload.test.tsx (1 test) 32ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  14:23:13
   Duration  2.68s (transform 344ms, setup 339ms, collect 378ms, tests 32ms, environment 1.23s, prepare 243ms) ✅\n- 
> @hachej/boring-workspace@0.1.31 typecheck /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-35/packages/workspace
> tsc --noEmit -p tsconfig.front.json && tsc --noEmit -p tsconfig.server.json ✅\n\n## Notes\n- Narrow first pass: this listens to existing  events and bumps a per-pane reload key only when the changed path matches the open media pane path.\n- Cache busting is deterministic per reload action/event (), so the viewer does not require a hard browser refresh.\n- Cross-review helper was unavailable in this environment ( invoked the system linker instead of the reviewer binary), so I am explicitly calling that out here instead of claiming review that did not run.\n\nCloses #35