### PR TITLE
#390 fix(cli): create local workspace folders from hub

### DIFF
--- a/packages/cli/src/__tests__/localWorkspaces.test.ts
+++ b/packages/cli/src/__tests__/localWorkspaces.test.ts
@@ -55,3 +55,17 @@ test("keeps missing workspace paths as unavailable", async () => {
     available: false,
   }))
 })
+
+test("creates missing workspace directories when requested", async () => {
+  const root = await makeTempDir("boring-cli-registry-root-")
+  const missing = join(root, "created-project")
+  const registry = createLocalWorkspaceRegistry(join(root, "workspaces.yaml"))
+
+  const added = await registry.add(missing, { name: "Created", createIfMissing: true })
+  expect(added.available).toBe(true)
+  await expect(registry.get(added.id)).resolves.toEqual(expect.objectContaining({
+    name: "Created",
+    path: missing,
+    available: true,
+  }))
+})

--- a/packages/cli/src/__tests__/localWorkspaces.test.ts
+++ b/packages/cli/src/__tests__/localWorkspaces.test.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
+import { homedir, tmpdir } from "node:os"
 import { join } from "node:path"
 import { afterEach, expect, test } from "vitest"
 import { createLocalWorkspaceRegistry } from "../server/localWorkspaces.js"
@@ -68,4 +68,16 @@ test("creates missing workspace directories when requested", async () => {
     path: missing,
     available: true,
   }))
