### PR TITLE
mcp-integration: Add boring-mcp source handler contracts

### DIFF
--- a/plugins/boring-mcp/src/__tests__/sourceHandlers.test.ts
+++ b/plugins/boring-mcp/src/__tests__/sourceHandlers.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest"
+import { createBoringMcpSourceHandlers } from "../server"
+import {
+  MCP_ERROR_CODES,
+  type McpActor,
+  type McpSource,
+  type McpSourceRegistry,
+  type McpTransportClient,
+} from "../shared"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+
+function makeSource(overrides: Partial<McpSource> = {}): McpSource {
+  return {
+    id: "source:notion:user-1",
+    workspaceId: actor.workspaceId,
+    userId: actor.userId,
+    provider: "notion",
+    displayName: "Notion",
+    status: "connected",
+    ownerKind: "user",
+    credentialProvider: "provider-managed",
+    ...overrides,
+  }
+}
+
+function makeRegistry(source = makeSource()): McpSourceRegistry {
+  let current = source
+  return {
+    async listSources(requestActor) {
+      return requestActor.userId === current.userId && requestActor.workspaceId === current.workspaceId ? [current] : []
+    },
+    async getSource(sourceId) {
+      return sourceId === current.id ? current : undefined
+    },
+    async disconnectSource(requestActor, sourceId) {
+      if (sourceId !== current.id || requestActor.userId !== current.userId || requestActor.workspaceId !== current.workspaceId) return undefined
+      current = { ...current, status: "unconfigured", updatedAt: "2026-01-01T00:00:00.000Z" }
+      return current
+    },
+  }
+}
+
+function makeTransport(): McpTransportClient {
+  return {
+    listTools: vi.fn(async () => [{ name: "NOTION_SEARCH_NOTION_PAGE" }, { name: "update_page" }]),
+    listResources: vi.fn(async () => []),
+    readResource: vi.fn(),
+    callTool: vi.fn(),
+  }
+}
+
+describe("boring-mcp source handlers", () => {
+  it("lists secret-free source DTOs", async () => {
+    const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport: makeTransport() })
+    const result = await handlers.listSources(actor)
+
+    expect(result.sources).toEqual([
+      expect.objectContaining({ id: "source:notion:user-1", provider: "notion", credentialProvider: "provider-managed" }),
+    ])
+    expect(result.sources[0]).not.toHaveProperty("tokenRef")
+    expect(result.sources[0]).not.toHaveProperty("sessionHeaders")
+  })
+
+  it("returns status only for the owning actor", async () => {
+    const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport: makeTransport() })
+
+    await expect(handlers.getSourceStatus(actor, "source:notion:user-1")).resolves.toMatchObject({
+      source: { id: "source:notion:user-1" },
+      connectable: true,
+      canProbe: true,
+      canDisconnect: true,
+    })
+    await expect(handlers.getSourceStatus({ ...actor, userId: "user-2" }, "source:notion:user-1")).rejects.toMatchObject({
+      code: MCP_ERROR_CODES.SOURCE_NOT_FOUND,
+    })
+  })
+
+  it("probes through the facade and classifies tools", async () => {
+    const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport: makeTransport() })
+    const result = await handlers.probeSource(actor, " source:notion:user-1 ")
+
+    expect(result.tools).toEqual([
+      expect.objectContaining({ name: "NOTION_SEARCH_NOTION_PAGE", decision: expect.objectContaining({ allowed: true }) }),
+      expect.objectContaining({ name: "update_page", decision: expect.objectContaining({ allowed: false }) }),
+    ])
+  })
+
+  it("does not call disconnect on unowned sources", async () => {
+    const registry = makeRegistry()
+    const disconnect = vi.spyOn(registry, "disconnectSource")
+    const handlers = createBoringMcpSourceHandlers({ registry, transport: makeTransport() })
+
+    await expect(handlers.disconnectSource({ ...actor, userId: "user-2" }, "source:notion:user-1")).rejects.toMatchObject({
+      code: MCP_ERROR_CODES.SOURCE_NOT_FOUND,
+    })
+    expect(disconnect).not.toHaveBeenCalled()
+  })
+
+  it("disconnects through the injected registry without provider execution", async () => {
+    const transport = makeTransport()
+    const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport })
+    const result = await handlers.disconnectSource(actor, "source:notion:user-1")
+
+    expect(result).toMatchObject({ source: { status: "unconfigured" }, canDisconnect: false })
+    expect(transport.callTool).not.toHaveBeenCalled()
+  })
+})

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -14,4 +14,5 @@ export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPlugin
 }
 
 export default createBoringMcpServerPlugin()
+export * from "./sourceHandlers"
 export * from "../shared"

