### PR TITLE
fix(agent): persist chat sessions on mounted storage

### DIFF
--- a/apps/full-app/Dockerfile
+++ b/apps/full-app/Dockerfile
@@ -79,10 +79,12 @@ COPY --from=build /app/apps/full-app/node_modules/ apps/full-app/node_modules/
 
 # BORING_AGENT_MODE=vercel-sandbox: even on Fly.io the server itself runs here
 # but agent tool execution (bash/files) runs in remote Vercel sandbox containers.
-# BORING_AGENT_WORKSPACE_ROOT and model config come from fly secrets.
+# Store chat transcripts on the Fly volume; the container root filesystem is ephemeral.
+# Model config comes from Fly secrets.
 ENV NODE_ENV=production \
   BORING_AGENT_MODE=vercel-sandbox \
-  BORING_AGENT_WORKSPACE_ROOT=/data/workspaces
+  BORING_AGENT_WORKSPACE_ROOT=/data/workspaces \
+  BORING_AGENT_SESSION_ROOT=/data/pi-sessions
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
@@ -369,6 +369,25 @@ describe("PiSessionStore", () => {
     expect(() => new PiSessionStore("/tmp", { sessionNamespace: "../bad" })).toThrow("session namespace");
   });
 
+  it("honors BORING_AGENT_SESSION_ROOT for namespaced session stores", async () => {
+    const previous = process.env.BORING_AGENT_SESSION_ROOT;
+    process.env.BORING_AGENT_SESSION_ROOT = tmpDir;
+    try {
+      const store = new PiSessionStore("/workspace", { sessionNamespace: "workspace-a" });
+      expect(store.getSessionDir()).toBe(join(tmpDir, "workspace-a"));
+
+      const session = await store.create(ctx, { title: "Persistent" });
+      await expect(readFile(join(tmpDir, "workspace-a", `${session.id}.jsonl`), "utf-8"))
+        .resolves.toContain("Persistent");
+    } finally {
+      if (previous === undefined) {
+        delete process.env.BORING_AGENT_SESSION_ROOT;
+      } else {
+        process.env.BORING_AGENT_SESSION_ROOT = previous;
+      }
+    }
+  });
+
   it("can store session files under host cwd while writing runtime cwd in session header", async () => {
     const store = new PiSessionStore("/workspace", { storageCwd: "/tmp/host-storage-root", sessionDir: tmpDir });
     const session = await store.create(ctx, { title: "Runtime cwd" });

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -13,6 +13,7 @@ import {
 import { closeSync, openSync, readFileSync, readSync, readdirSync, writeFileSync } from "node:fs";
 import { join, basename, resolve } from "node:path";
 import { homedir } from "node:os";
+import { getEnv } from "../../config/env.js";
 import {
   parseSessionEntries,
   type SessionEntry,
@@ -37,13 +38,19 @@ export interface PiSessionEntries {
   messages: unknown[];
 }
 
+function sessionBaseDir(): string {
+  const configured = getEnv(SESSION_ROOT_ENV)?.trim();
+  return configured ? resolve(configured) : join(homedir(), ".pi", "agent", "sessions");
+}
+
 function defaultSessionDir(cwd: string): string {
   const safePath = `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
-  return join(homedir(), ".pi", "agent", "sessions", safePath);
+  return join(sessionBaseDir(), safePath);
 }
 
 const SAFE_ID = /^[a-zA-Z0-9_-]+$/;
 const SAFE_SESSION_NAMESPACE = /^[a-zA-Z0-9_-]+$/;
+const SESSION_ROOT_ENV = "BORING_AGENT_SESSION_ROOT";
 const SUMMARY_PREFIX_BYTES = 64 * 1024;
 
 type SessionFileStat = { filepath: string; stat: Awaited<ReturnType<typeof fsStat>> };
@@ -68,7 +75,7 @@ function sessionDirForNamespace(namespace: string): string {
   if (!SAFE_SESSION_NAMESPACE.test(safeNamespace)) {
     throw new Error("session namespace must contain only letters, numbers, underscores, and dashes");
   }
-  return join(homedir(), ".pi", "agent", "sessions", safeNamespace);
+  return join(sessionBaseDir(), safeNamespace);
 }
 
 function normalizeListOptions(options: SessionListOptions | undefined): NormalizedListOptions {


### PR DESCRIPTION
## Summary
- add BORING_AGENT_SESSION_ROOT support for Pi session stores
- configure full-app Docker runtime to store chat transcripts under /data/pi-sessions on Fly
- add regression coverage for namespaced session stores honoring the session root env

## Why
Prod Fly deploys replace the ephemeral root filesystem. Chat transcripts were under /root/.pi/agent/sessions, so a deploy during a session could wipe history. /data is the mounted Fly volume.

## Test plan
- pnpm --dir packages/agent exec vitest run src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
- pnpm --filter @hachej/boring-agent typecheck