### PR TITLE
fix(workspace): tame file watcher and delete-event fanout

### DIFF
--- a/packages/agent/src/server/workspace/__tests__/createNodeWorkspace.watch.test.ts
+++ b/packages/agent/src/server/workspace/__tests__/createNodeWorkspace.watch.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach } from 'vitest'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createNodeWorkspace } from '../createNodeWorkspace'
@@ -68,6 +68,22 @@ describe('createNodeWorkspace.watch', () => {
     if (writes[0]!.mtimeMs !== undefined) expect(writes[0]!.mtimeMs).toBeGreaterThan(0)
   })
 
+  it('does not ignore everything when the workspace root is under an ignored-name parent', async () => {
+    const workspaceRoot = join(root, '.worktrees', 'child-workspace')
+    await mkdir(workspaceRoot, { recursive: true })
+    const ws = createNodeWorkspace(workspaceRoot)
+    watcher = ws.watch!()
+
+    const events: WorkspaceChangeEvent[] = []
+    watcher.subscribe((e) => events.push(e))
+    await wait(SETTLE_MS)
+
+    await ws.writeFile('inside-root.txt', 'visible')
+    await waitForEvent(events, (e) => e.op === 'write' && e.path === 'inside-root.txt')
+
+    expect(events.some((e) => e.op === 'write' && e.path === 'inside-root.txt')).toBe(true)
+  })
+
   it('shares one underlying watcher across multiple subscribers', async () => {
     const ws = createNodeWorkspace(root)
     const w1 = ws.watch!()
@@ -89,6 +105,30 @@ describe('createNodeWorkspace.watch', () => {
     await waitForEvent(events, (e) => e.op === 'unlink' && e.path === 'b.txt')
 
     expect(events.some((e) => e.op === 'unlink' && e.path === 'b.txt')).toBe(true)
+  })
+
+  it('ignores heavyweight internal directories', async () => {
+    const ws = createNodeWorkspace(root)
+    const ignoredDirs = ['.worktrees', '.boring-agent', '.cache']
+    for (const dir of ignoredDirs) await ws.mkdir(dir, { recursive: true })
+
+    watcher = ws.watch!()
+
+    const events: WorkspaceChangeEvent[] = []
+    watcher.subscribe((e) => events.push(e))
+    await wait(SETTLE_MS)
+
+    await ws.writeFile('visible.txt', 'visible')
+    await waitForEvent(events, (e) => e.op === 'write' && e.path === 'visible.txt')
+    expect(events.some((e) => e.op === 'write' && e.path === 'visible.txt')).toBe(true)
+    events.length = 0
+
+    for (const dir of ignoredDirs) {
+      await ws.writeFile(`${dir}/hidden.txt`, 'hidden')
+    }
+    await wait(SETTLE_MS)
+
+    expect(events).toEqual([])
   })
 
   it('subscribe returns an unsubscribe fn — events stop flowing after it is called', async () => {

--- a/packages/agent/src/server/workspace/createNodeWorkspace.ts
+++ b/packages/agent/src/server/workspace/createNodeWorkspace.ts
@@ -21,14 +21,18 @@ const DEFAULT_WATCH_IGNORES = [
   'node_modules',
   '.git',
   '.DS_Store',
+  '.worktrees',
+  '.boring-agent',
+  '.cache',
   'dist',
   '.next',
   '.turbo',
   'test-results',
 ] as const
 
-function shouldIgnoreWatchPath(path: string): boolean {
-  const parts = path.split(sep)
+function shouldIgnoreWatchPath(root: string, path: string): boolean {
+  const relPath = relative(root, path)
+  const parts = relPath.split(sep)
   return parts.some((part) =>
     DEFAULT_WATCH_IGNORES.includes(part as (typeof DEFAULT_WATCH_IGNORES)[number]) ||
     part.endsWith('.tsbuildinfo'),
@@ -48,7 +52,7 @@ function createNodeWatcher(root: string): WorkspaceWatcher {
   const ensureFsw = (): FSWatcher => {
     if (fsw) return fsw
     fsw = chokidar.watch(root, {
-      ignored: shouldIgnoreWatchPath,
+      ignored: (path) => shouldIgnoreWatchPath(root, path),
       ignoreInitial: true,
       persistent: true,
       followSymlinks: false,

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest"
-import { renderHook } from "@testing-library/react"
+import { renderHook, waitFor } from "@testing-library/react"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
 
@@ -24,6 +24,10 @@ function makeWrapper(queryClient: QueryClient) {
   }
 }
 
+function queryKeyCalls(invalidate: ReturnType<typeof vi.fn>): Array<readonly unknown[]> {
+  return invalidate.mock.calls.map(([f]) => (f as { queryKey: readonly unknown[] }).queryKey)
+}
+
 describe("useFileEventInvalidation", () => {
   let qc: QueryClient
   // Untyped on purpose — vitest's MockInstance generic doesn't compose
@@ -38,29 +42,29 @@ describe("useFileEventInvalidation", () => {
     ;(qc as any).invalidateQueries = invalidate
   })
 
-  it("filesystem changed invalidates files + stat for the path only (granular)", () => {
+  it("filesystem changed invalidates files + stat for the path only (granular)", async () => {
     renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
     events.emit(filesystemEvents.changed, { ...agentMeta("tc-1"), path: "src/a.ts" })
 
-    expect(invalidate).toHaveBeenCalledWith({
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "src/a.ts"],
-    })
+    }))
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "stat", "src/a.ts"],
     })
     // Tree/search are NOT touched on a content-only change.
-    const calls = invalidate.mock.calls.map(([f]) => (f as { queryKey: readonly unknown[] }).queryKey)
+    const calls = queryKeyCalls(invalidate)
     expect(calls.some((k) => k[2] === "tree")).toBe(false)
     expect(calls.some((k) => k[2] === "search")).toBe(false)
   })
 
-  it("filesystem created (file) invalidates tree + files + stat", () => {
+  it("filesystem created (file) invalidates tree + files + stat", async () => {
     renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
     events.emit(filesystemEvents.created, { ...userMeta(), path: "src/new.ts", kind: "file" })
 
-    expect(invalidate).toHaveBeenCalledWith({
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree"],
-    })
+    }))
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "src/new.ts"],
     })
@@ -69,24 +73,24 @@ describe("useFileEventInvalidation", () => {
     })
   })
 
-  it("filesystem created (dir) invalidates tree only", () => {
+  it("filesystem created (dir) invalidates tree only", async () => {
     renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
     events.emit(filesystemEvents.created, { ...userMeta(), path: "scripts", kind: "dir" })
 
-    expect(invalidate).toHaveBeenCalledWith({
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree"],
-    })
-    const calls = invalidate.mock.calls.map(([f]) => (f as { queryKey: readonly unknown[] }).queryKey)
+    }))
+    const calls = queryKeyCalls(invalidate)
     expect(calls.some((k) => k[2] === "stat")).toBe(false)
   })
 
-  it("filesystem moved invalidates tree + files(from,to) + search", () => {
+  it("filesystem moved invalidates tree + files(from,to) + search", async () => {
     renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
     events.emit(filesystemEvents.moved, { ...userMeta(), from: "old.ts", to: "new.ts" })
 
-    expect(invalidate).toHaveBeenCalledWith({
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree"],
-    })
+    }))
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "old.ts"],
     })
