### PR TITLE
docs: clarify sandbox storage roots

### DIFF
--- a/apps/full-app/README.md
+++ b/apps/full-app/README.md
@@ -56,7 +56,8 @@ Common optional:
 | `CORS_ORIGINS` | `http://localhost:3000,http://localhost:5173` | Allowed origins |
 | `BORING_PLUGIN_AUTHORING` | `0` | `1` installs the plugin-authoring surface |
 | `RESEND_API_KEY` | — | Resend mail transport |
-| `BORING_AGENT_WORKSPACE_ROOT` | — | Override the agent workspace root |
+| `BORING_AGENT_WORKSPACE_ROOT` | — | Host/control-plane workspace root. In `vercel-sandbox` prod this is `/data/workspaces`; it is not the sandbox cwd. Agent files live in sandbox `/workspace`. |
+| `BORING_AGENT_SESSION_ROOT` | — | Durable Pi chat transcript root. In Fly prod use a mounted-volume path such as `/data/pi-sessions`; do not rely on container `/root/.pi`. |
 | `BORING_AGENT_DEFAULT_MODEL_PROVIDER`, `BORING_AGENT_DEFAULT_MODEL_ID`, `INFOMANIAK_API_TOKEN`, `BORING_AGENT_INFOMANIAK_PRODUCT_ID`, `BORING_AGENT_INFOMANIAK_MODEL` | — | Default chat model, incl. OpenAI-compatible Infomaniak endpoint |
 | `BORING_AGENT_MODE` | `local` | Set `vercel-sandbox` to run the agent in a Vercel Firecracker microVM. Also configure Vercel credentials such as `VERCEL_TEAM_ID`, `VERCEL_PROJECT_ID`, and local/dev auth via `VERCEL_TOKEN` when OIDC is not available. |
 
@@ -66,6 +67,21 @@ The post-deploy smoke script reads `DEPLOY_URL` plus a family of `SMOKE_*` vars 
 
 - **Fly.io**: `fly.toml` (app `boring-full-app`, region `cdg`, `/health` checks, `release_command` runs `migrate.js`, mounted `workspace_data` volume at `/data`). Secrets via `fly secrets set`.
 - **Docker**: `Dockerfile` builds the app; run with `-p 3000:3000 --env-file apps/full-app/.env`.
+
+In the production Docker image, `BORING_AGENT_MODE=vercel-sandbox` splits storage:
+
+```txt
+Fly volume:
+  /data/workspaces/<workspaceId>   host/control-plane anchor, normally empty in sandbox mode
+  /data/pi-sessions/<workspaceId>  durable chat transcripts
+
+Vercel sandbox:
+  /workspace                       actual agent cwd, file tree, and shell workspace
+```
+
+Do not debug missing sandbox files by looking under `/data/workspaces/<id>`; inspect
+the Vercel sandbox `/workspace` instead. Do inspect `/data/pi-sessions/<id>` when
+checking whether chat history survives Fly deploy/restart.
 
 After deploy, run `pnpm --filter full-app smoke:post-deploy` (with `DEPLOY_URL` set) to verify the live instance.
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -54,7 +54,8 @@ function App() {
 
 Set an API key for the model provider (e.g. `ANTHROPIC_API_KEY`). Common env
 vars: `BORING_AGENT_MODE` (default `direct`), `BORING_AGENT_WORKSPACE_ROOT`
-(default cwd), `BORING_AGENT_PORT`, and the `BORING_AGENT_DEFAULT_MODEL*` /
+(default cwd), `BORING_AGENT_SESSION_ROOT` (durable Pi session storage),
+`BORING_AGENT_PORT`, and the `BORING_AGENT_DEFAULT_MODEL*` /
 `BORING_AGENT_CUSTOM_MODEL*` / `BORING_AGENT_INFOMANIAK*` provider settings. See
 [docs/runtime.md](./docs/runtime.md) and [docs/API.md](./docs/API.md).
 

--- a/packages/agent/docs/runtime.md
+++ b/packages/agent/docs/runtime.md
@@ -199,6 +199,31 @@ In `direct` mode this is also the model-visible workspace root. In isolated
 modes, the adapter maps that host path into the public runtime namespace
 (`/workspace`).
 
+### Production storage roots in `vercel-sandbox` mode
+
+In a Fly-hosted app using `BORING_AGENT_MODE=vercel-sandbox`, there are two
+filesystems with different jobs:
+
+```txt
+Fly app container / mounted volume:
+  /data/workspaces/<workspaceId>   host/control-plane workspace anchor
+  /data/pi-sessions/<workspaceId>  durable chat transcript storage
+
+Vercel sandbox:
+  /workspace                       agent-visible cwd, file tree, and shell root
+```
+
+`BORING_AGENT_WORKSPACE_ROOT=/data/workspaces` is a host-side configuration
+input. Core resolves each authorized workspace to `/data/workspaces/<id>` and
+ensures that directory exists so host-side resource lookups have a durable,
+workspace-scoped anchor. In `vercel-sandbox` mode, it is not where normal agent
+file edits, shell output, Python files, or uploaded workspace files should live.
+Those belong to the sandbox runtime root, `/workspace`.
+
+Production chat history also must not use the container root filesystem. Set
+`BORING_AGENT_SESSION_ROOT` to a mounted-volume path such as `/data/pi-sessions`
+so Pi wrapper/native transcripts survive Fly deploys and restarts.
+
 ## Adding a custom runtime mode
 
 A mode is a `RuntimeModeAdapter` (defined in `src/server/runtime/mode.ts`).

--- a/packages/core/docs/DEPLOYMENT_WORKFLOW.md
+++ b/packages/core/docs/DEPLOYMENT_WORKFLOW.md
@@ -51,7 +51,15 @@ node:22-slim
 bubblewrap ca-certificates
 BORING_AGENT_MODE=vercel-sandbox
 BORING_AGENT_WORKSPACE_ROOT=/data/workspaces
+BORING_AGENT_SESSION_ROOT=/data/pi-sessions
 ```
+
+In this mode, `/data/workspaces/<workspaceId>` is the Fly app's durable
+host/control-plane anchor. Core creates the directory and host-side resource
+lookups may read workspace-scoped config from it, but normal agent file edits and
+shell state live in the Vercel sandbox at `/workspace`. Chat transcripts are not
+sandbox files; they are Pi session files and should use the mounted Fly volume
+via `/data/pi-sessions/<workspaceId>`.
 
 Fly release command currently runs migrations:
 


### PR DESCRIPTION
Document the storage split in vercel-sandbox production mode: Fly /data/workspaces as host/control-plane anchor, /data/pi-sessions for durable chat transcripts, and Vercel /workspace as the actual agent workspace.