### PR TITLE
docs(pi): clarify new plugin requests

### DIFF
--- a/packages/pi/skills/boring-plugin-authoring/SKILL.md
+++ b/packages/pi/skills/boring-plugin-authoring/SKILL.md
@@ -5,6 +5,27 @@ description: Create, extend, or update boring-ui workspace plugins, including ho
 
 # Boring Plugin Authoring
 
+## STEP -1 — Clarify vague new-plugin requests
+
+When the user asks for a **new plugin** but the request is broad or underspecified
+(e.g. "make me a plugin", "build a dashboard plugin", "make this plugin UI more complex"),
+ask for the missing product details **before scaffolding or editing**. Do not silently
+invent the domain, data source, navigation behavior, or visual direction.
+
+If the `ask_user` tool is installed, prefer it for this clarification so the user gets
+a structured form in the Workspace Questions pane. Ask only for decisions that affect
+implementation, such as:
+
+- plugin purpose and target user
+- data source or sample data to use
+- whether it needs a persistent left tab, a slash command, a file opener/surface resolver, or some combination
+- main panels/views to include
+- desired visual tone and complexity
+- any must-have interactions or constraints
+
+If `ask_user` is not available, ask the same concise questions in chat. Once the user
+answers, proceed to STEP 0.
+
 ## STEP 0 — Always scaffold first
 
 Don't write plugin files from scratch. The CLI scaffold produces a known-correct

--- a/packages/pi/skills/boring-plugin-authoring/SKILL.md
+++ b/packages/pi/skills/boring-plugin-authoring/SKILL.md
@@ -22,9 +22,13 @@ implementation, such as:
 - main panels/views to include
 - desired visual tone and complexity
 - any must-have interactions or constraints
+- a final free-text `remarks` / `notes` field for anything the structured fields missed
 
-If `ask_user` is not available, ask the same concise questions in chat. Once the user
-answers, proceed to STEP 0.
+When using `ask_user`, always include that final `remarks` field as a `textarea` at
+the end of the form. It can be optional, but it must be present.
+
+If `ask_user` is not available, ask the same concise questions in chat and include a
+final "Anything else / remarks?" question. Once the user answers, proceed to STEP 0.
 
 ## STEP 0 — Always scaffold first
 
@@ -230,6 +234,19 @@ Notes:
 
 Plugins have three different navigation surfaces. Pick the one that matches the
 user intent; do not register all of them by default.
+
+**Left pane vs main pane rule:** if a plugin has a persistent `leftTabs` entry
+and a main workbench panel, create **two separate components**:
+
+- `LeftPane` / sidebar component: compact navigator, filters, summaries, recent
+  items, buttons, and quick actions. It lives in the narrow left workbench.
+- `MainPane` / center component: full detail view with tables, charts, editors,
+  previews, and multi-step workflows.
+
+Do **not** register the same full `MainPane` component as both `panels[].component`
+and `leftTabs[].panelId`. That duplicates the center UI in the narrow sidebar and
+makes plugins feel broken. Left-pane buttons can open the center pane with
+`PaneProps.containerApi.addPanel({ id, component: "<plugin>.panel", title, params })`.
 
 | User intent | Use | Why |
 |---|---|---|

--- a/packages/plugin-cli/templates/front-canonical.tsx
+++ b/packages/plugin-cli/templates/front-canonical.tsx
@@ -1,14 +1,14 @@
-// CANONICAL front/index.tsx for a boring-ui plugin.
+// CANONICAL front/index.tsx for a boring-ui runtime plugin.
 // Copy this shape — replace <kebab-name> and <Label>.
 //
-// definePlugin takes a single DECLARATIVE config object. For
-// conditional registration or runtime branching that the declarative
-// fields can't express, use the optional `setup: (api) => void`
-// escape hatch — it runs LAST, after every declarative field has
-// been registered.
+// Structure rule:
+// - Commands open full-size center panes for detailed work.
+// - Left tabs are compact, persistent sidebar/navigator panes.
+// - If a plugin has both, do NOT render the same component in both places.
+//   Register a small LeftPane and a separate MainPane.
 
 import React from "react"
