### PR TITLE
fix(workspace): nonce CodeMirror runtime styles

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditor.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditor.tsx
@@ -31,6 +31,7 @@ import { cn } from "../../../../front/lib/utils"
 
 const LARGE_FILE_THRESHOLD = 1_000_000
 const DOWNLOAD_THRESHOLD = 10_000_000
+const CSP_NONCE_META_NAME = "boring-csp-nonce"
 
 export interface CodeEditorProps {
   content: string
@@ -40,6 +41,15 @@ export interface CodeEditorProps {
   lineNumbers?: boolean
   wordWrap?: boolean
   className?: string
+}
+
+function readCspNonceFromDom(): string | null {
+  if (typeof document === "undefined") return null
+  const nonce = document
+    .querySelector(`meta[name="${CSP_NONCE_META_NAME}"]`)
+    ?.getAttribute("content")
+    ?.trim()
+  return nonce || null
 }
 
 function getLanguageExtension(language: string): Extension | null {
@@ -96,12 +106,14 @@ export function CodeEditor({
   const effectiveReadOnly = readOnly || isLargeFile
 
   const extensions = useMemo(() => {
+    const cspNonce = readCspNonceFromDom()
     const exts: Extension[] = [
       readOnlyCompartment.current.of(EditorState.readOnly.of(effectiveReadOnly)),
       lineNumbersCompartment.current.of(lineNumbers ? lineNumbersExt() : []),
       wordWrapCompartment.current.of(wordWrap ? EditorView.lineWrapping : []),
       drawSelection(),
       highlightActiveLine(),
+      ...(cspNonce ? [EditorView.cspNonce.of(cspNonce)] : []),
       bracketMatching(),
       indentOnInput(),
       history(),

--- a/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditor.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditor.test.tsx
@@ -14,6 +14,18 @@ afterEach(() => {
 })
 
 describe("CodeEditor", () => {
+  it("passes the app CSP nonce to CodeMirror style tags", () => {
+    const meta = document.createElement("meta")
+    meta.setAttribute("name", "boring-csp-nonce")
+    meta.setAttribute("content", "test-csp-nonce")
+    document.head.appendChild(meta)
+
+    render(<CodeEditor content="const x = 1" language="typescript" />)
+
+    expect(document.head.querySelector('style[nonce="test-csp-nonce"]')).toBeTruthy()
+    meta.remove()
+  })
+
   it("renders with content", () => {
     const { container: root } = render(
       <CodeEditor content="const x = 1" language="typescript" />,


### PR DESCRIPTION
## Summary
- Pass the app CSP nonce into CodeMirror via `EditorView.cspNonce`.
- Add a regression test that CodeMirror style tags receive the nonce.

## Root cause
Prod sends a nonce-only `style-src` CSP. CodeMirror injects runtime style tags for its editor layout. Without `EditorView.cspNonce`, those style tags violate CSP in prod, causing the editor layer to mount broken: gutters/line numbers can show, but text/input are blank or unusable. Local dev does not enforce this CSP, so it worked locally.

## Proof
- `pnpm --filter @hachej/boring-workspace exec vitest run src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditor.test.tsx src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditorPane.test.tsx`
- `pnpm --filter @hachej/boring-workspace run typecheck`
- `pnpm --filter full-app run build`
- Verified built full-app bundle contains `boring-csp-nonce` / CodeMirror `cspNonce` and no `CodeEditor-*` lazy chunk reference.
