### PR TITLE
mcp-integration: Add governed read-only MCP calls

### DIFF
--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -9,6 +9,7 @@ This package is the generic MCP capability that child apps can enable. It owns:
 - deny-before-allow read-only policy helpers;
 - fake-transport-testable facade seams;
 - normalized tool catalog search/describe contracts;
+- governed `mcp_readonly_call` execution boundary with audit metadata;
 - server-only managed connector adapter seam with app-injected secret resolution.
 
 It intentionally does **not** perform real connector-provider calls, OAuth, provider execution, secret storage, or app-specific environment binding in the foundation PR.
@@ -53,4 +54,4 @@ Managed connector adapters must pass the [Composio security preflight](./docs/co
 
 ## Current status
 
-Foundation plus source handlers, executable preflight, generic managed connector adapter seam, and normalized tool catalog search/describe. Real Composio SDK/API calls, route registration, agent bridge tools, and provider execution land in later PRs.
+Foundation plus source handlers, executable preflight, generic managed connector adapter seam, normalized tool catalog search/describe, and governed fake-transport-testable read-only execution. Real Composio SDK/API calls, route registration, and agent bridge tools land in later PRs.

--- a/plugins/boring-mcp/src/__tests__/readonlyCall.test.ts
+++ b/plugins/boring-mcp/src/__tests__/readonlyCall.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from "vitest"
+import { createBoringMcpReadonlyCaller } from "../server/readonlyCall"
+import {
+  MCP_ERROR_CODES,
+  type McpActor,
+  type McpDiscoveredTool,
+  type McpReadonlyCallAuditEvent,
+  type McpToolCallResult,
+  type McpSource,
+  type McpSourceRegistry,
+  type McpTransportClient,
+} from "../shared"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+const source: McpSource = {
+  id: "source:notion:user-1",
+  workspaceId: actor.workspaceId,
+  userId: actor.userId,
+  provider: "notion",
+  displayName: "Notion",
+  status: "connected",
+  ownerKind: "user",
+  credentialProvider: "composio-managed",
+}
+const readonlyTool: McpDiscoveredTool = {
+  name: "NOTION_SEARCH_NOTION_PAGE",
+  description: "Search pages",
+  inputSchema: { type: "object", properties: { query: { type: "string" } } },
+}
+
+function registry(current: McpSource = source): McpSourceRegistry {
+  return {
+    async listSources(requestActor) {
+      return requestActor.userId === current.userId && requestActor.workspaceId === current.workspaceId ? [current] : []
+    },
+    async getSource(sourceId) {
+      return sourceId === current.id ? current : undefined
+    },
+  }
+}
+
+function transport(tools: McpDiscoveredTool[], result: McpToolCallResult = { content: [{ type: "text", text: "ok" }] }): McpTransportClient {
+  return {
+    listTools: vi.fn(async () => tools),
+    listResources: vi.fn(async () => []),
+    readResource: vi.fn(),
+    callTool: vi.fn(async () => result),
+  }
+}
+
+function auditSink() {
+  const events: McpReadonlyCallAuditEvent[] = []
+  return { events, audit: { record: vi.fn((event: McpReadonlyCallAuditEvent) => { events.push(event) }) } }
+}
+
+describe("boring-mcp governed read-only execution", () => {
+  it("executes an allowlisted read-only call through a fake transport", async () => {
+    const tx = transport([readonlyTool])
+    const { audit, events } = auditSink()
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, audit })
+
+    const result = await caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name, input: { query: "demo" } })
+
+    expect(result).toEqual({ content: { content: [{ type: "text", text: "ok" }] } })
+    expect(tx.callTool).toHaveBeenCalledWith(source, readonlyTool.name, { query: "demo" })
+    expect(events).toEqual([expect.objectContaining({ operation: "mcp_readonly_call", outcome: "success", sourceId: source.id, toolName: readonlyTool.name })])
+    expect(JSON.stringify(events)).not.toMatch(/query|ok|token|session/i)
+  })
+
+  it("blocks mutating tools before provider execution and audits the block", async () => {
+    const tx = transport([{ name: "update_page", inputSchema: { type: "object" } }])
+    const { audit, events } = auditSink()
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, audit })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: "update_page", input: { title: "new" } })).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
+
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+    expect(events).toEqual([expect.objectContaining({ outcome: "blocked", code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED, toolName: "update_page" })])
+  })
+
+  it("blocks unknown/disabled tools before provider discovery", async () => {
+    const tx = transport([{ name: "NOTION_LIST_DATABASES" }])
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: "NOTION_LIST_DATABASES" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
+
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("rejects malformed requests before provider discovery and audits a sanitized block", async () => {
+    const tx = transport([readonlyTool])
+    const { audit, events } = auditSink()
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, audit })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id } as never)).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+    expect(events).toEqual([expect.objectContaining({ outcome: "blocked", code: MCP_ERROR_CODES.INPUT_INVALID, sourceId: source.id, toolName: "[invalid]" })])
+  })
+
+  it("blocks secret-like input before provider discovery", async () => {
+    const tx = transport([readonlyTool])
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name, input: { access_token: "abcdefghijklmnop" } })).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("rejects non-json-safe input before provider discovery", async () => {
+    const tx = transport([readonlyTool])
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name, input: { at: new Date() } })).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name, input: { limit: Number.NaN } })).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("sanitizes invalid audit labels that look secret-like", async () => {
+    const tx = transport([readonlyTool])
+    const { audit, events } = auditSink()
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, audit })
+
+    await expect(caller.callReadonly(actor, { sourceId: "access_token=abcdefghijklmnop", toolName: "bad name" } as never)).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+
+    expect(events).toEqual([expect.objectContaining({ outcome: "blocked", sourceId: "[invalid]", toolName: "[invalid]" })])
+    expect(JSON.stringify(events)).not.toContain("abcdefghijklmnop")
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("blocks disconnected and unowned sources before provider discovery", async () => {
+    const tx = transport([readonlyTool])
+    const disconnectedCaller = createBoringMcpReadonlyCaller({ registry: registry({ ...source, status: "expired" }), transport: tx })
+
+    await expect(disconnectedCaller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name })).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE })
+    await expect(disconnectedCaller.callReadonly({ ...actor, userId: "other" }, { sourceId: source.id, toolName: readonlyTool.name })).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_NOT_FOUND })
+
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("blocks unknown providers before provider discovery", async () => {
+    const tx = transport([readonlyTool])
+    const caller = createBoringMcpReadonlyCaller({ registry: registry({ ...source, provider: "custom" as never }), transport: tx })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name })).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
+
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("blocks schema drift before provider execution", async () => {
+    const tx = transport([readonlyTool])
+    const { audit, events } = auditSink()
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, audit })
+    const staleHash = `sha256:${"0".repeat(64)}`
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name, expectedSchemaHash: staleHash })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_TOOL_DRIFT })
+
+    expect(tx.listTools).toHaveBeenCalledOnce()
+    expect(tx.callTool).not.toHaveBeenCalled()
+    expect(events).toEqual([expect.objectContaining({ outcome: "blocked", code: MCP_ERROR_CODES.PROVIDER_TOOL_DRIFT, expectedSchemaHash: staleHash })])
+  })
+
+  it("does not audit invalid or secret-like expected schema hashes", async () => {
+    const tx = transport([readonlyTool])
+    const { audit, events } = auditSink()
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, audit })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name, expectedSchemaHash: "access_token=abcdefghijklmnop" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name, expectedSchemaHash: `sha256:${"A".repeat(64)}` })).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+
+    expect(events).toEqual([
+      expect.objectContaining({ outcome: "blocked", expectedSchemaHash: undefined }),
+      expect.objectContaining({ outcome: "blocked", expectedSchemaHash: undefined }),
+    ])
+    expect(JSON.stringify(events)).not.toContain("abcdefghijklmnop")
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("blocks oversized input before provider execution", async () => {
+    const tx = transport([readonlyTool])
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, maxInputBytes: 16 })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name, input: { query: "x".repeat(100) } })).rejects.toMatchObject({ code: MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED })
+
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("does not let audit failures mask successful calls", async () => {
+    const tx = transport([readonlyTool])
+    const audit = { record: vi.fn(() => { throw new Error("audit offline") }) }
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, audit })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name, input: { query: "demo" } })).resolves.toEqual({ content: { content: [{ type: "text", text: "ok" }] } })
+  })
+
+  it("rejects secret-like provider output and audits without payloads", async () => {
+    const tx = transport([readonlyTool], { content: [{ type: "text", text: "access_token=abcdefghijklmnop" }] })
+    const { audit, events } = auditSink()
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, audit })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name })).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+
+    expect(tx.callTool).toHaveBeenCalledOnce()
+    expect(events).toEqual([expect.objectContaining({ outcome: "failure", code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })])
+    expect(JSON.stringify(events)).not.toContain("abcdefghijklmnop")
+  })
+
+  it("redacts provider errors and audits failures", async () => {
+    const tx = transport([readonlyTool])
+    tx.callTool = vi.fn(async () => { throw new Error("upstream leaked api_key=abcdefghijklmnop") })
+    const { audit, events } = auditSink()
+    const caller = createBoringMcpReadonlyCaller({ registry: registry(), transport: tx, audit })
+
+    await expect(caller.callReadonly(actor, { sourceId: source.id, toolName: readonlyTool.name })).rejects.toMatchObject({
+      code: MCP_ERROR_CODES.PROVIDER_ERROR,
+      details: { message: "upstream leaked [REDACTED_MCP_SECRET]" },
+    })
+    expect(events).toEqual([expect.objectContaining({ outcome: "failure", code: MCP_ERROR_CODES.PROVIDER_ERROR })])
+  })
+})

