### PR TITLE
fix(cli): stop Vite optimizer churn + rescan plugin sources on /reload

### DIFF
--- a/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
+++ b/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
@@ -492,6 +492,40 @@ describe("pluginFrontRuntime", () => {
     }
   }, 20_000)
 
+  test("maps installed-layout @hachej/boring-workspace imports to the host singleton", async () => {
+    // In an installed CLI the workspace package resolves under
+    // node_modules/@hachej/boring-workspace (not packages/workspace). The
+    // root import must hit the host singleton — a proxied second copy reads
+    // the wrong React context and drags un-interop'd app-level CJS deps.
+    const pluginRoot = await makeTempDir("plugin-front-runtime-installed-ws-")
+    const plugin = await writeRuntimePlugin(pluginRoot, {
+      "front/index.tsx": 'import { useApiBaseUrl } from "@hachej/boring-workspace"\nexport const hook = useApiBaseUrl\n',
+      "node_modules/@hachej/boring-workspace/package.json": JSON.stringify({
+        name: "@hachej/boring-workspace",
+        version: "0.0.0",
+        exports: { ".": "./dist/workspace.js" },
+      }),
+      "node_modules/@hachej/boring-workspace/dist/workspace.js": "export const useApiBaseUrl = () => { throw new Error('proxied copy must not load') }\n",
+    })
+
+    const host = await createPluginFrontRuntimeHost()
+    const app = fastify({ logger: false })
+    await host.registerRoutes(app)
+    host.trackPlugin({ workspaceId: "workspace-a", plugin, revision: 1, frontEntrySubpath: "front/index.tsx" })
+
+    try {
+      const entry = await app.inject({
+        method: "GET",
+        url: `${PLUGIN_FRONT_RUNTIME_BASE_PATH}/workspace-a/runtime-plugin/1/front/index.tsx`,
+      })
+      expect(entry.statusCode).toBe(200)
+      expect(entry.body).toContain("/__vite/singleton/%40hachej%2Fboring-workspace")
+      expect(entry.body).not.toContain("boring-workspace%2Fdist%2Fworkspace.js")
+    } finally {
+      await app.close()
+    }
+  }, 20_000)
+
   test("rejects plugin-local dependency attempts to import arbitrary /@fs paths", async () => {
     const pluginRoot = await makeTempDir("plugin-front-runtime-bad-dep-")
     const plugin = await writeRuntimePlugin(pluginRoot, {

--- a/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
+++ b/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
@@ -450,6 +450,48 @@ describe("pluginFrontRuntime", () => {
     }
   }, 20_000)
 
+  test("does not rewrite a dependency's own react.js module to the react singleton", async () => {
+    // Regression: dockview ships dist/esm/react.js (exporting ReactPart).
+    // The optimizer-chunk filename heuristic ("react.js" → react singleton)
+    // must not capture dependency-internal modules that merely share the
+    // filename — the singleton lacks their exports, which kills the whole
+    // importing plugin graph with a named-export SyntaxError.
+    const pluginRoot = await makeTempDir("plugin-front-runtime-react-name-clash-")
+    const plugin = await writeRuntimePlugin(pluginRoot, {
+      "front/index.tsx": 'import { value } from "dockish"\nexport const answer = value\n',
+      "node_modules/dockish/package.json": JSON.stringify({ name: "dockish", version: "1.0.0", main: "index.js" }),
+      "node_modules/dockish/index.js": 'import { ReactPart } from "./react.js"\nexport const value = ReactPart\n',
+      "node_modules/dockish/react.js": 'export const ReactPart = "dep-owned react module"\n',
+    })
+
+    const host = await createPluginFrontRuntimeHost()
+    const app = fastify({ logger: false })
+    await host.registerRoutes(app)
+    host.trackPlugin({ workspaceId: "workspace-a", plugin, revision: 1, frontEntrySubpath: "front/index.tsx" })
+
+    try {
+      const entry = await app.inject({
+        method: "GET",
+        url: `${PLUGIN_FRONT_RUNTIME_BASE_PATH}/workspace-a/runtime-plugin/1/front/index.tsx`,
+      })
+      expect(entry.statusCode).toBe(200)
+      const depPath = entry.body.match(new RegExp(`"(${PLUGIN_FRONT_RUNTIME_BASE_PATH}/__vite/proxy/[^"']*)"`))?.[1]
+      expect(depPath, entry.body).toBeTruthy()
+
+      const dep = await app.inject({ method: "GET", url: depPath! })
+      expect(dep.statusCode, dep.body).toBe(200)
+      // The dep's internal ./react.js import must stay a proxy URL, not the singleton.
+      expect(dep.body).not.toContain("/__vite/singleton/react")
+      const innerPath = dep.body.match(new RegExp(`"(${PLUGIN_FRONT_RUNTIME_BASE_PATH}/__vite/proxy/[^"']*react[^"']*)"`))?.[1]
+      expect(innerPath, dep.body).toBeTruthy()
+      const inner = await app.inject({ method: "GET", url: innerPath! })
+      expect(inner.statusCode, inner.body).toBe(200)
+      expect(inner.body).toContain("dep-owned react module")
+    } finally {
+      await app.close()
+    }
+  }, 20_000)
+
   test("rejects plugin-local dependency attempts to import arbitrary /@fs paths", async () => {
     const pluginRoot = await makeTempDir("plugin-front-runtime-bad-dep-")
     const plugin = await writeRuntimePlugin(pluginRoot, {

--- a/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
+++ b/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
@@ -232,6 +232,43 @@ describe("workspaces mode runtime plugin wiring", () => {
     }
   }, 20_000)
 
+  test("package sources added to .pi/settings.json after boot are picked up by /reload", async () => {
+    const homeRoot = await makeTempDir("boring-cli-workspaces-pkgsrc-home-")
+    const registryPath = join(await makeTempDir("boring-cli-workspaces-pkgsrc-registry-"), "workspaces.yaml")
+    const workspaceRoot = await makeTempDir("boring-cli-workspace-pkgsrc-")
+    process.env.HOME = homeRoot
+
+    const [workspace] = await setupRegistry([workspaceRoot], registryPath)
+    const app = await createWorkspacesModeApp({ mode: "direct", registryPath, provisionWorkspace: false })
+
+    try {
+      // Boot the workspace runtime with no plugin sources.
+      const before = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${workspace.id}` })
+      expect(before.json()).toEqual([])
+
+      // Simulate `boring-ui-plugin install ../some-plugin`: a package source
+      // dir outside .pi/extensions, registered in .pi/settings.json packages.
+      const pluginDir = join(workspaceRoot, "vendor", "settings-plugin")
+      await writePlugin(pluginDir, "settings-plugin")
+      await mkdir(join(workspaceRoot, ".pi"), { recursive: true })
+      await writeFile(join(workspaceRoot, ".pi", "settings.json"), JSON.stringify({
+        packages: ["../vendor/settings-plugin"],
+      }), "utf8")
+
+      const reload = await app.inject({
+        method: "POST",
+        url: "/api/v1/agent/reload?workspaceId=" + encodeURIComponent(workspace.id),
+        payload: {},
+      })
+      expect(reload.statusCode).toBe(200)
+
+      const afterReload = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${workspace.id}` })
+      expect((afterReload.json() as Array<{ id: string }>).map((plugin) => plugin.id)).toEqual(["settings-plugin"])
+    } finally {
+      await app.close()
+    }
+  }, 20_000)
+
   test("workspace eviction closes active SSE streams and disposes runtime targets", async () => {
     const homeRoot = await makeTempDir("boring-cli-workspaces-evict-home-")
     const registryPath = join(await makeTempDir("boring-cli-workspaces-evict-registry-"), "workspaces.yaml")

--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -668,6 +668,12 @@ export async function createWorkspacesModeApp(opts: {
     beforeReload: async ({ workspaceId }) => {
       const workspace = await requireWorkspace(workspaceId)
       const runtime = await getLoadedPluginRuntime(workspace)
+      // Re-resolve discovery roots before rescanning: package sources in
+      // .pi/settings.json can gain entries after boot (boring-ui-plugin
+      // install), but the manager's dirs were resolved once when this
+      // workspace runtime was created. Without this, newly installed plugin
+      // sources stay invisible until a full process restart.
+      runtime.manager.setPluginDirs(pluginDiscovery.resolveCliBoringPluginDirs(workspace.path))
       const scan = await runtime.manager.load()
       syncLoadedPluginPiSnapshot(workspace, runtime.manager)
       syncRuntimeHostFromPluginEvents(runtimeHost, workspaceId, scan.events)

--- a/packages/cli/src/server/pluginFrontRuntime.ts
+++ b/packages/cli/src/server/pluginFrontRuntime.ts
@@ -519,6 +519,13 @@ function optimizedDependencySingletonSource(targetPath: string): HostVirtualSing
   for (const [suffix, source] of workspaceSingletonByPath) {
     if (normalizedPath.endsWith(suffix)) return source
   }
+  // Filename-based mapping applies ONLY to Vite optimizer output
+  // (.vite/deps/react.js etc.). Matching by bare filename anywhere would
+  // also capture a dependency's own module that happens to be named
+  // react.js — e.g. dockview/dist/esm/react.js, whose exports (ReactPart)
+  // do not exist on the react singleton, killing the whole importing
+  // plugin module graph with a named-export SyntaxError.
+  if (!normalizedPath.includes("/.vite/deps/")) return undefined
   const fileName = normalizedPath.slice(normalizedPath.lastIndexOf("/") + 1)
   const sourceByFileName: Record<string, HostVirtualSingletonModule> = {
     "react.js": "react",

--- a/packages/cli/src/server/pluginFrontRuntime.ts
+++ b/packages/cli/src/server/pluginFrontRuntime.ts
@@ -509,12 +509,22 @@ function optimizedDependencySingletonSource(targetPath: string): HostVirtualSing
   const cleanPath = targetPath.split("?")[0]
   const normalizedPath = cleanPath.replaceAll("\\", "/")
   const workspaceSingletonByPath: Array<[string, HostVirtualSingletonModule]> = [
+    // Monorepo dev layout.
     ["/packages/workspace/dist/workspace.js", "@hachej/boring-workspace"],
     ["/packages/workspace/src/index.ts", "@hachej/boring-workspace"],
     ["/packages/workspace/dist/plugin.js", "@hachej/boring-workspace/plugin"],
     ["/packages/workspace/src/plugin.ts", "@hachej/boring-workspace/plugin"],
     ["/packages/workspace/dist/events.js", "@hachej/boring-workspace/events"],
     ["/packages/workspace/src/front/events/index.ts", "@hachej/boring-workspace/events"],
+    // Installed layout (npm global / pnpm store): the scoped-package suffix
+    // matches both node_modules/@hachej/... and .pnpm/.../@hachej/... paths.
+    // Without these, a plugin importing the workspace root in an installed
+    // CLI gets a proxied SECOND copy of the workspace bundle — its context
+    // hooks (useApiBaseUrl, ...) read the wrong React context, and the
+    // proxied app-level graph drags un-interop'd CJS deps that fail to load.
+    ["/@hachej/boring-workspace/dist/workspace.js", "@hachej/boring-workspace"],
+    ["/@hachej/boring-workspace/dist/plugin.js", "@hachej/boring-workspace/plugin"],
+    ["/@hachej/boring-workspace/dist/events.js", "@hachej/boring-workspace/events"],
   ]
   for (const [suffix, source] of workspaceSingletonByPath) {
     if (normalizedPath.endsWith(suffix)) return source

--- a/packages/cli/src/server/pluginFrontRuntime.ts
+++ b/packages/cli/src/server/pluginFrontRuntime.ts
@@ -1149,6 +1149,14 @@ export async function createPluginFrontRuntimeHost(
     appType: "custom",
     configFile: false,
     logLevel: "silent",
+    // Disable the dep optimizer entirely. With discovery on, Vite re-optimizes
+    // mid-session as plugin imports surface new deps; each pass rewrites
+    // node_modules/.vite/deps and bumps the browserHash, invalidating chunk
+    // URLs the browser already holds (ERR_FILE_NOT_FOUND_IN_OPTIMIZED_DEP_DIR)
+    // and stalling in-flight plugin front transforms indefinitely. The runtime
+    // host serves deps through its own proxy/singleton routes, so pre-bundling
+    // buys nothing here.
+    optimizeDeps: { entries: [], noDiscovery: true },
     root: repoRoot,
     plugins: [
       react(),

--- a/packages/workspace/src/front/agentPlugins/__tests__/registerAgentPlugin.test.tsx
+++ b/packages/workspace/src/front/agentPlugins/__tests__/registerAgentPlugin.test.tsx
@@ -674,6 +674,55 @@ describe("useAgentPluginHotReload", () => {
     await waitFor(() => expect(screen.getByTestId("hot-left-pane")).toHaveTextContent("left tab content"))
   })
 
+  test("warns when a left tab references an unknown panelId", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      const importFront = async (): Promise<{ default: BoringFrontFactoryWithId }> => ({
+        default: hotPlugin("hot-plugin", (api) => {
+          api.registerPanel({
+            id: "hot-plugin.panel",
+            label: "Real Panel",
+            component: function RealPanel() { return null },
+          })
+          api.registerLeftTab({
+            id: "hot-plugin.tab",
+            title: "Typo Tab",
+            panelId: "hot-plugin-typo.panel",
+          })
+        }),
+      })
+
+      function WarnHarness() {
+        const panelRegistry = React.useMemo(() => new PanelRegistry(), [])
+        const commandRegistry = React.useMemo(() => new CommandRegistry(), [])
+        const surfaceResolverRegistry = React.useMemo(() => new SurfaceResolverRegistry(), [])
+        function Listener() {
+          useAgentPluginHotReload({ workspaceId: "test-workspace", importFront })
+          return null
+        }
+        return (
+          <RegistryProvider panelRegistry={panelRegistry} commandRegistry={commandRegistry} surfaceResolverRegistry={surfaceResolverRegistry}>
+            <Listener />
+          </RegistryProvider>
+        )
+      }
+
+      render(<WarnHarness />)
+      MockEventSource.instances[0].dispatch("boring.plugin.load", {
+        type: "boring.plugin.load",
+        id: "hot-plugin",
+        version: "1.0.0",
+        revision: 1,
+        frontUrl: "/@fs/front.mjs",
+        boring: { front: "./front.mjs" },
+      })
+
+      await waitFor(() => expect(warn).toHaveBeenCalledWith(expect.stringContaining('references unknown panelId "hot-plugin-typo.panel"')))
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   test("updates command palette entries when plugin front registrations change", async () => {
     const importFront = async (_url: string, revision: number): Promise<{ default: BoringFrontFactoryWithId }> => ({
       default: hotPlugin("hot-plugin", (api) => {

--- a/packages/workspace/src/front/agentPlugins/registerAgentPlugin.tsx
+++ b/packages/workspace/src/front/agentPlugins/registerAgentPlugin.tsx
@@ -187,6 +187,16 @@ function buildRegistryPayloads(
   }
   for (const tab of captured.leftTabs) {
     const referencedPanel = panelsById.get(tab.panelId)
+    if (!tab.component && !referencedPanel) {
+      // A leftTab pointing at an unknown panelId renders an empty pane —
+      // almost always a typo in the plugin (the panel id and the tab's
+      // panelId drifted apart). Be loud: the silent fallback cost real
+      // debugging time in the field.
+      console.warn(
+        `[boring-ui] plugin "${pluginId}": left tab "${tab.id}" references unknown panelId "${tab.panelId}" `
+        + `(registered panels: ${[...panelsById.keys()].join(", ") || "none"}). The tab will render empty.`,
+      )
+    }
     panels.push({
       id: tab.id,
       title: tab.title,

--- a/packages/workspace/src/server/agentPlugins/manager.ts
+++ b/packages/workspace/src/server/agentPlugins/manager.ts
@@ -224,7 +224,7 @@ function computeRequiresRestart(
 }
 
 export class BoringPluginAssetManager {
-  private readonly pluginDirs: BoringPluginSourceInput[]
+  private pluginDirs: BoringPluginSourceInput[]
   private readonly errorRoot: string
   private readonly frontTargetResolver?: BoringPluginFrontTargetResolver
   private readonly includeLegacyFrontUrl: boolean
@@ -240,6 +240,17 @@ export class BoringPluginAssetManager {
     this.errorRoot = options.errorRoot ?? join(process.cwd(), ".pi", "extensions") // callers MUST override errorRoot in non-trivial deployments
     this.frontTargetResolver = options.frontTargetResolver
     this.includeLegacyFrontUrl = options.includeLegacyFrontUrl ?? true
+  }
+
+  /**
+   * Replace the scanned source roots. Lets hosts re-resolve discovery inputs
+   * (e.g. workspace `.pi/settings.json` package sources, which can gain
+   * entries after `boring-ui-plugin install`) before the next load() so
+   * `/reload` picks up newly installed plugin sources without a process
+   * restart.
+   */
+  setPluginDirs(pluginDirs: BoringPluginSourceInput[]): void {
+    this.pluginDirs = pluginDirs
   }
 
   preflight(): BoringPluginPreflightResult {


### PR DESCRIPTION
## Context

Diagnosed live on the workspaces hub (global CLI 0.1.35, `boring-ui-workspaces.service`): no plugin panels loaded in the browser despite the server listing and replaying them.

## Fix 1 — Vite dep-optimizer churn breaks plugin front loading

**Symptom:** plugins stuck at `boring.plugin.front-pending`, console shows `ERR_FILE_NOT_FOUND_IN_OPTIMIZED_DEP_DIR` under the global install's `node_modules/.vite/deps`, dynamic imports of plugin modules hang forever inside the app page.

**Cause:** the plugin front runtime's embedded Vite server runs with dep discovery enabled. As plugin imports surface new deps mid-session, Vite re-optimizes, rewriting `.vite/deps` and bumping the `browserHash` — invalidating chunk URLs the browser already holds and stalling in-flight transforms. (Caught it live: `.vite/deps` was being rewritten while the page was broken.)

**Fix:** `optimizeDeps: { entries: [], noDiscovery: true }`. The runtime host serves dependencies through its own proxy/singleton routes, so pre-bundling buys nothing. Verified on the live instance (hot-patched dist): transforms serve in ~3ms with zero `.vite/deps` references; only the small stable react set from `@vitejs/plugin-react`'s `include` is pre-bundled once at boot.

Same change already exists on the PR #194 branch; this PR ports it to main standalone so it can ship as a patch release.

## Fix 2 — plugin sources added after boot are invisible until restart

**Symptom:** restoring package sources to `.pi/settings.json` + `/reload` did nothing; only a process restart picked them up.

**Cause:** workspaces mode resolves discovery roots once when a workspace runtime is created; `/reload` rescans the same frozen root list.

**Fix:** `BoringPluginAssetManager.setPluginDirs()` (small additive API) + `beforeReload` re-resolves roots via `resolveCliBoringPluginDirs` before rescanning. Covered by a new test simulating `boring-ui-plugin install` → `/reload`.

## Test plan

- New test: package source added to `.pi/settings.json` after boot appears after `/reload`
- Existing workspaces-mode suite: 7/7
- Workspace manager suite: 32/32, typecheck clean (cli + workspace)
- Live verification of fix 1 on the running hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)