### PR TITLE
docs: document nonce-only CSP runtime-style bug class

### DIFF
--- a/docs/web/reference/troubleshooting.md
+++ b/docs/web/reference/troubleshooting.md
@@ -161,7 +161,51 @@ Assuming all modes should expose identical host env details. The mental model st
 **Common mistake**
 Encoding product/domain behavior directly into panel ids.
 
-## 8. "Where should this feature live?"
+## 8. An editor or preview renders blank/unstyled in prod but works locally
+
+**Typical symptoms**
+- a component (e.g. the CodeMirror code editor) mounts but is blank and uninteractive in prod
+- gutters/line numbers show, but the content area is empty and you can't type
+- it works perfectly when run locally against the Vite dev server
+
+**Root cause**
+Production sends a strict, **nonce-only** Content-Security-Policy. `style-src` is
+`'self' https://fonts.googleapis.com 'nonce-<per-request>'` — there is **no
+`'unsafe-inline'`** (see `packages/core/src/server/app/createCoreApp.ts`). Any library
+that injects a `<style>` tag at runtime must stamp it with the request nonce, or the
+browser silently drops the styles. Local dev does not enforce this — the dev policy is
+`style-src 'self' 'unsafe-inline'` (`packages/agent/src/server/http/csp.ts`), so inline
+styles work unconditionally and the bug is invisible locally.
+
+The nonce is published to the page as `<meta name="boring-csp-nonce" content="…">`
+(injected in `packages/core/src/app/server/createCoreWorkspaceAgentServer.ts`) and matches
+the CSP header. Front-end code reads it and forwards it to the library:
+- **CodeMirror** — `EditorView.cspNonce.of(nonce)`
+  (`packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditor.tsx`,
+  fixed in PR #343).
+
+**Whether it breaks visibly depends on whether the injected styles are load-bearing**
+- **Load-bearing** (CodeMirror: layout + `.cm-content` contentEditable sizing) → hard
+  break, blank and unusable.
+- **Non-load-bearing** (TipTap markdown editor: real styling comes from the bundled
+  `tiptap-prose` stylesheet loaded as a normal `'self'` sheet; TipTap's own injected
+  defaults are minor) → no visible break even though the tag is dropped. Verified working
+  in prod, so it does **not** need a nonce today.
+
+**What is allowed**
+- inline `style="…"` **attributes** are permitted via `styleSrcAttr: 'unsafe-inline'`
+  (kept so DockView/React runtime layout sizing survives). Only `<style>` **tags** need a
+  nonce.
+- there is no `'unsafe-eval'` and `connect-src` is `'self'` only — `eval`/`new Function`
+  and cross-origin fetches will also be blocked.
+
+**If you add a new runtime-style-injecting library**
+Read the nonce from the meta tag and pass it through the library's nonce option. One
+still-unverified spot is mermaid diagram rendering in agent chat (`@streamdown/mermaid`),
+whose SVG `<style>` is the same load-bearing kind — check it if diagrams look unstyled in
+prod.
+
+## 9. "Where should this feature live?"
 
 Use this fast rule:
 - needs DB, auth, membership, or durable app identity → `@hachej/boring-core`


### PR DESCRIPTION
## Summary
Adds a troubleshooting entry for the bug class behind the CodeMirror prod failure fixed in #343: an editor/preview that renders blank or unstyled **in prod but works locally**.

## Why
Prod sends a strict **nonce-only** `style-src` (`'self' fonts.googleapis.com 'nonce-…'`, no `'unsafe-inline'` — `packages/core/src/server/app/createCoreApp.ts`). Any library that injects a `<style>` tag at runtime must stamp it with the per-request nonce (published as `<meta name="boring-csp-nonce">`) or the browser silently drops the styles. Dev CSP allows `'unsafe-inline'`, so the bug is invisible locally. This kept costing debugging time, so it now lives in the triage map.

## What the entry captures
- Root cause + the dev-vs-prod CSP difference.
- The `boring-csp-nonce` meta plumbing and how CodeMirror consumes it (`EditorView.cspNonce`, #343).
- **Load-bearing vs non-load-bearing** distinction — why CodeMirror broke hard but the TipTap markdown editor did **not** (its real styling comes from the bundled `tiptap-prose` sheet), so it needs no nonce today.
- What the policy still allows (`style=""` attributes via `styleSrcAttr`, no `eval`, `connect-src 'self'`).
- Guidance for adding new style-injecting libraries, plus mermaid (`@streamdown/mermaid`) flagged as the one unverified spot.

Docs-only; new section 8 in `docs/web/reference/troubleshooting.md` (old closing rule → section 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)