### PR TITLE
fix(workspace): un-stick "Preparing workspace" overlay on slow/restarting servers

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceBackgroundBoot.tsx
+++ b/packages/workspace/src/app/front/WorkspaceBackgroundBoot.tsx
@@ -17,6 +17,14 @@ import {
 } from "./workspacePreload"
 
 const PREPARING_RETRY_DELAY_MS = 500
+// Per-attempt budget for a single warmup request. Right after a server
+// (re)start the event loop can be saturated for tens of seconds by cold
+// plugin transforms; an un-timed fetch issued in that window hangs
+// indefinitely and pins the "Preparing workspace" overlay even though the
+// server becomes ready moments later (recoverable only by remounting, e.g.
+// switching workspaces). Treat a slow attempt as retryable-preparing so the
+// normal retry loop re-issues a fresh request against the recovered server.
+const WARMUP_ATTEMPT_TIMEOUT_MS = 10_000
 
 export interface WorkspaceBackgroundBootProps {
   workspaceId: string
@@ -127,20 +135,40 @@ async function fetchWarmupPath({
   signal: AbortSignal
   workspaceId: string
 }): Promise<WarmupPathResult> {
-  const response = await fetch(preloadUrl(apiBaseUrl, path), { headers, signal })
-  if (isReadyStatusPath(path)) return fetchReadyStatusWarmupPath(response)
+  // Bound each attempt and treat timeouts/network-level failures (server
+  // restarting, connection refused) as retryable-preparing rather than a
+  // terminal failure: the caller's retry loop re-issues a fresh attempt.
+  const attempt = new AbortController()
+  const timeout = globalThis.setTimeout(() => attempt.abort(new DOMException("Warmup attempt timed out", "TimeoutError")), WARMUP_ATTEMPT_TIMEOUT_MS)
+  const onOuterAbort = () => attempt.abort(signal.reason)
+  if (signal.aborted) onOuterAbort()
+  signal.addEventListener("abort", onOuterAbort, { once: true })
+  try {
+    const response = await fetch(preloadUrl(apiBaseUrl, path), { headers, signal: attempt.signal })
+    if (isReadyStatusPath(path)) return await fetchReadyStatusWarmupPath(response)
 
-  const payload = await readResponsePayload(response)
-  if (!response.ok) {
-    const preparing = parseRetryableWarmupPreparing(payload)
-    if (preparing) return { status: "preparing", ...preparing }
-    throw new Error(errorMessageFromPayload(payload) ?? `${path} failed with ${response.status}`)
-  }
+    const payload = await readResponsePayload(response)
+    if (!response.ok) {
+      const preparing = parseRetryableWarmupPreparing(payload)
+      if (preparing) return { status: "preparing", ...preparing }
+      throw new Error(errorMessageFromPayload(payload) ?? `${path} failed with ${response.status}`)
+    }
 
-  if (payload && typeof payload === "object") {
-    seedTreePreloadFromBody(apiBaseUrl, headers["x-boring-workspace-id"] ?? workspaceId, path, payload as { entries?: unknown })
+    if (payload && typeof payload === "object") {
+      seedTreePreloadFromBody(apiBaseUrl, headers["x-boring-workspace-id"] ?? workspaceId, path, payload as { entries?: unknown })
+    }
+    return { status: "ready" }
+  } catch (error) {
+    if (signal.aborted) throw error
+    // Attempt timeout or network-level failure (TypeError: Failed to fetch /
+    // aborted body read): retryable, not fatal. HTTP-level errors with a
+    // payload are thrown above and stay terminal.
+    if (attempt.signal.aborted || (error instanceof TypeError)) return { status: "preparing" }
+    throw error
+  } finally {
+    globalThis.clearTimeout(timeout)
+    signal.removeEventListener("abort", onOuterAbort)
   }
-  return { status: "ready" }
 }
 
 export function WorkspaceBackgroundBoot({

--- a/packages/workspace/src/app/front/__tests__/WorkspaceBackgroundBoot.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceBackgroundBoot.test.tsx
@@ -254,6 +254,77 @@ it("updates runtime dependency status after workspace becomes usable", async () 
   }), { timeout: 2_500 })
 })
 
