### PR TITLE
refactor(workspace): keep createIfMissing in file-content query

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
@@ -8,14 +8,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type { ReactNode } from "react"
 import { events, workspaceEvents } from "../../../../front/events"
 import { useFilePane } from "../useFilePane"
-import { FetchError, FileConflictError } from "../data/fetchClient"
+import { FileConflictError } from "../data/fetchClient"
 
 // Mock the data layer — we exercise the hook's state machine, not React Query.
 const mockWriteFile = vi.fn()
 const mockFileContent = vi.fn()
 
 vi.mock("../data", () => ({
-  useFileContent: (path: string | null) => mockFileContent(path),
+  useFileContent: (path: string | null, options?: { createIfMissing?: string }) => (
+    options === undefined ? mockFileContent(path) : mockFileContent(path, options)
+  ),
   useFileWrite: () => ({ mutateAsync: mockWriteFile }),
 }))
 
@@ -291,72 +293,12 @@ describe("useFilePane", () => {
   })
 
   describe("createIfMissing", () => {
-    it("auto-creates a missing file when createIfMissing content is provided", async () => {
-      mockFileContent.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: new FetchError(404, "not found"),
-        refetch: vi.fn(async () => ({ data: { content: "default", mtimeMs: 2000 } })),
-      })
-
-      const { result } = renderHook(
-        () => useFilePane({ path: "deck/new.md", createIfMissing: "# Default\n" }),
-        { wrapper },
-      )
+    it("delegates missing-file creation to the file-content query", async () => {
+      renderHook(() => useFilePane({ path: "deck/new.md", createIfMissing: "# Default\n" }), { wrapper })
       await act(async () => {})
 
-      expect(mockWriteFile).toHaveBeenCalledTimes(1)
-      expect(mockWriteFile).toHaveBeenCalledWith(
-        expect.objectContaining({ path: "deck/new.md", content: "# Default\n" }),
-      )
-
-      // After write resolves, auto-creating finishes. The mocked refetch
-      // does not update React Query state in this unit test, so content
-      // remains null; we just verify the hook is no longer in a creating/
-      // loading state and no error is surfaced.
-      await act(async () => {
-        await Promise.resolve()
-      })
-      // The mock refetch does not update React Query state in this unit
-      // test, so the 404 error remains. The real hook clears it once
-      // the query re-runs with data after the write succeeds.
-      expect(result.current.error).toBeInstanceOf(FetchError)
-      expect(result.current.isLoading).toBe(false)
-    })
-
-    it("does not auto-create when createIfMissing is omitted", async () => {
-      mockFileContent.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: new FetchError(404, "not found"),
-        refetch: vi.fn(),
-      })
-
-      renderHook(() => useFilePane({ path: "deck/new.md" }), { wrapper })
-      await act(async () => {})
-
+      expect(mockFileContent).toHaveBeenCalledWith("deck/new.md", { createIfMissing: "# Default\n" })
       expect(mockWriteFile).not.toHaveBeenCalled()
-    })
-
-    it("only attempts auto-creation once per path mount", async () => {
-      mockFileContent.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: new FetchError(404, "not found"),
-        refetch: vi.fn(),
-      })
-
-      const { rerender } = renderHook(
-        () => useFilePane({ path: "deck/new.md", createIfMissing: "# A\n" }),
-        { wrapper },
-      )
-      await act(async () => {})
-      expect(mockWriteFile).toHaveBeenCalledTimes(1)
-
-      // Re-render with the same path should not re-trigger.
-      rerender({ path: "deck/new.md", createIfMissing: "# A\n" })
-      await act(async () => {})
-      expect(mockWriteFile).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx
@@ -12,6 +12,7 @@ import {
   useMoveFile,
   useDeleteFile,
 } from "../hooks"
+import { FetchError } from "../fetchClient"
 import { events } from "../../../../../front/events"
 import { filesystemEvents } from "../../../shared/events"
 
@@ -45,6 +46,7 @@ beforeEach(() => {
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   })
+  events._reset()
   mockClient = {
     getFile: vi.fn(),
     getTree: vi.fn(),
@@ -81,6 +83,60 @@ describe("useFileContent", () => {
     await waitFor(() => expect(r2.current.isSuccess).toBe(true))
     expect(r1.current.data?.content).toBe("a")
     expect(r2.current.data?.content).toBe("b")
+  })
+
+  it("creates and returns missing file content when createIfMissing is provided", async () => {
+    const created = vi.fn()
+    events.on(filesystemEvents.created, created)
+    mockClient.getFile.mockRejectedValueOnce(new FetchError(404, "not found"))
+    mockClient.writeFile.mockResolvedValue({ mtimeMs: 2000 })
+
+    const { result } = renderHook(
+      () => useFileContent("/deck/new.md", { createIfMissing: "# Default\n" }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockClient.writeFile).toHaveBeenCalledWith("/deck/new.md", "# Default\n")
+    expect(result.current.data).toEqual({ content: "# Default\n", mtimeMs: 2000 })
+    expect(created).toHaveBeenCalledWith(expect.objectContaining({ path: "/deck/new.md", kind: "file" }))
+  })
+
+  it("allows empty createIfMissing content", async () => {
+    mockClient.getFile.mockRejectedValueOnce(new FetchError(404, "not found"))
+    mockClient.writeFile.mockResolvedValue({ mtimeMs: 2001 })
+
+    const { result } = renderHook(
+      () => useFileContent("/empty.md", { createIfMissing: "" }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockClient.writeFile).toHaveBeenCalledWith("/empty.md", "")
+    expect(result.current.data).toEqual({ content: "", mtimeMs: 2001 })
+  })
+
+  it("does not create missing files unless createIfMissing is provided", async () => {
+    mockClient.getFile.mockRejectedValue(new FetchError(404, "not found"))
+
+    const { result } = renderHook(() => useFileContent("/deck/new.md"), { wrapper })
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(mockClient.writeFile).not.toHaveBeenCalled()
+  })
+
+  it("surfaces create failures instead of leaving the stale 404 as the error", async () => {
+    const createError = new Error("permission denied")
+    mockClient.getFile.mockRejectedValueOnce(new FetchError(404, "not found"))
+    mockClient.writeFile.mockRejectedValue(createError)
+
+    const { result } = renderHook(
+      () => useFileContent("/deck/new.md", { createIfMissing: "# Default\n" }),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current.isError).toBe(true))
+    expect(result.current.error).toBe(createError)
   })
 })
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
@@ -20,16 +20,36 @@ function noRetryOn404(count: number, error: Error): boolean {
   return count < 3
 }
 
