### PR TITLE
Stabilize Pi front-end sessions for local packages

### DIFF
--- a/packages/agent/src/front/chat/piChatPanelHooks.ts
+++ b/packages/agent/src/front/chat/piChatPanelHooks.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import type { PiChatState } from './pi/piChatReducer'
 import { createRemotePiSession, type RemotePiSession, type RemotePiSessionOptions } from './pi/remotePiSession'
 import type { UsePiSessionsOptions } from './session'
@@ -25,13 +25,19 @@ export function useExternalRemotePiSession({
   remoteSessionOptions?: UsePiSessionsOptions['remoteSessionOptions']
 }): RemotePiSession | undefined {
   const [session, setSession] = useState<RemotePiSession | undefined>()
+  const remoteSessionOptionsRef = useRef(remoteSessionOptions)
+  remoteSessionOptionsRef.current = remoteSessionOptions
+  const remoteSessionOptionsKey = useMemo(
+    () => remoteSessionOptionsIdentity(remoteSessionOptions),
+    [remoteSessionOptions],
+  )
   useEffect(() => {
     if (!sessionId) {
       setSession(undefined)
       return
     }
     const next = (createRemoteSession ?? createRemotePiSession)({
-      ...remoteSessionOptions,
+      ...remoteSessionOptionsRef.current,
       sessionId,
       workspaceId,
       storageScope,
@@ -41,8 +47,44 @@ export function useExternalRemotePiSession({
     })
     setSession(next)
     return () => next.dispose()
-  }, [apiBaseUrl, createRemoteSession, fetch, remoteSessionOptions, requestHeaders, sessionId, storageScope, workspaceId])
+  }, [apiBaseUrl, createRemoteSession, fetch, remoteSessionOptionsKey, requestHeaders, sessionId, storageScope, workspaceId])
   return session
+}
+
+const remoteSessionOptionObjectIds = new WeakMap<object, number>()
+let remoteSessionOptionObjectSeq = 0
+function remoteSessionOptionObjectIdentity(value: unknown): string | undefined {
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) return undefined
+  const object = value as object
+  let id = remoteSessionOptionObjectIds.get(object)
+  if (!id) {
+    id = ++remoteSessionOptionObjectSeq
+    remoteSessionOptionObjectIds.set(object, id)
+  }
+  return String(id)
+}
+
+function remoteSessionOptionsIdentity(options: UsePiSessionsOptions['remoteSessionOptions']): string {
+  if (!options) return '{}'
+  return JSON.stringify({
+    autoStart: options.autoStart,
+    requestTimeoutMs: options.requestTimeoutMs,
+    onEvent: remoteSessionOptionObjectIdentity(options.onEvent),
+    storeOptions: remoteSessionOptionObjectIdentity(options.storeOptions),
+    setTimeoutFn: remoteSessionOptionObjectIdentity(options.setTimeoutFn),
+    clearTimeoutFn: remoteSessionOptionObjectIdentity(options.clearTimeoutFn),
+    reconnect: options.reconnect ? {
+      baseMs: options.reconnect.baseMs,
+      maxMs: options.reconnect.maxMs,
+      jitterRatio: options.reconnect.jitterRatio,
+      random: remoteSessionOptionObjectIdentity(options.reconnect.random),
+    } : undefined,
+    debug: options.debug ? {
+      largeStateWarningBytes: options.debug.largeStateWarningBytes,
+      largeStateWarningMessages: options.debug.largeStateWarningMessages,
+      onWarning: remoteSessionOptionObjectIdentity(options.debug.onWarning),
+    } : undefined,
+  })
 }
 
 export function useRemotePiSessionState(session: RemotePiSession | undefined): PiChatState | undefined {

--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
@@ -52,6 +52,7 @@ describe('usePiSessions', () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    window.localStorage.clear()
     fetchMock = vi.fn()
   })
 
@@ -79,6 +80,54 @@ describe('usePiSessions', () => {
       headers: { authorization: 'Bearer redacted', 'x-boring-storage-scope': 'scope-a' },
     })
     expect(persisted.values.get(activeSessionStorageKey('scope-a'))).toBe('pi-running')
