### PR TITLE
fix(workspace,agent): chat/workspace QA — open-path 403, tree live-refresh, dedup question prompt

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -377,12 +377,10 @@ export function PiChatPanel({
     const sessionNotice = sessionsError
       ? [{ id: 'session-navigation-error', level: 'error' as const, text: sessionsError.message, dismissible: true }]
       : []
-    const blockerNotices = activeBlockers.map((blocker) => ({
-      id: `composer-blocker:${blocker.id}`,
-      level: 'warning' as const,
-      text: blocker.label ?? blocker.reason ?? 'Workspace is not ready for a new message.',
-      dismissible: false,
-    }))
+    // Composer blockers already render as an actionable bar right above the
+    // input (ComposerBlockerNotice, with Open/Cancel buttons), so surfacing
+    // them again as a timeline warning notice just duplicates the same line.
+    // Keep the single actionable bar; don't echo it here.
     const largeStateNotice = debug && debugState?.largeStateWarning
       ? [{
           id: 'large-state-warning',
@@ -391,8 +389,8 @@ export function PiChatPanel({
           dismissible: true,
         }]
       : []
-    return [...fromState, ...sessionNotice, ...blockerNotices, ...largeStateNotice, ...localNotices].filter((notice) => !dismissedNoticeIds.has(notice.id))
-  }, [activeBlockers, debug, debugState?.largeStateWarning, dismissedNoticeIds, localNotices, selectedChatState, sessionsError])
+    return [...fromState, ...sessionNotice, ...largeStateNotice, ...localNotices].filter((notice) => !dismissedNoticeIds.has(notice.id))
+  }, [debug, debugState?.largeStateWarning, dismissedNoticeIds, localNotices, selectedChatState, sessionsError])
 
   const addLocalNotice = useCallback((notice: PanelNotice) => {
     setLocalNotices((previous) => {

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -1290,8 +1290,10 @@ describe('PiChatPanel sandbox shell', () => {
     )
 
     const textarea = await screen.findByLabelText('Agent prompt')
-    expect(textarea.getAttribute('placeholder')).toBe('Select a file before chatting')
-    expect(screen.getAllByText('Select a file before chatting').length).toBeGreaterThan(0)
+    // The blocker text is shown once, in the actionable blocker bar — not also
+    // echoed into the input placeholder (which would duplicate the same line).
+    expect(textarea.getAttribute('placeholder')).toBe('')
+    expect(screen.getAllByText('Select a file before chatting').length).toBe(1)
   })
 
   test('/reset does not race empty-session auto-create into duplicate session creation', async () => {

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -328,7 +328,14 @@ export function PiChatComposerSurface({
             </div>
             <PromptInputTextarea
               value={draft}
-              placeholder={composerBlocked ? composerBlockerLabel : composerPlaceholder ?? 'Ask anything…'}
+              placeholder={
+                composerBlocked
+                  // Warmup has no action bar, so the label belongs in the
+                  // placeholder. A real blocker already shows the label in the
+                  // ComposerBlockerNotice bar above — don't repeat it here.
+                  ? (workspaceWarmupBlocked ? composerBlockerLabel : '')
+                  : composerPlaceholder ?? 'Ask anything…'
+              }
               disabled={disabled}
               readOnly={composerBlocked}
               aria-label="Agent prompt"

--- a/packages/workspace/src/app/front/__tests__/workspacePreload.test.ts
+++ b/packages/workspace/src/app/front/__tests__/workspacePreload.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+import { relativizeWorkspacePath } from "../workspacePreload"
+
+describe("relativizeWorkspacePath", () => {
+  const root = "/home/ubuntu/projects/app/.worktrees/main-cli"
+
+  it("strips the workspace root from an in-root absolute path", () => {
+    expect(relativizeWorkspacePath(`${root}/secret-remember.md`, root)).toBe("secret-remember.md")
+    expect(relativizeWorkspacePath(`${root}/src/front/App.tsx`, root)).toBe("src/front/App.tsx")
+  })
+
+  it("maps the workspace root itself to '.'", () => {
+    expect(relativizeWorkspacePath(root, root)).toBe(".")
+    expect(relativizeWorkspacePath(`${root}/`, root)).toBe(".")
+  })
+
+  it("leaves already-relative paths untouched", () => {
+    expect(relativizeWorkspacePath("src/front/App.tsx", root)).toBe("src/front/App.tsx")
+    expect(relativizeWorkspacePath("./README.md", root)).toBe("./README.md")
+  })
+
+  it("leaves absolute paths outside the root untouched (they legitimately 403)", () => {
+    expect(relativizeWorkspacePath("/etc/passwd", root)).toBe("/etc/passwd")
+    // A sibling worktree must not be mistaken for an in-root child via prefix.
+    expect(relativizeWorkspacePath("/home/ubuntu/projects/app/.worktrees/main-cli-other/x.ts", root))
+      .toBe("/home/ubuntu/projects/app/.worktrees/main-cli-other/x.ts")
+  })
+
+  it("tolerates a trailing slash on the root", () => {
+    expect(relativizeWorkspacePath(`${root}/a.ts`, `${root}/`)).toBe("a.ts")
+  })
+
+  it("returns the input when root is missing", () => {
+    expect(relativizeWorkspacePath(`${root}/a.ts`, null)).toBe(`${root}/a.ts`)
+    expect(relativizeWorkspacePath(`${root}/a.ts`, undefined)).toBe(`${root}/a.ts`)
+  })
+})

--- a/packages/workspace/src/app/front/workspacePreload.ts
+++ b/packages/workspace/src/app/front/workspacePreload.ts
@@ -19,6 +19,27 @@ export type WorkspaceWarmupStatus =
   | { status: "ready"; runtimeDependencies?: WorkspaceRuntimeDependenciesWarmupStatus }
   | { status: "failed"; message: string; requirement?: "workspace-fs" | "sandbox-exec" | "ui-bridge"; runtimeDependencies?: WorkspaceRuntimeDependenciesWarmupStatus }
 
+/**
+ * Convert an absolute filesystem path into a workspace-relative one when it
+ * lives inside `workspaceRoot`. The workspace HTTP file API (`/api/v1/files`,
+ * tree, etc.) is relative-only and rejects absolute paths with a 403 — but the
+ * agent's tool inputs (read/write/edit) surface absolute paths. Clicking such
+ * a path to open it in the workbench therefore needs this translation.
+ *
+ * Already-relative paths and absolute paths that fall outside the root are
+ * returned unchanged (the latter will legitimately 403). The workspace root
+ * itself maps to ".".
+ */
+export function relativizeWorkspacePath(path: string, workspaceRoot: string | null | undefined): string {
+  if (!path || !workspaceRoot) return path
+  const p = path.replace(/\\/g, "/").replace(/\/+$/, "")
+  const root = workspaceRoot.replace(/\\/g, "/").replace(/\/+$/, "")
+  if (!p.startsWith("/")) return path
+  if (p === root) return "."
+  if (p.startsWith(`${root}/`)) return p.slice(root.length + 1)
+  return path
+}
+
 export function preloadUrl(apiBaseUrl: string | null | undefined, path: string): string {
   if (/^https?:\/\//i.test(path)) return path
   if (!apiBaseUrl) return path

--- a/packages/workspace/src/front/chrome/chat/ChatPanelHost.tsx
+++ b/packages/workspace/src/front/chrome/chat/ChatPanelHost.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useCallback, useEffect } from "react"
+import { useCallback, useEffect, useRef } from "react"
 import { useWorkspaceAttention, useWorkspaceChatPanel } from "../../provider"
 import { emitAgentData } from "../../events"
 import { dispatchUiCommand, startUiCommandStream } from "../../bridge"
+import { relativizeWorkspacePath } from "../../../app/front/workspacePreload"
 import type { SurfaceShellApi } from "../artifact-surface/SurfaceShell"
 import type { WorkspaceChatPanelProps } from "./types"
 
@@ -60,15 +61,35 @@ export function ChatPanelHost(props: ChatPanelHostProps) {
     ...chatPanelProps
   } = props
 
+  // Agent tool inputs (read/write/edit) carry absolute filesystem paths, but
+  // the workspace file API is relative-only (absolute paths 403). Learn the
+  // workspace root once so click-to-open can translate absolute → relative.
+  const workspaceRootRef = useRef<string | null>(null)
+  const apiBase = streamEndpointFromBridgeEndpoint(bridgeEndpoint) ?? ""
+  const metaWorkspaceId = workspaceIdFromHeaders(chatPanelProps.requestHeaders)
+  useEffect(() => {
+    let cancelled = false
+    const headers: Record<string, string> = metaWorkspaceId ? { "x-boring-workspace-id": metaWorkspaceId } : {}
+    void fetch(`${apiBase}/api/v1/workspace/meta`, { headers })
+      .then((res) => (res.ok ? res.json() as Promise<{ workspaceRoot?: unknown }> : null))
+      .then((meta) => {
+        if (cancelled) return
+        if (meta && typeof meta.workspaceRoot === "string") workspaceRootRef.current = meta.workspaceRoot
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [apiBase, metaWorkspaceId])
+
   const openArtifact = useCallback(
     (path: string) => {
+      const resolved = relativizeWorkspacePath(path, workspaceRootRef.current)
       if (getSurface && isWorkbenchOpen && openWorkbench) {
         dispatchUiCommand(
-          { kind: "openFile", params: { path } },
+          { kind: "openFile", params: { path: resolved } },
           { surface: getSurface, isWorkbenchOpen, openWorkbench, openWorkbenchSources, closeWorkbench },
         )
       }
-      props.onOpenArtifact?.(path)
+      props.onOpenArtifact?.(resolved)
     },
     [getSurface, isWorkbenchOpen, openWorkbench, openWorkbenchSources, closeWorkbench, props.onOpenArtifact],
   )

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -339,6 +339,42 @@ export function FileTreeView({
     [dataClient, rootDir, ignoreNames],
   )
 
+  // Expanded subfolders cache their children in local state (not react-query),
+  // so `useFileList`'s invalidation only refreshes the root level. Mirror the
+  // expanded dir set into a ref and re-fetch the affected dir when an
+  // agent/remote change lands inside it — otherwise a file the agent writes
+  // into an open folder stays hidden until the user collapses + re-expands it.
+  // `user`-caused changes already refresh locally at their call sites.
+  const expandedDirsRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    expandedDirsRef.current = new Set(expandedChildren.keys())
+  }, [expandedChildren])
+
+  useEffect(() => {
+    const affected = (paths: string[]): string[] =>
+      Array.from(new Set(paths.map(parentDir))).filter((dir) => expandedDirsRef.current.has(dir))
+    const offCreated = events.on(filesystemEvents.created, (e) => {
+      if (e.cause === "user") return
+      const dirs = affected([e.path])
+      if (dirs.length) void refreshDirs(dirs)
+    })
+    const offDeleted = events.on(filesystemEvents.deleted, (e) => {
+      if (e.cause === "user") return
+      const dirs = affected([e.path])
+      if (dirs.length) void refreshDirs(dirs)
+    })
+    const offMoved = events.on(filesystemEvents.moved, (e) => {
+      if (e.cause === "user") return
+      const dirs = affected([e.from, e.to])
+      if (dirs.length) void refreshDirs(dirs)
+    })
+    return () => {
+      offCreated()
+      offDeleted()
+      offMoved()
+    }
+  }, [refreshDirs])
+
   const revealTreePath = useCallback(
     async (path: string | null, options?: { refreshTargetDir?: boolean }) => {
       if (!path) return

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -151,6 +151,8 @@ vi.mock("../FileTree", () => {
 })
 
 import { FileTreePane, clampContextMenuPosition } from "../FileTreeView"
+import { events, remoteMeta, userMeta } from "../../../../../front/events"
+import { filesystemEvents } from "../../../shared/events"
 
 const sampleFiles = [
   { name: "src", kind: "dir" as const, path: "src" },
@@ -401,6 +403,45 @@ describe("FileTreePane", () => {
       expect(screen.getByTestId("file-tree")).toHaveAttribute("data-reveal", "src")
     })
     expect(bridge.openFile).not.toHaveBeenCalled()
+  })
+
+  it("refreshes an expanded folder when an agent/remote change lands inside it", async () => {
+    mockGetTree.mockResolvedValue([{ name: "old.ts", kind: "file", path: "src/old.ts" }])
+    let expandHandler: ((payload: { path: string }) => void) | null = null
+    const bridge = {
+      getActiveFile: () => null,
+      openFile: vi.fn().mockResolvedValue({ seq: 1, status: "ok" }),
+      subscribe: vi.fn((event, handler) => {
+        if (event === "tree:expand") expandHandler = handler
+        return vi.fn()
+      }),
+    }
+
+    render(<FileTreePane bridge={bridge as any} />, { wrapper })
+    await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+    await waitFor(() => expect(bridge.subscribe).toHaveBeenCalled())
+
+    // Expand "src" so its children live in local state (not react-query).
+    // Wait for the child to actually render — that guarantees expandedChildren
+    // committed (getTree is called synchronously, before its promise resolves).
+    act(() => expandHandler?.({ path: "src" }))
+    await screen.findByText("old.ts")
+    mockGetTree.mockClear()
+
+    // A remote (agent/SSE) create inside the expanded dir must re-fetch it…
+    act(() => {
+      events.emit(filesystemEvents.created, { ...remoteMeta(), path: "src/new.ts", kind: "file" })
+    })
+    await waitFor(() => expect(mockGetTree).toHaveBeenCalledWith("src"))
+
+    // …but a create in a non-expanded dir, or a user-caused one, must not.
+    mockGetTree.mockClear()
+    act(() => {
+      events.emit(filesystemEvents.created, { ...remoteMeta(), path: "other/x.ts", kind: "file" })
+      events.emit(filesystemEvents.created, { ...userMeta(), path: "src/typed.ts", kind: "file" })
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(mockGetTree).not.toHaveBeenCalled()
   })
 
   it("reveals folder requests forwarded through left-tab params", async () => {


### PR DESCRIPTION
Three small UX fixes found during release QA of the pi-native chat workbench. Each is independently small; bundled because they're all chat/workspace QA polish with focused tests.

## 1. Click-to-open file path → 403
Agent tool inputs (read/write/edit) carry **absolute** filesystem paths, but the workspace file API (`/api/v1/files`) is relative-only and rejects absolute paths with 403 — a deliberate boundary shared with the agent tools, left strict. Clicking the path in a tool card therefore failed.

`ChatPanelHost` (the agent↔workspace bridge) now learns the workspace root from `/api/v1/workspace/meta` and relativizes the path (new pure `relativizeWorkspacePath`) before dispatching `openFile`. In-root absolutes → relative; already-relative and out-of-root paths untouched (the latter still legitimately 403).

## 2. Expanded folder didn't show new agent-created files
The tree loads **root** children via react-query (invalidated by the fs-event SSE), but **expanded subfolders cache their children in local component state**, which invalidation can't reach. So a file the agent wrote into an *open* folder stayed hidden until the user collapsed + re-expanded it (root-level files worked, masking it).

`FileTreeView` now subscribes to filesystem `created`/`deleted`/`moved` events and re-fetches just the affected expanded directory — only for `remote`/`agent` causes (local user edits already refresh at their call site) and only when that dir is open (bounded, no wasted fetches).

## 3. Asked question shown three times
`PiChatPanel` surfaced a composer blocker as (a) a top timeline warning banner, (b) the actionable composer bar with `Open`/`Cancel` buttons, and (c) the input placeholder — three copies of the same line. Keep only the actionable bar: dropped the blocker→notice mapping, and the placeholder no longer echoes the blocker label (blank while the bar is shown). Warmup is unaffected (no bar → its placeholder/notice still reads "Preparing workspace…").

## Tests
- New `relativizeWorkspacePath` unit suite (6 cases: in-root, root→".", already-relative, out-of-root sibling, trailing slash, missing root).
- New `FileTreePane` test: a remote change inside an expanded dir refreshes it; non-expanded dirs and user-caused events don't.
- Updated `PiChatPanel` blocker-reason test: prompt renders **once** (in the bar) with an empty placeholder.
- Workspace + agent `tsc` clean; affected suites green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)