### PR TITLE
docs: add navigation UX specs

### DIFF
--- a/packages/agent/docs/plans/COMPOSER_SLASH_SETTINGS_UX_SPEC.md
+++ b/packages/agent/docs/plans/COMPOSER_SLASH_SETTINGS_UX_SPEC.md
@@ -21,6 +21,7 @@ Keep the composer compact and one-line by moving model/thinking controls into sl
 - No persistent model picker button.
 - No persistent thinking picker button.
 - Status can be compact text below or near composer.
+- `/model` and `/thinking` status labels are clickable buttons that open the same picker menus as the slash commands.
 
 ## Slash commands
 
@@ -57,6 +58,6 @@ Keep the composer compact and one-line by moving model/thinking controls into sl
 
 ## Success criteria
 
-- User can discover settings by typing `/`.
+- User can discover settings by typing `/` or clicking the compact `/model` / `/thinking` status labels.
 - Composer remains visually quiet with one or multiple chat panes.
-- Model/thinking state is visible but not dominant.
+- Model/thinking state is visible, clickable, and not dominant.

--- a/packages/agent/docs/plans/COMPOSER_SLASH_SETTINGS_UX_SPEC.md
+++ b/packages/agent/docs/plans/COMPOSER_SLASH_SETTINGS_UX_SPEC.md
@@ -1,0 +1,62 @@
+# Composer Slash Settings UX Spec
+
+Status: draft from POC.
+
+## Goal
+
+Keep the composer compact and one-line by moving model/thinking controls into slash menus.
+
+```text
+┌──────────────────────────────────────────────┐
+│ 📎  Ask anything...                      ↵   │
+└──────────────────────────────────────────────┘
+        /model: GPT 5.5   /thinking: medium
+```
+
+## Composer rules
+
+- Attach button on the left.
+- Text input in the center.
+- Send/stop on the right.
+- No persistent model picker button.
+- No persistent thinking picker button.
+- Status can be compact text below or near composer.
+
+## Slash commands
+
+```text
+/model             → opens model picker
+/model 1           → selects numbered model
+/model provider:id → selects exact model id
+/model gpt         → fuzzy/select by name
+
+/thinking          → opens thinking picker
+/thinking low      → set low
+/thinking medium   → set medium
+/thinking high     → set high
+/thinking off      → disable
+/think             → alias for /thinking
+```
+
+## Picker behavior
+
+- Menus open in-chat, close on selection/escape.
+- Rows must wrap or show full provider/model IDs; no hidden horizontal scroll.
+- Selected row uses neutral selection with a small check; avoid loud accent fills.
+
+## Defaults
+
+- Thinking defaults to `medium` in the POC.
+- Reasoning visibility can be on by default while the product learns user expectations.
+
+## Visual rules
+
+- Composer CTA should be calm and neutral in workspace shell.
+- Accent color is for semantic state or focus, not large persistent buttons.
+- The one-line composer should remain usable at split-pane widths.
+
+## Success criteria
+
+- User can discover settings by typing `/`.
+- Composer remains visually quiet with one or multiple chat panes.
+- Model/thinking state is visible but not dominant.

--- a/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
+++ b/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
@@ -1,0 +1,58 @@
+# Agent Chat + Sessions UX Spec
+
+Status: draft from POC.
+
+## Shape
+
+```text
+┌───────────────────────────────────────────────────────────────┐
+│ Chat stage                                                     │
+│ ┌──────────── chat pane A ────────────┐┌──── chat pane B ────┐ │
+│ │ [grip] [+] [x]                      ││ [grip] [+] [x]     │ │
+│ │ active pane gets neutral border     ││ inactive is normal │ │
+│ │                                     ││                    │ │
+│ │ composer                            ││ composer           │ │
+│ └─────────────────────────────────────┘└────────────────────┘ │
+└───────────────────────────────────────────────────────────────┘
+```
+
+## Session model
+
+- Session history is data; chat panes are views.
+- Closing a pane closes the view only, not the run/session.
+- Only opened/focused sessions become panes.
+- Clicking a session row loads it into the currently active chat pane.
+- Clicking row `open-as-tab` opens that session as an additional pane.
+
+```text
+Session row click          → replace active pane session
+Session row external icon  → open/focus separate pane
+Pane close                 → remove view only
+Pane +                     → create new session to the right
+```
+
+## Pane controls
+
+- Use DockView native tab/header for drag; fake overlay grips do not work.
+- Header controls are compact: drag grip, `+`, close.
+- Per-pane `+` belongs in the pane header, not as a clipped border overlay.
+- Active pane indication must be neutral but visible: full-pane hairline or header treatment.
+
+## Session drawer
+
+```text
+┌ Sessions ────────────── + close ┐
+│ Today                         8 │
+│ New session  33m        [open↗] │ ← row click replaces active pane
+│ New session  36m        [open↗] │ ← icon opens separate pane
+└─────────────────────────────────┘
+```
+
+- Row and open-as-tab icon need distinct hit areas.
+- Open-as-tab icon uses the same external-link visual language as deck open-in-new-tab.
+- The drawer reserves space for fixed agent-side floating controls.
+
+## Top bar rule
+
+- Do not show a global top-right `+` once per-pane `+` exists.
+- Keep session creation contextual: drawer header `+` and pane header `+`.

