### PR TITLE
sharepoint-plug: add Office cloud-ref display wiring

### DIFF
--- a/plugins/boring-sharepoint/README.md
+++ b/plugins/boring-sharepoint/README.md
@@ -25,8 +25,8 @@ This workbook will become the operator guide as implementation PRs land.
    - Confirm Microsoft scopes needed by each capability.
    - Confirm tenant/admin consent requirements.
 3. **boring-ui workspace connection**
-   - Open the SharePoint / Microsoft 365 integration entry in the boring-ui MCP/integrations menu.
-   - Connect or verify the workspace Arcade user mapping.
+   - Open the SharePoint app-left action or run `SharePoint: Open settings/status` from the command palette.
+   - Connect or verify the workspace Arcade user mapping once provider status/auth lands.
    - Confirm status: connected / needs auth / pending auth / admin consent required / failed.
 4. **Create test documents**
    - Upload a sample `.xlsx` and `.pptx` to the SharePoint document library.

--- a/plugins/boring-sharepoint/README.md
+++ b/plugins/boring-sharepoint/README.md
@@ -42,45 +42,23 @@ This workbook will become the operator guide as implementation PRs land.
    - Stale `webUrl`: re-resolve by durable `driveId + driveItemId`.
    - Arcade tool failure: inspect stable `SHAREPOINT_*` error code and provider status.
 
-## Existing MCP/integrations menu audit
+## MCP/integrations menu path
 
-PR 1 only audits and documents the current menu integration path; it does not add a new menu registry.
+The workspace already exposes generic plugin chrome surfaces for integration/status UI:
 
-Current documented front plugin surfaces in `definePlugin` are:
+- `commands` for command-palette entries that open panels.
+- `appLeftActions` for app-left management overlays, the same chrome family used by the MCP/Sources management UI.
 
-- `panels`
-- `commands`
-- `leftTabs`
-- `catalogs`
-- `surfaceResolvers`
-- `providers` / `bindings`
-- `toolRenderers`
-
-There is no documented generic `integrations` contribution in `definePlugin` today. The selected path for PR 2 is to add the smallest generic integration-menu contribution surface to the existing MCP/integrations menu, then have this plugin contribute data to that surface:
-
-```ts
-interface WorkspaceIntegrationContribution {
-  id: string
-  pluginId: string
-  label: string
-  description?: string
-  statusEndpoint?: string
-  openCommandId: string
-  capabilities?: string[]
-}
-```
-
-The SharePoint contribution should be data/config only:
+PR 2 uses those existing generic surfaces instead of adding SharePoint-specific branches to workspace chrome:
 
 ```txt
-id: sharepoint
-pluginId: boring-sharepoint
-label: SharePoint / Microsoft 365
-openCommandId: boring-sharepoint.open-settings
-capabilities: office.preview, office.excel.edit, office.powerpoint.edit
+command id: boring-sharepoint.open-settings
+panel id: boring-sharepoint.settings
+app-left action id: boring-sharepoint.settings
+label: SharePoint
 ```
 
-If PR 2 discovers an existing generic integration registry in the MCP menu, use that instead and document the files/API in the PR. It must not hard-code SharePoint-specific branches in workspace chrome.
+The app-left action opens the placeholder SharePoint / Microsoft 365 status overlay. The command opens the same status placeholder as a center panel. A future PR can replace the placeholder body with provider status and authorization controls without changing the menu path.
 
 ## Package surfaces
 
@@ -90,10 +68,14 @@ If PR 2 discovers an existing generic integration registry in the MCP menu, use 
 
 ## Current scope
 
-This PR is shell + contracts only:
+This PR adds front-only display wiring on top of the shell + contracts:
 
+- surface resolver for `*.xlsx.cloud.json` and `*.pptx.cloud.json`
+- virtual display metadata for Office cloud-ref paths
+- placeholder Office preview panel with an **Open in SharePoint** action when a safe `webUrl` is available
+- placeholder SharePoint / Microsoft 365 settings/status panel and app-left overlay
 - no Arcade SDK dependency
 - no Microsoft Graph calls
 - no external network calls
-- no preview panel behavior beyond future contracts
-- no integration menu registry changes
+- no iframe preview/edit/provider behavior
+- no SharePoint-specific workspace chrome branches

