### PR TITLE
fix(credits): separate run admission threshold

### DIFF
--- a/apps/full-app/src/server/__tests__/credits.test.ts
+++ b/apps/full-app/src/server/__tests__/credits.test.ts
@@ -126,8 +126,10 @@ describe('readCreditsConfig + assessReservationHold', () => {
     expect(config.lemonSqueezyCheckout).toBeUndefined()
   })
 
-  it('default signup grant admits a first run out of the box (grant >= hold + floor)', () => {
+  it('defaults run admission to €0.10 while sizing the starter grant with hold runway', () => {
     const config = readCreditsConfig({})
+    expect(config.minBalanceMicros).toBe(50_000)
+    expect(config.runAdmissionMicros).toBe(100_000)
     expect(config.signupGrantMicros).toBeGreaterThanOrEqual(config.runReservationMicros + config.minBalanceMicros)
   })
 

--- a/apps/full-app/src/server/credits.ts
+++ b/apps/full-app/src/server/credits.ts
@@ -418,18 +418,23 @@ export function readCreditsConfig(env: NodeJS.ProcessEnv = process.env): FullApp
     )
   }
   const minBalanceMicros = eurToMicros('BORING_CREDITS_MIN_BALANCE_EUR', env.BORING_CREDITS_MIN_BALANCE_EUR, 0.05)
+  // Product admission threshold: let users spend down to roughly CHF/EUR 0.10
+  // while keeping the per-run hold as the fallback-charge/usage budget. This is
+  // deliberately separate from minBalanceMicros so low-balance admission is an
+  // explicit app policy, not a semantic change to the generic credits service.
+  const runAdmissionMicros = eurToMicros('BORING_CREDITS_RUN_ADMISSION_EUR', env.BORING_CREDITS_RUN_ADMISSION_EUR, 0.1)
   // Background stale-reservation sweep cadence. The per-user expiry in reserve()
   // covers active users; this sweeper charges-on-expire the marked reservations of
   // users who don't return, so a durable fallback charge whose write failed isn't
   // lost. Off the request path (no cross-user coupling). Default 5 min.
   const sweepIntervalSeconds = Math.max(30, parseNumberEnv('BORING_CREDITS_SWEEP_INTERVAL_SECONDS', env.BORING_CREDITS_SWEEP_INTERVAL_SECONDS, 300, 30))
-  // Default the signup grant so a FRESH user can start their first run out of the box.
-  // reserveRun admits a run only when available ≥ hold + floor, so an UNSET grant
-  // defaults to max(€2, hold + floor). Without this, an unconfigured/dev deploy (high
-  // served-rate floor → ~€4 hold) would 402 every first run with no in-app way to buy.
-  // An EXPLICIT BORING_CREDITS_SIGNUP_GRANT_EUR is respected as-is (attach() still warns
-  // if an explicit grant is below the hold). A configured deploy with cheap rates has a
-  // low hold, so this stays at €2.
+  // Default the signup grant so a FRESH user has at least one full hold of runway.
+  // runAdmissionMicros lets existing users spend down to the low-balance floor, but
+  // an UNSET grant still defaults to max(€2, hold + floor) to avoid immediately
+  // pushing first-run users into debt on fallback. An EXPLICIT
+  // BORING_CREDITS_SIGNUP_GRANT_EUR is respected as-is (attach() still warns if a
+  // positive grant is below the start-balance floor). A configured deploy with cheap
+  // rates has a low hold, so this stays at €2.
   const defaultSignupGrantMicros = Math.max(2 * CREDIT_MICROS_PER_EUR, runReservationMicros + minBalanceMicros)
   const signupGrantMicros = env.BORING_CREDITS_SIGNUP_GRANT_EUR
     ? eurToMicros('BORING_CREDITS_SIGNUP_GRANT_EUR', env.BORING_CREDITS_SIGNUP_GRANT_EUR, 2)
@@ -441,6 +446,7 @@ export function readCreditsConfig(env: NodeJS.ProcessEnv = process.env): FullApp
     runReservationMicros,
     reservationTtlSeconds,
     minBalanceMicros,
+    runAdmissionMicros,
     sweepIntervalSeconds,
     pricing: { margin, creditMicrosPerUnit: CREDIT_MICROS_PER_EUR, rates },
   }
