### PR TITLE
docs: plan boring-tasks kanban plugin

### DIFF
--- a/docs/plans/boring-tasks-kanban-plugin-plan.md
+++ b/docs/plans/boring-tasks-kanban-plugin-plan.md
@@ -253,7 +253,7 @@ Acceptance:
 - Cards can be dragged across columns.
 - Within-column reorder is disabled or snaps back.
 - Move calls the adapter boundary, not local-only hardcoded mutation.
-- Baseline route/model/component tests cover provider list, board config, task list, move, move/revert, and workspace isolation.
+- Baseline route/model/component tests cover adapter list, board config, task list, move, move/revert, and workspace isolation.
 - No task-specific branches in `WorkspaceAgentFront`.
 
 ### Slice 2 — adapter hardening
@@ -328,14 +328,14 @@ Narrow these once the files exist.
 | External adapter credentials leak | All adapter calls are server-side; browser sees only normalized task contracts. |
 | Hosted auth bypass | Later DB adapter must use boring-core workspace membership/auth, not a plugin-local permission model. |
 | Large external trackers need pagination/filtering | V1 `listTasks()` is unpaginated for mock/small boards. External adapters should add an optional query/cursor input as an additive interface change before GitHub/Linear-scale boards ship. |
-| Unknown task statuses drop cards | Unknown `statusId` values render in `defaultColumnId` or a non-droppable `Unmapped` column; never filter them out silently. |
+| Unknown task statuses drop cards | Unknown `statusId` values render in a non-droppable `Unmapped` column; never filter them out silently. |
 | Board surface chosen too late | #438 currently exposes overlay-shaped app-left actions; implementation must explicitly choose overlay vs workbench panel before coding slice 1. |
 | Stale data surprises users | V1 is fetch-on-open/refetch-after-move only; document no live sync until a later polling/SSE slice. |
 
 ## Open questions
 
 1. Final app-left/explorer contribution API name and opening surface after PR #438 lands. This is a hard precondition for implementation, not a detail to discover mid-slice. #438 is currently overlay-shaped; a Kanban board may need a workbench panel/surface instead.
-2. Whether `boring-tasks` should live as a publishable `plugins/boring-tasks` package or app-local plugin first. Default: publishable plugin package because multiple apps may want it.
+2. Whether `boring-tasks` should live as a publishable `plugins/tasks` package or app-local plugin first. Default: publishable plugin package because multiple apps may want it.
 3. Whether the Postgres adapter belongs in `boring-tasks` or a child-app adapter package. Default: keep the adapter interface in `boring-tasks`, allow app-owned adapter registration later if core auth coupling gets heavy.
 4. How external adapters get per-workspace source configuration, such as GitHub repo or Linear team. Options include one adapter id per configured source (for example `github:owner/repo`) or adapter-owned workspace settings. Either way, source configuration must stay out of the Kanban UI plugin.
 

--- a/docs/plans/boring-tasks-kanban-plugin-plan.md
+++ b/docs/plans/boring-tasks-kanban-plugin-plan.md
@@ -25,9 +25,9 @@ The first user-visible requirement is intentionally small:
 
 ## Goal
 
-Create a dedicated plugin package, `boring-tasks`, that owns a universal task-board UI and talks to task sources through provider adapters.
+Create a dedicated plugin package, `boring-tasks`, that owns a universal task-board UI and talks to task sources through adapters.
 
-The first implementation slice should prove the plugin and UI shape with a mock/in-memory provider. Persistence and external providers come later.
+The first implementation slice should prove the plugin and UI shape with a mock/in-memory adapter. Persistence and external adapters come later.
 
 ## Non-goals
 
@@ -35,8 +35,9 @@ The first implementation slice should prove the plugin and UI shape with a mock/
 - No boring-ui database migration in the first slice.
 - No GitHub, Linear, Kata, or Plane credentials in the first slice.
 - No task-specific branches in `WorkspaceAgentFront`.
-- No runtime-generated plugin route registration; this is an app/internal trusted plugin when backend providers are needed.
-- No attempt to make every provider support every mutation. Read-only providers are valid.
+- No runtime-generated plugin route registration; this is an app/internal trusted plugin when backend adapters are needed.
+- No attempt to make every adapter support every mutation. Read-only adapters are valid.
+- No GitHub/Kata/Linear/Plane-specific logic in the Kanban UI plugin. Source-specific behavior belongs in adapters.
 
 ## Required architecture
 
@@ -58,10 +59,10 @@ plugins/boring-tasks/
   src/front/taskBoardModel.ts
   src/front/useTaskBoardData.ts
   src/server/index.ts
-  src/server/providers/mockProvider.ts
+  src/server/adapters/mockAdapter.ts
 ```
 
-The plugin is app/internal because later providers need trusted server-side credentials and routes. A future runtime/generated frontend-only demo can consume the same shared model, but should not be the canonical hosted integration. Generate the package from the canonical app/internal plugin shape (`boring-ui-plugin create boring-tasks --path plugins`) rather than inventing a custom layout.
+The plugin is app/internal because later adapters need trusted server-side credentials and routes. A future runtime/generated frontend-only demo can consume the same shared model, but should not be the canonical hosted integration. Generate the package from the canonical app/internal plugin shape (`boring-ui-plugin create boring-tasks --path plugins`) rather than inventing a custom layout.
 
 ### 2. App-left/explorer contribution, not host special-casing
 
@@ -92,7 +93,7 @@ export interface BoringTaskColumn {
 }
 
 export interface BoringTaskBoardConfig {
-  providerId: string;
+  adapterId: string;
   columns: BoringTaskColumn[];
   defaultColumnId?: BoringTaskStatusId;
 }
@@ -103,12 +104,12 @@ export interface BoringTaskCard {
   title: string;
   description?: string;
   statusId: BoringTaskStatusId;
-  providerId: string;
+  adapterId: string;
   url?: string;
 }
 
 // Later slices may add non-required display metadata such as assignee, labels,
-// and priority after a real provider needs them.
+// and priority after a real adapter needs them.
 ```
 
 Keep the initial card UI constrained to:
@@ -119,53 +120,55 @@ Keep the initial card UI constrained to:
 [description]
 ```
 
-Do not expose provider-native shapes to the frontend card component. Provider-native payloads may stay server-side or in an explicitly non-rendered debug field later.
+Do not expose source-native shapes to the frontend card component. Source-native payloads may stay server-side or in an explicitly non-rendered debug field later.
 
-### 4. Provider boundary
+### 4. Adapter boundary
 
-Define a backend provider interface. Keep it narrow until real providers require more. Providers are injected at boot; the generic plugin must not directly own hosted DB/auth/secret resolution:
+`boring-tasks` should stay lean: it owns the standard card model, board chrome, selectors, drag/drop mechanics, loading/error states, and optimistic/revert behavior. It does **not** own tracker-specific actions. Adapters own source-specific status mapping, mutation semantics, credentials, and action translation.
+
+Define a backend adapter interface. Keep it narrow until real adapters require more. Adapters are injected at boot; the generic plugin must not directly own hosted DB/auth/secret resolution:
 
 ```ts