--- a/plugins/boring-mcp/src/__tests__/shared.test.ts
+++ b/plugins/boring-mcp/src/__tests__/shared.test.ts
@@ -82,7 +82,7 @@ describe("McpAccessFacade", () => {
     ])
   })
 
-  it("blocks unowned sources and mutating calls before transport execution", async () => {
+  it("blocks unowned sources before transport execution", async () => {
     const transport: McpTransportClient = {
       listTools: vi.fn(async () => []),
       listResources: vi.fn(async () => []),
@@ -91,7 +91,6 @@ describe("McpAccessFacade", () => {
     }
     const facade = new McpAccessFacade({ store: makeStore(), transport })
     await expect(facade.probeSource({ ...actor, userId: "other" }, notionSource.id)).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_NOT_FOUND })
-    await expect(facade.callReadonlyTool(actor, notionSource.id, "update_page", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
     expect(transport.listTools).not.toHaveBeenCalled()
     expect(transport.callTool).not.toHaveBeenCalled()
   })
@@ -105,7 +104,6 @@ describe("McpAccessFacade", () => {
     }
     const facade = new McpAccessFacade({ store: makeStore({ ...notionSource, status: "expired" }), transport })
     await expect(facade.probeSource(actor, notionSource.id)).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE })
-    await expect(facade.callReadonlyTool(actor, notionSource.id, "NOTION_SEARCH_NOTION_PAGE", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE })
     expect(transport.listTools).not.toHaveBeenCalled()
     expect(transport.listResources).not.toHaveBeenCalled()
     expect(transport.callTool).not.toHaveBeenCalled()
@@ -136,14 +134,4 @@ describe("McpAccessFacade", () => {
     await expect(policyFacade.probeSource(actor, teamSource.id)).resolves.toMatchObject({ sourceId: teamSource.id })
   })
 
-  it("rejects provider responses that look like secrets", async () => {
-    const transport: McpTransportClient = {
-      listTools: vi.fn(async () => []),
-      listResources: vi.fn(async () => []),
-      readResource: vi.fn(),
-      callTool: vi.fn(async () => ({ content: { access_token: "secret" } })),
-    }
-    const facade = new McpAccessFacade({ store: makeStore(), transport })
-    await expect(facade.callReadonlyTool(actor, notionSource.id, "NOTION_SEARCH_NOTION_PAGE", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
-  })
 })

--- a/plugins/boring-mcp/src/__tests__/sourceHandlers.test.ts
+++ b/plugins/boring-mcp/src/__tests__/sourceHandlers.test.ts
@@ -103,14 +103,19 @@ describe("boring-mcp source handlers", () => {
     await expect(handlers.probeSource(actor, "source:notion:user-1")).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
   })
 
-  it("exposes exact catalog backend operation names", async () => {
-    const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport: makeTransport() })
+  it("exposes exact catalog and readonly backend operation names", async () => {
+    const transport = makeTransport()
+    transport.callTool = vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] }))
+    const handlers = createBoringMcpSourceHandlers({ registry: makeRegistry(), transport })
 
     await expect(handlers.mcp_tools_search(actor, { query: "search" })).resolves.toMatchObject({
       tools: [expect.objectContaining({ toolName: "NOTION_SEARCH_NOTION_PAGE", enabled: true })],
     })
     await expect(handlers.mcp_tool_describe(actor, { sourceId: "source:notion:user-1", toolName: "update_page" })).resolves.toMatchObject({
       tool: expect.objectContaining({ toolName: "update_page", enabled: false }),
+    })
+    await expect(handlers.mcp_readonly_call(actor, { sourceId: "source:notion:user-1", toolName: "NOTION_SEARCH_NOTION_PAGE", input: { query: "demo" } })).resolves.toMatchObject({
+      content: { content: [{ type: "text", text: "ok" }] },
     })
   })
 

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -17,5 +17,6 @@ export default createBoringMcpServerPlugin()
 export * from "./managedConnectorAdapter"
 export * from "./managedConnectorPreflight"
 export * from "./sourceHandlers"
