### PR TITLE
boring-governance: Add YAML governance status

### DIFF
--- a/apps/full-app/package.json
+++ b/apps/full-app/package.json
@@ -27,7 +27,8 @@
     "@vercel/sandbox": "2.0.0-beta.14",
     "fastify": "^5.3.3",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/apps/full-app/src/front/GovernanceAdminView.tsx
+++ b/apps/full-app/src/front/GovernanceAdminView.tsx
@@ -1,0 +1,157 @@
+import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '@hachej/boring-ui-kit'
+
+export interface GovernancePolicyStatus {
+  state: 'disabled' | 'active' | 'invalid'
+  reason?: string
+  path?: string | null
+  message?: string
+  tenantId?: string
+  userCount?: number
+}
+
+export interface GovernanceMeResponse {
+  enabled: boolean
+  role: 'admin' | 'user' | null
+  admin: boolean
+  policyStatus?: GovernancePolicyStatus
+  tenant?: {
+    id: string
+    companyContextWorkspaceId: string | null
+    defaultMonthlyModelBudgetEur: number
+    perRunHoldEur: number
+  }
+  users?: Array<{
+    email: string
+    role: 'admin' | 'user'
+    modelCount: number
+    contextRuleCount: number
+  }>
+  models?: Array<{
+    email: string
+    provider: string
+    id: string
+    monthlyBudgetEur: number
+    monthlyBudgetMicros: number
+  }>
+  companyContextRules?: Array<{ email: string; pattern: string }>
+}
+
+export function GovernanceAdminView({ status }: { status: GovernanceMeResponse }) {
+  return (
+    <main className="min-h-screen bg-background px-4 py-8 text-foreground sm:px-6 lg:px-8">
+      <div className="mx-auto flex max-w-6xl flex-col gap-6">
+        <header className="rounded-2xl border border-border bg-card p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Company admin</p>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="text-3xl font-semibold tracking-tight">Tenant governance</h1>
+              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
+                YAML-managed in v1. Review effective tenant roles, exact model grants, monthly EUR budgets, and company-context rules.
+              </p>
+            </div>
+            <Button asChild variant="outline">
+              <a href="/">Back to workspace</a>
+            </Button>
+          </div>
+        </header>
+
+        <section className="grid gap-4 rounded-2xl border border-border bg-card p-6 shadow-sm md:grid-cols-3">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">Policy source</p>
+            <p className="mt-2 text-sm font-medium text-foreground">YAML-managed in v1</p>
+            <p className="mt-1 text-xs text-muted-foreground">Edit the host policy file and restart to reload.</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">Tenant</p>
+            <p className="mt-2 text-sm font-medium text-foreground">{status.tenant?.id ?? status.policyStatus?.tenantId ?? '—'}</p>
+            <p className="mt-1 text-xs text-muted-foreground">Role: {status.role ?? 'none'}</p>
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">Policy status</p>
+            <p className="mt-2 text-sm font-medium text-foreground">{status.policyStatus?.state ?? 'active'}</p>
+            <p className="mt-1 text-xs text-muted-foreground">Tenant invites are deferred/not implemented in v1.</p>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-border bg-card p-4 shadow-sm sm:p-6">
+          <Tabs defaultValue="context" className="gap-4">
+            <TabsList aria-label="Company admin tabs" variant="line" className="flex-wrap justify-start">
+              <TabsTrigger value="context">Context access</TabsTrigger>
+              <TabsTrigger value="models">Model control</TabsTrigger>
+              <TabsTrigger value="users">Users</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="context">
+              <div className="rounded-xl border border-dashed border-border bg-muted/20 p-6">
+                <h2 className="text-xl font-semibold tracking-tight">Context access</h2>
+                <p className="mt-2 max-w-2xl text-sm text-muted-foreground">Read-only effective company-context path grants from the YAML policy.</p>
+                <div className="mt-5 overflow-hidden rounded-lg border border-border bg-background">
+                  <table className="w-full text-left text-sm">
+                    <thead className="bg-muted/60 text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                      <tr><th className="px-3 py-2 font-medium">User</th><th className="px-3 py-2 font-medium">Allowed pattern</th></tr>
+                    </thead>
+                    <tbody>
+                      {(status.companyContextRules ?? []).length > 0 ? status.companyContextRules!.map((rule, index) => (
+                        <tr key={`${rule.email}-${index}`} className="border-t border-border">
+                          <td className="px-3 py-2 font-medium">{rule.email}</td>
+                          <td className="px-3 py-2 font-mono text-xs text-muted-foreground">{rule.pattern}</td>
+                        </tr>
+                      )) : <tr><td colSpan={2} className="px-3 py-4 text-muted-foreground">No company-context rules in policy.</td></tr>}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="models">
+              <div className="rounded-xl border border-dashed border-border bg-muted/20 p-6">
+                <h2 className="text-xl font-semibold tracking-tight">Model control</h2>
+                <p className="mt-2 max-w-2xl text-sm text-muted-foreground">Read-only exact model grants and monthly EUR budgets from the YAML policy.</p>
+                <div className="mt-5 overflow-hidden rounded-lg border border-border bg-background">
+                  <table className="w-full text-left text-sm">
+                    <thead className="bg-muted/60 text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                      <tr><th className="px-3 py-2 font-medium">User</th><th className="px-3 py-2 font-medium">Model</th><th className="px-3 py-2 font-medium">Monthly budget</th></tr>
+                    </thead>
+                    <tbody>
+                      {(status.models ?? []).length > 0 ? status.models!.map((model) => (
+                        <tr key={`${model.email}-${model.provider}-${model.id}`} className="border-t border-border">
+                          <td className="px-3 py-2 font-medium">{model.email}</td>
+                          <td className="px-3 py-2 font-mono text-xs text-muted-foreground">{model.provider}/{model.id}</td>
+                          <td className="px-3 py-2">€{model.monthlyBudgetEur}</td>
+                        </tr>
+                      )) : <tr><td colSpan={3} className="px-3 py-4 text-muted-foreground">No model grants in policy.</td></tr>}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </TabsContent>
+
+            <TabsContent value="users">
+              <div className="rounded-xl border border-dashed border-border bg-muted/20 p-6">
+                <h2 className="text-xl font-semibold tracking-tight">Users</h2>
+                <p className="mt-2 max-w-2xl text-sm text-muted-foreground">Read-only tenant users from the YAML policy. Tenant invites are not implemented in v1.</p>
+                <div className="mt-5 overflow-hidden rounded-lg border border-border bg-background">
+                  <table className="w-full text-left text-sm">
+                    <thead className="bg-muted/60 text-xs uppercase tracking-[0.12em] text-muted-foreground">
+                      <tr><th className="px-3 py-2 font-medium">User</th><th className="px-3 py-2 font-medium">Role</th><th className="px-3 py-2 font-medium">Models</th><th className="px-3 py-2 font-medium">Context rules</th></tr>
+                    </thead>
+                    <tbody>
+                      {(status.users ?? []).length > 0 ? status.users!.map((user) => (
+                        <tr key={user.email} className="border-t border-border">
+                          <td className="px-3 py-2 font-medium">{user.email}</td>
+                          <td className="px-3 py-2">{user.role}</td>
+                          <td className="px-3 py-2">{user.modelCount}</td>
+                          <td className="px-3 py-2">{user.contextRuleCount}</td>
+                        </tr>
+                      )) : <tr><td colSpan={4} className="px-3 py-4 text-muted-foreground">No users in policy.</td></tr>}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </TabsContent>
+          </Tabs>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/apps/full-app/src/front/main.tsx
+++ b/apps/full-app/src/front/main.tsx
@@ -9,9 +9,15 @@ import {
   isPaymentRequiredNotice,
   useCreditBalance,
 } from '@hachej/boring-core/app/front'
-import { UserMenu, UserSettingsPage, WorkspaceSwitcher } from '@hachej/boring-core/front'
+import {
+  UserMenu,
+  UserSettingsPage,
+  WorkspaceSwitcher,
+  type CompanyAdminStatus,
+} from '@hachej/boring-core/front'
 import '@hachej/boring-core/app/front/styles.css'
 import './app.css'
+import { GovernanceAdminView, type GovernanceMeResponse } from './GovernanceAdminView'
 import { PublicHeroDescription, publicLaunchPlugin } from './PublicLaunchPages'
 import { fullAppBoringMcpPlugin } from './boringMcp'
 
@@ -62,6 +68,26 @@ const AccountSettingsPage = () => {
 //    run-rejected notice. Wired unconditionally: BuyCreditsNoticeAction self-hides on
 //    the SERVER's checkoutEnabled, so it can't be suppressed by a missing/stale Vite
 //    flag while checkout actually works (the flag only feeds the badge fallback).
+async function loadCompanyAdminStatus(): Promise<CompanyAdminStatus | null> {
+  const response = await fetch('/api/v1/governance/me', { credentials: 'include' })
+  if (response.status === 404) return null
+  if (!response.ok) throw new Error(`Company admin status failed: HTTP ${response.status}`)
+  const body = await response.json() as GovernanceMeResponse
+  if (body.policyStatus?.state === 'invalid') {
+    throw new Error(body.policyStatus.message ?? 'Governance policy is invalid')
+  }
+  return {
+    enabled: body.enabled,
+    admin: body.admin,
+    role: body.role,
+    details: body,
+  }
+}
+
+function renderCompanyAdminContent(status: CompanyAdminStatus) {
+  return <GovernanceAdminView status={status.details as GovernanceMeResponse} />
+}
+
 const chatParams = {
   thinkingControl: true,
   hideDefaultModelOption: true,
@@ -90,6 +116,7 @@ createRoot(document.getElementById('root')!).render(
       apiBaseUrl=""
       apiTimeout={10_000}
       persistenceEnabled
+      companyAdmin={{ loadStatus: loadCompanyAdminStatus, renderContent: renderCompanyAdminContent }}
       appTitle={PRODUCT_NAME}
       workspaceLayout="plugin-tabs"
       appLeftHeaderMode="workspace"

--- a/apps/full-app/src/server/dev.ts
+++ b/apps/full-app/src/server/dev.ts
@@ -1,10 +1,13 @@
+import path from 'node:path'
 import {
   appRootFromImportMeta,
   createCoreWorkspaceAgentServer,
   startCoreWorkspaceAgentDevServer,
 } from '@hachej/boring-core/app/server'
-import { serverPlugins } from './plugins.js'
+import { loadConfig } from '@hachej/boring-core/server'
+import { createFullAppServerPlugins } from './plugins.js'
 import { buildCreditsWiring } from './credits.js'
+import { buildGovernanceService, createGovernanceServerPlugin } from './governance/index.js'
 
 const appRoot = appRootFromImportMeta(import.meta.url, 2)
 
@@ -74,10 +77,16 @@ startCoreWorkspaceAgentDevServer({
   appRoot,
   ...(frontendPort ? { frontendPort } : {}),
   buildServer: async (options) => {
+    const config = await loadConfig({
+      allowMissingSecrets: process.env.NODE_ENV !== 'production',
+      tomlPath: path.resolve(appRoot, 'boring.app.toml'),
+    })
+    const governance = await buildGovernanceService({ config })
     const credits = buildCreditsWiring()
     const app = await createCoreWorkspaceAgentServer({
       ...options,
-      plugins: serverPlugins,
+      config,
+      plugins: createFullAppServerPlugins([createGovernanceServerPlugin(governance)]),
       externalPlugins: false,
       installPluginAuthoring: pluginAuthoringEnabledFromEnv(),
       metering: credits.meteringSink,

--- a/apps/full-app/src/server/governance/__tests__/governance.test.ts
+++ b/apps/full-app/src/server/governance/__tests__/governance.test.ts
@@ -1,0 +1,197 @@
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import os from 'node:os'
+import Fastify from 'fastify'
+import { describe, expect, it } from 'vitest'
+
+import { createGovernanceService } from '../governanceService.js'
+import { loadGovernancePolicy, GOVERNANCE_DEV_EMAIL_VERIFICATION_OVERRIDE_ENV } from '../loadPolicy.js'
+import { governanceRoutes } from '../routes.js'
+import { validateGovernancePolicy } from '../validatePolicy.js'
+
+const configWithMail = { auth: { mail: { enabled: true } } } as any
+
+async function writePolicy(contents: string): Promise<string> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'boring-governance-'))
+  const file = path.join(dir, 'policy.yaml')
+  await writeFile(file, contents, 'utf8')
+  return file
+}
+
+const VALID_POLICY = `
+tenant:
+  id: company
+  companyContextWorkspaceId: company-ws
+  defaultMonthlyModelBudgetEur: 0
+  perRunHoldEur: 1
+users:
+  - email: Admin@Example.COM
+    role: admin
+    models:
+      - provider: infomaniak
+        id: qwen
+        monthlyBudgetEur: 25
+    companyContext:
+      allow:
+        - '^/.*'
+  - email: user@example.com
+    role: user
+    models:
+      - provider: infomaniak
+        id: qwen
+        monthlyBudgetEur: 5
+    companyContext:
+      allow:
+        - '^/public/.*'
+`
+
+describe('governance policy loader', () => {
+  it('returns disabled when no policy path is configured', async () => {
+    const result = await loadGovernancePolicy({ env: {}, config: configWithMail })
+
+    expect(result.enabled).toBe(false)
+    expect(result.status).toMatchObject({ state: 'disabled', reason: 'missing-env' })
+  })
+
+  it('loads and normalizes a valid policy', async () => {
+    const policyPath = await writePolicy(VALID_POLICY)
+    const result = await loadGovernancePolicy({
+      env: { BORING_GOVERNANCE_POLICY_PATH: policyPath },
+      config: configWithMail,
+    })
+
+    expect(result.enabled).toBe(true)
+    expect(result.policy?.users[0]?.email).toBe('admin@example.com')
+    expect(result.policy?.users[0]?.models[0]?.monthlyBudgetMicros).toBe(25_000_000)
+    expect(result.status).toMatchObject({ state: 'active', tenantId: 'company', userCount: 2 })
+  })
+
+  it('returns invalid in development for bad YAML and throws in production', async () => {
+    const policyPath = await writePolicy('tenant: [')
+
+    const dev = await loadGovernancePolicy({
+      env: { BORING_GOVERNANCE_POLICY_PATH: policyPath },
+      nodeEnv: 'development',
+      config: configWithMail,
+    })
+    expect(dev.enabled).toBe(true)
+    expect(dev.status.state).toBe('invalid')
+
+    await expect(loadGovernancePolicy({
+      env: { BORING_GOVERNANCE_POLICY_PATH: policyPath },
+      nodeEnv: 'production',
+      config: configWithMail,
+    })).rejects.toThrow()
+  })
+
+  it('rejects duplicate users after lowercase trim normalization', () => {
+    expect(() => validateGovernancePolicy({
+      tenant: { id: 'company', perRunHoldEur: 1 },
+      users: [
+        { email: ' Admin@Example.com ', role: 'admin' },
+        { email: 'admin@example.com', role: 'user' },
+      ],
+    })).toThrow(/duplicate user email/)
+  })
+
+  it('rejects invalid roles, budgets, and unsafe regexes', () => {
+    expect(() => validateGovernancePolicy({
+      tenant: { id: 'company', perRunHoldEur: 1 },
+      users: [{ email: 'a@example.com', role: 'owner' }],
+    })).toThrow(/role/)
+
+    expect(() => validateGovernancePolicy({
+      tenant: { id: 'company', perRunHoldEur: 1 },
+      users: [{ email: 'a@example.com', role: 'user', models: [{ provider: 'p', id: 'm', monthlyBudgetEur: -1 }] }],
+    })).toThrow(/monthlyBudgetEur/)
+
+    expect(() => validateGovernancePolicy({
+      tenant: { id: 'company', perRunHoldEur: 1 },
+      users: [{ email: 'a@example.com', role: 'user', companyContext: { allow: ['(a+)+$'] } }],
+    })).toThrow(/must start with/)
+  })
+
+  it('fails governance-enabled boot without email verification config unless dev override is set', async () => {
+    const policyPath = await writePolicy(VALID_POLICY)
+
+    await expect(loadGovernancePolicy({
+      env: { BORING_GOVERNANCE_POLICY_PATH: policyPath },
+      nodeEnv: 'production',
+      config: { auth: {} } as any,
+    })).rejects.toThrow(/email verification/)
+
+    const dev = await loadGovernancePolicy({
+      env: {
+        BORING_GOVERNANCE_POLICY_PATH: policyPath,
+        [GOVERNANCE_DEV_EMAIL_VERIFICATION_OVERRIDE_ENV]: '1',
+      },
+      nodeEnv: 'development',
+      config: { auth: {} } as any,
+    })
+    expect(dev.enabled).toBe(true)
+    expect(dev.status.state).toBe('active')
+  })
+})
+
+describe('governance service and route', () => {
+  it('denies all policy-derived privileges for unverified users', async () => {
+    const policyPath = await writePolicy(VALID_POLICY)
+    const loaded = await loadGovernancePolicy({ env: { BORING_GOVERNANCE_POLICY_PATH: policyPath }, config: configWithMail })
+    const service = createGovernanceService(loaded)
+    const user = { email: 'admin@example.com', emailVerified: false }
+
+    expect(service.roleForUser(user)).toBeNull()
+    expect(service.isAdmin(user)).toBe(false)
+    expect(service.allowedModelsForUser(user, [{ provider: 'infomaniak', id: 'qwen' }])).toEqual([])
+    expect(service.monthlyBudgetMicros(user, { provider: 'infomaniak', id: 'qwen' })).toBeNull()
+    expect(service.companyContextRules(user)).toEqual([])
+  })
+
+  it('returns safe /api/v1/governance/me payloads for admin and normal users', async () => {
+    const policyPath = await writePolicy(VALID_POLICY)
+    const service = createGovernanceService(await loadGovernancePolicy({
+      env: { BORING_GOVERNANCE_POLICY_PATH: policyPath },
+      config: configWithMail,
+    }))
+    const app = Fastify()
+    app.addHook('preHandler', async (request) => {
+      const email = request.headers['x-test-email'] as string
+      request.user = { id: email, email, name: null, emailVerified: request.headers['x-test-verified'] === '1' }
+    })
+    await app.register(governanceRoutes(service))
+
+    const admin = await app.inject({ method: 'GET', url: '/api/v1/governance/me', headers: { 'x-test-email': 'admin@example.com', 'x-test-verified': '1' } })
+    expect(admin.statusCode).toBe(200)
+    expect(admin.json()).toMatchObject({ enabled: true, role: 'admin', admin: true, tenant: { id: 'company' } })
+
+    const normal = await app.inject({ method: 'GET', url: '/api/v1/governance/me', headers: { 'x-test-email': 'user@example.com', 'x-test-verified': '1' } })
+    expect(normal.statusCode).toBe(200)
+    expect(normal.json()).toEqual({ enabled: true, role: 'user', admin: false })
+
+    await app.close()
+  })
+
+  it('surfaces invalid dev policy status because no policy-derived admin exists', async () => {
+    const service = createGovernanceService({
+      enabled: true,
+      policy: null,
+      status: { state: 'invalid', path: '/tmp/policy.yaml', message: 'bad yaml' },
+    })
+    const app = Fastify()
+    app.addHook('preHandler', async (request) => {
+      request.user = { id: 'user-1', email: 'user@example.com', name: null, emailVerified: true }
+    })
+    await app.register(governanceRoutes(service))
+
+    const response = await app.inject({ method: 'GET', url: '/api/v1/governance/me' })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toMatchObject({
+      enabled: true,
+      role: null,
+      admin: false,
+      policyStatus: { state: 'invalid', message: 'bad yaml' },
+    })
+    await app.close()
+  })
+})

--- a/apps/full-app/src/server/governance/governanceService.ts
+++ b/apps/full-app/src/server/governance/governanceService.ts
@@ -1,0 +1,145 @@
+import type {
+  GovernanceLoadResult,
+  GovernanceModelGrant,
+  GovernancePolicy,
+  GovernancePolicyStatus,
+  GovernanceUserLike,
+  GovernanceUserPolicy,
+  ServedModelLike,
+  TenantRole,
+} from './policyTypes.js'
+import { normalizePolicyEmail } from './validatePolicy.js'
+
+export class GovernancePolicyError extends Error {
+  constructor(message: string, readonly code: 'disabled' | 'invalid' | 'denied' | 'not_allowed') {
+    super(message)
+    this.name = 'GovernancePolicyError'
+  }
+}
+
+export interface GovernanceMeResponse {
+  enabled: boolean
+  role: TenantRole | null
+  admin: boolean
+  policyStatus?: GovernancePolicyStatus
+  tenant?: {
+    id: string
+    companyContextWorkspaceId: string | null
+    defaultMonthlyModelBudgetEur: number
+    perRunHoldEur: number
+  }
+  users?: Array<{
+    email: string
+    role: TenantRole
+    modelCount: number
+    contextRuleCount: number
+  }>
+  models?: Array<GovernanceModelGrant & { email: string }>
+  companyContextRules?: Array<{ email: string; pattern: string }>
+}
+
+export class GovernanceService {
+  constructor(private readonly loaded: GovernanceLoadResult) {}
+
+  isEnabled(): boolean {
+    return this.loaded.enabled
+  }
+
+  policyStatus(): GovernancePolicyStatus {
+    return this.loaded.status
+  }
+
+  policy(): GovernancePolicy | null {
+    return this.loaded.policy
+  }
+
+  private enabledPolicy(): GovernancePolicy | null {
+    if (!this.loaded.enabled) return null
+    if (!this.loaded.policy) return null
+    return this.loaded.policy
+  }
+
+  private userPolicy(user: GovernanceUserLike | null | undefined): GovernanceUserPolicy | null {
+    const policy = this.enabledPolicy()
+    if (!policy || !user?.email || user.emailVerified !== true) return null
+    return policy.usersByEmail.get(normalizePolicyEmail(user.email)) ?? null
+  }
+
+  roleForUser(user: GovernanceUserLike | null | undefined): TenantRole | null {
+    return this.userPolicy(user)?.role ?? null
+  }
+
+  isAdmin(user: GovernanceUserLike | null | undefined): boolean {
+    return this.roleForUser(user) === 'admin'
+  }
+
+  allowedModelsForUser<TModel extends ServedModelLike>(user: GovernanceUserLike, servedModels: TModel[]): TModel[] {
+    const userPolicy = this.userPolicy(user)
+    if (!this.loaded.enabled) return servedModels
+    if (!userPolicy) return []
+    const allowed = new Set(userPolicy.models.map((model) => `${model.provider}\u0000${model.id}`))
+    return servedModels.filter((model) => allowed.has(`${model.provider}\u0000${model.id}`))
+  }
+
+  assertModelAllowed(user: GovernanceUserLike, model: ServedModelLike): void {
+    if (!this.loaded.enabled) return
+    const allowed = this.allowedModelsForUser(user, [model])
+    if (allowed.length === 0) throw new GovernancePolicyError('model is not allowed by governance policy', 'not_allowed')
+  }
+
+  monthlyBudgetMicros(user: GovernanceUserLike, model: ServedModelLike): number | null {
+    if (!this.loaded.enabled) return null
+    const userPolicy = this.userPolicy(user)
+    const grant = userPolicy?.models.find((entry) => entry.provider === model.provider && entry.id === model.id)
+    return grant?.monthlyBudgetMicros ?? null
+  }
+
+  companyContextRules(user: GovernanceUserLike): string[] {
+    if (!this.loaded.enabled) return []
+    return this.userPolicy(user)?.companyContext.allow ?? []
+  }
+
+  companyContextWorkspaceId(): string | null {
+    return this.enabledPolicy()?.tenant.companyContextWorkspaceId ?? null
+  }
+
+  me(user: GovernanceUserLike | null | undefined): GovernanceMeResponse {
+    const role = this.roleForUser(user)
+    const admin = role === 'admin'
+    const base: GovernanceMeResponse = {
+      enabled: this.loaded.enabled,
+      role,
+      admin,
+    }
+    if (!this.loaded.enabled) return base
+    const policy = this.loaded.policy
+    if (!policy) {
+      return { ...base, policyStatus: this.loaded.status }
+    }
+    if (!admin) return base
+    return {
+      ...base,
+      policyStatus: this.loaded.status,
+      tenant: {
+        id: policy.tenant.id,
+        companyContextWorkspaceId: policy.tenant.companyContextWorkspaceId,
+        defaultMonthlyModelBudgetEur: policy.tenant.defaultMonthlyModelBudgetEur,
+        perRunHoldEur: policy.tenant.perRunHoldEur,
+      },
+      users: policy.users.map((entry) => ({
+        email: entry.email,
+        role: entry.role,
+        modelCount: entry.models.length,
+        contextRuleCount: entry.companyContext.allow.length,
+      })),
+      models: policy.users.flatMap((entry) => entry.models.map((model) => ({ ...model, email: entry.email }))),
+      companyContextRules: policy.users.flatMap((entry) => (
+        entry.companyContext.allow.map((pattern) => ({ email: entry.email, pattern }))
+      )),
+    }
+  }
+}
+
+export function createGovernanceService(result: GovernanceLoadResult): GovernanceService {
+  return new GovernanceService(result)
+}

--- a/apps/full-app/src/server/governance/index.ts
+++ b/apps/full-app/src/server/governance/index.ts
@@ -1,0 +1,40 @@
+import type { CoreConfig } from '@hachej/boring-core/shared'
+import type { CoreWorkspaceAgentServerPlugin } from '@hachej/boring-core/app/server'
+import { loadGovernancePolicy, type LoadGovernancePolicyOptions } from './loadPolicy.js'
+import { createGovernanceService, type GovernanceService } from './governanceService.js'
+import { governanceRoutes } from './routes.js'
+
+export { GovernancePolicyError, GovernanceService } from './governanceService.js'
+export type { GovernanceMeResponse } from './governanceService.js'
+export type {
+  GovernanceLoadResult,
+  GovernanceModelGrant,
+  GovernancePolicy,
+  GovernancePolicyStatus,
+  GovernanceUserLike,
+  GovernanceUserPolicy,
+  ServedModelLike,
+  TenantRole,
+} from './policyTypes.js'
+export {
+  GOVERNANCE_DEV_EMAIL_VERIFICATION_OVERRIDE_ENV,
+  GOVERNANCE_POLICY_PATH_ENV,
+  loadGovernancePolicy,
+} from './loadPolicy.js'
+export { normalizePolicyEmail, validateGovernancePolicy } from './validatePolicy.js'
+
+export interface BuildGovernanceOptions extends Omit<LoadGovernancePolicyOptions, 'config'> {
+  config?: Pick<CoreConfig, 'auth'>
+}
+
+export async function buildGovernanceService(options: BuildGovernanceOptions = {}): Promise<GovernanceService> {
+  return createGovernanceService(await loadGovernancePolicy(options))
+}
+
+export function createGovernanceServerPlugin(service: GovernanceService): CoreWorkspaceAgentServerPlugin {
+  return {
+    id: 'full-app-governance',
+    label: 'Full-app governance',
+    routes: governanceRoutes(service),
+  }
+}

--- a/apps/full-app/src/server/governance/loadPolicy.ts
+++ b/apps/full-app/src/server/governance/loadPolicy.ts
@@ -1,0 +1,92 @@
+import { readFile, stat } from 'node:fs/promises'
+import { parse } from 'yaml'
+import { isCoreEmailVerificationEnabled, type CoreConfig } from '@hachej/boring-core/shared'
+import type { GovernanceLoadResult } from './policyTypes.js'
+import { validateGovernancePolicy } from './validatePolicy.js'
+
+const MAX_POLICY_BYTES = 256 * 1024
+export const GOVERNANCE_POLICY_PATH_ENV = 'BORING_GOVERNANCE_POLICY_PATH'
+export const GOVERNANCE_DEV_EMAIL_VERIFICATION_OVERRIDE_ENV = 'BORING_GOVERNANCE_ALLOW_UNVERIFIED_EMAIL_DEV'
+
+export interface LoadGovernancePolicyOptions {
+  env?: NodeJS.ProcessEnv
+  nodeEnv?: string
+  config?: Pick<CoreConfig, 'auth'>
+}
+
+function invalidResult(path: string, error: unknown): GovernanceLoadResult {
+  return {
+    enabled: true,
+    policy: null,
+    status: {
+      state: 'invalid',
+      path,
+      message: error instanceof Error ? error.message : String(error),
+    },
+  }
+}
+
+function shouldAllowDevEmailVerificationOverride(env: NodeJS.ProcessEnv, nodeEnv: string): boolean {
+  return nodeEnv !== 'production' && env[GOVERNANCE_DEV_EMAIL_VERIFICATION_OVERRIDE_ENV] === '1'
+}
+
+export async function loadGovernancePolicy({
+  env = process.env,
+  nodeEnv = process.env.NODE_ENV ?? 'development',
+  config,
+}: LoadGovernancePolicyOptions = {}): Promise<GovernanceLoadResult> {
+  const configuredPath = env[GOVERNANCE_POLICY_PATH_ENV]?.trim()
+  if (!configuredPath) {
+    return {
+      enabled: false,
+      policy: null,
+      status: { state: 'disabled', reason: 'missing-env', path: null },
+    }
+  }
+
+  let fileStat
+  try {
+    fileStat = await stat(configuredPath)
+  } catch (error) {
+    const code = (error as { code?: unknown }).code
+    if (code === 'ENOENT') {
+      return {
+        enabled: false,
+        policy: null,
+        status: { state: 'disabled', reason: 'missing-file', path: configuredPath },
+      }
+    }
+    throw error
+  }
+
+  if (fileStat.size > MAX_POLICY_BYTES) {
+    const result = invalidResult(configuredPath, new Error(`policy file exceeds ${MAX_POLICY_BYTES} bytes`))
+    if (nodeEnv === 'production') throw new Error(result.status.state === 'invalid' ? result.status.message : 'invalid governance policy')
+    return result
+  }
+
+  try {
+    if (config && !isCoreEmailVerificationEnabled(config) && !shouldAllowDevEmailVerificationOverride(env, nodeEnv)) {
+      throw new Error(
+        `governance requires email verification; configure mail or set ${GOVERNANCE_DEV_EMAIL_VERIFICATION_OVERRIDE_ENV}=1 outside production`,
+      )
+    }
+    const raw = await readFile(configuredPath, 'utf8')
+    const parsed = parse(raw)
+    const policy = validateGovernancePolicy(parsed)
+    return {
+      enabled: true,
+      policy,
+      status: {
+        state: 'active',
+        path: configuredPath,
+        tenantId: policy.tenant.id,
+        userCount: policy.users.length,
+      },
+    }
+  } catch (error) {
+    const result = invalidResult(configuredPath, error)
+    if (nodeEnv === 'production') throw new Error(result.status.state === 'invalid' ? result.status.message : 'invalid governance policy')
+    return result
+  }
+}

--- a/apps/full-app/src/server/governance/policyTypes.ts
+++ b/apps/full-app/src/server/governance/policyTypes.ts
@@ -1,0 +1,61 @@
+export type TenantRole = 'admin' | 'user'
+
+export interface GovernancePolicyFile {
+  tenant?: {
+    id?: unknown
+    companyContextWorkspaceId?: unknown
+    defaultMonthlyModelBudgetEur?: unknown
+    perRunHoldEur?: unknown
+  }
+  users?: unknown
+}
+
+export interface GovernanceModelGrant {
+  provider: string
+  id: string
+  monthlyBudgetEur: number
+  monthlyBudgetMicros: number
+}
+
+export interface GovernanceUserPolicy {
+  email: string
+  role: TenantRole
+  models: GovernanceModelGrant[]
+  companyContext: {
+    allow: string[]
+  }
+}
+
+export interface GovernancePolicy {
+  tenant: {
+    id: string
+    companyContextWorkspaceId: string | null
+    defaultMonthlyModelBudgetEur: number
+    perRunHoldEur: number
+    perRunHoldMicros: number
+  }
+  users: GovernanceUserPolicy[]
+  usersByEmail: Map<string, GovernanceUserPolicy>
+}
+
+export type GovernancePolicyStatus =
+  | { state: 'disabled'; reason: 'missing-env' | 'missing-file'; path: string | null }
+  | { state: 'active'; path: string; tenantId: string; userCount: number }
+  | { state: 'invalid'; path: string; message: string }
+
+export interface GovernanceLoadResult {
+  enabled: boolean
+  policy: GovernancePolicy | null
+  status: GovernancePolicyStatus
+}
+
+export interface GovernanceUserLike {
+  id?: string
+  email: string
+  emailVerified: boolean
+}
+
+export interface ServedModelLike {
+  provider: string
+  id: string
+}

--- a/apps/full-app/src/server/governance/routes.ts
+++ b/apps/full-app/src/server/governance/routes.ts
@@ -1,0 +1,10 @@
+import type { FastifyPluginAsync } from 'fastify'
+import type { GovernanceService } from './governanceService.js'
+
+export function governanceRoutes(service: GovernanceService): FastifyPluginAsync {
+  return async (app) => {
+    app.get('/api/v1/governance/me', async (request) => {
+      return service.me(request.user ?? null)
+    })
+  }
+}

--- a/apps/full-app/src/server/governance/validatePolicy.ts
+++ b/apps/full-app/src/server/governance/validatePolicy.ts
@@ -1,0 +1,143 @@
+import type {
+  GovernanceModelGrant,
+  GovernancePolicy,
+  GovernancePolicyFile,
+  GovernanceUserPolicy,
+  TenantRole,
+} from './policyTypes.js'
+
+const MICROS_PER_EUR = 1_000_000
+const MAX_REGEX_LENGTH = 512
+const MAX_CONTEXT_RULES_PER_USER = 128
+
+function fail(message: string): never {
+  throw new Error(message)
+}
+
+export function normalizePolicyEmail(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nonEmptyString(value: unknown, path: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    fail(`${path} must be a non-empty string`)
+  }
+  return value.trim()
+}
+
+function finiteNumber(value: unknown, path: string, opts: { min: number; allowZero: boolean }): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    fail(`${path} must be a finite number`)
+  }
+  if (opts.allowZero ? value < opts.min : value <= opts.min) {
+    fail(`${path} must be ${opts.allowZero ? '>=' : '>'} ${opts.min}`)
+  }
+  return value
+}
+
+function validateRegexPattern(value: unknown, path: string): string {
+  const pattern = nonEmptyString(value, path)
+  if (pattern.length > MAX_REGEX_LENGTH) fail(`${path} must be at most ${MAX_REGEX_LENGTH} characters`)
+  // v1 safety subset: require anchored path-like allow rules and reject common catastrophic nested quantifier shapes.
+  if (!pattern.startsWith('^/')) fail(`${path} must start with ^/`)
+  if (/\([^)]*[+*][^)]*\)[+*{]/.test(pattern)) {
+    fail(`${path} contains an unsafe nested quantifier`)
+  }
+  try {
+    new RegExp(pattern)
+  } catch (error) {
+    fail(`${path} must compile as a JavaScript RegExp: ${error instanceof Error ? error.message : String(error)}`)
+  }
+  return pattern
+}
+
+function validateModels(value: unknown, userPath: string): GovernanceModelGrant[] {
+  if (value === undefined) return []
+  if (!Array.isArray(value)) fail(`${userPath}.models must be an array`)
+  return value.map((entry, index) => {
+    const path = `${userPath}.models[${index}]`
+    if (!isRecord(entry)) fail(`${path} must be an object`)
+    const provider = nonEmptyString(entry.provider, `${path}.provider`)
+    const id = nonEmptyString(entry.id, `${path}.id`)
+    const monthlyBudgetEur = finiteNumber(entry.monthlyBudgetEur, `${path}.monthlyBudgetEur`, {
+      min: 0,
+      allowZero: true,
+    })
+    return {
+      provider,
+      id,
+      monthlyBudgetEur,
+      monthlyBudgetMicros: Math.round(monthlyBudgetEur * MICROS_PER_EUR),
+    }
+  })
+}
+
+function validateCompanyContext(value: unknown, userPath: string): { allow: string[] } {
+  if (value === undefined) return { allow: [] }
+  if (!isRecord(value)) fail(`${userPath}.companyContext must be an object`)
+  const allow = value.allow
+  if (allow === undefined) return { allow: [] }
+  if (!Array.isArray(allow)) fail(`${userPath}.companyContext.allow must be an array`)
+  if (allow.length > MAX_CONTEXT_RULES_PER_USER) {
+    fail(`${userPath}.companyContext.allow must contain at most ${MAX_CONTEXT_RULES_PER_USER} rules`)
+  }
+  return {
+    allow: allow.map((pattern, index) => validateRegexPattern(pattern, `${userPath}.companyContext.allow[${index}]`)),
+  }
+}
+
+function validateRole(value: unknown, path: string): TenantRole {
+  if (value !== 'admin' && value !== 'user') fail(`${path} must be admin or user`)
+  return value
+}
+
+export function validateGovernancePolicy(input: unknown): GovernancePolicy {
+  if (!isRecord(input)) fail('policy must be an object')
+  const candidate = input as GovernancePolicyFile
+  if (!isRecord(candidate.tenant)) fail('tenant must be an object')
+  const tenant = candidate.tenant
+  const tenantId = nonEmptyString(tenant.id, 'tenant.id')
+  const companyContextWorkspaceId = tenant.companyContextWorkspaceId === undefined || tenant.companyContextWorkspaceId === null
+    ? null
+    : nonEmptyString(tenant.companyContextWorkspaceId, 'tenant.companyContextWorkspaceId')
+  const defaultMonthlyModelBudgetEur = tenant.defaultMonthlyModelBudgetEur === undefined
+    ? 0
+    : finiteNumber(tenant.defaultMonthlyModelBudgetEur, 'tenant.defaultMonthlyModelBudgetEur', { min: 0, allowZero: true })
+  const perRunHoldEur = tenant.perRunHoldEur === undefined
+    ? 1
+    : finiteNumber(tenant.perRunHoldEur, 'tenant.perRunHoldEur', { min: 0, allowZero: false })
+
+  if (!Array.isArray(candidate.users)) fail('users must be an array')
+  const usersByEmail = new Map<string, GovernanceUserPolicy>()
+  const users: GovernanceUserPolicy[] = candidate.users.map((entry, index) => {
+    const path = `users[${index}]`
+    if (!isRecord(entry)) fail(`${path} must be an object`)
+    const email = normalizePolicyEmail(nonEmptyString(entry.email, `${path}.email`))
+    if (!email.includes('@')) fail(`${path}.email must be an email address`)
+    if (usersByEmail.has(email)) fail(`duplicate user email: ${email}`)
+    const user: GovernanceUserPolicy = {
+      email,
+      role: validateRole(entry.role, `${path}.role`),
+      models: validateModels(entry.models, path),
+      companyContext: validateCompanyContext(entry.companyContext, path),
+    }
+    usersByEmail.set(email, user)
+    return user
+  })
+
+  return {
+    tenant: {
+      id: tenantId,
+      companyContextWorkspaceId,
+      defaultMonthlyModelBudgetEur,
+      perRunHoldEur,
+      perRunHoldMicros: Math.round(perRunHoldEur * MICROS_PER_EUR),
+    },
+    users,
+    usersByEmail,
+  }
+}

--- a/apps/full-app/src/server/main.ts
+++ b/apps/full-app/src/server/main.ts
@@ -1,10 +1,13 @@
+import path from 'node:path'
 import {
   appRootFromImportMeta,
   createCoreWorkspaceAgentServer,
 } from '@hachej/boring-core/app/server'
-import { serverPlugins } from './plugins.js'
+import { loadConfig } from '@hachej/boring-core/server'
+import { createFullAppServerPlugins } from './plugins.js'
 import { buildCreditsWiring } from './credits.js'
 import { assertProductionAgentModeIsSafe } from './productionSafety.js'
+import { buildGovernanceService, createGovernanceServerPlugin } from './governance/index.js'
 
 function pluginAuthoringEnabledFromEnv(): boolean {
   return process.env.BORING_PLUGIN_AUTHORING === '1'
@@ -13,13 +16,19 @@ function pluginAuthoringEnabledFromEnv(): boolean {
 async function main() {
   assertProductionAgentModeIsSafe()
   const appRoot = appRootFromImportMeta(import.meta.url, 2)
+  const config = await loadConfig({
+    allowMissingSecrets: process.env.NODE_ENV !== 'production',
+    tomlPath: path.resolve(appRoot, 'boring.app.toml'),
+  })
+  const governance = await buildGovernanceService({ config })
   // Build the metering sink up-front; the credit service attaches after the
   // server (and its db) exists.
   const credits = buildCreditsWiring()
   const app = await createCoreWorkspaceAgentServer({
     appRoot,
+    config,
     serveFrontend: true,
-    plugins: serverPlugins,
+    plugins: createFullAppServerPlugins([createGovernanceServerPlugin(governance)]),
     externalPlugins: false,
     installPluginAuthoring: pluginAuthoringEnabledFromEnv(),
     metering: credits.meteringSink,

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -1,5 +1,11 @@
+import type { CoreWorkspaceAgentServerPlugin } from '@hachej/boring-core/app/server'
 import { createFullAppBoringMcpServerPlugins } from './boringMcp.js'
 
-export const serverPlugins = [
-  ...createFullAppBoringMcpServerPlugins(),
-]
+export function createFullAppServerPlugins(extra: CoreWorkspaceAgentServerPlugin[] = []): CoreWorkspaceAgentServerPlugin[] {
+  return [
+    ...createFullAppBoringMcpServerPlugins(),
+    ...extra,
+  ]
+}
+
+export const serverPlugins = createFullAppServerPlugins()

--- a/docs/issues/475/todo-stack-tenant-yaml-governance.md
+++ b/docs/issues/475/todo-stack-tenant-yaml-governance.md
@@ -75,72 +75,74 @@ Introduce full-app-owned tenant governance policy parsing and expose read-only e
 
 ### TODO
 
-- [ ] Add `yaml` dependency to `apps/full-app`.
-- [ ] Add `apps/full-app/src/server/governance/` module:
-  - [ ] `policyTypes.ts` — typed parsed policy model;
-  - [ ] `loadPolicy.ts` — reads `BORING_GOVERNANCE_POLICY_PATH`;
-  - [ ] `validatePolicy.ts` — validation + normalized policy;
-  - [ ] `governanceService.ts` — request-time methods;
-  - [ ] `routes.ts` — authenticated governance routes;
-  - [ ] `index.ts` — public full-app wiring surface.
-- [ ] Policy loading semantics:
-  - [ ] missing env/path/file => governance disabled;
-  - [ ] file present but parse/validation fails in production => refuse to boot;
-  - [ ] file present but parse/validation fails in dev => visible startup error + all policy-dependent actions denied;
-  - [ ] never silently disable governance when policy file exists but is invalid;
-  - [ ] restart-only reload for v1;
-  - [ ] max YAML size 256 KiB;
-  - [ ] duplicate user emails rejected after the same lowercase/trim normalization used at request time.
-- [ ] Email verification boot check:
-  - [ ] governance-enabled boot requires core email verification configured;
-  - [ ] define production detection explicitly (prefer `NODE_ENV === 'production'` unless codebase has a better existing signal);
-  - [ ] name the dev-only override env var before implementation;
-  - [ ] if verification is not configured, refuse production boot unless that explicit dev-only override is set;
-  - [ ] test both production fail and dev override behavior.
-- [ ] Validation:
-  - [ ] one tenant block;
-  - [ ] optional `companyContextWorkspaceId` now, but PR 5a will make it required before company-context enforcement;
-  - [ ] roles only `admin | user`;
-  - [ ] exact model rows require non-empty `provider` and `id`;
-  - [ ] `monthlyBudgetEur` finite and `>= 0`;
-  - [ ] `defaultMonthlyModelBudgetEur` is documented but not used for absent rows in v1; absent model row still denies;
-  - [ ] `perRunHoldEur` finite positive when model-budget enforcement is enabled; hold amount is `perRunHoldEur * 1_000_000` micros;
-  - [ ] regex rules compile and pass safe subset/safety check.
-- [ ] Request-time user policy:
-  - [ ] normalize request user email;
-  - [ ] if governance enabled and `emailVerified !== true`, all policy-derived privileges deny;
-  - [ ] `roleForUser`, `isAdmin`, `allowedModelsForUser`, `assertModelAllowed`, `monthlyBudgetMicros`, `companyContextRules`.
-- [ ] Per-user admin-status seam for shared core UI:
-  - [ ] before coding PR2, pick exactly one seam in a short branch note: generic core hook/prop/context vs full-app-injected menu item;
-  - [ ] do **not** hard-code `/api/v1/governance/me` into `@hachej/boring-core` UserMenu as a full-app-only dependency;
-  - [ ] add a small generic hook/prop/context in core for optional admin entry status, where absence/404 = disabled; or inject the user-menu extra item from full-app;
-  - [ ] full-app implements `/api/v1/governance/me` returning `{ enabled, role, admin }` to normal users and admin-only `policyStatus` details;
-  - [ ] per-user admin status must not use app-global capabilities because capabilities are cached globally.
-- [ ] CompanyAdminPage v1:
-  - [ ] read-only policy/status view;
-  - [ ] clear copy: “YAML-managed in v1”; no fake edit controls;
-  - [ ] tenant invites shown as deferred/not implemented if present in copy.
+Branch note / seam choice: PR2 uses a generic `CompanyAdminProvider` context in `@hachej/boring-core/front`. Core never hard-codes `/api/v1/governance/me`; full-app injects a loader that calls the full-app route. Missing provider or 404/null status preserves the PR1 owner fallback; governance loading/errors fail closed.
+
+- [x] Add `yaml` dependency to `apps/full-app`.
+- [x] Add `apps/full-app/src/server/governance/` module:
+  - [x] `policyTypes.ts` — typed parsed policy model;
+  - [x] `loadPolicy.ts` — reads `BORING_GOVERNANCE_POLICY_PATH`;
+  - [x] `validatePolicy.ts` — validation + normalized policy;
+  - [x] `governanceService.ts` — request-time methods;
+  - [x] `routes.ts` — authenticated governance routes;
+  - [x] `index.ts` — public full-app wiring surface.
+- [x] Policy loading semantics:
+  - [x] missing env/path/file => governance disabled;
+  - [x] file present but parse/validation fails in production => refuse to boot;
+  - [x] file present but parse/validation fails in dev => visible startup error + all policy-dependent actions denied;
+  - [x] never silently disable governance when policy file exists but is invalid;
+  - [x] restart-only reload for v1;
+  - [x] max YAML size 256 KiB;
+  - [x] duplicate user emails rejected after the same lowercase/trim normalization used at request time.
+- [x] Email verification boot check:
+  - [x] governance-enabled boot requires core email verification configured;
+  - [x] define production detection explicitly (prefer `NODE_ENV === 'production'` unless codebase has a better existing signal);
+  - [x] name the dev-only override env var before implementation;
+  - [x] if verification is not configured, refuse production boot unless that explicit dev-only override is set;
+  - [x] test both production fail and dev override behavior.
+- [x] Validation:
+  - [x] one tenant block;
+  - [x] optional `companyContextWorkspaceId` now, but PR 5a will make it required before company-context enforcement;
+  - [x] roles only `admin | user`;
+  - [x] exact model rows require non-empty `provider` and `id`;
+  - [x] `monthlyBudgetEur` finite and `>= 0`;
+  - [x] `defaultMonthlyModelBudgetEur` is documented but not used for absent rows in v1; absent model row still denies;
+  - [x] `perRunHoldEur` finite positive when model-budget enforcement is enabled; hold amount is `perRunHoldEur * 1_000_000` micros;
+  - [x] regex rules compile and pass safe subset/safety check.
+- [x] Request-time user policy:
+  - [x] normalize request user email;
+  - [x] if governance enabled and `emailVerified !== true`, all policy-derived privileges deny;
+  - [x] `roleForUser`, `isAdmin`, `allowedModelsForUser`, `assertModelAllowed`, `monthlyBudgetMicros`, `companyContextRules`.
+- [x] Per-user admin-status seam for shared core UI:
+  - [x] before coding PR2, pick exactly one seam in a short branch note: generic core hook/prop/context vs full-app-injected menu item;
+  - [x] do **not** hard-code `/api/v1/governance/me` into `@hachej/boring-core` UserMenu as a full-app-only dependency;
+  - [x] add a small generic hook/prop/context in core for optional admin entry status, where absence/404 = disabled; or inject the user-menu extra item from full-app;
+  - [x] full-app implements `/api/v1/governance/me` returning `{ enabled, role, admin }` to normal users and admin-only `policyStatus` details;
+  - [x] per-user admin status must not use app-global capabilities because capabilities are cached globally.
+- [x] CompanyAdminPage v1:
+  - [x] read-only policy/status view;
+  - [x] clear copy: “YAML-managed in v1”; no fake edit controls;
+  - [x] tenant invites shown as deferred/not implemented if present in copy.
 
 ### Tests / proof
 
-- [ ] Governance loader unit tests:
-  - [ ] missing policy disabled;
-  - [ ] valid policy normalizes;
-  - [ ] invalid YAML production boot fails;
-  - [ ] invalid YAML dev mode returns visible error and denies policy-dependent actions;
-  - [ ] duplicate users rejected after normalization;
-  - [ ] invalid roles rejected;
-  - [ ] invalid budgets rejected;
-  - [ ] invalid/unsafe regex rejected;
-  - [ ] governance-enabled boot fails without email verification config unless dev override;
-  - [ ] unverified admin denied;
-  - [ ] unverified normal user with configured model/context grants denied.
-- [ ] Governance route tests for `/api/v1/governance/me`.
-- [ ] UserMenu/admin-entry tests for governance admin visible/user hidden/disabled fallback/404 absence.
-- [ ] CompanyAdminPage read-only view tests.
-- [ ] `pnpm --filter full-app test -- governance`
-- [ ] targeted core/front tests affected by UserMenu/admin page.
-- [ ] typecheck for affected packages.
+- [x] Governance loader unit tests:
+  - [x] missing policy disabled;
+  - [x] valid policy normalizes;
+  - [x] invalid YAML production boot fails;
+  - [x] invalid YAML dev mode returns visible error and denies policy-dependent actions;
+  - [x] duplicate users rejected after normalization;
+  - [x] invalid roles rejected;
+  - [x] invalid budgets rejected;
+  - [x] invalid/unsafe regex rejected;
+  - [x] governance-enabled boot fails without email verification config unless dev override;
+  - [x] unverified admin denied;
+  - [x] unverified normal user with configured model/context grants denied.
+- [x] Governance route tests for `/api/v1/governance/me`.
+- [x] UserMenu/admin-entry tests for governance admin visible/user hidden/disabled fallback/404 absence.
+- [x] CompanyAdminPage read-only view tests.
+- [x] `pnpm --filter full-app test -- governance`
+- [x] targeted core/front tests affected by UserMenu/admin page.
+- [x] typecheck for affected packages.
 
 ### Review focus
 

--- a/packages/core/SIZE.md
+++ b/packages/core/SIZE.md
@@ -2,20 +2,21 @@
 
 | Entry  | Gzip (KB) |
 |--------|-----------|
-| front  |     31.26 |
-| server |     58.06 |
+| front  |     34.97 |
+| server |     59.66 |
 
 ### Chunk breakdown
 
 **front**
 - `chunk-HYNKZSTF.js`: 0.24 KB
-- `chunk-WK7GFJZX.js`: 30.47 KB
-- `front/index.js`: 0.56 KB
+- `chunk-NKJO5ASV.js`: 34.14 KB
+- `front/index.js`: 0.60 KB
 
 **server**
-- `chunk-I56OTSPB.js`: 19.54 KB
-- `chunk-LIBHVT7V.js`: 0.88 KB
-- `chunk-RG2NE33D.js`: 19.69 KB
-- `server/index.js`: 17.95 KB
+- `chunk-AQBXNPMD.js`: 0.17 KB
+- `chunk-BVZ2YT3M.js`: 19.56 KB
+- `chunk-QZGYKLXB.js`: 0.89 KB
+- `chunk-ZMS6O4CY.js`: 20.62 KB
+- `server/index.js`: 18.42 KB
 
-_Updated: 2026-06-15_
+_Updated: 2026-07-03_

--- a/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
+++ b/packages/core/src/app/front/CoreWorkspaceAgentFront.tsx
@@ -11,6 +11,7 @@ import {
   useSession,
   useWorkspaceRouteStatus,
   type CoreFrontAuthPagesOverride,
+  type CoreFrontCompanyAdminOptions,
 } from '../../front/index.js'
 import {
   parseFullPagePanelLocation,
@@ -53,6 +54,7 @@ export interface CoreWorkspaceAgentFrontProps<
   chatFirstPublicWorkspaceProps?: Partial<RoutedWorkspaceAgentProps<TSession>>
   publicPaths?: string[]
   authPages?: CoreFrontAuthPagesOverride
+  companyAdmin?: CoreFrontCompanyAdminOptions
   cspNonce?: string
   children?: ReactNode
   workspaceRoute?: string
@@ -510,6 +512,7 @@ export function CoreWorkspaceAgentFront<
   TSession extends WorkspaceAgentSession = WorkspaceAgentSession,
 >({
   authPages,
+  companyAdmin,
   cspNonce,
   children,
   workspaceRoute = DEFAULT_WORKSPACE_ROUTE,
@@ -543,6 +546,7 @@ export function CoreWorkspaceAgentFront<
   return (
     <CoreFront
       authPages={authPages}
+      companyAdmin={companyAdmin}
       cspNonce={cspNonce}
       workspaceRoute={workspaceRoute}
       workspaceIdParam={workspaceIdParam}

--- a/packages/core/src/front/CompanyAdminProvider.tsx
+++ b/packages/core/src/front/CompanyAdminProvider.tsx
@@ -1,0 +1,103 @@
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+
+export interface CompanyAdminStatus {
+  enabled: boolean
+  admin: boolean
+  role?: string | null
+  details?: unknown
+}
+
+export type LoadCompanyAdminStatus = () => Promise<CompanyAdminStatus | null>
+export type RenderCompanyAdminContent = (status: CompanyAdminStatus) => ReactNode
+
+interface CompanyAdminContextValue {
+  configured: boolean
+  loading: boolean
+  status: CompanyAdminStatus | null
+  error: string | null
+  renderContent: RenderCompanyAdminContent | null
+  refresh(): Promise<void>
+}
+
+const CompanyAdminContext = createContext<CompanyAdminContextValue>({
+  configured: false,
+  loading: false,
+  status: null,
+  error: null,
+  renderContent: null,
+  refresh: async () => {},
+})
+
+export interface CompanyAdminProviderProps {
+  children: ReactNode
+  loadStatus?: LoadCompanyAdminStatus
+  renderContent?: RenderCompanyAdminContent
+  /**
+   * Optional authenticated-user cache key. When null, status is cleared and no
+   * request is made. When it changes, status is refetched.
+   */
+  identityKey?: string | null
+}
+
+export function CompanyAdminProvider({ children, loadStatus, renderContent, identityKey }: CompanyAdminProviderProps) {
+  const [status, setStatus] = useState<CompanyAdminStatus | null>(null)
+  const [loading, setLoading] = useState(Boolean(loadStatus && identityKey !== null))
+  const [error, setError] = useState<string | null>(null)
+
+  async function refresh(): Promise<void> {
+    if (!loadStatus) return
+    setLoading(true)
+    setError(null)
+    try {
+      setStatus(await loadStatus())
+    } catch (err) {
+      setStatus(null)
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false
+    if (!loadStatus || identityKey === null) {
+      setStatus(null)
+      setError(null)
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(null)
+    loadStatus()
+      .then((next) => {
+        if (!cancelled) setStatus(next)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setStatus(null)
+          setError(err instanceof Error ? err.message : String(err))
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [identityKey, loadStatus])
+
+  const value = useMemo<CompanyAdminContextValue>(() => ({
+    configured: Boolean(loadStatus),
+    loading,
+    status,
+    error,
+    renderContent: renderContent ?? null,
+    refresh,
+  }), [error, loadStatus, loading, renderContent, status])
+
+  return <CompanyAdminContext.Provider value={value}>{children}</CompanyAdminContext.Provider>
+}
+
+export function useCompanyAdminStatus(): CompanyAdminContextValue {
+  return useContext(CompanyAdminContext)
+}

--- a/packages/core/src/front/CoreFront.tsx
+++ b/packages/core/src/front/CoreFront.tsx
@@ -7,8 +7,9 @@ import { Helmet, HelmetProvider } from 'react-helmet-async'
 import { AppErrorBoundary } from './AppErrorBoundary.js'
 import { ConfigProvider, useConfig } from './ConfigProvider.js'
 import { ThemeProvider } from './ThemeProvider.js'
-import { AuthProvider } from './auth/AuthProvider.js'
+import { AuthProvider, useSession } from './auth/AuthProvider.js'
 import { UserIdentityProvider } from './auth/UserIdentityProvider.js'
+import { CompanyAdminProvider, type LoadCompanyAdminStatus, type RenderCompanyAdminContent } from './CompanyAdminProvider.js'
 import { WorkspaceAuthProvider } from './WorkspaceAuthProvider.js'
 import { AuthGate } from './AuthGate.js'
 import { TopBarSlotProvider, UserMenu } from './components/index.js'
@@ -37,6 +38,11 @@ export interface CoreFrontAuthPagesOverride {
   userSettings?: React.FC
 }
 
+export interface CoreFrontCompanyAdminOptions {
+  loadStatus?: LoadCompanyAdminStatus
+  renderContent?: RenderCompanyAdminContent
+}
+
 export interface CoreFrontProps {
   children?: ReactNode
   authPages?: CoreFrontAuthPagesOverride
@@ -44,6 +50,7 @@ export interface CoreFrontProps {
   workspaceRoute?: string
   workspaceIdParam?: string
   publicPaths?: string[]
+  companyAdmin?: CoreFrontCompanyAdminOptions
 }
 
 const CSP_NONCE_META_NAME = 'boring-csp-nonce'
@@ -68,6 +75,20 @@ function createDefaultQueryClient(): QueryClient {
       },
     },
   })
+}
+
+function CompanyAdminScopedProvider({ children, companyAdmin }: { children: ReactNode; companyAdmin?: CoreFrontCompanyAdminOptions }) {
+  const session = useSession()
+  const identityKey = session.data?.user?.id ?? null
+  return (
+    <CompanyAdminProvider
+      loadStatus={companyAdmin?.loadStatus}
+      renderContent={companyAdmin?.renderContent}
+      identityKey={identityKey}
+    >
+      {children}
+    </CompanyAdminProvider>
+  )
 }
 
 function RouterAuthGate({ children, publicPaths }: { children: ReactNode; publicPaths?: string[] }) {
@@ -97,7 +118,7 @@ function RouterAuthGate({ children, publicPaths }: { children: ReactNode; public
   )
 }
 
-export function CoreFront({ children, authPages, cspNonce, workspaceRoute, workspaceIdParam, publicPaths }: CoreFrontProps) {
+export function CoreFront({ children, authPages, cspNonce, workspaceRoute, workspaceIdParam, publicPaths, companyAdmin }: CoreFrontProps) {
   const queryClient = useMemo(createDefaultQueryClient, [])
   const resolvedCspNonce = useMemo(
     () => cspNonce ?? readCspNonceFromDom(),
@@ -121,9 +142,10 @@ export function CoreFront({ children, authPages, cspNonce, workspaceRoute, works
               <AuthProvider queryClient={queryClient}>
                 <UserIdentityProvider>
                   <BrowserRouter>
-                    <WorkspaceAuthProvider workspaceRoute={workspaceRoute} workspaceIdParam={workspaceIdParam}>
-                      <TopBarSlotProvider slot={<UserMenu />}>
-                        <Helmet>
+                    <CompanyAdminScopedProvider companyAdmin={companyAdmin}>
+                      <WorkspaceAuthProvider workspaceRoute={workspaceRoute} workspaceIdParam={workspaceIdParam}>
+                        <TopBarSlotProvider slot={<UserMenu />}>
+                          <Helmet>
                           {resolvedCspNonce ? (
                             <>
                               <meta name={CSP_NONCE_META_NAME} content={resolvedCspNonce} />
@@ -162,8 +184,9 @@ export function CoreFront({ children, authPages, cspNonce, workspaceRoute, works
                             </Routes>
                           </Suspense>
                         </RouterAuthGate>
-                      </TopBarSlotProvider>
-                    </WorkspaceAuthProvider>
+                        </TopBarSlotProvider>
+                      </WorkspaceAuthProvider>
+                    </CompanyAdminScopedProvider>
                   </BrowserRouter>
                 </UserIdentityProvider>
               </AuthProvider>

--- a/packages/core/src/front/__tests__/CompanyAdminPage.test.tsx
+++ b/packages/core/src/front/__tests__/CompanyAdminPage.test.tsx
@@ -1,9 +1,11 @@
 // @vitest-environment jsdom
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import type { ReactNode } from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { CompanyAdminProvider, type CompanyAdminStatus } from '../CompanyAdminProvider'
 import { CompanyAdminPage } from '../workspace/CompanyAdminPage'
 
 const mockUseCurrentWorkspace = vi.fn()
@@ -20,14 +22,15 @@ vi.mock('../WorkspaceAuthProvider', async () => {
   }
 })
 
-function renderPage(path = '/w/ws-a/admin') {
-  return render(
+function renderPage(path = '/w/ws-a/admin', wrapper?: (children: ReactNode) => ReactNode) {
+  const page = (
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/w/:id/admin" element={<CompanyAdminPage />} />
       </Routes>
-    </MemoryRouter>,
+    </MemoryRouter>
   )
+  return render(wrapper ? <>{wrapper(page)}</> : page)
 }
 
 beforeEach(() => {
@@ -96,6 +99,34 @@ describe('CompanyAdminPage', () => {
     expect(screen.getByText('Owner access required')).toBeInTheDocument()
     expect(screen.getByText(/Only workspace owners can manage/)).toBeInTheDocument()
     expect(screen.queryByText('Loading company admin…')).toBeNull()
+  })
+
+  it('renders app-owned content for governance admins through the generic seam', async () => {
+    mockUseWorkspaceRole.mockReturnValue('viewer')
+    const status: CompanyAdminStatus = { enabled: true, role: 'admin', admin: true, details: { source: 'test' } }
+
+    renderPage('/w/ws-a/admin', (children) => (
+      <CompanyAdminProvider
+        loadStatus={async () => status}
+        renderContent={(resolved) => <div>App-owned admin content: {(resolved.details as { source: string }).source}</div>}
+      >
+        {children}
+      </CompanyAdminProvider>
+    ))
+
+    expect(await screen.findByText('App-owned admin content: test')).toBeInTheDocument()
+    expect(screen.queryByText('YAML-managed in v1')).toBeNull()
+  })
+
+  it('blocks governance-enabled non-admins even when they own the workspace', async () => {
+    const status: CompanyAdminStatus = { enabled: true, role: 'user', admin: false }
+
+    renderPage('/w/ws-a/admin', (children) => (
+      <CompanyAdminProvider loadStatus={async () => status}>{children}</CompanyAdminProvider>
+    ))
+
+    expect(await screen.findByText('Company admin access required')).toBeInTheDocument()
+    expect(screen.getByText(/do not have access/)).toBeInTheDocument()
   })
 
   it('blocks non-owner members in the client shell', () => {

--- a/packages/core/src/front/__tests__/userNavComponents.test.tsx
+++ b/packages/core/src/front/__tests__/userNavComponents.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { withBeadId } from '../../server/__tests__/_setup'
 import type { Workspace } from '../../shared/types'
 import { useMswHandler } from './_setup'
+import { CompanyAdminProvider, type CompanyAdminStatus } from '../CompanyAdminProvider'
 import { ThemeToggle } from '../components/ThemeToggle'
 import { UserMenu } from '../components/UserMenu'
 import { WorkspaceSwitcher } from '../components/WorkspaceSwitcher'
@@ -241,6 +242,48 @@ describe('UserMenu', () => {
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Company admin' }))
 
     expect(mockNavigate).toHaveBeenCalledWith('/w/ws-a/admin')
+  })
+
+  it('shows company admin for governance admins even when they are not workspace owners', async () => {
+    mockUseWorkspaceRole.mockReturnValue('editor')
+    const status: CompanyAdminStatus = { enabled: true, role: 'admin', admin: true }
+    renderWithProviders(
+      <CompanyAdminProvider loadStatus={async () => status}>
+        <UserMenu />
+      </CompanyAdminProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'User menu' })).toBeInTheDocument())
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Company admin' })).toBeInTheDocument()
+  })
+
+  it('hides company admin for governance non-admins even when they own the workspace', async () => {
+    const status: CompanyAdminStatus = { enabled: true, role: 'user', admin: false }
+    renderWithProviders(
+      <CompanyAdminProvider loadStatus={async () => status}>
+        <UserMenu />
+      </CompanyAdminProvider>,
+    )
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'User menu' })).toBeInTheDocument())
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'User settings' })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Company admin' })).toBeNull()
+  })
+
+  it('falls back to owner visibility when governance status is disabled or absent', async () => {
+    renderWithProviders(
+      <CompanyAdminProvider loadStatus={async () => null}>
+        <UserMenu />
+      </CompanyAdminProvider>,
+    )
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Company admin' })).toBeInTheDocument()
   })
 })
 

--- a/packages/core/src/front/components/UserMenu.tsx
+++ b/packages/core/src/front/components/UserMenu.tsx
@@ -22,6 +22,7 @@ import {
 import { useNavigate } from 'react-router-dom'
 
 import { useSignOut, useUser } from '../auth/index.js'
+import { useCompanyAdminStatus } from '../CompanyAdminProvider.js'
 import { useCurrentWorkspace, useWorkspaceRole } from '../WorkspaceAuthProvider.js'
 import { useTheme } from '../hooks/index.js'
 import { routeHref, routes } from '../utils.js'
@@ -74,10 +75,18 @@ export function UserMenu({ contentSide = 'bottom', contentAlign = 'end', variant
   const { preference, setTheme } = useTheme()
   const workspace = useCurrentWorkspace()
   const workspaceRole = useWorkspaceRole()
+  const companyAdmin = useCompanyAdminStatus()
   const [isSigningOut, setIsSigningOut] = useState(false)
 
   const user = identity?.user
-  const companyAdminWorkspaceId = workspaceRole === 'owner' ? workspace?.id ?? null : null
+  const governanceEnabled = companyAdmin.status?.enabled === true
+  const companyAdminStatusPending = companyAdmin.configured && companyAdmin.loading && !companyAdmin.status
+  const canOpenCompanyAdmin = companyAdminStatusPending || companyAdmin.error
+    ? false
+    : governanceEnabled
+      ? companyAdmin.status?.admin === true
+      : workspaceRole === 'owner'
+  const companyAdminWorkspaceId = canOpenCompanyAdmin ? workspace?.id ?? null : null
 
   const userName = user?.name ?? 'Unknown user'
   const userEmail = user?.email ?? 'unknown@example.com'

--- a/packages/core/src/front/index.ts
+++ b/packages/core/src/front/index.ts
@@ -3,6 +3,13 @@ export { ConfigProvider, useConfig, useConfigLoaded } from './ConfigProvider.js'
 export type { ConfigProviderProps } from './ConfigProvider.js'
 export { ThemeProvider } from './ThemeProvider.js'
 export type { ThemeApi, ThemeProviderProps } from './ThemeProvider.js'
+export { CompanyAdminProvider, useCompanyAdminStatus } from './CompanyAdminProvider.js'
+export type {
+  CompanyAdminProviderProps,
+  CompanyAdminStatus,
+  LoadCompanyAdminStatus,
+  RenderCompanyAdminContent,
+} from './CompanyAdminProvider.js'
 export {
   useTheme,
   useKeyboardShortcuts,
@@ -70,7 +77,7 @@ export { AuthGate } from './AuthGate.js'
 export type { AuthGateProps } from './AuthGate.js'
 
 export { CoreFront } from './CoreFront.js'
-export type { CoreFrontProps, CoreFrontAuthPagesOverride } from './CoreFront.js'
+export type { CoreFrontProps, CoreFrontAuthPagesOverride, CoreFrontCompanyAdminOptions } from './CoreFront.js'
 
 export { useCoreCommands } from './commands/CoreCommandContributions.js'
 export type { CoreCommand } from './commands/CoreCommandContributions.js'

--- a/packages/core/src/front/workspace/CompanyAdminPage.tsx
+++ b/packages/core/src/front/workspace/CompanyAdminPage.tsx
@@ -1,5 +1,6 @@
 import { Navigate } from 'react-router-dom'
 import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '@hachej/boring-ui-kit'
+import { useCompanyAdminStatus } from '../CompanyAdminProvider.js'
 import { useCurrentWorkspace, useWorkspaceRole, useWorkspaceRouteStatus } from '../WorkspaceAuthProvider.js'
 import { routeHref } from '../utils.js'
 
@@ -22,6 +23,7 @@ export function CompanyAdminPage() {
   const currentWorkspace = useCurrentWorkspace()
   const role = useWorkspaceRole()
   const routeStatus = useWorkspaceRouteStatus()
+  const companyAdmin = useCompanyAdminStatus()
 
   if (routeStatus.status === 'loading') {
     return (
@@ -57,14 +59,43 @@ export function CompanyAdminPage() {
 
   if (!workspaceId) return <Navigate to="/" replace />
 
-  if (routeStatus.status === 'forbidden' || role !== 'owner') {
+  const governanceEnabled = companyAdmin.status?.enabled === true
+
+  if (companyAdmin.configured && companyAdmin.loading && !companyAdmin.status) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
+        <section className="rounded-xl border border-border bg-card p-6 shadow-sm" aria-busy="true">
+          <p className="text-sm text-muted-foreground">Loading company admin policy…</p>
+        </section>
+      </main>
+    )
+  }
+
+  if (companyAdmin.error) {
     return (
       <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
         <section className="rounded-xl border border-border bg-card p-6 shadow-sm">
-          <p className="text-sm font-medium text-destructive">Owner access required</p>
+          <p className="text-sm font-medium text-destructive">Company admin unavailable</p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">Company admin</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{companyAdmin.error}</p>
+          <Button asChild className="mt-5">
+            <a href={routeHref('workspaceSettings', { id: workspaceId })}>Back to workspace settings</a>
+          </Button>
+        </section>
+      </main>
+    )
+  }
+
+  if (routeStatus.status === 'forbidden' || (governanceEnabled ? companyAdmin.status?.admin !== true : role !== 'owner')) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
+        <section className="rounded-xl border border-border bg-card p-6 shadow-sm">
+          <p className="text-sm font-medium text-destructive">{governanceEnabled ? 'Company admin access required' : 'Owner access required'}</p>
           <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">Company admin</h1>
           <p className="mt-2 text-sm text-muted-foreground">
-            Only workspace owners can manage company context and model access controls.
+            {governanceEnabled
+              ? 'You do not have access to this company admin surface.'
+              : 'Only workspace owners can manage company context and model access controls.'}
           </p>
           <Button asChild className="mt-5">
             <a href={routeHref('workspaceSettings', { id: workspaceId })}>Back to workspace settings</a>
@@ -73,6 +104,12 @@ export function CompanyAdminPage() {
       </main>
     )
   }
+
+  const renderedAppContent = governanceEnabled && companyAdmin.status && companyAdmin.renderContent
+    ? companyAdmin.renderContent(companyAdmin.status)
+    : null
+
+  if (renderedAppContent) return <>{renderedAppContent}</>
 
   return (
     <main className="min-h-screen bg-background px-4 py-8 text-foreground sm:px-6 lg:px-8">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.5(react@19.2.5)
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@playwright/test':
         specifier: ^1.59.1


### PR DESCRIPTION
Stacked on #476 / issue/475-admin-layout.\n\nScope:\n- Add full-app YAML governance policy loader/service/routes.\n- Add /api/v1/governance/me with per-user admin status and admin-only policy details.\n- Add generic core CompanyAdminProvider seam; no full-app route hard-coded in core.\n- Full-app renders read-only YAML-managed Company Admin view.\n- No model/filesystem/budget enforcement yet.\n\nProof:\n- pnpm --filter full-app test -- governance — 4 files, 41 tests passed\n- pnpm --filter @hachej/boring-core exec vitest run src/front/__tests__/CompanyAdminPage.test.tsx src/front/__tests__/userNavComponents.test.tsx src/front/__tests__/CoreFront.test.tsx --no-file-parallelism — 3 files, 27 tests passed\n- pnpm --filter @hachej/boring-core run typecheck — passed\n- pnpm --filter @hachej/boring-core build — passed\n- pnpm --filter full-app run typecheck — passed\n- git diff --check — passed\n\nReview:\n- GPT-5.5 found and rechecked blockers around core tenant leakage, fail-open initial load, invalid policy visibility, and stale per-user status. Final verdict: PASS.


// approved-growth: boring-governance Company Admin provider/context tabs add small approved core-front bundle growth; reviewed in issue #475 stack.
