### PR TITLE
fix(agent): stabilize launch workspace smoke

### DIFF
--- a/packages/agent/src/front/__tests__/chatSubmit.test.ts
+++ b/packages/agent/src/front/__tests__/chatSubmit.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { createEnrichedSubmitPayload } from '../chatSubmit'
+
+describe('createEnrichedSubmitPayload', () => {
+  it('includes uploaded workspace paths for binary attachments', async () => {
+    const result = await createEnrichedSubmitPayload({
+      text: 'can you read this?',
+      mentionedFiles: [],
+      files: [{
+        type: 'file',
+        filename: 'Screenshot.png',
+        mediaType: 'image/png',
+        url: '../assets/images/screenshot-abc.png',
+        path: 'assets/images/screenshot-abc.png',
+      } as never],
+    })
+
+    expect(result.serverMessage).toContain('can you read this?')
+    expect(result.serverMessage).toContain('Screenshot.png')
+    expect(result.serverMessage).toContain('Saved in workspace at: assets/images/screenshot-abc.png')
+    expect(result.attachments).toEqual([
+      expect.objectContaining({
+        filename: 'Screenshot.png',
+        mediaType: 'image/png',
+        url: '../assets/images/screenshot-abc.png',
+        path: 'assets/images/screenshot-abc.png',
+      }),
+    ])
+  })
+})

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -27,6 +27,7 @@ import {
 } from '../../primitives/prompt-input'
 import { SlashCommandPicker } from '../../primitives/slash-command-picker'
 import type { SlashCommand } from '../../slashCommands'
