### PR TITLE
fix(workspace): harden runtime plugin reload evals

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -4,7 +4,11 @@ import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { FileUIPart } from 'ai'
 import { ArtifactOpenProvider } from '../ArtifactOpenContext'
-import { WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT } from '../../shared/agentPluginEvents'
+import {
+  WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT,
+  WORKSPACE_COMMAND_NOTIFY_EVENT,
+  type CommandNotifyPayload,
+} from '../../shared/agentPluginEvents'
 import type { PiChatEvent, PiChatStatus } from '../../shared/chat'
 import type { AvailableModel, ModelSelection, ThinkingLevel } from '../chatPanelSettings'
 import { DEFAULT_THINKING } from '../chatPanelSettings'
@@ -15,6 +19,7 @@ import { builtinCommands, createCommandRegistry } from '../slashCommands'
 import type { ToolRendererOverrides } from '../bareToolRenderers'
 import { mergeShadcnToolRenderers } from '../toolRenderers'
 import type { PluginUpdateState } from '../composer/PluginUpdateStatus'
+import type { CommandRunState } from '../composer/CommandRunStatus'
 import { useComposerHistory } from '../useComposerHistory'
 import { useComposerPickers } from '../useComposerPickers'
 import { useChatModelSelection } from '../hooks/useChatModelSelection'
