### PR TITLE
feat(workspace): add browser-native HTML screenshot copy

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
@@ -1,9 +1,10 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { ErrorState, IconButton, Spinner } from "@hachej/boring-ui-kit"
-import { ExternalLink, RefreshCcw } from "lucide-react"
+import { Camera, ExternalLink, RefreshCcw } from "lucide-react"
 import { cn } from "../../../../front/lib/utils"
+import { toast } from "../../../../front/toast"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
 
 export interface HtmlViewerProps {
@@ -116,6 +117,39 @@ async function fetchText(url: string, headers: Record<string, string>, signal: A
   return res.text()
 }
 
+async function screenshotViaDisplayMedia(rect: DOMRect): Promise<Blob> {
+  if (!navigator.mediaDevices?.getDisplayMedia) {
+    throw new Error("Screen capture is not supported in this browser")
+  }
+
+  const stream = await navigator.mediaDevices.getDisplayMedia({
+    video: { displaySurface: "browser" },
+    audio: false,
+    preferCurrentTab: true,
+  } as DisplayMediaStreamOptions & { preferCurrentTab?: boolean })
+
+  try {
+    const track = stream.getVideoTracks()[0]
+    if (!track) throw new Error("No screen capture track returned")
+
+    const imageCapture = new ImageCapture(track) as ImageCapture & { grabFrame(): Promise<ImageBitmap> }
+    const bitmap = await imageCapture.grabFrame()
+    const scaleX = bitmap.width / window.innerWidth
+    const scaleY = bitmap.height / window.innerHeight
+    const sx = Math.round(rect.left * scaleX)
+    const sy = Math.round(rect.top * scaleY)
+    const sw = Math.max(1, Math.round(rect.width * scaleX))
+    const sh = Math.max(1, Math.round(rect.height * scaleY))
+    const canvas = new OffscreenCanvas(sw, sh)
+    const ctx = canvas.getContext("2d")
+    if (!ctx) throw new Error("Could not create screenshot canvas")
+    ctx.drawImage(bitmap, sx, sy, sw, sh, 0, 0, sw, sh)
+    return await canvas.convertToBlob({ type: "image/png" })
+  } finally {
+    for (const track of stream.getTracks()) track.stop()
+  }
+}
+
 export async function prepareHtmlPreviewDocument(options: {
   html: string
   path: string
@@ -187,6 +221,7 @@ export async function prepareHtmlPreviewDocument(options: {
 export function HtmlViewer({ path, className }: HtmlViewerProps) {
   const apiBaseUrl = useApiBaseUrl()
   const workspaceRequestId = useWorkspaceRequestId()
+  const containerRef = useRef<HTMLDivElement>(null)
   const [html, setHtml] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
@@ -200,6 +235,38 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
   const refresh = useCallback(() => {
     setReloadKey((current) => current + 1)
   }, [])
+
+  const handleScreenshot = useCallback(async () => {
+    const rect = containerRef.current?.getBoundingClientRect()
+    if (!rect) {
+      toast.error({ title: "Screenshot failed", description: "Preview element not found" })
+      return
+    }
+
+    let blob: Blob
+    try {
+      blob = await screenshotViaDisplayMedia(rect)
+    } catch (error) {
+      toast.error({
+        title: "Screenshot failed",
+        description: error instanceof Error ? error.message : "Screen capture failed",
+      })
+      return
+    }
+
+    try {
+      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })])
+      toast.success({ title: "Screenshot copied to clipboard" })
+    } catch {
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${filename(path).replace(/\.[^.]+$/, "")}-screenshot.png`
+      a.click()
+      URL.revokeObjectURL(url)
+      toast.success({ title: "Screenshot downloaded" })
+    }
+  }, [path])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -258,9 +325,20 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
   }
 
   return (
-    <div className={cn("flex h-full min-h-0 flex-col bg-background", className)}>
+    <div ref={containerRef} className={cn("flex h-full min-h-0 flex-col bg-background", className)}>
       <div className="flex shrink-0 items-center justify-end gap-3 border-b border-border/60 px-3 py-2">
         <div className="flex items-center gap-1">
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="text-muted-foreground hover:text-foreground"
+            onClick={handleScreenshot}
+            aria-label="Copy screenshot"
+            title="Copy screenshot"
+          >
+            <Camera className="h-3.5 w-3.5" strokeWidth={1.75} />
+          </IconButton>
           <IconButton
             type="button"
             variant="ghost"

--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
@@ -1,10 +1,11 @@
 "use client"
 
 import { useEffect, useMemo, useState } from "react"
-import { Download, RefreshCw } from "lucide-react"
+import { Camera, Download, RefreshCw } from "lucide-react"
 import { ErrorState, Spinner } from "@hachej/boring-ui-kit"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
 import { cn } from "../../../../front/lib/utils"
+import { toast } from "../../../../front/toast"
 
 export interface MediaViewerProps {
   path: string
@@ -23,6 +24,24 @@ function filename(path: string): string {
   return path.split("/").pop() ?? path
 }
 
+async function imageUrlToPngBlob(url: string): Promise<Blob> {
+  const image = new Image()
+  image.decoding = "async"
+  image.src = url
+  await image.decode()
+
+  const canvas = document.createElement("canvas")
+  canvas.width = image.naturalWidth
+  canvas.height = image.naturalHeight
+  const ctx = canvas.getContext("2d")
+  if (!ctx) throw new Error("Could not create screenshot canvas")
+  ctx.drawImage(image, 0, 0)
+
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/png"))
+  if (!blob) throw new Error("Could not render image screenshot")
+  return blob
+}
+
 export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: MediaViewerProps) {
   const apiBaseUrl = useApiBaseUrl()
   const workspaceRequestId = useWorkspaceRequestId()
@@ -35,6 +54,34 @@ export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: 
     if (reloadKey > 0) query.set("reload", String(reloadKey))
     return apiUrl(apiBaseUrl, `/api/v1/files/raw?${query.toString()}`)
   }, [apiBaseUrl, path, reloadKey])
+
+  async function handleScreenshot() {
+    if (!objectUrl) return
+
+    let blob: Blob
+    try {
+      blob = await imageUrlToPngBlob(objectUrl)
+    } catch (error) {
+      toast.error({
+        title: "Screenshot failed",
+        description: error instanceof Error ? error.message : "Image screenshot failed",
+      })
+      return
+    }
+
+    try {
+      await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })])
+      toast.success({ title: "Screenshot copied to clipboard" })
+    } catch {
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${filename(path).replace(/\.[^.]+$/, "")}-screenshot.png`
+      a.click()
+      URL.revokeObjectURL(url)
+      toast.success({ title: "Screenshot downloaded" })
+    }
+  }
 
   useEffect(() => {
     const controller = new AbortController()
@@ -96,6 +143,17 @@ export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: 
           >
             <RefreshCw className="size-3.5" />
           </button>
+          {kind === "image" && objectUrl ? (
+            <button
+              type="button"
+              onClick={handleScreenshot}
+              className="inline-flex size-7 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label={`Copy screenshot of ${filename(path)}`}
+              title="Copy screenshot"
+            >
+              <Camera className="size-3.5" />
+            </button>
+          ) : null}
           {objectUrl ? (
             <a
               href={objectUrl}


### PR DESCRIPTION
## Summary
- add a camera action to the HTML viewer toolbar
- use browser-native screen capture to crop the preview pane and copy PNG to clipboard
- fall back to downloading the PNG when clipboard writes are unavailable

## Validation
- pnpm --filter @hachej/boring-workspace run typecheck
- pnpm --filter @hachej/boring-ui-kit run build
- pnpm --filter @hachej/boring-workspace run test src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.test.ts

## Notes
- no Playwright dependency
- no agent/server browser tool included in this PR
