### PR TITLE
fix(cli): install plugin deps and fix cross-device EXDEV on npm/git install

### DIFF
--- a/packages/plugin-cli/src/__tests__/pluginCli.test.ts
+++ b/packages/plugin-cli/src/__tests__/pluginCli.test.ts
@@ -191,14 +191,30 @@ test("boring-ui-plugin list ignores uninspectable Pi package sources", async () 
   expect(JSON.parse(list.stdout).records).toEqual([])
 })
 
-test("boring-ui-plugin installs git and npm plugin source without installing dependencies", async () => {
+async function writeLocalDependency(dir: string, name: string): Promise<void> {
+  await mkdir(dir, { recursive: true })
+  await writeFile(join(dir, "package.json"), JSON.stringify({ name, version: "1.0.0", main: "index.js" }, null, 2), "utf8")
+  await writeFile(join(dir, "index.js"), "module.exports = {}\n", "utf8")
+}
+
+test("boring-ui-plugin installs git and npm plugin sources with their declared dependencies", async () => {
   const root = await tempDir("boring-plugin-source-remote-")
   const workspaceRoot = join(root, "workspace")
   const gitSource = join(root, "git-source")
   const npmSource = join(root, "npm-source")
+  // A real, network-free dependency referenced by absolute file: spec so the
+  // install resolves it offline and after the package is relocated into .pi.
+  const dependency = join(root, "dep-pkg")
   await mkdir(workspaceRoot, { recursive: true })
-  await writeRuntimePlugin(gitSource, "git-plugin", { leftpad: "^0.0.1" })
-  await writeRuntimePlugin(npmSource, "npm-plugin", { leftpad: "^0.0.1" })
+  // npm materializes a file: dependency as a *relative* symlink even from an
+  // absolute spec, so this also guards the "install at the final path, not in
+  // staging" rationale: installing in staging then moving would leave the
+  // symlink dangling and these assertions would fail.
+  await writeLocalDependency(dependency, "boring-source-dep")
+  // `react` is host-provided: it must be stripped before install (never fetched,
+  // never shadowed), while the real file: dependency is installed.
+  await writeRuntimePlugin(gitSource, "git-plugin", { "boring-source-dep": `file:${dependency}`, react: "^18.0.0" })
+  await writeRuntimePlugin(npmSource, "npm-plugin", { "boring-source-dep": `file:${dependency}`, react: "^18.0.0" })
 
   await execFileAsync("git", ["init"], { cwd: gitSource })
   await execFileAsync("git", ["config", "user.email", "test@example.com"], { cwd: gitSource })
@@ -209,14 +225,20 @@ test("boring-ui-plugin installs git and npm plugin source without installing dep
   const gitInstall = await runPluginCli(["install", `git:${gitSource}`, "--workspace", workspaceRoot], { cwd: root })
   expect(gitInstall.stderr).toContain("Security: Boring plugins run as trusted local code")
   expect(gitInstall.stdout).toContain("installed git-plugin")
+  expect(gitInstall.stdout).not.toContain("Missing dependency")
   await expect(access(join(workspaceRoot, ".pi", "git", "git-plugin", "package.json"))).resolves.toBeUndefined()
-  await expect(access(join(workspaceRoot, ".pi", "git", "git-plugin", "node_modules"))).rejects.toThrow()
+  // Dependencies are installed into the cloned package's own node_modules, like Pi.
+  await expect(access(join(workspaceRoot, ".pi", "git", "git-plugin", "node_modules", "boring-source-dep", "package.json"))).resolves.toBeUndefined()
+  // Host-provided react is stripped, never shadowed into the plugin tree.
+  await expect(access(join(workspaceRoot, ".pi", "git", "git-plugin", "node_modules", "react"))).rejects.toThrow()
 
   const npmInstall = await runPluginCli(["install", `npm:${npmSource}`, "--workspace", workspaceRoot], { cwd: root })
   expect(npmInstall.stderr).toContain("Security: Boring plugins run as trusted local code")
   expect(npmInstall.stdout).toContain("installed npm-plugin")
+  expect(npmInstall.stdout).not.toContain("Missing dependency")
   await expect(access(join(workspaceRoot, ".pi", "npm", "npm-plugin", "package.json"))).resolves.toBeUndefined()
-  await expect(access(join(workspaceRoot, ".pi", "npm", "npm-plugin", "node_modules"))).rejects.toThrow()
+  await expect(access(join(workspaceRoot, ".pi", "npm", "npm-plugin", "node_modules", "boring-source-dep", "package.json"))).resolves.toBeUndefined()
+  await expect(access(join(workspaceRoot, ".pi", "npm", "npm-plugin", "node_modules", "react"))).rejects.toThrow()
 
   expect(await readPiSettingsPackages(join(workspaceRoot, ".pi", "settings.json"))).toEqual([
     "./git/git-plugin",
@@ -236,6 +258,20 @@ test("boring-ui-plugin installs git and npm plugin source without installing dep
 
   await runPluginCli(["remove", "git-plugin", "--workspace", workspaceRoot], { cwd: root })
   await expect(access(join(workspaceRoot, ".pi", "git", "git-plugin"))).rejects.toThrow()
+})
+
+test("boring-ui-plugin local install references the source and never installs its dependencies", async () => {
+  const root = await tempDir("boring-plugin-source-local-deps-")
+  const workspaceRoot = join(root, "workspace")
+  const source = join(root, "local-source")
+  await mkdir(workspaceRoot, { recursive: true })
+  await writeRuntimePlugin(source, "local-dep-plugin", { recharts: "^2.0.0" })
+
+  const install = await runPluginCli(["install", source], { cwd: workspaceRoot })
+  expect(install.stdout).toContain("installed local-dep-plugin")
+  expect(install.stdout).toContain("Missing dependency: recharts")
+  // Local-path sources are an editable tree the author owns: never mutated.
+  await expect(access(join(source, "node_modules"))).rejects.toThrow()
 })
 
 test("boring-ui-plugin supports explicit global source scope", async () => {

--- a/packages/plugin-cli/src/server/pluginSources.ts
+++ b/packages/plugin-cli/src/server/pluginSources.ts
@@ -9,7 +9,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs"
-import { homedir, tmpdir } from "node:os"
+import { homedir } from "node:os"
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { validateBoringPluginManifest } from "../manifest"
 
@@ -282,12 +282,25 @@ function validateInstallablePluginRoot(pluginRoot: string): { id: string; packag
   }
 }
 
+/**
+ * Packages the workspace host always supplies at runtime. A plugin must resolve
+ * these from the host, never from a copy inside its own tree — a second React in
+ * particular causes dual-React / invalid-hook-call crashes. We never report them
+ * as missing, and `installPluginDependencies` strips them from the plugin's own
+ * `dependencies` before installing so npm can't pull a shadow copy even when a
+ * plugin lists them under `dependencies` instead of `peerDependencies`. (This
+ * covers the plugin's direct deps; a transitive dep that wrongly declares React
+ * under `dependencies` rather than `peerDependencies` could still hoist a copy —
+ * `--legacy-peer-deps` plus the React-as-peer convention is what guards that.)
+ */
+const HOST_PROVIDED_DEPENDENCIES = new Set(["react", "react-dom", "@hachej/boring-workspace", "@hachej/boring-ui-kit"])
+
 function dependencyHints(pluginRoot: string, pkg: Record<string, unknown>): string[] {
   const dependencies = pkg.dependencies
   if (!dependencies || typeof dependencies !== "object" || Array.isArray(dependencies)) return []
   const hints: string[] = []
   for (const dep of Object.keys(dependencies)) {
-    if (dep === "react" || dep === "react-dom" || dep === "@hachej/boring-workspace" || dep === "@hachej/boring-ui-kit") continue
+    if (HOST_PROVIDED_DEPENDENCIES.has(dep)) continue
     const depDir = dep.startsWith("@") ? join(pluginRoot, "node_modules", ...dep.split("/")) : join(pluginRoot, "node_modules", dep)
     if (!existsSync(depDir)) hints.push(`Missing dependency: ${dep}\nRun: cd ${pluginRoot} && npm install`)
   }
@@ -330,6 +343,9 @@ function safeInstallDir(parent: string, id: string): string {
   return join(parent, cleaned)
 }
 
+// Promote a staged package to its final path. Callers stage inside the
+// destination's own parent dir (see withStagingDir), so `from` and `to` are
+// always on the same filesystem and this rename can't hit EXDEV.
 function moveFreshDir(from: string, to: string): void {
   if (existsSync(to)) throw new Error(`plugin install target already exists: ${to}. Remove it first with boring-ui-plugin remove ${basename(to)}`)
   mkdirSync(dirname(to), { recursive: true })
@@ -341,29 +357,87 @@ function installLocalSource(source: string, paths: PluginSourceScopePaths): { ro
   return { rootDir, packageSource: sourceForLocalPackage(paths, rootDir) }
 }
 
-function installGitSource(spec: string, paths: PluginSourceScopePaths, ref?: string): { rootDir: string; packageSource: string; ref?: string } {
-  const tmp = mkdtempSync(join(tmpdir(), "boring-plugin-git-"))
-  const cloneDir = join(tmp, "repo")
+/**
+ * Install a freshly placed plugin package's declared dependencies into its own
+ * `node_modules`, the same way Pi installs package sources: delegate to the
+ * package manager rather than shipping a bare tarball. Runs at the FINAL install
+ * path (not in staging) so package-manager-authored relative symlinks — e.g.
+ * `file:` deps — resolve correctly and survive.
+ *
+ * Host-provided packages are stripped from the manifest first so npm cannot pull
+ * a shadow copy into the plugin tree; the workspace supplies them at runtime.
+ * Rolls the package back out on failure so a partial install never lingers.
+ * Local-path sources are excluded by the caller: those reference an editable tree
+ * the author owns and must not be mutated.
+ */
+function installPluginDependencies(pluginRoot: string): void {
+  const pkg = readPackageJson(pluginRoot)
+  const declared = pkg.dependencies
+  if (!declared || typeof declared !== "object" || Array.isArray(declared)) return
+  const installable = Object.fromEntries(
+    Object.entries(declared).filter(([name]) => !HOST_PROVIDED_DEPENDENCIES.has(name)),
+  )
+  if (Object.keys(installable).length === 0) return
+  if (Object.keys(installable).length !== Object.keys(declared).length) {
+    writeFileSync(
+      join(pluginRoot, "package.json"),
+      `${JSON.stringify({ ...pkg, dependencies: installable }, null, 2)}\n`,
+      "utf8",
+    )
+  }
   try {
+    // Scripts run (no --ignore-scripts), matching Pi: install lifecycle scripts of
+    // the plugin and its deps execute here. The install path already warns that
+    // plugins are trusted local code.
+    run("npm", ["install", "--omit=dev", "--no-audit", "--no-fund", "--legacy-peer-deps"], { cwd: pluginRoot })
+  } catch (err) {
+    // Deps are mandatory for npm/git sources (a plugin missing them won't load),
+    // so a failed install is a failed install: roll the package back out — leaving
+    // no settings entry and no half-placed dir — rather than register a broken
+    // plugin. Re-run the install once the registry is reachable again.
+    rmSync(pluginRoot, { recursive: true, force: true })
+    const detail = err instanceof Error ? err.message : String(err)
+    throw new Error(`failed to install dependencies for plugin at ${pluginRoot}; install rolled back. ${detail}`)
+  }
+}
+
+/**
+ * Stage a fetched package next to its final destination (inside the scope's
+ * git/npm root, on the same filesystem) so promoting it is an atomic rename.
+ * The previous implementation staged under the OS temp dir and renamed across
+ * mounts, which throws EXDEV whenever `/tmp` is a separate filesystem (tmpfs,
+ * Docker, most CI) — i.e. the common case.
+ */
+function withStagingDir<T>(parent: string, fn: (stagingDir: string) => T): T {
+  mkdirSync(parent, { recursive: true })
+  const staging = mkdtempSync(join(parent, ".staging-"))
+  try {
+    return fn(staging)
+  } finally {
+    rmSync(staging, { recursive: true, force: true })
+  }
+}
+
+function installGitSource(spec: string, paths: PluginSourceScopePaths, ref?: string): { rootDir: string; packageSource: string; ref?: string } {
+  return withStagingDir(paths.gitDir, (staging) => {
+    const cloneDir = join(staging, "repo")
     run("git", ["clone", "--quiet", spec, cloneDir])
     if (ref) run("git", ["checkout", "--quiet", ref], { cwd: cloneDir })
     const meta = validateInstallablePluginRoot(cloneDir)
     const target = safeInstallDir(paths.gitDir, meta.id)
     moveFreshDir(cloneDir, target)
+    installPluginDependencies(target)
     return { rootDir: target, packageSource: sourceForLocalPackage(paths, target), ...(ref ? { ref } : {}) }
-  } finally {
-    rmSync(tmp, { recursive: true, force: true })
-  }
+  })
 }
 
 function installNpmSource(spec: string, paths: PluginSourceScopePaths): { rootDir: string; packageSource: string } {
-  const tmp = mkdtempSync(join(tmpdir(), "boring-plugin-npm-"))
-  const packDir = join(tmp, "pack")
-  const extractDir = join(tmp, "extract")
-  mkdirSync(packDir, { recursive: true })
-  mkdirSync(extractDir, { recursive: true })
-  try {
-    const stdout = runWithStdout("npm", ["pack", "--silent", spec, "--pack-destination", packDir], { cwd: tmp })
+  return withStagingDir(paths.npmDir, (staging) => {
+    const packDir = join(staging, "pack")
+    const extractDir = join(staging, "extract")
+    mkdirSync(packDir, { recursive: true })
+    mkdirSync(extractDir, { recursive: true })
+    const stdout = runWithStdout("npm", ["pack", "--silent", spec, "--pack-destination", packDir], { cwd: staging })
     const tarballName = stdout.trim().split(/\r?\n/).filter(Boolean).at(-1)
     if (!tarballName) throw new Error(`npm pack did not produce a tarball for ${spec}`)
     const tarball = isAbsolute(tarballName) ? tarballName : join(packDir, tarballName)
@@ -371,10 +445,9 @@ function installNpmSource(spec: string, paths: PluginSourceScopePaths): { rootDi
     const meta = validateInstallablePluginRoot(extractDir)
     const target = safeInstallDir(paths.npmDir, meta.id)
     moveFreshDir(extractDir, target)
+    installPluginDependencies(target)
     return { rootDir: target, packageSource: sourceForLocalPackage(paths, target) }
-  } finally {
-    rmSync(tmp, { recursive: true, force: true })
-  }
+  })
 }
 
 function recordFromPackageSource(paths: PluginSourceScopePaths, entry: PiPackageEntry): PluginSourceRecord | null {


### PR DESCRIPTION
## Summary

`boring-ui-plugin install` for `npm:`/`git:` sources had two bugs that both trace back to the installer hand-rolling package fetching instead of mirroring Pi the way the plan specified:

1. **Cross-device `EXDEV` crash.** It extracted the package into the OS temp dir (`os.tmpdir()`) and `renameSync`'d it into the workspace `.pi/`. `rename()` can't span filesystems, so on any machine where `/tmp` is a separate mount — tmpfs, Docker, most CI — the install died with `EXDEV: cross-device link not permitted`. Only same-filesystem setups (where CI happened to pass) worked.
2. **Dependencies were never installed.** It shipped the bare published tarball (`npm pack`), so a plugin's runtime deps (e.g. deck's `lucide-react`, `react-markdown`, `remark-gfm`) were missing and the front bundle couldn't resolve them.

Both contradict the plan (`docs/plans/runtime-plugin-cli-local/prs/03-cli-install-and-verification.md`), which is explicit:
> npm — *"Install into scope-specific package root. Use package manager behavior close to Pi. Dependencies are installed in the installed package directory…"*
> git — *"Run dependency install in the cloned plugin package directory if `package.json` exists, like Pi."*
> Success criterion — *"npm/git/URL installs leave declared package dependencies present."*

This was implementation drift, not a deliberate decision — and it was locked in by a test literally named *"installs git and npm plugin source **without installing dependencies**"* that asserted `node_modules` was absent, which (together with CI's same-FS `/tmp`) gave the green light.

## How Pi does it (the model we now mirror)

Pi (`core/package-manager.js`) never stages-then-moves across devices and never ships a bare tarball: it installs **directly into a destination inside the workspace** and **delegates to the package manager** (`npm install`), which pulls the full dependency tree. This PR brings boring's installer in line.

## Changes

`packages/plugin-cli/src/server/pluginSources.ts`:
- **Stage on the same filesystem.** `installNpmSource`/`installGitSource` now stage inside the scope's own `npm`/`git` root (via `withStagingDir`) instead of `os.tmpdir()`, so promoting the package is an atomic same-FS rename. `moveFreshDir` keeps a defensive `cpSync`+`rm` fallback if a rename ever returns `EXDEV` anyway.
- **Install dependencies like Pi.** After the package is placed at its final path, run `npm install --omit=dev --no-audit --no-fund --legacy-peer-deps` in its own dir. Host-provided peers (`react`, `react-dom`, `@hachej/boring-workspace`, `@hachej/boring-ui-kit`) are skipped. Dependency install runs at the **final** location (not staging) so package-manager-authored relative symlinks — e.g. `file:` deps — resolve correctly; a failed install rolls the package back out so nothing partial lingers.
- **Local installs unchanged:** still reference-only, never mutate the author's source tree.
- De-duplicated the host-provided-deps list shared by `dependencyHints`.

`packages/plugin-cli/src/__tests__/pluginCli.test.ts`:
- Rewrote the "without installing dependencies" test to assert deps **do** land in the installed package's `node_modules` (using an offline `file:` dependency so it's network-free in CI).
- Added a counterpart test that a local-path install never creates `node_modules` in the source.

## Verification

- `pnpm --filter @hachej/boring-ui-plugin-cli run typecheck` ✅
- `pnpm --filter @hachej/boring-ui-plugin-cli run test` ✅ (15/15)
- `pnpm lint` ✅ (generated-artifacts + import audit)
- End-to-end against the running playground: `install -l npm:@hachej/boring-deck` now pulls `lucide-react`/`react-markdown`/`remark-gfm` into `.pi/npm/deck/node_modules`, prints no "Missing dependency" hint, and `deck` loads after `/reload`.

## Note / follow-up

This keeps boring's per-id install dir + path-based `settings.json#packages` entries (deps live in each plugin's own `node_modules`, matching the plan's "installed package directory" wording and Pi's git flow). It does **not** adopt Pi's shared `--prefix` npm root with `npm:<name>` settings entries + node-resolution, which would dedupe deps across plugins but requires changes to the workspace-side discovery/resolver — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)