### PR TITLE
fix: keep file tree context menu visible near bottom rows (#199)

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -5,6 +5,7 @@ import {
   Suspense,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -76,6 +77,27 @@ interface ContextMenuState {
   x: number
   y: number
   isBackground?: boolean
+}
+
+const CONTEXT_MENU_MARGIN = 8
+
+function clampContextMenuPosition(
+  x: number,
+  y: number,
+  menuRect: Pick<DOMRect, "width" | "height">,
+  viewportWidth: number,
+  viewportHeight: number,
+) {
+  return {
+    x: Math.max(
+      CONTEXT_MENU_MARGIN,
+      Math.min(x, viewportWidth - menuRect.width - CONTEXT_MENU_MARGIN),
+    ),
+    y: Math.max(
+      CONTEXT_MENU_MARGIN,
+      Math.min(y, viewportHeight - menuRect.height - CONTEXT_MENU_MARGIN),
+    ),
+  }
 }
 
 export interface FileTreeViewProps {
@@ -200,6 +222,23 @@ export function FileTreeView({
     }
     document.addEventListener("pointerdown", onPointerDown)
     return () => document.removeEventListener("pointerdown", onPointerDown)
+  }, [ctxMenu])
+
+  useLayoutEffect(() => {
+    if (!ctxMenu || !menuRef.current) return
+    const { x, y } = clampContextMenuPosition(
+      ctxMenu.x,
+      ctxMenu.y,
+      menuRef.current.getBoundingClientRect(),
+      window.innerWidth,
+      window.innerHeight,
+    )
+    if (x === ctxMenu.x && y === ctxMenu.y) return
+    setCtxMenu((prev) => {
+      if (!prev) return prev
+      if (prev.x === x && prev.y === y) return prev
+      return { ...prev, x, y }
+    })
   }, [ctxMenu])
 
   useEffect(() => {
@@ -745,6 +784,8 @@ export function FileTreeView({
     </div>
   )
 }
+
+export { clampContextMenuPosition }
 
 export interface FileTreePaneParams extends LeftTabParams {
   rootDir?: string

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest"
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type React from "react"
@@ -148,7 +148,7 @@ vi.mock("../FileTree", () => {
   }
 })
 
-import { FileTreePane } from "../FileTreeView"
+import { FileTreePane, clampContextMenuPosition } from "../FileTreeView"
 
 const sampleFiles = [
   { name: "src", kind: "dir" as const, path: "src" },
@@ -163,6 +163,35 @@ function wrapper({ children }: { children: React.ReactNode }) {
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
 }
 
+const originalInnerWidth = window.innerWidth
+const originalInnerHeight = window.innerHeight
+
+beforeAll(() => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: 320,
+  })
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: 420,
+  })
+})
+
+afterAll(() => {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    writable: true,
+    value: originalInnerWidth,
+  })
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    writable: true,
+    value: originalInnerHeight,
+  })
+})
+
 beforeEach(() => {
   vi.clearAllMocks()
   mockFileSearch.mockReturnValue({ data: undefined })
@@ -170,6 +199,20 @@ beforeEach(() => {
     data: sampleFiles,
     isLoading: false,
     error: undefined,
+  })
+})
+
+describe("clampContextMenuPosition", () => {
+  it("keeps the menu inside the viewport when opened near the bottom-right edge", () => {
+    expect(
+      clampContextMenuPosition(280, 390, { width: 120, height: 100 }, 320, 420),
+    ).toEqual({ x: 192, y: 312 })
+  })
+
+  it("leaves in-bounds positions unchanged", () => {
+    expect(
+      clampContextMenuPosition(40, 60, { width: 120, height: 100 }, 320, 420),
+    ).toEqual({ x: 40, y: 60 })
   })
 })
 
@@ -418,6 +461,57 @@ describe("FileTreePane", () => {
     expect(screen.getByRole("menuitem", { name: "Rename" })).toBeInTheDocument()
     expect(screen.getByRole("menuitem", { name: "Delete" })).toBeInTheDocument()
     expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeInTheDocument()
+  })
+
+  it("repositions the context menu when opened too close to the viewport bottom", async () => {
+    const rectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.getAttribute("role") === "menu") {
+          return {
+            x: 0,
+            y: 0,
+            top: 0,
+            left: 0,
+            right: 120,
+            bottom: 100,
+            width: 120,
+            height: 100,
+            toJSON: () => ({}),
+          } as DOMRect
+        }
+        return {
+          x: 0,
+          y: 0,
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          width: 0,
+          height: 0,
+          toJSON: () => ({}),
+        } as DOMRect
+      })
+
+    try {
+      render(<FileTreePane />, { wrapper })
+
+      await waitFor(() => {
+        expect(screen.getByText("index.ts")).toBeInTheDocument()
+      })
+
+      fireEvent.contextMenu(screen.getByText("index.ts"), {
+        clientX: 280,
+        clientY: 390,
+      })
+
+      await waitFor(() => {
+        const menu = screen.getByRole("menu")
+        expect(menu).toHaveStyle({ left: "192px", top: "312px" })
+      })
+    } finally {
+      rectSpy.mockRestore()
+    }
   })
 
   it("delete context action shows AlertDialog confirmation", async () => {


### PR DESCRIPTION
Fixes #199.

## What changed
- clamp the custom file tree context menu to the viewport after it renders
- keep existing behavior unchanged for in-bounds opens
- add focused regression coverage for the clamp helper and bottom-edge repositioning

## Verification
- `pnpm --filter @hachej/boring-workspace run typecheck` ✅
- `pnpm --filter @hachej/boring-ui-kit run build` ✅
- `pnpm --filter @hachej/boring-workspace run test src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx` ✅

## Notes
- workspace-playground launch in this environment hit `ENOSPC` file watcher exhaustion before Vite came up, so visual proof is currently blocked pending available watcher capacity. Log: `/tmp/boring-ui-playground-199.log`
- opposite-model `cc -p` review command from repo instructions is blocked here because `cc` resolves to the system C compiler, not Claude Code.