### PR TITLE
Add clickable workspace session links (#211)

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -362,6 +362,11 @@ export function WorkspaceAgentFront<
     failed: false,
   }))
   const [freshEmptySession, setFreshEmptySession] = useState<{ workspaceId: string; id: string } | null>(null)
+  const [requestedSessionState, setRequestedSessionState] = useState<{
+    workspaceId: string
+    sessionId: string
+    missing: boolean
+  } | null>(null)
   const workspaceWarmupStatus = workspaceWarmupState.workspaceId === workspaceId
     ? workspaceWarmupState.status
     : PREPARING_WARMUP_STATUS
@@ -601,6 +606,7 @@ export function WorkspaceAgentFront<
     setInitialRemoteSessionCreating({ workspaceId, creating: false })
     setInitialRemoteSessionCreateFailed({ workspaceId, failed: false })
     setFreshEmptySession(null)
+    setRequestedSessionState(null)
   }, [workspaceId])
 
   useEffect(() => {
@@ -749,6 +755,38 @@ export function WorkspaceAgentFront<
     onActiveSessionIdChange?.(effectiveActiveSessionId ?? null)
   }, [effectiveActiveSessionId, onActiveSessionIdChange, remoteSessionsPending])
 
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const command = (event as CustomEvent).detail as { kind?: unknown; params?: Record<string, unknown> } | undefined
+      if (command?.kind !== "openSession") return
+      const sessionId = typeof command.params?.sessionId === "string" ? command.params.sessionId : null
+      if (!sessionId) return
+      const sessionExists = resolvedSessions.some((session) => session.id === sessionId)
+      if (!sessionExists) {
+        setRequestedSessionState({ workspaceId, sessionId, missing: true })
+        setNavOpen(true)
+        return
+      }
+      setRequestedSessionState({ workspaceId, sessionId, missing: false })
+      resolvedSwitch(sessionId)
+      setNavOpen(true)
+    }
+    globalThis.addEventListener?.(UI_COMMAND_EVENT, handler)
+    return () => globalThis.removeEventListener?.(UI_COMMAND_EVENT, handler)
+  }, [resolvedSessions, resolvedSwitch, setNavOpen, workspaceId])
+
+  useEffect(() => {
+    setRequestedSessionState((current) => {
+      if (!current || current.workspaceId !== workspaceId) return current
+      if (current.missing) {
+        return resolvedSessions.some((session) => session.id === current.sessionId)
+          ? { workspaceId, sessionId: current.sessionId, missing: false }
+          : current
+      }
+      return effectiveActiveSessionId === current.sessionId ? null : current
+    })
+  }, [effectiveActiveSessionId, resolvedSessions, workspaceId])
+
   const workbenchBlocked = workspaceWarmupStatus.status !== "ready"
   const workbenchOverlay = workbenchBlocked ? <WorkbenchWarmupOverlay status={workspaceWarmupStatus} /> : undefined
 
@@ -868,7 +906,6 @@ export function WorkspaceAgentFront<
             <ChatSessionTransitionState />
           ) : (
             <ChatLayout
-              className={className}
               nav={effectiveNavOpen ? "session-list" : null}
               navParams={{
                 sessions: resolvedSessions,
@@ -905,6 +942,8 @@ export function WorkspaceAgentFront<
                 setSurfaceOpen(true)
                 setWorkbenchLeftOpen(true)
               } : undefined}
+              className={className}
+              statusBanner={requestedSessionState?.workspaceId === workspaceId ? requestedSessionState : null}
             />
           )}
         </div>

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -824,6 +824,51 @@ describe("WorkspaceAgentFront", () => {
     )
   })
 
