### PR TITLE
fix(agent): preserve host HOME in direct mode so host CLIs keep auth

### DIFF
--- a/packages/agent/src/server/sandbox/__tests__/workspacePythonEnv.test.ts
+++ b/packages/agent/src/server/sandbox/__tests__/workspacePythonEnv.test.ts
@@ -21,3 +21,38 @@ test('sandbox runtime env rewrites host workspace roots to sandbox roots', () =>
     '/workspace/.boring-agent/sdk/uv/bin',
   ])
 })
+
+test('isolated sandbox modes rewrite HOME to the sandbox runtime root', () => {
+  const env = withWorkspacePythonEnv({
+    workspaceRoot: '/host/workspace',
+    sandboxRoot: '/workspace',
+    env: { HOME: '/home/ubuntu', PATH: '/usr/bin' },
+  })
+
+  expect(env.HOME).toBe('/workspace')
+})
+
+test('HOME is rewritten by default even without a sandboxRoot (e.g. vercel)', () => {
+  // The vercel-sandbox adapter does not pass sandboxRoot but is still an
+  // isolated remote runtime, so HOME must be rewritten to the runtime root.
+  const env = withWorkspacePythonEnv({
+    workspaceRoot: '/workspace',
+    env: { HOME: '/plugin-home', PATH: '/usr/bin' },
+  })
+
+  expect(env.HOME).toBe('/workspace')
+})
+
+test('preserveHostHome keeps the host HOME so host-auth CLIs keep working', () => {
+  const env = withWorkspacePythonEnv({
+    workspaceRoot: '/host/workspace',
+    env: { HOME: '/home/ubuntu', PATH: '/usr/bin' },
+    preserveHostHome: true,
+  })
+
+  // HOME must stay on the host so gh/git resolve their host config/auth, while
+  // the workspace-scoped python/venv vars are still rewritten to the workspace.
+  expect(env.HOME).toBe('/home/ubuntu')
+  expect(env.VIRTUAL_ENV).toBe('/host/workspace/.boring-agent/venv')
+  expect(env.BORING_AGENT_WORKSPACE_ROOT).toBe('/host/workspace')
+})

