### PR TITLE
fix(workspace,agent): converge direct workspace+session boot without a workspace switch

### DIFF
--- a/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
@@ -155,6 +155,38 @@ describe('RemotePiSession', () => {
     session.dispose()
   })
 
+  it('recovers a hung /state hydration via the request timeout instead of stalling forever', async () => {
+    // First /state never settles (saturated/restarting server). Without a
+    // per-attempt timeout the chat stays stuck "Loading chat history…"; the
+    // timeout must abort it so the reconnect loop re-issues a fresh request
+    // that succeeds — no remount/workspace-switch needed.
+    const events = openNdjsonStream()
+    let stateCalls = 0
+    const hang = deferred<Response>()
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url.endsWith('/state')) {
+        stateCalls += 1
+        if (stateCalls === 1) {
+          // Hang until aborted by the request timeout.
+          const signal = init?.signal
+          return new Promise<Response>((_resolve, reject) => {
+            signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true })
+          })
+        }
+        return Promise.resolve(jsonResponse(snapshot({ seq: 7 })))
+      }
+      if (url.endsWith('/events?cursor=7')) return Promise.resolve(new Response(events.stream))
+      return hang.promise
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock, { requestTimeoutMs: 20 })
+
+    await waitUntil(() => session.getState().hydrated === true, 3000)
+    expect(session.getState()).toMatchObject({ hydrated: true, lastSeq: 7 })
+    expect(stateCalls).toBeGreaterThanOrEqual(2)
+
+    session.dispose()
+  })
+
   it('rehydrates /state and reconnects from returned seq on replay_gap route errors', async () => {
     const events = openNdjsonStream()
     const fetchMock = vi.fn(async (url: string) => {

--- a/packages/agent/src/front/chat/pi/remotePiSession.ts
+++ b/packages/agent/src/front/chat/pi/remotePiSession.ts
@@ -34,6 +34,15 @@ import {
 const SUPPORTED_PROTOCOL_VERSION = 1
 const DEFAULT_RECONNECT_BASE_MS = 1_000
 const DEFAULT_RECONNECT_MAX_MS = 30_000
+// Per-attempt budget for the /state hydration (and command) fetches. Right
+// after a server (re)start the event loop can be saturated for tens of seconds
+// by cold plugin transforms; an un-timed fetch issued in that window hangs
+// indefinitely and pins the chat on "Loading chat history…" forever, because a
+// hung request never throws so hydrateAndConnect never reaches its retry path.
+// The only escape was remounting (switching workspaces). Bound each request so
+// a slow/hung attempt surfaces as a (retryable) error and the reconnect loop
+// re-issues a fresh request against the recovered server.
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000
 const DEFAULT_LARGE_STATE_WARNING_BYTES = 5 * 1024 * 1024
 const DEFAULT_LARGE_STATE_WARNING_MESSAGES = 300
 const EVENT_TYPE_RING_LIMIT = 20
@@ -68,6 +77,9 @@ export interface RemotePiSessionOptions {
   }
   setTimeoutFn?: typeof globalThis.setTimeout
   clearTimeoutFn?: typeof globalThis.clearTimeout
+  // Per-attempt timeout for /state and command fetches. Defaults to
+  // DEFAULT_REQUEST_TIMEOUT_MS; exposed mainly for tests.
+  requestTimeoutMs?: number
 }
 
 export interface RemotePiSessionLargeStateWarning {
@@ -117,6 +129,7 @@ export class RemotePiSession {
   private readonly storageScope: string
   private readonly setTimeoutFn: typeof globalThis.setTimeout
   private readonly clearTimeoutFn: typeof globalThis.clearTimeout
+  private readonly requestTimeoutMs: number
   private generation = 0
   private streamRunId = 0
   private reconnectAttempt = 0
@@ -136,6 +149,7 @@ export class RemotePiSession {
     this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis)
     this.setTimeoutFn = options.setTimeoutFn ?? globalThis.setTimeout
     this.clearTimeoutFn = options.clearTimeoutFn ?? globalThis.clearTimeout
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     this.store = createPiChatStore(createInitialPiChatState({
       sessionId: options.sessionId,
       workspaceId: options.workspaceId,
@@ -318,9 +332,25 @@ export class RemotePiSession {
       opened = true
       onOpen?.()
     }
+    // Bound only the time-to-first-response of the (long-lived) stream fetch:
+    // a saturated/restarting server can leave the request hanging before any
+    // bytes arrive, which would otherwise never reconnect. Cleared as soon as
+    // the response headers land so the streaming body is never timed out.
+    let connectTimedOut = false
+    let connectTimer: ReturnType<typeof globalThis.setTimeout> | undefined = globalThis.setTimeout(() => {
+      connectTimedOut = true
+      controller.abort()
+    }, this.requestTimeoutMs)
+    const clearConnectTimer = () => {
+      if (connectTimer !== undefined) {
+        globalThis.clearTimeout(connectTimer)
+        connectTimer = undefined
+      }
+    }
     try {
       const headers = await this.requestHeaders()
       if (!this.isStreamActive(generation, runId)) {
+        clearConnectTimer()
         markOpen()
         return
       }
@@ -329,6 +359,7 @@ export class RemotePiSession {
         headers,
         signal: controller.signal,
       })
+      clearConnectTimer()
       if (!this.isStreamActive(generation, runId)) {
         markOpen()
         return
@@ -393,10 +424,19 @@ export class RemotePiSession {
         this.scheduleReconnect(generation)
       }
     } catch (error) {
+      clearConnectTimer()
       markOpen()
-      if (!this.isStreamActive(generation, runId) || shouldIgnoreStreamClose(error, controller)) return
-      this.dispatchProtocolError(errorMessage(error, 'Pi chat event stream disconnected.'))
+      if (!this.isStreamActive(generation, runId)) return
+      // A connect-timeout aborts the controller, so shouldIgnoreStreamClose
+      // would normally swallow it; treat it instead as a recoverable
+      // disconnect that schedules a reconnect against the recovered server.
+      if (!connectTimedOut && shouldIgnoreStreamClose(error, controller)) return
+      this.dispatchProtocolError(connectTimedOut
+        ? `Pi chat event stream timed out after ${this.requestTimeoutMs}ms.`
+        : errorMessage(error, 'Pi chat event stream disconnected.'))
       this.scheduleReconnect(generation)
+    } finally {
+      clearConnectTimer()
     }
   }
 
@@ -454,12 +494,28 @@ export class RemotePiSession {
   private async fetchJson(url: string, init: RequestInit): Promise<unknown> {
     const controller = new AbortController()
     this.fetchControllers.add(controller)
+    // Bound the attempt: a hung request (saturated server right after a
+    // restart, dead keep-alive socket) would otherwise never settle, leaving
+    // the chat stuck hydrating. On timeout we abort the in-flight fetch so it
+    // rejects with an AbortError, surfacing as a retryable hydrate error.
+    let timedOut = false
+    const timer = globalThis.setTimeout(() => {
+      timedOut = true
+      controller.abort()
+    }, this.requestTimeoutMs)
     try {
       const response = await this.fetchImpl(url, { ...init, signal: controller.signal })
       const body = await safeReadJson(response)
       if (!response.ok) throw new RemotePiSessionHttpError(response.status, routeErrorMessage(body, `HTTP ${response.status}`), body)
       return body
+    } catch (error) {
+      // Distinguish our own timeout abort from a dispose-driven abort: a
+      // dispose abort must stay an (ignored) AbortError, but a timeout should
+      // throw a real error so the caller's catch reaches scheduleReconnect.
+      if (timedOut) throw new Error(`Request to ${url} timed out after ${this.requestTimeoutMs}ms.`)
+      throw error
     } finally {
+      globalThis.clearTimeout(timer)
       this.fetchControllers.delete(controller)
     }
   }

--- a/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
+++ b/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
@@ -218,6 +218,49 @@ describe("pluginFrontRuntime", () => {
     }
   }, 20_000)
 
+  test("warmupWorkspace pre-transforms tracked front entries so the first browser hit is a cache-hit", async () => {
+    const diagnostics: PluginFrontRuntimeDiagnostic[] = []
+    const pluginRoot = await makeTempDir("plugin-front-runtime-warmup-")
+    const plugin = await writeRuntimePlugin(pluginRoot, {
+      "front/index.tsx": 'import "./styles.css"\nexport const ok = true\n',
+      "front/styles.css": ".runtime-panel { color: tomato; }\n",
+    })
+
+    const host = await createPluginFrontRuntimeHost({ onDiagnostic: (entry) => diagnostics.push(entry) })
+    host.trackPlugin({
+      workspaceId: "workspace-a",
+      plugin,
+      revision: 1,
+      frontEntrySubpath: "front/index.tsx",
+    })
+
+    try {
+      // No-op for an unknown / empty workspace — must not throw.
+      await host.warmupWorkspace("does-not-exist")
+
+      await host.warmupWorkspace("workspace-a")
+      const afterWarmupCacheMisses = diagnostics.filter(
+        (d) => d.outcome === "cache-miss" && d.requestedPath === "front/index.tsx",
+      ).length
+      expect(afterWarmupCacheMisses).toBe(1)
+
+      // The browser's first request now reuses the warm transform cache.
+      const served = await host.serve({
+        workspaceId: "workspace-a",
+        pluginId: "runtime-plugin",
+        revision: 1,
+        subpath: "front/index.tsx",
+      })
+      expect(served.body).toContain("export const ok")
+      const cacheHits = diagnostics.filter(
+        (d) => d.outcome === "cache-hit" && d.requestedPath === "front/index.tsx",
+      ).length
+      expect(cacheHits).toBeGreaterThanOrEqual(1)
+    } finally {
+      await host.close()
+    }
+  }, 20_000)
+
   test("rejects direct __vite proxy access that was never minted by a validated runtime request", async () => {
     const host = await createPluginFrontRuntimeHost()
     const app = fastify({ logger: false })

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -466,6 +466,14 @@ export async function createWorkspacesModeApp(opts: {
         ensureLoaded: manager.load().then(async () => {
           syncLoadedPluginPiSnapshot(workspace, manager)
           await backendRegistry.reloadFromLoadedPlugins(manager.inspectLoaded())
+          // Fire-and-forget: pre-transform the loaded plugins' front entries
+          // (and their react/@hachej/boring-workspace singletons) so the first
+          // browser request hits a warm Vite transform cache instead of paying
+          // ~4s of cold compilation that starves the event loop and delays
+          // /state, /tree, etc. Never block binding creation; swallow errors.
+          void Promise.resolve()
+            .then(() => runtimeHost.warmupWorkspace(workspace.id))
+            .catch(() => undefined)
         }),
       }
       pluginRuntimes.set(key, runtime)

--- a/packages/cli/src/server/pluginFrontRuntime.ts
+++ b/packages/cli/src/server/pluginFrontRuntime.ts
@@ -1211,6 +1211,7 @@ export interface PluginFrontRuntimeHost {
   invalidatePlugin(workspaceId: string, pluginId: string, keepRevision?: number): Promise<void>
   disposeWorkspace(workspaceId: string): Promise<void>
   serve(request: PluginFrontRuntimeServeRequest): Promise<PluginFrontRuntimeResponse>
+  warmupWorkspace(workspaceId: string): Promise<void>
   registerRoutes(app: FastifyInstance): Promise<void>
   close(): Promise<void>
 }
@@ -1902,6 +1903,43 @@ export async function createPluginFrontRuntimeHost(
     }
   }
 
+  // Pre-transform the front entry (and, transitively, the react /
+  // @hachej/boring-workspace singleton modules it imports) for every tracked
+  // plugin in a workspace so the first browser request hits a warm transform
+  // cache instead of paying ~4s of cold Vite resolve/transform that starves
+  // the event loop. Fire-and-forget: failures are swallowed (the real browser
+  // request will surface them) and serve()'s own promise-dedupe means a
+  // concurrent browser hit reuses this in-flight transform rather than racing.
+  async function warmupWorkspace(workspaceId: string): Promise<void> {
+    if (closed) return
+    const records = trackedWorkspaces.get(workspaceId)
+    if (!records || records.size === 0) return
+    await Promise.all(
+      [...records.values()].map(async (record) => {
+        try {
+          await serve({
+            workspaceId,
+            pluginId: record.pluginId,
+            revision: record.revision,
+            subpath: record.frontEntrySubpath,
+          })
+        } catch (error) {
+          emit({
+            level: "warn",
+            stage: "transform",
+            outcome: "rejected",
+            msg: "plugin front warmup transform failed (ignored)",
+            workspaceId,
+            pluginId: record.pluginId,
+            revision: record.revision,
+            requestedPath: record.frontEntrySubpath,
+            details: { error: error instanceof Error ? error.message : String(error) },
+          })
+        }
+      }),
+    )
+  }
+
   function untrackPlugin(workspaceId: string, pluginId: string): void {
     const tracked = trackedWorkspaces.get(workspaceId)?.get(pluginId)
     trackedWorkspaces.get(workspaceId)?.delete(pluginId)
@@ -1935,6 +1973,7 @@ export async function createPluginFrontRuntimeHost(
     invalidatePlugin,
     disposeWorkspace,
     serve,
+    warmupWorkspace,
     registerRoutes,
     close,
   }

--- a/packages/workspace/src/front/agentPlugins/__tests__/registerAgentPlugin.test.tsx
+++ b/packages/workspace/src/front/agentPlugins/__tests__/registerAgentPlugin.test.tsx
@@ -1174,7 +1174,9 @@ describe("useAgentPluginHotReload", () => {
       const commandRegistry = React.useMemo(() => new CommandRegistry(), [])
       const surfaceResolverRegistry = React.useMemo(() => new SurfaceResolverRegistry(), [])
       function Listener() {
-        useAgentPluginHotReload({ workspaceId: "test-workspace", importFront })
+        // Disable the cold-start auto-retry so this test exercises the
+        // single-attempt fail → error-event → recover-on-next-dispatch path.
+        useAgentPluginHotReload({ workspaceId: "test-workspace", importFront, frontImportRetry: { attempts: 1 } })
         return null
       }
       return (
@@ -1213,6 +1215,68 @@ describe("useAgentPluginHotReload", () => {
     }
   })
 
+  test("auto-recovers a transient cold-start front import failure without a re-dispatch", async () => {
+    // Mirrors the hard-refresh case where the first import evaluates against a
+    // not-yet-warm singleton graph and throws, but the same revision imports
+    // cleanly a moment later. The hook must retry in place and register the
+    // plugin without a workspace switch or another load event.
+    const browserEvents: Array<Record<string, unknown>> = []
+    const listener = (event: Event) => browserEvents.push((event as CustomEvent<Record<string, unknown>>).detail)
+    window.addEventListener(WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT, listener)
+    let attempts = 0
+    const importFront = async (): Promise<{ default?: BoringFrontFactoryWithId }> => {
+      attempts += 1
+      if (attempts < 3) throw new Error("definePlugin: `id` is required and must be a non-empty string")
+      return {
+        default: hotPlugin("hot-plugin", (api) => {
+          api.registerPanel({
+            id: "hot-pane",
+            label: "Hot Pane",
+            component: function HotPane() {
+              return React.createElement("div", { "data-testid": "hot-pane" }, "auto recovered")
+            },
+          })
+        }),
+      }
+    }
+
+    function AutoRetryHarness() {
+      const panelRegistry = React.useMemo(() => new PanelRegistry(), [])
+      const commandRegistry = React.useMemo(() => new CommandRegistry(), [])
+      const surfaceResolverRegistry = React.useMemo(() => new SurfaceResolverRegistry(), [])
+      function Listener() {
+        useAgentPluginHotReload({ workspaceId: "test-workspace", importFront, frontImportRetry: { attempts: 4, delayMs: 5 } })
+        return null
+      }
+      return (
+        <RegistryProvider panelRegistry={panelRegistry} commandRegistry={commandRegistry} surfaceResolverRegistry={surfaceResolverRegistry}>
+          <Listener />
+          <PaneRenderer id="hot-pane" />
+        </RegistryProvider>
+      )
+    }
+
+    const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      render(<AutoRetryHarness />)
+      MockEventSource.instances[0].dispatch("boring.plugin.load", {
+        type: "boring.plugin.load",
+        id: "hot-plugin",
+        version: "1.0.0",
+        revision: 1,
+        frontTarget: { kind: "module-url", entryUrl: "/@fs/flaky.mjs", revision: 1 },
+        boring: { front: "./front.mjs" },
+      })
+      await waitFor(() => expect(screen.getByTestId("hot-pane")).toHaveTextContent("auto recovered"))
+      expect(attempts).toBe(3)
+      // No terminal front-error should be emitted once the retry succeeds.
+      expect(browserEvents).not.toContainEqual(expect.objectContaining({ type: "boring.plugin.front-error" }))
+    } finally {
+      consoleWarn.mockRestore()
+      window.removeEventListener(WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT, listener)
+    }
+  })
+
   test("keeps the current pane live when generated plugin code has no valid default factory", async () => {
     const browserEvents: Array<Record<string, unknown>> = []
     const listener = (event: Event) => browserEvents.push((event as CustomEvent<Record<string, unknown>>).detail)
@@ -1231,7 +1295,9 @@ describe("useAgentPluginHotReload", () => {
         return await importFrontFromDisk(url)
       }, [])
       function Listener() {
-        useAgentPluginHotReload({ workspaceId: "test-workspace", importFront })
+        // Disable the cold-start auto-retry so this test exercises the
+        // single-attempt "keep previous version on a broken replacement" path.
+        useAgentPluginHotReload({ workspaceId: "test-workspace", importFront, frontImportRetry: { attempts: 1 } })
         return null
       }
       return (

--- a/packages/workspace/src/front/agentPlugins/registerAgentPlugin.tsx
+++ b/packages/workspace/src/front/agentPlugins/registerAgentPlugin.tsx
@@ -49,6 +49,9 @@ export interface RegisterAgentPluginOptions {
   enabled?: boolean
   authHeaders?: Record<string, string>
   importFront?: (frontUrl: string, revision: number) => Promise<{ default?: BoringFrontFactoryWithId }>
+  // Bounded retry for transient cold-start front-import failures (singleton
+  // graph not yet warm after a hard refresh). Exposed mainly for tests.
+  frontImportRetry?: { attempts?: number; delayMs?: number }
 }
 
 function joinUrl(base: string, path: string): string {
@@ -147,6 +150,53 @@ async function captureFrontFactory(pluginId: string, frontUrl: string, revision:
   const api = createCapturingBoringFrontAPI({ pluginId })
   await mod.default(api)
   return api.flush()
+}
+
+// Cold-start retry for plugin front imports. On a hard refresh while the
+// embedded Vite plugin runtime is still warming, the imported module can
+// evaluate against a not-yet-ready singleton graph and throw (the silent
+// "keeping previous version" + "definePlugin: id is required" path). That
+// failure is transient — a moment later the same revision imports cleanly —
+// but it used to be permanent until a revision bump or workspace switch. Retry
+// the import (NOT the register) a few times with a short backoff so the plugin
+// recovers in place.
+const FRONT_IMPORT_RETRY_ATTEMPTS = 4
+const FRONT_IMPORT_RETRY_DELAY_MS = 750
+
+async function importFrontWithRetry({
+  pluginId,
+  frontEntryUrl,
+  revision,
+  importFront,
+  isStale,
+  attempts = FRONT_IMPORT_RETRY_ATTEMPTS,
+  delayMs = FRONT_IMPORT_RETRY_DELAY_MS,
+}: {
+  pluginId: string
+  frontEntryUrl: string
+  revision: number
+  importFront: RegisterAgentPluginOptions["importFront"]
+  isStale: () => boolean
+  attempts?: number
+  delayMs?: number
+}): Promise<CapturedBoringFrontRegistrations> {
+  const maxAttempts = Math.max(1, attempts)
+  let lastError: unknown
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    if (isStale()) throw lastError ?? new Error(`plugin ${pluginId} front import superseded`)
+    try {
+      return await captureFrontFactory(pluginId, frontEntryUrl, revision, importFront)
+    } catch (error) {
+      lastError = error
+      if (attempt === maxAttempts - 1 || isStale()) break
+      console.warn(
+        `[boring-ui] plugin ${pluginId} front import failed (attempt ${attempt + 1}/${maxAttempts}); retrying`,
+        error,
+      )
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+  throw lastError
 }
 
 /**
@@ -437,7 +487,16 @@ export function useAgentPluginHotReload(options: RegisterAgentPluginOptions): vo
           let captured: CapturedBoringFrontRegistrations | null = null
           try {
             captured = frontEntryUrl
-              ? await captureFrontFactory(event.id, frontEntryUrl, event.revision, options.importFront)
+              ? await importFrontWithRetry({
+                  pluginId: event.id,
+                  frontEntryUrl,
+                  revision: event.revision,
+                  importFront: options.importFront,
+                  isStale: () =>
+                    disposed || latestRequestedRef.current.get(event!.id) !== event!.revision,
+                  ...(options.frontImportRetry?.attempts !== undefined ? { attempts: options.frontImportRetry.attempts } : {}),
+                  ...(options.frontImportRetry?.delayMs !== undefined ? { delayMs: options.frontImportRetry.delayMs } : {}),
+                })
               : null
           } catch (error) {
             throw {
@@ -620,5 +679,5 @@ export function useAgentPluginHotReload(options: RegisterAgentPluginOptions): vo
       }
       es.close()
     }
-  }, [options.apiBaseUrl, options.workspaceId, options.enabled, options.authHeaders, options.importFront, panels, commands, catalogs, surfaceResolvers, reloadNonce])
+  }, [options.apiBaseUrl, options.workspaceId, options.enabled, options.authHeaders, options.importFront, options.frontImportRetry, panels, commands, catalogs, surfaceResolvers, reloadNonce])
 }


### PR DESCRIPTION
## Symptoms (reported on the live hub, CLI 0.1.38)

1. Hard refresh on a direct `/workspace/<id>?session=<sid>` URL → stuck forever on "Preparing workspace…" + "Loading chat history…". Switching workspace and back made it appear **instantly** (server warm → client-side recovery bug).
2. Plugins in the boring-ui-v2 workspace sometimes never load/display in the browser, while the server reports them loaded.
3. Cold first-open of a workspace pays ~4s of embedded-Vite plugin-front compilation that starves the event loop and delays `/state`, tree, commands (V8 CPU profile: vite resolveId/transform + module compile dominate).

## Root causes & fixes

**1. Un-timed pi chat fetches (`remotePiSession.ts`)** — the `/state` hydration and the `/events` stream *connect* had no per-attempt timeout, only dispose-driven aborts. A fetch issued while the server event loop is saturated (right after restart) hangs forever; `hydrateAndConnect` never reaches its retry path, so the chat pins on "Loading chat history…" until remount. Fix: 15s per-attempt budget; timed-out attempts surface as recoverable errors and the existing reconnect loop re-issues them. The stream *body* is never timed out (timer cleared once headers land).

**2. Permanent stale plugin front on transient import failure (`registerAgentPlugin.tsx`)** — a front import that failed transiently (e.g. `definePlugin: id is required` while the server's singleton transform graph is cold) logged "keeping previous version" and never retried; the server won't re-send the same revision, so the plugin stayed missing until a workspace switch. Fix: bounded in-place retry (4 attempts / 750ms) around the import; deterministic registration errors still fail fast.

**3. Cold-start vite warmup (`pluginFrontRuntime.ts` + `modeApps.ts`)** — after a workspace's plugin runtime loads, a fire-and-forget `warmupWorkspace()` pre-serves each plugin front entry so the react/`@hachej/boring-workspace` singleton transforms are warm before any browser asks. Never blocks binding creation.

## Verification

- E2E with a persistent browser profile against a self-hosted hub sharing the registry:
  - warm-profile hard refresh of the `?session=` URL: preparing gone in 534ms, history in 1.2s;
  - kill+restart hub under an open tab, hard refresh against the cold hub: converges (4.4s / 7.7s), plugin fronts load 200, nothing stuck.
- agent 1408 passed (new hung-`/state` recovery test), workspace 1441 passed (new import-retry test), cli pluginFrontRuntime 18 passed (new warmup test); typechecks green. Pre-existing CLI vite-integration flakes fail identically on clean baseline.

Note: the permanently-missing-plugin state could not be reproduced live (fronts loaded every time in test envs); the retry is a defensive fix for the documented `definePlugin` transient. If it recurs after this lands, `plugin_diagnostics` (#269) + the runtime diagnostics endpoint should show the error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)