### PR TITLE
docs: add issue 391 runtime refactor plan pack

### DIFF
--- a/docs/issues/391/plan.md
+++ b/docs/issues/391/plan.md
@@ -1,0 +1,18 @@
+# Boring Bash agent/runtime refactor
+
+This plan is now split into a plan pack.
+
+Canonical source: [`docs/plans/boring-bash-agent-runtime-refactor/README.md`](boring-bash-agent-runtime-refactor/README.md)
+
+Preserved monolithic source snapshot: [`docs/plans/boring-bash-agent-runtime-refactor/legacy-monolith-source.md`](boring-bash-agent-runtime-refactor/legacy-monolith-source.md)
+
+## Files
+
+1. [`00-global-isa.md`](boring-bash-agent-runtime-refactor/00-global-isa.md) — global intent, lessons, destination.
+2. [`01-agent-core-runtime-free.md`](boring-bash-agent-runtime-refactor/01-agent-core-runtime-free.md) — pure runtime-free agent core.
+3. [`02-boring-bash-environment.md`](boring-bash-agent-runtime-refactor/02-boring-bash-environment.md) — boring-bash package, providers, file/bash/source-of-truth.
+4. [`03-policy-provisioning-readiness.md`](boring-bash-agent-runtime-refactor/03-policy-provisioning-readiness.md) — policy, provisioning, readiness, secrets, services.
+5. [`04-plugin-child-app-runtime.md`](boring-bash-agent-runtime-refactor/04-plugin-child-app-runtime.md) — plugins, hosted runtimes, child apps/Macro.
+6. [`05-multi-agent-sessions-hooks.md`](boring-bash-agent-runtime-refactor/05-multi-agent-sessions-hooks.md) — multi-agent workspaces, sessions, hooks.
+7. [`06-migration-phases.md`](boring-bash-agent-runtime-refactor/06-migration-phases.md) — dependency-ordered migration phases.
+8. [`07-tests-review-acceptance.md`](boring-bash-agent-runtime-refactor/07-tests-review-acceptance.md) — tests, review gates, acceptance.

--- a/docs/issues/391/runtime-refactor/00-global-isa.md
+++ b/docs/issues/391/runtime-refactor/00-global-isa.md
@@ -1,0 +1,131 @@
+# 00 — Global ISA: intent, strategy, architecture
+
+ISA here means **Intent, Strategy, Architecture**.
+
+## Intent
+
+Make boring-ui support true headless agents while preserving the coding-agent workspace experience.
+
+Today `@hachej/boring-agent` is too coupled to `Workspace + Sandbox + FileSearch`. We want:
+
+- pure/headless agents with no filesystem, no sandbox, no cwd, no file routes, no bash tools;
+- optional working environments for coding/file tasks through `@hachej/boring-bash`;
+- multiple agent personalities/runtimes inside one deployed app and one workspace;
+- child apps such as Macro hosted inside the same full-app deployment without leaking tools/prompts/provisioning into generic workspaces.
+
+## Target package ownership
+
+| Package | Owns | Must not own |
+| --- | --- | --- |
+| `@hachej/boring-agent` | model loop, sessions, runner API, tool registry, channel-neutral event stream, non-bash operational hooks, provisioning engine types/orchestration by injected adapter | filesystem, file routes, bash, file UI, concrete sandbox providers, bash requirement normalization |
+| `@hachej/boring-bash` | optional fs + exec working environment, path safety, search/watch, file routes, file/bash/upload tools, file UI, bash requirement normalizer, provider adapters/capabilities | auth, billing, app membership, LLM harness core, provisioning engine ownership |
+| `@hachej/boring-workspace` | UI shell, layout, plugin host, UI bridge/RPC, surface registry | agent model loop, concrete bash providers |
+| `@hachej/boring-core` / app composition layer | auth, DB, workspaces, child-app context resolution, billing, deployment composition; final child-app registry location follows the shared child-app plan | concrete bash provider internals |
+
+Non-negotiable: `@hachej/boring-agent` has **zero value imports** from `@hachej/boring-bash`. Bash is injected by host/CLI/composition.
+
+Provisioning ownership rule: the existing provisioning engine and `ProvisionWorkspaceRuntimeOptions` stay in agent/server as type-safe orchestration over an injected provisioning adapter. `@hachej/boring-bash` owns bash requirement normalization and concrete provider adapters. The host/core/CLI wires the two together. Agent must never import concrete bash providers.
+
+## What we learned from Flue
+
+- `SessionEnv` is the key seam: file tools, programmatic fs, shell, grep/glob all share one backing environment.
+- Conversation/session durability does not imply sandbox/file durability.
+- Durable submissions need stable environment identity and conservative recovery.
+- Subagent profiles are useful for cheap delegation but normally share parent environment; they are not enough for isolated agent sandboxes.
+- Default fs/bash tools are too powerful for our target. Boring-agent must default to none.
+- Transcript-visible shell operations and out-of-band host fs plumbing are different contracts.
+
+## What we learned from eve
+
+- Filesystem-discovered slots are excellent DX: `agent.ts`, `instructions.md`, `tools/*`, `skills/*`, `subagents/*`, `channels/*`, `connections/*`, `sandbox/workspace/**`.
+- Discovery should be import-free; compile/runtime can reattach live exports later.
+- Path-derived names avoid drift.
+- Authored tools/routes can override or disable framework defaults.
+- Declared subagents as separate runtime nodes are the right model for different sandbox/tool policies.
+- Sandbox lifecycle should separate reusable template/bootstrap from live session setup.
+- `/workspace` as one model-visible namespace prevents split brain.
+- Read-before-write/stale-write stamps are worth stealing for model-facing file edits.
+- Provider labels are insufficient; a capability matrix must say real bash, real binaries, network isolation, and persistence semantics.
+
+## Direction
+
+Build one platform with three clean layers:
+
+```txt
+Agent core       model/session/tool loop; no implicit runtime
+Feature layer    optional UI, bash, web, plugin, approval, search capabilities
+Runtime layer    concrete storage/sandbox/provider implementation
+```
+
+Then one deployed app can host:
+
+- generic Seneca coding workspaces;
+- Macro child-app workspaces;
+- concierge/support agents with no files;
+- reviewers with readonly files and no shell;
+- coding agents with full bash;
+- hosted iframe plugins with no backend code;
+- trusted internal plugins with explicit server/runtime requirements.
+
+## Current seams to reuse, not replace
+
+This repo already has real seams. The refactor must extend them:
+
+- `disableDefaultFileTools`;
+- `buildHarnessAgentTools()` for `bash` / `execute_isolated_code`;
+- `buildFilesystemAgentTools()` for `read/write/edit/find/grep/ls`;
+- `buildUploadAgentTools()`;
+- `workspaceFsCapability` on runtime modes;
+- `RuntimeBundle.storageRoot`, `Workspace.root`, `WorkspaceRuntimeContext.runtimeCwd`, and `getRuntimeBundleStorageRoot()`;
+- `provisionWorkspaceRuntime()` with merge-by-id, fingerprint skipping, and `WorkspaceProvisioningResult.changed`;
+- `RuntimeDependencyReadiness`, `ReadyStatusTracker`, and `mergeTools({ checkReadiness })`;
+- `registerCapabilitiesContributor`;
+- workspace-owned `/api/v1/ui/*`, `exec_ui`, `get_ui_state`, `WorkspaceBridge`, and `/api/v1/plugins/:pluginId/*`.
+
+## Non-negotiable invariants
+
+1. Pure agents run without `Workspace`, `Sandbox`, cwd, file routes, or bash tools.
+2. Bash and file APIs are optional and live in `@hachej/boring-bash`.
+3. File routes/search/watch/bash/git/status must use the same source of truth.
+4. Partial file exposure with shell is physical: mount/seed only allowed files for untrusted exec.
+5. Session history durability and file/workspace durability are separate.
+6. Plugins/agents declare requirements; hosts resolve and intersect policy. No silent widening.
+7. Provider fallback is policy-driven. Never silently downgrade isolation or capability.
+8. Child-app/workspace-kind policy can narrow defaults and requirements.
+9. Users are principals/supervisors/approval channels, not model-callable root agents.
+10. Open backlog issues are not automatically solved; the abstraction only supplies the spine.
+
+## Issue coverage posture
+
+Do not overclaim. This abstraction directly owns #391 and materially advances parts of other issues only when their acceptance criteria land.
+
+Materially advanced by this plan:
+
+- #12 harness pluggability, if pure runtime-free harness acceptance passes;
+- #242 app assembler / route composition, if dependency injection lands;
+- #16 and #223 runtime/provider abstraction, if provider capability matrix lands;
+- #26, #220, #221 file API/UI ownership, if file routes/tools/UI move;
+- #357, #254, #256 plugin/runtime capability declaration, if plugin validation/runtime context lands;
+- #243, #211 multi-agent/session scoping foundations, if route/session/search work lands.
+
+Explicitly not fully solved but must be supported by extension points:
+
+- #376 child-app platform / Macro hosted in full-app;
+- #380 external harness hooks;
+- #379 session-history search;
+- #307 remote-worker hardening;
+- #181 secrets;
+- #328/#258 managed plugin services;
+- #295 file tree replacement;
+- #367/#226 document-authoritative collaboration;
+- #189 git/source-of-truth consistency;
+- #371/#228/#224 provider recovery and operational commands.
+
+## Open decisions before implementation
+
+1. Is pure/headless mode implemented through pi-coding-agent with cwd disabled/sealed, or a separate non-pi harness? This decision blocks Phase 1 exit.
+2. Is arbitrary multi-mount/overlay support v1, or do we preserve one `/workspace` view and defer advanced projections? If deferred, public shapes must mark `mounts` as internal/future.
+3. Do providers live under `@hachej/boring-bash/providers` forever, or move to a private provider package later?
+4. Multi-agent route shape: path prefix `/api/v1/agents/:agentId` or header/request-scope equivalent?
+5. Provisioning sharing defaults: workspace-shared, agent-private, or requirement-controlled?
+6. Readonly fs in v1 or deferred?

--- a/docs/issues/391/runtime-refactor/01-agent-core-runtime-free.md
+++ b/docs/issues/391/runtime-refactor/01-agent-core-runtime-free.md
@@ -1,0 +1,182 @@
+# 01 — Runtime-free `@hachej/boring-agent`
+
+## Goal
+
+Make `@hachej/boring-agent` a model/session/tool harness that can run with no filesystem and no sandbox.
+
+A pure agent must be valid for Slack/email/support/concierge/research workflows where the only state is session history plus app-owned tools.
+
+## Current blocker
+
+The agent server composition still assumes a runtime bundle and imports runtime mode resolution. File/bash/upload tools and file routes are registered by agent server paths.
+
+This creates two bugs in the architecture:
+
+1. `direct` means host filesystem, not no-runtime.
+2. Any app wanting a headless agent has to fake a workspace/cwd or avoid the normal server composition.
+
+## Dependency inversion first
+
+Before moving providers to `@hachej/boring-bash`, invert composition:
+
+- `createAgentApp()` and `registerAgentRoutes()` stop value-importing built-in runtime modes in the pure path.
+- Host/CLI/core passes runtime/features in.
+- `@hachej/boring-agent` exports only type contracts for features/tool registration.
+- A package invariant test fails if agent has value imports from `@hachej/boring-bash`.
+- Existing runtime mode support may remain as compatibility wiring only if it does not force a runtime bundle for pure agents.
+
+This prevents the cycle:
+
+```txt
+bad: boring-agent -> boring-bash -> boring-agent
+```
+
+Target:
+
+```txt
+boring-core/full-app/cli compose boring-agent + optional boring-bash
+boring-agent has no bash knowledge except type-level feature hooks
+```
+
+## Public core contracts
+
+This must not become a second plugin registry. `AgentFeature` is a small composition façade over existing server/plugin seams (`WorkspaceServerPlugin`, tool contributors, route contributors, system prompt contributors, `registerCapabilitiesContributor`) so pure agents and non-workspace hosts can use the same concepts without importing workspace internals.
+
+```ts
+interface AgentEnvironment {
+  sessionStorageRoot: string
+  workspaceId?: string
+  agentId?: string
+  featureGrants?: Record<string, unknown>
+}
+
+interface AgentFeature {
+  id: string
+  tools?(ctx: AgentFeatureContext): AgentTool[] | Promise<AgentTool[]>
+  systemPrompt?(ctx: AgentFeatureContext): string | undefined | Promise<string | undefined>
+  readinessRequirements?: string[]
+}
+
+interface AgentServerFeature extends AgentFeature {
+  routes?(ctx: AgentFeatureContext): FastifyPluginAsync | undefined
+}
+
+interface AgentFeatureContext {
+  agentId: string
+  workspaceId?: string
+  environment: AgentEnvironment
+  getGrant<T>(id: string): T | undefined
+}
+```
+
+Rules:
+
+- `routes` is server-only; no `Fastify` value/type leaks into shared/front packages.
+- `featureGrants` must not be confused with current `AgentRuntimeCapabilities`.
+- `sessionStorageRoot` is transcript/session storage, not workspace file storage.
+
+## Pure runtime mode
+
+Add a composition path equivalent to:
+
+```ts
+features: []
+runtime: 'none'
+```
+
+It registers only:
+
+- chat/session/model routes;
+- session store routes;
+- non-bash operational hooks explicitly configured by host;
+- app-owned tools that do not require files or shell.
+
+Pure mode must not build the harness with `process.cwd()` or any host workspace path. It must pass no cwd, or a sealed virtual root with no host files. This is stronger than "do not mention cwd in prompt"; the harness itself must not have ambient host file authority. Pure mode must also skip or relocate boot-time plugin discovery that currently receives a cwd, unless the host explicitly enables a non-bash plugin source.
+
+It must not register:
+
+- file/tree/search/fs-events/git routes;
+- `read/write/edit/find/grep/ls`;
+- `bash`;
+- `execute_isolated_code`;
+- upload/runtime artifact tools bound to a workspace;
+- cwd, workspace path, or AGENTS.md context in the system prompt.
+
+## Pi harness audit
+
+`createPiCodingAgentHarness` must be audited before pure mode ships.
+
+Questions to answer:
+
+1. Can pi-coding-agent run with no cwd?
+2. Does it auto-load AGENTS.md/CLAUDE.md/workspace resources?
+3. Does it inject current directory, file tree, or file tool hints into the prompt?
+4. Does compaction assume file tools exist?
+5. Does session identity assume workspace root?
+
+Outcome must be explicit:
+
+- either pure mode uses pi with cwd/resource loading disabled and snapshot-tested;
+- or pure mode uses a separate non-pi harness.
+
+## Non-bash operational seams
+
+Some open issues are agent/session problems, not bash problems. The agent core needs optional seams for them:
+
+### External review/question hooks (#380)
+
+Add a channel-neutral hook ingestion contract:
+
+```ts
+interface ExternalAgentHookRequest {
+  source: {
+    harnessId: string
+    agentId?: string
+    workspaceId?: string
+    sessionId?: string
+    provider?: string
+  }
+  kind: 'review' | 'question' | 'approval'
+  body: unknown
+  redactionPolicy?: string
+  callback?: { url: string; authRef?: string }
+}
+```
+
+Requirements:
+
+- auth before accept;
+- redaction before session write;
+- clear source attribution;
+- routing to correct workspace/agent/session;
+- works without boring-bash.
+
+### Operational event/command seam (#371, #228, #224)
+
+Expose command/event hooks for reload, slash commands, compaction/provider recovery, and session operational notices without depending on bash.
+
+Do not route these through `boring-bash`; they are agent/session concerns.
+
+## Feature/tool readiness
+
+The agent core should know readiness keys only as opaque gates. Concrete runtime readiness is supplied by features.
+
+Preserve existing `mergeTools({ checkReadiness })` behavior. Do not replace it with a parallel tool catalog.
+
+## Tests
+
+Required tests for this area:
+
+- pure agent starts without workspace/sandbox/runtime bundle;
+- no file/bash/upload routes are registered in pure mode;
+- no file/bash/upload tools appear in catalog;
+- harness construction receives no host cwd/path, or receives a sealed virtual root with no host files;
+- system prompt snapshot has no cwd/workspace/AGENTS.md leakage;
+- pi pure-mode audit result is encoded in tests;
+- external hook accepts/renders/rejects with auth/redaction rules;
+- operational command seam works without boring-bash;
+- import invariant: `@hachej/boring-agent` has no value import from `@hachej/boring-bash`.
+
+## Acceptance
+
+This area is done when an app can instantiate a useful conversational agent with app-owned tools, durable sessions, and no host file authority anywhere in the request path.

--- a/docs/issues/391/runtime-refactor/02-boring-bash-environment.md
+++ b/docs/issues/391/runtime-refactor/02-boring-bash-environment.md
@@ -1,0 +1,211 @@
+# 02 — `@hachej/boring-bash` environment
+
+## Goal
+
+Create `@hachej/boring-bash` as the optional working environment package for files and shell.
+
+It owns:
+
+- filesystem API;
+- exec/bash API;
+- runtime cwd semantics;
+- path validation and containment;
+- file watch/search;
+- file/tree/search/stat/fs-event routes;
+- file/bash/upload agent tools;
+- file tree/editor/viewer UI plugin;
+- provider adapters and provider capability descriptions.
+
+It does not own the model loop, auth, billing, workspace membership, or UI bridge core.
+
+## Layered exports
+
+```txt
+@hachej/boring-bash/shared
+  BashEnvironment, BashFs, BashExec, BashRequirement, provider capability types
+
+@hachej/boring-bash/server
+  file/tree/search/watch routes, createBashEnvironment, runtime route adapters
+
+@hachej/boring-bash/agent
+  createBashAgentFeature(), file/bash/upload tools
+
+@hachej/boring-bash/plugin
+  file tree, editor/viewer panes, workspace.open.path resolver
+
+@hachej/boring-bash/providers
+  direct, bwrap, vercel-sandbox, remote-worker, readonly, none
+```
+
+No `@hachej/boring-agent` value import cycle is allowed.
+
+## Runtime mode vs provider names
+
+Do not collapse current runtime modes into provider names.
+
+| Current mode | Current sandbox provider | Boring-bash provider | Notes |
+| --- | --- | --- | --- |
+| `direct` | `direct` | `direct` | Trusted host mode; no isolation. |
+| `local` | `bwrap` | `bwrap` | Linux bubblewrap. Mode id differs from provider id. |
+| `vercel-sandbox` | `vercel-sandbox` | `vercel-sandbox` | Remote sandbox. |
+| remote-worker adapter | `remote-worker` | `remote-worker` | Client/mode and worker server split must stay explicit; worker handshake must declare capabilities. |
+| pure/headless | none | none | No boring-bash. |
+| readonly files | provider-specific | `readonly` facade | fs/search/watch without exec. |
+
+## Provider capability matrix
+
+Provider labels lie unless backed by capability facts.
+
+| Provider | FS | Exec | Real Bash | Real binaries | Network isolation | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `none` | none | no | no | no | n/a | Pure agent. |
+| `readonly` | readonly | no | no | no | n/a | File UI/search only. |
+| `direct` | readwrite | yes | host-dependent | host-dependent | none | Trusted dev/CI only. |
+| `bwrap` | readwrite | yes | host-dependent | host-dependent | process/container-ish | Linux-only. |
+| `vercel-sandbox` | readwrite | yes | yes | provider image | provider | Good sandbox-primary remote coding. |
+| `remote-worker` | readwrite | yes | worker-dependent | worker-dependent | worker-dependent | Must report matrix in handshake; provisioning adapter support requires widening current adapter mode union. |
+
+## BashEnvironment
+
+```ts
+interface BashEnvironment {
+  id: string
+  provider: 'direct' | 'bwrap' | 'vercel-sandbox' | 'remote-worker' | string
+  runtimeCwd: string
+  fs?: BashFs
+  exec?: BashExec
+  search?: BashSearch
+  watch?: BashWatch
+  provisioning?: BashProvisioningState // runtime summary/readiness, not requirement input
+  providerCapabilities: {
+    fs: 'none' | 'readonly' | 'readwrite'
+    exec: boolean
+    realBash?: boolean
+    realBinaries?: boolean
+    networkIsolation?: 'none' | 'process' | 'container' | 'microvm' | 'provider'
+    watch: boolean
+    search: boolean
+  }
+}
+```
+
+## One namespace rule
+
+V1 should preserve one coherent model-visible namespace, normally `/workspace`.
+
+Multiple mounts and overlays may exist internally, but file routes, search, watch, bash, git/status, and model-facing paths must agree on one view.
+
+Forbidden:
+
+- file tree reads host `/data/workspaces/<id>` while bash edits remote `/workspace`;
+- git/status reads a different root than file routes;
+- `read_file` hides files that raw bash can still cat;
+- session durability is treated as file durability.
+
+## Storage-primary vs sandbox-primary
+
+| Model | Source of truth | Use when |
+| --- | --- | --- |
+| sandbox-primary | live sandbox `/workspace` | remote coding sessions; file routes/search/bash delegate to sandbox |
+| storage-primary | host/object/git storage; sandbox is materialized projection | review, disposable runs, restricted exposure, patch workflows |
+
+Existing `getRuntimeBundleStorageRoot()` and git/file route decisions are the starting seams. Reuse them; do not invent a second storage-root resolver.
+
+## Volume view
+
+```ts
+interface BashVolumeView {
+  id: string
+  workspaceId?: string
+  root: '/workspace'
+  mounts: BashMount[]
+  overlay?: {
+    mode: 'none' | 'scratch' | 'branch' | 'persistent'
+    persistAs?: 'workspace-patch' | 'artifact' | 'discard'
+  }
+}
+```
+
+V1 decision: keep one public root by default. `mounts` are internal/future unless Phase 0 ADR explicitly defines how multiple mounts materialize into one coherent `/workspace` namespace.
+
+## Remote-worker split
+
+Current code has a real split:
+
+- client/protocol/mode code lives under `packages/agent/src/server/sandbox/remote-worker/*` and `packages/agent/src/server/runtime/modes/remote-worker.ts`;
+- worker server code lives under `apps/full-app/src/server/worker/*`.
+
+Extraction rule:
+
+- shared protocol/types move to `boring-bash/shared`;
+- client/provider adapter moves to `boring-bash/providers/remote-worker`;
+- full-app worker server may move to `boring-bash/server/remote-worker` or stay app-owned, but it must depend only on shared protocol/provider server contracts, not on agent core.
+
+Current `WorkspaceProvisioningAdapter.mode` is closed around existing modes. Supporting `remote-worker`, `readonly`, or `none` provisioning requires explicitly widening or short-circuiting that union.
+
+## Tools to move or consciously assign
+
+Current true inventory:
+
+- `buildFilesystemAgentTools()` → `read`, `write`, `edit`, `find`, `grep`, `ls`;
+- `buildHarnessAgentTools()` → `bash`, `execute_isolated_code`;
+- `buildUploadAgentTools()` → upload/runtime artifact tools.
+
+Move these to `boring-bash/agent` or document why a tool stays elsewhere.
+
+Must preserve:
+
+- `disableDefaultFileTools` behavior;
+- readiness tags (`workspace-fs`, `sandbox-exec`, `runtime-dependencies`, `runtime:<id>`);
+- model-facing stale-read/write safety;
+- existing renderer behavior.
+
+## File tree and document authority
+
+### FileTreeDataProvider (#295)
+
+`boring-bash/plugin` should expose a replaceable file tree data boundary:
+
+```ts
+interface FileTreeDataProvider {
+  listTree(root: string, options: TreeOptions): Promise<TreeNode[]>
+  listPaths?(root: string, options: PathIndexOptions): Promise<string[]>
+  subscribe?(root: string): AsyncIterable<FileTreeDelta>
+}
+```
+
+This lets Pierre Trees or another tree UI replace the view without changing server routes again.
+
+### Document-authority override (#367, #226)
+
+When a live document system owns a file (TipTap/Yjs/etc.), model-facing `write`/`edit` must be overridable:
+
+- route through document coordinator;
+- validate stale version/hash;
+- avoid bypassing live collaborative state;
+- fall back to raw file edit only when no document authority is active.
+
+## UI plugin ownership
+
+Move `packages/workspace/src/plugins/filesystemPlugin/front/*` into `boring-bash/plugin` while preserving:
+
+- panel ids;
+- `workspace.open.path` surface resolver;
+- file panel binding;
+- agent file bridge/session-change integration;
+- `/api/v1/files/*` route compatibility or aliases.
+
+The workspace bridge remains owned by `@hachej/boring-workspace`.
+
+## Tests
+
+- provider mode mapping test;
+- one namespace/split-brain tests per provider;
+- direct/local/vercel/remote-worker file+exec consistency;
+- readonly fs without exec;
+- `disableDefaultFileTools` parity;
+- `execute_isolated_code` ownership/readiness;
+- upload/download route ownership;
+- file tree provider path-list and deltas;
+- document-authority write/edit override;
+- git/status source-of-truth consistency.

