### PR TITLE
#416 company-fs: isolate file panel state by filesystem

### DIFF
--- a/packages/workspace/src/front/dock/DockviewShell.tsx
+++ b/packages/workspace/src/front/dock/DockviewShell.tsx
@@ -42,7 +42,14 @@ function matchesPanel(
   const params = panel.params as Record<string, unknown> | undefined
   if ("paramPrefix" in match) {
     const value = params?.[match.paramPrefix]
-    return typeof value === "string" && value.startsWith(match.value)
+    const prefixMatches = typeof value === "string" && value.startsWith(match.value)
+    const paramsMatch = match.params
+      ? Object.entries(match.params).every(([key, expected]) => params?.[key] === expected)
+      : true
+    return prefixMatches && paramsMatch
+  }
+  if ("params" in match) {
+    return Object.entries(match.params).every(([key, value]) => params?.[key] === value)
   }
   return params?.[match.param] === match.value
 }

--- a/packages/workspace/src/front/events/types.ts
+++ b/packages/workspace/src/front/events/types.ts
@@ -9,6 +9,7 @@
  * — they get added when their concrete emitter and consumer land in
  * the same step.
  */
+import type { FilesystemId } from "../../shared/types/filesystem"
 import type { UiCommand } from "../bridge/types"
 
 export const WORKSPACE_PLUGIN_ID = "workspace"
