### PR TITLE
fix(core): enforce email verification before workspace access

### DIFF
--- a/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
+++ b/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
@@ -39,7 +39,8 @@ vi.mock('../../../front/index.js', () => ({
   UserMenu: () => <div>User menu</div>,
   ThemeToggle: () => <div>Theme toggle</div>,
   WorkspaceSwitcher: () => <div>Switcher</div>,
-  routes: { signin: '/auth/signin', forgotPassword: '/auth/forgot-password' },
+  routes: { signin: '/auth/signin', forgotPassword: '/auth/forgot-password', verifyEmail: '/auth/verify-email' },
+  useConfig: () => ({ features: { emailVerification: false } }),
   useCurrentWorkspace: () => currentWorkspaceId ? ({ id: currentWorkspaceId, name: 'Workspace A' }) : null,
   useSession: () => unstableSessionObject && sessionState.data
     ? { data: { user: { ...sessionState.data.user } }, isPending: sessionState.isPending }

--- a/packages/core/src/app/front/chatFirst/AuthCard.tsx
+++ b/packages/core/src/app/front/chatFirst/AuthCard.tsx
@@ -1,7 +1,9 @@
 import { useState, type FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { isRuntimeEmailVerificationEnabled } from '../../../shared/authPolicy.js'
 import {
   routes,
+  useConfig,
   useSignIn,
   useSignUp,
 } from '../../../front/index.js'
@@ -14,6 +16,7 @@ export function AuthCard({
   onClose?: () => void
 }) {
   const navigate = useNavigate()
+  const config = useConfig()
   const signIn = useSignIn()
   const signUp = useSignUp()
   const [mode, setMode] = useState<'signin' | 'signup'>('signin')
@@ -36,6 +39,10 @@ export function AuthCard({
         return
       }
       onClose?.()
+      if (mode === 'signup' && isRuntimeEmailVerificationEnabled(config)) {
+        navigate(routes.verifyEmail, { replace: true })
+        return
+      }
       navigate(returnTo, { replace: true })
     } catch (err) {
       setError(err instanceof Error ? err.message : `${mode === 'signin' ? 'Sign in' : 'Sign up'} failed`)

--- a/packages/core/src/front/AuthGate.tsx
+++ b/packages/core/src/front/AuthGate.tsx
@@ -6,6 +6,15 @@ import { routes } from './utils.js'
 
 const DEFAULT_GRACE_MS = 30_000
 const UNSAFE_REDIRECT_RE = /[\0\r\n<>"'`]/
+const UNVERIFIED_ALLOWED_PATHS = new Set<string>([
+  routes.signup,
+  routes.forgotPassword,
+  routes.resetPassword,
+  routes.verifyEmail,
+  routes.authError,
+  routes.callbackGithub,
+  routes.callbackGoogle,
+])
 
 export interface AuthGateLocation {
   pathname: string
@@ -20,6 +29,7 @@ export interface AuthGateProps {
   location?: AuthGateLocation
   navigate?: (to: string, options?: { replace?: boolean }) => void
   now?: () => number
+  requireEmailVerification?: boolean
 }
 
 function normalizePath(pathname: string): string {
@@ -92,6 +102,7 @@ export function AuthGate({
   location,
   navigate,
   now,
+  requireEmailVerification = false,
 }: AuthGateProps) {
   const session = useSession()
   const nullSinceRef = useRef<number | null>(null)
@@ -104,6 +115,7 @@ export function AuthGate({
     () => publicPaths.map(normalizePublicPath),
     [publicPaths],
   )
+  const isEmailVerified = session.data?.user?.emailVerified ?? false
 
   useEffect(() => {
     return () => {
@@ -124,6 +136,16 @@ export function AuthGate({
 
     if (session.data) {
       nullSinceRef.current = null
+
+      // Better-auth signs users in immediately after signup. When email verification
+      // is available, keep unverified signed-in users in the verification flow
+      // instead of letting the fresh session through to the workspace.
+      if (requireEmailVerification && !isEmailVerified) {
+        if (!UNVERIFIED_ALLOWED_PATHS.has(pathname)) {
+          goTo(routes.verifyEmail, { replace: true })
+          return
+        }
+      }
 
       if (pathname === routes.signin) {
         const destination = readSafeRedirect(currentLocation.search) ?? '/'
@@ -160,7 +182,7 @@ export function AuthGate({
       goTo(`${routes.signin}?redirect=${encodeURIComponent(currentPath)}`, { replace: true })
     }, remainingMs)
     redirectTimerRef.current.unref?.()
-  }, [currentLocation, goTo, graceMs, normalizedPublicPaths, readNow, session.data, session.isPending])
+  }, [currentLocation, goTo, graceMs, isEmailVerified, normalizedPublicPaths, readNow, requireEmailVerification, session.data, session.isPending])
 
   const pathname = normalizePath(currentLocation.pathname)
   if (session.isPending && !isPublicPath(pathname, normalizedPublicPaths)) return null

--- a/packages/core/src/front/AuthGate.tsx
+++ b/packages/core/src/front/AuthGate.tsx
@@ -69,6 +69,18 @@ function isPublicPath(pathname: string, publicPaths: string[]): boolean {
   })
 }
 
+function shouldBlockUnverifiedUser(
+  pathname: string,
+  hasSession: boolean,
+  requireEmailVerification: boolean,
+  isEmailVerified: boolean,
+): boolean {
+  return hasSession
+    && requireEmailVerification
+    && !isEmailVerified
+    && !UNVERIFIED_ALLOWED_PATHS.has(normalizePath(pathname))
+}
+
 function readSafeRedirect(search?: string): string | null {
   const redirect = new URLSearchParams(normalizeSearch(search)).get('redirect')
   if (!redirect) return null
@@ -140,11 +152,9 @@ export function AuthGate({
       // Better-auth signs users in immediately after signup. When email verification
       // is available, keep unverified signed-in users in the verification flow
       // instead of letting the fresh session through to the workspace.
-      if (requireEmailVerification && !isEmailVerified) {
-        if (!UNVERIFIED_ALLOWED_PATHS.has(pathname)) {
-          goTo(routes.verifyEmail, { replace: true })
-          return
-        }
+      if (shouldBlockUnverifiedUser(pathname, true, requireEmailVerification, isEmailVerified)) {
+        goTo(routes.verifyEmail, { replace: true })
+        return
       }
 
       if (pathname === routes.signin) {
@@ -185,6 +195,7 @@ export function AuthGate({
   }, [currentLocation, goTo, graceMs, isEmailVerified, normalizedPublicPaths, readNow, requireEmailVerification, session.data, session.isPending])
 
   const pathname = normalizePath(currentLocation.pathname)
+  if (shouldBlockUnverifiedUser(pathname, Boolean(session.data), requireEmailVerification, isEmailVerified)) return null
   if (session.isPending && !isPublicPath(pathname, normalizedPublicPaths)) return null
 
   return <>{children}</>

--- a/packages/core/src/front/CoreFront.tsx
+++ b/packages/core/src/front/CoreFront.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { Helmet, HelmetProvider } from 'react-helmet-async'
 
 import { AppErrorBoundary } from './AppErrorBoundary.js'
-import { ConfigProvider } from './ConfigProvider.js'
+import { ConfigProvider, useConfig } from './ConfigProvider.js'
 import { ThemeProvider } from './ThemeProvider.js'
 import { AuthProvider } from './auth/AuthProvider.js'
 import { UserIdentityProvider } from './auth/UserIdentityProvider.js'
@@ -23,6 +23,7 @@ import { InvitesPage } from './workspace/InvitesPage.js'
 import { MembersPage } from './workspace/MembersPage.js'
 import { WorkspaceSettingsPage } from './workspace/WorkspaceSettingsPage.js'
 import { InviteAcceptPage } from './auth/InviteAcceptPage.js'
+import { isRuntimeEmailVerificationEnabled } from '../shared/authPolicy.js'
 import { routes } from './utils.js'
 
 export interface CoreFrontAuthPagesOverride {
@@ -69,6 +70,7 @@ function createDefaultQueryClient(): QueryClient {
 }
 
 function RouterAuthGate({ children, publicPaths }: { children: ReactNode; publicPaths?: string[] }) {
+  const config = useConfig()
   const location = useLocation()
   const navigate = useNavigate()
   const authLocation = useMemo(
@@ -87,6 +89,7 @@ function RouterAuthGate({ children, publicPaths }: { children: ReactNode; public
       location={authLocation}
       navigate={navigateWithinRouter}
       publicPaths={publicPaths}
+      requireEmailVerification={isRuntimeEmailVerificationEnabled(config)}
     >
       {children}
     </AuthGate>

--- a/packages/core/src/front/WorkspaceAuthProvider.tsx
+++ b/packages/core/src/front/WorkspaceAuthProvider.tsx
@@ -2,8 +2,10 @@ import { createContext, useContext } from 'react'
 import type { ReactNode } from 'react'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { matchPath, useLocation, useParams } from 'react-router-dom'
+import { useOptionalConfig } from './ConfigProvider.js'
 import { useSession } from './auth/AuthProvider.js'
 import { apiFetchJson, getHttpErrorDetail } from './utils.js'
+import { canUseProtectedApi, isRuntimeEmailVerificationEnabled } from '../shared/authPolicy.js'
 import type { MemberRole, Workspace } from '../shared/types.js'
 
 type WorkspaceDetail = {
@@ -101,12 +103,17 @@ export function WorkspaceAuthProvider({
   const queryClient = useQueryClient()
   const routeWorkspaceId = id?.trim() ? id : workspaceIdFromPath(location.pathname, workspaceRoute, workspaceIdParam)
   const session = useSession()
-  const isAuthenticated = Boolean(session.data?.user)
+  const config = useOptionalConfig()
+  const user = session.data?.user ?? null
+  const canQueryProtectedApi = canUseProtectedApi(
+    user,
+    isRuntimeEmailVerificationEnabled(config),
+  )
 
   const workspacesQuery = useQuery({
     queryKey: WORKSPACES_QUERY_KEY,
     queryFn: fetchWorkspaces,
-    enabled: isAuthenticated,
+    enabled: canQueryProtectedApi,
   })
 
   const defaultWorkspace =
@@ -128,14 +135,14 @@ export function WorkspaceAuthProvider({
       }
       return fetchWorkspace(resolvedId)
     },
-    enabled: isAuthenticated && resolvedId !== null,
+    enabled: canQueryProtectedApi && resolvedId !== null,
   })
 
   const detail = detailQuery.data ?? cachedDetail ?? null
   const workspace = detailQuery.isError ? null : detail?.workspace ?? null
   const role = detailQuery.isError ? null : detail?.role ?? null
   const routeStatus: WorkspaceRouteStatus = (() => {
-    if (!isAuthenticated) return { status: 'idle', workspaceId: routeWorkspaceId }
+    if (!canQueryProtectedApi) return { status: 'idle', workspaceId: routeWorkspaceId }
     if (routeWorkspaceId === null) return { status: 'idle', workspaceId: null }
     if (detailQuery.isError) return routeStatusFromError(routeWorkspaceId, detailQuery.error)
     if (detailQuery.isPending && !detail) return { status: 'loading', workspaceId: routeWorkspaceId }

--- a/packages/core/src/front/__tests__/AuthGate.test.tsx
+++ b/packages/core/src/front/__tests__/AuthGate.test.tsx
@@ -288,6 +288,7 @@ describe('AuthGate', () => {
     )
 
     expect(navigate).toHaveBeenCalledWith('/auth/verify-email', { replace: true })
+    expect(screen.queryByText('Protected Content')).toBeNull()
   })
 
   it('allows unverified users on verify-email page when requireEmailVerification is true', () => {

--- a/packages/core/src/front/__tests__/AuthGate.test.tsx
+++ b/packages/core/src/front/__tests__/AuthGate.test.tsx
@@ -21,14 +21,14 @@ import { AuthProvider } from '../auth/AuthProvider'
 import { AuthGate } from '../AuthGate'
 import type { AuthGateLocation } from '../AuthGate'
 
-function makeAuthenticatedSession() {
+function makeSession({ emailVerified = true }: { emailVerified?: boolean } = {}) {
   return {
     data: {
       user: {
         id: 'u1',
         email: 'test@test.dev',
         name: 'Test',
-        emailVerified: true,
+        emailVerified,
         image: null,
         createdAt: new Date('2026-01-01'),
         updatedAt: new Date('2026-01-02'),
@@ -38,6 +38,10 @@ function makeAuthenticatedSession() {
     isPending: false,
     error: null,
   }
+}
+
+function makeAuthenticatedSession() {
+  return makeSession()
 }
 
 function makeNullSession() {
@@ -54,6 +58,7 @@ interface HarnessProps {
   now: () => number
   graceMs?: number
   publicPaths?: string[]
+  requireEmailVerification?: boolean
   children?: ReactNode
 }
 
@@ -63,6 +68,7 @@ function Harness({
   now,
   graceMs,
   publicPaths,
+  requireEmailVerification,
   children,
 }: HarnessProps) {
   return (
@@ -73,6 +79,7 @@ function Harness({
         now={now}
         graceMs={graceMs}
         publicPaths={publicPaths}
+        requireEmailVerification={requireEmailVerification}
       >
         {children ?? <div>Protected Content</div>}
       </AuthGate>
@@ -264,5 +271,145 @@ describe('AuthGate', () => {
     expect(navigate).toHaveBeenCalledWith('/auth/signin?redirect=%2Fprojects%2Fabc%2Fsettings', {
       replace: true,
     })
+  })
+
+  it('redirects unverified users to verify-email page when requireEmailVerification is true', () => {
+    const navigate = vi.fn()
+
+    mockUseSession.mockReturnValue(makeSession({ emailVerified: false }))
+
+    render(
+      <Harness
+        location={{ pathname: '/dashboard' }}
+        navigate={navigate}
+        now={() => 0}
+        requireEmailVerification
+      />,
+    )
+
+    expect(navigate).toHaveBeenCalledWith('/auth/verify-email', { replace: true })
+  })
+
+  it('allows unverified users on verify-email page when requireEmailVerification is true', () => {
+    const navigate = vi.fn()
+
+    mockUseSession.mockReturnValue(makeSession({ emailVerified: false }))
+
+    render(
+      <Harness
+        location={{ pathname: '/auth/verify-email' }}
+        navigate={navigate}
+        now={() => 0}
+        requireEmailVerification
+      />,
+    )
+
+    expect(navigate).not.toHaveBeenCalled()
+    expect(screen.getByText('Protected Content')).toBeTruthy()
+  })
+
+  it('allows unverified users on auth pages when requireEmailVerification is true', () => {
+    const navigate = vi.fn()
+
+    mockUseSession.mockReturnValue(makeSession({ emailVerified: false }))
+
+    // Auth pages are allowed for unverified users
+    render(
+      <Harness
+        location={{ pathname: '/auth/verify-email' }}
+        navigate={navigate}
+        now={() => 0}
+        requireEmailVerification
+      />,
+    )
+
+    expect(navigate).not.toHaveBeenCalled()
+
+    // Also allow signup page
+    navigate.mockClear()
+    const { rerender } = render(
+      <Harness
+        location={{ pathname: '/auth/signup' }}
+        navigate={navigate}
+        now={() => 0}
+        requireEmailVerification
+      />,
+    )
+
+    expect(navigate).not.toHaveBeenCalled()
+
+    // Also allow forgot-password page
+    navigate.mockClear()
+    rerender(
+      <Harness
+        location={{ pathname: '/auth/forgot-password' }}
+        navigate={navigate}
+        now={() => 0}
+        requireEmailVerification
+      />,
+    )
+
+    expect(navigate).not.toHaveBeenCalled()
+  })
+
+  it('redirects unverified users away from non-allowlisted auth pages', () => {
+    const navigate = vi.fn()
+
+    mockUseSession.mockReturnValue(makeSession({ emailVerified: false }))
+
+    render(
+      <Harness
+        location={{ pathname: '/auth/new-future-page' }}
+        navigate={navigate}
+        now={() => 0}
+        requireEmailVerification
+      />,
+    )
+
+    expect(navigate).toHaveBeenCalledWith('/auth/verify-email', { replace: true })
+  })
+
+  it('does not redirect verified users when requireEmailVerification is true', () => {
+    let nowMs = 0
+    const now = () => nowMs
+    const navigate = vi.fn()
+
+    mockUseSession.mockReturnValue(makeAuthenticatedSession())
+
+    render(
+      <Harness
+        location={{ pathname: '/dashboard' }}
+        navigate={navigate}
+        now={now}
+        requireEmailVerification
+      />,
+    )
+
+    nowMs += 60_000
+    vi.advanceTimersByTime(60_000)
+    expect(navigate).not.toHaveBeenCalled()
+    expect(screen.getByText('Protected Content')).toBeTruthy()
+  })
+
+  it('does not enforce email verification when requireEmailVerification is false', () => {
+    let nowMs = 0
+    const now = () => nowMs
+    const navigate = vi.fn()
+
+    mockUseSession.mockReturnValue(makeSession({ emailVerified: false }))
+
+    render(
+      <Harness
+        location={{ pathname: '/dashboard' }}
+        navigate={navigate}
+        now={now}
+        requireEmailVerification={false}
+      />,
+    )
+
+    nowMs += 60_000
+    vi.advanceTimersByTime(60_000)
+    expect(navigate).not.toHaveBeenCalled()
+    expect(screen.getByText('Protected Content')).toBeTruthy()
   })
 })

--- a/packages/core/src/front/__tests__/ConfigProvider.test.tsx
+++ b/packages/core/src/front/__tests__/ConfigProvider.test.tsx
@@ -22,7 +22,7 @@ const VALID_CONFIG: RuntimeConfig = {
   appName: 'Test App',
   appLogo: null,
   apiBase: 'http://localhost:3000',
-  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, emailVerification: false },
 }
 
 const FAST_BACKOFF = [0, 0, 0]

--- a/packages/core/src/front/__tests__/CoreFront.test.tsx
+++ b/packages/core/src/front/__tests__/CoreFront.test.tsx
@@ -50,7 +50,7 @@ function mockConfigEndpoint() {
     appName: 'Test App',
     appLogo: null,
     apiBase: '',
-    features: { githubOauth: false, googleOauth: false, invitesEnabled: false, sendWelcomeEmail: false },
+    features: { githubOauth: false, googleOauth: false, invitesEnabled: false, sendWelcomeEmail: false, emailVerification: false },
   }
   useMswHandler(async (input) => {
     const url =

--- a/packages/core/src/front/__tests__/SignUpPage.test.tsx
+++ b/packages/core/src/front/__tests__/SignUpPage.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ReactNode } from 'react'
+import { MemoryRouter, useLocation } from 'react-router-dom'
 
 const { mockUseOptionalConfig } = vi.hoisted(() => ({
   mockUseOptionalConfig: vi.fn(),
@@ -38,7 +39,16 @@ const BEAD_ID = 'boring-ui-v2-1pas'
 const GOOGLE_BEAD_ID = 'boring-ui-v2-reorg-mip7'
 
 function Wrapper({ children }: { children: ReactNode }) {
-  return <AuthProvider>{children}</AuthProvider>
+  return (
+    <MemoryRouter>
+      <AuthProvider>{children}</AuthProvider>
+    </MemoryRouter>
+  )
+}
+
+function CurrentPath() {
+  const location = useLocation()
+  return <div data-testid="current-path">{location.pathname}</div>
 }
 
 beforeEach(() => {
@@ -94,6 +104,33 @@ describe('SignUpPage', () => {
         expect(screen.getByText(/check your email/i)).toBeTruthy(),
       )
       assertionPassed('signup-check-email-state')
+    }),
+  )
+
+  it(
+    'redirects to email verification flow after signup when email verification is enabled',
+    withBeadId(BEAD_ID, async ({ assertionPassed }) => {
+      mockUseOptionalConfig.mockReturnValue({ features: { googleOauth: false, emailVerification: true } })
+      mockSignUpEmail.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null })
+
+      render(
+        <>
+          <SignUpPage />
+          <CurrentPath />
+        </>,
+        { wrapper: Wrapper },
+      )
+
+      const user = userEvent.setup()
+      await user.type(screen.getByLabelText(/name/i), 'Test User')
+      await user.type(screen.getByLabelText(/email/i), 'test@example.com')
+      await user.type(screen.getByLabelText(/password/i), 'secret12345')
+      await user.click(screen.getByRole('button', { name: /sign up/i }))
+
+      await waitFor(() =>
+        expect(screen.getByTestId('current-path').textContent).toBe('/auth/verify-email'),
+      )
+      assertionPassed('signup-redirects-verify-email')
     }),
   )
 

--- a/packages/core/src/front/__tests__/UserIdentityProvider.test.tsx
+++ b/packages/core/src/front/__tests__/UserIdentityProvider.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../utils.js', async (importOriginal) => {
   }
 })
 
+import { ConfigProvider } from '../ConfigProvider'
 import { AuthProvider } from '../auth/AuthProvider'
 import { UserIdentityProvider, useUser } from '../auth/UserIdentityProvider'
 
@@ -33,13 +34,17 @@ beforeEach(() => {
   vi.clearAllMocks()
 })
 
-function createWrapper() {
+function createWrapper(opts?: { withConfig?: boolean }) {
   return function Wrapper({ children }: { children: ReactNode }) {
-    return (
+    const content = (
       <AuthProvider baseURL="http://localhost:3000">
         <UserIdentityProvider>{children}</UserIdentityProvider>
       </AuthProvider>
     )
+
+    return opts?.withConfig
+      ? <ConfigProvider retryBackoff={[]}>{content}</ConfigProvider>
+      : content
   }
 }
 
@@ -55,6 +60,47 @@ describe('UserIdentityProvider', () => {
       wrapper: createWrapper(),
     })
 
+    expect(result.current).toBeNull()
+  })
+
+  it('does not fetch /api/v1/me when email verification is required and session is unverified', async () => {
+    mockApiFetchJson.mockImplementation(async (url: string) => {
+      if (url === '/api/v1/config') {
+        return {
+          appId: 'test-app',
+          appName: 'Test App',
+          appLogo: null,
+          apiBase: '',
+          features: {
+            githubOauth: false,
+            googleOauth: false,
+            invitesEnabled: true,
+            sendWelcomeEmail: true,
+            emailVerification: true,
+          },
+        }
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    mockUseSession.mockReturnValue({
+      data: {
+        user: { id: 'u1', email: 'test@test.dev', name: 'Test User', emailVerified: false },
+        session: { expiresAt: new Date('2026-02-01') },
+      },
+      isPending: false,
+      error: null,
+    })
+
+    const { result } = renderHook(() => useUser(), {
+      wrapper: createWrapper({ withConfig: true }),
+    })
+
+    await waitFor(() => {
+      expect(mockApiFetchJson).toHaveBeenCalledWith('/api/v1/config')
+    })
+
+    expect(mockApiFetchJson).not.toHaveBeenCalledWith('/api/v1/me')
     expect(result.current).toBeNull()
   })
 

--- a/packages/core/src/front/__tests__/VerifyEmailPage.test.tsx
+++ b/packages/core/src/front/__tests__/VerifyEmailPage.test.tsx
@@ -66,6 +66,26 @@ describe('VerifyEmailPage', () => {
   )
 
   it(
+    'shows check-your-email UI for signed-in users redirected without a token',
+    withBeadId(BEAD_ID, async ({ assertionPassed }) => {
+      mockUseSession.mockReturnValue({
+        data: { user: { id: 'u1', email: 'test@test.dev', emailVerified: false }, expiresAt: '' },
+        isPending: false,
+        error: null,
+      })
+      window.history.pushState({}, '', '/auth/verify-email')
+
+      render(<VerifyEmailPage />, { wrapper: Wrapper })
+
+      expect(screen.getByText(/check your email/i)).toBeTruthy()
+      expect(screen.getByText(/we sent a verification link/i)).toBeTruthy()
+      expect(screen.getByRole('button', { name: /resend verification email/i })).not.toBeDisabled()
+      expect(mockVerifyEmail).not.toHaveBeenCalled()
+      assertionPassed('no-token-signed-in-check-email-ui')
+    }),
+  )
+
+  it(
     'shows verifying state then verified on success',
     withBeadId(BEAD_ID, async ({ assertionPassed }) => {
       let resolveVerify!: (v: unknown) => void

--- a/packages/core/src/front/__tests__/WorkspaceAuthProvider.test.tsx
+++ b/packages/core/src/front/__tests__/WorkspaceAuthProvider.test.tsx
@@ -29,7 +29,8 @@ vi.mock('../auth/AuthProvider', () => ({
 }))
 
 import { withBeadId } from '../../server/__tests__/_setup'
-import type { MemberRole, Workspace } from '../../shared/types'
+import type { MemberRole, RuntimeConfig, Workspace } from '../../shared/types'
+import { ConfigProvider } from '../ConfigProvider'
 import {
   WORKSPACES_QUERY_KEY,
   WorkspaceAuthProvider,
@@ -49,6 +50,20 @@ const WS_1: Workspace = {
   createdAt: '2026-01-01T00:00:00.000Z',
   deletedAt: null,
   isDefault: true,
+}
+
+const RUNTIME_CONFIG: RuntimeConfig = {
+  appId: 'test-app',
+  appName: 'Test App',
+  appLogo: null,
+  apiBase: '',
+  features: {
+    githubOauth: false,
+    googleOauth: false,
+    invitesEnabled: true,
+    sendWelcomeEmail: true,
+    emailVerification: true,
+  },
 }
 
 const WS_2: Workspace = {
@@ -81,29 +96,38 @@ function Probe() {
 function renderWithRouter(
   initialPath: string,
   queryClient: QueryClient,
+  options?: { withConfig?: boolean },
 ) {
+  const routes = (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route
+          path="/workspace/:id"
+          element={
+            <WorkspaceAuthProvider>
+              <Probe />
+            </WorkspaceAuthProvider>
+          }
+        />
+        <Route
+          path="/"
+          element={
+            <WorkspaceAuthProvider>
+              <Probe />
+            </WorkspaceAuthProvider>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  const content = options?.withConfig
+    ? <ConfigProvider retryBackoff={[]}>{routes}</ConfigProvider>
+    : routes
+
   return render(
     <QueryClientProvider client={queryClient}>
-      <MemoryRouter initialEntries={[initialPath]}>
-        <Routes>
-          <Route
-            path="/workspace/:id"
-            element={
-              <WorkspaceAuthProvider>
-                <Probe />
-              </WorkspaceAuthProvider>
-            }
-          />
-          <Route
-            path="/"
-            element={
-              <WorkspaceAuthProvider>
-                <Probe />
-              </WorkspaceAuthProvider>
-            }
-          />
-        </Routes>
-      </MemoryRouter>
+      {content}
     </QueryClientProvider>,
   )
 }
@@ -118,6 +142,22 @@ function mockWorkspaceDetail(ws: Workspace, role: MemberRole) {
           : input.url
     if (!url.endsWith(`/api/v1/workspaces/${ws.id}`)) return undefined
     return new Response(JSON.stringify({ workspace: ws, role }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  })
+}
+
+function mockConfig(config: RuntimeConfig) {
+  useMswHandler(async (input) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url
+    if (!url.endsWith('/api/v1/config')) return undefined
+    return new Response(JSON.stringify(config), {
       status: 200,
       headers: { 'content-type': 'application/json' },
     })
@@ -183,6 +223,21 @@ function setPendingSession() {
   mockSessionState.current = { data: null, isPending: true, error: null }
 }
 
+function setUnverifiedSession() {
+  mockSessionState.current = {
+    ...mockSessionState.current,
+    data: mockSessionState.current.data
+      ? {
+          ...mockSessionState.current.data,
+          user: {
+            ...mockSessionState.current.data.user,
+            emailVerified: false,
+          },
+        }
+      : null,
+  }
+}
+
 function waitOneTick() {
   return new Promise((resolve) => setTimeout(resolve, 0))
 }
@@ -192,6 +247,40 @@ afterEach(() => {
 })
 
 describe('WorkspaceAuthProvider', () => {
+  it(
+    'does not fetch workspace list or detail when email verification is required and user is unverified',
+    withBeadId(BEAD_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      let workspaceRequests = 0
+      setUnverifiedSession()
+      mockConfig(RUNTIME_CONFIG)
+
+      useMswHandler(async (input) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url
+        if (url.includes('/api/v1/workspaces')) {
+          workspaceRequests += 1
+          return new Response(JSON.stringify({ workspaces: [WS_1] }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        }
+        return undefined
+      })
+
+      renderWithRouter(`/workspace/${WS_1.id}`, qc, { withConfig: true })
+      await waitFor(() => expect(screen.getByTestId('ws-name').textContent).toBe('none'))
+      await waitOneTick()
+
+      expect(workspaceRequests).toBe(0)
+      assertionPassed('workspace-unverified-no-fetch')
+    }),
+  )
+
   it(
     'does not fetch workspace list or detail before auth resolves',
     withBeadId(BEAD_ID, async ({ assertionPassed }) => {

--- a/packages/core/src/front/auth/SignUpPage.tsx
+++ b/packages/core/src/front/auth/SignUpPage.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, Input, Label } from '@hachej/boring-ui-kit'
 import { useSignUp } from './AuthProvider.js'
 import { GoogleAuthButton } from './GoogleAuthButton.js'
+import { isRuntimeEmailVerificationEnabled } from '../../shared/authPolicy.js'
 import { useOptionalConfig } from '../ConfigProvider.js'
 import { routes } from '../utils.js'
 
@@ -26,6 +28,7 @@ function readGoogleAuthError(): string | null {
 
 export function SignUpPage() {
   const signUp = useSignUp()
+  const navigate = useNavigate()
   const config = useOptionalConfig()
   const [serverError, setServerError] = useState<string | null>(null)
   const [oauthError, setOauthError] = useState<string | null>(() => readGoogleAuthError())
@@ -60,6 +63,8 @@ export function SignUpPage() {
       )
       if (result.error) {
         setServerError(result.error.message ?? 'Sign up failed')
+      } else if (isRuntimeEmailVerificationEnabled(config)) {
+        navigate(routes.verifyEmail, { replace: true })
       } else {
         setSuccess(true)
       }

--- a/packages/core/src/front/auth/UserIdentityProvider.tsx
+++ b/packages/core/src/front/auth/UserIdentityProvider.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useEffect, useState, useRef } from 'react'
 import type { ReactNode } from 'react'
+import { canUseProtectedApi, isRuntimeEmailVerificationEnabled } from '../../shared/authPolicy.js'
 import { useSession } from './AuthProvider.js'
+import { useOptionalConfig } from '../ConfigProvider.js'
 import { apiFetchJson } from '../utils.js'
 import type { User } from '../../shared/types.js'
 
@@ -25,12 +27,17 @@ export interface UserIdentityProviderProps {
 
 export function UserIdentityProvider({ children }: UserIdentityProviderProps) {
   const { data: session } = useSession()
+  const config = useOptionalConfig()
+  const canFetchIdentity = canUseProtectedApi(
+    session?.user,
+    isRuntimeEmailVerificationEnabled(config),
+  )
   const [identity, setIdentity] = useState<UserIdentity | null>(null)
   const fetchedForRef = useRef<string | null>(null)
   const lastFetchRef = useRef(0)
 
   useEffect(() => {
-    if (!session?.user) {
+    if (!session?.user || !canFetchIdentity) {
       setIdentity(null)
       fetchedForRef.current = null
       return
@@ -57,7 +64,7 @@ export function UserIdentityProvider({ children }: UserIdentityProviderProps) {
       })
 
     return () => { cancelled = true }
-  }, [session?.user?.id])
+  }, [canFetchIdentity, session?.user?.id])
 
   return <UserContext.Provider value={identity}>{children}</UserContext.Provider>
 }

--- a/packages/core/src/front/auth/VerifyEmailPage.tsx
+++ b/packages/core/src/front/auth/VerifyEmailPage.tsx
@@ -191,6 +191,8 @@ export function VerifyEmailPage() {
     )
   }
 
+  const isWaitingForEmailClick = status === 'no-token' && Boolean(sessionEmail)
+
   // 'invalid' or 'no-token'
   return (
     <div className="flex min-h-screen items-center justify-center p-4">
@@ -203,11 +205,13 @@ export function VerifyEmailPage() {
           </div>
         )}
         <CardHeader>
-          <CardTitle>Invalid verification link</CardTitle>
+          <CardTitle>{isWaitingForEmailClick ? 'Check your email' : 'Invalid verification link'}</CardTitle>
           <CardDescription>
-            {status === 'no-token'
-              ? 'No verification token found. Check the link in your email.'
-              : 'This verification link is invalid. Request a new one below.'}
+            {isWaitingForEmailClick
+              ? 'We sent a verification link to your email address. Please check your inbox to continue.'
+              : status === 'no-token'
+                ? 'No verification token found. Check the link in your email.'
+                : 'This verification link is invalid. Request a new one below.'}
           </CardDescription>
         </CardHeader>
         <CardContent>{resendSection}</CardContent>

--- a/packages/core/src/server/app/__tests__/routes.test.ts
+++ b/packages/core/src/server/app/__tests__/routes.test.ts
@@ -50,7 +50,11 @@ let sessionCookie: string
 let sessionUserId: string
 let sessionUserEmail: string
 
-async function createSessionUser(prefix: string): Promise<{
+async function verifyUserEmail(userId: string): Promise<void> {
+  await rawSql`UPDATE users SET email_verified = true WHERE id = ${userId}`
+}
+
+async function createSessionUser(prefix: string, opts?: { verified?: boolean }): Promise<{
   id: string
   email: string
   cookie: string
@@ -73,6 +77,9 @@ async function createSessionUser(prefix: string): Promise<{
   const cookie = cookies.map((c) => c.split(';')[0]).join('; ')
 
   const body = signupRes.json() as { user: { id: string; email: string } }
+  if (opts?.verified !== false) {
+    await verifyUserEmail(body.user.id)
+  }
   return { id: body.user.id, email: body.user.email, cookie }
 }
 
@@ -116,25 +123,10 @@ beforeAll(async () => {
 
   await app.ready()
 
-  const signupRes = await app.inject({
-    method: 'POST',
-    url: '/auth/sign-up/email',
-    payload: {
-      name: 'Routes Test User',
-      email: 'routes-test@routes-test.dev',
-      password: 'Zk8$mN!qR2xFgWpJ',
-    },
-  })
-
-  const setCookie = signupRes.headers['set-cookie']
-  if (setCookie) {
-    const cookies = Array.isArray(setCookie) ? setCookie : [setCookie]
-    sessionCookie = cookies.map((c) => c.split(';')[0]).join('; ')
-  }
-
-  const signupBody = signupRes.json() as { user: { id: string; email: string } }
-  sessionUserId = signupBody.user.id
-  sessionUserEmail = signupBody.user.email
+  const sessionUser = await createSessionUser('routes-test')
+  sessionCookie = sessionUser.cookie
+  sessionUserId = sessionUser.id
+  sessionUserEmail = sessionUser.email
 })
 
 afterAll(async () => {
@@ -287,7 +279,7 @@ describe('GET /api/v1/config', () => {
       appName: 'Test App',
       appLogo: null,
       apiBase: 'http://localhost:3000',
-      features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true },
+      features: { githubOauth: false, googleOauth: false, invitesEnabled: true, sendWelcomeEmail: true, emailVerification: true },
     })
     expect(body.auth).toBeUndefined()
     expect(body.databaseUrl).toBeUndefined()
@@ -300,6 +292,19 @@ describe('GET /api/v1/me', () => {
     const res = await app.inject({ method: 'GET', url: '/api/v1/me' })
     expect(res.statusCode).toBe(401)
     expect(res.json().code).toBe('unauthorized')
+  })
+
+  it('returns 403 for unverified sessions when email verification is enabled', async () => {
+    const user = await createSessionUser('unverified-me', { verified: false })
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/me',
+      headers: { cookie: user.cookie },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.json().code).toBe('email_not_verified')
   })
 
   it('returns user and settings with valid session', async () => {

--- a/packages/core/src/server/app/capabilities.ts
+++ b/packages/core/src/server/app/capabilities.ts
@@ -4,6 +4,7 @@ import type { CapabilitiesContributor } from './types.js'
 import { existsSync, readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { isCoreEmailVerificationEnabled } from '../../shared/authPolicy.js'
 import { isGoogleOauthUsable } from '../config/loadConfig.js'
 
 let cachedVersion: string | undefined
@@ -52,7 +53,7 @@ export function registerCapabilities(app: FastifyInstance) {
     },
   )
 
-  const hasMail = !!app.config.auth.mail
+  const emailVerificationEnabled = isCoreEmailVerificationEnabled(app.config)
 
   app.registerCapabilitiesContributor('core', () => {
     const googleOauth = isGoogleOauthUsable(app.config)
@@ -62,15 +63,15 @@ export function registerCapabilities(app: FastifyInstance) {
         invitesEnabled: app.config.features.invitesEnabled,
         githubOauth: app.config.features.githubOauth,
         googleOauth,
-        emailFlows: hasMail,
+        emailFlows: emailVerificationEnabled,
       },
       auth: {
         emailPassword: true,
         github: false,
         google: googleOauth,
-        emailVerification: hasMail,
-        passwordReset: hasMail,
-        magicLink: hasMail,
+        emailVerification: emailVerificationEnabled,
+        passwordReset: emailVerificationEnabled,
+        magicLink: emailVerificationEnabled,
       },
     }
     return { core }

--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -102,7 +102,7 @@ declare module 'fastify' {
     capabilitiesCache: CapabilitiesResponse | null
   }
   interface FastifyRequest {
-    user?: { id: string; email: string; name: string | null } | null
+    user?: { id: string; email: string; name: string | null; emailVerified: boolean } | null
     cspNonce?: string
   }
 }

--- a/packages/core/src/server/auth/__tests__/authHook.test.ts
+++ b/packages/core/src/server/auth/__tests__/authHook.test.ts
@@ -45,6 +45,24 @@ let app: FastifyInstance
 let rawSql: postgres.Sql
 let sessionCookie: string
 
+async function signUpAndReadCookie(email: string): Promise<string> {
+  const signupRes = await app.inject({
+    method: 'POST',
+    url: '/auth/sign-up/email',
+    payload: {
+      name: 'Hook Test User',
+      email,
+      password: 'Zk8$mN!qR2xFgWpJ',
+    },
+  })
+
+  const setCookie = signupRes.headers['set-cookie']
+  const cookies = Array.isArray(setCookie) ? setCookie : setCookie ? [setCookie] : []
+  return cookies
+    .map((c) => c.split(';')[0])
+    .join('; ')
+}
+
 beforeAll(async () => {
   const config = makeConfig()
   await runMigrations(config)
@@ -83,23 +101,7 @@ beforeAll(async () => {
 
   await app.ready()
 
-  const signupRes = await app.inject({
-    method: 'POST',
-    url: '/auth/sign-up/email',
-    payload: {
-      name: 'Hook Test User',
-      email: 'hook-test@auth-test.dev',
-      password: 'Zk8$mN!qR2xFgWpJ',
-    },
-  })
-
-  const setCookie = signupRes.headers['set-cookie']
-  if (setCookie) {
-    const cookies = Array.isArray(setCookie) ? setCookie : [setCookie]
-    sessionCookie = cookies
-      .map((c) => c.split(';')[0])
-      .join('; ')
-  }
+  sessionCookie = await signUpAndReadCookie('hook-test@auth-test.dev')
 })
 
 afterAll(async () => {
@@ -130,8 +132,23 @@ describe('authHook', () => {
     expect(body.code).toBe('unauthorized')
   })
 
-  it('private path with valid session returns user', async () => {
+  it('private path with unverified session returns 403 when email verification is enabled', async () => {
+    const cookie = await signUpAndReadCookie(`unverified-${Date.now()}@auth-test.dev`)
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/me',
+      headers: { cookie },
+    })
+
+    expect(res.statusCode).toBe(403)
+    const body = res.json()
+    expect(body.code).toBe('email_not_verified')
+  })
+
+  it('private path with verified session returns user', async () => {
     expect(sessionCookie).toBeDefined()
+    await rawSql`UPDATE users SET email_verified = true WHERE email = 'hook-test@auth-test.dev'`
 
     const res = await app.inject({
       method: 'GET',
@@ -143,6 +160,7 @@ describe('authHook', () => {
     const body = res.json()
     expect(body.user).toBeDefined()
     expect(body.user.email).toBe('hook-test@auth-test.dev')
+    expect(body.user.emailVerified).toBe(true)
     expect(body.user.id).toBeDefined()
   })
 

--- a/packages/core/src/server/auth/__tests__/requireWorkspaceMember.test.ts
+++ b/packages/core/src/server/auth/__tests__/requireWorkspaceMember.test.ts
@@ -59,7 +59,7 @@ beforeAll(async () => {
   app.addHook('onRequest', async (request) => {
     const userId = request.headers['x-test-user'] as string | undefined
     if (userId) {
-      request.user = { id: userId, email: `${userId}@test.dev`, name: null }
+      request.user = { id: userId, email: `${userId}@test.dev`, name: null, emailVerified: true }
     } else {
       request.user = null
     }

--- a/packages/core/src/server/auth/authHook.ts
+++ b/packages/core/src/server/auth/authHook.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync, FastifyRequest, FastifyReply } from 'fastify'
 import fp from 'fastify-plugin'
+import { isCoreEmailVerificationEnabled } from '../../shared/authPolicy.js'
 import { HttpError, ERROR_CODES } from '../../shared/errors.js'
 import type { BetterAuthInstance } from './createAuth.js'
 
@@ -38,6 +39,7 @@ const authHookPlugin: FastifyPluginAsync<AuthHookOptions> = async (app, opts) =>
             id: result.user.id,
             email: result.user.email,
             name: result.user.name ?? null,
+            emailVerified: Boolean(result.user.emailVerified),
           }
         }
       } catch {
@@ -46,15 +48,22 @@ const authHookPlugin: FastifyPluginAsync<AuthHookOptions> = async (app, opts) =>
     }
 
     const path = request.url.split('?')[0]
-    if (
-      path.startsWith('/api/v1/') &&
-      !publicPatterns.some((re) => re.test(path)) &&
-      !request.user
-    ) {
+    const isProtectedApi = path.startsWith('/api/v1/') && !publicPatterns.some((re) => re.test(path))
+
+    if (isProtectedApi && !request.user) {
       throw new HttpError({
         status: 401,
         code: ERROR_CODES.UNAUTHORIZED,
         message: 'Authentication required',
+        requestId: request.id,
+      })
+    }
+
+    if (isProtectedApi && isCoreEmailVerificationEnabled(app.config) && request.user?.emailVerified !== true) {
+      throw new HttpError({
+        status: 403,
+        code: ERROR_CODES.EMAIL_NOT_VERIFIED,
+        message: 'Email verification required',
         requestId: request.id,
       })
     }

--- a/packages/core/src/server/auth/createAuth.ts
+++ b/packages/core/src/server/auth/createAuth.ts
@@ -16,6 +16,7 @@ import {
   renderMagicLink,
 } from '../mail/templates/index.js'
 import { createPostSignupHook } from './postSignupHook.js'
+import { isCoreEmailVerificationEnabled } from '../../shared/authPolicy.js'
 import { safeCapture, noopTelemetry, type TelemetrySink } from '../../shared/telemetry.js'
 
 const MIN_ZXCVBN_SCORE = 2
@@ -66,8 +67,9 @@ export interface CreateAuthOptions {
 export function createAuth(config: CoreConfig, db: Database, opts?: CreateAuthOptions): Auth<any> {
   const transport = buildMailTransport(config)
   const telemetry = opts?.telemetry ?? noopTelemetry
+  const emailVerificationEnabled = isCoreEmailVerificationEnabled(config)
 
-  const emailVerificationConfig = transport
+  const emailVerificationConfig = emailVerificationEnabled && transport
     ? {
         sendOnSignUp: true as const,
         sendVerificationEmail: async (data: any) => {

--- a/packages/core/src/server/config/__tests__/loadConfig.test.ts
+++ b/packages/core/src/server/config/__tests__/loadConfig.test.ts
@@ -459,6 +459,7 @@ describe('buildRuntimeConfigPayload', () => {
           googleOauth: false,
           invitesEnabled: true,
           sendWelcomeEmail: true,
+          emailVerification: false,
         },
       })
 

--- a/packages/core/src/server/config/loadConfig.ts
+++ b/packages/core/src/server/config/loadConfig.ts
@@ -1,6 +1,7 @@
 import { readFileSync, existsSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { parse as parseTOML } from 'smol-toml'
+import { isCoreEmailVerificationEnabled } from '../../shared/authPolicy.js'
 import type { CoreConfig, RuntimeConfig } from '../../shared/types.js'
 import { ConfigValidationError } from '../../shared/errors.js'
 import { coreConfigSchema } from './schema.js'
@@ -277,6 +278,7 @@ export function buildRuntimeConfigPayload(config: CoreConfig): RuntimeConfig {
       googleOauth: isGoogleOauthUsable(config),
       invitesEnabled: config.features.invitesEnabled,
       sendWelcomeEmail: config.features.sendWelcomeEmail,
+      emailVerification: isCoreEmailVerificationEnabled(config),
     },
   }
 }

--- a/packages/core/src/server/routes/__tests__/idempotency.test.ts
+++ b/packages/core/src/server/routes/__tests__/idempotency.test.ts
@@ -127,7 +127,7 @@ beforeAll(async () => {
   app.addHook('onRequest', async (request) => {
     const userId = request.headers['x-test-user'] as string | undefined
     if (userId) {
-      request.user = { id: userId, email: `${userId}@test.dev`, name: null }
+      request.user = { id: userId, email: `${userId}@test.dev`, name: null, emailVerified: true }
     } else {
       request.user = null
     }

--- a/packages/core/src/server/routes/__tests__/invites.test.ts
+++ b/packages/core/src/server/routes/__tests__/invites.test.ts
@@ -193,8 +193,8 @@ beforeAll(async () => {
     if (userId) {
       const user = fakeUsers[userId]
       request.user = user
-        ? { id: user.id, email: user.email, name: user.name }
-        : { id: userId, email: `${userId}@test.dev`, name: null }
+        ? { id: user.id, email: user.email, name: user.name, emailVerified: true }
+        : { id: userId, email: `${userId}@test.dev`, name: null, emailVerified: true }
     } else {
       request.user = null
     }

--- a/packages/core/src/server/routes/__tests__/members.test.ts
+++ b/packages/core/src/server/routes/__tests__/members.test.ts
@@ -122,7 +122,7 @@ beforeAll(async () => {
   app.addHook('onRequest', async (request) => {
     const userId = request.headers['x-test-user'] as string | undefined
     if (userId) {
-      request.user = { id: userId, email: `${userId}@test.dev`, name: null }
+      request.user = { id: userId, email: `${userId}@test.dev`, name: null, emailVerified: true }
     } else {
       request.user = null
     }

--- a/packages/core/src/server/routes/__tests__/settings.test.ts
+++ b/packages/core/src/server/routes/__tests__/settings.test.ts
@@ -94,7 +94,7 @@ beforeAll(async () => {
   app.addHook('onRequest', async (request) => {
     const userId = request.headers['x-test-user'] as string | undefined
     if (userId) {
-      request.user = { id: userId, email: `${userId}@test.dev`, name: null }
+      request.user = { id: userId, email: `${userId}@test.dev`, name: null, emailVerified: true }
     } else {
       request.user = null
     }
@@ -299,7 +299,7 @@ describe('POST /api/v1/workspaces/:id/runtime/retry (with provisioner)', () => {
     provApp.addHook('onRequest', async (request) => {
       const userId = request.headers['x-test-user'] as string | undefined
       if (userId) {
-        request.user = { id: userId, email: `${userId}@test.dev`, name: null }
+        request.user = { id: userId, email: `${userId}@test.dev`, name: null, emailVerified: true }
       } else {
         request.user = null
       }

--- a/packages/core/src/server/routes/__tests__/workspaceAuthAudit.test.ts
+++ b/packages/core/src/server/routes/__tests__/workspaceAuthAudit.test.ts
@@ -267,7 +267,7 @@ beforeAll(async () => {
   app.addHook('onRequest', async (request, reply) => {
     const userId = request.headers['x-test-user'] as string | undefined
     if (userId) {
-      request.user = { id: userId, email: `${userId}@test.dev`, name: null }
+      request.user = { id: userId, email: `${userId}@test.dev`, name: null, emailVerified: true }
     } else {
       request.user = null
       // Simulate core's authHook: reject unauthenticated requests to /api/v1/

--- a/packages/core/src/server/routes/__tests__/workspaces.test.ts
+++ b/packages/core/src/server/routes/__tests__/workspaces.test.ts
@@ -86,7 +86,7 @@ beforeAll(async () => {
   app.addHook('onRequest', async (request) => {
     const userId = request.headers['x-test-user'] as string | undefined
     if (userId) {
-      request.user = { id: userId, email: `${userId}@test.dev`, name: null }
+      request.user = { id: userId, email: `${userId}@test.dev`, name: null, emailVerified: true }
     } else {
       request.user = null
     }
@@ -445,7 +445,7 @@ describe('Provisioner integration', () => {
     provApp.addHook('onRequest', async (request) => {
       const userId = request.headers['x-test-user'] as string | undefined
       if (userId) {
-        request.user = { id: userId, email: `${userId}@test.dev`, name: null }
+        request.user = { id: userId, email: `${userId}@test.dev`, name: null, emailVerified: true }
       } else {
         request.user = null
       }

--- a/packages/core/src/shared/authPolicy.ts
+++ b/packages/core/src/shared/authPolicy.ts
@@ -1,0 +1,21 @@
+import type { CoreConfig, RuntimeConfig, User } from './types.js'
+
+export function isCoreEmailVerificationEnabled(
+  config: Pick<CoreConfig, 'auth'>,
+): boolean {
+  return Boolean(config.auth.mail)
+}
+
+export function isRuntimeEmailVerificationEnabled(
+  config: Pick<RuntimeConfig, 'features'> | null | undefined,
+): boolean {
+  return config?.features.emailVerification === true
+}
+
+export function canUseProtectedApi(
+  user: Pick<User, 'emailVerified'> | null | undefined,
+  requireEmailVerification: boolean,
+): boolean {
+  if (!user) return false
+  return !requireEmailVerification || user.emailVerified === true
+}

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -4,6 +4,7 @@ export const ERROR_CODES = {
   FORBIDDEN: 'forbidden',
   WEAK_PASSWORD: 'weak_password',
   EMAIL_IN_USE: 'email_in_use',
+  EMAIL_NOT_VERIFIED: 'email_not_verified',
 
   // Workspace membership
   NOT_MEMBER: 'not_member',

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -25,3 +25,9 @@ export type { ErrorCode } from './errors.js'
 
 export { noopTelemetry, safeCapture } from './telemetry.js'
 export type { TelemetryEvent, TelemetrySink } from './telemetry.js'
+
+export {
+  canUseProtectedApi,
+  isCoreEmailVerificationEnabled,
+  isRuntimeEmailVerificationEnabled,
+} from './authPolicy.js'

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -190,6 +190,7 @@ export interface RuntimeConfig {
     googleOauth: boolean
     invitesEnabled: boolean
     sendWelcomeEmail: boolean
+    emailVerification: boolean
   }
 }
 

--- a/packages/workspace/src/__tests__/WorkspaceProvider.test.tsx
+++ b/packages/workspace/src/__tests__/WorkspaceProvider.test.tsx
@@ -512,6 +512,10 @@ describe("WorkspaceProvider — document title", () => {
     expect(formatWorkspaceDocumentTitle({ workspaceLabel: "deadbeef" })).toBe("deadbeef · Boring UI")
   })
 
+  it("uses the app title when provided", () => {
+    expect(formatWorkspaceDocumentTitle({ appTitle: "Seneca AI", workspaceLabel: "Workspace A" })).toBe("Workspace A · Seneca AI")
+  })
+
   it("falls back to the default title when no safe workspace metadata exists", () => {
     expect(formatWorkspaceDocumentTitle({})).toBe("Boring UI")
     expect(formatWorkspaceDocumentTitle({ workspaceLabel: "   ", workspaceId: "" })).toBe("Boring UI")
@@ -527,20 +531,20 @@ describe("WorkspaceProvider — document title", () => {
 
   it("updates document.title when workspace metadata changes", () => {
     const { rerender } = render(
-      <WorkspaceProvider workspaceId="workspace-a" workspaceLabel="Workspace A" persistenceEnabled={false}>
+      <WorkspaceProvider appTitle="Seneca AI" workspaceId="workspace-a" workspaceLabel="Workspace A" persistenceEnabled={false}>
         <div />
       </WorkspaceProvider>,
     )
 
-    expect(document.title).toBe("Workspace A · Boring UI")
+    expect(document.title).toBe("Workspace A · Seneca AI")
 
     rerender(
-      <WorkspaceProvider workspaceId="workspace-b" workspaceLabel="Workspace B" persistenceEnabled={false}>
+      <WorkspaceProvider appTitle="Seneca AI" workspaceId="workspace-b" workspaceLabel="Workspace B" persistenceEnabled={false}>
         <div />
       </WorkspaceProvider>,
     )
 
-    expect(document.title).toBe("Workspace B · Boring UI")
+    expect(document.title).toBe("Workspace B · Seneca AI")
   })
 
   it("falls back to workspaceId in document.title when label is missing", () => {

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1290,6 +1290,7 @@ export function WorkspaceAgentFront<
         onThemeChange={onThemeChange}
         workspaceId={workspaceId}
         workspaceLabel={workspaceLabel}
+        appTitle={appTitle}
         storageKey={resolvedProviderStorageKey}
         persistenceEnabled={persistenceEnabled}
         debug={debug}

--- a/packages/workspace/src/front/provider/WorkspaceProvider.tsx
+++ b/packages/workspace/src/front/provider/WorkspaceProvider.tsx
@@ -359,6 +359,7 @@ export interface WorkspaceProviderProps {
   onThemeChange?: (theme: "light" | "dark") => void
   workspaceId?: string
   workspaceLabel?: string
+  appTitle?: string
   storageKey?: string
   persistenceEnabled?: boolean
   manageDocumentTitle?: boolean
@@ -410,6 +411,7 @@ export function WorkspaceProvider({
   onThemeChange,
   workspaceId,
   workspaceLabel,
+  appTitle,
   storageKey,
   persistenceEnabled = true,
   manageDocumentTitle = true,
@@ -573,8 +575,8 @@ export function WorkspaceProvider({
 
   useEffect(() => {
     if (!manageDocumentTitle) return
-    document.title = formatWorkspaceDocumentTitle({ workspaceLabel, workspaceId })
-  }, [manageDocumentTitle, workspaceId, workspaceLabel])
+    document.title = formatWorkspaceDocumentTitle({ appTitle, workspaceLabel, workspaceId })
+  }, [appTitle, manageDocumentTitle, workspaceId, workspaceLabel])
 
   const [bridgeConnected, setBridgeConnected] = useState(false)
 

--- a/packages/workspace/src/front/provider/workspaceTitle.ts
+++ b/packages/workspace/src/front/provider/workspaceTitle.ts
@@ -10,14 +10,16 @@ function sanitizeWorkspaceTitleSegment(value: string | null | undefined): string
 }
 
 export function formatWorkspaceDocumentTitle(input: {
+  appTitle?: string | null
   workspaceLabel?: string | null
   workspaceId?: string | null
 }): string {
+  const appTitle = sanitizeWorkspaceTitleSegment(input.appTitle) ?? DEFAULT_WORKSPACE_TITLE
   const label = sanitizeWorkspaceTitleSegment(input.workspaceLabel)
-  if (label) return `${label} · ${DEFAULT_WORKSPACE_TITLE}`
+  if (label) return `${label} · ${appTitle}`
 
   const workspaceId = sanitizeWorkspaceTitleSegment(input.workspaceId)
-  if (workspaceId) return `${workspaceId} · ${DEFAULT_WORKSPACE_TITLE}`
+  if (workspaceId) return `${workspaceId} · ${appTitle}`
 
-  return DEFAULT_WORKSPACE_TITLE
+  return appTitle
 }


### PR DESCRIPTION
## Summary
- redirect signed-in-but-unverified users to `/auth/verify-email` after signup and from protected UI routes
- enforce email verification server-side for protected `/api/v1/*` requests with `email_not_verified`
- centralize verification policy helpers and prevent unverified frontend providers from fetching protected APIs
- require `features.emailVerification` in runtime config and tighten AuthGate's unverified allowlist to explicit auth pages

## Tests
- `cd /tmp/boring-ui-email-verification/packages/core && npm test -- src/server/auth/__tests__/authHook.test.ts src/server/app/__tests__/routes.test.ts src/front/__tests__/SignUpPage.test.tsx src/front/__tests__/VerifyEmailPage.test.tsx src/front/__tests__/AuthGate.test.tsx src/front/__tests__/WorkspaceAuthProvider.test.tsx src/front/__tests__/UserIdentityProvider.test.tsx src/server/config/__tests__/loadConfig.test.ts src/server/app/__tests__/capabilities.test.ts`
- `cd /tmp/boring-ui-email-verification && pnpm --filter @hachej/boring-core typecheck`
- `cd /tmp/boring-ui-email-verification && git diff --check`

## Notes
- Autoreview helper was requested by repo workflow, but no configured executable helper was present in this environment.
