### PR TITLE
fix(agent): retry session-list fetches across server restarts

### DIFF
--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
@@ -773,6 +773,27 @@ describe('usePiSessions', () => {
     expect(result.current.error).toBeUndefined()
   })
 
+  test('retries network-level fetch failures (server restarting) instead of failing terminally', async () => {
+    const remote = remoteFactory()
+    fetchMock
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockRejectedValueOnce(new TypeError('Failed to fetch'))
+      .mockResolvedValueOnce(jsonResponse([session('pi-after-restart')]))
+
+    const { result } = renderHook(() => usePiSessions({
+      storageScope: 'scope-a',
+      fetch: fetchMock as unknown as typeof fetch,
+      createRemoteSession: remote.factory,
+      retry: { baseMs: 1, maxMs: 1, maxRetries: 4 },
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(result.current.activeSessionId).toBe('pi-after-restart')
+    expect(result.current.error).toBeUndefined()
+  })
+
   test('preserves the current active session while retrying a transient cold-runtime 503 refresh', async () => {
     const remote = remoteFactory()
     const retryResponse = deferred<Response>()

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -5,7 +5,10 @@ import { readActiveSessionId, writeActiveSessionId, type ActiveSessionStorageLik
 
 const DEFAULT_SESSIONS_API_PATH = '/api/v1/agent/pi-chat/sessions'
 const SESSION_PAGE_SIZE = 50
-const DEFAULT_MAX_RETRIES = 8
+// 60 attempts with the 2s backoff cap ≈ two minutes of resilience — enough
+// to ride out a hub restart plus its cold-start window, after which the
+// session list recovers without a remount.
+const DEFAULT_MAX_RETRIES = 60
 const DEFAULT_RETRY_BASE_MS = 250
 const DEFAULT_RETRY_MAX_MS = 2_000
 
@@ -61,6 +64,14 @@ class SessionsPreparingError extends Error {
     super('Agent runtime is still preparing')
     this.name = 'SessionsPreparingError'
   }
+}
+
+// Network-level failure (server restarting, connection refused). fetch()
+// rejects with TypeError in every browser for these; they are transient by
+// nature and must be retried like a 503, not surfaced as a terminal error
+// that pins "Loading sessions" until the component remounts.
+function isNetworkFetchError(error: unknown): boolean {
+  return error instanceof TypeError
 }
 
 export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessionsResult {
@@ -219,7 +230,8 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
           data = await fetchSessionList(fetchImpl, sessionsListUrl(0, preferredSessionId()), requestHeaders())
           break
         } catch (err) {
-          const retryable = err instanceof SessionsPreparingError && attempt < retryMaxRetries
+          const transient = err instanceof SessionsPreparingError || isNetworkFetchError(err)
+          const retryable = transient && attempt < retryMaxRetries
           if (!retryable) throw err
           if (!isCurrent()) return
           await delayWithRef(retryDelayMs(attempt, { baseMs: retryBaseMs, maxMs: retryMaxMs }), retryTimerRef)


### PR DESCRIPTION
Companion to #265. The sessions list (`usePiSessions`) only retried cold-runtime 503s; a network-level fetch failure during a hub restart was terminal — "Loading sessions…" pinned until a remount (workspace switch). The chat-history side (`remotePiSession`) already reconnects with unbounded backoff, so this was the remaining un-retried chat path.

- fetch `TypeError` (connection refused / server restarting) now retries with the same bounded backoff as 503s
- default retry budget raised 8 → 60 attempts (~2 min at the 2s backoff cap), covering a restart plus its cold-start window
- regression test: two network failures then success → list loads, no terminal error

Tests: sessions hook 30/30, chat front suite 186/186, agent typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)