@@ -316,6 +321,7 @@ export function PiChatPanel({
   const [localNotices, setLocalNotices] = useState<PanelNotice[]>([])
   const [dismissedNoticeIds, setDismissedNoticeIds] = useState<Set<string>>(() => new Set())
   const [pluginUpdateState, setPluginUpdateState] = useState<PluginUpdateState | null>(null)
+  const [commandNotifyState, setCommandNotifyState] = useState<CommandRunState | null>(null)
   const [serverSkillsRefreshKey, setServerSkillsRefreshKey] = useState(0)
   const [localSubmittedSessionId, setLocalSubmittedSessionId] = useState<string | undefined>()
   const localSubmittedSessionRef = useRef<string | undefined>(undefined)
@@ -479,6 +485,25 @@ export function PiChatPanel({
   }, [reloadAgentPlugins])
 
   const dismissPluginUpdate = useCallback(() => setPluginUpdateState(null), [])
+
+  const dismissCommandNotify = useCallback(() => setCommandNotifyState(null), [])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const onCommandNotify = (event: Event) => {
+      const payload = (event as CustomEvent<CommandNotifyPayload>).detail
+      if (!payload || typeof payload.message !== 'string') return
+      const tone = payload.tone
+      if (tone === 'error') {
+        setCommandNotifyState({ kind: 'error', command: '', message: payload.message })
+      } else {
+        // 'success' and 'info' both use the success banner tone
+        setCommandNotifyState({ kind: 'success', command: '', detail: payload.message })
+      }
+    }
+    window.addEventListener(WORKSPACE_COMMAND_NOTIFY_EVENT, onCommandNotify as EventListener)
+    return () => window.removeEventListener(WORKSPACE_COMMAND_NOTIFY_EVENT, onCommandNotify as EventListener)
+  }, [])
 
   useEffect(() => {
     if (!hotReloadEnabled || typeof window === 'undefined') return
@@ -715,6 +740,7 @@ export function PiChatPanel({
 
   useEffect(() => {
     setPluginUpdateState(null)
+    setCommandNotifyState(null)
     setLocalNotices([])
     setDismissedNoticeIds(new Set())
   }, [activeSessionId])
@@ -907,6 +933,8 @@ export function PiChatPanel({
               pluginUpdateState={pluginUpdateState}
               onDismissPluginUpdate={dismissPluginUpdate}
               onRunPluginUpdate={runPluginUpdate}
+              commandNotifyState={commandNotifyState}
+              onDismissCommandNotify={dismissCommandNotify}
               attachmentNotice={attachmentNotice}
               onAttachmentNotice={setAttachmentNotice}
               mentionState={mentionState}

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -18,7 +18,7 @@ import type { PluginUpdateState } from '../composer/PluginUpdateStatus'
 import { useComposerHistory } from '../useComposerHistory'
 import { useComposerPickers } from '../useComposerPickers'
 import { useChatModelSelection } from '../hooks/useChatModelSelection'
-import { useServerSkills } from '../hooks/useServerSkills'
+import { useServerCommands } from '../hooks/useServerCommands'
 import { useAttachmentNotice } from '../hooks/useAttachmentNotice'
 import {
   composerNoticeForRuntimeDependencies,
@@ -340,16 +340,14 @@ export function PiChatPanel({
     for (const command of commands) next.register(command)
     return next
   }, [apiBaseUrl, commands, extraCommands, hotReloadEnabled, normalizedRequestHeaders, serverResourcesEnabled, serverSkillsRefreshKey, storageScope])
-  const skillsStamp = useServerSkills({
-    apiBaseUrl,
-    fetch,
+  const commandsStamp = useServerCommands({
     registry,
-    refreshKey: serverSkillsRefreshKey,
     requestHeaders: normalizedRequestHeaders,
-    storageScope,
+    sessionId: activeSessionId ?? 'default',
+    refreshKey: serverSkillsRefreshKey,
     enabled: serverResourcesEnabled,
   })
-  const allCommands = useMemo(() => registry.list(), [registry, skillsStamp])
+  const allCommands = useMemo(() => registry.list(), [registry, commandsStamp])
 
   const activeChatSessionId = selectedChatState?.sessionId
   const warmupNotice = composerNoticeForWarmup(workspaceWarmupStatus)

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -8,6 +8,8 @@ import type { QueuedUserMessage } from '../../../shared/chat'
 import type { AvailableModel, ModelSelection, ThinkingLevel } from '../../chatPanelSettings'
 import type { PluginUpdateState } from '../../composer/PluginUpdateStatus'
 import { PluginUpdateStatus } from '../../composer/PluginUpdateStatus'
+import type { CommandRunState } from '../../composer/CommandRunStatus'
+import { CommandRunStatus } from '../../composer/CommandRunStatus'
 import {
   ModelPickerMenu,
   ModelSelectTrigger,
@@ -79,6 +81,8 @@ export interface PiChatComposerSurfaceProps {
   pluginUpdateState: PluginUpdateState | null
   onDismissPluginUpdate: () => void
   onRunPluginUpdate: () => Promise<string>
+  commandNotifyState: CommandRunState | null
+  onDismissCommandNotify: () => void
   attachmentNotice?: string | null
   onAttachmentNotice: (message: string) => void
   mentionState: MentionState | null
@@ -134,6 +138,8 @@ export function PiChatComposerSurface({
   pluginUpdateState,
   onDismissPluginUpdate,
   onRunPluginUpdate,
+  commandNotifyState,
+  onDismissCommandNotify,
   attachmentNotice,
   onAttachmentNotice,
   mentionState,
@@ -240,6 +246,10 @@ export function PiChatComposerSurface({
           onRetry={onRunPluginUpdate}
         />
       ) : null}
+      <CommandRunStatus
+        state={commandNotifyState}
+        onDismiss={onDismissCommandNotify}
+      />
       {attachmentNotice ? (
         <div
           role="status"

--- a/packages/agent/src/front/composer/CommandRunStatus.tsx
+++ b/packages/agent/src/front/composer/CommandRunStatus.tsx
@@ -1,0 +1,99 @@
+/**
+ * Server slash-command run status banner. Rendered above the composer in the
+ * same slot and through the same shared `ComposerStatusBanner` as the
+ * `/reload` banner (`PluginUpdateStatus`) — server commands like
+ * `/open-<plugin>` report progress in the status bar, not in the chat
+ * transcript.
+ *
+ * Surfaces:
+ *  - "running"  — accent pulse, while /api/v1/agent/commands/execute is in flight.
+ *  - "success"  — green accent with an optional detail line (e.g. "ran in 12ms");
+ *    auto-dismisses like the reload success banner.
+ *  - "error"    — red accent with the failure reason and a dismiss button.
+ */
+import { useEffect, useRef, type ReactElement } from "react"
+import { ComposerStatusBanner } from "./ComposerStatusBanner"
+
+export type CommandRunState =
+  | { kind: "running"; command: string }
+  | { kind: "success"; command: string; detail?: string }
+  | { kind: "error"; command: string; message: string }
+
+export interface CommandRunStatusProps {
+  state: CommandRunState | null
+  onDismiss: () => void
+  /** Auto-dismiss clean success banners. Set to 0 to disable. */
+  successAutoDismissMs?: number
+  /** Width class supplied by ChatPanel so the banner matches the composer. */
+  maxWidthClassName?: string
+}
+
+export function CommandRunStatus({
+  state,
+  onDismiss,
+  successAutoDismissMs = 1400,
+  maxWidthClassName = "max-w-3xl",
+}: CommandRunStatusProps): ReactElement | null {
+  const onDismissRef = useRef(onDismiss)
+  useEffect(() => {
+    onDismissRef.current = onDismiss
+  }, [onDismiss])
+
+  const successKey = state?.kind === "success" ? `${state.command}:${state.detail ?? ""}` : null
+  useEffect(() => {
+    if (!state || state.kind !== "success" || successAutoDismissMs <= 0) return
+    const timeout = window.setTimeout(() => onDismissRef.current(), successAutoDismissMs)
+    return () => window.clearTimeout(timeout)
+  }, [state?.kind, successKey, successAutoDismissMs])
+
+  if (!state) return null
+
+  if (state.kind === "running") {
+    return (
+      <ComposerStatusBanner
+        tone="running"
+        dataAttribute="data-boring-command-run"
+        maxWidthClassName={maxWidthClassName}
+        runningContent={
+          <>
+            Running <code className="font-mono">/{state.command}</code>…
+          </>
+        }
+      />
+    )
+  }
+
+  if (state.kind === "success") {
+    return (
+      <ComposerStatusBanner
+        tone="success"
+        dataAttribute="data-boring-command-run"
+        maxWidthClassName={maxWidthClassName}
+        title={
+          <>
+            Ran <code className="font-mono">/{state.command}</code>
+          </>
+        }
+        detail={state.detail}
+        onDismiss={onDismiss}
+        dismissAriaLabel="Dismiss command status"
+      />
+    )
+  }
+
+  return (
+    <ComposerStatusBanner
+      tone="error"
+      dataAttribute="data-boring-command-run"
+      maxWidthClassName={maxWidthClassName}
+      title={
+        <>
+          <code className="font-mono">/{state.command}</code> failed.
+        </>
+      }
+      message={state.message}
+      onDismiss={onDismiss}
+      dismissAriaLabel="Dismiss command status"
+    />
+  )
+}

--- a/packages/agent/src/front/composer/ComposerStatusBanner.tsx
+++ b/packages/agent/src/front/composer/ComposerStatusBanner.tsx
@@ -1,0 +1,152 @@
+/**
+ * Shared presentational status banner rendered above the composer. It owns the
+ * three visual tones (running / success / error) and nothing else — no state,
+ * no timers, no domain copy. Callers map their own state onto these props and
+ * own any auto-dismiss timing.
+ *
+ * Used by:
+ *  - `PluginUpdateStatus` — the `/reload` banner (restart warnings + diagnostics
+ *    passed as `children`).
+ *  - `CommandRunStatus` — server slash-command runs (e.g. `/open-<plugin>`).
+ *
+ * Keeping a single component here means both surfaces stay visually identical:
+ * a server command and a reload report through the same status bar.
+ */
+import type { ReactElement, ReactNode } from "react"
+import { cn } from "../lib"
+
+export type ComposerStatusTone = "running" | "success" | "error"
+
+export interface ComposerStatusBannerProps {
+  tone: ComposerStatusTone
+  /**
+   * Full data attribute name (e.g. "data-boring-plugin-update"). Its value is
+   * set to the tone so existing selectors like
+   * `[data-boring-plugin-update="success"]` keep working.
+   */
+  dataAttribute: string
+  /** running tone: inline content next to the pulse. */
+  runningContent?: ReactNode
+  /** success/error tone: the bold title line. */
+  title?: ReactNode
+  /** success tone: optional muted detail line under the title. */
+  detail?: ReactNode
+  /** error tone: monospace body (the failure message). */
+  message?: ReactNode
+  /** Extra content rendered below the success header (diagnostics/warnings). */
+  children?: ReactNode
+  onDismiss?: () => void
+  onRetry?: () => void
+  retryLabel?: string
+  dismissAriaLabel?: string
+  maxWidthClassName?: string
+}
+
+export function ComposerStatusBanner({
+  tone,
+  dataAttribute,
+  runningContent,
+  title,
+  detail,
+  message,
+  children,
+  onDismiss,
+  onRetry,
+  retryLabel = "Try again",
+  dismissAriaLabel = "Dismiss status",
+  maxWidthClassName = "max-w-3xl",
+}: ComposerStatusBannerProps): ReactElement {
+  const toneAttr = { [dataAttribute]: tone }
+
+  if (tone === "running") {
+    return (
+      <div
+        {...toneAttr}
+        role="status"
+        aria-live="polite"
+        className={cn(
+          "mx-auto mb-2 w-full rounded-[var(--radius-md)] border border-accent/30 bg-[color:var(--accent-soft)]",
+          "px-3 py-2 text-xs text-foreground flex items-center gap-2",
+          maxWidthClassName,
+        )}
+      >
+        <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-accent" aria-hidden="true" />
+        <span>{runningContent}</span>
+      </div>
+    )
+  }
+
+  if (tone === "success") {
+    return (
+      <div
+        {...toneAttr}
+        role="status"
+        aria-live="polite"
+        className={cn(
+          "mx-auto mb-2 w-full rounded-[var(--radius-md)] border border-[oklch(0.78_0.13_148)]/35 bg-[oklch(0.95_0.05_148/0.28)]",
+          "px-3 py-2 text-xs text-foreground shadow-sm",
+          maxWidthClassName,
+        )}
+      >
+        <div className="flex items-start gap-2">
+          <span className="mt-0.5 text-[oklch(0.45_0.13_148)]" aria-hidden="true">✓</span>
+          <span className="min-w-0 flex-1">
+            <span className="block font-medium leading-5">{title}</span>
+            {detail ? <span className="block leading-4 text-muted-foreground">{detail}</span> : null}
+          </span>
+          {onDismiss ? (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="-mr-1 rounded border border-transparent px-1.5 py-0.5 text-[13px] leading-none text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label={dismissAriaLabel}
+            >
+              ×
+            </button>
+          ) : null}
+        </div>
+        {children}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      {...toneAttr}
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "mx-auto mb-2 w-full rounded-[var(--radius-md)] border border-destructive/40 bg-destructive/10",
+        "px-3 py-2 text-xs text-foreground",
+        maxWidthClassName,
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-destructive" aria-hidden="true">⚠</span>
+        <span className="flex-1 font-medium">{title}</span>
+        {onRetry ? (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="rounded border border-destructive/40 px-2 py-0.5 text-[11px] font-medium hover:bg-destructive/10"
+          >
+            {retryLabel}
+          </button>
+        ) : null}
+        {onDismiss ? (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded border border-transparent px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label={dismissAriaLabel}
+          >
+            Dismiss
+          </button>
+        ) : null}
+      </div>
+      {message ? (
+        <pre className="mt-2 whitespace-pre-wrap break-words text-[11px] text-destructive/90">{message}</pre>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/agent/src/front/composer/PluginUpdateStatus.tsx
+++ b/packages/agent/src/front/composer/PluginUpdateStatus.tsx
@@ -14,10 +14,9 @@
  *    "Try again" button that re-runs `/reload`.
  */
 import { useEffect, useRef, type ReactElement } from "react"
-import { AlertCircleIcon, XIcon } from "lucide-react"
 import { cn } from "../lib"
+import { ComposerStatusBanner } from "./ComposerStatusBanner"
 import type { PluginRestartWarning } from "../../shared/agentPluginEvents"
-import { noticeIconClass, noticeSurfaceClass, noticeTextClass } from "../chat/components/noticeStyles"
 
 export type { PluginRestartWarning }
 
@@ -70,19 +69,12 @@ export function PluginUpdateStatus({
 
   if (state.kind === "running") {
     return (
-      <div
-        data-boring-plugin-update="running"
-        role="status"
-        aria-live="polite"
-        className={cn(
-          "mx-auto mb-2 w-full rounded-[var(--radius-md)] border border-accent/30 bg-[color:var(--accent-soft)]",
-          "px-3 py-2 text-xs text-foreground flex items-center gap-2",
-          maxWidthClassName,
-        )}
-      >
-        <span className="inline-block h-2 w-2 animate-pulse rounded-full bg-accent" aria-hidden="true" />
-        <span>Updating plugins…</span>
-      </div>
+      <ComposerStatusBanner
+        tone="running"
+        dataAttribute="data-boring-plugin-update"
+        maxWidthClassName={maxWidthClassName}
+        runningContent="Updating plugins…"
+      />
     )
   }
 
@@ -104,31 +96,15 @@ export function PluginUpdateStatus({
           : "Changes are live."
       : undefined
     return (
-      <div
-        data-boring-plugin-update="success"
-        role="status"
-        aria-live="polite"
-        className={cn(
-          "mx-auto mb-2 w-full rounded-[var(--radius-md)] border border-[oklch(0.78_0.13_148)]/35 bg-[oklch(0.95_0.05_148/0.28)]",
-          "px-3 py-2 text-xs text-foreground shadow-sm",
-          maxWidthClassName,
-        )}
+      <ComposerStatusBanner
+        tone="success"
+        dataAttribute="data-boring-plugin-update"
+        maxWidthClassName={maxWidthClassName}
+        title={title}
+        detail={detail}
+        onDismiss={onDismiss}
+        dismissAriaLabel="Dismiss plugin update status"
       >
-        <div className="flex items-start gap-2">
-          <span className="mt-0.5 text-[oklch(0.45_0.13_148)]" aria-hidden="true">✓</span>
-          <span className="min-w-0 flex-1">
-            <span className="block font-medium leading-5">{title}</span>
-            {detail ? <span className="block leading-4 text-muted-foreground">{detail}</span> : null}
-          </span>
-          <button
-            type="button"
-            onClick={onDismiss}
-            className="-mr-1 rounded border border-transparent px-1.5 py-0.5 text-[13px] leading-none text-muted-foreground hover:bg-muted hover:text-foreground"
-            aria-label="Dismiss plugin update status"
-          >
-            ×
-          </button>
-        </div>
         {diagnostics.length > 0 ? (
           <div
             data-boring-plugin-update-diagnostics=""
@@ -178,37 +154,21 @@ export function PluginUpdateStatus({
             </p>
           </div>
         ) : null}
-      </div>
+      </ComposerStatusBanner>
     )
   }
 
   return (
-    <div
-      data-boring-plugin-update="error"
-      role="status"
-      aria-live="polite"
-      className={noticeSurfaceClass("error", cn("mx-auto mb-2 w-full text-xs", maxWidthClassName))}
-    >
-      <div className="flex items-start gap-2.5">
-        <AlertCircleIcon className={noticeIconClass("error", "size-3.5")} aria-hidden="true" />
-        <span className="flex-1 font-medium">Plugin update failed.</span>
-        <button
-          type="button"
-          onClick={onRetry}
-          className="shrink-0 rounded border border-destructive/25 px-2 py-0.5 text-[11px] font-medium hover:bg-destructive/10"
-        >
-          Try again
-        </button>
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="-mr-1 -mt-1 inline-flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
-          aria-label="Dismiss plugin update status"
-        >
-          <XIcon className="size-3" aria-hidden="true" />
-        </button>
-      </div>
-      <pre className={noticeTextClass("mt-2 text-[11px] text-muted-foreground")}>{state.message}</pre>
-    </div>
+    <ComposerStatusBanner
+      tone="error"
+      dataAttribute="data-boring-plugin-update"
+      maxWidthClassName={maxWidthClassName}
+      title="Plugin update failed."
+      message={state.message}
+      onRetry={onRetry}
+      onDismiss={onDismiss}
+      retryLabel="Try again"
+      dismissAriaLabel="Dismiss plugin update status"
+    />
   )
 }

--- a/packages/agent/src/front/composer/__tests__/CommandRunStatus.test.tsx
+++ b/packages/agent/src/front/composer/__tests__/CommandRunStatus.test.tsx
@@ -1,0 +1,82 @@
+/* @vitest-environment jsdom */
+import { act, type ReactElement } from "react"
+import { createRoot } from "react-dom/client"
+import { afterEach, beforeAll, describe, expect, test, vi } from "vitest"
+import { CommandRunStatus } from "../CommandRunStatus"
+
+let roots: Array<ReturnType<typeof createRoot>> = []
+let containers: HTMLElement[] = []
+
+beforeAll(() => {
+  ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+})
+
+function render(ui: ReactElement): HTMLElement {
+  const container = document.createElement("div")
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  containers.push(container)
+  act(() => {
+    root.render(ui)
+  })
+  return container
+}
+
+afterEach(() => {
+  for (const root of roots) act(() => root.unmount())
+  for (const container of containers) container.remove()
+  roots = []
+  containers = []
+  vi.useRealTimers()
+})
+
+describe("CommandRunStatus", () => {
+  test("running banner names the command", () => {
+    const container = render(
+      <CommandRunStatus state={{ kind: "running", command: "open-demo-cmd" }} onDismiss={vi.fn()} />,
+    )
+    const banner = container.querySelector('[data-boring-command-run="running"]')
+    expect(banner?.textContent).toContain("Running")
+    expect(banner?.textContent).toContain("/open-demo-cmd")
+  })
+
+  test("success banner shows the detail and auto-dismisses", () => {
+    vi.useFakeTimers()
+    const onDismiss = vi.fn()
+    const container = render(
+      <CommandRunStatus
+        state={{ kind: "success", command: "open-demo-cmd", detail: "ran in 12ms" }}
+        onDismiss={onDismiss}
+        successAutoDismissMs={1400}
+      />,
+    )
+    const banner = container.querySelector('[data-boring-command-run="success"]')
+    expect(banner?.textContent).toContain("Ran")
+    expect(banner?.textContent).toContain("/open-demo-cmd")
+    expect(banner?.textContent).toContain("ran in 12ms")
+    expect(onDismiss).not.toHaveBeenCalled()
+    act(() => {
+      vi.advanceTimersByTime(1400)
+    })
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+
+  test("error banner shows the message and does not auto-dismiss", () => {
+    vi.useFakeTimers()
+    const onDismiss = vi.fn()
+    const container = render(
+      <CommandRunStatus
+        state={{ kind: "error", command: "open-demo-cmd", message: "boom" }}
+        onDismiss={onDismiss}
+      />,
+    )
+    const banner = container.querySelector('[data-boring-command-run="error"]')
+    expect(banner?.textContent).toContain("/open-demo-cmd")
+    expect(banner?.textContent).toContain("boom")
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+})

--- a/packages/agent/src/front/hooks/useServerCommands.ts
+++ b/packages/agent/src/front/hooks/useServerCommands.ts
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react'
+import type { CommandRegistry, SlashCommand } from '../slashCommands/registry'
+
+interface ServerCommandSummary {
+  name: string
+  description?: string
+  source: 'extension' | 'prompt' | 'skill'
+  sourcePlugin?: string
+}
+
+function toSlashCommand(command: ServerCommandSummary): SlashCommand {
+  return {
+    name: command.name,
+    description: command.description ?? '',
+    kind: 'server',
+    source: command.source,
+    ...(command.sourcePlugin ? { sourcePlugin: command.sourcePlugin } : {}),
+    handler: () => {},
+  }
+}
+
+export function useServerCommands({
+  registry,
+  requestHeaders,
+  sessionId,
+  enabled = true,
+  refreshKey = 0,
+}: {
+  registry: CommandRegistry
+  requestHeaders?: Record<string, string>
+  sessionId: string
+  enabled?: boolean
+  refreshKey?: number
+}): number {
+  const [stamp, setStamp] = useState(0)
+  const registeredNamesRef = useRef<Set<string>>(new Set())
+
+  useEffect(() => {
+    const clearRegistered = () => {
+      if (registeredNamesRef.current.size === 0) return false
+      for (const name of registeredNamesRef.current) registry.unregister(name)
+      registeredNamesRef.current = new Set()
+      return true
+    }
+
+    if (!enabled) {
+      if (clearRegistered()) setStamp((n) => n + 1)
+      return
+    }
+
+    let aborted = false
+    const url = `/api/v1/agent/commands?sessionId=${encodeURIComponent(sessionId)}`
+
+    fetch(url, { headers: requestHeaders })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`commands request failed (${res.status})`)
+        return await res.json() as { commands?: ServerCommandSummary[] }
+      })
+      .then((payload) => {
+        if (aborted) return
+
+        const removed = clearRegistered()
+        let added = false
+        for (const serverCommand of payload.commands ?? []) {
+          const command = toSlashCommand(serverCommand)
+          if (registry.get(command.name)) continue
+          registry.register(command)
+          registeredNamesRef.current.add(command.name)
+          added = true
+        }
+        if (removed || added) setStamp((n) => n + 1)
+      })
+      .catch(() => {
+        if (aborted) return
+        if (clearRegistered()) setStamp((n) => n + 1)
+      })
+
+    return () => { aborted = true }
+  }, [enabled, refreshKey, requestHeaders, registry, sessionId])
+
+  return stamp
+}

--- a/packages/agent/src/front/hooks/useServerCommands.ts
+++ b/packages/agent/src/front/hooks/useServerCommands.ts
@@ -12,7 +12,6 @@ function toSlashCommand(command: ServerCommandSummary): SlashCommand {
   return {
     name: command.name,
     description: command.description ?? '',
-    kind: 'server',
     source: command.source,
     ...(command.sourcePlugin ? { sourcePlugin: command.sourcePlugin } : {}),
     handler: () => {},

--- a/packages/agent/src/front/primitives/__tests__/slash-command-picker.test.tsx
+++ b/packages/agent/src/front/primitives/__tests__/slash-command-picker.test.tsx
@@ -1,27 +1,103 @@
 // @vitest-environment jsdom
-import { fireEvent, render } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
 import { SlashCommandPicker } from '../slash-command-picker'
 
 describe('SlashCommandPicker', () => {
-  it('keeps Escape dismissal active when no commands match', () => {
-    const onDismiss = vi.fn()
+  beforeAll(() => {
+    // jsdom does not implement scrollIntoView, which the picker calls to keep
+    // the active row visible.
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  const commands = [
+    { name: 'skill:boring-plugin-authoring', description: 'Author a plugin', source: 'skill' as const },
+    { name: 'open-demo-cmd', description: 'Open the demo panel', source: 'extension' as const, sourcePlugin: 'demo-cmd' },
+    { name: 'run', description: 'Run a subagent', source: 'extension' as const, sourcePlugin: 'pi-subagents' },
+    { name: 'reload', description: 'Reload plugins', source: 'local' as const },
+  ]
+
+  const searchInput = () => screen.getByLabelText('Search commands') as HTMLInputElement
+
+  it('tags skill commands "skill" and other commands with their source plugin', () => {
+    render(<SlashCommandPicker query="" commands={commands} onSelect={() => {}} onDismiss={() => {}} />)
+
+    const skillRow = screen.getByText('/skill:boring-plugin-authoring').closest('li')
+    expect(skillRow?.querySelector('.uppercase')?.textContent).toBe('skill')
+
+    const extensionRow = screen.getByText('/open-demo-cmd').closest('li')
+    expect(extensionRow?.textContent).toContain('demo-cmd')
+    expect(extensionRow?.querySelector('.uppercase')).toBeNull()
+
+    const localRow = screen.getByText('/reload').closest('li')
+    expect(localRow?.textContent).toBe('/reloadReload plugins')
+  })
+
+  it('exposes the full description on hover via the row title attribute', () => {
+    render(<SlashCommandPicker query="" commands={commands} onSelect={() => {}} onDismiss={() => {}} />)
+    const skillRow = screen.getByText('/skill:boring-plugin-authoring').closest('li')
+    expect(skillRow?.getAttribute('title')).toBe('Author a plugin')
+  })
+
+  it('seeds the search box from the typed query and filters (substring, name or description)', () => {
+    render(<SlashCommandPicker query="skill" commands={commands} onSelect={() => {}} onDismiss={() => {}} />)
+    expect(searchInput().value).toBe('skill')
+    expect(screen.getByText('/skill:boring-plugin-authoring')).toBeTruthy()
+    expect(screen.queryByText('/open-demo-cmd')).toBeNull()
+    expect(screen.queryByText('/reload')).toBeNull()
+
+    // Typing in the search box updates the filter (matches description too).
+    act(() => {
+      fireEvent.change(searchInput(), { target: { value: 'subagent' } })
+    })
+    expect(screen.getByText('/run')).toBeTruthy()
+    expect(screen.queryByText('/skill:boring-plugin-authoring')).toBeNull()
+  })
+
+  it('filters by the selected plugin chip', () => {
+    render(<SlashCommandPicker query="" commands={commands} onSelect={() => {}} onDismiss={() => {}} />)
+    // Pick the demo-cmd plugin chip.
+    act(() => {
+      fireEvent.mouseDown(screen.getByRole('tab', { name: 'demo-cmd' }))
+    })
+    expect(screen.getByText('/open-demo-cmd')).toBeTruthy()
+    expect(screen.queryByText('/run')).toBeNull()
+    expect(screen.queryByText('/reload')).toBeNull()
+  })
+
+  it('wraps selection with arrow keys from the search input', () => {
+    render(<SlashCommandPicker query="" commands={commands} onSelect={() => {}} onDismiss={() => {}} />)
+    const options = () => Array.from(document.querySelectorAll('[role="option"]'))
+    expect(options()[0]?.getAttribute('aria-selected')).toBe('true')
+
+    act(() => {
+      fireEvent.keyDown(searchInput(), { key: 'ArrowUp' })
+    })
+    const opts = options()
+    expect(opts[opts.length - 1]?.getAttribute('aria-selected')).toBe('true')
+    expect(opts[0]?.getAttribute('aria-selected')).toBe('false')
+
+    act(() => {
+      fireEvent.keyDown(searchInput(), { key: 'ArrowDown' })
+    })
+    expect(options()[0]?.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('selects the active command on Enter', () => {
     const onSelect = vi.fn()
-    const { container } = render(
-      <SlashCommandPicker
-        query="unknown"
-        commands={[]}
-        onSelect={onSelect}
-        onDismiss={onDismiss}
-      />,
-    )
+    render(<SlashCommandPicker query="" commands={commands} onSelect={onSelect} onDismiss={() => {}} />)
+    act(() => {
+      fireEvent.keyDown(searchInput(), { key: 'Enter' })
+    })
+    expect(onSelect).toHaveBeenCalledWith('skill:boring-plugin-authoring')
+  })
 
-    expect(container.firstChild).toBeNull()
-
-    fireEvent.keyDown(window, { key: 'Enter' })
-    fireEvent.keyDown(window, { key: 'Escape' })
-
-    expect(onSelect).not.toHaveBeenCalled()
-    expect(onDismiss).toHaveBeenCalledTimes(1)
+  it('dismisses on Escape', () => {
+    const onDismiss = vi.fn()
+    render(<SlashCommandPicker query="" commands={commands} onSelect={() => {}} onDismiss={onDismiss} />)
+    act(() => {
+      fireEvent.keyDown(searchInput(), { key: 'Escape' })
+    })
+    expect(onDismiss).toHaveBeenCalled()
   })
 })

--- a/packages/agent/src/front/primitives/slash-command-picker.tsx
+++ b/packages/agent/src/front/primitives/slash-command-picker.tsx
@@ -1,60 +1,166 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { cn } from '../lib'
-import { usePickerKeyboard } from './use-picker-keyboard'
 
 interface Command {
   name: string
   description: string
+  source?: 'local' | 'extension' | 'prompt' | 'skill'
+  sourcePlugin?: string
 }
 
 interface SlashCommandPickerProps {
+  /** Initial filter text, seeded from what the user typed after `/`. */
   query: string
   commands: Command[]
   onSelect: (name: string) => void
   onDismiss: () => void
 }
 
+const ALL_PLUGINS = '__all__'
+
+/** Group a command lives under for the plugin selector: its skill bucket, its
+ *  originating plugin/package, or "built-in" for local commands. */
+function commandGroup(cmd: Command): string {
+  if (cmd.source === 'skill') return 'skills'
+  if (cmd.sourcePlugin) return cmd.sourcePlugin
+  return 'built-in'
+}
+
 export function SlashCommandPicker({ query, commands, onSelect, onDismiss }: SlashCommandPickerProps) {
-  const filtered = useMemo(
-    () => commands.filter((c) => c.name.toLowerCase().startsWith(query.toLowerCase())),
-    [commands, query],
-  )
+  const [search, setSearch] = useState(query)
+  const [plugin, setPlugin] = useState<string>(ALL_PLUGINS)
   const [activeIdx, setActiveIdx] = useState(0)
+  const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLUListElement>(null)
 
-  // Reset selection when filter changes
-  useEffect(() => setActiveIdx(0), [filtered.length])
+  // Distinct plugin groups, for the selector chips at the top of the menu.
+  const groups = useMemo(() => {
+    const set = new Set(commands.map(commandGroup))
+    return Array.from(set).sort((a, b) => a.localeCompare(b))
+  }, [commands])
 
-  const handleSelect = useCallback((idx: number) => {
-    if (filtered[idx]) onSelect(filtered[idx].name)
-  }, [filtered, onSelect])
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return commands.filter((c) => {
+      if (plugin !== ALL_PLUGINS && commandGroup(c) !== plugin) return false
+      if (!q) return true
+      return c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q)
+    })
+  }, [commands, search, plugin])
 
-  usePickerKeyboard({ count: filtered.length, activeIdx, setActiveIdx, listRef, onSelect: handleSelect, onDismiss })
+  // Auto-focus the search input when the menu opens so the user can type/filter
+  // immediately without leaving the keyboard.
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
 
-  if (filtered.length === 0) return null
+  // Keep the active row in range and scrolled into view as the list changes.
+  useEffect(() => {
+    setActiveIdx((i) => (filtered.length === 0 ? 0 : Math.min(i, filtered.length - 1)))
+  }, [filtered.length])
+  useEffect(() => {
+    const el = listRef.current?.children[activeIdx] as HTMLElement | undefined
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [activeIdx])
+
+  const move = (delta: number) => {
+    if (filtered.length === 0) return
+    setActiveIdx((i) => (i + delta + filtered.length) % filtered.length)
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') { e.preventDefault(); move(1) }
+    else if (e.key === 'ArrowUp') { e.preventDefault(); move(-1) }
+    else if (e.key === 'Enter' || e.key === 'Tab') {
+      e.preventDefault()
+      if (filtered[activeIdx]) onSelect(filtered[activeIdx].name)
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      onDismiss()
+    }
+  }
 
   return (
     <div className="mb-1 w-full overflow-hidden rounded-lg border border-border/60 bg-popover shadow-lg">
-      <ul ref={listRef} className="max-h-48 overflow-y-auto py-1" role="listbox" aria-label="Commands">
-        {filtered.map((cmd, i) => (
-          <li
-            key={cmd.name}
-            role="option"
-            aria-selected={i === activeIdx}
-            className={cn(
-              'flex cursor-pointer flex-col gap-0.5 px-3 py-1.5 text-[12px]',
-              i === activeIdx ? 'bg-accent/10 text-foreground' : 'text-muted-foreground hover:bg-muted/40',
-            )}
-            onMouseEnter={() => setActiveIdx(i)}
-            onMouseDown={(e) => { e.preventDefault(); onSelect(cmd.name) }}
-          >
-            <span className="font-medium text-foreground/80">/{cmd.name}</span>
-            <span className="truncate text-[11px] opacity-50">{cmd.description}</span>
-          </li>
-        ))}
-      </ul>
+      {/* Search bar */}
+      <div className="border-b border-border/50 px-2 py-1.5">
+        <input
+          ref={inputRef}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Search commands…"
+          aria-label="Search commands"
+          className="w-full bg-transparent px-1 text-[12px] text-foreground outline-none placeholder:text-muted-foreground"
+        />
+      </div>
+
+      {/* Plugin selection */}
+      {groups.length > 1 && (
+        <div className="flex flex-wrap gap-1 border-b border-border/50 px-2 py-1.5" role="tablist" aria-label="Filter by plugin">
+          {[ALL_PLUGINS, ...groups].map((g) => {
+            const selected = plugin === g
+            return (
+              <button
+                key={g}
+                type="button"
+                role="tab"
+                aria-selected={selected}
+                onMouseDown={(e) => { e.preventDefault(); setPlugin(g); setActiveIdx(0) }}
+                className={cn(
+                  'rounded-full px-2 py-px text-[10px] font-medium transition-colors',
+                  selected ? 'bg-accent/15 text-accent-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted',
+                )}
+              >
+                {g === ALL_PLUGINS ? 'All' : g}
+              </button>
+            )
+          })}
+        </div>
+      )}
+
+      {/* Command list — sized to show ~8 rows before scrolling. */}
+      {filtered.length === 0 ? (
+        <div className="px-3 py-2 text-[11px] text-muted-foreground">No matching commands.</div>
+      ) : (
+        <ul ref={listRef} className="max-h-80 overflow-y-auto py-1" role="listbox" aria-label="Commands">
+          {filtered.map((cmd, i) => (
+            <li
+              key={cmd.name}
+              role="option"
+              aria-selected={i === activeIdx}
+              // Full (untruncated) description on hover — skill descriptions in
+              // particular are long and clipped in the row.
+              title={cmd.description || undefined}
+              className={cn(
+                'flex cursor-pointer flex-col gap-0.5 px-3 py-1.5 text-[12px]',
+                // Single highlight: hovering moves the active row (onMouseEnter),
+                // so the active style is the only highlight — no separate hover bg.
+                i === activeIdx ? 'bg-accent/10 text-foreground' : 'text-muted-foreground',
+              )}
+              onMouseEnter={() => setActiveIdx(i)}
+              onMouseDown={(e) => { e.preventDefault(); onSelect(cmd.name) }}
+            >
+              <span className="flex items-center gap-1.5">
+                <span className="font-medium text-foreground/80">/{cmd.name}</span>
+                {cmd.source === 'skill' ? (
+                  <span className="rounded-sm bg-accent/15 px-1 py-px text-[9px] font-medium uppercase tracking-wide text-accent-foreground">
+                    skill
+                  </span>
+                ) : cmd.sourcePlugin ? (
+                  // Originating plugin/package for non-skill commands.
+                  <span className="rounded-sm bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
+                    {cmd.sourcePlugin}
+                  </span>
+                ) : null}
+              </span>
+              <span className="truncate text-[11px] opacity-50">{cmd.description}</span>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   )
 }

--- a/packages/agent/src/front/primitives/use-picker-keyboard.ts
+++ b/packages/agent/src/front/primitives/use-picker-keyboard.ts
@@ -30,15 +30,14 @@ export function usePickerKeyboard({
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.key === 'ArrowDown') {
-        if (count <= 0) return
         e.preventDefault()
-        setActiveIdx((i) => Math.min(i + 1, count - 1))
+        // Wrap around: past the last item loops back to the first.
+        setActiveIdx((i) => (count === 0 ? 0 : (i + 1) % count))
       } else if (e.key === 'ArrowUp') {
-        if (count <= 0) return
         e.preventDefault()
-        setActiveIdx((i) => Math.max(i - 1, 0))
+        // Wrap around: up from the first item loops to the last.
+        setActiveIdx((i) => (count === 0 ? 0 : (i - 1 + count) % count))
       } else if (e.key === 'Enter' || e.key === 'Tab') {
-        if (count <= 0) return
         e.preventDefault()
         selectRef.current(activeIdx)
       } else if (e.key === 'Escape') {

--- a/packages/agent/src/front/slashCommands/__tests__/builtins.test.ts
+++ b/packages/agent/src/front/slashCommands/__tests__/builtins.test.ts
@@ -23,54 +23,33 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-describe('/clear intentionally absent', () => {
-  test('does not register /clear in the Pi-native first cut', () => {
-    // First-cut Pi-native chat intentionally omits local-only transcript
-    // filtering. Canonical history is Pi JSONL; a future viewport clear must
-    // be non-canonical and should be tested separately when reintroduced.
-    expect(builtinCommands.find((c) => c.name === 'clear')).toBeUndefined()
-  })
-})
-
-describe('/reset', () => {
-  test('resets session when confirmed', () => {
-    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true))
+describe('/clear', () => {
+  test('calls clearMessages', () => {
     const ctx = makeContext()
-    const result = getBuiltin('reset').handler('', ctx)
-    expect(ctx.resetSession).toHaveBeenCalledOnce()
-    expect(result).toBe('Session reset.')
+    getBuiltin('clear').handler('', ctx)
+    expect(ctx.clearMessages).toHaveBeenCalledOnce()
   })
 
-  test('does nothing when cancelled', () => {
-    vi.stubGlobal('confirm', vi.fn().mockReturnValue(false))
+  test('returns no message', () => {
     const ctx = makeContext()
-    const result = getBuiltin('reset').handler('', ctx)
-    expect(ctx.resetSession).not.toHaveBeenCalled()
+    const result = getBuiltin('clear').handler('', ctx)
     expect(result).toBeUndefined()
   })
 })
 
 describe('/help', () => {
-  test('lists Pi-native builtin commands and omits /clear', () => {
+  test('renders commands as a GFM table (one row per command)', () => {
     const ctx = makeContext()
-    const result = getBuiltin('help').handler('', ctx)
-    expect(result).not.toContain('/clear')
-    expect(result).toContain('/reset')
+    const result = getBuiltin('help').handler('', ctx) as string
+    expect(result).toContain('/clear')
+    expect(result).not.toContain('/reset')
     expect(result).toContain('/reload')
     expect(result).toContain('/help')
-  })
-
-  test('includes skill and extra commands from the registry context', () => {
-    const ctx = makeContext({
-      listCommands: vi.fn().mockReturnValue([
-        ...builtinCommands,
-        { name: 'review', description: 'Run review skill', kind: 'skill', handler: vi.fn() },
-        { name: 'ask-user', description: 'Ask user', handler: vi.fn() },
-      ]),
-    })
-    const result = getBuiltin('help').handler('', ctx)
-    expect(result).toContain('/review — Run review skill')
-    expect(result).toContain('/ask-user — Ask user')
+    // GFM table so Streamdown renders each command on its own row.
+    expect(result).toContain('| Command | Description |')
+    expect(result).toContain('| --- | --- |')
+    expect(result).toContain('| `/clear` |')
+    expect(result.split('\n').filter((l) => l.startsWith('| `/')).length).toBeGreaterThanOrEqual(3)
   })
 
   test('returns message when no commands', () => {
@@ -98,43 +77,18 @@ describe('/reload', () => {
   })
 })
 
-describe('/model and /thinking', () => {
-  test('/model opens the model picker without args and delegates selection with args', () => {
-    const openModelPicker = vi.fn()
-    const selectComposerModel = vi.fn().mockReturnValue('Model set.')
-    const ctx = makeContext({ openModelPicker, selectComposerModel })
-
-    expect(getBuiltin('model').handler('', ctx)).toBeUndefined()
-    expect(openModelPicker).toHaveBeenCalledOnce()
-    expect(getBuiltin('model').handler('gpt', ctx)).toBe('Model set.')
-    expect(selectComposerModel).toHaveBeenCalledWith('gpt')
+describe('all 3 builtins are registered', () => {
+  test('has exactly 3 commands', () => {
+    expect(builtinCommands).toHaveLength(3)
   })
 
-  test('/thinking and /think open or set the thinking picker', () => {
-    const openThinkingPicker = vi.fn()
-    const selectComposerThinking = vi.fn().mockReturnValue('Thinking set.')
-    const ctx = makeContext({ openThinkingPicker, selectComposerThinking })
-
-    expect(getBuiltin('thinking').handler('', ctx)).toBeUndefined()
-    expect(openThinkingPicker).toHaveBeenCalledOnce()
-    expect(getBuiltin('thinking').handler('low', ctx)).toBe('Thinking set.')
-    expect(getBuiltin('think').handler('high', ctx)).toBe('Thinking set.')
-    expect(selectComposerThinking).toHaveBeenCalledWith('low')
-    expect(selectComposerThinking).toHaveBeenCalledWith('high')
-  })
-})
-
-describe('Pi-native builtins are registered', () => {
-  test('has exactly 6 commands', () => {
-    expect(builtinCommands).toHaveLength(6)
-  })
-
-  test.each(['reset', 'reload', 'model', 'thinking', 'think', 'help'])('includes /%s', (name) => {
+  test.each(['clear', 'reload', 'help'])('includes /%s', (name) => {
     expect(builtinCommands.find((c) => c.name === name)).toBeDefined()
   })
 
-  test('does NOT include removed/deferred local commands', () => {
-    expect(builtinCommands.find((c) => c.name === 'clear')).toBeUndefined()
+  test('does NOT include /model, /reset, or /cost (removed)', () => {
+    expect(builtinCommands.find((c) => c.name === 'model')).toBeUndefined()
+    expect(builtinCommands.find((c) => c.name === 'reset')).toBeUndefined()
     expect(builtinCommands.find((c) => c.name === 'cost')).toBeUndefined()
   })
 })

--- a/packages/agent/src/front/slashCommands/builtins.ts
+++ b/packages/agent/src/front/slashCommands/builtins.ts
@@ -2,12 +2,10 @@ import type { SlashCommand } from './registry'
 
 export const builtinCommands: SlashCommand[] = [
   {
-    name: 'reset',
-    description: 'Delete current session and start fresh',
+    name: 'clear',
+    description: 'Hide messages from display',
     handler(_, ctx) {
-      if (!globalThis.confirm('Reset this session? All messages will be cleared.')) return
-      ctx.resetSession()
-      return 'Session reset.'
+      ctx.clearMessages()
     },
   },
   {
@@ -21,39 +19,20 @@ export const builtinCommands: SlashCommand[] = [
     },
   },
   {
-    name: 'model',
-    description: 'Open or set the composer model',
-    handler(args, ctx) {
-      const query = args.trim()
-      if (query) return ctx.selectComposerModel?.(query)
-      if (ctx.openModelPicker?.() === false) return { preserveDraft: true }
-    },
-  },
-  {
-    name: 'thinking',
-    description: 'Open or set the thinking level',
-    handler(args, ctx) {
-      const query = args.trim()
-      if (query) return ctx.selectComposerThinking?.(query)
-      if (ctx.openThinkingPicker?.() === false) return { preserveDraft: true }
-    },
-  },
-  {
-    name: 'think',
-    description: 'Alias for /thinking',
-    handler(args, ctx) {
-      const query = args.trim()
-      if (query) return ctx.selectComposerThinking?.(query)
-      if (ctx.openThinkingPicker?.() === false) return { preserveDraft: true }
-    },
-  },
-  {
     name: 'help',
     description: 'Show available commands',
     handler(_, ctx) {
       const cmds = ctx.listCommands()
       if (cmds.length === 0) return 'No commands available.'
-      return cmds.map((c) => `/${c.name} — ${c.description}`).join('\n')
+      // Render as a GFM table. The chat renders assistant messages through
+      // Streamdown (GFM), so a plain "\n"-joined list would collapse into one
+      // run-on line; a table keeps each command on its own row.
+      const escape = (text: string) => text.replace(/\|/g, '\\|').replace(/\n/g, ' ')
+      return [
+        '| Command | Description |',
+        '| --- | --- |',
+        ...cmds.map((c) => `| \`/${c.name}\` | ${escape(c.description ?? '')} |`),
+      ].join('\n')
     },
   },
 ]

--- a/packages/agent/src/front/slashCommands/registry.ts
+++ b/packages/agent/src/front/slashCommands/registry.ts
@@ -4,8 +4,20 @@ export type SlashCommandHandler = (args: string, ctx: SlashCommandContext) => Sl
 export interface SlashCommand {
   name: string
   description: string
-  /** 'skill' commands are forwarded to the PI agent as `skill: <name>\n\n<args>` instead of running locally. */
-  kind?: 'local' | 'skill'
+  /**
+   * - local: handled in the browser.
+   * - server: forwarded as the original slash command so PI extension/prompt commands run natively.
+   * - skill: forwarded to the PI agent as `skill: <name>\n\n<args>`.
+   */
+  kind?: 'local' | 'server' | 'skill'
+  /**
+   * Origin of the command, surfaced as a tag in the slash-command picker.
+   * Mirrors Pi's command sources for server commands; `local` for built-in
+   * browser commands. Display only.
+   */
+  source?: 'local' | 'extension' | 'prompt' | 'skill'
+  /** Originating plugin/package name (when known), shown as a tag. */
+  sourcePlugin?: string
   handler: SlashCommandHandler
 }
 
@@ -34,6 +46,7 @@ export interface SlashCommandContext {
 
 export interface CommandRegistry {
   register(cmd: SlashCommand): void
+  unregister(name: string): void
   get(name: string): SlashCommand | undefined
   list(): SlashCommand[]
 }
@@ -48,6 +61,9 @@ export function createCommandRegistry(initial?: SlashCommand[]): CommandRegistry
   return {
     register(cmd: SlashCommand) {
       commands.set(cmd.name, cmd)
+    },
+    unregister(name: string) {
+      commands.delete(name)
     },
     get(name: string) {
       return commands.get(name)

--- a/packages/agent/src/front/slashCommands/registry.ts
+++ b/packages/agent/src/front/slashCommands/registry.ts
@@ -6,10 +6,12 @@ export interface SlashCommand {
   description: string
   /**
    * - local: handled in the browser.
-   * - server: forwarded as the original slash command so PI extension/prompt commands run natively.
    * - skill: forwarded to the PI agent as `skill: <name>\n\n<args>`.
+   * Server commands registered via `useServerCommands` omit `kind` (or set
+   * it to `local`) — Pi handles execution natively so no frontend kind-check
+   * is needed.
    */
-  kind?: 'local' | 'server' | 'skill'
+  kind?: 'local' | 'skill'
   /**
    * Origin of the command, surfaced as a tag in the slash-command picker.
    * Mirrors Pi's command sources for server commands; `local` for built-in

--- a/packages/agent/src/server/__tests__/createAgentApp.test.ts
+++ b/packages/agent/src/server/__tests__/createAgentApp.test.ts
@@ -138,6 +138,11 @@ test('createAgentApp can use a custom harness factory for non-pi runtimes', asyn
       telemetryEvents.push(event)
     },
   }
+  const getSlashCommands = vi.fn((sessionId: string) => [{
+    name: 'open-test-panel',
+    description: `Open test panel for ${sessionId}`,
+    source: 'extension' as const,
+  }])
   const harnessFactory = vi.fn(async (input) => ({
     id: 'custom-test-harness',
     placement: 'server' as const,
@@ -154,6 +159,7 @@ test('createAgentApp can use a custom harness factory for non-pi runtimes', asyn
       async delete() {},
     },
     reloadSession,
+    getSlashCommands,
   }))
 
   const app = await createAgentApp({
@@ -175,12 +181,51 @@ test('createAgentApp can use a custom harness factory for non-pi runtimes', asyn
     expect(harnessFactory.mock.calls[0]?.[0].telemetry).toBe(telemetry)
     expect(harnessFactory.mock.calls[0]?.[0].tools.map((tool: { name: string }) => tool.name)).toContain('custom_runtime_tool')
 
+    const commandsRes = await app.inject({ method: 'GET', url: '/api/v1/agent/commands?sessionId=custom' })
+    expect(commandsRes.statusCode).toBe(200)
+    expect(commandsRes.json()).toMatchObject({
+      commands: [{ name: 'open-test-panel', source: 'extension' }],
+    })
+
     expect(telemetryEvents).toEqual([])
 
     const res = await app.inject({ method: 'POST', url: '/api/v1/agent/reload', payload: { sessionId: 'custom' } })
     expect(res.statusCode).toBe(200)
     expect(res.json()).toEqual({ ok: true, sessionId: 'custom', reloaded: true })
     expect(reloadSession).toHaveBeenCalledWith('custom')
+  } finally {
+    await app.close()
+  }
+})
+
+test('GET /api/v1/agent/commands reports command discovery failures', async () => {
+  const workspaceRoot = await makeTempDir('boring-ui-command-route-failure-')
+  const app = await createAgentApp({
+    workspaceRoot,
+    mode: 'direct',
+    logger: false,
+    harnessFactory: vi.fn(async () => ({
+      id: 'failing-command-harness',
+      placement: 'server' as const,
+      sessions: {
+        async list() { return [] },
+        async create() {
+          const now = new Date().toISOString()
+          return { id: 'default', title: 'Default', createdAt: now, updatedAt: now, turnCount: 0 }
+        },
+        async load() {
+          const now = new Date().toISOString()
+          return { id: 'default', title: 'Default', createdAt: now, updatedAt: now, turnCount: 0, messages: [] }
+        },
+        async delete() {},
+      },
+      getSlashCommands: () => { throw new Error('command loader failed') },
+    })),
+  })
+  try {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/agent/commands' })
+    expect(res.statusCode).toBe(500)
+    expect(res.json()).toMatchObject({ commands: [], error: 'command loader failed' })
   } finally {
     await app.close()
   }

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -24,6 +24,7 @@ import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
 import { readyStatusRoutes } from './http/routes/readyStatus'
+import { commandsRoutes } from './http/routes/commands'
 import { reloadRoutes } from './http/routes/reload'
 import { searchRoutes } from './http/routes/search'
 import { gitRoutes } from './http/routes/git'
@@ -220,6 +221,7 @@ export async function createAgentApp(
   })
   await app.register(sessionChangesRoutes, { tracker: sessionChangesTracker })
   await app.register(catalogRoutes, { tools })
+  await app.register(commandsRoutes, { harness, defaultSessionId: sessionId, workdir: runtimeBundle.workspace.root })
   await app.register(reloadRoutes, { harness, defaultSessionId: sessionId, beforeReload: opts.beforeReload })
   await app.register(readyStatusRoutes, { tracker: readyTracker })
 

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -13,8 +13,9 @@ import {
   getAgentDir,
   loadSkills,
   type ExtensionFactory,
+  type SlashCommandInfo,
 } from "@mariozechner/pi-coding-agent";
-import type { AgentHarness, SendMessageInput, RunContext } from "../../../shared/harness.js";
+import type { AgentHarness, AgentSlashCommandSummary, SendMessageInput, RunContext } from "../../../shared/harness.js";
 import { createLogger } from "../../logging.js";
 import type { AgentTool } from "../../../shared/tool.js";
 import type { TelemetrySink } from "../../../shared/telemetry.js";
@@ -34,6 +35,7 @@ interface PiSessionHandle {
   piSession: AgentSession;
   modelRegistry: ModelRegistry;
   sessionManager: SessionManager;
+  resourceLoader: DefaultResourceLoader;
 }
 
 export { mergePiPackageSources } from "../../piPackages.js";
@@ -268,6 +270,40 @@ function basenameForAttachment(filename: string): string {
   return safe || "image";
 }
 
+/**
+ * Derive the originating plugin/package name from Pi's command sourceInfo.
+ * Returns the extension directory name for boring runtime plugins (.pi/extensions/<name>),
+ * the package name for npm sources, the repo name for git sources, and the
+ * filename for user-global single-file extensions. Returns undefined for built-in/top-level
+ * commands with no package origin.
+ */
+export function deriveSourcePlugin(sourceInfo: SlashCommandInfo["sourceInfo"] | undefined): string | undefined {
+  if (!sourceInfo) return undefined;
+  const path = typeof sourceInfo.path === "string" ? sourceInfo.path : "";
+  const source = typeof sourceInfo.source === "string" ? sourceInfo.source : "";
+  // Boring runtime plugin: .pi/extensions/<name>/...
+  const runtimePlugin = path.match(/[/\\]\.pi[/\\]extensions[/\\]([^/\\]+)/);
+  if (runtimePlugin) return runtimePlugin[1];
+  // npm package source: "npm:<pkg>"
+  if (source.startsWith("npm:")) return source.slice(4) || undefined;
+  // git source: "git/<host>/<owner>/<repo>" -> repo
+  if (source.startsWith("git/")) return source.split("/").filter(Boolean).pop();
+  // User-global single-file extension: .../extensions/<file>.ts
+  const fileExtension = path.match(/[/\\]extensions[/\\]([^/\\]+)\.[cm]?[tj]sx?$/);
+  if (fileExtension) return fileExtension[1];
+  return undefined;
+}
+
+function normalizeSlashCommandInfo(command: SlashCommandInfo): AgentSlashCommandSummary {
+  const sourcePlugin = deriveSourcePlugin(command.sourceInfo);
+  return {
+    name: command.name,
+    ...(command.description ? { description: command.description } : {}),
+    source: command.source,
+    ...(sourcePlugin ? { sourcePlugin } : {}),
+  };
+}
+
 export function createPiCodingAgentHarness(opts: {
   tools: AgentTool[];
   /** Host/storage cwd used for harness-owned resources (.pi settings, attachments, plugin discovery). */
@@ -455,7 +491,7 @@ export function createPiCodingAgentHarness(opts: {
       }
     }
 
-    const handle: PiSessionHandle = { piSession, modelRegistry, sessionManager };
+    const handle: PiSessionHandle = { piSession, modelRegistry, sessionManager, resourceLoader };
     piSessions.set(sessionId, handle);
     return handle;
   }
@@ -502,6 +538,11 @@ export function createPiCodingAgentHarness(opts: {
     },
 
     reloadSession: reloadPiSession,
+
+    async getSlashCommands(sessionId: string, ctx: RunContext): Promise<ReadonlyArray<AgentSlashCommandSummary>> {
+      const handle = await getOrCreatePiSession(sessionId, { sessionId, message: "" }, ctx);
+      return handle.resourceLoader.getExtensions().runtime.getCommands().map(normalizeSlashCommandInfo);
+    },
 
     async getPiSessionAdapter(input: SendMessageInput, ctx: RunContext) {
       const { piSession } = await getOrCreatePiSession(input.sessionId, input, ctx);

--- a/packages/agent/src/server/http/routes/commands.ts
+++ b/packages/agent/src/server/http/routes/commands.ts
@@ -1,0 +1,37 @@
+import type { FastifyInstance } from 'fastify'
+import type { AgentHarness, AgentSlashCommandSummary } from '../../../shared/harness'
+
+export interface CommandsRoutesOptions {
+  harness: AgentHarness
+  defaultSessionId: string
+  workdir: string
+}
+
+function normalizeSessionId(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : fallback
+}
+
+export function commandsRoutes(
+  app: FastifyInstance,
+  opts: CommandsRoutesOptions,
+  done: (err?: Error) => void,
+): void {
+  app.get('/api/v1/agent/commands', async (request, reply) => {
+    try {
+      const query = request.query as Record<string, unknown>
+      const sessionId = normalizeSessionId(query.sessionId, opts.defaultSessionId)
+      const commands: ReadonlyArray<AgentSlashCommandSummary> = await opts.harness.getSlashCommands?.(sessionId, {
+        abortSignal: new AbortController().signal,
+        workdir: opts.workdir,
+      }) ?? []
+      return reply.code(200).send({ commands })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return reply.code(500).send({ commands: [], error: message })
+    }
+  })
+
+  done()
+}

--- a/packages/agent/src/shared/agentPluginEvents.ts
+++ b/packages/agent/src/shared/agentPluginEvents.ts
@@ -25,3 +25,20 @@ export interface PluginRestartWarning {
   surfaces: string[]
   message: string
 }
+
+/**
+ * Browser CustomEvent name dispatched on `window` when a `showNotification`
+ * UI command arrives from the server (e.g. from a plugin slash command that
+ * calls `notify()`). `PiChatPanel` listens for this to show the
+ * `CommandRunStatus` banner above the composer.
+ */
+export const WORKSPACE_COMMAND_NOTIFY_EVENT = 'boring-ui:command-notify'
+
+/**
+ * Payload carried by `WORKSPACE_COMMAND_NOTIFY_EVENT`. Maps directly to
+ * what `uiCommandDispatcher` extracts from the `showNotification` command.
+ */
+export interface CommandNotifyPayload {
+  message: string
+  tone: 'success' | 'error' | 'info'
+}

--- a/packages/agent/src/shared/harness.ts
+++ b/packages/agent/src/shared/harness.ts
@@ -41,6 +41,22 @@ export interface AgentHarness {
 
   /** Reload native agent resources/extensions for an existing session. */
   reloadSession?: (sessionId: string) => Promise<boolean>
+
+  /** List slash commands registered in the agent runtime for a given session. */
+  getSlashCommands?: (sessionId: string, ctx: RunContext) => ReadonlyArray<AgentSlashCommandSummary> | Promise<ReadonlyArray<AgentSlashCommandSummary>>
+}
+
+export interface AgentSlashCommandSummary {
+  name: string
+  description?: string
+  source: 'extension' | 'prompt' | 'skill'
+  /**
+   * Name of the originating plugin/package, when derivable from Pi's
+   * sourceInfo (e.g. a `.pi/extensions/<name>` runtime plugin, or an
+   * `npm:`/`git/` package). Surfaced as a tag in the slash-command picker.
+   * Absent for built-in/top-level commands with no package origin.
+   */
+  sourcePlugin?: string
 }
 
 /* Resume is NOT a harness concern — see Stream resumption section.

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -53,7 +53,11 @@ export {
 } from './capabilities'
 export type { AgentRuntimeCapabilities } from './capabilities'
 export { validateTool } from './validateTool'
-export { WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT } from './agentPluginEvents'
+export {
+  WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT,
+  WORKSPACE_COMMAND_NOTIFY_EVENT,
+} from './agentPluginEvents'
+export type { CommandNotifyPayload } from './agentPluginEvents'
 
 export type {
   BoringChatMessage,

--- a/packages/plugin-cli/templates/agent-canonical.ts
+++ b/packages/plugin-cli/templates/agent-canonical.ts
@@ -1,0 +1,45 @@
+// CANONICAL agent/index.ts for a boring-ui runtime plugin.
+// Registers a hot-reloadable Pi slash command for deterministic plugin activation.
+//
+// The command opens its panel through the in-process workspace UI bridge via
+// `openPanel` from "@hachej/boring-workspace/plugin" — the SAME path the agent's
+// own `exec_ui` tool uses. No BORING_UI_URL, no env vars, no HTTP self-call:
+// the bridge is already connected to the browser.
+
+import { NoWorkspaceUiBridgeError, notify, openPanel } from "@hachej/boring-workspace/plugin"
+
+const PLUGIN_ID = "<kebab-name>"
+const PANEL_ID = "<kebab-name>.panel"
+const PANEL_TITLE = "<Label>"
+const OPEN_COMMAND = "open-<kebab-name>"
+
+export default function (pi: any) {
+  // User-facing deterministic slash command. Add pi.registerTool(...) below
+  // when this plugin also needs an LLM-callable tool.
+  pi.registerCommand(OPEN_COMMAND, {
+    description: `Open the ${PANEL_TITLE} panel`,
+    handler: async () => {
+      try {
+        await openPanel({
+          id: `${PLUGIN_ID}.slash-open`,
+          component: PANEL_ID,
+          params: { source: `/${OPEN_COMMAND}` },
+        })
+        // Surfaces as a workspace toast (unlike Pi's ctx.ui.notify, which is a
+        // terminal notification that is swallowed in server/headless mode).
+        await notify(`Opened ${PANEL_TITLE}.`, "info")
+      } catch (error) {
+        if (error instanceof NoWorkspaceUiBridgeError) {
+          // Running outside a workspace agent (e.g. a bare Pi CLI). Nothing to
+          // open; rethrow so the caller logs a clear reason.
+          throw error
+        }
+        await notify(
+          `Could not open ${PANEL_TITLE}: ${error instanceof Error ? error.message : String(error)}`,
+          "error",
+        ).catch(() => {})
+        throw error
+      }
+    },
+  })
+}

--- a/packages/plugin-cli/templates/front-file-visualizer.tsx
+++ b/packages/plugin-cli/templates/front-file-visualizer.tsx
@@ -1,0 +1,113 @@
+// CANONICAL file visualizer front/index.tsx for a boring-ui runtime plugin.
+// Recipe contract: the imports, surfaceResolvers shape, file fetch route, and
+// workspace-id header below are supported public API. Do not grep workspace
+// internals for these names unless `boring-ui-plugin test` fails. Change
+// FILE_EXT and parser/rendering for your file type.
+
+import React, { useEffect, useMemo, useState } from "react"
+import { definePlugin, WORKSPACE_OPEN_PATH_SURFACE_KIND, type PaneProps } from "@hachej/boring-workspace/plugin"
+import { useApiBaseUrl, useWorkspaceRequestId } from "@hachej/boring-workspace"
+
+const MAIN_PANEL_ID = "<kebab-name>.panel"
+const FILE_EXT = ".csv"
+
+interface FilePaneParams {
+  path?: string
+}
+
+function parseCsv(text: string): string[][] {
+  return text
+    .trim()
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((row) => row.split(",").map((cell) => cell.trim()))
+}
+
+function FilePane({ params }: PaneProps<FilePaneParams>) {
+  const path = params?.path ?? ""
+  const apiBaseUrl = useApiBaseUrl()
+  const workspaceId = useWorkspaceRequestId()
+  const [text, setText] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!path) return
+    let cancelled = false
+    const url = `${apiBaseUrl}/api/v1/files/raw?path=${encodeURIComponent(path)}`
+    fetch(url, {
+      credentials: "include",
+      headers: workspaceId ? { "x-boring-workspace-id": workspaceId } : {},
+    })
+      .then((response) => {
+        if (!response.ok) throw new Error(`Failed to load ${path}: ${response.status}`)
+        return response.text()
+      })
+      .then((body) => { if (!cancelled) setText(body) })
+      .catch((err) => { if (!cancelled) setError(err instanceof Error ? err.message : String(err)) })
+    return () => { cancelled = true }
+  }, [apiBaseUrl, path, workspaceId])
+
+  const rows = useMemo(() => parseCsv(text), [text])
+  const headers = rows[0] ?? []
+  const dataRows = rows.slice(1)
+  const numericValues = dataRows
+    .map((row) => Number(row[1] ?? row[0]))
+    .filter((value) => Number.isFinite(value))
+  const max = Math.max(1, ...numericValues)
+
+  return (
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-background text-foreground">
+      <div className="border-b border-border px-4 py-3">
+        <div className="text-sm font-semibold"><Label></div>
+        <div className="text-xs text-muted-foreground">{path || `Open a ${FILE_EXT} file`}</div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        {error ? <div className="text-sm text-destructive">{error}</div> : null}
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr>{headers.map((header, index) => <th key={index} className="border border-border px-2 py-1 text-left">{header}</th>)}</tr>
+          </thead>
+          <tbody>
+            {dataRows.map((row, rowIndex) => (
+              <tr key={rowIndex}>{row.map((cell, cellIndex) => <td key={cellIndex} className="border border-border px-2 py-1">{cell}</td>)}</tr>
+            ))}
+          </tbody>
+        </table>
+        <svg className="mt-4 h-32 w-full overflow-visible" viewBox="0 0 320 120" role="img" aria-label="CSV value chart">
+          {numericValues.map((value, index) => {
+            const width = 280 / Math.max(1, numericValues.length)
+            const height = (value / max) * 100
+            return <rect key={index} x={10 + index * width} y={110 - height} width={Math.max(2, width - 2)} height={height} fill="currentColor" opacity="0.7" />
+          })}
+        </svg>
+      </div>
+    </div>
+  )
+}
+
+export default definePlugin({
+  id: "<kebab-name>",
+  label: "<Label>",
+  panels: [
+    { id: MAIN_PANEL_ID, label: "<Label>", component: FilePane },
+  ],
+  commands: [
+    { id: "<kebab-name>.open", title: "Open <Label>", panelId: MAIN_PANEL_ID },
+  ],
+  surfaceResolvers: [
+    {
+      id: "<kebab-name>.open-file",
+      kind: WORKSPACE_OPEN_PATH_SURFACE_KIND,
+      resolve: (request) => {
+        if (request.kind !== WORKSPACE_OPEN_PATH_SURFACE_KIND) return null
+        if (!request.target.endsWith(FILE_EXT)) return null
+        return {
+          id: `<kebab-name>:${request.target}`,
+          component: MAIN_PANEL_ID,
+          title: request.target.split("/").pop() ?? "<Label>",
+          params: { path: request.target },
+        }
+      },
+    },
+  ],
+})

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -38,6 +38,7 @@ import { rebuildServerPlugins, type PluginRebuildResult } from "./rebuildServerP
 import { resolveDefaultWorkspacePluginPackagePaths } from "./defaultPluginPackages"
 import { pluginRootFromExtensionPath, scanBoringPlugins } from "../../server/agentPlugins/scan"
 import { createInMemoryBridge } from "../../server/bridge/createInMemoryBridge"
+import { registerWorkspaceUiBridge } from "../../shared/plugins/uiBridgeRegistry"
 import { createWorkspaceUiTools } from "../../server/ui-control/tools/uiTools"
 import { uiRoutes } from "../../server/ui-control/http/uiRoutes"
 import {
@@ -579,6 +580,7 @@ export async function createWorkspaceAgentServer(
 ): Promise<FastifyInstance> {
   const workspaceRoot = opts.workspaceRoot ?? process.cwd()
   const bridge = createInMemoryBridge()
+  const unregisterUiBridge = registerWorkspaceUiBridge(bridge)
   const resolvedMode = opts.runtimeModeAdapter?.id ?? opts.mode ?? autoDetectMode()
   const modeAdapter = opts.runtimeModeAdapter ?? resolveMode(resolvedMode)
   const workspaceFsCapability = modeAdapter.workspaceFsCapability ?? "best-effort"
@@ -823,6 +825,7 @@ export async function createWorkspaceAgentServer(
   if (typeof app.addHook === "function") {
     app.addHook("onClose", async () => {
       await runtimeBackendRegistry.close()
+      unregisterUiBridge()
     })
   }
   await app.register(uiRoutes, { bridge, preserveStateKeys: pluginCollection.preservedUiStateKeys })

--- a/packages/workspace/src/front/bridge/index.ts
+++ b/packages/workspace/src/front/bridge/index.ts
@@ -1,6 +1,6 @@
 export { createBridge } from "./createBridge"
 export { createBridgeClient } from "./client"
-export { dispatchUiCommand } from "./uiCommandDispatcher"
+export { dispatchUiCommand, WORKSPACE_COMMAND_NOTIFY_EVENT } from "./uiCommandDispatcher"
 export { UI_COMMAND_EVENT, postUiCommand } from "./uiCommandBus"
 export { WorkspaceLink, workspaceLinkCommand, workspaceLinkHref } from "./WorkspaceLink"
 export type { WorkspaceLinkProps, WorkspaceLinkTarget } from "./WorkspaceLink"

--- a/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
+++ b/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
@@ -9,6 +9,13 @@ import type { SurfaceShellApi, OpenPanelConfig } from "../chrome/artifact-surfac
 import type { UiCommand } from "./types"
 import type { SurfaceOpenRequest } from "../../shared/types/surface"
 
+/**
+ * Browser CustomEvent name dispatched on `window` when a `showNotification`
+ * UI command is dispatched from the server. Keep in sync with
+ * `WORKSPACE_COMMAND_NOTIFY_EVENT` in `@hachej/boring-agent/shared`.
+ */
+export const WORKSPACE_COMMAND_NOTIFY_EVENT = "boring-ui:command-notify"
+
 export interface DispatchContext {
   /**
    * Imperative handle to the workbench surface. Function (getter) so a
@@ -189,6 +196,21 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
     }
     case "closeWorkbenchLeftPane": {
       runWhenSurfaceReady(ctx, (surface) => surface.closeWorkbenchLeftPane())
+      return
+    }
+    case "showNotification": {
+      const msg = strParam(cmd.params, "msg")
+      if (!msg) return
+      const rawLevel = cmd.params?.level
+      const level: "success" | "error" | "info" =
+        rawLevel === "error" ? "error" : rawLevel === "warn" ? "info" : "info"
+      if (typeof globalThis.dispatchEvent === "function" && typeof CustomEvent !== "undefined") {
+        globalThis.dispatchEvent(
+          new CustomEvent(WORKSPACE_COMMAND_NOTIFY_EVENT, {
+            detail: { message: msg, tone: level },
+          }),
+        )
+      }
       return
     }
   }

--- a/packages/workspace/src/plugin.ts
+++ b/packages/workspace/src/plugin.ts
@@ -34,6 +34,17 @@ export {
   isValidBoringPluginId,
 } from "./shared/plugins/manifest"
 export { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "./shared/types/surface"
+
+// In-process UI bridge access for plugin Pi slash commands. Lets a command
+// open panels / show notifications directly (no BORING_UI_URL, no fetch).
+export {
+  execWorkspaceUi,
+  getWorkspaceUiBridge,
+  notify,
+  openPanel,
+  NoWorkspaceUiBridgeError,
+} from "./shared/plugins/uiBridgeRegistry"
+export type { OpenPanelArgs } from "./shared/plugins/uiBridgeRegistry"
 export type {
   BoringPackageBoringField,
   BoringPackagePiField,

--- a/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -472,9 +472,7 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
   // Issue #200: a workspace-local `.agents/skills/<name>` skill must appear in
   // the slash-command list (the unified /api/v1/agent/commands endpoint), not
   // only in the /skills API — alongside the existing package/global skills.
-  // NOTE: This test requires the /api/v1/agent/commands route (commandsRoutes in
-  // createAgentApp.ts) which is ported in Phase 2. Skip until then.
-  test.skip("local .agents/skills skill appears in the slash-command list (#200)", async () => {
+  test("local .agents/skills skill appears in the slash-command list (#200)", async () => {
     const workspaceRoot = await makeTempDir("boring-local-skill-slash-")
     await mkdir(join(workspaceRoot, ".agents", "skills", "local-test-skill"), { recursive: true })
     await writeFile(

--- a/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -469,6 +469,40 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
     }
   }, 15_000)
 
+  // Issue #200: a workspace-local `.agents/skills/<name>` skill must appear in
+  // the slash-command list (the unified /api/v1/agent/commands endpoint), not
+  // only in the /skills API — alongside the existing package/global skills.
+  // NOTE: This test requires the /api/v1/agent/commands route (commandsRoutes in
+  // createAgentApp.ts) which is ported in Phase 2. Skip until then.
+  test.skip("local .agents/skills skill appears in the slash-command list (#200)", async () => {
+    const workspaceRoot = await makeTempDir("boring-local-skill-slash-")
+    await mkdir(join(workspaceRoot, ".agents", "skills", "local-test-skill"), { recursive: true })
+    await writeFile(
+      join(workspaceRoot, ".agents", "skills", "local-test-skill", "SKILL.md"),
+      "---\nname: local-test-skill\ndescription: A workspace-local skill for the slash list.\n---\n# Local test skill\n",
+      "utf8",
+    )
+
+    const app = await createWorkspaceAgentServer({
+      workspaceRoot,
+      mode: "direct",
+      logger: false,
+    })
+
+    try {
+      const res = await app.inject({ method: "GET", url: "/api/v1/agent/commands?sessionId=default" })
+      expect(res.statusCode).toBe(200)
+      const commands = res.json().commands as Array<{ name: string; source: string }>
+      const skillCommands = commands.filter((c) => c.source === "skill").map((c) => c.name)
+      // Pi prefixes skill commands with `skill:`. The local skill must be listed
+      // and existing package skills must still be present.
+      expect(skillCommands).toContain("skill:local-test-skill")
+      expect(skillCommands).toContain("skill:boring-plugin-authoring")
+    } finally {
+      await app.close()
+    }
+  }, 15_000)
+
   test("collects plugin provisioning declarations and asks agent to seed workspace", async () => {
     const workspaceRoot = await makeTempDir("boring-workspace-provisioned-")
     const templateRoot = await makeTempDir("boring-workspace-template-")

--- a/packages/workspace/src/shared/plugins/__tests__/uiBridgeRegistry.test.ts
+++ b/packages/workspace/src/shared/plugins/__tests__/uiBridgeRegistry.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { CommandResult, UiBridge, UiCommand } from "../../ui-bridge"
+import {
+  execWorkspaceUi,
+  getWorkspaceUiBridge,
+  NoWorkspaceUiBridgeError,
+  notify,
+  openPanel,
+  registerWorkspaceUiBridge,
+} from "../uiBridgeRegistry"
+
+function makeBridge(): { bridge: UiBridge; posted: UiCommand[] } {
+  const posted: UiCommand[] = []
+  const bridge: UiBridge = {
+    getState: async () => null,
+    setState: async () => {},
+    postCommand: async (cmd: UiCommand): Promise<CommandResult> => {
+      posted.push(cmd)
+      return { seq: posted.length, status: "ok" }
+    },
+    subscribeCommands: () => () => {},
+  }
+  return { bridge, posted }
+}
+
+describe("workspace UI bridge registry", () => {
+  afterEach(() => {
+    // Clear the globalThis slot so no bridge leaks across tests:
+    // register-then-immediately-unregister always empties it.
+    registerWorkspaceUiBridge(makeBridge().bridge)()
+  })
+
+  it("throws an actionable error when no bridge is registered", async () => {
+    await expect(execWorkspaceUi({ kind: "openPanel", params: { id: "a", component: "b" } })).rejects.toBeInstanceOf(
+      NoWorkspaceUiBridgeError,
+    )
+    await expect(openPanel({ id: "a", component: "b" })).rejects.toBeInstanceOf(NoWorkspaceUiBridgeError)
+  })
+
+  it("dispatches openPanel through the registered bridge (no URL, no fetch)", async () => {
+    const { bridge, posted } = makeBridge()
+    const fetchSpy = vi.fn()
+    vi.stubGlobal("fetch", fetchSpy)
+    const unregister = registerWorkspaceUiBridge(bridge)
+    try {
+      const result = await openPanel({ id: "demo.slash-open", component: "demo.panel", params: { source: "/x" } })
+      expect(result).toEqual({ seq: 1, status: "ok" })
+      expect(posted).toEqual([
+        { kind: "openPanel", params: { id: "demo.slash-open", component: "demo.panel", params: { source: "/x" } } },
+      ])
+      // Crucially: the helper goes in-process, it never calls fetch.
+      expect(fetchSpy).not.toHaveBeenCalled()
+    } finally {
+      unregister()
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it("routes notify to a showNotification UI command", async () => {
+    const { bridge, posted } = makeBridge()
+    const unregister = registerWorkspaceUiBridge(bridge)
+    try {
+      await notify("hello", "error")
+      expect(posted).toEqual([{ kind: "showNotification", params: { msg: "hello", level: "error" } }])
+    } finally {
+      unregister()
+    }
+  })
+
+  it("unregister only clears the slot if it still holds the same bridge", () => {
+    const first = makeBridge().bridge
+    const second = makeBridge().bridge
+    const unregisterFirst = registerWorkspaceUiBridge(first)
+    registerWorkspaceUiBridge(second)
+    // first's unregister must not clobber second (last-registered wins).
+    unregisterFirst()
+    expect(getWorkspaceUiBridge()).toBe(second)
+    registerWorkspaceUiBridge(second)()
+  })
+})

--- a/packages/workspace/src/shared/plugins/uiBridgeRegistry.ts
+++ b/packages/workspace/src/shared/plugins/uiBridgeRegistry.ts
@@ -1,0 +1,120 @@
+/**
+ * In-process registry that lets a plugin's Pi slash command reach the live
+ * workspace `UiBridge` WITHOUT an HTTP round-trip or a `BORING_UI_URL` env var.
+ *
+ * Why this exists
+ * ---------------
+ * A Pi extension slash-command handler only receives Pi's terminal-oriented
+ * `ctx.ui` (notify/select/confirm). It has no concept of the boring-ui
+ * workspace UI bridge, so the old canonical template resorted to
+ * `fetch(BORING_UI_URL + "/api/v1/ui/commands")` — fragile, and it silently
+ * no-op'd whenever the env var was unset (which is the common case). The bridge
+ * is already an in-process object owned by the agent server, so the right thing
+ * is to call `bridge.postCommand(...)` directly — the exact same path the
+ * agent's `exec_ui` tool uses.
+ *
+ * Why globalThis
+ * --------------
+ * Hot-reloadable plugins are loaded by Pi through jiti, which keeps its own
+ * module cache. A plain module-level singleton populated by the server is NOT
+ * guaranteed to be the same instance the plugin imports. `globalThis` is shared
+ * across every module realm in the process, so a `Symbol.for`-keyed slot is the
+ * one storage that both the server and a jiti-loaded plugin observe identically.
+ *
+ * This module is browser-safe (only `globalThis` + types), so it can live on
+ * the `@hachej/boring-workspace/plugin` authoring surface.
+ */
+import type { CommandResult, UiBridge, UiCommand } from "../ui-bridge"
+
+const REGISTRY_KEY = Symbol.for("@hachej/boring-workspace:active-ui-bridge")
+
+type GlobalWithBridge = typeof globalThis & {
+  [REGISTRY_KEY]?: UiBridge | undefined
+}
+
+function slot(): GlobalWithBridge {
+  return globalThis as GlobalWithBridge
+}
+
+/**
+ * Publish the workspace `UiBridge` for the current process so plugin slash
+ * commands can dispatch UI commands in-process. The agent server calls this
+ * once per server instance (see `createWorkspaceAgentServer`). Returns an
+ * unregister function — call it on server shutdown so a closed bridge is not
+ * left dangling for the next server in the same process (eval harness, tests).
+ */
+export function registerWorkspaceUiBridge(bridge: UiBridge): () => void {
+  slot()[REGISTRY_KEY] = bridge
+  return () => {
+    if (slot()[REGISTRY_KEY] === bridge) {
+      slot()[REGISTRY_KEY] = undefined
+    }
+  }
+}
+
+/** The active workspace `UiBridge`, or `undefined` when none is registered. */
+export function getWorkspaceUiBridge(): UiBridge | undefined {
+  return slot()[REGISTRY_KEY]
+}
+
+/**
+ * Thrown by the plugin-facing helpers when no workspace bridge is active — for
+ * example when plugin code runs under a bare Pi CLI with no workspace UI
+ * attached. The message is deliberately actionable.
+ */
+export class NoWorkspaceUiBridgeError extends Error {
+  constructor() {
+    super(
+      "No workspace UI bridge is active. This plugin command must run inside a " +
+        "boring-ui workspace agent (it cannot open panels from a bare Pi CLI).",
+    )
+    this.name = "NoWorkspaceUiBridgeError"
+  }
+}
+
+function requireBridge(): UiBridge {
+  const bridge = getWorkspaceUiBridge()
+  if (!bridge) throw new NoWorkspaceUiBridgeError()
+  return bridge
+}
+
+/**
+ * Dispatch an arbitrary UI command through the active workspace bridge. This is
+ * the same call the agent's `exec_ui` tool makes; the connected browser drains
+ * the command. Prefer the named helpers below for common actions.
+ */
+export async function execWorkspaceUi(command: UiCommand): Promise<CommandResult> {
+  return requireBridge().postCommand(command)
+}
+
+export interface OpenPanelArgs {
+  /** Tab instance id. Reuse the same id to re-activate an existing tab. */
+  id: string
+  /** Panel component id (one of the workspace's registered panels). */
+  component: string
+  /** Optional params forwarded to the panel component. */
+  params?: Record<string, unknown>
+}
+
+/**
+ * Open an app/plugin panel in the workspace from a plugin slash command.
+ * In-process — no URL, no env. Throws `NoWorkspaceUiBridgeError` if no bridge.
+ */
+export async function openPanel(args: OpenPanelArgs): Promise<CommandResult> {
+  return execWorkspaceUi({
+    kind: "openPanel",
+    params: { id: args.id, component: args.component, params: args.params },
+  })
+}
+
+/**
+ * Show a workspace notification (toast) from a plugin slash command. Unlike
+ * Pi's `ctx.ui.notify` (a terminal notification that is swallowed in
+ * server/headless mode), this surfaces in the browser via the UI bridge.
+ */
+export async function notify(
+  msg: string,
+  level: "info" | "warn" | "error" = "info",
+): Promise<CommandResult> {
+  return execWorkspaceUi({ kind: "showNotification", params: { msg, level } })
+}


### PR DESCRIPTION
## Summary
- clarify `boring-ui-plugin verify` as manifest/file-only and make `boring-ui-plugin test` the primary one-command validation path when a workspace URL exists
- `boring-ui-plugin test` now runs verify internally before reload/panel checks and returns phase-shaped JSON (`verify`, `reload`, `pane`, `determinism`, `nextAction`)
- reject unsafe plugin ids, filesystem paths passed to `--workspace`, and missing/ambiguous workspace roots for local verify
- add stale-front determinism checks: ready panes must report a revision matching the canonical server/plugin revision, with stable errors for missing/stale revisions
- poll stale ready pane revisions until timeout so browser reload races do not false-fail immediately
- simplify runtime plugin scaffold to a smoke-first panel without risky default data/hook imports
- update the boring-ui system prompt: use `test` when possible, `verify` as manifest-only fallback, then ask the user to run `/reload` for activation
- provision `boring-ui-plugin` in direct-mode workspaces so the authoring prompt and actual PATH agree
- add live LLM eval coverage for smoke-first plugin generation and no false render-success claims
- add `docs/plans/runtime-plugin-reload-eval-hardening-plan.md` with the revised one-command validation plan and follow-up singleton work

## Nuclear review loop
Ran iterative autoreview/nuclear loop until clean. Accepted/fixed findings included:
- pass explicit `--workspace-root` through verify→test workflow
- mark skipped reload phase as not attempted / not ok
- fail stale or missing revision evidence before claiming `ok`
- prefer `serverLoadedRevision` over stale host revision
- reject unsafe plugin ids before filesystem path resolution
- poll stale ready panes until current revision appears or timeout
- align prompt and plan with implemented JSON/command contract

Final review:
- `/home/ubuntu/.pi/agent/skills/coding-autoreview/scripts/autoreview --mode local` → clean, no accepted/actionable findings

## Live eval proof
- `BORING_USE_LOCAL_PACKAGES=1 GEMINI_API_KEY=... pnpm --filter @hachej/boring-workspace test src/eval/__tests__/plugin-creation.test.ts -t "smoke-first"`
- Result: passed with `google/gemini-2.5-flash`
- Eval verifies generated plugin:
  - `package.json` exists
  - `front/index.tsx` exists
  - contains `eval-smoke-first ready`
  - does not import `@hachej/boring-ui-kit`
  - does not use `useApiBaseUrl`
  - does not use `useWorkspaceRequestId`
  - agent ran `boring-ui-plugin verify`
  - final asks `/reload`
  - final does not claim browser render success from verify alone

## Other proof
- `pnpm --filter @hachej/boring-ui-plugin-cli test src/__tests__/testPlugin.test.ts src/__tests__/pluginCli.test.ts`
- `pnpm --filter @hachej/boring-ui-plugin-cli typecheck`
- `pnpm --filter @hachej/boring-workspace test src/server/__tests__/boringSystemPrompt.test.ts`
- `pnpm --filter @hachej/boring-workspace test src/server/__tests__/createWorkspaceAgentServer.test.ts -t "direct mode provisions"`
- `pnpm --filter @hachej/boring-workspace test src/app/server/__tests__/createWorkspaceAgentServer.test.ts -t "default plugin CLI provisioning"`
- `pnpm --filter @hachej/boring-workspace typecheck`

## Notes
- Live LLM eval additions remain provider-key gated like the existing eval suite.
- Host singleton identity probing for `@hachej/boring-ui-kit`/React remains planned follow-up; this PR enforces the verify/test/revision path now.



---
Closes #200 — workspace-local `.agents/skills` skills now appear in the slash-command list via the unified `/api/v1/agent/commands` endpoint (regression test added). Supersedes #206.
