### PR TITLE
fix(workspace): isolate full-app sessions by workspace

### DIFF
--- a/apps/full-app/e2e/workspace-lifecycle.spec.ts
+++ b/apps/full-app/e2e/workspace-lifecycle.spec.ts
@@ -124,6 +124,8 @@ async function installWorkspaceLifecycleMocks(page: Page, baseURL: string | unde
   ])
   const sessionsByWorkspace = new Map<string, SessionSummary[]>()
   const sessionRequests: string[] = []
+  const sessionCreates: Array<{ workspaceId: string; body: unknown }> = []
+  const piChatRequests: Array<{ workspaceId: string; sessionId: string; endpoint: string; method: string }> = []
   const treeRequests: string[] = []
   const fileWrites: Array<{ workspaceId: string; path: string; content: string }> = []
   const uiCommandsByWorkspace = new Map<string, unknown[]>()
@@ -234,6 +236,7 @@ async function installWorkspaceLifecycleMocks(page: Page, baseURL: string | unde
       const workspaceId = workspaceIdFromRequest(route)
       sessionRequests.push(workspaceId)
       const body = JSON.parse(request.postData() ?? '{}') as { title?: string }
+      sessionCreates.push({ workspaceId, body })
       const now = new Date().toISOString()
       const session: SessionSummary = {
         id: `${workspaceId}-session-${++sessionSeq}`,
@@ -247,6 +250,30 @@ async function installWorkspaceLifecycleMocks(page: Page, baseURL: string | unde
         ...(sessionsByWorkspace.get(workspaceId) ?? []),
       ])
       return route.fulfill(json(session, 201))
+    }
+
+    const piChatMatch = path.match(/^\/api\/v1\/agent\/pi-chat\/([^/]+)\/(state|events|prompt)$/)
+    if (piChatMatch) {
+      const workspaceId = workspaceIdFromRequest(route)
+      const [, sessionId, endpoint] = piChatMatch
+      piChatRequests.push({ workspaceId, sessionId, endpoint, method })
+      if (endpoint === 'events') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/x-ndjson',
+          body: '{"type":"heartbeat","now":"2026-01-01T00:00:00.000Z"}\n',
+        })
+      }
+      if (endpoint === 'prompt') return route.fulfill(json({ accepted: true, cursor: 0, clientNonce: sessionId }))
+      return route.fulfill(json({
+        protocolVersion: 1,
+        sessionId,
+        seq: 0,
+        status: 'idle',
+        messages: [],
+        queue: { followUps: [] },
+        followUpMode: 'one-at-a-time',
+      }))
     }
 
     const sessionDetailMatch = path.match(/^\/api\/v1\/agent\/sessions\/([^/]+)$/)
@@ -292,7 +319,7 @@ async function installWorkspaceLifecycleMocks(page: Page, baseURL: string | unde
     return route.continue()
   })
 
-  return { filesByWorkspace, fileWrites, sessionRequests, treeRequests, uiCommandsByWorkspace }
+  return { filesByWorkspace, fileWrites, sessionsByWorkspace, sessionRequests, sessionCreates, piChatRequests, treeRequests, uiCommandsByWorkspace }
 }
 
 async function openWorkspaceMenu(page: Page) {
@@ -341,6 +368,43 @@ test('agent openFile command opens a closed workbench and focuses the file', asy
   await expect(page.getByLabel('Surface')).toBeVisible({ timeout: 10_000 })
   await expect(page.getByText('Nothing open yet')).toBeHidden({ timeout: 10_000 })
   await expect(page.locator('.cm-content')).toContainText('export const alpha = 1', { timeout: 10_000 })
+})
+
+test('new chat in additional workspace preserves the first session and stays workspace-scoped', async ({ page, baseURL }) => {
+  const state = await installWorkspaceLifecycleMocks(page, baseURL)
+
+  await page.goto('/workspace/ws-beta')
+  await expect(page.getByRole('button', { name: /Workspace menu: Beta Workspace/ }))
+    .toBeVisible({ timeout: 10_000 })
+
+  await expect.poll(() => state.sessionsByWorkspace.get('ws-beta')?.length ?? 0, {
+    timeout: 10_000,
+  }).toBe(1)
+  const firstSession = state.sessionsByWorkspace.get('ws-beta')?.[0]
+  expect(firstSession?.id).toMatch(/^ws-beta-session-/)
+
+  await page.getByRole('button', { name: 'New chat' }).click()
+
+  await expect.poll(() => state.sessionsByWorkspace.get('ws-beta')?.length ?? 0, {
+    timeout: 10_000,
+  }).toBe(2)
+  const betaSessionIds = state.sessionsByWorkspace.get('ws-beta')?.map((session) => session.id) ?? []
+  expect(betaSessionIds).toContain(firstSession?.id)
+  expect(betaSessionIds.every((id) => id.startsWith('ws-beta-session-'))).toBe(true)
+
+  const betaCreates = state.sessionCreates.filter((create) => create.workspaceId === 'ws-beta')
+  expect(betaCreates.map((create) => create.body)).toEqual([
+    { title: 'New session' },
+    {},
+  ])
+  expect(state.sessionsByWorkspace.get('ws-alpha') ?? []).toHaveLength(0)
+  expect(state.piChatRequests.some((request) => request.workspaceId === 'ws-beta' && request.sessionId === 'default')).toBe(false)
+
+  await switchWorkspace(page, 'Alpha Workspace', 'ws-alpha')
+  await expect.poll(() => state.sessionsByWorkspace.get('ws-alpha')?.length ?? 0, {
+    timeout: 10_000,
+  }).toBe(1)
+  expect(state.sessionsByWorkspace.get('ws-beta')?.map((session) => session.id)).toEqual(betaSessionIds)
 })
 
 test('workspace create and switch keeps files and sessions scoped per workspace', async ({ page, baseURL }) => {

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -117,6 +117,37 @@ test('core/full-app composition forwards collected runtime provisioning plugins 
   }
 })
 
