### PR TITLE
feat(workspace): chat session panes UX (multi-pane stage, session browser, pins)

### DIFF
--- a/packages/agent/src/front/ChatEmptyState.tsx
+++ b/packages/agent/src/front/ChatEmptyState.tsx
@@ -109,6 +109,8 @@ export function ChatEmptyState({
         ["--chat-empty-accent" as string]: "var(--accent)",
       }}
       className={cn(
+        // @container lets the hero scale to the pane it lives in, not the
+        // viewport — split chat panes get the compact variant.
         "@container mx-auto flex w-full max-w-[640px] flex-col px-2 pt-12 pb-4",
         className,
       )}
@@ -120,19 +122,19 @@ export function ChatEmptyState({
         </div>
       )}
       {title && (
-        <h3 className="mt-3 text-[34px] font-medium leading-[1.05] tracking-[-0.02em] text-[color:var(--chat-empty-title-color)]">
+        <h3 className="mt-3 text-[24px] font-medium leading-[1.05] tracking-[-0.02em] text-[color:var(--chat-empty-title-color)] @[480px]:text-[34px]">
           {title}
         </h3>
       )}
       {description && (
-        <p className="mt-3 max-w-[440px] text-[14px] leading-relaxed text-[color:var(--chat-empty-description-color)]">
+        <p className="mt-3 hidden max-w-[440px] text-[14px] leading-relaxed text-[color:var(--chat-empty-description-color)] @[420px]:block">
           {description}
         </p>
       )}
       {suggestions.length > 0 && (
         <div
           data-boring-agent-part="suggestion-grid"
-          className="mt-8 grid w-full grid-cols-1 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70 @[32rem]:grid-cols-2"
+          className="mt-8 grid w-full grid-cols-1 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70 @[480px]:grid-cols-2"
         >
           {suggestions.map((suggestion) => {
             const Icon = suggestion.icon

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -813,6 +813,24 @@ export function PiChatPanel({
     setThinkingPickerOpen(false)
   }, [isStreaming])
 
+  // Broadcast per-session busy state so shell chrome (e.g. the session
+  // browser) can show a "working" indicator without coupling to this panel.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !activeChatSessionId) return
+    window.dispatchEvent(new CustomEvent('boring:chat-session-status', {
+      detail: { sessionId: activeChatSessionId, working: isStreaming },
+    }))
+    if (!isStreaming) return
+    const sessionId = activeChatSessionId
+    return () => {
+      // Pane unmounted (or session switched) mid-stream: clear the signal
+      // rather than leaving a stale "working" badge behind.
+      window.dispatchEvent(new CustomEvent('boring:chat-session-status', {
+        detail: { sessionId, working: false },
+      }))
+    }
+  }, [activeChatSessionId, isStreaming])
+
   const onTextareaKeyDown = useCallback((event: ReactKeyboardEvent<HTMLTextAreaElement>) => {
     if (event.key === 'Escape' && isStreaming) {
       if (event.defaultPrevented || mentionState !== null || slashQuery !== null) {

--- a/packages/workspace/scripts/build-workspace-css.mjs
+++ b/packages/workspace/scripts/build-workspace-css.mjs
@@ -9,11 +9,13 @@ const require = createRequire(import.meta.url)
 const globalsInput = resolve("src/globals.css")
 const dockviewCssPath = require.resolve("dockview-react/dist/styles/dockview.css")
 const dockviewOverridesPath = resolve("src/front/dock/dockview-overrides.css")
+const chatPaneStagePath = resolve("src/front/layout/chat-pane-stage.css")
 const output = resolve("dist/workspace.css")
 
-const [dockviewCss, dockviewOverridesCss, globalsCss] = await Promise.all([
+const [dockviewCss, dockviewOverridesCss, chatPaneStageCss, globalsCss] = await Promise.all([
   readFile(dockviewCssPath, "utf8"),
   readFile(dockviewOverridesPath, "utf8"),
+  readFile(chatPaneStagePath, "utf8"),
   readFile(globalsInput, "utf8"),
 ])
 
@@ -29,6 +31,8 @@ const css = [
   globalsResult.css,
   "/* @hachej/boring-workspace dockview overrides */",
   dockviewOverridesCss,
+  "/* @hachej/boring-workspace chat pane stage */",
+  chatPaneStageCss,
 ].join("\n\n")
 
 await mkdir(dirname(output), { recursive: true })

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -24,6 +24,18 @@ import {
 import { WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT } from "../../front/agentPlugins/reloadEvent"
 import { WorkspaceBackgroundBoot } from "./WorkspaceBackgroundBoot"
 import { workspaceRequestHeaders, type WorkspaceWarmupStatus } from "./workspacePreload"
+import {
+  createdSessionId,
+  insertPaneAfter,
+  replaceActivePane,
+  type ChatPaneState,
+} from "./chatPaneState"
+
+interface PendingCreatePane {
+  afterId: string
+  knownIds: Set<string>
+  createdId?: string
+}
 
 export interface WorkspaceAgentSession {
   id: string
@@ -63,7 +75,24 @@ export type UseWorkspaceAgentSessions<
 export interface WorkspaceAgentFrontProps<
   TSession extends WorkspaceAgentSession = WorkspaceAgentSession,
 > extends Omit<WorkspaceProviderProps, "children" | "workspaceId" | "storageKey" | "chatPanel">,
-    Omit<ChatLayoutProps, "nav" | "navParams" | "center" | "centerParams" | "surface" | "surfaceParams" | "sidebar" | "sidebarParams" | "storageKey"> {
+    Omit<ChatLayoutProps,
+      | "nav"
+      | "navParams"
+      | "center"
+      | "centerParams"
+      | "chatPanes"
+      | "activeChatPaneId"
+      | "onActiveChatPaneChange"
+      | "onCloseChatPane"
+      | "onCreateChatPaneAfter"
+      | "onDropChatSession"
+      | "flashChatPaneId"
+      | "surface"
+      | "surfaceParams"
+      | "sidebar"
+      | "sidebarParams"
+      | "storageKey"
+    > {
   workspaceId: string
   chatPanel?: ComponentType<WorkspaceChatPanelProps>
   useSessions?: UseWorkspaceAgentSessions<TSession>
@@ -93,7 +122,7 @@ export interface WorkspaceAgentFrontProps<
   sessions?: Array<{ id: string; title?: string | null; updatedAt?: string | number; turnCount?: number }>
   activeSessionId?: string | null
   onSwitchSession?: (id: string) => void
-  onCreateSession?: () => void
+  onCreateSession?: () => unknown | Promise<unknown>
   onDeleteSession?: (id: string) => void
   onActiveSessionIdChange?: (sessionId: string | null) => void
   chatParams?: Record<string, unknown>
@@ -147,6 +176,7 @@ function useStoredBooleanState(
 }
 
 const EMPTY_HEADERS: Record<string, string> = {}
+const EMPTY_STRING_LIST: string[] = []
 const PREPARING_WARMUP_STATUS: WorkspaceWarmupStatus = { status: "preparing" }
 
 const emptySurfaceSnapshot: SurfaceShellSnapshot = {
@@ -218,6 +248,65 @@ function readStoredSessionId(storageKey: string): string | null {
     return globalThis.localStorage?.getItem(storageKey) ?? null
   } catch {
     return null
+  }
+}
+
+function readStoredChatPaneState(storageKey: string, workspaceId: string): ChatPaneState | null {
+  try {
+    const raw = globalThis.localStorage?.getItem(storageKey)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { ids?: unknown; activeId?: unknown }
+    const ids = Array.isArray(parsed.ids)
+      ? parsed.ids.filter((id): id is string => typeof id === "string" && id.length > 0)
+      : []
+    if (ids.length === 0) return null
+    const activeId = typeof parsed.activeId === "string" && ids.includes(parsed.activeId)
+      ? parsed.activeId
+      : ids[0]
+    return { workspaceId, ids, activeId }
+  } catch {
+    return null
+  }
+}
+
+function writeStoredChatPaneState(storageKey: string, state: ChatPaneState): void {
+  try {
+    if (state.ids.length === 0) {
+      globalThis.localStorage?.removeItem(storageKey)
+      return
+    }
+    globalThis.localStorage?.setItem(
+      storageKey,
+      JSON.stringify({ ids: state.ids, activeId: state.activeId }),
+    )
+  } catch {
+    // Best-effort persistence only.
+  }
+}
+
+function readStoredPinnedSessions(storageKey: string, workspaceId: string): { workspaceId: string; ids: string[] } | null {
+  try {
+    const raw = globalThis.localStorage?.getItem(storageKey)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as { ids?: unknown }
+    const ids = Array.isArray(parsed.ids)
+      ? parsed.ids.filter((id): id is string => typeof id === "string" && id.length > 0)
+      : []
+    return { workspaceId, ids }
+  } catch {
+    return null
+  }
+}
+
+function writeStoredPinnedSessions(storageKey: string, ids: string[]): void {
+  try {
+    if (ids.length === 0) {
+      globalThis.localStorage?.removeItem(storageKey)
+      return
+    }
+    globalThis.localStorage?.setItem(storageKey, JSON.stringify({ ids }))
+  } catch {
+    // Best-effort persistence only.
   }
 }
 
@@ -361,6 +450,7 @@ export function WorkspaceAgentFront<
   onOpenNav,
   onOpenSurface,
   surfaceButtonBottomOffset,
+  chatPaneEngine,
   className,
 }: WorkspaceAgentFrontProps<TSession>) {
   const resolvedProviderStorageKey =
@@ -404,6 +494,53 @@ export function WorkspaceAgentFront<
     failed: false,
   }))
   const [freshEmptySession, setFreshEmptySession] = useState<{ workspaceId: string; id: string } | null>(null)
+  const chatPaneStorageKey = `boring-workspace:chat-panes:${workspaceId}`
+  const [chatPaneState, setChatPaneState] = useState<ChatPaneState>(() =>
+    (shellPersistenceEnabled ? readStoredChatPaneState(chatPaneStorageKey, workspaceId) : null)
+      ?? { workspaceId, ids: [], activeId: null },
+  )
+  const [flashChatPane, setFlashChatPane] = useState<{ workspaceId: string; id: string } | null>(null)
+  useEffect(() => {
+    if (!flashChatPane) return
+    const timer = setTimeout(() => setFlashChatPane(null), 700)
+    return () => clearTimeout(timer)
+  }, [flashChatPane])
+
+  const pinnedStorageKey = `boring-workspace:pinned-sessions:${workspaceId}`
+  const [pinnedState, setPinnedState] = useState<{ workspaceId: string; ids: string[] }>(() =>
+    (shellPersistenceEnabled ? readStoredPinnedSessions(pinnedStorageKey, workspaceId) : null)
+      ?? { workspaceId, ids: [] },
+  )
+  const pinnedIds = pinnedState.workspaceId === workspaceId ? pinnedState.ids : EMPTY_STRING_LIST
+  useEffect(() => {
+    setPinnedState((previous) => {
+      if (previous.workspaceId === workspaceId) return previous
+      return (shellPersistenceEnabled ? readStoredPinnedSessions(pinnedStorageKey, workspaceId) : null)
+        ?? { workspaceId, ids: [] }
+    })
+  }, [pinnedStorageKey, shellPersistenceEnabled, workspaceId])
+  const toggleSessionPinned = useCallback((sessionId: string) => {
+    setPinnedState((previous) => {
+      const current = previous.workspaceId === workspaceId ? previous.ids : []
+      const ids = current.includes(sessionId)
+        ? current.filter((id) => id !== sessionId)
+        : [sessionId, ...current]
+      if (shellPersistenceEnabled) writeStoredPinnedSessions(pinnedStorageKey, ids)
+      return { workspaceId, ids }
+    })
+  }, [pinnedStorageKey, shellPersistenceEnabled, workspaceId])
+  useEffect(() => {
+    if (!shellPersistenceEnabled) return
+    if (chatPaneState.workspaceId !== workspaceId) return
+    writeStoredChatPaneState(chatPaneStorageKey, chatPaneState)
+  }, [chatPaneState, chatPaneStorageKey, shellPersistenceEnabled, workspaceId])
+  useEffect(() => {
+    setChatPaneState((previous) => {
+      if (previous.workspaceId === workspaceId) return previous
+      return (shellPersistenceEnabled ? readStoredChatPaneState(chatPaneStorageKey, workspaceId) : null)
+        ?? { workspaceId, ids: [], activeId: null }
+    })
+  }, [chatPaneStorageKey, shellPersistenceEnabled, workspaceId])
   const workspaceWarmupStatus = workspaceWarmupState.workspaceId === workspaceId
     ? workspaceWarmupState.status
     : PREPARING_WARMUP_STATUS
@@ -624,6 +761,7 @@ export function WorkspaceAgentFront<
     shellPersistenceEnabled,
   )
   const autoCreateSessionRef = useRef(false)
+  const pendingCreatePaneRef = useRef<PendingCreatePane | null>(null)
   const surfaceOpenRef = useRef(surfaceOpen)
   const surfaceKeyRef = useRef(resolvedSurfaceStorageKey)
   const surfaceRef = useRef<{ key: string; api: SurfaceShellApi } | null>(null)
@@ -755,6 +893,182 @@ export function WorkspaceAgentFront<
   const chatSessionId = shouldUseRemoteSessions && !useSessionsProp && remoteSessionSnapshot.workspaceId !== workspaceId
     ? "default"
     : effectiveActiveSessionId ?? (autoSubmitSessionId !== undefined ? "default" : resolvedSessions[0]?.id ?? "default")
+  // While remote sessions load, resolvedSessions is a one-item placeholder
+  // for the stored active session — never an authoritative list to prune
+  // restored panes against.
+  const sessionListAuthoritative = !sessionApi?.hasMore && !remoteSessionsPending
+  useEffect(() => {
+    if (remoteSessionsTransitioning) return
+    const pendingCreatePane = pendingCreatePaneRef.current
+    const sessionIds = new Set(resolvedSessions.map((session) => session.id))
+    const pendingCreatedId = pendingCreatePane
+      ? pendingCreatePane.createdId
+        ?? (sessionIds.has(chatSessionId) && !pendingCreatePane.knownIds.has(chatSessionId)
+          ? chatSessionId
+          : resolvedSessions.find((session) => !pendingCreatePane.knownIds.has(session.id))?.id ?? null)
+      : null
+    if (pendingCreatedId && sessionIds.has(pendingCreatedId)) pendingCreatePaneRef.current = null
+    const preservingEphemeralDefault = chatSessionId === "default" && autoSubmitSessionId !== undefined
+    const canPruneMissingSessions = sessionListAuthoritative && sessionIds.size > 0 && !preservingEphemeralDefault
+    const desiredSessionId = pendingCreatedId
+      ?? (canPruneMissingSessions && !sessionIds.has(chatSessionId)
+        ? resolvedSessions[0]?.id ?? chatSessionId
+        : chatSessionId)
+    setChatPaneState((previous) => {
+      const current = previous.workspaceId === workspaceId
+        ? previous
+        : { workspaceId, ids: [], activeId: null }
+      // While remote sessions are still loading, chatSessionId may be the
+      // ephemeral "default" placeholder — restored pane state is more
+      // trustworthy than it, so leave the layout untouched until the real
+      // session list arrives.
+      if (remoteSessionsPending && current.ids.length > 0 && !pendingCreatedId) return current
+      const rawIds = current.ids.length > 0 ? current.ids : [desiredSessionId]
+      const prunedIds = canPruneMissingSessions
+        ? rawIds.filter((id) => sessionIds.has(id) || id === pendingCreatedId)
+        : rawIds
+      const ids = prunedIds.length > 0 ? prunedIds : [desiredSessionId]
+      const activeId = current.activeId && ids.includes(current.activeId) ? current.activeId : ids[0] ?? desiredSessionId
+      const nextIds = pendingCreatedId
+        ? insertPaneAfter(ids, pendingCreatePane?.afterId, pendingCreatedId)
+        : desiredSessionId === activeId || ids.includes(desiredSessionId)
+          ? ids
+          : replaceActivePane(ids, activeId, desiredSessionId)
+      const nextActiveId = nextIds.includes(desiredSessionId) ? desiredSessionId : nextIds[0] ?? desiredSessionId
+      if (
+        previous.workspaceId === workspaceId
+        && previous.activeId === nextActiveId
+        && previous.ids.length === nextIds.length
+        && previous.ids.every((id, index) => id === nextIds[index])
+      ) return previous
+      return { workspaceId, ids: nextIds, activeId: nextActiveId }
+    })
+  }, [autoSubmitSessionId, chatSessionId, remoteSessionsPending, remoteSessionsTransitioning, resolvedSessions, sessionListAuthoritative, workspaceId])
+
+  const sessionTitleById = useMemo(() => {
+    const titles = new Map<string, string | null | undefined>()
+    for (const session of resolvedSessions) titles.set(session.id, session.title)
+    return titles
+  }, [resolvedSessions])
+
+  const activeChatPaneState = chatPaneState.workspaceId === workspaceId
+    ? chatPaneState
+    : { workspaceId, ids: [], activeId: null }
+  const chatPaneIds = activeChatPaneState.ids.length > 0 ? activeChatPaneState.ids : [chatSessionId]
+  const activeChatPaneId = activeChatPaneState.activeId ?? chatPaneIds[0] ?? chatSessionId
+
+  const switchToChatPane = useCallback((nextSessionId: string) => {
+    const current = chatPaneState.workspaceId === workspaceId
+      ? chatPaneState
+      : { workspaceId, ids: [chatSessionId], activeId: chatSessionId }
+    const alreadyVisible = current.ids.includes(nextSessionId)
+    setChatPaneState((previous) => {
+      const paneState = previous.workspaceId === workspaceId
+        ? previous
+        : { workspaceId, ids: [chatSessionId], activeId: chatSessionId }
+      const ids = paneState.ids.includes(nextSessionId)
+        ? paneState.ids
+        : replaceActivePane(paneState.ids, paneState.activeId, nextSessionId)
+      return { workspaceId, ids, activeId: nextSessionId }
+    })
+    return alreadyVisible ? rawSwitch(nextSessionId) : resolvedSwitch(nextSessionId)
+  }, [chatPaneState, chatSessionId, rawSwitch, resolvedSwitch, workspaceId])
+
+  const activateChatPane = useCallback((nextSessionId: string) => {
+    setChatPaneState((previous) => {
+      const current = previous.workspaceId === workspaceId
+        ? previous
+        : { workspaceId, ids: [chatSessionId], activeId: chatSessionId }
+      return {
+        workspaceId,
+        ids: current.ids.includes(nextSessionId) ? current.ids : insertPaneAfter(current.ids, current.activeId, nextSessionId),
+        activeId: nextSessionId,
+      }
+    })
+    return rawSwitch(nextSessionId)
+  }, [chatSessionId, rawSwitch, workspaceId])
+
+  const openChatPane = useCallback((nextSessionId: string) => {
+    const current = chatPaneState.workspaceId === workspaceId
+      ? chatPaneState
+      : { workspaceId, ids: [chatSessionId], activeId: chatSessionId }
+    // Opening a session that is already on the stage is a focus, not an
+    // insert — flash the pane so the click visibly landed somewhere.
+    if (current.ids.includes(nextSessionId)) {
+      setFlashChatPane({ workspaceId, id: nextSessionId })
+    }
+    setChatPaneState((previous) => {
+      const paneState = previous.workspaceId === workspaceId
+        ? previous
+        : { workspaceId, ids: [chatSessionId], activeId: chatSessionId }
+      return {
+        workspaceId,
+        ids: insertPaneAfter(paneState.ids, paneState.activeId, nextSessionId),
+        activeId: nextSessionId,
+      }
+    })
+    return rawSwitch(nextSessionId)
+  }, [chatPaneState, chatSessionId, rawSwitch, workspaceId])
+
+  const closeChatPane = useCallback((sessionId: string) => {
+    const current = chatPaneState.workspaceId === workspaceId
+      ? chatPaneState
+      : { workspaceId, ids: [chatSessionId], activeId: chatSessionId }
+    if (current.ids.length <= 1) return
+    const closingIndex = current.ids.indexOf(sessionId)
+    if (closingIndex < 0) return
+    const nextIds = current.ids.filter((id) => id !== sessionId)
+    const nextActiveId = current.activeId === sessionId
+      ? nextIds[Math.max(0, closingIndex - 1)] ?? nextIds[0] ?? null
+      : current.activeId
+    setChatPaneState({ workspaceId, ids: nextIds, activeId: nextActiveId })
+    if (nextActiveId && current.activeId === sessionId) rawSwitch(nextActiveId)
+  }, [chatPaneState, chatSessionId, rawSwitch, workspaceId])
+
+  const createChatPaneAfter = useCallback((afterId: string) => {
+    const pendingCreatePane = {
+      afterId,
+      knownIds: new Set(resolvedSessions.map((session) => session.id)),
+    }
+    pendingCreatePaneRef.current = pendingCreatePane
+    const created = resolvedCreate()
+    void Promise.resolve(created).then((session) => {
+      const id = createdSessionId(session)
+      if (!id) return
+      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = { ...pendingCreatePane, createdId: id }
+      setChatPaneState((previous) => {
+        const current = previous.workspaceId === workspaceId
+          ? previous
+          : { workspaceId, ids: [chatSessionId], activeId: chatSessionId }
+        return {
+          workspaceId,
+          ids: insertPaneAfter(current.ids, afterId, id),
+          activeId: id,
+        }
+      })
+    }).catch(() => {
+      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
+    })
+    return created
+  }, [chatSessionId, resolvedCreate, resolvedSessions, workspaceId])
+
+  const deleteSessionAndPane = useCallback((sessionId: string) => {
+    const current = chatPaneState.workspaceId === workspaceId
+      ? chatPaneState
+      : { workspaceId, ids: [chatSessionId], activeId: chatSessionId }
+    const deletingIndex = current.ids.indexOf(sessionId)
+    let nextActiveId = current.activeId
+    if (deletingIndex >= 0) {
+      const nextIds = current.ids.filter((id) => id !== sessionId)
+      nextActiveId = current.activeId === sessionId
+        ? nextIds[Math.max(0, deletingIndex - 1)] ?? nextIds[0] ?? null
+        : current.activeId
+      setChatPaneState({ workspaceId, ids: nextIds, activeId: nextActiveId })
+      if (nextActiveId && current.activeId === sessionId) resolvedSwitch(nextActiveId)
+    }
+    return resolvedDelete(sessionId)
+  }, [chatPaneState, chatSessionId, resolvedDelete, resolvedSwitch, workspaceId])
+
   const [autoSubmitHydrationDisabled, setAutoSubmitHydrationDisabled] = useState(requestedAutoSubmitInitialDraft)
   const autoSubmitHydrationWorkspaceRef = useRef(workspaceId)
   useEffect(() => {
@@ -806,13 +1120,13 @@ export function WorkspaceAgentFront<
 
   const workbenchBlocked = workspaceWarmupStatus.status !== "ready"
   const workbenchOverlay = workbenchBlocked ? <WorkbenchWarmupOverlay status={workspaceWarmupStatus} /> : undefined
-  const reloadAgentPlugins = useCallback(async () => {
+  const reloadAgentPluginsForSession = useCallback(async (sessionId: string) => {
     const endpoint = `${apiBaseUrl?.replace(/\/$/, "") ?? ""}/api/v1/agent/reload`
     try {
       const response = await fetch(endpoint, {
         method: "POST",
         headers: { ...resolvedRequestHeaders, "content-type": "application/json" },
-        body: JSON.stringify({ sessionId: chatSessionId }),
+        body: JSON.stringify({ sessionId }),
       })
       if (!response.ok) {
         const payload = await response.json().catch(() => ({})) as { error?: string }
@@ -824,25 +1138,26 @@ export function WorkspaceAgentFront<
     } catch (error) {
       return error instanceof Error ? error.message : "Agent plugin reload failed."
     }
-  }, [apiBaseUrl, chatSessionId, resolvedRequestHeaders])
+  }, [apiBaseUrl, resolvedRequestHeaders])
 
-  const centerParams = useMemo(
-    () => {
+  const makeCenterParams = useCallback(
+    (sessionId: string, options: { bridgeEnabled?: boolean } = {}) => {
+      const bridgeEnabled = options.bridgeEnabled ?? true
       const chatToolRenderers = (chatParams?.toolRenderers && typeof chatParams.toolRenderers === "object")
         ? chatParams.toolRenderers as ToolRendererOverrides
         : undefined
       return {
       ...chatParams,
       ...(delayAutoSubmitDraft ? { autoSubmitInitialDraft: false, initialDraft: undefined } : {}),
-      sessionId: chatSessionId,
+      sessionId,
       apiBaseUrl,
       workspaceId,
       storageScope: workspaceId,
       requestHeaders: resolvedRequestHeaders,
       showSessions: false,
-      onReloadAgentPlugins: chatParams?.onReloadAgentPlugins ?? reloadAgentPlugins,
+      onReloadAgentPlugins: chatParams?.onReloadAgentPlugins ?? (() => reloadAgentPluginsForSession(sessionId)),
       toolRenderers: { ...pluginToolRenderers, ...(chatToolRenderers ?? {}) },
-      bridgeEndpoint,
+      bridgeEndpoint: bridgeEnabled ? bridgeEndpoint : null,
       getSurface,
       isWorkbenchOpen,
       openWorkbench,
@@ -864,8 +1179,20 @@ export function WorkspaceAgentFront<
       ...(hotReloadEnabled !== undefined ? { hotReloadEnabled } : {}),
     }
     },
-    [apiBaseUrl, chatParams, delayAutoSubmitDraft, chatSessionId, resolvedRequestHeaders, bridgeEndpoint, getSurface, isWorkbenchOpen, openWorkbench, openWorkbenchSources, closeWorkbench, extraCommands, workspaceWarmupStatus, hydrateMessages, hotReloadEnabled, pluginToolRenderers, reloadAgentPlugins, workspaceId],
+    [apiBaseUrl, chatParams, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, getSurface, isWorkbenchOpen, openWorkbench, openWorkbenchSources, closeWorkbench, extraCommands, workspaceWarmupStatus, hydrateMessages, hotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, workspaceId],
   )
+  const centerParams = useMemo(
+    () => makeCenterParams(chatSessionId),
+    [chatSessionId, makeCenterParams],
+  )
+  const chatPanes = useMemo(() => (
+    chatPaneIds.map((id) => ({
+      id,
+      title: sessionTitleById.get(id) ?? (id === "default" ? defaultSessionTitle : id),
+      panel: "chat",
+      params: makeCenterParams(id, { bridgeEnabled: id === activeChatPaneId }),
+    }))
+  ), [activeChatPaneId, chatPaneIds, defaultSessionTitle, makeCenterParams, sessionTitleById])
   const surfaceParams = useMemo<SurfaceShellProps>(() => ({
     storageKey: resolvedSurfaceStorageKey,
     defaultLeftTab: defaultWorkbenchLeftTab,
@@ -941,7 +1268,6 @@ export function WorkspaceAgentFront<
             appTitle={appTitle}
             sessionTitle={remoteSessionsTransitioning ? "Loading sessions…" : resolvedSessionTitle ?? defaultSessionTitle}
             onCommandPalette={openCommandPalette}
-            onNewChat={resolvedCreate}
             topBarLeft={topBarLeft}
             topBarRight={
               <>
@@ -958,10 +1284,14 @@ export function WorkspaceAgentFront<
               nav={effectiveNavOpen ? "session-list" : null}
               navParams={{
                 sessions: resolvedSessions,
-                activeId: resolvedActiveId,
-                onSwitch: resolvedSwitch,
+                activeId: activeChatPaneId,
+                openIds: chatPaneIds,
+                pinnedIds,
+                onTogglePin: toggleSessionPinned,
+                onSwitch: switchToChatPane,
+                onOpenAsTab: openChatPane,
                 onCreate: resolvedCreate,
-                onDelete: resolvedDelete,
+                onDelete: deleteSessionAndPane,
                 onLoadMore: sessionApi?.loadMore,
                 hasMore: sessionApi?.hasMore,
                 loadingMore: sessionApi?.loadingMore,
@@ -969,6 +1299,14 @@ export function WorkspaceAgentFront<
               }}
               center="chat"
               centerParams={centerParams}
+              chatPanes={chatPanes}
+              activeChatPaneId={activeChatPaneId}
+              onActiveChatPaneChange={activateChatPane}
+              onCloseChatPane={closeChatPane}
+              onCreateChatPaneAfter={createChatPaneAfter}
+              onDropChatSession={openChatPane}
+              flashChatPaneId={flashChatPane?.workspaceId === workspaceId ? flashChatPane.id : null}
+              chatPaneEngine={chatPaneEngine}
               surface={surfaceOpen ? "artifact-surface" : null}
               surfaceParams={surfaceParams as Record<string, unknown>}
               surfaceOverlay={workbenchOverlay}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT } from "../../../front/agentPlugins/reloadEvent"
@@ -24,6 +24,33 @@ function ChatPanel(props: WorkspaceChatPanelProps) {
       <button type="button" onClick={() => props.onOpenArtifact?.("src/example.ts")}>Open artifact</button>
     </div>
   )
+}
+
+function SessionIdChatPanel(props: WorkspaceChatPanelProps) {
+  return <div data-testid="chat-pane" data-session-id={props.sessionId}>Chat pane {props.sessionId}</div>
+}
+
+function TextareaChatPanel(props: WorkspaceChatPanelProps) {
+  return (
+    <textarea
+      name="message"
+      data-testid={`composer-${props.sessionId}`}
+      defaultValue={`Composer ${props.sessionId}`}
+    />
+  )
+}
+
+function visibleChatSessionIds(): string[] {
+  return screen.getAllByTestId("chat-pane").map((node) => node.getAttribute("data-session-id") ?? "")
+}
+
+// History starts collapsed when chat panes are open; expand it so tests can
+// reach history rows. No-op when there is no collapsed History toggle.
+function expandHistory(): void {
+  const toggle = screen.queryByRole("button", { name: "History", hidden: true })
+  if (toggle && toggle.getAttribute("aria-expanded") === "false") {
+    fireEvent.click(toggle)
+  }
 }
 
 function GlobalCommandPanel() {
@@ -141,6 +168,473 @@ describe("WorkspaceAgentFront", () => {
 
     expect(onOpenNav).toHaveBeenCalledOnce()
     expect(screen.getByLabelText("Session browser")).toHaveAttribute("aria-hidden", "false")
+  })
+
+  it("treats session history as data and opened chat panes as views", async () => {
+    const user = userEvent.setup()
+    const switchCalls: string[] = []
+    const sessions = [
+      { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+      { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+      { id: "s3", title: "Third session", updatedAt: Date.now() - 3_000 },
+    ]
+
+    function Harness() {
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="multi-pane-sessions"
+          chatPanel={SessionIdChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSwitchSession={(id) => {
+            switchCalls.push(id)
+            setActiveSessionId(id)
+          }}
+          onCreateSession={vi.fn()}
+          defaultNavOpen
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expandHistory()
+
+    // Session creation is contextual: with the drawer open its header "+"
+    // is the affordance and the floating "New chat" button hides.
+    expect(screen.queryByRole("button", { name: "New chat" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "New session" })).toBeInTheDocument()
+    expect(visibleChatSessionIds()).toEqual(["s1"])
+
+    await user.click(screen.getByText("Second session"))
+    expect(switchCalls).toContain("s2")
+    expect(visibleChatSessionIds()).toEqual(["s2"])
+
+    await user.click(screen.getByLabelText("Open Third session in chat pane"))
+    expect(switchCalls).toContain("s3")
+    expect(visibleChatSessionIds()).toEqual(["s2", "s3"])
+
+    await user.click(screen.getByText("First session"))
+    expect(switchCalls).toContain("s1")
+    expect(visibleChatSessionIds()).toEqual(["s2", "s1"])
+
+    await user.click(screen.getByLabelText("Close First session pane"))
+    expect(switchCalls).toContain("s2")
+    expect(visibleChatSessionIds()).toEqual(["s2"])
+    expect(screen.getByText("First session")).toBeInTheDocument()
+  })
+
+  it("opens a controlled void-created session as a pane to the right", async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [sessions, setSessions] = useState([
+        { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+      ])
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="controlled-create-pane"
+          chatPanel={SessionIdChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSwitchSession={setActiveSessionId}
+          onCreateSession={() => {
+            setSessions((previous) => [
+              { id: "created", title: "Created session", updatedAt: Date.now() },
+              ...previous,
+            ])
+            setActiveSessionId("created")
+          }}
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expandHistory()
+
+    await user.click(screen.getByRole("button", { name: "New chat" }))
+
+    await waitFor(() => {
+      expect(visibleChatSessionIds()).toEqual(["s1", "created"])
+    })
+  })
+
+  it("restores the persisted pane layout on reload", async () => {
+    localStorage.setItem(
+      "boring-workspace:chat-panes:restore-panes",
+      JSON.stringify({ ids: ["s1", "s2"], activeId: "s2" }),
+    )
+    const sessions = [
+      { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+      { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+    ]
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="restore-panes"
+        chatPanel={SessionIdChatPanel}
+        sessions={sessions}
+        activeSessionId="s2"
+        onSwitchSession={vi.fn()}
+        onCreateSession={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(visibleChatSessionIds()).toEqual(["s1", "s2"])
+    })
+  })
+
+  it("restores the persisted pane layout while remote sessions load", async () => {
+    localStorage.setItem(
+      "boring-workspace:chat-panes:remote-restore",
+      JSON.stringify({ ids: ["s1", "s2"], activeId: "s2" }),
+    )
+    localStorage.setItem("boring-workspace:sessions:remote-restore", "s2")
+
+    function useDelayedSessions() {
+      const [loading, setLoading] = useState(true)
+      useEffect(() => {
+        const timer = setTimeout(() => setLoading(false), 50)
+        return () => clearTimeout(timer)
+      }, [])
+      const sessions = loading
+        ? []
+        : [
+            { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+            { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+          ]
+      return {
+        sessions,
+        loading,
+        activeSessionId: loading ? null : "s2",
+        activeSession: sessions[1] ?? null,
+        switch: vi.fn(),
+        create: vi.fn(),
+        delete: vi.fn(),
+      }
+    }
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="remote-restore"
+        chatPanel={SessionIdChatPanel}
+        useSessions={useDelayedSessions}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(visibleChatSessionIds()).toEqual(["s1", "s2"])
+    })
+  })
+
+  it("keeps an async returned created pane while controlled sessions catch up", async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [sessions, setSessions] = useState([
+        { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+      ])
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="async-created-pane"
+          chatPanel={SessionIdChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSwitchSession={setActiveSessionId}
+          onCreateSession={() => Promise.resolve({ id: "created", title: "Created session", updatedAt: Date.now() })}
+          beforeShell={
+            <button type="button" onClick={() => setSessions((previous) => [...previous])}>
+              Refresh stale sessions
+            </button>
+          }
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expandHistory()
+
+    await user.click(screen.getByRole("button", { name: "New chat" }))
+
+    await waitFor(() => {
+      expect(visibleChatSessionIds()).toEqual(["s1", "created"])
+    })
+
+    await user.click(screen.getByRole("button", { name: "Refresh stale sessions" }))
+
+    await waitFor(() => {
+      expect(visibleChatSessionIds()).toEqual(["s1", "created"])
+    })
+  })
+
+  it("removes an open chat pane when its session is deleted from history", async () => {
+    const user = userEvent.setup()
+    const deleted = vi.fn()
+
+    function Harness() {
+      const [sessions, setSessions] = useState([
+        { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+        { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+      ])
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="delete-open-pane"
+          chatPanel={SessionIdChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSwitchSession={setActiveSessionId}
+          onDeleteSession={(id) => {
+            deleted(id)
+            setSessions((previous) => previous.filter((session) => session.id !== id))
+          }}
+          defaultNavOpen
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expandHistory()
+
+    await user.click(screen.getByLabelText("Open Second session in chat pane"))
+    expect(visibleChatSessionIds()).toEqual(["s1", "s2"])
+
+    await user.click(screen.getByLabelText("Delete Second session"))
+
+    await waitFor(() => {
+      expect(deleted).toHaveBeenCalledWith("s2")
+      expect(visibleChatSessionIds()).toEqual(["s1"])
+      expect(screen.queryByText("Second session")).not.toBeInTheDocument()
+    })
+  })
+
+  it("prunes open panes when a controlled session list drops a session", async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [sessions, setSessions] = useState([
+        { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+        { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+      ])
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="external-session-prune"
+          chatPanel={SessionIdChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSwitchSession={setActiveSessionId}
+          beforeShell={
+            <button type="button" onClick={() => setSessions((previous) => previous.filter((session) => session.id !== "s2"))}>
+              Drop second session
+            </button>
+          }
+          defaultNavOpen
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expandHistory()
+
+    await user.click(screen.getByLabelText("Open Second session in chat pane"))
+    expect(visibleChatSessionIds()).toEqual(["s1", "s2"])
+
+    await user.click(screen.getByRole("button", { name: "Drop second session" }))
+
+    await waitFor(() => {
+      expect(visibleChatSessionIds()).toEqual(["s1"])
+      expect(screen.queryByText("Second session")).not.toBeInTheDocument()
+    })
+  })
+
+  it("keeps open panes that are missing from a paginated remote session page", async () => {
+    const user = userEvent.setup()
+
+    function Harness() {
+      const [sessions, setSessions] = useState([
+        { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+        { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+      ])
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      const usePaginatedSessions = () => ({
+        sessions,
+        activeSessionId,
+        activeSession: sessions.find((session) => session.id === activeSessionId) ?? null,
+        loading: false,
+        hasMore: true,
+        create: vi.fn(),
+        switch: setActiveSessionId,
+        delete: vi.fn(),
+      })
+      return (
+        <WorkspaceAgentFront
+          workspaceId="paginated-session-pane"
+          chatPanel={SessionIdChatPanel}
+          useSessions={usePaginatedSessions}
+          beforeShell={
+            <button type="button" onClick={() => setSessions((previous) => previous.filter((session) => session.id !== "s2"))}>
+              Show first page
+            </button>
+          }
+          defaultNavOpen
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expandHistory()
+
+    await user.click(screen.getByLabelText("Open Second session in chat pane"))
+    expect(visibleChatSessionIds()).toEqual(["s1", "s2"])
+
+    await user.click(screen.getByRole("button", { name: "Show first page" }))
+
+    await waitFor(() => {
+      expect(visibleChatSessionIds()).toEqual(["s1", "s2"])
+    })
+  })
+
+  it("keeps the UI command stream owned by the active chat pane only", async () => {
+    const user = userEvent.setup()
+    MockEventSource.instances = []
+    vi.stubGlobal("EventSource", MockEventSource)
+    const sessions = [
+      { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+      { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+    ]
+    const activeStreams = () => MockEventSource.instances.filter((instance) => (
+      instance.url.includes("/api/v1/ui/commands/next")
+      && instance.close.mock.calls.length === 0
+    ))
+
+    function Harness() {
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="single-ui-command-stream"
+          chatPanel={SessionIdChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSwitchSession={setActiveSessionId}
+          bridgeEndpoint="/api/v1/ui"
+          defaultNavOpen
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expandHistory()
+
+    await waitFor(() => {
+      expect(activeStreams()).toHaveLength(1)
+    })
+
+    await user.click(screen.getByLabelText("Open Second session in chat pane"))
+
+    await waitFor(() => {
+      expect(visibleChatSessionIds()).toEqual(["s1", "s2"])
+      expect(activeStreams()).toHaveLength(1)
+    })
+  })
+
+  it("does not stop still-visible sessions when changing visible chat panes", async () => {
+    const user = userEvent.setup()
+    const stopEvents: unknown[] = []
+    const onStop = (event: Event) => stopEvents.push((event as CustomEvent).detail)
+    window.addEventListener("boring:workspace-composer-stop", onStop)
+    const sessions = [
+      { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+      { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+    ]
+
+    function Harness() {
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="visible-pane-no-stop"
+          chatPanel={SessionIdChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSwitchSession={setActiveSessionId}
+          defaultNavOpen
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expandHistory()
+
+    try {
+      await user.click(screen.getByLabelText("Open Second session in chat pane"))
+      await user.click(screen.getByLabelText("Chat session First session"))
+      await user.click(screen.getByLabelText("Chat session Second session"))
+      await user.click(screen.getByLabelText("Close Second session pane"))
+
+      expect(stopEvents).toEqual([])
+    } finally {
+      window.removeEventListener("boring:workspace-composer-stop", onStop)
+    }
+  })
+
+  it("keeps keyboard focus aligned with the active chat pane", async () => {
+    const user = userEvent.setup()
+    const switchCalls: string[] = []
+    const sessions = [
+      { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+      { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+    ]
+
+    function Harness() {
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="keyboard-pane-focus"
+          chatPanel={TextareaChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSwitchSession={(id) => {
+            switchCalls.push(id)
+            setActiveSessionId(id)
+          }}
+          defaultNavOpen
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expandHistory()
+
+    await user.click(screen.getByLabelText("Open Second session in chat pane"))
+    document.dispatchEvent(new KeyboardEvent("keydown", {
+      key: "Escape",
+      bubbles: true,
+      cancelable: true,
+    }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("composer-s2")).toHaveFocus()
+    })
+
+    act(() => {
+      screen.getByTestId("composer-s1").focus()
+    })
+
+    await waitFor(() => {
+      expect(switchCalls).toContain("s1")
+    })
   })
 
   it("restores session history and workbench visibility per workspace", async () => {
@@ -785,7 +1279,7 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
-    fireEvent.click(screen.getAllByRole("button", { name: "New chat" })[0])
+    fireEvent.click(screen.getByRole("button", { name: "New chat" }))
 
     await waitFor(() => {
       expect(create).toHaveBeenCalledOnce()
@@ -1002,6 +1496,7 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
+    expandHistory()
     await user.click(screen.getByText("Session two"))
     expect(onSwitchSession).toHaveBeenCalledWith("s2")
     expect(observed).toHaveBeenCalledWith(expect.objectContaining({ detail: { sessionId: "s1" } }))

--- a/packages/workspace/src/app/front/__tests__/chatPaneState.property.test.ts
+++ b/packages/workspace/src/app/front/__tests__/chatPaneState.property.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import * as fc from "fast-check"
+import { insertPaneAfter, replaceActivePane } from "../chatPaneState"
+
+const sessionId = fc.stringMatching(/^s[0-9a-z]{1,6}$/)
+const sessionIds = fc.uniqueArray(sessionId, { maxLength: 8 })
+
+function expectUnique(ids: string[]) {
+  expect(new Set(ids).size).toBe(ids.length)
+}
+
+describe("chat pane state randomized invariants", () => {
+  it("inserts panes without duplicating existing session views", () => {
+    fc.assert(
+      fc.property(sessionIds, fc.option(sessionId, { nil: undefined }), sessionId, (ids, afterId, nextId) => {
+        const next = insertPaneAfter(ids, afterId, nextId)
+
+        expectUnique(next)
+        expect(next).toContain(nextId)
+        expect(next.filter((id) => ids.includes(id))).toEqual(ids)
+
+        if (ids.includes(nextId)) {
+          expect(next).toEqual(ids)
+        } else if (afterId && ids.includes(afterId)) {
+          expect(next.indexOf(nextId)).toBe(next.indexOf(afterId) + 1)
+        } else {
+          expect(next.at(-1)).toBe(nextId)
+        }
+      }),
+      { numRuns: 100, seed: 424242 },
+    )
+  })
+
+  it("replaces only the active pane unless the session is already visible", () => {
+    fc.assert(
+      fc.property(sessionIds, fc.option(sessionId, { nil: undefined }), sessionId, (ids, activeId, nextId) => {
+        const next = replaceActivePane(ids, activeId, nextId)
+
+        expectUnique(next)
+        expect(next).toContain(nextId)
+
+        if (ids.includes(nextId)) {
+          expect(next).toEqual(ids)
+          return
+        }
+
+        if (ids.length === 0) {
+          expect(next).toEqual([nextId])
+          return
+        }
+
+        expect(next).toHaveLength(ids.length)
+        const replaceIndex = activeId && ids.includes(activeId) ? ids.indexOf(activeId) : 0
+        expect(next[replaceIndex]).toBe(nextId)
+        for (const [index, id] of ids.entries()) {
+          if (index !== replaceIndex) expect(next[index]).toBe(id)
+        }
+      }),
+      { numRuns: 100, seed: 424242 },
+    )
+  })
+})

--- a/packages/workspace/src/app/front/chatPaneState.ts
+++ b/packages/workspace/src/app/front/chatPaneState.ts
@@ -1,0 +1,26 @@
+export interface ChatPaneState {
+  workspaceId: string
+  ids: string[]
+  activeId: string | null
+}
+
+export function createdSessionId(value: unknown): string | null {
+  return typeof (value as { id?: unknown } | null | undefined)?.id === "string"
+    ? (value as { id: string }).id
+    : null
+}
+
+export function insertPaneAfter(ids: string[], afterId: string | null | undefined, nextId: string): string[] {
+  if (ids.includes(nextId)) return ids
+  const index = afterId ? ids.indexOf(afterId) : -1
+  const insertAt = index >= 0 ? index + 1 : ids.length
+  return [...ids.slice(0, insertAt), nextId, ...ids.slice(insertAt)]
+}
+
+export function replaceActivePane(ids: string[], activeId: string | null | undefined, nextId: string): string[] {
+  if (ids.includes(nextId)) return ids
+  if (ids.length === 0) return [nextId]
+  const index = activeId ? ids.indexOf(activeId) : -1
+  const replaceAt = index >= 0 ? index : 0
+  return ids.map((id, currentIndex) => currentIndex === replaceAt ? nextId : id)
+}

--- a/packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx
+++ b/packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx
@@ -1,16 +1,53 @@
 "use client"
 
-import { useMemo } from "react"
-import { ChevronLeft, Plus } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { ChevronLeft, ChevronRight, ExternalLink, Pin, Plus } from "lucide-react"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import { ControlTooltip } from "../../components/ControlTooltip"
+import { useWorkspaceAttention } from "../../attention/WorkspaceAttentionProvider"
+import { CHAT_SESSION_DRAG_TYPE } from "../../layout/ChatPaneStage"
 import type { SessionItem } from "../../components/SessionList"
+
+const CHAT_SESSION_STATUS_EVENT = "boring:chat-session-status"
+
+/**
+ * Session ids whose chat panel is currently streaming. Fed by the
+ * "boring:chat-session-status" window event each mounted chat panel emits —
+ * the browser stays decoupled from any particular chat implementation.
+ */
+function useWorkingSessionIds(): ReadonlySet<string> {
+  const [working, setWorking] = useState<ReadonlySet<string>>(() => new Set())
+  useEffect(() => {
+    const onStatus = (event: Event) => {
+      const detail = (event as CustomEvent).detail as { sessionId?: unknown; working?: unknown } | undefined
+      if (typeof detail?.sessionId !== "string") return
+      const sessionId = detail.sessionId
+      const isWorking = detail.working === true
+      setWorking((current) => {
+        if (current.has(sessionId) === isWorking) return current
+        const next = new Set(current)
+        if (isWorking) next.add(sessionId)
+        else next.delete(sessionId)
+        return next
+      })
+    }
+    window.addEventListener(CHAT_SESSION_STATUS_EVENT, onStatus)
+    return () => window.removeEventListener(CHAT_SESSION_STATUS_EVENT, onStatus)
+  }, [])
+  return working
+}
 
 export interface SessionBrowserProps {
   sessions: SessionItem[]
   activeId?: string | null
+  /** Session ids currently open as chat panes, in pane order. */
+  openIds?: string[]
+  /** Session ids the user pinned; surfaced in a Pinned section on top. */
+  pinnedIds?: string[]
+  onTogglePin?: (id: string) => void
   onSwitch?: (id: string) => void
+  onOpenAsTab?: (id: string) => void
   onCreate?: () => void
   onDelete?: (id: string) => void
   onLoadMore?: () => void
@@ -98,7 +135,11 @@ function relativeTime(value: SessionItem["updatedAt"]): string {
 export function SessionBrowser({
   sessions,
   activeId,
+  openIds,
+  pinnedIds,
+  onTogglePin,
   onSwitch,
+  onOpenAsTab,
   onCreate,
   onDelete,
   onLoadMore,
@@ -107,7 +148,49 @@ export function SessionBrowser({
   onClose,
   className,
 }: SessionBrowserProps) {
-  const groups = useMemo(() => groupSessions(sessions), [sessions])
+  // Pinned sessions sit in their own section on top, in pin order. Open
+  // panes surface in "Active" (in pane order); everything else is history
+  // grouped by recency. A session appears in only the highest-priority
+  // section it qualifies for: Pinned > Active > History.
+  const openSet = useMemo(() => new Set(openIds ?? []), [openIds])
+  const pinnedSet = useMemo(() => new Set(pinnedIds ?? []), [pinnedIds])
+  const pinnedSessions = useMemo(
+    () => (pinnedIds ?? [])
+      .map((id) => sessions.find((session) => session.id === id))
+      .filter((session): session is SessionItem => Boolean(session)),
+    [pinnedIds, sessions],
+  )
+  const activeSessions = useMemo(
+    () => (openIds ?? [])
+      .filter((id) => !pinnedSet.has(id))
+      .map((id) => sessions.find((session) => session.id === id))
+      .filter((session): session is SessionItem => Boolean(session)),
+    [openIds, pinnedSet, sessions],
+  )
+  const historySessions = useMemo(
+    () => (openSet.size > 0 || pinnedSet.size > 0
+      ? sessions.filter((session) => !openSet.has(session.id) && !pinnedSet.has(session.id))
+      : sessions),
+    [openSet, pinnedSet, sessions],
+  )
+  const groups = useMemo(() => groupSessions(historySessions), [historySessions])
+  const [pinnedCollapsed, setPinnedCollapsed] = useState(false)
+  const [activeCollapsed, setActiveCollapsed] = useState(false)
+  // History starts collapsed so the drawer leads with what's open; expands
+  // on click. With no panes open there is no Active section, so history
+  // shows by default to avoid an empty-looking drawer.
+  const [historyCollapsed, setHistoryCollapsed] = useState(
+    () => (openIds?.length ?? 0) > 0 || (pinnedIds?.length ?? 0) > 0,
+  )
+  const workingSessionIds = useWorkingSessionIds()
+  const { blockers } = useWorkspaceAttention()
+  const needsInputSessionIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const blocker of blockers) {
+      if (blocker.reason === "waiting_for_user_input" && blocker.sessionId) ids.add(blocker.sessionId)
+    }
+    return ids
+  }, [blockers])
 
   return (
     <div
@@ -141,7 +224,7 @@ export function SessionBrowser({
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto py-2.5">
+      <div className="boring-scrollbar-discreet flex-1 overflow-y-auto py-2.5">
         {sessions.length === 0 && (
           <div className="px-3 py-8 text-center text-[13px] text-muted-foreground">
             No sessions yet.
@@ -150,52 +233,179 @@ export function SessionBrowser({
           </div>
         )}
 
-        {groups.map((group, i) => (
-          <section key={group.key} className={cn(i > 0 && "mt-4")}>
-            <div className="flex items-baseline justify-between gap-2 px-3.5 pb-2 pt-2 text-[11px] font-medium tracking-tight text-muted-foreground/75">
-              <span>{group.label}</span>
-              <span aria-hidden="true" className="text-[10.5px] tabular-nums text-muted-foreground/40">{group.items.length}</span>
-            </div>
-            <ul role="list" className="flex flex-col">
-              {group.items.map((session) => (
-                <SessionRow
-                  key={session.id}
-                  session={session}
-                  active={session.id === activeId}
-                  onSwitch={onSwitch}
-                  onDelete={onDelete}
-                />
-              ))}
-            </ul>
+        {pinnedSessions.length > 0 && (
+          <section data-boring-workspace-part="session-pinned-section">
+            <SectionHeader
+              label="Pinned"
+              count={pinnedSessions.length}
+              collapsed={pinnedCollapsed}
+              onToggle={() => setPinnedCollapsed((value) => !value)}
+            />
+            {!pinnedCollapsed && (
+              <ul role="list" className="flex flex-col">
+                {pinnedSessions.map((session) => (
+                  <SessionRow
+                    key={session.id}
+                    session={session}
+                    active={session.id === activeId}
+                    open={openSet.has(session.id)}
+                    pinned
+                    working={workingSessionIds.has(session.id)}
+                    needsInput={needsInputSessionIds.has(session.id)}
+                    onSwitch={onSwitch}
+                    onOpenAsTab={onOpenAsTab}
+                    onTogglePin={onTogglePin}
+                    onDelete={onDelete}
+                  />
+                ))}
+              </ul>
+            )}
           </section>
-        ))}
+        )}
 
-        {hasMore && onLoadMore ? (
-          <div className="px-3 py-3">
-            <button
-              type="button"
-              onClick={onLoadMore}
-              disabled={loadingMore}
-              className="w-full rounded-md border border-border/60 px-2.5 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
-            >
-              {loadingMore ? "Loading…" : "Load more"}
-            </button>
-          </div>
-        ) : null}
+        {activeSessions.length > 0 && (
+          <section data-boring-workspace-part="session-active-section" className={cn(pinnedSessions.length > 0 && "mt-3")}>
+            <SectionHeader
+              label="Active"
+              count={activeSessions.length}
+              collapsed={activeCollapsed}
+              onToggle={() => setActiveCollapsed((value) => !value)}
+            />
+            {!activeCollapsed && (
+              <ul role="list" className="flex flex-col">
+                {activeSessions.map((session) => (
+                  <SessionRow
+                    key={session.id}
+                    session={session}
+                    active={session.id === activeId}
+                    open
+                    pinned={pinnedSet.has(session.id)}
+                    working={workingSessionIds.has(session.id)}
+                    needsInput={needsInputSessionIds.has(session.id)}
+                    onSwitch={onSwitch}
+                    onOpenAsTab={onOpenAsTab}
+                    onTogglePin={onTogglePin}
+                    onDelete={onDelete}
+                  />
+                ))}
+              </ul>
+            )}
+          </section>
+        )}
+
+        {groups.length > 0 && (
+          <section
+            data-boring-workspace-part="session-history-section"
+            className={cn(activeSessions.length > 0 && "mt-3")}
+          >
+            <SectionHeader
+              label="History"
+              count={historySessions.length}
+              collapsed={historyCollapsed}
+              onToggle={() => setHistoryCollapsed((value) => !value)}
+            />
+            {!historyCollapsed && (
+              <>
+                {groups.map((group, i) => (
+                  <section key={group.key} className={cn(i > 0 && "mt-2")}>
+                    <div className="flex items-baseline justify-between gap-2 px-5 pb-2 pt-2 text-[11px] font-medium tracking-tight text-muted-foreground/60">
+                      <span>{group.label}</span>
+                      <span aria-hidden="true" className="text-[10.5px] tabular-nums text-muted-foreground/40">{group.items.length}</span>
+                    </div>
+                    <ul role="list" className="flex flex-col">
+                      {group.items.map((session) => (
+                        <SessionRow
+                          key={session.id}
+                          session={session}
+                          active={session.id === activeId}
+                          open={false}
+                          pinned={pinnedSet.has(session.id)}
+                          working={workingSessionIds.has(session.id)}
+                          needsInput={needsInputSessionIds.has(session.id)}
+                          onSwitch={onSwitch}
+                          onOpenAsTab={onOpenAsTab}
+                          onTogglePin={onTogglePin}
+                          onDelete={onDelete}
+                        />
+                      ))}
+                    </ul>
+                  </section>
+                ))}
+
+                {hasMore && onLoadMore ? (
+                  <div className="px-3 py-3">
+                    <button
+                      type="button"
+                      onClick={onLoadMore}
+                      disabled={loadingMore}
+                      className="w-full rounded-md border border-border/60 px-2.5 py-1.5 text-[12px] font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:pointer-events-none disabled:opacity-60"
+                    >
+                      {loadingMore ? "Loading…" : "Load more"}
+                    </button>
+                  </div>
+                ) : null}
+              </>
+            )}
+          </section>
+        )}
       </div>
     </div>
+  )
+}
+
+function SectionHeader({
+  label,
+  count,
+  collapsed,
+  onToggle,
+}: {
+  label: string
+  count: number
+  collapsed: boolean
+  onToggle: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={!collapsed}
+      data-boring-workspace-part="session-section-toggle"
+      className="flex w-full items-baseline justify-between gap-2 px-3.5 pb-2 pt-2 text-[11px] font-medium tracking-tight text-muted-foreground/75 transition-colors hover:text-foreground/80"
+    >
+      <span className="flex items-center gap-1">
+        <ChevronRight
+          aria-hidden="true"
+          className={cn("h-3 w-3 transition-transform duration-150", !collapsed && "rotate-90")}
+          strokeWidth={2}
+        />
+        {label}
+      </span>
+      <span aria-hidden="true" className="text-[10.5px] tabular-nums text-muted-foreground/40">{count}</span>
+    </button>
   )
 }
 
 function SessionRow({
   session,
   active,
+  open,
+  pinned,
+  working,
+  needsInput,
   onSwitch,
+  onOpenAsTab,
+  onTogglePin,
   onDelete,
 }: {
   session: SessionItem
   active: boolean
+  open: boolean
+  pinned: boolean
+  working: boolean
+  needsInput: boolean
   onSwitch?: (id: string) => void
+  onOpenAsTab?: (id: string) => void
+  onTogglePin?: (id: string) => void
   onDelete?: (id: string) => void
 }) {
   const time = relativeTime(session.updatedAt)
@@ -210,7 +420,25 @@ function SessionRow({
         active && "bg-foreground/[0.06] text-foreground",
       )}
       onClick={() => onSwitch?.(session.id)}
+      // Rows can be dragged onto the chat stage to open the session as a
+      // pane at the drop position (dock engine).
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.setData(CHAT_SESSION_DRAG_TYPE, session.id)
+        e.dataTransfer.setData("text/plain", session.title || session.id)
+        e.dataTransfer.effectAllowed = "copyMove"
+      }}
     >
+      {open && (
+        <span
+          aria-hidden="true"
+          data-boring-workspace-part="session-open-dot"
+          className={cn(
+            "h-1.5 w-1.5 shrink-0 rounded-full",
+            active ? "bg-foreground/70" : "bg-foreground/30",
+          )}
+        />
+      )}
       <span className="min-w-0 flex-1 truncate leading-5" title={session.title}>
         <span className={cn(active ? "font-medium text-foreground" : "text-foreground/90")}>
           {session.title || "Untitled"}
@@ -226,22 +454,87 @@ function SessionRow({
           </span>
         )}
       </span>
-      {onDelete && (
-        <IconButton
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          className="shrink-0 text-muted-foreground opacity-0 hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDelete(session.id)
-          }}
-          aria-label={`Delete ${session.title || "session"}`}
+      {needsInput ? (
+        <span
+          data-boring-workspace-part="session-badge"
+          data-boring-badge="needs-input"
+          className="inline-flex shrink-0 items-center gap-1 rounded-full bg-destructive/12 px-1.5 py-0.5 text-[10px] font-medium leading-none text-destructive"
         >
-          <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-            <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" />
-          </svg>
-        </IconButton>
+          <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-destructive" />
+          needs input
+        </span>
+      ) : working ? (
+        <span
+          data-boring-workspace-part="session-badge"
+          data-boring-badge="working"
+          className="inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
+        >
+          <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--accent)]" />
+          working
+        </span>
+      ) : null}
+      {onTogglePin && (
+        <ControlTooltip label={pinned ? "Unpin session" : "Pin session"}>
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            data-boring-workspace-part="session-pin-toggle"
+            data-boring-state={pinned ? "pinned" : undefined}
+            className={cn(
+              "shrink-0 focus-visible:opacity-100 group-hover:opacity-100",
+              // A pinned session keeps its pin lit so the state is legible;
+              // unpinned rows reveal the affordance on hover like the others.
+              pinned
+                ? "text-[color:var(--accent)] opacity-100 hover:text-[color:var(--accent)]"
+                : "text-muted-foreground/70 opacity-0 hover:text-foreground",
+            )}
+            onClick={(e) => {
+              e.stopPropagation()
+              onTogglePin(session.id)
+            }}
+            aria-label={pinned ? `Unpin ${session.title || "session"}` : `Pin ${session.title || "session"}`}
+            aria-pressed={pinned}
+          >
+            <Pin className={cn("h-3.5 w-3.5", pinned && "fill-current")} strokeWidth={1.75} />
+          </IconButton>
+        </ControlTooltip>
+      )}
+      {onOpenAsTab && (
+        <ControlTooltip label="Open in chat pane">
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="shrink-0 text-muted-foreground/70 opacity-0 hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+            onClick={(e) => {
+              e.stopPropagation()
+              onOpenAsTab(session.id)
+            }}
+            aria-label={`Open ${session.title || "session"} in chat pane`}
+          >
+            <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} />
+          </IconButton>
+        </ControlTooltip>
+      )}
+      {onDelete && (
+        <ControlTooltip label="Delete session">
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="shrink-0 text-muted-foreground opacity-0 hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
+            onClick={(e) => {
+              e.stopPropagation()
+              onDelete(session.id)
+            }}
+            aria-label={`Delete ${session.title || "session"}`}
+          >
+            <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+              <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" />
+            </svg>
+          </IconButton>
+        </ControlTooltip>
       )}
     </li>
   )

--- a/packages/workspace/src/front/chrome/session-list/__tests__/SessionBrowser.test.tsx
+++ b/packages/workspace/src/front/chrome/session-list/__tests__/SessionBrowser.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi } from "vitest"
-import { render, fireEvent, screen } from "@testing-library/react"
+import { act, render, fireEvent, screen } from "@testing-library/react"
+import { useEffect } from "react"
 import { SessionBrowser } from "../SessionBrowser"
+import { WorkspaceAttentionProvider, useWorkspaceAttention } from "../../../attention/WorkspaceAttentionProvider"
 import type { SessionItem } from "../../../components/SessionList"
 
 const now = Date.now()
@@ -64,6 +66,17 @@ describe("SessionBrowser", () => {
     expect(onSwitch).not.toHaveBeenCalled()
   })
 
+  it("opens a row as a separate pane without also switching the active pane", () => {
+    const onSwitch = vi.fn()
+    const onOpenAsTab = vi.fn()
+    render(<SessionBrowser sessions={sample} activeId="s1" onSwitch={onSwitch} onOpenAsTab={onOpenAsTab} />)
+
+    fireEvent.click(screen.getByLabelText("Open Second session in chat pane"))
+
+    expect(onOpenAsTab).toHaveBeenCalledWith("s2")
+    expect(onSwitch).not.toHaveBeenCalled()
+  })
+
   it("calls onLoadMore from the load-more footer", () => {
     const onLoadMore = vi.fn()
     render(<SessionBrowser sessions={sample} hasMore onLoadMore={onLoadMore} />)
@@ -74,5 +87,118 @@ describe("SessionBrowser", () => {
   it("renders empty state when no sessions are supplied", () => {
     render(<SessionBrowser sessions={[]} />)
     expect(screen.getByText(/No sessions yet/)).toBeInTheDocument()
+  })
+
+  it("splits open sessions into an Active section above history", () => {
+    render(<SessionBrowser sessions={sample} activeId="s1" openIds={["s1", "s3"]} />)
+
+    expect(screen.getByText("Active")).toBeInTheDocument()
+    expect(screen.getByText("History")).toBeInTheDocument()
+    const activeSection = document.querySelector('[data-boring-workspace-part="session-active-section"]')
+    expect(activeSection?.textContent).toContain("First session")
+    expect(activeSection?.textContent).toContain("Third session")
+    expect(activeSection?.textContent).not.toContain("Second session")
+    // Open rows carry the open indicator dot.
+    expect(activeSection?.querySelectorAll('[data-boring-workspace-part="session-open-dot"]')).toHaveLength(2)
+  })
+
+  it("collapses the Active and History sections", () => {
+    render(<SessionBrowser sessions={sample} activeId="s1" openIds={["s1"]} />)
+
+    fireEvent.click(screen.getByRole("button", { name: /Active/ }))
+    const activeSection = document.querySelector('[data-boring-workspace-part="session-active-section"]')
+    expect(activeSection?.querySelector("li")).toBeNull()
+
+    // History starts collapsed when panes are open; clicking it expands.
+    expect(screen.queryByText(/Second session/)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /History/ }))
+    expect(screen.getByText(/Second session/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: /History/ }))
+    expect(screen.queryByText(/Second session/)).not.toBeInTheDocument()
+  })
+
+  it("shows history expanded by default when no panes are open", () => {
+    render(<SessionBrowser sessions={sample} activeId="s1" />)
+    expect(screen.getByText(/Second session/)).toBeInTheDocument()
+  })
+
+  it("renders a Pinned section and toggles pin state", () => {
+    const onTogglePin = vi.fn()
+    // s1 open (Active, unpinned), s2 pinned.
+    render(
+      <SessionBrowser
+        sessions={sample}
+        activeId="s1"
+        openIds={["s1"]}
+        pinnedIds={["s2"]}
+        onTogglePin={onTogglePin}
+      />,
+    )
+
+    const pinnedSection = document.querySelector('[data-boring-workspace-part="session-pinned-section"]')
+    expect(pinnedSection).toBeInTheDocument()
+    expect(pinnedSection?.textContent).toContain("Second session")
+    // A pinned session shows its toggle in the pinned state, and a pinned
+    // session is pulled out of the Active section.
+    expect(pinnedSection?.querySelector('[data-boring-state="pinned"]')).toBeInTheDocument()
+    const activeSection = document.querySelector('[data-boring-workspace-part="session-active-section"]')
+    expect(activeSection?.textContent).not.toContain("Second session")
+
+    fireEvent.click(screen.getByRole("button", { name: /Unpin Second session/ }))
+    expect(onTogglePin).toHaveBeenCalledWith("s2")
+
+    // Pinning an un-pinned (Active) row.
+    fireEvent.click(screen.getByRole("button", { name: /^Pin First session/ }))
+    expect(onTogglePin).toHaveBeenCalledWith("s1")
+  })
+
+  it("shows a working badge while a session's chat panel streams", () => {
+    render(<SessionBrowser sessions={sample} activeId="s1" />)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("boring:chat-session-status", {
+        detail: { sessionId: "s2", working: true },
+      }))
+    })
+    const badge = document.querySelector('[data-boring-badge="working"]')
+    expect(badge).toBeInTheDocument()
+    expect(badge?.closest("li")?.textContent).toContain("Second session")
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("boring:chat-session-status", {
+        detail: { sessionId: "s2", working: false },
+      }))
+    })
+    expect(document.querySelector('[data-boring-badge="working"]')).toBeNull()
+  })
+
+  it("shows a needs-input badge for sessions blocked on the user", () => {
+    function BlockSession({ sessionId }: { sessionId: string }) {
+      const { addBlocker, removeBlocker } = useWorkspaceAttention()
+      useEffect(() => {
+        addBlocker({ id: `ask:${sessionId}`, reason: "waiting_for_user_input", sessionId })
+        return () => removeBlocker(`ask:${sessionId}`)
+      }, [addBlocker, removeBlocker, sessionId])
+      return null
+    }
+
+    render(
+      <WorkspaceAttentionProvider>
+        <BlockSession sessionId="s3" />
+        <SessionBrowser sessions={sample} activeId="s1" />
+      </WorkspaceAttentionProvider>,
+    )
+
+    // A blocked session outranks "working": send both signals for s3.
+    act(() => {
+      window.dispatchEvent(new CustomEvent("boring:chat-session-status", {
+        detail: { sessionId: "s3", working: true },
+      }))
+    })
+    const badge = document.querySelector('[data-boring-badge="needs-input"]')
+    expect(badge).toBeInTheDocument()
+    expect(badge?.closest("li")?.textContent).toContain("Third session")
+    expect(document.querySelector('[data-boring-badge="working"]')).toBeNull()
   })
 })

--- a/packages/workspace/src/front/chrome/session-list/definition.ts
+++ b/packages/workspace/src/front/chrome/session-list/definition.ts
@@ -6,7 +6,11 @@ import { SessionBrowser } from "./SessionBrowser"
 interface SessionListPaneParams {
   sessions?: SessionItem[]
   activeId?: string | null
+  openIds?: string[]
+  pinnedIds?: string[]
+  onTogglePin?: (id: string) => void
   onSwitch?: (id: string) => void
+  onOpenAsTab?: (id: string) => void
   onCreate?: () => void
   onDelete?: (id: string) => void
   onLoadMore?: () => void
@@ -19,7 +23,11 @@ function SessionListPane({ params }: PaneProps<SessionListPaneParams | undefined
   return createElement(SessionBrowser, {
     sessions: params?.sessions ?? [],
     activeId: params?.activeId,
+    openIds: params?.openIds,
+    pinnedIds: params?.pinnedIds,
+    onTogglePin: params?.onTogglePin,
     onSwitch: params?.onSwitch,
+    onOpenAsTab: params?.onOpenAsTab,
     onCreate: params?.onCreate,
     onDelete: params?.onDelete,
     onLoadMore: params?.onLoadMore,

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -13,6 +13,7 @@ import type { PaneProps } from "../registry/types"
 import { readStoredNumber, writeStoredNumber } from "../store/localStorageValues"
 import type { ChatLayoutProps } from "./types"
 import { useWorkspaceAttention, useWorkspaceContext } from "../provider"
+import { ChatPaneStage } from "./ChatPaneStage"
 
 export function buildChatLayout(props: ChatLayoutProps = {}): LayoutConfig {
   const {
@@ -110,6 +111,8 @@ export function ChatLayout(props: ChatLayoutProps) {
   const closeSurface = getCallback(props.surfaceParams, "onClose")
   const closeSidebar = getCallback(props.sidebarParams, "onClose")
   const createSession = getCallback(props.navParams, "onCreate")
+  const chatPanes = props.chatPanes?.filter((pane) => pane.id.length > 0) ?? []
+  const hasChatPanes = chatPanes.length > 0
   const sidebarOpen = Boolean(props.sidebar)
   const canControlNav = navOpen ? Boolean(closeNav) : Boolean(props.onOpenNav)
   const canControlSurface = surfaceOpen ? Boolean(closeSurface) : Boolean(props.onOpenSurface)
@@ -287,7 +290,7 @@ export function ChatLayout(props: ChatLayoutProps) {
   // Switching to a different session re-opens the chat if it was collapsed, so
   // the newly selected conversation is visible. Skips the initial mount (only
   // reacts to an actual change of the active session id).
-  const activeSessionId = props.centerParams?.sessionId as string | undefined
+  const activeSessionId = (props.activeChatPaneId ?? props.centerParams?.sessionId) as string | undefined
   const prevSessionIdRef = useRef(activeSessionId)
   useEffect(() => {
     const prev = prevSessionIdRef.current
@@ -373,16 +376,41 @@ export function ChatLayout(props: ChatLayoutProps) {
               chatCollapsed ? "opacity-0" : "opacity-100",
             )}
           >
-            <PanelSlot id={centerId} params={props.centerParams} />
+            {hasChatPanes ? (
+              <ChatPaneStage
+                panes={chatPanes}
+                activePaneId={props.activeChatPaneId}
+                onActivePaneChange={props.onActiveChatPaneChange}
+                onClosePane={props.onCloseChatPane}
+                flashPaneId={props.flashChatPaneId}
+                storageKey={props.storageKey}
+                onDropSession={props.onDropChatSession}
+                engine={props.chatPaneEngine}
+                renderPane={(pane) => (
+                  <PanelSlot
+                    id={pane.panel ?? centerId}
+                    params={pane.params ?? props.centerParams}
+                  />
+                )}
+              />
+            ) : (
+              <PanelSlot id={centerId} params={props.centerParams} />
+            )}
           </div>
           {!chatCollapsed ? (
-            <ControlTooltip label="Collapse chat" hint="⌘\\" side="bottom">
+            <ControlTooltip label="Collapse chat" hint="⌘\" side="bottom">
               <IconButton
                 type="button"
                 variant="ghost"
                 size="icon-xs"
                 onClick={toggleChatCollapsed}
-                className="absolute right-2 top-2 z-20"
+                // With multiple panes the rightmost pane header owns the
+                // top-right corner; drop the collapse control to the
+                // bottom-right so the two never overlap.
+                className={cn(
+                  "absolute right-2 z-30 rounded-full bg-background/80 text-muted-foreground shadow-sm backdrop-blur hover:bg-muted hover:text-foreground",
+                  hasChatPanes && chatPanes.length > 1 ? "bottom-2" : "top-2",
+                )}
                 aria-label="Collapse chat"
               >
                 <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
@@ -466,6 +494,20 @@ export function ChatLayout(props: ChatLayoutProps) {
           onClick={props.onOpenNav}
           label="Sessions"
           hint="⌘1"
+        />
+      ) : null}
+      {!chatCollapsed && !navOpen && hasChatPanes && props.onCreateChatPaneAfter ? (
+        <FloatingEdgeButton
+          side="left"
+          icon="plus"
+          onClick={() => {
+            const targetId = props.activeChatPaneId ?? chatPanes[chatPanes.length - 1]?.id
+            if (targetId) props.onCreateChatPaneAfter?.(targetId)
+          }}
+          label="New chat"
+          // Sits directly above the Sessions toggle; when the session drawer
+          // is open the drawer's own header "+" takes over and this hides.
+          stackIndex={props.onOpenNav ? 1 : 0}
         />
       ) : null}
       {chatCollapsed ? (
@@ -638,7 +680,11 @@ function getCallback(params: Record<string, unknown> | undefined, key: string): 
 
 function focusAgentComposer(): void {
   if (typeof document === "undefined") return
-  const textarea = document.querySelector<HTMLTextAreaElement>(
+  const activePane = document.querySelector<HTMLElement>(
+    '[data-boring-workspace-part="chat-pane"][data-boring-state="active"]',
+  )
+  const root: Document | HTMLElement = activePane ?? document
+  const textarea = root.querySelector<HTMLTextAreaElement>(
     '[data-boring-agent] textarea[name="message"], textarea[name="message"]',
   )
   textarea?.focus()
@@ -708,7 +754,7 @@ function FloatingEdgeButton({
   pulse = false,
 }: {
   side: "left" | "right"
-  icon: "sessions" | "workbench" | "chat"
+  icon: "sessions" | "workbench" | "chat" | "plus"
   onClick: () => void
   label: string
   hint?: string
@@ -755,6 +801,10 @@ function FloatingEdgeButton({
             <span className="absolute -right-1.5 -top-1.5 h-2 w-2 rounded-full bg-[color:var(--accent)]" aria-hidden="true" />
           ) : null}
         </span>
+      ) : icon === "plus" ? (
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
+        </svg>
       ) : (
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
           <path d="M3 7.5 A1.5 1.5 0 0 1 4.5 6 h4 l2 2 h9 A1.5 1.5 0 0 1 21 9.5 V17.5 A1.5 1.5 0 0 1 19.5 19 H4.5 A1.5 1.5 0 0 1 3 17.5 Z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />

--- a/packages/workspace/src/front/layout/ChatPaneStage.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStage.tsx
@@ -1,0 +1,99 @@
+import type { ReactNode } from "react"
+import { cn } from "../lib/utils"
+import { ChatPaneStageDock } from "./ChatPaneStageDock"
+import { ChatPaneStageFlex } from "./ChatPaneStageFlex"
+
+export interface ChatPaneDescriptor {
+  id: string
+  title?: string | null
+  panel?: string
+  params?: Record<string, unknown>
+}
+
+/**
+ * Layout engine for the chat pane stage.
+ *
+ * - `flex` (default): panes lay out as a single row of vertical splits.
+ * - `dock`: dockview-backed stage — drag pane headers to split in any
+ *   direction and resize; geometry persists per workspace.
+ *
+ * Resolution order: explicit prop, then the
+ * `boring-workspace:chat-pane-engine` localStorage override, then `flex`.
+ */
+export type ChatPaneEngine = "flex" | "dock"
+
+const ENGINE_STORAGE_KEY = "boring-workspace:chat-pane-engine"
+
+export function resolveChatPaneEngine(preferred?: ChatPaneEngine | null): ChatPaneEngine {
+  if (preferred === "dock" || preferred === "flex") return preferred
+  try {
+    const stored = globalThis.localStorage?.getItem(ENGINE_STORAGE_KEY)
+    if (stored === "dock" || stored === "flex") return stored
+  } catch {
+    // Storage may be unavailable; fall through to the default.
+  }
+  return "flex"
+}
+
+export interface ChatPaneStageProps {
+  panes: ChatPaneDescriptor[]
+  activePaneId?: string | null
+  renderPane: (pane: ChatPaneDescriptor) => ReactNode
+  onActivePaneChange?: (id: string) => void
+  onClosePane?: (id: string) => void
+  /**
+   * Pane to flash with a brief highlight ring — feedback when an action
+   * targets a pane that is already visible (e.g. "open as pane" on an open
+   * session). The parent clears it after a beat; the fade-out is CSS.
+   */
+  flashPaneId?: string | null
+  /**
+   * Dock engine only: persist the dockview layout (splits, sizes) under
+   * `${storageKey}:chatPaneLayout`.
+   */
+  storageKey?: string
+  /**
+   * Called when a session is dropped onto the stage (drag a session-browser
+   * row in). The parent opens the session as a pane; the dock engine places
+   * it where it was dropped.
+   */
+  onDropSession?: (sessionId: string) => void
+  engine?: ChatPaneEngine | null
+}
+
+export function ChatPaneStage({ engine, ...props }: ChatPaneStageProps) {
+  return resolveChatPaneEngine(engine) === "dock"
+    ? <ChatPaneStageDock {...props} />
+    : <ChatPaneStageFlex {...props} />
+}
+
+export function paneTitle(pane: { title?: string | null }): string {
+  return pane.title || "Untitled"
+}
+
+/**
+ * DataTransfer type for dragging a chat session (e.g. a session-browser row)
+ * into the chat stage. The payload is the session id.
+ */
+export const CHAT_SESSION_DRAG_TYPE = "application/x-boring-chat-session"
+
+/**
+ * The pane focus treatment shared by both engines: the selected chat stays
+ * white while the others recede behind a faint grey wash — no border on the
+ * active pane, the background contrast alone marks the selection. Flash is a
+ * stronger transient ring for open-as-pane feedback.
+ */
+export function PaneFocusRing({ dimmed, flash }: { active?: boolean; dimmed: boolean; flash: boolean }) {
+  return (
+    <div
+      aria-hidden="true"
+      data-boring-workspace-part="chat-pane-focus-ring"
+      className={cn(
+        "pointer-events-none absolute inset-0 z-30",
+        "transition-[background-color,box-shadow] duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+        dimmed && !flash && "bg-[color:oklch(from_var(--foreground)_l_c_h/0.035)]",
+        flash && "shadow-[inset_0_0_0_2px_oklch(from_var(--foreground)_l_c_h/0.55)]",
+      )}
+    />
+  )
+}

--- a/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
@@ -1,0 +1,418 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import {
+  DockviewReact,
+  type DockviewApi,
+  type DockviewReadyEvent,
+  type IDockviewPanelHeaderProps,
+  type IDockviewPanelProps,
+} from "dockview-react"
+import "dockview-react/dist/styles/dockview.css"
+import "../dock/dockview-overrides.css"
+import "./chat-pane-stage.css"
+import { GripVertical, X } from "lucide-react"
+import { IconButton } from "@hachej/boring-ui-kit"
+import { cn } from "../lib/utils"
+import { ControlTooltip } from "../components/ControlTooltip"
+import { CHAT_SESSION_DRAG_TYPE, PaneFocusRing, paneTitle, type ChatPaneDescriptor, type ChatPaneStageProps } from "./ChatPaneStage"
+
+type ChatPaneStageDockProps = Omit<ChatPaneStageProps, "engine">
+
+const CHAT_PANE_COMPONENT = "chat-pane"
+const PANE_MIN_WIDTH = 280
+const PERSIST_DEBOUNCE_MS = 300
+
+interface StageContextValue {
+  panes: ChatPaneDescriptor[]
+  activePaneId: string | null
+  flashPaneId: string | null
+  renderPane: ChatPaneStageProps["renderPane"]
+  onActivePaneChange?: (id: string) => void
+  onClosePane?: (id: string) => void
+}
+
+const StageContext = createContext<StageContextValue | null>(null)
+
+function layoutStorageKey(storageKey: string): string {
+  return `${storageKey}:chatPaneLayout`
+}
+
+type DropDirection = "left" | "right" | "above" | "below" | "within"
+
+interface PendingPlacement {
+  referencePanelId: string | null
+  direction: DropDirection
+}
+
+function dropPositionToDirection(position: string): DropDirection {
+  switch (position) {
+    case "left": return "left"
+    case "right": return "right"
+    case "top": return "above"
+    case "bottom": return "below"
+    default: return "within"
+  }
+}
+
+interface SerializedDockLayout {
+  grid?: unknown
+  panels?: Record<string, unknown>
+}
+
+function readStoredLayout(storageKey: string, paneIds: string[]): SerializedDockLayout | null {
+  try {
+    const raw = globalThis.localStorage?.getItem(layoutStorageKey(storageKey))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as SerializedDockLayout
+    const storedIds = Object.keys(parsed.panels ?? {})
+    if (storedIds.length !== paneIds.length) return null
+    const wanted = new Set(paneIds)
+    if (!storedIds.every((id) => wanted.has(id))) return null
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+function writeStoredLayout(storageKey: string, layout: unknown): void {
+  try {
+    globalThis.localStorage?.setItem(layoutStorageKey(storageKey), JSON.stringify(layout))
+  } catch {
+    // Best-effort persistence only.
+  }
+}
+
+function addChatPanel(
+  api: DockviewApi,
+  pane: ChatPaneDescriptor,
+  position: Parameters<DockviewApi["addPanel"]>[0]["position"],
+): void {
+  const panel = api.addPanel({
+    id: pane.id,
+    component: CHAT_PANE_COMPONENT,
+    title: paneTitle(pane),
+    params: { paneId: pane.id },
+    position,
+  })
+  panel.group?.api.setConstraints({ minimumWidth: PANE_MIN_WIDTH })
+}
+
+/**
+ * Project the authoritative pane list onto the dockview layout: remove
+ * panels whose session pane closed, add new ones next to their list
+ * neighbour, keep titles fresh, and align the active panel. Geometry that
+ * the user arranged (splits, sizes) is dockview's to keep.
+ */
+function syncPanesToDock(
+  api: DockviewApi,
+  panes: ChatPaneDescriptor[],
+  activePaneId: string | null,
+  pendingPlacements?: Map<string, PendingPlacement>,
+): void {
+  const wanted = new Map(panes.map((pane) => [pane.id, pane]))
+  for (const panel of [...api.panels]) {
+    if (!wanted.has(panel.id)) api.removePanel(panel)
+  }
+  panes.forEach((pane, index) => {
+    if (api.getPanel(pane.id)) return
+    const placement = pendingPlacements?.get(pane.id)
+    if (placement) {
+      pendingPlacements?.delete(pane.id)
+      const reference = placement.referencePanelId ? api.getPanel(placement.referencePanelId) : undefined
+      addChatPanel(
+        api,
+        pane,
+        reference
+          ? { referencePanel: reference, direction: placement.direction }
+          : { direction: placement.direction === "within" ? "right" : placement.direction },
+      )
+      return
+    }
+    const before = index > 0 ? api.getPanel(panes[index - 1].id) : undefined
+    const after = !before && index + 1 < panes.length ? api.getPanel(panes[index + 1].id) : undefined
+    addChatPanel(
+      api,
+      pane,
+      before
+        ? { referencePanel: before, direction: "right" }
+        : after
+          ? { referencePanel: after, direction: "left" }
+          : undefined,
+    )
+  })
+  for (const pane of panes) {
+    const panel = api.getPanel(pane.id)
+    if (panel && panel.title !== paneTitle(pane)) panel.api.setTitle(paneTitle(pane))
+  }
+  if (activePaneId) {
+    const panel = api.getPanel(activePaneId)
+    if (panel && api.activePanel?.id !== activePaneId) panel.api.setActive()
+  }
+}
+
+/** Dockview-backed chat stage: drag pane headers to split in any direction. */
+export function ChatPaneStageDock({
+  panes,
+  activePaneId,
+  renderPane,
+  onActivePaneChange,
+  onClosePane,
+  flashPaneId,
+  storageKey,
+  onDropSession,
+}: ChatPaneStageDockProps) {
+  const apiRef = useRef<DockviewApi | null>(null)
+  // True while this component mutates dockview itself; dockview activation
+  // events fired during programmatic sync must not echo back to the parent.
+  const syncingRef = useRef(false)
+  const disposeRef = useRef<(() => void) | null>(null)
+  // Drop placements recorded by onDidDrop, consumed by the next pane sync
+  // so a dropped session's panel appears where it was dropped.
+  const pendingPlacementsRef = useRef(new Map<string, PendingPlacement>())
+
+  const latestRef = useRef({ panes, activePaneId: activePaneId ?? null, onActivePaneChange, onDropSession, storageKey })
+  latestRef.current = { panes, activePaneId: activePaneId ?? null, onActivePaneChange, onDropSession, storageKey }
+
+  const resolvedActiveId = activePaneId ?? panes[0]?.id ?? null
+
+  const contextValue = useMemo<StageContextValue>(() => ({
+    panes,
+    activePaneId: resolvedActiveId,
+    flashPaneId: flashPaneId ?? null,
+    renderPane,
+    onActivePaneChange,
+    onClosePane: panes.length > 1 ? onClosePane : undefined,
+  }), [panes, resolvedActiveId, flashPaneId, renderPane, onActivePaneChange, onClosePane])
+
+  const handleReady = useCallback((event: DockviewReadyEvent) => {
+    const api = event.api
+    apiRef.current = api
+    const { panes: currentPanes, activePaneId: currentActive, storageKey: currentKey } = latestRef.current
+
+    syncingRef.current = true
+    try {
+      const stored = currentKey ? readStoredLayout(currentKey, currentPanes.map((pane) => pane.id)) : null
+      if (stored) {
+        try {
+          api.fromJSON(stored as Parameters<DockviewApi["fromJSON"]>[0])
+        } catch {
+          // A stale/incompatible layout must never block the chat stage.
+        }
+      }
+      syncPanesToDock(api, currentPanes, currentActive, pendingPlacementsRef.current)
+    } finally {
+      syncingRef.current = false
+    }
+
+    const activeDisposable = api.onDidActivePanelChange((panel) => {
+      if (syncingRef.current) return
+      const id = panel?.id
+      if (id && id !== latestRef.current.activePaneId) {
+        latestRef.current.onActivePaneChange?.(id)
+      }
+    })
+
+    // Panes split, they don't stack: veto tab-strip and center drops so a
+    // drag can only dock to pane edges.
+    const overlayDisposable = api.onWillShowOverlay((overlayEvent) => {
+      if (overlayEvent.kind === "tab" || overlayEvent.kind === "header_space") {
+        overlayEvent.preventDefault()
+        return
+      }
+      if (overlayEvent.kind === "content" && overlayEvent.position === "center") {
+        overlayEvent.preventDefault()
+      }
+    })
+
+    // Accept session rows dragged in from outside the dock (the session
+    // browser). The drop opens the session as a pane at the drop position.
+    const dragOverDisposable = api.onUnhandledDragOverEvent((dragEvent) => {
+      const types = dragEvent.nativeEvent.dataTransfer?.types
+      if (types && Array.from(types).includes(CHAT_SESSION_DRAG_TYPE)) dragEvent.accept()
+    })
+    const dropDisposable = api.onDidDrop((dropEvent) => {
+      const sessionId = dropEvent.nativeEvent.dataTransfer?.getData(CHAT_SESSION_DRAG_TYPE)
+      if (!sessionId) return
+      pendingPlacementsRef.current.set(sessionId, {
+        referencePanelId: dropEvent.group?.activePanel?.id ?? null,
+        direction: dropPositionToDirection(dropEvent.position),
+      })
+      latestRef.current.onDropSession?.(sessionId)
+    })
+
+    let persistTimer: ReturnType<typeof setTimeout> | null = null
+    const layoutDisposable = api.onDidLayoutChange(() => {
+      const key = latestRef.current.storageKey
+      if (!key) return
+      if (persistTimer) clearTimeout(persistTimer)
+      persistTimer = setTimeout(() => writeStoredLayout(key, api.toJSON()), PERSIST_DEBOUNCE_MS)
+    })
+
+    disposeRef.current = () => {
+      if (persistTimer) clearTimeout(persistTimer)
+      activeDisposable.dispose()
+      overlayDisposable.dispose()
+      dragOverDisposable.dispose()
+      dropDisposable.dispose()
+      layoutDisposable.dispose()
+    }
+  }, [])
+
+  useEffect(() => () => disposeRef.current?.(), [])
+
+  useEffect(() => {
+    const api = apiRef.current
+    if (!api) return
+    syncingRef.current = true
+    try {
+      syncPanesToDock(api, panes, resolvedActiveId, pendingPlacementsRef.current)
+    } finally {
+      syncingRef.current = false
+    }
+  }, [panes, resolvedActiveId])
+
+  if (panes.length === 0) return null
+
+  return (
+    <StageContext.Provider value={contextValue}>
+      <div
+        data-boring-workspace-part="chat-pane-stage"
+        data-multi-pane={panes.length > 1 ? "true" : "false"}
+        className="relative h-full min-h-0 w-full bg-background"
+      >
+        <DockviewReact
+          className="dv-shell dv-chat-stage h-full"
+          components={STAGE_COMPONENTS}
+          defaultTabComponent={ChatPaneHeader as React.FunctionComponent<IDockviewPanelHeaderProps>}
+          // Groups always hold exactly one pane (center drops are vetoed),
+          // so the single header stretches across the full group width and
+          // reads as a flat pane header, not a tab.
+          singleTabMode="fullwidth"
+          onReady={handleReady}
+        />
+      </div>
+    </StageContext.Provider>
+  )
+}
+
+function useStage(): StageContextValue {
+  const value = useContext(StageContext)
+  if (!value) throw new Error("Chat pane components must render inside ChatPaneStageDock")
+  return value
+}
+
+function ChatPanePanel(props: IDockviewPanelProps) {
+  const stage = useStage()
+  const paneId = typeof (props.params as { paneId?: unknown })?.paneId === "string"
+    ? (props.params as { paneId: string }).paneId
+    : props.api.id
+  const pane = stage.panes.find((candidate) => candidate.id === paneId)
+  if (!pane) return null
+
+  const active = paneId === stage.activePaneId
+  const flash = paneId === stage.flashPaneId
+  return (
+    <div
+      data-boring-workspace-part="chat-pane"
+      data-boring-state={active ? "active" : "inactive"}
+      aria-label={`Chat session ${paneTitle(pane)}`}
+      className="relative flex h-full min-h-0 w-full flex-col overflow-hidden bg-background"
+      onMouseDown={(event) => {
+        const target = event.target instanceof HTMLElement ? event.target : null
+        if (target?.closest('[data-boring-workspace-part="chat-pane-control"]')) return
+        stage.onActivePaneChange?.(paneId)
+      }}
+      onFocusCapture={(event) => {
+        const target = event.target instanceof HTMLElement ? event.target : null
+        if (target?.closest('[data-boring-workspace-part="chat-pane-control"]')) return
+        stage.onActivePaneChange?.(paneId)
+      }}
+    >
+      {/* The active ring lives at the dockview group level (CSS) so it wraps
+          the header too; this inner ring only serves the flash pulse. */}
+      <PaneFocusRing active={false} dimmed={false} flash={flash} />
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {stage.renderPane(pane)}
+      </div>
+    </div>
+  )
+}
+
+const STAGE_COMPONENTS: Record<string, React.FunctionComponent<IDockviewPanelProps>> = {
+  [CHAT_PANE_COMPONENT]: ChatPanePanel,
+}
+
+/**
+ * Flat pane header — not a tab. The whole bar is dockview's drag handle;
+ * the grip is the visual affordance for it, the X closes the view.
+ */
+function ChatPaneHeader(props: IDockviewPanelHeaderProps) {
+  const stage = useStage()
+  const { api } = props
+  const [title, setTitle] = useState(api.title ?? api.id)
+
+  useEffect(() => {
+    const sync = () => setTitle(api.title ?? api.id)
+    sync()
+    const sub = api.onDidTitleChange?.(sync)
+    return () => sub?.dispose?.()
+  }, [api])
+
+  // With a single pane there is nothing to move or close — show a plain
+  // title bar without the drag grip and close control.
+  const multiPane = stage.panes.length > 1
+  const canClose = Boolean(stage.onClosePane)
+  return (
+    <div
+      className={cn(
+        "group flex h-full w-full min-w-0 select-none items-center gap-1.5 px-2 text-[12px] font-medium leading-none tracking-tight",
+        multiPane && "cursor-grab active:cursor-grabbing",
+      )}
+      title={title}
+    >
+      {multiPane ? (
+        <GripVertical
+          aria-hidden="true"
+          data-boring-workspace-part="chat-pane-grip"
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground/45 transition-colors group-hover:text-muted-foreground"
+          strokeWidth={1.75}
+        />
+      ) : null}
+      <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-foreground/70">
+        {title}
+      </span>
+      {canClose ? (
+        <ControlTooltip label="Close pane" side="bottom">
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            data-boring-workspace-part="chat-pane-control"
+            className="h-5 w-5 shrink-0 text-muted-foreground/80 opacity-0 focus-visible:opacity-100 group-hover:opacity-100 [.dv-active-tab_&]:opacity-55 [.dv-active-tab_&]:hover:opacity-100"
+            // Dockview activates a panel from a NATIVE pointerdown listener on
+            // the tab wrapper (an ancestor of this button). React's capture
+            // handlers run at root-capture, before that bubble listener — stop
+            // the native event there so closing a pane never activates it.
+            onPointerDownCapture={(event) => event.nativeEvent.stopPropagation()}
+            onMouseDownCapture={(event) => event.nativeEvent.stopPropagation()}
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              stage.onClosePane?.(api.id)
+            }}
+            aria-label={`Close ${title} pane`}
+          >
+            <X className="h-3 w-3" strokeWidth={2.25} />
+          </IconButton>
+        </ControlTooltip>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/workspace/src/front/layout/ChatPaneStageFlex.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageFlex.tsx
@@ -1,0 +1,145 @@
+import { Fragment, useEffect, useRef, useState } from "react"
+import { X } from "lucide-react"
+import { IconButton } from "@hachej/boring-ui-kit"
+import { cn } from "../lib/utils"
+import { ControlTooltip } from "../components/ControlTooltip"
+import { PaneFocusRing, paneTitle, type ChatPaneDescriptor, type ChatPaneStageProps } from "./ChatPaneStage"
+
+type ChatPaneStageFlexProps = Omit<ChatPaneStageProps, "engine">
+
+/** Default chat stage: a single row of vertical splits, no drag. */
+export function ChatPaneStageFlex({
+  panes,
+  activePaneId,
+  renderPane,
+  onActivePaneChange,
+  onClosePane,
+  flashPaneId,
+}: ChatPaneStageFlexProps) {
+  // Panes present on the stage's first render must not play the enter
+  // animation (a page load would animate every pane in from zero width).
+  const stageMountedRef = useRef(false)
+  useEffect(() => {
+    stageMountedRef.current = true
+  }, [])
+
+  if (panes.length === 0) return null
+
+  return (
+    <div
+      data-boring-workspace-part="chat-pane-stage"
+      className="relative flex h-full min-h-0 w-full overflow-x-auto overflow-y-hidden bg-background"
+    >
+      {panes.map((pane, index) => (
+        <Fragment key={pane.id}>
+          {index > 0 ? (
+            <div
+              data-boring-workspace-part="chat-pane-divider"
+              className="w-px shrink-0 self-stretch bg-[color:oklch(from_var(--border)_l_c_h/0.7)]"
+            />
+          ) : null}
+          <ChatPane
+            pane={pane}
+            active={pane.id === activePaneId || (!activePaneId && index === 0)}
+            flash={pane.id === flashPaneId}
+            multiPane={panes.length > 1}
+            animateIn={stageMountedRef.current}
+            renderPane={renderPane}
+            onActivePaneChange={onActivePaneChange}
+            onClosePane={onClosePane}
+          />
+        </Fragment>
+      ))}
+    </div>
+  )
+}
+
+function ChatPane({
+  pane,
+  active,
+  flash,
+  multiPane,
+  animateIn,
+  renderPane,
+  onActivePaneChange,
+  onClosePane,
+}: {
+  pane: ChatPaneDescriptor
+  active: boolean
+  flash: boolean
+  multiPane: boolean
+  animateIn: boolean
+  renderPane: (pane: ChatPaneDescriptor) => React.ReactNode
+  onActivePaneChange?: (id: string) => void
+  onClosePane?: (id: string) => void
+}) {
+  // Enter animation: start collapsed, expand to the normal flex basis on the
+  // next frame. Panes restored on initial load mount at full size directly.
+  const [entered, setEntered] = useState(!animateIn)
+  useEffect(() => {
+    if (entered) return
+    const raf = requestAnimationFrame(() => setEntered(true))
+    return () => cancelAnimationFrame(raf)
+  }, [entered])
+
+  const title = paneTitle(pane)
+  return (
+    <div
+      data-boring-workspace-part="chat-pane"
+      data-boring-state={active ? "active" : "inactive"}
+      aria-label={`Chat session ${title}`}
+      className={cn(
+        "group/chat-pane relative flex h-full flex-col overflow-hidden bg-background",
+        "transition-[flex-grow,flex-basis,min-width] duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
+        entered ? "min-w-[350px] flex-[1_0_350px]" : "min-w-0 flex-[0_0_0px]",
+      )}
+      onMouseDown={() => onActivePaneChange?.(pane.id)}
+      onFocusCapture={(event) => {
+        const target = event.target instanceof HTMLElement ? event.target : null
+        if (target?.closest('[data-boring-workspace-part="chat-pane-control"]')) return
+        onActivePaneChange?.(pane.id)
+      }}
+    >
+      <PaneFocusRing active={multiPane && active} dimmed={multiPane && !active} flash={flash} />
+      <div
+        data-boring-workspace-part="chat-pane-header"
+        // Seamless with the content: no separating border, no tint — the
+        // full-pane focus ring is the active indicator.
+        className="flex h-8 shrink-0 items-center justify-between bg-background px-2"
+      >
+        <div className="flex min-w-0 items-center gap-1.5 px-1">
+          <span
+            className={cn(
+              "truncate text-[12px] font-medium",
+              !multiPane || active ? "text-foreground/70" : "text-foreground/40",
+            )}
+          >
+            {title}
+          </span>
+        </div>
+        {multiPane ? (
+          <ControlTooltip label="Close pane" side="bottom">
+            <IconButton
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              data-boring-workspace-part="chat-pane-control"
+              className="text-muted-foreground hover:text-foreground"
+              onMouseDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation()
+                onClosePane?.(pane.id)
+              }}
+              aria-label={`Close ${title} pane`}
+            >
+              <X className="h-3.5 w-3.5" strokeWidth={1.75} />
+            </IconButton>
+          </ControlTooltip>
+        ) : null}
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {renderPane(pane)}
+      </div>
+    </div>
+  )
+}

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -615,6 +615,150 @@ describe("ChatLayout component", () => {
     expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded")
   })
 
+  it("renders chat panes with active focus state and pane-level controls", async () => {
+    const user = userEvent.setup()
+    const setActive = vi.fn()
+    const closePane = vi.fn()
+    const createAfter = vi.fn()
+
+    renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        nav={null}
+        chatPanes={[
+          { id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } },
+          { id: "s2", title: "Second", panel: "chat", params: { sessionId: "s2" } },
+        ]}
+        activeChatPaneId="s2"
+        onActiveChatPaneChange={setActive}
+        onCloseChatPane={closePane}
+        onCreateChatPaneAfter={createAfter}
+      />,
+      ["chat", "session-list"],
+    )
+
+    expect(screen.getByLabelText("Chat session First")).toHaveAttribute("data-boring-state", "inactive")
+    expect(screen.getByLabelText("Chat session Second")).toHaveAttribute("data-boring-state", "active")
+    // Default engine is the flex row; the dock engine is behind the flag.
+    expect(document.querySelector('[data-boring-workspace-part="chat-pane-stage"]')?.className).toContain("overflow-x-auto")
+    expect(document.querySelector(".dv-chat-stage")).toBeNull()
+    expect(screen.getByRole("button", { name: "New chat" })).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText("Chat session First"))
+    expect(setActive).toHaveBeenCalledWith("s1")
+
+    await user.click(screen.getByLabelText("Close Second pane"))
+    expect(closePane).toHaveBeenCalledWith("s2")
+
+    // The floating left-edge "+" creates next to the active pane.
+    await user.click(screen.getByRole("button", { name: "New chat" }))
+    expect(createAfter).toHaveBeenCalledWith("s2")
+  })
+
+  it("renders the dockview chat stage when the dock engine flag is set", async () => {
+    const user = userEvent.setup()
+    const closePane = vi.fn()
+
+    renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        chatPanes={[
+          { id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } },
+          { id: "s2", title: "Second", panel: "chat", params: { sessionId: "s2" } },
+        ]}
+        activeChatPaneId="s2"
+        onCloseChatPane={closePane}
+        chatPaneEngine="dock"
+      />,
+      ["chat", "session-list"],
+    )
+
+    expect(document.querySelector(".dv-chat-stage")).not.toBeNull()
+    expect(screen.getByLabelText("Chat session Second")).toHaveAttribute("data-boring-state", "active")
+
+    await user.click(screen.getByLabelText("Close Second pane"))
+    expect(closePane).toHaveBeenCalledWith("s2")
+  })
+
+  it("reads the dock engine flag from localStorage when no prop is set", () => {
+    localStorage.setItem("boring-workspace:chat-pane-engine", "dock")
+    try {
+      renderWithRegistry(
+        <ChatLayout
+          center="chat"
+          chatPanes={[{ id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } }]}
+          activeChatPaneId="s1"
+        />,
+        ["chat", "session-list"],
+      )
+      expect(document.querySelector(".dv-chat-stage")).not.toBeNull()
+    } finally {
+      localStorage.removeItem("boring-workspace:chat-pane-engine")
+    }
+  })
+
+  it("does not activate an inactive pane when using its header controls", async () => {
+    const user = userEvent.setup()
+    const setActive = vi.fn()
+    const closePane = vi.fn()
+    const createAfter = vi.fn()
+
+    renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        nav={null}
+        chatPanes={[
+          { id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } },
+          { id: "s2", title: "Second", panel: "chat", params: { sessionId: "s2" } },
+        ]}
+        activeChatPaneId="s2"
+        onActiveChatPaneChange={setActive}
+        onCloseChatPane={closePane}
+        onCreateChatPaneAfter={createAfter}
+      />,
+      ["chat", "session-list"],
+    )
+
+    await user.click(screen.getByLabelText("Close First pane"))
+    expect(closePane).toHaveBeenCalledWith("s1")
+    expect(setActive).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "New chat" }))
+    expect(createAfter).toHaveBeenCalledWith("s2")
+    expect(setActive).not.toHaveBeenCalled()
+  })
+
+  it("keeps the collapse control with a single chat pane", () => {
+    renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        chatPanes={[
+          { id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } },
+        ]}
+        activeChatPaneId="s1"
+      />,
+      ["chat", "session-list"],
+    )
+
+    expect(screen.getByRole("button", { name: "Collapse chat" })).toBeInTheDocument()
+  })
+
+  it("keeps the collapse control with multiple chat panes", () => {
+    renderWithRegistry(
+      <ChatLayout
+        center="chat"
+        chatPanes={[
+          { id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } },
+          { id: "s2", title: "Second", panel: "chat", params: { sessionId: "s2" } },
+        ]}
+        activeChatPaneId="s1"
+      />,
+      ["chat", "session-list"],
+    )
+
+    expect(screen.getByRole("button", { name: "Collapse chat" })).toBeInTheDocument()
+  })
+
   it("stacks the floating expand-chat button above the sessions button on the left edge", () => {
     renderWithRegistry(
       <ChatLayout center="chat" nav={null} onOpenNav={vi.fn()} storageKey="chat-layout-stack" />,

--- a/packages/workspace/src/front/layout/chat-pane-stage.css
+++ b/packages/workspace/src/front/layout/chat-pane-stage.css
@@ -1,0 +1,84 @@
+/* Chat pane stage — compact dockview chrome scoped under .dv-chat-stage.
+   Inherits the token mapping from dockview-overrides.css (.dv-shell). */
+
+.dv-chat-stage {
+  --dv-tabs-and-actions-container-height: 32px;
+  --dv-tabs-and-actions-container-font-size: 0.75rem;
+
+  /* Panes, not tabs: no pill — the header shares the pane background and
+     blends seamlessly into the content (no separating border). */
+  --dv-activegroup-visiblepanel-tab-background-color: transparent;
+  --dv-activegroup-hiddenpanel-tab-background-color: transparent;
+  --dv-inactivegroup-visiblepanel-tab-background-color: transparent;
+  --dv-inactivegroup-hiddenpanel-tab-background-color: transparent;
+}
+
+/* Neutralize the workbench pill-tab chrome (.dv-shell .dv-tab in
+   dockview-overrides.css): no rounded corners, no active-tab border or
+   accent, no header underline, no tab sizing caps. The double class on
+   the stage root (.dv-shell.dv-chat-stage) out-specifies the workbench
+   rules; the header must read as part of the pane, not a tab strip. */
+.dv-shell.dv-chat-stage .dv-tabs-and-actions-container {
+  border-bottom: none;
+  padding: 0;
+  gap: 0;
+  align-items: stretch;
+}
+
+/* dockview's fullwidth single-tab rules stop at the scroll wrapper; carry
+   the full width down to the tab itself. */
+.dv-shell.dv-chat-stage .dv-tabs-and-actions-container.dv-single-tab .dv-tabs-container {
+  width: 100%;
+}
+
+.dv-shell.dv-chat-stage .dv-tab,
+.dv-shell.dv-chat-stage .dv-tab.dv-active-tab {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  max-width: none;
+  flex: 1 1 auto;
+  align-self: stretch;
+  margin-bottom: 0;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background-color: transparent !important;
+}
+
+.dv-shell.dv-chat-stage .dv-tab.dv-active-tab::before {
+  content: none;
+}
+
+/* The chat stage hides dockview's built-in tab close icon entirely — the
+   custom header renders its own close control with pane semantics. */
+.dv-chat-stage .dv-default-tab-action {
+  display: none;
+}
+
+/* Active-pane focus ring drawn at the GROUP level so it wraps the whole
+   pane — header included. Always present but transparent, so activation
+   fades instead of popping. Only meaningful with 2+ panes; the stage
+   wrapper gates it via data-multi-pane. */
+.dv-chat-stage .dv-groupview {
+  position: relative;
+}
+
+.dv-chat-stage .dv-groupview::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 40;
+  pointer-events: none;
+  background: transparent;
+  transition: background-color 220ms cubic-bezier(0.22, 1, 0.36, 1),
+    box-shadow 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* The selected chat stays white; the others recede behind a faint grey
+   wash. No border on the active pane — the background contrast alone marks
+   the selection. */
+[data-boring-workspace-part="chat-pane-stage"][data-multi-pane="true"]
+  .dv-groupview:not(.dv-active-group)::after {
+  background: oklch(from var(--foreground) l c h / 0.035);
+}

--- a/packages/workspace/src/front/layout/types.ts
+++ b/packages/workspace/src/front/layout/types.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react"
+import type { ChatPaneDescriptor, ChatPaneEngine } from "./ChatPaneStage"
 
 export interface IdeLayoutProps {
   sidebar?: string
@@ -12,6 +13,20 @@ export interface ChatLayoutProps {
   navParams?: Record<string, unknown>
   center?: string
   centerParams?: Record<string, unknown>
+  chatPanes?: ChatPaneDescriptor[]
+  activeChatPaneId?: string | null
+  onActiveChatPaneChange?: (id: string) => void
+  onCloseChatPane?: (id: string) => void
+  onCreateChatPaneAfter?: (id: string) => void
+  onDropChatSession?: (sessionId: string) => void
+  flashChatPaneId?: string | null
+  /**
+   * Chat stage layout engine. `dock` enables the dockview-backed stage
+   * (drag headers to split in any direction); defaults to the flex row.
+   * The `boring-workspace:chat-pane-engine` localStorage key overrides
+   * when no explicit value is passed.
+   */
+  chatPaneEngine?: ChatPaneEngine | null
   surface?: string | null
   surfaceParams?: Record<string, unknown>
   surfaceOverlay?: ReactNode

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -327,3 +327,52 @@
 }
 .tiptap-prose strong { font-weight: 600; }
 .tiptap-prose mark { background-color: oklch(from var(--accent) l c h / 0.2); color: inherit; padding: 0 2px; border-radius: 2px; }
+
+/* Discreet scrollbar — thin, dim, and only tinted on hover. Applied to
+   workspace chrome scroll regions (session list, etc.). */
+.boring-scrollbar-discreet {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(from var(--foreground) l c h / 0.14) transparent;
+}
+.boring-scrollbar-discreet::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.boring-scrollbar-discreet::-webkit-scrollbar-track {
+  background: transparent;
+}
+.boring-scrollbar-discreet::-webkit-scrollbar-thumb {
+  background-color: oklch(from var(--foreground) l c h / 0.12);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+.boring-scrollbar-discreet:hover::-webkit-scrollbar-thumb {
+  background-color: oklch(from var(--foreground) l c h / 0.22);
+}
+.boring-scrollbar-discreet::-webkit-scrollbar-thumb:hover {
+  background-color: oklch(from var(--foreground) l c h / 0.34);
+}
+
+/* Apply the discreet treatment to every scroll region inside the workspace
+   shell (chat transcript, panes, file tree…) so scrollbars read quietly. */
+[data-boring-workspace] {
+  scrollbar-width: thin;
+  scrollbar-color: oklch(from var(--foreground) l c h / 0.14) transparent;
+}
+[data-boring-workspace] ::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+[data-boring-workspace] ::-webkit-scrollbar-track {
+  background: transparent;
+}
+[data-boring-workspace] ::-webkit-scrollbar-thumb {
+  background-color: oklch(from var(--foreground) l c h / 0.12);
+  border-radius: 9999px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+}
+[data-boring-workspace] ::-webkit-scrollbar-thumb:hover {
+  background-color: oklch(from var(--foreground) l c h / 0.3);
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -210,6 +210,7 @@ export {
   userMeta,
   agentMeta,
   emitAgentData,
+  workspaceEvents,
 } from "./front/events"
 export type {
   Origin,

--- a/plugins/ask-user/src/front/index.tsx
+++ b/plugins/ask-user/src/front/index.tsx
@@ -3,7 +3,9 @@
 import { Button, EmptyState, Notice, Pane, PaneBody, PaneFooter, PaneHeader, PaneTitle } from "@hachej/boring-ui-kit"
 import {
   UI_COMMAND_EVENT,
+  events,
   useWorkspaceAttention,
+  workspaceEvents,
   type PaneProps,
   type PluginProviderProps,
 } from "@hachej/boring-workspace"
@@ -111,12 +113,27 @@ function AskUserProvider({ apiBaseUrl, authHeaders, children }: PluginProviderPr
     }
     const onVisibility = () => { if (document.visibilityState === "visible") void refreshPending() }
     const onUiCommand = () => { void refreshPending() }
+    // Questions are created mid-run by the ask_user tool, with no focus or
+    // UI-command transition to piggyback on. Throttle-refresh while agent
+    // stream parts flow so the pending question (and its blocker/badge)
+    // appears without requiring a tab switch or reload.
+    let agentDataTimer: ReturnType<typeof setTimeout> | null = null
+    const onAgentData = () => {
+      if (agentDataTimer) return
+      agentDataTimer = setTimeout(() => {
+        agentDataTimer = null
+        void refreshPending()
+      }, 1200)
+    }
+    const offAgentData = events.on(workspaceEvents.agentData, onAgentData)
     void refreshPending()
     window.addEventListener("focus", refreshPending)
     document.addEventListener("visibilitychange", onVisibility)
     window.addEventListener(UI_COMMAND_EVENT, onUiCommand)
     return () => {
       stopped = true
+      if (agentDataTimer) clearTimeout(agentDataTimer)
+      offAgentData()
       window.removeEventListener("focus", refreshPending)
       document.removeEventListener("visibilitychange", onVisibility)
       window.removeEventListener(UI_COMMAND_EVENT, onUiCommand)


### PR DESCRIPTION
## Summary
Re-lands the chat-session-panes UX cleanly on current `main`. The original branch (#229) was based on `plan/pi-native-chat-ui-rewrite` and carried a divergent pi-native backend that conflicts wholesale with main (46 conflicts, 31 in backend code the UX never touched). This PR is **the UX layer only**, reconciled against main — same shipped result, none of the backend risk. Closes #229.

## What's included
- **Multi-pane chat stage**, two engines behind a `chatPaneEngine` flag: default flex row + opt-in dockview stage (drag flat pane headers to split any direction, edge-only drops, geometry persisted per workspace).
- **Sessions are data, panes are views**: open-as-pane, drag a row onto the stage, close = view only, layout persisted per workspace.
- **Active-pane treatment**: selected chat stays white, inactive panes recede behind a faint grey wash (no border).
- **Session browser**: Pinned / Active / History sections (collapsible; History collapsed by default), open-indicator dots, **working** + **needs-input** status badges, per-workspace pin persistence, consistent hover-revealed row actions (pin · open-as-pane · delete).
- **Polish**: instant tooltips across shell chrome, discreet scrollbars, collapse-chat with multiple panes, left-rail "New chat" (hidden when the drawer is open).
- **Agent**: pane-aware empty state (container queries), per-session busy broadcast for the working badge, ask-user surfaces mid-run questions for the needs-input badge.

## Proof of work
- `pnpm --filter @hachej/boring-workspace run typecheck` — clean; agent typecheck clean.
- Core pane/session suites: 95 passed (WorkspaceAgentFront pane tests, presets, SessionBrowser, chatPaneState). Full workspace suite green aside from pre-existing parallelism flakes in untouched files (createWorkspaceAgentServer, CommandPalette).
- ask-user 58 passed; agent harness 85 passed.

## Follow-up
Content-derived session titles depend on a title scheduler absent from main's harness — deferred to a backend-aware change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)