@@ -619,22 +625,24 @@ export function buildCreditsWiring(env: NodeJS.ProcessEnv = process.env): {
           throw new Error('credits: BORING_CREDITS_LS_WEBHOOK_SECRET is set but server-side checkout is not configured (need BORING_CREDITS_LS_API_KEY + store id + variants). The webhook requires a server-signed attribution token that only server-created checkouts mint, so real orders would 500 forever as untrusted_attribution. Configure checkout or unset the webhook secret.')
         }
       }
-      // The per-run hold bounds a single run's overdraft. Evaluate it against the
-      // served + effective worst cases (a 'throw' verdict is fatal; a 'warn' is a
-      // documented accepted posture). Extracted as a pure function so the default
-      // (served-rate) config is regression-tested to boot, not crash.
+      // The per-run hold is the fallback-charge/usage budget. Evaluate it against
+      // the served + effective worst cases (a 'throw' verdict is fatal; a 'warn' is
+      // a documented accepted posture). Admission itself uses runAdmissionMicros so
+      // low-balance users can start down to the configured floor.
       const verdict = assessReservationHold(config, env)
       if (config.enabled) {
         if (verdict.action === 'throw') throw new Error(verdict.message)
         if (verdict.action === 'warn') app.log.warn(verdict.fields, verdict.message)
       }
-      // A free-grant smaller than the per-run hold means new users can't start a
-      // run at all (reserve needs the full hold available). Surface it — the
-      // operator must raise the grant, lower the hold, or configure cheaper rates.
-      if (config.enabled && config.signupGrantMicros > 0 && config.signupGrantMicros < config.runReservationMicros) {
+      // A positive free-grant smaller than the admission floor means new users still
+      // can't start a run. Surface it — the operator must raise the grant or lower
+      // BORING_CREDITS_RUN_ADMISSION_EUR. A zero grant is a deliberate no-trial setup.
+      const runAdmissionMicros = config.runAdmissionMicros
+        ?? config.runReservationMicros + config.minBalanceMicros
+      if (config.enabled && config.signupGrantMicros > 0 && config.signupGrantMicros < runAdmissionMicros) {
         app.log.warn(
-          { signupGrantMicros: config.signupGrantMicros, runReservationMicros: config.runReservationMicros },
-          'credits: signup grant is below the per-run hold — new users will be blocked from their first run until they buy credits',
+          { signupGrantMicros: config.signupGrantMicros, runAdmissionMicros },
+          'credits: signup grant is below the run admission threshold — new users will be blocked from their first run until they buy credits',
         )
       }
       // Background charge-on-expire sweeper. reserve() expires the CURRENT user's

--- a/docs/credits-launch-plan.md
+++ b/docs/credits-launch-plan.md
@@ -95,7 +95,8 @@ All money config is **fail-closed**: a provided-but-invalid value throws at star
 | `BORING_CREDITS_SIGNUP_GRANT_EXPIRES_DAYS` | no (default never) | `0`/unset = never (the only supported value). A positive integer **throws at startup**: an expiring grant drops from `grantedMicros` on expiry while spent usage debits stay, turning a partly-spent trial into debt. Re-enable only once usage is allocated/capped against the promo balance. |
 | `BORING_CREDITS_RESERVATION_EUR` | no | Per-run hold. **Unset ⇒ computed SERVED worst-case run** (see limitations). An explicit value below the **served** worst case **throws** unless `BORING_CREDITS_ALLOW_UNSAFE_LOW_RESERVATION=1`; below the *effective* worst case only warns. |
 | `BORING_CREDITS_ALLOW_UNSAFE_LOW_RESERVATION` | no | `1` accepts a per-run hold below the **served** worst-case run (soft stop; launch-blocking debt). Forbidden in production. Not needed for the served-rate default. |
-| `BORING_CREDITS_MIN_BALANCE_EUR` | no (default 0.05) | Floor kept available **after** a run's hold. |
+| `BORING_CREDITS_RUN_ADMISSION_EUR` | no (default 0.10) | Minimum available balance required **before** starting a run. The per-run hold is still placed, but it is not added to this admission threshold. Low-balance runs can create bounded recoverable debt. |
+| `BORING_CREDITS_MIN_BALANCE_EUR` | no (default 0.05) | Conservative post-hold floor used for grant sizing and by the generic credits service when no explicit run-admission threshold is set. |
 | `BORING_CREDITS_MARGIN` | no (default 1.3) | Pricing margin; must be ≥ 1. |
 | `BORING_CREDITS_RATES` | recommended | `regex=inEur:outEur;…` per-MTok rates (e.g. `infomaniak=0.5:1.5`). Matched against `provider/id`. Non-positive/malformed entries throw. |
 | `BORING_CREDITS_MAX_CONTEXT_TOKENS` / `_MAX_OUTPUT_TOKENS` / `_MAX_CALLS_PER_RUN` | no (200k/16k/4) | Worst-case-run inputs for hold sizing. |
@@ -118,10 +119,12 @@ detection; refund reconciliation by order id with store/mode matching; unknown m
 fail closed at the highest effective rate.
 
 ## Known limitations (accepted for launch, documented)
-1. **Per-run hard stop is not per-call.** The hold bounds a run's overdraft (sized for
-   `MAX_CALLS_PER_RUN` worst-case calls); a run exceeding that budget can overshoot, bounded,
-   and the user's *next* run is then refused. True per-call enforcement needs a Pi-runtime
-   abort hook (the metering coordinator is an observer) — a deliberate follow-up.
+1. **Per-run hard stop is not per-call.** The hold bounds the fallback charge/usage budget
+   (sized for `MAX_CALLS_PER_RUN` worst-case calls), but app admission only requires the
+   explicit `BORING_CREDITS_RUN_ADMISSION_EUR` floor. A low-balance run can therefore create
+   bounded recoverable debt (up to roughly hold minus starting balance, plus any over-budget
+   usage), and the user's *next* run is then refused. True per-call enforcement needs a
+   Pi-runtime abort hook (the metering coordinator is an observer) — a deliberate follow-up.
 2. **Hold sizing: served vs effective.** The per-run hold defaults to the SERVED-rate worst
    case (`maxServedRate` — configured rates + conservative floor, excluding the built-in
    Opus default), so it's proportional to the models you serve and a small starter grant