+it("treats network-level fetch failures as retryable preparing, then recovers", async () => {
+  // Server restarting: fetch rejects with TypeError. The warmup must keep
+  // retrying (preparing), not fail terminally, and recover once the server
+  // is back — without a remount.
+  const onStatusChange = vi.fn()
+  let calls = 0
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input)
+    calls += 1
+    if (calls <= 2) throw new TypeError("Failed to fetch")
+    if (url.includes("/api/v1/tree")) return json({ entries: [] })
+    if (url.includes("/api/v1/ready-status")) return new Response(null, { status: 200 })
+    return json([])
+  }))
+
+  render(
+    <WorkspaceBackgroundBoot
+      workspaceId="w-netfail"
+      apiBaseUrl="/base"
+      requestHeaders={{ "x-boring-workspace-id": "w-netfail" }}
+      onStatusChange={onStatusChange}
+    />,
+  )
+
+  await waitFor(() => expect(onStatusChange).toHaveBeenLastCalledWith({ status: "ready" }), { timeout: 8000 })
+  expect(onStatusChange.mock.calls.some(([status]) => status.status === "failed")).toBe(false)
+}, 15_000)
+
+it("times out a hung warmup attempt and recovers on retry", async () => {
+  // Right after a server restart the event loop can be saturated for tens of
+  // seconds; an un-timed first fetch would hang forever and pin the
+  // "Preparing workspace" overlay until remount. A hung attempt must be
+  // aborted and retried.
+  vi.useFakeTimers()
+  try {
+    const onStatusChange = vi.fn()
+    let calls = 0
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      calls += 1
+      if (calls <= 2) {
+        // Hang until aborted by the per-attempt timeout.
+        return new Promise<Response>((_, reject) => {
+          init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true })
+        })
+      }
+      if (url.includes("/api/v1/tree")) return Promise.resolve(json({ entries: [] }))
+      if (url.includes("/api/v1/ready-status")) return Promise.resolve(new Response(null, { status: 200 }))
+      return Promise.resolve(json([]))
+    }))
+
+    render(
+      <WorkspaceBackgroundBoot
+        workspaceId="w-hang"
+        apiBaseUrl="/base"
+        requestHeaders={{ "x-boring-workspace-id": "w-hang" }}
+        onStatusChange={onStatusChange}
+      />,
+    )
+
+    // First attempts hang; advance past the attempt timeout + retry delay.
+    await vi.advanceTimersByTimeAsync(11_000)
+    await vi.advanceTimersByTimeAsync(11_000)
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(onStatusChange).toHaveBeenLastCalledWith({ status: "ready" })
+    expect(onStatusChange.mock.calls.some(([status]) => status.status === "failed")).toBe(false)
+  } finally {
+    vi.useRealTimers()
+  }
+}, 20_000)
+
 it("reports degraded ready-status SSE as failed", async () => {
   const onStatusChange = vi.fn()
   vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Symptom

Opening a workspace right after the hub (re)starts shows "Preparing workspace…" indefinitely. Switching to another workspace and back makes it load instantly — reported live on the workspaces hub.

## Root cause

`WorkspaceBackgroundBoot`'s warmup fetches have **no timeout** and treat network-level failures as terminal:

1. Right after a restart, the server's event loop is saturated by cold plugin transforms (measured: single transforms taking 12s, `index.html` 30s+). A warmup fetch issued in that window hangs on `await fetch` forever — no retry loop ever runs, the overlay pins. Remounting the component (workspace switch) re-runs the effect against the now-warm server → instant ready. Exactly the reported recovery gesture.
2. If the fetch lands while the server is still down (connection refused), the `TypeError` flipped status to a terminal `failed` with no retry.

## Fix

- Bound each warmup attempt at 10s (per-attempt `AbortController` chained to the outer signal, covering both headers and body/SSE-snapshot reads)
- Convert attempt timeouts and network-level failures into retryable-`preparing` results — the existing 500ms retry loop then re-issues fresh requests until the server recovers
- HTTP-level errors with a payload remain terminal (unchanged)

## Tests

Two new regressions: hung-fetch → timeout → retry → ready (fake timers), and connection-refused ×2 → retry → ready, both asserting no terminal `failed`. Full `app/front` suite 26/26, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)