--- a/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
+++ b/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
@@ -36,7 +36,7 @@ Single pane:
 Session row click          → replace active pane session
 Session row external icon  → open/focus separate pane
 Pane close                 → remove view only
-Border/edge +              → create new session to the right
+Divider/edge +             → create new session to the right
 ```
 
 ## Pane controls
@@ -47,7 +47,21 @@ Border/edge +              → create new session to the right
 - With one pane, the `+` floats on the pane's right edge.
 - With adjacent panes, the `+` sits on the divider between them.
 - Implement the `+` from the chat-stage/DockView overlay layer so it can straddle the divider without being clipped by pane overflow.
-- Active pane indication must be neutral but visible: full-pane hairline or header treatment.
+- Active pane indication uses a neutral **focus frame**:
+  - a 1px inset border around the active pane;
+  - a slightly darker native header/control pill;
+  - no colored stripe, no orange, no dimming inactive content.
+
+```text
+active pane                         inactive pane
+┌══════════════════════════════┐    ┌──────────────────────┐
+║ [grip] [x]                   ║    │ [grip] [x]           │
+║                              ║    │                      │
+║ composer                     ║    │ composer             │
+└══════════════════════════════┘    └──────────────────────┘
+```
+
+The frame should read like keyboard focus for a pro editor: obvious when scanning, quiet when reading.
 
 ## Session drawer
 

--- a/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
+++ b/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
@@ -44,8 +44,8 @@ Divider/edge +             → create new session to the right
 - Use DockView native tab/header for drag; fake overlay grips do not work.
 - Header controls are compact: drag grip and close only.
 - Per-pane `+` belongs on the right edge/divider between panes, not in the pane header.
-- With one pane, the `+` is the floating button on the right of the chat/session history side.
-- With adjacent panes, the `+` sits on the divider between them.
+- With exactly one chat session pane open, the `+` is the floating button on the right of the chat/session history side.
+- With two or more chat session panes open, the `+` sits on the divider/border between panes.
 - Implement the `+` from the chat-stage/DockView overlay layer so it can straddle the divider without being clipped by pane overflow.
 - Active pane indication uses a neutral **focus frame**:
   - a 1px inset border around the active pane;

--- a/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
+++ b/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
@@ -7,12 +7,20 @@ Status: draft from POC.
 ```text
 ┌───────────────────────────────────────────────────────────────┐
 │ Chat stage                                                     │
