### PR TITLE
fix(agent,core): chat /help rendering and settings home link

### DIFF
--- a/packages/agent/src/front/slashCommands/__tests__/builtins.test.ts
+++ b/packages/agent/src/front/slashCommands/__tests__/builtins.test.ts
@@ -56,18 +56,19 @@ describe('/clear', () => {
 })
 
 describe('/help', () => {
-  test('renders commands as a GFM table (one row per command)', () => {
+  test('renders commands as a plain-text list (one line per command)', () => {
     const ctx = makeContext()
     const result = getBuiltin('help').handler('', ctx) as string
     expect(result).toContain('/clear')
     expect(result).toContain('/reset')
     expect(result).toContain('/reload')
     expect(result).toContain('/help')
-    // GFM table so Streamdown renders each command on its own row.
-    expect(result).toContain('| Command | Description |')
-    expect(result).toContain('| --- | --- |')
-    expect(result).toContain('| `/clear` |')
-    expect(result.split('\n').filter((l) => l.startsWith('| `/')).length).toBeGreaterThanOrEqual(3)
+    // Command results render as a plain-text notice (white-space: pre-wrap),
+    // not Streamdown — so no GFM table markup, one command per line.
+    expect(result).not.toContain('|')
+    expect(result.startsWith('Available commands:')).toBe(true)
+    expect(result).toContain('/clear — Hide messages from display')
+    expect(result.split('\n').filter((l) => l.startsWith('/')).length).toBeGreaterThanOrEqual(3)
   })
 
   test('returns message when no commands', () => {

--- a/packages/agent/src/front/slashCommands/builtins.ts
+++ b/packages/agent/src/front/slashCommands/builtins.ts
@@ -51,14 +51,15 @@ export const builtinCommands: SlashCommand[] = [
     handler(_, ctx) {
       const cmds = ctx.listCommands()
       if (cmds.length === 0) return 'No commands available.'
-      // Render as a GFM table. The chat renders assistant messages through
-      // Streamdown (GFM), so a plain "\n"-joined list would collapse into one
-      // run-on line; a table keeps each command on its own row.
-      const escape = (text: string) => text.replace(/\|/g, '\\|').replace(/\n/g, ' ')
+      // Command results render as a plain-text notice (RuntimeNotices uses
+      // `white-space: pre-wrap`, not Streamdown), so a GFM table would show as
+      // raw pipes. A "\n"-joined list keeps each command on its own line.
       return [
-        '| Command | Description |',
-        '| --- | --- |',
-        ...cmds.map((c) => `| \`/${c.name}\` | ${escape(c.description ?? '')} |`),
+        'Available commands:',
+        ...cmds.map((c) => {
+          const desc = (c.description ?? '').replace(/\s+/g, ' ').trim()
+          return desc ? `/${c.name} — ${desc}` : `/${c.name}`
+        }),
       ].join('\n')
     },
   },

--- a/packages/core/src/front/__tests__/UserSettingsPage.test.tsx
+++ b/packages/core/src/front/__tests__/UserSettingsPage.test.tsx
@@ -109,6 +109,17 @@ describe('UserSettingsPage', () => {
   )
 
   it(
+    'links the top-left brand to home',
+    withBeadId(BEAD_ID, async ({ assertionPassed }) => {
+      render(<UserSettingsPage />, { wrapper: Wrapper })
+      await waitFor(() => expect(screen.getByText('test@test.dev')).toBeTruthy())
+      const homeLink = screen.getByRole('link', { name: /home/i })
+      expect(homeLink.getAttribute('href')).toBe('/')
+      assertionPassed('brand-links-home')
+    }),
+  )
+
+  it(
     'renders host-provided extra sections with their own nav entry (stays feature-agnostic)',
     withBeadId(BEAD_ID, async ({ assertionPassed }) => {
       render(

--- a/packages/core/src/front/auth/UserSettingsPage.tsx
+++ b/packages/core/src/front/auth/UserSettingsPage.tsx
@@ -97,15 +97,21 @@ function SettingsTopBar() {
       aria-label="App top bar"
     >
       <div className="flex min-w-0 flex-1 items-center gap-2.5">
-        <div
-          aria-hidden="true"
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-foreground text-[12px] font-semibold text-background"
+        <a
+          href="/"
+          aria-label={`${appTitle} home`}
+          className="flex min-w-0 items-center gap-2.5 rounded-md outline-none transition-opacity hover:opacity-80 focus-visible:ring-2 focus-visible:ring-ring"
         >
-          {appInitial}
-        </div>
-        <span className="truncate text-[13px] font-medium tracking-tight text-foreground">
-          {appTitle}
-        </span>
+          <div
+            aria-hidden="true"
+            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-foreground text-[12px] font-semibold text-background"
+          >
+            {appInitial}
+          </div>
+          <span className="truncate text-[13px] font-medium tracking-tight text-foreground">
+            {appTitle}
+          </span>
+        </a>
         <span aria-hidden="true" className="text-muted-foreground/30">/</span>
         <span className="truncate text-[13px] text-muted-foreground">Account settings</span>
       </div>


### PR DESCRIPTION
## Summary
Two small, independent front-end UX fixes.

### 1. `/help` renders as raw pipes in chat
Command results are shown via `addLocalNotice(...)` → `RuntimeNotices` as a **plain-text** notice (`white-space: pre-wrap`), **not** through Streamdown. The `/help` handler built a GFM markdown table assuming Streamdown, so it rendered as literal `| Command | Description | … |`.

**Fix:** return a `\n`-joined plain-text list (one command per line), which `pre-wrap` renders correctly.

### 2. Top-left brand icon on `/me` settings doesn't go home
On the account settings page (`/me#profile`), the top-left brand icon in `SettingsTopBar` was a decorative `<div aria-hidden="true">` with no link/handler, so clicking it did nothing.

**Fix:** wrap the brand block (icon + app title) in `<a href="/">` with an accessible label + hover/focus affordance. Used a plain anchor (not router `<Link>`) — no Router context needed, matches the `VerifyEmailPage.tsx` precedent, and a full nav home from settings is fine.

> Note: this fixes the **default** `SettingsTopBar`. `UserSettingsPage` accepts a host `topBar` override — a host that supplies its own header is responsible for its own home link.

## Tests
- `packages/agent/.../slashCommands/__tests__/builtins.test.ts` — asserts plain-text list, no `|` markup (19/19 pass locally).
- `packages/core/src/front/__tests__/UserSettingsPage.test.tsx` — adds "links the top-left brand to home" asserting `href="/"` (15/15 pass locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)