### PR TITLE
ci: harden visual diff detection

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -35,8 +35,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             base="origin/${{ github.base_ref }}"
-            git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" || true
-            files=$(git diff --name-only "$base...HEAD")
+            git fetch --no-tags origin "${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}" || true
+            files=$(git diff --name-only "$base...HEAD" || git diff --name-only "$base" HEAD)
           else
             files=$(git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" || true)
           fi


### PR DESCRIPTION
Fixes the red Visual Regression detector currently affecting version-bump PRs.\n\nCause: the detector fetched origin/main with --depth=1, then used a three-dot diff against the PR merge commit. On shallow base history Git cannot find a merge base and exits with fatal: origin/main...HEAD: no merge base.\n\nChange: fetch the base ref without forcing depth=1 and fall back to a two-dot diff if merge-base discovery still fails.