@@ -31,7 +32,8 @@ export const workspaceEvents = {
 export type WorkspacePanelMatch =
   | { id: string }
   | { param: string; value: unknown }
-  | { paramPrefix: string; value: string }
+  | { params: Record<string, unknown> }
+  | { paramPrefix: string; value: string; params?: Record<string, unknown> }
 
 /**
  * Discriminated origin metadata. Encoded as a union (rather than a
@@ -110,10 +112,10 @@ export interface WorkspaceHostEventMap {
  * though that only works in source compilation — it does not survive dist bundling.
  */
 export interface WorkspacePluginEventMap {
-  "filesystem:file.changed": EventMeta & { path: string }
-  "filesystem:file.created": EventMeta & { path: string; kind: "file" | "dir" }
-  "filesystem:file.moved": EventMeta & { from: string; to: string }
-  "filesystem:file.deleted": EventMeta & { path: string }
+  "filesystem:file.changed": EventMeta & { filesystem?: FilesystemId; path: string }
+  "filesystem:file.created": EventMeta & { filesystem?: FilesystemId; path: string; kind: "file" | "dir" }
+  "filesystem:file.moved": EventMeta & { filesystem?: FilesystemId; from: string; to: string }
+  "filesystem:file.deleted": EventMeta & { filesystem?: FilesystemId; path: string }
 }
 
 export interface WorkspaceEventMap

--- a/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
@@ -4,7 +4,8 @@ import { lazy, Suspense } from "react"
 import type { ReactNode } from "react"
 import { EmptyState, ErrorState, Spinner } from "@hachej/boring-ui-kit"
 import { ConflictBanner } from "./ConflictBanner"
-import type { FileConflictError } from "./data/fetchClient"
+import { FetchError, type FileConflictError } from "./data/fetchClient"
+import { redactedFilesystemErrorMessage } from "./data/filesystemErrorRedaction"
 
 export interface FilePaneShellProps {
   /** The file path being edited (for "no file selected" check). */
@@ -36,6 +37,8 @@ export interface FilePaneShellProps {
   loadingFallback?: ReactNode
   /** Custom error message (optional). */
   errorMessage?: string
+  /** Filesystem identity for disclosure-safe governed filesystem error rendering. */
+  filesystem?: string
   /** Wrapper className for the root element. */
   className?: string
 }
@@ -85,6 +88,7 @@ export function FilePaneShell({
   editorProps = {},
   loadingFallback,
   errorMessage,
+  filesystem,
   className,
 }: FilePaneShellProps) {
   // No file selected
@@ -98,9 +102,12 @@ export function FilePaneShell({
 
   // Error state
   if (error) {
+    const description = error instanceof FetchError
+      ? redactedFilesystemErrorMessage(filesystem, error.status, error.message)
+      : error.message
     return (
       <div className="flex h-full items-center justify-center p-6">
-        <ErrorState title="Failed to load file" description={errorMessage ?? error.message} />
+        <ErrorState title="Failed to load file" description={errorMessage ?? description} />
       </div>
     )
   }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/filePanelBinding.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/filePanelBinding.test.tsx
@@ -67,10 +67,10 @@ describe("FilesystemFilePanelBinding", () => {
         cause: "agent",
         toolCallId: "tc-1",
         match: [
-          { id: "file:src/old.ts" },
-          { param: "path", value: "src/old.ts" },
+          { id: "file:user:src/old.ts" },
+          { params: { path: "src/old.ts", filesystem: "user" } },
         ],
-        params: { path: "src/new.ts" },
+        params: { path: "src/new.ts", filesystem: "user" },
         title: "new.ts",
       }),
     )
@@ -90,9 +90,9 @@ describe("FilesystemFilePanelBinding", () => {
       expect.objectContaining({
         cause: "user",
         match: [
-          { id: "file:src/dead.ts" },
-          { param: "path", value: "src/dead.ts" },
-          { paramPrefix: "path", value: "src/dead.ts/" },
+          { id: "file:user:src/dead.ts" },
+          { params: { path: "src/dead.ts", filesystem: "user" } },
+          { paramPrefix: "path", value: "src/dead.ts/", params: { filesystem: "user" } },
         ],
       }),
     )
@@ -112,11 +112,59 @@ describe("FilesystemFilePanelBinding", () => {
     expect(observed).not.toHaveBeenCalled()
   })
 
+  it("does not retarget a company panel from a same-path user move", async () => {
+    const api = renderBindingWithDockview()
+    act(() => {
+      api.addPanel({
+        id: "file:company_context:src/old.ts",
+        component: "editor",
+        title: "old.ts",
+        params: { path: "src/old.ts", filesystem: "company_context" },
+      })
+    })
+
+    act(() => {
+      events.emit(filesystemEvents.moved, {
+        ...userMeta(),
+        filesystem: "user",
+        from: "src/old.ts",
+        to: "src/new.ts",
+      })
+    })
+
+    const panel = api.getPanel("file:company_context:src/old.ts")
+    expect(panel).toBeTruthy()
+    expect((panel!.params as { path?: string; filesystem?: string }).path).toBe("src/old.ts")
+    expect((panel!.params as { path?: string; filesystem?: string }).filesystem).toBe("company_context")
+  })
+
+  it("does not close a company panel from a same-path user delete", async () => {
+    const api = renderBindingWithDockview()
+    act(() => {
+      api.addPanel({
+        id: "file:company_context:src/dead.ts",
+        component: "editor",
+        title: "dead.ts",
+        params: { path: "src/dead.ts", filesystem: "company_context" },
+      })
+    })
+
+    act(() => {
+      events.emit(filesystemEvents.deleted, {
+        ...userMeta(),
+        filesystem: "user",
+        path: "src/dead.ts",
+      })
+    })
+
+    expect(api.getPanel("file:company_context:src/dead.ts")).toBeTruthy()
+  })
+
   it("wires agent SSE rename chunks through to open Dockview file panels", async () => {
     const api = renderBindingWithDockview()
     act(() => {
       api.addPanel({
-        id: "file:src/old.ts",
+        id: "file:user:src/old.ts",
         component: "editor",
         title: "old.ts",
         params: { path: "src/old.ts" },
@@ -136,7 +184,7 @@ describe("FilesystemFilePanelBinding", () => {
     })
 
     await waitFor(() => {
-      const panel = api.getPanel("file:src/old.ts")
+      const panel = api.getPanel("file:user:src/old.ts")
       expect(panel).toBeTruthy()
       expect((panel!.params as { path?: string }).path).toBe("src/new.ts")
       expect(panel!.title).toBe("new.ts")

--- a/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
@@ -280,7 +280,7 @@ describe("useFilePane", () => {
       renderHook(() => useFilePane({ path: "   " }), { wrapper })
       await act(async () => {})
 
-      expect(mockFileContent).toHaveBeenCalledWith(null)
+      expect(mockFileContent).toHaveBeenCalledWith(null, { filesystem: "user" })
       expect(mockWriteFile).not.toHaveBeenCalled()
     })
 
@@ -288,7 +288,30 @@ describe("useFilePane", () => {
       renderHook(() => useFilePane({ path: " notes.md " }), { wrapper })
       await act(async () => {})
 
-      expect(mockFileContent).toHaveBeenCalledWith(" notes.md ")
+      expect(mockFileContent).toHaveBeenCalledWith(" notes.md ", { filesystem: "user" })
+    })
+
+    it("separates same-path panes by filesystem for queries and writes", async () => {
+      const { result, rerender } = renderHook(
+        ({ filesystem }) => useFilePane({ path: "same.md", filesystem }),
+        { wrapper, initialProps: { filesystem: "user" as "user" | "company_context" } },
+      )
+      await act(async () => {})
+      expect(mockFileContent).toHaveBeenCalledWith("same.md", { filesystem: "user" })
+
+      rerender({ filesystem: "company_context" })
+      await act(async () => {})
+      expect(mockFileContent).toHaveBeenCalledWith("same.md", { filesystem: "company_context" })
+
+      act(() => result.current.setContent("company edits"))
+      await act(async () => {
+        await result.current.flushSave()
+      })
+      expect(mockWriteFile).toHaveBeenCalledWith(expect.objectContaining({
+        filesystem: "company_context",
+        path: "same.md",
+        content: "company edits",
+      }))
     })
   })
 
@@ -297,7 +320,7 @@ describe("useFilePane", () => {
       renderHook(() => useFilePane({ path: "deck/new.md", createIfMissing: "# Default\n" }), { wrapper })
       await act(async () => {})
 
-      expect(mockFileContent).toHaveBeenCalledWith("deck/new.md", { createIfMissing: "# Default\n" })
+      expect(mockFileContent).toHaveBeenCalledWith("deck/new.md", { filesystem: "user", createIfMissing: "# Default\n" })
       expect(mockWriteFile).not.toHaveBeenCalled()
     })
   })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditorPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditorPane.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import type { PaneProps } from "../../../../front/registry/types"
 import { useFilePane } from "../useFilePane"
 import { FilePaneShell } from "../FilePaneShell"
@@ -31,10 +32,11 @@ function extToLanguage(path: string): string {
   }
 }
 
-export type CodeEditorPaneProps = PaneProps<{ path?: string; mode?: "view" | "edit" | "diff" }>
+export type CodeEditorPaneProps = PaneProps<{ path?: string; filesystem?: FilesystemId; mode?: "view" | "edit" | "diff" }>
 
 export function CodeEditorPane({ params, api, className }: CodeEditorPaneProps) {
   const path = typeof params?.path === "string" ? params.path : ""
+  const filesystem = normalizeUiFilesystem(params?.filesystem)
   const readOnly = params?.mode === "view"
 
   const {
@@ -46,7 +48,7 @@ export function CodeEditorPane({ params, api, className }: CodeEditorPaneProps) 
     onReloadFromServer,
     onOverwrite,
     tabTitle,
-  } = useFilePane({ path, panelId: api?.id })
+  } = useFilePane({ filesystem, path, panelId: api?.id })
 
   // Update panel title with dirty indicator
   if (api && tabTitle) {
@@ -58,6 +60,7 @@ export function CodeEditorPane({ params, api, className }: CodeEditorPaneProps) 
   return (
     <FilePaneShell
       path={path}
+      filesystem={filesystem}
       content={content}
       isLoading={isLoading}
       error={error}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditorPane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditorPane.test.tsx
@@ -8,7 +8,7 @@ const mockFileWrite = vi.fn()
 const mockUseEditorLifecycle = vi.fn()
 
 vi.mock("../../data", () => ({
-  useFileContent: (path: string) => mockFileContent(path),
+  useFileContent: (path: string, options?: unknown) => mockFileContent(path, options),
   useFileWrite: () => ({ mutateAsync: mockFileWrite }),
   useDataClient: () => ({}),
   useApiBaseUrl: () => "/api",
@@ -37,6 +37,7 @@ vi.mock("../CodeEditor", () => ({
   ),
 }))
 
+import { FetchError } from "../../data/fetchClient"
 import { CodeEditorPane } from "../CodeEditorPane"
 import { createMockPaneProps } from "../../../../../front/testing/createMockPaneProps"
 
@@ -101,6 +102,23 @@ describe("CodeEditorPane", () => {
     render(<CodeEditorPane {...paneProps("missing.ts")} />, { wrapper })
     expect(screen.getByText(/Failed to load file/)).toBeInTheDocument()
     expect(screen.getByText(/Not found/)).toBeInTheDocument()
+  })
+
+  it("passes filesystem to loading hook and sanitizes denied company errors", () => {
+    mockFileContent.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new FetchError(404, "FORBIDDEN_FINANCE_SECRET_123 /secret/finance.md"),
+      dataUpdatedAt: 0,
+    })
+    const props = createMockPaneProps({ params: { path: "/company/hr/policy.md", filesystem: "company_context" } })
+
+    render(<CodeEditorPane {...props} />, { wrapper })
+
+    expect(mockFileContent).toHaveBeenCalledWith("/company/hr/policy.md", expect.objectContaining({ filesystem: "company_context" }))
+    expect(screen.getByText("not found or denied")).toBeInTheDocument()
+    expect(screen.queryByText(/FORBIDDEN_FINANCE_SECRET_123/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/secret\/finance/)).not.toBeInTheDocument()
   })
 
   it("infers language from file extension", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.test.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.test.ts
@@ -65,6 +65,15 @@ describe("FetchClient", () => {
     expect(result).toEqual({ content: "hello" })
   })
 
+  it("GET /api/v1/files includes explicit non-user filesystem", async () => {
+    mockFetch.mockReturnValue(ok({ content: "company" }))
+    const client = new FetchClient({ apiBaseUrl: "" })
+    await client.getFile("/company/hr/policy.md", undefined, "company_context")
+    const url = String(mockFetch.mock.calls[0][0])
+    expect(url).toContain("path=%2Fcompany%2Fhr%2Fpolicy.md")
+    expect(url).toContain("filesystem=company_context")
+  })
+
   it("POST /api/v1/files sends path and content", async () => {
     mockFetch.mockReturnValue(ok({ ok: true }))
     const client = new FetchClient({ apiBaseUrl: "" })
@@ -85,6 +94,17 @@ describe("FetchClient", () => {
       returnMtimeMs: false,
     })
     expect(result).toEqual({ mtimeMs: undefined })
+  })
+
+  it("POST /api/v1/files forwards explicit non-user filesystem when supplied", async () => {
+    mockFetch.mockReturnValue(ok({ ok: true }))
+    const client = new FetchClient({ apiBaseUrl: "" })
+    await client.writeFile("/company/hr/policy.md", "code", { filesystem: "company_context" })
+    expect(JSON.parse(mockFetch.mock.calls[0][1].body)).toEqual({
+      path: "/company/hr/policy.md",
+      content: "code",
+      filesystem: "company_context",
+    })
   })
 
   it("POST /api/v1/files forwards expectedMtimeMs when supplied", async () => {
@@ -190,6 +210,18 @@ describe("FetchClient", () => {
     await client.createDir("/src/new")
     const body = JSON.parse(mockFetch.mock.calls[0][1].body)
     expect(body).toEqual({ path: "/src/new" })
+  })
+
+  it("filesystem-aware mutations preserve explicit filesystem identity", async () => {
+    mockFetch.mockImplementation(() => ok({ ok: true }))
+    const client = new FetchClient({ apiBaseUrl: "" })
+    await client.deleteFile("/company/hr/policy.md", { filesystem: "company_context" })
+    await client.createDir("/company/new", { filesystem: "company_context" })
+    await client.moveFile("/company/a.md", "/company/b.md", { filesystem: "company_context" })
+
+    expect(mockFetch.mock.calls[0][0]).toContain("filesystem=company_context")
+    expect(JSON.parse(mockFetch.mock.calls[1][1].body)).toEqual({ path: "/company/new", filesystem: "company_context" })
+    expect(JSON.parse(mockFetch.mock.calls[2][1].body)).toEqual({ from: "/company/a.md", to: "/company/b.md", filesystem: "company_context" })
   })
 
   it("POST /api/v1/files/move sends from and to", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx
@@ -65,7 +65,7 @@ describe("useFileContent", () => {
     const { result } = renderHook(() => useFileContent("/a.ts"), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data).toEqual({ content: "hello" })
-    expect(mockClient.getFile).toHaveBeenCalledWith("/a.ts", expect.any(AbortSignal))
+    expect(mockClient.getFile).toHaveBeenCalledWith("/a.ts", expect.any(AbortSignal), "user")
   })
 
   it("is disabled when path is null", () => {
@@ -97,7 +97,7 @@ describe("useFileContent", () => {
     )
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(mockClient.writeFile).toHaveBeenCalledWith("/deck/new.md", "# Default\n")
+    expect(mockClient.writeFile).toHaveBeenCalledWith("/deck/new.md", "# Default\n", { filesystem: "user" })
     expect(result.current.data).toEqual({ content: "# Default\n", mtimeMs: 2000 })
     expect(created).toHaveBeenCalledWith(expect.objectContaining({ path: "/deck/new.md", kind: "file" }))
   })
@@ -112,8 +112,15 @@ describe("useFileContent", () => {
     )
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(mockClient.writeFile).toHaveBeenCalledWith("/empty.md", "")
+    expect(mockClient.writeFile).toHaveBeenCalledWith("/empty.md", "", { filesystem: "user" })
     expect(result.current.data).toEqual({ content: "", mtimeMs: 2001 })
+  })
+
+  it("preserves explicit filesystem when reading company content", async () => {
+    mockClient.getFile.mockResolvedValue({ content: "company" })
+    const { result } = renderHook(() => useFileContent("/company/hr/policy.md", { filesystem: "company_context" }), { wrapper })
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(mockClient.getFile).toHaveBeenCalledWith("/company/hr/policy.md", expect.any(AbortSignal), "company_context")
   })
 
   it("does not create missing files unless createIfMissing is provided", async () => {
@@ -157,7 +164,7 @@ describe("useStat", () => {
     const { result } = renderHook(() => useStat("/a.ts"), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
     expect(result.current.data).toEqual({ size: 42, mtimeMs: 100, kind: "file" })
-    expect(mockClient.stat).toHaveBeenCalledWith("/a.ts", expect.any(AbortSignal))
+    expect(mockClient.stat).toHaveBeenCalledWith("/a.ts", expect.any(AbortSignal), "user")
   })
 })
 
@@ -192,9 +199,6 @@ describe("useFileWrite", () => {
       await result.current.mutateAsync({ path: "/a.ts", content: "new" })
     })
 
-    // useFileWrite passes through expectedMtimeMs (third arg). When
-    // not supplied, it forwards `undefined` so callers explicitly opt
-    // into OCC.
     expect(mockClient.writeFile).toHaveBeenCalledWith("/a.ts", "new", undefined)
     expect(invalidateSpy).not.toHaveBeenCalled()
   })
@@ -213,6 +217,23 @@ describe("useFileWrite", () => {
 
     expect(mockClient.writeFile).toHaveBeenCalledWith("/a.ts", "new", {
       expectedMtimeMs: 1000,
+    })
+  })
+
+  it("forwards explicit filesystem through to the data client", async () => {
+    mockClient.writeFile.mockResolvedValue({ mtimeMs: 999 })
+    const { result } = renderHook(() => useFileWrite(), { wrapper })
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        filesystem: "company_context",
+        path: "/company/hr/policy.md",
+        content: "new",
+      })
+    })
+
+    expect(mockClient.writeFile).toHaveBeenCalledWith("/company/hr/policy.md", "new", {
+      filesystem: "company_context",
     })
   })
 })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx
@@ -47,10 +47,10 @@ describe("useFileEventInvalidation", () => {
     events.emit(filesystemEvents.changed, { ...agentMeta("tc-1"), path: "src/a.ts" })
 
     await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "src/a.ts"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "src/a.ts"],
     }))
     expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "stat", "src/a.ts"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "stat", "user", "src/a.ts"],
     })
     // Tree/search are NOT touched on a content-only change.
     const calls = queryKeyCalls(invalidate)
@@ -66,10 +66,10 @@ describe("useFileEventInvalidation", () => {
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "src"],
     }))
     expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "src/new.ts"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "src/new.ts"],
     })
     expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "stat", "src/new.ts"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "stat", "user", "src/new.ts"],
     })
   })
 
