### PR TITLE
fix(plugins): surface plugin/skill load errors to the UI and the agent

### DIFF
--- a/.agents/skills/documentation-website-for-software-project/SKILL.md
+++ b/.agents/skills/documentation-website-for-software-project/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: documentation-website-for-software-project‍​‌‌​​‌‌​​‌‌​​​​‌​‌‌​​​‌​
+name: documentation-website-for-software-project
 description: >-
   Generate a polished Nextra documentation site from any source repo. Use when
   building a docs site, "docs site for this repo", MDX docs, or deploying docs
@@ -111,7 +111,7 @@ Full per-phase playbook with exact prompts for each parallel subagent: **[PHASES
 
 ## Parallelism Model
 
-Research and drafting are the large, parallelizable phases. The partition is the repo's module boundary — usually `src/<module>` or top-level folder.​​‌‌​​​​​‌‌​​‌​​​​‌‌​​‌‌
+Research and drafting are the large, parallelizable phases. The partition is the repo's module boundary — usually `src/<module>` or top-level folder.
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
@@ -203,7 +203,7 @@ Every page belongs to exactly one of four quadrants: **Tutorial**, **How-to**, *
 - **Tutorial** — teach by doing. Linear. Has a concrete end state.
 - **How-to** — accomplish a named task. For readers who know what they want.
 - **Reference** — authoritative, exhaustive, austere. For lookup.
-- **Explanation** — discursive. For readers who want to understand *why*.​‌‌​​‌​​​‌‌​​​​‌​‌‌​​​​‌
+- **Explanation** — discursive. For readers who want to understand *why*.
 
 Sidebar mirrors this by default (top-level Tutorials / Guides / Reference / Concepts sections). See **[DIATAXIS.md](references/DIATAXIS.md)** for the full framework, classification rubric, and mixing antipatterns.
 
@@ -300,7 +300,7 @@ Canonical, paste-ready code for every one of these: **[NEXTRA.md](references/NEX
 | Need | File |
 |------|------|
 | Technical-writing craft (curse of knowledge, progressive disclosure, rhythm, voice) | [WRITING-CRAFT.md](references/WRITING-CRAFT.md) |
-| Per-audience content strategy (5 personas, routing, narrowing) | [AUDIENCE.md](references/AUDIENCE.md) |​‌‌​​​‌‌​‌‌​​‌​‌​‌‌​​‌​‌‍
+| Per-audience content strategy (5 personas, routing, narrowing) | [AUDIENCE.md](references/AUDIENCE.md) |
 | Diagramming (Mermaid, D2, PlantUML, Excalidraw, ASCII, dark-mode) | [DIAGRAMS.md](references/DIAGRAMS.md) |
 | Glossary + FAQ authoring craft | [GLOSSARY-CRAFT.md](references/GLOSSARY-CRAFT.md) |
 | ADR / design-decision records embedded in docs | [ADR-PATTERNS.md](references/ADR-PATTERNS.md) |

--- a/packages/agent/src/server/__tests__/createAgentApp.test.ts
+++ b/packages/agent/src/server/__tests__/createAgentApp.test.ts
@@ -198,6 +198,46 @@ test('createAgentApp can use a custom harness factory for non-pi runtimes', asyn
   }
 })
 
