### PR TITLE
fix(workspace): polish resize handle and slash filters

### DIFF
--- a/packages/agent/src/front/primitives/__tests__/slash-command-picker.test.tsx
+++ b/packages/agent/src/front/primitives/__tests__/slash-command-picker.test.tsx
@@ -66,6 +66,14 @@ describe('SlashCommandPicker', () => {
     expect(screen.queryByText('/reload')).toBeNull()
   })
 
+  it('keeps the filter bar visible even when there is only one command group', () => {
+    render(<SlashCommandPicker query="" commands={[commands[3]]} onSelect={() => {}} onDismiss={() => {}} />)
+
+    expect(screen.getByRole('tablist', { name: 'Filter by plugin' })).toBeTruthy()
+    expect(screen.getByRole('tab', { name: 'All' })).toBeTruthy()
+    expect(screen.getByRole('tab', { name: 'built-in' })).toBeTruthy()
+  })
+
   it('wraps selection with arrow keys from the search input', () => {
     render(<SlashCommandPicker query="" commands={commands} onSelect={() => {}} onDismiss={() => {}} />)
     const options = () => Array.from(document.querySelectorAll('[role="option"]'))

--- a/packages/agent/src/front/primitives/slash-command-picker.tsx
+++ b/packages/agent/src/front/primitives/slash-command-picker.tsx
@@ -94,28 +94,26 @@ export function SlashCommandPicker({ query, commands, onSelect, onDismiss }: Sla
       />
 
       {/* Plugin selection */}
-      {groups.length > 1 && (
-        <div className="flex flex-wrap gap-1 border-b border-border/50 px-2 py-1.5" role="tablist" aria-label="Filter by plugin">
-          {[ALL_PLUGINS, ...groups].map((g) => {
-            const selected = plugin === g
-            return (
-              <button
-                key={g}
-                type="button"
-                role="tab"
-                aria-selected={selected}
-                onMouseDown={(e) => { e.preventDefault(); setPlugin(g); setActiveIdx(0) }}
-                className={cn(
-                  'rounded-full px-2 py-px text-[10px] font-medium transition-colors',
-                  selected ? 'bg-accent/15 text-accent-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted',
-                )}
-              >
-                {g === ALL_PLUGINS ? 'All' : g}
-              </button>
-            )
-          })}
-        </div>
-      )}
+      <div className="flex flex-wrap gap-1 border-b border-border/50 px-2 py-1.5" role="tablist" aria-label="Filter by plugin">
+        {[ALL_PLUGINS, ...groups].map((g) => {
+          const selected = plugin === g
+          return (
+            <button
+              key={g}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              onMouseDown={(e) => { e.preventDefault(); setPlugin(g); setActiveIdx(0) }}
+              className={cn(
+                'rounded-full px-2 py-px text-[10px] font-medium transition-colors',
+                selected ? 'bg-accent/15 text-accent-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted',
+              )}
+            >
+              {g === ALL_PLUGINS ? 'All' : g}
+            </button>
+          )
+        })}
+      </div>
 
       {/* Command list — sized to show ~8 rows before scrolling. */}
       {filtered.length === 0 ? (

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -655,11 +655,10 @@ function ResizeHandle({ side, ariaLabel, onResize }: ResizeHandleProps) {
       onPointerUp={handlePointerUp}
       onPointerCancel={handlePointerUp}
       className={cn(
-        "absolute top-0 bottom-0 z-20 bg-transparent",
-        "transition-colors duration-200",
-        "hover:bg-border/70 hover:[transition-delay:150ms]",
-        "active:bg-muted-foreground/30",
-        side === "drawer-right" ? "right-0" : "left-0",
+        "absolute -top-px -bottom-px z-20 w-3 bg-transparent hover:!bg-transparent active:!bg-transparent",
+        "after:absolute after:inset-y-2 after:left-1/2 after:w-px after:-translate-x-1/2 after:rounded-full after:bg-border/55",
+        "after:transition-[width,background-color] after:duration-150 hover:after:w-1 hover:after:bg-foreground/35 active:after:w-1 active:after:bg-foreground/50",
+        side === "drawer-right" ? "-right-1.5" : "-left-1.5",
       )}
     />
   )


### PR DESCRIPTION
## Summary
- widen the workspace resize handle hit target and make its visible rail clearer
- keep the slash command picker filter chips visible at the top even with one command group
- add regression coverage for the always-visible slash filter bar

## Verification
- pnpm --filter @hachej/boring-agent run test src/front/primitives/__tests__/slash-command-picker.test.tsx
- pnpm run build:packages
- pnpm --filter @hachej/boring-agent run typecheck
- pnpm --filter @hachej/boring-workspace run typecheck
- /home/ubuntu/.agents/skills/coding-autoreview/scripts/autoreview --mode local (clean)

## Notes
- No manual browser screenshot captured; change is limited to CSS/DOM rendering and covered by focused test/typecheck/build.