### PR TITLE
perf(agent): skip sandbox stat for file creates

### DIFF
--- a/packages/agent/src/server/http/routes/__tests__/file.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/file.test.ts
@@ -2,8 +2,9 @@ import Fastify, { type FastifyInstance } from 'fastify'
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
 
+import type { Workspace } from '../../../../shared/workspace'
 import { createNodeWorkspace } from '../../../workspace/createNodeWorkspace'
 import { fileRoutes } from '../file'
 
@@ -18,6 +19,14 @@ afterEach(async () => {
     }),
   )
 })
+
+async function createTestAppWithWorkspace(workspace: Workspace): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false })
+  await app.register(fileRoutes, { workspace })
+  await app.ready()
+  apps.push(app)
+  return app
+}
 
 async function createTestApp(): Promise<{ app: FastifyInstance; workspaceRoot: string }> {
   const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-file-routes-'))
@@ -113,6 +122,71 @@ describe('file routes (NodeWorkspace integration)', () => {
     })
     expect(readRes.statusCode).toBe(200)
     expect(readRes.json().content).toBe('export {}')
+  })
+
+  test('POST /api/v1/files can skip post-write stat when mtime is not needed', async () => {
+    const writeFileMock = vi.fn(async () => {})
+    const writeFileWithStatMock = vi.fn(async () => ({ kind: 'file' as const, size: 4, mtimeMs: 123 }))
+    const app = await createTestAppWithWorkspace({
+      root: '/workspace',
+      runtimeContext: { runtimeCwd: '/workspace' },
+      fsCapability: 'best-effort',
+      readFile: vi.fn(async () => ''),
+      writeFile: writeFileMock,
+      writeFileWithStat: writeFileWithStatMock,
+      unlink: vi.fn(async () => {}),
+      readdir: vi.fn(async () => []),
+      stat: vi.fn(async () => ({ kind: 'file' as const, size: 4, mtimeMs: 123 })),
+      mkdir: vi.fn(async () => {}),
+      rename: vi.fn(async () => {}),
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files',
+      payload: { path: 'fast.txt', content: 'fast', returnMtimeMs: false },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ ok: true })
+    expect(writeFileMock).toHaveBeenCalledWith('fast.txt', 'fast')
+    expect(writeFileWithStatMock).not.toHaveBeenCalled()
+  })
+
+  test('POST /api/v1/files keeps mtime result for OCC writes even when returnMtimeMs is false', async () => {
+    const writeFileMock = vi.fn(async () => {})
+    const writeFileWithStatMock = vi.fn(async () => ({ kind: 'file' as const, size: 4, mtimeMs: 456 }))
+    const statMock = vi.fn(async () => ({ kind: 'file' as const, size: 3, mtimeMs: 123 }))
+    const app = await createTestAppWithWorkspace({
+      root: '/workspace',
+      runtimeContext: { runtimeCwd: '/workspace' },
+      fsCapability: 'best-effort',
+      readFile: vi.fn(async () => ''),
+      writeFile: writeFileMock,
+      writeFileWithStat: writeFileWithStatMock,
+      unlink: vi.fn(async () => {}),
+      readdir: vi.fn(async () => []),
+      stat: statMock,
+      mkdir: vi.fn(async () => {}),
+      rename: vi.fn(async () => {}),
+    })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files',
+      payload: {
+        path: 'occ.txt',
+        content: 'next',
+        expectedMtimeMs: 123,
+        returnMtimeMs: false,
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ ok: true, mtimeMs: 456 })
+    expect(statMock).toHaveBeenCalledWith('occ.txt')
+    expect(writeFileWithStatMock).toHaveBeenCalledWith('occ.txt', 'next')
+    expect(writeFileMock).not.toHaveBeenCalled()
   })
 
   test('multi-tab stale write overwrites newer content (last write wins)', async () => {

--- a/packages/agent/src/server/http/routes/file.ts
+++ b/packages/agent/src/server/http/routes/file.ts
@@ -325,6 +325,7 @@ export function fileRoutes(
     const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
       ? body.expectedMtimeMs
       : null
+    const shouldReturnMtimeMs = body.returnMtimeMs !== false || expectedMtimeMs !== null
 
     try {
       const workspace = await resolveWorkspace(request)
@@ -364,6 +365,10 @@ export function fileRoutes(
         if (dir) await workspace.mkdir(dir, { recursive: true })
       }
       const content = body.content
+      if (!shouldReturnMtimeMs) {
+        await workspace.writeFile(path, content)
+        return { ok: true }
+      }
       const stat = workspace.writeFileWithStat
         ? await workspace.writeFileWithStat(path, content)
         : await (async () => {

--- a/packages/agent/src/server/workspace/__tests__/createVercelSandboxWorkspace.test.ts
+++ b/packages/agent/src/server/workspace/__tests__/createVercelSandboxWorkspace.test.ts
@@ -77,20 +77,39 @@ test('optimized read/write with stat helpers return content and metadata', async
   }
 })
 
-test('optimized small writes return stat in a single sandbox command', async () => {
+test('optimized small writes avoid sandbox command startup', async () => {
   const harness = await createMockVercelSandboxHarness()
   const runSpy = vi.spyOn(harness.sandbox, 'runCommand')
   const writeFilesSpy = vi.spyOn(harness.sandbox, 'writeFiles')
+  const statSpy = vi.spyOn((harness.sandbox as any).fs, 'stat')
   const workspace = createVercelSandboxWorkspace(harness.sandbox)
 
   try {
-    await workspace.writeFileWithStat?.('single-call.txt', 'hello')
+    const stat = await workspace.writeFileWithStat?.('single-call.txt', 'hello')
 
-    expect(runSpy).toHaveBeenCalledTimes(1)
-    expect(writeFilesSpy).not.toHaveBeenCalled()
+    expect(stat).toMatchObject({ kind: 'file', size: 5 })
+    expect(writeFilesSpy).toHaveBeenCalledTimes(1)
+    expect(statSpy).toHaveBeenCalledTimes(1)
+    expect(runSpy).not.toHaveBeenCalled()
   } finally {
     await harness.cleanup()
   }
+})
+
+test('optimized small writes keep single-command fallback when native stat is unavailable', async () => {
+  const runCommand = vi.fn(async () => ({
+    exitCode: 0,
+    stdout: async () => JSON.stringify({ size: 5, mtimeMs: 123, kind: 'file' }),
+    stderr: async () => '',
+  }))
+  const writeFiles = vi.fn(async () => {})
+  const workspace = createVercelSandboxWorkspace({ writeFiles, runCommand } as any)
+
+  const stat = await workspace.writeFileWithStat?.('single-call.txt', 'hello')
+
+  expect(stat).toMatchObject({ kind: 'file', size: 5, mtimeMs: 123 })
+  expect(runCommand).toHaveBeenCalledTimes(1)
+  expect(writeFiles).not.toHaveBeenCalled()
 })
 
 test('reuses stat/readdir cache entries inside ttl and refreshes after expiry', async () => {

--- a/packages/agent/src/server/workspace/createVercelSandboxWorkspace.ts
+++ b/packages/agent/src/server/workspace/createVercelSandboxWorkspace.ts
@@ -248,6 +248,21 @@ export function createVercelSandboxWorkspace(
     )
   }
 
+  async function statSandboxPath(sandboxPath: string): Promise<Stat> {
+    if (remote.fs?.stat) {
+      const fileStat = await remote.fs.stat(sandboxPath)
+      return {
+        size: fileStat.size,
+        mtimeMs: fileStat.mtimeMs,
+        kind: fileStat.isDirectory() ? 'dir' : 'file',
+      }
+    }
+    return await runJson<Stat>(
+      remote,
+      `node -e ${shellQuote(`const fs=require('fs'); const p=process.argv[1]; const s=fs.statSync(p); process.stdout.write(JSON.stringify({size:s.size,mtimeMs:s.mtimeMs,kind:s.isDirectory()?'dir':'file'}))`)} ${shellQuote(sandboxPath)}`,
+    )
+  }
+
   return {
     root: VERCEL_SANDBOX_RUNTIME_CONTEXT.runtimeCwd,
     runtimeContext: VERCEL_SANDBOX_RUNTIME_CONTEXT,
@@ -351,7 +366,7 @@ export function createVercelSandboxWorkspace(
       const sandboxPath = toSandboxPath(relPath)
       const payload = Buffer.from(data, 'utf-8')
 
-      if (payload.byteLength > MAX_INLINE_WRITE_BYTES) {
+      if (remote.fs?.stat || payload.byteLength > MAX_INLINE_WRITE_BYTES) {
         await sandbox.writeFiles([
           {
             path: sandboxPath,
@@ -360,19 +375,7 @@ export function createVercelSandboxWorkspace(
         ])
         invalidateMetadataCache()
         workspaceOpts.onMutation?.()
-        const writtenStat = remote.fs?.stat
-          ? await (async (): Promise<Stat> => {
-              const fileStat = await remote.fs!.stat(sandboxPath)
-              return {
-                size: fileStat.size,
-                mtimeMs: fileStat.mtimeMs,
-                kind: fileStat.isDirectory() ? 'dir' : 'file',
-              }
-            })()
-          : await runJson<Stat>(
-              remote,
-              `node -e ${shellQuote(`const fs=require('fs'); const p=process.argv[1]; const s=fs.statSync(p); process.stdout.write(JSON.stringify({size:s.size,mtimeMs:s.mtimeMs,kind:s.isDirectory()?'dir':'file'}))`)} ${shellQuote(sandboxPath)}`,
-            )
+        const writtenStat = await statSandboxPath(sandboxPath)
         statCache.set(sandboxPath, writtenStat)
         emitChange({ op: 'write', path: relPath, mtimeMs: writtenStat.mtimeMs })
         return cloneStat(writtenStat)
@@ -393,7 +396,7 @@ export function createVercelSandboxWorkspace(
       const sandboxPath = toSandboxPath(relPath)
       const payload = Buffer.from(data)
 
-      if (payload.byteLength > MAX_INLINE_WRITE_BYTES) {
+      if (remote.fs?.stat || payload.byteLength > MAX_INLINE_WRITE_BYTES) {
         await sandbox.writeFiles([
           {
             path: sandboxPath,
@@ -402,19 +405,7 @@ export function createVercelSandboxWorkspace(
         ])
         invalidateMetadataCache()
         workspaceOpts.onMutation?.()
-        const writtenStat = remote.fs?.stat
-          ? await (async (): Promise<Stat> => {
-              const fileStat = await remote.fs!.stat(sandboxPath)
-              return {
-                size: fileStat.size,
-                mtimeMs: fileStat.mtimeMs,
-                kind: fileStat.isDirectory() ? 'dir' : 'file',
-              }
-            })()
-          : await runJson<Stat>(
-              remote,
-              `node -e ${shellQuote(`const fs=require('fs'); const p=process.argv[1]; const s=fs.statSync(p); process.stdout.write(JSON.stringify({size:s.size,mtimeMs:s.mtimeMs,kind:s.isDirectory()?'dir':'file'}))`)} ${shellQuote(sandboxPath)}`,
-            )
+        const writtenStat = await statSandboxPath(sandboxPath)
         statCache.set(sandboxPath, writtenStat)
         emitChange({ op: 'write', path: relPath, mtimeMs: writtenStat.mtimeMs })
         return cloneStat(writtenStat)

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.test.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.test.ts
@@ -75,6 +75,18 @@ describe("FetchClient", () => {
     expect(JSON.parse(opts.body)).toEqual({ path: "/a.ts", content: "code" })
   })
 
+  it("POST /api/v1/files forwards returnMtimeMs opt-out when supplied", async () => {
+    mockFetch.mockReturnValue(ok({ ok: true }))
+    const client = new FetchClient({ apiBaseUrl: "" })
+    const result = await client.writeFile("/a.ts", "code", { returnMtimeMs: false })
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({
+      path: "/a.ts",
+      content: "code",
+      returnMtimeMs: false,
+    })
+    expect(result).toEqual({ mtimeMs: undefined })
+  })
+
   it("POST /api/v1/files forwards expectedMtimeMs when supplied", async () => {
     mockFetch.mockReturnValue(ok({ ok: true, mtimeMs: 12345 }))
     const client = new FetchClient({ apiBaseUrl: "" })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
@@ -157,20 +157,27 @@ export class FetchClient {
    * `FileConflictError` so the editor can ask the user to reload or
    * force-overwrite. The returned `mtimeMs` is the server's stat
    * after the write; callers use it as the OCC baseline for the
-   * next save.
+   * next save. Set `returnMtimeMs: false` only for writes that do
+   * not need a fresh OCC baseline (for example, creating an empty
+   * file before immediately opening/refetching it). That lets remote
+   * sandboxes skip an expensive post-write stat.
    */
   async writeFile(
     path: string,
     content: string,
-    opts?: { expectedMtimeMs?: number },
+    opts?: { expectedMtimeMs?: number; returnMtimeMs?: boolean },
   ): Promise<{ mtimeMs?: number }> {
     try {
+      const body: { path: string; content: string; expectedMtimeMs?: number; returnMtimeMs?: boolean } = {
+        path,
+        content,
+      }
+      if (opts?.expectedMtimeMs != null) body.expectedMtimeMs = opts.expectedMtimeMs
+      if (opts?.returnMtimeMs === false) body.returnMtimeMs = false
       const res = await this.request<{ ok: boolean; mtimeMs?: number }>(
         "POST",
         "/api/v1/files",
-        opts?.expectedMtimeMs != null
-          ? { path, content, expectedMtimeMs: opts.expectedMtimeMs }
-          : { path, content },
+        body,
       )
       return { mtimeMs: res.mtimeMs }
     } catch (err) {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
@@ -108,6 +108,11 @@ export interface FileWriteVariables {
    * if the file has changed since. Omit to force-overwrite.
    */
   expectedMtimeMs?: number
+  /**
+   * Set false for writes that do not need a fresh server mtime. Keeps
+   * remote-sandbox creates fast by avoiding an immediate post-write stat.
+   */
+  returnMtimeMs?: boolean
 }
 
 export interface FileWriteResult {
@@ -118,8 +123,13 @@ export interface FileWriteResult {
 export function useFileWrite(): UseMutationResult<FileWriteResult, Error, FileWriteVariables> {
   const client = useDataClient()
   return useMutation({
-    mutationFn: ({ path, content, expectedMtimeMs }) =>
-      client.writeFile(path, content, expectedMtimeMs != null ? { expectedMtimeMs } : undefined),
+    mutationFn: ({ path, content, expectedMtimeMs, returnMtimeMs }) => {
+      const opts = {
+        ...(expectedMtimeMs != null ? { expectedMtimeMs } : {}),
+        ...(returnMtimeMs === false ? { returnMtimeMs: false } : {}),
+      }
+      return client.writeFile(path, content, Object.keys(opts).length > 0 ? opts : undefined)
+    },
     onSuccess: (_, { path }) => {
       // Single source of truth: emit onto the bus, the centralized
       // invalidator (`useFileEventInvalidation`) handles cache

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -673,7 +673,7 @@ export function FileTreeView({
           addOptimisticEntry(dir, optimisticEntry)
           addedOptimisticPath = newPath
           if (current.kind === "create-file") {
-            await writeFile({ path: newPath, content: "" })
+            await writeFile({ path: newPath, content: "", returnMtimeMs: false })
             // useFileWrite emits changed (it can't tell create from edit);
             // the call site knows this was a creation, so emit here.
             // useCreateDir already emits its own filesystem create event.

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -829,6 +829,7 @@ describe("FileTreePane", () => {
         expect(mockFileWrite).toHaveBeenCalledWith({
           path: "notes.md",
           content: "",
+          returnMtimeMs: false,
         }),
       )
     })
@@ -958,6 +959,7 @@ describe("FileTreePane", () => {
         expect(mockFileWrite).toHaveBeenCalledWith({
           path: "src/child.ts",
           content: "",
+          returnMtimeMs: false,
         }),
       )
     })


### PR DESCRIPTION
## Summary
- add explicit `returnMtimeMs: false` opt-out for `POST /api/v1/files`
- use the fast no-stat write path for file-tree empty-file creation
- keep OCC writes returning mtime even if the caller accidentally opts out
- keep Vercel write+stat fallback non-regressing when the current SDK lacks native `fs.stat`

## Validation
- `pnpm --filter @hachej/boring-agent run test src/server/http/routes/__tests__/file.test.ts src/server/workspace/__tests__/createVercelSandboxWorkspace.test.ts src/server/runtime/modes/__tests__/vercel-sandbox.test.ts`
- `pnpm --filter @hachej/boring-agent run typecheck`
- `pnpm --filter @hachej/boring-workspace run test src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.test.ts`
- `pnpm --filter @hachej/boring-workspace run test src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTree.test.tsx src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx`
- `pnpm --filter @hachej/boring-workspace run typecheck`
- `pnpm --filter @hachej/boring-workspace run build`
- `pnpm --filter @hachej/boring-core run build && pnpm --filter full-app run typecheck`
- autoreview: clean, no accepted/actionable findings

## Direct Vercel sandbox PoC
Current SDK exposed no native `sandbox.fs.stat`; direct `writeFiles` was ~201ms p50 for 4KB, current single-command write+stat was ~360ms p50, but naive `writeFiles + runCommand(stat)` was slower (~553ms p50). This patch therefore only uses no-stat when the caller explicitly does not need mtime.