### PR TITLE
perf(cli): cache content-hashed front assets as immutable

### DIFF
--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -79,6 +79,22 @@ export async function registerStatic(app: FastifyInstance, publicDir: string) {
   await app.register(fastifyStatic, {
     root: publicDir,
     prefix: "/",
+    // @fastify/send writes its own Cache-Control after setHeaders runs, so
+    // disable it and set the header explicitly for both cases below.
+    cacheControl: false,
+    setHeaders(res, filePath) {
+      // Vite emits content-hashed filenames under /assets, so they can be
+      // cached forever — without this the multi-MB bundle is revalidated
+      // (or re-downloaded) on every workspace open. Everything else (notably
+      // index.html) keeps max-age=0 + etag so deploys are picked up
+      // immediately.
+      res.setHeader(
+        "cache-control",
+        /[\\/]assets[\\/]/.test(filePath)
+          ? "public, max-age=31536000, immutable"
+          : "public, max-age=0",
+      )
+    },
   })
 
   app.setNotFoundHandler(async (req, reply) => {


### PR DESCRIPTION
Re-lands commit 0c8bee76, which was pushed to the #269 branch after its squash-merge and never reached main. Hashed /assets get cache-control: public, max-age=31536000, immutable; index.html keeps max-age=0 + etag. Verified earlier: second open transfers 0 bytes for the 4.9MB bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)