### PR TITLE
#473 feat(workspace): expose composable left pane actions

### DIFF
--- a/docs/issues/473/reviews/claude-fable-review.md
+++ b/docs/issues/473/reviews/claude-fable-review.md
@@ -1,0 +1,17 @@
+# Issue #473 Claude Code fable review
+
+Reviewer: Claude Code `--model fable`
+Date: 2026-07-01
+
+## Final result
+
+CLEAN.
+
+## Notes
+
+Claude reviewed the complete final diff after two small follow-up fixes:
+
+- public hook defaults host composition to `railOnly: true` using `options.railOnly ?? true`, so re-clicking an active host action re-opens instead of toggling a hidden source pane;
+- accent/focus gating rationale was restored at the extracted model location.
+
+Remaining observations were non-blocking documentation/internal-naming notes.

--- a/docs/issues/473/reviews/implementation-review.md
+++ b/docs/issues/473/reviews/implementation-review.md
@@ -1,0 +1,15 @@
+# Issue #473 implementation review
+
+Result: CLEAN.
+
+- Public hook is narrow and returns action descriptors only.
+- Internal `useWorkbenchLeftPaneModel()` keeps source/panel details private to the left-pane implementation.
+- Host explorer test renders actions without `WorkbenchLeftPane` and verifies default-panel opening plus host re-click behavior.
+- `WorkbenchLeftPane` removes local registry/selection orchestration and delegates to the model hook.
+- Claude Code fable review result: CLEAN (`docs/issues/473/reviews/claude-fable-review.md`).
+
+## Proof
+
+- PASS: `pnpm --filter @hachej/boring-workspace exec vitest run src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx`
+- PASS: `git diff --check`
+- LOCAL TYPECHECK NOTE: `pnpm --filter @hachej/boring-workspace run typecheck` could not be trusted in the temporary worktree because it used the parent checkout's linked `node_modules` and failed on an unrelated `@hachej/boring-agent/front` export mismatch (`searchPiSessions`).

--- a/packages/workspace/docs/README.md
+++ b/packages/workspace/docs/README.md
@@ -34,6 +34,7 @@ the doc that matches your task.
 | Abstraction | Where | What it is |
 | --- | --- | --- |
 | `WorkspaceProvider` | `src/front/provider` | Root provider; boots plugins, layout, bridge. |
+| `useWorkspaceLeftPaneActions()` | `@hachej/boring-workspace` | Public hook for host apps that want to render workspace left-pane category buttons inside their own explorer/sidebar without mounting `WorkbenchLeftPane`. |
 | `definePlugin()` | `@hachej/boring-workspace/plugin` | Declarative front plugin: panels, commands, catalogs, bindings, providers, surfaceResolvers. |
 | `defineServerPlugin()` | `@hachej/boring-workspace/server` | Trusted boot-time server plugin: routes, agent tools, system prompt, Pi packages, provisioning. |
 | `PaneProps<T>` | `src/shared/types/panel.ts` | Props every panel/page component receives (`params`, `api`, `containerApi`). |
@@ -65,6 +66,34 @@ the doc that matches your task.
 - **Style isolation.** Workspace owns public `--boring-*` tokens and Tailwind base
   reset; agent consumes them under `[data-boring-agent]`. See
   [`docs/TAILWIND-V4-STYLE-ISOLATION.md`](../../../docs/TAILWIND-V4-STYLE-ISOLATION.md).
+
+## Host explorer composition
+
+Standalone workspaces can keep using `WorkbenchLeftPane`. Apps that already own a
+left explorer/sidebar can instead render the category actions themselves:
+
+```tsx
+import { useWorkspaceLeftPaneActions } from "@hachej/boring-workspace"
+
+function HostExplorer({ onOpenPanel, activePanelId }) {
+  const actions = useWorkspaceLeftPaneActions({ onOpenPanel, activePanelId })
+
+  return actions.map((action) => (
+    <button key={action.id} aria-pressed={action.active} onClick={action.select}>
+      {action.icon}
+      {action.title}
+    </button>
+  ))
+}
+```
+
+Pass `activePanelId` when the host also renders `workspace-page` panels and wants
+those launcher actions to show the focused page as active.
+
+Use this public hook rather than deep-importing chrome internals. Search UI,
+workspace-source content hosting, and plugin chrome action portals remain owned
+by the default `WorkbenchLeftPane` unless a host explicitly renders that full
+component.
 
 ## Docs
 

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -8,8 +8,6 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
-  type ReactNode,
 } from "react"
 import { PanelLeftClose, Search, X } from "lucide-react"
 import { IconButton, Input } from "@hachej/boring-ui-kit"
