### PR TITLE
Allow first prompt during empty chat hydration

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -149,6 +149,7 @@ export interface PiChatPanelProps<
   createRemoteSession?: (options: RemotePiSessionOptions) => RemotePiSession
   remoteSessionOptions?: UsePiSessionsOptions['remoteSessionOptions']
   hydrateMessages?: boolean
+  allowPromptDuringInitialHydration?: boolean
   workspaceWarmupStatus?: ChatPanelWorkspaceWarmupStatus
   onSessionReset?: () => void | Promise<void>
   onBeforeSubmit?: (draft: string, context: ChatSubmitContext) => false | void | boolean | Promise<false | void | boolean>
@@ -156,6 +157,7 @@ export interface PiChatPanelProps<
   onCommandResult?: (message: string) => void
   onComposerWarning?: (message: string) => void
   onMentionedFilesConsumed?: () => void
+  onPromptSubmitStarted?: (context: { sessionId: string; clientNonce: string }) => void
   onData?: (part: unknown) => void
   onOpenArtifact?: (path: string) => void
   composerBlockers?: TComposerBlocker[]
@@ -212,6 +214,7 @@ export function PiChatPanel<
   createRemoteSession,
   remoteSessionOptions,
   hydrateMessages = true,
+  allowPromptDuringInitialHydration = false,
   workspaceWarmupStatus,
   onSessionReset,
   onBeforeSubmit,
@@ -219,6 +222,7 @@ export function PiChatPanel<
   onCommandResult,
   onComposerWarning,
   onMentionedFilesConsumed,
+  onPromptSubmitStarted,
   onData,
   onOpenArtifact,
   composerBlockers = EMPTY_BLOCKERS,
@@ -725,6 +729,7 @@ export function PiChatPanel<
       mentionedFiles: effectiveMentionedFiles,
       getDraft: () => draftRef.current,
       onDraftChange: setComposerDraft,
+      allowPromptDuringInitialHydration,
       onPromptSubmitStarted: () => {
         markLocalSubmitted(activeChatSessionId)
       },
@@ -748,7 +753,7 @@ export function PiChatPanel<
         onMentionedFilesConsumed?.()
       },
     })
-  }, [activeChatSessionId, addLocalNotice, clearMentionedFiles, composerBlocked, composerBlockerLabel, effectiveMentionedFiles, markLocalSubmitted, onBeforeSubmit, onCommandResult, onComposerWarning, onMentionedFilesConsumed, openModelPicker, openThinkingPicker, registry, reloadAgentPlugins, resetSession, runPluginUpdate, selectComposerModel, selectComposerThinking, selectedModel, selectedPiSession, selectedThinking, setComposerDraft, submitThinkingControl, suppressPreSubmitCancelledWarning])
+  }, [activeChatSessionId, addLocalNotice, allowPromptDuringInitialHydration, clearMentionedFiles, composerBlocked, composerBlockerLabel, effectiveMentionedFiles, markLocalSubmitted, onBeforeSubmit, onCommandResult, onComposerWarning, onMentionedFilesConsumed, onPromptSubmitStarted, openModelPicker, openThinkingPicker, registry, reloadAgentPlugins, resetSession, runPluginUpdate, selectComposerModel, selectComposerThinking, selectedModel, selectedPiSession, selectedThinking, setComposerDraft, submitThinkingControl, suppressPreSubmitCancelledWarning])
 
   // Turn a rejected send (prompt/follow-up/auto-submit) into the single run-rejected
   // notice, carrying the stable server error code so a host can attach a recovery
@@ -795,6 +800,7 @@ export function PiChatPanel<
         dropLocalNotice(RUN_REJECTED_NOTICE_ID)
       }
       if (result.type === 'prompt' && activeChatSessionId) {
+        onPromptSubmitStarted?.({ sessionId: activeChatSessionId, clientNonce: result.clientNonce })
         if (shouldHoldLocalSubmitted(selectedPiSession, result.cursor)) markLocalSubmitted(activeChatSessionId)
         else clearLocalSubmitted(activeChatSessionId)
       }
