### PR TITLE
Support composer file uploads

### DIFF
--- a/packages/agent/src/front/__tests__/chatSubmit.test.ts
+++ b/packages/agent/src/front/__tests__/chatSubmit.test.ts
@@ -16,8 +16,10 @@ describe('createEnrichedSubmitPayload', () => {
     })
 
     expect(result.serverMessage).toContain('can you read this?')
-    expect(result.serverMessage).toContain('Screenshot.png')
-    expect(result.serverMessage).toContain('Saved in workspace at: assets/images/screenshot-abc.png')
+    expect(result.serverMessage).toContain('<attachment data-boring-agent="composer-file"')
+    expect(result.serverMessage).toContain('filename="Screenshot.png"')
+    expect(result.serverMessage).toContain('path="assets/images/screenshot-abc.png"')
+    expect(result.serverMessage).toContain('binary="true"')
     expect(result.attachments).toEqual([
       expect.objectContaining({
         filename: 'Screenshot.png',

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -2,7 +2,7 @@
 
 import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react'
 import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import type { FileUIPart } from 'ai'
+import type { PromptInputFilePart } from '../primitives/prompt-input'
 import { ArtifactOpenProvider } from '../ArtifactOpenContext'
 import {
   WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT,
@@ -86,14 +86,14 @@ export type { ChatPanelRuntimeDependenciesWarmupStatus, ChatPanelWorkspaceWarmup
 export type ChatSubmitSource = 'composer' | 'suggestion' | 'auto-submit'
 
 export interface ChatSubmitContext {
-  files: FileUIPart[]
+  files: PromptInputFilePart[]
   sessionId: string
   source: ChatSubmitSource
 }
 
 interface ComposerSendPayload {
   text: string
-  files: FileUIPart[]
+  files: PromptInputFilePart[]
   source?: ChatSubmitSource
 }
 
@@ -815,10 +815,11 @@ export function PiChatPanel({
 
   const stop = useCallback(() => {
     onComposerStop?.()
+    clearLocalSubmitted(activeChatSessionId)
     void policy?.stop().catch((error) => {
       addLocalNotice({ id: 'stop-error', level: 'error', text: errorMessage(error, 'Could not stop the chat session.'), dismissible: true })
     })
-  }, [addLocalNotice, onComposerStop, policy])
+  }, [activeChatSessionId, addLocalNotice, clearLocalSubmitted, onComposerStop, policy])
 
   const interrupt = useCallback(() => {
     void policy?.interrupt().catch((error) => {

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -290,6 +290,31 @@ describe('PiChatPanel sandbox shell', () => {
     })
   })
 
+  test('stop clears local submitted state when no stream events arrived yet', async () => {
+    const remote = new FakeRemotePiSession(remoteState({ status: 'idle', lastSeq: 7 }))
+    const promptReceipt = deferred<{ accepted: true; cursor: number; clientNonce: string }>()
+    remote.prompt.mockImplementationOnce(async () => promptReceipt.promise)
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))
+    render(<PiChatPanel serverResourcesEnabled={false} storageScope="scope-a" fetch={fetchMock as unknown as typeof fetch} createRemoteSession={remoteFactory(remote)} />)
+
+    const textarea = await screen.findByLabelText('Agent prompt') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: 'will be stopped before events' } })
+    fireEvent.keyDown(textarea, { key: 'Enter' })
+    await waitFor(() => expect(remote.prompt).toHaveBeenCalledWith(expect.objectContaining({ message: 'will be stopped before events' })))
+
+    await act(async () => {
+      promptReceipt.resolve({ accepted: true, cursor: 8, clientNonce: 'nonce' })
+      await promptReceipt.promise
+    })
+
+    await screen.findByTestId('chat-working')
+    fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+
+    await waitFor(() => expect(remote.stop).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(screen.queryByTestId('chat-working')).toBeNull())
+    await screen.findByRole('button', { name: 'Submit' })
+  })
+
   test('does not hold submitted state when stream events catch up before prompt receipt resolves', async () => {
     const remote = new FakeRemotePiSession(remoteState({ status: 'idle', lastSeq: 7 }))
     const promptReceipt = deferred<{ accepted: true; cursor: number; clientNonce: string }>()

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -2,7 +2,6 @@
 
 import type { CSSProperties, ChangeEvent, KeyboardEvent as ReactKeyboardEvent, RefObject } from 'react'
 import { useCallback, useLayoutEffect } from 'react'
-import type { FileUIPart } from 'ai'
 import { motion } from 'motion/react'
 import type { QueuedUserMessage } from '../../../shared/chat'
 import type { AvailableModel, ModelSelection, ThinkingLevel } from '../../chatPanelSettings'
@@ -24,6 +23,7 @@ import {
   PromptInputFooter,
   PromptInputSubmit,
   PromptInputTextarea,
+  type PromptInputFilePart,
 } from '../../primitives/prompt-input'
 import { SlashCommandPicker } from '../../primitives/slash-command-picker'
 import type { SlashCommand } from '../../slashCommands'
@@ -117,7 +117,7 @@ export interface PiChatComposerSurfaceProps {
   textareaRef: RefObject<HTMLTextAreaElement | null>
   onTextareaChange: (event: ChangeEvent<HTMLTextAreaElement>) => void
   onTextareaKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void
-  onSubmitMessage: (payload: { text: string; files: FileUIPart[] }) => false | void | Promise<false | void>
+  onSubmitMessage: (payload: { text: string; files: PromptInputFilePart[] }) => false | void | Promise<false | void>
   onStop: () => void
 }
 
@@ -179,11 +179,13 @@ export function PiChatComposerSurface({
   onSubmitMessage,
   onStop,
 }: PiChatComposerSurfaceProps) {
+  const workspaceRequestId = getHeaderValue(requestHeaders, 'x-boring-workspace-id')
   const uploadAttachment = useCallback((file: File) => uploadFile(file, {
     apiBaseUrl,
-    workspaceRequestId: requestHeaders?.['x-boring-workspace-id'],
+    workspaceRequestId,
+    responseUrl: 'raw',
     fetch,
-  }), [apiBaseUrl, fetch, requestHeaders])
+  }), [apiBaseUrl, fetch, workspaceRequestId])
 
   const resizeTextarea = useCallback((node: HTMLTextAreaElement | null) => {
     if (!node) return
@@ -447,3 +449,9 @@ export function PiChatComposerSurface({
     </div>
   )
 }
+
+function getHeaderValue(headers: Record<string, string> | undefined, name: string): string | undefined {
+  if (!headers) return undefined
+  return headers[name] ?? Object.entries(headers).find(([key]) => key.toLowerCase() === name.toLowerCase())?.[1]
+}
+

--- a/packages/agent/src/front/chat/components/PiConversationSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiConversationSurface.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import type { FileUIPart } from 'ai'
 import type { ReactNode } from 'react'
+import type { PromptInputFilePart } from '../../primitives/prompt-input'
 import { Loader2 } from 'lucide-react'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useStickToBottomContext } from 'use-stick-to-bottom'
@@ -45,7 +45,7 @@ export interface PiConversationSurfaceProps {
    * code. Forwarded to RuntimeNoticeMessages. */
   renderNoticeAction?: (notice: PanelNotice) => ReactNode
   onScrollToBottomReady: (scrollToBottom: () => void) => void
-  onSuggestionSubmit: (payload: { text: string; files: FileUIPart[]; source: 'suggestion' }) => Promise<false | void>
+  onSuggestionSubmit: (payload: { text: string; files: PromptInputFilePart[]; source: 'suggestion' }) => Promise<false | void>
   onRestoreDraft: (text: string) => void
   /** Changes when the active session changes; resets the history window to the latest page. */
   windowResetKey?: string

--- a/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
+++ b/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import type { MouseEvent as ReactMouseEvent } from 'react'
+import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent } from 'react'
 import { useCallback, useEffect, useState } from 'react'
 import { CheckIcon, CopyIcon } from 'lucide-react'
 import { Button } from '@hachej/boring-ui-kit'
 import type { BoringChatMessage, BoringChatPart } from '../../../shared/chat'
+import { useOpenArtifact } from '../../ArtifactOpenContext'
 import { resolveToolRendererForPart, toToolPart, type ToolRendererOverrides } from '../../bareToolRenderers'
 import { cn } from '../../lib'
 import {
@@ -46,6 +47,8 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
   const textParts = message.parts.filter((part): part is Extract<BoringChatPart, { type: 'text' }> => part.type === 'text')
   const fileParts = message.parts.filter((part): part is Extract<BoringChatPart, { type: 'file' }> => part.type === 'file')
   const finalParts = groupRenderableParts(message)
+  const attachmentSummaryPaths = role === 'user' ? attachmentPathsFromTextParts(textParts) : []
+  const openArtifact = useOpenArtifact()
   const shouldReserveStreamingActions = isStreaming && isAssistant && isLast
 
   return (
@@ -79,15 +82,40 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
                 : undefined,
             )}
           >
-            {fileParts.map((file, index) => (
-              <Attachment
-                key={`file-${message.id}-${index}`}
-                data={toAttachmentData(file, `file-${message.id}-${index}`)}
-              >
-                <AttachmentPreview className={role === 'user' ? '!size-5 shrink-0 rounded-[var(--radius-sm)]' : 'size-10 shrink-0 rounded-[var(--radius-md)]'} />
-                <AttachmentInfo className={role === 'user' ? 'min-w-0 max-w-[220px] flex-1 text-[12px]' : 'min-w-0 flex-1'} />
-              </Attachment>
-            ))}
+            {fileParts.map((file, index) => {
+              const openPath = file.path ?? attachmentSummaryPaths[index]
+              const canOpen = Boolean(openArtifact && openPath)
+              const openAttachment = () => {
+                if (!openPath) return
+                openArtifact?.(openPath)
+              }
+              const openAttachmentFromKeyboard = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+                if (event.key !== 'Enter' && event.key !== ' ') return
+                event.preventDefault()
+                openAttachment()
+              }
+
+              return (
+                <Attachment
+                  key={`file-${message.id}-${index}`}
+                  data={toAttachmentData(file, `file-${message.id}-${index}`)}
+                  {...(canOpen
+                    ? {
+                        role: 'button',
+                        tabIndex: 0,
+                        title: `Open ${openPath} in workspace`,
+                        'aria-label': `Open ${file.filename ?? openPath} in workspace`,
+                        'data-workspace-path': openPath,
+                        onClick: openAttachment,
+                        onKeyDown: openAttachmentFromKeyboard,
+                      }
+                    : undefined)}
+                >
+                  <AttachmentPreview className={role === 'user' ? '!size-5 shrink-0 rounded-[var(--radius-sm)]' : 'size-10 shrink-0 rounded-[var(--radius-md)]'} />
+                  <AttachmentInfo className={role === 'user' ? 'min-w-0 max-w-[220px] flex-1 text-[12px]' : 'min-w-0 flex-1'} />
+                </Attachment>
+              )
+            })}
           </Attachments>
         ) : null}
         {finalParts.map((item) => {
@@ -289,7 +317,35 @@ function stripAttachmentSummaryBlocks(text: string): string {
 }
 
 function isAttachmentSummaryLine(line: string): boolean {
-  return /^\[attached: .+ \(.+\)\]$/.test(line.trim())
+  const trimmed = line.trim()
+  return trimmed.startsWith('[attached: ')
+    || (trimmed.startsWith('<attachment ') && trimmed.includes('data-boring-agent="composer-file"'))
+}
+
+function attachmentPathsFromTextParts(parts: Extract<BoringChatPart, { type: 'text' }>[]): string[] {
+  return parts.flatMap((part) => part.text.split('\n').flatMap((line) => {
+    const trimmed = line.trim()
+    const taggedPath = attachmentTagAttr(trimmed, 'path')
+    if (taggedPath) return [taggedPath]
+    const oldInline = trimmed.match(/^\[attached: .+ Saved in workspace at: (.+?) Use the workspace file\/read tools/)
+    if (oldInline?.[1]) return [oldInline[1]]
+    const oldMultiline = trimmed.match(/^Saved in workspace at: (.+)$/)
+    return oldMultiline?.[1] ? [oldMultiline[1]] : []
+  }))
+}
+
+function attachmentTagAttr(line: string, name: string): string | undefined {
+  if (!line.startsWith('<attachment ') || !line.includes('data-boring-agent="composer-file"')) return undefined
+  const match = line.match(new RegExp(`\\b${name}="([^"]*)"`))
+  return match?.[1] ? unescapeAttachmentAttr(match[1]) : undefined
+}
+
+function unescapeAttachmentAttr(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&')
 }
 
 function MessageActionsBar({

--- a/packages/agent/src/front/chat/components/__tests__/PiTimelineMessage.test.tsx
+++ b/packages/agent/src/front/chat/components/__tests__/PiTimelineMessage.test.tsx
@@ -2,6 +2,7 @@
 import { fireEvent, render, screen, within } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 import type { BoringChatMessage } from '../../../../shared/chat'
+import { ArtifactOpenProvider } from '../../../ArtifactOpenContext'
 import { PiTimelineMessage } from '../PiTimelineMessage'
 
 vi.mock('../../../primitives/message', () => ({
@@ -34,7 +35,7 @@ vi.mock('../../../primitives/tool-call-group', () => ({
 
 vi.mock('../../../primitives/attachments', () => ({
   Attachments: ({ children }: any) => <div data-testid="attachments">{children}</div>,
-  Attachment: ({ children, data }: any) => <div data-filename={data.filename}>{children}</div>,
+  Attachment: ({ children, data, ...props }: any) => <div data-filename={data.filename} {...props}>{children}</div>,
   AttachmentPreview: () => <span>preview</span>,
   AttachmentInfo: () => <span>info</span>,
 }))
@@ -140,6 +141,112 @@ describe('PiTimelineMessage', () => {
     expect(screen.getByTestId('attachments').querySelector('[data-filename="image.png"]')).toBeTruthy()
     expect(screen.getByTestId('message-response').textContent).toBe('wait is inside the image?')
     expect(screen.queryByText(/attached: image\.png/)).toBeNull()
+  })
+
+  test('opens uploaded workspace attachment chips through the artifact opener', () => {
+    const onOpenArtifact = vi.fn()
+    const message: BoringChatMessage = {
+      id: 'u-open-file',
+      role: 'user',
+      status: 'done',
+      parts: [
+        { type: 'file', id: 'u-open-file:file', filename: 'image.png', mediaType: 'image/png', url: '/raw', path: 'assets/images/image.png' },
+      ],
+    }
+
+    render(
+      <ArtifactOpenProvider onOpenArtifact={onOpenArtifact}>
+        <PiTimelineMessage
+          message={message}
+          isLast={false}
+          isStreaming={false}
+          showThoughts={false}
+          toolRenderers={{}}
+        />
+      </ArtifactOpenProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open image.png in workspace' }))
+    expect(onOpenArtifact).toHaveBeenCalledWith('assets/images/image.png')
+  })
+
+  test('opens recovered history attachment chips using the stripped workspace path note', () => {
+    const onOpenArtifact = vi.fn()
+    const message: BoringChatMessage = {
+      id: 'u-recovered-path',
+      role: 'user',
+      status: 'done',
+      parts: [
+        { type: 'file', id: 'u-recovered-path:file', mediaType: 'image/png', url: 'data:image/png;base64,abc123' },
+        { type: 'text', id: 'u-recovered-path:text', text: 'can you read this ?\n\n[attached: grafik.png (image/png, not inlined — binary)\nSaved in workspace at: assets/images/grafik-mqhmrp1k-2drpcs.png\nUse the workspace file/read tools with this path if you need to inspect it.]' },
+      ],
+    }
+
+    render(
+      <ArtifactOpenProvider onOpenArtifact={onOpenArtifact}>
+        <PiTimelineMessage
+          message={message}
+          isLast={false}
+          isStreaming={false}
+          showThoughts={false}
+          toolRenderers={{}}
+        />
+      </ArtifactOpenProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open assets/images/grafik-mqhmrp1k-2drpcs.png in workspace' }))
+    expect(onOpenArtifact).toHaveBeenCalledWith('assets/images/grafik-mqhmrp1k-2drpcs.png')
+    expect(screen.getByTestId('message-response').textContent).toBe('can you read this ?')
+  })
+
+  test('strips generated binary attachment path notes from recovered user text', () => {
+    const message: BoringChatMessage = {
+      id: 'u-path-note',
+      role: 'user',
+      status: 'done',
+      parts: [
+        { type: 'text', id: 'u-path-note:text', text: 'can you read this ?\n\n[attached: grafik.png (image/png, not inlined — binary)\nSaved in workspace at: assets/images/grafik-mqhmrp1k-2drpcs.png\nUse the workspace file/read tools with this path if you need to inspect it.]' },
+      ],
+    }
+
+    render(
+      <PiTimelineMessage
+        message={message}
+        isLast={false}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+      />,
+    )
+
+    expect(screen.getByTestId('message-response').textContent).toBe('can you read this ?')
+    expect(screen.queryByText(/attached: grafik\.png/)).toBeNull()
+    expect(screen.queryByText(/Saved in workspace at/)).toBeNull()
+  })
+
+  test('strips generated structured attachment tags from recovered user text', () => {
+    const message: BoringChatMessage = {
+      id: 'u-tag-note',
+      role: 'user',
+      status: 'done',
+      parts: [
+        { type: 'text', id: 'u-tag-note:text', text: 'please review\n\n<attachment data-boring-agent="composer-file" filename="spec.md" mime="text/markdown" path="assets/uploads/spec.md">\n```\n# spec\n```\n</attachment>' },
+      ],
+    }
+
+    render(
+      <PiTimelineMessage
+        message={message}
+        isLast={false}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+      />,
+    )
+
+    expect(screen.getByTestId('message-response').textContent).toBe('please review')
+    expect(screen.queryByText(/attachment data-boring-agent/)).toBeNull()
+    expect(screen.queryByText(/# spec/)).toBeNull()
   })
 
   test('strips generated text attachment blocks from recovered user text', () => {

--- a/packages/agent/src/front/chat/pi/remotePiSession.ts
+++ b/packages/agent/src/front/chat/pi/remotePiSession.ts
@@ -646,6 +646,7 @@ function toOptimisticUserMessage(payload: PromptPayload | FollowUpPayload): Opti
         filename: attachment.filename,
         mediaType: attachment.mediaType,
         url: attachment.url,
+        path: attachment.path,
       })),
     ],
   }

--- a/packages/agent/src/front/chat/session/__tests__/composerPolicy.test.ts
+++ b/packages/agent/src/front/chat/session/__tests__/composerPolicy.test.ts
@@ -147,7 +147,7 @@ describe('PiComposerPolicyController submit policy', () => {
       attachments: [{ filename: 'spec.md', mediaType: 'text/markdown', url: 'https://files.test/spec.md' }],
     })])
     expect(session.prompts[0]?.message).toContain('Build it')
-    expect(session.prompts[0]?.message).toContain('[attached: spec.md (text/markdown)]')
+    expect(session.prompts[0]?.message).toContain('<attachment data-boring-agent="composer-file" filename="spec.md" mime="text/markdown">')
     expect(session.prompts[0]?.message).toContain('@files: src/app.ts')
     expect(session.prompts[0]?.displayMessage).toBe('Build it')
   })

--- a/packages/agent/src/front/chat/session/composerPolicy.ts
+++ b/packages/agent/src/front/chat/session/composerPolicy.ts
@@ -1,5 +1,5 @@
-import type { FileUIPart } from 'ai'
 import type { BoringChatMessage, ChatAttachmentPayload, PromptPayload } from '../../../shared/chat'
+import type { PromptInputFilePart } from '../../primitives/prompt-input-context'
 import type { AvailableModel, ModelSelection, ThinkingLevel } from '../../chatPanelSettings'
 import { DEFAULT_THINKING, isThinkingLevel, parseModelSelection } from '../../chatPanelSettings'
 import { createEnrichedSubmitPayload } from '../../chatSubmit'
@@ -31,7 +31,7 @@ export interface PiComposerSettings {
 
 export interface PiComposerSubmitInput {
   text: string
-  files?: FileUIPart[]
+  files?: PromptInputFilePart[]
   source?: 'composer' | 'suggestion' | 'auto-submit'
 }
 
@@ -46,7 +46,7 @@ export interface PiComposerPolicyOptions extends PiQueueControllerOptions {
   composerBlocked?: boolean
   blockerMessage?: string
   isActiveSession?: () => boolean
-  onBeforeSubmit?: (draft: string, context: { files: FileUIPart[]; source: PiComposerSubmitInput['source'] }) => boolean | Promise<boolean>
+  onBeforeSubmit?: (draft: string, context: { files: PromptInputFilePart[]; source: PiComposerSubmitInput['source'] }) => boolean | Promise<boolean>
   onCommandResult?: (message: string) => void
   onMentionedFilesConsumed?: () => void
 }
@@ -159,7 +159,7 @@ export class PiComposerPolicyController {
     return { type: 'command', command: commandName, ...(message ? { result: message } : {}), preserveDraft }
   }
 
-  private async runBeforeSubmit(draft: string, files: FileUIPart[], source: PiComposerSubmitInput['source']): Promise<boolean> {
+  private async runBeforeSubmit(draft: string, files: PromptInputFilePart[], source: PiComposerSubmitInput['source']): Promise<boolean> {
     const result = await this.options.onBeforeSubmit?.(draft, { files, source })
     return result !== false
   }
@@ -181,11 +181,12 @@ export class PiComposerPolicyController {
     return mentioned ?? []
   }
 
-  private toAttachmentPayloads(files: FileUIPart[]): ChatAttachmentPayload[] {
+  private toAttachmentPayloads(files: PromptInputFilePart[]): ChatAttachmentPayload[] {
     return files.map((file) => ({
       filename: file.filename,
       mediaType: file.mediaType,
       url: file.url,
+      ...(file.path ? { path: file.path } : {}),
     }))
   }
 }

--- a/packages/agent/src/front/chatAttachments.ts
+++ b/packages/agent/src/front/chatAttachments.ts
@@ -1,9 +1,9 @@
-import type { FileUIPart } from 'ai'
+import type { PromptInputFilePart } from './primitives/prompt-input-context'
 import { convertBlobUrlToDataUrl } from './browserFiles'
 
 const INLINE_TEXT_MIME_PREFIXES = ['text/', 'application/json', 'application/xml', 'application/yaml']
 
-export async function resolveAttachmentUrls(files: FileUIPart[] | undefined) {
+export async function resolveAttachmentUrls(files: PromptInputFilePart[] | undefined) {
   if (!files) return []
   return Promise.all(files.map(async (file) => ({
     filename: file.filename,
@@ -11,14 +11,12 @@ export async function resolveAttachmentUrls(files: FileUIPart[] | undefined) {
     url: file.url.startsWith('blob:')
       ? (await convertBlobUrlToDataUrl(file.url)) ?? file.url
       : file.url,
-    ...(typeof (file as unknown as { path?: unknown }).path === 'string'
-      ? { path: (file as unknown as { path: string }).path }
-      : {}),
+    ...(file.path ? { path: file.path } : {}),
   })))
 }
 
 /** Best-effort fetch of a FileUIPart's bytes as UTF-8 text. */
-export async function readFileAsText(file: FileUIPart): Promise<string | null> {
+export async function readFileAsText(file: PromptInputFilePart): Promise<string | null> {
   const looksText =
     INLINE_TEXT_MIME_PREFIXES.some((p) => file.mediaType?.startsWith(p)) ||
     /\.(md|txt|csv|json|yaml|yml|ts|tsx|js|jsx|py|rb|rs|go|sh|bash|css|html|sql|log)$/i.test(file.filename ?? '')

--- a/packages/agent/src/front/chatSubmit.ts
+++ b/packages/agent/src/front/chatSubmit.ts
@@ -1,9 +1,17 @@
-import type { FileUIPart } from 'ai'
+import type { PromptInputFilePart } from './primitives/prompt-input-context'
 import { readFileAsText, resolveAttachmentUrls } from './chatAttachments'
 
 export interface EnrichedSubmitPayload {
   serverMessage: string
   attachments: Awaited<ReturnType<typeof resolveAttachmentUrls>>
+}
+
+function escapeAttachmentAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
 }
 
 export async function createEnrichedSubmitPayload({
@@ -12,29 +20,31 @@ export async function createEnrichedSubmitPayload({
   mentionedFiles,
 }: {
   text: string
-  files: FileUIPart[]
+  files: PromptInputFilePart[]
   mentionedFiles: string[]
 }): Promise<EnrichedSubmitPayload> {
   // Build the server-side enriched message (text attachments inlined for
   // pi, which is text-only). Importantly, the VISIBLE user bubble only
   // shows the raw `text` plus file chips — the enriched version is not
-  // rendered in the UI, just sent to the server. This keeps
-  // "[attached: foo.png …]" markers out of the message bubble.
+  // rendered in the UI, just sent to the server. Keep the model-facing
+  // attachment note structured so reload/history code can strip it reliably.
   const attachmentSummaries: string[] = []
   for (const file of files ?? []) {
     const label = file.filename ?? 'attachment'
     const mime = file.mediaType ?? 'application/octet-stream'
-    const workspacePath = typeof (file as unknown as { path?: unknown }).path === 'string'
-      ? (file as unknown as { path: string }).path
-      : undefined
-    const pathNote = workspacePath
-      ? `\nSaved in workspace at: ${workspacePath}\nUse the workspace file/read tools with this path if you need to inspect it.`
-      : ''
+    const workspacePath = file.path
+    const attrs: Array<[string, string]> = [
+      ['data-boring-agent', 'composer-file'],
+      ['filename', label],
+      ['mime', mime],
+    ]
+    if (workspacePath) attrs.push(['path', workspacePath])
+    const attrText = attrs.map(([name, value]) => `${name}="${escapeAttachmentAttr(value)}"`).join(' ')
     const content = await readFileAsText(file)
     if (content !== null) {
-      attachmentSummaries.push(`[attached: ${label} (${mime})${pathNote}]\n\`\`\`\n${content}\n\`\`\``)
+      attachmentSummaries.push(`<attachment ${attrText}>\n\`\`\`\n${content}\n\`\`\`\n</attachment>`)
     } else {
-      attachmentSummaries.push(`[attached: ${label} (${mime}, not inlined — binary)${pathNote}]`)
+      attachmentSummaries.push(`<attachment ${attrText} binary="true" />`)
     }
   }
 

--- a/packages/agent/src/front/primitives/prompt-input-context.ts
+++ b/packages/agent/src/front/primitives/prompt-input-context.ts
@@ -1,7 +1,8 @@
 import type { FileUIPart, SourceDocumentUIPart } from 'ai'
 import { createContext, useContext, type RefObject } from 'react'
 
-export type AttachmentEntry = FileUIPart & { id: string; status?: 'uploading' | 'ready' | 'error'; path?: string }
+export type PromptInputFilePart = FileUIPart & { path?: string }
+export type AttachmentEntry = PromptInputFilePart & { id: string; status?: 'uploading' | 'ready' | 'error' }
 
 export interface AttachmentsContext {
   files: AttachmentEntry[]

--- a/packages/agent/src/front/primitives/prompt-input.tsx
+++ b/packages/agent/src/front/primitives/prompt-input.tsx
@@ -25,7 +25,7 @@ import {
 } from "@hachej/boring-ui-kit";
 import { Input, Spinner } from "@hachej/boring-ui-kit";
 import { cn } from "@/front/lib";
-import type { ChatStatus, FileUIPart, SourceDocumentUIPart } from "ai";
+import type { ChatStatus, SourceDocumentUIPart } from "ai";
 import {
   CornerDownLeftIcon,
   ImageIcon,
@@ -59,6 +59,7 @@ import {
   type AttachmentEntry,
   type AttachmentsContext,
   type PromptInputControllerProps,
+  type PromptInputFilePart,
   type ReferencedSourcesContext,
 } from "./prompt-input-context";
 import {
@@ -77,6 +78,7 @@ export {
   type AttachmentEntry,
   type AttachmentsContext,
   type PromptInputControllerProps,
+  type PromptInputFilePart,
   type ReferencedSourcesContext,
   type TextInputContext,
 } from "./prompt-input-context";
@@ -300,7 +302,7 @@ export const PromptInputActionAddScreenshot = ({
 
 export interface PromptInputMessage {
   text: string;
-  files: FileUIPart[];
+  files: PromptInputFilePart[];
 }
 
 export type PromptInputProps = Omit<
@@ -716,7 +718,7 @@ export const PromptInput = ({
       try {
         // Convert remaining blob URLs to data URLs (fallback for files without
         // onUploadFile, or files whose upload failed and kept the blob URL).
-        const convertedFiles: FileUIPart[] = await Promise.all(
+        const convertedFiles: PromptInputFilePart[] = await Promise.all(
           files.map(async ({ id: _id, status: _status, ...item }) => {
             if (item.url?.startsWith("blob:")) {
               const dataUrl = await convertBlobUrlToDataUrl(item.url);

--- a/packages/agent/src/front/slashCommands/__tests__/builtins.test.ts
+++ b/packages/agent/src/front/slashCommands/__tests__/builtins.test.ts
@@ -111,7 +111,7 @@ describe('/model', () => {
   })
 })
 
-describe('/thinking and /think', () => {
+describe('/thinking', () => {
   test('/thinking opens thinking picker when no args', () => {
     const openThinkingPicker = vi.fn(() => true)
     const ctx = makeContext({ openThinkingPicker })
@@ -119,16 +119,13 @@ describe('/thinking and /think', () => {
     expect(openThinkingPicker).toHaveBeenCalledOnce()
   })
 
-  test('/think is an alias for /thinking', () => {
-    const selectComposerThinking = vi.fn()
-    const ctx = makeContext({ selectComposerThinking })
-    getBuiltin('think').handler('high', ctx)
-    expect(selectComposerThinking).toHaveBeenCalledWith('high')
+  test('does not register the old /think alias', () => {
+    expect(builtinCommands.find((c) => c.name === 'think')).toBeUndefined()
   })
 })
 
 describe('all builtins registered', () => {
-  test.each(['reset', 'clear', 'reload', 'model', 'thinking', 'think', 'help'])('includes /%s', (name) => {
+  test.each(['reset', 'clear', 'reload', 'model', 'thinking', 'help'])('includes /%s', (name) => {
     expect(builtinCommands.find((c) => c.name === name)).toBeDefined()
   })
 

--- a/packages/agent/src/front/slashCommands/builtins.ts
+++ b/packages/agent/src/front/slashCommands/builtins.ts
@@ -46,15 +46,6 @@ export const builtinCommands: SlashCommand[] = [
     },
   },
   {
-    name: 'think',
-    description: 'Alias for /thinking',
-    handler(args, ctx) {
-      const query = args.trim()
-      if (query) return ctx.selectComposerThinking?.(query)
-      if (ctx.openThinkingPicker?.() === false) return { preserveDraft: true }
-    },
-  },
-  {
     name: 'help',
     description: 'Show available commands',
     handler(_, ctx) {

--- a/packages/agent/src/front/upload/uploadFile.ts
+++ b/packages/agent/src/front/upload/uploadFile.ts
@@ -3,6 +3,7 @@ export interface UploadFileOptions {
   workspaceRequestId?: string | null
   directory?: string
   sourcePath?: string
+  responseUrl?: 'markdown' | 'raw'
   fetch?: typeof globalThis.fetch
 }
 
@@ -24,7 +25,7 @@ export async function uploadFile(
   file: File,
   opts: UploadFileOptions = {},
 ): Promise<UploadFileResult> {
-  const { apiBaseUrl = '', workspaceRequestId, directory, sourcePath, fetch: fetchImpl = globalThis.fetch } = opts
+  const { apiBaseUrl = '', workspaceRequestId, directory, sourcePath, responseUrl = 'markdown', fetch: fetchImpl = globalThis.fetch } = opts
 
   const dataUrl = await readAsDataUrl(file)
   const comma = dataUrl.indexOf(',')
@@ -50,7 +51,23 @@ export async function uploadFile(
   if (!res.ok) throw new Error(`Upload failed: ${res.status}`)
 
   const body = (await res.json()) as { markdownUrl?: string; path?: string }
-  const url = body.markdownUrl ?? body.path
+  const path = body.path
+  if (responseUrl === 'raw') {
+    if (!path) throw new Error('Upload response missing path')
+    return { url: rawWorkspaceFileUrl(path, { apiBaseUrl, workspaceRequestId }), path }
+  }
+
+  const url = body.markdownUrl ?? path
   if (!url) throw new Error('Upload response missing url')
-  return { url, path: body.path ?? url }
+  return { url, path: path ?? url }
+}
+
+function rawWorkspaceFileUrl(
+  path: string,
+  opts: { apiBaseUrl?: string; workspaceRequestId?: string | null },
+): string {
+  const base = (opts.apiBaseUrl ?? '').replace(/\/$/, '')
+  const params = new URLSearchParams({ path })
+  if (opts.workspaceRequestId) params.set('workspaceId', opts.workspaceRequestId)
+  return `${base}/api/v1/files/raw?${params.toString()}`
 }

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -207,6 +207,40 @@ test('registerAgentRoutes provisions the resolved request workspace, not the hos
   }
 }, 15_000)
 
+test('registerAgentRoutes resolves raw file preview workspace from query param', async () => {
+  const baseRoot = await makeTempDir('boring-agent-raw-preview-base-')
+  const workspaceA = await makeTempDir('boring-agent-raw-preview-a-')
+  await writeFile(join(baseRoot, 'chart.png'), 'base-root')
+  await writeFile(join(workspaceA, 'chart.png'), 'workspace-a')
+  const getWorkspaceId = vi.fn(async (request: { headers: Record<string, unknown> }) => String(request.headers['x-boring-workspace-id'] ?? ''))
+  const getWorkspaceRoot = vi.fn(async (workspaceId: string) => workspaceId === 'workspace-a' ? workspaceA : baseRoot)
+  const app = Fastify({ logger: false })
+
+  await app.register(registerAgentRoutes, {
+    workspaceRoot: baseRoot,
+    mode: 'direct',
+    getWorkspaceId,
+    getWorkspaceRoot,
+  })
+  await app.ready()
+
+  try {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/files/raw?path=chart.png&workspaceId=workspace-a',
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toBe('workspace-a')
+    expect(getWorkspaceId).toHaveBeenCalledWith(expect.objectContaining({
+      headers: expect.objectContaining({ 'x-boring-workspace-id': 'workspace-a' }),
+    }))
+    expect(getWorkspaceRoot).toHaveBeenCalledWith('workspace-a', expect.anything())
+  } finally {
+    await app.close()
+  }
+})
+
 test('request-scoped ready-status resolves the requested workspace', async () => {
   const baseRoot = await makeTempDir('boring-agent-ready-base-')
   const workspaceA = await makeTempDir('boring-agent-ready-workspace-a-')

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -239,6 +239,7 @@ export async function createAgentApp(
     harness,
     sessionStore: harness.sessions,
     workdir: runtimeBundle.workspace.root,
+    workspace: runtimeBundle.workspace,
     metering: opts.metering,
   })
   await app.register(piChatRoutes, { service: piChatService })

--- a/packages/agent/src/server/http/routes/__tests__/file.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/file.test.ts
@@ -517,6 +517,64 @@ describe('file routes (NodeWorkspace integration)', () => {
     await expect(readFile(join(workspaceRoot, body.path))).resolves.toEqual(pngBytes)
   })
 
+  test('POST /api/v1/files/upload stores non-image files under uploads path', async () => {
+    const { app, workspaceRoot } = await createTestApp()
+    const pdfBytes = Buffer.from('%PDF-1.4\n')
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files/upload',
+      payload: {
+        filename: 'Report.pdf',
+        contentType: 'application/pdf',
+        contentBase64: pdfBytes.toString('base64'),
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.path).toMatch(/^assets\/uploads\/Report-[a-z0-9]+-[a-z0-9]+\.pdf$/)
+    expect(body.markdownUrl).toBe(body.path)
+    await expect(readFile(join(workspaceRoot, body.path))).resolves.toEqual(pdfBytes)
+
+    const raw = await app.inject({ method: 'GET', url: `/api/v1/files/raw?path=${encodeURIComponent(body.path)}` })
+    expect(raw.statusCode).toBe(200)
+    expect(raw.headers['content-type']).toBe('application/pdf')
+    expect(raw.headers['x-content-type-options']).toBe('nosniff')
+  })
+
+  test('POST /api/v1/files/upload does not preserve SVG as active web content', async () => {
+    const { app } = await createTestApp()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files/upload',
+      payload: {
+        filename: 'payload.svg',
+        contentType: 'image/svg+xml',
+        contentBase64: Buffer.from('<svg><script>alert(1)</script></svg>').toString('base64'),
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().path).toMatch(/^assets\/images\/payload-[a-z0-9]+-[a-z0-9]+\.bin$/)
+  })
+
+  test('POST /api/v1/files/upload does not preserve executable web extensions', async () => {
+    const { app } = await createTestApp()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files/upload',
+      payload: {
+        filename: 'payload.html',
+        contentType: 'text/html',
+        contentBase64: Buffer.from('<script>alert(1)</script>').toString('base64'),
+      },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json().path).toMatch(/^assets\/uploads\/payload-[a-z0-9]+-[a-z0-9]+\.bin$/)
+  })
+
   test('GET/PUT /api/v1/workspace-settings round-trips markdown image path', async () => {
     const { app, workspaceRoot } = await createTestApp()
 

--- a/packages/agent/src/server/http/routes/file.ts
+++ b/packages/agent/src/server/http/routes/file.ts
@@ -27,7 +27,32 @@ interface PathValidationLike {
 
 const BORING_SETTINGS_PATH = '.boring/settings'
 const DEFAULT_MARKDOWN_IMAGE_UPLOAD_DIR = 'assets/images'
+const DEFAULT_FILE_UPLOAD_DIR = 'assets/uploads'
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+
+const IMAGE_UPLOAD_EXTENSIONS = new Set(['avif', 'gif', 'jpg', 'jpeg', 'png', 'webp'])
+const SAFE_UNKNOWN_FILE_EXTENSIONS = new Set(['csv', 'doc', 'docx', 'json', 'md', 'pdf', 'ppt', 'pptx', 'rtf', 'txt', 'xls', 'xlsx', 'zip'])
+const MIME_UPLOAD_EXTENSIONS: Record<string, string[]> = {
+  'application/json': ['json'],
+  'application/msword': ['doc'],
+  'application/pdf': ['pdf'],
+  'application/rtf': ['rtf'],
+  'application/vnd.ms-excel': ['xls'],
+  'application/vnd.ms-powerpoint': ['ppt'],
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': ['pptx'],
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ['xlsx'],
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ['docx'],
+  'application/zip': ['zip'],
+  'image/avif': ['avif'],
+  'image/gif': ['gif'],
+  'image/jpeg': ['jpg', 'jpeg'],
+  'image/png': ['png'],
+  'image/svg+xml': ['bin'],
+  'image/webp': ['webp'],
+  'text/csv': ['csv'],
+  'text/markdown': ['md'],
+  'text/plain': ['txt'],
+}
 
 interface BoringWorkspaceSettings {
   markdown?: {
@@ -161,12 +186,11 @@ function normalizeUploadDir(value: unknown): string | null {
 
 function extForUpload(filename: string, contentType: string): string {
   const fromName = extname(filename).toLowerCase().replace(/^\./, '')
-  if (/^[a-z0-9]{1,12}$/.test(fromName)) return fromName
-  if (contentType === 'image/jpeg') return 'jpg'
-  if (contentType === 'image/png') return 'png'
-  if (contentType === 'image/gif') return 'gif'
-  if (contentType === 'image/webp') return 'webp'
-  if (contentType === 'image/svg+xml') return 'svg'
+  const safeFromName = /^[a-z0-9]{1,12}$/.test(fromName) ? fromName : ''
+  const allowed = MIME_UPLOAD_EXTENSIONS[contentType]
+  if (allowed) return safeFromName && allowed.includes(safeFromName) ? safeFromName : allowed[0] ?? 'bin'
+  if (contentType.startsWith('image/')) return safeFromName && IMAGE_UPLOAD_EXTENSIONS.has(safeFromName) ? safeFromName : 'bin'
+  if (contentType === 'application/octet-stream' && safeFromName && SAFE_UNKNOWN_FILE_EXTENSIONS.has(safeFromName)) return safeFromName
   return 'bin'
 }
 
@@ -197,12 +221,19 @@ function contentTypeForPath(path: string): string {
     case '.png': return 'image/png'
     case '.svg': return 'image/svg+xml'
     case '.webp': return 'image/webp'
-    case '.css': return 'text/css; charset=utf-8'
-    case '.html':
-    case '.htm': return 'text/html; charset=utf-8'
-    case '.js': return 'text/javascript; charset=utf-8'
-    case '.mjs': return 'text/javascript; charset=utf-8'
+    case '.txt': return 'text/plain; charset=utf-8'
+    case '.md': return 'text/markdown; charset=utf-8'
+    case '.json': return 'application/json; charset=utf-8'
+    case '.csv': return 'text/csv; charset=utf-8'
     case '.pdf': return 'application/pdf'
+    case '.doc': return 'application/msword'
+    case '.docx': return 'application/vnd.openxmlformats-officedocument.wordprocessingml.document'
+    case '.xls': return 'application/vnd.ms-excel'
+    case '.xlsx': return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    case '.ppt': return 'application/vnd.ms-powerpoint'
+    case '.pptx': return 'application/vnd.openxmlformats-officedocument.presentationml.presentation'
+    case '.rtf': return 'application/rtf'
+    case '.zip': return 'application/zip'
     default: return 'application/octet-stream'
   }
 }
@@ -251,6 +282,7 @@ export function fileRoutes(
         .header('content-type', contentTypeForPath(path))
         .header('content-length', String(bytes.byteLength))
         .header('cache-control', 'no-store')
+        .header('x-content-type-options', 'nosniff')
         .send(Buffer.from(bytes))
     } catch (err) {
       return classifyError(err, reply, 'file')
@@ -387,17 +419,17 @@ export function fileRoutes(
     if (filename === null) return
     const contentBase64 = requireStringParam(body?.contentBase64, 'contentBase64', reply)
     if (contentBase64 === null) return
-    const contentType = typeof body.contentType === 'string' ? body.contentType.trim().toLowerCase() : ''
-    if (!contentType.startsWith('image/')) {
-      return reply.code(400).send({
-        error: { code: ERROR_CODE_VALIDATION_ERROR, message: 'contentType must be an image/* MIME type', field: 'contentType' },
-      })
-    }
+    const contentType = typeof body.contentType === 'string' && body.contentType.trim()
+      ? body.contentType.trim().toLowerCase()
+      : 'application/octet-stream'
 
     try {
       const workspace = await resolveWorkspace(request)
       const settings = await readWorkspaceSettings(workspace)
-      const dir = normalizeUploadDir(body.directory) ?? normalizeUploadDir(settings.markdown?.imageUploadDir) ?? DEFAULT_MARKDOWN_IMAGE_UPLOAD_DIR
+      const isImage = contentType.startsWith('image/')
+      const dir = isImage
+        ? normalizeUploadDir(body.directory) ?? normalizeUploadDir(settings.markdown?.imageUploadDir) ?? DEFAULT_MARKDOWN_IMAGE_UPLOAD_DIR
+        : DEFAULT_FILE_UPLOAD_DIR
       const ext = extForUpload(filename, contentType)
       const base = basenameForUpload(filename)
       const unique = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -3,6 +3,7 @@ import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent'
 import type { AgentHarness, RunContext, SendMessageInput } from '../../../shared/harness'
 import type { SessionStore } from '../../../shared/session'
 import type { PiChatEvent } from '../../../shared/chat'
+import type { Workspace } from '../../../shared/workspace'
 import { createInitialPiChatState, piChatReducer } from '../../../front/chat/pi/piChatReducer'
 import { selectMessagesForRender } from '../../../front/chat/pi/selectors'
 import type { PiAgentSessionAdapter, PiAgentSessionSnapshot } from '../PiAgentSessionAdapter'
@@ -99,12 +100,13 @@ function createHarness(adapter: PiAgentSessionAdapter): AgentHarness & {
   }
 }
 
-function createService(adapter = createAdapter()) {
+function createService(adapter = createAdapter(), workspace?: Workspace) {
   const harness = createHarness(adapter)
   const service = new HarnessPiChatService({
     harness,
     sessionStore,
     workdir: '/workspace',
+    ...(workspace ? { workspace } : {}),
   })
   return { service, harness, adapter }
 }
@@ -154,6 +156,48 @@ describe('HarnessPiChatService', () => {
     if (subscription.type === 'ok') subscription.unsubscribe()
   })
 
+  it('keeps enriched prompt notes out of visible user message finals', async () => {
+    const adapter = createAdapter()
+    const { service } = createService(adapter)
+    const events: PiChatEvent[] = []
+    const subscription = await service.subscribe(ctx, 's1', 0, (event) => events.push(event))
+    expect(subscription.type).toBe('ok')
+
+    const displayText = 'can you read this ?'
+    const serverText = `${displayText}\n\n[attached: grafik.png (image/png, not inlined — binary) Saved in workspace at: assets/images/grafik.png]`
+
+    await service.prompt(ctx, 's1', {
+      message: serverText,
+      displayMessage: displayText,
+      clientNonce: 'nonce-attachment-note',
+      attachments: [{ filename: 'grafik.png', mediaType: 'image/png', url: '/api/v1/files/raw?path=assets%2Fimages%2Fgrafik.png', path: 'assets/images/grafik.png' }],
+    })
+
+    adapter.emit({
+      type: 'message_start',
+      message: { id: 'u-attachment', role: 'user', content: [{ type: 'text', text: serverText }] },
+    } as unknown as AgentSessionEvent)
+    adapter.emit({
+      type: 'message_end',
+      message: { id: 'u-attachment', role: 'user', content: [{ type: 'text', text: serverText }] },
+    } as unknown as AgentSessionEvent)
+
+    expect(events.find((event) => event.type === 'message-start')).toMatchObject({
+      type: 'message-start',
+      text: displayText,
+      clientNonce: 'nonce-attachment-note',
+      files: [expect.objectContaining({ type: 'file', path: 'assets/images/grafik.png' })],
+    })
+    const final = events.find((event): event is Extract<PiChatEvent, { type: 'message-end' }> => event.type === 'message-end')?.final
+    expect(final?.clientNonce).toBe('nonce-attachment-note')
+    expect(final?.parts).toEqual([
+      expect.objectContaining({ type: 'text', text: displayText }),
+      expect.objectContaining({ type: 'file', filename: 'grafik.png', path: 'assets/images/grafik.png' }),
+    ])
+
+    if (subscription.type === 'ok') subscription.unsubscribe()
+  })
+
   it('forwards prompt model, thinking, and image attachments through the Pi-native adapter path', async () => {
     const adapter = createAdapter()
     const { service, harness } = createService(adapter)
@@ -183,6 +227,138 @@ describe('HarnessPiChatService', () => {
         images: [{ type: 'image', mimeType: 'image/png', data: 'abc123' }],
       },
     })
+  })
+
+  it('expands uploaded workspace image paths before prompting Pi', async () => {
+    const adapter = createAdapter()
+    const pngBytes = new Uint8Array(Buffer.from('iVBORw0KGgo=', 'base64'))
+    const workspace = {
+      stat: vi.fn(async () => ({ kind: 'file', size: pngBytes.byteLength, mtimeMs: 1 })),
+      readBinaryFile: vi.fn(async (path: string) => {
+        expect(path).toBe('assets/images/diagram.png')
+        return pngBytes
+      }),
+    } as unknown as Workspace
+    const { service } = createService(adapter, workspace)
+
+    await service.prompt(ctx, 's1', {
+      message: 'look at this',
+      clientNonce: 'nonce-workspace-image',
+      attachments: [
+        {
+          filename: 'diagram.png',
+          mediaType: 'image/png',
+          url: '/api/v1/files/raw?path=assets%2Fimages%2Fdiagram.png&workspaceId=workspace-a',
+          path: 'assets/images/diagram.png',
+        },
+      ],
+    })
+
+    expect(adapter.prompt).toHaveBeenCalledWith({
+      text: 'look at this',
+      options: {
+        images: [{ type: 'image', mimeType: 'image/png', data: Buffer.from(pngBytes).toString('base64') }],
+      },
+    })
+  })
+
+  it('does not expand non-image workspace file attachments', async () => {
+    const adapter = createAdapter()
+    const workspace = {
+      stat: vi.fn(async () => ({ kind: 'file', size: 8, mtimeMs: 1 })),
+      readBinaryFile: vi.fn(async () => new Uint8Array(Buffer.from('%PDF-1.4'))),
+    } as unknown as Workspace
+    const { service } = createService(adapter, workspace)
+
+    await service.prompt(ctx, 's1', {
+      message: 'read this pdf',
+      clientNonce: 'nonce-pdf',
+      attachments: [
+        {
+          filename: 'manual.pdf',
+          mediaType: 'application/pdf',
+          url: '/api/v1/files/raw?path=assets%2Fuploads%2Fmanual.pdf&workspaceId=workspace-a',
+          path: 'assets/uploads/manual.pdf',
+        },
+      ],
+    })
+
+    expect(workspace.readBinaryFile).not.toHaveBeenCalled()
+    expect(adapter.prompt).toHaveBeenCalledWith('read this pdf')
+  })
+
+  it('does not expand fake workspace image paths with non-image bytes', async () => {
+    const adapter = createAdapter()
+    const workspace = {
+      stat: vi.fn(async () => ({ kind: 'file', size: 8, mtimeMs: 1 })),
+      readBinaryFile: vi.fn(async () => new Uint8Array(Buffer.from('%PDF-1.4'))),
+    } as unknown as Workspace
+    const { service } = createService(adapter, workspace)
+
+    await service.prompt(ctx, 's1', {
+      message: 'attached fake image',
+      clientNonce: 'nonce-fake-image',
+      attachments: [
+        {
+          filename: 'fake.png',
+          mediaType: 'image/png',
+          url: '/api/v1/files/raw?path=assets%2Fimages%2Ffake.png&workspaceId=workspace-a',
+          path: 'assets/images/fake.png',
+        },
+      ],
+    })
+
+    expect(workspace.readBinaryFile).toHaveBeenCalledWith('assets/images/fake.png')
+    expect(adapter.prompt).toHaveBeenCalledWith('attached fake image')
+  })
+
+  it('does not expand oversized workspace image paths', async () => {
+    const adapter = createAdapter()
+    const workspace = {
+      stat: vi.fn(async () => ({ kind: 'file', size: 11 * 1024 * 1024, mtimeMs: 1 })),
+      readBinaryFile: vi.fn(async () => new Uint8Array(Buffer.from('too-large'))),
+    } as unknown as Workspace
+    const { service } = createService(adapter, workspace)
+
+    await service.prompt(ctx, 's1', {
+      message: 'attached large image',
+      clientNonce: 'nonce-large-image',
+      attachments: [
+        {
+          filename: 'large.png',
+          mediaType: 'image/png',
+          url: '/api/v1/files/raw?path=assets%2Fimages%2Flarge.png&workspaceId=workspace-a',
+          path: 'assets/images/large.png',
+        },
+      ],
+    })
+
+    expect(workspace.readBinaryFile).not.toHaveBeenCalled()
+    expect(adapter.prompt).toHaveBeenCalledWith('attached large image')
+  })
+
+  it('does not expand workspace images that grow after stat', async () => {
+    const adapter = createAdapter()
+    const workspace = {
+      stat: vi.fn(async () => ({ kind: 'file', size: 8, mtimeMs: 1 })),
+      readBinaryFile: vi.fn(async () => new Uint8Array(11 * 1024 * 1024)),
+    } as unknown as Workspace
+    const { service } = createService(adapter, workspace)
+
+    await service.prompt(ctx, 's1', {
+      message: 'attached growing image',
+      clientNonce: 'nonce-growing-image',
+      attachments: [
+        {
+          filename: 'growing.png',
+          mediaType: 'image/png',
+          url: '/api/v1/files/raw?path=assets%2Fimages%2Fgrowing.png&workspaceId=workspace-a',
+          path: 'assets/images/growing.png',
+        },
+      ],
+    })
+
+    expect(adapter.prompt).toHaveBeenCalledWith('attached growing image')
   })
 
   it('acknowledges prompt acceptance before the active run settles', async () => {

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -1,5 +1,6 @@
 import type { AgentHarness, RunContext, SendMessageInput } from '../../shared/harness'
 import type { SessionListOptions, SessionStore } from '../../shared/session'
+import type { Workspace } from '../../shared/workspace'
 import type { BoringChatMessage, BoringChatPart, ChatError, FollowUpPayload, FollowUpReceipt, InterruptPayload, PiChatEvent, PiChatSnapshot, PromptPayload, PromptReceipt, QueuedUserMessage, QueueClearPayload, QueueClearReceipt, StopPayload, StopReceipt } from '../../shared/chat'
 import { ErrorCode } from '../../shared/error-codes'
 import type { PiChatSessionService, PiChatEventSubscriber, PiChatEventStreamResult } from '../http/routes/piChat'
@@ -16,6 +17,9 @@ type PiNativeHarness = AgentHarness & {
   getPiSessionAdapter?: (input: SendMessageInput, ctx: RunContext) => Promise<PiAgentSessionAdapter>
   hasPiSession?: (sessionId: string) => boolean
 }
+
+const MAX_PROMPT_IMAGE_BYTES = 10 * 1024 * 1024
+const PROMPT_IMAGE_EXTENSIONS = new Set(['.avif', '.gif', '.jpg', '.jpeg', '.png', '.webp'])
 
 /** Pi session stores additionally expose the raw persisted message entries so
  * the cold-load path can run them through the same buildPiChatHistory mapping
@@ -42,6 +46,7 @@ export interface HarnessPiChatServiceOptions {
   harness: AgentHarness
   sessionStore: SessionStore
   workdir: string
+  workspace?: Workspace
   /**
    * Optional host billing sink. When set, accepted prompts/follow-ups reserve
    * before execution (a rejecting sink blocks the request), native assistant
@@ -57,6 +62,7 @@ export class HarnessPiChatService implements PiChatSessionService {
   private readonly harness: PiNativeHarness
   private readonly sessionStore: PiSessionStoreLike
   private readonly workdir: string
+  private readonly workspace?: Workspace
   private readonly channels = new Map<string, LiveSessionChannel>()
   // Single-flight guard so concurrent cold callers (e.g. two browser tabs each
   // opening /events while the session is still being created) converge on one
@@ -73,6 +79,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     this.harness = options.harness as PiNativeHarness
     this.sessionStore = options.sessionStore
     this.workdir = options.workdir
+    this.workspace = options.workspace
     this.metering = options.metering
       ? new PiChatMeteringCoordinator(options.metering, options.meteringLogger)
       : undefined
@@ -191,7 +198,8 @@ export class HarnessPiChatService implements PiChatSessionService {
     const channel = this.channels.get(sessionId)
     const receiptCursor = nextPromptReceiptCursor(channel)
     try {
-      const run = this.trackActiveRun(sessionId, adapter.prompt(toPiPromptInput(payload)))
+      const input = await toPiPromptInput(payload, this.workspace)
+      const run = this.trackActiveRun(sessionId, adapter.prompt(input))
       run.catch((error) => {
         this.metering?.failPromptRun(sessionId, payload.clientNonce)
         if (!this.messageMetadata.hasPrompt(sessionId, { clientNonce: payload.clientNonce, displayText: payload.displayMessage ?? payload.message })) return
@@ -543,6 +551,7 @@ function promptPayloadFileParts(payload: PromptPayload, messageId: string): Bori
     filename: attachment.filename,
     mediaType: attachment.mediaType,
     url: attachment.url,
+    path: attachment.path,
   }))
 }
 
@@ -584,21 +593,74 @@ function messageTime(message: BoringChatMessage): number | undefined {
   return Number.isFinite(timestamp) ? timestamp : undefined
 }
 
-function toPiPromptInput(payload: PromptPayload): PiAgentPromptInput {
-  const images = promptImagesFromAttachments(payload.attachments)
+async function toPiPromptInput(payload: PromptPayload, workspace?: Workspace): Promise<PiAgentPromptInput> {
+  const images = await promptImagesFromAttachments(payload.attachments, workspace)
   if (images.length === 0) return payload.message
   return { text: payload.message, options: { images } }
 }
 
-function promptImagesFromAttachments(attachments: PromptPayload['attachments']): Array<{ type: 'image'; mimeType: string; data: string }> {
+async function promptImagesFromAttachments(
+  attachments: PromptPayload['attachments'],
+  workspace?: Workspace,
+): Promise<Array<{ type: 'image'; mimeType: string; data: string }>> {
   const images: Array<{ type: 'image'; mimeType: string; data: string }> = []
   for (const attachment of attachments ?? []) {
     const match = attachment.url.match(/^data:(image\/[^;]+);base64,(.+)$/)
-    if (!match) continue
-    const [, mimeType, data] = match
-    images.push({ type: 'image', mimeType, data })
+    if (match) {
+      const [, mimeType, data] = match
+      images.push({ type: 'image', mimeType, data })
+      continue
+    }
+
+    if (!workspace?.readBinaryFile || !isWorkspaceImageAttachment(attachment)) continue
+    try {
+      const stat = await workspace.stat(attachment.path)
+      if (stat.kind !== 'file' || stat.size <= 0 || stat.size > MAX_PROMPT_IMAGE_BYTES) continue
+      const bytes = await workspace.readBinaryFile(attachment.path)
+      if (bytes.byteLength <= 0 || bytes.byteLength > MAX_PROMPT_IMAGE_BYTES) continue
+      const detectedMimeType = detectPromptImageMimeType(bytes)
+      if (!detectedMimeType) continue
+      images.push({
+        type: 'image',
+        mimeType: detectedMimeType,
+        data: Buffer.from(bytes).toString('base64'),
+      })
+    } catch {
+      // Best effort: the enriched prompt still points the agent at the
+      // workspace path, so a transient read miss must not reject the turn.
+    }
   }
   return images
+}
+
+function isWorkspaceImageAttachment(
+  attachment: NonNullable<PromptPayload['attachments']>[number],
+): attachment is NonNullable<PromptPayload['attachments']>[number] & { mediaType: string; path: string } {
+  if (!attachment.mediaType?.startsWith('image/') || !attachment.path) return false
+  const lowerPath = attachment.path.toLowerCase()
+  return [...PROMPT_IMAGE_EXTENSIONS].some((ext) => lowerPath.endsWith(ext))
+}
+
+function detectPromptImageMimeType(bytes: Uint8Array): string | null {
+  const buffer = Buffer.from(bytes)
+  if (buffer.length >= 8 && buffer.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+    return 'image/png'
+  }
+  if (buffer.length >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg'
+  }
+  if (buffer.length >= 6) {
+    const gif = buffer.subarray(0, 6).toString('ascii')
+    if (gif === 'GIF87a' || gif === 'GIF89a') return 'image/gif'
+  }
+  if (buffer.length >= 12 && buffer.subarray(0, 4).toString('ascii') === 'RIFF' && buffer.subarray(8, 12).toString('ascii') === 'WEBP') {
+    return 'image/webp'
+  }
+  if (buffer.length >= 12 && buffer.subarray(4, 8).toString('ascii') === 'ftyp') {
+    const brand = buffer.subarray(8, 12).toString('ascii')
+    if (brand === 'avif' || brand === 'avis') return 'image/avif'
+  }
+  return null
 }
 
 function removedFollowUps(before: readonly string[], after: readonly string[]): string[] {

--- a/packages/agent/src/server/pi-chat/piChatEvents.ts
+++ b/packages/agent/src/server/pi-chat/piChatEvents.ts
@@ -452,6 +452,7 @@ function filePartsFromContent(content: unknown, messageId: string): BoringChatPa
       ...(optionalString(part.filename) ? { filename: optionalString(part.filename) } : {}),
       ...(mediaType ? { mediaType } : {}),
       ...(url ? { url } : {}),
+      ...(optionalString(part.path) ? { path: optionalString(part.path) } : {}),
     }]
   })
 }

--- a/packages/agent/src/server/pi-chat/piChatHistory.ts
+++ b/packages/agent/src/server/pi-chat/piChatHistory.ts
@@ -71,6 +71,7 @@ function filePartsFromContent(content: unknown, messageId: string): BoringChatPa
         ...(optionalString(part.filename) ? { filename: optionalString(part.filename) } : {}),
         ...(mediaType ? { mediaType } : {}),
         ...(imagePartUrl(part, mediaType) ? { url: imagePartUrl(part, mediaType) } : {}),
+        ...(optionalString(part.path) ? { path: optionalString(part.path) } : {}),
       },
     ]
   })

--- a/packages/agent/src/server/pi-chat/piChatMessageMetadataReconciler.ts
+++ b/packages/agent/src/server/pi-chat/piChatMessageMetadataReconciler.ts
@@ -1,5 +1,6 @@
 import type {
   BoringChatMessage,
+  BoringChatPart,
   FollowUpPayload,
   PiChatEvent,
   PiChatSnapshot,
@@ -15,6 +16,7 @@ interface FollowUpMetadata {
   clientNonce?: string
   clientSeq?: number
   recordedAt?: number
+  files?: Extract<BoringChatPart, { type: 'file' }>[]
 }
 
 export class PiChatMessageMetadataReconciler {
@@ -35,11 +37,13 @@ export class PiChatMessageMetadataReconciler {
   recordPrompt(sessionId: string, payload: PromptPayload): void {
     const metadata = this.promptMetadata.get(sessionId) ?? []
     const displayText = payload.displayMessage ?? payload.message
+    const files = filePartsFromPromptPayload(payload)
     metadata.push({
       displayText,
       ...(displayText !== payload.message ? { serverText: payload.message } : {}),
       clientNonce: payload.clientNonce,
       recordedAt: Date.now(),
+      ...(files ? { files } : {}),
     })
     this.promptMetadata.set(sessionId, metadata)
   }
@@ -117,9 +121,16 @@ export class PiChatMessageMetadataReconciler {
     }
     if (event.type === 'message-start' && event.role === 'user' && !hasFollowUpSelector(event)) {
       const promptMetadata = this.findPrompt(sessionId, event.text)
-      if (promptMetadata) return { ...event, text: promptMetadata.displayText, clientNonce: promptMetadata.clientNonce }
+      if (promptMetadata) return withMessageStartMetadata(event, promptMetadata)
       const metadata = this.findFollowUp(sessionId, event.text)
-      if (metadata) return { ...event, text: metadata.displayText, clientNonce: metadata.clientNonce, clientSeq: metadata.clientSeq }
+      if (metadata) return withMessageStartMetadata(event, metadata)
+    }
+    if (event.type === 'message-end' && event.final.role === 'user' && !hasMessageSelector(event.final)) {
+      const text = messageText(event.final)
+      const promptMetadata = this.findPrompt(sessionId, text)
+      if (promptMetadata) return { ...event, final: withMessageSelector(event.final, promptMetadata) }
+      const metadata = this.findFollowUp(sessionId, text)
+      if (metadata) return { ...event, final: withMessageSelector(event.final, metadata) }
     }
     return event
   }
@@ -207,13 +218,30 @@ export class PiChatMessageMetadataReconciler {
   }
 
   private consumePromptFromEvent(sessionId: string, event: PiChatEvent): void {
-    if (event.type !== 'message-start' || event.role !== 'user') return
-    if (event.clientSeq !== undefined) return
-    if (event.clientNonce) {
-      this.removePrompt(sessionId, { clientNonce: event.clientNonce })
+    if (event.type === 'message-start' && event.role === 'user') {
+      if (event.clientSeq !== undefined) return
+      const prompt = event.clientNonce
+        ? this.promptMetadata.get(sessionId)?.find((entry) => entry.clientNonce === event.clientNonce)
+        : this.findPrompt(sessionId, event.text)
+      // Keep enriched prompts past `message-start`: Pi can later emit a final
+      // `message-end` carrying the raw server prompt, and that final replaces
+      // the start message in the reducer. Plain prompts can be consumed now.
+      if (prompt?.serverText) return
+      if (event.clientNonce) {
+        this.removePrompt(sessionId, { clientNonce: event.clientNonce })
+        return
+      }
+      this.removePrompt(sessionId, { displayText: event.text })
       return
     }
-    this.removePrompt(sessionId, { displayText: event.text })
+
+    if (event.type !== 'message-end' || event.final.role !== 'user') return
+    if (event.final.clientSeq !== undefined) return
+    if (event.final.clientNonce) {
+      this.removePrompt(sessionId, { clientNonce: event.final.clientNonce })
+      return
+    }
+    this.removePrompt(sessionId, { displayText: messageText(event.final) })
   }
 
   private removeFirstFollowUpByText(sessionId: string, text: string | undefined): void {
@@ -276,9 +304,19 @@ function matchesMetadataText(entry: FollowUpMetadata | undefined, text: string |
   return entry.displayText === text || entry.serverText === text
 }
 
+function withMessageStartMetadata(event: Extract<PiChatEvent, { type: 'message-start' }>, metadata: FollowUpMetadata): PiChatEvent {
+  return {
+    ...event,
+    text: metadata.displayText,
+    ...(metadata.clientNonce ? { clientNonce: metadata.clientNonce } : {}),
+    ...(metadata.clientSeq !== undefined ? { clientSeq: metadata.clientSeq } : {}),
+    ...(metadata.files && metadata.files.length > 0 ? { files: metadata.files } : {}),
+  }
+}
+
 function withMessageSelector(message: BoringChatMessage, metadata: FollowUpMetadata): BoringChatMessage {
   return {
-    ...withMessageDisplayText(message, metadata.displayText),
+    ...withMessageFiles(withMessageDisplayText(message, metadata.displayText), metadata.files),
     ...(metadata.clientNonce ? { clientNonce: metadata.clientNonce } : {}),
     ...(metadata.clientSeq !== undefined ? { clientSeq: metadata.clientSeq } : {}),
   }
@@ -293,6 +331,24 @@ function withMessageDisplayText(message: BoringChatMessage, displayText: string)
     return [{ ...part, text: displayText }]
   })
   return { ...message, parts }
+}
+
+function withMessageFiles(message: BoringChatMessage, files: FollowUpMetadata['files']): BoringChatMessage {
+  if (!files || files.length === 0) return message
+  const nonFileParts = message.parts.filter((part) => part.type !== 'file')
+  return { ...message, parts: [...nonFileParts, ...files] }
+}
+
+function filePartsFromPromptPayload(payload: PromptPayload): Extract<BoringChatPart, { type: 'file' }>[] | undefined {
+  if (!payload.attachments || payload.attachments.length === 0) return undefined
+  return payload.attachments.map((attachment, index) => ({
+    type: 'file',
+    id: `prompt:${payload.clientNonce}:file:${index}`,
+    filename: attachment.filename,
+    mediaType: attachment.mediaType,
+    url: attachment.url,
+    path: attachment.path,
+  }))
 }
 
 function withQueuedSelector(followUp: QueuedUserMessage, metadata: FollowUpMetadata): QueuedUserMessage {

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -159,6 +159,22 @@ function getRequestWorkspaceId(request: FastifyRequest): string {
   return request.workspaceContext?.workspaceId ?? DEFAULT_WORKSPACE_ID
 }
 
+function promoteRawFileWorkspaceQueryToHeader(request: FastifyRequest): void {
+  const pathname = request.url.split('?')[0] ?? request.url
+  // Browser media previews (img/object/etc.) cannot attach custom headers, so
+  // raw workspace file URLs carry workspaceId as a query param. Promote it into
+  // the existing header-based resolver path instead of bypassing host auth.
+  if (pathname !== '/api/v1/files/raw') return
+  const hasWorkspaceHeader = Object.keys(request.headers)
+    .some((key) => key.toLowerCase() === 'x-boring-workspace-id')
+  if (hasWorkspaceHeader) return
+  const queryIndex = request.url.indexOf('?')
+  if (queryIndex < 0) return
+  const workspaceId = new URLSearchParams(request.url.slice(queryIndex + 1)).get('workspaceId')?.trim()
+  if (!workspaceId) return
+  request.headers['x-boring-workspace-id'] = workspaceId
+}
+
 function isWorkspaceAgnosticAgentRequest(
   request: FastifyRequest,
   options?: { readyStatusWorkspaceScoped?: boolean },
@@ -885,6 +901,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
   app.addHook('onRequest', async (request, reply) => {
     const user = (request as unknown as { user?: { id: string } | null }).user
     let workspaceId = DEFAULT_WORKSPACE_ID
+    promoteRawFileWorkspaceQueryToHeader(request)
     if (opts.getWorkspaceId && !isWorkspaceAgnosticAgentRequest(request, { readyStatusWorkspaceScoped: requestScopedRuntime })) {
       try {
         workspaceId = (await opts.getWorkspaceId(request)).trim()
@@ -953,6 +970,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
         harness: binding.harness,
         sessionStore: binding.harness.sessions,
         workdir: binding.runtimeBundle.workspace.root,
+        workspace: binding.runtimeBundle.workspace,
         metering: opts.metering,
       })
       return binding.piChatService

--- a/packages/agent/src/server/sandbox/vercel-sandbox/createVercelSandboxExec.ts
+++ b/packages/agent/src/server/sandbox/vercel-sandbox/createVercelSandboxExec.ts
@@ -166,7 +166,7 @@ export function createVercelSandboxExec(
         }
       } catch (error) {
         if (timedOut) {
-          return timeoutResult(Date.now() - start)
+          return timeoutResult(Math.max(Date.now() - start, timeoutMs))
         }
         throw error
       } finally {

--- a/packages/agent/src/shared/chat/boringChatMessage.ts
+++ b/packages/agent/src/shared/chat/boringChatMessage.ts
@@ -26,7 +26,7 @@ export type BoringChatPart =
       errorText?: string
       ui?: ToolUiMetadata
     }
-  | { type: 'file'; id?: string; filename?: string; mediaType?: string; url?: string }
+  | { type: 'file'; id?: string; filename?: string; mediaType?: string; url?: string; path?: string }
   | { type: 'notice'; id?: string; level: 'info' | 'warning' | 'error'; text: string }
 
 export interface BoringChatMessage {

--- a/packages/agent/src/shared/chat/piChatSchemas.ts
+++ b/packages/agent/src/shared/chat/piChatSchemas.ts
@@ -83,6 +83,7 @@ export const BoringChatPartSchema: z.ZodType<BoringChatPart, z.ZodTypeDef, unkno
     filename: z.string().optional(),
     mediaType: z.string().optional(),
     url: z.string().optional(),
+    path: z.string().optional(),
   }),
   z.object({
     type: z.literal('notice'),


### PR DESCRIPTION
## Summary
- allow composer uploads for PDFs/docs/spreadsheets/text/etc. under `assets/uploads` while keeping images in the markdown image upload dir
- use raw workspace file URLs for attachment previews, including query-based workspace scoping for browser media loads
- expand uploaded workspace image attachments into Pi image input only after size + magic-byte validation; non-images remain workspace path references
- preserve typed attachment `path` through composer submission without casts
- keep markdown-editor image uploads backward-compatible with `markdownUrl`-only responses

## Validation
- `pnpm --filter @hachej/boring-agent exec vitest run src/server/http/routes/__tests__/file.test.ts src/server/pi-chat/__tests__/harnessPiChatService.test.ts src/server/__tests__/registerAgentRoutes.test.ts`
- `pnpm --filter @hachej/boring-workspace exec vitest run src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditor.test.tsx`
- `pnpm --filter @hachej/boring-agent typecheck`
- `pnpm --filter @hachej/boring-ui-kit build`
- `pnpm --filter @hachej/boring-agent build`
- `pnpm --filter @hachej/boring-agent exec vitest run src/front/__tests__/agentPlaygroundDefaults.test.tsx src/front/__tests__/agentPlaygroundShowcase.test.tsx src/server/workspace/__tests__/createNodeWorkspace.watch.test.ts src/server/runtime/modes/__tests__/provisioningAdapter.test.ts`
- `pnpm --filter @hachej/boring-agent lint:invariants`

## Reviews
- scoped reviewer: clean
- thermo-nuclear maintainability review: clean after simplifying raw URL ownership + typed attachment paths

## CI
- GitHub checks green on PR #333: Lint, Typecheck, Unit Tests, E2E, Remote Worker Smoke, Bundle Budget, Storybook Visual Baseline, invariants.