### PR TITLE
feat: make assistant slash-command mentions clickable (#174)

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -1052,6 +1052,43 @@ export function PiChatPanel<
               onSuggestionSubmit={({ text, files, source }) => sendComposerMessage({ text, files, source })}
               onRestoreDraft={setComposerDraft}
               windowResetKey={activeSessionId}
+              availableCommands={allCommands.map(c => c.name)}
+              onMentionClick={(mention) => {
+                if (mention.kind === 'slash-command') {
+                  const cmdName = mention.value.replace('/', '')
+                  const command = registry.get(cmdName)
+                  if (command?.clickBehavior === 'execute') {
+                    // Run immediately
+                    void (async () => {
+                      if (!sessionId) return
+                      const currentSessionId = sessionId
+                      const ctx = {
+                        sessionId: currentSessionId,
+                        clearMessages: () => addLocalNotice({ id: `cmd-clear:${Date.now()}`, level: 'info' as const, text: 'Messages cleared', dismissible: true }),
+                        resetSession: () => {
+                          addLocalNotice({ id: `cmd-reset:${Date.now()}`, level: 'info' as const, text: 'Session reset', dismissible: true })
+                          if (onSessionReset) void onSessionReset()
+                        },
+                        listCommands: () => registry.list(),
+                        reloadAgentPlugins,
+                        openModelPicker: undefined,
+                        selectComposerModel: undefined,
+                        openThinkingPicker: undefined,
+                        selectComposerThinking: undefined,
+                        pluginUpdate: { run: runPluginUpdate },
+                      }
+                      const result = await Promise.resolve(command.handler('', ctx))
+                      if (typeof result === 'string') {
+                        addLocalNotice({ id: `cmd-result:${Date.now()}`, level: 'info' as const, text: result, dismissible: true })
+                      }
+                    })()
+                  } else if (command?.clickBehavior === 'insert' || !command?.clickBehavior) {
+                    // Insert into composer
+                    setComposerDraft(`/${cmdName} `, true)
+                  }
+                }
+                // TODO: Handle file-path, skill, and other mention kinds
+              }}
             />
 
             <PiChatComposerSurface

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -14,7 +14,7 @@ import type { AvailableModel, ModelSelection, ThinkingLevel } from '../chatPanel
 import { DEFAULT_THINKING } from '../chatPanelSettings'
 import { cn } from '../lib'
 import { defaultChatSuggestions, type ChatSuggestion } from '../ChatEmptyState'
-import type { SlashCommand } from '../slashCommands'
+import type { SlashCommand, SlashCommandContext, SlashCommandHandlerResult } from '../slashCommands'
 import { builtinCommands, createCommandRegistry } from '../slashCommands'
 import type { ToolRendererOverrides } from '../bareToolRenderers'
 import { mergeShadcnToolRenderers } from '../toolRenderers'
@@ -171,6 +171,12 @@ export interface PiChatPanelProps<
    * Lets a host attach a recovery action for a specific error code without the agent
    * knowing what the code means or what the action does. */
   renderNoticeAction?: (notice: PiChatRuntimeNotice) => ReactNode
+}
+
+function slashCommandResultMessage(result: SlashCommandHandlerResult): string | undefined {
+  if (typeof result === 'string') return result
+  if (result && typeof result === 'object' && typeof result.message === 'string') return result.message
+  return undefined
 }
 
 export function PiChatPanel<
@@ -1054,40 +1060,40 @@ export function PiChatPanel<
               windowResetKey={activeSessionId}
               availableCommands={allCommands.map(c => c.name)}
               onMentionClick={(mention) => {
-                if (mention.kind === 'slash-command') {
-                  const cmdName = mention.value.replace('/', '')
-                  const command = registry.get(cmdName)
-                  if (command?.clickBehavior === 'execute') {
-                    // Run immediately
-                    void (async () => {
-                      if (!sessionId) return
-                      const currentSessionId = sessionId
-                      const ctx = {
-                        sessionId: currentSessionId,
-                        clearMessages: () => addLocalNotice({ id: `cmd-clear:${Date.now()}`, level: 'info' as const, text: 'Messages cleared', dismissible: true }),
-                        resetSession: () => {
-                          addLocalNotice({ id: `cmd-reset:${Date.now()}`, level: 'info' as const, text: 'Session reset', dismissible: true })
-                          if (onSessionReset) void onSessionReset()
-                        },
-                        listCommands: () => registry.list(),
-                        reloadAgentPlugins,
-                        openModelPicker: undefined,
-                        selectComposerModel: undefined,
-                        openThinkingPicker: undefined,
-                        selectComposerThinking: undefined,
-                        pluginUpdate: { run: runPluginUpdate },
-                      }
-                      const result = await Promise.resolve(command.handler('', ctx))
-                      if (typeof result === 'string') {
-                        addLocalNotice({ id: `cmd-result:${Date.now()}`, level: 'info' as const, text: result, dismissible: true })
-                      }
-                    })()
-                  } else if (command?.clickBehavior === 'insert' || !command?.clickBehavior) {
-                    // Insert into composer
-                    setComposerDraft(`/${cmdName} `, true)
-                  }
+                if (mention.kind !== 'slash-command') return
+                const cmdName = mention.value.replace('/', '')
+                const command = registry.get(cmdName)
+                if (!command || command.clickBehavior === 'disabled') return
+                if (command.clickBehavior === 'insert') {
+                  setComposerDraft(`/${cmdName} `, true)
+                  return
                 }
-                // TODO: Handle file-path, skill, and other mention kinds
+                void (async () => {
+                  const currentSessionId = activeChatSessionId ?? activeSessionId ?? sessionId ?? 'default'
+                  const ctx: SlashCommandContext = {
+                    sessionId: currentSessionId,
+                    clearMessages: () => addLocalNotice({
+                      id: 'clear-not-supported',
+                      level: 'info',
+                      text: '/clear is not available in this chat panel.',
+                      dismissible: true,
+                    }),
+                    resetSession,
+                    listCommands: () => registry.list(),
+                    reloadAgentPlugins,
+                    pluginUpdate: { run: runPluginUpdate },
+                    openModelPicker,
+                    selectComposerModel,
+                    openThinkingPicker,
+                    selectComposerThinking,
+                  }
+                  const result = await Promise.resolve(command.handler('', ctx))
+                  const message = slashCommandResultMessage(result)
+                  if (message) {
+                    onCommandResult?.(message)
+                    addLocalNotice({ id: `command:${Date.now()}`, level: 'info', text: message, dismissible: true })
+                  }
+                })()
               }}
             />
 

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -14,7 +14,7 @@ import type { AvailableModel, ModelSelection, ThinkingLevel } from '../chatPanel
 import { DEFAULT_THINKING } from '../chatPanelSettings'
 import { cn } from '../lib'
 import { defaultChatSuggestions, type ChatSuggestion } from '../ChatEmptyState'
-import type { SlashCommand, SlashCommandContext, SlashCommandHandlerResult } from '../slashCommands'
+import type { SlashCommand } from '../slashCommands'
 import { builtinCommands, createCommandRegistry } from '../slashCommands'
 import type { ToolRendererOverrides } from '../bareToolRenderers'
 import { mergeShadcnToolRenderers } from '../toolRenderers'
@@ -25,6 +25,7 @@ import { useComposerPickers } from '../useComposerPickers'
 import { useChatModelSelection } from '../hooks/useChatModelSelection'
 import { useServerCommands } from '../hooks/useServerCommands'
 import { useAttachmentNotice } from '../hooks/useAttachmentNotice'
+import { useSlashCommandUi } from './useSlashCommandUi'
 import {
   composerNoticeForRuntimeDependencies,
   composerNoticeForWarmup,
@@ -171,12 +172,6 @@ export interface PiChatPanelProps<
    * Lets a host attach a recovery action for a specific error code without the agent
    * knowing what the code means or what the action does. */
   renderNoticeAction?: (notice: PiChatRuntimeNotice) => ReactNode
-}
-
-function slashCommandResultMessage(result: SlashCommandHandlerResult): string | undefined {
-  if (typeof result === 'string') return result
-  if (result && typeof result === 'object' && typeof result.message === 'string') return result.message
-  return undefined
 }
 
 export function PiChatPanel<
@@ -410,6 +405,7 @@ export function PiChatPanel<
     enabled: serverResourcesEnabled,
   })
   const allCommands = useMemo(() => registry.list(), [registry, commandsStamp])
