### PR TITLE
feat(workspace): workspace left nav icon rail (implements left-nav UX spec)

### DIFF
--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import type { DockviewApi } from "dockview-react"
-import { ChevronRight, FolderTree } from "lucide-react"
+import { ChevronRight, Menu } from "lucide-react"
 import { Button, IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import { ArtifactSurfacePane } from "./ArtifactSurfacePane"
@@ -690,10 +690,10 @@ export function SurfaceShell({
                 size="icon-xs"
                 onClick={() => setCollapsed(false)}
                 className="pointer-events-auto ml-2"
-                aria-label="Show sources"
-                title="Show sources"
+                aria-label="Show workspace menu"
+                title="Show workspace menu"
               >
-                <FolderTree className="h-4 w-4" strokeWidth={1.75} />
+                <Menu className="h-4 w-4" strokeWidth={1.75} />
               </IconButton>
             )}
           </div>
@@ -758,10 +758,10 @@ function EmptyWorkbenchOverlay({
             size="icon-xs"
             onClick={onExpandFiles}
             className="pointer-events-auto mx-1"
-            aria-label="Show sources"
-            title="Show sources"
+            aria-label="Show workspace menu"
+            title="Show workspace menu"
           >
-            <FolderTree className="h-4 w-4" strokeWidth={1.75} />
+            <Menu className="h-4 w-4" strokeWidth={1.75} />
           </IconButton>
         )}
         <div className="flex-1" />
@@ -784,8 +784,8 @@ function EmptyWorkbenchOverlay({
             onClick={onExpandFiles}
             className="pointer-events-auto mt-2 gap-1.5 text-[12px] hover:border-[color:var(--accent)]/40 hover:text-[color:var(--accent)]"
           >
-            <FolderTree className="h-3.5 w-3.5" strokeWidth={1.75} />
-            Show sources
+            <Menu className="h-3.5 w-3.5" strokeWidth={1.75} />
+            Show workspace menu
           </Button>
         )}
       </div>

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import type { DockviewApi } from "dockview-react"
 import { ChevronRight, Menu } from "lucide-react"
+import { ControlTooltip } from "../../components/ControlTooltip"
 import { Button, IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import { ArtifactSurfacePane } from "./ArtifactSurfacePane"
@@ -684,17 +685,18 @@ export function SurfaceShell({
         >
           <div>
             {collapsed && (
-              <IconButton
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                onClick={() => setCollapsed(false)}
-                className="pointer-events-auto ml-2"
-                aria-label="Show workspace menu"
-                title="Show workspace menu"
-              >
-                <Menu className="h-4 w-4" strokeWidth={1.75} />
-              </IconButton>
+              <ControlTooltip label="Show workspace menu" side="right">
+                <IconButton
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => setCollapsed(false)}
+                  className="pointer-events-auto ml-2"
+                  aria-label="Show workspace menu"
+                >
+                  <Menu className="h-4 w-4" strokeWidth={1.75} />
+                </IconButton>
+              </ControlTooltip>
             )}
           </div>
           {onClose && <WorkbenchCloseAction onClose={onClose} />}
@@ -752,17 +754,18 @@ function EmptyWorkbenchOverlay({
       {/* Fallback top bar so icons are always visible even with no tabs */}
       <div className="pointer-events-none absolute inset-x-0 top-0 flex items-center gap-0.5 border-b border-[color:oklch(from_var(--border)_l_c_h/0.4)] bg-background px-1" style={{ height: 44 }}>
         {collapsed && (
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            onClick={onExpandFiles}
-            className="pointer-events-auto mx-1"
-            aria-label="Show workspace menu"
-            title="Show workspace menu"
-          >
-            <Menu className="h-4 w-4" strokeWidth={1.75} />
-          </IconButton>
+          <ControlTooltip label="Show workspace menu" side="right">
+            <IconButton
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={onExpandFiles}
+              className="pointer-events-auto mx-1"
+              aria-label="Show workspace menu"
+            >
+              <Menu className="h-4 w-4" strokeWidth={1.75} />
+            </IconButton>
+          </ControlTooltip>
         )}
         <div className="flex-1" />
       </div>

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -205,6 +205,6 @@ describe("SurfaceShell", () => {
     })
 
     expect(screen.queryByLabelText("Workbench left pane")).not.toBeInTheDocument()
-    expect(screen.getAllByRole("button", { name: "Show sources" }).length).toBeGreaterThan(0)
+    expect(screen.getAllByRole("button", { name: "Show workspace menu" }).length).toBeGreaterThan(0)
   })
 })

--- a/packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx
+++ b/packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx
@@ -4,6 +4,7 @@ import { useMemo } from "react"
 import { ChevronLeft, Plus } from "lucide-react"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
+import { ControlTooltip } from "../../components/ControlTooltip"
 import type { SessionItem } from "../../components/SessionList"
 
 export interface SessionBrowserProps {
@@ -124,14 +125,18 @@ export function SessionBrowser({
         </span>
         <div className="flex items-center gap-0.5">
           {onCreate && (
-            <IconButton type="button" variant="ghost" size="icon-xs" onClick={onCreate} aria-label="New session" title="New chat">
-              <Plus className="h-3.5 w-3.5" strokeWidth={1.75} />
-            </IconButton>
+            <ControlTooltip label="New chat" side="bottom">
+              <IconButton type="button" variant="ghost" size="icon-xs" onClick={onCreate} aria-label="New session">
+                <Plus className="h-3.5 w-3.5" strokeWidth={1.75} />
+              </IconButton>
+            </ControlTooltip>
           )}
           {onClose && (
-            <IconButton type="button" variant="ghost" size="icon-xs" onClick={onClose} aria-label="Close sessions" title="Close sessions (⌘1)">
-              <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
-            </IconButton>
+            <ControlTooltip label="Close sessions" hint="⌘1" side="bottom">
+              <IconButton type="button" variant="ghost" size="icon-xs" onClick={onClose} aria-label="Close sessions">
+                <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
+              </IconButton>
+            </ControlTooltip>
           )}
         </div>
       </div>

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -13,7 +13,7 @@ import {
   type ComponentType,
 } from "react"
 import { Menu, Search, X } from "lucide-react"
-import { IconButton, Input } from "@hachej/boring-ui-kit"
+import { IconButton, Input, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import type { WorkspaceBridge } from "../../bridge/types"
 import { useRegistry } from "../../registry"
@@ -142,42 +142,52 @@ export function WorkbenchLeftPane({
   // visually connects to the content pane as one calm grey surface — same
   // background on the icon and the pane, bridged across the rail gutter,
   // with no accent marker or side stripe (see WORKSPACE_LEFT_NAV_UX_SPEC).
+  // Instant tooltips (no OS hover delay) name the icon-only categories.
   const rail = (
-    <nav
-      className="flex w-11 shrink-0 flex-col items-center gap-1 bg-muted/35 px-1.5 py-2"
-      aria-label="Workspace categories"
-    >
-      {onCollapse && (
-        <button
-          type="button"
-          title="Hide workspace menu"
-          aria-label="Hide workspace menu"
-          onClick={onCollapse}
-          className="mb-1 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-        >
-          <Menu className="h-4 w-4" strokeWidth={1.75} />
-        </button>
-      )}
-      {tabs.map((entry) => {
-        const active = entry.id === activeTab
-        return (
-          <button
-            key={entry.id}
-            type="button"
-            title={entry.title}
-            aria-label={entry.title}
-            aria-pressed={active}
-            onClick={() => setTab(entry.id)}
-            className={cn(
-              "relative flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
-              active && "rounded-r-none bg-muted/35 text-foreground shadow-none hover:bg-muted/35 before:absolute before:-right-1.5 before:top-0 before:h-full before:w-1.5 before:bg-muted/35",
-            )}
-          >
-            {entry.icon}
-          </button>
-        )
-      })}
-    </nav>
+    <TooltipProvider delayDuration={0} skipDelayDuration={300}>
+      <nav
+        className="flex w-11 shrink-0 flex-col items-center gap-1 bg-muted/35 px-1.5 py-2"
+        aria-label="Workspace categories"
+      >
+        {onCollapse && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                aria-label="Hide workspace menu"
+                onClick={onCollapse}
+                className="mb-1 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              >
+                <Menu className="h-4 w-4" strokeWidth={1.75} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Hide workspace menu</TooltipContent>
+          </Tooltip>
+        )}
+        {tabs.map((entry) => {
+          const active = entry.id === activeTab
+          return (
+            <Tooltip key={entry.id}>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={entry.title}
+                  aria-pressed={active}
+                  onClick={() => setTab(entry.id)}
+                  className={cn(
+                    "relative flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+                    active && "rounded-r-none bg-muted/35 text-foreground shadow-none hover:bg-muted/35 before:absolute before:-right-1.5 before:top-0 before:h-full before:w-1.5 before:bg-muted/35",
+                  )}
+                >
+                  {entry.icon}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="right">{entry.title}</TooltipContent>
+            </Tooltip>
+          )
+        })}
+      </nav>
+    </TooltipProvider>
   )
 
   return (

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -13,7 +13,8 @@ import {
   type ComponentType,
 } from "react"
 import { Menu, Search, X } from "lucide-react"
-import { IconButton, Input, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@hachej/boring-ui-kit"
+import { IconButton, Input } from "@hachej/boring-ui-kit"
+import { ControlTooltip } from "../../components/ControlTooltip"
 import { cn } from "../../lib/utils"
 import type { WorkspaceBridge } from "../../bridge/types"
 import { useRegistry } from "../../registry"
@@ -144,50 +145,42 @@ export function WorkbenchLeftPane({
   // with no accent marker or side stripe (see WORKSPACE_LEFT_NAV_UX_SPEC).
   // Instant tooltips (no OS hover delay) name the icon-only categories.
   const rail = (
-    <TooltipProvider delayDuration={0} skipDelayDuration={300}>
-      <nav
-        className="flex w-11 shrink-0 flex-col items-center gap-1 bg-muted/35 px-1.5 py-2"
-        aria-label="Workspace categories"
-      >
-        {onCollapse && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                aria-label="Hide workspace menu"
-                onClick={onCollapse}
-                className="mb-1 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-              >
-                <Menu className="h-4 w-4" strokeWidth={1.75} />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="right">Hide workspace menu</TooltipContent>
-          </Tooltip>
-        )}
-        {tabs.map((entry) => {
-          const active = entry.id === activeTab
-          return (
-            <Tooltip key={entry.id}>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  aria-label={entry.title}
-                  aria-pressed={active}
-                  onClick={() => setTab(entry.id)}
-                  className={cn(
-                    "relative flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
-                    active && "rounded-r-none bg-muted/35 text-foreground shadow-none hover:bg-muted/35 before:absolute before:-right-1.5 before:top-0 before:h-full before:w-1.5 before:bg-muted/35",
-                  )}
-                >
-                  {entry.icon}
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="right">{entry.title}</TooltipContent>
-            </Tooltip>
-          )
-        })}
-      </nav>
-    </TooltipProvider>
+    <nav
+      className="flex w-11 shrink-0 flex-col items-center gap-1 bg-muted/35 px-1.5 py-2"
+      aria-label="Workspace categories"
+    >
+      {onCollapse && (
+        <ControlTooltip label="Hide workspace menu" side="right">
+          <button
+            type="button"
+            aria-label="Hide workspace menu"
+            onClick={onCollapse}
+            className="mb-1 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          >
+            <Menu className="h-4 w-4" strokeWidth={1.75} />
+          </button>
+        </ControlTooltip>
+      )}
+      {tabs.map((entry) => {
+        const active = entry.id === activeTab
+        return (
+          <ControlTooltip key={entry.id} label={entry.title} side="right">
+            <button
+              type="button"
+              aria-label={entry.title}
+              aria-pressed={active}
+              onClick={() => setTab(entry.id)}
+              className={cn(
+                "relative flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+                active && "rounded-r-none bg-muted/35 text-foreground shadow-none hover:bg-muted/35 before:absolute before:-right-1.5 before:top-0 before:h-full before:w-1.5 before:bg-muted/35",
+              )}
+            >
+              {entry.icon}
+            </button>
+          </ControlTooltip>
+        )
+      })}
+    </nav>
   )
 
   return (
@@ -201,17 +194,18 @@ export function WorkbenchLeftPane({
             <div className="truncate text-[14px] font-medium tracking-tight text-foreground">{activeEntry?.title ?? "Sources"}</div>
           </div>
           {showChromeSearch && (
-            <IconButton
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              onClick={toggleSearch}
-              className={cn(searchOpen && "bg-foreground/5 text-foreground")}
-              aria-label="Search"
-              title="Search"
-            >
-              <Search className="h-3.5 w-3.5" strokeWidth={1.75} />
-            </IconButton>
+            <ControlTooltip label="Search" side="bottom">
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={toggleSearch}
+                className={cn(searchOpen && "bg-foreground/5 text-foreground")}
+                aria-label="Search"
+              >
+                <Search className="h-3.5 w-3.5" strokeWidth={1.75} />
+              </IconButton>
+            </ControlTooltip>
           )}
         </div>
 

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -12,8 +12,8 @@ import {
   useSyncExternalStore,
   type ComponentType,
 } from "react"
-import { ChevronLeft, PanelLeft, Search, X } from "lucide-react"
-import { IconButton, Input, Tabs, TabsList, TabsTrigger } from "@hachej/boring-ui-kit"
+import { Menu, PanelLeft, Search, X } from "lucide-react"
+import { IconButton, Input } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import type { WorkspaceBridge } from "../../bridge/types"
 import { useRegistry } from "../../registry"
@@ -68,7 +68,7 @@ export function WorkbenchLeftPane({
       next.push({
         id: panel.id,
         title: panel.title,
-        icon: Icon ? <Icon className="h-3.5 w-3.5" /> : <PanelLeft className="h-3.5 w-3.5" />,
+        icon: Icon ? <Icon className="h-4 w-4" /> : <PanelLeft className="h-4 w-4" />,
         panel,
       })
     }
@@ -135,79 +135,102 @@ export function WorkbenchLeftPane({
     [bridge, debouncedQuery, revealFileTreeRequest, rootDir],
   )
 
+  // Workspace categories live on a quiet icon rail. The active category
+  // visually connects to the content pane as one calm grey surface — same
+  // background on the icon and the pane, bridged across the rail gutter,
+  // with no accent marker or side stripe (see WORKSPACE_LEFT_NAV_UX_SPEC).
+  const rail = (
+    <nav
+      className="flex w-11 shrink-0 flex-col items-center gap-1 bg-muted/35 px-1.5 py-2"
+      aria-label="Workspace categories"
+    >
+      {onCollapse && (
+        <button
+          type="button"
+          title="Hide workspace menu"
+          aria-label="Hide workspace menu"
+          onClick={onCollapse}
+          className="mb-1 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+        >
+          <Menu className="h-4 w-4" strokeWidth={1.75} />
+        </button>
+      )}
+      {tabs.map((entry) => {
+        const active = entry.id === activeTab
+        return (
+          <button
+            key={entry.id}
+            type="button"
+            title={entry.title}
+            aria-label={entry.title}
+            aria-pressed={active}
+            onClick={() => setTab(entry.id)}
+            className={cn(
+              "relative flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+              active && "rounded-r-none bg-muted/35 text-foreground shadow-none hover:bg-muted/35 before:absolute before:-right-1.5 before:top-0 before:h-full before:w-1.5 before:bg-muted/35",
+            )}
+          >
+            {entry.icon}
+          </button>
+        )
+      })}
+    </nav>
+  )
+
   return (
-    <div data-boring-workspace-part="workbench-left" className={cn("workbench-left-root flex h-full min-h-0 flex-col", className)}>
-      <div className="flex h-11 items-center gap-1 border-b border-border/60 px-2.5">
-        <Tabs value={activeTab} onValueChange={setTab} className="min-w-0 flex-1 overflow-hidden" aria-label="Workbench sources">
-          <TabsList variant="line" className="h-auto min-w-0 max-w-full gap-0.5 overflow-x-auto p-0 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-            {tabs.map((entry) => (
-              <TabsTrigger
-                key={entry.id}
-                value={entry.id}
-                className="h-8 flex-none gap-1.5 px-2 py-1 text-[12px] data-[state=active]:text-foreground data-[state=active]:after:bg-[color:var(--accent)]"
-              >
-                <span className="data-[state=active]:text-[color:var(--accent)]">{entry.icon}</span>
-                <span className="tracking-tight">{entry.title}</span>
-              </TabsTrigger>
-            ))}
-          </TabsList>
-        </Tabs>
+    <div data-boring-workspace-part="workbench-left" className={cn("workbench-left-root flex h-full min-h-0", className)}>
+      {rail}
 
-        {showChromeSearch && (
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            onClick={toggleSearch}
-            className={cn(searchOpen && "bg-foreground/5 text-foreground")}
-            aria-label="Search"
-            title="Search"
-          >
-            <Search className="h-3.5 w-3.5" strokeWidth={1.75} />
-          </IconButton>
-        )}
-        {onCollapse && (
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            onClick={onCollapse}
-            aria-label="Hide sources"
-            title="Hide sources"
-          >
-            <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
-          </IconButton>
-        )}
-      </div>
-
-      {showChromeSearch && searchOpen && (
-        <div className="flex items-center gap-1 border-b border-border/60 px-2 py-1.5">
-          <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-          <Input
-            ref={searchInputRef}
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={onSearchKeyDown}
-            placeholder={`Search ${(activeEntry?.title ?? "sources").toLowerCase()}...`}
-            className="h-7 flex-1 border-0 bg-transparent px-0 py-0 text-xs shadow-none focus-visible:ring-0 dark:bg-transparent"
-          />
-          {query && (
+      <div className="flex h-full min-w-0 flex-1 flex-col bg-muted/35">
+        <div className="flex h-11 items-center gap-1 border-b border-border/60 bg-muted/35 px-2.5">
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
+            <span className="shrink-0 text-foreground/80">{activeEntry?.icon}</span>
+            <div className="truncate text-[14px] font-medium tracking-tight text-foreground">{activeEntry?.title ?? "Sources"}</div>
+          </div>
+          {showChromeSearch && (
             <IconButton
               type="button"
               variant="ghost"
               size="icon-xs"
-              onClick={() => setQuery("")}
-              aria-label="Clear search"
+              onClick={toggleSearch}
+              className={cn(searchOpen && "bg-foreground/5 text-foreground")}
+              aria-label="Search"
+              title="Search"
             >
-              <X className="h-3 w-3" />
+              <Search className="h-3.5 w-3.5" strokeWidth={1.75} />
             </IconButton>
           )}
         </div>
-      )}
 
-      <div className="min-h-0 flex-1 overflow-hidden">
-        <LeftTabPanelHost panel={activeEntry?.panel} params={leftTabParams} onOpenPanel={onOpenPanel} />
+        {showChromeSearch && searchOpen && (
+          <div className="flex items-center gap-1 border-b border-border/60 px-2 py-1.5">
+            <Search className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <Input
+              ref={searchInputRef}
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={onSearchKeyDown}
+              placeholder={`Search ${(activeEntry?.title ?? "sources").toLowerCase()}...`}
+              className="h-7 flex-1 border-0 bg-transparent px-0 py-0 text-xs shadow-none focus-visible:ring-0 dark:bg-transparent"
+            />
+            {query && (
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => setQuery("")}
+                aria-label="Clear search"
+              >
+                <X className="h-3 w-3" />
+              </IconButton>
+            )}
+          </div>
+        )}
+
+        <div className="min-h-0 flex-1 overflow-hidden">
+          <LeftTabPanelHost panel={activeEntry?.panel} params={leftTabParams} onOpenPanel={onOpenPanel} />
+        </div>
       </div>
     </div>
   )
@@ -248,7 +271,7 @@ function LeftTabPanelHost({ panel, params, onOpenPanel }: { panel?: PanelConfig;
   if (!panel || !Inner) {
     return (
       <div className="flex h-full items-center justify-center px-4 text-center text-[12px] text-muted-foreground">
-        No workbench source registered.
+        No workspace category registered.
       </div>
     )
   }
@@ -261,7 +284,7 @@ function LeftTabPanelHost({ panel, params, onOpenPanel }: { panel?: PanelConfig;
       <Suspense
         fallback={
           <div className="flex h-full items-center justify-center px-4 text-center text-[12px] text-muted-foreground">
-            Loading source...
+            Loading workspace category...
           </div>
         }
       >

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -12,7 +12,7 @@ import {
   useSyncExternalStore,
   type ComponentType,
 } from "react"
-import { Menu, PanelLeft, Search, X } from "lucide-react"
+import { Menu, Search, X } from "lucide-react"
 import { IconButton, Input } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import type { WorkspaceBridge } from "../../bridge/types"
@@ -68,7 +68,10 @@ export function WorkbenchLeftPane({
       next.push({
         id: panel.id,
         title: panel.title,
-        icon: Icon ? <Icon className="h-4 w-4" /> : <PanelLeft className="h-4 w-4" />,
+        // Icon-less plugins get an initial-letter glyph instead of a shared
+        // generic icon — on an icon-only rail, two identical fallback icons
+        // would be indistinguishable.
+        icon: Icon ? <Icon className="h-4 w-4" /> : <CategoryInitial title={panel.title} />,
         panel,
       })
     }
@@ -233,6 +236,19 @@ export function WorkbenchLeftPane({
         </div>
       </div>
     </div>
+  )
+}
+
+function CategoryInitial({ title }: { title: string }) {
+  const letter = (title.trim()[0] ?? "?").toUpperCase()
+  return (
+    <span
+      aria-hidden="true"
+      data-boring-workspace-part="category-initial"
+      className="flex h-4 w-4 items-center justify-center rounded-[5px] bg-foreground/10 text-[10px] font-semibold leading-none text-foreground/70"
+    >
+      {letter}
+    </span>
   )
 }
 

--- a/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
@@ -94,4 +94,35 @@ describe("WorkbenchLeftPane", () => {
     fireEvent.click(screen.getByRole("button", { name: "Hide workspace menu" }))
     expect(onCollapse).toHaveBeenCalled()
   })
+
+  test("icon-less categories fall back to an initial-letter glyph", () => {
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("files", {
+      title: "Files",
+      placement: "left-tab",
+      component: () => <div>files body</div>,
+    })
+    panelRegistry.register("data", {
+      title: "Data",
+      placement: "left-tab",
+      component: () => <div>data body</div>,
+    })
+
+    render(
+      <RegistryProvider
+        panelRegistry={panelRegistry}
+        commandRegistry={new CommandRegistry()}
+        surfaceResolverRegistry={new SurfaceResolverRegistry()}
+      >
+        <WorkbenchLeftPane defaultTab="files" />
+      </RegistryProvider>,
+    )
+
+    // Neither panel registers an icon: each rail button shows its own
+    // initial instead of a shared generic glyph.
+    const filesButton = screen.getByRole("button", { name: "Files" })
+    const dataButton = screen.getByRole("button", { name: "Data" })
+    expect(filesButton.querySelector('[data-boring-workspace-part="category-initial"]')?.textContent).toBe("F")
+    expect(dataButton.querySelector('[data-boring-workspace-part="category-initial"]')?.textContent).toBe("D")
+  })
 })

--- a/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
@@ -53,4 +53,45 @@ describe("WorkbenchLeftPane", () => {
       params: { from: "left-tab" },
     })
   })
+
+  test("categories render as a rail with a calm active state and menu collapse", () => {
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("files", {
+      title: "Files",
+      placement: "left-tab",
+      component: () => <div>files body</div>,
+    })
+    panelRegistry.register("data", {
+      title: "Data",
+      placement: "left-tab",
+      component: () => <div>data body</div>,
+    })
+    const onCollapse = vi.fn()
+
+    render(
+      <RegistryProvider
+        panelRegistry={panelRegistry}
+        commandRegistry={new CommandRegistry()}
+        surfaceResolverRegistry={new SurfaceResolverRegistry()}
+      >
+        <WorkbenchLeftPane defaultTab="files" onCollapse={onCollapse} />
+      </RegistryProvider>,
+    )
+
+    const rail = screen.getByRole("navigation", { name: "Workspace categories" })
+    expect(rail).toBeInTheDocument()
+    const filesButton = screen.getByRole("button", { name: "Files" })
+    const dataButton = screen.getByRole("button", { name: "Data" })
+    expect(filesButton).toHaveAttribute("aria-pressed", "true")
+    expect(dataButton).toHaveAttribute("aria-pressed", "false")
+    // No accent stripe: the active state is the shared grey surface.
+    expect(filesButton.className).not.toContain("accent")
+
+    fireEvent.click(dataButton)
+    expect(dataButton).toHaveAttribute("aria-pressed", "true")
+    expect(screen.getByText("data body")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Hide workspace menu" }))
+    expect(onCollapse).toHaveBeenCalled()
+  })
 })

--- a/packages/workspace/src/front/components/ControlTooltip.tsx
+++ b/packages/workspace/src/front/components/ControlTooltip.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import type { ReactElement, ReactNode } from "react"
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@hachej/boring-ui-kit"
+
+/**
+ * Instant tooltip for icon-only chrome controls — no OS hover delay, with
+ * an optional keyboard hint rendered after the label. Wrap the control and
+ * drop its native `title` (the two together double up).
+ */
+export function ControlTooltip({
+  label,
+  hint,
+  side = "top",
+  children,
+}: {
+  label: ReactNode
+  hint?: string
+  side?: "top" | "bottom" | "left" | "right"
+  children: ReactElement
+}) {
+  return (
+    <TooltipProvider delayDuration={0} skipDelayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side}>
+          {label}
+          {hint ? <span className="ml-1.5 opacity-60">{hint}</span> : null}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -2,6 +2,7 @@ import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExt
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
 import { ChevronLeft, MessageSquare } from "lucide-react"
 import { cn } from "../lib/utils"
+import { ControlTooltip } from "../components/ControlTooltip"
 import { dispatchUiCommand, type DispatchContext } from "../bridge"
 import { events, useEvent, workspaceEvents } from "../events"
 import { useKeyboardShortcuts, type ShortcutBinding } from "../hooks/useKeyboardShortcuts"
@@ -375,17 +376,18 @@ export function ChatLayout(props: ChatLayoutProps) {
             <PanelSlot id={centerId} params={props.centerParams} />
           </div>
           {!chatCollapsed ? (
-            <IconButton
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              onClick={toggleChatCollapsed}
-              className="absolute right-2 top-2 z-20"
-              aria-label="Collapse chat"
-              title="Collapse chat (⌘\\)"
-            >
-              <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
-            </IconButton>
+            <ControlTooltip label="Collapse chat" hint="⌘\\" side="bottom">
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={toggleChatCollapsed}
+                className="absolute right-2 top-2 z-20"
+                aria-label="Collapse chat"
+              >
+                <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
+              </IconButton>
+            </ControlTooltip>
           ) : null}
         </main>
 
@@ -429,17 +431,18 @@ export function ChatLayout(props: ChatLayoutProps) {
                 <div className="relative h-full min-h-0">
                   {props.surfaceOverlay}
                   {closeSurface ? (
-                    <IconButton
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={closeSurface}
-                      className="absolute right-3 top-3 z-20 rounded-full bg-background/80 text-muted-foreground shadow-sm backdrop-blur hover:bg-muted hover:text-foreground"
-                      aria-label="Close workbench"
-                      title="Close workbench (⌘2)"
-                    >
-                      <span aria-hidden="true">›</span>
-                    </IconButton>
+                    <ControlTooltip label="Close workbench" hint="⌘2" side="left">
+                      <IconButton
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={closeSurface}
+                        className="absolute right-3 top-3 z-20 rounded-full bg-background/80 text-muted-foreground shadow-sm backdrop-blur hover:bg-muted hover:text-foreground"
+                        aria-label="Close workbench"
+                      >
+                        <span aria-hidden="true">›</span>
+                      </IconButton>
+                    </ControlTooltip>
                   ) : null}
                 </div>
               ) : <PanelSlot id={surfaceId} params={props.surfaceParams} />}
@@ -719,13 +722,13 @@ function FloatingEdgeButton({
   // Buttons are h-9 (36px); stack them with a 8px gap so they never overlap.
   const stackOffset = stackIndex * 44
   return (
+    <ControlTooltip label={label} hint={hint} side={side === "left" ? "right" : "left"}>
     <IconButton
       type="button"
       variant="ghost"
       size="icon-sm"
       onClick={onClick}
       aria-label={label}
-      title={hint ? `${label} (${hint})` : label}
       className={cn(
         "absolute z-30 h-9 w-9 gap-0.5 rounded-lg bg-background text-muted-foreground",
         side === "left" ? "left-2" : "right-2",
@@ -758,5 +761,6 @@ function FloatingEdgeButton({
         </svg>
       )}
     </IconButton>
+    </ControlTooltip>
   )
 }


### PR DESCRIPTION
## Summary
- Implements `WORKSPACE_LEFT_NAV_UX_SPEC.md` (#247), ported from the leftbar POC:
  - Workspace categories (built-in Files + plugin `left-tab` outputs) render as a **quiet icon rail** instead of a text tab strip.
  - **Calm grey active state**: the active icon's background and the content pane share one surface, bridged across the rail gutter — no accent stripe, no seam. The pane header repeats the active icon in neutral foreground.
  - **Collapse = absent**: collapsing removes rail + pane entirely; reopen via the stable ☰ "Show workspace menu" control at the top-left of the workbench surface. Same menu icon both ways.

## Proof of work
- `pnpm --filter @hachej/boring-workspace run test` — 1398 passed
- typecheck green
- Verified live in workspace-playground: rail renders Files/Data categories with `aria-pressed`, switching works, collapse hides rail completely, reopen restores it (screenshots in session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)