### PR TITLE
Persist Pi sessions on durable host storage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ Detailed coding practices, workflow, architecture, and package docs live under `
 7. **Run relevant quality gates** before calling work done.
 8. **Never launch bare `bv`; use only `bv --robot-*`.**
 9. **Never edit `.beads/*.jsonl` by hand.** Use `br` commands.
-10. **Default communication mode:** caveman skill, full intensity, unless user says `stop caveman` or `normal mode`.
+10. **Session history is host app user data:** Pi chat transcripts/session lists are owned by the deployed core app host, not by the sandbox/workspace runtime. Store them on the host app's durable volume via `BORING_AGENT_SESSION_ROOT` (typically `/data/pi-sessions`), not in container home/root. If host-side `BORING_AGENT_WORKSPACE_ROOT=/data/workspaces`, keep the host session root as sibling `/data/pi-sessions` unless the user explicitly chooses another mounted volume.
+11. **Default communication mode:** caveman skill, full intensity, unless user says `stop caveman` or `normal mode`.
 
 ## Start here
 

--- a/packages/agent/docs/runtime.md
+++ b/packages/agent/docs/runtime.md
@@ -222,7 +222,9 @@ Those belong to the sandbox runtime root, `/workspace`.
 
 Production chat history also must not use the container root filesystem. Set
 `BORING_AGENT_SESSION_ROOT` to a mounted-volume path such as `/data/pi-sessions`
-so Pi wrapper/native transcripts survive Fly deploys and restarts.
+so Pi wrapper/native transcripts survive Fly deploys and restarts. Core-hosted
+apps that run `vercel-sandbox` with `BORING_AGENT_WORKSPACE_ROOT=/data/workspaces`
+default this to the sibling `/data/pi-sessions` path when the env var is absent.
 
 ## Adding a custom runtime mode
 

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
@@ -388,6 +388,25 @@ describe("PiSessionStore", () => {
     }
   });
 
+  it("lets hosts pass an explicit session root without mutating process env", async () => {
+    const previous = process.env.BORING_AGENT_SESSION_ROOT;
+    process.env.BORING_AGENT_SESSION_ROOT = join(tmpDir, "env-root");
+    try {
+      const store = new PiSessionStore("/workspace", {
+        sessionNamespace: "workspace-a",
+        sessionRoot: join(tmpDir, "explicit-root"),
+      });
+      expect(store.getSessionDir()).toBe(join(tmpDir, "explicit-root", "workspace-a"));
+
+      const session = await store.create(ctx, { title: "Explicit" });
+      await expect(readFile(join(tmpDir, "explicit-root", "workspace-a", `${session.id}.jsonl`), "utf-8"))
+        .resolves.toContain("Explicit");
+    } finally {
+      if (previous === undefined) delete process.env.BORING_AGENT_SESSION_ROOT;
+      else process.env.BORING_AGENT_SESSION_ROOT = previous;
+    }
+  });
+
   it("can store session files under host cwd while writing runtime cwd in session header", async () => {
     const store = new PiSessionStore("/workspace", { storageCwd: "/tmp/host-storage-root", sessionDir: tmpDir });
     const session = await store.create(ctx, { title: "Runtime cwd" });

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -347,6 +347,8 @@ export function createPiCodingAgentHarness(opts: {
   pi?: PiHarnessOptions;
   /** Optional stable namespace for file-backed session storage. */
   sessionNamespace?: string;
+  /** Optional explicit root for file-backed session directories. */
+  sessionRoot?: string;
   /** Optional explicit file-backed session directory. Mostly for tests/hosts. */
   sessionDir?: string;
   /** Optional best-effort telemetry sink supplied by an embedding host. */
