### PR TITLE
#416 company-fs: add management binding lifecycle

### DIFF
--- a/packages/boring-bash/src/server/__tests__/managementCompanyContextOperations.test.ts
+++ b/packages/boring-bash/src/server/__tests__/managementCompanyContextOperations.test.ts
@@ -1,0 +1,270 @@
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, test } from "vitest";
+
+import type { BoundFilesystemContext, FilesystemBinding, FilesystemBindingResolver } from "../../shared/index";
+import type { CompanyContextFixturePreparedHandle, FilesystemRuntimeLifecycleEvent } from "../index";
+import {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  COMPANY_CONTEXT_SENTINEL,
+  FixtureCompanyContextBindingProvider,
+  ScopedFilesystemRuntimeBindingManager,
+  createManagementProjectionOperations,
+  createReadonlyProjectionOperations,
+  seedCompanyContextFixture,
+} from "../index";
+
+const readonlyBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readonly",
+  mountPath: "/company_context",
+  projection: "policy-filtered",
+};
+
+const managementBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readwrite",
+  mountPath: "/company_context",
+  projection: "management",
+};
+
+const normalCtx: BoundFilesystemContext = {
+  humanUserId: "human-1",
+  agentId: "agent-normal",
+  sessionId: "session-normal",
+  workspaceId: "workspace-1",
+  requestId: "runtime-normal",
+};
+
+const managementCtx: BoundFilesystemContext = {
+  humanUserId: "human-1",
+  agentId: "agent-management",
+  sessionId: "session-management",
+  workspaceId: "workspace-1",
+  requestId: "runtime-management",
+};
+
+function logManagementE2e(event: {
+  readonly profile: "normal" | "management";
+  readonly sessionId: string;
+  readonly requestId: string;
+  readonly bindings: readonly string[];
+  readonly preparedLabels?: readonly string[];
+  readonly operation: string;
+  readonly result: string;
+}): void {
+  console.info(
+    "[company-fs-management-e2e] profile=%s session=%s request=%s bindings=%j prepared=%j op=%s result=%s sentinelScan=absent",
+    event.profile,
+    event.sessionId,
+    event.requestId,
+    event.bindings,
+    event.preparedLabels ?? [],
+    event.operation,
+    event.result,
+  );
+}
+
+describe("management company_context operations", () => {
+  test("management write/edit updates provider state visible to later readonly projections without exposing denied content", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-source-"));
+    await seedCompanyContextFixture(sourceRoot);
+
+    let grantManagementBinding = true;
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: (ctx) => ({
+        allowedPathPrefixes: ctx.requestId === managementCtx.requestId ? ["/company"] : ["/company/hr"],
+        grantManagementBinding: ctx.requestId === managementCtx.requestId && grantManagementBinding,
+      }),
+    });
+    const resolver: FilesystemBindingResolver = {
+      resolveBindings: async (ctx) => (
+        ctx.requestId === managementCtx.requestId && grantManagementBinding ? [managementBinding] : [readonlyBinding]
+      ),
+    };
+    const lifecycleEvents: FilesystemRuntimeLifecycleEvent[] = [];
+    const manager = new ScopedFilesystemRuntimeBindingManager({
+      resolver,
+      providers: { [COMPANY_CONTEXT_FILESYSTEM_ID]: provider },
+      onLifecycleEvent: (event) => lifecycleEvents.push(event),
+    });
+
+    const managementPlan = await manager.prepareRuntime(managementCtx);
+    logManagementE2e({
+      profile: "management",
+      sessionId: managementCtx.sessionId,
+      requestId: managementCtx.requestId,
+      bindings: managementPlan.bindings.map((binding) => `${binding.binding.filesystem}:${binding.binding.access}:${binding.binding.projection}`),
+      preparedLabels: managementPlan.bindings.map((binding) => binding.preparedLabel),
+      operation: "prepare",
+      result: "readwrite-management-granted",
+    });
+    const managementHandle = managementPlan.bindings[0].handle as CompanyContextFixturePreparedHandle;
+    const managementOps = createManagementProjectionOperations(managementHandle);
+
+    await managementOps.write(
+      { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/managed.md" },
+      "# Managed\nVisible to HR readers.\n",
+    );
+    await managementOps.edit(
+      { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/policy.md" },
+      "Vacation",
+      "Vacation, sick leave, and parental leave",
+    );
+    await managementOps.write(
+      { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/finance/new-secret.md" },
+      `# Finance secret\n${COMPANY_CONTEXT_SENTINEL}\n`,
+    );
+    logManagementE2e({
+      profile: "management",
+      sessionId: managementCtx.sessionId,
+      requestId: managementCtx.requestId,
+      bindings: ["company_context:readwrite:management"],
+      preparedLabels: managementPlan.bindings.map((binding) => binding.preparedLabel),
+      operation: "write-edit",
+      result: "provider-state-updated-denied-content-redacted",
+    });
+
+    const readonlyPlan = await manager.prepareRuntime(normalCtx);
+    logManagementE2e({
+      profile: "normal",
+      sessionId: normalCtx.sessionId,
+      requestId: normalCtx.requestId,
+      bindings: readonlyPlan.bindings.map((binding) => `${binding.binding.filesystem}:${binding.binding.access}:${binding.binding.projection}`),
+      preparedLabels: readonlyPlan.bindings.map((binding) => binding.preparedLabel),
+      operation: "prepare-readonly-after-management-write",
+      result: "readonly-policy-filtered",
+    });
+    const readonlyOps = createReadonlyProjectionOperations(readonlyPlan.bindings[0].handle as CompanyContextFixturePreparedHandle);
+
+    await expect(readonlyOps.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/managed.md" }))
+      .resolves.toMatchObject({ content: expect.stringContaining("Visible to HR readers") });
+    await expect(readonlyOps.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/policy.md" }))
+      .resolves.toMatchObject({ content: expect.stringContaining("parental leave") });
+    await expect(readonlyOps.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/finance/new-secret.md" }))
+      .rejects.toMatchObject({ metadata: { path: "not_found_or_denied" } });
+
+    const visibleGrep = await readonlyOps.grep({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company" }, COMPANY_CONTEXT_SENTINEL);
+    expect(visibleGrep.matches).toEqual([]);
+
+    await manager.invalidate(managementCtx, COMPANY_CONTEXT_FILESYSTEM_ID);
+    expect(manager.getPreparedBinding(managementCtx, { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, access: "readwrite", projection: "management" }))
+      .toBeUndefined();
+    await expect(managementOps.write(
+      { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/stale.md" },
+      "stale write should fail",
+    )).rejects.toThrow("management binding is no longer active");
+    logManagementE2e({
+      profile: "management",
+      sessionId: managementCtx.sessionId,
+      requestId: managementCtx.requestId,
+      bindings: ["company_context:readwrite:management"],
+      preparedLabels: managementPlan.bindings.map((binding) => binding.preparedLabel),
+      operation: "invalidate-stale-write",
+      result: "stale-management-handle-rejected",
+    });
+    grantManagementBinding = false;
+    const afterRevocation = await manager.prepareRuntime(managementCtx);
+    logManagementE2e({
+      profile: "management",
+      sessionId: managementCtx.sessionId,
+      requestId: managementCtx.requestId,
+      bindings: afterRevocation.bindings.map((binding) => `${binding.binding.filesystem}:${binding.binding.access}:${binding.binding.projection}`),
+      preparedLabels: afterRevocation.bindings.map((binding) => binding.preparedLabel),
+      operation: "prepare-after-grant-removal",
+      result: "management-not-granted",
+    });
+    expect(afterRevocation.bindings[0].binding).toEqual(readonlyBinding);
+    expect(manager.getPreparedBinding(managementCtx, { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, access: "readwrite", projection: "management" }))
+      .toBeUndefined();
+
+    expect(lifecycleEvents.map((event) => event.type)).toEqual([
+      "prepare",
+      "prepare",
+      "invalidate",
+      "prepare",
+    ]);
+    expect(lifecycleEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        type: "prepare",
+        context: managementCtx,
+        bindings: ["company_context:readwrite:management"],
+        preparedLabels: [managementPlan.bindings[0].preparedLabel],
+      }),
+      expect.objectContaining({
+        type: "invalidate",
+        context: managementCtx,
+        bindings: ["company_context:readwrite:management"],
+        preparedLabels: [managementPlan.bindings[0].preparedLabel],
+      }),
+    ]));
+    const serializedEvents = JSON.stringify(lifecycleEvents);
+    expect(serializedEvents).not.toContain(COMPANY_CONTEXT_SENTINEL);
+    expect(serializedEvents).not.toContain("new-secret.md");
+  });
+
+  test("non-granted management profile fails through the runtime/provider path", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-source-"));
+    await seedCompanyContextFixture(sourceRoot);
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr"], grantManagementBinding: false }),
+    });
+    const lifecycleEvents: FilesystemRuntimeLifecycleEvent[] = [];
+    const manager = new ScopedFilesystemRuntimeBindingManager({
+      resolver: { resolveBindings: async () => [managementBinding] },
+      providers: { [COMPANY_CONTEXT_FILESYSTEM_ID]: provider },
+      onLifecycleEvent: (event) => lifecycleEvents.push(event),
+    });
+
+    await expect(manager.prepareRuntime(managementCtx)).rejects.toThrow("policy did not grant readwrite management binding");
+    expect(manager.getPreparedBinding(managementCtx, { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, access: "readwrite", projection: "management" }))
+      .toBeUndefined();
+    expect(lifecycleEvents).toEqual([
+      expect.objectContaining({
+        type: "prepare-error",
+        context: managementCtx,
+        bindings: ["company_context:readwrite:management"],
+        preparedLabels: [],
+      }),
+    ]);
+  });
+
+  test("management projection operations reject symlink escapes", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-source-"));
+    const outsideRoot = await mkdtemp(join(tmpdir(), "boring-company-outside-"));
+    await seedCompanyContextFixture(sourceRoot);
+    await mkdir(join(sourceRoot, "company", "hr"), { recursive: true });
+    await writeFile(join(outsideRoot, "secret.md"), "outside secret", "utf8");
+
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: () => ({ allowedPathPrefixes: ["/company"], grantManagementBinding: true }),
+    });
+    const prepared = await provider.prepareBinding(managementCtx, managementBinding);
+    await symlink(join(outsideRoot, "secret.md"), join(sourceRoot, "company", "hr", "escape.md"));
+    const managementOps = createManagementProjectionOperations(prepared.handle);
+
+    await expect(managementOps.read({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/escape.md" }))
+      .rejects.toThrow("path escapes management projection root");
+    await expect(managementOps.write({ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, path: "/company/hr/escape.md" }, "mutated"))
+      .rejects.toThrow("path escapes management projection root");
+    await expect(readFile(join(outsideRoot, "secret.md"), "utf8")).resolves.toBe("outside secret");
+  });
+
+  test("management operations require a readwrite management handle", async () => {
+    const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-source-"));
+    await seedCompanyContextFixture(sourceRoot);
+    const provider = new FixtureCompanyContextBindingProvider({
+      sourceRoot,
+      resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr"] }),
+    });
+
+    const readonlyPrepared = await provider.prepareBinding(normalCtx, readonlyBinding);
+    expect(() => createManagementProjectionOperations(readonlyPrepared.handle))
+      .toThrow("requires a readwrite management binding");
+  });
+});

