### PR TITLE
#416 company-fs: route agent file tools through explicit filesystem bindings

### DIFF
--- a/packages/agent/src/server/http/routes/__tests__/file.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/file.test.ts
@@ -5,8 +5,9 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, test, vi } from 'vitest'
 
 import type { Workspace } from '../../../../shared/workspace'
+import type { RuntimeFilesystemBindingOperations } from '../../../runtime/mode'
 import { createNodeWorkspace } from '../../../workspace/createNodeWorkspace'
-import { fileRoutes } from '../file'
+import { ERROR_CODE_NOT_FOUND_OR_DENIED, ERROR_CODE_READONLY, fileRoutes } from '../file'
 
 const tempRoots: string[] = []
 const apps: FastifyInstance[] = []
@@ -20,9 +21,17 @@ afterEach(async () => {
   )
 })
 
-async function createTestAppWithWorkspace(workspace: Workspace): Promise<FastifyInstance> {
+async function createTestAppWithWorkspace(
+  workspace: Workspace,
+  companyOperations?: RuntimeFilesystemBindingOperations,
+): Promise<FastifyInstance> {
   const app = Fastify({ logger: false })
-  await app.register(fileRoutes, { workspace })
+  await app.register(fileRoutes, {
+    workspace,
+    ...(companyOperations
+      ? { filesystemBindings: [{ filesystem: 'company_context', access: 'readonly', operations: companyOperations }] }
+      : {}),
+  })
   await app.ready()
   apps.push(app)
   return app
@@ -42,6 +51,165 @@ async function createTestApp(): Promise<{ app: FastifyInstance; workspaceRoot: s
 }
 
 describe('file routes (NodeWorkspace integration)', () => {
+  test('GET /api/v1/files preserves explicit company_context and sanitizes denied reads', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-file-routes-'))
+    tempRoots.push(workspaceRoot)
+    const operations: RuntimeFilesystemBindingOperations = {
+      read: vi.fn(async ({ path }) => {
+        if (path.includes('denied')) {
+          const err = new Error('FORBIDDEN_FINANCE_SECRET_123 at /secret/finance.md') as Error & { statusCode?: number; code?: string }
+          err.statusCode = 404
+          err.code = 'not_found_or_denied'
+          throw err
+        }
+        return { content: `company:${path}` }
+      }),
+      list: vi.fn(),
+      find: vi.fn(),
+      grep: vi.fn(),
+      stat: vi.fn(async ({ path }) => ({ isDirectory: path.endsWith('/hr') })),
+      rejectMutation: vi.fn((operation) => {
+        throw new Error(`readonly ${operation}`)
+      }),
+    }
+    const app = await createTestAppWithWorkspace(createNodeWorkspace(workspaceRoot), operations)
+
+    const allowed = await app.inject({
+      method: 'GET',
+      url: '/api/v1/files?filesystem=company_context&path=%2Fcompany%2Fhr%2Fpolicy.md',
+    })
+    expect(allowed.statusCode).toBe(200)
+    expect(allowed.json()).toEqual({ content: 'company:/company/hr/policy.md' })
+    expect(operations.read).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/hr/policy.md' })
+
+    const rawAllowed = await app.inject({
+      method: 'GET',
+      url: '/api/v1/files/raw?filesystem=company_context&path=%2Fcompany%2Fhr%2Fpolicy.md',
+    })
+    expect(rawAllowed.statusCode).toBe(200)
+    expect(rawAllowed.body).toBe('company:/company/hr/policy.md')
+
+    const denied = await app.inject({
+      method: 'GET',
+      url: '/api/v1/files?filesystem=company_context&path=%2Fcompany%2Fdenied.md',
+    })
+    expect(denied.statusCode).toBe(404)
+    expect(denied.json()).toEqual({ error: { code: ERROR_CODE_NOT_FOUND_OR_DENIED, message: 'not found or denied' } })
+    expect(denied.body).not.toContain('FORBIDDEN_FINANCE_SECRET_123')
+    expect(denied.body).not.toContain('/secret/finance.md')
+
+    const rawDenied = await app.inject({
+      method: 'GET',
+      url: '/api/v1/files/raw?filesystem=company_context&path=%2Fcompany%2Fdenied.md',
+    })
+    expect(rawDenied.statusCode).toBe(404)
+    expect(rawDenied.json()).toEqual({ error: { code: ERROR_CODE_NOT_FOUND_OR_DENIED, message: 'not found or denied' } })
+    expect(rawDenied.body).not.toContain('FORBIDDEN_FINANCE_SECRET_123')
+
+    const statAllowed = await app.inject({
+      method: 'GET',
+      url: '/api/v1/stat?filesystem=company_context&path=%2Fcompany%2Fhr',
+    })
+    expect(statAllowed.statusCode).toBe(200)
+    expect(statAllowed.json()).toEqual({ kind: 'dir' })
+    expect(operations.stat).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/hr' })
+
+    const writeDenied = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files',
+      payload: { filesystem: 'company_context', path: '/company/hr/policy.md', content: 'mutate' },
+    })
+    expect(writeDenied.statusCode).toBe(403)
+    expect(writeDenied.json()).toEqual({ error: { code: ERROR_CODE_READONLY, message: 'company_context binding is readonly' } })
+  })
+
+  test('GET /api/v1/files routes arbitrary named filesystem bindings without company_context special casing', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-file-routes-'))
+    tempRoots.push(workspaceRoot)
+    const operations: RuntimeFilesystemBindingOperations = {
+      read: vi.fn(async ({ filesystem, path }) => ({ content: `${filesystem}:${path}` })),
+      list: vi.fn(),
+      find: vi.fn(),
+      grep: vi.fn(),
+      stat: vi.fn(async () => ({ isDirectory: false })),
+      rejectMutation: vi.fn((operation) => {
+        throw new Error(`readonly ${operation}`)
+      }),
+    }
+    const app = Fastify({ logger: false })
+    await app.register(fileRoutes, {
+      workspace: createNodeWorkspace(workspaceRoot),
+      filesystemBindings: [{ filesystem: 'project_alpha', access: 'readonly', operations }],
+    })
+    await app.ready()
+    apps.push(app)
+
+    const allowed = await app.inject({
+      method: 'GET',
+      url: '/api/v1/files?filesystem=project_alpha&path=%2Fsrc%2Findex.ts',
+    })
+    expect(allowed.statusCode).toBe(200)
+    expect(allowed.json()).toEqual({ content: 'project_alpha:/src/index.ts' })
+    expect(operations.read).toHaveBeenCalledWith({ filesystem: 'project_alpha', path: '/src/index.ts' })
+
+    const writeDenied = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files',
+      payload: { filesystem: 'project_alpha', path: '/src/index.ts', content: 'mutate' },
+    })
+    expect(writeDenied.statusCode).toBe(403)
+    expect(writeDenied.json()).toEqual({ error: { code: ERROR_CODE_READONLY, message: 'project_alpha binding is readonly' } })
+  })
+
+  test('company_context filesystem rejects delete move and mkdir before user workspace mutation', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-file-routes-'))
+    tempRoots.push(workspaceRoot)
+    await writeFile(join(workspaceRoot, 'user.txt'), 'safe')
+    const workspace = createNodeWorkspace(workspaceRoot)
+    const unlink = vi.spyOn(workspace, 'unlink')
+    const rename = vi.spyOn(workspace, 'rename')
+    const mkdir = vi.spyOn(workspace, 'mkdir')
+    const operations: RuntimeFilesystemBindingOperations = {
+      read: vi.fn(),
+      list: vi.fn(),
+      find: vi.fn(),
+      grep: vi.fn(),
+      stat: vi.fn(),
+      rejectMutation: vi.fn((operation) => {
+        throw new Error(`readonly ${operation}`)
+      }),
+    }
+    const app = await createTestAppWithWorkspace(workspace, operations)
+
+    const deleteDenied = await app.inject({
+      method: 'DELETE',
+      url: '/api/v1/files?filesystem=company_context&path=%2Fcompany%2Fhr%2Fpolicy.md',
+    })
+    expect(deleteDenied.statusCode).toBe(403)
+    expect(deleteDenied.json()).toEqual({ error: { code: ERROR_CODE_READONLY, message: 'company_context binding is readonly' } })
+
+    const moveDenied = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files/move',
+      payload: { filesystem: 'company_context', from: '/company/hr/policy.md', to: '/company/hr/policy-2.md' },
+    })
+    expect(moveDenied.statusCode).toBe(403)
+    expect(moveDenied.json()).toEqual({ error: { code: ERROR_CODE_READONLY, message: 'company_context binding is readonly' } })
+
+    const mkdirDenied = await app.inject({
+      method: 'POST',
+      url: '/api/v1/dirs',
+      payload: { filesystem: 'company_context', path: '/company/new', recursive: true },
+    })
+    expect(mkdirDenied.statusCode).toBe(403)
+    expect(mkdirDenied.json()).toEqual({ error: { code: ERROR_CODE_READONLY, message: 'company_context binding is readonly' } })
+
+    expect(unlink).not.toHaveBeenCalled()
+    expect(rename).not.toHaveBeenCalled()
+    expect(mkdir).not.toHaveBeenCalled()
+    expect(await readFile(join(workspaceRoot, 'user.txt'), 'utf8')).toBe('safe')
+  })
+
   test('GET/POST/DELETE /api/v1/files roundtrip', async () => {
     const { app } = await createTestApp()
 

--- a/packages/agent/src/server/http/routes/file.ts
+++ b/packages/agent/src/server/http/routes/file.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { dirname, extname, relative } from 'node:path/posix'
 import type { Workspace } from '../../../shared/workspace'
+import type { RuntimeFilesystemBinding } from '../../runtime/mode'
 import {
   ERROR_CODE_INVALID_PATH,
   ERROR_CODE_PATH_REJECTED,
@@ -30,6 +31,9 @@ const BORING_SETTINGS_PATH = '.boring/settings'
 const DEFAULT_MARKDOWN_IMAGE_UPLOAD_DIR = 'assets/images'
 const DEFAULT_FILE_UPLOAD_DIR = 'assets/uploads'
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024
+const USER_FILESYSTEM_ID = 'user'
+export const ERROR_CODE_NOT_FOUND_OR_DENIED = 'not_found_or_denied'
+export const ERROR_CODE_READONLY = 'readonly'
 
 const IMAGE_UPLOAD_EXTENSIONS = new Set(['avif', 'gif', 'jpg', 'jpeg', 'png', 'webp'])
 const SAFE_UNKNOWN_FILE_EXTENSIONS = new Set(['csv', 'doc', 'docx', 'json', 'md', 'pdf', 'ppt', 'pptx', 'rtf', 'txt', 'xls', 'xlsx', 'zip'])
@@ -118,6 +122,16 @@ function classifyError(
 
   return reply.code(500).send({
     error: { code: ERROR_CODE_INTERNAL, message },
+  })
+}
+
+function requestedFilesystem(value: unknown): string {
+  return typeof value === 'string' && value.length > 0 ? value : USER_FILESYSTEM_ID
+}
+
+function sendNotFoundOrDenied(reply: FastifyReply): FastifyReply {
+  return reply.code(404).send({
+    error: { code: ERROR_CODE_NOT_FOUND_OR_DENIED, message: 'not found or denied' },
   })
 }
 
@@ -246,11 +260,23 @@ function sendValidationError(reply: FastifyReply, message: string, field?: strin
   })
 }
 
+function sendFilesystemBindingMutationDenied(
+  reply: FastifyReply,
+  filesystem: string,
+  access: RuntimeFilesystemBinding['access'],
+): FastifyReply {
+  return reply.code(403).send({
+    error: { code: ERROR_CODE_READONLY, message: `${filesystem} binding is ${access}` },
+  })
+}
+
 export function fileRoutes(
   app: FastifyInstance,
   opts: {
     workspace?: Workspace
     getWorkspace?: (request: FastifyRequest) => Workspace | Promise<Workspace>
+    filesystemBindings?: RuntimeFilesystemBinding[]
+    getFilesystemBindings?: (request: FastifyRequest) => RuntimeFilesystemBinding[] | undefined | Promise<RuntimeFilesystemBinding[] | undefined>
   },
   done: (err?: Error) => void,
 ): void {
@@ -260,10 +286,47 @@ export function fileRoutes(
     throw new Error('file route requires workspace or getWorkspace')
   }
 
+  async function resolveFilesystemBindings(request: FastifyRequest): Promise<RuntimeFilesystemBinding[]> {
+    if (opts.getFilesystemBindings) return await opts.getFilesystemBindings(request) ?? []
+    if (opts.filesystemBindings) return opts.filesystemBindings
+    return []
+  }
+
+  async function resolveFilesystemBinding(request: FastifyRequest, filesystem: string): Promise<RuntimeFilesystemBinding | undefined> {
+    return (await resolveFilesystemBindings(request)).find((binding) => binding.filesystem === filesystem)
+  }
+
+  async function rejectUnsupportedFilesystemMutation(request: FastifyRequest, reply: FastifyReply, filesystem: string): Promise<FastifyReply> {
+    const binding = await resolveFilesystemBinding(request, filesystem)
+    if (!binding) return sendNotFoundOrDenied(reply)
+    if (binding.access === 'readonly') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
+    return reply.code(501).send({
+      error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} binding access is not supported by this route` },
+    })
+  }
+
   app.get('/api/v1/files/raw', async (request, reply) => {
     const query = request.query as Record<string, unknown>
     const path = requireStringParam(query.path, 'path', reply)
     if (path === null) return
+    const filesystem = requestedFilesystem(query.filesystem)
+
+    if (filesystem !== USER_FILESYSTEM_ID) {
+      try {
+        const binding = await resolveFilesystemBinding(request, filesystem)
+        if (!binding || binding.access !== 'readonly') return sendNotFoundOrDenied(reply)
+        const result = await binding.operations.read({ filesystem, path })
+        const bytes = Buffer.from(result.content, 'utf8')
+        return reply
+          .header('content-type', contentTypeForPath(path))
+          .header('content-length', String(bytes.byteLength))
+          .header('cache-control', 'no-store')
+          .header('x-content-type-options', 'nosniff')
+          .send(bytes)
+      } catch {
+        return sendNotFoundOrDenied(reply)
+      }
+    }
 
     try {
       const workspace = await resolveWorkspace(request)
@@ -325,6 +388,18 @@ export function fileRoutes(
     const query = request.query as Record<string, unknown>
     const path = requireStringParam(query.path, 'path', reply)
     if (path === null) return
+    const filesystem = requestedFilesystem(query.filesystem)
+
+    if (filesystem !== USER_FILESYSTEM_ID) {
+      try {
+        const binding = await resolveFilesystemBinding(request, filesystem)
+        if (!binding || binding.access !== 'readonly') return sendNotFoundOrDenied(reply)
+        const result = await binding.operations.read({ filesystem, path })
+        return { content: result.content }
+      } catch {
+        return sendNotFoundOrDenied(reply)
+      }
+    }
 
     try {
       if (isReadonlySkillFilePath(path)) {
@@ -364,6 +439,9 @@ export function fileRoutes(
     // read, verify the file hasn't moved underneath them. Mismatch →
     // 409 with the current mtime so the client can decide whether to
     // reload or force-overwrite.
+    const filesystem = requestedFilesystem(body.filesystem)
+    if (filesystem !== USER_FILESYSTEM_ID) return await rejectUnsupportedFilesystemMutation(request, reply, filesystem)
+
     const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
       ? body.expectedMtimeMs
       : null
@@ -529,6 +607,8 @@ export function fileRoutes(
     const query = request.query as Record<string, unknown>
     const path = requireStringParam(query.path, 'path', reply)
     if (path === null) return
+    const filesystem = requestedFilesystem(query.filesystem)
+    if (filesystem !== USER_FILESYSTEM_ID) return await rejectUnsupportedFilesystemMutation(request, reply, filesystem)
 
     try {
       const workspace = await resolveWorkspace(request)
@@ -545,6 +625,8 @@ export function fileRoutes(
     if (from === null) return
     const to = requireStringParam(body?.to, 'to', reply)
     if (to === null) return
+    const filesystem = requestedFilesystem(body.filesystem)
+    if (filesystem !== USER_FILESYSTEM_ID) return await rejectUnsupportedFilesystemMutation(request, reply, filesystem)
 
     try {
       const workspace = await resolveWorkspace(request)
@@ -561,6 +643,8 @@ export function fileRoutes(
     if (path === null) return
 
     const recursive = body.recursive === true
+    const filesystem = requestedFilesystem(body.filesystem)
+    if (filesystem !== USER_FILESYSTEM_ID) return await rejectUnsupportedFilesystemMutation(request, reply, filesystem)
 
     try {
       const workspace = await resolveWorkspace(request)
@@ -575,6 +659,18 @@ export function fileRoutes(
     const query = request.query as Record<string, unknown>
     const path = requireStringParam(query.path, 'path', reply)
     if (path === null) return
+    const filesystem = requestedFilesystem(query.filesystem)
+
+    if (filesystem !== USER_FILESYSTEM_ID) {
+      try {
+        const binding = await resolveFilesystemBinding(request, filesystem)
+        if (!binding || binding.access !== 'readonly') return sendNotFoundOrDenied(reply)
+        const result = await binding.operations.stat({ filesystem, path })
+        return result.isDirectory ? { kind: 'dir' as const } : { kind: 'file' as const, size: 0 }
+      } catch {
+        return sendNotFoundOrDenied(reply)
+      }
+    }
 
     try {
       if (isReadonlySkillFilePath(path)) {

--- a/packages/agent/src/server/runtime/mode.ts
+++ b/packages/agent/src/server/runtime/mode.ts
@@ -68,6 +68,22 @@ export interface ModeContext {
   telemetry?: TelemetrySink
 }
 
+export interface RuntimeFilesystemBindingOperations {
+  read(descriptor: { filesystem: string; path: string }): Promise<{ content: string; metadata?: unknown }>
+  list(descriptor: { filesystem: string; path: string }): Promise<{ entries: string[]; metadata?: unknown }>
+  find(descriptor: { filesystem: string; path: string }, pattern: string, options?: { limit?: number; offset?: number }): Promise<{ paths: string[]; metadata?: unknown }>
+  grep(descriptor: { filesystem: string; path: string }, pattern: string, options?: { limit?: number; offset?: number }): Promise<{ matches: Array<{ path: string; line: number; text: string }>; metadata?: unknown }>
+  stat(descriptor: { filesystem: string; path: string }): Promise<{ isDirectory: boolean; metadata?: unknown }>
+  rejectMutation(operation: string, descriptor: { filesystem: string; path: string }): never
+}
+
+export interface RuntimeFilesystemBinding {
+  readonly filesystem: string
+  readonly access: 'readonly'
+  readonly operations: RuntimeFilesystemBindingOperations
+}
+
+
 export interface RuntimeBundle {
   runtimeContext?: WorkspaceRuntimeContext
   /**
@@ -85,6 +101,8 @@ export interface RuntimeBundle {
   bash?: RuntimeBashStrategy
   /** Runtime-owned filesystem strategy, consumed by the agent filesystem tool builder. */
   filesystem?: RuntimeFilesystemStrategy
+  /** Optional filesystem bindings prepared for this runtime/session. */
+  filesystemBindings?: RuntimeFilesystemBinding[]
 }
 
 export function getOptionalRuntimeBundleStorageRoot(bundle: RuntimeBundle): string | undefined {

--- a/packages/agent/src/server/tools/filesystem/__tests__/filesystem.test.ts
+++ b/packages/agent/src/server/tools/filesystem/__tests__/filesystem.test.ts
@@ -2,19 +2,31 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { createReadToolDefinition } from '@mariozechner/pi-coding-agent'
 import { describe, expect, test, vi } from 'vitest'
 
 import type { FileSearch } from '../../../../shared/file-search'
 import type { ExecResult, Sandbox } from '../../../../shared/sandbox'
 import type { Workspace } from '../../../../shared/workspace'
 import { createLogger } from '../../../logging'
-import type { RuntimeBundle } from '../../../runtime/mode'
+import type { RuntimeBundle, RuntimeFilesystemBindingOperations } from '../../../runtime/mode'
 import { buildFilesystemAgentTools } from '../index'
 
 const logger = createLogger('[test:tools:filesystem]')
 
 function logStep(step: string, details: Record<string, unknown> = {}): void {
   logger.info('step', { suite: 'filesystem', step, ...details })
+}
+
+function logToolE2e(details: {
+  tool: string
+  filesystem: string
+  path?: string
+  pattern?: string
+  expectedBinding: string
+  resultSummary: string
+}): void {
+  logger.info('company-fs-tool-e2e', details)
 }
 
 function mockWorkspace(root = '/workspace'): Workspace {
@@ -61,6 +73,19 @@ function mockFileSearch(): FileSearch {
   return { search: vi.fn(async () => []) }
 }
 
+function mockReadonlyBindingOperations(): RuntimeFilesystemBindingOperations {
+  return {
+    read: vi.fn(async ({ path }) => ({ content: `company read ${path}`, metadata: { filesystem: 'company_context', path, operation: 'read' } })),
+    list: vi.fn(async ({ path }) => ({ entries: [`company list ${path}`], metadata: { filesystem: 'company_context', path, operation: 'list' } })),
+    find: vi.fn(async ({ path }, pattern) => ({ paths: [`${path}/${pattern}`], metadata: { filesystem: 'company_context', path, operation: 'find' } })),
+    grep: vi.fn(async ({ path }, pattern) => ({ matches: [{ path: `${path}/match.md`, line: 1, text: `company grep ${pattern}` }], metadata: { filesystem: 'company_context', path, operation: 'grep' } })),
+    stat: vi.fn(async ({ path }) => ({ isDirectory: path.endsWith('/'), metadata: { filesystem: 'company_context', path, operation: 'stat' } })),
+    rejectMutation: vi.fn((operation, descriptor) => {
+      throw new Error(`company_context is readonly for ${operation}:${descriptor.path}`)
+    }),
+  }
+}
+
 function mockBundle(provider: string, root = '/workspace', storageRoot?: string): RuntimeBundle {
   const runtimeContext = { runtimeCwd: root }
   return {
@@ -70,6 +95,17 @@ function mockBundle(provider: string, root = '/workspace', storageRoot?: string)
     sandbox: { ...mockSandbox(provider), runtimeContext },
     fileSearch: mockFileSearch(),
     filesystem: provider === 'vercel-sandbox' ? { kind: 'remote-workspace' } : { kind: 'host' },
+  }
+}
+
+function withFilesystemBinding(bundle: RuntimeBundle, operations = mockReadonlyBindingOperations()): RuntimeBundle {
+  return {
+    ...bundle,
+    filesystemBindings: [{
+      filesystem: 'company_context',
+      access: 'readonly',
+      operations,
+    }],
   }
 }
 
@@ -192,6 +228,136 @@ describe('buildFilesystemAgentTools', () => {
     } finally {
       await rm(workspaceRoot, { recursive: true, force: true })
     }
+  })
+
+  test('preserves Pi factory tool identity and does not introduce duplicate company tools', () => {
+    const tools = buildFilesystemAgentTools(mockBundle('direct'))
+    const names = tools.map((tool) => tool.name)
+    const read = tools.find((tool) => tool.name === 'read')
+
+    expect(names).toEqual(['read', 'write', 'edit', 'find', 'grep', 'ls'])
+    expect(names).not.toContain('read_company_context')
+    expect(names).not.toContain('grep_company_context')
+    expect(read?.description).toBe(createReadToolDefinition('/workspace').description)
+    expect(read?.promptSnippet).toBe(createReadToolDefinition('/workspace').promptSnippet)
+  })
+
+  test('named filesystem prompt and schema guidance are gated on advertised binding', () => {
+    const absent = buildFilesystemAgentTools(mockBundle('direct')).find((tool) => tool.name === 'ls')!
+    const present = buildFilesystemAgentTools(withFilesystemBinding(mockBundle('direct'))).find((tool) => tool.name === 'ls')!
+
+    expect(JSON.stringify(absent.parameters)).not.toContain('company_context')
+    expect(absent.promptSnippet ?? '').not.toContain('company_context')
+    expect(JSON.stringify(present.parameters)).toContain('company_context')
+    expect(present.promptSnippet).toContain('Named filesystem bindings')
+    expect(present.promptSnippet).toContain('company_context')
+    expect(present.promptSnippet).toContain('default to the user workspace')
+    expect(present.promptSnippet).toContain('Readonly filesystem bindings reject writes')
+    expect(present.promptSnippet).toContain('do not use path prefixes')
+  })
+
+  test('filesystem parameter is optional and explicit user behaves like omission', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'filesystem-tools-user-'))
+    try {
+      await writeFile(join(workspaceRoot, 'hello.txt'), 'hello user fs', 'utf8')
+      const tools = buildFilesystemAgentTools(withFilesystemBinding(mockBundle('direct', workspaceRoot)))
+      const read = tools.find((tool) => tool.name === 'read')
+      expect(read).toBeDefined()
+      expect((read!.parameters.properties as Record<string, unknown>).filesystem).toMatchObject({ enum: ['user', 'company_context'] })
+
+      const omitted = await read!.execute(
+        { path: 'hello.txt' },
+        { abortSignal: new AbortController().signal, toolCallId: 'read-user-omitted' },
+      )
+      const explicit = await read!.execute(
+        { filesystem: 'user', path: 'hello.txt' },
+        { abortSignal: new AbortController().signal, toolCallId: 'read-user-explicit' },
+      )
+
+      expect(omitted.content[0].text).toContain('hello user fs')
+      expect(explicit.content[0].text).toContain('hello user fs')
+      logToolE2e({ tool: 'read', filesystem: 'default', path: 'hello.txt', expectedBinding: 'user', resultSummary: 'matches explicit user output' })
+    } finally {
+      await rm(workspaceRoot, { recursive: true, force: true })
+    }
+  })
+
+  test('explicit company_context routes read ls find and grep to readonly company operations', async () => {
+    const operations = mockReadonlyBindingOperations()
+    const tools = buildFilesystemAgentTools(withFilesystemBinding(mockBundle('direct'), operations))
+
+    const read = tools.find((tool) => tool.name === 'read')!
+    const ls = tools.find((tool) => tool.name === 'ls')!
+    const find = tools.find((tool) => tool.name === 'find')!
+    const grep = tools.find((tool) => tool.name === 'grep')!
+
+    await expect(read.execute({ filesystem: 'company_context', path: '/company/hr/policy.md' }, { abortSignal: new AbortController().signal, toolCallId: 'company-read' }))
+      .resolves.toMatchObject({
+        content: [{ text: expect.stringContaining('company read /company/hr/policy.md') }],
+        details: { metadata: { filesystem: 'company_context', path: '/company/hr/policy.md', operation: 'read' } },
+      })
+    await expect(ls.execute({ filesystem: 'company_context', path: '/company' }, { abortSignal: new AbortController().signal, toolCallId: 'company-ls' }))
+      .resolves.toMatchObject({ content: [{ text: expect.stringContaining('company list /company') }] })
+    await expect(find.execute({ filesystem: 'company_context', path: '/company', pattern: '*.md' }, { abortSignal: new AbortController().signal, toolCallId: 'company-find' }))
+      .resolves.toMatchObject({ content: [{ text: expect.stringContaining('/company/*.md') }] })
+    await expect(grep.execute({ filesystem: 'company_context', path: '/company', pattern: 'vacation' }, { abortSignal: new AbortController().signal, toolCallId: 'company-grep' }))
+      .resolves.toMatchObject({ content: [{ text: expect.stringContaining('company grep vacation') }] })
+
+    expect(operations.read).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/hr/policy.md' })
+    expect(operations.list).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company' })
+    expect(operations.find).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company' }, '*.md', { limit: undefined })
+    expect(operations.grep).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company' }, 'vacation', { limit: undefined })
+    logToolE2e({ tool: 'read', filesystem: 'company_context', path: '/company/hr/policy.md', expectedBinding: 'company_context', resultSummary: 'company read returned metadata' })
+    logToolE2e({ tool: 'ls', filesystem: 'company_context', path: '/company', expectedBinding: 'company_context', resultSummary: 'company list returned allowed entries' })
+    logToolE2e({ tool: 'find', filesystem: 'company_context', path: '/company', pattern: '*.md', expectedBinding: 'company_context', resultSummary: 'company find returned allowed paths' })
+    logToolE2e({ tool: 'grep', filesystem: 'company_context', path: '/company', pattern: 'vacation', expectedBinding: 'company_context', resultSummary: 'company grep returned allowed matches' })
+  })
+
+  test('company_context mutation tools reject readonly binding and path spoofing does not switch filesystem', async () => {
+    const operations = mockReadonlyBindingOperations()
+    const tools = buildFilesystemAgentTools(withFilesystemBinding(mockBundle('direct'), operations))
+    const write = tools.find((tool) => tool.name === 'write')!
+    const read = tools.find((tool) => tool.name === 'read')!
+
+    await expect(write.execute(
+      { filesystem: 'company_context', path: '/company/hr/policy.md', content: 'mutate' },
+      { abortSignal: new AbortController().signal, toolCallId: 'company-write' },
+    )).rejects.toThrow('company_context is readonly for write')
+    expect(operations.rejectMutation).toHaveBeenCalledWith('write', { filesystem: 'company_context', path: '/company/hr/policy.md' })
+
+    await expect(read.execute(
+      { filesystem: 'company_context', path: 'company_context:/company/hr/policy.md' },
+      { abortSignal: new AbortController().signal, toolCallId: 'company-spoof-uri' },
+    )).rejects.toThrow('filesystem prefixes are not valid path strings')
+    await expect(read.execute(
+      { filesystem: 'company_context', path: '/company_context/company/hr/policy.md' },
+      { abortSignal: new AbortController().signal, toolCallId: 'company-spoof-prefix' },
+    )).rejects.toThrow('filesystem prefixes are not valid path strings')
+    expect(operations.read).not.toHaveBeenCalledWith({ filesystem: 'company_context', path: 'company_context:/company/hr/policy.md' })
+    logToolE2e({ tool: 'write', filesystem: 'company_context', path: '/company/hr/policy.md', expectedBinding: 'company_context-readonly', resultSummary: 'mutation rejected' })
+    logToolE2e({ tool: 'read', filesystem: 'company_context', path: '<spoof>', expectedBinding: 'none', resultSummary: 'path spoof rejected before company read' })
+  })
+
+  test('remote filesystem tools also accept company_context without bypassing workspace user default', async () => {
+    const operations = mockReadonlyBindingOperations()
+    const bundle = withFilesystemBinding(mockBundle('vercel-sandbox'), operations)
+    vi.mocked(bundle.workspace.readFile).mockResolvedValueOnce('remote user content')
+    const tools = buildFilesystemAgentTools(bundle)
+    const read = tools.find((tool) => tool.name === 'read')!
+
+    const userResult = await read.execute(
+      { filesystem: 'user', path: 'remote.txt' },
+      { abortSignal: new AbortController().signal, toolCallId: 'remote-user' },
+    )
+    const companyResult = await read.execute(
+      { filesystem: 'company_context', path: '/company/hr/policy.md' },
+      { abortSignal: new AbortController().signal, toolCallId: 'remote-company' },
+    )
+
+    expect(userResult.content[0].text).toContain('remote user content')
+    expect(companyResult.content[0].text).toContain('company read /company/hr/policy.md')
+    expect(bundle.workspace.readFile).toHaveBeenCalledWith('remote.txt')
+    expect(operations.read).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/hr/policy.md' })
   })
 
   test('direct find rejects absolute paths outside the workspace', async () => {

--- a/packages/agent/src/server/tools/filesystem/index.ts
+++ b/packages/agent/src/server/tools/filesystem/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@mariozechner/pi-coding-agent'
 
 import type { AgentTool } from '../../../shared/tool'
-import { getRuntimeBundleStorageRoot, type RuntimeBundle, type RuntimeFilesystemStrategy } from '../../runtime/mode'
+import { getRuntimeBundleStorageRoot, type RuntimeBundle, type RuntimeFilesystemBindingOperations, type RuntimeFilesystemStrategy } from '../../runtime/mode'
 import { boundFs } from '../operations/bound'
 import { buildRemoteWorkspaceFilesystemAgentTools } from './remoteWorkspaceTools'
 
@@ -37,19 +37,162 @@ function isTextContent(
   return content.type === 'text' && typeof content.text === 'string'
 }
 
-function adaptPiTool<TParams extends Record<string, unknown>>(
-  piTool: PiToolLike<TParams>,
-): AgentTool {
+function filesystemBindings(bundle: RuntimeBundle) {
+  return bundle.filesystemBindings ?? []
+}
+
+function filesystemIds(bundle: RuntimeBundle): string[] {
+  return filesystemBindings(bundle).map((binding) => binding.filesystem)
+}
+
+function withFilesystemParameter(parameters: unknown, filesystemIds: readonly string[]): Record<string, unknown> {
+  const schema: Record<string, unknown> = parameters && typeof parameters === 'object'
+    ? { ...(parameters as Record<string, unknown>) }
+    : { type: 'object' }
+  const properties = schema.properties && typeof schema.properties === 'object'
+    ? { ...(schema.properties as Record<string, unknown>) }
+    : {}
+  return {
+    ...schema,
+    properties: {
+      ...properties,
+      filesystem: {
+        type: 'string',
+        description: filesystemIds.length > 0
+          ? 'Logical filesystem to use. Omit or use user for workspace files; use an advertised named filesystem for bound readonly context.'
+          : 'Logical filesystem to use. Omit or use user for workspace files.',
+        enum: ['user', ...filesystemIds],
+      },
+    },
+  }
+}
+
+function requestedFilesystem(params: Record<string, unknown>): string {
+  const value = params.filesystem
+  return typeof value === 'string' && value.length > 0 ? value : 'user'
+}
+
+function withoutFilesystem<TParams extends Record<string, unknown>>(params: Record<string, unknown>): TParams {
+  const { filesystem: _filesystem, ...rest } = params
+  return rest as TParams
+}
+
+function boundFilesystemPath(params: Record<string, unknown>): string {
+  const value = params.path
+  return typeof value === 'string' && value.length > 0 ? value : '/'
+}
+
+function assertNotFilesystemPathSpoof(path: string, filesystemIds: readonly string[]): void {
+  const normalized = path.replace(/\\/g, '/')
+  if (normalized.includes(':/') || filesystemIds.some((filesystem) => normalized === `/${filesystem}` || normalized.startsWith(`/${filesystem}/`))) {
+    throw new Error('filesystem prefixes are not valid path strings; use the filesystem parameter')
+  }
+}
+
+function filesystemBinding(bundle: RuntimeBundle, filesystem: string) {
+  return filesystemBindings(bundle).find((binding) => binding.filesystem === filesystem)
+}
+
+function boundOperations(bundle: RuntimeBundle, filesystem: string): RuntimeFilesystemBindingOperations {
+  const binding = filesystemBinding(bundle, filesystem)
+  if (!binding) throw new Error(`No filesystem binding is available for ${filesystem}`)
+  return binding.operations
+}
+
+function formatBoundRead(content: string): PiToolResultLike {
+  return { content: [{ type: 'text', text: content }] }
+}
+
+function formatBoundList(entries: string[]): PiToolResultLike {
+  return { content: [{ type: 'text', text: entries.join('\n') }] }
+}
+
+function formatBoundFind(paths: string[]): PiToolResultLike {
+  return { content: [{ type: 'text', text: paths.join('\n') }] }
+}
+
+function formatBoundGrep(matches: Array<{ path: string; line: number; text: string }>): PiToolResultLike {
+  return { content: [{ type: 'text', text: matches.map((match) => `${match.path}:${match.line}:${match.text}`).join('\n') }] }
+}
+
+async function executeBoundFilesystemTool(toolName: string, filesystem: string, params: Record<string, unknown>, bundle: RuntimeBundle): Promise<PiToolResultLike> {
+  const path = boundFilesystemPath(params)
+  assertNotFilesystemPathSpoof(path, filesystemIds(bundle))
+  const operations = boundOperations(bundle, filesystem)
+
+  if (toolName === 'read') {
+    const result = await operations.read({ filesystem, path })
+    return { ...formatBoundRead(result.content), details: { metadata: result.metadata } }
+  }
+  if (toolName === 'ls') {
+    const result = await operations.list({ filesystem, path })
+    return { ...formatBoundList(result.entries), details: { metadata: result.metadata } }
+  }
+  if (toolName === 'find') {
+    const pattern = typeof params.pattern === 'string' ? params.pattern : '*'
+    const limit = typeof params.limit === 'number' ? params.limit : undefined
+    const result = await operations.find({ filesystem, path }, pattern, { limit })
+    return { ...formatBoundFind(result.paths), details: { metadata: result.metadata } }
+  }
+  if (toolName === 'grep') {
+    const pattern = typeof params.pattern === 'string' ? params.pattern : ''
+    const limit = typeof params.limit === 'number' ? params.limit : undefined
+    const result = await operations.grep({ filesystem, path }, pattern, { limit })
+    return { ...formatBoundGrep(result.matches), details: { metadata: result.metadata } }
+  }
+  if (toolName === 'write' || toolName === 'edit') {
+    operations.rejectMutation(toolName, { filesystem, path })
+  }
+  throw new Error(`Tool ${toolName} does not support filesystem ${filesystem}`)
+}
+
+function withBoundFilesystemPromptGuidance(promptSnippet: string | undefined, filesystemIds: readonly string[]): string | undefined {
+  if (filesystemIds.length === 0) return promptSnippet
+  const guidance = [
+    'Named filesystem bindings: file tools default to the user workspace when filesystem is omitted.',
+    `Use the filesystem parameter explicitly for bound readonly context (${filesystemIds.join(', ')}), and start browsing at / unless told otherwise.`,
+    'Readonly filesystem bindings reject writes; do not use path prefixes like filesystem:/x to switch filesystem.',
+  ].join('\n')
+  return [promptSnippet, guidance].filter(Boolean).join('\n')
+}
+
+function withFilesystemRouting(tool: AgentTool, bundle: RuntimeBundle): AgentTool {
+  const ids = filesystemIds(bundle)
+  return {
+    ...tool,
+    promptSnippet: withBoundFilesystemPromptGuidance(tool.promptSnippet, ids),
+    parameters: withFilesystemParameter(tool.parameters, ids),
+    async execute(params, ctx) {
+      const filesystem = requestedFilesystem(params)
+      if (filesystem !== 'user') {
+        const result = await executeBoundFilesystemTool(tool.name, filesystem, params, bundle)
+        const textContent = (result.content ?? [])
+          .filter(isTextContent)
+          .map((c) => ({ type: 'text' as const, text: c.text }))
+        return {
+          content: textContent.length > 0 ? textContent : [{ type: 'text', text: '' }],
+          isError: false,
+          details: result.details,
+        }
+      }
+      return await tool.execute(withoutFilesystem(params), ctx)
+    },
+  }
+}
+
+function adaptPiTool<TParams extends Record<string, unknown>>(piTool: PiToolLike<TParams>): AgentTool {
   return {
     name: piTool.name,
     readinessRequirements: ['workspace-fs'],
     description: piTool.description,
     promptSnippet: piTool.promptSnippet,
-    parameters: piTool.parameters as Record<string, unknown>,
+    parameters: piTool.parameters && typeof piTool.parameters === 'object'
+      ? { ...(piTool.parameters as Record<string, unknown>) }
+      : { type: 'object' },
     async execute(params, ctx) {
       const result = await piTool.execute(
         ctx.toolCallId,
-        params as TParams,
+        withoutFilesystem<TParams>(params),
         ctx.abortSignal,
         ctx.onUpdate
           ? (update) => {
@@ -86,6 +229,7 @@ export function buildFilesystemAgentTools(bundle: RuntimeBundle): AgentTool[] {
 
   if (strategy.kind === 'remote-workspace') {
     return buildRemoteWorkspaceFilesystemAgentTools(bundle, strategy.pathOptions)
+      .map((tool) => withFilesystemRouting(tool, bundle))
   }
 
   const storageRoot = getRuntimeBundleStorageRoot(bundle)
@@ -97,5 +241,5 @@ export function buildFilesystemAgentTools(bundle: RuntimeBundle): AgentTool[] {
     adaptPiTool(createFindToolDefinition(cwd, { operations: ops.find })),
     adaptPiTool(createGrepToolDefinition(cwd, { operations: ops.grep })),
     adaptPiTool(createLsToolDefinition(cwd, { operations: ops.ls })),
-  ]
+  ].map((tool) => withFilesystemRouting(tool, bundle))
 }

--- a/packages/agent/src/server/workspace/__tests__/createNodeWorkspace.watch.test.ts
+++ b/packages/agent/src/server/workspace/__tests__/createNodeWorkspace.watch.test.ts
@@ -122,6 +122,7 @@ describe('createNodeWorkspace.watch', () => {
     await ws.writeFile('visible.txt', 'visible')
     await waitForEvent(events, (e) => e.op === 'write' && e.path === 'visible.txt')
     expect(events.some((e) => e.op === 'write' && e.path === 'visible.txt')).toBe(true)
+    await wait(SETTLE_MS)
     events.length = 0
 
     for (const dir of ignoredDirs) {


### PR DESCRIPTION
## Stack position
2 / 5 in the #416 governed `company_context` filesystem stack.

Base: #428 / `bclaw/416-pr1-boring-bash-bindings`.
Next: `bclaw/416-pr3-workspace-ui-identity`.

## What this adds
- Threads optional `filesystem?: "user" | "company_context" | string` through the existing agent filesystem tools instead of adding duplicate company-specific tools.
- Keeps omitted/explicit `user` behavior identical to today's workspace filesystem behavior.
- Routes explicit `company_context` reads/list/find/grep through the readonly company operations.
- Rejects company mutations with a stable readonly error.
- Updates file HTTP routes so persisted/deeplink company tabs can fetch `/api/v1/files`, `/api/v1/files/raw`, and `/api/v1/stat` using explicit `filesystem=company_context`.
- Sanitizes denied/missing company reads as `not_found_or_denied`.

## Review notes
The important behavior is explicit identity only: strings such as `company_context:/x` remain normal user paths unless the caller supplies `filesystem: "company_context"`.

This PR depends on #428 for the binding/operation implementation but keeps the agent surface backward compatible.

## Validation
- `pnpm --dir packages/agent exec vitest run src/server/tools/filesystem/__tests__/filesystem.test.ts src/server/http/routes/__tests__/file.test.ts` — passed
- `pnpm --filter @hachej/boring-agent typecheck` — passed on the full final stack