--- a/plugins/boring-sharepoint/src/__tests__/frontPlugin.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/frontPlugin.test.ts
@@ -1,0 +1,87 @@
+import { WORKSPACE_OPEN_PATH_SURFACE_KIND, captureFrontPlugin } from "@hachej/boring-workspace/plugin"
+import { describe, expect, it } from "vitest"
+import sharePointPlugin from "../front"
+import {
+  BORING_SHAREPOINT_APP_LEFT_ACTION_ID,
+  BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
+  BORING_SHAREPOINT_SETTINGS_COMMAND_ID,
+  BORING_SHAREPOINT_SETTINGS_PANEL_ID,
+  EXCEL_MIME_TYPE,
+  POWERPOINT_CLOUD_REF_SUFFIX,
+  officeCloudRefDisplayMetadataForPath,
+  type SharePointDocumentRef,
+} from "../shared"
+
+const excelRef: SharePointDocumentRef = {
+  kind: "office-cloud-document",
+  provider: "sharepoint",
+  version: 1,
+  name: "forecast.xlsx",
+  officeKind: "excel",
+  mimeType: EXCEL_MIME_TYPE,
+  webUrl: "https://tenant.sharepoint.com/sites/team/Shared%20Documents/forecast.xlsx",
+  siteId: "tenant.sharepoint.com,site-id,web-id",
+  driveId: "drive-id",
+  driveItemId: "item-id",
+}
+
+describe("SharePoint front plugin", () => {
+  it("registers Office preview, settings command, app-left settings, and path resolver", () => {
+    const captured = captureFrontPlugin(sharePointPlugin)
+
+    expect(captured.registrations.panels.map((panel) => panel.id)).toEqual([
+      BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
+      BORING_SHAREPOINT_SETTINGS_PANEL_ID,
+    ])
+    expect(captured.registrations.panelCommands).toEqual([
+      expect.objectContaining({
+        id: BORING_SHAREPOINT_SETTINGS_COMMAND_ID,
+        panelId: BORING_SHAREPOINT_SETTINGS_PANEL_ID,
+      }),
+    ])
+    expect(captured.registrations.appLeftActions).toEqual([
+      expect.objectContaining({ id: BORING_SHAREPOINT_APP_LEFT_ACTION_ID, label: "SharePoint" }),
+    ])
+    expect(captured.registrations.surfaceResolvers).toEqual([
+      expect.objectContaining({ kind: WORKSPACE_OPEN_PATH_SURFACE_KIND }),
+    ])
+  })
+
+  it("resolves xlsx and pptx cloud-ref paths to the Office preview panel", () => {
+    const [resolver] = captureFrontPlugin(sharePointPlugin).registrations.surfaceResolvers
+
+    expect(resolver.resolve({ kind: WORKSPACE_OPEN_PATH_SURFACE_KIND, target: "reports/forecast.xlsx.cloud.json", meta: { sharePointRef: excelRef } })).toEqual({
+      component: BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
+      id: "boring-sharepoint:reports/forecast.xlsx.cloud.json",
+      title: "forecast.xlsx",
+      params: {
+        path: "reports/forecast.xlsx.cloud.json",
+        officeKind: "excel",
+        displayName: "forecast.xlsx",
+        webUrl: excelRef.webUrl,
+      },
+      score: 100,
+    })
+
+    expect(resolver.resolve({ kind: WORKSPACE_OPEN_PATH_SURFACE_KIND, target: `slides/roadmap${POWERPOINT_CLOUD_REF_SUFFIX}` })).toMatchObject({
+      component: BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
+      title: "roadmap.pptx",
+      params: {
+        path: `slides/roadmap${POWERPOINT_CLOUD_REF_SUFFIX}`,
+        officeKind: "powerpoint",
+        displayName: "roadmap.pptx",
+      },
+    })
+    expect(resolver.resolve({ kind: WORKSPACE_OPEN_PATH_SURFACE_KIND, target: "notes.md" })).toBeUndefined()
+  })
+
+  it("derives virtual display metadata without reading provider state", () => {
+    expect(officeCloudRefDisplayMetadataForPath("nested/report.xlsx.cloud.json")).toEqual({
+      cloudRefPath: "nested/report.xlsx.cloud.json",
+      officeKind: "excel",
+      displayName: "report.xlsx",
+      title: "report.xlsx",
+    })
+    expect(officeCloudRefDisplayMetadataForPath("notes.md")).toBeNull()
+  })
+})

