### PR TITLE
fix(ask-user): make questions pane scroll and submit on enter

### DIFF
--- a/packages/agent/src/front/ChatPanel.tsx
+++ b/packages/agent/src/front/ChatPanel.tsx
@@ -49,7 +49,7 @@ import {
   AttachmentInfo,
   AttachmentRemove,
 } from './primitives/attachments'
-import { PaperclipIcon, CopyIcon, CheckIcon, RefreshCwIcon, Loader2, AlertCircleIcon, XIcon } from 'lucide-react'
+import { PaperclipIcon, CopyIcon, CheckIcon, RefreshCwIcon, Loader2, AlertCircleIcon, XIcon, SquareArrowOutUpRight } from 'lucide-react'
 import {
   Button,
   IconButton,
@@ -547,11 +547,14 @@ export function ChatPanel(props: ChatPanelProps) {
   const runtimeDependenciesNotice = composerNoticeForRuntimeDependencies(workspaceWarmupStatus)
   const composerStatusNotice = composerRuntimeNotice ?? runtimeErrorNotice ?? warmupNotice ?? runtimeDependenciesNotice
   const workspaceWarmupBlocked = Boolean(warmupNotice)
-  const composerBlocked = workspaceWarmupBlocked || composerBlockers.length > 0
+  const hostComposerBlocked = composerBlockers.length > 0
+  const composerBlocked = workspaceWarmupBlocked || hostComposerBlocked
   const primaryComposerBlocker = composerBlockers[0]
   const composerBlockerLabel = workspaceWarmupBlocked
     ? (warmupNotice?.title ?? 'Preparing workspace…')
     : primaryComposerBlocker?.label ?? 'Complete the pending workspace action to continue.'
+  const composerSubmitStatus = hostComposerBlocked && !workspaceWarmupBlocked ? 'streaming' : status
+  const activityBadgeLabel = hostComposerBlocked && !workspaceWarmupBlocked ? 'Waiting for your answer…' : 'Working…'
 
   const registry = useMemo(
     () => {
@@ -751,11 +754,15 @@ export function ChatPanel(props: ChatPanelProps) {
   const emptyHero = emptyPlacement === 'hero' && renderMessages.length === 0 && !hydratingMessages
 
   // Stop button: cancels stream, clears the queued follow-up, and lets host UI
-  // cancel any host-level blocker that is waiting for user attention.
+  // cancel any host-level blocker that is waiting for user attention. When the
+  // stop affordance is shown only because a host blocker (for example ask_user)
+  // is pending, do not abort the agent stream: cancelling the blocker lets the
+  // tool resolve and update its card out of Running state.
   const handleStop = useCallback(() => {
     onComposerStop?.()
+    if (hostComposerBlocked && !workspaceWarmupBlocked) return
     stopAndClearFollowUps()
-  }, [onComposerStop, stopAndClearFollowUps])
+  }, [hostComposerBlocked, onComposerStop, stopAndClearFollowUps, workspaceWarmupBlocked])
 
   // Escape: interrupts the stream but keeps the queued message — it auto-sends next.
   // Same behaviour as pi's keyboard interrupt: "stop this, do my follow-up instead."
@@ -1391,7 +1398,7 @@ export function ChatPanel(props: ChatPanelProps) {
       <div className={cn(chrome ? "px-4 pb-4 pt-2 sm:px-6 sm:pb-5" : "px-3 pb-3 pt-1")}>
         {/* Working… badge. Unmount when idle so restored completed chats do not
             expose stale live-region text to screen readers or text extraction. */}
-        {isStreaming && (
+        {(isStreaming || (hostComposerBlocked && !workspaceWarmupBlocked)) && (
           <div
             className={cn(
               "mx-auto mb-2 w-full overflow-hidden transition-all duration-300 max-h-8",
@@ -1412,7 +1419,7 @@ export function ChatPanel(props: ChatPanelProps) {
                 animate={{ opacity: [0.35, 1, 0.35] }}
                 transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
               />
-              <span>Working…</span>
+              <span>{activityBadgeLabel}</span>
             </div>
           </div>
         )}
@@ -1444,21 +1451,29 @@ export function ChatPanel(props: ChatPanelProps) {
             role="status"
             aria-live="polite"
             className={cn(
-              "mx-auto mb-2 w-full max-w-3xl rounded-[var(--radius-md)] border border-primary/30 bg-primary/10",
+              "mx-auto mb-2 w-full rounded-[var(--radius-md)] border border-primary/30 bg-primary/10",
               "px-3 py-2 text-xs text-foreground",
+              chrome ? "max-w-3xl" : "max-w-[680px]",
             )}
           >
-            <span>{composerBlockerLabel}</span>
-            {primaryComposerBlocker?.actions?.map((action) => (
-              <button
-                key={action.id}
-                type="button"
-                className="ml-2 rounded border border-primary/30 px-2 py-0.5 text-[11px] font-medium hover:bg-primary/10"
-                onClick={() => onComposerBlockerAction?.(primaryComposerBlocker, action.id)}
-              >
-                {action.label}
-              </button>
-            ))}
+            <div className="flex items-center gap-2">
+              <span className="min-w-0 flex-1 truncate">{composerBlockerLabel}</span>
+              {primaryComposerBlocker?.actions?.map((action) => {
+                const ActionIcon = action.id === 'open' ? SquareArrowOutUpRight : action.id === 'cancel' ? XIcon : null
+                return (
+                  <button
+                    key={action.id}
+                    type="button"
+                    aria-label={action.label}
+                    title={action.label}
+                    className="inline-flex size-6 shrink-0 items-center justify-center rounded border border-primary/30 text-primary hover:bg-primary/10"
+                    onClick={() => onComposerBlockerAction?.(primaryComposerBlocker, action.id)}
+                  >
+                    {ActionIcon ? <ActionIcon aria-hidden="true" className="size-3.5" /> : <span className="px-1 text-[11px] font-medium">{action.label}</span>}
+                  </button>
+                )
+              })}
+            </div>
           </div>
         )}
         {hotReloadEnabled && (
@@ -1599,9 +1614,9 @@ export function ChatPanel(props: ChatPanelProps) {
                 <div className="ml-1 flex items-center gap-1.5">
                   <KbdHints />
                   <PromptInputSubmit
-                    status={status}
+                    status={composerSubmitStatus}
                   onStop={handleStop}
-                  disabled={composerBlocked && !isStreaming}
+                  disabled={workspaceWarmupBlocked}
                   className={cn(
                     // Primary action. Uses the warm accent (not `primary`,
                     // which is a neutral foreground tone) — this is the one

--- a/packages/agent/src/front/__tests__/ChatPanel.test.tsx
+++ b/packages/agent/src/front/__tests__/ChatPanel.test.tsx
@@ -70,7 +70,7 @@ vi.mock('../primitives/prompt-input', () => ({
     return <textarea data-testid="prompt-textarea" defaultValue={props.defaultValue} />
   },
   PromptInputFooter: ({ children }: any) => <div data-testid="prompt-footer">{children}</div>,
-  PromptInputSubmit: ({ status }: any) => <div data-testid="prompt-submit" data-status={status} />,
+  PromptInputSubmit: ({ status, disabled, onStop }: any) => <button data-testid="prompt-submit" data-status={status} disabled={disabled} onClick={onStop} />,
   usePromptInputAttachments: (...args: unknown[]) => mockUseAttachments(...args),
 }))
 
@@ -1087,6 +1087,54 @@ describe('ChatPanel (shadcn)', () => {
 
     const html = renderToStaticMarkup(<ChatPanel sessionId="sess-stream" />)
     expect(html).toContain('data-status="streaming"')
+  })
+
+  test('host composer blocker turns submit into stop and shows waiting copy', () => {
+    mockUseAgentChat.mockReturnValue({
+      messages: [],
+      sendMessage: mockSendMessage,
+      setMessages: mockSetMessages,
+      stop: mockStop,
+      status: 'ready',
+      error: undefined,
+    })
+
+    const html = renderToStaticMarkup(
+      <ChatPanel
+        sessionId="sess-question"
+        chrome={false}
+        composerBlockers={[{ id: 'question', reason: 'waiting_for_user_input', label: 'Waiting for your answer…', actions: [{ id: 'open', label: 'Open Questions' }, { id: 'cancel', label: 'Cancel question' }] }]}
+      />,
+    )
+    expect(html).toContain('Waiting for your answer…')
+    expect(html).toContain('max-w-[680px]')
+    expect(html).toContain('aria-label="Open Questions"')
+    expect(html).toContain('aria-label="Cancel question"')
+    expect(html).toContain('data-status="streaming"')
+    expect(html).not.toContain('data-testid="prompt-submit" disabled=""')
+  })
+
+  test('host composer blocker stop button notifies the host', () => {
+    const onComposerStop = vi.fn()
+    mockUseAgentChat.mockReturnValue({
+      messages: [],
+      sendMessage: mockSendMessage,
+      setMessages: mockSetMessages,
+      stop: mockStop,
+      status: 'ready',
+      error: undefined,
+    })
+
+    render(
+      <ChatPanel
+        sessionId="sess-question-stop"
+        composerBlockers={[{ id: 'question', reason: 'waiting_for_user_input', label: 'Waiting for your answer…' }]}
+        onComposerStop={onComposerStop}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('prompt-submit'))
+    expect(onComposerStop).toHaveBeenCalledOnce()
+    expect(mockStop).not.toHaveBeenCalled()
   })
 
   test('Escape stops active streaming from a workspace target', () => {

--- a/plugins/ask-user/src/front/index.tsx
+++ b/plugins/ask-user/src/front/index.tsx
@@ -82,7 +82,7 @@ function AskUserProvider({ apiBaseUrl, authHeaders, children }: PluginProviderPr
         target: pending.questionId,
         label: "Answer the question in Questions to continue",
         sessionId: sessionScopedBlockerId(pending.sessionId),
-        actions: [{ id: "open", label: "Open Questions" }],
+        actions: [{ id: "open", label: "Open Questions" }, { id: "cancel", label: "Cancel question" }],
       })
     }
     return () => { if (blockerId) removeBlocker(blockerId) }
@@ -151,8 +151,8 @@ function QuestionsPane({ api, params, className }: PaneProps<QuestionsPaneParams
     if (question && pending === null && !paramQuestion) api.close()
   }, [api, pending, paramQuestion, question])
 
-  return <div className={className ?? "h-full"}>
-    <Pane className="h-full border-0 bg-background text-sm">
+  return <div className={className ? `${className} min-h-0` : "h-full min-h-0"}>
+    <Pane className="h-full min-h-0 overflow-hidden border-0 bg-background text-sm">
       <PaneHeader className="border-b bg-background/95">
         <div>
           <PaneTitle className="flex items-center gap-2"><HelpCircle className="h-4 w-4 text-muted-foreground" /> Agent needs input</PaneTitle>
@@ -171,7 +171,7 @@ function QuestionsPane({ api, params, className }: PaneProps<QuestionsPaneParams
           catch (err) { setError(err instanceof QuestionsClientError ? err.message : String(err)) }
           finally { setSubmitting(false) }
         }}>
-          <QuestionForm>
+          <QuestionForm className="flex min-h-0 flex-1 flex-col">
             <PaneBody className="overflow-auto p-4">
               <div className="space-y-4">
                 <section className="rounded-md border border-border/60 bg-muted/30 p-4">

--- a/plugins/ask-user/src/front/primitives/QuestionForm.tsx
+++ b/plugins/ask-user/src/front/primitives/QuestionForm.tsx
@@ -124,15 +124,26 @@ export function QuestionFormProvider({
   return <QuestionFormContext.Provider value={value}>{children}</QuestionFormContext.Provider>
 }
 
-export function QuestionForm({ children, "aria-label": ariaLabel = "Question form" }: React.PropsWithChildren<{ "aria-label"?: string }>) {
+export function QuestionForm({ children, "aria-label": ariaLabel = "Question form", className }: React.PropsWithChildren<{ "aria-label"?: string; className?: string }>) {
   const { submit, cancel, status, formRef } = useQuestionForm()
-  return <form ref={formRef} data-question-form aria-label={ariaLabel} onSubmit={(event) => { event.preventDefault(); void submit() }} onKeyDown={(event) => {
-    if ((event.metaKey || event.ctrlKey) && event.key === "Enter") { event.preventDefault(); void submit() }
+  return <form ref={formRef} data-question-form aria-label={ariaLabel} className={className} onSubmit={(event) => { event.preventDefault(); void submit() }} onKeyDown={(event) => {
+    if (event.key === "Enter" && shouldSubmitOnEnter(event)) { event.preventDefault(); void submit() }
     if (event.key === "Escape") { event.preventDefault(); cancel() }
   }}>
     <div aria-live="polite" className="sr-only">{status === "ready" ? "Question ready" : `Question ${status}`}</div>
     {children}
   </form>
+}
+
+function shouldSubmitOnEnter(event: React.KeyboardEvent<HTMLFormElement>): boolean {
+  if (event.metaKey || event.ctrlKey) return true
+  if (event.shiftKey) return false
+  const target = event.target as HTMLElement | null
+  if (!target) return true
+  const tagName = target.tagName.toLowerCase()
+  if (tagName === "textarea" || tagName === "button" || tagName === "a") return false
+  if (target.isContentEditable) return false
+  return true
 }
 
 export function QuestionFields() {

--- a/plugins/ask-user/src/front/primitives/__tests__/QuestionForm.test.tsx
+++ b/plugins/ask-user/src/front/primitives/__tests__/QuestionForm.test.tsx
@@ -13,9 +13,9 @@ const allFields: AskUserFormSchema = { wireVersion: 1, fields: [
   { type: "number", name: "num", label: "Num", min: 1, max: 5, integer: true },
 ] }
 
-function Form(props: { schema?: AskUserFormSchema; onSubmit?: (values: any) => void; onCancel?: () => void; registry?: any }) {
+function Form(props: { schema?: AskUserFormSchema; onSubmit?: (values: any) => void; onCancel?: () => void; registry?: any; formClassName?: string }) {
   return <QuestionFormProvider schema={props.schema} rendererRegistry={props.registry} onSubmit={props.onSubmit} onCancel={props.onCancel}>
-    <QuestionForm><QuestionFields /><QuestionSubmitButton /><QuestionCancelButton /></QuestionForm>
+    <QuestionForm className={props.formClassName}><QuestionFields /><QuestionSubmitButton /><QuestionCancelButton /></QuestionForm>
   </QuestionFormProvider>
 }
 
@@ -49,10 +49,19 @@ describe("QuestionForm primitives", () => {
     fireEvent.change(screen.getByRole("combobox"), { target: { value: "a" } })
     fireEvent.click(screen.getByLabelText(/X/))
     fireEvent.change(screen.getByLabelText(/Num/), { target: { value: "2" } })
-    fireEvent.keyDown(screen.getByRole("form", { name: "Question form" }), { key: "Enter", ctrlKey: true })
+    fireEvent.keyDown(screen.getByRole("form", { name: "Question form" }), { key: "Enter" })
     expect(submit).toHaveBeenCalled()
+    fireEvent.keyDown(screen.getByLabelText(/Area/), { key: "Enter" })
+    expect(submit).toHaveBeenCalledTimes(1)
+    fireEvent.keyDown(screen.getByLabelText(/Area/), { key: "Enter", ctrlKey: true })
+    expect(submit).toHaveBeenCalledTimes(2)
     fireEvent.keyDown(screen.getByRole("form", { name: "Question form" }), { key: "Escape" })
     expect(cancel).toHaveBeenCalled()
+  })
+
+  it("passes form layout classes through", () => {
+    render(<Form schema={allFields} formClassName="flex min-h-0 flex-1 flex-col" />)
+    expect(screen.getByRole("form", { name: "Question form" })).toHaveClass("flex", "min-h-0", "flex-1", "flex-col")
   })
 
   it("cancel button composes caller onClick without losing default cancel", () => {


### PR DESCRIPTION
## Summary
- make the Questions pane a bounded flex column so long forms scroll instead of getting cut off
- allow plain Enter to submit forms while preserving textarea newlines
- when a question blocks the composer, show “Waiting for your answer…” and turn the composer submit button into Stop
- make the pending-question banner match the composer width and use icon-only actions for open/cancel
- expose a Cancel question blocker action and keep composer Stop wired to cancel pending questions
- canceling a pending question no longer aborts the agent stream, so the ask_user tool card can leave Running state
- add regression coverage for keyboard submit, form layout, blocked-composer stop state, and blocker action icons

## Verification
- pnpm --filter @hachej/boring-agent run test src/front/__tests__/ChatPanel.test.tsx
- pnpm --filter @hachej/boring-ask-user run test src/front/primitives/__tests__/QuestionForm.test.tsx src/front/__tests__/askUserPlugin.test.tsx
- pnpm --filter @hachej/boring-agent run typecheck
- pnpm --filter @hachej/boring-ask-user run typecheck
- pnpm --filter @hachej/boring-agent run build
- pnpm --filter @hachej/boring-ask-user run build