### PR TITLE
fix(cli): wire ask-user bridge in workspaces mode

### DIFF
--- a/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
+++ b/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
@@ -210,6 +210,64 @@ describe("workspaces mode runtime plugin wiring", () => {
     }
   }, 60_000)
 
+  test("workspaces mode exposes default plugin workspace bridge handlers", async () => {
+    const homeRoot = await makeTempDir("boring-cli-workspaces-bridge-home-")
+    const registryPath = join(await makeTempDir("boring-cli-workspaces-bridge-registry-"), "workspaces.yaml")
+    const workspaceRoot = await makeTempDir("boring-cli-workspace-bridge-")
+    process.env.HOME = homeRoot
+
+    const [workspace] = await setupRegistry([workspaceRoot], registryPath)
+    const app = await createWorkspacesModeApp({ mode: "direct", registryPath, provisionWorkspace: false })
+
+    try {
+      const headers = {
+        "content-type": "application/json",
+        "x-boring-workspace-id": workspace.id,
+        "x-boring-session-id": "s1",
+      }
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/v1/workspace-bridge/call",
+        headers,
+        payload: { op: "ask-user.v1.pending", input: { sessionId: "s1" } },
+      })
+
+      expect(response.statusCode).toBe(200)
+      expect(response.json()).toMatchObject({
+        ok: true,
+        op: "ask-user.v1.pending",
+        output: { pending: null },
+      })
+
+      const pendingState = {
+        hint: { questionId: "q1", sessionId: "s1", status: "ready" },
+        hintsBySession: { s1: { questionId: "q1", sessionId: "s1", status: "ready" } },
+      }
+      const stateHeaders = { "x-boring-workspace-id": workspace.id }
+      const publishPending = await app.inject({
+        method: "PUT",
+        url: "/api/v1/ui/state",
+        headers: stateHeaders,
+        payload: { state: { "questions.pending": pendingState } },
+      })
+      expect(publishPending.statusCode).toBe(204)
+      const browserSnapshot = await app.inject({
+        method: "PUT",
+        url: "/api/v1/ui/state",
+        headers: stateHeaders,
+        payload: { state: { drawerOpen: true } },
+      })
+      expect(browserSnapshot.statusCode).toBe(204)
+      const state = await app.inject({ method: "GET", url: "/api/v1/ui/state", headers: stateHeaders })
+      expect(state.json()).toMatchObject({ drawerOpen: true, "questions.pending": pendingState })
+
+      const catalog = await app.inject({ method: "GET", url: "/api/v1/agent/catalog", headers })
+      expect((catalog.json() as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).toContain("ask_user")
+    } finally {
+      await app.close()
+    }
+  }, 20_000)
+
   test("external plugin server routes dispatch through the gateway and hot-reload via /reload", async () => {
     const homeRoot = await makeTempDir("boring-cli-workspaces-routes-home-")
     const registryPath = join(await makeTempDir("boring-cli-workspaces-routes-registry-"), "workspaces.yaml")

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -19,6 +19,7 @@ import type {
 } from "../shared/runtimePluginDiagnostics.js"
 import { resolveBoringUiCliPackageRoot } from "./pluginDiscovery.js"
 import type { readCliPluginPiSnapshot as readCliPluginPiSnapshotFn } from "./pluginDiscovery.js"
+import { ASK_USER_UI_STATE_SLOTS } from "@hachej/boring-ask-user/shared"
 
 type CliPluginPiSnapshot = ReturnType<typeof readCliPluginPiSnapshotFn>
 
@@ -487,6 +488,12 @@ export async function createWorkspacesModeApp(opts: {
     },
   })
   const bridges = new Map<string, ReturnType<typeof workspaceServer.createInMemoryBridge>>()
+  type WorkspaceBridgeCore = {
+    registry: ReturnType<typeof workspaceServer.createWorkspaceBridgeRuntimeCore>["registry"]
+    idempotencyStore: InstanceType<typeof workspaceServer.InMemoryWorkspaceBridgeIdempotencyStore>
+    extraTools: NonNullable<ReturnType<typeof workspaceAppServer.collectWorkspaceAgentServerPlugins>["agentOptions"]["extraTools"]>
+  }
+  const workspaceBridgeCores = new Map<string, Promise<WorkspaceBridgeCore>>()
   const workspaceEventClosers = new Map<string, Set<() => void>>()
   const pluginRuntimes = new Map<string, {
     manager: InstanceType<typeof workspaceServer.BoringPluginAssetManager>
@@ -503,6 +510,42 @@ export async function createWorkspacesModeApp(opts: {
       bridges.set(workspaceId, bridge)
     }
     return bridge
+  }
+
+  async function getWorkspaceBridgeCore(workspace: LocalWorkspace) {
+    let core = workspaceBridgeCores.get(workspace.id)
+    if (core) return await core
+    core = (async (): Promise<WorkspaceBridgeCore> => {
+      const bridge = getBridge(workspace.id)
+      const ctx = { workspaceRoot: workspace.path, bridge }
+      const defaultPluginDirEntries = pluginDiscovery.resolveCliDefaultPluginPackagePaths()
+        .map((dir) => ({ dir, hotReload: true, trust: "internal" as const }))
+        .filter((entry) => workspaceAppServer.hasDirServerPlugin(entry))
+      const resolvedPlugins = await Promise.all(defaultPluginDirEntries.map(async (entry) => {
+        const plugin = await workspaceAppServer.resolveOnePluginEntry(entry, ctx)
+        workspaceAppServer.assertWorkspaceBridgeHandlersTrusted(plugin, entry)
+        return plugin
+      }))
+      const pluginCollection = workspaceAppServer.collectWorkspaceAgentServerPlugins({
+        plugins: resolvedPlugins,
+        installPluginAuthoring: false,
+        excludeDefaults: ["boring-ui-plugin-cli-package"],
+      })
+      const bridgeCore = workspaceServer.createWorkspaceBridgeRuntimeCore({
+        ownerWorkspaceId: workspace.id,
+        handlers: pluginCollection.workspaceBridgeHandlers ?? [],
+      })
+      return {
+        registry: bridgeCore.registry,
+        idempotencyStore: new workspaceServer.InMemoryWorkspaceBridgeIdempotencyStore(),
+        extraTools: pluginCollection.agentOptions.extraTools ?? [],
+      }
+    })().catch((error) => {
+      workspaceBridgeCores.delete(workspace.id)
+      throw error
+    })
+    workspaceBridgeCores.set(workspace.id, core)
+    return await core
   }
 
   async function requireWorkspace(workspaceId: string): Promise<LocalWorkspace> {
@@ -580,6 +623,7 @@ export async function createWorkspacesModeApp(opts: {
     pluginRuntimes.delete(runtimeKey)
     pluginPiSnapshots.delete(runtimeKey)
     runtimeProvisioningByWorkspace.delete(workspace.id)
+    workspaceBridgeCores.delete(workspace.id)
     bridges.delete(workspace.id)
     diagnosticsStore.disposeWorkspace(workspace.id)
     await runtimeHost.disposeWorkspace(workspace.id)
@@ -730,12 +774,25 @@ export async function createWorkspacesModeApp(opts: {
       ...workspaceServer.createWorkspaceUiTools(getBridge(workspaceId), {
         workspaceRoot: workspaceFsCapability === "strong" ? workspaceRoot : undefined,
       }),
+      ...(await getWorkspaceBridgeCore(await requireWorkspace(workspaceId))).extraTools,
     ],
   })
 
   await app.register(workspaceServer.uiRoutes, {
     getWorkspaceId: async (request) => (await workspaceFromRequest(request)).id,
     getBridge: async (request) => getBridge((await workspaceFromRequest(request)).id),
+    preserveStateKeys: [ASK_USER_UI_STATE_SLOTS.PENDING],
+  })
+
+  await app.register(workspaceServer.workspaceBridgeHttpRoutes, {
+    getRegistry: async (request) => (await getWorkspaceBridgeCore(await workspaceFromRequest(request))).registry,
+    getOwnerWorkspaceId: async (request) => (await workspaceFromRequest(request)).id,
+    getIdempotencyStore: async (request) => (await getWorkspaceBridgeCore(await workspaceFromRequest(request))).idempotencyStore,
+    browserAuthPolicy: {
+      resolve(input) {
+        return workspaceServer.createLocalCliBridgeAuthPolicy({ workspaceId: input.workspaceId }).resolve(input)
+      },
+    },
   })
 
   app.get("/api/v1/runtime-plugin-diagnostics", async (request) => {

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -516,18 +516,10 @@ export async function createWorkspacesModeApp(opts: {
     let core = workspaceBridgeCores.get(workspace.id)
     if (core) return await core
     core = (async (): Promise<WorkspaceBridgeCore> => {
-      const bridge = getBridge(workspace.id)
-      const ctx = { workspaceRoot: workspace.path, bridge }
-      const defaultPluginDirEntries = pluginDiscovery.resolveCliDefaultPluginPackagePaths()
-        .map((dir) => ({ dir, hotReload: true, trust: "internal" as const }))
-        .filter((entry) => workspaceAppServer.hasDirServerPlugin(entry))
-      const resolvedPlugins = await Promise.all(defaultPluginDirEntries.map(async (entry) => {
-        const plugin = await workspaceAppServer.resolveOnePluginEntry(entry, ctx)
-        workspaceAppServer.assertWorkspaceBridgeHandlersTrusted(plugin, entry)
-        return plugin
-      }))
-      const pluginCollection = workspaceAppServer.collectWorkspaceAgentServerPlugins({
-        plugins: resolvedPlugins,
+      const pluginCollection = await workspaceAppServer.resolveWorkspaceAgentServerPluginCollection({
+        workspaceRoot: workspace.path,
+        bridge: getBridge(workspace.id),
+        defaultPluginPackages: pluginDiscovery.resolveCliDefaultPluginPackagePaths(),
         installPluginAuthoring: false,
         excludeDefaults: ["boring-ui-plugin-cli-package"],
       })

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -19,7 +19,6 @@ import type {
 } from "../shared/runtimePluginDiagnostics.js"
 import { resolveBoringUiCliPackageRoot } from "./pluginDiscovery.js"
 import type { readCliPluginPiSnapshot as readCliPluginPiSnapshotFn } from "./pluginDiscovery.js"
-import { ASK_USER_UI_STATE_SLOTS } from "@hachej/boring-ask-user/shared"
 
 type CliPluginPiSnapshot = ReturnType<typeof readCliPluginPiSnapshotFn>
 
@@ -492,6 +491,7 @@ export async function createWorkspacesModeApp(opts: {
     registry: ReturnType<typeof workspaceServer.createWorkspaceBridgeRuntimeCore>["registry"]
     idempotencyStore: InstanceType<typeof workspaceServer.InMemoryWorkspaceBridgeIdempotencyStore>
     extraTools: NonNullable<ReturnType<typeof workspaceAppServer.collectWorkspaceAgentServerPlugins>["agentOptions"]["extraTools"]>
+    preservedUiStateKeys: NonNullable<ReturnType<typeof workspaceAppServer.collectWorkspaceAgentServerPlugins>["preservedUiStateKeys"]>
   }
   const workspaceBridgeCores = new Map<string, Promise<WorkspaceBridgeCore>>()
   const workspaceEventClosers = new Map<string, Set<() => void>>()
@@ -539,6 +539,7 @@ export async function createWorkspacesModeApp(opts: {
         registry: bridgeCore.registry,
         idempotencyStore: new workspaceServer.InMemoryWorkspaceBridgeIdempotencyStore(),
         extraTools: pluginCollection.agentOptions.extraTools ?? [],
+        preservedUiStateKeys: pluginCollection.preservedUiStateKeys ?? [],
       }
     })().catch((error) => {
       workspaceBridgeCores.delete(workspace.id)
@@ -781,7 +782,7 @@ export async function createWorkspacesModeApp(opts: {
   await app.register(workspaceServer.uiRoutes, {
     getWorkspaceId: async (request) => (await workspaceFromRequest(request)).id,
     getBridge: async (request) => getBridge((await workspaceFromRequest(request)).id),
-    preserveStateKeys: [ASK_USER_UI_STATE_SLOTS.PENDING],
+    getPreserveStateKeys: async (request) => (await getWorkspaceBridgeCore(await workspaceFromRequest(request))).preservedUiStateKeys,
   })
 
   await app.register(workspaceServer.workspaceBridgeHttpRoutes, {

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -334,6 +334,7 @@ export interface WorkspaceAgentServerPluginCollection {
   routeContributions: WorkspaceRouteContribution[]
   workspaceBridgeHandlers: WorkspaceServerPlugin["workspaceBridgeHandlers"]
   preservedUiStateKeys: string[]
+  defaultPluginPackagePaths: string[]
   agentOptions: Pick<
     WorkspaceAgentCreateOptions,
     "extraTools" | "systemPromptAppend" | "pi"
@@ -347,6 +348,15 @@ export interface CollectWorkspaceAgentServerPluginsOptions
   pi?: WorkspaceAgentPiOptions
   /** Whether to include built-in boring plugin-authoring provisioning/prompt resources. */
   installPluginAuthoring?: boolean
+}
+
+export interface ResolveWorkspaceAgentServerPluginCollectionOptions
+  extends Omit<CollectWorkspaceAgentServerPluginsOptions, "plugins"> {
+  workspaceRoot: string
+  bridge: ReturnType<typeof createInMemoryBridge>
+  defaultPluginPackages?: string[]
+  appRoot?: string
+  plugins?: WorkspacePluginEntry[]
 }
 
 export function buildWorkspaceContextPrompt(options: { pluginAuthoringEnabled?: boolean } = {}): string {
@@ -399,6 +409,7 @@ export function collectWorkspaceAgentServerPlugins(
     routeContributions: result.routeContributions,
     workspaceBridgeHandlers: result.workspaceBridgeHandlers,
     preservedUiStateKeys: result.preservedUiStateKeys,
+    defaultPluginPackagePaths: [],
     agentOptions: {
       extraTools: result.agentTools,
       systemPromptAppend: [opts.systemPromptAppend, result.systemPromptAppend]
@@ -416,6 +427,36 @@ export function collectWorkspaceAgentServerPlugins(
       },
     },
   }
+}
+
+export async function resolveWorkspaceAgentServerPluginCollection(
+  opts: ResolveWorkspaceAgentServerPluginCollectionOptions,
+): Promise<WorkspaceAgentServerPluginCollection> {
+  const ctx: WorkspaceAgentServerPluginContext = { workspaceRoot: opts.workspaceRoot, bridge: opts.bridge }
+  const defaultPluginPackagePaths = resolveDefaultWorkspacePluginPackagePaths({
+    workspaceRoot: opts.workspaceRoot,
+    defaultPluginPackages: opts.defaultPluginPackages,
+    anchorDir: opts.appRoot,
+  })
+  const defaultPluginDirEntries: WorkspacePluginEntry[] = defaultPluginPackagePaths
+    .map((dir) => ({ dir, hotReload: true, trust: "internal" as const }))
+    .filter((entry) => hasDirServerPlugin(entry))
+  const allPluginEntries: WorkspacePluginEntry[] = [
+    ...defaultPluginDirEntries,
+    ...(opts.plugins ?? []),
+  ]
+  const resolvedPlugins = await Promise.all(
+    allPluginEntries.map(async (entry) => {
+      const plugin = await resolveOnePluginEntry<WorkspaceServerPlugin>(entry, ctx)
+      assertWorkspaceBridgeHandlersTrusted(plugin, entry)
+      return plugin
+    }),
+  )
+  const collection = collectWorkspaceAgentServerPlugins({
+    ...opts,
+    plugins: resolvedPlugins,
+  })
+  return { ...collection, defaultPluginPackagePaths }
 }
 
 export async function provisionWorkspaceAgentServer(opts: {
@@ -644,45 +685,23 @@ export async function createWorkspaceAgentServer(
   const uiTools = createWorkspaceUiTools(bridge, {
     workspaceRoot: validateUiPaths ? workspaceRoot : undefined,
   })
-  const ctx: WorkspaceAgentServerPluginContext = { workspaceRoot, bridge }
-
-  // Resolve app-default plugin packages (explicit list set in host boot
-  // code — the server-side mirror of the app's static front imports). Each
-  // entry is resolved to an absolute package dir. All default package dirs
-  // flow into the boring asset manager + dynamic Pi scan; only packages
-  // that actually declare/provide a server entry flow into the server-side
-  // install array. Front/Pi-only default packages must not be forced through
-  // a server import.
-  const defaultPluginPackagePaths = resolveDefaultWorkspacePluginPackagePaths({
-    workspaceRoot,
-    defaultPluginPackages: opts.defaultPluginPackages,
-    anchorDir: opts.appRoot,
-  })
-  const defaultPluginDirEntries: WorkspacePluginEntry[] = defaultPluginPackagePaths
-    .map((dir) => ({ dir, hotReload: true, trust: "internal" as const }))
-    .filter((entry) => hasDirServerPlugin(entry))
-
-  const allPluginEntries: WorkspacePluginEntry[] = [
-    ...defaultPluginDirEntries,
-    ...(opts.plugins ?? []),
-  ]
-  // Each entry (pre-built plugin or { dir, ... }) is resolved by
-  // resolveOnePluginEntry. Same logic serves rebuilds on /reload.
-  const resolvedPlugins = await Promise.all(
-    allPluginEntries.map(async (entry) => {
-      const plugin = await resolveOnePluginEntry<WorkspaceServerPlugin>(entry, ctx)
-      assertWorkspaceBridgeHandlersTrusted(plugin, entry)
-      return plugin
-    }),
-  )
   const pluginAuthoringEnabled = externalPluginsEnabled
     && (opts.installPluginAuthoring ?? workspaceFsCapability === "strong")
     && !(opts.excludeDefaults ?? []).includes("boring-ui-plugin-cli-package")
-  const pluginCollection = collectWorkspaceAgentServerPlugins({
+  const pluginCollection = await resolveWorkspaceAgentServerPluginCollection({
     ...opts,
-    plugins: resolvedPlugins,
+    workspaceRoot,
+    bridge,
     installPluginAuthoring: pluginAuthoringEnabled,
   })
+  const defaultPluginPackagePaths = pluginCollection.defaultPluginPackagePaths
+  const ctx: WorkspaceAgentServerPluginContext = { workspaceRoot, bridge }
+  const allPluginEntries: WorkspacePluginEntry[] = [
+    ...defaultPluginPackagePaths
+      .map((dir) => ({ dir, hotReload: true, trust: "internal" as const }))
+      .filter((entry) => hasDirServerPlugin(entry)),
+    ...(opts.plugins ?? []),
+  ]
 
   const { registry: workspaceBridgeRegistry } = createWorkspaceBridgeRuntimeCore({
     registry: opts.workspaceBridge?.registry,

--- a/packages/workspace/src/app/server/index.ts
+++ b/packages/workspace/src/app/server/index.ts
@@ -6,6 +6,7 @@ export {
   createWorkspaceAgentServer,
   omitPluginAuthoringProvisioning,
   provisionWorkspaceAgentServer,
+  resolveWorkspaceAgentServerPluginCollection,
   readWorkspacePluginPackagePiSnapshot,
   readWorkspacePluginPackageRuntimePlugins,
   PLUGIN_AUTHORING_PROVISIONING_IDS,
@@ -17,6 +18,7 @@ export {
   type WorkspacePluginPackagePiSnapshot,
   type WorkspacePluginEntry,
   type WorkspaceRuntimeProvisioningInput,
+  type ResolveWorkspaceAgentServerPluginCollectionOptions,
 } from "./createWorkspaceAgentServer"
 export {
   resolveDefaultWorkspacePluginPackagePaths,

--- a/packages/workspace/src/server/ui-control/http/uiRoutes.ts
+++ b/packages/workspace/src/server/ui-control/http/uiRoutes.ts
@@ -50,6 +50,7 @@ export interface UiRoutesOptions {
    * these slots are published out-of-band by server plugins.
    */
   preserveStateKeys?: string[];
+  getPreserveStateKeys?: (request: FastifyRequest) => string[] | Promise<string[]>;
   paneStatusStore?: PaneRenderStatusStore;
 }
 
@@ -94,8 +95,11 @@ export function uiRoutes(
       const body = request.body as z.infer<typeof setStateBodySchema>;
       const bridge = await resolveBridge(request);
       const current = (await bridge.getState()) ?? {};
+      const preserveStateKeys = opts.getPreserveStateKeys
+        ? await opts.getPreserveStateKeys(request)
+        : opts.preserveStateKeys ?? [];
       const preserved = Object.fromEntries(
-        (opts.preserveStateKeys ?? [])
+        preserveStateKeys
           .filter((key) => !(key in body.state) && key in current)
           .map((key) => [key, current[key]]),
       );


### PR DESCRIPTION
## Summary
- register WorkspaceBridge HTTP routes in CLI workspaces mode
- resolve trusted default server plugin contributions per workspace so ask-user tool and bridge handlers share one runtime/store
- preserve ask-user pending UI state across browser state snapshots

## Verification
- Reproduced deployed issue: workspaces mode returned 404 for `POST /api/v1/workspace-bridge/call`, leaving Questions pane unable to hydrate a form
- pnpm --filter @hachej/boring-ui-kit build
- pnpm --filter @hachej/boring-agent build
- pnpm --filter @hachej/boring-workspace build
- pnpm --filter @hachej/boring-ask-user build
- pnpm --filter @hachej/boring-ui-cli typecheck
- TMPDIR=/home/ubuntu/tmp pnpm --filter @hachej/boring-ui-cli exec vitest run src/__tests__/workspacesModeRuntimePlugins.test.ts -t "workspace bridge"
- /home/ubuntu/.agents/skills/coding-autoreview/scripts/autoreview --mode local

Note: `/tmp` inode exhaustion required `TMPDIR=/home/ubuntu/tmp` for Vitest.
