### PR TITLE
fix(plugins): surface broken registered plugin sources as preflight errors

### DIFF
--- a/packages/cli/src/__tests__/pluginDiscovery.test.ts
+++ b/packages/cli/src/__tests__/pluginDiscovery.test.ts
@@ -151,6 +151,7 @@ describe("plugin discovery helpers", () => {
       })).toContainEqual({
         rootDir: resolve(plugin),
         kind: "external",
+        registered: true,
         workspaceId: resolve(workspaceRoot),
       })
       const snapshot = readCliPluginPiSnapshot(workspaceRoot, {
@@ -179,7 +180,7 @@ describe("plugin discovery helpers", () => {
     }
   })
 
-  test("workspace-local Pi package sources ignore uninspectable package entries", async () => {
+  test("workspace-local Pi package sources surface broken local entries as load errors", async () => {
     const root = await makeTempDir("boring-cli-plugin-settings-uninspectable-")
     const workspaceRoot = join(root, "host-workspace")
     await writePiSettings(join(workspaceRoot, ".pi", "settings.json"), ["../missing", "npm:future-package"])
@@ -188,8 +189,13 @@ describe("plugin discovery helpers", () => {
       const snapshot = readCliPluginPiSnapshot(workspaceRoot, { globalRoot: join(root, "global-extensions"), includeDefaultPackages: false })
       expect(snapshot.systemPromptAppend).toBeUndefined()
       const manager = createCliPluginAssetManager(workspaceRoot, { globalRoot: join(root, "global-extensions"), includeDefaultPackages: false })
-      await manager.load()
+      const result = await manager.load()
       expect(manager.list()).toEqual([])
+      // Remote specs (npm:) stay silent until installed; the registered
+      // local path that no longer exists must not vanish silently.
+      expect(result.errors).toEqual([expect.objectContaining({
+        message: expect.stringContaining("MISSING_PLUGIN_DIR"),
+      })])
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/packages/cli/src/server/pluginDiscovery.ts
+++ b/packages/cli/src/server/pluginDiscovery.ts
@@ -12,8 +12,8 @@ import {
   type WorkspacePluginPackagePiSnapshot,
 } from "@hachej/boring-workspace/app/server"
 import {
-  readPluginSourceRecords,
   resolvePluginSourceScopePaths,
+  resolveRegisteredPluginSourceDirs,
 } from "@hachej/boring-ui-plugin-cli"
 
 /**
@@ -86,9 +86,13 @@ export function resolveCliBoringPluginDirs(
   const globalAgentRoot = getGlobalPiAgentRoot(options)
   const globalScope = resolvePluginSourceScopePaths("global", { globalRoot: globalAgentRoot })
   const localScope = resolvePluginSourceScopePaths("local", { workspaceRoot: resolvedWorkspaceRoot })
+  // Resolved WITHOUT validation: registered sources are passed to the
+  // scanner as-is (flagged `registered`) so a broken one — deleted dir,
+  // stripped package.json — produces a visible preflight error instead
+  // of silently dropping the plugin.
   const packageSources = [
-    ...readPluginSourceRecords(globalScope),
-    ...readPluginSourceRecords(localScope),
+    ...resolveRegisteredPluginSourceDirs(globalScope).map((dir) => ({ ...dir, scope: "global" as const })),
+    ...resolveRegisteredPluginSourceDirs(localScope).map((dir) => ({ ...dir, scope: "local" as const })),
   ]
   const includeDefaultPackages = options.includeDefaultPackages ?? true
   const roots: BoringPluginSourceInput[] = [
@@ -104,6 +108,7 @@ export function resolveCliBoringPluginDirs(
     ...packageSources.map((record): BoringPluginSourceInput => ({
       rootDir: record.rootDir,
       kind: "external",
+      registered: true,
       ...(record.scope === "local" ? { workspaceId: resolvedWorkspaceRoot } : {}),
     })),
   ]

--- a/packages/plugin-cli/src/__tests__/pluginCli.test.ts
+++ b/packages/plugin-cli/src/__tests__/pluginCli.test.ts
@@ -191,6 +191,24 @@ test("boring-ui-plugin list ignores uninspectable Pi package sources", async () 
   expect(JSON.parse(list.stdout).records).toEqual([])
 })
 
+test("resolveRegisteredPluginSourceDirs keeps broken local entries and skips remote specs", async () => {
+  const { resolvePluginSourceScopePaths, resolveRegisteredPluginSourceDirs } = await import("../index")
+  const root = await tempDir("boring-plugin-registered-dirs-")
+  const workspaceRoot = join(root, "host-workspace")
+  const validPlugin = join(workspaceRoot, "plugins", "valid-plugin")
+  await mkdir(join(workspaceRoot, ".pi"), { recursive: true })
+  await writeRuntimePlugin(validPlugin, "valid-plugin")
+  await writeFile(join(workspaceRoot, ".pi", "settings.json"), JSON.stringify({
+    packages: ["../plugins/valid-plugin", "../plugins/deleted-plugin", "npm:not-installed-yet"],
+  }), "utf8")
+
+  const scope = resolvePluginSourceScopePaths("local", { workspaceRoot })
+  expect(resolveRegisteredPluginSourceDirs(scope)).toEqual([
+    { source: "../plugins/valid-plugin", rootDir: resolve(validPlugin) },
+    { source: "../plugins/deleted-plugin", rootDir: resolve(workspaceRoot, "plugins", "deleted-plugin") },
+  ])
+})
+
 async function writeLocalDependency(dir: string, name: string): Promise<void> {
   await mkdir(dir, { recursive: true })
   await writeFile(join(dir, "package.json"), JSON.stringify({ name, version: "1.0.0", main: "index.js" }, null, 2), "utf8")

--- a/packages/plugin-cli/src/index.ts
+++ b/packages/plugin-cli/src/index.ts
@@ -229,6 +229,7 @@ export {
   readPluginSourceRecordsForRoots,
   removePluginSource,
   resolvePluginSourceScopePaths,
+  resolveRegisteredPluginSourceDirs,
   scaffoldPlugin,
   verifyPlugin,
 } from "./server/index"
@@ -245,6 +246,7 @@ export type {
   PluginSourceRecord,
   PluginSourceScopePaths,
   PluginVerifyOutcome,
+  RegisteredPluginSourceDir,
   RemovePluginSourceOptions,
   ScaffoldPluginOptions,
   ScaffoldPluginResult,

--- a/packages/plugin-cli/src/server/index.ts
+++ b/packages/plugin-cli/src/server/index.ts
@@ -15,6 +15,7 @@ export {
   readPluginSourceRecordsForRoots,
   removePluginSource,
   resolvePluginSourceScopePaths,
+  resolveRegisteredPluginSourceDirs,
 } from "./pluginSources"
 export type {
   InstallPluginSourceOptions,
@@ -26,6 +27,7 @@ export type {
   PluginSourceKind,
   PluginSourceRecord,
   PluginSourceScopePaths,
+  RegisteredPluginSourceDir,
   RemovePluginSourceOptions,
 } from "./pluginSources"
 

--- a/packages/plugin-cli/src/server/pluginSources.ts
+++ b/packages/plugin-cli/src/server/pluginSources.ts
@@ -488,6 +488,34 @@ export function readPluginSourceRecordsForRoots(opts: {
   return [...readPluginSourceRecords(global), ...readPluginSourceRecords(local)]
 }
 
+export interface RegisteredPluginSourceDir {
+  /** Raw package source string as written in settings.json. */
+  source: string
+  /** Absolute directory the source resolves to (may not exist). */
+  rootDir: string
+}
+
+/**
+ * Resolve every local-path `packages` entry in the scope's settings.json
+ * to its directory WITHOUT validating the plugin root. Remote specs
+ * (npm:, git:, URLs) are skipped — their installed copies live under the
+ * scope's npm/git dirs, which hosts already scan directly.
+ *
+ * Unlike `readPluginSourceRecords`, broken entries are returned rather
+ * than dropped: hosts pass these dirs to the Boring plugin scanner with
+ * `registered: true`, so a deleted dir or stripped package.json surfaces
+ * as a preflight error in the plugin UI instead of the plugin silently
+ * vanishing.
+ */
+export function resolveRegisteredPluginSourceDirs(paths: PluginSourceScopePaths): RegisteredPluginSourceDir[] {
+  return packageEntries(readPiSettings(paths.settingsPath)).flatMap((entry) => {
+    const source = packageEntrySource(entry)
+    if (!source) return []
+    const rootDir = resolvePackageSourcePath(paths.baseDir, source)
+    return rootDir ? [{ source, rootDir }] : []
+  })
+}
+
 function upsertPackageSource(paths: PluginSourceScopePaths, record: PluginSourceRecord): boolean {
   const settings = readPiSettings(paths.settingsPath)
   const entries = packageEntries(settings)

--- a/packages/workspace/src/server/__tests__/agentPlugins.test.ts
+++ b/packages/workspace/src/server/__tests__/agentPlugins.test.ts
@@ -359,6 +359,59 @@ describe("boring agent plugin assets", () => {
     expect(readBoringPlugins([collection])).toEqual([])
   })
 
+  test("reports registered source dirs that do not exist", async () => {
+    const root = await tmp("boring-plugin-registered-missing-")
+    const gone = join(root, "deleted-plugin")
+
+    // Speculative scan roots stay silent when absent…
+    expect(preflightBoringPlugins([{ rootDir: gone, kind: "external" }])).toEqual({ ok: true, errors: [] })
+    // …registered ones surface a preflight error.
+    const result = preflightBoringPlugins([{ rootDir: gone, kind: "external", registered: true }])
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatchObject({
+      pluginDir: gone,
+      code: "MISSING_PLUGIN_DIR",
+    })
+  })
+
+  test("reports registered source dirs without package.json even with non-package children", async () => {
+    const root = await tmp("boring-plugin-registered-stripped-")
+    await mkdir(join(root, "dist"), { recursive: true })
+
+    const result = preflightBoringPlugins([{ rootDir: root, kind: "external", registered: true }])
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatchObject({
+      pluginDir: root,
+      code: "MISSING_PACKAGE_JSON",
+    })
+  })
+
+  test("reports registered source dirs whose package.json has no plugin metadata", async () => {
+    const root = await tmp("boring-plugin-registered-no-metadata-")
+    await writeFile(join(root, "package.json"), JSON.stringify({ name: "not-a-plugin", version: "1.0.0" }), "utf8")
+
+    // Non-registered package dirs without metadata are skipped silently…
+    expect(preflightBoringPlugins([{ rootDir: root, kind: "external" }])).toEqual({ ok: true, errors: [] })
+    // …registered ones surface a preflight error.
+    const result = preflightBoringPlugins([{ rootDir: root, kind: "external", registered: true }])
+    expect(result.ok).toBe(false)
+    expect(result.errors[0]).toMatchObject({
+      pluginDir: root,
+      code: "INVALID_PLUGIN_METADATA",
+      message: expect.stringContaining("no \"boring\" or \"pi\" plugin metadata"),
+    })
+  })
+
+  test("registered source dirs with valid plugins still load normally", async () => {
+    const root = await tmp("boring-plugin-registered-valid-")
+    await writePlugin(root)
+
+    const result = scanBoringPlugins([{ rootDir: root, kind: "external", registered: true }])
+    expect(result.preflight).toEqual({ ok: true, errors: [] })
+    expect(result.plugins).toHaveLength(1)
+    expect(result.plugins[0].id).toBe("boring-plugin-test")
+  })
+
   test("rejects explicit server entries that resolve outside the plugin root", async () => {
     const root = await tmp("boring-plugin-explicit-server-symlink-escape-")
     const outside = await tmp("boring-plugin-outside-server-target-")

--- a/packages/workspace/src/server/agentPlugins/scan.ts
+++ b/packages/workspace/src/server/agentPlugins/scan.ts
@@ -13,7 +13,7 @@ import { resolveContainedPluginPath } from "./pluginPaths"
 export interface BoringPluginPreflightIssue {
   pluginDir: string
   pluginId?: string
-  code: "MISSING_PACKAGE_JSON" | "INVALID_PACKAGE_JSON" | "INVALID_PLUGIN_METADATA"
+  code: "MISSING_PLUGIN_DIR" | "MISSING_PACKAGE_JSON" | "INVALID_PACKAGE_JSON" | "INVALID_PLUGIN_METADATA"
   message: string
 }
 
@@ -30,6 +30,8 @@ export interface BoringPluginScanResult {
 interface DiscoveredBoringPluginDirs {
   sources: BoringPluginSource[]
   missingPackageJson: string[]
+  /** Registered source dirs that do not exist on disk. */
+  missingDirs: string[]
 }
 
 function normalizeBoringPluginSource(input: BoringPluginSourceInput): BoringPluginSource {
@@ -38,6 +40,7 @@ function normalizeBoringPluginSource(input: BoringPluginSourceInput): BoringPlug
     rootDir: resolve(input.rootDir),
     kind: input.kind,
     ...(input.workspaceId ? { workspaceId: input.workspaceId } : {}),
+    ...(input.registered ? { registered: true } : {}),
   }
 }
 
@@ -118,10 +121,14 @@ function packagePathContainmentIssues(rootDir: string, pkg: BoringPluginPackageJ
 function discoverBoringPluginDirs(pluginDirs: BoringPluginSourceInput[]): DiscoveredBoringPluginDirs {
   const out = new Map<string, BoringPluginSource>()
   const missingPackageJson: string[] = []
+  const missingDirs: string[] = []
   for (const raw of pluginDirs) {
     const source = normalizeBoringPluginSource(raw)
     const dir = source.rootDir
-    if (!existsSync(dir)) continue
+    if (!existsSync(dir)) {
+      if (source.registered) missingDirs.push(dir)
+      continue
+    }
     const info = statSync(dir)
     if (!info.isDirectory()) continue
 
@@ -140,15 +147,18 @@ function discoverBoringPluginDirs(pluginDirs: BoringPluginSourceInput[]): Discov
 
     // Parent collection directories such as .pi/extensions are valid even when empty.
     // A non-collection directory with no package.json and no package children is treated
-    // as an explicitly supplied plugin dir and reported to the caller.
+    // as an explicitly supplied plugin dir and reported to the caller. Registered
+    // sources always point at a single plugin root, so a missing package.json is an
+    // error there regardless of name or children.
     const collectionDirNames = new Set(["extensions", "npm", "git"])
-    if (!hasPackageJson && childPackageDirs.length === 0 && !collectionDirNames.has(basename(dir))) {
+    if (!hasPackageJson && (source.registered || (childPackageDirs.length === 0 && !collectionDirNames.has(basename(dir))))) {
       missingPackageJson.push(dir)
     }
   }
   return {
     sources: [...out.values()].sort((a, b) => a.rootDir.localeCompare(b.rootDir)),
     missingPackageJson: [...new Set(missingPackageJson)].sort(),
+    missingDirs: [...new Set(missingDirs)].sort(),
   }
 }
 
@@ -158,6 +168,9 @@ export function scanBoringPlugins(pluginDirs: BoringPluginSourceInput[]): Boring
   const seenIds = new Map<string, string>()
   const discovered = discoverBoringPluginDirs(pluginDirs)
 
+  for (const pluginDir of discovered.missingDirs) {
+    errors.push({ pluginDir, code: "MISSING_PLUGIN_DIR", message: "registered plugin source directory does not exist" })
+  }
   for (const pluginDir of discovered.missingPackageJson) {
     errors.push({ pluginDir, code: "MISSING_PACKAGE_JSON", message: "package.json is missing" })
   }
@@ -175,7 +188,16 @@ export function scanBoringPlugins(pluginDirs: BoringPluginSourceInput[]): Boring
       })
       continue
     }
-    if (!hasPluginMetadata(raw)) continue
+    if (!hasPluginMetadata(raw)) {
+      if (source.registered) {
+        errors.push({
+          pluginDir: rootDir,
+          code: "INVALID_PLUGIN_METADATA",
+          message: 'package.json has no "boring" or "pi" plugin metadata',
+        })
+      }
+      continue
+    }
 
     const result = validateBoringPluginManifest(raw)
     if (!result.valid) {

--- a/packages/workspace/src/server/agentPlugins/types.ts
+++ b/packages/workspace/src/server/agentPlugins/types.ts
@@ -16,6 +16,14 @@ export interface BoringPluginSource {
   rootDir: string
   kind: BoringPluginSourceKind
   workspaceId?: string
+  /**
+   * True when the user explicitly registered this directory as a plugin
+   * source (e.g. a `packages` entry in Pi settings.json). Registered
+   * sources that are missing, lack a package.json, or carry no plugin
+   * metadata surface as preflight errors instead of being silently
+   * skipped the way speculative scan roots are.
+   */
+  registered?: boolean
 }
 
 export type BoringPluginSourceInput = string | BoringPluginSource


### PR DESCRIPTION
## Problem

A `packages` entry in `.pi/settings.json` whose directory was deleted — or whose `package.json` was stripped — vanished **silently**: `readPluginSourceRecords` swallowed the validation failure in a bare `catch`, the directory never reached the Boring plugin scanner, and the plugin simply disappeared from the left rail with no error anywhere.

This bit us today: a cleanup moved the sources of `github-pr-tracker` and `ccusage-dashboard` out of `plugins/`, and the only symptom was "the plugins are gone" — it looked like merged work had been discarded.

## Fix

Registered sources are explicit user intent, so they now fail loudly through the existing preflight/error channel (`boring.plugin.error` events + the plugin-errors UI):

- New `resolveRegisteredPluginSourceDirs()` in plugin-cli resolves settings entries **without validating** the plugin root (remote `npm:`/`git:` specs are still skipped — their installed copies are scanned via the npm/git dirs).
- The CLI's `resolveCliBoringPluginDirs` passes those dirs to the scanner flagged `registered: true`.
- The scanner reports registered sources that are broken:
  - `MISSING_PLUGIN_DIR` (new code) — registered dir does not exist
  - `MISSING_PACKAGE_JSON` — even when the dir still has non-package children (e.g. only `dist/` left)
  - `INVALID_PLUGIN_METADATA` — package.json has no `boring`/`pi` metadata

Speculative scan roots (collection dirs, npm/git install dirs, CLI defaults) keep their silent-skip behavior — only explicitly registered sources get the strict treatment.

## Tests

- workspace: 4 new scan tests covering missing dir / stripped package.json / metadata-less package.json / valid registered plugin (38 pass)
- plugin-cli: new `resolveRegisteredPluginSourceDirs` unit test (11 pass)
- cli: updated `pluginDiscovery` tests — broken local entry now asserts a `MISSING_PLUGIN_DIR` load error (9 pass)
- `typecheck` green on workspace, plugin-cli, cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)