--- a/docs/credits-prod-deployment.md
+++ b/docs/credits-prod-deployment.md
@@ -33,11 +33,12 @@ items flagged "UNPROVEN" below. This is the punch list to take it live.
 ### Configured values (current policy)
 - **Signup grant**: `BORING_CREDITS_SIGNUP_GRANT_EUR=1` → 1 CHF free per signup.
 - **Per-run hold**: `BORING_CREDITS_MAX_CALLS_PER_RUN=1` → hold ≈ CHF 0.93 (worst case floors at
-  the conservative 3/15 rate × maxCalls × margin), so a 1 CHF signup can start a run. Default
-  (4) would hold CHF 3.72 and block the trial. Actual billing is the cheap Qwen rate, so normal
-  runs settle in cents; only a pathological long run overshoots into small bounded debt (next
-  run refused). NB: `BORING_CREDITS_ALLOW_UNSAFE_LOW_RESERVATION` is **rejected in production**,
-  so lower the hold via maxCalls (not RESERVATION_EUR below the served worst case).
+  the conservative 3/15 rate × maxCalls × margin). The user-facing start threshold is separate:
+  `BORING_CREDITS_RUN_ADMISSION_EUR=0.1`, so a user with CHF 0.90 can still start a run. Default
+  maxCalls (4) would hold CHF 3.72. Actual billing is the cheap Qwen rate, so normal runs settle
+  in cents; only a pathological long run overshoots into bounded debt (next run refused). NB:
+  `BORING_CREDITS_ALLOW_UNSAFE_LOW_RESERVATION` is **rejected in production**, so lower the hold
+  via maxCalls (not RESERVATION_EUR below the served worst case).
 - **Margin**: `BORING_CREDITS_MARGIN=1.1` → 10% over raw provider cost.
 - **Rates** (`BORING_CREDITS_RATES`, raw provider CHF/MTok — margin applied on top):
   verified Infomaniak AI prices (excl. VAT, source: infomaniak.com/en/hosting/ai-services/prices):
@@ -76,9 +77,9 @@ trial into debt — the service rejects expiring grants for this reason).
       reserve/hold is proven but real token→credit pricing is not.
 - [ ] Tune the per-run hold: `BORING_CREDITS_RESERVATION_EUR` (or the derived served
       worst-case), `BORING_CREDITS_MAX_CONTEXT_TOKENS/_OUTPUT_TOKENS/_CALLS_PER_RUN`.
