### PR TITLE
mcp-integration: Add boring-mcp connector security preflight

### DIFF
--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -41,7 +41,7 @@ Apps may also list the package in `package.json#boring.defaultPluginPackages`, b
 
 ## Security boundaries
 
-Managed connector adapters must pass the [Composio security preflight](./docs/composio-security-preflight.md) before real product provider calls.
+Managed connector adapters must pass the [Composio security preflight](./docs/composio-security-preflight.md) and the executable `validateManagedConnectorPreflight` server check before real product provider calls.
 
 - Browser UI never receives provider OAuth tokens, connector API keys, or MCP session headers.
 - Raw provider meta-tools are not exposed by this foundation.

--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -41,6 +41,8 @@ Apps may also list the package in `package.json#boring.defaultPluginPackages`, b
 
 ## Security boundaries
 
+Managed connector adapters must pass the [Composio security preflight](./docs/composio-security-preflight.md) before real product provider calls.
+
 - Browser UI never receives provider OAuth tokens, connector API keys, or MCP session headers.
 - Raw provider meta-tools are not exposed by this foundation.
 - Unknown tools are disabled by default.

--- a/plugins/boring-mcp/docs/composio-security-preflight.md
+++ b/plugins/boring-mcp/docs/composio-security-preflight.md
@@ -1,0 +1,69 @@
+# Composio security preflight
+
+This checklist gates any boring-mcp implementation that talks to Composio or another managed connector provider.
+
+The foundation plugin is provider-neutral. A Composio adapter may only land after this checklist is green for the target app/environment, or after the owner explicitly accepts the named gaps for a non-production spike.
+
+## Required before product provider calls
+
+- [ ] The Composio project/account used by the app is isolated from unrelated production data.
+- [ ] `COMPOSIO_API_KEY` is resolved server-side only.
+- [ ] The key is stored in an app-approved secret backend such as server environment, Vault, KMS, or another server-only secret store.
+- [ ] The key is never exposed to browser bundles, workspace files, agent prompts, session transcripts, audit payloads, or logs.
+- [ ] MCP session headers are treated as secret material.
+- [ ] Provider OAuth codes, provider access tokens, refresh tokens, cookies, and raw connected-account secrets are never returned to browser or agent tools.
+- [ ] Browser DTOs for connect/status/probe/search/describe contain only secret-free source/tool/status summaries.
+- [ ] Log redaction covers connector API keys, MCP session headers, OAuth codes, bearer tokens, cookies, and seeded canary strings.
+- [ ] Provider result/error redaction is tested with seeded canaries before agent/browser output.
+- [ ] Revoke/disconnect and connected-account status behavior is verified for each live provider slice.
+- [ ] Data residency, subprocessors, DPA/security review, and incident-history risk are accepted for production use, or the work is explicitly marked non-production.
+
+## Adapter implementation rules
+
+A managed connector adapter must keep these boundaries:
+
+```txt
+browser/UI       → boring-mcp app-owned endpoints only
+agent tools      → boring-mcp bridge tools only
+boring-mcp       → connector provider through server-only adapter
+connector secret → server-only resolver, never DTO/log/prompt/workspace file
+```
+
+Forbidden in adapter PRs:
+
+```txt
+raw connector API key in front/shared code
+raw MCP session headers in browser DTOs
+raw provider OAuth token in source/tool DTOs
+raw connector meta-tools exposed as agent tools
+provider execution before deny-before-allow policy passes
+```
+
+## PR evidence template
+
+Every managed connector PR must include:
+
+```txt
+Secret resolver used:
+Secret values printed/logged: no
+Browser DTO contains session headers/tokens: no
+Canary redaction test: pass
+Disconnect/revoke status checked: pass or accepted gap
+DPA/security/subprocessor status: accepted / non-production only / blocked
+Line cap output: <n> / <cap>
+Thermo review: GREEN
+```
+
+## Owner acceptance for temporary gaps
+
+For non-production spikes, a gap may be accepted only when the PR states:
+
+```txt
+accepted gap:
+owner:
+reason:
+expiration / follow-up PR:
+production blocked until resolved: yes/no
+```
+
+Production launch cannot depend on unresolved gaps unless explicitly accepted by the owner in the launch PR.

