### PR TITLE
mcp-integration: Add reusable boring-mcp plugin foundation

### DIFF
--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -1,0 +1,52 @@
+# `@hachej/boring-mcp`
+
+Reusable boring-ui MCP/Sources plugin foundation.
+
+This package is the generic MCP capability that child apps can enable. It owns:
+
+- generic Sources left-tab and MCP Sources panel shell;
+- provider template, source, tool, policy, redaction, status, and facade contracts;
+- deny-before-allow read-only policy helpers;
+- fake-transport-testable facade seams.
+
+It intentionally does **not** perform real connector-provider calls, OAuth, provider execution, secret storage, or app-specific environment binding in the foundation PR.
+
+## Enable in an app
+
+Static front composition is still required when a shipped app needs the UI to render:
+
+```tsx
+import { createBoringMcpPlugin } from '@hachej/boring-mcp/front'
+
+const boringMcpPlugin = createBoringMcpPlugin({
+  providers: [/* optional app provider templates */],
+  enabledProviderIds: ['notion', 'airtable'],
+  label: 'Sources',
+})
+
+<CoreWorkspaceAgentFront plugins={[boringMcpPlugin]} />
+```
+
+Server composition can use the server plugin once an app wants the boring-mcp prompt/seams at boot:
+
+```ts
+import { createBoringMcpServerPlugin } from '@hachej/boring-mcp/server'
+
+createCoreWorkspaceAgentServer({
+  plugins: [createBoringMcpServerPlugin()],
+})
+```
+
+Apps may also list the package in `package.json#boring.defaultPluginPackages`, but core-based shipped apps should still statically compose front plugins when the UI must render.
+
+## Security boundaries
+
+- Browser UI never receives provider OAuth tokens, connector API keys, or MCP session headers.
+- Raw provider meta-tools are not exposed by this foundation.
+- Unknown tools are disabled by default.
+- Mutating/admin tool names are denied before any provider call.
+- Provider results pass redaction and secret-leak checks before agent/UI use.
+
+## Current status
+
+Foundation only. Real connector providers, route registration, agent bridge tools, and provider execution land in later PRs.

--- a/plugins/boring-mcp/package.json
+++ b/plugins/boring-mcp/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@hachej/boring-mcp",
+  "version": "0.0.0",
+  "type": "module",
+  "private": false,
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "description": "Reusable boring-ui MCP/Sources plugin foundation: generic Sources UI, policy, redaction, and facade contracts.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hachej/boring-ui"
+  },
+  "homepage": "https://github.com/hachej/boring-ui",
+  "boring": {
+    "id": "boring-mcp",
+    "label": "Sources",
+    "front": "dist/front/index.js",
+    "server": "dist/server/index.js"
+  },
+  "pi": {
+    "systemPrompt": "Use boring-mcp bridge tools only when an app has enabled them. Treat MCP sources as read-only unless a tool is explicitly allowed."
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/front/index.d.ts",
+      "import": "./dist/front/index.js"
+    },
+    "./front": {
+      "types": "./dist/front/index.d.ts",
+      "import": "./dist/front/index.js"
+    },
+    "./server": {
+      "types": "./dist/server/index.d.ts",
+      "import": "./dist/server/index.js"
+    },
+    "./shared": {
+      "types": "./dist/shared/index.d.ts",
+      "import": "./dist/shared/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --no-file-parallelism",
+    "lint": "pnpm run typecheck",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "peerDependencies": {
+    "@hachej/boring-workspace": "workspace:*",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@hachej/boring-workspace": "workspace:*",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@types/node": "^22.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "jsdom": "^29.0.2",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tsup": "^8.4.0",
+    "typescript": "~5.9.3",
+    "vitest": "^3.2.6"
+  }
+}

--- a/plugins/boring-mcp/src/__tests__/shared.test.ts
+++ b/plugins/boring-mcp/src/__tests__/shared.test.ts
@@ -46,10 +46,18 @@ describe("boring-mcp shared policy", () => {
     expect(() => assertMcpToolAllowed(AIRTABLE_MCP_TEMPLATE, "surprise_tool")).toThrow(McpError)
   })
 