+export * from "./readonlyCall"
 export * from "./toolCatalog"
 export * from "../shared"

--- a/plugins/boring-mcp/src/server/readonlyCall.ts
+++ b/plugins/boring-mcp/src/server/readonlyCall.ts
@@ -1,0 +1,238 @@
+import {
+  MCP_ERROR_CODES,
+  McpError,
+  classifyMcpTool,
+  containsMcpSecret,
+  getMcpProviderTemplate,
+  redactMcpSecrets,
+  validateMcpToolName,
+  type McpActor,
+  type McpProviderTemplate,
+  type McpReadonlyCallAuditEvent,
+  type McpReadonlyCallInput,
+  type McpReadonlyCallResult,
+  type McpSourceRegistry,
+  type McpToolCatalogEntry,
+  type McpTransportClient,
+} from "../shared"
+import { assertMcpPublicPayloadSecretFree, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
+import { createBoringMcpToolCatalog } from "./toolCatalog"
+
+export interface McpReadonlyCallAuditSink {
+  record(event: McpReadonlyCallAuditEvent): void | Promise<void>
+}
+
+export interface BoringMcpReadonlyCallOptions {
+  registry: McpSourceRegistry
+  transport: McpTransportClient
+  templates?: readonly McpProviderTemplate[]
+  maxInputBytes?: number
+  audit?: McpReadonlyCallAuditSink
+}
+
+export interface BoringMcpReadonlyCaller {
+  callReadonly(actor: McpActor, input: McpReadonlyCallInput): Promise<McpReadonlyCallResult>
+}
+
+interface ParsedReadonlyCall {
+  sourceId: string
+  toolName: string
+  expectedSchemaHash?: string
+  toolInput: unknown
+}
+
+const DEFAULT_MAX_INPUT_BYTES = 64 * 1024
+const INVALID_AUDIT_VALUE = "[invalid]"
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function normalizeJsonValue(value: unknown): unknown {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP tool input must be JSON-safe")
+    return value
+  }
+  if (Array.isArray(value)) return value.map(normalizeJsonValue)
+  if (isPlainRecord(value)) {
+    return Object.fromEntries(Object.entries(value).map(([key, nested]) => [key, normalizeJsonValue(nested)]))
+  }
+  throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP tool input must be JSON-safe")
+}
+
+function inputSizeBytes(input: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(input)).byteLength
+}
+
+function parseReadonlyCall(input: unknown, maxInputBytes: number): ParsedReadonlyCall {
+  if (!isPlainRecord(input)) throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP readonly call input must be an object")
+  if (typeof input.sourceId !== "string") throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP sourceId must be a string")
+  if (typeof input.toolName !== "string") throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP toolName must be a string")
+  if (input.expectedSchemaHash !== undefined && (typeof input.expectedSchemaHash !== "string" || !isValidSchemaHash(input.expectedSchemaHash))) {
+    throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP expectedSchemaHash must be a sha256 schema hash")
+  }
+
+  if (containsMcpSecret(input.sourceId) || containsMcpSecret(input.toolName)) {
+    throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP readonly call identifiers looked like they contained a secret")
+  }
+
+  const toolInput = normalizeJsonValue(input.input ?? {})
+  if (inputSizeBytes(toolInput) > maxInputBytes) {
+    throw new McpError(MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED, "MCP tool input is too large")
+  }
+  if (containsMcpSecret(toolInput)) {
+    throw new McpError(MCP_ERROR_CODES.SECRET_LEAK_GUARD, "MCP tool input looked like it contained a secret")
+  }
+
+  const sourceId = validateMcpSourceId(input.sourceId)
+  validateMcpToolName(input.toolName)
+  return {
+    sourceId,
+    toolName: input.toolName,
+    expectedSchemaHash: input.expectedSchemaHash,
+    toolInput,
+  }
+}
+
+function assertReadOnlyTool(tool: McpToolCatalogEntry): void {
+  if (!tool.enabled || tool.risk !== "read") {
+    throw new McpError(MCP_ERROR_CODES.TOOL_NOT_ALLOWED, tool.blockedReasons[0] ?? "MCP tool is not allowed for read-only execution")
+  }
+}
+
+function assertSchemaCurrent(tool: McpToolCatalogEntry, expectedSchemaHash?: string): void {
+  if (expectedSchemaHash && expectedSchemaHash !== tool.schemaHash) {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_TOOL_DRIFT, "MCP tool schema changed before execution")
+  }
+}
+
+function assertTemplateAllowsReadonly(sourceProvider: string, toolName: string, templates?: readonly McpProviderTemplate[]): void {
+  const template = getMcpProviderTemplate(sourceProvider, templates)
+  const decision = template
+    ? classifyMcpTool(template, toolName)
+    : { allowed: false, risk: "unknown" as const, reason: "Tool provider has no read-only allowlist" }
+  if (!decision.allowed || decision.risk !== "read") throw new McpError(MCP_ERROR_CODES.TOOL_NOT_ALLOWED, decision.reason)
+}
+
+function auditEvent(
+  actor: McpActor,
+  input: Pick<McpReadonlyCallInput, "sourceId" | "toolName" | "expectedSchemaHash">,
+  outcome: McpReadonlyCallAuditEvent["outcome"],
+  code?: string,
+): McpReadonlyCallAuditEvent {
+  return {
+    operation: "mcp_readonly_call",
+    outcome,
+    workspaceId: actor.workspaceId,
+    userId: actor.userId,
+    sourceId: input.sourceId,
+    toolName: input.toolName,
+    expectedSchemaHash: input.expectedSchemaHash,
+    code,
+  }
+}
+
+function toErrorCode(error: unknown): string {
+  return error instanceof McpError ? error.code : MCP_ERROR_CODES.PROVIDER_ERROR
+}
+
+function isValidSchemaHash(value: string): boolean {
+  return /^sha256:[a-f0-9]{64}$/.test(value)
+}
+
+function auditSourceId(value: unknown): string {
+  if (typeof value !== "string" || containsMcpSecret(value)) return INVALID_AUDIT_VALUE
+  try {
+    return validateMcpSourceId(value)
+  } catch {
+    return INVALID_AUDIT_VALUE
+  }
+}
+
+function auditToolName(value: unknown): string {
+  if (typeof value !== "string" || containsMcpSecret(value)) return INVALID_AUDIT_VALUE
+  try {
+    validateMcpToolName(value)
+    return value
+  } catch {
+    return INVALID_AUDIT_VALUE
+  }
+}
+
+function auditSchemaHash(value: unknown): string | undefined {
+  return typeof value === "string" && !containsMcpSecret(value) && isValidSchemaHash(value) ? value : undefined
+}
+
+export function createBoringMcpReadonlyCaller(options: BoringMcpReadonlyCallOptions): BoringMcpReadonlyCaller {
+  const catalog = createBoringMcpToolCatalog(options)
+  const maxInputBytes = options.maxInputBytes ?? DEFAULT_MAX_INPUT_BYTES
+
+  async function record(event: McpReadonlyCallAuditEvent): Promise<void> {
+    try {
+      await options.audit?.record(event)
+    } catch {
+      // Audit is metadata-only and must not mask security decisions or successful provider calls.
+    }
+  }
+
+  return {
+    async callReadonly(actor, input) {
+      const raw: Record<string, unknown> = isPlainRecord(input) ? input : {}
+      let request: Pick<McpReadonlyCallInput, "sourceId" | "toolName" | "expectedSchemaHash"> = {
+        sourceId: auditSourceId(raw.sourceId),
+        toolName: auditToolName(raw.toolName),
+        expectedSchemaHash: auditSchemaHash(raw.expectedSchemaHash),
+      }
+      let audited = false
+      try {
+        const parsed = parseReadonlyCall(input, maxInputBytes)
+        request = parsed
+        const source = await requireActorOwnedMcpSource(options.registry, actor, parsed.sourceId)
+        if (source.status !== "connected") throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source is not connected")
+
+        // Deny before provider discovery: only pre-approved read tools may reach listTools/callTool.
+        assertTemplateAllowsReadonly(source.provider, parsed.toolName, options.templates)
+
+        const described = await catalog.describeTool(actor, {
+          sourceId: parsed.sourceId,
+          toolName: parsed.toolName,
+          expectedSchemaHash: parsed.expectedSchemaHash,
+          refresh: true,
+        })
+        assertReadOnlyTool(described.tool)
+        assertSchemaCurrent(described.tool, parsed.expectedSchemaHash)
+
+        let providerResult: unknown
+        try {
+          providerResult = await options.transport.callTool(source, parsed.toolName, parsed.toolInput)
+        } catch (error) {
+          const redacted = redactMcpSecrets(error instanceof Error ? { name: error.name, message: error.message } : error)
+          await record(auditEvent(actor, request, "failure", MCP_ERROR_CODES.PROVIDER_ERROR))
+          audited = true
+          throw new McpError(MCP_ERROR_CODES.PROVIDER_ERROR, "MCP provider tool call failed", redacted)
+        }
+
+        const redacted = redactMcpSecrets(providerResult)
+        if (containsMcpSecret(providerResult)) {
+          await record(auditEvent(actor, request, "failure", MCP_ERROR_CODES.SECRET_LEAK_GUARD))
+          audited = true
+          throw new McpError(MCP_ERROR_CODES.SECRET_LEAK_GUARD, "MCP provider response looked like it contained a secret")
+        }
+        const response = { content: redacted }
+        assertMcpPublicPayloadSecretFree(response)
+        await record(auditEvent(actor, request, "success"))
+        audited = true
+        return response
+      } catch (error) {
+        const code = toErrorCode(error)
+        if (!audited) {
+          await record(auditEvent(actor, request, "blocked", code))
+        }
+        throw error
+      }
+    },
+  }
+}

