### PR TITLE
Visualize markdown frontmatter above editor

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditor.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/MarkdownEditor.tsx
@@ -80,8 +80,90 @@ export interface MarkdownEditorProps {
   filesystem?: FilesystemId
 }
 
+export interface MarkdownFrontmatterEntry {
+  key: string
+  value: string
+}
+
+export interface MarkdownFrontmatterSummary {
+  entries: MarkdownFrontmatterEntry[]
+  block: string
+  raw: string
+  body: string
+}
+
+function stripWrappingQuotes(value: string): string {
+  const trimmed = value.trim()
+  if (trimmed.length < 2) return trimmed
+  const first = trimmed[0]
+  const last = trimmed[trimmed.length - 1]
+  if ((first === "\"" && last === "\"") || (first === "'" && last === "'")) {
+    return trimmed.slice(1, -1)
+  }
+  return trimmed
+}
+
+function formatFrontmatterValue(rawValue: string): string {
+  const normalized = rawValue
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^-\s+/, ""))
+    .join(", ")
+  return stripWrappingQuotes(normalized)
+}
+
+export function parseMarkdownFrontmatter(content: string): MarkdownFrontmatterSummary | null {
+  const normalized = content.replace(/^\uFEFF/, "")
+  const match = normalized.match(/^---[ \t]*\r?\n([\s\S]*?)\r?\n(?:---|\.\.\.)[ \t]*(?:\r?\n|$)/)
+  if (!match || match.index !== 0) return null
+
+  const raw = match[1] ?? ""
+  const body = normalized.slice(match[0].length)
+  const entries: MarkdownFrontmatterEntry[] = []
+  let current: { key: string; lines: string[] } | null = null
+
+  const flushCurrent = () => {
+    if (!current) return
+    const value = formatFrontmatterValue(current.lines.join("\n"))
+    if (value) entries.push({ key: current.key, value })
+    current = null
+  }
+
+  for (const line of raw.split(/\r?\n/)) {
+    if (!line.trim() || line.trimStart().startsWith("#")) continue
+    const keyMatch = line.match(/^([A-Za-z0-9_-]+):(?:\s*(.*))?$/)
+    if (keyMatch) {
+      flushCurrent()
+      current = { key: keyMatch[1], lines: [keyMatch[2] ?? ""] }
+      continue
+    }
+    if (current && /^\s+/.test(line)) current.lines.push(line)
+  }
+  flushCurrent()
+
+  return entries.length > 0 ? { entries, block: match[0], raw, body } : null
+}
+
+function applyFrontmatterToBody(summary: MarkdownFrontmatterSummary | null, body: string): string {
+  if (!summary) return body
+  const separator = summary.block.endsWith("\n") || body.length === 0 ? "" : "\n"
+  return `${summary.block}${separator}${body}`
+}
+
+export function serializeMarkdownEditorChange(
+  nextBody: string,
+  editorFocused: boolean,
+  frontmatter: MarkdownFrontmatterSummary | null,
+  userInteracted = false,
+): string | null {
+  if (!isUserEditedChange(nextBody, editorFocused, userInteracted)) return null
+  return applyFrontmatterToBody(frontmatter, nextBody)
+}
+
 export function countMarkdownWords(content: string): number {
-  const plainText = content
+  const body = parseMarkdownFrontmatter(content)?.body ?? content
+  const plainText = body
     .replace(/```[\s\S]*?```/g, " ")
     .replace(/`[^`]*`/g, " ")
     .replace(/^\s{0,3}#{1,6}\s+/gm, "")
@@ -499,6 +581,34 @@ function Toolbar({
   )
 }
 
+function FrontmatterSummary({ summary }: { summary: MarkdownFrontmatterSummary }) {
+  return (
+    <section
+      aria-label="Frontmatter"
+      className="border-b border-border/60 bg-transparent px-6 py-5"
+      data-testid="markdown-frontmatter-summary"
+    >
+      <div className="rounded-xl border border-[#3a3a3a] bg-[#262626] px-6 py-5 shadow-sm">
+        <h2 className="mb-5 text-base font-medium text-[#c9c9c9]">
+          Metadata
+        </h2>
+        <dl className="grid gap-x-10 gap-y-4 text-sm sm:grid-cols-[minmax(9rem,17rem)_minmax(0,1fr)]">
+          {summary.entries.map((entry, index) => (
+            <div key={`${entry.key}-${index}`} className="contents">
+              <dt className="font-mono text-[#b8b8b8]">
+                {entry.key}
+              </dt>
+              <dd className="min-w-0 whitespace-pre-wrap break-words font-mono text-[#f5f5f5]">
+                {entry.value}
+              </dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  )
+}
+
 export function MarkdownEditor({
   content,
   onChange,
@@ -541,9 +651,13 @@ export function MarkdownEditor({
   const lastEmittedRef = useRef<string>(content)
   const editorRef = useRef<Editor | null>(null)
   const wordCount = useMemo(() => countMarkdownWords(content), [content])
+  const frontmatter = useMemo(() => parseMarkdownFrontmatter(content), [content])
+  const richContent = frontmatter?.body ?? content
 
   // Stable ref so handlePaste (created once in useEditor) always calls the latest version.
   const insertImageRef = useRef<(file: File) => Promise<void>>(async () => {})
+  const frontmatterRef = useRef<MarkdownFrontmatterSummary | null>(frontmatter)
+  frontmatterRef.current = frontmatter
   insertImageRef.current = async (file: File) => {
     userInteractedRef.current = true
     const editor = editorRef.current
@@ -606,10 +720,11 @@ export function MarkdownEditor({
     }
   }
 
-  const editorContent = content
-    ? content
-    : { type: "doc", content: [{ type: "paragraph" }] }
-  const editorContentType = content ? "markdown" : "json"
+  const editorContent = useMemo(
+    () => richContent ? richContent : { type: "doc", content: [{ type: "paragraph" }] },
+    [richContent],
+  )
+  const editorContentType = richContent ? "markdown" : "json"
 
   const editor = useEditor({
     extensions: editorExtensions,
@@ -632,15 +747,14 @@ export function MarkdownEditor({
     },
     onUpdate: ({ editor: e }) => {
       if (suppressChangeRef.current) return
-      const next = e.getMarkdown?.() ?? e.getHTML()
+      const nextBody = e.getMarkdown?.() ?? e.getHTML()
+      const next = serializeMarkdownEditorChange(nextBody, e.isFocused, frontmatterRef.current, userInteractedRef.current)
+      if (next === null) return
       // Remember our own serialized output so the content-sync effect can tell
       // a save round-trip (normalized markdown) apart from a genuine external
       // change, and never re-seeds / re-dirties on what we produced. This is the
       // load-bearing fix for the autosave/conflict storm — see the sync effect.
       lastEmittedRef.current = next
-      // Drop a transient empty emission from an unfocused editor (settling on
-      // init/remount); real edits — typing AND toolbar actions — still flow.
-      if (!isUserEditedChange(next, e.isFocused, userInteractedRef.current)) return
       onChangeRef.current?.(next)
     },
   })
@@ -660,7 +774,7 @@ export function MarkdownEditor({
     // Backstop: if the editor's current serialization already matches, there's
     // nothing to apply.
     const current = editor.getMarkdown?.() ?? editor.getHTML()
-    if (current === content) return
+    if (current === richContent) return
     // Genuine external change (a different document, e.g. an agent write) —
     // apply it and record it as our new baseline so the round-trip of THIS
     // content doesn't re-trigger a re-seed.
@@ -668,7 +782,7 @@ export function MarkdownEditor({
     editor.commands.setContent(editorContent, { contentType: editorContentType })
     suppressChangeRef.current = false
     lastEmittedRef.current = content
-  }, [editor, content])
+  }, [editor, content, editorContent, editorContentType, richContent])
 
   const handleEditorClick = (event: ReactMouseEvent<HTMLDivElement>) => {
     if (!shouldHandleWorkspaceLinkClick(event.nativeEvent)) return
@@ -717,7 +831,10 @@ export function MarkdownEditor({
             onChange={(e) => onChangeRef.current?.(e.target.value)}
           />
         ) : (
-          <EditorContent editor={editor} />
+          <>
+            {frontmatter && <FrontmatterSummary summary={frontmatter} />}
+            <EditorContent editor={editor} />
+          </>
         )}
       </div>
       <div className="border-t border-border/60 px-4 py-2 text-right text-xs text-muted-foreground" data-testid="markdown-word-count">

--- a/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditor.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditor.test.tsx
@@ -1,7 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { UI_COMMAND_EVENT } from "../../../../../front/bridge/uiCommandBus"
-import { MarkdownEditor, sanitizeHtml, isSafeUrl, rawFileUrlForMarkdownImage, workspaceFilePathForMarkdownLink, isUserEditedChange, countMarkdownWords } from "../MarkdownEditor"
+import {
+  MarkdownEditor,
+  sanitizeHtml,
+  isSafeUrl,
+  rawFileUrlForMarkdownImage,
+  workspaceFilePathForMarkdownLink,
+  isUserEditedChange,
+  countMarkdownWords,
+  parseMarkdownFrontmatter,
+  serializeMarkdownEditorChange,
+} from "../MarkdownEditor"
 
 describe("MarkdownEditor", () => {
   beforeEach(() => {
@@ -43,6 +53,74 @@ describe("MarkdownEditor", () => {
 
     it("ignores fenced code blocks and images", () => {
       expect(countMarkdownWords("Intro words\n\n```ts\nconst hidden = true\n```\n\n![Diagram](./diagram.png)")).toBe(2)
+    })
+
+    it("ignores YAML frontmatter", () => {
+      expect(countMarkdownWords("---\ntitle: Hidden words\n---\n# Visible words")).toBe(2)
+    })
+  })
+
+  describe("frontmatter summary", () => {
+    it("parses simple YAML frontmatter entries", () => {
+      expect(
+        parseMarkdownFrontmatter("---\ntitle: Launch Note\ntags:\n  - ui\n  - docs\n---\n# Body"),
+      ).toEqual({
+        block: "---\ntitle: Launch Note\ntags:\n  - ui\n  - docs\n---\n",
+        raw: "title: Launch Note\ntags:\n  - ui\n  - docs",
+        body: "# Body",
+        entries: [
+          { key: "title", value: "Launch Note" },
+          { key: "tags", value: "ui, docs" },
+        ],
+      })
+    })
+
+    it("renders a visual frontmatter summary above the rich editor", async () => {
+      render(
+        <MarkdownEditor
+          content={"---\ntitle: Launch Note\nstatus: draft\n---\n# Body"}
+          readOnly
+        />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTestId("markdown-frontmatter-summary")).toBeInTheDocument()
+      })
+      expect(screen.getByText("Metadata")).toBeInTheDocument()
+      expect(screen.getByText("title")).toBeInTheDocument()
+      expect(screen.getByText("Launch Note")).toBeInTheDocument()
+      expect(screen.getByText("status")).toBeInTheDocument()
+      expect(screen.getByText("draft")).toBeInTheDocument()
+    })
+
+    it("preserves frontmatter when editing the rich body", async () => {
+      const onChange = vi.fn()
+      render(
+        <MarkdownEditor
+          content={"---\ntitle: Launch Note\n---\nBody"}
+          onChange={onChange}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(screen.getByTitle("Horizontal rule")).toBeInTheDocument()
+      })
+      fireEvent.click(screen.getByTitle("Horizontal rule"))
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalled()
+      })
+      const next = onChange.mock.calls.at(-1)?.[0] as string
+      expect(next).toMatch(/^---\ntitle: Launch Note\n---\n/)
+      expect(next).toContain("Body")
+    })
+
+    it("drops transient empty body emissions before reattaching frontmatter", () => {
+      const summary = parseMarkdownFrontmatter("---\ntitle: Launch Note\n---\nBody")
+      expect(serializeMarkdownEditorChange("", false, summary)).toBeNull()
+      expect(serializeMarkdownEditorChange("", true, summary)).toBe(
+        "---\ntitle: Launch Note\n---\n",
+      )
     })
   })
 


### PR DESCRIPTION
Closes #358.\n\nClean replacement for polluted PR #359.\n\n## Summary\n- Parses YAML frontmatter at the top of Markdown files.\n- Renders frontmatter as a single dynamic Metadata panel above the rich Markdown body.\n- Keeps raw mode editing the full file.\n- Preserves the original frontmatter block when editing in rich mode.\n- Excludes frontmatter from the word count.\n\n## Proof\n- ✅ `pnpm --filter @hachej/boring-ui-kit build`\n- ✅ `pnpm --filter @hachej/boring-agent build`\n- ✅ `pnpm --dir packages/workspace exec vitest run src/plugins/filesystemPlugin/front/markdown-editor/__tests__/MarkdownEditor.test.tsx` — 77 tests passed\n- ✅ `pnpm --filter @hachej/boring-workspace build`\n\n## Notes\n- This PR intentionally contains only the Markdown frontmatter implementation, tests, and updated visual baseline.