@@ -122,10 +122,10 @@ describe("useFileEventInvalidation", () => {
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "docs"],
     })
     expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "old.ts"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "old.ts"],
     })
     expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "docs/new.ts"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "docs/new.ts"],
     })
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "search"],
@@ -144,17 +144,17 @@ describe("useFileEventInvalidation", () => {
     const matches = (key: readonly unknown[]) => predicates[0]({ queryKey: key })
 
     // Descendants under the OLD prefix are invalidated…
-    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "src/deep/a.ts"])).toBe(true)
-    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "stat", "src/a.ts"])).toBe(true)
+    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "src/deep/a.ts"])).toBe(true)
+    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "stat", "user", "src/a.ts"])).toBe(true)
     expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "tree", "src/deep"])).toBe(true)
     // The moved dir's OWN listing is dead too (panes mounted at rootDir="src").
     expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "tree", "src"])).toBe(true)
     // …unrelated paths, the new prefix, and other workspaces are not.
-    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "other/a.ts"])).toBe(false)
-    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "lib/a.ts"])).toBe(false)
-    expect(matches([TEST_BASE, "other-workspace", "files", "src/a.ts"])).toBe(false)
+    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "other/a.ts"])).toBe(false)
+    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "lib/a.ts"])).toBe(false)
+    expect(matches([TEST_BASE, "other-workspace", "files", "user", "src/a.ts"])).toBe(false)
     // Prefix match is path-segment-aware: "src-other" is not under "src/".
-    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "src-other/a.ts"])).toBe(false)
+    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "src-other/a.ts"])).toBe(false)
   })
 
   it("filesystem deleted invalidates parent tree listing + files(path) + search", async () => {
@@ -165,7 +165,7 @@ describe("useFileEventInvalidation", () => {
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "."],
     }))
     expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "doomed.ts"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "doomed.ts"],
     })
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "search"],

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
@@ -140,10 +140,12 @@ export class FetchClient {
     return res.entries
   }
 
