### PR TITLE
feat: add opt-in visual artifacts to runtime plugin test command (#173)

### DIFF
--- a/packages/agent/src/front/pi/__tests__/piNativeFollowUpQueue.test.ts
+++ b/packages/agent/src/front/pi/__tests__/piNativeFollowUpQueue.test.ts
@@ -5,6 +5,10 @@ import { usePiNativeFollowUpQueue } from '../piNativeFollowUpQueue'
 
 const stop = vi.fn()
 
+async function flushPromises(iterations = 4): Promise<void> {
+  for (let index = 0; index < iterations; index += 1) await Promise.resolve()
+}
+
 function installStorage(): void {
   const store = new Map<string, string>()
   Object.defineProperty(globalThis, 'localStorage', {
@@ -27,6 +31,250 @@ describe('usePiNativeFollowUpQueue', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+  })
+
+  it('restores a queued follow-up for the same session after remount', async () => {
+    const first = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-remount',
+      status: 'streaming',
+      stop,
+    }))
+
+    act(() => {
+      first.result.current.queueFollowUp({
+        text: 'keep this queued message',
+        files: [],
+        serverMessage: 'keep this queued message',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-remount/followup',
+        expect.objectContaining({ method: 'POST' }),
+      )
+      expect(first.result.current.pendingMessages[0]?.posted).toBe(true)
+    })
+
+    vi.mocked(fetch).mockClear()
+    first.unmount()
+
+    const second = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-remount',
+      status: 'streaming',
+      stop,
+    }))
+
+    expect(second.result.current.pendingMessages).toHaveLength(1)
+    expect(second.result.current.pendingMessages[0]?.text).toBe('keep this queued message')
+    expect(second.result.current.projectedTailMessages).toHaveLength(1)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('does not erase another session queued follow-up when switching sessions', async () => {
+    const { result, rerender } = renderHook(
+      ({ sessionId }) => usePiNativeFollowUpQueue({ sessionId, status: 'streaming', stop }),
+      { initialProps: { sessionId: 'sess-a' } },
+    )
+
+    act(() => {
+      result.current.queueFollowUp({
+        text: 'queued on a',
+        files: [],
+        serverMessage: 'queued on a',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-a/followup',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    rerender({ sessionId: 'sess-b' })
+    expect(result.current.pendingMessages).toHaveLength(0)
+
+    rerender({ sessionId: 'sess-a' })
+    expect(result.current.pendingMessages).toHaveLength(1)
+    expect(result.current.projectedTailMessages).toHaveLength(1)
+  })
+
+  it('keeps queued follow-ups isolated between workspaces sharing a session id', async () => {
+    const { result, rerender } = renderHook(
+      ({ workspaceId }) => usePiNativeFollowUpQueue({
+        sessionId: 'sess-shared',
+        status: 'streaming',
+        requestHeaders: { 'x-boring-workspace-id': workspaceId },
+        stop,
+      }),
+      { initialProps: { workspaceId: 'workspace-a' } },
+    )
+
+    act(() => {
+      result.current.queueFollowUp({
+        text: 'queued in workspace a',
+        files: [],
+        serverMessage: 'queued in workspace a',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-shared/followup',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'x-boring-workspace-id': 'workspace-a' }),
+        }),
+      )
+    })
+
+    rerender({ workspaceId: 'workspace-b' })
+    expect(result.current.pendingMessages).toHaveLength(0)
+    expect(result.current.projectedTailMessages).toHaveLength(0)
+
+    act(() => {
+      result.current.queueFollowUp({
+        text: 'queued in workspace b',
+        files: [],
+        serverMessage: 'queued in workspace b',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-shared/followup',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ 'x-boring-workspace-id': 'workspace-b' }),
+        }),
+      )
+    })
+
+    expect(result.current.pendingMessages[0]?.text).toBe('queued in workspace b')
+
+    rerender({ workspaceId: 'workspace-a' })
+    expect(result.current.pendingMessages).toHaveLength(1)
+    expect(result.current.pendingMessages[0]?.text).toBe('queued in workspace a')
+    expect(result.current.projectedTailMessages).toHaveLength(1)
+  })
+
+  it('reposts a restored unposted follow-up while streaming', async () => {
+    localStorage.setItem('boring-agent:followup-queue:global:sess-unposted', JSON.stringify([{
+      id: 'pending-unposted',
+      sessionId: 'sess-unposted',
+      text: 'restore and send me',
+      files: [],
+      serverMessage: 'restore and send me',
+      attachments: [],
+      posted: false,
+      consumed: false,
+      clientNonce: 'nonce-unposted',
+      clientSeq: 1,
+      postAttempts: 0,
+    }]))
+
+    const { result } = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-unposted',
+      status: 'streaming',
+      stop,
+    }))
+
+    expect(result.current.pendingMessages).toHaveLength(1)
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-unposted/followup',
+        expect.objectContaining({
+          method: 'POST',
+          body: expect.stringContaining('nonce-unposted'),
+        }),
+      )
+      expect(result.current.pendingMessages[0]?.posted).toBe(true)
+    })
+  })
+
+  it('preserves a queued follow-up when posting fails after switching sessions', async () => {
+    let rejectPost: ((reason?: unknown) => void) | undefined
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(() => new Promise((_, reject) => {
+      rejectPost = reject
+    })))
+
+    const { result, rerender } = renderHook(
+      ({ sessionId }) => usePiNativeFollowUpQueue({ sessionId, status: 'streaming', stop }),
+      { initialProps: { sessionId: 'sess-a-fail' } },
+    )
+
+    act(() => {
+      result.current.queueFollowUp({
+        text: 'queued before failed post',
+        files: [],
+        serverMessage: 'queued before failed post',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => expect(rejectPost).toBeDefined())
+
+    rerender({ sessionId: 'sess-b-fail' })
+    expect(result.current.pendingMessages).toHaveLength(0)
+
+    await act(async () => {
+      rejectPost?.(new Error('offline'))
+      await flushPromises()
+    })
+
+    rerender({ sessionId: 'sess-a-fail' })
+    expect(result.current.pendingMessages).toHaveLength(1)
+    expect(result.current.pendingMessages[0]).toEqual(expect.objectContaining({
+      text: 'queued before failed post',
+      posted: false,
+    }))
+  })
+
+  it('does not replay a consumed follow-up after remount', async () => {
+    const first = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-consumed',
+      status: 'streaming',
+      stop,
+    }))
+
+    act(() => {
+      first.result.current.queueFollowUp({
+        text: 'consumed follow-up',
+        files: [],
+        serverMessage: 'consumed follow-up',
+        attachments: [],
+      })
+    })
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith(
+        '/api/v1/agent/chat/sess-consumed/followup',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+
+    act(() => {
+      first.result.current.handleData({
+        type: 'data-followup-consumed',
+        data: { text: 'consumed follow-up' },
+      })
+    })
+
+    first.unmount()
+
+    const second = renderHook(() => usePiNativeFollowUpQueue({
+      sessionId: 'sess-consumed',
+      status: 'streaming',
+      stop,
+    }))
+
+    expect(second.result.current.pendingMessages).toHaveLength(0)
+    expect(second.result.current.projectedTailMessages).toHaveLength(0)
   })
 
   it('deletes one queued follow-up locally and asks the server to drop the matching nonce', async () => {

--- a/packages/agent/src/front/pi/piNativeFollowUpQueue.ts
+++ b/packages/agent/src/front/pi/piNativeFollowUpQueue.ts
@@ -2,10 +2,19 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { FileUIPart, UIMessage } from 'ai'
 
 const STORAGE_FOLLOWUP_SEQ_PREFIX = 'boring-agent:followup-seq:'
+const STORAGE_FOLLOWUP_QUEUE_PREFIX = 'boring-agent:followup-queue:'
 const MAX_FOLLOWUP_POST_ATTEMPTS = 5
 
-function nextStoredFollowUpSeq(sessionId: string): number {
-  const key = `${STORAGE_FOLLOWUP_SEQ_PREFIX}${sessionId}`
+function workspaceScopeFromHeaders(headers?: Record<string, string>): string {
+  return headers?.['x-boring-workspace-id'] ?? headers?.['X-Boring-Workspace-Id'] ?? 'global'
+}
+
+function scopedStorageKey(prefix: string, storageScope: string, sessionId: string): string {
+  return `${prefix}${encodeURIComponent(storageScope)}:${encodeURIComponent(sessionId)}`
+}
+
+function nextStoredFollowUpSeq(storageScope: string, sessionId: string): number {
+  const key = scopedStorageKey(STORAGE_FOLLOWUP_SEQ_PREFIX, storageScope, sessionId)
   try {
     const current = Number(globalThis.localStorage?.getItem(key) ?? '0')
     const next = Number.isFinite(current) ? current + 1 : 1
@@ -38,6 +47,61 @@ export type ProjectedFollowUpMessage = {
   status: 'queued' | 'streaming' | 'done'
 }
 
+function followUpQueueStorageKey(storageScope: string, sessionId: string): string {
+  return scopedStorageKey(STORAGE_FOLLOWUP_QUEUE_PREFIX, storageScope, sessionId)
+}
+
+function isPendingFollowUp(value: unknown, sessionId: string): value is PendingFollowUp {
+  const item = value as PendingFollowUp
+  return Boolean(
+    item &&
+    item.sessionId === sessionId &&
+    typeof item.id === 'string' &&
+    typeof item.text === 'string' &&
+    typeof item.serverMessage === 'string' &&
+    typeof item.clientNonce === 'string' &&
+    typeof item.clientSeq === 'number' &&
+    typeof item.postAttempts === 'number' &&
+    Array.isArray(item.files) &&
+    Array.isArray(item.attachments) &&
+    typeof item.posted === 'boolean' &&
+    typeof item.consumed === 'boolean',
+  )
+}
+
+function pendingToProjected(item: PendingFollowUp): ProjectedFollowUpMessage {
+  return {
+    id: item.id,
+    role: 'user',
+    text: item.text,
+    files: item.files,
+    status: item.consumed ? 'done' : 'queued',
+  }
+}
+
+function readStoredFollowUps(storageScope: string, sessionId: string): PendingFollowUp[] {
+  try {
+    const raw = globalThis.localStorage?.getItem(followUpQueueStorageKey(storageScope, sessionId))
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((item): item is PendingFollowUp => isPendingFollowUp(item, sessionId))
+  } catch {
+    return []
+  }
+}
+
+function writeStoredFollowUps(storageScope: string, sessionId: string, items: PendingFollowUp[]): void {
+  try {
+    const scoped = items.filter((item) => item.sessionId === sessionId && !item.consumed)
+    const storage = globalThis.localStorage
+    if (!storage) return
+    const key = followUpQueueStorageKey(storageScope, sessionId)
+    if (scoped.length === 0) storage.removeItem(key)
+    else storage.setItem(key, JSON.stringify(scoped))
+  } catch { /* quota exceeded / storage unavailable: keep in-memory only */ }
+}
+
 export function usePiNativeFollowUpQueue({
   sessionId,
   status,
@@ -49,22 +113,26 @@ export function usePiNativeFollowUpQueue({
   requestHeaders?: Record<string, string>
   stop: () => void
 }) {
-  const [pendingMessages, setPendingMessages] = useState<PendingFollowUp[]>([])
-  const pendingMessagesRef = useRef<PendingFollowUp[]>([])
-  const [projectedFollowUps, setProjectedFollowUps] = useState<ProjectedFollowUpMessage[]>([])
-  const projectedFollowUpsRef = useRef<ProjectedFollowUpMessage[]>([])
+  const storageScope = workspaceScopeFromHeaders(requestHeaders)
+  const [pendingMessages, setPendingMessages] = useState<PendingFollowUp[]>(() => readStoredFollowUps(storageScope, sessionId))
+  const pendingMessagesRef = useRef<PendingFollowUp[]>(pendingMessages)
+  const [projectedFollowUps, setProjectedFollowUps] = useState<ProjectedFollowUpMessage[]>(() => pendingMessages.map(pendingToProjected))
+  const projectedFollowUpsRef = useRef<ProjectedFollowUpMessage[]>(projectedFollowUps)
   const activeProjectedAssistantRef = useRef<string | null>(null)
   const lastConsumedProjectedUserRef = useRef<string | null>(null)
   const followUpPostTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const followUpPostInFlightRef = useRef(false)
   const postPendingFollowUpsRef = useRef<() => void>(() => {})
   const consumedFollowUpRef = useRef<{ text: string; files: FileUIPart[] } | null>(null)
+  const activeStorageRef = useRef({ storageScope, sessionId })
+  activeStorageRef.current = { storageScope, sessionId }
 
   const updatePendingMessages = useCallback((updater: (items: PendingFollowUp[]) => PendingFollowUp[]) => {
     const next = updater(pendingMessagesRef.current)
     pendingMessagesRef.current = next
+    writeStoredFollowUps(storageScope, sessionId, next)
     setPendingMessages(next)
-  }, [])
+  }, [storageScope, sessionId])
 
   const updateProjectedFollowUps = useCallback((updater: (items: ProjectedFollowUpMessage[]) => ProjectedFollowUpMessage[]) => {
     const next = updater(projectedFollowUpsRef.current)
@@ -72,25 +140,40 @@ export function usePiNativeFollowUpQueue({
     setProjectedFollowUps(next)
   }, [])
 
-  const clearLocal = useCallback(() => {
+  const clearRuntimeState = useCallback(() => {
     consumedFollowUpRef.current = null
-    pendingMessagesRef.current = []
-    projectedFollowUpsRef.current = []
     activeProjectedAssistantRef.current = null
     lastConsumedProjectedUserRef.current = null
     if (followUpPostTimerRef.current) clearTimeout(followUpPostTimerRef.current)
     followUpPostTimerRef.current = null
     followUpPostInFlightRef.current = false
-    setPendingMessages([])
-    setProjectedFollowUps([])
   }, [])
 
-  const previousSessionIdRef = useRef(sessionId)
+  const loadLocalForScope = useCallback((nextStorageScope: string, nextSessionId: string) => {
+    clearRuntimeState()
+    const restored = readStoredFollowUps(nextStorageScope, nextSessionId)
+    const projected = restored.map(pendingToProjected)
+    pendingMessagesRef.current = restored
+    projectedFollowUpsRef.current = projected
+    setPendingMessages(restored)
+    setProjectedFollowUps(projected)
+  }, [clearRuntimeState])
+
+  const clearLocal = useCallback(() => {
+    clearRuntimeState()
+    pendingMessagesRef.current = []
+    projectedFollowUpsRef.current = []
+    writeStoredFollowUps(storageScope, sessionId, [])
+    setPendingMessages([])
+    setProjectedFollowUps([])
+  }, [clearRuntimeState, storageScope, sessionId])
+
+  const previousStorageRef = useRef({ storageScope, sessionId })
   useEffect(() => {
-    if (previousSessionIdRef.current === sessionId) return
-    previousSessionIdRef.current = sessionId
-    clearLocal()
-  }, [sessionId, clearLocal])
+    if (previousStorageRef.current.storageScope === storageScope && previousStorageRef.current.sessionId === sessionId) return
+    previousStorageRef.current = { storageScope, sessionId }
+    loadLocalForScope(storageScope, sessionId)
+  }, [storageScope, sessionId, loadLocalForScope])
 
   // Clean up timers on unmount to prevent stale retries after component
   // unmounts (e.g. when switching sessions).
@@ -105,16 +188,20 @@ export function usePiNativeFollowUpQueue({
 
   const postPendingFollowUps = useCallback(() => {
     if (followUpPostInFlightRef.current) return
+    const postStorageScope = storageScope
+    const postSessionId = sessionId
+    const isActiveScope = () => activeStorageRef.current.storageScope === postStorageScope && activeStorageRef.current.sessionId === postSessionId
+    if (!isActiveScope()) return
     followUpPostInFlightRef.current = true
     void (async () => {
       let shouldContinue = true
       try {
         while (true) {
-          const pending = pendingMessagesRef.current.find((item) => item.sessionId === sessionId && !item.posted)
+          if (!isActiveScope()) return
+          const pending = pendingMessagesRef.current.find((item) => item.sessionId === postSessionId && !item.posted)
           if (!pending) return
-          updatePendingMessages((items) => items.map((item) => item.id === pending.id ? { ...item, posted: true } : item))
           try {
-            const res = await fetch(`/api/v1/agent/chat/${encodeURIComponent(sessionId)}/followup`, {
+            const res = await fetch(`/api/v1/agent/chat/${encodeURIComponent(postSessionId)}/followup`, {
               method: 'POST',
               headers: {
                 'Content-Type': 'application/json',
@@ -129,8 +216,11 @@ export function usePiNativeFollowUpQueue({
               }),
             })
             if (!res.ok) throw new Error(`follow-up rejected: ${res.status}`)
+            if (!isActiveScope()) return
+            updatePendingMessages((items) => items.map((item) => item.id === pending.id ? { ...item, posted: true } : item))
           } catch {
             shouldContinue = false
+            if (!isActiveScope()) return
             const nextAttempts = pending.postAttempts + 1
             updatePendingMessages((items) => items.map((item) => item.id === pending.id ? { ...item, posted: false, postAttempts: nextAttempts } : item))
             if (nextAttempts < MAX_FOLLOWUP_POST_ATTEMPTS) {
@@ -144,13 +234,15 @@ export function usePiNativeFollowUpQueue({
           }
         }
       } finally {
-        followUpPostInFlightRef.current = false
-        if (shouldContinue && pendingMessagesRef.current.some((item) => item.sessionId === sessionId && !item.posted)) {
-          postPendingFollowUps()
+        if (isActiveScope()) {
+          followUpPostInFlightRef.current = false
+          if (shouldContinue && pendingMessagesRef.current.some((item) => item.sessionId === postSessionId && !item.posted)) {
+            postPendingFollowUps()
+          }
         }
       }
     })()
-  }, [sessionId, requestHeaders, updatePendingMessages])
+  }, [storageScope, sessionId, requestHeaders, updatePendingMessages])
   postPendingFollowUpsRef.current = postPendingFollowUps
 
   const queueFollowUp = useCallback((input: {
@@ -169,7 +261,7 @@ export function usePiNativeFollowUpQueue({
       posted: false,
       consumed: false,
       clientNonce: globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random()}-nonce`,
-      clientSeq: nextStoredFollowUpSeq(sessionId),
+      clientSeq: nextStoredFollowUpSeq(storageScope, sessionId),
       postAttempts: 0,
     }
     updatePendingMessages((items) => [...items, nextPending])
@@ -188,7 +280,7 @@ export function usePiNativeFollowUpQueue({
         postPendingFollowUps()
       }, 1000)
     }
-  }, [sessionId, status, postPendingFollowUps, updatePendingMessages, updateProjectedFollowUps])
+  }, [storageScope, sessionId, status, postPendingFollowUps, updatePendingMessages, updateProjectedFollowUps])
 
   const handleData = useCallback((part: unknown) => {
     const typed = part as { type?: string; data?: Record<string, unknown> }

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/followup.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/followup.test.ts
@@ -107,6 +107,74 @@ describe("native pi follow-up integration", () => {
     await reader.return?.();
   });
 
+  it("dedupes repeated queued follow-up posts with the same nonce", async () => {
+    const harness = createPiCodingAgentHarness({ tools: [], cwd: "/tmp/test-followup" });
+    const iter = harness.sendMessage({ sessionId: "sess-dedupe", message: "first" }, makeCtx());
+    const reader = iter[Symbol.asyncIterator]();
+
+    const boot = reader.next();
+    await new Promise((r) => setTimeout(r, 5));
+    emit({ type: "message_start", message: { id: "a1", role: "assistant" } });
+    await boot;
+
+    await harness.followUp!("sess-dedupe", "same nonce", undefined, "same nonce", { clientNonce: "nonce-dedupe", clientSeq: 1 });
+    await harness.followUp!("sess-dedupe", "same nonce", undefined, "same nonce", { clientNonce: "nonce-dedupe", clientSeq: 1 });
+
+    expect(promptCalls.map((c) => c.message)).toEqual(["first", "same nonce"]);
+    expect(mockSessions[0].agent.followUpQueue.messages.map((msg: any) => msg.content[0].text)).toEqual(["same nonce"]);
+
+    promptHandle.resolve?.();
+    await reader.return?.();
+  });
+
+  it("does not dedupe distinct nonces that reuse a client sequence", async () => {
+    const harness = createPiCodingAgentHarness({ tools: [], cwd: "/tmp/test-followup" });
+    const iter = harness.sendMessage({ sessionId: "sess-seq-reuse", message: "first" }, makeCtx());
+    const reader = iter[Symbol.asyncIterator]();
+
+    const boot = reader.next();
+    await new Promise((r) => setTimeout(r, 5));
+    emit({ type: "message_start", message: { id: "a1", role: "assistant" } });
+    await boot;
+
+    await harness.followUp!("sess-seq-reuse", "first seq", undefined, "first seq", { clientNonce: "nonce-seq-a", clientSeq: 1 });
+    await harness.followUp!("sess-seq-reuse", "second seq", undefined, "second seq", { clientNonce: "nonce-seq-b", clientSeq: 1 });
+
+    expect(promptCalls.map((c) => c.message)).toEqual(["first", "first seq", "second seq"]);
+    expect(mockSessions[0].agent.followUpQueue.messages.map((msg: any) => msg.content[0].text)).toEqual(["first seq", "second seq"]);
+
+    promptHandle.resolve?.();
+    await reader.return?.();
+  });
+
+  it("dedupes a repeated follow-up post after pi consumes the first copy", async () => {
+    const harness = createPiCodingAgentHarness({ tools: [], cwd: "/tmp/test-followup" });
+    const iter = harness.sendMessage({ sessionId: "sess-consumed-dedupe", message: "first" }, makeCtx());
+    const reader = iter[Symbol.asyncIterator]();
+
+    const boot = reader.next();
+    await new Promise((r) => setTimeout(r, 5));
+    emit({ type: "message_start", message: { id: "a1", role: "assistant" } });
+    await boot;
+
+    await harness.followUp!("sess-consumed-dedupe", "same consumed nonce", undefined, "same consumed nonce", { clientNonce: "nonce-consumed", clientSeq: 1 });
+
+    const consumed = reader.next();
+    emit({
+      type: "message_start",
+      message: { id: "u2", role: "user", content: [{ type: "text", text: "same consumed nonce" }] },
+    });
+    await consumed;
+
+    await harness.followUp!("sess-consumed-dedupe", "same consumed nonce", undefined, "same consumed nonce", { clientNonce: "nonce-consumed", clientSeq: 1 });
+
+    expect(promptCalls.map((c) => c.message)).toEqual(["first", "same consumed nonce"]);
+    expect(mockSessions[0].agent.followUpQueue.messages.map((msg: any) => msg.content[0].text)).toEqual(["same consumed nonce"]);
+
+    promptHandle.resolve?.();
+    await reader.return?.();
+  });
+
   it("can delete a queued follow-up before pi drains it", async () => {
     const harness = createPiCodingAgentHarness({ tools: [], cwd: "/tmp/test-followup" });
     const iter = harness.sendMessage({ sessionId: "sess-delete", message: "first" }, makeCtx());

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -552,6 +552,7 @@ export function createPiCodingAgentHarness(opts: {
     handle.piSession.dispose();
     piSessions.delete(sessionId);
     clearNativeFollowUpWork(sessionId);
+    consumedNativeFollowUpKeys.delete(sessionId);
   }
 
   const originalDelete = sessionStore.delete.bind(sessionStore);
@@ -562,6 +563,7 @@ export function createPiCodingAgentHarness(opts: {
 
   const nativeFollowUpPending = new Set<string>();
   const nativeFollowUpQueues = new Map<string, NativeFollowUpRequest[]>();
+  const consumedNativeFollowUpKeys = new Map<string, Set<string>>();
 
   function clearNativeFollowUpWork(sessionId: string): void {
     nativeFollowUpPending.delete(sessionId);
@@ -611,14 +613,43 @@ export function createPiCodingAgentHarness(opts: {
     session._emitQueueUpdate?.();
   }
 
+  function followUpDedupeKeys(options?: FollowUpOptions | NativeFollowUpRequest): string[] {
+    const keys: string[] = [];
+    if (options?.clientNonce) keys.push(`nonce:${options.clientNonce}`);
+    if (options?.clientSeq !== undefined) keys.push(`seq:${options.clientSeq}`);
+    return keys;
+  }
+
   function hasFollowUpSelector(options?: FollowUpOptions): boolean {
-    return Boolean(options?.clientNonce) || options?.clientSeq !== undefined;
+    return followUpDedupeKeys(options).length > 0;
   }
 
   function matchesFollowUpSelector(item: NativeFollowUpRequest, options?: FollowUpOptions): boolean {
     if (!hasFollowUpSelector(options)) return true;
-    return Boolean(options?.clientNonce && item.clientNonce === options.clientNonce)
-      || (options?.clientSeq !== undefined && item.clientSeq === options.clientSeq);
+    const optionKeys = new Set(followUpDedupeKeys(options));
+    return followUpDedupeKeys(item).some((key) => optionKeys.has(key));
+  }
+
+  function rememberConsumedNativeFollowUp(sessionId: string, request: NativeFollowUpRequest | undefined): void {
+    const keys = followUpDedupeKeys(request);
+    if (keys.length === 0) return;
+    const consumed = consumedNativeFollowUpKeys.get(sessionId) ?? new Set<string>();
+    for (const key of keys) consumed.add(key);
+    consumedNativeFollowUpKeys.set(sessionId, consumed);
+  }
+
+  function followUpPostDedupeKeys(options?: FollowUpOptions | NativeFollowUpRequest): string[] {
+    if (options?.clientNonce) return [`nonce:${options.clientNonce}`];
+    if (options?.clientSeq !== undefined) return [`seq:${options.clientSeq}`];
+    return [];
+  }
+
+  function hasQueuedOrConsumedNativeFollowUp(sessionId: string, options?: FollowUpOptions): boolean {
+    const optionKeys = new Set(followUpPostDedupeKeys(options));
+    if (optionKeys.size === 0) return false;
+    const consumed = consumedNativeFollowUpKeys.get(sessionId);
+    if (consumed && [...optionKeys].some((key) => consumed.has(key))) return true;
+    return (nativeFollowUpQueues.get(sessionId) ?? []).some((request) => followUpPostDedupeKeys(request).some((key) => optionKeys.has(key)));
   }
 
   function removeNativeFollowUp(sessionId: string, options?: FollowUpOptions): NativeFollowUpRemoval[] {
@@ -651,6 +682,7 @@ export function createPiCodingAgentHarness(opts: {
     async followUp(sessionId: string, text: string, _attachments?: MessageAttachment[], displayText = text, options?: FollowUpOptions): Promise<void> {
       const handle = piSessions.get(sessionId);
       if (!handle) throw new Error("followup_session_not_ready");
+      if (hasQueuedOrConsumedNativeFollowUp(sessionId, options)) return;
       const queue = nativeFollowUpQueues.get(sessionId) ?? [];
       queue.push({
         text,
@@ -983,8 +1015,8 @@ export function createPiCodingAgentHarness(opts: {
             const queue = nativeFollowUpQueues.get(input.sessionId);
             if (queue?.length) {
               const index = queue.findIndex((item) => item.text === text || item.displayText === text);
-              if (index >= 0) queue.splice(index, 1);
-              else queue.shift();
+              const consumed = index >= 0 ? queue.splice(index, 1)[0] : queue.shift();
+              rememberConsumedNativeFollowUp(input.sessionId, consumed);
               if (queue.length > 0) nativeFollowUpQueues.set(input.sessionId, queue);
               else clearNativeFollowUpWork(input.sessionId);
             } else {

--- a/packages/plugin-cli/package.json
+++ b/packages/plugin-cli/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.15.3",
+    "playwright": "^1.59.1",
     "tsup": "^8.4.0",
     "typescript": "^5.8.3",
     "vitest": "^3.1.3"

--- a/packages/plugin-cli/src/__tests__/testPlugin.test.ts
+++ b/packages/plugin-cli/src/__tests__/testPlugin.test.ts
@@ -1,8 +1,12 @@
 import Fastify from "fastify"
+import { access, mkdtemp, rm } from "node:fs/promises"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
 import { afterEach, describe, expect, test } from "vitest"
 import { runPluginSelfTest } from "../server/testPlugin"
 
 const apps: Array<{ close: () => Promise<unknown> }> = []
+const tempDirs: string[] = []
 
 async function startApp(setup: (app: ReturnType<typeof Fastify>) => void | Promise<void>) {
   const app = Fastify({ logger: false })
@@ -16,7 +20,14 @@ async function startApp(setup: (app: ReturnType<typeof Fastify>) => void | Promi
 
 afterEach(async () => {
   for (const app of apps.splice(0)) await app.close()
+  for (const dir of tempDirs.splice(0)) await rm(dir, { recursive: true, force: true })
 })
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
 
 describe("runPluginSelfTest", () => {
   test("returns no-browser-connected when the UI has not connected", async () => {
@@ -100,5 +111,26 @@ describe("runPluginSelfTest", () => {
     expect(result.ok).toBe(true)
     expect(result.revision).toBe(2)
     expect(result.pane).toMatchObject({ state: "ready", found: true })
+  })
+
+  test("saves status artifact on failure when browser capture fails", async () => {
+    const url = await startApp((app) => {
+      app.post("/api/v1/agent/reload", async () => ({ ok: true }))
+      app.get("/api/v1/ui/panels/status", async () => ({ ok: true, connected: true, state: "error", status: {
+        pluginId: "demo",
+        panelId: "demo.panel",
+        panelInstanceId: "self-test:demo:demo.panel",
+        state: "error",
+        error: { code: "PLUGIN_PANEL_RENDER_ERROR", message: "boom" },
+        reportedAt: new Date().toISOString(),
+      } }))
+    })
+
+    const artifactsDir = await tempDir("boring-plugin-artifacts-")
+    const result = await runPluginSelfTest({ pluginId: "demo", url, timeoutMs: 100, artifactsDir })
+    expect(result.ok).toBe(false)
+    expect(result.artifacts?.attempted).toBe(true)
+    expect(result.artifacts?.files?.statusJson).toBeTruthy()
+    await expect(access(result.artifacts!.files!.statusJson!)).resolves.toBeUndefined()
   })
 })

--- a/packages/plugin-cli/src/index.ts
+++ b/packages/plugin-cli/src/index.ts
@@ -21,7 +21,7 @@ export function pluginCommandUsage(): string {
     "  boring-ui-plugin create <name> [--path <dir>]",
     "  boring-ui-plugin scaffold <name> [workspace]",
     "  boring-ui-plugin verify [name] [workspace]",
-    "  boring-ui-plugin test <name> [--url <url>] [--workspace <id>] [--panel-id <id>] [--timeout-ms <ms>] [--json]",
+    "  boring-ui-plugin test <name> [--url <url>] [--workspace <id>] [--panel-id <id>] [--timeout-ms <ms>] [--open] [--screenshot] [--artifacts-dir <path>] [--json]",
   ].join("\n")
 }
 
@@ -99,7 +99,7 @@ function readOption(argv: string[], name: string): string | undefined {
 
 async function handleTest(argv: string[], positionals: string[], json: boolean): Promise<void> {
   const name = positionals[0]
-  if (!name) throw new Error("usage: boring-ui-plugin test <name> [--url <local-server-url>] [--workspace <id>] [--panel-id <id>] [--timeout-ms <ms>] [--json]")
+  if (!name) throw new Error("usage: boring-ui-plugin test <name> [--url <local-server-url>] [--workspace <id>] [--panel-id <id>] [--timeout-ms <ms>] [--open] [--screenshot] [--artifacts-dir <path>] [--json]")
   const timeoutRaw = readOption(argv, "--timeout-ms")
   const timeoutMs = timeoutRaw ? Number(timeoutRaw) : undefined
   if (timeoutRaw && (timeoutMs == null || !Number.isFinite(timeoutMs) || timeoutMs <= 0)) throw new Error("--timeout-ms must be a positive number")
@@ -109,6 +109,9 @@ async function handleTest(argv: string[], positionals: string[], json: boolean):
     ...(readOption(argv, "--workspace") ? { workspaceId: readOption(argv, "--workspace") } : {}),
     ...(readOption(argv, "--panel-id") ? { panelId: readOption(argv, "--panel-id") } : {}),
     ...(timeoutMs == null ? {} : { timeoutMs }),
+    ...(argv.includes("--open") ? { open: true } : {}),
+    ...(argv.includes("--screenshot") ? { screenshot: true } : {}),
+    ...(readOption(argv, "--artifacts-dir") ? { artifactsDir: readOption(argv, "--artifacts-dir") } : {}),
   })
   console.log(json ? JSON.stringify(result, null, 2) : formatSelfTestResult(result))
   if (!result.ok) process.exit(1)

--- a/packages/plugin-cli/src/server/testPlugin.ts
+++ b/packages/plugin-cli/src/server/testPlugin.ts
@@ -1,8 +1,28 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import { join, resolve } from "node:path"
+
 export type PaneSelfTestState = "ready" | "loading" | "error" | "missing" | "timeout" | "no-browser-connected"
 
 export interface SelfTestEvent {
   code: string
   message: string
+}
+
+export interface PluginTestArtifactFiles {
+  panelPng?: string
+  appPng?: string
+  consoleJson?: string
+  networkJson?: string
+  statusJson?: string
+}
+
+export interface PluginTestArtifacts {
+  attempted: boolean
+  saved: boolean
+  mode: "none" | "failure-only" | "screenshot" | "open" | "open+screenshot"
+  dir?: string
+  files?: PluginTestArtifactFiles
+  captureError?: SelfTestEvent
 }
 
 export interface SelfTestResult {
@@ -19,6 +39,7 @@ export interface SelfTestResult {
     error?: SelfTestEvent
     lastReportedAt?: string
   }
+  artifacts?: PluginTestArtifacts
 }
 
 export interface RunPluginSelfTestOptions {
@@ -27,11 +48,40 @@ export interface RunPluginSelfTestOptions {
   workspaceId?: string
   panelId?: string
   timeoutMs?: number
+  screenshot?: boolean
+  open?: boolean
+  artifactsDir?: string
 }
 
 interface FetchJsonResult {
   status: number
   body: unknown
+}
+
+interface BrowserConsoleEntry {
+  type: string
+  text: string
+  location?: { url?: string; lineNumber?: number; columnNumber?: number }
+  timestamp: string
+}
+
+interface BrowserFailedRequestEntry {
+  url: string
+  method: string
+  failureText?: string
+  status?: number
+  statusText?: string
+  timestamp: string
+}
+
+interface SelfTestRunContext {
+  pluginId: string
+  baseUrl: string
+  workspaceId?: string
+  timeoutMs: number
+  panelId: string
+  panelInstanceId: string
+  headers: Record<string, string>
 }
 
 const DEFAULT_TIMEOUT_MS = 10_000
@@ -75,6 +125,21 @@ function truncateMessage(message: string): string {
 
 function event(code: string, message: string): SelfTestEvent {
   return { code, message: truncateMessage(message) }
+}
+
+function artifactMode(options: RunPluginSelfTestOptions): PluginTestArtifacts["mode"] {
+  if (options.open && options.screenshot) return "open+screenshot"
+  if (options.open) return "open"
+  if (options.screenshot) return "screenshot"
+  return "failure-only"
+}
+
+function defaultArtifactsRoot(pluginId: string): string {
+  return resolve(process.cwd(), ".pi", "extensions", pluginId, ".boring", "test-artifacts")
+}
+
+function timestampDirName(now = new Date()): string {
+  return now.toISOString().replace(/[:.]/g, "-")
 }
 
 async function readJson(response: Response): Promise<unknown> {
@@ -197,34 +262,26 @@ async function openPanel(args: { baseUrl: string; headers: Record<string, string
   return []
 }
 
-export async function runPluginSelfTest(options: RunPluginSelfTestOptions): Promise<SelfTestResult> {
-  const pluginId = options.pluginId.trim()
-  if (!pluginId) throw new Error("plugin id is required")
-  const baseUrl = normalizeBaseUrl(inferSelfTestUrl(options.url))
-  const workspaceId = inferSelfTestWorkspaceId(options.workspaceId) ?? await inferWorkspaceIdFromMeta(baseUrl)
-  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
-  const panelId = buildPanelId(pluginId, options.panelId)
-  const panelInstanceId = buildPanelInstanceId(pluginId, panelId)
-  const headers = workspaceHeaders(workspaceId)
+async function executeSelfTest(context: SelfTestRunContext): Promise<SelfTestResult> {
   const reloadErrors: SelfTestEvent[] = []
   let revision: number | undefined
 
   try {
-    const reload = await fetchJson(apiUrl(baseUrl, "/api/v1/agent/reload"), {
+    const reload = await fetchJson(apiUrl(context.baseUrl, "/api/v1/agent/reload"), {
       method: "POST",
-      headers: { "content-type": "application/json", ...headers },
-      body: JSON.stringify({ ...(workspaceId ? { sessionId: workspaceId } : {}) }),
+      headers: { "content-type": "application/json", ...context.headers },
+      body: JSON.stringify({ ...(context.workspaceId ? { sessionId: context.workspaceId } : {}) }),
     })
     if (reload.status < 200 || reload.status >= 300) reloadErrors.push(event("RELOAD_HTTP_ERROR", `/api/v1/agent/reload returned ${reload.status}`))
-    reloadErrors.push(...collectReloadDiagnostics(pluginId, reload.body))
+    reloadErrors.push(...collectReloadDiagnostics(context.pluginId, reload.body))
   } catch (error) {
     reloadErrors.push(event("RELOAD_FAILED", error instanceof Error ? error.message : String(error)))
   }
 
   try {
-    const diagnostics = await fetchJson(apiUrl(baseUrl, "/api/v1/runtime-plugin-diagnostics"), { headers })
+    const diagnostics = await fetchJson(apiUrl(context.baseUrl, "/api/v1/runtime-plugin-diagnostics"), { headers: context.headers })
     if (diagnostics.status >= 200 && diagnostics.status < 300) {
-      const normalized = collectRuntimeDiagnostics(pluginId, diagnostics.body)
+      const normalized = collectRuntimeDiagnostics(context.pluginId, diagnostics.body)
       reloadErrors.push(...normalized.events)
       revision = normalized.revision
     } else if (diagnostics.status !== 404) {
@@ -233,7 +290,7 @@ export async function runPluginSelfTest(options: RunPluginSelfTestOptions): Prom
   } catch {
     // Optional endpoint. Workspace playground hosts can still decide by pane status.
   }
-  reloadErrors.push(...await maybeReadPluginError(baseUrl, pluginId, headers))
+  reloadErrors.push(...await maybeReadPluginError(context.baseUrl, context.pluginId, context.headers))
 
   const start = Date.now()
   let lastOpenAt = 0
@@ -241,16 +298,33 @@ export async function runPluginSelfTest(options: RunPluginSelfTestOptions): Prom
   let lastStatus: Record<string, unknown> | undefined
   let openErrors: SelfTestEvent[] = []
 
-  while (Date.now() - start <= timeoutMs) {
-    const status = await pollPaneStatus({ baseUrl, headers, workspaceId, pluginId, panelId, panelInstanceId, minReportedAtMs: start })
+  while (Date.now() - start <= context.timeoutMs) {
+    const status = await pollPaneStatus({
+      baseUrl: context.baseUrl,
+      headers: context.headers,
+      workspaceId: context.workspaceId,
+      pluginId: context.pluginId,
+      panelId: context.panelId,
+      panelInstanceId: context.panelInstanceId,
+      minReportedAtMs: start,
+    })
     lastState = status.state
     lastStatus = status.status
     if (status.state === "no-browser-connected") {
-      return buildResult({ pluginId, workspaceId, revision, reloadErrors, panelId, panelInstanceId, state: "no-browser-connected", status: lastStatus })
+      return buildResult({
+        pluginId: context.pluginId,
+        workspaceId: context.workspaceId,
+        revision,
+        reloadErrors,
+        panelId: context.panelId,
+        panelInstanceId: context.panelInstanceId,
+        state: "no-browser-connected",
+        status: lastStatus,
+      })
     }
     if (status.state === "ready" || status.state === "error") break
     if (Date.now() - lastOpenAt >= POLL_MS) {
-      openErrors = await openPanel({ baseUrl, headers, pluginId, panelId, panelInstanceId })
+      openErrors = await openPanel(context)
       lastOpenAt = Date.now()
     }
     await new Promise((resolve) => setTimeout(resolve, POLL_MS))
@@ -258,7 +332,16 @@ export async function runPluginSelfTest(options: RunPluginSelfTestOptions): Prom
 
   if (openErrors.length > 0) reloadErrors.push(...openErrors)
   const finalState = lastState === "ready" || lastState === "error" ? lastState : "timeout"
-  return buildResult({ pluginId, workspaceId, revision, reloadErrors, panelId, panelInstanceId, state: finalState, status: lastStatus })
+  return buildResult({
+    pluginId: context.pluginId,
+    workspaceId: context.workspaceId,
+    revision,
+    reloadErrors,
+    panelId: context.panelId,
+    panelInstanceId: context.panelInstanceId,
+    state: finalState,
+    status: lastStatus,
+  })
 }
 
 function buildResult(args: {
@@ -293,6 +376,127 @@ function buildResult(args: {
   }
 }
 
+async function captureArtifacts(result: SelfTestResult, context: SelfTestRunContext, options: RunPluginSelfTestOptions): Promise<PluginTestArtifacts> {
+  const mode = artifactMode(options)
+  const rootDir = resolve(options.artifactsDir ?? defaultArtifactsRoot(context.pluginId), timestampDirName())
+  const consoleEntries: BrowserConsoleEntry[] = []
+  const failedRequests: BrowserFailedRequestEntry[] = []
+  const files: PluginTestArtifactFiles = {}
+
+  try {
+    await mkdir(rootDir, { recursive: true })
+    const { chromium } = await import("playwright")
+    const browser = await chromium.launch({ headless: !options.open })
+    const page = await browser.newPage()
+
+    page.on("console", (message) => {
+      const location = message.location()
+      consoleEntries.push({
+        type: message.type(),
+        text: truncateMessage(message.text()),
+        location: {
+          ...(location.url ? { url: location.url } : {}),
+          ...(location.lineNumber ? { lineNumber: location.lineNumber } : {}),
+          ...(location.columnNumber ? { columnNumber: location.columnNumber } : {}),
+        },
+        timestamp: new Date().toISOString(),
+      })
+    })
+    page.on("requestfailed", (request) => {
+      failedRequests.push({
+        url: request.url(),
+        method: request.method(),
+        failureText: request.failure()?.errorText,
+        timestamp: new Date().toISOString(),
+      })
+    })
+    page.on("response", (response) => {
+      if (response.status() < 400) return
+      failedRequests.push({
+        url: response.url(),
+        method: response.request().method(),
+        status: response.status(),
+        statusText: response.statusText(),
+        timestamp: new Date().toISOString(),
+      })
+    })
+
+    await page.goto(context.baseUrl, { waitUntil: "load", timeout: context.timeoutMs })
+    await page.waitForTimeout(500)
+
+    const selector = `[data-boring-panel-instance-id="${context.panelInstanceId}"]`
+    const fallbackSelector = `[data-boring-panel-id="${context.panelId}"]`
+    const locator = page.locator(selector)
+    const fallbackLocator = page.locator(fallbackSelector)
+    const target = await locator.count() > 0 ? locator : fallbackLocator
+
+    const appPath = join(rootDir, "app.png")
+    await page.screenshot({ path: appPath, fullPage: true })
+    files.appPng = appPath
+
+    if (await target.count() > 0) {
+      const panelPath = join(rootDir, "panel.png")
+      await target.first().screenshot({ path: panelPath })
+      files.panelPng = panelPath
+    }
+
+    const consolePath = join(rootDir, "console.json")
+    await writeFile(consolePath, `${JSON.stringify(consoleEntries, null, 2)}\n`, "utf8")
+    files.consoleJson = consolePath
+
+    const networkPath = join(rootDir, "network.json")
+    await writeFile(networkPath, `${JSON.stringify(failedRequests, null, 2)}\n`, "utf8")
+    files.networkJson = networkPath
+
+    const statusPath = join(rootDir, "status.json")
+    await writeFile(statusPath, `${JSON.stringify(result, null, 2)}\n`, "utf8")
+    files.statusJson = statusPath
+
+    if (options.open) {
+      await page.waitForTimeout(context.timeoutMs)
+    }
+
+    await browser.close()
+    return { attempted: true, saved: true, mode, dir: rootDir, files }
+  } catch (error) {
+    const statusPath = join(rootDir, "status.json")
+    try {
+      await mkdir(rootDir, { recursive: true })
+      await writeFile(statusPath, `${JSON.stringify(result, null, 2)}\n`, "utf8")
+      files.statusJson = statusPath
+    } catch {
+      // best effort
+    }
+    return {
+      attempted: true,
+      saved: Object.keys(files).length > 0,
+      mode,
+      ...(Object.keys(files).length > 0 ? { dir: rootDir, files } : {}),
+      captureError: event("CAPTURE_FAILED", error instanceof Error ? error.message : String(error)),
+    }
+  }
+}
+
+export async function runPluginSelfTest(options: RunPluginSelfTestOptions): Promise<SelfTestResult> {
+  const pluginId = options.pluginId.trim()
+  if (!pluginId) throw new Error("plugin id is required")
+  const baseUrl = normalizeBaseUrl(inferSelfTestUrl(options.url))
+  const workspaceId = inferSelfTestWorkspaceId(options.workspaceId) ?? await inferWorkspaceIdFromMeta(baseUrl)
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const panelId = buildPanelId(pluginId, options.panelId)
+  const panelInstanceId = buildPanelInstanceId(pluginId, panelId)
+  const headers = workspaceHeaders(workspaceId)
+  const context: SelfTestRunContext = { pluginId, baseUrl, workspaceId, timeoutMs, panelId, panelInstanceId, headers }
+
+  let result = await executeSelfTest(context)
+  const shouldCapture = options.screenshot || options.open || !result.ok
+  if (shouldCapture) {
+    const artifacts = await captureArtifacts(result, context, options)
+    result = { ...result, artifacts }
+  }
+  return result
+}
+
 export function formatSelfTestResult(result: SelfTestResult): string {
   const lines = [
     result.ok ? `OK ${result.pluginId}` : `FAIL ${result.pluginId}`,
@@ -301,6 +505,8 @@ export function formatSelfTestResult(result: SelfTestResult): string {
   if (result.revision !== undefined) lines.push(`  revision ${result.revision}`)
   for (const item of result.reloadErrors) lines.push(`  reload   ${item.code}: ${item.message}`)
   if (result.pane.error) lines.push(`  pane     ${result.pane.error.code}: ${result.pane.error.message}`)
+  if (result.artifacts?.dir) lines.push(`  artifacts ${result.artifacts.dir}`)
+  if (result.artifacts?.captureError) lines.push(`  artifacts ${result.artifacts.captureError.code}: ${result.artifacts.captureError.message}`)
   if (result.pane.state === "no-browser-connected") {
     lines.push(`  hint     open the workspace UI, then rerun boring-ui-plugin test ${result.pluginId}`)
   }

--- a/packages/plugin-cli/tsup.config.ts
+++ b/packages/plugin-cli/tsup.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   dts: true,
   sourcemap: false,
   clean: true,
+  external: ["playwright"],
 })

--- a/packages/workspace/src/front/registry/PanelRenderStatusBoundary.tsx
+++ b/packages/workspace/src/front/registry/PanelRenderStatusBoundary.tsx
@@ -108,6 +108,7 @@ export function PanelRenderStatusBoundary(props: PanelRenderStatusBoundaryProps)
     {
       className: "h-full min-h-0",
       "data-boring-plugin-id": props.pluginId,
+      "data-boring-panel-id": props.panelId,
       "data-boring-panel-component-id": props.panelId,
       ...(panelInstanceId ? { "data-boring-panel-instance-id": panelInstanceId } : {}),
       ...(props.revision !== undefined ? { "data-boring-plugin-revision": String(props.revision) } : {}),

--- a/packages/workspace/src/front/registry/__tests__/registry.test.tsx
+++ b/packages/workspace/src/front/registry/__tests__/registry.test.tsx
@@ -186,6 +186,23 @@ describe("PanelRegistry", () => {
     expect(await screen.findByText("lazy-two")).toBeInTheDocument()
     expect(screen.queryByText("lazy-one")).not.toBeInTheDocument()
   })
+
+  it("adds stable panel markers for plugin pane screenshots", async () => {
+    const reg = new PanelRegistry()
+    reg.register("chart-demo.panel", {
+      title: "Chart Demo",
+      pluginId: "chart-demo",
+      pluginRevision: 7,
+      component: () => <div>chart demo pane</div>,
+    })
+    const Panel = reg.getComponents()["chart-demo.panel"]
+    render(<Panel api={{ id: "self-test:chart-demo:chart-demo.panel" }} />)
+    const wrapper = screen.getByText("chart demo pane").closest("[data-boring-panel-id]")
+    expect(wrapper).toHaveAttribute("data-boring-panel-id", "chart-demo.panel")
+    expect(wrapper).toHaveAttribute("data-boring-plugin-id", "chart-demo")
+    expect(wrapper).toHaveAttribute("data-boring-panel-instance-id", "self-test:chart-demo:chart-demo.panel")
+    expect(wrapper).toHaveAttribute("data-boring-plugin-revision", "7")
+  })
 })
 
 // --- Surface resolver routing ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,6 +577,9 @@ importers:
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.17
+      playwright:
+        specifier: ^1.59.1
+        version: 1.59.1
       tsup:
         specifier: ^8.4.0
         version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@22.19.17))(jiti@2.7.0)(postcss@8.5.13)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)


### PR DESCRIPTION
Closes #173.

## What changed
- add `--open`, `--screenshot`, and `--artifacts-dir` to `boring-ui-plugin test`
- capture browser artifacts for plugin test runs using Playwright
- save failure artifacts by default and success artifacts when `--screenshot` is used
- add stable `data-boring-panel-id` marker on workspace panel wrappers
- cover artifact fallback + panel marker behavior with tests

## Verification
- `pnpm --filter @hachej/boring-ui-plugin-cli build`
- `cd packages/plugin-cli && pnpm exec vitest run src/__tests__/testPlugin.test.ts src/__tests__/pluginCli.test.ts`
- `pnpm --filter @hachej/boring-ui-kit build`
- `pnpm --filter @hachej/boring-workspace exec vitest run src/front/registry/__tests__/registry.test.tsx`

## Notes
- default mode still uses the existing pane-status route/oracle for pass/fail
- artifact capture is additive and does not install plugin-local dependencies