@@ -809,7 +815,7 @@ export function PiChatPanel<
       surfaceRunRejected(error)
       return false
     }
-  }, [activeChatSessionId, clearLocalSubmitted, dropLocalNotice, markLocalSubmitted, policy, selectedPiSession, setComposerDraft, surfaceRunRejected])
+  }, [activeChatSessionId, clearLocalSubmitted, dropLocalNotice, markLocalSubmitted, onPromptSubmitStarted, policy, selectedPiSession, setComposerDraft, surfaceRunRejected])
 
   const editQueued = useCallback(() => {
     if (!policy) return
@@ -898,6 +904,7 @@ export function PiChatPanel<
         dropLocalNotice(RUN_REJECTED_NOTICE_ID)
       }
       if (result.type === 'prompt') {
+        onPromptSubmitStarted?.({ sessionId: activeSessionId, clientNonce: result.clientNonce })
         if (shouldHoldLocalSubmitted(selectedPiSession, result.cursor)) markLocalSubmitted(activeSessionId)
         else clearLocalSubmitted(activeSessionId)
       }
@@ -915,7 +922,7 @@ export function PiChatPanel<
       // of an inert generic error.
       surfaceRunRejected(error)
     })
-  }, [activeSessionId, autoSubmitInitialDraft, clearLocalSubmitted, composerBlocked, dropLocalNotice, initialDraft, markLocalSubmitted, onAutoSubmitInitialDraftAccepted, policy, selectedPiSession, setComposerDraft, settlePendingAutoSubmit, surfaceRunRejected])
+  }, [activeSessionId, autoSubmitInitialDraft, clearLocalSubmitted, composerBlocked, dropLocalNotice, initialDraft, markLocalSubmitted, onAutoSubmitInitialDraftAccepted, onPromptSubmitStarted, policy, selectedPiSession, setComposerDraft, settlePendingAutoSubmit, surfaceRunRejected])
 
   useEffect(() => {
     if (workspaceWarmupStatus?.status === 'ready') {
@@ -923,9 +930,20 @@ export function PiChatPanel<
     }
   }, [clearLocalNotice, workspaceWarmupStatus?.status])
 
+  const initialHydrationPromptAllowed = Boolean(
+    allowPromptDuringInitialHydration
+      && selectedChatState
+      && selectedChatState.status === 'hydrating'
+      && !selectedChatState.hydrated
+      && selectedChatState.history.messageCount === 0
+      && selectedChatState.committedMessages.length === 0
+      && selectedChatState.queue.followUps.length === 0
+      && Object.keys(selectedChatState.optimisticOutbox).length === 0
+      && !selectedChatState.streamingMessage,
+  )
   const disabled = !policy || sessionsLoading || composerBlocked
   const isStreaming = isPiBusyStatus(status)
-  const submitStatus = toPromptSubmitStatus(status)
+  const submitStatus = initialHydrationPromptAllowed ? 'ready' : toPromptSubmitStatus(status)
   const submitDisabled = !policy || sessionsLoading || (composerBlocked && !isStreaming)
   const mergedToolRenderers = useMemo(() => mergeShadcnToolRenderers(toolRenderers), [toolRenderers])
   const debugMessages = useMemo(() => messages.map(toDebugUiMessage), [messages])

--- a/packages/agent/src/front/chat/pi/__tests__/piChatReducer.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/piChatReducer.test.ts
@@ -80,6 +80,26 @@ describe('piChatReducer', () => {
     expect(state.notices).toContainEqual(expect.objectContaining({ id: 'stale-outbox-cleared', level: 'warning' }))
   })
 
