### PR TITLE
mcp-integration: Add normalized tool catalog search and describe

### DIFF
--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -8,6 +8,7 @@ This package is the generic MCP capability that child apps can enable. It owns:
 - provider template, source, tool, policy, redaction, status, and facade contracts;
 - deny-before-allow read-only policy helpers;
 - fake-transport-testable facade seams;
+- normalized tool catalog search/describe contracts;
 - server-only managed connector adapter seam with app-injected secret resolution.
 
 It intentionally does **not** perform real connector-provider calls, OAuth, provider execution, secret storage, or app-specific environment binding in the foundation PR.
@@ -52,4 +53,4 @@ Managed connector adapters must pass the [Composio security preflight](./docs/co
 
 ## Current status
 
-Foundation plus source handlers, executable preflight, and generic managed connector adapter seam. Real Composio SDK/API calls, route registration, agent bridge tools, and provider execution land in later PRs.
+Foundation plus source handlers, executable preflight, generic managed connector adapter seam, and normalized tool catalog search/describe. Real Composio SDK/API calls, route registration, agent bridge tools, and provider execution land in later PRs.

--- a/plugins/boring-mcp/src/__tests__/sourceHandlers.test.ts
+++ b/plugins/boring-mcp/src/__tests__/sourceHandlers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { createBoringMcpSourceHandlers } from "../server"
+import { createBoringMcpSourceHandlers } from "../server/sourceHandlers"
 import {
   MCP_ERROR_CODES,
   type McpActor,
@@ -101,6 +101,17 @@ describe("boring-mcp source handlers", () => {
     const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport })
 
     await expect(handlers.probeSource(actor, "source:notion:user-1")).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+  })