--- a/plugins/boring-mcp/src/server/sourceHandlers.ts
+++ b/plugins/boring-mcp/src/server/sourceHandlers.ts
@@ -1,0 +1,90 @@
+import {
+  MCP_ERROR_CODES,
+  McpAccessFacade,
+  McpError,
+  toMcpSourceDto,
+  type McpActor,
+  type McpProbeResult,
+  type McpSource,
+  type McpSourceDto,
+  type McpSourceRegistry,
+  type McpSourceStatusPayload,
+  type McpTransportClient,
+} from "../shared"
+
+export interface BoringMcpSourceHandlersOptions {
+  registry: McpSourceRegistry
+  transport: McpTransportClient
+}
+
+export interface BoringMcpSourceHandlers {
+  listSources(actor: McpActor): Promise<{ sources: McpSourceDto[] }>
+  getSourceStatus(actor: McpActor, sourceId: string): Promise<McpSourceStatusPayload>
+  probeSource(actor: McpActor, sourceId: string): Promise<McpProbeResult>
+  disconnectSource(actor: McpActor, sourceId: string): Promise<McpSourceStatusPayload>
+}
+
+const SOURCE_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,160}$/
+
+function validateSourceId(sourceId: string): string {
+  const trimmed = sourceId.trim()
+  if (!SOURCE_ID_PATTERN.test(trimmed)) {
+    throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
+  }
+  return trimmed
+}
+
+function isOwnedSource(actor: McpActor, source: McpSource | undefined): source is McpSource {
+  return Boolean(source && source.workspaceId === actor.workspaceId && source.userId === actor.userId)
+}
+
+async function requireOwnedSource(registry: McpSourceRegistry, actor: McpActor, sourceId: string): Promise<McpSource> {
+  const source = await registry.getSource(validateSourceId(sourceId))
+  if (!isOwnedSource(actor, source)) {
+    throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
+  }
+  return source
+}
+
+function statusPayload(source: McpSource): McpSourceStatusPayload {
+  return {
+    source: toMcpSourceDto(source),
+    connectable: source.credentialProvider === "provider-managed" || source.credentialProvider === "app-managed",
+    canProbe: source.status !== "revoked",
+    canDisconnect: source.status !== "unconfigured" && source.status !== "revoked",
+  }
+}
+
+export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOptions): BoringMcpSourceHandlers {
+  const facade = new McpAccessFacade({ store: options.registry, transport: options.transport })
+
+  return {
+    async listSources(actor) {
+      const sources = await options.registry.listSources(actor)
+      return { sources: sources.map(toMcpSourceDto) }
+    },
+
+    async getSourceStatus(actor, sourceId) {
+      const source = await requireOwnedSource(options.registry, actor, sourceId)
+      return statusPayload(source)
+    },
+
+    async probeSource(actor, sourceId) {
+      const normalizedSourceId = validateSourceId(sourceId)
+      return facade.probeSource(actor, normalizedSourceId)
+    },
+
+    async disconnectSource(actor, sourceId) {
+      const normalizedSourceId = validateSourceId(sourceId)
+      await requireOwnedSource(options.registry, actor, normalizedSourceId)
+      if (!options.registry.disconnectSource) {
+        throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source disconnect is not configured")
+      }
+      const source = await options.registry.disconnectSource(actor, normalizedSourceId)
+      if (!isOwnedSource(actor, source)) {
+        throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
+      }
+      return statusPayload(source)
+    },
+  }
+}

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -140,6 +140,33 @@ export interface McpSourceStore {
   getSource(sourceId: string): Promise<McpSource | undefined>
 }
 
+export interface McpSourceRegistry extends McpSourceStore {
+  disconnectSource?(actor: McpActor, sourceId: string): Promise<McpSource | undefined>
+}
+
+export interface McpSourceStatusPayload {
+  source: McpSourceDto
+  connectable: boolean
+  canProbe: boolean
+  canDisconnect: boolean
+}
+
+export function toMcpSourceDto(source: McpSource): McpSourceDto {
+  return {
+    id: source.id,
+    provider: source.provider,
+    displayName: source.displayName,
+    status: source.status,
+    ownerKind: source.ownerKind,
+    credentialProvider: source.credentialProvider,
+    scopes: source.scopes,
+    providerAccountLabel: source.providerAccountLabel,
+    lastVerifiedAt: source.lastVerifiedAt,
+    createdAt: source.createdAt,
+    updatedAt: source.updatedAt,
+  }
+}
+
 export interface McpTransportClient {
   listTools(source: McpSource): Promise<McpDiscoveredTool[]>
   listResources(source: McpSource): Promise<McpDiscoveredResource[]>


### PR DESCRIPTION
## Summary

PR 2 for issue #416, stacked on #423.

Adds reusable boring-mcp source management handler contracts:

- source registry contract extension
- secret-free source DTO mapper/status payload
- reusable list/status/probe/disconnect handlers
- actor/workspace ownership checks before source access
- no Fastify/app-runtime coupling
- no real provider calls/OAuth/secrets
- tests for list/status/probe/disconnect/cross-user denial

## Review-size cap

```txt
118 / 900 non-test/non-doc added lines
```

## Validation

```txt
git diff --check: pass
pnpm --filter @hachej/boring-mcp test: pass, 11 tests
pnpm --filter @hachej/boring-mcp typecheck: pass
pnpm --filter @hachej/boring-mcp build: pass
thermo-nuclear review: GREEN after one RED fix loop
```

## Thermo loop

Pass 1: RED
- fixed disconnect ownership: require owned source before registry mutation
- fixed probe normalization: pass trimmed/validated source id into facade

Pass 2: GREEN