### PR TITLE
sharepoint-plug: add read-only discovery status

### DIFF
--- a/plugins/boring-sharepoint/README.md
+++ b/plugins/boring-sharepoint/README.md
@@ -31,10 +31,11 @@ This workbook will become the operator guide as implementation PRs land.
    - Confirm tenant/admin consent requirements.
 3. **boring-ui workspace connection**
    - Open the SharePoint app-left action or run `SharePoint: Open settings/status` from the command palette.
-   - Connect or verify the workspace Arcade user mapping once provider status/auth lands.
-   - Confirm status: connected / needs auth / pending auth / admin consent required / failed.
+   - Connect or verify the workspace Arcade user mapping.
+   - Confirm status from the plugin-owned `GET /api/sharepoint/status` route: connected / needs auth / pending auth / admin consent required / failed.
 4. **Create test documents**
    - Upload a sample `.xlsx` and `.pptx` to the SharePoint document library.
+   - Use `POST /api/sharepoint/resolve` with either `webUrl` or `driveId + driveItemId` to resolve canonical ref metadata.
    - Capture their SharePoint identity as `siteId`, `driveId`, and `driveItemId`.
 5. **Validate V1 flows**
    - Open in SharePoint using `webUrl`.
@@ -73,15 +74,23 @@ The app-left action opens the placeholder SharePoint / Microsoft 365 status over
 
 ## Current scope
 
-This PR adds server-only Arcade runtime primitives on top of the shell/display stack:
+This PR adds read-only SharePoint discovery/status on top of the shell/display/runtime stack:
 
-- `ArcadeJsToolRuntime` wraps `@arcadeai/arcadejs` behind server internals.
-- Arcade tool execution uses the SDK shape `{ tool_name, user_id, input }`.
-- Arcade authorization/tool auth responses normalize into shared `IntegrationAuthState` without exporting Arcade SDK types.
-- Arcade config is read from the `BORING_SHAREPOINT_ARCADE_*` environment variables listed above.
-- Redaction helpers keep API keys, bearer tokens, and token query strings out of logs.
-- tests use mocked Arcade clients only.
-- no Microsoft Graph calls
-- no external network calls in tests
-- no SharePoint discovery, iframe preview, edit, or provider behavior yet
+- `ArcadeSharePointProvider` keeps Arcade tool names and snake_case inputs inside server/provider internals.
+- Status uses the read-only status probe tool `MicrosoftSharepoint_ListSites` through `ArcadeJsToolRuntime` and normalizes responses to `IntegrationAuthState`.
+- Authorization uses Arcade auth start with read-only scopes `Sites.Read.All` and `Files.Read.All`.
+- Discovery resolves SharePoint Office documents with mocked/read-only Arcade tool calls:
+  - `MicrosoftSharepoint_GetSite` with `{ site }` when a site URL is provided.
+  - `MicrosoftSharepoint_GetDriveItemByUrl` with `{ web_url }` when an Office web URL is provided.
+  - `MicrosoftSharepoint_GetDriveItem` with `{ drive_id, item_id }` when durable IDs are provided.
+- Plugin-owned routes:
+  - `GET /api/sharepoint/status` returns `{ status }` only.
+  - `POST /api/sharepoint/resolve` accepts `{ siteUrl?, webUrl?, driveId?, driveItemId? }` and returns `{ ref }` canonical metadata only.
+- The settings/status panel queries `GET /api/sharepoint/status` via a relative route and displays a compact status summary.
+- Ref mapping accepts only `.xlsx` Excel and `.pptx` PowerPoint files; unsupported Office/file types fail with stable `SHAREPOINT_INVALID_REF` errors.
+- Tests use mocked Arcade/provider calls only.
+- no Microsoft Graph direct calls
+- no preview iframe or `driveItem:preview`
+- no Office edit calls
+- no local import/upload
 - no SharePoint-specific workspace chrome branches

--- a/plugins/boring-sharepoint/README.md
+++ b/plugins/boring-sharepoint/README.md
@@ -2,7 +2,7 @@
 
 App/internal plugin shell for SharePoint / Microsoft 365 Office document support in boring-ui.
 
-This package is intentionally a trusted app/internal plugin, not a runtime-generated `.pi/extensions` plugin. Future PRs will add SharePoint discovery, preview, Office agent edits, and import flows behind the contracts introduced in this shell.
+This package is intentionally a trusted app/internal plugin, not a runtime-generated `.pi/extensions` plugin. The current stack includes the plugin shell, Office cloud-ref display wiring, Arcade runtime primitives, and read-only SharePoint discovery/status. Future PRs will add preview, Office agent edits, and import flows behind these contracts.
 
 ## Trust boundary
 

