### PR TITLE
Guard chat-first shell while auth is pending

### DIFF
--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -196,6 +196,8 @@ function HomeRedirect<TSession extends WorkspaceAgentSession = WorkspaceAgentSes
     location.search,
     location.hash,
   )
+  if (session.isPending) return <>{resolvedLoadingFallback}</>
+
   if (!session.data?.user && chatEntryMode === 'chat-first') {
     return (
       <ChatFirstPublicShell
@@ -313,6 +315,8 @@ function WorkspaceRoute<
   )
 
   if (!workspaceId) return <>{resolvedLoadingFallback}</>
+
+  if (session.isPending) return <>{resolvedLoadingFallback}</>
 
   if (!session.data?.user && chatEntryMode === 'chat-first') {
     return (

--- a/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
+++ b/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
@@ -281,6 +281,19 @@ describe('CoreWorkspaceAgentFront', () => {
     })
   })
 
+  it('keeps chat-first public shell hidden while auth session is still loading', async () => {
+    const { CoreWorkspaceAgentFront } = await importSubject()
+    sessionState = { data: null, isPending: true }
+    currentWorkspaceId = null
+    routePath = '/workspace/workspace-a'
+
+    render(<CoreWorkspaceAgentFront chatEntryMode="chat-first" loadingFallback={<div>Checking session</div>} />)
+
+    expect(screen.getByText('Checking session')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Sign in' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-agent-front')).not.toBeInTheDocument()
+  })
+
   it('renders the regular workspace shell with sign-in chrome before auth', async () => {
     const { CoreWorkspaceAgentFront } = await importSubject()
     sessionState = { data: null, isPending: false }


### PR DESCRIPTION
## Context
In chat-first apps, the public unauthenticated shell could flash while Better Auth was still resolving the real session. That made signed-in users briefly see sign-in chrome/public state during route loads.

## Changes
- Gate both home and workspace chat-first public-shell branches behind `session.isPending`.
- Keep rendering the configured loading fallback until auth state is known.

## Proof this fixes the bug
- New test sets `session.isPending=true` with no user and verifies the loading fallback renders while the Sign in button and workspace shell do not.

## Verification
- `pnpm --filter @hachej/boring-core exec vitest run src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx`
- `pnpm --filter @hachej/boring-core run typecheck`

## Thermo review
- Thermo-nuclear review: no blockers.