@@ -362,6 +364,7 @@ export function createPiCodingAgentHarness(opts: {
   const pi = withPiHarnessDefaults(opts.pi);
   const sessionStore = new PiSessionStore(opts.runtimeCwd ?? opts.cwd, {
     sessionNamespace: opts.sessionNamespace,
+    sessionRoot: opts.sessionRoot,
     sessionDir: opts.sessionDir,
     storageCwd: opts.cwd,
   });

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -38,14 +38,16 @@ export interface PiSessionEntries {
   messages: unknown[];
 }
 
-function sessionBaseDir(): string {
+function sessionBaseDir(explicitRoot?: string): string {
+  const explicit = explicitRoot?.trim();
+  if (explicit) return resolve(explicit);
   const configured = getEnv(SESSION_ROOT_ENV)?.trim();
   return configured ? resolve(configured) : join(homedir(), ".pi", "agent", "sessions");
 }
 
-function defaultSessionDir(cwd: string): string {
+function defaultSessionDir(cwd: string, explicitRoot?: string): string {
   const safePath = `--${cwd.replace(/^[/\\]/, "").replace(/[/\\:]/g, "-")}--`;
-  return join(sessionBaseDir(), safePath);
+  return join(sessionBaseDir(explicitRoot), safePath);
 }
 
 const SAFE_ID = /^[a-zA-Z0-9_-]+$/;
@@ -70,12 +72,12 @@ interface NormalizedListOptions {
   includeId: string | undefined;
 }
 
-function sessionDirForNamespace(namespace: string): string {
+function sessionDirForNamespace(namespace: string, explicitRoot?: string): string {
   const safeNamespace = namespace.trim();
   if (!SAFE_SESSION_NAMESPACE.test(safeNamespace)) {
     throw new Error("session namespace must contain only letters, numbers, underscores, and dashes");
   }
-  return join(sessionBaseDir(), safeNamespace);
+  return join(sessionBaseDir(explicitRoot), safeNamespace);
 }
 
 function normalizeListOptions(options: SessionListOptions | undefined): NormalizedListOptions {
@@ -89,6 +91,8 @@ function normalizeListOptions(options: SessionListOptions | undefined): Normaliz
 export interface PiSessionStoreOptions {
   sessionDir?: string;
   sessionNamespace?: string;
+  /** Explicit root for file-backed session directories. Overrides BORING_AGENT_SESSION_ROOT. */
+  sessionRoot?: string;
   /** Host/storage cwd used only to derive the default file-backed session directory. */
   storageCwd?: string;
 }
@@ -107,8 +111,8 @@ export class PiSessionStore implements SessionStore {
     }
     this.sessionDir = options?.sessionDir
       ?? (options?.sessionNamespace
-        ? sessionDirForNamespace(options.sessionNamespace)
-        : defaultSessionDir(options?.storageCwd ?? cwd));
+        ? sessionDirForNamespace(options.sessionNamespace, options.sessionRoot)
+        : defaultSessionDir(options?.storageCwd ?? cwd, options?.sessionRoot));
   }
 
   getSessionDir(): string {

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -274,6 +274,8 @@ export interface RegisterAgentRoutesOptions {
     request?: FastifyRequest
   }) => PiHarnessOptions | undefined | Promise<PiHarnessOptions | undefined>
   sessionNamespace?: string
+  /** Optional explicit root for file-backed Pi chat transcript storage. */
+  sessionRoot?: string
   /** Optional best-effort telemetry sink supplied by an embedding host. */
   telemetry?: TelemetrySink
   /**
@@ -658,6 +660,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       tools,
       cwd: root,
       sessionNamespace: scope.sessionNamespace,
+      sessionRoot: opts.sessionRoot,
       systemPromptAppend: opts.systemPromptAppend,
       systemPromptDynamic: opts.getSystemPromptDynamic
         ? () => opts.getSystemPromptDynamic?.({ workspaceId, workspaceRoot: root })
@@ -830,6 +833,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
     if (cached) return cached
     const store = new PiSessionStore(scope.root, {
       sessionNamespace: scope.sessionNamespace,
+      sessionRoot: opts.sessionRoot,
       storageCwd: scope.root,
     })
     earlySessionStores.set(scope.key, store)

--- a/packages/agent/src/shared/harness.ts
+++ b/packages/agent/src/shared/harness.ts
@@ -10,6 +10,7 @@ export interface AgentHarnessFactoryInput {
   runtimeCwd?: string
   systemPromptAppend?: string
   sessionNamespace?: string
+  sessionRoot?: string
   sessionDir?: string
   /**
    * Optional dynamic system-prompt source. Harness calls it whenever it

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -265,7 +265,11 @@ test('core/full-app composition honors BORING_AGENT_WORKSPACE_ROOT for workspace
   })
 
   const previous = process.env.BORING_AGENT_WORKSPACE_ROOT
-  process.env.BORING_AGENT_WORKSPACE_ROOT = '/tmp/from-env-workspaces'
+  const previousSessionRoot = process.env.BORING_AGENT_SESSION_ROOT
+  const previousMode = process.env.BORING_AGENT_MODE
+  process.env.BORING_AGENT_WORKSPACE_ROOT = '/tmp/workspaces'
+  process.env.BORING_AGENT_SESSION_ROOT = '  '
+  process.env.BORING_AGENT_MODE = 'vercel-sandbox'
 
   try {
     const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
@@ -277,7 +281,8 @@ test('core/full-app composition honors BORING_AGENT_WORKSPACE_ROOT for workspace
 
     try {
       const options = (mocks.registerAgentRoutes as any).mock.calls.at(-1)?.[1] as Record<string, unknown>
-      expect(options.workspaceRoot).toBe('/tmp/from-env-workspaces')
+      expect(options.workspaceRoot).toBe('/tmp/workspaces')
+      expect(options.sessionRoot).toBe('/tmp/pi-sessions')
       expect(mocks.collectWorkspaceAgentServerPlugins).toHaveBeenCalledWith(expect.objectContaining({
         workspaceRoot: process.cwd(),
       }))
@@ -287,5 +292,9 @@ test('core/full-app composition honors BORING_AGENT_WORKSPACE_ROOT for workspace
   } finally {
     if (previous === undefined) delete process.env.BORING_AGENT_WORKSPACE_ROOT
     else process.env.BORING_AGENT_WORKSPACE_ROOT = previous
+    if (previousSessionRoot === undefined) delete process.env.BORING_AGENT_SESSION_ROOT
+    else process.env.BORING_AGENT_SESSION_ROOT = previousSessionRoot
+    if (previousMode === undefined) delete process.env.BORING_AGENT_MODE
+    else process.env.BORING_AGENT_MODE = previousMode
   }
 })

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -182,6 +182,18 @@ export interface CreateCoreWorkspaceAgentServerOptions
 
 type AgentPiOptions = RegisterAgentRoutesOptions['pi']
 
+function normalizeOptionalPath(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function inferSessionRootForWorkspaceRoot(workspaceRoot: string, runtimeMode: string | undefined): string | undefined {
+  if (runtimeMode !== 'vercel-sandbox') return undefined
+  const resolvedRoot = path.resolve(workspaceRoot)
+  if (path.basename(resolvedRoot) !== 'workspaces') return undefined
+  return path.join(path.dirname(resolvedRoot), 'pi-sessions')
+}
+
 export function resolveCoreLoadConfigOptions(
   options: Pick<
     CreateCoreWorkspaceAgentServerOptions,
@@ -690,6 +702,10 @@ export async function createCoreWorkspaceAgentServer(
     options.serveFrontend ?? (process.env.NODE_ENV !== 'development' && Boolean(appRoot))
   const pluginWorkspaceRoot = process.cwd()
   const workspaceRoot = options.workspaceRoot ?? process.env.BORING_AGENT_WORKSPACE_ROOT ?? process.cwd()
+  const agentRuntimeMode = options.runtimeModeAdapter?.id ?? options.mode ?? process.env.BORING_AGENT_MODE
+  const sessionRoot = normalizeOptionalPath(options.sessionRoot)
+    ?? normalizeOptionalPath(process.env.BORING_AGENT_SESSION_ROOT)
+    ?? inferSessionRootForWorkspaceRoot(workspaceRoot, agentRuntimeMode)
   registerTelemetryHooks(app, telemetry)
 
   await registerCoreRoutes({ app, sql, db, userStore, workspaceStore })
@@ -867,6 +883,7 @@ export async function createCoreWorkspaceAgentServer(
     systemPromptAppend: pluginCollection.agentOptions.systemPromptAppend,
     pi: pluginCollection.agentOptions.pi,
     getPi: resolvePiOptions,
+    sessionRoot,
     getSessionNamespace: resolveSessionNamespace,
     getExtraTools: async (ctx) => {
       const callerTools = options.getExtraTools ? await options.getExtraTools(ctx) : []


### PR DESCRIPTION
## Context
Macro chat history disappeared after deploy/restart because Pi transcript storage could fall back to a host-container default under home/root when no session root was configured. The session list/transcripts are host app user data, not sandbox data, so deployed core apps need an explicit durable host volume path.

## Changes
- Add `sessionRoot` plumbing from core server options/env through agent routes and the Pi harness session store.
- Infer `/data/pi-sessions` when core `vercel-sandbox` apps use `/data/workspaces` and no explicit session root is set.
- Document the host-owned durable session-root rule.

## Proof this fixes the bug
- New provisioning test verifies `/data/workspaces` infers `/data/pi-sessions`.
- Harness tests verify configured `sessionRoot` is passed to `PiSessionStore`.
- This moves transcript/session-list files from ephemeral container home/root to the durable host app volume.

## Verification
- `pnpm --filter @hachej/boring-agent exec vitest run src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts`
- `pnpm --filter @hachej/boring-core exec vitest run src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts --no-file-parallelism`
- `pnpm --filter @hachej/boring-agent run typecheck`
- `pnpm --filter @hachej/boring-core run typecheck`

## Thermo review
- Thermo-nuclear review: no blockers.
