### PR TITLE
polish(full-app): load Caveat font for arrows + looser hero spacing

### DIFF
--- a/apps/full-app/index.html
+++ b/apps/full-app/index.html
@@ -6,6 +6,13 @@
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <link rel="alternate icon" type="image/png" href="/favicon-64.png" />
     <link rel="apple-touch-icon" href="/logo.png" />
+    <!-- Handwritten font for the public-shell teaching arrow annotations. -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Caveat:wght@600;700&display=swap"
+    />
     <title>Seneca AI</title>
   </head>
   <body>

--- a/apps/full-app/src/front/app.css
+++ b/apps/full-app/src/front/app.css
@@ -127,12 +127,12 @@ body,
 
 .public-chat-first-shell [data-boring-agent-part="empty-state"] > p {
   display: block;
-  /* Match the subhead's own line gap (17px × 1.6 ≈ 10px) so the title → line 1
-     spacing equals the line 1 → line 2 spacing for an even rhythm. */
-  margin-top: 10px;
+  /* Let the subhead breathe: more space from the title and looser leading
+     between the two lines. */
+  margin-top: 18px;
   max-width: 58ch;
   font-size: 17px;
-  line-height: 1.6;
+  line-height: 1.85;
   /* Honor the explicit \n after "Choose the AI you trust." in the subhead. */
   white-space: pre-line;
 }
@@ -208,7 +208,7 @@ body,
   align-items: center;
   justify-content: center;
   gap: 8px;
-  margin-top: 22px;
+  margin-top: 30px;
   font-size: 12.5px;
   line-height: 1.4;
 }


### PR DESCRIPTION
Two small no-auth landing tweaks (follow-up to #319):

- **Arrow font fix** — the teaching arrows (`Ask your AI here` / `Review its work here`) requested `"Caveat"` but it was never loaded, so they fell back to generic `cursive`. Adds the Caveat Google-Fonts `<link>` (with preconnect) in `index.html`.
- **Hero breathing room** — looser subhead leading (`1.6 → 1.85`), more title→subhead gap (`10 → 18px`), and more space above the footer line (`22 → 30px`).

CSS/HTML only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)