### PR TITLE
mcp-integration: Add boring-mcp production hardening gate

### DIFF
--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -53,6 +53,18 @@ Managed connector adapters must pass the [Composio security preflight](./docs/co
 - Mutating/admin tool names are denied before any provider call.
 - Provider results pass redaction and secret-leak checks before agent/UI use.
 
+## Production launch gate / smoke checklist
+
+Before enabling boring-mcp in a shipped app, operators should verify:
+
+1. `evaluateBoringMcpLaunchGate` passes for the app composition: plugin id, registry list/get/disconnect, transport, provider templates, all seven bridge tools, timeout, rate/budget gate, readonly input limit, and reviewed docs.
+2. Managed providers pass `validateManagedConnectorPreflight`; app secrets stay server-side and never appear in browser/workspace files.
+3. Source list/status/probe/tool catalog/read-only call responses pass the secret-leak guard using representative OAuth/session canaries.
+4. Provider metadata calls use timeout + retry policy; read-only tool calls use timeout but no automatic retry.
+5. Rate/budget hooks block before provider `listTools`/`callTool` when local limits are exceeded.
+6. Disconnect/revoke is verified through the injected registry status/result and never performs provider tool execution.
+7. Local smoke with a fake managed connector: connect -> status connected -> search tools -> describe tool -> governed readonly call -> disconnect -> verify non-connected status.
+
 ## Current status
 
-Foundation plus source handlers, executable preflight, generic managed connector adapter seam, normalized tool catalog search/describe, governed fake-transport-testable read-only execution, and exported agent bridge tool definitions. Real Composio SDK/API calls, route/app registration, and Constellation binding land in later PRs.
+Foundation plus source handlers, executable preflight, generic managed connector adapter seam, normalized tool catalog search/describe, governed fake-transport-testable read-only execution, exported agent bridge tool definitions, and production launch-gate helpers. Real Composio SDK/API calls, route/app registration, and Constellation binding land in later PRs.

--- a/plugins/boring-mcp/src/__tests__/hardening.test.ts
+++ b/plugins/boring-mcp/src/__tests__/hardening.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest"
+import { BORING_MCP_AGENT_BRIDGE_TOOL_NAMES, createBoringMcpAgentBridgeRegistry } from "../server/agentBridge"
+import {
+  createHardenedMcpTransport,
+  evaluateBoringMcpLaunchGate,
+  InMemoryMcpRateBudgetGate,
+  verifyMcpDisconnectResult,
+} from "../server/hardening"
+import { createBoringMcpSourceHandlers } from "../server/sourceHandlers"
+import {
+  BORING_MCP_PLUGIN_ID,
+  MCP_ERROR_CODES,
+  NOTION_MCP_TEMPLATE,
+  containsMcpSecret,
+  redactMcpSecrets,
+  type McpActor,
+  type McpReadonlyCallAuditEvent,
+  type McpSource,
+  type McpSourceRegistry,
+  type McpTransportClient,
+} from "../shared"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+
+const source: McpSource = {
+  id: "source:notion:user-1",
+  workspaceId: actor.workspaceId,
+  userId: actor.userId,
+  provider: "notion",
+  displayName: "Notion",
+  status: "connected",
+  ownerKind: "user",
+  credentialProvider: "composio-managed",
+}
+
+function registry(current: McpSource = source): McpSourceRegistry {
+  return {
+    async listSources(requestActor) {
+      return requestActor.userId === current.userId && requestActor.workspaceId === current.workspaceId ? [current] : []
+    },
+    async getSource(sourceId) {
+      return sourceId === current.id ? current : undefined
+    },
+    async disconnectSource() {
+      return { ...current, status: "revoked" }
+    },
+  }
+}
+
+function transport(overrides: Partial<McpTransportClient> = {}): McpTransportClient {
+  return {
+    listTools: vi.fn(async () => [{ name: "NOTION_SEARCH_NOTION_PAGE", description: "Search pages" }]),
+    listResources: vi.fn(async () => []),
+    readResource: vi.fn(),
+    callTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+    ...overrides,
+  }
+}
+
+function flushMicrotasks(): Promise<void> {
+  return Promise.resolve()
+}
+
+describe("boring-mcp production hardening", () => {
+  it("covers representative redaction canaries for public/audit/error payloads", () => {
+    const sourcePayload = { displayName: "access_token=abcdefghijklmnop" }
+    const toolPayload = { description: "x-composio-mcp-session: abcdefghijklmnop" }
+    const auditPayload: McpReadonlyCallAuditEvent = {
+      operation: "mcp_readonly_call",
+      outcome: "failure",
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      sourceId: "source:notion:user-1",
+      toolName: "NOTION_SEARCH_NOTION_PAGE",
+      code: "MCP_PROVIDER_ERROR",
+    }
+    const errorPayload = { message: "provider leaked client_secret=abcdefghijklmnop" }
+
+    expect(containsMcpSecret(sourcePayload)).toBe(true)
+    expect(containsMcpSecret(toolPayload)).toBe(true)
+    expect(containsMcpSecret(auditPayload)).toBe(false)
+    expect(redactMcpSecrets(errorPayload)).toEqual({ message: "provider leaked [REDACTED_MCP_SECRET]" })
+  })
+
+  it("rate/budget gate blocks before provider listTools and callTool", async () => {
+    const callTx = transport()
+    const callHardened = createHardenedMcpTransport(callTx, { gate: new InMemoryMcpRateBudgetGate({ maxCalls: 10, maxToolCalls: 0, windowMs: 60_000 }) }, actor)
+    await expect(callHardened.callTool(source, "NOTION_SEARCH_NOTION_PAGE", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED })
+    expect(callTx.callTool).not.toHaveBeenCalled()
+
+    const metadataTx = transport()
+    const metadataHardened = createHardenedMcpTransport(metadataTx, { gate: new InMemoryMcpRateBudgetGate({ maxCalls: 1, windowMs: 60_000 }) }, actor)
+    await metadataHardened.listTools(source)
+    await expect(metadataHardened.listTools(source)).rejects.toMatchObject({ code: MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED })
+    expect(metadataTx.listTools).toHaveBeenCalledOnce()
+  })
+
+  it("rate/budget gate accounts for each metadata retry attempt", async () => {
+    const tx = transport({
+      listTools: vi.fn()
+        .mockRejectedValueOnce(new Error("temporary upstream failure"))
+        .mockResolvedValueOnce([{ name: "NOTION_SEARCH_NOTION_PAGE" }]),
+    })
+    const hardened = createHardenedMcpTransport(tx, {
+      gate: new InMemoryMcpRateBudgetGate({ maxCalls: 1, windowMs: 60_000 }),
+      metadataRetries: 1,
+    }, actor)
+
+    await expect(hardened.listTools(source)).rejects.toMatchObject({ code: MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED })
+    expect(tx.listTools).toHaveBeenCalledOnce()
+  })
+
+  it("normalizes and redacts provider metadata errors at the hardened boundary", async () => {
+    const tx = transport({ listTools: vi.fn(async () => { throw new Error("provider leaked api_key=abcdefghijklmnop") }) })
+    const hardened = createHardenedMcpTransport(tx, {}, actor)
+
+    await expect(hardened.listTools(source)).rejects.toMatchObject({
+      code: MCP_ERROR_CODES.PROVIDER_ERROR,
+      details: { message: "provider leaked [REDACTED_MCP_SECRET]" },
+    })
+  })
+
+  it("readonly calls preserve hardening rate-limit codes", async () => {
+    const tx = transport()
+    const handlers = createBoringMcpSourceHandlers({
+      registry: registry(),
+      transport: tx,
+      hardening: { gate: new InMemoryMcpRateBudgetGate({ maxCalls: 10, maxToolCalls: 0, windowMs: 60_000 }) },
+    })
+
+    await expect(handlers.mcp_readonly_call(actor, { sourceId: source.id, toolName: "NOTION_SEARCH_NOTION_PAGE" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED })
+    expect(tx.callTool).not.toHaveBeenCalled()
+  })
+
+  it("provider timeout returns stable code without provider details", async () => {
+    vi.useFakeTimers()
+    const tx = transport({ listTools: vi.fn(() => new Promise(() => undefined)) as never })
+    const hardened = createHardenedMcpTransport(tx, { timeoutMs: 5 }, actor)
+    const promise = hardened.listTools(source)
+    const expectation = expect(promise).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_TIMEOUT, details: undefined })
+
+    await vi.advanceTimersByTimeAsync(5)
+    await flushMicrotasks()
+
+    await expectation
+    vi.useRealTimers()
+  })
+
+  it("disconnect verification checks registry status and never calls provider execution", async () => {
+    const tx = transport()
+    const revoked = { ...source, status: "revoked" as const }
+    const verified = await verifyMcpDisconnectResult(registry(revoked), actor, source.id, revoked)
+
+    expect(verified.source.status).toBe("revoked")
+    expect(tx.listTools).not.toHaveBeenCalled()
+    expect(tx.callTool).not.toHaveBeenCalled()
+
+    await expect(verifyMcpDisconnectResult(registry(source), actor, source.id, source)).rejects.toMatchObject({ code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE })
+  })
+
+  it("launch gate reports missing invariants with stable codes and passes fake configured stack", () => {
+    const incompleteTransport = { listTools: vi.fn(), listResources: vi.fn(), callTool: vi.fn() } as unknown as McpTransportClient
+    expect(evaluateBoringMcpLaunchGate({ pluginId: BORING_MCP_PLUGIN_ID, transport: incompleteTransport }).issues.map((entry) => entry.code)).toContain("MCP_LAUNCH_TRANSPORT_MISSING")
+
+    const failed = evaluateBoringMcpLaunchGate({ pluginId: "wrong" })
+    expect(failed.ok).toBe(false)
+    expect(failed.issues.map((entry) => entry.code)).toEqual(expect.arrayContaining([
+      "MCP_LAUNCH_PLUGIN_MISSING",
+      "MCP_LAUNCH_REGISTRY_INCOMPLETE",
+      "MCP_LAUNCH_TRANSPORT_MISSING",
+      "MCP_LAUNCH_BRIDGE_TOOL_MISSING",
+      "MCP_LAUNCH_RATE_BUDGET_MISSING",
+      "MCP_LAUNCH_TIMEOUT_MISSING",
+    ]))
+
+    const tx = transport()
+    const handlers = createBoringMcpSourceHandlers({ registry: registry(), transport: tx })
+    const bridge = createBoringMcpAgentBridgeRegistry(handlers)
+    const passed = evaluateBoringMcpLaunchGate({
+      pluginId: BORING_MCP_PLUGIN_ID,
+      registry: registry(),
+      transport: tx,
+      bridge,
+      templates: [NOTION_MCP_TEMPLATE],
+      hardening: { gate: new InMemoryMcpRateBudgetGate({ maxCalls: 10, maxToolCalls: 5, windowMs: 60_000 }), timeoutMs: 1000 },
+      maxReadonlyInputBytes: 1024,
+      docsReviewed: true,
+    })
+
+    expect(BORING_MCP_AGENT_BRIDGE_TOOL_NAMES.every((name) => bridge[name])).toBe(true)
+    expect(passed).toEqual({ ok: true, issues: [] })
+  })
+})