-  it("redacts secret-like keys and values", () => {
-    const value = { ok: true, authorization: "Bearer secret-token", nested: { text: "x-api-key: abcdefghijklmnop" } }
+  it("redacts secret-like keys and all secret-like values", () => {
+    const value = {
+      ok: true,
+      authorization: "Bearer secret-token",
+      nested: { text: "Bearer abcdefghijklmnop and sk-abcdefghijklmnop and x-api-key: abcdefghijklmnop" },
+    }
     expect(containsMcpSecret(value)).toBe(true)
-    expect(redactMcpSecrets(value)).toEqual({ ok: true, authorization: "[REDACTED_MCP_SECRET]", nested: { text: "[REDACTED_MCP_SECRET]" } })
+    expect(redactMcpSecrets(value)).toEqual({
+      ok: true,
+      authorization: "[REDACTED_MCP_SECRET]",
+      nested: { text: "[REDACTED_MCP_SECRET] and [REDACTED_MCP_SECRET] and [REDACTED_MCP_SECRET]" },
+    })
   })
 
   it("reports disconnected and unknown sources in doctor output", () => {
@@ -84,7 +92,48 @@ describe("McpAccessFacade", () => {
     const facade = new McpAccessFacade({ store: makeStore(), transport })
     await expect(facade.probeSource({ ...actor, userId: "other" }, notionSource.id)).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_NOT_FOUND })
     await expect(facade.callReadonlyTool(actor, notionSource.id, "update_page", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
+    expect(transport.listTools).not.toHaveBeenCalled()
     expect(transport.callTool).not.toHaveBeenCalled()
+  })
+
+  it("blocks unavailable sources before transport execution", async () => {
+    const transport: McpTransportClient = {
+      listTools: vi.fn(async () => []),
+      listResources: vi.fn(async () => []),
+      readResource: vi.fn(),
+      callTool: vi.fn(async () => ({ content: "ok" })),
+    }
+    const facade = new McpAccessFacade({ store: makeStore({ ...notionSource, status: "expired" }), transport })
+    await expect(facade.probeSource(actor, notionSource.id)).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE })
+    await expect(facade.callReadonlyTool(actor, notionSource.id, "NOTION_SEARCH_NOTION_PAGE", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE })
+    expect(transport.listTools).not.toHaveBeenCalled()
+    expect(transport.listResources).not.toHaveBeenCalled()
+    expect(transport.callTool).not.toHaveBeenCalled()
+  })
+
+  it("requires an explicit access policy for non-user-owned sources", async () => {
+    const teamSource: McpSource = { ...notionSource, ownerKind: "team_context", userId: "team-owner" }
+    const store: McpSourceStore = {
+      async listSources() { return [teamSource] },
+      async getSource(sourceId) { return sourceId === teamSource.id ? teamSource : undefined },
+    }
+    const transport: McpTransportClient = {
+      listTools: vi.fn(async () => []),
+      listResources: vi.fn(async () => []),
+      readResource: vi.fn(),
+      callTool: vi.fn(async () => ({ content: "ok" })),
+    }
+    const defaultFacade = new McpAccessFacade({ store, transport })
+    expect(await defaultFacade.listSources(actor)).toEqual([])
+    await expect(defaultFacade.probeSource(actor, teamSource.id)).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_NOT_FOUND })
+
+    const policyFacade = new McpAccessFacade({
+      store,
+      transport,
+      accessPolicy: { canAccessSource: (requestActor, source) => requestActor.workspaceId === source.workspaceId && source.ownerKind === "team_context" },
+    })
+    expect(await policyFacade.listSources(actor)).toEqual([teamSource])
+    await expect(policyFacade.probeSource(actor, teamSource.id)).resolves.toMatchObject({ sourceId: teamSource.id })
   })
 
   it("rejects provider responses that look like secrets", async () => {

--- a/plugins/boring-mcp/src/__tests__/shared.test.ts
+++ b/plugins/boring-mcp/src/__tests__/shared.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  AIRTABLE_MCP_TEMPLATE,
+  MCP_ERROR_CODES,
+  McpAccessFacade,
+  McpError,
+  NOTION_MCP_TEMPLATE,
+  assertMcpToolAllowed,
+  classifyMcpTool,
+  containsMcpSecret,
+  doctorMcpSource,
+  redactMcpSecrets,
+  type McpActor,
+  type McpSource,
+  type McpSourceStore,
+  type McpTransportClient,
+} from "../shared"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+const notionSource: McpSource = {
+  id: "source-1",
+  workspaceId: actor.workspaceId,
+  userId: actor.userId,
+  provider: "notion",
+  displayName: "Notion",
+  status: "connected",
+  ownerKind: "user",
+  credentialProvider: "provider-managed",
+}
+
+function makeStore(source: McpSource = notionSource): McpSourceStore {
+  return {
+    async listSources(requestActor) {
+      return requestActor.userId === source.userId && requestActor.workspaceId === source.workspaceId ? [source] : []
+    },
+    async getSource(sourceId) {
+      return sourceId === source.id ? source : undefined
+    },
+  }
+}
+
+describe("boring-mcp shared policy", () => {
+  it("allows only read allowlisted tools and denies mutating patterns", () => {
+    expect(classifyMcpTool(NOTION_MCP_TEMPLATE, "NOTION_SEARCH_NOTION_PAGE")).toMatchObject({ allowed: true, risk: "read" })
+    expect(classifyMcpTool(AIRTABLE_MCP_TEMPLATE, "create_record")).toMatchObject({ allowed: false, risk: "write" })
+    expect(() => assertMcpToolAllowed(AIRTABLE_MCP_TEMPLATE, "surprise_tool")).toThrow(McpError)
+  })
+
+  it("redacts secret-like keys and values", () => {
+    const value = { ok: true, authorization: "Bearer secret-token", nested: { text: "x-api-key: abcdefghijklmnop" } }
+    expect(containsMcpSecret(value)).toBe(true)
+    expect(redactMcpSecrets(value)).toEqual({ ok: true, authorization: "[REDACTED_MCP_SECRET]", nested: { text: "[REDACTED_MCP_SECRET]" } })
+  })
+
+  it("reports disconnected and unknown sources in doctor output", () => {
+    expect(doctorMcpSource({ ...notionSource, status: "unconfigured" }).issues).toContainEqual(expect.objectContaining({ code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE }))
+    expect(doctorMcpSource({ ...notionSource, provider: "unknown" }).issues).toContainEqual(expect.objectContaining({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID }))
+  })
+})
+
+describe("McpAccessFacade", () => {
+  it("probes tools through fake transport and classifies them", async () => {
+    const transport: McpTransportClient = {
+      listTools: vi.fn(async () => [{ name: "NOTION_SEARCH_NOTION_PAGE" }, { name: "update_page" }]),
+      listResources: vi.fn(async () => []),
+      readResource: vi.fn(),
+      callTool: vi.fn(),
+    }
+    const facade = new McpAccessFacade({ store: makeStore(), transport })
+    const result = await facade.probeSource(actor, notionSource.id)
+    expect(result.tools).toEqual([
+      expect.objectContaining({ name: "NOTION_SEARCH_NOTION_PAGE", decision: expect.objectContaining({ allowed: true }) }),
+      expect.objectContaining({ name: "update_page", decision: expect.objectContaining({ allowed: false }) }),
+    ])
+  })
+
+  it("blocks unowned sources and mutating calls before transport execution", async () => {
+    const transport: McpTransportClient = {
+      listTools: vi.fn(async () => []),
+      listResources: vi.fn(async () => []),
+      readResource: vi.fn(),
+      callTool: vi.fn(async () => ({ content: "ok" })),
+    }
+    const facade = new McpAccessFacade({ store: makeStore(), transport })
+    await expect(facade.probeSource({ ...actor, userId: "other" }, notionSource.id)).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_NOT_FOUND })
+    await expect(facade.callReadonlyTool(actor, notionSource.id, "update_page", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
+    expect(transport.callTool).not.toHaveBeenCalled()
+  })
+
+  it("rejects provider responses that look like secrets", async () => {
+    const transport: McpTransportClient = {
+      listTools: vi.fn(async () => []),
+      listResources: vi.fn(async () => []),
+      readResource: vi.fn(),
+      callTool: vi.fn(async () => ({ content: { access_token: "secret" } })),
+    }
+    const facade = new McpAccessFacade({ store: makeStore(), transport })
+    await expect(facade.callReadonlyTool(actor, notionSource.id, "NOTION_SEARCH_NOTION_PAGE", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+  })
+})

--- a/plugins/boring-mcp/src/front/index.tsx
+++ b/plugins/boring-mcp/src/front/index.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import type { CSSProperties } from "react"
+import type { PaneProps } from "@hachej/boring-workspace"
+import { definePlugin, type BoringFrontFactoryWithId } from "@hachej/boring-workspace/plugin"
+import {
+  BORING_MCP_PLUGIN_ID,
+  BORING_MCP_SOURCES_PANEL_ID,
+  BORING_MCP_SOURCES_TAB_PANEL_ID,
+  DEFAULT_MCP_PROVIDER_TEMPLATES,
+  type McpProviderTemplate,
+} from "../shared"
+
+export interface CreateBoringMcpPluginOptions {
+  label?: string
+  tabTitle?: string
+  panelTitle?: string
+  providers?: readonly McpProviderTemplate[]
+  enabledProviderIds?: readonly string[]
+  intro?: string
+  governanceNotes?: readonly string[]
+}
+
+const defaultGovernanceNotes = [
+  "Read-only by default",
+  "No raw tokens to agents or browser",
+  "Audit and redaction before output",
+  "Personal and company context stay separate",
+]
+
+function resolveProviders(options: CreateBoringMcpPluginOptions): readonly McpProviderTemplate[] {
+  const providers = options.providers ?? DEFAULT_MCP_PROVIDER_TEMPLATES
+  const enabled = new Set(options.enabledProviderIds ?? providers.map((provider) => provider.id))
+  return providers.filter((provider) => enabled.has(provider.id))
+}
+
+function openSourcesPanel(containerApi: PaneProps["containerApi"]) {
+  containerApi.addPanel({
+    id: BORING_MCP_SOURCES_PANEL_ID,
+    component: BORING_MCP_SOURCES_PANEL_ID,
+    title: "MCP Sources",
+  })
+}
+
+const styles: Record<string, CSSProperties> = {
+  tab: { display: "flex", height: "100%", flexDirection: "column", gap: 10, padding: 10 },
+  eyebrow: { margin: 0, color: "var(--muted-foreground)", fontSize: 10, fontWeight: 800, letterSpacing: "0.14em", textTransform: "uppercase" },
+  title: { margin: 0, fontSize: 18, letterSpacing: "-0.03em" },
+  muted: { color: "var(--muted-foreground)", fontSize: 12, lineHeight: 1.45 },
+  button: { width: "100%", border: "1px solid var(--border)", borderRadius: 12, background: "var(--card)", color: "var(--foreground)", cursor: "pointer", padding: "11px 12px", textAlign: "left" },
+  note: { marginTop: "auto", border: "1px solid var(--border)", borderRadius: 16, background: "var(--card)", padding: 12 },
+  panel: { minHeight: "100%", overflow: "auto", padding: 24, background: "var(--background)", color: "var(--foreground)" },
+  hero: { display: "flex", justifyContent: "space-between", gap: 20, maxWidth: 1120, margin: "0 auto 18px" },
+  heroTitle: { margin: 0, maxWidth: 760, fontSize: "clamp(34px, 5vw, 64px)", lineHeight: 0.95, letterSpacing: "-0.065em" },
+  pillGrid: { display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10, maxWidth: 1120, margin: "0 auto 18px" },
+  pill: { border: "1px solid var(--border)", borderRadius: 999, background: "var(--card)", padding: "10px 12px", fontSize: 12, fontWeight: 700, textAlign: "center" },
+  grid: { display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 14, maxWidth: 1120, margin: "0 auto" },
+  card: { display: "flex", minHeight: 250, flexDirection: "column", border: "1px solid var(--border)", borderRadius: 24, background: "var(--card)", padding: 18 },
+  cardTop: { display: "flex", justifyContent: "space-between", gap: 12 },
+  badge: { border: "1px solid var(--border)", borderRadius: 999, padding: "5px 8px", color: "var(--muted-foreground)", fontSize: 11, fontWeight: 800, whiteSpace: "nowrap" },
+  codeBox: { display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 14, maxWidth: 1120, margin: "18px auto 0" },
+  codeCard: { border: "1px solid var(--border)", borderRadius: 22, background: "var(--card)", padding: 16 },
+  code: { display: "block", overflow: "hidden", marginTop: 7, borderRadius: 8, background: "var(--muted)", padding: "7px 8px", color: "var(--muted-foreground)", fontSize: 12, textOverflow: "ellipsis", whiteSpace: "nowrap" },
+}
+
+function SourcesTab({ containerApi, options }: PaneProps & { options: CreateBoringMcpPluginOptions }) {
+  return (
+    <div style={styles.tab}>
+      <div>
+        <p style={styles.eyebrow}>Context</p>
+        <h2 style={styles.title}>{options.tabTitle ?? "Sources"}</h2>
+        <p style={styles.muted}>Connect approved context providers behind governed MCP tools.</p>
+      </div>
+      <button type="button" style={styles.button} onClick={() => openSourcesPanel(containerApi)}>
+        <strong>Manage sources</strong>
+        <span style={{ ...styles.muted, display: "block", marginTop: 4 }}>Search, describe, and read-only call</span>
+      </button>
+      <div style={styles.note}>
+        <strong>V0 rule</strong>
+        <span style={{ ...styles.muted, display: "block", marginTop: 6 }}>Agents only see boring-mcp bridge tools. Provider meta-tools stay server-side.</span>
+      </div>
+    </div>
+  )
+}
+
+function SourcesPanel({ options }: { options: CreateBoringMcpPluginOptions }) {
+  const providers = resolveProviders(options)
+  const governanceNotes = options.governanceNotes ?? defaultGovernanceNotes
+  return (
+    <main style={styles.panel}>
+      <section style={styles.hero}>
+        <div>
+          <p style={styles.eyebrow}>Sources</p>
+          <h1 style={styles.heroTitle}>{options.panelTitle ?? "Connect context safely."}</h1>
+          <p style={{ ...styles.muted, maxWidth: 680, fontSize: 15 }}>{options.intro ?? "Sources are read-only by default and routed through governed MCP tools."}</p>
+        </div>
+        <div style={styles.note}><strong>boring-mcp</strong><span style={{ ...styles.muted, display: "block", marginTop: 6 }}>Reusable plugin foundation</span></div>
+      </section>
+      <section style={styles.pillGrid} aria-label="MCP governance guarantees">
+        {governanceNotes.map((note) => <div key={note} style={styles.pill}>{note}</div>)}
+      </section>
+      <section style={styles.grid} aria-label="Configured source providers">
+        {providers.map((provider) => (
+          <article key={provider.id} style={styles.card}>
+            <div style={styles.cardTop}>
+              <h2 style={{ margin: 0, fontSize: 24 }}>{provider.displayName}</h2>
+              <span style={styles.badge}>{provider.readOnlyDefault ? "Read-only" : "Configured"}</span>
+            </div>
+            <p style={styles.muted}>Configured provider template. Connection, status, probe, and tool catalog wiring are supplied by the host app's boring-mcp backend.</p>
+            <div style={styles.badge}>{provider.allowedTools.length} allowed read tools</div>
+            <button type="button" disabled style={{ ...styles.button, cursor: "not-allowed", marginTop: "auto", color: "var(--muted-foreground)" }}>Connect through app backend</button>
+          </article>
+        ))}
+      </section>
+      <section style={styles.codeBox}>
+        <div style={styles.codeCard}>
+          <h2>Browser can call</h2>
+          <code style={styles.code}>app-owned boring-mcp source APIs</code>
+          <code style={styles.code}>search / describe / read-only call</code>
+        </div>
+        <div style={styles.codeCard}>
+          <h2>Browser never receives</h2>
+          <code style={styles.code}>provider OAuth tokens</code>
+          <code style={styles.code}>MCP session headers</code>
+          <code style={styles.code}>raw connector API keys</code>
+        </div>
+      </section>
+    </main>
+  )
+}
+
+export function createBoringMcpPlugin(options: CreateBoringMcpPluginOptions = {}): BoringFrontFactoryWithId {
+  const label = options.label ?? "Sources"
+  return definePlugin({
+    id: BORING_MCP_PLUGIN_ID,
+    label,
+    panels: [
+      { id: BORING_MCP_SOURCES_TAB_PANEL_ID, label, placement: "left-tab", component: (props) => <SourcesTab {...props} options={options} /> },
+      { id: BORING_MCP_SOURCES_PANEL_ID, label: options.panelTitle ?? "MCP Sources", placement: "center", component: () => <SourcesPanel options={options} /> },
+    ],
+    commands: [{ id: "boring-mcp.open-sources", title: "Open Sources", panelId: BORING_MCP_SOURCES_PANEL_ID, keywords: ["mcp", "sources", "context"] }],
+  })
+}
+
+const boringMcpPlugin = createBoringMcpPlugin()
+export default boringMcpPlugin
+export * from "../shared"

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -1,0 +1,17 @@
+import { defineServerPlugin } from "@hachej/boring-workspace/server"
+import { BORING_MCP_PLUGIN_ID } from "../shared"
+
+export interface CreateBoringMcpServerPluginOptions {
+  systemPrompt?: string
+}
+
+export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPluginOptions = {}) {
+  return defineServerPlugin({
+    id: BORING_MCP_PLUGIN_ID,
+    label: "Sources",
+    systemPrompt: options.systemPrompt ?? "Use boring-mcp bridge tools only when an app has enabled them. Treat MCP sources as read-only unless a tool is explicitly allowed.",
+  })
+}
+
+export default createBoringMcpServerPlugin()
+export * from "../shared"

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -1,0 +1,301 @@
+export const BORING_MCP_PLUGIN_ID = "boring-mcp"
+export const BORING_MCP_SOURCES_TAB_PANEL_ID = "boring-mcp.sources.tab"
+export const BORING_MCP_SOURCES_PANEL_ID = "boring-mcp.sources.panel"
+
+export const MCP_ERROR_CODES = {
+  SOURCE_NOT_FOUND: "MCP_SOURCE_NOT_FOUND",
+  SOURCE_FORBIDDEN: "MCP_SOURCE_FORBIDDEN",
+  SOURCE_UNAVAILABLE: "MCP_SOURCE_UNAVAILABLE",
+  PROVIDER_CONFIG_INVALID: "MCP_PROVIDER_CONFIG_INVALID",
+  PROVIDER_TIMEOUT: "MCP_PROVIDER_TIMEOUT",
+  PROVIDER_ERROR: "MCP_PROVIDER_ERROR",
+  TOOL_NOT_FOUND: "MCP_TOOL_NOT_FOUND",
+  TOOL_NOT_ALLOWED: "MCP_TOOL_NOT_ALLOWED",
+  PROVIDER_TOOL_DRIFT: "MCP_PROVIDER_TOOL_DRIFT",
+  RESOURCE_LIMIT_EXCEEDED: "MCP_RESOURCE_LIMIT_EXCEEDED",
+  SECRET_LEAK_GUARD: "MCP_SECRET_LEAK_GUARD",
+  INPUT_INVALID: "MCP_INPUT_INVALID",
+  RESOURCE_URI_INVALID: "MCP_RESOURCE_URI_INVALID",
+} as const
+
+export type McpErrorCode = (typeof MCP_ERROR_CODES)[keyof typeof MCP_ERROR_CODES]
+export type McpProviderId = "notion" | "airtable" | (string & {})
+export type McpTransport = "streamable-http" | "sse" | "stdio"
+export type McpSourceStatus = "connected" | "expired" | "revoked" | "error" | "unconfigured"
+export type McpToolRisk = "read" | "write" | "admin" | "unknown"
+export type McpCredentialProvider = "provider-managed" | "app-managed" | "user-managed" | (string & {})
+export type McpSourceOwnerKind = "user" | "company_context" | "team_context" | "project_context"
+
+export interface McpActor {
+  userId: string
+  workspaceId: string
+  isAdmin?: boolean
+}
+
+export interface McpProviderTemplate {
+  id: McpProviderId
+  displayName: string
+  endpoint?: string
+  transport?: McpTransport
+  readOnlyDefault: boolean
+  allowedTools: string[]
+  deniedTools: string[]
+  allowedResourceUriPrefixes?: string[]
+}
+
+export interface McpSource {
+  id: string
+  workspaceId: string
+  userId: string
+  provider: McpProviderId
+  displayName: string
+  status: McpSourceStatus
+  ownerKind: McpSourceOwnerKind
+  credentialProvider: McpCredentialProvider
+  scopes?: string[]
+  providerAccountLabel?: string
+  lastVerifiedAt?: string
+  createdAt?: string
+  updatedAt?: string
+}
+
+export type McpSourceDto = Pick<
+  McpSource,
+  | "id"
+  | "provider"
+  | "displayName"
+  | "status"
+  | "ownerKind"
+  | "credentialProvider"
+  | "scopes"
+  | "providerAccountLabel"
+  | "lastVerifiedAt"
+  | "createdAt"
+  | "updatedAt"
+>
+
+export interface McpDiscoveredTool {
+  name: string
+  description?: string
+  inputSchema?: unknown
+}
+
+export interface McpDiscoveredResource {
+  uri: string
+  name?: string
+  description?: string
+  mimeType?: string
+}
+
+export interface McpToolDecision {
+  allowed: boolean
+  risk: McpToolRisk
+  reason: string
+}
+
+export interface McpProbeResult {
+  sourceId: string
+  provider: McpProviderId
+  tools: Array<McpDiscoveredTool & { decision: McpToolDecision }>
+  resources: McpDiscoveredResource[]
+}
+
+export interface McpDoctorIssue {
+  level: "error" | "warning"
+  code: McpErrorCode
+  message: string
+}
+
+export interface McpDoctorResult {
+  ok: boolean
+  sourceId: string
+  issues: McpDoctorIssue[]
+}
+
+export interface NormalizedMcpTool {
+  serverId: string
+  toolName: string
+  displayName: string
+  summary: string
+  description?: string
+  inputSchema: unknown
+  outputSchema?: unknown
+  risk: McpToolRisk
+  enabled: boolean
+  reason: string
+  schemaHash?: string
+  nativeRef?: {
+    provider: string
+    toolkit?: string
+    action: string
+  }
+}
+
+export interface McpToolCallResult {
+  content: unknown
+}
+
+export interface McpSourceStore {
+  listSources(actor: McpActor): Promise<McpSource[]>
+  getSource(sourceId: string): Promise<McpSource | undefined>
+}
+
+export interface McpTransportClient {
+  listTools(source: McpSource): Promise<McpDiscoveredTool[]>
+  listResources(source: McpSource): Promise<McpDiscoveredResource[]>
+  readResource(source: McpSource, uri: string): Promise<unknown>
+  callTool(source: McpSource, toolName: string, input: unknown): Promise<McpToolCallResult>
+}
+
+export class McpError extends Error {
+  readonly code: McpErrorCode
+  readonly details: unknown
+
+  constructor(code: McpErrorCode, message: string, details?: unknown) {
+    super(message)
+    this.name = "McpError"
+    this.code = code
+    this.details = details
+  }
+}
+
+export const NOTION_MCP_TEMPLATE: McpProviderTemplate = {
+  id: "notion",
+  displayName: "Notion",
+  readOnlyDefault: true,
+  allowedTools: ["NOTION_SEARCH_NOTION_PAGE", "NOTION_GET_PAGE_MARKDOWN", "NOTION_RETRIEVE_PAGE"],
+  deniedTools: ["create_*", "update_*", "delete_*", "publish_*", "admin_*"],
+  allowedResourceUriPrefixes: ["notion:", "notion://"],
+}
+
+export const AIRTABLE_MCP_TEMPLATE: McpProviderTemplate = {
+  id: "airtable",
+  displayName: "Airtable",
+  readOnlyDefault: true,
+  allowedTools: ["ping", "list_bases", "list_workspaces", "list_tables_for_base", "get_table_schema", "search_records"],
+  deniedTools: ["create_*", "update_*", "delete_*", "publish_*", "admin_*"],
+  allowedResourceUriPrefixes: ["airtable:", "airtable://"],
+}
+
+export const DEFAULT_MCP_PROVIDER_TEMPLATES = [NOTION_MCP_TEMPLATE, AIRTABLE_MCP_TEMPLATE] as const
+
+export function getMcpProviderTemplate(
+  provider: string,
+  templates: readonly McpProviderTemplate[] = DEFAULT_MCP_PROVIDER_TEMPLATES,
+): McpProviderTemplate | undefined {
+  return templates.find((template) => template.id === provider)
+}
+
+export const MCP_TOOL_NAME_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/
+
+export function validateMcpToolName(toolName: string): void {
+  if (!MCP_TOOL_NAME_PATTERN.test(toolName)) {
+    throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "Invalid MCP tool name")
+  }
+}
+
+function wildcardMatch(pattern: string, value: string): boolean {
+  if (!pattern.includes("*")) return pattern === value
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*")
+  return new RegExp(`^${escaped}$`, "i").test(value)
+}
+
+export function classifyMcpTool(template: McpProviderTemplate, toolName: string): McpToolDecision {
+  validateMcpToolName(toolName)
+  if (template.deniedTools.some((pattern) => wildcardMatch(pattern, toolName))) {
+    return { allowed: false, risk: "write", reason: "Tool matches a denied write/admin pattern" }
+  }
+  if (template.allowedTools.some((pattern) => wildcardMatch(pattern, toolName))) {
+    return { allowed: true, risk: "read", reason: "Tool is on the read-only allowlist" }
+  }
+  return { allowed: false, risk: "unknown", reason: "Tool is not on the read-only allowlist" }
+}
+
+export function assertMcpToolAllowed(template: McpProviderTemplate, toolName: string): void {
+  const decision = classifyMcpTool(template, toolName)
+  if (!decision.allowed) throw new McpError(MCP_ERROR_CODES.TOOL_NOT_ALLOWED, decision.reason)
+}
+
+const REDACTION = "[REDACTED_MCP_SECRET]"
+const SECRET_KEY_PATTERN = /(api[_-]?key|access[_-]?token|refresh[_-]?token|authorization|cookie|client[_-]?secret|session[_-]?headers?)/i
+const SECRET_VALUE_PATTERN = /(Bearer\s+[A-Za-z0-9._~+\/-]{12,}|sk-[A-Za-z0-9_-]{12,}|x-api-key\s*[:=]\s*[^\s,}]+)/i
+
+export function redactMcpSecrets(value: unknown): unknown {
+  if (typeof value === "string") return value.replace(SECRET_VALUE_PATTERN, REDACTION)
+  if (Array.isArray(value)) return value.map(redactMcpSecrets)
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(Object.entries(value).map(([key, nested]) => [key, SECRET_KEY_PATTERN.test(key) ? REDACTION : redactMcpSecrets(nested)]))
+}
+
+export function containsMcpSecret(value: unknown): boolean {
+  const redacted = redactMcpSecrets(value)
+  return JSON.stringify(redacted) !== JSON.stringify(value)
+}
+
+export function doctorMcpSource(source: McpSource, templates = DEFAULT_MCP_PROVIDER_TEMPLATES): McpDoctorResult {
+  const issues: McpDoctorIssue[] = []
+  if (!getMcpProviderTemplate(source.provider, templates)) {
+    issues.push({ level: "error", code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, message: "Unknown MCP provider template" })
+  }
+  if (source.status !== "connected") {
+    issues.push({ level: "warning", code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE, message: "MCP source is not connected" })
+  }
+  return { ok: issues.every((issue) => issue.level !== "error"), sourceId: source.id, issues }
+}
+
+export class McpAccessFacade {
+  constructor(
+    private readonly params: {
+      store: McpSourceStore
+      transport: McpTransportClient
+      templates?: readonly McpProviderTemplate[]
+      maxInputBytes?: number
+    },
+  ) {}
+
+  listSources(actor: McpActor): Promise<McpSource[]> {
+    return this.params.store.listSources(actor)
+  }
+
+  async probeSource(actor: McpActor, sourceId: string): Promise<McpProbeResult> {
+    const source = await this.requireOwnedSource(actor, sourceId)
+    const template = this.requireTemplate(source)
+    const [tools, resources] = await Promise.all([
+      this.params.transport.listTools(source),
+      this.params.transport.listResources(source),
+    ])
+    return {
+      sourceId: source.id,
+      provider: source.provider,
+      tools: tools.map((tool) => ({ ...tool, decision: classifyMcpTool(template, tool.name) })),
+      resources,
+    }
+  }
+
+  async callReadonlyTool(actor: McpActor, sourceId: string, toolName: string, input: unknown): Promise<McpToolCallResult> {
+    const source = await this.requireOwnedSource(actor, sourceId)
+    const template = this.requireTemplate(source)
+    assertMcpToolAllowed(template, toolName)
+    const bytes = new TextEncoder().encode(JSON.stringify(input ?? {})).byteLength
+    if (bytes > (this.params.maxInputBytes ?? 64 * 1024)) {
+      throw new McpError(MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED, "MCP tool input is too large")
+    }
+    const result = await this.params.transport.callTool(source, toolName, input)
+    if (containsMcpSecret(result)) throw new McpError(MCP_ERROR_CODES.SECRET_LEAK_GUARD, "MCP provider response looked like it contained a secret")
+    return redactMcpSecrets(result) as McpToolCallResult
+  }
+
+  private async requireOwnedSource(actor: McpActor, sourceId: string): Promise<McpSource> {
+    const source = await this.params.store.getSource(sourceId)
+    if (!source || source.workspaceId !== actor.workspaceId || source.userId !== actor.userId) {
+      throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
+    }
+    return source
+  }
+
+  private requireTemplate(source: McpSource): McpProviderTemplate {
+    const template = getMcpProviderTemplate(source.provider, this.params.templates)
+    if (!template) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown MCP provider")
+    return template
+  }
+}

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -147,6 +147,10 @@ export interface McpTransportClient {
   callTool(source: McpSource, toolName: string, input: unknown): Promise<McpToolCallResult>
 }
 
