### PR TITLE
sharepoint-plug: add Arcade runtime primitives

### DIFF
--- a/plugins/boring-sharepoint/README.md
+++ b/plugins/boring-sharepoint/README.md
@@ -22,6 +22,11 @@ This workbook will become the operator guide as implementation PRs land.
    - Arcade project configured for the workspace/tenant.
 2. **Arcade backend/provider setup**
    - Connect the SharePoint/Microsoft 365 integration through Arcade.
+   - Configure the server runtime environment:
+     - `BORING_SHAREPOINT_ARCADE_API_KEY` — required Arcade API key; never log this value.
+     - `BORING_SHAREPOINT_ARCADE_DEFAULT_USER_ID` — optional default Arcade user id for local/operator testing.
+     - `BORING_SHAREPOINT_ARCADE_PROVIDER_ID` — optional provider id, defaults to `microsoft`.
+     - `BORING_SHAREPOINT_ARCADE_BASE_URL` — optional Arcade API base URL override.
    - Confirm Microsoft scopes needed by each capability.
    - Confirm tenant/admin consent requirements.
 3. **boring-ui workspace connection**
@@ -68,14 +73,15 @@ The app-left action opens the placeholder SharePoint / Microsoft 365 status over
 
 ## Current scope
 
-This PR adds front-only display wiring on top of the shell + contracts:
+This PR adds server-only Arcade runtime primitives on top of the shell/display stack:
 
-- surface resolver for `*.xlsx.cloud.json` and `*.pptx.cloud.json`
-- virtual display metadata for Office cloud-ref paths
-- placeholder Office preview panel with an **Open in SharePoint** action when a safe `webUrl` is available
-- placeholder SharePoint / Microsoft 365 settings/status panel and app-left overlay
-- no Arcade SDK dependency
+- `ArcadeJsToolRuntime` wraps `@arcadeai/arcadejs` behind server internals.
+- Arcade tool execution uses the SDK shape `{ tool_name, user_id, input }`.
+- Arcade authorization/tool auth responses normalize into shared `IntegrationAuthState` without exporting Arcade SDK types.
+- Arcade config is read from the `BORING_SHAREPOINT_ARCADE_*` environment variables listed above.
+- Redaction helpers keep API keys, bearer tokens, and token query strings out of logs.
+- tests use mocked Arcade clients only.
 - no Microsoft Graph calls
-- no external network calls
-- no iframe preview/edit/provider behavior
+- no external network calls in tests
+- no SharePoint discovery, iframe preview, edit, or provider behavior yet
 - no SharePoint-specific workspace chrome branches

--- a/plugins/boring-sharepoint/package.json
+++ b/plugins/boring-sharepoint/package.json
@@ -57,5 +57,8 @@
     "tsup": "^8.4.0",
     "typescript": "~5.9.3",
     "vitest": "^4.1.9"
+  },
+  "dependencies": {
+    "@arcadeai/arcadejs": "^2.4.1"
   }
 }

--- a/plugins/boring-sharepoint/src/__tests__/arcadeBoundary.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/arcadeBoundary.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync, readdirSync, statSync } from "node:fs"
+import { join, relative } from "node:path"
+import { describe, expect, it } from "vitest"
+
+const packageRoot = new URL("../..", import.meta.url)
+
+describe("Arcade package boundaries", () => {
+  it("keeps Arcade SDK imports out of shared and front source", () => {
+    const forbiddenMatches = listSourceFiles("src")
+      .filter((path) => path.includes("/shared/") || path.includes("/front/"))
+      .flatMap((path) => {
+        const source = readFileSync(path, "utf8")
+        return source.includes("@arcadeai/arcadejs") ? [relative(packageRoot.pathname, path)] : []
+      })
+
+    expect(forbiddenMatches).toEqual([])
+  })
+})
+
+function listSourceFiles(path: string): string[] {
+  const absolutePath = join(packageRoot.pathname, path)
+  const stat = statSync(absolutePath)
+  if (stat.isFile()) return absolutePath.endsWith(".ts") || absolutePath.endsWith(".tsx") ? [absolutePath] : []
+  return readdirSync(absolutePath).flatMap((entry) => listSourceFiles(join(path, entry)))
+}