-  async getFile(path: string, signal?: AbortSignal): Promise<FileContent> {
+  async getFile(path: string, signal?: AbortSignal, filesystem?: string): Promise<FileContent> {
+    const params = new URLSearchParams({ path })
+    if (filesystem && filesystem !== "user") params.set("filesystem", filesystem)
     return this.request<FileContent>(
       "GET",
-      `/api/v1/files?path=${encodeURIComponent(path)}`,
+      `/api/v1/files?${params.toString()}`,
       undefined,
       undefined,
       signal,
@@ -165,13 +167,14 @@ export class FetchClient {
   async writeFile(
     path: string,
     content: string,
-    opts?: { expectedMtimeMs?: number; returnMtimeMs?: boolean },
+    opts?: { expectedMtimeMs?: number; returnMtimeMs?: boolean; filesystem?: string },
   ): Promise<{ mtimeMs?: number }> {
     try {
-      const body: { path: string; content: string; expectedMtimeMs?: number; returnMtimeMs?: boolean } = {
+      const body: { path: string; content: string; expectedMtimeMs?: number; returnMtimeMs?: boolean; filesystem?: string } = {
         path,
         content,
       }
+      if (opts?.filesystem && opts.filesystem !== "user") body.filesystem = opts.filesystem
       if (opts?.expectedMtimeMs != null) body.expectedMtimeMs = opts.expectedMtimeMs
       if (opts?.returnMtimeMs === false) body.returnMtimeMs = false
       const res = await this.request<{ ok: boolean; mtimeMs?: number }>(
@@ -188,14 +191,18 @@ export class FetchClient {
     }
   }
 
-  async deleteFile(path: string): Promise<void> {
-    await this.request<void>("DELETE", `/api/v1/files?path=${encodeURIComponent(path)}`)
+  async deleteFile(path: string, options?: { filesystem?: string }): Promise<void> {
+    const params = new URLSearchParams({ path })
+    if (options?.filesystem) params.set("filesystem", options.filesystem)
+    await this.request<void>("DELETE", `/api/v1/files?${params}`)
   }
 
-  async stat(path: string, signal?: AbortSignal): Promise<FileStat> {
+  async stat(path: string, signal?: AbortSignal, filesystem?: string): Promise<FileStat> {
+    const params = new URLSearchParams({ path })
+    if (filesystem && filesystem !== "user") params.set("filesystem", filesystem)
     return this.request<FileStat>(
       "GET",
-      `/api/v1/stat?path=${encodeURIComponent(path)}`,
+      `/api/v1/stat?${params.toString()}`,
       undefined,
       undefined,
       signal,
@@ -225,12 +232,12 @@ export class FetchClient {
     return res.results
   }
 
-  async createDir(path: string): Promise<void> {
-    await this.request<void>("POST", "/api/v1/dirs", { path })
+  async createDir(path: string, options?: { filesystem?: string }): Promise<void> {
+    await this.request<void>("POST", "/api/v1/dirs", { path, ...(options?.filesystem ? { filesystem: options.filesystem } : {}) })
   }
 
-  async moveFile(from: string, to: string): Promise<void> {
-    await this.request<void>("POST", "/api/v1/files/move", { from, to })
+  async moveFile(from: string, to: string, options?: { filesystem?: string }): Promise<void> {
+    await this.request<void>("POST", "/api/v1/files/move", { from, to, ...(options?.filesystem ? { filesystem: options.filesystem } : {}) })
   }
 }
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/filesystemErrorRedaction.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/filesystemErrorRedaction.ts
@@ -1,0 +1,9 @@
+import { USER_FILESYSTEM_ID } from "../../../../shared/types/filesystem"
+
+export function shouldRedactFilesystemError(filesystem: string | undefined, status: number): boolean {
+  return filesystem !== undefined && filesystem !== USER_FILESYSTEM_ID && (status === 403 || status === 404)
+}
+
+export function redactedFilesystemErrorMessage(filesystem: string | undefined, status: number, fallback: string): string {
+  return shouldRedactFilesystemError(filesystem, status) ? "not found or denied" : fallback
+}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
@@ -13,6 +13,7 @@ import { getPreloadedTreeEntries } from "./treePreloadCache"
 import { events, userMeta } from "../../../../front/events"
 import { filesystemEvents } from "../../shared/events"
 import { FILES_QUERY_KEY_SEGMENT } from "../../shared/constants"
+import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import type { FileContent, FileEntry, FileStat, GitUrlMetadata } from "./types"
 
 function noRetryOn404(count: number, error: Error): boolean {
@@ -21,6 +22,8 @@ function noRetryOn404(count: number, error: Error): boolean {
 }
 
 export interface UseFileContentOptions {
+  /** Filesystem identity for cache/event separation. Data transport remains provider-owned. */
+  filesystem?: FilesystemId
   /** Create the file with this content when the initial read returns 404. */
   createIfMissing?: string
 }
@@ -33,17 +36,18 @@ export function useFileContent(
   const base = useApiBaseUrl()
   const workspaceId = useWorkspaceRequestId()
   const createIfMissing = options.createIfMissing
+  const filesystem = normalizeUiFilesystem(options.filesystem)
   return useQuery({
-    queryKey: [base, workspaceId, FILES_QUERY_KEY_SEGMENT, path, createIfMissing ?? null],
+    queryKey: [base, workspaceId, FILES_QUERY_KEY_SEGMENT, filesystem, path, createIfMissing ?? null],
     queryFn: async ({ signal }) => {
       const activePath = path!
       try {
-        return await client.getFile(activePath, signal)
+        return await client.getFile(activePath, signal, filesystem)
       } catch (err) {
         if (createIfMissing === undefined || !(err instanceof FetchError) || err.status !== 404) throw err
         if (signal.aborted) throw new DOMException("Aborted", "AbortError")
-        const created = await client.writeFile(activePath, createIfMissing)
-        events.emit(filesystemEvents.created, { ...userMeta(), path: activePath, kind: "file" })
+        const created = await client.writeFile(activePath, createIfMissing, { filesystem })
+        events.emit(filesystemEvents.created, { ...userMeta(), filesystem, path: activePath, kind: "file" })
         return { content: createIfMissing, mtimeMs: created.mtimeMs }
       }
     },
@@ -70,13 +74,14 @@ export function useFileList(dir: string | null): UseQueryResult<FileEntry[]> {
   })
 }
 
-export function useStat(path: string | null): UseQueryResult<FileStat> {
+export function useStat(path: string | null, filesystem?: FilesystemId): UseQueryResult<FileStat> {
   const client = useDataClient()
   const base = useApiBaseUrl()
   const workspaceId = useWorkspaceRequestId()
+  const fs = normalizeUiFilesystem(filesystem)
   return useQuery({
-    queryKey: [base, workspaceId, "stat", path],
-    queryFn: ({ signal }) => client.stat(path!, signal),
+    queryKey: [base, workspaceId, "stat", fs, path],
+    queryFn: ({ signal }) => client.stat(path!, signal, fs),
     enabled: path != null,
     retry: noRetryOn404,
   })
@@ -120,6 +125,7 @@ export function useFileSearch(
 }
 
 export interface FileWriteVariables {
+  filesystem?: FilesystemId
   path: string
   content: string
   /**
@@ -143,52 +149,53 @@ export interface FileWriteResult {
 export function useFileWrite(): UseMutationResult<FileWriteResult, Error, FileWriteVariables> {
   const client = useDataClient()
   return useMutation({
-    mutationFn: ({ path, content, expectedMtimeMs, returnMtimeMs }) => {
+    mutationFn: ({ path, content, expectedMtimeMs, returnMtimeMs, filesystem }) => {
       const opts = {
         ...(expectedMtimeMs != null ? { expectedMtimeMs } : {}),
         ...(returnMtimeMs === false ? { returnMtimeMs: false } : {}),
+        ...(filesystem ? { filesystem } : {}),
       }
       return client.writeFile(path, content, Object.keys(opts).length > 0 ? opts : undefined)
     },
-    onSuccess: (_, { path }) => {
+    onSuccess: (_, { path, filesystem }) => {
       // Single source of truth: emit onto the bus, the centralized
       // invalidator (`useFileEventInvalidation`) handles cache
       // invalidation. We can't tell create-vs-edit from the mutation
       // alone, so consumers wanting "created" emits do it themselves
       // at the call site (see FileTreeView.handleSubmitEdit). Plain
       // edits emit filesystem changed — file identity didn't change.
-      events.emit(filesystemEvents.changed, { ...userMeta(), path })
+      events.emit(filesystemEvents.changed, { ...userMeta(), filesystem: normalizeUiFilesystem(filesystem), path })
     },
   })
 }
 
-export function useCreateDir(): UseMutationResult<void, Error, { path: string }> {
+export function useCreateDir(): UseMutationResult<void, Error, { path: string; filesystem?: string }> {
   const client = useDataClient()
   return useMutation({
-    mutationFn: ({ path }) => client.createDir(path),
-    onSuccess: (_, { path }) => {
+    mutationFn: ({ path, filesystem }) => client.createDir(path, { filesystem }),
+    onSuccess: (_, { path, filesystem }) => {
       // Bus emit only — `useFileEventInvalidation` runs the cache invalidation.
-      events.emit(filesystemEvents.created, { ...userMeta(), path, kind: "dir" })
+      events.emit(filesystemEvents.created, { ...userMeta(), path, kind: "dir", filesystem })
     },
   })
 }
 
-export function useMoveFile(): UseMutationResult<void, Error, { from: string; to: string }> {
+export function useMoveFile(): UseMutationResult<void, Error, { from: string; to: string; filesystem?: string }> {
   const client = useDataClient()
   return useMutation({
-    mutationFn: ({ from, to }) => client.moveFile(from, to),
-    onSuccess: (_, { from, to }) => {
-      events.emit(filesystemEvents.moved, { ...userMeta(), from, to })
+    mutationFn: ({ from, to, filesystem }) => client.moveFile(from, to, { filesystem }),
+    onSuccess: (_, { from, to, filesystem }) => {
+      events.emit(filesystemEvents.moved, { ...userMeta(), from, to, filesystem })
     },
   })
 }
 
-export function useDeleteFile(): UseMutationResult<void, Error, { path: string }> {
+export function useDeleteFile(): UseMutationResult<void, Error, { path: string; filesystem?: string }> {
   const client = useDataClient()
   return useMutation({
-    mutationFn: ({ path }) => client.deleteFile(path),
-    onSuccess: (_, { path }) => {
-      events.emit(filesystemEvents.deleted, { ...userMeta(), path })
+    mutationFn: ({ path, filesystem }) => client.deleteFile(path, { filesystem }),
+    onSuccess: (_, { path, filesystem }) => {
+      events.emit(filesystemEvents.deleted, { ...userMeta(), path, filesystem })
     },
   })
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventInvalidation.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventInvalidation.ts
@@ -5,6 +5,7 @@ import { useQueryClient, type QueryClient } from "@tanstack/react-query"
 import { events } from "../../../../front/events"
 import { useApiBaseUrl, useWorkspaceRequestId } from "./DataProvider"
 import { filesystemEvents } from "../../shared/events"
+import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import { FILES_QUERY_KEY_SEGMENT } from "../../shared/constants"
 import { parentDir } from "../file-tree/treeModel"
 import type { FileEntry } from "./types"
@@ -53,7 +54,7 @@ export function useFileEventInvalidation(): void {
     }
 
     const offChanged = events.on(filesystemEvents.changed, (e) => {
-      invalidateFile(batch, base, workspaceId, e.path)
+      invalidateFile(batch, base, workspaceId, e.path, e.filesystem)
     })
     const offCreated = events.on(filesystemEvents.created, (e) => {
       upsertTreeCache(queryClient, base, workspaceId, {
@@ -64,7 +65,7 @@ export function useFileEventInvalidation(): void {
       const invalidate = () => {
         invalidateTree(batch, base, workspaceId, e.path)
         if (e.kind === "file") {
-          invalidateFile(batch, base, workspaceId, e.path)
+          invalidateFile(batch, base, workspaceId, e.path, e.filesystem)
         }
       }
       invalidate()
@@ -83,9 +84,9 @@ export function useFileEventInvalidation(): void {
       const invalidate = () => {
         invalidateTree(batch, base, workspaceId, e.from)
         invalidateTree(batch, base, workspaceId, e.to)
-        invalidateFile(batch, base, workspaceId, e.from)
-        invalidateFile(batch, base, workspaceId, e.to)
-        invalidateMovedDescendants(batch, base, workspaceId, e.from)
+        invalidateFile(batch, base, workspaceId, e.from, e.filesystem)
+        invalidateFile(batch, base, workspaceId, e.to, e.filesystem)
+        invalidateMovedDescendants(batch, base, workspaceId, e.from, e.filesystem)
         invalidateSearch(batch, base, workspaceId)
       }
       invalidate()
@@ -95,7 +96,7 @@ export function useFileEventInvalidation(): void {
       removeTreeCacheEntry(queryClient, base, workspaceId, e.path)
       const invalidate = () => {
         invalidateTree(batch, base, workspaceId, e.path)
-        invalidateFile(batch, base, workspaceId, e.path)
+        invalidateFile(batch, base, workspaceId, e.path, e.filesystem)
         invalidateSearch(batch, base, workspaceId)
       }
       invalidate()
@@ -207,9 +208,11 @@ function invalidateFile(
   base: string,
   workspaceId: string | null,
   path: string,
+  filesystem?: FilesystemId,
 ): void {
-  batch.enqueue([base, workspaceId, FILES_QUERY_KEY_SEGMENT, path])
-  batch.enqueue([base, workspaceId, "stat", path])
+  const fs = normalizeUiFilesystem(filesystem)
+  batch.enqueue([base, workspaceId, FILES_QUERY_KEY_SEGMENT, fs, path])
+  batch.enqueue([base, workspaceId, "stat", fs, path])
 }
 
 /**
@@ -240,16 +243,25 @@ function invalidateMovedDescendants(
   base: string,
   workspaceId: string | null,
   from: string,
+  filesystem?: FilesystemId,
 ): void {
+  const fs = normalizeUiFilesystem(filesystem)
   const prefix = `${from}/`
-  batch.enqueueFilter(`descendants:${base}:${workspaceId}:${prefix}`, {
+  batch.enqueueFilter(`descendants:${base}:${workspaceId}:${fs}:${prefix}`, {
     predicate: (query) => {
       const key = query.queryKey
       return key[0] === base
         && key[1] === workspaceId
-        && (key[2] === FILES_QUERY_KEY_SEGMENT || key[2] === "stat" || key[2] === "tree")
-        && typeof key[3] === "string"
-        && (key[3] === from || key[3].startsWith(prefix))
+        && (
+          ((key[2] === FILES_QUERY_KEY_SEGMENT || key[2] === "stat")
+            && key[3] === fs
+            && typeof key[4] === "string"
+            && (key[4] === from || key[4].startsWith(prefix)))
+          || (key[2] === "tree"
+            && fs === "user"
+            && typeof key[3] === "string"
+            && (key[3] === from || key[3].startsWith(prefix)))
+        )
     },
   })
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/filePanelBinding.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/filePanelBinding.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from "react"
 import { events, workspaceEvents } from "../../../front/events"
+import { normalizeUiFilesystem, uiFileResourceKey } from "../../../shared/types/filesystem"
 import { filesystemEvents } from "../shared/events"
 
 function titleFromPath(path: string): string {
@@ -10,22 +11,27 @@ function titleFromPath(path: string): string {
 
 export function FilesystemFilePanelBinding() {
   useEffect(() => {
-    const offMoved = events.on(filesystemEvents.moved, ({ from, to, ...meta }) => {
+    const offMoved = events.on(filesystemEvents.moved, ({ filesystem: rawFilesystem, from, to, ...meta }) => {
+      const filesystem = normalizeUiFilesystem(rawFilesystem)
       events.emit(workspaceEvents.panelUpdate, {
         ...meta,
-        match: [{ id: `file:${from}` }, { param: "path", value: from }],
-        params: { path: to },
+        match: [
+          { id: `file:${uiFileResourceKey({ filesystem, path: from })}` },
+          { params: { path: from, filesystem } },
+        ],
+        params: { path: to, filesystem },
         title: titleFromPath(to),
       })
     })
 
-    const offDeleted = events.on(filesystemEvents.deleted, ({ path, ...meta }) => {
+    const offDeleted = events.on(filesystemEvents.deleted, ({ filesystem: rawFilesystem, path, ...meta }) => {
+      const filesystem = normalizeUiFilesystem(rawFilesystem)
       events.emit(workspaceEvents.panelClose, {
         ...meta,
         match: [
-          { id: `file:${path}` },
-          { param: "path", value: path },
-          { paramPrefix: "path", value: `${path}/` },
+          { id: `file:${uiFileResourceKey({ filesystem, path })}` },
+          { params: { path, filesystem } },
+          { paramPrefix: "path", value: `${path}/`, params: { filesystem } },
         ],
       })
     })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.test.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.test.ts
@@ -33,6 +33,8 @@ describe("HtmlViewer asset rewriting", () => {
       .toBe("/api/v1/files/raw?path=docs%2Fassets%2Freadme%2Fhero.png&workspaceId=boring-ui-v2-36cd3172")
     expect(rewriteCssAssetUrls("body{background:url('../img/bg.png')}", "pages/css/site.css", "", "ws-1"))
       .toBe("body{background:url('/api/v1/files/raw?path=pages%2Fimg%2Fbg.png&workspaceId=ws-1')}")
+    expect(rawFileUrlFor("", "docs/policy.html", null, "company_context"))
+      .toBe("/api/v1/files/raw?path=docs%2Fpolicy.html&filesystem=company_context")
   })
 
   it("inlines linked stylesheets and rewrites stylesheet-relative assets", async () => {
@@ -57,6 +59,17 @@ describe("HtmlViewer asset rewriting", () => {
     expect(html).toContain("url('/api/v1/files/raw?path=pages%2Fassets%2Fhero.png')")
     expect(html).toContain('src="/api/v1/files/raw?path=pages%2Fassets%2Flogo.png"')
     expect(html).toContain('src="/api/v1/files/raw?path=pages%2Fscripts%2Fbook.js"')
+  })
+
+  it("sanitizes denied company HTML preview errors", async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL) => new Response("FORBIDDEN_FINANCE_SECRET_123", { status: 404 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    render(React.createElement(HtmlViewer, { path: "pages/index.html", filesystem: "company_context" }))
+
+    expect(await screen.findByText("not found or denied")).toBeTruthy()
+    expect(String(fetchMock.mock.calls[0][0])).toContain("filesystem=company_context")
+    expect(screen.queryByText(/FORBIDDEN_FINANCE_SECRET_123/)).toBeNull()
   })
 
   it("refresh button re-fetches and rebuilds the preview document", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
@@ -5,9 +5,11 @@ import { ErrorState, IconButton, Spinner } from "@hachej/boring-ui-kit"
 import { ExternalLink, RefreshCcw } from "lucide-react"
 import { cn } from "../../../../front/lib/utils"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
+import { redactedFilesystemErrorMessage } from "../data/filesystemErrorRedaction"
 
 export interface HtmlViewerProps {
   path: string
+  filesystem?: string
   className?: string
 }
 
@@ -66,42 +68,43 @@ export function resolveHtmlPreviewAssetPath(sourcePath: string, assetUrl: string
   return normalized.join("/")
 }
 
-export function rawFileUrlFor(base: string, path: string, workspaceRequestId?: string | null): string {
+export function rawFileUrlFor(base: string, path: string, workspaceRequestId?: string | null, filesystem?: string): string {
   const params = new URLSearchParams({ path })
   if (workspaceRequestId) params.set("workspaceId", workspaceRequestId)
+  if (filesystem && filesystem !== "user") params.set("filesystem", filesystem)
   return apiUrl(base, `/api/v1/files/raw?${params.toString()}`)
 }
 
-function previewAssetUrl(base: string, sourcePath: string, assetUrl: string, workspaceRequestId?: string | null): string {
+function previewAssetUrl(base: string, sourcePath: string, assetUrl: string, workspaceRequestId?: string | null, filesystem?: string): string {
   const resolvedPath = resolveHtmlPreviewAssetPath(sourcePath, assetUrl)
   if (!resolvedPath) return assetUrl
 
   const { suffix } = splitUrlSuffix(assetUrl.trim())
   const hashIndex = suffix.indexOf("#")
   const hash = hashIndex === -1 ? "" : suffix.slice(hashIndex)
-  return `${rawFileUrlFor(base, resolvedPath, workspaceRequestId)}${hash}`
+  return `${rawFileUrlFor(base, resolvedPath, workspaceRequestId, filesystem)}${hash}`
 }
 
-export function rewriteCssAssetUrls(css: string, sourcePath: string, base: string, workspaceRequestId?: string | null): string {
+export function rewriteCssAssetUrls(css: string, sourcePath: string, base: string, workspaceRequestId?: string | null, filesystem?: string): string {
   return css
     .replace(/url\(\s*(["']?)([^"')]+)\1\s*\)/gi, (_match, quote: string, url: string) => {
-      return `url(${quote}${previewAssetUrl(base, sourcePath, url, workspaceRequestId)}${quote})`
+      return `url(${quote}${previewAssetUrl(base, sourcePath, url, workspaceRequestId, filesystem)}${quote})`
     })
     .replace(/@import\s+(url\(\s*)?(["'])([^"']+)\2\s*\)?/gi, (match, urlPrefix: string | undefined, quote: string, url: string) => {
-      const rewritten = previewAssetUrl(base, sourcePath, url, workspaceRequestId)
+      const rewritten = previewAssetUrl(base, sourcePath, url, workspaceRequestId, filesystem)
       if (urlPrefix) return `@import ${urlPrefix}${quote}${rewritten}${quote})`
       return match.replace(`${quote}${url}${quote}`, `${quote}${rewritten}${quote}`)
     })
 }
 
-function rewriteSrcSet(value: string, sourcePath: string, base: string, workspaceRequestId?: string | null): string {
+function rewriteSrcSet(value: string, sourcePath: string, base: string, workspaceRequestId?: string | null, filesystem?: string): string {
   return value
     .split(",")
     .map((entry) => {
       const trimmed = entry.trim()
       const [url, ...descriptor] = trimmed.split(/\s+/)
       if (!url) return entry
-      return [previewAssetUrl(base, sourcePath, url, workspaceRequestId), ...descriptor].join(" ")
+      return [previewAssetUrl(base, sourcePath, url, workspaceRequestId, filesystem), ...descriptor].join(" ")
     })
     .join(", ")
 }
@@ -122,9 +125,10 @@ export async function prepareHtmlPreviewDocument(options: {
   apiBaseUrl: string
   headers: Record<string, string>
   workspaceRequestId?: string | null
+  filesystem?: string
   signal: AbortSignal
 }): Promise<string> {
-  const { html, path, apiBaseUrl, headers, workspaceRequestId, signal } = options
+  const { html, path, apiBaseUrl, headers, workspaceRequestId, filesystem, signal } = options
   const doc = new DOMParser().parseFromString(html, "text/html")
 
   await Promise.all(
@@ -135,25 +139,25 @@ export async function prepareHtmlPreviewDocument(options: {
       if (!stylesheetPath) return
 
       try {
-        const css = await fetchText(rawFileUrlFor(apiBaseUrl, stylesheetPath, workspaceRequestId), headers, signal)
+        const css = await fetchText(rawFileUrlFor(apiBaseUrl, stylesheetPath, workspaceRequestId, filesystem), headers, signal)
         const style = doc.createElement("style")
         style.setAttribute("data-boring-html-viewer-href", href)
-        style.textContent = rewriteCssAssetUrls(css, stylesheetPath, apiBaseUrl, workspaceRequestId)
+        style.textContent = rewriteCssAssetUrls(css, stylesheetPath, apiBaseUrl, workspaceRequestId, filesystem)
         link.replaceWith(style)
       } catch {
-        link.setAttribute("href", previewAssetUrl(apiBaseUrl, path, href, workspaceRequestId))
+        link.setAttribute("href", previewAssetUrl(apiBaseUrl, path, href, workspaceRequestId, filesystem))
       }
     }),
   )
 
   for (const style of Array.from(doc.querySelectorAll<HTMLStyleElement>("style"))) {
     if (style.hasAttribute("data-boring-html-viewer-href")) continue
-    style.textContent = rewriteCssAssetUrls(style.textContent ?? "", path, apiBaseUrl, workspaceRequestId)
+    style.textContent = rewriteCssAssetUrls(style.textContent ?? "", path, apiBaseUrl, workspaceRequestId, filesystem)
   }
 
   for (const element of Array.from(doc.querySelectorAll<HTMLElement>("[style]"))) {
     const style = element.getAttribute("style")
-    if (style) element.setAttribute("style", rewriteCssAssetUrls(style, path, apiBaseUrl, workspaceRequestId))
+    if (style) element.setAttribute("style", rewriteCssAssetUrls(style, path, apiBaseUrl, workspaceRequestId, filesystem))
   }
 
   const assetAttributes = [
@@ -172,19 +176,19 @@ export async function prepareHtmlPreviewDocument(options: {
   for (const [selector, attribute] of assetAttributes) {
     for (const element of Array.from(doc.querySelectorAll<HTMLElement>(`${selector}[${attribute}]`))) {
       const value = element.getAttribute(attribute)
-      if (value) element.setAttribute(attribute, previewAssetUrl(apiBaseUrl, path, value, workspaceRequestId))
+      if (value) element.setAttribute(attribute, previewAssetUrl(apiBaseUrl, path, value, workspaceRequestId, filesystem))
     }
   }
 
   for (const element of Array.from(doc.querySelectorAll<HTMLElement>("[srcset]"))) {
     const srcset = element.getAttribute("srcset")
-    if (srcset) element.setAttribute("srcset", rewriteSrcSet(srcset, path, apiBaseUrl, workspaceRequestId))
+    if (srcset) element.setAttribute("srcset", rewriteSrcSet(srcset, path, apiBaseUrl, workspaceRequestId, filesystem))
   }
 
   return `<!doctype html>\n${doc.documentElement.outerHTML}`
 }
 
-export function HtmlViewer({ path, className }: HtmlViewerProps) {
+export function HtmlViewer({ path, filesystem, className }: HtmlViewerProps) {
   const apiBaseUrl = useApiBaseUrl()
   const workspaceRequestId = useWorkspaceRequestId()
   const [html, setHtml] = useState<string | null>(null)
@@ -192,8 +196,8 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
   const [loading, setLoading] = useState(true)
 
   const rawUrl = useMemo(
-    () => rawFileUrlFor(apiBaseUrl, path, workspaceRequestId),
-    [apiBaseUrl, path, workspaceRequestId],
+    () => rawFileUrlFor(apiBaseUrl, path, workspaceRequestId, filesystem),
+    [apiBaseUrl, path, workspaceRequestId, filesystem],
   )
   const [reloadKey, setReloadKey] = useState(0)
 
@@ -218,19 +222,22 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
           apiBaseUrl,
           headers,
           workspaceRequestId,
+          filesystem,
           signal: controller.signal,
         }))
       })
       .catch((err) => {
         if (controller.signal.aborted) return
-        setError(err instanceof Error ? err.message : "Failed to load HTML preview")
+        const message = err instanceof Error ? err.message : "Failed to load HTML preview"
+        const status = /^HTTP (403|404)$/.exec(message)?.[1]
+        setError(status ? redactedFilesystemErrorMessage(filesystem, Number(status), message) : message)
       })
       .finally(() => {
         if (!controller.signal.aborted) setLoading(false)
       })
 
     return () => controller.abort()
-  }, [apiBaseUrl, path, rawUrl, workspaceRequestId, reloadKey])
+  }, [apiBaseUrl, path, rawUrl, workspaceRequestId, filesystem, reloadKey])
 
   if (!path) {
     return (

--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewerPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewerPane.tsx
@@ -1,10 +1,11 @@
 "use client"
 
+import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import type { PaneProps } from "../../../../shared/types/panel"
 import { HtmlViewer } from "./HtmlViewer"
 
-export type HtmlViewerPaneProps = PaneProps<{ path?: string }>
+export type HtmlViewerPaneProps = PaneProps<{ path?: string; filesystem?: FilesystemId }>
 
 export function HtmlViewerPane({ params, className }: HtmlViewerPaneProps) {
-  return <HtmlViewer path={params?.path ?? ""} className={className} />
+  return <HtmlViewer path={params?.path ?? ""} filesystem={normalizeUiFilesystem(params?.filesystem)} className={className} />
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditorPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditorPane.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { lazy } from "react"
+import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import type { PaneProps } from "../../../../front/registry/types"
 import { useFilePane } from "../useFilePane"
 import { FilePaneShell } from "../FilePaneShell"
@@ -12,10 +13,11 @@ const MarkdownEditor = lazy(() =>
 // `path` is optional: dockview can restore a panel from serialized
 // layout where params got lost. Read defensively, render a placeholder
 // rather than crash when path isn't there.
-export type MarkdownEditorPaneProps = PaneProps<{ path?: string; mode?: "view" | "edit" | "diff" }>
+export type MarkdownEditorPaneProps = PaneProps<{ path?: string; filesystem?: FilesystemId; mode?: "view" | "edit" | "diff" }>
 
 export function MarkdownEditorPane({ params, api, className }: MarkdownEditorPaneProps) {
   const path = typeof params?.path === "string" ? params.path : ""
+  const filesystem = normalizeUiFilesystem(params?.filesystem)
   const readOnly = params?.mode === "view"
 
   const {
@@ -27,7 +29,7 @@ export function MarkdownEditorPane({ params, api, className }: MarkdownEditorPan
     onReloadFromServer,
     onOverwrite,
     tabTitle,
-  } = useFilePane({ path, panelId: api?.id })
+  } = useFilePane({ filesystem, path, panelId: api?.id })
 
   // Update panel title with dirty indicator
   if (api && tabTitle) {
@@ -37,6 +39,7 @@ export function MarkdownEditorPane({ params, api, className }: MarkdownEditorPan
   return (
     <FilePaneShell
       path={path}
+      filesystem={filesystem}
       content={content}
       isLoading={isLoading}
       error={error}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.test.tsx
@@ -3,10 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { DataProvider } from "../data/DataProvider"
 import { MediaViewer } from "./MediaViewer"
 
-function renderViewer() {
+function renderViewer(filesystem?: string) {
   return render(
     <DataProvider apiBaseUrl="">
-      <MediaViewer path="assets/chart.png" kind="image" onReload={vi.fn()} />
+      <MediaViewer path="assets/chart.png" kind="image" filesystem={filesystem} onReload={vi.fn()} />
     </DataProvider>,
   )
 }
@@ -34,5 +34,13 @@ describe("MediaViewer", () => {
     expect(screen.getByRole("button", { name: "Reload chart.png" })).toBeInTheDocument()
     expect(await screen.findByText("Failed to load preview")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Reload chart.png" })).toBeInTheDocument()
+  })
+
+  it("passes company filesystem to raw preview and sanitizes denied errors", async () => {
+    renderViewer("company_context")
+
+    expect(await screen.findByText("not found or denied")).toBeInTheDocument()
+    const url = String(vi.mocked(globalThis.fetch).mock.calls[0][0])
+    expect(url).toContain("filesystem=company_context")
   })
 })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
@@ -4,11 +4,13 @@ import { useEffect, useMemo, useState } from "react"
 import { Download, RefreshCw } from "lucide-react"
 import { ErrorState, Spinner } from "@hachej/boring-ui-kit"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
+import { redactedFilesystemErrorMessage } from "../data/filesystemErrorRedaction"
 import { cn } from "../../../../front/lib/utils"
 
 export interface MediaViewerProps {
   path: string
   kind: "image" | "pdf"
+  filesystem?: string
   reloadKey?: number
   onReload?: () => void
   className?: string
@@ -23,7 +25,7 @@ function filename(path: string): string {
   return path.split("/").pop() ?? path
 }
 
-export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: MediaViewerProps) {
+export function MediaViewer({ path, kind, filesystem, reloadKey = 0, onReload, className }: MediaViewerProps) {
   const apiBaseUrl = useApiBaseUrl()
   const workspaceRequestId = useWorkspaceRequestId()
   const [objectUrl, setObjectUrl] = useState<string | null>(null)
@@ -32,9 +34,10 @@ export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: 
 
   const rawUrl = useMemo(() => {
     const query = new URLSearchParams({ path })
+    if (filesystem && filesystem !== "user") query.set("filesystem", filesystem)
     if (reloadKey > 0) query.set("reload", String(reloadKey))
     return apiUrl(apiBaseUrl, `/api/v1/files/raw?${query.toString()}`)
-  }, [apiBaseUrl, path, reloadKey])
+  }, [apiBaseUrl, path, filesystem, reloadKey])
 
   useEffect(() => {
     const controller = new AbortController()
@@ -52,7 +55,7 @@ export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: 
       signal: controller.signal,
     })
       .then(async (res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        if (!res.ok) throw new Error(redactedFilesystemErrorMessage(filesystem, res.status, `HTTP ${res.status}`))
         const blob = await res.blob()
         nextObjectUrl = URL.createObjectURL(blob)
         setObjectUrl(nextObjectUrl)

--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewerPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewerPane.tsx
@@ -1,10 +1,11 @@
 "use client"
 
+import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import type { PaneProps } from "../../../../shared/types/panel"
 import { MediaViewer } from "./MediaViewer"
 import { useMediaViewerReload } from "./useMediaViewerReload"
 
-export type MediaViewerPaneProps = PaneProps<{ path?: string; kind?: "image" | "pdf" }>
+export type MediaViewerPaneProps = PaneProps<{ path?: string; kind?: "image" | "pdf"; filesystem?: FilesystemId }>
 
 function inferKind(path: string, explicit?: "image" | "pdf"): "image" | "pdf" {
   if (explicit) return explicit
@@ -13,12 +14,14 @@ function inferKind(path: string, explicit?: "image" | "pdf"): "image" | "pdf" {
 
 export function MediaViewerPane({ params, className }: MediaViewerPaneProps) {
   const path = params?.path ?? ""
+  const filesystem = normalizeUiFilesystem(params?.filesystem)
   const { reloadKey, reload } = useMediaViewerReload({ path })
 
   return (
     <MediaViewer
       path={path}
       kind={inferKind(path, params?.kind)}
+      filesystem={filesystem}
       reloadKey={reloadKey}
       onReload={reload}
       className={className}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
@@ -1,6 +1,7 @@
 "use client"
 
 import { useCallback, useEffect, useRef, useState } from "react"
+import { normalizeUiFilesystem, uiFileResourceKey, type FilesystemId } from "../../../shared/types/filesystem"
 import { useFileContent, useFileWrite } from "./data"
 import { FileConflictError } from "./data/fetchClient"
 import { useEditorLifecycle, type EditorLifecycleAdapter } from "../../../front/hooks"
@@ -10,6 +11,8 @@ let nextFallbackPanelId = 0
 export interface UseFilePaneOptions {
   /** The file path to load/edit. If empty/undefined, pane shows "no file selected". */
   path: string
+  /** Filesystem identity for cache/dirty/stale separation. Defaults to user. */
+  filesystem?: FilesystemId
   /** Unique panel ID for lifecycle tracking. Omit to use a stable per-pane fallback ID. */
   panelId?: string
   /** Initial content (optional, for draft/unsaved files). */
@@ -75,11 +78,13 @@ export interface UseFilePaneReturn {
  */
 export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   const { path, panelId, initialContent = null, createIfMissing } = options
+  const filesystem = normalizeUiFilesystem(options.filesystem)
   const activePath = /\S/.test(path) ? path : null
+  const activeResourceKey = activePath ? uiFileResourceKey({ filesystem, path: activePath }) : null
   const fallbackPanelIdRef = useRef(panelId ?? `file-pane:${nextFallbackPanelId++}`)
   const lifecyclePanelId = panelId ?? fallbackPanelIdRef.current
 
-  const fileContentOptions = createIfMissing === undefined ? undefined : { createIfMissing }
+  const fileContentOptions = createIfMissing === undefined ? { filesystem } : { filesystem, createIfMissing }
   const { data: fileData, isLoading, error, refetch: refetchFileData } = useFileContent(activePath, fileContentOptions)
   const { mutateAsync: writeFile } = useFileWrite()
 
@@ -88,6 +93,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   const contentRef = useRef<string>("")
   const dirtyRef = useRef(false)
   const loadedPathRef = useRef<string | null>(null)
+  const loadedResourceKeyRef = useRef<string | null>(null)
   const baselineMtimeRef = useRef<number | null>(null)
   // Ref so the save callback (defined before lifecycle) can call lifecycle.notifySaved.
   const notifySavedRef = useRef<((mtime: number) => void) | null>(null)
@@ -108,7 +114,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
 
   // Reset state when path changes
   useEffect(() => {
-    if (loadedPathRef.current !== path) {
+    if (loadedPathRef.current !== path || loadedResourceKeyRef.current !== activeResourceKey) {
       setContentState(initialContent)
       contentRef.current = initialContent ?? ""
       dirtyRef.current = false
@@ -116,8 +122,9 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
       saveGenRef.current += 1
       setConflict(null)
       loadedPathRef.current = path
+      loadedResourceKeyRef.current = activeResourceKey
     }
-  }, [path, initialContent])
+  }, [path, activeResourceKey, initialContent])
 
   // Load file content on mount or when file data changes
   useEffect(() => {
@@ -140,6 +147,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
             const myGen = ++saveGenRef.current
             try {
               const result = await writeFile({
+                filesystem,
                 path: activePath,
                 content: contentRef.current,
                 expectedMtimeMs: baselineMtimeRef.current ?? undefined,
@@ -181,7 +189,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
         }
       : null
 
-  const lifecycle = useEditorLifecycle(activePath, {
+  const lifecycle = useEditorLifecycle(activeResourceKey, {
     adapter,
     panelId: lifecyclePanelId,
     serverMtime: fileData?.mtimeMs ?? null,
@@ -271,7 +279,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
       // content. (Earlier comment claimed the opposite — it was wrong.)
       if (!activePath) return
       const contentToSave = contentRef.current
-      const result = await writeFile({ path: activePath, content: contentToSave })
+      const result = await writeFile({ filesystem, path: activePath, content: contentToSave })
       if (saveGenRef.current !== myGen) return
       if (typeof result.mtimeMs === "number") {
         baselineMtimeRef.current = result.mtimeMs
@@ -287,7 +295,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
     } catch {
       // Leave conflict UI up so user can retry
     }
-  }, [activePath, writeFile])
+  }, [activePath, filesystem, writeFile])
 
   const save = useCallback(async () => {
     if (!adapter || !dirtyRef.current) return

--- a/packages/workspace/src/plugins/filesystemPlugin/shared/events.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/shared/events.ts
@@ -1,3 +1,5 @@
+import type { FilesystemId } from "../../../shared/types/filesystem"
+
 export const FILESYSTEM_FILE_CHANGED_EVENT = "filesystem:file.changed"
 export const FILESYSTEM_FILE_CREATED_EVENT = "filesystem:file.created"
 export const FILESYSTEM_FILE_MOVED_EVENT = "filesystem:file.moved"
@@ -14,7 +16,7 @@ export type FilesystemEventMeta = (
   | { cause: "user" }
   | { cause: "agent"; toolCallId: string }
   | { cause: "remote"; toolCallId?: string }
-) & { ts: number }
+) & { ts: number; filesystem?: FilesystemId }
 
 export interface FilesystemEventMap {
   [FILESYSTEM_FILE_MOVED_EVENT]: FilesystemEventMeta & { from: string; to: string }


### PR DESCRIPTION
## Stack position
4 / 5 in the #416 governed `company_context` filesystem stack.

Base: #430 / `bclaw/416-pr3-workspace-ui-identity`.
Next: `bclaw/416-pr5-chat-reference-identity`.

## What this adds
- Qualifies file pane cache keys, dirty/stale state, event invalidation, and dock matching by filesystem identity.
- Ensures same-path user events cannot retarget, stale, move, or close `company_context` panels.
- Sends explicit filesystem identity through file content/stat/write hooks and fetch clients.
- Keeps company writes readonly from UI hooks.
- Preserves explicit `company_context` through raw/media/html preview reloads and asset fetching.
- Adds denied reload handling so company tabs fail closed with sanitized status instead of leaking denied metadata.

## Review notes
This PR is the file panel/viewer hardening layer. It is where the UI stops treating path strings as globally unique.

Specific review targets:
- Query/cache keys include filesystem.
- File event invalidation matches filesystem plus path.
- Raw/media/html viewers keep `company_context` on reload/fetch.
- Same-path `user` events cannot affect `company_context` tabs.

## Validation
- `pnpm --dir packages/workspace exec vitest run src/plugins/filesystemPlugin/front/__tests__/filePanelBinding.test.tsx src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.test.ts src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditorPane.test.tsx src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.test.ts src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.test.tsx` — passed
- `pnpm --filter @hachej/boring-workspace typecheck` — passed on the full final stack
