### PR TITLE
boring-governance: Add Company Admin shell

### DIFF
--- a/docs/issues/475/plan-tenant-yaml-governance.md
+++ b/docs/issues/475/plan-tenant-yaml-governance.md
@@ -1,0 +1,288 @@
+---
+github: https://github.com/hachej/boring-ui/issues/475
+issue: 475
+state: active
+phase: plan
+track: owner
+flag: not-needed
+updated: 2026-07-02
+supersedes: docs/issues/475/plan.md
+---
+
+# gh-475 tenant YAML governance plan
+
+## Decision
+
+Final product model:
+
+- One app/company tenant for now.
+- A preprovisioned **Company Context workspace** exists for the tenant.
+- Tenant `admin` is separate from workspace `owner`.
+- Admin users can:
+  - see the Company Context workspace in the workspace switcher;
+  - open Company Admin from the user menu;
+  - invite app/tenant users;
+  - assign tenant role `admin` or `user`;
+  - decide which exact models each user can use;
+  - set euro budgets per user per exact model;
+  - decide which company-context paths each user can see.
+- Normal users:
+  - are invited to the app/tenant, not directly to the Company Context workspace;
+  - never see the Company Context workspace in the workspace switcher;
+  - only see `company_context` as a mounted/named filesystem inside their personal workspace, filtered by policy;
+  - only see/use models allowed by policy;
+  - get `Budget reached for this model.` when the model budget is exhausted.
+
+Policy v1 is YAML-backed and read-only from the app UI. Admins edit the YAML on the host/volume for v1; the Company Admin UI shows the effective policy and status. UI editing and DB-backed policy persistence are later work.
+
+Usage accounting uses the existing metering ledger; budget admission adds a minimal governance hold table so concurrent runs cannot all pass the same limit check.
+
+## Superseded plan
+
+`docs/issues/475/plan.md` is superseded by this plan. Keep it only as historical context for the admin shell PR. This plan is the source of truth for tenant/admin/model/company-context governance.
+
+## Policy shape v1
+
+Environment variable:
+
+```bash
+BORING_GOVERNANCE_POLICY_PATH=/data/boring-governance-policy.yaml
+```
+
+Example:
+
+```yaml
+tenant:
+  id: company
+  companyContextWorkspaceId: 00000000-0000-0000-0000-000000000001
+  defaultMonthlyModelBudgetEur: 0
+  perRunHoldEur: 1
+
+users:
+  - email: admin@example.com
+    role: admin
+    models:
+      - provider: infomaniak
+        id: Qwen/Qwen3.5-122B-A10B-FP8
+        monthlyBudgetEur: 25
+    companyContext:
+      allow:
+        - '^/.*'
+
+  - email: user@example.com
+    role: user
+    models:
+      - provider: infomaniak
+        id: Qwen/Qwen3.5-122B-A10B-FP8
+        monthlyBudgetEur: 5
+    companyContext:
+      allow:
+        - '^/public/.*'
+```
+
+Rules:
+- Missing policy file means governance is disabled, preserving existing behavior.
+- Present-but-invalid policy means fail closed: refuse to boot the full app in production; in dev, return a visible startup error and deny policy-dependent actions. Never silently disable governance when the file exists but is invalid.
+- Policy present means deny-by-default for users/models/company context not listed.
+- Any policy-derived privilege requires `emailVerified === true` when governance is enabled. This includes tenant role, admin access, model access/budgets, and company-context path grants. Unverified accounts get deny-by-default. If email verification is not configured, governance-enabled boot must fail unless an explicit dev-only override is set.
+- User emails are normalized to lowercase trimmed strings; duplicate emails are rejected.
+- Model IDs are exact (`provider` + `id`) for v1; no glob/regex model matching.
+- Budgets are UTC calendar-month budgets in EUR, converted to credit micros using the existing `1 EUR = 1_000_000 credit micros` convention.
+- `monthlyBudgetEur: 0` means deny usage for that exact model. Absence of a model row means deny. No unlimited budget in v1.
+- Budgets are hard admission caps against ledger usage plus active governance holds, with bounded overshoot only if real usage exceeds the configured per-run hold.
+- Company-context regexes must compile and must pass a safe subset/safety check before use.
+- YAML size is bounded (initial cap: 256 KiB). Policy reload is restart-only for v1.
+
+## Implementation slices
+
+### Slice A — Company Admin entry point + effective-policy view
+
+- Restore the Company Admin shortcut in the user menu.
+- Keep `/w/:id/admin` shell only as the current admin page route for PR #476; the route target for the menu is the current workspace until a tenant-level `/admin` route is introduced.
+- Entry point visibility:
+  - governance disabled: workspace owner shortcut remains for local/dev compatibility;
+  - governance enabled: only verified tenant `admin` users see Company Admin.
+- Remove the Workspace Settings Company Admin card; this is tenant/company admin, not workspace settings.
+- Company Admin UI v1 is read-only: show effective tenant policy summary, loaded policy path/status, admin/user rows, model rows, and company-context rules. It does not edit policy.
+
+Implementation seam:
+- Do not put tenant/YAML logic in shared core front code.
+- Add a full-app-owned authenticated route, e.g. `/api/v1/governance/me`, returning `{ enabled, role, admin, policyStatus }`.
+- `UserMenu` can consume that route or a core extension prop; per-user admin status must not ride app-global capabilities because capabilities are cached globally.
+
+Proof:
+- User menu tests for admin visible/non-admin hidden.
+- Company admin shell tests still pass.
+- Governance route tests for missing policy, admin, user, unverified user.
+
+### Slice B — YAML policy loader
+
+- Add full-app server governance module under `apps/full-app/src/server/governance/`.
+- Add `yaml` as a full-app dependency.
+- Parse/validate/cache policy at startup; restart-only reload for v1.
+- Validate:
+  - tenant is present;
+  - companyContextWorkspaceId exists when governance is enabled;
+  - user emails are normalized and unique;
+  - roles are `admin | user`;
+  - all policy-derived privileges require a verified user at request time; unverified users get deny-by-default;
+  - model rows have exact `provider` + `id`;
+  - budgets are finite non-negative EUR;
+  - company-context regex rules compile and pass safety constraints.
+- Expose service methods:
+  - `isEnabled()`;
+  - `policyStatus()`;
+  - `roleForUser(user)`;
+  - `isAdmin(user)`;
+  - `allowedModelsForUser(user, servedModels)`;
+  - `assertModelAllowed(user, model)`;
+  - `monthlyBudgetMicros(user, model)`;
+  - `companyContextRules(user)`;
+  - `companyContextWorkspaceId()`.
+
+Proof:
+- Unit tests with missing policy, valid policy, invalid file, duplicate users, invalid role/model/budget/regex, unverified admin, and unverified normal user with configured model/context grants denied.
+
+### Slice C — model picker filtering
+
+- Add a generic agent seam for model filtering; full-app supplies tenant policy callback.
+- `modelsRoutes` gets an options object like other subroutes:
+  - `filterModels?: (request, models, defaultModel) => Promise<{ models; defaultModel? }>`.
+- `GET /api/v1/agent/models` remains existing behavior when no policy callback is configured.
+- When configured, the route must be request/workspace/user aware and not workspace-agnostic. Remove/avoid `/api/v1/agent/models` from workspace-agnostic handling when policy filtering is enabled.
+- Filter served models through policy; do not mutate shared registry/model arrays.
+- Return `defaultModel` only if it is allowed.
+- UI model picker naturally receives only allowed models. Add UI coverage for no allowed models and denied default.
+
+Proof:
+- Agent `modelsRoutes` tests: filtered models, denied default removed, no-policy unchanged.
+- Register routes test verifies model-policy callback disables workspace-agnostic model route behavior.
+- Full-app wiring test verifies callback is passed to `registerAgentRoutes`.
+
+### Slice D — model run admission + monthly budget governance
+
+- Wrap the existing credits metering sink in a full-app governance metering decorator. Keep this outside `apps/full-app/src/server/credits.ts`; add `apps/full-app/src/server/governance/`.
+- On `reserveRun` when governance is enabled:
+  - require authenticated verified user;
+  - resolve the actual model that will execute;
+  - reject unknown/unavailable requested model instead of silently approving one model while the harness falls back to another;
+  - require model allowed by policy;
+  - reserve budget against `(userId, provider, model, utcMonth)` before delegating to credits sink;
+  - if delegated credits reserve fails, release the governance hold immediately.
+- Follow-up runs must carry the session's resolved model into metering reserve. Add the required agent-package change; do not assume follow-up model is present today.
+- Add stable error code and message for budget admission:
+  - code: `MODEL_BUDGET_EXCEEDED` (exact naming can follow existing error-code conventions);
+  - message: `Budget reached for this model.`
+
+Governance hold persistence:
+- Add a generic, currency-neutral core table/store, similar in spirit to existing credit reservations:
+  - `boring_model_budget_reservations`
+  - columns: `id`, `user_id`, `workspace_id`, `provider`, `model`, `period`, `run_id`, `amount_micros`, `status`, `expires_at`, timestamps.
+- Use core migrations because full-app currently only runs core migrations.
+- Keep table/store generic; full-app owns tenant/YAML semantics.
+- Admission is serialized with a Postgres advisory transaction lock. Prefer per-user lock (same precedent as credit admission) unless a narrower lock is clearly simpler.
+- Remaining budget formula:
+  - monthly ledger usage for `(user, provider, model, period)`
+  - plus active governance holds for that tuple
+  - avoid double-counting ledger rows for runs whose governance hold is still active.
+- Add expired-hold sweep, matching the existing credit reservation lifecycle pattern.
+- On `settleRun` / `releaseRun`, settle/release governance hold alongside the delegated credits sink.
+- Actual usage remains recorded in existing `boring_usage_ledger`; governance uses ledger sums plus active holds for admission.
+
+Proof:
+- Unit/integration tests:
+  - disallowed model fails before credits reserve;
+  - over-budget model returns `Budget reached for this model.` before execution;
+  - concurrent reserves cannot exceed budget + holds;
+  - delegated credits failure releases governance hold;
+  - release frees a hold;
+  - expired-hold sweep frees stale holds;
+  - settlement leaves actual usage in existing ledger as source of truth;
+  - follow-up reserves use the resolved session model.
+
+### Slice E — Company Context workspace + filesystem policy enforcement
+
+Preprovisioning:
+- Governance policy names the preprovisioned Company Context workspace id.
+- Admin users must be members/owners of the Company Context workspace. Add startup/reconcile logic or a documented bootstrap command to ensure YAML admins have membership.
+- Normal users are not added as members of the Company Context workspace.
+- Workspace list behavior follows membership:
+  - admins see Company Context workspace;
+  - normal users do not.
+
+Binding source:
+- Full-app must create/advertise the `company_context` binding for personal workspaces when governance is enabled and policy allows any paths for the user.
+- Define the storage source explicitly: the binding operations read from the Company Context workspace storage/root, not from the user's personal workspace.
+- Wire `company_context` bindings into every consumer path that can touch files:
+  - file/tree HTTP routes;
+  - agent filesystem tools;
+  - front file tree root discovery/props.
+
+Policy enforcement seam:
+- Do not bake user policy into cached workspace runtime bundles.
+- Current runtime bundles are workspace-scoped, and agent filesystem tools capture bindings from the bundle. Therefore implement one of these before enforcing:
+  1. user-scoped runtime bundle/cache key; or
+  2. a per-request/per-run filesystem-binding resolver seam used by both HTTP routes and agent tool execution.
+- Prefer option 2 if it avoids multiplying runtime bundles.
+- Add a cross-user cache-leak regression test.
+
+Rules:
+- Policy present means deny by default.
+- Normal users never see Company Context as a workspace, only filtered `company_context` mount in personal file tree.
+- Admins can see Company Context workspace and broad context rules.
+- Preserve binding access mode:
+  - readonly stays readonly;
+  - readwrite mutates only matched paths.
+- Policy-denied paths use #416 sanitized `not_found_or_denied`/403/404 semantics in both HTTP and agent tool paths.
+
+Proof:
+- Fake binding tests: allowed read, denied sanitized read/stat, readonly mutation denied, readwrite mutation allowed only for matched paths.
+- Agent tool tests, not only HTTP route tests.
+- Workspace list/direct-access tests: normal user cannot list/open Company Context workspace; admin can.
+- Front file tree test: normal user sees only mounted allowed `company_context` root/paths.
+- Cross-user cache-leak regression test.
+
+### Slice F — tenant invites and roles
+
+V1 must not pretend workspace invites are tenant invites.
+
+- Existing workspace invites remain workspace-scoped.
+- Add tenant invite semantics only if UI promises invites in Company Admin.
+- If tenant invites are not implemented in this stack, Company Admin v1 must show them as `not implemented`/read-only and the plan must not claim invitation support is shipped.
+- Recommended v1 scope: policy YAML lists users and roles; app signup is still existing auth. Tenant invite UI is deferred.
+
+Proof if deferred:
+- Company Admin copy says policy is YAML-managed and tenant invites are not implemented in v1.
+
+## Open implementation questions
+
+Resolved by owner:
+- one tenant now;
+- deny-by-default when policy exists;
+- app-level `admin | user` roles;
+- YAML v1;
+- EUR monthly budgets;
+- exact model IDs;
+- tenant invite for normal users;
+- normal users never see Company Context workspace, only filtered mount.
+
+Remaining design choice before Slice E implementation:
+- choose user-scoped runtime bundles vs per-request/per-run filesystem binding resolver. This should be settled after a short code spike/review, before coding enforcement.
+
+## Thermo/Fable review notes addressed
+
+This revision incorporates Fable blockers from the first plan review:
+- restores cache-leak mechanism and test for company-context enforcement;
+- scopes real production binding/provisioning work instead of assuming playground bindings exist;
+- requires model enforcement against the resolved executed model and follow-up model propagation;
+- closes email-keyed policy privilege escalation via verified-email requirement for all policy-derived privileges;
+- defines invalid-policy fail-closed behavior;
+- resolves incoherent workspace-owner vs tenant-admin gating by adding a full-app governance/me route and read-only v1 admin UI;
+- avoids over-promising tenant invites in YAML v1;
+- gives governance holds a migration home, lifecycle, and delegated-credit-failure release behavior.
+
+## Review bar before implementation
+
+- Get Fable Claude Code CLI review on this plan.
+- Do not start implementation until Fable says implementation may start or all blockers are explicitly resolved.
+- After implementation, run thermo review again before finalizing PRs.

