### PR TITLE
feat(workspace): add plugin-tabs app left pane

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ packages/workspace/src/plugins/eval-*/
 
 # Dev-server workspace runtime dirs (UUID-named) created under the app cwd during local runs
 /apps/full-app/*-*-*-*-*/
+
+/artifacts/ui-review/

--- a/apps/full-app/src/front/main.tsx
+++ b/apps/full-app/src/front/main.tsx
@@ -130,10 +130,12 @@ createRoot(document.getElementById('root')!).render(
       }}
       authPages={{ userSettings: AccountSettingsPage }}
       topBarRight={
-        <>
+        <div className="flex w-full min-w-0 flex-col gap-2">
           <CreditBalanceBadge buyEnabled={buyEnabled} />
-          <UserMenu contentSide="top" contentAlign="start" />
-        </>
+          <div className="flex justify-end">
+            <UserMenu contentSide="top" contentAlign="start" />
+          </div>
+        </div>
       }
     />
     {/* Post-checkout return (LS redirects to ?checkout=return); confirms server-side. */}

--- a/apps/full-app/src/front/main.tsx
+++ b/apps/full-app/src/front/main.tsx
@@ -6,11 +6,10 @@ import {
   CREDITS_REFRESH_EVENT,
   CreditBalanceBadge,
   CreditsSettingsPanel,
-  DefaultTopBarRight,
   isPaymentRequiredNotice,
   useCreditBalance,
 } from '@hachej/boring-core/app/front'
-import { UserSettingsPage } from '@hachej/boring-core/front'
+import { UserMenu, UserSettingsPage } from '@hachej/boring-core/front'
 import '@hachej/boring-core/app/front/styles.css'
 import './app.css'
 import { PublicHeroDescription, publicLaunchPlugin } from './PublicLaunchPages'
