### PR TITLE
feat(human-action): show target review actions

### DIFF
--- a/packages/workspace/src/front/attention/WorkspaceAttentionProvider.tsx
+++ b/packages/workspace/src/front/attention/WorkspaceAttentionProvider.tsx
@@ -30,11 +30,17 @@ export type WorkspaceAttentionInboxSourceMetadata =
   | { type: "review"; id: string; label: string }
   | { type: "generic"; id?: string; label: string }
 
+export type WorkspaceAttentionInboxArtifactMetadata =
+  | { type: "surface"; id?: string; label?: string; surfaceKind: string; target?: string; params?: Record<string, unknown> }
+  | { type: "panel"; id?: string; label?: string; panelComponentId: string; params?: Record<string, unknown> }
+
 export type WorkspaceAttentionInboxMetadata = {
   kind: "question" | "review" | "approval" | "notice"
   sourceLabel: string
   /** Explicit generic provenance for Inbox rows. Plugins should prefer this over reason parsing. */
   source?: WorkspaceAttentionInboxSourceMetadata
+  /** Pointer-only artifacts the human can inspect before deciding. No raw artifact/file content. */
+  artifacts?: WorkspaceAttentionInboxArtifactMetadata[]
   createdAt?: string | number | Date
   updatedAt?: string | number | Date
   priority?: number

--- a/packages/workspace/src/front/attention/index.ts
+++ b/packages/workspace/src/front/attention/index.ts
@@ -10,6 +10,7 @@ export type {
   WorkspaceAttentionBlocker,
   WorkspaceAttentionBlockerAction,
   WorkspaceAttentionContextValue,
+  WorkspaceAttentionInboxArtifactMetadata,
   WorkspaceAttentionInboxSourceMetadata,
   WorkspaceAttentionSessionBadge,
 } from "./WorkspaceAttentionProvider"

--- a/packages/workspace/src/front/humanActions/WorkspaceHumanActionTargetsProvider.tsx
+++ b/packages/workspace/src/front/humanActions/WorkspaceHumanActionTargetsProvider.tsx
@@ -1,0 +1,153 @@
+"use client"
+
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
+import { Button } from "@hachej/boring-ui-kit"
+import { cn } from "../lib/utils"
+
+export type WorkspaceHumanActionTargetRef =
+  | { type: "surface"; surfaceKind: string; target: string; label?: string }
+  | { type: "panel"; component: string; instanceId?: string; label?: string }
+  | { type: "file"; workspaceId?: string; path: string; label?: string }
+
+export type WorkspaceHumanActionButton = {
+  id: string
+  label: string
+  tone?: "default" | "positive" | "warning" | "danger"
+  comment?: "none" | "optional" | "required"
+}
+
+export type WorkspaceHumanActionTargetAction = {
+  id: string
+  title: string
+  body?: string
+  target: WorkspaceHumanActionTargetRef
+  actions: WorkspaceHumanActionButton[]
+  pluginId?: string
+  createdAt?: string
+  onAction: (args: { action: WorkspaceHumanActionButton; comment?: string }) => void | Promise<void>
+}
+
+export interface WorkspaceHumanActionTargetsContextValue {
+  registerTargetAction(action: WorkspaceHumanActionTargetAction): () => void
+  getTargetActions(target: WorkspaceHumanActionTargetRef): WorkspaceHumanActionTargetAction[]
+}
+
+const noopContext: WorkspaceHumanActionTargetsContextValue = {
+  registerTargetAction: () => () => undefined,
+  getTargetActions: () => [],
+}
+
+const WorkspaceHumanActionTargetsContext = createContext<WorkspaceHumanActionTargetsContextValue | null>(null)
+
+export function workspaceHumanActionTargetKey(target: WorkspaceHumanActionTargetRef): string {
+  if (target.type === "surface") return `surface:${target.surfaceKind}:${target.target}`
+  if (target.type === "panel") return `panel:${target.component}:${target.instanceId ?? ""}`
+  return `file:${target.workspaceId ?? ""}:${target.path}`
+}
+
+function targetActionRegistryKey(action: WorkspaceHumanActionTargetAction): string {
+  return `${workspaceHumanActionTargetKey(action.target)}:${action.pluginId ?? "plugin"}:${action.id}`
+}
+
+export function useWorkspaceHumanActionTargets(): WorkspaceHumanActionTargetsContextValue {
+  return useContext(WorkspaceHumanActionTargetsContext) ?? noopContext
+}
+
+export function useWorkspaceHumanActionsForTarget(target: WorkspaceHumanActionTargetRef): WorkspaceHumanActionTargetAction[] {
+  const context = useWorkspaceHumanActionTargets()
+  const key = workspaceHumanActionTargetKey(target)
+  return useMemo(() => context.getTargetActions(target), [context, key])
+}
+
+export function WorkspaceHumanActionTargetsProvider({ children }: { children: ReactNode }) {
+  const [actions, setActions] = useState<WorkspaceHumanActionTargetAction[]>([])
+  const registerTargetAction = useCallback((action: WorkspaceHumanActionTargetAction) => {
+    const key = targetActionRegistryKey(action)
+    setActions((current) => [...current.filter((item) => targetActionRegistryKey(item) !== key), action])
+    return () => setActions((current) => current.filter((item) => targetActionRegistryKey(item) !== key))
+  }, [])
+  const getTargetActions = useCallback((target: WorkspaceHumanActionTargetRef) => {
+    const key = workspaceHumanActionTargetKey(target)
+    return actions.filter((action) => workspaceHumanActionTargetKey(action.target) === key)
+  }, [actions])
+  const value = useMemo<WorkspaceHumanActionTargetsContextValue>(() => ({ registerTargetAction, getTargetActions }), [registerTargetAction, getTargetActions])
+  return <WorkspaceHumanActionTargetsContext.Provider value={value}>{children}</WorkspaceHumanActionTargetsContext.Provider>
+}
+
+function buttonClassName(tone: WorkspaceHumanActionButton["tone"]): string {
+  if (tone === "positive") return "border-emerald-500/60 text-emerald-700 hover:bg-emerald-500/10 dark:text-emerald-300"
+  if (tone === "warning") return "border-amber-500/60 text-amber-700 hover:bg-amber-500/10 dark:text-amber-300"
+  if (tone === "danger") return "border-destructive/60 text-destructive hover:bg-destructive/10"
+  return ""
+}
+
+export function WorkspaceHumanActionTargetButtons({ target, className }: { target: WorkspaceHumanActionTargetRef; className?: string }) {
+  const actions = useWorkspaceHumanActionsForTarget(target)
+  const [draft, setDraft] = useState<{ humanActionId: string; actionId: string; value: string } | null>(null)
+  const [submitting, setSubmitting] = useState<string | null>(null)
+  const runAction = (humanAction: WorkspaceHumanActionTargetAction, action: WorkspaceHumanActionButton, comment?: string) => {
+    const submitKey = `${humanAction.id}:${action.id}`
+    setSubmitting(submitKey)
+    void Promise.resolve()
+      .then(() => humanAction.onAction({ action, ...(comment ? { comment } : {}) }))
+      .finally(() => setSubmitting((current) => current === submitKey ? null : current))
+  }
+  if (actions.length === 0) return null
+  return (
+    <div className={cn("flex min-w-0 flex-wrap items-center gap-2", className)} data-testid="workspace-human-action-target-buttons">
+      {actions.map((humanAction) => {
+        const selected = draft?.humanActionId === humanAction.id
+          ? humanAction.actions.find((action) => action.id === draft.actionId)
+          : null
+        return (
+          <div key={humanAction.id} className="flex min-w-0 items-center gap-1 rounded-md border border-border/60 bg-background/80 px-2 py-1 shadow-sm" title={humanAction.body ?? humanAction.title}>
+            <span className="max-w-[14rem] truncate text-xs font-medium text-muted-foreground">{humanAction.title}</span>
+            <div className="flex items-center gap-1">
+              {humanAction.actions.map((action) => (
+                <Button
+                  key={action.id}
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className={cn("h-7 px-2 text-xs", buttonClassName(action.tone))}
+                  aria-label={`${humanAction.title}: ${action.label}`}
+                  disabled={submitting === `${humanAction.id}:${action.id}`}
+                  onClick={() => {
+                    if (action.comment === "required") {
+                      setDraft({ humanActionId: humanAction.id, actionId: action.id, value: "" })
+                      return
+                    }
+                    runAction(humanAction, action)
+                  }}
+                >
+                  {action.label}
+                </Button>
+              ))}
+            </div>
+            {selected && draft ? (
+              <form
+                className="ml-2 flex items-center gap-1"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  if (!draft.value.trim()) return
+                  setDraft(null)
+                  runAction(humanAction, selected, draft.value.trim())
+                }}
+              >
+                <input
+                  aria-label={`${selected.label} comment`}
+                  className="h-7 w-44 rounded-md border border-border bg-background px-2 text-xs outline-none focus:ring-2 focus:ring-ring"
+                  value={draft.value}
+                  placeholder="Comment required"
+                  onChange={(event) => setDraft({ ...draft, value: event.target.value })}
+                />
+                <Button type="submit" size="sm" className="h-7 px-2 text-xs" disabled={!draft.value.trim() || submitting === `${humanAction.id}:${selected.id}`}>Send</Button>
+                <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => setDraft(null)}>Cancel</Button>
+              </form>
+            ) : null}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/workspace/src/front/humanActions/WorkspaceHumanActionTargetsProvider.tsx
+++ b/packages/workspace/src/front/humanActions/WorkspaceHumanActionTargetsProvider.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react"
+import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from "react"
 import { Button } from "@hachej/boring-ui-kit"
 import { cn } from "../lib/utils"
+import { toast } from "../toast"
 
 export type WorkspaceHumanActionTargetRef =
   | { type: "surface"; surfaceKind: string; target: string; label?: string }
@@ -49,6 +50,17 @@ function targetActionRegistryKey(action: WorkspaceHumanActionTargetAction): stri
   return `${workspaceHumanActionTargetKey(action.target)}:${action.pluginId ?? "plugin"}:${action.id}`
 }
 
+function workspaceHumanActionTargetsMatch(left: WorkspaceHumanActionTargetRef, right: WorkspaceHumanActionTargetRef): boolean {
+  if (left.type !== right.type) return false
+  if (left.type === "surface" && right.type === "surface") return left.surfaceKind === right.surfaceKind && left.target === right.target
+  if (left.type === "panel" && right.type === "panel") return left.component === right.component && (left.instanceId ?? "") === (right.instanceId ?? "")
+  if (left.type === "file" && right.type === "file") {
+    if (left.path !== right.path) return false
+    return !left.workspaceId || !right.workspaceId || left.workspaceId === right.workspaceId
+  }
+  return false
+}
+
 export function useWorkspaceHumanActionTargets(): WorkspaceHumanActionTargetsContextValue {
   return useContext(WorkspaceHumanActionTargetsContext) ?? noopContext
 }
@@ -66,10 +78,7 @@ export function WorkspaceHumanActionTargetsProvider({ children }: { children: Re
     setActions((current) => [...current.filter((item) => targetActionRegistryKey(item) !== key), action])
     return () => setActions((current) => current.filter((item) => targetActionRegistryKey(item) !== key))
   }, [])
-  const getTargetActions = useCallback((target: WorkspaceHumanActionTargetRef) => {
-    const key = workspaceHumanActionTargetKey(target)
-    return actions.filter((action) => workspaceHumanActionTargetKey(action.target) === key)
-  }, [actions])
+  const getTargetActions = useCallback((target: WorkspaceHumanActionTargetRef) => actions.filter((action) => workspaceHumanActionTargetsMatch(action.target, target)), [actions])
   const value = useMemo<WorkspaceHumanActionTargetsContextValue>(() => ({ registerTargetAction, getTargetActions }), [registerTargetAction, getTargetActions])
   return <WorkspaceHumanActionTargetsContext.Provider value={value}>{children}</WorkspaceHumanActionTargetsContext.Provider>
 }
@@ -84,13 +93,30 @@ function buttonClassName(tone: WorkspaceHumanActionButton["tone"]): string {
 export function WorkspaceHumanActionTargetButtons({ target, className }: { target: WorkspaceHumanActionTargetRef; className?: string }) {
   const actions = useWorkspaceHumanActionsForTarget(target)
   const [draft, setDraft] = useState<{ humanActionId: string; actionId: string; value: string } | null>(null)
-  const [submitting, setSubmitting] = useState<string | null>(null)
+  const submittingIdsRef = useRef(new Set<string>())
+  const [submittingIds, setSubmittingIds] = useState<Set<string>>(() => new Set())
+  const [error, setError] = useState<{ humanActionId: string; message: string } | null>(null)
+  const beginSubmit = (humanActionId: string): boolean => {
+    if (submittingIdsRef.current.has(humanActionId)) return false
+    submittingIdsRef.current.add(humanActionId)
+    setSubmittingIds(new Set(submittingIdsRef.current))
+    return true
+  }
+  const finishSubmit = (humanActionId: string): void => {
+    submittingIdsRef.current.delete(humanActionId)
+    setSubmittingIds(new Set(submittingIdsRef.current))
+  }
   const runAction = (humanAction: WorkspaceHumanActionTargetAction, action: WorkspaceHumanActionButton, comment?: string) => {
-    const submitKey = `${humanAction.id}:${action.id}`
-    setSubmitting(submitKey)
+    if (!beginSubmit(humanAction.id)) return
+    setError(null)
     void Promise.resolve()
       .then(() => humanAction.onAction({ action, ...(comment ? { comment } : {}) }))
-      .finally(() => setSubmitting((current) => current === submitKey ? null : current))
+      .catch(() => {
+        const message = "Decision was not submitted. Try again or open the request from Inbox."
+        setError({ humanActionId: humanAction.id, message })
+        toast.error({ title: "Decision not submitted", description: message })
+      })
+      .finally(() => finishSubmit(humanAction.id))
   }
   if (actions.length === 0) return null
   return (
@@ -99,6 +125,9 @@ export function WorkspaceHumanActionTargetButtons({ target, className }: { targe
         const selected = draft?.humanActionId === humanAction.id
           ? humanAction.actions.find((action) => action.id === draft.actionId)
           : null
+        const selectedRequiresComment = selected?.comment === "required"
+        const rowSubmitting = submittingIds.has(humanAction.id)
+        const rowError = error?.humanActionId === humanAction.id ? error.message : null
         return (
           <div key={humanAction.id} className="flex min-w-0 items-center gap-1 rounded-md border border-border/60 bg-background/80 px-2 py-1 shadow-sm" title={humanAction.body ?? humanAction.title}>
             <span className="max-w-[14rem] truncate text-xs font-medium text-muted-foreground">{humanAction.title}</span>
@@ -111,9 +140,10 @@ export function WorkspaceHumanActionTargetButtons({ target, className }: { targe
                   variant="outline"
                   className={cn("h-7 px-2 text-xs", buttonClassName(action.tone))}
                   aria-label={`${humanAction.title}: ${action.label}`}
-                  disabled={submitting === `${humanAction.id}:${action.id}`}
+                  disabled={rowSubmitting}
                   onClick={() => {
-                    if (action.comment === "required") {
+                    if (rowSubmitting) return
+                    if (action.comment === "required" || action.comment === "optional") {
                       setDraft({ humanActionId: humanAction.id, actionId: action.id, value: "" })
                       return
                     }
@@ -129,22 +159,24 @@ export function WorkspaceHumanActionTargetButtons({ target, className }: { targe
                 className="ml-2 flex items-center gap-1"
                 onSubmit={(event) => {
                   event.preventDefault()
-                  if (!draft.value.trim()) return
+                  const comment = draft.value.trim()
+                  if (selectedRequiresComment && !comment) return
                   setDraft(null)
-                  runAction(humanAction, selected, draft.value.trim())
+                  runAction(humanAction, selected, comment || undefined)
                 }}
               >
                 <input
                   aria-label={`${selected.label} comment`}
                   className="h-7 w-44 rounded-md border border-border bg-background px-2 text-xs outline-none focus:ring-2 focus:ring-ring"
                   value={draft.value}
-                  placeholder="Comment required"
+                  placeholder={selectedRequiresComment ? "Comment required" : "Comment optional"}
                   onChange={(event) => setDraft({ ...draft, value: event.target.value })}
                 />
-                <Button type="submit" size="sm" className="h-7 px-2 text-xs" disabled={!draft.value.trim() || submitting === `${humanAction.id}:${selected.id}`}>Send</Button>
+                <Button type="submit" size="sm" className="h-7 px-2 text-xs" disabled={(selectedRequiresComment && !draft.value.trim()) || rowSubmitting}>Send</Button>
                 <Button type="button" size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => setDraft(null)}>Cancel</Button>
               </form>
             ) : null}
+            {rowError ? <span role="status" className="ml-2 text-xs text-destructive">{rowError}</span> : null}
           </div>
         )
       })}

--- a/packages/workspace/src/front/humanActions/__tests__/WorkspaceHumanActionTargetsProvider.test.tsx
+++ b/packages/workspace/src/front/humanActions/__tests__/WorkspaceHumanActionTargetsProvider.test.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   WorkspaceHumanActionTargetButtons,
   WorkspaceHumanActionTargetsProvider,
@@ -8,6 +8,7 @@ import {
   workspaceHumanActionTargetKey,
   type WorkspaceHumanActionTargetAction,
 } from "../WorkspaceHumanActionTargetsProvider"
+import { clearToasts, getActiveToasts } from "../../toast"
 
 function RegisterAction({ action }: { action: WorkspaceHumanActionTargetAction }) {
   const { registerTargetAction } = useWorkspaceHumanActionTargets()
@@ -16,6 +17,8 @@ function RegisterAction({ action }: { action: WorkspaceHumanActionTargetAction }
 }
 
 describe("WorkspaceHumanActionTargetsProvider", () => {
+  beforeEach(() => clearToasts())
+
   it("keys targets without storing raw content", () => {
     expect(workspaceHumanActionTargetKey({ type: "file", workspaceId: "w1", path: "README.md", label: "Readme" })).toBe("file:w1:README.md")
     expect(workspaceHumanActionTargetKey({ type: "surface", surfaceKind: "artifact", target: "html-1" })).toBe("surface:artifact:html-1")
@@ -42,10 +45,38 @@ describe("WorkspaceHumanActionTargetsProvider", () => {
     await waitFor(() => expect(onAction).toHaveBeenCalledWith({ action: action.actions[0] }))
   })
 
+  it("disables sibling buttons while a target action is submitting", async () => {
+    let resolveSubmit!: () => void
+    const onAction = vi.fn(() => new Promise<void>((resolve) => { resolveSubmit = resolve }))
+    const action: WorkspaceHumanActionTargetAction = {
+      id: "review-2",
+      title: "Review README",
+      target: { type: "file", path: "README.md" },
+      actions: [
+        { id: "accept", label: "Accept", tone: "positive" },
+        { id: "request_changes", label: "Request changes", tone: "warning" },
+      ],
+      onAction,
+    }
+
+    render(
+      <WorkspaceHumanActionTargetsProvider>
+        <RegisterAction action={action} />
+        <WorkspaceHumanActionTargetButtons target={{ type: "file", path: "README.md" }} />
+      </WorkspaceHumanActionTargetsProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Review README: Accept" }))
+    await waitFor(() => expect(screen.getByRole("button", { name: "Review README: Request changes" })).toBeDisabled())
+    fireEvent.click(screen.getByRole("button", { name: "Review README: Request changes" }))
+    expect(onAction).toHaveBeenCalledTimes(1)
+    resolveSubmit()
+  })
+
   it("requires a comment before submitting comment-required actions", async () => {
     const onAction = vi.fn()
     const action: WorkspaceHumanActionTargetAction = {
-      id: "review-2",
+      id: "review-3",
       title: "Review README",
       target: { type: "file", path: "README.md" },
       actions: [{ id: "request_changes", label: "Request changes", tone: "warning", comment: "required" }],
@@ -65,5 +96,50 @@ describe("WorkspaceHumanActionTargetsProvider", () => {
     fireEvent.change(screen.getByRole("textbox", { name: "Request changes comment" }), { target: { value: "Needs clearer install steps" } })
     fireEvent.click(screen.getByRole("button", { name: "Send" }))
     await waitFor(() => expect(onAction).toHaveBeenCalledWith({ action: action.actions[0], comment: "Needs clearer install steps" }))
+  })
+
+  it("lets optional-comment actions submit a comment", async () => {
+    const onAction = vi.fn()
+    const action: WorkspaceHumanActionTargetAction = {
+      id: "review-4",
+      title: "Review README",
+      target: { type: "file", path: "README.md" },
+      actions: [{ id: "accept", label: "Accept", tone: "positive", comment: "optional" }],
+      onAction,
+    }
+
+    render(
+      <WorkspaceHumanActionTargetsProvider>
+        <RegisterAction action={action} />
+        <WorkspaceHumanActionTargetButtons target={{ type: "file", path: "README.md" }} />
+      </WorkspaceHumanActionTargetsProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Review README: Accept" }))
+    fireEvent.change(screen.getByRole("textbox", { name: "Accept comment" }), { target: { value: "Looks good" } })
+    fireEvent.click(screen.getByRole("button", { name: "Send" }))
+    await waitFor(() => expect(onAction).toHaveBeenCalledWith({ action: action.actions[0], comment: "Looks good" }))
+  })
+
+  it("surfaces target action submit failures", async () => {
+    const onAction = vi.fn().mockRejectedValue(new Error("boom"))
+    const action: WorkspaceHumanActionTargetAction = {
+      id: "review-5",
+      title: "Review README",
+      target: { type: "file", path: "README.md" },
+      actions: [{ id: "accept", label: "Accept", tone: "positive" }],
+      onAction,
+    }
+
+    render(
+      <WorkspaceHumanActionTargetsProvider>
+        <RegisterAction action={action} />
+        <WorkspaceHumanActionTargetButtons target={{ type: "file", path: "README.md" }} />
+      </WorkspaceHumanActionTargetsProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Review README: Accept" }))
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent("Decision was not submitted"))
+    expect(getActiveToasts().some((toast) => toast.title === "Decision not submitted")).toBe(true)
   })
 })

--- a/packages/workspace/src/front/humanActions/__tests__/WorkspaceHumanActionTargetsProvider.test.tsx
+++ b/packages/workspace/src/front/humanActions/__tests__/WorkspaceHumanActionTargetsProvider.test.tsx
@@ -1,0 +1,69 @@
+import { useEffect } from "react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import {
+  WorkspaceHumanActionTargetButtons,
+  WorkspaceHumanActionTargetsProvider,
+  useWorkspaceHumanActionTargets,
+  workspaceHumanActionTargetKey,
+  type WorkspaceHumanActionTargetAction,
+} from "../WorkspaceHumanActionTargetsProvider"
+
+function RegisterAction({ action }: { action: WorkspaceHumanActionTargetAction }) {
+  const { registerTargetAction } = useWorkspaceHumanActionTargets()
+  useEffect(() => registerTargetAction(action), [action, registerTargetAction])
+  return null
+}
+
+describe("WorkspaceHumanActionTargetsProvider", () => {
+  it("keys targets without storing raw content", () => {
+    expect(workspaceHumanActionTargetKey({ type: "file", workspaceId: "w1", path: "README.md", label: "Readme" })).toBe("file:w1:README.md")
+    expect(workspaceHumanActionTargetKey({ type: "surface", surfaceKind: "artifact", target: "html-1" })).toBe("surface:artifact:html-1")
+  })
+
+  it("renders registered target action buttons and invokes plugin callback", async () => {
+    const onAction = vi.fn()
+    const action: WorkspaceHumanActionTargetAction = {
+      id: "review-1",
+      title: "Review README",
+      target: { type: "file", path: "README.md" },
+      actions: [{ id: "accept", label: "Accept", tone: "positive" }],
+      onAction,
+    }
+
+    render(
+      <WorkspaceHumanActionTargetsProvider>
+        <RegisterAction action={action} />
+        <WorkspaceHumanActionTargetButtons target={{ type: "file", path: "README.md" }} />
+      </WorkspaceHumanActionTargetsProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Review README: Accept" }))
+    await waitFor(() => expect(onAction).toHaveBeenCalledWith({ action: action.actions[0] }))
+  })
+
+  it("requires a comment before submitting comment-required actions", async () => {
+    const onAction = vi.fn()
+    const action: WorkspaceHumanActionTargetAction = {
+      id: "review-2",
+      title: "Review README",
+      target: { type: "file", path: "README.md" },
+      actions: [{ id: "request_changes", label: "Request changes", tone: "warning", comment: "required" }],
+      onAction,
+    }
+
+    render(
+      <WorkspaceHumanActionTargetsProvider>
+        <RegisterAction action={action} />
+        <WorkspaceHumanActionTargetButtons target={{ type: "file", path: "README.md" }} />
+      </WorkspaceHumanActionTargetsProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Review README: Request changes" }))
+    fireEvent.click(screen.getByRole("button", { name: "Send" }))
+    expect(onAction).not.toHaveBeenCalled()
+    fireEvent.change(screen.getByRole("textbox", { name: "Request changes comment" }), { target: { value: "Needs clearer install steps" } })
+    fireEvent.click(screen.getByRole("button", { name: "Send" }))
+    await waitFor(() => expect(onAction).toHaveBeenCalledWith({ action: action.actions[0], comment: "Needs clearer install steps" }))
+  })
+})

--- a/packages/workspace/src/front/humanActions/index.ts
+++ b/packages/workspace/src/front/humanActions/index.ts
@@ -1,0 +1,13 @@
+export {
+  WorkspaceHumanActionTargetButtons,
+  WorkspaceHumanActionTargetsProvider,
+  useWorkspaceHumanActionsForTarget,
+  useWorkspaceHumanActionTargets,
+  workspaceHumanActionTargetKey,
+} from "./WorkspaceHumanActionTargetsProvider"
+export type {
+  WorkspaceHumanActionButton,
+  WorkspaceHumanActionTargetAction,
+  WorkspaceHumanActionTargetRef,
+  WorkspaceHumanActionTargetsContextValue,
+} from "./WorkspaceHumanActionTargetsProvider"

--- a/packages/workspace/src/front/provider/WorkspaceProvider.tsx
+++ b/packages/workspace/src/front/provider/WorkspaceProvider.tsx
@@ -42,6 +42,7 @@ import type { CommandConfig, PanelConfig, WorkspaceSourceRegistration } from "..
 import type { CatalogConfig } from "../../shared/plugins/types"
 import type { WorkspaceChatPanelComponent, WorkspaceChatPanelProps } from "../chrome/chat/types"
 import { WorkspaceAttentionProvider } from "../attention"
+import { WorkspaceHumanActionTargetsProvider } from "../humanActions"
 import { useAgentPluginHotReload } from "../agentPlugins/registerAgentPlugin"
 import { formatWorkspaceDocumentTitle } from "./workspaceTitle"
 
@@ -630,6 +631,7 @@ export function WorkspaceProvider({
         <WorkspaceBridgeContext.Provider value={bridgeValue}>
           <FullPageBasePathProvider basePath={fullPageBasePath}>
             <WorkspaceAttentionProvider>
+              <WorkspaceHumanActionTargetsProvider>
           <PluginErrorProvider>
             <RegistryProvider
               panelRegistry={panelRegistry}
@@ -673,6 +675,7 @@ export function WorkspaceProvider({
               </PanelRenderStatusProvider>
             </RegistryProvider>
           </PluginErrorProvider>
+              </WorkspaceHumanActionTargetsProvider>
           </WorkspaceAttentionProvider>
           </FullPageBasePathProvider>
         </WorkspaceBridgeContext.Provider>

--- a/packages/workspace/src/front/provider/index.ts
+++ b/packages/workspace/src/front/provider/index.ts
@@ -34,6 +34,19 @@ export type {
   WorkspaceAttentionInboxSourceMetadata,
   WorkspaceAttentionSessionBadge,
 } from "../attention"
+export {
+  WorkspaceHumanActionTargetButtons,
+  WorkspaceHumanActionTargetsProvider,
+  useWorkspaceHumanActionsForTarget,
+  useWorkspaceHumanActionTargets,
+  workspaceHumanActionTargetKey,
+} from "../humanActions"
+export type {
+  WorkspaceHumanActionButton,
+  WorkspaceHumanActionTargetAction,
+  WorkspaceHumanActionTargetRef,
+  WorkspaceHumanActionTargetsContextValue,
+} from "../humanActions"
 export type {
   OpenArtifactHandler,
   WorkspaceChatPanelComponent,

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -344,6 +344,11 @@ export {
   emitWorkspaceAttentionAction,
   useWorkspaceAttention,
   workspaceAttentionSessionBadgeForBlocker,
+  WorkspaceHumanActionTargetButtons,
+  WorkspaceHumanActionTargetsProvider,
+  useWorkspaceHumanActionsForTarget,
+  useWorkspaceHumanActionTargets,
+  workspaceHumanActionTargetKey,
 } from "./front/provider"
 export type {
   WorkspaceProviderProps,
@@ -357,6 +362,10 @@ export type {
   WorkspaceAttentionContextValue,
   WorkspaceAttentionInboxSourceMetadata,
   WorkspaceAttentionSessionBadge,
+  WorkspaceHumanActionButton,
+  WorkspaceHumanActionTargetAction,
+  WorkspaceHumanActionTargetRef,
+  WorkspaceHumanActionTargetsContextValue,
 } from "./front/provider"
 
 // Store (selectors only — store itself is NOT exported)

--- a/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react"
 import { EmptyState, ErrorState, Spinner } from "@hachej/boring-ui-kit"
 import { WorkspaceHumanActionTargetButtons } from "../../../front/humanActions"
 import { ConflictBanner } from "./ConflictBanner"
+import { useWorkspaceRequestId } from "./data/DataProvider"
 import type { FileConflictError } from "./data/fetchClient"
 
 export interface FilePaneShellProps {
@@ -88,6 +89,9 @@ export function FilePaneShell({
   errorMessage,
   className,
 }: FilePaneShellProps) {
+  const workspaceRequestId = useWorkspaceRequestId()
+  const target = { type: "file" as const, path, ...(workspaceRequestId ? { workspaceId: workspaceRequestId } : {}) }
+
   // No file selected
   if (!/\S/.test(path)) {
     return (
@@ -123,7 +127,7 @@ export function FilePaneShell({
         />
       )}
       <WorkspaceHumanActionTargetButtons
-        target={{ type: "file", path }}
+        target={target}
         className="shrink-0 border-b border-border/60 bg-background/95 px-3 py-2"
       />
       <Suspense fallback={loadingSpinner}>

--- a/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
@@ -3,6 +3,7 @@
 import { lazy, Suspense } from "react"
 import type { ReactNode } from "react"
 import { EmptyState, ErrorState, Spinner } from "@hachej/boring-ui-kit"
+import { WorkspaceHumanActionTargetButtons } from "../../../front/humanActions"
 import { ConflictBanner } from "./ConflictBanner"
 import type { FileConflictError } from "./data/fetchClient"
 
@@ -121,6 +122,10 @@ export function FilePaneShell({
           onOverwrite={onOverwrite}
         />
       )}
+      <WorkspaceHumanActionTargetButtons
+        target={{ type: "file", path }}
+        className="shrink-0 border-b border-border/60 bg-background/95 px-3 py-2"
+      />
       <Suspense fallback={loadingSpinner}>
         {isLoading || content === null ? (
           loadingSpinner

--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
@@ -188,6 +188,7 @@ export async function prepareHtmlPreviewDocument(options: {
 export function HtmlViewer({ path, className }: HtmlViewerProps) {
   const apiBaseUrl = useApiBaseUrl()
   const workspaceRequestId = useWorkspaceRequestId()
+  const target = { type: "file" as const, path, ...(workspaceRequestId ? { workspaceId: workspaceRequestId } : {}) }
   const [html, setHtml] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
@@ -261,7 +262,9 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
   return (
     <div className={cn("flex h-full min-h-0 flex-col bg-background", className)}>
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/60 px-3 py-2">
-        <WorkspaceHumanActionTargetButtons target={{ type: "file", path }} />
+        <div className="min-w-0 flex-1">
+          <WorkspaceHumanActionTargetButtons target={target} />
+        </div>
         <div className="flex items-center gap-1">
           <IconButton
             type="button"

--- a/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/html-viewer/HtmlViewer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { ErrorState, IconButton, Spinner } from "@hachej/boring-ui-kit"
 import { ExternalLink, RefreshCcw } from "lucide-react"
+import { WorkspaceHumanActionTargetButtons } from "../../../../front/humanActions"
 import { cn } from "../../../../front/lib/utils"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
 
@@ -259,7 +260,8 @@ export function HtmlViewer({ path, className }: HtmlViewerProps) {
 
   return (
     <div className={cn("flex h-full min-h-0 flex-col bg-background", className)}>
-      <div className="flex shrink-0 items-center justify-end gap-3 border-b border-border/60 px-3 py-2">
+      <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/60 px-3 py-2">
+        <WorkspaceHumanActionTargetButtons target={{ type: "file", path }} />
         <div className="flex items-center gap-1">
           <IconButton
             type="button"

--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from "react"
 import { Download, RefreshCw } from "lucide-react"
 import { ErrorState, Spinner } from "@hachej/boring-ui-kit"
 import { useApiBaseUrl, useWorkspaceRequestId } from "../data/DataProvider"
+import { WorkspaceHumanActionTargetButtons } from "../../../../front/humanActions"
 import { cn } from "../../../../front/lib/utils"
 
 export interface MediaViewerProps {
@@ -82,8 +83,11 @@ export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: 
   return (
     <div className={cn("flex h-full min-h-0 flex-col bg-background", className)}>
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border/60 px-3 py-2">
-        <div className="min-w-0 truncate text-xs font-medium text-muted-foreground" title={path}>
-          {filename(path)}
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="min-w-0 truncate text-xs font-medium text-muted-foreground" title={path}>
+            {filename(path)}
+          </div>
+          <WorkspaceHumanActionTargetButtons target={{ type: "file", path }} />
         </div>
         <div className="flex items-center gap-1">
           <button

--- a/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/media-viewer/MediaViewer.tsx
@@ -27,6 +27,7 @@ function filename(path: string): string {
 export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: MediaViewerProps) {
   const apiBaseUrl = useApiBaseUrl()
   const workspaceRequestId = useWorkspaceRequestId()
+  const target = { type: "file" as const, path, ...(workspaceRequestId ? { workspaceId: workspaceRequestId } : {}) }
   const [objectUrl, setObjectUrl] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
@@ -87,7 +88,7 @@ export function MediaViewer({ path, kind, reloadKey = 0, onReload, className }: 
           <div className="min-w-0 truncate text-xs font-medium text-muted-foreground" title={path}>
             {filename(path)}
           </div>
-          <WorkspaceHumanActionTargetButtons target={{ type: "file", path }} />
+          <WorkspaceHumanActionTargetButtons target={target} />
         </div>
         <div className="flex items-center gap-1">
           <button

--- a/plugins/ask-user/e2e/ask-user.spec.ts
+++ b/plugins/ask-user/e2e/ask-user.spec.ts
@@ -80,6 +80,70 @@ test.describe("ask_user Questions pane", () => {
     await expect.poll(() => pendingRequestCount).toBeGreaterThanOrEqual(2)
   })
 
+  test("target-scoped review action appears in file header and submits", async ({ page }) => {
+    const commands: unknown[] = []
+    await page.route("**/api/v1/ui/state", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          json: {
+            "questions.pending": {
+              hint: { questionId: "q-e2e-review", sessionId: "default", status: "ready" },
+            },
+          },
+        })
+        return
+      }
+      await route.fulfill({ status: 204 })
+    })
+
+    await page.route("**/api/v1/workspace-bridge/call", async (route) => {
+      const body = route.request().postDataJSON()
+      commands.push(body)
+      if (body.op === "ask-user.v1.pending") {
+        const sessionId = body.input?.sessionId ?? "default"
+        await route.fulfill({
+          json: {
+            ok: true,
+            op: body.op,
+            requestId: "req-e2e-review",
+            output: {
+              pending: {
+                ...question,
+                questionId: "q-e2e-review",
+                sessionId,
+                title: "Review README",
+                schema: {
+                  wireVersion: 1,
+                  fields: [{ type: "radio", name: "action", label: "Action", required: true, options: [{ value: "accept", label: "Accept" }, { value: "request_changes", label: "Request changes" }] }],
+                },
+                humanAction: {
+                  kind: "review",
+                  title: "Review README",
+                  target: { type: "file", path: "README.md", label: "README.md" },
+                  actions: [{ id: "accept", label: "Accept", tone: "positive" }],
+                  actionFieldName: "action",
+                },
+              },
+            },
+          },
+        })
+        return
+      }
+      await route.fulfill({ json: { ok: true, op: body.op, requestId: "req-e2e-review", output: { ok: true, status: "answered" } } })
+    })
+
+    await page.goto("/?fresh=1", { waitUntil: "domcontentloaded" })
+    await expect(page.getByRole("textbox", { name: "Agent prompt" })).toBeVisible({ timeout: 15_000 })
+    const workbenchButton = page.getByRole("button", { name: /^open workbench$/i })
+    if (await workbenchButton.isVisible().catch(() => false)) await workbenchButton.click()
+    await page.request.post("/api/v1/ui/commands", { data: { kind: "openFile", params: { path: "README.md" } } })
+
+    await expect(page.getByRole("button", { name: "Review README: Accept" })).toBeVisible({ timeout: 15_000 })
+    await page.getByRole("button", { name: "Review README: Accept" }).click()
+
+    await expect.poll(() => commands.some((cmd: any) => cmd.op === "ask-user.v1.answer" && cmd.input?.values?.action === "accept" && cmd.input?.answerToken === "secret-e2e")).toBe(true)
+  })
+
   test("ui command opens pane from metadata, submits, and closes", async ({ page }) => {
     const commands: unknown[] = []
     await page.route("**/api/v1/ui/state", async (route) => {

--- a/plugins/ask-user/e2e/ask-user.spec.ts
+++ b/plugins/ask-user/e2e/ask-user.spec.ts
@@ -134,14 +134,133 @@ test.describe("ask_user Questions pane", () => {
 
     await page.goto("/?fresh=1", { waitUntil: "domcontentloaded" })
     await expect(page.getByRole("textbox", { name: "Agent prompt" })).toBeVisible({ timeout: 15_000 })
-    const workbenchButton = page.getByRole("button", { name: /^open workbench$/i })
-    if (await workbenchButton.isVisible().catch(() => false)) await workbenchButton.click()
-    await page.request.post("/api/v1/ui/commands", { data: { kind: "openFile", params: { path: "README.md" } } })
+    await page.evaluate(() => {
+      window.dispatchEvent(new CustomEvent("boring-workspace:ui-command", { detail: { kind: "openFile", params: { path: "README.md" } } }))
+    })
+    await page.getByRole("complementary", { name: "Surface" }).getByText("README.md", { exact: true }).first().click({ force: true })
 
     await expect(page.getByRole("button", { name: "Review README: Accept" })).toBeVisible({ timeout: 15_000 })
-    await page.getByRole("button", { name: "Review README: Accept" }).click()
+    await page.getByRole("button", { name: "Review README: Accept" }).click({ force: true })
 
     await expect.poll(() => commands.some((cmd: any) => cmd.op === "ask-user.v1.answer" && cmd.input?.values?.action === "accept" && cmd.input?.answerToken === "secret-e2e")).toBe(true)
+  })
+
+  test("inbox review opens an HTML target and sends annotation payload back to the agent", async ({ page }) => {
+    const commands: unknown[] = []
+    const htmlReviewQuestion = {
+      ...question,
+      questionId: "q-e2e-html-review",
+      sessionId: "default",
+      title: "Review generated landing page",
+      context: "Review the generated HTML artifact and request changes if needed.",
+      schema: {
+        wireVersion: 1,
+        fields: [
+          {
+            type: "radio",
+            name: "decision",
+            label: "Decision",
+            required: true,
+            options: [
+              { value: "accept", label: "Accept" },
+              { value: "request_changes", label: "Request changes" },
+            ],
+          },
+          { type: "textarea", name: "comment", label: "Human comment", maxLength: 4000 },
+          { type: "textarea", name: "review", label: "LLM review handoff", maxLength: 4000 },
+          { type: "textarea", name: "annotations", label: "Machine annotation payload", maxLength: 4000 },
+        ],
+      },
+      humanAction: {
+        id: "review-html-artifact",
+        kind: "review",
+        title: "Review generated landing page",
+        body: "Check the generated HTML before the agent continues.",
+        target: { type: "file", path: "docs/generated-review.html", label: "Generated HTML" },
+        artifacts: [{ id: "generated-html", label: "Generated HTML", target: { type: "file", path: "docs/generated-review.html", label: "Generated HTML" } }],
+        actions: [{ id: "request_changes", label: "Request changes", tone: "warning", comment: "required" }],
+        actionFieldName: "decision",
+        commentFieldName: "comment",
+        reviewFieldName: "review",
+        annotationsFieldName: "annotations",
+      },
+    }
+
+    await page.route("**/api/v1/ui/state", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          json: {
+            "questions.pending": {
+              hint: { questionId: htmlReviewQuestion.questionId, sessionId: htmlReviewQuestion.sessionId, status: "ready" },
+            },
+          },
+        })
+        return
+      }
+      await route.fulfill({ status: 204 })
+    })
+
+    await page.route("**/api/v1/files/raw?**", async (route) => {
+      const url = new URL(route.request().url())
+      if (url.searchParams.get("path") === "docs/generated-review.html") {
+        await route.fulfill({
+          contentType: "text/html",
+          body: "<!doctype html><html><body><main><h1>Ship faster</h1><p>Signup now.</p></main></body></html>",
+        })
+        return
+      }
+      await route.continue()
+    })
+
+    await page.route("**/api/v1/workspace-bridge/call", async (route) => {
+      const body = route.request().postDataJSON()
+      commands.push(body)
+      if (body.op === "ask-user.v1.pending") {
+        await route.fulfill({ json: { ok: true, op: body.op, requestId: "req-e2e-html-review", output: { pending: htmlReviewQuestion } } })
+        return
+      }
+      await route.fulfill({ json: { ok: true, op: body.op, requestId: "req-e2e-html-review", output: { ok: true, status: "answered" } } })
+    })
+
+    await page.goto("/?inboxDemo=1&fresh=1", { waitUntil: "domcontentloaded" })
+    await expect(page.getByRole("heading", { name: "Inbox" })).toBeVisible({ timeout: 15_000 })
+    const inboxRow = page.getByRole("button", { name: /Review generated landing page.*Generated HTML/ })
+    await expect(inboxRow).toBeVisible()
+
+    await inboxRow.click()
+    await expect(page.getByRole("button", { name: "Review generated landing page: Request changes" })).toBeVisible({ timeout: 15_000 })
+
+    await page.getByRole("button", { name: "Review generated landing page: Request changes" }).click()
+    await page.getByRole("textbox", { name: "Request changes comment" }).fill("CTA must explain pricing before signup.")
+    await page.getByRole("button", { name: "Send" }).click()
+
+    await expect.poll(() => {
+      const answer = commands.find((cmd: any) => cmd.op === "ask-user.v1.answer") as any
+      return answer?.input?.values?.decision
+    }).toBe("request_changes")
+
+    const answer = commands.find((cmd: any) => cmd.op === "ask-user.v1.answer") as any
+    expect(answer.input.answerToken).toBe("secret-e2e")
+    expect(answer.input.values.comment).toBe("CTA must explain pricing before signup.")
+    expect(answer.input.values.review).toContain("# Human Review Feedback")
+    expect(answer.input.values.review).toContain("Decision: `request_changes`")
+    expect(answer.input.values.review).toContain("Generated HTML")
+    expect(answer.input.values.review).toContain("CTA must explain pricing before signup.")
+
+    const reviewPayload = JSON.parse(answer.input.values.annotations)
+    expect(reviewPayload).toMatchObject({
+      humanActionId: "review-html-artifact",
+      decisionId: "request_changes",
+      comment: "CTA must explain pricing before signup.",
+      annotations: [
+        {
+          target: { type: "file", path: "docs/generated-review.html", label: "Generated HTML" },
+          anchor: { type: "global" },
+          body: "CTA must explain pricing before signup.",
+          severity: "issue",
+        },
+      ],
+    })
   })
 
   test("ui command opens pane from metadata, submits, and closes", async ({ page }) => {

--- a/plugins/ask-user/src/front/__tests__/client.test.ts
+++ b/plugins/ask-user/src/front/__tests__/client.test.ts
@@ -60,8 +60,12 @@ describe("ask-user front client", () => {
             kind: "review",
             title: "Review README",
             target: { type: "file", path: "README.md", label: "Readme" },
+            artifacts: [{ id: "html", label: "Generated HTML", target: { type: "file", path: "docs/generated.html", label: "Generated HTML" } }],
             actions: [{ id: "accept", label: "Accept", tone: "positive" }],
             actionFieldName: "action",
+            commentFieldName: "comment",
+            reviewFieldName: "review",
+            annotationsFieldName: "annotations",
           },
         },
       },
@@ -73,8 +77,12 @@ describe("ask-user front client", () => {
       kind: "review",
       title: "Review README",
       target: { type: "file", path: "README.md", label: "Readme" },
+      artifacts: [{ id: "html", label: "Generated HTML", target: { type: "file", path: "docs/generated.html", label: "Generated HTML" } }],
       actions: [{ id: "accept", label: "Accept", tone: "positive" }],
       actionFieldName: "action",
+      commentFieldName: "comment",
+      reviewFieldName: "review",
+      annotationsFieldName: "annotations",
     })
   })
 

--- a/plugins/ask-user/src/front/__tests__/client.test.ts
+++ b/plugins/ask-user/src/front/__tests__/client.test.ts
@@ -50,6 +50,34 @@ describe("ask-user front client", () => {
     expect(readPendingQuestionHintFromState(state)).toEqual({ questionId: "legacy", sessionId: "s-legacy", status: "ready" })
   })
 
+  it("normalizes target-scoped human actions from pending bridge payloads", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => Response.json({
+      ok: true,
+      output: {
+        pending: {
+          ...question,
+          humanAction: {
+            kind: "review",
+            title: "Review README",
+            target: { type: "file", path: "README.md", label: "Readme" },
+            actions: [{ id: "accept", label: "Accept", tone: "positive" }],
+            actionFieldName: "action",
+          },
+        },
+      },
+    }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const pending = await createQuestionsClient().pending("default")
+    expect(pending?.humanAction).toMatchObject({
+      kind: "review",
+      title: "Review README",
+      target: { type: "file", path: "README.md", label: "Readme" },
+      actions: [{ id: "accept", label: "Accept", tone: "positive" }],
+      actionFieldName: "action",
+    })
+  })
+
   it("cancels through the bridge when crypto.subtle is unavailable", async () => {
     vi.stubGlobal("crypto", {})
     const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => Response.json({ ok: true, output: { ok: true, status: "cancelled" } }))

--- a/plugins/ask-user/src/front/client.ts
+++ b/plugins/ask-user/src/front/client.ts
@@ -1,7 +1,7 @@
 import { ASK_USER_BRIDGE_OPS } from "../shared/bridge"
 import { ASK_USER_UI_STATE_SLOTS } from "../shared/constants"
 import { ASK_USER_ERROR_CODES } from "../shared/error-codes"
-import type { AskUserAnswerValue, AskUserFormSchema, AskUserQuestion } from "../shared/types"
+import type { AskUserAnswerValue, AskUserFormSchema, AskUserQuestion, AskUserTargetHumanAction, AskUserHumanActionButton } from "../shared/types"
 import { validateQuestionValues, type QuestionFormValues, type QuestionValidationResult } from "./primitives"
 
 export type QuestionsClientResult = { ok: true; status: string }
@@ -144,10 +144,69 @@ export function normalizeQuestion(value: unknown): AskUserQuestion | null {
     title: typeof raw.title === "string" ? raw.title : undefined,
     context: typeof raw.context === "string" ? raw.context : undefined,
     schema,
+    humanAction: normalizeTargetHumanAction(raw.humanAction),
     answerToken: typeof raw.answerToken === "string" ? raw.answerToken : "",
     createdAt: typeof raw.createdAt === "string" ? raw.createdAt : new Date(0).toISOString(),
     updatedAt: typeof raw.updatedAt === "string" ? raw.updatedAt : new Date(0).toISOString(),
   }
+}
+
+function boundedString(value: unknown, max = 512): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value.slice(0, max) : undefined
+}
+
+function normalizeTargetHumanAction(value: unknown): AskUserTargetHumanAction | undefined {
+  if (!value || typeof value !== "object") return undefined
+  const raw = value as Record<string, unknown>
+  const kind = raw.kind === "review" || raw.kind === "approval" || raw.kind === "acknowledgement" || raw.kind === "choice" ? raw.kind : undefined
+  const title = boundedString(raw.title)
+  const target = normalizeHumanActionTarget(raw.target)
+  const actions = Array.isArray(raw.actions) ? raw.actions.map(normalizeHumanActionButton).filter((action): action is AskUserHumanActionButton => !!action) : []
+  if (!kind || !title || !target || actions.length === 0) return undefined
+  return {
+    ...(boundedString(raw.id) ? { id: boundedString(raw.id) } : {}),
+    kind,
+    title,
+    ...(boundedString(raw.body, 4000) ? { body: boundedString(raw.body, 4000) } : {}),
+    target,
+    actions,
+    ...(boundedString(raw.actionFieldName, 64) ? { actionFieldName: boundedString(raw.actionFieldName, 64) } : {}),
+    ...(boundedString(raw.commentFieldName, 64) ? { commentFieldName: boundedString(raw.commentFieldName, 64) } : {}),
+  }
+}
+
+function normalizeHumanActionButton(value: unknown): AskUserHumanActionButton | null {
+  if (!value || typeof value !== "object") return null
+  const raw = value as Record<string, unknown>
+  const id = boundedString(raw.id, 128)
+  const label = boundedString(raw.label, 160)
+  if (!id || !label) return null
+  const tone = raw.tone === "positive" || raw.tone === "warning" || raw.tone === "danger" || raw.tone === "default" ? raw.tone : undefined
+  const comment = raw.comment === "optional" || raw.comment === "required" || raw.comment === "none" ? raw.comment : undefined
+  return { id, label, ...(tone ? { tone } : {}), ...(comment ? { comment } : {}) }
+}
+
+function normalizeHumanActionTarget(value: unknown): AskUserTargetHumanAction["target"] | null {
+  if (!value || typeof value !== "object") return null
+  const raw = value as Record<string, unknown>
+  const label = boundedString(raw.label)
+  if (raw.type === "file") {
+    const path = boundedString(raw.path)
+    if (!path) return null
+    return { type: "file", path, ...(boundedString(raw.workspaceId, 128) ? { workspaceId: boundedString(raw.workspaceId, 128) } : {}), ...(label ? { label } : {}) }
+  }
+  if (raw.type === "surface") {
+    const surfaceKind = boundedString(raw.surfaceKind, 128)
+    const target = boundedString(raw.target)
+    if (!surfaceKind || !target) return null
+    return { type: "surface", surfaceKind, target, ...(label ? { label } : {}) }
+  }
+  if (raw.type === "panel") {
+    const component = boundedString(raw.component, 128)
+    if (!component) return null
+    return { type: "panel", component, ...(boundedString(raw.instanceId, 128) ? { instanceId: boundedString(raw.instanceId, 128) } : {}), ...(label ? { label } : {}) }
+  }
+  return null
 }
 
 export async function deriveIdempotencyKey(op: string, inputValue: Record<string, unknown>): Promise<string> {

--- a/plugins/ask-user/src/front/client.ts
+++ b/plugins/ask-user/src/front/client.ts
@@ -1,7 +1,7 @@
 import { ASK_USER_BRIDGE_OPS } from "../shared/bridge"
 import { ASK_USER_UI_STATE_SLOTS } from "../shared/constants"
 import { ASK_USER_ERROR_CODES } from "../shared/error-codes"
-import type { AskUserAnswerValue, AskUserFormSchema, AskUserQuestion, AskUserTargetHumanAction, AskUserHumanActionButton } from "../shared/types"
+import type { AskUserAnswerValue, AskUserFormSchema, AskUserHumanActionArtifact, AskUserHumanActionButton, AskUserQuestion, AskUserTargetHumanAction } from "../shared/types"
 import { validateQuestionValues, type QuestionFormValues, type QuestionValidationResult } from "./primitives"
 
 export type QuestionsClientResult = { ok: true; status: string }
@@ -163,15 +163,31 @@ function normalizeTargetHumanAction(value: unknown): AskUserTargetHumanAction | 
   const target = normalizeHumanActionTarget(raw.target)
   const actions = Array.isArray(raw.actions) ? raw.actions.map(normalizeHumanActionButton).filter((action): action is AskUserHumanActionButton => !!action) : []
   if (!kind || !title || !target || actions.length === 0) return undefined
+  const artifacts = Array.isArray(raw.artifacts) ? raw.artifacts.map(normalizeHumanActionArtifact).filter((artifact): artifact is AskUserHumanActionArtifact => !!artifact) : []
   return {
     ...(boundedString(raw.id) ? { id: boundedString(raw.id) } : {}),
     kind,
     title,
     ...(boundedString(raw.body, 4000) ? { body: boundedString(raw.body, 4000) } : {}),
     target,
+    ...(artifacts.length > 0 ? { artifacts } : {}),
     actions,
     ...(boundedString(raw.actionFieldName, 64) ? { actionFieldName: boundedString(raw.actionFieldName, 64) } : {}),
     ...(boundedString(raw.commentFieldName, 64) ? { commentFieldName: boundedString(raw.commentFieldName, 64) } : {}),
+    ...(boundedString(raw.reviewFieldName, 64) ? { reviewFieldName: boundedString(raw.reviewFieldName, 64) } : {}),
+    ...(boundedString(raw.annotationsFieldName, 64) ? { annotationsFieldName: boundedString(raw.annotationsFieldName, 64) } : {}),
+  }
+}
+
+function normalizeHumanActionArtifact(value: unknown): AskUserHumanActionArtifact | null {
+  if (!value || typeof value !== "object") return null
+  const raw = value as Record<string, unknown>
+  const target = normalizeHumanActionTarget(raw.target)
+  if (!target) return null
+  return {
+    ...(boundedString(raw.id, 128) ? { id: boundedString(raw.id, 128) } : {}),
+    ...(boundedString(raw.label) ? { label: boundedString(raw.label) } : {}),
+    target,
   }
 }
 

--- a/plugins/ask-user/src/front/inbox/InboxOverlay.tsx
+++ b/plugins/ask-user/src/front/inbox/InboxOverlay.tsx
@@ -13,6 +13,7 @@ import {
   mergeInboxPinnedState,
   sortInboxItems,
   type InboxFilter,
+  type WorkspaceInboxItemArtifactTarget,
   type WorkspaceInboxItemViewModel,
 } from "./inboxItemModel"
 import { useWorkspaceInboxShell } from "./WorkspaceInboxShellContext"
@@ -51,6 +52,7 @@ export function InboxOverlay({ onClose, headerInsetStart = false, headerInsetEnd
   const shell = useWorkspaceInboxShell()
   const [filter, setFilter] = useState<InboxFilter>("all")
   const [shellError, setShellError] = useState<string | null>(null)
+  const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(() => new Set())
   const [pinnedIds, setPinnedIds] = useState<ReadonlySet<string>>(() => readPinnedIds(pinStorageKey))
   const sorted = useMemo(() => sortInboxItems(blockers.filter(isInboxAttentionBlocker).map(attentionBlockerToInboxItem)), [blockers])
   const filtered = useMemo(() => filterInboxItems(sorted, filter), [filter, sorted])
@@ -63,6 +65,14 @@ export function InboxOverlay({ onClose, headerInsetStart = false, headerInsetEnd
     reviews: filterInboxItems(sorted, "reviews").length,
   }), [sorted])
 
+  const toggleExpanded = useCallback((id: string) => {
+    setExpandedIds((current) => {
+      const next = new Set(current)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
   const togglePinned = useCallback((id: string) => {
     setPinnedIds((current) => {
       const next = new Set(current)
@@ -75,7 +85,7 @@ export function InboxOverlay({ onClose, headerInsetStart = false, headerInsetEnd
   const handleShellResult = useCallback((result: ReturnType<typeof shell.openInboxArtifact>) => {
     setShellError(result.success ? null : result.message)
   }, [])
-  const openArtifact = useCallback((item: WorkspaceInboxItemViewModel) => { handleShellResult(shell.openInboxArtifact(item)) }, [handleShellResult, shell])
+  const openArtifact = useCallback((item: WorkspaceInboxItemViewModel, artifact: WorkspaceInboxItemArtifactTarget) => { handleShellResult(shell.openInboxArtifact(item, artifact)) }, [handleShellResult, shell])
   const openChat = useCallback((item: WorkspaceInboxItemViewModel) => {
     if (!item.sessionId) return
     handleShellResult(shell.openDetachedChat(item.sessionId, { title: item.title }))
@@ -118,8 +128,8 @@ export function InboxOverlay({ onClose, headerInsetStart = false, headerInsetEnd
           </div>
         ) : (
           <>
-            <InboxSection title="Pinned" items={pinnedItems} onTogglePinned={togglePinned} onOpenArtifact={openArtifact} onOpenChat={openChat} />
-            <InboxSection title="Inbox" items={unpinnedItems} onTogglePinned={togglePinned} onOpenArtifact={openArtifact} onOpenChat={openChat} />
+            <InboxSection title="Pinned" items={pinnedItems} expandedIds={expandedIds} onTogglePinned={togglePinned} onToggleExpanded={toggleExpanded} onOpenChat={openChat} onOpenArtifact={openArtifact} />
+            <InboxSection title="Inbox" items={unpinnedItems} expandedIds={expandedIds} onTogglePinned={togglePinned} onToggleExpanded={toggleExpanded} onOpenChat={openChat} onOpenArtifact={openArtifact} />
           </>
         )}
       </div>

--- a/plugins/ask-user/src/front/inbox/InboxRow.tsx
+++ b/plugins/ask-user/src/front/inbox/InboxRow.tsx
@@ -2,7 +2,7 @@
 
 import { MessageSquare, Star } from "lucide-react"
 import { cn } from "@hachej/boring-workspace"
-import { formatInboxTime, inboxItemDate, inboxItemSender, type WorkspaceInboxItemViewModel } from "./inboxItemModel"
+import { formatInboxTime, inboxItemDate, inboxItemSender, type WorkspaceInboxItemArtifactTarget, type WorkspaceInboxItemViewModel } from "./inboxItemModel"
 
 function badgeTone(kind: WorkspaceInboxItemViewModel["kind"]): string {
   switch (kind) {
@@ -13,29 +13,49 @@ function badgeTone(kind: WorkspaceInboxItemViewModel["kind"]): string {
   }
 }
 
+function artifactLabel(artifact: WorkspaceInboxItemArtifactTarget, index: number): string {
+  if (artifact.label) return artifact.label
+  if (artifact.type === "surface") return artifact.target ?? artifact.surfaceKind
+  return artifact.panelComponentId || `Artifact ${index + 1}`
+}
+
 export function InboxRow({
   item,
+  expanded,
   onTogglePinned,
-  onOpenArtifact,
+  onToggleExpanded,
   onOpenChat,
+  onOpenArtifact,
 }: {
   item: WorkspaceInboxItemViewModel
+  expanded: boolean
   onTogglePinned: (id: string) => void
-  onOpenArtifact: (item: WorkspaceInboxItemViewModel) => void
+  onToggleExpanded: (id: string) => void
   onOpenChat: (item: WorkspaceInboxItemViewModel) => void
+  onOpenArtifact: (item: WorkspaceInboxItemViewModel, artifact: WorkspaceInboxItemArtifactTarget) => void
 }) {
   const subtitle = [item.sessionId ? `Session ${item.sessionId}` : null, item.targetLabel || null].filter(Boolean).join(" · ")
+  const artifacts = item.artifacts
+  const canExpand = artifacts.length > 1
+  const activateRow = () => {
+    if (artifacts.length === 1) {
+      onOpenArtifact(item, artifacts[0]!)
+      return
+    }
+    if (canExpand) onToggleExpanded(item.id)
+  }
   return (
     <li>
       <div
         role="button"
         tabIndex={0}
         className="group flex h-11 w-full items-center gap-2 overflow-hidden px-4 text-left text-[12px] transition-colors hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-        onClick={() => onOpenArtifact(item)}
+        aria-expanded={canExpand ? expanded : undefined}
+        onClick={activateRow}
         onKeyDown={(event) => {
           if (event.key !== "Enter" && event.key !== " ") return
           event.preventDefault()
-          onOpenArtifact(item)
+          activateRow()
         }}
       >
         <span className="size-2 shrink-0 rounded-full bg-[color:var(--accent)]" />
@@ -79,6 +99,25 @@ export function InboxRow({
           <Star className={cn("size-3.5", item.pinned && "fill-current")} strokeWidth={1.75} />
         </button>
       </div>
+      {expanded && canExpand ? (
+        <div className="ml-[calc(18px+1rem)] border-l border-border/60 px-4 pb-3 pt-1">
+          <div className="flex flex-wrap gap-2" aria-label={`Artifacts for ${item.title}`}>
+            {artifacts.map((artifact, index) => {
+              const label = artifactLabel(artifact, index)
+              return (
+                <button
+                  key={artifact.id ?? `${artifact.type}:${label}:${index}`}
+                  type="button"
+                  className="rounded-md border border-border/70 bg-background px-2.5 py-1.5 text-[11px] font-medium text-foreground shadow-sm transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                  onClick={() => onOpenArtifact(item, artifact)}
+                >
+                  {label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      ) : null}
     </li>
   )
 }

--- a/plugins/ask-user/src/front/inbox/InboxSection.tsx
+++ b/plugins/ask-user/src/front/inbox/InboxSection.tsx
@@ -1,21 +1,25 @@
 "use client"
 
 import { Pin } from "lucide-react"
-import type { WorkspaceInboxItemViewModel } from "./inboxItemModel"
+import type { WorkspaceInboxItemArtifactTarget, WorkspaceInboxItemViewModel } from "./inboxItemModel"
 import { InboxRow } from "./InboxRow"
 
 export function InboxSection({
   title,
   items,
+  expandedIds,
   onTogglePinned,
-  onOpenArtifact,
+  onToggleExpanded,
   onOpenChat,
+  onOpenArtifact,
 }: {
   title: string
   items: WorkspaceInboxItemViewModel[]
+  expandedIds: ReadonlySet<string>
   onTogglePinned: (id: string) => void
-  onOpenArtifact: (item: WorkspaceInboxItemViewModel) => void
+  onToggleExpanded: (id: string) => void
   onOpenChat: (item: WorkspaceInboxItemViewModel) => void
+  onOpenArtifact: (item: WorkspaceInboxItemViewModel, artifact: WorkspaceInboxItemArtifactTarget) => void
 }) {
   if (items.length === 0) return null
   return (
@@ -29,9 +33,11 @@ export function InboxSection({
           <InboxRow
             key={item.id}
             item={item}
+            expanded={expandedIds.has(item.id)}
             onTogglePinned={onTogglePinned}
-            onOpenArtifact={onOpenArtifact}
+            onToggleExpanded={onToggleExpanded}
             onOpenChat={onOpenChat}
+            onOpenArtifact={onOpenArtifact}
           />
         ))}
       </ul>

--- a/plugins/ask-user/src/front/inbox/__tests__/inboxItemModel.test.ts
+++ b/plugins/ask-user/src/front/inbox/__tests__/inboxItemModel.test.ts
@@ -11,6 +11,7 @@ function item(partial: Partial<WorkspaceInboxItem> & Pick<WorkspaceInboxItem, 'i
     sessionId: null,
     targetLabel: '',
     artifact: null,
+    artifacts: [],
     createdAt: partial.updatedAt,
     priority: 0,
     actions: [],
@@ -47,8 +48,31 @@ describe('inbox item model', () => {
       priority: 5,
     })
     expect(inbox.source).toEqual({ type: 'plugin', pluginId: 'ask-user', label: 'question' })
-    expect(inbox.artifact).toEqual({ type: 'surface', surfaceKind: 'file', target: 'file.ts' })
+    expect(inbox.artifact).toEqual({ type: 'surface', surfaceKind: 'file', target: 'file.ts', label: 'file.ts' })
+    expect(inbox.artifacts).toEqual([{ type: 'surface', surfaceKind: 'file', target: 'file.ts', label: 'file.ts' }])
     expect(inbox.actions).toEqual([{ id: 'open', label: 'Open' }])
+  })
+
+  it('uses explicit inbox artifact pointers when present', () => {
+    const inbox = attentionBlockerToInboxItem({
+      id: 'review-artifacts',
+      reason: 'ask-user.review',
+      label: 'Review landing page',
+      target: 'legacy-target',
+      surfaceKind: 'legacy-surface',
+      inbox: {
+        kind: 'review',
+        sourceLabel: 'review',
+        artifacts: [
+          { type: 'surface', id: 'html', label: 'Generated HTML', surfaceKind: 'workspace.open.path', target: 'docs/generated.html' },
+          { type: 'surface', id: 'brief', label: 'Review brief', surfaceKind: 'questions', target: 'q1' },
+        ],
+      },
+    })
+
+    expect(inbox.targetLabel).toBe('Generated HTML')
+    expect(inbox.artifact).toEqual({ type: 'surface', id: 'html', label: 'Generated HTML', surfaceKind: 'workspace.open.path', target: 'docs/generated.html' })
+    expect(inbox.artifacts).toHaveLength(2)
   })
 
   it('uses explicit external and review source metadata without parsing reason', () => {

--- a/plugins/ask-user/src/front/inbox/attentionBlockerAdapter.ts
+++ b/plugins/ask-user/src/front/inbox/attentionBlockerAdapter.ts
@@ -1,5 +1,5 @@
 import { workspaceAttentionSessionBadgeForBlocker, type WorkspaceAttentionBlocker } from "@hachej/boring-workspace"
-import type { InboxItemKind, WorkspaceInboxItem } from "./inboxItemModel"
+import type { InboxItemKind, WorkspaceInboxItem, WorkspaceInboxItemArtifactTarget } from "./inboxItemModel"
 
 const FALLBACK_TIMESTAMP = "1970-01-01T00:00:00.000Z"
 
@@ -41,8 +41,25 @@ export function isInboxAttentionBlocker(blocker: WorkspaceAttentionBlocker): boo
   return !!blocker.inbox
 }
 
+function blockerArtifacts(blocker: WorkspaceAttentionBlocker): WorkspaceInboxItemArtifactTarget[] {
+  const explicit = blocker.inbox?.artifacts?.map((artifact): WorkspaceInboxItemArtifactTarget => artifact.type === "panel"
+    ? { type: "panel", ...(artifact.id ? { id: artifact.id } : {}), ...(artifact.label ? { label: artifact.label } : {}), panelComponentId: artifact.panelComponentId, ...(artifact.params ? { params: artifact.params } : {}) }
+    : { type: "surface", ...(artifact.id ? { id: artifact.id } : {}), ...(artifact.label ? { label: artifact.label } : {}), surfaceKind: artifact.surfaceKind, ...(artifact.target ? { target: artifact.target } : {}), ...(artifact.params ? { params: artifact.params } : {}) }) ?? []
+  if (explicit.length > 0) return explicit
+  return blocker.surfaceKind ? [{ type: "surface", surfaceKind: blocker.surfaceKind, target: blocker.target, ...(blocker.target ? { label: blocker.target } : {}) }] : []
+}
+
+function artifactTargetLabel(artifact: WorkspaceInboxItemArtifactTarget | null, fallback = ""): string {
+  if (!artifact) return fallback
+  if (artifact.label) return artifact.label
+  if (artifact.type === "surface") return artifact.target ?? artifact.surfaceKind
+  return artifact.panelComponentId
+}
+
 export function attentionBlockerToInboxItem(blocker: WorkspaceAttentionBlocker): WorkspaceInboxItem {
   const updatedAt = blockerTimestamp(blocker)
+  const artifacts = blockerArtifacts(blocker)
+  const primaryArtifact = artifacts[0] ?? null
   return {
     id: blocker.id,
     kind: blockerKind(blocker),
@@ -51,8 +68,9 @@ export function attentionBlockerToInboxItem(blocker: WorkspaceAttentionBlocker):
     description: blocker.reason,
     source: blockerSource(blocker),
     sessionId: blocker.sessionId ?? null,
-    targetLabel: blocker.target ?? "",
-    artifact: blocker.surfaceKind ? { type: "surface", surfaceKind: blocker.surfaceKind, target: blocker.target } : null,
+    targetLabel: artifactTargetLabel(primaryArtifact, blocker.target ?? ""),
+    artifact: primaryArtifact,
+    artifacts,
     createdAt: dateValue(blocker.inbox?.createdAt) ?? updatedAt,
     updatedAt,
     priority: blocker.inbox?.priority ?? workspaceAttentionSessionBadgeForBlocker(blocker)?.priority ?? 0,

--- a/plugins/ask-user/src/front/inbox/inboxItemModel.ts
+++ b/plugins/ask-user/src/front/inbox/inboxItemModel.ts
@@ -9,8 +9,8 @@ export interface WorkspaceInboxItemAction {
 }
 
 export type WorkspaceInboxItemArtifactTarget =
-  | { type: "surface"; surfaceKind: string; target?: string; params?: Record<string, unknown> }
-  | { type: "panel"; panelComponentId: string; params?: Record<string, unknown> }
+  | { type: "surface"; id?: string; label?: string; surfaceKind: string; target?: string; params?: Record<string, unknown> }
+  | { type: "panel"; id?: string; label?: string; panelComponentId: string; params?: Record<string, unknown> }
 
 export interface WorkspaceInboxItemSourceBase {
   label: string
@@ -32,6 +32,7 @@ export interface WorkspaceInboxItem {
   sessionId: string | null
   targetLabel: string
   artifact: WorkspaceInboxItemArtifactTarget | null
+  artifacts: WorkspaceInboxItemArtifactTarget[]
   createdAt: string
   updatedAt: string
   priority: number
@@ -47,7 +48,7 @@ export type WorkspaceInboxShellResult =
   | { success: false; reason: "no-artifact" | "open-failed" | "invalid-session" | "placement-failed"; message: string }
 
 export interface WorkspaceInboxShellApi {
-  openInboxArtifact(item: WorkspaceInboxItem): WorkspaceInboxShellResult
+  openInboxArtifact(item: WorkspaceInboxItem, artifact?: WorkspaceInboxItemArtifactTarget): WorkspaceInboxShellResult
   openDetachedChat(sessionId: string, options?: { anchor?: DOMRect; title?: string }): WorkspaceInboxShellResult
 }
 

--- a/plugins/ask-user/src/front/index.tsx
+++ b/plugins/ask-user/src/front/index.tsx
@@ -30,6 +30,7 @@ import {
   useAskUserAutoOpen,
   useAskUserComposerStopCancel,
   useAskUserPendingRefresh,
+  useAskUserTargetActions,
 } from "./providerHooks"
 import { QuestionCancelButton, QuestionFields, QuestionForm, QuestionFormProvider, QuestionSubmitButton } from "./primitives"
 import { InboxOverlay, WorkspaceInboxShellProvider, type WorkspaceInboxItem, type WorkspaceInboxShellApi } from "./inbox"
@@ -53,6 +54,7 @@ function AskUserProvider({ apiBaseUrl, authHeaders, activeSessionId, openSession
   useAskUserAutoOpen(runtime, activeSessionId, pendingSnapshot)
   useAskUserAttentionActions(runtime)
   useAskUserComposerStopCancel(runtime)
+  useAskUserTargetActions(runtime, pendingSnapshot)
   useAskUserPendingRefresh(runtime, { activeSessionId, apiBaseUrl, authHeaders })
 
   return <QuestionsRuntimeContext.Provider value={runtime}>{children}</QuestionsRuntimeContext.Provider>

--- a/plugins/ask-user/src/front/index.tsx
+++ b/plugins/ask-user/src/front/index.tsx
@@ -177,21 +177,21 @@ function panelInstanceId(prefix: string, id: string): string {
 
 function createInboxShellApi(shell: BoringFrontAppLeftActionOverlayProps["shell"]): WorkspaceInboxShellApi {
   return {
-    openInboxArtifact(item: WorkspaceInboxItem) {
-      if (!item.artifact) return { success: false, reason: "no-artifact", message: "This inbox item has no artifact target." }
-      if (item.artifact.type === "panel") {
+    openInboxArtifact(item: WorkspaceInboxItem, artifact = item.artifact ?? undefined) {
+      if (!artifact) return { success: false, reason: "no-artifact", message: "This inbox item has no artifact target." }
+      if (artifact.type === "panel") {
         shell.openPanel({
-          id: panelInstanceId(item.artifact.panelComponentId, item.id),
-          component: item.artifact.panelComponentId,
-          title: item.title,
-          params: item.artifact.params,
+          id: panelInstanceId(artifact.panelComponentId, artifact.id ?? item.id),
+          component: artifact.panelComponentId,
+          title: artifact.label ?? item.title,
+          params: artifact.params,
         })
         return { success: true }
       }
       shell.openSurface({
-        kind: item.artifact.surfaceKind,
-        target: item.artifact.target,
-        meta: item.sessionId ? { sessionId: item.sessionId, openOnlyWhenSessionOpen: true } : {},
+        kind: artifact.surfaceKind,
+        target: artifact.target,
+        meta: item.sessionId ? { sessionId: item.sessionId } : {},
       })
       return { success: true }
     },

--- a/plugins/ask-user/src/front/providerHooks.ts
+++ b/plugins/ask-user/src/front/providerHooks.ts
@@ -17,7 +17,8 @@ import {
 } from "@hachej/boring-workspace"
 import { ASK_USER_SURFACE_KIND, ASK_USER_UI_STATE_SLOTS } from "../shared/constants"
 import { askUserHumanActionToBlockerProjection } from "../shared/humanAction"
-import type { AskUserTargetHumanAction } from "../shared/types"
+import { formatHumanActionReviewForLlm, type HumanActionReviewResult } from "../shared/humanActionAnnotations"
+import type { AskUserFormSchema, AskUserQuestion, AskUserTargetHumanAction } from "../shared/types"
 import { createQuestionsClient, readPendingQuestionHintsFromState, type PendingQuestionHint } from "./client"
 import { isSessionOpen, type QuestionsRuntime } from "./runtime"
 
@@ -49,6 +50,54 @@ function workspaceTargetFromAskUserTarget(target: AskUserTargetHumanAction["targ
   return _exhaustive
 }
 
+function schemaHasField(schema: AskUserFormSchema | undefined, name: string): boolean {
+  return !!schema?.fields.some((field) => field.name === name)
+}
+
+function annotationSeverityForButton(button: WorkspaceHumanActionButton): NonNullable<HumanActionReviewResult["annotations"]>[number]["severity"] {
+  if (button.tone === "danger") return "blocker"
+  if (button.tone === "warning") return "issue"
+  if (button.tone === "positive") return "note"
+  return "suggestion"
+}
+
+function buildTargetReviewValues(args: {
+  pending: AskUserQuestion
+  action: AskUserTargetHumanAction
+  button: WorkspaceHumanActionButton
+  comment?: string
+}): Record<string, string> {
+  const { pending, action, button, comment } = args
+  const values: Record<string, string> = {
+    [action.actionFieldName ?? "action"]: button.id,
+  }
+  const commentFieldName = action.commentFieldName ?? "comment"
+  const reviewFieldName = action.reviewFieldName ?? "review"
+  const annotationsFieldName = action.annotationsFieldName ?? "annotations"
+  if (comment && schemaHasField(pending.schema, commentFieldName)) values[commentFieldName] = comment
+
+  if (schemaHasField(pending.schema, reviewFieldName) || schemaHasField(pending.schema, annotationsFieldName)) {
+    const review: HumanActionReviewResult = {
+      humanActionId: action.id ?? pending.questionId,
+      decisionId: button.id,
+      ...(comment ? { comment } : {}),
+      ...(comment ? {
+        annotations: [{
+          id: `${pending.questionId}:${button.id}:global`,
+          target: action.target,
+          anchor: { type: "global" },
+          body: comment,
+          severity: annotationSeverityForButton(button),
+          createdAt: new Date().toISOString(),
+        }],
+      } : {}),
+    }
+    if (schemaHasField(pending.schema, reviewFieldName)) values[reviewFieldName] = formatHumanActionReviewForLlm(review)
+    if (schemaHasField(pending.schema, annotationsFieldName)) values[annotationsFieldName] = JSON.stringify(review)
+  }
+  return values
+}
+
 export function useAskUserTargetActions(runtime: QuestionsRuntime, pendingSnapshot: string): void {
   const { registerTargetAction } = useWorkspaceHumanActionTargets()
   useEffect(() => {
@@ -73,11 +122,7 @@ export function useAskUserTargetActions(runtime: QuestionsRuntime, pendingSnapsh
           ...(button.comment ? { comment: button.comment } : {}),
         })),
         async onAction({ action: button, comment }) {
-          const values: Record<string, string> = {
-            [action.actionFieldName ?? "action"]: button.id,
-          }
-          if (comment) values[action.commentFieldName ?? "comment"] = comment
-          await client.submit(pending, values)
+          await client.submit(pending, buildTargetReviewValues({ pending, action, button, comment }))
           runtime.setPending(null, pending.sessionId)
         },
       }))

--- a/plugins/ask-user/src/front/providerHooks.ts
+++ b/plugins/ask-user/src/front/providerHooks.ts
@@ -7,10 +7,13 @@ import {
   events,
   postUiCommand,
   useWorkspaceAttention,
+  useWorkspaceHumanActionTargets,
   workspaceComposerStopAppliesToSession,
   workspaceComposerStopTargetSessionId,
   workspaceEvents,
   type WorkspaceAttentionActionDetail,
+  type WorkspaceHumanActionButton,
+  type WorkspaceHumanActionTargetRef,
 } from "@hachej/boring-workspace"
 import { ASK_USER_SURFACE_KIND, ASK_USER_UI_STATE_SLOTS } from "../shared/constants"
 import { askUserHumanActionToBlockerProjection } from "../shared/humanAction"
@@ -35,6 +38,43 @@ export function useAskUserAttentionBlockers(runtime: QuestionsRuntime, pendingSn
     }
     return () => { for (const blockerId of blockerIds) removeBlocker(blockerId) }
   }, [addBlocker, removeBlocker, runtime, pendingSnapshot])
+}
+
+export function useAskUserTargetActions(runtime: QuestionsRuntime, pendingSnapshot: string): void {
+  const { registerTargetAction } = useWorkspaceHumanActionTargets()
+  useEffect(() => {
+    const cleanups: Array<() => void> = []
+    const client = createQuestionsClient({ apiBaseUrl: runtime.apiBaseUrl, headers: runtime.authHeaders })
+    for (const hint of runtime.getPendingHints()) {
+      const pending = runtime.getPending(hint.sessionId)
+      const action = pending?.humanAction
+      if (!pending || pending.status !== "ready" || !action) continue
+      const target = action.target as WorkspaceHumanActionTargetRef
+      cleanups.push(registerTargetAction({
+        id: `${pending.questionId}:${action.id ?? action.kind}`,
+        title: action.title,
+        ...(action.body ? { body: action.body } : {}),
+        target,
+        pluginId: "ask-user",
+        createdAt: pending.createdAt,
+        actions: action.actions.map((button): WorkspaceHumanActionButton => ({
+          id: button.id,
+          label: button.label,
+          ...(button.tone ? { tone: button.tone } : {}),
+          ...(button.comment ? { comment: button.comment } : {}),
+        })),
+        async onAction({ action: button, comment }) {
+          const values: Record<string, string> = {
+            [action.actionFieldName ?? "action"]: button.id,
+          }
+          if (comment) values[action.commentFieldName ?? "comment"] = comment
+          await client.submit(pending, values)
+          runtime.setPending(null, pending.sessionId)
+        },
+      }))
+    }
+    return () => { for (const cleanup of cleanups) cleanup() }
+  }, [pendingSnapshot, registerTargetAction, runtime])
 }
 
 export function useAskUserAutoOpen(runtime: QuestionsRuntime, activeSessionId: string | null | undefined, pendingSnapshot: string): void {

--- a/plugins/ask-user/src/front/providerHooks.ts
+++ b/plugins/ask-user/src/front/providerHooks.ts
@@ -17,6 +17,7 @@ import {
 } from "@hachej/boring-workspace"
 import { ASK_USER_SURFACE_KIND, ASK_USER_UI_STATE_SLOTS } from "../shared/constants"
 import { askUserHumanActionToBlockerProjection } from "../shared/humanAction"
+import type { AskUserTargetHumanAction } from "../shared/types"
 import { createQuestionsClient, readPendingQuestionHintsFromState, type PendingQuestionHint } from "./client"
 import { isSessionOpen, type QuestionsRuntime } from "./runtime"
 
@@ -40,6 +41,14 @@ export function useAskUserAttentionBlockers(runtime: QuestionsRuntime, pendingSn
   }, [addBlocker, removeBlocker, runtime, pendingSnapshot])
 }
 
+function workspaceTargetFromAskUserTarget(target: AskUserTargetHumanAction["target"]): WorkspaceHumanActionTargetRef {
+  if (target.type === "file") return { type: "file", path: target.path, ...(target.workspaceId ? { workspaceId: target.workspaceId } : {}), ...(target.label ? { label: target.label } : {}) }
+  if (target.type === "surface") return { type: "surface", surfaceKind: target.surfaceKind, target: target.target, ...(target.label ? { label: target.label } : {}) }
+  if (target.type === "panel") return { type: "panel", component: target.component, ...(target.instanceId ? { instanceId: target.instanceId } : {}), ...(target.label ? { label: target.label } : {}) }
+  const _exhaustive: never = target
+  return _exhaustive
+}
+
 export function useAskUserTargetActions(runtime: QuestionsRuntime, pendingSnapshot: string): void {
   const { registerTargetAction } = useWorkspaceHumanActionTargets()
   useEffect(() => {
@@ -49,7 +58,7 @@ export function useAskUserTargetActions(runtime: QuestionsRuntime, pendingSnapsh
       const pending = runtime.getPending(hint.sessionId)
       const action = pending?.humanAction
       if (!pending || pending.status !== "ready" || !action) continue
-      const target = action.target as WorkspaceHumanActionTargetRef
+      const target = workspaceTargetFromAskUserTarget(action.target)
       cleanups.push(registerTargetAction({
         id: `${pending.questionId}:${action.id ?? action.kind}`,
         title: action.title,

--- a/plugins/ask-user/src/shared/__tests__/humanAction.test.ts
+++ b/plugins/ask-user/src/shared/__tests__/humanAction.test.ts
@@ -58,6 +58,37 @@ describe("human action ask-user projections", () => {
     expect(JSON.stringify(blocker)).not.toContain("answerToken")
   })
 
+  it("projects target-scoped review questions into review inbox metadata", () => {
+    const reviewQuestion: AskUserQuestion = {
+      ...question,
+      humanAction: {
+        kind: "review",
+        title: "Review README changes",
+        target: { type: "file", path: "README.md" },
+        actions: [{ id: "accept", label: "Accept", tone: "positive" }],
+        actionFieldName: "action",
+      },
+    }
+
+    const view = askUserQuestionToHumanActionView(reviewQuestion)
+    expect(view).toMatchObject({
+      kind: "review",
+      title: "Review README changes",
+      artifact: { surfaceKind: "workspace.open.path", target: "README.md" },
+      response: { mode: "review", actions: [{ id: "accept", label: "Accept" }] },
+    })
+
+    const blocker = askUserHumanActionToBlockerProjection({ hint: reviewQuestion, question: reviewQuestion })
+    expect(blocker).toMatchObject({
+      reason: "ask-user.review",
+      surfaceKind: "workspace.open.path",
+      target: "README.md",
+      sessionBadge: { kind: "review", label: "review" },
+      inbox: { kind: "review", source: { type: "plugin", id: "ask-user", label: "review" } },
+    })
+    expect(JSON.stringify(blocker)).not.toContain("secret-answer-token")
+  })
+
   it("does not project non-ready questions as active blockers", () => {
     expect(askUserHumanActionToBlockerProjection({
       hint: { questionId: "q1", sessionId: "s1", status: "answered" },

--- a/plugins/ask-user/src/shared/humanAction.ts
+++ b/plugins/ask-user/src/shared/humanAction.ts
@@ -1,5 +1,5 @@
 import { ASK_USER_PLUGIN_ID, ASK_USER_SURFACE_KIND } from "./constants"
-import type { AskUserFormSchema, AskUserQuestion, AskUserQuestionStatus } from "./types"
+import type { AskUserFormSchema, AskUserQuestion, AskUserQuestionStatus, AskUserTargetHumanAction } from "./types"
 
 export type HumanActionKind = "question" | "approval" | "review" | "choice" | "ack"
 
@@ -14,7 +14,7 @@ export type HumanActionResponse =
   | { mode: "form"; schema?: AskUserFormSchema; submitLabel?: string }
   | { mode: "approval"; approveLabel?: string; rejectLabel?: string; requireCommentOnReject?: boolean }
   | { mode: "choice"; choices: Array<{ id: string; label: string; description?: string }> }
-  | { mode: "review"; actions: Array<{ id: string; label: string; destructive?: boolean; comment?: "optional" | "required" }> }
+  | { mode: "review"; actions: Array<{ id: string; label: string; destructive?: boolean; comment?: "none" | "optional" | "required" }> }
   | { mode: "ack"; label?: string }
 
 export type HumanActionView = {
@@ -87,25 +87,44 @@ function questionStatusToHumanActionStatus(status: AskUserQuestionStatus): Human
   return "ready"
 }
 
+function humanActionKind(action: AskUserTargetHumanAction | undefined): HumanActionKind {
+  if (!action) return "question"
+  if (action.kind === "approval") return "approval"
+  if (action.kind === "review") return "review"
+  if (action.kind === "choice") return "choice"
+  return "ack"
+}
+
+function targetArtifact(action: AskUserTargetHumanAction | undefined, questionId: string): HumanActionView["artifact"] {
+  if (!action) return { surfaceKind: ASK_USER_SURFACE_KIND, target: questionId, label: "Questions" }
+  if (action.target.type === "file") return { surfaceKind: "workspace.open.path", target: action.target.path, label: action.target.label ?? action.target.path }
+  if (action.target.type === "surface") return { surfaceKind: action.target.surfaceKind, target: action.target.target, label: action.target.label ?? action.target.target }
+  return undefined
+}
+
 export function askUserQuestionToHumanActionView(
   question: AskUserQuestion,
   options: { workspaceId?: string; priority?: number } = {},
 ): HumanActionView {
+  const targetAction = question.humanAction
   return {
     actionId: question.questionId,
     workspaceId: options.workspaceId ?? "default",
     scope: { type: "session", sessionId: question.sessionId },
     ownerPrincipalId: question.ownerPrincipalId,
     status: questionStatusToHumanActionStatus(question.status),
-    kind: "question",
-    title: question.title ?? "Answer the question in Questions to continue",
+    kind: humanActionKind(targetAction),
+    title: targetAction?.title ?? question.title ?? "Answer the question in Questions to continue",
+    body: targetAction?.body,
     context: question.context,
     priority: options.priority ?? 10,
     blocking: true,
     createdAt: question.createdAt,
     updatedAt: question.updatedAt,
-    artifact: { surfaceKind: ASK_USER_SURFACE_KIND, target: question.questionId, label: "Questions" },
-    response: { mode: "form", schema: question.schema, submitLabel: question.schema?.submitLabel },
+    artifact: targetArtifact(targetAction, question.questionId),
+    response: targetAction?.kind === "review"
+      ? { mode: "review", actions: targetAction.actions }
+      : { mode: "form", schema: question.schema, submitLabel: question.schema?.submitLabel },
   }
 }
 
@@ -118,24 +137,26 @@ export function askUserHumanActionToBlockerProjection(args: {
   if (hint.status && hint.status !== "ready") return null
 
   const action = question ? askUserQuestionToHumanActionView(question) : null
+  const displayKind = action?.kind === "review" || action?.kind === "approval" ? action.kind : "question"
+  const openLabel = displayKind === "review" ? "Open review target" : displayKind === "approval" ? "Open approval target" : "Open Questions"
   const actions = question
-    ? [{ id: "open", label: "Open Questions" }, { id: "cancel", label: "Cancel question" }]
+    ? [{ id: "open", label: openLabel }, { id: "cancel", label: displayKind === "question" ? "Cancel question" : "Cancel request" }]
     : isActiveHint
-      ? [{ id: "open", label: "Open Questions" }]
+      ? [{ id: "open", label: openLabel }]
       : undefined
 
   return {
     id: `${ASK_USER_PLUGIN_ID}:${hint.sessionId}:${hint.questionId}`,
-    reason: "ask-user.question",
-    surfaceKind: ASK_USER_SURFACE_KIND,
-    target: hint.questionId,
+    reason: displayKind === "question" ? "ask-user.question" : `ask-user.${displayKind}`,
+    surfaceKind: action?.artifact?.surfaceKind ?? ASK_USER_SURFACE_KIND,
+    target: action?.artifact?.target ?? hint.questionId,
     label: action?.title ?? "Answer the question in Questions to continue",
     sessionId: hint.sessionId,
-    sessionBadge: { kind: "question", label: "question", tone: "attention", priority: 10 },
+    sessionBadge: { kind: displayKind, label: displayKind, tone: "attention", priority: 10 },
     inbox: {
-      kind: "question",
-      sourceLabel: "question",
-      source: { type: "plugin", id: ASK_USER_PLUGIN_ID, label: "question" },
+      kind: displayKind,
+      sourceLabel: displayKind,
+      source: { type: "plugin", id: ASK_USER_PLUGIN_ID, label: displayKind },
       createdAt: action?.createdAt,
       updatedAt: action?.updatedAt ?? action?.createdAt,
       priority: action?.priority ?? 10,

--- a/plugins/ask-user/src/shared/humanAction.ts
+++ b/plugins/ask-user/src/shared/humanAction.ts
@@ -52,10 +52,15 @@ export type HumanActionInboxSourceMetadata =
   | { type: "review"; id: string; label: string }
   | { type: "generic"; id?: string; label: string }
 
+export type HumanActionInboxArtifactMetadata =
+  | { type: "surface"; id?: string; label?: string; surfaceKind: string; target?: string; params?: Record<string, unknown> }
+  | { type: "panel"; id?: string; label?: string; panelComponentId: string; params?: Record<string, unknown> }
+
 export type HumanActionInboxMetadata = {
   kind: "question" | "review" | "approval" | "notice"
   sourceLabel: string
   source?: HumanActionInboxSourceMetadata
+  artifacts?: HumanActionInboxArtifactMetadata[]
   createdAt?: string
   updatedAt?: string
   priority?: number
@@ -95,11 +100,41 @@ function humanActionKind(action: AskUserTargetHumanAction | undefined): HumanAct
   return "ack"
 }
 
-function targetArtifact(action: AskUserTargetHumanAction | undefined, questionId: string): HumanActionView["artifact"] {
-  if (!action) return { surfaceKind: ASK_USER_SURFACE_KIND, target: questionId, label: "Questions" }
-  if (action.target.type === "file") return { surfaceKind: "workspace.open.path", target: action.target.path, label: action.target.label ?? action.target.path }
-  if (action.target.type === "surface") return { surfaceKind: action.target.surfaceKind, target: action.target.target, label: action.target.label ?? action.target.target }
-  return undefined
+function artifactLabel(target: AskUserTargetHumanAction["target"], fallback?: string): string {
+  if (target.label) return target.label
+  if (target.type === "file") return target.path
+  if (target.type === "surface") return target.target
+  return fallback ?? target.component
+}
+
+function targetArtifact(target: AskUserTargetHumanAction["target"], label?: string, id?: string): HumanActionInboxArtifactMetadata {
+  if (target.type === "file") return { type: "surface", ...(id ? { id } : {}), label: label ?? artifactLabel(target), surfaceKind: "workspace.open.path", target: target.path }
+  if (target.type === "surface") return { type: "surface", ...(id ? { id } : {}), label: label ?? artifactLabel(target), surfaceKind: target.surfaceKind, target: target.target }
+  return { type: "panel", ...(id ? { id } : {}), label: label ?? artifactLabel(target), panelComponentId: target.component, ...(target.instanceId ? { params: { instanceId: target.instanceId } } : {}) }
+}
+
+function artifactKey(artifact: HumanActionInboxArtifactMetadata): string {
+  if (artifact.type === "panel") return `panel:${artifact.panelComponentId}:${JSON.stringify(artifact.params ?? {})}`
+  return `surface:${artifact.surfaceKind}:${artifact.target ?? ""}`
+}
+
+function actionArtifacts(action: AskUserTargetHumanAction | undefined, questionId: string): HumanActionInboxArtifactMetadata[] {
+  if (!action) return [{ type: "surface", id: "question", surfaceKind: ASK_USER_SURFACE_KIND, target: questionId, label: "Questions" }]
+  const artifacts: HumanActionInboxArtifactMetadata[] = [targetArtifact(action.target, undefined, "target")]
+  for (const artifact of action.artifacts ?? []) artifacts.push(targetArtifact(artifact.target, artifact.label, artifact.id))
+  const seen = new Set<string>()
+  return artifacts.filter((artifact) => {
+    const key = artifactKey(artifact)
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function primaryArtifact(action: AskUserTargetHumanAction | undefined, questionId: string): HumanActionView["artifact"] {
+  const artifact = actionArtifacts(action, questionId)[0]
+  if (!artifact || artifact.type !== "surface") return undefined
+  return { surfaceKind: artifact.surfaceKind, target: artifact.target, label: artifact.label }
 }
 
 export function askUserQuestionToHumanActionView(
@@ -121,7 +156,7 @@ export function askUserQuestionToHumanActionView(
     blocking: true,
     createdAt: question.createdAt,
     updatedAt: question.updatedAt,
-    artifact: targetArtifact(targetAction, question.questionId),
+    artifact: primaryArtifact(targetAction, question.questionId),
     response: targetAction?.kind === "review"
       ? { mode: "review", actions: targetAction.actions }
       : { mode: "form", schema: question.schema, submitLabel: question.schema?.submitLabel },
@@ -137,6 +172,7 @@ export function askUserHumanActionToBlockerProjection(args: {
   if (hint.status && hint.status !== "ready") return null
 
   const action = question ? askUserQuestionToHumanActionView(question) : null
+  const artifacts = actionArtifacts(question?.humanAction, hint.questionId)
   const displayKind = action?.kind === "review" || action?.kind === "approval" ? action.kind : "question"
   const openLabel = displayKind === "review" ? "Open review target" : displayKind === "approval" ? "Open approval target" : "Open Questions"
   const actions = question
@@ -157,6 +193,7 @@ export function askUserHumanActionToBlockerProjection(args: {
       kind: displayKind,
       sourceLabel: displayKind,
       source: { type: "plugin", id: ASK_USER_PLUGIN_ID, label: displayKind },
+      artifacts,
       createdAt: action?.createdAt,
       updatedAt: action?.updatedAt ?? action?.createdAt,
       priority: action?.priority ?? 10,

--- a/plugins/ask-user/src/shared/types.ts
+++ b/plugins/ask-user/src/shared/types.ts
@@ -1,4 +1,5 @@
 import type { ASK_USER_COMMAND_KINDS } from "./constants"
+import type { HumanActionAnnotationTargetRef } from "./humanActionAnnotations"
 
 export type AskUserOption = {
   value: string
@@ -105,6 +106,24 @@ export type AskUserToolInput = {
 
 export type AskUserQuestionStatus = "ready" | "answered" | "cancelled" | "abandoned"
 
+export type AskUserHumanActionButton = {
+  id: string
+  label: string
+  tone?: "default" | "positive" | "warning" | "danger"
+  comment?: "none" | "optional" | "required"
+}
+
+export type AskUserTargetHumanAction = {
+  id?: string
+  kind: "review" | "approval" | "acknowledgement" | "choice"
+  title: string
+  body?: string
+  target: HumanActionAnnotationTargetRef
+  actions: AskUserHumanActionButton[]
+  actionFieldName?: string
+  commentFieldName?: string
+}
+
 export type AskUserQuestion = {
   questionId: string
   sessionId: string
@@ -113,6 +132,7 @@ export type AskUserQuestion = {
   title?: string
   context?: string
   schema?: AskUserFormSchema
+  humanAction?: AskUserTargetHumanAction
   answerToken: string
   createdAt: string
   updatedAt: string

--- a/plugins/ask-user/src/shared/types.ts
+++ b/plugins/ask-user/src/shared/types.ts
@@ -113,15 +113,24 @@ export type AskUserHumanActionButton = {
   comment?: "none" | "optional" | "required"
 }
 
+export type AskUserHumanActionArtifact = {
+  id?: string
+  label?: string
+  target: HumanActionAnnotationTargetRef
+}
+
 export type AskUserTargetHumanAction = {
   id?: string
   kind: "review" | "approval" | "acknowledgement" | "choice"
   title: string
   body?: string
   target: HumanActionAnnotationTargetRef
+  artifacts?: AskUserHumanActionArtifact[]
   actions: AskUserHumanActionButton[]
   actionFieldName?: string
   commentFieldName?: string
+  reviewFieldName?: string
+  annotationsFieldName?: string
 }
 
 export type AskUserQuestion = {


### PR DESCRIPTION
Follow-up to #445.\n\nImplements the first target-action UI slice:\n\n- generic workspace target-action registry/provider\n- reusable target action buttons for workspace surfaces/files\n- file, HTML, image/PDF viewers render active target actions in their header\n- ask-user pending questions can carry a target-scoped humanAction projection\n- header buttons submit through the existing ask-user answer bridge\n- target-scoped review e2e: open README target, see Accept in file header, click resolves ask-user answer\n\nSafety/boundaries:\n- workspace owns only generic target/action slots; no workspace -> ask-user import\n- Inbox/blockers carry pointers only; no raw artifact/file content\n- plugin callback owns resolution; agent cannot forge a human click\n\nValidation:\n- TMPDIR=/home/ubuntu/tmp/pi-tests pnpm --filter @hachej/boring-workspace exec vitest run src/front/humanActions/__tests__/WorkspaceHumanActionTargetsProvider.test.tsx\n- TMPDIR=/home/ubuntu/tmp/pi-tests pnpm --filter @hachej/boring-ask-user exec vitest run src/shared/__tests__/humanAction.test.ts src/front/__tests__/client.test.ts\n- TMPDIR=/home/ubuntu/tmp/pi-tests pnpm --filter @hachej/boring-workspace typecheck\n- TMPDIR=/home/ubuntu/tmp/pi-tests pnpm --filter @hachej/boring-ask-user typecheck\n- CI=1 TMPDIR=/home/ubuntu/tmp/pi-tests pnpm --filter workspace-playground run test:e2e -- plugins/ask-user/e2e/ask-user.spec.ts\n\nReview note: attempted subagent thermo review, but the subagent runtime could not start because /tmp is at 100% inode usage (ENOSPC creating /tmp/pi-subagents...). I applied the thermo-nuclear skill rubric manually and fixed issues found during self-review: target-action registry collision keying and double-submit/in-flight handling.