--- a/plugins/boring-mcp/src/server/sourceHandlers.ts
+++ b/plugins/boring-mcp/src/server/sourceHandlers.ts
@@ -9,17 +9,22 @@ import {
   type McpSourceDto,
   type McpSourceRegistry,
   type McpSourceStatusPayload,
+  type McpReadonlyCallInput,
+  type McpReadonlyCallResult,
   type McpToolDescribeResult,
   type McpToolSearchResult,
   type McpTransportClient,
 } from "../shared"
 import { assertMcpPublicPayloadSecretFree, createMcpSourceStatusPayload, isActorOwnedMcpSource, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
+import { createBoringMcpReadonlyCaller, type McpReadonlyCallAuditSink } from "./readonlyCall"
 import { createBoringMcpToolCatalog, type McpToolDescribeInput, type McpToolsSearchInput } from "./toolCatalog"
 
 export interface BoringMcpSourceHandlersOptions {
   registry: McpSourceRegistry
   transport: McpTransportClient
   templates?: readonly McpProviderTemplate[]
+  maxReadonlyInputBytes?: number
+  audit?: McpReadonlyCallAuditSink
 }
 
 export interface BoringMcpSourceHandlers {
@@ -30,12 +35,21 @@ export interface BoringMcpSourceHandlers {
   describeTool(actor: McpActor, input: McpToolDescribeInput): Promise<McpToolDescribeResult>
   mcp_tools_search(actor: McpActor, input?: McpToolsSearchInput): Promise<McpToolSearchResult>
   mcp_tool_describe(actor: McpActor, input: McpToolDescribeInput): Promise<McpToolDescribeResult>
+  callReadonly(actor: McpActor, input: McpReadonlyCallInput): Promise<McpReadonlyCallResult>
+  mcp_readonly_call(actor: McpActor, input: McpReadonlyCallInput): Promise<McpReadonlyCallResult>
   disconnectSource(actor: McpActor, sourceId: string): Promise<McpSourceStatusPayload>
 }
 
 export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOptions): BoringMcpSourceHandlers {
   const facade = new McpAccessFacade({ store: options.registry, transport: options.transport, templates: options.templates })
   const catalog = createBoringMcpToolCatalog(options)
+  const readonlyCaller = createBoringMcpReadonlyCaller({
+    registry: options.registry,
+    transport: options.transport,
+    templates: options.templates,
+    maxInputBytes: options.maxReadonlyInputBytes,
+    audit: options.audit,
+  })
 
   return {
     async listSources(actor) {
@@ -70,6 +84,14 @@ export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOp
 
     async mcp_tool_describe(actor, input) {
       return catalog.describeTool(actor, input)
+    },
+
+    async callReadonly(actor, input) {
+      return readonlyCaller.callReadonly(actor, input)
+    },
+
+    async mcp_readonly_call(actor, input) {
+      return readonlyCaller.callReadonly(actor, input)
     },
 
     async disconnectSource(actor, sourceId) {

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -153,6 +153,28 @@ export interface McpToolDescribeResult {
   schemaDrifted: boolean
 }
 
+export interface McpReadonlyCallInput {
+  sourceId: string
+  toolName: string
+  input?: unknown
+  expectedSchemaHash?: string
+}
+
+export interface McpReadonlyCallResult {
+  content: unknown
+}
+
+export interface McpReadonlyCallAuditEvent {
+  operation: "mcp_readonly_call"
+  outcome: "success" | "blocked" | "failure"
+  workspaceId: string
+  userId: string
+  sourceId: string
+  toolName: string
+  expectedSchemaHash?: string
+  code?: string
+}
+
 export interface McpToolCallResult {
   content: unknown
 }
@@ -328,19 +350,6 @@ export class McpAccessFacade {
     }
   }
 
-  async callReadonlyTool(actor: McpActor, sourceId: string, toolName: string, input: unknown): Promise<McpToolCallResult> {
-    const source = await this.requireAccessibleSource(actor, sourceId)
-    this.requireConnectedSource(source)
-    const template = this.requireTemplate(source)
-    assertMcpToolAllowed(template, toolName)
-    const bytes = new TextEncoder().encode(JSON.stringify(input ?? {})).byteLength
-    if (bytes > (this.params.maxInputBytes ?? 64 * 1024)) {
-      throw new McpError(MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED, "MCP tool input is too large")
-    }
-    const result = await this.params.transport.callTool(source, toolName, input)
-    if (containsMcpSecret(result)) throw new McpError(MCP_ERROR_CODES.SECRET_LEAK_GUARD, "MCP provider response looked like it contained a secret")
-    return redactMcpSecrets(result) as McpToolCallResult
-  }
 
   private async requireAccessibleSource(actor: McpActor, sourceId: string): Promise<McpSource> {
     const source = await this.params.store.getSource(sourceId)


### PR DESCRIPTION
## Summary
- add governed `mcp_readonly_call` / `callReadonly` operation
- enforce owned+connected source, read-only allowlist, schema hash drift, JSON-safe input, byte limits, and input secret guard before provider execution
- redact provider errors, reject secret-like provider output, and emit metadata-only best-effort audit events
- remove the legacy shared facade execution bypass so readonly execution has one server boundary

## Constraints
- no write/admin execution
- no real provider/Composio/OAuth calls
- no Constellation-specific code
- no queue/framework expansion

## Validation
- `pnpm --filter @hachej/boring-mcp test`: 49 passed
- `pnpm --filter @hachej/boring-mcp typecheck`: pass
- `pnpm --filter @hachej/boring-mcp build`: pass
- `pnpm lint:workspace-plugin-invariants`: pass
- `git diff --check`: pass
- non-test/non-doc line count: 283

## Reviews
- worker implementation complete
- thermo review RED -> fixed blocker order, audit best-effort/sanitization, JSON-safe input, input secret guard, removed legacy bypass, added no-provider-contact regressions
- thermo final: GREEN
- independent reviewer final: GREEN