--- a/docs/issues/475/plan.md
+++ b/docs/issues/475/plan.md
@@ -1,0 +1,127 @@
+---
+github: https://github.com/hachej/boring-ui/issues/475
+issue: 475
+state: superseded
+phase: plan
+track: owner
+flag: not-needed
+updated: 2026-07-02
+---
+
+# gh-475 company admin controls
+
+> Superseded by [`plan-tenant-yaml-governance.md`](./plan-tenant-yaml-governance.md). Historical sections below are obsolete where they conflict with the tenant YAML governance plan and [`todo-stack-tenant-yaml-governance.md`](./todo-stack-tenant-yaml-governance.md). For PR #476 specifically, the final IA is **user-menu Company Admin shortcut**, not Workspace Settings.
+
+## Decision
+
+Add a workspace/company owner-only admin surface in core, reachable from workspace settings, then stack two policy features on top:
+
+1. **Admin layout:** `/w/:id/admin` page with tabs, linked from workspace settings only when the current workspace role is `owner`.
+2. **Company context access:** owner-managed simple regex allow rules that filter the advertised `company_context` filesystem binding per user.
+3. **Model controls:** owner-managed per-user model allowlist plus per-model token/credit budgets, enforced at model discovery and run admission/metering.
+
+This belongs in `@hachej/boring-core` because core owns users/workspaces/members/persistence and already composes the agent/workspace app. Enforcement seams stay in agent/workspace through existing injection points rather than value-importing core from front/shared workspace code.
+
+## Research summary
+
+- Company FS stack (merged on `main` as #416):
+  - `origin/main` now contains the company-fs stack through `ccbc5f92` (`#416 company-fs: enforce readonly company viewers`).
+  - The merged stack preserves explicit filesystem identity in chat references, adds named runtime filesystem bindings, exposes a company file-tree root, and supports binding-driven access (`readonly` or `readwrite`) without company-specific tool names.
+  - Tools/routes accept `filesystem: 'company_context'` and route read/list/find/grep/stat and supported mutations through `RuntimeFilesystemBindingOperations` when the binding permits them.
+  - Readonly company viewers reject writes; denied company-context reads are sanitized as 403/404 without leaking path existence.
+  - The key seam is `RuntimeBundle.filesystemBindings?: RuntimeFilesystemBinding[]`, consumed by file/tree routes and filesystem tools. Policy should wrap/filter the `company_context` binding for the current request/session, not create separate company-specific tools.
+- Model/metering stack:
+  - Model selector fetches `GET /api/v1/agent/models`; the server builds from Pi `ModelRegistry` plus configured custom/Infomaniak providers (`modelConfig.ts`).
+  - Chat payload includes `{ provider, id }`; Pi metering reserves before execution and records native token/cost usage through `AgentMeteringSink`.
+  - Core credits persist `boring_usage_reservations` and `boring_usage_ledger` with `provider`, `model`, input/output/cache token counts, and billed/provider cost micros. `CreditsService.reserveRun` is currently a user-level credit hard stop; token→credit rates live in `credits/pricing.ts`.
+  - Existing billing is account/user-level credits. Per-model budgets should layer as an additional policy gate and usage query, not replace the credit ledger.
+
+## Flag
+
+`not-needed`: owner-only routes are fail-closed; when no policy rows exist, preserve current behavior:
+
+- company context binding behavior remains whatever the merged company-fs stack advertises today;
+- model list remains the existing registry-derived list;
+- credits/billing admission remains unchanged.
+
+## Acceptance
+
+- A workspace owner can open **Company admin** from workspace settings and see two tabs: **Context access** and **Model control**.
+- Non-owners cannot see the menu item and receive 403 from admin APIs/pages that require owner privileges.
+- Context access rules support simple regex strings, validate invalid regex at write time, reject unsafe regex shapes or run on a safe regex engine/subset, and are enforced before company-context tree/file/tool operations are exposed.
+- Context policy semantics are exact: if a workspace has no context-policy rows, preserve existing company-fs behavior; once any context policy exists for the workspace, a user with no matching allow rule is deny-all for `company_context`.
+- Model controls support per-user allowed models and per-model budget limits, validate against the served model catalog, and prevent disallowed/over-budget model runs before tokens are spent.
+- Model policy semantics are exact: if a workspace has no model-policy rows, preserve existing model behavior; once any model policy exists for the workspace, a user/model with no allow row is denied/unlisted.
+- Model selector shows only the current user's allowed available models and clears/falls back safely if the stored model becomes disallowed.
+- Usage/budget enforcement reuses the existing usage ledger fields (`userId`, `provider`, `model`, token counts, billed micros) plus budget reservations/holds so concurrent runs cannot over-admit; all admission remains idempotent with run reservation/settlement.
+
+## Slices / stacked branches
+
+### PR 1 — admin layout
+
+Branch: `issue/475-admin-layout` from `origin/main`.
+
+Scope:
+- Add `routes.companyAdmin = '/w/:id/admin'` and legacy `/workspace/:id/admin` route.
+- Add `CompanyAdminPage` shell in `packages/core/src/front/workspace/` with two tabs: Context access and Model control.
+- Add a Workspace settings **Company admin** card guarded by `useWorkspaceRole() === 'owner'` and current workspace id. Do not add this to the user menu; this is workspace/company settings, not user settings.
+- Add read-only placeholder copy and test coverage for owner visibility/non-owner hiding in workspace settings, route rendering, and tab switching.
+
+Proof:
+- `pnpm --filter @hachej/boring-core test -- UserMenu CompanyAdminPage CoreFront`
+- `pnpm --filter @hachej/boring-core run typecheck`
+
+### PR 2 — company context regex access
+
+Branch: `issue/475-context-access` from `issue/475-admin-layout`.
+
+Scope:
+- Add migration/table for workspace-scoped context policies, e.g. `boring_company_context_access_rules` with `workspace_id`, `user_id`, `pattern`, `created_by`, timestamps. Rules are allow rules; no rows means unchanged behavior for compatibility.
+- Add store/service APIs to list/upsert/delete rules and compile regex safely. Bound length/count; invalid regex returns `VALIDATION_FAILED`.
+- Add owner-only routes under `/api/v1/workspaces/:id/admin/company-context-access`.
+- In the core→agent runtime binding composition, add a request/user-scoped policy layer for `company_context` operations so list/find/grep/read/stat and any binding-permitted mutations only operate on paths matching the current user's compiled allow rules. Do **not** bake one user's rules into a cached runtime bundle; include a cross-user cache/leak regression test.
+- Preserve the merged binding's access mode: readonly stays readonly; readwrite may mutate only matched paths. For denied reads/stat, return sanitized forbidden/not-found consistent with #416.
+- Regex safety: either use RE2/safe-regex-compatible matching or restrict to an anchored/simple subset; bound rule length/count and list/find/grep path evaluation count.
+- UI: Context access tab lists members and regex rules, with add/remove controls and inline validation.
+
+Proof:
+- Core route/store tests for owner-only access and regex validation.
+- Agent/workspace integration tests using fake `company_context` bindings: allowed path passes, denied path is sanitized, readonly mutation remains denied, and readwrite mutation is allowed only for matched paths.
+- `pnpm --filter @hachej/boring-core test -- CompanyAdmin companyContext`
+- `pnpm --filter @hachej/boring-agent test -- file tree filesystem`
+
+### PR 3 — model controls and budgets
+
+Branch: `issue/475-model-controls` from `issue/475-context-access`.
+
+Scope:
+- Add workspace-scoped model policy tables, e.g. `boring_workspace_model_policies` (`workspace_id`, `user_id`, `provider`, `model`, optional `token_budget_input`, `token_budget_output`, optional `credit_budget_micros`, period key) and optional aggregate/materialized query helpers over `boring_usage_ledger`.
+- Add owner-only routes under `/api/v1/workspaces/:id/admin/model-control` to list served models, list member policies, and upsert/delete per-user model limits.
+- Add an agent/core model policy seam:
+  - pass a host-provided policy callback into `modelsRoutes` and `registerAgentRoutes`;
+  - make `/api/v1/agent/models` authenticated/workspace-scoped when policy is enabled (remove/avoid workspace-agnostic handling for this route in the composed core app);
+  - filter returned models/default by current user/workspace allowlist;
+  - reject prompt/follow-up reservation when the selected/default model is disallowed;
+  - reserve/check budget remaining transactionally before run admission using `(workspaceId,userId,provider,model,period)` budget holds plus ledger totals, so concurrent runs cannot all pass the same pre-run check.
+- Ensure custom model list per user is derived from `registry.getAll()` intersected with policy rows, preserving configured custom/Infomaniak providers and default-model semantics. When any workspace model policy exists, omission is deny; admins must create explicit allow rows.
+- UI: Model control tab lists members × models, supports allow/deny and per-model token/credit limits, and displays current usage from ledger totals.
+
+Proof:
+- Model route tests: user sees only allowed models; disallowed stored selection is not returned as available/default.
+- Metering/admission tests: disallowed model rejects before reserve/execute; over-budget rejects before tokens are spent; allowed in-budget usage records normally.
+- UI tests for policy editing and validation.
+- `pnpm --filter @hachej/boring-core test -- modelControl credits`
+- `pnpm --filter @hachej/boring-agent test -- models metering`
+
+## Open Questions
+
+- Should empty context/model policy mean **compatibility allow existing behavior** (planned) or **fail-closed deny until configured**? For rollout safety this plan uses compatibility behavior.
+- Budget period: monthly calendar, rolling 30 days, or lifetime? Planned schema should support a period key; initial UI can use monthly if owner confirms. Until confirmed, use calendar-month period keys internally and keep the UI copy explicit.
+- Are budgets token-only, credit-only, or both? Plan supports both but can ship credit budget first because credits are already product policy.
+
+## Review notes
+
+- Owner-track: permissions and billing-adjacent changes are not fast-track.
+- Keep enforcement server-side. Frontend filtering is convenience only.
+- Do not fork company-context filesystem semantics from #416; consume the generic named-filesystem binding seam.
+- Do not mutate provider/API-key configuration per user; user custom model list is a policy-filtered view over the served registry.

--- a/docs/issues/475/todo-stack-tenant-yaml-governance.md
+++ b/docs/issues/475/todo-stack-tenant-yaml-governance.md
@@ -1,0 +1,468 @@
+---
+github: https://github.com/hachej/boring-ui/issues/475
+issue: 475
+state: active
+phase: plan
+track: owner
+updated: 2026-07-02
+source_plan: docs/issues/475/plan-tenant-yaml-governance.md
+thermo_review: fable pass 1 found blockers; this revision addresses them
+---
+
+# gh-475 stacked TODOs — tenant YAML governance
+
+## Stack rules
+
+- Keep each PR reviewable; do not combine UI, policy parsing, model filtering, budget admission, and filesystem enforcement.
+- Tenant-specific governance logic lives in `apps/full-app/src/server/governance/` unless a slice explicitly adds a generic seam/table to `@hachej/boring-agent` or `@hachej/boring-core`.
+- Missing YAML policy = governance disabled and current behavior preserved.
+- Present invalid YAML policy = fail closed; never silently disable governance.
+- Policy-derived privileges require `emailVerified === true`.
+- Use exact `(provider, model id)` matches only.
+- Budgets are EUR monthly calendar budgets, converted to credit micros.
+- Post proof comments on every PR.
+
+---
+
+## PR 1 — Admin shell + user-menu entry
+
+Branch: `issue/475-admin-layout`  
+Base: `origin/main`  
+PR: #476
+
+### Goal
+
+Keep the admin shell small and make the entry point match the final IA: Company Admin is reachable from the user menu, not Workspace Settings.
+
+### TODO
+
+- [x] Keep `/w/:id/admin` route for the current shell.
+- [x] Keep `CompanyAdminPage` tabs:
+  - [x] Context access
+  - [x] Model control
+- [x] User menu:
+  - [x] show Company Admin to workspace owners when governance is disabled/local-dev compatibility;
+  - [x] do **not** add Workspace Settings Company Admin card;
+  - [x] leave tenant-admin-only gating for PR 2 when the generic per-user admin-status seam exists.
+- [x] Remove any Workspace Settings admin card/link from current branch.
+- [x] Plan docs:
+  - [x] mark old `plan.md` superseded;
+  - [x] keep `plan-tenant-yaml-governance.md` as source of truth;
+  - [x] include this TODO stack.
+
+### Tests / proof
+
+- [x] `pnpm --filter @hachej/boring-ui-kit build`
+- [x] `pnpm --filter @hachej/boring-core exec vitest run src/front/__tests__/CompanyAdminPage.test.tsx src/front/__tests__/userNavComponents.test.tsx src/front/__tests__/WorkspaceSettingsPage.test.tsx src/front/__tests__/CoreFront.test.tsx --no-file-parallelism`
+- [x] `pnpm --filter @hachej/boring-core run typecheck`
+- [x] `git diff --check`
+
+### Review focus
+
+- No tenant/YAML semantics leak into core UI yet.
+- No actual policy enforcement in PR 1.
+
+---
+
+## PR 2 — YAML governance policy loader + read-only admin status/view
+
+Branch: `issue/475-governance-yaml`  
+Base: `issue/475-admin-layout`
+
+### Goal
+
+Introduce full-app-owned tenant governance policy parsing and expose read-only effective governance state. No model/filesystem enforcement yet.
+
+### TODO
+
+- [ ] Add `yaml` dependency to `apps/full-app`.
+- [ ] Add `apps/full-app/src/server/governance/` module:
+  - [ ] `policyTypes.ts` — typed parsed policy model;
+  - [ ] `loadPolicy.ts` — reads `BORING_GOVERNANCE_POLICY_PATH`;
+  - [ ] `validatePolicy.ts` — validation + normalized policy;
+  - [ ] `governanceService.ts` — request-time methods;
+  - [ ] `routes.ts` — authenticated governance routes;
+  - [ ] `index.ts` — public full-app wiring surface.
+- [ ] Policy loading semantics:
+  - [ ] missing env/path/file => governance disabled;
+  - [ ] file present but parse/validation fails in production => refuse to boot;
+  - [ ] file present but parse/validation fails in dev => visible startup error + all policy-dependent actions denied;
+  - [ ] never silently disable governance when policy file exists but is invalid;
+  - [ ] restart-only reload for v1;
+  - [ ] max YAML size 256 KiB;
+  - [ ] duplicate user emails rejected after the same lowercase/trim normalization used at request time.
+- [ ] Email verification boot check:
+  - [ ] governance-enabled boot requires core email verification configured;
+  - [ ] define production detection explicitly (prefer `NODE_ENV === 'production'` unless codebase has a better existing signal);
+  - [ ] name the dev-only override env var before implementation;
+  - [ ] if verification is not configured, refuse production boot unless that explicit dev-only override is set;
+  - [ ] test both production fail and dev override behavior.
+- [ ] Validation:
+  - [ ] one tenant block;
+  - [ ] optional `companyContextWorkspaceId` now, but PR 5a will make it required before company-context enforcement;
+  - [ ] roles only `admin | user`;
+  - [ ] exact model rows require non-empty `provider` and `id`;
+  - [ ] `monthlyBudgetEur` finite and `>= 0`;
+  - [ ] `defaultMonthlyModelBudgetEur` is documented but not used for absent rows in v1; absent model row still denies;
+  - [ ] `perRunHoldEur` finite positive when model-budget enforcement is enabled; hold amount is `perRunHoldEur * 1_000_000` micros;
+  - [ ] regex rules compile and pass safe subset/safety check.
+- [ ] Request-time user policy:
+  - [ ] normalize request user email;
+  - [ ] if governance enabled and `emailVerified !== true`, all policy-derived privileges deny;
+  - [ ] `roleForUser`, `isAdmin`, `allowedModelsForUser`, `assertModelAllowed`, `monthlyBudgetMicros`, `companyContextRules`.
+- [ ] Per-user admin-status seam for shared core UI:
+  - [ ] before coding PR2, pick exactly one seam in a short branch note: generic core hook/prop/context vs full-app-injected menu item;
+  - [ ] do **not** hard-code `/api/v1/governance/me` into `@hachej/boring-core` UserMenu as a full-app-only dependency;
+  - [ ] add a small generic hook/prop/context in core for optional admin entry status, where absence/404 = disabled; or inject the user-menu extra item from full-app;
+  - [ ] full-app implements `/api/v1/governance/me` returning `{ enabled, role, admin }` to normal users and admin-only `policyStatus` details;
+  - [ ] per-user admin status must not use app-global capabilities because capabilities are cached globally.
+- [ ] CompanyAdminPage v1:
+  - [ ] read-only policy/status view;
+  - [ ] clear copy: “YAML-managed in v1”; no fake edit controls;
+  - [ ] tenant invites shown as deferred/not implemented if present in copy.
+
+### Tests / proof
+
+- [ ] Governance loader unit tests:
+  - [ ] missing policy disabled;
+  - [ ] valid policy normalizes;
+  - [ ] invalid YAML production boot fails;
+  - [ ] invalid YAML dev mode returns visible error and denies policy-dependent actions;
+  - [ ] duplicate users rejected after normalization;
+  - [ ] invalid roles rejected;
+  - [ ] invalid budgets rejected;
+  - [ ] invalid/unsafe regex rejected;
+  - [ ] governance-enabled boot fails without email verification config unless dev override;
+  - [ ] unverified admin denied;
+  - [ ] unverified normal user with configured model/context grants denied.
+- [ ] Governance route tests for `/api/v1/governance/me`.
+- [ ] UserMenu/admin-entry tests for governance admin visible/user hidden/disabled fallback/404 absence.
+- [ ] CompanyAdminPage read-only view tests.
+- [ ] `pnpm --filter full-app test -- governance`
+- [ ] targeted core/front tests affected by UserMenu/admin page.
+- [ ] typecheck for affected packages.
+
+### Review focus
+
+- Full-app owns tenant semantics.
+- No app-global capabilities for per-user admin status.
+- No policy enforcement yet beyond UI visibility/read-only status.
+
+---
+
+## PR 3 — Model picker filtering via generic agent seam
+
+Branch: `issue/475-model-picker-policy`  
+Base: `issue/475-governance-yaml`
+
+### Goal
+
+Filter visible/selectable models per user from YAML policy. No budget admission yet.
+
+### TODO
+
+- [ ] Add generic model filtering seam to `@hachej/boring-agent`:
+  - [ ] `modelsRoutes(app, { filterModels? })` accepts request-aware callback;
+  - [ ] callback receives immutable served model summaries and candidate default;
+  - [ ] callback returns filtered `{ models, defaultModel? }`;
+  - [ ] no mutation of cached registry arrays.
+- [ ] Register routes plumbing:
+  - [ ] `RegisterAgentRoutesOptions` adds model policy/filter option;
+  - [ ] `registerAgentRoutes` passes it to `modelsRoutes`;
+  - [ ] `createAgentApp` keeps no-policy behavior;
+  - [ ] when policy callback configured, `/api/v1/agent/models` is not workspace-agnostic and has request user/workspace context.
+- [ ] Provider capability leak check:
+  - [ ] `getAvailableModelProviders()` duplicates registry/provider discovery;
+  - [ ] either filter provider names using the same policy or explicitly accept provider-name leakage with rationale;
+  - [ ] prefer filtering to keep model governance coherent.
+- [ ] Full-app wiring:
+  - [ ] pass governance model filter callback from `createCoreWorkspaceAgentServer` options/wiring;
+  - [ ] governance disabled preserves existing model list;
+  - [ ] governance enabled filters exact `(provider,id)` rows;
+  - [ ] unverified user sees no policy-derived models;
+  - [ ] default model omitted if denied.
+- [ ] Front behavior:
+  - [ ] existing `useChatModelSelection` clearing behavior is likely sufficient; add regression coverage rather than new logic unless tests fail;
+  - [ ] define what “Default model (automatic)” means under governance;
+  - [ ] hide/disable “Default model (automatic)” when the resolved default would be denied; do not wait for PR 4 admission because PR3 lands first.
+
+### Tests / proof
+
+- [ ] Agent route tests:
+  - [ ] no callback = current behavior;
+  - [ ] callback filters models;
+  - [ ] denied default removed;
+  - [ ] callback does not mutate cached models;
+  - [ ] workspace context is required when callback configured;
+  - [ ] provider names are filtered or accepted with explicit test/rationale.
+- [ ] Full-app wiring test verifies callback is passed.
+- [ ] Front test for empty allowed models / denied stored selection / automatic default behavior.
+- [ ] `pnpm --filter @hachej/boring-agent test -- models`
+- [ ] targeted full-app/core tests.
+- [ ] typecheck for affected packages.
+
+### Review focus
+
+- Agent seam stays generic; no YAML/tenant semantics in agent.
+- Filtering is not security by itself; run admission lands in PR 4.
+
+---
+
+## PR 4 — Model run admission + EUR monthly budget holds
+
+Branch: `issue/475-model-budget-governance`  
+Base: `issue/475-model-picker-policy`
+
+### Goal
+
+Enforce exact model allowlist and monthly EUR budget before execution. Use existing usage ledger plus a minimal governance hold table to prevent concurrent over-admission.
+
+### TODO
+
+- [ ] Generic agent strict model seam:
+  - [ ] add `strictModelResolution` (or equivalent generic option) to register/harness options;
+  - [ ] default preserves current silent fallback behavior;
+  - [ ] full-app enables strict model resolution when governance is enabled;
+  - [ ] do **not** add tenant/governance conditionals inside agent harness.
+- [ ] Agent metering changes:
+  - [ ] propagate resolved session model into follow-up metering reserve;
+  - [ ] when strict model resolution is active, reject unknown/unavailable requested model instead of silent fallback;
+  - [ ] ensure reserve sees the model that will actually execute.
+- [ ] Stable error:
+  - [ ] add `MODEL_BUDGET_EXCEEDED` (or repo-conformant equivalent) to `packages/agent/src/shared/error-codes.ts` because agent routes serialize this enum;
+  - [ ] user message: `Budget reached for this model.`
+- [ ] Core generic persistence:
+  - [ ] add migration for `boring_model_budget_reservations`;
+  - [ ] add schema export;
+  - [ ] add a new sibling store file; do **not** grow `PostgresMeteringStore.ts` past 1k lines;
+  - [ ] add indexes for `(user_id, provider, model, period)` and stale active holds.
+- [ ] Hold lifecycle:
+  - [ ] active/settled/released/expired statuses;
+  - [ ] expiresAt TTL;
+  - [ ] stale hold sweep;
+  - [ ] idempotent reserve per run;
+  - [ ] per-user advisory transaction lock.
+- [ ] Budget calculation:
+  - [ ] UTC month period key;
+  - [ ] ledger `created_at` is timestamp without time zone, so month truncation must explicitly use UTC semantics;
+  - [ ] sum existing `boring_usage_ledger` rows by `(user, provider, model, period)`;
+  - [ ] include active holds;
+  - [ ] double-count prevention mechanism: exclude ledger rows whose `run_id` has an active governance hold for the same tuple;
+  - [ ] no unlimited budget in v1.
+- [ ] Hold amount:
+  - [ ] `holdMicros = perRunHoldEur * 1_000_000`;
+  - [ ] use existing credits reservation sizing patterns as reference, but keep governance config independent.
+- [ ] Full-app governance metering decorator:
+  - [ ] wraps `AgentMeteringSink`, not `CreditsService`;
+  - [ ] runs before delegated credits reserve;
+  - [ ] checks verified user, exact model allowed, budget remaining;
+  - [ ] reserves governance hold;
+  - [ ] delegates to credits sink;
+  - [ ] releases governance hold immediately if delegated credits reserve fails;
+  - [ ] settles/releases governance hold when run settles/releases.
+- [ ] Keep code out of `apps/full-app/src/server/credits.ts`; use sibling governance module.
+
+### Tests / proof
+
+- [ ] Store tests:
+  - [ ] idempotent reserve;
+  - [ ] concurrent reserve cannot exceed budget;
+  - [ ] release frees hold;
+  - [ ] expiry sweep frees stale holds;
+  - [ ] ledger + active hold double-count prevention.
+- [ ] Governance decorator tests:
+  - [ ] disallowed model fails before credits reserve;
+  - [ ] over-budget fails before execution with stable code/message;
+  - [ ] delegated credits failure releases governance hold;
+  - [ ] settle/release lifecycle correct;
+  - [ ] unverified user denied.
+- [ ] Agent metering tests:
+  - [ ] prompt reserve uses resolved model;
+  - [ ] follow-up reserve uses session resolved model;
+  - [ ] unknown requested model fails under strict model resolution.
+- [ ] `pnpm --filter @hachej/boring-core test -- budget governance metering`
+- [ ] `pnpm --filter @hachej/boring-agent test -- metering piChat`
+- [ ] typecheck for affected packages.
+
+### Review focus
+
+- No Stripe/LiteLLM dependency.
+- Governance is policy/admission, not invoicing.
+- Budget races are actually closed.
+
+---
+
+## PR 5a — Company Context workspace bootstrap + membership visibility
+
+Branch: `issue/475-company-context-bootstrap`  
+Base: `issue/475-model-budget-governance`
+
+### Goal
+
+Make the preprovisioned Company Context workspace a real tenant resource with correct admin-only workspace visibility. No filesystem mount yet.
+
+### TODO
+
+- [ ] Before PR 5a, resolve ownership of existing `packages/boring-bash` work; do not duplicate or collide with another agent’s binding model.
+- [ ] Update policy validation:
+  - [ ] `companyContextWorkspaceId` becomes required when company-context enforcement is enabled;
+  - [ ] test required-when-enabled behavior.
+- [ ] Bootstrap/reconcile Company Context workspace:
+  - [ ] governance policy names `companyContextWorkspaceId`;
+  - [ ] admins have workspace membership/visibility;
+  - [ ] normal users do not get workspace membership;
+  - [ ] document/create bootstrap command if auto-reconcile is deferred;
+  - [ ] bootstrap must not let the normal default-workspace autocreate path create/claim the Company Context workspace.
+- [ ] Workspace list/direct access:
+  - [ ] admins see Company Context workspace;
+  - [ ] normal users do not see Company Context workspace;
+  - [ ] normal users cannot direct-open `/w/:companyContextWorkspaceId`.
+
+### Tests / proof
+
+- [ ] Admin workspace list/direct open tests.
+- [ ] Normal user workspace list/direct forbidden tests.
+- [ ] Bootstrap/reconcile tests.
+- [ ] Policy validation test for missing companyContextWorkspaceId when enforcement enabled.
+
+### Review focus
+
+- Membership remains the workspace-visibility mechanism.
+- Normal users are not workspace members of Company Context.
+
+---
+
+## PR 5b — Generic per-request/per-run filesystem binding seam
+
+Branch: `issue/475-filesystem-binding-seam`  
+Base: `issue/475-company-context-bootstrap`
+
+### Goal
+
+Add/choose the generic binding resolver seam with parity behavior and no tenant policy semantics yet.
+
+### Pre-coding gate
+
+Evaluate existing `packages/boring-bash` before building anything new:
+
+- `FilesystemBindingResolver.resolveBindings(ctx)` already exists.
+- `runtimeBindingManager` already scopes by `humanUserId`.
+- readonly/management projection operations and fixture company-context provider already exist.
+- Decide whether to bridge boring-bash into `RuntimeBundle.filesystemBindings` or create a smaller agent-native resolver. Document the decision before code.
+
+### TODO
+
+- [ ] Fix production binding wiring gaps:
+  - [ ] `fileRoutes` supports `getFilesystemBindings`, but production registration currently omits it; wire it;
+  - [ ] tree routes already have shape but read from shared bundle; make it use the chosen resolver;
+  - [ ] agent tools must not capture user-agnostic bindings at bundle creation.
+- [ ] Add generic resolver context:
+  - [ ] `workspaceId`;
+  - [ ] authenticated human user id/email where available;
+  - [ ] session/run/request id as needed;
+  - [ ] no tenant/YAML concepts in generic agent/workspace packages.
+- [ ] Parity behavior:
+  - [ ] when no resolver configured, current `runtimeBundle.filesystemBindings` behavior unchanged;
+  - [ ] when resolver configured, both HTTP file/tree routes and agent filesystem tools resolve bindings through the same user-aware seam.
+- [ ] Add cross-user cache-leak regression test with two users and one workspace.
+
+### Tests / proof
+
+- [ ] Agent file route binding tests now cover `getFilesystemBindings` wiring.
+- [ ] Agent tool tests prove per-user bindings are not cached across users.
+- [ ] Tree route tests still pass.
+- [ ] No policy semantics in this PR.
+
+### Review focus
+
+- Avoid a third parallel binding abstraction if boring-bash can be reused.
+- Do not multiply runtime bundles unnecessarily.
+- No tenant-specific logic in agent generic seam.
+
+---
+
+## PR 5c — Company Context policy-filtered mount + front discovery
+
+Branch: `issue/475-company-context-policy`  
+Base: `issue/475-filesystem-binding-seam`
+
+### Goal
+
+Expose Company Context as a filtered `company_context` filesystem mount inside normal users’ personal workspaces.
+
+### TODO
+
+- [ ] Binding source:
+  - [ ] `company_context` operations read from Company Context workspace storage/root;
+  - [ ] not from the user's personal workspace;
+  - [ ] preserve #416 binding access mode.
+- [ ] Binding advertisement / front discovery:
+  - [ ] personal workspace file tree can discover allowed `company_context` root;
+  - [ ] per-user root discovery cannot use app-global capabilities;
+  - [ ] choose concrete mechanism: extend `/api/v1/governance/me` with allowed roots or add a dedicated per-user roots endpoint;
+  - [ ] wire the workspace filesystem plugin/FileTree props from that per-user source, without tenant semantics in workspace package.
+- [ ] Enforcement:
+  - [ ] policy present = deny by default;
+  - [ ] only matched regex paths are visible/usable;
+  - [ ] denied paths use #416 sanitized `not_found_or_denied` / 403/404 semantics;
+  - [ ] readonly mutation denied;
+  - [ ] readwrite mutation allowed only on matched paths;
+  - [ ] agent filesystem tools and HTTP file/tree routes both enforced;
+  - [ ] no user rules baked into shared cached runtime bundle.
+- [ ] Regex safety:
+  - [ ] compile at policy-load time;
+  - [ ] safe subset/safe-regex check;
+  - [ ] path/rule count bounds for list/find/grep.
+
+### Tests / proof
+
+- [ ] Binding tests:
+  - [ ] allowed read/stat/list;
+  - [ ] denied read/stat sanitized;
+  - [ ] find/grep filtered;
+  - [ ] readonly mutation denied;
+  - [ ] readwrite mutation allowed only on matched path.
+- [ ] Agent tool tests for the same policy paths.
+- [ ] Front file-tree test for mounted `company_context` root visibility.
+- [ ] Cross-user cache-leak regression remains green.
+
+### Review focus
+
+- Highest-risk security slice.
+- Must prove agent tools cannot bypass HTTP-layer policy.
+- Must prove normal users only get a filtered mount, never workspace visibility.
+
+---
+
+## PR 6 — Tenant invites (optional/deferred)
+
+Branch: `issue/475-tenant-invites`  
+Base: `issue/475-company-context-policy`
+
+### Goal
+
+Only do this if owner wants app-managed tenant invites in v1. Otherwise keep invites YAML/auth-managed and copy says deferred.
+
+### TODO if implemented
+
+- [ ] Define tenant invite model separate from workspace invites.
+- [ ] Add DB table + routes for tenant invites.
+- [ ] Invite accepts create/sign in account and apply tenant `user` role.
+- [ ] Invited normal users do not become Company Context workspace members.
+- [ ] Admin UI can create/revoke tenant invites.
+- [ ] Email verification remains required before policy privileges apply.
+
+### Tests / proof
+
+- [ ] Tenant invite route tests.
+- [ ] Accept flow tests.
+- [ ] Normal user workspace visibility tests.
+
+---
+
+## Required reviews
+
+- [ ] Fable/Claude plan review before implementation starts. ✅ done once; rerun after major plan edits.
+- [ ] Thermo review this TODO stack before implementation starts.
+- [ ] Thermo review after each implementation PR before finalizing.
+- [ ] Extra strict review for PR 4 and PR 5b/5c because they touch budget and filesystem access enforcement.

--- a/packages/core/src/front/CoreFront.tsx
+++ b/packages/core/src/front/CoreFront.tsx
@@ -22,6 +22,7 @@ import { UserSettingsPage as DefaultUserSettingsPage } from './auth/UserSettings
 import { InvitesPage } from './workspace/InvitesPage.js'
 import { MembersPage } from './workspace/MembersPage.js'
 import { WorkspaceSettingsPage } from './workspace/WorkspaceSettingsPage.js'
+import { CompanyAdminPage } from './workspace/CompanyAdminPage.js'
 import { InviteAcceptPage } from './auth/InviteAcceptPage.js'
 import { isRuntimeEmailVerificationEnabled } from '../shared/authPolicy.js'
 import { routes } from './utils.js'
@@ -154,6 +155,8 @@ export function CoreFront({ children, authPages, cspNonce, workspaceRoute, works
                               <Route path="/workspace/:id/invites" element={<InvitesPage />} />
                               <Route path={routes.workspaceSettings} element={<WorkspaceSettingsPage />} />
                               <Route path="/workspace/:id/settings" element={<WorkspaceSettingsPage />} />
+                              <Route path={routes.companyAdmin} element={<CompanyAdminPage />} />
+                              <Route path="/workspace/:id/admin" element={<CompanyAdminPage />} />
                               <Route path={routes.inviteAccept} element={<InviteAcceptPage />} />
                               {children}
                             </Routes>

--- a/packages/core/src/front/__tests__/CompanyAdminPage.test.tsx
+++ b/packages/core/src/front/__tests__/CompanyAdminPage.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CompanyAdminPage } from '../workspace/CompanyAdminPage'
+
+const mockUseCurrentWorkspace = vi.fn()
+const mockUseWorkspaceRole = vi.fn()
+const mockUseWorkspaceRouteStatus = vi.fn()
+
+vi.mock('../WorkspaceAuthProvider', async () => {
+  const actual = await vi.importActual<typeof import('../WorkspaceAuthProvider')>('../WorkspaceAuthProvider')
+  return {
+    ...actual,
+    useCurrentWorkspace: () => mockUseCurrentWorkspace(),
+    useWorkspaceRole: () => mockUseWorkspaceRole(),
+    useWorkspaceRouteStatus: () => mockUseWorkspaceRouteStatus(),
+  }
+})
+
+function renderPage(path = '/w/ws-a/admin') {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/w/:id/admin" element={<CompanyAdminPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockUseCurrentWorkspace.mockReturnValue({ id: 'ws-a', name: 'Workspace A' })
+  mockUseWorkspaceRole.mockReturnValue('owner')
+  mockUseWorkspaceRouteStatus.mockReturnValue({
+    status: 'matched',
+    workspaceId: 'ws-a',
+    workspace: { id: 'ws-a', name: 'Workspace A' },
+  })
+})
+
+describe('CompanyAdminPage', () => {
+  it('renders owner admin shell with context and model tabs', async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    expect(screen.getByRole('heading', { name: 'Workspace A' })).toBeInTheDocument()
+    expect(screen.getByRole('tab', { name: 'Context access' })).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByRole('tab', { name: 'Model control' })).toHaveAttribute('aria-selected', 'false')
+    expect(screen.getByRole('heading', { name: 'Context access' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('tab', { name: 'Model control' }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Model control' })).toHaveAttribute('aria-selected', 'true')
+    })
+    expect(screen.getByRole('heading', { name: 'Model control' })).toBeInTheDocument()
+  })
+
+  it('shows loading state while workspace role is resolving', () => {
+    mockUseWorkspaceRole.mockReturnValue(null)
+    mockUseWorkspaceRouteStatus.mockReturnValue({ status: 'loading', workspaceId: 'ws-a' })
+
+    renderPage()
+
+    expect(screen.getByText('Loading company admin…')).toBeInTheDocument()
+    expect(screen.queryByText('Owner access required')).toBeNull()
+  })
+
+  it('shows not-found route errors instead of hanging on loading', () => {
+    mockUseWorkspaceRole.mockReturnValue(null)
+    mockUseWorkspaceRouteStatus.mockReturnValue({
+      status: 'not-found',
+      workspaceId: 'missing-ws',
+      message: 'Workspace not found',
+    })
+
+    renderPage('/w/missing-ws/admin')
+
+    expect(screen.getByText('Workspace unavailable')).toBeInTheDocument()
+    expect(screen.getByText('Workspace not found')).toBeInTheDocument()
+    expect(screen.queryByText('Loading company admin…')).toBeNull()
+  })
+
+  it('shows forbidden route errors instead of hanging on loading', () => {
+    mockUseWorkspaceRole.mockReturnValue(null)
+    mockUseWorkspaceRouteStatus.mockReturnValue({
+      status: 'forbidden',
+      workspaceId: 'ws-a',
+      message: 'Forbidden',
+    })
+
+    renderPage()
+
+    expect(screen.getByText('Owner access required')).toBeInTheDocument()
+    expect(screen.getByText(/Only workspace owners can manage/)).toBeInTheDocument()
+    expect(screen.queryByText('Loading company admin…')).toBeNull()
+  })
+
+  it('blocks non-owner members in the client shell', () => {
+    mockUseWorkspaceRole.mockReturnValue('viewer')
+
+    renderPage()
+
+    expect(screen.getByText('Owner access required')).toBeInTheDocument()
+    expect(screen.getByText(/Only workspace owners can manage/)).toBeInTheDocument()
+  })
+})

--- a/packages/core/src/front/__tests__/userNavComponents.test.tsx
+++ b/packages/core/src/front/__tests__/userNavComponents.test.tsx
@@ -18,6 +18,7 @@ const mockNavigate = vi.fn()
 const mockUseUser = vi.fn()
 const mockSignOut = vi.fn()
 const mockUseCurrentWorkspace = vi.fn()
+const mockUseWorkspaceRole = vi.fn()
 const mockUseTheme = vi.fn()
 const mockToast = vi.fn()
 
@@ -43,6 +44,7 @@ vi.mock('../WorkspaceAuthProvider', async () => {
   return {
     ...actual,
     useCurrentWorkspace: () => mockUseCurrentWorkspace(),
+    useWorkspaceRole: () => mockUseWorkspaceRole(),
   }
 })
 
@@ -159,6 +161,7 @@ beforeEach(() => {
   mockUseUser.mockReset()
   mockSignOut.mockReset()
   mockUseCurrentWorkspace.mockReset()
+  mockUseWorkspaceRole.mockReset()
   mockUseTheme.mockReset()
   mockToast.mockReset()
 
@@ -181,6 +184,7 @@ beforeEach(() => {
 
   mockSignOut.mockResolvedValue(undefined)
   mockUseCurrentWorkspace.mockReturnValue(WORKSPACES[0])
+  mockUseWorkspaceRole.mockReturnValue('owner')
   mockUseTheme.mockReturnValue({
     theme: 'light',
     preference: 'light',
@@ -205,6 +209,7 @@ describe('UserMenu', () => {
       expect(screen.getByText('menu-user@boring.dev')).toBeInTheDocument()
       expect(screen.getByRole('menuitem', { name: 'Light' })).toHaveAttribute('data-current', 'true')
       expect(screen.getByRole('menuitem', { name: 'User settings' })).toBeInTheDocument()
+      expect(screen.getByRole('menuitem', { name: 'Company admin' })).toBeInTheDocument()
       expect(screen.queryByRole('menuitem', { name: 'Create workspace' })).toBeNull()
       expect(screen.queryByRole('menuitem', { name: 'Workspace settings' })).toBeNull()
       assertionPassed('user-menu-renders-user')
@@ -218,6 +223,25 @@ describe('UserMenu', () => {
       assertionPassed('user-menu-signout-navigates')
     }),
   )
+
+  it('hides company admin for non-owner workspace members', async () => {
+    mockUseWorkspaceRole.mockReturnValue('editor')
+    renderWithProviders(<UserMenu />)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'User settings' })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Company admin' })).toBeNull()
+  })
+
+  it('navigates owners to company admin', async () => {
+    renderWithProviders(<UserMenu />)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Company admin' }))
+
+    expect(mockNavigate).toHaveBeenCalledWith('/w/ws-a/admin')
+  })
 })
 
 describe('WorkspaceSwitcher', () => {

--- a/packages/core/src/front/components/UserMenu.tsx
+++ b/packages/core/src/front/components/UserMenu.tsx
@@ -16,13 +16,15 @@ import {
   Monitor,
   Moon,
   Settings,
+  ShieldCheck,
   Sun,
 } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 
 import { useSignOut, useUser } from '../auth/index.js'
+import { useCurrentWorkspace, useWorkspaceRole } from '../WorkspaceAuthProvider.js'
 import { useTheme } from '../hooks/index.js'
-import { routes } from '../utils.js'
+import { routeHref, routes } from '../utils.js'
 
 type ThemePreference = 'light' | 'dark' | 'system'
 
@@ -70,9 +72,12 @@ export function UserMenu({ contentSide = 'bottom', contentAlign = 'end', variant
   const signOut = useSignOut()
   const navigate = useNavigate()
   const { preference, setTheme } = useTheme()
+  const workspace = useCurrentWorkspace()
+  const workspaceRole = useWorkspaceRole()
   const [isSigningOut, setIsSigningOut] = useState(false)
 
   const user = identity?.user
+  const companyAdminWorkspaceId = workspaceRole === 'owner' ? workspace?.id ?? null : null
 
   const userName = user?.name ?? 'Unknown user'
   const userEmail = user?.email ?? 'unknown@example.com'
@@ -180,6 +185,20 @@ export function UserMenu({ contentSide = 'bottom', contentAlign = 'end', variant
             <span className="text-xs text-muted-foreground">Password and account controls</span>
           </span>
         </DropdownMenuItem>
+
+        {companyAdminWorkspaceId ? (
+          <DropdownMenuItem
+            aria-label="Company admin"
+            onSelect={() => navigate(routeHref('companyAdmin', { id: companyAdminWorkspaceId }))}
+            className="gap-3 rounded-md py-2 text-[13px] focus:bg-foreground/[0.06] focus:text-foreground"
+          >
+            <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            <span className="flex min-w-0 flex-col">
+              <span>Company admin</span>
+              <span className="text-xs text-muted-foreground">Context and model controls</span>
+            </span>
+          </DropdownMenuItem>
+        ) : null}
 
         <DropdownMenuSeparator className="-mx-2" />
 

--- a/packages/core/src/front/index.ts
+++ b/packages/core/src/front/index.ts
@@ -78,6 +78,7 @@ export type { CoreCommand } from './commands/CoreCommandContributions.js'
 export { InvitesPage } from './workspace/InvitesPage.js'
 export { MembersPage } from './workspace/MembersPage.js'
 export { WorkspaceSettingsPage } from './workspace/WorkspaceSettingsPage.js'
+export { CompanyAdminPage } from './workspace/CompanyAdminPage.js'
 export { getWorkspaceCommands } from './workspace/commands.js'
 export type { WorkspaceCommand } from './workspace/commands.js'
 

--- a/packages/core/src/front/utils.ts
+++ b/packages/core/src/front/utils.ts
@@ -125,6 +125,7 @@ export type RouteMap = {
   workspaceMembers: '/w/:id/members'
   workspaceInvites: '/w/:id/invites'
   workspaceSettings: '/w/:id/settings'
+  companyAdmin: '/w/:id/admin'
   inviteAccept: '/invites/:token'
 }
 
@@ -141,6 +142,7 @@ export const routes: RouteMap = {
   workspaceMembers: '/w/:id/members',
   workspaceInvites: '/w/:id/invites',
   workspaceSettings: '/w/:id/settings',
+  companyAdmin: '/w/:id/admin',
   inviteAccept: '/invites/:token',
 }
 

--- a/packages/core/src/front/workspace/CompanyAdminPage.tsx
+++ b/packages/core/src/front/workspace/CompanyAdminPage.tsx
@@ -1,0 +1,121 @@
+import { Navigate } from 'react-router-dom'
+import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '@hachej/boring-ui-kit'
+import { useCurrentWorkspace, useWorkspaceRole, useWorkspaceRouteStatus } from '../WorkspaceAuthProvider.js'
+import { routeHref } from '../utils.js'
+
+type AdminTab = 'context' | 'models'
+
+const TABS: Array<{ id: AdminTab; label: string; description: string }> = [
+  {
+    id: 'context',
+    label: 'Context access',
+    description: 'Control which company context paths each user can read with simple regex allow rules.',
+  },
+  {
+    id: 'models',
+    label: 'Model control',
+    description: 'Control which models each user can select and the budget allowed per model.',
+  },
+]
+
+export function CompanyAdminPage() {
+  const currentWorkspace = useCurrentWorkspace()
+  const role = useWorkspaceRole()
+  const routeStatus = useWorkspaceRouteStatus()
+
+  if (routeStatus.status === 'loading') {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
+        <section className="rounded-xl border border-border bg-card p-6 shadow-sm" aria-busy="true">
+          <p className="text-sm text-muted-foreground">Loading company admin…</p>
+        </section>
+      </main>
+    )
+  }
+
+  if (routeStatus.status === 'not-found' || routeStatus.status === 'switch-failed' || routeStatus.status === 'mismatched') {
+    const message = routeStatus.status === 'mismatched'
+      ? 'The requested workspace could not be loaded.'
+      : routeStatus.message
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
+        <section className="rounded-xl border border-border bg-card p-6 shadow-sm">
+          <p className="text-sm font-medium text-destructive">Workspace unavailable</p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">Company admin</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{message}</p>
+          <Button asChild className="mt-5">
+            <a href="/">Back to workspace</a>
+          </Button>
+        </section>
+      </main>
+    )
+  }
+
+  const workspace = routeStatus.status === 'matched' ? routeStatus.workspace : currentWorkspace
+  const workspaceId = routeStatus.workspaceId ?? workspace?.id ?? null
+  const workspaceName = workspace?.name ?? 'Current workspace'
+
+  if (!workspaceId) return <Navigate to="/" replace />
+
+  if (routeStatus.status === 'forbidden' || role !== 'owner') {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
+        <section className="rounded-xl border border-border bg-card p-6 shadow-sm">
+          <p className="text-sm font-medium text-destructive">Owner access required</p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">Company admin</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Only workspace owners can manage company context and model access controls.
+          </p>
+          <Button asChild className="mt-5">
+            <a href={routeHref('workspaceSettings', { id: workspaceId })}>Back to workspace settings</a>
+          </Button>
+        </section>
+      </main>
+    )
+  }
+
+  return (
+    <main className="min-h-screen bg-background px-4 py-8 text-foreground sm:px-6 lg:px-8">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <header className="rounded-2xl border border-border bg-card p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Company admin</p>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-3xl font-semibold tracking-tight">{workspaceName}</h1>
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                Manage user access to company context and model budgets for this workspace.
+              </p>
+            </div>
+            <Button asChild variant="outline">
+              <a href={routeHref('workspaceSettings', { id: workspaceId })}>Workspace settings</a>
+            </Button>
+          </div>
+        </header>
+
+        <section className="rounded-2xl border border-border bg-card p-4 shadow-sm sm:p-6">
+          <Tabs defaultValue="context" className="gap-4">
+            <TabsList aria-label="Company admin tabs" variant="line" className="flex-wrap justify-start">
+              {TABS.map((tab) => (
+                <TabsTrigger key={tab.id} value={tab.id}>
+                  {tab.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+
+            {TABS.map((tab) => (
+              <TabsContent key={tab.id} value={tab.id}>
+                <div className="rounded-xl border border-dashed border-border bg-muted/20 p-6">
+                  <h2 className="text-xl font-semibold tracking-tight">{tab.label}</h2>
+                  <p className="mt-2 max-w-2xl text-sm text-muted-foreground">{tab.description}</p>
+                  <p className="mt-5 text-sm text-muted-foreground">
+                    Configuration controls will land in the next stacked PR. This shell establishes the owner-only admin surface and navigation entry point.
+                  </p>
+                </div>
+              </TabsContent>
+            ))}
+          </Tabs>
+        </section>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
## Summary
- adds the #475 plan at `docs/issues/475/plan.md`
- adds `/w/:id/admin` and `/workspace/:id/admin` company admin shell routes
- adds an owner-only Company admin user-menu entry
- adds placeholder Context access and Model control tabs for the stacked follow-up PRs

## Proof
- ✅ `pnpm --filter @hachej/boring-ui-kit build`
- ✅ `pnpm --filter @hachej/boring-core exec vitest run src/front/__tests__/CompanyAdminPage.test.tsx src/front/__tests__/userNavComponents.test.tsx src/front/__tests__/CoreFront.test.tsx --no-file-parallelism`
- ⚠️ `pnpm --filter @hachej/boring-core run typecheck` fails on base/source mismatch: `packages/workspace/src/app/front/WorkspaceAgentFront.tsx` imports missing `searchPiSessions` from `@hachej/boring-agent/front`.

Stack: 1/3. Follow-ups: context regex access, model controls/budgets.

Closes #475 only when the full stack lands.