### PR TITLE
fix(cli): avoid auth check blocking workspace cold start

### DIFF
--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -830,7 +830,10 @@ async function startWorkspacesMode(opts: {
 
   console.log(`  workspaces ${registry.path}`)
   console.log(`  ${initialUrl}  ready\n`)
-  if ((await checkAuth()) === 0) console.log(AUTH_GUIDE)
+  // Do not run checkAuth() in workspaces server startup. It imports Pi's model
+  // registry after the socket is listening, which can block the event loop and
+  // make the first direct workspace URL wait on static assets. The browser can
+  // surface provider/auth state through /api/v1/agent/models when needed.
   openBrowser(initialUrl)
 }
 

--- a/packages/workspace/src/app/front/__tests__/WorkspaceBackgroundBoot.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceBackgroundBoot.test.tsx
@@ -10,16 +10,18 @@ function json(data: unknown, init?: ResponseInit) {
   })
 }
 
+const SESSION_PRELOAD_PATHS = ["/api/v1/tree?path=.", "/api/v1/agent/sessions"]
+
 afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-it("runs warmup in the background and seeds the tree cache", async () => {
+it("runs warmup in the background without gating on sessions and seeds the tree cache", async () => {
   const onStatusChange = vi.fn()
   const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
     const url = String(input)
     if (url.includes("/api/v1/tree")) return json({ entries: [{ name: "src", type: "directory", path: "src" }] })
-    if (url.includes("/api/v1/agent/sessions")) return json([])
+    if (url.includes("/api/v1/agent/sessions")) throw new Error("sessions should not gate workspace warmup")
     if (url.includes("/api/v1/ready-status")) return new Response(null, { status: 200 })
     return new Response(null, { status: 404 })
   })
@@ -35,6 +37,7 @@ it("runs warmup in the background and seeds the tree cache", async () => {
   )
 
   await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith({ status: "ready" }))
+  expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/api/v1/agent/sessions"))).toBe(false)
   expect(getPreloadedTreeEntries("/base", "w-bg", ".")).toEqual([
     { name: "src", type: "directory", path: "src" },
   ])
@@ -89,6 +92,7 @@ it("keeps retryable AGENT_RUNTIME_NOT_READY as preparing", async () => {
     <WorkspaceBackgroundBoot
       workspaceId="w-runtime-preparing"
       requestHeaders={{ "x-boring-workspace-id": "w-runtime-preparing" }}
+      preloadPaths={SESSION_PRELOAD_PATHS}
       onStatusChange={onStatusChange}
     />,
   )
@@ -126,6 +130,7 @@ it("keeps polling transient runtime-preparing warmup after ready-status complete
     <WorkspaceBackgroundBoot
       workspaceId="w-runtime-eventually-ready"
       requestHeaders={{ "x-boring-workspace-id": "w-runtime-eventually-ready" }}
+      preloadPaths={SESSION_PRELOAD_PATHS}
       onStatusChange={onStatusChange}
     />,
   )
@@ -299,6 +304,7 @@ it("reports JSON error envelope messages for non-retryable warmup failures", asy
     <WorkspaceBackgroundBoot
       workspaceId="w-runtime-failed"
       requestHeaders={{ "x-boring-workspace-id": "w-runtime-failed" }}
+      preloadPaths={SESSION_PRELOAD_PATHS}
       onStatusChange={onStatusChange}
     />,
   )

--- a/packages/workspace/src/app/front/__tests__/WorkspaceBootGate.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceBootGate.test.tsx
@@ -2,13 +2,15 @@ import { render, screen, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { WorkspaceBootGate } from "../WorkspaceBootGate"
 
+const SESSION_PRELOAD_PATHS = ["/api/v1/tree?path=.", "/api/v1/agent/sessions"]
+
 describe("WorkspaceBootGate", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
   it("preloads workspace endpoints before rendering children", async () => {
-    const fetchMock = vi.fn(async () => new Response(null, { status: 204 }))
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => new Response(null, { status: 204 }))
     vi.stubGlobal("fetch", fetchMock)
 
     render(
@@ -29,12 +31,7 @@ describe("WorkspaceBootGate", () => {
         headers: { "x-boring-workspace-id": "w1" },
       }),
     )
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/base/api/v1/agent/sessions",
-      expect.objectContaining({
-        headers: { "x-boring-workspace-id": "w1" },
-      }),
-    )
+    expect(fetchMock.mock.calls.some(([input]) => String(input).includes("/api/v1/agent/sessions"))).toBe(false)
   })
 
   it("skips agent runtime warmup when provisioning is disabled", async () => {
@@ -73,7 +70,7 @@ describe("WorkspaceBootGate", () => {
     vi.stubGlobal("fetch", fetchMock)
 
     render(
-      <WorkspaceBootGate workspaceId="w1">
+      <WorkspaceBootGate workspaceId="w1" preloadPaths={SESSION_PRELOAD_PATHS}>
         <div>Workspace ready</div>
       </WorkspaceBootGate>,
     )

--- a/packages/workspace/src/app/front/workspacePreload.ts
+++ b/packages/workspace/src/app/front/workspacePreload.ts
@@ -1,6 +1,6 @@
 import { setPreloadedTreeEntries } from "../../plugins/filesystemPlugin/front/data/treePreloadCache"
 
-export const DEFAULT_BOOT_PRELOAD_PATHS = ["/api/v1/tree?path=.", "/api/v1/agent/sessions"]
+export const DEFAULT_BOOT_PRELOAD_PATHS = ["/api/v1/tree?path=."]
 
 const PREPARING_ERROR_CODES = new Set([
   "WORKSPACE_NOT_READY",


### PR DESCRIPTION
Stops workspaces mode from importing Pi auth/model registry after the HTTP socket starts listening. That cold import can block static asset serving for direct workspace URLs. Auth/model state remains available through /api/v1/agent/models.\n\nVerified:\n- pnpm --filter @hachej/boring-ui-cli run typecheck\n- pnpm --filter @hachej/boring-ui-cli exec vitest run src/front/App.test.tsx src/__tests__/cli.integration.test.ts