--- a/plugins/boring-sharepoint/src/__tests__/arcadeRuntime.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/arcadeRuntime.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest"
+import { SHAREPOINT_ERROR_CODES } from "../shared"
+import { normalizeArcadeAuthState, normalizeArcadeToolAuthState } from "../server/authNormalization"
+import {
+  ARCADE_ENV_KEYS,
+  loadArcadeSharePointRuntimeConfig,
+  redactArcadeConfigForLog,
+  redactArcadeSecret,
+  requireArcadeSharePointRuntimeConfig,
+} from "../server/arcadeConfig"
+import { ArcadeJsToolRuntime } from "../server/arcadeRuntime"
+
+describe("ArcadeJsToolRuntime", () => {
+  it("wraps Arcade tool execution with the required Arcade input shape", async () => {
+    const execute = vi.fn().mockResolvedValue({ success: true, output: { value: { ok: true } } })
+    const runtime = new ArcadeJsToolRuntime(
+      { apiKey: "arcade-secret", defaultUserId: "user@example.com", defaultProviderId: "microsoft" },
+      {
+        tools: { execute },
+        auth: {
+          start: vi.fn(),
+          status: vi.fn(),
+        },
+      },
+    )
+
+    await runtime.executeTool({ toolName: "MicrosoftSharepoint_GetSite", input: { site: "https://tenant.sharepoint.com/sites/test" } })
+
+    expect(execute).toHaveBeenCalledWith({
+      tool_name: "MicrosoftSharepoint_GetSite",
+      user_id: "user@example.com",
+      input: { site: "https://tenant.sharepoint.com/sites/test" },
+    })
+  })
+
+  it("starts provider authorization with configured user/provider defaults", async () => {
+    const start = vi.fn().mockResolvedValue({ status: "pending", url: "https://arcade.dev/auth" })
+    const runtime = new ArcadeJsToolRuntime(
+      { apiKey: "arcade-secret", defaultUserId: "user@example.com", defaultProviderId: "microsoft" },
+      {
+        tools: { execute: vi.fn() },
+        auth: { start, status: vi.fn() },
+      },
+    )
+
+    await runtime.startAuthorization({ scopes: ["Sites.Read.All"] })
+
+    expect(start).toHaveBeenCalledWith("user@example.com", "microsoft", { scopes: ["Sites.Read.All"] })
+  })
+})
+
+describe("Arcade auth/status normalization", () => {
+  it("maps connected, needs-auth, and pending Arcade authorization states", () => {
+    expect(normalizeArcadeAuthState({ status: "completed" })).toEqual({ status: "connected" })
+    expect(normalizeArcadeAuthState({ status: "not_started", url: "https://arcade.dev/authorize" })).toEqual({
+      status: "needs_auth",
+      authorizationUrl: "https://arcade.dev/authorize",
+    })
+    expect(normalizeArcadeAuthState({ status: "pending", url: "https://arcade.dev/authorize" })).toEqual({
+      status: "pending_auth",
+      authorizationUrl: "https://arcade.dev/authorize",
+    })
+  })
+
+  it("maps admin-consent and failed Arcade authorization states", () => {
+    expect(normalizeArcadeAuthState({ status: "failed", message: "tenant admin consent required" })).toEqual({
+      status: "admin_consent_required",
+      message: "tenant admin consent required",
+    })
+    expect(normalizeArcadeAuthState({ status: "failed", error: { message: "provider unavailable" } })).toEqual({
+      status: "failed",
+      code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE,
+      message: "provider unavailable",
+    })
+  })
+
+  it("normalizes authorization nested in tool execution responses", () => {
+    expect(
+      normalizeArcadeToolAuthState({ output: { authorization: { status: "not_started", url: "https://arcade.dev/auth" } } }),
+    ).toEqual({ status: "needs_auth", authorizationUrl: "https://arcade.dev/auth" })
+    expect(normalizeArcadeToolAuthState({ success: true, output: { value: { ok: true } } })).toEqual({ status: "connected" })
+    expect(normalizeArcadeToolAuthState({ success: false, output: { error: { message: "tool failed" } } })).toEqual({
+      status: "failed",
+      code: SHAREPOINT_ERROR_CODES.PROVIDER_TOOL_FAILED,
+      message: "tool failed",
+    })
+  })
+})
+
+describe("Arcade runtime config and redaction", () => {
+  it("loads placeholder env/config names without logging secrets", () => {
+    const config = loadArcadeSharePointRuntimeConfig({
+      [ARCADE_ENV_KEYS.apiKey]: "sk-test-secret",
+      [ARCADE_ENV_KEYS.defaultUserId]: "user@example.com",
+      [ARCADE_ENV_KEYS.defaultProviderId]: "microsoft",
+      [ARCADE_ENV_KEYS.baseUrl]: "https://api.arcade.dev",
+    })
+
+    expect(config).toEqual({
+      apiKey: "sk-test-secret",
+      defaultUserId: "user@example.com",
+      defaultProviderId: "microsoft",
+      baseUrl: "https://api.arcade.dev",
+    })
+    expect(requireArcadeSharePointRuntimeConfig(config)).toEqual(config)
+    expect(redactArcadeSecret(config.apiKey)).toBe("sk-t…cret")
+  })
+
+  it("redacts API keys, bearer tokens, and token query strings recursively", () => {
+    expect(
+      redactArcadeConfigForLog({
+        apiKey: "sk-test-secret",
+        nested: {
+          authorization: "Bearer abc.def.ghi",
+          url: "https://example.test/callback?access_token=secret-token",
+          safe: "microsoft",
+        },
+      }),
+    ).toEqual({
+      apiKey: "[REDACTED]",
+      nested: {
+        authorization: "[REDACTED]",
+        url: "[REDACTED]",
+        safe: "microsoft",
+      },
+    })
+  })
+
+  it("fails fast when the Arcade API key placeholder is missing", () => {
+    expect(() => requireArcadeSharePointRuntimeConfig({ defaultProviderId: "microsoft" })).toThrow(
+      `${ARCADE_ENV_KEYS.apiKey} is required`,
+    )
+  })
+})