@@ -85,6 +84,10 @@ createRoot(document.getElementById('root')!).render(
       apiTimeout={10_000}
       persistenceEnabled
       appTitle={PRODUCT_NAME}
+      workspaceLayout="plugin-tabs"
+      workspaceSectionTitle="Projects"
+      showSkills={false}
+      showPlugins={false}
       chatEntryMode="chat-first"
       publicPaths={[]}
       chatFirstPublicShell={{
@@ -129,7 +132,7 @@ createRoot(document.getElementById('root')!).render(
       topBarRight={
         <>
           <CreditBalanceBadge buyEnabled={buyEnabled} />
-          <DefaultTopBarRight />
+          <UserMenu contentSide="top" contentAlign="start" />
         </>
       }
     />

--- a/apps/workspace-playground/index.html
+++ b/apps/workspace-playground/index.html
@@ -13,6 +13,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/front/main.tsx"></script>
+    <script type="module" src="/src/front/main.tsx?v=workspace-playground"></script>
   </body>
 </html>

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -161,6 +161,7 @@ export function WorkspaceShell() {
       persistenceEnabled
       debug
       providerStorageKey={showcase ? "boring-ui-v2:layout:playground" : `boring-ui-v2:layout:playground:${workspaceId}`}
+      workspaceLayout="plugin-tabs"
       appTitle={showcase ? "Boring" : projectName}
       workspaceLabel={showcase ? undefined : projectName}
       defaultSessionTitle={showcase ? "New session" : projectName}

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -159,7 +159,6 @@ export function WorkspaceShell() {
       workspaceId={showcase ? "playground" : workspaceId}
       apiBaseUrl=""
       persistenceEnabled
-      debug
       providerStorageKey={showcase ? "boring-ui-v2:layout:playground" : `boring-ui-v2:layout:playground:${workspaceId}`}
       workspaceLayout="plugin-tabs"
       appTitle={showcase ? "Boring" : projectName}

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -64,6 +64,11 @@ export async function startPlaygroundServer(): Promise<void> {
       logger: true,
       externalPlugins: EXTERNAL_PLUGINS_ENABLED,
       defaultPluginPackages: ["@hachej/boring-ask-user"],
+      // Surface a sample project-local skill so the Skills overlay has content
+      // in the playground. `additionalSkillPaths` are loaded even with the
+      // harness default `noSkills: true`, so this opts into ONE seeded skill
+      // without surfacing the full user-global skill set.
+      pi: { additionalSkillPaths: [resolve(APP_ROOT, "src/skills")] },
     })
     app.get("/api/v1/workspace/meta", async () => {
       const localName = basename(workspaceRoot) || "Workspace"

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -12,17 +12,17 @@ export const PLAYGROUND_SKILLS_DIR = resolve(APP_ROOT, "src/skills")
 export const WORKSPACE_DIR = resolve(APP_ROOT, "workspace")
 const EXTERNAL_PLUGINS_ENABLED = process.env.BORING_EXTERNAL_PLUGINS === "1"
 
-function seedFixtureEntry(srcRoot: string, destRoot: string): void {
+function seedFixtureEntry(srcRoot: string, destRoot: string, overwrite = false): void {
   for (const name of readdirSync(srcRoot)) {
     const src = resolve(srcRoot, name)
     const stats = statSync(src)
     if (stats.isDirectory()) {
-      seedFixtureEntry(src, resolve(destRoot, name))
+      seedFixtureEntry(src, resolve(destRoot, name), overwrite)
       continue
     }
     if (!stats.isFile()) continue
     const dest = resolve(destRoot, name)
-    if (existsSync(dest)) continue
+    if (existsSync(dest) && !overwrite) continue
     mkdirSync(dirname(dest), { recursive: true })
     copyFileSync(src, dest)
   }
@@ -39,7 +39,7 @@ function seedPlaygroundSkills(workspaceRoot = WORKSPACE_DIR): string {
   const workspaceSkillsDir = resolve(workspaceRoot, ".agents/skills")
   if (existsSync(PLAYGROUND_SKILLS_DIR)) {
     mkdirSync(workspaceSkillsDir, { recursive: true })
-    seedFixtureEntry(PLAYGROUND_SKILLS_DIR, workspaceSkillsDir)
+    seedFixtureEntry(PLAYGROUND_SKILLS_DIR, workspaceSkillsDir, true)
   }
   return workspaceSkillsDir
 }

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -8,6 +8,7 @@ export const AGENT_API_PORT = Number(process.env.AGENT_API_PORT) || 5210
 export const VITE_PORT = Number(process.env.PORT) || 5200
 export const APP_ROOT = resolve(import.meta.dirname, "../..")
 export const FIXTURES_DIR = resolve(APP_ROOT, "src/fixtures")
+export const PLAYGROUND_SKILLS_DIR = resolve(APP_ROOT, "src/skills")
 export const WORKSPACE_DIR = resolve(APP_ROOT, "workspace")
 const EXTERNAL_PLUGINS_ENABLED = process.env.BORING_EXTERNAL_PLUGINS === "1"
 
@@ -34,6 +35,15 @@ export function seedWorkspaceFromFixtures(workspaceRoot = WORKSPACE_DIR): void {
   seedFixtureEntry(FIXTURES_DIR, workspaceRoot)
 }
 
+function seedPlaygroundSkills(workspaceRoot = WORKSPACE_DIR): string {
+  const workspaceSkillsDir = resolve(workspaceRoot, ".agents/skills")
+  if (existsSync(PLAYGROUND_SKILLS_DIR)) {
+    mkdirSync(workspaceSkillsDir, { recursive: true })
+    seedFixtureEntry(PLAYGROUND_SKILLS_DIR, workspaceSkillsDir)
+  }
+  return workspaceSkillsDir
+}
+
 let agentBoot: Promise<void> | null = null
 
 export async function startPlaygroundServer(): Promise<void> {
@@ -43,6 +53,7 @@ export async function startPlaygroundServer(): Promise<void> {
     if (process.env.BORING_WORKSPACE_PLAYGROUND_SEED_FIXTURES !== "0") {
       seedWorkspaceFromFixtures(workspaceRoot)
     }
+    const playgroundSkillsDir = seedPlaygroundSkills(workspaceRoot)
     const workerBaseUrl = process.env.BORING_WORKER_BASE_URL?.trim()
     const remoteWorkerModeAdapter = workerBaseUrl
       ? createRemoteWorkerModeAdapter({ baseUrl: workerBaseUrl })
@@ -65,10 +76,10 @@ export async function startPlaygroundServer(): Promise<void> {
       externalPlugins: EXTERNAL_PLUGINS_ENABLED,
       defaultPluginPackages: ["@hachej/boring-ask-user"],
       // Surface a sample project-local skill so the Skills overlay has content
-      // in the playground. `additionalSkillPaths` are loaded even with the
-      // harness default `noSkills: true`, so this opts into ONE seeded skill
-      // without surfacing the full user-global skill set.
-      pi: { additionalSkillPaths: [resolve(APP_ROOT, "src/skills")] },
+      // in the playground. We copy it into the workspace-local .agents/skills
+      // tree so clicking it can use the UI bridge openFile command against a
+      // normal workspace-relative path.
+      pi: { additionalSkillPaths: [playgroundSkillsDir] },
     })
     app.get("/api/v1/workspace/meta", async () => {
       const localName = basename(workspaceRoot) || "Workspace"

--- a/apps/workspace-playground/src/skills/playground-demo/SKILL.md
+++ b/apps/workspace-playground/src/skills/playground-demo/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: playground-demo
-description: A sample skill seeded into the workspace playground so the Skills overlay has content to show. It demonstrates skill discovery and rendering — not a functional workflow.
+name: local-test
+description: Local test skill seeded into the workspace playground. Use it to verify the Skills overlay, workspace-local skill discovery, and UI-bridge open-file behavior.
 ---
 
-# Playground Demo Skill
+# Local Test Skill
 
-This is a sample skill seeded into the **workspace playground** so the
-Skills overlay (chat left overlay) has at least one entry to render.
+This skill is intentionally tiny and workspace-local. It is copied into:
 
-It exists purely to verify:
+`.agents/skills/playground-demo/SKILL.md`
 
-- The `/api/v1/agent/skills` endpoint discovers project-local skills passed
-  via `additionalSkillPaths`.
-- The Skills overlay lists skills with their name and description.
+when the workspace playground starts, then loaded through `pi.additionalSkillPaths`.
 
-It does not define a functional workflow. Remove it or replace it with real
-workspace skills when wiring a production app.
+Use it to verify:
+
+- the Skills overlay shows workspace-local skills;
+- clicking a skill opens its `SKILL.md` through the UI bridge;
+- reloading skills picks up the seeded workspace copy.

--- a/apps/workspace-playground/src/skills/playground-demo/SKILL.md
+++ b/apps/workspace-playground/src/skills/playground-demo/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: playground-demo
+description: A sample skill seeded into the workspace playground so the Skills overlay has content to show. It demonstrates skill discovery and rendering — not a functional workflow.
+---
+
+# Playground Demo Skill
+
+This is a sample skill seeded into the **workspace playground** so the
+Skills overlay (chat left overlay) has at least one entry to render.
+
+It exists purely to verify:
+
+- The `/api/v1/agent/skills` endpoint discovers project-local skills passed
+  via `additionalSkillPaths`.
+- The Skills overlay lists skills with their name and description.
+
+It does not define a functional workflow. Remove it or replace it with real
+workspace skills when wiring a production app.

--- a/docs/plans/plugin-tabs-workspace-layout/02-left-pane-implementation-plan.md
+++ b/docs/plans/plugin-tabs-workspace-layout/02-left-pane-implementation-plan.md
@@ -1,0 +1,103 @@
+# Phase 2 — App Left Pane Implementation Plan
+
+## Scope
+
+Implement the Phase 2 app/session left pane as an opt-in workspace shell for the existing `WorkspaceAgentFront`.
+
+- Public opt-in prop: `workspaceLayout="plugin-tabs"`.
+- Default remains classic layout with existing `TopBar` + `ChatLayout` session drawer behavior unchanged.
+- Phase 2 owns app/session navigation only: New chat, Search, Plugins, Skills, pinned sessions, regular sessions, collapse/expand.
+- No workspace tab system, filetree ownership changes, plugin pane state model, panel params model, or `SurfaceShell` behavior rewrite.
+
+## Architecture
+
+### 1. Add a sibling plugin-tabs shell, not a mutation of classic
+
+Create small layout components under workspace front code:
+
+- `PluginTabsWorkspaceShell`
+  - Renders the optional `AppLeftPane` beside existing main content.
+  - When collapsed, renders no left pane or icon rail; only an absolute overlay button to restore it.
+  - Receives the already-constructed main content node from `WorkspaceAgentFront`.
+- `AppLeftPane`
+  - Pure app/session navigation.
+  - Uses existing session actions from `WorkspaceAgentFront`.
+  - Uses registry read-only access only to find a workspace-page panel for the Plugins button.
+
+Classic render path stays byte-for-byte equivalent except for extracting the current `ChatLayout` node into a local variable.
+
+### 2. Keep ChatLayout responsible for chat/workbench mechanics
+
+For `workspaceLayout="plugin-tabs"`:
+
+- Do not render the classic `TopBar`.
+- Do not enable the classic session drawer (`nav={null}`, no `onOpenNav`) to avoid duplicate session navigation.
+- Suppress ChatLayout's classic left-edge session controls too: omit `onCreateChatPaneAfter` in plugin-tabs mode so the legacy floating `New chat` edge button cannot duplicate the app-left-pane New chat action. Session split/open remains available from the app-left-pane session rows.
+- Continue using `ChatLayout` for chat panes, collapse chat, workbench open/close, surface queueing, and Dockview mechanics.
+- Continue using `SurfaceShell` unchanged.
+
+### 3. Session semantics
+
+Rows compute a simple state:
+
+```ts
+type SessionRowState = "normal" | "open" | "active"
+```
+
+- `active`: `session.id === activeChatPaneId`.
+- `open`: session is in `chatPaneIds` but not active.
+- `normal`: otherwise.
+
+Click behavior:
+
+- active row: no-op.
+- open inactive row: call `switchToChatPane(id)` to activate existing pane.
+- normal row: call `switchToChatPane(id)` to replace/switch the current primary pane.
+- split/open icon: call `openChatPane(id)`; existing panes focus/flash via existing parent logic.
+- pin/unpin: call `toggleSessionPinned(id)` and stop propagation.
+
+### 4. Primary actions
+
+- New chat: call `resolvedCreate()`; existing parent logic decides local vs remote session creation.
+- Search: open the existing command palette and extend that same palette with a plugin-tabs-only `Chat session search` section. Do not introduce a second palette. Result click calls `switchToChatPane(id)`; the row split/open affordance calls `openChatPane(id)`.
+- Plugins: open/focus the current workspace/plugin content area without introducing a plugin catalog/list. Resolve "current" in this order:
+  1. active open tab whose registered component is a non-core `workspace-page` panel,
+  2. most recently open non-core `workspace-page` tab from the surface snapshot,
+  3. first registered non-core `workspace-page` panel,
+  4. otherwise just open the workbench area.
+  Opening uses the same parent surface-open + pending-operation queue path used by UI command dispatch so closed/unready surfaces do not drop the request.
+- Skills: add one small `workspace:skills` workspace-page panel only to the plugin-tabs render path by appending it to `WorkspaceAgentFront`'s `panels` prop when `workspaceLayout="plugin-tabs"`. It must not be part of `coreWorkspacePanels`, so classic workbench rails stay unchanged. The panel fetches `/api/v1/agent/skills` through `WorkspacePluginClient.getJson()` and displays the same endpoint data used by slash-command skill discovery. The left-pane Skills item opens/focuses this panel.
+
+### 5. Plugin client extension
+
+Add `getJson<T>(path)` to `WorkspacePluginClient`, using the same path/base validation, auth headers, workspace header/query handling, credentials, and response error behavior as `postJson`.
+
+### 6. Persistence and collapsed overlay
+
+- Reuse existing shell storage namespace.
+- Add one boolean: `${shellStorageKey}:appLeftPaneCollapsed`.
+- Do not persist app-left-pane selected primary action in Phase 2.
+- Collapsed means the `<aside data-boring-workspace-part="app-left-pane">` is not rendered at all; no rail and no reserved width.
+- Render exactly one restore control for app navigation. Position it on a small top-left overlay but offset below Dockview/tab headers (e.g. `top: 52px; left: 8px`) with a tight hitbox so it does not cover the first workspace/chat tab activation or close target. The workbench's own collapsed-source restore control remains inside `SurfaceShell`; this PR must not stack another control directly on top of that header area.
+
+### 7. Tests
+
+Add focused tests for:
+
+- Default classic layout still renders the classic top bar/session drawer path and does not register/show the plugin-tabs Skills workspace page.
+- `workspaceLayout="plugin-tabs"` renders the app left pane, primary actions, no Projects/Codex/Automations items, and no duplicate classic left-edge `New chat` floating control.
+- Collapse removes the pane entirely and shows only the app-navigation restore overlay control, with no collapsed app-left-pane rail in the DOM.
+- Session row states distinguish active/open/normal and pin/split controls do not accidentally switch via propagation.
+- Search opens the existing command palette with a `Chat session search` section; selecting a session calls `switchToChatPane`, and the split icon calls `openChatPane`.
+- Plugins opens/focuses active/last/fallback non-core workspace-page panels through the existing workbench/surface path.
+- Skills opens the plugin-tabs-gated Skills workspace-page and fetches `/api/v1/agent/skills` with workspace scoping.
+- `WorkspacePluginClient.getJson()` rejects unsafe paths and forwards workspace/auth context.
+
+## Non-goals / guardrails
+
+- Do not edit `SurfaceShell` except if strictly needed for a bug found by tests; current plan expects zero `SurfaceShell` changes.
+- Do not change `WorkbenchLeftPane` ownership semantics.
+- Do not add workspace tabs in this PR.
+- Do not add plugin marketplace/catalog/list in this PR.
+- Do not make `plugin-tabs` the default layout.
+- Do not import `@hachej/boring-agent` from workspace front/shared code beyond existing `WorkspaceAgentFront` usage.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "release:minor": "node scripts/release.mjs minor",
     "release:major": "node scripts/release.mjs major",
     "build:packages": "pnpm -r --filter './packages/*' --filter './plugins/*' --workspace-concurrency=4 run build",
-    "typecheck:changed": "node scripts/typecheck-changed-workspaces.mjs"
+    "typecheck:changed": "node scripts/typecheck-changed-workspaces.mjs",
+    "review:workspace-ui": "node scripts/review-workspace-playground-ui.mjs"
   },
   "packageManager": "pnpm@10.33.2",
   "engines": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -67,6 +67,7 @@
     "smoke:capability-readiness:vercel": "tsx ./scripts/smoke-capability-readiness-vercel.mts"
   },
   "dependencies": {
+    "@earendil-works/pi-tui": "0.75.5",
     "@hachej/boring-ui-kit": "workspace:*",
     "@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.75.5",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/agent/src/front/chat/session/__tests__/piSessionSearch.test.ts
+++ b/packages/agent/src/front/chat/session/__tests__/piSessionSearch.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  parsePiSessionSearchQuery,
+  searchPiSessions,
+} from '../piSessionSearch'
+
+const sessions = [
+  {
+    id: 'session-a',
+    title: 'Alpha architecture plan',
+    allMessagesText: 'discussed workspace left pane and skills overlay',
+    cwd: '/repo/boring-ui',
+    updatedAt: '2026-06-21T10:00:00Z',
+  },
+  {
+    id: 'session-b',
+    title: 'Beta build polish',
+    allMessagesText: 'fixed command palette and catalog search',
+    cwd: '/repo/boring-ui',
+    updatedAt: '2026-06-21T11:00:00Z',
+  },
+  {
+    id: 'session-c',
+    title: 'Release checklist',
+    allMessagesText: 'publish package and update CLI',
+    cwd: '/repo/boring-ui',
+    updatedAt: '2026-06-21T12:00:00Z',
+  },
+]
+
+describe('piSessionSearch', () => {
+  it('uses pi-style fuzzy matching for session titles and transcript text', () => {
+    expect(searchPiSessions(sessions, 'bbp').map((session) => session.id)).toEqual(['session-b'])
+    expect(searchPiSessions(sessions, 'sk ov').map((session) => session.id)).toEqual(['session-a'])
+  })
+
+  it('supports quoted phrases and regex mode like pi session picker', () => {
+    expect(searchPiSessions(sessions, '"catalog search"').map((session) => session.id)).toEqual(['session-b'])
+    expect(searchPiSessions(sessions, 're:release|alpha').map((session) => session.id)).toEqual(['session-c', 'session-a'])
+  })
+
+  it('returns no results for invalid regex', () => {
+    const parsed = parsePiSessionSearchQuery('re:[')
+    expect(parsed.error).toBeTruthy()
+    expect(searchPiSessions(sessions, 're:[')).toEqual([])
+  })
+})

--- a/packages/agent/src/front/chat/session/index.ts
+++ b/packages/agent/src/front/chat/session/index.ts
@@ -9,6 +9,14 @@ export {
 export { usePiSessions, type UsePiSessionsOptions, type UsePiSessionsResult, type PiSessionCreateInit, type PiSessionRefreshOptions } from './usePiSessions'
 export { SessionList, SessionBrowser, type SessionListProps } from './SessionList'
 export {
+  searchPiSessions,
+  parsePiSessionSearchQuery,
+  matchPiSessionSearch,
+  type PiSessionSearchItem,
+  type PiSessionSearchOptions,
+  type PiSessionSearchSortMode,
+} from './piSessionSearch'
+export {
   InitialDraftAutoSubmitGuard,
   createPiComposerPolicyController,
   readPiComposerSettings,

--- a/packages/agent/src/front/chat/session/piSessionSearch.ts
+++ b/packages/agent/src/front/chat/session/piSessionSearch.ts
@@ -1,0 +1,185 @@
+import { fuzzyMatch } from "@earendil-works/pi-tui/dist/fuzzy.js"
+
+export interface PiSessionSearchItem {
+  id: string
+  /** boring-ui session title maps to pi's session display name. */
+  title?: string | null
+  /** Optional pi-style session name for callers that already expose it. */
+  name?: string | null
+  /** Optional full transcript search text when available from a pi session listing. */
+  allMessagesText?: string | null
+  /** Optional cwd from the underlying pi session. */
+  cwd?: string | null
+  updatedAt?: string | number | Date | null
+}
+
+export type PiSessionSearchSortMode = "fuzzy" | "recent"
+
+export interface PiSessionSearchOptions {
+  sortMode?: PiSessionSearchSortMode
+  limit?: number
+}
+
+type SearchToken = { kind: "fuzzy" | "phrase"; value: string }
+
+type ParsedSearchQuery =
+  | { mode: "tokens"; tokens: SearchToken[]; regex: null; error?: undefined }
+  | { mode: "regex"; tokens: []; regex: RegExp | null; error?: string }
+
+function normalizeWhitespaceLower(text: string): string {
+  return text.toLowerCase().replace(/\s+/g, " ").trim()
+}
+
+function sessionModifiedMs(session: PiSessionSearchItem): number {
+  const value = session.updatedAt
+  if (value instanceof Date) return value.getTime()
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0
+  if (typeof value === "string") {
+    const parsed = Date.parse(value)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
+}
+
+function getSessionSearchText(session: PiSessionSearchItem): string {
+  const name = session.name ?? session.title ?? ""
+  return `${session.id} ${name} ${session.allMessagesText ?? ""} ${session.cwd ?? ""}`
+}
+
+/**
+ * Parse session-search queries with the same user-facing syntax as pi's native
+ * session picker: whitespace fuzzy tokens, quoted exact phrases, and `re:`
+ * regex mode. Kept intentionally small so boring-agent frontends can reuse the
+ * pi search behavior without importing the terminal-only session picker UI.
+ */
+export function parsePiSessionSearchQuery(query: string): ParsedSearchQuery {
+  const trimmed = query.trim()
+  if (!trimmed) return { mode: "tokens", tokens: [], regex: null }
+
+  if (trimmed.startsWith("re:")) {
+    const pattern = trimmed.slice(3).trim()
+    if (!pattern) return { mode: "regex", tokens: [], regex: null, error: "Empty regex" }
+    try {
+      return { mode: "regex", tokens: [], regex: new RegExp(pattern, "i") }
+    } catch (error) {
+      return {
+        mode: "regex",
+        tokens: [],
+        regex: null,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  const tokens: SearchToken[] = []
+  let buffer = ""
+  let inQuote = false
+  let hadUnclosedQuote = false
+
+  const flush = (kind: SearchToken["kind"]) => {
+    const value = buffer.trim()
+    buffer = ""
+    if (value) tokens.push({ kind, value })
+  }
+
+  for (let index = 0; index < trimmed.length; index += 1) {
+    const char = trimmed[index]
+    if (char === '"') {
+      if (inQuote) {
+        flush("phrase")
+        inQuote = false
+      } else {
+        flush("fuzzy")
+        inQuote = true
+      }
+      continue
+    }
+    if (!inQuote && /\s/.test(char)) {
+      flush("fuzzy")
+      continue
+    }
+    buffer += char
+  }
+
+  if (inQuote) hadUnclosedQuote = true
+  if (hadUnclosedQuote) {
+    return {
+      mode: "tokens",
+      tokens: trimmed
+        .split(/\s+/)
+        .map((token) => token.trim())
+        .filter((token) => token.length > 0)
+        .map((value) => ({ kind: "fuzzy", value })),
+      regex: null,
+    }
+  }
+
+  flush(inQuote ? "phrase" : "fuzzy")
+  return { mode: "tokens", tokens, regex: null }
+}
+
+export function matchPiSessionSearch(session: PiSessionSearchItem, parsed: ParsedSearchQuery): { matches: boolean; score: number } {
+  const text = getSessionSearchText(session)
+
+  if (parsed.mode === "regex") {
+    if (!parsed.regex) return { matches: false, score: 0 }
+    const index = text.search(parsed.regex)
+    if (index < 0) return { matches: false, score: 0 }
+    return { matches: true, score: index * 0.1 }
+  }
+
+  if (parsed.tokens.length === 0) return { matches: true, score: 0 }
+
+  let totalScore = 0
+  let normalizedText: string | null = null
+  for (const token of parsed.tokens) {
+    if (token.kind === "phrase") {
+      normalizedText ??= normalizeWhitespaceLower(text)
+      const phrase = normalizeWhitespaceLower(token.value)
+      if (!phrase) continue
+      const index = normalizedText.indexOf(phrase)
+      if (index < 0) return { matches: false, score: 0 }
+      totalScore += index * 0.1
+      continue
+    }
+
+    const match = fuzzyMatch(token.value, text)
+    if (!match.matches) return { matches: false, score: 0 }
+    totalScore += match.score
+  }
+
+  return { matches: true, score: totalScore }
+}
+
+export function searchPiSessions<T extends PiSessionSearchItem>(
+  sessions: readonly T[],
+  query: string,
+  options: PiSessionSearchOptions = {},
+): T[] {
+  const { sortMode = "fuzzy", limit } = options
+  const trimmed = query.trim()
+  const source = [...sessions]
+  if (!trimmed) return limit == null ? source : source.slice(0, limit)
+
+  const parsed = parsePiSessionSearchQuery(trimmed)
+  if (parsed.error) return []
+
+  if (sortMode === "recent") {
+    const filtered = source.filter((session) => matchPiSessionSearch(session, parsed).matches)
+    return limit == null ? filtered : filtered.slice(0, limit)
+  }
+
+  const scored: Array<{ session: T; score: number }> = []
+  for (const session of source) {
+    const result = matchPiSessionSearch(session, parsed)
+    if (result.matches) scored.push({ session, score: result.score })
+  }
+
+  scored.sort((a, b) => {
+    if (a.score !== b.score) return a.score - b.score
+    return sessionModifiedMs(b.session) - sessionModifiedMs(a.session)
+  })
+
+  const results = scored.map((result) => result.session)
+  return limit == null ? results : results.slice(0, limit)
+}

--- a/packages/agent/src/front/index.ts
+++ b/packages/agent/src/front/index.ts
@@ -30,8 +30,19 @@ export {
   clearActiveSessionId,
   SessionList as PiSessionList,
   SessionBrowser as PiSessionBrowser,
+  searchPiSessions,
+  parsePiSessionSearchQuery,
+  matchPiSessionSearch,
 } from './chat/session'
-export type { UsePiSessionsOptions, UsePiSessionsResult, PiSessionCreateInit, SessionListProps } from './chat/session'
+export type {
+  UsePiSessionsOptions,
+  UsePiSessionsResult,
+  PiSessionCreateInit,
+  SessionListProps,
+  PiSessionSearchItem,
+  PiSessionSearchOptions,
+  PiSessionSearchSortMode,
+} from './chat/session'
 export {
   builtinCommands,
   createCommandRegistry,

--- a/packages/agent/src/server/http/routes/skills.ts
+++ b/packages/agent/src/server/http/routes/skills.ts
@@ -7,8 +7,14 @@
  * host apps having to hardcode skill names in extraCommands.
  *
  * Shape:
- *   { skills: [{ name: string, description: string }] }
+ *   { skills: [{ name: string, description: string, filePath?: string }] }
+ *
+ * `filePath` is the path to the skill's SKILL.md exposed for the workspace UI
+ * bridge. It is workspace-relative when the skill lives under the workspace
+ * root (so `openFile` can load it), and falls back to the absolute path for
+ * external skill sources.
  */
+import { isAbsolute, relative } from 'node:path'
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import {
   DefaultPackageManager,
@@ -21,10 +27,18 @@ import { createResourceSettingsManager, withPiHarnessDefaults } from '../../harn
 export interface SkillSummary {
   name: string
   description: string
+  /** Path to the skill's SKILL.md for UI bridge openFile (workspace-relative when possible). */
+  filePath?: string
 }
 
 interface SkillsQuery {
   refresh?: string
+}
+
+function skillPathForUiBridge(workspaceRoot: string, filePath: string): string {
+  const rel = relative(workspaceRoot, filePath).replace(/\\/g, '/')
+  if (rel && !rel.startsWith('..') && !isAbsolute(rel)) return rel
+  return filePath
 }
 
 const CACHE_TTL_MS = 30_000
@@ -103,6 +117,7 @@ export function skillsRoutes(
       const skills: SkillSummary[] = result.skills.map((s) => ({
         name: s.name,
         description: s.description,
+        filePath: skillPathForUiBridge(workspaceRoot, s.filePath),
       }))
       cached.set(cacheKey, { skills, expiresAt: now + CACHE_TTL_MS })
       return reply.code(200).send({ skills })

--- a/packages/cli/src/front/App.test.tsx
+++ b/packages/cli/src/front/App.test.tsx
@@ -90,7 +90,11 @@ describe("CliWorkspaceShell", () => {
 
     // Must mount the URL workspace, never the fallback.
     await waitFor(() => expect(workspaceAgentFrontSpy).toHaveBeenCalled())
-    expect(workspaceAgentFrontSpy.mock.calls.at(-1)?.[0]).toMatchObject({ workspaceId: "target" })
+    expect(workspaceAgentFrontSpy.mock.calls.at(-1)?.[0]).toMatchObject({
+      workspaceId: "target",
+      workspaceLayout: "plugin-tabs",
+      workspaceSectionTitle: "Projects",
+    })
     expect(window.location.pathname).toBe("/workspace/target")
   })
 
@@ -156,6 +160,8 @@ describe("CliWorkspaceShell", () => {
     await waitFor(() => expect(workspaceAgentFrontSpy).toHaveBeenCalled())
     expect(workspaceAgentFrontSpy.mock.calls.at(-1)?.[0]).toMatchObject({
       frontPluginHotReload: "vite",
+      workspaceLayout: "plugin-tabs",
+      workspaceSectionTitle: "Project",
       appTitle: "Folder Workspace",
       plugins: [expect.objectContaining({ pluginId: "ask-user" })],
     })
@@ -251,6 +257,8 @@ describe("CliWorkspaceShell", () => {
     expect(workspaceAgentFrontSpy.mock.calls.at(-1)?.[0]).toMatchObject({
       workspaceId: "ws-alpha-be8d3c24",
       workspaceLabel: "Alpha Project",
+      workspaceLayout: "plugin-tabs",
+      workspaceSectionTitle: "Projects",
     })
   })
 

--- a/packages/cli/src/front/App.test.tsx
+++ b/packages/cli/src/front/App.test.tsx
@@ -70,6 +70,12 @@ describe("CliWorkspaceShell", () => {
           headers: { "Content-Type": "application/json" },
         })
       }
+      if (url.includes("/api/v1/agent/pi-chat/sessions")) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
       throw new Error(`unexpected fetch: ${url}`)
     }) as typeof fetch
   }
@@ -246,6 +252,15 @@ describe("CliWorkspaceShell", () => {
           headers: { "Content-Type": "application/json" },
         })
       }
+      if (url.includes("/api/v1/agent/pi-chat/sessions")) {
+        return new Response(JSON.stringify([
+          { id: "chat-1", title: "Check Qwen compatibility", updatedAt: "2026-06-15T00:00:00.000Z" },
+          { id: "chat-2", title: "Research account deletion", updatedAt: "2026-06-14T00:00:00.000Z" },
+        ]), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
       throw new Error(`unexpected fetch: ${url}`)
     }) as typeof fetch
 
@@ -254,12 +269,18 @@ describe("CliWorkspaceShell", () => {
     await waitFor(() => expect(workspaceAgentFrontSpy).toHaveBeenCalled())
     // The tab title comes from workspaceLabel; it must be the friendly name,
     // not the slug+hash workspace id.
-    expect(workspaceAgentFrontSpy.mock.calls.at(-1)?.[0]).toMatchObject({
+    await waitFor(() => expect(workspaceAgentFrontSpy.mock.calls.at(-1)?.[0]).toMatchObject({
       workspaceId: "ws-alpha-be8d3c24",
       workspaceLabel: "Alpha Project",
       workspaceLayout: "plugin-tabs",
       workspaceSectionTitle: "Projects",
-    })
+      appLeftProjects: expect.arrayContaining([expect.objectContaining({
+        id: "ws-alpha-be8d3c24",
+        name: "Alpha Project",
+        sessionCount: 2,
+        sessions: expect.arrayContaining([expect.objectContaining({ id: "chat-1", title: "Check Qwen compatibility" })]),
+      })]),
+    }))
   })
 
   test("recovers from a transient local-workspaces fetch failure instead of latching the empty state", async () => {
@@ -286,6 +307,12 @@ describe("CliWorkspaceShell", () => {
         return new Response(JSON.stringify({
           workspaces: [{ id: "ws-alpha-be8d3c24", name: "Alpha Project", path: "/tmp/ws-alpha", available: true }],
         }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      if (url.includes("/api/v1/agent/pi-chat/sessions")) {
+        return new Response(JSON.stringify([]), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         })

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -328,6 +328,8 @@ export function CliWorkspaceShell() {
         key={activeWorkspace.id}
         workspaceId={activeWorkspace.id}
         workspaceLabel={activeWorkspace.name}
+        workspaceSectionTitle="Projects"
+        workspaceLayout="plugin-tabs"
         requestHeaders={requestHeaders}
         authHeaders={requestHeaders}
         plugins={plugins}
@@ -371,6 +373,9 @@ export function CliWorkspaceShell() {
       persistenceEnabled
       providerStorageKey={`boring-ui-v2:layout:${projectName}`}
       appTitle={projectName}
+      workspaceLabel={projectName}
+      workspaceSectionTitle="Project"
+      workspaceLayout="plugin-tabs"
       defaultSessionTitle={projectName}
       activeSessionId={initialSessionId ?? undefined}
       chatParams={{ thinkingControl: true }}

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -41,6 +41,21 @@ interface LocalWorkspace {
   available: boolean
 }
 
+interface ProjectSessionSummary {
+  id: string
+  title?: string | null
+  updatedAt?: string | number
+}
+
+interface ProjectSessionOverview {
+  sessions: ProjectSessionSummary[]
+  loading: boolean
+  error?: string
+}
+
+const PROJECT_SESSION_PREVIEW_INITIAL_LIMIT = 5
+const PROJECT_SESSION_PREVIEW_FETCH_LIMIT = 25
+
 export function workspaceIdFromCliUrl(pathname: string): string | null {
   const match = pathname.match(/^\/workspace\/([^/?#]+)/)
   if (!match?.[1]) return null
@@ -97,6 +112,33 @@ function areWorkspacesEqual(a: LocalWorkspace[], b: LocalWorkspace[]): boolean {
   })
 }
 
+function piActiveSessionStorageKey(workspaceId: string): string {
+  return `boring-agent:v2:${workspaceId}:activeSessionId`
+}
+
+function toProjectSessionSummary(value: unknown): ProjectSessionSummary | null {
+  if (typeof value !== "object" || value === null) return null
+  const record = value as Record<string, unknown>
+  if (typeof record.id !== "string" || record.id.length === 0) return null
+  return {
+    id: record.id,
+    title: typeof record.title === "string" ? record.title : "Untitled",
+    updatedAt: typeof record.updatedAt === "string" || typeof record.updatedAt === "number" ? record.updatedAt : undefined,
+  }
+}
+
+async function fetchProjectSessionOverview(workspaceId: string): Promise<ProjectSessionSummary[]> {
+  const query = new URLSearchParams({ limit: String(PROJECT_SESSION_PREVIEW_FETCH_LIMIT) })
+  const response = await fetch(`/api/v1/agent/pi-chat/sessions?${query.toString()}`, {
+    headers: { "x-boring-workspace-id": workspaceId },
+  })
+  if (!response.ok) throw new Error(`sessions ${response.status}`)
+  const payload = await response.json()
+  return Array.isArray(payload)
+    ? payload.map(toProjectSessionSummary).filter((session): session is ProjectSessionSummary => Boolean(session))
+    : []
+}
+
 export function CliVersionBadge({ version }: { version?: string | null }) {
   const label = version?.trim()
   if (!label) return null
@@ -130,6 +172,8 @@ export function CliWorkspaceShell() {
   // and retry) so a transient error never strands the page on the empty state.
   const [workspacesLoaded, setWorkspacesLoaded] = useState(false)
   const [runtimePluginFrontLoadingEnabled, setRuntimePluginFrontLoadingEnabled] = useState(false)
+  const [projectSessionOverviews, setProjectSessionOverviews] = useState<Record<string, ProjectSessionOverview>>({})
+  const [projectSessionPreviewLimits, setProjectSessionPreviewLimits] = useState<Record<string, number>>({})
 
   const refreshWorkspacesRef = useRef<(() => void) | null>(null)
 
@@ -267,6 +311,70 @@ export function CliWorkspaceShell() {
     () => activeWorkspaceId ? { "x-boring-workspace-id": activeWorkspaceId } : null,
     [activeWorkspaceId],
   )
+  const availableWorkspaceIdsKey = useMemo(
+    () => workspaces.filter((workspace) => workspace.available).map((workspace) => workspace.id).sort().join("\n"),
+    [workspaces],
+  )
+
+  useEffect(() => {
+    if (!workspacesMode || !availableWorkspaceIdsKey) return
+    const ids = availableWorkspaceIdsKey.split("\n").filter(Boolean)
+    let cancelled = false
+    setProjectSessionOverviews((current) => {
+      const next: Record<string, ProjectSessionOverview> = {}
+      for (const id of ids) next[id] = current[id] ?? { sessions: [], loading: true }
+      return next
+    })
+    for (const id of ids) {
+      void fetchProjectSessionOverview(id)
+        .then((sessions) => {
+          if (cancelled) return
+          setProjectSessionOverviews((current) => ({
+            ...current,
+            [id]: { sessions, loading: false },
+          }))
+        })
+        .catch((error) => {
+          if (cancelled) return
+          setProjectSessionOverviews((current) => ({
+            ...current,
+            [id]: {
+              sessions: current[id]?.sessions ?? [],
+              loading: false,
+              error: error instanceof Error ? error.message : "sessions failed",
+            },
+          }))
+        })
+    }
+    return () => { cancelled = true }
+  }, [availableWorkspaceIdsKey, workspacesMode])
+
+  const appLeftProjects = useMemo(() => workspaces.map((workspace) => {
+    const overview = projectSessionOverviews[workspace.id]
+    const limit = projectSessionPreviewLimits[workspace.id] ?? PROJECT_SESSION_PREVIEW_INITIAL_LIMIT
+    const sessions = overview?.sessions ?? []
+    return {
+      id: workspace.id,
+      name: workspace.name,
+      available: workspace.available,
+      sessions: sessions.slice(0, limit),
+      sessionCount: sessions.length,
+      hasMoreSessions: sessions.length > limit,
+      loadingSessions: overview?.loading ?? (workspace.available && !overview),
+    }
+  }), [projectSessionOverviews, projectSessionPreviewLimits, workspaces])
+
+  const openProjectSession = useCallback((workspaceId: string, sessionId: string) => {
+    window.localStorage.setItem(piActiveSessionStorageKey(workspaceId), sessionId)
+    setActiveWorkspaceId(workspaceId)
+  }, [])
+
+  const showMoreProjectSessions = useCallback((workspaceId: string) => {
+    setProjectSessionPreviewLimits((current) => ({
+      ...current,
+      [workspaceId]: (current[workspaceId] ?? PROJECT_SESSION_PREVIEW_INITIAL_LIMIT) + PROJECT_SESSION_PREVIEW_INITIAL_LIMIT,
+    }))
+  }, [])
 
   if (!metaLoaded) {
     return <div className="h-screen w-screen bg-background" />
@@ -330,6 +438,14 @@ export function CliWorkspaceShell() {
         workspaceLabel={activeWorkspace.name}
         workspaceSectionTitle="Projects"
         workspaceLayout="plugin-tabs"
+        appLeftProjects={appLeftProjects}
+        appLeftActiveProjectId={activeWorkspace.id}
+        onSwitchAppLeftProject={(workspaceId) => {
+          window.localStorage.setItem("boring-ui:local-workspace-id", workspaceId)
+          setActiveWorkspaceId(workspaceId)
+        }}
+        onOpenAppLeftProjectSession={openProjectSession}
+        onShowMoreAppLeftProjectSessions={showMoreProjectSessions}
         requestHeaders={requestHeaders}
         authHeaders={requestHeaders}
         plugins={plugins}

--- a/packages/core/src/front/components/UserMenu.tsx
+++ b/packages/core/src/front/components/UserMenu.tsx
@@ -25,6 +25,15 @@ import { routes } from '../utils.js'
 
 type ThemePreference = 'light' | 'dark' | 'system'
 
+type UserMenuContentSide = 'top' | 'right' | 'bottom' | 'left'
+type UserMenuContentAlign = 'start' | 'center' | 'end'
+
+export interface UserMenuProps {
+  /** Dropdown side relative to the trigger. Use "top" when the trigger lives in an app-left footer. */
+  contentSide?: UserMenuContentSide
+  contentAlign?: UserMenuContentAlign
+}
+
 const THEME_ORDER: ThemePreference[] = ['light', 'dark', 'system']
 
 function labelForTheme(preference: ThemePreference): string {
@@ -52,7 +61,7 @@ function initialsFor(name: string | null, email: string): string {
   return email.slice(0, 2).toUpperCase()
 }
 
-export function UserMenu() {
+export function UserMenu({ contentSide = 'bottom', contentAlign = 'end' }: UserMenuProps = {}) {
   const identity = useUser()
   const signOut = useSignOut()
   const navigate = useNavigate()
@@ -93,7 +102,8 @@ export function UserMenu() {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent
-        align="end"
+        align={contentAlign}
+        side={contentSide}
         sideOffset={8}
         className="w-80 rounded-lg border-border/70 bg-[color:var(--surface-workbench-left)] p-2 shadow-2xl"
       >

--- a/packages/core/src/front/components/index.ts
+++ b/packages/core/src/front/components/index.ts
@@ -1,4 +1,5 @@
 export { UserMenu } from './UserMenu.js'
+export type { UserMenuProps } from './UserMenu.js'
 export { TopBarSlotProvider, useTopBarSlot } from './TopBarSlot.js'
 export { WorkspaceSwitcher } from './WorkspaceSwitcher.js'
 export { ThemeToggle } from './ThemeToggle.js'

--- a/packages/ui/src/dialog.tsx
+++ b/packages/ui/src/dialog.tsx
@@ -45,13 +45,15 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  overlayClassName,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
+  overlayClassName?: string
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1414,7 +1414,6 @@ export function WorkspaceAgentFront<
     <PluginTabsWorkspaceShell
       collapsed={appLeftPaneCollapsed}
       onExpand={() => setAppLeftPaneCollapsed(false)}
-      onCollapse={() => setAppLeftPaneCollapsed(true)}
       leftOverlay={leftOverlayNode}
       leftPane={(
         <AppLeftPane
@@ -1433,6 +1432,7 @@ export function WorkspaceAgentFront<
           onToggleSessionPinned={toggleSessionPinned}
           onOpenPlugins={() => setLeftOverlay((cur) => cur === "plugins" ? null : "plugins")}
           onOpenSkills={() => setLeftOverlay((cur) => cur === "skills" ? null : "skills")}
+          onCollapse={() => setAppLeftPaneCollapsed(true)}
         />
       )}
     >

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1129,6 +1129,31 @@ export function WorkspaceAgentFront<
     if (nextActiveId && current.activeId === sessionId) rawSwitch(nextActiveId)
   }, [chatPaneState, chatSessionId, rawSwitch, workspaceId])
 
+  const createChatSession = useCallback(() => {
+    const created = resolvedCreate()
+    void Promise.resolve(created).then((session) => {
+      const id = createdSessionId(session)
+      if (!id) return
+      setChatPaneState((previous) => {
+        const current = previous.workspaceId === workspaceId
+          ? previous
+          : { workspaceId, ids: [chatSessionId], activeId: chatSessionId }
+        const ids = current.ids.length > 0 ? current.ids : [chatSessionId]
+        const activeId = current.activeId ?? ids[0] ?? chatSessionId
+        return {
+          workspaceId,
+          ids: replaceActivePane(ids, activeId, id),
+          activeId: id,
+        }
+      })
+      rawSwitch(id)
+    }).catch(() => {
+      // Creation errors are surfaced by the session API/chat layer; the left
+      // action should not leave stale optimistic panes behind.
+    })
+    return created
+  }, [chatSessionId, rawSwitch, resolvedCreate, workspaceId])
+
   const createChatPaneAfter = useCallback((afterId: string) => {
     const pendingCreatePane = {
       afterId,
@@ -1429,7 +1454,7 @@ export function WorkspaceAgentFront<
           activeSessionId={activeChatPaneId}
           openSessionIds={chatPaneIds}
           pinnedSessionIds={pinnedIds}
-          onCreateSession={() => { void createChatPaneAfter(activeChatPaneId) }}
+          onCreateSession={() => { void createChatSession() }}
           onOpenCommandPalette={openCommandPalette}
           onSwitchSession={switchToChatPane}
           onOpenSessionAsPane={openChatPane}

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1354,6 +1354,11 @@ export function WorkspaceAgentFront<
         }
       : undefined
   ), [activeChatPaneId, chatPaneIds, isPluginTabsLayout, openChatPane, resolvedSessions, switchToChatPane])
+  const leftOverlayNode = leftOverlay === "skills" ? (
+    <SkillsPage onClose={() => setLeftOverlay(null)} />
+  ) : leftOverlay === "plugins" ? (
+    <PluginsOverlay plugins={capturedPlugins} onClose={() => setLeftOverlay(null)} />
+  ) : null
   const mainContent = remoteSessionsTransitioning ? (
     <ChatSessionTransitionState />
   ) : (
@@ -1372,6 +1377,7 @@ export function WorkspaceAgentFront<
       flashChatPaneId={flashChatPane?.workspaceId === workspaceId ? flashChatPane.id : null}
       surface={surfaceOpen ? "artifact-surface" : null}
       surfaceParams={surfaceParams as Record<string, unknown>}
+      chatOverlay={isPluginTabsLayout ? leftOverlayNode : null}
       surfaceOverlay={workbenchOverlay}
       sidebar={surfaceOpen && !workbenchBlocked && hasLeftTabs && effectiveWorkbenchLeftOpen ? "workbench-left" : null}
       sidebarParams={surfaceOpen && !workbenchBlocked && hasLeftTabs ? {
@@ -1405,16 +1411,11 @@ export function WorkspaceAgentFront<
       } : undefined}
     />
   )
-  const leftOverlayNode = leftOverlay === "skills" ? (
-    <SkillsPage onClose={() => setLeftOverlay(null)} />
-  ) : leftOverlay === "plugins" ? (
-    <PluginsOverlay plugins={capturedPlugins} onClose={() => setLeftOverlay(null)} />
-  ) : null
   const shellContent = isPluginTabsLayout ? (
     <PluginTabsWorkspaceShell
       collapsed={appLeftPaneCollapsed}
       onExpand={() => setAppLeftPaneCollapsed(false)}
-      leftOverlay={leftOverlayNode}
+      onCollapse={() => setAppLeftPaneCollapsed(true)}
       leftPane={(
         <AppLeftPane
           appTitle={appTitle}
@@ -1432,7 +1433,6 @@ export function WorkspaceAgentFront<
           onToggleSessionPinned={toggleSessionPinned}
           onOpenPlugins={() => setLeftOverlay((cur) => cur === "plugins" ? null : "plugins")}
           onOpenSkills={() => setLeftOverlay((cur) => cur === "skills" ? null : "skills")}
-          onCollapse={() => setAppLeftPaneCollapsed(true)}
         />
       )}
     >

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -9,10 +9,14 @@ import { WorkspaceProvider, type WorkspaceProviderProps } from "../../front/prov
 import { ChatLayout, TopBar, ThemeToggle, type ChatLayoutProps } from "../../front/layout"
 import type { WorkspaceChatPanelProps } from "../../front/chrome/chat/types"
 import type {
+  OpenPanelConfig,
   SurfaceShellApi,
   SurfaceShellProps,
   SurfaceShellSnapshot,
 } from "../../front/chrome/artifact-surface/SurfaceShell"
+import { WORKSPACE_SKILLS_PANEL_ID, workspaceSkillsPanel } from "../../front/chrome/skills/definition"
+import { AppLeftPane } from "../../front/layout/plugin-tabs/AppLeftPane"
+import { PluginTabsWorkspaceShell } from "../../front/layout/plugin-tabs/PluginTabsWorkspaceShell"
 import { useRegistry, useSurfaceResolverRegistry } from "../../front/registry"
 import { captureFrontPlugin } from "../../shared/plugins/frontFactory"
 import { surfaceResolverDescriptor } from "../../shared/types/surface"
@@ -74,9 +78,11 @@ export type UseWorkspaceAgentSessions<
   refreshKey?: unknown
 }) => WorkspaceAgentSessionsApi<TSession>
 
+export type WorkspaceAgentLayout = "classic" | "plugin-tabs"
+
 export interface WorkspaceAgentFrontProps<
   TSession extends WorkspaceAgentSession = WorkspaceAgentSession,
-> extends Omit<WorkspaceProviderProps, "children" | "workspaceId" | "storageKey" | "chatPanel">,
+> extends Omit<WorkspaceProviderProps, "children" | "workspaceId" | "storageKey" | "chatPanel" | "commandPaletteSessionSearch">,
     Omit<ChatLayoutProps,
       | "nav"
       | "navParams"
@@ -107,6 +113,11 @@ export interface WorkspaceAgentFrontProps<
   appTitle?: string
   workspaceLabel?: string
   defaultSessionTitle?: string
+  /**
+   * Opt into the Phase 2 app/session left-pane shell. Defaults to the
+   * existing classic top-bar + session-drawer workspace layout.
+   */
+  workspaceLayout?: WorkspaceAgentLayout
   navEnabled?: boolean
   defaultNavOpen?: boolean
   defaultSurfaceOpen?: boolean
@@ -452,6 +463,7 @@ export function WorkspaceAgentFront<
   appTitle = "Boring UI",
   workspaceLabel,
   defaultSessionTitle = "New session",
+  workspaceLayout = "classic",
   navEnabled = true,
   defaultNavOpen = false,
   defaultSurfaceOpen,
@@ -487,6 +499,12 @@ export function WorkspaceAgentFront<
     resolvedProviderStorageKey,
   )
   const shellPersistenceEnabled = persistenceEnabled !== false
+  const isPluginTabsLayout = workspaceLayout === "plugin-tabs"
+  const providerPanels = useMemo(() => {
+    if (!isPluginTabsLayout) return panels
+    if (panels?.some((panel) => panel.id === WORKSPACE_SKILLS_PANEL_ID)) return panels
+    return [...(panels ?? []), workspaceSkillsPanel]
+  }, [isPluginTabsLayout, panels])
   const resolvedSessionStorageKey =
     sessionStorageKey ?? `boring-workspace:sessions:${workspaceId}`
   const resolvedRequestHeaders = useMemo(
@@ -773,6 +791,11 @@ export function WorkspaceAgentFront<
     defaultNavOpen,
     shellPersistenceEnabled,
   )
+  const [appLeftPaneCollapsed, setAppLeftPaneCollapsed] = useStoredBooleanState(
+    `${shellStorageKey}:appLeftPaneCollapsed`,
+    false,
+    shellPersistenceEnabled,
+  )
   const effectiveNavOpen = navEnabled && navOpen
   const [surfaceOpen, setSurfaceOpen] = useStoredBooleanState(
     // Key must NOT match resolvedSurfaceStorageKey (which stores the dockview
@@ -923,6 +946,17 @@ export function WorkspaceAgentFront<
     closeWorkbench,
     enqueue: enqueueSurfaceOp,
   }), [getSurface, isWorkbenchOpen, openWorkbench, openWorkbenchSources, closeWorkbench, enqueueSurfaceOp])
+
+  const openWorkspacePanel = useCallback((panel?: OpenPanelConfig) => {
+    surfaceOpenRef.current = true
+    setSurfaceOpen(true)
+    onOpenSurface?.()
+    if (!panel) return
+    const run = (api: SurfaceShellApi) => api.openPanel(panel)
+    const surface = getSurface()
+    if (surface) run(surface)
+    else enqueueSurfaceOp(run)
+  }, [enqueueSurfaceOp, getSurface, onOpenSurface, setSurfaceOpen])
 
   // Minimal surface-backed bridge for the file tree. The left-tab file tree
   // only needs click-to-open + active-file reveal. Click-to-open routes through
@@ -1286,11 +1320,141 @@ export function WorkspaceAgentFront<
     }))
   }
 
+  const topBarRightContent = (
+    <>
+      {showThemeToggle ? <ThemeToggle /> : null}
+      {topBarRight}
+    </>
+  )
+  const navParams = {
+    sessions: resolvedSessions,
+    activeId: activeChatPaneId,
+    openIds: chatPaneIds,
+    pinnedIds,
+    onTogglePin: toggleSessionPinned,
+    onSwitch: switchToChatPane,
+    onOpenAsTab: openChatPane,
+    onCreate: resolvedCreate,
+    onDelete: deleteSessionAndPane,
+    onLoadMore: sessionApi?.loadMore,
+    hasMore: sessionApi?.hasMore,
+    loadingMore: sessionApi?.loadingMore,
+    onClose: () => setNavOpen(false),
+  }
+  const commandPaletteSessionSearch = useMemo(() => (
+    isPluginTabsLayout
+      ? {
+          sessions: resolvedSessions,
+          activeId: activeChatPaneId,
+          openIds: chatPaneIds,
+          onSwitch: switchToChatPane,
+          onOpenAsTab: openChatPane,
+        }
+      : undefined
+  ), [activeChatPaneId, chatPaneIds, isPluginTabsLayout, openChatPane, resolvedSessions, switchToChatPane])
+  const mainContent = remoteSessionsTransitioning ? (
+    <ChatSessionTransitionState />
+  ) : (
+    <ChatLayout
+      className={className}
+      nav={isPluginTabsLayout ? null : effectiveNavOpen ? "session-list" : null}
+      navParams={navParams}
+      center="chat"
+      centerParams={centerParams}
+      chatPanes={chatPanes}
+      activeChatPaneId={activeChatPaneId}
+      onActiveChatPaneChange={activateChatPane}
+      onCloseChatPane={closeChatPane}
+      onCreateChatPaneAfter={isPluginTabsLayout ? undefined : createChatPaneAfter}
+      onDropChatSession={openChatPane}
+      flashChatPaneId={flashChatPane?.workspaceId === workspaceId ? flashChatPane.id : null}
+      surface={surfaceOpen ? "artifact-surface" : null}
+      surfaceParams={surfaceParams as Record<string, unknown>}
+      surfaceOverlay={workbenchOverlay}
+      sidebar={surfaceOpen && !workbenchBlocked && hasLeftTabs && effectiveWorkbenchLeftOpen ? "workbench-left" : null}
+      sidebarParams={surfaceOpen && !workbenchBlocked && hasLeftTabs ? {
+        ...(defaultWorkbenchLeftTab ? { defaultTab: defaultWorkbenchLeftTab } : {}),
+        bridge: fileTreeBridge,
+        onClose: () => {
+          setWorkbenchLeftOpen(false)
+          setWorkbenchLeftExplicitOpen(false)
+        },
+        onCollapse: () => {
+          setWorkbenchLeftOpen(false)
+          setWorkbenchLeftExplicitOpen(false)
+        },
+      } : undefined}
+      storageKey={shellPersistenceEnabled ? shellStorageKey : undefined}
+      onOpenNav={!isPluginTabsLayout && navEnabled ? () => {
+        setNavOpen(true)
+        onOpenNav?.()
+      } : undefined}
+      onOpenSurface={() => {
+        surfaceOpenRef.current = true
+        setSurfaceOpen(true)
+        onOpenSurface?.()
+      }}
+      surfaceButtonBottomOffset={surfaceButtonBottomOffset}
+      onOpenSidebar={hasLeftTabs ? () => {
+        surfaceOpenRef.current = true
+        setSurfaceOpen(true)
+        setWorkbenchLeftOpen(true)
+        setWorkbenchLeftExplicitOpen(true)
+      } : undefined}
+    />
+  )
+  const shellContent = isPluginTabsLayout ? (
+    <PluginTabsWorkspaceShell
+      collapsed={appLeftPaneCollapsed}
+      onExpand={() => setAppLeftPaneCollapsed(false)}
+      leftPane={(
+        <AppLeftPane
+          appTitle={appTitle}
+          sessionTitle={remoteSessionsTransitioning ? "Loading sessions…" : resolvedSessionTitle ?? defaultSessionTitle}
+          topSlot={topBarLeft}
+          bottomSlot={showThemeToggle || topBarRight != null ? <div className="flex items-center gap-2">{topBarRightContent}</div> : undefined}
+          sessions={resolvedSessions}
+          activeSessionId={activeChatPaneId}
+          openSessionIds={chatPaneIds}
+          pinnedSessionIds={pinnedIds}
+          surfaceSnapshot={surfaceSnapshot}
+          skillsPanelId={WORKSPACE_SKILLS_PANEL_ID}
+          onCollapse={() => setAppLeftPaneCollapsed(true)}
+          onCreateSession={() => { void resolvedCreate() }}
+          onOpenCommandPalette={openCommandPalette}
+          onSwitchSession={switchToChatPane}
+          onOpenSessionAsPane={openChatPane}
+          onToggleSessionPinned={toggleSessionPinned}
+          onOpenPlugins={openWorkspacePanel}
+          onOpenSkills={() => openWorkspacePanel({
+            id: WORKSPACE_SKILLS_PANEL_ID,
+            component: WORKSPACE_SKILLS_PANEL_ID,
+            title: "Skills",
+          })}
+        />
+      )}
+    >
+      {mainContent}
+    </PluginTabsWorkspaceShell>
+  ) : (
+    <div className="flex h-full min-h-0 flex-col">
+      <TopBar
+        appTitle={appTitle}
+        sessionTitle={remoteSessionsTransitioning ? "Loading sessions…" : resolvedSessionTitle ?? defaultSessionTitle}
+        onCommandPalette={openCommandPalette}
+        topBarLeft={topBarLeft}
+        topBarRight={topBarRightContent}
+      />
+      {mainContent}
+    </div>
+  )
+  const publishedNavOpen = isPluginTabsLayout ? !appLeftPaneCollapsed : effectiveNavOpen
+
   return (
     <div className="h-full bg-background text-foreground">
       <WorkspaceProvider
         chatPanel={chatPanel}
-        panels={panels}
+        panels={providerPanels}
         commands={commands}
         catalogs={catalogs}
         plugins={plugins}
@@ -1311,6 +1475,7 @@ export function WorkspaceAgentFront<
         onAuthError={onAuthError}
         frontPluginHotReload={resolvedFrontPluginHotReload}
         fullPageBasePath={fullPageBasePath}
+        commandPaletteSessionSearch={commandPaletteSessionSearch}
       >
         {beforeShell}
         <WorkspaceBackgroundBoot
@@ -1324,90 +1489,12 @@ export function WorkspaceAgentFront<
         <WorkspaceUiStateSync
           bridgeEndpoint={bridgeEndpoint}
           requestHeaders={resolvedRequestHeaders}
-          navOpen={effectiveNavOpen}
+          navOpen={publishedNavOpen}
           surfaceOpen={surfaceOpen}
           surfaceReady={surfaceReady}
           snapshot={surfaceSnapshot}
         />
-        <div className="flex h-full min-h-0 flex-col">
-          <TopBar
-            appTitle={appTitle}
-            sessionTitle={remoteSessionsTransitioning ? "Loading sessions…" : resolvedSessionTitle ?? defaultSessionTitle}
-            onCommandPalette={openCommandPalette}
-            topBarLeft={topBarLeft}
-            topBarRight={
-              <>
-                {showThemeToggle ? <ThemeToggle /> : null}
-                {topBarRight}
-              </>
-            }
-          />
-          {remoteSessionsTransitioning ? (
-            <ChatSessionTransitionState />
-          ) : (
-            <ChatLayout
-              className={className}
-              nav={effectiveNavOpen ? "session-list" : null}
-              navParams={{
-                sessions: resolvedSessions,
-                activeId: activeChatPaneId,
-                openIds: chatPaneIds,
-                pinnedIds,
-                onTogglePin: toggleSessionPinned,
-                onSwitch: switchToChatPane,
-                onOpenAsTab: openChatPane,
-                onCreate: resolvedCreate,
-                onDelete: deleteSessionAndPane,
-                onLoadMore: sessionApi?.loadMore,
-                hasMore: sessionApi?.hasMore,
-                loadingMore: sessionApi?.loadingMore,
-                onClose: () => setNavOpen(false),
-              }}
-              center="chat"
-              centerParams={centerParams}
-              chatPanes={chatPanes}
-              activeChatPaneId={activeChatPaneId}
-              onActiveChatPaneChange={activateChatPane}
-              onCloseChatPane={closeChatPane}
-              onCreateChatPaneAfter={createChatPaneAfter}
-              onDropChatSession={openChatPane}
-              flashChatPaneId={flashChatPane?.workspaceId === workspaceId ? flashChatPane.id : null}
-              surface={surfaceOpen ? "artifact-surface" : null}
-              surfaceParams={surfaceParams as Record<string, unknown>}
-              surfaceOverlay={workbenchOverlay}
-              sidebar={surfaceOpen && !workbenchBlocked && hasLeftTabs && effectiveWorkbenchLeftOpen ? "workbench-left" : null}
-              sidebarParams={surfaceOpen && !workbenchBlocked && hasLeftTabs ? {
-                ...(defaultWorkbenchLeftTab ? { defaultTab: defaultWorkbenchLeftTab } : {}),
-                bridge: fileTreeBridge,
-                onClose: () => {
-                  setWorkbenchLeftOpen(false)
-                  setWorkbenchLeftExplicitOpen(false)
-                },
-                onCollapse: () => {
-                  setWorkbenchLeftOpen(false)
-                  setWorkbenchLeftExplicitOpen(false)
-                },
-              } : undefined}
-              storageKey={shellPersistenceEnabled ? shellStorageKey : undefined}
-              onOpenNav={navEnabled ? () => {
-                setNavOpen(true)
-                onOpenNav?.()
-              } : undefined}
-              onOpenSurface={() => {
-                surfaceOpenRef.current = true
-                setSurfaceOpen(true)
-                onOpenSurface?.()
-              }}
-              surfaceButtonBottomOffset={surfaceButtonBottomOffset}
-              onOpenSidebar={hasLeftTabs ? () => {
-                surfaceOpenRef.current = true
-                setSurfaceOpen(true)
-                setWorkbenchLeftOpen(true)
-                setWorkbenchLeftExplicitOpen(true)
-              } : undefined}
-            />
-          )}
-        </div>
+        {shellContent}
         {afterShell}
       </WorkspaceProvider>
     </div>

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -23,7 +23,7 @@ import { captureFrontPlugin } from "../../shared/plugins/frontFactory"
 import { surfaceResolverDescriptor } from "../../shared/types/surface"
 import { UI_COMMAND_EVENT, dispatchUiCommand } from "../../front/bridge"
 import type { CommandResult, DispatchContext, FileTreeBridge, Unsubscribe } from "../../front/bridge"
-import { readStoredBoolean, writeStoredBoolean } from "../../front/store/localStorageValues"
+import { readStoredBoolean, readStoredNumber, writeStoredBoolean, writeStoredNumber } from "../../front/store/localStorageValues"
 import {
   createLocalStorageSessions,
   useLocalStorageSessions,
@@ -170,6 +170,31 @@ function shellStorageKeyFromSurfaceStorage(
     : fallback
 }
 
+function useStoredNumberState(
+  key: string,
+  fallback: number,
+  enabled: boolean,
+): [number, (next: number | ((previous: number) => number)) => void] {
+  const [value, setValue] = useState(() => readStoredNumber(key, fallback, enabled))
+
+  useEffect(() => {
+    setValue(readStoredNumber(key, fallback, enabled))
+  }, [key, fallback, enabled])
+
+  const setStoredValue = useCallback(
+    (next: number | ((previous: number) => number)) => {
+      setValue((previous) => {
+        const resolved = typeof next === "function" ? next(previous) : next
+        writeStoredNumber(key, resolved, enabled)
+        return resolved
+      })
+    },
+    [enabled, key],
+  )
+
+  return [value, setStoredValue]
+}
+
 function useStoredBooleanState(
   key: string,
   fallback: boolean,
@@ -195,6 +220,10 @@ function useStoredBooleanState(
 const EMPTY_HEADERS: Record<string, string> = {}
 const EMPTY_STRING_LIST: string[] = []
 const PREPARING_WARMUP_STATUS: WorkspaceWarmupStatus = { status: "preparing" }
+
+function clampNumber(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
 
 const emptySurfaceSnapshot: SurfaceShellSnapshot = {
   openTabs: [],
@@ -796,6 +825,12 @@ export function WorkspaceAgentFront<
     false,
     shellPersistenceEnabled,
   )
+  const [appLeftPaneWidth, setAppLeftPaneWidth] = useStoredNumberState(
+    `${shellStorageKey}:appLeftPaneWidth`,
+    268,
+    shellPersistenceEnabled,
+  )
+  const effectiveAppLeftPaneWidth = clampNumber(appLeftPaneWidth, 220, 420)
   const [leftOverlay, setLeftOverlay] = useState<"skills" | "plugins" | null>(null)
   const effectiveNavOpen = navEnabled && navOpen
   const [surfaceOpen, setSurfaceOpen] = useStoredBooleanState(
@@ -1444,8 +1479,10 @@ export function WorkspaceAgentFront<
       collapsed={appLeftPaneCollapsed}
       onExpand={() => setAppLeftPaneCollapsed(false)}
       onCollapse={() => setAppLeftPaneCollapsed(true)}
+      onResizeLeftPane={(delta) => setAppLeftPaneWidth((width) => clampNumber(width + delta, 220, 420))}
       leftPane={(
         <AppLeftPane
+          width={effectiveAppLeftPaneWidth}
           appTitle={appTitle}
           sessionTitle={remoteSessionsTransitioning ? "Loading sessions…" : resolvedSessionTitle ?? defaultSessionTitle}
           topSlot={topBarLeft}

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -136,6 +136,10 @@ export interface WorkspaceAgentFrontProps<
    * UserMenu) should set this to false to avoid a duplicate control.
    */
   showThemeToggle?: boolean
+  /** Show the plugin-tabs Skills action/overlay. Defaults to true. */
+  showSkills?: boolean
+  /** Show the plugin-tabs Plugins action/overlay. Defaults to true. */
+  showPlugins?: boolean
   sessions?: Array<{ id: string; title?: string | null; updatedAt?: string | number; turnCount?: number }>
   activeSessionId?: string | null
   onSwitchSession?: (id: string) => void
@@ -505,6 +509,8 @@ export function WorkspaceAgentFront<
   topBarLeft,
   topBarRight,
   showThemeToggle = true,
+  showSkills = true,
+  showPlugins = true,
   chatParams,
   externalPlugins,
   hotReloadEnabled,
@@ -532,6 +538,8 @@ export function WorkspaceAgentFront<
   )
   const shellPersistenceEnabled = persistenceEnabled !== false
   const isPluginTabsLayout = workspaceLayout === "plugin-tabs"
+  const skillsActionEnabled = showSkills !== false
+  const pluginsActionEnabled = showPlugins !== false
   // Skills is only ever a chat-left overlay (see leftOverlay node below); it is
   // intentionally NOT registered as a workspace panel so it never appears in the
   // workbench surface.
@@ -834,6 +842,11 @@ export function WorkspaceAgentFront<
   )
   const effectiveAppLeftPaneWidth = clampNumber(appLeftPaneWidth, 220, 420)
   const [leftOverlay, setLeftOverlay] = useState<"skills" | "plugins" | null>(null)
+  useEffect(() => {
+    if ((leftOverlay === "skills" && !skillsActionEnabled) || (leftOverlay === "plugins" && !pluginsActionEnabled)) {
+      setLeftOverlay(null)
+    }
+  }, [leftOverlay, pluginsActionEnabled, skillsActionEnabled])
   const effectiveNavOpen = navEnabled && navOpen
   const [surfaceOpen, setSurfaceOpen] = useStoredBooleanState(
     // Key must NOT match resolvedSurfaceStorageKey (which stores the dockview
@@ -1417,12 +1430,16 @@ export function WorkspaceAgentFront<
         }
       : undefined
   ), [activeChatPaneId, chatPaneIds, isPluginTabsLayout, openChatPane, resolvedSessions, switchToChatPane])
-  const leftOverlayNode = leftOverlay === "skills" ? (
-    <SkillsPage onClose={() => setLeftOverlay(null)} />
-  ) : leftOverlay === "plugins" ? (
+  const leftOverlayNode = leftOverlay === "skills" && skillsActionEnabled ? (
+    <SkillsPage
+      onClose={() => setLeftOverlay(null)}
+      headerInsetStart={appLeftPaneCollapsed}
+    />
+  ) : leftOverlay === "plugins" && pluginsActionEnabled ? (
     <PluginsOverlay
       onClose={() => setLeftOverlay(null)}
       onReloadExternalPlugins={() => reloadAgentPluginsForSession(effectiveActiveSessionId ?? chatSessionId)}
+      headerInsetStart={appLeftPaneCollapsed}
     />
   ) : null
   const mainContent = remoteSessionsTransitioning ? (
@@ -1499,8 +1516,14 @@ export function WorkspaceAgentFront<
           onSwitchSession={switchToChatPane}
           onOpenSessionAsPane={openChatPane}
           onToggleSessionPinned={toggleSessionPinned}
-          onOpenPlugins={() => setLeftOverlay((cur) => cur === "plugins" ? null : "plugins")}
-          onOpenSkills={() => setLeftOverlay((cur) => cur === "skills" ? null : "skills")}
+          showPlugins={pluginsActionEnabled}
+          showSkills={skillsActionEnabled}
+          onOpenPlugins={() => {
+            if (pluginsActionEnabled) setLeftOverlay((cur) => cur === "plugins" ? null : "plugins")
+          }}
+          onOpenSkills={() => {
+            if (skillsActionEnabled) setLeftOverlay((cur) => cur === "skills" ? null : "skills")
+          }}
         />
       )}
     >

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1511,7 +1511,10 @@ export function WorkspaceAgentFront<
           activeSessionId={activeChatPaneId}
           openSessionIds={chatPaneIds}
           pinnedSessionIds={pinnedIds}
-          onCreateSession={() => { void createChatSession() }}
+          onCreateSession={() => {
+            setLeftOverlay(null)
+            void createChatSession()
+          }}
           onOpenCommandPalette={openCommandPalette}
           onSwitchSession={switchToChatPane}
           onOpenSessionAsPane={openChatPane}

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import {
   PiChatPanel as DefaultPiChatPanel,
   usePiSessions as useDefaultPiSessions,
+  searchPiSessions,
   type SlashCommand,
   type ToolRendererOverrides,
 } from "@hachej/boring-agent/front"
@@ -22,6 +23,7 @@ import { useRegistry, useSurfaceResolverRegistry } from "../../front/registry"
 import { captureFrontPlugin } from "../../shared/plugins/frontFactory"
 import { surfaceResolverDescriptor } from "../../shared/types/surface"
 import { UI_COMMAND_EVENT, dispatchUiCommand } from "../../front/bridge"
+import type { CommandPaletteSessionItem } from "../../front/components/CommandPalette"
 import type { CommandResult, DispatchContext, FileTreeBridge, Unsubscribe } from "../../front/bridge"
 import { readStoredBoolean, readStoredNumber, writeStoredBoolean, writeStoredNumber } from "../../front/store/localStorageValues"
 import {
@@ -1409,6 +1411,7 @@ export function WorkspaceAgentFront<
           sessions: resolvedSessions,
           activeId: activeChatPaneId,
           openIds: chatPaneIds,
+          search: (sessions: readonly CommandPaletteSessionItem[], query: string) => searchPiSessions(sessions, query, { limit: 8 }),
           onSwitch: switchToChatPane,
           onOpenAsTab: openChatPane,
         }

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -17,7 +17,7 @@ import type {
 } from "../../front/chrome/artifact-surface/SurfaceShell"
 import { SkillsPage } from "../../front/chrome/skills/SkillsPage"
 import { PluginsOverlay } from "../../front/chrome/plugins/PluginsOverlay"
-import { AppLeftPane } from "../../front/layout/plugin-tabs/AppLeftPane"
+import { AppLeftPane, type AppLeftPaneProject } from "../../front/layout/plugin-tabs/AppLeftPane"
 import { PluginTabsWorkspaceShell } from "../../front/layout/plugin-tabs/PluginTabsWorkspaceShell"
 import { useRegistry, useSurfaceResolverRegistry } from "../../front/registry"
 import { captureFrontPlugin } from "../../shared/plugins/frontFactory"
@@ -117,6 +117,12 @@ export interface WorkspaceAgentFrontProps<
   workspaceLabel?: string
   /** App-left workspace/project section title. Defaults to "Workspaces". */
   workspaceSectionTitle?: string
+  /** Optional cross-project overview rendered in the app-left workspace/project section. */
+  appLeftProjects?: AppLeftPaneProject[]
+  appLeftActiveProjectId?: string | null
+  onSwitchAppLeftProject?: (projectId: string) => void
+  onOpenAppLeftProjectSession?: (projectId: string, sessionId: string) => void
+  onShowMoreAppLeftProjectSessions?: (projectId: string) => void
   defaultSessionTitle?: string
   /**
    * Opt into the Phase 2 app/session left-pane shell. Defaults to the
@@ -501,6 +507,11 @@ export function WorkspaceAgentFront<
   appTitle = "Boring UI",
   workspaceLabel,
   workspaceSectionTitle = "Workspaces",
+  appLeftProjects,
+  appLeftActiveProjectId,
+  onSwitchAppLeftProject,
+  onOpenAppLeftProjectSession,
+  onShowMoreAppLeftProjectSessions,
   defaultSessionTitle = "New session",
   workspaceLayout = "classic",
   navEnabled = true,
@@ -1509,9 +1520,14 @@ export function WorkspaceAgentFront<
           appTitle={appTitle}
           workspaceLabel={workspaceLabel}
           workspaceSectionTitle={workspaceSectionTitle}
+          projects={appLeftProjects}
+          activeProjectId={appLeftActiveProjectId ?? workspaceId}
+          onSwitchProject={onSwitchAppLeftProject}
+          onOpenProjectSession={onOpenAppLeftProjectSession}
+          onShowMoreProjectSessions={onShowMoreAppLeftProjectSessions}
           sessionTitle={remoteSessionsTransitioning ? "Loading sessions…" : resolvedSessionTitle ?? defaultSessionTitle}
           topSlot={topBarLeft}
-          bottomSlot={showThemeToggle || topBarRight != null ? <div className="flex items-center gap-2">{topBarRightContent}</div> : undefined}
+          bottomSlot={showThemeToggle || topBarRight != null ? <div className="flex w-full min-w-0 items-center gap-2">{topBarRightContent}</div> : undefined}
           sessions={resolvedSessions}
           activeSessionId={activeChatPaneId}
           openSessionIds={chatPaneIds}

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -115,6 +115,8 @@ export interface WorkspaceAgentFrontProps<
   afterShell?: ReactNode
   appTitle?: string
   workspaceLabel?: string
+  /** App-left workspace/project section title. Defaults to "Workspaces". */
+  workspaceSectionTitle?: string
   defaultSessionTitle?: string
   /**
    * Opt into the Phase 2 app/session left-pane shell. Defaults to the
@@ -498,6 +500,7 @@ export function WorkspaceAgentFront<
   onActiveSessionIdChange,
   appTitle = "Boring UI",
   workspaceLabel,
+  workspaceSectionTitle = "Workspaces",
   defaultSessionTitle = "New session",
   workspaceLayout = "classic",
   navEnabled = true,
@@ -1504,6 +1507,8 @@ export function WorkspaceAgentFront<
         <AppLeftPane
           width={effectiveAppLeftPaneWidth}
           appTitle={appTitle}
+          workspaceLabel={workspaceLabel}
+          workspaceSectionTitle={workspaceSectionTitle}
           sessionTitle={remoteSessionsTransitioning ? "Loading sessions…" : resolvedSessionTitle ?? defaultSessionTitle}
           topSlot={topBarLeft}
           bottomSlot={showThemeToggle || topBarRight != null ? <div className="flex items-center gap-2">{topBarRightContent}</div> : undefined}

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1296,6 +1296,7 @@ export function WorkspaceAgentFront<
     onReady: handleSurfaceReady,
     onChange: handleSurfaceChange,
     onClose: closeWorkbench,
+    showCloseAction: false,
   }), [
     closeWorkbench,
     defaultWorkbenchLeftTab,
@@ -1407,6 +1408,7 @@ export function WorkspaceAgentFront<
     <PluginTabsWorkspaceShell
       collapsed={appLeftPaneCollapsed}
       onExpand={() => setAppLeftPaneCollapsed(false)}
+      onCollapse={() => setAppLeftPaneCollapsed(true)}
       leftPane={(
         <AppLeftPane
           appTitle={appTitle}
@@ -1419,7 +1421,6 @@ export function WorkspaceAgentFront<
           pinnedSessionIds={pinnedIds}
           surfaceSnapshot={surfaceSnapshot}
           skillsPanelId={WORKSPACE_SKILLS_PANEL_ID}
-          onCollapse={() => setAppLeftPaneCollapsed(true)}
           onCreateSession={() => { void resolvedCreate() }}
           onOpenCommandPalette={openCommandPalette}
           onSwitchSession={switchToChatPane}

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -15,6 +15,8 @@ import type {
   SurfaceShellSnapshot,
 } from "../../front/chrome/artifact-surface/SurfaceShell"
 import { WORKSPACE_SKILLS_PANEL_ID, workspaceSkillsPanel } from "../../front/chrome/skills/definition"
+import { SkillsPage } from "../../front/chrome/skills/SkillsPage"
+import { PluginsOverlay } from "../../front/chrome/plugins/PluginsOverlay"
 import { AppLeftPane } from "../../front/layout/plugin-tabs/AppLeftPane"
 import { PluginTabsWorkspaceShell } from "../../front/layout/plugin-tabs/PluginTabsWorkspaceShell"
 import { useRegistry, useSurfaceResolverRegistry } from "../../front/registry"
@@ -796,6 +798,7 @@ export function WorkspaceAgentFront<
     false,
     shellPersistenceEnabled,
   )
+  const [leftOverlay, setLeftOverlay] = useState<"skills" | "plugins" | null>(null)
   const effectiveNavOpen = navEnabled && navOpen
   const [surfaceOpen, setSurfaceOpen] = useStoredBooleanState(
     // Key must NOT match resolvedSurfaceStorageKey (which stores the dockview
@@ -1404,11 +1407,17 @@ export function WorkspaceAgentFront<
       } : undefined}
     />
   )
+  const leftOverlayNode = leftOverlay === "skills" ? (
+    <SkillsPage onClose={() => setLeftOverlay(null)} />
+  ) : leftOverlay === "plugins" ? (
+    <PluginsOverlay plugins={capturedPlugins} onClose={() => setLeftOverlay(null)} />
+  ) : null
   const shellContent = isPluginTabsLayout ? (
     <PluginTabsWorkspaceShell
       collapsed={appLeftPaneCollapsed}
       onExpand={() => setAppLeftPaneCollapsed(false)}
       onCollapse={() => setAppLeftPaneCollapsed(true)}
+      leftOverlay={leftOverlayNode}
       leftPane={(
         <AppLeftPane
           appTitle={appTitle}
@@ -1419,19 +1428,13 @@ export function WorkspaceAgentFront<
           activeSessionId={activeChatPaneId}
           openSessionIds={chatPaneIds}
           pinnedSessionIds={pinnedIds}
-          surfaceSnapshot={surfaceSnapshot}
-          skillsPanelId={WORKSPACE_SKILLS_PANEL_ID}
           onCreateSession={() => { void resolvedCreate() }}
           onOpenCommandPalette={openCommandPalette}
           onSwitchSession={switchToChatPane}
           onOpenSessionAsPane={openChatPane}
           onToggleSessionPinned={toggleSessionPinned}
-          onOpenPlugins={openWorkspacePanel}
-          onOpenSkills={() => openWorkspacePanel({
-            id: WORKSPACE_SKILLS_PANEL_ID,
-            component: WORKSPACE_SKILLS_PANEL_ID,
-            title: "Skills",
-          })}
+          onOpenPlugins={() => setLeftOverlay((cur) => cur === "plugins" ? null : "plugins")}
+          onOpenSkills={() => setLeftOverlay((cur) => cur === "skills" ? null : "skills")}
         />
       )}
     >

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -14,7 +14,6 @@ import type {
   SurfaceShellProps,
   SurfaceShellSnapshot,
 } from "../../front/chrome/artifact-surface/SurfaceShell"
-import { WORKSPACE_SKILLS_PANEL_ID, workspaceSkillsPanel } from "../../front/chrome/skills/definition"
 import { SkillsPage } from "../../front/chrome/skills/SkillsPage"
 import { PluginsOverlay } from "../../front/chrome/plugins/PluginsOverlay"
 import { AppLeftPane } from "../../front/layout/plugin-tabs/AppLeftPane"
@@ -502,11 +501,10 @@ export function WorkspaceAgentFront<
   )
   const shellPersistenceEnabled = persistenceEnabled !== false
   const isPluginTabsLayout = workspaceLayout === "plugin-tabs"
-  const providerPanels = useMemo(() => {
-    if (!isPluginTabsLayout) return panels
-    if (panels?.some((panel) => panel.id === WORKSPACE_SKILLS_PANEL_ID)) return panels
-    return [...(panels ?? []), workspaceSkillsPanel]
-  }, [isPluginTabsLayout, panels])
+  // Skills is only ever a chat-left overlay (see leftOverlay node below); it is
+  // intentionally NOT registered as a workspace panel so it never appears in the
+  // workbench surface.
+  const providerPanels = panels
   const resolvedSessionStorageKey =
     sessionStorageKey ?? `boring-workspace:sessions:${workspaceId}`
   const resolvedRequestHeaders = useMemo(

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1357,7 +1357,10 @@ export function WorkspaceAgentFront<
   const leftOverlayNode = leftOverlay === "skills" ? (
     <SkillsPage onClose={() => setLeftOverlay(null)} />
   ) : leftOverlay === "plugins" ? (
-    <PluginsOverlay plugins={capturedPlugins} onClose={() => setLeftOverlay(null)} />
+    <PluginsOverlay
+      onClose={() => setLeftOverlay(null)}
+      onReloadExternalPlugins={() => reloadAgentPluginsForSession(effectiveActiveSessionId ?? chatSessionId)}
+    />
   ) : null
   const mainContent = remoteSessionsTransitioning ? (
     <ChatSessionTransitionState />
@@ -1426,7 +1429,7 @@ export function WorkspaceAgentFront<
           activeSessionId={activeChatPaneId}
           openSessionIds={chatPaneIds}
           pinnedSessionIds={pinnedIds}
-          onCreateSession={() => { void resolvedCreate() }}
+          onCreateSession={() => { void createChatPaneAfter(activeChatPaneId) }}
           onOpenCommandPalette={openCommandPalette}
           onSwitchSession={switchToChatPane}
           onOpenSessionAsPane={openChatPane}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -374,7 +374,7 @@ describe("WorkspaceAgentFront", () => {
     await user.click(within(appNav).getByRole("button", { name: "Open Third session in new chat pane" }))
     expect(onSwitchSession).toHaveBeenCalledWith("s3")
 
-    await user.click(within(appNav).getByRole("button", { name: "Collapse app navigation" }))
+    await user.click(screen.getByRole("button", { name: "Collapse app navigation" }))
     expect(screen.queryByLabelText("App navigation")).not.toBeInTheDocument()
     expect(document.querySelector('[data-boring-workspace-part="app-left-pane"]')).toBeNull()
     expect(screen.getByRole("button", { name: "Open app navigation" })).toBeInTheDocument()
@@ -972,7 +972,7 @@ describe("WorkspaceAgentFront", () => {
     )
 
     expect(screen.getByText("Preparing workspace…")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Workbench" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Open workbench" })).toBeInTheDocument()
   })
 
   it("does not start default remote session warmup when provisioning is disabled", async () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -385,6 +385,27 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.getByRole("button", { name: "Open app navigation" })).toBeInTheDocument()
   })
 
+  it("can hide plugin-tabs Skills and Plugins actions", () => {
+    render(
+      <WorkspaceAgentFront
+        workspaceId="plugin-tabs-hidden-overlays"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        sessions={[{ id: "s1", title: "First session" }]}
+        activeSessionId="s1"
+        showSkills={false}
+        showPlugins={false}
+        persistenceEnabled={false}
+      />,
+    )
+
+    const appNav = screen.getByLabelText("App navigation")
+    expect(within(appNav).getByRole("button", { name: "New chat" })).toBeInTheDocument()
+    expect(within(appNav).getByRole("button", { name: "Search" })).toBeInTheDocument()
+    expect(within(appNav).queryByRole("button", { name: "Skills" })).not.toBeInTheDocument()
+    expect(within(appNav).queryByRole("button", { name: "Plugins" })).not.toBeInTheDocument()
+  })
+
   it("opens the Plugins overlay from the app nav and lists external plugins only", async () => {
     const user = userEvent.setup()
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
@@ -495,8 +516,12 @@ describe("WorkspaceAgentFront", () => {
       })
       expect(screen.getByText("/review")).toBeInTheDocument()
 
+      await user.click(screen.getByRole("button", { name: "Hide app navigation" }))
+      expect(screen.getByText("Skills").closest("header")?.className).toContain("pl-12")
+
       await user.click(screen.getByRole("button", { name: "Close skills" }))
       expect(screen.queryByText("/review")).not.toBeInTheDocument()
+      await user.click(screen.getByRole("button", { name: "Open app navigation" }))
       await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Skills" }))
       await waitFor(() => expect(screen.getByText("/review")).toBeInTheDocument())
 

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -380,56 +380,41 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.getByRole("button", { name: "Open app navigation" })).toBeInTheDocument()
   })
 
-  it("focuses the current workspace-page instance from Plugins", async () => {
+  it("opens the Plugins overlay from the app nav and lists registered front plugins", async () => {
     const user = userEvent.setup()
 
-    function FallbackPluginPage() {
-      return <div>Fallback plugin page body</div>
+    function PluginPanel() {
+      return <div>Demo plugin panel body</div>
     }
-    function CurrentPluginPage() {
-      return <div>Current plugin page body</div>
-    }
+    const plugin = definePlugin({
+      id: "demo-plugin",
+      label: "Demo Plugin",
+      panels: [{ id: "demo-plugin.panel", label: "Demo Panel", placement: "workspace-page", component: PluginPanel }],
+    })
 
     render(
       <WorkspaceAgentFront
-        workspaceId="plugin-tabs-current-page"
+        workspaceId="plugin-tabs-plugins-overlay"
         workspaceLayout="plugin-tabs"
         chatPanel={SessionIdChatPanel}
         sessions={[{ id: "s1", title: "First session" }]}
         activeSessionId="s1"
-        panels={[
-          {
-            id: "plugin.fallback",
-            title: "Fallback Plugin",
-            placement: "workspace-page",
-            source: "plugin",
-            component: FallbackPluginPage,
-          },
-          {
-            id: "plugin.current",
-            title: "Current Plugin",
-            placement: "workspace-page",
-            source: "plugin",
-            component: CurrentPluginPage,
-          },
-        ]}
-        surfaceInitialPanels={[{
-          id: "current-instance",
-          component: "plugin.current",
-          title: "Current Plugin Instance",
-        }]}
-        defaultSurfaceOpen
+        plugins={[plugin]}
         persistenceEnabled={false}
       />,
     )
 
-    await waitFor(() => expect(screen.getByText("Current plugin page body")).toBeInTheDocument())
     await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
-    await waitFor(() => expect(screen.getByText("Current plugin page body")).toBeInTheDocument())
-    expect(screen.queryByText("Fallback plugin page body")).not.toBeInTheDocument()
+    const overlay = document.querySelector('[data-boring-workspace-part="plugins-overlay"]')
+    expect(overlay).not.toBeNull()
+    expect(overlay!).toHaveTextContent("Demo Plugin")
+    expect(overlay!).toHaveTextContent("Demo Panel")
+
+    await user.click(screen.getByRole("button", { name: "Close plugins" }))
+    expect(document.querySelector('[data-boring-workspace-part="plugins-overlay"]')).toBeNull()
   })
 
-  it("opens plugin-tabs workspace pages from Plugins and Skills", async () => {
+  it("opens Skills and Plugins as chat left overlays", async () => {
     const user = userEvent.setup()
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
@@ -445,34 +430,35 @@ describe("WorkspaceAgentFront", () => {
       return new Response(null, { status: 204 })
     }))
 
-    function PluginPage() {
-      return <div>Plugin workspace page body</div>
+    function PluginPanel() {
+      return <div>Plugin panel body</div>
     }
+    const plugin = definePlugin({
+      id: "overlay-plugin",
+      label: "Demo Plugin",
+      panels: [{ id: "overlay-plugin.panel", label: "Demo Panel", placement: "workspace-page", component: PluginPanel }],
+    })
 
     render(
       <WorkspaceAgentFront
-        workspaceId="plugin-tabs-pages"
+        workspaceId="plugin-tabs-overlays"
         workspaceLayout="plugin-tabs"
         chatPanel={SessionIdChatPanel}
         sessions={[{ id: "s1", title: "First session" }]}
         activeSessionId="s1"
-        panels={[{
-          id: "plugin.page",
-          title: "Plugin Page",
-          placement: "workspace-page",
-          source: "plugin",
-          component: PluginPage,
-        }]}
+        plugins={[plugin]}
         persistenceEnabled={false}
       />,
     )
 
-    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
-    await waitFor(() => expect(screen.getByText("Plugin workspace page body")).toBeInTheDocument())
-
     await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Skills" }))
     await waitFor(() => expect(screen.getByText("/review")).toBeInTheDocument())
     expect(screen.getByText("Review the current diff")).toBeInTheDocument()
+
+    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
+    const overlay = document.querySelector('[data-boring-workspace-part="plugins-overlay"]')
+    expect(overlay).not.toBeNull()
+    expect(overlay!).toHaveTextContent("Demo Plugin")
   })
 
   it("opens a controlled void-created session as a pane to the right", async () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -352,7 +352,7 @@ describe("WorkspaceAgentFront", () => {
     expect(within(appNav).getByRole("button", { name: "Plugins" })).toBeInTheDocument()
     expect(within(appNav).getByRole("button", { name: "Skills" })).toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Sessions" })).not.toBeInTheDocument()
-    expect(screen.queryByText("Projects")).not.toBeInTheDocument()
+    expect(screen.getByText("Projects")).toBeInTheDocument()
     expect(screen.queryByText("Codex mobile")).not.toBeInTheDocument()
     expect(screen.queryByText("Automations")).not.toBeInTheDocument()
 
@@ -374,7 +374,7 @@ describe("WorkspaceAgentFront", () => {
     await user.click(within(appNav).getByRole("button", { name: "Open Third session in new chat pane" }))
     expect(onSwitchSession).toHaveBeenCalledWith("s3")
 
-    await user.click(screen.getByRole("button", { name: "Collapse app navigation" }))
+    await user.click(screen.getByRole("button", { name: "Hide app navigation" }))
     expect(screen.queryByLabelText("App navigation")).not.toBeInTheDocument()
     expect(document.querySelector('[data-boring-workspace-part="app-left-pane"]')).toBeNull()
     expect(screen.getByRole("button", { name: "Open app navigation" })).toBeInTheDocument()

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -421,7 +421,14 @@ describe("WorkspaceAgentFront", () => {
       if (url.includes("/api/v1/tree")) return new Response(JSON.stringify({ entries: [] }), { status: 200 })
       if (url.includes("/api/v1/ready-status")) return new Response(null, { status: 200 })
       if (url.includes("/api/v1/agent/skills")) {
-        return new Response(JSON.stringify({ skills: [{ name: "review", description: "Review the current diff", source: "project" }] }), {
+        return new Response(JSON.stringify({
+          skills: [{
+            name: "review",
+            description: "Review the current diff",
+            source: "project",
+            filePath: ".agents/skills/review/SKILL.md",
+          }],
+        }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         })
@@ -439,26 +446,40 @@ describe("WorkspaceAgentFront", () => {
       panels: [{ id: "overlay-plugin.panel", label: "Demo Panel", placement: "workspace-page", component: PluginPanel }],
     })
 
-    render(
-      <WorkspaceAgentFront
-        workspaceId="plugin-tabs-overlays"
-        workspaceLayout="plugin-tabs"
-        chatPanel={SessionIdChatPanel}
-        sessions={[{ id: "s1", title: "First session" }]}
-        activeSessionId="s1"
-        plugins={[plugin]}
-        persistenceEnabled={false}
-      />,
-    )
+    const commands: UiCommand[] = []
+    const onUiCommand = (event: Event) => commands.push((event as CustomEvent<UiCommand>).detail)
+    window.addEventListener(UI_COMMAND_EVENT, onUiCommand)
+    try {
+      render(
+        <WorkspaceAgentFront
+          workspaceId="plugin-tabs-overlays"
+          workspaceLayout="plugin-tabs"
+          chatPanel={SessionIdChatPanel}
+          sessions={[{ id: "s1", title: "First session" }]}
+          activeSessionId="s1"
+          plugins={[plugin]}
+          persistenceEnabled={false}
+        />,
+      )
 
-    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Skills" }))
-    await waitFor(() => expect(screen.getByText("/review")).toBeInTheDocument())
-    expect(screen.getByText("Review the current diff")).toBeInTheDocument()
+      await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Skills" }))
+      await waitFor(() => expect(screen.getByText("/review")).toBeInTheDocument())
+      expect(screen.getByText("Review the current diff")).toBeInTheDocument()
 
-    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
-    const overlay = document.querySelector('[data-boring-workspace-part="plugins-overlay"]')
-    expect(overlay).not.toBeNull()
-    expect(overlay!).toHaveTextContent("Demo Plugin")
+      await user.click(screen.getByRole("button", { name: "Open skill review in workspace" }))
+      expect(commands).toContainEqual({
+        kind: "openFile",
+        params: { path: ".agents/skills/review/SKILL.md", mode: "view" },
+      })
+      expect(screen.queryByText("/review")).not.toBeInTheDocument()
+
+      await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
+      const overlay = document.querySelector('[data-boring-workspace-part="plugins-overlay"]')
+      expect(overlay).not.toBeNull()
+      expect(overlay!).toHaveTextContent("Demo Plugin")
+    } finally {
+      window.removeEventListener(UI_COMMAND_EVENT, onUiCommand)
+    }
   })
 
   it("opens a controlled void-created session as a pane to the right", async () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -449,7 +449,7 @@ describe("WorkspaceAgentFront", () => {
     expect(overlay!).not.toHaveTextContent("Demo Plugin")
     expect(overlay!).not.toHaveTextContent("Demo Panel")
 
-    await user.click(screen.getByRole("button", { name: "Close plugins" }))
+    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "New chat" }))
     expect(document.querySelector('[data-boring-workspace-part="plugins-overlay"]')).toBeNull()
   })
 
@@ -524,6 +524,8 @@ describe("WorkspaceAgentFront", () => {
       await user.click(screen.getByRole("button", { name: "Open app navigation" }))
       await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Skills" }))
       await waitFor(() => expect(screen.getByText("/review")).toBeInTheDocument())
+      await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "New chat" }))
+      expect(screen.queryByText("/review")).not.toBeInTheDocument()
 
     } finally {
       window.removeEventListener(UI_COMMAND_EVENT, onUiCommand)

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -364,6 +364,7 @@ describe("WorkspaceAgentFront", () => {
     const firstRow = appRows.find((row) => row.textContent?.includes("First session"))
     const secondRow = appRows.find((row) => row.textContent?.includes("Second session"))
     expect(firstRow).toHaveAttribute("data-boring-session-state", "active")
+    expect(firstRow?.className).not.toContain("border-l-2")
     expect(secondRow).toHaveAttribute("data-boring-session-state", "normal")
 
     await user.click(within(secondRow!).getByText("Second session"))
@@ -492,7 +493,12 @@ describe("WorkspaceAgentFront", () => {
         kind: "openFile",
         params: { path: ".agents/skills/review/SKILL.md", mode: "view" },
       })
+      expect(screen.getByText("/review")).toBeInTheDocument()
+
+      await user.click(screen.getByRole("button", { name: "Close skills" }))
       expect(screen.queryByText("/review")).not.toBeInTheDocument()
+      await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Skills" }))
+      await waitFor(() => expect(screen.getByText("/review")).toBeInTheDocument())
 
     } finally {
       window.removeEventListener(UI_COMMAND_EVENT, onUiCommand)

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { useEffect, useState } from "react"
 import userEvent from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
@@ -320,6 +320,159 @@ describe("WorkspaceAgentFront", () => {
     expect(switchCalls).toContain("s2")
     expect(visibleChatSessionIds()).toEqual(["s2"])
     expect(screen.getByText("First session")).toBeInTheDocument()
+  })
+
+  it("renders plugin-tabs app navigation without classic session edge controls", async () => {
+    const user = userEvent.setup()
+    const onSwitchSession = vi.fn()
+    const onCreateSession = vi.fn()
+    const sessions = [
+      { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
+      { id: "s2", title: "Second session", updatedAt: Date.now() - 2_000 },
+      { id: "s3", title: "Third session", updatedAt: Date.now() - 3_000 },
+    ]
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="plugin-tabs-nav"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        sessions={sessions}
+        activeSessionId="s1"
+        onSwitchSession={onSwitchSession}
+        onCreateSession={onCreateSession}
+        persistenceEnabled={false}
+      />,
+    )
+
+    const appNav = screen.getByLabelText("App navigation")
+    expect(appNav).toBeInTheDocument()
+    expect(within(appNav).getAllByRole("button", { name: "New chat" })).toHaveLength(1)
+    expect(within(appNav).getByRole("button", { name: "Search" })).toBeInTheDocument()
+    expect(within(appNav).getByRole("button", { name: "Plugins" })).toBeInTheDocument()
+    expect(within(appNav).getByRole("button", { name: "Skills" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Sessions" })).not.toBeInTheDocument()
+    expect(screen.queryByText("Projects")).not.toBeInTheDocument()
+    expect(screen.queryByText("Codex mobile")).not.toBeInTheDocument()
+    expect(screen.queryByText("Automations")).not.toBeInTheDocument()
+
+    const appRows = Array.from(appNav.querySelectorAll<HTMLElement>('[data-boring-workspace-part="app-session-row"]'))
+    const firstRow = appRows.find((row) => row.textContent?.includes("First session"))
+    const secondRow = appRows.find((row) => row.textContent?.includes("Second session"))
+    expect(firstRow).toHaveAttribute("data-boring-session-state", "active")
+    expect(secondRow).toHaveAttribute("data-boring-session-state", "normal")
+
+    await user.click(within(secondRow!).getByText("Second session"))
+    expect(onSwitchSession).toHaveBeenCalledWith("s2")
+
+    const switchCallsAfterRowClick = onSwitchSession.mock.calls.length
+    await user.click(within(appNav).getByRole("button", { name: "Pin Second session" }))
+    expect(onSwitchSession).toHaveBeenCalledTimes(switchCallsAfterRowClick)
+    expect(within(appNav).getByText("Pinned")).toBeInTheDocument()
+    expect(within(appNav).getByText("Sessions")).toBeInTheDocument()
+
+    await user.click(within(appNav).getByRole("button", { name: "Open Third session in new chat pane" }))
+    expect(onSwitchSession).toHaveBeenCalledWith("s3")
+
+    await user.click(within(appNav).getByRole("button", { name: "Collapse app navigation" }))
+    expect(screen.queryByLabelText("App navigation")).not.toBeInTheDocument()
+    expect(document.querySelector('[data-boring-workspace-part="app-left-pane"]')).toBeNull()
+    expect(screen.getByRole("button", { name: "Open app navigation" })).toBeInTheDocument()
+  })
+
+  it("focuses the current workspace-page instance from Plugins", async () => {
+    const user = userEvent.setup()
+
+    function FallbackPluginPage() {
+      return <div>Fallback plugin page body</div>
+    }
+    function CurrentPluginPage() {
+      return <div>Current plugin page body</div>
+    }
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="plugin-tabs-current-page"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        sessions={[{ id: "s1", title: "First session" }]}
+        activeSessionId="s1"
+        panels={[
+          {
+            id: "plugin.fallback",
+            title: "Fallback Plugin",
+            placement: "workspace-page",
+            source: "plugin",
+            component: FallbackPluginPage,
+          },
+          {
+            id: "plugin.current",
+            title: "Current Plugin",
+            placement: "workspace-page",
+            source: "plugin",
+            component: CurrentPluginPage,
+          },
+        ]}
+        surfaceInitialPanels={[{
+          id: "current-instance",
+          component: "plugin.current",
+          title: "Current Plugin Instance",
+        }]}
+        defaultSurfaceOpen
+        persistenceEnabled={false}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText("Current plugin page body")).toBeInTheDocument())
+    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
+    await waitFor(() => expect(screen.getByText("Current plugin page body")).toBeInTheDocument())
+    expect(screen.queryByText("Fallback plugin page body")).not.toBeInTheDocument()
+  })
+
+  it("opens plugin-tabs workspace pages from Plugins and Skills", async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/api/v1/tree")) return new Response(JSON.stringify({ entries: [] }), { status: 200 })
+      if (url.includes("/api/v1/ready-status")) return new Response(null, { status: 200 })
+      if (url.includes("/api/v1/agent/skills")) {
+        return new Response(JSON.stringify({ skills: [{ name: "review", description: "Review the current diff", source: "project" }] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      }
+      if (url.includes("/api/v1/ui/commands/next")) return new Response(JSON.stringify([]), { status: 200 })
+      return new Response(null, { status: 204 })
+    }))
+
+    function PluginPage() {
+      return <div>Plugin workspace page body</div>
+    }
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="plugin-tabs-pages"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        sessions={[{ id: "s1", title: "First session" }]}
+        activeSessionId="s1"
+        panels={[{
+          id: "plugin.page",
+          title: "Plugin Page",
+          placement: "workspace-page",
+          source: "plugin",
+          component: PluginPage,
+        }]}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
+    await waitFor(() => expect(screen.getByText("Plugin workspace page body")).toBeInTheDocument())
+
+    await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Skills" }))
+    await waitFor(() => expect(screen.getByText("/review")).toBeInTheDocument())
+    expect(screen.getByText("Review the current diff")).toBeInTheDocument()
   })
 
   it("opens a controlled void-created session as a pane to the right", async () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -431,7 +431,7 @@ describe("WorkspaceAgentFront", () => {
     expect(document.querySelector('[data-boring-workspace-part="plugins-overlay"]')).toBeNull()
   })
 
-  it("opens Skills and Plugins as chat left overlays", async () => {
+  it("opens Skills as a chat overlay and uses the UI bridge to open a skill", async () => {
     const user = userEvent.setup()
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
@@ -494,11 +494,6 @@ describe("WorkspaceAgentFront", () => {
       })
       expect(screen.queryByText("/review")).not.toBeInTheDocument()
 
-      await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
-      const overlay = document.querySelector('[data-boring-workspace-part="plugins-overlay"]')
-      expect(overlay).not.toBeNull()
-      await waitFor(() => expect(overlay!).toHaveTextContent("External Overlay"))
-      expect(overlay!).not.toHaveTextContent("Demo Plugin")
     } finally {
       window.removeEventListener(UI_COMMAND_EVENT, onUiCommand)
     }

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -100,6 +100,8 @@ describe("WorkspaceAgentFront", () => {
         return new Response(JSON.stringify([]), { status: 200 })
       }
       if (url.includes("/api/v1/ready-status")) return new Response(null, { status: 200 })
+      if (url.includes("/api/v1/agent-plugins")) return new Response(JSON.stringify([]), { status: 200 })
+      if (url.includes("/api/v1/agent/reload")) return new Response(JSON.stringify({ reloaded: true }), { status: 200 })
       if (url.includes("/api/v1/ui/commands/next")) return new Response(JSON.stringify([]), { status: 200 })
       return new Response(null, { status: 204 })
     }))
@@ -351,8 +353,10 @@ describe("WorkspaceAgentFront", () => {
     expect(within(appNav).getByRole("button", { name: "Search" })).toBeInTheDocument()
     expect(within(appNav).getByRole("button", { name: "Plugins" })).toBeInTheDocument()
     expect(within(appNav).getByRole("button", { name: "Skills" })).toBeInTheDocument()
+    await user.click(within(appNav).getByRole("button", { name: "New chat" }))
+    expect(onCreateSession).toHaveBeenCalledOnce()
     expect(screen.queryByRole("button", { name: "Sessions" })).not.toBeInTheDocument()
-    expect(screen.getByText("Projects")).toBeInTheDocument()
+    expect(screen.getByText("Workspaces")).toBeInTheDocument()
     expect(screen.queryByText("Codex mobile")).not.toBeInTheDocument()
     expect(screen.queryByText("Automations")).not.toBeInTheDocument()
 
@@ -380,8 +384,19 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.getByRole("button", { name: "Open app navigation" })).toBeInTheDocument()
   })
 
-  it("opens the Plugins overlay from the app nav and lists registered front plugins", async () => {
+  it("opens the Plugins overlay from the app nav and lists external plugins only", async () => {
     const user = userEvent.setup()
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/api/v1/tree")) return new Response(JSON.stringify({ entries: [] }), { status: 200 })
+      if (url.includes("/api/v1/ready-status")) return new Response(null, { status: 200 })
+      if (url.includes("/api/v1/agent-plugins")) {
+        return new Response(JSON.stringify([{ id: "external-plugin", boring: { label: "External Plugin" }, version: "1.2.3", revision: 4, frontTarget: { kind: "module-url", revision: 4 } }]), { status: 200 })
+      }
+      if (url.includes("/api/v1/agent/reload")) return new Response(JSON.stringify({ reloaded: true }), { status: 200 })
+      if (url.includes("/api/v1/ui/commands/next")) return new Response(JSON.stringify([]), { status: 200 })
+      return new Response(null, { status: 204 })
+    }))
 
     function PluginPanel() {
       return <div>Demo plugin panel body</div>
@@ -407,8 +422,10 @@ describe("WorkspaceAgentFront", () => {
     await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
     const overlay = document.querySelector('[data-boring-workspace-part="plugins-overlay"]')
     expect(overlay).not.toBeNull()
-    expect(overlay!).toHaveTextContent("Demo Plugin")
-    expect(overlay!).toHaveTextContent("Demo Panel")
+    await waitFor(() => expect(overlay!).toHaveTextContent("External Plugin"))
+    expect(overlay!).toHaveTextContent("external-plugin")
+    expect(overlay!).not.toHaveTextContent("Demo Plugin")
+    expect(overlay!).not.toHaveTextContent("Demo Panel")
 
     await user.click(screen.getByRole("button", { name: "Close plugins" }))
     expect(document.querySelector('[data-boring-workspace-part="plugins-overlay"]')).toBeNull()
@@ -433,6 +450,10 @@ describe("WorkspaceAgentFront", () => {
           headers: { "Content-Type": "application/json" },
         })
       }
+      if (url.includes("/api/v1/agent-plugins")) {
+        return new Response(JSON.stringify([{ id: "external-overlay-plugin", boring: { label: "External Overlay" }, revision: 2 }]), { status: 200 })
+      }
+      if (url.includes("/api/v1/agent/reload")) return new Response(JSON.stringify({ reloaded: true }), { status: 200 })
       if (url.includes("/api/v1/ui/commands/next")) return new Response(JSON.stringify([]), { status: 200 })
       return new Response(null, { status: 204 })
     }))
@@ -476,7 +497,8 @@ describe("WorkspaceAgentFront", () => {
       await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Plugins" }))
       const overlay = document.querySelector('[data-boring-workspace-part="plugins-overlay"]')
       expect(overlay).not.toBeNull()
-      expect(overlay!).toHaveTextContent("Demo Plugin")
+      await waitFor(() => expect(overlay!).toHaveTextContent("External Overlay"))
+      expect(overlay!).not.toHaveTextContent("Demo Plugin")
     } finally {
       window.removeEventListener(UI_COMMAND_EVENT, onUiCommand)
     }

--- a/packages/workspace/src/app/front/index.ts
+++ b/packages/workspace/src/app/front/index.ts
@@ -1,6 +1,7 @@
 export {
   WorkspaceAgentFront,
   type WorkspaceAgentFrontProps,
+  type WorkspaceAgentLayout,
   type WorkspaceAgentSession,
   type WorkspaceAgentSessionsApi,
   type UseWorkspaceAgentSessions,

--- a/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
+++ b/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
@@ -3,24 +3,24 @@ import { dispatchUiCommand, type DispatchContext } from "../uiCommandDispatcher"
 import type { SurfaceShellApi, SurfaceShellSnapshot } from "../../chrome/artifact-surface/SurfaceShell"
 
 function fakeSurface(): SurfaceShellApi & {
-  __opened: string[]
+  __opened: Array<{ path: string; opts?: { mode?: "view" | "edit" | "diff" } }>
   __surfaces: unknown[]
   __panels: unknown[]
   __expanded: string[]
   __leftClosed: number
 } {
-  const opened: string[] = []
+  const opened: Array<{ path: string; opts?: { mode?: "view" | "edit" | "diff" } }> = []
   const surfaces: unknown[] = []
   const panels: unknown[] = []
   const expanded: string[] = []
   const surface: SurfaceShellApi & {
-    __opened: string[]
+    __opened: Array<{ path: string; opts?: { mode?: "view" | "edit" | "diff" } }>
     __surfaces: unknown[]
     __panels: unknown[]
     __expanded: string[]
     __leftClosed: number
   } = {
-    openFile: (path: string) => opened.push(path),
+    openFile: (path: string, opts?: { mode?: "view" | "edit" | "diff" }) => opened.push({ path, opts }),
     openSurface: (request: unknown) => surfaces.push(request),
     openPanel: (cfg: unknown) => panels.push(cfg),
     expandToFile: (path: string) => expanded.push(path),
@@ -54,7 +54,13 @@ describe("dispatchUiCommand", () => {
   it("openFile calls surface.openFile with the path", () => {
     const c = ctx()
     dispatchUiCommand({ kind: "openFile", params: { path: "greeter.ts" } }, c)
-    expect(c.__surface.__opened).toEqual(["greeter.ts"])
+    expect(c.__surface.__opened).toEqual([{ path: "greeter.ts", opts: undefined }])
+  })
+
+  it("openFile forwards view/edit/diff mode to the surface", () => {
+    const c = ctx()
+    dispatchUiCommand({ kind: "openFile", params: { path: "SKILL.md", mode: "view" } }, c)
+    expect(c.__surface.__opened).toEqual([{ path: "SKILL.md", opts: { mode: "view" } }])
   })
 
   it("openFile is a no-op when path is missing or non-string", () => {
@@ -115,7 +121,7 @@ describe("dispatchUiCommand", () => {
       }
       flushRaf()
       flushRaf()
-      expect(surface.__opened).toEqual(["greeter.ts"])
+      expect(surface.__opened).toEqual([{ path: "greeter.ts", opts: undefined }])
     } finally {
       global.requestAnimationFrame = originalRaf
     }
@@ -286,7 +292,7 @@ describe("dispatchUiCommand", () => {
       expect(openedSurface.__opened).toEqual([])
       surface = openedSurface
       rafQueue.shift()?.(0)
-      expect(openedSurface.__opened).toEqual(["x.ts"])
+      expect(openedSurface.__opened).toEqual([{ path: "x.ts", opts: undefined }])
     } finally {
       global.requestAnimationFrame = originalRaf
     }

--- a/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
+++ b/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
@@ -116,11 +116,15 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
     case "openFile": {
       const path = strParam(cmd.params, "path")
       if (!path) return
+      const mode = strParam(cmd.params, "mode")
+      let openMode: "view" | "edit" | "diff" | undefined
+      if (mode === "view" || mode === "edit" || mode === "diff") openMode = mode
+      const openOpts = openMode ? { mode: openMode } : undefined
       const wasClosed = !ctx.isWorkbenchOpen()
       if (wasClosed) ctx.openWorkbench()
       const run = (surface: SurfaceShellApi) => {
         try {
-          surface.openFile(path)
+          surface.openFile(path, openOpts)
         } catch (err) {
           // eslint-disable-next-line no-console -- intentional dev signal
           console.warn(

--- a/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
+++ b/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
@@ -124,7 +124,8 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
       if (wasClosed) ctx.openWorkbench()
       const run = (surface: SurfaceShellApi) => {
         try {
-          surface.openFile(path, openOpts)
+          if (openOpts) surface.openFile(path, openOpts)
+          else surface.openFile(path)
         } catch (err) {
           // eslint-disable-next-line no-console -- intentional dev signal
           console.warn(

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -24,6 +24,8 @@ export { normalizeSurfaceOpenRequest, resolvePanelForPath } from "./surfaceShell
 
 export interface SurfaceShellTab {
   id: string
+  /** Registered panel component id for this tab. May differ from the tab instance id. */
+  component?: string
   title: string
   params?: Record<string, unknown>
 }
@@ -423,11 +425,15 @@ export function SurfaceShell({
   const getSnapshot = useCallback((): SurfaceShellSnapshot => {
     const api = apiRef.current
     if (!api) return { openTabs: [], activeTab: null }
-    const openTabs: SurfaceShellTab[] = api.panels.map((p) => ({
-      id: p.id,
-      title: (p.title ?? p.id) as string,
-      params: (p.params as Record<string, unknown> | undefined) ?? undefined,
-    }))
+    const openTabs: SurfaceShellTab[] = api.panels.map((p) => {
+      const component = dockviewPanelComponent(p)
+      return {
+        id: p.id,
+        ...(component ? { component } : {}),
+        title: (p.title ?? p.id) as string,
+        params: (p.params as Record<string, unknown> | undefined) ?? undefined,
+      }
+    })
     return { openTabs, activeTab: api.activePanel?.id ?? null }
   }, [])
 

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import type { DockviewApi } from "dockview-react"
-import { ChevronRight, PanelLeftOpen } from "lucide-react"
+import { ChevronRight, PanelLeft } from "lucide-react"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
@@ -801,7 +801,7 @@ export function SurfaceShell({
           <div className="self-start pl-1.5 pt-2">
             {leftBlockCollapsed && (
               <PaneCollapseButton label="Show workspace menu" side="right" onClick={expandLeftBlock}>
-                <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
+                <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
               </PaneCollapseButton>
             )}
           </div>

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -6,6 +6,7 @@ import { ChevronRight, PanelLeftOpen } from "lucide-react"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
+import { PaneCollapseButton } from "../../layout/paneCollapseButton"
 import { ArtifactSurfacePane } from "./ArtifactSurfacePane"
 import type { WorkspaceBridge, CommandResult, BridgeEventMap } from "../../bridge/types"
 import type { WorkspaceState, PanelState } from "../../store/types"
@@ -797,20 +798,11 @@ export function SurfaceShell({
           className="pointer-events-none absolute inset-x-0 top-0 flex items-center justify-between"
           style={{ height: 44, zIndex: 2000 }}
         >
-          <div>
+          <div className="self-start pl-1.5 pt-2">
             {leftBlockCollapsed && (
-              <ControlTooltip label="Show workspace menu" side="right">
-                <IconButton
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={expandLeftBlock}
-                  className="pointer-events-auto ml-2"
-                  aria-label="Show workspace menu"
-                >
-                  <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
-                </IconButton>
-              </ControlTooltip>
+              <PaneCollapseButton label="Show workspace menu" side="right" onClick={expandLeftBlock}>
+                <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
+              </PaneCollapseButton>
             )}
           </div>
           {showCloseAction && onClose && <WorkbenchCloseAction onClose={onClose} />}

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import type { DockviewApi } from "dockview-react"
-import { ChevronRight, PanelLeft } from "lucide-react"
+import { ChevronRight, PanelLeftOpen } from "lucide-react"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
@@ -808,7 +808,7 @@ export function SurfaceShell({
           <div className="self-start pl-1.5 pt-2">
             {leftBlockCollapsed && (
               <PaneCollapseButton label="Show workspace menu" side="right" onClick={expandLeftBlock}>
-                <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
+                <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
               </PaneCollapseButton>
             )}
           </div>

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -49,7 +49,7 @@ export interface OpenPanelConfig {
 
 export interface SurfaceShellApi {
   /** Open a file in the workbench. Idempotent — re-activates an existing pane for the same path. */
-  openFile: (path: string) => void
+  openFile: (path: string, opts?: { mode?: "view" | "edit" | "diff" }) => void
   /** Open a plugin-defined surface target through the registered surface resolvers. */
   openSurface: (request: SurfaceOpenRequest) => void
   /**
@@ -189,10 +189,12 @@ let seqCounter = 0
 function fileBackedParams(
   params: Record<string, unknown> | undefined,
   path: string,
+  opts?: { mode?: "view" | "edit" | "diff" },
 ): Record<string, unknown> {
   return {
     ...(params ?? {}),
     path: typeof params?.path === "string" ? params.path : path,
+    ...(opts?.mode ? { mode: opts.mode } : {}),
     [FILE_BACKED_PARAM]: true,
   }
 }
@@ -337,7 +339,7 @@ export function SurfaceShell({
     if (component) applyPanelPlacementTransition(component)
   }, [applyPanelPlacementTransition])
 
-  const openFileSync = useCallback((path: string) => {
+  const openFileSync = useCallback((path: string, opts?: { mode?: "view" | "edit" | "diff" }) => {
     const api = apiRef.current
     if (!api) {
       console.warn("[SurfaceShell] openFile: surface not ready (dockview not initialized)")
@@ -360,7 +362,7 @@ export function SurfaceShell({
         id: panelId,
         component: resolved.component,
         title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
-        params: fileBackedParams(resolved.params, normalizedPath),
+        params: fileBackedParams(resolved.params, normalizedPath, opts),
       })
       return
     }
@@ -393,8 +395,13 @@ export function SurfaceShell({
       fileBackedPanelIdsRef.current.add(panelId)
     }
     const closeWorkbenchOnDone = normalizedRequest.meta?.closeWorkbenchOnDone === true
+    const surfaceMode = normalizedRequest.meta?.mode
     const baseParams = normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND
-      ? fileBackedParams(resolved.params, normalizedRequest.target)
+      ? fileBackedParams(
+          resolved.params,
+          normalizedRequest.target,
+          surfaceMode === "view" || surfaceMode === "edit" || surfaceMode === "diff" ? { mode: surfaceMode } : undefined,
+        )
       : resolved.params
     const resolvedParams = closeWorkbenchOnDone && onCloseRef.current
       ? { ...(baseParams ?? {}), __closeWorkbenchOnDone: onCloseRef.current }
@@ -543,7 +550,7 @@ export function SurfaceShell({
 
 
   const openFile = useCallback(
-    async (path: string): Promise<CommandResult> => {
+    async (path: string, opts?: { mode?: "view" | "edit" | "diff" }): Promise<CommandResult> => {
       try {
         const api = apiRef.current
         if (!api) return err("not-ready", "surface not ready")
@@ -566,7 +573,7 @@ export function SurfaceShell({
             id: panelId,
             component: resolved.component,
             title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
-            params: fileBackedParams(resolved.params, normalizedPath),
+            params: fileBackedParams(resolved.params, normalizedPath, opts),
           })
           return ok()
         }

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -78,6 +78,8 @@ export interface SurfaceShellProps {
   onChange?: (snapshot: SurfaceShellSnapshot) => void
   /** Optional close action for hosts that model the workbench as collapsible. */
   onClose?: () => void
+  /** Render the built-in top-right close affordance. Hosts can set false when they provide their own chrome. */
+  showCloseAction?: boolean
   /**
    * Extra panel ids (registered via WorkspaceProvider's `panels` prop) that
    * this workbench is allowed to render. Defaults to the built-in
@@ -210,6 +212,7 @@ export function SurfaceShell({
   onReady,
   onChange,
   onClose,
+  showCloseAction = true,
   extraPanels,
   defaultLeftTab,
   onReloadAgentPlugins,
@@ -810,7 +813,7 @@ export function SurfaceShell({
               </ControlTooltip>
             )}
           </div>
-          {onClose && <WorkbenchCloseAction onClose={onClose} />}
+          {showCloseAction && onClose && <WorkbenchCloseAction onClose={onClose} />}
         </div>
         <EmptyWorkbenchOverlay api={api} />
       </div>

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import type { DockviewApi } from "dockview-react"
-import { ChevronRight, Menu } from "lucide-react"
+import { ChevronRight, PanelLeftOpen } from "lucide-react"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
@@ -808,7 +808,7 @@ export function SurfaceShell({
                   className="pointer-events-auto ml-2"
                   aria-label="Show workspace menu"
                 >
-                  <Menu className="h-4 w-4" strokeWidth={1.75} />
+                  <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
                 </IconButton>
               </ControlTooltip>
             )}

--- a/packages/workspace/src/front/chrome/plugins/PluginsOverlay.tsx
+++ b/packages/workspace/src/front/chrome/plugins/PluginsOverlay.tsx
@@ -12,6 +12,8 @@ export interface PluginsOverlayProps {
   /** Reload external/runtime plugins. The host owns the exact session-aware
    *  reload payload; this overlay owns only the chrome. */
   onReloadExternalPlugins?: () => Promise<string | undefined> | string | undefined
+  /** Reserve room for shell-level chrome that floats over collapsed app nav. */
+  headerInsetStart?: boolean
 }
 
 interface ExternalPluginEntry {
@@ -48,7 +50,7 @@ function upsertPlugin(plugins: ExternalPluginEntry[], plugin: ExternalPluginEntr
  * Lists only runtime/external plugins; statically bundled app plugins (Deck,
  * Questions, etc.) are intentionally hidden here.
  */
-export function PluginsOverlay({ onClose, onReloadExternalPlugins }: PluginsOverlayProps) {
+export function PluginsOverlay({ onClose, onReloadExternalPlugins, headerInsetStart = false }: PluginsOverlayProps) {
   const client = useWorkspacePluginClient()
   const [state, setState] = useState<LoadState>({ status: "loading", plugins: [] })
   const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(() => new Set())
@@ -147,7 +149,10 @@ export function PluginsOverlay({ onClose, onReloadExternalPlugins }: PluginsOver
 
   return (
     <div data-boring-workspace-part="plugins-overlay" className="flex h-full min-h-0 flex-col bg-background">
-      <header className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 px-4">
+      <header className={cn(
+        "flex h-12 shrink-0 items-center justify-between border-b border-border/60 pr-4",
+        headerInsetStart ? "pl-12" : "pl-4",
+      )}>
         <div className="flex min-w-0 items-center gap-2">
           <span className="grid size-7 place-items-center rounded-lg bg-foreground/[0.06] text-muted-foreground">
             <Plug className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />

--- a/packages/workspace/src/front/chrome/plugins/PluginsOverlay.tsx
+++ b/packages/workspace/src/front/chrome/plugins/PluginsOverlay.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { Plug, X } from "lucide-react"
+import { IconButton } from "@hachej/boring-ui-kit"
+import type { CapturedFrontPlugin } from "../../../shared/plugins/frontFactory"
+import { isWorkspacePagePlacement } from "../../../shared/types/panel"
+
+export interface PluginsOverlayProps {
+  /** Captured front plugins to list. */
+  plugins: readonly CapturedFrontPlugin[]
+  onClose: () => void
+}
+
+interface PanelSummary {
+  id: string
+  label?: string
+  placement?: string
+}
+
+/**
+ * Plugins overlay — hosted as a chat left overlay (not a workspace/workbench
+ * panel). Lists the workspace's registered front plugins and the panels each
+ * one contributes, so clicking "Plugins" in the app nav surfaces something
+ * even when no plugin registers a workspace-page panel.
+ */
+export function PluginsOverlay({ plugins, onClose }: PluginsOverlayProps) {
+  const sorted = [...plugins].sort((a, b) => (a.label ?? a.id).localeCompare(b.label ?? b.id))
+  return (
+    <div data-boring-workspace-part="plugins-overlay" className="flex h-full min-h-0 flex-col bg-background">
+      <header className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 px-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="grid size-7 place-items-center rounded-lg bg-foreground/[0.06] text-muted-foreground">
+            <Plug className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <h2 className="truncate text-sm font-semibold tracking-tight text-foreground">Plugins</h2>
+            <p className="truncate text-xs text-muted-foreground">Front plugins registered in this workspace</p>
+          </div>
+        </div>
+        <IconButton
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          onClick={onClose}
+          aria-label="Close plugins"
+          title="Close"
+          className="text-muted-foreground hover:text-foreground"
+        >
+          <X className="size-3" strokeWidth={1.75} />
+        </IconButton>
+      </header>
+
+      <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto p-4">
+        {sorted.length === 0 ? (
+          <div className="flex h-full min-h-[180px] items-center justify-center text-center text-sm text-muted-foreground">
+            <div>
+              <div className="font-medium text-foreground/80">No plugins registered</div>
+              <p className="mt-1 max-w-xs">Register a front plugin to see it listed here.</p>
+            </div>
+          </div>
+        ) : (
+          <ul role="list" className="grid gap-2">
+            {sorted.map((plugin) => {
+              const panels: PanelSummary[] = plugin.registrations.panels.map((panel) => ({
+                id: panel.id,
+                label: panel.label,
+                placement: panel.placement,
+              }))
+              return (
+                <li
+                  key={plugin.id}
+                  className="rounded-xl border border-border/60 bg-card/70 px-3 py-2.5"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium text-foreground">{plugin.label ?? plugin.id}</div>
+                      <div className="mt-0.5 truncate text-[11px] text-muted-foreground/80">{plugin.id}</div>
+                    </div>
+                    <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                      {panels.length} panel{panels.length === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                  {panels.length > 0 ? (
+                    <ul className="mt-2 space-y-1" role="list">
+                      {panels.map((panel) => (
+                        <li key={panel.id} className="flex items-center gap-2 text-xs text-muted-foreground">
+                          <span className="truncate">{panel.label ?? panel.id}</span>
+                          {isWorkspacePagePlacement(panel.placement) ? (
+                            <span className="shrink-0 rounded bg-foreground/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                              page
+                            </span>
+                          ) : null}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/workspace/src/front/chrome/plugins/PluginsOverlay.tsx
+++ b/packages/workspace/src/front/chrome/plugins/PluginsOverlay.tsx
@@ -1,30 +1,150 @@
 "use client"
 
-import { Plug, X } from "lucide-react"
-import { IconButton } from "@hachej/boring-ui-kit"
-import type { CapturedFrontPlugin } from "../../../shared/plugins/frontFactory"
-import { isWorkspacePagePlacement } from "../../../shared/types/panel"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { Plug, RefreshCw, X } from "lucide-react"
+import { Button, IconButton } from "@hachej/boring-ui-kit"
+import { WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT } from "../../agentPlugins/reloadEvent"
+import { cn } from "../../lib/utils"
+import { useWorkspacePluginClient } from "../../plugin/useWorkspacePluginClient"
 
 export interface PluginsOverlayProps {
-  /** Captured front plugins to list. */
-  plugins: readonly CapturedFrontPlugin[]
   onClose: () => void
+  /** Reload external/runtime plugins. The host owns the exact session-aware
+   *  reload payload; this overlay owns only the chrome. */
+  onReloadExternalPlugins?: () => Promise<string | undefined> | string | undefined
 }
 
-interface PanelSummary {
+interface ExternalPluginEntry {
   id: string
-  label?: string
-  placement?: string
+  boring?: { id?: string; label?: string; front?: string | false; server?: string | false }
+  version?: string
+  revision?: number
+  frontTarget?: { kind?: string; entryUrl?: string; revision?: number }
+}
+
+interface ExternalPluginEvent extends ExternalPluginEntry {
+  type?: string
+  replay?: boolean
+  message?: string
+}
+
+type LoadState =
+  | { status: "loading"; plugins: ExternalPluginEntry[]; error?: undefined }
+  | { status: "ready"; plugins: ExternalPluginEntry[]; error?: undefined }
+  | { status: "error"; plugins: ExternalPluginEntry[]; error: string }
+
+function pluginLabel(plugin: ExternalPluginEntry): string {
+  return plugin.boring?.label || plugin.boring?.id || plugin.id
+}
+
+function upsertPlugin(plugins: ExternalPluginEntry[], plugin: ExternalPluginEntry): ExternalPluginEntry[] {
+  const next = plugins.filter((entry) => entry.id !== plugin.id)
+  next.push(plugin)
+  return next.sort((a, b) => pluginLabel(a).localeCompare(pluginLabel(b)))
 }
 
 /**
- * Plugins overlay — hosted as a chat left overlay (not a workspace/workbench
- * panel). Lists the workspace's registered front plugins and the panels each
- * one contributes, so clicking "Plugins" in the app nav surfaces something
- * even when no plugin registers a workspace-page panel.
+ * External plugins overlay — hosted as a chat overlay, not as a workbench panel.
+ * Lists only runtime/external plugins; statically bundled app plugins (Deck,
+ * Questions, etc.) are intentionally hidden here.
  */
-export function PluginsOverlay({ plugins, onClose }: PluginsOverlayProps) {
-  const sorted = [...plugins].sort((a, b) => (a.label ?? a.id).localeCompare(b.label ?? b.id))
+export function PluginsOverlay({ onClose, onReloadExternalPlugins }: PluginsOverlayProps) {
+  const client = useWorkspacePluginClient()
+  const [state, setState] = useState<LoadState>({ status: "loading", plugins: [] })
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<string>>(() => new Set())
+  const [reloading, setReloading] = useState(false)
+  const [reloadMessage, setReloadMessage] = useState<string | null>(null)
+
+  const loadPlugins = useCallback(async () => {
+    setState((current) => ({ status: "loading", plugins: current.plugins }))
+    try {
+      const plugins = await client.getJson<ExternalPluginEntry[]>("/api/v1/agent-plugins?external=1", {
+        missingMessage: "Failed to load external plugins.",
+      })
+      const sorted = Array.isArray(plugins)
+        ? [...plugins].sort((a, b) => pluginLabel(a).localeCompare(pluginLabel(b)))
+        : []
+      setState({ status: "ready", plugins: sorted })
+    } catch (error) {
+      setState((current) => ({
+        status: "error",
+        plugins: current.plugins,
+        error: error instanceof Error ? error.message : "Failed to load external plugins.",
+      }))
+    }
+  }, [client])
+
+  useEffect(() => {
+    void loadPlugins()
+  }, [loadPlugins])
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<ExternalPluginEvent>).detail
+      if (!detail || typeof detail !== "object") return
+      switch (detail.type) {
+        case "boring.plugin.load":
+          setState((current) => ({ ...current, plugins: upsertPlugin(current.plugins, detail) }))
+          setPendingIds((current) => {
+            const next = new Set(current)
+            next.delete(detail.id)
+            return next
+          })
+          break
+        case "boring.plugin.unload":
+          setState((current) => ({ ...current, plugins: current.plugins.filter((plugin) => plugin.id !== detail.id) }))
+          setPendingIds((current) => {
+            const next = new Set(current)
+            next.delete(detail.id)
+            return next
+          })
+          break
+        case "boring.plugin.front-pending":
+          setPendingIds((current) => new Set(current).add(detail.id))
+          break
+        case "boring.plugin.front-settled":
+          setPendingIds((current) => {
+            const next = new Set(current)
+            next.delete(detail.id)
+            return next
+          })
+          break
+        case "boring.plugin.error":
+        case "boring.plugin.front-error":
+          setReloadMessage(detail.message ? `${detail.id}: ${detail.message}` : `${detail.id} failed to reload`)
+          setPendingIds((current) => {
+            const next = new Set(current)
+            next.delete(detail.id)
+            return next
+          })
+          break
+        case "boring.plugin.replay-complete":
+          void loadPlugins()
+          break
+      }
+    }
+    window.addEventListener(WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT, handler as EventListener)
+    return () => window.removeEventListener(WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT, handler as EventListener)
+  }, [loadPlugins])
+
+  const sorted = useMemo(() => [...state.plugins].sort((a, b) => pluginLabel(a).localeCompare(pluginLabel(b))), [state.plugins])
+
+  const reload = useCallback(async () => {
+    setReloading(true)
+    setReloadMessage(null)
+    try {
+      const message = onReloadExternalPlugins
+        ? await onReloadExternalPlugins()
+        : undefined
+      setReloadMessage(message || "External plugins reloaded.")
+      await loadPlugins()
+    } catch (error) {
+      setReloadMessage(error instanceof Error ? error.message : "External plugin reload failed.")
+    } finally {
+      setReloading(false)
+    }
+  }, [loadPlugins, onReloadExternalPlugins])
+
   return (
     <div data-boring-workspace-part="plugins-overlay" className="flex h-full min-h-0 flex-col bg-background">
       <header className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 px-4">
@@ -34,38 +154,61 @@ export function PluginsOverlay({ plugins, onClose }: PluginsOverlayProps) {
           </span>
           <div className="min-w-0">
             <h2 className="truncate text-sm font-semibold tracking-tight text-foreground">Plugins</h2>
-            <p className="truncate text-xs text-muted-foreground">Front plugins registered in this workspace</p>
+            <p className="truncate text-xs text-muted-foreground">External plugins loaded for this workspace</p>
           </div>
         </div>
-        <IconButton
-          type="button"
-          variant="ghost"
-          size="icon-xs"
-          onClick={onClose}
-          aria-label="Close plugins"
-          title="Close"
-          className="text-muted-foreground hover:text-foreground"
-        >
-          <X className="size-3" strokeWidth={1.75} />
-        </IconButton>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => void reload()}
+            disabled={reloading || state.status === "loading"}
+            className="gap-1.5 text-xs"
+          >
+            <RefreshCw className={cn("h-3.5 w-3.5", (reloading || state.status === "loading") && "animate-spin")} strokeWidth={1.75} />
+            Reload
+          </Button>
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={onClose}
+            aria-label="Close plugins"
+            title="Close"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-3" strokeWidth={1.75} />
+          </IconButton>
+        </div>
       </header>
 
-      <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto p-4">
-        {sorted.length === 0 ? (
+      <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">
+        {state.status === "error" ? (
+          <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-sm text-destructive">
+            {state.error}
+          </div>
+        ) : null}
+        {reloadMessage ? (
+          <div className="mb-4 rounded-lg border border-border/70 bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+            {reloadMessage}
+          </div>
+        ) : null}
+        {state.status === "loading" && sorted.length === 0 ? (
+          <div className="flex h-full min-h-[180px] items-center justify-center text-sm text-muted-foreground">
+            Loading external plugins…
+          </div>
+        ) : sorted.length === 0 ? (
           <div className="flex h-full min-h-[180px] items-center justify-center text-center text-sm text-muted-foreground">
             <div>
-              <div className="font-medium text-foreground/80">No plugins registered</div>
-              <p className="mt-1 max-w-xs">Register a front plugin to see it listed here.</p>
+              <div className="font-medium text-foreground/80">No external plugins loaded</div>
+              <p className="mt-1 max-w-xs">Create or install an external plugin, then reload external plugins.</p>
             </div>
           </div>
         ) : (
           <ul role="list" className="grid gap-2">
             {sorted.map((plugin) => {
-              const panels: PanelSummary[] = plugin.registrations.panels.map((panel) => ({
-                id: panel.id,
-                label: panel.label,
-                placement: panel.placement,
-              }))
+              const pending = pendingIds.has(plugin.id)
               return (
                 <li
                   key={plugin.id}
@@ -73,26 +216,23 @@ export function PluginsOverlay({ plugins, onClose }: PluginsOverlayProps) {
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0">
-                      <div className="truncate text-sm font-medium text-foreground">{plugin.label ?? plugin.id}</div>
+                      <div className="truncate text-sm font-medium text-foreground">{pluginLabel(plugin)}</div>
                       <div className="mt-0.5 truncate text-[11px] text-muted-foreground/80">{plugin.id}</div>
                     </div>
-                    <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                      {panels.length} panel{panels.length === 1 ? "" : "s"}
-                    </span>
+                    <div className="flex shrink-0 items-center gap-1">
+                      {pending ? (
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">loading</span>
+                      ) : null}
+                      {plugin.frontTarget ? (
+                        <span className="rounded bg-foreground/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">front</span>
+                      ) : null}
+                      {typeof plugin.revision === "number" ? (
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">r{plugin.revision}</span>
+                      ) : null}
+                    </div>
                   </div>
-                  {panels.length > 0 ? (
-                    <ul className="mt-2 space-y-1" role="list">
-                      {panels.map((panel) => (
-                        <li key={panel.id} className="flex items-center gap-2 text-xs text-muted-foreground">
-                          <span className="truncate">{panel.label ?? panel.id}</span>
-                          {isWorkspacePagePlacement(panel.placement) ? (
-                            <span className="shrink-0 rounded bg-foreground/[0.06] px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                              page
-                            </span>
-                          ) : null}
-                        </li>
-                      ))}
-                    </ul>
+                  {plugin.version ? (
+                    <div className="mt-2 text-xs text-muted-foreground">Version {plugin.version}</div>
                   ) : null}
                 </li>
               )

--- a/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
+++ b/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { RefreshCw, Sparkles } from "lucide-react"
+import { Button } from "@hachej/boring-ui-kit"
+import { cn } from "../../lib/utils"
+import { useWorkspacePluginClient } from "../../plugin/useWorkspacePluginClient"
+import type { PaneProps } from "../../registry/types"
+
+interface SkillSummary {
+  name: string
+  description?: string
+  source?: string
+}
+
+interface SkillsResponse {
+  skills?: SkillSummary[]
+}
+
+type LoadState =
+  | { status: "loading"; skills: SkillSummary[]; error?: undefined }
+  | { status: "ready"; skills: SkillSummary[]; error?: undefined }
+  | { status: "error"; skills: SkillSummary[]; error: string }
+
+export function SkillsPage(_props: PaneProps) {
+  const client = useWorkspacePluginClient()
+  const [state, setState] = useState<LoadState>({ status: "loading", skills: [] })
+
+  const loadSkills = useCallback(async (refresh = false) => {
+    setState((current) => ({ status: "loading", skills: current.skills }))
+    try {
+      const payload = await client.getJson<SkillsResponse>(`/api/v1/agent/skills${refresh ? "?refresh=1" : ""}`, {
+        missingMessage: "Failed to load workspace skills.",
+      })
+      const skills = Array.isArray(payload.skills)
+        ? payload.skills.filter((skill): skill is SkillSummary => typeof skill?.name === "string" && skill.name.length > 0)
+        : []
+      setState({ status: "ready", skills })
+    } catch (error) {
+      setState((current) => ({
+        status: "error",
+        skills: current.skills,
+        error: error instanceof Error ? error.message : "Failed to load workspace skills.",
+      }))
+    }
+  }, [client])
+
+  useEffect(() => {
+    void loadSkills(false)
+  }, [loadSkills])
+
+  const sortedSkills = useMemo(
+    () => [...state.skills].sort((a, b) => a.name.localeCompare(b.name)),
+    [state.skills],
+  )
+
+  return (
+    <div data-boring-workspace-part="skills-page" className="flex h-full min-h-0 flex-col bg-background">
+      <header className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 px-4">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="grid size-7 place-items-center rounded-lg bg-[color:oklch(from_var(--accent)_l_c_h/0.12)] text-[color:var(--accent)]">
+            <Sparkles className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <h2 className="truncate text-sm font-semibold tracking-tight text-foreground">Skills</h2>
+            <p className="truncate text-xs text-muted-foreground">Workspace skills available to slash commands</p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => void loadSkills(true)}
+          disabled={state.status === "loading"}
+          className="gap-1.5 text-xs"
+        >
+          <RefreshCw className={cn("h-3.5 w-3.5", state.status === "loading" && "animate-spin")} strokeWidth={1.75} />
+          Refresh
+        </Button>
+      </header>
+
+      <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">
+        {state.status === "error" ? (
+          <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-sm text-destructive">
+            {state.error}
+          </div>
+        ) : null}
+
+        {state.status === "loading" && sortedSkills.length === 0 ? (
+          <div className="flex h-full min-h-[180px] items-center justify-center text-sm text-muted-foreground">
+            Loading skills…
+          </div>
+        ) : sortedSkills.length === 0 ? (
+          <div className="flex h-full min-h-[180px] items-center justify-center text-center text-sm text-muted-foreground">
+            <div>
+              <div className="font-medium text-foreground/80">No skills found</div>
+              <p className="mt-1 max-w-xs">Reload plugins or add workspace skills to make them available in chat.</p>
+            </div>
+          </div>
+        ) : (
+          <ul role="list" className="grid gap-2">
+            {sortedSkills.map((skill) => (
+              <li
+                key={skill.name}
+                className="rounded-xl border border-border/60 bg-card/70 px-3 py-2.5 shadow-sm"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-medium text-foreground">/{skill.name}</div>
+                    {skill.description ? (
+                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">{skill.description}</p>
+                    ) : null}
+                  </div>
+                  {skill.source ? (
+                    <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                      {skill.source}
+                    </span>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
+++ b/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
@@ -39,8 +39,7 @@ export function SkillsPage({ onClose }: SkillsPageProps) {
   const openSkillInWorkspace = useCallback((skill: SkillSummary) => {
     if (!skill.filePath) return
     postUiCommand({ kind: "openFile", params: { path: skill.filePath, mode: "view" } })
-    onClose?.()
-  }, [onClose])
+  }, [])
 
   const loadSkills = useCallback(async (refresh = false) => {
     setState((current) => ({ status: "loading", skills: current.skills }))

--- a/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
+++ b/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { RefreshCw, Sparkles, X } from "lucide-react"
+import { FileText, RefreshCw, Sparkles, X } from "lucide-react"
 import { Button, IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
+import { postUiCommand } from "../../bridge"
 import { useWorkspacePluginClient } from "../../plugin/useWorkspacePluginClient"
 import type { PaneProps } from "../../registry/types"
 
@@ -11,6 +12,9 @@ interface SkillSummary {
   name: string
   description?: string
   source?: string
+  /** Absolute path to the skill's SKILL.md. Used to open the skill through
+   *  the workspace UI bridge, not by mutating chat/composer DOM. */
+  filePath?: string
 }
 
 interface SkillsResponse {
@@ -31,6 +35,12 @@ export type SkillsPageProps = Partial<PaneProps> & {
 export function SkillsPage({ onClose }: SkillsPageProps) {
   const client = useWorkspacePluginClient()
   const [state, setState] = useState<LoadState>({ status: "loading", skills: [] })
+
+  const openSkillInWorkspace = useCallback((skill: SkillSummary) => {
+    if (!skill.filePath) return
+    postUiCommand({ kind: "openFile", params: { path: skill.filePath, mode: "view" } })
+    onClose?.()
+  }, [onClose])
 
   const loadSkills = useCallback(async (refresh = false) => {
     setState((current) => ({ status: "loading", skills: current.skills }))
@@ -120,26 +130,54 @@ export function SkillsPage({ onClose }: SkillsPageProps) {
           </div>
         ) : (
           <ul role="list" className="grid gap-2">
-            {sortedSkills.map((skill) => (
-              <li
-                key={skill.name}
-                className="rounded-xl border border-border/60 bg-card/70 px-3 py-2.5 shadow-sm"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-medium text-foreground">/{skill.name}</div>
-                    {skill.description ? (
-                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">{skill.description}</p>
-                    ) : null}
-                  </div>
-                  {skill.source ? (
-                    <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
-                      {skill.source}
-                    </span>
-                  ) : null}
-                </div>
-              </li>
-            ))}
+            {sortedSkills.map((skill) => {
+              const openable = Boolean(skill.filePath)
+              return (
+                <li
+                  key={skill.name}
+                  className={cn(
+                    "rounded-xl border border-border/60 bg-card/70 px-3 py-2.5",
+                    openable
+                      ? "cursor-pointer transition-colors hover:border-border hover:bg-muted/60"
+                      : "",
+                  )}
+                >
+                  {openable ? (
+                    <button
+                      type="button"
+                      onClick={() => openSkillInWorkspace(skill)}
+                      title="Open skill in workspace"
+                      aria-label={`Open skill ${skill.name} in workspace`}
+                      className="block w-full text-left"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="truncate text-sm font-medium text-foreground">/{skill.name}</div>
+                          {skill.description ? (
+                            <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">{skill.description}</p>
+                          ) : null}
+                        </div>
+                        <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
+                      </div>
+                    </button>
+                  ) : (
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-foreground">/{skill.name}</div>
+                        {skill.description ? (
+                          <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">{skill.description}</p>
+                        ) : null}
+                      </div>
+                      {skill.source ? (
+                        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          {skill.source}
+                        </span>
+                      ) : null}
+                    </div>
+                  )}
+                </li>
+              )
+            })}
           </ul>
         )}
       </div>

--- a/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
+++ b/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
@@ -30,9 +30,11 @@ export type SkillsPageProps = Partial<PaneProps> & {
   /** When provided, renders a close control in the header — used when Skills
    *  is hosted as a chat left overlay rather than a workspace panel. */
   onClose?: () => void
+  /** Reserve room for shell-level chrome that floats over collapsed app nav. */
+  headerInsetStart?: boolean
 }
 
-export function SkillsPage({ onClose }: SkillsPageProps) {
+export function SkillsPage({ onClose, headerInsetStart = false }: SkillsPageProps) {
   const client = useWorkspacePluginClient()
   const [state, setState] = useState<LoadState>({ status: "loading", skills: [] })
 
@@ -71,7 +73,10 @@ export function SkillsPage({ onClose }: SkillsPageProps) {
 
   return (
     <div data-boring-workspace-part="skills-page" className="flex h-full min-h-0 flex-col bg-background">
-      <header className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 px-4">
+      <header className={cn(
+        "flex h-12 shrink-0 items-center justify-between border-b border-border/60 pr-4",
+        headerInsetStart ? "pl-12" : "pl-4",
+      )}>
         <div className="flex min-w-0 items-center gap-2">
           <span className="grid size-7 place-items-center rounded-lg bg-[color:oklch(from_var(--accent)_l_c_h/0.12)] text-[color:var(--accent)]">
             <Sparkles className="h-4 w-4" strokeWidth={1.75} aria-hidden="true" />

--- a/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
+++ b/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useState } from "react"
-import { RefreshCw, Sparkles } from "lucide-react"
-import { Button } from "@hachej/boring-ui-kit"
+import { RefreshCw, Sparkles, X } from "lucide-react"
+import { Button, IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import { useWorkspacePluginClient } from "../../plugin/useWorkspacePluginClient"
 import type { PaneProps } from "../../registry/types"
@@ -22,7 +22,13 @@ type LoadState =
   | { status: "ready"; skills: SkillSummary[]; error?: undefined }
   | { status: "error"; skills: SkillSummary[]; error: string }
 
-export function SkillsPage(_props: PaneProps) {
+export type SkillsPageProps = Partial<PaneProps> & {
+  /** When provided, renders a close control in the header — used when Skills
+   *  is hosted as a chat left overlay rather than a workspace panel. */
+  onClose?: () => void
+}
+
+export function SkillsPage({ onClose }: SkillsPageProps) {
   const client = useWorkspacePluginClient()
   const [state, setState] = useState<LoadState>({ status: "loading", skills: [] })
 
@@ -66,17 +72,32 @@ export function SkillsPage(_props: PaneProps) {
             <p className="truncate text-xs text-muted-foreground">Workspace skills available to slash commands</p>
           </div>
         </div>
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          onClick={() => void loadSkills(true)}
-          disabled={state.status === "loading"}
-          className="gap-1.5 text-xs"
-        >
-          <RefreshCw className={cn("h-3.5 w-3.5", state.status === "loading" && "animate-spin")} strokeWidth={1.75} />
-          Refresh
-        </Button>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => void loadSkills(true)}
+            disabled={state.status === "loading"}
+            className="gap-1.5 text-xs"
+          >
+            <RefreshCw className={cn("h-3.5 w-3.5", state.status === "loading" && "animate-spin")} strokeWidth={1.75} />
+            Refresh
+          </Button>
+          {onClose ? (
+            <IconButton
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              onClick={onClose}
+              aria-label="Close skills"
+              title="Close"
+              className="text-muted-foreground hover:text-foreground"
+            >
+              <X className="size-3" strokeWidth={1.75} />
+            </IconButton>
+          ) : null}
+        </div>
       </header>
 
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">

--- a/packages/workspace/src/front/chrome/skills/definition.ts
+++ b/packages/workspace/src/front/chrome/skills/definition.ts
@@ -1,0 +1,14 @@
+import { Sparkles } from "lucide-react"
+import type { PanelConfig } from "../../registry/types"
+import { SkillsPage } from "./SkillsPage"
+
+export const WORKSPACE_SKILLS_PANEL_ID = "workspace:skills"
+
+export const workspaceSkillsPanel: PanelConfig = {
+  id: WORKSPACE_SKILLS_PANEL_ID,
+  title: "Skills",
+  icon: Sparkles,
+  placement: "workspace-page",
+  source: "core",
+  component: SkillsPage,
+}

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react"
-import { PanelLeft, Search, X } from "lucide-react"
+import { PanelLeftClose, Search, X } from "lucide-react"
 import { IconButton, Input } from "@hachej/boring-ui-kit"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { cn } from "../../lib/utils"
@@ -236,7 +236,7 @@ export function WorkbenchLeftPane({
     >
       {onCollapse && (
         <PaneCollapseButton label="Hide workspace menu" side="right" onClick={onCollapse} className="mb-1">
-          <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
+          <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
         </PaneCollapseButton>
       )}
       {tabs.map((entry) => {

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -14,6 +14,7 @@ import { PanelLeftClose, Search, X } from "lucide-react"
 import { IconButton, Input } from "@hachej/boring-ui-kit"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { cn } from "../../lib/utils"
+import { PaneCollapseButton } from "../../layout/paneCollapseButton"
 import type { FileTreeBridge } from "../../bridge/types"
 import { useRegistry, useWorkspaceSourceRegistry } from "../../registry"
 import type { PanelConfig, WorkspaceSourceConfig } from "../../registry/types"
@@ -234,16 +235,9 @@ export function WorkbenchLeftPane({
       aria-label="Workspace categories"
     >
       {onCollapse && (
-        <ControlTooltip label="Hide workspace menu" side="right">
-          <button
-            type="button"
-            aria-label="Hide workspace menu"
-            onClick={onCollapse}
-            className="mb-1 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-          >
-            <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
-          </button>
-        </ControlTooltip>
+        <PaneCollapseButton label="Hide workspace menu" side="right" onClick={onCollapse} className="mb-1">
+          <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
+        </PaneCollapseButton>
       )}
       {tabs.map((entry) => {
         const active = entry.id === activeTab

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react"
-import { PanelLeftClose, Search, X } from "lucide-react"
+import { PanelLeft, Search, X } from "lucide-react"
 import { IconButton, Input } from "@hachej/boring-ui-kit"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { cn } from "../../lib/utils"
@@ -236,7 +236,7 @@ export function WorkbenchLeftPane({
     >
       {onCollapse && (
         <PaneCollapseButton label="Hide workspace menu" side="right" onClick={onCollapse} className="mb-1">
-          <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
+          <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
         </PaneCollapseButton>
       )}
       {tabs.map((entry) => {

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -10,7 +10,7 @@ import {
   useState,
   useSyncExternalStore,
 } from "react"
-import { Menu, Search, X } from "lucide-react"
+import { PanelLeftClose, Search, X } from "lucide-react"
 import { IconButton, Input } from "@hachej/boring-ui-kit"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { cn } from "../../lib/utils"
@@ -241,7 +241,7 @@ export function WorkbenchLeftPane({
             onClick={onCollapse}
             className="mb-1 flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
           >
-            <Menu className="h-4 w-4" strokeWidth={1.75} />
+            <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
           </button>
         </ControlTooltip>
       )}

--- a/packages/workspace/src/front/components/CommandPalette.tsx
+++ b/packages/workspace/src/front/components/CommandPalette.tsx
@@ -7,6 +7,8 @@ import {
   ClockIcon,
   CornerDownLeft,
   FileIcon,
+  MessageSquare,
+  MessageSquarePlus,
   TerminalIcon,
 } from "lucide-react"
 import {
@@ -44,9 +46,26 @@ import type { CatalogConfig, CatalogRow } from "../../shared/plugins/types"
 import type { CommandConfig } from "../registry/types"
 import type { RecentEntry } from "./recent"
 
-export type CommandPaletteProps = Record<string, never>
+export interface CommandPaletteSessionItem {
+  id: string
+  title?: string | null
+  updatedAt?: string | number
+  turnCount?: number
+}
 
-export function CommandPalette(_props?: CommandPaletteProps) {
+export interface CommandPaletteSessionSearchConfig {
+  sessions: CommandPaletteSessionItem[]
+  activeId?: string | null
+  openIds?: readonly string[]
+  onSwitch: (id: string) => void
+  onOpenAsTab: (id: string) => void
+}
+
+export interface CommandPaletteProps {
+  sessionSearch?: CommandPaletteSessionSearchConfig
+}
+
+export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState("")
   const [mode, setMode] = useState<PaletteMode>("catalogs")
@@ -90,6 +109,18 @@ export function CommandPalette(_props?: CommandPaletteProps) {
     if (!isCommandMode) return []
     return searchCommands(commands, searchQuery)
   }, [commands, isCommandMode, searchQuery])
+
+  const sessionResults = useMemo(() => {
+    if (!sessionSearch || isCommandMode) return []
+    const normalized = searchQuery.toLowerCase()
+    return sessionSearch.sessions
+      .filter((session) => {
+        if (!normalized) return true
+        const title = session.title || session.id
+        return title.toLowerCase().includes(normalized) || session.id.toLowerCase().includes(normalized)
+      })
+      .slice(0, 8)
+  }, [isCommandMode, searchQuery, sessionSearch])
 
   const {
     recentEntries,
@@ -141,6 +172,12 @@ export function CommandPalette(_props?: CommandPaletteProps) {
               recentEntries={recentEntries}
               searchQuery={searchQuery}
               onRecentSelect={handleRecentSelect}
+            />
+            <SessionSearchResultsSection
+              isCommandMode={isCommandMode}
+              sessionSearch={sessionSearch}
+              sessions={sessionResults}
+              close={() => setOpen(false)}
             />
             <CatalogResultsSections
               catalogGroups={catalogGroups}
@@ -279,6 +316,75 @@ function RecentResultsSection({
                 </span>
               </>
             )}
+          </CommandItem>
+        )
+      })}
+    </CommandGroup>
+  )
+}
+
+function SessionSearchResultsSection({
+  isCommandMode,
+  sessionSearch,
+  sessions,
+  close,
+}: {
+  isCommandMode: boolean
+  sessionSearch?: CommandPaletteSessionSearchConfig
+  sessions: CommandPaletteSessionItem[]
+  close: () => void
+}) {
+  if (isCommandMode || !sessionSearch || sessions.length === 0) return null
+  const openSet = new Set(sessionSearch.openIds ?? [])
+  const activeId = sessionSearch.activeId ?? null
+
+  return (
+    <CommandGroup heading="Chat session search">
+      {sessions.map((session) => {
+        const title = session.title || "Untitled"
+        const active = session.id === activeId
+        const open = openSet.has(session.id)
+        return (
+          <CommandItem
+            key={`chat-session:${session.id}`}
+            value={`chat-session:${session.id}:${title}`}
+            onSelect={() => {
+              if (!active) sessionSearch.onSwitch(session.id)
+              close()
+            }}
+            className="group flex items-center gap-3 rounded-md px-3 py-2 text-sm aria-selected:bg-[color:oklch(from_var(--accent)_l_c_h/0.10)] aria-selected:text-foreground"
+          >
+            <MessageSquare className="size-4 shrink-0 text-muted-foreground/70 group-aria-selected:text-[color:var(--accent)]" />
+            <span className="flex min-w-0 flex-1 items-center gap-2 truncate">
+              <span className="truncate font-medium text-foreground">{title}</span>
+              {active ? (
+                <span className="shrink-0 rounded bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] px-1.5 py-0.5 text-[10px] font-medium text-[color:var(--accent)]">active</span>
+              ) : open ? (
+                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">open</span>
+              ) : null}
+            </span>
+            <button
+              type="button"
+              aria-label={`Open ${title} in new chat pane`}
+              title="Open in new chat pane"
+              onPointerDown={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              onMouseDown={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+              }}
+              onClick={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                sessionSearch.onOpenAsTab(session.id)
+                close()
+              }}
+              className="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground opacity-0 transition-opacity hover:bg-background hover:text-foreground focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 group-hover:opacity-100 group-aria-selected:opacity-100"
+            >
+              <MessageSquarePlus className="h-3.5 w-3.5" strokeWidth={1.75} />
+            </button>
           </CommandItem>
         )
       })}

--- a/packages/workspace/src/front/components/CommandPalette.tsx
+++ b/packages/workspace/src/front/components/CommandPalette.tsx
@@ -58,6 +58,7 @@ export interface CommandPaletteSessionSearchConfig {
   sessions: CommandPaletteSessionItem[]
   activeId?: string | null
   openIds?: readonly string[]
+  search?: (sessions: readonly CommandPaletteSessionItem[], query: string) => CommandPaletteSessionItem[]
   onSwitch: (id: string) => void
   onOpenAsTab: (id: string) => void
 }
@@ -90,6 +91,18 @@ function toFileSearchGlob(query: string): string {
 
 function emptySearchResult(): CatalogSearchResult {
   return { items: [], total: 0, hasMore: false }
+}
+
+function defaultSessionSearch(
+  sessions: readonly CommandPaletteSessionItem[],
+  query: string,
+): CommandPaletteSessionItem[] {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return [...sessions]
+  return sessions.filter((session) => {
+    const title = session.title || session.id
+    return title.toLowerCase().includes(normalized) || session.id.toLowerCase().includes(normalized)
+  })
 }
 
 function createFallbackFilesCatalog(): CatalogConfig {
@@ -178,14 +191,10 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
 
   const sessionResults = useMemo(() => {
     if (!sessionSearch || !isChatMode) return []
-    const normalized = searchQuery.toLowerCase()
-    return sessionSearch.sessions
-      .filter((session) => {
-        if (!normalized) return true
-        const title = session.title || session.id
-        return title.toLowerCase().includes(normalized) || session.id.toLowerCase().includes(normalized)
-      })
-      .slice(0, 8)
+    const results = sessionSearch.search
+      ? sessionSearch.search(sessionSearch.sessions, searchQuery)
+      : defaultSessionSearch(sessionSearch.sessions, searchQuery)
+    return results.slice(0, 8)
   }, [isChatMode, searchQuery, sessionSearch])
 
   const {

--- a/packages/workspace/src/front/components/CommandPalette.tsx
+++ b/packages/workspace/src/front/components/CommandPalette.tsx
@@ -68,7 +68,7 @@ export interface CommandPaletteProps {
 export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState("")
-  const [mode, setMode] = useState<PaletteMode>("catalogs")
+  const [mode, setMode] = useState<PaletteMode>(() => sessionSearch ? "chats" : "catalogs")
   const catalogs = useCatalogs()
   const commands = useCommands()
   const workspaceCtx = useWorkspaceContextOptional()
@@ -79,12 +79,15 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
     }
     return map
   }, [workspaceCtx?.registeredPlugins])
+  const hasChatMode = Boolean(sessionSearch)
+  const isChatMode = mode === "chats"
+  const isCatalogMode = mode === "catalogs"
   const isCommandMode = mode === "commands"
   const searchQuery = query.trim()
 
   const catalogGroups = useCommandPaletteCatalogSearch({
     catalogs,
-    isCommandMode,
+    isCommandMode: !isCatalogMode,
     searchQuery,
   })
 
@@ -94,6 +97,7 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
     mode,
     setMode,
     setQuery,
+    defaultMode: hasChatMode ? "chats" : "catalogs",
   })
 
   const handleQueryChange = useCallback((next: string) => {
@@ -111,7 +115,7 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
   }, [commands, isCommandMode, searchQuery])
 
   const sessionResults = useMemo(() => {
-    if (!sessionSearch || isCommandMode) return []
+    if (!sessionSearch || !isChatMode) return []
     const normalized = searchQuery.toLowerCase()
     return sessionSearch.sessions
       .filter((session) => {
@@ -120,7 +124,7 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
         return title.toLowerCase().includes(normalized) || session.id.toLowerCase().includes(normalized)
       })
       .slice(0, 8)
-  }, [isCommandMode, searchQuery, sessionSearch])
+  }, [isChatMode, searchQuery, sessionSearch])
 
   const {
     recentEntries,
@@ -151,12 +155,15 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
         <Command shouldFilter={false} className="flex min-h-0 flex-1 flex-col bg-transparent">
           <PaletteSearchHeader
             inputRef={inputRef}
+            hasChatMode={hasChatMode}
+            isChatMode={isChatMode}
+            isCatalogMode={isCatalogMode}
             isCommandMode={isCommandMode}
             query={query}
             onQueryChange={handleQueryChange}
             onInputKeyDown={handleInputKeyDown}
             onSwitchMode={switchMode}
-            loading={!isCommandMode && catalogGroups.some((group) => group.loading)}
+            loading={isCatalogMode && catalogGroups.some((group) => group.loading)}
           />
 
           <CommandList
@@ -164,24 +171,24 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
             style={{ maxHeight: "none" }}
           >
             <CommandEmpty className="py-10 text-center text-sm text-muted-foreground">
-              {isCommandMode ? "No matching commands" : "No catalog results"}
+              {isCommandMode ? "No matching commands" : isChatMode ? "No matching chats" : "No catalog results"}
             </CommandEmpty>
 
             <RecentResultsSection
-              isCommandMode={isCommandMode}
+              isCatalogMode={isCatalogMode}
               recentEntries={recentEntries}
               searchQuery={searchQuery}
               onRecentSelect={handleRecentSelect}
             />
             <SessionSearchResultsSection
-              isCommandMode={isCommandMode}
+              isChatMode={isChatMode}
               sessionSearch={sessionSearch}
               sessions={sessionResults}
               close={() => setOpen(false)}
             />
             <CatalogResultsSections
               catalogGroups={catalogGroups}
-              isCommandMode={isCommandMode}
+              isCatalogMode={isCatalogMode}
               onCatalogSelect={handleCatalogSelect}
             />
             <CommandResultsSection
@@ -192,7 +199,7 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
             />
           </CommandList>
 
-          <PaletteFooter isCommandMode={isCommandMode} />
+          <PaletteFooter mode={mode} />
         </Command>
       </DialogContent>
     </Dialog>
@@ -201,6 +208,9 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
 
 function PaletteSearchHeader({
   inputRef,
+  hasChatMode,
+  isChatMode,
+  isCatalogMode,
   isCommandMode,
   query,
   onQueryChange,
@@ -209,6 +219,9 @@ function PaletteSearchHeader({
   loading,
 }: {
   inputRef: React.RefObject<HTMLInputElement | null>
+  hasChatMode: boolean
+  isChatMode: boolean
+  isCatalogMode: boolean
   isCommandMode: boolean
   query: string
   onQueryChange: (next: string) => void
@@ -235,8 +248,16 @@ function PaletteSearchHeader({
           aria-label="Palette mode"
           className="my-2 ml-3 inline-flex shrink-0 self-center rounded-md border border-border/60 bg-muted/40 p-0.5"
         >
+          {hasChatMode ? (
+            <ModeButton
+              active={isChatMode}
+              icon={<MessageSquare className="size-3" />}
+              label="Chats"
+              onClick={() => onSwitchMode("chats")}
+            />
+          ) : null}
           <ModeButton
-            active={!isCommandMode}
+            active={isCatalogMode}
             icon={<FileIcon className="size-3" />}
             label={CATALOG_MODE_LABEL}
             onClick={() => onSwitchMode("catalogs")}
@@ -253,7 +274,9 @@ function PaletteSearchHeader({
           placeholder={
             isCommandMode
               ? "Run a command..."
-              : "Search catalogs or type > for commands"
+              : isChatMode
+                ? "Search chats..."
+                : "Search catalogs or type > for commands"
           }
           value={query}
           onValueChange={onQueryChange}
@@ -276,17 +299,17 @@ function PaletteSearchHeader({
 }
 
 function RecentResultsSection({
-  isCommandMode,
+  isCatalogMode,
   recentEntries,
   searchQuery,
   onRecentSelect,
 }: {
-  isCommandMode: boolean
+  isCatalogMode: boolean
   recentEntries: RecentEntry[]
   searchQuery: string
   onRecentSelect: (entry: RecentEntry) => void
 }) {
-  if (isCommandMode || recentEntries.length === 0 || searchQuery) return null
+  if (!isCatalogMode || recentEntries.length === 0 || searchQuery) return null
 
   return (
     <CommandGroup heading="Recent">
@@ -324,22 +347,22 @@ function RecentResultsSection({
 }
 
 function SessionSearchResultsSection({
-  isCommandMode,
+  isChatMode,
   sessionSearch,
   sessions,
   close,
 }: {
-  isCommandMode: boolean
+  isChatMode: boolean
   sessionSearch?: CommandPaletteSessionSearchConfig
   sessions: CommandPaletteSessionItem[]
   close: () => void
 }) {
-  if (isCommandMode || !sessionSearch || sessions.length === 0) return null
+  if (!isChatMode || !sessionSearch || sessions.length === 0) return null
   const openSet = new Set(sessionSearch.openIds ?? [])
   const activeId = sessionSearch.activeId ?? null
 
   return (
-    <CommandGroup heading="Chat session search">
+    <CommandGroup heading="Chats">
       {sessions.map((session) => {
         const title = session.title || "Untitled"
         const active = session.id === activeId
@@ -394,14 +417,14 @@ function SessionSearchResultsSection({
 
 function CatalogResultsSections({
   catalogGroups,
-  isCommandMode,
+  isCatalogMode,
   onCatalogSelect,
 }: {
   catalogGroups: CatalogSearchGroup[]
-  isCommandMode: boolean
+  isCatalogMode: boolean
   onCatalogSelect: (catalog: CatalogConfig, row: CatalogRow) => void
 }) {
-  if (isCommandMode) return null
+  if (!isCatalogMode) return null
 
   return (
     <>
@@ -484,11 +507,12 @@ function CommandResultsSection({
   )
 }
 
-function PaletteFooter({ isCommandMode }: { isCommandMode: boolean }) {
+function PaletteFooter({ mode }: { mode: PaletteMode }) {
+  const label = mode === "commands" ? "Commands" : mode === "chats" ? "Chats" : CATALOG_MODE_LABEL
   return (
     <div className="flex items-center justify-between border-t border-border/50 bg-muted/30 px-3 py-2 text-[11px] text-muted-foreground">
       <span className="font-medium tracking-wide uppercase">
-        {isCommandMode ? "Commands" : CATALOG_MODE_LABEL}
+        {label}
       </span>
       <div className="flex items-center gap-3">
         <span className="flex items-center gap-1">

--- a/packages/workspace/src/front/components/CommandPalette.tsx
+++ b/packages/workspace/src/front/components/CommandPalette.tsx
@@ -142,9 +142,10 @@ export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
-        className="cmdk-shell flex flex-col gap-0 overflow-hidden border-border/60 p-0 shadow-2xl backdrop-blur-md [&>button.dialog-close]:hidden"
+        className="cmdk-shell flex flex-col gap-0 overflow-hidden border-border/60 bg-background p-0 shadow-none backdrop-blur-0 [&>button.dialog-close]:hidden"
         style={{ height: 520, width: "min(640px, calc(100vw - 2rem))", maxWidth: 640 }}
         showCloseButton={false}
+        overlayClassName="bg-transparent"
         onPointerDownOutside={() => setOpen(false)}
         onEscapeKeyDown={() => setOpen(false)}
       >

--- a/packages/workspace/src/front/components/CommandPalette.tsx
+++ b/packages/workspace/src/front/components/CommandPalette.tsx
@@ -31,6 +31,7 @@ import {
 } from "@hachej/boring-ui-kit"
 import { useCatalogs } from "../plugin/useCatalogs"
 import { useCommands } from "../plugin/useCommands"
+import { postUiCommand } from "../bridge"
 import {
   CATALOG_MODE_LABEL,
   searchCommands,
@@ -42,7 +43,7 @@ import { useWorkspaceContextOptional } from "../provider/WorkspaceProvider"
 import { useCommandPaletteSelection } from "./useCommandPaletteSelection"
 import { useCommandPaletteChrome } from "./useCommandPaletteChrome"
 import { useCommandPaletteCatalogSearch } from "./useCommandPaletteCatalogSearch"
-import type { CatalogConfig, CatalogRow } from "../../shared/plugins/types"
+import type { CatalogConfig, CatalogRow, CatalogSearchResult } from "../../shared/plugins/types"
 import type { CommandConfig } from "../registry/types"
 import type { RecentEntry } from "./recent"
 
@@ -65,11 +66,72 @@ export interface CommandPaletteProps {
   sessionSearch?: CommandPaletteSessionSearchConfig
 }
 
+const FILES_CATALOG_ID = "files"
+
+function fileRowFromPath(path: string): CatalogRow {
+  const lastSlash = path.lastIndexOf("/")
+  return {
+    id: path,
+    title: lastSlash >= 0 ? path.slice(lastSlash + 1) : path,
+    subtitle: lastSlash >= 0 ? path.slice(0, lastSlash + 1) : undefined,
+  }
+}
+
+function toFileSearchGlob(query: string): string {
+  const trimmed = query.trim()
+  if (!trimmed) return trimmed
+  const glob = /[*?\[\]{}]/.test(trimmed) ? trimmed : `*${trimmed}*`
+  return glob.replace(/[a-z]/gi, (char) => {
+    const lower = char.toLowerCase()
+    const upper = char.toUpperCase()
+    return lower === upper ? char : `[${upper}${lower}]`
+  })
+}
+
+function emptySearchResult(): CatalogSearchResult {
+  return { items: [], total: 0, hasMore: false }
+}
+
+function createFallbackFilesCatalog(): CatalogConfig {
+  return {
+    id: FILES_CATALOG_ID,
+    label: "Files",
+    adapter: {
+      async search({ query, limit, signal }) {
+        const trimmed = query.trim()
+        if (!trimmed || signal?.aborted) return emptySearchResult()
+        const params = new URLSearchParams({ q: toFileSearchGlob(trimmed) })
+        if (limit != null) params.set("limit", String(limit))
+        const response = await fetch(`/api/v1/files/search?${params.toString()}`, {
+          credentials: "include",
+          signal,
+        })
+        if (!response.ok) throw new Error(`File search failed (${response.status})`)
+        const payload = await response.json() as { results?: unknown }
+        const paths = Array.isArray(payload.results)
+          ? payload.results.filter((path): path is string => typeof path === "string")
+          : []
+        if (signal?.aborted) return emptySearchResult()
+        return { items: paths.map(fileRowFromPath), total: paths.length, hasMore: false }
+      },
+    },
+    onSelect(row) {
+      postUiCommand({ kind: "openFile", params: { path: row.id } })
+    },
+  }
+}
+
 export function CommandPalette({ sessionSearch }: CommandPaletteProps = {}) {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState("")
   const [mode, setMode] = useState<PaletteMode>(() => sessionSearch ? "chats" : "catalogs")
-  const catalogs = useCatalogs()
+  const registeredCatalogs = useCatalogs()
+  const fallbackFilesCatalog = useMemo(createFallbackFilesCatalog, [])
+  const catalogs = useMemo(() => (
+    registeredCatalogs.some((catalog) => catalog.id === FILES_CATALOG_ID)
+      ? registeredCatalogs
+      : [fallbackFilesCatalog, ...registeredCatalogs]
+  ), [fallbackFilesCatalog, registeredCatalogs])
   const commands = useCommands()
   const workspaceCtx = useWorkspaceContextOptional()
   const pluginLabelMap = useMemo(() => {

--- a/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
+++ b/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { CommandPalette } from "../CommandPalette"
+import { UI_COMMAND_EVENT, type UiCommand } from "../../bridge"
 import { RegistryProvider } from "../../registry/RegistryProvider"
 import { PanelRegistry } from "../../registry/PanelRegistry"
 import { CommandRegistry } from "../../../shared/plugins/CommandRegistry"
@@ -141,6 +142,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe("CommandPalette", () => {
@@ -297,6 +299,39 @@ describe("CommandPalette", () => {
         expect(getFileOption("/src/App.tsx")).toBeInTheDocument()
         expect(getFileOption("/src/index.ts")).toBeInTheDocument()
       })
+    })
+
+    it("falls back to workspace file search when no files catalog is registered", async () => {
+      const user = userEvent.setup()
+      vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes("/api/v1/files/search")) {
+          return new Response(JSON.stringify({ results: ["README.md", "src/readme-helper.ts"] }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })
+        }
+        return new Response(null, { status: 404 })
+      }))
+      const commands: UiCommand[] = []
+      const onUiCommand = (event: Event) => commands.push((event as CustomEvent<UiCommand>).detail)
+      window.addEventListener(UI_COMMAND_EVENT, onUiCommand)
+      try {
+        render(<CommandPalette />, { wrapper: createWrapper() })
+        fireKeydown("p", { metaKey: true })
+        await waitFor(() => {
+          expect(screen.getByRole("dialog")).toBeInTheDocument()
+        })
+        await typePaletteQuery(user, "readme")
+        await waitFor(() => {
+          expect(getFileOption("README.md")).toBeInTheDocument()
+          expect(getFileOption("src/readme-helper.ts")).toBeInTheDocument()
+        })
+        await user.click(getFileOption("README.md"))
+        expect(commands).toContainEqual({ kind: "openFile", params: { path: "README.md" } })
+      } finally {
+        window.removeEventListener(UI_COMMAND_EVENT, onUiCommand)
+      }
     })
 
     it("calls catalog onSelect when row is selected", async () => {

--- a/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
+++ b/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
@@ -239,6 +239,39 @@ describe("CommandPalette", () => {
   })
 
   describe("chat session search", () => {
+    it("uses an injected session search adapter before rendering chat results", async () => {
+      const user = userEvent.setup()
+      const onSwitch = vi.fn()
+      const onOpenAsTab = vi.fn()
+      const search = vi.fn((sessions: readonly { id: string; title?: string | null }[], query: string) => (
+        query === "bbp" ? sessions.filter((session) => session.id === "session-b") : [...sessions]
+      ))
+
+      render(
+        <CommandPalette
+          sessionSearch={{
+            sessions: [
+              { id: "session-a", title: "Alpha plan" },
+              { id: "session-b", title: "Beta build polish" },
+            ],
+            activeId: "session-a",
+            openIds: ["session-a"],
+            search,
+            onSwitch,
+            onOpenAsTab,
+          }}
+        />,
+        { wrapper: createWrapper() },
+      )
+
+      fireKeydown("k", { metaKey: true })
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+      await typePaletteQuery(user, "bbp")
+      expect(search).toHaveBeenLastCalledWith(expect.any(Array), "bbp")
+      expect(screen.getByRole("option", { name: /Beta build polish/ })).toBeInTheDocument()
+      expect(screen.queryByRole("option", { name: /Alpha plan/ })).not.toBeInTheDocument()
+    })
+
     it("shows session results and routes select/split actions", async () => {
       const user = userEvent.setup()
       const onSwitch = vi.fn()

--- a/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
+++ b/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
@@ -260,7 +260,9 @@ describe("CommandPalette", () => {
 
       fireKeydown("k", { metaKey: true })
       await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
-      expect(screen.getByText("Chat session search")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Chats" })).toHaveAttribute("aria-pressed", "true")
+      expect(screen.getByRole("button", { name: "Catalogs" })).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Commands" })).toBeInTheDocument()
 
       await typePaletteQuery(user, "beta")
       await user.click(screen.getByRole("option", { name: /Beta build/ }))

--- a/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
+++ b/packages/workspace/src/front/components/__tests__/CommandPalette.test.tsx
@@ -236,6 +236,45 @@ describe("CommandPalette", () => {
     })
   })
 
+  describe("chat session search", () => {
+    it("shows session results and routes select/split actions", async () => {
+      const user = userEvent.setup()
+      const onSwitch = vi.fn()
+      const onOpenAsTab = vi.fn()
+
+      render(
+        <CommandPalette
+          sessionSearch={{
+            sessions: [
+              { id: "session-a", title: "Alpha plan" },
+              { id: "session-b", title: "Beta build" },
+            ],
+            activeId: "session-a",
+            openIds: ["session-a"],
+            onSwitch,
+            onOpenAsTab,
+          }}
+        />,
+        { wrapper: createWrapper() },
+      )
+
+      fireKeydown("k", { metaKey: true })
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+      expect(screen.getByText("Chat session search")).toBeInTheDocument()
+
+      await typePaletteQuery(user, "beta")
+      await user.click(screen.getByRole("option", { name: /Beta build/ }))
+      expect(onSwitch).toHaveBeenCalledWith("session-b")
+      await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument())
+
+      fireKeydown("k", { metaKey: true })
+      await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument())
+      await typePaletteQuery(user, "alpha")
+      await user.click(screen.getByRole("button", { name: "Open Alpha plan in new chat pane" }))
+      expect(onOpenAsTab).toHaveBeenCalledWith("session-a")
+    })
+  })
+
   describe("catalog quick-open", () => {
     it("shows catalog results from registered catalogs", async () => {
       const user = userEvent.setup()

--- a/packages/workspace/src/front/components/commandPaletteHelpers.ts
+++ b/packages/workspace/src/front/components/commandPaletteHelpers.ts
@@ -5,7 +5,7 @@ import type { RecentEntry } from './recent'
 export const MAX_RESULTS = 50
 export const CATALOG_MODE_LABEL = 'Catalogs'
 
-export type PaletteMode = 'catalogs' | 'commands'
+export type PaletteMode = 'chats' | 'catalogs' | 'commands'
 
 export interface CatalogSearchGroup {
   catalog: CatalogConfig

--- a/packages/workspace/src/front/components/useCommandPaletteChrome.ts
+++ b/packages/workspace/src/front/components/useCommandPaletteChrome.ts
@@ -8,12 +8,14 @@ export function useCommandPaletteChrome({
   mode,
   setMode,
   setQuery,
+  defaultMode = 'catalogs',
 }: {
   open: boolean
   setOpen: Dispatch<SetStateAction<boolean>>
   mode: PaletteMode
   setMode: Dispatch<SetStateAction<PaletteMode>>
   setQuery: Dispatch<SetStateAction<string>>
+  defaultMode?: PaletteMode
 }) {
   const inputRef = useRef<HTMLInputElement>(null)
   const priorFocusRef = useRef<HTMLElement | null>(null)
@@ -78,7 +80,7 @@ export function useCommandPaletteChrome({
   useEffect(() => {
     if (open) {
       setQuery('')
-      setMode('catalogs')
+      setMode(defaultMode)
       requestAnimationFrame(() => {
         inputRef.current?.focus()
       })
@@ -90,7 +92,7 @@ export function useCommandPaletteChrome({
       priorFocusRef.current = null
     }
     wasOpenRef.current = open
-  }, [open, setMode, setQuery])
+  }, [defaultMode, open, setMode, setQuery])
 
   const switchMode = useCallback((nextMode: PaletteMode) => {
     setMode(nextMode)
@@ -99,8 +101,12 @@ export function useCommandPaletteChrome({
   }, [setMode, setQuery])
 
   const toggleMode = useCallback(() => {
+    if (defaultMode === 'chats') {
+      switchMode(mode === 'chats' ? 'catalogs' : mode === 'catalogs' ? 'commands' : 'chats')
+      return
+    }
     switchMode(mode === 'commands' ? 'catalogs' : 'commands')
-  }, [mode, switchMode])
+  }, [defaultMode, mode, switchMode])
 
   const handleInputKeyDown = useCallback((event: KeyboardEvent<HTMLInputElement>) => {
     if (event.key !== 'Tab') return

--- a/packages/workspace/src/front/dock/dockview-overrides.css
+++ b/packages/workspace/src/front/dock/dockview-overrides.css
@@ -67,11 +67,11 @@
 /* The app shell renders fixed top-right workbench/full-workspace controls
    over this 44px tab strip. Reserve enough room so dockview's built-in open-tabs
    overflow trigger sits left of that chrome instead of underneath it.
-   Two 36px controls + 6px gap anchored at right-3 (12px) reach ~90px from the
-   right edge; 100px keeps them clear with breathing room. */
+   Two 24px controls + 4px gap anchored at right-3 (12px) reach ~64px from the
+   right edge; 72px keeps them clear with breathing room. */
 .workbench-dockview .dv-tabs-and-actions-container,
 .workbench-dockview .tabs-and-actions-container {
-  padding-right: 100px !important;
+  padding-right: 72px !important;
 }
 
 /* Tab base — pill-style, rounded top */

--- a/packages/workspace/src/front/dock/dockview-overrides.css
+++ b/packages/workspace/src/front/dock/dockview-overrides.css
@@ -64,16 +64,12 @@
   padding-left: 44px !important;
 }
 
-/* The workbench renders a "close workspace" control as an absolute overlay on
-   the right edge of the tab strip (see SurfaceShell's WorkbenchCloseAction:
-   a 24px icon button + 4px margins each side = ~32px wide, vertically centred
-   in the 44px bar). Reserve room at the right of the tab strip so dockview's
-   built-in "open tabs" overflow dropdown trigger (the ⌄ chevron at the end of
-   the tab row) sits clearly LEFT of that control with a visible gap, instead of
-   tucking right under it. 32px control + ~8px gap + the chevron's own width. */
+/* The app shell renders fixed top-right workbench/full-workspace controls
+   over this 44px tab strip. Reserve enough room so dockview's built-in open-tabs
+   overflow trigger sits left of that chrome instead of underneath it. */
 .workbench-dockview .dv-tabs-and-actions-container,
 .workbench-dockview .tabs-and-actions-container {
-  padding-right: 44px !important;
+  padding-right: 88px !important;
 }
 
 /* Tab base — pill-style, rounded top */

--- a/packages/workspace/src/front/dock/dockview-overrides.css
+++ b/packages/workspace/src/front/dock/dockview-overrides.css
@@ -64,6 +64,18 @@
   padding-left: 44px !important;
 }
 
+/* Plugin-tabs shell: when the app-navigation left pane is collapsed, the
+   fixed top-left "Open app navigation" corner control (24px at left-3,
+   right edge x=36) overlays the chat stage. Reserve header-only space on the
+   chat stage's flat pane header so the session title clears that control
+   instead of sitting underneath it. Only applies in the collapsed state; when
+   the left pane is open the control sits over the app-nav header, not the
+   chat. 48px = control right edge (36) + 12px gap. */
+[data-boring-workspace-part="plugin-tabs-shell"][data-boring-state="collapsed"] .dv-chat-stage .dv-tabs-and-actions-container,
+[data-boring-workspace-part="plugin-tabs-shell"][data-boring-state="collapsed"] .dv-chat-stage .tabs-and-actions-container {
+  padding-left: 48px !important;
+}
+
 /* The app shell renders fixed top-right workbench/full-workspace controls
    over this 44px tab strip. Reserve enough room so dockview's built-in open-tabs
    overflow trigger sits left of that chrome instead of underneath it.

--- a/packages/workspace/src/front/dock/dockview-overrides.css
+++ b/packages/workspace/src/front/dock/dockview-overrides.css
@@ -66,10 +66,12 @@
 
 /* The app shell renders fixed top-right workbench/full-workspace controls
    over this 44px tab strip. Reserve enough room so dockview's built-in open-tabs
-   overflow trigger sits left of that chrome instead of underneath it. */
+   overflow trigger sits left of that chrome instead of underneath it.
+   Two 36px controls + 6px gap anchored at right-3 (12px) reach ~90px from the
+   right edge; 100px keeps them clear with breathing room. */
 .workbench-dockview .dv-tabs-and-actions-container,
 .workbench-dockview .tabs-and-actions-container {
-  padding-right: 88px !important;
+  padding-right: 100px !important;
 }
 
 /* Tab base — pill-style, rounded top */

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,6 +1,6 @@
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType, type ReactNode } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
-import { ChevronLeft, MessageSquare } from "lucide-react"
+import { Maximize2, Minimize2, PanelRight } from "lucide-react"
 import { cn } from "../lib/utils"
 import { ControlTooltip } from "../components/ControlTooltip"
 import { dispatchUiCommand, type DispatchContext } from "../bridge"
@@ -396,26 +396,6 @@ export function ChatLayout(props: ChatLayoutProps) {
               <PanelSlot id={centerId} params={props.centerParams} />
             )}
           </div>
-          {!chatCollapsed ? (
-            <ControlTooltip label="Collapse chat" hint="⌘\" side="bottom">
-              <IconButton
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                onClick={toggleChatCollapsed}
-                // With multiple panes the rightmost pane header owns the
-                // top-right corner; drop the collapse control to the
-                // bottom-right so the two never overlap.
-                className={cn(
-                  "absolute right-2 z-30 rounded-full bg-background/80 text-muted-foreground shadow-sm backdrop-blur hover:bg-muted hover:text-foreground",
-                  hasChatPanes && chatPanes.length > 1 ? "bottom-2" : "top-2",
-                )}
-                aria-label="Collapse chat"
-              >
-                <ChevronLeft className="h-4 w-4" strokeWidth={1.75} />
-              </IconButton>
-            </ControlTooltip>
-          ) : null}
         </main>
 
         {surfaceConfigured ? (
@@ -448,29 +428,11 @@ export function ChatLayout(props: ChatLayoutProps) {
                 "h-full min-h-0 overflow-hidden",
                 "transition-[opacity,padding] duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
                 surfaceOpen ? "opacity-100" : "opacity-0",
-                // When the chat is collapsed the workbench fills the full width
-                // and the left-edge "expand chat" float button would sit on top
-                // of the filetree — inset the content to leave a clear gutter.
-                chatCollapsed && surfaceOpen && !navOpen && "pl-14",
               )}
             >
               {props.surfaceOverlay ? (
                 <div className="relative h-full min-h-0">
                   {props.surfaceOverlay}
-                  {closeSurface ? (
-                    <ControlTooltip label="Close workbench" hint="⌘2" side="left">
-                      <IconButton
-                        type="button"
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={closeSurface}
-                        className="absolute right-3 top-3 z-20 rounded-full bg-background/80 text-muted-foreground shadow-sm backdrop-blur hover:bg-muted hover:text-foreground"
-                        aria-label="Close workbench"
-                      >
-                        <span aria-hidden="true">›</span>
-                      </IconButton>
-                    </ControlTooltip>
-                  ) : null}
                 </div>
               ) : <PanelSlot id={surfaceId} params={props.surfaceParams} />}
             </div>
@@ -485,6 +447,17 @@ export function ChatLayout(props: ChatLayoutProps) {
         ) : null}
 
       </div>
+
+      <TopRightWorkspaceControls
+        surfaceOpen={surfaceOpen}
+        canToggleSurface={canControlSurface}
+        onToggleSurface={toggleSurface}
+        chatCollapsed={chatCollapsed}
+        canToggleChat={centerId === "chat"}
+        onToggleChat={toggleChatCollapsed}
+        chatPulse={chatRailPulse || blockers.length > 0}
+        surfaceConfigured={surfaceConfigured}
+      />
 
       {!navOpen && props.onOpenNav ? (
         <FloatingEdgeButton
@@ -507,30 +480,6 @@ export function ChatLayout(props: ChatLayoutProps) {
           // Sits directly above the Sessions toggle; when the session drawer
           // is open the drawer's own header "+" takes over and this hides.
           stackIndex={props.onOpenNav ? 1 : 0}
-        />
-      ) : null}
-      {chatCollapsed ? (
-        <FloatingEdgeButton
-          side="left"
-          icon="chat"
-          onClick={toggleChatCollapsed}
-          label="Expand chat"
-          hint="⌘\\"
-          // Anchored to the shell's left edge (not the content region) so it
-          // stays pinned to the left even when the session drawer is open and
-          // pushes the content rightward.
-          stackIndex={1}
-          pulse={chatRailPulse || blockers.length > 0}
-        />
-      ) : null}
-      {!surfaceOpen && props.onOpenSurface ? (
-        <FloatingEdgeButton
-          side="right"
-          icon="workbench"
-          onClick={props.onOpenSurface}
-          label="Workbench"
-          hint="⌘2"
-          bottomOffset={props.surfaceButtonBottomOffset}
         />
       ) : null}
     </div>
@@ -741,6 +690,103 @@ function createPanelApi(id: string): Partial<PaneProps["api"]> {
   } as Partial<PaneProps["api"]>
 }
 
+function TopRightWorkspaceControls({
+  surfaceOpen,
+  canToggleSurface,
+  onToggleSurface,
+  chatCollapsed,
+  canToggleChat,
+  onToggleChat,
+  chatPulse,
+  surfaceConfigured,
+}: {
+  surfaceOpen: boolean
+  canToggleSurface: boolean
+  onToggleSurface: () => void
+  chatCollapsed: boolean
+  canToggleChat: boolean
+  onToggleChat: () => void
+  chatPulse: boolean
+  surfaceConfigured: boolean
+}) {
+  const showSurfaceToggle = canToggleSurface
+  const showChatToggle = canToggleChat
+  if (!showSurfaceToggle && !showChatToggle) return null
+
+  const chatLabel = chatCollapsed
+    ? "Show chat"
+    : surfaceConfigured ? "Expand workbench" : "Collapse chat"
+
+  return (
+    <div className="pointer-events-none absolute right-3 top-3 z-[70] flex items-center gap-1">
+      {showChatToggle ? (
+        <CornerChromeButton
+          label={chatLabel}
+          hint="⌘\\"
+          onClick={onToggleChat}
+          pressed={chatCollapsed}
+          pulse={chatPulse}
+        >
+          {chatCollapsed ? (
+            <Minimize2 className="h-4 w-4" strokeWidth={1.75} />
+          ) : (
+            <Maximize2 className="h-4 w-4" strokeWidth={1.75} />
+          )}
+        </CornerChromeButton>
+      ) : null}
+      {showSurfaceToggle ? (
+        <CornerChromeButton
+          label={surfaceOpen ? "Close workbench" : "Open workbench"}
+          hint="⌘2"
+          onClick={onToggleSurface}
+          pressed={surfaceOpen}
+        >
+          <PanelRight className="h-4 w-4" strokeWidth={1.75} />
+        </CornerChromeButton>
+      ) : null}
+    </div>
+  )
+}
+
+function CornerChromeButton({
+  label,
+  hint,
+  onClick,
+  pressed,
+  pulse = false,
+  children,
+}: {
+  label: string
+  hint?: string
+  onClick: () => void
+  pressed: boolean
+  pulse?: boolean
+  children: ReactNode
+}) {
+  return (
+    <ControlTooltip label={label} hint={hint} side="bottom">
+      <IconButton
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={onClick}
+        aria-label={label}
+        aria-pressed={pressed}
+        title={label}
+        className={cn(
+          "pointer-events-auto relative h-9 w-9 rounded-xl bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_10px_-5px_oklch(0_0_0/0.18),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-ring/40",
+          pressed && "bg-foreground/[0.09] text-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.10),0_4px_14px_-6px_oklch(0_0_0/0.22),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.9)]",
+        )}
+      >
+        {children}
+        {pulse ? (
+          <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-[color:var(--accent)]" aria-hidden="true" />
+        ) : null}
+      </IconButton>
+    </ControlTooltip>
+  )
+}
+
 function FloatingEdgeButton({
   side,
   icon,
@@ -749,10 +795,9 @@ function FloatingEdgeButton({
   hint,
   bottomOffset,
   stackIndex = 0,
-  pulse = false,
 }: {
   side: "left" | "right"
-  icon: "sessions" | "workbench" | "chat" | "plus"
+  icon: "sessions" | "plus"
   onClick: () => void
   label: string
   hint?: string
@@ -760,7 +805,6 @@ function FloatingEdgeButton({
   // Stack offset for multiple buttons sharing the same vertical edge anchor.
   // Each step lifts the button by one button-height + gap above the previous.
   stackIndex?: number
-  pulse?: boolean
 }) {
   const dockToBottom = side === "right" && bottomOffset !== undefined
   // Buttons are h-9 (36px); stack them with a 8px gap so they never overlap.
@@ -792,20 +836,9 @@ function FloatingEdgeButton({
           <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="1.8" />
           <path d="M12 7v5l3.2 2" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
         </svg>
-      ) : icon === "chat" ? (
-        <span className="relative flex items-center justify-center">
-          <MessageSquare className="h-[15px] w-[15px]" strokeWidth={1.8} aria-hidden="true" />
-          {pulse ? (
-            <span className="absolute -right-1.5 -top-1.5 h-2 w-2 rounded-full bg-[color:var(--accent)]" aria-hidden="true" />
-          ) : null}
-        </span>
-      ) : icon === "plus" ? (
-        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
-        </svg>
       ) : (
         <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-          <path d="M3 7.5 A1.5 1.5 0 0 1 4.5 6 h4 l2 2 h9 A1.5 1.5 0 0 1 21 9.5 V17.5 A1.5 1.5 0 0 1 19.5 19 H4.5 A1.5 1.5 0 0 1 3 17.5 Z" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" />
+          <path d="M12 5v14M5 12h14" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
         </svg>
       )}
     </IconButton>

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -402,7 +402,7 @@ export function ChatLayout(props: ChatLayoutProps) {
               data-boring-workspace-part="chat-left-overlay"
               className="absolute inset-0 z-40 flex bg-background"
             >
-              <div className="flex h-full w-full max-w-[520px] flex-col border-r border-border bg-background">
+              <div className="flex h-full w-full flex-col border-r border-border bg-background">
                 {props.chatOverlay}
               </div>
             </div>

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -719,7 +719,7 @@ function TopRightWorkspaceControls({
     : surfaceConfigured ? "Expand workbench" : "Collapse chat"
 
   return (
-    <div className="pointer-events-none absolute right-3 top-2 z-[70] flex items-center gap-1.5">
+    <div className="pointer-events-none absolute right-3 top-2.5 z-[70] flex items-center gap-1">
       {showChatToggle ? (
         <CornerChromeButton
           label={chatLabel}
@@ -729,9 +729,9 @@ function TopRightWorkspaceControls({
           pulse={chatPulse}
         >
           {chatCollapsed ? (
-            <Minimize2 className="h-4 w-4" strokeWidth={1.75} />
+            <Minimize2 className="size-3" strokeWidth={1.75} />
           ) : (
-            <Maximize2 className="h-4 w-4" strokeWidth={1.75} />
+            <Maximize2 className="size-3" strokeWidth={1.75} />
           )}
         </CornerChromeButton>
       ) : null}
@@ -742,7 +742,7 @@ function TopRightWorkspaceControls({
           onClick={onToggleSurface}
           pressed={surfaceOpen}
         >
-          <PanelRight className="h-4 w-4" strokeWidth={1.75} />
+          <PanelRight className="size-3" strokeWidth={1.75} />
         </CornerChromeButton>
       ) : null}
     </div>

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
-import { Maximize2, Minimize2, PanelRight } from "lucide-react"
+import { Maximize2, Minimize2, PanelRightClose, PanelRightOpen } from "lucide-react"
 import { cn } from "../lib/utils"
 import { ControlTooltip } from "../components/ControlTooltip"
 import { dispatchUiCommand, type DispatchContext } from "../bridge"
@@ -768,7 +768,11 @@ function TopRightWorkspaceControls({
           onClick={onToggleSurface}
           pressed={surfaceOpen}
         >
-          <PanelRight className="size-3" strokeWidth={1.75} />
+          {surfaceOpen ? (
+            <PanelRightClose className="size-3" strokeWidth={1.75} />
+          ) : (
+            <PanelRightOpen className="size-3" strokeWidth={1.75} />
+          )}
         </CornerChromeButton>
       ) : null}
     </div>

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
-import { Maximize2, Minimize2, PanelRight } from "lucide-react"
+import { Maximize2, Minimize2, PanelRightClose, PanelRightOpen } from "lucide-react"
 import { cn } from "../lib/utils"
 import { ControlTooltip } from "../components/ControlTooltip"
 import { dispatchUiCommand, type DispatchContext } from "../bridge"
@@ -397,6 +397,16 @@ export function ChatLayout(props: ChatLayoutProps) {
               <PanelSlot id={centerId} params={props.centerParams} />
             )}
           </div>
+          {!chatCollapsed && props.chatOverlay ? (
+            <div
+              data-boring-workspace-part="chat-left-overlay"
+              className="absolute inset-0 z-40 flex bg-background"
+            >
+              <div className="mx-auto flex w-full max-w-2xl flex-col border-x border-border bg-background">
+                {props.chatOverlay}
+              </div>
+            </div>
+          ) : null}
         </main>
 
         {surfaceConfigured ? (
@@ -742,7 +752,11 @@ function TopRightWorkspaceControls({
           onClick={onToggleSurface}
           pressed={surfaceOpen}
         >
-          <PanelRight className="size-3" strokeWidth={1.75} />
+          {surfaceOpen ? (
+            <PanelRightClose className="size-3" strokeWidth={1.75} />
+          ) : (
+            <PanelRightOpen className="size-3" strokeWidth={1.75} />
+          )}
         </CornerChromeButton>
       ) : null}
     </div>

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -301,6 +301,15 @@ export function ChatLayout(props: ChatLayoutProps) {
     }
   }, [activeSessionId, chatCollapsed, setChatCollapsed])
 
+  // On compact widths, a fixed workbench beside app navigation can crush the
+  // chat into an unusable sliver. Prefer a calm one-pane workbench takeover:
+  // the workbench fills the available center area and the chat can be restored
+  // from the stable top-right chrome.
+  useEffect(() => {
+    if (!surfaceOpen || chatCollapsed) return
+    if (viewport < 1180) setChatCollapsed(true)
+  }, [chatCollapsed, setChatCollapsed, surfaceOpen, viewport])
+
   // Never leave a blank middle: if the workbench is closed while the chat is
   // collapsed, re-open the chat. Mirror of "collapsing the chat opens the
   // workbench" so at least one of the two is always visible.

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -774,7 +774,7 @@ function CornerChromeButton({
         aria-pressed={pressed}
         title={label}
         className={cn(
-          "pointer-events-auto relative h-9 w-9 rounded-xl bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_10px_-5px_oklch(0_0_0/0.18),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-ring/40",
+          "pointer-events-auto relative !h-9 !w-9 rounded-xl bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_10px_-5px_oklch(0_0_0/0.18),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-ring/40",
           pressed && "bg-foreground/[0.09] text-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.10),0_4px_14px_-6px_oklch(0_0_0/0.22),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.9)]",
         )}
       >

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType, type ReactNode } from "react"
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
 import { Maximize2, Minimize2, PanelRight } from "lucide-react"
 import { cn } from "../lib/utils"
@@ -14,6 +14,7 @@ import { readStoredNumber, writeStoredNumber } from "../store/localStorageValues
 import type { ChatLayoutProps } from "./types"
 import { useWorkspaceAttention, useWorkspaceContext } from "../provider"
 import { ChatPaneStage } from "./ChatPaneStage"
+import { CornerChromeButton } from "./cornerChrome"
 
 export function buildChatLayout(props: ChatLayoutProps = {}): LayoutConfig {
   const {
@@ -718,7 +719,7 @@ function TopRightWorkspaceControls({
     : surfaceConfigured ? "Expand workbench" : "Collapse chat"
 
   return (
-    <div className="pointer-events-none absolute right-3 top-3 z-[70] flex items-center gap-1">
+    <div className="pointer-events-none absolute right-3 top-2 z-[70] flex items-center gap-1.5">
       {showChatToggle ? (
         <CornerChromeButton
           label={chatLabel}
@@ -745,45 +746,6 @@ function TopRightWorkspaceControls({
         </CornerChromeButton>
       ) : null}
     </div>
-  )
-}
-
-function CornerChromeButton({
-  label,
-  hint,
-  onClick,
-  pressed,
-  pulse = false,
-  children,
-}: {
-  label: string
-  hint?: string
-  onClick: () => void
-  pressed: boolean
-  pulse?: boolean
-  children: ReactNode
-}) {
-  return (
-    <ControlTooltip label={label} hint={hint} side="bottom">
-      <IconButton
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        onClick={onClick}
-        aria-label={label}
-        aria-pressed={pressed}
-        title={label}
-        className={cn(
-          "pointer-events-auto relative !h-9 !w-9 rounded-xl bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_10px_-5px_oklch(0_0_0/0.18),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-ring/40",
-          pressed && "bg-foreground/[0.09] text-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.10),0_4px_14px_-6px_oklch(0_0_0/0.22),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.9)]",
-        )}
-      >
-        {children}
-        {pulse ? (
-          <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-[color:var(--accent)]" aria-hidden="true" />
-        ) : null}
-      </IconButton>
-    </ControlTooltip>
   )
 }
 

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
-import { Maximize2, Minimize2, PanelRightClose, PanelRightOpen } from "lucide-react"
+import { Maximize2, Minimize2, PanelRight } from "lucide-react"
 import { cn } from "../lib/utils"
 import { ControlTooltip } from "../components/ControlTooltip"
 import { dispatchUiCommand, type DispatchContext } from "../bridge"
@@ -402,7 +402,7 @@ export function ChatLayout(props: ChatLayoutProps) {
               data-boring-workspace-part="chat-left-overlay"
               className="absolute inset-0 z-40 flex bg-background"
             >
-              <div className="mx-auto flex w-full max-w-2xl flex-col border-x border-border bg-background">
+              <div className="flex h-full w-full max-w-[520px] flex-col border-r border-border bg-background">
                 {props.chatOverlay}
               </div>
             </div>
@@ -752,11 +752,7 @@ function TopRightWorkspaceControls({
           onClick={onToggleSurface}
           pressed={surfaceOpen}
         >
-          {surfaceOpen ? (
-            <PanelRightClose className="size-3" strokeWidth={1.75} />
-          ) : (
-            <PanelRightOpen className="size-3" strokeWidth={1.75} />
-          )}
+          <PanelRight className="size-3" strokeWidth={1.75} />
         </CornerChromeButton>
       ) : null}
     </div>

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -306,9 +306,16 @@ export function ChatLayout(props: ChatLayoutProps) {
   // the workbench fills the available center area and the chat can be restored
   // from the stable top-right chrome.
   useEffect(() => {
-    if (!surfaceOpen || chatCollapsed) return
+    if (!surfaceOpen || chatCollapsed || props.chatOverlay) return
     if (viewport < 1180) setChatCollapsed(true)
-  }, [chatCollapsed, setChatCollapsed, surfaceOpen, viewport])
+  }, [chatCollapsed, props.chatOverlay, setChatCollapsed, surfaceOpen, viewport])
+
+  // Chat-hosted overlays (Skills/Plugins) must remain visible while workbench
+  // content opens beside them. If chat was collapsed by a previous compact
+  // workbench takeover, opening an overlay restores the chat area first.
+  useEffect(() => {
+    if (props.chatOverlay && chatCollapsed) setChatCollapsed(false)
+  }, [chatCollapsed, props.chatOverlay, setChatCollapsed])
 
   // Never leave a blank middle: if the workbench is closed while the chat is
   // collapsed, re-open the chat. Mirror of "collapsing the chat opens the

--- a/packages/workspace/src/front/layout/ResponsiveDockviewShell.tsx
+++ b/packages/workspace/src/front/layout/ResponsiveDockviewShell.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react"
-import { MenuIcon, PanelLeftCloseIcon, PanelLeftOpenIcon, PinIcon } from "lucide-react"
+import { MenuIcon, PanelLeftIcon, PinIcon } from "lucide-react"
 import { DockviewShell } from "../dock"
 import type { LayoutConfig } from "../dock"
 import { useRegistry } from "../registry"
@@ -148,7 +148,7 @@ export function ResponsiveDockviewShell({
             onClick={handleOpenOverlay}
             aria-label={isMobile ? "Open sidebar menu" : "Open collapsed sidebar"}
           >
-            {isMobile ? <MenuIcon className="h-4 w-4" /> : <PanelLeftOpenIcon className="h-4 w-4" />}
+            {isMobile ? <MenuIcon className="h-4 w-4" /> : <PanelLeftIcon className="h-4 w-4" />}
           </Button>
         </div>
       )}
@@ -162,7 +162,7 @@ export function ResponsiveDockviewShell({
             onClick={handleCollapseToRail}
             aria-label="Collapse sidebar"
           >
-            <PanelLeftCloseIcon className="h-4 w-4" />
+            <PanelLeftIcon className="h-4 w-4" />
           </Button>
         </div>
       )}

--- a/packages/workspace/src/front/layout/ResponsiveDockviewShell.tsx
+++ b/packages/workspace/src/front/layout/ResponsiveDockviewShell.tsx
@@ -138,7 +138,7 @@ export function ResponsiveDockviewShell({
         <div
           className={cn(
             "absolute z-30",
-            isMobile ? "left-2 top-2" : "left-1 top-2",
+            "left-2 top-2",
           )}
         >
           <Button

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -593,13 +593,14 @@ describe("ChatLayout component", () => {
     expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded")
   })
 
-  it("collapses the chat to zero width and shows a floating expand button", () => {
+  it("collapses the chat to zero width and restores from fixed top-right chrome", () => {
     renderWithRegistry(
       <ChatLayout center="chat" storageKey="chat-layout-rail" />,
       ["chat", "session-list"],
     )
 
-    expect(screen.queryByRole("button", { name: "Expand chat" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Collapse chat" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Show chat" })).not.toBeInTheDocument()
 
     act(() => fireShortcut("\\", { metaKey: true }))
 
@@ -607,11 +608,11 @@ describe("ChatLayout component", () => {
     const collapsed = screen.getByLabelText("Collapsed chat")
     expect(collapsed).toHaveAttribute("data-boring-state", "collapsed")
     expect(collapsed).toHaveAttribute("aria-hidden", "true")
-    // ... and re-opening is a floating left-edge button.
-    expect(screen.getByRole("button", { name: "Expand chat" })).toBeInTheDocument()
+    // ... and re-opening is fixed top-right chrome, not a left-edge rail.
+    expect(screen.getByRole("button", { name: "Show chat" })).toBeInTheDocument()
 
     act(() => fireShortcut("\\", { metaKey: true }))
-    expect(screen.queryByRole("button", { name: "Expand chat" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Show chat" })).not.toBeInTheDocument()
     expect(screen.getByLabelText("Chat")).toHaveAttribute("data-boring-state", "expanded")
   })
 
@@ -715,7 +716,7 @@ describe("ChatLayout component", () => {
     expect(screen.getByRole("button", { name: "Collapse chat" })).toBeInTheDocument()
   })
 
-  it("stacks the floating expand-chat button above the sessions button on the left edge", () => {
+  it("keeps chat restore in fixed top-right chrome instead of stacking on the left edge", () => {
     renderWithRegistry(
       <ChatLayout center="chat" nav={null} onOpenNav={vi.fn()} storageKey="chat-layout-stack" />,
       ["chat", "session-list"],
@@ -724,12 +725,10 @@ describe("ChatLayout component", () => {
     act(() => fireShortcut("\\", { metaKey: true }))
 
     const sessionsButton = screen.getByRole("button", { name: "Sessions" })
-    const chatButton = screen.getByRole("button", { name: "Expand chat" })
-    // Both anchor to the left edge and are vertically offset so they never overlap.
+    const chatButton = screen.getByRole("button", { name: "Show chat" })
     expect(sessionsButton.className).toContain("left-2")
-    expect(chatButton.className).toContain("left-2")
-    expect(sessionsButton.style.transform).toContain("translateY(calc(-50% - 0px))")
-    expect(chatButton.style.transform).toContain("translateY(calc(-50% - 44px))")
+    expect(chatButton.className).not.toContain("left-2")
+    expect(chatButton.closest(".right-3")).not.toBeNull()
   })
 
   it("auto-expands the chat panel when a blocker appears while collapsed", async () => {

--- a/packages/workspace/src/front/layout/cornerChrome.tsx
+++ b/packages/workspace/src/front/layout/cornerChrome.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { IconButton } from "@hachej/boring-ui-kit"
+import { ControlTooltip } from "../components/ControlTooltip"
+import { cn } from "../lib/utils"
+
+/**
+ * Shared fixed-position corner chrome control.
+ *
+ * Design-system contract (see `.impeccable.md`):
+ * - Opaque `bg-muted` (one lightness step above `--background`) + 1px `border`
+ *   for separation. No glassmorphism blur, no soft drop shadows (design
+ *   system: "separation via borders and opacity, not big elevation jumps";
+ *   "no glassmorphism blur for chrome"). The muted fill lifts the control off
+ *   same-background content without an elevation jump.
+ * - `rounded-lg` (ramp step) — matches the sibling `FloatingEdgeButton` rail
+ *   controls so all corner chrome reads as one family.
+ * - 36px hit target (`!h-9 !w-9`), resting `text-muted-foreground` so chrome
+ *   recedes; hover/pressed lift to `text-foreground` on a darker fill
+ *   (`bg-foreground/[0.06]` → `bg-foreground/[0.09]`) — a monotonic step, no shadow.
+ * - Visible focus ring is provided by the `IconButton` base
+ *   (`focus-visible:ring-[3px] ring-ring/50`) — keyboard-accessible by default.
+ *
+ * Used by the top-right workbench/chat toggles (`ChatLayout`) and the top-left
+ * app-navigation toggle (`PluginTabsWorkspaceShell`). One component = one
+ * family, no drift.
+ */
+
+const CORNER_CHROME_CLASS =
+  "pointer-events-auto relative !h-9 !w-9 rounded-lg border border-border/70 bg-muted text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+
+const CORNER_CHROME_PRESSED_CLASS =
+  "border-border bg-foreground/[0.09] text-foreground"
+
+export function CornerChromeButton({
+  label,
+  hint,
+  side = "bottom",
+  onClick,
+  pressed,
+  pulse = false,
+  children,
+}: {
+  label: string
+  hint?: string
+  side?: "top" | "bottom" | "left" | "right"
+  onClick: () => void
+  pressed: boolean
+  pulse?: boolean
+  children: ReactNode
+}) {
+  return (
+    <ControlTooltip label={label} hint={hint} side={side}>
+      <IconButton
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        onClick={onClick}
+        aria-label={label}
+        aria-pressed={pressed}
+        title={label}
+        className={cn(
+          CORNER_CHROME_CLASS,
+          pressed && CORNER_CHROME_PRESSED_CLASS,
+        )}
+      >
+        {children}
+        {pulse ? (
+          <span
+            className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-[color:var(--accent)] ring-2 ring-background"
+            aria-hidden="true"
+          />
+        ) : null}
+      </IconButton>
+    </ControlTooltip>
+  )
+}

--- a/packages/workspace/src/front/layout/cornerChrome.tsx
+++ b/packages/workspace/src/front/layout/cornerChrome.tsx
@@ -21,15 +21,14 @@ import { cn } from "../lib/utils"
  * - Resting `text-muted-foreground` so chrome recedes; hover/pressed lift to
  *   `text-foreground` on a darker fill (`bg-foreground/[0.06]` →
  *   `bg-foreground/[0.09]`) — a monotonic step, no shadow.
- * - Vertical position is set per-corner at the call site so each control
- *   centers in its own header band (44px workbench strip / 61px app-nav
- *   header), since those bands have different heights.
+ * - Vertical position is set at the call site so the top-right controls
+ *   center in the 44px workbench/header strip.
  * - Visible focus ring is provided by the `IconButton` base
  *   (`focus-visible:ring-[3px] ring-ring/50`) — keyboard-accessible by default.
  *
- * Used by the top-right workbench/chat toggles (`ChatLayout`) and the top-left
- * app-navigation toggle (`PluginTabsWorkspaceShell`). One component = one
- * family, no drift.
+ * Used by the top-right workbench/chat toggles (`ChatLayout`). Left-pane
+ * collapse controls use `PaneCollapseButton` because they belong to the
+ * workspace-left rail family (32px button / 16px icon).
  */
 
 const CORNER_CHROME_CLASS =

--- a/packages/workspace/src/front/layout/cornerChrome.tsx
+++ b/packages/workspace/src/front/layout/cornerChrome.tsx
@@ -9,16 +9,21 @@ import { cn } from "../lib/utils"
  * Shared fixed-position corner chrome control.
  *
  * Design-system contract (see `.impeccable.md`):
+ * - Sized to the in-header chrome family: `IconButton size="icon-xs"` → 24px
+ *   button, `rounded-md` (8px, ramp step), 12px icon at stroke 1.75. This
+ *   matches WorkbenchCloseAction / session-list header buttons so the corner
+ *   controls read as part of the same family, not a larger foreign element.
  * - Opaque `bg-muted` (one lightness step above `--background`) + 1px `border`
  *   for separation. No glassmorphism blur, no soft drop shadows (design
  *   system: "separation via borders and opacity, not big elevation jumps";
  *   "no glassmorphism blur for chrome"). The muted fill lifts the control off
  *   same-background content without an elevation jump.
- * - `rounded-lg` (ramp step) — matches the sibling `FloatingEdgeButton` rail
- *   controls so all corner chrome reads as one family.
- * - 36px hit target (`!h-9 !w-9`), resting `text-muted-foreground` so chrome
- *   recedes; hover/pressed lift to `text-foreground` on a darker fill
- *   (`bg-foreground/[0.06]` → `bg-foreground/[0.09]`) — a monotonic step, no shadow.
+ * - Resting `text-muted-foreground` so chrome recedes; hover/pressed lift to
+ *   `text-foreground` on a darker fill (`bg-foreground/[0.06]` →
+ *   `bg-foreground/[0.09]`) — a monotonic step, no shadow.
+ * - Vertical position is set per-corner at the call site so each control
+ *   centers in its own header band (44px workbench strip / 61px app-nav
+ *   header), since those bands have different heights.
  * - Visible focus ring is provided by the `IconButton` base
  *   (`focus-visible:ring-[3px] ring-ring/50`) — keyboard-accessible by default.
  *
@@ -28,7 +33,7 @@ import { cn } from "../lib/utils"
  */
 
 const CORNER_CHROME_CLASS =
-  "pointer-events-auto relative !h-9 !w-9 rounded-lg border border-border/70 bg-muted text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+  "pointer-events-auto relative border border-border/70 bg-muted text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
 
 const CORNER_CHROME_PRESSED_CLASS =
   "border-border bg-foreground/[0.09] text-foreground"
@@ -55,7 +60,7 @@ export function CornerChromeButton({
       <IconButton
         type="button"
         variant="ghost"
-        size="icon-sm"
+        size="icon-xs"
         onClick={onClick}
         aria-label={label}
         aria-pressed={pressed}
@@ -68,7 +73,7 @@ export function CornerChromeButton({
         {children}
         {pulse ? (
           <span
-            className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-[color:var(--accent)] ring-2 ring-background"
+            className="absolute right-1 top-1 h-1.5 w-1.5 rounded-full bg-[color:var(--accent)] ring-1 ring-background"
             aria-hidden="true"
           />
         ) : null}

--- a/packages/workspace/src/front/layout/paneCollapseButton.tsx
+++ b/packages/workspace/src/front/layout/paneCollapseButton.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { ControlTooltip } from "../components/ControlTooltip"
+import { cn } from "../lib/utils"
+
+export interface PaneCollapseButtonProps {
+  label: string
+  onClick: () => void
+  children: ReactNode
+  side?: "top" | "right" | "bottom" | "left"
+  className?: string
+}
+
+/**
+ * Canonical chrome for left-pane collapse/expand controls.
+ *
+ * Rule: collapsed and expanded states must keep the same button position,
+ * size, and style; only the icon changes (PanelLeftClose ↔ PanelLeftOpen).
+ */
+export function PaneCollapseButton({
+  label,
+  onClick,
+  children,
+  side = "right",
+  className,
+}: PaneCollapseButtonProps) {
+  return (
+    <ControlTooltip label={label} side={side}>
+      <button
+        type="button"
+        aria-label={label}
+        onClick={onClick}
+        className={cn(
+          "pointer-events-auto flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors",
+          "hover:bg-background/70 hover:text-foreground",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+          className,
+        )}
+      >
+        {children}
+      </button>
+    </ControlTooltip>
+  )
+}

--- a/packages/workspace/src/front/layout/paneCollapseButton.tsx
+++ b/packages/workspace/src/front/layout/paneCollapseButton.tsx
@@ -15,8 +15,8 @@ export interface PaneCollapseButtonProps {
 /**
  * Canonical chrome for left-pane collapse/expand controls.
  *
- * Rule: collapsed and expanded states must keep the same button position,
- * size, and style; only the icon changes (PanelLeftClose ↔ PanelLeftOpen).
+ * Rule: collapsed and expanded states keep the same button position, size,
+ * style, and icon family. The action changes; the chrome does not jump.
  */
 export function PaneCollapseButton({
   label,

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useMemo, useState, type ReactNode } from "react"
-import { ChevronRight, Clock3, MessageSquarePlus, Pin, Plug, Plus, Search, Sparkles } from "lucide-react"
+import { ChevronRight, Clock3, Folder, FolderOpen, MessageSquarePlus, Pin, Plug, Plus, Search, Sparkles } from "lucide-react"
 import { cn } from "../../lib/utils"
 
 export interface AppLeftPaneSession {
@@ -11,11 +11,32 @@ export interface AppLeftPaneSession {
   turnCount?: number
 }
 
+export interface AppLeftPaneProjectSession {
+  id: string
+  title?: string | null
+  updatedAt?: string | number
+}
+
+export interface AppLeftPaneProject {
+  id: string
+  name: string
+  available?: boolean
+  sessionCount?: number
+  sessions?: AppLeftPaneProjectSession[]
+  hasMoreSessions?: boolean
+  loadingSessions?: boolean
+}
+
 export interface AppLeftPaneProps {
   width?: number
   appTitle?: string
   workspaceLabel?: string
   workspaceSectionTitle?: string
+  projects?: AppLeftPaneProject[]
+  activeProjectId?: string | null
+  onSwitchProject?: (projectId: string) => void
+  onOpenProjectSession?: (projectId: string, sessionId: string) => void
+  onShowMoreProjectSessions?: (projectId: string) => void
   sessionTitle?: string
   topSlot?: ReactNode
   bottomSlot?: ReactNode
@@ -42,6 +63,11 @@ export function AppLeftPane({
   appTitle,
   workspaceLabel,
   workspaceSectionTitle = "Workspaces",
+  projects,
+  activeProjectId,
+  onSwitchProject,
+  onOpenProjectSession,
+  onShowMoreProjectSessions,
   topSlot,
   bottomSlot,
   sessions,
@@ -70,6 +96,7 @@ export function AppLeftPane({
     () => sessions.filter((session) => !pinnedSet.has(session.id)),
     [pinnedSet, sessions],
   )
+  const projectItems = useMemo(() => projects ?? [], [projects])
   const renderSession = (session: AppLeftPaneSession, pinned: boolean) => {
     const state: SessionRowState = session.id === activeSessionId
       ? "active"
@@ -120,10 +147,21 @@ export function AppLeftPane({
       </nav>
 
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
-        <CollapsibleSection title={workspaceSectionTitle} defaultOpen={false}>
-          <div className="flex min-h-9 w-full items-center gap-2 rounded-lg bg-foreground/[0.06] px-2.5 py-1.5 text-[13px] font-medium text-foreground">
-            <span className="truncate">{workspaceLabel || appTitle || "Boring UI"}</span>
-          </div>
+        <CollapsibleSection title={workspaceSectionTitle} defaultOpen={projectItems.length > 0}>
+          {projectItems.length > 0 ? (
+            <ProjectOverview
+              projects={projectItems}
+              activeProjectId={activeProjectId}
+              fallbackName={workspaceLabel || appTitle || "Boring UI"}
+              onSwitchProject={onSwitchProject}
+              onOpenProjectSession={onOpenProjectSession}
+              onShowMoreProjectSessions={onShowMoreProjectSessions}
+            />
+          ) : (
+            <div className="flex min-h-9 w-full items-center gap-2 rounded-lg bg-foreground/[0.06] px-2.5 py-1.5 text-[13px] font-medium text-foreground">
+              <span className="truncate">{workspaceLabel || appTitle || "Boring UI"}</span>
+            </div>
+          )}
         </CollapsibleSection>
         <CollapsibleSection title="Chats" defaultOpen>
           <SessionSubSection title="Pinned" empty="No pinned sessions yet.">
@@ -138,6 +176,124 @@ export function AppLeftPane({
       {bottomSlot ? <footer className="shrink-0 border-t border-border/60 p-2">{bottomSlot}</footer> : null}
     </aside>
   )
+}
+
+function ProjectOverview({
+  projects,
+  activeProjectId,
+  fallbackName,
+  onSwitchProject,
+  onOpenProjectSession,
+  onShowMoreProjectSessions,
+}: {
+  projects: AppLeftPaneProject[]
+  activeProjectId?: string | null
+  fallbackName: string
+  onSwitchProject?: (projectId: string) => void
+  onOpenProjectSession?: (projectId: string, sessionId: string) => void
+  onShowMoreProjectSessions?: (projectId: string) => void
+}) {
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => (
+    activeProjectId ? new Set([activeProjectId]) : new Set(projects[0]?.id ? [projects[0].id] : [])
+  ))
+
+  const activeId = activeProjectId ?? projects[0]?.id ?? null
+
+  return (
+    <div className="space-y-1">
+      {projects.map((project) => {
+        const active = project.id === activeId
+        const expanded = expandedIds.has(project.id) || active
+        const sessions = project.sessions ?? []
+        const count = project.sessionCount ?? sessions.length
+        const unavailable = project.available === false
+        return (
+          <div key={project.id} className="space-y-0.5">
+            <button
+              type="button"
+              aria-expanded={expanded}
+              aria-current={active ? "page" : undefined}
+              onClick={() => {
+                if (!active && !unavailable) onSwitchProject?.(project.id)
+                setExpandedIds((current) => {
+                  const next = new Set(current)
+                  if (next.has(project.id) && !active) next.delete(project.id)
+                  else next.add(project.id)
+                  return next
+                })
+              }}
+              className={cn(
+                "group flex min-h-9 w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+                active
+                  ? "bg-foreground/[0.085] text-foreground"
+                  : unavailable
+                    ? "text-muted-foreground/45"
+                    : "text-foreground/84 hover:bg-foreground/[0.055] hover:text-foreground",
+              )}
+            >
+              {expanded ? (
+                <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
+              ) : (
+                <Folder className="h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
+              )}
+              <span className="min-w-0 flex-1 truncate text-[13px] font-medium">{project.name || fallbackName}</span>
+              {count > 0 ? (
+                <span className="grid min-w-6 place-items-center rounded-full bg-foreground/[0.08] px-1.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+                  {count > 99 ? "99+" : count}
+                </span>
+              ) : null}
+            </button>
+            {expanded ? (
+              <div className="space-y-0.5 pl-8">
+                {project.loadingSessions && sessions.length === 0 ? (
+                  <div className="px-1 py-1.5 text-xs text-muted-foreground/70">Loading sessions…</div>
+                ) : sessions.length === 0 ? (
+                  <div className="px-1 py-1.5 text-xs text-muted-foreground/70">No sessions yet.</div>
+                ) : (
+                  sessions.map((session) => (
+                    <button
+                      key={session.id}
+                      type="button"
+                      onClick={() => onOpenProjectSession?.(project.id, session.id)}
+                      className="flex min-h-8 w-full items-center gap-2 rounded-md px-1 py-1 text-left text-[13px] text-foreground/78 hover:bg-foreground/[0.045] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                    >
+                      <span className="min-w-0 flex-1 truncate">{session.title || "Untitled"}</span>
+                      {session.updatedAt ? <span className="shrink-0 text-xs text-muted-foreground/70">{relativeSessionTime(session.updatedAt)}</span> : null}
+                    </button>
+                  ))
+                )}
+                {project.hasMoreSessions ? (
+                  <button
+                    type="button"
+                    onClick={() => onShowMoreProjectSessions?.(project.id)}
+                    className="rounded-md px-1 py-1 text-left text-[13px] text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                  >
+                    Show more
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function relativeSessionTime(value: string | number): string {
+  const timestamp = typeof value === "number" ? value : Date.parse(value)
+  if (!Number.isFinite(timestamp)) return ""
+  const diffMs = Date.now() - timestamp
+  if (diffMs < 60_000) return "now"
+  const minutes = Math.floor(diffMs / 60_000)
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+  const days = Math.floor(hours / 24)
+  if (days < 14) return `${days}d`
+  const weeks = Math.floor(days / 7)
+  if (weeks < 10) return `${weeks}w`
+  return `${Math.floor(days / 30)}mo`
 }
 
 function PrimaryAction({ icon, label, onClick }: { icon: ReactNode; label: string; onClick: () => void }) {

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,9 +1,7 @@
 "use client"
 
 import { useMemo, useSyncExternalStore, type ReactNode } from "react"
-import { Clock3, MessageSquarePlus, PanelLeftClose, Pin, Plug, Plus, Search, Sparkles } from "lucide-react"
-import { IconButton } from "@hachej/boring-ui-kit"
-import { ControlTooltip } from "../../components/ControlTooltip"
+import { Clock3, MessageSquarePlus, Pin, Plug, Plus, Search, Sparkles } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { useRegistry } from "../../registry"
 import type { OpenPanelConfig, SurfaceShellSnapshot } from "../../chrome/artifact-surface/SurfaceShell"
@@ -28,7 +26,6 @@ export interface AppLeftPaneProps {
   pinnedSessionIds: readonly string[]
   surfaceSnapshot: SurfaceShellSnapshot
   skillsPanelId: string
-  onCollapse: () => void
   onCreateSession: () => void
   onOpenCommandPalette: () => void
   onSwitchSession: (id: string) => void
@@ -51,7 +48,6 @@ export function AppLeftPane({
   pinnedSessionIds,
   surfaceSnapshot,
   skillsPanelId,
-  onCollapse,
   onCreateSession,
   onOpenCommandPalette,
   onSwitchSession,
@@ -108,20 +104,7 @@ export function AppLeftPane({
       className="flex h-full min-h-0 w-[268px] shrink-0 flex-col border-r border-border bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)] text-sm"
       aria-label="App navigation"
     >
-      <header className="flex shrink-0 items-start gap-2 border-b border-border/60 px-3 py-3">
-        <ControlTooltip label="Collapse app navigation" side="right">
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={onCollapse}
-            aria-label="Collapse app navigation"
-            title="Collapse app navigation"
-            className="mt-0.5 h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
-          >
-            <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
-          </IconButton>
-        </ControlTooltip>
+      <header className="flex shrink-0 items-start border-b border-border/60 py-3 pl-14 pr-3">
         <div className="min-w-0 flex-1">
           <div className="truncate text-[13px] font-semibold tracking-tight text-foreground">{appTitle || "Boring UI"}</div>
           <div className="truncate text-[12px] text-muted-foreground">{sessionTitle || "New session"}</div>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -26,6 +26,8 @@ export interface AppLeftPaneProps {
   onSwitchSession: (id: string) => void
   onOpenSessionAsPane: (id: string) => void
   onToggleSessionPinned: (id: string) => void
+  showPlugins?: boolean
+  showSkills?: boolean
   onOpenPlugins: () => void
   onOpenSkills: () => void
 
@@ -47,6 +49,8 @@ export function AppLeftPane({
   onSwitchSession,
   onOpenSessionAsPane,
   onToggleSessionPinned,
+  showPlugins = true,
+  showSkills = true,
   onOpenPlugins,
   onOpenSkills,
 }: AppLeftPaneProps) {
@@ -107,8 +111,8 @@ export function AppLeftPane({
       <nav className="shrink-0 space-y-1 border-b border-border/60 px-2 py-2" aria-label="Primary workspace actions">
         <PrimaryAction icon={<Plus className="h-4 w-4" strokeWidth={1.75} />} label="New chat" onClick={onCreateSession} />
         <PrimaryAction icon={<Search className="h-4 w-4" strokeWidth={1.75} />} label="Search" onClick={onOpenCommandPalette} />
-        <PrimaryAction icon={<Plug className="h-4 w-4" strokeWidth={1.75} />} label="Plugins" onClick={onOpenPlugins} />
-        <PrimaryAction icon={<Sparkles className="h-4 w-4" strokeWidth={1.75} />} label="Skills" onClick={onOpenSkills} />
+        {showPlugins ? <PrimaryAction icon={<Plug className="h-4 w-4" strokeWidth={1.75} />} label="Plugins" onClick={onOpenPlugins} /> : null}
+        {showSkills ? <PrimaryAction icon={<Sparkles className="h-4 w-4" strokeWidth={1.75} />} label="Skills" onClick={onOpenSkills} /> : null}
       </nav>
 
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -104,7 +104,7 @@ export function AppLeftPane({
       className="flex h-full min-h-0 w-[268px] shrink-0 flex-col border-r border-border bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)] text-sm"
       aria-label="App navigation"
     >
-      <header className="flex shrink-0 items-start border-b border-border/60 py-3 pl-14 pr-3">
+      <header className="flex shrink-0 items-start border-b border-border/60 py-3 pl-11 pr-3">
         <div className="min-w-0 flex-1">
           <div className="truncate text-[13px] font-semibold tracking-tight text-foreground">{appTitle || "Boring UI"}</div>
           <div className="truncate text-[12px] text-muted-foreground">{sessionTitle || "New session"}</div>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -14,6 +14,8 @@ export interface AppLeftPaneSession {
 export interface AppLeftPaneProps {
   width?: number
   appTitle?: string
+  workspaceLabel?: string
+  workspaceSectionTitle?: string
   sessionTitle?: string
   topSlot?: ReactNode
   bottomSlot?: ReactNode
@@ -38,6 +40,8 @@ type SessionRowState = "normal" | "open" | "active"
 export function AppLeftPane({
   width = 268,
   appTitle,
+  workspaceLabel,
+  workspaceSectionTitle = "Workspaces",
   topSlot,
   bottomSlot,
   sessions,
@@ -116,9 +120,9 @@ export function AppLeftPane({
       </nav>
 
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
-        <CollapsibleSection title="Workspaces" defaultOpen={false}>
+        <CollapsibleSection title={workspaceSectionTitle} defaultOpen={false}>
           <div className="flex min-h-9 w-full items-center gap-2 rounded-lg bg-foreground/[0.06] px-2.5 py-1.5 text-[13px] font-medium text-foreground">
-            <span className="truncate">{appTitle || "Boring UI"}</span>
+            <span className="truncate">{workspaceLabel || appTitle || "Boring UI"}</span>
           </div>
         </CollapsibleSection>
         <CollapsibleSection title="Chats" defaultOpen>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,12 +1,8 @@
 "use client"
 
-import { useMemo, useSyncExternalStore, type ReactNode } from "react"
+import { useMemo, type ReactNode } from "react"
 import { Clock3, MessageSquarePlus, Pin, Plug, Plus, Search, Sparkles } from "lucide-react"
 import { cn } from "../../lib/utils"
-import { useRegistry } from "../../registry"
-import type { OpenPanelConfig, SurfaceShellSnapshot } from "../../chrome/artifact-surface/SurfaceShell"
-import type { PanelConfig } from "../../registry/types"
-import { isWorkspacePagePlacement } from "../../../shared/types/panel"
 
 export interface AppLeftPaneSession {
   id: string
@@ -24,14 +20,12 @@ export interface AppLeftPaneProps {
   activeSessionId?: string | null
   openSessionIds: readonly string[]
   pinnedSessionIds: readonly string[]
-  surfaceSnapshot: SurfaceShellSnapshot
-  skillsPanelId: string
   onCreateSession: () => void
   onOpenCommandPalette: () => void
   onSwitchSession: (id: string) => void
   onOpenSessionAsPane: (id: string) => void
   onToggleSessionPinned: (id: string) => void
-  onOpenPlugins: (panel?: OpenPanelConfig) => void
+  onOpenPlugins: () => void
   onOpenSkills: () => void
 }
 
@@ -46,8 +40,6 @@ export function AppLeftPane({
   activeSessionId,
   openSessionIds,
   pinnedSessionIds,
-  surfaceSnapshot,
-  skillsPanelId,
   onCreateSession,
   onOpenCommandPalette,
   onSwitchSession,
@@ -56,12 +48,6 @@ export function AppLeftPane({
   onOpenPlugins,
   onOpenSkills,
 }: AppLeftPaneProps) {
-  const panelRegistry = useRegistry()
-  const panels = useSyncExternalStore(
-    panelRegistry.subscribe,
-    panelRegistry.getSnapshot,
-    panelRegistry.getSnapshot,
-  )
   const openSet = useMemo(() => new Set(openSessionIds), [openSessionIds])
   const pinnedSet = useMemo(() => new Set(pinnedSessionIds), [pinnedSessionIds])
   const pinnedSessions = useMemo(
@@ -74,11 +60,6 @@ export function AppLeftPane({
     () => sessions.filter((session) => !pinnedSet.has(session.id)),
     [pinnedSet, sessions],
   )
-  const pluginPanel = useMemo(
-    () => resolveCurrentPluginWorkspacePage(panels, surfaceSnapshot, skillsPanelId),
-    [panels, skillsPanelId, surfaceSnapshot],
-  )
-
   const renderSession = (session: AppLeftPaneSession, pinned: boolean) => {
     const state: SessionRowState = session.id === activeSessionId
       ? "active"
@@ -115,7 +96,7 @@ export function AppLeftPane({
       <nav className="shrink-0 space-y-1 border-b border-border/60 px-2 py-2" aria-label="Primary workspace actions">
         <PrimaryAction icon={<Plus className="h-4 w-4" />} label="New chat" onClick={onCreateSession} />
         <PrimaryAction icon={<Search className="h-4 w-4" />} label="Search" onClick={onOpenCommandPalette} />
-        <PrimaryAction icon={<Plug className="h-4 w-4" />} label="Plugins" onClick={() => onOpenPlugins(pluginPanel)} />
+        <PrimaryAction icon={<Plug className="h-4 w-4" />} label="Plugins" onClick={onOpenPlugins} />
         <PrimaryAction icon={<Sparkles className="h-4 w-4" />} label="Skills" onClick={onOpenSkills} />
       </nav>
 
@@ -257,39 +238,4 @@ function AppSessionRow({
       </span>
     </div>
   )
-}
-
-function resolveCurrentPluginWorkspacePage(
-  panels: readonly PanelConfig[],
-  snapshot: SurfaceShellSnapshot,
-  skillsPanelId: string,
-): OpenPanelConfig | undefined {
-  const workspacePages = panels.filter((panel) => (
-    isWorkspacePagePlacement(panel.placement)
-    && panel.id !== skillsPanelId
-    && panel.source !== "core"
-  ))
-  if (workspacePages.length === 0) return undefined
-
-  type ResolvedWorkspacePage = { panel: PanelConfig; tab?: SurfaceShellSnapshot["openTabs"][number] }
-  const byComponent = new Map(workspacePages.map((panel) => [panel.id, panel]))
-  const panelForTab = (tab: SurfaceShellSnapshot["openTabs"][number]): ResolvedWorkspacePage | undefined => {
-    const panel = byComponent.get(tab.component ?? tab.id)
-    return panel ? { panel, tab } : undefined
-  }
-  const activeTab = snapshot.activeTab
-    ? snapshot.openTabs.find((tab) => tab.id === snapshot.activeTab)
-    : undefined
-  const active = activeTab ? panelForTab(activeTab) : undefined
-  const lastOpen = [...snapshot.openTabs]
-    .reverse()
-    .map(panelForTab)
-    .find((entry): entry is ResolvedWorkspacePage => Boolean(entry))
-  const fallback: ResolvedWorkspacePage | undefined = workspacePages[0] ? { panel: workspacePages[0] } : undefined
-  const resolved: ResolvedWorkspacePage | undefined = active ?? lastOpen ?? fallback
-  return resolved ? {
-    id: resolved.tab?.id ?? resolved.panel.id,
-    component: resolved.panel.id,
-    title: resolved.tab?.title ?? resolved.panel.title,
-  } : undefined
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -226,12 +226,12 @@ function AppSessionRow({
         activate()
       }}
       className={cn(
-        "group flex min-h-9 w-full items-center gap-2 rounded-lg border-l-2 px-2.5 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+        "group flex min-h-9 w-full items-center gap-2 rounded-lg border px-2.5 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
         state === "active"
-          ? "border-l-[color:var(--accent)] bg-foreground/[0.09] text-foreground"
+          ? "border-[color:oklch(from_var(--accent)_l_c_h/0.28)] bg-[color:oklch(from_var(--accent)_l_c_h/0.10)] text-foreground"
           : state === "open"
-            ? "border-l-[color:var(--accent)] bg-transparent text-foreground/90 hover:bg-foreground/[0.04]"
-            : "border-l-transparent text-foreground/78 hover:bg-foreground/[0.055] hover:text-foreground",
+            ? "border-border/45 bg-background/25 text-foreground/90 hover:bg-foreground/[0.04]"
+            : "border-transparent text-foreground/78 hover:border-border/35 hover:bg-foreground/[0.055] hover:text-foreground",
       )}
     >
       <Clock3

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import { useMemo, useState, type ReactNode } from "react"
-import { ChevronRight, Clock3, MessageSquarePlus, Pin, Plug, Plus, Search, Sparkles, PanelLeftClose } from "lucide-react"
-import { ControlTooltip } from "../../components/ControlTooltip"
+import { ChevronRight, Clock3, MessageSquarePlus, Pin, Plug, Plus, Search, Sparkles } from "lucide-react"
 import { cn } from "../../lib/utils"
 
 export interface AppLeftPaneSession {
@@ -28,10 +27,7 @@ export interface AppLeftPaneProps {
   onToggleSessionPinned: (id: string) => void
   onOpenPlugins: () => void
   onOpenSkills: () => void
-  /** Collapse the app-left pane to nothing (reveal reserves nothing). Rendered
-   *  as an in-pane control so it matches the workbench-left "Hide workspace
-   *  menu" rail button rather than a floating corner chrome. */
-  onCollapse: () => void
+
 }
 
 type SessionRowState = "normal" | "open" | "active"
@@ -51,7 +47,6 @@ export function AppLeftPane({
   onToggleSessionPinned,
   onOpenPlugins,
   onOpenSkills,
-  onCollapse,
 }: AppLeftPaneProps) {
   const openSet = useMemo(() => new Set(openSessionIds), [openSessionIds])
   const pinnedSet = useMemo(() => new Set(pinnedSessionIds), [pinnedSessionIds])
@@ -90,11 +85,11 @@ export function AppLeftPane({
       className="flex h-full min-h-0 w-[268px] shrink-0 flex-col border-r border-border bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)] text-sm"
       aria-label="App navigation"
     >
-      {/* Top row: current project label (or host topSlot) + in-pane collapse
-          control. The collapse control mirrors the workbench-left "Hide
-          workspace menu" rail button (32px, 16px icon, ghost) so the app-nav
-          collapse reads as the same family as the workspace collapse. */}
-      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border/60 px-2 py-2">
+      {/* Top row: current project label (or host topSlot). The fixed-position
+          app-nav collapse/expand button is rendered by PluginTabsWorkspaceShell
+          at the same x/y in both states, so reserve the same quiet leading
+          space here instead of moving the button into this row. */}
+      <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border/60 py-2 pl-11 pr-2">
         <div className="min-w-0 flex-1">
           {topSlot ? (
             topSlot
@@ -104,23 +99,13 @@ export function AppLeftPane({
             </span>
           )}
         </div>
-        <ControlTooltip label="Hide app navigation" side="bottom">
-          <button
-            type="button"
-            aria-label="Hide app navigation"
-            onClick={onCollapse}
-            className="grid size-8 shrink-0 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-          >
-            <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
-          </button>
-        </ControlTooltip>
       </div>
 
       <nav className="shrink-0 space-y-1 border-b border-border/60 px-2 py-2" aria-label="Primary workspace actions">
-        <PrimaryAction icon={<Plus className="h-4 w-4" />} label="New chat" onClick={onCreateSession} />
-        <PrimaryAction icon={<Search className="h-4 w-4" />} label="Search" onClick={onOpenCommandPalette} />
-        <PrimaryAction icon={<Plug className="h-4 w-4" />} label="Plugins" onClick={onOpenPlugins} />
-        <PrimaryAction icon={<Sparkles className="h-4 w-4" />} label="Skills" onClick={onOpenSkills} />
+        <PrimaryAction icon={<Plus className="h-4 w-4" strokeWidth={1.75} />} label="New chat" onClick={onCreateSession} />
+        <PrimaryAction icon={<Search className="h-4 w-4" strokeWidth={1.75} />} label="Search" onClick={onOpenCommandPalette} />
+        <PrimaryAction icon={<Plug className="h-4 w-4" strokeWidth={1.75} />} label="Plugins" onClick={onOpenPlugins} />
+        <PrimaryAction icon={<Sparkles className="h-4 w-4" strokeWidth={1.75} />} label="Skills" onClick={onOpenSkills} />
       </nav>
 
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
@@ -187,7 +172,7 @@ function CollapsibleSection({
         />
         <span>{title}</span>
       </button>
-      {open ? <div className="mt-0.5 space-y-1.5">{children}</div> : null}
+      {open ? <div className="mt-0.5 space-y-1.5 pl-5">{children}</div> : null}
     </section>
   )
 }
@@ -238,12 +223,12 @@ function AppSessionRow({
         activate()
       }}
       className={cn(
-        "group flex min-h-9 w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+        "group flex min-h-9 w-full items-center gap-2 rounded-lg border-l-2 px-2.5 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
         state === "active"
-          ? "bg-foreground/[0.09] text-foreground"
+          ? "border-l-[color:var(--accent)] bg-foreground/[0.09] text-foreground"
           : state === "open"
-            ? "bg-foreground/[0.045] text-foreground/90 hover:bg-foreground/[0.07]"
-            : "text-foreground/78 hover:bg-foreground/[0.055] hover:text-foreground",
+            ? "border-l-[color:var(--accent)] bg-transparent text-foreground/90 hover:bg-foreground/[0.04]"
+            : "border-l-transparent text-foreground/78 hover:bg-foreground/[0.055] hover:text-foreground",
       )}
     >
       <Clock3

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,0 +1,312 @@
+"use client"
+
+import { useMemo, useSyncExternalStore, type ReactNode } from "react"
+import { Clock3, MessageSquarePlus, PanelLeftClose, Pin, Plug, Plus, Search, Sparkles } from "lucide-react"
+import { IconButton } from "@hachej/boring-ui-kit"
+import { ControlTooltip } from "../../components/ControlTooltip"
+import { cn } from "../../lib/utils"
+import { useRegistry } from "../../registry"
+import type { OpenPanelConfig, SurfaceShellSnapshot } from "../../chrome/artifact-surface/SurfaceShell"
+import type { PanelConfig } from "../../registry/types"
+import { isWorkspacePagePlacement } from "../../../shared/types/panel"
+
+export interface AppLeftPaneSession {
+  id: string
+  title?: string | null
+  updatedAt?: string | number
+  turnCount?: number
+}
+
+export interface AppLeftPaneProps {
+  appTitle?: string
+  sessionTitle?: string
+  topSlot?: ReactNode
+  bottomSlot?: ReactNode
+  sessions: AppLeftPaneSession[]
+  activeSessionId?: string | null
+  openSessionIds: readonly string[]
+  pinnedSessionIds: readonly string[]
+  surfaceSnapshot: SurfaceShellSnapshot
+  skillsPanelId: string
+  onCollapse: () => void
+  onCreateSession: () => void
+  onOpenCommandPalette: () => void
+  onSwitchSession: (id: string) => void
+  onOpenSessionAsPane: (id: string) => void
+  onToggleSessionPinned: (id: string) => void
+  onOpenPlugins: (panel?: OpenPanelConfig) => void
+  onOpenSkills: () => void
+}
+
+type SessionRowState = "normal" | "open" | "active"
+
+export function AppLeftPane({
+  appTitle,
+  sessionTitle,
+  topSlot,
+  bottomSlot,
+  sessions,
+  activeSessionId,
+  openSessionIds,
+  pinnedSessionIds,
+  surfaceSnapshot,
+  skillsPanelId,
+  onCollapse,
+  onCreateSession,
+  onOpenCommandPalette,
+  onSwitchSession,
+  onOpenSessionAsPane,
+  onToggleSessionPinned,
+  onOpenPlugins,
+  onOpenSkills,
+}: AppLeftPaneProps) {
+  const panelRegistry = useRegistry()
+  const panels = useSyncExternalStore(
+    panelRegistry.subscribe,
+    panelRegistry.getSnapshot,
+    panelRegistry.getSnapshot,
+  )
+  const openSet = useMemo(() => new Set(openSessionIds), [openSessionIds])
+  const pinnedSet = useMemo(() => new Set(pinnedSessionIds), [pinnedSessionIds])
+  const pinnedSessions = useMemo(
+    () => pinnedSessionIds
+      .map((id) => sessions.find((session) => session.id === id))
+      .filter((session): session is AppLeftPaneSession => Boolean(session)),
+    [pinnedSessionIds, sessions],
+  )
+  const regularSessions = useMemo(
+    () => sessions.filter((session) => !pinnedSet.has(session.id)),
+    [pinnedSet, sessions],
+  )
+  const pluginPanel = useMemo(
+    () => resolveCurrentPluginWorkspacePage(panels, surfaceSnapshot, skillsPanelId),
+    [panels, skillsPanelId, surfaceSnapshot],
+  )
+
+  const renderSession = (session: AppLeftPaneSession, pinned: boolean) => {
+    const state: SessionRowState = session.id === activeSessionId
+      ? "active"
+      : openSet.has(session.id)
+        ? "open"
+        : "normal"
+    return (
+      <AppSessionRow
+        key={session.id}
+        session={session}
+        state={state}
+        pinned={pinned}
+        onSwitch={onSwitchSession}
+        onOpenAsPane={onOpenSessionAsPane}
+        onTogglePinned={onToggleSessionPinned}
+      />
+    )
+  }
+
+  return (
+    <aside
+      data-boring-workspace-part="app-left-pane"
+      className="flex h-full min-h-0 w-[268px] shrink-0 flex-col border-r border-border bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)] text-sm"
+      aria-label="App navigation"
+    >
+      <header className="flex shrink-0 items-start gap-2 border-b border-border/60 px-3 py-3">
+        <ControlTooltip label="Collapse app navigation" side="right">
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={onCollapse}
+            aria-label="Collapse app navigation"
+            title="Collapse app navigation"
+            className="mt-0.5 h-8 w-8 shrink-0 rounded-lg text-muted-foreground hover:text-foreground"
+          >
+            <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
+          </IconButton>
+        </ControlTooltip>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[13px] font-semibold tracking-tight text-foreground">{appTitle || "Boring UI"}</div>
+          <div className="truncate text-[12px] text-muted-foreground">{sessionTitle || "New session"}</div>
+          {topSlot ? <div className="mt-2 min-w-0">{topSlot}</div> : null}
+        </div>
+      </header>
+
+      <nav className="shrink-0 space-y-1 border-b border-border/60 px-2 py-2" aria-label="Primary workspace actions">
+        <PrimaryAction icon={<Plus className="h-4 w-4" />} label="New chat" onClick={onCreateSession} />
+        <PrimaryAction icon={<Search className="h-4 w-4" />} label="Search" onClick={onOpenCommandPalette} />
+        <PrimaryAction icon={<Plug className="h-4 w-4" />} label="Plugins" onClick={() => onOpenPlugins(pluginPanel)} />
+        <PrimaryAction icon={<Sparkles className="h-4 w-4" />} label="Skills" onClick={onOpenSkills} />
+      </nav>
+
+      <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        <SessionSection title="Pinned" empty="No pinned sessions yet.">
+          {pinnedSessions.map((session) => renderSession(session, true))}
+        </SessionSection>
+        <SessionSection title="Sessions" empty="No sessions yet.">
+          {regularSessions.map((session) => renderSession(session, false))}
+        </SessionSection>
+      </div>
+
+      {bottomSlot ? <footer className="shrink-0 border-t border-border/60 p-2">{bottomSlot}</footer> : null}
+    </aside>
+  )
+}
+
+function PrimaryAction({ icon, label, onClick }: { icon: ReactNode; label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex h-9 w-full items-center gap-2 rounded-lg px-2.5 text-left text-[13px] font-medium text-foreground/82 transition-colors hover:bg-foreground/[0.055] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+    >
+      <span className="grid size-5 shrink-0 place-items-center text-muted-foreground" aria-hidden="true">{icon}</span>
+      <span className="truncate">{label}</span>
+    </button>
+  )
+}
+
+function SessionSection({ title, empty, children }: { title: string; empty: string; children: ReactNode }) {
+  const hasChildren = Array.isArray(children) ? children.length > 0 : Boolean(children)
+  return (
+    <section data-boring-workspace-part="app-left-pane-section" className="py-2">
+      <div className="px-2 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/60">
+        {title}
+      </div>
+      <div className="space-y-0.5">
+        {hasChildren ? children : <div className="px-2 py-2 text-xs text-muted-foreground/70">{empty}</div>}
+      </div>
+    </section>
+  )
+}
+
+function AppSessionRow({
+  session,
+  state,
+  pinned,
+  onSwitch,
+  onOpenAsPane,
+  onTogglePinned,
+}: {
+  session: AppLeftPaneSession
+  state: SessionRowState
+  pinned: boolean
+  onSwitch: (id: string) => void
+  onOpenAsPane: (id: string) => void
+  onTogglePinned: (id: string) => void
+}) {
+  const title = session.title || "Untitled"
+  const activate = () => {
+    if (state !== "active") onSwitch(session.id)
+  }
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-boring-workspace-part="app-session-row"
+      data-boring-session-state={state}
+      onClick={activate}
+      onKeyDown={(event) => {
+        if (event.key !== "Enter" && event.key !== " ") return
+        event.preventDefault()
+        activate()
+      }}
+      className={cn(
+        "group flex min-h-9 w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+        state === "active"
+          ? "bg-foreground/[0.09] text-foreground"
+          : state === "open"
+            ? "bg-foreground/[0.045] text-foreground/90 hover:bg-foreground/[0.07]"
+            : "text-foreground/78 hover:bg-foreground/[0.055] hover:text-foreground",
+      )}
+    >
+      <Clock3
+        className={cn(
+          "h-3.5 w-3.5 shrink-0",
+          state === "active" ? "text-[color:var(--accent)]" : "text-muted-foreground/65",
+        )}
+        strokeWidth={1.75}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5" title={title}>{title}</span>
+      <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100 group-focus-within:opacity-100">
+        <span
+          role="button"
+          tabIndex={0}
+          aria-label={pinned ? `Unpin ${title}` : `Pin ${title}`}
+          title={pinned ? "Unpin" : "Pin"}
+          aria-pressed={pinned}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onTogglePinned(session.id)
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter" && event.key !== " ") return
+            event.preventDefault()
+            event.stopPropagation()
+            onTogglePinned(session.id)
+          }}
+          className={cn(
+            "grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+            pinned && "text-[color:var(--accent)]",
+          )}
+        >
+          <Pin className={cn("h-3.5 w-3.5", pinned && "fill-current")} strokeWidth={1.75} />
+        </span>
+        <span
+          role="button"
+          tabIndex={0}
+          aria-label={`Open ${title} in new chat pane`}
+          title="Open in new chat pane"
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onOpenAsPane(session.id)
+          }}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter" && event.key !== " ") return
+            event.preventDefault()
+            event.stopPropagation()
+            onOpenAsPane(session.id)
+          }}
+          className="grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+        >
+          <MessageSquarePlus className="h-3.5 w-3.5" strokeWidth={1.75} />
+        </span>
+      </span>
+    </div>
+  )
+}
+
+function resolveCurrentPluginWorkspacePage(
+  panels: readonly PanelConfig[],
+  snapshot: SurfaceShellSnapshot,
+  skillsPanelId: string,
+): OpenPanelConfig | undefined {
+  const workspacePages = panels.filter((panel) => (
+    isWorkspacePagePlacement(panel.placement)
+    && panel.id !== skillsPanelId
+    && panel.source !== "core"
+  ))
+  if (workspacePages.length === 0) return undefined
+
+  type ResolvedWorkspacePage = { panel: PanelConfig; tab?: SurfaceShellSnapshot["openTabs"][number] }
+  const byComponent = new Map(workspacePages.map((panel) => [panel.id, panel]))
+  const panelForTab = (tab: SurfaceShellSnapshot["openTabs"][number]): ResolvedWorkspacePage | undefined => {
+    const panel = byComponent.get(tab.component ?? tab.id)
+    return panel ? { panel, tab } : undefined
+  }
+  const activeTab = snapshot.activeTab
+    ? snapshot.openTabs.find((tab) => tab.id === snapshot.activeTab)
+    : undefined
+  const active = activeTab ? panelForTab(activeTab) : undefined
+  const lastOpen = [...snapshot.openTabs]
+    .reverse()
+    .map(panelForTab)
+    .find((entry): entry is ResolvedWorkspacePage => Boolean(entry))
+  const fallback: ResolvedWorkspacePage | undefined = workspacePages[0] ? { panel: workspacePages[0] } : undefined
+  const resolved: ResolvedWorkspacePage | undefined = active ?? lastOpen ?? fallback
+  return resolved ? {
+    id: resolved.tab?.id ?? resolved.panel.id,
+    component: resolved.panel.id,
+    title: resolved.tab?.title ?? resolved.panel.title,
+  } : undefined
+}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -109,7 +109,7 @@ export function AppLeftPane({
       </nav>
 
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
-        <CollapsibleSection title="Projects" defaultOpen={false}>
+        <CollapsibleSection title="Workspaces" defaultOpen={false}>
           <div className="flex min-h-9 w-full items-center gap-2 rounded-lg bg-foreground/[0.06] px-2.5 py-1.5 text-[13px] font-medium text-foreground">
             <span className="truncate">{appTitle || "Boring UI"}</span>
           </div>
@@ -144,7 +144,7 @@ function PrimaryAction({ icon, label, onClick }: { icon: ReactNode; label: strin
 
 /**
  * Collapsible section header with a rotating chevron. Matches the reference
- * shape: "Projects >" / "Chats >" — right-pointing chevron when collapsed,
+ * shape: "Workspaces >" / "Chats >" — right-pointing chevron when collapsed,
  * rotating 90° to point down when expanded.
  */
 function CollapsibleSection({

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -12,6 +12,7 @@ export interface AppLeftPaneSession {
 }
 
 export interface AppLeftPaneProps {
+  width?: number
   appTitle?: string
   sessionTitle?: string
   topSlot?: ReactNode
@@ -33,6 +34,7 @@ export interface AppLeftPaneProps {
 type SessionRowState = "normal" | "open" | "active"
 
 export function AppLeftPane({
+  width = 268,
   appTitle,
   topSlot,
   bottomSlot,
@@ -82,7 +84,8 @@ export function AppLeftPane({
   return (
     <aside
       data-boring-workspace-part="app-left-pane"
-      className="flex h-full min-h-0 w-[268px] shrink-0 flex-col border-r border-border bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)] text-sm"
+      className="flex h-full min-h-0 shrink-0 flex-col border-r border-border bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)] text-sm"
+      style={{ width, minWidth: width, maxWidth: width }}
       aria-label="App navigation"
     >
       {/* Top row: current project label (or host topSlot). The fixed-position

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useMemo, type ReactNode } from "react"
-import { Clock3, MessageSquarePlus, Pin, Plug, Plus, Search, Sparkles } from "lucide-react"
+import { useMemo, useState, type ReactNode } from "react"
+import { ChevronRight, Clock3, MessageSquarePlus, Pin, Plug, Plus, Search, Sparkles, PanelLeftClose } from "lucide-react"
+import { ControlTooltip } from "../../components/ControlTooltip"
 import { cn } from "../../lib/utils"
 
 export interface AppLeftPaneSession {
@@ -27,13 +28,16 @@ export interface AppLeftPaneProps {
   onToggleSessionPinned: (id: string) => void
   onOpenPlugins: () => void
   onOpenSkills: () => void
+  /** Collapse the app-left pane to nothing (reveal reserves nothing). Rendered
+   *  as an in-pane control so it matches the workbench-left "Hide workspace
+   *  menu" rail button rather than a floating corner chrome. */
+  onCollapse: () => void
 }
 
 type SessionRowState = "normal" | "open" | "active"
 
 export function AppLeftPane({
   appTitle,
-  sessionTitle,
   topSlot,
   bottomSlot,
   sessions,
@@ -47,6 +51,7 @@ export function AppLeftPane({
   onToggleSessionPinned,
   onOpenPlugins,
   onOpenSkills,
+  onCollapse,
 }: AppLeftPaneProps) {
   const openSet = useMemo(() => new Set(openSessionIds), [openSessionIds])
   const pinnedSet = useMemo(() => new Set(pinnedSessionIds), [pinnedSessionIds])
@@ -85,13 +90,31 @@ export function AppLeftPane({
       className="flex h-full min-h-0 w-[268px] shrink-0 flex-col border-r border-border bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)] text-sm"
       aria-label="App navigation"
     >
-      <header className="flex shrink-0 items-start border-b border-border/60 py-3 pl-11 pr-3">
+      {/* Top row: current project label (or host topSlot) + in-pane collapse
+          control. The collapse control mirrors the workbench-left "Hide
+          workspace menu" rail button (32px, 16px icon, ghost) so the app-nav
+          collapse reads as the same family as the workspace collapse. */}
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border/60 px-2 py-2">
         <div className="min-w-0 flex-1">
-          <div className="truncate text-[13px] font-semibold tracking-tight text-foreground">{appTitle || "Boring UI"}</div>
-          <div className="truncate text-[12px] text-muted-foreground">{sessionTitle || "New session"}</div>
-          {topSlot ? <div className="mt-2 min-w-0">{topSlot}</div> : null}
+          {topSlot ? (
+            topSlot
+          ) : (
+            <span className="truncate px-1 text-[12px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/70">
+              {appTitle || "Boring UI"}
+            </span>
+          )}
         </div>
-      </header>
+        <ControlTooltip label="Hide app navigation" side="bottom">
+          <button
+            type="button"
+            aria-label="Hide app navigation"
+            onClick={onCollapse}
+            className="grid size-8 shrink-0 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          >
+            <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
+          </button>
+        </ControlTooltip>
+      </div>
 
       <nav className="shrink-0 space-y-1 border-b border-border/60 px-2 py-2" aria-label="Primary workspace actions">
         <PrimaryAction icon={<Plus className="h-4 w-4" />} label="New chat" onClick={onCreateSession} />
@@ -101,12 +124,19 @@ export function AppLeftPane({
       </nav>
 
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
-        <SessionSection title="Pinned" empty="No pinned sessions yet.">
-          {pinnedSessions.map((session) => renderSession(session, true))}
-        </SessionSection>
-        <SessionSection title="Sessions" empty="No sessions yet.">
-          {regularSessions.map((session) => renderSession(session, false))}
-        </SessionSection>
+        <CollapsibleSection title="Projects" defaultOpen={false}>
+          <div className="flex min-h-9 w-full items-center gap-2 rounded-lg bg-foreground/[0.06] px-2.5 py-1.5 text-[13px] font-medium text-foreground">
+            <span className="truncate">{appTitle || "Boring UI"}</span>
+          </div>
+        </CollapsibleSection>
+        <CollapsibleSection title="Chats" defaultOpen>
+          <SessionSubSection title="Pinned" empty="No pinned sessions yet.">
+            {pinnedSessions.map((session) => renderSession(session, true))}
+          </SessionSubSection>
+          <SessionSubSection title="Sessions" empty="No sessions yet.">
+            {regularSessions.map((session) => renderSession(session, false))}
+          </SessionSubSection>
+        </CollapsibleSection>
       </div>
 
       {bottomSlot ? <footer className="shrink-0 border-t border-border/60 p-2">{bottomSlot}</footer> : null}
@@ -127,17 +157,52 @@ function PrimaryAction({ icon, label, onClick }: { icon: ReactNode; label: strin
   )
 }
 
-function SessionSection({ title, empty, children }: { title: string; empty: string; children: ReactNode }) {
+/**
+ * Collapsible section header with a rotating chevron. Matches the reference
+ * shape: "Projects >" / "Chats >" — right-pointing chevron when collapsed,
+ * rotating 90° to point down when expanded.
+ */
+function CollapsibleSection({
+  title,
+  defaultOpen = true,
+  children,
+}: {
+  title: string
+  defaultOpen?: boolean
+  children: ReactNode
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <section data-boring-workspace-part="app-left-pane-section" className="py-1">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/70 transition-colors hover:bg-foreground/[0.04] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+      >
+        <ChevronRight
+          className={cn("h-3.5 w-3.5 shrink-0 transition-transform duration-150", open && "rotate-90")}
+          strokeWidth={1.75}
+          aria-hidden="true"
+        />
+        <span>{title}</span>
+      </button>
+      {open ? <div className="mt-0.5 space-y-1.5">{children}</div> : null}
+    </section>
+  )
+}
+
+function SessionSubSection({ title, empty, children }: { title: string; empty: string; children: ReactNode }) {
   const hasChildren = Array.isArray(children) ? children.length > 0 : Boolean(children)
   return (
-    <section data-boring-workspace-part="app-left-pane-section" className="py-2">
-      <div className="px-2 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/60">
+    <div className="space-y-0.5">
+      <div className="px-2 pb-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-muted-foreground/50">
         {title}
       </div>
       <div className="space-y-0.5">
-        {hasChildren ? children : <div className="px-2 py-2 text-xs text-muted-foreground/70">{empty}</div>}
+        {hasChildren ? children : <div className="px-2 py-1.5 text-xs text-muted-foreground/70">{empty}</div>}
       </div>
-    </section>
+    </div>
   )
 }
 

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -11,6 +11,10 @@ export interface PluginTabsWorkspaceShellProps {
   children: ReactNode
   onExpand: () => void
   onCollapse: () => void
+  /** Optional content hosted as a chat left overlay (e.g. Skills / Plugins).
+   *  When set, rendered as an absolute panel over the chat region's left
+   *  edge — not as a workbench/workspace panel. */
+  leftOverlay?: ReactNode | null
   className?: string
 }
 
@@ -20,6 +24,7 @@ export function PluginTabsWorkspaceShell({
   children,
   onExpand,
   onCollapse,
+  leftOverlay,
   className,
 }: PluginTabsWorkspaceShellProps) {
   return (
@@ -29,17 +34,29 @@ export function PluginTabsWorkspaceShell({
       className={cn("relative flex h-full min-h-0 w-full overflow-hidden bg-background", className)}
     >
       {collapsed ? null : leftPane}
-      <div className="min-w-0 flex-1">{children}</div>
-:      <div className="pointer-events-none absolute left-3 top-2.5 z-[70]">
-        <CornerChromeButton
-          label={collapsed ? "Open app navigation" : "Collapse app navigation"}
-          side="right"
-          onClick={collapsed ? onExpand : onCollapse}
-          pressed={!collapsed}
-        >
-          <PanelLeft className="size-3" strokeWidth={1.75} />
-        </CornerChromeButton>
+      <div className="relative min-w-0 flex-1">
+        {children}
+        {leftOverlay ? (
+          <div
+            data-boring-workspace-part="chat-left-overlay"
+            className="absolute inset-y-0 left-0 z-40 flex w-[400px] max-w-[85%] flex-col border-r border-border bg-background"
+          >
+            {leftOverlay}
+          </div>
+        ) : null}
       </div>
+      {leftOverlay && collapsed ? null : (
+        <div className="pointer-events-none absolute left-3 top-2.5 z-[70]">
+          <CornerChromeButton
+            label={collapsed ? "Open app navigation" : "Collapse app navigation"}
+            side="right"
+            onClick={collapsed ? onExpand : onCollapse}
+            pressed={!collapsed}
+          >
+            <PanelLeft className="size-3" strokeWidth={1.75} />
+          </CornerChromeButton>
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -2,9 +2,8 @@
 
 import type { ReactNode } from "react"
 import { PanelLeft } from "lucide-react"
-import { IconButton } from "@hachej/boring-ui-kit"
-import { ControlTooltip } from "../../components/ControlTooltip"
 import { cn } from "../../lib/utils"
+import { CornerChromeButton } from "../cornerChrome"
 
 export interface PluginTabsWorkspaceShellProps {
   collapsed: boolean
@@ -31,24 +30,15 @@ export function PluginTabsWorkspaceShell({
     >
       {collapsed ? null : leftPane}
       <div className="min-w-0 flex-1">{children}</div>
-      <div className="pointer-events-none absolute left-3 top-3 z-[70]">
-        <ControlTooltip label={collapsed ? "Open app navigation" : "Collapse app navigation"} side="right">
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            onClick={collapsed ? onExpand : onCollapse}
-            aria-label={collapsed ? "Open app navigation" : "Collapse app navigation"}
-            title={collapsed ? "Open app navigation" : "Collapse app navigation"}
-            aria-pressed={!collapsed}
-            className={cn(
-              "pointer-events-auto !h-9 !w-9 rounded-xl bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_10px_-5px_oklch(0_0_0/0.18),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-ring/40",
-              !collapsed && "bg-foreground/[0.09] text-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.10),0_4px_14px_-6px_oklch(0_0_0/0.22),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.9)]",
-            )}
-          >
-            <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
-          </IconButton>
-        </ControlTooltip>
+:      <div className="pointer-events-none absolute left-3 top-2 z-[70]">
+        <CornerChromeButton
+          label={collapsed ? "Open app navigation" : "Collapse app navigation"}
+          side="right"
+          onClick={collapsed ? onExpand : onCollapse}
+          pressed={!collapsed}
+        >
+          <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
+        </CornerChromeButton>
       </div>
     </div>
   )

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { PanelLeftOpen } from "lucide-react"
+import { IconButton } from "@hachej/boring-ui-kit"
+import { ControlTooltip } from "../../components/ControlTooltip"
+import { cn } from "../../lib/utils"
+
+export interface PluginTabsWorkspaceShellProps {
+  collapsed: boolean
+  leftPane: ReactNode
+  children: ReactNode
+  onExpand: () => void
+  className?: string
+}
+
+export function PluginTabsWorkspaceShell({
+  collapsed,
+  leftPane,
+  children,
+  onExpand,
+  className,
+}: PluginTabsWorkspaceShellProps) {
+  return (
+    <div
+      data-boring-workspace-part="plugin-tabs-shell"
+      data-boring-state={collapsed ? "collapsed" : "expanded"}
+      className={cn("relative flex h-full min-h-0 w-full overflow-hidden bg-background", className)}
+    >
+      {collapsed ? null : leftPane}
+      <div className="min-w-0 flex-1">{children}</div>
+      {collapsed ? (
+        <div className="pointer-events-none absolute left-2 top-[52px] z-40">
+          <ControlTooltip label="Open app navigation" side="right">
+            <IconButton
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={onExpand}
+              aria-label="Open app navigation"
+              title="Open app navigation"
+              className="pointer-events-auto h-9 w-9 rounded-lg bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_8px_-4px_oklch(0_0_0/0.10),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur hover:bg-muted hover:text-foreground"
+            >
+              <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
+            </IconButton>
+          </ControlTooltip>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
+import { PanelLeft } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { PaneCollapseButton } from "../paneCollapseButton"
 
@@ -33,8 +33,8 @@ export function PluginTabsWorkspaceShell({
         {children}
       </div>
 
-      {/* One collapse rule: same place, same button style in both states;
-          only the icon changes. The app pane reserves matching header padding
+      {/* One collapse rule: same place, same button style, same plain panel
+          icon in both states. The app pane reserves matching header padding
           while expanded, and the collapsed chat tab strip keeps 48px leading
           clearance via dockview-overrides.css. */}
       <div className="pointer-events-none absolute left-1.5 top-2 z-[70]">
@@ -43,11 +43,7 @@ export function PluginTabsWorkspaceShell({
           side="right"
           onClick={collapsed ? onExpand : onCollapse}
         >
-          {collapsed ? (
-            <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
-          ) : (
-            <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
-          )}
+          <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
         </PaneCollapseButton>
       </div>
     </div>

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -1,20 +1,16 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { PanelLeftOpen } from "lucide-react"
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
 import { cn } from "../../lib/utils"
-import { CornerChromeButton } from "../cornerChrome"
+import { PaneCollapseButton } from "../paneCollapseButton"
 
 export interface PluginTabsWorkspaceShellProps {
   collapsed: boolean
   leftPane: ReactNode
   children: ReactNode
   onExpand: () => void
-  /** Optional content hosted as a chat overlay (e.g. Skills / Plugins).
-   *  When set, rendered over the entire chat region — not as a workbench/
-   *  workspace panel — so it covers all open chat panes (including split
-   *  panes), not just the left edge. */
-  leftOverlay?: ReactNode | null
+  onCollapse: () => void
   className?: string
 }
 
@@ -23,7 +19,7 @@ export function PluginTabsWorkspaceShell({
   leftPane,
   children,
   onExpand,
-  leftOverlay,
+  onCollapse,
   className,
 }: PluginTabsWorkspaceShellProps) {
   return (
@@ -35,36 +31,25 @@ export function PluginTabsWorkspaceShell({
       {collapsed ? null : leftPane}
       <div className="relative min-w-0 flex-1">
         {children}
-        {leftOverlay ? (
-          <div
-            data-boring-workspace-part="chat-left-overlay"
-            className="absolute inset-0 z-40 flex bg-background"
-          >
-            <div className="mx-auto flex w-full max-w-2xl flex-col border-x border-border bg-background">
-              {leftOverlay}
-            </div>
-          </div>
-        ) : null}
       </div>
-      {/* Collapsed-only restore control. When the pane is expanded, the
-          collapse control lives inside AppLeftPane (matching the
-          workbench-left "Hide workspace menu" rail button). When collapsed,
-          render a floating restore control whose icon size (16px) matches the
-          workbench "Show workspace menu" overlay so the two left-pane collapse
-          controls read as the same family. Hidden while a chat overlay is open
-          over the collapsed pane. */}
-      {collapsed && !leftOverlay ? (
-        <div className="pointer-events-none absolute left-3 top-2.5 z-[70]">
-          <CornerChromeButton
-            label="Open app navigation"
-            side="right"
-            onClick={onExpand}
-            pressed={false}
-          >
+
+      {/* One collapse rule: same place, same button style in both states;
+          only the icon changes. The app pane reserves matching header padding
+          while expanded, and the collapsed chat tab strip keeps 48px leading
+          clearance via dockview-overrides.css. */}
+      <div className="pointer-events-none absolute left-1.5 top-2 z-[70]">
+        <PaneCollapseButton
+          label={collapsed ? "Open app navigation" : "Hide app navigation"}
+          side="right"
+          onClick={collapsed ? onExpand : onCollapse}
+        >
+          {collapsed ? (
             <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
-          </CornerChromeButton>
-        </div>
-      ) : null}
+          ) : (
+            <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
+          )}
+        </PaneCollapseButton>
+      </div>
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -42,7 +42,7 @@ export function PluginTabsWorkspaceShell({
             title={collapsed ? "Open app navigation" : "Collapse app navigation"}
             aria-pressed={!collapsed}
             className={cn(
-              "pointer-events-auto h-9 w-9 rounded-xl bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_10px_-5px_oklch(0_0_0/0.18),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-ring/40",
+              "pointer-events-auto !h-9 !w-9 rounded-xl bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_10px_-5px_oklch(0_0_0/0.18),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-ring/40",
               !collapsed && "bg-foreground/[0.09] text-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.10),0_4px_14px_-6px_oklch(0_0_0/0.22),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.9)]",
             )}
           >

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -1,9 +1,48 @@
 "use client"
 
-import type { ReactNode } from "react"
+import { useCallback, useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from "react"
 import { PanelLeft } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { PaneCollapseButton } from "../paneCollapseButton"
+
+function AppLeftPaneResizeHandle({ onResize }: { onResize: (delta: number) => void }) {
+  const lastXRef = useRef<number | null>(null)
+  const handlePointerMove = useCallback((event: PointerEvent) => {
+    if (lastXRef.current == null) return
+    const delta = event.clientX - lastXRef.current
+    lastXRef.current = event.clientX
+    if (delta !== 0) onResize(delta)
+  }, [onResize])
+  const stopResize = useCallback(() => {
+    lastXRef.current = null
+    document.body.style.cursor = ""
+    document.body.style.userSelect = ""
+    window.removeEventListener("pointermove", handlePointerMove)
+    window.removeEventListener("pointerup", stopResize)
+  }, [handlePointerMove])
+  const startResize = useCallback((event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.currentTarget.setPointerCapture?.(event.pointerId)
+    lastXRef.current = event.clientX
+    document.body.style.cursor = "col-resize"
+    document.body.style.userSelect = "none"
+    window.addEventListener("pointermove", handlePointerMove)
+    window.addEventListener("pointerup", stopResize)
+  }, [handlePointerMove, stopResize])
+
+  return (
+    <div
+      role="separator"
+      aria-label="Resize app navigation"
+      aria-orientation="vertical"
+      tabIndex={0}
+      onPointerDown={startResize}
+      className="group relative z-20 -ml-px w-1 shrink-0 cursor-col-resize touch-none bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+    >
+      <span className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-transparent transition-colors group-hover:bg-foreground/30 group-active:bg-foreground/45" />
+    </div>
+  )
+}
 
 export interface PluginTabsWorkspaceShellProps {
   collapsed: boolean
@@ -11,6 +50,7 @@ export interface PluginTabsWorkspaceShellProps {
   children: ReactNode
   onExpand: () => void
   onCollapse: () => void
+  onResizeLeftPane?: (delta: number) => void
   className?: string
 }
 
@@ -20,6 +60,7 @@ export function PluginTabsWorkspaceShell({
   children,
   onExpand,
   onCollapse,
+  onResizeLeftPane,
   className,
 }: PluginTabsWorkspaceShellProps) {
   return (
@@ -29,6 +70,7 @@ export function PluginTabsWorkspaceShell({
       className={cn("relative flex h-full min-h-0 w-full overflow-hidden bg-background", className)}
     >
       {collapsed ? null : leftPane}
+      {!collapsed && onResizeLeftPane ? <AppLeftPaneResizeHandle onResize={onResizeLeftPane} /> : null}
       <div className="relative min-w-0 flex-1">
         {children}
       </div>

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { PanelLeftOpen } from "lucide-react"
+import { PanelLeft } from "lucide-react"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { cn } from "../../lib/utils"
@@ -11,6 +11,7 @@ export interface PluginTabsWorkspaceShellProps {
   leftPane: ReactNode
   children: ReactNode
   onExpand: () => void
+  onCollapse: () => void
   className?: string
 }
 
@@ -19,6 +20,7 @@ export function PluginTabsWorkspaceShell({
   leftPane,
   children,
   onExpand,
+  onCollapse,
   className,
 }: PluginTabsWorkspaceShellProps) {
   return (
@@ -29,23 +31,25 @@ export function PluginTabsWorkspaceShell({
     >
       {collapsed ? null : leftPane}
       <div className="min-w-0 flex-1">{children}</div>
-      {collapsed ? (
-        <div className="pointer-events-none absolute left-2 top-[52px] z-40">
-          <ControlTooltip label="Open app navigation" side="right">
-            <IconButton
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              onClick={onExpand}
-              aria-label="Open app navigation"
-              title="Open app navigation"
-              className="pointer-events-auto h-9 w-9 rounded-lg bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_8px_-4px_oklch(0_0_0/0.10),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur hover:bg-muted hover:text-foreground"
-            >
-              <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
-            </IconButton>
-          </ControlTooltip>
-        </div>
-      ) : null}
+      <div className="pointer-events-none absolute left-3 top-3 z-[70]">
+        <ControlTooltip label={collapsed ? "Open app navigation" : "Collapse app navigation"} side="right">
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={collapsed ? onExpand : onCollapse}
+            aria-label={collapsed ? "Open app navigation" : "Collapse app navigation"}
+            title={collapsed ? "Open app navigation" : "Collapse app navigation"}
+            aria-pressed={!collapsed}
+            className={cn(
+              "pointer-events-auto h-9 w-9 rounded-xl bg-background/90 text-muted-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.08),0_2px_10px_-5px_oklch(0_0_0/0.18),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.75)] backdrop-blur transition-colors hover:bg-muted hover:text-foreground focus-visible:ring-ring/40",
+              !collapsed && "bg-foreground/[0.09] text-foreground shadow-[0_1px_2px_-1px_oklch(0_0_0/0.10),0_4px_14px_-6px_oklch(0_0_0/0.22),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.9)]",
+            )}
+          >
+            <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
+          </IconButton>
+        </ControlTooltip>
+      </div>
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
+import { PanelLeftOpen } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { CornerChromeButton } from "../cornerChrome"
 
@@ -10,10 +10,10 @@ export interface PluginTabsWorkspaceShellProps {
   leftPane: ReactNode
   children: ReactNode
   onExpand: () => void
-  onCollapse: () => void
-  /** Optional content hosted as a chat left overlay (e.g. Skills / Plugins).
-   *  When set, rendered as an absolute panel over the chat region's left
-   *  edge — not as a workbench/workspace panel. */
+  /** Optional content hosted as a chat overlay (e.g. Skills / Plugins).
+   *  When set, rendered over the entire chat region — not as a workbench/
+   *  workspace panel — so it covers all open chat panes (including split
+   *  panes), not just the left edge. */
   leftOverlay?: ReactNode | null
   className?: string
 }
@@ -23,7 +23,6 @@ export function PluginTabsWorkspaceShell({
   leftPane,
   children,
   onExpand,
-  onCollapse,
   leftOverlay,
   className,
 }: PluginTabsWorkspaceShellProps) {
@@ -39,28 +38,33 @@ export function PluginTabsWorkspaceShell({
         {leftOverlay ? (
           <div
             data-boring-workspace-part="chat-left-overlay"
-            className="absolute inset-y-0 left-0 z-40 flex w-[400px] max-w-[85%] flex-col border-r border-border bg-background"
+            className="absolute inset-0 z-40 flex bg-background"
           >
-            {leftOverlay}
+            <div className="mx-auto flex w-full max-w-2xl flex-col border-x border-border bg-background">
+              {leftOverlay}
+            </div>
           </div>
         ) : null}
       </div>
-      {leftOverlay && collapsed ? null : (
+      {/* Collapsed-only restore control. When the pane is expanded, the
+          collapse control lives inside AppLeftPane (matching the
+          workbench-left "Hide workspace menu" rail button). When collapsed,
+          render a floating restore control whose icon size (16px) matches the
+          workbench "Show workspace menu" overlay so the two left-pane collapse
+          controls read as the same family. Hidden while a chat overlay is open
+          over the collapsed pane. */}
+      {collapsed && !leftOverlay ? (
         <div className="pointer-events-none absolute left-3 top-2.5 z-[70]">
           <CornerChromeButton
-            label={collapsed ? "Open app navigation" : "Collapse app navigation"}
+            label="Open app navigation"
             side="right"
-            onClick={collapsed ? onExpand : onCollapse}
-            pressed={!collapsed}
+            onClick={onExpand}
+            pressed={false}
           >
-            {collapsed ? (
-              <PanelLeftOpen className="size-3" strokeWidth={1.75} />
-            ) : (
-              <PanelLeftClose className="size-3" strokeWidth={1.75} />
-            )}
+            <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
           </CornerChromeButton>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { PanelLeft } from "lucide-react"
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { CornerChromeButton } from "../cornerChrome"
 
@@ -53,7 +53,11 @@ export function PluginTabsWorkspaceShell({
             onClick={collapsed ? onExpand : onCollapse}
             pressed={!collapsed}
           >
-            <PanelLeft className="size-3" strokeWidth={1.75} />
+            {collapsed ? (
+              <PanelLeftOpen className="size-3" strokeWidth={1.75} />
+            ) : (
+              <PanelLeftClose className="size-3" strokeWidth={1.75} />
+            )}
           </CornerChromeButton>
         </div>
       )}

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -30,14 +30,14 @@ export function PluginTabsWorkspaceShell({
     >
       {collapsed ? null : leftPane}
       <div className="min-w-0 flex-1">{children}</div>
-:      <div className="pointer-events-none absolute left-3 top-2 z-[70]">
+:      <div className="pointer-events-none absolute left-3 top-2.5 z-[70]">
         <CornerChromeButton
           label={collapsed ? "Open app navigation" : "Collapse app navigation"}
           side="right"
           onClick={collapsed ? onExpand : onCollapse}
           pressed={!collapsed}
         >
-          <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
+          <PanelLeft className="size-3" strokeWidth={1.75} />
         </CornerChromeButton>
       </div>
     </div>

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCallback, useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from "react"
-import { PanelLeft } from "lucide-react"
+import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { PaneCollapseButton } from "../paneCollapseButton"
 
@@ -75,17 +75,21 @@ export function PluginTabsWorkspaceShell({
         {children}
       </div>
 
-      {/* One collapse rule: same place, same button style, same plain panel
-          icon in both states. The app pane reserves matching header padding
-          while expanded, and the collapsed chat tab strip keeps 48px leading
-          clearance via dockview-overrides.css. */}
+      {/* One collapse rule: same place and style in both states; only the
+          quiet panel glyph changes to show open vs close mode. The app pane
+          reserves matching header padding while expanded, and the collapsed
+          chat tab strip keeps 48px leading clearance via dockview-overrides.css. */}
       <div className="pointer-events-none absolute left-1.5 top-2 z-[70]">
         <PaneCollapseButton
           label={collapsed ? "Open app navigation" : "Hide app navigation"}
           side="right"
           onClick={collapsed ? onExpand : onCollapse}
         >
-          <PanelLeft className="h-4 w-4" strokeWidth={1.75} />
+          {collapsed ? (
+            <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
+          ) : (
+            <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
+          )}
         </PaneCollapseButton>
       </div>
     </div>

--- a/packages/workspace/src/front/layout/types.ts
+++ b/packages/workspace/src/front/layout/types.ts
@@ -22,6 +22,8 @@ export interface ChatLayoutProps {
   flashChatPaneId?: string | null
   surface?: string | null
   surfaceParams?: Record<string, unknown>
+  /** Opaque overlay rendered over the full chat stage only (not over the workbench). */
+  chatOverlay?: ReactNode
   surfaceOverlay?: ReactNode
   sidebar?: string | null
   sidebarParams?: Record<string, unknown>

--- a/packages/workspace/src/front/plugin/__tests__/useWorkspacePluginClient.test.tsx
+++ b/packages/workspace/src/front/plugin/__tests__/useWorkspacePluginClient.test.tsx
@@ -36,6 +36,8 @@ describe("createWorkspacePluginClient", () => {
 
     await expect(client.postJson("https://attacker.example/collect", {})).rejects.toThrow("same-origin API paths")
     await expect(client.postJson("//attacker.example/collect", {})).rejects.toThrow("same-origin API paths")
+    await expect(client.getJson("https://attacker.example/collect")).rejects.toThrow("same-origin API paths")
+    await expect(client.getJson("//attacker.example/collect")).rejects.toThrow("same-origin API paths")
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
@@ -94,6 +96,32 @@ describe("createWorkspacePluginClient", () => {
     )
     const firstCall = fetchMock.mock.calls[0] as unknown as [string, RequestInit]
     expect(firstCall[1].body).toBeUndefined()
+  })
+
+  it("adds workspace query, workspace header, and auth headers for GET requests", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const client = createWorkspacePluginClient("/base/", "workspace-1", {
+      Authorization: "Bearer token",
+    })
+
+    await client.getJson("/api/v1/agent/skills?refresh=1")
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/base/api/v1/agent/skills?refresh=1&workspaceId=workspace-1",
+      expect.objectContaining({
+        credentials: "include",
+        method: "GET",
+        headers: {
+          Authorization: "Bearer token",
+          "x-boring-workspace-id": "workspace-1",
+        },
+      }),
+    )
   })
 
   it("adds workspace query, workspace header, auth headers, and JSON content type", async () => {

--- a/packages/workspace/src/front/plugin/useWorkspacePluginClient.ts
+++ b/packages/workspace/src/front/plugin/useWorkspacePluginClient.ts
@@ -4,6 +4,7 @@ export interface WorkspacePluginClient {
   apiBaseUrl: string
   workspaceId?: string
   workspaceHeaders(): Record<string, string>
+  getJson<T = unknown>(path: string, options?: { missingMessage?: string }): Promise<T>
   readJsonFile<T>(path: string, options?: { missingMessage?: string }): Promise<T>
   postJson<T = unknown>(path: string, body?: unknown, options?: { headers?: Record<string, string> }): Promise<T>
   sendAgentPrompt(message: string, options?: { title?: string; noncePrefix?: string }): Promise<void>
@@ -123,6 +124,10 @@ function createWorkspacePluginClientWithOptions(
     }
     return await response.json() as T
   }
+  const getJson = async <T = unknown,>(
+    path: string,
+    options?: { missingMessage?: string },
+  ): Promise<T> => fetchJson<T>(path, { method: "GET" }, options?.missingMessage ?? `request failed for ${path}`)
   const postJson = async <T = unknown,>(
     path: string,
     body?: unknown,
@@ -164,6 +169,7 @@ function createWorkspacePluginClientWithOptions(
     apiBaseUrl: base,
     ...(workspaceId ? { workspaceId } : {}),
     workspaceHeaders,
+    getJson,
     readJsonFile,
     postJson,
     sendAgentPrompt,

--- a/packages/workspace/src/front/provider/WorkspaceProvider.tsx
+++ b/packages/workspace/src/front/provider/WorkspaceProvider.tsx
@@ -26,7 +26,7 @@ import { createBridge } from "../bridge/createBridge"
 import { postUiCommand } from "../bridge"
 import { createBridgeClient, type BridgeClient } from "../bridge/client"
 import { PanelRenderStatusProvider } from "../registry/PanelRenderStatusBoundary"
-import { CommandPalette } from "../components/CommandPalette"
+import { CommandPalette, type CommandPaletteSessionSearchConfig } from "../components/CommandPalette"
 import { events, workspaceEvents } from "../events"
 import { Toaster } from "../toast"
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts"
@@ -380,6 +380,7 @@ export interface WorkspaceProviderProps {
    */
   frontPluginHotReload?: FrontPluginHotReloadMode
   fullPageBasePath?: string
+  commandPaletteSessionSearch?: CommandPaletteSessionSearchConfig
 }
 
 // ---------------------------------------------------------------------------
@@ -426,6 +427,7 @@ export function WorkspaceProvider({
   debug = false,
   frontPluginHotReload = (typeof import.meta !== 'undefined' && import.meta.env?.DEV) ? 'vite' as const : false,
   fullPageBasePath,
+  commandPaletteSessionSearch,
 }: WorkspaceProviderProps) {
   const storeRef = useRef<ReturnType<typeof createWorkspaceStore> | null>(null)
   if (!storeRef.current) {
@@ -653,7 +655,7 @@ export function WorkspaceProvider({
                       catalogs={catalogs}
                     />
                     <WorkspaceShortcuts store={store} />
-                    <CommandPalette />
+                    <CommandPalette sessionSearch={commandPaletteSessionSearch} />
                     <Toaster />
                     {children}
                     {(typeof import.meta !== 'undefined' && import.meta.env?.DEV) && <PluginInspector plugins={pluginMetas} />}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditorPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditorPane.tsx
@@ -31,10 +31,11 @@ function extToLanguage(path: string): string {
   }
 }
 
-export type CodeEditorPaneProps = PaneProps<{ path?: string }>
+export type CodeEditorPaneProps = PaneProps<{ path?: string; mode?: "view" | "edit" | "diff" }>
 
 export function CodeEditorPane({ params, api, className }: CodeEditorPaneProps) {
   const path = typeof params?.path === "string" ? params.path : ""
+  const readOnly = params?.mode === "view"
 
   const {
     content,
@@ -65,7 +66,7 @@ export function CodeEditorPane({ params, api, className }: CodeEditorPaneProps) 
       onReload={onReloadFromServer}
       onOverwrite={onOverwrite}
       editorComponent={CodeEditor}
-      editorProps={{ language, wordWrap: true, className }}
+      editorProps={{ language, wordWrap: true, className, readOnly }}
     />
   )
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditor.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditor.tsx
@@ -526,6 +526,7 @@ export function MarkdownEditor({
   // Stable ref so handlePaste (created once in useEditor) always calls the latest version.
   const insertImageRef = useRef<(file: File) => Promise<void>>(async () => {})
   insertImageRef.current = async (file: File) => {
+    userInteractedRef.current = true
     const editor = editorRef.current
     if (!editor) return
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditor.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditor.tsx
@@ -107,14 +107,19 @@ function isExternalImageSrc(src: string): boolean {
  * propagating to `onChange`.
  *
  * TipTap fires `onUpdate` not only for typed input but also while the editor
- * settles on init / remount / DOM re-parent, which can momentarily report an
- * empty document right after non-empty content was loaded. Emptying a document
- * is only ever a user action when the editor is focused (it requires keyboard
- * input), so an empty emission from an unfocused editor is a spurious artifact.
- * Dropping it prevents autosave from overwriting a real file with "".
+ * settles on init / remount / DOM re-parent. Those unfocused emissions can be
+ * non-empty normalized markdown (for example frontmatter rewritten as a rule +
+ * heading), so saving them can corrupt files before the user touches anything.
+ * Keep toolbar edits working too: focus may be on a toolbar button, so a prior
+ * pointer/key interaction inside this editor shell also marks updates as user
+ * initiated.
  */
-export function isUserEditedChange(nextContent: string, editorFocused: boolean): boolean {
-  return !(nextContent === "" && !editorFocused)
+export function isUserEditedChange(
+  _nextContent: string,
+  editorFocused: boolean,
+  userInteracted = false,
+): boolean {
+  return editorFocused || userInteracted
 }
 
 function normalizeRelativeImagePath(src: string, documentPath?: string): string {
@@ -508,6 +513,7 @@ export function MarkdownEditor({
   const onChangeRef = useRef(onChange)
   onChangeRef.current = onChange
   const suppressChangeRef = useRef(false)
+  const userInteractedRef = useRef(false)
   // Tracks the last markdown string the editor itself emitted (or was seeded
   // with). TipTap normalizes markdown on serialize, so the `content` prop that
   // comes back from a save round-trip rarely equals the original disk bytes.
@@ -614,7 +620,7 @@ export function MarkdownEditor({
       lastEmittedRef.current = next
       // Drop a transient empty emission from an unfocused editor (settling on
       // init/remount); real edits — typing AND toolbar actions — still flow.
-      if (!isUserEditedChange(next, e.isFocused)) return
+      if (!isUserEditedChange(next, e.isFocused, userInteractedRef.current)) return
       onChangeRef.current?.(next)
     },
   })
@@ -657,7 +663,12 @@ export function MarkdownEditor({
   }
 
   return (
-    <div className={cn("flex h-full min-h-0 flex-col overflow-hidden", className)}>
+    <div
+      className={cn("flex h-full min-h-0 flex-col overflow-hidden", className)}
+      onPointerDownCapture={() => { userInteractedRef.current = true }}
+      onClickCapture={() => { userInteractedRef.current = true }}
+      onKeyDownCapture={() => { userInteractedRef.current = true }}
+    >
       {!readOnly && (
         <Toolbar
           editor={editor}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditorPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditorPane.tsx
@@ -12,10 +12,11 @@ const MarkdownEditor = lazy(() =>
 // `path` is optional: dockview can restore a panel from serialized
 // layout where params got lost. Read defensively, render a placeholder
 // rather than crash when path isn't there.
-export type MarkdownEditorPaneProps = PaneProps<{ path?: string }>
+export type MarkdownEditorPaneProps = PaneProps<{ path?: string; mode?: "view" | "edit" | "diff" }>
 
 export function MarkdownEditorPane({ params, api, className }: MarkdownEditorPaneProps) {
   const path = typeof params?.path === "string" ? params.path : ""
+  const readOnly = params?.mode === "view"
 
   const {
     content,
@@ -44,7 +45,7 @@ export function MarkdownEditorPane({ params, api, className }: MarkdownEditorPan
       onReload={onReloadFromServer}
       onOverwrite={onOverwrite}
       editorComponent={MarkdownEditor}
-      editorProps={{ className, documentPath: path }}
+      editorProps={{ className, documentPath: path, readOnly }}
     />
   )
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditor.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditor.test.tsx
@@ -47,18 +47,19 @@ describe("MarkdownEditor", () => {
   })
 
   describe("isUserEditedChange", () => {
-    // Regression: an editor that emits an empty document while unfocused is a
-    // spurious init/remount/re-parent artifact, not a user clearing the file.
-    // Propagating it let autosave overwrite a real markdown file with "".
-    it("drops an empty emission from an unfocused editor", () => {
+    // Regression: TipTap can emit non-empty normalized markdown while settling
+    // an unfocused editor. Propagating that let autosave rewrite untouched
+    // SKILL.md frontmatter into rendered markdown.
+    it("drops unfocused emissions even when they are non-empty", () => {
+      expect(isUserEditedChange("---\n\n## name: local-test", false)).toBe(false)
       expect(isUserEditedChange("", false)).toBe(false)
     })
-    it("keeps an empty emission while the editor is focused (user cleared it)", () => {
+    it("keeps focused emissions, including a user clearing the file", () => {
       expect(isUserEditedChange("", true)).toBe(true)
-    })
-    it("keeps non-empty emissions regardless of focus", () => {
-      expect(isUserEditedChange("hello", false)).toBe(true)
       expect(isUserEditedChange("hello", true)).toBe(true)
+    })
+    it("keeps toolbar/button edits after explicit user interaction", () => {
+      expect(isUserEditedChange("hello", false, true)).toBe(true)
     })
   })
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditorPane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditorPane.test.tsx
@@ -102,6 +102,14 @@ describe("MarkdownEditorPane", () => {
     )
   })
 
+  it("opens Markdown files read-only when panel mode is view", async () => {
+    const props = createMockPaneProps({ params: { path: "SKILL.md", mode: "view" as const } })
+    render(<MarkdownEditorPane {...props} />, { wrapper })
+    await waitFor(() => {
+      expect(screen.getByTestId("markdown-editor")).toHaveAttribute("data-readonly", "true")
+    })
+  })
+
   it("shows error state on load failure", () => {
     mockFileContent.mockReturnValue({
       data: undefined,

--- a/packages/workspace/src/server/agentPlugins/routes.ts
+++ b/packages/workspace/src/server/agentPlugins/routes.ts
@@ -42,8 +42,10 @@ export interface BoringPluginRoutesOptions {
 export async function boringPluginRoutes(app: FastifyInstance, opts: BoringPluginRoutesOptions): Promise<void> {
   const { manager } = opts
 
-  const listPlugins = async () => manager.list()
-  app.get("/api/v1/agent-plugins", listPlugins)
+  const listPlugins = async (request: FastifyRequest<{ Querystring: { external?: string } }>) => (
+    request.query.external === "1" ? manager.listExternal() : manager.list()
+  )
+  app.get<{ Querystring: { external?: string } }>("/api/v1/agent-plugins", listPlugins)
 
   const getPluginError = async (request: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
     const error = manager.getError(request.params.id)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
 
   packages/agent:
     dependencies:
+      '@earendil-works/pi-tui':
+        specifier: 0.75.5
+        version: 0.75.5
       '@hachej/boring-ui-kit':
         specifier: workspace:*
         version: link:../ui

--- a/scripts/review-workspace-playground-ui.mjs
+++ b/scripts/review-workspace-playground-ui.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+/**
+ * Capture workspace-playground UI states and ask Gemini for a visual rating.
+ *
+ * Usage:
+ *   # Start playground separately first.
+ *   pnpm review:workspace-ui
+ *
+ * Options/env:
+ *   SHOT_BASE_URL=http://127.0.0.1:5255
+ *   UI_REVIEW_OUT=artifacts/ui-review/<name>
+ *   GEMINI_API_KEY=...       # optional; falls back to vault secret/agent/gemini
+ *   GEMINI_MODEL=gemini-3.1-pro-preview
+ *   MIN_RATING=9
+ *   SKIP_GEMINI=1            # capture screenshots only
+ */
+import { chromium } from "@playwright/test"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { execFileSync } from "node:child_process"
+import { basename, dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const ROOT = resolve(__dirname, "..")
+const BASE = process.env.SHOT_BASE_URL || "http://127.0.0.1:5255"
+const OUT = resolve(ROOT, process.env.UI_REVIEW_OUT || `artifacts/ui-review/${new Date().toISOString().replace(/[:.]/g, "-")}`)
+const MODEL = process.env.GEMINI_MODEL || "gemini-3.1-pro-preview"
+const MIN_RATING = Number(process.env.MIN_RATING || "9")
+const SKIP_GEMINI = process.env.SKIP_GEMINI === "1"
+const VIEWPORT = { width: 1440, height: 900 }
+const TABLET_VIEWPORT = { width: 980, height: 760 }
+
+const shots = []
+const metrics = {}
+
+function shotPath(id) {
+  return resolve(OUT, `${String(shots.length + 1).padStart(2, "0")}-${id}.png`)
+}
+
+async function screenshot(page, id, description, options = {}) {
+  const path = shotPath(id)
+  await page.screenshot({ path, ...options })
+  shots.push({ id, path, file: basename(path), description })
+  console.log("captured", basename(path), "-", description)
+}
+
+async function box(page, selector) {
+  return await page.evaluate((sel) => {
+    const el = document.querySelector(sel)
+    if (!el) return null
+    const r = el.getBoundingClientRect()
+    const style = getComputedStyle(el)
+    return { x: r.x, y: r.y, width: r.width, height: r.height, position: style.position, zIndex: style.zIndex }
+  }, selector)
+}
+
+async function innerText(page, selector) {
+  return await page.locator(selector).first().innerText().catch(() => null)
+}
+
+async function openWorkbench(page) {
+  const btn = page.getByRole("button", { name: "Open workbench" }).first()
+  if (await btn.isVisible().catch(() => false)) {
+    await btn.click()
+    await page.waitForTimeout(900)
+  }
+}
+
+async function closeOverlayIfOpen(page, label) {
+  const btn = page.getByRole("button", { name: label }).first()
+  if (await btn.isVisible().catch(() => false)) {
+    await btn.click()
+    await page.waitForTimeout(250)
+  }
+}
+
+async function captureDesktop(browser) {
+  const ctx = await browser.newContext({ viewport: VIEWPORT, deviceScaleFactor: 1 })
+  const page = await ctx.newPage()
+  await page.goto(`${BASE}?fresh=1&ui-review=1`, { waitUntil: "domcontentloaded", timeout: 60_000 })
+  await page.waitForTimeout(2400)
+
+  const appNav = page.getByLabel("App navigation")
+  metrics.initial = {
+    appLeft: await box(page, '[data-boring-workspace-part="app-left-pane"]'),
+    chat: await box(page, '[data-boring-workspace-part="chat-stage"]'),
+    workbench: await box(page, '[data-boring-workspace-part="workbench"]'),
+  }
+  await screenshot(page, "desktop-left-bar", "Desktop default: app-left navigation, Workspaces/Chats sections, chat stage")
+
+  const rowsBefore = await page.locator('[data-boring-workspace-part="app-session-row"]').count()
+  await appNav.getByRole("button", { name: "New chat", exact: true }).click()
+  await page.waitForTimeout(1200)
+  const rowsAfter = await page.locator('[data-boring-workspace-part="app-session-row"]').count()
+  metrics.newChat = { rowsBefore, rowsAfter, increments: rowsAfter > rowsBefore }
+  await screenshot(page, "new-chat-created", "After clicking New chat in the left pane")
+
+  await openWorkbench(page)
+  metrics.workbenchOpen = {
+    chat: await box(page, '[data-boring-workspace-part="chat-stage"]'),
+    workbench: await box(page, '[data-boring-workspace-part="workbench"]'),
+    appHideButton: await box(page, '[aria-label="Hide app navigation"]'),
+    workspaceMenuButton: await box(page, '[aria-label="Hide workspace menu"]'),
+  }
+  await screenshot(page, "workbench-open", "Workbench open next to chat")
+
+  await appNav.getByRole("button", { name: "Skills", exact: true }).click()
+  await page.waitForTimeout(1000)
+  metrics.skillsOverlay = {
+    chat: await box(page, '[data-boring-workspace-part="chat-stage"]'),
+    overlay: await box(page, '[data-boring-workspace-part="chat-left-overlay"]'),
+    inner: await box(page, '[data-boring-workspace-part="chat-left-overlay"] > div'),
+    workbench: await box(page, '[data-boring-workspace-part="workbench"]'),
+    text: await innerText(page, '[data-boring-workspace-part="skills-page"]'),
+  }
+  await screenshot(page, "skills-overlay-workbench", "Skills overlay fills chat stage; workbench remains visible")
+  await closeOverlayIfOpen(page, "Close skills")
+
+  await appNav.getByRole("button", { name: "Plugins", exact: true }).click()
+  await page.waitForTimeout(1000)
+  metrics.pluginsOverlay = {
+    chat: await box(page, '[data-boring-workspace-part="chat-stage"]'),
+    overlay: await box(page, '[data-boring-workspace-part="chat-left-overlay"]'),
+    inner: await box(page, '[data-boring-workspace-part="chat-left-overlay"] > div'),
+    workbench: await box(page, '[data-boring-workspace-part="workbench"]'),
+    text: await innerText(page, '[data-boring-workspace-part="plugins-overlay"]'),
+  }
+  await screenshot(page, "plugins-overlay-workbench", "External plugins overlay fills chat stage; workbench remains visible")
+  await closeOverlayIfOpen(page, "Close plugins")
+
+  await page.getByRole("button", { name: "Hide app navigation" }).click()
+  await page.waitForTimeout(700)
+  metrics.appNavCollapsed = {
+    button: await box(page, '[aria-label="Open app navigation"]'),
+    appLeft: await box(page, '[data-boring-workspace-part="app-left-pane"]'),
+    chat: await box(page, '[data-boring-workspace-part="chat-stage"]'),
+  }
+  await screenshot(page, "app-nav-collapsed", "App-left pane collapsed; restore control fixed in place")
+  await page.getByRole("button", { name: "Open app navigation" }).click()
+  await page.waitForTimeout(600)
+
+  await page.keyboard.press("ControlOrMeta+KeyK")
+  await page.waitForTimeout(700)
+  metrics.commandPaletteChats = { text: await innerText(page, '[role="dialog"]') }
+  await screenshot(page, "palette-chats", "Command palette opened in Chats mode")
+  await page.getByRole("button", { name: "Catalogs" }).click()
+  await page.waitForTimeout(500)
+  metrics.commandPaletteCatalogs = { text: await innerText(page, '[role="dialog"]') }
+  await screenshot(page, "palette-catalogs", "Command palette Catalogs mode")
+  await page.getByRole("button", { name: "Commands" }).click()
+  await page.waitForTimeout(500)
+  metrics.commandPaletteCommands = { text: await innerText(page, '[role="dialog"]') }
+  await screenshot(page, "palette-commands", "Command palette Commands mode")
+
+  await ctx.close()
+}
+
+async function captureTablet(browser) {
+  const ctx = await browser.newContext({ viewport: TABLET_VIEWPORT, deviceScaleFactor: 1 })
+  const page = await ctx.newPage()
+  await page.goto(`${BASE}?fresh=1&ui-review=tablet`, { waitUntil: "domcontentloaded", timeout: 60_000 })
+  await page.waitForTimeout(2400)
+  await screenshot(page, "tablet-default", "Tablet viewport default layout", { fullPage: false })
+  await openWorkbench(page)
+  await page.waitForTimeout(700)
+  await screenshot(page, "tablet-workbench", "Tablet viewport with workbench open", { fullPage: false })
+  await ctx.close()
+}
+
+function geminiApiKey() {
+  if (process.env.GEMINI_API_KEY) return process.env.GEMINI_API_KEY
+  try {
+    return execFileSync("vault", ["kv", "get", "-field=api_key", "secret/agent/gemini"], { encoding: "utf8" }).trim()
+  } catch (error) {
+    throw new Error("GEMINI_API_KEY not set and vault lookup failed. Set SKIP_GEMINI=1 to capture screenshots only.")
+  }
+}
+
+async function inlinePart(path) {
+  const data = await readFile(path)
+  return { inline_data: { mime_type: "image/png", data: data.toString("base64") } }
+}
+
+function prompt() {
+  return `You are Gemini reviewing a production coding-agent workspace UI from screenshots.
+
+Goal: give an honest design rating out of 10. Target is >= ${MIN_RATING}/10.
+
+Design direction / constraints:
+- Precise, calm, editorial, refined minimal, dark-first compatible.
+- Conversation is the interface; chrome should be quiet and stable.
+- No glassmorphism blur for app/workspace chrome; avoid soft drop shadows.
+- Separation via borders and opacity. Radius ramp 6/8/10/12/16/24.
+- Icons should feel from one system; left collapse controls use plain panel glyphs.
+- Skills/Plugins overlays must cover the full chat area only, never the workbench.
+- Workbench remains visible when open.
+- Left nav sections should read Workspaces / Chats.
+- Command palette should expose Chats, Catalogs, Commands as first-class modes.
+
+DOM metrics collected by the script:
+${JSON.stringify(metrics, null, 2)}
+
+Review instructions:
+1. Inspect every screenshot.
+2. Use a RAW 0-10 production-design scale. Do NOT use a compressed scale. Do NOT write a lower formal rating while saying the UI clears a higher uncompressed bar.
+3. Score each major area on the same raw 0-10 scale: left navigation, collapse chrome, chat overlay behavior, skills page, plugins page, command palette, workbench coexistence, responsive/tablet.
+4. Give ONE overall raw rating in this exact line format: RATING: X.X/10
+5. The RATING line must match your conclusion. If you think it clears the >= ${MIN_RATING}/10 bar, the RATING must be >= ${MIN_RATING}/10.
+6. List P0/P1/P2 issues. P0/P1 should block claiming >9/10.
+7. If overall rating is below ${MIN_RATING}, give the shortest concrete changes that would likely push it above ${MIN_RATING}.
+8. If score is >= ${MIN_RATING}, say why it clears the bar and any remaining polish only.`
+}
+
+async function askGemini() {
+  const key = geminiApiKey()
+  const parts = [{ text: prompt() }]
+  for (const shot of shots) {
+    parts.push({ text: `\nScreenshot ${shot.file}: ${shot.description}` })
+    parts.push(await inlinePart(shot.path))
+  }
+  const body = {
+    contents: [{ parts }],
+    generationConfig: {
+      maxOutputTokens: 8192,
+      temperature: 0.25,
+      thinkingConfig: { thinkingBudget: 8192 },
+    },
+  }
+  const response = await fetch(`https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${key}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    throw new Error(`Gemini request failed ${response.status}: ${await response.text()}`)
+  }
+  const json = await response.json()
+  const text = json.candidates?.[0]?.content?.parts?.map((part) => part.text || "").join("\n")?.trim()
+  if (!text) throw new Error(`Gemini returned no text: ${JSON.stringify(json).slice(0, 1000)}`)
+  const out = resolve(OUT, "gemini-review.md")
+  await writeFile(out, text)
+  const match = text.match(/RATING:\s*([0-9]+(?:\.[0-9]+)?)\s*\/\s*10/i)
+  const rating = match ? Number(match[1]) : null
+  await writeFile(resolve(OUT, "rating.json"), JSON.stringify({ rating, minRating: MIN_RATING, model: MODEL }, null, 2))
+  console.log("gemini review", out)
+  if (rating !== null) console.log(`rating ${rating}/10 (target >= ${MIN_RATING})`)
+  if (rating !== null && rating < MIN_RATING) {
+    process.exitCode = 2
+  }
+  return { text, rating }
+}
+
+async function run() {
+  await mkdir(OUT, { recursive: true })
+  const browser = await chromium.launch({ headless: true })
+  try {
+    await captureDesktop(browser)
+    await captureTablet(browser)
+  } finally {
+    await browser.close()
+  }
+  const manifest = { baseUrl: BASE, outDir: OUT, viewport: VIEWPORT, tabletViewport: TABLET_VIEWPORT, shots, metrics }
+  await writeFile(resolve(OUT, "manifest.json"), JSON.stringify(manifest, null, 2))
+  console.log("manifest", resolve(OUT, "manifest.json"))
+  if (!SKIP_GEMINI) {
+    const result = await askGemini()
+    console.log("\n--- Gemini summary ---\n")
+    console.log(result.text)
+  } else {
+    console.log("SKIP_GEMINI=1 set; screenshots only")
+  }
+  console.log(`done. output: ${OUT}`)
+}
+
+run().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Adds opt-in `workspaceLayout="plugin-tabs"` app/session left pane for Phase 2.
- Keeps classic workspace layout as default and suppresses duplicate classic left-edge session controls in plugin-tabs mode.
- Adds plugin-tabs-only Skills workspace page, chat-session command-palette search, and component-aware workbench snapshots so Plugins focuses existing workspace-page tab instances.

## Stacked on

- #355 / `phase1-workspace-page-implementation`

## Proof

- Plan thermo review loop: CLEAR (`/tmp/phase2-left-pane-plan-review2-reviewer.md`, `/tmp/phase2-left-pane-plan-review2-oracle.md`)
- Implementation thermo review loop: CLEAR (`/tmp/phase2-left-pane-impl-review2-reviewer.md`, `/tmp/phase2-left-pane-impl-review2-oracle.md`)
- `git diff --check`
- `node packages/workspace/scripts/check-plugin-invariants.mjs`
- `pnpm --filter @hachej/boring-workspace lint:plugin-invariants`
- Focused tests in isolated temp copy (worktree has no node_modules):
  - `pnpm exec vitest run src/front/plugin/__tests__/useWorkspacePluginClient.test.tsx src/front/components/__tests__/CommandPalette.test.tsx src/app/front/__tests__/WorkspaceAgentFront.test.tsx`
  - result: 3 files / 86 tests passed

## Known local validation gap

- `pnpm --filter @hachej/boring-workspace typecheck` still fails in the temp copy only on the pre-existing stale local `@hachej/boring-agent` chat-props/type-resolution mismatch (e.g. `onOpenArtifact`, `hydrateMessages`, `PiChatPanelProps is not generic`). No new Phase 2 type error remains after fixing the readonly panel snapshot issue.