-│ ┌──────────── chat pane A ────────────┐┌──── chat pane B ────┐ │
-│ │ [grip] [+] [x]                      ││ [grip] [+] [x]     │ │
-│ │ active pane gets neutral border     ││ inactive is normal │ │
-│ │                                     ││                    │ │
-│ │ composer                            ││ composer           │ │
-│ └─────────────────────────────────────┘└────────────────────┘ │
+│ ┌──────────── chat pane A ────────────┬──── chat pane B ────┐ │
+│ │ [grip] [x]                          │ [grip] [x]          │ │
+│ │ active pane gets neutral border     │ inactive is normal  │ │
+│ │                                     +                    │ │
+│ │ composer                            │ composer            │ │
+│ └─────────────────────────────────────┴─────────────────────┘ │
+└───────────────────────────────────────────────────────────────┘
+
+Single pane:
+┌───────────────────────────────────────────────────────────────┐
+│ ┌──────────────────── chat pane ───────────────────────────┐ + │
+│ │ [grip] [x]                                               │   │
+│ │ composer                                                 │   │
+│ └───────────────────────────────────────────────────────────┘   │
 └───────────────────────────────────────────────────────────────┘
 ```
 
@@ -28,14 +36,17 @@ Status: draft from POC.
 Session row click          → replace active pane session
 Session row external icon  → open/focus separate pane
 Pane close                 → remove view only
-Pane +                     → create new session to the right
+Border/edge +              → create new session to the right
 ```
 
 ## Pane controls
 
 - Use DockView native tab/header for drag; fake overlay grips do not work.
-- Header controls are compact: drag grip, `+`, close.
-- Per-pane `+` belongs in the pane header, not as a clipped border overlay.
+- Header controls are compact: drag grip and close only.
+- Per-pane `+` belongs on the right edge/divider between panes, not in the pane header.
+- With one pane, the `+` floats on the pane's right edge.
+- With adjacent panes, the `+` sits on the divider between them.
+- Implement the `+` from the chat-stage/DockView overlay layer so it can straddle the divider without being clipped by pane overflow.
 - Active pane indication must be neutral but visible: full-pane hairline or header treatment.
 
 ## Session drawer
@@ -55,4 +66,4 @@ Pane +                     → create new session to the right
 ## Top bar rule
 
 - Do not show a global top-right `+` once per-pane `+` exists.
-- Keep session creation contextual: drawer header `+` and pane header `+`.
+- Keep session creation contextual: drawer header `+` and pane border/edge `+`.

--- a/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
+++ b/packages/workspace/docs/plans/AGENT_CHAT_SESSIONS_UX_SPEC.md
@@ -44,7 +44,7 @@ Divider/edge +             → create new session to the right
 - Use DockView native tab/header for drag; fake overlay grips do not work.
 - Header controls are compact: drag grip and close only.
 - Per-pane `+` belongs on the right edge/divider between panes, not in the pane header.
-- With one pane, the `+` floats on the pane's right edge.
+- With one pane, the `+` is the floating button on the right of the chat/session history side.
 - With adjacent panes, the `+` sits on the divider between them.
 - Implement the `+` from the chat-stage/DockView overlay layer so it can straddle the divider without being clipped by pane overflow.
 - Active pane indication uses a neutral **focus frame**:

--- a/packages/workspace/docs/plans/AGENT_CONTROL_KNOWLEDGE_UX_SPEC.md
+++ b/packages/workspace/docs/plans/AGENT_CONTROL_KNOWLEDGE_UX_SPEC.md
@@ -1,0 +1,71 @@
+# Agent Control + Knowledge UX Spec
+
+Status: draft from POC.
+
+## Goal
+
+Make the collapsed agent side an agent cockpit, not a chat-history drawer.
+
+```text
+Floating controls
+┌───────┐
+│ ↺     │ Sessions, only in Chat mode
+│ Chat  │ Return to chat stage
+│ Agent │ Open agent control stage
+└───────┘
+```
+
+## Agent control stage
+
+Agent control replaces the chat stage.
+
+```text
+┌──────────────────────────────────────────────┐
+│ Agent / Control center                  back │
+├──────────────────────────────────────────────┤
+│ Resume chat                                  │
+│                                              │
+│ Knowledge                                    │
+│  profile.md                                  │
+│  project.md                                  │
+│  decisions.md                                │
+│  skills/.../SKILL.md                         │
+│                                              │
+│ Plugins + tools                              │
+│ Settings                                     │
+└──────────────────────────────────────────────┘
+```
+
+## Ownership
+
+- Agent owns memory, skills, tools, plugins, model settings, and session state.
+- Workspace owns editors and file surfaces.
+- Clicking memory/skill docs opens files in workspace editor via UI command.
+
+```text
+Agent control list item
+  → dispatch openFile(.boring-agent/...md)
+  → workspace opens editor pane
+```
+
+## Storage convention
+
+- Boring-native v1 uses workspace-local Markdown under `.boring-agent/`.
+- Provider-backed memory can come later behind adapters.
+
+```text
+.boring-agent/
+  memory/
+    profile.md
+    project.md
+    decisions.md
+  skills/
+    boring-plugin-build/
+      SKILL.md
+```
+
+## Interaction rules
+
+- Agent button label/icon must be neutral: “Agent”, not “Chat settings”.
+- Opening Agent control must not close session drawer implicitly unless needed for space.
+- Agent control internal navigation should live inside the stage, not in workspace left rail.

