### PR TITLE
perf(cli): pre-warm workspace plugin runtimes at hub boot

### DIFF
--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -766,7 +766,11 @@ export async function createWorkspacesModeApp(opts: {
   void (async () => {
     await new Promise((resolve) => setTimeout(resolve, 250))
     try {
-      for (const workspace of await registry.list()) {
+      // Most-recently-used first: a user refreshing right after a restart is
+      // almost always in the workspace they touched last.
+      const byRecency = [...await registry.list()]
+        .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
+      for (const workspace of byRecency) {
         if (!workspace.available) continue
         try {
           await getLoadedPluginRuntime(workspace)

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -757,17 +757,19 @@ export async function createWorkspacesModeApp(opts: {
     runtimePluginDiagnosticsEnabled: true,
   }))
 
-  // Pre-warm plugin runtimes for every registered workspace in the background
-  // so a freshly-restarted hub doesn't pay cold plugin loads + Vite singleton
-  // transforms on the first browser request (several seconds of event-loop
-  // saturation that delays /state, tree, and commands). Serial and
-  // best-effort: a failing workspace must not block the others, and a real
-  // request arriving mid-warm simply reuses the in-flight runtime promise.
+  // Pre-warm plugin runtimes so a freshly-restarted hub doesn't pay cold
+  // plugin loads + Vite singleton transforms on the first browser request
+  // (several seconds of event-loop saturation that delays /state, tree, and
+  // commands). Priority: the most-recently-used workspace — the one the hub
+  // opens by default and the one a user hard-refreshes after a restart —
+  // warms immediately; the remaining workspaces warm afterwards in the
+  // background. Serial and best-effort: a failing workspace must not block
+  // the others, and a real browser request never waits on this queue — the
+  // lazy path creates (or reuses the in-flight) runtime for its workspace
+  // directly.
   void (async () => {
     await new Promise((resolve) => setTimeout(resolve, 250))
     try {
-      // Most-recently-used first: a user refreshing right after a restart is
-      // almost always in the workspace they touched last.
       const byRecency = [...await registry.list()]
         .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))
       for (const workspace of byRecency) {

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -757,5 +757,27 @@ export async function createWorkspacesModeApp(opts: {
     runtimePluginDiagnosticsEnabled: true,
   }))
 
+  // Pre-warm plugin runtimes for every registered workspace in the background
+  // so a freshly-restarted hub doesn't pay cold plugin loads + Vite singleton
+  // transforms on the first browser request (several seconds of event-loop
+  // saturation that delays /state, tree, and commands). Serial and
+  // best-effort: a failing workspace must not block the others, and a real
+  // request arriving mid-warm simply reuses the in-flight runtime promise.
+  void (async () => {
+    await new Promise((resolve) => setTimeout(resolve, 250))
+    try {
+      for (const workspace of await registry.list()) {
+        if (!workspace.available) continue
+        try {
+          await getLoadedPluginRuntime(workspace)
+        } catch (error) {
+          app.log.warn({ err: error, workspaceId: workspace.id }, "[cli] workspace plugin prewarm failed")
+        }
+      }
+    } catch (error) {
+      app.log.warn({ err: error }, "[cli] workspace plugin prewarm skipped")
+    }
+  })()
+
   return app
 }


### PR DESCRIPTION
After a hub restart, plugin loading + embedded-Vite singleton transforms ran lazily on the first browser request per workspace, saturating the event loop and delaying /state, tree, and commands (~7.7s to interactive on a direct workspace+session URL — the stuck-feeling load reported on the live hub).

This pre-warms every registered workspace's plugin runtime in the background at boot (serial, best-effort, never blocks listen; a request arriving mid-warm reuses the in-flight runtime promise).

Measured on boring-ui-v2 (direct URL with ?session=):
- refresh immediately after restart: 7.7s → 4.1s
- refresh once prewarm settles (~15s after boot): 7.7s → **2.6s, zero slow requests**

CLI tests 64 passed, typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)