@@ -98,13 +102,13 @@ describe("useFileEventInvalidation", () => {
     })
   })
 
-  it("filesystem deleted invalidates tree + files(path) + search", () => {
+  it("filesystem deleted invalidates tree + files(path) + search", async () => {
     renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
     events.emit(filesystemEvents.deleted, { ...userMeta(), path: "doomed.ts" })
 
-    expect(invalidate).toHaveBeenCalledWith({
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree"],
-    })
+    }))
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "doomed.ts"],
     })
@@ -113,12 +117,29 @@ describe("useFileEventInvalidation", () => {
     })
   })
 
-  it("unsubscribes on unmount — events fired afterwards do not invalidate", () => {
+  it("coalesces a delete burst to one tree and one search invalidation", async () => {
+    renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
+
+    for (let i = 0; i < 50; i += 1) {
+      events.emit(filesystemEvents.deleted, { ...agentMeta("burst"), path: `folder/file-${i}.txt` })
+    }
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree"],
+    }))
+    const calls = queryKeyCalls(invalidate)
+    expect(calls.filter((k) => k[2] === "tree")).toHaveLength(1)
+    expect(calls.filter((k) => k[2] === "search")).toHaveLength(1)
+    expect(calls.filter((k) => k[2] === "files")).toHaveLength(50)
+  })
+
+  it("unsubscribes on unmount — events fired afterwards do not invalidate", async () => {
     const { unmount } = renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
     unmount()
     invalidate.mockClear()
 
     events.emit(filesystemEvents.changed, { ...userMeta(), path: "x.ts" })
+    await new Promise((resolve) => setTimeout(resolve, 50))
     expect(invalidate).not.toHaveBeenCalled()
   })
 })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventInvalidation.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventInvalidation.ts
