### PR TITLE
build(core): assert exported artifacts + CSS @imports resolve

### DIFF
--- a/apps/full-app/Dockerfile
+++ b/apps/full-app/Dockerfile
@@ -21,7 +21,10 @@ COPY apps/full-app/ apps/full-app/
 # workspace tsup skips dts (vite-plugin-dts covers the front entries instead).
 # tsup's onSuccess hook copies core's hand-authored CSS (theme.css, styles.css,
 # chatFirst/*) into dist, so this stays in sync with `pnpm build` automatically.
-RUN pnpm --filter @hachej/boring-core exec tsup --no-dts
+# build:assert (dts-agnostic) then verifies every exported artifact + CSS @import
+# is present in dist, so a drift fails the image build instead of reaching prod.
+RUN pnpm --filter @hachej/boring-core exec tsup --no-dts \
+  && pnpm --filter @hachej/boring-core run build:assert
 
 RUN pnpm --filter @hachej/boring-ui-kit exec tsup \
   && pnpm --filter @hachej/boring-ui-kit exec node scripts/build-styles.mjs

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,8 @@
     "drizzle"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && pnpm run build:assert",
+    "build:assert": "node ./scripts/assert-build-artifacts.mjs",
     "dev": "tsup --watch",
     "test": "vitest run --no-file-parallelism",
     "test:watch": "vitest",

--- a/packages/core/scripts/assert-build-artifacts.mjs
+++ b/packages/core/scripts/assert-build-artifacts.mjs
@@ -1,0 +1,116 @@
+import { access, readFile } from "node:fs/promises"
+import { constants } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+// Every entry declared in package.json#exports must produce a real file, and
+// every @import inside a shipped stylesheet must resolve to a built sibling.
+// Mismatch between exports and what's built — or a stylesheet that @imports a
+// file the build forgot to copy — is the bug this script catches. That is the
+// exact failure mode behind the chat-first CSS relocation (#327): styles.css
+// shipped with `@import "./chatFirst/chatFirstPublicShell.css"` but the file
+// wasn't copied into dist, so consumers' bundlers failed to resolve it.
+//
+// Intentionally dts-agnostic: type declarations are built conditionally (the
+// Docker image skips them via `tsup --no-dts` for speed), so this guard checks
+// only the runtime artifacts (JS + CSS) and therefore runs identically in
+// `pnpm build` and the Docker build path.
+
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+)
+
+async function exists(rel) {
+  try {
+    await access(path.resolve(packageRoot, rel), constants.F_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Collect every runtime artifact referenced by package.json#exports.
+// - a string value that is a .css file (e.g. "./theme.css")
+// - the `import` condition of an object value (the .js entry)
+// `types` (.d.ts) is skipped on purpose — see header.
+function collectRequiredFiles(exportsField) {
+  const required = new Set()
+  for (const value of Object.values(exportsField)) {
+    if (typeof value === "string") {
+      if (value.endsWith(".css")) required.add(value)
+    } else if (value && typeof value === "object" && typeof value.import === "string") {
+      required.add(value.import)
+    }
+  }
+  return [...required].map((p) => p.replace(/^\.\//, ""))
+}
+
+const pkg = JSON.parse(
+  await readFile(path.resolve(packageRoot, "package.json"), "utf8"),
+)
+const requiredFiles = collectRequiredFiles(pkg.exports ?? {})
+
+const missing = []
+for (const rel of requiredFiles) {
+  if (!(await exists(rel))) missing.push(rel)
+}
+
+if (missing.length > 0) {
+  console.error(
+    `assert-build-artifacts: missing ${missing.length} exported artifact(s):`,
+  )
+  for (const m of missing) console.error(`  - ${m}`)
+  console.error(
+    "\nFix: ensure tsup emits every exports#import entry, and that tsup.config.ts's " +
+      "onSuccess hook copies every hand-authored CSS file referenced by exports.",
+  )
+  process.exit(1)
+}
+
+// Recursively assert that every relative @import inside a shipped stylesheet
+// resolves to a built file. This is the check that would have caught #327.
+const IMPORT_RE = /@import\s+(?:url\()?["']([^"']+)["']\)?/g
+const cssSeen = new Set()
+const importMisses = []
+
+async function assertCssImports(relCssPath) {
+  if (cssSeen.has(relCssPath)) return
+  cssSeen.add(relCssPath)
+  const text = await readFile(path.resolve(packageRoot, relCssPath), "utf8")
+  for (const match of text.matchAll(IMPORT_RE)) {
+    const spec = match[1]
+    // Only validate relative imports — bare specifiers (e.g. "tailwindcss",
+    // "@hachej/...") are resolved by the consumer's bundler from node_modules.
+    if (!spec.startsWith(".")) continue
+    const target = path.join(path.dirname(relCssPath), spec)
+    if (!(await exists(target))) {
+      importMisses.push({ from: relCssPath, spec, target })
+      continue
+    }
+    if (target.endsWith(".css")) await assertCssImports(target)
+  }
+}
+
+for (const rel of requiredFiles) {
+  if (rel.endsWith(".css")) await assertCssImports(rel)
+}
+
+if (importMisses.length > 0) {
+  console.error(
+    `assert-build-artifacts: ${importMisses.length} unresolved CSS @import(s):`,
+  )
+  for (const m of importMisses) {
+    console.error(`  - ${m.from} @imports "${m.spec}" -> missing ${m.target}`)
+  }
+  console.error(
+    "\nFix: add the missing stylesheet to tsup.config.ts's CSS_ASSETS so the " +
+      "onSuccess hook copies it into dist.",
+  )
+  process.exit(1)
+}
+
+console.log(
+  `assert-build-artifacts: all ${requiredFiles.length} exported artifact(s) present, ` +
+    `${cssSeen.size} stylesheet(s) with resolvable @imports`,
+)


### PR DESCRIPTION
## Why
Follow-up to #327. That PR shipped a broken core build — `dist/app/front/styles.css` `@import`ed `./chatFirst/chatFirstPublicShell.css`, but the Docker image-build path (which hand-copied core's CSS) never copied it, so full-app's `vite build` failed in CI (*Remote Worker Smoke*). #327 fixed the copy (single source of truth in tsup's `onSuccess`); this PR adds the **guard that would have caught it at the source**.

`core` — unlike `workspace` and `agent` — had no build-artifact assertion, which is exactly why the drift sailed past core's build and only exploded downstream.

## What
- **`packages/core/scripts/assert-build-artifacts.mjs`** — driven off `package.json#exports` (auto-covers future entries). Verifies:
  1. every exported JS/CSS artifact exists in `dist`, and
  2. every **relative `@import`** inside a shipped stylesheet resolves to a built sibling (the precise #327 failure).
- Intentionally **dts-agnostic** — declarations are built conditionally (Docker uses `tsup --no-dts` for speed), so the guard checks only runtime artifacts and runs **identically in `pnpm build` and the Docker build**.
- Wired into core's `build`, exposed as `build:assert`, and run in the Dockerfile's core step so a drift **fails the image build instead of reaching prod**.

## Validation
- ✅ Positive: `all 10 exported artifact(s) present, 3 stylesheet(s) with resolvable @imports`
- ✅ Negative (simulated #327 drift — removed the `@import` target): assert **fails with exit 1** and a precise fix message pointing at `tsup.config.ts`'s `CSS_ASSETS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)