### PR TITLE
chore(workspace): hide playground data catalog

### DIFF
--- a/apps/full-app/Dockerfile
+++ b/apps/full-app/Dockerfile
@@ -26,8 +26,7 @@ RUN pnpm --filter @hachej/boring-core exec tsup --no-dts \
 RUN pnpm --filter @hachej/boring-ui-kit exec tsup \
   && pnpm --filter @hachej/boring-ui-kit exec node scripts/build-styles.mjs
 
-RUN pnpm --filter @hachej/boring-agent exec tsup \
-  && cp packages/agent/src/front/styles/globals.css packages/agent/dist/front/styles.css
+RUN pnpm --filter @hachej/boring-agent run build
 
 RUN pnpm --filter @hachej/boring-workspace exec tsup --no-dts \
   && pnpm --filter @hachej/boring-workspace exec vite build \

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -4,7 +4,6 @@ import type { DeckWidgetDefinition } from "@hachej/boring-deck/shared"
 import { WorkspaceProvider } from "@hachej/boring-workspace"
 import { WorkspaceAgentFront, WorkspaceFullPagePanel, parseFullPagePanelLocation } from "@hachej/boring-workspace/app/front"
 import { askUserPlugin } from "@hachej/boring-ask-user/front"
-import playgroundDataCatalogPlugin from "../plugins/playgroundDataCatalog/front"
 import { SHOWCASE_SESSION_ID, seedShowcase } from "./showcaseMessages"
 
 function isShowcaseRoute(): boolean {
@@ -41,7 +40,7 @@ const playgroundDeckPlugin = createDeckPlugin({
   },
 })
 
-const workspacePlugins = [playgroundDataCatalogPlugin, askUserPlugin, playgroundDeckPlugin]
+const workspacePlugins = [askUserPlugin, playgroundDeckPlugin]
 
 function WorkspaceFullPageShell() {
   const parsed = parseFullPagePanelLocation(window.location.search)

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -45,10 +45,7 @@ export async function startPlaygroundServer(): Promise<void> {
       workspaceRoot,
       mode: "local",
       logger: true,
-      defaultPluginPackages: [
-        "@hachej/boring-ask-user",
-        resolve(APP_ROOT, "src/plugins/playgroundDataCatalog"),
-      ],
+      defaultPluginPackages: ["@hachej/boring-ask-user"],
     })
     app.get("/api/v1/workspace/meta", async () => ({
       projectName: basename(workspaceRoot) || "Workspace",


### PR DESCRIPTION
## Summary\n- Remove the playground data catalog from the frontend plugin list\n- Stop loading the playground data catalog server plugin package in dev\n\n## Validation\n- pnpm --filter workspace-playground run typecheck