+  })
+
+  test('does not dispose the active remote session when equal remote options are re-created by the host', async () => {
+    const remote = remoteFactory()
+    fetchMock.mockResolvedValue(jsonResponse([session('pi-running')]))
+
+    const { rerender } = renderHook(
+      ({ timeout }) => usePiSessions({
+        storageScope: 'scope-a',
+        fetch: fetchMock as unknown as typeof fetch,
+        createRemoteSession: remote.factory,
+        remoteSessionOptions: { requestTimeoutMs: timeout },
+      }),
+      { initialProps: { timeout: 60_000 } },
+    )
+
+    await waitFor(() => expect(remote.factory).toHaveBeenCalledTimes(1))
+
+    rerender({ timeout: 60_000 })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(remote.factory).toHaveBeenCalledTimes(1)
+    expect(remote.created[0]?.dispose).not.toHaveBeenCalled()
+  })
+
+  test('recreates the active remote session when callback remote options change', async () => {
+    const remote = remoteFactory()
+    fetchMock.mockResolvedValue(jsonResponse([session('pi-running')]))
+    const onEventA = vi.fn()
+    const onEventB = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ onEvent }) => usePiSessions({
+        storageScope: 'scope-a',
+        fetch: fetchMock as unknown as typeof fetch,
+        createRemoteSession: remote.factory,
+        remoteSessionOptions: { requestTimeoutMs: 60_000, onEvent },
+      }),
+      { initialProps: { onEvent: onEventA } },
+    )
+
+    await waitFor(() => expect(remote.factory).toHaveBeenCalledTimes(1))
+
+    rerender({ onEvent: onEventB })
+
+    await waitFor(() => expect(remote.factory).toHaveBeenCalledTimes(2))
+    expect(remote.created[0]?.dispose).toHaveBeenCalledTimes(1)
+    expect(remote.created[1]?.options.onEvent).toBe(onEventB)
   })
 
   test('loads the first session page before fetching older sessions on demand', async () => {

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -114,6 +114,12 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
   const loadedDataSourceRef = useRef(dataSourceKey)
   const requestScopeRef = useRef(requestScopeKey)
   requestScopeRef.current = requestScopeKey
+  const remoteSessionOptionsRef = useRef(options.remoteSessionOptions)
+  remoteSessionOptionsRef.current = options.remoteSessionOptions
+  const remoteSessionOptionsKey = useMemo(
+    () => remoteSessionOptionsIdentity(options.remoteSessionOptions),
+    [options.remoteSessionOptions],
+  )
 
   useEffect(() => {
     sessionsRef.current = sessions
@@ -301,7 +307,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     }
 
     const session = createRemoteSession({
-      ...options.remoteSessionOptions,
+      ...remoteSessionOptionsRef.current,
       sessionId: activeSessionId,
       workspaceId: options.workspaceId,
       storageScope,
@@ -313,7 +319,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     return () => {
       session.dispose()
     }
-  }, [activeSessionId, activeSessionKnown, apiBaseUrl, connectActiveSession, createRemoteSession, enabled, fetchImpl, options.remoteSessionOptions, options.workspaceId, requestHeaders, storageScope])
+  }, [activeSessionId, activeSessionKnown, apiBaseUrl, connectActiveSession, createRemoteSession, enabled, fetchImpl, remoteSessionOptionsKey, options.workspaceId, requestHeaders, storageScope])
 
   const create = useCallback(async (init?: PiSessionCreateInit): Promise<SessionSummary> => {
     if (!enabled) throw new Error('Pi sessions are disabled')
@@ -434,6 +440,42 @@ function toSessionSummary(value: unknown): SessionSummary {
 
 function canonicalPageCount(data: SessionSummary[]): number {
   return Math.min(data.length, SESSION_PAGE_SIZE)
+}
+
+const remoteSessionOptionObjectIds = new WeakMap<object, number>()
+let remoteSessionOptionObjectSeq = 0
+function remoteSessionOptionObjectIdentity(value: unknown): string | undefined {
+  if ((typeof value !== 'object' && typeof value !== 'function') || value === null) return undefined
+  const object = value as object
+  let id = remoteSessionOptionObjectIds.get(object)
+  if (!id) {
+    id = ++remoteSessionOptionObjectSeq
+    remoteSessionOptionObjectIds.set(object, id)
+  }
+  return String(id)
+}
+
+function remoteSessionOptionsIdentity(options: UsePiSessionsOptions['remoteSessionOptions']): string {
+  if (!options) return '{}'
+  return JSON.stringify({
+    autoStart: options.autoStart,
+    requestTimeoutMs: options.requestTimeoutMs,
+    onEvent: remoteSessionOptionObjectIdentity(options.onEvent),
+    storeOptions: remoteSessionOptionObjectIdentity(options.storeOptions),
+    setTimeoutFn: remoteSessionOptionObjectIdentity(options.setTimeoutFn),
+    clearTimeoutFn: remoteSessionOptionObjectIdentity(options.clearTimeoutFn),
+    reconnect: options.reconnect ? {
+      baseMs: options.reconnect.baseMs,
+      maxMs: options.reconnect.maxMs,
+      jitterRatio: options.reconnect.jitterRatio,
+      random: remoteSessionOptionObjectIdentity(options.reconnect.random),
+    } : undefined,
+    debug: options.debug ? {
+      largeStateWarningBytes: options.debug.largeStateWarningBytes,
+      largeStateWarningMessages: options.debug.largeStateWarningMessages,
+      onWarning: remoteSessionOptionObjectIdentity(options.debug.onWarning),
+    } : undefined,
+  })
 }
 
 function mergeSessions(...lists: SessionSummary[][]): SessionSummary[] {

--- a/packages/agent/src/front/primitives/artifact.tsx
+++ b/packages/agent/src/front/primitives/artifact.tsx
@@ -7,7 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { LucideIcon } from "lucide-react";
 import { XIcon } from "lucide-react";
 import type { ComponentProps, HTMLAttributes } from "react";

--- a/packages/agent/src/front/primitives/attachments.tsx
+++ b/packages/agent/src/front/primitives/attachments.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button, HoverCard, HoverCardContent, HoverCardTrigger } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { FileUIPart, SourceDocumentUIPart } from "ai";
 import {
   FileTextIcon,

--- a/packages/agent/src/front/primitives/code-block.tsx
+++ b/packages/agent/src/front/primitives/code-block.tsx
@@ -8,8 +8,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@hachej/boring-ui-kit";
-import { copyTextToClipboard } from "@/front/clipboard";
-import { cn } from "@/front/lib";
+import { copyTextToClipboard } from "../clipboard";
+import { cn } from "../lib";
 import { CheckIcon, CopyIcon } from "lucide-react";
 import type { ComponentProps, CSSProperties, HTMLAttributes } from "react";
 import {

--- a/packages/agent/src/front/primitives/conversation.tsx
+++ b/packages/agent/src/front/primitives/conversation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { UIMessage } from "ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
 import type { ComponentProps, ReactNode } from "react";

--- a/packages/agent/src/front/primitives/message.tsx
+++ b/packages/agent/src/front/primitives/message.tsx
@@ -7,7 +7,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";

--- a/packages/agent/src/front/primitives/prompt-input-wrappers.tsx
+++ b/packages/agent/src/front/primitives/prompt-input-wrappers.tsx
@@ -7,7 +7,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { ComponentProps, HTMLAttributes, ReactNode } from "react";
 import { Children } from "react";
 

--- a/packages/agent/src/front/primitives/prompt-input.tsx
+++ b/packages/agent/src/front/primitives/prompt-input.tsx
@@ -24,7 +24,7 @@ import {
   InputGroupTextarea,
 } from "@hachej/boring-ui-kit";
 import { Input, Spinner } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { ChatStatus, SourceDocumentUIPart } from "ai";
 import {
   CornerDownLeftIcon,

--- a/packages/agent/src/front/primitives/reasoning.tsx
+++ b/packages/agent/src/front/primitives/reasoning.tsx
@@ -6,7 +6,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";

--- a/packages/agent/src/front/primitives/shimmer.tsx
+++ b/packages/agent/src/front/primitives/shimmer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import type { MotionProps } from "motion/react";
 import { motion } from "motion/react";
 import type { CSSProperties, ElementType, JSX } from "react";

--- a/packages/agent/src/front/primitives/tool.tsx
+++ b/packages/agent/src/front/primitives/tool.tsx
@@ -8,7 +8,7 @@
  * without local invention.
  */
 import { Badge, Collapsible, CollapsibleContent, CollapsibleTrigger } from "@hachej/boring-ui-kit";
-import { cn } from "@/front/lib";
+import { cn } from "../lib";
 import {
   CheckCircleIcon,
   ChevronDownIcon,


### PR DESCRIPTION
## Context
Macro/local-package verification hit two frontend stability problems: re-created option objects could unnecessarily dispose/recreate the active Pi remote session, while `@/front/*` imports inside the agent package resolved through the consuming app's Vite alias and failed in boring-macro.

## Changes
- Use a stable identity for `remoteSessionOptions` so equivalent scalar options do not churn the active `RemotePiSession`.
- Include callback/object/timer options in that identity so real callback/store changes still recreate the session instead of going stale.
- Replace package-internal `@/front/*` imports in agent primitives with relative imports.

## Proof this fixes the bug
- New hook test proves equal re-created option objects do not dispose the active remote session.
- New hook test proves changing `onEvent` recreates the remote session, preventing stale callback regressions.
- Vite can now resolve `packages/agent/src/front/primitives/tool.tsx` through local-package imports because it no longer depends on the host app `@` alias.

## Verification
- `pnpm --filter @hachej/boring-agent exec vitest run src/front/chat/session/__tests__/usePiSessions.test.tsx`
- `pnpm --filter @hachej/boring-agent run typecheck`

## Thermo review
- Thermo-nuclear review: no blockers after fixing incomplete option identity.
