### PR TITLE
#416 company-fs: add readonly company_context fixture projection

### DIFF
--- a/packages/boring-bash/src/server/__tests__/fixtureCompanyContextProvider.test.ts
+++ b/packages/boring-bash/src/server/__tests__/fixtureCompanyContextProvider.test.ts
@@ -1,0 +1,134 @@
+import { mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, test } from "vitest";
+
+import type { BoundFilesystemContext, FilesystemBinding } from "../../shared/index";
+import {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  COMPANY_CONTEXT_SENTINEL,
+  FixtureCompanyContextBindingProvider,
+  listFixtureProjectionFiles,
+  readFixtureProjectionFile,
+  seedCompanyContextFixture,
+} from "../testing/companyContextFixtureProvider";
+
+const ctx: BoundFilesystemContext = {
+  humanUserId: "human-1",
+  agentId: "agent-1",
+  sessionId: "session-1",
+  workspaceId: "workspace-1",
+  requestId: "request-1",
+};
+
+const readonlyBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readonly",
+  mountPath: "/company_context",
+  projection: "policy-filtered",
+};
+
+const managementBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readwrite",
+  mountPath: "/company_context",
+  projection: "management",
+};
+
+async function createFixtureSource() {
+  const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-source-"));
+  await seedCompanyContextFixture(sourceRoot);
+  return sourceRoot;
+}
+
+describe("FixtureCompanyContextBindingProvider", () => {
+  test("physically projects only policy-allowed company files", async () => {
+    const sourceRoot = await createFixtureSource();
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr", "/company/legal"] }),
+    });
+
+    const prepared = await provider.prepareBinding(ctx, readonlyBinding);
+    const visibleFiles = await listFixtureProjectionFiles(prepared.handle);
+
+    expect(visibleFiles).toEqual([
+      "/company/hr/onboarding.md",
+      "/company/hr/policy.md",
+      "/company/legal/contract.md",
+    ]);
+    await expect(readFixtureProjectionFile(prepared.handle, "/company/finance/budget.md")).rejects.toThrow();
+
+    const projectedPolicyPath = join(prepared.handle.projectionRoot, "company", "hr", "policy.md");
+    const projectedText = await readFile(projectedPolicyPath, "utf8");
+    expect(projectedText).toContain("HR policy");
+    await expect(writeFile(projectedPolicyPath, "mutated")).rejects.toThrow();
+    await expect(writeFile(join(prepared.handle.projectionRoot, "company", "hr", "new.md"), "mutated")).rejects.toThrow();
+    const allProjectedContent = await Promise.all(
+      visibleFiles.map((path) => readFixtureProjectionFile(prepared.handle, path)),
+    );
+    expect(allProjectedContent.join("\n")).not.toContain(COMPANY_CONTEXT_SENTINEL);
+  });
+
+  test("prepares policy-granted readwrite management binding distinctly from readonly projection", async () => {
+    const sourceRoot = await createFixtureSource();
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: (ctx) => ({
+        allowedPathPrefixes: ctx.agentId === "curator-agent" ? ["/company"] : ["/company/hr"],
+        grantManagementBinding: ctx.agentId === "curator-agent",
+      }),
+    });
+
+    const readonlyPrepared = await provider.prepareBinding({ ...ctx, agentId: "normal-agent" }, readonlyBinding);
+    await expect(provider.prepareBinding({ ...ctx, agentId: "normal-agent" }, managementBinding))
+      .rejects.toThrow("policy did not grant readwrite management binding");
+    const managementPrepared = await provider.prepareBinding({ ...ctx, agentId: "curator-agent" }, managementBinding);
+
+    expect(readonlyPrepared.handle).toMatchObject({ access: "readonly", projection: "policy-filtered" });
+    expect(managementPrepared.handle).toMatchObject({ access: "readwrite", projection: "management" });
+    expect(managementPrepared.handle.projectionRoot).toBe(sourceRoot);
+    expect(readonlyPrepared.handle.projectionRoot).not.toBe(managementPrepared.handle.projectionRoot);
+    await expect(writeFile(join(managementPrepared.handle.projectionRoot, "company", "hr", "managed.md"), "managed"))
+      .resolves.toBeUndefined();
+  });
+
+  test("generic policy resolver can withhold management binding from non-granted actors", async () => {
+    const resolveBindings = (policy: { grantManagementBinding?: boolean }): FilesystemBinding[] => (
+      policy.grantManagementBinding ? [managementBinding] : [readonlyBinding]
+    );
+
+    expect(resolveBindings({})).toEqual([readonlyBinding]);
+    expect(resolveBindings({ grantManagementBinding: true })).toEqual([managementBinding]);
+  });
+
+  test("rejects unsupported company bindings", async () => {
+    const sourceRoot = await createFixtureSource();
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: () => ({ allowedPathPrefixes: ["/company"] }),
+    });
+
+    await expect(
+      provider.prepareBinding(ctx, { ...readonlyBinding, access: "readwrite" }),
+    ).rejects.toThrow("only prepares readonly policy-filtered or readwrite management bindings");
+    await expect(
+      provider.prepareBinding(ctx, { ...readonlyBinding, projection: "management" }),
+    ).rejects.toThrow("only prepares readonly policy-filtered or readwrite management bindings");
+  });
+
+  test("does not include symlink escapes in readonly projections", async () => {
+    const sourceRoot = await createFixtureSource();
+    const outside = await mkdtemp(join(tmpdir(), "boring-company-outside-"));
+    await writeFile(join(outside, "secret.md"), COMPANY_CONTEXT_SENTINEL);
+    await symlink(join(outside, "secret.md"), join(sourceRoot, "company", "hr", "escape.md"));
+
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr"] }),
+    });
+
+    await expect(provider.prepareBinding(ctx, readonlyBinding)).rejects.toThrow("escapes company context root");
+  });
+});

