### PR TITLE
Fix empty chat proposals on narrow chat panels (#192)

### DIFF
--- a/apps/workspace-playground/vite.config.ts
+++ b/apps/workspace-playground/vite.config.ts
@@ -64,6 +64,9 @@ const dynamicPluginReactRefreshExclude = [
   /packages\/(workspace|agent|ui)\/dist\//,
 ]
 
+const usePollingWatch = process.env.CHOKIDAR_USEPOLLING === "1" || process.env.BORING_VITE_USEPOLLING === "1"
+const pollingInterval = Number(process.env.CHOKIDAR_INTERVAL ?? process.env.BORING_VITE_POLL_INTERVAL ?? "300")
+
 export default defineConfig({
   plugins: [
     react({
@@ -95,6 +98,12 @@ export default defineConfig({
   server: {
     port: VITE_PORT,
     host: true,
+    watch: usePollingWatch
+      ? {
+          usePolling: true,
+          interval: Number.isFinite(pollingInterval) && pollingInterval > 0 ? pollingInterval : 300,
+        }
+      : undefined,
     proxy: {
       // All API traffic goes to the agent server — the agent owns the
       // filesystem and the UI bridge. No vite-side mocks.

--- a/packages/agent/src/front/ChatEmptyState.tsx
+++ b/packages/agent/src/front/ChatEmptyState.tsx
@@ -109,7 +109,7 @@ export function ChatEmptyState({
         ["--chat-empty-accent" as string]: "var(--accent)",
       }}
       className={cn(
-        "mx-auto flex w-full max-w-[640px] flex-col px-2 pt-12 pb-4",
+        "@container mx-auto flex w-full max-w-[640px] flex-col px-2 pt-12 pb-4",
         className,
       )}
     >
@@ -132,7 +132,7 @@ export function ChatEmptyState({
       {suggestions.length > 0 && (
         <div
           data-boring-agent-part="suggestion-grid"
-          className="mt-8 grid w-full grid-cols-1 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70 sm:grid-cols-2"
+          className="mt-8 grid w-full grid-cols-1 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70 @[32rem]:grid-cols-2"
         >
           {suggestions.map((suggestion) => {
             const Icon = suggestion.icon
@@ -158,11 +158,11 @@ export function ChatEmptyState({
                   />
                 )}
                 <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <span className="truncate text-[13px] font-medium text-foreground">
+                  <span className="text-[13px] font-medium text-foreground">
                     {suggestion.label}
                   </span>
                   {suggestion.hint && (
-                    <span className="truncate text-[12px] text-muted-foreground">
+                    <span className="text-[12px] text-muted-foreground">
                       {suggestion.hint}
                     </span>
                   )}

--- a/packages/agent/src/front/__tests__/ChatPanel.test.tsx
+++ b/packages/agent/src/front/__tests__/ChatPanel.test.tsx
@@ -135,12 +135,15 @@ describe('ChatPanel (shadcn)', () => {
     expect(html).toContain('aria-live="polite"')
   })
 
-  test('renders empty state with default suggestion grid when no messages', () => {
+  test('renders empty state with container-responsive suggestion layout when no messages', () => {
     const html = renderToStaticMarkup(<ChatPanel sessionId="sess-empty" />)
     // Default headline + at least one default suggestion card.
     expect(html).toContain('What are we building?')
     expect(html).toContain('Summarize the README')
     expect(html).toContain('Explain this codebase')
+    expect(html).toContain('@container')
+    expect(html).toContain('@[32rem]:grid-cols-2')
+    expect(html).not.toContain('sm:grid-cols-2')
   })
 
   test('custom suggestions override defaults and prompt label fallback works', () => {

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -10,9 +10,26 @@ import type { RuntimeModeAdapter } from '../runtime/mode'
 
 const tempDirs: string[] = []
 
+async function removeDirEventually(dir: string, timeoutMs = 5000): Promise<void> {
+  const startedAt = Date.now()
+  let lastError: unknown
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      await rm(dir, { recursive: true, force: true })
+      return
+    } catch (error) {
+      lastError = error
+      const code = typeof error === 'object' && error && 'code' in error ? (error as { code?: string }).code : undefined
+      if (code !== 'ENOTEMPTY' && code !== 'EBUSY') throw error
+      await new Promise((resolve) => setTimeout(resolve, 50))
+    }
+  }
+  if (lastError) throw lastError
+}
+
 afterEach(async () => {
   await Promise.all(
-    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    tempDirs.splice(0).map((dir) => removeDirEventually(dir)),
   )
 })
 


### PR DESCRIPTION
Closes #192

## Summary
- make empty-chat proposal cards container-responsive to the chat panel width
- keep the existing 2-column layout when enough width is available
- stack proposals vertically in narrow panes and stop truncating proposal text

## Verification
- `pnpm --filter @hachej/boring-agent run typecheck` ✅
- `pnpm --filter @hachej/boring-ui-kit build` ✅
- `pnpm --filter @hachej/boring-agent run test src/front/__tests__/ChatPanel.test.tsx` ✅
- `workspace-playground` proof launch using ports 5292/5392 ❌ blocked by unrelated existing `@hachej/boring-workspace build` failure during app dependency build (see proof comment)
