### PR TITLE
fix: auto-refresh file tree for remote file writes (#202)

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventStream.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventStream.test.tsx
@@ -105,9 +105,11 @@ describe("useFileEventStream", () => {
     )
   })
 
-  it("emits filesystem changed onto the bus with cause:remote on a write event", () => {
-    const fn = vi.fn()
-    events.on(filesystemEvents.changed, fn)
+  it("emits filesystem created + changed onto the bus for a write event", () => {
+    const created = vi.fn()
+    const changed = vi.fn()
+    events.on(filesystemEvents.created, created)
+    events.on(filesystemEvents.changed, changed)
     renderHook(() => useFileEventStream(), { wrapper: Wrapper })
 
     MockEventSource.lastInstance().dispatch(
@@ -115,7 +117,10 @@ describe("useFileEventStream", () => {
       envelope({ op: "write", path: "src/a.ts", mtimeMs: 9 }),
     )
 
-    expect(fn).toHaveBeenCalledWith(
+    expect(created).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "src/a.ts", kind: "file", cause: "remote" }),
+    )
+    expect(changed).toHaveBeenCalledWith(
       expect.objectContaining({ path: "src/a.ts", cause: "remote" }),
     )
   })
@@ -166,8 +171,10 @@ describe("useFileEventStream", () => {
   })
 
   it("dedupes by eventId — repeated envelopes only relay once", () => {
-    const fn = vi.fn()
-    events.on(filesystemEvents.changed, fn)
+    const created = vi.fn()
+    const changed = vi.fn()
+    events.on(filesystemEvents.created, created)
+    events.on(filesystemEvents.changed, changed)
     renderHook(() => useFileEventStream(), { wrapper: Wrapper })
 
     const dup = JSON.stringify({
@@ -180,7 +187,8 @@ describe("useFileEventStream", () => {
     MockEventSource.lastInstance().dispatch("change", dup)
     MockEventSource.lastInstance().dispatch("change", dup)
 
-    expect(fn).toHaveBeenCalledTimes(1)
+    expect(created).toHaveBeenCalledTimes(1)
+    expect(changed).toHaveBeenCalledTimes(1)
   })
 
   it("on resync-required: invalidates file/tree/stat/search keys, keeps stream open", () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventStream.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventStream.ts
@@ -130,6 +130,7 @@ interface ChangeEnvelope {
 function relay(c: ChangeEnvelope["change"]): void {
   switch (c.op) {
     case "write":
+      events.emit(filesystemEvents.created, { ...remoteMeta(), path: c.path, kind: "file" })
       events.emit(filesystemEvents.changed, { ...remoteMeta(), path: c.path })
       return
     case "mkdir":


### PR DESCRIPTION
## Summary\n- treat remote workspace write events as both file creation candidates and content changes so tree queries invalidate when new files appear\n- keep existing content-refresh behavior by still emitting filesystem:file.changed\n- add regression coverage for remote SSE write relays and dedupe behavior\n\n## Verification\n- pnpm --filter @hachej/boring-workspace exec vitest run src/plugins/filesystemPlugin/front/data/__tests__/useFileEventStream.test.tsx src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx\n- pnpm --filter @hachej/boring-agent exec vitest run src/server/workspace/__tests__/createNodeWorkspace.watch.test.ts src/server/workspace/__tests__/createVercelSandboxWorkspace.test.ts\n- pnpm --filter @hachej/boring-workspace exec vitest run src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx\n\nCloses #202.