--- a/plugins/boring-mcp/src/__tests__/managedConnectorPreflight.test.ts
+++ b/plugins/boring-mcp/src/__tests__/managedConnectorPreflight.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest"
+import { MCP_ERROR_CODES, McpError } from "../shared"
+import { assertManagedConnectorPreflight, validateManagedConnectorPreflight, type ManagedConnectorPreflightEvidence } from "../server/managedConnectorPreflight"
+
+const cleanEvidence: ManagedConnectorPreflightEvidence = {
+  connectorName: "composio-test",
+  isolatedTestProject: true,
+  apiKeyStorage: "server-vault",
+  browserDtoSamples: [{ sourceId: "source-1", status: "connected", providerAccountLabel: "demo@example.com" }],
+  redactedLogSamples: [{ message: "connected", authorization: "[REDACTED_MCP_SECRET]" }],
+  redactedProviderResultSamples: [{ content: "ok", session_headers: "[REDACTED_MCP_SECRET]" }],
+  redactionCanaries: ["COMPOSIO_CANARY_DO_NOT_LEAK_123"],
+  revokeDisconnectVerified: true,
+  connectedAccountStatusVerified: true,
+  vendorRisk: {
+    dpaStatus: "approved",
+    subprocessorStatus: "approved",
+    dataResidencyStatus: "approved",
+    incidentHistoryStatus: "approved",
+  },
+}
+
+describe("managed connector preflight", () => {
+  it("passes only when every connector security gate has evidence", () => {
+    const result = validateManagedConnectorPreflight(cleanEvidence)
+
+    expect(result.ok).toBe(true)
+    expect(result.checks.every((item) => item.ok)).toBe(true)
+    expect(() => assertManagedConnectorPreflight(cleanEvidence)).not.toThrow()
+  })
+
+  it("fails closed when browser DTOs or redaction canaries contain secrets", () => {
+    const result = validateManagedConnectorPreflight({
+      ...cleanEvidence,
+      browserDtoSamples: [{ sourceId: "source-1", mcp: { headers: { authorization: "Bearer abcdefghijklmnop" } } }],
+      redactedLogSamples: ["x-api-key: abcdefghijklmnop"],
+      redactedProviderResultSamples: [{ access_token: "provider-token" }],
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.checks).toContainEqual(expect.objectContaining({ id: "browser-dto-secret-free", ok: false, code: MCP_ERROR_CODES.SECRET_LEAK_GUARD }))
+    expect(result.checks).toContainEqual(expect.objectContaining({ id: "log-redaction-canary", ok: false, code: MCP_ERROR_CODES.SECRET_LEAK_GUARD }))
+    expect(result.checks).toContainEqual(expect.objectContaining({ id: "provider-result-redaction-canary", ok: false, code: MCP_ERROR_CODES.SECRET_LEAK_GUARD }))
+  })
+
+  it("requires non-empty evidence samples and explicit arbitrary canaries", () => {
+    const emptyEvidence = validateManagedConnectorPreflight({
+      ...cleanEvidence,
+      browserDtoSamples: [],
+      redactedLogSamples: [],
+      redactedProviderResultSamples: [],
+      redactionCanaries: [],
+    })
+    expect(emptyEvidence.ok).toBe(false)
+    expect(emptyEvidence.checks).toContainEqual(expect.objectContaining({ id: "redaction-canaries-present", ok: false }))
+    expect(emptyEvidence.checks).toContainEqual(expect.objectContaining({ id: "browser-dto-secret-free", ok: false }))
+    expect(emptyEvidence.checks).toContainEqual(expect.objectContaining({ id: "log-redaction-canary", ok: false }))
+    expect(emptyEvidence.checks).toContainEqual(expect.objectContaining({ id: "provider-result-redaction-canary", ok: false }))
+
+    const leakedCanary = validateManagedConnectorPreflight({
+      ...cleanEvidence,
+      redactedLogSamples: ["COMPOSIO_CANARY_DO_NOT_LEAK_123"],
+    })
+    expect(leakedCanary.ok).toBe(false)
+    expect(leakedCanary.checks).toContainEqual(expect.objectContaining({ id: "log-redaction-canary", ok: false }))
+
+    const escapedCanary = 'COMPOSIO_CANARY_"quoted"\\line\nnext'
+    const escapedLeak = validateManagedConnectorPreflight({
+      ...cleanEvidence,
+      redactionCanaries: [escapedCanary],
+      redactedProviderResultSamples: [{ nested: [escapedCanary] }],
+    })
+    expect(escapedLeak.ok).toBe(false)
+    expect(escapedLeak.checks).toContainEqual(expect.objectContaining({ id: "provider-result-redaction-canary", ok: false }))
+  })
+
+  it("requires owner-tracked accepted gaps for unresolved vendor-risk gates", () => {
+    const missingGap = validateManagedConnectorPreflight({
+      ...cleanEvidence,
+      vendorRisk: { ...cleanEvidence.vendorRisk, dpaStatus: "owner-accepted-gap" },
+    })
+    expect(missingGap.ok).toBe(false)
+    expect(missingGap.checks).toContainEqual(expect.objectContaining({ id: "vendor-risk", ok: false }))
+
+    const whitespaceGap = validateManagedConnectorPreflight({
+      ...cleanEvidence,
+      vendorRisk: {
+        ...cleanEvidence.vendorRisk,
+        dpaStatus: "owner-accepted-gap",
+        acceptedGaps: [{ id: "dpaStatus", owner: " ", followUp: " ", reason: " " }],
+      },
+    })
+    expect(whitespaceGap.ok).toBe(false)
+
+    const acceptedGap = validateManagedConnectorPreflight({
+      ...cleanEvidence,
+      vendorRisk: {
+        ...cleanEvidence.vendorRisk,
+        dpaStatus: "owner-accepted-gap",
+        acceptedGaps: [{ id: "dpaStatus", owner: "julien", followUp: "PR 3 launch gate", reason: "non-production connector spike only" }],
+      },
+    })
+    expect(acceptedGap.ok).toBe(true)
+  })
+
+  it("reports missing revoke and status verification before real connector use", () => {
+    const result = validateManagedConnectorPreflight({
+      ...cleanEvidence,
+      revokeDisconnectVerified: false,
+      connectedAccountStatusVerified: false,
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.checks).toContainEqual(expect.objectContaining({ id: "revoke-disconnect", ok: false }))
+    expect(result.checks).toContainEqual(expect.objectContaining({ id: "connected-account-status", ok: false }))
+  })
+
+  it("requires stable coded assertion failures", () => {
+    expect(() => assertManagedConnectorPreflight({ ...cleanEvidence, isolatedTestProject: false })).toThrow(McpError)
+    expect(() => assertManagedConnectorPreflight({ ...cleanEvidence, isolatedTestProject: false })).toThrow(/isolated-test-project/)
+  })
+})

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -14,5 +14,6 @@ export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPlugin
 }
 
 export default createBoringMcpServerPlugin()
+export * from "./managedConnectorPreflight"
 export * from "./sourceHandlers"
 export * from "../shared"

--- a/plugins/boring-mcp/src/server/managedConnectorPreflight.ts
+++ b/plugins/boring-mcp/src/server/managedConnectorPreflight.ts
@@ -1,0 +1,108 @@
+import { MCP_ERROR_CODES, McpError, containsMcpSecret, type McpErrorCode } from "../shared"
+
+export type ManagedConnectorSecretStorage = "server-env" | "server-vault"
+export type ManagedConnectorRiskStatus = "approved" | "owner-accepted-gap"
+
+export interface ManagedConnectorAcceptedGap {
+  id: string
+  owner: string
+  followUp: string
+  reason: string
+}
+
+export interface ManagedConnectorVendorRiskEvidence {
+  dpaStatus: ManagedConnectorRiskStatus
+  subprocessorStatus: ManagedConnectorRiskStatus
+  dataResidencyStatus: ManagedConnectorRiskStatus
+  incidentHistoryStatus: ManagedConnectorRiskStatus
+  acceptedGaps?: readonly ManagedConnectorAcceptedGap[]
+}
+
+export interface ManagedConnectorPreflightEvidence {
+  connectorName: string
+  isolatedTestProject: boolean
+  apiKeyStorage: ManagedConnectorSecretStorage
+  browserDtoSamples: readonly unknown[]
+  redactedLogSamples: readonly unknown[]
+  redactedProviderResultSamples: readonly unknown[]
+  redactionCanaries: readonly string[]
+  revokeDisconnectVerified: boolean
+  connectedAccountStatusVerified: boolean
+  vendorRisk: ManagedConnectorVendorRiskEvidence
+}
+
+export interface ManagedConnectorPreflightCheck {
+  id: string
+  ok: boolean
+  code?: McpErrorCode
+  message: string
+}
+
+export interface ManagedConnectorPreflightResult {
+  ok: boolean
+  connectorName: string
+  checks: ManagedConnectorPreflightCheck[]
+}
+
+const VENDOR_RISK_FIELDS = [
+  "dpaStatus",
+  "subprocessorStatus",
+  "dataResidencyStatus",
+  "incidentHistoryStatus",
+] as const
+
+function check(id: string, ok: boolean, message: string, code: McpErrorCode = MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID): ManagedConnectorPreflightCheck {
+  return ok ? { id, ok, message } : { id, ok, code, message }
+}
+
+function hasText(value: string): boolean {
+  return value.trim().length > 0
+}
+
+function hasAcceptedGap(evidence: ManagedConnectorVendorRiskEvidence, field: (typeof VENDOR_RISK_FIELDS)[number]): boolean {
+  return evidence[field] === "approved" || Boolean(evidence.acceptedGaps?.some((gap) => gap.id === field && hasText(gap.owner) && hasText(gap.followUp) && hasText(gap.reason)))
+}
+
+function stringContainsCanary(value: string, canaries: readonly string[]): boolean {
+  return canaries.some((canary) => hasText(canary) && value.includes(canary))
+}
+
+function containsCanary(value: unknown, canaries: readonly string[]): boolean {
+  if (typeof value === "string") return stringContainsCanary(value, canaries)
+  if (Array.isArray(value)) return value.some((item) => containsCanary(item, canaries))
+  if (!value || typeof value !== "object") return false
+  return Object.entries(value).some(([key, nested]) => stringContainsCanary(key, canaries) || containsCanary(nested, canaries))
+}
+
+export function validateManagedConnectorPreflight(evidence: ManagedConnectorPreflightEvidence): ManagedConnectorPreflightResult {
+  const hasBrowserSamples = evidence.browserDtoSamples.length > 0
+  const hasLogSamples = evidence.redactedLogSamples.length > 0
+  const hasProviderResultSamples = evidence.redactedProviderResultSamples.length > 0
+  const hasCanaries = evidence.redactionCanaries.some(hasText)
+  const browserHasSecret = evidence.browserDtoSamples.some(containsMcpSecret) || containsCanary(evidence.browserDtoSamples, evidence.redactionCanaries)
+  const logsHaveSecret = evidence.redactedLogSamples.some(containsMcpSecret) || containsCanary(evidence.redactedLogSamples, evidence.redactionCanaries)
+  const providerResultsHaveSecret = evidence.redactedProviderResultSamples.some(containsMcpSecret) || containsCanary(evidence.redactedProviderResultSamples, evidence.redactionCanaries)
+  const vendorRiskOk = VENDOR_RISK_FIELDS.every((field) => hasAcceptedGap(evidence.vendorRisk, field))
+
+  const checks: ManagedConnectorPreflightCheck[] = [
+    check("isolated-test-project", evidence.isolatedTestProject, "Connector test project is isolated from production data"),
+    check("server-only-api-key", evidence.apiKeyStorage === "server-env" || evidence.apiKeyStorage === "server-vault", "Connector API key resolves only from server env/Vault"),
+    check("redaction-canaries-present", hasCanaries, "Explicit redaction canaries are provided for browser/log/provider-result evidence"),
+    check("browser-dto-secret-free", hasBrowserSamples && !browserHasSecret, "Browser DTO samples contain no API keys, OAuth tokens, cookies, MCP session headers, or seeded canaries", MCP_ERROR_CODES.SECRET_LEAK_GUARD),
+    check("log-redaction-canary", hasLogSamples && !logsHaveSecret, "Redacted log samples contain no connector/API/session/OAuth canaries", MCP_ERROR_CODES.SECRET_LEAK_GUARD),
+    check("provider-result-redaction-canary", hasProviderResultSamples && !providerResultsHaveSecret, "Redacted provider result samples contain no connector/API/session/OAuth canaries", MCP_ERROR_CODES.SECRET_LEAK_GUARD),
+    check("revoke-disconnect", evidence.revokeDisconnectVerified, "Revoke/disconnect behavior has been verified for the connector"),
+    check("connected-account-status", evidence.connectedAccountStatusVerified, "Connected-account status refresh behavior has been verified"),
+    check("vendor-risk", vendorRiskOk, "DPA, subprocessors, data residency, and incident-history risk are approved or owner-accepted"),
+  ]
+
+  return { ok: checks.every((item) => item.ok), connectorName: evidence.connectorName, checks }
+}
+
+export function assertManagedConnectorPreflight(evidence: ManagedConnectorPreflightEvidence): void {
+  const result = validateManagedConnectorPreflight(evidence)
+  if (!result.ok) {
+    const failed = result.checks.filter((item) => !item.ok).map((item) => item.id).join(", ")
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, `Managed connector preflight failed for ${result.connectorName}: ${failed}`, result)
+  }
+}


### PR DESCRIPTION
## Summary

PR 2.5 for issue #416, stacked on #425.

Adds executable reusable boring-mcp managed-connector security preflight checks plus docs. This gates future Composio/managed connector provider calls before adapter implementation.

Covers:
- server-only connector API key storage evidence
- non-empty browser DTO/log/provider-result redaction evidence
- arbitrary seeded redaction canaries, including escaped strings
- MCP secret/key/header/token leak checks
- revoke/disconnect and connected-account status verification gates
- DPA/subprocessor/data-residency/incident-history vendor-risk acceptance
- owner/follow-up/reason requirements for accepted gaps
- stable coded `McpError` assertion failures

No real Composio calls, OAuth, provider execution, credentials, or app env binding are introduced.

## Review-size cap

```txt
109 non-test/non-doc added lines
```

## Validation

```txt
git diff --check: pass
pnpm --filter @hachej/boring-mcp test: pass, 19 tests
pnpm --filter @hachej/boring-mcp typecheck: pass
pnpm --filter @hachej/boring-mcp build: pass
thermo-nuclear review: GREEN after fix loop
independent review: GREEN after fix loop
```