--- a/docs/issues/391/runtime-refactor/03-policy-provisioning-readiness.md
+++ b/docs/issues/391/runtime-refactor/03-policy-provisioning-readiness.md
@@ -1,0 +1,216 @@
+# 03 — Policy, provisioning, readiness
+
+## Goal
+
+Make bash/files/service capabilities declarative, scoped, and readiness-gated without replacing the provisioning system that already exists.
+
+## Effective policy stack
+
+Power is an intersection, not a union:
+
+```txt
+effective = backend capabilities
+          ∩ app defaults
+          ∩ childApp/workspaceKind policy
+          ∩ workspace max policy
+          ∩ agent policy
+          ∩ subagent policy
+          ∩ session/user grants
+          ∩ plugin/tool requirements
+```
+
+Resolution order:
+
+```txt
+app defaults < childApp/workspaceKind < workspace < agent < subagent < session/user grants < plugin/tool requirement
+```
+
+The resolver rejects impossible merges instead of silently widening access.
+
+## Policy inputs
+
+```ts
+interface BashSandboxPolicy {
+  provider: 'none' | 'direct' | 'bwrap' | 'vercel-sandbox' | 'remote-worker' | string
+  volume: BashVolumeView
+  exec?: {
+    enabled: boolean
+    rawBash?: boolean
+    predefinedTools?: string[]
+    commandPolicy?: BashCommandPolicy
+    timeoutMs?: number
+  }
+  network?: 'disabled' | 'allowlisted' | 'allow-all'
+  env?: Record<string, string>
+  secrets?: string[]
+  services?: BashManagedServiceRequirement[]
+  provision?: BashRequirement['provisioning']
+}
+```
+
+Child app and workspace kind are first-class because of #376: Macro and generic Seneca can share deployment/auth/DB while having different default tools/prompts/provisioning.
+
+## Requirement shape
+
+```ts
+interface BashRequirement {
+  id: string
+  source: 'agent' | 'plugin' | 'app' | 'child-app' | 'workspace-kind'
+  optional?: boolean
+  capabilities?: {
+    fs?: 'readonly' | 'readwrite'
+    exec?: boolean
+    servicePorts?: boolean
+    secrets?: string[]
+  }
+  provisioning?: {
+    templateDirs?: RuntimeTemplateContribution[]
+    nodePackages?: RuntimeNodePackageSpec[]
+    python?: RuntimePythonSpec[]
+    sdkArchives?: BashSdkArchiveSpec[]
+    env?: Record<string, string>
+    pathEntries?: string[]
+  }
+  services?: BashManagedServiceRequirement[]
+  readiness?: {
+    timeoutMs?: number
+    healthCheck?: BashHealthCheckSpec
+  }
+}
+```
+
+## Extend existing provisioning
+
+Do **not** create a parallel provisioning engine.
+
+Package ownership:
+
+- `@hachej/boring-agent` keeps the provisioning engine/types/orchestration (`provisionWorkspaceRuntime()`, `ProvisionWorkspaceRuntimeOptions`) over injected adapters.
+- `@hachej/boring-bash` owns `BashRequirement`, requirement normalization, provider capability validation, and concrete provisioning adapters.
+- host/core/CLI composition calls the boring-bash normalizer, then passes normalized `ProvisionWorkspaceRuntimeOptions` into the agent-owned engine.
+- agent must not value-import boring-bash normalizers/providers.
+
+Current seams to extend:
+
+- `provisionWorkspaceRuntime()`;
+- `ProvisionWorkspaceRuntimeOptions`;
+- `RuntimeProvisioningContribution`;
+- merge-by-`id`;
+- fingerprint skip / `WorkspaceProvisioningResult.changed`;
+- existing per-binding `RuntimeDependencyReadiness`;
+- `ReadyStatusTracker`;
+- `mergeTools({ checkReadiness })`.
+
+Add a thin normalizer in boring-bash/core composition:
+
+```ts
+resolveBashProvisioningRequirements(input) -> ProvisionWorkspaceRuntimeOptions
+```
+
+It collects app, child-app, workspace-kind, workspace, agent, plugin, and session requirements, validates them against provider capabilities, and feeds the existing provisioning function via host composition.
+
+## Readiness model
+
+Use the real current two-tier model:
+
+- aggregate `ReadyState`: `provisioning | ready | degraded`;
+- per-capability `CapabilityState`: `not-started | preparing | ready | failed`;
+- `CapabilityReadinessDetail` already carries `requirement`, `errorCode`, `causeCode`, `retryable`, `message`, `startedAt`, `completedAt`;
+- `AgentCapabilityReadiness` is currently fixed to `chat`, `workspace`, and `runtimeDependencies`.
+
+Extension target:
+
+- keep aggregate `ReadyState` unchanged;
+- extend or wrap `AgentCapabilityReadiness` so N bash requirements can be reported without losing current `chat/workspace/runtimeDependencies` fields;
+- reuse `CapabilityReadinessDetail` instead of inventing a parallel metadata bag;
+- represent optional failures as a derived/display concept over `CapabilityState='failed'` + `optional=true`, not a breaking enum value.
+
+Existing readiness tags must continue to work:
+
+- `runtime-dependencies`
+- `runtime:<id>`
+- `workspace-fs`
+- `sandbox-exec`
+
+## Secrets (#181)
+
+Secrets are names/grants, never raw values in plans or browser contexts.
+
+Required contracts:
+
+- host-owned secret store/status API;
+- browser/plugin sees only status: missing, granted, denied, expired;
+- model sees only names and availability unless a typed tool deliberately uses the secret in host code;
+- shell env injection requires explicit policy and audit logging;
+- secrets never get written into provisioning plan files or logs.
+
+## Managed services (#328, #258)
+
+Some plugins need long-lived processes, not one-shot `bash`:
+
+```ts
+interface BashManagedServiceRequirement {
+  id: string
+  command: string | string[]
+  cwd?: string
+  ports?: Array<{ port: number; purpose: 'iframe' | 'api' | 'preview'; public?: boolean }>
+  healthCheck?: BashHealthCheckSpec
+  teardown?: 'kill-process-tree' | 'provider-default'
+}
+```
+
+Use cases: Remotion Studio, browser-use, local preview servers.
+
+Requirements:
+
+- explicit trusted plugin/service requirement;
+- process supervision;
+- health check;
+- port proxy/iframe grants;
+- teardown;
+- no automatic exposure to public internet;
+- readiness gates before tools/panels activate.
+
+## Remote-worker hardening (#307)
+
+`remote-worker` must report its actual isolation capabilities in handshake:
+
+- gVisor/seccomp status;
+- per-workspace network namespace/firewall;
+- metadata/private CIDR egress policy;
+- same-host cross-workspace boundary;
+- filesystem persistence model;
+- real bash/binaries availability.
+
+If a policy requires a hardening property that the worker cannot prove, fail closed.
+
+## Two-phase sandbox lifecycle
+
+Adopt eve’s useful split while preserving existing Vercel packaging/snapshot code:
+
+- **template/bootstrap phase**: install common deps, seed template files, create provider snapshot;
+- **session/onSession phase**: apply session grants, env, services, per-session readiness.
+
+Fingerprint keys should include:
+
+- provider;
+- workspace/child-app/agent ids;
+- requirement ids;
+- seed content hash;
+- source graph hash;
+- provider contract version;
+- revalidation key.
+
+## Tests
+
+- requirements merge by id;
+- conflict rejection;
+- optional requirement failure does not block unrelated tools;
+- capability-vs-provider validation;
+- existing readiness state compatibility;
+- health check gating;
+- secret status without raw value exposure;
+- service start/health/port/teardown;
+- remote-worker handshake fail-closed;
+- child-app/workspace-kind policy narrows but never widens;
+- Vercel pack-artifact rules still prevent host path leakage.

--- a/docs/issues/391/runtime-refactor/04-plugin-child-app-runtime.md
+++ b/docs/issues/391/runtime-refactor/04-plugin-child-app-runtime.md
@@ -1,0 +1,196 @@
+# 04 — Plugins, hosted runtimes, and child apps
+
+## Goal
+
+Make plugins and child apps declare runtime needs safely, while allowing one full-app deployment to host multiple product shells such as generic Seneca and Macro.
+
+## Child-app target (#376)
+
+One deployment/runtime/auth/Postgres DB/global billing service can serve multiple child apps selected by:
+
+- hostname;
+- workspace kind;
+- trusted plugins;
+- prompts;
+- provisioning requirements;
+- frontend shell/branding.
+
+Macro-specific tools/prompts/provisioning must not leak into generic workspaces.
+
+## Relationship to shared child-app platform plan
+
+The product/registry/billing/workspace-kind design is owned by [`docs/plans/shared-child-app-platform.md`](../shared-child-app-platform.md) and issue #376.
+
+This plan only consumes the resolved child-app context for bash/runtime intersection. It must not define a competing `ChildAppDefinition`, workspace-kind schema, billing model, or hostname registry.
+
+Effective bash policy includes the resolved context:
+
+```txt
+app defaults < resolved childApp/workspaceKind policy < workspace policy < agent policy < session grants < plugin/tool requirements
+```
+
+Inputs consumed from the child-app plan:
+
+- `childAppId`;
+- `workspaceKind`;
+- resolved default agent set;
+- resolved default/trusted plugins;
+- resolved bash/provisioning requirements.
+
+Billing/product ids remain core-owned data and are out of scope for `boring-bash`.
+
+## Plugin manifest requirements
+
+Validation must be import-free and must extend the existing trusted-plugin manifest model (`boring.front`, `boring.server`, hosted iframe fields, plugin system scan), not introduce a second manifest reader.
+
+```jsonc
+{
+  "boring": {
+    "front": "front/index.tsx",
+    "server": "server/index.ts",
+    "requires": ["boring-bash"]
+  },
+  "bash": {
+    "capabilities": { "fs": "readwrite", "exec": true },
+    "nodePackages": [{ "id": "my-cli", "packageName": "my-cli" }],
+    "python": [{ "id": "my-sdk", "projectFile": "sdk/pyproject.toml" }],
+    "services": [{ "id": "studio", "command": "pnpm studio", "ports": [{ "port": 3000, "purpose": "iframe" }] }]
+  }
+}
+```
+
+Rules:
+
+- validate `boring.requires` and `bash` before executing plugin code;
+- fail closed when required features are missing;
+- optional requirements degrade with diagnostics;
+- remote modes reject unsupported trust tiers;
+- frontend-only viewers can request readonly fs without exec;
+- shell/service requirements must be explicit.
+
+## Hosted external plugins (#357)
+
+Hosted iframe plugin mode is intentionally constrained:
+
+- no host React/plugin factory execution;
+- no plugin backend code;
+- no host route access;
+- no generic filesystem access;
+- constrained iframe sandbox/CSP;
+- diagnostics bridge only.
+
+The new abstraction must preserve this fail-closed posture.
+
+Remote-hosted plugins may declare:
+
+- readonly file visibility;
+- iframe panels;
+- capability diagnostics.
+
+They may not get bash/server/tools unless promoted to a trusted plugin tier by host policy.
+
+## Runtime plugin RPC
+
+Do not add a competing route family. Keep:
+
+- `/api/v1/plugins/:pluginId/*`;
+- runtime backend gateway;
+- workspace plugin runtime manager;
+- `WorkspaceBridge`.
+
+Add feature context:
+
+```ts
+interface RuntimePluginContext {
+  pluginId: string
+  workspaceId?: string
+  childAppId?: string
+  workspaceKind?: string
+  availableFeatures: {
+    bash?: BashEnvironmentSummary
+    uiBridge?: boolean
+    secrets?: Record<string, 'missing' | 'granted' | 'denied' | 'expired'>
+    services?: Record<string, 'not-started' | 'starting' | 'ready' | 'failed'>
+  }
+}
+```
+
+## Shared per-workspace plugin runtime (#254)
+
+This plan should compose with a shared per-workspace plugin runtime:
+
+- manager;
+- backend registry;
+- reload;
+- Pi/plugin snapshots;
+- dispose;
+- multi-tenant route resolver.
+
+Do not duplicate plugin runtime maps in CLI/full-app/workspace modes.
+
+## Hot reload in full-app (#41)
+
+Multi-tenant reload must resolve per-request:
+
+- workspace;
+- agent binding;
+- plugin runtime;
+- beforeReload hook;
+- asset manager.
+
+The new runtime-free agent composition should make this easier, not harder.
+
+## Secrets (#181)
+
+Plugin contexts receive secret status and explicit grants only.
+
+No raw secrets in:
+
+- browser plugin contexts;
+- manifest files;
+- logs;
+- issue comments;
+- model-visible prompts;
+- provisioning plan artifacts.
+
+## Managed service plugins (#328, #258)
+
+Trusted plugins can request managed services through bash requirements.
+
+Examples:
+
+- Remotion Studio preview;
+- browser-use runtime;
+- local dev preview server.
+
+Required lifecycle:
+
+1. provision deps;
+2. start process;
+3. health check;
+4. grant port/proxy/iframe if policy allows;
+5. surface readiness to UI/tools;
+6. teardown on workspace/plugin dispose.
+
+## Macro hosted inside full-app
+
+For a Macro child app:
+
+- `childAppId = 'macro'`;
+- workspace kind selects Macro default workspace behavior;
+- Macro prompts/tools/provisioning are scoped to Macro workspaces;
+- generic Seneca workspace does not see Macro requirements;
+- billing remains core/global;
+- `boring-bash` only receives the resolved policy/requirements.
+
+## Tests
+
+- import-free manifest validation before code execution;
+- hosted plugin fail-closed in remote mode;
+- child-app scoped default plugins/prompts/provisioning;
+- Macro requirements do not leak into generic workspace;
+- plugin requiring bash is skipped/diagnosed when bash disabled;
+- plugin requiring secrets receives status only;
+- trusted service plugin lifecycle works;
+- runtime backend RPC still dispatches after bash extraction;
+- full-app reload route resolves per workspace/agent/plugin runtime.

--- a/docs/issues/391/runtime-refactor/05-multi-agent-sessions-hooks.md
+++ b/docs/issues/391/runtime-refactor/05-multi-agent-sessions-hooks.md
@@ -1,0 +1,144 @@
+# 05 — Multi-agent workspaces, sessions, and hooks
+
+## Goal
+
+Allow one deployed app/workspace to compose multiple agents with different tools, files, shell access, channels, and durability behavior.
+
+This is the platform layer needed for child apps like Macro and for multiple agent roles in the same full-app deployment.
+
+## Agent concepts
+
+| Concept | Environment | Use case |
+| --- | --- | --- |
+| `AgentProfile` | same parent bash environment, maybe narrower cwd/view | cheap delegated tasks, same trust boundary |
+| `AgentNode` | own config, tools, channels, sandbox policy, durability | specialist agents with different tools/provider/mount/network policy |
+
+Defaults:
+
+- declared child agents inherit nothing unless explicit;
+- copy/current-agent delegation may share sandbox state only when explicit;
+- narrower views are okay;
+- wider views require owner/workspace policy approval;
+- delegation depth is capped;
+- shared-sandbox write access needs stale-write or non-overlapping write scopes.
+
+## Workspace agent registry
+
+A workspace may declare:
+
+```ts
+agents: [
+  { id: 'coding', package: '@hachej/coding-agent', features: ['boring-bash'] },
+  { id: 'reviewer', package: '@hachej/review-agent', features: ['boring-bash'], bash: { fs: 'readonly', exec: false } },
+  { id: 'concierge', package: '@hachej/email-agent', features: [] }
+]
+```
+
+Child-app defaults can seed this registry, but workspace/user policy can narrow it.
+
+## Route/session namespace
+
+Required scoping:
+
+- routes: `/api/v1/agents/:agentId/...` or equivalent request-scope header;
+- add `agentId` to the real per-workspace runtime binding/scope used by `registerAgentRoutes` and core workspace server caches; do not assume a preexisting single composite key has every field;
+- `sessionNamespace` includes `agentId`; legacy fields such as root/template/pi/session namespace must remain isolated where they currently exist;
+- session root layout preserves AGENTS.md rule: transcripts live under host durable `BORING_AGENT_SESSION_ROOT`, not workspace/container home;
+- tool catalog is per agent;
+- provisioning is per `(workspaceId, agentId, bashPlanFingerprint)`;
+- UI commands include `agentId` for attribution where useful, while workspace UI state remains shared.
+
+Isolation test: two agents in one workspace with same `sessionId` do not share bindings, tool catalogs, transcripts, or provisioning readiness incorrectly.
+
+## Session history search (#379)
+
+Add a session index/search API independent of boring-bash.
+
+Scope:
+
+- `workspaceId`;
+- `agentId`;
+- `sessionId`;
+- title/name;
+- messages/content;
+- operational events;
+- links/deep-link metadata.
+
+Requirements:
+
+- Pi-native content search parity;
+- no filesystem requirement;
+- redaction for private/tool outputs;
+- URL/deep-link compatibility;
+- multi-project browse support without loading every workspace.
+
+## Deep links and session links (#243, #211)
+
+The multi-agent route model must support:
+
+- opening a specific session history;
+- preserving focused session in URL;
+- resolving inaccessible/deleted sessions gracefully;
+- not overwriting active work without user intent;
+- later multi-pane layout encoding.
+
+## External harness review/question hooks (#380)
+
+External systems can create review/question/approval hooks against a workspace/agent/session. The authoritative contract is defined in [`01-agent-core-runtime-free.md`](01-agent-core-runtime-free.md); this file only defines multi-agent routing requirements.
+
+Requirements:
+
+- authenticate caller;
+- validate target workspace/agent/session;
+- redact before writing to history;
+- route to correct UI/HITL channel;
+- audit attribution;
+- no boring-bash dependency.
+
+## User as principal
+
+Do not model human user as a model-callable max-power agent.
+
+Model user as:
+
+- principal;
+- supervisor;
+- approval channel;
+- grant source;
+- audit actor.
+
+Agents request grants; users approve/reject through UI/HITL channels. Privileged host actions stay in trusted app tools.
+
+## Concurrency
+
+Shared environment risks:
+
+- simultaneous writes;
+- one agent invalidating another agent’s read stamps;
+- session transcript confusion;
+- tool readiness bleed;
+- child agent widening access.
+
+Required safeguards:
+
+- write scopes;
+- stale-write stamps;
+- merge/patch artifacts for isolated agents;
+- per-agent tool catalog;
+- per-agent readiness;
+- explicit delegation depth cap.
+
+## Tests
+
+- resolved child-app/default agent set can seed the agent registry before plugin/runtime policy uses it;
+- two agents same workspace/session id do not collide;
+- session namespace includes agent id;
+- binding cache includes agent id;
+- per-agent tool catalog differs as expected;
+- reviewer has readonly fs/no exec while coding agent has bash;
+- pure concierge has no boring-bash;
+- session search scoped by workspace+agent;
+- deep links open target session safely;
+- external hooks authenticate/redact/route;
+- delegation depth cap works;
+- shared-sandbox stale-write protection works.

--- a/docs/issues/391/runtime-refactor/06-migration-phases.md
+++ b/docs/issues/391/runtime-refactor/06-migration-phases.md
@@ -1,0 +1,171 @@
+# 06 — Migration phases
+
+## Rule
+
+Dependency inversion happens before package extraction. Otherwise we create an agent↔bash import cycle.
+
+Each phase must preserve existing workspace behavior unless that phase explicitly changes a documented invariant.
+
+## Phase 0 — ADR, naming lock, invariant update
+
+Deliverables:
+
+- ADR: `@hachej/boring-agent` becomes runtime-free; `@hachej/boring-bash` owns files/bash/file UI.
+- Update `docs/DECISIONS.md` §7 and `packages/agent/docs/runtime.md`.
+- Lock package name: `@hachej/boring-bash`.
+- Decide v1 namespace semantics: preserve one `/workspace` namespace or formally supersede current invariant.
+- State that old monolithic plan is superseded by this plan pack.
+
+Exit criteria:
+
+- ADR accepted;
+- plan pack reviewed;
+- issue #391 points to plan pack.
+
+## Phase 1 — Agent dependency inversion and pure mode
+
+Deliverables:
+
+- `createAgentApp()` / `registerAgentRoutes()` receive runtime/features by injection.
+- Remove static value imports from agent server composition to built-in mode resolution where needed for pure mode.
+- Define destination for mode resolution: type-only `RuntimeModeAdapter` contracts may stay in agent during migration, but `resolveMode()` and concrete mode adapters move to boring-bash/host composition after compatibility shims.
+- Add package invariant test: no agent value import from boring-bash.
+- Add `runtime: none` / `features: []` path.
+- Separate `sessionStorageRoot` from workspace roots.
+- Audit pi-coding-agent cwd/resource assumptions.
+- Add external hook and operational event seams if route composition changes.
+
+Exit criteria:
+
+- pure agent starts with no workspace/sandbox/cwd/file routes/bash tools;
+- existing direct/local/vercel modes still work through host composition.
+
+## Phase 2 — Create `@hachej/boring-bash`
+
+Deliverables:
+
+- package skeleton and exports;
+- type-only shared contracts;
+- provider capability model;
+- mode/provider mapping docs;
+- move concrete provider implementations (direct, bwrap, vercel-sandbox, remote-worker client) to `boring-bash/providers`;
+- provisioning ownership docs: agent owns engine/types over injected adapters; boring-bash owns requirement normalizer and provider adapters;
+- remote-worker split docs: protocol/shared types, client/provider adapter, optional server package path;
+- compatibility strategy: type-only old-path exports are allowed where safe; moved boring-bash values must not be re-exported from agent/workspace if doing so creates package cycles. Use host/composition shims or clear import migrations instead.
+
+Do not move providers until Phase 1 injection is complete.
+
+Exit criteria:
+
+- package builds;
+- no import cycle;
+- current apps still compile after import migration or through safe host-level shims.
+
+## Phase 3 — Move server routes and tools
+
+Deliverables:
+
+- move file/tree/search/fs-events/stat/dir routes to `boring-bash/server`;
+- move filesystem tools to `boring-bash/agent`;
+- move or explicitly assign `bash`, `execute_isolated_code`, and upload tools;
+- preserve readiness tags and `disableDefaultFileTools`;
+- replace hardwired registration with `createBashAgentFeature()`.
+
+Exit criteria:
+
+- workspace playground still opens file tree/editor;
+- read/write/edit/find/grep/ls/bash work when boring-bash enabled;
+- pure mode still has none of those routes/tools.
+
+## Phase 4 — Move filesystem front plugin
+
+Deliverables:
+
+- move filesystem front plugin to `boring-bash/plugin`;
+- preserve panel ids and `workspace.open.path` resolver;
+- preserve file panel binding and agent file bridge/session changes;
+- add `FileTreeDataProvider` boundary;
+- add document-authority override seam.
+
+Exit criteria:
+
+- `exec_ui openFile` still opens files;
+- file tree can consume provider boundary;
+- active document coordinator can intercept writes.
+
+## Phase 5 — Extend provisioning/readiness
+
+Deliverables:
+
+- `BashRequirement` normalizer lives outside agent and feeds `provisionWorkspaceRuntime()` through host/core/CLI composition;
+- re-point callers in core full-app, workspace server, and CLI/workspaces-mode composition;
+- import-free requirement validation;
+- per-requirement readiness metadata;
+- `optional_failed` as compatible derived/display state;
+- health checks;
+- SDK archive support;
+- managed service requirements;
+- secret status/grant model;
+- remote-worker capability handshake;
+- two-phase bootstrap/onSession reconciliation.
+
+Exit criteria:
+
+- existing provisioning fingerprint skip still works;
+- tools gate on existing readiness keys;
+- plugin SDK provisioned and gated until ready;
+- remote-worker fail-closes when required hardening unavailable.
+
+## Phase 6 — Plugin and child-app integration
+
+Prerequisite: consume resolved child-app/workspace-kind context from `docs/plans/shared-child-app-platform.md`; do not define a competing child-app registry here.
+
+Deliverables:
+
+- introduce the `AgentRegistry` data structure so child-app defaults can declare agent sets; full route/session migration follows in Phase 7;
+- import-free plugin manifest validation for `boring.requires` and `bash`;
+- runtime plugin context exposes available features;
+- hosted plugin remote-mode fail-closed behavior;
+- child-app/workspace-kind policy input consumed from shared child-app platform;
+- Macro child-app requirements can be scoped;
+- full-app reload/plugin runtime remains multi-tenant.
+
+Exit criteria:
+
+- Macro requirements do not leak into generic workspace;
+- hosted iframe plugin stays constrained;
+- runtime plugin RPC still works;
+- full-app reload resolves per workspace/agent/plugin runtime.
+
+## Phase 7 — Multi-agent routing/session/search
+
+Deliverables:
+
+- implement `agentId` scoped routes or request-scope equivalent against the Phase 6 `AgentRegistry`;
+- binding scope key includes `agentId`;
+- `sessionNamespace` includes `agentId`;
+- session root layout preserves durable host session root;
+- per-agent catalog and readiness;
+- session index/search scoped by workspace+agent;
+- external hook target resolution.
+
+Exit criteria:
+
+- same workspace/same session id/two agents do not collide;
+- deep links can open target agent session;
+- pure/headless and bash-enabled agents coexist in one deployed app.
+
+## Phase 8 — Cleanup and deprecation
+
+Deliverables:
+
+- remove remaining safe type-only/host-level compatibility exports after downstream migration window;
+- update package docs;
+- create migration notes for app authors;
+- convert remaining plan tasks into beads/issues.
+
+Exit criteria:
+
+- no code imports old moved paths;
+- docs reflect new package ownership;
+- issue #391 can close or split remaining follow-ups.