+  const availableCommandNames = useMemo(() => allCommands.map((command) => command.name), [allCommands])
 
   const activeChatSessionId = selectedChatState?.sessionId
   const warmupNotice = composerNoticeForWarmup(workspaceWarmupStatus)
@@ -677,49 +673,24 @@ export function PiChatPanel<
     return `Thinking set to ${thinkingLabel(match)}.`
   }, [thinkingControl, thinkingLevel])
 
-  const runSlashCommandFromUi = useCallback((name: string) => {
-    const command = registry.get(name)
-    if (!command || command.clickBehavior === 'disabled') return
-    void (async () => {
-      const currentSessionId = activeChatSessionId ?? activeSessionId ?? sessionId ?? 'default'
-      const ctx: SlashCommandContext = {
-        sessionId: currentSessionId,
-        clearMessages: () => addLocalNotice({
-          id: 'clear-not-supported',
-          level: 'info',
-          text: '/clear is not available in this chat panel.',
-          dismissible: true,
-        }),
-        resetSession,
-        listCommands: () => registry.list(),
-        reloadAgentPlugins,
-        pluginUpdate: { run: runPluginUpdate },
-        openModelPicker,
-        selectComposerModel,
-        openThinkingPicker,
-        selectComposerThinking,
-      }
-      const result = await Promise.resolve(command.handler('', ctx))
-      const message = slashCommandResultMessage(result) ?? `/${name} triggered.`
-      onCommandResult?.(message)
-      addLocalNotice({ id: `command:${Date.now()}`, level: 'info', text: message, dismissible: true })
-    })()
-  }, [activeChatSessionId, activeSessionId, addLocalNotice, onCommandResult, openModelPicker, openThinkingPicker, registry, reloadAgentPlugins, resetSession, runPluginUpdate, selectComposerModel, selectComposerThinking, sessionId])
-
-  const selectSlashCommand = useCallback((name: string) => {
-    const command = registry.get(name)
-    if (command?.clickBehavior === 'execute') {
-      dismissSlash()
-      setComposerDraft('')
-      runSlashCommandFromUi(name)
-      return
-    }
-    if (command?.clickBehavior === 'disabled') {
-      dismissSlash()
-      return
-    }
-    insertSlashCommand(name)
-  }, [dismissSlash, insertSlashCommand, registry, runSlashCommandFromUi, setComposerDraft])
+  const { selectSlashCommand, handleMentionClick } = useSlashCommandUi({
+    registry,
+    activeChatSessionId,
+    activeSessionId,
+    sessionId,
+    addLocalNotice,
+    resetSession,
+    reloadAgentPlugins,
+    runPluginUpdate,
+    openModelPicker,
+    selectComposerModel,
+    openThinkingPicker,
+    selectComposerThinking,
+    onCommandResult,
+    dismissSlash,
+    insertSlashCommand,
+    setComposerDraft,
+  })
 
   const policy = useMemo(() => {
     if (!selectedPiSession || !activeChatSessionId) return undefined
@@ -1088,18 +1059,8 @@ export function PiChatPanel<
               onSuggestionSubmit={({ text, files, source }) => sendComposerMessage({ text, files, source })}
               onRestoreDraft={setComposerDraft}
               windowResetKey={activeSessionId}
-              availableCommands={allCommands.map(c => c.name)}
-              onMentionClick={(mention) => {
-                if (mention.kind !== 'slash-command') return
-                const cmdName = mention.value.replace('/', '')
-                const command = registry.get(cmdName)
-                if (!command || command.clickBehavior === 'disabled') return
-                if (command.clickBehavior === 'insert') {
-                  setComposerDraft(`/${cmdName} `, true)
-                  return
-                }
-                runSlashCommandFromUi(cmdName)
-              }}
+              availableCommands={availableCommandNames}
+              onMentionClick={handleMentionClick}
             />
 
             <PiChatComposerSurface

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -677,19 +677,49 @@ export function PiChatPanel<
     return `Thinking set to ${thinkingLabel(match)}.`
   }, [thinkingControl, thinkingLevel])
 
+  const runSlashCommandFromUi = useCallback((name: string) => {
+    const command = registry.get(name)
+    if (!command || command.clickBehavior === 'disabled') return
+    void (async () => {
+      const currentSessionId = activeChatSessionId ?? activeSessionId ?? sessionId ?? 'default'
+      const ctx: SlashCommandContext = {
+        sessionId: currentSessionId,
+        clearMessages: () => addLocalNotice({
+          id: 'clear-not-supported',
+          level: 'info',
+          text: '/clear is not available in this chat panel.',
+          dismissible: true,
+        }),
+        resetSession,
+        listCommands: () => registry.list(),
+        reloadAgentPlugins,
+        pluginUpdate: { run: runPluginUpdate },
+        openModelPicker,
+        selectComposerModel,
+        openThinkingPicker,
+        selectComposerThinking,
+      }
+      const result = await Promise.resolve(command.handler('', ctx))
+      const message = slashCommandResultMessage(result) ?? `/${name} triggered.`
+      onCommandResult?.(message)
+      addLocalNotice({ id: `command:${Date.now()}`, level: 'info', text: message, dismissible: true })
+    })()
+  }, [activeChatSessionId, activeSessionId, addLocalNotice, onCommandResult, openModelPicker, openThinkingPicker, registry, reloadAgentPlugins, resetSession, runPluginUpdate, selectComposerModel, selectComposerThinking, sessionId])
+
   const selectSlashCommand = useCallback((name: string) => {
-    if (name === 'model') {
+    const command = registry.get(name)
+    if (command?.clickBehavior === 'execute') {
       dismissSlash()
-      if (openModelPicker()) setComposerDraft('')
+      setComposerDraft('')
+      runSlashCommandFromUi(name)
       return
     }
-    if (name === 'thinking' || name === 'think') {
+    if (command?.clickBehavior === 'disabled') {
       dismissSlash()
-      if (openThinkingPicker()) setComposerDraft('')
       return
     }
     insertSlashCommand(name)
-  }, [dismissSlash, insertSlashCommand, openModelPicker, openThinkingPicker, setComposerDraft])
+  }, [dismissSlash, insertSlashCommand, registry, runSlashCommandFromUi, setComposerDraft])
 
   const policy = useMemo(() => {
     if (!selectedPiSession || !activeChatSessionId) return undefined
@@ -1068,32 +1098,7 @@ export function PiChatPanel<
                   setComposerDraft(`/${cmdName} `, true)
                   return
                 }
-                void (async () => {
-                  const currentSessionId = activeChatSessionId ?? activeSessionId ?? sessionId ?? 'default'
-                  const ctx: SlashCommandContext = {
-                    sessionId: currentSessionId,
-                    clearMessages: () => addLocalNotice({
-                      id: 'clear-not-supported',
-                      level: 'info',
-                      text: '/clear is not available in this chat panel.',
-                      dismissible: true,
-                    }),
-                    resetSession,
-                    listCommands: () => registry.list(),
-                    reloadAgentPlugins,
-                    pluginUpdate: { run: runPluginUpdate },
-                    openModelPicker,
-                    selectComposerModel,
-                    openThinkingPicker,
-                    selectComposerThinking,
-                  }
-                  const result = await Promise.resolve(command.handler('', ctx))
-                  const message = slashCommandResultMessage(result)
-                  if (message) {
-                    onCommandResult?.(message)
-                    addLocalNotice({ id: `command:${Date.now()}`, level: 'info', text: message, dismissible: true })
-                  }
-                })()
+                runSlashCommandFromUi(cmdName)
               }}
             />
 

