### PR TITLE
feat: refine chat-first public landing CTA

### DIFF
--- a/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
+++ b/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
@@ -1,7 +1,6 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 import { useLocation } from 'react-router-dom'
-import { builtinCommands, type ChatSuggestion, type SlashCommand } from '@hachej/boring-agent/front'
-import { postUiCommand } from '@hachej/boring-workspace'
+import { builtinCommands, type ChatSuggestion } from '@hachej/boring-agent/front'
 import type {
   WorkspaceAgentFrontProps,
   WorkspaceAgentSession,
@@ -28,6 +27,16 @@ export interface ChatFirstPublicShellOptions {
    * passed in here. `available` defaults to `true`.
    */
   models?: Array<{ provider: string; id: string; label: string; available?: boolean }>
+  /**
+   * Optional public top-bar contact CTA. When set, the no-auth top bar shows a
+   * “Get in touch” button that opens a Calendly popover instead of asking users
+   * to discover hidden chat commands.
+   */
+  contact?: {
+    label?: string
+    calendlyUrl: string
+    title?: string
+  }
   /**
    * Hand-drawn "Ask your AI here" / "Review its work here" annotations point at the
    * composer and the workspace surface to teach the empty public shell. Apps
@@ -63,6 +72,37 @@ function readComposerDraftFromDom(): string {
   return input?.value ?? ''
 }
 
+function PublicTopBarActions({
+  contact,
+  onSignIn,
+}: {
+  contact?: ChatFirstPublicShellOptions['contact']
+  onSignIn: () => void
+}) {
+  const [contactOpen, setContactOpen] = useState(false)
+  return (
+    <div className="public-topbar-actions">
+      {contact ? (
+        <div className="public-contact-popover-wrap">
+          <button type="button" className="public-contact-button" onClick={() => setContactOpen((open) => !open)}>
+            {contact.label ?? 'Get in touch'}
+          </button>
+          {contactOpen ? (
+            <div className="public-contact-popover" role="dialog" aria-label={contact.title ?? 'Schedule a call'}>
+              <div className="public-contact-popover-header">
+                <span>{contact.title ?? 'Schedule a call'}</span>
+                <button type="button" aria-label="Close contact popover" onClick={() => setContactOpen(false)}>×</button>
+              </div>
+              <iframe title={contact.title ?? 'Schedule a call'} src={contact.calendlyUrl} loading="lazy" />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+      <button type="button" className="public-sign-in-button" onClick={onSignIn}>Sign in</button>
+    </div>
+  )
+}
+
 export function ChatFirstPublicShell<
   TSession extends WorkspaceAgentSession = WorkspaceAgentSession,
 >({
@@ -78,7 +118,6 @@ export function ChatFirstPublicShell<
 }) {
   const location = useLocation()
   const [modalOpen, setModalOpen] = useState(false)
-  const lastAutoRunCommandRef = useRef('')
   const returnTo = safeReturnTo(location.pathname, location.search, location.hash)
   const promptedDraft = new URLSearchParams(location.search).get('prompt')?.trim() ?? ''
   const pendingReturnTo = promptedDraft ? '/' : returnTo
@@ -89,93 +128,6 @@ export function ChatFirstPublicShell<
     writePendingChatEntry({ draft, returnTo: pendingReturnTo, ...(intendedWorkspaceId ? { intendedWorkspaceId } : {}) })
     setModalOpen(true)
   }
-  const normalizePublicCommand = (draft: string) => draft.trim().toLowerCase().replace(/[’`]/g, "'")
-  const openLandingPage = () => postUiCommand({
-    kind: 'openPanel',
-    params: { id: 'public-landing-page', component: 'public.launch.landing', title: 'Landing page' },
-  })
-  const openLetsChat = () => postUiCommand({
-    kind: 'openPanel',
-    params: { id: 'public-lets-chat', component: 'public.launch.lets-chat', title: 'Let’s chat' },
-  })
-  const publicCommands: SlashCommand[] = [
-    {
-      name: 'landing-page',
-      description: 'Open the landing page workspace tab.',
-      kind: 'local',
-      handler: () => {
-        openLandingPage()
-        return { message: 'Opened Landing page.' }
-      },
-    },
-    {
-      name: 'reach-out',
-      description: 'Open the Calendly workspace tab.',
-      kind: 'local',
-      handler: () => {
-        openLetsChat()
-        return { message: 'Opened Let’s chat.' }
-      },
-    },
-  ]
-  const runPublicCommand = (draft: string): boolean => {
-    const command = normalizePublicCommand(draft)
-    if (command === '/landing-page') {
-      openLandingPage()
-      return true
-    }
-    if (command === '/reach-out' || command === "/let's-chat" || command === '/lets-chat') {
-      openLetsChat()
-      return true
-    }
-    return false
-  }
-
-  useEffect(() => {
-    const intercept = (event: Event): boolean => {
-      const draft = readComposerDraftFromDom()
-      if (!runPublicCommand(draft)) return false
-      event.preventDefault()
-      event.stopPropagation()
-      return true
-    }
-    const onClick = (event: MouseEvent) => {
-      const target = event.target instanceof Element ? event.target : null
-      if (!target?.closest('[data-boring-agent-part="composer-submit"], [aria-label="Submit"]')) return
-      intercept(event)
-    }
-    const maybeAutoRunDraft = () => {
-      const draft = readComposerDraftFromDom()
-      const command = normalizePublicCommand(draft)
-      const isCommand = command === '/landing-page' || command === '/reach-out' || command === "/let's-chat" || command === '/lets-chat'
-      if (!isCommand) {
-        lastAutoRunCommandRef.current = ''
-        return
-      }
-      if (lastAutoRunCommandRef.current === command) return
-      lastAutoRunCommandRef.current = command
-      runPublicCommand(draft)
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      const target = event.target instanceof Element ? event.target : null
-      if (!target?.closest('[data-boring-agent-part="composer-input"]')) return
-      if (event.key === 'Enter' && !event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) intercept(event)
-    }
-    const onInput = (event: Event) => {
-      const target = event.target instanceof Element ? event.target : null
-      if (!target?.closest('[data-boring-agent-part="composer-input"]')) return
-      window.setTimeout(maybeAutoRunDraft, 0)
-    }
-    document.addEventListener('click', onClick, true)
-    document.addEventListener('keydown', onKeyDown, true)
-    document.addEventListener('input', onInput, true)
-    return () => {
-      document.removeEventListener('click', onClick, true)
-      document.removeEventListener('keydown', onKeyDown, true)
-      document.removeEventListener('input', onInput, true)
-    }
-  })
-
   return (
     <div className="public-chat-first-shell relative h-screen min-h-0 bg-background">
       {publicShell?.showTeachingArrows !== false && (
@@ -217,9 +169,9 @@ export function ChatFirstPublicShell<
             ...workspaceProps,
             // No-auth landing should open with the workspace surface closed —
             // a fresh load/hard refresh shows just the hero, not a re-opened
-            // panel. The /landing-page command still opens it on demand.
-            defaultSurfaceOpen: false,
-            topBarRight: <button type="button" className="rounded-md border border-border px-3 py-1.5 text-sm font-medium hover:bg-muted" onClick={() => openAuth()}>Sign in</button>,
+            // panel unless the app explicitly overrides defaultSurfaceOpen.
+            defaultSurfaceOpen: workspaceProps.defaultSurfaceOpen ?? false,
+            topBarRight: <PublicTopBarActions contact={publicShell?.contact} onSignIn={() => openAuth()} />,
             // No-auth shell has no real session yet — show just the brand, hide the
             // "· New session" placeholder that the default TopBar would render.
             topBarLeft: (
@@ -245,7 +197,7 @@ export function ChatFirstPublicShell<
             chatParams: {
               ...workspaceProps.chatParams,
               emptyPlacement: 'hero',
-              composerPlaceholder: publicShell?.composerPlaceholder ?? 'Type /landing-page or /reach-out',
+              composerPlaceholder: publicShell?.composerPlaceholder ?? 'Sign in to continue in a private workspace',
               hideComposerSettings: !showComposerSettings,
               suppressPreSubmitCancelledWarning: true,
               thinkingControl: showComposerSettings,
@@ -262,10 +214,10 @@ export function ChatFirstPublicShell<
                 ...publicShell?.emptyState,
               },
               suggestions: publicShell?.suggestions ?? defaultPublicSuggestions,
-              commands: publicCommands,
+              commands: [],
               excludeBuiltinCommands: builtinCommands.map((command) => command.name),
               onBeforeSubmit: (draft: string) => {
-                if (!runPublicCommand(draft)) openAuth(draft)
+                openAuth(draft)
                 return false as const
               },
             },

--- a/packages/core/src/app/front/chatFirst/chatFirstPublicShell.css
+++ b/packages/core/src/app/front/chatFirst/chatFirstPublicShell.css
@@ -17,6 +17,109 @@
   );
 }
 
+/* --- Public top-bar CTA + Calendly popover --- */
+.public-topbar-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.public-contact-popover-wrap {
+  position: relative;
+}
+
+.public-contact-button,
+.public-sign-in-button {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.2;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+}
+
+.public-contact-button {
+  background: var(--foreground);
+  color: var(--background);
+  border-color: var(--foreground);
+}
+
+.public-contact-button:hover {
+  background: color-mix(in oklch, var(--foreground) 88%, var(--accent));
+}
+
+.public-sign-in-button {
+  background: transparent;
+  color: var(--foreground);
+}
+
+.public-sign-in-button:hover {
+  background: var(--muted);
+}
+
+.public-contact-popover {
+  position: absolute;
+  top: calc(100% + 10px);
+  right: 0;
+  z-index: 80;
+  width: min(420px, calc(100vw - 24px));
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--background);
+  box-shadow: 0 24px 80px color-mix(in oklch, var(--foreground) 18%, transparent);
+}
+
+.public-contact-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid var(--border);
+  padding: 10px 12px 10px 14px;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.public-contact-popover-header button {
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.public-contact-popover-header button:hover {
+  background: var(--muted);
+  color: var(--foreground);
+}
+
+.public-contact-popover iframe {
+  display: block;
+  width: 100%;
+  height: min(680px, calc(100vh - 120px));
+  min-height: 520px;
+  border: 0;
+  background: var(--background);
+}
+
+@media (max-width: 560px) {
+  .public-contact-popover {
+    position: fixed;
+    top: 56px;
+    right: 8px;
+    left: 8px;
+    width: auto;
+  }
+}
+
 /* --- Hand-drawn teaching annotations (public no-auth shell) --- */
 .public-arrow {
   pointer-events: none;
@@ -165,7 +268,7 @@
   padding-top: clamp(28px, 9vh, 132px);
 }
 
-/* Move the /command cards to the bottom of the hero block (after the footer),
+/* Move suggestion cards to the bottom of the hero block (after the footer),
    so they sit directly above the composer. The empty-state is a flex column,
    so `order` reorders without touching the React tree. */
 .public-chat-first-shell [data-boring-agent-part="empty-state"] .public-hero-foot {
@@ -175,7 +278,7 @@
   order: 20;
 }
 
-/* Command launcher cards — make the slash commands read as runnable. */
+/* Suggestion cards — keep example prompts visually connected to the composer. */
 .public-chat-first-shell [data-boring-agent-part="suggestion-grid"] {
   margin-top: 28px;
   max-width: 560px;


### PR DESCRIPTION
## Summary
- Moves the public chat-first landing CTA away from hidden slash commands.
- Adds an optional contact/Calendly top-bar CTA plus Sign in button.
- Keeps public composer submissions routing to auth/private workspace flow.

## Split from
- Extracted from #404 so PR 404 can keep only the workspace shell/navigation changes.