### PR TITLE
mcp-integration: Add generic managed connector adapter

### DIFF
--- a/packages/workspace/src/front/components/CommandPalette.tsx
+++ b/packages/workspace/src/front/components/CommandPalette.tsx
@@ -227,7 +227,6 @@ export function CommandPalette({ sessionSearch, apiBaseUrl, authHeaders }: Comma
         className="cmdk-shell flex flex-col gap-0 overflow-hidden border-border/60 bg-background p-0 shadow-none backdrop-blur-0 [&>button.dialog-close]:hidden"
         style={{ height: 520, width: "min(640px, calc(100vw - 2rem))", maxWidth: 640 }}
         showCloseButton={false}
-        overlayClassName="bg-transparent"
         onPointerDownOutside={() => setOpen(false)}
         onEscapeKeyDown={() => setOpen(false)}
       >

--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -7,7 +7,8 @@ This package is the generic MCP capability that child apps can enable. It owns:
 - generic Sources left-tab and MCP Sources panel shell;
 - provider template, source, tool, policy, redaction, status, and facade contracts;
 - deny-before-allow read-only policy helpers;
-- fake-transport-testable facade seams.
+- fake-transport-testable facade seams;
+- server-only managed connector adapter seam with app-injected secret resolution.
 
 It intentionally does **not** perform real connector-provider calls, OAuth, provider execution, secret storage, or app-specific environment binding in the foundation PR.
 
@@ -41,7 +42,7 @@ Apps may also list the package in `package.json#boring.defaultPluginPackages`, b
 
 ## Security boundaries
 
-Managed connector adapters must pass the [Composio security preflight](./docs/composio-security-preflight.md) and the executable `validateManagedConnectorPreflight` server check before real product provider calls.
+Managed connector adapters must pass the [Composio security preflight](./docs/composio-security-preflight.md) and the executable `validateManagedConnectorPreflight` server check before real product provider calls. The generic `createManagedConnectorAdapter` seam accepts provider config plus an app-owned server secret resolver; reusable boring-mcp never binds app env/Vault details.
 
 - Browser UI never receives provider OAuth tokens, connector API keys, or MCP session headers.
 - Raw provider meta-tools are not exposed by this foundation.
@@ -51,4 +52,4 @@ Managed connector adapters must pass the [Composio security preflight](./docs/co
 
 ## Current status
 
-Foundation only. Real connector providers, route registration, agent bridge tools, and provider execution land in later PRs.
+Foundation plus source handlers, executable preflight, and generic managed connector adapter seam. Real Composio SDK/API calls, route registration, agent bridge tools, and provider execution land in later PRs.

--- a/plugins/boring-mcp/src/__tests__/managedConnectorAdapter.test.ts
+++ b/plugins/boring-mcp/src/__tests__/managedConnectorAdapter.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi } from "vitest"
+import { MCP_ERROR_CODES, McpError, type McpActor, type McpSource } from "../shared"
+import { createManagedConnectorAdapter, type ManagedConnectorConfig, type ManagedConnectorProvider, type ManagedConnectorSourceRegistry } from "../server/managedConnectorAdapter"
+import type { ManagedConnectorPreflightEvidence } from "../server/managedConnectorPreflight"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+const config: ManagedConnectorConfig = {
+  provider: "notion",
+  displayName: "Notion",
+  toolkitId: "notion-toolkit",
+  scopes: ["read:pages"],
+  connectUrlOrigins: ["https://connect.example"],
+}
+const preflightEvidence: ManagedConnectorPreflightEvidence = {
+  connectorName: "fake-managed-connector",
+  isolatedTestProject: true,
+  apiKeyStorage: "server-vault",
+  browserDtoSamples: [{ status: "connected", providerAccountLabel: "demo@example.com" }],
+  redactedLogSamples: [{ message: "ok", authorization: "[REDACTED_MCP_SECRET]" }],
+  redactedProviderResultSamples: [{ content: "ok", session_headers: "[REDACTED_MCP_SECRET]" }],
+  redactionCanaries: ["MCP_CANARY_DO_NOT_LEAK"],
+  revokeDisconnectVerified: true,
+  connectedAccountStatusVerified: true,
+  vendorRisk: {
+    dpaStatus: "approved",
+    subprocessorStatus: "approved",
+    dataResidencyStatus: "approved",
+    incidentHistoryStatus: "approved",
+  },
+}
+
+function createRegistry(): ManagedConnectorSourceRegistry {
+  const sources = new Map<string, McpSource>()
+  return {
+    async listSources(requestActor) {
+      return [...sources.values()].filter((source) => source.workspaceId === requestActor.workspaceId && source.userId === requestActor.userId)
+    },
+    async getSource(sourceId) {
+      return sources.get(sourceId)
+    },
+    async upsertSource(_actor, source) {
+      sources.set(source.id, source)
+      return source
+    },
+    async disconnectSource(requestActor, sourceId) {
+      const source = sources.get(sourceId)
+      if (!source || source.workspaceId !== requestActor.workspaceId || source.userId !== requestActor.userId) return undefined
+      const next = { ...source, status: "revoked" as const }
+      sources.set(sourceId, next)
+      return next
+    },
+  }
+}
+
+function createProvider(): ManagedConnectorProvider {
+  return {
+    startConnect: vi.fn(async ({ sourceId }) => ({
+      connectorRef: { provider: "notion", toolkitId: "notion-toolkit", externalSourceId: "provider-source-1", sessionId: "session-1" },
+      status: "connected" as const,
+      connectUrl: `https://connect.example/${sourceId}`,
+      providerAccountLabel: "demo@example.com",
+    })),
+    refreshStatus: vi.fn(async () => ({ status: "connected" as const, providerAccountLabel: "demo@example.com", lastVerifiedAt: "2026-06-29T20:00:00.000Z" })),
+    probe: vi.fn(async () => ({
+      tools: [{ name: "NOTION_SEARCH_NOTION_PAGE", description: "Search pages" }, { name: "update_page", description: "Mutate page" }],
+      resources: [{ uri: "notion://page/demo", name: "Demo page" }],
+    })),
+  }
+}
+
+function createAdapter(overrides: Partial<Parameters<typeof createManagedConnectorAdapter>[0]> = {}) {
+  const provider = createProvider()
+  const registry = createRegistry()
+  return {
+    provider,
+    registry,
+    adapter: createManagedConnectorAdapter({
+      registry,
+      provider,
+      configs: [config],
+      preflightEvidence,
+      secretResolver: { resolveSecret: vi.fn(async () => ({ storage: "server-vault" as const, value: "server-only-secret" })) },
+      ...overrides,
+    }),
+  }
+}
+
+describe("managed connector adapter", () => {
+  it("starts a generic managed connector flow and stores only a secret-free source DTO", async () => {
+    const { adapter, provider } = createAdapter()
+
+    const result = await adapter.startConnect(actor, { provider: "notion" })
+
+    expect(result.connectUrl).toBe("https://connect.example/managed:workspace-1:user-1:notion")
+    expect(result.source).toEqual(expect.objectContaining({
+      id: "managed:workspace-1:user-1:notion",
+      provider: "notion",
+      status: "unconfigured",
+      credentialProvider: "composio-managed",
+      connectorRef: expect.objectContaining({ externalSourceId: "provider-source-1", sessionId: "session-1" }),
+    }))
+    expect(JSON.stringify(result)).not.toContain("server-only-secret")
+    expect(provider.startConnect).toHaveBeenCalledWith(expect.objectContaining({ config: expect.objectContaining({ toolkitId: "notion-toolkit" }), sourceId: "managed:workspace-1:user-1:notion" }))
+  })
+
+  it("refreshes status and probes normalized read-only tool decisions through fake provider", async () => {
+    const { adapter } = createAdapter()
+
+    await adapter.startConnect(actor, { provider: "notion" })
+    const status = await adapter.refreshStatus(actor, "managed:workspace-1:user-1:notion")
+    const probe = await adapter.probeSource(actor, "managed:workspace-1:user-1:notion")
+
+    expect(status.source.status).toBe("connected")
+    expect(status.source.providerAccountLabel).toBe("demo@example.com")
+    expect(probe.tools).toEqual([
+      expect.objectContaining({ name: "NOTION_SEARCH_NOTION_PAGE", decision: expect.objectContaining({ allowed: true, risk: "read" }) }),
+      expect.objectContaining({ name: "update_page", decision: expect.objectContaining({ allowed: false, risk: "write" }) }),
+    ])
+  })
+
+  it("blocks cross-user status/probe access before provider calls", async () => {
+    const { adapter, provider } = createAdapter()
+
+    await adapter.startConnect(actor, { provider: "notion" })
+    await expect(adapter.refreshStatus({ ...actor, userId: "other" }, "managed:workspace-1:user-1:notion")).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_NOT_FOUND })
+    await expect(adapter.probeSource({ ...actor, userId: "other" }, "managed:workspace-1:user-1:notion")).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_NOT_FOUND })
+    expect(provider.refreshStatus).not.toHaveBeenCalled()
+    expect(provider.probe).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when provider responses leak API keys, session headers, tokens, canaries, or the resolved secret", async () => {
+    const provider = createProvider()
+    provider.startConnect = vi.fn(async () => ({
+      connectorRef: { provider: "notion", externalSourceId: "provider-source-1" },
+      status: "unconfigured" as const,
+      providerAccountLabel: "Bearer abcdefghijklmnop MCP_CANARY_DO_NOT_LEAK server-only-secret",
+    }))
+    const adapter = createManagedConnectorAdapter({
+      registry: createRegistry(),
+      provider,
+      configs: [config],
+      preflightEvidence,
+      secretResolver: { resolveSecret: vi.fn(async () => ({ storage: "server-env" as const, value: "server-only-secret" })) },
+    })
+
+    await expect(adapter.startConnect(actor, { provider: "notion" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+  })
+
+  it("fails closed when provider connect URLs contain token-like query params", async () => {
+    const provider = createProvider()
+    provider.startConnect = vi.fn(async () => ({
+      connectorRef: { provider: "notion", externalSourceId: "provider-source-1" },
+      status: "unconfigured" as const,
+      connectUrl: "https://connect.example/callback?access_token=abcdefghijklmnop&state=ok",
+    }))
+    const adapter = createManagedConnectorAdapter({
+      registry: createRegistry(),
+      provider,
+      configs: [config],
+      preflightEvidence,
+      secretResolver: { resolveSecret: vi.fn(async () => ({ storage: "server-env" as const, value: "server-only-secret" })) },
+    })
+
+    await expect(adapter.startConnect(actor, { provider: "notion" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+  })
+
+  it("rejects unsafe or unapproved browser connect URLs", async () => {
+    const provider = createProvider()
+    provider.startConnect = vi.fn(async () => ({
+      connectorRef: { provider: "notion", externalSourceId: "provider-source-1" },
+      status: "unconfigured" as const,
+      connectUrl: "https://user:pass@connect.example/callback",
+    }))
+    const adapter = createManagedConnectorAdapter({
+      registry: createRegistry(),
+      provider,
+      configs: [config],
+      preflightEvidence,
+      secretResolver: { resolveSecret: vi.fn(async () => ({ storage: "server-env" as const, value: "server-only-secret" })) },
+    })
+
+    await expect(adapter.startConnect(actor, { provider: "notion" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
+  })
+
+  it("requires preflight evidence and server-only secret configuration before provider use", () => {
+    expect(() => createManagedConnectorAdapter({
+      registry: createRegistry(),
+      provider: createProvider(),
+      configs: [config],
+      preflightEvidence: { ...preflightEvidence, redactionCanaries: [] },
+      secretResolver: { resolveSecret: vi.fn(async () => ({ storage: "server-vault" as const, value: "server-only-secret" })) },
+    })).toThrow(McpError)
+  })
+})

--- a/plugins/boring-mcp/src/__tests__/sourceHandlers.test.ts
+++ b/plugins/boring-mcp/src/__tests__/sourceHandlers.test.ts
@@ -62,6 +62,15 @@ describe("boring-mcp source handlers", () => {
     expect(result.sources[0]).not.toHaveProperty("sessionHeaders")
   })
 
+  it("rejects source DTOs that contain secret-like provider metadata", async () => {
+    const handlers = createBoringMcpSourceHandlers({
+      registry: makeRegistry(makeSource({ providerAccountLabel: "access_token=abcdefghijklmnop" })),
+      transport: makeTransport(),
+    })
+
+    await expect(handlers.listSources(actor)).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+  })
+
   it("returns status only for the owning actor", async () => {
     const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport: makeTransport() })
 
@@ -84,6 +93,14 @@ describe("boring-mcp source handlers", () => {
       expect.objectContaining({ name: "NOTION_SEARCH_NOTION_PAGE", decision: expect.objectContaining({ allowed: true }) }),
       expect.objectContaining({ name: "update_page", decision: expect.objectContaining({ allowed: false }) }),
     ])
+  })
+
+  it("rejects probe metadata that contains secret-like values", async () => {
+    const transport = makeTransport()
+    transport.listResources = vi.fn(async () => [{ uri: "notion://page/demo?oauth_token=abcdefghijklmnop" }])
+    const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport })
+
+    await expect(handlers.probeSource(actor, "source:notion:user-1")).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
   })
 
   it("does not call disconnect on unowned sources", async () => {

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -14,6 +14,7 @@ export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPlugin
 }
 
 export default createBoringMcpServerPlugin()
+export * from "./managedConnectorAdapter"
 export * from "./managedConnectorPreflight"
 export * from "./sourceHandlers"
 export * from "../shared"

--- a/plugins/boring-mcp/src/server/managedConnectorAdapter.ts
+++ b/plugins/boring-mcp/src/server/managedConnectorAdapter.ts
@@ -1,0 +1,222 @@
+import {
+  MCP_ERROR_CODES,
+  McpError,
+  classifyMcpTool,
+  containsMcpSecret,
+  getMcpProviderTemplate,
+  type McpActor,
+  type McpConnectorRef,
+  type McpDiscoveredResource,
+  type McpDiscoveredTool,
+  type McpErrorCode,
+  type McpProviderId,
+  type McpProviderTemplate,
+  type McpProbeResult,
+  type McpSource,
+  type McpSourceRegistry,
+  type McpSourceStatus,
+  type McpSourceStatusPayload,
+} from "../shared"
+import {
+  assertManagedConnectorPreflight,
+  type ManagedConnectorPreflightEvidence,
+  type ManagedConnectorSecretStorage,
+} from "./managedConnectorPreflight"
+import { createMcpSourceStatusPayload, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
+
+export interface ManagedConnectorSecret {
+  storage: ManagedConnectorSecretStorage
+  value: string
+}
+
+export interface ManagedConnectorSecretResolver {
+  resolveSecret(provider: McpProviderId): Promise<ManagedConnectorSecret>
+}
+
+export interface ManagedConnectorConfig {
+  provider: McpProviderId
+  displayName: string
+  toolkitId: string
+  scopes?: readonly string[]
+  connectUrlOrigins?: readonly string[]
+}
+
+export interface ManagedConnectorSourceRegistry extends McpSourceRegistry {
+  upsertSource(actor: McpActor, source: McpSource): Promise<McpSource>
+}
+
+export interface ManagedConnectorStartInput {
+  provider: McpProviderId
+  displayName?: string
+}
+
+export interface ManagedConnectorStartResponse {
+  connectorRef: McpConnectorRef
+  status?: McpSourceStatus
+  connectUrl?: string
+  providerAccountLabel?: string
+}
+
+export interface ManagedConnectorStatusResponse {
+  status: McpSourceStatus
+  providerAccountLabel?: string
+  lastVerifiedAt?: string
+  connectorRef?: McpConnectorRef
+}
+
+export interface ManagedConnectorProbeResponse {
+  tools: McpDiscoveredTool[]
+  resources: McpDiscoveredResource[]
+}
+
+export interface ManagedConnectorProvider {
+  startConnect(args: { actor: McpActor; config: ManagedConnectorConfig; secret: ManagedConnectorSecret; sourceId: string }): Promise<ManagedConnectorStartResponse>
+  refreshStatus(args: { actor: McpActor; source: McpSource; config: ManagedConnectorConfig; secret: ManagedConnectorSecret }): Promise<ManagedConnectorStatusResponse>
+  probe(args: { actor: McpActor; source: McpSource; config: ManagedConnectorConfig; secret: ManagedConnectorSecret }): Promise<ManagedConnectorProbeResponse>
+}
+
+export interface ManagedConnectorAdapterOptions {
+  registry: ManagedConnectorSourceRegistry
+  provider: ManagedConnectorProvider
+  secretResolver: ManagedConnectorSecretResolver
+  configs: readonly ManagedConnectorConfig[]
+  preflightEvidence: ManagedConnectorPreflightEvidence
+  templates?: readonly McpProviderTemplate[]
+  redactionCanaries?: readonly string[]
+  sourceIdFactory?: (actor: McpActor, config: ManagedConnectorConfig) => string
+}
+
+export interface ManagedConnectorAdapter {
+  startConnect(actor: McpActor, input: ManagedConnectorStartInput): Promise<ManagedConnectorStartResult>
+  refreshStatus(actor: McpActor, sourceId: string): Promise<McpSourceStatusPayload>
+  probeSource(actor: McpActor, sourceId: string): Promise<McpProbeResult>
+}
+
+export interface ManagedConnectorStartResult extends McpSourceStatusPayload {
+  connectUrl?: string
+}
+
+function findConfig(configs: readonly ManagedConnectorConfig[], provider: McpProviderId): ManagedConnectorConfig | undefined {
+  return configs.find((config) => config.provider === provider)
+}
+
+function defaultSourceId(actor: McpActor, config: ManagedConnectorConfig): string {
+  return validateMcpSourceId(`managed:${actor.workspaceId}:${actor.userId}:${config.provider}`)
+}
+
+function containsCanary(value: unknown, canaries: readonly string[]): boolean {
+  if (typeof value === "string") return canaries.some((canary) => canary.trim() && value.includes(canary))
+  if (Array.isArray(value)) return value.some((item) => containsCanary(item, canaries))
+  if (!value || typeof value !== "object") return false
+  return Object.entries(value).some(([key, nested]) => containsCanary(key, canaries) || containsCanary(nested, canaries))
+}
+
+function assertSecretFree(value: unknown, canaries: readonly string[], code: McpErrorCode = MCP_ERROR_CODES.SECRET_LEAK_GUARD): void {
+  if (containsMcpSecret(value) || containsCanary(value, canaries)) {
+    throw new McpError(code, "Managed connector response contained secret material")
+  }
+}
+
+function safeConnectUrl(rawUrl: string | undefined, config: ManagedConnectorConfig): string | undefined {
+  if (!rawUrl) return undefined
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Managed connector returned an invalid connect URL")
+  }
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password) {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Managed connector returned an unsafe connect URL")
+  }
+  if (config.connectUrlOrigins?.length && !config.connectUrlOrigins.includes(parsed.origin)) {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Managed connector returned an unapproved connect URL origin")
+  }
+  return parsed.toString()
+}
+
+export function createManagedConnectorAdapter(options: ManagedConnectorAdapterOptions): ManagedConnectorAdapter {
+  assertManagedConnectorPreflight(options.preflightEvidence)
+  const canaries = [...options.preflightEvidence.redactionCanaries, ...(options.redactionCanaries ?? [])]
+  const templates = options.templates
+
+  async function getSecret(provider: McpProviderId): Promise<ManagedConnectorSecret> {
+    const secret = await options.secretResolver.resolveSecret(provider)
+    if ((secret.storage !== "server-env" && secret.storage !== "server-vault") || !secret.value) {
+      throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Managed connector secret is not configured")
+    }
+    return secret
+  }
+
+  function requireConfig(provider: McpProviderId): ManagedConnectorConfig {
+    const config = findConfig(options.configs, provider)
+    const template = getMcpProviderTemplate(provider, templates)
+    if (!config || !template) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown managed connector provider")
+    return config
+  }
+
+  return {
+    async startConnect(actor, input) {
+      const config = requireConfig(input.provider)
+      const sourceId = validateMcpSourceId((options.sourceIdFactory ?? defaultSourceId)(actor, config))
+      const secret = await getSecret(config.provider)
+      const secretCanaries = [...canaries, secret.value]
+      const response = await options.provider.startConnect({ actor, config, secret, sourceId })
+      const connectUrl = safeConnectUrl(response.connectUrl, config)
+      assertSecretFree({ ...response, connectUrl }, secretCanaries)
+      const source: McpSource = {
+        id: sourceId,
+        workspaceId: actor.workspaceId,
+        userId: actor.userId,
+        provider: config.provider,
+        displayName: input.displayName ?? config.displayName,
+        status: response.status === "connected" ? "unconfigured" : (response.status ?? "unconfigured"),
+        ownerKind: "user",
+        credentialProvider: "composio-managed",
+        scopes: config.scopes ? [...config.scopes] : undefined,
+        providerAccountLabel: response.providerAccountLabel,
+        connectorRef: response.connectorRef,
+      }
+      assertSecretFree(source, secretCanaries)
+      const saved = await options.registry.upsertSource(actor, source)
+      assertSecretFree(saved, secretCanaries)
+      return { ...createMcpSourceStatusPayload(saved), connectUrl }
+    },
+
+    async refreshStatus(actor, sourceId) {
+      const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
+      const config = requireConfig(source.provider)
+      const secret = await getSecret(config.provider)
+      const secretCanaries = [...canaries, secret.value]
+      const response = await options.provider.refreshStatus({ actor, source, config, secret })
+      assertSecretFree(response, secretCanaries)
+      const saved = await options.registry.upsertSource(actor, {
+        ...source,
+        status: response.status,
+        providerAccountLabel: response.providerAccountLabel ?? source.providerAccountLabel,
+        connectorRef: response.connectorRef ?? source.connectorRef,
+        lastVerifiedAt: response.lastVerifiedAt,
+      })
+      assertSecretFree(saved, secretCanaries)
+      return createMcpSourceStatusPayload(saved)
+    },
+
+    async probeSource(actor, sourceId) {
+      const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
+      if (source.status !== "connected") throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source is not connected")
+      const config = requireConfig(source.provider)
+      const template = getMcpProviderTemplate(source.provider, templates)
+      if (!template) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown managed connector provider")
+      const secret = await getSecret(config.provider)
+      const response = await options.provider.probe({ actor, source, config, secret })
+      assertSecretFree(response, [...canaries, secret.value])
+      const result = {
+        sourceId: source.id,
+        provider: source.provider,
+        tools: response.tools.map((tool) => ({ ...tool, decision: classifyMcpTool(template, tool.name) })),
+        resources: response.resources,
+      }
+      assertSecretFree(result, [...canaries, secret.value])
+      return result
+    },
+  }
+}

--- a/plugins/boring-mcp/src/server/sourceAccess.ts
+++ b/plugins/boring-mcp/src/server/sourceAccess.ts
@@ -1,0 +1,43 @@
+import {
+  MCP_ERROR_CODES,
+  McpError,
+  containsMcpSecret,
+  toMcpSourceDto,
+  type McpActor,
+  type McpSource,
+  type McpSourceRegistry,
+  type McpSourceStatusPayload,
+} from "../shared"
+
+const SOURCE_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,160}$/
+
+export function validateMcpSourceId(sourceId: string): string {
+  const trimmed = sourceId.trim()
+  if (!SOURCE_ID_PATTERN.test(trimmed)) throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
+  return trimmed
+}
+
+export function isActorOwnedMcpSource(actor: McpActor, source: McpSource | undefined): source is McpSource {
+  return Boolean(source && source.workspaceId === actor.workspaceId && source.userId === actor.userId)
+}
+
+export async function requireActorOwnedMcpSource(registry: McpSourceRegistry, actor: McpActor, sourceId: string): Promise<McpSource> {
+  const source = await registry.getSource(validateMcpSourceId(sourceId))
+  if (!isActorOwnedMcpSource(actor, source)) throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
+  return source
+}
+
+export function assertMcpPublicPayloadSecretFree(value: unknown): void {
+  if (containsMcpSecret(value)) throw new McpError(MCP_ERROR_CODES.SECRET_LEAK_GUARD, "MCP public payload contained secret material")
+}
+
+export function createMcpSourceStatusPayload(source: McpSource): McpSourceStatusPayload {
+  const payload = {
+    source: toMcpSourceDto(source),
+    connectable: source.credentialProvider === "provider-managed" || source.credentialProvider === "composio-managed" || source.credentialProvider === "app-managed",
+    canProbe: source.status === "connected",
+    canDisconnect: source.status !== "unconfigured" && source.status !== "revoked",
+  }
+  assertMcpPublicPayloadSecretFree(payload)
+  return payload
+}

--- a/plugins/boring-mcp/src/server/sourceHandlers.ts
+++ b/plugins/boring-mcp/src/server/sourceHandlers.ts
@@ -5,12 +5,12 @@ import {
   toMcpSourceDto,
   type McpActor,
   type McpProbeResult,
-  type McpSource,
   type McpSourceDto,
   type McpSourceRegistry,
   type McpSourceStatusPayload,
   type McpTransportClient,
 } from "../shared"
+import { assertMcpPublicPayloadSecretFree, createMcpSourceStatusPayload, isActorOwnedMcpSource, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
 
 export interface BoringMcpSourceHandlersOptions {
   registry: McpSourceRegistry
@@ -24,67 +24,39 @@ export interface BoringMcpSourceHandlers {
   disconnectSource(actor: McpActor, sourceId: string): Promise<McpSourceStatusPayload>
 }
 
-const SOURCE_ID_PATTERN = /^[A-Za-z0-9_.:-]{1,160}$/
-
-function validateSourceId(sourceId: string): string {
-  const trimmed = sourceId.trim()
-  if (!SOURCE_ID_PATTERN.test(trimmed)) {
-    throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
-  }
-  return trimmed
-}
-
-function isOwnedSource(actor: McpActor, source: McpSource | undefined): source is McpSource {
-  return Boolean(source && source.workspaceId === actor.workspaceId && source.userId === actor.userId)
-}
-
-async function requireOwnedSource(registry: McpSourceRegistry, actor: McpActor, sourceId: string): Promise<McpSource> {
-  const source = await registry.getSource(validateSourceId(sourceId))
-  if (!isOwnedSource(actor, source)) {
-    throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
-  }
-  return source
-}
-
-function statusPayload(source: McpSource): McpSourceStatusPayload {
-  return {
-    source: toMcpSourceDto(source),
-    connectable: source.credentialProvider === "provider-managed" || source.credentialProvider === "app-managed",
-    canProbe: source.status !== "revoked",
-    canDisconnect: source.status !== "unconfigured" && source.status !== "revoked",
-  }
-}
-
 export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOptions): BoringMcpSourceHandlers {
   const facade = new McpAccessFacade({ store: options.registry, transport: options.transport })
 
   return {
     async listSources(actor) {
-      const sources = await options.registry.listSources(actor)
-      return { sources: sources.map(toMcpSourceDto) }
+      const result = { sources: (await options.registry.listSources(actor)).map(toMcpSourceDto) }
+      assertMcpPublicPayloadSecretFree(result)
+      return result
     },
 
     async getSourceStatus(actor, sourceId) {
-      const source = await requireOwnedSource(options.registry, actor, sourceId)
-      return statusPayload(source)
+      const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
+      return createMcpSourceStatusPayload(source)
     },
 
     async probeSource(actor, sourceId) {
-      const normalizedSourceId = validateSourceId(sourceId)
-      return facade.probeSource(actor, normalizedSourceId)
+      const normalizedSourceId = validateMcpSourceId(sourceId)
+      const result = await facade.probeSource(actor, normalizedSourceId)
+      assertMcpPublicPayloadSecretFree(result)
+      return result
     },
 
     async disconnectSource(actor, sourceId) {
-      const normalizedSourceId = validateSourceId(sourceId)
-      await requireOwnedSource(options.registry, actor, normalizedSourceId)
+      const normalizedSourceId = validateMcpSourceId(sourceId)
+      await requireActorOwnedMcpSource(options.registry, actor, normalizedSourceId)
       if (!options.registry.disconnectSource) {
         throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source disconnect is not configured")
       }
       const source = await options.registry.disconnectSource(actor, normalizedSourceId)
-      if (!isOwnedSource(actor, source)) {
+      if (!isActorOwnedMcpSource(actor, source)) {
         throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
       }
-      return statusPayload(source)
+      return createMcpSourceStatusPayload(source)
     },
   }
 }

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -23,7 +23,7 @@ export type McpProviderId = "notion" | "airtable" | (string & {})
 export type McpTransport = "streamable-http" | "sse" | "stdio"
 export type McpSourceStatus = "connected" | "expired" | "revoked" | "error" | "unconfigured"
 export type McpToolRisk = "read" | "write" | "admin" | "unknown"
-export type McpCredentialProvider = "provider-managed" | "app-managed" | "user-managed" | (string & {})
+export type McpCredentialProvider = "provider-managed" | "composio-managed" | "app-managed" | "user-managed" | (string & {})
 export type McpSourceOwnerKind = "user" | "company_context" | "team_context" | "project_context"
 
 export interface McpActor {
@@ -43,6 +43,14 @@ export interface McpProviderTemplate {
   allowedResourceUriPrefixes?: string[]
 }
 
+export interface McpConnectorRef {
+  provider: McpProviderId
+  toolkitId?: string
+  externalSourceId?: string
+  connectedAccountId?: string
+  sessionId?: string
+}
+
 export interface McpSource {
   id: string
   workspaceId: string
@@ -54,6 +62,7 @@ export interface McpSource {
   credentialProvider: McpCredentialProvider
   scopes?: string[]
   providerAccountLabel?: string
+  connectorRef?: McpConnectorRef
   lastVerifiedAt?: string
   createdAt?: string
   updatedAt?: string
@@ -69,6 +78,7 @@ export type McpSourceDto = Pick<
   | "credentialProvider"
   | "scopes"
   | "providerAccountLabel"
+  | "connectorRef"
   | "lastVerifiedAt"
   | "createdAt"
   | "updatedAt"
@@ -161,6 +171,7 @@ export function toMcpSourceDto(source: McpSource): McpSourceDto {
     credentialProvider: source.credentialProvider,
     scopes: source.scopes,
     providerAccountLabel: source.providerAccountLabel,
+    connectorRef: source.connectorRef,
     lastVerifiedAt: source.lastVerifiedAt,
     createdAt: source.createdAt,
     updatedAt: source.updatedAt,
@@ -248,8 +259,8 @@ export function assertMcpToolAllowed(template: McpProviderTemplate, toolName: st
 }
 
 const REDACTION = "[REDACTED_MCP_SECRET]"
-const SECRET_KEY_PATTERN = /(api[_-]?key|access[_-]?token|refresh[_-]?token|authorization|cookie|client[_-]?secret|session[_-]?headers?)/i
-const SECRET_VALUE_PATTERN = /(Bearer\s+[A-Za-z0-9._~+\/-]{12,}|sk-[A-Za-z0-9_-]{12,}|x-api-key\s*[:=]\s*[^\s,}]+)/gi
+const SECRET_KEY_PATTERN = /(api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|oauth[_-]?token|authorization|cookie|client[_-]?secret|session[_-]?headers?|mcp[_-]?session|x-composio-mcp-session)/i
+const SECRET_VALUE_PATTERN = /(Bearer\s+[A-Za-z0-9._~+\/-]{12,}|sk-[A-Za-z0-9_-]{12,}|(?:x-api-key|api[_-]?key|access[_-]?token|refresh[_-]?token|id[_-]?token|oauth[_-]?token|code|client[_-]?secret|session[_-]?headers?|mcp[_-]?session|x-composio-mcp-session)\s*[:=]\s*[^\s,&,}]+)/gi
 
 export function redactMcpSecrets(value: unknown): unknown {
   if (typeof value === "string") return value.replace(SECRET_VALUE_PATTERN, REDACTION)


### PR DESCRIPTION
## Summary

PR 3 for issue #416 MCP integration.

Adds a small generic managed connector adapter seam inside reusable `boring-mcp`:

- injected `ManagedConnectorProvider` interface for hosted connector/session providers
- app-owned server secret resolver interface (`server-env` / `server-vault` only)
- generic start-connect / refresh-status / probe operations
- non-secret source/status/probe DTOs only
- shared source access helper to avoid duplicated source-id/ownership/status logic
- stricter secret detector for URL/query token strings (`access_token`, `api_key`, `client_secret`, etc.)
- fake provider tests; no live Composio calls

No Constellation-specific code, no real OAuth/provider execution, no read-only tool execution, no materialized tools, no agent bridge tools.

## Review-size cap

```txt
237 non-test/non-doc added lines
```

## Validation

```txt
git diff --check: pass
pnpm --filter @hachej/boring-mcp test: pass, 25 tests
pnpm --filter @hachej/boring-mcp typecheck: pass
pnpm --filter @hachej/boring-mcp lint: pass
pnpm --filter @hachej/boring-mcp build: pass
pnpm lint:workspace-plugin-invariants: pass
thermo-nuclear review: GREEN after one RED fix loop
independent review: GREEN after one RED fix loop
```

## Review loop fixes

Initial review found:
- duplicated source status/id/ownership helpers diverged from source handlers
- URL query tokens in `connectUrl` were not caught by secret detector

Fixed by:
- adding shared `sourceAccess.ts`
- making `canProbe` semantics consistent (`connected` only)
- strengthening secret detection for token-like key/value and URL query strings
- adding a `connectUrl?access_token=...` regression test
