### PR TITLE
#421 Add reusable public Markdown share links

### DIFF
--- a/docs/plans/public-workspace-share-routes-plan.md
+++ b/docs/plans/public-workspace-share-routes-plan.md
@@ -1,0 +1,316 @@
+# Public Workspace Share Routes Plan
+
+## Goal
+
+Let a user share a URL for one workspace Markdown document for external review without exposing the full boring-ui workspace, agent APIs, local bridge, shell, file tree, or editor.
+
+Primary CLI UX:
+
+```bash
+boring-ui share docs/review.md --assets
+
+# Optional, explicit: anyone with the URL can edit the Markdown file.
+boring-ui share docs/review.md --assets --allow-edit
+```
+
+Output:
+
+```text
+Share URL: http://127.0.0.1:5200/share/<token>/
+Tunnel:    cloudflared tunnel --url http://127.0.0.1:5200
+```
+
+## Product stance
+
+This is not "run boring-ui publicly". It is a narrow public capability surface over selected workspace files. The MVP defaults to read-only; public editing is an explicit capability for the entry Markdown file only.
+
+- The reusable route belongs in the workspace/agent server layer because it owns workspace path reads and validation.
+- The CLI activates it and provides the one-command local workflow.
+- Deployed apps can later reuse the same primitive behind auth, invites, expiry, or project-specific share policies.
+
+## Non-goals for MVP
+
+- No public workspace UI.
+- No agent/chat access.
+- No file tree or arbitrary file browsing.
+- No comments or identity system.
+- No edits unless `--allow-edit` is explicitly set for the single Markdown entry file.
+- No persistent hosted storage.
+- No arbitrary app execution.
+- No automatic Cloudflare dependency in the first slice.
+
+## Architecture
+
+### 1. Shared route module
+
+Add a small public-share route module in the server package that already owns workspace file routes.
+
+Candidate location:
+
+```text
+packages/agent/src/server/http/routes/publicShare.ts
+```
+
+Export:
+
+```ts
+registerPublicShareRoutes(app, {
+  getShare(token),
+  workspace,
+})
+```
+
+or multi-workspace-ready:
+
+```ts
+registerPublicShareRoutes(app, {
+  getShare(token, request),
+  getWorkspace(share, request),
+})
+```
+
+Route shape:
+
+```text
+GET /share/:token/
+GET /share/:token/*
+```
+
+The route serves only paths declared by the share record.
+
+### 2. Share record model
+
+MVP in-memory for CLI start is acceptable; keep the model serializable for later persistence.
+
+```ts
+type PublicShareRecord = {
+  token: string
+  kind: 'markdown-review'
+  entryPath: string
+  capabilities: {
+    readFiles: string[]
+    renderMarkdown: true
+    /** Explicit opt-in: anyone with the URL may overwrite entryPath. */
+    writeEntry?: true
+  }
+  createdAt: string
+  expiresAt?: string
+  title?: string
+}
+```
+
+Rules:
+
+- `entryPath` is the Markdown file shown at `/share/:token/`.
+- `capabilities.readFiles` includes the entry file and optionally referenced assets.
+- Requests cannot supply arbitrary paths outside `capabilities.readFiles`.
+- `capabilities.writeEntry` allows editing only `entryPath`, never assets or arbitrary paths.
+- Path validation still flows through the workspace adapter.
+
+### 3. Markdown asset dependency collection
+
+For `--assets`, parse Markdown references conservatively:
+
+```md
+![alt](relative.png)
+![alt](./images/screenshot.png)
+<img src="relative.png">
+```
+
+Include only local relative asset paths.
+
+Exclude:
+
+- `http://`, `https://`, `data:`, `mailto:`
+- absolute `/...` paths unless explicitly mapped later
+- paths containing null bytes or traversal after normalization
+
+MVP can be regex-based and covered by tests. No need for a full Markdown parser yet.
+
+### 4. Rendering mode
+
+MVP should serve raw Markdown with a minimal review HTML wrapper at `/share/:token/`, not just `text/markdown`, so external reviewers get a readable page.
+
+Suggested routes:
+
+```text
+GET /share/:token/           -> rendered HTML shell for Markdown
+GET /share/:token/raw        -> original Markdown
+GET /share/:token/assets/*   -> allowed images/assets
+POST /share/:token/raw        -> overwrite entry Markdown only when writeEntry is true
+```
+
+The renderer can be intentionally minimal:
+
+- escape HTML
+- render headings, paragraphs, links, code blocks, lists, and images, or use an existing safe markdown renderer if already present server-side
+- rewrite local image URLs to `/share/:token/assets/<encoded-path>`
+- set `Content-Security-Policy: default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; base-uri 'none'; frame-ancestors 'none'`
+- set `X-Content-Type-Options: nosniff`
+
+If rendering is too large for MVP, serve a simple HTML page with a `<pre>` plus working asset links, then improve rendering in PR 2.
+
+### 5. CLI command
+
+Add:
+
+```bash
+boring-ui share <file> [options]
+```
+
+Options:
+
+```text
+--assets              include local Markdown image dependencies
+--allow-edit         anyone with the URL can edit the entry Markdown file
+--expires <duration>  optional: 1h, 24h, 7d
+--port <port>         existing server port option
+--host <host>         default 127.0.0.1 for share mode
+--no-open             do not open browser
+```
+
+Share mode should default host to `127.0.0.1`, even if normal folder mode defaults differently.
+
+CLI behavior:
+
+1. Resolve workspace root as current directory unless `--workspace` or folder arg is added later.
+2. Validate target is a file inside the workspace.
+3. Build share record.
+4. Start a Fastify app with only public share routes and minimal health route, or start normal folder app with public share routes mounted but keep printed guidance clear.
+5. Print local URL and tunnel command.
+
+Preferred MVP for safety: start a share-only app for `boring-ui share`, not the full workspace UI.
+
+### 6. Tunneling guidance
+
+Do not run cloudflared automatically in MVP. Print:
+
+```bash
+cloudflared tunnel --url http://127.0.0.1:<port>
+```
+
+Later option:
+
+```bash
+boring-ui share docs/review.md --assets --tunnel
+```
+
+This can spawn `cloudflared` only if installed and clearly label the external URL.
+
+## Security requirements
+
+- Public share route must not expose `/api`, file tree, shell, chat, bridge, or plugin code.
+- Public editing must be explicit (`--allow-edit`) and limited to the entry Markdown file.
+- Token must be unguessable: at least 128 bits of entropy.
+- Only explicitly allowed paths are readable.
+- No directory listing.
+- No symlink/path traversal bypass; all reads go through workspace path validation.
+- Do not log file contents.
+- Do not include secrets from env/config in the page.
+- Markdown HTML must be escaped/sanitized; no arbitrary script.
+- Assets get `nosniff` and conservative content types.
+
+## Test plan
+
+### Unit tests
+
+- token generation shape/entropy sanity
+- Markdown local asset extraction
+- rejects remote/data/mailto URLs from dependency list
+- rejects traversal paths
+- content type selection
+- Markdown link rewriting
+
+### Route tests
+
+- `GET /share/:token/` returns HTML for entry Markdown
+- `GET /share/:token/raw` returns Markdown
+- allowed image returns bytes with image content type
+- read-only share rejects Markdown overwrite
+- editable share overwrites only the entry Markdown file
+- unlisted workspace file returns 404
+- traversal under `/share/:token/assets/../secret` returns 403/404
+- unknown token returns 404
+- expired token returns 410
+
+### CLI tests
+
+- `boring-ui share --help` documents usage including `--allow-edit`
+- missing file fails clearly
+- file outside workspace fails clearly
+- command prints local URL and cloudflared command
+
+## PR slices
+
+### PR 1 — reusable public share route + tests
+
+- Add share record types and route registration.
+- Add Markdown dependency extraction helper.
+- Add route tests with an in-memory/mock workspace.
+- No CLI command yet except internal test harness if needed.
+
+### PR 2 — CLI `boring-ui share`
+
+- Add CLI command parser branch.
+- Start share-only Fastify server.
+- Mount public share routes.
+- Print local URL + cloudflared guidance.
+- Add CLI integration tests.
+- Update `packages/cli/README.md`.
+
+### PR 3 — nicer review page
+
+- Improve Markdown rendering/styling.
+- Add copy link / raw link.
+- Add better error pages.
+
+### PR 4 — optional tunnel integration
+
+- Add `--tunnel`.
+- Detect `cloudflared` safely.
+- Stream/print the generated `trycloudflare.com` URL.
+
+## Future: sharing mini apps from the workspace
+
+Yes, the same primitive can become the foundation for sharing mini apps, but mini apps should be a separate capability tier from Markdown review.
+
+Potential future command:
+
+```bash
+boring-ui share-app apps/demo --build npm:build --dist dist
+```
+
+or plugin/workspace-declared:
+
+```bash
+boring-ui share apps/demo/index.html --assets --spa
+```
+
+Required extra safeguards for mini apps:
+
+- Serve only a static build directory, not source with live workspace access.
+- No agent APIs, no workspace bridge, no shell.
+- Strict CSP by default.
+- Optional allowlist for external network origins.
+- Explicit warning if the static app contains JS.
+- Separate share kind:
+
+```ts
+type PublicShareRecord =
+  | { kind: 'file'; entryPath: string; allowedPaths: string[]; ... }
+  | { kind: 'static-app'; entryPath: string; allowedPaths: string[]; spaFallback?: boolean; ... }
+```
+
+Recommended sequence:
+
+1. Ship Markdown file + image dependency sharing.
+2. Add folder/static asset sharing.
+3. Add static mini-app sharing from build output.
+4. Only much later consider interactive workspace-backed mini apps with explicit auth/capabilities.
+
+## Open questions
+
+1. Should MVP render Markdown to HTML or serve raw Markdown plus assets?
+2. Should share records persist to `.boring/shares.json`, or stay in-memory for the first CLI session?
+3. Should `boring-ui share` default to a share-only server on port 5201 to avoid confusion with the full workspace UI?
+4. Should expiry default to session-only, 24h, or no expiry for local CLI shares?

--- a/packages/agent/src/server/http/routes/__tests__/publicShare.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/publicShare.test.ts
@@ -60,8 +60,25 @@ describe('public share routes', () => {
   })
 
 
