### PR TITLE
Fix macro session and workspace state bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ Detailed coding practices, workflow, architecture, and package docs live under `
 7. **Run relevant quality gates** before calling work done.
 8. **Never launch bare `bv`; use only `bv --robot-*`.**
 9. **Never edit `.beads/*.jsonl` by hand.** Use `br` commands.
-10. **Default communication mode:** caveman skill, full intensity, unless user says `stop caveman` or `normal mode`.
+10. **Session history is host app user data:** Pi chat transcripts/session lists are owned by the deployed core app host, not by the sandbox/workspace runtime. Store them on the host app's durable volume via `BORING_AGENT_SESSION_ROOT` (typically `/data/pi-sessions`), not in container home/root. If host-side `BORING_AGENT_WORKSPACE_ROOT=/data/workspaces`, keep the host session root as sibling `/data/pi-sessions` unless the user explicitly chooses another mounted volume.
+11. **Default communication mode:** caveman skill, full intensity, unless user says `stop caveman` or `normal mode`.
 
 ## Start here
 

--- a/packages/agent/docs/runtime.md
+++ b/packages/agent/docs/runtime.md
@@ -222,7 +222,9 @@ Those belong to the sandbox runtime root, `/workspace`.
 
 Production chat history also must not use the container root filesystem. Set
 `BORING_AGENT_SESSION_ROOT` to a mounted-volume path such as `/data/pi-sessions`
-so Pi wrapper/native transcripts survive Fly deploys and restarts.
+so Pi wrapper/native transcripts survive Fly deploys and restarts. Core-hosted
+apps that run `vercel-sandbox` with `BORING_AGENT_WORKSPACE_ROOT=/data/workspaces`
+default this to the sibling `/data/pi-sessions` path when the env var is absent.
 
 ## Adding a custom runtime mode
 

--- a/packages/agent/src/front/chat/piChatPanelHooks.ts
+++ b/packages/agent/src/front/chat/piChatPanelHooks.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import type { PiChatState } from './pi/piChatReducer'
 import { createRemotePiSession, type RemotePiSession, type RemotePiSessionOptions } from './pi/remotePiSession'
 import type { UsePiSessionsOptions } from './session'
@@ -25,13 +25,19 @@ export function useExternalRemotePiSession({
   remoteSessionOptions?: UsePiSessionsOptions['remoteSessionOptions']
 }): RemotePiSession | undefined {
   const [session, setSession] = useState<RemotePiSession | undefined>()
+  const remoteSessionOptionsRef = useRef(remoteSessionOptions)
+  remoteSessionOptionsRef.current = remoteSessionOptions
+  const remoteSessionOptionsKey = useMemo(
+    () => remoteSessionOptionsIdentity(remoteSessionOptions),
+    [remoteSessionOptions],
+  )
   useEffect(() => {
     if (!sessionId) {
       setSession(undefined)
       return
     }
     const next = (createRemoteSession ?? createRemotePiSession)({
-      ...remoteSessionOptions,
+      ...remoteSessionOptionsRef.current,
       sessionId,
       workspaceId,
       storageScope,
@@ -41,8 +47,21 @@ export function useExternalRemotePiSession({
     })
     setSession(next)
     return () => next.dispose()
-  }, [apiBaseUrl, createRemoteSession, fetch, remoteSessionOptions, requestHeaders, sessionId, storageScope, workspaceId])
+  }, [apiBaseUrl, createRemoteSession, fetch, remoteSessionOptionsKey, requestHeaders, sessionId, storageScope, workspaceId])
   return session
+}
+
+function remoteSessionOptionsIdentity(options: UsePiSessionsOptions['remoteSessionOptions']): string {
+  if (!options) return '{}'
+  return JSON.stringify({
+    autoStart: options.autoStart,
+    requestTimeoutMs: options.requestTimeoutMs,
+    reconnect: options.reconnect,
+    debug: options.debug ? {
+      largeStateWarningBytes: options.debug.largeStateWarningBytes,
+      largeStateWarningMessages: options.debug.largeStateWarningMessages,
+    } : undefined,
+  })
 }
 
 export function useRemotePiSessionState(session: RemotePiSession | undefined): PiChatState | undefined {

--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
@@ -52,6 +52,7 @@ describe('usePiSessions', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    window.localStorage.clear()
     fetchMock = vi.fn()
   })
 
@@ -79,6 +80,29 @@ describe('usePiSessions', () => {
       headers: { authorization: 'Bearer redacted', 'x-boring-storage-scope': 'scope-a' },
     })
     expect(persisted.values.get(activeSessionStorageKey('scope-a'))).toBe('pi-running')
+  })
+
+  test('does not dispose the active remote session when equal remote options are re-created by the host', async () => {
+    const remote = remoteFactory()
+    fetchMock.mockResolvedValue(jsonResponse([session('pi-running')]))
+
+    const { rerender } = renderHook(
+      ({ timeout }) => usePiSessions({
+        storageScope: 'scope-a',
+        fetch: fetchMock as unknown as typeof fetch,
+        createRemoteSession: remote.factory,
+        remoteSessionOptions: { requestTimeoutMs: timeout },
+      }),
+      { initialProps: { timeout: 60_000 } },
+    )
+
+    await waitFor(() => expect(remote.factory).toHaveBeenCalledTimes(1))
+
+    rerender({ timeout: 60_000 })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(remote.factory).toHaveBeenCalledTimes(1)
+    expect(remote.created[0]?.dispose).not.toHaveBeenCalled()
   })
 
   test('loads the first session page before fetching older sessions on demand', async () => {

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -114,6 +114,12 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
   const loadedDataSourceRef = useRef(dataSourceKey)
   const requestScopeRef = useRef(requestScopeKey)
   requestScopeRef.current = requestScopeKey
+  const remoteSessionOptionsRef = useRef(options.remoteSessionOptions)
+  remoteSessionOptionsRef.current = options.remoteSessionOptions
+  const remoteSessionOptionsKey = useMemo(
+    () => remoteSessionOptionsIdentity(options.remoteSessionOptions),
+    [options.remoteSessionOptions],
+  )
 
   useEffect(() => {
     sessionsRef.current = sessions
@@ -301,7 +307,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     }
 
     const session = createRemoteSession({
-      ...options.remoteSessionOptions,
+      ...remoteSessionOptionsRef.current,
       sessionId: activeSessionId,
       workspaceId: options.workspaceId,
       storageScope,
@@ -313,7 +319,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     return () => {
       session.dispose()
     }
-  }, [activeSessionId, activeSessionKnown, apiBaseUrl, connectActiveSession, createRemoteSession, enabled, fetchImpl, options.remoteSessionOptions, options.workspaceId, requestHeaders, storageScope])
+  }, [activeSessionId, activeSessionKnown, apiBaseUrl, connectActiveSession, createRemoteSession, enabled, fetchImpl, remoteSessionOptionsKey, options.workspaceId, requestHeaders, storageScope])
 
   const create = useCallback(async (init?: PiSessionCreateInit): Promise<SessionSummary> => {
     if (!enabled) throw new Error('Pi sessions are disabled')
@@ -434,6 +440,19 @@ function toSessionSummary(value: unknown): SessionSummary {
 
 function canonicalPageCount(data: SessionSummary[]): number {
   return Math.min(data.length, SESSION_PAGE_SIZE)
+}
+
+function remoteSessionOptionsIdentity(options: UsePiSessionsOptions['remoteSessionOptions']): string {
+  if (!options) return '{}'
+  return JSON.stringify({
+    autoStart: options.autoStart,
+    requestTimeoutMs: options.requestTimeoutMs,
+    reconnect: options.reconnect,
+    debug: options.debug ? {
+      largeStateWarningBytes: options.debug.largeStateWarningBytes,
+      largeStateWarningMessages: options.debug.largeStateWarningMessages,
+    } : undefined,
+  })
 }
 
 function mergeSessions(...lists: SessionSummary[][]): SessionSummary[] {

--- a/packages/agent/src/front/primitives/artifact.tsx
+++ b/packages/agent/src/front/primitives/artifact.tsx
@@ -7,7 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { LucideIcon } from "lucide-react";
 import { XIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";

--- a/packages/agent/src/front/primitives/attachments.tsx
+++ b/packages/agent/src/front/primitives/attachments.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, HoverCard, HoverCardContent, HoverCardTrigger } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { FileUIPart, SourceDocumentUIPart } from "ai";
 import {
   FileTextIcon,

--- a/packages/agent/src/front/primitives/code-block.tsx
+++ b/packages/agent/src/front/primitives/code-block.tsx
@@ -8,8 +8,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@hachej/boring-ui-kit";
-import { copyTextToClipboard } from "@/front/clipboard";
-import { cn } from "@/front/lib";
+import { copyTextToClipboard } from "../clipboard";
+import { cn } from "../lib";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import type { ComponentProps, CSSProperties, HTMLAttributes } from "react";
 import {

--- a/packages/agent/src/front/primitives/conversation.tsx
+++ b/packages/agent/src/front/primitives/conversation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { UIMessage } from "ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";

--- a/packages/agent/src/front/primitives/message.tsx
+++ b/packages/agent/src/front/primitives/message.tsx
@@ -7,7 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";

--- a/packages/agent/src/front/primitives/prompt-input-wrappers.tsx
+++ b/packages/agent/src/front/primitives/prompt-input-wrappers.tsx
@@ -7,7 +7,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { ComponentProps, HTMLAttributes, ReactNode } from "react";
 import { Children } from "react";
 

--- a/packages/agent/src/front/primitives/prompt-input.tsx
+++ b/packages/agent/src/front/primitives/prompt-input.tsx
@@ -24,7 +24,7 @@ import {
   InputGroupTextarea,
 } from "@hachej/boring-ui-kit";
 import { Input, Spinner } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { ChatStatus, SourceDocumentUIPart } from "ai";
 import {
   CornerDownLeftIcon,

--- a/packages/agent/src/front/primitives/reasoning.tsx
+++ b/packages/agent/src/front/primitives/reasoning.tsx
@@ -6,7 +6,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";

--- a/packages/agent/src/front/primitives/shimmer.tsx
+++ b/packages/agent/src/front/primitives/shimmer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { MotionProps } from "motion/react";
 import { motion } from "motion/react";
 import type { CSSProperties, ElementType, JSX } from "react";

--- a/packages/agent/src/front/primitives/tool.tsx
+++ b/packages/agent/src/front/primitives/tool.tsx
@@ -8,7 +8,7 @@
  * without local invention.
  */
 import { Badge, Collapsible, CollapsibleContent, CollapsibleTrigger } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import {
   CheckCircleIcon,
   ChevronDownIcon,

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
@@ -388,6 +388,25 @@ describe("PiSessionStore", () => {
     }
   });
 
