### PR TITLE
fix(agent): type workspace chat blocker bridge

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -74,7 +74,7 @@ const DebugDrawer = lazy(() => import('../DebugDrawer').then((m) => ({ default: 
 
 const EMPTY_COMMANDS: SlashCommand[] = []
 const EMPTY_COMMAND_NAMES: string[] = []
-const EMPTY_BLOCKERS: Array<{ id: string; sessionId?: string; label?: string; reason?: string }> = []
+const EMPTY_BLOCKERS: never[] = []
 /** Stable id for the notice that surfaces a rejected run (so re-rejections replace
  * it rather than stacking, and the next admit can retract it). */
 const RUN_REJECTED_NOTICE_ID = 'run-rejected'
@@ -105,7 +105,9 @@ export interface ChatPanelEmptyState {
   footer?: ReactNode
 }
 
-export interface PiChatPanelProps {
+export interface PiChatPanelProps<
+  TComposerBlocker extends ComposerBlocker = ComposerBlocker,
+> {
   /** Optional externally selected Pi session id. When provided, session navigation is owned by the host. */
   sessionId?: string
   /** Alias kept for consumers that still pass the pre-cutover prop name. */
@@ -156,9 +158,9 @@ export interface PiChatPanelProps {
   onMentionedFilesConsumed?: () => void
   onData?: (part: unknown) => void
   onOpenArtifact?: (path: string) => void
-  composerBlockers?: ComposerBlocker[]
+  composerBlockers?: TComposerBlocker[]
   onComposerStop?: () => void
-  onComposerBlockerAction?: (blocker: ComposerBlocker, action: string) => void
+  onComposerBlockerAction?: (blocker: TComposerBlocker, action: string) => void
   /** Fired once each time a run settles (busy → idle). Hosts use it to refresh
    * out-of-band state after a turn (e.g. a usage/quota indicator). The agent stays
    * agnostic about what the host does with it. */
@@ -169,7 +171,9 @@ export interface PiChatPanelProps {
   renderNoticeAction?: (notice: PiChatRuntimeNotice) => ReactNode
 }
 
-export function PiChatPanel({
+export function PiChatPanel<
+  TComposerBlocker extends ComposerBlocker = ComposerBlocker,
+>({
   sessionId,
   extraCommands,
   apiBaseUrl,
@@ -222,7 +226,7 @@ export function PiChatPanel({
   onComposerBlockerAction,
   onTurnComplete,
   renderNoticeAction,
-}: PiChatPanelProps) {
+}: PiChatPanelProps<TComposerBlocker>) {
   const externalSessionId = sessionId?.trim() || undefined
   const showSessionSidebar = showSessions ?? externalSessionId === undefined
   const onDataRef = useRef(onData)

--- a/packages/agent/src/front/chat/components/ChatNotices.tsx
+++ b/packages/agent/src/front/chat/components/ChatNotices.tsx
@@ -96,14 +96,16 @@ function NoticeText({ className, children }: { className?: string; children: str
   )
 }
 
-export function ComposerBlockerNotice({
+export function ComposerBlockerNotice<
+  TComposerBlocker extends ComposerBlocker = ComposerBlocker,
+>({
   blocker,
   label,
   onAction,
 }: {
-  blocker?: ComposerBlocker
+  blocker?: TComposerBlocker
   label: string
-  onAction?: (blocker: ComposerBlocker, action: string) => void
+  onAction?: (blocker: TComposerBlocker, action: string) => void
 }) {
   return (
     <div

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -62,7 +62,9 @@ function hasSoftWrappedLine(node: HTMLTextAreaElement, style: CSSStyleDeclaratio
   })
 }
 
-export interface PiChatComposerSurfaceProps {
+export interface PiChatComposerSurfaceProps<
+  TComposerBlocker extends ComposerBlocker = ComposerBlocker,
+> {
   chrome: boolean
   isStreaming: boolean
   status: string
@@ -74,8 +76,8 @@ export interface PiChatComposerSurfaceProps {
   composerPlaceholder?: string
   composerStatusNotice: { title: string; detail?: string; code?: string } | null
   workspaceWarmupBlocked: boolean
-  primaryComposerBlocker?: ComposerBlocker
-  onComposerBlockerAction?: (blocker: ComposerBlocker, action: string) => void
+  primaryComposerBlocker?: TComposerBlocker
+  onComposerBlockerAction?: (blocker: TComposerBlocker, action: string) => void
   queuePreview: QueuedUserMessage[]
   onEditQueued: () => void
   hotReloadEnabled: boolean
@@ -121,7 +123,9 @@ export interface PiChatComposerSurfaceProps {
   onStop: () => void
 }
 
-export function PiChatComposerSurface({
+export function PiChatComposerSurface<
+  TComposerBlocker extends ComposerBlocker = ComposerBlocker,
+>({
   chrome,
   isStreaming,
   status,
@@ -178,7 +182,7 @@ export function PiChatComposerSurface({
   onTextareaKeyDown,
   onSubmitMessage,
   onStop,
-}: PiChatComposerSurfaceProps) {
+}: PiChatComposerSurfaceProps<TComposerBlocker>) {
   const workspaceRequestId = getHeaderValue(requestHeaders, 'x-boring-workspace-id')
   const uploadAttachment = useCallback((file: File) => uploadFile(file, {
     apiBaseUrl,

--- a/packages/agent/src/front/index.ts
+++ b/packages/agent/src/front/index.ts
@@ -4,7 +4,12 @@ export { uploadFile } from './upload/uploadFile'
 export type { UploadFileOptions, UploadFileResult } from './upload/uploadFile'
 
 export { PiChatPanel, PiChatPanel as ChatPanel } from './chat/PiChatPanel'
-export type { PiChatPanelProps, PiChatPanelProps as ChatPanelProps } from './chat/PiChatPanel'
+export type {
+  ComposerBlocker,
+  ComposerBlockerAction,
+  PiChatPanelProps,
+  PiChatPanelProps as ChatPanelProps,
+} from './chat/PiChatPanel'
 export { DebugDrawer } from './DebugDrawer'
 export {
   ArtifactOpenProvider,

--- a/packages/workspace/src/front/chrome/chat/types.ts
+++ b/packages/workspace/src/front/chrome/chat/types.ts
@@ -1,15 +1,12 @@
+import type { PiChatPanelProps } from "@hachej/boring-agent/front"
 import type { ComponentType } from "react"
 import type { WorkspaceAttentionBlocker } from "../../provider"
 import type { SurfaceShellApi } from "../artifact-surface/SurfaceShell"
 
 export type OpenArtifactHandler = (path: string) => void
 
-export interface WorkspaceChatPanelProps {
+export interface WorkspaceChatPanelProps extends PiChatPanelProps<WorkspaceAttentionBlocker> {
   sessionId: string
-  onData?: (part: unknown) => void
-  requestHeaders?: Record<string, string>
-  onOpenArtifact?: OpenArtifactHandler
-  className?: string
   /** Endpoint base for agent → visible-workbench UI commands. */
   bridgeEndpoint?: string | null
   /** Imperative handle getter for the visible workbench surface. */
@@ -22,13 +19,6 @@ export interface WorkspaceChatPanelProps {
   openWorkbenchSources?: () => void
   /** Closes the visible workbench surface after an ephemeral command finishes. */
   closeWorkbench?: () => void
-  /** Generic workspace blockers that should prevent submitting new chat turns. */
-  composerBlockers?: WorkspaceAttentionBlocker[]
-  /** Called when the user presses Stop in the composer. */
-  onComposerStop?: () => void
-  /** Called when the chat implementation wants to run an action exposed by a blocker. */
-  onComposerBlockerAction?: (blocker: WorkspaceAttentionBlocker, action: string) => void
-  [key: string]: unknown
 }
 
 // The app shell owns the actual chat implementation. Workspace only needs a


### PR DESCRIPTION
Replaces the broad passthrough-props escape hatch with an explicit typed bridge between the workspace chat host and PiChatPanel.

Changes:
- PiChatPanelProps is now generic over the composer blocker subtype.
- Composer blocker UI components preserve that blocker type through action callbacks.
- WorkspaceChatPanelProps extends PiChatPanelProps<WorkspaceAttentionBlocker> and only adds workspace bridge methods.
- Removes the need for `[key: string]: unknown` on PiChatPanelProps.

Validation:
- CI typecheck/unit jobs are passing on the updated branch.