+  test('returns generic metadata and download routes for the public app dispatcher', async () => {
+    const { app } = await createTestApp({ allowEdit: true })
+
+    const meta = await app.inject({ method: 'GET', url: '/share/s_test/meta' })
+    expect(meta.statusCode).toBe(200)
+    const body = JSON.parse(meta.body) as { kind: string; appId: string; editable: boolean; links: { downloads: Record<string, string> }; downloads: Record<string, { href: string }> }
+    expect(body.kind).toBe('markdown-review')
+    expect(body.appId).toBe('markdown-review')
+    expect(body.editable).toBe(true)
+    expect(body.links.downloads.portableMarkdown).toBe('/share/s_test/download/portableMarkdown')
+    expect(body.downloads.portableMarkdown.href).toBe('/share/s_test/portable.md')
+  })
+
   test('exports portable Markdown and a ZIP bundle with images', async () => {
     const { app } = await createTestApp()
+
+    const genericPortable = await app.inject({ method: 'GET', url: '/share/s_test/download/portableMarkdown', headers: { host: 'review.test' } })
+    expect(genericPortable.statusCode).toBe(200)
+    expect(genericPortable.body).toContain('http://review.test/share/s_test/assets/docs/images/hero.png')
 
     const portable = await app.inject({ method: 'GET', url: '/share/s_test/portable.md', headers: { host: 'review.test' } })
     expect(portable.statusCode).toBe(200)
@@ -81,6 +98,28 @@ describe('public share routes', () => {
 
     const res = await app.inject({ method: 'GET', url: '/share/s_test/assets/docs/secret.md' })
     expect(res.statusCode).toBe(404)
+  })
+
+  test('returns unsupported for shares without a registered public app handler', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-public-share-'))
+    tempRoots.push(workspaceRoot)
+    await writeFile(join(workspaceRoot, 'image.png'), Buffer.from([137, 80, 78, 71]), 'binary')
+    const workspace = createNodeWorkspace(workspaceRoot)
+    const app = Fastify({ logger: false })
+    await app.register(registerPublicShareRoutes, {
+      getShare: () => ({ token: 's_image', kind: 'image-preview', appId: 'image-preview', entryPath: 'image.png', capabilities: { readFiles: ['image.png'] } }),
+      getWorkspace: () => workspace,
+    })
+    await app.ready()
+    apps.push(app)
+
+    const res = await app.inject({ method: 'GET', url: '/share/s_image/meta' })
+    expect(res.statusCode).toBe(501)
+
+    const raw = await app.inject({ method: 'GET', url: '/share/s_image/api/v1/files/raw?path=image.png' })
+    expect(raw.statusCode).toBe(501)
+    const asset = await app.inject({ method: 'GET', url: '/share/s_image/assets/image.png' })
+    expect(asset.statusCode).toBe(501)
   })
 
   test('read-only shares reject public edits', async () => {

--- a/packages/agent/src/server/http/routes/__tests__/publicShare.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/publicShare.test.ts
@@ -1,0 +1,111 @@
+import Fastify, { type FastifyInstance } from 'fastify'
+import { mkdir, mkdtemp, rm, writeFile, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { createNodeWorkspace } from '../../../workspace/createNodeWorkspace'
+import { createMarkdownReviewShare, registerPublicShareRoutes } from '../publicShare'
+
+const tempRoots: string[] = []
+const apps: FastifyInstance[] = []
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map(async (app) => app.close()))
+  await Promise.all(tempRoots.splice(0).map(async (root) => rm(root, { recursive: true, force: true })))
+})
+
+async function createTestApp(opts: { allowEdit?: boolean } = {}) {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-public-share-'))
+  tempRoots.push(workspaceRoot)
+  await mkdir(join(workspaceRoot, 'docs', 'images'), { recursive: true })
+  await writeFile(join(workspaceRoot, 'docs', 'review.md'), '# Review\n\n![Hero](images/hero.png)\n\n<img src="images/inline.png" alt="Inline image">\n', 'utf8')
+  await writeFile(join(workspaceRoot, 'docs', 'images', 'hero.png'), Buffer.from([137, 80, 78, 71]), 'binary')
+  await writeFile(join(workspaceRoot, 'docs', 'images', 'inline.png'), Buffer.from([137, 80, 78, 71]), 'binary')
+  await writeFile(join(workspaceRoot, 'docs', 'secret.md'), 'secret', 'utf8')
+
+  const workspace = createNodeWorkspace(workspaceRoot)
+  const share = createMarkdownReviewShare({
+    token: 's_test',
+    entryPath: 'docs/review.md',
+    markdown: await readFile(join(workspaceRoot, 'docs', 'review.md'), 'utf8'),
+    includeAssets: true,
+    allowEdit: opts.allowEdit,
+  })
+  const app = Fastify({ logger: false })
+  await app.register(registerPublicShareRoutes, {
+    getShare: (token: string) => token === share.token ? share : undefined,
+    getWorkspace: () => workspace,
+  })
+  await app.ready()
+  apps.push(app)
+  return { app, workspaceRoot }
+}
+
+describe('public share routes', () => {
+  test('renders a Markdown review page with allowed image assets', async () => {
+    const { app } = await createTestApp()
+
+    const page = await app.inject({ method: 'GET', url: '/share/s_test/' })
+    expect(page.statusCode).toBe(200)
+    expect(page.headers['content-type']).toContain('text/html')
+    expect(page.body).toContain('<h1>Review</h1>')
+    expect(page.body).toContain('/share/s_test/assets/docs/images/hero.png')
+    expect(page.body).toContain('/share/s_test/assets/docs/images/inline.png')
+    expect(page.body).not.toContain('&lt;img')
+
+    const image = await app.inject({ method: 'GET', url: '/share/s_test/assets/docs/images/hero.png' })
+    expect(image.statusCode).toBe(200)
+    expect(image.headers['content-type']).toContain('image/png')
+  })
+
+
+  test('exports portable Markdown and a ZIP bundle with images', async () => {
+    const { app } = await createTestApp()
+
+    const portable = await app.inject({ method: 'GET', url: '/share/s_test/portable.md', headers: { host: 'review.test' } })
+    expect(portable.statusCode).toBe(200)
+    expect(portable.body).toContain('http://review.test/share/s_test/assets/docs/images/hero.png')
+    expect(portable.body).toContain('http://review.test/share/s_test/assets/docs/images/inline.png')
+
+    const zip = await app.inject({ method: 'GET', url: '/share/s_test/bundle.zip' })
+    expect(zip.statusCode).toBe(200)
+    expect(zip.headers['content-type']).toContain('application/zip')
+    expect(zip.body).toContain('docs/review.md')
+    expect(zip.body).toContain('docs/images/hero.png')
+    expect(zip.body).toContain('docs/images/inline.png')
+  })
+
+  test('does not expose unlisted workspace files', async () => {
+    const { app } = await createTestApp()
+
+    const res = await app.inject({ method: 'GET', url: '/share/s_test/assets/docs/secret.md' })
+    expect(res.statusCode).toBe(404)
+  })
+
+  test('read-only shares reject public edits', async () => {
+    const { app } = await createTestApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/share/s_test/raw',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({ content: '# Changed' }).toString(),
+    })
+    expect(res.statusCode).toBe(403)
+  })
+
+  test('editable shares overwrite only the entry Markdown file', async () => {
+    const { app, workspaceRoot } = await createTestApp({ allowEdit: true })
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/share/s_test/raw',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: new URLSearchParams({ content: '# Changed' }).toString(),
+    })
+    expect(res.statusCode).toBe(303)
+    await expect(readFile(join(workspaceRoot, 'docs', 'review.md'), 'utf8')).resolves.toBe('# Changed')
+    await expect(readFile(join(workspaceRoot, 'docs', 'secret.md'), 'utf8')).resolves.toBe('secret')
+  })
+})

--- a/packages/agent/src/server/http/routes/__tests__/publicShare.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/publicShare.test.ts
@@ -1,5 +1,5 @@
 import Fastify, { type FastifyInstance } from 'fastify'
-import { mkdir, mkdtemp, rm, writeFile, readFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile, readFile } from 'fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, test } from 'vitest'

--- a/packages/agent/src/server/http/routes/publicShare.ts
+++ b/packages/agent/src/server/http/routes/publicShare.ts
@@ -1,28 +1,69 @@
-import type { FastifyInstance, FastifyReply } from 'fastify'
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import { dirname, extname, posix } from 'node:path'
 import type { Workspace } from '../../../shared/workspace'
 
-export type PublicShareKind = 'markdown-review'
+export const MARKDOWN_REVIEW_SHARE_KIND = 'markdown-review'
+
+export type PublicShareKind = string
+
+export interface PublicShareDownloadLink {
+  href: string
+  contentType?: string
+  label?: string
+}
 
 export interface PublicShareCapabilities {
   readFiles: string[]
-  renderMarkdown?: true
+  /** Workspace-relative files that may be written through this share. */
+  writeFiles?: string[]
+  /** Back-compat shorthand for allowing writes to entryPath. */
   writeEntry?: true
+  /** Back-compat marker for the current Markdown review renderer. */
+  renderMarkdown?: true
+  downloads?: Record<string, PublicShareDownloadLink>
 }
 
 export interface PublicShareRecord {
   token: string
   kind: PublicShareKind
+  /** Public app/viewer id used by front-end dispatchers. Defaults to kind. */
+  appId?: string
   entryPath: string
+  /** Content type of the entry file; downloads/assets may have their own type. */
+  contentType?: string
   capabilities: PublicShareCapabilities
   createdAt?: string
   expiresAt?: string
   title?: string
 }
 
+export interface PublicShareResponse {
+  body: string | Uint8Array | Buffer
+  contentType: string
+  headers?: Record<string, string>
+  statusCode?: number
+}
+
+export interface PublicShareHandlerContext {
+  share: PublicShareRecord
+  workspace: Workspace
+  request: FastifyRequest
+}
+
+export interface PublicShareHandler {
+  kind: string
+  canHandle?: (share: PublicShareRecord) => boolean
+  meta: (context: Omit<PublicShareHandlerContext, 'workspace' | 'request'>) => Record<string, unknown>
+  renderIndex?: (context: PublicShareHandlerContext) => Promise<PublicShareResponse> | PublicShareResponse
+  readRaw?: (context: PublicShareHandlerContext) => Promise<PublicShareResponse> | PublicShareResponse
+  writeRaw?: (context: PublicShareHandlerContext, content: string) => Promise<void> | void
+  downloads?: Record<string, (context: PublicShareHandlerContext) => Promise<PublicShareResponse> | PublicShareResponse>
+}
+
 export interface PublicShareRoutesOptions {
   getShare: (token: string) => PublicShareRecord | undefined | Promise<PublicShareRecord | undefined>
   getWorkspace: (share: PublicShareRecord) => Workspace | Promise<Workspace>
+  handlers?: PublicShareHandler[]
 }
 
 const LOCAL_MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)|<img\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi
