### PR TITLE
#416 company-fs: add company file tree root

### DIFF
--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -237,7 +237,7 @@ export async function createAgentApp(
 
   await app.register(fileRoutes, { workspace: runtimeBundle.workspace })
   await app.register(fsEventsRoutes, { workspace: runtimeBundle.workspace })
-  await app.register(treeRoutes, { workspace: runtimeBundle.workspace })
+  await app.register(treeRoutes, { workspace: runtimeBundle.workspace, filesystemBindings: runtimeBundle.filesystemBindings })
   // /api/v1/files/search powers BOTH the cmd-palette / file-tree
   // search (browser → fetchClient.search) AND shares the same
   // FileSearch instance the LLM's `find` tool already uses

--- a/packages/agent/src/server/http/routes/__tests__/tree.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/tree.test.ts
@@ -1,7 +1,9 @@
 import Fastify, { type FastifyInstance } from 'fastify'
-import { describe, test, expect } from 'vitest'
+import { describe, test, expect, vi } from 'vitest'
+import { ERROR_CODE_NOT_FOUND_OR_DENIED } from '../file'
 import { treeRoutes } from '../tree'
 import type { Workspace, Entry, Stat } from '../../../../shared/workspace'
+import type { RuntimeFilesystemBindingOperations } from '../../../runtime/mode'
 
 const runtimeContext = { runtimeCwd: '/repo' }
 
@@ -34,9 +36,14 @@ function createWorkspace(
   }
 }
 
-async function buildApp(workspace: Workspace): Promise<FastifyInstance> {
+async function buildApp(workspace: Workspace, operations?: RuntimeFilesystemBindingOperations): Promise<FastifyInstance> {
   const app = Fastify({ logger: false })
-  await app.register(treeRoutes, { workspace })
+  await app.register(treeRoutes, {
+    workspace,
+    ...(operations
+      ? { filesystemBindings: [{ filesystem: 'company_context', access: 'readonly' as const, operations }] }
+      : {}),
+  })
   await app.ready()
   return app
 }
@@ -347,6 +354,37 @@ describe('GET /api/v1/tree', () => {
     expect(res.json().error.code).toBe('SANDBOX_EXPIRED')
 
     await app.close()
+  })
+
+  test('company_context tree uses company binding and sanitizes missing bindings', async () => {
+    const workspace = createWorkspace({ '.': [] })
+    const operations: RuntimeFilesystemBindingOperations = {
+      read: vi.fn(),
+      list: vi.fn(async ({ path }) => ({ entries: path === '/' ? ['company'] : ['policy.md'], metadata: {} })),
+      find: vi.fn(),
+      grep: vi.fn(),
+      stat: vi.fn(async ({ path }) => ({ isDirectory: path === 'company', metadata: {} })),
+      rejectMutation: vi.fn((operation) => { throw new Error(`readonly ${operation}`) }),
+    }
+    const app = await buildApp(workspace, operations)
+
+    const res = await app.inject({ method: 'GET', url: '/api/v1/tree?filesystem=company_context' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json().entries).toEqual([{ name: 'company', kind: 'dir', path: 'company' }])
+    expect(operations.list).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/' })
+    expect(operations.stat).toHaveBeenCalledWith({ filesystem: 'company_context', path: 'company' })
+
+    const slashRoot = await app.inject({ method: 'GET', url: '/api/v1/tree?filesystem=company_context&path=%2F' })
+    expect(slashRoot.statusCode).toBe(200)
+    expect(slashRoot.json().entries).toEqual([{ name: 'company', kind: 'dir', path: 'company' }])
+    expect(operations.stat).not.toHaveBeenCalledWith({ filesystem: 'company_context', path: '//company' })
+    await app.close()
+
+    const deniedApp = await buildApp(workspace)
+    const denied = await deniedApp.inject({ method: 'GET', url: '/api/v1/tree?filesystem=company_context' })
+    expect(denied.statusCode).toBe(404)
+    expect(denied.json()).toEqual({ error: { code: ERROR_CODE_NOT_FOUND_OR_DENIED, message: 'not found or denied' } })
+    await deniedApp.close()
   })
 
   test('non-recursive returns only direct children', async () => {

--- a/packages/agent/src/server/http/routes/tree.ts
+++ b/packages/agent/src/server/http/routes/tree.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
+import type { RuntimeFilesystemBinding } from '../../runtime/mode'
 import type { Workspace, Entry } from '../../../shared/workspace'
 import { isIgnoredDirName } from '../../workspace/ignore'
 import {
@@ -7,6 +8,7 @@ import {
   ERROR_CODE_NOT_FOUND,
   ERROR_CODE_INTERNAL,
 } from '../middleware'
+import { ERROR_CODE_NOT_FOUND_OR_DENIED } from './file'
 
 const MAX_DEPTH = 10
 const MAX_ENTRIES = 5000
@@ -20,6 +22,7 @@ interface TreeEntry {
 interface TreeQuerystring {
   path?: string
   recursive?: string
+  filesystem?: string
 }
 
 function normalizePath(raw: string | undefined): string {
@@ -38,6 +41,16 @@ class PathError extends Error {
 function joinPath(base: string, name: string): string {
   if (base === '.') return name
   return `${base}/${name}`
+}
+
+function requestedFilesystem(value: unknown): string {
+  return typeof value === 'string' && value.length > 0 ? value : 'user'
+}
+
+function sendNotFoundOrDenied(reply: FastifyReply): FastifyReply {
+  return reply.code(404).send({
+    error: { code: ERROR_CODE_NOT_FOUND_OR_DENIED, message: 'not found or denied' },
+  })
 }
 
 async function listTree(
@@ -89,11 +102,49 @@ async function listTree(
   return entries
 }
 
+async function listBoundTree(
+  binding: RuntimeFilesystemBinding,
+  dir: string,
+  recursive: boolean,
+): Promise<TreeEntry[]> {
+  const root = dir === '.' ? '/' : dir
+  const displayParentDir = dir === '.' || dir === '/' ? '.' : dir.replace(/\/+$/, '')
+  const entries: TreeEntry[] = []
+  const rootEntries = await binding.operations.list({ filesystem: binding.filesystem, path: root })
+  const queue: Array<{ parentDir: string; items: string[]; depth: number }> = [
+    { parentDir: displayParentDir || '.', items: rootEntries.entries, depth: 0 },
+  ]
+
+  while (queue.length > 0) {
+    if (entries.length >= MAX_ENTRIES) break
+    const batch = queue.shift()!
+    for (const name of batch.items) {
+      if (entries.length >= MAX_ENTRIES) break
+      const entryPath = joinPath(batch.parentDir, name)
+      const stat = await binding.operations.stat({ filesystem: binding.filesystem, path: entryPath })
+      const kind = stat.isDirectory ? 'dir' : 'file'
+      entries.push({ name, kind, path: entryPath })
+      if (recursive && kind === 'dir' && batch.depth < MAX_DEPTH && !isIgnoredDirName(name)) {
+        try {
+          const childEntries = await binding.operations.list({ filesystem: binding.filesystem, path: entryPath })
+          queue.push({ parentDir: entryPath, items: childEntries.entries, depth: batch.depth + 1 })
+        } catch {
+          // skip unreadable subdirectories
+        }
+      }
+    }
+  }
+
+  return entries
+}
+
 export function treeRoutes(
   app: FastifyInstance,
   opts: {
     workspace?: Workspace
     getWorkspace?: (request: FastifyRequest) => Workspace | Promise<Workspace>
+    filesystemBindings?: RuntimeFilesystemBinding[]
+    getFilesystemBindings?: (request: FastifyRequest) => RuntimeFilesystemBinding[] | undefined | Promise<RuntimeFilesystemBinding[] | undefined>
   },
   done: (err?: Error) => void,
 ): void {
@@ -101,6 +152,13 @@ export function treeRoutes(
     if (opts.getWorkspace) return await opts.getWorkspace(request)
     if (opts.workspace) return opts.workspace
     throw new Error('workspace route requires workspace or getWorkspace')
+  }
+
+  async function resolveFilesystemBinding(request: FastifyRequest, filesystem: string): Promise<RuntimeFilesystemBinding | undefined> {
+    const bindings = opts.getFilesystemBindings
+      ? await opts.getFilesystemBindings(request) ?? []
+      : opts.filesystemBindings ?? []
+    return bindings.find((binding) => binding.filesystem === filesystem)
   }
 
   app.get(
@@ -122,6 +180,17 @@ export function treeRoutes(
       }
 
       const recursive = request.query.recursive === 'true'
+      const filesystem = requestedFilesystem(request.query.filesystem)
+
+      if (filesystem !== 'user') {
+        try {
+          const binding = await resolveFilesystemBinding(request, filesystem)
+          if (!binding || binding.access !== 'readonly') return sendNotFoundOrDenied(reply)
+          return { entries: await listBoundTree(binding, dir, recursive) }
+        } catch {
+          return sendNotFoundOrDenied(reply)
+        }
+      }
 
       try {
         const workspace = await resolveWorkspace(request)

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -922,6 +922,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
   })
   await app.register(treeRoutes, {
     getWorkspace: async (request) => (await getBindingForRequest(request)).runtimeBundle.workspace,
+    getFilesystemBindings: async (request) => (await getBindingForRequest(request)).runtimeBundle.filesystemBindings,
   })
   await app.register(searchRoutes, {
     getFileSearch: async (request) => (await getBindingForRequest(request)).runtimeBundle.fileSearch,

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx
@@ -63,7 +63,7 @@ describe("useFileEventInvalidation", () => {
     events.emit(filesystemEvents.created, { ...userMeta(), path: "src/new.ts", kind: "file" })
 
     await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "src"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src"],
     }))
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "src/new.ts"],
@@ -78,26 +78,38 @@ describe("useFileEventInvalidation", () => {
     events.emit(filesystemEvents.created, { ...remoteMeta(), path: "src/new.ts", kind: "file" })
 
     await waitFor(() => expect(
-      queryKeyCalls(invalidate).filter((k) => k[2] === "tree" && k[3] === "src"),
+      queryKeyCalls(invalidate).filter((k) => k[2] === "tree" && k[3] === "user" && k[4] === "src"),
     ).toHaveLength(1))
 
     await waitFor(() => expect(
-      queryKeyCalls(invalidate).filter((k) => k[2] === "tree" && k[3] === "src"),
+      queryKeyCalls(invalidate).filter((k) => k[2] === "tree" && k[3] === "user" && k[4] === "src"),
     ).toHaveLength(2), { timeout: 1000 })
   })
 
   it("updates cached parent tree entries for remote creates before refetch completes", async () => {
-    qc.setQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "src"], [
+    qc.setQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src"], [
       { name: "old.ts", kind: "file", path: "src/old.ts" },
     ])
     renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
 
     events.emit(filesystemEvents.created, { ...remoteMeta(), path: "src/new.ts", kind: "file" })
 
-    await waitFor(() => expect(qc.getQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "src"])).toEqual([
+    await waitFor(() => expect(qc.getQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src"])).toEqual([
       { name: "old.ts", kind: "file", path: "src/old.ts" },
       { name: "new.ts", kind: "file", path: "src/new.ts" },
     ]))
+  })
+
+  it("keeps tree invalidation scoped by filesystem", async () => {
+    renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
+    events.emit(filesystemEvents.created, { ...userMeta(), filesystem: "project_alpha", path: "src/new.ts", kind: "file" })
+
+    await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "project_alpha", "src"],
+    }))
+    expect(invalidate).not.toHaveBeenCalledWith({
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src"],
+    })
   })
 
   it("filesystem created (dir) invalidates the root tree listing only", async () => {
@@ -105,7 +117,7 @@ describe("useFileEventInvalidation", () => {
     events.emit(filesystemEvents.created, { ...userMeta(), path: "scripts", kind: "dir" })
 
     await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "."],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "."],
     }))
     const calls = queryKeyCalls(invalidate)
     expect(calls.some((k) => k[2] === "stat")).toBe(false)
@@ -116,10 +128,10 @@ describe("useFileEventInvalidation", () => {
     events.emit(filesystemEvents.moved, { ...userMeta(), from: "old.ts", to: "docs/new.ts" })
 
     await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "."],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "."],
     }))
     expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "docs"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "docs"],
     })
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "old.ts"],
@@ -146,9 +158,9 @@ describe("useFileEventInvalidation", () => {
     // Descendants under the OLD prefix are invalidated…
     expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "src/deep/a.ts"])).toBe(true)
     expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "stat", "user", "src/a.ts"])).toBe(true)