+})
+
+test("expands home-relative workspace paths before creating directories", async () => {
+  const root = await makeTempDir("boring-cli-registry-root-")
+  const homeProjectName = `.boring-cli-registry-home-${process.pid}-${Date.now()}`
+  const homeProject = join(homedir(), homeProjectName)
+  tempDirs.push(homeProject)
+  const registry = createLocalWorkspaceRegistry(join(root, "workspaces.yaml"))
+
+  const added = await registry.add(`~/${homeProjectName}`, { createIfMissing: true })
+  expect(added.available).toBe(true)
+  expect(added.path).toBe(homeProject)
 })

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -178,6 +178,32 @@ export function CliWorkspaceShell() {
 
   refreshWorkspacesRef.current = refreshWorkspaces
 
+  const createLocalWorkspace = useCallback(() => {
+    const rawPath = window.prompt("Path for the local workspace folder to create or add")
+    const path = rawPath?.trim()
+    if (!path) return
+    const rawName = window.prompt("Workspace name", path.split(/[\\/]+/).filter(Boolean).at(-1) ?? "Workspace")
+    const name = rawName?.trim() || undefined
+    void fetch("/api/v1/local-workspaces", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ path, name, createIfMissing: true }),
+    })
+      .then(async (res) => {
+        const data = await res.json().catch(() => ({})) as { workspace?: LocalWorkspace; error?: string }
+        if (!res.ok || !data.workspace) throw new Error(data.error || `local-workspaces ${res.status}`)
+        setWorkspacesLoaded(true)
+        setWorkspaces((current) => current.some((workspace) => workspace.id === data.workspace!.id) ? current : [...current, data.workspace!])
+        window.localStorage.setItem("boring-ui:local-workspace-id", data.workspace.id)
+        setActiveWorkspaceId(data.workspace.id)
+        syncCliWorkspaceUrl(data.workspace.id)
+        refreshWorkspaces()
+      })
+      .catch((error) => {
+        window.alert(error instanceof Error ? error.message : "Unable to create workspace")
+      })
+  }, [refreshWorkspaces])
+
   useEffect(() => {
     let cancelled = false
     void fetch("/api/v1/workspace/meta")
@@ -314,8 +340,15 @@ export function CliWorkspaceShell() {
             <p className="mt-2 text-sm text-muted-foreground">
               {hasUnavailableWorkspaces
                 ? "Registered workspace folders are missing or not directories. Restore one of the folders, then focus or refresh this page."
-                : <>Add one with <code>boring-ui workspaces add /path/to/project</code>, then refresh this page.</>}
+                : "Create or add a local workspace folder from this screen."}
             </p>
+            <button
+              type="button"
+              onClick={createLocalWorkspace}
+              className="mt-4 rounded-md bg-foreground px-3 py-2 text-sm font-medium text-background hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Create or add local folder
+            </button>
           </div>
         </div>
       )
@@ -349,9 +382,10 @@ export function CliWorkspaceShell() {
             appTitle="Boring UI"
             workspaces={workspaces}
             activeWorkspaceId={activeWorkspace.id}
-            createLabel="Add local folder"
-            createDescription="Use `boring-ui workspaces add /path`"
+            createLabel="Create or add local folder"
+            createDescription="Create the folder if it does not exist"
             settingsDescription={activeWorkspace.path}
+            onCreateWorkspace={createLocalWorkspace}
             onSelectWorkspace={(workspaceId) => {
               window.localStorage.setItem("boring-ui:local-workspace-id", workspaceId)
               setActiveWorkspaceId(workspaceId)

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -183,7 +183,8 @@ export function CliWorkspaceShell() {
     const path = rawPath?.trim()
     if (!path) return
     const rawName = window.prompt("Workspace name", path.split(/[\\/]+/).filter(Boolean).at(-1) ?? "Workspace")
-    const name = rawName?.trim() || undefined
+    if (rawName === null) return
+    const name = rawName.trim() || undefined
     void fetch("/api/v1/local-workspaces", {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/packages/cli/src/server/localWorkspaces.ts
+++ b/packages/cli/src/server/localWorkspaces.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto"
 import { existsSync, statSync } from "node:fs"
 import { mkdir, readFile, realpath, rename, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
-import { basename, dirname, resolve } from "node:path"
+import { basename, dirname, join, resolve } from "node:path"
 
 export interface LocalWorkspace {
   id: string
@@ -109,8 +109,14 @@ function serializeRegistryYaml(workspaces: StoredLocalWorkspace[]): string {
   return `${lines.join("\n")}\n`
 }
 
+function expandHomePath(input: string): string {
+  if (input === "~") return homedir()
+  if (input.startsWith("~/") || input.startsWith("~\\")) return join(homedir(), input.slice(2))
+  return input
+}
+
 async function resolveWorkspacePath(input: string): Promise<string> {
-  const absolute = resolve(input)
+  const absolute = resolve(expandHomePath(input))
   try {
     return await realpath(absolute)
   } catch {

--- a/packages/cli/src/server/localWorkspaces.ts
+++ b/packages/cli/src/server/localWorkspaces.ts
@@ -18,7 +18,7 @@ interface StoredLocalWorkspace extends Omit<LocalWorkspace, "available"> {}
 export interface LocalWorkspaceRegistry {
   path: string
   list(): Promise<LocalWorkspace[]>
-  add(path: string, opts?: { name?: string }): Promise<LocalWorkspace>
+  add(path: string, opts?: { name?: string; createIfMissing?: boolean }): Promise<LocalWorkspace>
   remove(id: string): Promise<void>
   rename(id: string, name: string): Promise<LocalWorkspace>
   get(id: string): Promise<LocalWorkspace | null>
@@ -160,10 +160,13 @@ export function createLocalWorkspaceRegistry(path = getDefaultLocalWorkspaceRegi
       const workspace = (await readStored()).find((entry) => entry.id === id)
       return workspace ? withAvailability(workspace) : null
     },
-    async add(inputPath: string, opts?: { name?: string }) {
+    async add(inputPath: string, opts?: { name?: string; createIfMissing?: boolean }) {
       const workspacePath = await resolveWorkspacePath(inputPath)
       if (pathExists(workspacePath) && !pathIsDirectory(workspacePath)) {
         throw new Error(`workspace path is not a directory: ${workspacePath}`)
+      }
+      if (!pathExists(workspacePath) && opts?.createIfMissing) {
+        await mkdir(workspacePath, { recursive: true })
       }
       const now = new Date().toISOString()
       const workspaces = await readStored()

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -597,13 +597,14 @@ export async function createWorkspacesModeApp(opts: {
     workspaces: await registry.list(),
   }))
   app.post("/api/v1/local-workspaces", async (request, reply) => {
-    const body = request.body as { path?: unknown; name?: unknown }
+    const body = request.body as { path?: unknown; name?: unknown; createIfMissing?: unknown }
     if (typeof body?.path !== "string" || !body.path.trim()) {
       return reply.code(400).send({ error: "workspace path is required" })
     }
     try {
       const workspace = await registry.add(body.path, {
         name: typeof body.name === "string" ? body.name : undefined,
+        createIfMissing: body.createIfMissing === true,
       })
       return { workspace }
     } catch (error) {


### PR DESCRIPTION
## Summary
- Add UI flow to create/add local workspace folders from the workspaces hub
- Let POST /api/v1/local-workspaces create missing directories when requested
- Add registry coverage for createIfMissing
- Hot-deployed to the VM service on :5213

## Proof
- `pnpm --filter @hachej/boring-ui-cli exec vitest run src/__tests__/localWorkspaces.test.ts` ✅
- `pnpm --filter @hachej/boring-ui-cli build:full` ✅
- live VM smoke: POST `/api/v1/local-workspaces` with `createIfMissing:true` created an available folder-backed workspace ✅
- `systemctl --user restart boring-ui-workspaces.service` ✅

## Notes
- `pnpm --filter @hachej/boring-ui-cli typecheck` still fails on pre-existing workspace chat prop/type errors unrelated to this PR.
