### PR TITLE
polish(full-app): refine no-auth landing page

### DIFF
--- a/apps/full-app/src/front/app.css
+++ b/apps/full-app/src/front/app.css
@@ -6,6 +6,16 @@ body,
   overflow: hidden;
 }
 
+/* Subtle warm glow behind the hero so the flat background reads with depth.
+   Layers as a background-image over the shell's bg-background color. */
+.public-chat-first-shell {
+  background-image: radial-gradient(
+    70% 52% at 30% 22%,
+    color-mix(in oklch, var(--accent) 11%, transparent),
+    transparent 68%
+  );
+}
+
 /* --- Hand-drawn teaching annotations (public no-auth shell) --- */
 .public-arrow {
   pointer-events: none;
@@ -79,6 +89,12 @@ body,
   }
 }
 
+/* Hide the chat-pane header strip ("New session") in the no-auth shell — there's
+   only ever a single pane here, so its title/drag/close bar is pure noise. */
+.public-chat-first-shell .dv-chat-stage .dv-tabs-and-actions-container {
+  display: none;
+}
+
 /* Keep opened workspace panes above the teaching arrows. */
 .public-chat-first-shell [data-boring-workspace-part="workbench"] {
   z-index: 30;
@@ -96,19 +112,29 @@ body,
 
 .public-chat-first-shell [data-boring-agent-part="empty-state"] h3 {
   margin-top: 22px;
-  font-size: clamp(34px, 5.4vw, 82px);
+  font-size: clamp(30px, 4.4vw, 60px);
   font-weight: 600;
   line-height: 1;
   letter-spacing: -0.04em;
   white-space: nowrap;
 }
 
+/* Editorial accent on the closing period (the title string omits its own). */
+.public-chat-first-shell [data-boring-agent-part="empty-state"] h3::after {
+  content: ".";
+  color: var(--accent);
+}
+
 .public-chat-first-shell [data-boring-agent-part="empty-state"] > p {
   display: block;
-  margin-top: 22px;
+  /* Match the subhead's own line gap (17px × 1.6 ≈ 10px) so the title → line 1
+     spacing equals the line 1 → line 2 spacing for an even rhythm. */
+  margin-top: 10px;
   max-width: 58ch;
   font-size: 17px;
   line-height: 1.6;
+  /* Honor the explicit \n after "Choose the AI you trust." in the subhead. */
+  white-space: pre-line;
 }
 
 @media (max-width: 560px) {
@@ -124,13 +150,36 @@ body,
   padding-top: clamp(28px, 9vh, 132px);
 }
 
+/* Move the /command cards to the bottom of the hero block (after the footer),
+   so they sit directly above the composer. The empty-state is a flex column,
+   so `order` reorders without touching the React tree. */
+.public-chat-first-shell [data-boring-agent-part="empty-state"] .public-hero-foot {
+  order: 10;
+}
+.public-chat-first-shell [data-boring-agent-part="empty-state"] [data-boring-agent-part="suggestion-grid"] {
+  order: 20;
+}
+
 /* Command launcher cards — make the slash commands read as runnable. */
 .public-chat-first-shell [data-boring-agent-part="suggestion-grid"] {
   margin-top: 28px;
   max-width: 560px;
   margin-left: auto;
   margin-right: auto;
-  border-radius: 14px;
+  /* Match the composer's rounding + 1px outline so cards + input read as one
+     design system (composer rail is rounded-[28px] with a border/0.7 outline). */
+  border-radius: 20px;
+}
+
+/* Accent send button — make the composer's primary action carry the accent so
+   the orange reads as intentional, not just decoration on the slash cards.
+   Scoped to the public hero; the shared composer elsewhere stays neutral. */
+.public-chat-first-shell [data-boring-agent-part="composer-submit"] {
+  background-color: var(--accent);
+}
+
+.public-chat-first-shell [data-boring-agent-part="composer-submit"]:hover {
+  background-color: color-mix(in oklch, var(--accent) 90%, var(--foreground));
 }
 
 .public-chat-first-shell [data-boring-agent-part="suggestion-card"] {
@@ -151,13 +200,16 @@ body,
   font-size: 12.5px;
 }
 
+/* Single compact footer line: "providers … · Open source [logo]". */
 .public-chat-first-shell .public-hero-foot {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 7px;
+  justify-content: center;
+  gap: 8px;
   margin-top: 22px;
-  font-size: 13px;
+  font-size: 12.5px;
   line-height: 1.4;
 }
 
@@ -165,18 +217,40 @@ body,
   color: var(--muted-foreground);
 }
 