-export function useFileContent(path: string | null): UseQueryResult<FileContent> {
+export interface UseFileContentOptions {
+  /** Create the file with this content when the initial read returns 404. */
+  createIfMissing?: string
+}
+
+export function useFileContent(
+  path: string | null,
+  options: UseFileContentOptions = {},
+): UseQueryResult<FileContent> {
   const client = useDataClient()
   const base = useApiBaseUrl()
   const workspaceId = useWorkspaceRequestId()
+  const createIfMissing = options.createIfMissing
   return useQuery({
-    queryKey: [base, workspaceId, FILES_QUERY_KEY_SEGMENT, path],
-    queryFn: ({ signal }) => client.getFile(path!, signal),
+    queryKey: [base, workspaceId, FILES_QUERY_KEY_SEGMENT, path, createIfMissing ?? null],
+    queryFn: async ({ signal }) => {
+      const activePath = path!
+      try {
+        return await client.getFile(activePath, signal)
+      } catch (err) {
+        if (createIfMissing === undefined || !(err instanceof FetchError) || err.status !== 404) throw err
+        if (signal.aborted) throw new DOMException("Aborted", "AbortError")
+        const created = await client.writeFile(activePath, createIfMissing)
+        events.emit(filesystemEvents.created, { ...userMeta(), path: activePath, kind: "file" })
+        return { content: createIfMissing, mtimeMs: created.mtimeMs }
+      }
+    },
     enabled: path != null,
     staleTime: 0,
-    retry: noRetryOn404,
+    retry: createIfMissing === undefined ? noRetryOn404 : false,
   })
 }
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useFileContent, useFileWrite } from "./data"
-import { FetchError, FileConflictError } from "./data/fetchClient"
+import { FileConflictError } from "./data/fetchClient"
 import { useEditorLifecycle, type EditorLifecycleAdapter } from "../../../front/hooks"
 
 let nextFallbackPanelId = 0
@@ -79,7 +79,8 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   const fallbackPanelIdRef = useRef(panelId ?? `file-pane:${nextFallbackPanelId++}`)
   const lifecyclePanelId = panelId ?? fallbackPanelIdRef.current
 
-  const { data: fileData, isLoading, error, refetch: refetchFileData } = useFileContent(activePath)
+  const fileContentOptions = createIfMissing === undefined ? undefined : { createIfMissing }
+  const { data: fileData, isLoading, error, refetch: refetchFileData } = useFileContent(activePath, fileContentOptions)
   const { mutateAsync: writeFile } = useFileWrite()
 
   // Local content state
@@ -102,10 +103,6 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   // Conflict state
   const [conflict, setConflict] = useState<FileConflictError | null>(null)
 
-  // Auto-create state
-  const [autoCreating, setAutoCreating] = useState(false)
-  const autoCreateAttempted = useRef(false)
-
   // TypeScript workaround: track content state for the return type
   // so we can reference it in the function body
 
@@ -121,18 +118,6 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
       loadedPathRef.current = path
     }
   }, [path, initialContent])
-
-  // Auto-create missing file exactly once per path mount.
-  useEffect(() => {
-    if (!activePath || !createIfMissing || autoCreateAttempted.current) return
-    if (!(error instanceof FetchError) || error.status !== 404) return
-    autoCreateAttempted.current = true
-    setAutoCreating(true)
-    writeFile({ path: activePath, content: createIfMissing })
-      .then(() => refetchFileData())
-      .catch(() => {})
-      .finally(() => setAutoCreating(false))
-  }, [activePath, createIfMissing, error, writeFile, refetchFileData])
 
   // Load file content on mount or when file data changes
   useEffect(() => {
@@ -314,7 +299,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   }, [lifecycle])
 
   return {
-    isLoading: isLoading || autoCreating,
+    isLoading,
     error: error as Error | null,
     content,
     isDirty: lifecycle.isDirty,


### PR DESCRIPTION
Follow-up to #348 after thermo-nuclear review.\n\nInstead of bolting a write/refetch side-effect into useFilePane, this moves createIfMissing into the file-content query itself:\n\n- useFilePane stays focused on editor state/lifecycle.\n- 404 -> create -> returned content is handled in one React Query state machine.\n- create failures surface as the real write error instead of leaving the stale 404.\n- no manual autoCreating state/refetch/catch-swallow branch.\n- emits filesystem created when the query creates the file.\n\nValidation:\n- vitest run --environment jsdom packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx\n- tsc -p packages/workspace/tsconfig.json --noEmit\n- tsc -p plugins/deck/tsconfig.json --noEmit