@@ -17,22 +15,18 @@ import { ControlTooltip } from "../../components/ControlTooltip"
 import { cn } from "../../lib/utils"
 import { PaneCollapseButton } from "../../layout/paneCollapseButton"
 import type { FileTreeBridge } from "../../bridge/types"
-import { useRegistry, useWorkspaceSourceRegistry } from "../../registry"
-import type { PanelConfig, WorkspaceSourceConfig } from "../../registry/types"
-import { isWorkspacePagePlacement } from "../../../shared/types/panel"
+import { useWorkspaceSourceRegistry } from "../../registry"
+import type { WorkspaceSourceConfig } from "../../registry/types"
 import type { LeftTabParams } from "../../../shared/plugins/types"
 import { PluginErrorBoundary } from "../../plugin/PluginErrorBoundary"
 
-export type WorkbenchLeftTabId = string
+import {
+  useWorkbenchLeftPaneModel,
+  type WorkbenchLeftTabId,
+  type WorkspaceLeftPaneOpenPanelConfig as WorkbenchLeftPaneOpenPanelConfig,
+} from "./useWorkspaceLeftPaneActions"
 
-const FILES_LEFT_TAB_ID = "files"
-
-export interface WorkbenchLeftPaneOpenPanelConfig {
-  id: string
-  component: string
-  title?: string
-  params?: Record<string, unknown>
-}
+export type { WorkbenchLeftTabId, WorkspaceLeftPaneOpenPanelConfig as WorkbenchLeftPaneOpenPanelConfig } from "./useWorkspaceLeftPaneActions"
 
 export interface WorkbenchLeftPaneProps {
   rootDir?: string
@@ -72,64 +66,18 @@ export function WorkbenchLeftPane({
   railOnly = false,
   className,
 }: WorkbenchLeftPaneProps) {
-  const panelRegistry = useRegistry()
-  const workspaceSourceRegistry = useWorkspaceSourceRegistry()
-  const panels = useSyncExternalStore(
-    panelRegistry.subscribe,
-    panelRegistry.getSnapshot,
-    panelRegistry.getSnapshot,
-  )
-  const workspaceSources = useSyncExternalStore(
-    workspaceSourceRegistry.subscribe,
-    workspaceSourceRegistry.getSnapshot,
-    workspaceSourceRegistry.getSnapshot,
-  )
-  type LeftPaneEntry = {
-    id: string
-    title: string
-    icon: ReactNode
-    source?: WorkspaceSourceConfig
-    panel?: PanelConfig
-    kind: "source" | "workspace-page"
-  }
-  const workspacePagePanels = useMemo(
-    () => panels.filter((panel) => isWorkspacePagePlacement(panel.placement)),
-    [panels],
-  )
-  const tabs = useMemo(() => {
-    const next: LeftPaneEntry[] = []
-    for (const source of workspaceSources) {
-      const Icon = source.icon
-      next.push({
-        id: source.id,
-        title: source.title,
-        kind: "source",
-        // Icon-less plugins get an initial-letter glyph instead of a shared
-        // generic icon — on an icon-only rail, two identical fallback icons
-        // would be indistinguishable.
-        icon: Icon ? <Icon className="h-4 w-4" /> : <CategoryInitial title={source.title} />,
-        source,
-      })
-    }
-    for (const panel of workspacePagePanels) {
-      const Icon = panel.icon
-      next.push({
-        id: panel.id,
-        title: panel.title,
-        kind: "workspace-page",
-        icon: Icon ? <Icon className="h-4 w-4" /> : <CategoryInitial title={panel.title} />,
-        panel,
-      })
-    }
-    return next
-  }, [workspacePagePanels, workspaceSources])
-  const [tab, setTab] = useState<WorkbenchLeftTabId>(defaultTab ?? "")
-  const selectedTab = controlledActiveTab ?? tab
-  const activeTab = tabs.some((entry) => entry.id === selectedTab) ? selectedTab : (tabs[0]?.id ?? "")
-  const setActiveTab = useCallback((next: WorkbenchLeftTabId) => {
-    if (controlledActiveTab === undefined) setTab(next)
-    onActiveTabChange?.(next)
-  }, [controlledActiveTab, onActiveTabChange])
+  const { actions: tabs, activeTab, activeAction, activeSource } = useWorkbenchLeftPaneModel({
+    defaultTab,
+    activeTab: controlledActiveTab,
+    activePanelId,
+    onActiveTabChange,
+    revealFileTreeRequest,
+    onOpenPanel,
+    onReloadAgentPlugins,
+    onExpand,
+    onCloseSourcePane,
+    railOnly,
+  })
   const [searchOpen, setSearchOpen] = useState(false)
   const [query, setQuery] = useState("")
   const [debouncedQuery, setDebouncedQuery] = useState("")
@@ -150,56 +98,6 @@ export function WorkbenchLeftPane({
     if (searchOpen) searchInputRef.current?.focus()
   }, [searchOpen])
 
-  useEffect(() => {
-    if (tabs.length > 0 && !tabs.some((entry) => entry.id === selectedTab)) {
-      setActiveTab(tabs[0]!.id)
-    }
-  }, [selectedTab, setActiveTab, tabs])
-
-  useEffect(() => {
-    if (!revealFileTreeRequest) return
-    if (tabs.some((entry) => entry.id === FILES_LEFT_TAB_ID)) {
-      setActiveTab(FILES_LEFT_TAB_ID)
-    }
-  }, [revealFileTreeRequest, setActiveTab, tabs])
-
-  const openPanelForEntry = useCallback((entry: LeftPaneEntry) => {
-    if (!onOpenPanel) return
-    if (entry.kind === "workspace-page" && entry.panel) {
-      onOpenPanel({
-        id: entry.panel.id,
-        component: entry.panel.id,
-        title: entry.panel.title,
-      })
-      return
-    }
-    const defaultPanelId = entry.source?.defaultPanelId
-    if (!defaultPanelId) return
-    const target = panels.find((panel) => panel.id === defaultPanelId)
-    if (!target) return
-    onOpenPanel({
-      id: target.id,
-      component: target.id,
-      title: target.title,
-    })
-  }, [onOpenPanel, panels])
-
-  const selectTab = useCallback((entry: LeftPaneEntry) => {
-    if (entry.kind === "source") {
-      if (!railOnly && entry.id === activeTab) {
-        onCloseSourcePane?.()
-        return
-      }
-      setActiveTab(entry.id)
-      onExpand?.(entry.id)
-      openPanelForEntry(entry)
-      return
-    }
-    setActiveTab(entry.id)
-    openPanelForEntry(entry)
-    onCloseSourcePane?.()
-  }, [activeTab, onCloseSourcePane, onExpand, openPanelForEntry, railOnly, setActiveTab])
-
   const toggleSearch = useCallback(() => {
     setSearchOpen((s) => {
       if (s) setQuery("")
@@ -215,8 +113,7 @@ export function WorkbenchLeftPane({
     }
   }, [])
 
-  const activeEntry = tabs.find((entry) => entry.id === activeTab)
-  const activeSource = activeEntry?.kind === "source" ? activeEntry.source : undefined
+  const activeEntry = activeAction
   const activeOwnsSearch = Boolean(activeSource?.chromeless)
   const showChromeSearch = !activeOwnsSearch
   const leftTabParams = useMemo<LeftTabParams>(
@@ -248,30 +145,17 @@ export function WorkbenchLeftPane({
         </PaneCollapseButton>
       )}
       {tabs.map((entry) => {
-        // A "source" lives in the collapsible left pane: its "selected" state is the
-        // rail's own activeTab. A "workspace-page" is a full-window surface tab: its
-        // "selected" state is whether it's the focused surface tab (activePanelId),
-        // NOT the rail click — otherwise the icon stays lit after you switch tabs.
-        const isPage = entry.kind === "workspace-page"
-        const active = isPage ? entry.id === activePanelId : entry.id === activeTab
-        // At most ONE plugin is "focused" (accent/orange) at a time. A source pane and
-        // a page surface tab can be open at once (source on the left, page in the main
-        // area), so gate by railOnly (= source pane collapsed): while a source pane is
-        // open the active source is focused; while it's collapsed the active surface
-        // page is focused. The other, if still open, falls through to the quiet neutral
-        // highlight below — never a second accent.
-        const showAccent = isPage ? active && railOnly : active && !railOnly
         return (
           <ControlTooltip key={entry.id} label={entry.title} side="right">
             <button
               type="button"
               aria-label={entry.title}
-              aria-pressed={active}
-              onClick={() => selectTab(entry)}
+              aria-pressed={entry.active}
+              onClick={entry.select}
               onContextMenu={(event) => {
-                if (!onReloadAgentPlugins) return
+                if (!entry.reloadAgentPlugins) return
                 event.preventDefault()
-                void onReloadAgentPlugins()
+                void entry.reloadAgentPlugins()
               }}
               className={cn(
                 "relative flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-background/70 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
@@ -281,7 +165,7 @@ export function WorkbenchLeftPane({
               // actually open/focused plugin gets the accent chip; a remembered
               // selection in collapsed rail mode stays visually quiet so it does
               // not read as opened.
-              style={showAccent
+              style={entry.focused
                 ? { color: "var(--accent)", backgroundColor: "color-mix(in oklch, var(--foreground) 10%, transparent)" }
                 : undefined}
             >
@@ -378,19 +262,6 @@ function WorkspacePageLauncher({ title }: { title: string }) {
       <div className="mb-1 text-sm font-medium text-foreground">{title}</div>
       <div>Opened in the workspace.</div>
     </div>
-  )
-}
-
-function CategoryInitial({ title }: { title: string }) {
-  const letter = (title.trim()[0] ?? "?").toUpperCase()
-  return (
-    <span
-      aria-hidden="true"
-      data-boring-workspace-part="category-initial"
-      className="flex h-4 w-4 items-center justify-center rounded-[5px] bg-foreground/10 text-[10px] font-semibold leading-none text-foreground/70"
-    >
-      {letter}
-    </span>
   )
 }
 

--- a/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
@@ -8,6 +8,7 @@ import { CommandRegistry } from "../../../../shared/plugins/CommandRegistry"
 import { SurfaceResolverRegistry } from "../../../../shared/plugins/SurfaceResolverRegistry"
 import type { WorkspaceSourceProps } from "../../../registry/types"
 import { WorkbenchLeftPane } from "../WorkbenchLeftPane"
+import { useWorkspaceLeftPaneActions, type WorkspaceLeftPaneOpenPanelConfig } from "../useWorkspaceLeftPaneActions"
 
 function renderLeftPane({
   panels = new PanelRegistry(),
@@ -43,6 +44,26 @@ function WorkspaceSourceWithButton({ openPanel }: WorkspaceSourceProps) {
     >
       Open demo panel
     </button>
+  )
+}
+
+function HostExplorer({ onOpenPanel }: { onOpenPanel: (config: WorkspaceLeftPaneOpenPanelConfig) => void }) {
+  const actions = useWorkspaceLeftPaneActions({ onOpenPanel })
+  return (
+    <aside aria-label="Host explorer">
+      {actions.map((action) => (
+        <button
+          key={action.id}
+          type="button"
+          aria-label={`Host ${action.title}`}
+          aria-current={action.active ? "page" : undefined}
+          onClick={action.select}
+        >
+          {action.icon}
+          {action.title}
+        </button>
+      ))}
+    </aside>
   )
 }
 
@@ -112,6 +133,47 @@ describe("WorkbenchLeftPane", () => {
       component: "data.panel",
       title: "Data Panel",
     })
+  })
+
+  test("host explorers can render category actions without mounting the default left pane", () => {
+    const panelRegistry = new PanelRegistry()
+    const sources = new WorkspaceSourceRegistry()
+    sources.register("files", {
+      title: "Files",
+      component: () => <div>files body</div>,
+    })
+    panelRegistry.register("data.panel", {
+      title: "Data Panel",
+      placement: "center",
+      component: () => <div>data center</div>,
+    })
+    sources.register("data", {
+      title: "Data",
+      defaultPanelId: "data.panel",
+      component: () => <div>data body</div>,
+    })
+    const onOpenPanel = vi.fn()
+
+    renderLeftPane({ panels: panelRegistry, sources, children: <HostExplorer onOpenPanel={onOpenPanel} /> })
+
+    expect(screen.getByRole("complementary", { name: "Host explorer" })).toBeInTheDocument()
+    expect(screen.queryByRole("navigation", { name: "Workspace categories" })).not.toBeInTheDocument()
+    const filesButton = screen.getByRole("button", { name: "Host Files" })
+    const dataButton = screen.getByRole("button", { name: "Host Data" })
+    expect(filesButton).toHaveAttribute("aria-current", "page")
+    expect(dataButton).not.toHaveAttribute("aria-current")
+
+    fireEvent.click(dataButton)
+
+    expect(dataButton).toHaveAttribute("aria-current", "page")
+    expect(onOpenPanel).toHaveBeenCalledWith({
+      id: "data.panel",
+      component: "data.panel",
+      title: "Data Panel",
+    })
+
+    fireEvent.click(dataButton)
+    expect(onOpenPanel).toHaveBeenCalledTimes(2)
   })
 
   test("right-clicking a category reloads agent plugins", () => {

--- a/packages/workspace/src/front/chrome/workbench-left/useWorkspaceLeftPaneActions.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/useWorkspaceLeftPaneActions.tsx
@@ -1,0 +1,235 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore, type ReactNode } from "react"
+import { useRegistry, useWorkspaceSourceRegistry } from "../../registry"
+import type { PanelConfig, WorkspaceSourceConfig } from "../../registry/types"
+import { isWorkspacePagePlacement } from "../../../shared/types/panel"
+
+export type WorkbenchLeftTabId = string
+
+const FILES_LEFT_TAB_ID = "files"
+
+export interface WorkspaceLeftPaneOpenPanelConfig {
+  id: string
+  component: string
+  title?: string
+  params?: Record<string, unknown>
+}
+
+export interface UseWorkspaceLeftPaneActionsOptions {
+  defaultTab?: WorkbenchLeftTabId
+  activeTab?: WorkbenchLeftTabId
+  activePanelId?: string | null
+  onActiveTabChange?: (tab: WorkbenchLeftTabId) => void
+  revealFileTreeRequest?: { path: string; seq: number } | null
+  onOpenPanel?: (config: WorkspaceLeftPaneOpenPanelConfig) => void
+  onReloadAgentPlugins?: () => void | Promise<unknown>
+  onExpand?: (tab?: WorkbenchLeftTabId) => void
+  onCloseSourcePane?: () => void
+  railOnly?: boolean
+}
+
+export interface WorkspaceLeftPaneAction {
+  id: WorkbenchLeftTabId
+  title: string
+  icon: ReactNode
+  kind: "source" | "workspace-page"
+  active: boolean
+  select: () => void
+  reloadAgentPlugins?: () => void | Promise<unknown>
+}
+
+type WorkbenchLeftPaneEntry = {
+  id: string
+  title: string
+  icon: ReactNode
+  source?: WorkspaceSourceConfig
+  panel?: PanelConfig
+  kind: "source" | "workspace-page"
+}
+
+interface WorkbenchLeftPaneActionModel extends WorkspaceLeftPaneAction {
+  source?: WorkspaceSourceConfig
+  panel?: PanelConfig
+  focused: boolean
+}
+
+interface WorkbenchLeftPaneModel {
+  actions: WorkbenchLeftPaneActionModel[]
+  publicActions: WorkspaceLeftPaneAction[]
+  activeTab: WorkbenchLeftTabId
+  activeAction?: WorkbenchLeftPaneActionModel
+  activeSource?: WorkspaceSourceConfig
+}
+
+export function useWorkspaceLeftPaneActions(options: UseWorkspaceLeftPaneActionsOptions = {}): WorkspaceLeftPaneAction[] {
+  return useWorkbenchLeftPaneModel({ ...options, railOnly: options.railOnly ?? true }).publicActions
+}
+
+export function useWorkbenchLeftPaneModel({
+  defaultTab,
+  activeTab: controlledActiveTab,
+  activePanelId,
+  onActiveTabChange,
+  revealFileTreeRequest,
+  onOpenPanel,
+  onReloadAgentPlugins,
+  onExpand,
+  onCloseSourcePane,
+  railOnly = false,
+}: UseWorkspaceLeftPaneActionsOptions = {}): WorkbenchLeftPaneModel {
+  const panelRegistry = useRegistry()
+  const workspaceSourceRegistry = useWorkspaceSourceRegistry()
+  const panels = useSyncExternalStore(
+    panelRegistry.subscribe,
+    panelRegistry.getSnapshot,
+    panelRegistry.getSnapshot,
+  )
+  const workspaceSources = useSyncExternalStore(
+    workspaceSourceRegistry.subscribe,
+    workspaceSourceRegistry.getSnapshot,
+    workspaceSourceRegistry.getSnapshot,
+  )
+  const workspacePagePanels = useMemo(
+    () => panels.filter((panel) => isWorkspacePagePlacement(panel.placement)),
+    [panels],
+  )
+  const entries = useMemo<WorkbenchLeftPaneEntry[]>(() => {
+    const next: WorkbenchLeftPaneEntry[] = []
+    for (const source of workspaceSources) {
+      const Icon = source.icon
+      next.push({
+        id: source.id,
+        title: source.title,
+        kind: "source",
+        // Icon-less plugins get an initial-letter glyph instead of a shared
+        // generic icon — on an icon-only rail, two identical fallback icons
+        // would be indistinguishable.
+        icon: Icon ? <Icon className="h-4 w-4" /> : <CategoryInitial title={source.title} />,
+        source,
+      })
+    }
+    for (const panel of workspacePagePanels) {
+      const Icon = panel.icon
+      next.push({
+        id: panel.id,
+        title: panel.title,
+        kind: "workspace-page",
+        icon: Icon ? <Icon className="h-4 w-4" /> : <CategoryInitial title={panel.title} />,
+        panel,
+      })
+    }
+    return next
+  }, [workspacePagePanels, workspaceSources])
+
+  const [tab, setTab] = useState<WorkbenchLeftTabId>(defaultTab ?? "")
+  const selectedTab = controlledActiveTab ?? tab
+  const activeTab = entries.some((entry) => entry.id === selectedTab) ? selectedTab : (entries[0]?.id ?? "")
+  const setActiveTab = useCallback((next: WorkbenchLeftTabId) => {
+    if (controlledActiveTab === undefined) setTab(next)
+    onActiveTabChange?.(next)
+  }, [controlledActiveTab, onActiveTabChange])
+
+  useEffect(() => {
+    if (entries.length > 0 && !entries.some((entry) => entry.id === selectedTab)) {
+      setActiveTab(entries[0]!.id)
+    }
+  }, [entries, selectedTab, setActiveTab])
+
+  useEffect(() => {
+    if (!revealFileTreeRequest) return
+    if (entries.some((entry) => entry.id === FILES_LEFT_TAB_ID)) {
+      setActiveTab(FILES_LEFT_TAB_ID)
+    }
+  }, [entries, revealFileTreeRequest, setActiveTab])
+
+  const openPanelForEntry = useCallback((entry: WorkbenchLeftPaneEntry) => {
+    if (!onOpenPanel) return
+    if (entry.kind === "workspace-page" && entry.panel) {
+      onOpenPanel({
+        id: entry.panel.id,
+        component: entry.panel.id,
+        title: entry.panel.title,
+      })
+      return
+    }
+    const defaultPanelId = entry.source?.defaultPanelId
+    if (!defaultPanelId) return
+    const target = panels.find((panel) => panel.id === defaultPanelId)
+    if (!target) return
+    onOpenPanel({
+      id: target.id,
+      component: target.id,
+      title: target.title,
+    })
+  }, [onOpenPanel, panels])
+
+  const selectEntry = useCallback((entry: WorkbenchLeftPaneEntry) => {
+    if (entry.kind === "source") {
+      if (!railOnly && entry.id === activeTab) {
+        onCloseSourcePane?.()
+        return
+      }
+      setActiveTab(entry.id)
+      onExpand?.(entry.id)
+      openPanelForEntry(entry)
+      return
+    }
+    setActiveTab(entry.id)
+    openPanelForEntry(entry)
+    onCloseSourcePane?.()
+  }, [activeTab, onCloseSourcePane, onExpand, openPanelForEntry, railOnly, setActiveTab])
+
+  const actions = useMemo<WorkbenchLeftPaneActionModel[]>(() => {
+    return entries.map((entry) => {
+      // A source lives in the collapsible left pane; a workspace-page is a
+      // full-window surface tab. At most one plugin should receive the accent:
+      // sources are focused while the source pane is open, pages are focused
+      // while the rail is collapsed and their surface tab is active.
+      const active = entry.kind === "workspace-page" ? entry.id === activePanelId : entry.id === activeTab
+      const focused = entry.kind === "workspace-page" ? active && railOnly : active && !railOnly
+      return {
+        ...entry,
+        active,
+        focused,
+        select: () => selectEntry(entry),
+        reloadAgentPlugins: onReloadAgentPlugins,
+      }
+    })
+  }, [activePanelId, activeTab, entries, onReloadAgentPlugins, railOnly, selectEntry])
+
+  const publicActions = useMemo<WorkspaceLeftPaneAction[]>(() => {
+    return actions.map(({ id, title, icon, kind, active, select, reloadAgentPlugins }) => ({
+      id,
+      title,
+      icon,
+      kind,
+      active,
+      select,
+      reloadAgentPlugins,
+    }))
+  }, [actions])
+
+  const activeAction = actions.find((entry) => entry.id === activeTab)
+
+  return {
+    actions,
+    publicActions,
+    activeTab,
+    activeAction,
+    activeSource: activeAction?.kind === "source" ? activeAction.source : undefined,
+  }
+}
+
+function CategoryInitial({ title }: { title: string }) {
+  const letter = (title.trim()[0] ?? "?").toUpperCase()
+  return (
+    <span
+      aria-hidden="true"
+      data-boring-workspace-part="category-initial"
+      className="flex h-4 w-4 items-center justify-center rounded-[5px] bg-foreground/10 text-[10px] font-semibold leading-none text-foreground/70"
+    >
+      {letter}
+    </span>
+  )
+}

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -297,6 +297,7 @@ export type {
 export { SessionBrowser } from "./front/chrome/session-list/SessionBrowser"
 export { SurfaceShell } from "./front/chrome/artifact-surface/SurfaceShell"
 export { WorkbenchLeftPane } from "./front/chrome/workbench-left/WorkbenchLeftPane"
+export { useWorkspaceLeftPaneActions } from "./front/chrome/workbench-left/useWorkspaceLeftPaneActions"
 export type { SessionBrowserProps } from "./front/chrome/session-list/SessionBrowser"
 export type {
   OpenArtifactHandler,
@@ -328,6 +329,11 @@ export type {
   WorkbenchLeftPaneProps,
   WorkbenchLeftTabId,
 } from "./front/chrome/workbench-left/WorkbenchLeftPane"
+export type {
+  UseWorkspaceLeftPaneActionsOptions,
+  WorkspaceLeftPaneAction,
+  WorkspaceLeftPaneOpenPanelConfig,
+} from "./front/chrome/workbench-left/useWorkspaceLeftPaneActions"
 
 // Provider
 export {


### PR DESCRIPTION
## Summary

Closes #473.

- Extracts a narrow `useWorkspaceLeftPaneActions()` public hook for host explorers/sidebars.
- Rewires `WorkbenchLeftPane` to consume the extracted internal model while keeping search/content/chrome-action portal state private.
- Adds host-composition coverage that renders actions without mounting the default `WorkbenchLeftPane` rail.
- Documents the supported public import path and host usage.
- Records implementation + Claude Code fable review artifacts under `docs/issues/473/reviews/`.

## Proof

- ✅ `pnpm --filter @hachej/boring-workspace exec vitest run src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx`
- ✅ `git diff --check`
- ⚠️ Local temp-worktree typecheck was not reliable because the worktree reused the parent checkout's linked `node_modules` and failed on an unrelated `@hachej/boring-agent/front` export mismatch (`searchPiSessions`). CI should run with a fresh install.

## Review

- Claude Code `--model fable`: CLEAN
- Artifact: `docs/issues/473/reviews/claude-fable-review.md`
