### PR TITLE
fix(agent): recover chat reconnect state

### DIFF
--- a/packages/agent/src/front/chat/pi/__tests__/piChatReducer.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/piChatReducer.test.ts
@@ -29,6 +29,16 @@ function assistantFinal(id: string, text: string): BoringChatMessage {
   return { id, role: 'assistant', status: 'done', parts: [{ type: 'text', id: 'p1', text }] }
 }
 
+function optimistic(clientNonce: string, text: string): OptimisticUserMessage {
+  return {
+    id: `optimistic:${clientNonce}`,
+    role: 'user',
+    status: 'pending',
+    clientNonce,
+    parts: [{ type: 'text', text }],
+  }
+}
+
 function reduceEvents(events: PiChatEvent[]) {
   return events.reduce((state, event) => piChatReducer(state, { type: 'event', event }), initial())
 }
@@ -68,6 +78,34 @@ describe('piChatReducer', () => {
     expect(state.committedMessages).toEqual([userMessage('u1', 'committed')])
     expect(state.optimisticOutbox).toEqual({})
     expect(state.notices).toContainEqual(expect.objectContaining({ id: 'stale-outbox-cleared', level: 'warning' }))
+  })
+
+  it('does not let a reconnect hydration reset local history with a short snapshot', () => {
+    let state = piChatReducer(initial(), {
+      type: 'hydrate',
+      snapshot: snapshot({
+        seq: 10,
+        status: 'idle',
+        activeTurnId: undefined,
+        messages: [userMessage('u1', 'hello'), assistantFinal('a1', 'hi')],
+      }),
+    })
+    state = piChatReducer(state, { type: 'optimistic-user-message', message: optimistic('nonce-next', 'next') })
+
+    state = piChatReducer(state, {
+      type: 'hydrate',
+      snapshot: snapshot({
+        seq: 11,
+        status: 'streaming',
+        activeTurnId: 'turn-next',
+        messages: [],
+      }),
+    })
+
+    expect(state).toMatchObject({ status: 'streaming', turnId: 'turn-next', lastSeq: 11, hydrated: true })
+    expect(state.committedMessages).toEqual([userMessage('u1', 'hello'), assistantFinal('a1', 'hi')])
+    expect(state.optimisticOutbox['nonce-next']).toEqual(expect.objectContaining({ clientNonce: 'nonce-next' }))
+    expect(state.notices.some((notice) => notice.id === 'stale-outbox-cleared')).toBe(false)
   })
 
   it('preserves the emitted part order from the snapshot during /state hydration', () => {

--- a/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
@@ -155,6 +155,34 @@ describe('RemotePiSession', () => {
     session.dispose()
   })
 
+  it('silently reconnects after a hung event stream connect times out', async () => {
+    const events = openNdjsonStream()
+    let eventCalls = 0
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      if (url.endsWith('/state')) return Promise.resolve(jsonResponse(snapshot({ seq: 7, status: 'idle', activeTurnId: undefined })))
+      if (url.endsWith('/events?cursor=7')) {
+        eventCalls += 1
+        if (eventCalls === 1) {
+          const signal = init?.signal
+          return new Promise<Response>((_resolve, reject) => {
+            signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')), { once: true })
+          })
+        }
+        return Promise.resolve(new Response(events.stream))
+      }
+      throw new Error(`unexpected URL ${url}`)
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock, { requestTimeoutMs: 20 })
+
+    await waitUntil(() => eventCalls >= 2, 3000)
+    await waitUntil(() => session.getState().connection.state === 'connected', 3000)
+
+    expect(session.getState().notices.some((notice) => notice.id === 'protocol-error')).toBe(false)
+    expect(session.getState().error).toBeUndefined()
+
+    session.dispose()
+  })
+
   it('recovers a hung /state hydration via the request timeout instead of stalling forever', async () => {
     // First /state never settles (saturated/restarting server). Without a
     // per-attempt timeout the chat stays stuck "Loading chat history…"; the

--- a/packages/agent/src/front/chat/pi/__tests__/selectors.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/selectors.test.ts
@@ -289,6 +289,27 @@ describe('Pi chat selectors and store', () => {
     expect(selectMessagesForRender(state)).toEqual([])
   })
 
+  it('hides background reconnect notices while an idle chat has no pending work', () => {
+    let state = createInitialPiChatState({ sessionId: 's1', storageScope: 'scope', status: 'idle' })
+    state = piChatReducer(state, { type: 'connection-state', state: 'reconnecting' })
+
+    expect(selectRuntimeNotices(state).map((notice) => notice.id)).toEqual([])
+
+    state = piChatReducer(state, {
+      type: 'optimistic-user-message',
+      message: {
+        id: 'optimistic:nonce-1',
+        role: 'user',
+        status: 'pending',
+        clientNonce: 'nonce-1',
+        createdAt: '2026-06-15T00:00:00.000Z',
+        parts: [{ type: 'text', id: 'optimistic:nonce-1:text', text: 'hello' }],
+      },
+    })
+
+    expect(selectRuntimeNotices(state).map((notice) => notice.id)).toEqual(['connection-reconnecting'])
+  })
+
   it('coalesces high-frequency delta notifications while reducer seq advances immediately', () => {
     const notify = vi.fn()
     const scheduled: Array<() => void> = []

--- a/packages/agent/src/front/chat/pi/piChatReducer.ts
+++ b/packages/agent/src/front/chat/pi/piChatReducer.ts
@@ -157,10 +157,18 @@ export function piChatReducer(state: PiChatState, action: PiChatReducerAction): 
         queue: { followUps: clearQueuedFollowUps(state.queue.followUps, action) },
         optimisticOutbox: clearOptimisticFollowUps(state.optimisticOutbox, action),
       }
-    case 'connection-state':
-      return { ...state, connection: { ...state.connection, state: action.state } }
+    case 'connection-state': {
+      const nextState = {
+        ...state,
+        connection: { ...state.connection, state: action.state },
+      }
+      return action.state === 'connected' ? clearProtocolError(nextState) : nextState
+    }
     case 'heartbeat':
-      return { ...state, connection: { ...state.connection, lastHeartbeatAt: action.now ?? Date.now() } }
+      return clearProtocolError({
+        ...state,
+        connection: { ...state.connection, lastHeartbeatAt: action.now ?? Date.now() },
+      })
     case 'protocol-error':
       return {
         ...state,
@@ -178,6 +186,15 @@ export function piChatReducer(state: PiChatState, action: PiChatReducerAction): 
   }
 }
 
+function clearProtocolError(state: PiChatState): PiChatState {
+  if (!state.notices.some((notice) => notice.id === 'protocol-error')) return state
+  return {
+    ...state,
+    error: undefined,
+    notices: state.notices.filter((notice) => notice.id !== 'protocol-error'),
+  }
+}
+
 function syncCursor(state: PiChatState, cursor: number): PiChatState {
   if (cursor <= state.lastSeq) return { ...state, hydrated: true, needsResync: undefined }
   return { ...state, lastSeq: cursor, hydrated: true, needsResync: undefined }
@@ -191,7 +208,11 @@ function hydrateFromSnapshot(
   if (snapshot.seq < state.lastSeq && !options.allowSeqRewind) return state
 
   const queue = { followUps: enrichQueueWithKnownMetadata(snapshot.queue.followUps, state.optimisticOutbox, state.queue.followUps) }
-  const committedMessages = normalizeSnapshotMessages(snapshot.messages)
+  const snapshotMessages = normalizeSnapshotMessages(snapshot.messages)
+  const preserveLocalHistory = shouldPreserveLocalCommittedHistory(state, snapshot, snapshotMessages, options)
+  const committedMessages = preserveLocalHistory
+    ? mergeSnapshotMessagesIntoLocal(state.committedMessages, snapshotMessages)
+    : snapshotMessages
   const serverNonces = new Set<string>()
   for (const message of committedMessages) {
     if (message.clientNonce) serverNonces.add(message.clientNonce)
@@ -201,7 +222,14 @@ function hydrateFromSnapshot(
   }
 
   const nextOutbox: Record<string, OptimisticUserMessage> = {}
-  const staleOutbox = Object.values(state.optimisticOutbox).filter((message) => !serverNonces.has(message.clientNonce))
+  if (preserveLocalHistory) {
+    for (const message of Object.values(state.optimisticOutbox)) {
+      if (!serverNonces.has(message.clientNonce)) nextOutbox[message.clientNonce] = message
+    }
+  }
+  const staleOutbox = preserveLocalHistory
+    ? []
+    : Object.values(state.optimisticOutbox).filter((message) => !serverNonces.has(message.clientNonce))
 
   const notices = staleOutbox.length > 0
     ? upsertNotice(state.notices, {
@@ -231,6 +259,32 @@ function hydrateFromSnapshot(
     hydrated: true,
     needsResync: undefined,
   }
+}
+
+function shouldPreserveLocalCommittedHistory(
+  state: PiChatState,
+  snapshot: PiChatSnapshot,
+  snapshotMessages: BoringChatMessage[],
+  options: { allowSeqRewind?: boolean },
+): boolean {
+  if (options.allowSeqRewind) return false
+  if (!state.hydrated) return false
+  if (state.sessionId !== snapshot.sessionId) return false
+  if (state.committedMessages.length === 0) return false
+  if (snapshotMessages.length < state.committedMessages.length) return true
+  for (let index = 0; index < state.committedMessages.length; index += 1) {
+    if (snapshotMessages[index]?.id !== state.committedMessages[index]?.id) return true
+  }
+  return false
+}
+
+function mergeSnapshotMessagesIntoLocal(
+  currentMessages: BoringChatMessage[],
+  snapshotMessages: BoringChatMessage[],
+): BoringChatMessage[] {
+  let merged = currentMessages
+  for (const message of snapshotMessages) merged = replaceOrAppendMessage(merged, message)
+  return merged
 }
 
 function applySequencedEvent(state: PiChatState, event: PiChatEvent): PiChatState {

--- a/packages/agent/src/front/chat/pi/remotePiSession.ts
+++ b/packages/agent/src/front/chat/pi/remotePiSession.ts
@@ -217,6 +217,7 @@ export class RemotePiSession {
       this.store.dispatch({ type: 'optimistic-user-message', message: toOptimisticUserMessage(payload) }, { flush: true })
     }
     if (!this.started) await this.start(this.store.getState().lastSeq)
+    else this.ensureReconnectScheduled()
     try {
       const receipt = await this.postCommand('/prompt', payload, PromptReceiptSchema)
       return receipt
@@ -231,6 +232,7 @@ export class RemotePiSession {
       this.store.dispatch({ type: 'optimistic-user-message', message: toOptimisticUserMessage(payload) }, { flush: true })
     }
     if (!this.started) await this.start(this.store.getState().lastSeq)
+    else this.ensureReconnectScheduled()
     try {
       const receipt = await this.postCommand('/followup', payload, FollowUpReceiptSchema)
       return receipt
@@ -431,9 +433,9 @@ export class RemotePiSession {
       // would normally swallow it; treat it instead as a recoverable
       // disconnect that schedules a reconnect against the recovered server.
       if (!connectTimedOut && shouldIgnoreStreamClose(error, controller)) return
-      this.dispatchProtocolError(connectTimedOut
-        ? `Pi chat event stream timed out after ${this.requestTimeoutMs}ms.`
-        : errorMessage(error, 'Pi chat event stream disconnected.'))
+      if (!connectTimedOut) {
+        this.dispatchProtocolError(errorMessage(error, 'Pi chat event stream disconnected.'))
+      }
       this.scheduleReconnect(generation)
     } finally {
       clearConnectTimer()
@@ -445,6 +447,14 @@ export class RemotePiSession {
     this.streamRunId += 1
     this.abortEventStream()
     void this.hydrateAndConnect(generation, options)
+  }
+
+  private ensureReconnectScheduled(): void {
+    if (!this.isGenerationActive(this.generation)) return
+    const state = this.store.getState()
+    if (state.connection.state === 'connected' || state.connection.state === 'connecting') return
+    if (this.reconnectTimer !== undefined) return
+    void this.hydrateAndConnect(this.generation)
   }
 
   private scheduleReconnect(generation: number): void {

--- a/packages/agent/src/front/chat/pi/selectors.ts
+++ b/packages/agent/src/front/chat/pi/selectors.ts
@@ -50,7 +50,7 @@ export function selectQueuePreview(state: PiChatState): QueuedUserMessage[] {
 
 export function selectRuntimeNotices(state: PiChatState): PiChatRuntimeNotice[] {
   const notices = [...state.notices]
-  if (state.connection.state === 'reconnecting') {
+  if (state.connection.state === 'reconnecting' && hasVisibleReconnectWork(state)) {
     notices.push({ id: 'connection-reconnecting', level: 'warning', text: 'Reconnecting to the agent session…' })
   }
   if (state.retryNotice) {
@@ -64,6 +64,13 @@ export function selectRuntimeNotices(state: PiChatState): PiChatRuntimeNotice[] 
     notices.push({ id: 'chat-error', level: 'error', text: state.error.message, dismissible: true })
   }
   return notices
+}
+
+function hasVisibleReconnectWork(state: PiChatState): boolean {
+  return state.status !== 'idle'
+    || state.queue.followUps.length > 0
+    || Object.keys(state.optimisticOutbox).length > 0
+    || state.pendingToolCallIds.size > 0
 }
 
 function optimisticText(message: BoringChatMessage): string {

--- a/packages/agent/src/server/runtime/modes/vercel-sandbox.ts
+++ b/packages/agent/src/server/runtime/modes/vercel-sandbox.ts
@@ -234,8 +234,8 @@ async function ensureVercelRuntimePrimitives(
     throw new Error(`runtime bootstrap (uv) failed (exit ${result.exitCode ?? 'unknown'})`)
   }
   // Provisioning invokes uv by explicit path (correctness must not depend on the
-  // non-interactive exec PATH). Default BORING_AGENT_UV_BIN to where the Node
-  // bootstrap installs uv; an explicit deploy-config value still wins. Routed
+  // non-interactive exec PATH). Default BORING_AGENT_UV_BIN to the `.boring-agent`
+  // uv installed by the Node bootstrap; an explicit deploy-config value still wins. Routed
   // through config/env so we never touch process.env directly (invariant).
   if (isNodeFamilyRuntime(runtime)) {
     setEnvDefault('BORING_AGENT_UV_BIN', VERCEL_UV_BIN)

--- a/packages/agent/src/server/sandbox/snapshots/__tests__/deploymentSnapshot.test.ts
+++ b/packages/agent/src/server/sandbox/snapshots/__tests__/deploymentSnapshot.test.ts
@@ -40,6 +40,9 @@ test('Node-family runtimes install uv via the standalone curl installer (no pip/
     expect(joined, `runtime=${runtime} must install uv via the curl installer`).toContain(
       'curl -LsSf https://astral.sh/uv/install.sh',
     )
+    expect(joined, `runtime=${runtime} must install uv into .boring-agent`).toContain(
+      `UV_INSTALL_DIR=/workspace/.boring-agent/sdk/uv/bin sh`,
+    )
     expect(joined, `runtime=${runtime} must verify the explicit UV_BIN`).toContain(
       `${VERCEL_UV_BIN} --version`,
     )

--- a/packages/agent/src/server/sandbox/snapshots/deploymentSnapshot.ts
+++ b/packages/agent/src/server/sandbox/snapshots/deploymentSnapshot.ts
@@ -1,10 +1,10 @@
 /**
- * Authoritative uv path installed by the Vercel Node-runtime bootstrap (the
- * Astral standalone installer drops the binary in `$HOME/.local/bin`). That dir
- * is NOT on PATH for non-interactive provisioning exec, so internal callers must
- * invoke uv via this explicit path, never bare `uv`.
+ * Authoritative uv path installed by the Vercel Node-runtime bootstrap.
+ * This path is intentionally inside the workspace's `.boring-agent` runtime
+ * directory because the interactive agent shell includes it on PATH.
  */
-export const VERCEL_UV_BIN = '/home/vercel-sandbox/.local/bin/uv'
+export const VERCEL_UV_BIN_DIR = '/workspace/.boring-agent/sdk/uv/bin'
+export const VERCEL_UV_BIN = `${VERCEL_UV_BIN_DIR}/uv`
 
 /**
  * uv setup for Python-family runtimes (e.g. Vercel `python3.13`), which already
@@ -19,14 +19,15 @@ export const UV_SETUP_COMMANDS = [
  * uv setup for Node-family runtimes (Vercel `node22`/`node24`/`node26`), which
  * ship node/npm/pnpm + Amazon Linux `python3` but NO `pip` and NO Astral `uv`.
  *
- * Install uv via the Astral standalone installer (`curl … | sh`), which lands a
- * prebuilt binary at `$HOME/.local/bin/uv` and needs NEITHER `pip` NOR `dnf`.
- * Verified live on node24: ~1.3s vs ~15.6s for the old `dnf install python3-pip`
- * + `pip install --user uv` path (the `dnf` step alone was ~13s). Provisioning
- * uses uv exclusively, so no system `pip3` is required at all.
+ * Install uv via the Astral standalone installer (`curl … | sh`), pinned to the
+ * workspace's `.boring-agent` runtime directory with `UV_INSTALL_DIR`; it needs
+ * NEITHER `pip` NOR `dnf`. Verified live on node24: ~1.3s vs ~15.6s for the old
+ * `dnf install python3-pip` + `pip install --user uv` path (the `dnf` step alone
+ * was ~13s). Provisioning uses uv exclusively, so no system `pip3` is required.
  */
 export const NODE_UV_SETUP_COMMANDS = [
-  `[ -x ${VERCEL_UV_BIN} ] || curl -LsSf https://astral.sh/uv/install.sh | sh`,
+  `mkdir -p ${VERCEL_UV_BIN_DIR}`,
+  `[ -x ${VERCEL_UV_BIN} ] || curl -LsSf https://astral.sh/uv/install.sh | UV_INSTALL_DIR=${VERCEL_UV_BIN_DIR} sh`,
   `${VERCEL_UV_BIN} --version`,
 ] as const
 

--- a/packages/agent/src/server/workspace/__tests__/helpers/mockVercelSandbox.ts
+++ b/packages/agent/src/server/workspace/__tests__/helpers/mockVercelSandbox.ts
@@ -140,7 +140,7 @@ export async function createMockVercelSandboxHarness(): Promise<MockVercelSandbo
       }
 
       // uv runtime bootstrap (Layer A): simulate uv installing/verifying successfully.
-      if (script.includes('astral.sh/uv/install') || script.includes('.local/bin/uv --version')) {
+      if (script.includes('astral.sh/uv/install') || script.includes('/.boring-agent/sdk/uv/bin/uv --version')) {
         return emitResult(0, 'uv 0.0.0\n', '')
       }
 

--- a/packages/agent/src/server/workspace/provisioning/__tests__/python.test.ts
+++ b/packages/agent/src/server/workspace/provisioning/__tests__/python.test.ts
@@ -98,7 +98,7 @@ async function fakePyprojectRoot(prefix = 'boring macro sdk-'): Promise<{ root: 
   return { root, pyproject }
 }
 
-const VERCEL_UV = '/home/vercel-sandbox/.local/bin/uv'
+const VERCEL_UV = '/workspace/.boring-agent/sdk/uv/bin/uv'
 
 test('ensureUv prefers explicitUvBin over bare uv (PATH-independence)', async () => {
   const workspaceRoot = await tempWorkspace()

--- a/packages/agent/src/server/workspace/provisioning/python.ts
+++ b/packages/agent/src/server/workspace/provisioning/python.ts
@@ -45,11 +45,11 @@ export async function ensureUv(options: {
   runtimeLayout: BoringAgentRuntimePaths
   uvStandaloneSource?: string | URL
   /**
-   * Explicit absolute path to a uv binary (e.g. the Vercel Node-runtime
-   * bootstrap installs uv at /home/vercel-sandbox/.local/bin/uv, which is NOT on
-   * the non-interactive exec PATH). Provider-neutral: supplied by the caller, not
-   * hardcoded here. When set and runnable it is preferred over bare `uv`, so
-   * provisioning correctness never depends on PATH propagation.
+   * Explicit absolute path to a uv binary (e.g. Vercel Node-runtime bootstrap
+   * installs uv into `.boring-agent` before Python provisioning starts).
+   * Provider-neutral: supplied by the caller, not hardcoded here. When set and
+   * runnable it is preferred over bare `uv`, so provisioning correctness never
+   * depends on PATH propagation.
    */
   explicitUvBin?: string
 }): Promise<EnsureUvResult> {


### PR DESCRIPTION
## Summary
- silently reconnect idle Pi chat event stream connect timeouts instead of showing the 15000ms timeout error
- preserve committed chat history when reconnect hydration returns a stale/short snapshot after an error or next send
- install Vercel Node-runtime uv directly into `/workspace/.boring-agent/sdk/uv/bin/uv` so it is on the agent shell PATH

## Tests
- `pnpm --filter @hachej/boring-agent run test src/front/chat/pi/__tests__/piChatReducer.test.ts src/front/chat/pi/__tests__/remotePiSession.test.ts src/front/chat/pi/__tests__/selectors.test.ts src/server/runtime/modes/__tests__/vercel-sandbox.test.ts src/server/sandbox/snapshots/__tests__/deploymentSnapshot.test.ts src/server/workspace/provisioning/__tests__/python.test.ts`
- `pnpm --filter @hachej/boring-agent run typecheck`
- `/home/ubuntu/.pi/agent/skills/coding-autoreview/scripts/autoreview --mode local --engine claude ...` → clean

## Deployment plan
After merge: deploy merged `main` locally with `flyctl deploy --remote-only --app boring-full-app --config apps/full-app/fly.toml --build-target runtime`, then validate idle reconnect/history and `uv` in Vercel sandbox before cutting release.