+export interface McpSourceAccessPolicy {
+  canAccessSource(actor: McpActor, source: McpSource): boolean
+}
+
 export class McpError extends Error {
   readonly code: McpErrorCode
   readonly details: unknown
@@ -218,7 +222,7 @@ export function assertMcpToolAllowed(template: McpProviderTemplate, toolName: st
 
 const REDACTION = "[REDACTED_MCP_SECRET]"
 const SECRET_KEY_PATTERN = /(api[_-]?key|access[_-]?token|refresh[_-]?token|authorization|cookie|client[_-]?secret|session[_-]?headers?)/i
-const SECRET_VALUE_PATTERN = /(Bearer\s+[A-Za-z0-9._~+\/-]{12,}|sk-[A-Za-z0-9_-]{12,}|x-api-key\s*[:=]\s*[^\s,}]+)/i
+const SECRET_VALUE_PATTERN = /(Bearer\s+[A-Za-z0-9._~+\/-]{12,}|sk-[A-Za-z0-9_-]{12,}|x-api-key\s*[:=]\s*[^\s,}]+)/gi
 
 export function redactMcpSecrets(value: unknown): unknown {
   if (typeof value === "string") return value.replace(SECRET_VALUE_PATTERN, REDACTION)
@@ -250,15 +254,17 @@ export class McpAccessFacade {
       transport: McpTransportClient
       templates?: readonly McpProviderTemplate[]
       maxInputBytes?: number
+      accessPolicy?: McpSourceAccessPolicy
     },
   ) {}
 
