### PR TITLE
feat(core): public-shell navLinks slot for top-bar marketing links

### DIFF
--- a/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
+++ b/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
@@ -35,6 +35,12 @@ export interface ChatFirstPublicShellOptions {
    * otherwise the fixed-position arrows overlay the open panel. Defaults to on.
    */
   showTeachingArrows?: boolean
+  /**
+   * Marketing/navigation links rendered in the public (no-auth) top bar next to
+   * the brand — e.g. About, Pricing, Docs. The authenticated workspace top bar
+   * is unaffected. Use plain hrefs (router or full-page routes both work).
+   */
+  navLinks?: Array<{ label: string; href: string }>
 }
 
 const defaultPublicEmptyState = {
@@ -225,6 +231,13 @@ export function ChatFirstPublicShell<
                   {(appTitle?.[0] ?? 'B').toUpperCase()}
                 </span>
                 <span className="truncate text-[13px] font-medium leading-none tracking-tight text-foreground">{appTitle}</span>
+                {publicShell?.navLinks?.length ? (
+                  <nav className="public-topbar-nav" aria-label="Site">
+                    {publicShell.navLinks.map((link) => (
+                      <a key={link.href} href={link.href}>{link.label}</a>
+                    ))}
+                  </nav>
+                ) : null}
               </>
             ),
             className: workspaceProps.className,

--- a/packages/core/src/app/front/chatFirst/chatFirstPublicShell.css
+++ b/packages/core/src/app/front/chatFirst/chatFirstPublicShell.css
@@ -267,3 +267,24 @@
   font-weight: 600;
   color: color-mix(in oklch, var(--foreground) 88%, transparent);
 }
+
+/* Optional marketing/nav links rendered beside the brand in the public top bar
+   (ChatFirstPublicShellOptions.navLinks). The authed workspace is unaffected. */
+.public-topbar-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-left: 0.75rem;
+}
+
+.public-topbar-nav a {
+  font-size: 0.8125rem;
+  font-weight: 500;
+  text-decoration: none;
+  color: color-mix(in oklch, var(--foreground) 65%, transparent);
+  transition: color 0.15s ease;
+}
+
+.public-topbar-nav a:hover {
+  color: var(--foreground);
+}


### PR DESCRIPTION
## Problem

The chat-first public (no-auth) shell (`ChatFirstPublicShell`) **hardcodes** its top bar — brand on the left, Sign in / contact on the right. Consuming apps can't add marketing/nav links (About, Pricing, Docs) because the shell overrides `topBarLeft`/`topBarRight` passed via `chatFirstPublicWorkspaceProps`.

Discovered while building MacroAnalyst's public pages: About/Pricing had to be linked from the landing panel content as a workaround, not the actual top bar.

## Change

Add an optional `navLinks` field to `ChatFirstPublicShellOptions`:

```ts
navLinks?: Array<{ label: string; href: string }>
```

When provided, the links render in a `<nav class="public-topbar-nav">` beside the brand in the public top bar. No links → nothing renders (fully backward compatible). The **authenticated** workspace top bar is untouched.

- `ChatFirstPublicShell.tsx`: type + render beside the brand.
- `chatFirstPublicShell.css`: minimal styling using existing `--foreground` tokens.

## Consumer usage

```tsx
chatFirstPublicShell={{
  // …
  navLinks: [
    { label: "About", href: "/about" },
    { label: "Pricing", href: "/pricing" },
  ],
}}
```

Once released, MacroAnalyst can drop its landing-panel nav workaround and move the links into the real top bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)