### PR TITLE
Harden WorkspaceBridge runtime client SDK

### DIFF
--- a/apps/workspace-playground/scripts/bridge-e2e.ts
+++ b/apps/workspace-playground/scripts/bridge-e2e.ts
@@ -7,7 +7,7 @@
  * Exercises the generic bridge paths this PR owns:
  *   - runtimeCore registry bootstrap + dispatch
  *   - browser auth (createLocalCliBridgeAuthPolicy)
- *   - runtime token mint/verify
+ *   - runtime token mint/verify + refresh-token re-mint endpoint
  *   - idempotency replay + failure-releases-key
  *   - trusted boot-time server-plugin handler contribution
  *   - plugin-owned ask-user request→answer cycle
@@ -17,11 +17,12 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createWorkspaceAgentServer } from '@hachej/boring-workspace/app/server'
 import { WorkspaceBridgeClient } from '@hachej/boring-workspace/bridge-client'
-import { defineServerPlugin, mintWorkspaceBridgeRuntimeToken } from '@hachej/boring-workspace/server'
+import { defineServerPlugin, mintWorkspaceBridgeRuntimeRefreshToken, mintWorkspaceBridgeRuntimeToken } from '@hachej/boring-workspace/server'
 import { createAskUserServerPlugin } from '@hachej/boring-ask-user/server'
 import { ASK_USER_BRIDGE_CAPABILITIES, ASK_USER_BRIDGE_OPS } from '@hachej/boring-ask-user/shared'
 
 const SECRET = 'e2e-test-secret-do-not-use-in-prod'