--- a/packages/boring-bash/src/server/__tests__/runtimeBindingManager.test.ts
+++ b/packages/boring-bash/src/server/__tests__/runtimeBindingManager.test.ts
@@ -1,0 +1,150 @@
+import { mkdtemp } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { describe, expect, test, vi } from "vitest";
+
+import type {
+  BoundFilesystemContext,
+  FilesystemBinding,
+  FilesystemBindingProvider,
+  FilesystemBindingResolver,
+  PreparedFilesystemBinding,
+} from "../../shared/index";
+import {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  FixtureCompanyContextBindingProvider,
+  ScopedFilesystemRuntimeBindingManager,
+  filesystemRuntimeScopeKey,
+  seedCompanyContextFixture,
+} from "../index";
+
+const readonlyBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readonly",
+  mountPath: "/company_context",
+  projection: "policy-filtered",
+};
+
+const managementBinding: FilesystemBinding = {
+  filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+  access: "readwrite",
+  mountPath: "/company_context",
+  projection: "management",
+};
+
+const normalCtx: BoundFilesystemContext = {
+  humanUserId: "human-1",
+  agentId: "agent-normal",
+  sessionId: "session-normal",
+  workspaceId: "workspace-1",
+  requestId: "runtime-normal",
+};
+
+const managementCtx: BoundFilesystemContext = {
+  humanUserId: "human-1",
+  agentId: "agent-management",
+  sessionId: "session-management",
+  workspaceId: "workspace-1",
+  requestId: "runtime-management",
+};
+
+async function createProvider() {
+  const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-source-"));
+  await seedCompanyContextFixture(sourceRoot);
+  const fixtureProvider = new FixtureCompanyContextBindingProvider({
+    sourceRoot,
+    resolvePolicy: (ctx) => ({
+      allowedPathPrefixes: ctx.requestId === managementCtx.requestId ? ["/company"] : ["/company/hr"],
+      grantManagementBinding: ctx.requestId === managementCtx.requestId,
+    }),
+  });
+  const disposeBinding = vi.fn(async (_prepared: PreparedFilesystemBinding) => undefined);
+  const invalidateBinding = vi.fn<NonNullable<FilesystemBindingProvider["invalidateBinding"]>>(async () => undefined);
+  const provider: FilesystemBindingProvider = {
+    prepareBinding: (ctx, binding) => fixtureProvider.prepareBinding(ctx, binding),
+    disposeBinding,
+    invalidateBinding,
+  };
+  return { provider, disposeBinding, invalidateBinding };
+}
+
+describe("ScopedFilesystemRuntimeBindingManager", () => {
+  test("selects management by launching a management runtime profile, not upgrading normal runtime", async () => {
+    const { provider } = await createProvider();
+    const resolver: FilesystemBindingResolver = {
+      resolveBindings: async (ctx) => (ctx.requestId === managementCtx.requestId ? [managementBinding] : [readonlyBinding]),
+    };
+    const manager = new ScopedFilesystemRuntimeBindingManager({
+      resolver,
+      providers: { [COMPANY_CONTEXT_FILESYSTEM_ID]: provider },
+    });
+
+    const normalPlan = await manager.prepareRuntime(normalCtx);
+    const managementPlan = await manager.prepareRuntime(managementCtx);
+
+    expect(normalPlan.scopeKey).toBe(filesystemRuntimeScopeKey(normalCtx));
+    expect(managementPlan.scopeKey).toBe(filesystemRuntimeScopeKey(managementCtx));
+    expect(normalPlan.context).toEqual(normalCtx);
+    expect(managementPlan.context).toEqual(managementCtx);
+    expect(normalPlan.bindings).toHaveLength(1);
+    expect(managementPlan.bindings).toHaveLength(1);
+    expect(normalPlan.bindings[0].binding).toEqual(readonlyBinding);
+    expect(managementPlan.bindings[0].binding).toEqual(managementBinding);
+
+    expect(manager.getPreparedBinding(normalCtx, {
+      filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+      access: "readwrite",
+      projection: "management",
+    })).toBeUndefined();
+    expect(manager.getPreparedBinding(managementCtx, {
+      filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+      access: "readwrite",
+      projection: "management",
+    })).toBe(managementPlan.bindings[0]);
+  });
+
+  test("normal sessions cannot reuse management handles across scoped runtime keys", async () => {
+    const { provider } = await createProvider();
+    const resolver: FilesystemBindingResolver = {
+      resolveBindings: async (ctx) => (ctx.requestId === managementCtx.requestId ? [managementBinding] : [readonlyBinding]),
+    };
+    const manager = new ScopedFilesystemRuntimeBindingManager({
+      resolver,
+      providers: { [COMPANY_CONTEXT_FILESYSTEM_ID]: provider },
+    });
+
+    await manager.prepareRuntime(managementCtx);
+    const spoofedNormalCtx = { ...managementCtx, requestId: normalCtx.requestId };
+
+    expect(filesystemRuntimeScopeKey(spoofedNormalCtx)).not.toBe(filesystemRuntimeScopeKey(managementCtx));
+    expect(manager.getPreparedBinding(spoofedNormalCtx, {
+      filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
+      access: "readwrite",
+      projection: "management",
+    })).toBeUndefined();
+  });
+
+  test("dispose and invalidate remove scoped prepared access", async () => {
+    const { provider, disposeBinding, invalidateBinding } = await createProvider();
+    const resolver: FilesystemBindingResolver = { resolveBindings: async () => [managementBinding] };
+    const manager = new ScopedFilesystemRuntimeBindingManager({
+      resolver,
+      providers: { [COMPANY_CONTEXT_FILESYSTEM_ID]: provider },
+    });
+
+    await manager.prepareRuntime(managementCtx);
+    expect(manager.getPreparedBinding(managementCtx, { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID })).toBeDefined();
+
+    await manager.invalidate(managementCtx, COMPANY_CONTEXT_FILESYSTEM_ID);
+    expect(manager.getPreparedBinding(managementCtx, { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID })).toBeUndefined();
+    expect(disposeBinding).toHaveBeenCalledTimes(1);
+    expect(invalidateBinding).toHaveBeenCalledWith(managementCtx, COMPANY_CONTEXT_FILESYSTEM_ID);
+
+    await manager.prepareRuntime(managementCtx);
+    expect(manager.getPreparedBinding(managementCtx, { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID })).toBeDefined();
+    await manager.disposeRuntime(managementCtx);
+    expect(manager.getPreparedBinding(managementCtx, { filesystem: COMPANY_CONTEXT_FILESYSTEM_ID })).toBeUndefined();
+    expect(disposeBinding).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/boring-bash/src/server/index.ts
+++ b/packages/boring-bash/src/server/index.ts
@@ -9,6 +9,13 @@ export {
 } from "./testing/companyContextFixtureProvider";
 
 export {
+  MANAGEMENT_PROJECTION_BINDING_REQUIRED_CODE,
+  MANAGEMENT_PROJECTION_INVALID_PATH_CODE,
+  ManagementProjectionOperationError,
+  createManagementProjectionOperations,
+} from "./managementProjectionOperations";
+
+export {
   READONLY_PROJECTION_BINDING_NOT_FOUND_CODE,
   READONLY_PROJECTION_INVALID_PATH_CODE,
   READONLY_PROJECTION_MUTATION_CODE,
@@ -16,7 +23,10 @@ export {
   createReadonlyProjectionOperations,
 } from "./readonlyProjectionOperations";
 
-export { checkReadonlyProjectionConformance } from "./testing/readonlyProjectionConformance";
+export type {
+  ManagementProjectionOperationMetadata,
+  ManagementProjectionOperations,
+} from "./managementProjectionOperations";
 
 export type {
   ReadonlyProjectionOperationMetadata,
@@ -32,6 +42,21 @@ export type {
   CompanyContextFixtureProjectionPolicy,
   CompanyContextFixtureProviderOptions,
 } from "./testing/companyContextFixtureProvider";
+
+export {
+  ScopedFilesystemRuntimeBindingManager,
+  filesystemRuntimeScopeKey,
+} from "./runtimeBindingManager";
+
+export { checkReadonlyProjectionConformance } from "./testing/readonlyProjectionConformance";
+
+export type {
+  FilesystemRuntimeLifecycleEvent,
+  PreparedBindingSelector,
+  ScopedFilesystemRuntimeBindingManagerOptions,
+  ScopedPreparedFilesystemBinding,
+  ScopedRuntimeBindingPlan,
+} from "./runtimeBindingManager";
 
 export type {
   ReadonlyProjectionConformanceResult,

--- a/packages/boring-bash/src/server/managementProjectionOperations.ts
+++ b/packages/boring-bash/src/server/managementProjectionOperations.ts
@@ -1,0 +1,174 @@
+import { lstat, mkdir, readFile, readdir, realpath, stat, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+
+import type { FilesystemId } from "../shared/index";
+import type { FilesystemPathDescriptor } from "./readonlyProjectionOperations";
+
+export const MANAGEMENT_PROJECTION_BINDING_REQUIRED_CODE = "MANAGEMENT_PROJECTION_BINDING_REQUIRED";
+export const MANAGEMENT_PROJECTION_INVALID_PATH_CODE = "MANAGEMENT_PROJECTION_INVALID_PATH";
+
+export interface ManagementProjectionOperationMetadata {
+  readonly filesystem: FilesystemId;
+  readonly path: string;
+  readonly operation: string;
+}
+
+export class ManagementProjectionOperationError extends Error {
+  readonly code: string;
+  readonly metadata: ManagementProjectionOperationMetadata;
+
+  constructor(code: string, message: string, metadata: ManagementProjectionOperationMetadata) {
+    super(message);
+    this.name = "ManagementProjectionOperationError";
+    this.code = code;
+    this.metadata = metadata;
+  }
+}
+
+
+export interface ManagementProjectionHandle {
+  readonly filesystem: FilesystemId;
+  readonly projectionRoot: string;
+  readonly access?: "readonly" | "readwrite";
+  readonly projection?: "policy-filtered" | "management";
+  readonly lifecycle?: { readonly active: boolean };
+}
+
+export interface ManagementProjectionOperations {
+  read(descriptor: FilesystemPathDescriptor): Promise<{ content: string; metadata: ManagementProjectionOperationMetadata }>;
+  list(descriptor: FilesystemPathDescriptor): Promise<{ entries: string[]; metadata: ManagementProjectionOperationMetadata }>;
+  write(descriptor: FilesystemPathDescriptor, content: string): Promise<{ metadata: ManagementProjectionOperationMetadata }>;
+  edit(descriptor: FilesystemPathDescriptor, oldText: string, newText: string): Promise<{ metadata: ManagementProjectionOperationMetadata }>;
+}
+
+function normalizeProjectionPath(path: string): string {
+  const normalized = path.replace(/\\/g, "/");
+  if (normalized.includes("\0")) throw new Error("null byte in projection path");
+  if (normalized.includes(":/")) throw new Error("filesystem prefixes are not valid path strings");
+  if (normalized === "") return "/";
+  const withRoot = normalized.startsWith("/") ? normalized : `/${normalized}`;
+  const parts = withRoot.split("/").filter(Boolean);
+  if (parts.some((part) => part === ".." || part === ".")) throw new Error("path traversal is not allowed");
+  return `/${parts.join("/")}`;
+}
+
+function assertManagementHandle(handle: ManagementProjectionHandle): void {
+  if (handle.access !== "readwrite" || handle.projection !== "management") {
+    throw new ManagementProjectionOperationError(
+      MANAGEMENT_PROJECTION_BINDING_REQUIRED_CODE,
+      "management operation requires a readwrite management binding",
+      { filesystem: handle.filesystem, path: "management_binding_required", operation: "bind" },
+    );
+  }
+  if (handle.lifecycle?.active === false) {
+    throw new ManagementProjectionOperationError(
+      MANAGEMENT_PROJECTION_BINDING_REQUIRED_CODE,
+      "management binding is no longer active",
+      { filesystem: handle.filesystem, path: "management_binding_inactive", operation: "bind" },
+    );
+  }
+}
+
+function assertProjectionDescriptor(
+  descriptor: FilesystemPathDescriptor,
+  operation: string,
+  expectedFilesystem: FilesystemId,
+): ManagementProjectionOperationMetadata {
+  if (descriptor.filesystem !== expectedFilesystem) {
+    throw new ManagementProjectionOperationError(
+      MANAGEMENT_PROJECTION_BINDING_REQUIRED_CODE,
+      `No management binding for filesystem ${descriptor.filesystem}`,
+      { filesystem: descriptor.filesystem, path: descriptor.path, operation },
+    );
+  }
+  try {
+    return { filesystem: descriptor.filesystem, path: normalizeProjectionPath(descriptor.path), operation };
+  } catch (err) {
+    throw new ManagementProjectionOperationError(
+      MANAGEMENT_PROJECTION_INVALID_PATH_CODE,
+      (err as Error).message,
+      { filesystem: descriptor.filesystem, path: "invalid_path", operation },
+    );
+  }
+}
+
+function managementPath(handle: ManagementProjectionHandle, path: string): string {
+  const normalized = normalizeProjectionPath(path);
+  return join(handle.projectionRoot, ...normalized.slice(1).split("/"));
+}
+
+function assertRelativeInsideRoot(root: string, candidate: string): void {
+  const rel = relative(root, candidate);
+  if (rel.startsWith("..") || isAbsolute(rel)) throw new Error("path escapes management projection root");
+}
+
+async function assertExistingPathInsideManagementRoot(handle: ManagementProjectionHandle, candidate: string): Promise<void> {
+  const root = await realpath(handle.projectionRoot);
+  assertRelativeInsideRoot(root, await realpath(candidate));
+}
+
+async function assertWritablePathInsideManagementRoot(handle: ManagementProjectionHandle, candidate: string): Promise<void> {
+  try {
+    await lstat(candidate);
+    await assertExistingPathInsideManagementRoot(handle, candidate);
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+
+  const root = await realpath(handle.projectionRoot);
+  assertRelativeInsideRoot(root, await realpath(dirname(candidate)));
+}
+
+async function walkFiles(root: string, current = root): Promise<string[]> {
+  const entries = await readdir(current, { withFileTypes: true });
+  const out: string[] = [];
+  for (const entry of entries) {
+    const absolutePath = join(current, entry.name);
+    if (entry.isDirectory()) out.push(...await walkFiles(root, absolutePath));
+    else if (entry.isFile()) out.push(absolutePath);
+  }
+  return out;
+}
+
+export function createManagementProjectionOperations(handle: ManagementProjectionHandle): ManagementProjectionOperations {
+  assertManagementHandle(handle);
+
+  return {
+    async read(descriptor) {
+      assertManagementHandle(handle);
+      const metadata = assertProjectionDescriptor(descriptor, "read", handle.filesystem);
+      const target = managementPath(handle, metadata.path);
+      await assertExistingPathInsideManagementRoot(handle, target);
+      return { content: await readFile(target, "utf8"), metadata };
+    },
+    async list(descriptor) {
+      assertManagementHandle(handle);
+      const metadata = assertProjectionDescriptor(descriptor, "list", handle.filesystem);
+      const target = managementPath(handle, metadata.path);
+      await assertExistingPathInsideManagementRoot(handle, target);
+      const rootStat = await stat(target);
+      const files = rootStat.isDirectory() ? await walkFiles(handle.projectionRoot, target) : [target];
+      return { entries: files.map((file) => `/${relative(handle.projectionRoot, file).split(sep).join("/")}`).sort(), metadata };
+    },
+    async write(descriptor, content) {
+      assertManagementHandle(handle);
+      const metadata = assertProjectionDescriptor(descriptor, "write", handle.filesystem);
+      const target = managementPath(handle, metadata.path);
+      await mkdir(dirname(target), { recursive: true });
+      await assertWritablePathInsideManagementRoot(handle, target);
+      await writeFile(target, content, "utf8");
+      return { metadata };
+    },
+    async edit(descriptor, oldText, newText) {
+      assertManagementHandle(handle);
+      const metadata = assertProjectionDescriptor(descriptor, "edit", handle.filesystem);
+      const target = managementPath(handle, metadata.path);
+      await assertExistingPathInsideManagementRoot(handle, target);
+      const content = await readFile(target, "utf8");
+      if (!content.includes(oldText)) throw new Error("oldText not found in management projection file");
+      await writeFile(target, content.replace(oldText, newText), "utf8");
+      return { metadata };
+    },
+  };
+}

--- a/packages/boring-bash/src/server/runtimeBindingManager.ts
+++ b/packages/boring-bash/src/server/runtimeBindingManager.ts
@@ -1,0 +1,161 @@
+import type {
+  BoundFilesystemContext,
+  FilesystemAccess,
+  FilesystemBinding,
+  FilesystemBindingProvider,
+  FilesystemBindingResolver,
+  FilesystemId,
+  FilesystemProjection,
+  PreparedFilesystemBinding,
+  RuntimeBindingPlan,
+} from "../shared/index";
+
+export interface FilesystemRuntimeLifecycleEvent {
+  readonly type: "prepare" | "prepare-error" | "dispose" | "invalidate";
+  readonly context: BoundFilesystemContext;
+  readonly bindings: readonly string[];
+  readonly preparedLabels: readonly string[];
+}
+
+export interface ScopedFilesystemRuntimeBindingManagerOptions {
+  readonly resolver: FilesystemBindingResolver;
+  readonly providers: Readonly<Record<string, FilesystemBindingProvider>>;
+  readonly onLifecycleEvent?: (event: FilesystemRuntimeLifecycleEvent) => void;
+}
+
+export interface PreparedBindingSelector {
+  readonly filesystem: FilesystemId;
+  readonly access?: FilesystemAccess;
+  readonly projection?: FilesystemProjection;
+}
+
+export interface ScopedPreparedFilesystemBinding extends PreparedFilesystemBinding {
+  readonly scopeKey: string;
+  readonly context: BoundFilesystemContext;
+  readonly preparedLabel: string;
+}
+
+export interface ScopedRuntimeBindingPlan extends RuntimeBindingPlan {
+  readonly scopeKey: string;
+  readonly context: BoundFilesystemContext;
+  readonly bindings: ScopedPreparedFilesystemBinding[];
+}
+
+export function filesystemRuntimeScopeKey(ctx: BoundFilesystemContext): string {
+  return [
+    ctx.humanUserId,
+    ctx.agentId,
+    ctx.sessionId,
+    ctx.workspaceId,
+    ctx.requestId,
+  ].join("\0");
+}
+
+function sameBinding(binding: FilesystemBinding, selector: PreparedBindingSelector): boolean {
+  return binding.filesystem === selector.filesystem
+    && (selector.access === undefined || binding.access === selector.access)
+    && (selector.projection === undefined || binding.projection === selector.projection);
+}
+
+export class ScopedFilesystemRuntimeBindingManager {
+  readonly #resolver: FilesystemBindingResolver;
+  readonly #providers: Readonly<Record<string, FilesystemBindingProvider>>;
+  readonly #onLifecycleEvent: ScopedFilesystemRuntimeBindingManagerOptions["onLifecycleEvent"];
+  readonly #plans = new Map<string, ScopedRuntimeBindingPlan>();
+  #nextPreparedLabel = 1;
+
+  constructor(options: ScopedFilesystemRuntimeBindingManagerOptions) {
+    this.#resolver = options.resolver;
+    this.#providers = options.providers;
+    this.#onLifecycleEvent = options.onLifecycleEvent;
+  }
+
+  async prepareRuntime(ctx: BoundFilesystemContext): Promise<ScopedRuntimeBindingPlan> {
+    const scopeKey = filesystemRuntimeScopeKey(ctx);
+    await this.disposeRuntime(ctx);
+
+    const bindings = await this.#resolver.resolveBindings(ctx);
+    const prepared: ScopedPreparedFilesystemBinding[] = [];
+    try {
+      for (const binding of bindings) {
+        const provider = this.#providers[String(binding.filesystem)];
+        if (!provider) throw new Error(`no filesystem binding provider for ${binding.filesystem}`);
+        const preparedBinding = await provider.prepareBinding(ctx, binding);
+        prepared.push({
+          ...preparedBinding,
+          scopeKey,
+          context: { ...ctx },
+          preparedLabel: `prepared-${this.#nextPreparedLabel++}`,
+        });
+      }
+    } catch (error) {
+      this.#emit("prepare-error", ctx, bindings, prepared);
+      await Promise.allSettled(prepared.map((binding) => this.#disposePrepared(binding)));
+      throw error;
+    }
+
+    const plan: ScopedRuntimeBindingPlan = { scopeKey, context: { ...ctx }, bindings: prepared };
+    this.#plans.set(scopeKey, plan);
+    this.#emit("prepare", ctx, bindings, prepared);
+    return plan;
+  }
+
+  getPreparedBinding(ctx: BoundFilesystemContext, selector: PreparedBindingSelector): ScopedPreparedFilesystemBinding | undefined {
+    const plan = this.#plans.get(filesystemRuntimeScopeKey(ctx));
+    return plan?.bindings.find((binding) => sameBinding(binding.binding, selector));
+  }
+
+  async disposeRuntime(ctx: BoundFilesystemContext): Promise<void> {
+    const scopeKey = filesystemRuntimeScopeKey(ctx);
+    const plan = this.#plans.get(scopeKey);
+    if (!plan) return;
+    this.#plans.delete(scopeKey);
+    await Promise.all(plan.bindings.map((binding) => this.#disposePrepared(binding)));
+    this.#emit("dispose", ctx, plan.bindings.map((binding) => binding.binding), plan.bindings);
+  }
+
+  async invalidate(ctx: BoundFilesystemContext, filesystem: FilesystemId): Promise<void> {
+    const scopeKey = filesystemRuntimeScopeKey(ctx);
+    const plan = this.#plans.get(scopeKey);
+    if (!plan) return;
+
+    const remaining: ScopedPreparedFilesystemBinding[] = [];
+    for (const binding of plan.bindings) {
+      if (binding.binding.filesystem === filesystem) {
+        await this.#disposePrepared(binding);
+      } else {
+        remaining.push(binding);
+      }
+    }
+
+    const provider = this.#providers[String(filesystem)];
+    await provider?.invalidateBinding?.(ctx, filesystem);
+
+    const invalidated = plan.bindings.filter((binding) => binding.binding.filesystem === filesystem);
+    if (remaining.length === 0) {
+      this.#plans.delete(scopeKey);
+    } else {
+      this.#plans.set(scopeKey, { ...plan, bindings: remaining });
+    }
+    this.#emit("invalidate", ctx, invalidated.map((binding) => binding.binding), invalidated);
+  }
+
+  #emit(
+    type: FilesystemRuntimeLifecycleEvent["type"],
+    ctx: BoundFilesystemContext,
+    bindings: readonly FilesystemBinding[],
+    prepared: readonly ScopedPreparedFilesystemBinding[],
+  ): void {
+    this.#onLifecycleEvent?.({
+      type,
+      context: { ...ctx },
+      bindings: bindings.map((binding) => `${binding.filesystem}:${binding.access}:${binding.projection}`),
+      preparedLabels: prepared.map((binding) => binding.preparedLabel),
+    });
+  }
+
+  async #disposePrepared(binding: ScopedPreparedFilesystemBinding): Promise<void> {
+    const provider = this.#providers[String(binding.binding.filesystem)];
+    await provider?.disposeBinding?.(binding);
+  }
+}


### PR DESCRIPTION
Stack continuation after #440. Adds generic management projection operations and scoped runtime binding manager for readwrite management bindings, while keeping company_context-specific code in fixture/tests.