--- a/plugins/boring-sharepoint/src/server/arcadeConfig.ts
+++ b/plugins/boring-sharepoint/src/server/arcadeConfig.ts
@@ -1,0 +1,77 @@
+export interface ArcadeSharePointRuntimeConfig {
+  apiKey: string
+  defaultUserId?: string
+  defaultProviderId: string
+  baseUrl?: string
+}
+
+export interface ArcadeSharePointRuntimeConfigInput {
+  apiKey?: string
+  defaultUserId?: string
+  defaultProviderId?: string
+  baseUrl?: string
+}
+
+export const ARCADE_ENV_KEYS = {
+  apiKey: "BORING_SHAREPOINT_ARCADE_API_KEY",
+  defaultUserId: "BORING_SHAREPOINT_ARCADE_DEFAULT_USER_ID",
+  defaultProviderId: "BORING_SHAREPOINT_ARCADE_PROVIDER_ID",
+  baseUrl: "BORING_SHAREPOINT_ARCADE_BASE_URL",
+} as const
+
+const DEFAULT_PROVIDER_ID = "microsoft"
+const SECRET_KEY_PATTERN = /(api[_-]?key|access[_-]?token|refresh[_-]?token|authorization|cookie|secret)/i
+const SECRET_VALUE_PATTERN = /Bearer\s+[A-Za-z0-9._~+/-]+=*|([?&#](access_token|refresh_token|id_token|authorization|cookie)=)[^\s&]+/i
+
+export function loadArcadeSharePointRuntimeConfig(env: NodeJS.ProcessEnv = process.env): ArcadeSharePointRuntimeConfigInput {
+  return {
+    apiKey: readOptionalEnv(env, ARCADE_ENV_KEYS.apiKey),
+    defaultUserId: readOptionalEnv(env, ARCADE_ENV_KEYS.defaultUserId),
+    defaultProviderId: readOptionalEnv(env, ARCADE_ENV_KEYS.defaultProviderId) ?? DEFAULT_PROVIDER_ID,
+    baseUrl: readOptionalEnv(env, ARCADE_ENV_KEYS.baseUrl),
+  }
+}
+
+export function requireArcadeSharePointRuntimeConfig(
+  input: ArcadeSharePointRuntimeConfigInput = loadArcadeSharePointRuntimeConfig(),
+): ArcadeSharePointRuntimeConfig {
+  if (!input.apiKey) {
+    throw new Error(`${ARCADE_ENV_KEYS.apiKey} is required to initialize SharePoint Arcade runtime`)
+  }
+
+  return {
+    apiKey: input.apiKey,
+    defaultUserId: input.defaultUserId,
+    defaultProviderId: input.defaultProviderId ?? DEFAULT_PROVIDER_ID,
+    baseUrl: input.baseUrl,
+  }
+}
+
+export function redactArcadeSecret(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined
+  if (value.length <= 8) return "[REDACTED]"
+  return `${value.slice(0, 4)}…${value.slice(-4)}`
+}
+
+export function redactArcadeConfigForLog(value: unknown): unknown {
+  return redactUnknown(value)
+}
+
+function redactUnknown(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((entry) => redactUnknown(entry))
+  if (typeof value === "string") return SECRET_VALUE_PATTERN.test(value) ? "[REDACTED]" : value
+  if (!value || typeof value !== "object") return value
+
+  const redacted: Record<string, unknown> = {}
+  for (const [key, nested] of Object.entries(value)) {
+    redacted[key] = SECRET_KEY_PATTERN.test(key) ? "[REDACTED]" : redactUnknown(nested)
+  }
+  return redacted
+}
+
+function readOptionalEnv(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const value = env[key]
+  if (value === undefined) return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}

--- a/plugins/boring-sharepoint/src/server/arcadeRuntime.ts
+++ b/plugins/boring-sharepoint/src/server/arcadeRuntime.ts
@@ -1,0 +1,77 @@
+import Arcade from "@arcadeai/arcadejs"
+import type { ArcadeSharePointRuntimeConfig } from "./arcadeConfig"
+
+export interface ArcadeToolExecuteInput {
+  toolName: string
+  userId?: string
+  input?: Record<string, unknown>
+}
+
+export interface ArcadeAuthorizationInput {
+  userId?: string
+  providerId?: string
+  scopes?: string[]
+}
+
+export interface ArcadeAuthorizationStatusInput {
+  authorizationId: string
+}
+
+interface ArcadeClientLike {
+  tools: {
+    execute(body: {
+      tool_name: string
+      user_id?: string
+      input?: Record<string, unknown>
+    }): Promise<unknown>
+  }
+  auth: {
+    start(userId: string, provider: string, options?: { scopes?: string[] }): Promise<unknown>
+    status(query: { id: string }): Promise<unknown>
+  }
+}
+
+export class ArcadeJsToolRuntime {
+  private readonly client: ArcadeClientLike
+  private readonly config: ArcadeSharePointRuntimeConfig
+
+  constructor(config: ArcadeSharePointRuntimeConfig, client: ArcadeClientLike = createArcadeClient(config)) {
+    this.config = config
+    this.client = client
+  }
+
+  executeTool(request: ArcadeToolExecuteInput): Promise<unknown> {
+    return this.client.tools.execute({
+      tool_name: request.toolName,
+      user_id: this.resolveUserId(request.userId),
+      input: request.input,
+    })
+  }
+
+  startAuthorization(request: ArcadeAuthorizationInput = {}): Promise<unknown> {
+    return this.client.auth.start(
+      this.resolveUserId(request.userId),
+      request.providerId ?? this.config.defaultProviderId,
+      { scopes: request.scopes ?? [] },
+    )
+  }
+
+  getAuthorizationStatus(request: ArcadeAuthorizationStatusInput): Promise<unknown> {
+    return this.client.auth.status({ id: request.authorizationId })
+  }
+
+  private resolveUserId(userId?: string): string {
+    const resolved = userId ?? this.config.defaultUserId
+    if (!resolved) {
+      throw new Error("Arcade user id is required for SharePoint Arcade runtime calls")
+    }
+    return resolved
+  }
+}
+
+function createArcadeClient(config: ArcadeSharePointRuntimeConfig): ArcadeClientLike {
+  return new Arcade({
+    apiKey: config.apiKey,
+    baseURL: config.baseUrl,
+  })
+}

--- a/plugins/boring-sharepoint/src/server/authNormalization.ts
+++ b/plugins/boring-sharepoint/src/server/authNormalization.ts
@@ -1,0 +1,77 @@
+import { SHAREPOINT_ERROR_CODES, type IntegrationAuthState } from "../shared"
+
+type ArcadeAuthStatus = "not_started" | "pending" | "completed" | "failed"
+
+interface ArcadeAuthorizationLike {
+  status?: ArcadeAuthStatus | string
+  url?: string
+  error?: { message?: string; name?: string }
+  message?: string
+}
+
+interface ArcadeExecuteResponseLike {
+  success?: boolean
+  output?: {
+    authorization?: ArcadeAuthorizationLike
+    error?: { message?: string; kind?: string }
+  }
+}
+
+export function normalizeArcadeAuthState(response: unknown): IntegrationAuthState {
+  if (!isObject(response)) {
+    return failedState("Arcade authorization response was not an object")
+  }
+
+  const auth = response as ArcadeAuthorizationLike
+  switch (auth.status) {
+    case "completed":
+      return { status: "connected" }
+    case "not_started":
+      if (isNonEmptyString(auth.url)) return { status: "needs_auth", authorizationUrl: auth.url }
+      return { status: "failed", code: SHAREPOINT_ERROR_CODES.AUTH_REQUIRED, message: "SharePoint authorization has not started" }
+    case "pending":
+      return isNonEmptyString(auth.url)
+        ? { status: "pending_auth", authorizationUrl: auth.url }
+        : { status: "pending_auth" }
+    case "failed": {
+      const message = extractAuthMessage(auth) ?? "SharePoint authorization failed"
+      if (looksLikeAdminConsentRequired(message)) {
+        return { status: "admin_consent_required", message }
+      }
+      return { status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message }
+    }
+    default:
+      return failedState(`Unsupported Arcade authorization status: ${String(auth.status ?? "missing")}`)
+  }
+}
+
+export function normalizeArcadeToolAuthState(response: unknown): IntegrationAuthState {
+  if (!isObject(response)) return failedState("Arcade tool response was not an object")
+  const toolResponse = response as ArcadeExecuteResponseLike
+  if (toolResponse.output?.authorization) return normalizeArcadeAuthState(toolResponse.output.authorization)
+  if (toolResponse.success === true) return { status: "connected" }
+
+  const message = toolResponse.output?.error?.message ?? "Arcade tool response did not include authorization state"
+  if (looksLikeAdminConsentRequired(message)) return { status: "admin_consent_required", message }
+  return { status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_TOOL_FAILED, message }
+}
+
+function failedState(message: string): IntegrationAuthState {
+  return { status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message }
+}
+
+function extractAuthMessage(auth: ArcadeAuthorizationLike): string | undefined {
+  return auth.error?.message ?? auth.message
+}
+
+function looksLikeAdminConsentRequired(message: string): boolean {
+  return /admin(?:istrator)? consent|tenant admin|consent_required|AADSTS65001|AADSTS90094/i.test(message)
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0
+}

--- a/plugins/boring-sharepoint/src/server/index.ts
+++ b/plugins/boring-sharepoint/src/server/index.ts
@@ -15,3 +15,22 @@ export {
   BORING_SHAREPOINT_PLUGIN_ID,
   BORING_SHAREPOINT_PLUGIN_LABEL,
 } from "../shared"
+export {
+  ARCADE_ENV_KEYS,
+  loadArcadeSharePointRuntimeConfig,
+  redactArcadeConfigForLog,
+  redactArcadeSecret,
+  requireArcadeSharePointRuntimeConfig,
+  type ArcadeSharePointRuntimeConfig,
+  type ArcadeSharePointRuntimeConfigInput,
+} from "./arcadeConfig"
+export {
+  normalizeArcadeAuthState,
+  normalizeArcadeToolAuthState,
+} from "./authNormalization"
+export {
+  ArcadeJsToolRuntime,
+  type ArcadeAuthorizationInput,
+  type ArcadeAuthorizationStatusInput,
+  type ArcadeToolExecuteInput,
+} from "./arcadeRuntime"

--- a/plugins/boring-sharepoint/tsup.config.ts
+++ b/plugins/boring-sharepoint/tsup.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
   platform: "neutral",
   external: [
     /^@hachej\/boring-/,
+    "@arcadeai/arcadejs",
     "fastify",
     "react",
     "react-dom",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1126,6 +1126,10 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0))
 
   plugins/boring-sharepoint:
+    dependencies:
+      '@arcadeai/arcadejs':
+        specifier: ^2.4.1
+        version: 2.4.1
     devDependencies:
       '@hachej/boring-workspace':
         specifier: workspace:*
@@ -1150,7 +1154,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0))
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0))
 
   plugins/ccusage-dashboard:
     dependencies:
