### PR TITLE
perf(agent): make tree listing O(1) git calls per request

### DIFF
--- a/packages/agent/src/server/http/routes/__tests__/tree.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/tree.test.ts
@@ -108,6 +108,66 @@ describe('GET /api/v1/tree', () => {
     await app.close()
   })
 
+  test('recursive lists ignored dirs as entries but does not descend into them', async () => {
+    const workspace = createWorkspace({
+      '.': [
+        { name: 'src', kind: 'dir' },
+        { name: 'node_modules', kind: 'dir' },
+        { name: '.worktrees', kind: 'dir' },
+        { name: '.git', kind: 'dir' },
+      ],
+      'src': [{ name: 'index.ts', kind: 'file' }],
+      // These children must never be walked into:
+      'node_modules': [{ name: 'left-pad', kind: 'dir' }],
+      '.worktrees': [{ name: 'wt-1', kind: 'dir' }],
+      '.git': [{ name: 'HEAD', kind: 'file' }],
+    })
+    const app = await buildApp(workspace)
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/tree?recursive=true',
+    })
+
+    expect(res.statusCode).toBe(200)
+    const paths = res.json().entries.map((e: any) => e.path)
+    // The ignored dirs themselves are still listed (entry-equivalence preserved).
+    expect(paths).toContain('node_modules')
+    expect(paths).toContain('.worktrees')
+    expect(paths).toContain('.git')
+    // Real source is still walked.
+    expect(paths).toContain('src/index.ts')
+    // But their contents are NOT walked.
+    expect(paths).not.toContain('node_modules/left-pad')
+    expect(paths).not.toContain('.worktrees/wt-1')
+    expect(paths).not.toContain('.git/HEAD')
+
+    await app.close()
+  })
+
+  test('non-recursive listing of an ignored dir still returns its children', async () => {
+    // Users can expand an ignored dir on demand via a non-recursive request.
+    const workspace = createWorkspace({
+      'node_modules': [
+        { name: 'left-pad', kind: 'dir' },
+        { name: '.package-lock.json', kind: 'file' },
+      ],
+    })
+    const app = await buildApp(workspace)
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/tree?path=node_modules',
+    })
+
+    expect(res.statusCode).toBe(200)
+    const paths = res.json().entries.map((e: any) => e.path)
+    expect(paths).toContain('node_modules/left-pad')
+    expect(paths).toContain('node_modules/.package-lock.json')
+
+    await app.close()
+  })
+
   test('recursive respects max depth of 10', async () => {
     const tree: Record<string, Entry[]> = {}
     let current = '.'

--- a/packages/agent/src/server/http/routes/tree.ts
+++ b/packages/agent/src/server/http/routes/tree.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import type { Workspace, Entry } from '../../../shared/workspace'
+import { isIgnoredDirName } from '../../workspace/ignore'
 import {
   ERROR_CODE_INVALID_PATH,
   ERROR_CODE_PATH_REJECTED,
@@ -62,7 +63,19 @@ async function listTree(
       const entryPath = joinPath(batch.parentDir, e.name)
       entries.push({ name: e.name, kind: e.kind, path: entryPath })
 
-      if (recursive && e.kind === 'dir' && batch.depth < MAX_DEPTH) {
+      // The directory is always listed as an entry above; we only avoid
+      // *descending* into heavy/ignored dirs (node_modules, .worktrees, .git,
+      // dist, ...). On repos with many worktrees an unfiltered recursive walk
+      // takes seconds and exhausts MAX_ENTRIES on junk before reaching real
+      // source. Non-recursive listings are unaffected — the entry set for any
+      // single directory is identical to before. Users can still expand an
+      // ignored dir on demand via a non-recursive request for its path.
+      if (
+        recursive &&
+        e.kind === 'dir' &&
+        batch.depth < MAX_DEPTH &&
+        !isIgnoredDirName(e.name)
+      ) {
         try {
           const subEntries = await workspace.readdir(entryPath)
           queue.push({ parentDir: entryPath, items: subEntries, depth: batch.depth + 1 })

--- a/packages/agent/src/server/workspace/__tests__/ignore.test.ts
+++ b/packages/agent/src/server/workspace/__tests__/ignore.test.ts
@@ -1,0 +1,32 @@
+import { describe, test, expect } from 'vitest'
+import { DEFAULT_IGNORED_DIR_NAMES, isIgnoredDirName } from '../ignore'
+
+describe('isIgnoredDirName', () => {
+  test('matches every default ignored name', () => {
+    for (const name of DEFAULT_IGNORED_DIR_NAMES) {
+      expect(isIgnoredDirName(name)).toBe(true)
+    }
+  })
+
+  test('matches heavy directories that amplify on multi-worktree repos', () => {
+    expect(isIgnoredDirName('node_modules')).toBe(true)
+    expect(isIgnoredDirName('.worktrees')).toBe(true)
+    expect(isIgnoredDirName('.git')).toBe(true)
+    expect(isIgnoredDirName('dist')).toBe(true)
+  })
+
+  test('matches any .tsbuildinfo file', () => {
+    expect(isIgnoredDirName('tsconfig.tsbuildinfo')).toBe(true)
+    expect(isIgnoredDirName('packages.tsbuildinfo')).toBe(true)
+  })
+
+  test('does not match ordinary source names', () => {
+    expect(isIgnoredDirName('src')).toBe(false)
+    expect(isIgnoredDirName('packages')).toBe(false)
+    expect(isIgnoredDirName('README.md')).toBe(false)
+    expect(isIgnoredDirName('index.ts')).toBe(false)
+    // Substring / suffix false-positives must not occur.
+    expect(isIgnoredDirName('my-node_modules')).toBe(false)
+    expect(isIgnoredDirName('distribution')).toBe(false)
+  })
+})

--- a/packages/agent/src/server/workspace/createNodeWorkspace.ts
+++ b/packages/agent/src/server/workspace/createNodeWorkspace.ts
@@ -14,29 +14,14 @@ import {
   ensureWritableWorkspacePath,
   validatePath,
 } from './paths'
+import { isIgnoredDirName } from './ignore'
 
 const EPERM_CODE = 'EPERM'
-
-const DEFAULT_WATCH_IGNORES = [
-  'node_modules',
-  '.git',
-  '.DS_Store',
-  '.worktrees',
-  '.boring-agent',
-  '.cache',
-  'dist',
-  '.next',
-  '.turbo',
-  'test-results',
-] as const
 
 function shouldIgnoreWatchPath(root: string, path: string): boolean {
   const relPath = relative(root, path)
   const parts = relPath.split(sep)
-  return parts.some((part) =>
-    DEFAULT_WATCH_IGNORES.includes(part as (typeof DEFAULT_WATCH_IGNORES)[number]) ||
-    part.endsWith('.tsbuildinfo'),
-  )
+  return parts.some((part) => isIgnoredDirName(part))
 }
 
 /**

--- a/packages/agent/src/server/workspace/ignore.ts
+++ b/packages/agent/src/server/workspace/ignore.ts
@@ -1,0 +1,35 @@
+/**
+ * Directory/file names that are heavy and rarely useful to descend into.
+ *
+ * Single source of truth shared by the filesystem watcher (which skips them
+ * during chokidar's recursive scan) and the tree route (which lists them as
+ * entries but does NOT auto-recurse into them). Keeping these in one place
+ * ensures "what the watcher prunes" and "what the recursive tree prunes" stay
+ * identical.
+ *
+ * On a repo with ~100 worktrees under `.worktrees/`, each containing
+ * `node_modules`, an unfiltered recursive tree walk both takes seconds and
+ * exhausts the entry-count budget on junk before reaching real source files.
+ */
+export const DEFAULT_IGNORED_DIR_NAMES = [
+  'node_modules',
+  '.git',
+  '.DS_Store',
+  '.worktrees',
+  '.boring-agent',
+  '.cache',
+  'dist',
+  '.next',
+  '.turbo',
+  'test-results',
+] as const
+
+const IGNORED_SET: ReadonlySet<string> = new Set(DEFAULT_IGNORED_DIR_NAMES)
+
+/**
+ * True when a single path segment (not a full path) should be treated as an
+ * ignored/heavy directory.
+ */
+export function isIgnoredDirName(name: string): boolean {
+  return IGNORED_SET.has(name) || name.endsWith('.tsbuildinfo')
+}


### PR DESCRIPTION
## Problem

`GET /api/v1/tree?recursive=true` had **no ignore filtering** in its BFS walk. On repos with many git worktrees it descended into every `.worktrees/*`, `node_modules/*`, and `.git/*` subtree.

Measured on workspace `boring-ui-v2-36cd3172` (~77 worktrees, each with `node_modules`):
- **4342 of 5000 entries (87%) were junk** (`.worktrees/`, `node_modules/`, `.git/` descendants) — real source files were truncated by the `MAX_ENTRIES` cap before being reached.
- The walk took ~1.8s even when warm.

## Fix

Skip **descending** into heavy/ignored directory names during recursive expansion, reusing the **exact** ignore set the filesystem watcher already uses. The ignored dirs are still **listed** as entries, so:
- non-recursive listings are byte-identical to before, and
- the per-directory entry set (including `.worktrees`, `node_modules`, `.git` appearing as dir entries) is unchanged.

Users can still expand an ignored dir on demand via a non-recursive request for its path.

The watcher's previously-private ignore list was extracted into a shared `packages/agent/src/server/workspace/ignore.ts` (single source of truth) exposing `DEFAULT_IGNORED_DIR_NAMES` and `isIgnoredDirName`, now used by both `createNodeWorkspace` (watch pruning) and the tree route.

## Before / after

Measured against a local hub built from this branch (port 5392) vs. the live hub (5213), same workspace:

| request | before | after |
|---|---|---|
| `recursive path=.` | 1.76s, **4342/5000 junk** | **0.55s, 0 junk** |
| non-recursive `path=.` / `packages` / `packages/agent/src` | — | <40ms |

Non-recursive entry sets verified **identical** old-vs-new for `.`, `packages`, `packages/agent/src` (including `.worktrees`/`node_modules`/`.git` still listed as entries). Recursive top-level entries also identical; only the junk descendants are gone.

## Scope note

The originally-reported ~36s on a **cold** `GET /api/v1/tree?path=.` is **per-workspace runtime cold-boot** (harness + chokidar watcher + provisioning) that the *first* request to a workspace blocks on — the tree-listing code itself is ~4ms once warm, with no per-entry subprocess or git call. That cold-boot is a separate, larger architectural concern and is out of scope here (and unaffected by this change).

## Tests

- New `workspace/__tests__/ignore.test.ts` (helper unit tests).
- New cases in `routes/__tests__/tree.test.ts`: recursive lists ignored dirs but does not descend; non-recursive listing of an ignored dir still returns its children.
- `pnpm --filter @hachej/boring-agent test`: **1412 passed** (baseline ~1409-1411), no type errors. (2 unrelated `agentPlayground*` front-end test files fail pre-existing in the isolated worktree due to a CSS-transform flake.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)