### PR TITLE
fix(full-app): hide landing arrows + sign-in card on cramped viewports

### DIFF
--- a/apps/full-app/src/front/app.css
+++ b/apps/full-app/src/front/app.css
@@ -83,8 +83,12 @@ body,
   transform: rotate(-4deg);
 }
 
-@media (max-width: 1100px) {
-  .public-arrow {
+/* Cramped viewports: the (tall) model-picker menu and composer collide with the
+   fixed teaching arrows and the bottom-left sign-in card. Drop those decorations
+   on small/short screens — the top-right "Sign in" button still opens auth. */
+@media (max-width: 1366px), (max-height: 960px) {
+  .public-arrow,
+  .public-chat-first-shell > aside {
     display: none;
   }
 }


### PR DESCRIPTION
On smaller/shorter screens the (tall) model-picker menu overlapped the fixed teaching arrows and the bottom-left sign-in card. Hide both below `1366px` wide **or** `960px` tall — the top-right "Sign in" button still opens auth on those sizes.

CSS-only, scoped to the public no-auth shell. 🤖 Generated with [Claude Code](https://claude.com/claude-code)