--- a/plugins/boring-sharepoint/src/front/index.ts
+++ b/plugins/boring-sharepoint/src/front/index.ts
@@ -1,15 +1,58 @@
 import { definePlugin } from "@hachej/boring-workspace/plugin"
 import {
+  BORING_SHAREPOINT_APP_LEFT_ACTION_ID,
+  BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
   BORING_SHAREPOINT_PLUGIN_ID,
   BORING_SHAREPOINT_PLUGIN_LABEL,
+  BORING_SHAREPOINT_SETTINGS_COMMAND_ID,
+  BORING_SHAREPOINT_SETTINGS_PANEL_ID,
 } from "../shared"
+import { OfficePreviewPanel, SharePointSettingsOverlay, SharePointSettingsPanel } from "./panels"
+import { sharePointOfficeCloudRefSurfaceResolver } from "./surfaceResolver"
 
 export default definePlugin({
   id: BORING_SHAREPOINT_PLUGIN_ID,
   label: BORING_SHAREPOINT_PLUGIN_LABEL,
+  panels: [
+    {
+      id: BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
+      label: "Office preview",
+      component: OfficePreviewPanel,
+      placement: "center",
+    },
+    {
+      id: BORING_SHAREPOINT_SETTINGS_PANEL_ID,
+      label: "SharePoint settings",
+      component: SharePointSettingsPanel,
+      placement: "center",
+    },
+  ],
+  commands: [
+    {
+      id: BORING_SHAREPOINT_SETTINGS_COMMAND_ID,
+      title: "SharePoint: Open settings/status",
+      panelId: BORING_SHAREPOINT_SETTINGS_PANEL_ID,
+      keywords: ["sharepoint", "microsoft 365", "office", "integration", "settings", "status"],
+    },
+  ],
+  appLeftActions: [
+    {
+      id: BORING_SHAREPOINT_APP_LEFT_ACTION_ID,
+      label: "SharePoint",
+      overlay: SharePointSettingsOverlay,
+      order: 60,
+    },
+  ],
+  surfaceResolvers: [sharePointOfficeCloudRefSurfaceResolver],
 })
 
+export { OfficePreviewPanel, SharePointSettingsOverlay, SharePointSettingsPanel } from "./panels"
+export { sharePointOfficeCloudRefSurfaceResolver } from "./surfaceResolver"
 export {
+  BORING_SHAREPOINT_APP_LEFT_ACTION_ID,
+  BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
   BORING_SHAREPOINT_PLUGIN_ID,
   BORING_SHAREPOINT_PLUGIN_LABEL,
+  BORING_SHAREPOINT_SETTINGS_COMMAND_ID,
+  BORING_SHAREPOINT_SETTINGS_PANEL_ID,
 } from "../shared"

