### PR TITLE
mcp-integration: Address thermo cleanup findings

### DIFF
--- a/apps/full-app/src/server/boringMcp.ts
+++ b/apps/full-app/src/server/boringMcp.ts
@@ -10,6 +10,7 @@ import {
   evaluateBoringMcpLaunchGate,
   type BoringMcpLaunchGateResult,
   type ManagedConnectorAdapter,
+  type ManagedConnectorConfig,
   type ManagedConnectorProvider,
   type ManagedConnectorSecret,
   type ManagedConnectorSecretResolver,
@@ -45,10 +46,19 @@ export function readFullAppBoringMcpServerConfig(env: NodeJS.ProcessEnv = proces
   }
 }
 
-export function createFullAppManagedConnectorSecretResolver(env: NodeJS.ProcessEnv = process.env): ManagedConnectorSecretResolver {
+const FULL_APP_MANAGED_CONNECTOR_CONFIGS: readonly ManagedConnectorConfig[] = [
+  { provider: 'notion', displayName: 'Notion', toolkitId: 'notion', connectUrlOrigins: ['https://app.composio.dev'] },
+  { provider: 'airtable', displayName: 'Airtable', toolkitId: 'airtable', connectUrlOrigins: ['https://app.composio.dev'] },
+]
+
+export function createFullAppManagedConnectorSecretResolver(
+  env: NodeJS.ProcessEnv = process.env,
+  configs: readonly ManagedConnectorConfig[] = FULL_APP_MANAGED_CONNECTOR_CONFIGS,
+): ManagedConnectorSecretResolver {
+  const supportedProviders = new Set<McpProviderId>(configs.map((config) => config.provider))
   return {
     async resolveSecret(provider: McpProviderId): Promise<ManagedConnectorSecret> {
-      if (provider !== 'notion' && provider !== 'airtable') throw new Error(`Unsupported MCP provider: ${provider}`)
+      if (!supportedProviders.has(provider)) throw new Error(`Unsupported MCP provider: ${provider}`)
       const value = env.COMPOSIO_API_KEY?.trim()
       if (!value) throw new Error('COMPOSIO_API_KEY is not configured')
       return { storage: 'server-env', value }
@@ -66,13 +76,10 @@ export function createFullAppManagedConnectorAdapter(options: {
   return createManagedConnectorAdapter({
     registry: options.registry,
     provider: options.provider ?? createComposioManagedConnectorProvider(),
-    secretResolver: createFullAppManagedConnectorSecretResolver(options.env),
+    secretResolver: createFullAppManagedConnectorSecretResolver(options.env, FULL_APP_MANAGED_CONNECTOR_CONFIGS),
     templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
     redactionCanaries: FULL_APP_MCP_REDACTION_CANARIES,
-    configs: [
-      { provider: 'notion', displayName: 'Notion', toolkitId: 'notion', connectUrlOrigins: ['https://app.composio.dev'] },
-      { provider: 'airtable', displayName: 'Airtable', toolkitId: 'airtable', connectUrlOrigins: ['https://app.composio.dev'] },
-    ],
+    configs: FULL_APP_MANAGED_CONNECTOR_CONFIGS,
   })
 }
 

--- a/plugins/boring-mcp/src/__tests__/managedConnectorAdapter.test.ts
+++ b/plugins/boring-mcp/src/__tests__/managedConnectorAdapter.test.ts
@@ -56,7 +56,7 @@ function createProvider(): ManagedConnectorProvider {
   return {
     startConnect: vi.fn(async ({ sourceId }) => ({
       connectorRef: { provider: "notion", toolkitId: "notion-toolkit", externalSourceId: "provider-source-1", sessionId: "session-1" },
-      status: "connected" as const,
+      status: "unconfigured" as const,
       connectUrl: `https://connect.example/${sourceId}`,
       providerAccountLabel: "demo@example.com",
     })),

--- a/plugins/boring-mcp/src/server/managedConnectorAdapter.ts
+++ b/plugins/boring-mcp/src/server/managedConnectorAdapter.ts
@@ -1,8 +1,8 @@
 import {
   MCP_ERROR_CODES,
   McpError,
-  classifyMcpTool,
-  containsMcpSecret,
+  classifyMcpTools,
+  containsMcpSecretOrCanary,
   getMcpProviderTemplate,
   type McpActor,
   type McpConnectorRef,
@@ -51,7 +51,7 @@ export interface ManagedConnectorStartInput {
 
 export interface ManagedConnectorStartResponse {
   connectorRef: McpConnectorRef
-  status?: McpSourceStatus
+  status?: Exclude<McpSourceStatus, "connected">
   connectUrl?: string
   providerAccountLabel?: string
 }
@@ -103,15 +103,8 @@ function defaultSourceId(actor: McpActor, config: ManagedConnectorConfig): strin
   return validateMcpSourceId(`managed:${actor.workspaceId}:${actor.userId}:${config.provider}`)
 }
 
-function containsCanary(value: unknown, canaries: readonly string[]): boolean {
-  if (typeof value === "string") return canaries.some((canary) => canary.trim() && value.includes(canary))
-  if (Array.isArray(value)) return value.some((item) => containsCanary(item, canaries))
-  if (!value || typeof value !== "object") return false
-  return Object.entries(value).some(([key, nested]) => containsCanary(key, canaries) || containsCanary(nested, canaries))
-}
-
 function assertSecretFree(value: unknown, canaries: readonly string[], code: McpErrorCode = MCP_ERROR_CODES.SECRET_LEAK_GUARD): void {
-  if (containsMcpSecret(value) || containsCanary(value, canaries)) {
+  if (containsMcpSecretOrCanary(value, canaries)) {
     throw new McpError(code, "Managed connector response contained secret material")
   }
 }
@@ -145,16 +138,16 @@ export function createManagedConnectorAdapter(options: ManagedConnectorAdapterOp
     return secret
   }
 
-  function requireConfig(provider: McpProviderId): ManagedConnectorConfig {
+  function requireConfig(provider: McpProviderId): { config: ManagedConnectorConfig; template: McpProviderTemplate } {
     const config = findConfig(options.configs, provider)
     const template = getMcpProviderTemplate(provider, templates)
     if (!config || !template) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown managed connector provider")
-    return config
+    return { config, template }
   }
 
   return {
     async startConnect(actor, input) {
-      const config = requireConfig(input.provider)
+      const { config } = requireConfig(input.provider)
       const sourceId = validateMcpSourceId((options.sourceIdFactory ?? defaultSourceId)(actor, config))
       const secret = await getSecret(config.provider)
       const secretCanaries = [...canaries, secret.value]
@@ -167,7 +160,7 @@ export function createManagedConnectorAdapter(options: ManagedConnectorAdapterOp
         userId: actor.userId,
         provider: config.provider,
         displayName: input.displayName ?? config.displayName,
-        status: response.status === "connected" ? "unconfigured" : (response.status ?? "unconfigured"),
+        status: response.status ?? "unconfigured",
         ownerKind: "user",
         credentialProvider: "composio-managed",
         scopes: config.scopes ? [...config.scopes] : undefined,
@@ -176,41 +169,43 @@ export function createManagedConnectorAdapter(options: ManagedConnectorAdapterOp
       }
       assertSecretFree(source, secretCanaries)
       const saved = await options.registry.upsertSource(actor, source)
-      assertSecretFree(saved, secretCanaries)
-      return { ...createMcpSourceStatusPayload(saved), connectUrl }
+      const result = { ...createMcpSourceStatusPayload(saved), connectUrl }
+      assertSecretFree(result, secretCanaries)
+      return result
     },
 
     async refreshStatus(actor, sourceId) {
       const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
-      const config = requireConfig(source.provider)
+      const { config } = requireConfig(source.provider)
       const secret = await getSecret(config.provider)
       const secretCanaries = [...canaries, secret.value]
       const response = await options.provider.refreshStatus({ actor, source, config, secret })
       assertSecretFree(response, secretCanaries)
-      const saved = await options.registry.upsertSource(actor, {
+      const nextSource: McpSource = {
         ...source,
         status: response.status,
         providerAccountLabel: response.providerAccountLabel ?? source.providerAccountLabel,
         connectorRef: response.connectorRef ?? source.connectorRef,
         lastVerifiedAt: response.lastVerifiedAt,
-      })
-      assertSecretFree(saved, secretCanaries)
-      return createMcpSourceStatusPayload(saved)
+      }
+      assertSecretFree(nextSource, secretCanaries)
+      const saved = await options.registry.upsertSource(actor, nextSource)
+      const result = createMcpSourceStatusPayload(saved)
+      assertSecretFree(result, secretCanaries)
+      return result
     },
 
     async probeSource(actor, sourceId) {
       const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
       if (source.status !== "connected") throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source is not connected")
-      const config = requireConfig(source.provider)
-      const template = getMcpProviderTemplate(source.provider, templates)
-      if (!template) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown managed connector provider")
+      const { config, template } = requireConfig(source.provider)
       const secret = await getSecret(config.provider)
       const response = await options.provider.probe({ actor, source, config, secret })
       assertSecretFree(response, [...canaries, secret.value])
       const result = {
         sourceId: source.id,
         provider: source.provider,
-        tools: response.tools.map((tool) => ({ ...tool, decision: classifyMcpTool(template, tool.name) })),
+        tools: classifyMcpTools(template, response.tools),
         resources: response.resources,
       }
       assertSecretFree(result, [...canaries, secret.value])

--- a/plugins/boring-mcp/src/server/managedConnectorPreflight.ts
+++ b/plugins/boring-mcp/src/server/managedConnectorPreflight.ts
@@ -1,4 +1,4 @@
-import { MCP_ERROR_CODES, McpError, containsMcpSecret, type McpErrorCode } from "../shared"
+import { MCP_ERROR_CODES, McpError, containsMcpSecretOrCanary, type McpErrorCode } from "../shared"
 
 export type ManagedConnectorSecretStorage = "server-env" | "server-vault"
 export type ManagedConnectorRiskStatus = "approved" | "owner-accepted-gap"
@@ -63,25 +63,14 @@ function hasAcceptedGap(evidence: ManagedConnectorVendorRiskEvidence, field: (ty
   return evidence[field] === "approved" || Boolean(evidence.acceptedGaps?.some((gap) => gap.id === field && hasText(gap.owner) && hasText(gap.followUp) && hasText(gap.reason)))
 }
 
-function stringContainsCanary(value: string, canaries: readonly string[]): boolean {
-  return canaries.some((canary) => hasText(canary) && value.includes(canary))
-}
-
-function containsCanary(value: unknown, canaries: readonly string[]): boolean {
-  if (typeof value === "string") return stringContainsCanary(value, canaries)
-  if (Array.isArray(value)) return value.some((item) => containsCanary(item, canaries))
-  if (!value || typeof value !== "object") return false
-  return Object.entries(value).some(([key, nested]) => stringContainsCanary(key, canaries) || containsCanary(nested, canaries))
-}
-
 export function validateManagedConnectorPreflight(evidence: ManagedConnectorPreflightEvidence): ManagedConnectorPreflightResult {
   const hasBrowserSamples = evidence.browserDtoSamples.length > 0
   const hasLogSamples = evidence.redactedLogSamples.length > 0
   const hasProviderResultSamples = evidence.redactedProviderResultSamples.length > 0
   const hasCanaries = evidence.redactionCanaries.some(hasText)
-  const browserHasSecret = evidence.browserDtoSamples.some(containsMcpSecret) || containsCanary(evidence.browserDtoSamples, evidence.redactionCanaries)
-  const logsHaveSecret = evidence.redactedLogSamples.some(containsMcpSecret) || containsCanary(evidence.redactedLogSamples, evidence.redactionCanaries)
-  const providerResultsHaveSecret = evidence.redactedProviderResultSamples.some(containsMcpSecret) || containsCanary(evidence.redactedProviderResultSamples, evidence.redactionCanaries)
+  const browserHasSecret = containsMcpSecretOrCanary(evidence.browserDtoSamples, evidence.redactionCanaries)
+  const logsHaveSecret = containsMcpSecretOrCanary(evidence.redactedLogSamples, evidence.redactionCanaries)
+  const providerResultsHaveSecret = containsMcpSecretOrCanary(evidence.redactedProviderResultSamples, evidence.redactionCanaries)
   const vendorRiskOk = VENDOR_RISK_FIELDS.every((field) => hasAcceptedGap(evidence.vendorRisk, field))
 
   const checks: ManagedConnectorPreflightCheck[] = [

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -287,6 +287,10 @@ export function classifyMcpTool(template: McpProviderTemplate, toolName: string)
   return { allowed: false, risk: "unknown", reason: "Tool is not on the read-only allowlist" }
 }
 
+export function classifyMcpTools(template: McpProviderTemplate, tools: readonly McpDiscoveredTool[]): Array<McpDiscoveredTool & { decision: McpToolDecision }> {
+  return tools.map((tool) => ({ ...tool, decision: classifyMcpTool(template, tool.name) }))
+}
+
 export function assertMcpToolAllowed(template: McpProviderTemplate, toolName: string): void {
   const decision = classifyMcpTool(template, toolName)
   if (!decision.allowed) throw new McpError(MCP_ERROR_CODES.TOOL_NOT_ALLOWED, decision.reason)
@@ -306,6 +310,21 @@ export function redactMcpSecrets(value: unknown): unknown {
 export function containsMcpSecret(value: unknown): boolean {
   const redacted = redactMcpSecrets(value)
   return JSON.stringify(redacted) !== JSON.stringify(value)
+}
+
+function hasMcpCanaryText(value: string, canaries: readonly string[]): boolean {
+  return canaries.some((canary) => canary.trim() && value.includes(canary))
+}
+
+export function containsMcpCanary(value: unknown, canaries: readonly string[]): boolean {
+  if (typeof value === "string") return hasMcpCanaryText(value, canaries)
+  if (Array.isArray(value)) return value.some((item) => containsMcpCanary(item, canaries))
+  if (!value || typeof value !== "object") return false
+  return Object.entries(value).some(([key, nested]) => hasMcpCanaryText(key, canaries) || containsMcpCanary(nested, canaries))
+}
+
+export function containsMcpSecretOrCanary(value: unknown, canaries: readonly string[]): boolean {
+  return containsMcpSecret(value) || containsMcpCanary(value, canaries)
 }
 
 export function doctorMcpSource(source: McpSource, templates: readonly McpProviderTemplate[] = DEFAULT_MCP_PROVIDER_TEMPLATES): McpDoctorResult {
@@ -345,7 +364,7 @@ export class McpAccessFacade {
     return {
       sourceId: source.id,
       provider: source.provider,
-      tools: tools.map((tool) => ({ ...tool, decision: classifyMcpTool(template, tool.name) })),
+      tools: classifyMcpTools(template, tools),
       resources,
     }
   }


### PR DESCRIPTION
## Summary\n- centralize MCP secret/canary scanning in shared helpers\n- keep pre-persistence and output secret guards while removing duplicate local scanners\n- tighten managed connector start status so start-connect cannot report connected before refresh/probe verification\n- return config/template together to remove redundant template lookup\n- share MCP tool classification mapping helper\n- derive full-app managed connector provider support from the connector config list\n\n## Review loop\n- Claude Code CLI exact model `opus-4.8` was unavailable; `opus --effort max` later hit session quota until 12:20am UTC.\n- Used Gemini 3.1 Pro thermo review while Claude was blocked.\n- Gemini pass 1 RED: pre-persistence secret guard had been removed.\n- Fixed by restoring pre-save assertions before `registry.upsertSource`.\n- Gemini pass 2 GREEN.\n\n## Validation\n- `pnpm --filter @hachej/boring-mcp test` ✅\n- `pnpm --filter @hachej/boring-mcp typecheck` ✅\n- `pnpm --filter @hachej/boring-mcp build` ✅\n- `pnpm --filter full-app test -- src/server/__tests__/boringMcp.test.ts` ✅\n- `pnpm --filter full-app typecheck` ✅\n- `pnpm lint:workspace-plugin-invariants` ✅\n- `git diff --check` ✅