### PR TITLE
fix(core): derive email branding from app identity

### DIFF
--- a/apps/full-app/Dockerfile
+++ b/apps/full-app/Dockerfile
@@ -70,6 +70,7 @@ COPY --from=build /app/packages/workspace/package.json packages/workspace/packag
 COPY --from=build /app/packages/workspace/node_modules/ packages/workspace/node_modules/
 
 COPY --from=build /app/apps/full-app/dist/ apps/full-app/dist/
+COPY --from=build /app/apps/full-app/boring.app.toml apps/full-app/boring.app.toml
 COPY --from=build /app/apps/full-app/package.json apps/full-app/package.json
 COPY --from=build /app/apps/full-app/node_modules/ apps/full-app/node_modules/
 

--- a/apps/full-app/boring.app.toml
+++ b/apps/full-app/boring.app.toml
@@ -1,0 +1,2 @@
+[frontend.branding]
+name = "Seneca AI"

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.test.ts
@@ -1,5 +1,36 @@
 import { describe, expect, it } from 'vitest'
-import { createCoreWorkspaceAgentServer } from '../createCoreWorkspaceAgentServer.js'
+import { resolve } from 'node:path'
+import {
+  createCoreWorkspaceAgentServer,
+  resolveCoreLoadConfigOptions,
+} from '../createCoreWorkspaceAgentServer.js'
+
+describe('resolveCoreLoadConfigOptions', () => {
+  it('defaults to the app-root boring.app.toml when appRoot is provided', () => {
+    const appRoot = '/tmp/test-app'
+
+    expect(resolveCoreLoadConfigOptions({ appRoot }, 'development')).toEqual({
+      allowMissingSecrets: true,
+      tomlPath: resolve(appRoot, 'boring.app.toml'),
+    })
+  })
+
+  it('does not override an explicit TOML path', () => {
+    expect(resolveCoreLoadConfigOptions(
+      {
+        appRoot: '/tmp/test-app',
+        loadConfigOptions: {
+          tomlPath: '/tmp/custom.toml',
+          allowMissingSecrets: false,
+        },
+      },
+      'development',
+    )).toEqual({
+      allowMissingSecrets: false,
+      tomlPath: '/tmp/custom.toml',
+    })
+  })
+})
 
 describe('createCoreWorkspaceAgentServer', () => {
   it('fails fast when core app hot reload is requested', async () => {

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -148,6 +148,22 @@ export interface CreateCoreWorkspaceAgentServerOptions
 
 type AgentPiOptions = RegisterAgentRoutesOptions['pi']
 
+export function resolveCoreLoadConfigOptions(
+  options: Pick<
+    CreateCoreWorkspaceAgentServerOptions,
+    'appRoot' | 'loadConfigOptions'
+  > = {},
+  nodeEnv = process.env.NODE_ENV,
+): LoadConfigOptions {
+  return {
+    allowMissingSecrets: nodeEnv !== 'production',
+    ...(options.appRoot && !options.loadConfigOptions?.tomlPath
+      ? { tomlPath: path.resolve(options.appRoot, 'boring.app.toml') }
+      : {}),
+    ...options.loadConfigOptions,
+  }
+}
+
 function dedupeStrings(values: string[]): string[] {
   return Array.from(new Set(values))
 }
@@ -581,10 +597,7 @@ export async function createCoreWorkspaceAgentServer(
   }
   assertCoreStaticPluginEntries(options.plugins)
 
-  const config = options.config ?? (await loadConfig({
-    allowMissingSecrets: process.env.NODE_ENV !== 'production',
-    ...options.loadConfigOptions,
-  }))
+  const config = options.config ?? (await loadConfig(resolveCoreLoadConfigOptions(options)))
   const { app, sql, db, userStore, workspaceStore } = await createCoreRuntime(config)
   const appRoot = options.appRoot
   const serveFrontend =

--- a/packages/core/src/server/config/__tests__/loadConfig.test.ts
+++ b/packages/core/src/server/config/__tests__/loadConfig.test.ts
@@ -128,6 +128,22 @@ describe('loadConfig', () => {
     ).rejects.toThrow(ConfigValidationError)
   })
 
+  it('validates app name before normalizing the mail sender name', async () => {
+    writeToml(`
+[frontend.branding]
+name = 123
+`)
+
+    await expect(loadConfig({
+      tomlPath: TOML_PATH,
+      env: {
+        ...VALID_ENV,
+        MAIL_FROM: 'noreply@test.dev',
+        MAIL_TRANSPORT_URL: 'console://',
+      },
+    })).rejects.toThrow(ConfigValidationError)
+  })
+
   it('fills placeholders with allowMissingSecrets', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
@@ -205,9 +221,35 @@ describe('loadConfig', () => {
     })
 
     expect(config.auth.mail).toEqual({
-      from: 'noreply@test.dev',
+      from: 'Test App <noreply@test.dev>',
       transportUrl: 'console://',
     })
+  })
+
+  it('replaces the default boring.ui mail sender name with the app name', async () => {
+    const config = await loadConfig({
+      tomlPath: TOML_PATH,
+      env: {
+        ...VALID_ENV,
+        MAIL_FROM: 'boring.ui <noreply@test.dev>',
+        MAIL_TRANSPORT_URL: 'console://',
+      },
+    })
+
+    expect(config.auth.mail?.from).toBe('Test App <noreply@test.dev>')
+  })
+
+  it('preserves custom mail sender display names', async () => {
+    const config = await loadConfig({
+      tomlPath: TOML_PATH,
+      env: {
+        ...VALID_ENV,
+        MAIL_FROM: 'Acme Support <noreply@test.dev>',
+        MAIL_TRANSPORT_URL: 'console://',
+      },
+    })
+
+    expect(config.auth.mail?.from).toBe('Acme Support <noreply@test.dev>')
   })
 
   it('omits mail config when MAIL_FROM is missing', async () => {

--- a/packages/core/src/server/config/loadConfig.ts
+++ b/packages/core/src/server/config/loadConfig.ts
@@ -34,6 +34,35 @@ interface TomlAppConfig {
   }
 }
 
+function formatDisplayName(name: string): string {
+  const trimmed = name.trim().replace(/[<>]/g, '')
+  if (/^[A-Za-z0-9 ._-]+$/.test(trimmed)) return trimmed
+  return `"${trimmed.replace(/["\\]/g, '\\$&')}"`
+}
+
+function isDefaultBoringDisplayName(name: string): boolean {
+  return name.toLowerCase().replace(/[\s._-]+/g, '') === 'boringui'
+}
+
+function normalizeMailFrom(appName: string, rawFrom: string): string {
+  const from = rawFrom.trim()
+  const addressWithDisplay = from.match(/^(.*?)\s*<([^>]+)>$/)
+  if (addressWithDisplay) {
+    const displayName = addressWithDisplay[1].trim().replace(/^"(.*)"$/, '$1')
+    const address = addressWithDisplay[2].trim()
+    if (!displayName || isDefaultBoringDisplayName(displayName)) {
+      return `${formatDisplayName(appName)} <${address}>`
+    }
+    return from
+  }
+
+  if (/^[^\s@<>]+@[^\s@<>]+$/.test(from)) {
+    return `${formatDisplayName(appName)} <${from}>`
+  }
+
+  return from
+}
+
 function parseRateLimitOverrides(
   raw: string | undefined,
 ): Record<string, { max: number; window: string }> | undefined {
@@ -205,7 +234,19 @@ export async function loadConfig(
     },
   }
 
-  return validateConfig(raw)
+  const config = validateConfig(raw)
+  if (!config.auth.mail) return config
+
+  return {
+    ...config,
+    auth: {
+      ...config.auth,
+      mail: {
+        ...config.auth.mail,
+        from: normalizeMailFrom(config.appName, config.auth.mail.from),
+      },
+    },
+  }
 }
 
 export function validateConfig(raw: unknown): CoreConfig {

--- a/packages/core/src/server/mail/templates/WorkspaceInvite.tsx
+++ b/packages/core/src/server/mail/templates/WorkspaceInvite.tsx
@@ -3,6 +3,7 @@ import { Layout } from './Layout'
 
 interface WorkspaceInviteProps {
   acceptUrl: string
+  appName: string
   inviterName: string
   workspaceName: string
   role: string
@@ -11,6 +12,7 @@ interface WorkspaceInviteProps {
 
 export function WorkspaceInvite({
   acceptUrl,
+  appName,
   inviterName,
   workspaceName,
   role,
@@ -19,7 +21,7 @@ export function WorkspaceInvite({
   return (
     <Layout
       preview={`${inviterName} invited you to ${workspaceName}`}
-      appName={workspaceName}
+      appName={appName}
     >
       <Section style={content}>
         <Text style={heading}>You&apos;ve been invited</Text>

--- a/packages/core/src/server/mail/templates/__tests__/templates.test.ts
+++ b/packages/core/src/server/mail/templates/__tests__/templates.test.ts
@@ -89,6 +89,7 @@ describe('renderWorkspaceInvite', () => {
     const email = await renderWorkspaceInvite({
       to: 'invitee@test.dev',
       acceptUrl: 'https://app.test/invite/accept?token=inv1',
+      appName: 'TestApp',
       inviterName: 'Alice',
       workspaceName: 'Acme Corp',
       role: 'editor',
@@ -101,6 +102,7 @@ describe('renderWorkspaceInvite', () => {
     expect(email.html).toContain('Acme Corp')
     expect(email.html).toContain('editor')
     expect(email.html).toContain('https://app.test/invite/accept?token=inv1')
+    expect(email.text).toContain('TestApp')
     expect(email.text).toContain('Accept invitation')
     expect(email.text).toContain('7 days')
   })
@@ -109,6 +111,7 @@ describe('renderWorkspaceInvite', () => {
     const email = await renderWorkspaceInvite({
       to: 'invitee@test.dev',
       acceptUrl: 'https://app.test/invite',
+      appName: 'TestApp',
       inviterName: 'Bob',
       workspaceName: 'Team',
       role: 'viewer',
@@ -160,6 +163,7 @@ describe('plaintext output', () => {
       renderWorkspaceInvite({
         to: 'd@t.dev',
         acceptUrl: 'https://x',
+        appName: 'A',
         inviterName: 'X',
         workspaceName: 'W',
         role: 'admin',

--- a/packages/core/src/server/mail/templates/index.ts
+++ b/packages/core/src/server/mail/templates/index.ts
@@ -85,6 +85,7 @@ export async function renderMagicLink(
 interface WorkspaceInviteData {
   to: string
   acceptUrl: string
+  appName: string
   inviterName: string
   workspaceName: string
   role: string
@@ -96,6 +97,7 @@ export async function renderWorkspaceInvite(
 ): Promise<RenderedEmail> {
   const element = WorkspaceInvite({
     acceptUrl: data.acceptUrl,
+    appName: data.appName,
     inviterName: data.inviterName,
     workspaceName: data.workspaceName,
     role: data.role,

--- a/packages/core/src/server/routes/invites.ts
+++ b/packages/core/src/server/routes/invites.ts
@@ -85,6 +85,7 @@ const inviteRoutesPlugin: FastifyPluginAsync<InviteRoutesOptions> = async (app, 
           const email = await renderWorkspaceInvite({
             to: parsed.data.email,
             acceptUrl,
+            appName: app.config.appName,
             inviterName: request.user!.name ?? request.user!.email,
             workspaceName: workspace?.name ?? 'Workspace',
             role: parsed.data.role,


### PR DESCRIPTION
## Summary
- auto-load app-root boring.app.toml for composed core apps so child app branding reaches server/email config
- add full-app branding config for Seneca AI and copy it into the Docker runtime image
- normalize default/bare mail sender names to the validated app name while preserving custom sender names
- brand workspace invite email layout/footer with the app name

## Tests
- pnpm --filter @hachej/boring-core run test src/server/mail/templates/__tests__/templates.test.ts src/app/server/__tests__/createCoreWorkspaceAgentServer.test.ts src/server/config/__tests__/loadConfig.test.ts
- pnpm --filter @hachej/boring-core run typecheck
- pnpm --filter full-app run typecheck
- /home/ubuntu/.pi/agent/skills/coding-autoreview/scripts/autoreview --mode local