### PR TITLE
mcp-integration: Add boring-mcp agent bridge tools

### DIFF
--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -10,6 +10,7 @@ This package is the generic MCP capability that child apps can enable. It owns:
 - fake-transport-testable facade seams;
 - normalized tool catalog search/describe contracts;
 - governed `mcp_readonly_call` execution boundary with audit metadata;
+- thin agent bridge tool registry for the seven stable boring-mcp operations;
 - server-only managed connector adapter seam with app-injected secret resolution.
 
 It intentionally does **not** perform real connector-provider calls, OAuth, provider execution, secret storage, or app-specific environment binding in the foundation PR.
@@ -54,4 +55,4 @@ Managed connector adapters must pass the [Composio security preflight](./docs/co
 
 ## Current status
 
-Foundation plus source handlers, executable preflight, generic managed connector adapter seam, normalized tool catalog search/describe, and governed fake-transport-testable read-only execution. Real Composio SDK/API calls, route registration, and agent bridge tools land in later PRs.
+Foundation plus source handlers, executable preflight, generic managed connector adapter seam, normalized tool catalog search/describe, governed fake-transport-testable read-only execution, and exported agent bridge tool definitions. Real Composio SDK/API calls, route/app registration, and Constellation binding land in later PRs.

--- a/plugins/boring-mcp/src/__tests__/agentBridge.test.ts
+++ b/plugins/boring-mcp/src/__tests__/agentBridge.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  BORING_MCP_AGENT_BRIDGE_TOOL_DEFINITIONS,
+  BORING_MCP_AGENT_BRIDGE_TOOL_NAMES,
+  createBoringMcpAgentBridgeRegistry,
+  listBoringMcpAgentBridgeTools,
+} from "../server/agentBridge"
+import { createBoringMcpSourceHandlers, type BoringMcpSourceHandlers } from "../server/sourceHandlers"
+import {
+  MCP_ERROR_CODES,
+  type McpActor,
+  type McpDiscoveredTool,
+  type McpSource,
+  type McpSourceRegistry,
+  type McpTransportClient,
+} from "../shared"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+
+const source: McpSource = {
+  id: "source:notion:user-1",
+  workspaceId: actor.workspaceId,
+  userId: actor.userId,
+  provider: "notion",
+  displayName: "Notion",
+  status: "connected",
+  ownerKind: "user",
+  credentialProvider: "composio-managed",
+}
+
+const readonlyTool: McpDiscoveredTool = {
+  name: "NOTION_SEARCH_NOTION_PAGE",
+  description: "Search Notion pages",
+  inputSchema: { type: "object", properties: { query: { type: "string" } } },
+}
+
+function registry(current: McpSource = source): McpSourceRegistry {
+  return {
+    async listSources(requestActor) {
+      return requestActor.userId === current.userId && requestActor.workspaceId === current.workspaceId ? [current] : []
+    },
+    async getSource(sourceId) {
+      return sourceId === current.id ? current : undefined
+    },
+  }
+}
+
+function transport(tools: McpDiscoveredTool[] = [readonlyTool, { name: "update_page" }]): McpTransportClient {
+  return {
+    listTools: vi.fn(async () => tools),
+    listResources: vi.fn(async () => []),
+    readResource: vi.fn(),
+    callTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+  }
+}
+
+function bridge(tx = transport()) {
+  const handlers = createBoringMcpSourceHandlers({ registry: registry(), transport: tx })
+  return createBoringMcpAgentBridgeRegistry(handlers)
+}
+
+describe("boring-mcp agent bridge", () => {
+  it("exposes exactly the seven stable tool names with machine-readable schemas", () => {
+    const registry = bridge()
+
+    expect(Object.keys(registry)).toEqual([...BORING_MCP_AGENT_BRIDGE_TOOL_NAMES])
+    expect(BORING_MCP_AGENT_BRIDGE_TOOL_DEFINITIONS.map((tool) => tool.name)).toEqual([...BORING_MCP_AGENT_BRIDGE_TOOL_NAMES])
+    expect(listBoringMcpAgentBridgeTools(registry).map((tool) => tool.name)).toEqual([...BORING_MCP_AGENT_BRIDGE_TOOL_NAMES])
+    for (const tool of listBoringMcpAgentBridgeTools(registry)) {
+      expect(tool.description).toEqual(expect.any(String))
+      expect(tool.description.length).toBeGreaterThan(12)
+      expect(tool.inputSchema).toMatchObject({ type: "object" })
+      expect(tool.readOnly).toBe(true)
+    }
+  })
+
+  it("delegates list/status/doctor/probe/search/describe/read-only call to existing handlers", async () => {
+    const tx = transport()
+    const registry = bridge(tx)
+
+    await expect(registry.mcp_servers_list.invoke({ actor }, {})).resolves.toMatchObject({ sources: [expect.objectContaining({ id: source.id })] })
+    await expect(registry.mcp_server_status.invoke({ actor }, { sourceId: source.id })).resolves.toMatchObject({ source: { id: source.id }, canProbe: true })
+    await expect(registry.mcp_server_doctor.invoke({ actor }, { sourceId: source.id })).resolves.toMatchObject({ ok: true, sourceId: source.id, issues: [] })
+    await expect(registry.mcp_server_probe.invoke({ actor }, { sourceId: source.id })).resolves.toMatchObject({ sourceId: source.id, tools: expect.arrayContaining([expect.objectContaining({ name: readonlyTool.name })]) })
+    await expect(registry.mcp_tools_search.invoke({ actor }, { query: "search" })).resolves.toMatchObject({ tools: [expect.objectContaining({ toolName: readonlyTool.name })] })
+    await expect(registry.mcp_tool_describe.invoke({ actor }, { sourceId: source.id, toolName: readonlyTool.name })).resolves.toMatchObject({ tool: expect.objectContaining({ toolName: readonlyTool.name }) })
+    await expect(registry.mcp_readonly_call.invoke({ actor }, { sourceId: source.id, toolName: readonlyTool.name, input: { query: "demo" } })).resolves.toEqual({ content: { content: [{ type: "text", text: "ok" }] } })
+
+    expect(tx.listTools).toHaveBeenCalled()
+    expect(tx.callTool).toHaveBeenCalledWith(source, readonlyTool.name, { query: "demo" })
+  })
+
+  it("requires an explicit actor before invoking handlers or transport", async () => {
+    const tx = transport()
+    const handlers: BoringMcpSourceHandlers = {
+      listSources: vi.fn(),
+      getSourceStatus: vi.fn(),
+      doctorSource: vi.fn(),
+      probeSource: vi.fn(),
+      searchTools: vi.fn(),
+      describeTool: vi.fn(),
+      mcp_tools_search: vi.fn(),
+      mcp_tool_describe: vi.fn(),
+      callReadonly: vi.fn(),
+      mcp_readonly_call: vi.fn(),
+      disconnectSource: vi.fn(),
+    }
+    const registry = createBoringMcpAgentBridgeRegistry(handlers)
+
+    await expect(registry.mcp_servers_list.invoke(undefined as never, {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+
+    expect(handlers.listSources).not.toHaveBeenCalled()
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("rejects malformed bridge inputs before handlers or transport", async () => {
+    const tx = transport()
+    const handlers: BoringMcpSourceHandlers = {
+      listSources: vi.fn(),
+      getSourceStatus: vi.fn(),
+      doctorSource: vi.fn(),
+      probeSource: vi.fn(),
+      searchTools: vi.fn(),
+      describeTool: vi.fn(),
+      mcp_tools_search: vi.fn(),
+      mcp_tool_describe: vi.fn(),
+      callReadonly: vi.fn(),
+      mcp_readonly_call: vi.fn(),
+      disconnectSource: vi.fn(),
+    }
+    const registry = createBoringMcpAgentBridgeRegistry(handlers)
+
+    await expect(registry.mcp_servers_list.invoke({ actor }, [])).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+    await expect(registry.mcp_server_status.invoke({ actor }, { sourceId: 42 })).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+    await expect(registry.mcp_tools_search.invoke({ actor }, { sourceId: "", refresh: "yes" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+    await expect(registry.mcp_tool_describe.invoke({ actor }, { sourceId: source.id })).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+    await expect(registry.mcp_readonly_call.invoke({ actor }, { sourceId: source.id })).rejects.toMatchObject({ code: MCP_ERROR_CODES.INPUT_INVALID })
+
+    expect(handlers.listSources).not.toHaveBeenCalled()
+    expect(handlers.getSourceStatus).not.toHaveBeenCalled()
+    expect(handlers.mcp_tools_search).not.toHaveBeenCalled()
+    expect(handlers.mcp_tool_describe).not.toHaveBeenCalled()
+    expect(handlers.mcp_readonly_call).not.toHaveBeenCalled()
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("keeps the PR5 boundary: mutating tools are blocked before provider discovery/call", async () => {
+    const tx = transport([{ name: "update_page" }])
+    const registry = bridge(tx)
+
+    await expect(registry.mcp_readonly_call.invoke({ actor }, { sourceId: source.id, toolName: "update_page", input: { title: "new" } })).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
+
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("does not leak secret-like handler results or errors through the bridge", async () => {
+    const handlers: BoringMcpSourceHandlers = {
+      listSources: vi.fn(async () => ({ sources: [{ ...source, displayName: "access_token=abcdefghijklmnop" }] })),
+      getSourceStatus: vi.fn(),
+      doctorSource: vi.fn(),
+      probeSource: vi.fn(async () => { throw new Error("provider leaked api_key=abcdefghijklmnop") }),
+      searchTools: vi.fn(),
+      describeTool: vi.fn(),
+      mcp_tools_search: vi.fn(),
+      mcp_tool_describe: vi.fn(),
+      callReadonly: vi.fn(),
+      mcp_readonly_call: vi.fn(),
+      disconnectSource: vi.fn(),
+    }
+    const registry = createBoringMcpAgentBridgeRegistry(handlers)
+
+    await expect(registry.mcp_servers_list.invoke({ actor }, {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+    await expect(registry.mcp_server_probe.invoke({ actor }, { sourceId: source.id })).rejects.toMatchObject({
+      code: MCP_ERROR_CODES.PROVIDER_ERROR,
+      details: { message: "provider leaked [REDACTED_MCP_SECRET]" },
+    })
+  })
+})

--- a/plugins/boring-mcp/src/server/agentBridge.ts
+++ b/plugins/boring-mcp/src/server/agentBridge.ts
@@ -1,0 +1,248 @@
+import {
+  MCP_ERROR_CODES,
+  McpError,
+  containsMcpSecret,
+  redactMcpSecrets,
+  validateMcpToolName,
+  type McpActor,
+  type McpDoctorResult,
+  type McpProbeResult,
+  type McpReadonlyCallInput,
+  type McpReadonlyCallResult,
+  type McpSourceStatusPayload,
+  type McpToolDescribeResult,
+  type McpToolSearchResult,
+} from "../shared"
+import { assertMcpPublicPayloadSecretFree, validateMcpSourceId } from "./sourceAccess"
+import type { BoringMcpSourceHandlers } from "./sourceHandlers"
+import type { McpToolDescribeInput, McpToolsSearchInput } from "./toolCatalog"
+
+export const BORING_MCP_AGENT_BRIDGE_TOOL_NAMES = [
+  "mcp_servers_list",
+  "mcp_server_status",
+  "mcp_server_doctor",
+  "mcp_server_probe",
+  "mcp_tools_search",
+  "mcp_tool_describe",
+  "mcp_readonly_call",
+] as const
+
+export type BoringMcpAgentBridgeToolName = (typeof BORING_MCP_AGENT_BRIDGE_TOOL_NAMES)[number]
+
+export interface BoringMcpAgentBridgeContext {
+  actor: McpActor
+}
+
+export interface BoringMcpAgentBridgeToolDefinition {
+  name: BoringMcpAgentBridgeToolName
+  description: string
+  inputSchema: Record<string, unknown>
+  readOnly: true
+}
+
+export interface BoringMcpAgentBridgeTool<TInput = unknown, TResult = unknown> extends BoringMcpAgentBridgeToolDefinition {
+  invoke(context: BoringMcpAgentBridgeContext, input: TInput): Promise<TResult>
+}
+
+export type BoringMcpAgentBridgeRegistry = Record<BoringMcpAgentBridgeToolName, BoringMcpAgentBridgeTool>
+
+const EMPTY_INPUT_SCHEMA = {
+  type: "object",
+  properties: {},
+  additionalProperties: false,
+} as const
+
+const SOURCE_ID_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    sourceId: { type: "string", description: "Stable boring-mcp source id." },
+  },
+  required: ["sourceId"],
+  additionalProperties: false,
+} as const
+
+const TOOL_SEARCH_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    sourceId: { type: "string", description: "Optional source id to search within." },
+    query: { type: "string", description: "Optional text query for tool name, summary, provider, or description." },
+    refresh: { type: "boolean", description: "Refresh provider tool metadata before searching." },
+  },
+  additionalProperties: false,
+} as const
+
+const TOOL_DESCRIBE_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    sourceId: { type: "string", description: "Stable boring-mcp source id." },
+    toolName: { type: "string", description: "Provider-native tool/action name." },
+    expectedSchemaHash: { type: "string", description: "Optional sha256 schema hash to detect drift." },
+    refresh: { type: "boolean", description: "Refresh provider tool metadata before describing." },
+  },
+  required: ["sourceId", "toolName"],
+  additionalProperties: false,
+} as const
+
+const READONLY_CALL_INPUT_SCHEMA = {
+  type: "object",
+  properties: {
+    sourceId: { type: "string", description: "Stable boring-mcp source id." },
+    toolName: { type: "string", description: "Read-only provider-native tool/action name." },
+    input: { description: "JSON-safe provider input for the read-only tool." },
+    expectedSchemaHash: { type: "string", description: "Optional lowercase sha256 schema hash to detect drift before execution." },
+  },
+  required: ["sourceId", "toolName"],
+  additionalProperties: false,
+} as const
+
+export const BORING_MCP_AGENT_BRIDGE_TOOL_DEFINITIONS: readonly BoringMcpAgentBridgeToolDefinition[] = [
+  { name: "mcp_servers_list", description: "List MCP sources available to the current actor.", inputSchema: EMPTY_INPUT_SCHEMA, readOnly: true },
+  { name: "mcp_server_status", description: "Get status and available actions for one MCP source.", inputSchema: SOURCE_ID_INPUT_SCHEMA, readOnly: true },
+  { name: "mcp_server_doctor", description: "Diagnose configuration/status issues for one MCP source without provider execution.", inputSchema: SOURCE_ID_INPUT_SCHEMA, readOnly: true },
+  { name: "mcp_server_probe", description: "Probe one connected MCP source for provider metadata and classified tools.", inputSchema: SOURCE_ID_INPUT_SCHEMA, readOnly: true },
+  { name: "mcp_tools_search", description: "Search normalized MCP tool catalog entries across connected sources or one source.", inputSchema: TOOL_SEARCH_INPUT_SCHEMA, readOnly: true },
+  { name: "mcp_tool_describe", description: "Describe one normalized MCP tool and report schema drift.", inputSchema: TOOL_DESCRIBE_INPUT_SCHEMA, readOnly: true },
+  { name: "mcp_readonly_call", description: "Execute one governed read-only MCP tool call.", inputSchema: READONLY_CALL_INPUT_SCHEMA, readOnly: true },
+]
+
+function requireActor(context: BoringMcpAgentBridgeContext | undefined): McpActor {
+  const actor = context?.actor
+  if (!actor || typeof actor.userId !== "string" || typeof actor.workspaceId !== "string") {
+    throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP bridge tools require an explicit actor")
+  }
+  return actor
+}
+
+function inputRecord(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP bridge input must be an object")
+  }
+  return input as Record<string, unknown>
+}
+
+function optionalInputRecord(input: unknown): Record<string, unknown> {
+  if (input === undefined) return {}
+  return inputRecord(input)
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key]
+  if (typeof value !== "string") throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, `MCP bridge ${key} must be a string`)
+  return value
+}
+
+function optionalStringField(record: Record<string, unknown>, key: string): string | undefined {
+  const value = record[key]
+  if (value === undefined) return undefined
+  if (typeof value !== "string") throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, `MCP bridge ${key} must be a string`)
+  return value
+}
+
+function optionalBooleanField(record: Record<string, unknown>, key: string): boolean | undefined {
+  const value = record[key]
+  if (value === undefined) return undefined
+  if (typeof value !== "boolean") throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, `MCP bridge ${key} must be a boolean`)
+  return value
+}
+
+function parseEmptyInput(input: unknown): void {
+  const record = optionalInputRecord(input)
+  if (Object.keys(record).length > 0) throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP bridge input must be empty")
+}
+
+function parseBridgeSourceId(sourceId: string): string {
+  try {
+    return validateMcpSourceId(sourceId)
+  } catch {
+    throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "MCP bridge sourceId is invalid")
+  }
+}
+
+function parseSourceInput(input: unknown): { sourceId: string } {
+  const record = inputRecord(input)
+  return { sourceId: parseBridgeSourceId(stringField(record, "sourceId")) }
+}
+
+function parseSearchInput(input: unknown): McpToolsSearchInput {
+  const record = optionalInputRecord(input)
+  const sourceId = optionalStringField(record, "sourceId")
+  return {
+    sourceId: sourceId === undefined ? undefined : parseBridgeSourceId(sourceId),
+    query: optionalStringField(record, "query"),
+    refresh: optionalBooleanField(record, "refresh"),
+  }
+}
+
+function parseDescribeInput(input: unknown): McpToolDescribeInput {
+  const record = inputRecord(input)
+  const toolName = stringField(record, "toolName")
+  validateMcpToolName(toolName)
+  return {
+    sourceId: parseBridgeSourceId(stringField(record, "sourceId")),
+    toolName,
+    expectedSchemaHash: optionalStringField(record, "expectedSchemaHash"),
+    refresh: optionalBooleanField(record, "refresh"),
+  }
+}
+
+function parseReadonlyInput(input: unknown): McpReadonlyCallInput {
+  const record = inputRecord(input)
+  const toolName = stringField(record, "toolName")
+  validateMcpToolName(toolName)
+  const expectedSchemaHash = optionalStringField(record, "expectedSchemaHash")
+  return {
+    sourceId: parseBridgeSourceId(stringField(record, "sourceId")),
+    toolName,
+    input: record.input,
+    expectedSchemaHash,
+  }
+}
+
+async function invokeGuarded<TResult>(fn: () => Promise<TResult>): Promise<TResult> {
+  try {
+    const result = await fn()
+    assertMcpPublicPayloadSecretFree(result)
+    return result
+  } catch (error) {
+    if (error instanceof McpError) {
+      const redactedDetails = redactMcpSecrets(error.details)
+      const safeMessage = containsMcpSecret(error.message) ? "MCP bridge tool failed" : error.message
+      throw new McpError(error.code, safeMessage, redactedDetails)
+    }
+    const redacted = redactMcpSecrets(error instanceof Error ? { name: error.name, message: error.message } : error)
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_ERROR, "MCP bridge tool failed", redacted)
+  }
+}
+
+function tool<TInput, TResult>(
+  definition: BoringMcpAgentBridgeToolDefinition,
+  invoke: (actor: McpActor, input: TInput) => Promise<TResult>,
+): BoringMcpAgentBridgeTool<TInput, TResult> {
+  return {
+    ...definition,
+    async invoke(context, input) {
+      const actor = requireActor(context)
+      return invokeGuarded(() => invoke(actor, input))
+    },
+  }
+}
+
+export function createBoringMcpAgentBridgeRegistry(handlers: BoringMcpSourceHandlers): BoringMcpAgentBridgeRegistry {
+  const byName = Object.fromEntries(BORING_MCP_AGENT_BRIDGE_TOOL_DEFINITIONS.map((definition) => [definition.name, definition])) as Record<BoringMcpAgentBridgeToolName, BoringMcpAgentBridgeToolDefinition>
+  return {
+    mcp_servers_list: tool(byName.mcp_servers_list, (actor, input: unknown) => {
+      parseEmptyInput(input)
+      return handlers.listSources(actor)
+    }),
+    mcp_server_status: tool(byName.mcp_server_status, (actor, input: unknown) => handlers.getSourceStatus(actor, parseSourceInput(input).sourceId)) as BoringMcpAgentBridgeTool<unknown, McpSourceStatusPayload>,
+    mcp_server_doctor: tool(byName.mcp_server_doctor, (actor, input: unknown) => handlers.doctorSource(actor, parseSourceInput(input).sourceId)) as BoringMcpAgentBridgeTool<unknown, McpDoctorResult>,
+    mcp_server_probe: tool(byName.mcp_server_probe, (actor, input: unknown) => handlers.probeSource(actor, parseSourceInput(input).sourceId)) as BoringMcpAgentBridgeTool<unknown, McpProbeResult>,
+    mcp_tools_search: tool(byName.mcp_tools_search, (actor, input: unknown) => handlers.mcp_tools_search(actor, parseSearchInput(input))) as BoringMcpAgentBridgeTool<unknown, McpToolSearchResult>,
+    mcp_tool_describe: tool(byName.mcp_tool_describe, (actor, input: unknown) => handlers.mcp_tool_describe(actor, parseDescribeInput(input))) as BoringMcpAgentBridgeTool<unknown, McpToolDescribeResult>,
+    mcp_readonly_call: tool(byName.mcp_readonly_call, (actor, input: unknown) => handlers.mcp_readonly_call(actor, parseReadonlyInput(input))) as BoringMcpAgentBridgeTool<unknown, McpReadonlyCallResult>,
+  }
+}
+
+export function listBoringMcpAgentBridgeTools(registry: BoringMcpAgentBridgeRegistry): BoringMcpAgentBridgeTool[] {
+  return BORING_MCP_AGENT_BRIDGE_TOOL_NAMES.map((name) => registry[name])
+}

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -14,6 +14,7 @@ export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPlugin
 }
 
 export default createBoringMcpServerPlugin()
+export * from "./agentBridge"
 export * from "./managedConnectorAdapter"
 export * from "./managedConnectorPreflight"
 export * from "./sourceHandlers"

--- a/plugins/boring-mcp/src/server/sourceHandlers.ts
+++ b/plugins/boring-mcp/src/server/sourceHandlers.ts
@@ -2,8 +2,10 @@ import {
   MCP_ERROR_CODES,
   McpAccessFacade,
   McpError,
+  doctorMcpSource,
   toMcpSourceDto,
   type McpActor,
+  type McpDoctorResult,
   type McpProbeResult,
   type McpProviderTemplate,
   type McpSourceDto,
@@ -30,6 +32,7 @@ export interface BoringMcpSourceHandlersOptions {
 export interface BoringMcpSourceHandlers {
   listSources(actor: McpActor): Promise<{ sources: McpSourceDto[] }>
   getSourceStatus(actor: McpActor, sourceId: string): Promise<McpSourceStatusPayload>
+  doctorSource(actor: McpActor, sourceId: string): Promise<McpDoctorResult>
   probeSource(actor: McpActor, sourceId: string): Promise<McpProbeResult>
   searchTools(actor: McpActor, input?: McpToolsSearchInput): Promise<McpToolSearchResult>
   describeTool(actor: McpActor, input: McpToolDescribeInput): Promise<McpToolDescribeResult>
@@ -53,7 +56,7 @@ export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOp
 
   return {
     async listSources(actor) {
-      const result = { sources: (await options.registry.listSources(actor)).map(toMcpSourceDto) }
+      const result = { sources: (await facade.listSources(actor)).map(toMcpSourceDto) }
       assertMcpPublicPayloadSecretFree(result)
       return result
     },
@@ -61,6 +64,13 @@ export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOp
     async getSourceStatus(actor, sourceId) {
       const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
       return createMcpSourceStatusPayload(source)
+    },
+
+    async doctorSource(actor, sourceId) {
+      const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
+      const result = doctorMcpSource(source, options.templates)
+      assertMcpPublicPayloadSecretFree(result)
+      return result
     },
 
     async probeSource(actor, sourceId) {

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -308,7 +308,7 @@ export function containsMcpSecret(value: unknown): boolean {
   return JSON.stringify(redacted) !== JSON.stringify(value)
 }
 
-export function doctorMcpSource(source: McpSource, templates = DEFAULT_MCP_PROVIDER_TEMPLATES): McpDoctorResult {
+export function doctorMcpSource(source: McpSource, templates: readonly McpProviderTemplate[] = DEFAULT_MCP_PROVIDER_TEMPLATES): McpDoctorResult {
   const issues: McpDoctorIssue[] = []
   if (!getMcpProviderTemplate(source.provider, templates)) {
     issues.push({ level: "error", code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, message: "Unknown MCP provider template" })


### PR DESCRIPTION
## Summary
- add thin boring-mcp agent bridge registry for exactly seven tools
- expose stable tool definitions/input schemas for list/status/doctor/probe/search/describe/read-only call
- require explicit actor context and bridge-level input parsing before handlers
- delegate to existing source/catalog/readonly handlers; no new provider execution path
- make source listing access-filtered via `McpAccessFacade.listSources`

## Validation
- `pnpm --filter @hachej/boring-mcp test`: 55 passed
- `pnpm --filter @hachej/boring-mcp typecheck`: pass
- `pnpm --filter @hachej/boring-mcp build`: pass
- `pnpm lint:workspace-plugin-invariants`: pass
- `git diff --check`: pass
- non-test/non-doc line count: 261

## Reviews
- worker implementation complete
- thermo review RED -> fixed bridge input validation, malformed-id handling, list access filtering
- thermo re-review: GREEN
- independent reviewer: GREEN