--- a/packages/workspace/docs/plans/NAVIGATION_UX_OVERVIEW_SPEC.md
+++ b/packages/workspace/docs/plans/NAVIGATION_UX_OVERVIEW_SPEC.md
@@ -1,0 +1,38 @@
+# Navigation UX Overview Spec
+
+Status: draft from leftbar/chat POC visual iterations.
+
+## Goal
+
+Separate workspace navigation from agent control while keeping both reachable from the main shell.
+
+```text
+┌─────────────────────────────────────────────────────────────────────┐
+│ App top bar                                      Search / host chrome │
+├───────────────┬───────────────────────────────┬─────────────────────┤
+│ Agent rail    │ Chat stage / Agent control    │ Workspace surface   │
+│ Chat/Sessions │                               │ files/editors/panes │
+│ Agent         │                               │                     │
+└───────────────┴───────────────────────────────┴─────────────────────┘
+```
+
+## Decisions
+
+- Workspace left rail contains workspace/plugin categories only.
+- Agent side owns chat, sessions, memory/skills, tools, plugins, and settings.
+- Agent control opens from an agent-neutral floating control, not a workspace tab.
+- Opening Agent control replaces the chat stage; it does not open in the workspace surface.
+- Memory and skill files are listed by Agent control but edited in the workspace editor.
+
+## Non-goals
+
+- Do not overload workspace `left-tab` plugins for agent settings or session history.
+- Do not auto-open every historical chat as a DockView pane.
+- Do not put a persistent workspace rail in collapsed mode; collapsed means absent except stable reopen control.
+
+## Success criteria
+
+- A user can answer: “Am I navigating workspace content, or controlling the agent?”
+- One opened chat session equals one chat pane/tab.
+- Active workspace category visually belongs to its content pane.
+- Active chat pane is recognizable without loud color.

--- a/packages/workspace/docs/plans/README.md
+++ b/packages/workspace/docs/plans/README.md
@@ -9,4 +9,9 @@ Active ownership records live in this folder.
 - `MACRO_PLUGIN_GENERIC_HELPERS_AUDIT.md` - macro plugin audit for reusable explorer/surface/event helper extraction.
 - `PLUGIN_OUTPUTS_ISOLATION_PLAN.md` - plugin ownership and isolation plan.
 - `UI_BRIDGE_OWNERSHIP_REFACTOR.md` - UI bridge ownership decision.
+- `NAVIGATION_UX_OVERVIEW_SPEC.md` - shell-level split between workspace navigation and agent control.
+- `AGENT_CHAT_SESSIONS_UX_SPEC.md` - chat panes, sessions drawer, active pane, and per-pane new-session affordance.
+- `AGENT_CONTROL_KNOWLEDGE_UX_SPEC.md` - agent control center, memory/skills, and workspace editor handoff.
+- `WORKSPACE_LEFT_NAV_UX_SPEC.md` - plugin category rail, active grey connection, and collapse behavior.
+- `WORKSPACE_SURFACE_UX_SPEC.md` - workbench surface states, empty state, and neutral DockView chrome.
 - `archive/` - superseded implementation plans kept for history.

