### PR TITLE
Add Close all action to tab right-click menu (#204)

### DIFF
--- a/packages/workspace/src/front/dock/ShadcnTab.tsx
+++ b/packages/workspace/src/front/dock/ShadcnTab.tsx
@@ -135,9 +135,10 @@ export function ShadcnTab(props: IDockviewPanelHeaderProps) {
   const displayTitle = isDirty ? title.slice(0, -2) : title
   const Icon = getFileIcon(displayTitle)
   const filePath = readStringParam(props.params, "path") ?? readPathFromPanelId(api.id)
-  const otherTabs = siblingPanels(props)
+  const groupTabs = siblingPanels(props)
     .map(panelSnapshot)
-    .filter((sibling) => sibling.id !== api.id && sibling.close)
+    .filter((panel) => panel.close)
+  const otherTabs = groupTabs.filter((sibling) => sibling.id !== api.id)
 
   // Subscribe to editor save lifecycle keyed by panelId. The badge
   // flips on at save:start and off at save:end (regardless of ok).
@@ -195,6 +196,12 @@ export function ShadcnTab(props: IDockviewPanelHeaderProps) {
     for (const sibling of otherTabs) sibling.close?.()
   }
 
+  const handleCloseAll = () => {
+    setMenu(null)
+    api.setActive?.()
+    for (const panel of groupTabs) panel.close?.()
+  }
+
   const contextMenu =
     menu && typeof document !== "undefined"
       ? createPortal(
@@ -227,6 +234,16 @@ export function ShadcnTab(props: IDockviewPanelHeaderProps) {
                 onClick={handleCloseOthers}
               >
                 Close other tabs
+              </button>
+            ) : null}
+            {groupTabs.length > 0 ? (
+              <button
+                type="button"
+                role="menuitem"
+                className="flex w-full items-center rounded-sm px-2 py-1.5 text-left text-xs hover:bg-accent hover:text-accent-foreground"
+                onClick={handleCloseAll}
+              >
+                Close all
               </button>
             ) : null}
           </div>,

--- a/packages/workspace/src/front/dock/__tests__/dock.test.tsx
+++ b/packages/workspace/src/front/dock/__tests__/dock.test.tsx
@@ -507,6 +507,35 @@ describe("ShadcnTab", () => {
     expect(siblingApi.close).toHaveBeenCalledTimes(1)
   })
 
+  it("close all closes every tab in the current group", () => {
+    const currentApi = {
+      title: "Current",
+      id: "tab-current",
+      close: vi.fn(),
+      setActive: vi.fn(),
+    }
+    const siblingApi = { title: "Sibling", id: "tab-sibling", close: vi.fn() }
+    const otherGroupApi = { title: "Other", id: "tab-other", close: vi.fn() }
+    ;(currentApi as any).group = { panels: [{ api: currentApi }, { api: siblingApi }] }
+
+    render(
+      <ShadcnTab
+        api={currentApi as any}
+        containerApi={{ panels: [{ api: currentApi }, { api: siblingApi }, { api: otherGroupApi }] } as any}
+        params={{}}
+        tabLocation={"header" as any}
+      />,
+    )
+
+    fireEvent.contextMenu(screen.getByTitle("Current"))
+    fireEvent.click(screen.getByRole("menuitem", { name: "Close all" }))
+
+    expect(currentApi.setActive).toHaveBeenCalled()
+    expect(currentApi.close).toHaveBeenCalledTimes(1)
+    expect(siblingApi.close).toHaveBeenCalledTimes(1)
+    expect(otherGroupApi.close).not.toHaveBeenCalled()
+  })
+
   it("shows copy path and hides close-other when there are no other tabs", () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.defineProperty(navigator, "clipboard", {
@@ -529,6 +558,7 @@ describe("ShadcnTab", () => {
     expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeInTheDocument()
     expect(screen.queryByRole("menuitem", { name: "Copy absolute path" })).not.toBeInTheDocument()
     expect(screen.queryByRole("menuitem", { name: "Close other tabs" })).not.toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Close all" })).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy path" }))
     expect(writeText).toHaveBeenCalledWith("src/App.tsx")


### PR DESCRIPTION
Closes #204

## Summary
- add `Close all` to the Dockview tab context menu beside the existing close variants
- scope `Close all` to the current Dockview tab group, matching the existing `Close other tabs` sibling-group behavior
- keep closing on each panel's own `close()` path so existing dirty/unsaved protections stay in effect
- add focused dock tab tests for the new menu item and its group-scoped close behavior

## Verification
- `pnpm --filter @hachej/boring-workspace test src/front/dock/__tests__/dock.test.tsx` ✅
- `pnpm --filter @hachej/boring-workspace typecheck` ✅
- `pnpm --filter workspace-playground build:deps` ✅
- manual workspace-playground validation on Vite `5204` / API `5304` ✅

## Notes
- `Close all` closes the current Dockview group, not every tab in the entire center area. This is the smallest intuitive behavior consistent with the existing tab-menu pattern.