@@ -108,12 +149,18 @@ export function createMarkdownReviewShare(args: {
   }
   return {
     token: args.token,
-    kind: 'markdown-review',
+    kind: MARKDOWN_REVIEW_SHARE_KIND,
+    appId: MARKDOWN_REVIEW_SHARE_KIND,
     entryPath,
+    contentType: 'text/markdown; charset=utf-8',
     capabilities: {
       readFiles: [...readFiles].sort(),
       renderMarkdown: true,
-      ...(args.allowEdit ? { writeEntry: true as const } : {}),
+      ...(args.allowEdit ? { writeEntry: true as const, writeFiles: [entryPath] } : {}),
+      downloads: {
+        portableMarkdown: { href: `/share/${encodeURIComponent(args.token)}/portable.md`, contentType: 'text/markdown; charset=utf-8', label: 'Portable Markdown' },
+        bundleZip: { href: `/share/${encodeURIComponent(args.token)}/bundle.zip`, contentType: 'application/zip', label: 'Bundle ZIP' },
+      },
     },
     ...(args.expiresAt ? { expiresAt: args.expiresAt } : {}),
     ...(args.title ? { title: args.title } : {}),
@@ -318,6 +365,78 @@ async function readBinary(workspace: Workspace, path: string): Promise<Uint8Arra
   return Buffer.from(await workspace.readFile(path), 'utf8')
 }
 
+function canWriteEntry(share: PublicShareRecord): boolean {
+  if (share.capabilities.writeEntry === true) return true
+  return share.capabilities.writeFiles?.includes(share.entryPath) === true
+}
+
+function findShareHandler(handlers: PublicShareHandler[], share: PublicShareRecord): PublicShareHandler | null {
+  return handlers.find((handler) => {
+    if (handler.canHandle) return handler.canHandle(share)
+    return handler.kind === share.kind
+  }) ?? null
+}
+
+function createMarkdownDownloadLinks(share: PublicShareRecord): Record<string, PublicShareDownloadLink> {
+  return {
+    portableMarkdown: { href: `/share/${encodeURIComponent(share.token)}/portable.md`, contentType: 'text/markdown; charset=utf-8', label: 'Portable Markdown' },
+    bundleZip: { href: `/share/${encodeURIComponent(share.token)}/bundle.zip`, contentType: 'application/zip', label: 'Bundle ZIP' },
+  }
+}
+
+export const markdownReviewShareHandler: PublicShareHandler = {
+  kind: MARKDOWN_REVIEW_SHARE_KIND,
+  canHandle: (share) => share.kind === MARKDOWN_REVIEW_SHARE_KIND || share.capabilities.renderMarkdown === true,
+  meta: ({ share }) => ({
+    appId: share.appId ?? MARKDOWN_REVIEW_SHARE_KIND,
+    contentType: share.contentType ?? 'text/markdown; charset=utf-8',
+    downloads: share.capabilities.downloads ?? createMarkdownDownloadLinks(share),
+  }),
+  async renderIndex({ share, workspace }) {
+    if (!sharePathAllowed(share, share.entryPath)) throw new Error('share entry not allowed')
+    const markdown = await workspace.readFile(share.entryPath)
+    return { contentType: 'text/html; charset=utf-8', body: renderMarkdownDocument(markdown, share) }
+  },
+  async readRaw({ share, workspace }) {
+    if (!sharePathAllowed(share, share.entryPath)) throw new Error('share entry not allowed')
+    return { contentType: 'text/markdown; charset=utf-8', body: await workspace.readFile(share.entryPath) }
+  },
+  async writeRaw({ share, workspace }, content) {
+    if (!sharePathAllowed(share, share.entryPath)) throw new Error('share entry not allowed')
+    await workspace.writeFile(share.entryPath, content)
+  },
+  downloads: {
+    async portableMarkdown({ share, workspace, request }) {
+      if (!sharePathAllowed(share, share.entryPath)) throw new Error('share entry not allowed')
+      const origin = `${request.protocol}://${request.host}`
+      const markdown = rewriteMarkdownAssetUrls(await workspace.readFile(share.entryPath), share, origin)
+      return {
+        contentType: 'text/markdown; charset=utf-8',
+        body: markdown,
+        headers: { 'content-disposition': `attachment; filename="${posix.basename(share.entryPath).replace(/"/g, '')}"` },
+      }
+    },
+    async bundleZip({ share, workspace }) {
+      if (!sharePathAllowed(share, share.entryPath)) throw new Error('share entry not allowed')
+      const markdown = rewriteMarkdownAssetUrlsForBundle(await workspace.readFile(share.entryPath), share)
+      const files: Array<{ name: string; data: Uint8Array }> = [{ name: share.entryPath, data: Buffer.from(markdown, 'utf8') }]
+      for (const path of share.capabilities.readFiles) {
+        if (path === share.entryPath) continue
+        files.push({ name: path, data: await readBinary(workspace, path) })
+      }
+      const zip = createStoredZip(files)
+      return {
+        contentType: 'application/zip',
+        body: zip,
+        headers: {
+          'content-disposition': `attachment; filename="${posix.basename(share.entryPath, extname(share.entryPath)) || 'share'}.zip"`,
+          'content-length': String(zip.byteLength),
+        },
+      }
+    },
+  },
+}
+
 async function resolveShare(opts: PublicShareRoutesOptions, token: string, reply: FastifyReply): Promise<PublicShareRecord | null> {
   const share = await opts.getShare(token)
   if (!share) {
@@ -328,10 +447,6 @@ async function resolveShare(opts: PublicShareRoutesOptions, token: string, reply
     reply.code(410).send({ error: 'share expired' })
     return null
   }
-  if (share.kind !== 'markdown-review' || share.capabilities.renderMarkdown !== true) {
-    reply.code(501).send({ error: 'share kind not supported' })
-    return null
-  }
   return share
 }
 
@@ -340,10 +455,28 @@ export function registerPublicShareRoutes(
   opts: PublicShareRoutesOptions,
   done: (err?: Error) => void,
 ): void {
+  const handlers = opts.handlers ?? [markdownReviewShareHandler]
   const securityHeaders = (reply: FastifyReply) => reply
     .header('cache-control', 'no-store')
     .header('x-content-type-options', 'nosniff')
     .header('content-security-policy', "default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'")
+
+  const sendPublicResponse = (reply: FastifyReply, response: PublicShareResponse) => {
+    const secured = securityHeaders(reply).code(response.statusCode ?? 200).type(response.contentType)
+    for (const [name, value] of Object.entries(response.headers ?? {})) secured.header(name, value)
+    return secured.send(response.body instanceof Uint8Array && !(response.body instanceof Buffer) ? Buffer.from(response.body) : response.body)
+  }
+
+  const resolveHandledShare = async (token: string, reply: FastifyReply): Promise<{ share: PublicShareRecord; handler: PublicShareHandler } | null> => {
+    const share = await resolveShare(opts, token, reply)
+    if (!share) return null
+    const handler = findShareHandler(handlers, share)
+    if (!handler) {
+      reply.code(501).send({ error: 'share kind not supported' })
+      return null
+    }
+    return { share, handler }
+  }
 
   if (!app.hasContentTypeParser('application/x-www-form-urlencoded')) {
     app.addContentTypeParser('application/x-www-form-urlencoded', { parseAs: 'string' }, (_request, body, done) => {
@@ -353,13 +486,13 @@ export function registerPublicShareRoutes(
 
   app.get('/share/:token/', async (request, reply) => {
     const { token } = request.params as { token: string }
-    const share = await resolveShare(opts, token, reply)
-    if (!share) return
-    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
+    const resolved = await resolveHandledShare(token, reply)
+    if (!resolved) return
+    const { share, handler } = resolved
+    if (!handler.renderIndex) return reply.code(501).send({ error: 'share app cannot render an index' })
     try {
       const workspace = await opts.getWorkspace(share)
-      const markdown = await workspace.readFile(share.entryPath)
-      return securityHeaders(reply).type('text/html; charset=utf-8').send(renderMarkdownDocument(markdown, share))
+      return sendPublicResponse(reply, await handler.renderIndex({ share, workspace, request }))
     } catch {
       return reply.code(404).send({ error: 'share entry not found' })
     }
@@ -367,82 +500,79 @@ export function registerPublicShareRoutes(
 
   app.get('/share/:token/meta', async (request, reply) => {
     const { token } = request.params as { token: string }
-    const share = await resolveShare(opts, token, reply)
-    if (!share) return
+    const resolved = await resolveHandledShare(token, reply)
+    if (!resolved) return
+    const { share, handler } = resolved
+    const handlerMeta = handler.meta({ share })
+    const downloads = (handlerMeta.downloads as Record<string, PublicShareDownloadLink> | undefined) ?? share.capabilities.downloads ?? {}
+    const servedDownloadIds = Object.keys(handler.downloads ?? {})
     return securityHeaders(reply).send({
       token: share.token,
       kind: share.kind,
+      appId: share.appId ?? share.kind,
       entryPath: share.entryPath,
-      editable: share.capabilities.writeEntry === true,
-      downloads: {
-        portableMarkdown: `/share/${encodeURIComponent(share.token)}/portable.md`,
-        bundleZip: `/share/${encodeURIComponent(share.token)}/bundle.zip`,
+      contentType: share.contentType ?? contentTypeForPath(share.entryPath),
+      editable: canWriteEntry(share),
+      links: {
+        editor: `/share/${encodeURIComponent(share.token)}/editor`,
+        raw: `/share/${encodeURIComponent(share.token)}/raw`,
+        downloads: Object.fromEntries(servedDownloadIds.map((id) => [id, `/share/${encodeURIComponent(share.token)}/download/${encodeURIComponent(id)}`])),
       },
+      ...handlerMeta,
+      downloads,
     })
   })
 
   app.get('/share/:token/raw', async (request, reply) => {
     const { token } = request.params as { token: string }
-    const share = await resolveShare(opts, token, reply)
-    if (!share) return
-    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
+    const resolved = await resolveHandledShare(token, reply)
+    if (!resolved) return
+    const { share, handler } = resolved
+    if (!handler.readRaw) return reply.code(501).send({ error: 'share app cannot read raw content' })
     try {
       const workspace = await opts.getWorkspace(share)
-      return securityHeaders(reply).type('text/markdown; charset=utf-8').send(await workspace.readFile(share.entryPath))
+      return sendPublicResponse(reply, await handler.readRaw({ share, workspace, request }))
     } catch {
       return reply.code(404).send({ error: 'share entry not found' })
     }
   })
 
+  const sendDownload = async (request: FastifyRequest, reply: FastifyReply, token: string, downloadId: string) => {
+    const resolved = await resolveHandledShare(token, reply)
+    if (!resolved) return
+    const { share, handler } = resolved
+    const download = handler.downloads?.[downloadId]
+    if (!download) return reply.code(404).send({ error: 'share download not found' })
+    try {
+      const workspace = await opts.getWorkspace(share)
+      return sendPublicResponse(reply, await download({ share, workspace, request }))
+    } catch {
+      return reply.code(404).send({ error: 'share download not found' })
+    }
+  }
+
+  app.get('/share/:token/download/:downloadId', async (request, reply) => {
+    const params = request.params as { token: string; downloadId: string }
+    return sendDownload(request, reply, params.token, params.downloadId)
+  })
 
   app.get('/share/:token/portable.md', async (request, reply) => {
     const { token } = request.params as { token: string }
-    const share = await resolveShare(opts, token, reply)
-    if (!share) return
-    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
-    try {
-      const workspace = await opts.getWorkspace(share)
-      const origin = `${request.protocol}://${request.host}`
-      const markdown = rewriteMarkdownAssetUrls(await workspace.readFile(share.entryPath), share, origin)
-      return securityHeaders(reply)
-        .header('content-disposition', `attachment; filename="${posix.basename(share.entryPath).replace(/"/g, '')}"`)
-        .type('text/markdown; charset=utf-8')
-        .send(markdown)
-    } catch {
-      return reply.code(404).send({ error: 'share entry not found' })
-    }
+    return sendDownload(request, reply, token, 'portableMarkdown')
   })
 
   app.get('/share/:token/bundle.zip', async (request, reply) => {
     const { token } = request.params as { token: string }
-    const share = await resolveShare(opts, token, reply)
-    if (!share) return
-    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
-    try {
-      const workspace = await opts.getWorkspace(share)
-      const markdown = rewriteMarkdownAssetUrlsForBundle(await workspace.readFile(share.entryPath), share)
-      const files: Array<{ name: string; data: Uint8Array }> = [{ name: share.entryPath, data: Buffer.from(markdown, 'utf8') }]
-      for (const path of share.capabilities.readFiles) {
-        if (path === share.entryPath) continue
-        files.push({ name: path, data: await readBinary(workspace, path) })
-      }
-      const zip = createStoredZip(files)
-      return securityHeaders(reply)
-        .header('content-disposition', `attachment; filename="${posix.basename(share.entryPath, extname(share.entryPath)) || 'share'}.zip"`)
-        .type('application/zip')
-        .header('content-length', String(zip.byteLength))
-        .send(zip)
-    } catch {
-      return reply.code(404).send({ error: 'share bundle not found' })
-    }
+    return sendDownload(request, reply, token, 'bundleZip')
   })
 
   app.post('/share/:token/raw', async (request, reply) => {
     const { token } = request.params as { token: string }
-    const share = await resolveShare(opts, token, reply)
-    if (!share) return
-    if (share.capabilities.writeEntry !== true) return reply.code(403).send({ error: 'share is read-only' })
-    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
+    const resolved = await resolveHandledShare(token, reply)
+    if (!resolved) return
+    const { share, handler } = resolved
+    if (!canWriteEntry(share)) return reply.code(403).send({ error: 'share is read-only' })
+    if (!handler.writeRaw) return reply.code(501).send({ error: 'share app cannot write raw content' })
     const body = request.body
     const content = typeof body === 'string'
       ? new URLSearchParams(body).get('content')
@@ -452,7 +582,7 @@ export function registerPublicShareRoutes(
     if (content === null) return reply.code(400).send({ error: 'content is required' })
     try {
       const workspace = await opts.getWorkspace(share)
-      await workspace.writeFile(share.entryPath, content)
+      await handler.writeRaw({ share, workspace, request }, content)
       return reply.code(303).header('location', `/share/${encodeURIComponent(share.token)}/`).send()
     } catch {
       return reply.code(404).send({ error: 'share entry not found' })
@@ -463,8 +593,9 @@ export function registerPublicShareRoutes(
     const { token } = request.params as { token: string }
     const query = request.query as Record<string, unknown>
     const rawPath = typeof query.path === 'string' ? query.path : ''
-    const share = await resolveShare(opts, token, reply)
-    if (!share) return
+    const resolved = await resolveHandledShare(token, reply)
+    if (!resolved) return
+    const { share } = resolved
     const assetPath = normalizeWorkspacePath(rawPath)
     if (!assetPath || !sharePathAllowed(share, assetPath)) {
       return reply.code(404).send({ error: 'asset not found' })
@@ -483,8 +614,9 @@ export function registerPublicShareRoutes(
 
   app.get('/share/:token/assets/*', async (request, reply) => {
     const params = request.params as { token: string; '*': string }
-    const share = await resolveShare(opts, params.token, reply)
-    if (!share) return
+    const resolved = await resolveHandledShare(params.token, reply)
+    if (!resolved) return
+    const { share } = resolved
     const assetPath = normalizeWorkspacePath(params['*'])
     if (!assetPath || !sharePathAllowed(share, assetPath) || assetPath === share.entryPath) {
       return reply.code(404).send({ error: 'asset not found' })

--- a/packages/agent/src/server/http/routes/publicShare.ts
+++ b/packages/agent/src/server/http/routes/publicShare.ts
@@ -1,0 +1,505 @@
+import type { FastifyInstance, FastifyReply } from 'fastify'
+import { dirname, extname, posix } from 'node:path'
+import type { Workspace } from '../../../shared/workspace'
+
+export type PublicShareKind = 'markdown-review'
+
+export interface PublicShareCapabilities {
+  readFiles: string[]
+  renderMarkdown?: true
+  writeEntry?: true
+}
+
+export interface PublicShareRecord {
+  token: string
+  kind: PublicShareKind
+  entryPath: string
+  capabilities: PublicShareCapabilities
+  createdAt?: string
+  expiresAt?: string
+  title?: string
+}
+
+export interface PublicShareRoutesOptions {
+  getShare: (token: string) => PublicShareRecord | undefined | Promise<PublicShareRecord | undefined>
+  getWorkspace: (share: PublicShareRecord) => Workspace | Promise<Workspace>
+}
+
+const LOCAL_MARKDOWN_IMAGE_RE = /!\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)|<img\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi
+const MARKDOWN_LINK_RE = /(!?)\[([^\]]+)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g
+
+function contentTypeForPath(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case '.avif': return 'image/avif'
+    case '.gif': return 'image/gif'
+    case '.jpg':
+    case '.jpeg': return 'image/jpeg'
+    case '.png': return 'image/png'
+    case '.svg': return 'image/svg+xml'
+    case '.webp': return 'image/webp'
+    case '.css': return 'text/css; charset=utf-8'
+    case '.csv': return 'text/csv; charset=utf-8'
+    case '.html': return 'text/html; charset=utf-8'
+    case '.js': return 'application/javascript; charset=utf-8'
+    case '.json': return 'application/json; charset=utf-8'
+    case '.md': return 'text/markdown; charset=utf-8'
+    case '.pdf': return 'application/pdf'
+    case '.txt': return 'text/plain; charset=utf-8'
+    default: return 'application/octet-stream'
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+function isExternalOrUnsafeUrl(value: string): boolean {
+  return /^(?:[a-z][a-z0-9+.-]*:|\/|#)/i.test(value) || value.includes('\0')
+}
+
+function normalizeWorkspacePath(path: string): string | null {
+  if (!path || path.includes('\0') || path.startsWith('/')) return null
+  const normalized = posix.normalize(path.replace(/\\/g, '/'))
+  if (!normalized || normalized === '.' || normalized.startsWith('../') || normalized === '..') return null
+  return normalized
+}
+
+function resolveRelativePath(fromPath: string, target: string): string | null {
+  if (isExternalOrUnsafeUrl(target)) return null
+  const [pathPart, suffix = ''] = target.split(/([?#].*)/, 2)
+  const base = dirname(fromPath) === '.' ? '' : dirname(fromPath)
+  const normalized = normalizeWorkspacePath(posix.join(base, pathPart))
+  return normalized ? `${normalized}${suffix}` : null
+}
+
+function stripUrlSuffix(path: string): string {
+  return path.split(/[?#]/, 1)[0] ?? path
+}
+
+export function collectMarkdownAssetPaths(markdown: string, entryPath: string): string[] {
+  const assets = new Set<string>()
+  for (const match of markdown.matchAll(LOCAL_MARKDOWN_IMAGE_RE)) {
+    const raw = match[1] ?? match[2]
+    if (!raw) continue
+    const resolved = resolveRelativePath(entryPath, raw)
+    if (resolved) assets.add(stripUrlSuffix(resolved))
+  }
+  return [...assets].sort()
+}
+
+export function createMarkdownReviewShare(args: {
+  token: string
+  entryPath: string
+  markdown: string
+  includeAssets?: boolean
+  allowEdit?: boolean
+  expiresAt?: string
+  title?: string
+}): PublicShareRecord {
+  const entryPath = normalizeWorkspacePath(args.entryPath)
+  if (!entryPath) throw new Error('entryPath must be a workspace-relative file path')
+  const readFiles = new Set<string>([entryPath])
+  if (args.includeAssets) {
+    for (const asset of collectMarkdownAssetPaths(args.markdown, entryPath)) readFiles.add(asset)
+  }
+  return {
+    token: args.token,
+    kind: 'markdown-review',
+    entryPath,
+    capabilities: {
+      readFiles: [...readFiles].sort(),
+      renderMarkdown: true,
+      ...(args.allowEdit ? { writeEntry: true as const } : {}),
+    },
+    ...(args.expiresAt ? { expiresAt: args.expiresAt } : {}),
+    ...(args.title ? { title: args.title } : {}),
+  }
+}
+
+function sharePathAllowed(share: PublicShareRecord, requestedPath: string): boolean {
+  const normalized = normalizeWorkspacePath(stripUrlSuffix(requestedPath))
+  return normalized !== null && share.capabilities.readFiles.includes(normalized)
+}
+
+function rewriteMarkdownLinks(markdown: string, share: PublicShareRecord): string {
+  return markdown.replace(MARKDOWN_LINK_RE, (full, bang: string, label: string, rawUrl: string) => {
+    if (!bang) return full
+    const resolved = resolveRelativePath(share.entryPath, rawUrl)
+    if (!resolved || !sharePathAllowed(share, resolved)) return full
+    const suffix = rawUrl.match(/[?#].*$/)?.[0] ?? ''
+    const assetPath = stripUrlSuffix(resolved)
+    const url = `/share/${encodeURIComponent(share.token)}/assets/${assetPath.split('/').map(encodeURIComponent).join('/')}${suffix}`
+    return `![${label}](${url})`
+  })
+}
+
+function renderInlineMarkdown(value: string): string {
+  let html = escapeHtml(value)
+  html = html.replace(/`([^`]+)`/g, '<code>$1</code>')
+  html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img alt="$1" src="$2">')
+  html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2" rel="noreferrer noopener" target="_blank">$1</a>')
+  html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+  html = html.replace(/\*([^*]+)\*/g, '<em>$1</em>')
+  return html
+}
+
+function renderHtmlImageLine(line: string, share: PublicShareRecord): string | null {
+  const src = line.match(/<img\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/i)?.[1]
+  if (!src) return null
+  const resolved = resolveRelativePath(share.entryPath, src)
+  if (!resolved || !sharePathAllowed(share, resolved)) return null
+  const suffix = src.match(/[?#].*$/)?.[0] ?? ''
+  const assetPath = stripUrlSuffix(resolved)
+  const url = `/share/${encodeURIComponent(share.token)}/assets/${assetPath.split('/').map(encodeURIComponent).join('/')}${suffix}`
+  const alt = line.match(/<img\b[^>]*\balt=["']([^"']*)["'][^>]*>/i)?.[1] ?? ''
+  return `<p><img alt="${escapeHtml(alt)}" src="${url}"></p>`
+}
+
+function renderMarkdownDocument(markdown: string, share: PublicShareRecord): string {
+  const rewritten = rewriteMarkdownLinks(markdown, share)
+  const lines = rewritten.split(/\r?\n/)
+  const out: string[] = []
+  let inCode = false
+  let code: string[] = []
+  let inList = false
+
+  const closeList = () => {
+    if (inList) out.push('</ul>')
+    inList = false
+  }
+  const closeCode = () => {
+    if (!inCode) return
+    out.push(`<pre><code>${escapeHtml(code.join('\n'))}</code></pre>`)
+    code = []
+    inCode = false
+  }
+
+  for (const line of lines) {
+    if (line.startsWith('```')) {
+      if (inCode) closeCode()
+      else {
+        closeList()
+        inCode = true
+      }
+      continue
+    }
+    if (inCode) {
+      code.push(line)
+      continue
+    }
+    if (!line.trim()) {
+      closeList()
+      continue
+    }
+    const htmlImage = renderHtmlImageLine(line.trim(), share)
+    if (htmlImage) {
+      closeList()
+      out.push(htmlImage)
+      continue
+    }
+    const heading = line.match(/^(#{1,3})\s+(.+)$/)
+    if (heading) {
+      closeList()
+      const level = heading[1].length
+      out.push(`<h${level}>${renderInlineMarkdown(heading[2])}</h${level}>`)
+      continue
+    }
+    const item = line.match(/^[-*]\s+(.+)$/)
+    if (item) {
+      if (!inList) {
+        out.push('<ul>')
+        inList = true
+      }
+      out.push(`<li>${renderInlineMarkdown(item[1])}</li>`)
+      continue
+    }
+    closeList()
+    out.push(`<p>${renderInlineMarkdown(line)}</p>`)
+  }
+  closeCode()
+  closeList()
+  const title = escapeHtml(share.title ?? share.entryPath)
+  const editable = share.capabilities.writeEntry === true
+  const editPanel = editable ? `<details class="edit"><summary>Edit Markdown</summary><form method="post" action="/share/${encodeURIComponent(share.token)}/raw"><textarea name="content" spellcheck="false">${escapeHtml(markdown)}</textarea><div><button type="submit">Save changes</button><span>Anyone with this link can edit this document.</span></div></form></details>` : ''
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+:root{color-scheme:light dark;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;line-height:1.6}body{margin:0;background:#fafafa;color:#171717}.page{max-width:820px;margin:0 auto;padding:48px 24px 72px}.meta{display:flex;justify-content:space-between;gap:16px;margin-bottom:32px;color:#737373;font-size:13px}.meta a{color:inherit}article,.edit{background:white;border:1px solid #e5e5e5;border-radius:18px;padding:32px;box-shadow:0 18px 60px rgba(0,0,0,.06)}.edit{margin-top:18px}.edit summary{cursor:pointer;font-weight:700}.edit textarea{box-sizing:border-box;width:100%;min-height:420px;margin-top:18px;padding:14px;border:1px solid #d4d4d4;border-radius:12px;font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}.edit button{margin-top:12px;border:0;border-radius:999px;background:#171717;color:white;padding:9px 15px;font-weight:700;cursor:pointer}.edit span{margin-left:12px;color:#737373;font-size:12px}h1,h2,h3{line-height:1.2;margin:1.4em 0 .55em}h1:first-child,h2:first-child,h3:first-child{margin-top:0}p,ul,pre{margin:0 0 1em}img{max-width:100%;height:auto;border-radius:12px;border:1px solid #e5e5e5}pre{overflow:auto;padding:16px;border-radius:12px;background:#171717;color:#fafafa}code{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:.9em}p code,li code{background:#f5f5f5;border:1px solid #e5e5e5;border-radius:5px;padding:1px 4px;color:#171717}a{color:#2563eb}@media (prefers-color-scheme:dark){body{background:#0a0a0a;color:#ededed}article,.edit{background:#111;border-color:#262626}.meta{color:#a3a3a3}.edit textarea{background:#0a0a0a;color:#ededed;border-color:#333}.edit button{background:#ededed;color:#111}.edit span{color:#a3a3a3}p code,li code{background:#1f1f1f;border-color:#333;color:#ededed}img{border-color:#333}}
+</style>
+</head>
+<body><main class="page"><div class="meta"><span>${title}</span><span><a href="/share/${encodeURIComponent(share.token)}/editor">Rich editor</a> · <a href="/share/${encodeURIComponent(share.token)}/portable.md">Portable MD</a> · <a href="/share/${encodeURIComponent(share.token)}/bundle.zip">Bundle ZIP</a> · <a href="/share/${encodeURIComponent(share.token)}/raw">Raw</a></span></div><article>${out.join('\n')}</article>${editPanel}</main></body>
+</html>`
+}
+
+
+function rewriteMarkdownAssetUrls(markdown: string, share: PublicShareRecord, baseUrl = ''): string {
+  const prefix = baseUrl.replace(/\/$/, '')
+  let rewritten = markdown.replace(MARKDOWN_LINK_RE, (full, bang: string, label: string, rawUrl: string) => {
+    if (!bang) return full
+    const resolved = resolveRelativePath(share.entryPath, rawUrl)
+    if (!resolved || !sharePathAllowed(share, resolved)) return full
+    const suffix = rawUrl.match(/[?#].*$/)?.[0] ?? ''
+    const assetPath = stripUrlSuffix(resolved)
+    const url = `${prefix}/share/${encodeURIComponent(share.token)}/assets/${assetPath.split('/').map(encodeURIComponent).join('/')}${suffix}`
+    return `![${label}](${url})`
+  })
+  rewritten = rewritten.replace(/<img\b([^>]*?)\bsrc=["']([^"']+)["']([^>]*)>/gi, (full, before: string, rawUrl: string, after: string) => {
+    const resolved = resolveRelativePath(share.entryPath, rawUrl)
+    if (!resolved || !sharePathAllowed(share, resolved)) return full
+    const suffix = rawUrl.match(/[?#].*$/)?.[0] ?? ''
+    const assetPath = stripUrlSuffix(resolved)
+    const url = `${prefix}/share/${encodeURIComponent(share.token)}/assets/${assetPath.split('/').map(encodeURIComponent).join('/')}${suffix}`
+    return `<img${before} src="${url}"${after}>`
+  })
+  return rewritten
+}
+
+function rewriteMarkdownAssetUrlsForBundle(markdown: string, share: PublicShareRecord): string {
+  return markdown.replace(MARKDOWN_LINK_RE, (full, bang: string, label: string, rawUrl: string) => {
+    if (!bang) return full
+    const resolved = resolveRelativePath(share.entryPath, rawUrl)
+    if (!resolved || !sharePathAllowed(share, resolved)) return full
+    return `![${label}](${stripUrlSuffix(resolved)})`
+  }).replace(/<img\b([^>]*?)\bsrc=["']([^"']+)["']([^>]*)>/gi, (full, before: string, rawUrl: string, after: string) => {
+    const resolved = resolveRelativePath(share.entryPath, rawUrl)
+    if (!resolved || !sharePathAllowed(share, resolved)) return full
+    return `<img${before} src="${stripUrlSuffix(resolved)}"${after}>`
+  })
+}
+
+const CRC_TABLE = new Uint32Array(256).map((_, n) => {
+  let c = n
+  for (let k = 0; k < 8; k += 1) c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1
+  return c >>> 0
+})
+
+function crc32(bytes: Uint8Array): number {
+  let c = 0xffffffff
+  for (const byte of bytes) c = CRC_TABLE[(c ^ byte) & 0xff] ^ (c >>> 8)
+  return (c ^ 0xffffffff) >>> 0
+}
+
+function u16(value: number): Buffer { const b = Buffer.alloc(2); b.writeUInt16LE(value); return b }
+function u32(value: number): Buffer { const b = Buffer.alloc(4); b.writeUInt32LE(value >>> 0); return b }
+
+function createStoredZip(files: Array<{ name: string; data: Uint8Array }>): Buffer {
+  const localParts: Buffer[] = []
+  const centralParts: Buffer[] = []
+  let offset = 0
+  for (const file of files) {
+    const name = Buffer.from(file.name.replace(/^\/+/, ''), 'utf8')
+    const data = Buffer.from(file.data)
+    const crc = crc32(data)
+    const local = Buffer.concat([
+      u32(0x04034b50), u16(20), u16(0), u16(0), u16(0), u16(0), u32(crc), u32(data.length), u32(data.length), u16(name.length), u16(0), name, data,
+    ])
+    localParts.push(local)
+    centralParts.push(Buffer.concat([
+      u32(0x02014b50), u16(20), u16(20), u16(0), u16(0), u16(0), u16(0), u32(crc), u32(data.length), u32(data.length), u16(name.length), u16(0), u16(0), u16(0), u16(0), u32(0), u32(offset), name,
+    ]))
+    offset += local.length
+  }
+  const central = Buffer.concat(centralParts)
+  return Buffer.concat([...localParts, central, Buffer.concat([
+    u32(0x06054b50), u16(0), u16(0), u16(files.length), u16(files.length), u32(central.length), u32(offset), u16(0),
+  ])])
+}
+
+async function readBinary(workspace: Workspace, path: string): Promise<Uint8Array> {
+  if (workspace.readBinaryFile) return await workspace.readBinaryFile(path)
+  return Buffer.from(await workspace.readFile(path), 'utf8')
+}
+
+async function resolveShare(opts: PublicShareRoutesOptions, token: string, reply: FastifyReply): Promise<PublicShareRecord | null> {
+  const share = await opts.getShare(token)
+  if (!share) {
+    reply.code(404).send({ error: 'share not found' })
+    return null
+  }
+  if (share.expiresAt && Date.parse(share.expiresAt) <= Date.now()) {
+    reply.code(410).send({ error: 'share expired' })
+    return null
+  }
+  if (share.kind !== 'markdown-review' || share.capabilities.renderMarkdown !== true) {
+    reply.code(501).send({ error: 'share kind not supported' })
+    return null
+  }
+  return share
+}
+
+export function registerPublicShareRoutes(
+  app: FastifyInstance,
+  opts: PublicShareRoutesOptions,
+  done: (err?: Error) => void,
+): void {
+  const securityHeaders = (reply: FastifyReply) => reply
+    .header('cache-control', 'no-store')
+    .header('x-content-type-options', 'nosniff')
+    .header('content-security-policy', "default-src 'none'; img-src 'self' data:; style-src 'unsafe-inline'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'")
+
+  if (!app.hasContentTypeParser('application/x-www-form-urlencoded')) {
+    app.addContentTypeParser('application/x-www-form-urlencoded', { parseAs: 'string' }, (_request, body, done) => {
+      done(null, body)
+    })
+  }
+
+  app.get('/share/:token/', async (request, reply) => {
+    const { token } = request.params as { token: string }
+    const share = await resolveShare(opts, token, reply)
+    if (!share) return
+    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
+    try {
+      const workspace = await opts.getWorkspace(share)
+      const markdown = await workspace.readFile(share.entryPath)
+      return securityHeaders(reply).type('text/html; charset=utf-8').send(renderMarkdownDocument(markdown, share))
+    } catch {
+      return reply.code(404).send({ error: 'share entry not found' })
+    }
+  })
+
+  app.get('/share/:token/meta', async (request, reply) => {
+    const { token } = request.params as { token: string }
+    const share = await resolveShare(opts, token, reply)
+    if (!share) return
+    return securityHeaders(reply).send({
+      token: share.token,
+      kind: share.kind,
+      entryPath: share.entryPath,
+      editable: share.capabilities.writeEntry === true,
+      downloads: {
+        portableMarkdown: `/share/${encodeURIComponent(share.token)}/portable.md`,
+        bundleZip: `/share/${encodeURIComponent(share.token)}/bundle.zip`,
+      },
+    })
+  })
+
+  app.get('/share/:token/raw', async (request, reply) => {
+    const { token } = request.params as { token: string }
+    const share = await resolveShare(opts, token, reply)
+    if (!share) return
+    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
+    try {
+      const workspace = await opts.getWorkspace(share)
+      return securityHeaders(reply).type('text/markdown; charset=utf-8').send(await workspace.readFile(share.entryPath))
+    } catch {
+      return reply.code(404).send({ error: 'share entry not found' })
+    }
+  })
+
+
+  app.get('/share/:token/portable.md', async (request, reply) => {
+    const { token } = request.params as { token: string }
+    const share = await resolveShare(opts, token, reply)
+    if (!share) return
+    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
+    try {
+      const workspace = await opts.getWorkspace(share)
+      const origin = `${request.protocol}://${request.host}`
+      const markdown = rewriteMarkdownAssetUrls(await workspace.readFile(share.entryPath), share, origin)
+      return securityHeaders(reply)
+        .header('content-disposition', `attachment; filename="${posix.basename(share.entryPath).replace(/"/g, '')}"`)
+        .type('text/markdown; charset=utf-8')
+        .send(markdown)
+    } catch {
+      return reply.code(404).send({ error: 'share entry not found' })
+    }
+  })
+
+  app.get('/share/:token/bundle.zip', async (request, reply) => {
+    const { token } = request.params as { token: string }
+    const share = await resolveShare(opts, token, reply)
+    if (!share) return
+    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
+    try {
+      const workspace = await opts.getWorkspace(share)
+      const markdown = rewriteMarkdownAssetUrlsForBundle(await workspace.readFile(share.entryPath), share)
+      const files: Array<{ name: string; data: Uint8Array }> = [{ name: share.entryPath, data: Buffer.from(markdown, 'utf8') }]
+      for (const path of share.capabilities.readFiles) {
+        if (path === share.entryPath) continue
+        files.push({ name: path, data: await readBinary(workspace, path) })
+      }
+      const zip = createStoredZip(files)
+      return securityHeaders(reply)
+        .header('content-disposition', `attachment; filename="${posix.basename(share.entryPath, extname(share.entryPath)) || 'share'}.zip"`)
+        .type('application/zip')
+        .header('content-length', String(zip.byteLength))
+        .send(zip)
+    } catch {
+      return reply.code(404).send({ error: 'share bundle not found' })
+    }
+  })
+
+  app.post('/share/:token/raw', async (request, reply) => {
+    const { token } = request.params as { token: string }
+    const share = await resolveShare(opts, token, reply)
+    if (!share) return
+    if (share.capabilities.writeEntry !== true) return reply.code(403).send({ error: 'share is read-only' })
+    if (!sharePathAllowed(share, share.entryPath)) return reply.code(404).send({ error: 'share entry not allowed' })
+    const body = request.body
+    const content = typeof body === 'string'
+      ? new URLSearchParams(body).get('content')
+      : typeof (body as { content?: unknown } | undefined)?.content === 'string'
+        ? (body as { content: string }).content
+        : null
+    if (content === null) return reply.code(400).send({ error: 'content is required' })
+    try {
+      const workspace = await opts.getWorkspace(share)
+      await workspace.writeFile(share.entryPath, content)
+      return reply.code(303).header('location', `/share/${encodeURIComponent(share.token)}/`).send()
+    } catch {
+      return reply.code(404).send({ error: 'share entry not found' })
+    }
+  })
+
+  app.get('/share/:token/api/v1/files/raw', async (request, reply) => {
+    const { token } = request.params as { token: string }
+    const query = request.query as Record<string, unknown>
+    const rawPath = typeof query.path === 'string' ? query.path : ''
+    const share = await resolveShare(opts, token, reply)
+    if (!share) return
+    const assetPath = normalizeWorkspacePath(rawPath)
+    if (!assetPath || !sharePathAllowed(share, assetPath)) {
+      return reply.code(404).send({ error: 'asset not found' })
+    }
+    try {
+      const workspace = await opts.getWorkspace(share)
+      const bytes = await readBinary(workspace, assetPath)
+      return securityHeaders(reply)
+        .type(contentTypeForPath(assetPath))
+        .header('content-length', String(bytes.byteLength))
+        .send(Buffer.from(bytes))
+    } catch {
+      return reply.code(404).send({ error: 'asset not found' })
+    }
+  })
+
+  app.get('/share/:token/assets/*', async (request, reply) => {
+    const params = request.params as { token: string; '*': string }
+    const share = await resolveShare(opts, params.token, reply)
+    if (!share) return
+    const assetPath = normalizeWorkspacePath(params['*'])
+    if (!assetPath || !sharePathAllowed(share, assetPath) || assetPath === share.entryPath) {
+      return reply.code(404).send({ error: 'asset not found' })
+    }
+    try {
+      const workspace = await opts.getWorkspace(share)
+      const bytes = await readBinary(workspace, assetPath)
+      return securityHeaders(reply)
+        .type(contentTypeForPath(assetPath))
+        .header('content-length', String(bytes.byteLength))
+        .send(Buffer.from(bytes))
+    } catch {
+      return reply.code(404).send({ error: 'asset not found' })
+    }
+  })
+
+  done()
+}

--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -62,6 +62,13 @@ export type {
 // the whole agent app. Used by workspace's FetchClient ↔ server contract tests.
 export { fileRoutes } from './http/routes/file'
 export {
+  collectMarkdownAssetPaths,
+  createMarkdownReviewShare,
+  registerPublicShareRoutes,
+  type PublicShareRecord,
+  type PublicShareCapabilities,
+} from './http/routes/publicShare'
+export {
   provisionRuntimeWorkspace,
   type ProvisionRuntimeWorkspaceOptions,
   type RuntimeWorkspaceProvisioningResult,

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -50,11 +50,20 @@ boring-ui workspaces add <folder>       Register a folder as a saved workspace
 boring-ui workspaces list               List saved workspaces
 boring-ui workspaces remove <id>        Remove a saved workspace
 boring-ui workspaces rename <id> <name> Rename a saved workspace
+boring-ui share <file> [options]        Share one Markdown file for external review
 boring-ui plugin <subcommand> …         Plugin authoring (delegates to boring-ui-plugin)
 ```
 
 `boring-ui plugin …` forwards to `@hachej/boring-ui-plugin-cli`; run
 `boring-ui plugin` with no subcommand for its usage.
+
+`boring-ui share <file>` starts a narrow public review surface for one Markdown file:
+
+```bash
+boring-ui share docs/review.md --assets --allow-edit
+```
+
+It exposes review/editor, raw Markdown, portable Markdown, image assets, and a ZIP bundle for the selected file only. Editing is disabled unless `--allow-edit` is set.
 
 ### Options
 
@@ -63,6 +72,10 @@ boring-ui plugin <subcommand> …         Plugin authoring (delegates to boring-
 | `-p, --port <port>` | `5200` (or `$PORT`) | HTTP port |
 | `--host <host>` | `127.0.0.1` (or `$HOST`) | Listen host. Non-loopback hosts require `--allow-insecure-local-bridge` because the standalone CLI uses unauthenticated local-only bridge browser auth. |
 | `-m, --mode <mode>` | `local` | `local` (no sandbox, full network) or `local-sandbox` (bwrap-isolated, no network, Linux only) |
+| `--assets` | off | Include local Markdown image dependencies in share mode |
+| `--allow-edit` | off | Let anyone with the share URL edit the Markdown file |
+| `--expires <time>` | none | Expire a share after a duration such as `30m`, `1h`, or `7d` |
+| `--no-open` | off | Do not open the browser after starting a share |
 | `-h, --help` | | Show help |
 
 ### Environment variables

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -51,6 +51,16 @@ export function workspaceIdFromCliUrl(pathname: string): string | null {
   }
 }
 
+export function shareTokenFromCliUrl(pathname: string): string | null {
+  const match = pathname.match(/^\/share\/([^/?#]+)\/editor\/?$/)
+  if (!match?.[1]) return null
+  try {
+    return decodeURIComponent(match[1])
+  } catch {
+    return match[1]
+  }
+}
+
 const CHAT_SESSION_QUERY_PARAM = "session"
 
 // Read-only, for backward compatibility with legacy deep links. The workspace
@@ -112,6 +122,9 @@ export function CliVersionBadge({ version }: { version?: string | null }) {
 }
 
 export function CliWorkspaceShell() {
+  const shareToken = shareTokenFromCliUrl(window.location.pathname)
+  if (shareToken) return <WorkspaceSingleton.PublicMarkdownReviewApp token={shareToken} />
+
   const [projectName, setProjectName] = useState("Workspace")
   const [workspacesMode, setWorkspacesMode] = useState(false)
   const [cliVersion, setCliVersion] = useState<string | null>(null)

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -123,7 +123,7 @@ export function CliVersionBadge({ version }: { version?: string | null }) {
 
 export function CliWorkspaceShell() {
   const shareToken = shareTokenFromCliUrl(window.location.pathname)
-  if (shareToken) return <WorkspaceSingleton.PublicMarkdownReviewApp token={shareToken} />
+  if (shareToken) return <WorkspaceSingleton.PublicShareApp token={shareToken} />
 
   const [projectName, setProjectName] = useState("Workspace")
   const [workspacesMode, setWorkspacesMode] = useState(false)

--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -8,12 +8,13 @@ import type {
   WorkspaceProvisioningResult,
 } from "@hachej/boring-agent/server"
 import { execSync } from "node:child_process"
+import { randomBytes } from "node:crypto"
 import {
   existsSync,
   readFileSync,
 } from "node:fs"
 import { createRequire } from "node:module"
-import { basename, isAbsolute, join, resolve } from "node:path"
+import { basename, isAbsolute, join, relative, resolve } from "node:path"
 import { parseArgs } from "node:util"
 import { createLocalWorkspaceRegistry, type LocalWorkspace } from "./localWorkspaces.js"
 import type {
@@ -110,6 +111,7 @@ const HELP_TEXT = [
   "",
   "Commands:",
   "  boring-ui [workspace]                 Start the workspace UI for a folder",
+  "  boring-ui share <file>                Share one Markdown file for review",
   "  boring-ui workspaces <subcommand>     Manage saved local workspaces",
   "  boring-ui plugin <subcommand>         Install, list, and remove plugin sources",
   "",
@@ -118,6 +120,10 @@ const HELP_TEXT = [
   "      --host <host>       Listen host (default: 127.0.0.1)",
   "      --allow-insecure-local-bridge",
   "                            Allow unauthenticated local-cli bridge auth when binding a non-loopback host",
+  "      --assets            Include local Markdown image dependencies in share mode",
+  "      --allow-edit        Let anyone with the share URL edit the Markdown file",
+  "      --expires <time>    Expire share after duration (for example: 1h, 24h, 7d)",
+  "      --no-open           Do not open the browser",
   "  -m, --mode <mode>       local-sandbox or local (default: local)",
   "  -h, --help              Show this help",
 ].join("\n")
@@ -221,6 +227,69 @@ async function startWorkspacesMode(opts: {
   openBrowser(initialUrl)
 }
 
+function parseShareExpiry(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  const match = value.trim().match(/^(\d+)(m|h|d)$/i)
+  if (!match) throw new Error('invalid --expires. Use a duration like 30m, 1h, or 7d.')
+  const amount = Number(match[1])
+  const unit = match[2].toLowerCase()
+  const multiplier = unit === 'm' ? 60_000 : unit === 'h' ? 3_600_000 : 86_400_000
+  return new Date(Date.now() + amount * multiplier).toISOString()
+}
+
+async function startShareMode(opts: {
+  fileArg?: string
+  publicDir: string
+  port: number
+  host: string
+  includeAssets: boolean
+  allowEdit: boolean
+  expires?: string
+  open?: boolean
+}) {
+  if (!opts.fileArg) throw new Error('usage: boring-ui share <markdown-file> [--assets] [--allow-edit]')
+  const workspaceRoot = resolve(process.cwd())
+  const targetPath = resolve(opts.fileArg)
+  const entryPath = relative(workspaceRoot, targetPath).replace(/\\/g, '/')
+  if (!entryPath || entryPath.startsWith('..') || isAbsolute(entryPath)) {
+    throw new Error('shared file must be inside the current workspace')
+  }
+  if (!existsSync(targetPath)) throw new Error(`shared file not found: ${opts.fileArg}`)
+  const markdown = readFileSync(targetPath, 'utf8')
+  const token = `s_${randomBytes(18).toString('base64url')}`
+  const agent = await import('@hachej/boring-agent/server')
+  const { default: Fastify } = await import('fastify')
+  const workspace = agent.createNodeWorkspace(workspaceRoot)
+  const share = agent.createMarkdownReviewShare({
+    token,
+    entryPath,
+    markdown,
+    title: basename(targetPath),
+    includeAssets: opts.includeAssets,
+    allowEdit: opts.allowEdit,
+    expiresAt: parseShareExpiry(opts.expires),
+  })
+  const app = Fastify({ logger: false, bodyLimit: 2 * 1024 * 1024 })
+  await app.register(agent.registerPublicShareRoutes, {
+    getShare: (candidate: string) => candidate === token ? share : undefined,
+    getWorkspace: () => workspace,
+  })
+  app.get('/health', async () => ({ ok: true }))
+  await registerStatic(app, opts.publicDir)
+  await app.listen({ port: opts.port, host: opts.host })
+  const url = `http://localhost:${opts.port}/share/${encodeURIComponent(token)}/`
+  console.log(`\nShared Markdown review`)
+  console.log(`  file       ${entryPath}`)
+  console.log(`  mode       ${opts.allowEdit ? 'public edit' : 'read-only'}`)
+  console.log(`  assets     ${opts.includeAssets ? 'included' : 'off'}`)
+  if (share.expiresAt) console.log(`  expires    ${share.expiresAt}`)
+  console.log(`\n  review     ${url}`)
+  console.log(`  editor     ${url}editor`)
+  console.log(`  markdown   ${url}portable.md`)
+  console.log(`  bundle     ${url}bundle.zip\n`)
+  if (opts.open !== false) openBrowser(url)
+}
+
 async function handleWorkspacesCommand(opts: {
   args: { name?: string }
   positionals: string[]
@@ -289,6 +358,10 @@ export async function runCli(options: RunCliOptions): Promise<void> {
       "panel-id": { type: "string" as const },
       "timeout-ms": { type: "string" as const },
       "allow-insecure-local-bridge": { type: "boolean" as const },
+      assets: { type: "boolean" as const },
+      expires: { type: "string" as const },
+      "allow-edit": { type: "boolean" as const },
+      "no-open": { type: "boolean" as const },
       help: { type: "boolean", short: "h" },
     },
     allowPositionals: true,
@@ -337,6 +410,20 @@ export async function runCli(options: RunCliOptions): Promise<void> {
     allowInsecureLocalBridgeAuth,
   }
 
+
+  if (positionals[0] === "share") {
+    await startShareMode({
+      fileArg: positionals[1],
+      publicDir: options.publicDir,
+      port,
+      host,
+      includeAssets: args.assets === true,
+      allowEdit: args["allow-edit"] === true,
+      expires: args.expires as string | undefined,
+      open: args["no-open"] !== true,
+    })
+    return
+  }
 
   if (positionals[0] === "workspaces") {
     await handleWorkspacesCommand({

--- a/packages/workspace/src/front/public-share/PublicMarkdownReviewApp.tsx
+++ b/packages/workspace/src/front/public-share/PublicMarkdownReviewApp.tsx
@@ -12,13 +12,25 @@ export interface PublicMarkdownReviewAppProps {
   autosaveDelayMs?: number
 }
 
+interface PublicShareDownloadLink {
+  href?: string
+}
+
 interface PublicShareMeta {
   entryPath?: string
   editable?: boolean
-  downloads?: {
-    portableMarkdown?: string
-    bundleZip?: string
+  links?: {
+    downloads?: Record<string, string>
   }
+  downloads?: {
+    portableMarkdown?: string | PublicShareDownloadLink
+    bundleZip?: string | PublicShareDownloadLink
+  }
+}
+
+function downloadHref(value: string | PublicShareDownloadLink | undefined, fallback: string): string {
+  if (typeof value === "string") return value
+  return value?.href ?? fallback
 }
 
 export function PublicMarkdownReviewApp({
@@ -50,7 +62,11 @@ export function PublicMarkdownReviewApp({
       .then(([meta, text]) => {
         if (cancelled) return
         setEntryPath(meta.entryPath ?? "review.md")
-        setDownloads(meta.downloads ?? {})
+        setDownloads({
+          ...meta.downloads,
+          portableMarkdown: meta.downloads?.portableMarkdown ?? meta.links?.downloads?.portableMarkdown,
+          bundleZip: meta.downloads?.bundleZip ?? meta.links?.downloads?.bundleZip,
+        })
         setContent(text)
         setSavedContent(text)
         setError(null)
@@ -93,8 +109,8 @@ export function PublicMarkdownReviewApp({
     return () => window.clearTimeout(timer)
   }, [autosaveDelayMs, dirty, loading, save, saving])
 
-  const portableMarkdownHref = downloads?.portableMarkdown ?? `${shareBaseUrl}/portable.md`
-  const bundleZipHref = downloads?.bundleZip ?? `${shareBaseUrl}/bundle.zip`
+  const portableMarkdownHref = downloadHref(downloads?.portableMarkdown, `${shareBaseUrl}/portable.md`)
+  const bundleZipHref = downloadHref(downloads?.bundleZip, `${shareBaseUrl}/bundle.zip`)
 
   return (
     <WorkspaceFilesProvider apiBaseUrl={shareBaseUrl} fileEvents={false}>

--- a/packages/workspace/src/front/public-share/PublicMarkdownReviewApp.tsx
+++ b/packages/workspace/src/front/public-share/PublicMarkdownReviewApp.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { MarkdownEditor } from "../../plugins/filesystemPlugin/front/markdown-editor/MarkdownEditor"
+import { DataProvider as WorkspaceFilesProvider } from "../../plugins/filesystemPlugin/front/data"
+
+export interface PublicMarkdownReviewAppProps {
+  token: string
+  /** Base URL for share routes. Defaults to `/share/<token>`. */
+  shareBaseUrl?: string
+  /** Idle delay before writing changed Markdown back to the share endpoint. */
+  autosaveDelayMs?: number
+}
+
+interface PublicShareMeta {
+  entryPath?: string
+  editable?: boolean
+  downloads?: {
+    portableMarkdown?: string
+    bundleZip?: string
+  }
+}
+
+export function PublicMarkdownReviewApp({
+  token,
+  shareBaseUrl = `/share/${encodeURIComponent(token)}`,
+  autosaveDelayMs = 900,
+}: PublicMarkdownReviewAppProps) {
+  const [content, setContent] = useState("")
+  const [savedContent, setSavedContent] = useState("")
+  const [entryPath, setEntryPath] = useState("review.md")
+  const [downloads, setDownloads] = useState<PublicShareMeta["downloads"]>({})
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    Promise.all([
+      fetch(`${shareBaseUrl}/meta`).then(async (res) => {
+        if (!res.ok) throw new Error(await res.text())
+        return await res.json() as PublicShareMeta
+      }),
+      fetch(`${shareBaseUrl}/raw`).then(async (res) => {
+        if (!res.ok) throw new Error(await res.text())
+        return await res.text()
+      }),
+    ])
+      .then(([meta, text]) => {
+        if (cancelled) return
+        setEntryPath(meta.entryPath ?? "review.md")
+        setDownloads(meta.downloads ?? {})
+        setContent(text)
+        setSavedContent(text)
+        setError(null)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load document")
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => { cancelled = true }
+  }, [shareBaseUrl])
+
+  const save = useCallback(async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch(`${shareBaseUrl}/raw`, {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ content }).toString(),
+        redirect: "manual",
+      })
+      if (res.status !== 303 && !res.ok) throw new Error(await res.text())
+      setSavedContent(content)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save document")
+    } finally {
+      setSaving(false)
+    }
+  }, [content, shareBaseUrl])
+
+  const dirty = content !== savedContent
+
+  useEffect(() => {
+    if (loading || !dirty || saving) return
+    const timer = window.setTimeout(() => {
+      void save()
+    }, autosaveDelayMs)
+    return () => window.clearTimeout(timer)
+  }, [autosaveDelayMs, dirty, loading, save, saving])
+
+  const portableMarkdownHref = downloads?.portableMarkdown ?? `${shareBaseUrl}/portable.md`
+  const bundleZipHref = downloads?.bundleZip ?? `${shareBaseUrl}/bundle.zip`
+
+  return (
+    <WorkspaceFilesProvider apiBaseUrl={shareBaseUrl} fileEvents={false}>
+      <div className="min-h-screen bg-background text-foreground">
+        <header className="flex items-center justify-between border-b border-border px-4 py-3">
+          <div>
+            <div className="text-sm font-semibold">Public Markdown review</div>
+            <div className="text-xs text-muted-foreground">Constrained share editor</div>
+          </div>
+          <div className="flex items-center gap-2 text-xs">
+            {saving ? <span className="text-muted-foreground">Saving…</span> : dirty ? <span className="text-amber-600">Unsaved changes</span> : <span className="text-muted-foreground">Saved</span>}
+            <a className="rounded-md border border-border px-3 py-1.5" href={bundleZipHref}>Download ZIP</a>
+            <a className="rounded-md border border-border px-3 py-1.5" href={portableMarkdownHref}>Portable MD</a>
+            <button className="rounded-md bg-primary px-3 py-1.5 text-primary-foreground disabled:opacity-50" onClick={save} disabled={saving || loading || !dirty}>
+              {saving ? "Saving…" : "Save"}
+            </button>
+          </div>
+        </header>
+        {error ? <div className="m-4 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">{error}</div> : null}
+        {loading ? (
+          <div className="p-8 text-sm text-muted-foreground">Loading document…</div>
+        ) : (
+          <div className="mx-auto max-w-5xl p-4">
+            <div style={{ height: "calc(100vh - 96px)" }}>
+              <MarkdownEditor content={content} onChange={setContent} documentPath={entryPath} className="h-full overflow-hidden rounded-xl border border-border" />
+            </div>
+          </div>
+        )}
+      </div>
+    </WorkspaceFilesProvider>
+  )
+}

--- a/packages/workspace/src/front/public-share/PublicShareApp.tsx
+++ b/packages/workspace/src/front/public-share/PublicShareApp.tsx
@@ -1,0 +1,52 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { PublicMarkdownReviewApp } from "./PublicMarkdownReviewApp"
+
+export interface PublicShareAppProps {
+  token: string
+  /** Base URL for share routes. Defaults to `/share/<token>`. */
+  shareBaseUrl?: string
+}
+
+interface PublicShareMeta {
+  kind?: string
+  appId?: string
+}
+
+export function PublicShareApp({ token, shareBaseUrl = `/share/${encodeURIComponent(token)}` }: PublicShareAppProps) {
+  const [meta, setMeta] = useState<PublicShareMeta | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    fetch(`${shareBaseUrl}/meta`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(await res.text())
+        return await res.json() as PublicShareMeta
+      })
+      .then((nextMeta) => {
+        if (cancelled) return
+        setMeta(nextMeta)
+        setError(null)
+      })
+      .catch((err) => {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load share")
+      })
+    return () => { cancelled = true }
+  }, [shareBaseUrl])
+
+  if (error) {
+    return <div className="min-h-screen bg-background p-6 text-sm text-destructive">{error}</div>
+  }
+  if (!meta) {
+    return <div className="min-h-screen bg-background p-6 text-sm text-muted-foreground">Loading share…</div>
+  }
+
+  const appId = meta.appId ?? meta.kind
+  if (appId === "markdown-review") {
+    return <PublicMarkdownReviewApp token={token} shareBaseUrl={shareBaseUrl} />
+  }
+
+  return <div className="min-h-screen bg-background p-6 text-sm text-destructive">Unsupported public share app: {appId ?? "unknown"}</div>
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -369,3 +369,6 @@ export type {
   Notification,
   SidebarState,
 } from "./front/store/types"
+
+export { PublicMarkdownReviewApp } from './front/public-share/PublicMarkdownReviewApp'
+export type { PublicMarkdownReviewAppProps } from './front/public-share/PublicMarkdownReviewApp'

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -370,5 +370,7 @@ export type {
   SidebarState,
 } from "./front/store/types"
 
+export { PublicShareApp } from './front/public-share/PublicShareApp'
+export type { PublicShareAppProps } from './front/public-share/PublicShareApp'
 export { PublicMarkdownReviewApp } from './front/public-share/PublicMarkdownReviewApp'
 export type { PublicMarkdownReviewAppProps } from './front/public-share/PublicMarkdownReviewApp'

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/DataProvider.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/DataProvider.tsx
@@ -12,6 +12,8 @@ interface DataProviderProps {
   onAuthError?: (statusCode: number) => void
   timeout?: number
   client?: FetchClient
+  /** Disable workspace file-event streams for constrained public/share surfaces. */
+  fileEvents?: boolean
   children: ReactNode
 }
 
@@ -43,6 +45,7 @@ export function DataProvider({
   onAuthError,
   timeout,
   client: providedClient,
+  fileEvents = true,
   children,
 }: DataProviderProps) {
   const queryClientRef = useRef<QueryClient | null>(null)
@@ -71,7 +74,7 @@ export function DataProvider({
       <ApiBaseUrlContext.Provider value={apiBaseUrl}>
         <WorkspaceRequestIdContext.Provider value={workspaceRequestId}>
           <FetchClientContext.Provider value={client}>
-            <FileEventInvalidationMount />
+            {fileEvents ? <FileEventInvalidationMount /> : null}
             {children}
           </FetchClientContext.Provider>
         </WorkspaceRequestIdContext.Provider>


### PR DESCRIPTION
Closes #421.\n\nAdds a constrained public share surface for a single Markdown file, with reusable agent routes and a workspace-level review app instead of burying the editor in the CLI.\n\n## What changed\n- Adds reusable public share route registration in @hachej/boring-agent.\n- Adds CLI command: `boring-ui share <file> --assets --allow-edit`.\n- Adds workspace-exported `PublicMarkdownReviewApp` that reuses the real Markdown editor surface and disables file event streaming for public/constrained use.\n- Supports raw, portable Markdown, image assets, and ZIP bundle downloads.\n\n## Validation\n- ✅ `pnpm --filter @hachej/boring-agent test --run src/server/http/routes/__tests__/publicShare.test.ts`\n- ✅ `pnpm --filter @hachej/boring-agent build`\n- ✅ `pnpm --filter @hachej/boring-workspace build`\n- ✅ `pnpm --filter @hachej/boring-ui-cli build:front`\n- ✅ `pnpm --filter @hachej/boring-ui-cli build`\n- ⚠️ `pnpm --filter @hachej/boring-ui-cli typecheck` currently fails on pre-existing clean-main issues in `src/server/pluginFrontRuntime.ts` (missing `cjs-module-lexer` types and `Promise<void> | undefined`).