+
+  it("exposes exact catalog backend operation names", async () => {
+    const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport: makeTransport() })
+
+    await expect(handlers.mcp_tools_search(actor, { query: "search" })).resolves.toMatchObject({
+      tools: [expect.objectContaining({ toolName: "NOTION_SEARCH_NOTION_PAGE", enabled: true })],
+    })
+    await expect(handlers.mcp_tool_describe(actor, { sourceId: "source:notion:user-1", toolName: "update_page" })).resolves.toMatchObject({
+      tool: expect.objectContaining({ toolName: "update_page", enabled: false }),
+    })
   })
 
   it("does not call disconnect on unowned sources", async () => {

--- a/plugins/boring-mcp/src/__tests__/toolCatalog.test.ts
+++ b/plugins/boring-mcp/src/__tests__/toolCatalog.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from "vitest"
+import { createBoringMcpToolCatalog, createMcpSchemaHash, InMemoryMcpToolCatalogCache } from "../server/toolCatalog"
+import {
+  MCP_ERROR_CODES,
+  type McpActor,
+  type McpDiscoveredTool,
+  type McpSource,
+  type McpSourceRegistry,
+  type McpTransportClient,
+} from "../shared"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+
+const source: McpSource = {
+  id: "source:notion:user-1",
+  workspaceId: actor.workspaceId,
+  userId: actor.userId,
+  provider: "notion",
+  displayName: "Notion",
+  status: "connected",
+  ownerKind: "user",
+  credentialProvider: "composio-managed",
+}
+
+function registry(): McpSourceRegistry {
+  return {
+    async listSources(requestActor) {
+      return requestActor.userId === source.userId && requestActor.workspaceId === source.workspaceId ? [source] : []
+    },
+    async getSource(sourceId) {
+      return sourceId === source.id ? source : undefined
+    },
+  }
+}
+
+function transport(tools: McpDiscoveredTool[]): McpTransportClient {
+  return {
+    listTools: vi.fn(async () => tools),
+    listResources: vi.fn(async () => []),
+    readResource: vi.fn(),
+    callTool: vi.fn(),
+  }
+}
+
+const readonlySearch = {
+  name: "NOTION_SEARCH_NOTION_PAGE",
+  description: "Search Notion pages",
+  inputSchema: { type: "object", properties: { query: { type: "string" } }, required: ["query"] },
+}
+
+describe("boring-mcp tool catalog", () => {
+  it("searches normalized tool entries from a fake connector probe", async () => {
+    const tx = transport([readonlySearch, { name: "update_page", inputSchema: { type: "object" } }])
+    const catalog = createBoringMcpToolCatalog({ registry: registry(), transport: tx })
+
+    const result = await catalog.searchTools(actor, { query: "search" })
+
+    expect(result.tools).toEqual([
+      expect.objectContaining({
+        sourceId: source.id,
+        provider: "notion",
+        toolName: "NOTION_SEARCH_NOTION_PAGE",
+        enabled: true,
+        risk: "read",
+        blockedReasons: [],
+        schemaHash: createMcpSchemaHash(readonlySearch.inputSchema),
+      }),
+    ])
+    expect(tx.callTool).not.toHaveBeenCalled()
+    expect(tx.listResources).not.toHaveBeenCalled()
+  })
+
+  it("does not serve cached tools after a source is disconnected", async () => {
+    let currentSource = source
+    const dynamicRegistry: McpSourceRegistry = {
+      async listSources() {
+        return [currentSource]
+      },
+      async getSource(sourceId) {
+        return sourceId === currentSource.id ? currentSource : undefined
+      },
+    }
+    const catalog = createBoringMcpToolCatalog({ registry: dynamicRegistry, transport: transport([readonlySearch]) })
+
+    await expect(catalog.searchTools(actor, { sourceId: source.id })).resolves.toMatchObject({ tools: [expect.objectContaining({ toolName: "NOTION_SEARCH_NOTION_PAGE" })] })
+    currentSource = { ...source, status: "unconfigured" }
+
+    await expect(catalog.searchTools(actor, { sourceId: source.id })).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE })
+  })
+
+  it("describes exact schema and safety notes for a tool", async () => {
+    const catalog = createBoringMcpToolCatalog({ registry: registry(), transport: transport([readonlySearch]) })
+
+    const result = await catalog.describeTool(actor, { sourceId: source.id, toolName: "NOTION_SEARCH_NOTION_PAGE" })
+
+    expect(result.schemaDrifted).toBe(false)
+    expect(result.tool).toMatchObject({
+      toolName: "NOTION_SEARCH_NOTION_PAGE",
+      summary: "Search Notion pages",
+      inputSchema: readonlySearch.inputSchema,
+      enabled: true,
+      blockedReasons: [],
+      nativeRef: { provider: "notion", action: "NOTION_SEARCH_NOTION_PAGE" },
+    })
+  })
+
+  it("disables mutating and unknown tools by default with blocked reasons", async () => {
+    const catalog = createBoringMcpToolCatalog({ registry: registry(), transport: transport([
+      { name: "update_page", description: "Update page" },
+      { name: "NOTION_LIST_DATABASES", description: "Unknown read-like action" },
+    ]) })
+
+    const result = await catalog.searchTools(actor)
+
+    expect(result.tools).toEqual([
+      expect.objectContaining({ toolName: "update_page", enabled: false, risk: "write", blockedReasons: ["Tool matches a denied write/admin pattern"] }),
+      expect.objectContaining({ toolName: "NOTION_LIST_DATABASES", enabled: false, risk: "unknown", blockedReasons: ["Tool is not on the read-only allowlist"] }),
+    ])
+  })
+
+  it("detects schema drift when input schemas change", async () => {
+    const firstSchema = { type: "object", properties: { query: { type: "string" } } }
+    const secondSchema = { type: "object", properties: { query: { type: "string" }, limit: { type: "number" } } }
+    const tx = transport([{ name: "NOTION_SEARCH_NOTION_PAGE", inputSchema: firstSchema }])
+    const cache = new InMemoryMcpToolCatalogCache()
+    const catalog = createBoringMcpToolCatalog({ registry: registry(), transport: tx, cache })
+    const first = await catalog.describeTool(actor, { sourceId: source.id, toolName: "NOTION_SEARCH_NOTION_PAGE" })
+    tx.listTools = vi.fn(async () => [{ name: "NOTION_SEARCH_NOTION_PAGE", inputSchema: secondSchema }])
+
+    const second = await catalog.describeTool(actor, { sourceId: source.id, toolName: "NOTION_SEARCH_NOTION_PAGE", expectedSchemaHash: first.tool.schemaHash, refresh: true })
+
+    expect(second.tool.schemaHash).not.toBe(first.tool.schemaHash)
+    expect(second.schemaDrifted).toBe(true)
+  })
+
+  it("rejects secret-like tool metadata before returning catalog DTOs", async () => {
+    const catalog = createBoringMcpToolCatalog({ registry: registry(), transport: transport([
+      { name: "NOTION_SEARCH_NOTION_PAGE", description: "access_token=abcdefghijklmnop" },
+    ]) })
+
+    await expect(catalog.searchTools(actor)).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+  })
+})