--- a/packages/workspace/docs/plans/WORKSPACE_LEFT_NAV_UX_SPEC.md
+++ b/packages/workspace/docs/plans/WORKSPACE_LEFT_NAV_UX_SPEC.md
@@ -1,0 +1,72 @@
+# Workspace Left Navigation UX Spec
+
+Status: draft from POC.
+
+## Goal
+
+Workspace left navigation is only for workspace/plugin categories. File tree is one category.
+
+```text
+┌ rail ┬ content pane ┐
+│ ☰    │ Files     🔍 │
+│      │              │
+│ ▣    │ deck/        │
+│ ◇    │ README.md    │
+│      │ data.csv     │
+└──────┴──────────────┘
+```
+
+## Category model
+
+- Each plugin can register workspace categories through left-tab outputs.
+- Built-in file tree is just the `Files` category.
+- Agent settings, sessions, memory, and tools do not appear here.
+
+```text
+workspace categories = files + data + deck + app plugin tabs
+agent categories     = chat + sessions + memory + tools + settings
+```
+
+## Active state
+
+Active category should visually connect to the content pane as one calm grey surface.
+
+```text
+Good:
+┌──────┬──────────────┐
+│      │              │
+│ [▣───┼ Files        │  continuous grey bridge
+│      │              │
+└──────┴──────────────┘
+
+Bad:
+┌──────│──────────────┐
+│ [▣] │ Files         │  vertical seam / accent stripe
+└──────│──────────────┘
+```
+
+Rules:
+- No orange/accent marker for active workspace category.
+- No side stripe.
+- Active icon background and pane background must match.
+- Header may repeat the active icon, but in neutral foreground.
+
+## Collapse behavior
+
+Collapsed means the workspace left pane and rail are absent.
+
+```text
+Open:
+┌ rail ┬ files ┬ editor ┐
+│ ☰    │ ...   │ ...    │
+└──────┴───────┴────────┘
+
+Collapsed:
+┌☰──── editor/workbench ┐
+│                       │
+└───────────────────────┘
+```
+
+- Reopen via stable menu icon near the top-left of the workbench surface.
+- Use the same menu icon for collapse and uncollapse unless a later design pass standardizes sidebar arrows.
+- Do not keep a thin category rail visible in collapsed mode.

--- a/packages/workspace/docs/plans/WORKSPACE_SURFACE_UX_SPEC.md
+++ b/packages/workspace/docs/plans/WORKSPACE_SURFACE_UX_SPEC.md
@@ -1,0 +1,66 @@
+# Workspace Surface UX Spec
+
+Status: draft from POC.
+
+## Goal
+
+The right workspace surface is where files, artifacts, decks, and plugin panels open. It is separate from agent-side controls.
+
+```text
+┌ chat stage ┬ workspace surface ┐
+│            │ ┌ left nav ┬ pane │
+│            │ │ Files    │ ...  │
+│            │ └──────────┴──────┘
+└────────────┴───────────────────┘
+```
+
+## Open / collapsed states
+
+```text
+Surface open, left pane open
+┌────────────────────────────────────┐
+│ ☰ Files                     search │
+│ deck/                              │
+│ README.md                          │
+├────────────────────────────────────┤
+│ editor / artifact / empty state    │
+└────────────────────────────────────┘
+
+Surface open, left pane collapsed
+┌☰───────────────────────────────────┐
+│ editor / artifact / empty state    │
+└────────────────────────────────────┘
+```
+
+## Empty state
+
+- Empty state should teach the surface without duplicating controls.
+- Do not show a second “show workspace menu” CTA when the stable menu icon exists.
+- Empty labels use neutral border/foreground, not accent line.
+
+```text
+Workbench
+Nothing open yet
+Open a source item, or let the agent produce an artifact here.
+```
+
+## DockView chrome
+
+- Workspace DockView tabs use neutral active state.
+- Remove accent pseudo-elements from active tabs.
+- Drag/drop/resize hover may use subtle neutral feedback; avoid orange unless the action is truly semantic.
+
+## Surface resolver flow
+
+```text
+agent emits UI command
+  → workspace bridge
+  → surface resolver
+  → open panel/editor in workspace surface
+```
+
+## Success criteria
+
+- Workspace surface never feels like agent settings.
+- Collapsed left pane leaves a clean work area and one obvious reopen control.
+- Active workspace category and content pane read as connected.


### PR DESCRIPTION
## Summary

Adds plan-only UX specs distilled from the chat/workspace navigation POC:

- shell-level split between workspace navigation and agent control
- chat panes/sessions drawer/per-pane new-session behavior
- agent control center + .boring-agent knowledge docs
- workspace category rail and continuous grey active state
- workspace surface open/collapsed states
- compact composer slash settings for model/thinking

## Notes

This PR intentionally contains docs/plans only. No implementation files are changed.

## Validation

- docs-only change; no build required
