### PR TITLE
Guard surface layout hydration during plugin registration

### DIFF
--- a/packages/workspace/src/front/chrome/artifact-surface/ArtifactSurfacePane.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/ArtifactSurfacePane.tsx
@@ -23,43 +23,52 @@ interface StoredEnvelope {
   layout: SerializedLayout
 }
 
-// Read + validate a persisted layout. Returns undefined on any failure
-// (missing, parse error, version mismatch, panel referencing an unknown
-// component) so the caller falls back to a fresh layout. Filtering out
-// individual unknown panels would orphan the grid tree, so we drop the
-// whole layout if any one is invalid.
-function readStoredLayout(
+type StoredLayoutState =
+  | { status: "ready"; layout: SerializedLayout }
+  | { status: "blocked-by-allowed-panels" }
+  | { status: "empty" | "invalid" }
+
+// Read + validate a persisted layout. Malformed/stale payloads are invalid and
+// ignored. Layouts whose panel components are merely not registered/allowed yet
+// are treated as temporarily blocked so an early empty Dockview mount cannot
+// overwrite them before plugin registrations arrive.
+function readStoredLayoutState(
   key: string,
   allowed?: ReadonlySet<string>,
-): SerializedLayout | undefined {
-  if (typeof window === "undefined") return undefined
+): StoredLayoutState {
+  if (typeof window === "undefined") return { status: "empty" }
   let raw: string | null
   try {
     raw = window.localStorage.getItem(key)
   } catch {
-    return undefined
+    return { status: "empty" }
   }
-  if (!raw) return undefined
+  if (!raw) return { status: "empty" }
   let parsed: unknown
   try {
     parsed = JSON.parse(raw)
   } catch {
-    return undefined
+    return { status: "invalid" }
   }
-  if (!parsed || typeof parsed !== "object") return undefined
+  if (!parsed || typeof parsed !== "object") return { status: "invalid" }
   const envelope = parsed as Partial<StoredEnvelope>
-  if (envelope.v !== STORAGE_VERSION) return undefined
+  if (envelope.v !== STORAGE_VERSION) return { status: "invalid" }
   const layout = envelope.layout
-  if (!layout || typeof layout !== "object") return undefined
+  if (!layout || typeof layout !== "object") return { status: "invalid" }
   const panels = (layout as { panels?: unknown }).panels
-  if (!panels || typeof panels !== "object") return undefined
+  if (!panels || typeof panels !== "object") return { status: "invalid" }
   for (const entry of Object.values(panels as Record<string, unknown>)) {
-    if (!entry || typeof entry !== "object") return undefined
+    if (!entry || typeof entry !== "object") return { status: "invalid" }
     const comp = (entry as { contentComponent?: unknown }).contentComponent
-    if (typeof comp !== "string") return undefined
-    if (allowed && !allowed.has(comp)) return undefined
+    if (typeof comp !== "string") return { status: "invalid" }
+    if (allowed && !allowed.has(comp)) return { status: "blocked-by-allowed-panels" }
   }
-  return layout as SerializedLayout
+  return { status: "ready", layout: layout as SerializedLayout }
+}
+
+function layoutHasPanels(layout: SerializedLayout): boolean {
+  const panels = (layout as { panels?: unknown }).panels
+  return Boolean(panels && typeof panels === "object" && Object.keys(panels as Record<string, unknown>).length > 0)
 }
 
 export interface ArtifactSurfacePaneProps {
@@ -95,15 +104,26 @@ export function ArtifactSurfacePane({
   // new payload — without that, dockview consumes persistedLayout once on
   // its initial onReady and ignores subsequent changes.
   const allowedPanelsKey = allowedPanels?.slice().sort().join("\u0000") ?? "*"
-  const internalPersisted = useMemo(() => {
-    if (callerControlled) return undefined
-    return readStoredLayout(storageKey, allowedPanels ? new Set(allowedPanels) : undefined)
-  }, [allowedPanels, callerControlled, storageKey])
+  const allowedPanelSet = useMemo(
+    () => allowedPanels ? new Set(allowedPanels) : undefined,
+    [allowedPanels],
+  )
+  const internalLayoutState = useMemo(() => {
+    if (callerControlled) return { status: "empty" } as StoredLayoutState
+    return readStoredLayoutState(storageKey, allowedPanelSet)
+  }, [allowedPanelSet, callerControlled, storageKey])
+  const internalPersisted = internalLayoutState.status === "ready" ? internalLayoutState.layout : undefined
 
   const handleLayoutChange = useCallback(
     (layout: SerializedLayout) => {
       if (onLayoutChange) {
         onLayoutChange(layout)
+        return
+      }
+      if (
+        internalLayoutState.status === "blocked-by-allowed-panels" &&
+        !layoutHasPanels(layout)
+      ) {
         return
       }
       const envelope: StoredEnvelope = { v: STORAGE_VERSION, layout }
@@ -113,7 +133,7 @@ export function ArtifactSurfacePane({
         /* localStorage full / disabled — accept loss rather than block UI. */
       }
     },
-    [onLayoutChange, storageKey],
+    [internalLayoutState.status, onLayoutChange, storageKey],
   )
 
   if (!visible) return null

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/ArtifactSurfacePane.persistence.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/ArtifactSurfacePane.persistence.test.tsx
@@ -142,19 +142,50 @@ describe("ArtifactSurfacePane — layout persistence", () => {
     expect(capturedProps.persistedLayout).toBeUndefined()
   })
 
-  it("drops the layout when any panel's contentComponent isn't in allowedPanels", () => {
-    // A saved tab whose component was removed (or filtered out of this
-    // shell) would silently render an empty pane via dockview. Reject the
-    // whole layout so the user gets a fresh shell instead of a wedged one.
+  it("defers layout hydration when a panel is not allowed yet", () => {
     const layout = buildLayout([
       { id: "p1", component: "empty" },
-      { id: "p2", component: "removed-component" },
+      { id: "p2", component: "late-plugin" },
     ])
     localStorage.setItem(KEY, envelope(layout))
-    renderPane(
+    const { rerender } = renderPane(
       <ArtifactSurfacePane storageKey={KEY} allowedPanels={["empty"]} />,
     )
+
     expect(capturedProps.persistedLayout).toBeUndefined()
+    act(() => {
+      capturedProps.onLayoutChange?.(buildLayout([]))
+    })
+    expect(localStorage.getItem(KEY)).toBe(envelope(layout))
+
+    rerender(
+      <RegistryProvider
+        panelRegistry={(() => {
+          const r = new PanelRegistry()
+          r.register("empty", { title: "empty", component: DummyPanel })
+          r.register("late-plugin", { title: "late", component: DummyPanel })
+          return r
+        })()}
+        commandRegistry={new CommandRegistry()}
+      >
+        <ArtifactSurfacePane storageKey={KEY} allowedPanels={["empty", "late-plugin"]} />
+      </RegistryProvider>,
+    )
+
+    expect(capturedProps.persistedLayout).toEqual(layout)
+  })
+
+  it("still writes non-empty layouts while a stored layout is blocked by allowedPanels", () => {
+    const blocked = buildLayout([{ id: "p1", component: "late-plugin" }])
+    const replacement = buildLayout([{ id: "new", component: "empty" }])
+    localStorage.setItem(KEY, envelope(blocked))
+    renderPane(<ArtifactSurfacePane storageKey={KEY} allowedPanels={["empty"]} />)
+
+    act(() => {
+      capturedProps.onLayoutChange?.(replacement)
+    })
+
+    expect(localStorage.getItem(KEY)).toBe(envelope(replacement))
   })
 
   it("explicit persistedLayout prop wins over localStorage", () => {


### PR DESCRIPTION
## Context

PR #389 tried to preserve disappearing surface tabs by replacing the Dockview-backed `SurfaceShell`. Thermo review rejected that approach because it broke the real `PaneProps`/Dockview API contract and required unrelated bundle workarounds.

This PR restarts from latest `main` and keeps the existing owner/layer: `ArtifactSurfacePane` remains the only owner of Dockview layout persistence.

## Bug / root cause

A saved Dockview layout can reference app/plugin panels before those panels are present in `allowedPanels` during startup/hot registration. Before this PR, `ArtifactSurfacePane` treated that as an invalid layout and mounted Dockview empty. If Dockview then emitted an empty layout change, the empty layout overwrote the saved one, so tabs were lost.

## Changes

- Split stored-layout reads into explicit states:
  - `ready`
  - `blocked-by-allowed-panels`
  - `empty` / `invalid`
- Preserve valid stored layouts that are only temporarily blocked by `allowedPanels`.
- Skip empty layout writes while a stored layout is blocked by not-yet-registered allowed panels.
- Still allow non-empty writes to replace the blocked layout, so user-created layouts are not suppressed.
- Add regression tests for blocked hydration and non-empty replacement.

## Proof this fixes the bug

Applied the new regression test to unmodified `origin/main`; it failed because the empty layout overwrote the saved layout:

```text
ArtifactSurfacePane — layout persistence > defers layout hydration when a panel is not allowed yet
expected localStorage to remain the saved layout
received {"v":1,"layout":{"grid":{},"panels":{}}}
```

On this branch, the same test passes and then hydrates the saved layout once the previously missing panel is allowed.

## Verification

- `pnpm --filter @hachej/boring-workspace exec vitest run src/front/chrome/artifact-surface/__tests__/ArtifactSurfacePane.persistence.test.tsx`
- `pnpm --filter @hachej/boring-workspace exec vitest run src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx`
- `pnpm --filter @hachej/boring-workspace run typecheck`
- `pnpm --filter @hachej/boring-workspace build`

## Thermo review

- Plan thermo-review: no blockers.
- Implementation loop: no SurfaceShell rewrite, no fake Dockview API, no Vite config change, no new persistence owner.