--- a/plugins/boring-sharepoint/src/front/panels.tsx
+++ b/plugins/boring-sharepoint/src/front/panels.tsx
@@ -1,0 +1,92 @@
+import type { BoringFrontAppLeftOverlayProps, PaneProps } from "@hachej/boring-workspace/plugin"
+import type { OfficeDocumentSubtype } from "../shared"
+
+export interface OfficePreviewPanelParams {
+  path: string
+  officeKind: OfficeDocumentSubtype
+  displayName: string
+  webUrl?: string
+}
+
+export function OfficePreviewPanel({ params }: PaneProps<OfficePreviewPanelParams>) {
+  const webUrl = safeHttpsUrl(params?.webUrl)
+  const displayName = params?.displayName ?? "Office document"
+  const officeKind = params?.officeKind === "powerpoint" ? "PowerPoint" : "Excel"
+
+  return (
+    <section className="flex h-full min-h-0 flex-col bg-background p-4 text-sm text-foreground" data-boring-sharepoint-panel="office-preview">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">SharePoint / Microsoft 365</p>
+          <h2 className="truncate text-lg font-semibold">{displayName}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{officeKind} cloud reference</p>
+        </div>
+        {webUrl ? (
+          <a
+            className="inline-flex shrink-0 items-center rounded-md border border-border px-3 py-1.5 text-sm font-medium text-foreground hover:bg-muted"
+            href={webUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Open in SharePoint
+          </a>
+        ) : (
+          <button
+            type="button"
+            className="inline-flex shrink-0 cursor-not-allowed items-center rounded-md border border-border px-3 py-1.5 text-sm font-medium text-muted-foreground opacity-70"
+            disabled
+          >
+            Open in SharePoint
+          </button>
+        )}
+      </div>
+      <div className="rounded-lg border border-dashed border-border bg-muted/20 p-4 text-muted-foreground">
+        Office preview is not wired yet. A later SharePoint plugin PR will request a transient Microsoft preview URL on demand and render it here.
+      </div>
+    </section>
+  )
+}
+
+export function SharePointSettingsPanel() {
+  return (
+    <section className="flex h-full min-h-0 flex-col bg-background p-4 text-sm text-foreground" data-boring-sharepoint-panel="settings">
+      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Integration status</p>
+      <h2 className="mt-1 text-lg font-semibold">SharePoint / Microsoft 365</h2>
+      <div className="mt-4 rounded-lg border border-dashed border-border bg-muted/20 p-4 text-muted-foreground">
+        Connection status, authorization, and Arcade-backed provider checks will appear here in a later PR.
+      </div>
+    </section>
+  )
+}
+
+export function SharePointSettingsOverlay({ onClose }: BoringFrontAppLeftOverlayProps) {
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background" data-boring-sharepoint-overlay="settings">
+      <header className="flex h-12 shrink-0 items-center justify-between border-b border-border/60 px-4">
+        <div className="min-w-0">
+          <h2 className="truncate text-sm font-semibold tracking-tight text-foreground">SharePoint / Microsoft 365</h2>
+          <p className="truncate text-xs text-muted-foreground">Connection status and setup</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close SharePoint settings"
+          className="inline-flex size-6 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          ×
+        </button>
+      </header>
+      <SharePointSettingsPanel />
+    </div>
+  )
+}
+
+function safeHttpsUrl(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  try {
+    const parsed = new URL(value)
+    return parsed.protocol === "https:" ? parsed.toString() : undefined
+  } catch {
+    return undefined
+  }
+}

--- a/plugins/boring-sharepoint/src/front/surfaceResolver.ts
+++ b/plugins/boring-sharepoint/src/front/surfaceResolver.ts
@@ -1,0 +1,42 @@
+import { WORKSPACE_OPEN_PATH_SURFACE_KIND, type BoringFrontSurfaceResolverRegistration } from "@hachej/boring-workspace/plugin"
+import {
+  BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
+  EXCEL_CLOUD_REF_SUFFIX,
+  POWERPOINT_CLOUD_REF_SUFFIX,
+  isSharePointDocumentRef,
+  officeCloudRefDisplayMetadataForPath,
+} from "../shared"
+import type { OfficePreviewPanelParams } from "./panels"
+
+export const sharePointOfficeCloudRefSurfaceResolver: BoringFrontSurfaceResolverRegistration = {
+  id: "boring-sharepoint.office-cloud-ref",
+  kind: WORKSPACE_OPEN_PATH_SURFACE_KIND,
+  title: "SharePoint Office cloud reference",
+  description: "Opens SharePoint-backed Excel and PowerPoint cloud reference files in the SharePoint preview panel.",
+  targetHint: `*${EXCEL_CLOUD_REF_SUFFIX} or *${POWERPOINT_CLOUD_REF_SUFFIX}`,
+  examples: [
+    { target: `reports/forecast${EXCEL_CLOUD_REF_SUFFIX}`, label: "Excel cloud ref" },
+    { target: `decks/roadmap${POWERPOINT_CLOUD_REF_SUFFIX}`, label: "PowerPoint cloud ref" },
+  ],
+  resolve(request) {
+    const metadata = officeCloudRefDisplayMetadataForPath(request.target)
+    if (!metadata) return undefined
+
+    const params: OfficePreviewPanelParams = {
+      path: metadata.cloudRefPath,
+      officeKind: metadata.officeKind,
+      displayName: metadata.displayName,
+    }
+
+    const ref = request.meta?.sharePointRef
+    if (isSharePointDocumentRef(ref)) params.webUrl = ref.webUrl
+
+    return {
+      component: BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
+      id: `boring-sharepoint:${metadata.cloudRefPath}`,
+      title: metadata.title,
+      params: params as unknown as Record<string, unknown>,
+      score: 100,
+    }
+  },
+}

