### PR TITLE
fix(workspace): keep code editor available on prod

### DIFF
--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -17,6 +17,7 @@ import {
 } from '@hachej/boring-workspace/app/front'
 import { ChatFirstAuthenticatedShell } from './chatFirst/ChatFirstAuthenticatedShell.js'
 import { ChatFirstPublicShell, type ChatFirstPublicShellOptions } from './chatFirst/ChatFirstPublicShell.js'
+import { installVitePreloadRecovery } from './vitePreloadRecovery.js'
 import {
   clearPendingChatEntry,
   DEFAULT_CHAT_FIRST_PENDING_WORKSPACE_ID,
@@ -26,6 +27,8 @@ import {
   type PendingChatEntryState,
   workspaceIdFromPath,
 } from './chatFirst/pendingChatEntry.js'
+
+installVitePreloadRecovery()
 
 const DEFAULT_WORKSPACE_ROUTE = '/workspace/:id'
 const DEFAULT_WORKSPACE_ID_PARAM = 'id'

--- a/packages/core/src/app/front/__tests__/vitePreloadRecovery.test.ts
+++ b/packages/core/src/app/front/__tests__/vitePreloadRecovery.test.ts
@@ -1,0 +1,37 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import {
+  currentFrontendEntry,
+  shouldReloadForFrontendEntry,
+} from '../vitePreloadRecovery.js'
+
+describe('vite preload recovery', () => {
+  it('uses the hashed built app entry to scope reload attempts', () => {
+    document.head.innerHTML = ''
+    const preload = document.createElement('script')
+    preload.type = 'module'
+    preload.src = 'https://example.test/assets/index-new.js'
+    document.head.appendChild(preload)
+
+    const other = document.createElement('script')
+    other.type = 'module'
+    other.src = 'https://example.test/runtime-plugin.js'
+    document.head.appendChild(other)
+
+    expect(currentFrontendEntry(document, 'fallback')).toBe('https://example.test/assets/index-new.js')
+  })
+
+  it('allows one reload per built app entry', () => {
+    const values = new Map<string, string>()
+    const storage = {
+      getItem: vi.fn((key: string) => values.get(key) ?? null),
+      setItem: vi.fn((key: string, value: string) => {
+        values.set(key, value)
+      }),
+    }
+
+    expect(shouldReloadForFrontendEntry(storage, 'entry-a')).toBe(true)
+    expect(shouldReloadForFrontendEntry(storage, 'entry-a')).toBe(false)
+    expect(shouldReloadForFrontendEntry(storage, 'entry-b')).toBe(true)
+  })
+})

--- a/packages/core/src/app/front/vitePreloadRecovery.ts
+++ b/packages/core/src/app/front/vitePreloadRecovery.ts
@@ -1,0 +1,61 @@
+const INSTALL_FLAG = '__boringVitePreloadRecoveryInstalled__'
+const RELOADED_ENTRY_KEY = 'boring-ui:vite-preload-reloaded-entry'
+
+type RecoverableWindow = Window & {
+  [INSTALL_FLAG]?: boolean
+}
+
+type VitePreloadErrorEvent = Event & {
+  payload?: unknown
+}
+
+type ReloadStorage = Pick<Storage, 'getItem' | 'setItem'>
+
+export function currentFrontendEntry(documentRef: Document, fallback: string): string {
+  const moduleScripts = Array.from(documentRef.scripts).filter((script) => (
+    script.type === 'module' && Boolean(script.src)
+  ))
+  const assetEntry = moduleScripts.find((script) => script.src.includes('/assets/'))
+  return assetEntry?.src ?? moduleScripts[0]?.src ?? fallback
+}
+
+export function shouldReloadForFrontendEntry(storage: ReloadStorage, entry: string): boolean {
+  if (storage.getItem(RELOADED_ENTRY_KEY) === entry) return false
+  storage.setItem(RELOADED_ENTRY_KEY, entry)
+  return true
+}
+
+export function installVitePreloadRecovery(): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return
+
+  const recoverableWindow = window as RecoverableWindow
+  if (recoverableWindow[INSTALL_FLAG]) return
+  recoverableWindow[INSTALL_FLAG] = true
+
+  window.addEventListener('vite:preloadError', (event) => {
+    event.preventDefault()
+
+    const entry = currentFrontendEntry(document, window.location.href)
+    let shouldReload = false
+    try {
+      shouldReload = shouldReloadForFrontendEntry(window.sessionStorage, entry)
+    } catch {
+      // If storage is unavailable, do not risk an infinite reload loop.
+      shouldReload = false
+    }
+
+    if (!shouldReload) {
+      console.warn(
+        '[boring-core] dynamic import failed after a reload attempt; leaving the panel error visible.',
+        (event as VitePreloadErrorEvent).payload,
+      )
+      return
+    }
+
+    console.warn(
+      '[boring-core] dynamic import failed; reloading to pick up the latest app assets.',
+      (event as VitePreloadErrorEvent).payload,
+    )
+    window.location.reload()
+  })
+}

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
@@ -330,6 +330,24 @@ describe('createCoreWorkspaceAgentServer telemetry wiring', () => {
     }
   })
 