+  it("lets hosts pass an explicit session root without mutating process env", async () => {
+    const previous = process.env.BORING_AGENT_SESSION_ROOT;
+    process.env.BORING_AGENT_SESSION_ROOT = join(tmpDir, "env-root");
+    try {
+      const store = new PiSessionStore("/workspace", {
+        sessionNamespace: "workspace-a",
+        sessionRoot: join(tmpDir, "explicit-root"),
+      });
+      expect(store.getSessionDir()).toBe(join(tmpDir, "explicit-root", "workspace-a"));
+
+      const session = await store.create(ctx, { title: "Explicit" });
+      await expect(readFile(join(tmpDir, "explicit-root", "workspace-a", `${session.id}.jsonl`), "utf-8"))
+        .resolves.toContain("Explicit");
+    } finally {
+      if (previous === undefined) delete process.env.BORING_AGENT_SESSION_ROOT;
+      else process.env.BORING_AGENT_SESSION_ROOT = previous;
+    }
+  });
+
   it("can store session files under host cwd while writing runtime cwd in session header", async () => {
     const store = new PiSessionStore("/workspace", { storageCwd: "/tmp/host-storage-root", sessionDir: tmpDir });
     const session = await store.create(ctx, { title: "Runtime cwd" });

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -347,6 +347,8 @@ export function createPiCodingAgentHarness(opts: {
   pi?: PiHarnessOptions;
   /** Optional stable namespace for file-backed session storage. */
   sessionNamespace?: string;
+  /** Optional explicit root for file-backed session directories. */
+  sessionRoot?: string;
   /** Optional explicit file-backed session directory. Mostly for tests/hosts. */
   sessionDir?: string;
   /** Optional best-effort telemetry sink supplied by an embedding host. */
@@ -362,6 +364,7 @@ export function createPiCodingAgentHarness(opts: {
   const pi = withPiHarnessDefaults(opts.pi);
   const sessionStore = new PiSessionStore(opts.runtimeCwd ?? opts.cwd, {
     sessionNamespace: opts.sessionNamespace,
+    sessionRoot: opts.sessionRoot,
     sessionDir: opts.sessionDir,
     storageCwd: opts.cwd,
   });

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -38,14 +38,16 @@ export interface PiSessionEntries {
   messages: unknown[];
 }
 
-function sessionBaseDir(): string {
+function sessionBaseDir(explicitRoot?: string): string {
+  const explicit = explicitRoot?.trim();
+  if (explicit) return resolve(explicit);
   const configured = getEnv(SESSION_ROOT_ENV)?.trim();
   return configured ? resolve(configured) : join(homedir(), ".pi", "agent", "sessions");
 }
 
-function defaultSessionDir(cwd: string): string {
+function defaultSessionDir(cwd: string, explicitRoot?: string): string {
   const safePath = `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
-  return join(sessionBaseDir(), safePath);
+  return join(sessionBaseDir(explicitRoot), safePath);
 }
 
 const SAFE_ID = /^[a-zA-Z0-9_-]+$/;
@@ -70,12 +72,12 @@ interface NormalizedListOptions {
   includeId: string | undefined;
 }
 
-function sessionDirForNamespace(namespace: string): string {
+function sessionDirForNamespace(namespace: string, explicitRoot?: string): string {
   const safeNamespace = namespace.trim();
   if (!SAFE_SESSION_NAMESPACE.test(safeNamespace)) {
     throw new Error("session namespace must contain only letters, numbers, underscores, and dashes");
   }
-  return join(sessionBaseDir(), safeNamespace);
+  return join(sessionBaseDir(explicitRoot), safeNamespace);
 }
 
 function normalizeListOptions(options: SessionListOptions | undefined): NormalizedListOptions {
@@ -89,6 +91,8 @@ function normalizeListOptions(options: SessionListOptions | undefined): Normaliz
 export interface PiSessionStoreOptions {
   sessionDir?: string;
   sessionNamespace?: string;
+  /** Explicit root for file-backed session directories. Overrides BORING_AGENT_SESSION_ROOT. */
+  sessionRoot?: string;
   /** Host/storage cwd used only to derive the default file-backed session directory. */
   storageCwd?: string;
 }
@@ -107,8 +111,8 @@ export class PiSessionStore implements SessionStore {
     }
     this.sessionDir = options?.sessionDir
       ?? (options?.sessionNamespace
-        ? sessionDirForNamespace(options.sessionNamespace)
-        : defaultSessionDir(options?.storageCwd ?? cwd));
+        ? sessionDirForNamespace(options.sessionNamespace, options.sessionRoot)
+        : defaultSessionDir(options?.storageCwd ?? cwd, options?.sessionRoot));
   }
 
   getSessionDir(): string {

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -274,6 +274,8 @@ export interface RegisterAgentRoutesOptions {
     request?: FastifyRequest
   }) => PiHarnessOptions | undefined | Promise<PiHarnessOptions | undefined>
   sessionNamespace?: string
+  /** Optional explicit root for file-backed Pi chat transcript storage. */
+  sessionRoot?: string
   /** Optional best-effort telemetry sink supplied by an embedding host. */
   telemetry?: TelemetrySink
   /**
@@ -658,6 +660,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       tools,
       cwd: root,
       sessionNamespace: scope.sessionNamespace,
+      sessionRoot: opts.sessionRoot,
       systemPromptAppend: opts.systemPromptAppend,
       systemPromptDynamic: opts.getSystemPromptDynamic
         ? () => opts.getSystemPromptDynamic?.({ workspaceId, workspaceRoot: root })
@@ -830,6 +833,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
     if (cached) return cached
     const store = new PiSessionStore(scope.root, {
       sessionNamespace: scope.sessionNamespace,
+      sessionRoot: opts.sessionRoot,
       storageCwd: scope.root,
     })
     earlySessionStores.set(scope.key, store)

--- a/packages/agent/src/shared/harness.ts
+++ b/packages/agent/src/shared/harness.ts
@@ -10,6 +10,7 @@ export interface AgentHarnessFactoryInput {
   runtimeCwd?: string
   systemPromptAppend?: string
   sessionNamespace?: string
+  sessionRoot?: string
   sessionDir?: string
   /**
    * Optional dynamic system-prompt source. Harness calls it whenever it

--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -196,6 +196,8 @@ function HomeRedirect<TSession extends WorkspaceAgentSession = WorkspaceAgentSes
     location.search,
     location.hash,
   )
+  if (session.isPending) return <>{resolvedLoadingFallback}</>
+
   if (!session.data?.user && chatEntryMode === 'chat-first') {
     return (
       <ChatFirstPublicShell
@@ -313,6 +315,8 @@ function WorkspaceRoute<
   )
 
   if (!workspaceId) return <>{resolvedLoadingFallback}</>
+
+  if (session.isPending) return <>{resolvedLoadingFallback}</>
 
   if (!session.data?.user && chatEntryMode === 'chat-first') {
     return (

--- a/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
+++ b/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
@@ -281,6 +281,19 @@ describe('CoreWorkspaceAgentFront', () => {
     })
   })
 
+  it('keeps chat-first public shell hidden while auth session is still loading', async () => {
+    const { CoreWorkspaceAgentFront } = await importSubject()
+    sessionState = { data: null, isPending: true }
+    currentWorkspaceId = null
+    routePath = '/workspace/workspace-a'
+
+    render(<CoreWorkspaceAgentFront chatEntryMode="chat-first" loadingFallback={<div>Checking session</div>} />)
+
+    expect(screen.getByText('Checking session')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-agent-front')).not.toBeInTheDocument()
+  })
+
   it('renders the regular workspace shell with sign-in chrome before auth', async () => {
     const { CoreWorkspaceAgentFront } = await importSubject()
     sessionState = { data: null, isPending: false }

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -265,7 +265,11 @@ test('core/full-app composition honors BORING_AGENT_WORKSPACE_ROOT for workspace
   })
 
   const previous = process.env.BORING_AGENT_WORKSPACE_ROOT
-  process.env.BORING_AGENT_WORKSPACE_ROOT = '/tmp/from-env-workspaces'
+  const previousSessionRoot = process.env.BORING_AGENT_SESSION_ROOT
+  const previousMode = process.env.BORING_AGENT_MODE
+  process.env.BORING_AGENT_WORKSPACE_ROOT = '/tmp/workspaces'
+  process.env.BORING_AGENT_SESSION_ROOT = '  '
+  process.env.BORING_AGENT_MODE = 'vercel-sandbox'
 
   try {
     const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
@@ -277,7 +281,8 @@ test('core/full-app composition honors BORING_AGENT_WORKSPACE_ROOT for workspace
 
     try {
       const options = (mocks.registerAgentRoutes as any).mock.calls.at(-1)?.[1] as Record<string, unknown>
-      expect(options.workspaceRoot).toBe('/tmp/from-env-workspaces')
+      expect(options.workspaceRoot).toBe('/tmp/workspaces')
+      expect(options.sessionRoot).toBe('/tmp/pi-sessions')
       expect(mocks.collectWorkspaceAgentServerPlugins).toHaveBeenCalledWith(expect.objectContaining({
         workspaceRoot: process.cwd(),
       }))
@@ -287,5 +292,9 @@ test('core/full-app composition honors BORING_AGENT_WORKSPACE_ROOT for workspace
   } finally {
     if (previous === undefined) delete process.env.BORING_AGENT_WORKSPACE_ROOT
     else process.env.BORING_AGENT_WORKSPACE_ROOT = previous
+    if (previousSessionRoot === undefined) delete process.env.BORING_AGENT_SESSION_ROOT
+    else process.env.BORING_AGENT_SESSION_ROOT = previousSessionRoot
+    if (previousMode === undefined) delete process.env.BORING_AGENT_MODE
+    else process.env.BORING_AGENT_MODE = previousMode
   }
 })

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -182,6 +182,18 @@ export interface CreateCoreWorkspaceAgentServerOptions
 
 type AgentPiOptions = RegisterAgentRoutesOptions['pi']
 
+function normalizeOptionalPath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function inferSessionRootForWorkspaceRoot(workspaceRoot: string, runtimeMode: string | undefined): string | undefined {
+  if (runtimeMode !== 'vercel-sandbox') return undefined
+  const resolvedRoot = path.resolve(workspaceRoot)
+  if (path.basename(resolvedRoot) !== 'workspaces') return undefined
+  return path.join(path.dirname(resolvedRoot), 'pi-sessions')
+}
+
 export function resolveCoreLoadConfigOptions(
   options: Pick<
     CreateCoreWorkspaceAgentServerOptions,
@@ -690,6 +702,10 @@ export async function createCoreWorkspaceAgentServer(
     options.serveFrontend ?? (process.env.NODE_ENV !== 'development' && Boolean(appRoot))
   const pluginWorkspaceRoot = process.cwd()
   const workspaceRoot = options.workspaceRoot ?? process.env.BORING_AGENT_WORKSPACE_ROOT ?? process.cwd()
+  const agentRuntimeMode = options.runtimeModeAdapter?.id ?? options.mode ?? process.env.BORING_AGENT_MODE
+  const sessionRoot = normalizeOptionalPath(options.sessionRoot)
+    ?? normalizeOptionalPath(process.env.BORING_AGENT_SESSION_ROOT)
+    ?? inferSessionRootForWorkspaceRoot(workspaceRoot, agentRuntimeMode)
   registerTelemetryHooks(app, telemetry)
 
   await registerCoreRoutes({ app, sql, db, userStore, workspaceStore })
@@ -867,6 +883,7 @@ export async function createCoreWorkspaceAgentServer(
     systemPromptAppend: pluginCollection.agentOptions.systemPromptAppend,
     pi: pluginCollection.agentOptions.pi,
     getPi: resolvePiOptions,
+    sessionRoot,
     getSessionNamespace: resolveSessionNamespace,
     getExtraTools: async (ctx) => {
       const callerTools = options.getExtraTools ? await options.getExtraTools(ctx) : []

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
-import type { DockviewApi } from "dockview-react"
-import { ChevronRight, Menu } from "lucide-react"
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
+import type { DockviewApi, DockviewPanelApi } from "dockview-react"
+import { ChevronRight, FolderTree, Maximize2, Menu, MoreHorizontal, Plus } from "lucide-react"
 import { ControlTooltip } from "../../components/ControlTooltip"
 import { Button, IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
@@ -12,6 +12,7 @@ import type { WorkspaceState, PanelState } from "../../store/types"
 import { WorkbenchLeftPane } from "../workbench-left/WorkbenchLeftPane"
 import { useRegistry, useSurfaceResolverRegistry } from "../../registry"
 import type { SurfaceOpenRequest } from "../../../shared/types/surface"
+import type { PaneProps } from "../../../shared/types/panel"
 import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../../shared/types/surface"
 import {
   findOpenFilePanel,
@@ -41,6 +42,11 @@ export interface OpenPanelConfig {
   title?: string
   /** Arbitrary params passed to the pane component. */
   params?: Record<string, unknown>
+}
+
+interface WorkspacePaneTab extends OpenPanelConfig {
+  kind: "files" | "plugin"
+  filetreeOpen?: boolean
 }
 
 export interface SurfaceShellApi {
@@ -75,6 +81,8 @@ export interface SurfaceShellProps {
   onChange?: (snapshot: SurfaceShellSnapshot) => void
   /** Optional close action for hosts that model the workbench as collapsible. */
   onClose?: () => void
+  fullscreen?: boolean
+  onToggleFullscreen?: () => void
   /**
    * Extra panel ids (registered via WorkspaceProvider's `panels` prop) that
    * this workbench is allowed to render. Defaults to the built-in
@@ -95,6 +103,13 @@ export interface SurfaceShellProps {
 
 const COLLAPSED_WIDTH = 40
 const FILE_BACKED_PARAM = "__boringFileBacked"
+const WORKSPACE_TABS_STORAGE_VERSION = 1
+
+interface StoredWorkspaceTabsEnvelope {
+  v: number
+  tabs: WorkspacePaneTab[]
+  activeTab: string | null
+}
 
 function fileBackedPath(
   panel: PanelState | null | undefined,
@@ -130,6 +145,70 @@ function err(code: string, message: string): CommandResult {
   return { seq: ++seqCounter, status: "error", error: { code, message } }
 }
 
+function workspaceTabsStorageKey(storageKey: string): string {
+  return `${storageKey}:workspaceTabs`
+}
+
+function defaultWorkspaceTabs(): WorkspacePaneTab[] {
+  return [{
+    id: "files",
+    component: "__files-home",
+    title: "Files",
+    kind: "files" as const,
+    filetreeOpen: true,
+  }]
+}
+
+function tabsFromInitialPanels(initialPanels: SurfaceShellProps["initialPanels"]): WorkspacePaneTab[] {
+  const tabs = (initialPanels ?? []).map((panel) => ({
+    id: panel.id,
+    component: panel.component,
+    title: panel.title ?? panel.id,
+    params: panel.params,
+    kind: "plugin" as const,
+    filetreeOpen: false,
+  }))
+  return tabs.length > 0 ? tabs : defaultWorkspaceTabs()
+}
+
+function readStoredWorkspaceTabs(storageKey: string | undefined): StoredWorkspaceTabsEnvelope | null {
+  if (!storageKey) return null
+  try {
+    const raw = localStorage.getItem(workspaceTabsStorageKey(storageKey))
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<StoredWorkspaceTabsEnvelope>
+    if (parsed.v !== WORKSPACE_TABS_STORAGE_VERSION || !Array.isArray(parsed.tabs)) return null
+    const tabs = parsed.tabs.filter((tab): tab is WorkspacePaneTab => (
+      typeof tab === "object" && tab !== null &&
+      typeof tab.id === "string" && tab.id.length > 0 &&
+      typeof tab.component === "string" && tab.component.length > 0 &&
+      (tab.kind === "files" || tab.kind === "plugin")
+    ))
+    if (tabs.length === 0) return null
+    const activeTab = typeof parsed.activeTab === "string" && tabs.some((tab) => tab.id === parsed.activeTab)
+      ? parsed.activeTab
+      : tabs[0]?.id ?? null
+    return { v: WORKSPACE_TABS_STORAGE_VERSION, tabs, activeTab }
+  } catch {
+    return null
+  }
+}
+
+function writeStoredWorkspaceTabs(storageKey: string | undefined, tabs: WorkspacePaneTab[], activeTab: string | null): void {
+  if (!storageKey) return
+  try {
+    if (tabs.length === 0) {
+      localStorage.removeItem(workspaceTabsStorageKey(storageKey))
+      return
+    }
+    const safeActive = activeTab && tabs.some((tab) => tab.id === activeTab) ? activeTab : tabs[0]?.id ?? null
+    localStorage.setItem(
+      workspaceTabsStorageKey(storageKey),
+      JSON.stringify({ v: WORKSPACE_TABS_STORAGE_VERSION, tabs, activeTab: safeActive }),
+    )
+  } catch {}
+}
+
 export function SurfaceShell({
   rootDir = "",
   sidebarDefaultWidth = 240,
@@ -139,6 +218,8 @@ export function SurfaceShell({
   onReady,
   onChange,
   onClose,
+  fullscreen = false,
+  onToggleFullscreen,
   extraPanels,
   defaultLeftTab,
   onReloadAgentPlugins,
@@ -206,6 +287,9 @@ export function SurfaceShell({
   panelRegistryRef.current = panelRegistry
   const surfaceResolverRegistryRef = useRef(surfaceResolverRegistry)
   surfaceResolverRegistryRef.current = surfaceResolverRegistry
+  const collapsedRef = useRef(collapsed)
+  collapsedRef.current = collapsed
+  const autoCollapsedByRef = useRef<string | null>(null)
   const allowedPanels = useMemo(() => {
     const ids = new Set<string>()
     for (const panel of panelRegistrySnapshot) {
@@ -216,77 +300,80 @@ export function SurfaceShell({
     }
     return [...ids]
   }, [extraPanels, panelRegistrySnapshot])
+  const [workspaceTabs, setWorkspaceTabs] = useState<WorkspacePaneTab[]>(() => (
+    readStoredWorkspaceTabs(storageKey)?.tabs ?? tabsFromInitialPanels(initialPanels)
+  ))
+  const [activeWorkspaceTabId, setActiveWorkspaceTabId] = useState<string | null>(() => {
+    const stored = readStoredWorkspaceTabs(storageKey)
+    return stored?.activeTab ?? tabsFromInitialPanels(initialPanels)[0]?.id ?? null
+  })
+  const [pluginMenuOpen, setPluginMenuOpen] = useState(false)
+  const workspaceTabsRef = useRef<WorkspacePaneTab[]>([])
+  const activeWorkspaceTabIdRef = useRef<string | null>(null)
+  workspaceTabsRef.current = workspaceTabs
+  activeWorkspaceTabIdRef.current = activeWorkspaceTabId
+  const pluginMenuEntries = useMemo(() => {
+    const entries: Array<{ id: string; title: string; component?: string; kind: "files" | "panel"; multiple?: boolean }> = [
+      { id: "files", title: "File", kind: "files", multiple: true },
+    ]
+    for (const panel of panelRegistrySnapshot) {
+      if (panel.placement === "center" && panel.sidebarPolicy === "collapse") {
+        entries.push({ id: panel.id, title: panel.title, component: panel.id, kind: "panel", multiple: false })
+      }
+    }
+    return entries
+  }, [panelRegistrySnapshot])
+  const activeWorkspaceTab = useMemo(
+    () => workspaceTabs.find((tab) => tab.id === activeWorkspaceTabId) ?? workspaceTabs[0] ?? null,
+    [activeWorkspaceTabId, workspaceTabs],
+  )
+  const openWorkspaceTab = useCallback((tab: WorkspacePaneTab) => {
+    setWorkspaceTabs((current) => {
+      const existing = current.findIndex((candidate) => candidate.id === tab.id)
+      if (existing >= 0) {
+        const next = [...current]
+        next[existing] = { ...next[existing]!, ...tab }
+        return next
+      }
+      return [...current, tab]
+    })
+    setActiveWorkspaceTabId(tab.id)
+    setPluginMenuOpen(false)
+  }, [])
 
   const openFileSync = useCallback((path: string) => {
-    const api = apiRef.current
-    if (!api) {
-      console.warn("[SurfaceShell] openFile: surface not ready (dockview not initialized)")
-      return
-    }
     const normalizedPath = normalizeWorkbenchPath(path)
     const request: SurfaceOpenRequest = {
       kind: WORKSPACE_OPEN_PATH_SURFACE_KIND,
       target: normalizedPath,
     }
     const resolved = surfaceResolverRegistryRef.current.resolve(request)
-    if (resolved) {
-      if (!panelRegistryRef.current.has(resolved.component)) {
-        console.warn(`[SurfaceShell] openFile: resolver returned unknown panel "${resolved.component}" for "${normalizedPath}"`)
-        return
-      }
-      const panelId = surfacePanelId(request, resolved)
-      fileBackedPanelIdsRef.current.add(panelId)
-      const existingByResolvedId = api.getPanel(panelId)
-      const params = fileBackedParams(resolved.params, normalizedPath)
-      if (existingByResolvedId) {
-        existingByResolvedId.api.updateParameters(params)
-        existingByResolvedId.api.setActive()
-        return
-      }
-      api.addPanel({
-        id: panelId,
-        component: resolved.component,
-        title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
-        params,
-      })
+    if (!resolved) {
+      console.warn(`[SurfaceShell] openFile: no surface resolver matched "${normalizedPath}"`)
       return
     }
-
-    const existing = findOpenFilePanel(api, normalizedPath)
-    if (existing) {
-      existing.api.setActive()
+    if (!panelRegistryRef.current.has(resolved.component)) {
+      console.warn(`[SurfaceShell] openFile: resolver returned unknown panel "${resolved.component}" for "${normalizedPath}"`)
       return
     }
-    console.warn(`[SurfaceShell] openFile: no surface resolver matched "${normalizedPath}"`)
-  }, [])
+    const panelId = surfacePanelId(request, resolved)
+    fileBackedPanelIdsRef.current.add(panelId)
+    const params = fileBackedParams(resolved.params, normalizedPath)
+    openWorkspaceTab({
+      id: panelId,
+      component: resolved.component,
+      title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
+      params,
+      kind: "files",
+      filetreeOpen: false,
+    })
+  }, [openWorkspaceTab])
 
   const openSurfaceSync = useCallback((request: SurfaceOpenRequest) => {
-    const api = apiRef.current
-    if (!api) {
-      console.warn("[SurfaceShell] openSurface: surface not ready (dockview not initialized)")
-      return
-    }
     const normalizedRequest = normalizeSurfaceOpenRequest(request)
     const resolved = surfaceResolverRegistryRef.current.resolve(normalizedRequest)
     if (!resolved) {
       console.warn(`[SurfaceShell] openSurface: no resolver matched kind="${normalizedRequest.kind}" target="${normalizedRequest.target}"`)
-      return
-    }
-    const panelId = surfacePanelId(normalizedRequest, resolved)
-    if (normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND) {
-      fileBackedPanelIdsRef.current.add(panelId)
-    }
-    const existing = api.getPanel(panelId)
-    const closeWorkbenchOnDone = normalizedRequest.meta?.closeWorkbenchOnDone === true
-    const baseParams = normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND
-      ? fileBackedParams(resolved.params, normalizedRequest.target)
-      : resolved.params
-    const resolvedParams = closeWorkbenchOnDone && onCloseRef.current
-      ? { ...(baseParams ?? {}), __closeWorkbenchOnDone: onCloseRef.current }
-      : baseParams
-    if (existing) {
-      if (resolvedParams) existing.api.updateParameters(resolvedParams)
-      existing.api.setActive()
       return
     }
     const registry = panelRegistryRef.current
@@ -297,35 +384,28 @@ export function SurfaceShell({
           `Register the component through a panel output before resolving to it.`,
       )
     }
-    api.addPanel({
+    const panelId = surfacePanelId(normalizedRequest, resolved)
+    if (normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND) {
+      fileBackedPanelIdsRef.current.add(panelId)
+    }
+    const closeWorkbenchOnDone = normalizedRequest.meta?.closeWorkbenchOnDone === true
+    const baseParams = normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND
+      ? fileBackedParams(resolved.params, normalizedRequest.target)
+      : resolved.params
+    const resolvedParams = closeWorkbenchOnDone && onCloseRef.current
+      ? { ...(baseParams ?? {}), __closeWorkbenchOnDone: onCloseRef.current }
+      : baseParams
+    openWorkspaceTab({
       id: panelId,
       component: resolved.component,
       title: resolved.title ?? normalizedRequest.target,
       params: resolvedParams,
+      kind: normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND ? "files" : "plugin",
+      filetreeOpen: false,
     })
-  }, [])
+  }, [openWorkspaceTab])
 
   const openPanelSync = useCallback((config: OpenPanelConfig) => {
-    const api = apiRef.current
-    if (!api) return
-    const existing = api.getPanel(config.id)
-    if (existing) {
-      // Re-activate, and update params if they changed (so callers can drive
-      // pane state by re-issuing openPanel with new params — same panel, new
-      // input).
-      if (config.params) {
-        existing.api.updateParameters(config.params)
-      }
-      existing.api.setActive()
-      return
-    }
-    // Validate the component is actually registered. Without this check,
-    // dockview happily creates an empty tab when handed an unknown
-    // component name (it falls back to a no-op renderer). That's how the
-    // agent's "openPanel({component:'chart'})" produced a blank workbench
-    // with no error signal in either direction. Refuse loudly here so the
-    // failure is visible at the call site and (when called via exec_ui)
-    // surfaces back to the LLM through the UI bridge error path.
     const registry = panelRegistryRef.current
     if (!registry.has(config.component)) {
       const known = registry.list().map((p) => p.id).join(", ")
@@ -334,23 +414,23 @@ export function SurfaceShell({
           `Add the component to WorkspaceProvider's "panels" prop, or pick one of the registered ids.`,
       )
     }
-    api.addPanel({
+    const registeredPanel = registry.get(config.component)
+    openWorkspaceTab({
       id: config.id,
       component: config.component,
-      title: config.title ?? config.id,
+      title: config.title ?? registeredPanel?.title ?? config.id,
       params: config.params,
+      kind: registeredPanel?.sidebarPolicy === "collapse" ? "plugin" : "plugin",
+      filetreeOpen: false,
     })
-  }, [])
+  }, [openWorkspaceTab])
 
   const getSnapshot = useCallback((): SurfaceShellSnapshot => {
-    const api = apiRef.current
-    if (!api) return { openTabs: [], activeTab: null }
-    const openTabs: SurfaceShellTab[] = api.panels.map((p) => ({
-      id: p.id,
-      title: (p.title ?? p.id) as string,
-      params: (p.params as Record<string, unknown> | undefined) ?? undefined,
-    }))
-    return { openTabs, activeTab: api.activePanel?.id ?? null }
+    const tabs = workspaceTabsRef.current
+    return {
+      openTabs: tabs.map((tab) => ({ id: tab.id, title: tab.title ?? tab.id, params: tab.params })),
+      activeTab: activeWorkspaceTabIdRef.current,
+    }
   }, [])
 
   const emitBridgeEvent = useCallback(<K extends keyof BridgeEventMap>(
@@ -379,24 +459,34 @@ export function SurfaceShell({
     openFile: openFileSync,
     openSurface: openSurfaceSync,
     openPanel: openPanelSync,
-    closeWorkbenchLeftPane: () => setCollapsed(true),
+    closeWorkbenchLeftPane: () => {
+      autoCollapsedByRef.current = null
+      setCollapsed(true)
+      const activeId = activeWorkspaceTabIdRef.current
+      if (activeId) {
+        setWorkspaceTabs((prev) => prev.map((tab) => (
+          tab.id === activeId && tab.kind === "files"
+            ? { ...tab, filetreeOpen: false }
+            : tab
+        )))
+      }
+    },
     expandToFile: expandToFileSync,
     getSnapshot,
   }), [expandToFileSync, getSnapshot, openFileSync, openPanelSync, openSurfaceSync])
 
   const getBridgeState = useCallback((): WorkspaceState => {
-    const api = apiRef.current
-    const panels: PanelState[] = api
-      ? api.panels.map((p) => ({
-          id: p.id,
-          component: String((p as { component?: string }).component ?? ""),
-          params: (p.params as Record<string, unknown> | undefined) ?? undefined,
-        }))
-      : []
-    const activePanel = api?.activePanel?.id ?? null
-    const fileBackedPanelIds = fileBackedPanelIdsRef.current
-    const activePanelState = panels.find((panel) => panel.id === activePanel)
-    const activeFile = fileBackedPath(activePanelState, fileBackedPanelIds)
+    const tabs = workspaceTabsRef.current
+    const activePanel = activeWorkspaceTabIdRef.current
+    const panels: PanelState[] = tabs.map((tab) => ({
+      id: tab.id,
+      component: tab.component,
+      params: tab.params,
+    }))
+    const activePanelState = tabs.find((tab) => tab.id === activePanel)
+    const activeFile = activePanelState?.kind === "files" && typeof activePanelState.params?.path === "string"
+      ? activePanelState.params.path
+      : null
     return {
       hydrationComplete: true,
       layout: null,
@@ -406,9 +496,9 @@ export function SurfaceShell({
       panels,
       activePanel,
       activeFile,
-      visibleFiles: panels
-        .map((panel) => fileBackedPath(panel, fileBackedPanelIds))
-        .filter((p): p is string => p !== null),
+      visibleFiles: tabs
+        .filter((tab) => tab.kind === "files" && typeof tab.params?.path === "string")
+        .map((tab) => tab.params!.path as string),
       dirtyFiles: {},
       notifications: [],
     }
@@ -420,6 +510,16 @@ export function SurfaceShell({
       handler(state)
     }
   }, [getBridgeState])
+
+  useEffect(() => {
+    onReadyRef.current?.(localSurfaceApi)
+  }, [localSurfaceApi])
+
+  useEffect(() => {
+    const snapshot = getSnapshot()
+    onChangeRef.current?.(snapshot)
+    emitBridgeState()
+  }, [activeWorkspaceTabId, emitBridgeState, getSnapshot, workspaceTabs])
 
   const initializedPanelsRef = useRef(false)
   const handleReady = useCallback((ready: DockviewApi) => {
@@ -444,7 +544,26 @@ export function SurfaceShell({
     }
     ready.onDidAddPanel(emit)
     ready.onDidRemovePanel(emit)
-    ready.onDidActivePanelChange(emit)
+    ready.onDidActivePanelChange(() => {
+      emit()
+      const active = ready.activePanel
+      if (!active) return
+      const compId =
+        (active as { contentComponent?: string }).contentComponent ?? active.id
+      const config = panelRegistryRef.current.get(compId)
+      if (config?.sidebarPolicy === "collapse") {
+        if (!collapsedRef.current) {
+          autoCollapsedByRef.current = compId
+          setCollapsed(true)
+        }
+      } else if (
+        collapsedRef.current &&
+        autoCollapsedByRef.current !== null
+      ) {
+        // Leaving a standalone panel should not force-open the filetree.
+        autoCollapsedByRef.current = null
+      }
+    })
     // Initial snapshot once everyone's wired up.
     emit()
   }, [localSurfaceApi, getSnapshot, emitBridgeState])
@@ -453,45 +572,8 @@ export function SurfaceShell({
   const openFile = useCallback(
     async (path: string): Promise<CommandResult> => {
       try {
-        const api = apiRef.current
-        if (!api) return err("not-ready", "surface not ready")
-        const normalizedPath = normalizeWorkbenchPath(path)
-        const request: SurfaceOpenRequest = {
-          kind: WORKSPACE_OPEN_PATH_SURFACE_KIND,
-          target: normalizedPath,
-        }
-        const resolved = surfaceResolverRegistryRef.current.resolve(request)
-        if (resolved) {
-          if (!panelRegistryRef.current.has(resolved.component)) {
-            return err(
-              "NO_SURFACE_PANEL",
-              `surface resolver "${request.kind}" returned unknown panel "${resolved.component}"`,
-            )
-          }
-          const panelId = surfacePanelId(request, resolved)
-          fileBackedPanelIdsRef.current.add(panelId)
-          const params = fileBackedParams(resolved.params, normalizedPath)
-          const existingByResolvedId = api.getPanel(panelId)
-          if (existingByResolvedId) {
-            existingByResolvedId.api.updateParameters(params)
-            existingByResolvedId.api.setActive()
-            return ok()
-          }
-          api.addPanel({
-            id: panelId,
-            component: resolved.component,
-            title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
-            params,
-          })
-          return ok()
-        }
-
-        const existing = findOpenFilePanel(api, normalizedPath)
-        if (existing) {
-          existing.api.setActive()
-          return ok()
-        }
-        return err("NO_SURFACE_RESOLVER", `no registered surface resolver handles ${normalizedPath}`)
+        openFileSync(path)
+        return ok()
       } catch (error) {
         return err(
           "INVALID_SURFACE_PATH",
@@ -499,7 +581,7 @@ export function SurfaceShell({
         )
       }
     },
-    [],
+    [openFileSync],
   )
 
   const bridge = useMemo<WorkspaceBridge>(() => {
@@ -509,10 +591,33 @@ export function SurfaceShell({
       getDirtyFiles: () => [],
       getVisibleFiles: () => getBridgeState().visibleFiles,
       openFile,
-      openPanel: async () => ok(),
-      closePanel: async () => ok(),
+      openPanel: async (config) => {
+        try {
+          openPanelSync(config)
+          return ok()
+        } catch (error) {
+          return err("OPEN_PANEL", error instanceof Error ? error.message : "failed to open panel")
+        }
+      },
+      closePanel: async (id) => {
+        setWorkspaceTabs((current) => current.filter((tab) => tab.id !== id))
+        if (activeWorkspaceTabIdRef.current === id) {
+          const next = workspaceTabsRef.current.find((tab) => tab.id !== id) ?? null
+          setActiveWorkspaceTabId(next?.id ?? null)
+        }
+        return ok()
+      },
       closeWorkbenchLeftPane: async () => {
+        autoCollapsedByRef.current = null
         setCollapsed(true)
+        const activeId = activeWorkspaceTabIdRef.current
+        if (activeId) {
+          setWorkspaceTabs((prev) => prev.map((tab) => (
+            tab.id === activeId && tab.kind === "files"
+              ? { ...tab, filetreeOpen: false }
+              : tab
+          )))
+        }
         return ok()
       },
       showNotification: async () => ok(),
@@ -565,7 +670,7 @@ export function SurfaceShell({
       const state = dragStateRef.current
       if (!state) return
       const delta = e.clientX - state.startX
-      const next = Math.max(sidebarMinWidth, Math.min(sidebarMaxWidth, state.startWidth + delta))
+      const next = Math.max(sidebarMinWidth, Math.min(sidebarMaxWidth, state.startWidth - delta))
       setSidebarWidth(next)
     },
     [sidebarMinWidth, sidebarMaxWidth],
@@ -583,10 +688,10 @@ export function SurfaceShell({
       const step = e.shiftKey ? 32 : 16
       if (e.key === "ArrowLeft") {
         e.preventDefault()
-        setSidebarWidth((w) => Math.max(sidebarMinWidth, w - step))
+        setSidebarWidth((w) => Math.min(sidebarMaxWidth, w + step))
       } else if (e.key === "ArrowRight") {
         e.preventDefault()
-        setSidebarWidth((w) => Math.min(sidebarMaxWidth, w + step))
+        setSidebarWidth((w) => Math.max(sidebarMinWidth, w - step))
       } else if (e.key === "Home") {
         e.preventDefault()
         setSidebarWidth(sidebarMinWidth)
@@ -597,6 +702,17 @@ export function SurfaceShell({
     },
     [collapsed, sidebarMinWidth, sidebarMaxWidth],
   )
+
+  useEffect(() => {
+    const stored = readStoredWorkspaceTabs(storageKey)
+    const tabs = stored?.tabs ?? tabsFromInitialPanels(initialPanels)
+    setWorkspaceTabs(tabs)
+    setActiveWorkspaceTabId(stored?.activeTab ?? tabs[0]?.id ?? null)
+  }, [storageKey])
+
+  useEffect(() => {
+    writeStoredWorkspaceTabs(storageKey, workspaceTabs, activeWorkspaceTabId)
+  }, [activeWorkspaceTabId, storageKey, workspaceTabs])
 
   // Persist sidebar width. (The on-mount READ moved into the useState lazy
   // initializer so the first render is already hydrated — without that, the
@@ -616,101 +732,345 @@ export function SurfaceShell({
     } catch {}
   }, [storageKey, collapsed])
 
+  const panelComponents = useMemo(() => panelRegistry.getComponents(), [panelRegistry, panelRegistrySnapshot])
+  const activeComponent = activeWorkspaceTab ? panelComponents[activeWorkspaceTab.component] ?? null : null
+  const activeFilePath = activeWorkspaceTab?.kind === "files" && typeof activeWorkspaceTab.params?.path === "string"
+    ? activeWorkspaceTab.params.path
+    : null
+  const updateWorkspaceTab = useCallback((id: string, patch: Partial<WorkspacePaneTab>) => {
+    setWorkspaceTabs((current) => current.map((tab) => tab.id === id ? { ...tab, ...patch } : tab))
+  }, [])
+  const closeWorkspaceTab = useCallback((id: string) => {
+    setWorkspaceTabs((current) => {
+      const next = current.filter((tab) => tab.id !== id)
+      if (activeWorkspaceTabIdRef.current === id) {
+        setActiveWorkspaceTabId(next[0]?.id ?? null)
+      }
+      return next
+    })
+  }, [])
+  const openPluginEntry = useCallback((entry: { id: string; title: string; component?: string; kind: "files" | "panel"; multiple?: boolean }) => {
+    setPluginMenuOpen(false)
+    if (entry.kind === "files") {
+      openWorkspaceTab({
+        id: `files:${Date.now()}`,
+        component: "__files-home",
+        title: "Files",
+        params: {},
+        kind: "files",
+        filetreeOpen: true,
+      })
+      return
+    }
+    if (!entry.component) return
+    if (entry.multiple === false) {
+      const existing = workspaceTabsRef.current.find((tab) => tab.component === entry.component)
+      if (existing) {
+        setActiveWorkspaceTabId(existing.id)
+        return
+      }
+    }
+    openWorkspaceTab({
+      id: entry.multiple === false ? entry.component : `${entry.component}:${Date.now()}`,
+      component: entry.component,
+      title: entry.title,
+      params: {},
+      kind: "plugin",
+      filetreeOpen: false,
+    })
+  }, [openWorkspaceTab])
+
   return (
     <div
       ref={containerRef}
       data-boring-workspace-part="surface"
-      className={cn("flex h-full min-h-0 w-full bg-background", className)}
+      data-boring-surface-mode="workspace-tabs"
+      className={cn("flex h-full min-h-0 w-full flex-col bg-background", className)}
       data-testid="surface-shell"
     >
-      {!collapsed ? (
-        <>
-          <aside
-            data-boring-workspace-part="surface-sidebar"
-            data-boring-state="expanded"
-            className="flex h-full min-h-0 flex-col"
-            style={{ width: sidebarWidth, minWidth: sidebarWidth, maxWidth: sidebarWidth }}
-            aria-label="Workbench left pane"
-          >
-            <WorkbenchLeftPane
-              rootDir={rootDir}
-              bridge={bridge}
-              defaultTab={defaultLeftTab}
-              revealFileTreeRequest={fileTreeRevealRequest}
-              onOpenPanel={openPanelSync}
-              onReloadAgentPlugins={onReloadAgentPlugins}
-              onCollapse={() => setCollapsed(true)}
-            />
-          </aside>
+      <WorkspaceSurfaceTopBar
+        tabs={workspaceTabs}
+        activeTabId={activeWorkspaceTab?.id ?? null}
+        activePath={activeFilePath}
+        filetreeOpen={Boolean(activeWorkspaceTab?.kind === "files" && activeWorkspaceTab.filetreeOpen)}
+        pluginMenuOpen={pluginMenuOpen}
+        pluginEntries={pluginMenuEntries}
+        onActivateTab={setActiveWorkspaceTabId}
+        onCloseTab={closeWorkspaceTab}
+        onTogglePluginMenu={() => setPluginMenuOpen((open) => !open)}
+        onOpenPlugin={openPluginEntry}
+        onToggleFiletree={() => {
+          if (!activeWorkspaceTab || activeWorkspaceTab.kind !== "files") return
+          updateWorkspaceTab(activeWorkspaceTab.id, { filetreeOpen: !activeWorkspaceTab.filetreeOpen })
+        }}
+        fullscreen={fullscreen}
+        onToggleFullscreen={onToggleFullscreen}
+        onClose={onClose}
+      />
 
-          <div
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize sidebar"
-            tabIndex={0}
-            onPointerDown={startDrag}
-            onPointerMove={onDrag}
-            onPointerUp={endDrag}
-            onPointerCancel={endDrag}
-            onKeyDown={onHandleKeyDown}
-            className={cn(
-              "relative w-px shrink-0 cursor-col-resize bg-transparent transition-colors hover:bg-primary/40",
-              "focus-visible:outline-none focus-visible:bg-primary/50",
-            )}
-          >
-            <span aria-hidden="true" className="absolute inset-y-0 -left-1.5 -right-1.5" />
+      <div className="min-h-0 flex-1">
+        {!activeWorkspaceTab ? (
+          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+            Open a workspace tab with +
           </div>
-        </>
-      ) : null}
-
-      <div className="relative min-w-0 flex-1">
-        <div
-          data-boring-workspace-part="surface-tabs"
-          data-boring-state={collapsed ? "collapsed" : "expanded"}
-          className="workbench-dockview h-full"
-          data-collapsed-sources={collapsed ? "true" : undefined}
-        >
-          <ArtifactSurfacePane
-            storageKey={storageKey}
-            onReady={handleReady}
-            allowedPanels={allowedPanels}
-          />
-        </div>
-        {/* Header overlays — always reachable, including existing/single-tab
-            dockview groups where header action slots can be squeezed/hidden.
-            zIndex must beat dockview's "open tabs" overflow popover (built by
-            PopupService at --dv-overlay-z-index 999, sometimes doubled to ~1998)
-            so the close-workspace control on the right edge is never covered by
-            an open dropdown menu. */}
-        <div
-          className="pointer-events-none absolute inset-x-0 top-0 flex items-center justify-between"
-          style={{ height: 44, zIndex: 2000 }}
-        >
-          <div>
-            {collapsed && (
-              <ControlTooltip label="Show workspace menu" side="right">
-                <IconButton
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => setCollapsed(false)}
-                  className="pointer-events-auto ml-2"
-                  aria-label="Show workspace menu"
-                >
-                  <Menu className="h-4 w-4" strokeWidth={1.75} />
-                </IconButton>
-              </ControlTooltip>
-            )}
+        ) : (
+          <div className="flex h-full min-h-0 w-full">
+            <div className="min-w-0 flex-1">
+              {activeComponent ? (
+                <WorkspacePaneHost
+                  tab={activeWorkspaceTab}
+                  component={activeComponent}
+                  containerApi={apiRef.current}
+                  onParamsChange={(params) => updateWorkspaceTab(activeWorkspaceTab.id, { params })}
+                  onTitleChange={(title) => updateWorkspaceTab(activeWorkspaceTab.id, { title })}
+                />
+              ) : activeWorkspaceTab.component === "__files-home" ? (
+                <FilesHomePane />
+              ) : (
+                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">Missing plugin panel</div>
+              )}
+            </div>
+            {activeWorkspaceTab.kind === "files" && activeWorkspaceTab.filetreeOpen ? (
+              <aside
+                data-boring-workspace-part="surface-sidebar"
+                data-boring-state="expanded"
+                className="flex h-full min-h-0 flex-col border-l border-border"
+                style={{ width: sidebarWidth, minWidth: sidebarWidth, maxWidth: sidebarWidth }}
+                aria-label="Files"
+              >
+                <WorkbenchLeftPane
+                  rootDir={rootDir}
+                  bridge={bridge}
+                  defaultTab={defaultLeftTab}
+                  revealFileTreeRequest={fileTreeRevealRequest}
+                  onOpenPanel={openPanelSync}
+                  onReloadAgentPlugins={onReloadAgentPlugins}
+                  railSide="right"
+                  hideRail
+                />
+              </aside>
+            ) : null}
           </div>
-          {onClose && <WorkbenchCloseAction onClose={onClose} />}
-        </div>
-        <EmptyWorkbenchOverlay
-          api={api}
-          collapsed={collapsed}
-          onExpandFiles={() => setCollapsed(false)}
-        />
+        )}
       </div>
     </div>
+  )
+}
+
+function WorkspaceSurfaceTopBar({
+  tabs,
+  activeTabId,
+  activePath,
+  filetreeOpen,
+  pluginMenuOpen,
+  pluginEntries,
+  onActivateTab,
+  onCloseTab,
+  onTogglePluginMenu,
+  onOpenPlugin,
+  onToggleFiletree,
+  fullscreen,
+  onToggleFullscreen,
+  onClose,
+}: {
+  tabs: WorkspacePaneTab[]
+  activeTabId: string | null
+  activePath: string | null
+  filetreeOpen: boolean
+  pluginMenuOpen: boolean
+  pluginEntries: Array<{ id: string; title: string; component?: string; kind: "files" | "panel"; multiple?: boolean }>
+  onActivateTab: (id: string) => void
+  onCloseTab: (id: string) => void
+  onTogglePluginMenu: () => void
+  onOpenPlugin: (entry: { id: string; title: string; component?: string; kind: "files" | "panel"; multiple?: boolean }) => void
+  onToggleFiletree: () => void
+  fullscreen: boolean
+  onToggleFullscreen?: () => void
+  onClose?: () => void
+}) {
+  const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? null
+  const pathParts = activePath?.split("/").filter(Boolean) ?? []
+  const breadcrumbs = pathParts.length > 0 ? pathParts : [activeTab?.title ?? "Workspace"]
+  return (
+    <div data-boring-workspace-part="surface-topbar" className="shrink-0 border-b border-border bg-background">
+      <div className="relative flex h-11 items-center gap-1 px-3">
+        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
+          {tabs.map((tab) => {
+            const active = tab.id === activeTabId
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                aria-label={`Activate ${tab.title ?? tab.id}`}
+                aria-pressed={active}
+                onClick={() => onActivateTab(tab.id)}
+                className={`group flex h-8 max-w-[220px] items-center gap-2 rounded-xl px-3 text-sm transition-colors ${active ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/70 hover:text-foreground"}`}
+              >
+                <span className="truncate">{tab.title ?? tab.id}</span>
+                <span
+                  role="button"
+                  tabIndex={0}
+                  aria-label={`Close ${tab.title ?? tab.id}`}
+                  onClick={(event) => {
+                    event.stopPropagation()
+                    onCloseTab(tab.id)
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" && event.key !== " ") return
+                    event.preventDefault()
+                    event.stopPropagation()
+                    onCloseTab(tab.id)
+                  }}
+                  className="grid size-4 place-items-center rounded-full text-muted-foreground opacity-80 hover:bg-background hover:text-foreground"
+                >
+                  ×
+                </span>
+              </button>
+            )
+          })}
+          <div className="relative shrink-0">
+            <button
+              type="button"
+              aria-label="Add workspace tab"
+              title="Add workspace tab"
+              onClick={onTogglePluginMenu}
+              className="grid size-8 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              <Plus className="h-4 w-4" strokeWidth={1.75} />
+            </button>
+            {pluginMenuOpen ? (
+              <div
+                data-boring-workspace-part="plugin-tab-menu"
+                className="absolute left-0 top-9 z-[2500] w-64 overflow-hidden rounded-xl border border-border bg-popover p-1.5 text-sm shadow-xl"
+              >
+                <div className="px-2 pb-1 pt-1 text-xs font-medium text-muted-foreground">New workspace tab</div>
+                {pluginEntries.map((entry) => (
+                  <button
+                    key={entry.id}
+                    type="button"
+                    aria-label={`Create ${entry.title} tab`}
+                    onClick={() => onOpenPlugin(entry)}
+                    className="flex h-10 w-full items-center gap-2 rounded-lg px-2 text-left text-popover-foreground hover:bg-muted"
+                  >
+                    <span className="grid size-6 place-items-center rounded-md bg-muted text-muted-foreground">
+                      {entry.kind === "files" ? <FolderTree className="h-4 w-4" strokeWidth={1.75} /> : <Plus className="h-4 w-4" strokeWidth={1.75} />}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate">{entry.title}</span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+        <button type="button" aria-label="Workspace options" className="grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground">
+          <MoreHorizontal className="h-4 w-4" strokeWidth={1.75} />
+        </button>
+        {onToggleFullscreen ? (
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            onClick={onToggleFullscreen}
+            className="pointer-events-auto mx-1"
+            aria-label={fullscreen ? "Exit workspace fullscreen" : "Enter workspace fullscreen"}
+            title={fullscreen ? "Exit workspace fullscreen" : "Enter workspace fullscreen"}
+          >
+            <Maximize2 className="h-4 w-4" strokeWidth={1.75} />
+          </IconButton>
+        ) : null}
+        {onClose ? <WorkbenchCloseAction onClose={onClose} /> : null}
+      </div>
+      <div className="flex h-10 items-center gap-2 border-t border-border/60 px-3 text-sm">
+        <div className="flex min-w-0 flex-1 items-center gap-1 text-muted-foreground">
+          {breadcrumbs.map((part, index) => (
+            <span key={`${part}-${index}`} className="contents">
+              {index > 0 ? <span className="text-muted-foreground/60">›</span> : null}
+              <span className={index === breadcrumbs.length - 1 ? "truncate font-medium text-foreground" : "truncate"}>{part}</span>
+            </span>
+          ))}
+        </div>
+        <button type="button" aria-label="Open externally" className="rounded-lg border border-border px-3 py-1 text-foreground hover:bg-muted">
+          Open
+        </button>
+        {activeTab?.kind === "files" ? (
+          <button
+            type="button"
+            aria-label={filetreeOpen ? "Hide file tree" : "Show file tree"}
+            aria-pressed={filetreeOpen}
+            onClick={onToggleFiletree}
+            className="grid size-8 place-items-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground aria-pressed:bg-muted aria-pressed:text-foreground"
+          >
+            <FolderTree className="h-4 w-4" strokeWidth={1.75} />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function FilesHomePane() {
+  return (
+    <div className="flex h-full items-center justify-center p-8 text-center text-sm text-muted-foreground">
+      <div>
+        <div className="text-base font-medium text-foreground">Files</div>
+        <div className="mt-1">Pick a file from the file tree to open it in its own Files tab.</div>
+      </div>
+    </div>
+  )
+}
+
+function WorkspacePaneHost({
+  tab,
+  component: Component,
+  containerApi,
+  onParamsChange,
+  onTitleChange,
+}: {
+  tab: WorkspacePaneTab
+  component: ComponentType<PaneProps<Record<string, unknown>>>
+  containerApi: DockviewApi | null
+  onParamsChange: (params: Record<string, unknown>) => void
+  onTitleChange: (title: string) => void
+}) {
+  const [params, setParams] = useState<Record<string, unknown>>(tab.params ?? {})
+  const paramsRef = useRef<Record<string, unknown>>(tab.params ?? {})
+  const listenersRef = useRef(new Set<(event: { params: Record<string, unknown> }) => void>())
+
+  const publishParams = useCallback((next: Record<string, unknown>) => {
+    paramsRef.current = next
+    setParams(next)
+    onParamsChange(next)
+    for (const listener of [...listenersRef.current]) listener({ params: next })
+  }, [onParamsChange])
+
+  useEffect(() => {
+    publishParams(tab.params ?? {})
+  }, [tab.id])
+
+  const panelApi = useMemo(() => ({
+    id: tab.id,
+    updateParameters(next: Record<string, unknown>) {
+      publishParams({ ...paramsRef.current, ...next })
+    },
+    onDidParametersChange(listener: (event: { params: Record<string, unknown> }) => void) {
+      listenersRef.current.add(listener)
+      return { dispose: () => listenersRef.current.delete(listener) }
+    },
+    setActive() {},
+    setTitle(title: string) {
+      if (title === tab.title) return
+      window.queueMicrotask(() => onTitleChange(title))
+    },
+    close() {},
+  }) as unknown as DockviewPanelApi, [onTitleChange, publishParams, tab.id])
+
+  return (
+    <Component
+      params={params}
+      api={panelApi}
+      containerApi={containerApi as DockviewApi}
+      className="h-full"
+    />
   )
 }
 

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -7,36 +7,9 @@ import { CommandRegistry } from "../../../../shared/plugins/CommandRegistry"
 import { SurfaceResolverRegistry } from "../../../../shared/plugins/SurfaceResolverRegistry"
 import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../../../shared/types/surface"
 
-let capturedSurfaceStorageKey: string | undefined
-let capturedAllowedPanels: string[] | undefined
-let mockAddPanel = vi.fn()
-let mockGetPanel: (id: string) => unknown = vi.fn(() => undefined)
-
 vi.mock("../../workbench-left/WorkbenchLeftPane", () => ({
   WorkbenchLeftPane: () => <div data-testid="mock-left-pane" />,
 }))
-
-vi.mock("../ArtifactSurfacePane", async () => {
-  const React = await import("react")
-  function MockArtifactSurfacePane(props: { storageKey?: string; allowedPanels?: string[]; onReady?: (api: unknown) => void }) {
-    capturedSurfaceStorageKey = props.storageKey
-    capturedAllowedPanels = props.allowedPanels
-    React.useEffect(() => {
-      props.onReady?.({
-        panels: [],
-        activePanel: null,
-        getPanel: mockGetPanel,
-        addPanel: mockAddPanel,
-        onDidAddPanel: vi.fn(() => ({ dispose: vi.fn() })),
-        onDidRemovePanel: vi.fn(() => ({ dispose: vi.fn() })),
-        onDidActivePanelChange: vi.fn(() => ({ dispose: vi.fn() })),
-      })
-    }, [props.onReady])
-    return <div data-testid="mock-artifact-surface" />
-  }
-  MockArtifactSurfacePane.defaultAllowedPanels = [] as string[]
-  return { ArtifactSurfacePane: MockArtifactSurfacePane }
-})
 
 function renderSurface(
   storageKey?: string,
@@ -55,56 +28,81 @@ function renderSurface(
   )
 }
 
+function readStoredTabs(storageKey: string) {
+  const raw = localStorage.getItem(`${storageKey}:workspaceTabs`)
+  return raw ? JSON.parse(raw) as { tabs: Array<{ id: string; component: string; title: string }>; activeTab: string | null } : null
+}
+
 describe("SurfaceShell", () => {
   beforeEach(() => {
-    capturedSurfaceStorageKey = undefined
-    capturedAllowedPanels = undefined
-    mockAddPanel = vi.fn()
-    mockGetPanel = vi.fn(() => undefined)
     localStorage.clear()
   })
 
-  it("uses the workspace-scoped storage key for dockview pane persistence", () => {
-    renderSurface("boring-ui-v2:surface-shell:full-app:workspace-a")
+  it("persists workspace tabs under the workspace-scoped storage key", async () => {
+    let surface: SurfaceShellApi | undefined
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("chart", { title: "Chart", placement: "center", component: () => <div>Chart panel</div> })
 
-    expect(capturedSurfaceStorageKey).toBe("boring-ui-v2:surface-shell:full-app:workspace-a")
+    renderSurface("workspace-a", { onReady: (api) => { surface = api } }, panelRegistry)
+    await waitFor(() => expect(surface).toBeDefined())
+
+    act(() => {
+      surface?.openPanel({ id: "chart:gdp", component: "chart", title: "GDP" })
+    })
+
+    await waitFor(() => {
+      expect(readStoredTabs("workspace-a")?.tabs.map((tab) => tab.id)).toContain("chart:gdp")
+    })
+    expect(readStoredTabs("workspace-a")?.activeTab).toBe("chart:gdp")
   })
 
-  it("updates dockview pane persistence when the workspace storage key changes", () => {
-    const { rerender } = renderSurface("workspace-a")
-    expect(capturedSurfaceStorageKey).toBe("workspace-a")
+  it("restores persisted workspace tabs when remounted with the same storage key", async () => {
+    localStorage.setItem("workspace-a:workspaceTabs", JSON.stringify({
+      v: 1,
+      tabs: [{ id: "chart:gdp", component: "chart", title: "GDP", kind: "plugin", filetreeOpen: false }],
+      activeTab: "chart:gdp",
+    }))
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("chart", { title: "Chart", placement: "center", component: () => <div>Restored chart</div> })
+
+    renderSurface("workspace-a", {}, panelRegistry)
+
+    expect(await screen.findByRole("button", { name: "Activate GDP" })).toHaveAttribute("aria-pressed", "true")
+    expect(screen.getByText("Restored chart")).toBeInTheDocument()
+  })
+
+  it("switches to a different workspace tab set when the storage key changes", async () => {
+    localStorage.setItem("workspace-a:workspaceTabs", JSON.stringify({
+      v: 1,
+      tabs: [{ id: "chart:a", component: "chart", title: "A", kind: "plugin", filetreeOpen: false }],
+      activeTab: "chart:a",
+    }))
+    localStorage.setItem("workspace-b:workspaceTabs", JSON.stringify({
+      v: 1,
+      tabs: [{ id: "chart:b", component: "chart", title: "B", kind: "plugin", filetreeOpen: false }],
+      activeTab: "chart:b",
+    }))
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("chart", { title: "Chart", placement: "center", component: () => <div>Chart panel</div> })
+
+    const { rerender } = renderSurface("workspace-a", {}, panelRegistry)
+    expect(await screen.findByRole("button", { name: "Activate A" })).toBeInTheDocument()
 
     rerender(
-      <RegistryProvider panelRegistry={new PanelRegistry()} commandRegistry={new CommandRegistry()}>
+      <RegistryProvider panelRegistry={panelRegistry} commandRegistry={new CommandRegistry()} surfaceResolverRegistry={new SurfaceResolverRegistry()}>
         <SurfaceShell storageKey="workspace-b" />
       </RegistryProvider>,
     )
 
-    expect(capturedSurfaceStorageKey).toBe("workspace-b")
+    expect(await screen.findByRole("button", { name: "Activate B" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Activate A" })).not.toBeInTheDocument()
   })
 
-  it("updates allowed surface panels when a hot-loaded plugin panel registers after mount", async () => {
-    const panelRegistry = new PanelRegistry()
-    renderSurface("workspace-a", {}, panelRegistry)
-
-    expect(capturedAllowedPanels).not.toContain("hot-csv.panel")
-
-    act(() => {
-      panelRegistry.register("hot-csv.panel", {
-        title: "Hot CSV",
-        placement: "center",
-        component: () => null,
-      })
-    })
-
-    await waitFor(() => expect(capturedAllowedPanels).toContain("hot-csv.panel"))
-  })
-
-  it("routes file opens through the latest matching surface resolver before activating stale tabs", async () => {
+  it("routes file opens through the latest matching surface resolver before reusing stale file tabs", async () => {
     let surface: SurfaceShellApi | undefined
     const panelRegistry = new PanelRegistry()
-    panelRegistry.register("editor", { title: "Editor", placement: "center", component: () => null })
-    panelRegistry.register("hot-csv.panel", { title: "Hot CSV", placement: "center", component: () => null })
+    panelRegistry.register("editor", { title: "Editor", placement: "center", component: () => <div>Editor</div> })
+    panelRegistry.register("hot-csv.panel", { title: "Hot CSV", placement: "center", component: () => <div>CSV</div> })
     const surfaceResolverRegistry = new SurfaceResolverRegistry()
     surfaceResolverRegistry.register("filesystem", {
       source: "builtin",
@@ -118,47 +116,6 @@ describe("SurfaceShell", () => {
         ? { id: `hot-csv:${request.target}`, component: "hot-csv.panel", params: { path: request.target }, score: 100 }
         : undefined,
     })
-    mockGetPanel = vi.fn((id: string) => id === "file:data.csv"
-      ? { api: { setActive: vi.fn(), updateParameters: vi.fn() } }
-      : undefined,
-    )
-
-    renderSurface("workspace-a", { onReady: (api) => { surface = api } }, panelRegistry, surfaceResolverRegistry)
-    await waitFor(() => expect(surface).toBeDefined())
-
-    await act(async () => {
-      await surface?.openFile("data.csv")
-    })
-
-    expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({
-      id: "hot-csv:data.csv",
-      component: "hot-csv.panel",
-      params: expect.objectContaining({ path: "data.csv" }),
-    }))
-  })
-
-  it("routes openSurface path requests through the latest resolver before stale file tabs", async () => {
-    let surface: SurfaceShellApi | undefined
-    const panelRegistry = new PanelRegistry()
-    panelRegistry.register("editor", { title: "Editor", placement: "center", component: () => null })
-    panelRegistry.register("hot-csv.panel", { title: "Hot CSV", placement: "center", component: () => null })
-    const surfaceResolverRegistry = new SurfaceResolverRegistry()
-    surfaceResolverRegistry.register("filesystem", {
-      source: "builtin",
-      resolve: (request) => request.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND
-        ? { id: `file:${request.target}`, component: "editor", params: { path: request.target }, score: 0 }
-        : undefined,
-    })
-    surfaceResolverRegistry.register("hot-csv.surface", {
-      source: "plugin",
-      resolve: (request) => request.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND && request.target.endsWith(".csv")
-        ? { id: `hot-csv:${request.target}`, component: "hot-csv.panel", params: { path: request.target }, score: 100 }
-        : undefined,
-    })
-    mockGetPanel = vi.fn((id: string) => id === "file:data.csv"
-      ? { api: { setActive: vi.fn(), updateParameters: vi.fn() } }
-      : undefined,
-    )
 
     renderSurface("workspace-a", { onReady: (api) => { surface = api } }, panelRegistry, surfaceResolverRegistry)
     await waitFor(() => expect(surface).toBeDefined())
@@ -167,17 +124,11 @@ describe("SurfaceShell", () => {
       surface?.openSurface({ kind: WORKSPACE_OPEN_PATH_SURFACE_KIND, target: "data.csv" })
     })
 
-    expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({
-      id: "hot-csv:data.csv",
-      component: "hot-csv.panel",
-      params: expect.objectContaining({ path: "data.csv" }),
-    }))
+    await waitFor(() => expect(surface?.getSnapshot().activeTab).toBe("hot-csv:data.csv"))
+    expect(screen.getByRole("button", { name: "Activate data.csv" })).toBeInTheDocument()
   })
 
   it("renders a reachable close-workbench button as an overlay regardless of tab state", async () => {
-    // Regression: the close action used to live in dockview's right-header
-    // slot, which gets squeezed/hidden when exactly one tab is open. It is now
-    // an always-rendered overlay, so it must be present even with zero panels.
     renderSurface("workspace-a", { onClose: vi.fn() })
 
     expect(await screen.findByRole("button", { name: "Close workbench" })).toBeInTheDocument()
@@ -197,14 +148,14 @@ describe("SurfaceShell", () => {
       },
     })
 
-    expect(screen.getByLabelText("Workbench left pane")).toBeInTheDocument()
+    expect(screen.getByLabelText("Files")).toBeInTheDocument()
     await waitFor(() => expect(surface).toBeDefined())
 
     act(() => {
       surface?.closeWorkbenchLeftPane()
     })
 
-    expect(screen.queryByLabelText("Workbench left pane")).not.toBeInTheDocument()
-    expect(screen.getAllByRole("button", { name: "Show workspace menu" }).length).toBeGreaterThan(0)
+    expect(screen.queryByLabelText("Files")).not.toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: "Show file tree" }).length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary
- persist Pi chat transcripts on durable session roots for deployed vercel-sandbox apps
- stabilize remote Pi session option identity and remove package-local @ aliases that break local-package Vite consumers
- avoid chat-first public-shell flashes while auth is pending
- persist/restore SurfaceShell workspace tabs per workspace storage key

## Verification
- pnpm --filter @hachej/boring-agent exec vitest run src/front/chat/session/__tests__/usePiSessions.test.tsx
- pnpm --filter @hachej/boring-agent exec vitest run src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
- pnpm --filter @hachej/boring-core exec vitest run src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
- pnpm --filter @hachej/boring-core exec vitest run src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts --no-file-parallelism
- pnpm --filter @hachej/boring-workspace exec vitest run src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
- pnpm --filter @hachej/boring-agent run typecheck
- pnpm --filter @hachej/boring-core run typecheck
- pnpm --filter @hachej/boring-workspace run typecheck