### PR TITLE
fix(core): sign out before returning from verify email

### DIFF
--- a/packages/core/src/front/__tests__/VerifyEmailPage.test.tsx
+++ b/packages/core/src/front/__tests__/VerifyEmailPage.test.tsx
@@ -315,15 +315,23 @@ describe('VerifyEmailPage', () => {
   )
 
   it(
-    'has back to sign in link on error states',
+    'signs out before returning to sign in from error states',
     withBeadId(BEAD_ID, async ({ assertionPassed }) => {
+      mockUseSession.mockReturnValue({
+        data: { user: { id: 'u1', email: 'test@test.dev', emailVerified: false }, expiresAt: '' },
+        isPending: false,
+        error: null,
+      })
       window.history.pushState({}, '', '/auth/verify-email')
 
       render(<VerifyEmailPage />, { wrapper: Wrapper })
 
-      const link = screen.getByText(/back to sign in/i).closest('a')
-      expect(link?.getAttribute('href')).toBe('/auth/signin')
-      assertionPassed('back-to-signin-link')
+      const user = userEvent.setup()
+      await user.click(screen.getByRole('button', { name: /back to sign in/i }))
+
+      expect(mockSignOut).toHaveBeenCalledOnce()
+      expect(window.location.pathname).toBe('/auth/signin')
+      assertionPassed('back-to-signin-signs-out')
     }),
   )
 

--- a/packages/core/src/front/auth/VerifyEmailPage.tsx
+++ b/packages/core/src/front/auth/VerifyEmailPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button, Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle, Input, Label } from '@hachej/boring-ui-kit'
-import { useSession, useSendVerificationEmail, useVerifyEmail } from './AuthProvider.js'
+import { useSession, useSendVerificationEmail, useSignOut, useVerifyEmail } from './AuthProvider.js'
 import { routes } from '../utils.js'
 
 type VerifyStatus = 'verifying' | 'verified' | 'expired' | 'invalid' | 'no-token'
@@ -14,10 +14,17 @@ function deleteCookie(name: string) {
   document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`
 }
 
+function navigateToSignIn() {
+  if (typeof window === 'undefined') return
+  window.history.replaceState({}, '', routes.signin)
+  window.dispatchEvent(new PopStateEvent('popstate'))
+}
+
 export function VerifyEmailPage() {
   const session = useSession()
   const verifyEmail = useVerifyEmail()
   const sendVerificationEmail = useSendVerificationEmail()
+  const signOut = useSignOut()
 
   const token = typeof window !== 'undefined'
     ? new URLSearchParams(window.location.search).get('token')
@@ -28,6 +35,7 @@ export function VerifyEmailPage() {
   const [cooldown, setCooldown] = useState(0)
   const [resendEmail, setResendEmail] = useState('')
   const [resendSent, setResendSent] = useState(false)
+  const [isSigningOut, setIsSigningOut] = useState(false)
   const verifiedRef = useRef(false)
 
   const sessionEmail = session.data?.user?.email ?? null
@@ -88,6 +96,16 @@ export function VerifyEmailPage() {
     setResendSent(true)
     setCooldown(60)
   }, [sessionEmail, resendEmail, cooldown, sendVerificationEmail])
+
+  const handleBackToSignIn = useCallback(async () => {
+    if (isSigningOut) return
+    setIsSigningOut(true)
+    try {
+      await signOut()
+    } finally {
+      navigateToSignIn()
+    }
+  }, [isSigningOut, signOut])
 
   const resendButton = (
     <Button
@@ -182,9 +200,15 @@ export function VerifyEmailPage() {
           </CardHeader>
           <CardContent>{resendSection}</CardContent>
           <CardFooter>
-            <a href={routes.signin} className="text-sm text-muted-foreground hover:underline">
-              Back to sign in
-            </a>
+            <Button
+              type="button"
+              variant="link"
+              className="h-auto p-0 text-sm text-muted-foreground hover:underline"
+              disabled={isSigningOut}
+              onClick={handleBackToSignIn}
+            >
+              {isSigningOut ? 'Signing out…' : 'Back to sign in'}
+            </Button>
           </CardFooter>
         </Card>
       </div>
@@ -216,9 +240,15 @@ export function VerifyEmailPage() {
         </CardHeader>
         <CardContent>{resendSection}</CardContent>
         <CardFooter>
-          <a href={routes.signin} className="text-sm text-muted-foreground hover:underline">
-            Back to sign in
-          </a>
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto p-0 text-sm text-muted-foreground hover:underline"
+            disabled={isSigningOut}
+            onClick={handleBackToSignIn}
+          >
+            {isSigningOut ? 'Signing out…' : 'Back to sign in'}
+          </Button>
         </CardFooter>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- make verify-email Back to sign in sign out first
- avoid unverified-session redirect loop back to /auth/verify-email
- add regression test

## Test plan
- pnpm --dir packages/core exec vitest run src/front/__tests__/VerifyEmailPage.test.tsx src/front/__tests__/AuthGate.test.tsx src/front/__tests__/AuthProvider.test.tsx
- pnpm --filter @hachej/boring-core typecheck