@@ -35,66 +35,95 @@ export function useFileEventInvalidation(): void {
   const workspaceId = useWorkspaceRequestId()
 
   useEffect(() => {
+    const batch = createInvalidationBatch(queryClient)
+
     const offChanged = events.on(filesystemEvents.changed, (e) => {
-      invalidateFile(queryClient, base, workspaceId, e.path)
+      invalidateFile(batch, base, workspaceId, e.path)
     })
     const offCreated = events.on(filesystemEvents.created, (e) => {
-      invalidateTree(queryClient, base, workspaceId)
+      invalidateTree(batch, base, workspaceId)
       if (e.kind === "file") {
-        invalidateFile(queryClient, base, workspaceId, e.path)
+        invalidateFile(batch, base, workspaceId, e.path)
       }
     })
     const offMoved = events.on(filesystemEvents.moved, (e) => {
-      invalidateTree(queryClient, base, workspaceId)
-      invalidateFile(queryClient, base, workspaceId, e.from)
-      invalidateFile(queryClient, base, workspaceId, e.to)
-      invalidateSearch(queryClient, base, workspaceId)
+      invalidateTree(batch, base, workspaceId)
+      invalidateFile(batch, base, workspaceId, e.from)
+      invalidateFile(batch, base, workspaceId, e.to)
+      invalidateSearch(batch, base, workspaceId)
     })
     const offDeleted = events.on(filesystemEvents.deleted, (e) => {
-      invalidateTree(queryClient, base, workspaceId)
-      invalidateFile(queryClient, base, workspaceId, e.path)
-      invalidateSearch(queryClient, base, workspaceId)
+      invalidateTree(batch, base, workspaceId)
+      invalidateFile(batch, base, workspaceId, e.path)
+      invalidateSearch(batch, base, workspaceId)
     })
     return () => {
       offChanged()
       offCreated()
       offMoved()
       offDeleted()
+      batch.dispose()
     }
   }, [queryClient, base, workspaceId])
 }
 