--- a/packages/agent/src/front/chat/components/ClickableMention.tsx
+++ b/packages/agent/src/front/chat/components/ClickableMention.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import type { ComponentProps, ReactNode } from 'react'
+import { cn } from '../../lib'
+
+/**
+ * Generic clickable mention pattern - matches various mention types:
+ * - Slash commands: /command
+ * - File paths: @path/to/file
+ * - Skills: !skill-name
+ * - Future: #tags, $variables, etc.
+ */
+export interface ClickableMention {
+  kind: 'slash-command' | 'file-path' | 'skill' | string
+  value: string
+  label: string
+  data?: Record<string, string>
+}
+
+export interface ClickableMentionLinkProps {
+  mention: ClickableMention
+  onClick?: (mention: ClickableMention) => void
+  className?: string
+  'aria-disabled'?: boolean
+  title?: string
+  children?: ReactNode
+}
+
+export function ClickableMentionLink({ mention, onClick, className, 'aria-disabled': ariaDisabled, title, children, ...rest }: ClickableMentionLinkProps) {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    onClick?.(mention)
+  }
+
+  const kindStyles = {
+    'slash-command': 'border-[color:var(--accent)]/30 bg-[color:var(--accent-soft)] text-[color:var(--accent)] hover:border-[color:var(--accent)]/50 hover:bg-[color:var(--accent-soft)]/80',
+    'file-path': 'border-border/60 bg-muted/50 text-foreground hover:bg-muted',
+    'skill': 'border-[color:var(--accent)]/20 bg-[color:var(--accent-soft)]/50 text-[color:var(--accent)] hover:bg-[color:var(--accent-soft)]',
+  }
+
+  const style = kindStyles[mention.kind as keyof typeof kindStyles] ?? 'border-border/60 bg-muted/30 text-muted-foreground'
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-[12px] font-medium no-underline transition-colors cursor-pointer',
+        style,
+        className,
+      )}
+      onClick={handleClick}
+      {...rest}
+    >
+      {mention.label}
+    </button>
+  )
+}

