### PR TITLE
fix: sync local .agents skills into slash command list (#200)

### DIFF
--- a/packages/agent/src/front/__tests__/ChatPanel.test.tsx
+++ b/packages/agent/src/front/__tests__/ChatPanel.test.tsx
@@ -98,6 +98,10 @@ function withLocalStorage(values: Record<string, string>, fn: () => void): void 
 
 beforeEach(() => {
   vi.restoreAllMocks()
+  // useServerSkills fires a fetch on mount; stub it so render()-based tests
+  // (which run effects, unlike renderToStaticMarkup) don't hit an undefined
+  // global fetch. Individual tests can override with their own stub.
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
   capturedOnSubmit = undefined
   capturedTextareaProps = undefined
   mockPiProjection.piMessages = []

--- a/packages/agent/src/front/__tests__/ChatPanel.test.tsx
+++ b/packages/agent/src/front/__tests__/ChatPanel.test.tsx
@@ -97,6 +97,7 @@ function withLocalStorage(values: Record<string, string>, fn: () => void): void 
 }
 
 beforeEach(() => {
+  vi.restoreAllMocks()
   capturedOnSubmit = undefined
   capturedTextareaProps = undefined
   mockPiProjection.piMessages = []
@@ -978,6 +979,20 @@ describe('ChatPanel (shadcn)', () => {
         },
       },
     )
+  })
+
+  test('server-loaded skills are fetched for slash-command registration', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({
+        skills: [{ name: 'issue-200-local-test-skill', description: 'Local issue 200 reproduction skill.' }],
+      }), { status: 200 }),
+    )
+
+    render(<ChatPanel sessionId="sess-server-skill-picker" />)
+
+    await waitFor(() => {
+      expect(globalThis.fetch).toHaveBeenCalledWith('/api/v1/agent/skills', { headers: undefined })
+    })
   })
 
   test('extraCommands are available as slash commands', async () => {

--- a/packages/agent/src/front/hooks/useServerSkills.ts
+++ b/packages/agent/src/front/hooks/useServerSkills.ts
@@ -1,6 +1,18 @@
 import { useEffect, useState } from 'react'
 import type { CommandRegistry } from '../slashCommands/registry'
 
+interface ServerSkill {
+  name: string
+  description: string
+}
+
+function skillFingerprint(skills: ServerSkill[]): string {
+  return skills
+    .map((skill) => `${skill.name}\u0000${skill.description}`)
+    .sort()
+    .join('\u0001')
+}
+
 export function useServerSkills({
   registry,
   requestHeaders,
@@ -9,9 +21,10 @@ export function useServerSkills({
   registry: CommandRegistry
   requestHeaders?: Record<string, string>
   enabled?: boolean
-}): number {
-  // Bumped when server skills are added to registry so the picker re-renders.
-  const [skillsStamp, setSkillsStamp] = useState(0)
+}): string {
+  // Bumped when server skills change so the picker re-renders even when the
+  // same command name already existed in the registry from a previous render.
+  const [skillsStamp, setSkillsStamp] = useState('')
 
   // Fetch PI skills and register them so the slash picker shows them without
   // host apps needing to hardcode them in extraCommands. Server skills never
@@ -21,16 +34,14 @@ export function useServerSkills({
     let aborted = false
     fetch('/api/v1/agent/skills', { headers: requestHeaders })
       .then((res) => (res.ok ? res.json() : null))
-      .then((payload: { skills?: Array<{ name: string; description: string }> } | null) => {
+      .then((payload: { skills?: ServerSkill[] } | null) => {
         if (aborted || !payload?.skills) return
-        let added = 0
         for (const skill of payload.skills) {
           if (!registry.get(skill.name)) {
             registry.register({ name: skill.name, description: skill.description, kind: 'skill', handler: () => {} })
-            added++
           }
         }
-        if (added > 0) setSkillsStamp((n) => n + 1)
+        setSkillsStamp(skillFingerprint(payload.skills))
       })
       .catch(() => {})
     return () => { aborted = true }

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -851,6 +851,34 @@ test('skills endpoint lists Pi-resolved project skills', async () => {
   await app.close()
 })
 
+test('skills endpoint lists workspace-local .agents/skills entries from additionalSkillPaths', async () => {
+  const workspaceRoot = await makeTempDir('boring-agent-embed-local-skills-project-')
+  const localSkillDir = join(workspaceRoot, '.agents', 'skills', 'issue-200-local-test-skill')
+  await mkdir(localSkillDir, { recursive: true })
+  await writeFile(
+    join(localSkillDir, 'SKILL.md'),
+    '---\nname: issue-200-local-test-skill\ndescription: Local issue 200 reproduction skill.\n---\n',
+    'utf-8',
+  )
+
+  const app = Fastify({ logger: false })
+  await app.register(registerAgentRoutes, {
+    workspaceRoot,
+    mode: 'direct',
+    pi: {
+      additionalSkillPaths: [join(workspaceRoot, '.agents', 'skills')],
+    },
+  })
+  await app.ready()
+
+  const res = await app.inject({ method: 'GET', url: '/api/v1/agent/skills' })
+  expect(res.statusCode).toBe(200)
+  const names: string[] = res.json().skills.map((skill: { name: string }) => skill.name)
+  expect(names).toContain('issue-200-local-test-skill')
+
+  await app.close()
+})
+
 test('skills endpoint does not require unrelated runtime-only dynamic hooks', async () => {
   const workspaceRoot = await makeTempDir('boring-agent-embed-skills-runtime-hooks-')
   const projectSkillDir = join(workspaceRoot, '.pi', 'skills', 'project-skill')


### PR DESCRIPTION
## Summary\n- keep slash-command skill picker in sync with the latest  payload\n- add coverage for workspace-local  discovery via the skills endpoint\n- add front coverage that ChatPanel fetches server skills for slash registration\n\n## Verification\n- 
> @hachej/boring-ui-kit@0.1.32 build /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-200/packages/ui
> tsup && node scripts/build-styles.mjs

CLI Building entry: {"index":"src/index.ts"}
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-200/packages/ui/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
ESM dist/index.js 89.14 KB
ESM ⚡️ Build success in 175ms
DTS Build start
DTS ⚡️ Build success in 6052ms
DTS dist/index.d.ts 35.05 KB ✅\n- 
> @hachej/boring-agent@0.1.32 typecheck /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-200/packages/agent
> tsc --noEmit ✅\n- 
> @hachej/boring-agent@0.1.32 test /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-200/packages/agent
> vitest run src/server/__tests__/registerAgentRoutes.test.ts -t 'skills endpoint lists Pi-resolved project skills|skills endpoint lists workspace-local .agents/skills entries from additionalSkillPaths|skills endpoint mirrors noSkills while preserving explicit additional skill paths'


 RUN  v3.2.4 /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-200/packages/agent

 ✓ src/server/__tests__/registerAgentRoutes.test.ts (27 tests | 24 skipped) 390ms

 Test Files  1 passed (1)
      Tests  3 passed | 24 skipped (27)
Type Errors  no errors
   Start at  08:22:59
   Duration  4.21s (transform 965ms, setup 0ms, collect 3.21s, tests 390ms, environment 0ms, prepare 139ms) ✅\n- 
> @hachej/boring-agent@0.1.32 test /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-200/packages/agent
> vitest run src/front/__tests__/ChatPanel.test.tsx -t 'server-loaded skills are fetched for slash-command registration|extraCommands are available as slash commands|forwards to PI as skill: name'


 RUN  v3.2.4 /home/ubuntu/projects/boring-ui-v2/.worktrees/bclaw-issue-200/packages/agent

 ✓ src/front/__tests__/ChatPanel.test.tsx (87 tests | 83 skipped) 243ms

 Test Files  1 passed (1)
      Tests  4 passed | 83 skipped (87)
Type Errors  no errors
   Start at  08:23:04
   Duration  4.73s (transform 1.23s, setup 0ms, collect 2.57s, tests 243ms, environment 1.29s, prepare 209ms) ✅\n\nCloses #200