### PR TITLE
fix(workspace): portal file-tree menu + show provider in model label

### DIFF
--- a/packages/agent/src/front/__tests__/ModelSelect.test.tsx
+++ b/packages/agent/src/front/__tests__/ModelSelect.test.tsx
@@ -34,7 +34,7 @@ describe('ModelSelect', () => {
       />,
     )
     expect(screen.getByRole('button', { name: 'Model' })).toBeTruthy()
-    expect(screen.getByText('GPT-4o')).toBeTruthy()
+    expect(screen.getByText('GPT-4o (OpenAI)')).toBeTruthy()
   })
 
   it('uses the compact bordered composer control style', () => {
@@ -117,7 +117,7 @@ describe('ModelSelect', () => {
       />,
     )
 
-    expect(screen.getByText('Claude Sonnet')).toBeTruthy()
+    expect(screen.getByText('Claude Sonnet (Anthropic)')).toBeTruthy()
   })
 
   it('invokes onChange when a model is selected', () => {

--- a/packages/agent/src/front/chatPanelComposerControls.tsx
+++ b/packages/agent/src/front/chatPanelComposerControls.tsx
@@ -195,6 +195,10 @@ export const ModelSelectTrigger = forwardRef<HTMLButtonElement, ModelSelectTrigg
   ...props
 }, ref) {
   const triggerLabel = modelTriggerLabel(value, options)
+  // Show the provider alongside the model so the same model name across
+  // providers stays unambiguous, e.g. "Sonnet (Anthropic)". 'Pi default'
+  // (no explicit selection) has no provider to show.
+  const triggerDisplay = value ? `${triggerLabel} (${displayProviderLabel(value.provider)})` : triggerLabel
   return (
     <button
       ref={ref}
@@ -202,8 +206,8 @@ export const ModelSelectTrigger = forwardRef<HTMLButtonElement, ModelSelectTrigg
       data-boring-agent-part="model-select"
       data-boring-state={disabled ? "disabled" : undefined}
       disabled={disabled}
-      aria-label={trigger === 'slash' ? `Open model picker. Current model: ${triggerLabel}` : 'Model'}
-      title={trigger === 'slash' ? `Open model picker. Current model: ${triggerLabel}` : undefined}
+      aria-label={trigger === 'slash' ? `Open model picker. Current model: ${triggerDisplay}` : 'Model'}
+      title={trigger === 'slash' ? `Open model picker. Current model: ${triggerDisplay}` : undefined}
       onClick={onClick}
       className={cn(
         trigger === 'slash'
@@ -218,11 +222,11 @@ export const ModelSelectTrigger = forwardRef<HTMLButtonElement, ModelSelectTrigg
       {trigger === 'slash' ? (
         <>
           <span className="text-muted-foreground">/model: </span>
-          <span className="text-foreground">{triggerLabel}</span>
+          <span className="text-foreground">{triggerDisplay}</span>
         </>
       ) : (
         <>
-          <span className="min-w-0 truncate">{triggerLabel}</span>
+          <span className="min-w-0 truncate">{triggerDisplay}</span>
           <ChevronDownIcon className="h-3 w-3 shrink-0 text-muted-foreground/50" aria-hidden="true" />
         </>
       )}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from "react"
+import { createPortal } from "react-dom"
 import type { DockviewPanelApi } from "dockview-react"
 import {
   useFileList,
@@ -734,7 +735,7 @@ export function FileTreeView({
         )}
       </div>
 
-      {ctxMenu && (
+      {ctxMenu && createPortal(
         <div
           ref={menuRef}
           role="menu"
@@ -779,7 +780,12 @@ export function FileTreeView({
               ) : null}
             </>
           )}
-        </div>
+        </div>,
+        // Portal to <body>: the menu is position:fixed, but the dockview panel
+        // ancestor is transformed (its own containing block) and PanelChrome is
+        // overflow-hidden, which clipped the menu at the panel's bottom edge.
+        // Rendering at the body root makes "fixed" truly viewport-relative.
+        document.body,
       )}
 
       <AlertDialog


### PR DESCRIPTION
Two small QA fixes found while manually testing main after the pi-native chat rewrite (#227) landed.

## 1. File-tree context menu clipped at the bottom
The menu is `position: fixed` but was rendered **inline** inside a dockview panel. dockview transforms its panels (making each its own containing block), and `PanelChrome` is `overflow-hidden` — so a "fixed" child resolves relative to the transformed panel and gets clipped at the panel's bottom edge. The viewport-clamp math was correct, just applied in the wrong coordinate space.

**Fix:** render the menu through `createPortal(…, document.body)` so `fixed` is truly viewport-relative. (This is the same reason the *tab* right-click menu already worked — it goes through dockview's portal-based PopupService.) No behavior change otherwise; the clamp logic is untouched.

## 2. Provider name in the composer model label
The model indicator under the chat showed only the model (e.g. "Sonnet"), which is ambiguous when the same model name exists across providers. Now renders as **"Sonnet (Anthropic)"** via the existing `displayProviderLabel`. Trigger display + aria/title only; menu option labels are unchanged.

## Verification
- agent + workspace typecheck clean
- file-tree pane tests 81/81 pass; ModelSelect tests 16/16 pass (2 assertions updated to the new `Model (Provider)` label format)

Found during release QA of #227; both are safe, isolated changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)