-  listSources(actor: McpActor): Promise<McpSource[]> {
-    return this.params.store.listSources(actor)
+  async listSources(actor: McpActor): Promise<McpSource[]> {
+    return (await this.params.store.listSources(actor)).filter((source) => this.canAccessSource(actor, source))
   }
 
   async probeSource(actor: McpActor, sourceId: string): Promise<McpProbeResult> {
-    const source = await this.requireOwnedSource(actor, sourceId)
+    const source = await this.requireAccessibleSource(actor, sourceId)
+    this.requireConnectedSource(source)
     const template = this.requireTemplate(source)
     const [tools, resources] = await Promise.all([
       this.params.transport.listTools(source),
@@ -273,7 +279,8 @@ export class McpAccessFacade {
   }
 
   async callReadonlyTool(actor: McpActor, sourceId: string, toolName: string, input: unknown): Promise<McpToolCallResult> {
-    const source = await this.requireOwnedSource(actor, sourceId)
+    const source = await this.requireAccessibleSource(actor, sourceId)
+    this.requireConnectedSource(source)
     const template = this.requireTemplate(source)
     assertMcpToolAllowed(template, toolName)
     const bytes = new TextEncoder().encode(JSON.stringify(input ?? {})).byteLength
@@ -285,12 +292,23 @@ export class McpAccessFacade {
     return redactMcpSecrets(result) as McpToolCallResult
   }
 
-  private async requireOwnedSource(actor: McpActor, sourceId: string): Promise<McpSource> {
+  private async requireAccessibleSource(actor: McpActor, sourceId: string): Promise<McpSource> {
     const source = await this.params.store.getSource(sourceId)
-    if (!source || source.workspaceId !== actor.workspaceId || source.userId !== actor.userId) {
+    if (!source || source.workspaceId !== actor.workspaceId) {
       throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
     }
+    if (!this.canAccessSource(actor, source)) throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
     return source
+  }
+
+  private canAccessSource(actor: McpActor, source: McpSource): boolean {
+    if (source.workspaceId !== actor.workspaceId) return false
+    return this.params.accessPolicy?.canAccessSource(actor, source)
+      ?? (source.ownerKind === "user" && source.userId === actor.userId)
+  }
+
+  private requireConnectedSource(source: McpSource): void {
+    if (source.status !== "connected") throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source is not connected")
   }
 
   private requireTemplate(source: McpSource): McpProviderTemplate {

--- a/plugins/boring-mcp/tsconfig.json
+++ b/plugins/boring-mcp/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["node", "vitest/globals", "@testing-library/jest-dom"],
+    "paths": {
+      "@hachej/boring-workspace": ["../../packages/workspace/src/index.ts"],
+      "@hachej/boring-workspace/plugin": ["../../packages/workspace/src/plugin/index.ts"],
+      "@hachej/boring-workspace/server": ["../../packages/workspace/src/server/index.ts"]
+    }
+  },
+  "include": ["src/**/*", "vitest.config.ts", "tsup.config.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/boring-mcp/tsup.config.ts
+++ b/plugins/boring-mcp/tsup.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: {
+    "front/index": "src/front/index.tsx",
+    "server/index": "src/server/index.ts",
+    "shared/index": "src/shared/index.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  splitting: false,
+  clean: true,
+  outDir: "dist",
+  target: "es2022",
+  platform: "neutral",
+  external: [
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+    /^@hachej\/boring-workspace(\/.*)?$/,
+  ],
+})

--- a/plugins/boring-mcp/vitest.config.ts
+++ b/plugins/boring-mcp/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -964,6 +964,48 @@ importers:
         specifier: ^3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
+  plugins/boring-mcp:
+    devDependencies:
+      '@hachej/boring-workspace':
+        specifier: workspace:*
+        version: link:../../packages/workspace
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.0.0
+        version: 4.7.0(vite@6.4.2(@types/node@22.19.17)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0))
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2(@noble/hashes@2.2.0)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.5(react@19.2.5)
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(@microsoft/api-extractor@7.58.7(@types/node@22.19.17))(jiti@2.7.0)(postcss@8.5.13)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.2.6
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
+
   plugins/ccusage-dashboard:
     dependencies:
       ccusage:


### PR DESCRIPTION
## Summary

PR 1A for issue #416: adds the reusable `@hachej/boring-mcp` plugin/capability in boring-ui.

Includes:

- reusable plugin package at `plugins/boring-mcp`
- generic Sources left-tab and MCP Sources panel shell
- generic provider template/source/tool DTO contracts
- deny-before-allow read-only tool policy
- redaction and secret-leak guard
- status/doctor/probe/facade seams with fake transport tests
- server plugin prompt seam
- docs showing how child apps enable/configure boring-mcp

## Non-goals

- no Constellation-specific implementation
- no real Composio calls
- no OAuth/provider execution
- no secret storage
- no app env/Vault binding

## Review-size cap

```txt
635 / 1200 non-test/non-doc added lines
```

## Validation

```txt
git diff --check: pass
pnpm --filter @hachej/boring-mcp test: pass, 6 tests
pnpm --filter @hachej/boring-mcp typecheck: pass
pnpm --filter @hachej/boring-mcp build: pass
thermo-nuclear review: GREEN
```

## Thermo loop

Pass 1: RED
- removed Composio-specific credential contract/docs/tests from generic foundation
- added public publish config
- removed unused Fastify peer/dev dependency

Pass 2: GREEN