--- a/plugins/boring-sharepoint/src/shared/constants.ts
+++ b/plugins/boring-sharepoint/src/shared/constants.ts
@@ -1,5 +1,9 @@
 export const BORING_SHAREPOINT_PLUGIN_ID = "boring-sharepoint"
 export const BORING_SHAREPOINT_PLUGIN_LABEL = "SharePoint"
+export const BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID = "boring-sharepoint.office-preview"
+export const BORING_SHAREPOINT_SETTINGS_PANEL_ID = "boring-sharepoint.settings"
+export const BORING_SHAREPOINT_SETTINGS_COMMAND_ID = "boring-sharepoint.open-settings"
+export const BORING_SHAREPOINT_APP_LEFT_ACTION_ID = "boring-sharepoint.settings"
 
 export const OFFICE_CLOUD_DOCUMENT_KIND = "office-cloud-document"
 export const SHAREPOINT_PROVIDER_ID = "sharepoint"

--- a/plugins/boring-sharepoint/src/shared/display.ts
+++ b/plugins/boring-sharepoint/src/shared/display.ts
@@ -1,0 +1,26 @@
+import { EXCEL_CLOUD_REF_SUFFIX, POWERPOINT_CLOUD_REF_SUFFIX } from "./constants"
+import { officeKindForCloudRefPath } from "./ref"
+import type { OfficeDocumentSubtype } from "./types"
+
+export interface OfficeCloudRefDisplayMetadata {
+  cloudRefPath: string
+  officeKind: OfficeDocumentSubtype
+  displayName: string
+  title: string
+}
+
+export function officeCloudRefDisplayMetadataForPath(path: string): OfficeCloudRefDisplayMetadata | null {
+  const officeKind = officeKindForCloudRefPath(path)
+  if (!officeKind) return null
+
+  const suffix = officeKind === "excel" ? EXCEL_CLOUD_REF_SUFFIX : POWERPOINT_CLOUD_REF_SUFFIX
+  const fileName = path.split(/[\\/]/).pop() ?? path
+  const displayName = fileName.endsWith(suffix) ? fileName.slice(0, -".cloud.json".length) : fileName
+
+  return {
+    cloudRefPath: path,
+    officeKind,
+    displayName,
+    title: displayName,
+  }
+}

--- a/plugins/boring-sharepoint/src/shared/index.ts
+++ b/plugins/boring-sharepoint/src/shared/index.ts
@@ -1,6 +1,10 @@
 export {
+  BORING_SHAREPOINT_APP_LEFT_ACTION_ID,
+  BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
   BORING_SHAREPOINT_PLUGIN_ID,
   BORING_SHAREPOINT_PLUGIN_LABEL,
+  BORING_SHAREPOINT_SETTINGS_COMMAND_ID,
+  BORING_SHAREPOINT_SETTINGS_PANEL_ID,
   EXCEL_CLOUD_REF_SUFFIX,
   EXCEL_MIME_TYPE,
   OFFICE_CLOUD_DOCUMENT_KIND,
@@ -8,6 +12,8 @@ export {
   POWERPOINT_MIME_TYPE,
   SHAREPOINT_PROVIDER_ID,
 } from "./constants"
+export { officeCloudRefDisplayMetadataForPath } from "./display"
+export type { OfficeCloudRefDisplayMetadata } from "./display"
 export { SHAREPOINT_ERROR_CODES, SharePointRefValidationError } from "./errors"
 export type { SharePointErrorCode } from "./errors"
 export {


### PR DESCRIPTION
## Summary\n- add SharePoint Office cloud-ref resolver for *.xlsx.cloud.json and *.pptx.cloud.json\n- add placeholder Office preview and SharePoint settings/status surfaces\n- document the existing generic command/app-left MCP integrations path\n\n## Validation\n- pnpm --filter @hachej/boring-sharepoint test\n- pnpm --filter @hachej/boring-sharepoint typecheck\n- pnpm --filter @hachej/boring-sharepoint build