### PR TITLE
mcp-integration: Add reusable Composio connector

### DIFF
--- a/apps/full-app/src/server/boringMcp.ts
+++ b/apps/full-app/src/server/boringMcp.ts
@@ -5,6 +5,7 @@ import {
   createBoringMcpAgentBridgeRegistry,
   createBoringMcpServerPlugin,
   createBoringMcpSourceHandlers,
+  createComposioManagedConnectorProvider,
   createManagedConnectorAdapter,
   evaluateBoringMcpLaunchGate,
   type BoringMcpLaunchGateResult,
@@ -82,11 +83,11 @@ const FULL_APP_MANAGED_CONNECTOR_PREFLIGHT = {
 export function createFullAppManagedConnectorAdapter(options: {
   env?: NodeJS.ProcessEnv
   registry: ManagedConnectorSourceRegistry
-  provider: ManagedConnectorProvider
+  provider?: ManagedConnectorProvider
 }): ManagedConnectorAdapter {
   return createManagedConnectorAdapter({
     registry: options.registry,
-    provider: options.provider,
+    provider: options.provider ?? createComposioManagedConnectorProvider(),
     secretResolver: createFullAppManagedConnectorSecretResolver(options.env),
     templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
     preflightEvidence: FULL_APP_MANAGED_CONNECTOR_PREFLIGHT,

--- a/apps/full-app/src/server/boringMcp.ts
+++ b/apps/full-app/src/server/boringMcp.ts
@@ -56,29 +56,7 @@ export function createFullAppManagedConnectorSecretResolver(env: NodeJS.ProcessE
   }
 }
 
-const FULL_APP_MANAGED_CONNECTOR_PREFLIGHT = {
-  connectorName: 'Composio managed MCP',
-  isolatedTestProject: true,
-  apiKeyStorage: 'server-env' as const,
-  browserDtoSamples: [{ status: 'unconfigured', provider: 'notion' }],
-  redactedLogSamples: [{ message: 'connector configured with [REDACTED_MCP_SECRET]' }],
-  redactedProviderResultSamples: [{ status: 'connected', account: 'fake-user' }],
-  redactionCanaries: ['cmp_full_app_canary'],
-  revokeDisconnectVerified: true,
-  connectedAccountStatusVerified: true,
-  vendorRisk: {
-    dpaStatus: 'owner-accepted-gap' as const,
-    subprocessorStatus: 'owner-accepted-gap' as const,
-    dataResidencyStatus: 'owner-accepted-gap' as const,
-    incidentHistoryStatus: 'owner-accepted-gap' as const,
-    acceptedGaps: [
-      { id: 'dpaStatus', owner: 'app-owner', followUp: 'Review Composio DPA before production provider enablement', reason: 'Generic binding only; no real provider calls in this app smoke' },
-      { id: 'subprocessorStatus', owner: 'app-owner', followUp: 'Review Composio subprocessors before production provider enablement', reason: 'Generic binding only; no real provider calls in this app smoke' },
-      { id: 'dataResidencyStatus', owner: 'app-owner', followUp: 'Review Composio data residency before production provider enablement', reason: 'Generic binding only; no real provider calls in this app smoke' },
-      { id: 'incidentHistoryStatus', owner: 'app-owner', followUp: 'Review Composio incident history before production provider enablement', reason: 'Generic binding only; no real provider calls in this app smoke' },
-    ],
-  },
-}
+const FULL_APP_MCP_REDACTION_CANARIES = ['cmp_full_app_canary'] as const
 
 export function createFullAppManagedConnectorAdapter(options: {
   env?: NodeJS.ProcessEnv
@@ -90,7 +68,7 @@ export function createFullAppManagedConnectorAdapter(options: {
     provider: options.provider ?? createComposioManagedConnectorProvider(),
     secretResolver: createFullAppManagedConnectorSecretResolver(options.env),
     templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
-    preflightEvidence: FULL_APP_MANAGED_CONNECTOR_PREFLIGHT,
+    redactionCanaries: FULL_APP_MCP_REDACTION_CANARIES,
     configs: [
       { provider: 'notion', displayName: 'Notion', toolkitId: 'notion', connectUrlOrigins: ['https://app.composio.dev'] },
       { provider: 'airtable', displayName: 'Airtable', toolkitId: 'airtable', connectUrlOrigins: ['https://app.composio.dev'] },

--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -7,13 +7,15 @@ This package is the generic MCP capability that child apps can enable. It owns:
 - generic Sources left-tab and MCP Sources panel shell;
 - provider template, source, tool, policy, redaction, status, and facade contracts;
 - deny-before-allow read-only policy helpers;
+- reusable Composio managed connector provider for hosted OAuth/session onboarding;
+- MCP SDK Streamable HTTP transport for real MCP-compatible endpoints, including Composio session MCP URLs;
 - fake-transport-testable facade seams;
 - normalized tool catalog search/describe contracts;
 - governed `mcp_readonly_call` execution boundary with audit metadata;
 - thin agent bridge tool registry for the seven stable boring-mcp operations;
 - server-only managed connector adapter seam with app-injected secret resolution.
 
-It intentionally does **not** perform real connector-provider calls, OAuth, provider execution, secret storage, or app-specific environment binding in the foundation PR.
+It intentionally does **not** own app-specific secret storage or app identity. Apps provide the Composio API key resolver, source persistence, enabled provider config, and actor resolution; boring-mcp owns generic Composio session creation, hosted connect URL creation, MCP protocol transport, catalog, policy, bridge tools, redaction, and read-only execution path.
 
 ## Enable in an app
 
@@ -31,15 +33,47 @@ const boringMcpPlugin = createBoringMcpPlugin({
 <CoreWorkspaceAgentFront plugins={[boringMcpPlugin]} />
 ```
 
-Server composition can use the server plugin once an app wants the boring-mcp prompt/seams at boot:
+Server composition can enable just the prompt, or the full generic bridge tool stack. For hosted Composio-backed sources, the app supplies only source persistence, the server-side API key resolver, enabled provider config, and actor resolution:
 
 ```ts
-import { createBoringMcpServerPlugin } from '@hachej/boring-mcp/server'
+import {
+  createBoringMcpServerPlugin,
+  createComposioManagedConnectorProvider,
+  createComposioMcpTransport,
+  createManagedConnectorAdapter,
+} from '@hachej/boring-mcp/server'
+
+const configs = [
+  { provider: 'notion', displayName: 'Notion', toolkitId: 'notion', connectUrlOrigins: ['https://app.composio.dev'] },
+]
+const secretResolver = {
+  async resolveSecret() {
+    return { storage: 'server-env' as const, value: process.env.COMPOSIO_API_KEY! }
+  },
+}
+
+const connector = createManagedConnectorAdapter({
+  registry: mcpSourceRegistry,
+  provider: createComposioManagedConnectorProvider(),
+  secretResolver,
+  configs,
+  preflightEvidence,
+})
+
+const transport = createComposioMcpTransport({ secretResolver, configs })
 
 createCoreWorkspaceAgentServer({
-  plugins: [createBoringMcpServerPlugin()],
+  plugins: [createBoringMcpServerPlugin({
+    registry: mcpSourceRegistry,
+    transport,
+    resolveActor: async (_params, ctx) => resolveActorForAgentSession(ctx.sessionId),
+  })],
 })
 ```
+
+When `registry`, `transport`, and `resolveActor` are provided, the plugin contributes the seven stable agent tools automatically: `mcp_servers_list`, `mcp_server_status`, `mcp_server_doctor`, `mcp_server_probe`, `mcp_tools_search`, `mcp_tool_describe`, and `mcp_readonly_call`.
+
+For non-Composio MCP endpoints, apps can still use `createMcpSdkStreamableHttpTransport({ endpoint })` directly.
 
 Apps may also list the package in `package.json#boring.defaultPluginPackages`, but core-based shipped apps should still statically compose front plugins when the UI must render.
 
@@ -64,7 +98,9 @@ Before enabling boring-mcp in a shipped app, operators should verify:
 5. Rate/budget hooks block before provider `listTools`/`callTool` when local limits are exceeded.
 6. Disconnect/revoke is verified through the injected registry status/result and never performs provider tool execution.
 7. Local smoke with a fake managed connector: connect -> status connected -> search tools -> describe tool -> governed readonly call -> disconnect -> verify non-connected status.
+8. Protocol smoke with a fake Streamable HTTP MCP server: real MCP SDK client transport -> list tools -> describe -> governed readonly call -> block mutating tool -> disconnect blocks future call.
+9. Composio smoke with fake Composio HTTP API + fake MCP server: create session -> hosted connect URL -> session MCP headers -> search/readonly call -> raw `COMPOSIO_*` meta-tools hidden.
 
 ## Current status
 
-Foundation plus source handlers, executable preflight, generic managed connector adapter seam, normalized tool catalog search/describe, governed fake-transport-testable read-only execution, exported agent bridge tool definitions, and production launch-gate helpers. Real Composio SDK/API calls, route/app registration, and Constellation binding land in later PRs.
+Reusable boring-mcp now includes source handlers, executable preflight, generic managed connector adapter seam, reusable Composio managed connector provider, MCP SDK Streamable HTTP transport, normalized tool catalog search/describe, governed read-only execution, exported/generic agent bridge tools, and production launch-gate helpers. Real app secret binding remains app-owned; Constellation-specific code is not required for the generic MCP feature to run against Composio or another MCP-compatible endpoint.

--- a/plugins/boring-mcp/README.md
+++ b/plugins/boring-mcp/README.md
@@ -57,7 +57,7 @@ const connector = createManagedConnectorAdapter({
   provider: createComposioManagedConnectorProvider(),
   secretResolver,
   configs,
-  preflightEvidence,
+  redactionCanaries: ['app-owned-mcp-canary'],
 })
 
 const transport = createComposioMcpTransport({ secretResolver, configs })
@@ -79,7 +79,7 @@ Apps may also list the package in `package.json#boring.defaultPluginPackages`, b
 
 ## Security boundaries
 
-Managed connector adapters must pass the [Composio security preflight](./docs/composio-security-preflight.md) and the executable `validateManagedConnectorPreflight` server check before real product provider calls. The generic `createManagedConnectorAdapter` seam accepts provider config plus an app-owned server secret resolver; reusable boring-mcp never binds app env/Vault details.
+Before production provider enablement, apps should record the [Composio security preflight](./docs/composio-security-preflight.md) and run `validateManagedConnectorPreflight` as launch evidence. The runtime `createManagedConnectorAdapter` seam stays small: provider config plus an app-owned server secret resolver; reusable boring-mcp never binds app env/Vault details.
 
 - Browser UI never receives provider OAuth tokens, connector API keys, or MCP session headers.
 - Raw provider meta-tools are not exposed by this foundation.
@@ -103,4 +103,4 @@ Before enabling boring-mcp in a shipped app, operators should verify:
 
 ## Current status
 
-Reusable boring-mcp now includes source handlers, executable preflight, generic managed connector adapter seam, reusable Composio managed connector provider, MCP SDK Streamable HTTP transport, normalized tool catalog search/describe, governed read-only execution, exported/generic agent bridge tools, and production launch-gate helpers. Real app secret binding remains app-owned; Constellation-specific code is not required for the generic MCP feature to run against Composio or another MCP-compatible endpoint.
+Reusable boring-mcp now includes source handlers, optional launch preflight helpers, generic managed connector adapter seam, reusable Composio managed connector provider, MCP SDK Streamable HTTP transport, normalized tool catalog search/describe, governed read-only execution, exported/generic agent bridge tools, and production launch-gate helpers. Real app secret binding remains app-owned; Constellation-specific code is not required for the generic MCP feature to run against Composio or another MCP-compatible endpoint.

--- a/plugins/boring-mcp/docs/composio-security-preflight.md
+++ b/plugins/boring-mcp/docs/composio-security-preflight.md
@@ -1,8 +1,8 @@
 # Composio security preflight
 
-This checklist gates any boring-mcp implementation that talks to Composio or another managed connector provider.
+This checklist is production-launch evidence for any app that enables real Composio or another managed connector provider.
 
-The foundation plugin is provider-neutral. A Composio adapter may only land after this checklist is green for the target app/environment, or after the owner explicitly accepts the named gaps for a non-production spike.
+The reusable boring-mcp runtime keeps construction small and testable: source registry, connector config, server-only secret resolver, transport, and actor resolver. Apps should run this checklist before production provider enablement, or explicitly accept named gaps for a non-production spike.
 
 ## Required before product provider calls
 
@@ -39,9 +39,9 @@ raw connector meta-tools exposed as agent tools
 provider execution before deny-before-allow policy passes
 ```
 
-## PR evidence template
+## PR / launch evidence template
 
-Every managed connector PR must include:
+Every PR or launch checklist that enables real managed connector traffic should include:
 
 ```txt
 Secret resolver used:

--- a/plugins/boring-mcp/package.json
+++ b/plugins/boring-mcp/package.json
@@ -71,5 +71,8 @@
     "tsup": "^8.4.0",
     "typescript": "~5.9.3",
     "vitest": "^3.2.6"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0"
   }
 }

--- a/plugins/boring-mcp/src/__tests__/agentTools.test.ts
+++ b/plugins/boring-mcp/src/__tests__/agentTools.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest"
+import { BORING_MCP_AGENT_BRIDGE_TOOL_NAMES } from "../server/agentBridge"
+import { createBoringMcpAgentTools } from "../server/agentTools"
+import { createBoringMcpServerPlugin } from "../server/index"
+import type { McpActor, McpSource, McpSourceRegistry, McpTransportClient } from "../shared"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+const source: McpSource = {
+  id: "source:notion:user-1",
+  workspaceId: actor.workspaceId,
+  userId: actor.userId,
+  provider: "notion",
+  displayName: "Notion",
+  status: "connected",
+  ownerKind: "user",
+  credentialProvider: "composio-managed",
+}
+
+function registry(): McpSourceRegistry {
+  return {
+    async listSources(requestActor) {
+      return requestActor.userId === actor.userId && requestActor.workspaceId === actor.workspaceId ? [source] : []
+    },
+    async getSource(sourceId) {
+      return sourceId === source.id ? source : undefined
+    },
+  }
+}
+
+function transport(): McpTransportClient {
+  return {
+    listTools: vi.fn(async () => [{ name: "NOTION_SEARCH_NOTION_PAGE", description: "Search fake pages", inputSchema: { type: "object" } }]),
+    listResources: vi.fn(async () => []),
+    readResource: vi.fn(),
+    callTool: vi.fn(async () => ({ content: [{ type: "text", text: "ok" }] })),
+  }
+}
+
+describe("boring-mcp generic agent tools", () => {
+  it("creates the seven executable bridge tools with app-provided actor resolution", async () => {
+    const resolveActor = vi.fn(async () => actor)
+    const tools = createBoringMcpAgentTools({ registry: registry(), transport: transport(), resolveActor })
+
+    expect(tools.map((tool) => tool.name)).toEqual([...BORING_MCP_AGENT_BRIDGE_TOOL_NAMES])
+    const result = await tools.find((tool) => tool.name === "mcp_tools_search")!.execute({ query: "search" }, {
+      abortSignal: new AbortController().signal,
+      toolCallId: "tool-call-1",
+    })
+
+    expect(resolveActor).toHaveBeenCalledOnce()
+    expect(JSON.parse(result.content[0].text)).toMatchObject({ tools: [expect.objectContaining({ toolName: "NOTION_SEARCH_NOTION_PAGE" })] })
+  })
+
+  it("lets apps enable boring-mcp without custom bridge glue", () => {
+    const plugin = createBoringMcpServerPlugin({ registry: registry(), transport: transport(), resolveActor: async () => actor })
+
+    expect(plugin.id).toBe("boring-mcp")
+    expect(plugin.agentTools?.map((tool) => tool.name)).toEqual([...BORING_MCP_AGENT_BRIDGE_TOOL_NAMES])
+  })
+})

--- a/plugins/boring-mcp/src/__tests__/composioManagedConnector.test.ts
+++ b/plugins/boring-mcp/src/__tests__/composioManagedConnector.test.ts
@@ -1,0 +1,174 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
+import { AddressInfo } from "node:net"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import { createBoringMcpAgentBridgeRegistry } from "../server/agentBridge"
+import { createComposioManagedConnectorProvider, createComposioMcpTransport } from "../server/composioManagedConnector"
+import { createManagedConnectorAdapter, type ManagedConnectorConfig, type ManagedConnectorSecretResolver, type ManagedConnectorSourceRegistry } from "../server/managedConnectorAdapter"
+import type { ManagedConnectorPreflightEvidence } from "../server/managedConnectorPreflight"
+import { createBoringMcpSourceHandlers } from "../server/sourceHandlers"
+import type { McpActor, McpSource } from "../shared"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+const config: ManagedConnectorConfig = {
+  provider: "notion",
+  displayName: "Notion",
+  toolkitId: "notion",
+  connectUrlOrigins: ["https://app.composio.dev"],
+}
+const secretResolver: ManagedConnectorSecretResolver = {
+  resolveSecret: vi.fn(async () => ({ storage: "server-env" as const, value: "cmp_test_key" })),
+}
+const preflightEvidence: ManagedConnectorPreflightEvidence = {
+  connectorName: "Composio managed MCP",
+  isolatedTestProject: true,
+  apiKeyStorage: "server-env",
+  browserDtoSamples: [{ status: "unconfigured", provider: "notion" }],
+  redactedLogSamples: [{ message: "configured [REDACTED_MCP_SECRET]" }],
+  redactedProviderResultSamples: [{ content: "ok" }],
+  redactionCanaries: ["COMPOSIO_CANARY"],
+  revokeDisconnectVerified: true,
+  connectedAccountStatusVerified: true,
+  vendorRisk: {
+    dpaStatus: "approved",
+    subprocessorStatus: "approved",
+    dataResidencyStatus: "approved",
+    incidentHistoryStatus: "approved",
+  },
+}
+
+const servers: Array<{ close: () => Promise<void> }> = []
+
+function createRegistry(): ManagedConnectorSourceRegistry {
+  const sources = new Map<string, McpSource>()
+  return {
+    async listSources(requestActor) {
+      return [...sources.values()].filter((source) => source.workspaceId === requestActor.workspaceId && source.userId === requestActor.userId)
+    },
+    async getSource(sourceId) {
+      return sources.get(sourceId)
+    },
+    async upsertSource(_actor, source) {
+      sources.set(source.id, source)
+      return source
+    },
+    async disconnectSource(requestActor, sourceId) {
+      const source = sources.get(sourceId)
+      if (!source || source.workspaceId !== requestActor.workspaceId || source.userId !== requestActor.userId) return undefined
+      const next = { ...source, status: "revoked" as const }
+      sources.set(sourceId, next)
+      return next
+    },
+  }
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), { status, headers: { "content-type": "application/json" } })
+}
+
+function createComposioFetch(mcpUrl = "https://mcp.example/session") {
+  return vi.fn(async (input: string | URL, init?: RequestInit) => {
+    expect(init?.headers).toMatchObject({ "x-api-key": "cmp_test_key" })
+    const url = String(input)
+    if (url.endsWith("/api/v3.1/tool_router/session")) {
+      expect(JSON.parse(String(init?.body))).toMatchObject({ user_id: "workspace-1:user-1", mcp: true, toolkits: ["notion"] })
+      return jsonResponse({ id: "session-1", mcp: { url: mcpUrl, headers: { "x-composio-mcp-session": "server-only-session" } } })
+    }
+    if (url.endsWith("/api/v3/tool_router/session/session-1/link")) {
+      expect(JSON.parse(String(init?.body))).toMatchObject({ toolkit: "notion" })
+      return jsonResponse({ redirect_url: "https://app.composio.dev/connect/session-1" })
+    }
+    return jsonResponse({ error: "not found" }, 404)
+  }) as typeof fetch & ReturnType<typeof vi.fn>
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  return chunks.length ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : undefined
+}
+
+function createFakeMcpServer(seenHeaders: string[]) {
+  const server = new McpServer({ name: "composio-fake-mcp", version: "1.0.0" })
+  server.registerTool("NOTION_SEARCH_NOTION_PAGE", { description: "Search pages" }, async () => ({ content: [{ type: "text", text: "composio mcp ok" }] }))
+  server.registerTool("COMPOSIO_MANAGE_CONNECTIONS", { description: "Raw meta tool must stay hidden" }, async () => ({ content: [{ type: "text", text: "hidden" }] }))
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    if (req.url !== "/mcp" || req.method !== "POST") {
+      res.statusCode = 404
+      res.end("not found")
+      return
+    }
+    seenHeaders.push(String(req.headers["x-composio-mcp-session"] ?? ""))
+    const body = await readJson(req)
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined, enableJsonResponse: true })
+    res.on("close", () => void transport.close())
+    await server.connect(transport)
+    await transport.handleRequest(req, res, body)
+  })
+}
+
+async function listenFakeMcpServer() {
+  const seenHeaders: string[] = []
+  const httpServer = createFakeMcpServer(seenHeaders)
+  await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve))
+  const { port } = httpServer.address() as AddressInfo
+  const close = () => new Promise<void>((resolve, reject) => httpServer.close((error) => error ? reject(error) : resolve()))
+  servers.push({ close })
+  return { url: `http://127.0.0.1:${port}/mcp`, seenHeaders }
+}
+
+afterEach(async () => {
+  while (servers.length) await servers.pop()!.close()
+  vi.restoreAllMocks()
+})
+
+describe("Composio managed connector provider", () => {
+  it("creates a Composio MCP session and hosted connect URL through the generic adapter", async () => {
+    const fetch = createComposioFetch()
+    const registry = createRegistry()
+    const adapter = createManagedConnectorAdapter({
+      registry,
+      provider: createComposioManagedConnectorProvider({ fetch }),
+      secretResolver,
+      configs: [config],
+      preflightEvidence,
+    })
+
+    const result = await adapter.startConnect(actor, { provider: "notion" })
+
+    expect(result.connectUrl).toBe("https://app.composio.dev/connect/session-1")
+    expect(result.source).toMatchObject({ status: "unconfigured", credentialProvider: "composio-managed", connectorRef: { sessionId: "session-1", toolkitId: "notion" } })
+    expect(JSON.stringify(result)).not.toContain("cmp_test_key")
+    expect(JSON.stringify(result)).not.toContain("server-only-session")
+  })
+
+  it("uses Composio session MCP headers with the real MCP SDK transport and hides raw Composio meta tools", async () => {
+    const fakeMcp = await listenFakeMcpServer()
+    const fetch = createComposioFetch(fakeMcp.url)
+    const registry = createRegistry()
+    const source = await registry.upsertSource(actor, {
+      id: "managed:workspace-1:user-1:notion",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      provider: "notion",
+      displayName: "Notion",
+      status: "connected",
+      ownerKind: "user",
+      credentialProvider: "composio-managed",
+      connectorRef: { provider: "notion", toolkitId: "notion", sessionId: "session-1" },
+    })
+    const transport = createComposioMcpTransport({ fetch, secretResolver, configs: [config] })
+    const handlers = createBoringMcpSourceHandlers({ registry, transport })
+    const bridge = createBoringMcpAgentBridgeRegistry(handlers)
+
+    await expect(bridge.mcp_tools_search.invoke({ actor }, { query: "notion" })).resolves.toMatchObject({
+      tools: [expect.objectContaining({ toolName: "NOTION_SEARCH_NOTION_PAGE" })],
+    })
+    await expect(bridge.mcp_tools_search.invoke({ actor }, { query: "COMPOSIO" })).resolves.toMatchObject({ tools: [] })
+    await expect(bridge.mcp_readonly_call.invoke({ actor }, { sourceId: source.id, toolName: "NOTION_SEARCH_NOTION_PAGE", input: {} })).resolves.toEqual({
+      content: { content: [{ type: "text", text: "composio mcp ok" }] },
+    })
+    expect(fakeMcp.seenHeaders).toContain("server-only-session")
+  })
+})

--- a/plugins/boring-mcp/src/__tests__/composioManagedConnector.test.ts
+++ b/plugins/boring-mcp/src/__tests__/composioManagedConnector.test.ts
@@ -8,7 +8,7 @@ import { createComposioManagedConnectorProvider, createComposioMcpTransport } fr
 import { createManagedConnectorAdapter, type ManagedConnectorConfig, type ManagedConnectorSecretResolver, type ManagedConnectorSourceRegistry } from "../server/managedConnectorAdapter"
 import type { ManagedConnectorPreflightEvidence } from "../server/managedConnectorPreflight"
 import { createBoringMcpSourceHandlers } from "../server/sourceHandlers"
-import type { McpActor, McpSource } from "../shared"
+import { MCP_ERROR_CODES, type McpActor, type McpSource } from "../shared"
 
 const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
 const config: ManagedConnectorConfig = {
@@ -67,10 +67,16 @@ function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), { status, headers: { "content-type": "application/json" } })
 }
 
