### PR TITLE
docs: add issue 397 Seneca research

### DIFF
--- a/docs/issues/397/research/backlog-md-analysis.md
+++ b/docs/issues/397/research/backlog-md-analysis.md
@@ -1,0 +1,58 @@
+# Backlog.md analysis for a Seneca/background-agent task layer
+
+Scope: read-only analysis of `/tmp/backlog-md-E8dOkD/Backlog.md` as inspiration. No project files modified except this report.
+
+## High-value evidence
+
+### Product/workflow surface
+- `README.md:19-21` positions Backlog.md as markdown-native and AI-ready; `README.md:63` says data is project-local in `backlog/`, `.backlog/`, or configured via `backlog.config.yml`, with Git optional via `--no-git`.
+- `README.md:59-60`, `README.md:70`, `AGENTS.md:82-93`, `CLI-INSTRUCTIONS.md:25` establish the core agent nudge: agents should read `backlog instructions overview`; agents must use CLI/MCP/Web rather than editing task markdown directly.
+- `README.md:118` explicitly recommends command surfaces over manual edits so metadata stays consistent; also calls out `modified_files`, comments, Implementation Notes, and Final Summary as agent-useful fields.
+- `CLI-INSTRUCTIONS.md:39-55` shows task create API breadth: title, description, assignee, status, labels, priority, plan, acceptance criteria, Definition of Done, notes, dependencies, references, docs, parent tasks. `CLI-INSTRUCTIONS.md:168-180` covers drafts and dependencies.
+
+### Data model and markdown format
+- `src/types/index.ts:39-75` defines `Task`: id/title/status/assignee/reporter/dates/labels/milestone/dependencies/references/documentation/modifiedFiles plus description, implementationPlan, implementationNotes, comments, finalSummary, AC, DoD, parent/subtasks, priority, ordinal, source, onStatusChange.
+- `src/types/index.ts:103-165` separates `TaskCreateInput` and `TaskUpdateInput`; update supports add/remove/check/uncheck list operations and append fields, not just replace-all.
+- `backlog/tasks/back-470.1 - Core-task-comment-model-and-markdown-persistence.md` is a good canonical task file: YAML frontmatter, then sentinel-delimited sections (`<!-- SECTION:DESCRIPTION:BEGIN -->`, `<!-- AC:BEGIN -->`, `<!-- SECTION:PLAN:BEGIN -->`, etc.).
+- `src/markdown/parser.ts:147-198` parses YAML frontmatter and structured body sections into the `Task` model. `src/markdown/serializer.ts:49-120` serializes frontmatter and updates only changed structured sections, preserving raw content where possible.
+- `src/constants/index.ts:4-29` defines storage folders: `tasks`, `drafts`, `completed`, `archive/tasks`, `archive/drafts`, `milestones`, `docs`, `decisions`. `src/file-system/operations.ts:199-217` creates that tree.
+- `src/file-system/operations.ts:289-343` writes task markdown with filename `<id> - <sanitized-title>.md` and normalizes IDs while preserving existing file identity on updates. `src/file-system/operations.ts:362-407` lists tasks by glob + parser; `:409-480` does the same for completed/archived.
+- `src/file-system/operations.ts:234-286` uses a lockfile around create/promote/demote ID allocation. `src/core/backlog.ts:780-845` generates next IDs, including subtasks and optional zero-padding. This is worth copying conceptually for concurrent background agents.
+
+### CLI/API/MCP/Web surfaces
+- CLI: `src/cli.ts` is large, but public docs are clearer. `CLI-INSTRUCTIONS.md` documents stable commands: `init`, `task create/list/view/edit/archive`, `draft`, `milestone`, `doc`, `decision`, `search`, `board`, `browser`, `instructions`.
+- MCP: `src/mcp/tools/tasks/index.ts:10-100` registers `task_create`, `task_list`, `task_search`, `task_edit`, `task_view`, `task_archive`, `task_complete`. `src/mcp/tools/tasks/handlers.ts:63-146` routes create/list through the same core model, validates, and formats tool results.
+- MCP workflow resources: `src/mcp/workflow-guides.ts:32-66` defines `backlog://workflow/overview`, `task-creation`, `task-execution`, `task-finalization`; `src/mcp/resources/workflow/index.ts:5-24` exposes them as resources.
+- MCP project discovery: `src/mcp/server.ts:116-260` supports MCP roots, upgrades from fallback/init-required to a discovered project, and registers full tools only after valid config. Good pattern for multi-workspace Seneca clients.
+- Web UI/API: `src/server/index.ts:274-390` starts a local Bun server, exposes SPA routes and REST endpoints for tasks/docs/decisions/drafts/milestones/search/statistics; `:258-270` broadcasts WebSocket `tasks-updated`/`config-updated`; `:633-685` handles task list filters; `:687+` handles search. `README.md:126-151` describes browser kanban/CRUD.
+- Agent instruction injection: `src/agent-instructions.ts:124-180` appends managed instruction blocks to `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, Copilot instructions, replacing older Backlog-managed sections.
+
+### Current boring-ui/Seneca integration constraints
+- Agent tool contract is `packages/agent/src/shared/tool.ts:10-34`: `AgentTool` has `name`, `description`, JSON schema `parameters`, and `execute(params, ctx)` returning text content; ctx includes abort signal, toolCallId, onUpdate, sessionId.
+- Supported custom tool paths: `packages/agent/docs/tools.md:40-88` says use `createAgentApp({ extraTools })`, trusted `defineServerPlugin({ agentTools })`, or hot-reloadable Pi resources. For a sovereign task layer, a trusted server plugin is the likely fit; runtime plugins cannot add durable server routes.
+- Workspace plugin constraints: `packages/workspace/docs/README.md:17-30` and `PLUGIN_SYSTEM.md:43-56` distinguish trusted app/internal plugins from route-free `.pi/extensions`; plugin tools execute in host Node and bypass sandbox. Do not put untrusted task-storage code in runtime plugins.
+- UI integration: `packages/workspace/docs/README.md:20-25` and `docs/WORKSPACE_CONTRACT.md:96-100` show agents/servers should use `UiBridge`/SSE or app-hosted routes for UI updates. A task pane should be a workspace front plugin/surface resolver, not an agent-package import.
+
+## What to copy for Seneca
+1. **Local-first, repo/workspace-local markdown store.** Keep tasks human-readable and portable. Store under a predictable folder such as `.seneca/tasks/` or `.pi/tasks/`, with config at root or task folder.
+2. **Single canonical core service.** Backlog’s CLI, MCP, Web server, and TUI all route through a shared `Core`/`FileSystem` layer. Seneca should avoid separate implementations for background agents, CLI, web UI, and MCP.
+3. **Structured markdown with raw-content preservation.** Frontmatter for queryable metadata; sentinel sections for plan/notes/final summary/AC/DoD/comments. This is agent-friendly and diff-friendly.
+4. **Command-first mutation policy.** Explicitly tell agents not to edit task markdown directly; provide tools/CLI/API that preserve IDs, indexes, dates, and section order.
+5. **Agent workflow guides as first-class resources.** Copy the idea of `instructions overview` plus task creation/execution/finalization resources. In boring-ui this can be Pi skill/resource text and/or trusted task tools.
+6. **Concurrency locks for create/promote/demote.** Background agents will create tasks concurrently; copy the lock concept around ID allocation and file moves.
+7. **Modified-files/references/docs fields.** Very useful for background agents: tasks can claim affected paths and later support search/impact review.
+8. **Multiple surfaces over one store.** CLI for scripts, AgentTool/MCP-like tools for agents, REST routes for Web UI, and a workspace plugin pane.
+
+## What to avoid or adapt
+- **Avoid copying Backlog’s Bun-specific server/CLI wholesale.** Seneca/boring-ui is pnpm/Fastify/React/workspace-plugin oriented; integrate through trusted workspace server plugins and existing `AgentTool` contracts.
+- **Do not depend on Backlog source APIs.** Backlog’s own `AGENTS.md:50-55` says only CLI/MCP/instruction surfaces are public. Treat code as inspiration, not a library.
+- **Avoid excessive Git branch scanning as v1.** Backlog has cross-branch/remote ID logic (`src/core/backlog.ts:847-900`); sovereign local Seneca likely needs simpler per-workspace local persistence first. Add Git awareness later if needed.
+- **Avoid runtime plugin server routes for task storage.** boring-ui runtime plugins are route-free and trusted only as local code (`PLUGIN_SYSTEM.md:43-56`); use app/internal plugin or app-shell composition.
+- **Avoid manual markdown as the primary write path.** Keep markdown editable for recovery, but agents/UI should mutate through typed commands to prevent corrupting indexes/markers.
+
+## Suggested Seneca shape
+- Package/plugin: trusted internal `seneca-tasks` workspace server plugin with `agentTools` (`task_create`, `task_list`, `task_view`, `task_update`, `task_comment`, `task_complete/archive`, `task_search`) and Fastify routes (`/api/v1/tasks/*` or plugin-scoped route).
+- Front UI: workspace front plugin panel/left tab for task list/kanban/detail; surface resolver for `openSurface({kind: 'task', target: id})`.
+- Storage: local workspace folder; markdown files with YAML frontmatter and sentinel sections; lock around ID allocation; parser/serializer preserves unknown sections.
+- Agent instructions: Pi skill/resource: “read task workflow overview; use task tools; one active task per background worker; write plan before implementation; update notes/final summary; do not edit task files directly.”
+- Validation: unit tests for parser/serializer, create/update/list/search, lock/concurrent create, route/tool behavior, and a small workspace plugin smoke for opening a task panel.

--- a/docs/issues/397/research/beads-rust-analysis.md
+++ b/docs/issues/397/research/beads-rust-analysis.md
@@ -1,0 +1,208 @@
+# beads-rust / `br` workflow analysis for Seneca/background agents
+
+Scope: local read-only inspection of `br` CLI help, schemas, `.beads/` metadata, and sample JSON output in this repo.
+
+## What `br` models well
+
+### Task IDs
+
+- IDs are stable, human-copyable strings with a repo prefix and short suffix, e.g. `boring-ui-v2-reorg-r32b`.
+- Hierarchical work can use dotted IDs, e.g. `boring-ui-v2-reorg-cx6v.12` under an epic.
+- Local config/DB tracks the active prefix; JSONL rows store the full ID.
+
+Lesson for Seneca: use opaque-but-readable IDs, not database integers. Keep the prefix meaningful for cross-repo/background-agent logs, and allow dotted child IDs when decomposing epics.
+
+### Core task fields
+
+Observed/schema fields include:
+
+- `id`, `title`, `description`, `design`, `acceptance_criteria`, `notes`
+- `status`, `priority` (`0` critical through `4` backlog), `issue_type`
+- `assignee`, `owner`, `created_by`, timestamps, `closed_at`, `close_reason`
+- `labels`, `external_ref`, `due_at`, `defer_until`
+- dependency/dependent counts in list views; full relations in detail views
+
+Lesson: split long task intent from mutable operator notes. Seneca should preserve acceptance criteria and proof fields as first-class data, not only chat text.
+
+### Statuses
+
+Schema status enum includes:
+
+```text
+open, in_progress, blocked, deferred, draft, closed, tombstone, pinned
+```
+
+Common flow in project docs:
+
+```bash
+br ready
+br show <id>
+br update <id> --claim --actor <agent>
+br close <id> --reason "..."
+br sync --flush-only
+```
+
+Lesson: keep statuses simple. `blocked` can be computed from open dependencies for listing, but an explicit blocked/manual state is still useful. `deferred` is separate from blocked.
+
+### Dependencies
+
+`br` supports typed dependencies:
+
+```text
+blocks, parent-child, conditional-blocks, waits-for, related,
+discovered-from, replies-to, relates-to, duplicates, supersedes, caused-by
+```
+
+Important command shape:
+
+```bash
+br dep add <issue> <depends-on> --type blocks
+br dep list <issue> --direction down   # what this issue waits on
+br dep list <issue> --direction up     # what waits on this issue
+br dep tree <issue> --direction both --max-depth 3
+br dep cycles
+```
+
+Sample JSONL dependency row is embedded in each issue as:
+
+```json
+{"issue_id":"boring-ui-v2-00rm","depends_on_id":"boring-ui-v2-gi4n","type":"blocks"}
+```
+
+Lesson: model dependency direction explicitly as `issue depends_on target`; render it in UI as both blockers and dependents to avoid ambiguity.
+
+### Agent claims / assignment
+
+- Assignment is a field: `assignee`.
+- Atomic claiming exists: `br update <id> --claim`, documented as `assignee=actor + status=in_progress`.
+- `--actor <ACTOR>` controls audit/creator attribution.
+- Project workflow also uses out-of-band Agent Mail/file reservations for collision control; `br` alone is not the whole lock protocol.
+
+Useful examples:
+
+```bash
+br update boring-ui-v2-reorg-r32b --claim --actor SenecaWorker-7
+br update boring-ui-v2-reorg-r32b --assignee "" --status open
+br ready --unassigned --limit 10 --json
+br list --assignee SenecaWorker-7 --status in_progress --json
+```
+
+Lesson: a background-agent system should provide one atomic claim transition. Do not make workers separately set `assignee` and `in_progress`. If file/workspace locks are separate, show them beside task claims so humans see the full collision state.
+
+## Listing and detail flows
+
+### Discovery views
+
+```bash
+br ready --limit 20
+br ready --unassigned --label workspace-bridge --json
+br blocked --detailed --limit 20
+br list --status open --priority 1 --limit 50 --json
+br list --all --sort updated_at --reverse --limit 20
+br search "ask-user"
+br count --group status
+br stats
+```
+
+`ready` means open, unblocked, not deferred. `blocked` returns blockers with `blocked_by` arrays in JSON.
+
+### Detail views
+
+```bash
+br show <id>
+br show <id> --json
+br show <id> --format toon
+br dep list <id> --direction both --json
+br comments list <id>
+br audit log <id>
+```
+
+`show --json` returns the full issue plus labels, dependencies/dependents, comments/events where present. It is the right handoff payload for an agent before work starts.
+
+Lesson: Seneca should have separate optimized list rows and rich detail payloads. List rows need enough for triage (`id/title/status/priority/type/assignee/dependency counts`), while detail should include description, acceptance, proof notes, comments, and dependency objects.
+
+## Storage and sync tradeoffs
+
+Observed local storage:
+
+```text
+.beads/beads.db          # SQLite working database
+.beads/issues.jsonl      # git-friendly export
+.beads/config.yaml       # issue prefix/config
+.beads/metadata.json     # database/jsonl filenames
+.beads/*.lock            # write/sync locks
+.beads/.br_history/      # local history backups
+```
+
+`br info --json` reports direct SQLite mode, DB path, JSONL path, issue count, and file sizes. `br sync --status --json` reports dirty count, last import/export times, JSONL hash, and freshness.
+
+Sync commands and safety:
+
+```bash
+br sync --status         # read-only freshness/hash check
+br sync --flush-only     # DB -> JSONL
+br sync --import-only    # JSONL -> DB, validates first
+br sync --merge          # 3-way merge using base snapshot
+br sync --rebuild        # import and remove DB-only entries
+```
+
+Safety guards noted by CLI:
+
+- No git commands or auto-commits.
+- Writes only inside `.beads/` unless explicitly allowed.
+- Atomic temp-file-then-rename writes.
+- Export guards against empty DB overwriting non-empty JSONL and stale DB missing JSONL issues.
+- Import rejects conflict markers and invalid JSON.
+- Global flags: `--no-auto-flush`, `--no-auto-import`, `--allow-stale`, `--no-db` JSONL-only mode.
+
+Tradeoff lesson:
+
+- SQLite is good for fast local queries, atomic claim/update, dependency traversal, and locks.
+- JSONL is good for git diffs, offline review, conflict recovery, and durable sync across clones/agents.
+- Dual storage needs freshness checks and explicit sync discipline. Seneca should either make one store authoritative or expose very clear dirty/stale state in UI and worker APIs.
+- Append-only audit/comment logs are useful for background-agent accountability, but task state itself benefits from indexed DB queries.
+
+## Command examples worth copying into Seneca docs
+
+```bash
+# Find work
+br ready --unassigned --limit 10 --json
+br blocked --detailed --json
+br list --status in_progress --assignee SenecaWorker-7 --json
+
+# Inspect before claiming
+br show boring-ui-v2-reorg-r32b --json
+br dep list boring-ui-v2-reorg-r32b --direction both --json
+
+# Claim / assign
+br update boring-ui-v2-reorg-r32b --claim --actor SenecaWorker-7
+br update boring-ui-v2-reorg-r32b --assignee SenecaWorker-7 --status in_progress
+
+# Add graph edges
+br dep add child-id parent-id --type parent-child
+br dep add implementation-id adr-id --type blocks
+br dep tree epic-id --direction up --max-depth 4
+br dep cycles
+
+# Complete / reopen
+br close boring-ui-v2-reorg-r32b --reason "ADR approved; gates recorded"
+br reopen boring-ui-v2-reorg-r32b
+
+# Sync/debug storage
+br info --json
+br sync --status --json
+br sync --flush-only
+```
+
+## Design recommendations for Seneca/background agents
+
+1. Make `claim(taskId, actor)` atomic and idempotent; return the winning assignee and status.
+2. Represent blockers as typed edges, not prose-only checklists.
+3. Provide `ready`, `blocked`, `mine`, and `detail` APIs as separate optimized flows.
+4. Keep a compact list schema and a rich detail schema; agents should not parse huge descriptions from every list call.
+5. Record acceptance criteria, gate commands, proof/evidence, and close reason as structured fields or clearly named sections.
+6. Surface sync/freshness/dirty state if using DB + file export. Hidden auto-sync is convenient but dangerous under multi-agent concurrency.
+7. Treat comments/audit as append-only event streams; keep canonical task fields mutable but versioned/audited.
+8. Use human-readable IDs in logs and transcripts so background-agent runs can be joined to tasks without DB lookups.
+9. Keep dependency direction consistent in API names: `depends_on` for blockers, `dependents` for downstream work.
+10. If claims do not reserve files/resources, show that explicitly and integrate with a separate reservation layer.

--- a/docs/issues/397/research/local-session-context.md
+++ b/docs/issues/397/research/local-session-context.md
@@ -1,0 +1,309 @@
+# Local session/task primitives for Seneca background-agent supervision
+
+Scope: repo inspection only. No files changed except this research note.
+
+## Executive summary
+
+The repo already has strong **Pi session persistence, session list, chat-pane/session-open, workspace panel, attention/blocker, UI bridge, and plugin extension** primitives. It does **not** yet have a first-class background-agent/task supervision model. Seneca should likely integrate by treating background agents as session-scoped or agent-scoped records that reuse:
+
+- `SessionStore`/`PiSessionStore` for persisted transcripts and summaries.
+- `/api/v1/agent/pi-chat/*` for chat state, streaming, prompt/follow-up/stop/interrupt, create/list/delete.
+- `WorkspaceAgentFront` + `SessionBrowser`/`WorkspaceProjectsNav` for session list/open UI affordances.
+- `WorkspaceAttentionProvider` for “needs human input”/blocking status.
+- Workspace plugin front/server APIs for supervision panels, commands, surface resolvers, and trusted server routes/tools.
+- `UiBridge.postCommand`/`openSurface` for agent-to-workspace UI actions.
+
+Critical constraints from AGENTS/docs: persisted Pi chat/session history is **host app user data** and must live under durable host storage such as `BORING_AGENT_SESSION_ROOT=/data/pi-sessions`, not sandbox `/workspace`, workspace files, container home, or repo checkout. Workspace base front/shared code must not value-import `@hachej/boring-agent`; agent/workspace are composed only at app-shell seams.
+
+## Session persistence and storage
+
+### Shared session contract
+
+`packages/agent/src/shared/session.ts:1-27`
+
+```ts
+export interface SessionStore {
+  list(ctx: SessionCtx, options?: SessionListOptions): Promise<SessionSummary[]>
+  create(ctx: SessionCtx, init?: { title?: string }): Promise<SessionSummary>
+  load(ctx: SessionCtx, sessionId: string): Promise<SessionDetail>
+  delete(ctx: SessionCtx, sessionId: string): Promise<void>
+}
+
+export interface SessionCtx { workspaceId: string; userId?: string }
+export interface SessionListOptions { limit?: number; offset?: number; includeId?: string }
+export interface SessionSummary {
+  id: string
+  title: string
+  createdAt: string
+  updatedAt: string
+  turnCount: number
+}
+export type SessionDetail = SessionSummary
+```
+
+Implication: current persisted session summaries are minimal. A supervision/task layer needs either a separate index/table/API or encoded Pi metadata; `SessionSummary` itself has no status, agent id, parent task, progress, or ownership fields.
+
+### File-backed PiSessionStore
+
+`packages/agent/src/server/harness/pi-coding-agent/sessions.ts:29-74, 82-114`
+
+- Default root resolution:
+  - explicit `sessionRoot` option wins.
+  - else `BORING_AGENT_SESSION_ROOT`.
+  - else `~/.pi/agent/sessions`.
+- Default dir encodes storage cwd as `--<cwd-with-separators-replaced>--`.
+- Optional `sessionNamespace` maps to `<sessionRoot>/<namespace>` and is validated by `/^[a-zA-Z0-9_-]+$/`.
+- `list(ctx, { limit, offset, includeId })` returns sorted summaries and supports keeping an active session in the first page.
+
+`packages/agent/src/server/harness/pi-coding-agent/sessions.ts:120-209`
+
+- `create()` writes a Pi JSONL transcript header and optional `session_info` title.
+- `load()` derives title, created/updated timestamps, and turn count from transcript files.
+- `loadEntries()` exposes persisted Pi messages for cold-load chat reconstruction.
+
+### Harness wiring
+
+`packages/agent/src/server/harness/pi-coding-agent/createHarness.ts:346-370, 455-586`
+
+- `createPiCodingAgentHarness` accepts `sessionNamespace`, `sessionRoot`, and test/host `sessionDir`.
+- It constructs `new PiSessionStore(opts.runtimeCwd ?? opts.cwd, { sessionNamespace, sessionRoot, sessionDir, storageCwd: opts.cwd })`.
+- The resulting harness exposes `sessions: sessionStore`.
+
+### Core/full-app production storage
+
+`AGENTS.md:19` hard rule:
+
+> Session history is host app user data ... Store them on the host app's durable volume via `BORING_AGENT_SESSION_ROOT` (typically `/data/pi-sessions`), not in container home/root. If host-side `BORING_AGENT_WORKSPACE_ROOT=/data/workspaces`, keep the host session root as sibling `/data/pi-sessions` unless the user explicitly chooses another mounted volume.
+
+`packages/core/src/app/server/createCoreWorkspaceAgentServer.ts:650-662`
+
+- Core resolves `workspaceRoot` from options/env.
+- Core resolves `sessionRoot` from `options.sessionRoot`, `BORING_AGENT_SESSION_ROOT`, or infers sibling `pi-sessions` when mode is `vercel-sandbox` and workspace root basename is `workspaces`.
+
+`packages/core/src/app/server/createCoreWorkspaceAgentServer.ts:799-822`
+
+- Core defaults session namespace to `ctx.workspaceId` unless overridden.
+- It passes `sessionRoot` and `getSessionNamespace` into `registerAgentRoutes`.
+
+`packages/cli/src/server/modeApps.ts:642-648`
+
+- CLI intentionally returns `getSessionNamespace: async () => undefined` to share the exact Pi native `~/.pi/agent/sessions/--<workspace-root>--` directory with standalone `pi` for the same folder.
+- Tradeoff documented in code: sessions are keyed by filesystem path; moving a workspace orphans old sessions.
+
+## Session HTTP/API primitives
+
+### Pi chat routes
+
+`packages/agent/src/server/http/routes/piChat.ts:115-177`
+
+- `GET /api/v1/agent/pi-chat/sessions` — list sessions, accepts pagination parsed by `sessionListOptions`.
+- `POST /api/v1/agent/pi-chat/sessions` — create session `{ title? }`.
+- `DELETE /api/v1/agent/pi-chat/sessions/:sessionId` — delete.
+- `GET /api/v1/agent/pi-chat/:sessionId/state` — snapshot/messages.
+- `GET /api/v1/agent/pi-chat/:sessionId/events?cursor=` — NDJSON live event stream.
+- Additional prompt/follow-up/queue/interrupt/stop routes exist later in the same file.
+
+`packages/agent/src/server/pi-chat/harnessPiChatService.ts:79-142`
+
+- `listSessions/createSession/deleteSession` delegate to `SessionStore`.
+- `deleteSession` aborts active Pi adapter work, waits for active run, unsubscribes, releases metering, clears metadata, then deletes the store record.
+- `readState` uses live channel if present, otherwise `loadEntries()` to build a cold persisted snapshot.
+
+### Runtime boot coupling warning
+
+`packages/agent/src/server/registerAgentRoutes.ts:970-979`
+
+- Current `/api/v1/agent/pi-chat/sessions` registration resolves `getService` via `getBindingForRequest(request)`, which can create/boot a runtime binding.
+
+`packages/agent/src/server/registerAgentRoutes.ts:860-873`
+
+- There is already an internal `getSessionStoreForRequest()` that resolves `RuntimeScope` and constructs/caches a `PiSessionStore` without building `HarnessPiChatService`. In the current tree it is not exposed as a no-boot route.
+
+`packages/core/src/app/front/WorkspaceProjectsShell.tsx:68-80`
+
+- The multi-project shell currently fetches `/api/v1/agent/pi-chat/sessions` for project session lists and has a WIP comment: this route currently boots the runtime binding; PR0 must add a no-boot session-list route via `getSessionStoreForRequest` before multi-project lazy expansion ships.
+
+Implication for Seneca: background supervision list views should avoid accidentally booting each agent/runtime just to browse persisted sessions. Reuse or add a no-boot session-list endpoint backed by `getSessionStoreForRequest()`/`SessionStore.list(ctx, { limit, offset })`.
+
+## Frontend session list/open primitives
+
+### Agent package hook + component
+
+`packages/agent/src/front/chat/session/usePiSessions.ts:6-59, 80-96`
+
+- Default sessions API path is `/api/v1/agent/pi-chat/sessions`.
+- Hook state includes `sessions`, `activeSessionId`, `activePiSession`, loading/error, pagination, CRUD actions.
+- It supports `workspaceId`, `storageScope`, `requestHeaders`, custom `sessionsApiPath`, and retry behavior.
+
+`packages/agent/src/front/chat/session/usePiSessions.ts:418-438`
+
+- `fetchSessionList` expects an array response and maps to `SessionSummary`, defaulting missing fields (`title: Untitled`, timestamps now, `turnCount: 0`).
+
+`packages/agent/src/front/chat/session/SessionList.tsx:9-21, 42-111`
+
+- Agent-owned `SessionList` renders grouped session history, active row, create/delete/switch/load-more callbacks.
+- Exports `SessionBrowser = SessionList`.
+
+### Workspace session browser + panes
+
+`packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx:12-39`
+
+- `useWorkingSessionIds()` listens for `window` event `boring:chat-session-status` with `{ sessionId, working }` to show live working state without coupling to a chat implementation.
+
+`packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx:41-58, 150-193`
+
+- `SessionBrowserProps` supports `sessions`, `activeId`, `openIds`, `pinnedIds`, switch/open-as-tab/create/delete/load-more.
+- Browser groups sections as Pinned > Active > History.
+- It reads `WorkspaceAttentionProvider` blockers and marks sessions with `reason === "waiting_for_user_input"` as needing input.
+
+`packages/workspace/src/front/chrome/session-list/definition.ts:6-44`
+
+- Built-in panel id `session-list`, placement `left`, source `builtin`.
+- It passes `sessions`, `activeId`, `openIds`, `pinnedIds`, `onOpenAsTab`, etc. into `SessionBrowser`.
+
+`packages/workspace/src/app/front/WorkspaceAgentFront.tsx:520-572`
+
+- Persists pinned sessions per workspace in localStorage.
+- Uses default `usePiSessions` unless caller injects `useSessions`.
+- Sets `connectActiveSession: false` in default hook, so listing does not directly open an active remote session; chat panes connect separately.
+
+`packages/workspace/src/app/front/WorkspaceAgentFront.tsx:950-1018, 1030-1064, 1361-1384`
+
+- Calculates `chatSessionId`, prunes/restores chat pane state only when session list is authoritative, and supports placeholder session while remote sessions load.
+- `chatPanes` are generated from open session ids, with active pane bridge enabled only for the active chat pane.
+- `ChatLayout` receives `nav="session-list"` with `sessions`, `activeId`, `openIds`, `pinnedIds`, `onOpenAsTab`, `onLoadMore`, `hasMore`, etc.
+
+### Full-app multi-project nav shell
+
+`packages/core/src/app/front/WorkspaceProjectsShell.tsx:15-31, 68-130, 171-193`
+
+- Persistent left-bar shell lists workspaces as projects and lazily fetches sessions per project.
+- `openSession(projectId, sessionId)` synchronously writes `writeActiveSessionId(..., { storageScope: projectId })`, then navigates to the project. Same-project open is currently a no-op pending a typed workspace event.
+- `WorkspaceProjectsNav` is presentational and lives in workspace package; Core owns data/routing/auth.
+
+Implication for Seneca: for “open output”/supervision UX, reuse `SessionBrowser`/`WorkspaceProjectsNav` patterns: one row can open/switch a session, open as another chat pane, pin, show working/needs-input. For same-workspace same-page session switching, beware current TODO: no typed workspace event yet in `WorkspaceProjectsShell`.
+
+## Workspace panels, bridge, and attention primitives
+
+`docs/WORKSPACE_CONTRACT.md:8-35`
+
+- Agent and workspace are composed at app-shell level.
+- Rules: workspace base front/shared must not value-import agent; agent must not import workspace; app shell wires `WorkspaceAgentFront`/`WorkspaceProvider` and agent components.
+
+`packages/workspace/src/front/chrome/chat/types.ts:6-31`
+
+- Workspace injects `WorkspaceChatPanelProps`: `sessionId`, `requestHeaders`, `onOpenArtifact`, `bridgeEndpoint`, `getSurface`, open/close workbench callbacks, `composerBlockers`, stop/blocker actions.
+
+`packages/workspace/src/front/chrome/chat/ChatPanelHost.tsx:52-138`
+
+- Host gets injected chat component via `useWorkspaceChatPanel()`.
+- Filters attention blockers to current `sessionId` and passes them to chat implementation.
+- Dispatches stop/blocker action events and forwards UI command bridge props.
+
+`packages/workspace/src/front/attention/WorkspaceAttentionProvider.tsx:5-24, 38-51`
+
+- In-memory blockers: `{ id, reason, label?, surfaceKind?, target?, sessionId?, actions? }`.
+- Provides `addBlocker/removeBlocker`.
+- This is useful for supervision statuses such as “waiting for user input,” but it is not persisted and is only in mounted workspace UI state.
+
+`docs/WORKSPACE_CONTRACT.md:141+` and `packages/workspace/docs/README.md:18-25`
+
+- `UiBridge.postCommand()` is the single authoritative agent-to-UI dispatch source.
+- `openSurface` decouples agent requests from concrete panel ids; plugins register surface resolvers.
+
+Implication for Seneca: a supervisor panel should be a workspace panel/plugin surface. Background agents should not drive UI by parsing chat display parts; use bridge commands/surface resolvers.
+
+## Plugin extension points
+
+`packages/workspace/docs/README.md:12-28, 36-59`
+
+- Workspace plugin host populates panel, command, catalog, and surface-resolver registries via `WorkspaceProvider` bootstrap.
+- Two tiers:
+  - App/internal plugins: trusted, boot-time, can add routes/agent tools/Pi resources.
+  - Runtime/generated `.pi/extensions`: hot-reloaded front/Pi resources, route-free, local/direct-style contexts only, not `vercel-sandbox`.
+
+`packages/workspace/docs/PLUGIN_SYSTEM.md:30-61`
+
+- App/internal plugin may export `boring.server`, routes, agent tools, providers, domain APIs.
+- Runtime/generated plugin is workspace-local `.pi/extensions/<id>`, hot-loaded for front/Pi, **must not rely on dynamic backend routes**.
+- Plugin tools execute in host Node and bypass sandbox by design; untrusted hosted marketplace plugins are not implemented.
+
+`packages/workspace/docs/PLUGIN_SYSTEM.md:190-244`
+
+- `definePlugin({ panels, commands, surfaceResolvers })` is the front authoring API.
+- `defineServerPlugin({ systemPrompt, agentTools, routes })` is the trusted server authoring API.
+- Hot reload covers Pi resources and front outputs; `boring.server` routes/tools are boot-time only and require restart.
+
+`packages/workspace/docs/PLUGIN_STRUCTURE.md:8-44`
+
+- Runtime plugin shape: `.pi/extensions/<name>/package.json`, `front/index.tsx`, no server by default.
+- App/internal plugin shape: `plugins/<name>/src/front`, optional `src/server`, `src/shared`.
+
+Implication for Seneca: supervision UI can be a front plugin/panel. Any durable task/session index API, background worker launch/supervision route, or agent tool should be a trusted app/internal server plugin or core/agent server feature, not a runtime generated plugin route.
+
+## Task/background-agent primitives found or missing
+
+Found:
+
+- Session rows can display live-ish state using `boring:chat-session-status` (`working`) and `WorkspaceAttentionProvider` (`waiting_for_user_input`).
+- Session list summaries have `turnCount`, `updatedAt`, and titles.
+- `HarnessPiChatService` has stop/interrupt/delete hooks for active session lifecycle and metering release.
+- Plugin/server APIs can add panels, commands, agent tools, routes, system prompt addenda, Pi skills/extensions.
+
+Missing/gaps for Seneca:
+
+- No durable `Task`/`BackgroundAgent` data model in current source. README only advertises future “tasks/workflows” ideas; current code is session-centric.
+- `SessionSummary` cannot represent task state/progress/owner/parent-child relationships.
+- `WorkspaceAttentionProvider` status is in-memory UI state, not a durable background task state bus.
+- Current `/api/v1/agent/pi-chat/sessions` list can boot runtime; a no-boot list endpoint is only called out as WIP in `WorkspaceProjectsShell`.
+- Multi-agent isolation is not implemented in current code. Existing plans mention adding `agentId` to binding scope key and `sessionNamespace`, but current `registerAgentRoutes` scope key is `[mode, workspaceId, root, templatePath, pi, sessionNamespace]` (see `registerAgentRoutes.ts:432-447`). Seneca must not assume per-agent isolation unless implemented.
+
+## High-value integration points for Seneca
+
+1. **Durable session/transcript storage**
+   - Use `sessionRoot`/`BORING_AGENT_SESSION_ROOT` and `sessionNamespace` for any background-agent transcript grouping.
+   - For multi-agent Seneca roles, extend namespace with a safe `agentId`/task id segment rather than sharing a workspace namespace.
+
+2. **No-boot session/task listing**
+   - Add/reuse a route backed by `getSessionStoreForRequest()` and `SessionStore.list(ctx, { limit, offset, includeId })` for browsing background sessions without creating runtime bindings.
+   - Do not paginate by stuffing `limit/offset` into `SessionCtx`; options are the second arg.
+
+3. **Supervision UI panel**
+   - Implement as workspace front plugin panel/left-tab or app shell panel.
+   - Use `SessionBrowser` affordances for active/open/pinned/working/needs-input, or compose a custom panel from the same primitives.
+
+4. **Open session/output behavior**
+   - For active workspace, route through `WorkspaceAgentFront` chat pane mechanics (`onOpenAsTab`, `chatPanes`, `activeChatPaneId`).
+   - For cross-project open, existing pattern is `writeActiveSessionId(sessionId, { storageScope: projectId })` then navigate.
+   - Same-project open from `WorkspaceProjectsShell` currently lacks a typed event; avoid ad-hoc CustomEvents unless a proper workspace event is introduced.
+
+5. **Human supervision/approval**
+   - Reuse `WorkspaceAttentionProvider` for mounted UI blockers (“waiting_for_user_input”) and composer blockers.
+   - For durable background agents, add a persistent task/blocker source; don’t rely only on the in-memory provider.
+
+6. **Server-side extensions**
+   - Trusted supervision APIs/routes/tools belong in app/internal `defineServerPlugin` or core/agent server composition.
+   - Runtime `.pi/extensions` can contribute front panels/Pi skills but not dynamic backend routes.
+
+7. **UI bridge/surfaces**
+   - Use `UiBridge.postCommand`/`openSurface` to open panels/artifacts from agents.
+   - Register surface resolvers rather than hardcoding panel ids in agent outputs.
+
+## Constraints and risks
+
+- **Storage invariant:** transcripts/session lists are host-owned durable app data; never put them in sandbox `/workspace`, workspace root, repo checkout, or ephemeral container home for deployed core apps.
+- **Import boundary:** workspace base front/shared cannot value-import `@hachej/boring-agent`; app/front and app/server composition seams may import both.
+- **Runtime boot risk:** session browsing via current `/api/v1/agent/pi-chat/sessions` can provision runtime. Seneca list views should avoid this.
+- **Namespace collision risk:** `PiSessionStore` namespace accepts only `[A-Za-z0-9_-]`; any `agentId`/task id must be normalized. Without agent id in namespace/scope key, sessions for multiple background agents in one workspace can cross-contaminate.
+- **Plugin trust:** generated runtime plugins are local trusted front/Pi code only; no dynamic server routes/tools. Host-node plugin tools bypass sandbox.
+- **Stable errors:** AGENTS/docs require stable error codes; new task/session APIs should use canonical error-code patterns rather than arbitrary envelopes.
+- **UI state durability:** `pinnedIds`, chat pane layout, active session id are localStorage/browser state. Durable supervision needs backend state if it must survive browser/device changes.
+
+## Suggested validation paths if implementing later
+
+- Unit: `PiSessionStore` list pagination/includeId, namespace isolation, no workspace-root storage.
+- Server: no-boot session-list route does not call `getOrCreateRuntimeBinding`; returns stable errors for unauthorized/unknown workspace.
+- Front: `WorkspaceAgentFront` session open/pin/open-as-tab still works; same-workspace typed open event if added.
+- Workspace: `SessionBrowser` displays working and needs-input badges from events/blockers.
+- Plugin: front plugin panel registers without route assumptions; trusted server plugin route/tool only boot-wired.
+- Invariants: run `pnpm lint:invariants` for import boundary/shared-node constraints.

--- a/docs/issues/397/research/paperclip-analysis.md
+++ b/docs/issues/397/research/paperclip-analysis.md
@@ -1,0 +1,267 @@
+# Paperclip analysis for Seneca/background-agent task management
+
+Scope: direct read of cloned repo `/tmp/paperclip-LqFh5p/paperclip`; no files modified except this report.
+
+## Executive takeaways
+
+Paperclip’s strongest lesson is that background-agent management is not just `Task + Run + Session`. It is a **task execution control plane** with separate durable concepts for: task intent, assignment/checkout lock, wake request, run attempt, run event/log stream, per-agent/per-task session continuity, workspace/environment lease, activity/audit trail, blocker graph, and recovery/supervision state.
+
+For Seneca, keep the first version smaller than Paperclip, but do not collapse these into chat sessions. Add explicit task assignment/checkout and run/wakeup/session tables around existing Pi session persistence.
+
+## 1. Task / issue model
+
+### Paperclip model shape
+
+Paperclip’s primary task row is `issues`, not a thin todo item:
+
+- `packages/db/src/schema/issues.ts:22-72` defines `issues` with `companyId`, `projectId`, `projectWorkspaceId`, `goalId`, `parentId`, `title`, `description`, `status`, `workMode`, `priority`, `assigneeAgentId`, `assigneeUserId`, `checkoutRunId`, `executionRunId`, `executionAgentNameKey`, `executionLockedAt`, origin/idempotency fields, execution policy/state, monitor fields, execution workspace fields, and lifecycle timestamps.
+- `packages/shared/src/types/issue.ts:532-584` mirrors this to UI/API as `Issue`, including `checkoutRunId`, `executionRunId`, `executionWorkspaceId`, `blockedBy`, `blocks`, `blockerAttention`, recovery/watchdog summaries, labels, and timestamps.
+- Status values are documented in the agent skill: `backlog`, `todo`, `in_progress`, `in_review`, `done`, `blocked`, `cancelled` (`skills/paperclip/SKILL.md:139-148`).
+- `workMode` is separate from status (`standard` vs planning-mode work; see schema `work_mode` at `packages/db/src/schema/issues.ts:33` and shared type field at `packages/shared/src/types/issue.ts:543`).
+
+### Dependencies and blockers
+
+Paperclip treats blockers as first-class issue relations, not prose:
+
+- Agent instructions require `blockedByIssueIds` for dependencies and warn that `parentId` alone is not a blocker (`skills/paperclip/SKILL.md:153-176`, `skills/paperclip/SKILL.md:310`).
+- Checkout refuses blocked work with unresolved blockers: `server/src/services/issues.ts:5557-5561` loads dependency readiness and throws `Issue is blocked by unresolved blockers`.
+- Queued runs are also gated at claim time: `server/src/services/heartbeat.ts:7414-7421` cancels queued runs for unresolved blockers unless it is an allowed interaction wake.
+
+### Design lesson for Seneca
+
+Use `Task` as the durable business object, but include enough execution-control fields from day one:
+
+- status/work mode/priority
+- assignee agent/user
+- parent/children and explicit `blockedByTaskIds`
+- current checkout/run lock fields
+- origin/idempotency fields for recurring or generated tasks
+- workspace/session linkage fields
+- lifecycle timestamps and terminal reason
+
+Do not encode “blocked”, “waiting for user”, “review”, or “agent is still working” only in chat text.
+
+## 2. Agent heartbeat runtime
+
+### Paperclip heartbeat primitives
+
+Paperclip has a DB-backed wake/run pipeline:
+
+- `agent_wakeup_requests` is the durable wake queue: `companyId`, `agentId`, `source`, `reason`, JSON payload, `status`, `coalescedCount`, requester, `idempotencyKey`, `runId`, requested/claimed/finished timestamps (`packages/db/src/schema/agent_wakeup_requests.ts:6-37`).
+- `heartbeat_runs` is each execution attempt: `invocationSource`, `triggerDetail`, `status`, start/finish/error fields, `wakeupRequestId`, usage/result JSON, `sessionIdBefore/After`, log refs/excerpts, process PID/group, output heartbeat fields, retry/liveness fields, and `contextSnapshot` (`packages/db/src/schema/heartbeat_runs.ts:6-58`).
+- `heartbeat_run_events` is append-only-ish run event/log persistence with `runId`, monotonic `seq`, `eventType`, stream/level/message/payload (`packages/db/src/schema/heartbeat_run_events.ts:4-28`).
+
+Runtime claim/execution pattern:
+
+- `startNextQueuedRunForAgent()` enforces per-agent invokability and concurrency, sorts queued runs by issue readiness/status/priority, claims up to available slots, then launches `executeRun()` (`server/src/services/heartbeat.ts:8316-8391`).
+- `claimQueuedRun()` checks agent invokability, budgets, daily caps, pause holds, dependency gates, and stale issue context before atomically changing a run from `queued` to `running` via `WHERE id = ? AND status = 'queued'` (`server/src/services/heartbeat.ts:7369-7468`).
+- Claim is deliberately “lazy locking”: only when a run becomes `running` does it stamp the issue `executionRunId`/`executionLockedAt` (`server/src/services/heartbeat.ts:7491-7515`).
+- Orphan recovery scans `running` runs with no live in-memory execution/process and marks/retries/finalizes them (`server/src/services/heartbeat.ts:8057-8149`).
+
+### Design lesson for Seneca
+
+Model **wake request** separately from **run**. A task assignment/comment/schedule should create or coalesce a wake request, which then creates/points to a run. This avoids duplicate wakes, allows debouncing comments, makes “queued vs running vs deferred” visible, and gives recovery code something to reason about.
+
+## 3. Agent-task session continuity
+
+Paperclip does not rely only on global agent session state:
+
+- `agent_task_sessions` stores a unique session record per `(companyId, agentId, adapterType, taskKey)` with session params/display id, last run, and last error (`packages/db/src/schema/agent_task_sessions.ts:7-34`).
+- `deriveTaskKeyWithHeartbeatFallback()` resolves task key from context `taskKey`/`taskId`/`issueId`; timer wakes use a synthetic `__heartbeat__` key only for addressability (`server/src/services/heartbeat.ts:2266-2302`).
+- `shouldResetTaskSessionForWake()` forces fresh sessions for assignment/review/approval/timer wake reasons to avoid stale or bloated context (`server/src/services/heartbeat.ts:2304-2328`).
+- `getTaskSession()`, `upsertTaskSession()`, and `clearTaskSessions()` manage the per-task session row (`server/src/services/heartbeat.ts:3743-3760`, `server/src/services/heartbeat.ts:4938-4987`).
+- Runs record `sessionIdBefore` and `sessionIdAfter` (`packages/db/src/schema/heartbeat_runs.ts:24-25`) for audit/debug.
+
+Relevant release-note failures: stale session reuse across heartbeat runs and adapter/model swaps were real bugs (`releases/v2026.403.0.md:40-44`, `releases/v2026.618.0.md:39`).
+
+### Design lesson for Seneca
+
+Do not use a single “agent last session” for all background work. Add a per-task/per-agent session binding that can be reset on assignment/model/tooling changes. Store both before/after session ids on each run.
+
+## 4. Run/event persistence and logs
+
+Paperclip persists both structured run rows and streaming event/log rows:
+
+- Run status/result/usage/log pointers live on `heartbeat_runs` (`packages/db/src/schema/heartbeat_runs.ts:11-58`).
+- Events/log lines live in `heartbeat_run_events` and are indexed by `(runId, seq)` and `(companyId, runId)` (`packages/db/src/schema/heartbeat_run_events.ts:4-28`).
+- UI spec says run detail should show queued→running→outcome timeline, session before/after, tokens, cost, error code, exit/signal, and stream `heartbeat_run_events` ordered by `seq` (`docs/specs/agent-config-ui.md:145-183`).
+
+### Design lesson for Seneca
+
+Persist a bounded summary on `Run`, but keep detailed transcript/log events in a separate append-only table or file-backed log referenced from `Run`. UI needs list rows cheap; detail pages need drill-down.
+
+## 5. Atomic checkout / assignment
+
+Paperclip requires checkout before work:
+
+- Agent instructions: “You MUST checkout before doing any work”; checkout uses `POST /api/issues/{issueId}/checkout` with `X-Paperclip-Run-Id`; 409 means stop/pick another task (`skills/paperclip/SKILL.md:60-69`).
+- Route enforces that an agent can only checkout as itself and requires a run id for agent callers (`server/src/routes/issues.ts:6708-6734`).
+- Service checkout first clears terminal stale locks, blocks unresolved dependencies, then atomically updates only if status is expected, assignee is empty/same-agent, and execution lock is empty/same-run (`server/src/services/issues.ts:5533-5594`).
+- If already owned by same run, it returns normally; otherwise it returns `409 Issue checkout conflict` with current assignee/run lock details (`server/src/services/issues.ts:5709-5727`).
+- Stale lock adoption exists but is careful: terminal/missing run locks can be adopted or cleared (`server/src/services/issues.ts:4033-4087`, `server/src/services/issues.ts:3903-3973`).
+
+### Design lesson for Seneca
+
+Use a compare-and-set style checkout:
+
+- `expectedStatuses` guard
+- `assigneeAgentId` empty or caller
+- `checkoutRunId` null or same run
+- `executionRunId` null or same run
+- return stable `409` with owner/run details
+- self-checkout idempotent
+- stale terminal run cleanup path
+
+Avoid direct “PATCH task status=in_progress” as the work claim path.
+
+## 6. UI supervision surfaces
+
+Paperclip exposes work through task boards, detail threads, live runs, agent run lists, and recovery surfaces:
+
+- `ui/src/pages/Issues.tsx:1-113` loads tasks, agents/projects, company live runs via `heartbeatsApi.liveRunsForCompany`, refreshes every 5s, and derives `liveIssueIds` for list status.
+- `ui/src/pages/IssueDetail.tsx:286-324` resolves active/running issue runs from live run and issue lock state; issue detail imports `IssueChatThread`, `IssueRunLedger`, `heartbeatsApi`, and optimistic run helpers (`ui/src/pages/IssueDetail.tsx:8-99`).
+- Agent config UI spec includes grouped heartbeat run rows with status icon, invocation source chip, token/cost, result/error, expandable logs, session before/after, and live appends (`docs/specs/agent-config-ui.md:145-183`).
+- Plugin UI slots include `taskDetailView`, `detailTab`, context menus, and toolbar buttons (`ui/src/plugins/slots.tsx:152`; `ui/src/plugins/launchers.tsx:108`).
+
+### Design lesson for Seneca
+
+Build three surfaces, not one:
+
+1. **Task list/supervision panel**: cheap rows with status, assignee, blockers, current run, needs-input.
+2. **Task detail thread**: durable comments/events/artifacts and action buttons.
+3. **Run detail/log panel**: transcript/log stream, status timeline, stop/retry/cancel controls.
+
+Reuse existing boring-ui session browser/chat panes for opening output, but do not make session list the source of truth for task status.
+
+## 7. CLI / API / agent tools
+
+Paperclip’s agent-facing contract is explicit and small:
+
+- Hot endpoints are documented in `skills/paperclip/SKILL.md:403-420`: identity, inbox-lite, assignments, checkout, task context, update, comments, interactions, create subtask, release, search, documents, approvals, attachments, execution workspace/runtime, agents, dashboard.
+- `cli/src/commands/client/issue.ts:170-350` registers `issue list/get/delete/heartbeat-context/create/update`.
+- `cli/src/commands/client/issue.ts:360-418` registers comment add/list/get/delete.
+- `cli/src/commands/client/issue.ts:542+` includes child issue creation from JSON payload.
+- Agent instructions require `X-Paperclip-Run-Id` on all mutating issue API requests so actions can be attributed to the run (`skills/paperclip/SKILL.md:28`, `skills/paperclip/SKILL.md:60-65`).
+
+### Design lesson for Seneca
+
+Expose the same core service through UI, REST, CLI, and agent tools. Minimal v1 tool/API set:
+
+- `task_create`, `task_list`, `task_view`, `task_update`, `task_comment`
+- `task_checkout`, `task_release`
+- `task_context` compact endpoint
+- `run_list`, `run_view`, `run_events`, `run_cancel/retry`
+- `agent_inbox` compact endpoint
+
+Require `runId` on agent mutations for audit.
+
+## 8. Failure modes Paperclip had to harden against
+
+Avoid these in Seneca v1 design:
+
+1. **Double work / weak claim semantics**: solved by checkout CAS and 409 conflicts (`server/src/services/issues.ts:5533-5727`).
+2. **Stale checkout/execution locks**: Paperclip has `clearCheckoutRunIfTerminal`, `clearExecutionRunIfTerminal`, adoption paths, and a recovery sweeper (`server/src/services/issues.ts:4033-4087`; release notes `releases/v2026.618.0.md:15`).
+3. **Zombie/lost runs**: orphan reaper handles running DB rows with no process handle (`server/src/services/heartbeat.ts:8057-8149`; release notes `releases/v2026.618.0.md:42`).
+4. **Queued work becoming stale**: queued claim cancels if issue reassigned/cancelled/blocked/stale before start (`server/src/services/heartbeat.ts:7414-7455`).
+5. **Blocked dependency fanout waste**: scheduler/claim gates blocked issues and wakes dependents only when blockers resolve (`skills/paperclip/SKILL.md:153-176`; `server/src/services/heartbeat.ts:7414-7421`).
+6. **Session contamination**: per-task sessions and reset-on-wake avoid reusing wrong/stale sessions (`server/src/services/heartbeat.ts:2266-2328`; `releases/v2026.618.0.md:39`).
+7. **Missing progress evidence**: liveness classification records `livenessState`, `lastUsefulActionAt`, `nextAction`; run summary counts comments/doc revisions/work products/activity/events (`packages/db/src/schema/heartbeat_runs.ts:50-56`; `server/src/services/heartbeat.ts:8000-8052`).
+8. **Recovery loops**: release notes show bounded retries, blocked recovery issues, and cancellation on ownership changes (`releases/v2026.427.0.md:9-22`, `releases/v2026.428.0.md:13-14`).
+9. **UI invisibility of background state**: Paperclip surfaces live runs in task list/detail and run logs in agent pages (`ui/src/pages/Issues.tsx:97-107`; `docs/specs/agent-config-ui.md:145-183`).
+10. **Unaudited agent mutations**: run id header links task mutations/comments to the current run (`skills/paperclip/SKILL.md:28`).
+
+## 9. Recommended Seneca data-model delta vs current Task/Run/Session plan
+
+Current boring-ui/Seneca context found in this repo says there is **no durable Task/BackgroundAgent model yet**; existing primitives are session-centric and `SessionSummary` cannot represent task state, owner, parent/child, or durable blockers (`seneca-task-research/local-session-context.md:244-260`). Existing Pi session persistence should be reused, but not treated as the task store.
+
+### Add / adjust v1 entities
+
+#### `Task`
+
+Delta from a minimal Task:
+
+- `id`, human identifier/title/description
+- `workspaceId` / project/workspace scope
+- `status`: `backlog | todo | in_progress | in_review | blocked | done | cancelled`
+- `workMode`: `standard | planning` (or equivalent)
+- `priority`
+- `assigneeAgentId`, optional `assigneeUserId`
+- `parentTaskId`
+- `blockedByTaskIds` via relation table, not prose
+- `checkoutRunId`, `executionRunId`, `executionLockedAt`
+- `sessionKey` or `taskKey`
+- `originKind`, `originId`, `originFingerprint` for recurring/generated/idempotent tasks
+- `createdBy*`, `startedAt`, `completedAt`, `cancelledAt`, `updatedAt`
+- optional `requiresInput` / `reviewState` / `blockerOwner` fields if not modeled as thread interactions
+
+#### `TaskComment` / `TaskEvent`
+
+Add durable comments/events separate from Pi transcript:
+
+- comment body, author agent/user/system, `runId`, createdAt
+- event/action log for checkout/update/comment/status changes
+- maybe attachment/artifact references later
+
+#### `WakeRequest` (new, do not skip)
+
+Paperclip evidence strongly supports adding this between task and run:
+
+- `id`, `workspaceId`, `agentId`, `taskId?`
+- `source`: assignment/comment/timer/manual/automation
+- `reason`, payload/context snapshot
+- `status`: queued/claimed/deferred/cancelled/failed/done
+- `coalescedCount`, `idempotencyKey`
+- `runId?`, requester, timestamps, error
+
+#### `Run`
+
+Delta from a minimal Run:
+
+- link to `wakeRequestId`, `taskId?`, `agentId`, `workspaceId`
+- `invocationSource`, `triggerDetail`, `contextSnapshot`
+- `status`: queued/running/succeeded/failed/cancelled/timed_out/scheduled_retry
+- `sessionIdBefore`, `sessionIdAfter`
+- process/runtime info if local execution: pid/group, startedAt, lastOutputAt
+- usage/cost/result JSON, error and stable `errorCode`
+- log pointer/excerpts
+- retry fields: `retryOfRunId`, scheduled retry fields, attempt
+- liveness fields: `livenessState`, `lastUsefulActionAt`, `nextAction`
+
+#### `RunEvent`
+
+- `runId`, monotonically increasing `seq`, `eventType`, stream/level/message/payload, createdAt
+- store enough to render live logs without loading the whole transcript
+
+#### `AgentTaskSession`
+
+Add explicit per-agent/per-task continuity:
+
+- unique `(workspaceId, agentId, adapterType/runtimeKind, taskKey)`
+- `sessionId` / `sessionParamsJson` / display id
+- `lastRunId`, `lastError`, timestamps
+- reset when model/adapter/runtime changes or on assignment/timer reasons as needed
+
+#### `AgentRuntimeState` (optional but useful)
+
+- per-agent aggregate state: last run/status/error, global legacy session fallback, total tokens/cost if metering is used
+
+### v1 constraints for Seneca
+
+- Do not make Pi chat session the only task/run record.
+- Do not let `status=in_progress` be directly patchable by agents as claim; require checkout.
+- Do not browse task/session lists through routes that boot a runtime; existing analysis warns current session list can boot runtime (`seneca-task-research/local-session-context.md:296`).
+- Keep task supervision server-side/trusted; runtime plugins may render UI but should not define durable backend routes.
+- Require stable error codes for checkout conflicts, blocked dependencies, stale locks, unauthorized agent mutation, missing run id.
+
+## 10. Concrete implementation lessons for boring-ui/Seneca
+
+1. **Start with a small Paperclip-inspired core, not the whole org-chart product.** Seneca likely needs local/workspace task supervision, not company/goal/budget/approval breadth on day one.
+2. **Checkout is the critical primitive.** It prevents duplicate agent work and gives UI a single active owner/run.
+3. **WakeRequest is worth the extra table.** It enables coalescing, idempotency, deferred wakes, and clear UI states.
+4. **Session continuity must be task-scoped.** Existing Pi sessions are reusable storage, but add `AgentTaskSession` mapping to prevent cross-task context bleed.
+5. **Separate list vs detail payloads.** Task lists need cheap rows; task detail can load comments, run ledger, blockers, artifacts.
+6. **Persist run events separately.** UI supervision needs logs/timeline even when the live process is gone.
+7. **Build recovery from day one, even if simple.** At minimum: clear terminal run locks, reap orphan running runs, cancel stale queued runs, surface blocked recovery instead of infinite retry.
+8. **Make blockers machine-readable.** Use relation rows and wake dependents when blockers resolve; do not rely on comments.
+9. **Require run attribution headers/tool params.** Every agent mutation should carry `runId`.
+10. **Design UI around supervision, not chat.** Task list + detail thread + run log panel should coexist with open-session/chat panes.


### PR DESCRIPTION
## Summary
- Add Seneca/background-agent control-plane research under docs/issues/397/research/.
- Issue #399 has been folded into #397 as the canonical Seneca control-plane issue.

## Scope
Docs only.