-import { definePlugin } from "@hachej/boring-workspace/plugin"
+import { definePlugin, type PaneProps } from "@hachej/boring-workspace/plugin"
 import {
   Badge,
   Button,
@@ -22,31 +22,103 @@ import {
   ToolbarGroup,
 } from "@hachej/boring-ui-kit"
 
-function MyPane() {
+const MAIN_PANEL_ID = "<kebab-name>.panel"
+const LEFT_PANEL_ID = "<kebab-name>.left"
+
+function MainPane() {
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col bg-background text-foreground">
       <Toolbar className="border-b border-border px-3 py-2">
         <ToolbarGroup>
           <Badge variant="secondary">Runtime plugin</Badge>
+          <Badge variant="outline"><Label></Badge>
+        </ToolbarGroup>
+        <ToolbarGroup className="ml-auto">
+          <Button size="sm" variant="secondary">Refresh</Button>
         </ToolbarGroup>
       </Toolbar>
 
       <div className="min-h-0 min-w-0 flex-1 overflow-auto p-4">
-        <Card>
-          <CardHeader>
-            <CardTitle><Label></CardTitle>
-            <CardDescription>
-              Replace this scaffold with the plugin's real workspace UI.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <EmptyState
-              title="Nothing to show yet"
-              description="Connect data, register a surface resolver, or add actions for this plugin."
-              actions={<Button size="sm">Primary action</Button>}
-            />
-          </CardContent>
-        </Card>
+        <div className="grid min-w-0 gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+          <Card className="min-w-0">
+            <CardHeader>
+              <CardTitle><Label></CardTitle>
+              <CardDescription>
+                This is the full center pane. Put detailed views, tables, charts,
+                editors, previews, and multi-step workflows here.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <EmptyState
+                title="Nothing to show yet"
+                description="Connect data, register a surface resolver, or add actions for this plugin."
+                actions={<Button size="sm">Primary action</Button>}
+              />
+            </CardContent>
+          </Card>
+
+          <Card className="min-w-0">
+            <CardHeader>
+              <CardTitle className="text-sm">Details</CardTitle>
+              <CardDescription>Use side cards for metadata or secondary controls.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-2 text-sm text-muted-foreground">
+                <div className="flex items-center justify-between gap-3">
+                  <span>Status</span>
+                  <Badge variant="outline">Ready</Badge>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span>Items</span>
+                  <span>0</span>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function LeftPane({ containerApi }: PaneProps) {
+  const openMainPane = () => {
+    containerApi.addPanel({
+      id: `${MAIN_PANEL_ID}.from-left`,
+      component: MAIN_PANEL_ID,
+      title: "<Label>",
+      params: { source: "left-tab" },
+    })
+  }
+
+  return (
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-background text-foreground">
+      <div className="border-b border-border/60 px-3 py-2">
+        <div className="text-sm font-medium"><Label></div>
+        <div className="text-xs text-muted-foreground">Compact sidebar navigator</div>
+      </div>
+
+      <div className="min-h-0 min-w-0 flex-1 overflow-auto p-3">
+        <div className="space-y-3">
+          <Card className="min-w-0">
+            <CardHeader className="space-y-1 p-3">
+              <CardTitle className="text-sm">Overview</CardTitle>
+              <CardDescription className="text-xs">
+                Keep left tabs small: summary, filters, navigation, and actions.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="p-3 pt-0">
+              <Button size="sm" className="w-full" onClick={openMainPane}>
+                Open main pane
+              </Button>
+            </CardContent>
+          </Card>
+
+          <div className="space-y-1 text-xs text-muted-foreground">
+            <div className="rounded-md border border-border bg-card px-2 py-1.5">Recent item</div>
+            <div className="rounded-md border border-border bg-card px-2 py-1.5">Saved filter</div>
+          </div>
+        </div>
       </div>
     </div>
   )
@@ -56,20 +128,23 @@ export default definePlugin({
   id: "<kebab-name>",              // contribution namespace; matching package name is recommended
   label: "<Label>",
   panels: [
-    { id: "<kebab-name>.panel", label: "<Label>", component: MyPane },
+    { id: MAIN_PANEL_ID, label: "<Label>", component: MainPane },
+    // Optional left-tab component. Register separately from the main panel so
+    // the sidebar does not duplicate a full workbench view.
+    { id: LEFT_PANEL_ID, label: "<Label>", component: LeftPane },
   ],
   commands: [
-    { id: "<kebab-name>.open", title: "Open <Label>", panelId: "<kebab-name>.panel" },
+    { id: "<kebab-name>.open", title: "Open <Label>", panelId: MAIN_PANEL_ID },
   ],
-  // Do not add leftTabs by default: left tabs are persistent sidebar
-  // navigation. Use them only for always-on tools/catalogs that deserve a
-  // permanent sidebar entry; file visualizers should use surfaceResolvers.
-  // Keep left-tab panes responsive too: use min-w-0 + overflow-auto, and use
-  // containerApi.addPanel(...) from PaneProps when a sidebar button should open
-  // a center workbench pane.
+  // Do not add leftTabs just because a plugin has a panel. A left tab is a
+  // permanent sidebar category. Keep it compact, and use its buttons/rows to
+  // open the full center panel via containerApi.addPanel(...).
+  //
+  // If this plugin should have persistent sidebar navigation, uncomment this:
   // leftTabs: [
-  //   { id: "<kebab-name>.tab", title: "<Label>", panelId: "<kebab-name>.panel" },
+  //   { id: "<kebab-name>.tab", title: "<Label>", panelId: LEFT_PANEL_ID },
   // ],
+  //
   // File visualizer example: import WORKSPACE_OPEN_PATH_SURFACE_KIND from
   // "@hachej/boring-workspace/plugin", import useApiBaseUrl/useWorkspaceRequestId
   // from "@hachej/boring-workspace", set kind: WORKSPACE_OPEN_PATH_SURFACE_KIND,


### PR DESCRIPTION
## Summary

- Add a pre-scaffold clarification step to the boring plugin authoring skill.
- Tell agents to ask for missing product details before creating vague new plugins.
- Prefer the `ask_user` tool when installed, falling back to chat questions.
- Require a final free-text `remarks`/`notes` field in clarification forms.
- Clarify plugin structure: compact left pane/sidebar component vs full center/main pane component.
- Update the runtime plugin scaffold to model separate `LeftPane` and `MainPane` components instead of implying the same panel should be reused for both.

## Testing

- `PATH=/home/ubuntu/projects/boring-ui-v2/node_modules/.bin:$PATH pnpm --filter @hachej/boring-ui-plugin-cli run test src/__tests__/pluginCli.test.ts --reporter=verbose`