-- [ ] **Signup grant is 1 CHF** (`BORING_CREDITS_SIGNUP_GRANT_EUR=1`, hold lowered via
-      `BORING_CREDITS_MAX_CALLS_PER_RUN=1` so it's spendable) — new users get a free trial run;
-      the out-of-credits gate + Buy CTA fires once it's exhausted.
+- [ ] **Signup grant is 1 CHF** (`BORING_CREDITS_SIGNUP_GRANT_EUR=1`, with
+      `BORING_CREDITS_RUN_ADMISSION_EUR=0.1` so it remains spendable below the hold) — new users
+      get a free trial run; the out-of-credits gate + Buy CTA fires once it's exhausted.
 
 ## 3. App / infra
 - [ ] Run DB migrations on the prod DB (`pnpm --filter full-app run migrate`); the credits/
@@ -132,6 +133,7 @@ flyctl secrets set -a boring-full-app \
   BORING_CREDITS_ENABLED=1 \
   BORING_CREDITS_SIGNUP_GRANT_EUR=0 \
   BORING_CREDITS_MARGIN=1.1 \
+  BORING_CREDITS_RUN_ADMISSION_EUR=0.1 \
   BORING_CREDITS_RATES="Qwen3.5-122B=0.40:3.20;Kimi-K2=0.60:3.00;Apertus=0.70:2.50;Ministral=0.30:0.40;gemma-4=0.20:0.40;Nemotron=0.05:0.20;Mistral-Small=0.20:0.75" \
   BORING_CREDITS_STRIPE_SECRET_KEY="<vault: secret/shared/senecaapp/stripe live_sk>" \
   BORING_CREDITS_STRIPE_WEBHOOK_SECRET="<whsec from webhook we_1TidMg...>" \

--- a/packages/core/src/server/credits/__tests__/creditsService.test.ts
+++ b/packages/core/src/server/credits/__tests__/creditsService.test.ts
@@ -73,6 +73,10 @@ describe('CreditsService', () => {
     expect(() => new CreditsService(makeStore(), { ...CONFIG, signupGrantExpiresAfterDays: 30 })).toThrow(/signupGrantExpiresAfterDays is not supported/)
   })
 
+  it('rejects a malformed explicit run admission threshold', () => {
+    expect(() => new CreditsService(makeStore(), { ...CONFIG, runAdmissionMicros: -1 })).toThrow(/runAdmissionMicros/)
+  })
+
   it('grants the signup credits without an expiry', async () => {
     const store = makeStore()
     await new CreditsService(store, CONFIG).getBalance('u1')
@@ -107,8 +111,18 @@ describe('CreditsService', () => {
     // or slow this reserve).
     expect(store.expireStaleReservations).not.toHaveBeenCalled()
     expect(store.reserve).toHaveBeenCalledWith(expect.objectContaining({
-      // minAvailable = hold (250k) + floor (50k): keep the floor AFTER reserving.
+      // Conservative default admission = hold (250k) + post-hold floor (50k).
       userId: 'u1', runId: 'r', amountMicros: 250_000, ttlSeconds: 7200, minAvailableMicros: 300_000,
+    }))
+  })
+
+  it('allows apps to set an explicit low-balance run admission threshold', async () => {
+    const store = makeStore()
+    const service = new CreditsService(store, { ...CONFIG, runAdmissionMicros: 100_000 })
+    await service.reserveRun({ userId: 'u1', runId: 'r' })
+    expect(store.reserve).toHaveBeenCalledWith(expect.objectContaining({
+      amountMicros: 250_000,
+      minAvailableMicros: 100_000,
     }))
   })
 

--- a/packages/core/src/server/credits/creditsService.ts
+++ b/packages/core/src/server/credits/creditsService.ts
@@ -34,16 +34,21 @@ export interface CreditsConfig {
   /** Days until the signup grant expires; null = never. */
   signupGrantExpiresAfterDays: number | null
   /**
-   * Per-run hold, in credit micros. This is the per-run overdraft bound: a run
-   * is admitted against this hold, but the actual charge is posted afterward, so
-   * a single run can overshoot the hold by (actualCost − hold). Set this to
-   * cover your worst-case single run (max tokens on the priciest enabled model)
-   * so the hard stop is effectively exact.
+   * Per-run hold, in credit micros. This is the per-run fallback-charge / usage
+   * budget: the actual charge is posted afterward, so a single run can overshoot
+   * the hold by (actualCost − hold).
    */
   runReservationMicros: number
   reservationTtlSeconds: number
-  /** Floor below which a run is refused. */
+  /** Floor kept available after placing the hold when runAdmissionMicros is unset. */
   minBalanceMicros: number
+  /**
+   * Available balance required before a run can start. Defaults to
+   * runReservationMicros + minBalanceMicros for the conservative no-debt posture.
+   * Apps may set this lower intentionally to let users spend down to a product
+   * threshold, accepting bounded recoverable debt for low-balance runs.
+   */
+  runAdmissionMicros?: number
   pricing: CreditPricingConfig
 }
 
@@ -152,6 +157,7 @@ export class CreditsService {
     if (!nonNegInt(config.signupGrantMicros)) throw new Error('credits: signupGrantMicros must be a non-negative safe integer')
     if (!posInt(config.runReservationMicros)) throw new Error('credits: runReservationMicros must be a positive safe integer')
     if (!nonNegInt(config.minBalanceMicros)) throw new Error('credits: minBalanceMicros must be a non-negative safe integer')
+    if (config.runAdmissionMicros !== undefined && !nonNegInt(config.runAdmissionMicros)) throw new Error('credits: runAdmissionMicros must be a non-negative safe integer')
     if (!posInt(config.reservationTtlSeconds)) throw new Error('credits: reservationTtlSeconds must be a positive safe integer')
     if (!Number.isSafeInteger(config.runReservationMicros + config.minBalanceMicros)) {
       throw new Error('credits: runReservationMicros + minBalanceMicros exceeds the safe integer range')
@@ -283,9 +289,10 @@ export class CreditsService {
         source: 'pi-chat',
         amountMicros: this.config.runReservationMicros,
         ttlSeconds: this.config.reservationTtlSeconds,
-        // Must keep minBalanceMicros available AFTER placing the hold, so a run
-        // is admitted only when available ≥ hold + floor (matches the config doc).
-        minAvailableMicros: this.config.runReservationMicros + this.config.minBalanceMicros,
+        // Conservative default is hold + floor; apps can explicitly lower this
+        // threshold with runAdmissionMicros to allow bounded-debt low-balance runs.
+        minAvailableMicros: this.config.runAdmissionMicros
+          ?? this.config.runReservationMicros + this.config.minBalanceMicros,
       })
       // Only on a NEW hold — reserve is idempotent (a retry for the same run returns the
       // existing reservation), so gating on `created` avoids inflating started counts.


### PR DESCRIPTION
## Summary
- Add an explicit `runAdmissionMicros` credits policy knob so apps can choose a low-balance run-start threshold without changing the generic hold + floor default.
- Configure full-app credits from `BORING_CREDITS_RUN_ADMISSION_EUR` (default `0.10`) so users can spend down to roughly CHF/EUR 0.10 before the out-of-credits gate.
- Keep the per-run hold as the fallback-charge / usage budget and keep default core behavior conservative (`hold + minBalance`).
- Update credits tests and launch/deployment docs.

## Verification
- `pnpm install --frozen-lockfile` (PR worktree dependency setup)
- `pnpm --filter @hachej/boring-core exec vitest run src/server/credits/__tests__/creditsService.test.ts --no-file-parallelism` ✅
- `pnpm --filter @hachej/boring-core run build` ✅
- `pnpm --filter full-app exec vitest run src/server/__tests__/credits.test.ts` ✅
- `pnpm --filter @hachej/boring-core run typecheck` ✅
- `pnpm --filter full-app run typecheck` ✅

## Manual validation
- Reviewed the billing semantics: core default remains `runReservationMicros + minBalanceMicros`; only full-app opts into `runAdmissionMicros = 0.10`.
- Confirmed intended product case: a user with ~0.90 CHF available passes admission when `BORING_CREDITS_RUN_ADMISSION_EUR=0.1`, while the hold remains available as the fallback/usage budget.

## Known gaps
- No browser/UI validation; this is server-side credits policy/config and docs only.