@@ -1438,6 +1442,10 @@ packages:
 
   '@antithesishq/bombadil@0.6.1':
     resolution: {integrity: sha512-d1iufG3MI7gSMSiSmMeNdcMW+qR0yQXL2zdkVynC3n3DYgFJYlYXKUQzygmqU12m4RWlR5iOdQU1hsx5UT6+IA==}
+    hasBin: true
+
+  '@arcadeai/arcadejs@2.4.1':
+    resolution: {integrity: sha512-DLpvvDBvRNjzVmFYJ+upPrUJ8YRBoGWqPfzhuFp2+lh5Shxm0l9qLwe1Ah4pKvuCatU7TLOOTkFpICitTuuJeQ==}
     hasBin: true
 
   '@asamuzakjp/css-color@5.1.11':
@@ -8993,6 +9001,8 @@ snapshots:
 
   '@antithesishq/bombadil@0.6.1': {}
 
+  '@arcadeai/arcadejs@2.4.1': {}
+
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
@@ -12782,6 +12792,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.9(vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0))':
     dependencies:
@@ -16888,6 +16906,21 @@ snapshots:
       tsx: 4.22.5
       yaml: 2.9.0
 
+  vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.0
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.22.5
+      yaml: 2.9.0
+
   vite@8.1.3(@types/node@22.20.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -16924,6 +16957,35 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 6.4.3(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.5)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.20.0
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.3.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@22.20.0)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.22.5)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## Summary

PR 3 of the SharePoint Office plugin stack. Adds server-only Arcade JS runtime/config/auth-normalization primitives without implementing SharePoint discovery, preview, or edit flows.

## Changes

- adds @arcadeai/arcadejs as a SharePoint plugin dependency
- adds server-only ArcadeJsToolRuntime wrapper for tool execution and auth primitives
- adds BORING_SHAREPOINT_ARCADE_* env/config loading and redaction helpers
- maps Arcade authorization/tool auth responses into IntegrationAuthState
- adds mocked tests for execute shape, auth normalization, redaction, and import boundaries
- updates setup workbook docs with PR3 env/config scope

## Validation

- pnpm --filter @hachej/boring-sharepoint test
- pnpm --filter @hachej/boring-sharepoint typecheck
- pnpm --filter @hachej/boring-sharepoint build

## Scope limits

No Graph calls, no real Arcade network calls in tests, no SharePoint discovery, no iframe preview, no edit/provider implementation, and no core/workspace API changes.