--- a/packages/agent/src/front/chat/components/ClickableMention.tsx
+++ b/packages/agent/src/front/chat/components/ClickableMention.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import type { ComponentProps, ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { cn } from '../../lib'
 
 /**
@@ -27,10 +27,11 @@ export interface ClickableMentionLinkProps {
 }
 
 export function ClickableMentionLink({ mention, onClick, className, 'aria-disabled': ariaDisabled, title, children, ...rest }: ClickableMentionLinkProps) {
+  const disabled = ariaDisabled === true
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    onClick?.(mention)
+    if (!disabled) onClick?.(mention)
   }
 
   const kindStyles = {
@@ -45,10 +46,14 @@ export function ClickableMentionLink({ mention, onClick, className, 'aria-disabl
     <button
       type="button"
       className={cn(
-        'inline-flex items-center rounded-full border px-2 py-0.5 text-[12px] font-medium no-underline transition-colors cursor-pointer',
+        'inline-flex items-center rounded-full border px-2 py-0.5 text-[12px] font-medium no-underline transition-colors',
+        disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer',
         style,
         className,
       )}
+      aria-disabled={disabled || undefined}
+      disabled={disabled}
+      title={title}
       onClick={handleClick}
       {...rest}
     >

--- a/packages/agent/src/front/chat/components/PiConversationSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiConversationSurface.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../primitives/conversation'
 import { RuntimeNoticeMessages, type PanelNotice } from './ChatNotices'
 import { PiTimelineMessage } from './PiTimelineMessage'
+import type { ClickableMention } from './ClickableMention'
 
 // Heavy sessions (tool-heavy runs reach thousands of messages) must not mount
 // the whole transcript at once. Render a window anchored to the latest message
@@ -49,6 +50,10 @@ export interface PiConversationSurfaceProps {
   onRestoreDraft: (text: string) => void
   /** Changes when the active session changes; resets the history window to the latest page. */
   windowResetKey?: string
+  /** Available slash command names for clickable mention detection. */
+  availableCommands?: string[]
+  /** Callback when a clickable mention is clicked. */
+  onMentionClick?: (mention: ClickableMention) => void
 }
 
 export function PiConversationSurface({
@@ -68,6 +73,8 @@ export function PiConversationSurface({
   onSuggestionSubmit,
   onRestoreDraft,
   windowResetKey,
+  availableCommands,
+  onMentionClick,
 }: PiConversationSurfaceProps) {
   const messageItems = buildMessageRenderItems(messages)
   const total = messageItems.length
@@ -132,6 +139,8 @@ export function PiConversationSurface({
             isStreaming={isStreaming}
             showThoughts={showThoughts}
             toolRenderers={toolRenderers}
+            availableCommands={availableCommands}
+            onMentionClick={onMentionClick}
           />
         ))}
         <RuntimeNoticeMessages notices={runtimeNotices} onDismiss={onDismissNotice} renderAction={renderNoticeAction} />

--- a/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
+++ b/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
@@ -53,6 +53,13 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
   const finalParts = groupRenderableParts(message)
   const attachmentSummaryPaths = role === 'user' ? attachmentPathsFromTextParts(textParts) : []
   const openArtifact = useOpenArtifact()
+  const handleMentionClick = useCallback((mention: ClickableMention) => {
+    if (mention.kind === 'file-path') {
+      openArtifact?.(stripPathLocationSuffix(mention.value))
+      return
+    }
+    onMentionClick?.(mention)
+  }, [onMentionClick, openArtifact])
   const shouldReserveStreamingActions = isStreaming && isAssistant && isLast
 
   return (
@@ -150,7 +157,7 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
             const text = textForMessageDisplay(item.part.text, role)
             if (!text) return null
             const mentionMarkdownComponents = role === 'assistant' && availableCommands
-              ? createMentionMarkdownComponents(availableCommands, onMentionClick)
+              ? createMentionMarkdownComponents(availableCommands, handleMentionClick)
               : undefined
             return (
               <div key={item.key} data-boring-agent-part="message-text">
@@ -193,6 +200,10 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
 }
 
 type MentionMarkdownComponents = NonNullable<ComponentProps<typeof MessageResponse>['components']>
+
+function stripPathLocationSuffix(path: string): string {
+  return path.replace(/:\d+(?::\d+)?$/, '')
+}
 
 function createMentionMarkdownComponents(
   availableCommands: string[],

--- a/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
+++ b/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import type { ComponentProps, KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent, ReactNode } from 'react'
+import { Fragment, useCallback, useEffect, useState } from 'react'
 import { CheckIcon, CopyIcon } from 'lucide-react'
 import { Button } from '@hachej/boring-ui-kit'
 import type { BoringChatMessage, BoringChatPart } from '../../../shared/chat'
@@ -149,37 +149,30 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
           if (item.part.type === 'text') {
             const text = textForMessageDisplay(item.part.text, role)
             if (!text) return null
-            // For assistant messages, wrap text with clickable mention support
-            const renderContent = role === 'assistant' && availableCommands ? (
-              <TextWithClickableMentions
-                availableCommands={availableCommands}
-                onMentionClick={onMentionClick}
-              >
-                {text}
-              </TextWithClickableMentions>
-            ) : null
+            const mentionMarkdownComponents = role === 'assistant' && availableCommands
+              ? createMentionMarkdownComponents(availableCommands, onMentionClick)
+              : undefined
             return (
               <div key={item.key} data-boring-agent-part="message-text">
-                {renderContent ?? (
-                  <MessageResponse
-                    className={cn(
-                      'max-w-none',
-                      'prose prose-invert prose-neutral',
-                      'prose-p:my-3 prose-p:leading-[1.7] prose-p:text-[13px]',
-                      'prose-headings:mt-5 prose-headings:mb-2 prose-headings:font-semibold prose-headings:tracking-[-0.01em]',
-                      'prose-ul:my-3 prose-ul:pl-6 prose-ol:my-3 prose-ol:pl-6',
-                      'prose-li:my-1.5 prose-li:leading-[1.7] prose-li:pl-1 prose-li:marker:text-muted-foreground/70',
-                      'prose-strong:font-semibold prose-strong:text-foreground',
-                      'prose-em:text-foreground/90',
-                      'prose-a:text-[color:var(--accent)] prose-a:underline-offset-4 hover:prose-a:underline',
-                      'prose-code:before:content-none prose-code:after:content-none',
-                      'prose-pre:my-0 prose-pre:rounded-none prose-pre:border-0',
-                      'prose-pre:bg-transparent prose-pre:p-0',
-                    )}
-                  >
-                    {text}
-                  </MessageResponse>
-                )}
+                <MessageResponse
+                  components={mentionMarkdownComponents}
+                  className={cn(
+                    'max-w-none',
+                    'prose prose-invert prose-neutral',
+                    'prose-p:my-3 prose-p:leading-[1.7] prose-p:text-[13px]',
+                    'prose-headings:mt-5 prose-headings:mb-2 prose-headings:font-semibold prose-headings:tracking-[-0.01em]',
+                    'prose-ul:my-3 prose-ul:pl-6 prose-ol:my-3 prose-ol:pl-6',
+                    'prose-li:my-1.5 prose-li:leading-[1.7] prose-li:pl-1 prose-li:marker:text-muted-foreground/70',
+                    'prose-strong:font-semibold prose-strong:text-foreground',
+                    'prose-em:text-foreground/90',
+                    'prose-a:text-[color:var(--accent)] prose-a:underline-offset-4 hover:prose-a:underline',
+                    'prose-code:before:content-none prose-code:after:content-none',
+                    'prose-pre:my-0 prose-pre:rounded-none prose-pre:border-0',
+                    'prose-pre:bg-transparent prose-pre:p-0',
+                  )}
+                >
+                  {text}
+                </MessageResponse>
               </div>
             )
           }
@@ -197,6 +190,47 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
       ) : null}
     </Message>
   )
+}
+
+type MentionMarkdownComponents = NonNullable<ComponentProps<typeof MessageResponse>['components']>
+
+function createMentionMarkdownComponents(
+  availableCommands: string[],
+  onMentionClick: ((mention: ClickableMention) => void) | undefined,
+): MentionMarkdownComponents {
+  const decorate = (children: ReactNode): ReactNode => {
+    if (typeof children === 'string') {
+      return (
+        <TextWithClickableMentions availableCommands={availableCommands} onMentionClick={onMentionClick}>
+          {children}
+        </TextWithClickableMentions>
+      )
+    }
+    if (Array.isArray(children)) {
+      return children.map((child, index) => (
+        <Fragment key={index}>{decorate(child)}</Fragment>
+      ))
+    }
+    return children
+  }
+
+  const Paragraph = ({ children, ...props }: ComponentProps<'p'>) => <p {...props}>{decorate(children)}</p>
+  const ListItem = ({ children, ...props }: ComponentProps<'li'>) => <li {...props}>{decorate(children)}</li>
+  const Heading1 = ({ children, ...props }: ComponentProps<'h1'>) => <h1 {...props}>{decorate(children)}</h1>
+  const Heading2 = ({ children, ...props }: ComponentProps<'h2'>) => <h2 {...props}>{decorate(children)}</h2>
+  const Heading3 = ({ children, ...props }: ComponentProps<'h3'>) => <h3 {...props}>{decorate(children)}</h3>
+  const Heading4 = ({ children, ...props }: ComponentProps<'h4'>) => <h4 {...props}>{decorate(children)}</h4>
+  const Blockquote = ({ children, ...props }: ComponentProps<'blockquote'>) => <blockquote {...props}>{decorate(children)}</blockquote>
+
+  return {
+    p: Paragraph,
+    li: ListItem,
+    h1: Heading1,
+    h2: Heading2,
+    h3: Heading3,
+    h4: Heading4,
+    blockquote: Blockquote,
+  } as MentionMarkdownComponents
 }
 
 function TimelineReasoningPart({ item, showThoughts }: { item: Extract<RenderablePart, { kind: 'reasoning' }>; showThoughts: boolean }) {

--- a/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
+++ b/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
@@ -18,6 +18,8 @@ import { Message, MessageContent, MessageResponse } from '../../primitives/messa
 import { Reasoning, ReasoningContent, ReasoningTrigger } from '../../primitives/reasoning'
 import { ToolCallGroup, type GroupedToolEntry } from '../../primitives/tool-call-group'
 import { noticeSurfaceClass, noticeTextClass } from './noticeStyles'
+import { TextWithClickableMentions } from './TextWithClickableMentions'
+import type { ClickableMention } from './ClickableMention'
 
 /**
  * Read-only / inspection tools collapse into the grouped "Used X · Y" summary;
@@ -39,9 +41,11 @@ export interface PiTimelineMessageProps {
   isStreaming: boolean
   showThoughts: boolean
   toolRenderers: ToolRendererOverrides
+  availableCommands?: string[]
+  onMentionClick?: (mention: ClickableMention) => void
 }
 
-export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, toolRenderers }: PiTimelineMessageProps) {
+export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, toolRenderers, availableCommands, onMentionClick }: PiTimelineMessageProps) {
   const role = message.role
   const isAssistant = role === 'assistant'
   const textParts = message.parts.filter((part): part is Extract<BoringChatPart, { type: 'text' }> => part.type === 'text')
@@ -145,26 +149,37 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
           if (item.part.type === 'text') {
             const text = textForMessageDisplay(item.part.text, role)
             if (!text) return null
+            // For assistant messages, wrap text with clickable mention support
+            const renderContent = role === 'assistant' && availableCommands ? (
+              <TextWithClickableMentions
+                availableCommands={availableCommands}
+                onMentionClick={onMentionClick}
+              >
+                {text}
+              </TextWithClickableMentions>
+            ) : null
             return (
               <div key={item.key} data-boring-agent-part="message-text">
-                <MessageResponse
-                  className={cn(
-                    'max-w-none',
-                    'prose prose-invert prose-neutral',
-                    'prose-p:my-3 prose-p:leading-[1.7] prose-p:text-[13px]',
-                    'prose-headings:mt-5 prose-headings:mb-2 prose-headings:font-semibold prose-headings:tracking-[-0.01em]',
-                    'prose-ul:my-3 prose-ul:pl-6 prose-ol:my-3 prose-ol:pl-6',
-                    'prose-li:my-1.5 prose-li:leading-[1.7] prose-li:pl-1 prose-li:marker:text-muted-foreground/70',
-                    'prose-strong:font-semibold prose-strong:text-foreground',
-                    'prose-em:text-foreground/90',
-                    'prose-a:text-[color:var(--accent)] prose-a:underline-offset-4 hover:prose-a:underline',
-                    'prose-code:before:content-none prose-code:after:content-none',
-                    'prose-pre:my-0 prose-pre:rounded-none prose-pre:border-0',
-                    'prose-pre:bg-transparent prose-pre:p-0',
-                  )}
-                >
-                  {text}
-                </MessageResponse>
+                {renderContent ?? (
+                  <MessageResponse
+                    className={cn(
+                      'max-w-none',
+                      'prose prose-invert prose-neutral',
+                      'prose-p:my-3 prose-p:leading-[1.7] prose-p:text-[13px]',
+                      'prose-headings:mt-5 prose-headings:mb-2 prose-headings:font-semibold prose-headings:tracking-[-0.01em]',
+                      'prose-ul:my-3 prose-ul:pl-6 prose-ol:my-3 prose-ol:pl-6',
+                      'prose-li:my-1.5 prose-li:leading-[1.7] prose-li:pl-1 prose-li:marker:text-muted-foreground/70',
+                      'prose-strong:font-semibold prose-strong:text-foreground',
+                      'prose-em:text-foreground/90',
+                      'prose-a:text-[color:var(--accent)] prose-a:underline-offset-4 hover:prose-a:underline',
+                      'prose-code:before:content-none prose-code:after:content-none',
+                      'prose-pre:my-0 prose-pre:rounded-none prose-pre:border-0',
+                      'prose-pre:bg-transparent prose-pre:p-0',
+                    )}
+                  >
+                    {text}
+                  </MessageResponse>
+                )}
               </div>
             )
           }

--- a/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
+++ b/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
@@ -221,6 +221,37 @@ function createMentionMarkdownComponents(
   const Heading3 = ({ children, ...props }: ComponentProps<'h3'>) => <h3 {...props}>{decorate(children)}</h3>
   const Heading4 = ({ children, ...props }: ComponentProps<'h4'>) => <h4 {...props}>{decorate(children)}</h4>
   const Blockquote = ({ children, ...props }: ComponentProps<'blockquote'>) => <blockquote {...props}>{decorate(children)}</blockquote>
+  const Code = ({
+    inline,
+    className,
+    children,
+    ...props
+  }: {
+    inline?: boolean
+    className?: string
+    children?: ReactNode
+  } & Record<string, unknown>) => {
+    const text = typeof children === 'string' ? children : undefined
+    const commandName = text?.match(/^\/(\w[\w-]*)$/)?.[1]
+    if (inline !== false && commandName && availableCommands.includes(commandName)) {
+      return (
+        <TextWithClickableMentions availableCommands={availableCommands} onMentionClick={onMentionClick}>
+          {text}
+        </TextWithClickableMentions>
+      )
+    }
+    return (
+      <code
+        className={cn(
+          inline === false ? undefined : 'rounded-[0.3em] bg-muted/55 px-[0.32em] py-[0.08em] font-mono text-[0.9em] font-medium text-foreground/90',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </code>
+    )
+  }
 
   return {
     p: Paragraph,
@@ -230,6 +261,7 @@ function createMentionMarkdownComponents(
     h3: Heading3,
     h4: Heading4,
     blockquote: Blockquote,
+    code: Code,
   } as MentionMarkdownComponents
 }
 

--- a/packages/agent/src/front/chat/components/TextWithClickableMentions.tsx
+++ b/packages/agent/src/front/chat/components/TextWithClickableMentions.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import type { ReactNode } from 'react'
+import { ClickableMentionLink, type ClickableMention as MentionType } from './ClickableMention'
+import { parseMentions, type TextSegment } from './mentionParser'
+
+export interface TextWithClickableMentionsProps {
+  children: string
+  availableCommands?: string[]
+  onMentionClick?: (mention: MentionType) => void
+  className?: string
+}
+
+export function TextWithClickableMentions({
+  children,
+  availableCommands,
+  onMentionClick,
+  className,
+}: TextWithClickableMentionsProps) {
+  const text = typeof children === 'string' ? children : String(children)
+  const segments = parseMentions(text, availableCommands)
+
+  if (segments.every(s => s.type === 'text')) {
+    return <>{text}</>
+  }
+
+  return (
+    <>
+      {segments.map((segment, index) => {
+        if (segment.type === 'text') {
+          return <span key={index}>{segment.content}</span>
+        }
+        
+        if (segment.mention) {
+          return (
+            <ClickableMentionLink
+              key={index}
+              mention={segment.mention}
+              onClick={onMentionClick}
+              className={className}
+            />
+          )
+        }
+
+        return <span key={index}>{segment.content}</span>
+      })}
+    </>
+  )
+}

--- a/packages/agent/src/front/chat/components/__tests__/mentionParser.test.ts
+++ b/packages/agent/src/front/chat/components/__tests__/mentionParser.test.ts
@@ -25,10 +25,26 @@ describe('parseMentions', () => {
 
     expect(segments).toEqual([
       { type: 'text', content: 'Inspect ' },
-      { type: 'mention', content: '@packages/agent', mention: { kind: 'file-path', value: '@packages/agent', label: '@packages/agent' } },
+      { type: 'mention', content: '@packages/agent', mention: { kind: 'file-path', value: 'packages/agent', label: '@packages/agent' } },
       { type: 'text', content: ' and ' },
       { type: 'mention', content: '!design-impeccable', mention: { kind: 'skill', value: '!design-impeccable', label: '!design-impeccable' } },
       { type: 'text', content: '.' },
     ])
+  })
+
+  it('detects plain workspace file paths and keeps line suffixes out of the open path', () => {
+    const segments = parseMentions('Open packages/agent/src/front/chat/PiChatPanel.tsx:42 please.', ['help'])
+
+    expect(segments).toEqual([
+      { type: 'text', content: 'Open ' },
+      { type: 'mention', content: 'packages/agent/src/front/chat/PiChatPanel.tsx:42', mention: { kind: 'file-path', value: 'packages/agent/src/front/chat/PiChatPanel.tsx:42', label: 'packages/agent/src/front/chat/PiChatPanel.tsx:42' } },
+      { type: 'text', content: ' please.' },
+    ])
+  })
+
+  it('does not treat URLs as workspace file paths', () => {
+    const segments = parseMentions('Read https://example.com/packages/agent/src/file.ts.', ['help'])
+
+    expect(segments).toEqual([{ type: 'text', content: 'Read https://example.com/packages/agent/src/file.ts.' }])
   })
 })

--- a/packages/agent/src/front/chat/components/__tests__/mentionParser.test.ts
+++ b/packages/agent/src/front/chat/components/__tests__/mentionParser.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { parseMentions } from '../mentionParser'
+
+describe('parseMentions', () => {
+  it('detects available slash commands in prose', () => {
+    const segments = parseMentions('Try /help or /reload.', ['help', 'reload'])
+
+    expect(segments).toEqual([
+      { type: 'text', content: 'Try ' },
+      { type: 'mention', content: '/help', mention: { kind: 'slash-command', value: '/help', label: '/help' } },
+      { type: 'text', content: ' or ' },
+      { type: 'mention', content: '/reload', mention: { kind: 'slash-command', value: '/reload', label: '/reload' } },
+      { type: 'text', content: '.' },
+    ])
+  })
+
+  it('ignores slash-like text that is not an available command', () => {
+    const segments = parseMentions('Open https://example.com/foo and /missing.', ['help'])
+
+    expect(segments).toEqual([{ type: 'text', content: 'Open https://example.com/foo and /missing.' }])
+  })
+
+  it('keeps parsing future mention kinds', () => {
+    const segments = parseMentions('Inspect @packages/agent and !design-impeccable.', ['help'])
+
+    expect(segments).toEqual([
+      { type: 'text', content: 'Inspect ' },
+      { type: 'mention', content: '@packages/agent', mention: { kind: 'file-path', value: '@packages/agent', label: '@packages/agent' } },
+      { type: 'text', content: ' and ' },
+      { type: 'mention', content: '!design-impeccable', mention: { kind: 'skill', value: '!design-impeccable', label: '!design-impeccable' } },
+      { type: 'text', content: '.' },
+    ])
+  })
+})

--- a/packages/agent/src/front/chat/components/mentionParser.ts
+++ b/packages/agent/src/front/chat/components/mentionParser.ts
@@ -1,0 +1,120 @@
+import type { ClickableMention } from './ClickableMention'
+
+/**
+ * Parse text for clickable mentions.
+ * 
+ * Patterns (order matters - more specific first):
+ * - Slash commands: /command-name
+ * - File paths: @path/to/file
+ * - Skills: !skill-name
+ * 
+ * Returns text segments with mention markers for rendering.
+ */
+export interface TextSegment {
+  type: 'text' | 'mention'
+  content: string
+  mention?: ClickableMention
+}
+
+// Slash command: /word-characters (but not in code blocks)
+const SLASH_COMMAND_PATTERN = /(^|[^`\w])(\/[\w-]+)/g
+
+// File path mention: @path/to/file
+const FILE_PATH_PATTERN = /(^|\s)(@[A-Za-z0-9_./-]+)/g
+
+// Skill mention: !skill-name
+const SKILL_PATTERN = /(^|\s)(![\w-]+)/g
+
+export function parseMentions(text: string, availableCommands?: string[]): TextSegment[] {
+  if (!text.includes('/') && !text.includes('@') && !text.includes('!')) {
+    return [{ type: 'text', content: text }]
+  }
+
+  const segments: TextSegment[] = []
+  let remaining = text
+  let lastIndex = 0
+
+  // Find all potential mentions
+  const matches: Array<{ start: number; end: number; type: string; value: string }> = []
+
+  // Slash commands
+  for (const match of text.matchAll(SLASH_COMMAND_PATTERN)) {
+    const prefix = match[1]
+    const command = match[2]
+    const start = match.index! + prefix.length
+    const end = start + command.length
+    matches.push({ start, end, type: 'slash-command', value: command })
+  }
+
+  // File paths
+  for (const match of text.matchAll(FILE_PATH_PATTERN)) {
+    const prefix = match[1]
+    const path = match[2]
+    const start = match.index! + prefix.length
+    const end = start + path.length
+    matches.push({ start, end, type: 'file-path', value: path })
+  }
+
+  // Skills
+  for (const match of text.matchAll(SKILL_PATTERN)) {
+    const prefix = match[1]
+    const skill = match[2]
+    const start = match.index! + prefix.length
+    const end = start + skill.length
+    matches.push({ start, end, type: 'skill', value: skill })
+  }
+
+  // Sort by start position and merge overlapping
+  matches.sort((a, b) => a.start - b.start)
+  
+  const merged: typeof matches = []
+  for (const match of matches) {
+    if (merged.length === 0 || match.start >= merged[merged.length - 1].end) {
+      merged.push(match)
+    }
+  }
+
+  // Build segments
+  let pos = 0
+  for (const match of merged) {
+    // Add text before this mention
+    if (match.start > pos) {
+      segments.push({
+        type: 'text',
+        content: text.slice(pos, match.start),
+      })
+    }
+
+    // Add mention
+    const mention: ClickableMention = {
+      kind: match.type,
+      value: match.value,
+      label: match.value,
+    }
+    segments.push({
+      type: 'mention',
+      content: match.value,
+      mention,
+    })
+
+    pos = match.end
+  }
+
+  // Add remaining text
+  if (pos < text.length) {
+    segments.push({
+      type: 'text',
+      content: text.slice(pos),
+    })
+  }
+
+  return segments.length > 0 ? segments : [{ type: 'text', content: text }]
+}
+
+/**
+ * Check if a slash command is available (has clickBehavior defined)
+ */
+export function isSlashCommandAvailable(command: string, availableCommands?: string[]): boolean {
+  if (!availableCommands) return true // Assume all available if not specified
+  return availableCommands.includes(command)
+}

--- a/packages/agent/src/front/chat/components/mentionParser.ts
+++ b/packages/agent/src/front/chat/components/mentionParser.ts
@@ -16,8 +16,8 @@ export interface TextSegment {
   mention?: ClickableMention
 }
 
-// Slash command: /word-characters (but not in code blocks)
-const SLASH_COMMAND_PATTERN = /(^|[^`\w])(\/[\w-]+)/g
+// Slash command mention: /command-name at a word boundary, but not URL/path segments.
+const SLASH_COMMAND_PATTERN = /(^|[\s([{"'`])\/(\w[\w-]*)\b/g
 
 // File path mention: @path/to/file
 const FILE_PATH_PATTERN = /(^|\s)(@[A-Za-z0-9_./-]+)/g
@@ -40,7 +40,9 @@ export function parseMentions(text: string, availableCommands?: string[]): TextS
   // Slash commands
   for (const match of text.matchAll(SLASH_COMMAND_PATTERN)) {
     const prefix = match[1]
-    const command = match[2]
+    const commandName = match[2]
+    if (availableCommands && !availableCommands.includes(commandName)) continue
+    const command = `/${commandName}`
     const start = match.index! + prefix.length
     const end = start + command.length
     matches.push({ start, end, type: 'slash-command', value: command })

--- a/packages/agent/src/front/chat/components/mentionParser.ts
+++ b/packages/agent/src/front/chat/components/mentionParser.ts
@@ -31,8 +31,6 @@ export function parseMentions(text: string, availableCommands?: string[]): TextS
   }
 
   const segments: TextSegment[] = []
-  let remaining = text
-  let lastIndex = 0
 
   // Find all potential mentions
   const matches: Array<{ start: number; end: number; type: string; value: string }> = []
@@ -111,12 +109,4 @@ export function parseMentions(text: string, availableCommands?: string[]): TextS
   }
 
   return segments.length > 0 ? segments : [{ type: 'text', content: text }]
-}
-
-/**
- * Check if a slash command is available (has clickBehavior defined)
- */
-export function isSlashCommandAvailable(command: string, availableCommands?: string[]): boolean {
-  if (!availableCommands) return true // Assume all available if not specified
-  return availableCommands.includes(command)
 }

--- a/packages/agent/src/front/chat/components/mentionParser.ts
+++ b/packages/agent/src/front/chat/components/mentionParser.ts
@@ -19,21 +19,21 @@ export interface TextSegment {
 // Slash command mention: /command-name at a word boundary, but not URL/path segments.
 const SLASH_COMMAND_PATTERN = /(^|[\s([{"'`])\/(\w[\w-]*)\b/g
 
-// File path mention: @path/to/file
-const FILE_PATH_PATTERN = /(^|\s)(@[A-Za-z0-9_./-]+)/g
+// File path mention: @path/to/file, packages/foo.ts, ./src/file.ts, README.md:12
+const FILE_PATH_PATTERN = /(^|[\s([{"'`])(@?(?:(?:\.{1,2}\/)?[A-Za-z0-9_.-]+(?:\/[A-Za-z0-9_.-]+)+|[A-Za-z0-9_.-]+\.[A-Za-z0-9]{1,8})(?::\d+(?::\d+)?)?)/g
 
 // Skill mention: !skill-name
 const SKILL_PATTERN = /(^|\s)(![\w-]+)/g
 
 export function parseMentions(text: string, availableCommands?: string[]): TextSegment[] {
-  if (!text.includes('/') && !text.includes('@') && !text.includes('!')) {
+  if (!text.includes('/') && !text.includes('@') && !text.includes('!') && !text.includes('.')) {
     return [{ type: 'text', content: text }]
   }
 
   const segments: TextSegment[] = []
 
   // Find all potential mentions
-  const matches: Array<{ start: number; end: number; type: string; value: string }> = []
+  const matches: Array<{ start: number; end: number; type: string; value: string; label?: string }> = []
 
   // Slash commands
   for (const match of text.matchAll(SLASH_COMMAND_PATTERN)) {
@@ -49,10 +49,12 @@ export function parseMentions(text: string, availableCommands?: string[]): TextS
   // File paths
   for (const match of text.matchAll(FILE_PATH_PATTERN)) {
     const prefix = match[1]
-    const path = match[2]
+    const rawPath = trimTrailingPathPunctuation(match[2])
+    const path = rawPath.replace(/^@/, '')
+    if (!rawPath.startsWith('@') && !isLikelyWorkspacePath(path)) continue
     const start = match.index! + prefix.length
-    const end = start + path.length
-    matches.push({ start, end, type: 'file-path', value: path })
+    const end = start + rawPath.length
+    matches.push({ start, end, type: 'file-path', value: path, label: rawPath })
   }
 
   // Skills
@@ -89,11 +91,11 @@ export function parseMentions(text: string, availableCommands?: string[]): TextS
     const mention: ClickableMention = {
       kind: match.type,
       value: match.value,
-      label: match.value,
+      label: match.label ?? match.value,
     }
     segments.push({
       type: 'mention',
-      content: match.value,
+      content: match.label ?? match.value,
       mention,
     })
 
@@ -109,4 +111,23 @@ export function parseMentions(text: string, availableCommands?: string[]): TextS
   }
 
   return segments.length > 0 ? segments : [{ type: 'text', content: text }]
+}
+
+function trimTrailingPathPunctuation(path: string): string {
+  return path.replace(/[),.;:]+$/, '')
+}
+
+function isLikelyWorkspacePath(path: string): boolean {
+  if (!path || path.startsWith('http://') || path.startsWith('https://')) return false
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(path)) return false
+
+  const withoutLine = path.replace(/:\d+(?::\d+)?$/, '')
+  const slashCount = (withoutLine.match(/\//g) ?? []).length
+  if (withoutLine.startsWith('./') || withoutLine.startsWith('../')) return true
+  if (hasKnownFileExtension(withoutLine)) return true
+  return slashCount >= 2
+}
+
+function hasKnownFileExtension(path: string): boolean {
+  return /\.(?:ts|tsx|js|jsx|mjs|cjs|json|md|mdx|css|scss|html|yml|yaml|toml|rs|go|py|sh|sql|txt|png|jpg|jpeg|gif|webp|svg)$/i.test(path)
 }

--- a/packages/agent/src/front/chat/useSlashCommandUi.ts
+++ b/packages/agent/src/front/chat/useSlashCommandUi.ts
@@ -1,0 +1,111 @@
+import { useCallback } from 'react'
+import type { ClickableMention } from './components/ClickableMention'
+import type { PanelNotice } from './components/ChatNotices'
+import type {
+  CommandRegistry,
+  SlashCommandContext,
+  SlashCommandHandlerResult,
+} from '../slashCommands'
+
+interface UseSlashCommandUiOptions {
+  registry: CommandRegistry
+  activeChatSessionId?: string
+  activeSessionId?: string
+  sessionId?: string
+  addLocalNotice: (notice: PanelNotice) => void
+  resetSession: () => void
+  reloadAgentPlugins: () => Promise<string>
+  runPluginUpdate: () => Promise<string>
+  openModelPicker: () => boolean | void
+  selectComposerModel: (query: string) => string | void
+  openThinkingPicker: () => boolean | void
+  selectComposerThinking: (query: string) => string | void
+  onCommandResult?: (message: string) => void
+  dismissSlash: () => void
+  insertSlashCommand: (name: string) => void
+  setComposerDraft: (value: string, focus?: boolean) => void
+}
+
+function slashCommandResultMessage(result: SlashCommandHandlerResult): string | undefined {
+  if (typeof result === 'string') return result
+  if (result && typeof result === 'object' && typeof result.message === 'string') return result.message
+  return undefined
+}
+
+export function useSlashCommandUi({
+  registry,
+  activeChatSessionId,
+  activeSessionId,
+  sessionId,
+  addLocalNotice,
+  resetSession,
+  reloadAgentPlugins,
+  runPluginUpdate,
+  openModelPicker,
+  selectComposerModel,
+  openThinkingPicker,
+  selectComposerThinking,
+  onCommandResult,
+  dismissSlash,
+  insertSlashCommand,
+  setComposerDraft,
+}: UseSlashCommandUiOptions) {
+  const runSlashCommandFromUi = useCallback((name: string) => {
+    const command = registry.get(name)
+    if (!command || command.clickBehavior === 'disabled') return
+
+    void (async () => {
+      const currentSessionId = activeChatSessionId ?? activeSessionId ?? sessionId ?? 'default'
+      const ctx: SlashCommandContext = {
+        sessionId: currentSessionId,
+        clearMessages: () => addLocalNotice({
+          id: 'clear-not-supported',
+          level: 'info',
+          text: '/clear is not available in this chat panel.',
+          dismissible: true,
+        }),
+        resetSession,
+        listCommands: () => registry.list(),
+        reloadAgentPlugins,
+        pluginUpdate: { run: runPluginUpdate },
+        openModelPicker,
+        selectComposerModel,
+        openThinkingPicker,
+        selectComposerThinking,
+      }
+      const result = await Promise.resolve(command.handler('', ctx))
+      const message = slashCommandResultMessage(result) ?? `/${name} triggered.`
+      onCommandResult?.(message)
+      addLocalNotice({ id: `command:${Date.now()}`, level: 'info', text: message, dismissible: true })
+    })()
+  }, [activeChatSessionId, activeSessionId, addLocalNotice, onCommandResult, openModelPicker, openThinkingPicker, registry, reloadAgentPlugins, resetSession, runPluginUpdate, selectComposerModel, selectComposerThinking, sessionId])
+
+  const selectSlashCommand = useCallback((name: string) => {
+    const command = registry.get(name)
+    if (command?.clickBehavior === 'execute') {
+      dismissSlash()
+      setComposerDraft('')
+      runSlashCommandFromUi(name)
+      return
+    }
+    if (command?.clickBehavior === 'disabled') {
+      dismissSlash()
+      return
+    }
+    insertSlashCommand(name)
+  }, [dismissSlash, insertSlashCommand, registry, runSlashCommandFromUi, setComposerDraft])
+
+  const handleMentionClick = useCallback((mention: ClickableMention) => {
+    if (mention.kind !== 'slash-command') return
+    const name = mention.value.replace('/', '')
+    const command = registry.get(name)
+    if (!command || command.clickBehavior === 'disabled') return
+    if (command.clickBehavior === 'insert') {
+      setComposerDraft(`/${name} `, true)
+      return
+    }
+    runSlashCommandFromUi(name)
+  }, [registry, runSlashCommandFromUi, setComposerDraft])
+
+  return { selectSlashCommand, handleMentionClick }
+}

--- a/packages/agent/src/front/chat/useSlashCommandUi.ts
+++ b/packages/agent/src/front/chat/useSlashCommandUi.ts
@@ -96,6 +96,12 @@ export function useSlashCommandUi({
   }, [dismissSlash, insertSlashCommand, registry, runSlashCommandFromUi, setComposerDraft])
 
   const handleMentionClick = useCallback((mention: ClickableMention) => {
+    if (mention.kind === 'skill') {
+      const skillName = mention.value.replace(/^!/, '')
+      if (skillName) setComposerDraft(`skill: ${skillName}\n\n`, true)
+      return
+    }
+
     if (mention.kind !== 'slash-command') return
     const name = mention.value.replace('/', '')
     const command = registry.get(name)

--- a/packages/agent/src/front/chat/useSlashCommandUi.ts
+++ b/packages/agent/src/front/chat/useSlashCommandUi.ts
@@ -50,7 +50,7 @@ export function useSlashCommandUi({
   insertSlashCommand,
   setComposerDraft,
 }: UseSlashCommandUiOptions) {
-  const runSlashCommandFromUi = useCallback((name: string) => {
+  const runSlashCommandFromUi = useCallback((name: string, options?: { clearDraftUnlessPreserved?: boolean }) => {
     const command = registry.get(name)
     if (!command || command.clickBehavior === 'disabled') return
 
@@ -74,6 +74,8 @@ export function useSlashCommandUi({
         selectComposerThinking,
       }
       const result = await Promise.resolve(command.handler('', ctx))
+      const preserveDraft = Boolean(result && typeof result === 'object' && result.preserveDraft)
+      if (options?.clearDraftUnlessPreserved && !preserveDraft) setComposerDraft('')
       const message = slashCommandResultMessage(result) ?? `/${name} triggered.`
       onCommandResult?.(message)
       addLocalNotice({ id: `command:${Date.now()}`, level: 'info', text: message, dismissible: true })
@@ -84,8 +86,7 @@ export function useSlashCommandUi({
     const command = registry.get(name)
     if (command?.clickBehavior === 'execute') {
       dismissSlash()
-      setComposerDraft('')
-      runSlashCommandFromUi(name)
+      runSlashCommandFromUi(name, { clearDraftUnlessPreserved: true })
       return
     }
     if (command?.clickBehavior === 'disabled') {

--- a/packages/agent/src/front/slashCommands/builtins.ts
+++ b/packages/agent/src/front/slashCommands/builtins.ts
@@ -30,6 +30,7 @@ export const builtinCommands: SlashCommand[] = [
   {
     name: 'model',
     description: 'Open or set the composer model',
+    clickBehavior: 'execute',
     handler(args, ctx) {
       const query = args.trim()
       if (query) return ctx.selectComposerModel?.(query)
@@ -39,6 +40,7 @@ export const builtinCommands: SlashCommand[] = [
   {
     name: 'thinking',
     description: 'Open or set the thinking level',
+    clickBehavior: 'execute',
     handler(args, ctx) {
       const query = args.trim()
       if (query) return ctx.selectComposerThinking?.(query)

--- a/packages/agent/src/front/slashCommands/index.ts
+++ b/packages/agent/src/front/slashCommands/index.ts
@@ -6,6 +6,7 @@ export {
   type SlashCommandContext,
   type SlashCommandHandler,
   type SlashCommandHandlerResult,
+  type SlashCommandClickBehavior,
 } from './registry'
 export { builtinCommands } from './builtins'
 export { filterSlashCommandSuggestions, getSlashCommandQuery } from './suggestions'

--- a/packages/agent/src/front/slashCommands/index.ts
+++ b/packages/agent/src/front/slashCommands/index.ts
@@ -5,6 +5,7 @@ export {
   type SlashCommand,
   type SlashCommandContext,
   type SlashCommandHandler,
+  type SlashCommandHandlerResult,
 } from './registry'
 export { builtinCommands } from './builtins'
 export { filterSlashCommandSuggestions, getSlashCommandQuery } from './suggestions'

--- a/packages/agent/src/front/slashCommands/registry.ts
+++ b/packages/agent/src/front/slashCommands/registry.ts
@@ -1,5 +1,6 @@
 export type SlashCommandHandlerResult = string | void | { message?: string; preserveDraft?: boolean }
 export type SlashCommandHandler = (args: string, ctx: SlashCommandContext) => SlashCommandHandlerResult | Promise<SlashCommandHandlerResult>
+export type SlashCommandClickBehavior = 'execute' | 'insert' | 'disabled'
 
 export interface SlashCommand {
   name: string
@@ -12,6 +13,7 @@ export interface SlashCommand {
    * is needed.
    */
   kind?: 'local' | 'skill'
+  clickBehavior?: SlashCommandClickBehavior
   /**
    * Origin of the command, surfaced as a tag in the slash-command picker.
    * Mirrors Pi's command sources for server commands; `local` for built-in


### PR DESCRIPTION
## Summary
- render supported slash-command mentions in assistant chat text as actionable chips
- reuse the existing slash-command registry plus click-behavior metadata to decide execute vs insert
- route click execution through the same local slash-command path used by composer submits

## Verification
- pnpm --filter @hachej/boring-agent typecheck
- pnpm --filter @hachej/boring-agent test src/front/slashCommands/__tests__/registry.test.ts src/front/slashCommands/__tests__/builtins.test.ts src/front/__tests__/ChatPanel.test.tsx

## Issue
Closes #174