### PR TITLE
Fix session deletion replacement and left explorer actions

### DIFF
--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -163,7 +163,8 @@ export function WorkspaceShell() {
       providerStorageKey={showcase ? "boring-ui-v2:layout:playground" : `boring-ui-v2:layout:playground:${workspaceId}`}
       appTitle={showcase ? "Boring" : projectName}
       workspaceLabel={showcase ? undefined : projectName}
-      defaultSessionTitle={showcase ? "New session" : projectName}
+      workspaceLayout="plugin-tabs"
+      defaultSessionTitle="New chat"
       externalPlugins={externalPluginsEnabled}
       frontPluginHotReload={externalPluginsEnabled ? "vite" : undefined}
       fullPageBasePath="/full-page"

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -749,11 +749,37 @@ export function WorkspaceAgentFront<
     ? remoteSessionActionsUnavailable
     : sessionApi?.delete ?? onDeleteSession ?? localSessionStore.remove
   const resolvedDelete = useCallback((id: string) => {
-    if (sessionApi && activeRemoteSessions.length <= 1) {
+    if (sessionApi && remoteSessionsPending && activeRemoteSessions.length <= 1) {
       suppressEmptyAutoCreateRef.current = true
+      return rawDelete(id)
+    }
+    if (sessionApi && !remoteSessionsPending && activeRemoteSessions.length <= 1) {
+      if (sessionApi.hasMore) {
+        suppressEmptyAutoCreateRef.current = true
+        return rawDelete(id)
+      }
+      if (pendingLastSessionDeleteRef.current.has(id)) return Promise.resolve()
+      pendingLastSessionDeleteRef.current.add(id)
+      autoCreateSessionRef.current = true
+      setInitialRemoteSessionCreateFailed({ workspaceId, failed: false })
+      const replacement = sessionApi.create({ title: defaultSessionTitle })
+      return Promise.resolve(
+        replacement && typeof (replacement as PromiseLike<unknown>).then === "function"
+          ? Promise.resolve(replacement).then(() => rawDelete(id))
+          : rawDelete(id),
+      )
+        .catch((error) => {
+          autoCreateSessionRef.current = false
+          setInitialRemoteSessionCreateFailed({ workspaceId, failed: true })
+          throw error
+        })
+        .finally(() => {
+          pendingLastSessionDeleteRef.current.delete(id)
+        })
     }
     return rawDelete(id)
-  }, [activeRemoteSessions.length, rawDelete, sessionApi])
+  }, [activeRemoteSessions.length, defaultSessionTitle, rawDelete, remoteSessionsPending, sessionApi, workspaceId])
+
   const resolvedSessionTitle = resolvedSessions.find((session) => session.id === effectiveActiveSessionId)?.title ?? undefined
 
   const [navOpen, setNavOpen] = useStoredBooleanState(
@@ -802,6 +828,7 @@ export function WorkspaceAgentFront<
     setLeftOverlay(null)
   }, [setWorkbenchLeftOpen])
   const autoCreateSessionRef = useRef(false)
+  const pendingLastSessionDeleteRef = useRef<Set<string>>(new Set())
   const pendingCreatePaneRef = useRef<PendingCreatePane | null>(null)
   const surfaceOpenRef = useRef(surfaceOpen)
   const surfaceKeyRef = useRef(resolvedSurfaceStorageKey)
