### PR TITLE
fix(workspace): share data search chrome with files

### DIFF
--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -4,6 +4,7 @@ import type { DeckWidgetDefinition } from "@hachej/boring-deck/shared"
 import { WorkspaceProvider } from "@hachej/boring-workspace"
 import { WorkspaceAgentFront, WorkspaceFullPagePanel, parseFullPagePanelLocation } from "@hachej/boring-workspace/app/front"
 import { askUserPlugin } from "@hachej/boring-ask-user/front"
+import playgroundDataCatalogPlugin from "../plugins/playgroundDataCatalog/front"
 import { SHOWCASE_SESSION_ID, seedShowcase } from "./showcaseMessages"
 
 function isShowcaseRoute(): boolean {
@@ -40,7 +41,7 @@ const playgroundDeckPlugin = createDeckPlugin({
   },
 })
 
-const workspacePlugins = [askUserPlugin, playgroundDeckPlugin]
+const workspacePlugins = [playgroundDataCatalogPlugin, askUserPlugin, playgroundDeckPlugin]
 
 function WorkspaceFullPageShell() {
   const parsed = parseFullPagePanelLocation(window.location.search)

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -86,6 +86,10 @@ export function WorkbenchLeftPane({
   const [query, setQuery] = useState("")
   const [debouncedQuery, setDebouncedQuery] = useState("")
   const searchInputRef = useRef<HTMLInputElement>(null)
+  const [chromeActionsElement, setChromeActionsElement] = useState<HTMLDivElement | null>(null)
+  const setChromeActionsRef = useCallback((node: HTMLDivElement | null) => {
+    setChromeActionsElement(node)
+  }, [])
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   useEffect(() => {
@@ -153,9 +157,10 @@ export function WorkbenchLeftPane({
       query: debouncedQuery,
       searchQuery: debouncedQuery || undefined,
       chromeless: true,
+      chromeActionsElement,
       revealFileTreeRequest,
     }),
-    [bridge, debouncedQuery, revealFileTreeRequest, rootDir],
+    [bridge, chromeActionsElement, debouncedQuery, revealFileTreeRequest, rootDir],
   )
 
   // Workspace categories live on a quiet icon rail. The active category
@@ -232,6 +237,11 @@ export function WorkbenchLeftPane({
                 </IconButton>
               </ControlTooltip>
             )}
+            <div
+              ref={setChromeActionsRef}
+              className="flex shrink-0 items-center gap-1"
+              data-boring-workspace-part="left-tab-chrome-actions"
+            />
           </div>
         )}
 

--- a/packages/workspace/src/shared/plugins/types.ts
+++ b/packages/workspace/src/shared/plugins/types.ts
@@ -92,6 +92,8 @@ export interface LeftTabParams {
   searchQuery?: string
   bridge?: unknown
   chromeless?: boolean
+  /** Optional DOM target for left-tab toolbar actions owned by the pane. */
+  chromeActionsElement?: Element | null
   revealFileTreeRequest?: { path: string; seq: number } | null
 }
 

--- a/plugins/data-catalog/src/front/__tests__/dataCatalogPlugin.test.tsx
+++ b/plugins/data-catalog/src/front/__tests__/dataCatalogPlugin.test.tsx
@@ -107,6 +107,7 @@ describe("createDataCatalogPlugin (BoringFrontFactory)", () => {
         panelId: "warehouse-data-tab",
       }),
     )
+    expect(captured.leftTabs[0]).not.toHaveProperty("chromeless", true)
 
     expect(captured.panels).toHaveLength(1)
     expect(captured.panels[0]).toEqual(
@@ -155,6 +156,40 @@ describe("createDataCatalogPlugin (BoringFrontFactory)", () => {
         params: { bridge },
         bridge,
       }),
+    )
+  })
+
+  it("uses the host left-pane search when rendered chromeless with a controlled query", async () => {
+    const adapterWithSpy: ExplorerDataSource = {
+      search: vi.fn(adapter.search),
+    }
+    const factory = createDataCatalogPlugin({
+      id: "metrics",
+      label: "Metrics",
+      adapter: adapterWithSpy,
+      facets: [{ key: "category", label: "Category" }],
+    })
+    const { api, captured } = makeMockApi()
+    await factory(api)
+
+    const tab = captured.leftTabs[0]
+    if (!tab) throw new Error("missing left tab")
+    const Component = tab.component as ComponentType<any>
+    const chromeActionsElement = document.createElement("div")
+
+    const { container } = render(
+      <Component
+        params={{ chromeless: true, query: "customers", chromeActionsElement }}
+      />,
+    )
+
+    await screen.findByText("Customers")
+    expect(screen.queryByText("Daily Orders")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Search" })).not.toBeInTheDocument()
+    expect(chromeActionsElement.querySelector('[aria-label="Filters"]')).not.toBeNull()
+    expect(container.querySelector('[aria-label="Filters"]')).toBeNull()
+    expect(adapterWithSpy.search).toHaveBeenCalledWith(
+      expect.objectContaining({ query: "customers" }),
     )
   })
 

--- a/plugins/data-catalog/src/front/index.tsx
+++ b/plugins/data-catalog/src/front/index.tsx
@@ -106,8 +106,7 @@ export function createDataCatalogPlugin(
     const { query, controlled } = useDataCatalogQuery(params)
     const bridge = params?.bridge as WorkspaceBridge | undefined
     const handleSelect = (row: ExplorerItem) => onSelect(row, { params, bridge })
-    const ownsChrome = params?.chromeless === true
-    const effectiveControlled = controlled && !ownsChrome
+    const usesOuterChromeSearch = controlled && params?.chromeless === true
     return (
       <DataExplorer
         adapter={options.adapter}
@@ -117,10 +116,11 @@ export function createDataCatalogPlugin(
         getDragPayload={options.getDragPayload}
         emptyState={emptyState}
         searchPlaceholder={searchPlaceholder}
-        toolbarTitle={ownsChrome ? leftTabTitle : undefined}
-        toolbarIcon={ownsChrome ? leftTabIcon : undefined}
-        query={effectiveControlled ? query : undefined}
-        searchable={!effectiveControlled}
+        toolbarTitle={usesOuterChromeSearch ? undefined : leftTabTitle}
+        toolbarIcon={usesOuterChromeSearch ? undefined : leftTabIcon}
+        query={usesOuterChromeSearch ? query : undefined}
+        searchable={!usesOuterChromeSearch}
+        toolbarPortalElement={usesOuterChromeSearch ? params?.chromeActionsElement : undefined}
         pageSize={options.pageSize}
         debounceMs={options.debounceMs}
         className={className ?? "h-full"}
@@ -183,7 +183,6 @@ export function createDataCatalogPlugin(
         icon: leftTabIcon,
         component: DataCatalogLeftTab,
         source,
-        chromeless: true,
         panelId: leftTabId,
       }
     : undefined

--- a/plugins/data-explorer/src/front/DataExplorer.tsx
+++ b/plugins/data-explorer/src/front/DataExplorer.tsx
@@ -1,4 +1,5 @@
 import { useMemo, type ComponentType, type KeyboardEvent, type DragEvent, type ReactNode } from "react"
+import { createPortal } from "react-dom"
 import { ChevronRightIcon, ChevronDownIcon, FilterIcon, SearchIcon, XIcon } from "lucide-react"
 import { cn } from "./utils"
 import { Button, Chip as UiChip, ChipButton, EmptyState, Input, Spinner, Toolbar as UiToolbar } from "@hachej/boring-ui-kit"
@@ -39,6 +40,8 @@ export type DataExplorerProps = {
   query?: string
   /** Called when the toolbar search changes. Use with `query` for controlled per-tab search. */
   onQueryChange?: (query: string) => void
+  /** Optional external chrome target for toolbar-only actions such as filters. */
+  toolbarPortalElement?: Element | null
   /** Page size and debounce — passed through to useExplorerState. */
   pageSize?: number
   debounceMs?: number
@@ -58,6 +61,7 @@ export function DataExplorer({
   searchable = true,
   query,
   onQueryChange,
+  toolbarPortalElement,
   pageSize,
   debounceMs,
   className,
@@ -81,6 +85,9 @@ export function DataExplorer({
   const hasFilters = Object.values(state.filters).some((v) => v.length > 0)
   const treeMode = !!groupBy && !hasQuery && !hasFilters
   const filterCount = Object.values(state.filters).reduce((n, v) => n + v.length, 0)
+  const useExternalToolbarActions = Boolean(
+    toolbarPortalElement && !showSearch && facetConfigs?.length && !toolbarTitle,
+  )
 
   // Group entries from facets (canonical for tree mode).
   const groupEntries = useMemo(() => {
@@ -111,7 +118,20 @@ export function DataExplorer({
 
   return (
     <div className={cn("flex h-full flex-col", className)} data-slot="data-explorer">
-      {showSearch || facetConfigs?.length ? (
+      {useExternalToolbarActions && toolbarPortalElement
+        ? createPortal(
+            <ExternalToolbarActions
+              facetConfigs={facetConfigs}
+              facets={state.facets}
+              filters={state.filters}
+              filterCount={filterCount}
+              onToggleFilter={state.toggleFilter}
+              onClearFilters={state.clearFilters}
+            />,
+            toolbarPortalElement,
+          )
+        : null}
+      {(showSearch || facetConfigs?.length) && !useExternalToolbarActions ? (
         <Toolbar
           searchable={showSearch}
           searchPlaceholder={searchPlaceholder}
@@ -238,42 +258,75 @@ function Toolbar({
           </PopoverContent>
         </Popover>
       ) : null}
-      {facetConfigs?.length ? (
-        <Popover>
-          <PopoverTrigger
-            aria-label="Filters"
-            className={cn(
-              "inline-flex h-7 items-center gap-1 rounded-sm px-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground",
-              filterCount > 0 && "bg-muted text-foreground",
-            )}
-          >
-            <FilterIcon size={12} />
-            {filterCount > 0 ? <span className="font-mono text-[10px]">{filterCount}</span> : null}
-          </PopoverTrigger>
-          <PopoverContent
-            side="right"
-            align="start"
-            sideOffset={8}
-            className="w-64 space-y-3 p-3 text-[12px]"
-          >
-            {facetConfigs.map((config) => (
-              <FacetSection
-                key={config.key}
-                config={config}
-                values={facets?.[config.key] ?? []}
-                selected={filters[config.key] ?? []}
-                onToggle={onToggleFilter}
-              />
-            ))}
-            {filterCount > 0 ? (
-              <Button type="button" variant="ghost" size="xs" onClick={onClearFilters} className="gap-1 text-[11px] text-muted-foreground hover:text-foreground">
-                <XIcon size={11} /> Clear all
-              </Button>
-            ) : null}
-          </PopoverContent>
-        </Popover>
-      ) : null}
+      <FilterControl
+        facetConfigs={facetConfigs}
+        facets={facets}
+        filters={filters}
+        filterCount={filterCount}
+        onToggleFilter={onToggleFilter}
+        onClearFilters={onClearFilters}
+      />
     </UiToolbar>
+  )
+}
+
+type FilterControlProps = {
+  facetConfigs?: FacetConfig[]
+  facets: ReturnType<typeof useExplorerState>["facets"]
+  filters: Record<string, string[]>
+  filterCount: number
+  onToggleFilter: (key: string, value: string) => void
+  onClearFilters: () => void
+}
+
+function ExternalToolbarActions(props: FilterControlProps) {
+  return <FilterControl {...props} />
+}
+
+function FilterControl({
+  facetConfigs,
+  facets,
+  filters,
+  filterCount,
+  onToggleFilter,
+  onClearFilters,
+}: FilterControlProps) {
+  if (!facetConfigs?.length) return null
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        aria-label="Filters"
+        className={cn(
+          "inline-flex h-7 items-center gap-1 rounded-sm px-1.5 text-[11px] text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground",
+          filterCount > 0 && "bg-muted text-foreground",
+        )}
+      >
+        <FilterIcon size={12} />
+        {filterCount > 0 ? <span className="font-mono text-[10px]">{filterCount}</span> : null}
+      </PopoverTrigger>
+      <PopoverContent
+        side="right"
+        align="start"
+        sideOffset={8}
+        className="w-64 space-y-3 p-3 text-[12px]"
+      >
+        {facetConfigs.map((config) => (
+          <FacetSection
+            key={config.key}
+            config={config}
+            values={facets?.[config.key] ?? []}
+            selected={filters[config.key] ?? []}
+            onToggle={onToggleFilter}
+          />
+        ))}
+        {filterCount > 0 ? (
+          <Button type="button" variant="ghost" size="xs" onClick={onClearFilters} className="gap-1 text-[11px] text-muted-foreground hover:text-foreground">
+            <XIcon size={11} /> Clear all
+          </Button>
+        ) : null}
+      </PopoverContent>
+    </Popover>
   )
 }
 


### PR DESCRIPTION
## Summary
- register the workspace playground data catalog front plugin
- make Data tab search use the same left-pane chrome/search state as Files
- portal DataExplorer filter controls into the left-pane chrome next to the search button

## Validation
- pnpm --filter @hachej/boring-data-explorer typecheck
- pnpm --filter @hachej/boring-data-explorer test
- pnpm --filter @hachej/boring-data-explorer build
- pnpm --filter @hachej/boring-data-catalog typecheck
- pnpm --filter @hachej/boring-data-catalog test
- pnpm --filter @hachej/boring-data-catalog build
- pnpm --filter @hachej/boring-workspace typecheck
- pnpm --filter @hachej/boring-workspace build
- pnpm --filter workspace-playground typecheck
- pnpm --filter @hachej/boring-ui-cli run build:front
- pnpm --filter @hachej/boring-ui-cli run build