### PR TITLE
fix(cli): share session list between CLI mode and terminal pi

### DIFF
--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -638,7 +638,14 @@ export async function createWorkspacesModeApp(opts: {
     },
     getWorkspaceId: async (request) => (await workspaceFromRequest(request)).id,
     getWorkspaceRoot: async (workspaceId) => (await requireWorkspace(workspaceId)).path,
-    getSessionNamespace: async ({ workspaceId }) => `local-workspace-${workspaceId}`,
+    // Intentionally NOT namespaced by workspace id. Returning undefined makes the
+    // session store fall back to defaultSessionDir(workspaceRoot), whose cwd-encoding
+    // is byte-identical to pi-coding-agent's getDefaultSessionDirPath. So CLI-mode
+    // sessions land in the exact ~/.pi/agent/sessions/--<path>-- folder a standalone
+    // `pi` run in the same workspace uses, and the two share one session list both
+    // ways. Trade-off: sessions are keyed by filesystem path, not registry id — moving
+    // a workspace orphans its old sessions (acceptable; unification is the goal).
+    getSessionNamespace: async () => undefined,
     provisionRuntime: async ({ workspaceId, workspaceRoot, runtimeMode, runtimeLayout, provisioningAdapter }) => {
       if (runtimeProvisioningByWorkspace.has(workspaceId)) {
         return runtimeProvisioningByWorkspace.get(workspaceId)


### PR DESCRIPTION
## What

In workspaces (CLI hub) mode, agent sessions were namespaced by registry id — stored under `~/.pi/agent/sessions/local-workspace-<id>/`. A standalone `pi` run in the same workspace writes to `~/.pi/agent/sessions/--<path>--/` (its cwd-encoded default). So the two never shared a session list, even though the boring session store already knows how to surface native `pi` session files (`ensureWrapperForNativeSession`).

This changes `getSessionNamespace` in `modeApps.ts` to return `undefined`, which makes `PiSessionStore` fall back to `defaultSessionDir(workspaceRoot)`. That encoder is **byte-identical** to pi-coding-agent's `getDefaultSessionDirPath`, so CLI mode and terminal `pi` in the same workspace now read/write **one shared folder, both directions**.

```diff
-    getSessionNamespace: async ({ workspaceId }) => `local-workspace-${workspaceId}`,
+    getSessionNamespace: async () => undefined,
```

## Why it's safe (workspace isolation preserved in all modes)

- The session store is constructed with `scope.root` as both cwd and `storageCwd` (`registerAgentRoutes.ts:865`). `scope.root` is the **canonical host path** from the registry — unique per workspace — **not** the shared in-sandbox `/workspace` (that constant is only used as the agent's `runtimeCwd` at `registerAgentRoutes.ts:493`).
- The CLI registry derives the workspace **id from the path**: `workspaceIdForPath = slugify(basename) + "-" + sha1(path)` (`localWorkspaces.ts:44`), and `add()` resolves to `realpath` + dedupes by id. So id ⇔ path is a bijection — `local-workspace-<id>` and `--<path>--` are **equally** collision-proof. This change only renames the folder; it does not coarsen the key.

| Mode | runtimeCwd | Session folder key | Isolated? |
|------|-----------|--------------------|-----------|
| direct | host path | `--<host path>--` | ✅ unique |
| local (bwrap) | `/workspace` | `--<host path>--` | ✅ unique |
| vercel-sandbox | `/workspace` | `--<host path>--` | ✅ unique |

## Trade-off

Sessions are now keyed by filesystem path, not registry id — moving a workspace to a new path orphans its old sessions (acceptable; unification with terminal `pi` is the goal). Existing `local-workspace-<id>` session folders will no longer appear in the CLI list after this change.

## Test plan

- `pnpm -C packages/cli typecheck` ✅
- Manual: run `pi` in a workspace dir, then open that workspace in the CLI hub → sessions appear in both lists, both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)