--- a/plugins/boring-sharepoint/README.md
+++ b/plugins/boring-sharepoint/README.md
@@ -64,7 +64,7 @@ app-left action id: boring-sharepoint.settings
 label: SharePoint
 ```
 
-The app-left action opens the placeholder SharePoint / Microsoft 365 status overlay. The command opens the same status placeholder as a center panel. A future PR can replace the placeholder body with provider status and authorization controls without changing the menu path.
+The app-left action and command open the SharePoint / Microsoft 365 status surface. It now reads provider status from the plugin-owned route; future PRs can add authorization controls without changing the menu path.
 
 ## Package surfaces
 

--- a/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
@@ -117,6 +117,27 @@ describe("ArcadeSharePointProvider", () => {
     })
   })
 
+  it("rejects mismatched Office extension and MIME metadata with a stable code", async () => {
+    const providerWithItem = (item: Record<string, unknown>) =>
+      new ArcadeSharePointProvider({
+        runtime: {
+          executeTool: vi.fn().mockResolvedValue({ success: true, output: { value: item } }),
+          startAuthorization: vi.fn(),
+        },
+      })
+
+    await expect(
+      providerWithItem({ ...xlsxItemValue, name: "notes.docx", file: { mimeType: EXCEL_MIME_TYPE } }).resolveDriveItem(
+        { webUrl: "https://tenant/notes.docx" },
+        ctx,
+      ),
+    ).rejects.toMatchObject({ code: SHAREPOINT_ERROR_CODES.INVALID_REF } satisfies Partial<SharePointProviderError>)
+
+    await expect(
+      providerWithItem({ ...xlsxItemValue, file: { mimeType: POWERPOINT_MIME_TYPE } }).resolveDriveItem({ webUrl: xlsxItemValue.webUrl }, ctx),
+    ).rejects.toMatchObject({ code: SHAREPOINT_ERROR_CODES.INVALID_REF } satisfies Partial<SharePointProviderError>)
+  })
+
   it("rejects unsupported SharePoint file types with a stable code", async () => {
     const executeTool = vi.fn().mockResolvedValue({
       success: true,

--- a/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  EXCEL_MIME_TYPE,
+  POWERPOINT_MIME_TYPE,
+  SHAREPOINT_ERROR_CODES,
+  type SharePointProviderContext,
+} from "../shared"
+import { ARCADE_SHAREPOINT_TOOL_NAMES, ArcadeSharePointProvider, SharePointProviderError } from "../server/sharePointProvider"
+
+const ctx: SharePointProviderContext = { workspaceId: "workspace-1", actorUserId: "julien.hurault@sumeo.io" }
+
+const siteValue = {
+  id: "sumeo662.sharepoint.com,e8043020-774d-46ed-926c-f52c073140a1,92442a3f-a894-4bce-9e6b-895550db0275",
+  webUrl: "https://sumeo662.sharepoint.com/sites/sumeotest",
+}
+
+const xlsxItemValue = {
+  id: "01ROJOXDN53PWGVAWEJREZKIIY4VGYDIZ5",
+  name: "tttt.xlsx",
+  webUrl: "https://sumeo662.sharepoint.com/sites/sumeotest/Shared%20Documents/tttt.xlsx",
+  parentReference: {
+    driveId: "b!IDAE6E137UaSbPUsBzFAoT8qRJKUqM5LnmuJVVDbAnUI5HkM_PyuQovkEHDyaz3G",
+    siteId: siteValue.id,
+  },
+  file: { mimeType: EXCEL_MIME_TYPE },
+}
+
+const pptxItemValue = {
+  id: "01ROJOXDM7345DEYRHSFE2K7NEHOW6X3P2",
+  name: "tttt.pptx",
+  web_url: "https://sumeo662.sharepoint.com/sites/sumeotest/Shared%20Documents/tttt.pptx",
+  parent_reference: {
+    drive_id: "b!IDAE6E137UaSbPUsBzFAoT8qRJKUqM5LnmuJVVDbAnUI5HkM_PyuQovkEHDyaz3G",
+    site_id: siteValue.id,
+  },
+  file: { mime_type: POWERPOINT_MIME_TYPE },
+}
+
+describe("ArcadeSharePointProvider", () => {
+  it("normalizes read-only status through the Arcade runtime", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ success: true, output: { value: [] } })
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    await expect(provider.getStatus(ctx)).resolves.toEqual({ status: "connected" })
+    expect(executeTool).toHaveBeenCalledWith({
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.statusProbe,
+      userId: ctx.actorUserId,
+      input: {},
+    })
+  })
+
+  it("starts authorization through the Arcade runtime with read-only scopes", async () => {
+    const startAuthorization = vi.fn().mockResolvedValue({ status: "not_started", url: "https://arcade.dev/auth" })
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool: vi.fn(), startAuthorization } })
+
+    await expect(provider.authorize(ctx)).resolves.toEqual({ status: "needs_auth", authorizationUrl: "https://arcade.dev/auth" })
+    expect(startAuthorization).toHaveBeenCalledWith({ userId: ctx.actorUserId, scopes: ["Sites.Read.All", "Files.Read.All"] })
+  })
+
+  it("resolves a SharePoint site URL and Excel webUrl into a canonical cloud ref", async () => {
+    const executeTool = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: { value: siteValue } })
+      .mockResolvedValueOnce({ success: true, output: { value: xlsxItemValue } })
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    await expect(
+      provider.resolveDriveItem(
+        { siteUrl: "https://sumeo662.sharepoint.com/sites/sumeotest", webUrl: xlsxItemValue.webUrl },
+        ctx,
+      ),
+    ).resolves.toEqual({
+      kind: "office-cloud-document",
+      provider: "sharepoint",
+      version: 1,
+      name: "tttt.xlsx",
+      officeKind: "excel",
+      mimeType: EXCEL_MIME_TYPE,
+      webUrl: xlsxItemValue.webUrl,
+      siteId: siteValue.id,
+      driveId: xlsxItemValue.parentReference.driveId,
+      driveItemId: xlsxItemValue.id,
+      createdFrom: { type: "sharepoint" },
+    })
+    expect(executeTool).toHaveBeenNthCalledWith(1, {
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.getSite,
+      userId: ctx.actorUserId,
+      input: { site: "https://sumeo662.sharepoint.com/sites/sumeotest" },
+    })
+    expect(executeTool).toHaveBeenNthCalledWith(2, {
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.getDriveItemByUrl,
+      userId: ctx.actorUserId,
+      input: { web_url: xlsxItemValue.webUrl },
+    })
+  })
+
+  it("resolves PowerPoint metadata from durable drive id + item id", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ success: true, output: { value: pptxItemValue } })
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    const ref = await provider.resolveDriveItem({ driveId: pptxItemValue.parent_reference.drive_id, driveItemId: pptxItemValue.id }, ctx)
+
+    expect(ref).toMatchObject({
+      name: "tttt.pptx",
+      officeKind: "powerpoint",
+      mimeType: POWERPOINT_MIME_TYPE,
+      webUrl: pptxItemValue.web_url,
+      siteId: siteValue.id,
+      driveId: pptxItemValue.parent_reference.drive_id,
+      driveItemId: pptxItemValue.id,
+    })
+    expect(JSON.stringify(ref)).not.toMatch(/preview|getUrl|access_token|Bearer/i)
+    expect(executeTool).toHaveBeenCalledWith({
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.getDriveItem,
+      userId: ctx.actorUserId,
+      input: { drive_id: pptxItemValue.parent_reference.drive_id, item_id: pptxItemValue.id },
+    })
+  })
+
+  it("rejects unsupported SharePoint file types with a stable code", async () => {
+    const executeTool = vi.fn().mockResolvedValue({
+      success: true,
+      output: { value: { ...xlsxItemValue, name: "notes.docx", file: { mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" } } },
+    })
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    await expect(provider.resolveDriveItem({ webUrl: "https://tenant/notes.docx" }, ctx)).rejects.toMatchObject({
+      code: SHAREPOINT_ERROR_CODES.INVALID_REF,
+    } satisfies Partial<SharePointProviderError>)
+  })
+})

--- a/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
@@ -1,0 +1,88 @@
+import Fastify from "fastify"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { EXCEL_MIME_TYPE, SHAREPOINT_ERROR_CODES, type SharePointProvider } from "../shared"
+import { SHAREPOINT_ROUTE_PATHS, sharePointRoutes } from "../server/routes"
+import { SharePointProviderError } from "../server/sharePointProvider"
+
+const apps: Array<ReturnType<typeof Fastify>> = []
+
+const ref = {
+  kind: "office-cloud-document" as const,
+  provider: "sharepoint" as const,
+  version: 1 as const,
+  name: "tttt.xlsx",
+  officeKind: "excel" as const,
+  mimeType: EXCEL_MIME_TYPE,
+  webUrl: "https://sumeo662.sharepoint.com/sites/sumeotest/Shared%20Documents/tttt.xlsx",
+  siteId: "sumeo662.sharepoint.com,e8043020-774d-46ed-926c-f52c073140a1,92442a3f-a894-4bce-9e6b-895550db0275",
+  driveId: "b!IDAE6E137UaSbPUsBzFAoT8qRJKUqM5LnmuJVVDbAnUI5HkM_PyuQovkEHDyaz3G",
+  driveItemId: "01ROJOXDN53PWGVAWEJREZKIIY4VGYDIZ5",
+  createdFrom: { type: "sharepoint" as const },
+}
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.close()))
+})
+
+describe("SharePoint routes", () => {
+  it("returns stable status JSON from the provider", async () => {
+    const provider = fakeProvider({ getStatus: vi.fn().mockResolvedValue({ status: "connected" }) })
+    const app = await testApp(provider)
+
+    const response = await app.inject({ method: "GET", url: SHAREPOINT_ROUTE_PATHS.status })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({ status: { status: "connected" } })
+    expect(provider.getStatus).toHaveBeenCalledWith({ workspaceId: "default", actorUserId: "anonymous" })
+  })
+
+  it("returns canonical ref metadata only from resolve", async () => {
+    const provider = fakeProvider({ resolveDriveItem: vi.fn().mockResolvedValue(ref) })
+    const app = await testApp(provider)
+
+    const response = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.resolve,
+      payload: { webUrl: ref.webUrl },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({ ref })
+    expect(response.body).not.toMatch(/preview|getUrl|access_token|Bearer/i)
+    expect(provider.resolveDriveItem).toHaveBeenCalledWith(
+      { siteUrl: undefined, webUrl: ref.webUrl, driveId: undefined, driveItemId: undefined },
+      { workspaceId: "default", actorUserId: "anonymous" },
+    )
+  })
+
+  it("rejects route errors with stable JSON", async () => {
+    const provider = fakeProvider({
+      resolveDriveItem: vi.fn().mockRejectedValue(new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "unsupported file type")),
+    })
+    const app = await testApp(provider)
+
+    const response = await app.inject({ method: "POST", url: SHAREPOINT_ROUTE_PATHS.resolve, payload: { webUrl: "https://tenant/file.docx" } })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toEqual({ error: SHAREPOINT_ERROR_CODES.INVALID_REF, message: "unsupported file type" })
+  })
+})
+
+async function testApp(provider: SharePointProvider) {
+  const app = Fastify()
+  apps.push(app)
+  await app.register(sharePointRoutes, { provider })
+  await app.ready()
+  return app
+}
+
+function fakeProvider(overrides: Partial<SharePointProvider>): SharePointProvider {
+  return {
+    getStatus: vi.fn().mockResolvedValue({ status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: "not configured" }),
+    authorize: vi.fn(),
+    resolveDriveItem: vi.fn(),
+    createOfficePreviewUrl: vi.fn(),
+    editOfficeDocument: vi.fn(),
+    ...overrides,
+  }
+}

--- a/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
@@ -36,6 +36,17 @@ describe("SharePoint routes", () => {
     expect(provider.getStatus).toHaveBeenCalledWith({ workspaceId: "default", actorUserId: "anonymous" })
   })
 
+  it("strips authorization URLs from status route responses", async () => {
+    const provider = fakeProvider({ getStatus: vi.fn().mockResolvedValue({ status: "needs_auth", authorizationUrl: "https://arcade.dev/auth?token=secret" }) })
+    const app = await testApp(provider)
+
+    const response = await app.inject({ method: "GET", url: SHAREPOINT_ROUTE_PATHS.status })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({ status: { status: "needs_auth" } })
+    expect(response.body).not.toMatch(/arcade\.dev|token=secret|authorizationUrl/i)
+  })
+
   it("returns canonical ref metadata only from resolve", async () => {
     const provider = fakeProvider({ resolveDriveItem: vi.fn().mockResolvedValue(ref) })
     const app = await testApp(provider)

--- a/plugins/boring-sharepoint/src/front/panels.tsx
+++ b/plugins/boring-sharepoint/src/front/panels.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useState } from "react"
 import type { BoringFrontAppLeftOverlayProps, PaneProps } from "@hachej/boring-workspace/plugin"
-import type { OfficeDocumentSubtype } from "../shared"
+import type { IntegrationAuthState, OfficeDocumentSubtype } from "../shared"
 
 export interface OfficePreviewPanelParams {
   path: string
@@ -48,12 +49,18 @@ export function OfficePreviewPanel({ params }: PaneProps<OfficePreviewPanelParam
 }
 
 export function SharePointSettingsPanel() {
+  const status = useSharePointStatus()
+
   return (
     <section className="flex h-full min-h-0 flex-col bg-background p-4 text-sm text-foreground" data-boring-sharepoint-panel="settings">
       <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Integration status</p>
       <h2 className="mt-1 text-lg font-semibold">SharePoint / Microsoft 365</h2>
+      <div className="mt-4 rounded-lg border border-border bg-muted/20 p-4">
+        <p className="font-medium text-foreground">{status.label}</p>
+        <p className="mt-1 text-muted-foreground">{status.detail}</p>
+      </div>
       <div className="mt-4 rounded-lg border border-dashed border-border bg-muted/20 p-4 text-muted-foreground">
-        Connection status, authorization, and Arcade-backed provider checks will appear here in a later PR.
+        Read-only status and document discovery are wired through <code>/api/sharepoint/status</code> and <code>/api/sharepoint/resolve</code>. Preview, Office edits, and import are not enabled yet.
       </div>
     </section>
   )
@@ -79,6 +86,61 @@ export function SharePointSettingsOverlay({ onClose }: BoringFrontAppLeftOverlay
       <SharePointSettingsPanel />
     </div>
   )
+}
+
+interface SharePointStatusViewModel {
+  label: string
+  detail: string
+}
+
+function useSharePointStatus(): SharePointStatusViewModel {
+  const [status, setStatus] = useState<SharePointStatusViewModel>({
+    label: "Checking status…",
+    detail: "Contacting the SharePoint plugin route.",
+  })
+
+  useEffect(() => {
+    let cancelled = false
+    fetch("/api/sharepoint/status")
+      .then(async (response) => {
+        const payload = await response.json().catch(() => undefined)
+        if (!response.ok) throw new Error(typeof payload?.message === "string" ? payload.message : "SharePoint status request failed")
+        return payload?.status as IntegrationAuthState | undefined
+      })
+      .then((state) => {
+        if (!cancelled) setStatus(formatStatus(state))
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setStatus({
+            label: "Status unavailable",
+            detail: error instanceof Error ? error.message : "SharePoint status request failed",
+          })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return status
+}
+
+function formatStatus(state: IntegrationAuthState | undefined): SharePointStatusViewModel {
+  switch (state?.status) {
+    case "connected":
+      return { label: "Connected", detail: "Read-only SharePoint discovery is available." }
+    case "needs_auth":
+      return { label: "Authorization required", detail: "Connect SharePoint / Microsoft 365 to enable discovery." }
+    case "pending_auth":
+      return { label: "Authorization pending", detail: "Finish the Microsoft 365 authorization flow." }
+    case "admin_consent_required":
+      return { label: "Admin consent required", detail: state.message }
+    case "failed":
+      return { label: "Status unavailable", detail: state.message }
+    default:
+      return { label: "Status unavailable", detail: "The SharePoint status route returned an unexpected response." }
+  }
 }
 
 function safeHttpsUrl(value: unknown): string | undefined {

--- a/plugins/boring-sharepoint/src/server/index.ts
+++ b/plugins/boring-sharepoint/src/server/index.ts
@@ -1,15 +1,6 @@
-import { defineServerPlugin } from "@hachej/boring-workspace/server"
-import {
-  BORING_SHAREPOINT_PLUGIN_ID,
-  BORING_SHAREPOINT_PLUGIN_LABEL,
-} from "../shared"
+import { createSharePointServerPlugin } from "./serverPlugin"
 
-export default defineServerPlugin({
-  id: BORING_SHAREPOINT_PLUGIN_ID,
-  label: BORING_SHAREPOINT_PLUGIN_LABEL,
-  systemPrompt:
-    "SharePoint plugin shell is installed. Future versions will preview and agent-edit SharePoint-hosted Excel and PowerPoint documents.",
-})
+export default createSharePointServerPlugin
 
 export {
   BORING_SHAREPOINT_PLUGIN_ID,
@@ -34,3 +25,19 @@ export {
   type ArcadeAuthorizationStatusInput,
   type ArcadeToolExecuteInput,
 } from "./arcadeRuntime"
+export {
+  SHAREPOINT_ROUTE_PATHS,
+  sharePointRoutes,
+  type SharePointRoutesOptions,
+} from "./routes"
+export {
+  createSharePointServerPlugin,
+  type SharePointServerPluginOptions,
+} from "./serverPlugin"
+export {
+  ARCADE_SHAREPOINT_TOOL_NAMES,
+  ArcadeSharePointProvider,
+  SharePointProviderError,
+  toSharePointDocumentRef,
+  type ArcadeSharePointProviderOptions,
+} from "./sharePointProvider"

--- a/plugins/boring-sharepoint/src/server/routes.ts
+++ b/plugins/boring-sharepoint/src/server/routes.ts
@@ -1,7 +1,10 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
 import {
   SHAREPOINT_ERROR_CODES,
+  SharePointRefValidationError,
   assertSharePointDocumentRefSafeForStorage,
+  parseSharePointDocumentRef,
+  type IntegrationAuthState,
   type ResolveDriveItemInput,
   type SharePointProvider,
   type SharePointProviderContext,
@@ -22,7 +25,7 @@ export function sharePointRoutes(app: FastifyInstance, opts: SharePointRoutesOpt
   app.get(SHAREPOINT_ROUTE_PATHS.status, async (request, reply) => {
     try {
       const ctx = await resolveContext(request, opts)
-      return { status: await opts.provider.getStatus(ctx) }
+      return { status: safeStatusForRoute(await opts.provider.getStatus(ctx)) }
     } catch (error) {
       return sendSharePointRouteError(reply, error)
     }
@@ -32,7 +35,7 @@ export function sharePointRoutes(app: FastifyInstance, opts: SharePointRoutesOpt
     try {
       const input = parseResolveBody(request.body)
       const ctx = await resolveContext(request, opts)
-      const ref = await opts.provider.resolveDriveItem(input, ctx)
+      const ref = parseSharePointDocumentRef(await opts.provider.resolveDriveItem(input, ctx))
       assertSharePointDocumentRefSafeForStorage(ref)
       return { ref }
     } catch (error) {
@@ -41,6 +44,12 @@ export function sharePointRoutes(app: FastifyInstance, opts: SharePointRoutesOpt
   })
 
   done()
+}
+
+function safeStatusForRoute(status: IntegrationAuthState): Record<string, string> {
+  if (status.status === "needs_auth") return { status: "needs_auth" }
+  if (status.status === "pending_auth") return { status: "pending_auth" }
+  return status
 }
 
 function parseResolveBody(body: unknown): ResolveDriveItemInput {
@@ -67,6 +76,9 @@ async function resolveContext(request: FastifyRequest, opts: SharePointRoutesOpt
 function sendSharePointRouteError(reply: FastifyReply, error: unknown) {
   if (error instanceof SharePointProviderError) {
     return reply.code(error.statusCode).send({ error: error.code, message: error.message })
+  }
+  if (error instanceof SharePointRefValidationError) {
+    return reply.code(400).send({ error: error.code, message: error.message })
   }
   return reply.code(500).send({ error: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: "SharePoint provider request failed" })
 }

--- a/plugins/boring-sharepoint/src/server/routes.ts
+++ b/plugins/boring-sharepoint/src/server/routes.ts
@@ -1,0 +1,82 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
+import {
+  SHAREPOINT_ERROR_CODES,
+  assertSharePointDocumentRefSafeForStorage,
+  type ResolveDriveItemInput,
+  type SharePointProvider,
+  type SharePointProviderContext,
+} from "../shared"
+import { SharePointProviderError } from "./sharePointProvider"
+
+export const SHAREPOINT_ROUTE_PATHS = {
+  status: "/api/sharepoint/status",
+  resolve: "/api/sharepoint/resolve",
+} as const
+
+export interface SharePointRoutesOptions {
+  provider: SharePointProvider
+  getContext?: (request: FastifyRequest) => SharePointProviderContext | Promise<SharePointProviderContext>
+}
+
+export function sharePointRoutes(app: FastifyInstance, opts: SharePointRoutesOptions, done: (err?: Error) => void): void {
+  app.get(SHAREPOINT_ROUTE_PATHS.status, async (request, reply) => {
+    try {
+      const ctx = await resolveContext(request, opts)
+      return { status: await opts.provider.getStatus(ctx) }
+    } catch (error) {
+      return sendSharePointRouteError(reply, error)
+    }
+  })
+
+  app.post(SHAREPOINT_ROUTE_PATHS.resolve, async (request, reply) => {
+    try {
+      const input = parseResolveBody(request.body)
+      const ctx = await resolveContext(request, opts)
+      const ref = await opts.provider.resolveDriveItem(input, ctx)
+      assertSharePointDocumentRefSafeForStorage(ref)
+      return { ref }
+    } catch (error) {
+      return sendSharePointRouteError(reply, error)
+    }
+  })
+
+  done()
+}
+
+function parseResolveBody(body: unknown): ResolveDriveItemInput {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "resolve request body must be an object")
+  }
+  const candidate = body as Record<string, unknown>
+  return {
+    siteUrl: optionalString(candidate.siteUrl),
+    webUrl: optionalString(candidate.webUrl),
+    driveId: optionalString(candidate.driveId),
+    driveItemId: optionalString(candidate.driveItemId),
+  }
+}
+
+async function resolveContext(request: FastifyRequest, opts: SharePointRoutesOptions): Promise<SharePointProviderContext> {
+  if (opts.getContext) return opts.getContext(request)
+  return {
+    workspaceId: readQueryString(request, "workspaceId") ?? "default",
+    actorUserId: readQueryString(request, "actorUserId") ?? "anonymous",
+  }
+}
+
+function sendSharePointRouteError(reply: FastifyReply, error: unknown) {
+  if (error instanceof SharePointProviderError) {
+    return reply.code(error.statusCode).send({ error: error.code, message: error.message })
+  }
+  return reply.code(500).send({ error: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: "SharePoint provider request failed" })
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined
+}
+
+function readQueryString(request: FastifyRequest, key: string): string | undefined {
+  const query = request.query
+  if (!query || typeof query !== "object") return undefined
+  return optionalString((query as Record<string, unknown>)[key])
+}

--- a/plugins/boring-sharepoint/src/server/serverPlugin.ts
+++ b/plugins/boring-sharepoint/src/server/serverPlugin.ts
@@ -1,0 +1,74 @@
+import type { FastifyPluginAsync, FastifyRequest } from "fastify"
+import { defineServerPlugin, type WorkspaceServerPlugin } from "@hachej/boring-workspace/server"
+import {
+  BORING_SHAREPOINT_PLUGIN_ID,
+  BORING_SHAREPOINT_PLUGIN_LABEL,
+  SHAREPOINT_ERROR_CODES,
+  type CreateOfficePreviewUrlResult,
+  type IntegrationAuthState,
+  type OfficeEditRequest,
+  type OfficeEditResult,
+  type ResolveDriveItemInput,
+  type SharePointDocumentRef,
+  type SharePointProvider,
+  type SharePointProviderContext,
+} from "../shared"
+import { loadArcadeSharePointRuntimeConfig, requireArcadeSharePointRuntimeConfig, type ArcadeSharePointRuntimeConfigInput } from "./arcadeConfig"
+import { ArcadeJsToolRuntime } from "./arcadeRuntime"
+import { sharePointRoutes } from "./routes"
+import { ArcadeSharePointProvider, SharePointProviderError } from "./sharePointProvider"
+
+export interface SharePointServerPluginOptions {
+  provider?: SharePointProvider
+  arcadeConfig?: ArcadeSharePointRuntimeConfigInput
+  getContext?: (request: FastifyRequest) => SharePointProviderContext | Promise<SharePointProviderContext>
+}
+
+export function createSharePointServerPlugin(options: SharePointServerPluginOptions = {}): WorkspaceServerPlugin {
+  const provider = options.provider ?? createProviderFromConfig(options.arcadeConfig)
+  const routes: FastifyPluginAsync = async (app) => {
+    await app.register(sharePointRoutes, { provider, getContext: options.getContext })
+  }
+
+  return defineServerPlugin({
+    id: BORING_SHAREPOINT_PLUGIN_ID,
+    label: BORING_SHAREPOINT_PLUGIN_LABEL,
+    systemPrompt:
+      "SharePoint / Microsoft 365 integration is installed. It can resolve SharePoint-hosted Excel and PowerPoint documents into cloud refs; preview and Office edits are not enabled yet.",
+    routes,
+  })
+}
+
+function createProviderFromConfig(configInput?: ArcadeSharePointRuntimeConfigInput): SharePointProvider {
+  const loaded = configInput ?? loadArcadeSharePointRuntimeConfig()
+  try {
+    const config = requireArcadeSharePointRuntimeConfig(loaded)
+    return new ArcadeSharePointProvider({ runtime: new ArcadeJsToolRuntime(config) })
+  } catch (error) {
+    return new UnconfiguredSharePointProvider(error instanceof Error ? error.message : "SharePoint Arcade runtime is not configured")
+  }
+}
+
+class UnconfiguredSharePointProvider implements SharePointProvider {
+  constructor(private readonly message: string) {}
+
+  async getStatus(): Promise<IntegrationAuthState> {
+    return { status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: this.message }
+  }
+
+  async authorize(): Promise<IntegrationAuthState> {
+    return { status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: this.message }
+  }
+
+  async resolveDriveItem(_input: ResolveDriveItemInput): Promise<SharePointDocumentRef> {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, this.message, 503)
+  }
+
+  async createOfficePreviewUrl(): Promise<CreateOfficePreviewUrlResult> {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE, "SharePoint Office preview URLs are not implemented yet", 501)
+  }
+
+  async editOfficeDocument(_ref: SharePointDocumentRef, _request: OfficeEditRequest): Promise<OfficeEditResult> {
+    return { status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: "SharePoint Office edits are not implemented yet" }
+  }
+}

--- a/plugins/boring-sharepoint/src/server/sharePointProvider.ts
+++ b/plugins/boring-sharepoint/src/server/sharePointProvider.ts
@@ -1,7 +1,8 @@
 import {
-  EXCEL_MIME_TYPE,
-  POWERPOINT_MIME_TYPE,
   SHAREPOINT_ERROR_CODES,
+  SharePointRefValidationError,
+  expectedMimeTypeForOfficeKind,
+  parseSharePointDocumentRef,
   type IntegrationAuthState,
   type OfficeEditRequest,
   type OfficeEditResult,
@@ -141,12 +142,19 @@ export class ArcadeSharePointProvider implements SharePointProvider {
 
 export function toSharePointDocumentRef(input: { site?: Record<string, unknown>; item: Record<string, unknown> }): SharePointDocumentRef {
   const name = requireString(input.item, ["name", "fileName"], "drive item name")
-  const mimeType = optionalString(input.item, ["mimeType", "mime_type", "file.mimeType", "file.mime_type"]) ?? mimeTypeFromName(name)
-  const officeKind = officeKindFromNameAndMime(name, mimeType)
+  const suppliedMimeType = optionalString(input.item, ["mimeType", "mime_type", "file.mimeType", "file.mime_type"])
+  const officeKind = officeKindFromName(name)
   if (!officeKind) {
     throw new SharePointProviderError(
       SHAREPOINT_ERROR_CODES.INVALID_REF,
       "Only .xlsx Excel and .pptx PowerPoint SharePoint documents are supported",
+    )
+  }
+  const expectedMimeType = expectedMimeTypeForOfficeKind(officeKind)
+  if (suppliedMimeType && suppliedMimeType !== expectedMimeType) {
+    throw new SharePointProviderError(
+      SHAREPOINT_ERROR_CODES.INVALID_REF,
+      `SharePoint drive item MIME type does not match ${officeKind} file extension`,
     )
   }
 
@@ -156,7 +164,7 @@ export function toSharePointDocumentRef(input: { site?: Record<string, unknown>;
     version: 1,
     name,
     officeKind,
-    mimeType: officeKind === "excel" ? EXCEL_MIME_TYPE : POWERPOINT_MIME_TYPE,
+    mimeType: expectedMimeType,
     webUrl: requireString(input.item, ["webUrl", "web_url"], "drive item webUrl"),
     siteId:
       optionalString(input.item, ["siteId", "site_id", "parentReference.siteId", "parent_reference.site_id"]) ??
@@ -168,7 +176,14 @@ export function toSharePointDocumentRef(input: { site?: Record<string, unknown>;
   }
 
   if (!ref.siteId) throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "SharePoint site id is required")
-  return ref
+  try {
+    return parseSharePointDocumentRef(ref)
+  } catch (error) {
+    if (error instanceof SharePointRefValidationError) {
+      throw new SharePointProviderError(error.code, error.message)
+    }
+    throw error
+  }
 }
 
 function unwrapArcadeValueObject(response: unknown, toolName: string): Record<string, unknown> {
@@ -188,16 +203,10 @@ function unwrapArcadeValueObject(response: unknown, toolName: string): Record<st
   return value
 }
 
-function officeKindFromNameAndMime(name: string, mimeType: string | undefined): "excel" | "powerpoint" | null {
-  if (name.endsWith(".xlsx") || mimeType === EXCEL_MIME_TYPE) return "excel"
-  if (name.endsWith(".pptx") || mimeType === POWERPOINT_MIME_TYPE) return "powerpoint"
+function officeKindFromName(name: string): "excel" | "powerpoint" | null {
+  if (name.endsWith(".xlsx")) return "excel"
+  if (name.endsWith(".pptx")) return "powerpoint"
   return null
-}
-
-function mimeTypeFromName(name: string): string | undefined {
-  if (name.endsWith(".xlsx")) return EXCEL_MIME_TYPE
-  if (name.endsWith(".pptx")) return POWERPOINT_MIME_TYPE
-  return undefined
 }
 
 function requireString(object: Record<string, unknown> | undefined, paths: string[], label: string): string {

--- a/plugins/boring-sharepoint/src/server/sharePointProvider.ts
+++ b/plugins/boring-sharepoint/src/server/sharePointProvider.ts
@@ -1,0 +1,228 @@
+import {
+  EXCEL_MIME_TYPE,
+  POWERPOINT_MIME_TYPE,
+  SHAREPOINT_ERROR_CODES,
+  type IntegrationAuthState,
+  type OfficeEditRequest,
+  type OfficeEditResult,
+  type SharePointDocumentRef,
+  type SharePointErrorCode,
+  type SharePointProvider,
+  type SharePointProviderContext,
+  type ResolveDriveItemInput,
+  type CreateOfficePreviewUrlResult,
+} from "../shared"
+import { normalizeArcadeAuthState, normalizeArcadeToolAuthState } from "./authNormalization"
+import type { ArcadeJsToolRuntime } from "./arcadeRuntime"
+
+export const ARCADE_SHAREPOINT_TOOL_NAMES = {
+  statusProbe: "MicrosoftSharepoint_ListSites",
+  getSite: "MicrosoftSharepoint_GetSite",
+  getDriveItem: "MicrosoftSharepoint_GetDriveItem",
+  getDriveItemByUrl: "MicrosoftSharepoint_GetDriveItemByUrl",
+} as const
+
+export interface ArcadeSharePointProviderOptions {
+  runtime: Pick<ArcadeJsToolRuntime, "executeTool" | "startAuthorization">
+  scopes?: string[]
+  tools?: Partial<typeof ARCADE_SHAREPOINT_TOOL_NAMES>
+}
+
+export class SharePointProviderError extends Error {
+  readonly code: SharePointErrorCode
+  readonly statusCode: number
+
+  constructor(code: SharePointErrorCode, message: string, statusCode = 400) {
+    super(message)
+    this.name = "SharePointProviderError"
+    this.code = code
+    this.statusCode = statusCode
+  }
+}
+
+export class ArcadeSharePointProvider implements SharePointProvider {
+  private readonly runtime: ArcadeSharePointProviderOptions["runtime"]
+  private readonly scopes: string[]
+  private readonly tools: typeof ARCADE_SHAREPOINT_TOOL_NAMES
+
+  constructor(options: ArcadeSharePointProviderOptions) {
+    this.runtime = options.runtime
+    this.scopes = options.scopes ?? ["Sites.Read.All", "Files.Read.All"]
+    this.tools = { ...ARCADE_SHAREPOINT_TOOL_NAMES, ...options.tools }
+  }
+
+  async getStatus(ctx: SharePointProviderContext): Promise<IntegrationAuthState> {
+    try {
+      const response = await this.runtime.executeTool({
+        toolName: this.tools.statusProbe,
+        userId: ctx.actorUserId,
+        input: {},
+      })
+      return normalizeArcadeToolAuthState(response)
+    } catch (error) {
+      return {
+        status: "failed",
+        code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE,
+        message: error instanceof Error ? error.message : "SharePoint provider status check failed",
+      }
+    }
+  }
+
+  async authorize(ctx: SharePointProviderContext): Promise<IntegrationAuthState> {
+    try {
+      return normalizeArcadeAuthState(await this.runtime.startAuthorization({ userId: ctx.actorUserId, scopes: this.scopes }))
+    } catch (error) {
+      return {
+        status: "failed",
+        code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE,
+        message: error instanceof Error ? error.message : "SharePoint authorization failed",
+      }
+    }
+  }
+
+  async resolveDriveItem(input: ResolveDriveItemInput, ctx: SharePointProviderContext): Promise<SharePointDocumentRef> {
+    const site = input.siteUrl ? await this.getSite(input.siteUrl, ctx) : undefined
+    const item = input.webUrl
+      ? await this.getDriveItemByUrl(input.webUrl, ctx)
+      : await this.getDriveItemById(input, ctx)
+
+    return toSharePointDocumentRef({ site, item })
+  }
+
+  async createOfficePreviewUrl(): Promise<CreateOfficePreviewUrlResult> {
+    throw new SharePointProviderError(
+      SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE,
+      "SharePoint Office preview URLs are not implemented in this read-only discovery slice",
+      501,
+    )
+  }
+
+  async editOfficeDocument(_ref: SharePointDocumentRef, _request: OfficeEditRequest): Promise<OfficeEditResult> {
+    return {
+      status: "failed",
+      code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE,
+      message: "SharePoint Office edits are not implemented in this read-only discovery slice",
+    }
+  }
+
+  private async getSite(siteUrl: string, ctx: SharePointProviderContext): Promise<Record<string, unknown>> {
+    const response = await this.runtime.executeTool({
+      toolName: this.tools.getSite,
+      userId: ctx.actorUserId,
+      input: { site: siteUrl },
+    })
+    return unwrapArcadeValueObject(response, this.tools.getSite)
+  }
+
+  private async getDriveItemByUrl(webUrl: string, ctx: SharePointProviderContext): Promise<Record<string, unknown>> {
+    const response = await this.runtime.executeTool({
+      toolName: this.tools.getDriveItemByUrl,
+      userId: ctx.actorUserId,
+      input: { web_url: webUrl },
+    })
+    return unwrapArcadeValueObject(response, this.tools.getDriveItemByUrl)
+  }
+
+  private async getDriveItemById(input: ResolveDriveItemInput, ctx: SharePointProviderContext): Promise<Record<string, unknown>> {
+    if (!input.driveId || !input.driveItemId) {
+      throw new SharePointProviderError(
+        SHAREPOINT_ERROR_CODES.INVALID_REF,
+        "resolveDriveItem requires either webUrl or driveId + driveItemId",
+      )
+    }
+    const response = await this.runtime.executeTool({
+      toolName: this.tools.getDriveItem,
+      userId: ctx.actorUserId,
+      input: { drive_id: input.driveId, item_id: input.driveItemId },
+    })
+    return unwrapArcadeValueObject(response, this.tools.getDriveItem)
+  }
+}
+
+export function toSharePointDocumentRef(input: { site?: Record<string, unknown>; item: Record<string, unknown> }): SharePointDocumentRef {
+  const name = requireString(input.item, ["name", "fileName"], "drive item name")
+  const mimeType = optionalString(input.item, ["mimeType", "mime_type", "file.mimeType", "file.mime_type"]) ?? mimeTypeFromName(name)
+  const officeKind = officeKindFromNameAndMime(name, mimeType)
+  if (!officeKind) {
+    throw new SharePointProviderError(
+      SHAREPOINT_ERROR_CODES.INVALID_REF,
+      "Only .xlsx Excel and .pptx PowerPoint SharePoint documents are supported",
+    )
+  }
+
+  const ref: SharePointDocumentRef = {
+    kind: "office-cloud-document",
+    provider: "sharepoint",
+    version: 1,
+    name,
+    officeKind,
+    mimeType: officeKind === "excel" ? EXCEL_MIME_TYPE : POWERPOINT_MIME_TYPE,
+    webUrl: requireString(input.item, ["webUrl", "web_url"], "drive item webUrl"),
+    siteId:
+      optionalString(input.item, ["siteId", "site_id", "parentReference.siteId", "parent_reference.site_id"]) ??
+      optionalString(input.site, ["id", "siteId", "site_id"]) ??
+      "",
+    driveId: requireString(input.item, ["driveId", "drive_id", "parentReference.driveId", "parent_reference.drive_id"], "drive id"),
+    driveItemId: requireString(input.item, ["id", "itemId", "item_id", "driveItemId", "drive_item_id"], "drive item id"),
+    createdFrom: { type: "sharepoint" },
+  }
+
+  if (!ref.siteId) throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "SharePoint site id is required")
+  return ref
+}
+
+function unwrapArcadeValueObject(response: unknown, toolName: string): Record<string, unknown> {
+  const authState = normalizeArcadeToolAuthState(response)
+  if (authState.status !== "connected") {
+    throw new SharePointProviderError(
+      authState.status === "failed" ? authState.code : SHAREPOINT_ERROR_CODES.AUTH_REQUIRED,
+      authState.status === "failed" ? authState.message : "SharePoint authorization is required",
+      authState.status === "failed" ? 502 : 401,
+    )
+  }
+
+  const value = nested(response, ["output", "value"]) ?? nested(response, ["value"]) ?? response
+  if (!isObject(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.PROVIDER_TOOL_FAILED, `${toolName} did not return an object`, 502)
+  }
+  return value
+}
+
+function officeKindFromNameAndMime(name: string, mimeType: string | undefined): "excel" | "powerpoint" | null {
+  if (name.endsWith(".xlsx") || mimeType === EXCEL_MIME_TYPE) return "excel"
+  if (name.endsWith(".pptx") || mimeType === POWERPOINT_MIME_TYPE) return "powerpoint"
+  return null
+}
+
+function mimeTypeFromName(name: string): string | undefined {
+  if (name.endsWith(".xlsx")) return EXCEL_MIME_TYPE
+  if (name.endsWith(".pptx")) return POWERPOINT_MIME_TYPE
+  return undefined
+}
+
+function requireString(object: Record<string, unknown> | undefined, paths: string[], label: string): string {
+  const value = optionalString(object, paths)
+  if (!value) throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} is required`)
+  return value
+}
+
+function optionalString(object: Record<string, unknown> | undefined, paths: string[]): string | undefined {
+  for (const path of paths) {
+    const value = nested(object, path.split("."))
+    if (typeof value === "string" && value.length > 0) return value
+  }
+  return undefined
+}
+
+function nested(object: unknown, path: string[]): unknown {
+  let current = object
+  for (const segment of path) {
+    if (!isObject(current)) return undefined
+    current = current[segment]
+  }
+  return current
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}


### PR DESCRIPTION
## Summary

- adds server-side ArcadeSharePointProvider for read-only SharePoint status/discovery
- adds plugin-owned status and resolve routes
- maps mocked Arcade SharePoint tool responses to canonical xlsx/pptx SharePointDocumentRef metadata
- wires settings/status panel to the status route
- updates workbook docs with route/tool names

## Validation

- pnpm --filter @hachej/boring-sharepoint test
- pnpm --filter @hachej/boring-sharepoint typecheck
- pnpm --filter @hachej/boring-sharepoint build
- git diff --check

## Scope boundaries

- no direct Microsoft Graph calls
- no preview iframe or driveItem:preview
- no Office edits
- no local import/upload
- Arcade imports remain server-side only
