### PR TITLE
#416 company-fs: preserve filesystem identity in the workspace UI bridge

### DIFF
--- a/packages/workspace/src/front/bridge/WorkspaceLink.tsx
+++ b/packages/workspace/src/front/bridge/WorkspaceLink.tsx
@@ -1,10 +1,11 @@
 import type { MouseEvent, ReactElement, ReactNode } from "react"
+import type { FilesystemId } from "../../shared/types/filesystem"
 import type { UiCommand } from "./types"
 import { postUiCommand } from "./uiCommandBus"
 
 export type WorkspaceLinkTarget =
-  | { kind: "openFile"; path: string; mode?: "view" | "edit" | "diff" }
-  | { kind: "openSurface"; surfaceKind: string; target: string; meta?: Record<string, unknown> }
+  | { kind: "openFile"; path: string; mode?: "view" | "edit" | "diff"; filesystem?: FilesystemId }
+  | { kind: "openSurface"; surfaceKind: string; target: string; filesystem?: FilesystemId; meta?: Record<string, unknown> }
   | { kind: "openPanel"; id: string; component: string; title?: string; params?: Record<string, unknown> }
   | { kind: "expandToFile"; path: string }
 
@@ -20,9 +21,9 @@ export interface WorkspaceLinkProps {
 export function workspaceLinkCommand(to: WorkspaceLinkTarget): UiCommand {
   switch (to.kind) {
     case "openFile":
-      return { kind: "openFile", params: { path: to.path, ...(to.mode ? { mode: to.mode } : {}) } }
+      return { kind: "openFile", params: { path: to.path, ...(to.mode ? { mode: to.mode } : {}), ...(to.filesystem ? { filesystem: to.filesystem } : {}) } }
     case "openSurface":
-      return { kind: "openSurface", params: { kind: to.surfaceKind, target: to.target, ...(to.meta ? { meta: to.meta } : {}) } }
+      return { kind: "openSurface", params: { kind: to.surfaceKind, target: to.target, ...(to.filesystem ? { filesystem: to.filesystem } : {}), ...(to.meta ? { meta: to.meta } : {}) } }
     case "openPanel":
       return {
         kind: "openPanel",

--- a/packages/workspace/src/front/bridge/__tests__/WorkspaceLink.test.tsx
+++ b/packages/workspace/src/front/bridge/__tests__/WorkspaceLink.test.tsx
@@ -10,12 +10,20 @@ describe("workspaceLinkCommand", () => {
       kind: "openFile",
       params: { path: "src/app.ts", mode: "edit" },
     })
+    expect(workspaceLinkCommand({ kind: "openFile", path: "/company/hr/policy.md", filesystem: "company_context" })).toEqual({
+      kind: "openFile",
+      params: { path: "/company/hr/policy.md", filesystem: "company_context" },
+    })
   })
 
   test("maps openSurface targets to canonical UI commands", () => {
     expect(workspaceLinkCommand({ kind: "openSurface", surfaceKind: "niche", target: "climate", meta: { source: "test" } })).toEqual({
       kind: "openSurface",
       params: { kind: "niche", target: "climate", meta: { source: "test" } },
+    })
+    expect(workspaceLinkCommand({ kind: "openSurface", surfaceKind: "workspace.open.path", target: "/company/hr/policy.md", filesystem: "company_context" })).toEqual({
+      kind: "openSurface",
+      params: { kind: "workspace.open.path", target: "/company/hr/policy.md", filesystem: "company_context" },
     })
   })
 

--- a/packages/workspace/src/front/bridge/__tests__/bridge.test.ts
+++ b/packages/workspace/src/front/bridge/__tests__/bridge.test.ts
@@ -78,7 +78,7 @@ describe("createBridge", () => {
       const bridge = createBridge(store)
       const result = await bridge.openFile("/a.ts")
       expect(result.status).toBe("ok")
-      expect(store.state.openFile).toHaveBeenCalledWith("/a.ts", "file:/a.ts")
+      expect(store.state.openFile).toHaveBeenCalledWith("/a.ts", "file:user:/a.ts")
     })
 
     it("rejects path traversal", async () => {
@@ -99,7 +99,7 @@ describe("createBridge", () => {
       await bridge.openFile("/a.ts")
       const result = await bridge.openFile("/a.ts")
       expect(result.status).toBe("ok")
-      expect(store.state.activatePanel).toHaveBeenCalledWith("file:/a.ts")
+      expect(store.state.activatePanel).toHaveBeenCalledWith("file:user:/a.ts")
     })
 
     it("rejects when at max panels", async () => {
@@ -115,13 +115,13 @@ describe("createBridge", () => {
 
     it("activates existing panel even at max capacity", async () => {
       store.state.panels = Array.from({ length: 50 }, (_, i) => ({
-        id: i === 0 ? "file:/a.ts" : `p-${i}`,
+        id: i === 0 ? "file:user:/a.ts" : `p-${i}`,
         component: "editor",
       }))
       const bridge = createBridge(store)
       const result = await bridge.openFile("/a.ts")
       expect(result.status).toBe("ok")
-      expect(store.state.activatePanel).toHaveBeenCalledWith("file:/a.ts")
+      expect(store.state.activatePanel).toHaveBeenCalledWith("file:user:/a.ts")
     })
 
     it("fires file:opened event", async () => {
@@ -129,7 +129,28 @@ describe("createBridge", () => {
       const handler = vi.fn()
       bridge.subscribe("file:opened", handler)
       await bridge.openFile("/a.ts")
-      expect(handler).toHaveBeenCalledWith({ path: "/a.ts", mode: "edit" })
+      expect(handler).toHaveBeenCalledWith({ path: "/a.ts", mode: "edit", filesystem: "user" })
+    })
+
+    it("preserves explicit filesystem in openFile params, panel id, and events", async () => {
+      const bridge = createBridge(store)
+      const handler = vi.fn()
+      bridge.subscribe("file:opened", handler)
+      const result = await bridge.openFile("/company/hr/policy.md", { filesystem: "company_context", mode: "view" })
+      expect(result.status).toBe("ok")
+      expect(store.state.openPanel).toHaveBeenCalledWith(expect.objectContaining({
+        id: "file:company_context:/company/hr/policy.md",
+        params: { path: "/company/hr/policy.md", mode: "view", filesystem: "company_context" },
+      }))
+      expect(handler).toHaveBeenCalledWith({ path: "/company/hr/policy.md", mode: "view", filesystem: "company_context" })
+    })
+
+    it("opens same path in user and company_context as distinct panels", async () => {
+      const bridge = createBridge(store)
+      await bridge.openFile("/same.md")
+      await bridge.openFile("/same.md", { filesystem: "company_context" })
+      expect(store.state.openPanel).toHaveBeenCalledWith(expect.objectContaining({ id: "file:user:/same.md" }))
+      expect(store.state.openPanel).toHaveBeenCalledWith(expect.objectContaining({ id: "file:company_context:/same.md" }))
     })
   })
 

--- a/packages/workspace/src/front/bridge/__tests__/client.test.ts
+++ b/packages/workspace/src/front/bridge/__tests__/client.test.ts
@@ -191,7 +191,22 @@ describe("createBridgeClient", () => {
       )
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(bridge.openFile).toHaveBeenCalledWith("/foo.ts", { mode: "edit" })
+      expect(bridge.openFile).toHaveBeenCalledWith("/foo.ts", { mode: "edit", filesystem: undefined })
+      client.disconnect()
+    })
+
+    it("dispatches openFile filesystem command payloads through bridge", async () => {
+      const { client, bridge } = createClient()
+      client.connect()
+      const es = MockEventSource.instances[0]
+
+      es.emit(
+        "command",
+        JSON.stringify({ v: 1, kind: "openFile", params: { path: "/company/hr/policy.md", filesystem: "company_context" } }),
+      )
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(bridge.openFile).toHaveBeenCalledWith("/company/hr/policy.md", { mode: undefined, filesystem: "company_context" })
       client.disconnect()
     })
 

--- a/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
+++ b/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
@@ -8,8 +8,10 @@ function fakeSurface(): SurfaceShellApi & {
   __panels: unknown[]
   __expanded: string[]
   __leftClosed: number
+  __openFileCalls: Array<{ path: string; filesystem?: string }>
 } {
   const opened: string[] = []
+  const openFileCalls: Array<{ path: string; filesystem?: string }> = []
   const surfaces: unknown[] = []
   const panels: unknown[] = []
   const expanded: string[] = []
@@ -19,8 +21,12 @@ function fakeSurface(): SurfaceShellApi & {
     __panels: unknown[]
     __expanded: string[]
     __leftClosed: number
+    __openFileCalls: Array<{ path: string; filesystem?: string }>
   } = {
-    openFile: (path: string) => opened.push(path),
+    openFile: (path: string, options?: { filesystem?: string }) => {
+      opened.push(path)
+      openFileCalls.push({ path, filesystem: options?.filesystem })
+    },
     openSurface: (request: unknown) => surfaces.push(request),
     openPanel: (cfg: unknown) => panels.push(cfg),
     expandToFile: (path: string) => expanded.push(path),
@@ -29,6 +35,7 @@ function fakeSurface(): SurfaceShellApi & {
     },
     getSnapshot: (): SurfaceShellSnapshot => ({ openTabs: [], activeTab: null }),
     __opened: opened,
+    __openFileCalls: openFileCalls,
     __surfaces: surfaces,
     __panels: panels,
     __expanded: expanded,
@@ -51,10 +58,17 @@ function ctx(over: Partial<DispatchContext> = {}, surface = fakeSurface()): Disp
 }
 
 describe("dispatchUiCommand", () => {
-  it("openFile calls surface.openFile with the path", () => {
+  it("openFile calls surface.openFile with the path and legacy user filesystem", () => {
     const c = ctx()
     dispatchUiCommand({ kind: "openFile", params: { path: "greeter.ts" } }, c)
     expect(c.__surface.__opened).toEqual(["greeter.ts"])
+    expect(c.__surface.__openFileCalls).toEqual([{ path: "greeter.ts", filesystem: "user" }])
+  })
+
+  it("openFile forwards explicit company_context filesystem", () => {
+    const c = ctx()
+    dispatchUiCommand({ kind: "openFile", params: { path: "/company/hr/policy.md", filesystem: "company_context" } }, c)
+    expect(c.__surface.__openFileCalls).toEqual([{ path: "/company/hr/policy.md", filesystem: "company_context" }])
   })
 
   it("openFile is a no-op when path is missing or non-string", () => {
@@ -157,7 +171,31 @@ describe("dispatchUiCommand", () => {
       {
         kind: "data-catalog.open-row",
         target: "orders_daily",
+        filesystem: "user",
         meta: { catalogId: "metrics" },
+      },
+    ])
+  })
+
+  it("openSurface forwards explicit filesystem for path surfaces", () => {
+    const c = ctx()
+    dispatchUiCommand(
+      {
+        kind: "openSurface",
+        params: {
+          kind: "workspace.open.path",
+          target: "/company/hr/policy.md",
+          filesystem: "company_context",
+        },
+      },
+      c,
+    )
+    expect(c.__surface.__surfaces).toEqual([
+      {
+        kind: "workspace.open.path",
+        target: "/company/hr/policy.md",
+        filesystem: "company_context",
+        meta: undefined,
       },
     ])
   })
@@ -174,7 +212,7 @@ describe("dispatchUiCommand", () => {
     }
     expect(c.__surface.__surfaces).toEqual([])
     expect(openWorkbench).not.toHaveBeenCalled()
-    expect(skipped).toHaveBeenCalledWith(expect.objectContaining({ detail: { kind: "questions", target: "q1", meta: { openOnlyWhenSessionOpen: true } } }))
+    expect(skipped).toHaveBeenCalledWith(expect.objectContaining({ detail: { kind: "questions", target: "q1", filesystem: "user", meta: { openOnlyWhenSessionOpen: true } } }))
   })
 
   it("skips session-gated openSurface when no host policy is available", () => {
@@ -189,7 +227,7 @@ describe("dispatchUiCommand", () => {
     }
     expect(c.__surface.__surfaces).toEqual([])
     expect(openWorkbench).not.toHaveBeenCalled()
-    expect(skipped).toHaveBeenCalledWith(expect.objectContaining({ detail: { kind: "questions", target: "q1", meta: { sessionId: "s1", openOnlyWhenSessionOpen: true } } }))
+    expect(skipped).toHaveBeenCalledWith(expect.objectContaining({ detail: { kind: "questions", target: "q1", filesystem: "user", meta: { sessionId: "s1", openOnlyWhenSessionOpen: true } } }))
   })
 
   it("marks openSurface as ephemeral when it had to open a closed workbench", () => {
@@ -198,7 +236,7 @@ describe("dispatchUiCommand", () => {
     let open = false
     const c = ctx({ isWorkbenchOpen: () => open, openWorkbench: () => { open = true } }, surface)
     dispatchUiCommand({ kind: "openSurface", params: { kind: "questions", target: "q1" } }, c)
-    expect(c.__surface.__surfaces).toEqual([{ kind: "questions", target: "q1", meta: { closeWorkbenchOnDone: true } }])
+    expect(c.__surface.__surfaces).toEqual([{ kind: "questions", target: "q1", filesystem: "user", meta: { closeWorkbenchOnDone: true } }])
     raf.mockRestore()
   })
 

--- a/packages/workspace/src/front/bridge/client.ts
+++ b/packages/workspace/src/front/bridge/client.ts
@@ -82,7 +82,12 @@ async function dispatchCommand(
     case "openFile":
       await bridge.openFile(
         params.path as string,
-        params.mode ? { mode: params.mode as "view" | "edit" | "diff" } : undefined,
+        params.mode || params.filesystem
+          ? {
+              mode: params.mode as "view" | "edit" | "diff" | undefined,
+              filesystem: params.filesystem as string | undefined,
+            }
+          : undefined,
       )
       break
     case "openPanel":

--- a/packages/workspace/src/front/bridge/createBridge.ts
+++ b/packages/workspace/src/front/bridge/createBridge.ts
@@ -6,6 +6,7 @@ import type {
   DynamicPaneConfig,
   Unsubscribe,
 } from "./types"
+import { normalizeUiFilesystem, uiFileResourceKey } from "../../shared/types/filesystem"
 import {
   openFileSchema,
   openPanelSchema,
@@ -69,12 +70,13 @@ export function createBridge(store: StoreApi): WorkspaceBridge {
     },
 
     async openFile(path, opts) {
-      const parsed = openFileSchema.safeParse({ path, mode: opts?.mode })
+      const parsed = openFileSchema.safeParse({ path, mode: opts?.mode, filesystem: opts?.filesystem })
       if (!parsed.success) return err("VALIDATION", parsed.error.issues[0].message)
 
       const state = store.getState()
       const mode = parsed.data.mode ?? "edit"
-      const panelId = `file:${path}`
+      const filesystem = normalizeUiFilesystem(parsed.data.filesystem)
+      const panelId = `file:${uiFileResourceKey({ filesystem, path })}`
       const existing = state.panels.find((p) => p.id === panelId)
       if (existing) {
         const prev = state.activePanel
@@ -92,9 +94,9 @@ export function createBridge(store: StoreApi): WorkspaceBridge {
       }
 
       state.openFile(path, panelId)
-      state.openPanel({ id: panelId, component: "editor", params: { path, mode } })
-      emit("file:opened", { path, mode })
-      emit("panel:opened", { panelId, params: { path, mode } })
+      state.openPanel({ id: panelId, component: "editor", params: { path, mode, filesystem } })
+      emit("file:opened", { path, mode, filesystem })
+      emit("panel:opened", { panelId, params: { path, mode, filesystem } })
       return ok()
     },
 

--- a/packages/workspace/src/front/bridge/types.ts
+++ b/packages/workspace/src/front/bridge/types.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceState, PanelState } from "../store/types"
+import type { FilesystemId } from "../../shared/types/filesystem"
 
 export interface CommandResult {
   seq: number
@@ -17,7 +18,7 @@ export interface BridgeEventMap {
   "panel:opened": { panelId: string; params: Record<string, unknown> }
   "panel:closed": { panelId: string }
   "panel:activated": { panelId: string; previousPanelId: string | null }
-  "file:opened": { path: string; mode: "view" | "edit" | "diff" }
+  "file:opened": { path: string; mode: "view" | "edit" | "diff"; filesystem?: FilesystemId }
   "file:saved": { path: string }
   "file:dirty": { path: string; dirty: boolean }
   "sidebar:toggled": { collapsed: boolean }
@@ -43,7 +44,7 @@ export interface WorkspaceBridge {
 
   openFile(
     path: string,
-    opts?: { mode?: "view" | "edit" | "diff" },
+    opts?: { mode?: "view" | "edit" | "diff"; filesystem?: FilesystemId },
   ): Promise<CommandResult>
   openPanel(config: DynamicPaneConfig): Promise<CommandResult>
   closePanel(id: string): Promise<CommandResult>

--- a/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
+++ b/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
@@ -7,6 +7,7 @@
  */
 import type { SurfaceShellApi, OpenPanelConfig } from "../chrome/artifact-surface/SurfaceShell"
 import type { UiCommand } from "./types"
+import { normalizeUiFilesystem } from "../../shared/types/filesystem"
 import type { SurfaceOpenRequest } from "../../shared/types/surface"
 
 /**
@@ -83,6 +84,7 @@ function surfaceRequestParam(params: Record<string, unknown>): SurfaceOpenReques
   return {
     kind,
     target,
+    filesystem: normalizeUiFilesystem(strParam(params, "filesystem")),
     meta: recordParam(params, "meta"),
   }
 }
@@ -129,7 +131,7 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
       if (wasClosed) ctx.openWorkbench()
       const run = (surface: SurfaceShellApi) => {
         try {
-          surface.openFile(path)
+          surface.openFile(path, { filesystem: normalizeUiFilesystem(strParam(cmd.params, "filesystem")) })
         } catch (err) {
           // eslint-disable-next-line no-console -- intentional dev signal
           console.warn(

--- a/packages/workspace/src/front/bridge/validation.ts
+++ b/packages/workspace/src/front/bridge/validation.ts
@@ -17,6 +17,7 @@ const safePath = z
 export const openFileSchema = z.object({
   path: safePath,
   mode: z.enum(["view", "edit", "diff"]).optional(),
+  filesystem: z.string().min(1).optional(),
 })
 
 export const openPanelSchema = z.object({

--- a/packages/workspace/src/front/chrome/artifact-surface/ArtifactSurfacePane.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/ArtifactSurfacePane.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo } from "react"
 import type { DockviewApi } from "dockview-react"
+import { normalizeUiFilesystem, uiFileResourceKey } from "../../../shared/types/filesystem"
 import { DockviewShell } from "../../dock"
 import type { LayoutConfig, SerializedLayout } from "../../dock"
 import { cn } from "../../lib/utils"
@@ -63,7 +64,49 @@ function readStoredLayoutState(
     if (typeof comp !== "string") return { status: "invalid" }
     if (allowed && !allowed.has(comp)) return { status: "blocked-by-allowed-panels" }
   }
-  return { status: "ready", layout: layout as SerializedLayout }
+  return { status: "ready", layout: normalizePersistedFilePanelIdentity(layout as SerializedLayout) }
+}
+
+function replaceLayoutPanelId(value: unknown, from: string, to: string): unknown {
+  if (value === from) return to
+  if (Array.isArray(value)) return value.map((item) => replaceLayoutPanelId(item, from, to))
+  if (!value || typeof value !== "object") return value
+  const out: Record<string, unknown> = {}
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    out[key] = replaceLayoutPanelId(child, from, to)
+  }
+  return out
+}
+
+function normalizePersistedFilePanelIdentity(layout: SerializedLayout): SerializedLayout {
+  const clone = structuredClone(layout) as { panels?: Record<string, unknown> }
+  const panels = clone.panels
+  if (!panels || typeof panels !== "object") return clone as SerializedLayout
+
+  for (const [key, entry] of Object.entries(panels)) {
+    if (!entry || typeof entry !== "object") continue
+    const panel = entry as Record<string, unknown>
+    const params = panel.params && typeof panel.params === "object"
+      ? { ...(panel.params as Record<string, unknown>) }
+      : undefined
+    const rawPath = typeof params?.path === "string"
+      ? params.path
+      : key.startsWith("file:") ? key.slice("file:".length) : undefined
+    if (!rawPath) continue
+    const filesystem = normalizeUiFilesystem(typeof params?.filesystem === "string" ? params.filesystem : undefined)
+    const nextParams = { ...(params ?? {}), path: rawPath, filesystem }
+    panel.params = nextParams
+
+    if (!key.startsWith("file:")) continue
+    const nextId = `file:${uiFileResourceKey({ filesystem, path: rawPath })}`
+    if (key === nextId) continue
+    panel.id = typeof panel.id === "string" && panel.id === key ? nextId : panel.id
+    delete panels[key]
+    panels[nextId] = panel
+    Object.assign(clone, replaceLayoutPanelId(clone, key, nextId))
+  }
+
+  return clone as SerializedLayout
 }
 
 function layoutHasPanels(layout: SerializedLayout): boolean {
@@ -126,7 +169,7 @@ export function ArtifactSurfacePane({
       ) {
         return
       }
-      const envelope: StoredEnvelope = { v: STORAGE_VERSION, layout }
+      const envelope: StoredEnvelope = { v: STORAGE_VERSION, layout: normalizePersistedFilePanelIdentity(layout) }
       try {
         window.localStorage.setItem(storageKey, JSON.stringify(envelope))
       } catch {

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -12,6 +12,7 @@ import type { WorkspaceBridge, CommandResult, BridgeEventMap } from "../../bridg
 import type { WorkspaceState, PanelState } from "../../store/types"
 import { WorkbenchLeftPane } from "../workbench-left/WorkbenchLeftPane"
 import { useRegistry, useSurfaceResolverRegistry } from "../../registry"
+import { normalizeUiFilesystem, type FilesystemId } from "../../../shared/types/filesystem"
 import type { SurfaceOpenRequest } from "../../../shared/types/surface"
 import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../../shared/types/surface"
 import { isSharedDockviewPlacement, isWorkspacePagePlacement } from "../../../shared/types/panel"
@@ -47,9 +48,14 @@ export interface OpenPanelConfig {
   params?: Record<string, unknown>
 }
 
+export interface SurfaceShellOpenFileOptions {
+  filesystem?: FilesystemId
+  mode?: "view" | "edit" | "diff"
+}
+
 export interface SurfaceShellApi {
-  /** Open a file in the workbench. Idempotent — re-activates an existing pane for the same path. */
-  openFile: (path: string, opts?: { mode?: "view" | "edit" | "diff" }) => void
+  /** Open a file in the workbench. Idempotent — re-activates an existing pane for the same filesystem/path. */
+  openFile: (path: string, options?: SurfaceShellOpenFileOptions) => void
   /** Open a plugin-defined surface target through the registered surface resolvers. */
   openSurface: (request: SurfaceOpenRequest) => void
   /**
@@ -189,12 +195,13 @@ let seqCounter = 0
 function fileBackedParams(
   params: Record<string, unknown> | undefined,
   path: string,
-  opts?: { mode?: "view" | "edit" | "diff" },
+  options?: SurfaceShellOpenFileOptions,
 ): Record<string, unknown> {
   return {
     ...(params ?? {}),
     path: typeof params?.path === "string" ? params.path : path,
-    ...(opts?.mode ? { mode: opts.mode } : {}),
+    ...(options?.mode ? { mode: options.mode } : {}),
+    ...(options?.filesystem ? { filesystem: options.filesystem } : {}),
     [FILE_BACKED_PARAM]: true,
   }
 }
@@ -343,7 +350,26 @@ export function SurfaceShell({
     if (component) applyPanelPlacementTransition(component)
   }, [applyPanelPlacementTransition])
 
-  const openFileSync = useCallback((path: string, opts?: { mode?: "view" | "edit" | "diff" }) => {
+  const activateExistingFilePanel = useCallback((
+    api: DockviewApi,
+    path: string,
+    filesystem: FilesystemId,
+    component: string,
+    params: Record<string, unknown>,
+  ): boolean => {
+    const existing = findOpenFilePanel(api, path, filesystem)
+    if (!existing) return false
+    // Only reuse legacy/path-matched panels when they still resolve to the same
+    // component. If a newer resolver takes over the path (for example CSV),
+    // opening should create the newer panel instead of reactivating stale UI.
+    if (dockviewPanelComponent(existing) !== component) return false
+    existing.api.updateParameters(params)
+    existing.api.setActive()
+    applyPanelPlacementTransition(component)
+    return true
+  }, [applyPanelPlacementTransition])
+
+  const openFileSync = useCallback((path: string, options?: SurfaceShellOpenFileOptions) => {
     const api = apiRef.current
     if (!api) {
       console.warn("[SurfaceShell] openFile: surface not ready (dockview not initialized)")
@@ -353,6 +379,7 @@ export function SurfaceShell({
     const request: SurfaceOpenRequest = {
       kind: WORKSPACE_OPEN_PATH_SURFACE_KIND,
       target: normalizedPath,
+      filesystem: normalizeUiFilesystem(options?.filesystem),
     }
     const resolved = surfaceResolverRegistryRef.current.resolve(request)
     if (resolved) {
@@ -361,23 +388,25 @@ export function SurfaceShell({
         return
       }
       const panelId = surfacePanelId(request, resolved)
+      const params = fileBackedParams(resolved.params, normalizedPath, { filesystem: request.filesystem, mode: options?.mode })
       fileBackedPanelIdsRef.current.add(panelId)
+      if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) return
       activateDockviewPanel({
         id: panelId,
         component: resolved.component,
         title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
-        params: fileBackedParams(resolved.params, normalizedPath, opts),
+        params,
       })
       return
     }
 
-    const existing = findOpenFilePanel(api, normalizedPath)
+    const existing = findOpenFilePanel(api, normalizedPath, request.filesystem)
     if (existing) {
       existing.api.setActive()
       return
     }
     console.warn(`[SurfaceShell] openFile: no surface resolver matched "${normalizedPath}"`)
-  }, [activateDockviewPanel])
+  }, [activateDockviewPanel, activateExistingFilePanel])
 
   const openSurfaceSync = useCallback((request: SurfaceOpenRequest) => {
     const normalizedRequest = normalizeSurfaceOpenRequest(request)
@@ -404,12 +433,20 @@ export function SurfaceShell({
       ? fileBackedParams(
           resolved.params,
           normalizedRequest.target,
-          surfaceMode === "view" || surfaceMode === "edit" || surfaceMode === "diff" ? { mode: surfaceMode } : undefined,
+          {
+            filesystem: normalizedRequest.filesystem,
+            ...(surfaceMode === "view" || surfaceMode === "edit" || surfaceMode === "diff" ? { mode: surfaceMode } : {}),
+          },
         )
       : resolved.params
     const resolvedParams = closeWorkbenchOnDone && onCloseRef.current
       ? { ...(baseParams ?? {}), __closeWorkbenchOnDone: onCloseRef.current }
       : baseParams
+    if (
+      normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND &&
+      apiRef.current &&
+      activateExistingFilePanel(apiRef.current, normalizedRequest.target, normalizeUiFilesystem(normalizedRequest.filesystem), resolved.component, resolvedParams ?? {})
+    ) return
     if (!activateDockviewPanel({
       id: panelId,
       component: resolved.component,
@@ -418,7 +455,7 @@ export function SurfaceShell({
     })) {
       console.warn("[SurfaceShell] openSurface: surface not ready (dockview not initialized)")
     }
-  }, [activateDockviewPanel])
+  }, [activateDockviewPanel, activateExistingFilePanel])
 
   const openPanelSync = useCallback((config: OpenPanelConfig) => {
     const api = apiRef.current
@@ -575,7 +612,7 @@ export function SurfaceShell({
 
 
   const openFile = useCallback(
-    async (path: string, opts?: { mode?: "view" | "edit" | "diff" }): Promise<CommandResult> => {
+    async (path: string, options?: SurfaceShellOpenFileOptions): Promise<CommandResult> => {
       try {
         const api = apiRef.current
         if (!api) return err("not-ready", "surface not ready")
@@ -583,6 +620,7 @@ export function SurfaceShell({
         const request: SurfaceOpenRequest = {
           kind: WORKSPACE_OPEN_PATH_SURFACE_KIND,
           target: normalizedPath,
+          filesystem: normalizeUiFilesystem(options?.filesystem),
         }
         const resolved = surfaceResolverRegistryRef.current.resolve(request)
         if (resolved) {
@@ -593,17 +631,19 @@ export function SurfaceShell({
             )
           }
           const panelId = surfacePanelId(request, resolved)
+          const params = fileBackedParams(resolved.params, normalizedPath, { filesystem: request.filesystem, mode: options?.mode })
           fileBackedPanelIdsRef.current.add(panelId)
+          if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) return ok()
           activateDockviewPanel({
             id: panelId,
             component: resolved.component,
             title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
-            params: fileBackedParams(resolved.params, normalizedPath, opts),
+            params,
           })
           return ok()
         }
 
-        const existing = findOpenFilePanel(api, normalizedPath)
+        const existing = findOpenFilePanel(api, normalizedPath, request.filesystem)
         if (existing) {
           existing.api.setActive()
           return ok()
@@ -616,7 +656,7 @@ export function SurfaceShell({
         )
       }
     },
-    [activateDockviewPanel],
+    [activateDockviewPanel, activateExistingFilePanel],
   )
 
   const bridge = useMemo<WorkspaceBridge>(() => {

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/ArtifactSurfacePane.persistence.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/ArtifactSurfacePane.persistence.test.tsx
@@ -59,11 +59,11 @@ const KEY = "test:surface-layout"
 // allowedPanels component, since validation drops layouts with unknown
 // contentComponents.
 function buildLayout(
-  panels: Array<{ id: string; component: string }> = [{ id: "p1", component: "empty" }],
+  panels: Array<{ id: string; component: string; params?: Record<string, unknown> }> = [{ id: "p1", component: "empty" }],
 ): SerializedLayout {
   const panelMap: Record<string, unknown> = {}
   for (const p of panels) {
-    panelMap[p.id] = { id: p.id, contentComponent: p.component }
+    panelMap[p.id] = { id: p.id, contentComponent: p.component, ...(p.params ? { params: p.params } : {}) }
   }
   return {
     activeGroup: panels[0]?.id,
@@ -107,6 +107,49 @@ describe("ArtifactSurfacePane — layout persistence", () => {
     expect(raw).not.toBeNull()
     const parsed = JSON.parse(raw as string)
     expect(parsed).toEqual({ v: 1, layout })
+  })
+
+  it("migrates legacy persisted file panels to explicit user filesystem identity", () => {
+    const layout = buildLayout([{ id: "file:README.md", component: "empty", params: { path: "README.md" } }])
+    localStorage.setItem(KEY, envelope(layout))
+    renderPane(<ArtifactSurfacePane storageKey={KEY} />)
+    expect(capturedProps.persistedLayout).toEqual(expect.objectContaining({
+      panels: {
+        "file:user:README.md": expect.objectContaining({
+          id: "file:user:README.md",
+          params: { path: "README.md", filesystem: "user" },
+        }),
+      },
+    }))
+  })
+
+  it("preserves explicit company filesystem identity in persisted file panels", () => {
+    const layout = buildLayout([{ id: "file:company_context:/company/hr/policy.md", component: "empty", params: { path: "/company/hr/policy.md", filesystem: "company_context" } }])
+    localStorage.setItem(KEY, envelope(layout))
+    renderPane(<ArtifactSurfacePane storageKey={KEY} />)
+    expect(capturedProps.persistedLayout).toEqual(expect.objectContaining({
+      panels: {
+        "file:company_context:/company/hr/policy.md": expect.objectContaining({
+          id: "file:company_context:/company/hr/policy.md",
+          params: { path: "/company/hr/policy.md", filesystem: "company_context" },
+        }),
+      },
+    }))
+  })
+
+  it("writes file panel layouts with explicit filesystem identity", () => {
+    renderPane(<ArtifactSurfacePane storageKey={KEY} />)
+    const layout = buildLayout([{ id: "file:README.md", component: "empty", params: { path: "README.md" } }])
+    act(() => {
+      capturedProps.onLayoutChange?.(layout)
+    })
+    const parsed = JSON.parse(localStorage.getItem(KEY) as string)
+    expect(parsed.layout.panels).toEqual({
+      "file:user:README.md": expect.objectContaining({
+        id: "file:user:README.md",
+        params: { path: "README.md", filesystem: "user" },
+      }),
+    })
   })
 
   it("round-trips: a written layout is restored on next mount", () => {

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -11,6 +11,7 @@ let capturedSurfaceStorageKey: string | undefined
 let capturedAllowedPanels: string[] | undefined
 let capturedWorkbenchBridge: any
 let mockAddPanel = vi.fn()
+let mockPanels: any[] = []
 let mockGetPanel: (id: string) => unknown = vi.fn(() => undefined)
 
 vi.mock("../../workbench-left/WorkbenchLeftPane", () => ({
@@ -27,7 +28,7 @@ vi.mock("../ArtifactSurfacePane", async () => {
     capturedAllowedPanels = props.allowedPanels
     React.useEffect(() => {
       props.onReady?.({
-        panels: [],
+        panels: mockPanels,
         activePanel: null,
         getPanel: mockGetPanel,
         addPanel: mockAddPanel,
@@ -65,6 +66,7 @@ describe("SurfaceShell", () => {
     capturedAllowedPanels = undefined
     capturedWorkbenchBridge = undefined
     mockAddPanel = vi.fn()
+    mockPanels = []
     mockGetPanel = vi.fn(() => undefined)
     localStorage.clear()
   })
@@ -138,14 +140,80 @@ describe("SurfaceShell", () => {
     await waitFor(() => expect(surface).toBeDefined())
 
     await act(async () => {
-      await surface?.openFile("data.csv")
+      await surface?.openFile("README.md")
+    })
+    expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({
+      id: "file:user:README.md",
+      component: "editor",
+      params: expect.objectContaining({ path: "README.md", filesystem: "user" }),
+    }))
+
+    mockAddPanel.mockClear()
+    await act(async () => {
+      await surface?.openFile("data.csv", { filesystem: "company_context" })
     })
 
     expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({
-      id: "hot-csv:data.csv",
+      id: "file:company_context:data.csv",
       component: "hot-csv.panel",
-      params: expect.objectContaining({ path: "data.csv" }),
+      params: expect.objectContaining({ path: "data.csv", filesystem: "company_context" }),
     }))
+  })
+
+  it("reactivates legacy user file panels instead of duplicating default workspace opens", async () => {
+    let surface: SurfaceShellApi | undefined
+    const legacySetActive = vi.fn()
+    const legacyUpdateParameters = vi.fn()
+    mockPanels = [{
+      id: "file:README.md",
+      component: "editor",
+      params: { path: "README.md" },
+      api: { setActive: legacySetActive, updateParameters: legacyUpdateParameters },
+    }]
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("editor", { title: "Editor", placement: "center", component: () => null })
+    const surfaceResolverRegistry = new SurfaceResolverRegistry()
+    surfaceResolverRegistry.register("filesystem", {
+      source: "builtin",
+      resolve: (request) => request.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND
+        ? { component: "editor", params: { path: request.target }, score: 0 }
+        : undefined,
+    })
+
+    renderSurface("workspace-a", { onReady: (api) => { surface = api } }, panelRegistry, surfaceResolverRegistry)
+    await waitFor(() => expect(surface).toBeDefined())
+
+    await act(async () => {
+      await surface?.openFile("README.md")
+    })
+
+    expect(mockAddPanel).not.toHaveBeenCalled()
+    expect(legacyUpdateParameters).toHaveBeenCalledWith(expect.objectContaining({ path: "README.md", filesystem: "user" }))
+    expect(legacySetActive).toHaveBeenCalled()
+  })
+
+  it("opens the same path in user and company_context as distinct surface panels", async () => {
+    let surface: SurfaceShellApi | undefined
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("editor", { title: "Editor", placement: "center", component: () => null })
+    const surfaceResolverRegistry = new SurfaceResolverRegistry()
+    surfaceResolverRegistry.register("filesystem", {
+      source: "builtin",
+      resolve: (request) => request.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND
+        ? { component: "editor", params: { path: request.target }, score: 0 }
+        : undefined,
+    })
+
+    renderSurface("workspace-a", { onReady: (api) => { surface = api } }, panelRegistry, surfaceResolverRegistry)
+    await waitFor(() => expect(surface).toBeDefined())
+
+    await act(async () => {
+      await surface?.openFile("same.md")
+      await surface?.openFile("same.md", { filesystem: "company_context" })
+    })
+
+    expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({ id: "file:user:same.md" }))
+    expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({ id: "file:company_context:same.md" }))
   })
 
   it("routes openSurface path requests through the latest resolver before stale file tabs", async () => {
@@ -175,13 +243,13 @@ describe("SurfaceShell", () => {
     await waitFor(() => expect(surface).toBeDefined())
 
     act(() => {
-      surface?.openSurface({ kind: WORKSPACE_OPEN_PATH_SURFACE_KIND, target: "data.csv" })
+      surface?.openSurface({ kind: WORKSPACE_OPEN_PATH_SURFACE_KIND, target: "data.csv", filesystem: "company_context" })
     })
 
     expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({
-      id: "hot-csv:data.csv",
+      id: "file:company_context:data.csv",
       component: "hot-csv.panel",
-      params: expect.objectContaining({ path: "data.csv" }),
+      params: expect.objectContaining({ path: "data.csv", filesystem: "company_context" }),
     }))
   })
 

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/resolvePanelForPath.test.ts
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/resolvePanelForPath.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { normalizeSurfaceOpenRequest, resolvePanelForPath } from "../SurfaceShell"
+import { surfacePanelId } from "../surfaceShellHelpers"
 import { SurfaceResolverRegistry } from "../../../../shared/plugins/SurfaceResolverRegistry"
 
 function makeRegistry(matches: Record<string, string>) {
@@ -24,7 +25,20 @@ describe("normalizeSurfaceOpenRequest", () => {
     })).toEqual({
       kind: "workspace.open.path",
       target: "src/index.ts",
+      filesystem: "user",
       meta: { source: "test" },
+    })
+  })
+
+  it("preserves explicit filesystem on workspace path surface targets", () => {
+    expect(normalizeSurfaceOpenRequest({
+      kind: "workspace.open.path",
+      target: "/company/hr/policy.md",
+      filesystem: "company_context",
+    })).toEqual({
+      kind: "workspace.open.path",
+      target: "/company/hr/policy.md",
+      filesystem: "company_context",
     })
   })
 
@@ -38,6 +52,26 @@ describe("normalizeSurfaceOpenRequest", () => {
   it("does not alter non-path surface targets", () => {
     const request = { kind: "data-catalog.open-row", target: "../series" }
     expect(normalizeSurfaceOpenRequest(request)).toBe(request)
+  })
+})
+
+describe("surfacePanelId", () => {
+  it("uses filesystem resource identity for workspace path surfaces", () => {
+    expect(surfacePanelId(
+      { kind: "workspace.open.path", target: "/same.md" },
+      { id: "resolver:/same.md", component: "editor" },
+    )).toBe("file:user:/same.md")
+    expect(surfacePanelId(
+      { kind: "workspace.open.path", target: "/same.md", filesystem: "company_context" },
+      { id: "resolver:/same.md", component: "editor" },
+    )).toBe("file:company_context:/same.md")
+  })
+
+  it("does not infer filesystem from path prefixes", () => {
+    expect(surfacePanelId(
+      { kind: "workspace.open.path", target: "company_context:/same.md" },
+      { component: "editor" },
+    )).toBe("file:user:company_context:/same.md")
   })
 })
 

--- a/packages/workspace/src/front/chrome/artifact-surface/surfaceShellHelpers.ts
+++ b/packages/workspace/src/front/chrome/artifact-surface/surfaceShellHelpers.ts
@@ -4,6 +4,7 @@ import type {
   SurfacePanelResolution,
   SurfaceResolverConfig,
 } from "../../../shared/types/surface"
+import { normalizeUiFilesystem, uiFileResourceKey } from "../../../shared/types/filesystem"
 import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../../shared/types/surface"
 
 export function resolvePanelForPath(
@@ -24,12 +25,13 @@ export function normalizeWorkbenchPath(path: string): string {
   return normalized
 }
 
-export function findOpenFilePanel(api: DockviewApi, path: string) {
-  const panelId = `file:${path}`
+export function findOpenFilePanel(api: DockviewApi, path: string, filesystem = normalizeUiFilesystem(undefined)) {
+  const panelId = `file:${uiFileResourceKey({ filesystem, path })}`
   return api.getPanel(panelId)
-    ?? api.panels.find((panel) =>
-      (panel.params as Record<string, unknown> | undefined)?.path === path
-    )
+    ?? api.panels.find((panel) => {
+      const params = panel.params as Record<string, unknown> | undefined
+      return params?.path === path && normalizeUiFilesystem(typeof params.filesystem === "string" ? params.filesystem : undefined) === filesystem
+    })
 }
 
 export function normalizeSurfaceOpenRequest(
@@ -39,6 +41,7 @@ export function normalizeSurfaceOpenRequest(
   return {
     ...request,
     target: normalizeWorkbenchPath(request.target),
+    filesystem: normalizeUiFilesystem(request.filesystem),
   }
 }
 
@@ -46,5 +49,8 @@ export function surfacePanelId(
   request: SurfaceOpenRequest,
   resolved: SurfacePanelResolution,
 ): string {
+  if (request.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND) {
+    return `file:${uiFileResourceKey({ filesystem: normalizeUiFilesystem(request.filesystem), path: request.target })}`
+  }
   return resolved.id ?? `surface:${request.kind}:${request.target}`
 }

--- a/packages/workspace/src/front/chrome/chat/__tests__/ChatPanelHost.test.tsx
+++ b/packages/workspace/src/front/chrome/chat/__tests__/ChatPanelHost.test.tsx
@@ -223,7 +223,7 @@ describe("ChatPanelHost", () => {
       rafQueue.shift()?.(0)
       expect(openFile).not.toHaveBeenCalled()
       rafQueue.shift()?.(0)
-      expect(openFile).toHaveBeenCalledWith("src/example.ts")
+      expect(openFile).toHaveBeenCalledWith("src/example.ts", { filesystem: "user" })
       expect(onOpenArtifact).toHaveBeenCalledWith("src/example.ts")
     } finally {
       global.requestAnimationFrame = originalRaf

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -941,7 +941,7 @@ describe("ChatLayout component", () => {
       })
     })
 
-    expect(openFile).toHaveBeenCalledWith("src/App.tsx")
+    expect(openFile).toHaveBeenCalledWith("src/App.tsx", { filesystem: "user" })
   })
 
   it("updates panel slots when a panel registers after mount", async () => {

--- a/packages/workspace/src/server/__tests__/uiTools.test.ts
+++ b/packages/workspace/src/server/__tests__/uiTools.test.ts
@@ -122,6 +122,32 @@ describe("createExecUiTool — path validation", () => {
     }
   })
 
+  test("openFile with company_context bypasses user workspace stat validation", async () => {
+    const tool = createExecUiTool(bridge, { workspaceRoot })
+    const result = await tool.execute(
+      { kind: "openFile", params: { path: "/company/hr/policy.md", filesystem: "company_context" } },
+      FAKE_CTX,
+    )
+    expect(result.isError).toBeFalsy()
+    await expect(bridge.drainCommands!()).resolves.toEqual([
+      expect.objectContaining({
+        kind: "openFile",
+        params: { path: "/company/hr/policy.md", filesystem: "company_context" },
+      }),
+    ])
+  })
+
+  test("openFile with company_context still rejects traversal syntax", async () => {
+    const tool = createExecUiTool(bridge, { workspaceRoot })
+    const result = await tool.execute(
+      { kind: "openFile", params: { path: "../finance.txt", filesystem: "company_context" } },
+      FAKE_CTX,
+    )
+    expect(result.isError).toBe(true)
+    const text = result.content[0]
+    if (text?.type === "text") expect(text.text).toMatch(/escapes/)
+  })
+
   test("openFile rejects paths that escape the workspace root", async () => {
     const tool = createExecUiTool(bridge, { workspaceRoot })
     const result = await tool.execute(
@@ -165,13 +191,15 @@ describe("createExecUiTool — path validation", () => {
     expect(result.isError).toBe(true)
   })
 
-  test("exec_ui advertises openSurface", () => {
+  test("exec_ui advertises openSurface filesystem", () => {
     const tool = createExecUiTool(bridge, { workspaceRoot })
     const parameters = tool.parameters as {
       properties?: { kind?: { enum?: string[] } }
     }
     const kind = parameters.properties?.kind
     expect(kind?.enum).toContain("openSurface")
+    expect(tool.description).toContain("openSurface  params: { kind: string, target: string, filesystem?: 'user'|'company_context', meta?: object }")
+    expect(tool.description).toContain("For kind:'workspace.open.path', filesystem follows")
   })
 
   test("non-path kinds (openPanel, openSurface, showNotification, closeWorkbenchLeftPane) do not get path-validated", async () => {

--- a/packages/workspace/src/server/ui-control/tools/uiTools.ts
+++ b/packages/workspace/src/server/ui-control/tools/uiTools.ts
@@ -13,6 +13,7 @@
 import { stat } from "node:fs/promises"
 import { resolve, isAbsolute, relative, win32 } from "node:path"
 import type { AgentTool, ToolResult } from "../../../shared/types/agent-tool"
+import { normalizeUiFilesystem, USER_FILESYSTEM_ID } from "../../../shared/types/filesystem"
 import type { WorkspaceBridge, UiCommand, UiState } from "../../../shared/ui-bridge"
 
 function makeError(message: string): ToolResult {
@@ -76,9 +77,10 @@ function isOutsideWorkspaceRel(rel: string): boolean {
 function validatePathSyntax(
   relPath: string,
   workspaceRoot?: string,
+  opts: { allowAbsolute?: boolean } = {},
 ): { ok: true } | { ok: false; reason: string } {
   const rootHint = workspaceRoot ? ` (${workspaceRoot})` : ""
-  if (isPathAbsolute(relPath)) {
+  if (!opts.allowAbsolute && isPathAbsolute(relPath)) {
     return {
       ok: false,
       reason: `path "${relPath}" is absolute — pass a path relative to the workspace root${rootHint}.`,
@@ -175,7 +177,11 @@ function isVerified(
   const tabs = (state.openTabs as UiTab[] | undefined) ?? []
   if (kind === "openFile") {
     const path = typeof params.path === "string" ? params.path : null
-    return path !== null && tabs.some((t) => t.params?.path === path)
+    const filesystem = normalizeUiFilesystem(typeof params.filesystem === "string" ? params.filesystem : undefined)
+    return path !== null && tabs.some((t) =>
+      t.params?.path === path &&
+      normalizeUiFilesystem(typeof t.params?.filesystem === "string" ? t.params.filesystem : undefined) === filesystem
+    )
   }
   if (kind === "openPanel") {
     const id = typeof params.id === "string" ? params.id : null
@@ -220,7 +226,7 @@ export function createExecUiTool(
       "",
       "Supported `kind` values:",
       "",
-      "  openFile     params: { path: string, mode?: 'view'|'edit'|'diff' }",
+      "  openFile     params: { path: string, mode?: 'view'|'edit'|'diff', filesystem?: 'user'|'company_context' }",
       "               — Open a file in the workbench. The workbench pane",
       "                 auto-opens if collapsed. Path must be relative to the",
       "                 workspace root (e.g. `src/foo.ts`, not `foo.ts` if it",
@@ -235,6 +241,8 @@ export function createExecUiTool(
       "                 is found.",
       "                 If the path is a folder, openFile reveals/selects it in",
       "                 the file tree instead of opening an editor tab.",
+      "                 Omit filesystem for normal workspace files (defaults to user). Use filesystem:'company_context' only when a company_context binding is advertised.",
+      "                 Path prefixes such as company_context:/x do not switch filesystem identity.",
       "                 Example: {kind:'openFile', params:{path:'README.md'}}",
       "",
       "  openPanel    params: { id: string, component: string,",
@@ -249,11 +257,15 @@ export function createExecUiTool(
       "                          component:'chart-canvas',",
       "                          params:{seriesId:'GDPC1'}}}",
       "",
-      "  openSurface  params: { kind: string, target: string, meta?: object }",
+      "  openSurface  params: { kind: string, target: string, filesystem?: 'user'|'company_context', meta?: object }",
       "               — Open an app-owned target through the workspace",
       "                 surface resolver registry. Use this when the app",
       "                 defines the mapping from domain target to panel",
       "                 component, for example a catalog row.",
+      "                 For kind:'workspace.open.path', filesystem follows the",
+      "                 same rules as openFile: omit for user files; pass",
+      "                 filesystem:'company_context' only for advertised company",
+      "                 context bindings; path prefixes do not switch identity.",
       "                 Example: {kind:'openSurface', params:{",
       "                          kind:'catalog.open-row',",
       "                          target:'orders_daily',",
@@ -333,9 +345,10 @@ export function createExecUiTool(
 
       // Validate path-bearing kinds before queueing so the agent gets
       // immediate feedback rather than the frontend silently no-op'ing on a
-      // malformed path. In remote modes workspaceRoot may be omitted because
-      // the host cannot stat the microVM filesystem; still enforce relative,
-      // non-traversing paths, and only stat-check when a local root is known.
+      // malformed path. Only the default user filesystem is rooted at
+      // workspaceRoot; alternate filesystem identities are separate bindings,
+      // so they get syntax validation but must not be stat-checked against the
+      // user workspace or converted to expandToFile by user-workspace dirs.
       let effectiveKind = kind
 
       if (PATH_BEARING_KINDS.has(kind)) {
@@ -345,30 +358,35 @@ export function createExecUiTool(
             `${kind}: ${kind === "navigateToLine" ? "file" : "path"} param is required`,
           )
         }
-        const syntax = validatePathSyntax(relPath, workspaceRoot)
+        const filesystem = kind === "openFile"
+          ? normalizeUiFilesystem(typeof cmdParams.filesystem === "string" ? cmdParams.filesystem : undefined)
+          : USER_FILESYSTEM_ID
+        const syntax = validatePathSyntax(relPath, workspaceRoot, { allowAbsolute: filesystem !== USER_FILESYSTEM_ID })
         if (!syntax.ok) return makeError(syntax.reason)
-        if (workspaceRoot) {
-          const check = await validateExistingPath(workspaceRoot, relPath)
-          if (!check.ok) {
-            return makeError(check.reason)
-          }
-          if (kind === "openFile" && check.kind === "dir") {
-            effectiveKind = "expandToFile"
-          }
-        } else if (resolvePathKind) {
-          const pathKind = await resolvePathKind(relPath)
-          if (!pathKind) {
-            return makeError(`file not found at "${relPath}". Try find or grep to locate the file before retrying openFile.`)
-          }
-          if (kind === "openFile" && pathKind === "dir") {
-            effectiveKind = "expandToFile"
+        if (filesystem === USER_FILESYSTEM_ID) {
+          if (workspaceRoot) {
+            const check = await validateExistingPath(workspaceRoot, relPath)
+            if (!check.ok) {
+              return makeError(check.reason)
+            }
+            if (kind === "openFile" && check.kind === "dir") {
+              effectiveKind = "expandToFile"
+            }
+          } else if (resolvePathKind) {
+            const pathKind = await resolvePathKind(relPath)
+            if (!pathKind) {
+              return makeError(`file not found at "${relPath}". Try find or grep to locate the file before retrying openFile.`)
+            }
+            if (kind === "openFile" && pathKind === "dir") {
+              effectiveKind = "expandToFile"
+            }
           }
         }
       }
 
       try {
         const command: UiCommand = { kind: effectiveKind, params: cmdParams }
-        const result = await workspaceBridge.emitUiEffect(command)
+        const result = await workspaceBridge.postCommand(command)
         if (result.status === "error") {
           return {
             content: [{ type: "text", text: JSON.stringify(result) }],

--- a/packages/workspace/src/shared/__tests__/filesystem.test.ts
+++ b/packages/workspace/src/shared/__tests__/filesystem.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "vitest"
+
+import {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  USER_FILESYSTEM_ID,
+  normalizeUiFileResource,
+  normalizeUiFilesystem,
+  uiFileResourceKey,
+  withUiFileResource,
+} from "../types/filesystem"
+
+describe("UI filesystem identity primitives", () => {
+  test("legacy path-only resources bind to user filesystem", () => {
+    expect(normalizeUiFilesystem(undefined)).toBe(USER_FILESYSTEM_ID)
+    expect(normalizeUiFileResource("/src/app.ts")).toEqual({
+      filesystem: USER_FILESYSTEM_ID,
+      path: "/src/app.ts",
+    })
+    expect(normalizeUiFileResource({ path: "/src/app.ts" })).toEqual({
+      filesystem: USER_FILESYSTEM_ID,
+      path: "/src/app.ts",
+    })
+  })
+
+  test("company resources require explicit filesystem field", () => {
+    expect(normalizeUiFileResource({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/policy.md" }))
+      .toEqual({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/policy.md" })
+    expect(normalizeUiFileResource("/company/hr/policy.md")).toEqual({
+      filesystem: USER_FILESYSTEM_ID,
+      path: "/company/hr/policy.md",
+    })
+  })
+
+  test("path prefix strings do not switch filesystem identity", () => {
+    expect(normalizeUiFileResource("company_context:/company/hr/policy.md")).toEqual({
+      filesystem: USER_FILESYSTEM_ID,
+      path: "company_context:/company/hr/policy.md",
+    })
+    expect(normalizeUiFileResource("/company_context/company/hr/policy.md")).toEqual({
+      filesystem: USER_FILESYSTEM_ID,
+      path: "/company_context/company/hr/policy.md",
+    })
+  })
+
+  test("resource keys separate identical paths across filesystems", () => {
+    expect(uiFileResourceKey({ filesystem: USER_FILESYSTEM_ID, path: "/same.md" }))
+      .toBe("user:/same.md")
+    expect(uiFileResourceKey({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/same.md" }))
+      .toBe("company_context:/same.md")
+  })
+
+  test("withUiFileResource preserves payload while filling legacy user default", () => {
+    expect(withUiFileResource({ path: "/a.ts", mode: "edit" })).toEqual({
+      filesystem: USER_FILESYSTEM_ID,
+      path: "/a.ts",
+      mode: "edit",
+    })
+    expect(withUiFileResource({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/a.ts" })).toEqual({
+      filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+      path: "/a.ts",
+    })
+  })
+})

--- a/packages/workspace/src/shared/index.ts
+++ b/packages/workspace/src/shared/index.ts
@@ -34,6 +34,19 @@ export type {
 } from "./workspace-bridge-rpc"
 export type { PanelConfig, CommandConfig, PaneProps, PanelRegistration } from "./types/panel"
 export type {
+  FilesystemId,
+  UiFileResource,
+  UiFileResourceInput,
+} from "./types/filesystem"
+export {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  USER_FILESYSTEM_ID,
+  normalizeUiFileResource,
+  normalizeUiFilesystem,
+  uiFileResourceKey,
+  withUiFileResource,
+} from "./types/filesystem"
+export type {
   SurfaceOpenRequest,
   SurfacePanelResolution,
   SurfaceResolverConfig,

--- a/packages/workspace/src/shared/types/filesystem.ts
+++ b/packages/workspace/src/shared/types/filesystem.ts
@@ -1,0 +1,47 @@
+export type FilesystemId = "user" | "company_context" | (string & {})
+
+export const USER_FILESYSTEM_ID = "user" satisfies FilesystemId
+export const COMPANY_CONTEXT_FILESYSTEM_ID = "company_context" satisfies FilesystemId
+
+export interface UiFileResource {
+  readonly filesystem: FilesystemId
+  readonly path: string
+}
+
+export type UiFileResourceInput = string | {
+  readonly filesystem?: FilesystemId | null
+  readonly path: string
+}
+
+export function normalizeUiFilesystem(filesystem: FilesystemId | null | undefined): FilesystemId {
+  return filesystem && filesystem.length > 0 ? filesystem : USER_FILESYSTEM_ID
+}
+
+export function normalizeUiFileResource(input: UiFileResourceInput): UiFileResource {
+  if (typeof input === "string") {
+    return { filesystem: USER_FILESYSTEM_ID, path: input }
+  }
+  return {
+    filesystem: normalizeUiFilesystem(input.filesystem),
+    path: input.path,
+  }
+}
+
+export function uiFileResourceKey(resource: UiFileResourceInput): string {
+  const normalized = normalizeUiFileResource(resource)
+  return `${normalized.filesystem}:${normalized.path}`
+}
+
+export function withUiFileResource<T extends Record<string, unknown>>(
+  value: T,
+  fallbackFilesystem?: FilesystemId | null,
+): T & UiFileResource {
+  const filesystem = typeof value.filesystem === "string"
+    ? value.filesystem
+    : normalizeUiFilesystem(fallbackFilesystem)
+  return {
+    ...value,
+    filesystem,
+    path: String(value.path ?? ""),
+  } as T & UiFileResource
+}

--- a/packages/workspace/src/shared/types/surface.ts
+++ b/packages/workspace/src/shared/types/surface.ts
@@ -1,8 +1,11 @@
+import type { FilesystemId } from "./filesystem"
+
 export const WORKSPACE_OPEN_PATH_SURFACE_KIND = "workspace.open.path"
 
 export interface SurfaceOpenRequest {
   kind: string
   target: string
+  filesystem?: FilesystemId
   meta?: Record<string, unknown>
 }
 

--- a/packages/workspace/src/shared/ui-bridge.ts
+++ b/packages/workspace/src/shared/ui-bridge.ts
@@ -1,3 +1,5 @@
+import type { FilesystemId } from "./types/filesystem"
+
 export interface UiBridge {
   getState(): Promise<UiState | null>
   setState(state: UiState): Promise<void>
@@ -15,8 +17,8 @@ export type WorkspaceBridge = UiBridge & {
 export type UiState = Record<string, unknown>
 
 export type UiCommand =
-  | { kind: 'openFile'; params: { path: string; mode?: 'view' | 'edit' | 'diff' } }
-  | { kind: 'openSurface'; params: { kind: string; target: string; meta?: Record<string, unknown> } }
+  | { kind: 'openFile'; params: { path: string; mode?: 'view' | 'edit' | 'diff'; filesystem?: FilesystemId } }
+  | { kind: 'openSurface'; params: { kind: string; target: string; filesystem?: FilesystemId; meta?: Record<string, unknown> } }
   | { kind: 'openPanel'; params: { id: string; component: string; params?: Record<string, unknown> } }
   | { kind: 'closePanel'; params: { id: string } }
   | { kind: 'closeWorkbenchLeftPane'; params: Record<string, never> }

--- a/plugins/deck/src/front/__tests__/deckPluginScaffold.test.tsx
+++ b/plugins/deck/src/front/__tests__/deckPluginScaffold.test.tsx
@@ -144,10 +144,10 @@ describe("deck scaffold", () => {
     })
 
     expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({
-      id: "surface:workspace.open.path:briefings/weekly.md",
+      id: "file:user:briefings/weekly.md",
       component: "deck",
       title: "weekly.md",
-      params: expect.objectContaining({ path: "briefings/weekly.md" }),
+      params: expect.objectContaining({ filesystem: "user", path: "briefings/weekly.md" }),
     }))
   })
 })


### PR DESCRIPTION
## Stack position
3 / 5 in the #416 governed `company_context` filesystem stack.

Base: #429 / `bclaw/416-pr2-agent-tools-routes`.
Next: `bclaw/416-pr4-file-panels-denied-state`.

## What this adds
- Adds shared workspace filesystem identity primitives.
- Extends UI bridge/open-file payloads with explicit filesystem identity while preserving legacy user-file opens.
- Keeps `UiBridge.postCommand` as the single dispatch source for `exec_ui`.
- Updates bridge validation so alternate filesystem identities are syntax-validated without pretending they live under the user workspace root.
- Carries filesystem identity through artifact surface panel keys, persistence helpers, workspace links, and panel resolution.
- Adds/updates bridge and artifact-surface tests for user vs `company_context` separation.

## Review notes
This PR is the UI identity layer. It does not yet harden editor caches/viewers or chat transcript refs; those are split into the next PRs to keep review scoped.

Key thing to check: panel identity is `(filesystem, path)`, not path alone and not a path-prefix convention.

## Validation
- `pnpm --dir packages/workspace exec vitest run src/shared/__tests__/filesystem.test.ts src/front/bridge/__tests__/bridge.test.ts src/front/bridge/__tests__/client.test.ts src/front/bridge/__tests__/uiCommandDispatcher.test.ts src/front/bridge/__tests__/WorkspaceLink.test.tsx src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx src/front/chrome/artifact-surface/__tests__/ArtifactSurfacePane.persistence.test.tsx src/front/chrome/artifact-surface/__tests__/resolvePanelForPath.test.ts src/server/__tests__/uiTools.test.ts` — passed
- `pnpm --filter @hachej/boring-workspace typecheck` — passed on the full final stack
