### PR TITLE
mcp-integration: Add thermo cleanup coverage

### DIFF
--- a/apps/full-app/src/server/__tests__/boringMcp.test.ts
+++ b/apps/full-app/src/server/__tests__/boringMcp.test.ts
@@ -9,6 +9,7 @@ import {
   createBoringMcpSourceHandlers,
   type McpActor,
   type McpSource,
+  type ManagedConnectorConfig,
   type ManagedConnectorProvider,
   type ManagedConnectorSourceRegistry,
   type McpSourceRegistry,
@@ -93,6 +94,16 @@ describe('full-app boring-mcp binding', () => {
       maxReadonlyInputBytes: 1234,
     })
     expect(readTree(join(process.cwd(), 'src/front'))).not.toContain('COMPOSIO_API_KEY')
+  })
+
+  it('derives supported managed connector providers from connector configs', async () => {
+    const configs: readonly ManagedConnectorConfig[] = [
+      { provider: 'custom-provider', displayName: 'Custom Provider', toolkitId: 'custom-toolkit' },
+    ]
+    const resolver = createFullAppManagedConnectorSecretResolver({ COMPOSIO_API_KEY: 'cmp_test_secret' } as NodeJS.ProcessEnv, configs)
+
+    await expect(resolver.resolveSecret('custom-provider')).resolves.toEqual({ storage: 'server-env', value: 'cmp_test_secret' })
+    await expect(resolver.resolveSecret('notion')).rejects.toThrow('Unsupported MCP provider: notion')
   })
 
   it('falls back to the default input limit for unsafe configured values', () => {

--- a/plugins/boring-mcp/src/__tests__/shared.test.ts
+++ b/plugins/boring-mcp/src/__tests__/shared.test.ts
@@ -8,6 +8,7 @@ import {
   assertMcpToolAllowed,
   classifyMcpTool,
   containsMcpSecret,
+  containsMcpSecretOrCanary,
   doctorMcpSource,
   redactMcpSecrets,
   type McpActor,
@@ -58,6 +59,13 @@ describe("boring-mcp shared policy", () => {
       authorization: "[REDACTED_MCP_SECRET]",
       nested: { text: "[REDACTED_MCP_SECRET] and [REDACTED_MCP_SECRET] and [REDACTED_MCP_SECRET]" },
     })
+  })
+
+  it("detects MCP secrets or seeded redaction canaries through the shared guard", () => {
+    expect(containsMcpSecretOrCanary({ nested: { value: "MCP_CANARY_DO_NOT_LEAK" } }, ["MCP_CANARY_DO_NOT_LEAK", ""])).toBe(true)
+    expect(containsMcpSecretOrCanary({ "MCP_CANARY_DO_NOT_LEAK": "key hit" }, ["MCP_CANARY_DO_NOT_LEAK"])).toBe(true)
+    expect(containsMcpSecretOrCanary({ nested: { authorization: "Bearer abcdefghijklmnop" } }, ["MCP_CANARY_DO_NOT_LEAK"])).toBe(true)
+    expect(containsMcpSecretOrCanary({ nested: { value: "safe" } }, ["MCP_CANARY_DO_NOT_LEAK", ""])).toBe(false)
   })
 
   it("reports disconnected and unknown sources in doctor output", () => {


### PR DESCRIPTION
## Summary\n- add direct coverage for shared `containsMcpSecretOrCanary` across nested values, object keys, secret-like payloads, and clean values\n- add full-app coverage proving managed connector supported providers are derived from connector configs\n\n## Validation\n- `pnpm --filter @hachej/boring-mcp test -- src/__tests__/shared.test.ts` ✅\n- `pnpm --filter @hachej/boring-mcp typecheck` ✅\n- `pnpm --filter full-app test -- src/server/__tests__/boringMcp.test.ts` ✅\n- `pnpm --filter full-app typecheck` ✅\n- `pnpm lint:workspace-plugin-invariants` ✅\n- `git diff --check` ✅