### PR TITLE
Connect first auto-created chat session

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -503,7 +503,6 @@ export function WorkspaceAgentFront<
     workspaceId,
     failed: false,
   }))
-  const [freshEmptySession, setFreshEmptySession] = useState<{ workspaceId: string; id: string } | null>(null)
   const chatPaneStorageKey = `boring-workspace:chat-panes:${workspaceId}`
   const [chatPaneState, setChatPaneState] = useState<ChatPaneState>(() =>
     (shellPersistenceEnabled ? readStoredChatPaneState(chatPaneStorageKey, workspaceId) : null)
@@ -802,7 +801,6 @@ export function WorkspaceAgentFront<
     suppressEmptyAutoCreateRef.current = false
     setInitialRemoteSessionCreating({ workspaceId, creating: false })
     setInitialRemoteSessionCreateFailed({ workspaceId, failed: false })
-    setFreshEmptySession(null)
   }, [workspaceId])
 
   useEffect(() => {
@@ -837,10 +835,6 @@ export function WorkspaceAgentFront<
     setInitialRemoteSessionCreating({ workspaceId, creating: true })
     setInitialRemoteSessionCreateFailed({ workspaceId, failed: false })
     void Promise.resolve(sessionApi.create({ title: defaultSessionTitle }))
-      .then((session) => {
-        const id = (session as { id?: unknown } | null | undefined)?.id
-        if (typeof id === "string") setFreshEmptySession({ workspaceId, id })
-      })
       .catch(() => {
         autoCreateSessionRef.current = false
         setInitialRemoteSessionCreating({ workspaceId, creating: false })

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1754,7 +1754,7 @@ describe("WorkspaceAgentFront", () => {
     }, { timeout: 3000 })
   })
 
-  it("keeps the chat shell in transition until the first empty remote session is stable", async () => {
+  it("connects the first auto-created empty remote session after the transition", async () => {
     const captured: CapturedChatPanelProps[] = []
     const CapturingChatPanel = (props: WorkspaceChatPanelProps) => {
       captured.push(props)


### PR DESCRIPTION
## Context

User reproduced the production bug after deleting every session and hard-refreshing: the first auto-created `New chat session` appears, but the first prompt does not respond. Creating another session still works.

Root cause: the shell still treated the freshly auto-created empty remote session as a special "do not hydrate" session. That passes `hydrateMessages=false` to `PiChatPanel`, which maps to `remoteSessionOptions.autoStart=false`, so the real first session never opens its event stream until another session path wakes things up.

## Changes

- Remove the `freshEmptySession` suppression path from `WorkspaceAgentFront`.
- Keep the existing transition while the initial session is being created, but once the real session id is active, hydrate/connect it immediately.
- Flip the regression expectation so the first auto-created empty remote session must render with `hydrateMessages=true`.

## Verification

- `pnpm exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx --testNamePattern "connects the first auto-created empty remote session|creates the first remote session"` from `packages/workspace`
- `pnpm --filter @hachej/boring-workspace typecheck`

Note: an earlier broad workspace test command accidentally ran the whole workspace suite; the target `WorkspaceAgentFront` assertions passed, with unrelated existing package-build/test-environment failures elsewhere. The scoped command above is the clean proof for this fix.
