### PR TITLE
Make dock chat stage the default

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -450,7 +450,6 @@ export function WorkspaceAgentFront<
   onOpenNav,
   onOpenSurface,
   surfaceButtonBottomOffset,
-  chatPaneEngine,
   className,
 }: WorkspaceAgentFrontProps<TSession>) {
   const resolvedProviderStorageKey =
@@ -1306,7 +1305,6 @@ export function WorkspaceAgentFront<
               onCreateChatPaneAfter={createChatPaneAfter}
               onDropChatSession={openChatPane}
               flashChatPaneId={flashChatPane?.workspaceId === workspaceId ? flashChatPane.id : null}
-              chatPaneEngine={chatPaneEngine}
               surface={surfaceOpen ? "artifact-surface" : null}
               surfaceParams={surfaceParams as Record<string, unknown>}
               surfaceOverlay={workbenchOverlay}

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -385,7 +385,6 @@ export function ChatLayout(props: ChatLayoutProps) {
                 flashPaneId={props.flashChatPaneId}
                 storageKey={props.storageKey}
                 onDropSession={props.onDropChatSession}
-                engine={props.chatPaneEngine}
                 renderPane={(pane) => (
                   <PanelSlot
                     id={pane.panel ?? centerId}

--- a/packages/workspace/src/front/layout/ChatPaneStage.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStage.tsx
@@ -1,38 +1,12 @@
 import type { ReactNode } from "react"
 import { cn } from "../lib/utils"
 import { ChatPaneStageDock } from "./ChatPaneStageDock"
-import { ChatPaneStageFlex } from "./ChatPaneStageFlex"
 
 export interface ChatPaneDescriptor {
   id: string
   title?: string | null
   panel?: string
   params?: Record<string, unknown>
-}
-
-/**
- * Layout engine for the chat pane stage.
- *
- * - `flex` (default): panes lay out as a single row of vertical splits.
- * - `dock`: dockview-backed stage — drag pane headers to split in any
- *   direction and resize; geometry persists per workspace.
- *
- * Resolution order: explicit prop, then the
- * `boring-workspace:chat-pane-engine` localStorage override, then `flex`.
- */
-export type ChatPaneEngine = "flex" | "dock"
-
-const ENGINE_STORAGE_KEY = "boring-workspace:chat-pane-engine"
-
-export function resolveChatPaneEngine(preferred?: ChatPaneEngine | null): ChatPaneEngine {
-  if (preferred === "dock" || preferred === "flex") return preferred
-  try {
-    const stored = globalThis.localStorage?.getItem(ENGINE_STORAGE_KEY)
-    if (stored === "dock" || stored === "flex") return stored
-  } catch {
-    // Storage may be unavailable; fall through to the default.
-  }
-  return "flex"
 }
 
 export interface ChatPaneStageProps {
@@ -48,23 +22,26 @@ export interface ChatPaneStageProps {
    */
   flashPaneId?: string | null
   /**
-   * Dock engine only: persist the dockview layout (splits, sizes) under
+   * Persist the dockview layout (splits, sizes) under
    * `${storageKey}:chatPaneLayout`.
    */
   storageKey?: string
   /**
    * Called when a session is dropped onto the stage (drag a session-browser
-   * row in). The parent opens the session as a pane; the dock engine places
-   * it where it was dropped.
+   * row in). The parent opens the session as a pane placed where it was
+   * dropped.
    */
   onDropSession?: (sessionId: string) => void
-  engine?: ChatPaneEngine | null
 }
 
-export function ChatPaneStage({ engine, ...props }: ChatPaneStageProps) {
-  return resolveChatPaneEngine(engine) === "dock"
-    ? <ChatPaneStageDock {...props} />
-    : <ChatPaneStageFlex {...props} />
+/**
+ * Chat pane stage: a dockview-backed surface where each open session is a
+ * pane. Drag flat pane headers to split in any direction, drag a session
+ * row in to open it at a drop position, resize — geometry persists per
+ * workspace.
+ */
+export function ChatPaneStage(props: ChatPaneStageProps) {
+  return <ChatPaneStageDock {...props} />
 }
 
 export function paneTitle(pane: { title?: string | null }): string {

--- a/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
@@ -23,7 +23,7 @@ import { cn } from "../lib/utils"
 import { ControlTooltip } from "../components/ControlTooltip"
 import { CHAT_SESSION_DRAG_TYPE, PaneFocusRing, paneTitle, type ChatPaneDescriptor, type ChatPaneStageProps } from "./ChatPaneStage"
 
-type ChatPaneStageDockProps = Omit<ChatPaneStageProps, "engine">
+type ChatPaneStageDockProps = ChatPaneStageProps
 
 const CHAT_PANE_COMPONENT = "chat-pane"
 const PANE_MIN_WIDTH = 280

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -639,9 +639,7 @@ describe("ChatLayout component", () => {
 
     expect(screen.getByLabelText("Chat session First")).toHaveAttribute("data-boring-state", "inactive")
     expect(screen.getByLabelText("Chat session Second")).toHaveAttribute("data-boring-state", "active")
-    // Default engine is the flex row; the dock engine is behind the flag.
-    expect(document.querySelector('[data-boring-workspace-part="chat-pane-stage"]')?.className).toContain("overflow-x-auto")
-    expect(document.querySelector(".dv-chat-stage")).toBeNull()
+    expect(document.querySelector(".dv-chat-stage")).not.toBeNull()
     expect(screen.getByRole("button", { name: "New chat" })).toBeInTheDocument()
 
     await user.click(screen.getByLabelText("Chat session First"))
@@ -653,48 +651,6 @@ describe("ChatLayout component", () => {
     // The floating left-edge "+" creates next to the active pane.
     await user.click(screen.getByRole("button", { name: "New chat" }))
     expect(createAfter).toHaveBeenCalledWith("s2")
-  })
-
-  it("renders the dockview chat stage when the dock engine flag is set", async () => {
-    const user = userEvent.setup()
-    const closePane = vi.fn()
-
-    renderWithRegistry(
-      <ChatLayout
-        center="chat"
-        chatPanes={[
-          { id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } },
-          { id: "s2", title: "Second", panel: "chat", params: { sessionId: "s2" } },
-        ]}
-        activeChatPaneId="s2"
-        onCloseChatPane={closePane}
-        chatPaneEngine="dock"
-      />,
-      ["chat", "session-list"],
-    )
-
-    expect(document.querySelector(".dv-chat-stage")).not.toBeNull()
-    expect(screen.getByLabelText("Chat session Second")).toHaveAttribute("data-boring-state", "active")
-
-    await user.click(screen.getByLabelText("Close Second pane"))
-    expect(closePane).toHaveBeenCalledWith("s2")
-  })
-
-  it("reads the dock engine flag from localStorage when no prop is set", () => {
-    localStorage.setItem("boring-workspace:chat-pane-engine", "dock")
-    try {
-      renderWithRegistry(
-        <ChatLayout
-          center="chat"
-          chatPanes={[{ id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } }]}
-          activeChatPaneId="s1"
-        />,
-        ["chat", "session-list"],
-      )
-      expect(document.querySelector(".dv-chat-stage")).not.toBeNull()
-    } finally {
-      localStorage.removeItem("boring-workspace:chat-pane-engine")
-    }
   })
 
   it("does not activate an inactive pane when using its header controls", async () => {

--- a/packages/workspace/src/front/layout/types.ts
+++ b/packages/workspace/src/front/layout/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react"
-import type { ChatPaneDescriptor, ChatPaneEngine } from "./ChatPaneStage"
+import type { ChatPaneDescriptor } from "./ChatPaneStage"
 
 export interface IdeLayoutProps {
   sidebar?: string
@@ -20,13 +20,6 @@ export interface ChatLayoutProps {
   onCreateChatPaneAfter?: (id: string) => void
   onDropChatSession?: (sessionId: string) => void
   flashChatPaneId?: string | null
-  /**
-   * Chat stage layout engine. `dock` enables the dockview-backed stage
-   * (drag headers to split in any direction); defaults to the flex row.
-   * The `boring-workspace:chat-pane-engine` localStorage key overrides
-   * when no explicit value is passed.
-   */
-  chatPaneEngine?: ChatPaneEngine | null
   surface?: string | null
   surfaceParams?: Record<string, unknown>
   surfaceOverlay?: ReactNode


### PR DESCRIPTION
## Summary
- remove the chat pane engine prop/localStorage flag plumbing
- always render the dockview-backed chat pane stage
- update layout tests now that dock is the only chat pane stage

## Validation
- pnpm --filter @hachej/boring-workspace run typecheck
- pnpm --filter @hachej/boring-workspace run test src/front/layout/__tests__/presets.test.tsx
- pnpm --filter @hachej/boring-workspace run test
- pnpm --filter @hachej/boring-workspace run lint
- /home/ubuntu/.pi/agent/skills/coding-autoreview/scripts/autoreview --mode local