--- a/docs/issues/391/runtime-refactor/07-tests-review-acceptance.md
+++ b/docs/issues/391/runtime-refactor/07-tests-review-acceptance.md
@@ -1,0 +1,149 @@
+# 07 — Tests, review, acceptance
+
+## Goal
+
+Define proof required before implementation is accepted.
+
+## Global test gates
+
+### Runtime-free agent
+
+- pure agent server starts with no workspace/sandbox/runtime bundle;
+- no file/tree/search/git/fs-event routes;
+- no file/bash/upload tools;
+- no host cwd/path reaches harness construction, not just prompt;
+- no cwd/workspace/AGENTS.md prompt leakage;
+- pi audit encoded in snapshot tests or pure mode uses non-pi harness.
+
+### Package layering
+
+- `@hachej/boring-agent` has no value import from `@hachej/boring-bash`;
+- provisioning normalizer/provider adapters live outside agent and are injected by host/core/CLI;
+- `@hachej/boring-bash` can depend on agent types/tools only through approved boundaries;
+- workspace/core compose both packages without cycles.
+
+### Existing behavior compatibility
+
+- direct/local/vercel modes still launch;
+- workspace playground file tree/editor works;
+- read/write/edit/find/grep/ls/bash work when boring-bash enabled;
+- `execute_isolated_code` behavior preserved or consciously reassigned;
+- upload/download behavior preserved;
+- `exec_ui openFile` still opens file panes;
+- `/api/v1/ui/*` and `/api/v1/plugins/:pluginId/*` still work.
+
+### Split-brain prevention
+
+For each provider:
+
+- file route write visible to bash;
+- bash-created file visible to file routes/search;
+- git/status routes use same source of truth;
+- readonly facade exposes no exec;
+- partial view with exec physically excludes denied files.
+
+### Provisioning/readiness
+
+- requirement merge by id;
+- conflict rejection;
+- fingerprint skip preserved;
+- real two-tier readiness remains compatible: aggregate `ReadyState` (`provisioning|ready|degraded`) plus per-capability `CapabilityState` (`not-started|preparing|ready|failed`);
+- optional failure is represented without breaking existing enums and does not block unrelated tools;
+- health check gates tools/panels;
+- SDK artifacts do not leak host paths;
+- remote-worker hardening handshake fail-closes;
+- remote-worker client/provider/protocol/server split preserves package boundaries.
+
+### Plugins/child apps
+
+- import-free manifest validation;
+- hosted plugin fail-closed before code execution;
+- secret status exposed without raw value;
+- managed service plugin lifecycle: start, health, port/iframe/proxy, teardown;
+- child-app/workspace-kind policy narrows requirements;
+- Macro requirements do not leak into generic workspace;
+- full-app reload/plugin runtime resolves per workspace/agent.
+
+### Multi-agent/session
+
+- two agents in same workspace with same `sessionId` do not share binding/transcript/catalog;
+- `agentId` included in binding scope key and `sessionNamespace`;
+- session root uses host durable session root;
+- per-agent readiness/tool catalogs;
+- session search scoped by workspace+agent;
+- deep links open target session safely;
+- external hooks authenticate/redact/route;
+- delegation depth cap and stale-write safeguards.
+
+### UI/file/document
+
+- file tree provider path-list/tree-index works;
+- fs-event deltas update tree;
+- document-authority write/edit override routes through active coordinator;
+- file panes and surface resolver keep ids/behavior;
+- missing panels/capabilities produce clear UI diagnostics.
+
+## Issue coverage acceptance
+
+Do not close unrelated backlog issues just because this abstraction lands.
+
+Can close or materially advance:
+
+- #391;
+- #12 if harness pluggability acceptance is satisfied;
+- #242 if route composition acceptance is satisfied;
+- #16/#223 if provider capability abstraction and adapter composition land;
+- #26/#220/#221 if file API/UI ownership lands;
+- parts of #357/#254/#256 if plugin capability declaration lands;
+- parts of #243/#211 if multi-agent session routing/search lands.
+
+Must remain separate unless explicitly implemented:
+
+- #376 child-app platform product/deployment/billing;
+- #381/#197 product plugin specs;
+- #377/#361/#363/#362 multi-project nav UI;
+- #375/#358/#308 visual/theme/pane polish;
+- #318 desktop wrapper;
+- #267 performance;
+- #127/#51/#27 billing/auth/database;
+- #122 docs annotation UI;
+- #95 dependency migration;
+- #5 event bus typing.
+
+## Thermo review protocol
+
+Before implementation:
+
+1. Review each plan file independently.
+2. Review the pack as a whole for contradictions.
+3. Patch accepted blockers.
+4. Rerun blocker-only review.
+5. Record review artifacts in `.tmp/boring-bash-plan-reviews/`.
+
+Review prompt:
+
+```txt
+You are an extremely strict thermo architecture reviewer. Review only. Do not edit files.
+For the target plan file, find blockers, contradictions with sibling files, missing tests, package-boundary risks, split-brain risks, and implementation traps.
+Output: verdict, blockers, concrete edits, non-blocking concerns.
+```
+
+Approval bar:
+
+- no greenfield duplication of existing seams;
+- no import cycle;
+- no vague provider capability claims;
+- no unreviewed pure-agent cwd assumption;
+- no session/agent/child-app scope leak;
+- no missing split-brain test;
+- no overclaim about open issues.
+
+## Final acceptance
+
+The plan pack is ready for beads/implementation when:
+
+- all files pass blocker-only thermo review;
+- issue #391 body points to the plan pack;
+- open decisions are either resolved or explicitly deferred;
+- every implementation phase has clear exit criteria;
+- tests above are assigned to phases.

--- a/docs/issues/391/runtime-refactor/README.md
+++ b/docs/issues/391/runtime-refactor/README.md
@@ -1,0 +1,36 @@
+# Runtime-free agents + `@hachej/boring-bash` plan pack
+
+Status: first split pass, thermo-review loop required before implementation.
+
+This folder replaces the original monolithic plan. The preserved source snapshot is [`legacy-monolith-source.md`](legacy-monolith-source.md).
+
+## Plan files
+
+1. [`00-global-isa.md`](00-global-isa.md) — global intent/strategy/architecture, framework lessons, destination, non-negotiables.
+2. [`01-agent-core-runtime-free.md`](01-agent-core-runtime-free.md) — make `@hachej/boring-agent` truly fs-free by default.
+3. [`02-boring-bash-environment.md`](02-boring-bash-environment.md) — `@hachej/boring-bash` package boundary, providers, file/bash/source-of-truth, tools/UI.
+4. [`03-policy-provisioning-readiness.md`](03-policy-provisioning-readiness.md) — policy intersection, child-app/workspace-kind scoping, provisioning, readiness, secrets, services.
+5. [`04-plugin-child-app-runtime.md`](04-plugin-child-app-runtime.md) — plugin manifests, hosted plugin safety, child-app/Macro hosting, runtime RPC.
+6. [`05-multi-agent-sessions-hooks.md`](05-multi-agent-sessions-hooks.md) — multiple agents per deployed app/workspace, session namespaces, search, external hooks.
+7. [`06-migration-phases.md`](06-migration-phases.md) — dependency-ordered implementation phases.
+8. [`07-tests-review-acceptance.md`](07-tests-review-acceptance.md) — required tests, issue coverage, review gates, acceptance criteria.
+
+## Implementation rule
+
+Do not implement from only one file. Every implementation bead/PR must cite:
+
+- the global ISA;
+- the relevant area subplan;
+- the migration phase;
+- the acceptance/test section.
+
+## Review rule
+
+Each file must pass a thermo architecture review before coding starts. A clean review means:
+
+- no package import cycle;
+- no duplicated provisioning/readiness system;
+- no filesystem/bash split brain;
+- no hidden cwd/filesystem leak in pure agent mode;
+- no child-app or multi-agent scope leak;
+- no claim that unrelated backlog issues are solved by this abstraction.

