### PR TITLE
docs: add Seneca AI launch demo script

### DIFF
--- a/docs/seneca-launch-demo-script.md
+++ b/docs/seneca-launch-demo-script.md
@@ -1,0 +1,59 @@
+# Seneca AI — Launch Demo Script
+
+**Target length:** 45–60s
+
+---
+
+## Script
+
+**"After what happened last weekend, one thing is clear: don't let one AI provider own your workflow."**
+
+---
+
+**"Seneca is an open-source, model-agnostic AI workspace. Use local models, European-hosted models, or frontier AI labs — and switch whenever you need."**
+
+---
+
+*Cut to screen. Open the model picker.*
+
+**"For this demo, I'll pick one model."**
+
+---
+
+**"Seneca gives that AI a private remote computer to do real work for you. It can read files, use tools, run tasks, make changes, and show you what changed."**
+
+---
+
+*Show the workspace and `data.csv` in the file tree.*
+
+**"Here I have a CSV file with product metrics. I'll ask the agent:"**
+
+---
+
+*Type this prompt to the agent:*
+
+```txt
+Look at data.csv, find the top 3 trends, and write a report.md with the findings.
+```
+
+---
+
+**"The agent reads the file, analyzes the data, and writes the report back into the workspace."**
+
+---
+
+*Open the report.*
+
+**"Here's the result: a report created from the file, ready for review."**
+
+---
+
+**"Seneca is also extensible. Add plugins, dashboards, document search, internal tools, and workflows connected to your own data."**
+
+---
+
+**"Open-source. Self-hostable. Repo in the comments."**
+
+---
+
+**"Cheers."**


### PR DESCRIPTION
Adds the launch demo narration script (`docs/seneca-launch-demo-script.md`, ~45–60s).

The branding assets that were grouped with this (`logo.svg/png`, `favicon-64.png`, `public/landing.css|js`) turned out to be **already tracked on `main`**, so they're not included here — this PR is just the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)