--- a/plugins/boring-mcp/src/front/index.tsx
+++ b/plugins/boring-mcp/src/front/index.tsx
@@ -9,6 +9,7 @@ import {
   BORING_MCP_SOURCES_TAB_PANEL_ID,
   DEFAULT_MCP_PROVIDER_TEMPLATES,
   type McpProviderTemplate,
+  type McpToolCatalogEntry,
 } from "../shared"
 
 export interface CreateBoringMcpPluginOptions {
@@ -19,6 +20,7 @@ export interface CreateBoringMcpPluginOptions {
   enabledProviderIds?: readonly string[]
   intro?: string
   governanceNotes?: readonly string[]
+  catalogTools?: readonly McpToolCatalogEntry[]
 }
 
 const defaultGovernanceNotes = [
@@ -55,12 +57,14 @@ const styles: Record<string, CSSProperties> = {
   pillGrid: { display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))", gap: 10, maxWidth: 1120, margin: "0 auto 18px" },
   pill: { border: "1px solid var(--border)", borderRadius: 999, background: "var(--card)", padding: "10px 12px", fontSize: 12, fontWeight: 700, textAlign: "center" },
   grid: { display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))", gap: 14, maxWidth: 1120, margin: "0 auto" },
+  toolGrid: { display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 12, maxWidth: 1120, margin: "18px auto 0" },
   card: { display: "flex", minHeight: 250, flexDirection: "column", border: "1px solid var(--border)", borderRadius: 24, background: "var(--card)", padding: 18 },
   cardTop: { display: "flex", justifyContent: "space-between", gap: 12 },
   badge: { border: "1px solid var(--border)", borderRadius: 999, padding: "5px 8px", color: "var(--muted-foreground)", fontSize: 11, fontWeight: 800, whiteSpace: "nowrap" },
   codeBox: { display: "grid", gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))", gap: 14, maxWidth: 1120, margin: "18px auto 0" },
   codeCard: { border: "1px solid var(--border)", borderRadius: 22, background: "var(--card)", padding: 16 },
   code: { display: "block", overflow: "hidden", marginTop: 7, borderRadius: 8, background: "var(--muted)", padding: "7px 8px", color: "var(--muted-foreground)", fontSize: 12, textOverflow: "ellipsis", whiteSpace: "nowrap" },
+  pre: { overflow: "auto", maxHeight: 150, borderRadius: 10, background: "var(--muted)", padding: 10, color: "var(--muted-foreground)", fontSize: 11 },
 }
 
 function SourcesTab({ containerApi, options }: PaneProps & { options: CreateBoringMcpPluginOptions }) {
@@ -109,6 +113,25 @@ function SourcesPanel({ options }: { options: CreateBoringMcpPluginOptions }) {
             <p style={styles.muted}>Configured provider template. Connection, status, probe, and tool catalog wiring are supplied by the host app's boring-mcp backend.</p>
             <div style={styles.badge}>{provider.allowedTools.length} allowed read tools</div>
             <button type="button" disabled style={{ ...styles.button, cursor: "not-allowed", marginTop: "auto", color: "var(--muted-foreground)" }}>Connect through app backend</button>
+          </article>
+        ))}
+      </section>
+      <section style={styles.toolGrid} aria-label="Tool catalog preview">
+        {(options.catalogTools ?? []).length === 0 ? (
+          <article style={styles.codeCard}>
+            <h2>Tool catalog</h2>
+            <p style={styles.muted}>Host apps wire this panel to mcp_tools_search and mcp_tool_describe. No provider execution runs here.</p>
+          </article>
+        ) : options.catalogTools?.map((tool) => (
+          <article key={`${tool.sourceId}:${tool.toolName}`} style={styles.codeCard}>
+            <div style={styles.cardTop}>
+              <h2 style={{ margin: 0 }}>{tool.displayName}</h2>
+              <span style={styles.badge}>{tool.enabled ? "Enabled" : "Blocked"}</span>
+            </div>
+            <p style={styles.muted}>{tool.summary}</p>
+            {!tool.enabled && <p style={styles.muted}>Blocked: {tool.blockedReasons.join(", ")}</p>}
+            <code style={styles.code}>{tool.toolName}</code>
+            <pre style={styles.pre}>{JSON.stringify(tool.inputSchema, null, 2)}</pre>
           </article>
         ))}
       </section>

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -17,4 +17,5 @@ export default createBoringMcpServerPlugin()
 export * from "./managedConnectorAdapter"
 export * from "./managedConnectorPreflight"
 export * from "./sourceHandlers"
