### PR TITLE
Fix first remote chat session connection

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1152,12 +1152,7 @@ export function WorkspaceAgentFront<
   }, [requestedAutoSubmitInitialDraft, workspaceId])
   const autoSubmittingInitialDraft = requestedAutoSubmitInitialDraft
   const delayAutoSubmitDraft = autoSubmittingInitialDraft && shouldUseRemoteSessions && !effectiveActiveSessionId
-  const freshEmptySessionActive = Boolean(
-    freshEmptySession
-      && freshEmptySession.workspaceId === workspaceId
-      && freshEmptySession.id === effectiveActiveSessionId,
-  )
-  const hydrateMessages = !freshEmptySessionActive && !autoSubmitHydrationDisabled && provisionWorkspace !== false && (
+  const hydrateMessages = !autoSubmitHydrationDisabled && provisionWorkspace !== false && (
     shouldUseRemoteSessions ? Boolean(effectiveActiveSessionId) : true
   )
   const handleWorkspaceWarmupStatusChange = useCallback((status: WorkspaceWarmupStatus) => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1805,6 +1805,6 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => expect(screen.getByTestId("chat-panel").textContent).toContain("created-empty-session"), { timeout: 3000 })
 
     expect(captured.some((props) => props.sessionId === "default")).toBe(false)
-    expect(captured.at(-1)?.hydrateMessages).toBe(false)
+    expect(captured.at(-1)?.hydrateMessages).toBe(true)
   })
 })


### PR DESCRIPTION
## Context

On a brand-new workspace, the shell auto-creates the first remote Pi session (`New chat session`). We were keeping the chat shell hidden until that session existed, but then passing `hydrateMessages=false` for that freshly-created empty session.

That disables the `RemotePiSession` auto-start / event-stream hydration path. The first user submit then has to open the stream at submit time before posting the prompt, which can appear as a dead first chat on cold deployed workspaces. Creating another chat works because the runtime/session stream is already warm.

## Changes

- Stop disabling chat hydration for the first auto-created empty remote session.
- Keep the existing transition guard that prevents rendering a fake/default session before creation completes.
- Update the regression expectation so the first real remote session hydrates/connects immediately.

## Verification

- `pnpm --filter @hachej/boring-workspace exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx -t "keeps the chat shell in transition until the first empty remote session is stable"`
- `pnpm --filter @hachej/boring-workspace exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx`
- `pnpm --filter @hachej/boring-workspace run typecheck`