--- a/plugins/boring-mcp/src/server/hardening.ts
+++ b/plugins/boring-mcp/src/server/hardening.ts
@@ -1,0 +1,217 @@
+import {
+  BORING_MCP_PLUGIN_ID,
+  MCP_ERROR_CODES,
+  McpError,
+  containsMcpSecret,
+  redactMcpSecrets,
+  type McpActor,
+  type McpProviderTemplate,
+  type McpSource,
+  type McpSourceRegistry,
+  type McpTransportClient,
+} from "../shared"
+import { BORING_MCP_AGENT_BRIDGE_TOOL_NAMES, type BoringMcpAgentBridgeRegistry } from "./agentBridge"
+import { assertMcpPublicPayloadSecretFree, createMcpSourceStatusPayload, isActorOwnedMcpSource } from "./sourceAccess"
+
+export type McpProviderOperation = "listTools" | "listResources" | "readResource" | "callTool"
+
+export interface McpProviderCallContext {
+  actor?: McpActor
+  sourceId: string
+  operation: McpProviderOperation
+  toolName?: string
+}
+
+export interface McpProviderRateBudgetGate {
+  check(context: McpProviderCallContext): void | Promise<void>
+}
+
+export interface McpProviderHardeningOptions {
+  timeoutMs?: number
+  metadataRetries?: number
+  gate?: McpProviderRateBudgetGate
+}
+
+export interface InMemoryMcpRateBudgetGateOptions {
+  maxCalls: number
+  windowMs: number
+  maxToolCalls?: number
+}
+
+export class InMemoryMcpRateBudgetGate implements McpProviderRateBudgetGate {
+  private readonly buckets = new Map<string, { startedAt: number; calls: number; toolCalls: number }>()
+
+  constructor(private readonly options: InMemoryMcpRateBudgetGateOptions) {}
+
+  check(context: McpProviderCallContext): void {
+    const now = Date.now()
+    const key = `${context.actor?.workspaceId ?? "unknown"}:${context.actor?.userId ?? "unknown"}:${context.sourceId}`
+    const current = this.buckets.get(key)
+    const bucket = current && now - current.startedAt < this.options.windowMs
+      ? current
+      : { startedAt: now, calls: 0, toolCalls: 0 }
+    bucket.calls += 1
+    if (context.operation === "callTool") bucket.toolCalls += 1
+    this.buckets.set(key, bucket)
+
+    if (bucket.calls > this.options.maxCalls) {
+      throw new McpError(MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED, "MCP provider rate budget exceeded")
+    }
+    if (this.options.maxToolCalls !== undefined && bucket.toolCalls > this.options.maxToolCalls) {
+      throw new McpError(MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED, "MCP provider tool-call budget exceeded")
+    }
+  }
+}
+
+function isAbortLike(error: unknown): boolean {
+  return error instanceof Error && (error.name === "AbortError" || error.name === "TimeoutError")
+}
+
+async function withProviderTimeout<T>(operation: () => Promise<T>, timeoutMs?: number): Promise<T> {
+  if (!timeoutMs || timeoutMs <= 0) return operation()
+  let timeout: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      operation(),
+      new Promise<T>((_, reject) => {
+        timeout = setTimeout(() => reject(new McpError(MCP_ERROR_CODES.PROVIDER_TIMEOUT, "MCP provider operation timed out")), timeoutMs)
+      }),
+    ])
+  } catch (error) {
+    if (error instanceof McpError && error.code === MCP_ERROR_CODES.PROVIDER_TIMEOUT) throw error
+    if (isAbortLike(error)) throw new McpError(MCP_ERROR_CODES.PROVIDER_TIMEOUT, "MCP provider operation timed out")
+    throw error
+  } finally {
+    if (timeout) clearTimeout(timeout)
+  }
+}
+
+async function withMetadataRetry<T>(operation: () => Promise<T>, retries: number): Promise<T> {
+  let lastError: unknown
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await operation()
+    } catch (error) {
+      if (error instanceof McpError) throw error
+      lastError = error
+    }
+  }
+  throw lastError
+}
+
+function normalizeProviderError(error: unknown): never {
+  if (error instanceof McpError) {
+    const safeMessage = containsMcpSecret(error.message) ? "MCP provider operation failed" : error.message
+    throw new McpError(error.code, safeMessage, redactMcpSecrets(error.details))
+  }
+  const details = redactMcpSecrets(error instanceof Error ? { name: error.name, message: error.message } : error)
+  throw new McpError(MCP_ERROR_CODES.PROVIDER_ERROR, "MCP provider operation failed", details)
+}
+
+export function createHardenedMcpTransport(
+  transport: McpTransportClient,
+  options: McpProviderHardeningOptions = {},
+  actor?: McpActor,
+): McpTransportClient {
+  async function guard<T>(context: Omit<McpProviderCallContext, "actor">, operation: () => Promise<T>, retryMetadata = false): Promise<T> {
+    const run = async () => {
+      await options.gate?.check({ ...context, actor })
+      return withProviderTimeout(operation, options.timeoutMs)
+    }
+    try {
+      return retryMetadata ? await withMetadataRetry(run, options.metadataRetries ?? 0) : await run()
+    } catch (error) {
+      normalizeProviderError(error)
+    }
+  }
+
+  return {
+    listTools(source) {
+      return guard({ sourceId: source.id, operation: "listTools" }, () => transport.listTools(source), true)
+    },
+    listResources(source) {
+      return guard({ sourceId: source.id, operation: "listResources" }, () => transport.listResources(source), true)
+    },
+    readResource(source, uri) {
+      return guard({ sourceId: source.id, operation: "readResource" }, () => transport.readResource(source, uri), true)
+    },
+    callTool(source, toolName, input) {
+      return guard({ sourceId: source.id, operation: "callTool", toolName }, () => transport.callTool(source, toolName, input), false)
+    },
+  }
+}
+
+export async function verifyMcpDisconnectResult(
+  registry: McpSourceRegistry,
+  actor: McpActor,
+  sourceId: string,
+  disconnected: McpSource | undefined,
+) {
+  if (!isActorOwnedMcpSource(actor, disconnected)) {
+    throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
+  }
+  const disconnectedSource = disconnected
+  const latest = await registry.getSource(sourceId)
+  const source = isActorOwnedMcpSource(actor, latest) ? latest : disconnectedSource
+  if (source.status === "connected") {
+    throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source disconnect verification failed")
+  }
+  const result = createMcpSourceStatusPayload(source)
+  assertMcpPublicPayloadSecretFree(result)
+  return result
+}
+
+export interface BoringMcpLaunchGateInput {
+  pluginId?: string
+  registry?: McpSourceRegistry
+  transport?: McpTransportClient
+  bridge?: Partial<BoringMcpAgentBridgeRegistry>
+  templates?: readonly McpProviderTemplate[]
+  hardening?: McpProviderHardeningOptions
+  maxReadonlyInputBytes?: number
+  docsReviewed?: boolean
+}
+
+export type BoringMcpLaunchGateIssueCode =
+  | "MCP_LAUNCH_PLUGIN_MISSING"
+  | "MCP_LAUNCH_REGISTRY_INCOMPLETE"
+  | "MCP_LAUNCH_TRANSPORT_MISSING"
+  | "MCP_LAUNCH_BRIDGE_TOOL_MISSING"
+  | "MCP_LAUNCH_TEMPLATES_MISSING"
+  | "MCP_LAUNCH_RATE_BUDGET_MISSING"
+  | "MCP_LAUNCH_TIMEOUT_MISSING"
+  | "MCP_LAUNCH_INPUT_LIMIT_MISSING"
+  | "MCP_LAUNCH_OPERATOR_DOCS_MISSING"
+  | "MCP_LAUNCH_SECRET_LEAK"
+
+export interface BoringMcpLaunchGateIssue {
+  level: "error"
+  code: BoringMcpLaunchGateIssueCode
+  message: string
+}
+
+export interface BoringMcpLaunchGateResult {
+  ok: boolean
+  issues: BoringMcpLaunchGateIssue[]
+}
+
+function issue(code: BoringMcpLaunchGateIssueCode, message: string): BoringMcpLaunchGateIssue {
+  return { level: "error", code, message }
+}
+
+export function evaluateBoringMcpLaunchGate(input: BoringMcpLaunchGateInput): BoringMcpLaunchGateResult {
+  const issues: BoringMcpLaunchGateIssue[] = []
+  if (input.pluginId !== BORING_MCP_PLUGIN_ID) issues.push(issue("MCP_LAUNCH_PLUGIN_MISSING", "boring-mcp plugin id is not enabled"))
+  if (!input.registry?.listSources || !input.registry.getSource || !input.registry.disconnectSource) issues.push(issue("MCP_LAUNCH_REGISTRY_INCOMPLETE", "source registry must support list/get/disconnect"))
+  if (!input.transport?.listTools || !input.transport.listResources || !input.transport.readResource || !input.transport.callTool) issues.push(issue("MCP_LAUNCH_TRANSPORT_MISSING", "MCP transport client is not configured"))
+  for (const name of BORING_MCP_AGENT_BRIDGE_TOOL_NAMES) {
+    if (!input.bridge?.[name]) issues.push(issue("MCP_LAUNCH_BRIDGE_TOOL_MISSING", `missing bridge tool ${name}`))
+  }
+  if (!input.templates?.length) issues.push(issue("MCP_LAUNCH_TEMPLATES_MISSING", "at least one provider template must be configured"))
+  if (!input.hardening?.gate) issues.push(issue("MCP_LAUNCH_RATE_BUDGET_MISSING", "rate/budget gate is not configured"))
+  if (!input.hardening?.timeoutMs || input.hardening.timeoutMs <= 0) issues.push(issue("MCP_LAUNCH_TIMEOUT_MISSING", "provider timeout is not configured"))
+  if (!input.maxReadonlyInputBytes || input.maxReadonlyInputBytes <= 0) issues.push(issue("MCP_LAUNCH_INPUT_LIMIT_MISSING", "read-only input byte limit is not configured"))
+  if (!input.docsReviewed) issues.push(issue("MCP_LAUNCH_OPERATOR_DOCS_MISSING", "operator smoke checklist has not been reviewed"))
+  if (containsMcpSecret(input)) issues.push(issue("MCP_LAUNCH_SECRET_LEAK", "launch gate input looked like it contained a secret"))
+  return { ok: issues.length === 0, issues }
+}

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -15,6 +15,7 @@ export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPlugin
 
 export default createBoringMcpServerPlugin()
 export * from "./agentBridge"