+  it('does not serve the SPA shell for missing built assets', async () => {
+    const app = await createCoreWorkspaceAgentServer({
+      appRoot: await createBuiltFrontendRoot(),
+      serveFrontend: true,
+      telemetry: { capture: vi.fn() },
+    })
+    try {
+      const res = await app.inject({ method: 'GET', url: '/assets/missing-chunk.js' })
+
+      expect(res.statusCode).toBe(404)
+      expect(res.headers['cache-control']).toBe('no-store')
+      expect(res.body).toContain('asset_not_found')
+      expect(res.body).not.toContain('<!doctype html>')
+    } finally {
+      await app.close()
+    }
+  })
+
   it('keeps serving the shell when telemetry capture fails', async () => {
     const app = await createCoreWorkspaceAgentServer({
       appRoot: await createBuiltFrontendRoot(),

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -233,6 +233,10 @@ function contentType(filePath: string): string {
   return MIME_TYPES[ext] ?? 'application/octet-stream'
 }
 
+function isFrontendAssetPath(pathname: string): boolean {
+  return pathname === '/assets' || pathname.startsWith('/assets/')
+}
+
 function injectCspNonceIntoHtml(html: string, nonce: string | undefined): string {
   if (!nonce) return html
 
@@ -392,7 +396,12 @@ function shouldServeFrontend(pathname: string): boolean {
 
 async function serveFrontendShell(
   request: { id: string; cspNonce?: string },
-  reply: { status: (code: number) => unknown; type: (value: string) => unknown; send: (body: unknown) => unknown },
+  reply: {
+    status: (code: number) => unknown
+    type: (value: string) => unknown
+    header: (name: string, value: string) => unknown
+    send: (body: unknown) => unknown
+  },
   indexPath: string,
   telemetry: TelemetrySink,
 ) {
@@ -406,6 +415,7 @@ async function serveFrontendShell(
 
   const html = await readFile(indexPath, 'utf-8')
   captureAppOpened(telemetry, request.id)
+  reply.header('cache-control', 'no-store')
   reply.type('text/html; charset=utf-8')
   return reply.send(injectCspNonceIntoHtml(html, request.cspNonce))
 }
@@ -529,8 +539,17 @@ async function registerFrontendFallback(
     }
 
     if (await pathIsFile(candidate)) {
+      if (isFrontendAssetPath(pathname)) {
+        reply.header('cache-control', 'public, max-age=31536000, immutable')
+      }
       reply.type(contentType(candidate))
       return reply.send(createReadStream(candidate))
+    }
+
+    if (isFrontendAssetPath(pathname)) {
+      reply.status(404)
+      reply.header('cache-control', 'no-store')
+      return { error: 'asset_not_found' }
     }
 
     return serveFrontendShell(request, reply, indexPath, telemetry)

--- a/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditorPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditorPane.tsx
@@ -1,13 +1,9 @@
 "use client"
 
-import { lazy } from "react"
 import type { PaneProps } from "../../../../front/registry/types"
 import { useFilePane } from "../useFilePane"
 import { FilePaneShell } from "../FilePaneShell"
-
-const CodeEditor = lazy(() =>
-  import("./CodeEditor").then((m) => ({ default: m.CodeEditor })),
-)
+import { CodeEditor } from "./CodeEditor"
 
 function extToLanguage(path: string): string {
   const ext = path.split(".").pop()?.toLowerCase()


### PR DESCRIPTION
## Summary
- Inline the filesystem `CodeEditor` inside `CodeEditorPane` so prod code tabs no longer depend on a late `CodeEditor-*` lazy chunk.
- Return a real `404` for missing `/assets/*` files instead of serving the SPA shell HTML as JavaScript.
- Install a global Vite `vite:preloadError` recovery handler that reloads once per built app entry when any stale lazy chunk fails.
- Add regression coverage for missing built assets and preload-reload loop protection.

## Prod bug
Screenshot/error showed code tabs rendering only line numbers and:

```text
[filesystem] panel error: error loading dynamically imported module: https://app.senecaapp.ai/assets/CodeEditor-*.js
```

Missing/stale asset URLs could return `index.html` (`text/html`) instead of JS, so browser dynamic import failed. This is a deployment/version-skew class bug: an already-loaded app can reference lazy chunk filenames removed by a newer deploy.

## Proof
- `pnpm --filter @hachej/boring-workspace exec vitest run src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditorPane.test.tsx`
- `pnpm --filter @hachej/boring-core exec vitest run src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts`
- `pnpm --filter @hachej/boring-core exec vitest run src/app/front/__tests__/vitePreloadRecovery.test.ts src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts`
- `pnpm --filter @hachej/boring-workspace run typecheck`
- `pnpm --filter @hachej/boring-core run typecheck`
- `pnpm --filter full-app run build`
- Verified built full-app asset map contains no `CodeEditor-*` lazy chunk reference and includes Vite preload-error recovery.

## Notes
Build still emits existing Rollup/chunk-size warnings unrelated to this patch.