+  it("opens a referenced session through the workspace openSession command", async () => {
+    render(
+      <WorkspaceAgentFront
+        workspaceId="session-link-workspace"
+        chatPanel={ChatPanel}
+        sessions={[{ id: "sess-source", title: "Source" }, { id: "sess-target", title: "Target" }]}
+        activeSessionId="sess-source"
+        persistenceEnabled={false}
+      />,
+    )
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(UI_COMMAND_EVENT, {
+        detail: { kind: "openSession", params: { sessionId: "sess-target" } satisfies UiCommand["params"] },
+      }))
+    })
+
+    await waitFor(() => {
+      expect(screen.getByLabelText("Session browser")).toHaveAttribute("aria-hidden", "false")
+      expect(screen.getByText("Target")).toBeInTheDocument()
+    })
+  })
+
+  it("shows a clear missing-session banner when a referenced session is unavailable", async () => {
+    render(
+      <WorkspaceAgentFront
+        workspaceId="missing-session-link-workspace"
+        chatPanel={ChatPanel}
+        sessions={[{ id: "sess-source", title: "Source" }]}
+        activeSessionId="sess-source"
+        persistenceEnabled={false}
+      />,
+    )
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(UI_COMMAND_EVENT, {
+        detail: { kind: "openSession", params: { sessionId: "sess-missing" } satisfies UiCommand["params"] },
+      }))
+    })
+
+    expect(await screen.findByText(/was not found in this workspace\./)).toBeInTheDocument()
+    expect(screen.getByText("sess-missing")).toBeInTheDocument()
+    expect(screen.getByLabelText("Session browser")).toHaveAttribute("aria-hidden", "false")
+  })
+
   it("cancels pending session-scoped attention when switching sessions", async () => {
     const user = userEvent.setup()
     const onSwitchSession = vi.fn()

--- a/packages/workspace/src/front/bridge/WorkspaceLink.tsx
+++ b/packages/workspace/src/front/bridge/WorkspaceLink.tsx
@@ -7,6 +7,7 @@ export type WorkspaceLinkTarget =
   | { kind: "openSurface"; surfaceKind: string; target: string; meta?: Record<string, unknown> }
   | { kind: "openPanel"; id: string; component: string; title?: string; params?: Record<string, unknown> }
   | { kind: "expandToFile"; path: string }
+  | { kind: "openSession"; sessionId: string }
 
 export interface WorkspaceLinkProps {
   to: WorkspaceLinkTarget
@@ -35,6 +36,8 @@ export function workspaceLinkCommand(to: WorkspaceLinkTarget): UiCommand {
       }
     case "expandToFile":
       return { kind: "expandToFile", params: { path: to.path } }
+    case "openSession":
+      return { kind: "openSession", params: { sessionId: to.sessionId } }
   }
 }
 

--- a/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
+++ b/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
@@ -121,6 +121,14 @@ describe("dispatchUiCommand", () => {
     }
   })
 
+  it("openSession is a known command kind but does not touch the workbench dispatcher", () => {
+    const c = ctx()
+    expect(() => dispatchUiCommand({ kind: "openSession", params: { sessionId: "sess-123" } }, c)).not.toThrow()
+    expect(c.__surface.__opened).toEqual([])
+    expect(c.__surface.__panels).toEqual([])
+    expect(c.__surface.__surfaces).toEqual([])
+  })
+
   it("openPanel calls surface.openPanel with the full config", () => {
     const c = ctx()
     dispatchUiCommand(

--- a/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
+++ b/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
@@ -30,6 +30,7 @@ const KNOWN_KINDS = new Set([
   "openFile",
   "openSurface",
   "openPanel",
+  "openSession",
   "navigateToLine",
   "expandToFile",
   "showNotification",

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -372,6 +372,13 @@ export function ChatLayout(props: ChatLayoutProps) {
               chatCollapsed ? "opacity-0" : "opacity-100",
             )}
           >
+            {props.statusBanner ? (
+              <div className="border-b border-[color:oklch(from_var(--border)_l_c_h/0.6)] bg-muted/40 px-4 py-2 text-sm text-foreground">
+                {props.statusBanner.missing
+                  ? <>Session <code className="rounded bg-background px-1 py-0.5 text-xs">{props.statusBanner.sessionId}</code> was not found in this workspace.</>
+                  : <>Opening session <code className="rounded bg-background px-1 py-0.5 text-xs">{props.statusBanner.sessionId}</code>…</>}
+              </div>
+            ) : null}
             <PanelSlot id={centerId} params={props.centerParams} />
           </div>
           {!chatCollapsed ? (

--- a/packages/workspace/src/front/layout/types.ts
+++ b/packages/workspace/src/front/layout/types.ts
@@ -1,5 +1,10 @@
 import type { ReactNode } from "react"
 
+export interface ChatLayoutStatusBanner {
+  sessionId: string
+  missing: boolean
+}
+
 export interface IdeLayoutProps {
   sidebar?: string
   center?: string
@@ -23,4 +28,5 @@ export interface ChatLayoutProps {
   surfaceButtonBottomOffset?: number
   onOpenSidebar?: () => void
   className?: string
+  statusBanner?: ChatLayoutStatusBanner | null
 }


### PR DESCRIPTION
## Summary
- add an `openSession` workspace link/command target for clickable session references
- have `WorkspaceAgentFront` intentionally switch to the referenced session in the existing chat surface
- show a clear inline banner when the requested session is missing from the current workspace

## Tradeoff decision
For #211, this PR ships Option B first: reuse the existing agent/chat transcript UI instead of building a separate session-history viewer. This is the smallest low-risk path because it reuses current session loading/switching behavior and avoids duplicating transcript rendering.

## Verification
- `pnpm --filter @hachej/boring-workspace test src/app/front/__tests__/WorkspaceAgentFront.test.tsx src/front/bridge/__tests__/uiCommandDispatcher.test.ts` ✅
- `pnpm --filter @hachej/boring-workspace typecheck` ✅

## Notes
- missing sessions do not silently create/overwrite anything; they open the session drawer and show a clear message instead
- no workspace-playground run in this PR; behavior covered by unit tests only