+export * from "./hardening"
 export * from "./managedConnectorAdapter"
 export * from "./managedConnectorPreflight"
 export * from "./sourceHandlers"

--- a/plugins/boring-mcp/src/server/readonlyCall.ts
+++ b/plugins/boring-mcp/src/server/readonlyCall.ts
@@ -16,7 +16,7 @@ import {
   type McpTransportClient,
 } from "../shared"
 import { assertMcpPublicPayloadSecretFree, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
-import { createBoringMcpToolCatalog } from "./toolCatalog"
+import { createBoringMcpToolCatalog, type McpToolCatalogCache } from "./toolCatalog"
 
 export interface McpReadonlyCallAuditSink {
   record(event: McpReadonlyCallAuditEvent): void | Promise<void>
@@ -28,6 +28,7 @@ export interface BoringMcpReadonlyCallOptions {
   templates?: readonly McpProviderTemplate[]
   maxInputBytes?: number
   audit?: McpReadonlyCallAuditSink
+  catalogCache?: McpToolCatalogCache
 }
 
 export interface BoringMcpReadonlyCaller {
@@ -167,7 +168,7 @@ function auditSchemaHash(value: unknown): string | undefined {
 }
 
 export function createBoringMcpReadonlyCaller(options: BoringMcpReadonlyCallOptions): BoringMcpReadonlyCaller {
-  const catalog = createBoringMcpToolCatalog(options)
+  const catalog = createBoringMcpToolCatalog({ ...options, cache: options.catalogCache })
   const maxInputBytes = options.maxInputBytes ?? DEFAULT_MAX_INPUT_BYTES
 
   async function record(event: McpReadonlyCallAuditEvent): Promise<void> {
@@ -209,6 +210,12 @@ export function createBoringMcpReadonlyCaller(options: BoringMcpReadonlyCallOpti
         try {
           providerResult = await options.transport.callTool(source, parsed.toolName, parsed.toolInput)
         } catch (error) {
+          if (error instanceof McpError) {
+            const safeMessage = containsMcpSecret(error.message) ? "MCP provider tool call failed" : error.message
+            await record(auditEvent(actor, request, "failure", error.code))
+            audited = true
+            throw new McpError(error.code, safeMessage, redactMcpSecrets(error.details))
+          }
           const redacted = redactMcpSecrets(error instanceof Error ? { name: error.name, message: error.message } : error)
           await record(auditEvent(actor, request, "failure", MCP_ERROR_CODES.PROVIDER_ERROR))
           audited = true

--- a/plugins/boring-mcp/src/server/sourceHandlers.ts
+++ b/plugins/boring-mcp/src/server/sourceHandlers.ts
@@ -17,9 +17,10 @@ import {
   type McpToolSearchResult,
   type McpTransportClient,
 } from "../shared"
-import { assertMcpPublicPayloadSecretFree, createMcpSourceStatusPayload, isActorOwnedMcpSource, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
+import { createHardenedMcpTransport, verifyMcpDisconnectResult, type McpProviderHardeningOptions } from "./hardening"
+import { assertMcpPublicPayloadSecretFree, createMcpSourceStatusPayload, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
 import { createBoringMcpReadonlyCaller, type McpReadonlyCallAuditSink } from "./readonlyCall"
-import { createBoringMcpToolCatalog, type McpToolDescribeInput, type McpToolsSearchInput } from "./toolCatalog"
+import { InMemoryMcpToolCatalogCache, createBoringMcpToolCatalog, type McpToolDescribeInput, type McpToolsSearchInput } from "./toolCatalog"
 
 export interface BoringMcpSourceHandlersOptions {
   registry: McpSourceRegistry
@@ -27,6 +28,7 @@ export interface BoringMcpSourceHandlersOptions {
   templates?: readonly McpProviderTemplate[]
   maxReadonlyInputBytes?: number
   audit?: McpReadonlyCallAuditSink
+  hardening?: McpProviderHardeningOptions
 }
 
 export interface BoringMcpSourceHandlers {
@@ -44,19 +46,34 @@ export interface BoringMcpSourceHandlers {
 }
 
 export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOptions): BoringMcpSourceHandlers {
-  const facade = new McpAccessFacade({ store: options.registry, transport: options.transport, templates: options.templates })
-  const catalog = createBoringMcpToolCatalog(options)
-  const readonlyCaller = createBoringMcpReadonlyCaller({
-    registry: options.registry,
-    transport: options.transport,
-    templates: options.templates,
-    maxInputBytes: options.maxReadonlyInputBytes,
-    audit: options.audit,
-  })
+  const catalogCache = new InMemoryMcpToolCatalogCache()
+
+  function transportFor(actor: McpActor) {
+    return createHardenedMcpTransport(options.transport, options.hardening, actor)
+  }
+
+  function facadeFor(actor: McpActor) {
+    return new McpAccessFacade({ store: options.registry, transport: transportFor(actor), templates: options.templates })
+  }
+
+  function catalogFor(actor: McpActor) {
+    return createBoringMcpToolCatalog({ ...options, transport: transportFor(actor), cache: catalogCache })
+  }
+
+  function readonlyCallerFor(actor: McpActor) {
+    return createBoringMcpReadonlyCaller({
+      registry: options.registry,
+      transport: transportFor(actor),
+      templates: options.templates,
+      maxInputBytes: options.maxReadonlyInputBytes,
+      audit: options.audit,
+      catalogCache,
+    })
+  }
 
   return {
     async listSources(actor) {
-      const result = { sources: (await facade.listSources(actor)).map(toMcpSourceDto) }
+      const result = { sources: (await facadeFor(actor).listSources(actor)).map(toMcpSourceDto) }
       assertMcpPublicPayloadSecretFree(result)
       return result
     },
@@ -75,33 +92,33 @@ export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOp
 
     async probeSource(actor, sourceId) {
       const normalizedSourceId = validateMcpSourceId(sourceId)
-      const result = await facade.probeSource(actor, normalizedSourceId)
+      const result = await facadeFor(actor).probeSource(actor, normalizedSourceId)
       assertMcpPublicPayloadSecretFree(result)
       return result
     },
 
     async searchTools(actor, input) {
-      return catalog.searchTools(actor, input)
+      return catalogFor(actor).searchTools(actor, input)
     },
 
     async describeTool(actor, input) {
-      return catalog.describeTool(actor, input)
+      return catalogFor(actor).describeTool(actor, input)
     },
 
     async mcp_tools_search(actor, input) {
-      return catalog.searchTools(actor, input)
+      return catalogFor(actor).searchTools(actor, input)
     },
 
     async mcp_tool_describe(actor, input) {
-      return catalog.describeTool(actor, input)
+      return catalogFor(actor).describeTool(actor, input)
     },
 
     async callReadonly(actor, input) {
-      return readonlyCaller.callReadonly(actor, input)
+      return readonlyCallerFor(actor).callReadonly(actor, input)
     },
 
     async mcp_readonly_call(actor, input) {
-      return readonlyCaller.callReadonly(actor, input)
+      return readonlyCallerFor(actor).callReadonly(actor, input)
     },
 
     async disconnectSource(actor, sourceId) {
@@ -111,10 +128,7 @@ export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOp
         throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source disconnect is not configured")
       }
       const source = await options.registry.disconnectSource(actor, normalizedSourceId)
-      if (!isActorOwnedMcpSource(actor, source)) {
-        throw new McpError(MCP_ERROR_CODES.SOURCE_NOT_FOUND, "MCP source not found")
-      }
-      return createMcpSourceStatusPayload(source)
+      return verifyMcpDisconnectResult(options.registry, actor, normalizedSourceId, source)
     },
   }
 }


### PR DESCRIPTION
## Summary
- add production hardening helpers for boring-mcp provider calls: rate/budget gate, timeout wrapper, metadata retry policy, provider error normalization/redaction
- wire source handlers through actor-scoped hardened transports while preserving shared catalog cache lifecycle
- add disconnect verification helper and launch gate checklist/result types with stable launch codes
- document operator smoke checklist

## Validation
- `pnpm --filter @hachej/boring-mcp test`: 63 passed
- `pnpm --filter @hachej/boring-mcp typecheck`: pass
- `pnpm --filter @hachej/boring-mcp build`: pass
- `pnpm lint:workspace-plugin-invariants`: pass
- `git diff --check`: pass
- non-test/non-doc line count: 264

## Reviews
- worker implementation complete
- thermo review RED -> fixed cache lifecycle, retry/gate accounting, dedicated launch-gate codes, full transport checks, hardened error redaction, readonly error-code preservation
- thermo final: GREEN
- independent reviewer final: GREEN