+test('POST /api/v1/agent/reload surfaces harness resource diagnostics', async () => {
+  const workspaceRoot = await makeTempDir('boring-ui-reload-diagnostics-')
+  const app = await createAgentApp({
+    workspaceRoot,
+    mode: 'direct',
+    logger: false,
+    harnessFactory: vi.fn(async () => ({
+      id: 'diagnostics-harness',
+      placement: 'server' as const,
+      sessions: {
+        async list() { return [] },
+        async create() {
+          const now = new Date().toISOString()
+          return { id: 'custom', title: 'Custom', createdAt: now, updatedAt: now, turnCount: 0 }
+        },
+        async load() {
+          const now = new Date().toISOString()
+          return { id: 'custom', title: 'Custom', createdAt: now, updatedAt: now, turnCount: 0, messages: [] }
+        },
+        async delete() {},
+      },
+      reloadSession: async () => true,
+      getResourceDiagnostics: () => [
+        { source: 'pi-skills', message: 'bad SKILL.md', path: 'skills/broken' },
+      ],
+    })),
+  })
+  try {
+    const res = await app.inject({ method: 'POST', url: '/api/v1/agent/reload', payload: { sessionId: 'custom' } })
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.reloaded).toBe(true)
+    expect(body.diagnostics).toEqual([
+      { source: 'pi-skills', message: 'bad SKILL.md' },
+    ])
+  } finally {
+    await app.close()
+  }
+})
+
 test('GET /api/v1/agent/commands reports command discovery failures', async () => {
   const workspaceRoot = await makeTempDir('boring-ui-command-route-failure-')
   const app = await createAgentApp({
@@ -277,6 +317,7 @@ test('POST /api/v1/agent/reload includes beforeReload restart warnings and diagn
       ],
       diagnostics: [
         { source: 'directory (/plugin)', pluginId: 'broken-plugin', message: 'syntax error' },
+        { source: 'reload', message: 'No live agent session to reload yet — changes apply to the next session.' },
       ],
     })
   } finally {
@@ -556,7 +597,14 @@ test('POST /api/v1/agent/reload is available before first turn', async () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ ok: true, sessionId: 'default', reloaded: false })
+    expect(res.json()).toEqual({
+      ok: true,
+      sessionId: 'default',
+      reloaded: false,
+      diagnostics: [
+        { source: 'reload', message: 'No live agent session to reload yet — changes apply to the next session.' },
+      ],
+    })
   } finally {
     await app.close()
   }

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -1,6 +1,6 @@
 import Fastify, { type FastifyInstance } from 'fastify'
 import type { AgentTool } from '../shared/tool'
-import type { AgentHarnessFactory } from '../shared/harness'
+import type { AgentHarness, AgentHarnessFactory } from '../shared/harness'
 import type { TelemetrySink } from '../shared/telemetry'
 import { getEnv } from './config/env'
 import type { RuntimeModeAdapter, RuntimeModeId } from './runtime/mode'
@@ -31,6 +31,8 @@ import { gitRoutes } from './http/routes/git'
 import { InMemorySessionChangesTracker } from './http/sessionChangesTracker'
 import { ReadyStatusTracker } from './sandbox/vercel-sandbox/readyStatus'
 import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
+import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
+import type { ReloadHookDiagnostic } from './http/routes/reload'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_SESSION_ID = 'default'
@@ -86,6 +88,15 @@ export interface CreateAgentAppOptions {
    * the workspace plugin layer.
    */
   systemPromptDynamic?: () => string | undefined | Promise<string | undefined>
+  /**
+   * Optional host callback returning current plugin/skill load diagnostics
+   * for this workspace. Surfaced by the `plugin_diagnostics` agent tool so the
+   * model can iterate on plugin/skill load errors after a /reload.
+   */
+  getPluginDiagnostics?: (args: {
+    workspaceId: string
+    workspaceRoot: string
+  }) => Promise<Array<{ source: string; message: string; pluginId?: string }>>
 }
 
 export async function createAgentApp(
@@ -131,6 +142,12 @@ export async function createAgentApp(
     ],
   }
 