+  it('preserves a first prompt submitted while the empty session snapshot is hydrating', () => {
+    let state = initial()
+    state = piChatReducer(state, { type: 'optimistic-user-message', message: optimistic('nonce-first', 'first message') })
+
+    state = piChatReducer(state, {
+      type: 'hydrate',
+      snapshot: snapshot({
+        seq: 1,
+        status: 'streaming',
+        activeTurnId: 'turn-first',
+        messages: [],
+        queue: { followUps: [] },
+      }),
+    })
+
+    expect(state).toMatchObject({ status: 'streaming', turnId: 'turn-first', hydrated: true })
+    expect(state.optimisticOutbox['nonce-first']).toEqual(expect.objectContaining({ clientNonce: 'nonce-first' }))
+    expect(state.notices.some((notice) => notice.id === 'stale-outbox-cleared')).toBe(false)
+  })
+
   it('does not let a reconnect hydration reset local history with a short snapshot', () => {
     let state = piChatReducer(initial(), {
       type: 'hydrate',

--- a/packages/agent/src/front/chat/pi/piChatReducer.ts
+++ b/packages/agent/src/front/chat/pi/piChatReducer.ts
@@ -221,13 +221,15 @@ function hydrateFromSnapshot(
     if (followUp.clientNonce) serverNonces.add(followUp.clientNonce)
   }
 
+  const preserveInitialOptimisticOutbox = shouldPreserveInitialOptimisticOutbox(state, snapshot, snapshotMessages)
+  const preserveOutbox = preserveLocalHistory || preserveInitialOptimisticOutbox
   const nextOutbox: Record<string, OptimisticUserMessage> = {}
-  if (preserveLocalHistory) {
+  if (preserveOutbox) {
     for (const message of Object.values(state.optimisticOutbox)) {
       if (!serverNonces.has(message.clientNonce)) nextOutbox[message.clientNonce] = message
     }
   }
-  const staleOutbox = preserveLocalHistory
+  const staleOutbox = preserveOutbox
     ? []
     : Object.values(state.optimisticOutbox).filter((message) => !serverNonces.has(message.clientNonce))
 
@@ -259,6 +261,17 @@ function hydrateFromSnapshot(
     hydrated: true,
     needsResync: undefined,
   }
+}
+
+function shouldPreserveInitialOptimisticOutbox(
+  state: PiChatState,
+  snapshot: PiChatSnapshot,
+  snapshotMessages: BoringChatMessage[],
+): boolean {
+  return !state.hydrated
+    && Object.keys(state.optimisticOutbox).length > 0
+    && snapshotMessages.length === 0
+    && snapshot.queue.followUps.length === 0
 }
 
 function shouldPreserveLocalCommittedHistory(

--- a/packages/agent/src/front/chat/pi/piFollowUpQueueController.ts
+++ b/packages/agent/src/front/chat/pi/piFollowUpQueueController.ts
@@ -38,6 +38,7 @@ export interface PiQueueControllerOptions {
   getDraft?: () => string
   onWarning?: (message: string) => void
   onPromptSubmitStarted?: (clientNonce: string) => void
+  allowPromptDuringInitialHydration?: boolean
 }
 
 export type PiQueueSubmitResult =
@@ -66,7 +67,11 @@ export class PiFollowUpQueueController {
     }
 
     const state = this.session.getState()
-    if (state.status === 'hydrating') {
+    if (state.status === 'hydrating' && !(this.options.allowPromptDuringInitialHydration === true && canPromptDuringInitialHydration(state))) {
+      return this.block('hydrating', 'The agent session is still hydrating.')
+    }
+
+    if (state.status === 'idle' && hasPendingOptimisticPromptInEmptySession(state)) {
       return this.block('hydrating', 'The agent session is still hydrating.')
     }
 
@@ -151,6 +156,22 @@ export function createPiFollowUpQueueController(
 
 export function isPiChatBusy(status: PiChatStatus): boolean {
   return status === 'submitted' || status === 'streaming' || status === 'aborting'
+}
+
+export function canPromptDuringInitialHydration(state: PiChatState): boolean {
+  return !state.hydrated
+    && state.history.messageCount === 0
+    && state.committedMessages.length === 0
+    && state.queue.followUps.length === 0
+    && Object.keys(state.optimisticOutbox).length === 0
+    && !state.streamingMessage
+}
+
+function hasPendingOptimisticPromptInEmptySession(state: PiChatState): boolean {
+  return state.hydrated
+    && state.history.messageCount === 0
+    && state.committedMessages.length === 0
+    && Object.values(state.optimisticOutbox).some((message) => message.clientSeq === undefined)
 }
 
 export function nextFollowUpClientSeq(state: PiChatState, floor = 1): number {

--- a/packages/agent/src/front/chat/session/__tests__/composerPolicy.test.ts
+++ b/packages/agent/src/front/chat/session/__tests__/composerPolicy.test.ts
@@ -152,6 +152,70 @@ describe('PiComposerPolicyController submit policy', () => {
     expect(session.prompts[0]?.displayMessage).toBe('Build it')
   })
 
+  it('allows the first prompt while an empty initial session is still hydrating', async () => {
+    const session = new FakeComposerSession('hydrating')
+    const policy = createPiComposerPolicyController({
+      session,
+      registry: createCommandRegistry(builtinCommands),
+      slashContext: context(),
+      createClientNonce: nonceFactory(),
+      allowPromptDuringInitialHydration: true,
+    })
+
+    await expect(policy.submit({ text: 'first message' })).resolves.toMatchObject({
+      type: 'prompt',
+      clientNonce: 'nonce-1',
+      preserveDraft: false,
+    })
+    expect(session.prompts).toEqual([expect.objectContaining({ message: 'first message', clientNonce: 'nonce-1' })])
+  })
+
+  it('blocks another prompt while the first hydrating prompt is still optimistic', async () => {
+    const session = new FakeComposerSession('idle')
+    session.state = {
+      ...session.state,
+      hydrated: true,
+      optimisticOutbox: {
+        'nonce-first': {
+          id: 'optimistic:nonce-first',
+          role: 'user',
+          status: 'pending',
+          clientNonce: 'nonce-first',
+          parts: [{ type: 'text', text: 'first message' }],
+        },
+      },
+    }
+    const policy = createPiComposerPolicyController({
+      session,
+      registry: createCommandRegistry(builtinCommands),
+      slashContext: context(),
+    })
+
+    await expect(policy.submit({ text: 'second message' })).resolves.toMatchObject({
+      type: 'blocked',
+      reason: 'hydrating',
+      preserveDraft: true,
+    })
+    expect(session.prompts).toEqual([])
+  })
+
+  it('keeps blocking submit while a non-empty session is hydrating', async () => {
+    const session = new FakeComposerSession('hydrating')
+    session.state = { ...session.state, history: { mode: 'full', messageCount: 1 } }
+    const policy = createPiComposerPolicyController({
+      session,
+      registry: createCommandRegistry(builtinCommands),
+      slashContext: context(),
+    })
+
+    await expect(policy.submit({ text: 'too soon' })).resolves.toMatchObject({
+      type: 'blocked',
+      reason: 'hydrating',
+      preserveDraft: true,
+    })
+    expect(session.prompts).toEqual([])
+  })
+
   it('does not consume mentioned files when the remote prompt fails before acceptance', async () => {
     const session = new FakeComposerSession('idle')
     session.prompt = vi.fn(async (payload: PromptPayload) => {

--- a/packages/agent/src/front/chat/session/composerPolicy.ts
+++ b/packages/agent/src/front/chat/session/composerPolicy.ts
@@ -49,6 +49,7 @@ export interface PiComposerPolicyOptions extends PiQueueControllerOptions {
   onBeforeSubmit?: (draft: string, context: { files: PromptInputFilePart[]; source: PiComposerSubmitInput['source'] }) => boolean | Promise<boolean>
   onCommandResult?: (message: string) => void
   onMentionedFilesConsumed?: () => void
+  allowPromptDuringInitialHydration?: boolean
 }
 
 export type PiComposerBlockedReason =

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -61,6 +61,7 @@ export interface WorkspaceAgentSessionsApi<
   create: (input?: { title?: string }) => void | Promise<unknown>
   delete: (id: string) => void | Promise<unknown>
   loadMore?: () => void | Promise<unknown>
+  refresh?: (options?: { background?: boolean }) => void | Promise<unknown>
 }
 
 export type UseWorkspaceAgentSessions<
@@ -1010,6 +1011,27 @@ export function WorkspaceAgentFront<
     for (const session of resolvedSessions) titles.set(session.id, session.title)
     return titles
   }, [resolvedSessions])
+  const [initialHydrationPromptStarted, setInitialHydrationPromptStarted] = useState<{ workspaceId: string; ids: Set<string> }>(() => ({
+    workspaceId,
+    ids: new Set(),
+  }))
+  const emptySessionIds = useMemo(() => {
+    const ids = new Set<string>()
+    if (!remoteSessionsAvailable) return ids
+    const startedIds = initialHydrationPromptStarted.workspaceId === workspaceId
+      ? initialHydrationPromptStarted.ids
+      : new Set<string>()
+    for (const session of activeRemoteSessions) {
+      if (session.turnCount === 0 && !startedIds.has(session.id)) ids.add(session.id)
+    }
+    return ids
+  }, [activeRemoteSessions, initialHydrationPromptStarted, remoteSessionsAvailable, workspaceId])
+
+  useEffect(() => {
+    setInitialHydrationPromptStarted((current) => (
+      current.workspaceId === workspaceId ? current : { workspaceId, ids: new Set() }
+    ))
+  }, [workspaceId])
 
   const activeChatPaneState = chatPaneState.workspaceId === workspaceId
     ? chatPaneState
@@ -1215,6 +1237,21 @@ export function WorkspaceAgentFront<
       extraCommands,
       workspaceWarmupStatus,
       hydrateMessages,
+      allowPromptDuringInitialHydration: emptySessionIds.has(sessionId),
+      onPromptSubmitStarted: ({ sessionId: submittedSessionId }: { sessionId: string; clientNonce: string }) => {
+        setInitialHydrationPromptStarted((current) => {
+          const currentIds = current.workspaceId === workspaceId ? current.ids : new Set<string>()
+          if (currentIds.has(submittedSessionId)) return current.workspaceId === workspaceId ? current : { workspaceId, ids: currentIds }
+          const ids = new Set(currentIds)
+          ids.add(submittedSessionId)
+          return { workspaceId, ids }
+        })
+      },
+      onTurnComplete: () => {
+        void sessionApi?.refresh?.({ background: true })
+        const existing = chatParams?.onTurnComplete
+        if (typeof existing === "function") existing()
+      },
       onAutoSubmitInitialDraftSettled: () => {
         autoSubmitSessionCreateRef.current = false
         setAutoSubmitHydrationDisabled(false)
@@ -1228,7 +1265,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [apiBaseUrl, chatParams, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, workspaceId],
+    [apiBaseUrl, chatParams, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, sessionApi, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionId),

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -14,6 +14,7 @@ type CapturedChatPanelProps = WorkspaceChatPanelProps & {
   initialDraft?: string
   autoSubmitInitialDraft?: boolean
   hydrateMessages?: boolean
+  allowPromptDuringInitialHydration?: boolean
   onAutoSubmitInitialDraftSettled?: () => void
 }
 
@@ -1806,5 +1807,6 @@ describe("WorkspaceAgentFront", () => {
 
     expect(captured.some((props) => props.sessionId === "default")).toBe(false)
     expect(captured.at(-1)?.hydrateMessages).toBe(true)
+    expect(captured.at(-1)?.allowPromptDuringInitialHydration).toBe(true)
   })
 })


### PR DESCRIPTION
## Context

Production still reproduces after deleting the last session, letting the shell auto-create a new empty session, then hard-refreshing: the visible empty session can remain in the RemotePi `hydrating` state and the composer silently refuses the first prompt as "session still hydrating".

That guard is correct for non-empty sessions, but too strict for a brand-new empty session: there is no prior transcript or in-flight queue to protect, and `RemotePiSession.prompt()` can start/post the run safely.

## Changes

- Allow a prompt while status is `hydrating` only when the session is clearly an unhydrated, empty initial state:
  - no committed messages
  - history count is zero
  - no queued follow-ups
  - no optimistic outbox
  - no streaming message
- Keep the hydrating block for non-empty sessions.
- Add regression coverage for both allowed first prompt and still-blocked non-empty hydration.

## Verification

- `pnpm exec vitest run src/front/chat/session/__tests__/composerPolicy.test.ts` from `packages/agent`
- `pnpm --filter @hachej/boring-agent typecheck`
