### PR TITLE
fix(workspace): preserve chat pane scroll when switching panes (#276)

### DIFF
--- a/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
@@ -291,6 +291,14 @@ export function ChatPaneStageDock({
           className="dv-shell dv-chat-stage h-full"
           components={STAGE_COMPONENTS}
           defaultTabComponent={ChatPaneHeader as React.FunctionComponent<IDockviewPanelHeaderProps>}
+          // Keep every pane's content element permanently mounted in the
+          // overlay render container instead of the default "onlyWhenVisible"
+          // renderer, which detaches and re-appends a group's content element
+          // each time the group is activated. That detach/reattach resets the
+          // scroll container's scrollTop to 0, so switching panes used to jank
+          // the newly-active chat transcript back to the top (#276). "always"
+          // toggles visibility in place and preserves scroll position.
+          defaultRenderer="always"
           // Groups always hold exactly one pane (center drops are vetoed),
           // so the single header stretches across the full group width and
           // reads as a flat pane header, not a tab.

--- a/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest"
+import { render } from "@testing-library/react"
+
+// Capture the props handed to DockviewReact so we can assert the rendering
+// contract that keeps chat panes mounted across activation. The real dockview
+// component needs a DOM grid engine we don't exercise here, so it is mocked.
+const dockviewProps = vi.fn()
+vi.mock("dockview-react", () => ({
+  DockviewReact: (props: Record<string, unknown>) => {
+    dockviewProps(props)
+    return null
+  },
+}))
+// Side-effect CSS imports the component pulls in; no-op them under vitest.
+vi.mock("dockview-react/dist/styles/dockview.css", () => ({}))
+vi.mock("../dock/dockview-overrides.css", () => ({}))
+vi.mock("../chat-pane-stage.css", () => ({}))
+
+import { ChatPaneStageDock } from "../ChatPaneStageDock"
+
+describe("ChatPaneStageDock", () => {
+  it('mounts panes with the "always" renderer so switching panes preserves scroll (#276)', () => {
+    dockviewProps.mockClear()
+    render(
+      <ChatPaneStageDock
+        panes={[
+          { id: "a", title: "A" },
+          { id: "b", title: "B" },
+        ]}
+        activePaneId="a"
+        renderPane={(pane) => <div>{pane.id}</div>}
+      />,
+    )
+
+    // The default "onlyWhenVisible" renderer detaches and re-appends a group's
+    // content element on activation, which resets the transcript scroll
+    // container's scrollTop to 0. "always" keeps it mounted in place.
+    expect(dockviewProps).toHaveBeenCalled()
+    expect(dockviewProps.mock.calls[0][0]).toMatchObject({ defaultRenderer: "always" })
+  })
+})


### PR DESCRIPTION
## Problem

Fixes #276. Switching the active chat pane snapped the newly-activated pane's transcript back to the **top** instead of preserving the user's scroll position.

## Root cause

Reproduced in a real two-pane browser session (long-history pane scrolled up to `scrollTop=13350`, then activated → reset to `0`, with `scrollHeight` unchanged — i.e. not a content reflow).

Instrumenting the scroll container with a `MutationObserver` showed the reset is **not** from `use-stick-to-bottom` and **not** a React remount. It comes from dockview:

```
childList on .dv-content-container: -1 (content element removed)  scrollTop -> 0
childList on .dv-content-container: +1 (content element re-appended)
attr class on .dv-groupview -> dv-active-group
```

With dockview's default `onlyWhenVisible` renderer (`dockview-core/.../panel/content.js`), activating a group does `removeChild(content)` then `appendChild(content)`. Detaching a scrollable element from the DOM discards its `scrollTop`, so the chat jumps to the top.

## Fix

Set `defaultRenderer="always"` on the chat-stage `DockviewReact`. Panes then live permanently in dockview's overlay render container and activation toggles visibility in place rather than detaching/re-appending the content element, preserving `scrollTop`. Because center drops are vetoed, panes are always visible side-by-side, so no `display:none` toggling (which would also reset scroll) occurs.

## Verification

- Browser repro (same long-history pane, scrolled to `scrollTop=300`, then activated): position preserved `300 -> 300` after the fix (was `-> 0`).
- Two-pane layout renders correctly with the overlay renderer (no 0×0 collapse); scroll-to-bottom still works.
- `pnpm --filter @hachej/boring-agent test`: 1409 passed / 5 skipped, no type errors (baseline).
- `pnpm --filter @hachej/boring-workspace test`: 1447 passed incl. new regression test; typecheck clean.

Added a regression test (`ChatPaneStageDock.test.tsx`) asserting the stage mounts with `defaultRenderer="always"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)