+  // Captured after the harness is built; read through thunks because the
+  // plugin_diagnostics tool is added to the tool catalog before the harness
+  // exists, and diagnostics accumulate on each /reload.
+  let harnessRef: AgentHarness | undefined
+  let lastReloadDiagnostics: ReloadHookDiagnostic[] = []
+
   const tools: AgentTool[] = [
     ...buildHarnessAgentTools(runtimeBundle, {
       getCurrent: () => {
@@ -141,6 +158,16 @@ export async function createAgentApp(
     ...(opts.disableDefaultFileTools ? [] : buildFilesystemAgentTools(runtimeBundle)),
     ...(opts.extraTools ?? []),
     ...pluginTools,
+    createPluginDiagnosticsTool({
+      getLastReloadDiagnostics: () => lastReloadDiagnostics,
+      getHarness: () => harnessRef,
+      ...(opts.getPluginDiagnostics
+        ? {
+            getPluginErrors: () =>
+              opts.getPluginDiagnostics!({ workspaceId: sessionId, workspaceRoot }),
+          }
+        : {}),
+    }),
   ]
 
   const harnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
@@ -160,6 +187,7 @@ export async function createAgentApp(
     systemPromptDynamic: opts.systemPromptDynamic,
     telemetry: opts.telemetry,
   })
+  harnessRef = harness
   const sessionChangesTracker = new InMemorySessionChangesTracker()
 
   const readyTracker = new ReadyStatusTracker({
@@ -222,7 +250,14 @@ export async function createAgentApp(
   await app.register(sessionChangesRoutes, { tracker: sessionChangesTracker })
   await app.register(catalogRoutes, { tools })
   await app.register(commandsRoutes, { harness, defaultSessionId: sessionId, workdir: runtimeBundle.workspace.root })
-  await app.register(reloadRoutes, { harness, defaultSessionId: sessionId, beforeReload: opts.beforeReload })
+  await app.register(reloadRoutes, {
+    harness,
+    defaultSessionId: sessionId,
+    beforeReload: opts.beforeReload,
+    onDiagnostics: (diagnostics) => {
+      lastReloadDiagnostics = diagnostics
+    },
+  })
   await app.register(readyStatusRoutes, { tracker: readyTracker })
 
   return app

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -540,6 +540,45 @@ export function createPiCodingAgentHarness(opts: {
       return piSessions.has(sessionId);
     },
 
+    /**
+     * Surface Pi's skill/extension load diagnostics for a session so silent
+     * load failures (bad SKILL.md, extension import errors) reach the UI and
+     * the agent. Returns [] when the session has no live pi session yet.
+     * The resourceLoader getters are synchronous.
+     */
+    getResourceDiagnostics(sessionId: string): Array<{ source: string; message: string; path?: string }> {
+      const handle = piSessions.get(sessionId);
+      if (!handle) return [];
+      const out: Array<{ source: string; message: string; path?: string }> = [];
+      // Pi can emit the same diagnostic once per skill-path source, and its
+      // messages often embed the path already — append it only when missing
+      // and de-duplicate on the final (source, message) pair.
+      const seen = new Set<string>();
+      const push = (entry: { source: string; message: string; path?: string }) => {
+        const key = `${entry.source}\n${entry.message}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        out.push(entry);
+      };
+      for (const diagnostic of handle.resourceLoader.getSkills().diagnostics) {
+        push({
+          source: "pi-skills",
+          message: diagnostic.path && !diagnostic.message.includes(diagnostic.path)
+            ? `${diagnostic.message} (${diagnostic.path})`
+            : diagnostic.message,
+          ...(diagnostic.path ? { path: diagnostic.path } : {}),
+        });
+      }
+      for (const error of handle.resourceLoader.getExtensions().errors) {
+        push({
+          source: "pi-extensions",
+          message: error.error.includes(error.path) ? error.error : `${error.error} (${error.path})`,
+          path: error.path,
+        });
+      }
+      return out;
+    },
+
     reloadSession: reloadPiSession,
 
     async getSlashCommands(sessionId: string, ctx: RunContext): Promise<ReadonlyArray<AgentSlashCommandSummary>> {

--- a/packages/agent/src/server/http/routes/__tests__/skills.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/skills.test.ts
@@ -1,0 +1,40 @@
+import Fastify from 'fastify'
+import { describe, test, expect } from 'vitest'
+import { skillsRoutes } from '../skills'
+
+function buildApp(opts: Parameters<typeof skillsRoutes>[1]) {
+  const app = Fastify({ logger: false })
+  app.register(skillsRoutes, opts)
+  return app.ready().then(() => app)
+}
+
+describe('GET /api/v1/agent/skills', () => {
+  test('returns skills array (possibly empty) for a workspace root', async () => {
+    const app = await buildApp({ workspaceRoot: process.cwd(), noSkills: true })
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/agent/skills' })
+
+    expect(res.statusCode).toBe(200)
+    expect(Array.isArray(res.json().skills)).toBe(true)
+
+    await app.close()
+  })
+
+  test('surfaces an error field instead of silently swallowing failures', async () => {
+    const app = await buildApp({
+      workspaceRoot: process.cwd(),
+      getWorkspaceRoot: () => {
+        throw new Error('boom resolving workspace root')
+      },
+    })
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/agent/skills' })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.skills).toEqual([])
+    expect(body.error).toContain('boom resolving workspace root')
+
+    await app.close()
+  })
+})

--- a/packages/agent/src/server/http/routes/reload.ts
+++ b/packages/agent/src/server/http/routes/reload.ts
@@ -34,6 +34,12 @@ export interface ReloadRoutesOptions {
     | ReloadHookResult
     | undefined
     | Promise<void | ReloadHookResult | undefined>
+  /**
+   * Called with the combined diagnostics (hook + harness resource
+   * diagnostics) after a reload, so a host can stash them for the
+   * `plugin_diagnostics` tool to replay to the agent.
+   */
+  onDiagnostics?: (diagnostics: ReloadHookDiagnostic[]) => void
 }
 
 interface ReloadBody {
@@ -55,13 +61,27 @@ export function reloadRoutes(
       const hookResult = await opts.beforeReload?.()
       const reloaded = await opts.harness.reloadSession(sessionId)
       const restart_warnings = hookResult?.restart_warnings
-      const diagnostics = hookResult?.diagnostics
+      const diagnostics: ReloadHookDiagnostic[] = [
+        ...(hookResult?.diagnostics ?? []),
+        ...(opts.harness.getResourceDiagnostics?.(sessionId) ?? []).map((d) => ({
+          source: d.source,
+          // The harness already folds the path into the message.
+          message: d.message,
+        })),
+      ]
+      if (!reloaded) {
+        diagnostics.push({
+          source: "reload",
+          message: "No live agent session to reload yet — changes apply to the next session.",
+        })
+      }
+      opts.onDiagnostics?.(diagnostics)
       return {
         ok: true,
         sessionId,
         reloaded,
         ...(restart_warnings && restart_warnings.length > 0 ? { restart_warnings } : {}),
-        ...(diagnostics && diagnostics.length > 0 ? { diagnostics } : {}),
+        ...(diagnostics.length > 0 ? { diagnostics } : {}),
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)

--- a/packages/agent/src/server/http/routes/skills.ts
+++ b/packages/agent/src/server/http/routes/skills.ts
@@ -103,8 +103,12 @@ export function skillsRoutes(
       }))
       cached.set(cacheKey, { skills, expiresAt: now + CACHE_TTL_MS })
       return reply.code(200).send({ skills })
-    } catch {
-      return reply.code(200).send({ skills: [] })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      request.log.warn({ err: error }, '[agent] failed to load skills')
+      // Still 200 so the slash-command picker keeps working; the `error`
+      // field makes the failure observable to callers that inspect it.
+      return reply.code(200).send({ skills: [], error: message })
     }
   })
 

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -45,6 +45,7 @@ import { InMemorySessionChangesTracker } from './http/sessionChangesTracker'
 import { ReadyStatusTracker } from './sandbox/vercel-sandbox/readyStatus'
 import type { AgentHarness } from '../shared/harness'
 import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
+import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_WORKSPACE_ID = 'default'
@@ -106,6 +107,12 @@ interface RuntimeBinding {
   readyTracker: ReadyStatusTracker
   piChatService?: HarnessPiChatService
   lastHealthCheckMs?: number
+  /**
+   * Diagnostics from the most recent /api/v1/agent/reload (merged hook +
+   * harness resource diagnostics). Stashed so the `plugin_diagnostics` tool
+   * can replay them to the agent.
+   */
+  lastReloadDiagnostics?: Array<{ source: string; message: string; pluginId?: string }>
 }
 
 interface RuntimeBindingEntry {
@@ -311,6 +318,15 @@ export interface RegisterAgentRoutesOptions {
     workspaceRoot: string
     request: FastifyRequest
   }) => void | ReloadHookResult | undefined | Promise<void | ReloadHookResult | undefined>
+  /**
+   * Optional host callback returning current plugin/skill load diagnostics
+   * for a workspace. Surfaced by the `plugin_diagnostics` agent tool so the
+   * model can iterate on plugin/skill load errors after a /reload.
+   */
+  getPluginDiagnostics?: (args: {
+    workspaceId: string
+    workspaceRoot: string
+  }) => Promise<Array<{ source: string; message: string; pluginId?: string }>>
 }
 
 /**
@@ -557,6 +573,17 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       }),
       ...buildFilesystemAgentTools(runtimeBundle),
       ...buildUploadAgentTools(runtimeBundle),
+      createPluginDiagnosticsTool({
+        // `binding` is assigned later in this function; read through thunks.
+        getLastReloadDiagnostics: () => binding?.lastReloadDiagnostics ?? [],
+        getHarness: () => binding?.harness,
+        ...(opts.getPluginDiagnostics
+          ? {
+              getPluginErrors: () =>
+                opts.getPluginDiagnostics!({ workspaceId, workspaceRoot: root }),
+            }
+          : {}),
+      }),
     ]
     const pluginTools: PluginToolRegistration[] = []
 
@@ -947,13 +974,31 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       const reloadSessionId = request.body?.sessionId || sessionId
       const reloaded = await binding.harness.reloadSession(reloadSessionId)
       const restart_warnings = hookResult?.restart_warnings
-      const diagnostics = hookResult?.diagnostics
+      const diagnostics: Array<{ source: string; message: string; pluginId?: string }> = [
+        ...(hookResult?.diagnostics ?? []),
+        ...(binding.harness.getResourceDiagnostics?.(reloadSessionId) ?? []).map((d) => ({
+          source: d.source,
+          // The harness already folds the path into the message (front only
+          // renders `.message`).
+          message: d.message,
+        })),
+      ]
+      // If the harness reported nothing reloaded (no live agent session yet),
+      // surface a note so a "/reload had no effect" state is observable rather
+      // than looking like a clean reload.
+      if (!reloaded) {
+        diagnostics.push({
+          source: 'reload',
+          message: 'No live agent session to reload yet — changes apply to the next session.',
+        })
+      }
+      binding.lastReloadDiagnostics = diagnostics
       return {
         ok: true,
         sessionId: reloadSessionId,
         reloaded,
         ...(restart_warnings && restart_warnings.length > 0 ? { restart_warnings } : {}),
-        ...(diagnostics && diagnostics.length > 0 ? { diagnostics } : {}),
+        ...(diagnostics.length > 0 ? { diagnostics } : {}),
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)

--- a/packages/agent/src/server/tools/__tests__/pluginDiagnostics.test.ts
+++ b/packages/agent/src/server/tools/__tests__/pluginDiagnostics.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'vitest'
+import { createPluginDiagnosticsTool } from '../pluginDiagnostics'
+import type { AgentHarness } from '../../../shared/harness'
+import type { ToolExecContext } from '../../../shared/tool'
+
+function ctx(sessionId?: string): ToolExecContext {
+  return {
+    abortSignal: new AbortController().signal,
+    toolCallId: 'call-1',
+    ...(sessionId ? { sessionId } : {}),
+  }
+}
+
+describe('plugin_diagnostics tool', () => {
+  test('merges last-reload, harness resource, and host plugin diagnostics', async () => {
+    const harness = {
+      id: 'fake',
+      placement: 'server',
+      sessions: {} as AgentHarness['sessions'],
+      getResourceDiagnostics: (sessionId: string) => [
+        { source: 'pi-skills', message: `skill broken for ${sessionId}`, path: 'skills/x' },
+      ],
+    } as unknown as AgentHarness
+
+    const tool = createPluginDiagnosticsTool({
+      getLastReloadDiagnostics: () => [
+        { source: 'plugin-load', message: 'reload error', pluginId: 'p1' },
+      ],
+      getHarness: () => harness,
+      getPluginErrors: async () => [
+        { source: 'plugin-preflight', message: 'INVALID: nope (/tmp/p2)', pluginId: 'p2' },
+      ],
+    })
+
+    const result = await tool.execute({}, ctx('s-1'))
+    expect(result.isError).toBe(false)
+    const payload = result.details as Record<string, unknown>
+    expect(payload.lastReloadDiagnostics).toEqual([
+      { source: 'plugin-load', message: 'reload error', pluginId: 'p1' },
+    ])
+    expect(payload.resourceDiagnostics).toEqual([
+      { source: 'pi-skills', message: 'skill broken for s-1', path: 'skills/x' },
+    ])
+    expect(payload.pluginErrors).toEqual([
+      { source: 'plugin-preflight', message: 'INVALID: nope (/tmp/p2)', pluginId: 'p2' },
+    ])
+  })
+
+  test('handles missing harness, missing sessionId, and missing host callback', async () => {
+    const tool = createPluginDiagnosticsTool({
+      getLastReloadDiagnostics: () => [],
+      getHarness: () => undefined,
+    })
+
+    const result = await tool.execute({}, ctx())
+    const payload = result.details as Record<string, unknown>
+    expect(payload).toEqual({
+      lastReloadDiagnostics: [],
+      resourceDiagnostics: [],
+      pluginErrors: [],
+    })
+  })
+})

--- a/packages/agent/src/server/tools/pluginDiagnostics.ts
+++ b/packages/agent/src/server/tools/pluginDiagnostics.ts
@@ -1,0 +1,69 @@
+/**
+ * `plugin_diagnostics` built-in agent tool.
+ *
+ * Surfaces current plugin/skill loading errors to the agent so it can iterate
+ * on them without the failures being silently swallowed. It merges three
+ * sources:
+ *
+ *  - `lastReloadDiagnostics`: diagnostics captured by the most recent
+ *    /api/v1/agent/reload (hook + harness resource diagnostics).
+ *  - `resourceDiagnostics`: live Pi skill/extension load diagnostics for the
+ *    current session, read straight from the harness.
+ *  - `pluginErrors`: host-provided plugin load/preflight errors for the
+ *    workspace (wired by the embedding host).
+ *
+ * The tool is informational: it returns the diagnostics as data and never
+ * reports `isError`, even when diagnostics exist.
+ */
+import type { AgentTool, ToolExecContext, ToolResult } from '../../shared/tool'
+import type { AgentHarness } from '../../shared/harness'
+
+interface PluginDiagnostic {
+  source: string
+  message: string
+  pluginId?: string
+}
+
+export interface PluginDiagnosticsToolDeps {
+  /** Diagnostics stashed by the last /reload. Read via a thunk because the
+   * runtime binding is assigned after the tool catalog is built. */
+  getLastReloadDiagnostics: () => ReadonlyArray<PluginDiagnostic>
+  /** Live harness, used to read per-session resource diagnostics. */
+  getHarness: () => AgentHarness | undefined
+  /** Optional host callback returning workspace plugin load/preflight errors. */
+  getPluginErrors?: () => Promise<ReadonlyArray<PluginDiagnostic>>
+}
+
+export function createPluginDiagnosticsTool(deps: PluginDiagnosticsToolDeps): AgentTool {
+  return {
+    name: 'plugin_diagnostics',
+    description: [
+      'Return current plugin/skill loading errors plus the diagnostics from the',
+      'last /reload. Call this after asking the user to run /reload — or whenever a',
+      'plugin or skill you expected does not appear to be loaded — then fix the',
+      'reported error and ask the user to /reload again. Returns a JSON object with',
+      'lastReloadDiagnostics, resourceDiagnostics, and pluginErrors arrays; an empty',
+      'result means no load errors were detected.',
+    ].join(' '),
+    parameters: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+    async execute(_params: Record<string, unknown>, ctx: ToolExecContext): Promise<ToolResult> {
+      const harness = deps.getHarness()
+      const resourceDiagnostics = harness?.getResourceDiagnostics?.(ctx.sessionId ?? '') ?? []
+      const pluginErrors = deps.getPluginErrors ? await deps.getPluginErrors() : []
+      const payload = {
+        lastReloadDiagnostics: deps.getLastReloadDiagnostics(),
+        resourceDiagnostics,
+        pluginErrors,
+      }
+      return {
+        content: [{ type: 'text', text: JSON.stringify(payload) }],
+        details: payload,
+        isError: false,
+      }
+    },
+  }
+}

--- a/packages/agent/src/shared/harness.ts
+++ b/packages/agent/src/shared/harness.ts
@@ -42,6 +42,14 @@ export interface AgentHarness {
   /** Reload native agent resources/extensions for an existing session. */
   reloadSession?: (sessionId: string) => Promise<boolean>
 
+  /**
+   * Resource (skill/extension) load diagnostics for an existing session.
+   * Returns `[]` when the session has no live agent session yet. Lets the
+   * /reload route and the `plugin_diagnostics` tool surface silent
+   * skill/extension load failures back to the UI and the agent.
+   */
+  getResourceDiagnostics?: (sessionId: string) => Array<{ source: string; message: string; path?: string }>
+
   /** List slash commands registered in the agent runtime for a given session. */
   getSlashCommands?: (sessionId: string, ctx: RunContext) => ReadonlyArray<AgentSlashCommandSummary> | Promise<ReadonlyArray<AgentSlashCommandSummary>>
 

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -601,6 +601,22 @@ export async function createWorkspacesModeApp(opts: {
         ],
       }
     },
+    getPluginDiagnostics: async ({ workspaceId }) => {
+      const workspace = await requireWorkspace(workspaceId)
+      const runtime = await getLoadedPluginRuntime(workspace)
+      return [
+        ...runtime.manager.getErrors().map((error) => ({
+          source: "plugin-load",
+          message: error.message,
+          ...(error.id ? { pluginId: error.id } : {}),
+        })),
+        ...runtime.manager.preflight().errors.map((error) => ({
+          source: "plugin-preflight",
+          message: `${error.code}: ${error.message} (${error.pluginDir})`,
+          ...(error.pluginId ? { pluginId: error.pluginId } : {}),
+        })),
+      ]
+    },
     getPi: async ({ workspaceId, workspaceRoot }) => {
       const workspace = await requireWorkspace(workspaceId)
       await getLoadedPluginRuntime(workspace)

--- a/packages/pi/skills/boring-plugin-authoring/SKILL.md
+++ b/packages/pi/skills/boring-plugin-authoring/SKILL.md
@@ -613,6 +613,12 @@ front assets plus Pi extensions/skills/prompts. If you changed `boring.server`,
 say that `/reload` is not enough: the host must statically compose that server
 entry and restart the workspace process.
 
+After the user runs `/reload`, call the `plugin_diagnostics` tool to check for
+plugin/skill load errors. `/reload` surfaces silent load failures (bad
+`SKILL.md`, extension import errors, missing `pi.skills`/`pi.extensions` paths)
+there — read the reported errors, fix them, and ask the user to `/reload` again,
+iterating until `plugin_diagnostics` comes back clean.
+
 If the user reports a page reload, `Invalid hook call`, or
 `resolveDispatcher() is null` after editing a plugin, suspect host Vite config
 first: `.pi/extensions` files must be excluded from React Refresh and ignored by

--- a/packages/plugin-cli/src/index.ts
+++ b/packages/plugin-cli/src/index.ts
@@ -77,6 +77,7 @@ function handleScaffold(positionals: string[]): void {
   console.log("  3. bash `boring-ui-plugin verify` — confirms manifests + files are valid")
   console.log("  4. if the UI is open, bash `boring-ui-plugin test <name>` — catches panel render failures")
   console.log("  5. ask the user: /reload")
+  console.log("  6. after /reload, call the plugin_diagnostics tool to confirm no load errors — /reload reports plugin/skill errors there")
 }
 
 function handleVerify(positionals: string[]): void {

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -762,6 +762,18 @@ export async function createWorkspaceAgentServer(
         ...(mergedDiagnostics.length > 0 ? { diagnostics: mergedDiagnostics } : {}),
       }
     },
+    getPluginDiagnostics: async () => [
+      ...boringAssetManager.getErrors().map((error) => ({
+        source: "plugin-load",
+        message: error.message,
+        ...(error.id ? { pluginId: error.id } : {}),
+      })),
+      ...boringAssetManager.preflight().errors.map((error) => ({
+        source: "plugin-preflight",
+        message: `${error.code}: ${error.message} (${error.pluginDir})`,
+        ...(error.pluginId ? { pluginId: error.pluginId } : {}),
+      })),
+    ],
     runtimeProvisioning: currentRuntimeProvisioning,
     getRuntimeProvisioning: () => currentRuntimeProvisioning,
     pi: {

--- a/packages/workspace/src/server/__tests__/agentPlugins.test.ts
+++ b/packages/workspace/src/server/__tests__/agentPlugins.test.ts
@@ -276,6 +276,22 @@ describe("boring agent plugin assets", () => {
     expect(plugin.pi?.systemPrompt).toBe("Test plugin context")
   })
 
+  test("fails preflight when a declared pi.skills path does not exist", async () => {
+    const root = await tmp("boring-plugin-missing-skill-")
+    await writePlugin(root)
+    const pkg = JSON.parse(await readFile(join(root, "package.json"), "utf8"))
+    pkg.pi.skills = ["skills/missing"]
+    await writeFile(join(root, "package.json"), JSON.stringify(pkg), "utf8")
+
+    const result = preflightBoringPlugins([root])
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatchObject({
+      code: "INVALID_PLUGIN_METADATA",
+      message: expect.stringContaining("skills/missing"),
+    })
+    expect(readBoringPlugins([root])).toEqual([])
+  })
+
   test("uses boring.id as explicit plugin id when provided", async () => {
     const root = await tmp("boring-plugin-explicit-id-")
     await writePlugin(root)

--- a/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -667,7 +667,11 @@ describe("createWorkspaceAgentServer — plugin provisioning", () => {
         diagnostics?: unknown[]
       }
       expect(body.ok).toBe(true)
-      expect(body.diagnostics).toBeUndefined()
+      // Session "missing" has no live agent session, so the only diagnostic is
+      // the "nothing reloaded yet" note.
+      expect(body.diagnostics).toEqual([
+        { source: "reload", message: "No live agent session to reload yet — changes apply to the next session." },
+      ])
       expect(body.restart_warnings).toEqual([
         expect.objectContaining({
           id: "reload-warning-plugin",

--- a/packages/workspace/src/server/agentPlugins/scan.ts
+++ b/packages/workspace/src/server/agentPlugins/scan.ts
@@ -110,8 +110,8 @@ function packagePathContainmentIssues(rootDir: string, pkg: BoringPluginPackageJ
   if (boring?.server !== false && boring?.server !== undefined) {
     push(pathPreflightIssue(rootDir, boring.server, "boring.server"))
   }
-  pi?.extensions?.forEach((value, index) => push(pathPreflightIssue(rootDir, value, `pi.extensions[${index}]`)))
-  pi?.skills?.forEach((value, index) => push(pathPreflightIssue(rootDir, value, `pi.skills[${index}]`)))
+  pi?.extensions?.forEach((value, index) => push(pathPreflightIssue(rootDir, value, `pi.extensions[${index}]`, { mustExist: true })))
+  pi?.skills?.forEach((value, index) => push(pathPreflightIssue(rootDir, value, `pi.skills[${index}]`, { mustExist: true })))
   return issues
 }
 


### PR DESCRIPTION
## Context

Goal: (1) workspaces load fast and reliably (cold/warm, playground + CLI hub), (2) the plugin system reloads reliably and **errors reach the agent** so it can iterate.

### Findings on (1) — load speed

Measured against both a source-built hub and the live published CLI (0.1.37), with the boring-ui-v2 workspace (413 session dirs, 1.5 GB of session history):

| Scenario | Overlay duration |
|---|---|
| Hub cold open after restart, boring-ui-v2 | ~1.8 s |
| Hub cold open, never-provisioned workspace | ~2.0 s (provisioning continues in background) |
| Live hub (published 0.1.37), direct `/workspace/<id>?session=` URL | ~1.7 s |
| Playground (folder mode, cold vite) | ~3.9 s |
| Warm API probes (sessions / skills / tree) | 15–45 ms |

The long-"Preparing workspace…" reports reproduce only on pre-0.1.37 builds; the fixes in #263/#264/#265/#266 + bdffa879 (all first published in 0.1.37, ~1 h before this branch) resolve them. No further load-path changes needed — this PR focuses on (2).

### Findings on (2) — silent plugin/skill failures (all reproduced on 0.1.37)

- A plugin declaring a nonexistent `pi.skills`/`pi.extensions` path passed preflight silently: `/reload` returned `ok:true` with **zero diagnostics** and the skill never loaded.
- Pi's own skill/extension load diagnostics (bad `SKILL.md`, invalid skill names, extension import errors) were never read by anything.
- The skills route swallowed every error into `{ skills: [] }`.
- Diagnostics that did exist reached only the UI banner — the **agent** had no way to see them.

## Changes

- **scan.ts**: declared `pi.skills` / `pi.extensions` paths must exist (preflight error, consistent with `boring.front`).
- **skills route**: log + expose failures via an `error` field instead of silently returning an empty list.
- **pi harness**: new `getResourceDiagnostics(sessionId)` exposing Pi's skill diagnostics and extension load errors (deduped, path folded into the message once).
- **`/reload`** (both hub `registerAgentRoutes` and folder `createAgentApp`/`reloadRoutes`): merges harness resource diagnostics into the response, adds an explicit note when no live session was reloaded, stashes the result.
- **New `plugin_diagnostics` agent tool** (hub + folder modes): returns last-reload diagnostics, live Pi resource diagnostics, and host plugin load/preflight errors — the agent can now read the exact error and iterate.
- **Authoring guidance**: plugin-cli scaffold next-steps + `boring-plugin-authoring` skill now instruct calling `plugin_diagnostics` after `/reload`.
- **First real catch**: `.agents/skills/documentation-website-for-software-project/SKILL.md` contained invisible zero-width characters in its frontmatter `name`, so Pi silently rejected the skill — exactly the reported "/reload does not load skills, no error" symptom. Fixed.

## Verification (end-to-end on a source-built hub against this repo's workspace)

- `/reload` with a corrupt plugin `package.json` → diagnostic `INVALID_PACKAGE_JSON: …` in the response/banner.
- `/reload` with a missing `pi.skills` path → diagnostic `pi.skills[1]: declared path does not exist: …`.
- `/reload` with a live session → `pi-skills` diagnostics for the zero-width-name skill (before its fix).
- Agent prompted to call `plugin_diagnostics` → it reported both errors verbatim and could act on them.
- Happy path re-verified: new workspace skill + new plugin (skills, system prompt, tools) all visible to the agent after `/reload`, hub and folder modes.

Tests: agent 1407 passed, workspace 1440 passed, cli 63 passed; typecheck + `pnpm lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)