--- a/packages/boring-bash/src/server/__tests__/readonlyCompanyContextE2e.test.ts
+++ b/packages/boring-bash/src/server/__tests__/readonlyCompanyContextE2e.test.ts
@@ -1,0 +1,155 @@
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, test } from "vitest";
+
+import type { BoundFilesystemContext, FilesystemBinding } from "../../shared/index";
+import {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  COMPANY_CONTEXT_SENTINEL,
+  FixtureCompanyContextBindingProvider,
+  listFixtureProjectionFiles,
+  seedCompanyContextFixture,
+} from "../testing/companyContextFixtureProvider";
+import {
+  READONLY_PROJECTION_INVALID_PATH_CODE,
+  READONLY_PROJECTION_MUTATION_CODE,
+  ReadonlyProjectionOperationError,
+  createReadonlyProjectionOperations,
+} from "../readonlyProjectionOperations";
+import { checkReadonlyProjectionConformance } from "../testing/readonlyProjectionConformance";
+
+const ctx: BoundFilesystemContext = {
+  humanUserId: "human-denied-finance",
+  agentId: "agent-denied-finance",
+  sessionId: "session-denied-finance",
+  workspaceId: "workspace-1",
+  requestId: "request-1",
+};
+
+const readonlyBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readonly",
+  mountPath: "/company_context",
+  projection: "policy-filtered",
+};
+
+async function createSourceRoot() {
+  const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-e2e-source-"));
+  await seedCompanyContextFixture(sourceRoot);
+  return sourceRoot;
+}
+
+describe("readonly company_context e2e harness", () => {
+  test("policy rebuild changes visible projection without denied leakage", async () => {
+    const sourceRoot = await createSourceRoot();
+    let allowedPathPrefixes = ["/company/hr", "/company/legal"];
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: () => ({ allowedPathPrefixes }),
+    });
+
+    const first = await provider.prepareBinding(ctx, readonlyBinding);
+    expect(await listFixtureProjectionFiles(first.handle)).toEqual([
+      "/company/hr/onboarding.md",
+      "/company/hr/policy.md",
+      "/company/legal/contract.md",
+    ]);
+
+    allowedPathPrefixes = ["/company/legal"];
+    await provider.invalidateBinding?.(ctx, COMPANY_CONTEXT_FILESYSTEM_ID);
+    const rebuilt = await provider.prepareBinding(ctx, readonlyBinding);
+    const rebuiltVisible = await listFixtureProjectionFiles(rebuilt.handle);
+    console.info("[company-fs-e2e] actor=human-denied-finance policy=legal-only filesystem=company_context op=rebuild visible=%d sentinelScan=absent", rebuiltVisible.length);
+
+    expect(rebuiltVisible).toEqual(["/company/legal/contract.md"]);
+    expect(JSON.stringify(rebuiltVisible)).not.toContain("hr");
+    expect(JSON.stringify(rebuiltVisible)).not.toContain("finance");
+    expect(JSON.stringify(rebuiltVisible)).not.toContain(COMPANY_CONTEXT_SENTINEL);
+  });
+
+  test("path spoofing and readonly mutations fail closed with stable sanitized errors", async () => {
+    const sourceRoot = await createSourceRoot();
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr", "/company/legal"] }),
+    });
+    const prepared = await provider.prepareBinding(ctx, readonlyBinding);
+    const operations = createReadonlyProjectionOperations(prepared.handle);
+
+    for (const path of ["company_context:/company/hr/policy.md", "/company_context/company/hr/policy.md", "/company/../finance/budget.md"]) {
+      await expect(operations.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path }))
+        .rejects.toMatchObject({ code: READONLY_PROJECTION_INVALID_PATH_CODE });
+      try {
+        await operations.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path });
+      } catch (err) {
+        const simulatedToolEvent = { type: "tool-error", error: err };
+        expect(JSON.stringify(simulatedToolEvent)).not.toContain(COMPANY_CONTEXT_SENTINEL);
+        expect(JSON.stringify(simulatedToolEvent)).not.toContain("finance");
+        expect(JSON.stringify(simulatedToolEvent)).not.toContain("budget.md");
+        expect((err as ReadonlyProjectionOperationError).metadata.path).toMatch(/^(invalid_path|not_found_or_denied)$/);
+      }
+      console.info("[company-fs-e2e] actor=human-denied-finance op=path-spoof filesystem=company_context path=<spoof> visible=0 sentinelScan=absent");
+    }
+
+    for (const path of ["/company/hr/policy.md", "/company/finance/budget.md"]) {
+      try {
+        operations.rejectMutation("write", { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path });
+      } catch (err) {
+        expect(err).toBeInstanceOf(ReadonlyProjectionOperationError);
+        expect((err as ReadonlyProjectionOperationError).code).toBe(READONLY_PROJECTION_MUTATION_CODE);
+        expect((err as ReadonlyProjectionOperationError).metadata.path).toBe("readonly");
+        const simulatedToolEvent = { type: "tool-error", error: err };
+        expect(JSON.stringify(simulatedToolEvent)).not.toContain(COMPANY_CONTEXT_SENTINEL);
+        expect(JSON.stringify(simulatedToolEvent)).not.toContain("finance");
+        expect(JSON.stringify(simulatedToolEvent)).not.toContain("budget.md");
+        console.info("[company-fs-e2e] actor=human-denied-finance op=write filesystem=company_context path=<readonly> visible=0 sentinelScan=absent");
+      }
+    }
+  });
+
+  test("unsafe projection fails reusable conformance in the e2e harness", async () => {
+    const sourceRoot = await createSourceRoot();
+    const unsafeHandle = {
+      kind: "company-context-fixture-projection" as const,
+      filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+      sourceRoot,
+      projectionRoot: sourceRoot,
+      visiblePaths: await listFixtureProjectionFiles({
+        kind: "company-context-fixture-projection",
+        filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+        sourceRoot,
+        projectionRoot: sourceRoot,
+        visiblePaths: [],
+      }),
+    };
+    const operations = createReadonlyProjectionOperations(unsafeHandle);
+    const result = await checkReadonlyProjectionConformance({
+      filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+      rootPath: "/company",
+      operations,
+      allowedReadPath: "/company/hr/policy.md",
+      deniedReadPath: "/company/finance/budget.md",
+      deniedDirectoryName: "finance",
+      deniedSentinel: COMPANY_CONTEXT_SENTINEL,
+      allowedFindPattern: "policy.md",
+      expectedAllowedFindCount: 1,
+      expectedVisiblePaths: [
+        "/company/hr/onboarding.md",
+        "/company/hr/policy.md",
+        "/company/legal/contract.md",
+      ],
+      projection: {
+        listVisiblePaths: () => listFixtureProjectionFiles(unsafeHandle),
+        writeExistingAllowedPath: async () => undefined,
+        writeNewAllowedPath: async () => undefined,
+        followSymlinkEscape: async () => undefined,
+      },
+    });
+
+    console.info("[company-fs-e2e] actor=human-denied-finance op=unsafe-conformance filesystem=company_context path=/company visible=%d sentinelScan=failed", result.failures.length);
+    expect(result.passed).toBe(false);
+    expect(result.failures.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/boring-bash/src/server/__tests__/readonlyCompanyContextLeakage.test.ts
+++ b/packages/boring-bash/src/server/__tests__/readonlyCompanyContextLeakage.test.ts
@@ -1,0 +1,131 @@
+import { execFile } from "node:child_process";
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { promisify } from "node:util";
+
+import { describe, expect, test } from "vitest";
+
+import type { BoundFilesystemContext, FilesystemBinding } from "../../shared/index";
+import {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  COMPANY_CONTEXT_SENTINEL,
+  FixtureCompanyContextBindingProvider,
+  listFixtureProjectionFiles,
+  seedCompanyContextFixture,
+} from "../testing/companyContextFixtureProvider";
+import { ReadonlyProjectionOperationError, createReadonlyProjectionOperations } from "../readonlyProjectionOperations";
+
+const execFileAsync = promisify(execFile);
+
+const ctx: BoundFilesystemContext = {
+  humanUserId: "human-denied-finance",
+  agentId: "agent-denied-finance",
+  sessionId: "session-denied-finance",
+  workspaceId: "workspace-1",
+  requestId: "request-1",
+};
+
+const readonlyBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readonly",
+  mountPath: "/company_context",
+  projection: "policy-filtered",
+};
+
+async function createDeniedFinanceProjection() {
+  const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-leakage-source-"));
+  await seedCompanyContextFixture(sourceRoot);
+  const provider = new FixtureCompanyContextBindingProvider({
+    sourceRoot,
+    resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr", "/company/legal"] }),
+  });
+  const prepared = await provider.prepareBinding(ctx, readonlyBinding);
+  return { prepared, operations: createReadonlyProjectionOperations(prepared.handle) };
+}
+
+function assertNoDeniedLeak(label: string, value: unknown) {
+  const serialized = JSON.stringify(value);
+  expect(serialized, label).not.toContain(COMPANY_CONTEXT_SENTINEL);
+  expect(serialized, label).not.toContain("budget.md");
+  expect(serialized, label).not.toContain("hidden");
+  expect(serialized, label).not.toContain("total");
+}
+
+describe("readonly company_context leakage and pagination safety", () => {
+  test("list/find/grep/read errors and metadata do not expose denied sentinel or hidden counts", async () => {
+    const { operations } = await createDeniedFinanceProjection();
+
+    const list = await operations.list({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company" });
+    console.info("[company-fs-leakage] actor=human-denied-finance op=list filesystem=company_context path=/company visible=%d sentinelScan=absent", list.entries.length);
+    expect(list.entries).toEqual(["hr", "legal"]);
+    assertNoDeniedLeak("list output", list);
+
+    const findAll = await operations.find({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company" }, "*.md");
+    console.info("[company-fs-leakage] actor=human-denied-finance op=find filesystem=company_context path=/company pattern=*.md visible=%d sentinelScan=absent", findAll.paths.length);
+    expect(findAll.paths).toEqual([
+      "/company/hr/onboarding.md",
+      "/company/hr/policy.md",
+      "/company/legal/contract.md",
+    ]);
+    assertNoDeniedLeak("find output", findAll);
+
+    const grep = await operations.grep({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company" }, COMPANY_CONTEXT_SENTINEL);
+    console.info("[company-fs-leakage] actor=human-denied-finance op=grep filesystem=company_context path=/company pattern=<sentinel> visible=%d sentinelScan=absent", grep.matches.length);
+    expect(grep.matches).toEqual([]);
+    assertNoDeniedLeak("grep output", grep);
+
+    for (const [operation, invoke] of [
+      ["read", () => operations.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/finance/budget.md" })],
+      ["find", () => operations.find({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/finance/budget.md" }, "*.md")],
+      ["grep", () => operations.grep({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/finance/budget.md" }, COMPANY_CONTEXT_SENTINEL)],
+    ] as const) {
+      await expect(invoke()).rejects.toThrow();
+      try {
+        await invoke();
+      } catch (err) {
+        assertNoDeniedLeak(`${operation} denied error`, err);
+        expect((err as ReadonlyProjectionOperationError).metadata).toMatchObject({
+          filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+          path: "not_found_or_denied",
+          operation,
+        });
+      }
+    }
+  });
+
+  test("pagination is over the already-filtered visible result set and exposes no denied totals", async () => {
+    const { operations } = await createDeniedFinanceProjection();
+
+    const firstPage = await operations.find({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company" }, "*.md", { limit: 2 });
+    const secondPage = await operations.find({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company" }, "*.md", { offset: 2, limit: 2 });
+    const combined = [...firstPage.paths, ...secondPage.paths];
+
+    console.info("[company-fs-leakage] actor=human-denied-finance op=find-page filesystem=company_context path=/company pages=%j visible=%d sentinelScan=absent", [firstPage.paths.length, secondPage.paths.length], combined.length);
+    expect(firstPage.paths).toHaveLength(2);
+    expect(secondPage.paths).toHaveLength(1);
+    expect(combined).toEqual([
+      "/company/hr/onboarding.md",
+      "/company/hr/policy.md",
+      "/company/legal/contract.md",
+    ]);
+    assertNoDeniedLeak("paginated find output", { firstPage, secondPage });
+    expect("total" in firstPage).toBe(false);
+    expect("hidden" in firstPage).toBe(false);
+  });
+
+  test("mounted readonly projection shell output cannot observe denied sentinel", async () => {
+    const { prepared } = await createDeniedFinanceProjection();
+    const visibleFiles = await listFixtureProjectionFiles(prepared.handle);
+    expect(JSON.stringify(visibleFiles)).not.toContain("finance");
+
+    try {
+      await execFileAsync("grep", ["-R", COMPANY_CONTEXT_SENTINEL, prepared.handle.projectionRoot]);
+      throw new Error("grep unexpectedly found denied sentinel in readonly projection");
+    } catch (err) {
+      const output = `${(err as { stdout?: string }).stdout ?? ""}${(err as { stderr?: string }).stderr ?? ""}`;
+      console.info("[company-fs-leakage] actor=human-denied-finance op=shell-grep filesystem=company_context path=/company visible=%d sentinelScan=absent", visibleFiles.length);
+      expect(output).not.toContain(COMPANY_CONTEXT_SENTINEL);
+    }
+  });
+});

--- a/packages/boring-bash/src/server/__tests__/readonlyCompanyContextOperations.test.ts
+++ b/packages/boring-bash/src/server/__tests__/readonlyCompanyContextOperations.test.ts
@@ -1,0 +1,93 @@
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, test } from "vitest";
+
+import type { BoundFilesystemContext, FilesystemBinding } from "../../shared/index";
+import {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  COMPANY_CONTEXT_SENTINEL,
+  FixtureCompanyContextBindingProvider,
+  seedCompanyContextFixture,
+} from "../testing/companyContextFixtureProvider";
+import {
+  READONLY_PROJECTION_INVALID_PATH_CODE,
+  READONLY_PROJECTION_MUTATION_CODE,
+  ReadonlyProjectionOperationError,
+  createReadonlyProjectionOperations,
+} from "../readonlyProjectionOperations";
+
+const ctx: BoundFilesystemContext = {
+  humanUserId: "human-1",
+  agentId: "agent-1",
+  sessionId: "session-1",
+  workspaceId: "workspace-1",
+  requestId: "request-1",
+};
+
+const readonlyBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readonly",
+  mountPath: "/company_context",
+  projection: "policy-filtered",
+};
+
+async function createOps() {
+  const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-ops-source-"));
+  await seedCompanyContextFixture(sourceRoot);
+  const provider = new FixtureCompanyContextBindingProvider({
+    sourceRoot,
+    resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr", "/company/legal"] }),
+  });
+  const prepared = await provider.prepareBinding(ctx, readonlyBinding);
+  return createReadonlyProjectionOperations(prepared.handle);
+}
+
+describe("createReadonlyProjectionOperations", () => {
+  test("reads, lists, finds, and greps only projected company files", async () => {
+    const ops = await createOps();
+
+    await expect(ops.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/policy.md" }))
+      .resolves.toMatchObject({ content: expect.stringContaining("HR policy") });
+    await expect(ops.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/finance/budget.md" }))
+      .rejects.toThrow();
+
+    await expect(ops.list({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company" }))
+      .resolves.toMatchObject({ entries: ["hr", "legal"] });
+    await expect(ops.find({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company" }, "*.md"))
+      .resolves.toMatchObject({ paths: [
+        "/company/hr/onboarding.md",
+        "/company/hr/policy.md",
+        "/company/legal/contract.md",
+      ] });
+
+    const grep = await ops.grep({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company" }, "policy");
+    expect(grep.matches.map((match) => match.path)).toContain("/company/hr/policy.md");
+    expect(JSON.stringify(grep)).not.toContain(COMPANY_CONTEXT_SENTINEL);
+  });
+
+  test("rejects readonly mutations with stable metadata", async () => {
+    const ops = await createOps();
+    expect(() => ops.rejectMutation("write", { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/policy.md" }))
+      .toThrow(ReadonlyProjectionOperationError);
+    try {
+      ops.rejectMutation("write", { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/policy.md" });
+    } catch (err) {
+      expect((err as ReadonlyProjectionOperationError).code).toBe(READONLY_PROJECTION_MUTATION_CODE);
+      expect((err as ReadonlyProjectionOperationError).metadata).toEqual({
+        filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+        path: "readonly",
+        operation: "write",
+      });
+    }
+  });
+
+  test("rejects filesystem path spoofing", async () => {
+    const ops = await createOps();
+    await expect(ops.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "company_context:/company/hr/policy.md" }))
+      .rejects.toMatchObject({ code: READONLY_PROJECTION_INVALID_PATH_CODE });
+    await expect(ops.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/../finance/budget.md" }))
+      .rejects.toMatchObject({ code: READONLY_PROJECTION_INVALID_PATH_CODE });
+  });
+});

--- a/packages/boring-bash/src/server/__tests__/readonlyProjectionConformance.test.ts
+++ b/packages/boring-bash/src/server/__tests__/readonlyProjectionConformance.test.ts
@@ -1,0 +1,135 @@
+import { mkdtemp, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, test } from "vitest";
+
+import type { BoundFilesystemContext, FilesystemBinding } from "../../shared/index";
+import {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  COMPANY_CONTEXT_SENTINEL,
+  FixtureCompanyContextBindingProvider,
+  listFixtureProjectionFiles,
+  seedCompanyContextFixture,
+  type CompanyContextFixturePreparedHandle,
+} from "../testing/companyContextFixtureProvider";
+import { createReadonlyProjectionOperations } from "../readonlyProjectionOperations";
+import { checkReadonlyProjectionConformance, type ReadonlyProjectionConformanceSubject } from "../testing/readonlyProjectionConformance";
+
+const ctx: BoundFilesystemContext = {
+  humanUserId: "human-1",
+  agentId: "agent-1",
+  sessionId: "session-1",
+  workspaceId: "workspace-1",
+  requestId: "request-1",
+};
+
+const readonlyBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readonly",
+  mountPath: "/company_context",
+  projection: "policy-filtered",
+};
+
+const expectedVisiblePaths = [
+  "/company/hr/onboarding.md",
+  "/company/hr/policy.md",
+  "/company/legal/contract.md",
+];
+
+function fixtureProjectionProbe(handle: CompanyContextFixturePreparedHandle) {
+  return {
+    listVisiblePaths: () => listFixtureProjectionFiles(handle),
+    writeExistingAllowedPath: () => writeFile(join(handle.projectionRoot, "company", "hr", "policy.md"), "mutated"),
+    writeNewAllowedPath: () => writeFile(join(handle.projectionRoot, "company", "hr", "new.md"), "mutated"),
+    followSymlinkEscape: async () => {
+      const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-symlink-source-"));
+      await seedCompanyContextFixture(sourceRoot);
+      const outside = await mkdtemp(join(tmpdir(), "boring-company-outside-"));
+      await writeFile(join(outside, "secret.md"), COMPANY_CONTEXT_SENTINEL);
+      await symlink(join(outside, "secret.md"), join(sourceRoot, "company", "hr", "escape.md"));
+      const provider = new FixtureCompanyContextBindingProvider({
+        sourceRoot,
+        resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr"] }),
+      });
+      await provider.prepareBinding(ctx, readonlyBinding);
+    },
+  };
+}
+
+async function createSafeSubject(): Promise<ReadonlyProjectionConformanceSubject> {
+  const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-conformance-source-"));
+  await seedCompanyContextFixture(sourceRoot);
+  const provider = new FixtureCompanyContextBindingProvider({
+    sourceRoot,
+    resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr", "/company/legal"] }),
+  });
+  const prepared = await provider.prepareBinding(ctx, readonlyBinding);
+  return {
+    filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+    rootPath: "/company",
+    operations: createReadonlyProjectionOperations(prepared.handle),
+    allowedReadPath: "/company/hr/policy.md",
+    deniedReadPath: "/company/finance/budget.md",
+    deniedDirectoryName: "finance",
+    deniedSentinel: COMPANY_CONTEXT_SENTINEL,
+    allowedFindPattern: "policy.md",
+    expectedAllowedFindCount: 1,
+    expectedVisiblePaths,
+    projection: fixtureProjectionProbe(prepared.handle),
+  };
+}
+
+describe("readonly projection conformance", () => {
+  test("fixture/local readonly projection passes reusable conformance", async () => {
+    const result = await checkReadonlyProjectionConformance(await createSafeSubject());
+    expect(result).toEqual({ passed: true, failures: [] });
+  });
+
+  test("intentionally unsafe full-store projection fails conformance", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-unsafe-source-"));
+    await seedCompanyContextFixture(sourceRoot);
+    const unsafeHandle: CompanyContextFixturePreparedHandle = {
+      kind: "company-context-fixture-projection",
+      filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+      sourceRoot,
+      projectionRoot: sourceRoot,
+      visiblePaths: await listFixtureProjectionFiles({
+        kind: "company-context-fixture-projection",
+        filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+        sourceRoot,
+        projectionRoot: sourceRoot,
+        visiblePaths: [],
+      }),
+    };
+
+    const result = await checkReadonlyProjectionConformance({
+      filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+      rootPath: "/company",
+      operations: createReadonlyProjectionOperations(unsafeHandle),
+      allowedReadPath: "/company/hr/policy.md",
+      deniedReadPath: "/company/finance/budget.md",
+      deniedDirectoryName: "finance",
+      deniedSentinel: COMPANY_CONTEXT_SENTINEL,
+      allowedFindPattern: "policy.md",
+      expectedAllowedFindCount: 1,
+      expectedVisiblePaths,
+      projection: {
+        ...fixtureProjectionProbe(unsafeHandle),
+        followSymlinkEscape: async () => "unsafe provider followed escape",
+      },
+    });
+
+    expect(result.passed).toBe(false);
+    expect(result.failures).toEqual(expect.arrayContaining([
+      "visible path set/count does not match the expected policy-filtered projection",
+      "visiblePaths leaked denied directory name",
+      "list leaked denied directory name",
+      "find returned denied resource matches",
+      "grep returned denied sentinel matches",
+      "write to existing projection file unexpectedly succeeded",
+      "write to new projection file unexpectedly succeeded",
+      "symlink escape unexpectedly succeeded",
+    ]));
+  });
+});

--- a/packages/boring-bash/src/server/index.ts
+++ b/packages/boring-bash/src/server/index.ts
@@ -1,3 +1,45 @@
+export {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  COMPANY_CONTEXT_SENTINEL,
+  DEFAULT_COMPANY_CONTEXT_FIXTURE_FILES,
+  FixtureCompanyContextBindingProvider,
+  listFixtureProjectionFiles,
+  readFixtureProjectionFile,
+  seedCompanyContextFixture,
+} from "./testing/companyContextFixtureProvider";
+
+export {
+  READONLY_PROJECTION_BINDING_NOT_FOUND_CODE,
+  READONLY_PROJECTION_INVALID_PATH_CODE,
+  READONLY_PROJECTION_MUTATION_CODE,
+  ReadonlyProjectionOperationError,
+  createReadonlyProjectionOperations,
+} from "./readonlyProjectionOperations";
+
+export { checkReadonlyProjectionConformance } from "./testing/readonlyProjectionConformance";
+
+export type {
+  ReadonlyProjectionOperationMetadata,
+  FilesystemPathDescriptor,
+  ReadonlyProjectionOperations,
+} from "./readonlyProjectionOperations";
+
+export type {
+  CompanyContextFixtureFile,
+  CompanyContextFixturePreparedBinding,
+  CompanyContextFixturePreparedHandle,
+  CompanyContextFixturePreparedLifecycle,
+  CompanyContextFixtureProjectionPolicy,
+  CompanyContextFixtureProviderOptions,
+} from "./testing/companyContextFixtureProvider";
+
+export type {
+  ReadonlyProjectionConformanceResult,
+  ReadonlyProjectionConformanceSubject,
+  ReadonlyProjectionConformanceOperations,
+  ReadonlyProjectionProbe,
+} from "./testing/readonlyProjectionConformance";
+
 export type {
   BoundFilesystemContext,
   FilesystemBinding,

--- a/packages/boring-bash/src/server/readonlyProjectionOperations.ts
+++ b/packages/boring-bash/src/server/readonlyProjectionOperations.ts
@@ -1,0 +1,211 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import type { FilesystemId } from "../shared/index";
+
+export const READONLY_PROJECTION_MUTATION_CODE = "READONLY_PROJECTION_READONLY";
+export const READONLY_PROJECTION_INVALID_PATH_CODE = "READONLY_PROJECTION_INVALID_PATH";
+export const READONLY_PROJECTION_BINDING_NOT_FOUND_CODE = "READONLY_PROJECTION_BINDING_NOT_FOUND";
+
+export interface FilesystemPathDescriptor {
+  readonly filesystem: FilesystemId;
+  readonly path: string;
+}
+
+export interface ReadonlyProjectionOperationMetadata {
+  readonly filesystem: FilesystemId;
+  readonly path: string;
+  readonly operation: string;
+}
+
+export class ReadonlyProjectionOperationError extends Error {
+  readonly code: string;
+  readonly metadata: ReadonlyProjectionOperationMetadata;
+
+  constructor(code: string, message: string, metadata: ReadonlyProjectionOperationMetadata) {
+    super(message);
+    this.name = "ReadonlyProjectionOperationError";
+    this.code = code;
+    this.metadata = metadata;
+  }
+}
+
+export interface ReadonlyProjectionSearchOptions {
+  readonly offset?: number;
+  readonly limit?: number;
+}
+
+export interface ReadonlyProjectionOperations {
+  read(descriptor: FilesystemPathDescriptor): Promise<{ content: string; metadata: ReadonlyProjectionOperationMetadata }>;
+  list(descriptor: FilesystemPathDescriptor): Promise<{ entries: string[]; metadata: ReadonlyProjectionOperationMetadata }>;
+  find(descriptor: FilesystemPathDescriptor, pattern: string, options?: ReadonlyProjectionSearchOptions): Promise<{ paths: string[]; metadata: ReadonlyProjectionOperationMetadata }>;
+  grep(descriptor: FilesystemPathDescriptor, pattern: string, options?: ReadonlyProjectionSearchOptions): Promise<{ matches: Array<{ path: string; line: number; text: string }>; metadata: ReadonlyProjectionOperationMetadata }>;
+  stat(descriptor: FilesystemPathDescriptor): Promise<{ isDirectory: boolean; metadata: ReadonlyProjectionOperationMetadata }>;
+  rejectMutation(operation: string, descriptor: FilesystemPathDescriptor): never;
+}
+
+function normalizeProjectionPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  if (normalized.includes("\0")) throw new Error("null byte in projection path");
+  if (normalized.includes(":/")) throw new Error("filesystem prefixes are not valid path strings");
+  if (normalized === "") return "/";
+  const withRoot = normalized.startsWith("/") ? normalized : `/${normalized}`;
+  const parts = withRoot.split("/").filter(Boolean);
+  if (parts.some((part) => part === ".." || part === ".")) {
+    throw new Error("path traversal is not allowed");
+  }
+  return `/${parts.join("/")}`;
+}
+
+function unreadableProjectionPathError(metadata: ReadonlyProjectionOperationMetadata): ReadonlyProjectionOperationError {
+  return new ReadonlyProjectionOperationError(
+    READONLY_PROJECTION_INVALID_PATH_CODE,
+    "projection path is not readable",
+    { ...metadata, path: "not_found_or_denied" },
+  );
+}
+
+function assertProjectionDescriptor(
+  descriptor: FilesystemPathDescriptor,
+  operation: string,
+  expectedFilesystem: FilesystemId,
+): ReadonlyProjectionOperationMetadata {
+  if (descriptor.filesystem !== expectedFilesystem) {
+    throw new ReadonlyProjectionOperationError(
+      READONLY_PROJECTION_BINDING_NOT_FOUND_CODE,
+      `No readonly binding for filesystem ${descriptor.filesystem}`,
+      { filesystem: descriptor.filesystem, path: descriptor.path, operation },
+    );
+  }
+  try {
+    return { filesystem: descriptor.filesystem, path: normalizeProjectionPath(descriptor.path), operation };
+  } catch (err) {
+    throw new ReadonlyProjectionOperationError(
+      READONLY_PROJECTION_INVALID_PATH_CODE,
+      (err as Error).message,
+      { filesystem: descriptor.filesystem, path: "invalid_path", operation },
+    );
+  }
+}
+
+function projectionPath(handle: ReadonlyProjectionHandle, path: string): string {
+  const normalized = normalizeProjectionPath(path);
+  return join(handle.projectionRoot, ...normalized.slice(1).split("/"));
+}
+
+async function assertInsideProjection(handle: ReadonlyProjectionHandle, candidate: string): Promise<void> {
+  const root = resolve(handle.projectionRoot);
+  const parent = dirname(candidate);
+  const existingParent = await stat(parent).then(() => parent).catch(() => root);
+  const rel = relative(root, resolve(existingParent));
+  if (rel.startsWith("..") || isAbsolute(rel)) throw new Error("path escapes readonly projection");
+}
+
+async function walkFiles(root: string, current = root): Promise<string[]> {
+  const entries = await readdir(current, { withFileTypes: true });
+  const out: string[] = [];
+  for (const entry of entries) {
+    const absolutePath = join(current, entry.name);
+    if (entry.isDirectory()) out.push(...await walkFiles(root, absolutePath));
+    else if (entry.isFile()) out.push(absolutePath);
+  }
+  return out;
+}
+
+function pageVisibleResults<T>(items: T[], options: ReadonlyProjectionSearchOptions | undefined): T[] {
+  const offset = Math.max(0, Math.trunc(options?.offset ?? 0));
+  const limit = options?.limit == null ? undefined : Math.max(0, Math.trunc(options.limit));
+  return limit == null ? items.slice(offset) : items.slice(offset, offset + limit);
+}
+
+function globToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[|\\{}()[\]^$+?.]/g, "\\$&")
+    .replace(/\*\*/g, ".*")
+    .replace(/\*/g, "[^/]*");
+  return new RegExp(`^${escaped}$`);
+}
+
+export interface ReadonlyProjectionHandle {
+  readonly filesystem: FilesystemId;
+  readonly projectionRoot: string;
+}
+
+export function createReadonlyProjectionOperations(handle: ReadonlyProjectionHandle): ReadonlyProjectionOperations {
+  const expectedFilesystem = handle.filesystem;
+
+  async function filesUnder(path: string): Promise<string[]> {
+    const root = projectionPath(handle, path);
+    await assertInsideProjection(handle, root);
+    const rootStat = await stat(root);
+    const files = rootStat.isDirectory() ? await walkFiles(handle.projectionRoot, root) : [root];
+    return files.map((file) => `/${relative(handle.projectionRoot, file).split(sep).join("/")}`).sort();
+  }
+
+  return {
+    async read(descriptor) {
+      const metadata = assertProjectionDescriptor(descriptor, "read", expectedFilesystem);
+      const target = projectionPath(handle, metadata.path);
+      await assertInsideProjection(handle, target);
+      try {
+        return { content: await readFile(target, "utf8"), metadata };
+      } catch {
+        throw unreadableProjectionPathError(metadata);
+      }
+    },
+    async list(descriptor) {
+      const metadata = assertProjectionDescriptor(descriptor, "list", expectedFilesystem);
+      const target = projectionPath(handle, metadata.path);
+      await assertInsideProjection(handle, target);
+      try {
+        const entries = (await readdir(target)).sort();
+        return { entries, metadata };
+      } catch {
+        throw unreadableProjectionPathError(metadata);
+      }
+    },
+    async find(descriptor, pattern, options) {
+      const metadata = assertProjectionDescriptor(descriptor, "find", expectedFilesystem);
+      try {
+        const matcher = globToRegex(pattern);
+        const paths = (await filesUnder(metadata.path)).filter((path) => matcher.test(path.slice(1)) || matcher.test(path.split("/").at(-1) ?? path));
+        return { paths: pageVisibleResults(paths, options), metadata };
+      } catch {
+        throw unreadableProjectionPathError(metadata);
+      }
+    },
+    async grep(descriptor, pattern, options) {
+      const metadata = assertProjectionDescriptor(descriptor, "grep", expectedFilesystem);
+      try {
+        const matches: Array<{ path: string; line: number; text: string }> = [];
+        for (const path of await filesUnder(metadata.path)) {
+          const content = await readFile(projectionPath(handle, path), "utf8");
+          content.split("\n").forEach((text, index) => {
+            if (text.includes(pattern)) matches.push({ path, line: index + 1, text });
+          });
+        }
+        return { matches: pageVisibleResults(matches, options), metadata };
+      } catch {
+        throw unreadableProjectionPathError(metadata);
+      }
+    },
+    async stat(descriptor) {
+      const metadata = assertProjectionDescriptor(descriptor, "stat", expectedFilesystem);
+      const target = projectionPath(handle, metadata.path);
+      await assertInsideProjection(handle, target);
+      try {
+        return { isDirectory: (await stat(target)).isDirectory(), metadata };
+      } catch {
+        throw unreadableProjectionPathError(metadata);
+      }
+    },
+    rejectMutation(operation, descriptor): never {
+      const metadata = assertProjectionDescriptor(descriptor, operation, expectedFilesystem);
+      throw new ReadonlyProjectionOperationError(
+        READONLY_PROJECTION_MUTATION_CODE,
+        `filesystem is readonly for ${operation}`,
+        { ...metadata, path: "readonly" },
+      );
+    },
+  };
+}

--- a/packages/boring-bash/src/server/testing/companyContextFixtureProvider.ts
+++ b/packages/boring-bash/src/server/testing/companyContextFixtureProvider.ts
@@ -1,0 +1,233 @@
+import { constants } from "node:fs";
+import { access, chmod, copyFile, lstat, mkdir, mkdtemp, readFile, readdir, realpath } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { tmpdir } from "node:os";
+
+import type {
+  BoundFilesystemContext,
+  FilesystemBinding,
+  FilesystemBindingProvider,
+  FilesystemId,
+  FilesystemProjection,
+  PreparedFilesystemBinding,
+} from "../../shared/index";
+
+export const COMPANY_CONTEXT_FILESYSTEM_ID = "company_context" satisfies FilesystemId;
+export const COMPANY_CONTEXT_SENTINEL = "FORBIDDEN_FINANCE_SECRET_123";
+
+export interface CompanyContextFixtureFile {
+  path: string;
+  content: string;
+}
+
+export const DEFAULT_COMPANY_CONTEXT_FIXTURE_FILES: readonly CompanyContextFixtureFile[] = [
+  { path: "/company/hr/policy.md", content: "# HR policy\nVacation and onboarding policies.\n" },
+  { path: "/company/hr/onboarding.md", content: "# Onboarding\nWelcome to the company.\n" },
+  { path: "/company/finance/budget.md", content: `# Finance budget\n${COMPANY_CONTEXT_SENTINEL}\n` },
+  { path: "/company/legal/contract.md", content: "# Legal contract\nStandard terms.\n" },
+];
+
+export interface CompanyContextFixtureProjectionPolicy {
+  readonly allowedPathPrefixes: readonly string[];
+  readonly grantManagementBinding?: boolean;
+}
+
+export interface CompanyContextFixtureProviderOptions {
+  readonly sourceRoot: string;
+  readonly projectionRootParent?: string;
+  readonly resolvePolicy: (ctx: BoundFilesystemContext) => CompanyContextFixtureProjectionPolicy | Promise<CompanyContextFixtureProjectionPolicy>;
+}
+
+export interface CompanyContextFixturePreparedLifecycle {
+  active: boolean;
+}
+
+export interface CompanyContextFixturePreparedHandle {
+  readonly kind: "company-context-fixture-projection";
+  /** Logical filesystem identity for this prepared binding; paths are scoped by this id. */
+  readonly filesystem: FilesystemId;
+  readonly sourceRoot: string;
+  readonly projectionRoot: string;
+  readonly visiblePaths: readonly string[];
+  readonly access?: "readonly" | "readwrite";
+  readonly projection?: FilesystemProjection;
+  readonly lifecycle?: CompanyContextFixturePreparedLifecycle;
+}
+
+export type CompanyContextFixturePreparedBinding = PreparedFilesystemBinding & {
+  handle: CompanyContextFixturePreparedHandle;
+};
+
+function normalizeCompanyPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  if (!normalized.startsWith("/")) return `/${normalized}`;
+  return normalized;
+}
+
+function assertSafeCompanyPath(path: string): string {
+  const normalized = normalizeCompanyPath(path);
+  if (normalized.includes("\0")) throw new Error(`invalid company path: ${path}`);
+  for (const part of normalized.split("/")) {
+    if (part === "..") throw new Error(`invalid company path traversal: ${path}`);
+  }
+  return normalized.replace(/\/+/g, "/");
+}
+
+function isAllowed(path: string, prefixes: readonly string[]): boolean {
+  const normalized = assertSafeCompanyPath(path);
+  return prefixes.some((prefix) => {
+    const normalizedPrefix = assertSafeCompanyPath(prefix).replace(/\/+$/, "");
+    return normalized === normalizedPrefix || normalized.startsWith(`${normalizedPrefix}/`);
+  });
+}
+
+async function assertInsideRoot(root: string, candidate: string): Promise<void> {
+  const realRoot = await realpath(root);
+  const existing = await realpath(candidate);
+  const rel = relative(realRoot, existing);
+  if (rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(`path escapes company context root: ${candidate}`);
+  }
+}
+
+async function walkFiles(root: string, current = root): Promise<string[]> {
+  const entries = await readdir(current, { withFileTypes: true });
+  const out: string[] = [];
+  for (const entry of entries) {
+    const absolutePath = join(current, entry.name);
+    const entryStat = await lstat(absolutePath);
+    if (entryStat.isSymbolicLink()) {
+      await assertInsideRoot(root, absolutePath);
+      continue;
+    }
+    if (entry.isDirectory()) out.push(...await walkFiles(root, absolutePath));
+    else if (entry.isFile()) out.push(absolutePath);
+  }
+  return out;
+}
+
+async function makeProjectionReadonly(root: string, current = root): Promise<void> {
+  const entries = await readdir(current, { withFileTypes: true });
+  for (const entry of entries) {
+    const absolutePath = join(current, entry.name);
+    if (entry.isDirectory()) await makeProjectionReadonly(root, absolutePath);
+    else if (entry.isFile()) await chmod(absolutePath, 0o444);
+  }
+  await chmod(current, 0o555);
+}
+
+export async function seedCompanyContextFixture(root: string): Promise<void> {
+  for (const file of DEFAULT_COMPANY_CONTEXT_FIXTURE_FILES) {
+    const safePath = assertSafeCompanyPath(file.path);
+    const target = join(root, ...safePath.slice(1).split("/"));
+    await mkdir(dirname(target), { recursive: true });
+    await access(dirname(target), constants.W_OK);
+    await import("node:fs/promises").then(({ writeFile }) => writeFile(target, file.content));
+  }
+}
+
+export class FixtureCompanyContextBindingProvider implements FilesystemBindingProvider {
+  readonly #sourceRoot: string;
+  readonly #projectionRootParent: string;
+  readonly #resolvePolicy: CompanyContextFixtureProviderOptions["resolvePolicy"];
+
+  constructor(options: CompanyContextFixtureProviderOptions) {
+    this.#sourceRoot = resolve(options.sourceRoot);
+    this.#projectionRootParent = resolve(options.projectionRootParent ?? tmpdir());
+    this.#resolvePolicy = options.resolvePolicy;
+  }
+
+  async invalidateBinding(_ctx: BoundFilesystemContext, _filesystem: FilesystemId): Promise<void> {
+    // Fixture/local policies are resolved on every prepareBinding call; invalidation is a lifecycle hook for callers.
+  }
+
+  async disposeBinding(prepared: PreparedFilesystemBinding): Promise<void> {
+    const handle = prepared.handle as Partial<CompanyContextFixturePreparedHandle>;
+    if (handle.lifecycle) handle.lifecycle.active = false;
+  }
+
+  async prepareBinding(ctx: BoundFilesystemContext, binding: FilesystemBinding): Promise<CompanyContextFixturePreparedBinding> {
+    if (binding.filesystem !== COMPANY_CONTEXT_FILESYSTEM_ID) {
+      throw new Error(`fixture company provider cannot prepare filesystem ${binding.filesystem}`);
+    }
+    if (binding.access === "readwrite" && binding.projection === "management") {
+      const policy = await this.#resolvePolicy(ctx);
+      if (!policy.grantManagementBinding) {
+        throw new Error("fixture company provider policy did not grant readwrite management binding");
+      }
+      const lifecycle = { active: true };
+      return {
+        binding,
+        handle: {
+          kind: "company-context-fixture-projection",
+          filesystem: binding.filesystem,
+          sourceRoot: this.#sourceRoot,
+          projectionRoot: this.#sourceRoot,
+          visiblePaths: await listFixtureProjectionFiles({
+            kind: "company-context-fixture-projection",
+            filesystem: binding.filesystem,
+            sourceRoot: this.#sourceRoot,
+            projectionRoot: this.#sourceRoot,
+            visiblePaths: [],
+            access: "readwrite",
+            projection: "management",
+          }),
+          access: "readwrite",
+          projection: "management",
+          lifecycle,
+        },
+      };
+    }
+    if (binding.access !== "readonly" || binding.projection !== "policy-filtered") {
+      throw new Error("fixture company provider only prepares readonly policy-filtered or readwrite management bindings");
+    }
+
+    const policy = await this.#resolvePolicy(ctx);
+    const projectionRoot = await mkdtemp(join(this.#projectionRootParent, "boring-company-context-"));
+    const visiblePaths: string[] = [];
+    const files = await walkFiles(this.#sourceRoot);
+
+    for (const sourceFile of files) {
+      await assertInsideRoot(this.#sourceRoot, sourceFile);
+      const rel = relative(this.#sourceRoot, sourceFile).split(sep).join("/");
+      const companyPath = assertSafeCompanyPath(`/${rel}`);
+      if (!isAllowed(companyPath, policy.allowedPathPrefixes)) continue;
+
+      const destination = join(projectionRoot, ...companyPath.slice(1).split("/"));
+      await mkdir(dirname(destination), { recursive: true });
+      await copyFile(sourceFile, destination);
+      visiblePaths.push(companyPath);
+    }
+
+    visiblePaths.sort();
+    await makeProjectionReadonly(projectionRoot);
+    const lifecycle = { active: true };
+    return {
+      binding,
+      handle: {
+        kind: "company-context-fixture-projection",
+        filesystem: binding.filesystem,
+        sourceRoot: this.#sourceRoot,
+        projectionRoot,
+        visiblePaths,
+        access: "readonly",
+        projection: "policy-filtered",
+        lifecycle,
+      },
+    };
+  }
+}
+
+export async function readFixtureProjectionFile(handle: CompanyContextFixturePreparedHandle, companyPath: string): Promise<string> {
+  const safePath = assertSafeCompanyPath(companyPath);
+  const target = join(handle.projectionRoot, ...safePath.slice(1).split("/"));
+  await assertInsideRoot(handle.projectionRoot, target);
+  return await readFile(target, "utf8");
+}
+
+export async function listFixtureProjectionFiles(handle: CompanyContextFixturePreparedHandle): Promise<string[]> {
+  const files = await walkFiles(handle.projectionRoot);
+  return files
+    .map((file) => `/${relative(handle.projectionRoot, file).split(sep).join("/")}`)
+    .sort();
+}

--- a/packages/boring-bash/src/server/testing/readonlyProjectionConformance.ts
+++ b/packages/boring-bash/src/server/testing/readonlyProjectionConformance.ts
@@ -1,0 +1,127 @@
+export interface ReadonlyProjectionConformanceSubject {
+  readonly filesystem: string;
+  readonly rootPath: string;
+  readonly operations: ReadonlyProjectionConformanceOperations;
+  readonly allowedReadPath: string;
+  readonly deniedReadPath: string;
+  readonly deniedDirectoryName: string;
+  readonly deniedSentinel: string;
+  readonly allowedFindPattern: string;
+  readonly expectedAllowedFindCount: number;
+  readonly expectedVisiblePaths: readonly string[];
+  readonly projection: ReadonlyProjectionProbe;
+}
+
+export interface ReadonlyProjectionConformanceOperations {
+  read(descriptor: { filesystem: string; path: string }): Promise<{ content: string }>;
+  list(descriptor: { filesystem: string; path: string }): Promise<{ entries: readonly unknown[] }>;
+  find(descriptor: { filesystem: string; path: string }, pattern: string): Promise<{ matches?: readonly unknown[]; paths?: readonly unknown[] }>;
+  grep(descriptor: { filesystem: string; path: string }, pattern: string): Promise<{ matches: readonly unknown[] }>;
+}
+
+export interface ReadonlyProjectionProbe {
+  listVisiblePaths(): Promise<readonly string[]>;
+  writeExistingAllowedPath(): Promise<unknown>;
+  writeNewAllowedPath(): Promise<unknown>;
+  followSymlinkEscape(): Promise<unknown>;
+}
+
+export interface ReadonlyProjectionConformanceResult {
+  readonly passed: boolean;
+  readonly failures: readonly string[];
+}
+
+async function expectRejects(label: string, failures: string[], fn: () => Promise<unknown>): Promise<void> {
+  try {
+    await fn();
+    failures.push(label);
+  } catch {
+    // Expected for negative conformance checks.
+  }
+}
+
+function assertSerializedDoesNotLeak(
+  label: string,
+  value: unknown,
+  deniedDirectoryName: string,
+  deniedSentinel: string,
+  failures: string[],
+): void {
+  const serialized = JSON.stringify(value);
+  if (serialized.includes(deniedDirectoryName)) {
+    failures.push(`${label} leaked denied directory name`);
+  }
+  if (serialized.includes(deniedSentinel)) {
+    failures.push(`${label} leaked denied sentinel`);
+  }
+}
+
+export async function checkReadonlyProjectionConformance(
+  subject: ReadonlyProjectionConformanceSubject,
+): Promise<ReadonlyProjectionConformanceResult> {
+  const failures: string[] = [];
+  const {
+    filesystem,
+    rootPath,
+    operations,
+    allowedReadPath,
+    deniedReadPath,
+    deniedDirectoryName,
+    deniedSentinel,
+    allowedFindPattern,
+    expectedAllowedFindCount,
+    expectedVisiblePaths,
+    projection,
+  } = subject;
+
+  const visiblePaths = [...(await projection.listVisiblePaths())].sort();
+  const expectedPaths = [...expectedVisiblePaths].sort();
+  if (JSON.stringify(visiblePaths) !== JSON.stringify(expectedPaths)) {
+    failures.push("visible path set/count does not match the expected policy-filtered projection");
+  }
+  if (visiblePaths.some((path) => path === deniedReadPath || path.startsWith(`${deniedReadPath}/`))) {
+    failures.push("denied path is present in visiblePaths");
+  }
+  assertSerializedDoesNotLeak("visiblePaths", visiblePaths, deniedDirectoryName, deniedSentinel, failures);
+
+  const allowed = await operations.read({ filesystem, path: allowedReadPath });
+  assertSerializedDoesNotLeak("allowed read", allowed, deniedDirectoryName, deniedSentinel, failures);
+
+  await expectRejects("denied read unexpectedly succeeded", failures, async () => {
+    await operations.read({ filesystem, path: deniedReadPath });
+  });
+
+  const list = await operations.list({ filesystem, path: rootPath });
+  assertSerializedDoesNotLeak("list", list, deniedDirectoryName, deniedSentinel, failures);
+
+  const deniedFileName = deniedReadPath.split("/").at(-1) ?? deniedDirectoryName;
+  const findDeniedName = await operations.find({ filesystem, path: rootPath }, deniedFileName);
+  const deniedFindItems = findDeniedName.matches ?? findDeniedName.paths ?? [];
+  if (deniedFindItems.length > 0) {
+    failures.push("find returned denied resource matches");
+  }
+  assertSerializedDoesNotLeak("find denied resource", findDeniedName, deniedDirectoryName, deniedSentinel, failures);
+
+  const findAllowed = await operations.find({ filesystem, path: rootPath }, allowedFindPattern);
+  const allowedFindItems = findAllowed.matches ?? findAllowed.paths ?? [];
+  if (allowedFindItems.length !== expectedAllowedFindCount) {
+    failures.push("find visible count does not match expected policy-filtered results");
+  }
+  assertSerializedDoesNotLeak("find allowed", findAllowed, deniedDirectoryName, deniedSentinel, failures);
+
+  const grep = await operations.grep({ filesystem, path: rootPath }, deniedSentinel);
+  if (grep.matches.length > 0) {
+    failures.push("grep returned denied sentinel matches");
+  }
+  assertSerializedDoesNotLeak("grep", grep, deniedDirectoryName, deniedSentinel, failures);
+
+  await expectRejects("write to existing projection file unexpectedly succeeded", failures, () =>
+    projection.writeExistingAllowedPath(),
+  );
+  await expectRejects("write to new projection file unexpectedly succeeded", failures, () =>
+    projection.writeNewAllowedPath(),
+  );
+  await expectRejects("symlink escape unexpectedly succeeded", failures, () => projection.followSymlinkEscape());
+
+  return { passed: failures.length === 0, failures };
+}


### PR DESCRIPTION
## Stack position
3 / 8 in the #416 governed `company_context` filesystem stack.

Base: #437 / `bclaw/416-pr1b-boring-bash-skeleton`.
Next: `bclaw/416-pr1d-company-management-bindings`.

## What this adds
- Adds the fixture-backed `company_context` provider for dev/test/CLI use.
- Adds readonly company context operations for read/list/find/grep.
- Adds reusable readonly projection conformance checks.
- Adds leakage tests proving denied files and `FORBIDDEN_FINANCE_SECRET_123` are physically omitted/sanitized.

## Review notes
This is the critical readonly safety layer. It should be reviewed for fail-closed behavior, no path-prefix inference, denied metadata sanitization, and filtered projection semantics.

## Validation
- `TMPDIR=$PWD/.tmp-vitest pnpm --dir packages/boring-bash test` — 22 passed on final stack
- `pnpm --filter @hachej/boring-bash typecheck` — passed on final stack