-function invalidateFile(
-  qc: QueryClient,
-  base: string,
-  workspaceId: string | null,
-  path: string,
-): void {
-  qc.invalidateQueries({ queryKey: [base, workspaceId, FILES_QUERY_KEY_SEGMENT, path] })
-  qc.invalidateQueries({ queryKey: [base, workspaceId, "stat", path] })
+const INVALIDATION_BATCH_MS = 25
+
+type QueryKey = readonly unknown[]
+
+interface InvalidationBatch {
+  enqueue(queryKey: QueryKey): void
+  dispose(): void
 }
 
-function invalidateStat(
-  qc: QueryClient,
+function createInvalidationBatch(qc: QueryClient): InvalidationBatch {
+  const pending = new Map<string, QueryKey>()
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const flush = () => {
+    timer = undefined
+    const keys = Array.from(pending.values())
+    pending.clear()
+    for (const queryKey of keys) {
+      qc.invalidateQueries({ queryKey })
+    }
+  }
+
+  return {
+    enqueue(queryKey) {
+      pending.set(JSON.stringify(queryKey), queryKey)
+      if (timer === undefined) timer = setTimeout(flush, INVALIDATION_BATCH_MS)
+    },
+    dispose() {
+      if (timer !== undefined) clearTimeout(timer)
+      timer = undefined
+      pending.clear()
+    },
+  }
+}
+
+function invalidateFile(
+  batch: InvalidationBatch,
   base: string,
   workspaceId: string | null,
   path: string,
 ): void {
-  qc.invalidateQueries({ queryKey: [base, workspaceId, "stat", path] })
+  batch.enqueue([base, workspaceId, FILES_QUERY_KEY_SEGMENT, path])
+  batch.enqueue([base, workspaceId, "stat", path])
 }
 
 function invalidateTree(
-  qc: QueryClient,
+  batch: InvalidationBatch,
   base: string,
   workspaceId: string | null,
 ): void {
-  qc.invalidateQueries({ queryKey: [base, workspaceId, "tree"] })
+  batch.enqueue([base, workspaceId, "tree"])
 }
 
 function invalidateSearch(
-  qc: QueryClient,
+  batch: InvalidationBatch,
   base: string,
   workspaceId: string | null,
 ): void {
-  qc.invalidateQueries({ queryKey: [base, workspaceId, "search"] })
+  batch.enqueue([base, workspaceId, "search"])
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/search.test.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/search.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+import { DEFAULT_TREE_IGNORE, filterIgnoredEntries } from "./search"
+import type { FileEntry } from "./data/types"
+
+describe("filesystem plugin search helpers", () => {
+  it("hides heavyweight internal workspace directories by default", () => {
+    const entries: FileEntry[] = [
+      { name: ".worktrees", kind: "dir", path: ".worktrees" },
+      { name: ".local", kind: "dir", path: ".local" },
+      { name: ".boring-agent", kind: "dir", path: ".boring-agent" },
+      { name: ".cache", kind: "dir", path: ".cache" },
+      { name: "packages", kind: "dir", path: "packages" },
+      { name: "README.md", kind: "file", path: "README.md" },
+    ]
+
+    expect(filterIgnoredEntries(entries, DEFAULT_TREE_IGNORE)).toEqual([
+      { name: ".local", kind: "dir", path: ".local" },
+      { name: "packages", kind: "dir", path: "packages" },
+      { name: "README.md", kind: "file", path: "README.md" },
+    ])
+  })
+})

--- a/packages/workspace/src/plugins/filesystemPlugin/front/search.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/search.ts
@@ -3,6 +3,7 @@ import type { FileEntry } from "./data/types"
 export const DEFAULT_TREE_IGNORE: ReadonlyArray<string | RegExp> = [
   "node_modules",
   ".git",
+  ".worktrees",
   ".boring-agent",
   "dist",
   "test-results",


### PR DESCRIPTION
## Summary

- stop the Node workspace watcher from recursively watching heavyweight internal directories (`.worktrees`, `.boring-agent`, `.cache`)
- evaluate watcher ignores relative to the workspace root so a workspace located under a parent named `.worktrees` still receives events
- hide `.worktrees` from the default file tree so users do not accidentally browse/delete massive local agent worktree caches
- batch React Query invalidations for filesystem events over a short window so recursive folder deletes do not refetch tree/search for every child unlink
- add regression tests for watcher ignores, workspace roots under ignored-name parents, file-tree filtering, and delete-burst invalidation coalescing

## Why

On the live CLI workspace at port `5213`, the server process had ~472k inotify watch descriptors and high idle CPU. The workspace root contains a very large `.worktrees` directory. Folder deletion then fans out through chokidar as one `unlink` / `unlinkDir` event per child, which previously drove repeated frontend invalidations/refetches.

This PR contains two containment fixes:

1. do not watch or show the biggest internal heavyweight dirs by default
2. dedupe tree/search invalidations during event bursts

## Validation

- `pnpm --filter @hachej/boring-agent test src/server/workspace/__tests__/createNodeWorkspace.watch.test.ts` ✅
- `pnpm --filter @hachej/boring-workspace test src/plugins/filesystemPlugin/front/search.test.ts` ✅
- `pnpm --filter @hachej/boring-workspace test src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx` ✅
- `pnpm --filter @hachej/boring-agent typecheck` ✅
- `pnpm --filter @hachej/boring-workspace typecheck` ✅
- Autoreview clean after fixes ✅

## Investigation notes

- Live main CLI process on `5213`: ~472,846 inotify watch descriptors.
- One-off watcher with the final ignore set on the same workspace root: ~8,481 descriptors, ready in ~1.8s.
- Synthetic recursive delete of 1,000 files produced 1,021 chokidar events, confirming per-child delete fan-out.