-    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "tree", "src/deep"])).toBe(true)
+    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src/deep"])).toBe(true)
     // The moved dir's OWN listing is dead too (panes mounted at rootDir="src").
-    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "tree", "src"])).toBe(true)
+    expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src"])).toBe(true)
     // …unrelated paths, the new prefix, and other workspaces are not.
     expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "other/a.ts"])).toBe(false)
     expect(matches([TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "lib/a.ts"])).toBe(false)
@@ -162,7 +174,7 @@ describe("useFileEventInvalidation", () => {
     events.emit(filesystemEvents.deleted, { ...userMeta(), path: "doomed.ts" })
 
     await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "."],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "."],
     }))
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "files", "user", "doomed.ts"],
@@ -180,11 +192,11 @@ describe("useFileEventInvalidation", () => {
     }
 
     await waitFor(() => expect(invalidate).toHaveBeenCalledWith({
-      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "folder"],
+      queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "folder"],
     }))
     const calls = queryKeyCalls(invalidate)
     // All 50 deletions share one parent dir → one coalesced tree key.
-    expect(calls.filter((k) => k[2] === "tree")).toHaveLength(1)
+    expect(calls.filter((k) => k[2] === "tree" && k[3] === "user")).toHaveLength(1)
     expect(calls.filter((k) => k[2] === "search")).toHaveLength(1)
     expect(calls.filter((k) => k[2] === "files")).toHaveLength(50)
   })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
@@ -129,10 +129,12 @@ export class FetchClient {
     throw lastError ?? new FetchError(0, "Request failed after retries")
   }
 
