### PR TITLE
Fix full-page plugin panels in core app

### DIFF
--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Navigate, Route, useLocation, useParams } from 'react-router-dom'
+import { WorkspaceProvider } from '@hachej/boring-workspace'
+import { ErrorState } from '@hachej/boring-ui-kit'
 import {
   CoreFront,
   UserMenu,
@@ -11,7 +13,10 @@ import {
   type CoreFrontAuthPagesOverride,
 } from '../../front/index.js'
 import {
+  parseFullPagePanelLocation,
   WorkspaceAgentFront,
+  WorkspaceBootGate,
+  WorkspaceFullPagePanel,
   type WorkspaceAgentFrontProps,
   type WorkspaceAgentSession,
 } from '@hachej/boring-workspace/app/front'
@@ -29,6 +34,7 @@ import {
 
 const DEFAULT_WORKSPACE_ROUTE = '/workspace/:id'
 const DEFAULT_WORKSPACE_ID_PARAM = 'id'
+const DEFAULT_FULL_PAGE_BASE_PATH = '/full-page'
 
 type ChatEntryMode = 'auth-first' | 'chat-first'
 type RoutedWorkspaceAgentProps<TSession extends WorkspaceAgentSession = WorkspaceAgentSession> = Omit<WorkspaceAgentFrontProps<TSession>, 'workspaceId' | 'frontPluginHotReload' | 'hotReloadEnabled'>
@@ -296,6 +302,12 @@ function WorkspaceRoute<
     () => ({ ...resolvedWorkspaceProps.authHeaders, 'x-boring-workspace-id': workspaceId }),
     [workspaceId, resolvedWorkspaceProps.authHeaders],
   )
+  const scopedFullPageBasePath = useMemo(
+    () => resolvedWorkspaceProps.fullPageBasePath
+      ? withWorkspaceIdSearch(resolvedWorkspaceProps.fullPageBasePath, workspaceId)
+      : undefined,
+    [resolvedWorkspaceProps.fullPageBasePath, workspaceId],
+  )
 
   if (!workspaceId) return <>{resolvedLoadingFallback}</>
 
@@ -348,12 +360,138 @@ function WorkspaceRoute<
       workspaceLabel={resolvedWorkspaceProps.workspaceLabel ?? currentWorkspace.name}
       requestHeaders={requestHeaders}
       authHeaders={authHeaders}
+      fullPageBasePath={scopedFullPageBasePath}
       chatParams={chatParams}
       bootPreloadPaths={bootPreloadPaths}
       frontPluginHotReload={false}
       hotReloadEnabled={false}
       showThemeToggle={false}
     />
+  )
+}
+
+function fullPageRoutePath(basePath: string): string {
+  const path = basePath.split(/[?#]/, 1)[0]?.trim()
+  return path || DEFAULT_FULL_PAGE_BASE_PATH
+}
+
+function workspaceIdFromFullPageSearch(search: string): string | null {
+  const workspaceId = new URLSearchParams(search).get('workspaceId')?.trim()
+  return workspaceId || null
+}
+
+function withWorkspaceIdSearch(basePath: string, workspaceId: string): string {
+  const [pathWithSearch, hash = ''] = basePath.split('#', 2)
+  const [path, rawSearch = ''] = pathWithSearch.split('?', 2)
+  const search = new URLSearchParams(rawSearch)
+  search.set('workspaceId', workspaceId)
+  return `${path}?${search.toString()}${hash ? `#${hash}` : ''}`
+}
+
+function scopedWorkspaceHeaders(
+  workspaceId: string,
+  headers: Record<string, string> | undefined,
+): Record<string, string> {
+  return { ...(headers ?? {}), 'x-boring-workspace-id': workspaceId }
+}
+
+function FullPageRouteErrorPage({ code, title, description }: { code: string; title: string; description: string }) {
+  return (
+    <div
+      className="flex min-h-screen items-center justify-center bg-background p-6 text-foreground"
+      data-testid="full-page-error-state"
+      data-full-page-error-code={code}
+    >
+      <ErrorState className="w-full max-w-lg" title={title} description={description} />
+    </div>
+  )
+}
+
+function CoreFullPagePanelRoute<TSession extends WorkspaceAgentSession = WorkspaceAgentSession>({
+  fullPageBasePath,
+  loadingFallback,
+  bootPreloadPaths,
+  workspaceProps,
+  appTitle,
+}: {
+  fullPageBasePath: string
+  loadingFallback?: ReactNode
+  bootPreloadPaths?: string[]
+  workspaceProps: RoutedWorkspaceAgentProps<TSession>
+  appTitle?: string
+}) {
+  const location = useLocation()
+  const parsed = useMemo(() => parseFullPagePanelLocation(location.search), [location.search])
+  const currentWorkspace = useCurrentWorkspace()
+  const workspaceId = workspaceIdFromFullPageSearch(location.search) ?? currentWorkspace?.id ?? ''
+
+  const scopedFullPageBasePath = workspaceId
+    ? withWorkspaceIdSearch(fullPageBasePath, workspaceId)
+    : fullPageBasePath
+  const requestHeaders = workspaceId
+    ? scopedWorkspaceHeaders(workspaceId, workspaceProps.requestHeaders)
+    : workspaceProps.requestHeaders
+  const authHeaders = workspaceId
+    ? scopedWorkspaceHeaders(workspaceId, { ...(workspaceProps.requestHeaders ?? {}), ...(workspaceProps.authHeaders ?? {}) })
+    : { ...(workspaceProps.requestHeaders ?? {}), ...(workspaceProps.authHeaders ?? {}) }
+
+  if (parsed.error || !parsed.componentId) {
+    return (
+      <FullPageRouteErrorPage
+        code={parsed.error?.code ?? 'FULL_PAGE_PANEL_MISSING_COMPONENT'}
+        title="Invalid full-page panel route"
+        description={parsed.error?.message ?? 'Missing full-page panel component id.'}
+      />
+    )
+  }
+
+  if (!workspaceId) {
+    return <>{loadingFallback ?? (
+      <FullPageRouteErrorPage
+        code="FULL_PAGE_PANEL_MISSING_WORKSPACE"
+        title="Workspace unavailable"
+        description="The full-page panel route needs a workspace id. Open it from a workspace or include workspaceId in the URL."
+      />
+    )}</>
+  }
+
+  return (
+    <WorkspaceProvider
+      chatPanel={workspaceProps.chatPanel}
+      plugins={workspaceProps.plugins}
+      excludeDefaults={workspaceProps.excludeDefaults}
+      panels={workspaceProps.panels}
+      commands={workspaceProps.commands}
+      catalogs={workspaceProps.catalogs}
+      capabilities={workspaceProps.capabilities}
+      apiBaseUrl={workspaceProps.apiBaseUrl}
+      authHeaders={authHeaders}
+      apiTimeout={workspaceProps.apiTimeout}
+      defaultTheme={workspaceProps.defaultTheme}
+      onThemeChange={workspaceProps.onThemeChange}
+      workspaceId={workspaceId}
+      workspaceLabel={currentWorkspace?.id === workspaceId ? currentWorkspace.name : workspaceProps.workspaceLabel}
+      appTitle={appTitle}
+      storageKey={workspaceProps.providerStorageKey ?? `boring-ui-v2:layout:${workspaceId}`}
+      persistenceEnabled={workspaceProps.persistenceEnabled}
+      manageDocumentTitle={false}
+      bridgeEndpoint={null}
+      onAuthError={workspaceProps.onAuthError}
+      onOpenFile={workspaceProps.onOpenFile}
+      debug={workspaceProps.debug}
+      frontPluginHotReload={false}
+      fullPageBasePath={scopedFullPageBasePath}
+    >
+      <WorkspaceBootGate
+        workspaceId={workspaceId}
+        requestHeaders={requestHeaders}
+        apiBaseUrl={workspaceProps.apiBaseUrl}
+        preloadPaths={bootPreloadPaths}
+        provisionWorkspace={workspaceProps.provisionWorkspace}
+      >
+        <WorkspaceFullPagePanel componentId={parsed.componentId} params={parsed.params} />
+      </WorkspaceBootGate>
+    </WorkspaceProvider>
   )
 }
 
@@ -376,6 +514,7 @@ export function CoreWorkspaceAgentFront<
   topBarRight = <DefaultTopBarRight />,
   appTitle,
   bridgeEndpoint = '/api/v1/ui',
+  fullPageBasePath = DEFAULT_FULL_PAGE_BASE_PATH,
   hotReload = false,
   chatEntryMode = 'auth-first',
   chatFirstPublicShell,
@@ -391,6 +530,7 @@ export function CoreWorkspaceAgentFront<
   const routedWorkspaceProps: RoutedWorkspaceAgentProps<TSession> = {
     ...workspaceProps,
     bridgeEndpoint,
+    fullPageBasePath,
   }
 
   return (
@@ -432,6 +572,18 @@ export function CoreWorkspaceAgentFront<
             workspaceRoute={workspaceRoute}
             chatFirstPublicShell={chatFirstPublicShell}
             chatFirstPublicWorkspaceProps={chatFirstPublicWorkspaceProps}
+          />
+        }
+      />
+      <Route
+        path={fullPageRoutePath(fullPageBasePath)}
+        element={
+          <CoreFullPagePanelRoute
+            fullPageBasePath={fullPageBasePath}
+            loadingFallback={loadingFallback}
+            bootPreloadPaths={bootPreloadPaths}
+            workspaceProps={routedWorkspaceProps}
+            appTitle={appTitle}
           />
         }
       />

--- a/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
+++ b/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
@@ -12,6 +12,9 @@ let routeStatus: { status: string; workspaceId?: string | null; message?: string
   workspaceId: 'workspace-a',
 }
 let workspaceAgentProps: Record<string, unknown> | null = null
+let workspaceProviderProps: Record<string, unknown> | null = null
+let workspaceBootGateProps: Record<string, unknown> | null = null
+let workspaceFullPagePanelProps: Record<string, unknown> | null = null
 let coreFrontProps: Record<string, unknown> | null = null
 let sessionState: { data: { user: { id: string } } | null; isPending: boolean } = {
   data: { user: { id: 'user-1' } },
@@ -62,6 +65,17 @@ vi.mock('../../../front/index.js', () => ({
   useWorkspaceRouteStatus: () => routeStatus,
 }))
 
+vi.mock('@hachej/boring-workspace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hachej/boring-workspace')>()
+  return {
+    ...actual,
+    WorkspaceProvider: ({ children, ...props }: { children?: ReactNode }) => {
+      workspaceProviderProps = props
+      return <div data-testid="workspace-provider">{children}</div>
+    },
+  }
+})
+
 vi.mock('@hachej/boring-workspace/app/front', () => ({
   WorkspaceAgentFront: (props: Record<string, unknown>) => {
     workspaceAgentProps = props
@@ -71,6 +85,30 @@ vi.mock('@hachej/boring-workspace/app/front', () => ({
         {props.topBarRight as ReactNode}
       </div>
     )
+  },
+  WorkspaceBootGate: ({ children, ...props }: { children?: ReactNode }) => {
+    workspaceBootGateProps = props
+    return <div data-testid="workspace-boot-gate">{children}</div>
+  },
+  WorkspaceFullPagePanel: (props: Record<string, unknown>) => {
+    workspaceFullPagePanelProps = props
+    return <div data-testid="workspace-full-page-panel">Full page panel</div>
+  },
+  parseFullPagePanelLocation: (search: string) => {
+    const query = new URLSearchParams(search)
+    const componentId = query.get('component')?.trim() ?? ''
+    if (!componentId) {
+      return {
+        componentId: null,
+        params: {},
+        error: { code: 'FULL_PAGE_PANEL_MISSING_COMPONENT', message: 'Missing full-page panel component id.' },
+      }
+    }
+    const rawParams = query.get('params')
+    return {
+      componentId,
+      params: rawParams ? JSON.parse(rawParams) as Record<string, unknown> : {},
+    }
   },
 }))
 
@@ -84,6 +122,9 @@ describe('CoreWorkspaceAgentFront', () => {
     routePath = '/workspace/workspace-a'
     routeStatus = { status: 'matched', workspaceId: 'workspace-a' }
     workspaceAgentProps = null
+    workspaceProviderProps = null
+    workspaceBootGateProps = null
+    workspaceFullPagePanelProps = null
     coreFrontProps = null
     sessionState = { data: { user: { id: 'user-1' } }, isPending: false }
     unstableSessionObject = false
@@ -177,6 +218,66 @@ describe('CoreWorkspaceAgentFront', () => {
     expect(workspaceAgentProps).toMatchObject({
       workspaceId: 'project-1',
       requestHeaders: { 'x-boring-workspace-id': 'project-1' },
+    })
+  })
+
+  it('scopes full-page panel links to the routed workspace', async () => {
+    const { CoreWorkspaceAgentFront } = await importSubject()
+
+    render(<CoreWorkspaceAgentFront />)
+
+    expect(workspaceAgentProps).toMatchObject({
+      workspaceId: 'workspace-a',
+      fullPageBasePath: '/full-page?workspaceId=workspace-a',
+    })
+  })
+
+  it('renders the core full-page panel route inside workspace providers', async () => {
+    const { CoreWorkspaceAgentFront } = await importSubject()
+    const plugin = { id: 'deck-plugin' }
+    routePath = '/full-page?workspaceId=workspace-a&component=deck&params=%7B%22path%22%3A%22deck%2Fintro.md%22%7D'
+
+    render(
+      <CoreWorkspaceAgentFront
+        plugins={[plugin] as never}
+        apiBaseUrl="/api-base"
+        requestHeaders={{ request: 'header' }}
+        authHeaders={{ existing: 'auth' }}
+        providerStorageKey="layout-key"
+        bootPreloadPaths={['/api/v1/files?path=deck']}
+      />,
+    )
+
+    expect(screen.getByTestId('workspace-boot-gate')).toBeInTheDocument()
+    expect(screen.getByTestId('workspace-full-page-panel')).toBeInTheDocument()
+    expect(workspaceAgentProps).toBeNull()
+    expect(workspaceProviderProps).toMatchObject({
+      workspaceId: 'workspace-a',
+      plugins: [plugin],
+      apiBaseUrl: '/api-base',
+      authHeaders: {
+        request: 'header',
+        existing: 'auth',
+        'x-boring-workspace-id': 'workspace-a',
+      },
+      storageKey: 'layout-key',
+      manageDocumentTitle: false,
+      fullPageBasePath: '/full-page?workspaceId=workspace-a',
+    })
+    expect(workspaceProviderProps?.frontPluginHotReload).toBe(false)
+    expect(workspaceProviderProps?.bridgeEndpoint).toBeNull()
+    expect(workspaceBootGateProps).toMatchObject({
+      workspaceId: 'workspace-a',
+      requestHeaders: {
+        request: 'header',
+        'x-boring-workspace-id': 'workspace-a',
+      },
+      apiBaseUrl: '/api-base',
+      preloadPaths: ['/api/v1/files?path=deck'],
+    })
+    expect(workspaceFullPagePanelProps).toEqual({
+      componentId: 'deck',
+      params: { path: 'deck/intro.md' },
     })
   })
 

--- a/packages/workspace/src/app/front/__tests__/WorkspaceFullPagePanel.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceFullPagePanel.test.tsx
@@ -65,6 +65,14 @@ describe("full-page panel helpers", () => {
       }),
     ).toBe("/full-page?component=deck&params=%7B%22path%22%3A%22deck%2Fintro.md%22%7D")
 
+    expect(
+      buildFullPagePanelHref({
+        componentId: "deck",
+        params: { path: "deck/intro.md" },
+        basePath: "/full-page?workspaceId=workspace-a",
+      }),
+    ).toBe("/full-page?workspaceId=workspace-a&component=deck&params=%7B%22path%22%3A%22deck%2Fintro.md%22%7D")
+
     const wrapper = ({ children }: { children: ReactNode }) => (
       <WorkspaceProvider persistenceEnabled={false} fullPageBasePath="/full-page">
         {children}

--- a/packages/workspace/src/front/fullPage.tsx
+++ b/packages/workspace/src/front/fullPage.tsx
@@ -32,11 +32,17 @@ export interface BuildFullPagePanelHrefInput {
 }
 
 export function buildFullPagePanelHref({ componentId, params, basePath }: BuildFullPagePanelHrefInput): string {
-  const search = new URLSearchParams({ component: componentId })
+  const [pathWithSearch, hash = ""] = basePath.split("#", 2)
+  const [path, rawSearch = ""] = pathWithSearch.split("?", 2)
+  const search = new URLSearchParams(rawSearch)
+  search.set("component", componentId)
   if (params && Object.keys(params).length > 0) {
     search.set("params", JSON.stringify(params))
+  } else {
+    search.delete("params")
   }
-  return `${basePath}?${search.toString()}`
+  const suffix = hash ? `#${hash}` : ""
+  return `${path}?${search.toString()}${suffix}`
 }
 
 export function useFullPagePanelHref(input: {

--- a/plugins/deck/src/front/__tests__/DeckPane.fileState.test.tsx
+++ b/plugins/deck/src/front/__tests__/DeckPane.fileState.test.tsx
@@ -16,7 +16,7 @@ vi.mock("@hachej/boring-workspace", async () => {
   }
 })
 
-import { WorkspaceFilesProvider } from "@hachej/boring-workspace"
+import { WorkspaceFilesProvider, WorkspaceProvider } from "@hachej/boring-workspace"
 import { DeckPane } from "../DeckPane"
 
 function Wrapper({ children }: { children: ReactNode }) {
@@ -27,6 +27,18 @@ function Wrapper({ children }: { children: ReactNode }) {
     >
       {children}
     </WorkspaceFilesProvider>
+  )
+}
+
+function FullPageWrapper({ children }: { children: ReactNode }) {
+  return (
+    <WorkspaceProvider
+      persistenceEnabled={false}
+      manageDocumentTitle={false}
+      fullPageBasePath="/full-page?workspaceId=workspace-1"
+    >
+      <Wrapper>{children}</Wrapper>
+    </WorkspaceProvider>
   )
 }
 
@@ -59,6 +71,19 @@ describe("DeckPane file-state integration", () => {
         type: "storage",
         path: "deck/missing.md",
       }),
+    )
+  })
+
+  it("links the new-tab action to the workspace full-page route", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ content: "# Intro\n\nOpen me", mtimeMs: 1 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(<DeckPane params={{ path: "deck/intro.md" }} />, { wrapper: FullPageWrapper })
+
+    await waitFor(() => expect(screen.getByTestId("deck-open-present")).toBeInTheDocument())
+    expect(screen.getByTestId("deck-open-present")).toHaveAttribute(
+      "href",
+      "/full-page?workspaceId=workspace-1&component=deck&params=%7B%22path%22%3A%22deck%2Fintro.md%22%7D",
     )
   })
 


### PR DESCRIPTION
## Summary\n- add a first-class CoreWorkspaceAgentFront /full-page route that renders WorkspaceFullPagePanel inside WorkspaceProvider\n- scope generated full-page URLs with workspaceId so new tabs keep the source workspace\n- preserve request/auth headers and run WorkspaceBootGate before rendering full-page panels\n- add workspace/core/deck regression tests for deck new-tab links\n\n## Validation\n- pnpm run build:packages\n- pnpm --dir packages/workspace exec vitest run src/app/front/__tests__/WorkspaceFullPagePanel.test.tsx\n- pnpm --dir packages/core exec vitest run --no-file-parallelism src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx\n- pnpm --dir plugins/deck exec vitest run src/front/__tests__/DeckPane.fileState.test.tsx\n- pnpm --filter @hachej/boring-workspace typecheck\n- pnpm --filter @hachej/boring-core typecheck\n- pnpm --filter @hachej/boring-deck typecheck\n- autoreview --mode local