-function createComposioFetch(mcpUrl = "https://mcp.example/session") {
+function createComposioFetch(mcpUrl = "https://mcp.example/session", accounts: unknown[] = []) {
   return vi.fn(async (input: string | URL, init?: RequestInit) => {
     expect(init?.headers).toMatchObject({ "x-api-key": "cmp_test_key" })
     const url = String(input)
+    if (url.includes("/api/v3.1/connected_accounts?")) {
+      expect(init?.method).toBe("GET")
+      expect(url).toContain("user_id=workspace-1%3Auser-1")
+      expect(url).toContain("toolkit_slug=notion")
+      return jsonResponse({ items: accounts })
+    }
     if (url.endsWith("/api/v3.1/tool_router/session")) {
       expect(JSON.parse(String(init?.body))).toMatchObject({ user_id: "workspace-1:user-1", mcp: true, toolkits: ["notion"] })
       return jsonResponse({ id: "session-1", mcp: { url: mcpUrl, headers: { "x-composio-mcp-session": "server-only-session" } } })
@@ -141,6 +147,66 @@ describe("Composio managed connector provider", () => {
     expect(result.source).toMatchObject({ status: "unconfigured", credentialProvider: "composio-managed", connectorRef: { sessionId: "session-1", toolkitId: "notion" } })
     expect(JSON.stringify(result)).not.toContain("cmp_test_key")
     expect(JSON.stringify(result)).not.toContain("server-only-session")
+
+    await expect(adapter.refreshStatus(actor, result.source.id)).resolves.toMatchObject({ source: { status: "unconfigured" } })
+    expect(fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it("promotes an unconfigured source to connected only after Composio reports an active connected account", async () => {
+    const fetch = createComposioFetch("https://mcp.example/session", [{
+      id: "account-1",
+      user_id: "workspace-1:user-1",
+      status: "ACTIVE",
+      is_disabled: false,
+      toolkit: { slug: "notion" },
+      alias: "Demo Notion",
+    }])
+    const registry = createRegistry()
+    const adapter = createManagedConnectorAdapter({
+      registry,
+      provider: createComposioManagedConnectorProvider({ fetch }),
+      secretResolver,
+      configs: [config],
+      preflightEvidence,
+    })
+
+    const started = await adapter.startConnect(actor, { provider: "notion" })
+    await expect(adapter.refreshStatus(actor, started.source.id)).resolves.toMatchObject({
+      source: { status: "connected", providerAccountLabel: "Demo Notion", connectorRef: { connectedAccountId: "account-1" } },
+    })
+  })
+
+  it("rejects non-HTTPS Composio MCP session URLs unless using the loopback-only test override", async () => {
+    const fetch = createComposioFetch("http://evil.example/mcp")
+    const provider = createComposioManagedConnectorProvider({ fetch })
+
+    await expect(provider.probe({
+      actor,
+      config,
+      secret: { storage: "server-env", value: "cmp_test_key" },
+      source: {} as McpSource,
+    })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
+  })
+
+  it("rejects non-server Composio transport secrets before any provider request", async () => {
+    const fetch = createComposioFetch()
+    const transport = createComposioMcpTransport({
+      fetch,
+      secretResolver: { resolveSecret: vi.fn(async () => ({ storage: "browser" as never, value: "cmp_test_key" })) },
+      configs: [config],
+    })
+
+    await expect(transport.listTools({
+      id: "managed:workspace-1:user-1:notion",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      provider: "notion",
+      displayName: "Notion",
+      status: "connected",
+      ownerKind: "user",
+      credentialProvider: "composio-managed",
+    })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
+    expect(fetch).not.toHaveBeenCalled()
   })
 
   it("uses Composio session MCP headers with the real MCP SDK transport and hides raw Composio meta tools", async () => {
@@ -158,7 +224,7 @@ describe("Composio managed connector provider", () => {
       credentialProvider: "composio-managed",
       connectorRef: { provider: "notion", toolkitId: "notion", sessionId: "session-1" },
     })
-    const transport = createComposioMcpTransport({ fetch, secretResolver, configs: [config] })
+    const transport = createComposioMcpTransport({ fetch, secretResolver, configs: [config], allowInsecureMcpUrlsForTests: true })
     const handlers = createBoringMcpSourceHandlers({ registry, transport })
     const bridge = createBoringMcpAgentBridgeRegistry(handlers)
 

--- a/plugins/boring-mcp/src/__tests__/managedConnectorAdapter.test.ts
+++ b/plugins/boring-mcp/src/__tests__/managedConnectorAdapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { MCP_ERROR_CODES, McpError, type McpActor, type McpSource } from "../shared"
+import { MCP_ERROR_CODES, type McpActor, type McpSource } from "../shared"
 import { createManagedConnectorAdapter, type ManagedConnectorConfig, type ManagedConnectorProvider, type ManagedConnectorSourceRegistry } from "../server/managedConnectorAdapter"
 import type { ManagedConnectorPreflightEvidence } from "../server/managedConnectorPreflight"
 
@@ -182,13 +182,14 @@ describe("managed connector adapter", () => {
     await expect(adapter.startConnect(actor, { provider: "notion" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
   })
 
-  it("requires preflight evidence and server-only secret configuration before provider use", () => {
-    expect(() => createManagedConnectorAdapter({
+  it("does not require launch preflight evidence at construction, but still requires server-only secret configuration before provider use", async () => {
+    const adapter = createManagedConnectorAdapter({
       registry: createRegistry(),
       provider: createProvider(),
       configs: [config],
-      preflightEvidence: { ...preflightEvidence, redactionCanaries: [] },
-      secretResolver: { resolveSecret: vi.fn(async () => ({ storage: "server-vault" as const, value: "server-only-secret" })) },
-    })).toThrow(McpError)
+      secretResolver: { resolveSecret: vi.fn(async () => ({ storage: "browser" as never, value: "server-only-secret" })) },
+    })
+
+    await expect(adapter.startConnect(actor, { provider: "notion" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
   })
 })

--- a/plugins/boring-mcp/src/__tests__/mcpSdkTransport.test.ts
+++ b/plugins/boring-mcp/src/__tests__/mcpSdkTransport.test.ts
@@ -1,0 +1,119 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http"
+import { AddressInfo } from "node:net"
+import { afterEach, describe, expect, it } from "vitest"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
+import { createBoringMcpAgentBridgeRegistry } from "../server/agentBridge"
+import { createMcpSdkStreamableHttpTransport } from "../server/mcpSdkTransport"
+import { createBoringMcpSourceHandlers } from "../server/sourceHandlers"
+import type { McpActor, McpSource, McpSourceRegistry, McpToolDescribeResult } from "../shared"
+
+const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
+const source: McpSource = {
+  id: "source:notion:user-1",
+  workspaceId: actor.workspaceId,
+  userId: actor.userId,
+  provider: "notion",
+  displayName: "Protocol Fake Notion",
+  status: "connected",
+  ownerKind: "user",
+  credentialProvider: "composio-managed",
+  connectorRef: { provider: "notion", sessionId: "fake-session" },
+}
+
+const servers: Array<{ close: () => Promise<void> }> = []
+
+function registry(current: McpSource = source): McpSourceRegistry {
+  let stored = current
+  return {
+    async listSources(requestActor) {
+      return requestActor.userId === stored.userId && requestActor.workspaceId === stored.workspaceId ? [stored] : []
+    },
+    async getSource(sourceId) {
+      return sourceId === stored.id ? stored : undefined
+    },
+    async disconnectSource(_actor, sourceId) {
+      if (sourceId !== stored.id) return undefined
+      stored = { ...stored, status: "revoked" }
+      return stored
+    },
+  }
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  if (!chunks.length) return undefined
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"))
+}
+
+function createFakeMcpServer(seenHeaders: string[]) {
+  const server = new McpServer({ name: "boring-mcp-protocol-fake", version: "1.0.0" })
+  server.registerTool(
+    "NOTION_SEARCH_NOTION_PAGE",
+    { description: "Search fake Notion pages through a real MCP Streamable HTTP transport" },
+    async () => ({ content: [{ type: "text", text: "protocol fake ok" }] }),
+  )
+  server.registerTool(
+    "update_page",
+    { description: "Mutating fake tool that boring-mcp must block before provider calls" },
+    async () => ({ content: [{ type: "text", text: "should not be called" }] }),
+  )
+
+  return createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    if (req.url !== "/mcp" || req.method !== "POST") {
+      res.statusCode = 404
+      res.end("not found")
+      return
+    }
+    seenHeaders.push(String(req.headers["x-test-mcp-session"] ?? ""))
+    const body = await readJson(req)
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined, enableJsonResponse: true })
+    res.on("close", () => void transport.close())
+    await server.connect(transport)
+    await transport.handleRequest(req, res, body)
+  })
+}
+
+async function listenFakeMcpServer() {
+  const seenHeaders: string[] = []
+  const httpServer = createFakeMcpServer(seenHeaders)
+  await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve))
+  const { port } = httpServer.address() as AddressInfo
+  const close = () => new Promise<void>((resolve, reject) => httpServer.close((error) => error ? reject(error) : resolve()))
+  servers.push({ close })
+  return { url: `http://127.0.0.1:${port}/mcp`, seenHeaders }
+}
+
+afterEach(async () => {
+  while (servers.length) await servers.pop()!.close()
+})
+
+describe("MCP SDK Streamable HTTP transport", () => {
+  it("runs the generic boring-mcp search/describe/read-only bridge over a real fake MCP server", async () => {
+    const fake = await listenFakeMcpServer()
+    const transport = createMcpSdkStreamableHttpTransport({
+      endpoint: { url: fake.url, headers: { "x-test-mcp-session": "server-only-session-header" } },
+      clientName: "boring-mcp-test",
+      clientVersion: "0.0.0-test",
+    })
+    const handlers = createBoringMcpSourceHandlers({ registry: registry(), transport })
+    const bridge = createBoringMcpAgentBridgeRegistry(handlers)
+
+    await expect(bridge.mcp_servers_list.invoke({ actor }, {})).resolves.toMatchObject({ sources: [expect.objectContaining({ id: source.id })] })
+    await expect(bridge.mcp_tools_search.invoke({ actor }, { query: "search" })).resolves.toMatchObject({ tools: [expect.objectContaining({ toolName: "NOTION_SEARCH_NOTION_PAGE" })] })
+    const described = await bridge.mcp_tool_describe.invoke({ actor }, { sourceId: source.id, toolName: "NOTION_SEARCH_NOTION_PAGE" }) as McpToolDescribeResult
+    await expect(bridge.mcp_readonly_call.invoke({ actor }, {
+      sourceId: source.id,
+      toolName: "NOTION_SEARCH_NOTION_PAGE",
+      expectedSchemaHash: described.tool.schemaHash,
+      input: { query: "demo" },
+    })).resolves.toEqual({ content: { content: [{ type: "text", text: "protocol fake ok" }] } })
+
+    await expect(bridge.mcp_readonly_call.invoke({ actor }, { sourceId: source.id, toolName: "update_page", input: {} })).rejects.toMatchObject({ code: "MCP_TOOL_NOT_ALLOWED" })
+    await expect(handlers.disconnectSource(actor, source.id)).resolves.toMatchObject({ source: { status: "revoked" } })
+    await expect(bridge.mcp_readonly_call.invoke({ actor }, { sourceId: source.id, toolName: "NOTION_SEARCH_NOTION_PAGE", input: {} })).rejects.toMatchObject({ code: "MCP_SOURCE_UNAVAILABLE" })
+
+    expect(fake.seenHeaders).toContain("server-only-session-header")
+  })
+})

--- a/plugins/boring-mcp/src/server/agentTools.ts
+++ b/plugins/boring-mcp/src/server/agentTools.ts
@@ -1,0 +1,40 @@
+import type { AgentTool, ToolExecContext, ToolResult } from "@hachej/boring-workspace"
+import type { McpActor, McpProviderTemplate, McpSourceRegistry, McpTransportClient } from "../shared"
+import { createBoringMcpAgentBridgeRegistry, listBoringMcpAgentBridgeTools } from "./agentBridge"
+import type { McpProviderHardeningOptions } from "./hardening"
+import type { McpReadonlyCallAuditSink } from "./readonlyCall"
+import { createBoringMcpSourceHandlers } from "./sourceHandlers"
+
+export type BoringMcpAgentToolActorResolver = (
+  params: Record<string, unknown>,
+  ctx: ToolExecContext,
+) => McpActor | Promise<McpActor>
+
+export interface CreateBoringMcpAgentToolsOptions {
+  registry: McpSourceRegistry
+  transport: McpTransportClient
+  resolveActor: BoringMcpAgentToolActorResolver
+  templates?: readonly McpProviderTemplate[]
+  maxReadonlyInputBytes?: number
+  audit?: McpReadonlyCallAuditSink
+  hardening?: McpProviderHardeningOptions
+}
+
+function toolResult(value: unknown): ToolResult {
+  return { content: [{ type: "text", text: JSON.stringify(value) }] }
+}
+
+export function createBoringMcpAgentTools(options: CreateBoringMcpAgentToolsOptions): AgentTool[] {
+  const handlers = createBoringMcpSourceHandlers(options)
+  const bridge = createBoringMcpAgentBridgeRegistry(handlers)
+  return listBoringMcpAgentBridgeTools(bridge).map((tool): AgentTool => ({
+    name: tool.name,
+    description: tool.description,
+    parameters: tool.inputSchema,
+    promptSnippet: `${tool.name}: ${tool.description}`,
+    async execute(params, ctx) {
+      const actor = await options.resolveActor(params, ctx)
+      return toolResult(await tool.invoke({ actor }, params))
+    },
+  }))
+}

--- a/plugins/boring-mcp/src/server/composioManagedConnector.ts
+++ b/plugins/boring-mcp/src/server/composioManagedConnector.ts
@@ -33,12 +33,20 @@ export interface ComposioManagedConnectorProviderOptions {
   /** Optional client metadata for the MCP SDK client used during probe/transport calls. */
   clientName?: string
   clientVersion?: string
+  /** Test-only escape hatch for loopback fake MCP servers. Production Composio MCP URLs must be https. */
+  allowInsecureMcpUrlsForTests?: boolean
 }
 
-interface CreateSessionInput {
+export interface ResolveComposioMcpSessionInput {
   actor: McpActor
   config: ManagedConnectorConfig
   secret: ManagedConnectorSecret
+}
+
+interface ComposioConnectedAccountSummary {
+  id?: string
+  label?: string
+  active: boolean
 }
 
 function trimTrailingSlash(value: string): string {
@@ -49,8 +57,18 @@ function composioUserId(actor: McpActor): string {
   return `${actor.workspaceId}:${actor.userId}`
 }
 
+function actorForSource(source: McpSource): McpActor {
+  return { userId: source.userId, workspaceId: source.workspaceId }
+}
+
 function providerError(message: string, details?: unknown): McpError {
   return new McpError(MCP_ERROR_CODES.PROVIDER_ERROR, message, redactMcpSecrets(details))
+}
+
+function requireServerSecret(secret: ManagedConnectorSecret): void {
+  if ((secret.storage !== "server-env" && secret.storage !== "server-vault") || !secret.value) {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Composio connector secret is not configured server-side")
+  }
 }
 
 async function readJsonResponse(response: Response): Promise<unknown> {
@@ -67,24 +85,42 @@ function record(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {}
 }
 
+function array(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : []
+}
+
 function optionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined
 }
 
 function optionalHeaders(value: unknown): Record<string, string> | undefined {
-  const candidate = record(value)
-  const entries = Object.entries(candidate).filter((entry): entry is [string, string] => typeof entry[1] === "string")
+  const entries = Object.entries(record(value)).filter((entry): entry is [string, string] => typeof entry[1] === "string")
   return entries.length ? Object.fromEntries(entries) : undefined
 }
 
-function extractSession(payload: unknown): ComposioMcpSession {
+function normalizeComposioMcpUrl(rawUrl: string, options: ComposioManagedConnectorProviderOptions): string {
+  let parsed: URL
+  try {
+    parsed = new URL(rawUrl)
+  } catch {
+    throw providerError("Composio session response included an invalid MCP URL")
+  }
+  const loopback = parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost" || parsed.hostname === "::1"
+  const allowedInsecureLoopback = options.allowInsecureMcpUrlsForTests && parsed.protocol === "http:" && loopback
+  if ((parsed.protocol !== "https:" && !allowedInsecureLoopback) || parsed.username || parsed.password) {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Composio MCP URL must be https and must not include credentials")
+  }
+  return parsed.toString()
+}
+
+function extractSession(payload: unknown, options: ComposioManagedConnectorProviderOptions): ComposioMcpSession {
   const root = record(payload)
   const session = record(root.session ?? root.data ?? root)
   const mcp = record(session.mcp)
   const id = optionalString(session.id) ?? optionalString(session.session_id) ?? optionalString(root.id) ?? optionalString(root.session_id)
   const url = optionalString(mcp.url)
   if (!id || !url) throw providerError("Composio session response did not include an MCP session", payload)
-  return { id, mcp: { url, headers: optionalHeaders(mcp.headers) } }
+  return { id, mcp: { url: normalizeComposioMcpUrl(url, options), headers: optionalHeaders(mcp.headers) } }
 }
 
 function extractConnectUrl(payload: unknown): string | undefined {
@@ -110,26 +146,42 @@ function extractProviderAccountLabel(payload: unknown): string | undefined {
     ?? optionalString(nested.label)
     ?? optionalString(nested.email)
     ?? optionalString(nested.name)
+    ?? optionalString(nested.alias)
 }
 
-async function composioFetch(options: ComposioManagedConnectorProviderOptions, secret: ManagedConnectorSecret, path: string, body: unknown): Promise<unknown> {
+async function composioRequest(
+  options: ComposioManagedConnectorProviderOptions,
+  secret: ManagedConnectorSecret,
+  method: "GET" | "POST",
+  path: string,
+  body?: unknown,
+): Promise<unknown> {
+  requireServerSecret(secret)
   const fetchImpl = options.fetch ?? globalThis.fetch
   if (!fetchImpl) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "fetch is not available for Composio connector")
   const response = await fetchImpl(`${trimTrailingSlash(options.apiBaseUrl ?? "https://backend.composio.dev")}${path}`, {
-    method: "POST",
+    method,
     headers: {
       "content-type": "application/json",
       "x-api-key": secret.value,
     },
-    body: JSON.stringify(body),
+    body: body === undefined ? undefined : JSON.stringify(body),
   })
   const payload = await readJsonResponse(response)
   if (!response.ok) throw providerError("Composio request failed", { status: response.status, payload })
   return payload
 }
 
-async function createSession(options: ComposioManagedConnectorProviderOptions, input: CreateSessionInput): Promise<ComposioMcpSession> {
-  const payload = await composioFetch(options, input.secret, "/api/v3.1/tool_router/session", {
+function composioPost(options: ComposioManagedConnectorProviderOptions, secret: ManagedConnectorSecret, path: string, body: unknown): Promise<unknown> {
+  return composioRequest(options, secret, "POST", path, body)
+}
+
+function composioGet(options: ComposioManagedConnectorProviderOptions, secret: ManagedConnectorSecret, path: string): Promise<unknown> {
+  return composioRequest(options, secret, "GET", path)
+}
+
+export async function resolveComposioMcpSession(options: ComposioManagedConnectorProviderOptions, input: ResolveComposioMcpSessionInput): Promise<ComposioMcpSession> {
+  const payload = await composioPost(options, input.secret, "/api/v3.1/tool_router/session", {
     user_id: composioUserId(input.actor),
     mcp: true,
     toolkits: [input.config.toolkitId],
@@ -139,14 +191,39 @@ async function createSession(options: ComposioManagedConnectorProviderOptions, i
       callback_url: options.callbackUrl,
     },
   })
-  return extractSession(payload)
+  return extractSession(payload, options)
 }
 
 async function createLink(options: ComposioManagedConnectorProviderOptions, secret: ManagedConnectorSecret, sessionId: string, config: ManagedConnectorConfig): Promise<unknown> {
-  return composioFetch(options, secret, `/api/v3/tool_router/session/${encodeURIComponent(sessionId)}/link`, {
+  return composioPost(options, secret, `/api/v3/tool_router/session/${encodeURIComponent(sessionId)}/link`, {
     toolkit: config.toolkitId,
     callback_url: options.callbackUrl,
   })
+}
+
+function accountIsForConfig(account: Record<string, unknown>, actor: McpActor, config: ManagedConnectorConfig): boolean {
+  const toolkit = record(account.toolkit)
+  return optionalString(toolkit.slug) === config.toolkitId && optionalString(account.user_id) === composioUserId(actor)
+}
+
+function summarizeAccount(account: Record<string, unknown>): ComposioConnectedAccountSummary {
+  const status = optionalString(account.status)?.toUpperCase()
+  const disabled = account.is_disabled === true || record(account.auth_config).is_disabled === true
+  return {
+    id: optionalString(account.id) ?? optionalString(account.nanoid) ?? optionalString(account.word_id),
+    label: extractProviderAccountLabel(account),
+    active: !disabled && (status === "ACTIVE" || status === "CONNECTED" || status === "ENABLED"),
+  }
+}
+
+async function findConnectedAccount(options: ComposioManagedConnectorProviderOptions, input: ResolveComposioMcpSessionInput): Promise<ComposioConnectedAccountSummary | undefined> {
+  const params = new URLSearchParams({ user_id: composioUserId(input.actor), toolkit_slug: input.config.toolkitId })
+  const payload = await composioGet(options, input.secret, `/api/v3.1/connected_accounts?${params}`)
+  const items = array(record(payload).items)
+    .map(record)
+    .filter((account) => accountIsForConfig(account, input.actor, input.config))
+    .map(summarizeAccount)
+  return items.find((account) => account.active) ?? items[0]
 }
 
 function transportForSession(options: ComposioManagedConnectorProviderOptions, session: ComposioMcpSession): McpTransportClient {
@@ -164,7 +241,7 @@ function safeTools(tools: McpDiscoveredTool[]): McpDiscoveredTool[] {
 export function createComposioManagedConnectorProvider(options: ComposioManagedConnectorProviderOptions = {}): ManagedConnectorProvider {
   return {
     async startConnect({ actor, config, secret }) {
-      const session = await createSession(options, { actor, config, secret })
+      const session = await resolveComposioMcpSession(options, { actor, config, secret })
       const link = await createLink(options, secret, session.id, config)
       return {
         connectorRef: { provider: config.provider, toolkitId: config.toolkitId, sessionId: session.id },
@@ -175,17 +252,29 @@ export function createComposioManagedConnectorProvider(options: ComposioManagedC
     },
 
     async refreshStatus({ actor, source, config, secret }) {
-      const session = await createSession(options, { actor, config, secret })
+      if (source.status === "revoked") {
+        return { status: "revoked", providerAccountLabel: source.providerAccountLabel, lastVerifiedAt: source.lastVerifiedAt, connectorRef: source.connectorRef }
+      }
+      const account = await findConnectedAccount(options, { actor, config, secret })
+      if (!account?.active) {
+        return {
+          status: source.status === "connected" ? "expired" : source.status,
+          providerAccountLabel: account?.label ?? source.providerAccountLabel,
+          lastVerifiedAt: new Date().toISOString(),
+          connectorRef: { ...source.connectorRef, provider: config.provider, toolkitId: config.toolkitId, connectedAccountId: account?.id },
+        }
+      }
+      const session = await resolveComposioMcpSession(options, { actor, config, secret })
       return {
-        status: source.status === "revoked" ? "revoked" : "connected",
-        providerAccountLabel: source.providerAccountLabel,
+        status: "connected",
+        providerAccountLabel: account.label ?? source.providerAccountLabel,
         lastVerifiedAt: new Date().toISOString(),
-        connectorRef: { ...source.connectorRef, provider: config.provider, toolkitId: config.toolkitId, sessionId: session.id },
+        connectorRef: { ...source.connectorRef, provider: config.provider, toolkitId: config.toolkitId, sessionId: session.id, connectedAccountId: account.id },
       }
     },
 
     async probe({ actor, config, secret }) {
-      const session = await createSession(options, { actor, config, secret })
+      const session = await resolveComposioMcpSession(options, { actor, config, secret })
       const transport = transportForSession(options, session)
       const source: McpSource = {
         id: `composio-probe:${actor.workspaceId}:${actor.userId}:${config.provider}`,
@@ -216,7 +305,7 @@ export function createComposioMcpTransport(options: ComposioManagedConnectorProv
       const config = options.configs.find((entry) => entry.provider === source.provider)
       if (!config) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown Composio MCP provider")
       const secret = await options.secretResolver.resolveSecret(source.provider)
-      const session = await createSession(options, { actor: { userId: source.userId, workspaceId: source.workspaceId }, config, secret })
+      const session = await resolveComposioMcpSession(options, { actor: actorForSource(source), config, secret })
       return { url: session.mcp.url, headers: session.mcp.headers }
     },
     clientName: options.clientName ?? "boring-mcp-composio",

--- a/plugins/boring-mcp/src/server/composioManagedConnector.ts
+++ b/plugins/boring-mcp/src/server/composioManagedConnector.ts
@@ -1,0 +1,231 @@
+import {
+  MCP_ERROR_CODES,
+  McpError,
+  redactMcpSecrets,
+  type McpActor,
+  type McpDiscoveredResource,
+  type McpDiscoveredTool,
+  type McpSource,
+  type McpTransportClient,
+} from "../shared"
+import {
+  type ManagedConnectorConfig,
+  type ManagedConnectorProvider,
+  type ManagedConnectorSecret,
+} from "./managedConnectorAdapter"
+import { createMcpSdkStreamableHttpTransport } from "./mcpSdkTransport"
+
+export interface ComposioMcpSession {
+  id: string
+  mcp: {
+    url: string
+    headers?: Record<string, string>
+  }
+}
+
+export interface ComposioManagedConnectorProviderOptions {
+  /** Defaults to Composio production API. Override in tests or private deployments. */
+  apiBaseUrl?: string
+  /** Defaults to global fetch. */
+  fetch?: typeof fetch
+  /** Optional redirect URL Composio should use after hosted auth completes. */
+  callbackUrl?: string
+  /** Optional client metadata for the MCP SDK client used during probe/transport calls. */
+  clientName?: string
+  clientVersion?: string
+}
+
+interface CreateSessionInput {
+  actor: McpActor
+  config: ManagedConnectorConfig
+  secret: ManagedConnectorSecret
+}
+
+function trimTrailingSlash(value: string): string {
+  return value.endsWith("/") ? value.slice(0, -1) : value
+}
+
+function composioUserId(actor: McpActor): string {
+  return `${actor.workspaceId}:${actor.userId}`
+}
+
+function providerError(message: string, details?: unknown): McpError {
+  return new McpError(MCP_ERROR_CODES.PROVIDER_ERROR, message, redactMcpSecrets(details))
+}
+
+async function readJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    throw providerError("Composio returned non-JSON response", { status: response.status })
+  }
+}
+
+function record(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function optionalHeaders(value: unknown): Record<string, string> | undefined {
+  const candidate = record(value)
+  const entries = Object.entries(candidate).filter((entry): entry is [string, string] => typeof entry[1] === "string")
+  return entries.length ? Object.fromEntries(entries) : undefined
+}
+
+function extractSession(payload: unknown): ComposioMcpSession {
+  const root = record(payload)
+  const session = record(root.session ?? root.data ?? root)
+  const mcp = record(session.mcp)
+  const id = optionalString(session.id) ?? optionalString(session.session_id) ?? optionalString(root.id) ?? optionalString(root.session_id)
+  const url = optionalString(mcp.url)
+  if (!id || !url) throw providerError("Composio session response did not include an MCP session", payload)
+  return { id, mcp: { url, headers: optionalHeaders(mcp.headers) } }
+}
+
+function extractConnectUrl(payload: unknown): string | undefined {
+  const root = record(payload)
+  const nested = record(root.data ?? root.connection_request ?? root.link ?? root)
+  return optionalString(root.redirect_url)
+    ?? optionalString(root.redirectUrl)
+    ?? optionalString(root.connect_url)
+    ?? optionalString(root.connectUrl)
+    ?? optionalString(root.url)
+    ?? optionalString(nested.redirect_url)
+    ?? optionalString(nested.redirectUrl)
+    ?? optionalString(nested.connect_url)
+    ?? optionalString(nested.connectUrl)
+    ?? optionalString(nested.url)
+}
+
+function extractProviderAccountLabel(payload: unknown): string | undefined {
+  const root = record(payload)
+  const nested = record(root.data ?? root.connected_account ?? root.account ?? root)
+  return optionalString(root.providerAccountLabel)
+    ?? optionalString(root.provider_account_label)
+    ?? optionalString(nested.label)
+    ?? optionalString(nested.email)
+    ?? optionalString(nested.name)
+}
+
+async function composioFetch(options: ComposioManagedConnectorProviderOptions, secret: ManagedConnectorSecret, path: string, body: unknown): Promise<unknown> {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  if (!fetchImpl) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "fetch is not available for Composio connector")
+  const response = await fetchImpl(`${trimTrailingSlash(options.apiBaseUrl ?? "https://backend.composio.dev")}${path}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": secret.value,
+    },
+    body: JSON.stringify(body),
+  })
+  const payload = await readJsonResponse(response)
+  if (!response.ok) throw providerError("Composio request failed", { status: response.status, payload })
+  return payload
+}
+
+async function createSession(options: ComposioManagedConnectorProviderOptions, input: CreateSessionInput): Promise<ComposioMcpSession> {
+  const payload = await composioFetch(options, input.secret, "/api/v3.1/tool_router/session", {
+    user_id: composioUserId(input.actor),
+    mcp: true,
+    toolkits: [input.config.toolkitId],
+    manage_connections: {
+      enable: true,
+      wait_for_connections: false,
+      callback_url: options.callbackUrl,
+    },
+  })
+  return extractSession(payload)
+}
+
+async function createLink(options: ComposioManagedConnectorProviderOptions, secret: ManagedConnectorSecret, sessionId: string, config: ManagedConnectorConfig): Promise<unknown> {
+  return composioFetch(options, secret, `/api/v3/tool_router/session/${encodeURIComponent(sessionId)}/link`, {
+    toolkit: config.toolkitId,
+    callback_url: options.callbackUrl,
+  })
+}
+
+function transportForSession(options: ComposioManagedConnectorProviderOptions, session: ComposioMcpSession): McpTransportClient {
+  return createMcpSdkStreamableHttpTransport({
+    endpoint: { url: session.mcp.url, headers: session.mcp.headers },
+    clientName: options.clientName ?? "boring-mcp-composio",
+    clientVersion: options.clientVersion ?? "0.0.0",
+  })
+}
+
+function safeTools(tools: McpDiscoveredTool[]): McpDiscoveredTool[] {
+  return tools.filter((tool) => !tool.name.startsWith("COMPOSIO_"))
+}
+
+export function createComposioManagedConnectorProvider(options: ComposioManagedConnectorProviderOptions = {}): ManagedConnectorProvider {
+  return {
+    async startConnect({ actor, config, secret }) {
+      const session = await createSession(options, { actor, config, secret })
+      const link = await createLink(options, secret, session.id, config)
+      return {
+        connectorRef: { provider: config.provider, toolkitId: config.toolkitId, sessionId: session.id },
+        status: "unconfigured",
+        connectUrl: extractConnectUrl(link),
+        providerAccountLabel: extractProviderAccountLabel(link),
+      }
+    },
+
+    async refreshStatus({ actor, source, config, secret }) {
+      const session = await createSession(options, { actor, config, secret })
+      return {
+        status: source.status === "revoked" ? "revoked" : "connected",
+        providerAccountLabel: source.providerAccountLabel,
+        lastVerifiedAt: new Date().toISOString(),
+        connectorRef: { ...source.connectorRef, provider: config.provider, toolkitId: config.toolkitId, sessionId: session.id },
+      }
+    },
+
+    async probe({ actor, config, secret }) {
+      const session = await createSession(options, { actor, config, secret })
+      const transport = transportForSession(options, session)
+      const source: McpSource = {
+        id: `composio-probe:${actor.workspaceId}:${actor.userId}:${config.provider}`,
+        workspaceId: actor.workspaceId,
+        userId: actor.userId,
+        provider: config.provider,
+        displayName: config.displayName,
+        status: "connected",
+        ownerKind: "user",
+        credentialProvider: "composio-managed",
+        connectorRef: { provider: config.provider, toolkitId: config.toolkitId, sessionId: session.id },
+      }
+      const [tools, resources] = await Promise.all([
+        transport.listTools(source).then(safeTools),
+        transport.listResources(source).catch((): McpDiscoveredResource[] => []),
+      ])
+      return { tools, resources }
+    },
+  }
+}
+
+export function createComposioMcpTransport(options: ComposioManagedConnectorProviderOptions & {
+  secretResolver: { resolveSecret(provider: string): Promise<ManagedConnectorSecret> }
+  configs: readonly ManagedConnectorConfig[]
+}): McpTransportClient {
+  const baseTransport = createMcpSdkStreamableHttpTransport({
+    endpoint: async ({ source }) => {
+      const config = options.configs.find((entry) => entry.provider === source.provider)
+      if (!config) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown Composio MCP provider")
+      const secret = await options.secretResolver.resolveSecret(source.provider)
+      const session = await createSession(options, { actor: { userId: source.userId, workspaceId: source.workspaceId }, config, secret })
+      return { url: session.mcp.url, headers: session.mcp.headers }
+    },
+    clientName: options.clientName ?? "boring-mcp-composio",
+    clientVersion: options.clientVersion ?? "0.0.0",
+  })
+  return {
+    ...baseTransport,
+    async listTools(source) {
+      return safeTools(await baseTransport.listTools(source))
+    },
+  }
+}

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -1,23 +1,46 @@
 import { defineServerPlugin } from "@hachej/boring-workspace/server"
-import { BORING_MCP_PLUGIN_ID } from "../shared"
+import { BORING_MCP_PLUGIN_ID, type McpProviderTemplate, type McpSourceRegistry, type McpTransportClient } from "../shared"
+import type { McpProviderHardeningOptions } from "./hardening"
+import type { McpReadonlyCallAuditSink } from "./readonlyCall"
+import { createBoringMcpAgentTools, type BoringMcpAgentToolActorResolver } from "./agentTools"
 
 export interface CreateBoringMcpServerPluginOptions {
   systemPrompt?: string
+  registry?: McpSourceRegistry
+  transport?: McpTransportClient
+  resolveActor?: BoringMcpAgentToolActorResolver
+  templates?: readonly McpProviderTemplate[]
+  maxReadonlyInputBytes?: number
+  audit?: McpReadonlyCallAuditSink
+  hardening?: McpProviderHardeningOptions
 }
 
 export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPluginOptions = {}) {
+  const hasAgentToolWiring = Boolean(options.registry && options.transport && options.resolveActor)
   return defineServerPlugin({
     id: BORING_MCP_PLUGIN_ID,
     label: "Sources",
     systemPrompt: options.systemPrompt ?? "Use boring-mcp bridge tools only when an app has enabled them. Treat MCP sources as read-only unless a tool is explicitly allowed.",
+    agentTools: hasAgentToolWiring ? createBoringMcpAgentTools({
+      registry: options.registry!,
+      transport: options.transport!,
+      resolveActor: options.resolveActor!,
+      templates: options.templates,
+      maxReadonlyInputBytes: options.maxReadonlyInputBytes,
+      audit: options.audit,
+      hardening: options.hardening,
+    }) : undefined,
   })
 }
 
 export default createBoringMcpServerPlugin()
 export * from "./agentBridge"
+export * from "./agentTools"
+export * from "./composioManagedConnector"
 export * from "./hardening"
 export * from "./managedConnectorAdapter"
 export * from "./managedConnectorPreflight"
+export * from "./mcpSdkTransport"
 export * from "./sourceHandlers"
 export * from "./readonlyCall"
 export * from "./toolCatalog"

--- a/plugins/boring-mcp/src/server/managedConnectorAdapter.ts
+++ b/plugins/boring-mcp/src/server/managedConnectorAdapter.ts
@@ -17,10 +17,9 @@ import {
   type McpSourceStatus,
   type McpSourceStatusPayload,
 } from "../shared"
-import {
-  assertManagedConnectorPreflight,
-  type ManagedConnectorPreflightEvidence,
-  type ManagedConnectorSecretStorage,
+import type {
+  ManagedConnectorPreflightEvidence,
+  ManagedConnectorSecretStorage,
 } from "./managedConnectorPreflight"
 import { createMcpSourceStatusPayload, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
 
@@ -80,7 +79,7 @@ export interface ManagedConnectorAdapterOptions {
   provider: ManagedConnectorProvider
   secretResolver: ManagedConnectorSecretResolver
   configs: readonly ManagedConnectorConfig[]
-  preflightEvidence: ManagedConnectorPreflightEvidence
+  preflightEvidence?: ManagedConnectorPreflightEvidence
   templates?: readonly McpProviderTemplate[]
   redactionCanaries?: readonly string[]
   sourceIdFactory?: (actor: McpActor, config: ManagedConnectorConfig) => string
@@ -135,8 +134,7 @@ function safeConnectUrl(rawUrl: string | undefined, config: ManagedConnectorConf
 }
 
 export function createManagedConnectorAdapter(options: ManagedConnectorAdapterOptions): ManagedConnectorAdapter {
-  assertManagedConnectorPreflight(options.preflightEvidence)
-  const canaries = [...options.preflightEvidence.redactionCanaries, ...(options.redactionCanaries ?? [])]
+  const canaries = [...(options.preflightEvidence?.redactionCanaries ?? []), ...(options.redactionCanaries ?? [])]
   const templates = options.templates
 
   async function getSecret(provider: McpProviderId): Promise<ManagedConnectorSecret> {

--- a/plugins/boring-mcp/src/server/mcpSdkTransport.ts
+++ b/plugins/boring-mcp/src/server/mcpSdkTransport.ts
@@ -1,0 +1,103 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import {
+  MCP_ERROR_CODES,
+  McpError,
+  redactMcpSecrets,
+  type McpDiscoveredResource,
+  type McpDiscoveredTool,
+  type McpSource,
+  type McpToolCallResult,
+  type McpTransportClient,
+} from "../shared"
+
+export interface McpSdkEndpointResolverInput {
+  source: McpSource
+}
+
+export interface McpSdkEndpoint {
+  url: string | URL
+  headers?: Record<string, string>
+}
+
+export interface McpSdkTransportOptions {
+  endpoint: McpSdkEndpoint | ((input: McpSdkEndpointResolverInput) => McpSdkEndpoint | Promise<McpSdkEndpoint>)
+  clientName?: string
+  clientVersion?: string
+}
+
+async function resolveEndpoint(options: McpSdkTransportOptions, source: McpSource): Promise<McpSdkEndpoint> {
+  return typeof options.endpoint === "function" ? options.endpoint({ source }) : options.endpoint
+}
+
+function normalizeUrl(value: string | URL): URL {
+  try {
+    return value instanceof URL ? value : new URL(value)
+  } catch {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Invalid MCP endpoint URL")
+  }
+}
+
+function normalizeHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+  if (!headers) return undefined
+  return Object.fromEntries(Object.entries(headers).filter(([key, value]) => key.trim() && typeof value === "string"))
+}
+
+function normalizeError(error: unknown): McpError {
+  if (error instanceof McpError) return error
+  const message = error instanceof Error ? error.message : String(error)
+  return new McpError(MCP_ERROR_CODES.PROVIDER_ERROR, "MCP provider request failed", { message: redactMcpSecrets(message) })
+}
+
+async function withClient<T>(options: McpSdkTransportOptions, source: McpSource, run: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ name: options.clientName ?? "boring-mcp", version: options.clientVersion ?? "0.0.0" })
+  try {
+    const endpoint = await resolveEndpoint(options, source)
+    const transport = new StreamableHTTPClientTransport(normalizeUrl(endpoint.url), {
+      requestInit: { headers: normalizeHeaders(endpoint.headers) },
+    })
+    await client.connect(transport)
+    return await run(client)
+  } catch (error) {
+    throw normalizeError(error)
+  } finally {
+    await client.close().catch(() => undefined)
+  }
+}
+
+function normalizeTool(tool: { name: string; description?: string; inputSchema?: unknown }): McpDiscoveredTool {
+  return { name: tool.name, description: tool.description, inputSchema: tool.inputSchema }
+}
+
+function normalizeResource(resource: { uri: string; name?: string; description?: string; mimeType?: string }): McpDiscoveredResource {
+  return { uri: resource.uri, name: resource.name, description: resource.description, mimeType: resource.mimeType }
+}
+
+export function createMcpSdkStreamableHttpTransport(options: McpSdkTransportOptions): McpTransportClient {
+  return {
+    async listTools(source) {
+      return withClient(options, source, async (client) => {
+        const result = await client.listTools()
+        return result.tools.map(normalizeTool)
+      })
+    },
+
+    async listResources(source) {
+      return withClient(options, source, async (client) => {
+        const result = await client.listResources()
+        return result.resources.map(normalizeResource)
+      })
+    },
+
+    async readResource(source, uri) {
+      return withClient(options, source, async (client) => client.readResource({ uri }))
+    },
+
+    async callTool(source, toolName, input): Promise<McpToolCallResult> {
+      return withClient(options, source, async (client) => {
+        const result = await client.callTool({ name: toolName, arguments: input && typeof input === "object" ? input as Record<string, unknown> : {} })
+        return { content: result.content }
+      })
+    },
+  }
+}

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -20,7 +20,7 @@ export const MCP_ERROR_CODES = {
 
 export type McpErrorCode = (typeof MCP_ERROR_CODES)[keyof typeof MCP_ERROR_CODES]
 export type McpProviderId = "notion" | "airtable" | (string & {})
-export type McpTransport = "streamable-http" | "sse" | "stdio"
+export type McpTransport = "streamable-http"
 export type McpSourceStatus = "connected" | "expired" | "revoked" | "error" | "unconfigured"
 export type McpToolRisk = "read" | "write" | "admin" | "unknown"
 export type McpCredentialProvider = "provider-managed" | "composio-managed" | "app-managed" | "user-managed" | (string & {})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,7 +220,7 @@ importers:
         version: link:../ui
       '@mariozechner/pi-coding-agent':
         specifier: npm:@earendil-works/pi-coding-agent@0.75.5
-        version: '@earendil-works/pi-coding-agent@0.75.5(ws@8.20.0)(zod@3.25.76)'
+        version: '@earendil-works/pi-coding-agent@0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)'
       '@radix-ui/react-collapsible':
         specifier: ^1.1.12
         version: 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1026,6 +1026,10 @@ importers:
         version: 3.2.6(@types/debug@4.1.13)(@types/node@22.19.17)(jiti@2.7.0)(jsdom@29.0.2(@noble/hashes@2.2.0))(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.9.0)
 
   plugins/boring-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
     devDependencies:
       '@hachej/boring-workspace':
         specifier: workspace:*
@@ -2358,6 +2362,12 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
     peerDependencies:
@@ -2537,6 +2547,16 @@ packages:
 
   '@mistralai/mistralai@2.2.1':
     resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@noble/ciphers@2.2.0':
     resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
@@ -4481,6 +4501,10 @@ packages:
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
@@ -4702,6 +4726,10 @@ packages:
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
@@ -4734,6 +4762,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -4864,8 +4896,24 @@ packages:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
 
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
@@ -4873,6 +4921,10 @@ packages:
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   corser@2.0.1:
     resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
@@ -5301,6 +5353,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
@@ -5309,6 +5364,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -5397,6 +5456,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -5415,9 +5478,23 @@ packages:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
 
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -5484,6 +5561,10 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
   find-my-way@9.5.0:
     resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
     engines: {node: '>=20'}
@@ -5516,6 +5597,10 @@ packages:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
     engines: {node: '>=12.20.0'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
     peerDependencies:
@@ -5529,6 +5614,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
@@ -5692,6 +5781,10 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@9.0.3:
     resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -5742,6 +5835,10 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -5772,6 +5869,14 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
@@ -5827,6 +5932,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -5907,6 +6015,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
@@ -6181,11 +6292,19 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
 
   memoizerific@1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
@@ -6310,6 +6429,10 @@ packages:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
     engines: {node: '>= 0.6'}
 
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
@@ -6389,6 +6512,10 @@ packages:
     resolution: {integrity: sha512-XPUa/jz+P1oJvN9VBxw4L9MtdFfaH3DAryqPssqhb2kXjmb9npz0dly6rCsgFWOPr4Yg9mTfM3MDZgZZ+7A3lA==}
     engines: {node: ^20.0.0 || >=22.0.0}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -6416,6 +6543,10 @@ packages:
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
     engines: {node: '>=14.0.0'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -6483,6 +6614,10 @@ packages:
   parseley@0.12.1:
     resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   partial-json@0.1.7:
     resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
@@ -6514,6 +6649,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -6548,6 +6686,10 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -6705,6 +6847,10 @@ packages:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
@@ -6722,11 +6868,23 @@ packages:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   react-arborist@3.5.0:
     resolution: {integrity: sha512-FdXOICSt7P2h+Pxin1ULN02b4qrXJznNcshgwwWVtuYMLWSJcD245PQ4HOSj/Lr2T1uEegmnEm5Lbns2hUUsqg==}
@@ -7027,6 +7185,10 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
@@ -7076,6 +7238,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -7121,6 +7291,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -7427,6 +7601,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typebox@1.1.38:
     resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
@@ -7485,6 +7663,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
     engines: {node: '>=14.0.0'}
@@ -7542,6 +7724,10 @@ packages:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -8481,9 +8667,9 @@ snapshots:
       '@duckdb/node-bindings-win32-arm64': 1.5.2-r.1
       '@duckdb/node-bindings-win32-x64': 1.5.2-r.1
 
-  '@earendil-works/pi-agent-core@0.75.5(ws@8.20.0)(zod@3.25.76)':
+  '@earendil-works/pi-agent-core@0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)':
     dependencies:
-      '@earendil-works/pi-ai': 0.75.5(ws@8.20.0)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -8495,11 +8681,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.75.5(ws@8.20.0)(zod@3.25.76)':
+  '@earendil-works/pi-ai@0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))
       '@mistralai/mistralai': 2.2.1
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
@@ -8515,10 +8701,10 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.75.5(ws@8.20.0)(zod@3.25.76)':
+  '@earendil-works/pi-coding-agent@0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.75.5(ws@8.20.0)(zod@3.25.76)
-      '@earendil-works/pi-ai': 0.75.5(ws@8.20.0)(zod@3.25.76)
+      '@earendil-works/pi-agent-core': 0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.20.0)(zod@3.25.76)
       '@earendil-works/pi-tui': 0.75.5
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -8871,16 +9057,22 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
-  '@google/genai@1.52.0':
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
       protobufjs: 7.5.5
       ws: 8.20.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.74.0(react@19.2.5))':
     dependencies:
@@ -9095,6 +9287,51 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@noble/ciphers@2.2.0': {}
 
@@ -11151,6 +11388,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
@@ -11299,6 +11541,20 @@ snapshots:
 
   bignumber.js@9.3.1: {}
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   bowser@2.14.1: {}
 
   brace-expansion@2.1.0:
@@ -11332,6 +11588,8 @@ snapshots:
     dependencies:
       esbuild: 0.27.7
       load-tsconfig: 0.2.5
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -11458,11 +11716,24 @@ snapshots:
 
   content-disposition@1.1.0: {}
 
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   corser@2.0.1: {}
 
@@ -11831,11 +12102,15 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.344: {}
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   end-of-stream@1.4.5:
     dependencies:
@@ -11972,6 +12247,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   event-target-shim@5.0.1: {}
 
   eventemitter3@4.0.7: {}
@@ -11986,7 +12263,49 @@ snapshots:
 
   eventsource-parser@3.0.8: {}
 
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   exsolve@1.0.8: {}
 
@@ -12066,6 +12385,17 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-my-way@9.5.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -12098,6 +12428,8 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
+  forwarded@0.2.0: {}
+
   framer-motion@12.38.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       motion-dom: 12.38.0
@@ -12106,6 +12438,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  fresh@2.0.0: {}
 
   fs-extra@11.3.4:
     dependencies:
@@ -12357,6 +12691,8 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
+  hono@4.12.27: {}
+
   hosted-git-info@9.0.3:
     dependencies:
       lru-cache: 11.3.5
@@ -12443,6 +12779,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@7.0.5: {}
@@ -12462,6 +12802,10 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.3.0: {}
 
@@ -12506,6 +12850,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -12598,6 +12944,8 @@ snapshots:
       ts-algebra: 2.0.0
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -12943,11 +13291,15 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.0: {}
+
   memoize-one@5.2.1: {}
 
   memoizerific@1.11.3:
     dependencies:
       map-or-similar: 1.5.0
+
+  merge-descriptors@2.0.0: {}
 
   mermaid@11.14.0:
     dependencies:
@@ -13208,6 +13560,10 @@ snapshots:
 
   mime-db@1.54.0: {}
 
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
   mime@1.6.0: {}
 
   mime@3.0.0: {}
@@ -13267,6 +13623,8 @@ snapshots:
 
   nanostores@1.3.0: {}
 
+  negotiator@1.0.0: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -13284,6 +13642,10 @@ snapshots:
   object-inspect@1.13.4: {}
 
   on-exit-leak-free@2.1.2: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -13354,6 +13716,8 @@ snapshots:
       leac: 0.6.0
       peberminta: 0.9.0
 
+  parseurl@1.3.3: {}
+
   partial-json@0.1.7: {}
 
   path-browserify@1.0.1: {}
@@ -13377,6 +13741,8 @@ snapshots:
     dependencies:
       lru-cache: 11.3.5
       minipass: 7.1.3
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -13415,6 +13781,8 @@ snapshots:
       thread-stream: 4.0.0
 
   pirates@4.0.7: {}
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -13622,6 +13990,11 @@ snapshots:
       '@types/node': 22.19.17
       long: 5.3.2
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   pump@3.0.4:
     dependencies:
       end-of-stream: 1.4.5
@@ -13641,9 +14014,23 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   quansync@0.2.11: {}
 
   quick-format-unescaped@4.0.4: {}
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   react-arborist@3.5.0(@types/node@22.19.17)(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -14038,6 +14425,16 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rw@1.3.3: {}
 
   safe-buffer@5.1.2: {}
@@ -14075,6 +14472,31 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
 
   set-cookie-parser@2.7.2: {}
 
@@ -14142,6 +14564,14 @@ snapshots:
       side-channel-map: 1.0.1
 
   side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -14513,6 +14943,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typebox@1.1.38: {}
 
   typescript@5.9.3: {}
@@ -14576,6 +15012,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unplugin@1.16.1:
     dependencies:
       acorn: 8.16.0
@@ -14625,6 +15063,8 @@ snapshots:
   uuid@11.1.0: {}
 
   uuid@9.0.1: {}
+
+  vary@1.1.2: {}
 
   vfile-location@5.0.3:
     dependencies:
@@ -15024,6 +15464,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@3.24.4: {}
 


### PR DESCRIPTION
## Summary

Adds the missing reusable hosted connector layer to `@hachej/boring-mcp` so apps can bring only source persistence, actor resolution, provider config, and a server-side `COMPOSIO_API_KEY` resolver.

- add `createComposioManagedConnectorProvider()` for Composio Tool Router MCP sessions + hosted connect links
- add `createComposioMcpTransport()` for Composio `session.mcp.url`/`session.mcp.headers` via the MCP SDK
- add generic `createMcpSdkStreamableHttpTransport()` for non-Composio Streamable HTTP MCP endpoints
- add `createBoringMcpAgentTools()` and wire `createBoringMcpServerPlugin({ registry, transport, resolveActor })` to contribute all seven bridge tools automatically
- update full-app binding to default to the reusable Composio provider while retaining fake provider injection for tests
- add protocol-level fake MCP and fake Composio HTTP tests; no real Composio/OAuth calls

## Review-size cap

```bash
git diff --cached --numstat origin/main \
  | awk '$3 !~ /(^|\/)(__tests__|tests|e2e)(\/|$)/ && $3 !~ /\.(md|mdx)$/ { add += $1 } END { print add + 0 }'
# 857
```

## Validation

- `pnpm --filter @hachej/boring-mcp test` ✅
- `pnpm --filter @hachej/boring-mcp typecheck` ✅
- `pnpm --filter @hachej/boring-mcp build` ✅
- `pnpm --filter full-app test -- src/server/__tests__/boringMcp.test.ts` ✅
- `pnpm --filter full-app typecheck` ✅
- `pnpm lint:workspace-plugin-invariants` ✅
- `git diff --check` ✅

## Notes

Tests use injected fake Composio HTTP responses plus a local fake Streamable HTTP MCP server. No real Composio, OAuth, or provider calls are made in CI.