+import { uploadFile } from '../../upload/uploadFile'
 import { AttachmentButton, AttachmentsList } from './ComposerAttachments'
 import {
   ComposerBlockerNotice,
@@ -178,6 +179,12 @@ export function PiChatComposerSurface({
   onSubmitMessage,
   onStop,
 }: PiChatComposerSurfaceProps) {
+  const uploadAttachment = useCallback((file: File) => uploadFile(file, {
+    apiBaseUrl,
+    workspaceRequestId: requestHeaders?.['x-boring-workspace-id'],
+    fetch,
+  }), [apiBaseUrl, fetch, requestHeaders])
+
   const resizeTextarea = useCallback((node: HTMLTextAreaElement | null) => {
     if (!node) return
     node.style.height = 'auto'
@@ -323,6 +330,7 @@ export function PiChatComposerSurface({
         <PromptInput
           data-boring-state={status}
           onSubmit={(message) => onSubmitMessage({ text: message.text, files: message.files })}
+          onUploadFile={uploadAttachment}
           multiple
           maxFiles={disabled || isStreaming ? 0 : MAX_PROMPT_ATTACHMENTS}
           maxFileSize={MAX_PROMPT_ATTACHMENT_BYTES}

--- a/packages/agent/src/front/chatAttachments.ts
+++ b/packages/agent/src/front/chatAttachments.ts
@@ -11,6 +11,9 @@ export async function resolveAttachmentUrls(files: FileUIPart[] | undefined) {
     url: file.url.startsWith('blob:')
       ? (await convertBlobUrlToDataUrl(file.url)) ?? file.url
       : file.url,
+    ...(typeof (file as unknown as { path?: unknown }).path === 'string'
+      ? { path: (file as unknown as { path: string }).path }
+      : {}),
   })))
 }
 

--- a/packages/agent/src/front/chatSubmit.ts
+++ b/packages/agent/src/front/chatSubmit.ts
@@ -24,11 +24,17 @@ export async function createEnrichedSubmitPayload({
   for (const file of files ?? []) {
     const label = file.filename ?? 'attachment'
     const mime = file.mediaType ?? 'application/octet-stream'
+    const workspacePath = typeof (file as unknown as { path?: unknown }).path === 'string'
+      ? (file as unknown as { path: string }).path
+      : undefined
+    const pathNote = workspacePath
+      ? `\nSaved in workspace at: ${workspacePath}\nUse the workspace file/read tools with this path if you need to inspect it.`
+      : ''
     const content = await readFileAsText(file)
     if (content !== null) {
-      attachmentSummaries.push(`[attached: ${label} (${mime})]\n\`\`\`\n${content}\n\`\`\``)
+      attachmentSummaries.push(`[attached: ${label} (${mime})${pathNote}]\n\`\`\`\n${content}\n\`\`\``)
     } else {
-      attachmentSummaries.push(`[attached: ${label} (${mime}, not inlined — binary)]`)
+      attachmentSummaries.push(`[attached: ${label} (${mime}, not inlined — binary)${pathNote}]`)
     }
   }
 

--- a/packages/agent/src/front/primitives/__tests__/prompt-input-upload.test.tsx
+++ b/packages/agent/src/front/primitives/__tests__/prompt-input-upload.test.tsx
@@ -29,7 +29,7 @@ function AttachmentStatus() {
 }
 
 interface HarnessProps {
-  onUploadFile?: (f: File) => Promise<{ url: string }>
+  onUploadFile?: (f: File) => Promise<{ url: string; path?: string }>
   onSubmit?: (v: { text: string; files: unknown[] }) => false | void | Promise<false | void>
 }
 
@@ -123,7 +123,7 @@ describe('PromptInput — upload flow', () => {
   })
 
   it('submits uploaded stable attachment URLs once ready', async () => {
-    const onUploadFile = vi.fn(() => Promise.resolve({ url: 'https://example.com/img.png' }))
+    const onUploadFile = vi.fn(() => Promise.resolve({ url: 'https://example.com/img.png', path: 'assets/images/img.png' }))
     const onSubmit = vi.fn()
 
     render(<Harness onUploadFile={onUploadFile} onSubmit={onSubmit} />)
@@ -145,7 +145,7 @@ describe('PromptInput — upload flow', () => {
       expect(onSubmit).toHaveBeenCalledWith(
         {
           text: 'describe image',
-          files: [expect.objectContaining({ filename: 'img.png', mediaType: 'image/png', url: 'https://example.com/img.png' })],
+          files: [expect.objectContaining({ filename: 'img.png', mediaType: 'image/png', url: 'https://example.com/img.png', path: 'assets/images/img.png' })],
         },
         expect.anything(),
       )

--- a/packages/agent/src/front/primitives/prompt-input-context.ts
+++ b/packages/agent/src/front/primitives/prompt-input-context.ts
@@ -1,7 +1,7 @@
 import type { FileUIPart, SourceDocumentUIPart } from 'ai'
 import { createContext, useContext, type RefObject } from 'react'
 
-export type AttachmentEntry = FileUIPart & { id: string; status?: 'uploading' | 'ready' | 'error' }
+export type AttachmentEntry = FileUIPart & { id: string; status?: 'uploading' | 'ready' | 'error'; path?: string }
 
 export interface AttachmentsContext {
   files: AttachmentEntry[]
@@ -10,7 +10,7 @@ export interface AttachmentsContext {
   clear: () => void
   openFileDialog: () => void
   fileInputRef: RefObject<HTMLInputElement | null>
-  setFileUrl: (id: string, url: string, status: 'ready' | 'error') => void
+  setFileUrl: (id: string, url: string, status: 'ready' | 'error', path?: string) => void
 }
 
 export interface TextInputContext {

--- a/packages/agent/src/front/primitives/prompt-input.tsx
+++ b/packages/agent/src/front/primitives/prompt-input.tsx
@@ -181,7 +181,7 @@ const captureScreenshot = async (): Promise<File | null> => {
 
 export type PromptInputProviderProps = PropsWithChildren<{
   initialInput?: string;
-  onUploadFile?: (file: File) => Promise<{ url: string }>;
+  onUploadFile?: (file: File) => Promise<{ url: string; path?: string }>;
 }>;
 
 /**
@@ -328,7 +328,7 @@ export type PromptInputProps = Omit<
   ) => false | void | Promise<false | void>;
   /** When provided, files are uploaded to the server immediately on add and the
    * attachment URL is replaced with the stable server path before submit. */
-  onUploadFile?: (file: File) => Promise<{ url: string }>;
+  onUploadFile?: (file: File) => Promise<{ url: string; path?: string }>;
 };
 
 export const PromptInput = ({
@@ -360,11 +360,11 @@ export const PromptInput = ({
   // ----- Local attachments (only used when no provider)
   const [items, setItems] = useState<AttachmentEntry[]>([]);
 
-  const setFileUrlLocal = useCallback((id: string, url: string, status: 'ready' | 'error') => {
+  const setFileUrlLocal = useCallback((id: string, url: string, status: 'ready' | 'error', path?: string) => {
     setItems((prev) => prev.map((f) => {
       if (f.id !== id) return f;
       if (f.url !== url && f.url.startsWith('blob:')) URL.revokeObjectURL(f.url);
-      return { ...f, url, status };
+      return { ...f, url, status, ...(path ? { path } : {}) };
     }));
   }, []);
   const files = usingProvider ? controller.attachments.files : items;
@@ -459,7 +459,7 @@ export const PromptInput = ({
           const entry = entries[i];
           const file = capped[i];
           onUploadFile(file)
-            .then(({ url }) => setFileUrlLocal(entry.id, url, 'ready'))
+            .then(({ url, path }) => setFileUrlLocal(entry.id, url, 'ready', path))
             .catch(() => setFileUrlLocal(entry.id, entry.url, 'error'));
         }
       }

--- a/packages/agent/src/front/primitives/use-prompt-input-provider-attachments.ts
+++ b/packages/agent/src/front/primitives/use-prompt-input-provider-attachments.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } fro
 import type { AttachmentEntry, AttachmentsContext } from './prompt-input-context'
 
 export function usePromptInputProviderAttachments(
-  onUploadFile?: (file: File) => Promise<{ url: string }>,
+  onUploadFile?: (file: File) => Promise<{ url: string; path?: string }>,
 ): {
   attachments: AttachmentsContext
   registerFileInput: (ref: RefObject<HTMLInputElement | null>, open: () => void) => void
@@ -13,11 +13,11 @@ export function usePromptInputProviderAttachments(
   // oxlint-disable-next-line eslint(no-empty-function)
   const openRef = useRef<() => void>(() => {})
 
-  const setFileUrl = useCallback((id: string, url: string, status: 'ready' | 'error') => {
+  const setFileUrl = useCallback((id: string, url: string, status: 'ready' | 'error', path?: string) => {
     setAttachmentFiles((prev) => prev.map((f) => {
       if (f.id !== id) return f
       if (f.url !== url && f.url.startsWith('blob:')) URL.revokeObjectURL(f.url)
-      return { ...f, url, status }
+      return { ...f, url, status, ...(path ? { path } : {}) }
     }))
   }, [])
 
@@ -40,7 +40,7 @@ export function usePromptInputProviderAttachments(
       for (const entry of entries) {
         const file = incoming[entries.indexOf(entry)]
         onUploadFile(file)
-          .then(({ url }) => setFileUrl(entry.id, url, 'ready'))
+          .then(({ url, path }) => setFileUrl(entry.id, url, 'ready', path))
           .catch(() => setFileUrl(entry.id, entry.url, 'error'))
       }
     }

--- a/packages/agent/src/front/upload/uploadFile.ts
+++ b/packages/agent/src/front/upload/uploadFile.ts
@@ -3,6 +3,7 @@ export interface UploadFileOptions {
   workspaceRequestId?: string | null
   directory?: string
   sourcePath?: string
+  fetch?: typeof globalThis.fetch
 }
 
 export interface UploadFileResult {
@@ -23,7 +24,7 @@ export async function uploadFile(
   file: File,
   opts: UploadFileOptions = {},
 ): Promise<UploadFileResult> {
-  const { apiBaseUrl = '', workspaceRequestId, directory, sourcePath } = opts
+  const { apiBaseUrl = '', workspaceRequestId, directory, sourcePath, fetch: fetchImpl = globalThis.fetch } = opts
 
   const dataUrl = await readAsDataUrl(file)
   const comma = dataUrl.indexOf(',')
@@ -33,7 +34,7 @@ export async function uploadFile(
   if (workspaceRequestId) headers['x-boring-workspace-id'] = workspaceRequestId
 
   const base = apiBaseUrl.replace(/\/$/, '')
-  const res = await fetch(`${base}/api/v1/files/upload`, {
+  const res = await fetchImpl(`${base}/api/v1/files/upload`, {
     method: 'POST',
     headers,
     credentials: 'include',

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -803,6 +803,63 @@ test('request-scoped models endpoint does not require workspace header', async (
   await app.close()
 }, 15_000)
 
+test('request-scoped commands endpoint uses the workspace harness', async () => {
+  const workspaceRoot = await makeTempDir('boring-agent-embed-commands-')
+  const app = Fastify({ logger: false })
+  const getSlashCommands = vi.fn(async () => [{ name: 'open-test-panel', source: 'extension' as const }])
+  let scopeChecks = 0
+
+  await app.register(registerAgentRoutes, {
+    workspaceRoot,
+    mode: 'direct',
+    getWorkspaceId: (request) => {
+      scopeChecks += 1
+      const value = request.headers['x-boring-workspace-id']
+      if (typeof value !== 'string') {
+        const error = new Error('workspace id is required') as Error & { statusCode: number }
+        error.statusCode = 400
+        throw error
+      }
+      return value
+    },
+    getWorkspaceRoot: () => workspaceRoot,
+    harnessFactory: async () => ({
+      id: 'commands-test-harness',
+      placement: 'server' as const,
+      sessions: {
+        async list() { return [] },
+        async create() {
+          const now = new Date().toISOString()
+          return { id: 'custom', title: 'Custom', createdAt: now, updatedAt: now, turnCount: 0 }
+        },
+        async load() {
+          const now = new Date().toISOString()
+          return { id: 'custom', title: 'Custom', createdAt: now, updatedAt: now, turnCount: 0, messages: [] }
+        },
+        async delete() {},
+      },
+      getSlashCommands,
+    }),
+  })
+  await app.ready()
+
+  try {
+    const commandsRes = await app.inject({
+      method: 'GET',
+      url: '/api/v1/agent/commands?sessionId=custom',
+      headers: { 'x-boring-workspace-id': 'workspace-a' },
+    })
+    expect(commandsRes.statusCode).toBe(200)
+    expect(commandsRes.json()).toEqual({
+      commands: [{ name: 'open-test-panel', source: 'extension' }],
+    })
+    expect(getSlashCommands).toHaveBeenCalledWith('custom', expect.objectContaining({ workdir: workspaceRoot }))
+    expect(scopeChecks).toBe(1)
+  } finally {
+    await app.close()
+  }
+}, 15_000)
+
 test('skills endpoint lists Pi-resolved project skills', async () => {
   const workspaceRoot = await makeTempDir('boring-agent-embed-skills-project-')
   const projectSkillDir = join(workspaceRoot, '.pi', 'skills', 'project-skill')

--- a/packages/agent/src/server/http/routes/__tests__/models.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/models.test.ts
@@ -1,0 +1,80 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Fastify from 'fastify'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { modelsRoutes } from '../models.js'
+
+const ENV_KEYS = [
+  'BORING_AGENT_DEFAULT_MODEL',
+  'BORING_AGENT_DEFAULT_MODEL_PROVIDER',
+  'BORING_AGENT_DEFAULT_MODEL_ID',
+  'BORING_AGENT_INFOMANIAK_PROVIDER',
+  'BORING_AGENT_INFOMANIAK_PRODUCT_ID',
+  'BORING_AGENT_INFOMANIAK_BASE_URL',
+  'BORING_AGENT_INFOMANIAK_MODEL',
+  'BORING_AGENT_INFOMANIAK_MODELS',
+  'BORING_AGENT_INFOMANIAK_API_KEY_ENV',
+  'BORING_AGENT_INFOMANIAK_API_KEY',
+  'INFOMANIAK_API_TOKEN',
+  'HOME',
+]
+
+let previousEnv: Record<string, string | undefined>
+
+beforeEach(() => {
+  previousEnv = {}
+  for (const key of ENV_KEYS) {
+    previousEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+  process.env.HOME = join(tmpdir(), 'boring-model-routes-home-test')
+})
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const previous = previousEnv[key]
+    if (typeof previous === 'string') process.env[key] = previous
+    else delete process.env[key]
+  }
+})
+
+describe('modelsRoutes', () => {
+  it('uses configured launch models as an allowlist', async () => {
+    process.env.BORING_AGENT_INFOMANIAK_PRODUCT_ID = '108321'
+    process.env.BORING_AGENT_INFOMANIAK_MODEL = 'Qwen/Qwen3.5-122B-A10B-FP8'
+    process.env.INFOMANIAK_API_TOKEN = 'test-token'
+
+    const app = Fastify({ logger: false })
+    await app.register(modelsRoutes)
+    await app.ready()
+
+    try {
+      const res = await app.inject({ method: 'GET', url: '/api/v1/agent/models' })
+      expect(res.statusCode).toBe(200)
+      const body = res.json()
+      expect(body.defaultModel).toEqual({
+        provider: 'infomaniak',
+        id: 'Qwen/Qwen3.5-122B-A10B-FP8',
+      })
+      expect(body.models).toEqual([
+        expect.objectContaining({
+          provider: 'infomaniak',
+          id: 'moonshotai/Kimi-K2.6',
+          available: true,
+        }),
+        expect.objectContaining({
+          provider: 'infomaniak',
+          id: 'nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8',
+          available: true,
+        }),
+        expect.objectContaining({
+          provider: 'infomaniak',
+          id: 'Qwen/Qwen3.5-122B-A10B-FP8',
+          available: true,
+        }),
+      ])
+    } finally {
+      await app.close()
+    }
+  })
+})

--- a/packages/agent/src/server/http/routes/commands.ts
+++ b/packages/agent/src/server/http/routes/commands.ts
@@ -1,16 +1,28 @@
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyRequest } from 'fastify'
 import type { AgentHarness, AgentSlashCommandSummary } from '../../../shared/harness'
 
-export interface CommandsRoutesOptions {
+export type CommandsRoutesOptions = {
   harness: AgentHarness
   defaultSessionId: string
   workdir: string
+} | {
+  defaultSessionId: string
+  getHarness: (request: FastifyRequest) => AgentHarness | Promise<AgentHarness>
+  getWorkdir: (request: FastifyRequest) => string | Promise<string>
 }
 
 function normalizeSessionId(value: unknown, fallback: string): string {
   if (typeof value !== 'string') return fallback
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : fallback
+}
+
+function resolveHarness(opts: CommandsRoutesOptions, request: FastifyRequest): AgentHarness | Promise<AgentHarness> {
+  return 'getHarness' in opts ? opts.getHarness(request) : opts.harness
+}
+
+function resolveWorkdir(opts: CommandsRoutesOptions, request: FastifyRequest): string | Promise<string> {
+  return 'getWorkdir' in opts ? opts.getWorkdir(request) : opts.workdir
 }
 
 export function commandsRoutes(
@@ -22,9 +34,13 @@ export function commandsRoutes(
     try {
       const query = request.query as Record<string, unknown>
       const sessionId = normalizeSessionId(query.sessionId, opts.defaultSessionId)
-      const commands: ReadonlyArray<AgentSlashCommandSummary> = await opts.harness.getSlashCommands?.(sessionId, {
+      const [harness, workdir] = await Promise.all([
+        resolveHarness(opts, request),
+        resolveWorkdir(opts, request),
+      ])
+      const commands: ReadonlyArray<AgentSlashCommandSummary> = await harness.getSlashCommands?.(sessionId, {
         abortSignal: new AbortController().signal,
-        workdir: opts.workdir,
+        workdir,
       }) ?? []
       return reply.code(200).send({ commands })
     } catch (error) {
@@ -34,19 +50,23 @@ export function commandsRoutes(
   })
 
   app.post('/api/v1/agent/commands/execute', async (request, reply) => {
-    if (!opts.harness.executeSlashCommand) {
-      return reply.code(501).send({ error: 'Command execution not supported by this harness.' })
-    }
     try {
+      const [harness, workdir] = await Promise.all([
+        resolveHarness(opts, request),
+        resolveWorkdir(opts, request),
+      ])
+      if (!harness.executeSlashCommand) {
+        return reply.code(501).send({ error: 'Command execution not supported by this harness.' })
+      }
       const query = request.query as Record<string, unknown>
       const body = request.body && typeof request.body === 'object' ? request.body as Record<string, unknown> : {}
       const sessionId = normalizeSessionId(query.sessionId, opts.defaultSessionId)
       const name = typeof body.name === 'string' ? body.name.trim() : ''
       const args = typeof body.args === 'string' ? body.args : ''
       if (!name) return reply.code(400).send({ error: 'name body field is required' })
-      await opts.harness.executeSlashCommand(sessionId, name, args, {
+      await harness.executeSlashCommand(sessionId, name, args, {
         abortSignal: new AbortController().signal,
-        workdir: opts.workdir,
+        workdir,
       })
       return reply.code(200).send({ ok: true })
     } catch (error) {

--- a/packages/agent/src/server/http/routes/models.ts
+++ b/packages/agent/src/server/http/routes/models.ts
@@ -47,19 +47,27 @@ export function modelsRoutes(
   // Cached so repeated GETs don't re-scan auth every request.
   const authStorage = AuthStorage.create()
   const registry = ModelRegistry.create(authStorage)
-  registerConfiguredModelProviders(registry)
+  const configuredModels = registerConfiguredModelProviders(registry)
+  const configuredModelSet = new Set(
+    configuredModels.map((model) => `${model.provider}:${model.id}`),
+  )
   app.get('/api/v1/agent/models', async (_request, reply) => {
     const availableModels = registry.getAvailable()
     const availableSet = new Set(
       availableModels.map((m) => `${m.provider}:${m.id}`),
     )
-    const models: ModelSummary[] = registry.getAll().map((m) => ({
+    const allModels = configuredModelSet.size > 0
+      ? registry.getAll().filter((m) => configuredModelSet.has(`${m.provider}:${m.id}`))
+      : registry.getAll()
+    const models: ModelSummary[] = allModels.map((m) => ({
       provider: m.provider,
       id: m.id,
       label: (m as unknown as { label?: string }).label ?? m.id,
       // Keep this endpoint cheap: it is fetched on chat mount, so it must never
       // block workspace load on deep provider auth resolution. ModelRegistry's
-      // available set is already derived from configured auth sources.
+      // available set is already derived from configured auth sources. When
+      // hosts configure launch/custom providers, those configured models are an
+      // allowlist: do not leak the built-in registry's unavailable catalog.
       available: availableSet.has(`${m.provider}:${m.id}`),
     }))
     // Stable order: available first, then alphabetically by (provider, id).

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -38,6 +38,7 @@ import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
 import { readyStatusRoutes } from './http/routes/readyStatus'
+import { commandsRoutes } from './http/routes/commands'
 import type { ReloadHookResult } from './http/routes/reload'
 import { searchRoutes } from './http/routes/search'
 import { gitRoutes } from './http/routes/git'
@@ -78,9 +79,15 @@ function pluginNameFromPath(path: string): string {
 function getAvailableModelProviders(): string[] {
   const authStorage = AuthStorage.create()
   const registry = ModelRegistry.create(authStorage)
-  registerConfiguredModelProviders(registry)
+  const configuredModels = registerConfiguredModelProviders(registry)
+  const configuredModelSet = new Set(
+    configuredModels.map((model) => `${model.provider}:${model.id}`),
+  )
+  const availableModels = configuredModelSet.size > 0
+    ? registry.getAvailable().filter((model) => configuredModelSet.has(`${model.provider}:${model.id}`))
+    : registry.getAvailable()
   return Array.from(
-    new Set(registry.getAvailable().map((model) => model.provider)),
+    new Set(availableModels.map((model) => model.provider)),
   ).sort((a, b) => a.localeCompare(b))
 }
 
@@ -1038,6 +1045,18 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
   await app.register(catalogRoutes, staticBinding
     ? { tools: staticBinding.tools }
     : { getTools: async (request) => (await getBindingForRequest(request)).tools },
+  )
+  await app.register(commandsRoutes, staticBinding
+    ? {
+        harness: staticBinding.harness,
+        defaultSessionId: sessionId,
+        workdir: staticBinding.runtimeBundle.workspace.root,
+      }
+    : {
+        defaultSessionId: sessionId,
+        getHarness: async (request) => (await getBindingForRequest(request)).harness,
+        getWorkdir: async (request) => (await getBindingForRequest(request)).runtimeBundle.workspace.root,
+      },
   )
   await app.register(readyStatusRoutes, staticBinding
     ? { tracker: staticBinding.readyTracker }

--- a/packages/agent/src/shared/chat/chatSubmitPayload.ts
+++ b/packages/agent/src/shared/chat/chatSubmitPayload.ts
@@ -9,6 +9,8 @@ export interface ChatAttachmentPayload {
   filename?: string
   mediaType?: string
   url: string
+  /** Workspace-relative path when the browser upload endpoint persisted the attachment. */
+  path?: string
 }
 
 export interface ChatSubmitPayload {

--- a/packages/agent/src/shared/chat/piChatSchemas.ts
+++ b/packages/agent/src/shared/chat/piChatSchemas.ts
@@ -215,6 +215,7 @@ export const ChatAttachmentPayloadSchema = z.object({
   filename: z.string().optional(),
   mediaType: z.string().optional(),
   url: nonEmptyString,
+  path: z.string().optional(),
 }) satisfies z.ZodType<ChatAttachmentPayload>
 
 export const PromptPayloadSchema = z.object({

--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -304,6 +304,7 @@ function WorkspaceRoute<
       key={workspaceId}
       {...workspaceProps}
       workspaceId={workspaceId}
+      workspaceLabel={workspaceProps.workspaceLabel ?? currentWorkspace.name}
       requestHeaders={requestHeaders}
       authHeaders={authHeaders}
       chatParams={chatParams}

--- a/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
+++ b/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
@@ -95,6 +95,7 @@ describe('CoreWorkspaceAgentFront', () => {
     expect(screen.getByTestId('workspace-agent-front')).toBeInTheDocument()
     expect(workspaceAgentProps).toMatchObject({
       workspaceId: 'workspace-a',
+      workspaceLabel: 'Workspace A',
       requestHeaders: {
         existing: 'request',
         'x-boring-workspace-id': 'workspace-a',

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -714,6 +714,27 @@ export async function createCoreWorkspaceAgentServer(
     return mergePiOptions(pluginOptions, callerOptions)
   }
 
+  app.get('/api/v1/workspace/meta', async (request, reply) => {
+    try {
+      const workspaceId = await resolveWorkspaceId(request)
+      const [workspace, workspaceRootForRequest] = await Promise.all([
+        workspaceStore.get(workspaceId),
+        resolveRoot(workspaceId, request),
+      ])
+      return {
+        workspaceId,
+        workspaceRoot: workspaceRootForRequest,
+        projectName: workspace?.name ?? 'Workspace',
+      }
+    } catch (error) {
+      const statusCode = typeof (error as { statusCode?: unknown })?.statusCode === 'number'
+        ? (error as { statusCode: number }).statusCode
+        : 500
+      const message = error instanceof Error ? error.message : 'workspace meta failed'
+      return reply.code(statusCode).send({ error: message })
+    }
+  })
+
   await app.register(registerAgentRoutes, {
     workspaceRoot,
     sessionId: options.sessionId,

--- a/packages/workspace/src/__tests__/WorkspaceProvider.test.tsx
+++ b/packages/workspace/src/__tests__/WorkspaceProvider.test.tsx
@@ -522,6 +522,7 @@ describe("WorkspaceProvider — document title", () => {
     expect(formatWorkspaceDocumentTitle({ workspaceLabel: "::1" })).toBe("Boring UI")
     expect(formatWorkspaceDocumentTitle({ workspaceLabel: "C:/Users/demo/project" })).toBe("Boring UI")
     expect(formatWorkspaceDocumentTitle({ workspaceLabel: "HTTPS://workspace.example.com" })).toBe("Boring UI")
+    expect(formatWorkspaceDocumentTitle({ workspaceId: "ac9ea9fc-0151-4e89-bd39-be38ac4d53cc" })).toBe("Boring UI")
   })
 
   it("updates document.title when workspace metadata changes", () => {

--- a/packages/workspace/src/front/provider/workspaceTitle.ts
+++ b/packages/workspace/src/front/provider/workspaceTitle.ts
@@ -5,6 +5,7 @@ function sanitizeWorkspaceTitleSegment(value: string | null | undefined): string
   if (!trimmed) return null
   if (/^(?:[a-z][a-z\d+.-]*:\/\/|[a-z]:[\\/]|\\\\|\/|\.\.?[\\/])/i.test(trimmed)) return null
   if (/^(?:::1|localhost(?::\d+)?|\d{1,3}(?:\.\d{1,3}){3}(?::\d+)?|\[[a-f\d:]+\](?::\d+)?|[a-z\d-]+(?:\.[a-z\d-]+)+(?::\d+)?)$/i.test(trimmed)) return null
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(trimmed)) return null
   return trimmed
 }
 


### PR DESCRIPTION
## Summary
- whitelist configured launch models in the agent model API/UI
- add embedded `/api/v1/agent/commands` and core `/api/v1/workspace/meta` routes
- prevent UUID workspace IDs from becoming the browser title
- preserve uploaded screenshot workspace paths in chat attachments so text-only models can inspect saved files

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (reran unrelated flakes targeted: ask-user questionsBridge and workspace local skill slash)
- `pnpm lint:invariants`
- Claude review: ship

## Prod notes
- `boring-full-app` worker cutover was applied via Fly secrets: `BORING_WORKER_BASE_URL`, `BORING_WORKER_INTERNAL_TOKEN`
- worker `uv --version` smoke through the full-app machine returned `uv 0.11.21`
