### PR TITLE
#416 company-fs: enforce readonly company viewers

### DIFF
--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { createDeckPlugin } from "@hachej/boring-deck/front"
 import type { DeckWidgetDefinition } from "@hachej/boring-deck/shared"
-import { WorkspaceProvider } from "@hachej/boring-workspace"
+import { FileTreePane, WorkspaceProvider } from "@hachej/boring-workspace"
 import { WorkspaceAgentFront, WorkspaceFullPagePanel, parseFullPagePanelLocation } from "@hachej/boring-workspace/app/front"
+import { definePlugin, type WorkspaceSourceProps } from "@hachej/boring-workspace/plugin"
 import { askUserPlugin } from "@hachej/boring-ask-user/front"
 import { SHOWCASE_SESSION_ID, seedShowcase } from "./showcaseMessages"
 
@@ -14,6 +15,10 @@ function isShowcaseRoute(): boolean {
 function isFullPageRoute(): boolean {
   if (typeof window === "undefined") return false
   return window.location.pathname === "/full-page" || window.location.pathname === "/full-page/"
+}
+
+function isMultiFilesystemPlaygroundRoute(): boolean {
+  return (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_PLAYGROUND_MULTI_FS === "1"
 }
 
 interface WorkspaceMeta {
@@ -41,7 +46,49 @@ const playgroundDeckPlugin = createDeckPlugin({
   },
 })
 
+function MultiFilesystemFileTreeSource(props: WorkspaceSourceProps) {
+  return (
+    <FileTreePane
+      {...props}
+      params={{
+        ...(props.params as Record<string, unknown> | undefined),
+        chromeless: false,
+        roots: [
+          {
+            filesystem: "user",
+            label: "Workspace",
+            rootDir: ".",
+            access: "readwrite",
+            searchPlaceholder: "Search workspace files...",
+          },
+          {
+            filesystem: "company_context",
+            label: "Company",
+            rootDir: "/",
+            access: "readonly",
+            searchPlaceholder: "Filter company files...",
+          },
+        ],
+      }}
+    />
+  )
+}
+
+const multiFilesystemPlaygroundPlugin = definePlugin({
+  id: "workspace-playground-multi-fs",
+  label: "Workspace playground multi-filesystem fixtures",
+  workspaceSources: [
+    {
+      id: "files",
+      label: "Files",
+      source: "app",
+      component: MultiFilesystemFileTreeSource,
+    },
+  ],
+})
+
 const workspacePlugins = [askUserPlugin, playgroundDeckPlugin]
+const multiFilesystemWorkspacePlugins = [askUserPlugin, playgroundDeckPlugin, multiFilesystemPlaygroundPlugin]
 const externalPluginsEnabled = (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_BORING_EXTERNAL_PLUGINS === "1"
 
 function resetPlaygroundStorageIfRequested(): void {
@@ -97,6 +144,8 @@ export function WorkspaceShell() {
   resetPlaygroundStorageIfRequested()
   const showcase = useMemo(isShowcaseRoute, [])
   const fullPage = useMemo(isFullPageRoute, [])
+  const multiFilesystem = useMemo(isMultiFilesystemPlaygroundRoute, [])
+  const activeWorkspacePlugins = multiFilesystem ? multiFilesystemWorkspacePlugins : workspacePlugins
   const [projectName, setProjectName] = useState("Workspace")
   const [workspaceId, setWorkspaceId] = useState("Workspace")
   const [metaLoaded, setMetaLoaded] = useState(showcase || fullPage)
@@ -160,10 +209,10 @@ export function WorkspaceShell() {
       apiBaseUrl=""
       persistenceEnabled
       debug
-      providerStorageKey={showcase ? "boring-ui-v2:layout:playground" : `boring-ui-v2:layout:playground:${workspaceId}`}
+      providerStorageKey={showcase ? "boring-ui-v2:layout:playground" : `boring-ui-v2:layout:playground:${multiFilesystem ? "multi-fs:" : ""}${workspaceId}`}
       appTitle={showcase ? "Boring" : projectName}
       workspaceLabel={showcase ? undefined : projectName}
-      workspaceLayout="plugin-tabs"
+      workspaceLayout={multiFilesystem ? "classic" : "plugin-tabs"}
       defaultSessionTitle="New chat"
       externalPlugins={externalPluginsEnabled}
       frontPluginHotReload={externalPluginsEnabled ? "vite" : undefined}
@@ -172,7 +221,7 @@ export function WorkspaceShell() {
       sessions={sessions}
       activeSessionId={showcase ? SHOWCASE_SESSION_ID : undefined}
       onActiveSessionIdChange={handleActiveSessionIdChange}
-      plugins={workspacePlugins}
+      plugins={activeWorkspacePlugins}
       chatParams={{ thinkingControl: true }}
     />
   )

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto"
 import { existsSync, mkdirSync, readdirSync, copyFileSync, statSync } from "node:fs"
-import { basename, dirname, resolve } from "node:path"
+import { readFile, readdir, stat } from "node:fs/promises"
+import { basename, dirname, isAbsolute, relative, resolve } from "node:path"
 import { createRemoteWorkerModeAdapter } from "@hachej/boring-agent/server"
 import { createWorkspaceAgentServer } from "@hachej/boring-workspace/app/server"
 
@@ -34,6 +35,15 @@ export function seedWorkspaceFromFixtures(workspaceRoot = WORKSPACE_DIR): void {
   seedFixtureEntry(FIXTURES_DIR, workspaceRoot)
 }
 
+function resolvePlaygroundBindingPath(root: string, rawPath: string): string {
+  const normalized = rawPath.trim() || "/"
+  const withoutLeadingSlash = normalized.replace(/^\/+/, "")
+  const resolved = resolve(root, withoutLeadingSlash || ".")
+  const rel = relative(root, resolved)
+  if (rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))) return resolved
+  throw new Error("path escapes playground binding root")
+}
+
 let agentBoot: Promise<void> | null = null
 
 export async function startPlaygroundServer(): Promise<void> {
@@ -51,6 +61,7 @@ export async function startPlaygroundServer(): Promise<void> {
       ? (process.env.BORING_WORKSPACE_PLAYGROUND_WORKSPACE_ID?.trim() || randomUUID())
       : undefined
     const localRuntimeMode = process.env.BORING_AGENT_MODE?.trim() === "direct" ? "direct" : "local"
+    const multiFilesystemPlayground = process.env.BORING_WORKSPACE_PLAYGROUND_MULTI_FS === "1" || process.env.VITE_PLAYGROUND_MULTI_FS === "1"
     console.log(`[workspace-playground] workspace root: ${workspaceRoot}`)
     console.log(`[workspace-playground] runtime mode: ${remoteWorkerModeAdapter ? "remote-worker" : localRuntimeMode}`)
     if (remoteWorkerWorkspaceId) {
@@ -65,6 +76,40 @@ export async function startPlaygroundServer(): Promise<void> {
       logger: true,
       externalPlugins: EXTERNAL_PLUGINS_ENABLED,
       defaultPluginPackages: ["@hachej/boring-ask-user"],
+      runtimeProvisioner: multiFilesystemPlayground
+        ? async ({ runtimeBundle }) => {
+            runtimeBundle.filesystemBindings = [
+              ...(runtimeBundle.filesystemBindings ?? []),
+              {
+                filesystem: "company_context",
+                access: "readonly",
+                operations: {
+                  async read({ path }) {
+                    const target = resolvePlaygroundBindingPath(workspaceRoot, path)
+                    return { content: await readFile(target, "utf8") }
+                  },
+                  async list({ path }) {
+                    const target = resolvePlaygroundBindingPath(workspaceRoot, path)
+                    return { entries: await readdir(target) }
+                  },
+                  async find() {
+                    return { paths: [] }
+                  },
+                  async grep() {
+                    return { matches: [] }
+                  },
+                  async stat({ path }) {
+                    const target = resolvePlaygroundBindingPath(workspaceRoot, path)
+                    return { isDirectory: (await stat(target)).isDirectory() }
+                  },
+                  rejectMutation(operation) {
+                    throw new Error(`company_context binding is readonly: ${operation}`)
+                  },
+                },
+              },
+            ]
+          }
+        : undefined,
       workspaceBridge: { allowInsecureLocalCliBrowserAuth: true },
     })
     app.get("/api/v1/workspace/meta", async () => {

--- a/apps/workspace-playground/vite.config.ts
+++ b/apps/workspace-playground/vite.config.ts
@@ -18,9 +18,9 @@ const fsAllow = externalRuntimeExtensionsRoot ? [repoRoot, externalRuntimeExtens
 // aliases.
 const playgroundOnlyAliases = [
   // Keep app code importing the public package CSS subpath, but point the
-  // playground's local monorepo dev server at the built CSS artifact so Vite
-  // serves it as text/css instead of falling back through HTML history.
-  { find: "@hachej/boring-workspace/globals.css", replacement: resolve(__dirname, "../../packages/workspace/dist/workspace.css") },
+  // playground's local monorepo dev server at the source CSS so Vite serves
+  // it as text/css even when package dist artifacts are stale/missing.
+  { find: "@hachej/boring-workspace/globals.css", replacement: resolve(__dirname, "../../packages/workspace/src/globals.css") },
   // Cover subpath imports from runtime extensions (e.g. boring-ui-factory
   // .pi/extensions) that land through Vite's /@fs/ resolver.
   { find: "@hachej/boring-workspace/plugin", replacement: resolve(__dirname, "../../packages/workspace/dist/plugin.js") },

--- a/packages/agent/src/server/http/routes/__tests__/file.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/file.test.ts
@@ -23,13 +23,14 @@ afterEach(async () => {
 
 async function createTestAppWithWorkspace(
   workspace: Workspace,
-  companyOperations?: RuntimeFilesystemBindingOperations,
+  operations?: RuntimeFilesystemBindingOperations,
+  access: 'readonly' | 'readwrite' = 'readonly',
 ): Promise<FastifyInstance> {
   const app = Fastify({ logger: false })
   await app.register(fileRoutes, {
     workspace,
-    ...(companyOperations
-      ? { filesystemBindings: [{ filesystem: 'company_context', access: 'readonly', operations: companyOperations }] }
+    ...(operations
+      ? { filesystemBindings: [{ filesystem: 'company_context', access, operations }] }
       : {}),
   })
   await app.ready()
@@ -79,7 +80,7 @@ describe('file routes (NodeWorkspace integration)', () => {
       url: '/api/v1/files?filesystem=company_context&path=%2Fcompany%2Fhr%2Fpolicy.md',
     })
     expect(allowed.statusCode).toBe(200)
-    expect(allowed.json()).toEqual({ content: 'company:/company/hr/policy.md' })
+    expect(allowed.json()).toEqual({ content: 'company:/company/hr/policy.md', access: 'readonly' })
     expect(operations.read).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/hr/policy.md' })
 
     const rawAllowed = await app.inject({
@@ -149,7 +150,7 @@ describe('file routes (NodeWorkspace integration)', () => {
       url: '/api/v1/files?filesystem=project_alpha&path=%2Fsrc%2Findex.ts',
     })
     expect(allowed.statusCode).toBe(200)
-    expect(allowed.json()).toEqual({ content: 'project_alpha:/src/index.ts' })
+    expect(allowed.json()).toEqual({ content: 'project_alpha:/src/index.ts', access: 'readonly' })
     expect(operations.read).toHaveBeenCalledWith({ filesystem: 'project_alpha', path: '/src/index.ts' })
 
     const writeDenied = await app.inject({
@@ -159,6 +160,55 @@ describe('file routes (NodeWorkspace integration)', () => {
     })
     expect(writeDenied.statusCode).toBe(403)
     expect(writeDenied.json()).toEqual({ error: { code: ERROR_CODE_READONLY, message: 'project_alpha binding is readonly' } })
+  })
+
+  test('company_context readwrite binding routes management mutations through binding operations', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-file-routes-'))
+    tempRoots.push(workspaceRoot)
+    const operations: RuntimeFilesystemBindingOperations = {
+      read: vi.fn(async ({ path }) => ({ content: `company:${path}` })),
+      list: vi.fn(),
+      find: vi.fn(),
+      grep: vi.fn(),
+      stat: vi.fn(async () => ({ isDirectory: false })),
+      write: vi.fn(async () => ({ mtimeMs: 789 })),
+      delete: vi.fn(async () => ({})),
+      move: vi.fn(async () => ({})),
+      mkdir: vi.fn(async () => ({})),
+      rejectMutation: vi.fn((operation) => {
+        throw new Error(`readonly ${operation}`)
+      }),
+    }
+    const app = await createTestAppWithWorkspace(createNodeWorkspace(workspaceRoot), operations, 'readwrite')
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/files?filesystem=company_context&path=%2Fcompany%2Fcurated.md',
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ content: 'company:/company/curated.md', access: 'readwrite' })
+
+    const writeRes = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files',
+      payload: { filesystem: 'company_context', path: '/company/curated.md', content: 'updated', returnMtimeMs: true },
+    })
+    expect(writeRes.statusCode).toBe(200)
+    expect(writeRes.json()).toEqual({ ok: true, mtimeMs: 789 })
+    expect(operations.write).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/curated.md', content: 'updated' })
+
+    const deleteRes = await app.inject({ method: 'DELETE', url: '/api/v1/files?filesystem=company_context&path=%2Fcompany%2Fcurated.md' })
+    expect(deleteRes.statusCode).toBe(200)
+    expect(operations.delete).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/curated.md' })
+
+    const moveRes = await app.inject({ method: 'POST', url: '/api/v1/files/move', payload: { filesystem: 'company_context', from: '/company/a.md', to: '/company/b.md' } })
+    expect(moveRes.statusCode).toBe(200)
+    expect(operations.move).toHaveBeenCalledWith({ filesystem: 'company_context', from: '/company/a.md', to: '/company/b.md' })
+
+    const mkdirRes = await app.inject({ method: 'POST', url: '/api/v1/dirs', payload: { filesystem: 'company_context', path: '/company/new', recursive: true } })
+    expect(mkdirRes.statusCode).toBe(200)
+    expect(operations.mkdir).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/new', recursive: true })
   })
 
   test('company_context filesystem rejects delete move and mkdir before user workspace mutation', async () => {

--- a/packages/agent/src/server/http/routes/file.ts
+++ b/packages/agent/src/server/http/routes/file.ts
@@ -296,15 +296,6 @@ export function fileRoutes(
     return (await resolveFilesystemBindings(request)).find((binding) => binding.filesystem === filesystem)
   }
 
-  async function rejectUnsupportedFilesystemMutation(request: FastifyRequest, reply: FastifyReply, filesystem: string): Promise<FastifyReply> {
-    const binding = await resolveFilesystemBinding(request, filesystem)
-    if (!binding) return sendNotFoundOrDenied(reply)
-    if (binding.access === 'readonly') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
-    return reply.code(501).send({
-      error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} binding access is not supported by this route` },
-    })
-  }
-
   app.get('/api/v1/files/raw', async (request, reply) => {
     const query = request.query as Record<string, unknown>
     const path = requireStringParam(query.path, 'path', reply)
@@ -314,7 +305,7 @@ export function fileRoutes(
     if (filesystem !== USER_FILESYSTEM_ID) {
       try {
         const binding = await resolveFilesystemBinding(request, filesystem)
-        if (!binding || binding.access !== 'readonly') return sendNotFoundOrDenied(reply)
+        if (!binding) return sendNotFoundOrDenied(reply)
         const result = await binding.operations.read({ filesystem, path })
         const bytes = Buffer.from(result.content, 'utf8')
         return reply
@@ -393,9 +384,9 @@ export function fileRoutes(
     if (filesystem !== USER_FILESYSTEM_ID) {
       try {
         const binding = await resolveFilesystemBinding(request, filesystem)
-        if (!binding || binding.access !== 'readonly') return sendNotFoundOrDenied(reply)
+        if (!binding) return sendNotFoundOrDenied(reply)
         const result = await binding.operations.read({ filesystem, path })
-        return { content: result.content }
+        return { content: result.content, access: binding.access }
       } catch {
         return sendNotFoundOrDenied(reply)
       }
@@ -414,11 +405,11 @@ export function fileRoutes(
       const workspace = await resolveWorkspace(request)
       if (workspace.readFileWithStat) {
         const { content, stat } = await workspace.readFileWithStat(path)
-        return { content, mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined }
+        return { content, mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined, access: 'readwrite' }
       }
       const content = await workspace.readFile(path)
       const stat = await workspace.stat(path)
-      return { content, mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined }
+      return { content, mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined, access: 'readwrite' }
     } catch (err) {
       return classifyError(err, reply, 'file')
     }
@@ -440,12 +431,30 @@ export function fileRoutes(
     // 409 with the current mtime so the client can decide whether to
     // reload or force-overwrite.
     const filesystem = requestedFilesystem(body.filesystem)
-    if (filesystem !== USER_FILESYSTEM_ID) return await rejectUnsupportedFilesystemMutation(request, reply, filesystem)
-
-    const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
+const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
       ? body.expectedMtimeMs
       : null
     const shouldReturnMtimeMs = body.returnMtimeMs !== false || expectedMtimeMs !== null
+
+    if (filesystem !== USER_FILESYSTEM_ID) {
+      try {
+        const binding = await resolveFilesystemBinding(request, filesystem)
+        if (!binding) return sendNotFoundOrDenied(reply)
+        if (binding.access !== 'readwrite') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
+        if (!binding.operations.write) {
+          return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} write operation is unavailable` } })
+        }
+        const result = await binding.operations.write({
+          filesystem,
+          path,
+          content: body.content,
+          ...(expectedMtimeMs !== null ? { expectedMtimeMs } : {}),
+        })
+        return shouldReturnMtimeMs ? { ok: true, mtimeMs: result.mtimeMs } : { ok: true }
+      } catch (err) {
+        return classifyError(err, reply, 'file')
+      }
+    }
 
     try {
       const workspace = await resolveWorkspace(request)
@@ -608,7 +617,20 @@ export function fileRoutes(
     const path = requireStringParam(query.path, 'path', reply)
     if (path === null) return
     const filesystem = requestedFilesystem(query.filesystem)
-    if (filesystem !== USER_FILESYSTEM_ID) return await rejectUnsupportedFilesystemMutation(request, reply, filesystem)
+if (filesystem !== USER_FILESYSTEM_ID) {
+      try {
+        const binding = await resolveFilesystemBinding(request, filesystem)
+        if (!binding) return sendNotFoundOrDenied(reply)
+        if (binding.access !== 'readwrite') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
+        if (!binding.operations.delete) {
+          return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} delete operation is unavailable` } })
+        }
+        await binding.operations.delete({ filesystem, path })
+        return { ok: true }
+      } catch (err) {
+        return classifyError(err, reply, 'file')
+      }
+    }
 
     try {
       const workspace = await resolveWorkspace(request)
@@ -626,7 +648,20 @@ export function fileRoutes(
     const to = requireStringParam(body?.to, 'to', reply)
     if (to === null) return
     const filesystem = requestedFilesystem(body.filesystem)
-    if (filesystem !== USER_FILESYSTEM_ID) return await rejectUnsupportedFilesystemMutation(request, reply, filesystem)
+if (filesystem !== USER_FILESYSTEM_ID) {
+      try {
+        const binding = await resolveFilesystemBinding(request, filesystem)
+        if (!binding) return sendNotFoundOrDenied(reply)
+        if (binding.access !== 'readwrite') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
+        if (!binding.operations.move) {
+          return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} move operation is unavailable` } })
+        }
+        await binding.operations.move({ filesystem, from, to })
+        return { ok: true }
+      } catch (err) {
+        return classifyError(err, reply, 'file')
+      }
+    }
 
     try {
       const workspace = await resolveWorkspace(request)
@@ -644,7 +679,20 @@ export function fileRoutes(
 
     const recursive = body.recursive === true
     const filesystem = requestedFilesystem(body.filesystem)
-    if (filesystem !== USER_FILESYSTEM_ID) return await rejectUnsupportedFilesystemMutation(request, reply, filesystem)
+if (filesystem !== USER_FILESYSTEM_ID) {
+      try {
+        const binding = await resolveFilesystemBinding(request, filesystem)
+        if (!binding) return sendNotFoundOrDenied(reply)
+        if (binding.access !== 'readwrite') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
+        if (!binding.operations.mkdir) {
+          return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} mkdir operation is unavailable` } })
+        }
+        await binding.operations.mkdir({ filesystem, path, recursive })
+        return { ok: true }
+      } catch (err) {
+        return classifyError(err, reply, 'directory')
+      }
+    }
 
     try {
       const workspace = await resolveWorkspace(request)
@@ -664,7 +712,7 @@ export function fileRoutes(
     if (filesystem !== USER_FILESYSTEM_ID) {
       try {
         const binding = await resolveFilesystemBinding(request, filesystem)
-        if (!binding || binding.access !== 'readonly') return sendNotFoundOrDenied(reply)
+        if (!binding) return sendNotFoundOrDenied(reply)
         const result = await binding.operations.stat({ filesystem, path })
         return result.isDirectory ? { kind: 'dir' as const } : { kind: 'file' as const, size: 0 }
       } catch {

--- a/packages/agent/src/server/http/routes/tree.ts
+++ b/packages/agent/src/server/http/routes/tree.ts
@@ -185,7 +185,7 @@ export function treeRoutes(
       if (filesystem !== 'user') {
         try {
           const binding = await resolveFilesystemBinding(request, filesystem)
-          if (!binding || binding.access !== 'readonly') return sendNotFoundOrDenied(reply)
+          if (!binding) return sendNotFoundOrDenied(reply)
           return { entries: await listBoundTree(binding, dir, recursive) }
         } catch {
           return sendNotFoundOrDenied(reply)
@@ -193,6 +193,7 @@ export function treeRoutes(
       }
 
       try {
+
         const workspace = await resolveWorkspace(request)
         const entries = await listTree(workspace, dir, recursive)
         return { entries }

--- a/packages/agent/src/server/runtime/mode.ts
+++ b/packages/agent/src/server/runtime/mode.ts
@@ -74,12 +74,16 @@ export interface RuntimeFilesystemBindingOperations {
   find(descriptor: { filesystem: string; path: string }, pattern: string, options?: { limit?: number; offset?: number }): Promise<{ paths: string[]; metadata?: unknown }>
   grep(descriptor: { filesystem: string; path: string }, pattern: string, options?: { limit?: number; offset?: number }): Promise<{ matches: Array<{ path: string; line: number; text: string }>; metadata?: unknown }>
   stat(descriptor: { filesystem: string; path: string }): Promise<{ isDirectory: boolean; metadata?: unknown }>
+  write?(descriptor: { filesystem: string; path: string; content: string; expectedMtimeMs?: number }): Promise<{ mtimeMs?: number; metadata?: unknown }>
+  delete?(descriptor: { filesystem: string; path: string }): Promise<{ metadata?: unknown }>
+  move?(descriptor: { filesystem: string; from: string; to: string }): Promise<{ metadata?: unknown }>
+  mkdir?(descriptor: { filesystem: string; path: string; recursive?: boolean }): Promise<{ metadata?: unknown }>
   rejectMutation(operation: string, descriptor: { filesystem: string; path: string }): never
 }
 
 export interface RuntimeFilesystemBinding {
   readonly filesystem: string
-  readonly access: 'readonly'
+  readonly access: 'readonly' | 'readwrite'
   readonly operations: RuntimeFilesystemBindingOperations
 }
 

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -22,6 +22,7 @@ import { PluginsOverlay } from "../../front/chrome/plugins/PluginsOverlay"
 import { AppLeftPane } from "../../front/layout/plugin-tabs/AppLeftPane"
 import { PluginTabsWorkspaceShell } from "../../front/layout/plugin-tabs/PluginTabsWorkspaceShell"
 import { captureFrontPlugin } from "../../shared/plugins/frontFactory"
+import type { FilesystemId } from "../../shared/types/filesystem"
 import { UI_COMMAND_EVENT, dispatchUiCommand } from "../../front/bridge"
 import type { CommandPaletteSessionItem } from "../../front/components/CommandPalette"
 import type { CommandResult, DispatchContext, FileTreeBridge, Unsubscribe } from "../../front/bridge"
@@ -984,8 +985,8 @@ export function WorkspaceAgentFront<
   // retry + pending-op queue as agent commands (a direct getSurface().openFile()
   // drops the click when the surface hasn't mounted yet — the first-click race).
   const fileTreeBridge = useMemo<FileTreeBridge>(() => ({
-    openFile: async (path: string): Promise<CommandResult> => {
-      dispatchUiCommand({ kind: "openFile", params: { path } }, surfaceDispatch)
+    openFile: async (path: string, opts?: { filesystem?: FilesystemId }): Promise<CommandResult> => {
+      dispatchUiCommand({ kind: "openFile", params: { path, ...(opts?.filesystem ? { filesystem: opts.filesystem } : {}) } }, surfaceDispatch)
       return { seq: 0, status: "ok" }
     },
     getActiveFile: () => getSurface()?.getSnapshot().activeTab ?? null,

--- a/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
@@ -18,6 +18,8 @@ export interface FilePaneShellProps {
   error: Error | null
   /** Conflict state (if OCC check failed). */
   conflict: FileConflictError | null
+  /** Readonly panes disable mutation affordances by construction. */
+  readOnly?: boolean
   /** Handler for content changes. */
   onChange: (content: string) => void
   /** Handler for reload from server. */
@@ -28,6 +30,7 @@ export interface FilePaneShellProps {
   editorComponent: React.ComponentType<{
     content: string
     onChange: (content: string) => void
+    readOnly?: boolean
     className?: string
     [key: string]: unknown
   }>
@@ -81,6 +84,7 @@ export function FilePaneShell({
   isLoading,
   error,
   conflict,
+  readOnly = false,
   onChange,
   onReload,
   onOverwrite,
@@ -121,7 +125,13 @@ export function FilePaneShell({
 
   return (
     <div className={`flex h-full min-h-0 flex-col ${className ?? ""}`}>
-      {conflict && (
+      {readOnly && (
+        <div className="flex items-center gap-2 border-b border-border bg-muted/40 px-3 py-1.5 text-xs text-muted-foreground" role="status">
+          <span className="rounded-sm border border-border bg-background px-1.5 py-0.5 font-medium text-foreground">Readonly</span>
+          <span>{filesystem === "company_context" ? "Company context is policy-filtered and cannot be edited here." : "This file is readonly."}</span>
+        </div>
+      )}
+      {!readOnly && conflict && (
         <ConflictBanner
           conflict={conflict}
           onReload={onReload}
@@ -134,9 +144,10 @@ export function FilePaneShell({
         ) : (
           <Editor
             content={content}
-            onChange={onChange}
             className={editorProps.className as string | undefined}
             {...editorProps}
+            onChange={readOnly ? () => {} : onChange}
+            readOnly={readOnly}
           />
         )}
       </Suspense>

--- a/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
@@ -15,7 +15,7 @@ const mockWriteFile = vi.fn()
 const mockFileContent = vi.fn()
 
 vi.mock("../data", () => ({
-  useFileContent: (path: string | null, options?: { createIfMissing?: string }) => (
+  useFileContent: (path: string | null, options?: { createIfMissing?: string; filesystem?: string }) => (
     options === undefined ? mockFileContent(path) : mockFileContent(path, options)
   ),
   useFileWrite: () => ({ mutateAsync: mockWriteFile }),
@@ -291,27 +291,54 @@ describe("useFilePane", () => {
       expect(mockFileContent).toHaveBeenCalledWith(" notes.md ", { filesystem: "user" })
     })
 
-    it("separates same-path panes by filesystem for queries and writes", async () => {
-      const { result, rerender } = renderHook(
+    it("separates same-path panes by filesystem for queries", async () => {
+      const { rerender } = renderHook(
         ({ filesystem }) => useFilePane({ path: "same.md", filesystem }),
-        { wrapper, initialProps: { filesystem: "user" as "user" | "company_context" } },
+        { wrapper, initialProps: { filesystem: "user" as "user" | "project_alpha" } },
       )
       await act(async () => {})
       expect(mockFileContent).toHaveBeenCalledWith("same.md", { filesystem: "user" })
 
-      rerender({ filesystem: "company_context" })
+      rerender({ filesystem: "project_alpha" })
       await act(async () => {})
-      expect(mockFileContent).toHaveBeenCalledWith("same.md", { filesystem: "company_context" })
+      expect(mockFileContent).toHaveBeenCalledWith("same.md", { filesystem: "project_alpha" })
+    })
 
-      act(() => result.current.setContent("company edits"))
+    it("derives named-filesystem readonly state from server access, not filesystem id", async () => {
+      const { result } = renderHook(
+        () => useFilePane({ path: "same.md", filesystem: "project_alpha", createIfMissing: "new" }),
+        { wrapper },
+      )
+      await act(async () => {})
+
+      expect(result.current.isReadonly).toBe(false)
+      expect(mockFileContent).toHaveBeenCalledWith("same.md", { filesystem: "project_alpha", createIfMissing: "new" })
+      act(() => result.current.setContent("allowed edits"))
+      expect(result.current.isDirty).toBe(true)
+    })
+
+    it("blocks edits when server marks any named filesystem readonly", async () => {
+      mockFileContent.mockReturnValue({
+        data: { content: "initial", mtimeMs: 1000, access: "readonly" },
+        isLoading: false,
+        error: undefined,
+        refetch: vi.fn(async () => ({ data: { content: "initial", mtimeMs: 1000, access: "readonly" } })),
+      })
+      const { result } = renderHook(
+        () => useFilePane({ path: "same.md", filesystem: "project_alpha", createIfMissing: "new" }),
+        { wrapper },
+      )
+      await act(async () => {})
+
+      expect(result.current.isReadonly).toBe(true)
+      expect(mockFileContent).toHaveBeenCalledWith("same.md", { filesystem: "project_alpha", createIfMissing: "new" })
+      act(() => result.current.setContent("blocked edits"))
+      expect(result.current.isDirty).toBe(false)
       await act(async () => {
         await result.current.flushSave()
+        await result.current.onOverwrite()
       })
-      expect(mockWriteFile).toHaveBeenCalledWith(expect.objectContaining({
-        filesystem: "company_context",
-        path: "same.md",
-        content: "company edits",
-      }))
+      expect(mockWriteFile).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditor.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditor.tsx
@@ -97,6 +97,7 @@ export function CodeEditor({
 
   const languageCompartment = useRef(new Compartment())
   const readOnlyCompartment = useRef(new Compartment())
+  const editableCompartment = useRef(new Compartment())
   const lineNumbersCompartment = useRef(new Compartment())
   const wordWrapCompartment = useRef(new Compartment())
   const themeCompartment = useRef(new Compartment())
@@ -109,6 +110,7 @@ export function CodeEditor({
     const cspNonce = readCspNonceFromDom()
     const exts: Extension[] = [
       readOnlyCompartment.current.of(EditorState.readOnly.of(effectiveReadOnly)),
+      editableCompartment.current.of(EditorView.editable.of(!effectiveReadOnly)),
       lineNumbersCompartment.current.of(lineNumbers ? lineNumbersExt() : []),
       wordWrapCompartment.current.of(wordWrap ? EditorView.lineWrapping : []),
       drawSelection(),
@@ -172,9 +174,14 @@ export function CodeEditor({
     const view = viewRef.current
     if (!view) return
     view.dispatch({
-      effects: readOnlyCompartment.current.reconfigure(
-        EditorState.readOnly.of(effectiveReadOnly),
-      ),
+      effects: [
+        readOnlyCompartment.current.reconfigure(
+          EditorState.readOnly.of(effectiveReadOnly),
+        ),
+        editableCompartment.current.reconfigure(
+          EditorView.editable.of(!effectiveReadOnly),
+        ),
+      ],
     })
   }, [effectiveReadOnly])
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditorPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/CodeEditorPane.tsx
@@ -48,11 +48,12 @@ export function CodeEditorPane({ params, api, className }: CodeEditorPaneProps) 
     onReloadFromServer,
     onOverwrite,
     tabTitle,
+    isReadonly,
   } = useFilePane({ filesystem, path, panelId: api?.id })
 
-  // Update panel title with dirty indicator
+  // Update panel title with dirty/readonly indicator
   if (api && tabTitle) {
-    api.setTitle(tabTitle)
+    api.setTitle(isReadonly ? `${tabTitle} (readonly)` : tabTitle)
   }
 
   const language = extToLanguage(path)
@@ -65,11 +66,12 @@ export function CodeEditorPane({ params, api, className }: CodeEditorPaneProps) 
       isLoading={isLoading}
       error={error}
       conflict={conflict}
+      readOnly={readOnly || isReadonly}
       onChange={setContent}
       onReload={onReloadFromServer}
       onOverwrite={onOverwrite}
       editorComponent={CodeEditor}
-      editorProps={{ language, wordWrap: true, className, readOnly }}
+      editorProps={{ language, wordWrap: true, className, readOnly: readOnly || isReadonly }}
     />
   )
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditorPane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditorPane.test.tsx
@@ -23,12 +23,14 @@ vi.mock("../CodeEditor", () => ({
     content,
     language,
     onChange,
+    readOnly,
   }: {
     content: string
     language: string
     onChange?: (v: string) => void
+    readOnly?: boolean
   }) => (
-    <div data-testid="code-editor" data-language={language}>
+    <div data-testid="code-editor" data-language={language} data-readonly={readOnly ? "true" : "false"}>
       {content}
       <button type="button" onClick={() => onChange?.("changed")}>
         edit
@@ -119,6 +121,45 @@ describe("CodeEditorPane", () => {
     expect(screen.getByText("not found or denied")).toBeInTheDocument()
     expect(screen.queryByText(/FORBIDDEN_FINANCE_SECRET_123/)).not.toBeInTheDocument()
     expect(screen.queryByText(/secret\/finance/)).not.toBeInTheDocument()
+  })
+
+  it("opens company files in readonly mode without dirtying or writing", async () => {
+    const markDirty = vi.fn()
+    const setTitle = vi.fn()
+    mockFileContent.mockReturnValue({
+      data: { content: "secret policy", mtimeMs: 123, access: "readonly" },
+      isLoading: false,
+      error: undefined,
+      dataUpdatedAt: Date.now(),
+    })
+    mockUseEditorLifecycle.mockReturnValue({
+      isDirty: true,
+      isSaving: false,
+      lastSavedAt: null,
+      markDirty,
+      markClean: vi.fn(),
+      flushSave: vi.fn(),
+      shouldSync: false,
+      ackSync: vi.fn(),
+      externalChangeWhileDirty: false,
+      ackExternalChange: vi.fn(),
+      notifySaved: vi.fn(),
+    })
+    const props = createMockPaneProps({
+      params: { path: "/company/hr/policy.ts", filesystem: "company_context", access: "readwrite" },
+      apiOverrides: { setTitle },
+    })
+
+    render(<CodeEditorPane {...props} />, { wrapper })
+
+    await waitFor(() => expect(screen.getByTestId("code-editor")).toHaveAttribute("data-readonly", "true"))
+    expect(screen.getByText("Readonly")).toBeInTheDocument()
+    expect(setTitle).toHaveBeenCalledWith("policy.ts (readonly)")
+    expect(mockUseEditorLifecycle.mock.calls.at(-1)?.[1]).toEqual(expect.objectContaining({ adapter: null }))
+
+    screen.getByText("edit").click()
+    expect(markDirty).not.toHaveBeenCalled()
+    expect(mockFileWrite).not.toHaveBeenCalled()
   })
 
   it("infers language from file extension", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/types.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/types.ts
@@ -6,6 +6,8 @@ export interface FileEntry {
 
 export interface FileContent {
   content: string
+  /** Access granted by the resolved filesystem binding, when the server exposes it. */
+  access?: "readonly" | "readwrite"
   /**
    * Server-stat'd modification time. Used as the OCC baseline for the
    * next write — the client sends it back as `expectedMtimeMs` so the

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditor.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditor.tsx
@@ -18,6 +18,7 @@ import { TableHeader } from "@tiptap/extension-table-header"
 import { TableCell } from "@tiptap/extension-table-cell"
 import { ResizableImage } from "./ResizableImage"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
+import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import { useFileUpload } from "../data/useFileUpload"
 import CodeBlockLowlight from "@tiptap/extension-code-block-lowlight"
 import { common, createLowlight } from "lowlight"
@@ -75,6 +76,8 @@ export interface MarkdownEditorProps {
   className?: string
   /** Workspace-relative markdown file path, used to make uploaded image links relative. */
   documentPath?: string
+  /** Filesystem identity for relative markdown links/assets. Defaults to user. */
+  filesystem?: FilesystemId
 }
 
 export function countMarkdownWords(content: string): number {
@@ -142,12 +145,21 @@ export function rawFileUrlForMarkdownImage(
   documentPath: string | undefined,
   apiBaseUrl: string,
   workspaceRequestId?: string | null,
+  filesystem?: FilesystemId,
 ): string {
-  if (!src || isExternalImageSrc(src)) return src
-  const path = normalizeRelativeImagePath(src, documentPath)
+  if (!src) return src
+  const fs = normalizeUiFilesystem(filesystem)
+  const isNamedFilesystem = fs !== "user"
+  if (isExternalImageSrc(src) && !(isNamedFilesystem && src.startsWith("/") && !src.startsWith("//"))) return src
+  const path = isNamedFilesystem && src.startsWith("/")
+    ? src
+    : isNamedFilesystem && documentPath?.startsWith("/")
+      ? `/${normalizeRelativeImagePath(src, documentPath)}`
+      : normalizeRelativeImagePath(src, documentPath)
   const base = apiBaseUrl.replace(/\/$/, "")
   const params = new URLSearchParams({ path })
   if (workspaceRequestId) params.set("workspaceId", workspaceRequestId)
+  if (fs !== "user") params.set("filesystem", fs)
   return `${base}/api/v1/files/raw?${params.toString()}`
 }
 
@@ -288,12 +300,14 @@ function Toolbar({
   rawMode,
   onToggleRawMode,
   uploading,
+  allowImageUpload,
 }: {
   editor: Editor | null
   onInsertImage: (file: File) => Promise<void>
   rawMode: boolean
   onToggleRawMode: () => void
   uploading: boolean
+  allowImageUpload: boolean
 }) {
   const setBlockAlign = (align: "left" | "center" | "right") => {
     if (!editor) return
@@ -363,7 +377,7 @@ function Toolbar({
       promptImageUrl()
       return
     }
-    imageFileInputRef.current?.click()
+    if (allowImageUpload) imageFileInputRef.current?.click()
   }
   const handleImageFile = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -424,7 +438,8 @@ function Toolbar({
       </ToolbarButton>
       <ToolbarButton
         onClick={triggerImagePick}
-        title="Image (click to upload, Shift+click for URL)"
+        disabled={!allowImageUpload}
+        title={allowImageUpload ? "Image (click to upload, Shift+click for URL)" : "Image upload unavailable for this filesystem"}
       >
         <ImageIcon className="h-4 w-4" />
       </ToolbarButton>
@@ -491,16 +506,20 @@ export function MarkdownEditor({
   placeholder,
   className,
   documentPath,
+  filesystem: rawFilesystem,
 }: MarkdownEditorProps) {
+  const filesystem = normalizeUiFilesystem(rawFilesystem)
   const apiBaseUrl = useApiBaseUrl()
   const workspaceRequestId = useWorkspaceRequestId()
+  const allowImageUpload = filesystem === "user"
   const { upload, uploading } = useFileUpload()
   const [rawMode, setRawMode] = useState(false)
   const editorExtensions = useMemo(() => {
     const imageExtension = ResizableImage.configure({
       inline: false,
       allowBase64: true,
-      resolveSrc: (src: string) => rawFileUrlForMarkdownImage(src, documentPath, apiBaseUrl, workspaceRequestId),
+      resizable: !readOnly,
+      resolveSrc: (src: string) => rawFileUrlForMarkdownImage(src, documentPath, apiBaseUrl, workspaceRequestId, filesystem),
     })
     const configured = baseExtensions.map((extension) => extension.name === "image" ? imageExtension : extension)
     return placeholder
@@ -509,7 +528,7 @@ export function MarkdownEditor({
           Placeholder.configure({ placeholder }),
         ]
       : configured
-  }, [apiBaseUrl, documentPath, placeholder, workspaceRequestId])
+  }, [apiBaseUrl, documentPath, filesystem, placeholder, readOnly, workspaceRequestId])
   const onChangeRef = useRef(onChange)
   onChangeRef.current = onChange
   const suppressChangeRef = useRef(false)
@@ -528,7 +547,7 @@ export function MarkdownEditor({
   insertImageRef.current = async (file: File) => {
     userInteractedRef.current = true
     const editor = editorRef.current
-    if (!editor) return
+    if (!editor || !allowImageUpload) return
 
     // Insert with the data URL first so the image shows up instantly at the
     // caret. Uploads can be slow; without this the paste appears to do nothing.
@@ -656,11 +675,17 @@ export function MarkdownEditor({
     const target = event.target instanceof Element ? event.target.closest("a[href]") : null
     const href = target?.getAttribute("href")
     if (!href) return
+    const normalizedFilesystem = normalizeUiFilesystem(filesystem)
+    const isNamedFilesystem = normalizedFilesystem !== "user"
     const path = workspaceFilePathForMarkdownLink(href, documentPath)
+      ?? (isNamedFilesystem && href.startsWith("/") && !href.startsWith("//") ? href.split(/[?#]/, 1)[0] : null)
     if (!path) return
     event.preventDefault()
     event.stopPropagation()
-    postUiCommand({ kind: "openFile", params: { path } })
+    const canonicalPath = isNamedFilesystem && documentPath?.startsWith("/") && !path.startsWith("/")
+      ? `/${path}`
+      : path
+    postUiCommand({ kind: "openFile", params: { path: canonicalPath, ...(normalizedFilesystem === "user" ? {} : { filesystem: normalizedFilesystem }) } })
   }
 
   return (
@@ -677,6 +702,7 @@ export function MarkdownEditor({
           rawMode={rawMode}
           onToggleRawMode={() => setRawMode((v) => !v)}
           uploading={uploading}
+      allowImageUpload={allowImageUpload}
         />
       )}
       <div className="min-h-0 flex-1 overflow-auto" onClickCapture={handleEditorClick}>

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditorPane.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditorPane.tsx
@@ -29,11 +29,12 @@ export function MarkdownEditorPane({ params, api, className }: MarkdownEditorPan
     onReloadFromServer,
     onOverwrite,
     tabTitle,
+    isReadonly,
   } = useFilePane({ filesystem, path, panelId: api?.id })
 
-  // Update panel title with dirty indicator
+  // Update panel title with dirty/readonly indicator
   if (api && tabTitle) {
-    api.setTitle(tabTitle)
+    api.setTitle(isReadonly ? `${tabTitle} (readonly)` : tabTitle)
   }
 
   return (
@@ -44,11 +45,12 @@ export function MarkdownEditorPane({ params, api, className }: MarkdownEditorPan
       isLoading={isLoading}
       error={error}
       conflict={conflict}
+      readOnly={readOnly || isReadonly}
       onChange={setContent}
       onReload={onReloadFromServer}
       onOverwrite={onOverwrite}
       editorComponent={MarkdownEditor}
-      editorProps={{ className, documentPath: path, readOnly }}
+      editorProps={{ className, documentPath: path, readOnly: readOnly || isReadonly, filesystem }}
     />
   )
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/ResizableImage.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/ResizableImage.tsx
@@ -51,6 +51,7 @@ export const ResizableImage = Image.extend<any>({
     return {
       ...this.parent?.(),
       resolveSrc: (src: string) => src,
+      resizable: true,
     }
   },
 
@@ -155,13 +156,14 @@ function ResizableImageView({ node, updateAttributes, selected, extension }: Nod
   const storedSrc = (node.attrs.src as string | undefined) ?? ""
   const resolveSrc = (extension.options as { resolveSrc?: ImageSrcResolver }).resolveSrc ?? ((value: string) => value)
   const src = resolveSrc(storedSrc)
+  const resizable = (extension.options as { resizable?: boolean }).resizable !== false
   const alt = (node.attrs.alt as string | undefined) ?? ""
   const title = (node.attrs.title as string | undefined) ?? undefined
   const width = node.attrs.width as number | null | undefined
   const align = (node.attrs.align as "left" | "center" | "right" | undefined) ?? "left"
 
   useEffect(() => {
-    if (!dragging) return
+    if (!dragging || !resizable) return
     const onMove = (e: PointerEvent) => {
       const start = startRef.current
       if (!start) return
@@ -181,9 +183,10 @@ function ResizableImageView({ node, updateAttributes, selected, extension }: Nod
       window.removeEventListener("pointerup", onUp)
       window.removeEventListener("pointercancel", onUp)
     }
-  }, [dragging, updateAttributes])
+  }, [dragging, resizable, updateAttributes])
 
   const onHandlePointerDown = (e: React.PointerEvent<HTMLSpanElement>) => {
+    if (!resizable) return
     e.preventDefault()
     e.stopPropagation()
     const img = wrapperRef.current?.querySelector("img")
@@ -203,27 +206,29 @@ function ResizableImageView({ node, updateAttributes, selected, extension }: Nod
         align === "left" && "mr-auto",
         align === "center" && "mx-auto",
         align === "right" && "ml-auto",
-        selected &&
+        resizable && selected &&
           "ring-2 ring-[color:var(--accent)] ring-offset-1 ring-offset-background",
       )}
       style={{ width: width ? `${width}px` : undefined }}
     >
       <img src={src} alt={alt} title={title} draggable={false} />
-      <span
-        role="slider"
-        aria-label="Resize image"
-        aria-valuenow={width ?? 0}
-        aria-valuemin={MIN_WIDTH}
-        aria-valuemax={MAX_WIDTH}
-        data-testid="resize-handle"
-        onPointerDown={onHandlePointerDown}
-        className={cn(
-          "absolute right-0 bottom-0 h-3 w-3 translate-x-1/2 translate-y-1/2 cursor-nwse-resize",
-          "rounded-full border border-background bg-[color:var(--accent)] shadow",
-          "opacity-0 transition-opacity duration-150 ease-out",
-          (selected || dragging) && "opacity-100",
-        )}
-      />
+      {resizable && (
+        <span
+          role="slider"
+          aria-label="Resize image"
+          aria-valuenow={width ?? 0}
+          aria-valuemin={MIN_WIDTH}
+          aria-valuemax={MAX_WIDTH}
+          data-testid="resize-handle"
+          onPointerDown={onHandlePointerDown}
+          className={cn(
+            "absolute right-0 bottom-0 h-3 w-3 translate-x-1/2 translate-y-1/2 cursor-nwse-resize",
+            "rounded-full border border-background bg-[color:var(--accent)] shadow",
+            "opacity-0 transition-opacity duration-150 ease-out",
+            (selected || dragging) && "opacity-100",
+          )}
+        />
+      )}
     </NodeViewWrapper>
   )
 }

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditor.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditor.test.tsx
@@ -74,6 +74,36 @@ describe("MarkdownEditor", () => {
     ).toBe("/api/v1/files/raw?path=docs%2Fassets%2Freadme%2Fhero.png&workspaceId=boring-ui-v2-36cd3172")
   })
 
+  it("adds named filesystem identity to relative markdown image raw URLs", () => {
+    expect(
+      rawFileUrlForMarkdownImage(
+        "assets/diagram.png",
+        "handbook/index.md",
+        "",
+        null,
+        "project_alpha",
+      ),
+    ).toBe("/api/v1/files/raw?path=handbook%2Fassets%2Fdiagram.png&filesystem=project_alpha")
+    expect(
+      rawFileUrlForMarkdownImage(
+        "assets/diagram.png",
+        "/project/docs/handbook.md",
+        "",
+        null,
+        "project_alpha",
+      ),
+    ).toBe("/api/v1/files/raw?path=%2Fproject%2Fdocs%2Fassets%2Fdiagram.png&filesystem=project_alpha")
+    expect(
+      rawFileUrlForMarkdownImage(
+        "/project/docs/logo.png",
+        "/project/docs/handbook.md",
+        "",
+        null,
+        "project_alpha",
+      ),
+    ).toBe("/api/v1/files/raw?path=%2Fproject%2Fdocs%2Flogo.png&filesystem=project_alpha")
+  })
+
   it("resolves relative markdown file links against the current document", () => {
     expect(
       workspaceFilePathForMarkdownLink(
@@ -102,6 +132,54 @@ describe("MarkdownEditor", () => {
       expect(commands).toContainEqual({
         kind: "openFile",
         params: { path: "consulting-research/profiles/001-romain-rissoan.md" },
+      })
+    } finally {
+      window.removeEventListener(UI_COMMAND_EVENT, onCommand)
+    }
+  })
+
+  it("opens named-filesystem relative markdown links with filesystem identity", async () => {
+    const commands: unknown[] = []
+    const onCommand = (event: Event) => commands.push((event as CustomEvent).detail)
+    window.addEventListener(UI_COMMAND_EVENT, onCommand)
+    try {
+      render(
+        <MarkdownEditor
+          content="[Policy](policies/security.md)"
+          documentPath="/project/docs/handbook.md"
+          filesystem="project_alpha"
+          readOnly
+        />,
+      )
+      const link = await screen.findByRole("link", { name: "Policy" })
+      fireEvent.click(link)
+      expect(commands).toContainEqual({
+        kind: "openFile",
+        params: { path: "/project/docs/policies/security.md", filesystem: "project_alpha" },
+      })
+    } finally {
+      window.removeEventListener(UI_COMMAND_EVENT, onCommand)
+    }
+  })
+
+  it("opens root-relative named-filesystem markdown links with filesystem identity", async () => {
+    const commands: unknown[] = []
+    const onCommand = (event: Event) => commands.push((event as CustomEvent).detail)
+    window.addEventListener(UI_COMMAND_EVENT, onCommand)
+    try {
+      render(
+        <MarkdownEditor
+          content="[Policy](/project/docs/policies/security.md#overview)"
+          documentPath="/project/docs/handbook.md"
+          filesystem="project_alpha"
+          readOnly
+        />,
+      )
+      const link = await screen.findByRole("link", { name: "Policy" })
+      fireEvent.click(link)
+      expect(commands).toContainEqual({
+        kind: "openFile",
+        params: { path: "/project/docs/policies/security.md", filesystem: "project_alpha" },
       })
     } finally {
       window.removeEventListener(UI_COMMAND_EVENT, onCommand)
@@ -168,6 +246,14 @@ describe("MarkdownEditor", () => {
     expect(screen.getByTitle("Highlight")).toBeInTheDocument()
     expect(screen.getByTitle("Horizontal rule")).toBeInTheDocument()
     expect(screen.getByTitle("Raw markdown")).toBeInTheDocument()
+  })
+
+  it("disables workspace-backed image upload for non-user filesystems", async () => {
+    render(<MarkdownEditor content="test" filesystem="project_alpha" />)
+    await waitFor(() => {
+      expect(screen.getByRole("toolbar")).toBeInTheDocument()
+    })
+    expect(screen.getByTitle("Image upload unavailable for this filesystem")).toBeDisabled()
   })
 
   it("shows a word count footer", async () => {
@@ -746,8 +832,8 @@ describe("MarkdownEditor", () => {
         })
       })
 
-      it("renders a draggable resize handle on the image NodeView", async () => {
-        render(
+      it("renders a draggable resize handle on editable image NodeViews only", async () => {
+        const { unmount } = render(
           <MarkdownEditor content='<img src="https://example.com/x.png" />' />,
         )
         await waitFor(() => {
@@ -755,6 +841,15 @@ describe("MarkdownEditor", () => {
             document.querySelector("[data-testid='resize-handle']"),
           ).toBeTruthy()
         })
+        unmount()
+
+        render(
+          <MarkdownEditor content='<img src="https://example.com/x.png" />' readOnly />,
+        )
+        await waitFor(() => {
+          expect(document.querySelector("[data-resizable-image] img")).toBeTruthy()
+        })
+        expect(document.querySelector("[data-testid='resize-handle']")).toBeNull()
       })
     })
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditorPane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditorPane.test.tsx
@@ -7,7 +7,7 @@ const mockFileContent = vi.fn()
 const mockFileWrite = vi.fn()
 
 vi.mock("../../data", () => ({
-  useFileContent: (path: string) => mockFileContent(path),
+  useFileContent: (path: string, options?: unknown) => mockFileContent(path, options),
   useFileWrite: () => ({ mutateAsync: mockFileWrite }),
   useApiBaseUrl: () => "/api",
 }))
@@ -157,6 +157,31 @@ describe("MarkdownEditorPane", () => {
     await waitFor(() => {
       expect(setTitle).toHaveBeenCalledWith("test.md")
     })
+  })
+
+  it("opens company markdown in readonly mode without dirtying or writing", async () => {
+    mockFileContent.mockReturnValue({
+      data: { content: "# Hello\n\nWorld", access: "readonly" },
+      isLoading: false,
+      error: undefined,
+      dataUpdatedAt: 1000,
+    })
+    const setTitle = vi.fn()
+    const props = createMockPaneProps({
+      params: { path: "/company/hr/handbook.md", filesystem: "company_context" },
+      apiOverrides: { setTitle },
+    })
+
+    render(<MarkdownEditorPane {...props} />, { wrapper })
+
+    await waitFor(() => expect(screen.getByTestId("markdown-editor")).toHaveAttribute("data-readonly", "true"))
+    expect(screen.getByText("Readonly")).toBeInTheDocument()
+    expect(setTitle).toHaveBeenCalledWith("handbook.md (readonly)")
+    expect(mockFileContent).toHaveBeenCalledWith("/company/hr/handbook.md", expect.objectContaining({ filesystem: "company_context" }))
+
+    mockOnChange("changed content")
+    expect(mockMarkDirty).not.toHaveBeenCalled()
+    expect(mockFileWrite).not.toHaveBeenCalled()
   })
 
   it("calls markDirty on change", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
@@ -29,6 +29,7 @@ export interface UseFilePaneReturn {
   // Content state
   content: string | null
   isDirty: boolean
+  isReadonly: boolean
 
   // Conflict handling
   conflict: FileConflictError | null
@@ -84,8 +85,12 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   const fallbackPanelIdRef = useRef(panelId ?? `file-pane:${nextFallbackPanelId++}`)
   const lifecyclePanelId = panelId ?? fallbackPanelIdRef.current
 
+  // Readonly/readwrite is a trusted server binding property returned by the file
+  // route. Do not infer access from filesystem ids; arbitrary named filesystems
+  // may be readonly or readwrite.
   const fileContentOptions = createIfMissing === undefined ? { filesystem } : { filesystem, createIfMissing }
   const { data: fileData, isLoading, error, refetch: refetchFileData } = useFileContent(activePath, fileContentOptions)
+  const isReadonly = fileData?.access === "readonly"
   const { mutateAsync: writeFile } = useFileWrite()
 
   // Local content state
@@ -137,7 +142,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
 
   // Editor lifecycle adapter
   const adapter: EditorLifecycleAdapter | null =
-    activePath && content != null
+    activePath && content != null && !isReadonly
       ? {
           isDirty: () => dirtyRef.current,
           save: async () => {
@@ -222,28 +227,29 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   // next autosave force-overwrites the external change — matching the
   // 409-recovery path in adapter.save above (continued typing wins).
   useEffect(() => {
-    if (!lifecycle.externalChangeWhileDirty || fileData?.mtimeMs == null) return
+    if (isReadonly || !lifecycle.externalChangeWhileDirty || fileData?.mtimeMs == null) return
     setConflict(new FileConflictError(activePath ?? path, fileData.mtimeMs, baselineMtimeRef.current))
     baselineMtimeRef.current = fileData.mtimeMs
     lifecycle.ackExternalChange()
-  }, [activePath, lifecycle.externalChangeWhileDirty, lifecycle, fileData, path])
+  }, [activePath, isReadonly, lifecycle.externalChangeWhileDirty, lifecycle, fileData, path])
 
   // Tab title with dirty indicator
   const fileName = activePath ? (activePath.split("/").pop() ?? activePath) : ""
   const [tabTitle, setTabTitle] = useState("")
 
   useEffect(() => {
-    const title = fileName ? (lifecycle.isDirty ? `${fileName} ●` : fileName) : ""
+    const title = fileName ? (!isReadonly && lifecycle.isDirty ? `${fileName} ●` : fileName) : ""
     setTabTitle(title)
-  }, [fileName, lifecycle.isDirty])
+  }, [fileName, isReadonly, lifecycle.isDirty])
 
   // Actions
   const setContent = useCallback((newContent: string) => {
+    if (isReadonly) return
     setContentState(newContent)
     contentRef.current = newContent
     dirtyRef.current = true
     lifecycle.markDirty()
-  }, [setContentState, lifecycle])
+  }, [isReadonly, setContentState, lifecycle])
 
   const onReloadFromServer = useCallback(async () => {
     if (!activePath) return
@@ -266,6 +272,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   }, [activePath, lifecycle, refetchFileData, setContentState])
 
   const onOverwrite = useCallback(async () => {
+    if (isReadonly) return
     // Bump the save generation so any pending autosave (e.g., one that the
     // watchdog already abandoned) cannot later resolve and undo our state
     // mutations below.
@@ -295,23 +302,25 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
     } catch {
       // Leave conflict UI up so user can retry
     }
-  }, [activePath, filesystem, writeFile])
+  }, [activePath, filesystem, isReadonly, writeFile])
 
   const save = useCallback(async () => {
-    if (!adapter || !dirtyRef.current) return
+    if (isReadonly || !adapter || !dirtyRef.current) return
     await adapter.save()
-  }, [adapter])
+  }, [adapter, isReadonly])
 
   const flushSave = useCallback(async () => {
+    if (isReadonly) return
     await lifecycle.flushSave()
-  }, [lifecycle])
+  }, [isReadonly, lifecycle])
 
   return {
     isLoading,
     error: error as Error | null,
     content,
-    isDirty: lifecycle.isDirty,
-    conflict,
+    isDirty: isReadonly ? false : lifecycle.isDirty,
+    isReadonly,
+    conflict: isReadonly ? null : conflict,
     onReloadFromServer,
     onOverwrite,
     setContent,


### PR DESCRIPTION
## Summary\n- derive file-pane readonly/editable state from server-returned filesystem binding access\n- disable autosave, dirty state, shell callbacks, CodeMirror/Tiptap editing, markdown image resizing, and non-user image uploads for readonly company panes\n- preserve company_context identity for markdown links/assets and file-tree bridge opens\n- route readwrite company mutations through binding operations when a policy-granted binding provides them\n\n## Validation\n- pnpm --dir packages/workspace exec vitest run src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditorPane.test.tsx src/plugins/filesystemPlugin/front/code-editor/__tests__/CodeEditor.test.tsx src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditorPane.test.tsx src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditor.test.tsx src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx --reporter dot\n- pnpm --filter @hachej/boring-workspace typecheck\n- pnpm --dir packages/agent exec vitest run src/server/http/routes/__tests__/file.test.ts src/server/http/routes/__tests__/tree.test.ts --reporter dot\n- pnpm --filter @hachej/boring-agent typecheck\n- bash scripts/check-invariants.sh packages/agent\n- git diff --check\n- autoreview: clean, no accepted/actionable findings