-export interface BoringTaskProviderContext {
+export interface BoringTaskAdapterContext {
   workspaceId: string;
   actorId?: string;
   requestId: string;
 }
 
 export interface BoringTasksServerPluginOptions {
-  providers: BoringTaskProvider[];
-  resolveWorkspaceContext(request: unknown): Promise<BoringTaskProviderContext>;
+  adapters: BoringTaskAdapter[];
+  resolveWorkspaceContext(request: unknown): Promise<BoringTaskAdapterContext>;
 }
 
 export function createBoringTasksServerPlugin(
   options: BoringTasksServerPluginOptions,
 ): WorkspaceServerPlugin;
 
-export interface BoringTaskProvider {
+export interface BoringTaskAdapter {
   id: string;
   label: string;
   capabilities: {
     list: true;
     move: boolean;
   };
-  getBoardConfig(ctx: BoringTaskProviderContext): Promise<BoringTaskBoardConfig>;
-  listTasks(ctx: BoringTaskProviderContext): Promise<BoringTaskCard[]>;
-  moveTask?(ctx: BoringTaskProviderContext, input: {
+  getBoardConfig(ctx: BoringTaskAdapterContext): Promise<BoringTaskBoardConfig>;
+  listTasks(ctx: BoringTaskAdapterContext): Promise<BoringTaskCard[]>;
+  moveTask?(ctx: BoringTaskAdapterContext, input: {
     taskId: string;
     statusId: BoringTaskStatusId;
   }): Promise<BoringTaskCard>;
 }
 ```
 
-Provider rules:
+Adapter rules:
 
-- Providers expose their available status tags/columns through `getBoardConfig()`.
-- The playground/dev app injects `createMockTaskProvider()`; hosted apps inject DB or external providers.
-- Providers declare `capabilities.move`; the UI disables drag for providers that cannot move tasks.
-- Providers may normalize native statuses (`GitHub labels`, `Linear states`, `Kata status/claim`, custom DB enum) into stable `statusId` values, but the UI must not hardcode a global status enum.
-- Provider failures revert optimistic UI changes.
-- Credentials and provider-native API clients stay on the server.
-- Additional capabilities (`create`, `comment`, `assign`, `close`) are added only in the slice that introduces the corresponding route/tool.
+- Adapters expose their available status tags/columns through `getBoardConfig()`.
+- The playground/dev app injects `createMockTaskAdapter()`; hosted apps inject DB or external adapters.
+- Adapters declare `capabilities.move`; the UI disables drag for adapters that cannot move tasks.
+- Adapters may normalize native statuses (`GitHub labels`, `Linear states`, `Kata status/claim`, custom DB enum) into stable `statusId` values, but the UI must not hardcode a global status enum.
+- Adapter failures revert optimistic UI changes.
+- Credentials and source-native API clients stay on the server-side adapter.
+- Additional capabilities (`create`, `comment`, `assign`, `close`) are added only when a real adapter exposes the corresponding action. The UI renders those actions from adapter metadata instead of hardcoding tracker-specific buttons.
 
 ### 5. Kanban implementation
 
@@ -181,9 +184,9 @@ Use shadcn-style layout primitives from `@hachej/boring-ui-kit` where possible. 
 
 Board behavior:
 
-1. Fetch provider board config and render its columns in `order`.
+1. Fetch adapter board config and render its columns in `order`.
 2. Group cards by `statusId`.
-3. Provide a provider/status selector bar so the user can switch provider and, later, filter by status/tag.
+3. Provide an adapter/status selector bar so the user can switch adapter and, later, filter by status/tag.
 4. Support cross-column status moves. Within-column reordering is not persisted in v1 and should be disabled or snap back.
 5. Optimistically move the card.
 6. Call the backend move route.
@@ -194,38 +197,38 @@ Board behavior:
 First implementation slice needs only:
 
 ```txt
-GET  /api/boring-tasks/providers
-GET  /api/boring-tasks/providers/:providerId/board
-GET  /api/boring-tasks/providers/:providerId/tasks
-POST /api/boring-tasks/providers/:providerId/tasks/:taskId/move
+GET  /api/boring-tasks/adapters
+GET  /api/boring-tasks/adapters/:adapterId/board
+GET  /api/boring-tasks/adapters/:adapterId/tasks
+POST /api/boring-tasks/adapters/:adapterId/tasks/:taskId/move
 ```
 
 Route responses should use stable error codes and typed JSON contracts. Initial codes:
 
-- `BORING_TASK_PROVIDER_NOT_FOUND`
+- `BORING_TASK_ADAPTER_NOT_FOUND`
 - `BORING_TASK_MOVE_UNSUPPORTED`
 - `BORING_TASK_NOT_FOUND`
 - `BORING_TASK_MOVE_FAILED`
 - `BORING_TASK_WORKSPACE_REQUIRED`
 
-Do not leak provider credentials or raw provider errors to the browser.
+Do not leak adapter credentials or raw adapter errors to the browser.
 
-### 7. Workspace/provider context
+### 7. Workspace/adapter context
 
-Every request must resolve a `BoringTaskProviderContext` before touching provider state. Even the mock provider should be workspace-scoped so the first slice does not bake in a global task board assumption. Route tests must prove tasks and moves are isolated by workspace.
+Every request must resolve a `BoringTaskAdapterContext` before touching adapter state. Even the mock adapter should be workspace-scoped so the first slice does not bake in a global task board assumption. Route tests must prove tasks and moves are isolated by workspace.
 
 For hosted/core apps, later Postgres-backed tasks should use boring-core workspace membership and auth; the task plugin should not invent its own auth model.
 
 ## Implementation slices
 
-### Slice 1 — UI and mock provider
+### Slice 1 — UI and mock adapter
 
 - Add `plugins/boring-tasks` package.
 - Add shared task card/status types.
-- Add injected mock provider with sample cards, registered by workspace playground/dev app.
-- Add server plugin routes for provider list, board config, task list, and move.
+- Add injected mock adapter with sample cards, registered by workspace playground/dev app.
+- Add server plugin routes for adapter list, board config, task list, and move.
 - Add front plugin app-left/explorer contribution named `Tasks`.
-- Add a provider selector/status toolbar.
+- Add an adapter selector/status toolbar.
 - Add `TaskKanbanBoard`, `TaskKanbanColumn`, and `TaskCard`.
 - Implement drag/drop with optimistic move/revert.
 - Register plugin in workspace playground for development.
@@ -233,32 +236,32 @@ For hosted/core apps, later Postgres-backed tasks should use boring-core workspa
 Acceptance:
 
 - `Tasks` appears through plugin-owned app-left/explorer contribution.
-- Opening `Tasks` shows the columns returned by the selected provider's board config.
+- Opening `Tasks` shows the columns returned by the selected adapter's board config.
 - Cards display number, title, and description.
 - Cards can be dragged across columns.
 - Within-column reorder is disabled or snaps back.
-- Move calls the provider boundary, not local-only hardcoded mutation.
+- Move calls the adapter boundary, not local-only hardcoded mutation.
 - No task-specific branches in `WorkspaceAgentFront`.
 
-### Slice 2 — provider hardening
+### Slice 2 — adapter hardening
 
-- Add provider capability display/read-only behavior.
-- Keep create/comment/assign/close out of the provider contract unless this slice introduces those routes.
+- Add adapter capability display/read-only behavior.
+- Keep create/comment/assign/close out of the adapter contract unless a real adapter introduces those actions.
 - Add status/column mapping helpers.
 - Add empty/loading/error states.
-- Add tests for provider routing, frontend grouping, and move/revert behavior.
-- Add plugin README documenting provider contracts.
+- Add tests for adapter routing, frontend grouping, and move/revert behavior.
+- Add plugin README documenting adapter contracts.
 
 Acceptance:
 
-- Read-only providers render but do not allow drag.
+- Read-only adapters render but do not allow drag.
 - Failed moves revert the card.
-- Provider list/board/tasks/move routes have typed tests.
+- Adapter list/board/tasks/move routes have typed tests.
 
-### Slice 3 — boring-ui-native Postgres provider
+### Slice 3 — boring-ui-native Postgres adapter
 
 - Add Postgres schema for workspace tasks, comments, events, and labels.
-- Add `custom-db` or `boring-db` provider.
+- Add `custom-db` or `boring-db` adapter.
 - Use boring-core workspace/auth boundaries.
 - Add agent tools: list, create, claim/move, comment, close.
 - Add CLI/API design after the backend contract settles.
@@ -266,26 +269,26 @@ Acceptance:
 Acceptance:
 
 - Hosted boring-ui can persist tasks in its own Postgres.
-- The Kanban board uses the same provider interface as the mock provider.
+- The Kanban board uses the same adapter interface as the mock adapter.
 - Agent tools use the same task service layer as routes.
 
-### Slice 4 — external providers
+### Slice 4 — external adapters
 
-Add providers one at a time:
+Add adapters one at a time:
 
 1. GitHub Issues read-only, then status-label/close support.
 2. Kata via backend adapter if needed.
 3. Linear via API.
 4. Plane/custom API.
 
-Each external provider must document auth, status/column mapping, mutation support, and failure semantics. Columns are provider-supplied from the start. Providers that cannot safely move between native states should set `capabilities.move = false` or mark specific columns with `acceptsDrop: false`. Provider docs must state whether native status mapping is lossy and whether moves are safe.
+Each external adapter must document auth, status/column mapping, mutation support, and failure semantics. Columns are adapter-supplied from the start. Adapters that cannot safely move between native states should set `capabilities.move = false` or mark specific columns with `acceptsDrop: false`. Adapter docs must state whether native status mapping is lossy and whether moves are safe.
 
 ## Testing plan
 
 First implementation PR should include:
 
 - unit tests for task grouping and status/column mapping;
-- route tests for provider list/board/task list/move;
+- route tests for adapter list/board/task list/move;
 - component tests for card rendering and move callback;
 - one workspace-playground e2e smoke test for opening the Tasks action and dragging a card if the test harness can make drag deterministic.
 
@@ -305,26 +308,26 @@ Narrow these once the files exist.
 
 | Risk | Mitigation |
 | --- | --- |
-| Generic provider abstraction becomes too abstract | Keep v1 provider contract tiny: board config, list, and move only. Add methods only when a real provider needs them. |
-| Board leaks provider-native concepts | Normalize at provider boundary; card receives only `BoringTaskCard`. |
+| Generic adapter abstraction becomes too abstract | Keep v1 adapter contract tiny: board config, list, and move only. Add methods only when a real adapter needs them. |
+| Board leaks source-native concepts | Normalize at adapter boundary; card receives only `BoringTaskCard`. |
 | Host shell gets task-specific branches | Depend on #438 app-left/explorer plugin outputs; block implementation if this requires host special-casing. |
 | Drag/drop library complexity spreads | Contain `@dnd-kit` usage inside `TaskKanbanBoard` and child components. |
-| External provider credentials leak | All provider calls are server-side; browser sees only normalized task contracts. |
-| Hosted auth bypass | Later DB provider must use boring-core workspace membership/auth, not a plugin-local permission model. |
+| External adapter credentials leak | All adapter calls are server-side; browser sees only normalized task contracts. |
+| Hosted auth bypass | Later DB adapter must use boring-core workspace membership/auth, not a plugin-local permission model. |
 
 ## Open questions
 
 1. Final app-left/explorer contribution API name and opening surface after PR #438 lands. This is a hard precondition for implementation, not a detail to discover mid-slice.
 2. Whether `boring-tasks` should live as a publishable `plugins/boring-tasks` package or app-local plugin first. Default: publishable plugin package because multiple apps may want it.
-3. Whether the Postgres provider belongs in `boring-tasks` or a child-app adapter package. Default: keep provider interface in `boring-tasks`, allow app-owned provider registration later if core auth coupling gets heavy.
+3. Whether the Postgres adapter belongs in `boring-tasks` or a child-app adapter package. Default: keep the adapter interface in `boring-tasks`, allow app-owned adapter registration later if core auth coupling gets heavy.
 
 ## Definition of done for implementation slice 1
 
 - Dedicated `boring-tasks` plugin package exists with its own typecheck/test target.
 - App-left/explorer `Tasks` action is plugin-owned.
-- Provider-configured Kanban board renders mock tasks.
+- Adapter-configured Kanban board renders mock tasks.
 - Task card includes number, title, description.
-- Drag/drop move flows through injected provider boundary and supports revert on failure.
+- Drag/drop move flows through injected adapter boundary and supports revert on failure.
 - Tests cover model, route, and front behavior.
 - No host shell task special-casing.
 

--- a/docs/plans/boring-tasks-kanban-plugin-plan.md
+++ b/docs/plans/boring-tasks-kanban-plugin-plan.md
@@ -1,0 +1,313 @@
+# boring-tasks Kanban plugin plan
+
+## Status
+
+Planning PR. No implementation in this slice.
+
+This plan depends on the plugin app-left/explorer contribution work in PR #438 (`feat(workspace): add inbox shell plugin architecture`). **Do not start implementation slice 1 until #438 lands and documents the public plugin-owned app-left/explorer contribution API.** If #438 changes the final API names, keep the architecture below and update names during implementation.
+
+## Problem
+
+boring-ui needs a task surface that is not tied to one tracker. The same Kanban board should be able to display and move tasks from:
+
+- boring-ui-native Postgres tasks;
+- GitHub Issues;
+- Linear;
+- Kata;
+- Plane;
+- a custom API or static/dev task list.
+
+The first user-visible requirement is intentionally small:
+
+- a standard task card with a number, title, and description;
+- a Kanban board;
+- drag-and-drop between columns.
+
+## Goal
+
+Create a dedicated plugin package, `boring-tasks`, that owns a universal task-board UI and talks to task sources through provider adapters.
+
+The first implementation slice should prove the plugin and UI shape with a mock/in-memory provider. Persistence and external providers come later.
+
+## Non-goals
+
+- No full Jira/Linear clone in the first slice.
+- No boring-ui database migration in the first slice.
+- No GitHub, Linear, Kata, or Plane credentials in the first slice.
+- No task-specific branches in `WorkspaceAgentFront`.
+- No runtime-generated plugin route registration; this is an app/internal trusted plugin when backend providers are needed.
+- No attempt to make every provider support every mutation. Read-only providers are valid.
+
+## Required architecture
+
+### 1. Dedicated app/internal plugin
+
+Create the package at:
+
+```txt
+plugins/boring-tasks/
+  package.json
+  src/shared/types.ts
+  README.md
+  tsup.config.ts
+  vitest.config.ts
+  src/front/index.tsx
+  src/front/TaskKanbanBoard.tsx
+  src/front/TaskKanbanColumn.tsx
+  src/front/TaskCard.tsx
+  src/front/taskBoardModel.ts
+  src/front/useTaskBoardData.ts
+  src/server/index.ts
+  src/server/providers/mockProvider.ts
+```
+
+The plugin is app/internal because later providers need trusted server-side credentials and routes. A future runtime/generated frontend-only demo can consume the same shared model, but should not be the canonical hosted integration. Generate the package from the canonical app/internal plugin shape (`boring-ui-plugin create boring-tasks --path plugins`) rather than inventing a custom layout.
+
+### 2. App-left/explorer contribution, not host special-casing
+
+Use the app-left/explorer contribution model introduced by PR #438:
+
+- `boring-tasks` contributes a `Tasks` app-left action.
+- The action opens plugin-owned board content using the public #438 contribution API.
+- No app-shell prop injection is allowed as a substitute for plugin registration.
+- `WorkspaceAgentFront` remains generic and contains no `boring-tasks` or task-board branch.
+- The board renders inside the `WorkspaceProvider`/plugin provider topology, matching the Inbox plugin precedent.
+
+If #438 lands with a different output name than `appLeftActions`, adapt the name but preserve the ownership rule: the plugin registers the entry; the shell hosts it.
+
+### 3. Standard task card contract
+
+Define a small normalized card model in `src/shared/types.ts`:
+
+```ts
+export type BoringTaskStatus = "todo" | "in_progress" | "review" | "done";
+
+export interface BoringTaskCard {
+  id: string;
+  number: string;
+  title: string;
+  description?: string;
+  status: BoringTaskStatus;
+  providerId: string;
+  url?: string;
+}
+
+// Later slices may add non-required display metadata such as assignee, labels,
+// and priority after a real provider needs them.
+```
+
+Keep the initial card UI constrained to:
+
+```txt
+[number]
+[title]
+[description]
+```
+
+Do not expose provider-native shapes to the frontend card component. Provider-native payloads may stay server-side or in an explicitly non-rendered debug field later.
+
+### 4. Provider boundary
+
+Define a backend provider interface. Keep it narrow until real providers require more. Providers are injected at boot; the generic plugin must not directly own hosted DB/auth/secret resolution:
+
+```ts
+export interface BoringTaskProviderContext {
+  workspaceId: string;
+  actorId?: string;
+  requestId: string;
+}
+
+export interface BoringTasksServerPluginOptions {
+  providers: BoringTaskProvider[];
+  resolveWorkspaceContext(request: unknown): Promise<BoringTaskProviderContext>;
+}
+
+export function createBoringTasksServerPlugin(
+  options: BoringTasksServerPluginOptions,
+): WorkspaceServerPlugin;
+
+export interface BoringTaskProvider {
+  id: string;
+  label: string;
+  capabilities: {
+    list: true;
+    move: boolean;
+  };
+  listTasks(ctx: BoringTaskProviderContext): Promise<BoringTaskCard[]>;
+  moveTask?(ctx: BoringTaskProviderContext, input: {
+    taskId: string;
+    status: BoringTaskStatus;
+  }): Promise<BoringTaskCard>;
+}
+```
+
+Provider rules:
+
+- Providers map their native statuses into `BoringTaskStatus`.
+- The playground/dev app injects `createMockTaskProvider()`; hosted apps inject DB or external providers.
+- Providers declare `capabilities.move`; the UI disables drag for providers that cannot move tasks.
+- Provider failures revert optimistic UI changes.
+- Credentials and provider-native API clients stay on the server.
+- Additional capabilities (`create`, `comment`, `assign`, `close`) are added only in the slice that introduces the corresponding route/tool.
+
+### 5. Kanban implementation
+
+Use `@dnd-kit` directly rather than a heavy Kanban framework:
+
+```txt
+@dnd-kit/core
+@dnd-kit/sortable
+@dnd-kit/utilities
+```
+
+Use shadcn-style layout primitives from `@hachej/boring-ui-kit` where possible. The Georgegriff React + dnd-kit + Tailwind + shadcn Kanban demo is a useful reference, not a dependency to vendor wholesale.
+
+Board behavior:
+
+1. Render columns: `todo`, `in_progress`, `review`, `done`.
+2. Group cards by `status`.
+3. Support cross-column status moves. Within-column reordering is not persisted in v1 and should be disabled or snap back.
+4. Optimistically move the card.
+5. Call the backend move route.
+6. Revert and show a toast/inline error if the backend rejects.
+
+### 6. Routes
+
+First implementation slice needs only:
+
+```txt
+GET  /api/boring-tasks/providers
+GET  /api/boring-tasks/providers/:providerId/tasks
+POST /api/boring-tasks/providers/:providerId/tasks/:taskId/move
+```
+
+Route responses should use stable error codes and typed JSON contracts. Initial codes:
+
+- `BORING_TASK_PROVIDER_NOT_FOUND`
+- `BORING_TASK_MOVE_UNSUPPORTED`
+- `BORING_TASK_NOT_FOUND`
+- `BORING_TASK_MOVE_FAILED`
+- `BORING_TASK_WORKSPACE_REQUIRED`
+
+Do not leak provider credentials or raw provider errors to the browser.
+
+### 7. Workspace/provider context
+
+Every request must resolve a `BoringTaskProviderContext` before touching provider state. Even the mock provider should be workspace-scoped so the first slice does not bake in a global task board assumption. Route tests must prove tasks and moves are isolated by workspace.
+
+For hosted/core apps, later Postgres-backed tasks should use boring-core workspace membership and auth; the task plugin should not invent its own auth model.
+
+## Implementation slices
+
+### Slice 1 — UI and mock provider
+
+- Add `plugins/boring-tasks` package.
+- Add shared task card/status types.
+- Add injected mock provider with sample cards, registered by workspace playground/dev app.
+- Add server plugin routes for provider list, task list, and move.
+- Add front plugin app-left/explorer contribution named `Tasks`.
+- Add `TaskKanbanBoard`, `TaskKanbanColumn`, and `TaskCard`.
+- Implement drag/drop with optimistic move/revert.
+- Register plugin in workspace playground for development.
+
+Acceptance:
+
+- `Tasks` appears through plugin-owned app-left/explorer contribution.
+- Opening `Tasks` shows four Kanban columns.
+- Cards display number, title, and description.
+- Cards can be dragged across columns.
+- Within-column reorder is disabled or snaps back.
+- Move calls the provider boundary, not local-only hardcoded mutation.
+- No task-specific branches in `WorkspaceAgentFront`.
+
+### Slice 2 — provider hardening
+
+- Add provider capability display/read-only behavior.
+- Keep create/comment/assign/close out of the provider contract unless this slice introduces those routes.
+- Add status mapping helpers.
+- Add empty/loading/error states.
+- Add tests for provider routing, frontend grouping, and move/revert behavior.
+- Add plugin README documenting provider contracts.
+
+Acceptance:
+
+- Read-only providers render but do not allow drag.
+- Failed moves revert the card.
+- Provider list/tasks/move routes have typed tests.
+
+### Slice 3 — boring-ui-native Postgres provider
+
+- Add Postgres schema for workspace tasks, comments, events, and labels.
+- Add `custom-db` or `boring-db` provider.
+- Use boring-core workspace/auth boundaries.
+- Add agent tools: list, create, claim/move, comment, close.
+- Add CLI/API design after the backend contract settles.
+
+Acceptance:
+
+- Hosted boring-ui can persist tasks in its own Postgres.
+- The Kanban board uses the same provider interface as the mock provider.
+- Agent tools use the same task service layer as routes.
+
+### Slice 4 — external providers
+
+Add providers one at a time:
+
+1. GitHub Issues read-only, then status-label/close support.
+2. Kata via backend adapter if needed.
+3. Linear via API.
+4. Plane/custom API.
+
+Each external provider must document auth, status mapping, mutation support, and failure semantics. The v1 board schema is intentionally fixed to four canonical columns; providers that cannot safely map native states must be read-only until a later slice adds provider/workspace-configurable columns. Provider docs must state whether native status mapping is lossy and whether moves are safe.
+
+## Testing plan
+
+First implementation PR should include:
+
+- unit tests for task grouping and status mapping;
+- route tests for provider list/task list/move;
+- component tests for card rendering and move callback;
+- one workspace-playground e2e smoke test for opening the Tasks action and dragging a card if the test harness can make drag deterministic.
+
+Relevant commands will likely be:
+
+```bash
+pnpm --filter @hachej/boring-tasks typecheck
+pnpm --filter @hachej/boring-tasks test
+pnpm --filter @hachej/boring-workspace typecheck
+pnpm --filter @hachej/boring-workspace test
+pnpm --filter workspace-playground test
+```
+
+Narrow these once the files exist.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Generic provider abstraction becomes too abstract | Keep v1 provider contract tiny: list and move only. Add methods only when a real provider needs them. |
+| Board leaks provider-native concepts | Normalize at provider boundary; card receives only `BoringTaskCard`. |
+| Host shell gets task-specific branches | Depend on #438 app-left/explorer plugin outputs; block implementation if this requires host special-casing. |
+| Drag/drop library complexity spreads | Contain `@dnd-kit` usage inside `TaskKanbanBoard` and child components. |
+| External provider credentials leak | All provider calls are server-side; browser sees only normalized task contracts. |
+| Hosted auth bypass | Later DB provider must use boring-core workspace membership/auth, not a plugin-local permission model. |
+
+## Open questions
+
+1. Final app-left/explorer contribution API name and opening surface after PR #438 lands. This is a hard precondition for implementation, not a detail to discover mid-slice.
+2. Whether `boring-tasks` should live as a publishable `plugins/boring-tasks` package or app-local plugin first. Default: publishable plugin package because multiple apps may want it.
+3. Whether the Postgres provider belongs in `boring-tasks` or a child-app adapter package. Default: keep provider interface in `boring-tasks`, allow app-owned provider registration later if core auth coupling gets heavy.
+
+## Definition of done for implementation slice 1
+
+- Dedicated `boring-tasks` plugin package exists with its own typecheck/test target.
+- App-left/explorer `Tasks` action is plugin-owned.
+- Four-column Kanban board renders mock tasks.
+- Task card includes number, title, description.
+- Drag/drop move flows through injected provider boundary and supports revert on failure.
+- Tests cover model, route, and front behavior.
+- No host shell task special-casing.
+
+## Thermo review
+
+Plan review is recorded in [`reviews/boring-tasks-kanban-plugin-thermo-review.md`](reviews/boring-tasks-kanban-plugin-thermo-review.md). The review's blocker findings were incorporated into this plan before opening the PR.

--- a/docs/plans/boring-tasks-kanban-plugin-plan.md
+++ b/docs/plans/boring-tasks-kanban-plugin-plan.md
@@ -46,7 +46,7 @@ The first implementation slice should prove the plugin and UI shape with a mock/
 Create the package at:
 
 ```txt
-plugins/boring-tasks/
+plugins/tasks/
   package.json
   src/shared/types.ts
   README.md
@@ -62,7 +62,7 @@ plugins/boring-tasks/
   src/server/adapters/mockAdapter.ts
 ```
 
-The plugin is app/internal because later adapters need trusted server-side credentials and routes. A future runtime/generated frontend-only demo can consume the same shared model, but should not be the canonical hosted integration. Generate the package from the canonical app/internal plugin shape (`boring-ui-plugin create boring-tasks --path plugins`) rather than inventing a custom layout.
+The plugin is app/internal because later adapters need trusted server-side credentials and routes. A future runtime/generated frontend-only demo can consume the same shared model, but should not be the canonical hosted integration. Generate the package from the canonical app/internal plugin shape (`boring-ui-plugin create tasks --path plugins`) rather than inventing a custom layout. That yields the package name `@hachej/boring-tasks`; keep the public route prefix `/api/boring-tasks` as an explicit API constant rather than deriving it from the directory name.
 
 ### 2. App-left/explorer contribution, not host special-casing
 
@@ -94,6 +94,8 @@ export interface BoringTaskColumn {
 export interface BoringTaskBoardConfig {
   adapterId: string;
   columns: BoringTaskColumn[];
+  // Reserved for future create flows; unmapped existing cards still render in
+  // the non-droppable Unmapped overflow column.
   defaultColumnId?: BoringTaskStatusId;
 }
 
@@ -189,7 +191,7 @@ Use shadcn-style layout primitives from `@hachej/boring-ui-kit` where possible. 
 Board behavior:
 
 1. Fetch adapter board config and render its columns in returned array order.
-2. Group cards by `statusId`. Cards whose `statusId` matches no configured column render in `defaultColumnId` when set; otherwise they render in a non-droppable `Unmapped` overflow column. They must never silently disappear.
+2. Group cards by `statusId`. Cards whose `statusId` matches no configured column render in a non-droppable `Unmapped` overflow column. They must never silently disappear or be visually merged into a normal status column. `defaultColumnId` is reserved for future create/defaulting flows, not for rendering unmapped existing cards.
 3. Provide an adapter selector toolbar so the user can switch adapter. Status/tag filtering is a later slice.
 4. Support cross-column status moves. Within-column reordering is not persisted in v1 and should be disabled or snap back.
 5. Optimistically move the card.
@@ -232,7 +234,7 @@ For hosted/core apps, later Postgres-backed tasks should use boring-core workspa
 
 ### Slice 1 — UI and mock adapter
 
-- Add `plugins/boring-tasks` package.
+- Add `plugins/tasks` package (`@hachej/boring-tasks`).
 - Add shared task card/status types.
 - Add injected mock adapter with sample cards, registered by workspace playground/dev app.
 - Add server plugin routes for adapter list, board config, task list, and move.
@@ -251,15 +253,16 @@ Acceptance:
 - Cards can be dragged across columns.
 - Within-column reorder is disabled or snaps back.
 - Move calls the adapter boundary, not local-only hardcoded mutation.
+- Baseline route/model/component tests cover provider list, board config, task list, move, move/revert, and workspace isolation.
 - No task-specific branches in `WorkspaceAgentFront`.
 
 ### Slice 2 — adapter hardening
 
 - Add adapter capability display/read-only behavior.
 - Keep create/comment/assign/close out of the adapter contract unless a real adapter introduces those actions.
-- Add status/column mapping helpers.
+- Add status/column mapping helpers only as generic utilities (group-by-`statusId`, unmapped handling, column ordering) or shared adapter helpers; never tracker-aware UI code.
 - Add empty/loading/error states.
-- Add tests for adapter routing, frontend grouping, and move/revert behavior.
+- Add hardening/edge-case tests beyond the Slice 1 baseline.
 - Add plugin README documenting adapter contracts.
 
 Acceptance:
@@ -334,6 +337,7 @@ Narrow these once the files exist.
 1. Final app-left/explorer contribution API name and opening surface after PR #438 lands. This is a hard precondition for implementation, not a detail to discover mid-slice. #438 is currently overlay-shaped; a Kanban board may need a workbench panel/surface instead.
 2. Whether `boring-tasks` should live as a publishable `plugins/boring-tasks` package or app-local plugin first. Default: publishable plugin package because multiple apps may want it.
 3. Whether the Postgres adapter belongs in `boring-tasks` or a child-app adapter package. Default: keep the adapter interface in `boring-tasks`, allow app-owned adapter registration later if core auth coupling gets heavy.
+4. How external adapters get per-workspace source configuration, such as GitHub repo or Linear team. Options include one adapter id per configured source (for example `github:owner/repo`) or adapter-owned workspace settings. Either way, source configuration must stay out of the Kanban UI plugin.
 
 ## Definition of done for implementation slice 1
 

--- a/docs/plans/boring-tasks-kanban-plugin-plan.md
+++ b/docs/plans/boring-tasks-kanban-plugin-plan.md
@@ -77,17 +77,32 @@ If #438 lands with a different output name than `appLeftActions`, adapt the name
 
 ### 3. Standard task card contract
 
-Define a small normalized card model in `src/shared/types.ts`:
+Define small normalized models in `src/shared/types.ts`. Columns are data, not code. A task carries a status tag/id, and the board configuration decides which status tags appear as columns and in what order.
 
 ```ts
-export type BoringTaskStatus = "todo" | "in_progress" | "review" | "done";
+export type BoringTaskStatusId = string;
+
+export interface BoringTaskColumn {
+  id: BoringTaskStatusId;
+  title: string;
+  description?: string;
+  color?: string;
+  order: number;
+  acceptsDrop?: boolean;
+}
+
+export interface BoringTaskBoardConfig {
+  providerId: string;
+  columns: BoringTaskColumn[];
+  defaultColumnId?: BoringTaskStatusId;
+}
 
 export interface BoringTaskCard {
   id: string;
   number: string;
   title: string;
   description?: string;
-  status: BoringTaskStatus;
+  statusId: BoringTaskStatusId;
   providerId: string;
   url?: string;
 }
@@ -133,19 +148,21 @@ export interface BoringTaskProvider {
     list: true;
     move: boolean;
   };
+  getBoardConfig(ctx: BoringTaskProviderContext): Promise<BoringTaskBoardConfig>;
   listTasks(ctx: BoringTaskProviderContext): Promise<BoringTaskCard[]>;
   moveTask?(ctx: BoringTaskProviderContext, input: {
     taskId: string;
-    status: BoringTaskStatus;
+    statusId: BoringTaskStatusId;
   }): Promise<BoringTaskCard>;
 }
 ```
 
 Provider rules:
 
-- Providers map their native statuses into `BoringTaskStatus`.
+- Providers expose their available status tags/columns through `getBoardConfig()`.
 - The playground/dev app injects `createMockTaskProvider()`; hosted apps inject DB or external providers.
 - Providers declare `capabilities.move`; the UI disables drag for providers that cannot move tasks.
+- Providers may normalize native statuses (`GitHub labels`, `Linear states`, `Kata status/claim`, custom DB enum) into stable `statusId` values, but the UI must not hardcode a global status enum.
 - Provider failures revert optimistic UI changes.
 - Credentials and provider-native API clients stay on the server.
 - Additional capabilities (`create`, `comment`, `assign`, `close`) are added only in the slice that introduces the corresponding route/tool.
@@ -164,12 +181,13 @@ Use shadcn-style layout primitives from `@hachej/boring-ui-kit` where possible. 
 
 Board behavior:
 
-1. Render columns: `todo`, `in_progress`, `review`, `done`.
-2. Group cards by `status`.
-3. Support cross-column status moves. Within-column reordering is not persisted in v1 and should be disabled or snap back.
-4. Optimistically move the card.
-5. Call the backend move route.
-6. Revert and show a toast/inline error if the backend rejects.
+1. Fetch provider board config and render its columns in `order`.
+2. Group cards by `statusId`.
+3. Provide a provider/status selector bar so the user can switch provider and, later, filter by status/tag.
+4. Support cross-column status moves. Within-column reordering is not persisted in v1 and should be disabled or snap back.
+5. Optimistically move the card.
+6. Call the backend move route.
+7. Revert and show a toast/inline error if the backend rejects.
 
 ### 6. Routes
 
@@ -177,6 +195,7 @@ First implementation slice needs only:
 
 ```txt
 GET  /api/boring-tasks/providers
+GET  /api/boring-tasks/providers/:providerId/board
 GET  /api/boring-tasks/providers/:providerId/tasks
 POST /api/boring-tasks/providers/:providerId/tasks/:taskId/move
 ```
@@ -204,8 +223,9 @@ For hosted/core apps, later Postgres-backed tasks should use boring-core workspa
 - Add `plugins/boring-tasks` package.
 - Add shared task card/status types.
 - Add injected mock provider with sample cards, registered by workspace playground/dev app.
-- Add server plugin routes for provider list, task list, and move.
+- Add server plugin routes for provider list, board config, task list, and move.
 - Add front plugin app-left/explorer contribution named `Tasks`.
+- Add a provider selector/status toolbar.
 - Add `TaskKanbanBoard`, `TaskKanbanColumn`, and `TaskCard`.
 - Implement drag/drop with optimistic move/revert.
 - Register plugin in workspace playground for development.
@@ -213,7 +233,7 @@ For hosted/core apps, later Postgres-backed tasks should use boring-core workspa
 Acceptance:
 
 - `Tasks` appears through plugin-owned app-left/explorer contribution.
-- Opening `Tasks` shows four Kanban columns.
+- Opening `Tasks` shows the columns returned by the selected provider's board config.
 - Cards display number, title, and description.
 - Cards can be dragged across columns.
 - Within-column reorder is disabled or snaps back.
@@ -224,7 +244,7 @@ Acceptance:
 
 - Add provider capability display/read-only behavior.
 - Keep create/comment/assign/close out of the provider contract unless this slice introduces those routes.
-- Add status mapping helpers.
+- Add status/column mapping helpers.
 - Add empty/loading/error states.
 - Add tests for provider routing, frontend grouping, and move/revert behavior.
 - Add plugin README documenting provider contracts.
@@ -233,7 +253,7 @@ Acceptance:
 
 - Read-only providers render but do not allow drag.
 - Failed moves revert the card.
-- Provider list/tasks/move routes have typed tests.
+- Provider list/board/tasks/move routes have typed tests.
 
 ### Slice 3 — boring-ui-native Postgres provider
 
@@ -258,14 +278,14 @@ Add providers one at a time:
 3. Linear via API.
 4. Plane/custom API.
 
-Each external provider must document auth, status mapping, mutation support, and failure semantics. The v1 board schema is intentionally fixed to four canonical columns; providers that cannot safely map native states must be read-only until a later slice adds provider/workspace-configurable columns. Provider docs must state whether native status mapping is lossy and whether moves are safe.
+Each external provider must document auth, status/column mapping, mutation support, and failure semantics. Columns are provider-supplied from the start. Providers that cannot safely move between native states should set `capabilities.move = false` or mark specific columns with `acceptsDrop: false`. Provider docs must state whether native status mapping is lossy and whether moves are safe.
 
 ## Testing plan
 
 First implementation PR should include:
 
-- unit tests for task grouping and status mapping;
-- route tests for provider list/task list/move;
+- unit tests for task grouping and status/column mapping;
+- route tests for provider list/board/task list/move;
 - component tests for card rendering and move callback;
 - one workspace-playground e2e smoke test for opening the Tasks action and dragging a card if the test harness can make drag deterministic.
 
@@ -285,7 +305,7 @@ Narrow these once the files exist.
 
 | Risk | Mitigation |
 | --- | --- |
-| Generic provider abstraction becomes too abstract | Keep v1 provider contract tiny: list and move only. Add methods only when a real provider needs them. |
+| Generic provider abstraction becomes too abstract | Keep v1 provider contract tiny: board config, list, and move only. Add methods only when a real provider needs them. |
 | Board leaks provider-native concepts | Normalize at provider boundary; card receives only `BoringTaskCard`. |
 | Host shell gets task-specific branches | Depend on #438 app-left/explorer plugin outputs; block implementation if this requires host special-casing. |
 | Drag/drop library complexity spreads | Contain `@dnd-kit` usage inside `TaskKanbanBoard` and child components. |
@@ -302,7 +322,7 @@ Narrow these once the files exist.
 
 - Dedicated `boring-tasks` plugin package exists with its own typecheck/test target.
 - App-left/explorer `Tasks` action is plugin-owned.
-- Four-column Kanban board renders mock tasks.
+- Provider-configured Kanban board renders mock tasks.
 - Task card includes number, title, description.
 - Drag/drop move flows through injected provider boundary and supports revert on failure.
 - Tests cover model, route, and front behavior.

--- a/docs/plans/boring-tasks-kanban-plugin-plan.md
+++ b/docs/plans/boring-tasks-kanban-plugin-plan.md
@@ -92,7 +92,7 @@ export interface BoringTaskColumn {
 }
 
 export interface BoringTaskBoardConfig {
-  adapterId: string;
+  sourceId: string;
   columns: BoringTaskColumn[];
   // Reserved for future create flows; unmapped existing cards still render in
   // the non-droppable Unmapped overflow column.
@@ -102,14 +102,14 @@ export interface BoringTaskBoardConfig {
 export interface BoringTaskCard {
   id: string;
   // Display identifier only (for example "#42", "ENG-123", "kata#abc4").
-  // It is adapter-scoped and not guaranteed globally unique; `id` is the stable key.
+  // It is source-scoped and not guaranteed globally unique; `id` is the stable key.
   number: string;
   title: string;
   description?: string;
   statusId: BoringTaskStatusId;
-  // Lets card-level actions route back to the right adapter without relying on
-  // ambient selector state.
-  adapterId: string;
+  // Lets card-level actions route back to the right task source without relying
+  // on ambient selector state.
+  sourceId: string;
   url?: string;
 }
 
@@ -211,6 +211,12 @@ GET  /api/boring-tasks/adapters
 GET  /api/boring-tasks/adapters/:adapterId/board
 GET  /api/boring-tasks/adapters/:adapterId/tasks
 POST /api/boring-tasks/adapters/:adapterId/tasks/:taskId/move
+
+# Before real multi-source integrations ship, graduate to:
+GET  /api/boring-tasks/sources
+GET  /api/boring-tasks/sources/:sourceId/board
+GET  /api/boring-tasks/sources/:sourceId/tasks
+POST /api/boring-tasks/sources/:sourceId/tasks/:taskId/move
 ```
 
 Route responses should use stable error codes and typed JSON contracts. Initial codes:
@@ -229,6 +235,89 @@ Do not leak adapter credentials or raw adapter errors to the browser.
 Every request must resolve a `BoringTaskAdapterContext` before touching adapter state. Even the mock adapter should be workspace-scoped so the first slice does not bake in a global task board assumption. Route tests must prove tasks and moves are isolated by workspace.
 
 For hosted/core apps, later Postgres-backed tasks should use boring-core workspace membership and auth; the task plugin should not invent its own auth model.
+
+### 8. Multi-source integration model
+
+Use two words consistently:
+
+- **Adapter type** — code that knows one external system, for example `github`, `kata`, `linear`, or `boring-db`.
+- **Task source** — one configured instance of an adapter type, for example `github-hachej-boring-ui`, `github-hachej-boring-ui-v2`, `kata-local`, or `linear-eng-team`.
+
+The Kanban UI selects **task sources**, not adapter types. This is what makes multi-repo GitHub and local Kata coexist without special UI cases.
+
+Add a source registry in front of the adapter calls:
+
+```ts
+export interface BoringTaskSourceSummary {
+  id: string;              // URL-safe opaque id, e.g. "github-hachej-boring-ui"
+  adapterType: string;     // non-behavioral metadata: "github", "kata", "linear", "boring-db"
+  label: string;           // user-facing label, e.g. "GitHub hachej/boring-ui"
+  description?: string;
+  capabilities: { move: boolean };
+}
+
+export interface BoringTaskSourceConfig {
+  id: string;              // URL-safe stable source id; do not parse it in the UI
+  adapterType: string;
+  label?: string;
+  settings: Record<string, unknown>; // adapter-owned, validated server-side
+}
+
+export interface BoringTaskListQuery {
+  limit?: number;
+  cursor?: string;
+}
+
+export interface BoringTaskListResult {
+  tasks: BoringTaskCard[];
+  nextCursor?: string;
+}
+
+export interface BoringTaskSourceRegistry {
+  listSources(ctx: BoringTaskAdapterContext): Promise<BoringTaskSourceSummary[]>;
+  getSource(ctx: BoringTaskAdapterContext, sourceId: string): Promise<BoringTaskSourceRuntime>;
+}
+
+export interface BoringTaskSourceRuntime extends BoringTaskSourceSummary {
+  getBoardConfig(ctx: BoringTaskAdapterContext): Promise<BoringTaskBoardConfig>;
+  listTasks(ctx: BoringTaskAdapterContext, query?: BoringTaskListQuery): Promise<BoringTaskListResult>;
+  moveTask?(ctx: BoringTaskAdapterContext, input: {
+    taskId: string;
+    statusId: BoringTaskStatusId;
+  }): Promise<BoringTaskCard>;
+}
+```
+
+The existing `BoringTaskAdapter` can remain a simple source runtime for slice 1, but the production integration should grow toward `BoringTaskSourceRegistry` before adding multiple real systems.
+
+Source examples:
+
+```ts
+[
+  { id: "github-hachej-boring-ui", adapterType: "github", label: "GitHub hachej/boring-ui", settings: { owner: "hachej", repo: "boring-ui" } },
+  { id: "github-hachej-boring-ui-v2", adapterType: "github", label: "GitHub hachej/boring-ui-v2", settings: { owner: "hachej", repo: "boring-ui-v2" } },
+  { id: "kata-local", adapterType: "kata", label: "Kata local", settings: { mode: "local-cli", workspace: "current" } },
+  { id: "boring-db-workspace", adapterType: "boring-db", label: "Workspace tasks", settings: { scope: "workspace" } }
+]
+```
+
+Adapter-specific ownership:
+
+- GitHub adapter validates `owner/repo`, resolves credentials server-side, maps labels/state to columns, and performs issue label/close mutations only when configured. Multiple repos are multiple task sources using the same adapter type.
+- Kata adapter is backend-only. Local mode can shell out to `kata --json` or talk to a local/remote Kata daemon; the browser never calls Kata directly. `kata-local` should be read/write only when the hosted/runtime environment actually owns that Kata daemon or CLI context.
+- Linear/Plane/custom adapters resolve their workspace/team/project identifiers from source settings and keep tokens server-side.
+- boring-db adapter uses boring-core workspace/auth and stores tasks in the app Postgres.
+
+Route shape should therefore evolve from adapter ids to source ids before real integrations ship:
+
+```txt
+GET  /api/boring-tasks/sources
+GET  /api/boring-tasks/sources/:sourceId/board
+GET  /api/boring-tasks/sources/:sourceId/tasks?cursor=...&limit=...
+POST /api/boring-tasks/sources/:sourceId/tasks/:taskId/move
+```
+
+The UI remains unchanged conceptually: it renders a source selector, fetches the selected source's board config and task cards, and calls the selected source's move endpoint. It must not know whether a source is GitHub, Kata, Linear, or Postgres. `adapterType` is metadata for badges/debug/docs only; the UI must not branch behavior on it. The current slice-1 adapter selector is therefore a temporary one-source-per-adapter shape; before multi-system support, rename the UX and routes around task sources.
 
 ## Implementation slices
 
@@ -285,16 +374,24 @@ Acceptance:
 - The Kanban board uses the same adapter interface as the mock adapter.
 - Agent tools use the same task service layer as routes.
 
-### Slice 4 — external adapters
+### Slice 4 — source registry and external adapters
 
-Add adapters one at a time:
+Add the source registry before adding multiple real systems. Then add adapters one at a time:
 
-1. GitHub Issues read-only, then status-label/close support.
-2. Kata via backend adapter if needed.
-3. Linear via API.
-4. Plane/custom API.
+1. GitHub Issues read-only for multiple configured repos, e.g. `github-hachej-boring-ui` and `github-hachej-boring-ui-v2`; then status-label/close support.
+2. Kata backend adapter, starting with `kata-local` for local CLI/daemon contexts.
+3. boring-db Postgres source if Slice 3 did not already ship it.
+4. Linear via API.
+5. Plane/custom API.
 
-Each external adapter must document auth, status/column mapping, mutation support, and failure semantics. Columns are adapter-supplied from the start. Adapters that cannot safely move between native states should set `capabilities.move = false` or mark specific columns with `acceptsDrop: false`. Adapter docs must state whether native status mapping is lossy and whether moves are safe.
+Each external adapter must document auth, source configuration, status/column mapping, mutation support, pagination, and failure semantics. Columns are adapter-supplied from the start. Adapters that cannot safely move between native states should set `capabilities.move = false` or mark specific columns with `acceptsDrop: false`. Adapter docs must state whether native status mapping is lossy and whether moves are safe.
+
+Acceptance:
+
+- UI lists at least two task sources from the same adapter type without special cases.
+- GitHub multi-repo uses source ids, not hardcoded repo constants in the Kanban UI.
+- Kata local integration is backend-mediated; no browser direct call to the Kata CLI/daemon.
+- Source-specific settings and credentials stay outside the UI plugin.
 
 ## Testing plan
 
@@ -327,7 +424,9 @@ Narrow these once the files exist.
 | Drag/drop library complexity spreads | Contain `@dnd-kit` usage inside `TaskKanbanBoard` and child components. |
 | External adapter credentials leak | All adapter calls are server-side; browser sees only normalized task contracts. |
 | Hosted auth bypass | Later DB adapter must use boring-core workspace membership/auth, not a plugin-local permission model. |
-| Large external trackers need pagination/filtering | V1 `listTasks()` is unpaginated for mock/small boards. External adapters should add an optional query/cursor input as an additive interface change before GitHub/Linear-scale boards ship. |
+| Large external trackers need pagination/filtering | V1 `listTasks()` is unpaginated for mock/small boards. Add `BoringTaskListQuery` / `BoringTaskListResult` with cursor before GitHub/Linear-scale boards ship. |
+| Multi-source systems get hardcoded into UI | Introduce task sources (`sourceId`) above adapter types before real integrations. Multi-repo GitHub and local Kata are source configs behind the same generic selector. |
+| Local Kata leaks host assumptions to browser | Kata integration must be backend-mediated through a CLI/daemon adapter; browser receives only normalized task cards. |
 | Unknown task statuses drop cards | Unknown `statusId` values render in a non-droppable `Unmapped` column; never filter them out silently. |
 | Board surface chosen too late | #438 currently exposes overlay-shaped app-left actions; implementation must explicitly choose overlay vs workbench panel before coding slice 1. |
 | Stale data surprises users | V1 is fetch-on-open/refetch-after-move only; document no live sync until a later polling/SSE slice. |
@@ -337,7 +436,8 @@ Narrow these once the files exist.
 1. Final app-left/explorer contribution API name and opening surface after PR #438 lands. This is a hard precondition for implementation, not a detail to discover mid-slice. #438 is currently overlay-shaped; a Kanban board may need a workbench panel/surface instead.
 2. Whether `boring-tasks` should live as a publishable `plugins/tasks` package or app-local plugin first. Default: publishable plugin package because multiple apps may want it.
 3. Whether the Postgres adapter belongs in `boring-tasks` or a child-app adapter package. Default: keep the adapter interface in `boring-tasks`, allow app-owned adapter registration later if core auth coupling gets heavy.
-4. How external adapters get per-workspace source configuration, such as GitHub repo or Linear team. Options include one adapter id per configured source (for example `github:owner/repo`) or adapter-owned workspace settings. Either way, source configuration must stay out of the Kanban UI plugin.
+4. Where per-workspace task source configuration is stored. Default: app/core-owned settings or plugin server config, not the Kanban UI. The UI receives only source summaries from `/sources`.
+5. Whether source ids should be user-visible or opaque stable ids with labels. Default: source ids must be URL-safe opaque identifiers; the UI displays `label` and never parses the id.
 
 ## Definition of done for implementation slice 1
 

--- a/docs/plans/boring-tasks-kanban-plugin-plan.md
+++ b/docs/plans/boring-tasks-kanban-plugin-plan.md
@@ -88,7 +88,6 @@ export interface BoringTaskColumn {
   title: string;
   description?: string;
   color?: string;
-  order: number;
   acceptsDrop?: boolean;
 }
 
@@ -100,10 +99,14 @@ export interface BoringTaskBoardConfig {
 
 export interface BoringTaskCard {
   id: string;
+  // Display identifier only (for example "#42", "ENG-123", "kata#abc4").
+  // It is adapter-scoped and not guaranteed globally unique; `id` is the stable key.
   number: string;
   title: string;
   description?: string;
   statusId: BoringTaskStatusId;
+  // Lets card-level actions route back to the right adapter without relying on
+  // ambient selector state.
   adapterId: string;
   url?: string;
 }
@@ -142,13 +145,12 @@ export interface BoringTasksServerPluginOptions {
 
 export function createBoringTasksServerPlugin(
   options: BoringTasksServerPluginOptions,
-): WorkspaceServerPlugin;
+): /* defineServerPlugin-compatible server plugin; exact exported type follows PLUGIN_SYSTEM.md §4.4 */ unknown;
 
 export interface BoringTaskAdapter {
   id: string;
   label: string;
   capabilities: {
-    list: true;
     move: boolean;
   };
   getBoardConfig(ctx: BoringTaskAdapterContext): Promise<BoringTaskBoardConfig>;
@@ -162,13 +164,15 @@ export interface BoringTaskAdapter {
 
 Adapter rules:
 
+- Listing is implied by the `listTasks()` method; `capabilities` only describes optional mutations/actions.
 - Adapters expose their available status tags/columns through `getBoardConfig()`.
 - The playground/dev app injects `createMockTaskAdapter()`; hosted apps inject DB or external adapters.
 - Adapters declare `capabilities.move`; the UI disables drag for adapters that cannot move tasks.
 - Adapters may normalize native statuses (`GitHub labels`, `Linear states`, `Kata status/claim`, custom DB enum) into stable `statusId` values, but the UI must not hardcode a global status enum.
 - Adapter failures revert optimistic UI changes.
+- Per-transition legality is intentionally not modeled in v1; if an adapter rejects a specific from→to move, the UI reverts through the existing failed-move path.
 - Credentials and source-native API clients stay on the server-side adapter.
-- Additional capabilities (`create`, `comment`, `assign`, `close`) are added only when a real adapter exposes the corresponding action. The UI renders those actions from adapter metadata instead of hardcoding tracker-specific buttons.
+- Additional capabilities (`create`, `comment`, `assign`, `close`) are added only when a real adapter exposes the corresponding action. The UI renders those actions from a small enumerated capability set instead of hardcoding tracker-specific buttons or inventing a generic action-descriptor DSL.
 
 ### 5. Kanban implementation
 
@@ -184,13 +188,17 @@ Use shadcn-style layout primitives from `@hachej/boring-ui-kit` where possible. 
 
 Board behavior:
 
-1. Fetch adapter board config and render its columns in `order`.
-2. Group cards by `statusId`.
-3. Provide an adapter/status selector bar so the user can switch adapter and, later, filter by status/tag.
+1. Fetch adapter board config and render its columns in returned array order.
+2. Group cards by `statusId`. Cards whose `statusId` matches no configured column render in `defaultColumnId` when set; otherwise they render in a non-droppable `Unmapped` overflow column. They must never silently disappear.
+3. Provide an adapter selector toolbar so the user can switch adapter. Status/tag filtering is a later slice.
 4. Support cross-column status moves. Within-column reordering is not persisted in v1 and should be disabled or snap back.
 5. Optimistically move the card.
 6. Call the backend move route.
 7. Revert and show a toast/inline error if the backend rejects.
+
+Surface decision: #438's current app-left registration is overlay-shaped, but a full horizontal Kanban board may be better as a workbench panel/surface opened by shell capabilities. Implementation slice 1 must choose this explicitly after #438 lands; do not let the choice happen accidentally in host-shell glue.
+
+Freshness decision for v1: fetch on open and refetch after a successful move. No polling, push, or cross-user live sync in slice 1; stale external changes are accepted until manual/open-triggered refresh.
 
 ### 6. Routes
 
@@ -208,6 +216,7 @@ Route responses should use stable error codes and typed JSON contracts. Initial 
 - `BORING_TASK_ADAPTER_NOT_FOUND`
 - `BORING_TASK_MOVE_UNSUPPORTED`
 - `BORING_TASK_NOT_FOUND`
+- `BORING_TASK_STATUS_NOT_FOUND`
 - `BORING_TASK_MOVE_FAILED`
 - `BORING_TASK_WORKSPACE_REQUIRED`
 
@@ -237,6 +246,7 @@ Acceptance:
 
 - `Tasks` appears through plugin-owned app-left/explorer contribution.
 - Opening `Tasks` shows the columns returned by the selected adapter's board config.
+- Selector lists registered adapters from `GET /adapters` (`id`, `label`, `capabilities`); switching adapters reloads board config and tasks.
 - Cards display number, title, and description.
 - Cards can be dragged across columns.
 - Within-column reorder is disabled or snaps back.
@@ -314,10 +324,14 @@ Narrow these once the files exist.
 | Drag/drop library complexity spreads | Contain `@dnd-kit` usage inside `TaskKanbanBoard` and child components. |
 | External adapter credentials leak | All adapter calls are server-side; browser sees only normalized task contracts. |
 | Hosted auth bypass | Later DB adapter must use boring-core workspace membership/auth, not a plugin-local permission model. |
+| Large external trackers need pagination/filtering | V1 `listTasks()` is unpaginated for mock/small boards. External adapters should add an optional query/cursor input as an additive interface change before GitHub/Linear-scale boards ship. |
+| Unknown task statuses drop cards | Unknown `statusId` values render in `defaultColumnId` or a non-droppable `Unmapped` column; never filter them out silently. |
+| Board surface chosen too late | #438 currently exposes overlay-shaped app-left actions; implementation must explicitly choose overlay vs workbench panel before coding slice 1. |
+| Stale data surprises users | V1 is fetch-on-open/refetch-after-move only; document no live sync until a later polling/SSE slice. |
 
 ## Open questions
 
-1. Final app-left/explorer contribution API name and opening surface after PR #438 lands. This is a hard precondition for implementation, not a detail to discover mid-slice.
+1. Final app-left/explorer contribution API name and opening surface after PR #438 lands. This is a hard precondition for implementation, not a detail to discover mid-slice. #438 is currently overlay-shaped; a Kanban board may need a workbench panel/surface instead.
 2. Whether `boring-tasks` should live as a publishable `plugins/boring-tasks` package or app-local plugin first. Default: publishable plugin package because multiple apps may want it.
 3. Whether the Postgres adapter belongs in `boring-tasks` or a child-app adapter package. Default: keep the adapter interface in `boring-tasks`, allow app-owned adapter registration later if core auth coupling gets heavy.
 

--- a/docs/plans/reviews/boring-tasks-kanban-plugin-thermo-review.md
+++ b/docs/plans/reviews/boring-tasks-kanban-plugin-thermo-review.md
@@ -6,7 +6,7 @@ Reviewer: subagent `reviewer`
 
 ## Verdict
 
-The plan is directionally correct, but the first draft had several implementation-risk gaps that could push the future PR into host-shell special-casing, premature provider abstraction, or unsound drag/drop behavior. The plan was revised to address the blockers below.
+The plan is directionally correct, but the first draft had several implementation-risk gaps that could push the future PR into host-shell special-casing, premature adapter abstraction, or unsound drag/drop behavior. The plan was revised to address the blockers below.
 
 ## Findings and resolutions
 
@@ -16,41 +16,41 @@ The plan is directionally correct, but the first draft had several implementatio
 
 **Resolution:** Added a hard precondition: do not start implementation until PR #438 lands and documents the plugin-owned app-left/explorer contribution API. The plan now explicitly blocks app-shell prop injection and task-specific host wiring.
 
-### High — Provider registry seam was underspecified
+### High — Adapter registry seam was underspecified
 
-**Risk:** Routes could directly import the mock provider, making later app-owned DB/auth providers awkward and leaking core auth into a generic plugin.
+**Risk:** Routes could directly import the mock adapter, making later app-owned DB/auth adapters awkward and leaking core auth into a generic plugin.
 
 **Resolution:** Added an injected server factory shape:
 
 ```ts
-createBoringTasksServerPlugin({ providers, resolveWorkspaceContext })
+createBoringTasksServerPlugin({ adapters, resolveWorkspaceContext })
 ```
 
-The playground/dev app injects the mock provider; hosted apps inject their own providers.
+The playground/dev app injects the mock adapter; hosted apps inject their own adapters.
 
-### High — Drag/drop scope exceeded the provider contract
+### High — Drag/drop scope exceeded the adapter contract
 
-**Risk:** The original plan allowed within-column drag while the provider contract only moved statuses, so ordering could not persist.
+**Risk:** The original plan allowed within-column drag while the adapter contract only moved statuses, so ordering could not persist.
 
 **Resolution:** Scoped v1 to cross-column status moves only. Within-column reorder is not persisted and must be disabled or snap back until an ordering contract exists.
 
 ### Medium-high — Workspace scoping was asserted but not specified
 
-**Risk:** Mock or future provider state could become global/cross-workspace.
+**Risk:** Mock or future adapter state could become global/cross-workspace.
 
-**Resolution:** Added `BoringTaskProviderContext` with `workspaceId`, `actorId`, and `requestId`, plus route tests proving workspace isolation.
+**Resolution:** Added `BoringTaskAdapterContext` with `workspaceId`, `actorId`, and `requestId`, plus route tests proving workspace isolation.
 
-### Medium — Provider interface was too broad for Slice 1
+### Medium — Adapter interface was too broad for Slice 1
 
-**Risk:** Premature generic issue-tracker abstraction before real providers exist.
+**Risk:** Premature generic issue-tracker abstraction before real adapters exist.
 
-**Resolution:** Reduced Slice 1 capabilities to `list` and `move` only. Create/comment/assign/close are deferred until a real route/tool slice needs them.
+**Resolution:** Reduced Slice 1 capabilities to optional mutations only (`move` for v1); listing is implied by `listTasks()`. Create/comment/assign/close are deferred until a real route/tool slice needs them.
 
 ### Medium — Fixed four-column schema could be too rigid
 
 **Risk:** External workflows like Linear/Plane can have arbitrary states.
 
-**Resolution:** Documented the four statuses as the intentionally fixed v1 board schema. Providers that cannot safely map native states must be read-only until configurable columns exist.
+**Resolution:** Superseded by the final plan: columns are adapter-configured from the start via `getBoardConfig()`. Adapters that cannot safely move between native states must set `capabilities.move = false` or mark specific columns with `acceptsDrop: false`.
 
 ### Medium — Package skeleton missed canonical plugin files
 
@@ -71,3 +71,8 @@ The playground/dev app injects the mock provider; hosted apps inject their own p
 ## Residual risk
 
 The plan is still blocked on PR #438 finalizing the app-left/explorer contribution API. That is intentional: any implementation before that API lands risks adding exactly the shell special-casing this plugin is supposed to avoid.
+
+
+## Claude Code local review follow-up
+
+A local Claude Code review on the PR branch found that this review artifact was stale after the plan moved from fixed columns/providers to adapter-configured columns/adapters. The stale wording was corrected, and the plan was clarified around opening surface choice, pagination, freshness/staleness, adapter selector acceptance, `number` semantics, and `adapterId` rationale.

--- a/docs/plans/reviews/boring-tasks-kanban-plugin-thermo-review.md
+++ b/docs/plans/reviews/boring-tasks-kanban-plugin-thermo-review.md
@@ -1,0 +1,73 @@
+# Thermo review — boring-tasks Kanban plugin plan
+
+Source plan: [`../boring-tasks-kanban-plugin-plan.md`](../boring-tasks-kanban-plugin-plan.md)
+
+Reviewer: subagent `reviewer`
+
+## Verdict
+
+The plan is directionally correct, but the first draft had several implementation-risk gaps that could push the future PR into host-shell special-casing, premature provider abstraction, or unsound drag/drop behavior. The plan was revised to address the blockers below.
+
+## Findings and resolutions
+
+### High — Slice 1 depended on unresolved app-left/explorer API
+
+**Risk:** Implementation could stall or sneak task-specific wiring into `WorkspaceAgentFront` while waiting for PR #438.
+
+**Resolution:** Added a hard precondition: do not start implementation until PR #438 lands and documents the plugin-owned app-left/explorer contribution API. The plan now explicitly blocks app-shell prop injection and task-specific host wiring.
+
+### High — Provider registry seam was underspecified
+
+**Risk:** Routes could directly import the mock provider, making later app-owned DB/auth providers awkward and leaking core auth into a generic plugin.
+
+**Resolution:** Added an injected server factory shape:
+
+```ts
+createBoringTasksServerPlugin({ providers, resolveWorkspaceContext })
+```
+
+The playground/dev app injects the mock provider; hosted apps inject their own providers.
+
+### High — Drag/drop scope exceeded the provider contract
+
+**Risk:** The original plan allowed within-column drag while the provider contract only moved statuses, so ordering could not persist.
+
+**Resolution:** Scoped v1 to cross-column status moves only. Within-column reorder is not persisted and must be disabled or snap back until an ordering contract exists.
+
+### Medium-high — Workspace scoping was asserted but not specified
+
+**Risk:** Mock or future provider state could become global/cross-workspace.
+
+**Resolution:** Added `BoringTaskProviderContext` with `workspaceId`, `actorId`, and `requestId`, plus route tests proving workspace isolation.
+
+### Medium — Provider interface was too broad for Slice 1
+
+**Risk:** Premature generic issue-tracker abstraction before real providers exist.
+
+**Resolution:** Reduced Slice 1 capabilities to `list` and `move` only. Create/comment/assign/close are deferred until a real route/tool slice needs them.
+
+### Medium — Fixed four-column schema could be too rigid
+
+**Risk:** External workflows like Linear/Plane can have arbitrary states.
+
+**Resolution:** Documented the four statuses as the intentionally fixed v1 board schema. Providers that cannot safely map native states must be read-only until configurable columns exist.
+
+### Medium — Package skeleton missed canonical plugin files
+
+**Risk:** Implementation could drift from repository plugin conventions.
+
+**Resolution:** Updated the skeleton to include canonical app/internal plugin package files: README, tsup config, vitest config, and `src/front|server|shared`.
+
+### Medium — Test commands omitted the new plugin package
+
+**Risk:** Plugin could be untyped/untested while workspace tests pass.
+
+**Resolution:** Added expected `@hachej/boring-tasks` typecheck/test gates.
+
+### Low — Error contract was vague
+
+**Resolution:** Added initial stable error codes.
+
+## Residual risk
+
+The plan is still blocked on PR #438 finalizing the app-left/explorer contribution API. That is intentional: any implementation before that API lands risks adding exactly the shell special-casing this plugin is supposed to avoid.


### PR DESCRIPTION
## Summary

- Add a planning doc for a dedicated `boring-tasks` plugin: standard task cards, provider-backed Kanban board, and dnd-kit drag/drop.
- Scope the first implementation slice to a mock/injected provider and cross-column status moves.
- Record thermo review findings and incorporate the blockers into the plan.

## Key constraints

- Depends on PR #438 landing the plugin-owned app-left/explorer contribution API.
- No task-specific branches in `WorkspaceAgentFront`.
- Server providers are injected at boot so hosted apps can own DB/auth/secret resolution.

## Validation

- `git diff --cached --check` before commit
- Docs-only change; no package tests run
