### PR TITLE
docs: add local signoff workflow

### DIFF
--- a/docs/kanzen/README.md
+++ b/docs/kanzen/README.md
@@ -26,6 +26,8 @@ Read:
   [`procedures/repo-commands.md`](procedures/repo-commands.md).
 - Trunk/flag/review budget procedure:
   [`procedures/trunk-flags-review-budget.md`](procedures/trunk-flags-review-budget.md).
+- Local proof/signoff workflow:
+  [`procedures/local-signoff.md`](procedures/local-signoff.md).
 - Plan files live under `../issues/<issue-number>/`; see
   [`procedures/issue-plans.md`](procedures/issue-plans.md).
 - Visual owner handoffs use `visual-explainer` plus a thin ask-user-style

--- a/docs/kanzen/procedures/local-signoff.md
+++ b/docs/kanzen/procedures/local-signoff.md
@@ -1,0 +1,107 @@
+# Local Signoff Workflow
+
+Use local signoff to make handoffs cheap without turning GitHub Actions into the only source of proof.
+
+Remote CI still owns machine-verifiable release/deploy artifacts. Local signoff owns developer proof on the exact commit SHA.
+
+## Model
+
+| Gate | Owner | Purpose |
+| --- | --- | --- |
+| `PR Fast Summary` | GitHub Actions | Remote routing gate for changed/full checks. |
+| `signoff/local` | Developer or agent | Local proof passed on this exact commit. |
+| Optional `signoff/*` | Developer, agent, reviewer, owner | Per-PR proof such as `thermo`, `visual`, `self-host`, or `deploy`. |
+
+Only `signoff/local` should be considered for a global branch-protection requirement. Specialized signoffs are per-issue/per-PR proof and should be requested in the PR body, proof comment, or Kanzen gate fields.
+
+Do **not** run `gh signoff install` blindly: it can rewrite branch protection required checks. Update required checks manually or through a reviewed GitHub ruleset change.
+
+## Setup
+
+Install the GitHub CLI extension once:
+
+```bash
+gh extension install basecamp/gh-signoff
+```
+
+The extension creates GitHub commit statuses named `signoff/<name>` on the current HEAD.
+
+## Normal local proof
+
+Run the repo's changed-workflow checks:
+
+```bash
+pnpm signoff:local
+```
+
+That script runs:
+
+- `pnpm lint`
+- `pnpm typecheck:changed`
+- `pnpm test:changed`
+- `gh signoff local`
+
+The signoff attaches to the current commit SHA. If a later commit changes the PR, the previous signoff is stale and must be rerun.
+
+## Full local proof
+
+Use this before release-candidate or broad/high-risk PRs:
+
+```bash
+pnpm signoff:full
+```
+
+That script runs `pnpm ci` and then signs off `local` and `full`.
+
+## Self-host proof
+
+Use this for self-host deployment changes:
+
+```bash
+pnpm signoff:self-host
+```
+
+That script runs self-host manifest/action-pin checks and signs off `self-host`.
+
+## Handoff comment
+
+When handing work to another agent or owner, include:
+
+```md
+## Handoff
+
+Branch: <branch>
+Commit: <sha>
+Scope: <what changed>
+
+Proof:
+- pnpm signoff:local ✅
+- optional: pnpm signoff:self-host ✅
+- manual smoke: <url/check> ✅
+
+Signoffs:
+- signoff/local ✅ on <sha>
+- optional signoff/self-host ✅ on <sha>
+
+Remaining:
+- <next action or blocker>
+```
+
+The next agent should run:
+
+```bash
+gh signoff status
+```
+
+If the current commit has changed or required proof is missing, rerun the relevant signoff script before declaring ready.
+
+## Branch protection recommendation
+
+For normal PRs, prefer requiring:
+
+```text
+PR Fast Summary
+signoff/local
+```
+
+Avoid requiring path-filtered jobs directly when they may be skipped by design. Keep production deploy gates separate: protected `prod-*` tags, GHCR image build, manifest verification, attestation verification, and Kamal/deployd deploy.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "release:minor": "node scripts/release.mjs minor",
     "release:major": "node scripts/release.mjs major",
     "build:packages": "pnpm -r --filter './packages/*' --filter './plugins/*' --workspace-concurrency=4 run build",
-    "typecheck:changed": "node scripts/typecheck-changed-workspaces.mjs"
+    "typecheck:changed": "node scripts/typecheck-changed-workspaces.mjs",
+    "signoff:local": "bash scripts/signoff-local.sh",
+    "signoff:full": "bash scripts/signoff-full.sh",
+    "signoff:self-host": "bash scripts/signoff-self-host.sh"
   },
   "packageManager": "pnpm@10.33.2",
   "engines": {

--- a/scripts/signoff-full.sh
+++ b/scripts/signoff-full.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! gh extension list | grep -q '^gh-signoff\b'; then
+  echo "gh-signoff is not installed. Run: gh extension install basecamp/gh-signoff" >&2
+  exit 1
+fi
+
+pnpm ci
+
+gh signoff local full

--- a/scripts/signoff-local.sh
+++ b/scripts/signoff-local.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! gh extension list | grep -q '^gh-signoff\b'; then
+  echo "gh-signoff is not installed. Run: gh extension install basecamp/gh-signoff" >&2
+  exit 1
+fi
+
+pnpm lint
+pnpm typecheck:changed
+pnpm test:changed
+
+gh signoff local

--- a/scripts/signoff-self-host.sh
+++ b/scripts/signoff-self-host.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! gh extension list | grep -q '^gh-signoff\b'; then
+  echo "gh-signoff is not installed. Run: gh extension install basecamp/gh-signoff" >&2
+  exit 1
+fi
+
+bash scripts/check-action-pins.sh .github/workflows
+
+if [[ ! -f scripts/self-host/verify-deploy-manifest.test.mjs ]]; then
+  echo "scripts/self-host/verify-deploy-manifest.test.mjs is missing; self-host signoff is only available on branches that include self-host deployment tooling." >&2
+  exit 1
+fi
+node --test scripts/self-host/verify-deploy-manifest.test.mjs
+
+gh signoff self-host


### PR DESCRIPTION
## Summary
- document the local signoff handoff model for Kanzen
- add pnpm helpers for local/full/self-host signoff
- link the procedure from Kanzen docs

## Notes
- does not change branch protection automatically
- recommends requiring PR Fast Summary + signoff/local manually

## Validation
- python3 -m json.tool package.json
- bash -n scripts/signoff-local.sh scripts/signoff-full.sh scripts/signoff-self-host.sh
- git diff --check