### PR TITLE
feat(workspace): add createIfMissing option to useFilePane

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
@@ -8,7 +8,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
 import { events, workspaceEvents } from "../../../../front/events"
 import { useFilePane } from "../useFilePane"
-import { FileConflictError } from "../data/fetchClient"
+import { FetchError, FileConflictError } from "../data/fetchClient"
 
 // Mock the data layer — we exercise the hook's state machine, not React Query.
 const mockWriteFile = vi.fn()
@@ -287,6 +287,76 @@ describe("useFilePane", () => {
       await act(async () => {})
 
       expect(mockFileContent).toHaveBeenCalledWith(" notes.md ")
+    })
+  })
+
+  describe("createIfMissing", () => {
+    it("auto-creates a missing file when createIfMissing content is provided", async () => {
+      mockFileContent.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new FetchError(404, "not found"),
+        refetch: vi.fn(async () => ({ data: { content: "default", mtimeMs: 2000 } })),
+      })
+
+      const { result } = renderHook(
+        () => useFilePane({ path: "deck/new.md", createIfMissing: "# Default\n" }),
+        { wrapper },
+      )
+      await act(async () => {})
+
+      expect(mockWriteFile).toHaveBeenCalledTimes(1)
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.objectContaining({ path: "deck/new.md", content: "# Default\n" }),
+      )
+
+      // After write resolves, auto-creating finishes. The mocked refetch
+      // does not update React Query state in this unit test, so content
+      // remains null; we just verify the hook is no longer in a creating/
+      // loading state and no error is surfaced.
+      await act(async () => {
+        await Promise.resolve()
+      })
+      // The mock refetch does not update React Query state in this unit
+      // test, so the 404 error remains. The real hook clears it once
+      // the query re-runs with data after the write succeeds.
+      expect(result.current.error).toBeInstanceOf(FetchError)
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    it("does not auto-create when createIfMissing is omitted", async () => {
+      mockFileContent.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new FetchError(404, "not found"),
+        refetch: vi.fn(),
+      })
+
+      renderHook(() => useFilePane({ path: "deck/new.md" }), { wrapper })
+      await act(async () => {})
+
+      expect(mockWriteFile).not.toHaveBeenCalled()
+    })
+
+    it("only attempts auto-creation once per path mount", async () => {
+      mockFileContent.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        error: new FetchError(404, "not found"),
+        refetch: vi.fn(),
+      })
+
+      const { rerender } = renderHook(
+        () => useFilePane({ path: "deck/new.md", createIfMissing: "# A\n" }),
+        { wrapper },
+      )
+      await act(async () => {})
+      expect(mockWriteFile).toHaveBeenCalledTimes(1)
+
+      // Re-render with the same path should not re-trigger.
+      rerender({ path: "deck/new.md", createIfMissing: "# A\n" })
+      await act(async () => {})
+      expect(mockWriteFile).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useFileContent, useFileWrite } from "./data"
-import { FileConflictError } from "./data/fetchClient"
+import { FetchError, FileConflictError } from "./data/fetchClient"
 import { useEditorLifecycle, type EditorLifecycleAdapter } from "../../../front/hooks"
 
 let nextFallbackPanelId = 0
@@ -14,6 +14,8 @@ export interface UseFilePaneOptions {
   panelId?: string
   /** Initial content (optional, for draft/unsaved files). */
   initialContent?: string
+  /** When supplied, auto-create the file with this content if it does not exist. */
+  createIfMissing?: string
 }
 
 export interface UseFilePaneReturn {
@@ -72,7 +74,7 @@ export interface UseFilePaneReturn {
  * ```
  */
 export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
-  const { path, panelId, initialContent = null } = options
+  const { path, panelId, initialContent = null, createIfMissing } = options
   const activePath = /\S/.test(path) ? path : null
   const fallbackPanelIdRef = useRef(panelId ?? `file-pane:${nextFallbackPanelId++}`)
   const lifecyclePanelId = panelId ?? fallbackPanelIdRef.current
@@ -100,6 +102,10 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   // Conflict state
   const [conflict, setConflict] = useState<FileConflictError | null>(null)
 
+  // Auto-create state
+  const [autoCreating, setAutoCreating] = useState(false)
+  const autoCreateAttempted = useRef(false)
+
   // TypeScript workaround: track content state for the return type
   // so we can reference it in the function body
 
@@ -115,6 +121,18 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
       loadedPathRef.current = path
     }
   }, [path, initialContent])
+
+  // Auto-create missing file exactly once per path mount.
+  useEffect(() => {
+    if (!activePath || !createIfMissing || autoCreateAttempted.current) return
+    if (!(error instanceof FetchError) || error.status !== 404) return
+    autoCreateAttempted.current = true
+    setAutoCreating(true)
+    writeFile({ path: activePath, content: createIfMissing })
+      .then(() => refetchFileData())
+      .catch(() => {})
+      .finally(() => setAutoCreating(false))
+  }, [activePath, createIfMissing, error, writeFile, refetchFileData])
 
   // Load file content on mount or when file data changes
   useEffect(() => {
@@ -296,7 +314,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   }, [lifecycle])
 
   return {
-    isLoading,
+    isLoading: isLoading || autoCreating,
     error: error as Error | null,
     content,
     isDirty: lifecycle.isDirty,

--- a/plugins/deck/src/front/DeckPane.tsx
+++ b/plugins/deck/src/front/DeckPane.tsx
@@ -91,6 +91,7 @@ export interface DeckPaneProps {
   onError?: (error: DeckError) => void
   initialMode?: "read" | "edit" | "present"
   getPresentHref?: (path: string) => string
+  createIfMissing?: string
 }
 
 export function DeckPane(props: DeckPaneProps) {
@@ -225,6 +226,7 @@ function FileBackedDeckPane({
   onError,
   initialMode = "read",
   getPresentHref,
+  createIfMissing,
 }: DeckPaneProps) {
   const path = params?.path ?? ""
   const hasSelectedPath = /\S/.test(path)
@@ -243,7 +245,7 @@ function FileBackedDeckPane({
     onReloadFromServer,
     setContent,
     tabTitle,
-  } = useFilePane({ path, panelId: api?.id })
+  } = useFilePane({ path, panelId: api?.id, createIfMissing })
   const parsed = useMemo(() => (content == null ? null : parseDeckContent(content, path)), [content, path])
 
   useEffect(() => {


### PR DESCRIPTION
Downstream plugins (e.g. deck) currently have to preflight the file with a separate HTTP check-and-create roundtrip before mounting `useFilePane`, causing a double fetch and visible loading flash.

Add a `createIfMissing` option to `useFilePane`. When the file read returns a 404 and the option is provided, the hook issues a single `writeFile` followed by a `refetch`, treating the creation as part of the ordinary load sequence. A one-shot ref prevents loops, and `isLoading` stays true during the creation so callers continue to show their loading skeleton.

Also plumb the option through `DeckPane` so the deck plugin can opt in.

Closes downstream workaround in `boring-macro` where `MacroDeckPane` currently does `ensureMacroDeckExists` before rendering the generic `DeckPane`.