### PR TITLE
feat(agent): canonical pi harness defaults; ambient skills on in the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,11 @@ Near-term priorities:
 ### Plugins
 
 
-| Plugin                         | What it adds                                                                            | README                                                                   |
-| ------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `@hachej/boring-ask-user`      | Agent-to-user question/answer surface and `ask_user` tool                               | [plugins/ask-user](plugins/ask-user/README.md)                           |
-| `@hachej/boring-data-explorer` | Searchable, faceted data tables — the primitive for explorer-style panels               | [plugins/data-explorer](plugins/data-explorer/README.md)                 |
-| `@hachej/boring-data-catalog`  | Configurable catalog tab built on `data-explorer`                                       | [plugins/data-catalog](plugins/data-catalog/README.md)                   |
+| Plugin                         | What it adds                                                                | README                                                                                 |
+| ------------------------------ | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| `@hachej/boring-ask-user`      | Agent-to-user question/answer surface and `ask_user` tool                   | [plugins/ask-user](plugins/ask-user/README.md)                                         |
+| `@hachej/boring-data-explorer` | Searchable, faceted data tables — the primitive for explorer-style panels   | [plugins/data-explorer](plugins/data-explorer/README.md)                               |
+| `@hachej/boring-data-catalog`  | Configurable catalog tab built on `data-explorer`                           | [plugins/data-catalog](plugins/data-catalog/README.md)                                 |
 | App/internal plugin template   | Publishable package-plugin reference; create with `boring-ui-plugin create` | [packages/plugin-cli/templates/plugin](packages/plugin-cli/templates/plugin/README.md) |
 
 

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -777,6 +777,9 @@ test('skills endpoint lists Pi-resolved project skills', async () => {
   await app.register(registerAgentRoutes, {
     workspaceRoot,
     mode: 'direct',
+    // Skill discovery is off by default (withPiHarnessDefaults); hosts that
+    // want pi-resolved skills in the picker opt in, like the CLI does.
+    pi: { noSkills: false },
   })
   await app.ready()
 
@@ -784,6 +787,34 @@ test('skills endpoint lists Pi-resolved project skills', async () => {
   expect(res.statusCode).toBe(200)
   const names: string[] = res.json().skills.map((skill: { name: string }) => skill.name)
   expect(names).toContain('project-skill')
+
+  await app.close()
+})
+
+test('skills endpoint discovers workspace .agents/skills when ambient skills are enabled', async () => {
+  const workspaceRoot = await makeTempDir('boring-agent-embed-skills-ambient-')
+  const skillRoot = join(workspaceRoot, '.agents', 'skills', 'cli-project-skill')
+  await mkdir(skillRoot, { recursive: true })
+  await writeFile(
+    join(skillRoot, 'SKILL.md'),
+    '---\nname: cli-project-skill\ndescription: Project skill visible in standalone CLI mode.\n---\n# CLI project skill\n',
+    'utf-8',
+  )
+
+  const app = Fastify({ logger: false })
+  await app.register(registerAgentRoutes, {
+    workspaceRoot,
+    mode: 'direct',
+    // The standalone CLI's config: ambient discovery on (default is off).
+    pi: { noSkills: false },
+  })
+  await app.ready()
+
+  const res = await app.inject({ method: 'GET', url: '/api/v1/agent/skills?refresh=1' })
+  expect(res.statusCode).toBe(200)
+  expect(res.json().skills).toEqual(expect.arrayContaining([
+    expect.objectContaining({ name: 'cli-project-skill' }),
+  ]))
 
   await app.close()
 })
@@ -802,6 +833,7 @@ test('skills endpoint does not require unrelated runtime-only dynamic hooks', as
   await app.register(registerAgentRoutes, {
     workspaceRoot,
     mode: 'direct',
+    pi: { noSkills: false },
     getSessionNamespace: () => {
       throw new Error('session namespace should not be needed for skill listing')
     },

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -6,7 +6,7 @@ import { getEnv } from './config/env'
 import type { RuntimeModeAdapter, RuntimeModeId } from './runtime/mode'
 import { getRuntimeBundleStorageRoot } from './runtime/mode'
 import { resolveMode, autoDetectMode } from './runtime/resolveMode'
-import { createPiCodingAgentHarness } from './harness/pi-coding-agent/createHarness'
+import { createPiCodingAgentHarness, withPiHarnessDefaults } from './harness/pi-coding-agent/createHarness'
 import type { PiHarnessOptions } from './harness/pi-coding-agent/createHarness'
 import type { WorkspaceProvisioningResult } from './workspace/provisioning'
 import { loadPlugins } from './harness/pi-coding-agent/pluginLoader'
@@ -135,7 +135,7 @@ export async function createAgentApp(
 
   const getRuntimeProvisioning = opts.getRuntimeProvisioning ?? (() => opts.runtimeProvisioning)
   const runtimePi: PiHarnessOptions = {
-    ...opts.pi,
+    ...withPiHarnessDefaults(opts.pi),
     additionalSkillPaths: [
       ...(getRuntimeProvisioning()?.skillPaths ?? []),
       ...(opts.pi?.additionalSkillPaths ?? []),
@@ -172,11 +172,7 @@ export async function createAgentApp(
 
   const harnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
     ...input,
-    pi: {
-      noContextFiles: true,
-      noSkills: true,
-      ...runtimePi,
-    },
+    pi: runtimePi,
   }))
   const harness = await harnessFactory({
     tools,

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -110,6 +110,29 @@ export interface PiHarnessOptions {
   getHotReloadableResources?: () => HotReloadablePiResources;
 }
 
+/** Pi harness options with the discovery flags resolved to definite booleans. */
+export type ResolvedPiHarnessOptions = PiHarnessOptions & {
+  noContextFiles: boolean;
+  noSkills: boolean;
+};
+
+/**
+ * Boring's default pi resource-discovery policy — the ONE place these flags
+ * get their defaults. Harness factories must apply this instead of inlining
+ * flag literals; hosts override per-field through their `pi` config.
+ *
+ * - `noContextFiles: true` — boring composes its own workspace context
+ *   prompt; pi's ambient AGENTS.md/CLAUDE.md discovery stays off.
+ * - `noSkills: true` — ambient skill discovery (workspace + user-global
+ *   ~/.pi skills) stays off so user-global skills don't leak into hosted
+ *   agents. Hosts that run on the user's own machine (the standalone CLI)
+ *   opt in with `pi: { noSkills: false }`.
+ */
+export function withPiHarnessDefaults(pi?: PiHarnessOptions): ResolvedPiHarnessOptions {
+  const { noContextFiles = true, noSkills = true, ...rest } = pi ?? {};
+  return { ...rest, noContextFiles, noSkills };
+}
+
 export interface HotReloadablePiResources {
   additionalSkillPaths?: string[];
   packages?: PiPackageSource[];

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -355,6 +355,11 @@ export function createPiCodingAgentHarness(opts: {
   getPiSessionAdapter(input: SendMessageInput, ctx: RunContext): Promise<PiAgentSessionAdapter>;
   hasPiSession(sessionId: string): boolean;
 } {
+  // Normalize at the true boundary: direct callers and custom harnessFactory
+  // hosts get the canonical discovery policy even if they never heard of
+  // withPiHarnessDefaults. Idempotent for the built-in factories, which
+  // already pass defaulted options.
+  const pi = withPiHarnessDefaults(opts.pi);
   const sessionStore = new PiSessionStore(opts.runtimeCwd ?? opts.cwd, {
     sessionNamespace: opts.sessionNamespace,
     sessionDir: opts.sessionDir,
@@ -370,22 +375,22 @@ export function createPiCodingAgentHarness(opts: {
   const effectivePackages: PiPackageSource[] = []
   const effectiveExtensionPaths: string[] = []
   const refreshEffectiveResources = (): void => {
-    const dynamic = opts.pi?.getHotReloadableResources?.() ?? {}
+    const dynamic = pi.getHotReloadableResources?.() ?? {}
     effectiveSkillPaths.splice(
       0,
       effectiveSkillPaths.length,
-      ...(opts.pi?.additionalSkillPaths ?? []),
+      ...(pi.additionalSkillPaths ?? []),
       ...(dynamic.additionalSkillPaths ?? []),
     )
     effectivePackages.splice(
       0,
       effectivePackages.length,
-      ...mergePiPackageSources(opts.pi?.packages ?? [], dynamic.packages ?? []),
+      ...mergePiPackageSources(pi.packages ?? [], dynamic.packages ?? []),
     )
     effectiveExtensionPaths.splice(
       0,
       effectiveExtensionPaths.length,
-      ...(opts.pi?.extensionPaths ?? []),
+      ...(pi.extensionPaths ?? []),
       ...(dynamic.extensionPaths ?? []),
     )
   }
@@ -484,7 +489,7 @@ export function createPiCodingAgentHarness(opts: {
     const extensionFactories = [
       toolErrorResultExtension,
       ...(dynamicPromptExtension ? [dynamicPromptExtension] : []),
-      ...(opts.pi?.extensionFactories ?? []),
+      ...(pi.extensionFactories ?? []),
     ]
     const settingsManager = createResourceSettingsManager(
       opts.cwd,
@@ -498,8 +503,8 @@ export function createPiCodingAgentHarness(opts: {
       appendSystemPromptOverride: (base: string[]) => [...base, composedSystemPromptAppend],
       ...(effectiveExtensionPaths.length ? { additionalExtensionPaths: effectiveExtensionPaths } : {}),
       ...(extensionFactories.length ? { extensionFactories } : {}),
-      ...(opts.pi?.noContextFiles ? { noContextFiles: true } : {}),
-      ...(opts.pi?.noSkills ? { noSkills: true } : {}),
+      ...(pi.noContextFiles ? { noContextFiles: true } : {}),
+      ...(pi.noSkills ? { noSkills: true } : {}),
       ...(effectiveSkillPaths.length ? { additionalSkillPaths: effectiveSkillPaths } : {}),
       // skillsOverride REPLACES Pi's resolved skill set, which includes
       // skills contributed by host-declared pi packages (e.g.
@@ -508,7 +513,7 @@ export function createPiCodingAgentHarness(opts: {
       // Passing additionalSkillPaths is not, by itself, a request to throw
       // away package skills — those should keep flowing through Pi's loader
       // and merge with the additional paths.
-      ...(opts.pi?.noSkills
+      ...(pi.noSkills
         ? {
             skillsOverride: () =>
               loadSkills({

--- a/packages/agent/src/server/http/routes/__tests__/skills.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/skills.test.ts
@@ -20,6 +20,10 @@ describe('GET /api/v1/agent/skills', () => {
     await app.close()
   })
 
+  // Ambient-skill discovery (noSkills: false) is covered end-to-end in
+  // ../../../__tests__/registerAgentRoutes.test.ts — fs fixtures are not
+  // allowed under routes/ (see scripts/check-invariants.sh).
+
   test('surfaces an error field instead of silently swallowing failures', async () => {
     const app = await buildApp({
       workspaceRoot: process.cwd(),

--- a/packages/agent/src/server/http/routes/skills.ts
+++ b/packages/agent/src/server/http/routes/skills.ts
@@ -16,7 +16,7 @@ import {
   loadSkills,
 } from '@mariozechner/pi-coding-agent'
 import type { PiPackageSource } from '../../piPackages'
-import { createResourceSettingsManager } from '../../harness/pi-coding-agent/createHarness'
+import { createResourceSettingsManager, withPiHarnessDefaults } from '../../harness/pi-coding-agent/createHarness'
 
 export interface SkillSummary {
   name: string
@@ -58,10 +58,13 @@ export function skillsRoutes(
       const piPackages = opts.getPiPackages
         ? await opts.getPiPackages(request)
         : opts.piPackages
-      const noSkills = opts.getNoSkills
+      // `undefined` means the host didn't say — resolve through the canonical
+      // harness policy so a bare registration can't silently flip ambient
+      // skill discovery on.
+      const noSkills = (opts.getNoSkills
         ? await opts.getNoSkills(request)
-        : opts.noSkills
-      const cacheKey = JSON.stringify([workspaceRoot, additionalSkillPaths ?? [], piPackages ?? [], Boolean(noSkills)])
+        : opts.noSkills) ?? withPiHarnessDefaults().noSkills
+      const cacheKey = JSON.stringify([workspaceRoot, additionalSkillPaths ?? [], piPackages ?? [], noSkills])
       const now = Date.now()
       for (const [key, entry] of cached) {
         if (entry.expiresAt <= now) cached.delete(key)
@@ -95,7 +98,7 @@ export function skillsRoutes(
         cwd: workspaceRoot,
         agentDir,
         skillPaths: [...packageSkillPaths, ...(additionalSkillPaths ?? [])],
-        includeDefaults: false,
+        includeDefaults: !noSkills,
       })
       const skills: SkillSummary[] = result.skills.map((s) => ({
         name: s.name,

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -17,9 +17,9 @@ import { ErrorCode } from '../shared/error-codes'
 import { resolveMode, autoDetectMode } from './runtime/resolveMode'
 import { createVercelSandboxModeAdapter } from './runtime/modes/vercel-sandbox'
 import { evictSandboxHandleCacheForWorkspace } from './sandbox/vercel-sandbox/resolveSandboxHandle'
-import { createPiCodingAgentHarness } from './harness/pi-coding-agent/createHarness'
+import { createPiCodingAgentHarness, withPiHarnessDefaults } from './harness/pi-coding-agent/createHarness'
 import { PiSessionStore } from './harness/pi-coding-agent/sessions'
-import type { PiHarnessOptions } from './harness/pi-coding-agent/createHarness'
+import type { PiHarnessOptions, ResolvedPiHarnessOptions } from './harness/pi-coding-agent/createHarness'
 import { loadPlugins } from './harness/pi-coding-agent/pluginLoader'
 import { registerConfiguredModelProviders } from './models/modelConfig'
 import { mergeTools, type PluginToolRegistration } from './catalog/mergeTools'
@@ -125,13 +125,13 @@ interface RuntimeScope {
   root: string
   key: string
   templatePath?: string
-  pi?: PiHarnessOptions
+  pi: ResolvedPiHarnessOptions
   sessionNamespace?: string
 }
 
 interface SkillScope {
   root: string
-  pi?: PiHarnessOptions
+  pi: ResolvedPiHarnessOptions
 }
 
 function selectRuntimeModeAdapter(
@@ -364,6 +364,20 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     }
   }
 
+  // Chokepoint where a scope's pi options are born: resolve the host's
+  // static/dynamic pi config and apply boring's canonical harness defaults,
+  // so every downstream consumer (harness factory, skills routes) reads
+  // already-defaulted flags instead of re-applying the policy themselves.
+  async function resolveScopePi(
+    workspaceId: string,
+    root: string,
+    request?: FastifyRequest,
+  ): Promise<ResolvedPiHarnessOptions> {
+    return withPiHarnessDefaults(opts.getPi
+      ? await opts.getPi({ workspaceId, workspaceRoot: root, request })
+      : opts.pi)
+  }
+
   async function resolveRuntimeScope(
     workspaceId: string,
     request?: FastifyRequest,
@@ -374,9 +388,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     const scopedTemplatePath = opts.getTemplatePath
       ? await opts.getTemplatePath({ workspaceId, workspaceRoot: root, request })
       : templatePath
-    const pi = opts.getPi
-      ? await opts.getPi({ workspaceId, workspaceRoot: root, request })
-      : opts.pi
+    const pi = await resolveScopePi(workspaceId, root, request)
     const sessionNamespace = normalizeSessionNamespace(opts.getSessionNamespace
       ? await opts.getSessionNamespace({ workspaceId, workspaceRoot: root, request })
       : opts.sessionNamespace)
@@ -390,7 +402,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
         workspaceId,
         root,
         scopedTemplatePath ?? null,
-        pi ?? null,
+        pi,
         sessionNamespace ?? null,
       ]),
     }
@@ -403,24 +415,22 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     const root = request && opts.getWorkspaceRoot
       ? await opts.getWorkspaceRoot(workspaceId, request)
       : workspaceRoot
-    const pi = opts.getPi
-      ? await opts.getPi({ workspaceId, workspaceRoot: root, request })
-      : opts.pi
-    const hot = pi?.getHotReloadableResources?.()
+    const pi = await resolveScopePi(workspaceId, root, request)
+    const hot = pi.getHotReloadableResources?.()
     return {
       root,
       pi: hot ? {
         ...pi,
         additionalSkillPaths: [
-          ...(pi?.additionalSkillPaths ?? []),
+          ...(pi.additionalSkillPaths ?? []),
           ...(hot.additionalSkillPaths ?? []),
         ],
         packages: [
-          ...(pi?.packages ?? []),
+          ...(pi.packages ?? []),
           ...(hot.packages ?? []),
         ],
         extensionPaths: [
-          ...(pi?.extensionPaths ?? []),
+          ...(pi.extensionPaths ?? []),
           ...(hot.extensionPaths ?? []),
         ],
       } : pi,
@@ -623,14 +633,13 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     const harnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
       ...input,
       pi: {
-        noContextFiles: true,
-        noSkills: true,
+        // scope.pi is already defaulted at the resolveScopePi chokepoint.
         ...scope.pi,
         additionalSkillPaths: [
-          ...(scope.pi?.additionalSkillPaths ?? []),
+          ...(scope.pi.additionalSkillPaths ?? []),
         ],
         getHotReloadableResources: () => {
-          const hot = scope.pi?.getHotReloadableResources?.() ?? {}
+          const hot = scope.pi.getHotReloadableResources?.() ?? {}
           return {
             ...hot,
             additionalSkillPaths: [
@@ -934,6 +943,8 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       ...(opts.pi?.additionalSkillPaths ?? []),
     ],
     piPackages: opts.pi?.packages,
+    // Undefined is fine: skillsRoutes resolves it through the canonical
+    // harness policy (withPiHarnessDefaults), same as the factory above.
     noSkills: opts.pi?.noSkills,
     getWorkspaceRoot: staticBinding
       ? undefined
@@ -942,19 +953,19 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       ? undefined
       : async (request) => {
           const scope = await getSkillsScopeForRequest(request)
-          if (!hasRuntimeProvisioningInput) return scope.pi?.additionalSkillPaths
+          if (!hasRuntimeProvisioningInput) return scope.pi.additionalSkillPaths
           const binding = await getBindingForRequest(request)
           return [
             ...(binding.runtimeProvisioning?.skillPaths ?? []),
-            ...(scope.pi?.additionalSkillPaths ?? []),
+            ...(scope.pi.additionalSkillPaths ?? []),
           ]
         },
     getPiPackages: staticBinding
       ? undefined
-      : async (request) => (await getSkillsScopeForRequest(request)).pi?.packages,
+      : async (request) => (await getSkillsScopeForRequest(request)).pi.packages,
     getNoSkills: staticBinding
       ? undefined
-      : async (request) => (await getSkillsScopeForRequest(request)).pi?.noSkills,
+      : async (request) => (await getSkillsScopeForRequest(request)).pi.noSkills,
   })
   await app.register(sessionChangesRoutes, { tracker: sessionChangesTracker })
   app.post<{ Body: { sessionId?: string } }>('/api/v1/agent/reload', async (request, reply) => {

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -370,6 +370,10 @@ export async function createFolderModeApp(opts: {
     logger: false,
     provisionWorkspace: false,
     runtimeProvisioning,
+    // The standalone CLI runs on the user's own machine, so ambient skill
+    // discovery (workspace + user-global ~/.pi skills) is on. The library
+    // default is off (withPiHarnessDefaults) to keep hosted agents isolated.
+    pi: { noSkills: false },
     // CLI-bundled internal plugins, resolved to absolute package dirs. This
     // drives the server-side install array (boot-time routes/agentTools);
     // additionalBoringPluginDirs only feeds the asset-manager scan.
@@ -703,6 +707,9 @@ export async function createWorkspacesModeApp(opts: {
       const workspace = await requireWorkspace(workspaceId)
       await getLoadedPluginRuntime(workspace)
       return {
+        // Same policy as folder mode: the local hub runs on the user's own
+        // machine, so ambient skill discovery is on (library default is off).
+        noSkills: false,
         additionalSkillPaths: [join(workspaceRoot, ".agents", "skills")],
         packages: [],
         extensionPaths: [],

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -268,8 +268,9 @@ function createBoringPiPackageSource(workspaceRoot: string): WorkspacePiPackageS
  * The boring-pi package source above is the canonical declarative way to
  * register the skill, but Pi's DefaultResourceLoader skips package-resolved
  * skills (`enabledSkills`) when `noSkills: true` is set — and boring's
- * default agent factory does set `noSkills: true` so user-global skills
- * (~/.agents/skills) don't leak into the agent's prompt. To keep OUR
+ * canonical harness policy (`withPiHarnessDefaults` in @hachej/boring-agent)
+ * defaults to `noSkills: true` so user-global skills (~/.agents/skills)
+ * don't leak into hosted agents' prompts. To keep OUR
  * skill flowing regardless of that filter, we also push the SKILL.md
  * path into `additionalSkillPaths`, which Pi loads via its skillsOverride
  * even under noSkills. Belt-and-suspenders so the agent always sees the


### PR DESCRIPTION
## Why

The pi resource-discovery policy (`noContextFiles`/`noSkills`) was inlined in two parallel harness factories (`createAgentApp`, `registerAgentRoutes`) and implicitly inverted in the skills route. Changing one site silently forked behavior between CLI folder mode, the workspaces hub, and embedders — and the slash-command picker could disagree with the harness about whether ambient skills were on.

## What

- **One definition**: `withPiHarnessDefaults()` in `createHarness.ts` is now the single place the defaults live (`noContextFiles: true`, `noSkills: true`), returning `ResolvedPiHarnessOptions` so consumers get definite booleans enforced by the compiler.
- **One chokepoint per host**: `registerAgentRoutes` resolves + defaults a scope's pi in `resolveScopePi()`, deduplicating the `getPi ? … : opts.pi` resolution that `resolveRuntimeScope` and `resolveSkillScope` each reimplemented. `scope.pi` is now required and pre-defaulted (`scope.pi?.` → `scope.pi.`).
- **Safe-by-construction route**: `skillsRoutes` resolves an unset `noSkills` through the same helper, so a bare registration can't silently flip ambient discovery on, and the picker always matches the agent.
- **CLI = config**: standalone CLI passes `pi: { noSkills: false }` explicitly in both folder and workspaces modes — it runs on the user's own machine, so workspace + user-global `~/.pi` skills are discovered there. Hosted/embed defaults stay off.

## Behavior change for embedders

`registerAgentRoutes`/`createAgentApp` hosts that relied on the skills endpoint listing pi-resolved skills with no config must now pass `pi: { noSkills: false }`.

## Testing

- Full agent suite: 1422 passed / 0 failed (incl. `check-invariants.sh`)
- CLI suite: 52 passed; typecheck clean across `agent`, `cli`, `workspace`
- New e2e test: `.agents/skills` discovery through `registerAgentRoutes` with the CLI's config

🤖 Generated with [Claude Code](https://claude.com/claude-code)