-.public-chat-first-shell .public-hero-foot a {
+.public-chat-first-shell .public-hero-foot .public-hero-providers {
+  color: color-mix(in oklch, var(--foreground) 60%, transparent);
+  letter-spacing: 0.01em;
+}
+
+.public-chat-first-shell .public-hero-foot .public-hero-dot {
+  color: var(--muted-foreground);
+  opacity: 0.5;
+}
+
+.public-chat-first-shell .public-hero-foot .public-hero-github {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   color: var(--foreground);
   font-weight: 500;
   text-decoration: none;
-  border-bottom: 1px solid color-mix(in oklch, var(--accent) 55%, transparent);
-  padding-bottom: 1px;
-  transition: color 0.15s ease, border-color 0.15s ease;
+  transition: color 0.15s ease;
 }
 
-.public-chat-first-shell .public-hero-foot a:hover {
+.public-chat-first-shell .public-hero-foot .public-hero-github svg {
+  width: 15px;
+  height: 15px;
+}
+
+.public-chat-first-shell .public-hero-foot .public-hero-github:hover {
   color: var(--accent);
-  border-color: var(--accent);
+}
+
+/* Emphasize the trusted choice in the subhead without it reading as a link. */
+.public-chat-first-shell [data-boring-agent-part="empty-state"] > p .public-hero-trust {
+  font-style: normal;
+  font-weight: 600;
+  color: color-mix(in oklch, var(--foreground) 88%, transparent);
 }
 
 .public-pages-pane {

--- a/apps/full-app/src/front/main.tsx
+++ b/apps/full-app/src/front/main.tsx
@@ -91,15 +91,23 @@ createRoot(document.getElementById('root')!).render(
         showTeachingArrows: true,
         composerPlaceholder: 'Sign in to chat with the agent — or type a command like /landing-page',
         emptyState: {
-          eyebrow: 'Seneca AI · Live demo',
-          title: 'One workspace. Any AI provider.',
-          description:
-            'Seneca gives the AI of your choice a private remote computer to do real work for you: read files, run tasks, make changes, and show you what changed.',
+          eyebrow: 'Seneca AI',
+          title: 'One workspace. Any AI provider',
+          description: (
+            <>
+              Choose the AI you <em className="public-hero-trust">trust</em>.<br />
+              Seneca gives it a private remote computer where it can read files, run tasks, make changes, and show you the work for review.
+            </>
+          ),
           footer: (
             <div className="public-hero-foot">
-              <span>Sign in to test the chat.</span>
-              <a href="https://github.com/hachej/boring-ui" target="_blank" rel="noreferrer">
-                Open source — see the project on GitHub →
+              <span className="public-hero-providers">Supports local models, European-hosted providers, and frontier AI labs</span>
+              <span className="public-hero-dot" aria-hidden="true">·</span>
+              <a className="public-hero-github" href="https://github.com/hachej/boring-ui" target="_blank" rel="noreferrer">
+                Open source
+                <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" focusable="false">
+                  <path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.8 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.04-.02-2.05-3.34.73-4.04-1.61-4.04-1.61-.55-1.39-1.34-1.76-1.34-1.76-1.09-.75.08-.73.08-.73 1.21.09 1.84 1.24 1.84 1.24 1.07 1.84 2.81 1.31 3.5 1 .11-.78.42-1.31.76-1.61-2.67-.3-5.47-1.34-5.47-5.96 0-1.32.47-2.39 1.24-3.23-.12-.31-.54-1.53.12-3.18 0 0 1.01-.32 3.3 1.23a11.5 11.5 0 0 1 6.01 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.65.24 2.87.12 3.18.77.84 1.24 1.91 1.24 3.23 0 4.63-2.81 5.65-5.49 5.95.43.37.81 1.1.81 2.22 0 1.61-.01 2.9-.01 3.29 0 .32.22.7.83.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z" />
+                </svg>
               </a>
             </div>
           ),
@@ -107,6 +115,12 @@ createRoot(document.getElementById('root')!).render(
         suggestions: [
           { label: '/landing-page', hint: 'Get more details.', prompt: '/landing-page' },
           { label: '/reach-out', hint: 'Book a 30-minute live walkthrough.', prompt: '/reach-out' },
+        ],
+        models: [
+          // European-hosted · Frontier · Local — one per category.
+          { provider: 'infomaniak', id: 'minimax-2.5', label: 'MiniMax 2.5 · Infomaniak' },
+          { provider: 'openai', id: 'gpt-5.5-codex', label: 'GPT-5.5 Codex' },
+          { provider: 'local', id: 'qwen3.6', label: 'Qwen 3.6 · Local' },
         ],
       }}
       chatParams={chatParams}

--- a/packages/agent/src/front/ChatEmptyState.tsx
+++ b/packages/agent/src/front/ChatEmptyState.tsx
@@ -73,7 +73,7 @@ export interface ChatEmptyStateProps {
   /** Large headline. Editorial tone. */
   title?: string
   /** Single-paragraph description below the headline. */
-  description?: string
+  description?: ReactNode
   /**
    * Suggestion cards. Pass `[]` to hide the grid entirely (headline still
    * renders). Defaults to `defaultChatSuggestions`.

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -100,7 +100,7 @@ interface ComposerSendPayload {
 export interface ChatPanelEmptyState {
   eyebrow?: string
   title?: string
-  description?: string
+  description?: ReactNode
   /** Optional content rendered below the suggestion grid (e.g. a footer link). */
   footer?: ReactNode
 }

--- a/packages/agent/src/front/chat/components/PiConversationSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiConversationSurface.tsx
@@ -32,7 +32,7 @@ export interface PiConversationSurfaceProps {
   emptyState?: {
     eyebrow?: string
     title?: string
-    description?: string
+    description?: ReactNode
     footer?: ReactNode
   }
   suggestions: ChatSuggestion[]

--- a/packages/core/src/app/front/chatFirst/ChatFirstAuthenticatedShell.tsx
+++ b/packages/core/src/app/front/chatFirst/ChatFirstAuthenticatedShell.tsx
@@ -48,7 +48,7 @@ export function ChatFirstAuthenticatedShell<
       {...workspaceProps}
       workspaceId={workspaceId}
       appTitle={appTitle}
-      topBarLeft={null}
+      topBarLeft={workspaceProps.topBarLeft ?? null}
       sessions={[]}
       activeSessionId={null}
       onSwitchSession={() => undefined}

--- a/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
+++ b/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
@@ -16,12 +16,20 @@ export interface ChatFirstPublicShellOptions {
   emptyState?: {
     eyebrow?: string
     title?: string
-    description?: string
+    description?: ReactNode
     footer?: ReactNode
   }
   suggestions?: ChatSuggestion[]
   /**
-   * Hand-drawn "Your agent" / "Your remote computer" annotations point at the
+   * Predefined models for the composer's model picker. When provided, the
+   * composer settings row (model + thinking pickers) is shown in the no-auth
+   * hero, mirroring a regular chat session. The no-auth shell can't fetch the
+   * model list from the server (server resources are disabled), so it must be
+   * passed in here. `available` defaults to `true`.
+   */
+  models?: Array<{ provider: string; id: string; label: string; available?: boolean }>
+  /**
+   * Hand-drawn "Ask your AI here" / "Review its work here" annotations point at the
    * composer and the workspace surface to teach the empty public shell. Apps
    * that open a center panel on load (e.g. a landing page) should disable them,
    * otherwise the fixed-position arrows overlay the open panel. Defaults to on.
@@ -69,6 +77,8 @@ export function ChatFirstPublicShell<
   const promptedDraft = new URLSearchParams(location.search).get('prompt')?.trim() ?? ''
   const pendingReturnTo = promptedDraft ? '/' : returnTo
   const workspaceId = intendedWorkspaceId || 'public'
+  const publicModels = (publicShell?.models ?? []).map((m) => ({ ...m, available: m.available ?? true }))
+  const showComposerSettings = publicModels.length > 0
   const openAuth = (draft = readComposerDraftFromDom()) => {
     writePendingChatEntry({ draft, returnTo: pendingReturnTo, ...(intendedWorkspaceId ? { intendedWorkspaceId } : {}) })
     setModalOpen(true)
@@ -165,7 +175,7 @@ export function ChatFirstPublicShell<
       {publicShell?.showTeachingArrows !== false && (
         <>
           <div className="public-arrow public-arrow-computer" aria-hidden="true">
-            <span className="public-arrow-label">Your remote computer</span>
+            <span className="public-arrow-label">Review its work here</span>
             <svg className="public-arrow-svg" viewBox="0 0 190 140" fill="none">
               <path
                 className="paw-stroke"
@@ -184,7 +194,7 @@ export function ChatFirstPublicShell<
               <path className="paw-stroke" d="M76 10 C 70 16 62 19 53 20" />
               <path className="paw-stroke" d="M76 10 C 82 14 87 21 90 29" />
             </svg>
-            <span className="public-arrow-label">Your agent</span>
+            <span className="public-arrow-label">Ask your AI here</span>
           </div>
         </>
       )}
@@ -199,16 +209,40 @@ export function ChatFirstPublicShell<
         showComposerBlocker={false}
         workspaceProps={{
             ...workspaceProps,
+            // No-auth landing should open with the workspace surface closed —
+            // a fresh load/hard refresh shows just the hero, not a re-opened
+            // panel. The /landing-page command still opens it on demand.
+            defaultSurfaceOpen: false,
             topBarRight: <button type="button" className="rounded-md border border-border px-3 py-1.5 text-sm font-medium hover:bg-muted" onClick={() => openAuth()}>Sign in</button>,
+            // No-auth shell has no real session yet — show just the brand, hide the
+            // "· New session" placeholder that the default TopBar would render.
+            topBarLeft: (
+              <>
+                <span
+                  aria-hidden="true"
+                  className="grid size-[22px] shrink-0 place-items-center rounded-sm bg-foreground text-[11px] font-semibold leading-none tracking-tight text-background"
+                >
+                  {(appTitle?.[0] ?? 'B').toUpperCase()}
+                </span>
+                <span className="truncate text-[13px] font-medium leading-none tracking-tight text-foreground">{appTitle}</span>
+              </>
+            ),
             className: workspaceProps.className,
             surfaceButtonBottomOffset: 456,
             chatParams: {
               ...workspaceProps.chatParams,
               emptyPlacement: 'hero',
               composerPlaceholder: publicShell?.composerPlaceholder ?? 'Type /landing-page or /reach-out',
-              hideComposerSettings: true,
+              hideComposerSettings: !showComposerSettings,
               suppressPreSubmitCancelledWarning: true,
-              thinkingControl: false,
+              thinkingControl: showComposerSettings,
+              ...(showComposerSettings
+                ? {
+                    availableModels: publicModels,
+                    hideDefaultModelOption: true,
+                    defaultModel: { provider: publicModels[0].provider, id: publicModels[0].id },
+                  }
+                : {}),
               initialDraft: promptedDraft || undefined,
               emptyState: {
                 ...defaultPublicEmptyState,


### PR DESCRIPTION
Polish pass on the no-auth (chat-first) landing page. Ported cleanly onto `main` (preserves the credits/checkout wiring and `main`'s recent shared-component work).

## Landing page
- Accent the H1 closing period + the composer send button; subtle radial glow behind the hero
- Smaller title; unify command-card rounding with the composer
- New hero copy with an emphasized **trust** and a one-line footer: `Supports local models, European-hosted providers, and frontier AI labs · Open source [GitHub logo]`
- Hand-drawn arrows reworded: **"Ask your AI here"** / **"Review its work here"**
- Top-left shows just the brand (no "· New session") in no-auth mode; the single-pane dock header strip is hidden
- Show the model + thinking picker under the composer, fed a predefined model list (MiniMax 2.5 · Infomaniak, GPT-5.5 Codex, Qwen 3.6 · Local)
- Start with the workspace surface **closed** on a fresh load / hard refresh

## Shared components
- Widen `ChatEmptyState` / `ChatPanelEmptyState` / `PiConversationSurface` `description` to `ReactNode` so the subhead can render markup
- `ChatFirstPublicShell`: add a `models` option (feeds `availableModels` since the no-auth shell can't fetch from the server) and `defaultSurfaceOpen: false`; `ChatFirstAuthenticatedShell` honors an incoming `topBarLeft`

## Verification
- `pnpm --filter "@hachej/boring-core..." build` (topo) green, incl. agent/core/workspace DTS
- `full-app` `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)