@@ -825,6 +852,7 @@ export function WorkspaceAgentFront<
 
   useEffect(() => {
     autoCreateSessionRef.current = false
+    pendingLastSessionDeleteRef.current.clear()
     suppressEmptyAutoCreateRef.current = false
     setInitialRemoteSessionCreating({ workspaceId, creating: false })
     setInitialRemoteSessionCreateFailed({ workspaceId, failed: false })
@@ -1429,6 +1457,7 @@ export function WorkspaceAgentFront<
     loadingMore: sessionApi?.loadingMore,
     onClose: () => setNavOpen(false),
   }
+  const canDeleteSessions = Boolean(sessionApi || onDeleteSession || !hasExplicitSessionProps)
   const commandPaletteSessionSearch = useMemo(() => (
     isPluginTabsLayout
       ? {
@@ -1579,6 +1608,7 @@ export function WorkspaceAgentFront<
           onSwitchSession={switchToChatPane}
           onOpenSessionAsPane={openChatPane}
           onToggleSessionPinned={toggleSessionPinned}
+          onDeleteSession={canDeleteSessions ? deleteSessionAndPane : undefined}
           actions={managementActions}
         />
       )}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1800,22 +1800,30 @@ describe("WorkspaceAgentFront", () => {
     expect(create.mock.calls[0]).toEqual([])
   })
 
-  it("does not auto-create a replacement after the user deletes the last remote session", async () => {
-    vi.useFakeTimers()
-    const create = vi.fn(async () => ({ id: "created", title: "Created" }))
+  it("creates a replacement before deleting the last authoritative remote session", async () => {
+    const calls: string[] = []
+    const createArgs: unknown[] = []
     const deleted = vi.fn()
 
     function useDeletingSessions() {
       const [sessionIds, setSessionIds] = useState(["only"])
-      const sessions = sessionIds.map((id) => ({ id, title: "Only session", updatedAt: Date.now() }))
+      const create = vi.fn(async (...args: unknown[]) => {
+        calls.push("create")
+        createArgs.push(args)
+        setSessionIds((prev) => ["created", ...prev])
+        return { id: "created", title: "Created" }
+      })
+      const sessions = sessionIds.map((id) => ({ id, title: id === "created" ? "Created" : "Only session", updatedAt: Date.now() }))
       return {
         sessions,
         activeSessionId: sessions[0]?.id ?? null,
         activeSession: sessions[0] ?? null,
         loading: false,
+        hasMore: false,
         create,
         switch: vi.fn(),
         delete: (id: string) => {
+          calls.push("delete")
           deleted(id)
           setSessionIds((prev) => prev.filter((sessionId) => sessionId !== id))
         },
@@ -1827,6 +1835,7 @@ describe("WorkspaceAgentFront", () => {
         workspaceId="delete-last"
         chatPanel={ChatPanel}
         useSessions={useDeletingSessions}
+        defaultSessionTitle="New chat"
         persistenceEnabled={false}
       />,
     )
@@ -1834,11 +1843,52 @@ describe("WorkspaceAgentFront", () => {
     fireEvent.click(screen.getByRole("button", { name: "Sessions" }))
     fireEvent.click(screen.getByLabelText("Delete Only session"))
 
+    await waitFor(() => expect(calls).toEqual(["create", "delete"]))
+    expect(createArgs).toEqual([[{ title: "New chat" }]])
     expect(deleted).toHaveBeenCalledWith("only")
+    expect(screen.getAllByText("Created").length).toBeGreaterThan(0)
+    expect(screen.queryByText("Only session")).not.toBeInTheDocument()
+  })
+
+  it("does not create a replacement when deleting from a non-authoritative paginated remote page", async () => {
+    vi.useFakeTimers()
+    const create = vi.fn(async () => ({ id: "created", title: "Created" }))
+    const deleted = vi.fn()
+
+    function usePaginatedSessions() {
+      const [sessionIds, setSessionIds] = useState(["visible"])
+      const sessions = sessionIds.map((id) => ({ id, title: "Visible session", updatedAt: Date.now() }))
+      return {
+        sessions,
+        activeSessionId: sessions[0]?.id ?? null,
+        activeSession: sessions[0] ?? null,
+        loading: false,
+        hasMore: true,
+        create,
+        switch: vi.fn(),
+        delete: (id: string) => {
+          deleted(id)
+          setSessionIds((prev) => prev.filter((sessionId) => sessionId !== id))
+        },
+      }
+    }
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="delete-paginated"
+        chatPanel={ChatPanel}
+        useSessions={usePaginatedSessions}
+        persistenceEnabled={false}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Sessions" }))
+    fireEvent.click(screen.getByLabelText("Delete Visible session"))
+
+    expect(deleted).toHaveBeenCalledWith("visible")
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2500)
     })
-
     expect(create).not.toHaveBeenCalled()
     vi.useRealTimers()
   })

--- a/packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx
+++ b/packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx
@@ -452,13 +452,14 @@ function SessionRow({
   onDelete?: (id: string) => void
 }) {
   const time = relativeTime(session.updatedAt)
+  const hasSessionStatus = Boolean(attentionBadge || working || time)
   return (
     <li
       role="listitem"
       data-boring-workspace-part="session-row"
       data-boring-state={active ? "selected" : undefined}
       className={cn(
-        "group relative mx-2 mt-px flex items-center gap-2 rounded-md px-2.5 py-1.5 text-[13px] transition-colors duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]",
+        "group relative mx-2 mt-px flex items-center rounded-md px-2.5 py-1.5 text-[13px] transition-colors duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]",
         "cursor-pointer hover:bg-foreground/[0.04]",
         active && "bg-foreground/[0.06] text-foreground",
       )}
@@ -477,7 +478,7 @@ function SessionRow({
           aria-hidden="true"
           data-boring-workspace-part="session-open-dot"
           className={cn(
-            "h-1.5 w-1.5 shrink-0 rounded-full",
+            "mr-2 h-1.5 w-1.5 shrink-0 rounded-full",
             active ? "bg-foreground/70" : "bg-foreground/30",
           )}
         />
@@ -486,99 +487,121 @@ function SessionRow({
         <span className={cn(active ? "font-medium text-foreground" : "text-foreground/90")}>
           {session.title || "Untitled"}
         </span>
-        {time && (
+      </span>
+      <span
+        className={cn(
+          "flex shrink-0 items-center transition-[margin] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]",
+          hasSessionStatus || pinned ? "ml-2" : "ml-0 group-hover:ml-2 focus-within:ml-2",
+        )}
+      >
+        {attentionBadge ? (
           <span
+            data-boring-workspace-part="session-badge"
+            data-boring-badge={attentionBadge.kind}
+            className={cn("inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none", sessionBadgeToneClassName(attentionBadge.tone))}
+          >
+            <span aria-hidden="true" className={cn("h-1.5 w-1.5 animate-pulse rounded-full", sessionBadgeDotClassName(attentionBadge.tone))} />
+            {attentionBadge.label}
+          </span>
+        ) : working ? (
+          <span
+            data-boring-workspace-part="session-badge"
+            data-boring-badge="working"
+            className="inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
+          >
+            <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--accent)]" />
+            working
+          </span>
+        ) : time ? (
+          <span
+            data-boring-workspace-part="session-age"
             className={cn(
-              "ml-1.5 tabular-nums text-[11px]",
+              "shrink-0 tabular-nums text-[11px]",
               active ? "text-[color:var(--accent)]" : "text-muted-foreground/60",
             )}
           >
             {time}
           </span>
-        )}
-      </span>
-      {attentionBadge ? (
-        <span
-          data-boring-workspace-part="session-badge"
-          data-boring-badge={attentionBadge.kind}
-          className={cn("inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none", sessionBadgeToneClassName(attentionBadge.tone))}
-        >
-          <span aria-hidden="true" className={cn("h-1.5 w-1.5 animate-pulse rounded-full", sessionBadgeDotClassName(attentionBadge.tone))} />
-          {attentionBadge.label}
-        </span>
-      ) : working ? (
-        <span
-          data-boring-workspace-part="session-badge"
-          data-boring-badge="working"
-          className="inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
-        >
-          <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--accent)]" />
-          working
-        </span>
-      ) : null}
-      {onTogglePin && (
-        <ControlTooltip label={pinned ? "Unpin session" : "Pin session"}>
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            data-boring-workspace-part="session-pin-toggle"
-            data-boring-state={pinned ? "pinned" : undefined}
+        ) : null}
+        {onTogglePin ? (
+          <span
+            data-boring-workspace-part="session-pin-action"
             className={cn(
-              "shrink-0 focus-visible:opacity-100 group-hover:opacity-100",
-              // A pinned session keeps its pin lit so the state is legible;
-              // unpinned rows reveal the affordance on hover like the others.
-              pinned
-                ? "text-[color:var(--accent)] opacity-100 hover:text-[color:var(--accent)]"
-                : "text-muted-foreground/70 opacity-0 hover:text-foreground",
+              "flex w-0 shrink-0 items-center overflow-hidden opacity-0 transition-[width,opacity,margin] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] group-hover:w-auto group-hover:opacity-100 focus-within:w-auto focus-within:opacity-100",
+              hasSessionStatus && "group-hover:ml-1.5 focus-within:ml-1.5",
+              pinned && cn("w-auto opacity-100", hasSessionStatus && "ml-1.5"),
             )}
-            onClick={(e) => {
-              e.stopPropagation()
-              onTogglePin(session.id)
-            }}
-            aria-label={pinned ? `Unpin ${session.title || "session"}` : `Pin ${session.title || "session"}`}
-            aria-pressed={pinned}
           >
-            <Pin className={cn("h-3.5 w-3.5", pinned && "fill-current")} strokeWidth={1.75} />
-          </IconButton>
-        </ControlTooltip>
-      )}
-      {onOpenAsTab && (
-        <ControlTooltip label="Open in chat pane">
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="shrink-0 text-muted-foreground/70 opacity-0 hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
-            onClick={(e) => {
-              e.stopPropagation()
-              onOpenAsTab(session.id)
-            }}
-            aria-label={`Open ${session.title || "session"} in chat pane`}
-          >
-            <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} />
-          </IconButton>
-        </ControlTooltip>
-      )}
-      {onDelete && (
-        <ControlTooltip label="Delete session">
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            className="shrink-0 text-muted-foreground opacity-0 hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
-            onClick={(e) => {
-              e.stopPropagation()
-              onDelete(session.id)
-            }}
-            aria-label={`Delete ${session.title || "session"}`}
-          >
-            <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-              <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" />
-            </svg>
-          </IconButton>
-        </ControlTooltip>
-      )}
+            <ControlTooltip label={pinned ? "Unpin session" : "Pin session"}>
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                data-boring-workspace-part="session-pin-toggle"
+                data-boring-state={pinned ? "pinned" : undefined}
+                className={cn(
+                  "shrink-0 focus-visible:opacity-100",
+                  pinned
+                    ? "text-[color:var(--accent)] hover:text-[color:var(--accent)]"
+                    : "text-muted-foreground/70 hover:text-foreground",
+                )}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onTogglePin(session.id)
+                }}
+                aria-label={pinned ? `Unpin ${session.title || "session"}` : `Pin ${session.title || "session"}`}
+                aria-pressed={pinned}
+              >
+                <Pin className={cn("h-3.5 w-3.5", pinned && "fill-current")} strokeWidth={1.75} />
+              </IconButton>
+            </ControlTooltip>
+          </span>
+        ) : null}
+        <span
+          data-boring-workspace-part="session-actions"
+          className={cn(
+            "flex w-0 shrink-0 items-center gap-1 overflow-hidden opacity-0 transition-[width,opacity,margin] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] group-hover:w-auto group-hover:opacity-100 focus-within:w-auto focus-within:opacity-100",
+            (hasSessionStatus || onTogglePin) && "group-hover:ml-1 focus-within:ml-1",
+          )}
+        >
+          {onOpenAsTab && (
+            <ControlTooltip label="Open in chat pane">
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="shrink-0 text-muted-foreground/70 hover:text-foreground focus-visible:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onOpenAsTab(session.id)
+                }}
+                aria-label={`Open ${session.title || "session"} in chat pane`}
+              >
+                <ExternalLink className="h-3.5 w-3.5" strokeWidth={1.75} />
+              </IconButton>
+            </ControlTooltip>
+          )}
+          {onDelete && (
+            <ControlTooltip label="Delete session">
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                className="shrink-0 text-muted-foreground hover:text-destructive focus-visible:opacity-100"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onDelete(session.id)
+                }}
+                aria-label={`Delete ${session.title || "session"}`}
+              >
+                <svg width="12" height="12" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                  <path d="M3.5 3.5l7 7M10.5 3.5l-7 7" />
+                </svg>
+              </IconButton>
+            </ControlTooltip>
+          )}
+        </span>
+      </span>
     </li>
   )
 }

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -377,7 +377,9 @@ export function ChatLayout(props: ChatLayoutProps) {
         className={cn(
           "relative h-full min-h-0 shrink-0 overflow-hidden bg-background",
           "transition-[width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
-          navOpen && "border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
+          navOpen
+            ? "z-30 border-r border-[color:oklch(from_var(--border)_l_c_h/0.6)]"
+            : "pointer-events-none z-0",
         )}
         style={{
           width: navOpen ? effectiveNavWidth : 0,
@@ -390,7 +392,7 @@ export function ChatLayout(props: ChatLayoutProps) {
           className={cn(
             "h-full min-h-0 overflow-hidden",
             "transition-opacity duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
-            navOpen ? "opacity-100" : "opacity-0",
+            navOpen ? "opacity-100" : "invisible pointer-events-none opacity-0",
           )}
         >
           <PanelSlot id={navId} params={props.navParams} />

--- a/packages/workspace/src/front/layout/chat-pane-stage.css
+++ b/packages/workspace/src/front/layout/chat-pane-stage.css
@@ -19,6 +19,9 @@
    the stage root (.dv-shell.dv-chat-stage) out-specifies the workbench
    rules; the header must read as part of the pane, not a tab strip. */
 .dv-shell.dv-chat-stage .dv-tabs-and-actions-container {
+  height: var(--dv-tabs-and-actions-container-height);
+  box-sizing: border-box;
+  flex-shrink: 0;
   border-bottom: none;
   padding: 0;
   gap: 0;
@@ -26,9 +29,16 @@
 }
 
 /* dockview's fullwidth single-tab rules stop at the scroll wrapper; carry
-   the full width down to the tab itself. */
+   the full width and height down to the tab itself. */
+.dv-shell.dv-chat-stage .dv-tabs-and-actions-container.dv-single-tab .dv-scrollable,
+.dv-shell.dv-chat-stage .dv-tabs-and-actions-container.dv-single-tab .dv-tabs-container,
+.dv-shell.dv-chat-stage .dv-tabs-and-actions-container.dv-single-tab .dv-react-part {
+  height: 100%;
+}
+
 .dv-shell.dv-chat-stage .dv-tabs-and-actions-container.dv-single-tab .dv-tabs-container {
   width: 100%;
+  align-items: stretch;
 }
 
 .dv-shell.dv-chat-stage .dv-tab,

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -75,6 +75,7 @@ export interface AppLeftPaneProps {
   onSwitchSession: (id: string) => void
   onOpenSessionAsPane: (id: string) => void
   onToggleSessionPinned: (id: string) => void
+  onDeleteSession?: (id: string) => void
   /** Primary app-left actions supplied by the host/app/plugin shell after New chat/Search. */
   actions?: readonly AppLeftPaneAction[]
   /**
@@ -112,6 +113,7 @@ export function AppLeftPane({
   onSwitchSession,
   onOpenSessionAsPane,
   onToggleSessionPinned,
+  onDeleteSession,
   actions = [],
   layoutMode = "single-project",
 }: AppLeftPaneProps) {
@@ -192,6 +194,7 @@ export function AppLeftPane({
         onSwitch={isActiveProjectSession ? onSwitchSession : () => onOpenProjectSession?.(projectId, session.id)}
         onOpenAsPane={isActiveProjectSession ? onOpenSessionAsPane : () => onOpenProjectSession?.(projectId, session.id)}
         onTogglePinned={onToggleSessionPinned}
+        onDelete={isActiveProjectSession ? onDeleteSession : undefined}
       />
     )
   }

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Clock3, MessageSquarePlus, Pin } from "lucide-react"
+import { Clock3, MessageSquarePlus, Pin, X } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { CHAT_SESSION_DRAG_TYPE } from "../ChatPaneStage"
 import type { AppLeftPaneSession } from "./AppLeftPane"
@@ -16,6 +16,7 @@ export function AppSessionRow({
   onSwitch,
   onOpenAsPane,
   onTogglePinned,
+  onDelete,
 }: {
   session: AppLeftPaneSession
   state: AppSessionRowState
@@ -27,6 +28,7 @@ export function AppSessionRow({
   onSwitch: (id: string) => void
   onOpenAsPane: (id: string) => void
   onTogglePinned: (id: string) => void
+  onDelete?: (id: string) => void
 }) {
   const title = session.title || "Untitled"
   const activate = () => {
@@ -74,8 +76,14 @@ export function AppSessionRow({
       >
         {title}
       </button>
-      <span className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100">
-        {canPin ? (
+      {canPin ? (
+        <span
+          data-boring-workspace-part="app-session-pin-action"
+          className={cn(
+            "flex w-0 shrink-0 items-center overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100",
+            pinned && "ml-1 w-auto opacity-100",
+          )}
+        >
           <button
             type="button"
             aria-label={pinned ? `Unpin ${title}` : `Pin ${title}`}
@@ -89,22 +97,40 @@ export function AppSessionRow({
           >
             <Pin className={cn("h-3.5 w-3.5", pinned && "fill-current")} strokeWidth={1.75} />
           </button>
-        ) : null}
-        {/* "Open in new chat pane" only for closed, same-project sessions —
-            it's pointless once open, and a cross-project session can't share
-            this workspace's split stage. */}
-        {state === "normal" && canSplit ? (
-          <button
-            type="button"
-            aria-label={`Open ${title} in new chat pane`}
-            title="Open in new chat pane"
-            onClick={() => onOpenAsPane(session.id)}
-            className="grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-          >
-            <MessageSquarePlus className="h-3.5 w-3.5" strokeWidth={1.75} />
-          </button>
-        ) : null}
-      </span>
+        </span>
+      ) : null}
+      {/* "Open in new chat pane" only for closed, same-project sessions —
+          it's pointless once open, and a cross-project session can't share
+          this workspace's split stage. */}
+      {(state === "normal" && canSplit) || onDelete ? (
+        <span
+          data-boring-workspace-part="app-session-actions"
+          className="flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100"
+        >
+          {state === "normal" && canSplit ? (
+            <button
+              type="button"
+              aria-label={`Open ${title} in new chat pane`}
+              title="Open in new chat pane"
+              onClick={() => onOpenAsPane(session.id)}
+              className="grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            >
+              <MessageSquarePlus className="h-3.5 w-3.5" strokeWidth={1.75} />
+            </button>
+          ) : null}
+          {onDelete ? (
+            <button
+              type="button"
+              aria-label={`Delete ${title}`}
+              title="Delete"
+              onClick={() => onDelete(session.id)}
+              className="grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            >
+              <X className="h-3.5 w-3.5" strokeWidth={1.75} />
+            </button>
+          ) : null}
+        </span>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- create a real replacement before deleting the last authoritative remote session
- wire left-explorer delete through pane cleanup and expose it only when deletion is backed
- tighten session row hover/action layout in classic and plugin-tabs shells
- run playground on plugin-tabs layout with `New chat` default session titles

## Proof
- `pnpm --filter @hachej/boring-workspace typecheck`
- `TMPDIR=/home/ubuntu/tmp-playwright pnpm --filter @hachej/boring-workspace exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx` (54 passed)
- autoreview clean after fixes