--- a/packages/agent/src/server/sandbox/direct/__tests__/createDirectSandbox.test.ts
+++ b/packages/agent/src/server/sandbox/direct/__tests__/createDirectSandbox.test.ts
@@ -146,7 +146,10 @@ test('exec forces managed env roots and appends plugin PATH after runtime bins',
 
   const [root, home, venv, pythonHome, pathValue] = Buffer.from(result.stdout).toString('utf-8').split('\n')
   expect(root).toBe(workspaceRoot)
-  expect(home).toBe(workspaceRoot)
+  // Direct (host-passthrough) mode preserves the caller's HOME so host-auth
+  // CLIs (gh, git) keep working; only the workspace-scoped python vars below
+  // are rewritten to the workspace root.
+  expect(home).toBe('/plugin-home')
   expect(venv).toBe(join(workspaceRoot, '.boring-agent', 'venv'))
   expect(pythonHome).toBe('')
   expect(pathValue.split(':').slice(0, 5)).toEqual([

--- a/packages/agent/src/server/sandbox/direct/createDirectSandbox.ts
+++ b/packages/agent/src/server/sandbox/direct/createDirectSandbox.ts
@@ -99,7 +99,7 @@ export function createDirectSandbox(opts: CreateDirectSandboxOptions = {}): Sand
       return await new Promise((resolve, reject) => {
         const child = spawn(cmd, {
           cwd,
-          env: withWorkspacePythonEnv({ workspaceRoot, env: opts?.env }),
+          env: withWorkspacePythonEnv({ workspaceRoot, env: opts?.env, preserveHostHome: true }),
           shell: true,
           windowsHide: true,
           detached: process.platform !== 'win32',

--- a/packages/agent/src/server/sandbox/workspacePythonEnv.ts
+++ b/packages/agent/src/server/sandbox/workspacePythonEnv.ts
@@ -9,12 +9,22 @@ interface WorkspacePythonEnvOptions {
   workspaceRoot: string
   env?: Record<string, string | undefined>
   sandboxRoot?: string
+  /**
+   * When true, preserve the caller's HOME instead of rewriting it to the
+   * runtime root. This is used by the direct (host-passthrough) sandbox where
+   * the agent runs on the host with no FS isolation: keeping the host HOME lets
+   * host-auth CLIs (gh, git, ...) resolve their config/credentials. Isolated
+   * modes (bwrap, vercel-sandbox) leave this false so HOME stays inside the
+   * runtime root. The workspace-scoped python/venv vars below are rewritten in
+   * every mode regardless, so package resolution stays isolated.
+   */
+  preserveHostHome?: boolean
 }
 
 export function withWorkspacePythonEnv(
   opts: WorkspacePythonEnvOptions,
 ): Record<string, string | undefined> {
-  const { workspaceRoot, env, sandboxRoot } = opts
+  const { workspaceRoot, env, sandboxRoot, preserveHostHome } = opts
   const runtimeRoot = sandboxRoot ?? workspaceRoot
   const paths = getBoringAgentRuntimePaths(runtimeRoot)
   const baseEnv = env ?? getEnvSnapshot()
@@ -22,10 +32,12 @@ export function withWorkspacePythonEnv(
   const existingPath = baseEnv.PATH
   if (existingPath) pathParts.push(existingPath)
 
+  const home = preserveHostHome ? baseEnv.HOME : runtimeRoot
+
   return {
     ...baseEnv,
     PATH: pathParts.join(':'),
-    HOME: runtimeRoot,
+    HOME: home,
     VIRTUAL_ENV: paths.venv,
     PYTHONHOME: undefined,
     BORING_AGENT_WORKSPACE_ROOT: runtimeRoot,

--- a/packages/agent/src/server/tools/harness/index.ts
+++ b/packages/agent/src/server/tools/harness/index.ts
@@ -70,6 +70,7 @@ function directSpawnHook(
     env: withWorkspacePythonEnv({
       workspaceRoot,
       env: mergeRuntimeEnv(runtime, context.env),
+      preserveHostHome: true,
     }),
   })
 }

--- a/packages/cli/src/front/App.test.tsx
+++ b/packages/cli/src/front/App.test.tsx
@@ -195,4 +195,47 @@ describe("CliWorkspaceShell", () => {
       workspaceLabel: "Alpha Project",
     })
   })
+
+  test("recovers from a transient local-workspaces fetch failure instead of latching the empty state", async () => {
+    // Root URL (no /workspace/<id>); the first local-workspaces fetch fails
+    // transiently (e.g. cold-start 503), the retry succeeds and returns items.
+    window.history.replaceState(null, "", "/")
+    let wsCall = 0
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith("/api/v1/workspace/meta")) {
+        return new Response(JSON.stringify({ projectName: "Boring UI", workspacesMode: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      if (url.endsWith("/api/v1/local-workspaces")) {
+        wsCall += 1
+        if (wsCall === 1) {
+          return new Response(JSON.stringify({ error: "warming" }), {
+            status: 503,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+        return new Response(JSON.stringify({
+          workspaces: [{ id: "ws-alpha-be8d3c24", name: "Alpha Project", path: "/tmp/ws-alpha", available: true }],
+        }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      throw new Error(`unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    render(<CliWorkspaceShell />)
+
+    // The transient failure must NOT render the dead-end "No local workspaces" screen.
+    await screen.findByText("Loading workspaces…")
+    expect(screen.queryByText("No local workspaces")).toBeNull()
+
+    // The scheduled retry (1.5s) succeeds and the workspace mounts.
+    await waitFor(() => expect(workspaceAgentFrontSpy).toHaveBeenCalled(), { timeout: 4000 })
+    expect(workspaceAgentFrontSpy.mock.calls.at(-1)?.[0]).toMatchObject({ workspaceId: "ws-alpha-be8d3c24" })
+    expect(screen.queryByText("No local workspaces")).toBeNull()
+  })
 })

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -106,13 +106,28 @@ export function CliWorkspaceShell() {
   const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null)
   const [urlSessionId, setUrlSessionId] = useState<string | null>(() => chatSessionIdFromCliUrl(window.location.search))
   const [metaLoaded, setMetaLoaded] = useState(false)
+  // Tracks whether at least one local-workspaces fetch has *succeeded*. Used to
+  // tell "the registry is genuinely empty" (show the add-a-workspace screen)
+  // apart from "the first fetch hasn't landed / failed" (keep showing loading
+  // and retry) so a transient error never strands the page on the empty state.
+  const [workspacesLoaded, setWorkspacesLoaded] = useState(false)
   const [runtimePluginFrontLoadingEnabled, setRuntimePluginFrontLoadingEnabled] = useState(false)
+
+  const refreshWorkspacesRef = useRef<(() => void) | null>(null)
 
   const refreshWorkspaces = useCallback(() => {
     void fetch("/api/v1/local-workspaces")
-      .then(async (res) => res.ok ? await res.json() as { workspaces: LocalWorkspace[] } : { workspaces: [] })
+      .then(async (res) => {
+        // A failed fetch (transient 5xx during cold start, network blip, ...) is
+        // NOT an authoritative "no workspaces" answer. Throwing here routes it to
+        // the catch below, which preserves the current list and schedules a retry
+        // instead of latching the empty "No local workspaces" dead-end screen.
+        if (!res.ok) throw new Error(`local-workspaces ${res.status}`)
+        return await res.json() as { workspaces: LocalWorkspace[] }
+      })
       .then((data) => {
         const next = data.workspaces ?? []
+        setWorkspacesLoaded(true)
         setWorkspaces((current) => areWorkspacesEqual(current, next) ? current : next)
         setActiveWorkspaceId((current) => {
           const urlWorkspaceId = workspaceIdFromCliUrl(window.location.pathname)
@@ -136,8 +151,14 @@ export function CliWorkspaceShell() {
           return selected?.id ?? null
         })
       })
-      .catch(() => {})
+      .catch(() => {
+        // Leave the existing workspace list untouched and retry shortly so a
+        // transient failure can't strand the page on the empty-state screen.
+        window.setTimeout(() => refreshWorkspacesRef.current?.(), 1500)
+      })
   }, [])
+
+  refreshWorkspacesRef.current = refreshWorkspaces
 
   useEffect(() => {
     let cancelled = false
@@ -246,6 +267,20 @@ export function CliWorkspaceShell() {
               <p className="mt-2 text-sm text-muted-foreground">
                 Preparing <code>{activeWorkspaceId}</code>. This can take a moment on first load.
               </p>
+            </div>
+          </div>
+        )
+      }
+      // The workspace registry list hasn't successfully loaded yet (first fetch
+      // still in flight or transiently failed and retrying). Show a neutral
+      // loading state instead of the "No local workspaces" empty state, which
+      // would otherwise flash — and previously latch — on a transient error even
+      // though the API does return workspaces.
+      if (!workspacesLoaded && workspaces.length === 0) {
+        return (
+          <div className="flex h-screen w-screen items-center justify-center bg-background text-foreground">
+            <div className="max-w-md rounded-2xl border border-border bg-card p-6 text-center shadow-sm">
+              <h1 className="text-lg font-semibold">Loading workspaces…</h1>
             </div>
           </div>
         )


### PR DESCRIPTION
## Problem
In **direct (host-passthrough) mode** the agent runs on the host with no FS isolation, but `withWorkspacePythonEnv` unconditionally rewrote `HOME` to the workspace runtime root. Host-auth CLIs (`gh`, `git`) resolve their config/credentials from `$HOME`, so inside agent shells `gh auth status` reported *not logged in* even though the host was authenticated.

## Fix
- Add an explicit `preserveHostHome` option to `withWorkspacePythonEnv` and set it for the two host-passthrough call sites: `createDirectSandbox` and the `directSpawnHook` in the tools harness.
- Isolated modes (**bwrap**, **vercel-sandbox**) keep rewriting `HOME` to the runtime root, so isolation is unchanged.
- `sandboxRoot != null` was **not** a usable discriminator: the vercel adapter does not pass `sandboxRoot` yet is still isolated, so keying off it would have wrongly leaked the host HOME into the vercel sandbox.

## Bonus: CLI hub root page "No local workspaces" dead-end
While verifying, reproduced a separate bug: the workspaces-hub root page latched **"No local workspaces"** when the first `/api/v1/local-workspaces` fetch failed transiently (cold-start 5xx / network blip). The failed response was coerced into an authoritative empty list and the error swallowed. Now a failed fetch preserves the current list, schedules a retry, and the page shows a loading state until the registry list actually loads.

## Tests
- `withWorkspacePythonEnv`: isolated modes rewrite HOME; default (no sandboxRoot, e.g. vercel) still rewrites; `preserveHostHome` keeps host HOME.
- `createDirectSandbox`: direct exec preserves caller HOME.
- CLI `App.test.tsx`: recovers from a transient local-workspaces failure instead of latching the empty state.
- Full agent suite: 1411 passed / 0 failed / no type errors. CLI suite: 65 passed.

## E2E verification
Ran a live pi-chat session in direct mode (`gemini-2.5-flash`) prompting `gh auth status`; the agent shell returned **authenticated** output (`Logged in to github.com account hachej`), confirming the host HOME passthrough works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)