-  async getTree(path: string, signal?: AbortSignal): Promise<FileEntry[]> {
+  async getTree(path: string, signal?: AbortSignal, filesystem?: string): Promise<FileEntry[]> {
+    const params = new URLSearchParams({ path })
+    if (filesystem) params.set("filesystem", filesystem)
     const res = await this.request<{ entries: FileEntry[] }>(
       "GET",
-      `/api/v1/tree?path=${encodeURIComponent(path)}`,
+      `/api/v1/tree?${params}`,
       undefined,
       undefined,
       signal,

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
@@ -57,16 +57,17 @@ export function useFileContent(
   })
 }
 
-export function useFileList(dir: string | null): UseQueryResult<FileEntry[]> {
+export function useFileList(dir: string | null, filesystem?: FilesystemId): UseQueryResult<FileEntry[]> {
   const client = useDataClient()
   const base = useApiBaseUrl()
   const workspaceId = useWorkspaceRequestId()
+  const fs = normalizeUiFilesystem(filesystem)
   return useQuery({
-    queryKey: [base, workspaceId, "tree", dir],
-    queryFn: async ({ signal }) => (await client.getTree(dir!, signal)) ?? [],
+    queryKey: [base, workspaceId, "tree", fs, dir],
+    queryFn: async ({ signal }) => (await (fs === "user" ? client.getTree(dir!, signal) : client.getTree(dir!, signal, fs))) ?? [],
     enabled: dir != null,
     staleTime: 3_000,
-    initialData: () => getPreloadedTreeEntries(base, workspaceId, dir),
+    initialData: () => fs === "user" ? getPreloadedTreeEntries(base, workspaceId, dir) : undefined,
     // File-event SSE invalidates this query when files change. Polling every
     // 3s made slow/dev backends self-abort before the first tree response,
     // leaving the workbench tree stuck on its skeleton.

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventInvalidation.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventInvalidation.ts
@@ -57,13 +57,13 @@ export function useFileEventInvalidation(): void {
       invalidateFile(batch, base, workspaceId, e.path, e.filesystem)
     })
     const offCreated = events.on(filesystemEvents.created, (e) => {
-      upsertTreeCache(queryClient, base, workspaceId, {
+      upsertTreeCache(queryClient, base, workspaceId, e.filesystem, {
         name: basename(e.path),
         kind: e.kind,
         path: e.path,
       })
       const invalidate = () => {
-        invalidateTree(batch, base, workspaceId, e.path)
+        invalidateTree(batch, base, workspaceId, e.path, e.filesystem)
         if (e.kind === "file") {
           invalidateFile(batch, base, workspaceId, e.path, e.filesystem)
         }
@@ -72,18 +72,18 @@ export function useFileEventInvalidation(): void {
       if (e.cause === "remote") runAfterFsSettles(invalidate)
     })
     const offMoved = events.on(filesystemEvents.moved, (e) => {
-      const movedEntry = getTreeCacheEntry(queryClient, base, workspaceId, e.from)
-      removeTreeCacheEntry(queryClient, base, workspaceId, e.from)
+      const movedEntry = getTreeCacheEntry(queryClient, base, workspaceId, e.from, e.filesystem)
+      removeTreeCacheEntry(queryClient, base, workspaceId, e.from, e.filesystem)
       if (movedEntry) {
-        upsertTreeCache(queryClient, base, workspaceId, {
+        upsertTreeCache(queryClient, base, workspaceId, e.filesystem, {
           ...movedEntry,
           name: basename(e.to),
           path: e.to,
         })
       }
       const invalidate = () => {
-        invalidateTree(batch, base, workspaceId, e.from)
-        invalidateTree(batch, base, workspaceId, e.to)
+        invalidateTree(batch, base, workspaceId, e.from, e.filesystem)
+        invalidateTree(batch, base, workspaceId, e.to, e.filesystem)
         invalidateFile(batch, base, workspaceId, e.from, e.filesystem)
         invalidateFile(batch, base, workspaceId, e.to, e.filesystem)
         invalidateMovedDescendants(batch, base, workspaceId, e.from, e.filesystem)
@@ -93,9 +93,9 @@ export function useFileEventInvalidation(): void {
       if (e.cause === "remote") runAfterFsSettles(invalidate)
     })
     const offDeleted = events.on(filesystemEvents.deleted, (e) => {
-      removeTreeCacheEntry(queryClient, base, workspaceId, e.path)
+      removeTreeCacheEntry(queryClient, base, workspaceId, e.path, e.filesystem)
       const invalidate = () => {
-        invalidateTree(batch, base, workspaceId, e.path)
+        invalidateTree(batch, base, workspaceId, e.path, e.filesystem)
         invalidateFile(batch, base, workspaceId, e.path, e.filesystem)
         invalidateSearch(batch, base, workspaceId)
       }
@@ -164,8 +164,8 @@ function basename(path: string): string {
   return i >= 0 ? path.slice(i + 1) : path
 }
 
-function treeKey(base: string, workspaceId: string | null, dir: string): QueryKey {
-  return [base, workspaceId, "tree", dir]
+function treeKey(base: string, workspaceId: string | null, filesystem: FilesystemId | undefined, dir: string): QueryKey {
+  return [base, workspaceId, "tree", normalizeUiFilesystem(filesystem), dir]
 }
 
 function getTreeCacheEntry(
@@ -173,8 +173,9 @@ function getTreeCacheEntry(
   base: string,
   workspaceId: string | null,
   path: string,
+  filesystem?: FilesystemId,
 ): FileEntry | undefined {
-  const entries = qc.getQueryData<FileEntry[]>(treeKey(base, workspaceId, parentDir(path)))
+  const entries = qc.getQueryData<FileEntry[]>(treeKey(base, workspaceId, filesystem, parentDir(path)))
   return entries?.find((entry) => entry.path === path)
 }
 
@@ -182,9 +183,10 @@ function upsertTreeCache(
   qc: QueryClient,
   base: string,
   workspaceId: string | null,
+  filesystem: FilesystemId | undefined,
   entry: FileEntry,
 ): void {
-  qc.setQueryData<FileEntry[]>(treeKey(base, workspaceId, parentDir(entry.path)), (entries) => {
+  qc.setQueryData<FileEntry[]>(treeKey(base, workspaceId, filesystem, parentDir(entry.path)), (entries) => {
     if (!entries) return entries
     const withoutEntry = entries.filter((candidate) => candidate.path !== entry.path)
     return [...withoutEntry, entry]
@@ -196,8 +198,9 @@ function removeTreeCacheEntry(
   base: string,
   workspaceId: string | null,
   path: string,
+  filesystem?: FilesystemId,
 ): void {
-  qc.setQueryData<FileEntry[]>(treeKey(base, workspaceId, parentDir(path)), (entries) => {
+  qc.setQueryData<FileEntry[]>(treeKey(base, workspaceId, filesystem, parentDir(path)), (entries) => {
     if (!entries) return entries
     return entries.filter((entry) => entry.path !== path)
   })
@@ -216,7 +219,7 @@ function invalidateFile(
 }
 
 /**
- * Tree listing queries are keyed `[base, ws, "tree", dir]` — invalidate
+ * Tree listing queries are keyed `[base, ws, "tree", filesystem, dir]` — invalidate
  * only the listing that actually shows the changed path: its parent
  * (the same `parentDir` the file tree itself keys dirs with).
  */
@@ -225,8 +228,9 @@ function invalidateTree(
   base: string,
   workspaceId: string | null,
   path: string,
+  filesystem?: FilesystemId,
 ): void {
-  batch.enqueue([base, workspaceId, "tree", parentDir(path)])
+  batch.enqueue(treeKey(base, workspaceId, filesystem, parentDir(path)))
 }
 
 /**
@@ -258,9 +262,9 @@ function invalidateMovedDescendants(
             && typeof key[4] === "string"
             && (key[4] === from || key[4].startsWith(prefix)))
           || (key[2] === "tree"
-            && fs === "user"
-            && typeof key[3] === "string"
-            && (key[3] === from || key[3].startsWith(prefix)))
+            && key[3] === fs
+            && typeof key[4] === "string"
+            && (key[4] === from || key[4].startsWith(prefix)))
         )
     },
   })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -59,7 +59,7 @@ import { cn } from "../../../../front/lib/utils"
 import { toast } from "../../../../front/toast"
 import { events, userMeta } from "../../../../front/events"
 import { filesystemEvents } from "../../shared/events"
-import type { FilesystemId } from "../../../../shared/types/filesystem"
+import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import type { PaneProps } from "../../../../shared/types/panel"
 import type { LeftTabParams } from "../../../../shared/plugins/types"
 import { copyToClipboard } from "./clipboard"
@@ -174,7 +174,8 @@ export function FileTreeView({
 }: FileTreeViewProps) {
   const dataClient = useDataClient()
   const canMutate = access !== "readonly"
-  const requestFilesystem = filesystem === "user" ? undefined : filesystem
+  const activeFilesystem = normalizeUiFilesystem(filesystem)
+  const requestFilesystem = activeFilesystem === "user" ? undefined : activeFilesystem
   const getTreeEntries = useCallback(
     (path: string) => requestFilesystem ? dataClient.getTree(path, undefined, requestFilesystem) : dataClient.getTree(path),
     [dataClient, requestFilesystem],
@@ -383,6 +384,7 @@ export function FileTreeView({
     const settledTimers = new Set<ReturnType<typeof setTimeout>>()
     const affected = (paths: string[]): string[] =>
       Array.from(new Set(paths.map(parentDir))).filter((dir) => expandedDirsRef.current.has(dir))
+    const eventMatchesFilesystem = (eventFilesystem?: FilesystemId) => normalizeUiFilesystem(eventFilesystem) === activeFilesystem
     const refreshNowAndAfterSettle = (dirs: string[]) => {
       if (!dirs.length) return
       void refreshDirs(dirs)
@@ -393,15 +395,15 @@ export function FileTreeView({
       settledTimers.add(timer)
     }
     const offCreated = events.on(filesystemEvents.created, (e) => {
-      if (e.cause === "user") return
+      if (e.cause === "user" || !eventMatchesFilesystem(e.filesystem)) return
       refreshNowAndAfterSettle(affected([e.path]))
     })
     const offDeleted = events.on(filesystemEvents.deleted, (e) => {
-      if (e.cause === "user") return
+      if (e.cause === "user" || !eventMatchesFilesystem(e.filesystem)) return
       refreshNowAndAfterSettle(affected([e.path]))
     })
     const offMoved = events.on(filesystemEvents.moved, (e) => {
-      if (e.cause === "user") return
+      if (e.cause === "user" || !eventMatchesFilesystem(e.filesystem)) return
       refreshNowAndAfterSettle(affected([e.from, e.to]))
     })
     return () => {
@@ -411,7 +413,7 @@ export function FileTreeView({
       for (const timer of settledTimers) clearTimeout(timer)
       settledTimers.clear()
     }
-  }, [refreshDirs])
+  }, [activeFilesystem, refreshDirs])
 
   const revealTreePath = useCallback(
     async (path: string | null, options?: { refreshTargetDir?: boolean }) => {
@@ -520,7 +522,9 @@ export function FileTreeView({
 
   useEffect(() => {
     const shouldPatchDir = (dir: string) => dir === rootDirKey || expandedDirsRef.current.has(dir)
+    const eventMatchesFilesystem = (eventFilesystem?: FilesystemId) => normalizeUiFilesystem(eventFilesystem) === activeFilesystem
     const offCreated = events.on(filesystemEvents.created, (e) => {
+      if (!eventMatchesFilesystem(e.filesystem)) return
       unhideEntry(e.path)
       if (e.cause === "user") return
       const dir = parentDir(e.path)
@@ -529,12 +533,12 @@ export function FileTreeView({
       }
     })
     const offDeleted = events.on(filesystemEvents.deleted, (e) => {
-      if (e.cause === "user") return
+      if (e.cause === "user" || !eventMatchesFilesystem(e.filesystem)) return
       hideEntry(e.path)
       removeOptimisticEntry(parentDir(e.path), e.path)
     })
     const offMoved = events.on(filesystemEvents.moved, (e) => {
-      if (e.cause === "user") return
+      if (e.cause === "user" || !eventMatchesFilesystem(e.filesystem)) return
       hideEntry(e.from)
       unhideEntry(e.to)
       removeOptimisticEntry(parentDir(e.from), e.from)
@@ -544,7 +548,7 @@ export function FileTreeView({
       offDeleted()
       offMoved()
     }
-  }, [addOptimisticEntry, hideEntry, removeOptimisticEntry, rootDirKey, unhideEntry])
+  }, [activeFilesystem, addOptimisticEntry, hideEntry, removeOptimisticEntry, rootDirKey, unhideEntry])
 
   // Paths currently being mutated (move/rename/delete/create). Renders a
   // pending spinner on the affected rows. Set during the await; cleared in
@@ -953,6 +957,14 @@ export function FileTreeView({
 
 export { clampContextMenuPosition }
 
+export interface FileTreeRootConfig {
+  filesystem: FilesystemId
+  label: string
+  rootDir?: string
+  access?: "readonly" | "readwrite"
+  searchPlaceholder?: string
+}
+
 export interface FileTreePaneParams extends LeftTabParams {
   rootDir?: string
   searchQuery?: string
@@ -961,6 +973,7 @@ export interface FileTreePaneParams extends LeftTabParams {
   chromeless?: boolean
   filesystem?: FilesystemId
   access?: "readonly" | "readwrite"
+  roots?: FileTreeRootConfig[]
   revealFileTreeRequest?: { path: string; seq: number } | null
 }
 
@@ -972,6 +985,7 @@ export interface FileTreePaneProps extends Partial<PaneProps<FileTreePaneParams>
   chromeless?: boolean
   filesystem?: FilesystemId
   access?: "readonly" | "readwrite"
+  roots?: FileTreeRootConfig[]
   className?: string
 }
 
@@ -990,6 +1004,7 @@ export function FileTreePane({
   chromeless = false,
   filesystem = "user",
   access = "readwrite",
+  roots,
   className,
 }: FileTreePaneProps) {
   const effectiveRootDir = params?.rootDir ?? rootDir
@@ -997,18 +1012,33 @@ export function FileTreePane({
   const effectiveChromeless = params?.chromeless ?? chromeless
   const effectiveFilesystem = params?.filesystem ?? filesystem
   const effectiveAccess = params?.access ?? access
+  const effectiveRoots = params?.roots ?? roots
   const effectiveRevealRequest = params?.revealFileTreeRequest ?? null
   const externalSearchQuery =
     params?.searchQuery ?? params?.query ?? controlledSearchQuery
   const effectivePanelApi = panelApi ?? api
   const [searchQuery, setSearchQuery] = useState("")
   const [debouncedQuery, setDebouncedQuery] = useState("")
-  const [selectedFilesystem, setSelectedFilesystem] = useState<FilesystemId>(effectiveFilesystem)
-  const companyProbe = useFileList("/", "company_context")
-  const showCompany = effectiveFilesystem === "company_context" || companyProbe.isSuccess
+  const rootOptions = useMemo<FileTreeRootConfig[]>(() => {
+    if (effectiveRoots?.length) return effectiveRoots
+    return [{
+      filesystem: effectiveFilesystem,
+      label: effectiveFilesystem === "user" ? "Workspace" : effectiveFilesystem,
+      rootDir: effectiveFilesystem === "user" ? effectiveRootDir : "/",
+      access: effectiveAccess,
+    }]
+  }, [effectiveAccess, effectiveFilesystem, effectiveRootDir, effectiveRoots])
+  const [selectedFilesystem, setSelectedFilesystem] = useState<FilesystemId>(rootOptions[0]?.filesystem ?? "user")
   useEffect(() => {
-    if (!showCompany && selectedFilesystem === "company_context") setSelectedFilesystem("user")
-  }, [selectedFilesystem, showCompany])
+    const next = rootOptions.some((root) => root.filesystem === effectiveFilesystem)
+      ? effectiveFilesystem
+      : rootOptions[0]?.filesystem ?? "user"
+    setSelectedFilesystem(next)
+  }, [effectiveFilesystem, rootOptions])
+  const activeRoot = rootOptions.find((root) => root.filesystem === selectedFilesystem) ?? rootOptions[0]
+  const activeFilesystem = activeRoot?.filesystem ?? "user"
+  const activeRootDir = activeRoot?.rootDir ?? (activeFilesystem === "user" ? effectiveRootDir : "/")
+  const activeAccess = activeRoot?.access ?? effectiveAccess
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   useEffect(() => {
@@ -1022,13 +1052,10 @@ export function FileTreePane({
       ? externalSearchQuery || undefined
       : debouncedQuery || undefined
 
-  const activeFilesystem = showCompany ? selectedFilesystem : "user"
-  const activeRootDir = activeFilesystem === "company_context" ? "/" : effectiveRootDir
-  const activeAccess = activeFilesystem === "company_context" ? "readonly" : effectiveAccess
-
   if (effectiveChromeless) {
     return (
       <FileTreeView
+        key={`${activeFilesystem}:${activeRootDir}`}
         rootDir={activeRootDir}
         searchQuery={effectiveSearchQuery}
         bridge={effectiveBridge}
@@ -1044,18 +1071,17 @@ export function FileTreePane({
     <PanelChrome title="Files" panelApi={effectivePanelApi}>
       <div className="flex h-full flex-col">
         <div className="space-y-1.5 border-b border-border px-2 py-1.5">
-          {showCompany && (
-            <div className="grid grid-cols-2 gap-1 rounded-md bg-muted/45 p-0.5" role="tablist" aria-label="File roots">
-              <Button type="button" role="tab" aria-selected={activeFilesystem === "user"} variant={activeFilesystem === "user" ? "secondary" : "ghost"} size="sm" className="h-6 text-xs" onClick={() => setSelectedFilesystem("user")}>
-                Workspace
-              </Button>
-              <Button type="button" role="tab" aria-selected={activeFilesystem === "company_context"} variant={activeFilesystem === "company_context" ? "secondary" : "ghost"} size="sm" className="h-6 text-xs" onClick={() => setSelectedFilesystem("company_context")}>
-                Company
-              </Button>
+          {rootOptions.length > 1 && (
+            <div className="grid gap-1 rounded-md bg-muted/45 p-0.5" style={{ gridTemplateColumns: `repeat(${rootOptions.length}, minmax(0, 1fr))` }} role="tablist" aria-label="File roots">
+              {rootOptions.map((root) => (
+                <Button key={root.filesystem} type="button" role="tab" aria-selected={activeFilesystem === root.filesystem} variant={activeFilesystem === root.filesystem ? "secondary" : "ghost"} size="sm" className="h-6 text-xs" onClick={() => setSelectedFilesystem(root.filesystem)}>
+                  {root.label}
+                </Button>
+              ))}
             </div>
           )}
           <Input
-            placeholder={activeFilesystem === "company_context" ? "Filter company files..." : "Search files..."}
+            placeholder={activeRoot?.searchPlaceholder ?? "Search files..."}
             value={externalSearchQuery ?? searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="h-7 text-xs"
@@ -1064,6 +1090,7 @@ export function FileTreePane({
         </div>
         <div className="min-h-0 flex-1">
           <FileTreeView
+            key={`${activeFilesystem}:${activeRootDir}`}
             rootDir={activeRootDir}
             searchQuery={effectiveSearchQuery}
             bridge={effectiveBridge}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -59,6 +59,7 @@ import { cn } from "../../../../front/lib/utils"
 import { toast } from "../../../../front/toast"
 import { events, userMeta } from "../../../../front/events"
 import { filesystemEvents } from "../../shared/events"
+import type { FilesystemId } from "../../../../shared/types/filesystem"
 import type { PaneProps } from "../../../../shared/types/panel"
 import type { LeftTabParams } from "../../../../shared/plugins/types"
 import { copyToClipboard } from "./clipboard"
@@ -109,6 +110,8 @@ export interface FileTreeViewProps {
   searchQuery?: string
   bridge?: FileTreeBridge
   revealFileTreeRequest?: { path: string; seq: number } | null
+  filesystem?: FilesystemId
+  access?: "readonly" | "readwrite"
   /**
    * Names (or regex patterns) to hide from the tree. Defaults to
    * `DEFAULT_TREE_IGNORE` (node_modules, .git, dist, …). Pass `[]` to
@@ -164,11 +167,19 @@ export function FileTreeView({
   searchQuery,
   bridge,
   revealFileTreeRequest,
+  filesystem = "user",
+  access = "readwrite",
   ignoreNames = DEFAULT_TREE_IGNORE,
   className,
 }: FileTreeViewProps) {
   const dataClient = useDataClient()
-  const { data: rawFileList, error, isLoading } = useFileList(rootDir)
+  const canMutate = access !== "readonly"
+  const requestFilesystem = filesystem === "user" ? undefined : filesystem
+  const getTreeEntries = useCallback(
+    (path: string) => requestFilesystem ? dataClient.getTree(path, undefined, requestFilesystem) : dataClient.getTree(path),
+    [dataClient, requestFilesystem],
+  )
+  const { data: rawFileList, error, isLoading } = useFileList(rootDir, requestFilesystem)
   const [optimisticEntries, setOptimisticEntries] = useState<
     Map<string, FileEntry[]>
   >(new Map())
@@ -233,7 +244,7 @@ export function FileTreeView({
 
   const useServerSearch = (searchQuery?.trim().length ?? 0) > 0
   const { data: searchResults } = useFileSearch(
-    useServerSearch ? toFileSearchGlob(searchQuery ?? "") : "",
+    useServerSearch && filesystem === "user" ? toFileSearchGlob(searchQuery ?? "") : "",
     50,
   )
 
@@ -295,15 +306,15 @@ export function FileTreeView({
   const handleSelect = useCallback(
     (path: string) => {
       setSelectedPath(path)
-      bridge?.openFile(path, { mode: "edit" })
+      bridge?.openFile(path, { mode: "edit", ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
     },
-    [bridge],
+    [bridge, requestFilesystem],
   )
 
   const handleExpand = useCallback(
     async (dirPath: string) => {
       try {
-        const children = await dataClient.getTree(dirPath)
+        const children = await getTreeEntries(dirPath)
         const filtered =
           ignoreNames.length === 0
             ? children
@@ -313,7 +324,7 @@ export function FileTreeView({
         // Network error — directory stays empty, user can retry
       }
     },
-    [dataClient, ignoreNames],
+    [getTreeEntries, ignoreNames],
   )
 
   /**
@@ -331,7 +342,7 @@ export function FileTreeView({
       const results = await Promise.all(
         unique.map(async (dir) => {
           try {
-            const children = await dataClient.getTree(dir)
+            const children = await getTreeEntries(dir)
             const filtered =
               ignoreNames.length === 0
                 ? children
@@ -354,7 +365,7 @@ export function FileTreeView({
         return next
       })
     },
-    [dataClient, rootDir, ignoreNames],
+    [getTreeEntries, rootDir, ignoreNames],
   )
 
   // Expanded subfolders cache their children in local state (not react-query),
@@ -589,7 +600,8 @@ export function FileTreeView({
       if (newPath === sourcePath) return
       markPending(sourcePath)
       try {
-        await moveFile({ from: sourcePath, to: newPath })
+        if (!canMutate) return
+        await moveFile({ from: sourcePath, to: newPath, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
         await refreshDirs([parentDir(sourcePath), parentDir(newPath)])
         toast.success({ title: "Moved", description: `${sourcePath} → ${newPath}` })
       } catch (err) {
@@ -601,7 +613,7 @@ export function FileTreeView({
         clearPending(sourcePath)
       }
     },
-    [moveFile, refreshDirs, rootDir, markPending, clearPending],
+    [canMutate, requestFilesystem, moveFile, refreshDirs, rootDir, markPending, clearPending],
   )
 
   function ctxAction(fn: () => void | Promise<void>) {
@@ -645,7 +657,7 @@ export function FileTreeView({
       setEditing(null)
       if (!current) return
       const trimmed = value.trim()
-      if (!trimmed) return
+      if (!trimmed || !canMutate) return
       const dir = current.kind === "rename" ? parentDir(current.path) : current.parentDir
       const newPath = current.kind === "rename"
         ? current.path
@@ -661,7 +673,7 @@ export function FileTreeView({
           const parts = current.path.split("/")
           parts[parts.length - 1] = trimmed
           const to = parts.join("/")
-          await moveFile({ from: current.path, to })
+          await moveFile({ from: current.path, to, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
           await refreshDirs([parentDir(current.path)])
           toast.success({ title: "Renamed", description: `${current.path} → ${to}` })
         } else {
@@ -669,23 +681,25 @@ export function FileTreeView({
             name: trimmed,
             kind: current.kind === "create-file" ? "file" as const : "dir" as const,
             path: newPath,
+            filesystem: requestFilesystem,
           }
           addOptimisticEntry(dir, optimisticEntry)
           addedOptimisticPath = newPath
           if (current.kind === "create-file") {
-            await writeFile({ path: newPath, content: "", returnMtimeMs: false })
+            await writeFile({ path: newPath, content: "", returnMtimeMs: false, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
             // useFileWrite emits changed (it can't tell create from edit);
             // the call site knows this was a creation, so emit here.
             // useCreateDir already emits its own filesystem create event.
             events.emit(filesystemEvents.created, {
               ...userMeta(),
               path: newPath,
+              filesystem: requestFilesystem,
               kind: "file",
             })
             handleSelect(newPath)
             toast.success({ title: "File created", description: newPath })
           } else {
-            await createDir({ path: newPath })
+            await createDir({ path: newPath, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
             toast.success({ title: "Folder created", description: newPath })
           }
           await refreshDirs([dir], { force: true })
@@ -709,6 +723,8 @@ export function FileTreeView({
     },
     [
       editing,
+      canMutate,
+      requestFilesystem,
       moveFile,
       writeFile,
       createDir,
@@ -745,7 +761,8 @@ export function FileTreeView({
     setDeleteTarget(null)
     markPending(target.path)
     try {
-      await deleteFile({ path: target.path })
+      if (!canMutate) return
+      await deleteFile({ path: target.path, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
       removeOptimisticEntry(parentDir(target.path), target.path)
       if (target.kind === "dir") {
         setExpandedChildren((prev) => {
@@ -775,10 +792,12 @@ export function FileTreeView({
     markPending,
     clearPending,
     removeOptimisticEntry,
+    canMutate,
+    requestFilesystem,
   ])
 
   const effectiveQuery =
-    !useServerSearch && (searchQuery?.length ?? 0) > 0 ? searchQuery : undefined
+    (!useServerSearch || filesystem !== "user") && (searchQuery?.length ?? 0) > 0 ? searchQuery : undefined
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -838,7 +857,7 @@ export function FileTreeView({
               onContextMenu={handleContextMenu}
               onSubmitEdit={handleSubmitEdit}
               onCancelEdit={handleCancelEdit}
-              onDragDrop={handleDragDrop}
+              onDragDrop={canMutate ? handleDragDrop : undefined}
               height={treeHeight}
               className={cn(className)}
             />
@@ -853,30 +872,38 @@ export function FileTreeView({
           className="fixed z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
           style={{ left: ctxMenu.x, top: ctxMenu.y }}
         >
-          <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleNewFile}>
-            New file
-          </Button>
-          <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleNewFolder}>
-            New folder
-          </Button>
+          {canMutate && (
+            <>
+              <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleNewFile}>
+                New file
+              </Button>
+              <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleNewFolder}>
+                New folder
+              </Button>
+            </>
+          )}
           {!ctxMenu.isBackground && (
             <>
-              <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleRename}>
-                Rename
-              </Button>
-              <Button
-                type="button"
-                role="menuitem"
-                variant="ghost"
-                size="sm"
-                className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
-                onClick={() => {
-                  setDeleteTarget(ctxMenu.node)
-                  setCtxMenu(null)
-                }}
-              >
-                Delete
-              </Button>
+              {canMutate && (
+                <>
+                  <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleRename}>
+                    Rename
+                  </Button>
+                  <Button
+                    type="button"
+                    role="menuitem"
+                    variant="ghost"
+                    size="sm"
+                    className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    onClick={() => {
+                      setDeleteTarget(ctxMenu.node)
+                      setCtxMenu(null)
+                    }}
+                  >
+                    Delete
+                  </Button>
+                </>
+              )}
               <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleCopyPath}>
                 Copy path
               </Button>
@@ -932,6 +959,8 @@ export interface FileTreePaneParams extends LeftTabParams {
   query?: string
   bridge?: unknown
   chromeless?: boolean
+  filesystem?: FilesystemId
+  access?: "readonly" | "readwrite"
   revealFileTreeRequest?: { path: string; seq: number } | null
 }
 
@@ -941,6 +970,8 @@ export interface FileTreePaneProps extends Partial<PaneProps<FileTreePaneParams>
   panelApi?: DockviewPanelApi
   bridge?: FileTreeBridge
   chromeless?: boolean
+  filesystem?: FilesystemId
+  access?: "readonly" | "readwrite"
   className?: string
 }
 
@@ -957,17 +988,27 @@ export function FileTreePane({
   bridge,
   api,
   chromeless = false,
+  filesystem = "user",
+  access = "readwrite",
   className,
 }: FileTreePaneProps) {
   const effectiveRootDir = params?.rootDir ?? rootDir
   const effectiveBridge = (params?.bridge as FileTreeBridge | undefined) ?? bridge
   const effectiveChromeless = params?.chromeless ?? chromeless
+  const effectiveFilesystem = params?.filesystem ?? filesystem
+  const effectiveAccess = params?.access ?? access
   const effectiveRevealRequest = params?.revealFileTreeRequest ?? null
   const externalSearchQuery =
     params?.searchQuery ?? params?.query ?? controlledSearchQuery
   const effectivePanelApi = panelApi ?? api
   const [searchQuery, setSearchQuery] = useState("")
   const [debouncedQuery, setDebouncedQuery] = useState("")
+  const [selectedFilesystem, setSelectedFilesystem] = useState<FilesystemId>(effectiveFilesystem)
+  const companyProbe = useFileList("/", "company_context")
+  const showCompany = effectiveFilesystem === "company_context" || companyProbe.isSuccess
+  useEffect(() => {
+    if (!showCompany && selectedFilesystem === "company_context") setSelectedFilesystem("user")
+  }, [selectedFilesystem, showCompany])
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   useEffect(() => {
@@ -981,12 +1022,18 @@ export function FileTreePane({
       ? externalSearchQuery || undefined
       : debouncedQuery || undefined
 
+  const activeFilesystem = showCompany ? selectedFilesystem : "user"
+  const activeRootDir = activeFilesystem === "company_context" ? "/" : effectiveRootDir
+  const activeAccess = activeFilesystem === "company_context" ? "readonly" : effectiveAccess
+
   if (effectiveChromeless) {
     return (
       <FileTreeView
-        rootDir={effectiveRootDir}
+        rootDir={activeRootDir}
         searchQuery={effectiveSearchQuery}
         bridge={effectiveBridge}
+        filesystem={activeFilesystem}
+        access={activeAccess}
         revealFileTreeRequest={effectiveRevealRequest}
         className={cn("px-1 pt-1 [&_[role=treeitem]]:!indent-0", className)}
       />
@@ -996,9 +1043,19 @@ export function FileTreePane({
   return (
     <PanelChrome title="Files" panelApi={effectivePanelApi}>
       <div className="flex h-full flex-col">
-        <div className="border-b border-border px-2 py-1.5">
+        <div className="space-y-1.5 border-b border-border px-2 py-1.5">
+          {showCompany && (
+            <div className="grid grid-cols-2 gap-1 rounded-md bg-muted/45 p-0.5" role="tablist" aria-label="File roots">
+              <Button type="button" role="tab" aria-selected={activeFilesystem === "user"} variant={activeFilesystem === "user" ? "secondary" : "ghost"} size="sm" className="h-6 text-xs" onClick={() => setSelectedFilesystem("user")}>
+                Workspace
+              </Button>
+              <Button type="button" role="tab" aria-selected={activeFilesystem === "company_context"} variant={activeFilesystem === "company_context" ? "secondary" : "ghost"} size="sm" className="h-6 text-xs" onClick={() => setSelectedFilesystem("company_context")}>
+                Company
+              </Button>
+            </div>
+          )}
           <Input
-            placeholder="Search files..."
+            placeholder={activeFilesystem === "company_context" ? "Filter company files..." : "Search files..."}
             value={externalSearchQuery ?? searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="h-7 text-xs"
@@ -1007,9 +1064,11 @@ export function FileTreePane({
         </div>
         <div className="min-h-0 flex-1">
           <FileTreeView
-            rootDir={effectiveRootDir}
+            rootDir={activeRootDir}
             searchQuery={effectiveSearchQuery}
             bridge={effectiveBridge}
+            filesystem={activeFilesystem}
+            access={activeAccess}
             revealFileTreeRequest={effectiveRevealRequest}
             className={className}
           />

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -15,7 +15,7 @@ const mockGetTree = vi.fn()
 const mockGetGitUrlMetadata = vi.fn()
 
 vi.mock("../../data", () => ({
-  useFileList: (dir: string) => mockFileList(dir),
+  useFileList: (dir: string, filesystem?: string) => mockFileList(dir, filesystem),
   useFileWrite: () => ({ mutateAsync: mockFileWrite }),
   useCreateDir: () => ({ mutateAsync: mockCreateDir }),
   useMoveFile: () => ({ mutateAsync: mockMoveFile }),
@@ -238,6 +238,52 @@ describe("FileTreePane", () => {
       expect(screen.getByTestId("file-tree")).toBeInTheDocument()
     })
     expect(screen.getByText("index.ts")).toBeInTheDocument()
+  })
+
+  it("shows company as a separate readonly root when a company binding exists", async () => {
+    mockFileList.mockImplementation((dir: string, filesystem?: string) => ({
+      data: filesystem === "company_context"
+        ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
+        : sampleFiles,
+      isLoading: false,
+      isSuccess: filesystem === "company_context",
+      error: undefined,
+    }))
+    const bridge = {
+      openFile: vi.fn(),
+      select: vi.fn(() => vi.fn()),
+      getActiveFile: vi.fn(),
+    }
+
+    render(<FileTreePane bridge={bridge} />, { wrapper })
+
+    expect(await screen.findByRole("tab", { name: "Workspace" })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("tab", { name: "Company" }))
+
+    await waitFor(() => expect(screen.getByText("handbook.md")).toBeInTheDocument())
+    fireEvent.click(screen.getByText("handbook.md"))
+    expect(bridge.openFile).toHaveBeenCalledWith("handbook.md", {
+      mode: "edit",
+      filesystem: "company_context",
+    })
+
+    fireEvent.contextMenu(screen.getByText("handbook.md"))
+    expect(screen.queryByRole("menuitem", { name: "Rename" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("menuitem", { name: "Delete" })).not.toBeInTheDocument()
+  })
+
+  it("hides the company root when the company binding is unavailable", async () => {
+    mockFileList.mockImplementation((dir: string, filesystem?: string) => ({
+      data: filesystem === "company_context" ? undefined : sampleFiles,
+      isLoading: false,
+      isSuccess: false,
+      error: filesystem === "company_context" ? new Error("not_found_or_denied") : undefined,
+    }))
+
+    render(<FileTreePane />, { wrapper })
+
+    await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+    expect(screen.queryByRole("tab", { name: "Company" })).not.toBeInTheDocument()
   })
 
   it("hides .boring-agent from the default tree view", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -107,6 +107,7 @@ vi.mock("../FileTree", () => {
       onSubmitEdit,
       onCancelEdit,
       onDragDrop,
+      onExpand,
     }: {
       files: Node[]
       searchQuery?: string
@@ -119,6 +120,7 @@ vi.mock("../FileTree", () => {
       onSubmitEdit?: (p: string, v: string) => void
       onCancelEdit?: () => void
       onDragDrop?: (src: string, dst: string) => void
+      onExpand?: (path: string) => void
     }) => (
       <div
         data-testid="file-tree"
@@ -144,6 +146,13 @@ vi.mock("../FileTree", () => {
           onClick={() => onDragDrop?.("a.ts", "src")}
         >
           drag
+        </button>
+        <button
+          type="button"
+          data-testid="trigger-expand-src"
+          onClick={() => onExpand?.("src")}
+        >
+          expand src
         </button>
       </div>
     ),
@@ -240,13 +249,13 @@ describe("FileTreePane", () => {
     expect(screen.getByText("index.ts")).toBeInTheDocument()
   })
 
-  it("shows company as a separate readonly root when a company binding exists", async () => {
+  it("shows configured filesystem roots without probing hardcoded bindings", async () => {
     mockFileList.mockImplementation((dir: string, filesystem?: string) => ({
-      data: filesystem === "company_context"
+      data: filesystem === "project_alpha"
         ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
         : sampleFiles,
       isLoading: false,
-      isSuccess: filesystem === "company_context",
+      isSuccess: true,
       error: undefined,
     }))
     const bridge = {
@@ -255,16 +264,22 @@ describe("FileTreePane", () => {
       getActiveFile: vi.fn(),
     }
 
-    render(<FileTreePane bridge={bridge} />, { wrapper })
+    render(<FileTreePane
+      bridge={bridge}
+      roots={[
+        { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+        { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readonly", searchPlaceholder: "Filter project files..." },
+      ]}
+    />, { wrapper })
 
     expect(await screen.findByRole("tab", { name: "Workspace" })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole("tab", { name: "Company" }))
+    fireEvent.click(screen.getByRole("tab", { name: "Project" }))
 
     await waitFor(() => expect(screen.getByText("handbook.md")).toBeInTheDocument())
     fireEvent.click(screen.getByText("handbook.md"))
     expect(bridge.openFile).toHaveBeenCalledWith("handbook.md", {
       mode: "edit",
-      filesystem: "company_context",
+      filesystem: "project_alpha",
     })
 
     fireEvent.contextMenu(screen.getByText("handbook.md"))
@@ -272,18 +287,50 @@ describe("FileTreePane", () => {
     expect(screen.queryByRole("menuitem", { name: "Delete" })).not.toBeInTheDocument()
   })
 
-  it("hides the company root when the company binding is unavailable", async () => {
+  it("remounts the tree when switching configured filesystems so expanded path state cannot leak", async () => {
     mockFileList.mockImplementation((dir: string, filesystem?: string) => ({
-      data: filesystem === "company_context" ? undefined : sampleFiles,
+      data: [{ name: "src", kind: "dir" as const, path: "src" }],
       isLoading: false,
-      isSuccess: false,
-      error: filesystem === "company_context" ? new Error("not_found_or_denied") : undefined,
+      isSuccess: true,
+      error: undefined,
     }))
+    mockGetTree.mockImplementation(async (dir: string, _signal?: AbortSignal, filesystem?: string) => (
+      filesystem === "project_alpha"
+        ? [{ name: "project-only.ts", kind: "file" as const, path: `${dir}/project-only.ts` }]
+        : [{ name: "user-only.ts", kind: "file" as const, path: `${dir}/user-only.ts` }]
+    ))
+
+    render(<FileTreePane
+      roots={[
+        { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+        { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readonly" },
+      ]}
+    />, { wrapper })
+
+    await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+    fireEvent.click(screen.getByTestId("trigger-expand-src"))
+    await waitFor(() => expect(screen.getByText("user-only.ts")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("tab", { name: "Project" }))
+    await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+    expect(screen.queryByText("user-only.ts")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId("trigger-expand-src"))
+    await waitFor(() => expect(screen.getByText("project-only.ts")).toBeInTheDocument())
+  })
+
+  it("does not show extra filesystem roots unless configured", async () => {
+    mockFileList.mockReturnValue({
+      data: sampleFiles,
+      isLoading: false,
+      isSuccess: true,
+      error: undefined,
+    })
 
     render(<FileTreePane />, { wrapper })
 
     await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
-    expect(screen.queryByRole("tab", { name: "Company" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("tab", { name: "Workspace" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("tab", { name: "Project" })).not.toBeInTheDocument()
   })
 
   it("hides .boring-agent from the default tree view", async () => {
@@ -474,7 +521,14 @@ describe("FileTreePane", () => {
     await screen.findByText("old.ts")
     mockGetTree.mockClear()
 
-    // A remote (agent/SSE) create inside the expanded dir must re-fetch it…
+    // Cross-filesystem events must not touch this user tree.
+    act(() => {
+      events.emit(filesystemEvents.created, { ...remoteMeta(), filesystem: "project_alpha", path: "src/leak.ts", kind: "file" })
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(mockGetTree).not.toHaveBeenCalled()
+
+    // A remote (agent/SSE) create inside the expanded dir on the active filesystem must re-fetch it…
     act(() => {
       events.emit(filesystemEvents.created, { ...remoteMeta(), path: "src/new.ts", kind: "file" })
     })
@@ -488,6 +542,22 @@ describe("FileTreePane", () => {
     })
     await new Promise((r) => setTimeout(r, 20))
     expect(mockGetTree).not.toHaveBeenCalled()
+  })
+
+  it("does not optimistically patch root entries from another filesystem", async () => {
+    render(<FileTreePane />, { wrapper })
+    await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+    act(() => {
+      events.emit(filesystemEvents.created, { ...remoteMeta(), filesystem: "project_alpha", path: "leak.ts", kind: "file" })
+    })
+    await new Promise((r) => setTimeout(r, 20))
+    expect(screen.queryByText("leak.ts")).not.toBeInTheDocument()
+
+    act(() => {
+      events.emit(filesystemEvents.created, { ...remoteMeta(), path: "visible.ts", kind: "file" })
+    })
+    await waitFor(() => expect(screen.getByText("visible.ts")).toBeInTheDocument())
   })
 
   it("reveals folder requests forwarded through left-tab params", async () => {


### PR DESCRIPTION
## Summary\n- add explicit filesystem support to workspace tree fetching/cache keys\n- show Workspace/Company as separate file-tree roots when company_context is bound\n- open Company files with explicit filesystem identity and hide readonly mutation actions\n\n## Validation\n- pnpm --dir packages/workspace exec vitest run src/plugins/filesystemPlugin/front/data/__tests__/fetchClient.test.ts src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx --reporter dot\n- pnpm --filter @hachej/boring-workspace typecheck\n- pnpm --dir packages/agent exec vitest run src/server/http/routes/__tests__/tree.test.ts src/server/http/routes/__tests__/file.test.ts --reporter dot\n- pnpm --filter @hachej/boring-agent typecheck\n- git diff --check