+export * from "./toolCatalog"
 export * from "../shared"

--- a/plugins/boring-mcp/src/server/sourceHandlers.ts
+++ b/plugins/boring-mcp/src/server/sourceHandlers.ts
@@ -5,27 +5,37 @@ import {
   toMcpSourceDto,
   type McpActor,
   type McpProbeResult,
+  type McpProviderTemplate,
   type McpSourceDto,
   type McpSourceRegistry,
   type McpSourceStatusPayload,
+  type McpToolDescribeResult,
+  type McpToolSearchResult,
   type McpTransportClient,
 } from "../shared"
 import { assertMcpPublicPayloadSecretFree, createMcpSourceStatusPayload, isActorOwnedMcpSource, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
+import { createBoringMcpToolCatalog, type McpToolDescribeInput, type McpToolsSearchInput } from "./toolCatalog"
 
 export interface BoringMcpSourceHandlersOptions {
   registry: McpSourceRegistry
   transport: McpTransportClient
+  templates?: readonly McpProviderTemplate[]
 }
 
 export interface BoringMcpSourceHandlers {
   listSources(actor: McpActor): Promise<{ sources: McpSourceDto[] }>
   getSourceStatus(actor: McpActor, sourceId: string): Promise<McpSourceStatusPayload>
   probeSource(actor: McpActor, sourceId: string): Promise<McpProbeResult>
+  searchTools(actor: McpActor, input?: McpToolsSearchInput): Promise<McpToolSearchResult>
+  describeTool(actor: McpActor, input: McpToolDescribeInput): Promise<McpToolDescribeResult>
+  mcp_tools_search(actor: McpActor, input?: McpToolsSearchInput): Promise<McpToolSearchResult>
+  mcp_tool_describe(actor: McpActor, input: McpToolDescribeInput): Promise<McpToolDescribeResult>
   disconnectSource(actor: McpActor, sourceId: string): Promise<McpSourceStatusPayload>
 }
 
 export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOptions): BoringMcpSourceHandlers {
-  const facade = new McpAccessFacade({ store: options.registry, transport: options.transport })
+  const facade = new McpAccessFacade({ store: options.registry, transport: options.transport, templates: options.templates })
+  const catalog = createBoringMcpToolCatalog(options)
 
   return {
     async listSources(actor) {
@@ -44,6 +54,22 @@ export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOp
       const result = await facade.probeSource(actor, normalizedSourceId)
       assertMcpPublicPayloadSecretFree(result)
       return result
+    },
+
+    async searchTools(actor, input) {
+      return catalog.searchTools(actor, input)
+    },
+
+    async describeTool(actor, input) {
+      return catalog.describeTool(actor, input)
+    },
+
+    async mcp_tools_search(actor, input) {
+      return catalog.searchTools(actor, input)
+    },
+
+    async mcp_tool_describe(actor, input) {
+      return catalog.describeTool(actor, input)
     },
 
     async disconnectSource(actor, sourceId) {

--- a/plugins/boring-mcp/src/server/toolCatalog.ts
+++ b/plugins/boring-mcp/src/server/toolCatalog.ts
@@ -1,0 +1,170 @@
+import { createHash } from "node:crypto"
+import {
+  MCP_ERROR_CODES,
+  McpError,
+  classifyMcpTool,
+  containsMcpSecret,
+  getMcpProviderTemplate,
+  type McpActor,
+  type McpDiscoveredTool,
+  type McpProviderId,
+  type McpProviderTemplate,
+  type McpSourceRegistry,
+  type McpToolCatalogEntry,
+  type McpToolDescribeResult,
+  type McpToolSearchResult,
+  type McpTransportClient,
+} from "../shared"
+import { assertMcpPublicPayloadSecretFree, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
+
+interface McpToolCatalogSnapshot {
+  sourceId: string
+  provider: McpProviderId
+  tools: McpToolCatalogEntry[]
+}
+
+export interface McpToolCatalogCache {
+  get(actor: McpActor, sourceId: string): Promise<McpToolCatalogSnapshot | undefined>
+  set(actor: McpActor, sourceId: string, result: McpToolCatalogSnapshot): Promise<void>
+}
+
+export interface BoringMcpToolCatalogOptions {
+  registry: McpSourceRegistry
+  transport: McpTransportClient
+  templates?: readonly McpProviderTemplate[]
+  cache?: McpToolCatalogCache
+}
+
+export interface McpToolsSearchInput {
+  sourceId?: string
+  query?: string
+  refresh?: boolean
+}
+
+export interface McpToolDescribeInput {
+  sourceId: string
+  toolName: string
+  expectedSchemaHash?: string
+  refresh?: boolean
+}
+
+export interface BoringMcpToolCatalog {
+  searchTools(actor: McpActor, input?: McpToolsSearchInput): Promise<McpToolSearchResult>
+  describeTool(actor: McpActor, input: McpToolDescribeInput): Promise<McpToolDescribeResult>
+}
+
+export class InMemoryMcpToolCatalogCache implements McpToolCatalogCache {
+  private readonly values = new Map<string, McpToolCatalogSnapshot>()
+
+  async get(actor: McpActor, sourceId: string): Promise<McpToolCatalogSnapshot | undefined> {
+    return this.values.get(`${actor.workspaceId}:${actor.userId}:${sourceId}`)
+  }
+
+  async set(actor: McpActor, sourceId: string, result: McpToolCatalogSnapshot): Promise<void> {
+    this.values.set(`${actor.workspaceId}:${actor.userId}:${sourceId}`, result)
+  }
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`
+  if (!value || typeof value !== "object") return JSON.stringify(value)
+  return `{${Object.keys(value as Record<string, unknown>).sort().map((key) => `${JSON.stringify(key)}:${stableJson((value as Record<string, unknown>)[key])}`).join(",")}}`
+}
+
+export function createMcpSchemaHash(schema: unknown): string {
+  return `sha256:${createHash("sha256").update(stableJson(schema ?? {})).digest("hex")}`
+}
+
+function displayName(toolName: string): string {
+  return toolName.replace(/[_:.-]+/g, " ").replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+export function normalizeMcpCatalogTool(
+  sourceId: string,
+  provider: McpProviderId,
+  tool: McpDiscoveredTool,
+  templates?: readonly McpProviderTemplate[],
+): McpToolCatalogEntry {
+  const template = getMcpProviderTemplate(provider, templates)
+  const decision = template
+    ? classifyMcpTool(template, tool.name)
+    : { allowed: false, risk: "unknown" as const, reason: "Tool provider has no read-only allowlist" }
+  const inputSchema = tool.inputSchema ?? {}
+  return {
+    sourceId,
+    provider,
+    toolName: tool.name,
+    displayName: displayName(tool.name),
+    summary: tool.description ?? displayName(tool.name),
+    description: tool.description,
+    inputSchema,
+    risk: decision.risk,
+    enabled: decision.allowed,
+    blockedReasons: decision.allowed ? [] : [decision.reason],
+    schemaHash: createMcpSchemaHash(inputSchema),
+    nativeRef: { provider, action: tool.name },
+  }
+}
+
+function matchesQuery(entry: McpToolCatalogEntry, query: string): boolean {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return true
+  return [entry.toolName, entry.displayName, entry.summary, entry.description, entry.provider]
+    .filter(Boolean)
+    .some((value) => String(value).toLowerCase().includes(normalized))
+}
+
+function assertConnectedSource(sourceId: string, status: string): void {
+  if (status !== "connected") {
+    throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, `MCP source ${sourceId} is not connected`)
+  }
+}
+
+export function createBoringMcpToolCatalog(options: BoringMcpToolCatalogOptions): BoringMcpToolCatalog {
+  const cache = options.cache ?? new InMemoryMcpToolCatalogCache()
+
+  async function loadSourceCatalog(actor: McpActor, sourceId: string, refresh?: boolean): Promise<McpToolCatalogSnapshot> {
+    const normalizedSourceId = validateMcpSourceId(sourceId)
+    const source = await requireActorOwnedMcpSource(options.registry, actor, normalizedSourceId)
+    assertConnectedSource(normalizedSourceId, source.status)
+
+    if (!refresh) {
+      const cached = await cache.get(actor, normalizedSourceId)
+      if (cached && cached.provider === source.provider) return cached
+    }
+
+    const discoveredTools = await options.transport.listTools(source)
+    const tools = discoveredTools.map((tool) => normalizeMcpCatalogTool(normalizedSourceId, source.provider, tool, options.templates))
+    const snapshot = { sourceId: normalizedSourceId, provider: source.provider, tools }
+    assertMcpPublicPayloadSecretFree(snapshot)
+    await cache.set(actor, normalizedSourceId, snapshot)
+    return snapshot
+  }
+
+  return {
+    async searchTools(actor, input = {}) {
+      const sources = input.sourceId
+        ? [{ id: validateMcpSourceId(input.sourceId) }]
+        : (await options.registry.listSources(actor)).filter((source) => source.status === "connected")
+      const catalog: McpToolCatalogEntry[] = []
+      for (const source of sources) {
+        const result = await loadSourceCatalog(actor, source.id, input.refresh)
+        catalog.push(...result.tools)
+      }
+      const response = { tools: catalog.filter((entry) => matchesQuery(entry, input.query ?? "")) }
+      assertMcpPublicPayloadSecretFree(response)
+      return response
+    },
+
+    async describeTool(actor, input) {
+      const result = await loadSourceCatalog(actor, input.sourceId, input.refresh)
+      const tool = result.tools.find((candidate) => candidate.toolName === input.toolName)
+      if (!tool) throw new McpError(MCP_ERROR_CODES.TOOL_NOT_FOUND, "MCP tool not found")
+      const schemaDrifted = Boolean(input.expectedSchemaHash && input.expectedSchemaHash !== tool.schemaHash)
+      if (containsMcpSecret(tool)) throw new McpError(MCP_ERROR_CODES.SECRET_LEAK_GUARD, "MCP tool metadata looked like it contained a secret")
+      const response = { tool, schemaDrifted }
+      assertMcpPublicPayloadSecretFree(response)
+      return response
+    },
+  }
+}

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -122,8 +122,9 @@ export interface McpDoctorResult {
   issues: McpDoctorIssue[]
 }
 
-export interface NormalizedMcpTool {
-  serverId: string
+export interface McpToolCatalogEntry {
+  sourceId: string
+  provider: McpProviderId
   toolName: string
   displayName: string
   summary: string
@@ -132,13 +133,24 @@ export interface NormalizedMcpTool {
   outputSchema?: unknown
   risk: McpToolRisk
   enabled: boolean
-  reason: string
-  schemaHash?: string
-  nativeRef?: {
+  blockedReasons: string[]
+  schemaHash: string
+  nativeRef: {
     provider: string
     toolkit?: string
     action: string
   }
+}
+
+export type NormalizedMcpTool = McpToolCatalogEntry
+
+export interface McpToolSearchResult {
+  tools: McpToolCatalogEntry[]
+}
+
+export interface McpToolDescribeResult {
+  tool: McpToolCatalogEntry
+  schemaDrifted: boolean
 }
 
 export interface McpToolCallResult {


### PR DESCRIPTION
## Summary
- add normalized boring-mcp tool catalog DTOs with schema hashes and drift detection
- add tool-only catalog loader/cache plus backend operations `mcp_tools_search` and `mcp_tool_describe`
- add generic Sources UI tool catalog preview and tests for fake connector catalog behavior

## Constraints
- no provider execution
- no real Composio/OAuth calls
- no Constellation-specific wiring
- no V2 materialized tools/admin classification UI

## Validation
- `pnpm --filter @hachej/boring-mcp test`: 35 passed
- `pnpm --filter @hachej/boring-mcp typecheck`: pass
- `pnpm --filter @hachej/boring-mcp build`: pass
- `pnpm lint:workspace-plugin-invariants`: pass
- `git diff --check`: pass
- non-test/non-doc line count: 238

## Reviews
- worker implementation complete
- thermo review initially RED; fixed cache/status validation, resource overfetch, SHA-256 hash
- thermo re-review: GREEN
- independent reviewer: GREEN