--- a/docs/issues/391/runtime-refactor/legacy-monolith-source.md
+++ b/docs/issues/391/runtime-refactor/legacy-monolith-source.md
@@ -1,0 +1,745 @@
+# Boring Bash agent/runtime refactor plan
+
+## Goal
+
+Make `@hachej/boring-agent` a true agent harness that can run with **no filesystem at all**, while extracting the files + bash working environment into a first-class package named `@hachej/boring-bash`.
+
+`boring-bash` is the optional feature that gives an agent a place to work:
+
+- filesystem API
+- exec/bash API
+- runtime cwd/location semantics
+- path validation and containment
+- file watch/search
+- file/tree/search HTTP routes
+- agent tools (`read`, `write`, `edit`, `ls`, `find`, `grep`, `bash`, `execute_isolated_code`, upload/runtime artifact tools where applicable)
+- Boring UI file tree, editor/viewer panes, and `workspace.open.path` surface resolver
+
+A pure headless agent must be valid without `boring-bash`.
+
+## Current problem
+
+The current package boundaries are close but not clean enough:
+
+- `@hachej/boring-agent` still assumes a `RuntimeBundle` with `Workspace + Sandbox + FileSearch`.
+- `direct` mode means no isolation, **not** no filesystem.
+- File routes and file/bash/upload tools are still composed inside `createAgentApp()` / `registerAgentRoutes()`.
+- The filesystem front UI is plugin-shaped, but its server/API/tool half is still in agent.
+- Multiple chat panes exist, but they are panes over one backend agent/session namespace.
+- Headless Slack/email/Telegram agents would need to fake browser chat calls rather than use a clean runner/channel API.
+- Runtime provisioning already exists, but it is workspace-scoped and aggregate; future agents/plugins need explicit per-requirement bash capability validation/readiness.
+
+## Current seams already in place
+
+This is not greenfield. The migration must reuse and extend these seams instead of creating parallel systems:
+
+- `disableDefaultFileTools` already removes the six filesystem tools from the default catalog; bash/harness tools are currently separate.
+- `buildHarnessAgentTools()` registers `bash` plus `execute_isolated_code` when the runtime supports it.
+- `buildFilesystemAgentTools()` registers `read`, `write`, `edit`, `find`, `grep`, and `ls`.
+- `buildUploadAgentTools()` is also bound to the runtime bundle and must move or be consciously kept out of `boring-bash`.
+- UI control is already workspace-owned: `/api/v1/ui/*`, `exec_ui`, `get_ui_state`, `WorkspaceBridge`, and workspace UI-control routes live outside the agent core composition.
+- Runtime modes already advertise `workspaceFsCapability`; `RuntimeBundle` already separates host storage root, workspace root, sandbox provider, and `runtimeCwd` via `getRuntimeBundleStorageRoot()` / `WorkspaceRuntimeContext`.
+- `provisionWorkspaceRuntime()` already accepts structural provisioning contributions, merges by stable `id`, fingerprints/skips unchanged work, and returns `WorkspaceProvisioningResult.changed`.
+- Existing storage-primary/sandbox-primary seams exist in `getRuntimeBundleStorageRoot()` and current git/file route wiring; the refactor should reuse those decisions instead of re-deriving storage roots.
+- `RuntimeDependencyReadiness`, `ReadyStatusTracker`, and `mergeTools({ checkReadiness })` already gate tools on readiness keys such as `runtime-dependencies`, `workspace-fs`, `sandbox-exec`, and `runtime:<id>`.
+- `registerCapabilitiesContributor` already lets composition add runtime capability context.
+
+Required posture: **extend these seams; do not duplicate them under new names.**
+
+## Cloned framework findings
+
+Sources were cloned into `/tmp/boring-agent-frameworks.*` and inspected directly:
+
+- Flue: `withastro/flue`, especially `packages/runtime/src/*`, `packages/cli/src/lib/build.ts`, and `examples/*`.
+- eve: `vercel/eve`, especially `packages/eve/src/discover/*`, `packages/eve/src/compiler/*`, `packages/eve/src/runtime/*`, `packages/eve/src/execution/*`, and `e2e/fixtures/*`.
+
+### Flue patterns to steal
+
+- `defineAgent()` returns an opaque initializer; file/module discovery gives addressable identity. See `packages/runtime/src/agent-definition.ts` and `packages/cli/src/lib/build.ts`.
+- `defineAgentProfile()` is a reusable behavior pack. Profiles merge into root agents, and named profiles become `session.task({ agent })` subagents.
+- Subagent profiles are **self-contained** for instructions/tools/skills/subagents, while model/thinking/compaction can inherit. See `Harness.createTaskSession()` in `packages/runtime/src/harness.ts`.
+- Durable direct/dispatch submissions are explicit and separate from the normal prompt API. Flue tracks attempts, journals turn phases, repairs/retries where safe, and terminalizes uncertain interruptions. See `runtime/agent-submissions.ts`, `cloudflare/agent-coordinator.ts`, and `node/agent-coordinator.ts`.
+- `SandboxFactory` is the key seam: it returns a `SessionEnv` with fs + exec, and may replace the model-visible tool list via `tools`. This is the exact shape we need for predefined/limited bash tool profiles.
+- Flue’s `SessionEnv` is the single backing environment for model tools, programmatic `harness.fs`, `session.fs`, and shell calls. That reinforces the boring-bash invariant: file routes/tools/search and exec must point at one workspace view.
+- Flue separates transcript semantics: `session.shell()` records a synthetic bash tool exchange in conversation history, while `session.fs`/`harness.fs` are out-of-band. Boring-bash should make explicit which operations are agent-visible history versus host plumbing.
+- Flue durability covers sessions, submission queues, turn journals, event streams, and recovery decisions, but not sandbox filesystem snapshots. A durable agent that mutates files needs boring-bash to reconnect by stable `(workspaceId, agentId/session/run, plan fingerprint)` or to persist the file view separately.
+- Flue proves files and bash do not have to be identical capabilities: `examples/cloudflare/src/sandboxes/cloudflare-shell.ts` provides a durable filesystem and a custom `code` tool, while `exec()` throws and default bash tools are replaced.
+
+### Flue patterns to avoid
+
+- The default harness is not runtime-free: default tools include `read/write/edit/bash/grep/glob/task`, and the default env provides fs/exec unless an adapter overrides tools.
+- `cwd` and workspace context discovery are baked into the core harness. For boring-ui, those must live behind `boring-bash`, not `boring-agent`.
+- Subagent profiles cannot declare durability and normally share the parent environment. That is too weak for our desired “one subagent gets a different sandbox/provider/mount set” requirement.
+- Flue top-level agent identity comes from discovered module filenames, while profile names are behavior-pack names only. For boring-ui, keep agent IDs explicit and stable; avoid treating reusable profiles as addressable runtime agents.
+
+### eve patterns to steal
+
+- Filesystem slot discovery is strong DX. `agent/agent.ts`, `instructions.md`, `tools/*.ts`, `skills/*`, `subagents/*`, `channels/*`, `connections/*`, `sandbox.ts`, and `sandbox/workspace/**` compile into a manifest. See `packages/eve/src/discover/discover-agent.ts` and `docs/reference/project-layout.md`.
+- Discovery is intentionally import-free; compile/lowering later reattaches live authored exports through a generated module map. For boring-ui, this is the right trust boundary: validate/package manifests before executing plugin or agent code.
+- Identity is path-derived. Tools do not author `name`; `tools/billing/refund.ts` becomes `billing-refund`. This avoids name drift and duplicate config. See `compiler/normalize-tool.ts` and `public/definitions/tool.ts`.
+- Authored tools can override framework tools by filename, and `disableTool()` can remove framework defaults. `disableRoute()` applies the same idea to channel routes. This is the cleanest precedent for per-agent tool/channel profiles.
+- Dynamic tools/skills/instructions are lifecycle-scoped (`session.started`, `turn.started`, `step.started`) and durable metadata is carried in session/context state rather than live process memory. This maps to our need for per-session plugin tools and readiness-gated command tools.
+- Each runtime agent node owns exactly one sandbox registry. Declared subagents are separate nodes with their own tools/skills/sandbox; they do **not** inherit by default. See `runtime/resolve-agent-graph.ts` and `runtime/sandbox/registry.ts`.
+- eve has two subagent forms: declared subagents get their own sandbox; the built-in `agent` tool delegates to a fresh copy of the current agent and intentionally shares parent sandbox state. See `execution/subagent-tool.ts`.
+- Sandbox lifecycle separates template prewarm from live session create. `bootstrap()` writes reusable template state; `onSession()` runs per live session; template keys include backend, node id, session id, source hash, seed content hash, source graph hash, framework contract version, and revalidation key. See `runtime/sandbox/template-plan.ts`, `runtime/sandbox/keys.ts`, and `execution/sandbox/prewarm.ts`.
+- Seeded files are mounted into `/workspace` from `agent/sandbox/workspace/**`; skills are also materialized into the sandbox resource tree. See `compiler/workspace-resources.ts` and `runtime/workspace/seed-files.ts`.
+- Model-facing file tools require absolute `/workspace/...` paths and enforce read-before-write/stale-write stamps. That is a good safety pattern for boring-bash write/edit tools, but host/runtime tools can bypass it unless the adapter enforces lower-level policy.
+- Backend names do not imply equal capability: eve `just-bash` is a file-backed JS shell with no real binaries and weak network isolation, while Docker/Vercel provide real Bash/filesystems. Boring-bash providers must advertise a capability matrix, not just `exec: true`.
+- Durability is workflow-owned. The long-lived workflow driver owns the event stream and parks on hooks; each turn runs as a child workflow; durable session snapshots include history, state, dynamic tool metadata, authorization state, read stamps, and sandbox reconnect state. See `execution/workflow-entry.ts`, `turn-workflow.ts`, and `durable-session-store.ts`.
+
+### eve patterns to avoid
+
+- eve assumes every agent has one sandbox by default. For boring-ui, `sandbox: none` must be the default for pure/headless agents.
+- eve framework tools always exist unless disabled. For boring-ui, file/bash tools should not even be registered unless `boring-bash` is active and ready.
+- eve hardcodes `/workspace` as the user-visible root and requires absolute paths for model file tools. We can use a similar virtual root, but must support workspace-scoped partial mounts and multiple agents per workspace.
+- eve default backends fall back from Vercel → Docker → microsandbox → just-bash. For boring-ui, provider fallback must be policy-driven; silently dropping to a less-isolated or less-capable provider is dangerous.
+
+## Target vocabulary
+
+| Package | Owns | Does not own |
+| --- | --- | --- |
+| `@hachej/boring-agent` | model loop, sessions, runner API, tool registry, channel-neutral event stream | filesystem, file routes, bash, file UI |
+| `@hachej/boring-bash` | optional agent working environment: fs + exec + file UI/routes/tools/provisioning | LLM harness, auth, workspace membership, Slack/email transport |
+| `@hachej/boring-workspace` | UI shell, layout, plugin host, UI bridge/RPC | agent harness, bash substrate |
+| `@hachej/boring-core` | auth, DB, workspaces, billing, agent-instance registry | concrete bash providers except via config/composition |
+
+## Non-negotiable compatibility constraints
+
+1. **Agent without files is first-class.** `createAgent*` must support no `Workspace`, no `Sandbox`, no cwd exposed to the model, no file routes, no bash tools.
+2. **`boring-bash` is optional.** Hosts/plugins must declare whether they require it.
+3. **No value import cycle.** `@hachej/boring-agent` must have zero value imports from `@hachej/boring-bash`; bash/runtime features are injected by the host/CLI/composition layer.
+4. **UI bridge/RPC remains workspace-owned.** Existing `/api/v1/ui/*`, `exec_ui`, `get_ui_state`, `WorkspaceBridge`, and runtime plugin gateway `/api/v1/plugins/:pluginId/*` must keep working.
+5. **No split brain.** When `boring-bash` provides both fs and exec, they are one paired environment with the same model-visible cwd.
+6. **Provisioning is declarative and scoped.** Agent packages and plugins declare bash requirements; the host extends `provisionWorkspaceRuntime()` to resolve, fingerprint, provision, gate tools, and report readiness.
+7. **Custom SDKs are provisioning inputs, not ad-hoc host paths.** SDKs are packed/copied into the bash environment with stable runtime paths and no host path leakage.
+
+## Proposed public shapes
+
+### Agent: runtime-free runner
+
+```ts
+interface AgentEnvironment {
+  sessionStorageRoot: string
+  workspaceId?: string
+  agentId?: string
+  featureGrants?: Record<string, unknown>
+}
+
+interface AgentFeature {
+  id: string
+  tools?(ctx: AgentFeatureContext): AgentTool[] | Promise<AgentTool[]>
+  systemPrompt?(ctx: AgentFeatureContext): string | undefined | Promise<string | undefined>
+  readinessRequirements?: string[]
+}
+
+interface AgentServerFeature extends AgentFeature {
+  routes?(ctx: AgentFeatureContext): FastifyPluginAsync | undefined
+}
+
+interface AgentFeatureContext {
+  agentId: string
+  workspaceId?: string
+  environment: AgentEnvironment
+  getGrant<T>(id: string): T | undefined
+}
+```
+
+`@hachej/boring-agent` should create an agent with only storage/session state by default. Features add tools/routes/prompt context.
+
+### Boring Bash: one package, layered exports
+
+```txt
+@hachej/boring-bash/shared
+  BashEnvironment, BashFs, BashExec, BashCapability, BashRequirement
+
+@hachej/boring-bash/server
+  createBashEnvironment, file routes, fs event routes, search routes
+
+@hachej/boring-bash/agent
+  createBashAgentFeature() -> read/write/edit/ls/find/grep/bash tools
+
+@hachej/boring-bash/plugin
+  createBashFrontPlugin() -> file tree, editors/viewers, surface resolver
+
+@hachej/boring-bash/providers
+  direct, bwrap, vercel-sandbox, remote-worker, readonly, none
+```
+
+Internal layering is allowed; product vocabulary stays one package: `boring-bash`.
+
+### Bash environment
+
+```ts
+interface BashEnvironment {
+  id: string
+  provider: 'direct' | 'bwrap' | 'vercel-sandbox' | 'remote-worker' | string
+  runtimeCwd: string
+  fs?: BashFs
+  exec?: BashExec
+  search?: BashSearch
+  watch?: BashWatch
+  provisioning?: BashProvisioningRuntime
+  capabilities: {
+    fs: 'none' | 'readonly' | 'readwrite'
+    exec: boolean
+    realBash?: boolean
+    realBinaries?: boolean
+    networkIsolation?: 'none' | 'process' | 'container' | 'microvm' | 'provider'
+    watch: boolean
+    search: boolean
+  }
+}
+```
+
+`none` is valid for agent core, but `boring-bash` itself should no-op if no fs/exec capability exists.
+
+### Runtime mode vs bash provider taxonomy
+
+Do not collapse these names:
+
+| Current runtime mode | Current sandbox provider | Boring-bash provider | Notes |
+| --- | --- | --- | --- |
+| `direct` | `direct` | `direct` | Trusted host mode; lexical path safety only, no isolation. |
+| `local` | `bwrap` | `bwrap` | Linux bubblewrap mode; mode id differs from provider id. |
+| `vercel-sandbox` | `vercel-sandbox` | `vercel-sandbox` | Remote sandbox; browser file API and bash must delegate to same provider view. |
+| remote-worker adapter | `remote-worker` | `remote-worker` | Worker server/client split must stay explicit. |
+| pure/headless | none | none | No workspace/fs/bash/cwd at all. |
+| readonly files | provider-specific | `readonly` facade | Optional facade over fs/search without exec. |
+
+Avoid overloaded words:
+
+- use `featureGrants`, not generic `capabilities`, for agent feature grants;
+- use `sessionStorageRoot` for transcript/session storage;
+- keep `RuntimeBundle.storageRoot` / `getRuntimeBundleStorageRoot()` for host file roots until moved into boring-bash;
+- keep current `AgentRuntimeCapabilities` (`nativeFollowUp`, `aiSdkOwnsHistory`) separate from bash provider capabilities.
+
+Provider capability matrix must be explicit, for example:
+
+| Boring-bash provider | FS | Exec | Real Bash | Real binaries | Network isolation | Notes |
+| --- | --- | --- | --- | --- | --- | --- |
+| `none` | none | no | no | no | n/a | Pure/headless agent. |
+| `readonly` facade | readonly | no | no | no | n/a | File tree/search/viewer without shell. |
+| `direct` | readwrite | yes | host-dependent | host-dependent | none | Trusted developer/CI only. |
+| `bwrap` | readwrite | yes | host-dependent | host-dependent | process/container-ish | Linux-only; mode id is `local`. |
+| `vercel-sandbox` | readwrite | yes | yes | provider image | provider | Remote sandbox/source of truth for sandbox-primary workspaces. |
+| `remote-worker` | readwrite | yes | worker-dependent | worker-dependent | worker-dependent | Must report its own matrix through handshake. |
+
+## Bash, files, and storage model
+
+The right abstraction is not “bash implies whole workspace”. It is:
+
+```txt
+WorkspaceStorage     durable app/project data
+  -> BashVolumeView  selected files, mode, overlays, virtual root
+    -> BashSession   optional live process/sandbox over that view
+      -> BashTools   model-visible tools backed by that session/view
+```
+
+Rules:
+
+1. **Files can exist without bash.** Read-only docs, DB/R2-backed workspaces, file viewers, search, and review agents may need fs/search but no shell.
+2. **Bash cannot be separated from a file view.** If `exec` is enabled, it must run against the same virtual file view exposed by fs/search/watch tools. No split brain.
+3. **Partial workspace access must be physical for untrusted exec.** API-level path filters are insufficient once a shell exists. For sandbox providers, seed/copy/mount only the allowed subset; for direct mode, mark partial mounts as advisory or disallow untrusted use.
+4. **Storage lifetime and sandbox lifetime are different.** The durable workspace may outlive any sandbox. Sandbox templates/sessions are cached projections of a normalized plan.
+5. **Recovery needs a stable environment key.** If an interrupted durable session resumes, the bash adapter must either reconnect to the same file view or explicitly surface that file state is gone; conversation durability alone is not enough.
+6. **Mutable work should use overlays by default.** A coding agent can get a writable overlay/branch, while a reviewer can get read-only source plus scratch.
+
+### Volume view shape
+
+V1 must still present **one coherent model-visible namespace**. The current documented invariant says file tree root, shell cwd, model-visible cwd, and `BORING_AGENT_WORKSPACE_ROOT` correspond. Phase 0 must either refine/supersede that ADR/runtime-doc invariant or defer multi-mount overlays to v2. Multiple mounts may be implementation details only if they materialize under one `/workspace` view that file routes, search, watch, and exec all share.
+
+```ts
+interface BashVolumeView {
+  id: string
+  workspaceId?: string
+  root: '/workspace'
+  mounts: BashMount[]
+  overlay?: {
+    mode: 'none' | 'scratch' | 'branch' | 'persistent'
+    persistAs?: 'workspace-patch' | 'artifact' | 'discard'
+  }
+}
+
+interface BashMount {
+  id: string
+  source: 'workspace' | 'template' | 'artifact' | 'sdk' | 'scratch'
+  target: string // virtual absolute path, usually under /workspace
+  mode: 'readonly' | 'readwrite'
+  include?: string[]
+  exclude?: string[]
+}
+```
+
+### Sandbox policy shape
+
+```ts
+interface BashSandboxPolicy {
+  provider: 'none' | 'direct' | 'bwrap' | 'vercel-sandbox' | 'remote-worker' | string
+  volume: BashVolumeView
+  exec?: {
+    enabled: boolean
+    rawBash?: boolean
+    predefinedTools?: string[]
+    commandPolicy?: BashCommandPolicy
+    timeoutMs?: number
+  }
+  network?: 'disabled' | 'allowlisted' | 'allow-all'
+  env?: Record<string, string>
+  secrets?: string[] // names only; host exposes status/grants, never raw values to browser/model
+  services?: BashManagedServiceRequirement[] // long-lived dev servers, ports, iframe/proxy grants
+  provision?: BashRequirement['provisioning']
+}
+```
+
+This policy can be declared at app, child-app, workspace, agent, subagent, session, or plugin level. The effective runtime is an intersection, not a union of powers:
+
+```txt
+effective = backend capabilities ∩ app defaults ∩ childApp/workspaceKind policy ∩ workspace max policy ∩ agent policy ∩ session/user grants ∩ plugin/tool requirement
+```
+
+Resolution order should be explicit:
+
+```txt
+app defaults < childApp/workspaceKind policy < workspace policy < agent policy < subagent policy < session/user grants < plugin/tool requirement
+```
+
+The resolver must reject impossible merges instead of silently widening access.
+
+### Storage-primary vs sandbox-primary
+
+Every workspace runtime must choose one source-of-truth model:
+
+| Model | Source of truth | Use when |
+| --- | --- | --- |
+| sandbox-primary | live sandbox `/workspace` | remote coding sessions where file API/tree/search/bash should all delegate to the sandbox |
+| storage-primary | host/object/git storage; sandbox is materialized view/overlay | disposable sandboxes, review agents, patch workflows, restricted file exposure |
+
+Forbidden split-brain states:
+
+- file tree reads host `/data/workspaces/<id>` while bash edits remote `/workspace`;
+- git/branch/status routes read a different source of truth than file routes and bash;
+- `read_file` hides files but raw bash can still access them;
+- session durability is treated as file durability, or vice versa.
+
+## Declarative agent model
+
+We should support both a TypeScript API and manifest/layout-driven declarations.
+
+### TypeScript API
+
+```ts
+const codingAgent = defineBoringAgent({
+  id: 'coding',
+  model: 'anthropic/claude-sonnet-4-6',
+  instructions: './instructions.md',
+  features: [uiBridgeFeature()],
+  bash: {
+    provider: 'vercel-sandbox',
+    volume: {
+      root: '/workspace',
+      mounts: [{ id: 'repo', source: 'workspace', target: '/workspace', mode: 'readwrite' }],
+      overlay: { mode: 'branch', persistAs: 'workspace-patch' },
+    },
+    exec: {
+      enabled: true,
+      rawBash: false,
+      predefinedTools: ['git_diff', 'run_tests', 'apply_patch'],
+    },
+  },
+})
+```
+
+### Package/layout API
+
+Eve’s slot model is worth copying for authored agent packages:
+
+```txt
+agent/
+  agent.ts              runtime config
+  instructions.md       base prompt
+  tools/*.ts            authored tools, path-derived names
+  skills/*              on-demand procedures
+  subagents/*           child agents
+  channels/*            Slack/email/HTTP/etc.
+  bash.ts               sandbox policy, provider, mounts, bootstrap
+  bash/workspace/**     files seeded into /workspace
+```
+
+For boring-ui plugins, keep package manifests, but use the same concepts:
+
+```jsonc
+{
+  "boring": {
+    "requires": ["boring-bash"]
+  },
+  "bash": {
+    "capabilities": { "fs": "readonly", "exec": false },
+    "mounts": [{ "source": "workspace", "include": ["docs/**"] }]
+  }
+}
+```
+
+### Framework tool registration
+
+Borrow eve’s override/disable rule and Flue’s adapter tool-factory seam, but reconcile it with the existing boring-ui tool families:
+
+- core agent registers only model/session/channel tools;
+- `boring-bash` contributes default file/bash/upload tools only when active;
+- move or explicitly keep out of scope the true current inventory:
+  - `buildHarnessAgentTools()`: `bash`, `execute_isolated_code`;
+  - `buildFilesystemAgentTools()`: `read`, `write`, `edit`, `find`, `grep`, `ls`;
+  - `buildUploadAgentTools()`: upload/runtime artifact tools bound to the runtime bundle;
+- preserve existing readiness tags/contracts (`workspace-fs`, `sandbox-exec`, `runtime-dependencies`, `runtime:<id>`);
+- unify with `disableDefaultFileTools` instead of adding a parallel disable path; decide separately whether bash/harness tools get their own disable flag;
+- agent/plugin declarations may disable defaults (`read`, `write`, `bash`) or replace them by name;
+- a sandbox policy can expose predefined command tools without exposing raw `bash`;
+- reserved framework names (`task`, `finish`, `exec_ui`, etc.) remain protected.
+
+## Plugin and agent bash requirements
+
+Plugins and agent packages need to say whether they require `boring-bash` and what must be installed into it.
+
+### Requirement shape
+
+```ts
+interface BashRequirement {
+  id: string
+  source: 'agent' | 'plugin' | 'app'
+  optional?: boolean
+  capabilities?: {
+    fs?: 'readonly' | 'readwrite'
+    exec?: boolean
+  }
+  provisioning?: {
+    templateDirs?: RuntimeTemplateContribution[]
+    nodePackages?: RuntimeNodePackageSpec[]
+    python?: RuntimePythonSpec[]
+    sdkArchives?: BashSdkArchiveSpec[]
+    env?: Record<string, string>
+    pathEntries?: string[]
+  }
+  readiness?: {
+    timeoutMs?: number
+    healthCheck?: BashHealthCheckSpec
+  }
+  services?: BashManagedServiceRequirement[]
+}
+
+interface BashManagedServiceRequirement {
+  id: string
+  command: string | string[]
+  cwd?: string
+  ports?: Array<{ port: number; purpose: 'iframe' | 'api' | 'preview'; public?: boolean }>
+  healthCheck?: BashHealthCheckSpec
+  teardown?: 'kill-process-tree' | 'provider-default'
+}
+```
+
+### Manifest-level declaration
+
+Add a boring manifest field for runtime needs. Validation must be import-free: hosts should be able to inspect `boring.requires` and `bash` capability/provisioning blocks before executing plugin or workspace-authored agent code.
+
+```jsonc
+{
+  "boring": {
+    "front": "front/index.tsx",
+    "server": "server/index.ts",
+    "requires": ["boring-bash"]
+  },
+  "bash": {
+    "capabilities": { "fs": "readwrite", "exec": true },
+    "nodePackages": [{ "id": "my-cli", "packageName": "my-cli" }],
+    "python": [{ "id": "my-sdk", "projectFile": "sdk/pyproject.toml" }]
+  }
+}
+```
+
+Rules:
+
+- `requires: ["boring-bash"]` means the plugin should not activate unless the host enables the bash package/capability.
+- A front-only viewer can require only fs readonly.
+- A tool/plugin that runs commands must request exec.
+- Optional requirements degrade gracefully and surface diagnostics.
+
+## Smarter provisioning model
+
+Current provisioning (`ProvisionWorkspaceRuntimeOptions` / `provisionWorkspaceRuntime()`) should evolve, not be thrown away.
+
+### Extend the existing resolver
+
+Do not create a parallel `resolveBashProvisioningPlan()` path unless it is a thin normalization layer feeding `provisionWorkspaceRuntime()`. The real delta is:
+
+```ts
+resolveBashProvisioningRequirements({
+  workspaceId,
+  agentId,
+  enabledPlugins,
+  agentDefinition,
+  appDefaults,
+  provider,
+}) -> ProvisionWorkspaceRuntimeOptions
+```
+
+It should:
+
+1. collect requirements from app, agent definition, and plugins;
+2. validate capability needs against the selected bash provider before provisioning;
+3. merge into the existing structural provisioning contribution model by stable `id`;
+4. reject conflicting definitions for the same `id` unless a resolver is explicit;
+5. keep the existing fingerprint/`WorkspaceProvisioningResult.changed` skip behavior;
+6. preserve existing readiness keys used by `mergeTools({ checkReadiness })`;
+7. extend readiness from current aggregate states (`not-started`, `preparing`, `ready`, `failed`) to per-requirement states, adding `optional_failed` only as a compatible extension;
+8. add optional `healthCheck` / SDK archive support without bypassing pack-artifact rules.
+
+### Scoping
+
+Provisioning must support these scopes:
+
+| Scope | Use case |
+| --- | --- |
+| workspace | shared project files/CLIs used by all agents |
+| agent | agent-specific SDKs, prompts, tools, channel adapters |
+| plugin | plugin-specific CLIs/SDKs/assets |
+
+The physical layout can still be under `.boring-agent/` initially, but the metadata must know who requested each piece.
+
+### Custom SDKs
+
+Custom SDKs should enter the sandbox through declared provisioning, not arbitrary host paths:
+
+- local npm/Python packages are packed into tarballs for sandbox providers;
+- static SDK assets are copied via `templateDirs` / `sdkArchives`;
+- runtime env values that point at files are rewritten to sandbox-visible paths;
+- secrets are declared by name only and injected by the host, never written into plan files;
+- SDK health checks can gate related tools.
+
+This preserves the existing pack-artifact rule for sandbox modes and avoids leaking `/home/...` or app-private paths into the model.
+
+## UI bridge and runtime plugin RPC compatibility
+
+`boring-bash` must not swallow or replace the workspace bridge.
+
+Keep these workspace-owned surfaces stable:
+
+- `UiBridge.postCommand()`
+- `/api/v1/ui/state`
+- `/api/v1/ui/commands`
+- `/api/v1/ui/commands/next`
+- `exec_ui` / `get_ui_state` tools from workspace server composition
+- `WorkspaceBridge` front API
+- runtime plugin gateway `/api/v1/plugins/:pluginId/*`
+
+`boring-bash/plugin` contributes a `workspace.open.path` surface resolver and file panes. Agents still open files through `openSurface`/`openFile` commands. If the bash plugin is not enabled, those panels/resolvers simply are not registered and UI tools report missing panels/capabilities.
+
+Runtime plugin RPC should gain capability context, not a new route family:
+
+```ts
+interface RuntimePluginContext {
+  pluginId: string
+  workspaceId?: string
+  availableFeatures: {
+    bash?: BashEnvironmentSummary
+    uiBridge?: boolean
+  }
+}
+```
+
+Generated/runtime plugin backends that require bash should declare it in manifest. The runtime backend registry should skip or diagnose them when `boring-bash` is not active.
+
+## Multi-agent workspace model
+
+A workspace should be able to compose several agents with different bash needs:
+
+```ts
+agents: [
+  { id: 'coding', package: '@hachej/coding-agent', features: ['boring-bash'] },
+  { id: 'reviewer', package: '@hachej/review-agent', features: ['boring-bash'], bash: { fs: 'readonly', exec: false } },
+  { id: 'concierge', package: '@hachej/email-agent', features: [] },
+]
+```
+
+Required namespace additions:
+
+- routes: `/api/v1/agents/:agentId/...` or header-scoped equivalent;
+- bindings: include `agentId` in the existing binding scope key alongside mode, workspace id, root, template path, pi flag, and session namespace;
+- sessions: include `agentId` in `sessionNamespace` and the session-root layout, preserving the AGENTS.md rule that transcripts live on the host durable session volume (`BORING_AGENT_SESSION_ROOT`, not workspace/container home);
+- tool catalog: per agent;
+- provisioning: per `(workspaceId, agentId, bashPlanFingerprint)`;
+- bridge commands: include `agentId` where useful for attribution, but keep workspace UI state shared.
+
+Required isolation test: two agents in one workspace with same `sessionId` must not share harness bindings, tool catalogs, or transcripts.
+
+### Agent node vs subagent profile
+
+Use two distinct concepts, because Flue and eve prove they solve different problems:
+
+| Concept | Environment | Best for |
+| --- | --- | --- |
+| `AgentProfile` | Same parent bash environment, optionally narrower cwd/view | cheap delegated tasks, same workspace/tool trust |
+| `AgentNode` | Own config, tools, channels, sandbox policy, durability | specialist agents with different provider/mount/tool/network policy |
+
+Defaults should be conservative:
+
+- declared child agents inherit **nothing** unless explicitly configured;
+- “copy of current agent” delegation may share parent sandbox state, but must be explicit;
+- narrower child views are allowed; wider child views require owner approval or workspace policy;
+- delegation depth must be capped;
+- shared-sandbox copy agents need non-overlapping write scopes or stale-write detection before concurrent writes are allowed.
+
+### User as an agent?
+
+Do **not** model the human user as an autonomous agent with max powers.
+
+Model the user as a **Principal / Supervisor / Approval Channel**:
+
+- principals own capabilities (`workspace.owner`, `bash.grant`, `secret.grant`, `merge.approve`);
+- agents request capabilities through explicit gates;
+- UI/HITL channels carry user decisions into the session;
+- audit logs attribute every escalation to the user/principal, not to a model persona.
+
+It is useful to render the user as a node in an orchestration graph, but dangerous to make “user” a model-callable super-agent. If we later build a personal assistant with broad powers, it is still just an agent with a declared policy, not magic root authority.
+
+## Open issue coverage check
+
+A sweep of the current open GitHub issues says this abstraction covers the core runtime/package-boundary tracks, but it should not claim to cover the whole backlog.
+
+### Directly covered or materially advanced
+
+- Runtime-free agent / package boundary / harness pluggability: #391, #12, #242.
+- Bash/runtime provider abstraction and sandbox source-of-truth: #16, #223.
+- File API/UI ownership by boring-bash: #26, #220, #221.
+- Plugin/runtime capability declarations and remote-safe diagnostics: #357, #254, #256.
+- Multi-agent/session scoping foundation: #243, #211.
+
+### Indirectly helped, but requires explicit extra abstractions
+
+These are **not automatically solved** by boring-bash; the plan must leave hooks for them:
+
+1. **External harness review/question hooks (#380).** Add a channel-neutral hook ingestion API with source harness/session ids, auth, redaction, routing, and approval/HITL mapping.
+2. **Session history search (#379).** Add a session index/search API independent of bash, scoped by `workspaceId` + `agentId`, with Pi title/name/content parity and deep-link tests.
+3. **Child-app platform (#376).** Add `childAppId` / `workspaceKind` into the effective policy stack between app defaults and workspace policy. Auth, billing, domains, and Stripe products stay separate.
+4. **Remote-worker hardening (#307).** Remote-worker provider handshake must report concrete isolation claims: gVisor/seccomp status, per-workspace network isolation, private metadata/CIDR egress policy, and cross-workspace boundary.
+5. **Hosted external plugins and secrets (#357, #181).** Manifest validation must fail closed in remote modes before executing plugin code. Browser/plugin contexts get secret status/grant metadata only, never raw secrets.
+6. **Long-lived plugin services (#328, #258).** Some plugins need more than one-shot bash: managed process lifecycle, health checks, port/iframe grants, command policy, and teardown.
+7. **File tree replacement (#295).** `boring-bash/plugin` should expose a file tree data-provider boundary and optional path-list/tree-index endpoint so tree UI can change without reworking routes.
+8. **Markdown collaboration/document authority (#367, #226).** `write`/`edit` tools must be overridable/routable through document coordinators such as TipTap/Yjs, with stale version/hash checks, so file tools do not bypass live collaborative state.
+9. **Git/source-of-truth compatibility (#189).** Branch/status routes must use the same storage-primary or sandbox-primary source as file routes and bash.
+10. **Operational commands and provider failures (#371, #228, #224).** Compaction/provider recovery and slash-command handling are agent/session concerns, not boring-bash; expose a non-bash operational-event/command seam if route composition changes.
+
+### Out of scope for this abstraction
+
+Keep these as separate tracks: product plugins (#381, #197), multi-project left-bar UI work (#377, #361, #363, #362), visual/theme/pane polish (#375, #358, #308, #283, #257), desktop wrapper (#318), workbench performance (#267), billing/auth/database work (#127, #51, #27), docs annotation/review UI (#122), dependency migrations (#95), core-neutral catalog routes (#21), and event-bus typing (#5).
+
+## Migration phases
+
+### Phase 0 — ADR, naming lock, and invariant update
+
+- Add an ADR: `boring-agent` becomes runtime-free; `boring-bash` owns files/bash/file UI.
+- Update `docs/DECISIONS.md` §7 and `packages/agent/docs/runtime.md`: mark `Workspace + Sandbox` pairing as a `boring-bash` invariant, not an agent invariant.
+- Explicitly decide v1 namespace semantics: preserve one coherent model-visible `/workspace` namespace; defer arbitrary multi-mount overlays unless the ADR defines how they still materialize into one namespace.
+- Lock package name as `@hachej/boring-bash`.
+
+### Phase 1 — Dependency inversion and true no-runtime mode
+
+- Invert dependency first: `createAgentApp()` / `registerAgentRoutes()` stop statically importing `resolveMode()` / built-in runtime modes. Runtime/features are injected by host/CLI/composition.
+- Add an invariant test that `@hachej/boring-agent` has zero value imports from `@hachej/boring-bash`.
+- Add feature/grant registry to agent server composition, reusing existing `registerCapabilitiesContributor` where possible.
+- Add a channel-neutral external review/question hook ingestion API with source harness/session ids, auth, redaction, routing, and approval/HITL mapping.
+- Add a non-bash operational-event/command seam if route composition touches slash commands, reload, compaction, or provider recovery.
+- Add a `runtime: none` or `features: []` path that registers only chat/session/model routes.
+- Separate `sessionStorageRoot` from workspace root/cwd and existing `RuntimeBundle.storageRoot`.
+- Audit `createPiCodingAgentHarness` and pi-coding-agent resource/system-prompt loading for implicit cwd, AGENTS.md, workspace context, and file/tool assumptions. Decide whether pure headless mode can use pi or needs a non-pi harness.
+- Ensure no file/tree/search/git/bash/upload routes/tools are mounted without `boring-bash`.
+
+### Phase 2 — Create `@hachej/boring-bash`
+
+- Create package and type-only shared contracts without introducing an agent↔bash value import cycle.
+- Move shared workspace/sandbox/runtime contracts into `boring-bash/shared` only after Phase 1 injection is in place.
+- Move providers/adapters: direct, bwrap, vercel-sandbox, remote-worker, preserving the mode/provider mapping table.
+- Clarify the remote-worker split before moving: client/mode code currently lives under agent; worker server code currently lives in `apps/full-app`.
+- Keep compatibility re-exports from `@hachej/boring-agent/server` during migration.
+
+### Phase 3 — Move file routes and tools
+
+- Move file/tree/search/fs-events/stat/dir routes into `boring-bash/server`.
+- Move `buildFilesystemAgentTools()` (`read/write/edit/find/grep/ls`) and `buildHarnessAgentTools()` bash-related pieces (`bash`, `execute_isolated_code`) into `boring-bash/agent` or consciously split `execute_isolated_code` with a documented owner.
+- Move or explicitly retain `buildUploadAgentTools()` with a documented owner.
+- Preserve readiness tags and existing `disableDefaultFileTools` behavior; add a separate bash/harness disable flag only if needed.
+- Replace hardwired agent registration with injected `createBashAgentFeature()`.
+
+### Phase 4 — Move filesystem front plugin
+
+- Move `packages/workspace/src/plugins/filesystemPlugin/front/*` to `boring-bash/plugin`.
+- Preserve workspace coupling contracts: panel ids, `surfaceResolver`, file panel binding, agent file bridge/session-change integration, and fetch routes under `/api/v1/files/*` or compatibility aliases.
+- Introduce a `FileTreeDataProvider` boundary plus optional path-list/tree-index route and fs-event delta contract, so file tree UI can be replaced without rerouting file APIs again.
+- Support document-authority overrides: `write`/`edit` can route through editor/document coordinators (TipTap/Yjs/etc.) with stale version/hash checks when a live collaborative document owns the file.
+- Keep workspace default plugin import/re-export compatibility initially.
+- Preserve panel ids and surface resolver behavior.
+
+### Phase 5 — Smarter provisioning by extending current provisioning
+
+- Introduce `BashRequirement` and an import-free requirement normalizer that feeds `provisionWorkspaceRuntime()`.
+- Convert current plugin/app provisioning into requirement sources without losing `WorkspaceProvisioningResult.changed` fingerprint skipping.
+- Add readiness diagnostics per requirement while preserving current aggregate readiness keys and states.
+- Add `optional_failed`, health checks, and SDK archives as compatible extensions.
+- Gate tools on existing readiness keys (`runtime-dependencies`, `runtime:<id>`, `workspace-fs`, `sandbox-exec`).
+- Reconcile Vercel template packaging/snapshotting with a two-phase bootstrap/on-session model.
+
+### Phase 6 — Plugin manifest requirements
+
+- Add import-free manifest validation for `boring.requires` and `bash` block before executing plugin/agent code.
+- Runtime plugin manager reports clear diagnostics when a plugin requires missing bash capabilities.
+- Runtime backend RPC receives available feature context.
+- Add hosted-plugin remote-mode constraints: fail closed when a plugin requires unavailable bash/fs/exec/service/secret features.
+- Add host-owned secret status/grant API; browser plugin contexts see status only, never raw values.
+- Add managed service lifecycle for trusted plugins that need dev servers or previews: process supervision, health, port/iframe/proxy grants, and teardown.
+- Map user approval/HITL grants to concrete tool visibility; hide approval tools when a session cannot request input.
+
+### Phase 7 — Multi-agent routing
+
+- Add `agentId`-scoped routes/session/catalog/provisioning.
+- Thread `agentId` through binding scope key, `sessionNamespace`, and session root layout.
+- Add session-history index/search API scoped by `workspaceId` + `agentId`, independent of boring-bash, with title/name/content search parity for Pi sessions.
+- Preserve URL/deep-link compatibility for multi-project and multi-agent session routes.
+- Update `WorkspaceAgentFront` to compose agent definitions, not one implicit agent.
+- Keep one shared workspace UI bridge, with optional `agentId` attribution.
+
+## Test plan
+
+Minimum gates before considering the migration complete:
+
+- pure agent server starts with no workspace, no file routes, no file tools, no bash tool, no cwd prompt leakage;
+- pi no-filesystem system-prompt snapshot proves no AGENTS.md/workspace context is injected in pure mode, or pure mode uses a non-pi harness;
+- import invariant: `@hachej/boring-agent` has no value imports from `@hachej/boring-bash`;
+- mode/provider mapping tests cover `direct`, `local`→`bwrap`, `vercel-sandbox`, `remote-worker`, `none`, and readonly facade behavior;
+- existing workspace playground still opens file tree/editor and uses read/write/bash;
+- `exec_ui openFile` still opens files through the moved boring-bash panels;
+- runtime plugin RPC `/api/v1/plugins/:pluginId/*` still reloads and dispatches;
+- import-free plugin manifest validation diagnoses `boring-bash` requirements before executing plugin code;
+- plugin requiring `boring-bash` is skipped/diagnosed when bash disabled;
+- plugin requiring a custom SDK provisions it and gates tools until ready;
+- readiness compatibility: existing `not-started`/`preparing`/`ready`/`failed` states and readiness tags continue to gate tools;
+- `disableDefaultFileTools` parity is preserved after moving tools;
+- remote-worker mode still avoids split brain: browser file API and bash see same files;
+- Vercel sandbox provisioning still packs local SDKs, no symlink/host path leakage;
+- core full-app can disable external plugins and still compose static boring-bash;
+- multi-agent session namespaces do not collide and two agents with same session id do not share harness bindings/transcripts;
+- shared-sandbox subagents enforce delegation depth cap and stale-write/non-overlapping write safeguards;
+- external review/question hook creation, redaction, auth, and routing work without requiring boring-bash;
+- session-history index/search returns correct results scoped by `workspaceId` + `agentId` and preserves Pi title/name parity;
+- child-app/workspace-kind policy can narrow bash requirements and never widens workspace policy;
+- remote-worker provider handshake reports isolation/network capability claims and fail-closed behavior;
+- hosted plugin validation fails closed before executing plugin code when bash/service/secret requirements are unavailable;
+- managed service plugin lifecycle covers start, health, port/iframe/proxy grant, and teardown;
+- `FileTreeDataProvider` path-list/tree-index and fs-event deltas work with existing file routes;
+- document-authority override routes write/edit through collaborative document coordinator when active;
+- git/branch/status routes use the same source of truth as file routes and bash.
+
+## Open decisions
+
+1. Should bash providers live under `boring-bash/providers` or a separate private package later?
+2. Route shape for multi-agent: path prefix `/api/v1/agents/:agentId` vs header-based scoping?
+3. How much provisioning is workspace-shared vs agent-private by default?
+4. Should readonly fs be a first-class capability in v1 or deferred?
+5. Is arbitrary multi-mount/overlay support v1, or do we preserve a single `/workspace` view and defer advanced projections?
+6. Is pure/headless mode implemented through pi-coding-agent with cwd disabled, or a separate non-pi harness?

--- a/docs/issues/391/runtime-refactor/todos/README.md
+++ b/docs/issues/391/runtime-refactor/todos/README.md
@@ -1,0 +1,121 @@
+# Boring Bash runtime-free agents — TODO/bead plan pack
+
+Status: first generated TODO pass. Must pass thermo review before creating real `br` beads or implementation PRs.
+
+These TODO files plus this README are intentionally self-contained. A future implementer should not need to read the markdown architecture plan first, but every future real `br` bead should copy the relevant excerpts from this TODO pack into its own description and cite the source TODO id.
+
+## Source plan pack
+
+- `../00-global-isa.md`
+- `../01-agent-core-runtime-free.md`
+- `../02-boring-bash-environment.md`
+- `../03-policy-provisioning-readiness.md`
+- `../04-plugin-child-app-runtime.md`
+- `../05-multi-agent-sessions-hooks.md`
+- `../06-migration-phases.md`
+- `../07-tests-review-acceptance.md`
+
+## TODO files
+
+1. [`TODO-00-foundation-adr.md`](TODO-00-foundation-adr.md) — ADRs, package ownership, invariant updates, review gates.
+2. [`TODO-01-agent-core-pure-mode.md`](TODO-01-agent-core-pure-mode.md) — dependency inversion, pure no-filesystem agent, pi audit, operational hooks.
+3. [`TODO-02-boring-bash-package-providers.md`](TODO-02-boring-bash-package-providers.md) — package skeleton, providers, capability matrix, remote-worker split.
+4. [`TODO-03-routes-tools-ui.md`](TODO-03-routes-tools-ui.md) — routes/tools/UI plugin extraction, file tree provider, document authority.
+5. [`TODO-04-policy-provisioning-readiness.md`](TODO-04-policy-provisioning-readiness.md) — requirements, policy stack, provisioning, readiness, secrets, services.
+6. [`TODO-05-plugins-child-app-runtime.md`](TODO-05-plugins-child-app-runtime.md) — plugin manifests, hosted plugins, child-app/Macro scoping, full-app reload.
+7. [`TODO-06-multi-agent-sessions-hooks.md`](TODO-06-multi-agent-sessions-hooks.md) — AgentRegistry, agentId routing, sessions/search, external hooks.
+8. [`TODO-07-cleanup-release.md`](TODO-07-cleanup-release.md) — compatibility removal, docs, issue closure, release validation.
+
+## Key contract excerpts to copy into real beads
+
+### Agent feature façade
+
+```ts
+interface AgentEnvironment {
+  sessionStorageRoot: string
+  workspaceId?: string
+  agentId?: string
+  featureGrants?: Record<string, unknown>
+}
+
+interface AgentFeature {
+  id: string
+  tools?(ctx: AgentFeatureContext): AgentTool[] | Promise<AgentTool[]>
+  systemPrompt?(ctx: AgentFeatureContext): string | undefined | Promise<string | undefined>
+  readinessRequirements?: string[]
+}
+
+interface AgentServerFeature extends AgentFeature {
+  routes?(ctx: AgentFeatureContext): FastifyPluginAsync | undefined
+}
+```
+
+`AgentFeature` is a façade over existing tool/route/systemPrompt/capability contributors, not a second plugin system.
+
+### Bash provider capability facts
+
+Providers must declare fs mode, exec, real bash, real binaries, network isolation, watch/search, persistence, and provisioning support. Runtime mode ids and provider ids differ: `local` mode maps to `bwrap` provider.
+
+### Bash environment summary
+
+```ts
+interface BashEnvironment {
+  id: string
+  provider: 'direct' | 'bwrap' | 'vercel-sandbox' | 'remote-worker' | string
+  runtimeCwd: string
+  fs?: BashFs
+  exec?: BashExec
+  search?: BashSearch
+  watch?: BashWatch
+  provisioning?: BashProvisioningState
+  providerCapabilities: BashProviderCapabilities
+}
+```
+
+### Bash requirement normalizer
+
+`@hachej/boring-bash` owns requirement normalization and provider adapters. `@hachej/boring-agent` owns the existing provisioning engine over injected adapters. Host/core/CLI wires the two together.
+
+### Source-of-truth invariant
+
+For any active boring-bash environment, file routes, file tree, search/watch, bash, git/status, and model-visible cwd must share one source of truth.
+
+## Global dependency graph
+
+```txt
+BBA-000 foundation ADR/review gates
+  ├─> BBA-006 open decisions gate
+  ├─> BBA-010 dependency inversion + pure mode
+  │     ├─> BBA-020 boring-bash package/providers
+  │     │     ├─> BBA-030 routes/tools/UI extraction
+  │     │     │     ├─> BBA-037 source-of-truth model
+  │     │     │     │     └─> BBA-026 route-level source-of-truth regression
+  │     │     ├─> BBA-040 policy/provisioning/readiness
+  │     │     │     ├─> BBA-047 two-phase lifecycle/fingerprints
+  │     │     │     ├─> BBA-050 plugins/child-app/runtime services
+  │     │     │     └─> BBA-060 multi-agent/session/search/hooks
+  │     │     └─> BBA-070 cleanup/release
+  │     └─> BBA-060 multi-agent/session/search/hooks
+  └─> BBA-070 cleanup/release
+```
+
+## Global hard rules embedded into every task
+
+- Never work directly on `main` unless explicitly authorized.
+- No file deletion without explicit written permission.
+- No destructive git/filesystem ops.
+- No secrets in git/logs/prompts/issues.
+- Do not edit `.beads/*.jsonl` by hand; when converting to real beads, use `br` only.
+- Never launch bare `bv`; use `bv --robot-*` only.
+- Session history is host app user data: use host durable `BORING_AGENT_SESSION_ROOT`, normally `/data/pi-sessions`, not workspace/container home.
+- Preserve architectural invariants: no `node:*` or `Buffer` in shared code, routes/tools receive `Workspace`, path validation belongs to adapters, UI dispatch goes through `UiBridge.postCommand`, workspace base front/shared has no value import from agent, every error has stable code, pi file/shell tools flow through factories/adapters.
+
+## Review checklist for TODO pack
+
+- Every task has dependencies.
+- Every task is self-contained with why/context.
+- Every task has unit tests and e2e/smoke proof where applicable, with detailed structured logging.
+- Tests require detailed logging for mode/provider/workspace/agent/session ids.
+- No task creates package cycles.
+- No task creates parallel provisioning/readiness systems.
+- No task overclaims unrelated backlog issue closure.

--- a/docs/issues/391/runtime-refactor/todos/TODO-00-foundation-adr.md
+++ b/docs/issues/391/runtime-refactor/todos/TODO-00-foundation-adr.md
@@ -1,0 +1,191 @@
+# TODO-00 — Foundation, ADRs, and invariants
+
+## Purpose
+
+Create the unambiguous architecture foundation before touching code. This prevents import cycles, duplicated systems, split-brain runtime behavior, and accidental loss of the framework research that motivated the refactor.
+
+## Foundation proof/logging standard
+
+These are documentation/architecture beads, but they still need concrete proof. Each implementation PR for this file's beads should include a small validation/proof script or command transcript with detailed logging of:
+
+- docs/ADR files touched;
+- GitHub issue number(s) referenced;
+- expected invariant strings found or missing;
+- markdown link-check result;
+- import-invariant test targets that later code beads must implement;
+- open-decision ids and their status (`decided`, `deferred`, `blocked`);
+- reviewer/model review artifact paths and durable summary location.
+
+No secrets should appear in logs. Do not rely on `.tmp` as the only durable record of an architecture decision.
+
+## Beads / tasks
+
+### BBA-000 — Lock ADR: runtime-free agent + boring-bash ownership
+
+**Depends on:** none.
+
+**Why:** Implementation must start from a shared language. `@hachej/boring-agent` becomes a pure model/session/tool harness. `@hachej/boring-bash` owns optional files/bash/file UI/provider adapters.
+
+**Scope:**
+
+- Add an ADR under `docs/DECISIONS.md` or adjacent ADR location.
+- State the core research lessons the ADR is preserving:
+  - Flue: one `SessionEnv`-style backing environment for fs/tools/shell; session durability is not file durability; subagent profiles are not isolated sandboxes;
+  - Eve: import-free discovery before executing authored code; path-derived declarations; override/disable defaults; per-node sandbox policy; two-phase bootstrap/onSession lifecycle; one model-visible `/workspace` namespace.
+- State package ownership:
+  - agent owns model loop, sessions, runner API, tool registry, channel-neutral event stream, non-bash operational hooks, provisioning engine types/orchestration over injected adapters;
+  - boring-bash owns fs+exec environment, file routes/tools/UI, requirement normalizer, provider adapters/capabilities;
+  - workspace owns UI bridge/RPC/plugin host and remains the owner of `UiBridge.postCommand`;
+  - core/app composition owns auth/DB/workspaces/billing/child-app context resolution.
+- State child-app ownership boundary: `docs/plans/shared-child-app-platform.md` owns child-app registry/workspace-kind/billing/hostname decisions; this refactor only consumes resolved child-app context for runtime policy intersection.
+- State `@hachej/boring-agent` has no value imports from `@hachej/boring-bash`.
+- State provisioning ownership: existing agent-owned engine remains adapter-injected; bash normalizer/adapters live outside agent.
+- State compatibility strategy: moved boring-bash values must not be re-exported from agent/workspace barrels if that creates package cycles; type-only exports or host/composition shims are allowed when safe.
+- State user authority model: humans are principals/supervisors/approval channels, not model-callable root agents.
+
+**Unit/doc checks:**
+
+- Markdown link check for ADR references.
+- Static import invariant test planned in BBA-011.
+- Workspace↔boring-bash acyclicity test planned in BBA-011/BBA-034.
+- Proof script logs every required ADR keyword/invariant so reviewers can see if any core lesson was omitted.
+
+**Acceptance:** ADR is merged into docs, referenced by #391, and contains enough context that a future implementer understands why pure agents and boring-bash are separate without rereading the original research reports.
+
+### BBA-001 — Update runtime docs and current invariant wording
+
+**Depends on:** BBA-000.
+
+**Why:** Existing docs say Workspace + Sandbox swap as one runtime-mode pair. That remains true only when boring-bash is active; pure agents have no pair.
+
+**Scope:**
+
+- Update `packages/agent/docs/runtime.md` and relevant `docs/DECISIONS.md` §7 wording.
+- Clarify:
+  - pure agent: no workspace/sandbox/cwd and no boot-time plugin discovery over host cwd unless explicitly configured;
+  - boring-bash active: file tree root, shell cwd, model-visible cwd, git/status/search all share one source of truth;
+  - storage-primary vs sandbox-primary are explicit runtime choices;
+  - session history durability is separate from file durability;
+  - Pi transcripts/session lists live under host durable `BORING_AGENT_SESSION_ROOT` (normally `/data/pi-sessions`), not workspace/container home;
+  - UI bridge/RPC stays workspace-owned; boring-bash contributes file surfaces but does not replace `UiBridge.postCommand`.
+
+**Tests/proof:**
+
+- Docs links validated.
+- Grep/proof output shows no doc implies pure agents require `Workspace + Sandbox`.
+- Reviewers can answer where `BORING_AGENT_SESSION_ROOT`, workspace roots, sandbox `/workspace`, and UI bridge ownership live.
+- Proof log lists each updated doc path and the invariant it now states.
+
+**Acceptance:** No doc implies pure agent has `Workspace + Sandbox`, and boring-bash-active docs still preserve the no-split-brain runtime invariant.
+
+### BBA-002 — Choose v1 namespace decision
+
+**Depends on:** BBA-000.
+
+**Why:** Multi-mount public semantics can break the single `/workspace` model. V1 should not ship ambiguous file/bash paths.
+
+**Scope:**
+
+- Decide: preserve one public `/workspace` namespace for v1.
+- Mark `BashVolumeView.mounts` as internal/future unless materialized under one root.
+- Document forbidden split-brain states:
+  - file tree reads one root while bash edits another;
+  - git/status reads a different source than file routes/search/bash;
+  - API path filters hide files that raw shell can still access;
+  - session durability is treated as file durability.
+- State partial workspace exposure with exec must be physical mount/seed/copy, not just API filtering.
+
+**Tests/proof:**
+
+- Add planned tests in BBA-023/BBA-030/BBA-037 for file/bash/git source agreement.
+- Proof log records the chosen v1 namespace decision and every deferred multi-mount follow-up.
+
+**Acceptance:** No public v1 API promises arbitrary visible multi-mount overlays, and every provider/source-of-truth task knows which single namespace it must satisfy.
+
+### BBA-003 — Establish provider capability vocabulary
+
+**Depends on:** BBA-000.
+
+**Why:** `exec: true` is not enough. `just-bash`-style shells, host direct shells, bwrap, Vercel, and remote-worker have different safety and capability properties.
+
+**Scope:**
+
+- Define capability terms: fs mode, exec, real bash, real binaries, network isolation, persistence, watch/search, service ports, provisioning support.
+- Include providers: none, readonly, direct, bwrap, vercel-sandbox, remote-worker.
+- Explain mode/provider distinction: `local` mode uses `bwrap` provider.
+- State provider fallback policy: never silently downgrade to a less isolated or less capable provider; fail closed with stable diagnostics.
+- State remote-worker handshake must report actual hardening claims before policy grants trust.
+
+**Tests/proof:**
+
+- Provider mapping unit tests required by BBA-021.
+- Provider capability validation/fail-closed tests required by BBA-021/BBA-046.
+- Proof log prints the final provider matrix and every unsupported/fallback decision.
+
+**Acceptance:** Implementers cannot confuse mode id with provider id, or treat `exec: true` as sufficient proof of bash safety.
+
+### BBA-004 — Align #391 issue body and docs to plan pack
+
+**Depends on:** BBA-000.
+
+**Why:** The GitHub issue is the public coordination point. It must not contradict the canonical plan pack.
+
+**Scope:**
+
+- Ensure #391 links to `docs/plans/boring-bash-agent-runtime-refactor/README.md` and the TODO pack under `todos/README.md`.
+- Ensure phase list in issue matches `TODO-06`/`06-migration-phases.md` phases 0–8.
+- Ensure issue coverage language says "directly owned" vs "materially advanced if acceptance lands".
+- Ensure issue body does not reintroduce stale monolith wording, unsafe value re-export promises, or overbroad "all backlog solved" claims.
+
+**Tests/proof:**
+
+- Manual `gh issue view 391` check.
+- Markdown body comparison in proof comment.
+- Proof log records issue URL, body source file, phase count, and issue-coverage wording check.
+
+**Acceptance:** No phase drift between issue, plan pack, and TODO pack.
+
+### BBA-005 — Add plan review artifacts and no-implementation gate
+
+**Depends on:** BBA-000.
+
+**Why:** User requested iterative plan-space review before implementation. We must preserve the review trail and prevent premature coding.
+
+**Scope:**
+
+- Keep raw review artifacts under `.tmp/boring-bash-plan-reviews/` / `.tmp/boring-bash-todo-reviews/` during iteration.
+- Record durable Gemini/Claude review round summaries in the plan pack, GitHub issue, or another tracked docs note; `.tmp` alone is not durable.
+- Add a checklist stating no implementation starts until TODO pack passes thermo review and Gemini/second-model review reaches clean/no-relevant-feedback state.
+
+**Tests/proof:**
+
+- `ls .tmp/boring-bash-plan-reviews/` and `.tmp/boring-bash-todo-reviews/` show round artifacts.
+- Durable summary cites review verdicts and patch rounds.
+- Proof log records which feedback was accepted, rejected as non-relevant, or deferred.
+
+**Acceptance:** Plan pack and TODO pack have clean review results before code beads are created, and future implementers can find the review outcome even if `.tmp` is cleaned.
+
+### BBA-006 — Resolve or explicitly defer remaining open decisions
+
+**Depends on:** BBA-000.
+
+**Why:** Several implementation tasks depend on open decisions from the plan pack. They must be decided or explicitly deferred before coding beads are created.
+
+**Scope:**
+
+- Provider package location: default to `@hachej/boring-bash/providers` for v1; document if a private provider package is deferred.
+- Multi-agent route shape: choose path prefix `/api/v1/agents/:agentId/...` or request-scope/header equivalent before BBA-061.
+- Provisioning sharing default: choose requirement-controlled scope with explicit `workspace | agent | plugin | session` metadata unless owner decides otherwise.
+- Readonly fs: decide v1. Proposed default: implement readonly facade in v1 because file viewers/search/review agents need fs without exec.
+- Compatibility strategy: confirm no moved boring-bash values are re-exported from agent/workspace barrels if doing so creates cycles; choose host/composition shim vs explicit import migration.
+- Review artifact durability: decide where the durable summary lives if `.tmp` is cleaned.
+- Confirm one public `/workspace` namespace for v1; advanced multi-mount remains internal/future.
+- Confirm pure agent harness strategy: pi with no cwd/sealed root, or non-pi harness.
+
+**Tests/proof:**
+
+- Decision record lists each item, decision/defer status, owner, rationale, and affected BBA tasks.
+- BBA-021/BBA-061/BBA-062 cannot start until this record exists.
+- Proof log prints unresolved decisions and fails the gate if any required decision has no status.
+
+**Acceptance:** No open decision silently shapes implementation, and no implementation bead starts with an unstated product/architecture choice.

--- a/docs/issues/391/runtime-refactor/todos/TODO-01-agent-core-pure-mode.md
+++ b/docs/issues/391/runtime-refactor/todos/TODO-01-agent-core-pure-mode.md
@@ -1,0 +1,193 @@
+# TODO-01 — Agent core dependency inversion and pure mode
+
+## Purpose
+
+Make `@hachej/boring-agent` usable without any filesystem, sandbox, cwd, or bash capability, while preserving existing coding workspace behavior through host-injected features.
+
+## Beads / tasks
+
+### BBA-010 — Inventory current agent runtime coupling
+
+**Depends on:** BBA-000, BBA-001.
+
+**Why:** We need a precise map before cutting dependencies. Known coupling points include `createAgentApp`, `registerAgentRoutes`, runtime modes, file/bash/upload tools, pi harness cwd, and plugin discovery cwd.
+
+**Scope:**
+
+- Inspect and document imports from agent server to runtime modes, workspaces, sandboxes, file routes/tools, upload tools, pi harness, plugin discovery.
+- Include host composition call sites (`createCoreWorkspaceAgentServer`, workspace server/playground, CLI/workspaces mode, full-app) so dependency inversion does not strand one app path.
+- Identify which imports can become injected interfaces.
+- Identify compatibility paths required for current apps, and explicitly mark which old value imports must migrate rather than be re-exported from agent.
+
+**Tests/proof:**
+
+- Add a markdown table in implementation PR with file/path, current dependency, target owner.
+- Include `rg` output in PR proof.
+
+**Acceptance:** No runtime/file/bash dependency is unknown.
+
+### BBA-011 — Add package import invariant test
+
+**Depends on:** BBA-010.
+
+**Why:** Prevent future regressions where agent imports boring-bash and recreates a package cycle.
+
+**Scope:**
+
+- Add a unit/static test that fails if `packages/agent/src/**` has value imports from `@hachej/boring-bash`.
+- Provide a reusable import-graph/acyclicity helper that later TODOs can extend for workspace↔boring-bash and core/host composition once those packages/values exist; do not make BBA-011 depend on packages that have not been created yet.
+- Allow type-only imports only if they do not create runtime value cycles and are explicitly documented.
+- Mirror existing architectural invariant tests style.
+- Verify agent shared code still obeys project invariants: no `node:*`, no `Buffer`, and no server-only Fastify values in shared/front exports.
+
+**Tests/proof:**
+
+- Run targeted invariant test.
+- Include negative fixture or assertion proving value imports fail.
+
+**Acceptance:** Import invariant catches forbidden agent→bash value imports.
+
+### BBA-012 — Introduce injected runtime/feature composition seam
+
+**Depends on:** BBA-010, BBA-011.
+
+**Why:** Dependency inversion must happen before moving providers. Host/core/CLI should compose agent + optional boring-bash.
+
+**Scope:**
+
+- Refactor `createAgentApp` / `registerAgentRoutes` so pure path does not require static `resolveMode()` or runtime bundle.
+- Preserve compatibility for current direct/local/vercel modes through host-injected adapter or shim.
+- Reuse existing plugin/capability seams; do not create a second plugin registry.
+- `AgentFeature` is a façade over existing tools/routes/systemPrompt/capability contributors.
+
+**Unit tests:**
+
+- Existing createAgentApp/registerAgentRoutes direct/local/vercel-sandbox tests still pass; remote-worker stays covered by mock/contract tests where available.
+- New test: createAgentApp with `features: []` and no runtime adapter starts.
+- Test that route registration does not request a runtime bundle in pure mode.
+- Test the feature façade reuses existing tool/route/systemPrompt/capability contributors and does not create a second plugin registry.
+- Test `sessionStorageRoot` is distinct from workspace roots and can point at host `BORING_AGENT_SESSION_ROOT`.
+
+**E2E/smoke logging:**
+
+- Script logs `mode=none`, `workspaceId`, `agentId`, route count, tool names, session root, and whether a runtime adapter was requested.
+- Must prove no file routes and no bash tools.
+- Must prove session root is host durable session storage (for example under `BORING_AGENT_SESSION_ROOT`) and not workspace/container home.
+
+**Acceptance:** Agent server can be composed without runtime mode resolution.
+
+### BBA-014 — Audit and fix pi-coding-agent cwd/resource assumptions
+
+**Depends on:** BBA-012.
+
+**Phase note:** This task must complete before BBA-013 exits; pure mode cannot ship until the harness has no ambient host file authority.
+
+**Why:** Removing tools is not enough if the harness still receives `process.cwd()` or reads AGENTS.md/resources.
+
+**Scope:**
+
+- Audit `createPiCodingAgentHarness`, resource loading, system prompt building, session store, compaction, model-history ownership, and file tool assumptions.
+- Decide:
+  - pi supports no cwd/sealed root; or
+  - pure mode uses a non-pi harness.
+- Ensure pure mode skips or relocates boot-time plugin discovery that currently receives cwd.
+- Preserve existing `AgentRuntimeCapabilities` semantics (`nativeFollowUp`, `aiSdkOwnsHistory`) and do not confuse them with feature grants or bash provider capabilities.
+
+**Unit tests:**
+
+- Harness construction spy asserts no host cwd/path in pure mode.
+- Prompt snapshot has no cwd, workspace root, AGENTS.md, file-tool instructions, or workspace file hints.
+- Compaction/continue tests run in pure mode without trying to read files or workspace instructions.
+- If sealed root is used, test it contains no host files and cannot escape.
+
+**E2E/smoke logging:**
+
+- Log harness kind, cwd mode (`none` or `sealed`), session storage root.
+- Fail if any path under repo root or `/home/ubuntu` appears in model-visible prompt or pure harness config.
+
+**Acceptance:** Pure mode has no host file authority, not just no model-visible file tools.
+
+### BBA-013 — Implement pure no-filesystem mode
+
+**Depends on:** BBA-012, BBA-014.
+
+**Why:** This is the core user-facing ability: headless agents with app-owned tools only.
+
+**Scope:**
+
+- Add `runtime: none` or equivalent host composition.
+- Register only chat/session/model routes and explicitly configured non-bash tools/hooks.
+- No Workspace, Sandbox, FileSearch, cwd, file routes, git routes, file tools, bash, isolated code, upload/runtime artifact tools.
+- Skip boot-time workspace/plugin discovery that requires cwd unless the host explicitly configures a safe non-bash plugin source.
+- Ensure session history/list storage uses `sessionStorageRoot`/`BORING_AGENT_SESSION_ROOT`, never workspace or sandbox storage.
+
+**Unit tests:**
+
+- Pure app route list excludes file/tree/search/git/fs-events/upload routes.
+- Tool catalog excludes read/write/edit/find/grep/ls/bash/execute_isolated_code/upload.
+- Creating a session succeeds with app-owned non-file tool.
+- Session listing/deletion/history work from host durable session root without a workspace root.
+
+**E2E/smoke logging:**
+
+- Start pure agent test server.
+- Log route list and tool catalog.
+- Send a prompt using only an app-owned echo/status tool.
+- Assert no workspace root, repo root, sandbox cwd, or `/workspace` path appears in model-visible prompt, tool catalog, or pure-mode route diagnostics.
+- Log session root and assert it is the configured host durable root.
+
+**Acceptance:** Pure agent is usable and has no filesystem authority.
+
+### BBA-015 — Add non-bash external hook ingestion API
+
+**Depends on:** BBA-013.
+
+**Why:** #380 external harnesses need review/question/approval hooks independent of files/bash.
+
+**Scope:**
+
+- Define and implement `ExternalAgentHookRequest` ingestion.
+- Include source harness/session ids, kind, body, redaction policy, callback auth ref, and optional idempotency key to avoid duplicate hook creation on retries.
+- Authenticate caller, validate target workspace/agent/session, redact before history write, route to UI/HITL channel, audit attribution.
+- Treat callback auth references as secret references only; never log callback tokens or raw secret values.
+
+**Unit tests:**
+
+- Auth reject.
+- Unknown session/workspace reject with stable error code.
+- Duplicate idempotency key does not create a second hook.
+- Redaction applied before persistence.
+- Callback secret refs are not serialized to model-visible history/logs.
+- Hook routes without boring-bash enabled.
+
+**E2E/smoke logging:**
+
+- Script creates review hook against pure agent session.
+- Logs hook id, idempotency key hash, source ids, redaction count/result, routed UI event id, and callback status without secrets.
+
+**Acceptance:** External hooks work in pure agents with no boring-bash.
+
+### BBA-016 — Add non-bash operational command/event seam
+
+**Depends on:** BBA-013.
+
+**Why:** Slash commands, reload, compaction/provider recovery, and session notices are agent/session concerns, not bash concerns.
+
+**Scope:**
+
+- Add optional command/event contributor API.
+- Ensure `/reload` or slash-command composition can call into dynamic host context without requiring Workspace/Sandbox in pure mode.
+- Store operational events in session history/event stream now, and expose enough metadata for later session-search indexing without requiring the search subsystem to exist yet.
+- Keep stable error codes.
+
+**Unit tests:**
+
+- Operational command executes in pure mode.
+- Provider recovery/compaction event records in session history or event stream without filesystem.
+- Later search indexing can consume the event without changing its shape.
+
+**E2E/smoke logging:**
+
+- Trigger operational command; log command id, agent id, session id, event id, result/error code, and whether a workspace/runtime was requested.
+
+**Acceptance:** Operational commands do not depend on boring-bash.

--- a/docs/issues/391/runtime-refactor/todos/TODO-02-boring-bash-package-providers.md
+++ b/docs/issues/391/runtime-refactor/todos/TODO-02-boring-bash-package-providers.md
@@ -1,0 +1,236 @@
+# TODO-02 — `@hachej/boring-bash` package and providers
+
+## Purpose
+
+Create the optional files/bash working-environment package after dependency inversion is safe. It owns providers, source-of-truth rules, file/search/watch abstractions, and provider capability facts.
+
+This TODO is self-contained for the package/provider slice. It embeds the key architectural reasons:
+
+- `@hachej/boring-agent` must remain usable with no filesystem, no sandbox, no cwd, and no bash.
+- `@hachej/boring-agent` must not value-import `@hachej/boring-bash`.
+- `@hachej/boring-bash` owns concrete working-environment providers and provider capability facts.
+- Host/core/CLI composition wires agent + optional boring-bash together.
+- Provider labels are not enough: each provider must declare real capabilities such as fs mode, exec, real Bash, real binaries, network isolation, persistence/source-of-truth, watch/search, and provisioning support.
+- When boring-bash is active, file API/search/watch/bash/git/status must share one source of truth. No file/bash split brain.
+- `direct` is trusted host mode, not isolation. `local` mode maps to a `bwrap` provider. `vercel-sandbox` and `remote-worker` are remote/provider-backed modes with different lifecycle and provisioning semantics.
+
+## Beads / tasks
+
+### BBA-020 — Create package skeleton and exports
+
+**Depends on:** BBA-012, BBA-000.
+
+**Scope:**
+
+- Add `packages/boring-bash` with exact package name `@hachej/boring-bash`.
+- Add package build plumbing: `package.json`, tsup config, tsconfig/build integration, workspace package registration, docs README, and export map.
+- Exports:
+  - `/shared` for types only safe for front/shared;
+  - `/server` for server-only routes/env builders;
+  - `/agent` for agent feature/tool factories;
+  - `/plugin` for front plugin composition;
+  - `/providers` for concrete provider adapters.
+- `/shared` must not import server/provider/front implementation code.
+- `/shared` must obey project shared-code invariants: no `node:*`, no `Buffer`; use `Uint8Array` for bytes.
+- Do not add value imports from `@hachej/boring-agent` into shared/front code unless they are explicitly type-only and safe.
+- Document intended import direction:
+  - host/core/CLI may import both agent and boring-bash;
+  - boring-bash may expose agent integration factories from `/agent`;
+  - agent must not import boring-bash values.
+
+**Tests/proof:**
+
+- Typecheck package.
+- Package build emits expected subpaths.
+- Export-map test imports `/shared`, `/server`, `/agent`, `/plugin`, and `/providers` from a small fixture.
+- Shared-import invariant: `/shared` import graph does not pull server/provider/front code, `node:*`, or `Buffer`.
+- A minimal host fixture can import agent + boring-bash together without a package cycle.
+
+**E2E/smoke logging:**
+
+- Add a package smoke script that logs package version, resolved export subpaths, and whether each subpath is front-safe/server-only/provider-only.
+
+**Acceptance:** `@hachej/boring-bash` exists as a buildable package with safe subpath boundaries and no agent↔bash value cycle.
+
+### BBA-021 — Define mode/provider capability contracts
+
+**Depends on:** BBA-020, BBA-003, BBA-006.
+
+**Scope:**
+
+- Define provider capability types for:
+  - fs mode: `none | readonly | readwrite`;
+  - exec availability;
+  - real Bash availability;
+  - real binary/toolchain availability;
+  - network isolation level;
+  - watch/search support;
+  - persistence/source-of-truth model;
+  - provisioning adapter support;
+  - path namespace semantics (`/workspace`, direct host path, remote runtime cwd, readonly facade);
+  - provider contract version.
+- Encode mode/provider mapping:
+  - `direct` mode → `direct` provider;
+  - `local` mode → `bwrap` provider;
+  - `vercel-sandbox` mode → `vercel-sandbox` provider;
+  - remote-worker adapter → `remote-worker` provider;
+  - pure/headless → `none` provider/no boring-bash;
+  - readonly facade → fs/search/watch without exec.
+- Add stable error codes for unsupported provider requirements and unsafe fallback attempts.
+- Add policy rule: provider fallback is never automatic if it reduces isolation/capability. Fallback must be host-policy-approved and logged.
+- Include provider diagnostics shape that can be surfaced to readiness/UI/plugin diagnostics without leaking host paths or secrets.
+
+**Unit tests:**
+
+- Mapping table tests for every current mode/provider pair.
+- Provider capability validation tests.
+- Unsupported requirement returns stable error code.
+- Unsafe fallback fails closed.
+- `local`/`bwrap` distinction is preserved.
+- Provider diagnostics redact host paths/secrets where required.
+
+**E2E logging:**
+
+- Provider handshake/smoke logs mode, provider, provider contract version, fs mode, exec, realBash, realBinaries, networkIsolation, sourceOfTruth, workspace id, agent id, and decision/error code.
+
+**Acceptance:** Hosts and plugins can decide whether a provider satisfies a requirement without guessing from a provider name.
+
+### BBA-022 — Move concrete provider adapters after injection
+
+**Depends on:** BBA-020, BBA-021, BBA-012, BBA-006.
+
+**Scope:**
+
+- Move direct, bwrap/local, and vercel-sandbox provider implementations to `boring-bash/providers` after Phase 1 dependency injection is complete.
+- Remote-worker client/provider movement is coordinated in BBA-024 because it has a separate client/server/protocol split.
+- Implement readonly facade in v1 unless BBA-006 explicitly defers it; if deferred, gate all readonly tests/features as v2.
+- Ensure `none` and `readonly` short-circuit the closed provisioning adapter mode union instead of failing it.
+- Do not add value re-exports from old agent paths to moved boring-bash providers/tools/routes; that would violate the no agent→bash value import invariant.
+- Type-only runtime adapter contracts may remain temporarily in agent; concrete `resolveMode()` and concrete adapters move to host/boring-bash composition.
+- Any value compatibility shim must live outside `@hachej/boring-agent` in host/composition packages, or users must migrate imports to `@hachej/boring-bash`.
+- Preserve existing direct/local/vercel behavior and tests.
+- Preserve path-safety ownership: provider/adapters validate containment; routes/tools do not accept raw unchecked host paths.
+
+**Unit tests:**
+
+- Old type-only import paths work where explicitly allowed, or produce clear migration errors.
+- New provider imports work.
+- Readonly facade exposes fs/search/watch and no exec when enabled by BBA-006.
+- `none` and `readonly` do not call provisioning adapters unless explicitly configured.
+- Direct/local/vercel provider tests still pass after import move.
+- Agent package has no value import from boring-bash.
+- Provider adapters still reject path escapes at the adapter boundary.
+
+**E2E logging:**
+
+- Start direct/local/vercel smoke where possible; log old/new import path compatibility decision, mode, provider id, runtime cwd, workspace id, agent id, sourceOfTruth, and provider diagnostics.
+
+**Acceptance:** Concrete non-remote-worker providers live under boring-bash without breaking current runtime behavior or agent package boundaries.
+
+### BBA-023 — Implement provider-level one-namespace source-of-truth tests
+
+**Depends on:** BBA-021, BBA-022.
+
+**Scope:**
+
+- Add provider-level tests that prove workspace/provider API writes are visible to sandbox exec and sandbox-created files are visible to workspace/provider API/search for each provider that claims fs+exec.
+- Test readonly facade exposes provider fs/search/watch without exec.
+- Test denied partial file is not physically present inside the provider view when exec is enabled.
+- Ensure storage-primary and sandbox-primary modes report their source-of-truth model clearly; detailed implementation of `sourceOfTruth` metadata is owned by BBA-037.
+- Do not include route-level file/git assertions here; those live in BBA-026 after routes move.
+
+**Unit/e2e:**
+
+- Provider unit tests for direct, bwrap/local, vercel-sandbox, and remote-worker mock.
+- Readonly facade unit tests.
+- `none` provider unit tests proving no fs/exec/watch/search capabilities.
+- Smoke script with detailed logs:
+  - provider;
+  - provider contract version;
+  - sourceOfTruth;
+  - workspace/provider root;
+  - runtime cwd;
+  - file path;
+  - operation id;
+  - provider API path used;
+  - stdout/stderr;
+  - assertion summary.
+
+**Acceptance:** No provider can claim fs+exec support while splitting provider file API and provider exec roots.
+
+### BBA-026 — Add route-level source-of-truth regression tests after routes move
+
+**Depends on:** BBA-030, BBA-037.
+
+**Scope:**
+
+- Add route-level tests, after BBA-030 moves routes, proving file route writes are visible to bash and bash-created files are visible to file routes/search.
+- Test git/status routes use the same source as file routes and bash.
+- Test file tree/search/watch/UI roots agree with route/bash source-of-truth metadata from BBA-037.
+- Do not duplicate provider-level assertions from BBA-023; this bead covers route/tool/UI integration.
+
+**Unit/e2e:**
+
+- Route integration tests for file write ↔ bash read, bash write ↔ file route read/search, git/status root equality.
+- Smoke script with detailed logs:
+  - route path;
+  - provider;
+  - sourceOfTruth;
+  - git root;
+  - file API root;
+  - runtime cwd;
+  - operation id;
+  - assertion summary.
+
+**Acceptance:** Moved routes cannot regress into host-file-tree vs remote-bash split brain.
+
+### BBA-024 — Clarify and split remote-worker client/server ownership
+
+**Depends on:** BBA-020, BBA-021, BBA-022.
+
+**Scope:**
+
+- Move shared remote-worker protocol/types to `boring-bash/shared`.
+- Move remote-worker client/provider adapter to `boring-bash/providers/remote-worker`.
+- Decide whether full-app worker server stays app-owned or moves to `boring-bash/server/remote-worker`.
+- Worker server must not depend on agent core.
+- Widen or short-circuit provisioning adapter mode union for remote-worker/readonly/none.
+- Add remote-worker provider handshake that reports capability matrix and hardening facts needed by BBA-046.
+- Preserve protocol compatibility with existing full-app worker routes during migration.
+
+**Tests:**
+
+- Protocol compatibility unit tests.
+- Worker handshake reports provider capability matrix.
+- Handshake rejects missing/unknown contract version with stable error.
+- Fail closed when required hardening or source-of-truth claims are missing.
+- Full-app worker server import graph has no agent-core dependency after split.
+
+**E2E logging:**
+
+- Remote-worker smoke logs worker version, protocol version, isolation claims, provider matrix, workspace id, agent id, sourceOfTruth, network policy result, and fail-closed reason when blocked.
+
+**Acceptance:** Remote-worker can be provided by boring-bash without coupling the worker server to agent core or hiding isolation/source-of-truth uncertainty.
+
+### BBA-025 — Preserve type compatibility and migration docs without cycles
+
+**Depends on:** BBA-022, BBA-024.
+
+**Scope:**
+
+- Preserve only type-only old-path exports from `@hachej/boring-agent` where they do not create runtime imports.
+- Do not re-export moved boring-bash values from agent old paths.
+- If a value compatibility shim is required, place it in host/composition packages that already depend on both agent and boring-bash, not in agent.
+- Document migration windows and required import changes.
+- Add changelog notes and migration snippets for app authors.
+- Include examples for direct/local/vercel/remote-worker provider imports and readonly/none usage.
+
+**Tests:**
+
+- Compile current apps after migrating value imports or using host-level shims.
+- Compile sample using new `@hachej/boring-bash` imports.
+- Static test proves agent old paths have no value import from boring-bash.
+- Static test proves workspace↔boring-bash plugin imports stay acyclic when host-level shims are used.
+- Migration docs links and code snippets typecheck where possible.
+
+**Acceptance:** No package cycle and no silent public API break: users either get working host-level compatibility or clear migration diagnostics.

--- a/docs/issues/391/runtime-refactor/todos/TODO-03-routes-tools-ui.md
+++ b/docs/issues/391/runtime-refactor/todos/TODO-03-routes-tools-ui.md
@@ -1,0 +1,260 @@
+# TODO-03 — Routes, tools, and file UI extraction
+
+## Purpose
+
+Move file/bash/upload server routes, agent tools, and filesystem UI into `@hachej/boring-bash` while preserving current user behavior and avoiding split brain.
+
+This TODO file is self-contained for the routes/tools/UI area. The core invariant is: when boring-bash is active, file routes, file tree, search/watch, bash cwd, git/status, and model-visible paths must all refer to the same selected source of truth.
+
+## Current ownership anchors to preserve during migration
+
+- File/tree routes are currently under `packages/agent/src/server/http/routes/*` and registered through agent route composition.
+- Git/status routes are currently agent-owned too and must not be forgotten when file routes move.
+- Filesystem tools currently come from `buildFilesystemAgentTools()` and expose `read`, `write`, `edit`, `find`, `grep`, `ls`.
+- Harness tools currently come from `buildHarnessAgentTools()` and include `bash` and `execute_isolated_code` when supported.
+- Upload/runtime artifact tools currently come from `buildUploadAgentTools()` and are bound to the runtime/workspace file view.
+- Filesystem UI currently lives under `packages/workspace/src/plugins/filesystemPlugin/front/*` and is exported through workspace surfaces/panels.
+
+Do not create package cycles while preserving compatibility. In particular, `boring-bash/plugin` must not value-import workspace front internals if workspace also imports/registers the boring-bash plugin.
+
+## Beads / tasks
+
+### BBA-030 — Move file/tree/search/watch/git routes to boring-bash/server
+
+**Phase:** Phase 3 — server routes/tools extraction.
+
+**Depends on:** BBA-020, BBA-023.
+
+**Scope:**
+
+- Move file/tree/search/fs-events/stat/dir and git/status route registration out of agent.
+- Include current git route helpers such as git route registration and git file URL/source-root logic in the ownership move or compatibility shim.
+- Routes receive `Workspace`/boring-bash environment, not raw paths.
+- Preserve `/api/v1/files/*` and git route compatibility or add aliases with explicit deprecation/migration notes.
+- Preserve stable error codes and adapter-owned path validation.
+- Add assertion that git root/source equals file route source equals bash cwd source for active boring-bash environments.
+- Pure mode must register none of these routes.
+
+**Unit tests:**
+
+- Route handlers reject path escapes and symlink/special-file escapes according to adapter policy.
+- Read/write/list/search/git behavior matches previous implementation in direct/local/vercel-compatible modes.
+- Git/status route reads the same source of truth as file routes and bash.
+- Pure mode does not register file/tree/search/fs-events/stat/dir/git routes.
+- Route aliases, if added, return stable compatibility behavior and clear deprecation diagnostics.
+
+**E2E/smoke logging:**
+
+- Smoke script logs route list, workspace id, agent id, provider id, sourceOfTruth, runtime cwd, file path, git root, operation id, status code, stable error code, and elapsed time.
+- Failure logs must include which root disagreed: file API root, search root, git root, or bash cwd.
+
+**Acceptance:** All file-like and git-like HTTP surfaces are boring-bash-owned when enabled and absent in pure mode.
+
+### BBA-037 — Add source-of-truth model and single-resolver invariant
+
+**Phase:** Phase 3/4 boundary — must land before UI/tool behavior relies on moved routes.
+
+**Depends on:** BBA-030, BBA-023.
+
+**Scope:**
+
+- Add explicit `sourceOfTruth: 'sandbox-primary' | 'storage-primary'` metadata per provider/runtime composition.
+- Reuse existing `getRuntimeBundleStorageRoot()` and current git/file route decisions during migration; do not invent a second storage-root resolver.
+- Ensure git/status, file routes, search/watch, bash cwd, upload/download, and UI file tree derive from the same selected source.
+- Document sandbox-primary vs storage-primary behavior in provider diagnostics.
+- In storage-primary mode, sandbox files are materialized projections/overlays and are not durable unless explicitly synced/exported.
+- In sandbox-primary mode, host storage is control-plane/metadata unless explicitly synced/exported.
+
+**Tests:**
+
+- Direct/local/vercel/remote-worker mock source-of-truth assertions.
+- Git/file/bash root equality where appropriate.
+- Upload/download uses same root as file routes.
+- Storage-primary materialized projection does not pretend sandbox files are durable unless synced.
+- Sandbox-primary file API delegates to sandbox view rather than a stale host directory.
+
+**E2E/smoke logging:**
+
+- Smoke logs provider, sourceOfTruth, storage root, runtime cwd, git root, file API root, search root, upload root, and snapshot/projection id when applicable.
+
+**Acceptance:** There is exactly one canonical resolver for the active file/bash view.
+
+### BBA-031 — Move filesystem tools to boring-bash/agent
+
+**Phase:** Phase 3 — agent tool extraction.
+
+**Depends on:** BBA-030, BBA-037, BBA-012.
+
+**Scope:**
+
+- Move `read`, `write`, `edit`, `find`, `grep`, `ls` from `buildFilesystemAgentTools()`.
+- Introduce `createBashAgentFeature()` as the host composition factory that contributes boring-bash tools, prompt snippets, readiness gates, and route feature metadata.
+- Introduce or reuse `createBashEnvironment()` as the server-side environment factory consumed by routes/tools.
+- Preserve pi factory/Operations-adapter invariant: Pi file tools flow through pi factories plus Operations adapters; do not bypass those wrappers casually.
+- Preserve `disableDefaultFileTools` behavior exactly for the six filesystem tools.
+- Preserve readiness tags: `workspace-fs`, `runtime-dependencies`, `runtime:<id>` as applicable.
+- Add read-before-write/stale-write improvements where compatible, especially for `write`/`edit`; do not break existing tool schemas without an explicit migration.
+- Tools must fail clearly with stable errors when boring-bash is absent, disabled, or not ready.
+
+**Unit tests:**
+
+- Tool names and schemas match previous behavior unless an explicit migration note says otherwise.
+- `createBashAgentFeature()` registers the same tools that pure mode lacks.
+- `disableDefaultFileTools` hides the same six-tool set before and after extraction.
+- Tools fail clearly when boring-bash is not active or readiness gates are blocked.
+- Stale write/read-before-write tests cover create, overwrite, concurrent edit, and file changed by bash.
+- Tool renderer snapshots still render moved tools correctly.
+
+**E2E/smoke logging:**
+
+- Agent invokes read/write/edit/find/grep/ls; log tool call id, workspace id, agent id, session id, provider, sourceOfTruth, cwd, file stamp/hash, readiness requirement ids, result length/truncation, and stable error code on failure.
+
+**Acceptance:** Existing coding agents keep the same file tool behavior; pure agents have no file tools.
+
+### BBA-032 — Move bash and isolated-code ownership
+
+**Phase:** Phase 3 — agent tool extraction.
+
+**Depends on:** BBA-021, BBA-031, BBA-037.
+
+**Scope:**
+
+- Move or explicitly assign `bash` and `execute_isolated_code` from `buildHarnessAgentTools()`.
+- Gate raw bash by policy; agents that only need predefined commands should not receive raw shell.
+- Gate `execute_isolated_code` by sandbox/provider capability and readiness.
+- Add predefined command tool support for safer agents (`git_diff`, `run_tests`, `verify_plugin`, etc.) without exposing arbitrary shell.
+- Preserve timeout, abort, stdout/stderr truncation, and stable error semantics.
+- Shell cwd must be the same model-visible cwd/file view established by BBA-037.
+
+**Unit tests:**
+
+- Pure mode has no bash/isolated code.
+- Reviewer policy can expose predefined command without raw bash.
+- Raw bash appears only when policy and provider capability both allow it.
+- Timeout/abort behavior preserved, including process cleanup where provider supports it.
+- Readiness tags `sandbox-exec`/runtime dependencies work.
+- `execute_isolated_code` is absent or blocked with a stable diagnostic when provider cannot support it.
+
+**E2E/smoke logging:**
+
+- Run safe command; log command id, policy id, timeout, cwd, provider, sourceOfTruth, exit code, stdout/stderr truncation, abort/cleanup result.
+- Verify raw bash absent for readonly reviewer and pure concierge agents.
+
+**Acceptance:** Bash power is explicit, policy-scoped, readiness-gated, and source-of-truth consistent.
+
+### BBA-033 — Assign upload/download/runtime artifact tools
+
+**Phase:** Phase 3 — route/tool ownership decision and move.
+
+**Depends on:** BBA-030, BBA-037.
+
+**Scope:**
+
+- Decide ownership with a concrete rule:
+  - file-view-bound upload/download/runtime artifact tools move to boring-bash;
+  - non-bash app-owned artifact services may stay in workspace/core but must not assume a filesystem.
+- If moved, preserve route/tool compatibility and stable errors.
+- Include download/file artifact API work (#220/#221).
+- Upload/download must use the same source of truth as file routes, git/status, and bash.
+- Pure mode has no workspace-bound upload tool unless host explicitly provides a non-bash artifact feature.
+
+**Tests:**
+
+- Upload works in coding workspace.
+- Download uses same source of truth as file routes and bash.
+- Pure mode has no workspace-bound upload tool by default.
+- Non-bash artifact feature can be registered independently and does not import boring-bash.
+- Large file, binary file, missing file, and permission-denied cases return stable errors.
+
+**E2E/smoke logging:**
+
+- Upload/download smoke logs artifact id, workspace id, agent id, provider, sourceOfTruth, file size, checksum/hash, route id, tool id, and stable error code.
+
+**Acceptance:** Artifact movement is explicit and does not reintroduce hidden workspace assumptions into pure agents.
+
+### BBA-034 — Move filesystem front plugin to boring-bash/plugin
+
+**Phase:** Phase 4 — front plugin extraction.
+
+**Depends on:** BBA-030, BBA-037.
+
+**Scope:**
+
+- Move `packages/workspace/src/plugins/filesystemPlugin/front/*` to boring-bash/plugin without introducing a workspace↔boring-bash package cycle.
+- `boring-bash/plugin` must not value-import `@hachej/boring-workspace`; instead it receives a structural host adapter or lower neutral plugin SDK for frontFactory/bridge/registry/surface APIs.
+- Workspace may import/register/re-export boring-bash plugin values only if boring-bash has no workspace value import, preserving one-way dependency.
+- If old `@hachej/boring-workspace` barrel exports are kept, verify they are one-way workspace→boring-bash and do not create cycles; otherwise provide clear migration exports/diagnostics.
+- Preserve panel ids, `workspace.open.path` resolver, file panel binding, agent file bridge, session-change integration, and existing user workflows.
+- Workspace bridge remains workspace-owned; boring-bash plugin consumes bridge commands through the host adapter.
+- Missing boring-bash capability should produce clear UI diagnostics rather than broken panels.
+
+**Unit tests:**
+
+- Surface resolver resolves same file paths as before.
+- Panel ids unchanged.
+- Workspace↔boring-bash acyclicity test passes for front/plugin imports.
+- Missing boring-bash produces clear capability/panel diagnostics.
+- Existing workspace barrel exports either remain cycle-free or fail with explicit migration diagnostics.
+
+**E2E/smoke logging:**
+
+- `exec_ui openFile` opens moved file panel; log command id, workspace id, agent id, panel id, file path, resolver id, bridge command id, and route/provider source.
+
+**Acceptance:** File UI moves packages without changing user-visible behavior or introducing a package cycle.
+
+### BBA-035 — Add FileTreeDataProvider boundary
+
+**Phase:** Phase 4 — front plugin/data-provider boundary.
+
+**Depends on:** BBA-034, BBA-037.
+
+**Scope:**
+
+- Introduce replaceable file tree data provider with tree, path-list/tree-index, and fs-event deltas.
+- Keep current file tree as default provider.
+- Make Pierre Trees evaluation possible without route rewrites.
+- Provider must respect adapter path validation, source-of-truth metadata, hidden/denied files, symlink policy, and large-tree pagination.
+- File tree UI can show agent-visible view vs user-visible view when those differ.
+
+**Tests:**
+
+- Default provider returns current tree shape.
+- Path-list endpoint handles large trees with pagination/logging.
+- Delta subscription updates UI.
+- Hidden/denied files do not appear in agent-visible tree.
+- Symlink/special-file handling matches adapter policy.
+
+**E2E/smoke logging:**
+
+- Tree smoke logs root, workspace id, agent id, provider, sourceOfTruth, node count, page size, hidden/denied count, delta count, and latency.
+
+**Acceptance:** File tree rendering becomes replaceable without changing file route ownership again.
+
+### BBA-036 — Add document-authority write/edit override
+
+**Phase:** Phase 4 — collaboration/document safety.
+
+**Depends on:** BBA-031, BBA-034, BBA-037.
+
+**Scope:**
+
+- Allow active document systems (TipTap/Yjs) to own writes for a file.
+- `write`/`edit` tools route through document coordinator when active.
+- Validate stale document version/hash and reject stale writes with stable errors.
+- Do not bypass collaborative state, undo/redo assumptions, or live user edits.
+- Raw file writes still work when no document authority is active.
+- Document authority decisions should be visible in tool output/audit logs enough for debugging.
+
+**Tests:**
+
+- Active document intercepts edit.
+- Stale version rejects.
+- Raw file write works when no document authority active.
+- Concurrent human and agent edits do not silently overwrite each other.
+- Document coordinator failure returns stable diagnostic and does not corrupt file state.
+
+**E2E/smoke logging:**
+
+- Collaboration smoke logs document id, file path, version before/after, workspace id, agent id, session id, edit tool id, coordinator result, rejection reason, and resulting file/document hash.
+
+**Acceptance:** Agent file tools respect live collaborative document authority.

--- a/docs/issues/391/runtime-refactor/todos/TODO-04-policy-provisioning-readiness.md
+++ b/docs/issues/391/runtime-refactor/todos/TODO-04-policy-provisioning-readiness.md
@@ -1,0 +1,358 @@
+# TODO-04 — Policy, provisioning, readiness, secrets, services
+
+## Purpose
+
+Make runtime needs declarative and scoped while extending existing provisioning/readiness instead of building a parallel system.
+
+This TODO file is self-contained for future beads. The core idea is:
+
+```txt
+@hachej/boring-bash owns requirement normalization + concrete provider adapters.
+@hachej/boring-agent owns the existing provisioning engine over injected adapters.
+host/core/CLI composition wires them together.
+```
+
+No task in this file may introduce a value import from `@hachej/boring-agent` to `@hachej/boring-bash`, leak raw secrets into logs/prompts/browser contexts, or create a second provisioning/readiness engine.
+
+## Contract excerpts to embed in future beads
+
+### Effective policy stack
+
+Power is an intersection, never a union:
+
+```txt
+effective = backend capabilities
+          ∩ app defaults
+          ∩ resolved childApp/workspaceKind policy
+          ∩ workspace max policy
+          ∩ agent policy
+          ∩ subagent policy
+          ∩ session/user grants
+          ∩ plugin/tool requirements
+```
+
+Resolution order:
+
+```txt
+app defaults < childApp/workspaceKind < workspace < agent < subagent < session/user grants < plugin/tool requirement
+```
+
+The resolver must reject impossible merges instead of silently widening access. Every denial should have a stable error code and enough diagnostic context for a user/admin to understand which policy layer blocked the request.
+
+### BashSandboxPolicy
+
+```ts
+interface BashSandboxPolicy {
+  provider: 'none' | 'direct' | 'bwrap' | 'vercel-sandbox' | 'remote-worker' | string
+  volume: BashVolumeView
+  exec?: {
+    enabled: boolean
+    rawBash?: boolean
+    predefinedTools?: string[]
+    commandPolicy?: BashCommandPolicy
+    timeoutMs?: number
+  }
+  network?: 'disabled' | 'allowlisted' | 'allow-all'
+  env?: Record<string, string>
+  secrets?: string[] // names/grants only; never raw values
+  services?: BashManagedServiceRequirement[]
+  provision?: BashRequirement['provisioning']
+}
+```
+
+### BashRequirement
+
+```ts
+interface BashRequirement {
+  id: string
+  source: 'app' | 'child-app' | 'workspace-kind' | 'workspace' | 'agent' | 'subagent' | 'plugin' | 'session'
+  optional?: boolean
+  capabilities?: {
+    fs?: 'readonly' | 'readwrite'
+    exec?: boolean
+    servicePorts?: boolean
+    secrets?: string[]
+  }
+  provisioning?: {
+    templateDirs?: RuntimeTemplateContribution[]
+    nodePackages?: RuntimeNodePackageSpec[]
+    python?: RuntimePythonSpec[]
+    sdkArchives?: BashSdkArchiveSpec[]
+    env?: Record<string, string>
+    pathEntries?: string[]
+  }
+  services?: BashManagedServiceRequirement[]
+  readiness?: {
+    timeoutMs?: number
+    healthCheck?: BashHealthCheckSpec
+  }
+}
+```
+
+Requirement ids must be stable, human-readable, source-qualified where needed, and safe for logs/diagnostics. They must not contain raw secrets, host-private paths, or model-supplied arbitrary text.
+
+### Readiness model to preserve
+
+Current code has a two-tier model:
+
+- aggregate `ReadyState`: `provisioning | ready | degraded`;
+- per-capability `CapabilityState`: `not-started | preparing | ready | failed`;
+- `CapabilityReadinessDetail` already carries `requirement`, `errorCode`, `causeCode`, `retryable`, `message`, `startedAt`, `completedAt`;
+- `AgentCapabilityReadiness` is currently fixed to `chat`, `workspace`, and `runtimeDependencies`.
+
+Future work must extend or wrap this model; it must not break existing readiness enum values or tool-gating contracts.
+
+## Beads / tasks
+
+### BBA-040 — Implement BashRequirement types and normalizer outside agent
+
+**Depends on:** BBA-020, BBA-011, BBA-006.
+
+**Why:** The platform needs one declarative shape for app/child-app/workspace/agent/plugin/session runtime needs, but the agent package must not import concrete bash code.
+
+**Scope:**
+
+- Define `BashRequirement` and supporting types in boring-bash/shared or a composition-owned type surface that does not pull server/provider values into shared/front code.
+- Include source types: app, child-app, workspace-kind, workspace, agent, subagent, plugin, session.
+- Implement an import-free normalizer that consumes manifest/config data without executing plugin/agent code.
+- Normalizer lives in boring-bash/core composition, not agent.
+- Normalizer outputs existing `ProvisionWorkspaceRuntimeOptions` plus sidecar metadata needed for diagnostics/readiness.
+- Agent engine remains adapter-injected and does not import boring-bash.
+- Preserve stable requirement ids, optional/required semantics, source attribution, and conflict metadata.
+- Ensure no raw secrets or host-private paths are stored in normalized requirement records.
+
+**Unit tests:**
+
+- Import-direction test: agent has no value import from boring-bash normalizer/provider code.
+- Requirement collection order test across app, child-app, workspace-kind, workspace, agent, subagent, session, plugin.
+- Import-free manifest/config test proves plugin code is not executed while collecting requirements.
+- Stable-id validation rejects unsafe ids and duplicate conflicting ids.
+- Optional vs required metadata survives normalization.
+- Output matches expected existing `ProvisionWorkspaceRuntimeOptions` for template dirs, node packages, Python packages, env, path entries, and source metadata.
+
+**E2E/smoke logging:**
+
+- Normalizer fixture smoke logs source layer, requirement id, optional flag, requested capabilities, and normalized contribution ids.
+- Logs must redact host paths and prove no raw secret values are emitted.
+
+**Acceptance:** Requirement normalization is reusable by core/full-app/CLI composition and cannot create an agent→bash package cycle.
+
+### BBA-041 — Implement effective policy intersection
+
+**Depends on:** BBA-040, BBA-021, BBA-006.
+
+**Why:** Agents/plugins/child apps should only receive the intersection of allowed powers. A plugin or session grant must never silently widen workspace or child-app policy.
+
+**Scope:**
+
+- Implement the effective policy stack exactly as documented above.
+- Validate requested fs/exec/network/secrets/services/provisioning capabilities against provider capabilities and workspace maximum policy.
+- Reject impossible merges with stable error codes and actionable diagnostics.
+- Never silently widen access.
+- Include provider fallback policy: fallback only when allowed by policy and capability requirements; never silently downgrade isolation or functionality.
+- Explain denials by policy layer (backend, app, child-app/workspace-kind, workspace, agent, subagent, session/user grant, plugin/tool requirement).
+- Keep child-app/workspace-kind policy as a consumed resolved context from the shared child-app platform plan; do not define child-app registry here.
+
+**Unit tests:**
+
+- Child app narrows generic policy.
+- Plugin cannot widen workspace policy.
+- Session grant can approve only within workspace max.
+- Subagent can narrow parent policy but cannot widen it without explicit approved grant.
+- Impossible exec/fs/provider combinations fail with stable code.
+- Provider fallback rejects less-isolated/lower-capability provider unless policy explicitly allows it.
+- Denial diagnostics identify the blocking policy layer.
+
+**E2E/smoke logging:**
+
+- Policy smoke logs each policy layer, requested capability, effective decision, denial reason, workspace id, childAppId, agent id, plugin id, provider id, and stable error code.
+- Logs must not include secret values or host-private paths.
+
+**Acceptance:** Effective policy is deterministic, explainable, and cannot widen capability by accident.
+
+### BBA-042 — Extend provisioning without duplicating engine
+
+**Depends on:** BBA-040, BBA-041.
+
+**Why:** Existing `provisionWorkspaceRuntime()` already handles contribution merge, fingerprint skip, and provider adapters. We should extend it rather than creating a parallel provisioning path.
+
+**Scope:**
+
+- Feed normalized requirements into `provisionWorkspaceRuntime()` through host/core/CLI composition.
+- Preserve merge-by-id, conflict detection, fingerprint skip, `WorkspaceProvisioningResult.changed`, telemetry, and existing provisioning logger behavior.
+- Add SDK archives, health checks, requirement source metadata, and readiness hints as compatible extensions.
+- Preserve Vercel packaging/snapshot behavior.
+- Preserve pack-artifact rules: local npm/Python packages and SDK archives enter the runtime as packed/copied artifacts, not ad-hoc host paths.
+- Rewrite runtime env/path entries to sandbox-visible paths where needed.
+- Keep current provisioning adapter mode constraints explicit; `none`, `readonly`, and `remote-worker` must either short-circuit or use widened adapter support from provider work.
+- Ensure all provisioning failures produce stable codes and useful source requirement diagnostics.
+
+**Unit tests:**
+
+- Fingerprint skip still works.
+- Conflict same id/different spec rejects with stable code.
+- SDK archive does not leak host path.
+- Env/path entries are rewritten to runtime-visible paths.
+- Optional failed requirement does not block unrelated required contributions.
+- Existing direct/local/vercel provisioning tests still pass.
+- `none`/`readonly` short-circuit behavior does not call unsupported provisioning adapter paths.
+
+**E2E/smoke logging:**
+
+- Provision smoke logs requirement ids, source layers, fingerprint, changed/skipped, provider, elapsed, health result, generated path entries, and stable error code when failed.
+- Logs must include enough detail to debug merge/fingerprint decisions without revealing secrets or host-private paths.
+
+**Acceptance:** Existing provisioning behavior remains intact while new requirement metadata flows through the same engine.
+
+### BBA-043 — Extend readiness using real two-tier model
+
+**Depends on:** BBA-042, BBA-041.
+
+**Why:** Tool/UI readiness must become per-requirement without breaking existing readiness SSE, tool gates, or current enum values.
+
+**Scope:**
+
+- Preserve aggregate `ReadyState`: provisioning/ready/degraded.
+- Preserve per-capability `CapabilityState`: not-started/preparing/ready/failed.
+- Reuse `CapabilityReadinessDetail` fields instead of inventing a parallel detail bag.
+- Extend/wrap fixed `AgentCapabilityReadiness` so N requirement details can be reported without losing current `chat`, `workspace`, and `runtimeDependencies` fields.
+- Optional failures are derived display state over `failed + optional=true`, not a new breaking enum value.
+- Preserve existing readiness tags: `runtime-dependencies`, `runtime:<id>`, `workspace-fs`, `sandbox-exec`.
+- Preserve `mergeTools({ checkReadiness })` semantics.
+- Make readiness diagnostics useful for UI, plugin manager, and agent tool catalog.
+
+**Unit tests:**
+
+- Existing readyStatus tests pass.
+- Existing tool readiness tags still gate tools.
+- Optional failure does not block unrelated tool.
+- Failed required requirement degrades or blocks only the correct tools/panels.
+- Readiness SSE includes requirement detail without breaking old consumers.
+- Retryable vs terminal failures are represented with existing `retryable`, `errorCode`, `causeCode`, and `message` fields.
+
+**E2E/smoke logging:**
+
+- Readiness smoke logs state transitions with timestamps, requirement ids, readiness tags, blocking tool names, retryable flag, and final aggregate state.
+
+**Acceptance:** Existing readiness consumers keep working while per-requirement diagnostics become visible and actionable.
+
+### BBA-044 — Implement secret status/grant model
+
+**Depends on:** BBA-041.
+
+**Why:** Plugins/agents need to know whether named secrets are available, but raw secret values must never leak into browser contexts, prompts, provisioning artifacts, issue comments, or logs.
+
+**Scope:**
+
+- Host-owned secret status API.
+- Browser/plugin sees status only: missing/granted/denied/expired.
+- Model sees names/availability only unless a typed host tool uses the secret internally.
+- Shell env injection requires explicit policy, grant id, audit logging, and readiness dependency.
+- Secret requirements participate in policy intersection and readiness diagnostics.
+- Provisioning plans/fingerprints may include secret names/grant ids/status, never raw values.
+- Health checks and managed services must not echo secret values into logs.
+
+**Unit tests:**
+
+- Secret status visible without value.
+- Raw value never serialized to browser/plugin/model/readiness/provisioning artifacts/log payloads.
+- Missing secret blocks only dependent requirement.
+- Denied/expired grants produce stable error codes.
+- Shell env injection requires explicit policy and grant.
+
+**E2E/smoke logging:**
+
+- Secret smoke logs secret name hash/id, status, grant id, dependent requirement id, and no raw value.
+- Add a negative assertion that known fake secret values do not appear in captured logs/prompts/artifacts.
+
+**Acceptance:** Secret availability is diagnosable without exposing secrets.
+
+### BBA-045 — Implement managed service requirements
+
+**Depends on:** BBA-042, BBA-043, BBA-044, BBA-041.
+
+**Why:** Some trusted plugins need long-lived runtime processes, not one-shot shell commands. Examples include Remotion Studio, browser-use, local preview servers, and app-specific developer previews.
+
+**Scope:**
+
+- Define/implement managed service declarations with command, cwd, env, ports, purpose, health check, teardown, and secret grant references.
+- Trusted plugins can request services only when policy allows service ports and exec.
+- No public exposure without explicit port/proxy/iframe grant.
+- Readiness gates dependent panels/tools until health passes.
+- Teardown is deterministic: kill process tree or provider-specific cleanup.
+- Services run inside the same selected source-of-truth/runtime view as file/bash operations.
+- Service logs must be captured with truncation/redaction and linked to requirement ids.
+
+**Unit tests:**
+
+- Service starts, health passes, port grant surfaces.
+- Health failure gates panel/tool with stable diagnostic.
+- Teardown kills process tree or calls provider cleanup.
+- Service cannot start when exec/servicePorts policy is denied.
+- Service env never includes raw secrets unless explicit shell env grant exists.
+- Port/iframe grant respects child-app/workspace/plugin policy.
+
+**E2E/smoke logging:**
+
+- Service smoke logs service id, requirement id, process id/provider handle id, port, purpose, health URL/result, readiness transition, teardown result, and redaction count.
+
+**Acceptance:** Trusted plugin services are supervised, diagnosable, policy-gated, and cleanly torn down.
+
+### BBA-046 — Remote-worker hardening handshake
+
+**Depends on:** BBA-024, BBA-041.
+
+**Why:** Remote-worker is only safe if the worker can prove the isolation/network/filesystem properties that policy requires.
+
+**Scope:**
+
+- Handshake reports gVisor/seccomp, per-workspace network isolation, metadata/private CIDR egress policy, cross-workspace boundary, filesystem persistence model, real bash/binaries, provider version, and supported provisioning mode.
+- Policy requiring missing or unverifiable hardening fails closed.
+- Handshake claims are included in provider capability validation and readiness diagnostics.
+- Partial/forged/malformed handshakes produce stable errors.
+- Diagnostics must distinguish "provider unavailable" from "provider available but insufficiently hardened".
+
+**Unit tests:**
+
+- Mock worker claims/denies capabilities.
+- Required gVisor/network isolation missing rejects.
+- Partial or malformed handshake rejects with stable code.
+- Handshake info appears in diagnostics and policy logs.
+- Provider cannot silently downgrade to direct/local behavior.
+
+**E2E/smoke logging:**
+
+- Worker smoke logs worker version, isolation claims, policy decision, failure reason if blocked, workspace id, agent id, provider id, and network-hardening result.
+
+**Acceptance:** Remote-worker capabilities are explicit, verified, and fail closed when they do not satisfy policy.
+
+### BBA-047 — Add two-phase sandbox lifecycle and fingerprint key composition
+
+**Depends on:** BBA-042, BBA-043, BBA-044, BBA-045.
+
+**Why:** Provisioning must distinguish reusable template/bootstrap work from per-session grants/services/readiness. Otherwise durable sessions can resume against the wrong file/service state or rebuild expensive templates unnecessarily.
+
+**Scope:**
+
+- Split provisioning/runtime setup into template/bootstrap phase and session/onSession phase where providers support it.
+- Preserve existing single-phase paths while adding no-regression tests for Vercel snapshot/fingerprint skip.
+- Fingerprint keys include provider, workspace id, childAppId/workspaceKind, agent id, requirement ids, seed content hash, source graph hash, provider contract version, and revalidation key.
+- Fingerprints may include secret names/grant ids/status but never raw secret values.
+- Session/onSession applies session grants, env, managed services, and per-session readiness without rebuilding stable templates unnecessarily.
+- Different child apps/agents with different requirements must not reuse incompatible templates.
+- On recovery/resume, stale or missing provider state must be surfaced explicitly instead of silently pretending file/service state is durable.
+
+**Unit tests:**
+
+- Same fingerprint skips provisioning.
+- Changed requirement id/content/source graph/provider contract re-provisions.
+- Different agent/child app requirements do not share incompatible snapshot.
+- Secret value changes do not leak into fingerprint/logs; grant/status changes affect per-session readiness appropriately.
+- Session/onSession can rerun without rebuilding template.
+- Existing Vercel packaging/snapshot tests still pass.
+
+**E2E/smoke logging:**
+
+- Provision smoke logs phase (`bootstrap`/`onSession`), fingerprint inputs, changed/skipped, template/snapshot id, session id, requirement ids, service ids, readiness result, and recovery/resume decision.
+
+**Acceptance:** Template reuse is safe, observable, and scoped by the same policy/provisioning facts that determine runtime powers.

--- a/docs/issues/391/runtime-refactor/todos/TODO-05-plugins-child-app-runtime.md
+++ b/docs/issues/391/runtime-refactor/todos/TODO-05-plugins-child-app-runtime.md
@@ -1,0 +1,281 @@
+# TODO-05 — Plugins, child apps, hosted runtime
+
+## Purpose
+
+Safely connect boring-bash requirements to plugins and child apps, especially Macro hosted inside full-app, without redefining the shared child-app platform plan.
+
+This TODO is the bridge between three existing/desired systems:
+
+- the existing `@hachej/boring-workspace` plugin model, where trusted app/internal plugins may contribute routes, tools, prompts, Pi resources, and provisioning at boot;
+- hosted external plugin mode, where untrusted/remote-safe plugin UI runs in constrained iframes and must fail closed for backend/bash/secrets;
+- the shared child-app platform (#376), where one full-app deployment hosts multiple product surfaces such as generic Seneca and Macro, selected by hostname/workspace kind, with isolated prompts/tools/provisioning.
+
+Non-negotiables for this file:
+
+- Do not define a competing `ChildAppDefinition`, workspace-kind schema, billing model, or host registry. Consume resolved child-app context from `docs/plans/shared-child-app-platform.md`.
+- Do not create a parallel plugin manifest scanner. Extend the existing plugin manifest reader and trust tiers.
+- Do not add a competing runtime plugin route family. Preserve `/api/v1/plugins/:pluginId/*`.
+- Do not leak Macro tools/prompts/provisioning into generic workspaces.
+- Do not leak raw secrets to browser plugins, model prompts, logs, issue comments, or provisioning artifacts.
+- Hosted/untrusted plugin mode remains deliberately constrained unless host policy promotes a plugin to a trusted tier.
+
+## Beads / tasks
+
+### BBA-050 — Consume resolved child-app context
+
+**Depends on:** BBA-041 and the shared child-app platform plan (#376).
+
+**Why:** Macro hosted inside full-app needs child-app/workspace-kind scoping, but this boring-bash plan must not own the product registry, billing, hostname resolution, or workspace-kind schema. It should consume the resolved context and intersect it with plugin/agent/bash requirements.
+
+**Scope:**
+
+- Consume, but do not define, resolved child-app context from core/app composition:
+  - `childAppId` (for example `seneca` or `macro`);
+  - `workspaceKind` (for example `generic` or `macro`);
+  - resolved default agent set from the child-app platform;
+  - resolved default/trusted plugin ids/packages;
+  - resolved prompt/system-prompt contributions;
+  - resolved bash/provisioning requirements;
+  - resolved frontend shell/branding only as metadata for diagnostics, not as boring-bash ownership;
+  - billing/product context only as core-owned metadata for smoke/proof logs, never as boring-bash logic.
+- Apply the effective policy stack: app defaults < resolved childApp/workspaceKind policy < workspace policy < agent policy < session/user grants < plugin/tool requirements.
+- Ensure Macro requirements are scoped only to Macro workspaces.
+- Ensure generic Seneca workspaces do not see Macro prompts/tools/provisioning/default panels.
+- Preserve the child-app plan’s non-goal: trusted Macro domain routes such as `/api/macro/*` may remain trusted app/internal plugin APIs and do not need to be replaced by generic RPC for purity.
+
+**Unit/integration tests:**
+
+- Generic workspace does not see Macro tools, prompts, provisioning contributions, default plugins, or Macro-specific panels.
+- Macro workspace sees Macro defaults and requirements.
+- Child-app policy narrows but never widens workspace max policy.
+- Billing/product context is passed through diagnostics/proof only and is not consumed by boring-bash.
+- A missing or unknown `childAppId`/`workspaceKind` produces a stable diagnostic/error and does not silently fall back to Macro behavior.
+
+**E2E/smoke logging:**
+
+- Smoke resolves a generic host and a Macro host.
+- Logs: request host, workspace id, `childAppId`, `workspaceKind`, resolved plugin ids, resolved agent ids, resolved bash requirement ids, policy decision, and billing product id/name if provided by core.
+- Logs must not include secrets, raw env values, or credentials.
+
+**Acceptance:** The boring-bash/runtime layer can consume child-app context and scope requirements without owning or duplicating the child-app platform.
+
+### BBA-051 — Extend existing plugin manifest validation import-free
+
+**Depends on:** BBA-040.
+
+**Why:** Plugins must be able to declare boring-bash needs before host code imports or executes plugin modules. This protects hosted/remote modes and prevents malicious or accidental code execution during capability validation.
+
+**Scope:**
+
+- Extend the existing plugin manifest reader; do not create a second manifest scanner or second plugin id system.
+- Validate these fields before executing plugin code:
+  - existing `boring.front` / hosted iframe manifest fields;
+  - existing trusted `boring.server` shape;
+  - new `boring.requires` entries such as `boring-bash`;
+  - new `bash.capabilities` such as readonly fs, readwrite fs, exec, services, secrets;
+  - new `bash` provisioning fields such as node packages, Python specs, template dirs, SDK archives, env/path entries, and managed services.
+- Keep plugin id derived from the existing plugin package identity rules; do not add `boring.id`.
+- Validate safe relative paths and containment for any manifest file references.
+- Reject raw secret values in manifest; allow secret names/grant refs only.
+- Preserve hosted iframe manifest fields and current local/trusted plugin behavior.
+- Surface stable diagnostics for invalid fields, unsupported requirements, trust-tier mismatch, missing boring-bash, and optional requirement degradation.
+
+**Unit tests:**
+
+- Manifest requiring bash is skipped/diagnosed when bash is disabled.
+- Invalid `bash` block rejected before importing plugin code.
+- Fixture with side-effecting `boring.server`/`boring.front` proves validation happens import-free.
+- Existing trusted plugins still load.
+- Hosted iframe fields still validate.
+- Raw secret value in manifest is rejected with stable error code.
+- Optional requirement failure degrades with diagnostic instead of blocking unrelated plugin features.
+- Plugin id derivation remains existing behavior; `boring.id` remains rejected if current spec rejects it.
+
+**E2E/smoke logging:**
+
+- Plugin validation smoke logs plugin id, source path, trust tier, manifest revision/signature, declared requirements, optional/required split, validation decision, diagnostic ids/error codes, and whether code import was avoided.
+- Logs must include enough detail to debug why a plugin was skipped, without printing raw manifest secrets/env values.
+
+**Acceptance:** Hosts can determine whether a plugin is allowed/ready without executing untrusted plugin code.
+
+### BBA-052 — Preserve hosted external plugin safety
+
+**Depends on:** BBA-051.
+
+**Why:** Hosted external plugin mode intentionally loses local trusted powers for remote sandbox safety. The boring-bash abstraction must not accidentally re-open host route, backend, filesystem, or network powers to hosted iframe plugins.
+
+**Scope:**
+
+- Hosted remote mode fails closed for unsupported front/server/tool/bash/service/secret requirements.
+- Preserve iframe safety constraints:
+  - constrained iframe sandbox, normally `allow-scripts` only;
+  - no `allow-same-origin`, forms, popups, or top navigation unless a future explicit policy says otherwise;
+  - strict CSP, including no arbitrary network access by default;
+  - bounded diagnostics bridge only, with messages such as ready/log/error;
+  - manifest/document size limits;
+  - safe relative entry validation;
+  - no-follow file metadata checks for plugin assets where supported;
+  - symlinks/special files rejected before read;
+  - remote worker fails closed when required safe file metadata APIs are unavailable.
+- Hosted plugin may declare readonly visibility/diagnostics requests only when host policy and provider capability allow it.
+- Hosted plugin does not get `boring.server`, host routes, plugin-owned agent tools, runtime backend code, raw filesystem access, generic fetch proxy, or raw secrets.
+- If a plugin needs backend code, bash, services, or secrets, it must be promoted to a trusted plugin tier by app/child-app policy.
+
+**Unit tests:**
+
+- Hosted plugin cannot request server route/tool/backend runtime.
+- Hosted plugin with unsupported bash/service/secret requirement fails closed before code execution.
+- Hosted plugin with readonly diagnostic requirement succeeds only when policy allows readonly fs.
+- Iframe sandbox/CSP attributes match constraints.
+- Diagnostic bridge enforces message size/type limits.
+- Symlink/special file fixtures are rejected.
+- Missing safe metadata support causes fail-closed behavior.
+
+**E2E/smoke logging:**
+
+- Hosted-plugin smoke logs plugin id, trust tier, source path, requested requirements, fail-closed decision, iframe sandbox mode, CSP summary, diagnostics count, and rejection error code.
+- Logs must not include plugin source contents beyond bounded diagnostic snippets.
+
+**Acceptance:** Remote-safe hosted plugin mode remains safer after boring-bash integration than local/trusted plugin mode, not accidentally equivalent to it.
+
+### BBA-053 — Add runtime plugin context features
+
+**Depends on:** BBA-051, BBA-043, BBA-044, BBA-045.
+
+**Why:** Runtime plugin backends need to know which features are available without guessing from routes or probing unsafe capabilities. Context must be explicit and scoped by workspace, agent, child app, and trust tier.
+
+**Scope:**
+
+- Extend runtime plugin context for `/api/v1/plugins/:pluginId/*` dispatch. Do not add a competing route family.
+- Context includes:
+  - `pluginId`;
+  - `workspaceId`;
+  - `agentId` if request is agent-scoped;
+  - `childAppId` and `workspaceKind` when resolved;
+  - bash environment summary, if boring-bash is active;
+  - UI bridge availability;
+  - secret statuses only (`missing`, `granted`, `denied`, `expired`), never raw values;
+  - managed service statuses (`not-started`, `starting`, `ready`, `failed`);
+  - readiness diagnostic ids for unmet requirements.
+- Preserve current runtime backend gateway semantics and hot reload behavior.
+- Missing required feature produces clear diagnostic response; optional missing feature is visible but non-fatal.
+- Context must be derived from resolved policy/readiness, not from plugin-controlled input.
+
+**Unit tests:**
+
+- Runtime backend receives feature context for trusted plugin.
+- Missing required feature returns stable diagnostic and does not execute unsafe backend action.
+- Secret context includes status only, no raw value.
+- Service status is visible and updates with readiness.
+- Existing runtime plugin RPC still works through `/api/v1/plugins/:pluginId/*`.
+- Plugin cannot spoof `workspaceId`, `agentId`, `childAppId`, or feature availability through request params/body.
+
+**E2E/smoke logging:**
+
+- Runtime RPC smoke logs plugin id, workspace id, agent id, childAppId/workspaceKind, available feature keys, readiness states, response status, diagnostic ids, and reload generation.
+- No raw secrets or credentials in logs.
+
+**Acceptance:** Runtime plugin backends get enough context to degrade safely without route proliferation or unsafe probing.
+
+### BBA-054 — Shared per-workspace plugin runtime compatibility (#254)
+
+**Depends on:** BBA-053.
+
+**Why:** Workspaces mode and full-app should not maintain divergent plugin runtime maps and route copies. Boring-bash plugin requirements should flow through one shared per-workspace runtime unit.
+
+**Scope:**
+
+- Compose with shared per-workspace plugin runtime unit:
+  - asset manager;
+  - backend registry;
+  - reload;
+  - Pi/plugin snapshots;
+  - lifecycle bus/event stream;
+  - dispose/eviction;
+  - runtime backend gateway resolver.
+- Avoid duplicate maps in CLI/full-app/workspace modes.
+- Runtime backend gateway and plugin routes use resolver pattern for multi-tenant dispatch.
+- Preserve plugin SSE/load/unload/error behavior and revision/signature cache busting.
+- Handle workspace id semantics explicitly: HTTP registry id vs plugin source/workspace root path must not be confused.
+- Ensure boring-bash requirement/readiness state participates in reload and runtime snapshots.
+
+**Unit/integration tests:**
+
+- CLI workspaces mode and full-app use the same runtime unit or a thin adapter over it.
+- Plugin reload updates manifest, runtime context, Pi snapshot, and requirement readiness.
+- Runtime backend registry closes/disposes on workspace eviction.
+- SSE load/unload/error events remain correct after requirement validation changes.
+- Workspace id/root translation tests prevent registry-id vs root-path confusion.
+
+**E2E/smoke logging:**
+
+- Shared-runtime smoke logs host mode, HTTP workspace id, workspace root hash, runtime cache key, plugin ids, backend registry status, reload generation, Pi snapshot generation, and readiness generation.
+
+**Acceptance:** Adding boring-bash requirements does not make CLI/full-app/workspace plugin runtimes drift further apart.
+
+### BBA-055 — Full-app reload/plugin runtime integration (#41)
+
+**Depends on:** BBA-054.
+
+**Why:** Production full-app currently needs per-request workspace/plugin/harness resolution for reload. The new runtime-free composition must keep `/reload` and plugin reload working in multi-tenant deployments.
+
+**Scope:**
+
+- Multi-tenant reload resolves per request:
+  - workspace;
+  - agent binding;
+  - plugin runtime;
+  - boring-bash requirement/readiness state;
+  - beforeReload hook;
+  - asset manager;
+  - runtime backend registry;
+  - Pi/plugin snapshots.
+- `/api/v1/agent/reload` and `/reload` slash command/route work in full-app where enabled.
+- Reload does not require boring-bash in pure/headless agents unless plugin requirements do.
+- Reload diagnostics include manifest validation, requirement validation, provisioning readiness, and plugin import/runtime errors.
+- Preserve behavior where trusted server plugin route/tool changes require restart/redeploy; reload diagnoses drift but does not hot-register unsafe server routes.
+
+**Unit/integration tests:**
+
+- Full-app reload route resolves per workspace.
+- Missing/unauthorized workspace returns stable error.
+- Plugin assets reload and runtime backend dispatch still work.
+- Pure/headless agent reload works without boring-bash.
+- Trusted server plugin backend changes are diagnosed, not hot-swapped unsafely.
+- Reload surfaces requirement/provisioning errors without losing previous working UI where applicable.
+
+**E2E/smoke logging:**
+
+- Reload smoke logs request id, workspace id, agent id, childAppId/workspaceKind, plugin ids, asset revision, runtime backend generation, beforeReload duration, provisioning readiness state, diagnostic ids, and final reload decision.
+
+**Acceptance:** Full-app users can reload plugins/runtime diagnostics in multi-tenant production paths without route 404s or silent slash-command failures.
+
+### BBA-056 — Macro hosted inside full-app smoke
+
+**Depends on:** BBA-050, BBA-053, BBA-055.
+
+**Why:** Macro is the proving case for one deployed app hosting multiple product surfaces. This smoke must prove the abstraction supports the product goal without leaking Macro capabilities into generic Seneca workspaces.
+
+**Scope:**
+
+- Use resolved child-app context for Macro; do not hardcode Macro behavior in boring-bash.
+- Exercise generic Seneca and Macro host/workspace resolution in the same deployed app/server composition.
+- Verify Macro tools/prompts/provisioning/default panels visible only for Macro workspace kind.
+- Verify generic Seneca and Macro share deployment/auth/DB/billing infrastructure but not runtime requirements.
+- Verify Macro trusted domain routes remain valid app/internal plugin APIs where the child-app plan says they should.
+- Verify boring-bash receives only resolved policy/requirements and never billing secrets or raw child-app registry internals.
+
+**Unit/integration tests:**
+
+- Macro context resolution fixture produces Macro plugin/prompt/provisioning requirements.
+- Generic context fixture excludes Macro requirements.
+- Macro trusted routes are present only in Macro context when registered by trusted plugin/app policy.
+- Billing/product metadata is available to core smoke/proof but not to boring-bash provider logic.
+
+**E2E/smoke logging:**
+
+- Smoke hits generic and Macro hosts.
+- Logs request host, childAppId, workspaceKind, workspace id, active plugin ids, agent ids, bash requirement ids, runtime provider, readiness states, Macro route availability, and billing product context without secrets.
+- Logs assertion summary: no Macro leakage into generic workspace; Macro requirements ready or diagnosed; plugin/runtime gateway works.
+
+**Acceptance:** Macro-in-full-app platform is supported by the abstraction without leaking capabilities, secrets, prompts, tools, or provisioning across child-app/workspace-kind boundaries.

--- a/docs/issues/391/runtime-refactor/todos/TODO-06-multi-agent-sessions-hooks.md
+++ b/docs/issues/391/runtime-refactor/todos/TODO-06-multi-agent-sessions-hooks.md
@@ -1,0 +1,266 @@
+# TODO-06 — Multi-agent routing, sessions, search, hooks
+
+## Purpose
+
+Enable multiple agents inside one deployed app/workspace with isolated bindings, sessions, tools, readiness, and policy.
+
+This TODO exists because a single full-app deployment must eventually host several agent roles at once: a coding agent with full boring-bash, a reviewer with readonly files/no shell, a concierge/support agent with no filesystem at all, Macro-specific agents in Macro child-app workspaces, and external harnesses that can create review/question hooks. The implementation must preserve the host-owned session-history rule from `AGENTS.md`: transcripts live under durable `BORING_AGENT_SESSION_ROOT`, not in the workspace or sandbox.
+
+## Shared vocabulary for this TODO
+
+- **AgentNode**: addressable runtime agent with its own id, features, tool/channel configuration, generic requirements/feature grants, optional boring-bash requirement, session namespace, and policy. Use this for specialist agents with different sandbox/tool/network/readiness needs.
+- **AgentProfile**: reusable delegated behavior pack that normally runs inside the parent agent/environment unless a parent policy explicitly narrows or isolates it. Use this for cheap subtasks that should not silently widen access.
+- **Default agent**: compatibility agent used by existing routes until multi-agent routes are adopted.
+- **Principal/user**: human actor and approval/grant source. Never expose the human as a model-callable max-power agent.
+
+## Beads / tasks
+
+### BBA-060 — Introduce AgentRegistry data structure
+
+**Phase:** 6 seed interface, completed before Phase 7 route/session migration.
+
+**Depends on:** BBA-012.
+
+**Why:** Child apps and workspaces need to name available agents before route/session migration is complete. This registry must stay generic so pure agents do not depend on boring-bash concepts.
+
+**Scope:**
+
+- Add an `AgentRegistry` data structure for the workspace/default resolved agent set; child-app seeding from BBA-050 layers on top when available.
+- Support the AgentNode vs AgentProfile distinction:
+  - AgentNode is addressable and may have independent features/policy/session namespace;
+  - AgentProfile is reusable delegation configuration and cannot widen the parent environment by default.
+- Record agent id, package/source, label/description, features, generic requirements/featureGrants (no hardcoded bash concepts), tool/channel config, default session behavior, and optional attribution metadata.
+- Provide a default-agent compatibility entry for existing single-agent routes.
+- Validate ids early: safe path/URL segment, no duplicate ids, no reserved names, no collision with tool names where agent delegation becomes model-visible.
+- Phase 6 can seed the registry from child-app defaults; Phase 7 implements route/session/search behavior against it.
+
+**Unit tests:**
+
+- Registry validates duplicate ids, unsafe ids, reserved ids, and tool-name collisions.
+- Generic/default agent set resolves without child-app platform dependency.
+- Child-app default agent set resolves when BBA-050 context is available.
+- AgentProfile cannot accidentally widen environment or inherit parent tools/files/shell unless explicitly configured.
+- Default-agent compatibility entry exists and is deterministic.
+
+**E2E/smoke logging:**
+
+- Registry smoke logs workspace id, childAppId/workspaceKind when present, registered agent ids, default agent id, rejected ids, and source of each agent definition.
+
+**Acceptance:** Hosts can resolve a workspace agent set without enabling boring-bash and without loading child-app-specific code unless child-app context is supplied.
+
+### BBA-061 — Add agentId route/request scoping
+
+**Phase:** 7.
+
+**Depends on:** BBA-060, BBA-006.
+
+**Why:** Multiple agents need addressable routes without breaking existing single-agent callers. The route shape must be chosen in BBA-006 before implementation.
+
+**Scope:**
+
+- Add `/api/v1/agents/:agentId/...` or the BBA-006-approved equivalent scoped request mechanism.
+- Keep backwards compatibility for default-agent routes by resolving missing `agentId` to the default agent with explicit diagnostics.
+- Resolve agent before tool catalog/session/provisioning/readiness so the request never accidentally uses another agent's binding.
+- Ensure route params and headers cannot disagree silently; reject conflicts with stable error code.
+- Preserve existing UI bridge/RPC route ownership; agent scoping should not create a parallel UI bridge route family.
+
+**Unit tests:**
+
+- Unknown agent returns stable error with no fallback to another agent.
+- Default-agent route compatibility works for existing endpoints.
+- Conflicting path/header agent ids reject.
+- Two agents expose different route/catalog behavior as configured.
+- Pure agent route has no file/bash routes even when a coding agent in the same workspace has boring-bash.
+
+**E2E/smoke logging:**
+
+- Route smoke logs workspace id, requested agent id, resolved agent id, route pattern, default-agent fallback yes/no, and stable error code for unknown/conflicting agents.
+
+**Acceptance:** Every agent-scoped request resolves exactly one agent before touching sessions/tools/runtime state.
+
+### BBA-062 — Thread agentId through bindings and sessionNamespace
+
+**Phase:** 7.
+
+**Depends on:** BBA-061, BBA-006.
+
+**Why:** The dangerous failure mode is transcript/binding cross-contamination: two agents in one workspace with the same `sessionId` must not share harness bindings, tool catalogs, readiness, or transcript files.
+
+**Scope:**
+
+- Add `agentId` to the real per-workspace runtime binding/scope caches used by agent routes and core workspace server composition.
+- Add `agentId` to `sessionNamespace` and session root derivation.
+- Preserve host durable `BORING_AGENT_SESSION_ROOT` for transcripts; do not store session history in workspace root, sandbox `/workspace`, container home, or repo checkout.
+- Keep legacy fields such as root/template/pi/session namespace isolated where they currently exist.
+- Normalize/sanitize agent id before using it in namespace/path segments.
+- Ensure same `sessionId` across two agents does not collide.
+- Ensure a provisioning/readiness failure for one agent does not poison another agent's binding cache.
+
+**Unit tests:**
+
+- Same workspace + same `sessionId` + two agents produce distinct transcript directories/records.
+- Binding cache key includes agent id or equivalent scope component.
+- Session roots stay under host session root and never under workspace/container home.
+- Unsafe agent ids cannot escape or collide in session namespace.
+- Failed binding for one agent does not replace healthy binding for another.
+
+**E2E/smoke logging:**
+
+- Session isolation smoke logs workspace id, agent id, session id, session namespace, session root, binding cache key hash, and transcript path root classification (`host-session-root`, never raw secrets or full private path contents).
+
+**Acceptance:** Agent/session identity is `(workspaceId, agentId, sessionId)` everywhere user history or runtime binding state is addressed.
+
+### BBA-063 — Per-agent tool catalogs and readiness
+
+**Phase:** 7.
+
+**Depends on:** BBA-062, BBA-043.
+
+**Why:** Multi-agent value comes from different capabilities per role. A reviewer should not inherit a coding agent's raw bash, and a pure concierge should not be blocked by another agent's runtime dependency failure.
+
+**Scope:**
+
+- Tool catalog is per agent, assembled after agent resolution.
+- Readiness gates are per agent/runtime requirement and preserve existing readiness tags.
+- Reuse existing `mergeTools({ checkReadiness })`; do not create a parallel tool catalog system.
+- Reviewer can have readonly/no exec while coding agent has bash.
+- Concierge pure agent has no boring-bash.
+- Plugin tool requirements are scoped to the target agent and cannot widen workspace/agent policy.
+- Tool attribution includes agent id for audit/UI display.
+
+**Unit tests:**
+
+- Catalog differences by agent.
+- Readiness failure for one agent does not block unrelated pure agent.
+- Plugin tool requirements scoped correctly.
+- Raw `bash` absent for reviewer/concierge when policy denies it.
+- Existing default-agent tool catalog remains compatible.
+
+**E2E/smoke logging:**
+
+- Catalog/readiness smoke logs agent id, tool names, readiness tags, blocked/unblocked reason, requirement ids, policy source, and whether default-agent compatibility was used.
+
+**Acceptance:** The model-visible tool set always matches the resolved agent policy, not the workspace's most powerful agent.
+
+### BBA-064 — Session history index/search (#379)
+
+**Phase:** 7.
+
+**Depends on:** BBA-062.
+
+**Why:** Session search is independent of boring-bash and must work for pure agents, multi-agent workspaces, and cross-project browsing without loading every workspace.
+
+**Scope:**
+
+- Add a session index/search API independent of boring-bash.
+- Scope by workspaceId, agentId, sessionId.
+- Index title/name/messages/content/operational events/deep-link metadata.
+- Preserve Pi-native title/name parity.
+- Redact sensitive tool outputs and external hook payloads before indexing.
+- Handle session rename/title update, delete, compaction, and operational events.
+- Do not assume file storage exists.
+
+**Unit tests:**
+
+- Search finds correct session for agent/workspace.
+- Cross-agent and cross-workspace results do not leak.
+- Redaction works for tool outputs and external hook content.
+- Session rename/delete updates the index.
+- No filesystem/boring-bash capability required.
+
+**E2E/smoke logging:**
+
+- Search smoke logs query id, workspace id, agent id, result count, redaction count, index update count, and latency. Logs must avoid raw secrets/tool payloads.
+
+**Acceptance:** Users can find the right session history by workspace+agent without granting any file/bash access.
+
+### BBA-065 — Deep-linkable sessions and session links (#243, #211)
+
+**Phase:** 7.
+
+**Depends on:** BBA-064.
+
+**Why:** Proof-of-work comments, notifications, run history, and future operator surfaces need links to a specific agent/session history without clobbering the user's active work.
+
+**Scope:**
+
+- URL/session link model includes workspace and agent.
+- Existing focused-session behavior preserved.
+- Missing/deleted/inaccessible sessions show clear empty/error state with stable error code.
+- Does not overwrite active session without user intent.
+- Compatible with existing `?component=`/workspace route patterns and future multi-pane layout.
+- Start with focused-session URL semantics; full pane-layout-in-URL can remain a later extension.
+
+**Unit tests:**
+
+- Link opens target agent/session.
+- Invalid/deleted/inaccessible session fallback.
+- Browser back/forward preserves expected focused session.
+- Link to another agent in same workspace does not mutate current agent's active session unless user confirms.
+
+**E2E/smoke logging:**
+
+- Deep-link smoke logs URL, workspace id, agent id, session id, fallback reason, active/focused pane, and whether localStorage was updated.
+
+**Acceptance:** Session links are shareable/bookmarkable and agent-scoped without surprising session switches.
+
+### BBA-066 — External hook routing in multi-agent world (#380)
+
+**Phase:** 7.
+
+**Depends on:** BBA-015, BBA-062, BBA-064.
+
+**Why:** External harnesses need to create review/question/approval hooks against the correct agent/session, and those hooks must be searchable/auditable after redaction.
+
+**Scope:**
+
+- Route external hooks to correct workspace/agent/session.
+- Support no-session/new-session policy.
+- Preserve auth/redaction/audit from BBA-015.
+- Persist routed hooks into the correct session history and search index.
+- Callback delivery must be idempotent or carry stable ids so retries do not duplicate user-visible hooks.
+
+**Unit tests:**
+
+- Hook to agent A not visible in agent B.
+- Missing target stable error.
+- Redacted hook searchable in session index.
+- Duplicate/retried hook with same external id is idempotent or clearly versioned.
+- Unauthorized hook cannot reveal whether another agent/session exists beyond allowed error semantics.
+
+**E2E/smoke logging:**
+
+- Hook smoke logs source harness id, target workspace/agent/session ids, redaction count, routed event id, external id/idempotency key, search index update id, and callback status.
+
+**Acceptance:** External hooks are multi-agent-safe, redacted, auditable, and work without boring-bash.
+
+### BBA-067 — Delegation depth and shared-sandbox write safeguards
+
+**Phase:** 7.
+
+**Depends on:** BBA-063, BBA-036.
+
+**Why:** Delegation is powerful but can accidentally widen access or cause concurrent file edits. Flue and eve both show the need to distinguish cheap shared-env profiles from isolated agent nodes.
+
+**Scope:**
+
+- Cap delegation depth.
+- AgentProfile shares parent env only explicitly and cannot widen policy.
+- Shared-sandbox concurrent writes require stale-write stamps/non-overlapping write scopes.
+- Isolated AgentNode produces patch/artifact merge path instead of mutating source directly unless policy permits.
+- Human users are principals/supervisors/approval channels, not model-callable root agents; any escalation must be attributed to a user grant.
+- UI/provenance should distinguish human, agent, subagent/profile, plugin, and system writes where possible.
+
+**Unit tests:**
+
+- Depth cap rejects excessive delegation.
+- Shared stale write rejected.
+- Non-overlapping write scopes can proceed.
+- Isolated agent patch does not mutate source until merge.
+- User approval/grant is audit-attributed and not exposed as a model-callable super-agent tool.
+
+**E2E/smoke logging:**
+
+- Delegation smoke logs parent/child agent ids, delegation type (AgentProfile vs AgentNode), depth, sharing mode, write-scope decision, stale-write result, patch/artifact id, and user grant id when present.
+
+**Acceptance:** Delegated work is useful without making specialist agents silently more powerful than their parent/workspace policy allows.

--- a/docs/issues/391/runtime-refactor/todos/TODO-07-cleanup-release.md
+++ b/docs/issues/391/runtime-refactor/todos/TODO-07-cleanup-release.md
@@ -1,0 +1,235 @@
+# TODO-07 — Cleanup, deprecation, release readiness
+
+## Purpose
+
+Finish the migration safely after new package boundaries, routes, tools, plugins, provisioning, and multi-agent features are proven.
+
+This cleanup phase is not a rubber-stamp. It protects users from silent API breaks, package cycles, lost docs, broken deployments, leaked secrets, and overclaimed GitHub issue closure after the refactor lands.
+
+## Beads / tasks
+
+### BBA-070 — Compatibility import audit and migration map
+
+**Depends on:** BBA-022, BBA-025, BBA-030, BBA-031, BBA-032, BBA-033, BBA-034, BBA-040, BBA-042, BBA-051, BBA-053, BBA-060, BBA-061.
+
+**Why:** The refactor moves public values out of `@hachej/boring-agent` and `@hachej/boring-workspace`. Cleanup must not accidentally reintroduce value re-exports that create agent↔bash or workspace↔bash cycles, and it must not silently break downstream imports without a clear migration path.
+
+**Scope:**
+
+- Find all imports from old moved paths across apps, packages, plugins, examples, docs, tests, scripts, and generated declarations if present.
+- Classify each import as:
+  - safe type-only compatibility export;
+  - required source migration to `@hachej/boring-bash`;
+  - host/composition-level value shim allowed because the host already depends on both packages;
+  - forbidden value re-export that would create a package cycle.
+- Preserve type-only compatibility exports where safe.
+- Do not keep value compatibility re-exports in packages that would create agent↔bash or workspace↔bash cycles.
+- Host/composition-level value shims are allowed only where the host already depends on both packages.
+- Mark deprecations and required import migrations in package docs, changelog, and migration examples.
+- Include workspace/front barrel exports in the audit: moved filesystem UI values must not force boring-bash to import workspace internals while workspace also imports boring-bash.
+
+**Tests/proof:**
+
+- Static import audit output lists every old moved path and its classification.
+- Current apps compile after import migration or through safe host-level shims.
+- New sample app compiles using new `@hachej/boring-bash` imports.
+- Static acyclicity tests pass for agent↔bash, workspace↔bash, and core/host composition.
+- Type-only exports are verified as type-only in emitted JS where possible.
+
+**E2E/smoke logging:**
+
+- Compatibility smoke writes a structured report with old path, new path, classification, package owner, whether emitted JS imports a value, and migration status.
+
+**Acceptance:** No package cycle, no silent public API break, and every old moved import has either a safe compatibility path or an explicit migration diagnostic.
+
+### BBA-071 — Remove compatibility exports after migration window
+
+**Depends on:** BBA-070 and explicit maintainer approval.
+
+**Why:** Compatibility shims are temporary. Removing them must be deliberate, non-destructive, and backed by proof that all maintained code has migrated.
+
+**Scope:**
+
+- Remove old type-only or host-level compatibility exports only after explicit maintainer confirmation.
+- There should be no forbidden value re-export paths to remove from agent/workspace because they were never added.
+- Update package exports, package docs, changelog, and migration notes.
+- No file deletion without explicit written permission; if removal of files is needed, get written approval first.
+- Do not use destructive filesystem/git commands.
+
+**Tests/proof:**
+
+- `rg` confirms no maintained code imports old moved paths.
+- Typecheck/build confirms package exports are coherent after compatibility removal.
+- Static acyclicity tests still pass.
+- Migration guide tells downstream users exactly what changed.
+
+**E2E/smoke logging:**
+
+- Removal smoke logs removed export names, remaining aliases, packages checked, and compile/test results.
+
+**Acceptance:** Maintained code no longer depends on old moved paths, and removal does not violate no-deletion/no-destructive-operation rules.
+
+### BBA-072 — Update docs, examples, and migration guide
+
+**Depends on:** BBA-070.
+
+**Why:** The architecture change is large. Users and future implementers need docs that explain the why, not just changed import paths.
+
+**Scope:**
+
+- Update package docs for agent, workspace, core, CLI, plugin CLI, and boring-bash.
+- Document:
+  - pure no-filesystem agents;
+  - boring-bash activation;
+  - provider/mode matrix;
+  - source-of-truth model (`sandbox-primary` vs `storage-primary`);
+  - plugin requirements and hosted plugin fail-closed behavior;
+  - child-app/workspace-kind scoping;
+  - multi-agent sessions and `agentId` routing;
+  - secret status/grant model;
+  - managed service lifecycle;
+  - external hook/session-search behavior if shipped;
+  - host durable session storage rule: transcripts live under `BORING_AGENT_SESSION_ROOT`, not workspace/container home.
+- Add migration examples for:
+  - pure agent app;
+  - coding workspace with boring-bash;
+  - readonly reviewer agent;
+  - hosted plugin manifest requiring readonly fs;
+  - trusted plugin requiring managed service/SDK;
+  - Macro child-app scoped requirements.
+
+**Tests/proof:**
+
+- Markdown link check across changed docs.
+- Example snippets typecheck where possible.
+- Docs mention no raw secrets in logs/prompts/browser contexts.
+- Docs do not imply pure agents have `Workspace + Sandbox`.
+
+**E2E/smoke logging:**
+
+- Documentation smoke collects generated example commands, verifies they run or typecheck, and logs example name, package, command, exit code, and linked docs path.
+
+**Acceptance:** A future implementer or app author can understand package ownership, runtime modes, and migration steps without reading the old monolith.
+
+### BBA-073 — Full regression matrix
+
+**Depends on:** all implementation beads and BBA-072.
+
+**Why:** This refactor crosses package boundaries, runtime providers, plugins, sessions, UI, and deployment modes. A final matrix is required before declaring the migration safe.
+
+**Scope:**
+
+Run and document a full matrix:
+
+- pure agent;
+- direct;
+- local/bwrap;
+- vercel-sandbox;
+- remote-worker mock/real where available;
+- readonly facade;
+- hosted plugin;
+- trusted plugin service;
+- Macro child-app scoped workspace;
+- multi-agent workspace;
+- external hook path if implemented;
+- session-history search/deep-link path if implemented;
+- document-authority write/edit override if implemented.
+
+**Unit/regression tests:**
+
+- Run all targeted unit suites from the implementation beads, including:
+  - import/acyclicity invariants;
+  - pure-mode no-host-cwd tests;
+  - provider capability validation;
+  - source-of-truth/split-brain tests;
+  - readiness/provisioning tests;
+  - plugin manifest validation tests;
+  - multi-agent session isolation tests;
+  - secret/status no-leak tests;
+  - document-authority stale-write tests where applicable.
+
+**E2E/smoke logging:**
+
+- Each script writes structured JSON and markdown proof with:
+  - workspace id;
+  - agent id;
+  - session id;
+  - provider/mode;
+  - sourceOfTruth;
+  - childAppId/workspaceKind;
+  - plugin ids;
+  - requirement ids;
+  - readiness transitions;
+  - route/tool catalog;
+  - file/git/bash root comparison;
+  - secret status without secret values;
+  - timings;
+  - stable error codes;
+  - stdout/stderr truncation metadata where commands run.
+- Logs must be detailed enough to diagnose failures without reproducing locally.
+- Logs must not include secrets or tokens.
+
+**Acceptance:** No critical regression; logs are sufficient to debug failures; all optional/unavailable providers are explicitly marked skipped with reason.
+
+### BBA-074 — Issue triage and closure plan
+
+**Depends on:** BBA-073.
+
+**Why:** This refactor materially advances many issues but directly owns only parts of the backlog. Issue closure must be evidence-based and not overclaim unrelated product work.
+
+**Scope:**
+
+- Update #391 with proof, final architecture summary, package ownership, and test matrix links.
+- Identify which issues can be closed, partially advanced, or left untouched.
+- Do not close an issue unless its acceptance criteria are met and a proof comment links to tests/logs.
+- Keep product plugins, multi-project UI, performance, billing/auth/db, desktop, visual polish, dependency migrations, docs annotation UI, and event-bus typing separate unless actually implemented.
+- Apply labels/status according to project workflow.
+
+**Tests/proof:**
+
+- GitHub issue comments cite exact tests/proof.
+- Each closed/advanced issue includes a short mapping from acceptance criteria to proof artifact.
+- No issue comment includes secrets, host-private paths, or unredacted logs.
+- If using bead tooling for follow-up graph checks, use only `br` and `bv --robot-*`; never run bare `bv` and never edit `.beads/*.jsonl` by hand.
+
+**Acceptance:** Issue state accurately reflects delivered functionality and does not inflate scope.
+
+### BBA-075 — Release readiness and maintainer decision packet
+
+**Depends on:** BBA-072, BBA-073, BBA-074.
+
+**Why:** The final output should let the maintainer confidently decide whether to cut a release, keep iterating, or split follow-up work.
+
+**Scope:**
+
+- Verify package builds and exports.
+- Verify CLI, full-app, workspace playground, and relevant plugin flows.
+- Verify compatibility notes and migration guide.
+- Prepare release notes if cutting a release.
+- Produce a maintainer decision packet:
+  - what changed;
+  - what stayed compatible;
+  - known deferred decisions;
+  - risks;
+  - follow-up issues/beads;
+  - full test matrix summary;
+  - rollback/mitigation notes for deployment.
+
+**Checks:**
+
+- typecheck;
+- relevant unit tests;
+- e2e smoke scripts;
+- package build;
+- docs link check;
+- static import/acyclicity tests;
+- no secrets in logs;
+- no unapproved deletions;
+- no destructive git/filesystem operations;
+- no direct work on `main` unless explicitly authorized.
+
+**E2E/smoke logging:**
+
+- Release-readiness script aggregates all prior proof logs and writes a final summary with command, exit code, duration, artifact path, and pass/fail/skip reason for every gate.
+
+**Acceptance:** Maintainer can decide to cut release or continue with follow-up beads using a complete, auditable proof packet.


### PR DESCRIPTION
## Summary
- Add issue #391 plan pack under docs/issues/391.
- Includes top-level plan, split runtime-refactor docs, and TODO/bead plan pack.

## Scope
Docs only.