+const REFRESH_SECRET = 'e2e-refresh-secret-do-not-use-prod'
 const results: { name: string; ok: boolean; detail: string }[] = []
 function check(name: string, ok: boolean, detail = '') {
   results.push({ name, ok, detail })
@@ -96,6 +97,7 @@ async function main() {
     ],
     workspaceBridge: {
       runtimeTokenSecret: SECRET,
+      runtimeRefreshTokenSecret: REFRESH_SECRET,
       handlers: [
         { definition: echoDef, handler: echoHandler },
         { definition: failDef, handler: failHandler },
@@ -106,6 +108,7 @@ async function main() {
   const address = await app.listen({ port: 0, host: '127.0.0.1' })
   const base = address.replace('127.0.0.1', '127.0.0.1')
   const url = `${base}/api/v1/workspace-bridge/call`
+  const tokenUrl = `${base}/api/v1/workspace-bridge/token`
   console.log(`\n[bridge-e2e] server listening at ${base}\n`)
 
   const post = async (body: unknown, headers: Record<string, string> = {}) => {
@@ -173,7 +176,17 @@ async function main() {
       check('T7 trusted server-plugin bridge handler contribution', r.status === 200 && r.json.ok === true && r.json.output?.pluginEchoed?.from === 'plugin', `status=${r.status}`)
     }
 
-    // T8/T9 — ask-user owns and registers ask-user.v1.* bridge handlers.
+    // T8 — refresh endpoint re-mints a runtime token that the public client can use.
+    {
+      const refreshToken = mintWorkspaceBridgeRuntimeRefreshToken({ secret: REFRESH_SECRET, workspaceId: 'default', capabilities: [], runtimeId: 'e2e-runtime', tokenTtlMs: 60_000 })
+      const tokenRes = await fetch(tokenUrl, { method: 'POST', headers: { authorization: `Bearer ${refreshToken}`, 'content-type': 'application/json' }, body: '{}' })
+      const tokenJson = await tokenRes.json() as any
+      const client = new WorkspaceBridgeClient({ url, token: tokenJson.token, fetch })
+      const output = await client.call<{ echoed?: { hi?: string } }>('example.v1.echo', { hi: 'refresh' }, { idempotencyKey: 'k-refresh' })
+      check('T8 refresh endpoint re-mints usable runtime token', tokenRes.status === 200 && tokenJson.ok === true && output?.echoed?.hi === 'refresh', `status=${tokenRes.status}`)
+    }
+
+    // T9/T10 — ask-user owns and registers ask-user.v1.* bridge handlers.
     {
       const token = mintWorkspaceBridgeRuntimeToken({
         secret: SECRET,
@@ -197,7 +210,7 @@ async function main() {
         if (pending?.questionId) break
         await new Promise((resolve) => setTimeout(resolve, 50))
       }
-      check('T8 ask-user pending via plugin bridge', pending?.title === 'Bridge question' && typeof pending?.answerToken === 'string', `questionId=${pending?.questionId ?? 'none'}`)
+      check('T9 ask-user pending via plugin bridge', pending?.title === 'Bridge question' && typeof pending?.answerToken === 'string', `questionId=${pending?.questionId ?? 'none'}`)
 
       const answer = await post({
         op: ASK_USER_BRIDGE_OPS.answer,
@@ -206,7 +219,7 @@ async function main() {
       }, { 'x-boring-session-id': 's1' })
       const request = await requestPromise
       check(
-        'T9 ask-user answer resolves runtime client request',
+        'T10 ask-user answer resolves runtime client request',
         answer.status === 200 && answer.json.ok === true && request?.status === 'answered' && request?.answer?.values?.answer === 'yes',
         `answer.status=${answer.status} result=${request?.status}`,
       )

--- a/apps/workspace-playground/scripts/bridge-e2e.ts
+++ b/apps/workspace-playground/scripts/bridge-e2e.ts
@@ -96,6 +96,7 @@ async function main() {
       createAskUserServerPlugin({ workspaceRoot, sessionId: 's1' }),
     ],
     workspaceBridge: {
+      allowInsecureLocalCliBrowserAuth: true,
       runtimeTokenSecret: SECRET,
       runtimeRefreshTokenSecret: REFRESH_SECRET,
       handlers: [

--- a/apps/workspace-playground/scripts/bridge-e2e.ts
+++ b/apps/workspace-playground/scripts/bridge-e2e.ts
@@ -16,6 +16,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createWorkspaceAgentServer } from '@hachej/boring-workspace/app/server'
+import { WorkspaceBridgeClient } from '@hachej/boring-workspace/bridge-client'
 import { defineServerPlugin, mintWorkspaceBridgeRuntimeToken } from '@hachej/boring-workspace/server'
 import { createAskUserServerPlugin } from '@hachej/boring-ask-user/server'
 import { ASK_USER_BRIDGE_CAPABILITIES, ASK_USER_BRIDGE_OPS } from '@hachej/boring-ask-user/shared'
@@ -129,11 +130,12 @@ async function main() {
       check('T2 unknown op → 404 OpNotFound', r.status === 404 && r.json.error?.code === 'BRIDGE_OP_NOT_FOUND', `status=${r.status} code=${r.json.error?.code}`)
     }
 
-    // T3 — runtime-class dispatch with a minted token
+    // T3 — runtime-class dispatch with a minted token through the public client.
     {
       const token = mintWorkspaceBridgeRuntimeToken({ secret: SECRET, workspaceId: 'default', capabilities: [], runtimeId: 'e2e-runtime' })
-      const r = await post({ op: 'example.v1.echo', input: { hi: 'runtime' }, idempotencyKey: 'k-runtime-1' }, { authorization: `Bearer ${token}` })
-      check('T3 runtime token dispatch', r.status === 200 && r.json.ok === true && r.json.output?.echoed?.hi === 'runtime', `status=${r.status} seq=${r.json.output?.seq}`)
+      const client = new WorkspaceBridgeClient({ url, token, fetch })
+      const output = await client.call<{ echoed?: { hi?: string }; seq?: number }>('example.v1.echo', { hi: 'runtime' }, { idempotencyKey: 'k-runtime-1' })
+      check('T3 runtime token dispatch via client', output?.echoed?.hi === 'runtime', `seq=${output?.seq}`)
     }
 
     // T4 — invalid runtime token → 401
@@ -142,19 +144,27 @@ async function main() {
       check('T4 invalid token → 401', r.status === 401, `status=${r.status} code=${r.json.error?.code}`)
     }
 
-    // T5 — idempotency replay: same key returns the cached response (same seq)
+    // T5 — idempotency replay: same key returns the cached response (same seq), through the public client.
     {
-      const r1 = await post({ op: 'example.v1.echo', input: { n: 5 }, idempotencyKey: 'k-replay' })
-      const r2 = await post({ op: 'example.v1.echo', input: { n: 5 }, idempotencyKey: 'k-replay' })
-      check('T5 idempotency replay (cached, same seq)', r1.json.ok && r2.json.ok && r1.json.output?.seq === r2.json.output?.seq, `seq1=${r1.json.output?.seq} seq2=${r2.json.output?.seq}`)
+      const token = mintWorkspaceBridgeRuntimeToken({ secret: SECRET, workspaceId: 'default', capabilities: [], runtimeId: 'e2e-runtime' })
+      const client = new WorkspaceBridgeClient({ url, token, fetch })
+      const r1 = await client.call<{ seq?: number }>('example.v1.echo', { n: 5 }, { idempotencyKey: 'k-replay' })
+      const r2 = await client.call<{ seq?: number }>('example.v1.echo', { n: 5 }, { idempotencyKey: 'k-replay' })
+      check('T5 idempotency replay via client (cached, same seq)', r1.seq === r2.seq, `seq1=${r1.seq} seq2=${r2.seq}`)
     }
 
-    // T6 — failure releases the key: first call fails, retry with SAME key succeeds
+    // T6 — failure releases the key: first call fails, retry with SAME key succeeds, through the public client.
     {
-      const r1 = await post({ op: 'example.v1.fail', input: { x: 1 }, idempotencyKey: 'k-fail' })
-      const r2 = await post({ op: 'example.v1.fail', input: { x: 1 }, idempotencyKey: 'k-fail' })
-      const failedThenRecovered = r1.json.ok === false && r2.json.ok === true && r2.json.output?.recovered === true
-      check('T6 failure releases key (retry re-executes, not cached failure)', failedThenRecovered, `attempt1.ok=${r1.json.ok} attempt2.ok=${r2.json.ok} recovered=${r2.json.output?.recovered}`)
+      const token = mintWorkspaceBridgeRuntimeToken({ secret: SECRET, workspaceId: 'default', capabilities: [], runtimeId: 'e2e-runtime' })
+      const client = new WorkspaceBridgeClient({ url, token, fetch })
+      let firstFailed = false
+      try {
+        await client.call('example.v1.fail', { x: 1 }, { idempotencyKey: 'k-fail' })
+      } catch {
+        firstFailed = true
+      }
+      const r2 = await client.call<{ recovered?: boolean; attempt?: number }>('example.v1.fail', { x: 1 }, { idempotencyKey: 'k-fail' })
+      check('T6 failure releases key via client (retry re-executes, not cached failure)', firstFailed && r2.recovered === true, `attempt1.failed=${firstFailed} attempt2.recovered=${r2.recovered}`)
     }
 
     // T7 — trusted boot-time plugin contribution registers a host bridge op.
@@ -172,16 +182,13 @@ async function main() {
         capabilities: [ASK_USER_BRIDGE_CAPABILITIES.request],
         runtimeId: 'ask-user-e2e-runtime',
       })
-      const requestPromise = post({
-        op: ASK_USER_BRIDGE_OPS.request,
-        requestId: 'ask-user-e2e-request',
-        input: {
-          sessionId: 's1',
-          title: 'Bridge question',
-          schema: { wireVersion: 1, fields: [{ type: 'text', name: 'answer', label: 'Answer', required: true }] },
-          timeoutMs: 60_000,
-        },
-      }, { authorization: `Bearer ${token}` })
+      const askClient = new WorkspaceBridgeClient({ url, token, fetch })
+      const requestPromise = askClient.call<any>(ASK_USER_BRIDGE_OPS.request, {
+        sessionId: 's1',
+        title: 'Bridge question',
+        schema: { wireVersion: 1, fields: [{ type: 'text', name: 'answer', label: 'Answer', required: true }] },
+        timeoutMs: 60_000,
+      }, { requestId: 'ask-user-e2e-request', timeoutMs: 65_000 })
 
       let pending: any = null
       for (let i = 0; i < 40; i++) {
@@ -199,9 +206,9 @@ async function main() {
       }, { 'x-boring-session-id': 's1' })
       const request = await requestPromise
       check(
-        'T9 ask-user answer resolves runtime request',
-        answer.status === 200 && answer.json.ok === true && request.status === 200 && request.json.output?.status === 'answered' && request.json.output?.answer?.values?.answer === 'yes',
-        `answer.status=${answer.status} request.status=${request.status} result=${request.json.output?.status}`,
+        'T9 ask-user answer resolves runtime client request',
+        answer.status === 200 && answer.json.ok === true && request?.status === 'answered' && request?.answer?.values?.answer === 'yes',
+        `answer.status=${answer.status} result=${request?.status}`,
       )
     }
   } finally {

--- a/apps/workspace-playground/scripts/bridge-e2e.ts
+++ b/apps/workspace-playground/scripts/bridge-e2e.ts
@@ -187,6 +187,30 @@ async function main() {
       check('T8 refresh endpoint re-mints usable runtime token', tokenRes.status === 200 && tokenJson.ok === true && output?.echoed?.hi === 'refresh', `status=${tokenRes.status}`)
     }
 
+    // T11 — the published SDK's env-driven path: fromEnv() reads the injected
+    //        url/token/token-url/refresh-token and, on a 401 from an expired
+    //        call token, auto-refreshes against /token and retries. This is the
+    //        exact code a downstream runtime tool imports.
+    {
+      const expiredToken = mintWorkspaceBridgeRuntimeToken({ secret: SECRET, workspaceId: 'default', capabilities: [], runtimeId: 'e2e-runtime', ttlMs: 1_000, nowMs: Date.now() - 60_000 })
+      const refreshToken = mintWorkspaceBridgeRuntimeRefreshToken({ secret: REFRESH_SECRET, workspaceId: 'default', capabilities: [], runtimeId: 'e2e-runtime', tokenTtlMs: 60_000 })
+      const client = WorkspaceBridgeClient.fromEnv({
+        BORING_WORKSPACE_BRIDGE_URL: url,
+        BORING_WORKSPACE_BRIDGE_TOKEN: expiredToken,
+        BORING_WORKSPACE_BRIDGE_TOKEN_URL: tokenUrl,
+        BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN: refreshToken,
+      }, { fetch })
+      let recovered = false
+      try {
+        const output = await client.call<{ echoed?: { hi?: string } }>('example.v1.echo', { hi: 'fromEnv' }, { idempotencyKey: 'k-fromenv-refresh' })
+        recovered = output?.echoed?.hi === 'fromEnv'
+      } catch (err) {
+        recovered = false
+        console.error('[bridge-e2e] T11 fromEnv refresh error:', err)
+      }
+      check('T11 published SDK fromEnv() auto-refreshes an expired token', recovered)
+    }
+
     // T9/T10 — ask-user owns and registers ask-user.v1.* bridge handlers.
     {
       const token = mintWorkspaceBridgeRuntimeToken({

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -64,6 +64,7 @@ export async function startPlaygroundServer(): Promise<void> {
       logger: true,
       externalPlugins: EXTERNAL_PLUGINS_ENABLED,
       defaultPluginPackages: ["@hachej/boring-ask-user"],
+      workspaceBridge: { allowInsecureLocalCliBrowserAuth: true },
     })
     app.get("/api/v1/workspace/meta", async () => {
       const localName = basename(workspaceRoot) || "Workspace"

--- a/docs/WORKSPACE_BRIDGE_V1.md
+++ b/docs/WORKSPACE_BRIDGE_V1.md
@@ -26,7 +26,7 @@ createWorkspaceAgentServer({
 })
 ```
 
-`createCoreWorkspaceAgentServer(...)` accepts the same `workspaceBridge` shape. For the standalone/base factory, exposed or production hosts must provide `workspaceBridge.browserAuthPolicy`; the fallback `createLocalCliBridgeAuthPolicy` is unauthenticated and is only for local/dev CLI usage. `NODE_ENV=production` fails closed unless the host supplies a real browser policy or explicitly opts into the insecure local-cli policy for a local-only dev tool.
+`createCoreWorkspaceAgentServer(...)` accepts the same `workspaceBridge` shape. For the standalone/base factory, browser bridge calls fail closed unless the host provides `workspaceBridge.browserAuthPolicy` or explicitly opts into `allowInsecureLocalCliBrowserAuth` for a local-only dev tool. `createLocalCliBridgeAuthPolicy` is unauthenticated and dev-only; it is never selected implicitly.
 
 Runtime callers are also bounded to the workspace that owns the bridge registry. A token minted for workspace A cannot call a registry owned by workspace B; the registry returns `BRIDGE_RESOURCE_SCOPE_DENIED` unless an operation explicitly sets `allowCrossWorkspace: true`. Cross-workspace operations must do their own explicit resource authorization.
 
@@ -144,7 +144,7 @@ const bridge = new WorkspaceBridgeClient({
 })
 ```
 
-The stock refresh endpoint is `POST /api/v1/workspace-bridge/token` with `Authorization: Bearer $BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN`. It returns `{ ok: true, token }`. Refresh tokens are sandbox-bound by signed workspace/session/runtime/capability claims and should be treated as secrets; never log them.
+The stock refresh endpoint is `POST /api/v1/workspace-bridge/token` with `Authorization: Bearer $BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN`. It returns `{ ok: true, token }`. Refresh tokens are sandbox-bound by signed workspace/session/runtime/capability claims, default to a 1h TTL, are checked against a per-jti revocation/rate-limit store, and should be treated as secrets; never log them. Refresh env vars are not injected over plaintext non-loopback HTTP even when short-lived call-token env is allowed for local development.
 
 Non-TypeScript runtimes can call the HTTP transport directly:
 

--- a/docs/WORKSPACE_BRIDGE_V1.md
+++ b/docs/WORKSPACE_BRIDGE_V1.md
@@ -102,7 +102,7 @@ When enabled and valid, agent/runtime executions receive:
 - `BORING_WORKSPACE_ID`
 - `BORING_AGENT_SESSION_ID`
 
-Remote runtimes, such as `vercel-sandbox`, require an HTTPS non-localhost bridge URL. If the bridge cannot be enabled safely, the runtime receives `BORING_WORKSPACE_BRIDGE_DISABLED=<reason>` instead of a URL/token.
+Remote-placement runtimes (runtime bundles with remote bash or remote-workspace filesystem strategies) require an HTTPS non-localhost bridge URL. If the bridge cannot be enabled safely, the runtime receives `BORING_WORKSPACE_BRIDGE_DISABLED=<reason>` instead of a URL/token.
 
 ## Runtime client
 

--- a/docs/WORKSPACE_BRIDGE_V1.md
+++ b/docs/WORKSPACE_BRIDGE_V1.md
@@ -102,17 +102,45 @@ Remote runtimes, such as `vercel-sandbox`, require an HTTPS non-localhost bridge
 
 ## Runtime client
 
-TypeScript runtime code should use the package client:
+TypeScript runtime code should use the package client. It defaults to a 30s per-call timeout, accepts an `AbortSignal`, and wraps bridge/transport failures in stable `WorkspaceBridgeClientError` codes:
 
 ```ts
-import { WorkspaceBridgeClient } from "@hachej/boring-workspace/bridge-client"
+import {
+  WorkspaceBridgeClient,
+  WorkspaceBridgeClientError,
+  WorkspaceBridgeClientErrorCode,
+  WorkspaceBridgeErrorCode,
+} from "@hachej/boring-workspace/bridge-client"
 
 const bridge = WorkspaceBridgeClient.fromEnv()
-await bridge.call("example.v1.write", {
-  id: "output-1",
-  title: "Generated output",
-}, { idempotencyKey: "example-write:output-1" })
+try {
+  await bridge.call("example.v1.write", {
+    id: "output-1",
+    title: "Generated output",
+  }, { idempotencyKey: "example-write:output-1", timeoutMs: 30_000 })
+} catch (error) {
+  if (error instanceof WorkspaceBridgeClientError) {
+    if (error.code === WorkspaceBridgeErrorCode.ExpiredToken) {
+      // Recreate the client with a fresh token, or use a token provider below.
+    }
+    if (error.code === WorkspaceBridgeClientErrorCode.Timeout) {
+      // Host did not respond within the configured timeout.
+    }
+  }
+  throw error
+}
 ```
+
+Runtime env injection provides a static bearer token. Tokens expire (default 5 minutes; hosts may configure TTL), and static env tokens cannot refresh themselves in long-lived remote sandboxes. Long-running tools should pass a token provider; when a call receives a 401 bridge auth error, the client invokes the provider once with `{ refresh: true }` and retries the call once:
+
+```ts
+const bridge = new WorkspaceBridgeClient({
+  url: process.env.BORING_WORKSPACE_BRIDGE_URL!,
+  token: async ({ refresh }) => refresh ? await fetchFreshBridgeToken() : cachedBridgeToken,
+})
+```
+
+A token provider is only a client-side seam; the host still needs to expose a safe app-specific way to mint a fresh scoped token if it wants remote runtimes to refresh without reprovisioning.
 
 Non-TypeScript runtimes can call the HTTP transport directly:
 

--- a/docs/WORKSPACE_BRIDGE_V1.md
+++ b/docs/WORKSPACE_BRIDGE_V1.md
@@ -102,7 +102,7 @@ Remote runtimes, such as `vercel-sandbox`, require an HTTPS non-localhost bridge
 
 ## Runtime client
 
-TypeScript runtime code should use the package client. It defaults to a 30s per-call timeout, accepts an `AbortSignal`, and wraps bridge/transport failures in stable `WorkspaceBridgeClientError` codes:
+TypeScript runtime code should use the package client. It defaults to a 30s per-attempt timeout (covering token-provider resolution, the HTTP request, and response-body parsing), accepts an `AbortSignal`, and wraps bridge/transport failures in stable `WorkspaceBridgeClientError` codes:
 
 ```ts
 import {
@@ -131,7 +131,7 @@ try {
 }
 ```
 
-Runtime env injection provides a static bearer token. Tokens expire (default 5 minutes; hosts may configure TTL), and static env tokens cannot refresh themselves in long-lived remote sandboxes. Long-running tools should pass a token provider; when a call receives a 401 bridge auth error, the client invokes the provider once with `{ refresh: true }` and retries the call once:
+Runtime env injection provides a static bearer token. Tokens expire (default 5 minutes; hosts may configure TTL), and static env tokens cannot refresh themselves in long-lived remote sandboxes. Long-running tools should pass a token provider; when a call receives a 401 bridge auth error, the client invokes the provider once with `{ refresh: true }` and retries the call once. The timeout is per attempt, so a call that refresh-retries can take up to roughly `2 * timeoutMs` wall-clock time:
 
 ```ts
 const bridge = new WorkspaceBridgeClient({

--- a/docs/WORKSPACE_BRIDGE_V1.md
+++ b/docs/WORKSPACE_BRIDGE_V1.md
@@ -26,7 +26,9 @@ createWorkspaceAgentServer({
 })
 ```
 
-`createCoreWorkspaceAgentServer(...)` accepts the same `workspaceBridge` shape.
+`createCoreWorkspaceAgentServer(...)` accepts the same `workspaceBridge` shape. For the standalone/base factory, exposed or production hosts must provide `workspaceBridge.browserAuthPolicy`; the fallback `createLocalCliBridgeAuthPolicy` is unauthenticated and is only for local/dev CLI usage. `NODE_ENV=production` fails closed unless the host supplies a real browser policy or explicitly opts into the insecure local-cli policy for a local-only dev tool.
+
+Runtime callers are also bounded to the workspace that owns the bridge registry. A token minted for workspace A cannot call a registry owned by workspace B; the registry returns `BRIDGE_RESOURCE_SCOPE_DENIED` unless an operation explicitly sets `allowCrossWorkspace: true`. Cross-workspace operations must do their own explicit resource authorization.
 
 Trusted boot-time server plugins can also contribute handlers:
 
@@ -95,6 +97,8 @@ When enabled and valid, agent/runtime executions receive:
 
 - `BORING_WORKSPACE_BRIDGE_URL`
 - `BORING_WORKSPACE_BRIDGE_TOKEN`
+- `BORING_WORKSPACE_BRIDGE_TOKEN_URL` (when refresh is configured)
+- `BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN` (when refresh is configured)
 - `BORING_WORKSPACE_ID`
 - `BORING_AGENT_SESSION_ID`
 
@@ -131,16 +135,16 @@ try {
 }
 ```
 
-Runtime env injection provides a static bearer token. Tokens expire (default 5 minutes; hosts may configure TTL), and static env tokens cannot refresh themselves in long-lived remote sandboxes. Long-running tools should pass a token provider; when a call receives a 401 bridge auth error, the client invokes the provider once with `{ refresh: true }` and retries the call once. The timeout is per attempt, so a call that refresh-retries can take up to roughly `2 * timeoutMs` wall-clock time:
+Runtime env injection provides a short-lived bearer token. Tokens expire (default 5 minutes; hosts may configure TTL). When the host configures `runtimeRefreshTokenSecret`, env injection also provides `BORING_WORKSPACE_BRIDGE_TOKEN_URL` and `BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN`; `WorkspaceBridgeClient.fromEnv()` uses those automatically to re-mint once after a 401 bridge auth error. Custom long-running tools may also pass a token provider; when a call receives a 401 bridge auth error, the client invokes the provider once with `{ refresh: true }` and retries the call once. The timeout is per attempt, so a call that refresh-retries can take up to roughly `2 * timeoutMs` wall-clock time:
 
 ```ts
 const bridge = new WorkspaceBridgeClient({
   url: process.env.BORING_WORKSPACE_BRIDGE_URL!,
-  token: async ({ refresh }) => refresh ? await fetchFreshBridgeToken() : cachedBridgeToken,
+  token: async ({ refresh, signal }) => refresh ? await fetchFreshBridgeToken({ signal }) : cachedBridgeToken,
 })
 ```
 
-A token provider is only a client-side seam; the host still needs to expose a safe app-specific way to mint a fresh scoped token if it wants remote runtimes to refresh without reprovisioning.
+The stock refresh endpoint is `POST /api/v1/workspace-bridge/token` with `Authorization: Bearer $BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN`. It returns `{ ok: true, token }`. Refresh tokens are sandbox-bound by signed workspace/session/runtime/capability claims and should be treated as secrets; never log them.
 
 Non-TypeScript runtimes can call the HTTP transport directly:
 
@@ -168,7 +172,7 @@ Bridge calls are authorized by caller class plus capabilities. Capabilities are 
 - `runtime` calls use scoped bearer tokens minted from the runtime bridge secret.
 - `server` calls use trusted in-process context.
 
-Runtime tokens are scoped to the workspace/session/runtime/capability set and expiry. They protect the host and other workspaces from the sandbox; they are not secret from code already running inside that sandbox.
+Runtime tokens are scoped to the workspace/session/runtime/capability set and expiry, and the bridge rejects calls whose token workspace does not match the registry owner. They protect the host and other workspaces from the sandbox; they are not secret from code already running inside that sandbox. Domain handlers must still scope all reads/writes by `context.workspaceId` and must not trust input-supplied workspace, record, path, or session ids as authorization proof.
 
 Never log tokens, Authorization headers, full payloads, host paths, user answers, or sensitive SQL. Mutating/retryable operations should require an idempotency key.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -28,6 +28,9 @@ npx @hachej/boring-ui-cli ~/projects/foo
 
 # Custom port / host
 npx @hachej/boring-ui-cli --port 8080 --host 127.0.0.1
+
+# Exposing beyond loopback requires an explicit unsafe local-bridge opt-in
+npx @hachej/boring-ui-cli --host 0.0.0.0 --allow-insecure-local-bridge
 ```
 
 The CLI does not take an API key flag. On first run, if no LLM provider is
@@ -58,7 +61,7 @@ boring-ui plugin <subcommand> …         Plugin authoring (delegates to boring-
 | Flag | Default | Description |
 |------|---------|-------------|
 | `-p, --port <port>` | `5200` (or `$PORT`) | HTTP port |
-| `--host <host>` | `0.0.0.0` (or `$HOST`) | Listen host |
+| `--host <host>` | `127.0.0.1` (or `$HOST`) | Listen host. Non-loopback hosts require `--allow-insecure-local-bridge` because the standalone CLI uses unauthenticated local-only bridge browser auth. |
 | `-m, --mode <mode>` | `local` | `local` (no sandbox, full network) or `local-sandbox` (bwrap-isolated, no network, Linux only) |
 | `-h, --help` | | Show help |
 
@@ -69,6 +72,7 @@ boring-ui plugin <subcommand> …         Plugin authoring (delegates to boring-
 | `PORT`, `HOST` | Fallbacks for `--port` / `--host` |
 | `BORING_MODE` | Fallback for `--mode` |
 | `BORING_AGENT_WORKSPACE_ROOT` | Overrides the folder argument in folder mode |
+| `BORING_UI_ALLOW_INSECURE_LOCAL_BRIDGE` | `1`/`true`/`yes` to allow non-loopback binding with the unauthenticated local CLI bridge auth |
 | `BORING_UI_WORKSPACES_PATH` | Path to the workspaces registry (default `~/.boring-ui/workspaces.yaml`) |
 | `BORING_USE_LOCAL_PACKAGES` | `1` to resolve the bundled plugin-cli runtime from the local monorepo checkout |
 

--- a/packages/cli/src/__tests__/cli.integration.test.ts
+++ b/packages/cli/src/__tests__/cli.integration.test.ts
@@ -48,6 +48,16 @@ test("installed boring-ui --help exits without starting a workspace", async () =
   await expect(runCli(["--help"], {})).resolves.toMatchObject({
     stdout: expect.stringContaining("Usage: boring-ui"),
   })
+  const result = await runCli(["--help"], {})
+  expect(result.stdout).toContain("Listen host (default: 127.0.0.1)")
+  expect(result.stdout).toContain("--allow-insecure-local-bridge")
+})
+
+
+test("boring-ui refuses non-loopback host without explicit insecure bridge opt-in", async () => {
+  await expect(runCli(["--host", "0.0.0.0"], {})).rejects.toMatchObject({
+    stderr: expect.stringContaining("--allow-insecure-local-bridge"),
+  })
 })
 
 test("boring-ui plugin reuses plugin CLI install/list/remove handlers", async () => {

--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -115,7 +115,9 @@ const HELP_TEXT = [
   "",
   "Options:",
   "  -p, --port <port>       HTTP port (default: 5200)",
-  "      --host <host>       Listen host (default: 0.0.0.0)",
+  "      --host <host>       Listen host (default: 127.0.0.1)",
+  "      --allow-insecure-local-bridge",
+  "                            Allow unauthenticated local-cli bridge auth when binding a non-loopback host",
   "  -m, --mode <mode>       local-sandbox or local (default: local)",
   "  -h, --help              Show this help",
 ].join("\n")
@@ -145,6 +147,15 @@ async function checkAuth(): Promise<number> {
   return registry.getAvailable().length
 }
 
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().toLowerCase()
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1" || normalized === "[::1]"
+}
+
+function truthyEnv(value: string | undefined): boolean {
+  return value === "1" || value?.toLowerCase() === "true" || value?.toLowerCase() === "yes"
+}
+
 
 
 async function startFolderMode(opts: {
@@ -154,6 +165,7 @@ async function startFolderMode(opts: {
   host: string
   cliMode: CliMode
   mode: RuntimeMode
+  allowInsecureLocalBridgeAuth: boolean
 }) {
   const workspaceRoot = process.env.BORING_AGENT_WORKSPACE_ROOT ?? resolve(opts.folderArg ?? process.cwd())
   const projectName = basename(resolve(workspaceRoot)) || "workspace"
@@ -172,6 +184,7 @@ async function startFolderMode(opts: {
     workspaceRoot,
     mode: opts.mode,
     projectName,
+    allowInsecureLocalBridgeAuth: opts.allowInsecureLocalBridgeAuth,
   })
 
   await registerStatic(app as FastifyInstance, opts.publicDir)
@@ -275,6 +288,7 @@ export async function runCli(options: RunCliOptions): Promise<void> {
       workspace: { type: "string" as const },
       "panel-id": { type: "string" as const },
       "timeout-ms": { type: "string" as const },
+      "allow-insecure-local-bridge": { type: "boolean" as const },
       help: { type: "boolean", short: "h" },
     },
     allowPositionals: true,
@@ -287,7 +301,9 @@ export async function runCli(options: RunCliOptions): Promise<void> {
   }
 
   const port = Number(args.port ?? process.env.PORT) || 5200
-  const host = (args.host as string | undefined) ?? process.env.HOST ?? "0.0.0.0"
+  const explicitHost = args.host !== undefined || process.env.HOST !== undefined
+  const host = (args.host as string | undefined) ?? process.env.HOST ?? "127.0.0.1"
+  const allowInsecureLocalBridgeAuth = isLoopbackHost(host) || truthyEnv(process.env.BORING_UI_ALLOW_INSECURE_LOCAL_BRIDGE) || args["allow-insecure-local-bridge"] === true
   const rawMode = (args.mode as string | undefined) ?? process.env.BORING_MODE
   let cliMode: CliMode
   let mode: RuntimeMode
@@ -307,12 +323,18 @@ export async function runCli(options: RunCliOptions): Promise<void> {
     mode = "direct"
   }
 
+  const startsServer = positionals[0] !== "workspaces" || !new Set(["add", "list", "remove", "rename"]).has(positionals[1] ?? "")
+  if (startsServer && !isLoopbackHost(host) && (!explicitHost || !allowInsecureLocalBridgeAuth)) {
+    throw new Error("Binding boring-ui to a non-loopback host requires --host plus --allow-insecure-local-bridge. The local CLI WorkspaceBridge browser auth is unauthenticated.")
+  }
+
   const base = {
     publicDir: options.publicDir,
     port,
     host,
     cliMode,
     mode,
+    allowInsecureLocalBridgeAuth,
   }
 
 

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -345,6 +345,7 @@ export async function createFolderModeApp(opts: {
   mode: RuntimeMode
   projectName?: string
   provisionWorkspace?: boolean
+  allowInsecureLocalBridgeAuth?: boolean
 }): Promise<FastifyInstance> {
   const workspaceRoot = resolve(opts.workspaceRoot)
   const projectName = opts.projectName ?? (basename(workspaceRoot) || "workspace")
@@ -379,6 +380,7 @@ export async function createFolderModeApp(opts: {
     // additionalBoringPluginDirs only feeds the asset-manager scan.
     defaultPluginPackages: pluginDiscovery.resolveCliDefaultPluginPackagePaths(),
     additionalBoringPluginDirs: pluginDirs,
+    workspaceBridge: { allowInsecureLocalCliBrowserAuth: opts.allowInsecureLocalBridgeAuth === true },
     boringPluginFrontTargetResolver: runtimeHost.createFrontTargetResolver(FOLDER_RUNTIME_PLUGIN_WORKSPACE_ID),
   })
   await runtimeHost.registerRoutes(app as FastifyInstance)

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
@@ -262,6 +262,42 @@ describe('createCoreWorkspaceAgentServer workspace bridge wiring', () => {
     await app.close()
   })
 
+  it('wires the runtime refresh-token secret and a per-workspace refresh-token store into the core host', async () => {
+    const app = await createCoreWorkspaceAgentServer({
+      serveFrontend: false,
+      workspaceBridge: {
+        runtimeTokenSecret: '12345678901234567890123456789012',
+        runtimeRefreshTokenSecret: 'refresh-secret-1234567890123456789012',
+        runtimeEnv: {
+          bridgeUrl: 'https://bridge.test',
+          capabilities: ['test:runtime-env'],
+        },
+      },
+    })
+
+    const httpOpts = workspaceServerMock.httpRouteOpts.at(-1)
+    expect(httpOpts).toMatchObject({
+      runtimeTokenSecret: '12345678901234567890123456789012',
+      runtimeRefreshTokenSecret: 'refresh-secret-1234567890123456789012',
+    })
+
+    const getStore = httpOpts?.getRuntimeRefreshTokenStore as
+      | ((request: unknown, claims: { workspaceId: string }) => unknown)
+      | undefined
+    expect(typeof getStore).toBe('function')
+    const storeOne = getStore!({ headers: {} }, { workspaceId: 'workspace-1' })
+    const storeTwo = getStore!({ headers: {} }, { workspaceId: 'workspace-2' })
+    const storeOneAgain = getStore!({ headers: {} }, { workspaceId: 'workspace-1' })
+    expect(storeOne).toBeTruthy()
+    expect(storeTwo).toBeTruthy()
+    // Per-workspace isolation: distinct workspaces get distinct stores...
+    expect(storeOne).not.toBe(storeTwo)
+    // ...and the same workspace reuses one store (revoke/rate-limit state persists).
+    expect(storeOne).toBe(storeOneAgain)
+
+    await app.close()
+  })
+
   it('exposes bridge-aware Pi context so app shells do not need adapter tools', async () => {
     const app = await createCoreWorkspaceAgentServer({
       serveFrontend: false,

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
@@ -127,6 +127,7 @@ vi.mock('@hachej/boring-workspace/server', () => {
     return await execute()
   }),
   InMemoryWorkspaceBridgeIdempotencyStore: class InMemoryWorkspaceBridgeIdempotencyStore {},
+  InMemoryWorkspaceBridgeRuntimeRefreshTokenStore: class InMemoryWorkspaceBridgeRuntimeRefreshTokenStore {},
   uiRoutes: async () => {},
   verifyWorkspaceBridgeRuntimeToken: vi.fn((token: string) => {
     workspaceServerMock.runtimeTokenVerifications.push(token)

--- a/packages/core/src/app/server/coreWorkspaceBridge.ts
+++ b/packages/core/src/app/server/coreWorkspaceBridge.ts
@@ -5,6 +5,7 @@ import {
   createWorkspaceBridgeRuntimeCore,
   createWorkspaceBridgeRuntimeEnvContribution,
   InMemoryWorkspaceBridgeIdempotencyStore,
+  InMemoryWorkspaceBridgeRuntimeRefreshTokenStore,
   runWithWorkspaceBridgeIdempotency,
   verifyWorkspaceBridgeRuntimeToken,
   workspaceBridgeHttpRoutes,
@@ -14,6 +15,7 @@ import {
   type WorkspaceBridgeCallResponse,
   type WorkspaceBridgeHandler,
   type WorkspaceBridgeIdempotencyStore,
+  type WorkspaceBridgeRuntimeRefreshTokenStore,
   type WorkspaceBridgeOperationDefinition,
   type WorkspaceBridgeRegistry,
   type WorkspaceBridgeRuntimeEnvOptions,
@@ -25,6 +27,7 @@ const MAX_SESSION_OWNER_CACHE = 5_000
 interface CoreWorkspaceBridgeRuntime {
   registry: WorkspaceBridgeRegistry
   idempotencyStore: WorkspaceBridgeIdempotencyStore
+  refreshTokenStore: WorkspaceBridgeRuntimeRefreshTokenStore
   sessionOwners: Map<string, string>
 }
 
@@ -93,6 +96,7 @@ export function createCoreWorkspaceBridge(options: CoreWorkspaceBridgeOptions): 
       runtime = {
         registry: core.registry,
         idempotencyStore: new InMemoryWorkspaceBridgeIdempotencyStore(),
+        refreshTokenStore: new InMemoryWorkspaceBridgeRuntimeRefreshTokenStore(),
         sessionOwners,
       }
       runtimes.set(safeWorkspaceId, runtime)
@@ -203,6 +207,7 @@ export function createCoreWorkspaceBridge(options: CoreWorkspaceBridgeOptions): 
       getIdempotencyStore: async (request) => getRuntime(await resolveBridgeWorkspaceId(request)).idempotencyStore,
       runtimeTokenSecret: options.workspaceBridge?.runtimeTokenSecret,
       runtimeRefreshTokenSecret: options.workspaceBridge?.runtimeRefreshTokenSecret,
+      getRuntimeRefreshTokenStore: (_request, claims) => getRuntime(claims.workspaceId).refreshTokenStore,
       getOwnerWorkspaceId: async (request) => await resolveBridgeWorkspaceId(request),
       browserAuthPolicy: createBrowserBridgeAuthPolicy({
         getPrincipal: (input) => {

--- a/packages/core/src/app/server/coreWorkspaceBridge.ts
+++ b/packages/core/src/app/server/coreWorkspaceBridge.ts
@@ -31,6 +31,7 @@ interface CoreWorkspaceBridgeRuntime {
 export interface CoreWorkspaceBridgeOptions {
   workspaceBridge?: {
     runtimeTokenSecret?: string
+    runtimeRefreshTokenSecret?: string
     runtimeEnv?: WorkspaceBridgeRuntimeEnvOptions
     handlers?: ReadonlyArray<{ definition: WorkspaceBridgeOperationDefinition; handler: WorkspaceBridgeHandler }>
   }
@@ -87,6 +88,7 @@ export function createCoreWorkspaceBridge(options: CoreWorkspaceBridgeOptions): 
       const sessionOwners = new Map<string, string>()
       const core = createWorkspaceBridgeRuntimeCore({
         handlers: options.workspaceBridge?.handlers,
+        ownerWorkspaceId: safeWorkspaceId,
       })
       runtime = {
         registry: core.registry,
@@ -187,6 +189,7 @@ export function createCoreWorkspaceBridge(options: CoreWorkspaceBridgeOptions): 
               runtimeMode: ctx.runtimeMode,
               registry: getRuntime(ctx.workspaceId).registry,
               runtimeTokenSecret: options.workspaceBridge?.runtimeTokenSecret,
+              runtimeRefreshTokenSecret: options.workspaceBridge?.runtimeRefreshTokenSecret,
               runtimeEnv: options.workspaceBridge?.runtimeEnv,
             })
             return contribution ? await contribution.getEnv(ctx) : {}
@@ -199,6 +202,8 @@ export function createCoreWorkspaceBridge(options: CoreWorkspaceBridgeOptions): 
       getRegistry: async (request) => getRuntime(await resolveBridgeWorkspaceId(request)).registry,
       getIdempotencyStore: async (request) => getRuntime(await resolveBridgeWorkspaceId(request)).idempotencyStore,
       runtimeTokenSecret: options.workspaceBridge?.runtimeTokenSecret,
+      runtimeRefreshTokenSecret: options.workspaceBridge?.runtimeRefreshTokenSecret,
+      getOwnerWorkspaceId: async (request) => await resolveBridgeWorkspaceId(request),
       browserAuthPolicy: createBrowserBridgeAuthPolicy({
         getPrincipal: (input) => {
           const user = input.request?.user as { id?: string; email?: string | null; name?: string | null } | null | undefined

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -159,6 +159,7 @@ export interface CreateCoreWorkspaceAgentServerOptions
       handler: WorkspaceBridgeHandler
     }>
     runtimeTokenSecret?: string
+    runtimeRefreshTokenSecret?: string
     runtimeEnv?: WorkspaceBridgeRuntimeEnvOptions
   }
   getWorkspaceBridgeExtraTools?: (ctx: CoreWorkspaceBridgeExtraToolsContext) => CoreWorkspaceBridgeExtraTool[] | Promise<CoreWorkspaceBridgeExtraTool[]>

--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.workspaceBridge.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.workspaceBridge.test.ts
@@ -31,6 +31,7 @@ beforeEach(() => {
 })
 
 afterEach(async () => {
+  vi.unstubAllEnvs()
   await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
 })
 
@@ -198,6 +199,54 @@ export default {
   })
 
 
+
+  test("injects WorkspaceBridge refresh token env when refresh secret is configured", async () => {
+    const { createTestBridgeOperationDefinition } = await import("../../../server/workspaceBridge/testing/harness")
+    const definition = createTestBridgeOperationDefinition({
+      op: "test.v1.runtime-env-refresh",
+      callerClassesAllowed: ["runtime"],
+      requiredCapabilities: ["test:runtime-env"],
+    })
+    mockCreateAgentAppOnce(async () => Fastify())
+    const app = await createWorkspaceAgentServer({
+      workspaceRoot: await makeTempDir("bridge-runtime-env-refresh-"),
+      mode: "direct",
+      provisionWorkspace: false,
+      workspaceBridge: {
+        runtimeTokenSecret: "12345678901234567890123456789012",
+        runtimeRefreshTokenSecret: "abcdefghijklmnopqrstuvwxyz1234567890",
+        runtimeEnv: {
+          bridgeUrl: "http://localhost:7777",
+          allowInsecureHttp: true,
+          capabilities: ["test:runtime-env"],
+        },
+        handlers: [{ definition, handler: () => ({ ok: true }) }],
+      },
+    })
+
+    const [agentOptions] = agentServerMock.createAgentApp.mock.calls.at(-1) as unknown as [{
+      runtimeEnvContributions?: Array<{ id: string; getEnv: () => Promise<Record<string, string>> | Record<string, string> }>
+    }]
+    const env = await agentOptions.runtimeEnvContributions?.find((entry) => entry.id === "workspace-bridge-runtime-env")?.getEnv()
+
+    expect(env).toMatchObject({
+      BORING_WORKSPACE_BRIDGE_URL: "http://localhost:7777/api/v1/workspace-bridge/call",
+      BORING_WORKSPACE_BRIDGE_TOKEN_URL: "http://localhost:7777/api/v1/workspace-bridge/token",
+      BORING_WORKSPACE_ID: "default",
+    })
+    expect(env?.BORING_WORKSPACE_BRIDGE_TOKEN).toEqual(expect.any(String))
+    expect(env?.BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN).toEqual(expect.any(String))
+    await app.close()
+  })
+
+  test("requires explicit browser bridge auth in production", async () => {
+    vi.stubEnv("NODE_ENV", "production")
+    mockCreateAgentAppOnce(async () => Fastify())
+    await expect(createWorkspaceAgentServer({
+      workspaceRoot: await makeTempDir("bridge-prod-auth-"),
+      provisionWorkspace: false,
+    })).rejects.toThrow(/workspaceBridge\.browserAuthPolicy/)
+  })
 
   test("disables WorkspaceBridge runtime env when capabilities are omitted", async () => {
     mockCreateAgentAppOnce(async () => Fastify())

--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.workspaceBridge.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.workspaceBridge.test.ts
@@ -331,11 +331,15 @@ export default {
     await app.close()
   })
 
-  test("disables WorkspaceBridge runtime env for vercel sandbox without public HTTPS URL", async () => {
+  test("disables WorkspaceBridge runtime env for remote-placement runtimes without public HTTPS URL", async () => {
     mockCreateAgentAppOnce(async () => Fastify())
     const app = await createWorkspaceAgentServer({
-      workspaceRoot: await makeTempDir("bridge-runtime-env-vercel-"),
-      mode: "vercel-sandbox",
+      workspaceRoot: await makeTempDir("bridge-runtime-env-remote-"),
+      runtimeModeAdapter: {
+        id: "custom-remote-runtime",
+        workspaceFsCapability: "best-effort",
+        async create() { throw new Error("not used by this composition test") },
+      },
       provisionWorkspace: false,
       workspaceBridge: {
         allowInsecureLocalCliBrowserAuth: true,

--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.workspaceBridge.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.workspaceBridge.test.ts
@@ -59,13 +59,13 @@ describe("createWorkspaceAgentServer — WorkspaceBridge RPC composition", () =>
     const appA = await createWorkspaceAgentServer({
       workspaceRoot: workspaceA.root,
       provisionWorkspace: false,
-      workspaceBridge: { handlers: [{ definition, handler: ({ input }) => ({ value: `a:${(input as { value: string }).value}` }) }] },
+      workspaceBridge: { allowInsecureLocalCliBrowserAuth: true, handlers: [{ definition, handler: ({ input }) => ({ value: `a:${(input as { value: string }).value}` }) }] },
     })
     mockCreateAgentAppOnce(async () => Fastify())
     const appB = await createWorkspaceAgentServer({
       workspaceRoot: workspaceB.root,
       provisionWorkspace: false,
-      workspaceBridge: { handlers: [{ definition, handler: ({ input }) => ({ value: `b:${(input as { value: string }).value}` }) }] },
+      workspaceBridge: { allowInsecureLocalCliBrowserAuth: true, handlers: [{ definition, handler: ({ input }) => ({ value: `b:${(input as { value: string }).value}` }) }] },
     })
 
     const callA = await appA.inject({
@@ -103,6 +103,7 @@ describe("createWorkspaceAgentServer — WorkspaceBridge RPC composition", () =>
     const app = await createWorkspaceAgentServer({
       workspaceRoot: await makeTempDir("bridge-plugin-handler-"),
       provisionWorkspace: false,
+      workspaceBridge: { allowInsecureLocalCliBrowserAuth: true },
       plugins: [defineServerPlugin({
         id: "trusted-plugin",
         workspaceBridgeHandlers: [{ definition, handler: ({ input }) => ({ value: `plugin:${(input as { value: string }).value}` }) }],
@@ -172,6 +173,7 @@ export default {
       mode,
       provisionWorkspace: false,
       workspaceBridge: {
+        allowInsecureLocalCliBrowserAuth: true,
         runtimeTokenSecret: "12345678901234567890123456789012",
         runtimeEnv: {
           bridgeUrl: "http://localhost:7777",
@@ -213,6 +215,7 @@ export default {
       mode: "direct",
       provisionWorkspace: false,
       workspaceBridge: {
+        allowInsecureLocalCliBrowserAuth: true,
         runtimeTokenSecret: "12345678901234567890123456789012",
         runtimeRefreshTokenSecret: "abcdefghijklmnopqrstuvwxyz1234567890",
         runtimeEnv: {
@@ -239,13 +242,68 @@ export default {
     await app.close()
   })
 
-  test("requires explicit browser bridge auth in production", async () => {
-    vi.stubEnv("NODE_ENV", "production")
+  test("fails closed for browser bridge calls unless browser auth or dev opt-in is explicit", async () => {
+    const { createTestBridgeOperationDefinition } = await import("../../../server/workspaceBridge/testing/harness")
+    const definition = createTestBridgeOperationDefinition({
+      op: "test.v1.browser-denied",
+      callerClassesAllowed: ["browser"],
+      requiredCapabilities: [],
+    })
     mockCreateAgentAppOnce(async () => Fastify())
-    await expect(createWorkspaceAgentServer({
-      workspaceRoot: await makeTempDir("bridge-prod-auth-"),
+    const app = await createWorkspaceAgentServer({
+      workspaceRoot: await makeTempDir("bridge-explicit-auth-"),
       provisionWorkspace: false,
-    })).rejects.toThrow(/workspaceBridge\.browserAuthPolicy/)
+      workspaceBridge: { handlers: [{ definition, handler: () => ({ ok: true }) }] },
+    })
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/workspace-bridge/call",
+      headers: { "content-type": "application/json" },
+      payload: { op: "test.v1.browser-denied", input: {} },
+    })
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toMatchObject({ ok: false, error: { code: "BRIDGE_AUTH_REQUIRED" } })
+    await app.close()
+  })
+
+  test("does not inject refresh tokens over plaintext non-loopback HTTP", async () => {
+    const { createTestBridgeOperationDefinition } = await import("../../../server/workspaceBridge/testing/harness")
+    const definition = createTestBridgeOperationDefinition({
+      op: "test.v1.runtime-env-refresh-http",
+      callerClassesAllowed: ["runtime"],
+      requiredCapabilities: ["test:runtime-env"],
+    })
+    mockCreateAgentAppOnce(async () => Fastify())
+    const app = await createWorkspaceAgentServer({
+      workspaceRoot: await makeTempDir("bridge-runtime-env-refresh-http-"),
+      mode: "direct",
+      provisionWorkspace: false,
+      workspaceBridge: {
+        allowInsecureLocalCliBrowserAuth: true,
+        runtimeTokenSecret: "12345678901234567890123456789012",
+        runtimeRefreshTokenSecret: "abcdefghijklmnopqrstuvwxyz1234567890",
+        runtimeEnv: {
+          bridgeUrl: "http://example.test",
+          allowInsecureHttp: true,
+          capabilities: ["test:runtime-env"],
+        },
+        handlers: [{ definition, handler: () => ({ ok: true }) }],
+      },
+    })
+
+    const [agentOptions] = agentServerMock.createAgentApp.mock.calls.at(-1) as unknown as [{
+      runtimeEnvContributions?: Array<{ id: string; getEnv: () => Promise<Record<string, string>> | Record<string, string> }>
+    }]
+    const env = await agentOptions.runtimeEnvContributions?.find((entry) => entry.id === "workspace-bridge-runtime-env")?.getEnv()
+
+    expect(env).toMatchObject({
+      BORING_WORKSPACE_BRIDGE_URL: "http://example.test/api/v1/workspace-bridge/call",
+      BORING_WORKSPACE_BRIDGE_TOKEN: expect.any(String),
+    })
+    expect(env?.BORING_WORKSPACE_BRIDGE_TOKEN_URL).toBeUndefined()
+    expect(env?.BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN).toBeUndefined()
+    await app.close()
   })
 
   test("disables WorkspaceBridge runtime env when capabilities are omitted", async () => {
@@ -255,6 +313,7 @@ export default {
       mode: "direct",
       provisionWorkspace: false,
       workspaceBridge: {
+        allowInsecureLocalCliBrowserAuth: true,
         runtimeTokenSecret: "12345678901234567890123456789012",
         runtimeEnv: {
           bridgeUrl: "http://localhost:7777",
@@ -279,6 +338,7 @@ export default {
       mode: "vercel-sandbox",
       provisionWorkspace: false,
       workspaceBridge: {
+        allowInsecureLocalCliBrowserAuth: true,
         runtimeTokenSecret: "12345678901234567890123456789012",
         runtimeEnv: { bridgeUrl: "http://localhost:7777", allowInsecureHttp: true, capabilities: ["test:runtime-env"] },
       },

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -48,6 +48,7 @@ import {
   InMemoryWorkspaceBridgeIdempotencyStore,
   createWorkspaceBridgeRuntimeEnvContribution,
   workspaceBridgeHttpRoutes,
+  type BridgeAuthPolicy,
   type WorkspaceBridgeHandler,
   type WorkspaceBridgeOperationDefinition,
   type WorkspaceBridgeRegistry,
@@ -134,6 +135,15 @@ export interface CreateWorkspaceAgentServerOptions
   workspaceBridge?: {
     registry?: WorkspaceBridgeRegistry
     runtimeTokenSecret?: string
+    runtimeRefreshTokenSecret?: string
+    browserAuthPolicy?: BridgeAuthPolicy
+    /**
+     * Dev-only escape hatch for standalone/local CLI usage. When omitted,
+     * createWorkspaceAgentServer uses this unauthenticated policy only outside
+     * NODE_ENV=production. Production hosts must provide browserAuthPolicy or
+     * explicitly set this insecure local/dev opt-in.
+     */
+    allowInsecureLocalCliBrowserAuth?: boolean
     handlers?: Array<{
       definition: WorkspaceBridgeOperationDefinition
       handler: WorkspaceBridgeHandler
@@ -596,6 +606,41 @@ export function readWorkspacePluginPackagePiSnapshot(pluginDirs: BoringPluginSou
   }
 }
 
+function resolveWorkspaceBridgeBrowserAuthPolicy(
+  opts: CreateWorkspaceAgentServerOptions,
+  registry: WorkspaceBridgeRegistry,
+): BridgeAuthPolicy {
+  if (opts.workspaceBridge?.browserAuthPolicy) return opts.workspaceBridge.browserAuthPolicy
+
+  const explicitlyAllowed = opts.workspaceBridge?.allowInsecureLocalCliBrowserAuth === true
+  const isProduction = process.env.NODE_ENV === "production"
+  if (isProduction && !explicitlyAllowed) {
+    throw new Error(
+      "createWorkspaceAgentServer requires workspaceBridge.browserAuthPolicy in production. " +
+      "createLocalCliBridgeAuthPolicy is unauthenticated and dev-only; set allowInsecureLocalCliBrowserAuth only for local/dev tools that are not exposed to a network.",
+    )
+  }
+
+  emitLocalCliBridgeAuthWarning(explicitlyAllowed, isProduction)
+  return createLocalCliBridgeAuthPolicy({
+    workspaceId: "default",
+    capabilities: registry.listDefinitions().flatMap((definition) => [...definition.requiredCapabilities]),
+  })
+}
+
+function emitLocalCliBridgeAuthWarning(explicitlyAllowed: boolean, isProduction: boolean): void {
+  const message = "createWorkspaceAgentServer is using createLocalCliBridgeAuthPolicy for WorkspaceBridge browser calls. This policy is unauthenticated, grants registered bridge capabilities to a fixed local-cli principal, and is intended only for local/dev CLI usage. Provide workspaceBridge.browserAuthPolicy before exposing this server."
+  if (typeof process.emitWarning === "function") {
+    process.emitWarning(message, {
+      code: isProduction && explicitlyAllowed
+        ? "BORING_WORKSPACE_BRIDGE_INSECURE_AUTH_PRODUCTION_OPT_IN"
+        : "BORING_WORKSPACE_BRIDGE_INSECURE_AUTH",
+    })
+    return
+  }
+  console.warn(message)
+}
+
 export async function createWorkspaceAgentServer(
   opts: CreateWorkspaceAgentServerOptions = {},
 ): Promise<FastifyInstance> {
@@ -652,6 +697,7 @@ export async function createWorkspaceAgentServer(
 
   const { registry: workspaceBridgeRegistry } = createWorkspaceBridgeRuntimeCore({
     registry: opts.workspaceBridge?.registry,
+    ownerWorkspaceId: "default",
     handlers: [
       ...(opts.workspaceBridge?.handlers ?? []),
       ...(pluginCollection.workspaceBridgeHandlers ?? []),
@@ -764,6 +810,7 @@ export async function createWorkspaceAgentServer(
     runtimeMode: resolvedMode,
     registry: workspaceBridgeRegistry,
     runtimeTokenSecret: opts.workspaceBridge?.runtimeTokenSecret,
+    runtimeRefreshTokenSecret: opts.workspaceBridge?.runtimeRefreshTokenSecret,
     runtimeEnv: opts.workspaceBridge?.runtimeEnv,
   })
 
@@ -876,11 +923,10 @@ export async function createWorkspaceAgentServer(
   await app.register(workspaceBridgeHttpRoutes, {
     registry: workspaceBridgeRegistry,
     runtimeTokenSecret: opts.workspaceBridge?.runtimeTokenSecret,
+    runtimeRefreshTokenSecret: opts.workspaceBridge?.runtimeRefreshTokenSecret,
+    ownerWorkspaceId: "default",
     idempotencyStore: new InMemoryWorkspaceBridgeIdempotencyStore(),
-    browserAuthPolicy: createLocalCliBridgeAuthPolicy({
-      workspaceId: "default",
-      capabilities: workspaceBridgeRegistry.listDefinitions().flatMap((definition) => [...definition.requiredCapabilities]),
-    }),
+    browserAuthPolicy: resolveWorkspaceBridgeBrowserAuthPolicy(opts, workspaceBridgeRegistry),
   })
   // Internal handles exposed on the Fastify instance for external callers /
   // tests (e.g. the CLI reads __boringAssetManager). The rebuild closure is

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -138,10 +138,10 @@ export interface CreateWorkspaceAgentServerOptions
     runtimeRefreshTokenSecret?: string
     browserAuthPolicy?: BridgeAuthPolicy
     /**
-     * Dev-only escape hatch for standalone/local CLI usage. When omitted,
-     * createWorkspaceAgentServer uses this unauthenticated policy only outside
-     * NODE_ENV=production. Production hosts must provide browserAuthPolicy or
-     * explicitly set this insecure local/dev opt-in.
+     * Dev-only escape hatch for standalone/local CLI usage. This is never
+     * enabled implicitly: exposed hosts must provide browserAuthPolicy, and
+     * local tools that intentionally rely on the unauthenticated local-cli
+     * policy must opt in explicitly.
      */
     allowInsecureLocalCliBrowserAuth?: boolean
     handlers?: Array<{
@@ -609,33 +609,22 @@ export function readWorkspacePluginPackagePiSnapshot(pluginDirs: BoringPluginSou
 function resolveWorkspaceBridgeBrowserAuthPolicy(
   opts: CreateWorkspaceAgentServerOptions,
   registry: WorkspaceBridgeRegistry,
-): BridgeAuthPolicy {
+): BridgeAuthPolicy | undefined {
   if (opts.workspaceBridge?.browserAuthPolicy) return opts.workspaceBridge.browserAuthPolicy
 
-  const explicitlyAllowed = opts.workspaceBridge?.allowInsecureLocalCliBrowserAuth === true
-  const isProduction = process.env.NODE_ENV === "production"
-  if (isProduction && !explicitlyAllowed) {
-    throw new Error(
-      "createWorkspaceAgentServer requires workspaceBridge.browserAuthPolicy in production. " +
-      "createLocalCliBridgeAuthPolicy is unauthenticated and dev-only; set allowInsecureLocalCliBrowserAuth only for local/dev tools that are not exposed to a network.",
-    )
-  }
+  if (opts.workspaceBridge?.allowInsecureLocalCliBrowserAuth !== true) return undefined
 
-  emitLocalCliBridgeAuthWarning(explicitlyAllowed, isProduction)
+  emitLocalCliBridgeAuthWarning()
   return createLocalCliBridgeAuthPolicy({
     workspaceId: "default",
     capabilities: registry.listDefinitions().flatMap((definition) => [...definition.requiredCapabilities]),
   })
 }
 
-function emitLocalCliBridgeAuthWarning(explicitlyAllowed: boolean, isProduction: boolean): void {
+function emitLocalCliBridgeAuthWarning(): void {
   const message = "createWorkspaceAgentServer is using createLocalCliBridgeAuthPolicy for WorkspaceBridge browser calls. This policy is unauthenticated, grants registered bridge capabilities to a fixed local-cli principal, and is intended only for local/dev CLI usage. Provide workspaceBridge.browserAuthPolicy before exposing this server."
   if (typeof process.emitWarning === "function") {
-    process.emitWarning(message, {
-      code: isProduction && explicitlyAllowed
-        ? "BORING_WORKSPACE_BRIDGE_INSECURE_AUTH_PRODUCTION_OPT_IN"
-        : "BORING_WORKSPACE_BRIDGE_INSECURE_AUTH",
-    })
+    process.emitWarning(message, { code: "BORING_WORKSPACE_BRIDGE_INSECURE_AUTH" })
     return
   }
   console.warn(message)

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -801,6 +801,7 @@ export async function createWorkspaceAgentServer(
     runtimeTokenSecret: opts.workspaceBridge?.runtimeTokenSecret,
     runtimeRefreshTokenSecret: opts.workspaceBridge?.runtimeRefreshTokenSecret,
     runtimeEnv: opts.workspaceBridge?.runtimeEnv,
+    runtimePlacement: workspaceFsCapability === "strong" ? "local" : "remote",
   })
 
   const app = await createAgentApp({

--- a/packages/workspace/src/bridge-client/__tests__/client.test.ts
+++ b/packages/workspace/src/bridge-client/__tests__/client.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test, vi } from "vitest"
 import {
+  WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV,
   WORKSPACE_BRIDGE_TOKEN_ENV,
+  WORKSPACE_BRIDGE_TOKEN_URL_ENV,
   WORKSPACE_BRIDGE_URL_ENV,
   WorkspaceBridgeClient,
   WorkspaceBridgeClientConfigError,
@@ -110,8 +112,8 @@ describe("WorkspaceBridgeClient", () => {
 
     await expect(client.call("example.v1.records.read", {})).resolves.toEqual({ value: "ok" })
     expect(tokenProvider).toHaveBeenCalledTimes(2)
-    expect(tokenProvider).toHaveBeenNthCalledWith(1, { refresh: false })
-    expect(tokenProvider).toHaveBeenNthCalledWith(2, { refresh: true })
+    expect(tokenProvider).toHaveBeenNthCalledWith(1, { refresh: false, signal: expect.any(AbortSignal) })
+    expect(tokenProvider).toHaveBeenNthCalledWith(2, { refresh: true, signal: expect.any(AbortSignal) })
     expect((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).toMatchObject({ authorization: "Bearer expired-token" })
     expect((fetchMock.mock.calls[1]?.[1] as RequestInit).headers).toMatchObject({ authorization: "Bearer fresh-token" })
   })
@@ -131,6 +133,46 @@ describe("WorkspaceBridgeClient", () => {
     })
     expect(tokenProvider).toHaveBeenCalledTimes(1)
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test("fromEnv uses refresh env vars to re-mint after a 401", async () => {
+    const fetchMock = makeSequenceFetch([
+      {
+        status: 401,
+        body: { ok: false, error: { code: WorkspaceBridgeErrorCode.ExpiredToken, message: "expired" }, requestId: "req-1" },
+      },
+      { status: 200, body: { ok: true, token: "fresh-token" } },
+      { status: 200, body: { ok: true, output: { value: "ok" }, requestId: "req-1" } },
+    ])
+    const client = WorkspaceBridgeClient.fromEnv({
+      BORING_WORKSPACE_BRIDGE_URL: "https://example.test/api/v1/workspace-bridge/call",
+      BORING_WORKSPACE_BRIDGE_TOKEN: "expired-token",
+      BORING_WORKSPACE_BRIDGE_TOKEN_URL: "https://example.test/api/v1/workspace-bridge/token",
+      BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN: "refresh-token",
+    }, { fetch: fetchMock })
+
+    await expect(client.call("example.v1.records.read", {})).resolves.toEqual({ value: "ok" })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://example.test/api/v1/workspace-bridge/call")
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).toMatchObject({ authorization: "Bearer expired-token" })
+    expect(fetchMock.mock.calls[1]?.[0]).toBe("https://example.test/api/v1/workspace-bridge/token")
+    expect((fetchMock.mock.calls[1]?.[1] as RequestInit).headers).toMatchObject({ authorization: "Bearer refresh-token" })
+    expect(fetchMock.mock.calls[2]?.[0]).toBe("https://example.test/api/v1/workspace-bridge/call")
+    expect((fetchMock.mock.calls[2]?.[1] as RequestInit).headers).toMatchObject({ authorization: "Bearer fresh-token" })
+  })
+
+  test("fromEnv requires both refresh env vars when either is present", () => {
+    expect(() => WorkspaceBridgeClient.fromEnv({
+      BORING_WORKSPACE_BRIDGE_URL: "https://example.test/api/v1/workspace-bridge/call",
+      BORING_WORKSPACE_BRIDGE_TOKEN: "expired-token",
+      BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN: "refresh-token",
+    }, { fetch: makeFetch({ ok: true, output: null }) })).toThrowError(WORKSPACE_BRIDGE_TOKEN_URL_ENV)
+
+    expect(() => WorkspaceBridgeClient.fromEnv({
+      BORING_WORKSPACE_BRIDGE_URL: "https://example.test/api/v1/workspace-bridge/call",
+      BORING_WORKSPACE_BRIDGE_TOKEN: "expired-token",
+      BORING_WORKSPACE_BRIDGE_TOKEN_URL: "https://example.test/api/v1/workspace-bridge/token",
+    }, { fetch: makeFetch({ ok: true, output: null }) })).toThrowError(WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV)
   })
 
   test("does not retry static expired tokens", async () => {

--- a/packages/workspace/src/bridge-client/__tests__/client.test.ts
+++ b/packages/workspace/src/bridge-client/__tests__/client.test.ts
@@ -5,13 +5,29 @@ import {
   WorkspaceBridgeClient,
   WorkspaceBridgeClientConfigError,
   WorkspaceBridgeClientError,
+  WorkspaceBridgeClientErrorCode,
+  WorkspaceBridgeErrorCode,
 } from ".."
 
-function makeFetch(response: unknown, init: { status?: number } = {}) {
+function makeFetch(response: unknown, init: { status?: number; ok?: boolean; statusText?: string } = {}) {
   return vi.fn(async () => ({
+    ok: init.ok ?? ((init.status ?? 200) >= 200 && (init.status ?? 200) < 300),
     status: init.status ?? 200,
+    statusText: init.statusText ?? "",
     json: async () => response,
   })) as unknown as typeof fetch & ReturnType<typeof vi.fn>
+}
+
+function makeSequenceFetch(responses: Array<{ body: unknown; status?: number; ok?: boolean }>) {
+  return vi.fn(async () => {
+    const next = responses.shift()
+    if (!next) throw new Error("unexpected fetch call")
+    return {
+      ok: next.ok ?? ((next.status ?? 200) >= 200 && (next.status ?? 200) < 300),
+      status: next.status ?? 200,
+      json: async () => next.body,
+    }
+  }) as unknown as typeof fetch & ReturnType<typeof vi.fn>
 }
 
 describe("WorkspaceBridgeClient", () => {
@@ -25,14 +41,15 @@ describe("WorkspaceBridgeClient", () => {
     const output = await client.call("example.v1.records.read", { seriesId: "GDPC1" }, { requestId: "req-1" })
 
     expect(output).toEqual({ value: 42 })
-    expect(fetchMock).toHaveBeenCalledWith("https://example.test/api/v1/workspace-bridge/call", {
+    expect(fetchMock).toHaveBeenCalledWith("https://example.test/api/v1/workspace-bridge/call", expect.objectContaining({
       method: "POST",
       headers: {
         "content-type": "application/json",
         authorization: "Bearer secret-token",
       },
       body: JSON.stringify({ op: "example.v1.records.read", input: { seriesId: "GDPC1" }, requestId: "req-1" }),
-    })
+      signal: expect.any(AbortSignal),
+    }))
   })
 
   test("serializes idempotencyKey", async () => {
@@ -55,11 +72,11 @@ describe("WorkspaceBridgeClient", () => {
     })
   })
 
-  test("maps stable bridge errors", async () => {
+  test("maps stable bridge errors and exports bridge error codes", async () => {
     const fetchMock = makeFetch({
       ok: false,
       requestId: "req-error",
-      error: { code: "BRIDGE_CAPABILITY_DENIED", message: "denied" },
+      error: { code: WorkspaceBridgeErrorCode.CapabilityDenied, message: "denied" },
     }, { status: 403 })
     const client = new WorkspaceBridgeClient({
       url: "https://example.test/api/v1/workspace-bridge/call",
@@ -69,11 +86,148 @@ describe("WorkspaceBridgeClient", () => {
 
     await expect(client.call("example.v1.records.read", {})).rejects.toMatchObject({
       name: "WorkspaceBridgeClientError",
-      code: "BRIDGE_CAPABILITY_DENIED",
+      code: WorkspaceBridgeErrorCode.CapabilityDenied,
       status: 403,
       requestId: "req-error",
       message: "denied",
     } satisfies Partial<WorkspaceBridgeClientError>)
+  })
+
+  test("supports token providers and retries once after a 401 bridge auth error", async () => {
+    const fetchMock = makeSequenceFetch([
+      {
+        status: 401,
+        body: { ok: false, error: { code: WorkspaceBridgeErrorCode.ExpiredToken, message: "expired" }, requestId: "req-1" },
+      },
+      { status: 200, body: { ok: true, output: { value: "ok" }, requestId: "req-1" } },
+    ])
+    const tokenProvider = vi.fn(async ({ refresh }: { refresh: boolean }) => refresh ? "fresh-token" : "expired-token")
+    const client = new WorkspaceBridgeClient({
+      url: "https://example.test/api/v1/workspace-bridge/call",
+      token: tokenProvider,
+      fetch: fetchMock,
+    })
+
+    await expect(client.call("example.v1.records.read", {})).resolves.toEqual({ value: "ok" })
+    expect(tokenProvider).toHaveBeenCalledTimes(2)
+    expect(tokenProvider).toHaveBeenNthCalledWith(1, { refresh: false })
+    expect(tokenProvider).toHaveBeenNthCalledWith(2, { refresh: true })
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit).headers).toMatchObject({ authorization: "Bearer expired-token" })
+    expect((fetchMock.mock.calls[1]?.[1] as RequestInit).headers).toMatchObject({ authorization: "Bearer fresh-token" })
+  })
+
+  test("does not retry static expired tokens", async () => {
+    const fetchMock = makeFetch({
+      ok: false,
+      error: { code: WorkspaceBridgeErrorCode.ExpiredToken, message: "expired" },
+    }, { status: 401 })
+    const client = new WorkspaceBridgeClient({
+      url: "https://example.test/api/v1/workspace-bridge/call",
+      token: "expired-token",
+      fetch: fetchMock,
+    })
+
+    await expect(client.call("example.v1.records.read", {})).rejects.toMatchObject({
+      code: WorkspaceBridgeErrorCode.ExpiredToken,
+      status: 401,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  test("wraps gateway JSON without a bridge envelope as a stable HTTP error", async () => {
+    const fetchMock = makeFetch({ message: "bad gateway" }, { status: 502, ok: false })
+    const client = new WorkspaceBridgeClient({
+      url: "https://example.test/api/v1/workspace-bridge/call",
+      token: "secret-token",
+      fetch: fetchMock,
+    })
+
+    await expect(client.call("example.v1.records.read", {})).rejects.toMatchObject({
+      code: WorkspaceBridgeClientErrorCode.HttpError,
+      status: 502,
+      message: "bad gateway",
+    })
+  })
+
+  test("rejects invalid success envelopes with a stable client code", async () => {
+    const fetchMock = makeFetch({ ok: "yes", output: 1 })
+    const client = new WorkspaceBridgeClient({
+      url: "https://example.test/api/v1/workspace-bridge/call",
+      token: "secret-token",
+      fetch: fetchMock,
+    })
+
+    await expect(client.call("example.v1.records.read", {})).rejects.toMatchObject({
+      code: WorkspaceBridgeClientErrorCode.InvalidResponse,
+      status: 200,
+    })
+  })
+
+  test("wraps fetch failures as stable transport errors", async () => {
+    const fetchMock = vi.fn(async () => { throw new Error("ECONNRESET") }) as unknown as typeof fetch
+    const client = new WorkspaceBridgeClient({
+      url: "https://example.test/api/v1/workspace-bridge/call",
+      token: "secret-token",
+      fetch: fetchMock,
+    })
+
+    await expect(client.call("example.v1.records.read", {})).rejects.toMatchObject({
+      code: WorkspaceBridgeClientErrorCode.Transport,
+    })
+  })
+
+  test("supports AbortSignal", async () => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      init?.signal?.dispatchEvent(new Event("abort"))
+      throw new DOMException("aborted", "AbortError")
+    }) as unknown as typeof fetch
+    const client = new WorkspaceBridgeClient({
+      url: "https://example.test/api/v1/workspace-bridge/call",
+      token: "secret-token",
+      fetch: fetchMock,
+    })
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(client.call("example.v1.records.read", {}, { signal: controller.signal })).rejects.toMatchObject({
+      code: WorkspaceBridgeClientErrorCode.Aborted,
+    })
+  })
+
+  test("times out stalled requests", async () => {
+    const fetchMock = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => new Promise((_resolve, reject) => {
+      init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true })
+    })) as unknown as typeof fetch
+    const client = new WorkspaceBridgeClient({
+      url: "https://example.test/api/v1/workspace-bridge/call",
+      token: "secret-token",
+      fetch: fetchMock,
+      defaultTimeoutMs: 1,
+    })
+
+    await expect(client.call("example.v1.records.read", {})).rejects.toMatchObject({
+      code: WorkspaceBridgeClientErrorCode.Timeout,
+    })
+  })
+
+  test("times out stalled response bodies after headers arrive", async () => {
+    const fetchMock = vi.fn(async (_url: RequestInfo | URL, init?: RequestInit) => ({
+      ok: true,
+      status: 200,
+      json: async () => new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true })
+      }),
+    })) as unknown as typeof fetch
+    const client = new WorkspaceBridgeClient({
+      url: "https://example.test/api/v1/workspace-bridge/call",
+      token: "secret-token",
+      fetch: fetchMock,
+      defaultTimeoutMs: 1,
+    })
+
+    await expect(client.call("example.v1.records.read", {})).rejects.toMatchObject({
+      code: WorkspaceBridgeClientErrorCode.Timeout,
+    })
   })
 
   test("missing env names the missing var without leaking token", () => {

--- a/packages/workspace/src/bridge-client/__tests__/client.test.ts
+++ b/packages/workspace/src/bridge-client/__tests__/client.test.ts
@@ -116,6 +116,23 @@ describe("WorkspaceBridgeClient", () => {
     expect((fetchMock.mock.calls[1]?.[1] as RequestInit).headers).toMatchObject({ authorization: "Bearer fresh-token" })
   })
 
+  test("applies timeoutMs to token provider resolution", async () => {
+    const fetchMock = makeFetch({ ok: true, output: { value: "unused" } })
+    const tokenProvider = vi.fn(() => new Promise<string>(() => {}))
+    const client = new WorkspaceBridgeClient({
+      url: "https://example.test/api/v1/workspace-bridge/call",
+      token: tokenProvider,
+      fetch: fetchMock,
+      defaultTimeoutMs: 1,
+    })
+
+    await expect(client.call("example.v1.records.read", {})).rejects.toMatchObject({
+      code: WorkspaceBridgeClientErrorCode.Timeout,
+    })
+    expect(tokenProvider).toHaveBeenCalledTimes(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   test("does not retry static expired tokens", async () => {
     const fetchMock = makeFetch({
       ok: false,

--- a/packages/workspace/src/bridge-client/index.ts
+++ b/packages/workspace/src/bridge-client/index.ts
@@ -1,26 +1,62 @@
-import type {
-  WorkspaceBridgeCallRequest,
-  WorkspaceBridgeCallResponse,
+import {
   WorkspaceBridgeErrorCode,
+  type WorkspaceBridgeCallFailure,
+  type WorkspaceBridgeCallRequest,
+  type WorkspaceBridgeCallResponse,
+  type WorkspaceBridgeCallSuccess,
+  type WorkspaceBridgeError,
 } from "../shared/workspace-bridge-rpc"
+
+export {
+  WorkspaceBridgeErrorCode,
+  type WorkspaceBridgeCallFailure,
+  type WorkspaceBridgeCallRequest,
+  type WorkspaceBridgeCallResponse,
+  type WorkspaceBridgeCallSuccess,
+  type WorkspaceBridgeError,
+}
 
 export const WORKSPACE_BRIDGE_URL_ENV = "BORING_WORKSPACE_BRIDGE_URL"
 export const WORKSPACE_BRIDGE_TOKEN_ENV = "BORING_WORKSPACE_BRIDGE_TOKEN"
 export const WORKSPACE_BRIDGE_DISABLED_ENV = "BORING_WORKSPACE_BRIDGE_DISABLED"
 
+export enum WorkspaceBridgeClientErrorCode {
+  Config = "WORKSPACE_BRIDGE_CLIENT_CONFIG_ERROR",
+  InvalidResponse = "WORKSPACE_BRIDGE_INVALID_RESPONSE",
+  Transport = "WORKSPACE_BRIDGE_TRANSPORT_ERROR",
+  Timeout = "WORKSPACE_BRIDGE_TIMEOUT",
+  Aborted = "WORKSPACE_BRIDGE_ABORTED",
+  HttpError = "WORKSPACE_BRIDGE_HTTP_ERROR",
+}
+
+export interface WorkspaceBridgeTokenProviderContext {
+  /** True when the previous attempt failed with a 401 and the client is retrying once. */
+  refresh: boolean
+}
+
+export type WorkspaceBridgeTokenProvider = (
+  context: WorkspaceBridgeTokenProviderContext,
+) => string | Promise<string>
+
+export type WorkspaceBridgeClientToken = string | WorkspaceBridgeTokenProvider
+
 export interface WorkspaceBridgeClientOptions {
   url: string
-  token: string
+  token: WorkspaceBridgeClientToken
   fetch?: typeof fetch
+  /** Default per-call timeout. Defaults to 30s. */
+  defaultTimeoutMs?: number
 }
 
 export interface WorkspaceBridgeClientCallOptions {
   requestId?: string
   idempotencyKey?: string
+  timeoutMs?: number
+  signal?: AbortSignal
 }
 
 export class WorkspaceBridgeClientConfigError extends Error {
-  readonly code = "WORKSPACE_BRIDGE_CLIENT_CONFIG_ERROR"
+  readonly code = WorkspaceBridgeClientErrorCode.Config
   readonly missingVar?: string
 
   constructor(message: string, options: { missingVar?: string } = {}) {
@@ -31,41 +67,58 @@ export class WorkspaceBridgeClientConfigError extends Error {
 }
 
 export class WorkspaceBridgeClientError extends Error {
-  readonly code: WorkspaceBridgeErrorCode | string
+  readonly code: WorkspaceBridgeErrorCode | WorkspaceBridgeClientErrorCode
   readonly status?: number
   readonly requestId?: string
 
-  constructor(message: string, options: { code: WorkspaceBridgeErrorCode | string; status?: number; requestId?: string }) {
+  constructor(
+    message: string,
+    options: {
+      code: WorkspaceBridgeErrorCode | WorkspaceBridgeClientErrorCode
+      status?: number
+      requestId?: string
+      cause?: unknown
+    },
+  ) {
     super(message)
     this.name = "WorkspaceBridgeClientError"
     this.code = options.code
     this.status = options.status
     this.requestId = options.requestId
+    if (options.cause !== undefined) {
+      ;(this as Error & { cause?: unknown }).cause = options.cause
+    }
   }
 }
 
 export class WorkspaceBridgeClient {
   readonly url: string
-  private readonly token: string
+  private readonly token: WorkspaceBridgeClientToken
   private readonly fetchImpl: typeof fetch
+  private readonly defaultTimeoutMs: number
 
   constructor(options: WorkspaceBridgeClientOptions) {
     this.url = normalizeBridgeUrl(options.url)
     this.token = options.token
     this.fetchImpl = options.fetch ?? globalThis.fetch
+    this.defaultTimeoutMs = options.defaultTimeoutMs ?? 30_000
+    assertTimeoutMs(this.defaultTimeoutMs, "defaultTimeoutMs")
     if (!this.fetchImpl) {
       throw new WorkspaceBridgeClientConfigError("WorkspaceBridge client requires a fetch implementation")
     }
   }
 
-  static fromEnv(env: Record<string, string | undefined> = readProcessEnv(), options: { fetch?: typeof fetch } = {}): WorkspaceBridgeClient {
+  static fromEnv(
+    env: Record<string, string | undefined> = readProcessEnv(),
+    options: { fetch?: typeof fetch; token?: WorkspaceBridgeClientToken; defaultTimeoutMs?: number } = {},
+  ): WorkspaceBridgeClient {
     const disabled = env[WORKSPACE_BRIDGE_DISABLED_ENV]
     if (disabled) {
       throw new WorkspaceBridgeClientConfigError(`WorkspaceBridge runtime env is disabled: ${disabled}`)
     }
     const url = requireEnv(env, WORKSPACE_BRIDGE_URL_ENV)
-    const token = requireEnv(env, WORKSPACE_BRIDGE_TOKEN_ENV)
-    return new WorkspaceBridgeClient({ url, token, fetch: options.fetch })
+    const token = options.token ?? requireEnv(env, WORKSPACE_BRIDGE_TOKEN_ENV)
+    return new WorkspaceBridgeClient({ url, token, fetch: options.fetch, defaultTimeoutMs: options.defaultTimeoutMs })
   }
 
   async call<TOutput = unknown, TInput = unknown>(
@@ -79,33 +132,87 @@ export class WorkspaceBridgeClient {
       ...(options.requestId ? { requestId: options.requestId } : {}),
       ...(options.idempotencyKey ? { idempotencyKey: options.idempotencyKey } : {}),
     }
-    const response = await this.fetchImpl(this.url, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-        authorization: `Bearer ${this.token}`,
-      },
-      body: JSON.stringify(request),
-    })
-
-    let body: WorkspaceBridgeCallResponse | undefined
     try {
-      body = await response.json() as WorkspaceBridgeCallResponse
-    } catch {
-      throw new WorkspaceBridgeClientError("WorkspaceBridge response was not valid JSON", {
-        code: "WORKSPACE_BRIDGE_INVALID_RESPONSE",
-        status: response.status,
-      })
+      return await this.callOnce<TOutput>(request, options, false)
+    } catch (error) {
+      if (this.shouldRetryWithFreshToken(error)) {
+        return await this.callOnce<TOutput>(request, options, true)
+      }
+      throw error
     }
+  }
 
-    if (!body.ok) {
-      throw new WorkspaceBridgeClientError(body.error.message, {
-        code: body.error.code,
-        status: response.status,
-        requestId: body.requestId,
+  private async callOnce<TOutput>(
+    request: WorkspaceBridgeCallRequest,
+    options: WorkspaceBridgeClientCallOptions,
+    refreshToken: boolean,
+  ): Promise<TOutput> {
+    const timeoutMs = options.timeoutMs ?? this.defaultTimeoutMs
+    assertTimeoutMs(timeoutMs, "timeoutMs")
+    const token = await this.resolveToken(refreshToken)
+    const abort = createAbortController({ signal: options.signal, timeoutMs })
+    try {
+      const response = await this.fetchImpl(this.url, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(request),
+        signal: abort.signal,
       })
+
+      const body = await readJsonResponse(response, abort)
+      const envelope = parseBridgeEnvelope(body)
+      if (!envelope) {
+        if (!httpOk(response)) {
+          throw new WorkspaceBridgeClientError(httpErrorMessage(response, body), {
+            code: WorkspaceBridgeClientErrorCode.HttpError,
+            status: response.status,
+          })
+        }
+        throw new WorkspaceBridgeClientError("WorkspaceBridge response envelope was invalid", {
+          code: WorkspaceBridgeClientErrorCode.InvalidResponse,
+          status: response.status,
+        })
+      }
+
+      if (!envelope.ok) {
+        throw new WorkspaceBridgeClientError(envelope.error.message, {
+          code: envelope.error.code,
+          status: response.status,
+          requestId: envelope.requestId,
+        })
+      }
+
+      if (!httpOk(response)) {
+        throw new WorkspaceBridgeClientError(httpErrorMessage(response, body), {
+          code: WorkspaceBridgeClientErrorCode.HttpError,
+          status: response.status,
+          requestId: envelope.requestId,
+        })
+      }
+
+      return envelope.output as TOutput
+    } catch (error) {
+      if (error instanceof WorkspaceBridgeClientError) throw error
+      throw fetchError(error, abort)
+    } finally {
+      abort.cleanup()
     }
-    return body.output as TOutput
+  }
+
+  private async resolveToken(refresh: boolean): Promise<string> {
+    const value = typeof this.token === "function" ? await this.token({ refresh }) : this.token
+    if (!value) {
+      throw new WorkspaceBridgeClientConfigError("WorkspaceBridge token provider returned an empty token")
+    }
+    return value
+  }
+
+  private shouldRetryWithFreshToken(error: unknown): boolean {
+    if (typeof this.token !== "function") return false
+    return error instanceof WorkspaceBridgeClientError && error.status === 401
   }
 }
 
@@ -127,4 +234,121 @@ function normalizeBridgeUrl(value: string): string {
 
 function readProcessEnv(): Record<string, string | undefined> {
   return (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env ?? {}
+}
+
+function assertTimeoutMs(value: number, name: string): void {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new WorkspaceBridgeClientConfigError(`WorkspaceBridge client ${name} must be a positive finite number`)
+  }
+}
+
+type AbortState = {
+  signal: AbortSignal
+  timedOut: () => boolean
+  callerAborted: () => boolean
+  cleanup: () => void
+}
+
+function createAbortController(options: { signal?: AbortSignal; timeoutMs: number }): AbortState {
+  const controller = new AbortController()
+  let timedOut = false
+  let callerAborted = Boolean(options.signal?.aborted)
+  const abortFromCaller = () => {
+    callerAborted = true
+    controller.abort(options.signal?.reason)
+  }
+  if (options.signal?.aborted) abortFromCaller()
+  else options.signal?.addEventListener("abort", abortFromCaller, { once: true })
+  const timeout = setTimeout(() => {
+    timedOut = true
+    controller.abort(new Error("WorkspaceBridge request timed out"))
+  }, options.timeoutMs)
+  return {
+    signal: controller.signal,
+    timedOut: () => timedOut,
+    callerAborted: () => callerAborted,
+    cleanup: () => {
+      clearTimeout(timeout)
+      options.signal?.removeEventListener("abort", abortFromCaller)
+    },
+  }
+}
+
+function fetchError(error: unknown, abort: AbortState): WorkspaceBridgeClientError {
+  if (abort.timedOut()) {
+    return new WorkspaceBridgeClientError("WorkspaceBridge request timed out", {
+      code: WorkspaceBridgeClientErrorCode.Timeout,
+      cause: error,
+    })
+  }
+  if (abort.callerAborted()) {
+    return new WorkspaceBridgeClientError("WorkspaceBridge request was aborted", {
+      code: WorkspaceBridgeClientErrorCode.Aborted,
+      cause: error,
+    })
+  }
+  return new WorkspaceBridgeClientError("WorkspaceBridge transport failed", {
+    code: WorkspaceBridgeClientErrorCode.Transport,
+    cause: error,
+  })
+}
+
+async function readJsonResponse(response: Response, abort: AbortState): Promise<unknown> {
+  try {
+    return await response.json()
+  } catch (error) {
+    if (abort.timedOut() || abort.callerAborted()) throw fetchError(error, abort)
+    throw new WorkspaceBridgeClientError("WorkspaceBridge response was not valid JSON", {
+      code: WorkspaceBridgeClientErrorCode.InvalidResponse,
+      status: response.status,
+      cause: error,
+    })
+  }
+}
+
+type ParsedBridgeEnvelope =
+  | { ok: true; op: string; requestId?: string; output: unknown }
+  | { ok: false; op: string; requestId?: string; error: WorkspaceBridgeError }
+
+function parseBridgeEnvelope(value: unknown): ParsedBridgeEnvelope | null {
+  if (!value || typeof value !== "object") return null
+  const raw = value as Record<string, unknown>
+  const requestId = raw.requestId === undefined || typeof raw.requestId === "string" ? raw.requestId : undefined
+  if (raw.ok === true) {
+    return {
+      ok: true,
+      op: typeof raw.op === "string" ? raw.op : "",
+      ...(requestId ? { requestId } : {}),
+      output: raw.output,
+    }
+  }
+  if (raw.ok === false && raw.error && typeof raw.error === "object") {
+    const error = raw.error as Record<string, unknown>
+    if (typeof error.message !== "string" || !isWorkspaceBridgeErrorCode(error.code)) return null
+    return {
+      ok: false,
+      op: typeof raw.op === "string" ? raw.op : "",
+      ...(requestId ? { requestId } : {}),
+      error: { code: error.code, message: error.message },
+    }
+  }
+  return null
+}
+
+const WORKSPACE_BRIDGE_ERROR_CODES = new Set<string>(Object.values(WorkspaceBridgeErrorCode))
+
+function isWorkspaceBridgeErrorCode(value: unknown): value is WorkspaceBridgeErrorCode {
+  return typeof value === "string" && WORKSPACE_BRIDGE_ERROR_CODES.has(value)
+}
+
+function httpOk(response: Response): boolean {
+  return typeof response.ok === "boolean" ? response.ok : response.status >= 200 && response.status < 300
+}
+
+function httpErrorMessage(response: Response, body: unknown): string {
+  if (body && typeof body === "object" && typeof (body as { message?: unknown }).message === "string") {
+    return (body as { message: string }).message
+  }
+  const statusText = typeof response.statusText === "string" && response.statusText ? ` ${response.statusText}` : ""
+  return `WorkspaceBridge HTTP ${response.status}${statusText}`
 }

--- a/packages/workspace/src/bridge-client/index.ts
+++ b/packages/workspace/src/bridge-client/index.ts
@@ -44,7 +44,7 @@ export interface WorkspaceBridgeClientOptions {
   url: string
   token: WorkspaceBridgeClientToken
   fetch?: typeof fetch
-  /** Default per-call timeout. Defaults to 30s. */
+  /** Default per-attempt timeout. Defaults to 30s. */
   defaultTimeoutMs?: number
 }
 
@@ -149,10 +149,10 @@ export class WorkspaceBridgeClient {
   ): Promise<TOutput> {
     const timeoutMs = options.timeoutMs ?? this.defaultTimeoutMs
     assertTimeoutMs(timeoutMs, "timeoutMs")
-    const token = await this.resolveToken(refreshToken)
     const abort = createAbortController({ signal: options.signal, timeoutMs })
     try {
-      const response = await this.fetchImpl(this.url, {
+      const token = await runWithAbort(() => this.resolveToken(refreshToken), abort)
+      const response = await runWithAbort(() => this.fetchImpl(this.url, {
         method: "POST",
         headers: {
           "content-type": "application/json",
@@ -160,7 +160,7 @@ export class WorkspaceBridgeClient {
         },
         body: JSON.stringify(request),
         signal: abort.signal,
-      })
+      }), abort)
 
       const body = await readJsonResponse(response, abort)
       const envelope = parseBridgeEnvelope(body)
@@ -195,7 +195,7 @@ export class WorkspaceBridgeClient {
 
       return envelope.output as TOutput
     } catch (error) {
-      if (error instanceof WorkspaceBridgeClientError) throw error
+      if (error instanceof WorkspaceBridgeClientError || error instanceof WorkspaceBridgeClientConfigError) throw error
       throw fetchError(error, abort)
     } finally {
       abort.cleanup()
@@ -293,10 +293,35 @@ function fetchError(error: unknown, abort: AbortState): WorkspaceBridgeClientErr
   })
 }
 
+async function runWithAbort<T>(operation: () => T | Promise<T>, abort: AbortState): Promise<T> {
+  if (abort.signal.aborted) throw fetchError(undefined, abort)
+
+  return await new Promise<T>((resolve, reject) => {
+    let settled = false
+    const cleanup = () => abort.signal.removeEventListener("abort", onAbort)
+    const settle = (callback: () => void) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      callback()
+    }
+    const onAbort = () => settle(() => reject(fetchError(undefined, abort)))
+
+    abort.signal.addEventListener("abort", onAbort, { once: true })
+    Promise.resolve()
+      .then(operation)
+      .then(
+        (value) => settle(() => resolve(value)),
+        (error) => settle(() => reject(error)),
+      )
+  })
+}
+
 async function readJsonResponse(response: Response, abort: AbortState): Promise<unknown> {
   try {
-    return await response.json()
+    return await runWithAbort(() => response.json(), abort)
   } catch (error) {
+    if (error instanceof WorkspaceBridgeClientError) throw error
     if (abort.timedOut() || abort.callerAborted()) throw fetchError(error, abort)
     throw new WorkspaceBridgeClientError("WorkspaceBridge response was not valid JSON", {
       code: WorkspaceBridgeClientErrorCode.InvalidResponse,

--- a/packages/workspace/src/bridge-client/index.ts
+++ b/packages/workspace/src/bridge-client/index.ts
@@ -1,4 +1,9 @@
 import {
+  WORKSPACE_BRIDGE_DISABLED_ENV,
+  WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV,
+  WORKSPACE_BRIDGE_TOKEN_ENV,
+  WORKSPACE_BRIDGE_TOKEN_URL_ENV,
+  WORKSPACE_BRIDGE_URL_ENV,
   WorkspaceBridgeErrorCode,
   type WorkspaceBridgeCallFailure,
   type WorkspaceBridgeCallRequest,
@@ -8,6 +13,14 @@ import {
 } from "../shared/workspace-bridge-rpc"
 
 export {
+  // Canonical env var names live in ../shared so the runtimeEnv producer and
+  // this SDK consumer share one source of truth; re-exported here to keep the
+  // bridge-client public API surface stable for downstream integrators.
+  WORKSPACE_BRIDGE_DISABLED_ENV,
+  WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV,
+  WORKSPACE_BRIDGE_TOKEN_ENV,
+  WORKSPACE_BRIDGE_TOKEN_URL_ENV,
+  WORKSPACE_BRIDGE_URL_ENV,
   WorkspaceBridgeErrorCode,
   type WorkspaceBridgeCallFailure,
   type WorkspaceBridgeCallRequest,
@@ -15,12 +28,6 @@ export {
   type WorkspaceBridgeCallSuccess,
   type WorkspaceBridgeError,
 }
-
-export const WORKSPACE_BRIDGE_URL_ENV = "BORING_WORKSPACE_BRIDGE_URL"
-export const WORKSPACE_BRIDGE_TOKEN_ENV = "BORING_WORKSPACE_BRIDGE_TOKEN"
-export const WORKSPACE_BRIDGE_TOKEN_URL_ENV = "BORING_WORKSPACE_BRIDGE_TOKEN_URL"
-export const WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV = "BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN"
-export const WORKSPACE_BRIDGE_DISABLED_ENV = "BORING_WORKSPACE_BRIDGE_DISABLED"
 
 export enum WorkspaceBridgeClientErrorCode {
   Config = "WORKSPACE_BRIDGE_CLIENT_CONFIG_ERROR",

--- a/packages/workspace/src/bridge-client/index.ts
+++ b/packages/workspace/src/bridge-client/index.ts
@@ -18,6 +18,8 @@ export {
 
 export const WORKSPACE_BRIDGE_URL_ENV = "BORING_WORKSPACE_BRIDGE_URL"
 export const WORKSPACE_BRIDGE_TOKEN_ENV = "BORING_WORKSPACE_BRIDGE_TOKEN"
+export const WORKSPACE_BRIDGE_TOKEN_URL_ENV = "BORING_WORKSPACE_BRIDGE_TOKEN_URL"
+export const WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV = "BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN"
 export const WORKSPACE_BRIDGE_DISABLED_ENV = "BORING_WORKSPACE_BRIDGE_DISABLED"
 
 export enum WorkspaceBridgeClientErrorCode {
@@ -32,6 +34,8 @@ export enum WorkspaceBridgeClientErrorCode {
 export interface WorkspaceBridgeTokenProviderContext {
   /** True when the previous attempt failed with a 401 and the client is retrying once. */
   refresh: boolean
+  /** Aborts when the per-attempt timeout or caller AbortSignal fires. */
+  signal?: AbortSignal
 }
 
 export type WorkspaceBridgeTokenProvider = (
@@ -117,7 +121,7 @@ export class WorkspaceBridgeClient {
       throw new WorkspaceBridgeClientConfigError(`WorkspaceBridge runtime env is disabled: ${disabled}`)
     }
     const url = requireEnv(env, WORKSPACE_BRIDGE_URL_ENV)
-    const token = options.token ?? requireEnv(env, WORKSPACE_BRIDGE_TOKEN_ENV)
+    const token = options.token ?? tokenFromEnv(env, options.fetch ?? globalThis.fetch)
     return new WorkspaceBridgeClient({ url, token, fetch: options.fetch, defaultTimeoutMs: options.defaultTimeoutMs })
   }
 
@@ -151,7 +155,7 @@ export class WorkspaceBridgeClient {
     assertTimeoutMs(timeoutMs, "timeoutMs")
     const abort = createAbortController({ signal: options.signal, timeoutMs })
     try {
-      const token = await runWithAbort(() => this.resolveToken(refreshToken), abort)
+      const token = await runWithAbort(() => this.resolveToken(refreshToken, abort.signal), abort)
       const response = await runWithAbort(() => this.fetchImpl(this.url, {
         method: "POST",
         headers: {
@@ -202,8 +206,8 @@ export class WorkspaceBridgeClient {
     }
   }
 
-  private async resolveToken(refresh: boolean): Promise<string> {
-    const value = typeof this.token === "function" ? await this.token({ refresh }) : this.token
+  private async resolveToken(refresh: boolean, signal: AbortSignal): Promise<string> {
+    const value = typeof this.token === "function" ? await this.token({ refresh, signal }) : this.token
     if (!value) {
       throw new WorkspaceBridgeClientConfigError("WorkspaceBridge token provider returned an empty token")
     }
@@ -214,6 +218,70 @@ export class WorkspaceBridgeClient {
     if (typeof this.token !== "function") return false
     return error instanceof WorkspaceBridgeClientError && error.status === 401
   }
+}
+
+function tokenFromEnv(env: Record<string, string | undefined>, fetchImpl: typeof fetch | undefined): WorkspaceBridgeClientToken {
+  const initialToken = requireEnv(env, WORKSPACE_BRIDGE_TOKEN_ENV)
+  const tokenUrl = env[WORKSPACE_BRIDGE_TOKEN_URL_ENV]
+  const refreshToken = env[WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV]
+  if (!tokenUrl && !refreshToken) return initialToken
+  if (!tokenUrl) {
+    throw new WorkspaceBridgeClientConfigError(`WorkspaceBridge client missing required env var ${WORKSPACE_BRIDGE_TOKEN_URL_ENV}`, { missingVar: WORKSPACE_BRIDGE_TOKEN_URL_ENV })
+  }
+  if (!refreshToken) {
+    throw new WorkspaceBridgeClientConfigError(`WorkspaceBridge client missing required env var ${WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV}`, { missingVar: WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV })
+  }
+  if (!fetchImpl) {
+    throw new WorkspaceBridgeClientConfigError("WorkspaceBridge refresh token provider requires a fetch implementation")
+  }
+  const normalizedTokenUrl = normalizeBridgeUrl(tokenUrl)
+  let cachedToken = initialToken
+  return async ({ refresh, signal }) => {
+    if (!refresh) return cachedToken
+    cachedToken = await fetchRefreshedToken({ tokenUrl: normalizedTokenUrl, refreshToken, fetchImpl, signal })
+    return cachedToken
+  }
+}
+
+async function fetchRefreshedToken(options: {
+  tokenUrl: string
+  refreshToken: string
+  fetchImpl: typeof fetch
+  signal?: AbortSignal
+}): Promise<string> {
+  const response = await options.fetchImpl(options.tokenUrl, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${options.refreshToken}`,
+    },
+    body: "{}",
+    signal: options.signal,
+  })
+  const body = await response.json()
+  if (isTokenResponse(body)) return body.token
+  const envelope = parseBridgeEnvelope(body)
+  if (envelope && !envelope.ok) {
+    throw new WorkspaceBridgeClientError(envelope.error.message, {
+      code: envelope.error.code,
+      status: response.status,
+      requestId: envelope.requestId,
+    })
+  }
+  if (!httpOk(response)) {
+    throw new WorkspaceBridgeClientError(httpErrorMessage(response, body), {
+      code: WorkspaceBridgeClientErrorCode.HttpError,
+      status: response.status,
+    })
+  }
+  throw new WorkspaceBridgeClientError("WorkspaceBridge token response envelope was invalid", {
+    code: WorkspaceBridgeClientErrorCode.InvalidResponse,
+    status: response.status,
+  })
+}
+
+function isTokenResponse(value: unknown): value is { ok: true; token: string } {
+  return !!value && typeof value === "object" && (value as { ok?: unknown }).ok === true && typeof (value as { token?: unknown }).token === "string"
 }
 
 function requireEnv(env: Record<string, string | undefined>, name: string): string {

--- a/packages/workspace/src/server/index.ts
+++ b/packages/workspace/src/server/index.ts
@@ -51,6 +51,7 @@ export type {
   WorkspaceBridgeCallContext,
   WorkspaceBridgeHandler,
   WorkspaceBridgeHandlerArgs,
+  WorkspaceBridgeRegistryCallOptions,
   WorkspaceBridgeRegistryLogger,
   WorkspaceBridgeRegistryOptions,
 } from "./workspaceBridge/registry"
@@ -85,20 +86,28 @@ export type {
   WorkspaceBridgeIdempotencyStore,
 } from "./workspaceBridge/idempotency"
 export {
+  WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE,
   WORKSPACE_BRIDGE_TOKEN_AUDIENCE,
+  mintWorkspaceBridgeRuntimeRefreshToken,
   mintWorkspaceBridgeRuntimeToken,
   runtimeClaimsToBridgeAuthContext,
+  verifyWorkspaceBridgeRuntimeRefreshToken,
   verifyWorkspaceBridgeRuntimeToken,
 } from "./workspaceBridge/runtimeToken"
 export type {
+  MintWorkspaceBridgeRuntimeRefreshTokenOptions,
   MintWorkspaceBridgeRuntimeTokenOptions,
+  VerifiedWorkspaceBridgeRuntimeRefreshToken,
   VerifiedWorkspaceBridgeRuntimeToken,
+  VerifyWorkspaceBridgeRuntimeRefreshTokenOptions,
   VerifyWorkspaceBridgeRuntimeTokenOptions,
+  WorkspaceBridgeRuntimeRefreshTokenClaims,
   WorkspaceBridgeRuntimeTokenClaims,
 } from "./workspaceBridge/runtimeToken"
 export {
   createWorkspaceBridgeRuntimeEnvContribution,
   resolveBridgeCallUrl,
+  resolveBridgeTokenUrl,
 } from "./workspaceBridge/runtimeEnv"
 export { defineTrustedDomainBridgeHandler } from "./workspaceBridge/trustedDomainHandler"
 export type {

--- a/packages/workspace/src/server/index.ts
+++ b/packages/workspace/src/server/index.ts
@@ -124,6 +124,7 @@ export type {
   CreateWorkspaceBridgeRuntimeEnvContributionOptions,
   WorkspaceBridgeRuntimeEnvDisabledReason,
   WorkspaceBridgeRuntimeEnvOptions,
+  WorkspaceBridgeRuntimePlacement,
 } from "./workspaceBridge/runtimeEnv"
 export type {
   TrustedDomainBridgeHandlerOptions,

--- a/packages/workspace/src/server/index.ts
+++ b/packages/workspace/src/server/index.ts
@@ -61,6 +61,12 @@ export {
 } from "./workspaceBridge/authPolicy"
 export { workspaceBridgeHttpRoutes } from "./workspaceBridge/httpRoutes"
 export type { WorkspaceBridgeHttpRoutesOptions } from "./workspaceBridge/httpRoutes"
+export { InMemoryWorkspaceBridgeRuntimeRefreshTokenStore } from "./workspaceBridge/refreshTokenStore"
+export type {
+  WorkspaceBridgeRuntimeRefreshTokenStore,
+  WorkspaceBridgeRuntimeRefreshTokenUseOptions,
+  WorkspaceBridgeRuntimeRefreshTokenUseResult,
+} from "./workspaceBridge/refreshTokenStore"
 export {
   InMemoryWorkspaceBridgeIdempotencyStore,
   hashNormalizedInput,
@@ -86,8 +92,12 @@ export type {
   WorkspaceBridgeIdempotencyStore,
 } from "./workspaceBridge/idempotency"
 export {
+  DEFAULT_WORKSPACE_BRIDGE_RUNTIME_REFRESH_TOKEN_TTL_MS,
+  DEFAULT_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS,
+  MAX_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS,
   WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE,
   WORKSPACE_BRIDGE_TOKEN_AUDIENCE,
+  clampWorkspaceBridgeRuntimeTokenTtlMs,
   mintWorkspaceBridgeRuntimeRefreshToken,
   mintWorkspaceBridgeRuntimeToken,
   runtimeClaimsToBridgeAuthContext,

--- a/packages/workspace/src/server/workspaceBridge/__tests__/authPolicy.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/authPolicy.test.ts
@@ -145,4 +145,21 @@ describe("BridgeAuthPolicy adapters", () => {
       actor: { actorKind: "human", performedBy: { label: "local-cli:user" } },
     })
   })
+
+  it("denies local CLI browser callers for a workspace other than the configured one", async () => {
+    const policy = createLocalCliBridgeAuthPolicy({
+      workspaceId: "workspace-local",
+      capabilities: ["example:respond"],
+    })
+
+    // resolve() is synchronous for the local-cli policy, so normalize its throw
+    // into a rejection before asserting on the stable error code.
+    await expect(
+      (async () => policy.resolve({
+        callerClass: "browser",
+        definition: browserOp,
+        workspaceId: "workspace-other",
+      }))(),
+    ).rejects.toMatchObject({ code: WorkspaceBridgeErrorCode.ResourceScopeDenied })
+  })
 })

--- a/packages/workspace/src/server/workspaceBridge/__tests__/exampleSdkScenario.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/exampleSdkScenario.test.ts
@@ -1,0 +1,223 @@
+import Fastify from "fastify"
+import { describe, expect, it } from "vitest"
+import {
+  WorkspaceBridgeClient,
+  WorkspaceBridgeClientError,
+  WorkspaceBridgeErrorCode,
+} from "../../../bridge-client"
+import type { WorkspaceBridgeOperationDefinition } from "../../../shared/workspace-bridge-rpc"
+import { createBrowserBridgeAuthPolicy } from "../authPolicy"
+import { InMemoryWorkspaceBridgeIdempotencyStore } from "../idempotency"
+import { createWorkspaceBridgeRegistry } from "../registry"
+import { createWorkspaceBridgeRuntimeEnvContribution } from "../runtimeEnv"
+import { mintWorkspaceBridgeRuntimeToken } from "../runtimeToken"
+import { workspaceBridgeHttpRoutes } from "../httpRoutes"
+
+/**
+ * Realistic end-to-end scenario: a DOWNSTREAM app ships a domain SDK on top of
+ * WorkspaceBridge. The host registers a domain op with a real schema + scoped
+ * capability + idempotency; a sandboxed runtime imports the published
+ * WorkspaceBridgeClient, wraps it in a thin domain SDK, and reads its bridge
+ * URL/token from the env the host injected. This is the "custom SDK" story the
+ * bridge exists for — exercised over the real registry, auth, schema validator,
+ * idempotency store, and HTTP transport (no mocks beyond app.inject as fetch).
+ */
+
+const CALL_SECRET = "workspace-bridge-runtime-token-secret-32bytes"
+const REFRESH_SECRET = "workspace-bridge-runtime-refresh-secret-32bytes"
+const WORKSPACE = "workspace-acme"
+const CAPABILITY = "example:outputs.write"
+
+interface ExampleOutput {
+  id: string
+  title: string
+  content: string
+}
+
+// The host-owned domain operation a downstream product would register.
+const OUTPUTS_WRITE: WorkspaceBridgeOperationDefinition = {
+  op: "example.v1.outputs.write",
+  version: 1,
+  owner: "example-app",
+  callerClassesAllowed: ["runtime"],
+  requiredCapabilities: [CAPABILITY],
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: { type: "string" },
+      title: { type: "string" },
+      content: { type: "string" },
+    },
+    required: ["id", "title", "content"],
+    additionalProperties: false,
+  },
+  outputSchema: {
+    type: "object",
+    properties: { id: { type: "string" }, revision: { type: "integer" } },
+    required: ["id", "revision"],
+  },
+  timeoutMs: 2_000,
+  maxInputBytes: 64 * 1024,
+  maxOutputBytes: 4 * 1024,
+  idempotencyPolicy: "required",
+}
+
+// The thin "dummy SDK" a downstream integrator ships around WorkspaceBridgeClient.
+class ExampleOutputsClient {
+  private constructor(private readonly bridge: WorkspaceBridgeClient) {}
+
+  static fromEnv(env: Record<string, string | undefined>, fetchImpl: typeof fetch): ExampleOutputsClient {
+    return new ExampleOutputsClient(WorkspaceBridgeClient.fromEnv(env, { fetch: fetchImpl }))
+  }
+
+  writeOutput(output: ExampleOutput): Promise<{ id: string; revision: number }> {
+    return this.bridge.call("example.v1.outputs.write", output, {
+      idempotencyKey: `example-outputs-write:${output.id}`,
+    })
+  }
+}
+
+interface Harness {
+  env: Record<string, string>
+  fetch: typeof fetch
+  store: Map<string, ExampleOutput & { revision: number }>
+  writeCalls: () => number
+  close: () => Promise<void>
+}
+
+async function setupHarness(): Promise<Harness> {
+  const store = new Map<string, ExampleOutput & { revision: number }>()
+  let revision = 0
+  let writeCalls = 0
+
+  const registry = createWorkspaceBridgeRegistry({ ownerWorkspaceId: WORKSPACE })
+  registry.registerHandler<ExampleOutput, { id: string; revision: number }>(
+    OUTPUTS_WRITE as WorkspaceBridgeOperationDefinition<ExampleOutput, { id: string; revision: number }>,
+    ({ input }) => {
+      writeCalls += 1
+      revision += 1
+      store.set(input.id, { ...input, revision })
+      return { id: input.id, revision }
+    },
+  )
+
+  const app = Fastify()
+  await app.register(workspaceBridgeHttpRoutes, {
+    registry,
+    runtimeTokenSecret: CALL_SECRET,
+    runtimeRefreshTokenSecret: REFRESH_SECRET,
+    ownerWorkspaceId: WORKSPACE,
+    idempotencyStore: new InMemoryWorkspaceBridgeIdempotencyStore(),
+    browserAuthPolicy: createBrowserBridgeAuthPolicy({
+      getPrincipal: () => ({ userId: "user-1" }),
+      authorizeWorkspace: () => ({ allowed: true, capabilities: [CAPABILITY] }),
+    }),
+  })
+  await app.ready()
+
+  // Host injects the runtime env into the sandbox exactly as production does.
+  const contribution = createWorkspaceBridgeRuntimeEnvContribution({
+    workspaceId: WORKSPACE,
+    runtimeMode: "local",
+    registry,
+    runtimeTokenSecret: CALL_SECRET,
+    runtimeRefreshTokenSecret: REFRESH_SECRET,
+    runtimeEnv: { bridgeUrl: "http://127.0.0.1/", capabilities: [CAPABILITY] },
+  })
+  if (!contribution) throw new Error("expected a runtime env contribution")
+  const env = await contribution.getEnv({
+    workspaceId: WORKSPACE,
+    workspaceRoot: "/tmp/workspace-acme",
+    runtimeMode: "local",
+    runtimeBundle: {} as never,
+  }) as Record<string, string>
+
+  const fetchImpl = (async (input: string | URL, init?: RequestInit) => {
+    const url = new URL(typeof input === "string" ? input : input.toString())
+    const res = await app.inject({
+      method: (init?.method ?? "GET") as "GET" | "POST",
+      url: url.pathname + url.search,
+      headers: init?.headers as Record<string, string>,
+      payload: init?.body as string,
+    })
+    return {
+      status: res.statusCode,
+      ok: res.statusCode >= 200 && res.statusCode < 300,
+      statusText: "",
+      json: async () => res.json(),
+    } as unknown as Response
+  }) as unknown as typeof fetch
+
+  return { env, fetch: fetchImpl, store, writeCalls: () => writeCalls, close: () => app.close() }
+}
+
+describe("downstream domain SDK over WorkspaceBridge (fromEnv)", () => {
+  it("writes a domain output end-to-end through a runtime-injected SDK", async () => {
+    const h = await setupHarness()
+    try {
+      const sdk = ExampleOutputsClient.fromEnv(h.env, h.fetch)
+
+      const result = await sdk.writeOutput({ id: "out-1", title: "Quarterly summary", content: "hello" })
+
+      expect(result).toEqual({ id: "out-1", revision: 1 })
+      expect(h.store.get("out-1")).toMatchObject({ title: "Quarterly summary", content: "hello", revision: 1 })
+    } finally {
+      await h.close()
+    }
+  })
+
+  it("replays the cached result for a repeated idempotency key (handler runs once)", async () => {
+    const h = await setupHarness()
+    try {
+      const sdk = ExampleOutputsClient.fromEnv(h.env, h.fetch)
+
+      const first = await sdk.writeOutput({ id: "out-7", title: "T", content: "v1" })
+      const second = await sdk.writeOutput({ id: "out-7", title: "T", content: "v1" })
+
+      expect(second).toEqual(first)
+      expect(h.writeCalls()).toBe(1)
+    } finally {
+      await h.close()
+    }
+  })
+
+  it("surfaces a stable CapabilityDenied error when the runtime token lacks the op capability", async () => {
+    const h = await setupHarness()
+    try {
+      // A runtime whose injected token was scoped without the write capability.
+      const underScopedEnv = {
+        ...h.env,
+        BORING_WORKSPACE_BRIDGE_TOKEN: mintWorkspaceBridgeRuntimeToken({
+          secret: CALL_SECRET,
+          workspaceId: WORKSPACE,
+          capabilities: [],
+          runtimeId: "local",
+        }),
+      }
+      const sdk = ExampleOutputsClient.fromEnv(underScopedEnv, h.fetch)
+
+      await expect(sdk.writeOutput({ id: "out-9", title: "T", content: "c" }))
+        .rejects.toMatchObject({ code: WorkspaceBridgeErrorCode.CapabilityDenied, status: 403 })
+      expect(h.store.has("out-9")).toBe(false)
+    } finally {
+      await h.close()
+    }
+  })
+
+  it("surfaces a stable SchemaInvalid error for input that violates the op schema", async () => {
+    const h = await setupHarness()
+    try {
+      const sdk = ExampleOutputsClient.fromEnv(h.env, h.fetch)
+
+      // Missing required `content` — rejected by the registry schema validator
+      // before the handler runs.
+      const promise = sdk.writeOutput({ id: "out-bad", title: "T" } as ExampleOutput)
+
+      await expect(promise).rejects.toBeInstanceOf(WorkspaceBridgeClientError)
+      await expect(promise).rejects.toMatchObject({ code: WorkspaceBridgeErrorCode.SchemaInvalid })
+      expect(h.writeCalls()).toBe(0)
+    } finally {
+      await h.close()
+    }
+  })
+})

--- a/packages/workspace/src/server/workspaceBridge/__tests__/httpRoutes.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/httpRoutes.test.ts
@@ -1,10 +1,11 @@
 import Fastify from "fastify"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { WorkspaceBridgeErrorCode } from "../../../shared/workspace-bridge-rpc"
 import { createBrowserBridgeAuthPolicy } from "../authPolicy"
 import { InMemoryWorkspaceBridgeIdempotencyStore } from "../idempotency"
+import { InMemoryWorkspaceBridgeRuntimeRefreshTokenStore } from "../refreshTokenStore"
 import { createWorkspaceBridgeRegistry } from "../registry"
-import { mintWorkspaceBridgeRuntimeRefreshToken, mintWorkspaceBridgeRuntimeToken, verifyWorkspaceBridgeRuntimeToken } from "../runtimeToken"
+import { mintWorkspaceBridgeRuntimeRefreshToken, mintWorkspaceBridgeRuntimeToken, verifyWorkspaceBridgeRuntimeRefreshToken, verifyWorkspaceBridgeRuntimeToken } from "../runtimeToken"
 import { workspaceBridgeHttpRoutes } from "../httpRoutes"
 import { assertNoSensitiveBridgeLeaks, createTestBridgeOperationDefinition } from "../testing/harness"
 
@@ -153,12 +154,112 @@ describe("workspaceBridgeHttpRoutes", () => {
     const body = response.json()
     expect(body).toMatchObject({ ok: true, token: expect.any(String) })
     const verified = verifyWorkspaceBridgeRuntimeToken(body.token, { secret: SECRET, requiredCapabilities: ["runtime:echo"] })
+    const refreshClaims = verifyWorkspaceBridgeRuntimeRefreshToken(refreshToken, { secret: REFRESH_SECRET }).claims
+    expect(verified.claims.exp).toBeLessThanOrEqual(refreshClaims.exp)
     expect(verified.authContext).toMatchObject({
       callerClass: "runtime",
       workspaceId: "workspace-1",
       sessionId: "session-1",
       capabilities: ["runtime:echo"],
     })
+  })
+
+  it("rejects refresh tokens that expire while async refresh-store checks run", async () => {
+    const nowMs = Date.parse("2026-01-01T00:00:00.000Z")
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(nowMs)
+    try {
+      const registry = createWorkspaceBridgeRegistry()
+      const app = Fastify()
+      await app.register(workspaceBridgeHttpRoutes, {
+        registry,
+        runtimeTokenSecret: SECRET,
+        runtimeRefreshTokenSecret: REFRESH_SECRET,
+        getRuntimeRefreshTokenStore: async () => ({
+          revoke: async () => {},
+          recordUse: async () => {
+            dateNow.mockReturnValue(nowMs + 2_000)
+            return { allowed: true as const }
+          },
+        }),
+      })
+      const refreshToken = mintWorkspaceBridgeRuntimeRefreshToken({
+        secret: REFRESH_SECRET,
+        workspaceId: "workspace-1",
+        capabilities: [],
+        nowMs,
+        ttlMs: 1_000,
+      })
+
+      const response = await app.inject({ method: "POST", url: "/api/v1/workspace-bridge/token", headers: { authorization: `Bearer ${refreshToken}` }, payload: {} })
+      expect(response.statusCode).toBe(401)
+      expect(response.json()).toMatchObject({ ok: false, error: { code: WorkspaceBridgeErrorCode.ExpiredToken } })
+    } finally {
+      dateNow.mockRestore()
+    }
+  })
+
+  it("rate-limits and revokes runtime refresh tokens by jti", async () => {
+    const registry = createWorkspaceBridgeRegistry()
+    const store = new InMemoryWorkspaceBridgeRuntimeRefreshTokenStore()
+    const app = Fastify()
+    await app.register(workspaceBridgeHttpRoutes, {
+      registry,
+      runtimeTokenSecret: SECRET,
+      runtimeRefreshTokenSecret: REFRESH_SECRET,
+      runtimeRefreshTokenStore: store,
+      refreshTokenRateLimit: { maxUses: 1, windowMs: 60_000 },
+    })
+    const refreshToken = mintWorkspaceBridgeRuntimeRefreshToken({
+      secret: REFRESH_SECRET,
+      workspaceId: "workspace-1",
+      capabilities: [],
+      ttlMs: 60_000,
+      jti: "refresh-jti-1",
+    })
+
+    const first = await app.inject({ method: "POST", url: "/api/v1/workspace-bridge/token", headers: { authorization: `Bearer ${refreshToken}` }, payload: {} })
+    const second = await app.inject({ method: "POST", url: "/api/v1/workspace-bridge/token", headers: { authorization: `Bearer ${refreshToken}` }, payload: {} })
+    expect(first.statusCode).toBe(200)
+    expect(second.statusCode).toBe(429)
+    expect(second.json()).toMatchObject({ ok: false, error: { code: WorkspaceBridgeErrorCode.RateLimited } })
+
+    store.revoke("refresh-jti-1")
+    const revoked = await app.inject({ method: "POST", url: "/api/v1/workspace-bridge/token", headers: { authorization: `Bearer ${refreshToken}` }, payload: {} })
+    expect(revoked.statusCode).toBe(401)
+    expect(revoked.json()).toMatchObject({ ok: false, error: { code: WorkspaceBridgeErrorCode.InvalidToken } })
+  })
+
+  it("rejects runtime tokens that try to select another workspace registry", async () => {
+    const left = createWorkspaceBridgeRegistry({ ownerWorkspaceId: "workspace-left" })
+    const right = createWorkspaceBridgeRegistry({ ownerWorkspaceId: "workspace-right" })
+    for (const registry of [left, right]) {
+      registry.registerHandler(createTestBridgeOperationDefinition({
+        op: "runtime.v1.echo",
+        callerClassesAllowed: ["runtime"],
+        requiredCapabilities: ["runtime:echo"],
+      }), ({ context }) => ({ workspaceId: context.workspaceId }))
+    }
+    const app = Fastify()
+    await app.register(workspaceBridgeHttpRoutes, {
+      getRegistry: (request) => request.headers["x-boring-workspace-id"] === "workspace-right" ? right : left,
+      getOwnerWorkspaceId: (request) => String(request.headers["x-boring-workspace-id"] ?? "workspace-left"),
+      runtimeTokenSecret: SECRET,
+    })
+    const token = mintWorkspaceBridgeRuntimeToken({
+      secret: SECRET,
+      workspaceId: "workspace-left",
+      capabilities: ["runtime:echo"],
+      ttlMs: 60_000,
+    })
+
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/workspace-bridge/call",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}`, "x-boring-workspace-id": "workspace-right" },
+      payload: { op: "runtime.v1.echo", input: {} },
+    })
+    expect(response.statusCode).toBe(403)
+    expect(response.json()).toMatchObject({ ok: false, error: { code: WorkspaceBridgeErrorCode.ResourceScopeDenied } })
   })
 
   it("rejects expired and missing-capability runtime tokens", async () => {

--- a/packages/workspace/src/server/workspaceBridge/__tests__/httpRoutes.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/httpRoutes.test.ts
@@ -4,11 +4,12 @@ import { WorkspaceBridgeErrorCode } from "../../../shared/workspace-bridge-rpc"
 import { createBrowserBridgeAuthPolicy } from "../authPolicy"
 import { InMemoryWorkspaceBridgeIdempotencyStore } from "../idempotency"
 import { createWorkspaceBridgeRegistry } from "../registry"
-import { mintWorkspaceBridgeRuntimeToken } from "../runtimeToken"
+import { mintWorkspaceBridgeRuntimeRefreshToken, mintWorkspaceBridgeRuntimeToken, verifyWorkspaceBridgeRuntimeToken } from "../runtimeToken"
 import { workspaceBridgeHttpRoutes } from "../httpRoutes"
 import { assertNoSensitiveBridgeLeaks, createTestBridgeOperationDefinition } from "../testing/harness"
 
 const SECRET = "workspace-bridge-runtime-token-secret-32bytes"
+const REFRESH_SECRET = "workspace-bridge-runtime-refresh-secret-32bytes"
 
 async function makeApp() {
   const registry = createWorkspaceBridgeRegistry()
@@ -35,6 +36,8 @@ async function makeApp() {
   await app.register(workspaceBridgeHttpRoutes, {
     registry,
     runtimeTokenSecret: SECRET,
+    runtimeRefreshTokenSecret: REFRESH_SECRET,
+    ownerWorkspaceId: "workspace-1",
     idempotencyStore: new InMemoryWorkspaceBridgeIdempotencyStore(),
     browserAuthPolicy: createBrowserBridgeAuthPolicy({
       getPrincipal: () => ({ userId: "user-1" }),
@@ -107,6 +110,55 @@ describe("workspaceBridgeHttpRoutes", () => {
     })
     expect(denied.statusCode).toBe(403)
     expect(denied.json()).toMatchObject({ ok: false, error: { code: WorkspaceBridgeErrorCode.CallerNotAllowed } })
+  })
+
+  it("rejects runtime tokens scoped to another workspace", async () => {
+    const app = await makeApp()
+    const token = mintWorkspaceBridgeRuntimeToken({
+      secret: SECRET,
+      workspaceId: "workspace-2",
+      capabilities: ["runtime:echo"],
+      ttlMs: 60_000,
+    })
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/workspace-bridge/call",
+      headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+      payload: { op: "runtime.v1.echo", input: {} },
+    })
+    expect(response.statusCode).toBe(403)
+    expect(response.json()).toMatchObject({ ok: false, error: { code: WorkspaceBridgeErrorCode.ResourceScopeDenied } })
+  })
+
+  it("re-mints scoped runtime tokens from sandbox refresh tokens", async () => {
+    const app = await makeApp()
+    const refreshToken = mintWorkspaceBridgeRuntimeRefreshToken({
+      secret: REFRESH_SECRET,
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      runtimeId: "runtime-1",
+      capabilities: ["runtime:echo"],
+      ttlMs: 60_000,
+      tokenTtlMs: 30_000,
+    })
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/workspace-bridge/token",
+      headers: { authorization: `Bearer ${refreshToken}` },
+      payload: {},
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.headers["cache-control"]).toBe("no-store")
+    const body = response.json()
+    expect(body).toMatchObject({ ok: true, token: expect.any(String) })
+    const verified = verifyWorkspaceBridgeRuntimeToken(body.token, { secret: SECRET, requiredCapabilities: ["runtime:echo"] })
+    expect(verified.authContext).toMatchObject({
+      callerClass: "runtime",
+      workspaceId: "workspace-1",
+      sessionId: "session-1",
+      capabilities: ["runtime:echo"],
+    })
   })
 
   it("rejects expired and missing-capability runtime tokens", async () => {

--- a/packages/workspace/src/server/workspaceBridge/__tests__/refreshIntegration.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/refreshIntegration.test.ts
@@ -1,0 +1,98 @@
+import Fastify from "fastify"
+import { describe, expect, it } from "vitest"
+import { WorkspaceBridgeClient } from "../../../bridge-client"
+import { WORKSPACE_BRIDGE_TOKEN_ENV } from "../../../shared/workspace-bridge-rpc"
+import { createBrowserBridgeAuthPolicy } from "../authPolicy"
+import { InMemoryWorkspaceBridgeIdempotencyStore } from "../idempotency"
+import { createWorkspaceBridgeRegistry } from "../registry"
+import { createWorkspaceBridgeRuntimeEnvContribution } from "../runtimeEnv"
+import { mintWorkspaceBridgeRuntimeToken } from "../runtimeToken"
+import { workspaceBridgeHttpRoutes } from "../httpRoutes"
+import { createTestBridgeOperationDefinition } from "../testing/harness"
+
+const SECRET = "workspace-bridge-runtime-token-secret-32bytes"
+const REFRESH_SECRET = "workspace-bridge-runtime-refresh-secret-32bytes"
+
+// Closes the producer->consumer seam: runtimeEnv injection (server) -> fromEnv
+// (SDK) -> auto-refresh-on-401 against the live /token route. The pieces are
+// each unit-tested with mocked fetch elsewhere; this locks them together.
+describe("WorkspaceBridgeClient.fromEnv auto-refresh against the live bridge routes", () => {
+  it("refreshes an expired call token via the runtimeEnv-injected refresh token and retries the call", async () => {
+    const registry = createWorkspaceBridgeRegistry({ ownerWorkspaceId: "workspace-1" })
+    registry.registerHandler(createTestBridgeOperationDefinition({
+      op: "runtime.v1.echo",
+      callerClassesAllowed: ["runtime"],
+      requiredCapabilities: ["runtime:echo"],
+      idempotencyPolicy: "none",
+    }), ({ input }) => input)
+
+    const app = Fastify()
+    await app.register(workspaceBridgeHttpRoutes, {
+      registry,
+      runtimeTokenSecret: SECRET,
+      runtimeRefreshTokenSecret: REFRESH_SECRET,
+      ownerWorkspaceId: "workspace-1",
+      idempotencyStore: new InMemoryWorkspaceBridgeIdempotencyStore(),
+      browserAuthPolicy: createBrowserBridgeAuthPolicy({
+        getPrincipal: () => ({ userId: "user-1" }),
+        authorizeWorkspace: () => ({ allowed: true, capabilities: ["runtime:echo"] }),
+      }),
+    })
+    await app.ready()
+
+    // Producer: build the runtime env exactly as the host injects it into a sandbox.
+    // A loopback http URL keeps the refresh token injectable (isRefreshTokenUrlSafe).
+    const contribution = createWorkspaceBridgeRuntimeEnvContribution({
+      workspaceId: "workspace-1",
+      runtimeMode: "local",
+      registry,
+      runtimeTokenSecret: SECRET,
+      runtimeRefreshTokenSecret: REFRESH_SECRET,
+      runtimeEnv: { bridgeUrl: "http://127.0.0.1/", capabilities: ["runtime:echo"] },
+    })
+    expect(contribution).toBeTruthy()
+    const env = await contribution!.getEnv({
+      workspaceId: "workspace-1",
+      workspaceRoot: "/tmp/workspace-1",
+      runtimeMode: "local",
+      runtimeBundle: {} as never,
+    }) as Record<string, string>
+    expect(env.BORING_WORKSPACE_BRIDGE_TOKEN_URL).toContain("/api/v1/workspace-bridge/token")
+    expect(env.BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN).toBeTruthy()
+
+    // Force the first /call to 401 so the client MUST exercise the refresh path.
+    env[WORKSPACE_BRIDGE_TOKEN_ENV] = mintWorkspaceBridgeRuntimeToken({
+      secret: SECRET,
+      workspaceId: "workspace-1",
+      capabilities: ["runtime:echo"],
+      ttlMs: 1_000,
+      nowMs: Date.now() - 60_000,
+    })
+
+    let tokenRoundTrips = 0
+    const injectFetch = (async (input: string | URL, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" ? input : input.toString())
+      if (url.pathname.endsWith("/workspace-bridge/token")) tokenRoundTrips += 1
+      const res = await app.inject({
+        method: (init?.method ?? "GET") as "GET" | "POST",
+        url: url.pathname + url.search,
+        headers: init?.headers as Record<string, string>,
+        payload: init?.body as string,
+      })
+      return {
+        status: res.statusCode,
+        ok: res.statusCode >= 200 && res.statusCode < 300,
+        statusText: "",
+        json: async () => res.json(),
+      } as unknown as Response
+    }) as unknown as typeof fetch
+
+    const client = WorkspaceBridgeClient.fromEnv(env, { fetch: injectFetch })
+    const result = await client.call<{ value: number }>("runtime.v1.echo", { value: 7 })
+
+    expect(result).toMatchObject({ value: 7 })
+    expect(tokenRoundTrips).toBe(1)
+
+    await app.close()
+  })
+})

--- a/packages/workspace/src/server/workspaceBridge/__tests__/refreshTokenStore.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/refreshTokenStore.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { InMemoryWorkspaceBridgeRuntimeRefreshTokenStore } from "../refreshTokenStore"
+
+describe("InMemoryWorkspaceBridgeRuntimeRefreshTokenStore", () => {
+  it("prunes expired rate-limit and revoked jti records", () => {
+    const nowMs = Date.now()
+    const store = new InMemoryWorkspaceBridgeRuntimeRefreshTokenStore()
+    expect(store.recordUse({
+      jti: "refresh-jti-1",
+      nowMs,
+      windowMs: 60_000,
+      maxUses: 1,
+      expiresAtMs: nowMs + 10_000,
+    })).toEqual({ allowed: true })
+    store.revoke("refresh-jti-2", nowMs + 10_000)
+
+    expect(store.recordUse({
+      jti: "refresh-jti-2",
+      nowMs,
+      windowMs: 60_000,
+      maxUses: 1,
+      expiresAtMs: nowMs + 10_000,
+    })).toEqual({ allowed: false, reason: "revoked" })
+    expect(store.gc(nowMs + 70_000)).toBe(2)
+    expect(store.recordUse({
+      jti: "refresh-jti-2",
+      nowMs: nowMs + 70_000,
+      windowMs: 60_000,
+      maxUses: 1,
+      expiresAtMs: nowMs + 130_000,
+    })).toEqual({ allowed: true })
+    expect(store.recordUse({
+      jti: "refresh-jti-1",
+      nowMs: nowMs + 70_000,
+      windowMs: 60_000,
+      maxUses: 1,
+      expiresAtMs: nowMs + 130_000,
+    })).toEqual({ allowed: true })
+  })
+
+  it("does not shorten custom rate-limit windows during GC", () => {
+    const nowMs = Date.now()
+    const store = new InMemoryWorkspaceBridgeRuntimeRefreshTokenStore()
+    expect(store.recordUse({
+      jti: "refresh-jti-long-window",
+      nowMs,
+      windowMs: 60 * 60_000,
+      maxUses: 1,
+      expiresAtMs: nowMs + 2 * 60 * 60_000,
+    })).toEqual({ allowed: true })
+
+    expect(store.gc(nowMs + 2 * 60_000)).toBe(0)
+    expect(store.recordUse({
+      jti: "refresh-jti-long-window",
+      nowMs: nowMs + 2 * 60_000,
+      windowMs: 60 * 60_000,
+      maxUses: 1,
+      expiresAtMs: nowMs + 2 * 60 * 60_000,
+    })).toEqual({ allowed: false, reason: "rate-limited", retryAfterMs: 58 * 60_000 })
+  })
+})

--- a/packages/workspace/src/server/workspaceBridge/__tests__/registry.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/registry.test.ts
@@ -103,6 +103,37 @@ describe("WorkspaceBridgeRegistry", () => {
     )).resolves.toMatchObject({ ok: false, error: { code: WorkspaceBridgeErrorCode.CapabilityDenied } })
   })
 
+  it("rejects calls from the wrong workspace unless the op explicitly opts into cross-workspace", async () => {
+    const registry = createWorkspaceBridgeRegistry({ ownerWorkspaceId: "workspace-b" })
+    registry.registerHandler(
+      createTestBridgeOperationDefinition({
+        op: "test.v1.tenant-scoped",
+        callerClassesAllowed: ["runtime"],
+        requiredCapabilities: ["test:read"],
+      }),
+      () => ({ ok: true }),
+    )
+    registry.registerHandler(
+      createTestBridgeOperationDefinition({
+        op: "test.v1.cross-workspace",
+        callerClassesAllowed: ["runtime"],
+        requiredCapabilities: ["test:read"],
+        allowCrossWorkspace: true,
+      }),
+      () => ({ ok: true }),
+    )
+
+    await expect(registry.call(
+      { op: "test.v1.tenant-scoped", input: {}, requestId: "req_wrong_workspace" },
+      createTestBridgeContext({ callerClass: "runtime", workspaceId: "workspace-a", capabilities: ["test:read"] }),
+    )).resolves.toMatchObject({ ok: false, error: { code: WorkspaceBridgeErrorCode.ResourceScopeDenied } })
+
+    await expect(registry.call(
+      { op: "test.v1.cross-workspace", input: {}, requestId: "req_cross_workspace" },
+      createTestBridgeContext({ callerClass: "runtime", workspaceId: "workspace-a", capabilities: ["test:read"] }),
+    )).resolves.toMatchObject({ ok: true })
+  })
+
   it("validates input/output schemas and input/output size limits", async () => {
     const registry = createWorkspaceBridgeRegistry()
     registry.registerHandler(

--- a/packages/workspace/src/server/workspaceBridge/__tests__/runtimeEnv.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/runtimeEnv.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import {
+  WORKSPACE_BRIDGE_DISABLED_ENV,
+  WORKSPACE_BRIDGE_TOKEN_ENV,
+  WORKSPACE_BRIDGE_URL_ENV,
+} from "../../../shared/workspace-bridge-rpc"
+import { createWorkspaceBridgeRegistry } from "../registry"
+import {
+  createWorkspaceBridgeRuntimeEnvContribution,
+  type WorkspaceBridgeRuntimePlacement,
+} from "../runtimeEnv"
+
+const SECRET = "workspace-bridge-runtime-token-secret-32bytes"
+
+function getEnvFor(options: {
+  bridgeUrl: string
+  bundle?: Record<string, unknown>
+  runtimePlacement?: WorkspaceBridgeRuntimePlacement
+}): Record<string, string> {
+  const contribution = createWorkspaceBridgeRuntimeEnvContribution({
+    workspaceId: "workspace-1",
+    runtimeMode: "local",
+    registry: createWorkspaceBridgeRegistry(),
+    runtimeTokenSecret: SECRET,
+    runtimeEnv: { bridgeUrl: options.bridgeUrl, capabilities: ["runtime:echo"] },
+    runtimePlacement: options.runtimePlacement,
+  })
+  expect(contribution).toBeTruthy()
+  return contribution!.getEnv({
+    workspaceId: "workspace-1",
+    workspaceRoot: "/tmp/workspace-1",
+    runtimeMode: "local",
+    runtimeBundle: options.bundle,
+  } as never) as Record<string, string>
+}
+
+describe("createWorkspaceBridgeRuntimeEnvContribution placement", () => {
+  // These exercise the PRODUCTION code path: ctx.runtimeBundle markers drive
+  // remoteness (provider-neutral, replacing the old runtimeMode==="vercel-sandbox").
+  it("treats a remote-workspace filesystem bundle as remote and refuses a plaintext non-loopback bridge URL", () => {
+    const env = getEnvFor({ bridgeUrl: "http://bridge.test/", bundle: { filesystem: { kind: "remote-workspace" } } })
+    expect(env[WORKSPACE_BRIDGE_DISABLED_ENV]).toBe("remote-bridge-url-must-be-https")
+    expect(env[WORKSPACE_BRIDGE_TOKEN_ENV]).toBeUndefined()
+  })
+
+  it("treats a remote bash bundle as remote and refuses a plaintext non-loopback bridge URL", () => {
+    const env = getEnvFor({ bridgeUrl: "http://bridge.test/", bundle: { bash: { kind: "remote" } } })
+    expect(env[WORKSPACE_BRIDGE_DISABLED_ENV]).toBe("remote-bridge-url-must-be-https")
+  })
+
+  it("injects a token for a local bundle over https", () => {
+    const env = getEnvFor({ bridgeUrl: "https://bridge.test/", bundle: {} })
+    expect(env[WORKSPACE_BRIDGE_DISABLED_ENV]).toBeUndefined()
+    expect(env[WORKSPACE_BRIDGE_URL_ENV]).toBe("https://bridge.test/api/v1/workspace-bridge/call")
+    expect(env[WORKSPACE_BRIDGE_TOKEN_ENV]).toBeTruthy()
+  })
+
+  it("lets a bundle remote marker override a 'local' runtimePlacement fallback", () => {
+    const env = getEnvFor({
+      bridgeUrl: "http://bridge.test/",
+      bundle: { filesystem: { kind: "remote-workspace" } },
+      runtimePlacement: "local",
+    })
+    expect(env[WORKSPACE_BRIDGE_DISABLED_ENV]).toBe("remote-bridge-url-must-be-https")
+  })
+
+  it("uses the runtimePlacement fallback only when the bundle carries no placement markers", () => {
+    const env = getEnvFor({ bridgeUrl: "http://bridge.test/", bundle: {}, runtimePlacement: "remote" })
+    expect(env[WORKSPACE_BRIDGE_DISABLED_ENV]).toBe("remote-bridge-url-must-be-https")
+  })
+})

--- a/packages/workspace/src/server/workspaceBridge/__tests__/runtimeToken.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/runtimeToken.test.ts
@@ -2,8 +2,13 @@ import { createHmac } from "node:crypto"
 import { describe, expect, it } from "vitest"
 import { WorkspaceBridgeErrorCode } from "../../../shared/workspace-bridge-rpc"
 import {
+  DEFAULT_WORKSPACE_BRIDGE_RUNTIME_REFRESH_TOKEN_TTL_MS,
+  MAX_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS,
+  WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE,
   WORKSPACE_BRIDGE_TOKEN_AUDIENCE,
+  mintWorkspaceBridgeRuntimeRefreshToken,
   mintWorkspaceBridgeRuntimeToken,
+  verifyWorkspaceBridgeRuntimeRefreshToken,
   verifyWorkspaceBridgeRuntimeToken,
 } from "../runtimeToken"
 import { assertNoSensitiveBridgeLeaks } from "../testing/harness"
@@ -76,6 +81,26 @@ describe("WorkspaceBridge runtime token primitives", () => {
       secret: SECRET,
       nowMs: NOW,
     })).toThrow(expect.objectContaining({ code: WorkspaceBridgeErrorCode.InvalidToken }))
+  })
+
+  it("mints refresh tokens with bounded defaults and call-token ttl claims", () => {
+    const refreshToken = mintWorkspaceBridgeRuntimeRefreshToken({
+      secret: SECRET,
+      workspaceId: "workspace-1",
+      capabilities: ["example:records.read"],
+      nowMs: NOW,
+      tokenTtlMs: 999 * 60_000,
+      jti: "refresh-jti",
+    })
+    const verified = verifyWorkspaceBridgeRuntimeRefreshToken(refreshToken, { secret: SECRET, nowMs: NOW + 1_000 })
+
+    expect(verified.claims).toMatchObject({
+      aud: WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE,
+      workspaceId: "workspace-1",
+      jti: "refresh-jti",
+      tokenTtlMs: MAX_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS,
+    })
+    expect((verified.claims.exp - verified.claims.iat) * 1000).toBe(DEFAULT_WORKSPACE_BRIDGE_RUNTIME_REFRESH_TOKEN_TTL_MS)
   })
 
   it("rejects missing capabilities", () => {

--- a/packages/workspace/src/server/workspaceBridge/authPolicy.ts
+++ b/packages/workspace/src/server/workspaceBridge/authPolicy.ts
@@ -141,11 +141,16 @@ export function createBrowserBridgeAuthPolicy(
   }
 }
 
+/**
+ * Dev/local CLI only. This policy performs no user authentication and grants
+ * the configured capabilities (defaulting to the op's own) to a fixed
+ * local-cli principal. Do not use it for exposed or production servers; pass a
+ * host-owned createBrowserBridgeAuthPolicy-style policy instead.
+ */
 export function createLocalCliBridgeAuthPolicy(
   options: LocalCliBridgeAuthPolicyOptions,
 ): BridgeAuthPolicy {
-  // Trusted local/dev only: no Better Auth / core DB. Grants the configured
-  // capabilities (defaulting to the op's own) to a fixed local-cli principal.
+  // Trusted local/dev only: no Better Auth / core DB.
   return {
     resolve(input) {
       if (input.callerClass !== "browser") {
@@ -155,6 +160,12 @@ export function createLocalCliBridgeAuthPolicy(
         )
       }
       ensureCallerAllowed(input.definition, "browser")
+      if (input.workspaceId !== options.workspaceId) {
+        throw createWorkspaceBridgeError(
+          WorkspaceBridgeErrorCode.ResourceScopeDenied,
+          "Local CLI bridge caller is not authorized for workspace",
+        )
+      }
       const capabilities = options.capabilities ?? input.definition.requiredCapabilities
       ensureCapabilities(capabilities, input.requiredCapabilities ?? input.definition.requiredCapabilities)
       const context = makeContext({

--- a/packages/workspace/src/server/workspaceBridge/httpRoutes.ts
+++ b/packages/workspace/src/server/workspaceBridge/httpRoutes.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 import {
   WorkspaceBridgeErrorCode,
   createWorkspaceBridgeError,
+  type BridgeAuthContext,
   type WorkspaceBridgeCallRequest,
   type WorkspaceBridgeCallResponse,
 } from "../../shared/workspace-bridge-rpc"
@@ -11,7 +12,11 @@ import type { WorkspaceBridgeIdempotencyStore } from "./idempotency"
 import { runWithWorkspaceBridgeIdempotency } from "./idempotency"
 import type { WorkspaceBridgeRegistry } from "./registry"
 import { measureJsonBytes } from "./json"
-import { verifyWorkspaceBridgeRuntimeToken } from "./runtimeToken"
+import {
+  mintWorkspaceBridgeRuntimeToken,
+  verifyWorkspaceBridgeRuntimeRefreshToken,
+  verifyWorkspaceBridgeRuntimeToken,
+} from "./runtimeToken"
 
 const bridgeCallBodySchema = z.object({
   op: z.string().min(1),
@@ -25,6 +30,9 @@ export interface WorkspaceBridgeHttpRoutesOptions {
   getRegistry?: (request: FastifyRequest, body: WorkspaceBridgeCallRequest) => WorkspaceBridgeRegistry | Promise<WorkspaceBridgeRegistry>
   browserAuthPolicy?: BridgeAuthPolicy
   runtimeTokenSecret?: string
+  runtimeRefreshTokenSecret?: string
+  ownerWorkspaceId?: string
+  getOwnerWorkspaceId?: (request: FastifyRequest, body: WorkspaceBridgeCallRequest, auth: BridgeAuthContext) => string | undefined | Promise<string | undefined>
   idempotencyStore?: WorkspaceBridgeIdempotencyStore
   getIdempotencyStore?: (request: FastifyRequest, body: WorkspaceBridgeCallRequest) => WorkspaceBridgeIdempotencyStore | undefined | Promise<WorkspaceBridgeIdempotencyStore | undefined>
   maxBodyBytes?: number
@@ -68,18 +76,53 @@ export function workspaceBridgeHttpRoutes(
       const idempotencyStore = opts.getIdempotencyStore
         ? await opts.getIdempotencyStore(request, body)
         : opts.idempotencyStore
+      const expectedWorkspaceId = opts.getOwnerWorkspaceId
+        ? await opts.getOwnerWorkspaceId(request, body, authContext)
+        : opts.ownerWorkspaceId
 
       const response = await runWithWorkspaceBridgeIdempotency(idempotencyStore, {
         definition,
         request: body,
         auth: authContext,
-      }, async () => await registry.call(body, authContext))
+      }, async () => await registry.call(body, authContext, { expectedWorkspaceId }))
       return await sendResponse(reply, response)
     } catch (err) {
       const bridgeError = isBridgeError(err)
         ? err
         : createWorkspaceBridgeError(WorkspaceBridgeErrorCode.HandlerFailed, "WorkspaceBridge transport failed")
       return sendBridgeError(reply, statusForBridgeError(bridgeError.code), body.requestId, bridgeError.code, bridgeError.message)
+    }
+  })
+
+  app.post("/api/v1/workspace-bridge/token", async (request, reply) => {
+    reply.header("Cache-Control", "no-store")
+
+    const authHeader = firstHeader(request.headers.authorization)
+    if (!authHeader?.startsWith("Bearer ")) {
+      return sendBridgeError(reply, 401, undefined, WorkspaceBridgeErrorCode.AuthRequired, "WorkspaceBridge refresh token is required")
+    }
+    if (!opts.runtimeTokenSecret || !opts.runtimeRefreshTokenSecret) {
+      return sendBridgeError(reply, 401, undefined, WorkspaceBridgeErrorCode.AuthRequired, "WorkspaceBridge token refresh is not configured")
+    }
+
+    try {
+      const verified = verifyWorkspaceBridgeRuntimeRefreshToken(authHeader.slice("Bearer ".length), {
+        secret: opts.runtimeRefreshTokenSecret,
+      })
+      const token = mintWorkspaceBridgeRuntimeToken({
+        secret: opts.runtimeTokenSecret,
+        workspaceId: verified.claims.workspaceId,
+        sessionId: verified.claims.sessionId,
+        runtimeId: verified.claims.runtimeId,
+        capabilities: verified.claims.capabilities,
+        ttlMs: verified.claims.tokenTtlMs,
+      })
+      return reply.code(200).send({ ok: true, token })
+    } catch (err) {
+      const bridgeError = isBridgeError(err)
+        ? err
+        : createWorkspaceBridgeError(WorkspaceBridgeErrorCode.InvalidToken, "WorkspaceBridge refresh token is invalid")
+      return sendBridgeError(reply, statusForBridgeError(bridgeError.code), undefined, bridgeError.code, bridgeError.message)
     }
   })
   done()

--- a/packages/workspace/src/server/workspaceBridge/httpRoutes.ts
+++ b/packages/workspace/src/server/workspaceBridge/httpRoutes.ts
@@ -13,10 +13,17 @@ import { runWithWorkspaceBridgeIdempotency } from "./idempotency"
 import type { WorkspaceBridgeRegistry } from "./registry"
 import { measureJsonBytes } from "./json"
 import {
+  DEFAULT_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS,
+  clampWorkspaceBridgeRuntimeTokenTtlMs,
   mintWorkspaceBridgeRuntimeToken,
   verifyWorkspaceBridgeRuntimeRefreshToken,
   verifyWorkspaceBridgeRuntimeToken,
+  type WorkspaceBridgeRuntimeRefreshTokenClaims,
 } from "./runtimeToken"
+import {
+  InMemoryWorkspaceBridgeRuntimeRefreshTokenStore,
+  type WorkspaceBridgeRuntimeRefreshTokenStore,
+} from "./refreshTokenStore"
 
 const bridgeCallBodySchema = z.object({
   op: z.string().min(1),
@@ -31,6 +38,9 @@ export interface WorkspaceBridgeHttpRoutesOptions {
   browserAuthPolicy?: BridgeAuthPolicy
   runtimeTokenSecret?: string
   runtimeRefreshTokenSecret?: string
+  runtimeRefreshTokenStore?: WorkspaceBridgeRuntimeRefreshTokenStore
+  getRuntimeRefreshTokenStore?: (request: FastifyRequest, claims: WorkspaceBridgeRuntimeRefreshTokenClaims) => WorkspaceBridgeRuntimeRefreshTokenStore | undefined | Promise<WorkspaceBridgeRuntimeRefreshTokenStore | undefined>
+  refreshTokenRateLimit?: { maxUses?: number; windowMs?: number }
   ownerWorkspaceId?: string
   getOwnerWorkspaceId?: (request: FastifyRequest, body: WorkspaceBridgeCallRequest, auth: BridgeAuthContext) => string | undefined | Promise<string | undefined>
   idempotencyStore?: WorkspaceBridgeIdempotencyStore
@@ -38,11 +48,15 @@ export interface WorkspaceBridgeHttpRoutesOptions {
   maxBodyBytes?: number
 }
 
+const DEFAULT_REFRESH_TOKEN_RATE_LIMIT_MAX_USES = 30
+const DEFAULT_REFRESH_TOKEN_RATE_LIMIT_WINDOW_MS = 60_000
+
 export function workspaceBridgeHttpRoutes(
   app: FastifyInstance,
   opts: WorkspaceBridgeHttpRoutesOptions,
   done: (err?: Error) => void,
 ): void {
+  const defaultRefreshTokenStore = opts.runtimeRefreshTokenStore ?? new InMemoryWorkspaceBridgeRuntimeRefreshTokenStore()
   app.post("/api/v1/workspace-bridge/call", async (request, reply) => {
     reply.header("Cache-Control", "no-store")
 
@@ -106,16 +120,39 @@ export function workspaceBridgeHttpRoutes(
     }
 
     try {
+      const nowMs = Date.now()
       const verified = verifyWorkspaceBridgeRuntimeRefreshToken(authHeader.slice("Bearer ".length), {
         secret: opts.runtimeRefreshTokenSecret,
+        nowMs,
       })
+      const store = opts.getRuntimeRefreshTokenStore
+        ? await opts.getRuntimeRefreshTokenStore(request, verified.claims) ?? defaultRefreshTokenStore
+        : defaultRefreshTokenStore
+      const refreshUse = await store.recordUse({
+        jti: verified.claims.jti,
+        nowMs,
+        maxUses: opts.refreshTokenRateLimit?.maxUses ?? DEFAULT_REFRESH_TOKEN_RATE_LIMIT_MAX_USES,
+        windowMs: opts.refreshTokenRateLimit?.windowMs ?? DEFAULT_REFRESH_TOKEN_RATE_LIMIT_WINDOW_MS,
+        expiresAtMs: verified.claims.exp * 1000,
+      })
+      if (!refreshUse.allowed) {
+        if (refreshUse.reason === "revoked") {
+          return sendBridgeError(reply, 401, undefined, WorkspaceBridgeErrorCode.InvalidToken, "WorkspaceBridge refresh token is revoked")
+        }
+        reply.header("Retry-After", Math.ceil(refreshUse.retryAfterMs / 1000).toString())
+        return sendBridgeError(reply, 429, undefined, WorkspaceBridgeErrorCode.RateLimited, "WorkspaceBridge refresh token rate limit exceeded")
+      }
+      const ttlMs = refreshMintTtlMs(verified.claims, Date.now())
+      if (ttlMs === undefined) {
+        return sendBridgeError(reply, 401, undefined, WorkspaceBridgeErrorCode.ExpiredToken, "Runtime bridge refresh token has expired")
+      }
       const token = mintWorkspaceBridgeRuntimeToken({
         secret: opts.runtimeTokenSecret,
         workspaceId: verified.claims.workspaceId,
         sessionId: verified.claims.sessionId,
         runtimeId: verified.claims.runtimeId,
         capabilities: verified.claims.capabilities,
-        ttlMs: verified.claims.tokenTtlMs,
+        ttlMs,
       })
       return reply.code(200).send({ ok: true, token })
     } catch (err) {
@@ -179,6 +216,13 @@ async function sendResponse<T>(reply: FastifyReply, response: WorkspaceBridgeCal
   return reply.code(response.ok ? 200 : statusForBridgeError(response.error.code)).send(response)
 }
 
+function refreshMintTtlMs(claims: WorkspaceBridgeRuntimeRefreshTokenClaims, nowMs: number): number | undefined {
+  const requested = clampWorkspaceBridgeRuntimeTokenTtlMs(claims.tokenTtlMs) ?? DEFAULT_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS
+  const remaining = claims.exp * 1000 - nowMs
+  if (remaining <= 0) return undefined
+  return Math.min(requested, remaining)
+}
+
 function sendBridgeError(
   reply: FastifyReply,
   status: number,
@@ -192,6 +236,7 @@ function sendBridgeError(
 
 function statusForBridgeError(code: WorkspaceBridgeErrorCode): number {
   if (code === WorkspaceBridgeErrorCode.AuthRequired || code === WorkspaceBridgeErrorCode.InvalidToken || code === WorkspaceBridgeErrorCode.ExpiredToken) return 401
+  if (code === WorkspaceBridgeErrorCode.RateLimited) return 429
   if (code === WorkspaceBridgeErrorCode.CallerNotAllowed || code === WorkspaceBridgeErrorCode.CapabilityDenied || code === WorkspaceBridgeErrorCode.ResourceScopeDenied) return 403
   if (code === WorkspaceBridgeErrorCode.OpNotFound) return 404
   if (code === WorkspaceBridgeErrorCode.InputTooLarge || code === WorkspaceBridgeErrorCode.OutputTooLarge) return 413

--- a/packages/workspace/src/server/workspaceBridge/refreshTokenStore.ts
+++ b/packages/workspace/src/server/workspaceBridge/refreshTokenStore.ts
@@ -1,0 +1,85 @@
+export interface WorkspaceBridgeRuntimeRefreshTokenUseOptions {
+  jti: string
+  nowMs?: number
+  windowMs: number
+  maxUses: number
+  /** Expiry time for the refresh token that owns this jti. Used for bounded in-memory GC. */
+  expiresAtMs?: number
+}
+
+export type WorkspaceBridgeRuntimeRefreshTokenUseResult =
+  | { allowed: true }
+  | { allowed: false; reason: "revoked" }
+  | { allowed: false; reason: "rate-limited"; retryAfterMs: number }
+
+export interface WorkspaceBridgeRuntimeRefreshTokenStore {
+  revoke(jti: string, expiresAtMs?: number): void | Promise<void>
+  recordUse(options: WorkspaceBridgeRuntimeRefreshTokenUseOptions): WorkspaceBridgeRuntimeRefreshTokenUseResult | Promise<WorkspaceBridgeRuntimeRefreshTokenUseResult>
+}
+
+interface RateLimitRecord {
+  windowStartMs: number
+  windowMs: number
+  count: number
+  expiresAtMs?: number
+}
+
+export class InMemoryWorkspaceBridgeRuntimeRefreshTokenStore implements WorkspaceBridgeRuntimeRefreshTokenStore {
+  private readonly revoked = new Map<string, number | undefined>()
+  private readonly rateLimits = new Map<string, RateLimitRecord>()
+  private lastGcMs = 0
+
+  revoke(jti: string, expiresAtMs?: number): void {
+    this.gc()
+    this.revoked.set(jti, expiresAtMs)
+    this.rateLimits.delete(jti)
+  }
+
+  recordUse(options: WorkspaceBridgeRuntimeRefreshTokenUseOptions): WorkspaceBridgeRuntimeRefreshTokenUseResult {
+    const nowMs = options.nowMs ?? Date.now()
+    this.gc(nowMs)
+    if (this.revoked.has(options.jti)) return { allowed: false, reason: "revoked" }
+    if (options.maxUses <= 0) return { allowed: false, reason: "rate-limited", retryAfterMs: options.windowMs }
+
+    const existing = this.rateLimits.get(options.jti)
+    if (!existing || nowMs - existing.windowStartMs >= existing.windowMs || isExpired(existing.expiresAtMs, nowMs)) {
+      this.rateLimits.set(options.jti, {
+        windowStartMs: nowMs,
+        windowMs: options.windowMs,
+        count: 1,
+        expiresAtMs: options.expiresAtMs,
+      })
+      return { allowed: true }
+    }
+    if (existing.count >= options.maxUses) {
+      return { allowed: false, reason: "rate-limited", retryAfterMs: Math.max(0, existing.windowStartMs + existing.windowMs - nowMs) }
+    }
+    existing.count += 1
+    existing.windowMs = options.windowMs
+    existing.expiresAtMs = options.expiresAtMs ?? existing.expiresAtMs
+    return { allowed: true }
+  }
+
+  gc(nowMs = Date.now()): number {
+    if (nowMs - this.lastGcMs < 60_000) return 0
+    this.lastGcMs = nowMs
+    let removed = 0
+    for (const [jti, record] of this.rateLimits) {
+      if (isExpired(record.expiresAtMs, nowMs) || nowMs - record.windowStartMs >= record.windowMs) {
+        this.rateLimits.delete(jti)
+        removed += 1
+      }
+    }
+    for (const [jti, expiresAtMs] of this.revoked) {
+      if (isExpired(expiresAtMs, nowMs)) {
+        this.revoked.delete(jti)
+        removed += 1
+      }
+    }
+    return removed
+  }
+}
+
+function isExpired(expiresAtMs: number | undefined, nowMs: number): boolean {
+  return expiresAtMs !== undefined && expiresAtMs <= nowMs
+}

--- a/packages/workspace/src/server/workspaceBridge/registry.ts
+++ b/packages/workspace/src/server/workspaceBridge/registry.ts
@@ -43,6 +43,13 @@ export interface WorkspaceBridgeRegistryLogger {
 
 export interface WorkspaceBridgeRegistryOptions {
   logger?: WorkspaceBridgeRegistryLogger
+  /** Workspace that owns this registry instance. Calls from other workspace ids are rejected unless the op opts into allowCrossWorkspace. */
+  ownerWorkspaceId?: string
+}
+
+export interface WorkspaceBridgeRegistryCallOptions {
+  /** Per-call owner override for hosts that reuse a registry across workspaces. */
+  expectedWorkspaceId?: string
 }
 
 interface RegisteredOperation {
@@ -84,6 +91,9 @@ export function validateWorkspaceBridgeOperationDefinition(
   }
   if (!Array.isArray(definition.requiredCapabilities)) {
     throw invalidDefinition(`WorkspaceBridge operation ${definition.op} requiredCapabilities must be an array`)
+  }
+  if (definition.allowCrossWorkspace !== undefined && typeof definition.allowCrossWorkspace !== "boolean") {
+    throw invalidDefinition(`WorkspaceBridge operation ${definition.op} allowCrossWorkspace must be a boolean when provided`)
   }
   for (const capability of definition.requiredCapabilities) {
     if (typeof capability !== "string" || capability.trim().length === 0) {
@@ -214,9 +224,14 @@ interface SchemaResult {
 export class WorkspaceBridgeRegistry {
   private readonly handlers = new Map<string, RegisteredOperation>()
   private readonly logger?: WorkspaceBridgeRegistryLogger
+  private readonly ownerWorkspaceId?: string
 
   constructor(options: WorkspaceBridgeRegistryOptions = {}) {
+    if (options.ownerWorkspaceId !== undefined && options.ownerWorkspaceId.trim().length === 0) {
+      throw createWorkspaceBridgeError(WorkspaceBridgeErrorCode.InvalidRequest, "WorkspaceBridge registry ownerWorkspaceId must be non-empty when provided")
+    }
     this.logger = options.logger
+    this.ownerWorkspaceId = options.ownerWorkspaceId
   }
 
   registerHandler<TInput, TOutput>(
@@ -249,6 +264,7 @@ export class WorkspaceBridgeRegistry {
   async call<TInput = unknown, TOutput = unknown>(
     request: WorkspaceBridgeCallRequest<TInput>,
     context: WorkspaceBridgeCallContext,
+    options: WorkspaceBridgeRegistryCallOptions = {},
   ): Promise<WorkspaceBridgeCallResponse<TOutput>> {
     const requestId = request.requestId ?? context.requestId ?? createRequestId()
     const registered = this.handlers.get(request.op)
@@ -271,6 +287,14 @@ export class WorkspaceBridgeRegistry {
 
     if (!definition.callerClassesAllowed.includes(context.callerClass)) {
       return this.failure(request.op, requestId, WorkspaceBridgeErrorCode.CallerNotAllowed, "Caller class is not allowed for operation", logBase)
+    }
+
+    const expectedWorkspaceId = options.expectedWorkspaceId ?? this.ownerWorkspaceId
+    if (expectedWorkspaceId && context.workspaceId !== expectedWorkspaceId && definition.allowCrossWorkspace !== true) {
+      return this.failure(request.op, requestId, WorkspaceBridgeErrorCode.ResourceScopeDenied, "Caller workspace is not authorized for this bridge registry", {
+        ...logBase,
+        expectedWorkspaceId,
+      })
     }
 
     const missingCapability = definition.requiredCapabilities.find((capability) => !context.capabilities.includes(capability))

--- a/packages/workspace/src/server/workspaceBridge/runtimeCore.ts
+++ b/packages/workspace/src/server/workspaceBridge/runtimeCore.ts
@@ -6,6 +6,8 @@ export interface WorkspaceBridgeRuntimeCoreOptions {
   registry?: WorkspaceBridgeRegistry
   /** Host/app/internal plugin bridge handlers to register at boot. */
   handlers?: ReadonlyArray<{ definition: WorkspaceBridgeOperationDefinition; handler: WorkspaceBridgeHandler }>
+  /** Workspace that owns a newly-created registry. Ignored when registry is provided. */
+  ownerWorkspaceId?: string
 }
 
 export interface WorkspaceBridgeRuntimeCore {
@@ -20,7 +22,7 @@ export interface WorkspaceBridgeRuntimeCore {
 export function createWorkspaceBridgeRuntimeCore(
   options: WorkspaceBridgeRuntimeCoreOptions = {},
 ): WorkspaceBridgeRuntimeCore {
-  const registry = options.registry ?? createWorkspaceBridgeRegistry()
+  const registry = options.registry ?? createWorkspaceBridgeRegistry({ ownerWorkspaceId: options.ownerWorkspaceId })
   for (const entry of options.handlers ?? []) {
     registry.registerHandler(entry.definition, entry.handler)
   }

--- a/packages/workspace/src/server/workspaceBridge/runtimeEnv.ts
+++ b/packages/workspace/src/server/workspaceBridge/runtimeEnv.ts
@@ -1,4 +1,4 @@
-import type { RuntimeEnvContribution, RuntimeModeId } from "@hachej/boring-agent/server"
+import type { RuntimeBundle, RuntimeEnvContribution, RuntimeEnvContributionContext, RuntimeModeId } from "@hachej/boring-agent/server"
 import type { WorkspaceBridgeRegistry } from "./registry"
 import { mintWorkspaceBridgeRuntimeRefreshToken, mintWorkspaceBridgeRuntimeToken } from "./runtimeToken"
 
@@ -34,6 +34,8 @@ export interface WorkspaceBridgeRuntimeEnvOptions {
   sessionId?: string
 }
 
+export type WorkspaceBridgeRuntimePlacement = "local" | "remote"
+
 export interface CreateWorkspaceBridgeRuntimeEnvContributionOptions {
   workspaceId: string
   runtimeMode: RuntimeModeId
@@ -41,6 +43,8 @@ export interface CreateWorkspaceBridgeRuntimeEnvContributionOptions {
   runtimeTokenSecret?: string
   runtimeRefreshTokenSecret?: string
   runtimeEnv?: WorkspaceBridgeRuntimeEnvOptions
+  /** Provider-neutral fallback used when getEnv is called without a RuntimeEnvContributionContext (mostly tests). */
+  runtimePlacement?: WorkspaceBridgeRuntimePlacement
 }
 
 export function createWorkspaceBridgeRuntimeEnvContribution(
@@ -52,17 +56,18 @@ export function createWorkspaceBridgeRuntimeEnvContribution(
   const bridgeUrl = resolveBridgeCallUrl(options.runtimeEnv?.bridgeUrl)
   const tokenUrl = resolveBridgeTokenUrl(options.runtimeEnv?.bridgeUrl)
   const capabilities = options.runtimeEnv?.capabilities
-  const disabledReason = validateRuntimeBridgeUrl({
-    bridgeUrl,
-    runtimeMode: options.runtimeMode,
-    allowInsecureHttp: options.runtimeEnv?.allowInsecureHttp,
-    hasRuntimeTokenSecret: Boolean(options.runtimeTokenSecret),
-    hasCapabilities: Array.isArray(capabilities) && capabilities.length > 0,
-  })
 
   return {
     id: "workspace-bridge-runtime-env",
-    getEnv: (): Record<string, string> => {
+    getEnv: (ctx?: RuntimeEnvContributionContext): Record<string, string> => {
+      const runtimePlacement = resolveRuntimePlacement(ctx?.runtimeBundle, options.runtimePlacement)
+      const disabledReason = validateRuntimeBridgeUrl({
+        bridgeUrl,
+        runtimePlacement,
+        allowInsecureHttp: options.runtimeEnv?.allowInsecureHttp,
+        hasRuntimeTokenSecret: Boolean(options.runtimeTokenSecret),
+        hasCapabilities: Array.isArray(capabilities) && capabilities.length > 0,
+      })
       if (disabledReason) {
         return { BORING_WORKSPACE_BRIDGE_DISABLED: disabledReason }
       }
@@ -133,9 +138,17 @@ function isLoopbackHost(hostname: string): boolean {
   return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]"
 }
 
+function resolveRuntimePlacement(
+  runtimeBundle: RuntimeBundle | undefined,
+  fallback: WorkspaceBridgeRuntimePlacement | undefined,
+): WorkspaceBridgeRuntimePlacement {
+  if (runtimeBundle?.filesystem?.kind === "remote-workspace" || runtimeBundle?.bash?.kind === "remote") return "remote"
+  return fallback ?? "local"
+}
+
 function validateRuntimeBridgeUrl(options: {
   bridgeUrl: string | undefined
-  runtimeMode: RuntimeModeId
+  runtimePlacement: WorkspaceBridgeRuntimePlacement
   allowInsecureHttp?: boolean
   hasRuntimeTokenSecret: boolean
   hasCapabilities: boolean
@@ -149,7 +162,7 @@ function validateRuntimeBridgeUrl(options: {
   } catch {
     return "bridge-url-invalid"
   }
-  const isRemote = options.runtimeMode === "vercel-sandbox"
+  const isRemote = options.runtimePlacement === "remote"
   const isLocalhost = isLoopbackHost(url.hostname)
   if (isRemote && url.protocol !== "https:") return "remote-bridge-url-must-be-https"
   if (isRemote && isLocalhost) return "remote-bridge-url-must-not-be-localhost"

--- a/packages/workspace/src/server/workspaceBridge/runtimeEnv.ts
+++ b/packages/workspace/src/server/workspaceBridge/runtimeEnv.ts
@@ -1,4 +1,11 @@
 import type { RuntimeBundle, RuntimeEnvContribution, RuntimeEnvContributionContext, RuntimeModeId } from "@hachej/boring-agent/server"
+import {
+  WORKSPACE_BRIDGE_DISABLED_ENV,
+  WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV,
+  WORKSPACE_BRIDGE_TOKEN_ENV,
+  WORKSPACE_BRIDGE_TOKEN_URL_ENV,
+  WORKSPACE_BRIDGE_URL_ENV,
+} from "../../shared/workspace-bridge-rpc"
 import type { WorkspaceBridgeRegistry } from "./registry"
 import { mintWorkspaceBridgeRuntimeRefreshToken, mintWorkspaceBridgeRuntimeToken } from "./runtimeToken"
 
@@ -69,7 +76,7 @@ export function createWorkspaceBridgeRuntimeEnvContribution(
         hasCapabilities: Array.isArray(capabilities) && capabilities.length > 0,
       })
       if (disabledReason) {
-        return { BORING_WORKSPACE_BRIDGE_DISABLED: disabledReason }
+        return { [WORKSPACE_BRIDGE_DISABLED_ENV]: disabledReason }
       }
       const token = mintWorkspaceBridgeRuntimeToken({
         secret: options.runtimeTokenSecret!,
@@ -91,11 +98,11 @@ export function createWorkspaceBridgeRuntimeEnvContribution(
           })
         : undefined
       return {
-        BORING_WORKSPACE_BRIDGE_URL: bridgeUrl!,
-        BORING_WORKSPACE_BRIDGE_TOKEN: token,
+        [WORKSPACE_BRIDGE_URL_ENV]: bridgeUrl!,
+        [WORKSPACE_BRIDGE_TOKEN_ENV]: token,
         ...(refreshToken ? {
-          BORING_WORKSPACE_BRIDGE_TOKEN_URL: tokenUrl!,
-          BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN: refreshToken,
+          [WORKSPACE_BRIDGE_TOKEN_URL_ENV]: tokenUrl!,
+          [WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV]: refreshToken,
         } : {}),
         BORING_WORKSPACE_ID: options.workspaceId,
         BORING_AGENT_SESSION_ID: options.runtimeEnv?.sessionId ?? options.workspaceId,

--- a/packages/workspace/src/server/workspaceBridge/runtimeEnv.ts
+++ b/packages/workspace/src/server/workspaceBridge/runtimeEnv.ts
@@ -1,8 +1,9 @@
 import type { RuntimeEnvContribution, RuntimeModeId } from "@hachej/boring-agent/server"
 import type { WorkspaceBridgeRegistry } from "./registry"
-import { mintWorkspaceBridgeRuntimeToken } from "./runtimeToken"
+import { mintWorkspaceBridgeRuntimeRefreshToken, mintWorkspaceBridgeRuntimeToken } from "./runtimeToken"
 
 const BRIDGE_CALL_PATH = "/api/v1/workspace-bridge/call"
+const BRIDGE_TOKEN_PATH = "/api/v1/workspace-bridge/token"
 
 export type WorkspaceBridgeRuntimeEnvDisabledReason =
   | "bridge-url-missing"
@@ -25,8 +26,10 @@ export interface WorkspaceBridgeRuntimeEnvOptions {
    * operation handlers must still enforce their own domain/resource scope.
    */
   capabilities?: readonly string[]
-  /** Runtime token TTL. Defaults to the token primitive default. */
+  /** Runtime call-token TTL. Defaults to the token primitive default. */
   tokenTtlMs?: number
+  /** Runtime refresh-token TTL. Defaults to the token primitive default. */
+  refreshTokenTtlMs?: number
   /** Optional audit/session claim. */
   sessionId?: string
 }
@@ -36,6 +39,7 @@ export interface CreateWorkspaceBridgeRuntimeEnvContributionOptions {
   runtimeMode: RuntimeModeId
   registry: WorkspaceBridgeRegistry
   runtimeTokenSecret?: string
+  runtimeRefreshTokenSecret?: string
   runtimeEnv?: WorkspaceBridgeRuntimeEnvOptions
 }
 
@@ -46,6 +50,7 @@ export function createWorkspaceBridgeRuntimeEnvContribution(
   if (!enabled) return undefined
 
   const bridgeUrl = resolveBridgeCallUrl(options.runtimeEnv?.bridgeUrl)
+  const tokenUrl = resolveBridgeTokenUrl(options.runtimeEnv?.bridgeUrl)
   const capabilities = options.runtimeEnv?.capabilities
   const disabledReason = validateRuntimeBridgeUrl({
     bridgeUrl,
@@ -69,9 +74,24 @@ export function createWorkspaceBridgeRuntimeEnvContribution(
         capabilities: capabilities!,
         ttlMs: options.runtimeEnv?.tokenTtlMs,
       })
+      const refreshToken = options.runtimeRefreshTokenSecret && tokenUrl
+        ? mintWorkspaceBridgeRuntimeRefreshToken({
+            secret: options.runtimeRefreshTokenSecret,
+            workspaceId: options.workspaceId,
+            sessionId: options.runtimeEnv?.sessionId,
+            runtimeId: options.runtimeMode,
+            capabilities: capabilities!,
+            ttlMs: options.runtimeEnv?.refreshTokenTtlMs,
+            tokenTtlMs: options.runtimeEnv?.tokenTtlMs,
+          })
+        : undefined
       return {
         BORING_WORKSPACE_BRIDGE_URL: bridgeUrl!,
         BORING_WORKSPACE_BRIDGE_TOKEN: token,
+        ...(refreshToken ? {
+          BORING_WORKSPACE_BRIDGE_TOKEN_URL: tokenUrl!,
+          BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN: refreshToken,
+        } : {}),
         BORING_WORKSPACE_ID: options.workspaceId,
         BORING_AGENT_SESSION_ID: options.runtimeEnv?.sessionId ?? options.workspaceId,
       }
@@ -80,11 +100,19 @@ export function createWorkspaceBridgeRuntimeEnvContribution(
 }
 
 export function resolveBridgeCallUrl(value: string | undefined): string | undefined {
+  return resolveBridgeUrl(value, BRIDGE_CALL_PATH)
+}
+
+export function resolveBridgeTokenUrl(value: string | undefined): string | undefined {
+  return resolveBridgeUrl(value, BRIDGE_TOKEN_PATH)
+}
+
+function resolveBridgeUrl(value: string | undefined, path: string): string | undefined {
   if (!value?.trim()) return undefined
   try {
     const url = new URL(value)
-    if (url.pathname === "" || url.pathname === "/") {
-      url.pathname = BRIDGE_CALL_PATH
+    if (url.pathname === "" || url.pathname === "/" || url.pathname === BRIDGE_CALL_PATH || url.pathname === BRIDGE_TOKEN_PATH) {
+      url.pathname = path
     }
     return url.toString()
   } catch {

--- a/packages/workspace/src/server/workspaceBridge/runtimeEnv.ts
+++ b/packages/workspace/src/server/workspaceBridge/runtimeEnv.ts
@@ -74,7 +74,7 @@ export function createWorkspaceBridgeRuntimeEnvContribution(
         capabilities: capabilities!,
         ttlMs: options.runtimeEnv?.tokenTtlMs,
       })
-      const refreshToken = options.runtimeRefreshTokenSecret && tokenUrl
+      const refreshToken = options.runtimeRefreshTokenSecret && tokenUrl && isRefreshTokenUrlSafe(tokenUrl)
         ? mintWorkspaceBridgeRuntimeRefreshToken({
             secret: options.runtimeRefreshTokenSecret,
             workspaceId: options.workspaceId,
@@ -120,6 +120,19 @@ function resolveBridgeUrl(value: string | undefined, path: string): string | und
   }
 }
 
+function isRefreshTokenUrlSafe(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === "https:" || (url.protocol === "http:" && isLoopbackHost(url.hostname))
+  } catch {
+    return false
+  }
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1" || hostname === "[::1]"
+}
+
 function validateRuntimeBridgeUrl(options: {
   bridgeUrl: string | undefined
   runtimeMode: RuntimeModeId
@@ -137,7 +150,7 @@ function validateRuntimeBridgeUrl(options: {
     return "bridge-url-invalid"
   }
   const isRemote = options.runtimeMode === "vercel-sandbox"
-  const isLocalhost = url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "::1"
+  const isLocalhost = isLoopbackHost(url.hostname)
   if (isRemote && url.protocol !== "https:") return "remote-bridge-url-must-be-https"
   if (isRemote && isLocalhost) return "remote-bridge-url-must-not-be-localhost"
   if (url.protocol === "http:" && !options.allowInsecureHttp && !isLocalhost) return "remote-bridge-url-must-be-https"

--- a/packages/workspace/src/server/workspaceBridge/runtimeToken.ts
+++ b/packages/workspace/src/server/workspaceBridge/runtimeToken.ts
@@ -8,6 +8,9 @@ import {
 
 export const WORKSPACE_BRIDGE_TOKEN_AUDIENCE = "workspace-bridge"
 export const WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE = "workspace-bridge-refresh"
+export const DEFAULT_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS = 5 * 60_000
+export const DEFAULT_WORKSPACE_BRIDGE_RUNTIME_REFRESH_TOKEN_TTL_MS = 60 * 60_000
+export const MAX_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS = 15 * 60_000
 
 interface WorkspaceBridgeTokenClaimsBase {
   aud: string
@@ -73,7 +76,7 @@ export function mintWorkspaceBridgeRuntimeToken(
   return mintWorkspaceBridgeToken({
     ...options,
     audience: WORKSPACE_BRIDGE_TOKEN_AUDIENCE,
-    ttlMs: options.ttlMs ?? 5 * 60_000,
+    ttlMs: options.ttlMs ?? DEFAULT_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS,
   })
 }
 
@@ -85,8 +88,8 @@ export function mintWorkspaceBridgeRuntimeRefreshToken(
     audience: WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE,
     // Refresh tokens intentionally outlive short call tokens, but remain
     // sandbox-bound by workspace/session/runtime/capabilities claims.
-    ttlMs: options.ttlMs ?? 24 * 60 * 60_000,
-    tokenTtlMs: options.tokenTtlMs,
+    ttlMs: options.ttlMs ?? DEFAULT_WORKSPACE_BRIDGE_RUNTIME_REFRESH_TOKEN_TTL_MS,
+    tokenTtlMs: clampWorkspaceBridgeRuntimeTokenTtlMs(options.tokenTtlMs),
   })
 }
 
@@ -122,6 +125,12 @@ export function verifyWorkspaceBridgeRuntimeRefreshToken(
   const now = Math.floor((options.nowMs ?? Date.now()) / 1000)
   ensureLiveTokenClaims(claims, now, WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE, "Runtime bridge refresh token")
   return { claims: claims as WorkspaceBridgeRuntimeRefreshTokenClaims }
+}
+
+export function clampWorkspaceBridgeRuntimeTokenTtlMs(ttlMs: number | undefined): number | undefined {
+  if (ttlMs === undefined) return undefined
+  if (!Number.isFinite(ttlMs) || ttlMs <= 0) return undefined
+  return Math.min(ttlMs, MAX_WORKSPACE_BRIDGE_RUNTIME_TOKEN_TTL_MS)
 }
 
 export function runtimeClaimsToBridgeAuthContext(
@@ -244,7 +253,7 @@ function parseClaims(payload: unknown): WorkspaceBridgeTokenClaimsBase {
     iat: claims.iat,
     exp: claims.exp,
     jti: claims.jti,
-    ...(typeof claims.tokenTtlMs === "number" ? { tokenTtlMs: claims.tokenTtlMs } : {}),
+    ...(typeof claims.tokenTtlMs === "number" ? { tokenTtlMs: clampWorkspaceBridgeRuntimeTokenTtlMs(claims.tokenTtlMs) } : {}),
   }
 }
 

--- a/packages/workspace/src/server/workspaceBridge/runtimeToken.ts
+++ b/packages/workspace/src/server/workspaceBridge/runtimeToken.ts
@@ -7,9 +7,10 @@ import {
 } from "../../shared/workspace-bridge-rpc"
 
 export const WORKSPACE_BRIDGE_TOKEN_AUDIENCE = "workspace-bridge"
+export const WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE = "workspace-bridge-refresh"
 
-export interface WorkspaceBridgeRuntimeTokenClaims {
-  aud: typeof WORKSPACE_BRIDGE_TOKEN_AUDIENCE
+interface WorkspaceBridgeTokenClaimsBase {
+  aud: string
   workspaceId: string
   sessionId?: string
   runtimeId?: string
@@ -17,6 +18,17 @@ export interface WorkspaceBridgeRuntimeTokenClaims {
   iat: number
   exp: number
   jti: string
+  tokenTtlMs?: number
+}
+
+export interface WorkspaceBridgeRuntimeTokenClaims extends WorkspaceBridgeTokenClaimsBase {
+  aud: typeof WORKSPACE_BRIDGE_TOKEN_AUDIENCE
+}
+
+export interface WorkspaceBridgeRuntimeRefreshTokenClaims extends WorkspaceBridgeTokenClaimsBase {
+  aud: typeof WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE
+  /** Short-lived call-token TTL to use when this refresh token re-mints. */
+  tokenTtlMs?: number
 }
 
 export interface MintWorkspaceBridgeRuntimeTokenOptions {
@@ -30,10 +42,20 @@ export interface MintWorkspaceBridgeRuntimeTokenOptions {
   jti?: string
 }
 
+export interface MintWorkspaceBridgeRuntimeRefreshTokenOptions extends MintWorkspaceBridgeRuntimeTokenOptions {
+  /** Short-lived call-token TTL to use when this refresh token re-mints. */
+  tokenTtlMs?: number
+}
+
 export interface VerifyWorkspaceBridgeRuntimeTokenOptions {
   secret: string
   nowMs?: number
   requiredCapabilities?: readonly string[]
+}
+
+export interface VerifyWorkspaceBridgeRuntimeRefreshTokenOptions {
+  secret: string
+  nowMs?: number
 }
 
 export interface VerifiedWorkspaceBridgeRuntimeToken {
@@ -41,23 +63,31 @@ export interface VerifiedWorkspaceBridgeRuntimeToken {
   authContext: BridgeAuthContext
 }
 
+export interface VerifiedWorkspaceBridgeRuntimeRefreshToken {
+  claims: WorkspaceBridgeRuntimeRefreshTokenClaims
+}
+
 export function mintWorkspaceBridgeRuntimeToken(
   options: MintWorkspaceBridgeRuntimeTokenOptions,
 ): string {
-  assertUsableSecret(options.secret)
-  const nowMs = options.nowMs ?? Date.now()
-  const ttlMs = options.ttlMs ?? 5 * 60_000
-  const claims: WorkspaceBridgeRuntimeTokenClaims = {
-    aud: WORKSPACE_BRIDGE_TOKEN_AUDIENCE,
-    workspaceId: options.workspaceId,
-    sessionId: options.sessionId,
-    runtimeId: options.runtimeId,
-    capabilities: [...options.capabilities],
-    iat: Math.floor(nowMs / 1000),
-    exp: Math.floor((nowMs + ttlMs) / 1000),
-    jti: options.jti ?? randomUUID(),
-  }
-  return signClaims(claims, options.secret)
+  return mintWorkspaceBridgeToken({
+    ...options,
+    audience: WORKSPACE_BRIDGE_TOKEN_AUDIENCE,
+    ttlMs: options.ttlMs ?? 5 * 60_000,
+  })
+}
+
+export function mintWorkspaceBridgeRuntimeRefreshToken(
+  options: MintWorkspaceBridgeRuntimeRefreshTokenOptions,
+): string {
+  return mintWorkspaceBridgeToken({
+    ...options,
+    audience: WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE,
+    // Refresh tokens intentionally outlive short call tokens, but remain
+    // sandbox-bound by workspace/session/runtime/capabilities claims.
+    ttlMs: options.ttlMs ?? 24 * 60 * 60_000,
+    tokenTtlMs: options.tokenTtlMs,
+  })
 }
 
 export function verifyWorkspaceBridgeRuntimeToken(
@@ -67,15 +97,7 @@ export function verifyWorkspaceBridgeRuntimeToken(
   assertUsableSecret(options.secret)
   const claims = parseAndVerifyToken(token, options.secret)
   const now = Math.floor((options.nowMs ?? Date.now()) / 1000)
-  if (claims.aud !== WORKSPACE_BRIDGE_TOKEN_AUDIENCE) {
-    throw bridgeTokenError(WorkspaceBridgeErrorCode.InvalidToken, "Runtime bridge token has invalid audience")
-  }
-  if (claims.exp <= now) {
-    throw bridgeTokenError(WorkspaceBridgeErrorCode.ExpiredToken, "Runtime bridge token has expired")
-  }
-  if (claims.iat > now + 60) {
-    throw bridgeTokenError(WorkspaceBridgeErrorCode.InvalidToken, "Runtime bridge token is not valid yet")
-  }
+  ensureLiveTokenClaims(claims, now, WORKSPACE_BRIDGE_TOKEN_AUDIENCE, "Runtime bridge token")
 
   const missingCapability = (options.requiredCapabilities ?? []).find(
     (capability) => !claims.capabilities.includes(capability),
@@ -84,10 +106,22 @@ export function verifyWorkspaceBridgeRuntimeToken(
     throw bridgeTokenError(WorkspaceBridgeErrorCode.CapabilityDenied, "Runtime bridge token is missing a required capability")
   }
 
+  const runtimeClaims = claims as WorkspaceBridgeRuntimeTokenClaims
   return {
-    claims,
-    authContext: runtimeClaimsToBridgeAuthContext(claims),
+    claims: runtimeClaims,
+    authContext: runtimeClaimsToBridgeAuthContext(runtimeClaims),
   }
+}
+
+export function verifyWorkspaceBridgeRuntimeRefreshToken(
+  token: string,
+  options: VerifyWorkspaceBridgeRuntimeRefreshTokenOptions,
+): VerifiedWorkspaceBridgeRuntimeRefreshToken {
+  assertUsableSecret(options.secret)
+  const claims = parseAndVerifyToken(token, options.secret)
+  const now = Math.floor((options.nowMs ?? Date.now()) / 1000)
+  ensureLiveTokenClaims(claims, now, WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE, "Runtime bridge refresh token")
+  return { claims: claims as WorkspaceBridgeRuntimeRefreshTokenClaims }
 }
 
 export function runtimeClaimsToBridgeAuthContext(
@@ -111,7 +145,44 @@ export function runtimeClaimsToBridgeAuthContext(
   }
 }
 
-function signClaims(claims: WorkspaceBridgeRuntimeTokenClaims, secret: string): string {
+function mintWorkspaceBridgeToken(options: MintWorkspaceBridgeRuntimeTokenOptions & {
+  audience: typeof WORKSPACE_BRIDGE_TOKEN_AUDIENCE | typeof WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE
+  tokenTtlMs?: number
+}): string {
+  assertUsableSecret(options.secret)
+  const nowMs = options.nowMs ?? Date.now()
+  const claims: WorkspaceBridgeTokenClaimsBase = {
+    aud: options.audience,
+    workspaceId: options.workspaceId,
+    sessionId: options.sessionId,
+    runtimeId: options.runtimeId,
+    capabilities: [...options.capabilities],
+    iat: Math.floor(nowMs / 1000),
+    exp: Math.floor((nowMs + options.ttlMs!) / 1000),
+    jti: options.jti ?? randomUUID(),
+    ...(options.tokenTtlMs !== undefined ? { tokenTtlMs: options.tokenTtlMs } : {}),
+  }
+  return signClaims(claims, options.secret)
+}
+
+function ensureLiveTokenClaims(
+  claims: WorkspaceBridgeTokenClaimsBase,
+  now: number,
+  expectedAudience: typeof WORKSPACE_BRIDGE_TOKEN_AUDIENCE | typeof WORKSPACE_BRIDGE_REFRESH_TOKEN_AUDIENCE,
+  label: string,
+): void {
+  if (claims.aud !== expectedAudience) {
+    throw bridgeTokenError(WorkspaceBridgeErrorCode.InvalidToken, `${label} has invalid audience`)
+  }
+  if (claims.exp <= now) {
+    throw bridgeTokenError(WorkspaceBridgeErrorCode.ExpiredToken, `${label} has expired`)
+  }
+  if (claims.iat > now + 60) {
+    throw bridgeTokenError(WorkspaceBridgeErrorCode.InvalidToken, `${label} is not valid yet`)
+  }
+}
+
+function signClaims(claims: WorkspaceBridgeTokenClaimsBase, secret: string): string {
   const header = { alg: "HS256", typ: "JWT" }
   const encodedHeader = base64UrlEncode(JSON.stringify(header))
   const encodedPayload = base64UrlEncode(JSON.stringify(claims))
@@ -119,7 +190,7 @@ function signClaims(claims: WorkspaceBridgeRuntimeTokenClaims, secret: string): 
   return `${signingInput}.${hmac(signingInput, secret)}`
 }
 
-function parseAndVerifyToken(token: string, secret: string): WorkspaceBridgeRuntimeTokenClaims {
+function parseAndVerifyToken(token: string, secret: string): WorkspaceBridgeTokenClaimsBase {
   const parts = token.split(".")
   if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
     throw bridgeTokenError(WorkspaceBridgeErrorCode.InvalidToken, "Runtime bridge token is malformed")
@@ -145,7 +216,7 @@ function parseAndVerifyToken(token: string, secret: string): WorkspaceBridgeRunt
   return parseClaims(payload)
 }
 
-function parseClaims(payload: unknown): WorkspaceBridgeRuntimeTokenClaims {
+function parseClaims(payload: unknown): WorkspaceBridgeTokenClaimsBase {
   if (!payload || typeof payload !== "object") {
     throw bridgeTokenError(WorkspaceBridgeErrorCode.InvalidToken, "Runtime bridge token claims are invalid")
   }
@@ -161,8 +232,11 @@ function parseClaims(payload: unknown): WorkspaceBridgeRuntimeTokenClaims {
   ) {
     throw bridgeTokenError(WorkspaceBridgeErrorCode.InvalidToken, "Runtime bridge token claims are invalid")
   }
+  if (claims.tokenTtlMs !== undefined && (typeof claims.tokenTtlMs !== "number" || !Number.isFinite(claims.tokenTtlMs) || claims.tokenTtlMs <= 0)) {
+    throw bridgeTokenError(WorkspaceBridgeErrorCode.InvalidToken, "Runtime bridge token claims are invalid")
+  }
   return {
-    aud: claims.aud as typeof WORKSPACE_BRIDGE_TOKEN_AUDIENCE,
+    aud: claims.aud,
     workspaceId: claims.workspaceId,
     sessionId: optionalString(claims.sessionId),
     runtimeId: optionalString(claims.runtimeId),
@@ -170,6 +244,7 @@ function parseClaims(payload: unknown): WorkspaceBridgeRuntimeTokenClaims {
     iat: claims.iat,
     exp: claims.exp,
     jti: claims.jti,
+    ...(typeof claims.tokenTtlMs === "number" ? { tokenTtlMs: claims.tokenTtlMs } : {}),
   }
 }
 

--- a/packages/workspace/src/server/workspaceBridge/testing/harness.ts
+++ b/packages/workspace/src/server/workspaceBridge/testing/harness.ts
@@ -140,6 +140,7 @@ export function createTestBridgeOperationDefinition<TInput = unknown, TOutput = 
     owner: overrides.owner ?? "test",
     callerClassesAllowed: overrides.callerClassesAllowed ?? ["server"],
     requiredCapabilities: overrides.requiredCapabilities ?? [],
+    ...(overrides.allowCrossWorkspace !== undefined ? { allowCrossWorkspace: overrides.allowCrossWorkspace } : {}),
     inputSchema: overrides.inputSchema ?? { type: "object" },
     outputSchema: overrides.outputSchema ?? { type: "object" },
     timeoutMs: overrides.timeoutMs ?? 1_000,

--- a/packages/workspace/src/shared/workspace-bridge-rpc.ts
+++ b/packages/workspace/src/shared/workspace-bridge-rpc.ts
@@ -47,6 +47,13 @@ export interface WorkspaceBridgeOperationDefinition<
   owner: string
   callerClassesAllowed: readonly BridgeCallerClass[]
   requiredCapabilities: readonly string[]
+  /**
+   * Allow a caller authenticated for one workspace to invoke this operation on
+   * a registry owned by another workspace. Keep false/omitted for normal
+   * tenant-scoped operations; cross-workspace ops must perform their own
+   * explicit resource authorization.
+   */
+  allowCrossWorkspace?: boolean
   inputSchema: unknown
   outputSchema?: unknown
   timeoutMs: number

--- a/packages/workspace/src/shared/workspace-bridge-rpc.ts
+++ b/packages/workspace/src/shared/workspace-bridge-rpc.ts
@@ -5,6 +5,18 @@
  * Node-only types/imports and keep stable bridge error codes centralized here.
  */
 
+/**
+ * Canonical WorkspaceBridge runtime env var names. Defined in this browser- and
+ * server-safe module so the producer (server runtimeEnv injection) and the
+ * consumer (bridge-client SDK) share one source of truth and cannot drift on
+ * string equality.
+ */
+export const WORKSPACE_BRIDGE_URL_ENV = "BORING_WORKSPACE_BRIDGE_URL"
+export const WORKSPACE_BRIDGE_TOKEN_ENV = "BORING_WORKSPACE_BRIDGE_TOKEN"
+export const WORKSPACE_BRIDGE_TOKEN_URL_ENV = "BORING_WORKSPACE_BRIDGE_TOKEN_URL"
+export const WORKSPACE_BRIDGE_REFRESH_TOKEN_ENV = "BORING_WORKSPACE_BRIDGE_REFRESH_TOKEN"
+export const WORKSPACE_BRIDGE_DISABLED_ENV = "BORING_WORKSPACE_BRIDGE_DISABLED"
+
 export type BridgeCallerClass = "browser" | "runtime" | "server"
 
 export type BridgeActorKind = "human" | "agent" | "system" | "service"

--- a/packages/workspace/src/shared/workspace-bridge-rpc.ts
+++ b/packages/workspace/src/shared/workspace-bridge-rpc.ts
@@ -106,6 +106,7 @@ export enum WorkspaceBridgeErrorCode {
   IdempotencyRequired = "BRIDGE_IDEMPOTENCY_REQUIRED",
   IdempotencyConflict = "BRIDGE_IDEMPOTENCY_CONFLICT",
   ReplayRejected = "BRIDGE_REPLAY_REJECTED",
+  RateLimited = "BRIDGE_RATE_LIMITED",
   InvalidToken = "BRIDGE_INVALID_TOKEN",
   ExpiredToken = "BRIDGE_EXPIRED_TOKEN",
   InvalidRequest = "BRIDGE_INVALID_REQUEST",

--- a/packages/workspace/tsconfig.server.json
+++ b/packages/workspace/tsconfig.server.json
@@ -23,6 +23,7 @@
     "src/server/**/*",
     "src/app/server/**/*",
     "src/shared/**/*",
+    "src/bridge-client/index.ts",
     "src/plugins/**/server/**/*",
     "src/plugins/**/agent/**/*",
     "src/plugins/**/shared/**/*",

--- a/plugins/ask-user/src/server/__tests__/ask-user-tool.eval.test.ts
+++ b/plugins/ask-user/src/server/__tests__/ask-user-tool.eval.test.ts
@@ -1,11 +1,15 @@
 /**
  * Eval: a real model should choose the Workspace-owned ask_user tool when it
- * needs a missing blocking decision. This talks to OpenRouter with tool-calling
- * enabled, then executes the produced ask_user call against the real runtime.
+ * needs a missing blocking decision. This talks to an OpenAI-compatible chat
+ * completions API with tool-calling enabled, then executes the produced
+ * ask_user call against the real runtime.
  *
- * Gated on OPENROUTER_API_KEY — skipped silently in CI without it.
+ * Gated on OPENAI_API_KEY or OPENROUTER_API_KEY — skipped silently in CI without
+ * either. OpenAI (incl. codex / gpt-5 models) is preferred when its key is set.
  * Run manually:
- *   OPENROUTER_API_KEY=sk-or-v1-... ASK_USER_EVAL_MODEL=openai/gpt-5.5 pnpm --filter @hachej/boring-ask-user exec vitest run src/server/__tests__/ask-user-tool.eval.test.ts
+ *   OPENAI_API_KEY=sk-... pnpm --filter @hachej/boring-ask-user exec vitest run src/server/__tests__/ask-user-tool.eval.test.ts
+ *   OPENAI_API_KEY=sk-... ASK_USER_EVAL_MODEL=gpt-5.1-codex pnpm --filter @hachej/boring-ask-user exec vitest run src/server/__tests__/ask-user-tool.eval.test.ts
+ *   OPENROUTER_API_KEY=sk-or-v1-... ASK_USER_EVAL_MODEL=x-ai/grok-code-fast-1 pnpm --filter @hachej/boring-ask-user exec vitest run src/server/__tests__/ask-user-tool.eval.test.ts
  */
 import { describe, expect, test } from "vitest"
 import { mkdtemp } from "node:fs/promises"
@@ -13,10 +17,69 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { AskUserRuntime, createAskUserTool, FileAskUserStore } from "../index"
 
-const HAS_KEY = !!process.env.OPENROUTER_API_KEY
-const describeIf = HAS_KEY ? describe : describe.skip
+const HAS_OPENAI = !!process.env.OPENAI_API_KEY
+const HAS_GEMINI = !!process.env.GEMINI_API_KEY
+const HAS_OPENROUTER = !!process.env.OPENROUTER_API_KEY
+const describeIf = (HAS_OPENAI || HAS_GEMINI || HAS_OPENROUTER) ? describe : describe.skip
 const SESSION_ID = "eval-ask-user-session"
-const ASK_USER_EVAL_MODEL = process.env.ASK_USER_EVAL_MODEL ?? "x-ai/grok-code-fast-1"
+
+interface EvalProvider {
+  label: string
+  url: string
+  apiKey: string
+  model: string
+  headers: Record<string, string>
+  /** gpt-5 / codex / o-series take max_completion_tokens and only the default temperature. */
+  reasoning: boolean
+  /** Some OpenAI-compatible shims (Gemini) ignore a named-function force; "required" is honored. */
+  toolChoice: unknown
+  /** Output token budget; thinking models need headroom for reasoning + the call. */
+  maxTokens?: number
+}
+
+const NAMED_TOOL_CHOICE = { type: "function", function: { name: "ask_user" } }
+
+// Prefer OpenAI (incl. codex models) when its key is present, else OpenRouter.
+// Override the model with ASK_USER_EVAL_MODEL.
+function resolveEvalProvider(): EvalProvider {
+  if (HAS_OPENAI) {
+    const model = process.env.ASK_USER_EVAL_MODEL ?? "gpt-5.1-codex"
+    return {
+      label: `openai:${model}`,
+      url: "https://api.openai.com/v1/chat/completions",
+      apiKey: process.env.OPENAI_API_KEY!,
+      model,
+      headers: {},
+      reasoning: /^(gpt-5|o[134])/.test(model) || model.includes("codex"),
+      toolChoice: NAMED_TOOL_CHOICE,
+    }
+  }
+  if (HAS_GEMINI) {
+    // Gemini's OpenAI-compat shim honors tool_choice:"required" (not a named
+    // force) and 2.5-flash needs budget headroom for its thinking pass.
+    const model = process.env.ASK_USER_EVAL_MODEL ?? "gemini-2.5-flash"
+    return {
+      label: `gemini:${model}`,
+      url: "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
+      apiKey: process.env.GEMINI_API_KEY!,
+      model,
+      headers: {},
+      reasoning: false,
+      toolChoice: "required",
+      maxTokens: 2048,
+    }
+  }
+  const model = process.env.ASK_USER_EVAL_MODEL ?? "x-ai/grok-code-fast-1"
+  return {
+    label: `openrouter:${model}`,
+    url: "https://openrouter.ai/api/v1/chat/completions",
+    apiKey: process.env.OPENROUTER_API_KEY!,
+    model,
+    headers: { "http-referer": "https://localhost", "x-title": "boring-ui ask_user eval" },
+    reasoning: false,
+    toolChoice: NAMED_TOOL_CHOICE,
+  }
+}
 
 describeIf("ask-user eval (live LLM)", () => {
   test("real model calls ask_user for a required deployment-region decision", async () => {
@@ -24,7 +87,7 @@ describeIf("ask-user eval (live LLM)", () => {
     const store = new FileAskUserStore(join(dir, "questions.json"))
     const runtime = new AskUserRuntime({ store, ownerPrincipalId: "anonymous" })
     const tool = createAskUserTool({ runtime, sessionId: SESSION_ID })
-    const toolCall = await callOpenRouterWithAskUserTool(tool.parameters)
+    const toolCall = await callModelWithAskUserTool(tool.parameters)
     expect(toolCall.function.name).toBe("ask_user")
     const input = JSON.parse(toolCall.function.arguments || "{}") as Record<string, unknown>
     expect(JSON.stringify(input)).toMatch(/region/i)
@@ -45,20 +108,23 @@ type OpenRouterResponse = {
   choices: Array<{ message: { tool_calls?: OpenRouterToolCall[]; content?: string } }>
 }
 
-async function callOpenRouterWithAskUserTool(parameters: Record<string, unknown>): Promise<OpenRouterToolCall> {
-  const res = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+async function callModelWithAskUserTool(parameters: Record<string, unknown>): Promise<OpenRouterToolCall> {
+  const provider = resolveEvalProvider()
+  const tokenKey = provider.reasoning ? "max_completion_tokens" : "max_tokens"
+  const tokenBudget = { [tokenKey]: provider.maxTokens ?? (provider.reasoning ? 2000 : 300) }
+  const temperature = provider.reasoning ? {} : { temperature: 0 }
+  const res = await fetch(provider.url, {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      authorization: `Bearer ${process.env.OPENROUTER_API_KEY!}`,
-      "http-referer": "https://localhost",
-      "x-title": "boring-ui ask_user eval",
+      authorization: `Bearer ${provider.apiKey}`,
+      ...provider.headers,
     },
     body: JSON.stringify({
-      model: ASK_USER_EVAL_MODEL,
-      max_tokens: 300,
-      temperature: 0,
-      tool_choice: { type: "function", function: { name: "ask_user" } },
+      model: provider.model,
+      ...tokenBudget,
+      ...temperature,
+      tool_choice: provider.toolChoice,
       tools: [{
         type: "function",
         function: {
@@ -73,7 +139,7 @@ async function callOpenRouterWithAskUserTool(parameters: Record<string, unknown>
       ],
     }),
   })
-  if (!res.ok) throw new Error(`OpenRouter returned ${res.status}: ${await res.text()}`)
+  if (!res.ok) throw new Error(`${provider.label} returned ${res.status}: ${await res.text()}`)
   const json = await res.json() as OpenRouterResponse
   const toolCall = json.choices[0]?.message.tool_calls?.find((call) => call.function.name === "ask_user")
   if (!toolCall) throw new Error(`model did not call ask_user: ${JSON.stringify(json.choices[0]?.message)}`)


### PR DESCRIPTION
## Summary\n- add token provider support with one 401 refresh retry for long-lived runtimes\n- add default 30s timeout, per-call timeout/AbortSignal support, and stable transport/client errors\n- re-export WorkspaceBridge error codes/types from the bridge-client subpath\n- route bridge smoke runtime calls through the real WorkspaceBridgeClient\n- document token TTL/refresh expectations and client error handling\n\n## Validation\n- pnpm --filter @hachej/boring-workspace exec vitest run src/bridge-client/__tests__/client.test.ts\n- pnpm --filter @hachej/boring-workspace typecheck\n- pnpm --filter workspace-playground typecheck\n- pnpm --filter workspace-playground run smoke:bridge\n- /home/ubuntu/.pi/agent/skills/coding-autoreview/scripts/autoreview --mode local\n\nStacked on #71 / work/workspace-bridge-rpc-plan.