+test('core/full-app defaults session namespace to workspace id', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [],
+    provisioningContributions: [],
+    agentOptions: {
+      extraTools: [],
+      pi: { additionalSkillPaths: [], packages: [] },
+      systemPromptAppend: undefined,
+    },
+    preservedUiStateKeys: [],
+    routeContributions: [],
+  })
+
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    workspaceRoot: '/tmp/full-app-workspaces',
+    serveFrontend: false,
+    registerHealthRoute: false,
+  })
+
+  try {
+    const options = (mocks.registerAgentRoutes as any).mock.calls[0]?.[1] as Record<string, unknown>
+    expect(options).not.toHaveProperty('sessionNamespace')
+    const getSessionNamespace = options.getSessionNamespace as (ctx: { workspaceId: string; workspaceRoot: string }) => Promise<string>
+    await expect(getSessionNamespace({ workspaceId: 'workspace-a', workspaceRoot: '/tmp/full-app-workspaces/workspace-a' })).resolves.toBe('workspace-a')
+  } finally {
+    await app.close()
+  }
+})
+
 test('core/full-app skips built-in plugin CLI provisioning unless plugin authoring is enabled', async () => {
   const runtimePlugin = {
     id: 'workspace-runtime-plugin',

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -714,6 +714,12 @@ export async function createCoreWorkspaceAgentServer(
     return mergePiOptions(pluginOptions, callerOptions)
   }
 
+  const resolveSessionNamespace: NonNullable<RegisterAgentRoutesOptions['getSessionNamespace']> = async (ctx) => (
+    options.getSessionNamespace
+      ? await options.getSessionNamespace(ctx)
+      : options.sessionNamespace ?? ctx.workspaceId
+  )
+
   await app.register(registerAgentRoutes, {
     workspaceRoot,
     sessionId: options.sessionId,
@@ -730,8 +736,7 @@ export async function createCoreWorkspaceAgentServer(
     systemPromptAppend: pluginCollection.agentOptions.systemPromptAppend,
     pi: pluginCollection.agentOptions.pi,
     getPi: resolvePiOptions,
-    sessionNamespace: options.sessionNamespace,
-    getSessionNamespace: options.getSessionNamespace,
+    getSessionNamespace: resolveSessionNamespace,
     getExtraTools: async (ctx) => {
       const callerTools = options.getExtraTools ? await options.getExtraTools(ctx) : []
       return [

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -147,10 +147,6 @@ export interface WorkspaceAgentFrontProps<
   onWorkspaceWarmupStatusChange?: (status: WorkspaceWarmupStatus) => void
 }
 
-function isAutoCreatedEmptySession(session: WorkspaceAgentSession | null | undefined, defaultSessionTitle: string): boolean {
-  return Boolean(session && session.title === defaultSessionTitle && session.turnCount === 0)
-}
-
 function shellStorageKeyFromSurfaceStorage(
   surfaceKey: string,
   fallback: string,
@@ -597,6 +593,9 @@ export function WorkspaceAgentFront<
     && remoteSessionSnapshot.workspaceId === workspaceId
     && remoteSessionSnapshot.sessions.length > 0
   const pendingStoredActiveSessionId = remoteSessionsPending ? readStoredSessionId(resolvedSessionStorageKey) : null
+  const pendingRemoteActiveSessionId = remoteSessionsPending && !remoteSessionsArePreviousWorkspace
+    ? remoteSessionApi.activeSessionId ?? null
+    : null
   const activeRemoteSessions = remoteSessionsAvailable
     ? remoteSessionApi.sessions
     : remoteSessionsHaveStaleData
@@ -636,7 +635,17 @@ export function WorkspaceAgentFront<
       && !suppressEmptyAutoCreateRef.current
       && !remoteInitialSessionFailed,
   )
-  const remoteSessionsTransitioning = remoteEmptySessionsSettling || remoteInitialSessionCreating || remoteInitialSessionNeeded
+  const remoteSessionsInitialLoading = Boolean(
+    remoteSessionsPending
+      && remoteSessionApi.loading
+      && !remoteSessionApi.error
+      && shouldUseRemoteSessions
+      && !hasExplicitSessionProps
+      && !remoteSessionsHaveStaleData
+      && !pendingStoredActiveSessionId
+      && !pendingRemoteActiveSessionId,
+  )
+  const remoteSessionsTransitioning = remoteSessionsInitialLoading || remoteEmptySessionsSettling || remoteInitialSessionCreating || remoteInitialSessionNeeded
 
   useEffect(() => {
     if (!remoteEmptySessionsSettling) {
@@ -675,7 +684,7 @@ export function WorkspaceAgentFront<
   const resolvedActiveId = sessionApi
     ? activeRemoteSessionId ?? null
     : remoteSessionsPending
-      ? pendingStoredActiveSessionId
+      ? pendingStoredActiveSessionId ?? pendingRemoteActiveSessionId
       : hasExplicitSessionProps
         ? activeSessionId ?? null
         : localSessions.activeId
@@ -727,20 +736,10 @@ export function WorkspaceAgentFront<
   const resolvedCreate = remoteSessionsPending
     ? remoteSessionActionsUnavailable
     : sessionApi
-      ? () => {
-          const emptyAutoSession = activeRemoteSessions.find((session) => (
-            session.id === effectiveActiveSessionId
-            && isAutoCreatedEmptySession(session, defaultSessionTitle)
-          ))
-          const created = sessionApi.create()
-          if (emptyAutoSession) {
-            void Promise.resolve(created)
-              .then(() => sessionApi.delete(emptyAutoSession.id))
-              .catch(() => {})
-          }
-          return created
-        }
-      : onCreateSession ?? localSessionStore.create
+      ? () => sessionApi.create()
+      : onCreateSession
+        ? () => onCreateSession()
+        : () => localSessionStore.create()
   const rawDelete = remoteSessionsPending
     ? remoteSessionActionsUnavailable
     : sessionApi?.delete ?? onDeleteSession ?? localSessionStore.remove

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -170,7 +170,7 @@ describe("WorkspaceAgentFront", () => {
     expect(captured?.hotReloadEnabled).toBe(false)
   })
 
-  it("renders the chat shell while remote sessions are still loading", () => {
+  it("keeps the chat shell in transition while remote sessions are still loading without an active session", () => {
     const PendingChatPanel = (props: WorkspaceChatPanelProps) => (
       <div data-testid="chat-panel">Chat {props.sessionId} hydrate={String(props.hydrateMessages)}</div>
     )
@@ -192,8 +192,59 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
-    expect(screen.getByTestId("chat-panel")).toHaveTextContent("Chat default hydrate=false")
+    expect(screen.queryByTestId("chat-panel")).not.toBeInTheDocument()
+    expect(screen.getAllByText("Loading sessions…").length).toBeGreaterThan(0)
+  })
+
+  it("renders a known active session while remote sessions are still loading", () => {
+    const PendingChatPanel = (props: WorkspaceChatPanelProps) => (
+      <div data-testid="chat-panel">Chat {props.sessionId} hydrate={String(props.hydrateMessages)}</div>
+    )
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="known-session-list"
+        chatPanel={PendingChatPanel}
+        useSessions={() => ({
+          sessions: [],
+          activeSession: null,
+          activeSessionId: "known-active",
+          loading: true,
+          error: undefined,
+          create: vi.fn(),
+          switch: vi.fn(),
+          delete: vi.fn(),
+        })}
+      />,
+    )
+
+    expect(screen.getByTestId("chat-panel")).toHaveTextContent("Chat known-active hydrate=true")
     expect(screen.queryByText("Loading sessions…")).not.toBeInTheDocument()
+  })
+
+  it("renders the chat shell when remote sessions fail instead of pinning loading", () => {
+    const FailedChatPanel = (props: WorkspaceChatPanelProps) => (
+      <div data-testid="chat-panel">Chat {props.sessionId} hydrate={String(props.hydrateMessages)}</div>
+    )
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="failed-session-list"
+        chatPanel={FailedChatPanel}
+        useSessions={() => ({
+          sessions: [],
+          activeSession: null,
+          activeSessionId: null,
+          loading: false,
+          error: new Error("failed"),
+          create: vi.fn(),
+          switch: vi.fn(),
+          delete: vi.fn(),
+        })}
+      />,
+    )
+
+    expect(screen.getByTestId("chat-panel")).toHaveTextContent("Chat default hydrate=false")
   })
 
   it("keeps session history closed by default and opens it from the rail button", async () => {
@@ -1289,7 +1340,7 @@ describe("WorkspaceAgentFront", () => {
     })
   })
 
-  it("removes the empty auto-created default when the user manually creates a chat", async () => {
+  it("keeps the existing remote session when the user manually creates another chat", async () => {
     const create = vi.fn(async () => ({ id: "manual", title: "New session", updatedAt: Date.now(), turnCount: 0 }))
     const deleted = vi.fn()
 
@@ -1329,8 +1380,34 @@ describe("WorkspaceAgentFront", () => {
 
     await waitFor(() => {
       expect(create).toHaveBeenCalledOnce()
-      expect(deleted).toHaveBeenCalledWith("auto")
     })
+    expect(deleted).not.toHaveBeenCalled()
+  })
+
+  it("does not pass the New chat click event into remote session creation", () => {
+    const create = vi.fn(async () => ({ id: "manual", title: "Manual", updatedAt: Date.now(), turnCount: 0 }))
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="create-click-event"
+        chatPanel={ChatPanel}
+        useSessions={() => ({
+          sessions: [{ id: "existing", title: "Existing", updatedAt: Date.now(), turnCount: 0 }],
+          activeSessionId: "existing",
+          activeSession: { id: "existing", title: "Existing", updatedAt: Date.now(), turnCount: 0 },
+          loading: false,
+          create,
+          switch: vi.fn(),
+          delete: vi.fn(),
+        })}
+        persistenceEnabled={false}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "New chat" }))
+
+    expect(create).toHaveBeenCalledOnce()
+    expect(create.mock.calls[0]).toEqual([])
   })
 
   it("does not auto-create a replacement after the user deletes the last remote session", async () => {


### PR DESCRIPTION
## Summary

- Default core/full-app Pi session namespaces to the active workspace id.
- Keep the workspace chat shell in transition during initial remote-session loading when no known active session exists, avoiding accidental `/pi-chat/default/...` hydration.
- Preserve existing remote sessions when creating a new chat; no more deleting an auto-created empty session as a side effect.
- Keep create callbacks zero-arg so React click events are not serialized as session-create payloads.

## Thermo-nuclear review notes

Ran strict autoreview focused on workspace/session isolation, fallback `default` session ids, create/delete races, loading/error states, and click-event payload leaks.

Findings fixed during review:

1. Initial loading gate pinned errors behind loading overlay → gated on `remoteSessionApi.loading` and added error regression coverage.
2. Known active session from the remote hook was ignored during loading → use `pendingRemoteActiveSessionId` and added coverage.
3. Direct `sessionApi.create` leaked React click events into POST body → restored zero-arg wrapper and added coverage.

Final autoreview result: clean, no accepted/actionable findings.

## Tests

- `pnpm --filter @hachej/boring-workspace run test src/app/front/__tests__/WorkspaceAgentFront.test.tsx -- --runInBand`
- `pnpm --filter @hachej/boring-workspace run typecheck`
- `pnpm --filter @hachej/boring-core run test src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts`
- `pnpm --filter @hachej/boring-core run typecheck`
- `/home/ubuntu/.agents/skills/coding-autoreview/scripts/autoreview --mode local --engine codex --prompt "Thermo-nuclear review this session identity fix after repairs. Focus on workspace/session isolation, fallback default session IDs, creation/deletion races, loading/error states, click-event payload leaks, and maintainability. Do not nitpick style."`

## Manual validation plan

After deploy, verify in an additional workspace:

1. Open a non-default workspace.
2. Send a message in the first session.
3. Create a new chat and send another message.
4. Confirm both sessions remain in the session list and switching back restores the first message.
5. In DevTools, confirm session state/events/prompt requests use real session ids, not `/pi-chat/default/...`, once sessions are loaded.
