### PR TITLE
#416 company-fs: document governed filesystem stack

### DIFF
--- a/docs/issues/391/runtime-refactor/02-boring-bash-environment.md
+++ b/docs/issues/391/runtime-refactor/02-boring-bash-environment.md
@@ -126,7 +126,11 @@ interface BashVolumeView {
 }
 ```
 
-V1 decision: keep one public root by default. `mounts` are internal/future unless Phase 0 ADR explicitly defines how multiple mounts materialize into one coherent `/workspace` namespace.
+V1 decision: keep one public root by default for the normal private user workspace, but do **not** assume boring-bash has only one filesystem identity. V1 also supports named filesystem bindings where tools, routes, and UI identify resources as `(filesystem, path)`.
+
+A binding may project another logical filesystem, for example `company_context`, into the active runtime using provider-declared mount/projection modes. The provider decides whether that binding materializes as a mount, backend adapter view, or other runtime handle. Path text does not select filesystem identity: `/company_context/x` is not a filesystem switch, and `company_context:/x` is not accepted as a path string.
+
+For #416, PR1 only creates the tiny `@hachej/boring-bash` skeleton and binding contracts. It does not extract existing file/bash tools/routes/providers. Later PRs can use the binding model for readonly policy-filtered company projections and readwrite management projections without inventing a second storage-root resolver or a new sandbox type.
 
 ## Remote-worker split
 
@@ -201,7 +205,9 @@ The workspace bridge remains owned by `@hachej/boring-workspace`.
 
 - provider mode mapping test;
 - one namespace/split-brain tests per provider;
+- named filesystem binding tests for explicit `(filesystem, path)` identity;
 - direct/local/vercel/remote-worker file+exec consistency;
+- provider-declared projection/mount-mode tests;
 - readonly fs without exec;
 - `disableDefaultFileTools` parity;
 - `execute_isolated_code` ownership/readiness;

--- a/docs/issues/391/runtime-refactor/07-tests-review-acceptance.md
+++ b/docs/issues/391/runtime-refactor/07-tests-review-acceptance.md
@@ -42,6 +42,22 @@ For each provider:
 - readonly facade exposes no exec;
 - partial view with exec physically excludes denied files.
 
+### Named filesystem binding / projection conformance
+
+For #416 and future boring-bash ownership, tests must also prove that one active runtime can carry explicit named filesystem bindings without collapsing identity into path strings:
+
+- tools/routes/UI use `(filesystem, path)` identity; legacy path-only defaults to `user`;
+- `user:/x` and `company_context:/x` are distinct resources even when paths match;
+- path strings such as `/company_context/x` or `company_context:/x` do not switch filesystem identity;
+- provider-declared projection/mount modes are represented in prepared binding lifecycle tests;
+- readonly policy-filtered projections physically omit denied files/folders before exposure to shell/tools/UI;
+- readonly full-store mounts fail conformance if denied files are present;
+- denied names, snippets, sentinel contents, hidden counts, pagination side channels, and stale cached outputs do not leak through read/list/find/grep/search/shell/UI/transcript metadata;
+- policy invalidation rebuilds or drops stale prepared bindings;
+- readwrite management projections are distinct policy-granted bindings, not role-hardcoded upgrades of a normal readonly session.
+
+This is an additive update to #391: PR1 for #416 may create only a tiny `@hachej/boring-bash` skeleton and type contracts. Existing file/bash tools/routes/providers stay on their current code paths until the later extraction plan moves them. `@hachej/boring-agent` receives injected tools/features; it does not become the long-term owner of company filesystem behavior.
+
 ### Provisioning/readiness
 
 - requirement merge by id;

--- a/docs/issues/416/company-fs/01-foundation-binding-model.md
+++ b/docs/issues/416/company-fs/01-foundation-binding-model.md
@@ -1,0 +1,216 @@
+# PR 1 — Initialize boring-bash skeleton + foundation binding model
+
+## Objective
+
+Create the tiny initial `@hachej/boring-bash` package skeleton and introduce the minimal contracts/seams for policy-granted filesystem bindings, with no behavior change for existing agents.
+
+This PR starts the #391 boring-bash extraction in the smallest possible way. It does **not** move existing file/bash tools/routes/providers yet.
+
+## Scope
+
+### In scope
+
+- Create `packages/boring-bash` (or the repo-approved package path/name) with minimal package/build/export wiring.
+- Add no-op export surfaces for future ownership: `/shared`, `/server`, `/agent`, `/plugin`.
+- Shared `FilesystemId` / `FilesystemBinding` / capability types.
+- Bound context shape used to resolve bindings.
+- Provider lifecycle / prepared-binding contract for mounting/projecting filesystems.
+- Required #391 plan/ADR update stating boring-bash V1 supports named filesystem bindings with `(filesystem, path)` identity and provider-declared projection/mount modes.
+- Tool schema feasibility note for adding `filesystem?: FilesystemId` to existing Pi-style tools.
+- UI identity type note: resources are `filesystem + path`.
+
+### Out of scope
+
+- Company provider/projection implementation.
+- Moving existing file/bash tools/routes/providers into boring-bash.
+- Tool behavior changes.
+- UI changes.
+- Runtime mount changes.
+- Policy DSL.
+
+## #391 / boring-bash compatibility
+
+This PR must create the real tiny `@hachej/boring-bash` package skeleton instead of adding new long-lived staging code under `@hachej/boring-agent`.
+
+This PR must also update the #391 boring-bash plan/ADR before implementation proceeds. It adapts #391's original one-namespace assumption: boring-bash V1 supports named filesystem bindings with `(filesystem, path)` identity and provider-declared projection/mount modes.
+
+Required #391 docs to patch:
+
+- `docs/issues/391/runtime-refactor/02-boring-bash-environment.md` — update one-namespace/volume-view discussion with named filesystem bindings.
+- `docs/issues/391/runtime-refactor/07-tests-review-acceptance.md` — add binding/projection conformance and no-denied-file tests.
+
+Initial package shape:
+
+```txt
+packages/boring-bash/
+  src/shared/   # binding/capability contracts
+  src/server/   # provider lifecycle contracts, server-only helpers later
+  src/agent/    # injected tool feature boundary later
+  src/plugin/   # file tree/viewer plugin boundary later
+```
+
+Ownership target:
+
+```txt
+@hachej/boring-bash/shared
+  FilesystemId, FilesystemBinding, capability, prepared-binding contracts
+
+@hachej/boring-bash/server
+  binding resolver/provider lifecycle, routes, filesystem operations
+
+@hachej/boring-bash/agent
+  injected file/bash tool feature using Pi factories + Operations adapters
+
+@hachej/boring-bash/plugin
+  file tree roots, file viewers, workspace.open.path resolver
+
+@hachej/boring-workspace
+  hosts plugins and owns UiBridge dispatch/surface registry
+
+@hachej/boring-agent
+  receives injected tools/features only
+```
+
+Existing agents should remain on current code paths after this PR. The package exists for #416 contracts and future #391 migration only.
+
+No shared/front-safe type may import `node:*` or use `Buffer`; use `Uint8Array` or base64 for binary payloads if needed.
+
+## Contracts
+
+```ts
+export type FilesystemId = 'user' | 'company_context' | (string & {})
+
+export type FilesystemAccess = 'readonly' | 'readwrite'
+
+export type FilesystemProjection =
+  | 'policy-filtered' // contains only resources allowed for this actor/session
+  | 'management'      // broader management view, policy-granted
+
+export interface FilesystemBinding {
+  filesystem: FilesystemId
+  access: FilesystemAccess
+  mountPath: string
+  projection: FilesystemProjection
+}
+
+export interface BoundFilesystemContext {
+  humanUserId: string
+  agentId: string
+  sessionId: string
+  workspaceId: string
+  requestId: string
+}
+
+export interface FilesystemBindingResolver {
+  resolveBindings(ctx: BoundFilesystemContext): Promise<FilesystemBinding[]>
+}
+
+export interface PreparedFilesystemBinding {
+  binding: FilesystemBinding
+  /** Provider/runtime-specific mount/projection handle. Opaque to shared/front code. */
+  handle: unknown
+}
+
+export interface FilesystemBindingProvider {
+  prepareBinding(ctx: BoundFilesystemContext, binding: FilesystemBinding): Promise<PreparedFilesystemBinding>
+  disposeBinding?(prepared: PreparedFilesystemBinding): Promise<void>
+  invalidateBinding?(ctx: BoundFilesystemContext, filesystem: FilesystemId): Promise<void>
+}
+
+export interface RuntimeBindingPlan {
+  /** Bindings prepared for this one runtime/session. */
+  bindings: PreparedFilesystemBinding[]
+}
+```
+
+V0 has one active runtime per agent session/workspace. Do not add `environmentId` in this PR.
+
+## Policy model
+
+Do not hardcode product roles. Policy can return:
+
+```txt
+no company binding
+readonly policy-filtered company binding
+readwrite management company binding
+```
+
+The app/provider decides who gets which binding. PR 1 defines only the contract; later PRs implement readonly and readwrite behavior.
+
+Production policy source should be the host app DB, owned by core/full-app/Constellation. Boring-bash only receives a `FilesystemBindingResolver`. File-backed policy resolvers are allowed only for CLI/dev/test fixtures, not as production source of truth.
+
+## Provider lifecycle note
+
+The provider lifecycle seam exists so later PRs do not invent projection/mount cleanup ad hoc. Providers own persistence/snapshots/backups, but boring-bash owns the lifecycle hook shape:
+
+```txt
+resolve policy binding -> prepare provider projection/mount -> pass prepared bindings into runtime-mode adapter -> use in tools/routes/runtime -> dispose/invalidate
+```
+
+Prepared bindings are part of runtime creation, preserving the Workspace+Sandbox pairing invariant: file tools, shell, routes, and UI must all observe the same prepared binding set for a session/runtime.
+
+A readonly policy-filtered projection must be invalidatable when policy changes. A readwrite management binding must be a distinct prepared binding from a normal readonly projection.
+
+## Tool feasibility note
+
+Before PR 3, inspect current Pi factories:
+
+```txt
+createReadToolDefinition
+createWriteToolDefinition
+createEditToolDefinition
+createFindToolDefinition
+createGrepToolDefinition
+createLsToolDefinition
+```
+
+Record how to add `filesystem?: FilesystemId` while preserving Pi factory + Operations adapter flow. The PR1 feasibility note lives at [`pi-tool-schema-feasibility.md`](./pi-tool-schema-feasibility.md).
+
+Preferred:
+
+```txt
+Pi factory -> narrow schema wrapper -> operation resolver uses filesystem binding
+```
+
+No divergent ad-hoc file tool fork.
+
+## UI identity note
+
+Any UI surface that opens files must eventually identify resources by:
+
+```txt
+filesystem + path
+```
+
+Examples:
+
+```txt
+user:/src/app.ts
+company_context:/company/hr/policy.md
+```
+
+This PR only defines the type/contract; later PRs wire behavior.
+
+## Tests
+
+- New `@hachej/boring-bash` package builds/typechecks with minimal exports.
+- Existing agent/workspace apps continue to compile without adopting boring-bash globally.
+- #391 plan/ADR is updated to mention named filesystem bindings and `(filesystem, path)` identity.
+- Type exports compile in the new package.
+- Shared/front-safe contracts have no Node value imports and no `Buffer`.
+- Existing invariant tests still pass.
+- No `@hachej/boring-agent` → `@hachej/boring-bash` value import cycle.
+- Descriptor identity fields are required internally.
+- Prepared-binding lifecycle contracts are server-only or use opaque handles in shared types so front/shared code does not import runtime values.
+
+## Review checklist
+
+Block if:
+
+- behavior is added beyond package skeleton/contracts/seams;
+- existing file/bash tools/routes/providers are moved in this PR;
+- roles like `admin` are hardcoded into contracts;
+- `environmentId` or multi-runtime complexity is added to V0;
+- new long-lived staging code is added under agent instead of tiny boring-bash package ownership;
+- provider lifecycle is left for PR 2/4 to invent ad hoc;
+- Pi schema feasibility remains unknown before PR 3.

--- a/docs/issues/416/company-fs/02-readonly-company-binding.md
+++ b/docs/issues/416/company-fs/02-readonly-company-binding.md
@@ -1,0 +1,158 @@
+# PR 2 — Readonly policy-filtered company binding
+
+## Objective
+
+Implement readonly `company_context` for normal users/agents using a policy-filtered projection.
+
+Done when backend operations can browse/search/read allowed company files, denied files are absent, and no tool/UI behavior has changed yet.
+
+## Depends on
+
+- PR 1 foundation binding model.
+- #391 dependency inversion or approved boring-bash staging seam.
+
+## Scope
+
+### In scope
+
+- Fixture/local company provider projection.
+- Policy-filtered readonly company binding.
+- Read/list/find/grep/search operation support for readonly binding.
+- Readonly company routes or route params needed by tools/UI later.
+- Sentinel denied-content tests.
+- Transcript/tool-event metadata as V0 access trail.
+- Reusable readonly-projection conformance tests for providers.
+
+### Out of scope
+
+- Existing Pi-style tool schema/wiring changes; PR 3 owns `filesystem?` tool wiring.
+- Readwrite management binding.
+- UI tree/viewers.
+- Real company provider.
+- MCP integration.
+- Binary/download/preview.
+- Copy/export.
+- Transcript redaction/retention.
+
+## Binding behavior
+
+Normal user policy can grant:
+
+```ts
+{
+  filesystem: 'company_context',
+  access: 'readonly',
+  mountPath: '/company_context',
+  projection: 'policy-filtered',
+}
+```
+
+V0 implementation is bounded to a provider-prepared readonly projection for the fixture/local provider. The projection must contain only files/folders allowed for this context. Readonly mount/projection is not safe if denied files are present.
+
+Production policy lookup is DB-backed through the host-provided binding resolver. File-based policy is only acceptable for CLI/dev/test fixtures.
+
+The prepared readonly binding must be injected into the runtime-mode adapter for the session that receives it. File tools, shell, routes, and UI capability discovery must all refer to the same prepared binding to avoid split-brain.
+
+If a future provider cannot produce a safe projection, it must expose no shell mount for company_context and must use backend adapter reads/searches instead. That fallback is a follow-up provider mode, not part of this PR.
+
+## Operation behavior
+
+Allowed for readonly company binding:
+
+```txt
+read
+ls/list
+find
+grep
+stat/search if present
+```
+
+Rejected:
+
+```txt
+write
+edit
+delete/rename/mkdir/upload/watch
+```
+
+PR 3 wires these operations into existing Pi-style tools.
+
+## Path and filesystem identity
+
+Path prefix does not choose filesystem.
+
+Reject:
+
+```txt
+company_context:/company/hr/policy.md as a path string
+/company_context/company/hr/policy.md as a path-switch attempt
+```
+
+Accept operation descriptors with explicit filesystem:
+
+```ts
+{ filesystem: 'company_context', path: '/company/hr/policy.md' }
+```
+
+## Projection/filtering requirements
+
+Policy-filtered projection must ensure:
+
+- denied files physically absent from mounted/projected view;
+- denied directory names absent;
+- no hidden placeholders/counts;
+- symlink escapes blocked;
+- path traversal blocked by adapter/provider;
+- stale projections invalidated or rebuilt when policy changes.
+
+Search/list/find/grep must not leak denied names/snippets/total counts. Pagination/limits must be safe: do not return fewer visible items merely because denied items were dropped without continuing/overfetching where appropriate.
+
+Any provider exposing mounted readonly company bindings must pass readonly-projection conformance tests:
+
+```txt
+denied files absent
+symlink escapes blocked
+stale policy invalidation works
+writes fail
+no denied names/snippets/counts leak
+```
+
+## Fixture and sentinel
+
+Fixture:
+
+```txt
+/company/hr/policy.md
+/company/hr/onboarding.md
+/company/finance/budget.md  // contains FORBIDDEN_FINANCE_SECRET_123
+/company/legal/contract.md
+```
+
+A user denied finance must never observe `FORBIDDEN_FINANCE_SECRET_123` through any V0 access path.
+
+## Tests
+
+- Direct read/list/find/grep operation tests against readonly company binding pass.
+- Write/edit/mutation operations reject `company_context` readonly binding.
+- Path spoofing does not switch filesystem.
+- Readonly projection contains only allowed fixture files.
+- `list('/company')` with finance denied returns only allowed folders.
+- Search/find/grep return only readable paths/snippets and no denied counts.
+- Sentinel never appears in list/search/grep/read errors/operation output/shell output/transcript metadata for denied actor.
+- Fixture/local readonly projection, when mounted, contains only readonly allowed files and cannot write.
+- Providers without safe projection support expose no shell access to company_context; backend-adapter fallback is a follow-up provider mode, not part of this PR.
+- Missing identity/policy/binding fails closed.
+- Transcript/tool-event metadata includes filesystem/path/operation where available.
+- Readonly-projection provider conformance suite fails an intentionally unsafe projection that includes denied files.
+
+## Review checklist
+
+Block if:
+
+- denied files are present in readonly projection;
+- readonly projection is just full company store mounted `ro`;
+- path prefix decides filesystem;
+- write/edit can target readonly company binding;
+- provider exposes mounted readonly company binding without passing conformance tests;
+- result filtering/pagination leaks denied data;
+- company content is silently copied into user workspace/cache.

--- a/docs/issues/416/company-fs/03-agent-tool-wiring.md
+++ b/docs/issues/416/company-fs/03-agent-tool-wiring.md
@@ -1,0 +1,59 @@
+# PR 3 — Agent tool wiring for filesystem bindings
+
+## Objective
+
+Expose filesystem bindings to agents through existing Pi-style file tools with `filesystem?: FilesystemId`, while preserving current user workspace behavior.
+
+## Depends on
+
+- PR 1 foundation binding model.
+- PR 2 readonly company binding / fixture routes.
+
+## Scope
+
+### In scope
+
+- Add optional `filesystem?: FilesystemId` to existing `read`, `ls`, `find`, `grep` tool schemas.
+- Default omitted `filesystem` to `user`.
+- Route explicit `company_context` calls to the prepared readonly binding from PR 2.
+- Reject mutation tools (`write`, `edit`, etc.) against readonly bindings.
+- Add concise tool/prompt guidance when company_context is advertised.
+- Preserve Pi factory + Operations adapter path.
+
+### Out of scope
+
+- Projection/provider lifecycle.
+- UI bridge/tree/viewer work.
+- Readwrite management binding.
+- New company-specific duplicate tools.
+
+## Tool behavior
+
+```ts
+read({ path: 'README.md' }) // user default
+read({ filesystem: 'company_context', path: '/company/hr/policy.md' })
+ls({ filesystem: 'company_context', path: '/' })
+find({ filesystem: 'company_context', pattern: '*.md', path: '/' })
+grep({ filesystem: 'company_context', pattern: 'vacation', path: '/' })
+```
+
+Path prefix does not choose filesystem. `company_context:/x` inside `path` is invalid.
+
+## Tests
+
+- Existing tools without `filesystem` still hit `user` and existing tests pass.
+- Explicit `filesystem: 'user'` behaves same as omission.
+- Explicit `filesystem: 'company_context'` read/list/find/grep uses company binding.
+- Mutation tools reject readonly company binding.
+- Path spoofing does not switch filesystem.
+- Prompt/tool descriptions mention company_context only when capability is advertised and include root `/` guidance.
+- Pi factory/Operations adapter parity tests cover user behavior.
+
+## Review checklist
+
+Block if:
+
+- separate basic company tools are introduced;
+- omission of `filesystem` can mean company_context;
+- Pi factory/Operations adapter path is bypassed without parity tests;
+- mutation tools can write readonly company bindings.

--- a/docs/issues/416/company-fs/04-readwrite-management-binding.md
+++ b/docs/issues/416/company-fs/04-readwrite-management-binding.md
@@ -1,0 +1,110 @@
+# PR 4 — Readwrite company management binding
+
+## Objective
+
+Implement policy-granted readwrite management binding for `company_context` through regular runtime providers.
+
+Done when a privileged actor can manage company context as real files through a readwrite binding, while normal readonly actors cannot access that management projection.
+
+## Depends on
+
+- PR 1 foundation binding/provider lifecycle model.
+- PR 2 readonly company binding.
+
+## Scope
+
+### In scope
+
+- Policy-granted readwrite `company_context` management binding.
+- Prepared-binding lifecycle for management projection/mount.
+- Regular sandbox/runtime provider integration for the fixture/local provider first; do not invent a new sandbox type.
+- Tests proving writes update provider/fixture state later visible through readonly policy-filtered views.
+
+### Out of scope
+
+- UI bridge/file tree/viewers.
+- Product role names like `admin` hardcoded in contracts.
+- Real provider persistence implementation details.
+- MCP integration.
+- Copy/export UX.
+
+## Readwrite management binding
+
+Policy may grant:
+
+```ts
+{
+  filesystem: 'company_context',
+  access: 'readwrite',
+  mountPath: '/company_context',
+  projection: 'management',
+}
+```
+
+This binding uses the regular sandbox/runtime mechanism configured by the app/provider. V0 implementation is bounded to the fixture/local provider path; direct/vercel/other provider support should come via the provider lifecycle contract and conformance follow-ups. Contracts must not hardcode bwrap, direct, vercel, or product roles.
+
+Rules:
+
+- Only policy-granted actors can receive readwrite binding.
+- In production, that policy grant comes from the host DB-backed resolver; file-backed grants are CLI/dev/test only.
+- Readwrite management binding is distinct from normal readonly projection.
+- Normal user sessions must not receive management projection.
+- Management projection is selected only through an explicit policy-granted runtime/profile entrypoint.
+- Provider owns persistence/snapshots/backups.
+- Writes in management binding update the company_context provider state that later readonly projections observe.
+- Management binding must be prepared/disposed/invalidate through the lifecycle contract from PR 1.
+
+## Invocation / routing model
+
+A management binding is selected by launching a session/runtime profile whose policy resolves a readwrite `company_context` binding. It is not a hidden upgrade inside an existing normal readonly session.
+
+The app/host owns the entrypoint, for example:
+
+```txt
+agent profile: company-context-curator
+resolved bindings: company_context readwrite management
+runtime provider: fixture/local in V0
+```
+
+Tools and shell target the management binding because it is part of that runtime's prepared binding plan. Normal sessions cannot reuse this prepared binding; prepared bindings are scoped by `humanUserId + agentId + sessionId + workspaceId + requestId/runtime` and disposed/invalidated through the provider lifecycle.
+
+## Relation to normal user runtime
+
+A normal user may have:
+
+```txt
+user              readwrite  /workspace
+company_context   readonly   /company_context policy-filtered
+```
+
+A privileged management session may have:
+
+```txt
+company_context   readwrite  /company_context management
+```
+
+The app/provider decides whether the management session also gets a private scratch/user workspace. This PR does not require mixing management projection into normal user sessions.
+
+## Tests
+
+- Non-granted actor cannot receive readwrite company binding.
+- Normal readonly session cannot upgrade/reuse a prepared management binding.
+- Granted actor receives readwrite management binding with the fixture/local provider path.
+- Provider contract is sufficient for direct/vercel/other providers to add conformance later without changing shared types.
+- Management binding is distinct from readonly prepared binding.
+- Write/edit in management binding updates fixture/provider state.
+- Normal readonly actor later sees updated allowed content but still not denied content.
+- Normal readonly actor cannot access management projection.
+- Disposing management binding cleans up provider/runtime handles.
+- Policy invalidation does not leave stale management projection accessible to a no-longer-granted actor.
+
+## Review checklist
+
+Block if:
+
+- readwrite binding is role-hardcoded instead of policy-granted;
+- a new sandbox type is invented unnecessarily;
+- normal readonly user can access management projection;
+- readwrite projection lifecycle lacks cleanup/invalidation;
+- management binding is implemented inside `@hachej/boring-agent` instead of boring-bash/provider seam;
+- provider persistence details leak into shared contracts.

--- a/docs/issues/416/company-fs/05-ui-bridge-filesystem-identity.md
+++ b/docs/issues/416/company-fs/05-ui-bridge-filesystem-identity.md
@@ -1,0 +1,60 @@
+# PR 5 — UI bridge filesystem identity
+
+## Objective
+
+Make file-open UI plumbing filesystem-aware so later Company tree/viewer work cannot lose `company_context` identity.
+
+This PR is identity plumbing only.
+
+## Depends on
+
+- PR 1 foundation binding model.
+- PR 2 readonly company binding for test fixtures/capabilities.
+
+## Ownership
+
+This belongs to the future `@hachej/boring-bash/plugin` surface contracts where possible. `@hachej/boring-workspace` owns `UiBridge.postCommand`, surface registry, and plugin hosting; it should not own company-specific file UI logic long-term.
+
+## Scope
+
+### In scope
+
+- Add `filesystem?: FilesystemId` to UI bridge/surface file-open payloads.
+- Bind legacy path-only opens to `filesystem: 'user'`.
+- Include filesystem in panel params, tab ids, cache keys, dirty-state keys, stale-write keys, and persisted/deep-link state where file opens are encoded.
+- Chat file mentions / `@` mentions / transcript file-reference UI preserve filesystem identity where they reference files.
+
+### Out of scope
+
+- Company file tree root.
+- Readonly viewer mutation behavior.
+- Backend provider implementation.
+- Global search redesign.
+
+## Compatibility rule
+
+```txt
+legacy open path with no filesystem => user
+company open => { filesystem: 'company_context', path: '/company/hr/policy.md' }
+```
+
+Do not infer company context from path text.
+
+## Tests
+
+- Path-only open binds to `user`.
+- Company open requires filesystem field.
+- `user:/x` and `company_context:/x` open distinct tabs/panels.
+- Persisted company tab denied after policy change shows disclosure-safe not found/denied.
+- Chat mentions/file refs preserve filesystem identity.
+- `UiBridge.postCommand` remains the single UI dispatch source.
+- No `Buffer` in shared/front payload types.
+
+## Review checklist
+
+Block if:
+
+- UI opens company files path-only;
+- tab/cache/dirty keys omit filesystem;
+- path strings like `/company_context/x` or `company_context:/x` switch filesystem;
+- workspace base front/shared code imports agent values.

--- a/docs/issues/416/company-fs/06-company-filetree-root.md
+++ b/docs/issues/416/company-fs/06-company-filetree-root.md
@@ -1,0 +1,73 @@
+# PR 6 — Company file tree root
+
+## Objective
+
+Show `company_context` as a separate Company root/tab/section in the file tree.
+
+This PR is tree UX only; readonly viewer mutation hardening comes later.
+
+## Depends on
+
+- PR 2 readonly company binding.
+- PR 5 UI bridge filesystem identity.
+
+## Ownership
+
+This UI belongs to future `@hachej/boring-bash/plugin`. Workspace hosts the plugin and surface registry.
+
+## Scope
+
+### In scope
+
+- File tree capability/binding discovery.
+- Separate Workspace and Company roots/tabs/sections.
+- Company tree lists only readable folders/files for readonly bindings.
+- Company file tree opens include `filesystem: 'company_context'`.
+- Tree-level actions reflect binding access: readonly has no mutation actions.
+
+### Out of scope
+
+- Readonly viewer/editor internals.
+- Readwrite management UI polish.
+- Global search redesign.
+- Save/copy/export.
+
+## UX rule
+
+Do not show company context as a subfolder of the user workspace.
+
+Good:
+
+```txt
+Files
+  [Workspace] [Company]
+```
+
+or:
+
+```txt
+Workspace
+  src/
+
+Company
+  hr/
+```
+
+## Tests
+
+- Single-fs app unchanged.
+- Workspace and Company render as separate roots/tabs/sections.
+- Company root hidden when no binding exists.
+- Company tree hides denied files/counts for readonly actors.
+- Company tree click opens with `filesystem: 'company_context'`.
+- Tree mutation actions are absent/disabled for readonly Company root.
+
+## Review checklist
+
+Block if:
+
+- company files appear under user workspace tree;
+- tree opens company files path-only;
+- denied files/counts leak in tree/search;
+- tree actions can mutate readonly company_context;
+- UI code hardcodes product roles instead of binding capabilities.

--- a/docs/issues/416/company-fs/07-readonly-company-viewers.md
+++ b/docs/issues/416/company-fs/07-readonly-company-viewers.md
@@ -1,0 +1,69 @@
+# PR 7 — Readonly company viewers
+
+## Objective
+
+Make files opened from readonly `company_context` bindings readonly by construction.
+
+This PR is viewer/editor behavior only.
+
+## Depends on
+
+- PR 5 UI bridge filesystem identity.
+- PR 6 Company file tree root.
+
+## Ownership
+
+Viewer/editor pieces belong to future `@hachej/boring-bash/plugin`; workspace hosts the plugin.
+
+## Scope
+
+### In scope
+
+- Readonly viewer mode for readonly filesystem bindings.
+- Capability-based mutation affordance gating.
+- Readonly badge/breadcrumb/tab affordance.
+- Ensure mutation shortcuts and LSP/code actions cannot mutate readonly company files.
+
+### Out of scope
+
+- File tree roots.
+- Backend provider implementation.
+- Save As / export / copy-to-workspace.
+- Binary/download/preview.
+- Major editor redesign beyond necessary extraction.
+
+## Behavior
+
+Readonly binding:
+
+- no save/edit/rename/delete/upload/replace;
+- no Save As / Export-to-workspace in V0;
+- no drag/drop write;
+- no autosave/writeback;
+- no dirty state;
+- no optimistic write flow;
+- mutation shortcuts no-op or show readonly feedback;
+- LSP/code actions/rename-symbol cannot mutate.
+
+Use capabilities, not hardcoded role checks:
+
+```txt
+binding.access === 'readonly' | 'readwrite'
+```
+
+## Tests
+
+- Readonly company file opens in readonly viewer.
+- No save/edit/rename/delete/upload/drag-write/LSP mutation path for readonly company files.
+- User file editor behavior unchanged.
+- Readonly company viewer never calls write/edit/delete/move/upload routes.
+- No `Buffer` in shared/front payload types.
+
+## Review checklist
+
+Block if:
+
+- readonly viewer has reachable mutation paths;
+- UI code hardcodes roles instead of binding capabilities;
+- implementation creates giant branchy file panels instead of capability-based components;
+- current file panel is already above ~700 lines and no extraction/split lands before adding readonly behavior.

--- a/docs/issues/416/company-fs/index.md
+++ b/docs/issues/416/company-fs/index.md
@@ -1,0 +1,163 @@
+# Issue #416 — governed company filesystem binding plan
+
+## Goal
+
+Ship the Constellation-enabling feature as seven stacked PRs: a governed shared company filesystem that can be mounted/projected into agent runtimes with different policy-granted bindings.
+
+V0 supports:
+
+```txt
+user
+  private workspace filesystem
+  readwrite
+  default target for existing file tools/routes
+  mounted in the app's normal workspace runtime
+
+company_context
+  shared company filesystem
+  mounted/projected according to policy
+  readonly filtered binding for normal users/agents
+  readwrite management binding for privileged curator agents
+  persistence/snapshots/backups hidden behind provider/sandbox implementation
+```
+
+## Final architecture decision
+
+Do **not** create a new sandbox type. Add a generic filesystem binding model on top of regular runtime providers.
+
+The app/provider still chooses the sandbox/runtime implementation. V0 proves the binding model with the fixture/local provider path first; direct/vercel/other providers are follow-up conformance work.
+
+```txt
+V0 proven path: fixture/local provider
+future conformance: direct | local/bwrap | vercel | future providers
+```
+
+A filesystem binding says how a logical filesystem is projected into that runtime:
+
+```ts
+interface FilesystemBinding {
+  filesystem: 'user' | 'company_context' | string
+  access: 'readonly' | 'readwrite'
+  mountPath: string
+  projection: 'policy-filtered' | 'management'
+}
+```
+
+Policy resolves bindings. Roles are not hardcoded:
+
+```ts
+resolveFilesystemBindings(ctx) -> FilesystemBinding[]
+```
+
+Production policy source is the host app DB (owned by core/full-app/Constellation), not files in the workspace. File-backed policy is allowed only for CLI/dev/test fixtures.
+
+Example normal user/agent:
+
+```txt
+user              readwrite   /workspace         management/user workspace
+company_context   readonly    /company_context   policy-filtered
+```
+
+Example privileged curator agent:
+
+```txt
+company_context   readwrite   /company_context   management
+```
+
+A normal user's company binding is safe only if the mounted/projected tree contains **only files that policy allows them to read**. Readonly alone is not enough if denied files are present.
+
+## #391 / boring-bash alignment
+
+This plan intentionally adapts #391's original “one public `/workspace` namespace” assumption. The #391 boring-bash plan must explicitly allow named filesystem bindings with `(filesystem, path)` identity inside one active runtime.
+
+Ownership target:
+
+```txt
+@hachej/boring-bash/shared
+  FilesystemId, FilesystemBinding, capability, prepared-binding contracts
+
+@hachej/boring-bash/server
+  binding resolver/provider lifecycle, routes, filesystem operations
+
+@hachej/boring-bash/agent
+  injected file/bash tool feature using existing Pi factory + Operations path
+
+@hachej/boring-bash/plugin
+  file tree roots, file viewers, workspace.open.path resolver
+
+@hachej/boring-workspace
+  hosts plugins and owns UiBridge dispatch/surface registry
+
+@hachej/boring-agent
+  receives injected tools/features only; no company fs ownership
+```
+
+PR 1 should initialize a tiny `@hachej/boring-bash` package skeleton if it does not exist yet. This is not the full #391 extraction: existing file/bash tools/routes/providers keep their current code paths until later migration. The new package initially owns only #416 contracts and minimal no-op boundaries needed by this stack.
+
+PR 1 must also patch the #391 plan docs that currently assume one public namespace, at minimum `docs/issues/391/runtime-refactor/02-boring-bash-environment.md` and `docs/issues/391/runtime-refactor/07-tests-review-acceptance.md`, to mention named filesystem bindings and `(filesystem, path)` identity.
+
+## Non-negotiables
+
+- `company_context` is a separate filesystem identity, not a fake subfolder of `user`.
+- Existing tools may omit `filesystem`; omission means `user`.
+- Company access is explicit in tools/UI: `filesystem: 'company_context'` or equivalent bound root.
+- Normal-user company binding is readonly and policy-filtered before mount/projection.
+- Privileged readwrite company binding is policy-granted, generic, and not role-name hardcoded.
+- Storage persistence details are provider-owned and out of this plan.
+- Denied files are physically absent from readonly projections.
+- No denied names/snippets/counts leak through list/search/grep/find or UI.
+- Path prefix does not decide filesystem identity.
+- `user:/x` and `company_context:/x` are distinct resources and tabs.
+- UI shows Company as a separate root/tab/section, not as a user workspace subfolder.
+- Readonly company viewers disable mutation affordances.
+- MCP connections are out of scope.
+- Transcript behavior stays like today's tool/command output; special redaction/retention is follow-up.
+
+## PR stack
+
+| PR | Plan | Scope | Done when |
+| --- | --- | --- | --- |
+| 1 | [`01-foundation-binding-model.md`](./01-foundation-binding-model.md) | Tiny `@hachej/boring-bash` package skeleton, binding contracts, provider lifecycle seam, policy shape, tool/schema feasibility, no behavior change | Package builds; contracts compile; existing agents remain unchanged |
+| 2 | [`02-readonly-company-binding.md`](./02-readonly-company-binding.md) | Policy-filtered readonly company projection, fixture/local provider, leakage tests | Backend operations can read/search only allowed company files |
+| 3 | [`03-agent-tool-wiring.md`](./03-agent-tool-wiring.md) | Existing Pi-style tools get `filesystem?` and route to company binding | Normal agent can use existing tools against `company_context` |
+| 4 | [`04-readwrite-management-binding.md`](./04-readwrite-management-binding.md) | Policy-granted readwrite management binding through regular runtime providers | Curator agents can manage company fs through a readwrite binding without exposing it to normal users |
+| 5 | [`05-ui-bridge-filesystem-identity.md`](./05-ui-bridge-filesystem-identity.md) | UI bridge/surface file identity plumbing | UI opens distinguish `user:/x` and `company_context:/x` |
+| 6 | [`06-company-filetree-root.md`](./06-company-filetree-root.md) | Company root/tree beside Workspace | Users can browse policy-filtered Company root |
+| 7 | [`07-readonly-company-viewers.md`](./07-readonly-company-viewers.md) | Readonly viewer/editor behavior for readonly bindings | Company files open readonly with no mutation paths |
+
+Older drafts live under [`archive/`](./archive/) for context only.
+
+## Full-feature acceptance
+
+A host can configure policy like:
+
+```txt
+Julien default agent:
+  company_context:/company/hr/**       readonly
+  company_context:/company/finance/**  denied
+
+Curator agent:
+  company_context:/company/**          readwrite management
+```
+
+Then:
+
+- Julien sees/browses only allowed company files.
+- Julien's tools can use `filesystem: 'company_context'` explicitly.
+- Julien's shell can only see the readonly filtered projection if mounted; denied files are absent.
+- Curator agents can manage company files through a policy-granted readwrite runtime binding.
+- Search/list/find/grep never leak denied names/snippets/counts, including pagination/limits.
+- UI opens `company_context` files readonly for readonly bindings.
+
+## Review gate
+
+Before implementation, each PR plan must pass thermo review for:
+
+- #391 package layering and no permanent agent ownership;
+- no path-prefix filesystem inference;
+- no denied-file presence in readonly projection;
+- no shell/company-context bypass for normal bindings;
+- no denied-result leakage;
+- no UI identity loss;
+- no editable readonly viewer path;
+- one PR-sized scope.

--- a/docs/issues/416/company-fs/pi-tool-schema-feasibility.md
+++ b/docs/issues/416/company-fs/pi-tool-schema-feasibility.md
@@ -1,0 +1,85 @@
+# PR1 Pi tool schema feasibility note
+
+Bead: `boring-ui-v2-reorg-ko57`
+
+## Current factory path
+
+Current user-workspace file tools are built in `packages/agent/src/server/tools/filesystem/index.ts`:
+
+```txt
+buildFilesystemAgentTools(bundle)
+  -> choose runtime filesystem strategy
+  -> host strategy: boundFs(storageRoot, { runtimeRoot: cwd })
+  -> createReadToolDefinition(cwd, { operations: ops.read })
+  -> createWriteToolDefinition(cwd, { operations: ops.write })
+  -> createEditToolDefinition(cwd, { operations: ops.edit })
+  -> createFindToolDefinition(cwd, { operations: ops.find })
+  -> createGrepToolDefinition(cwd, { operations: ops.grep })
+  -> createLsToolDefinition(cwd, { operations: ops.ls })
+  -> adaptPiTool(...)
+```
+
+Remote-workspace mode follows the same pattern in `packages/agent/src/server/tools/filesystem/remoteWorkspaceTools.ts`, except grep uses `remoteWorkspaceGrepTool()` because remote grep shells into the sandbox while preserving Pi grep schema parity.
+
+The low-level user-workspace operations are in `packages/agent/src/server/tools/operations/bound.ts`. They already form the right seam: Pi factory schemas call Operations adapters, and adapters own path validation/containment.
+
+## Feasible PR3 wiring strategy
+
+Preferred strategy for PR3:
+
+```txt
+Pi factory output
+  -> narrow boring-bash schema wrapper adds optional filesystem?: FilesystemId
+  -> execution wrapper strips/defaults filesystem
+  -> filesystem-aware operation resolver selects prepared binding
+  -> existing Operations adapter shape executes read/write/edit/find/grep/ls
+```
+
+Rules:
+
+- Omitted `filesystem` defaults to `user`.
+- Explicit `filesystem: 'user'` must be behavior-identical to omission.
+- Explicit `filesystem: 'company_context'` routes to the prepared binding for that runtime/session.
+- Path strings never choose filesystem identity. Reject path spoofing such as `company_context:/x` or `/company_context/x`.
+- Do not add duplicate tools such as `read_company_context`.
+- Do not fork divergent file tool behavior. Keep Pi factory descriptions/rendering/result shapes unless PR3 has a targeted parity update.
+
+## Schema wrapper approach
+
+The existing `adaptPiTool()` receives a Pi tool with `parameters: unknown` and `execute(...)`. PR3 can wrap each Pi tool before or inside `adaptPiTool()`:
+
+1. Clone/extend the Pi tool parameter schema with optional `filesystem`.
+2. Wrap `execute` to parse/default `filesystem` and reject path spoofing.
+3. Pass params without `filesystem` (or with resolver-selected operations) to the Pi factory execution path.
+
+If TypeBox schema extension is awkward for upstream Pi definitions, use a tiny local wrapper that preserves the original schema fields byte-for-byte and adds only the optional `filesystem` property. Add parity tests comparing the `user` default path with current Pi factory output.
+
+## Operation resolver approach
+
+Introduce a filesystem-aware resolver that maps `(filesystem, access, projection)` to the existing operation interfaces:
+
+```txt
+resolveToolFilesystem(params.filesystem ?? 'user', runtimeBindingPlan)
+  -> user readwrite binding => current boundFs/remoteWorkspace ops
+  -> company_context readonly policy-filtered binding => readonly read/list/find/grep ops
+  -> company_context readwrite management binding => management ops in PR4
+```
+
+Mutation tools must reject readonly bindings before invoking write/edit operations.
+
+## Tests required for PR3
+
+- Existing tool calls without `filesystem` still hit `user` and existing tests pass.
+- Explicit `filesystem: 'user'` equals omission.
+- Explicit `filesystem: 'company_context'` read/list/find/grep uses the prepared company binding.
+- Mutation tools reject readonly company bindings.
+- Path spoofing does not switch filesystem.
+- Tool descriptions/prompt snippets mention `company_context` only when capability is advertised.
+- Pi factory / Operations adapter parity tests cover current user behavior.
+
+## Non-goals for PR3
+
+- No provider/projection lifecycle implementation.
+- No UI tree/viewer work.
+- No readwrite management binding.
+- No company-specific duplicate tools.


### PR DESCRIPTION
## Stack position
1 / 8 in the #416 governed `company_context` filesystem stack.

Base: `bclaw/issue-174-clickable-slash-commands`.
Next: `bclaw/416-pr1b-boring-bash-skeleton`.

## What this adds
- Documents the accepted #416 company-fs architecture and review stack.
- Records how the stack aligns with the future `@hachej/boring-bash` split.
- Keeps the final plan docs in `docs/issues/416/company-fs/` without introducing runtime code in this PR.

## Review notes
This is now docs-only. The previous large foundation PR was split so reviewers can separately inspect package skeleton, readonly projection, management lifecycle, agent routing, and UI behavior.

## Validation
Docs-only; downstream code PRs run package tests/typechecks.
