### PR TITLE
sharepoint-plug: add Office preview route

### DIFF
--- a/plugins/boring-sharepoint/README.md
+++ b/plugins/boring-sharepoint/README.md
@@ -2,7 +2,7 @@
 
 App/internal plugin shell for SharePoint / Microsoft 365 Office document support in boring-ui.
 
-This package is intentionally a trusted app/internal plugin, not a runtime-generated `.pi/extensions` plugin. The current stack includes the plugin shell, Office cloud-ref display wiring, Arcade runtime primitives, and read-only SharePoint discovery/status. Future PRs will add preview, Office agent edits, and import flows behind these contracts.
+This package is intentionally a trusted app/internal plugin, not a runtime-generated `.pi/extensions` plugin. The current stack includes the plugin shell, Office cloud-ref display wiring, Arcade runtime primitives, read-only SharePoint discovery/status, and on-demand Office preview. Future PRs will add Office agent edits and import flows behind these contracts.
 
 ## Trust boundary
 
@@ -27,6 +27,7 @@ This workbook will become the operator guide as implementation PRs land.
      - `BORING_SHAREPOINT_ARCADE_DEFAULT_USER_ID` — optional default Arcade user id for local/operator testing.
      - `BORING_SHAREPOINT_ARCADE_PROVIDER_ID` — optional provider id, defaults to `microsoft`.
      - `BORING_SHAREPOINT_ARCADE_BASE_URL` — optional Arcade API base URL override.
+   - Deploy/register the plugin-owned custom Arcade tool `BoringSharePoint_CreatePreviewUrl` in the operator's Arcade project. The tool wraps Microsoft Graph `driveItem:preview` using Arcade-managed Microsoft auth and returns only `{ getUrl, expiresAt? }`.
    - Confirm Microsoft scopes needed by each capability.
    - Confirm tenant/admin consent requirements.
 3. **boring-ui workspace connection**
@@ -39,12 +40,12 @@ This workbook will become the operator guide as implementation PRs land.
    - Capture their SharePoint identity as `siteId`, `driveId`, and `driveItemId`.
 5. **Validate V1 flows**
    - Open in SharePoint using `webUrl`.
-   - Preview in boring-ui once the custom preview tool lands.
+   - Preview in boring-ui through `POST /api/sharepoint/preview`, which requests a transient preview URL on demand.
    - Agent-edit Excel and PowerPoint once edit providers land.
 6. **Troubleshooting**
    - Auth required: reconnect SharePoint/Microsoft 365.
    - Admin consent required: tenant admin must approve Microsoft scopes.
-   - Preview blocked: check tenant iframe policy, browser auth, and host CSP.
+   - Preview blocked: check custom Arcade tool deployment, tenant iframe policy, browser auth, and host CSP.
    - Stale `webUrl`: re-resolve by durable `driveId + driveItemId`.
    - Arcade tool failure: inspect stable `SHAREPOINT_*` error code and provider status.
 
@@ -74,23 +75,17 @@ The app-left action and command open the SharePoint / Microsoft 365 status surfa
 
 ## Current scope
 
-This PR adds read-only SharePoint discovery/status on top of the shell/display/runtime stack:
+This PR adds on-demand Office preview on top of the shell/display/runtime/discovery stack:
 
-- `ArcadeSharePointProvider` keeps Arcade tool names and snake_case inputs inside server/provider internals.
-- Status uses the read-only status probe tool `MicrosoftSharepoint_ListSites` through `ArcadeJsToolRuntime` and normalizes responses to `IntegrationAuthState`.
-- Authorization uses Arcade auth start with read-only scopes `Sites.Read.All` and `Files.Read.All`.
-- Discovery resolves SharePoint Office documents with mocked/read-only Arcade tool calls:
-  - `MicrosoftSharepoint_GetSite` with `{ site }` when a site URL is provided.
-  - `MicrosoftSharepoint_GetDriveItemByUrl` with `{ web_url }` when an Office web URL is provided.
-  - `MicrosoftSharepoint_GetDriveItem` with `{ drive_id, item_id }` when durable IDs are provided.
-- Plugin-owned routes:
-  - `GET /api/sharepoint/status` returns `{ status }` only.
-  - `POST /api/sharepoint/resolve` accepts `{ siteUrl?, webUrl?, driveId?, driveItemId? }` and returns `{ ref }` canonical metadata only.
-- The settings/status panel queries `GET /api/sharepoint/status` via a relative route and displays a compact status summary.
-- Ref mapping accepts only `.xlsx` Excel and `.pptx` PowerPoint files; unsupported Office/file types fail with stable `SHAREPOINT_INVALID_REF` errors.
+- `ArcadeSharePointProvider.createOfficePreviewUrl()` calls the plugin-owned custom Arcade tool `BoringSharePoint_CreatePreviewUrl` with `{ drive_id, item_id, viewer: "office" }` and normalizes `{ getUrl, expiresAt? }`.
+- `POST /api/sharepoint/preview` accepts either `{ ref }` with a canonical SharePoint document ref or `{ driveId, driveItemId }` durable identity and returns the transient preview result only.
+- The preview route validates canonical refs and rejects token-bearing ref input before calling the provider.
+- The Office preview panel requests the preview URL only while rendering and stores it only in React component state.
+- Preview `getUrl` values are never stored in cloud-ref metadata, route logs, route errors, or session storage.
+- The custom Arcade tool deploy/register step remains an operator runbook task; this repo contains the contract/runtime call and mocked tests only.
 - Tests use mocked Arcade/provider calls only.
-- no Microsoft Graph direct calls
-- no preview iframe or `driveItem:preview`
+- no Microsoft Graph direct calls in boring-ui code
+- no Claude MCP/local MCP gateway dependency
 - no Office edit calls
 - no local import/upload
 - no SharePoint-specific workspace chrome branches

--- a/plugins/boring-sharepoint/src/__tests__/arcadeBoundary.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/arcadeBoundary.test.ts
@@ -15,6 +15,17 @@ describe("Arcade package boundaries", () => {
 
     expect(forbiddenMatches).toEqual([])
   })
+
+  it("does not call Microsoft Graph directly from plugin source", () => {
+    const forbiddenMatches = listSourceFiles("src")
+      .filter((path) => !path.includes("/__tests__/"))
+      .flatMap((path) => {
+        const source = readFileSync(path, "utf8")
+        return /graph\.microsoft\.com|driveItem:preview/i.test(source) ? [relative(packageRoot.pathname, path)] : []
+      })
+
+    expect(forbiddenMatches).toEqual([])
+  })
 })
 
 function listSourceFiles(path: string): string[] {

--- a/plugins/boring-sharepoint/src/__tests__/frontPlugin.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/frontPlugin.test.ts
@@ -1,6 +1,7 @@
 import { WORKSPACE_OPEN_PATH_SURFACE_KIND, captureFrontPlugin } from "@hachej/boring-workspace/plugin"
 import { describe, expect, it } from "vitest"
 import sharePointPlugin from "../front"
+import { previewRequestBody } from "../front/panels"
 import {
   BORING_SHAREPOINT_APP_LEFT_ACTION_ID,
   BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,
@@ -59,6 +60,9 @@ describe("SharePoint front plugin", () => {
         officeKind: "excel",
         displayName: "forecast.xlsx",
         webUrl: excelRef.webUrl,
+        driveId: excelRef.driveId,
+        driveItemId: excelRef.driveItemId,
+        sharePointRef: excelRef,
       },
       score: 100,
     })
@@ -73,6 +77,12 @@ describe("SharePoint front plugin", () => {
       },
     })
     expect(resolver.resolve({ kind: WORKSPACE_OPEN_PATH_SURFACE_KIND, target: "notes.md" })).toBeUndefined()
+  })
+
+  it("builds preview request bodies without preview URLs", () => {
+    expect(previewRequestBody({ path: "forecast.xlsx.cloud.json", officeKind: "excel", displayName: "forecast.xlsx", sharePointRef: excelRef })).toEqual({ ref: excelRef })
+    expect(previewRequestBody({ path: "forecast.xlsx.cloud.json", officeKind: "excel", displayName: "forecast.xlsx", driveId: "drive-id", driveItemId: "item-id" })).toEqual({ driveId: "drive-id", driveItemId: "item-id" })
+    expect(previewRequestBody({ path: "forecast.xlsx.cloud.json", officeKind: "excel", displayName: "forecast.xlsx" })).toBeNull()
   })
 
   it("derives virtual display metadata without reading provider state", () => {

--- a/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
@@ -117,6 +117,40 @@ describe("ArcadeSharePointProvider", () => {
     })
   })
 
+  it("creates a transient Office preview URL through the custom Arcade tool", async () => {
+    const executeTool = vi.fn().mockResolvedValue({
+      success: true,
+      output: { value: { getUrl: "https://tenant.sharepoint.com/:x:/preview.aspx?token=transient", expiresAt: "2026-07-03T15:00:00Z" } },
+    })
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    await expect(provider.createOfficePreviewUrl({ ...xlsxItemValue, kind: "office-cloud-document", provider: "sharepoint", version: 1, officeKind: "excel", mimeType: EXCEL_MIME_TYPE, siteId: siteValue.id, driveId: xlsxItemValue.parentReference.driveId, driveItemId: xlsxItemValue.id }, ctx)).resolves.toEqual({
+      getUrl: "https://tenant.sharepoint.com/:x:/preview.aspx?token=transient",
+      expiresAt: "2026-07-03T15:00:00Z",
+    })
+    expect(executeTool).toHaveBeenCalledWith({
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.createPreviewUrl,
+      userId: ctx.actorUserId,
+      input: { drive_id: xlsxItemValue.parentReference.driveId, item_id: xlsxItemValue.id, viewer: "office" },
+    })
+  })
+
+  it("rejects missing or non-HTTPS preview URLs without echoing returned URL data", async () => {
+    const providerWithPreview = (value: Record<string, unknown>) =>
+      new ArcadeSharePointProvider({
+        runtime: { executeTool: vi.fn().mockResolvedValue({ success: true, output: { value } }), startAuthorization: vi.fn() },
+      })
+
+    await expect(providerWithPreview({}).createOfficePreviewUrl({ driveId: "drive-id", driveItemId: "item-id" }, ctx)).rejects.toMatchObject({
+      code: SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE,
+      message: expect.not.stringContaining("http://tenant/preview"),
+    })
+    await expect(providerWithPreview({ getUrl: "http://tenant/preview" }).createOfficePreviewUrl({ driveId: "drive-id", driveItemId: "item-id" }, ctx)).rejects.toMatchObject({
+      code: SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE,
+      message: expect.not.stringContaining("http://tenant/preview"),
+    })
+  })
+
   it("rejects mismatched Office extension and MIME metadata with a stable code", async () => {
     const providerWithItem = (item: Record<string, unknown>) =>
       new ArcadeSharePointProvider({

--- a/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
@@ -91,6 +91,26 @@ describe("SharePoint routes", () => {
     )
   })
 
+  it("rejects invalid durable preview identifiers before provider calls", async () => {
+    const provider = fakeProvider({ createOfficePreviewUrl: vi.fn() })
+    const app = await testApp(provider)
+
+    const invalidCases = [
+      { driveId: " ", driveItemId: ref.driveItemId, error: SHAREPOINT_ERROR_CODES.INVALID_REF },
+      { driveId: ref.driveId, driveItemId: `Bearer ${ref.driveItemId}`, error: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET },
+      { driveId: `${ref.driveId}?access_token=secret`, driveItemId: ref.driveItemId, error: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET },
+      { driveId: "x".repeat(513), driveItemId: ref.driveItemId, error: SHAREPOINT_ERROR_CODES.INVALID_REF },
+    ]
+
+    for (const payload of invalidCases) {
+      const response = await app.inject({ method: "POST", url: SHAREPOINT_ROUTE_PATHS.preview, payload })
+      expect(response.statusCode).toBe(400)
+      expect(response.json()).toMatchObject({ error: payload.error })
+      expect(response.body).not.toMatch(/access_token=secret|Bearer 01ROJO|xxxxx/)
+    }
+    expect(provider.createOfficePreviewUrl).not.toHaveBeenCalled()
+  })
+
   it("rejects non-HTTPS preview results from the provider", async () => {
     const provider = fakeProvider({ createOfficePreviewUrl: vi.fn().mockResolvedValue({ getUrl: "http://tenant/preview?token=secret" }) })
     const app = await testApp(provider)

--- a/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
@@ -66,6 +66,57 @@ describe("SharePoint routes", () => {
     )
   })
 
+  it("returns transient preview result without persisting ref metadata", async () => {
+    const provider = fakeProvider({ createOfficePreviewUrl: vi.fn().mockResolvedValue({ getUrl: "https://tenant.sharepoint.com/preview?token=transient" }) })
+    const app = await testApp(provider)
+
+    const response = await app.inject({ method: "POST", url: SHAREPOINT_ROUTE_PATHS.preview, payload: { ref } })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({ getUrl: "https://tenant.sharepoint.com/preview?token=transient" })
+    expect(response.json()).not.toHaveProperty("ref")
+    expect(provider.createOfficePreviewUrl).toHaveBeenCalledWith(ref, { workspaceId: "default", actorUserId: "anonymous" })
+  })
+
+  it("accepts durable drive identity for preview requests", async () => {
+    const provider = fakeProvider({ createOfficePreviewUrl: vi.fn().mockResolvedValue({ getUrl: "https://tenant.sharepoint.com/preview" }) })
+    const app = await testApp(provider)
+
+    const response = await app.inject({ method: "POST", url: SHAREPOINT_ROUTE_PATHS.preview, payload: { driveId: ref.driveId, driveItemId: ref.driveItemId } })
+
+    expect(response.statusCode).toBe(200)
+    expect(provider.createOfficePreviewUrl).toHaveBeenCalledWith(
+      { driveId: ref.driveId, driveItemId: ref.driveItemId },
+      { workspaceId: "default", actorUserId: "anonymous" },
+    )
+  })
+
+  it("rejects non-HTTPS preview results from the provider", async () => {
+    const provider = fakeProvider({ createOfficePreviewUrl: vi.fn().mockResolvedValue({ getUrl: "http://tenant/preview?token=secret" }) })
+    const app = await testApp(provider)
+
+    const response = await app.inject({ method: "POST", url: SHAREPOINT_ROUTE_PATHS.preview, payload: { driveId: ref.driveId, driveItemId: ref.driveItemId } })
+
+    expect(response.statusCode).toBe(502)
+    expect(response.json()).toEqual({ error: SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE, message: "SharePoint preview provider returned an invalid preview URL" })
+    expect(response.body).not.toContain("http://tenant/preview")
+  })
+
+  it("rejects token-bearing preview ref input", async () => {
+    const provider = fakeProvider({ createOfficePreviewUrl: vi.fn() })
+    const app = await testApp(provider)
+
+    const response = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.preview,
+      payload: { ref: { ...ref, previewUrl: "https://tenant.sharepoint.com/preview?access_token=secret" } },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toMatchObject({ error: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET })
+    expect(provider.createOfficePreviewUrl).not.toHaveBeenCalled()
+  })
+
   it("rejects route errors with stable JSON", async () => {
     const provider = fakeProvider({
       resolveDriveItem: vi.fn().mockRejectedValue(new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "unsupported file type")),

--- a/plugins/boring-sharepoint/src/front/panels.tsx
+++ b/plugins/boring-sharepoint/src/front/panels.tsx
@@ -1,18 +1,22 @@
 import { useEffect, useState } from "react"
 import type { BoringFrontAppLeftOverlayProps, PaneProps } from "@hachej/boring-workspace/plugin"
-import type { IntegrationAuthState, OfficeDocumentSubtype } from "../shared"
+import type { CreateOfficePreviewUrlResult, IntegrationAuthState, OfficeDocumentSubtype, SharePointDocumentRef } from "../shared"
 
 export interface OfficePreviewPanelParams {
   path: string
   officeKind: OfficeDocumentSubtype
   displayName: string
   webUrl?: string
+  driveId?: string
+  driveItemId?: string
+  sharePointRef?: SharePointDocumentRef
 }
 
 export function OfficePreviewPanel({ params }: PaneProps<OfficePreviewPanelParams>) {
   const webUrl = safeHttpsUrl(params?.webUrl)
   const displayName = params?.displayName ?? "Office document"
   const officeKind = params?.officeKind === "powerpoint" ? "PowerPoint" : "Excel"
+  const preview = useOfficePreview(params)
 
   return (
     <section className="flex h-full min-h-0 flex-col bg-background p-4 text-sm text-foreground" data-boring-sharepoint-panel="office-preview">
@@ -41,8 +45,25 @@ export function OfficePreviewPanel({ params }: PaneProps<OfficePreviewPanelParam
           </button>
         )}
       </div>
-      <div className="rounded-lg border border-dashed border-border bg-muted/20 p-4 text-muted-foreground">
-        Office preview is not wired yet. A later SharePoint plugin PR will request a transient Microsoft preview URL on demand and render it here.
+      <div className="min-h-0 flex-1 overflow-hidden rounded-lg border border-border bg-muted/20">
+        {preview.status === "loading" ? (
+          <div className="p-4 text-muted-foreground">Requesting a transient Microsoft 365 preview URL…</div>
+        ) : preview.status === "error" ? (
+          <div className="p-4 text-muted-foreground" role="alert">
+            <p className="font-medium text-foreground">Preview unavailable</p>
+            <p className="mt-1">{preview.message}</p>
+          </div>
+        ) : preview.getUrl ? (
+          <iframe
+            title={`${displayName} preview`}
+            src={preview.getUrl}
+            className="h-full min-h-[480px] w-full border-0 bg-background"
+            sandbox="allow-downloads allow-forms allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts"
+            referrerPolicy="no-referrer"
+          />
+        ) : (
+          <div className="p-4 text-muted-foreground">Preview is unavailable for this SharePoint cloud reference.</div>
+        )}
       </div>
     </section>
   )
@@ -88,9 +109,60 @@ export function SharePointSettingsOverlay({ onClose }: BoringFrontAppLeftOverlay
   )
 }
 
+type OfficePreviewState =
+  | { status: "loading" }
+  | { status: "ready"; getUrl: string }
+  | { status: "error"; message: string }
+
 interface SharePointStatusViewModel {
   label: string
   detail: string
+}
+
+function useOfficePreview(params: OfficePreviewPanelParams | undefined): OfficePreviewState {
+  const [preview, setPreview] = useState<OfficePreviewState>({ status: "loading" })
+
+  useEffect(() => {
+    const body = previewRequestBody(params)
+    if (!body) {
+      setPreview({ status: "error", message: "This cloud reference does not include SharePoint drive identity." })
+      return
+    }
+
+    let cancelled = false
+    setPreview({ status: "loading" })
+    fetch("/api/sharepoint/preview", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    })
+      .then(async (response) => {
+        const payload = await response.json().catch(() => undefined)
+        if (!response.ok) throw new Error(typeof payload?.message === "string" ? payload.message : "SharePoint preview request failed")
+        const getUrl = safeHttpsUrl((payload as CreateOfficePreviewUrlResult | undefined)?.getUrl)
+        if (!getUrl) throw new Error("SharePoint preview response did not include a safe HTTPS URL")
+        return getUrl
+      })
+      .then((getUrl) => {
+        if (!cancelled) setPreview({ status: "ready", getUrl })
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          setPreview({ status: "error", message: error instanceof Error ? error.message : "SharePoint preview request failed" })
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [params])
+
+  return preview
+}
+
+export function previewRequestBody(params: OfficePreviewPanelParams | undefined): { ref: SharePointDocumentRef } | { driveId: string; driveItemId: string } | null {
+  if (params?.sharePointRef) return { ref: params.sharePointRef }
+  if (params?.driveId && params.driveItemId) return { driveId: params.driveId, driveItemId: params.driveItemId }
+  return null
 }
 
 function useSharePointStatus(): SharePointStatusViewModel {

--- a/plugins/boring-sharepoint/src/front/panels.tsx
+++ b/plugins/boring-sharepoint/src/front/panels.tsx
@@ -81,7 +81,7 @@ export function SharePointSettingsPanel() {
         <p className="mt-1 text-muted-foreground">{status.detail}</p>
       </div>
       <div className="mt-4 rounded-lg border border-dashed border-border bg-muted/20 p-4 text-muted-foreground">
-        Read-only status and document discovery are wired through <code>/api/sharepoint/status</code> and <code>/api/sharepoint/resolve</code>. Preview, Office edits, and import are not enabled yet.
+        Read-only status and document discovery are wired through <code>/api/sharepoint/status</code> and <code>/api/sharepoint/resolve</code>. Office preview is generated on demand through <code>/api/sharepoint/preview</code>; Office edits and import are not enabled yet.
       </div>
     </section>
   )

--- a/plugins/boring-sharepoint/src/front/surfaceResolver.ts
+++ b/plugins/boring-sharepoint/src/front/surfaceResolver.ts
@@ -29,7 +29,12 @@ export const sharePointOfficeCloudRefSurfaceResolver: BoringFrontSurfaceResolver
     }
 
     const ref = request.meta?.sharePointRef
-    if (isSharePointDocumentRef(ref)) params.webUrl = ref.webUrl
+    if (isSharePointDocumentRef(ref)) {
+      params.webUrl = ref.webUrl
+      params.driveId = ref.driveId
+      params.driveItemId = ref.driveItemId
+      params.sharePointRef = ref
+    }
 
     return {
       component: BORING_SHAREPOINT_OFFICE_PREVIEW_PANEL_ID,

--- a/plugins/boring-sharepoint/src/server/index.ts
+++ b/plugins/boring-sharepoint/src/server/index.ts
@@ -38,6 +38,7 @@ export {
   ARCADE_SHAREPOINT_TOOL_NAMES,
   ArcadeSharePointProvider,
   SharePointProviderError,
+  toOfficePreviewUrlResult,
   toSharePointDocumentRef,
   type ArcadeSharePointProviderOptions,
 } from "./sharePointProvider"

--- a/plugins/boring-sharepoint/src/server/routes.ts
+++ b/plugins/boring-sharepoint/src/server/routes.ts
@@ -4,8 +4,11 @@ import {
   SharePointRefValidationError,
   assertSharePointDocumentRefSafeForStorage,
   parseSharePointDocumentRef,
+  type CreateOfficePreviewUrlInput,
+  type CreateOfficePreviewUrlResult,
   type IntegrationAuthState,
   type ResolveDriveItemInput,
+  type SharePointDocumentRef,
   type SharePointProvider,
   type SharePointProviderContext,
 } from "../shared"
@@ -14,6 +17,7 @@ import { SharePointProviderError } from "./sharePointProvider"
 export const SHAREPOINT_ROUTE_PATHS = {
   status: "/api/sharepoint/status",
   resolve: "/api/sharepoint/resolve",
+  preview: "/api/sharepoint/preview",
 } as const
 
 export interface SharePointRoutesOptions {
@@ -43,6 +47,16 @@ export function sharePointRoutes(app: FastifyInstance, opts: SharePointRoutesOpt
     }
   })
 
+  app.post(SHAREPOINT_ROUTE_PATHS.preview, async (request, reply) => {
+    try {
+      const input = parsePreviewBody(request.body)
+      const ctx = await resolveContext(request, opts)
+      return safePreviewResultForRoute(await opts.provider.createOfficePreviewUrl(input, ctx))
+    } catch (error) {
+      return sendSharePointRouteError(reply, error)
+    }
+  })
+
   done()
 }
 
@@ -50,6 +64,37 @@ function safeStatusForRoute(status: IntegrationAuthState): Record<string, string
   if (status.status === "needs_auth") return { status: "needs_auth" }
   if (status.status === "pending_auth") return { status: "pending_auth" }
   return status
+}
+
+function safePreviewResultForRoute(result: CreateOfficePreviewUrlResult): CreateOfficePreviewUrlResult {
+  if (!isHttpsUrl(result.getUrl)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE, "SharePoint preview provider returned an invalid preview URL", 502)
+  }
+  return result.expiresAt ? { getUrl: result.getUrl, expiresAt: result.expiresAt } : { getUrl: result.getUrl }
+}
+
+function parsePreviewBody(body: unknown): SharePointDocumentRef | CreateOfficePreviewUrlInput {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "preview request body must be an object")
+  }
+  const candidate = body as Record<string, unknown>
+  if (candidate.ref !== undefined) {
+    const ref = parseSharePointDocumentRef(candidate.ref)
+    assertSharePointDocumentRefSafeForStorage(ref)
+    return ref
+  }
+  const input = {
+    driveId: optionalString(candidate.driveId),
+    driveItemId: optionalString(candidate.driveItemId),
+    viewer: optionalString(candidate.viewer),
+  }
+  if (!input.driveId || !input.driveItemId) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "preview requires ref or driveId + driveItemId")
+  }
+  if (input.viewer !== undefined && input.viewer !== "office") {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "preview viewer must be office")
+  }
+  return input.viewer ? { driveId: input.driveId, driveItemId: input.driveItemId, viewer: input.viewer } : { driveId: input.driveId, driveItemId: input.driveItemId }
 }
 
 function parseResolveBody(body: unknown): ResolveDriveItemInput {
@@ -81,6 +126,15 @@ function sendSharePointRouteError(reply: FastifyReply, error: unknown) {
     return reply.code(400).send({ error: error.code, message: error.message })
   }
   return reply.code(500).send({ error: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: "SharePoint provider request failed" })
+}
+
+function isHttpsUrl(value: unknown): value is string {
+  if (typeof value !== "string") return false
+  try {
+    return new URL(value).protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 function optionalString(value: unknown): string | undefined {

--- a/plugins/boring-sharepoint/src/server/routes.ts
+++ b/plugins/boring-sharepoint/src/server/routes.ts
@@ -14,6 +14,9 @@ import {
 } from "../shared"
 import { SharePointProviderError } from "./sharePointProvider"
 
+const SHAREPOINT_DURABLE_ID_PATTERN = /^[A-Za-z0-9._~!$'(),;=:@+-]{1,512}$/
+const SECRET_LIKE_ID_PATTERN = /([?&#](access_token|refresh_token|id_token|authorization|cookie)=)|Bearer\s+|token|secret|cookie|authorization/i
+
 export const SHAREPOINT_ROUTE_PATHS = {
   status: "/api/sharepoint/status",
   resolve: "/api/sharepoint/resolve",
@@ -91,10 +94,21 @@ function parsePreviewBody(body: unknown): SharePointDocumentRef | CreateOfficePr
   if (!input.driveId || !input.driveItemId) {
     throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "preview requires ref or driveId + driveItemId")
   }
+  validateDurablePreviewId(input.driveId, "driveId")
+  validateDurablePreviewId(input.driveItemId, "driveItemId")
   if (input.viewer !== undefined && input.viewer !== "office") {
     throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "preview viewer must be office")
   }
   return input.viewer ? { driveId: input.driveId, driveItemId: input.driveItemId, viewer: input.viewer } : { driveId: input.driveId, driveItemId: input.driveItemId }
+}
+
+function validateDurablePreviewId(value: string, label: "driveId" | "driveItemId"): void {
+  if (SECRET_LIKE_ID_PATTERN.test(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET, `${label} contains forbidden credential-like data`)
+  }
+  if (!SHAREPOINT_DURABLE_ID_PATTERN.test(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} must be a valid SharePoint durable identifier`)
+  }
 }
 
 function parseResolveBody(body: unknown): ResolveDriveItemInput {

--- a/plugins/boring-sharepoint/src/server/serverPlugin.ts
+++ b/plugins/boring-sharepoint/src/server/serverPlugin.ts
@@ -34,7 +34,7 @@ export function createSharePointServerPlugin(options: SharePointServerPluginOpti
     id: BORING_SHAREPOINT_PLUGIN_ID,
     label: BORING_SHAREPOINT_PLUGIN_LABEL,
     systemPrompt:
-      "SharePoint / Microsoft 365 integration is installed. It can resolve SharePoint-hosted Excel and PowerPoint documents into cloud refs; preview and Office edits are not enabled yet.",
+      "SharePoint / Microsoft 365 integration is installed. It can resolve SharePoint-hosted Excel and PowerPoint documents into cloud refs and request transient Office preview URLs on demand; Office edits are not enabled yet.",
     routes,
   })
 }
@@ -65,7 +65,7 @@ class UnconfiguredSharePointProvider implements SharePointProvider {
   }
 
   async createOfficePreviewUrl(): Promise<CreateOfficePreviewUrlResult> {
-    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE, "SharePoint Office preview URLs are not implemented yet", 501)
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE, this.message, 503)
   }
 
   async editOfficeDocument(_ref: SharePointDocumentRef, _request: OfficeEditRequest): Promise<OfficeEditResult> {

--- a/plugins/boring-sharepoint/src/server/sharePointProvider.ts
+++ b/plugins/boring-sharepoint/src/server/sharePointProvider.ts
@@ -3,6 +3,7 @@ import {
   SharePointRefValidationError,
   expectedMimeTypeForOfficeKind,
   parseSharePointDocumentRef,
+  type CreateOfficePreviewUrlInput,
   type IntegrationAuthState,
   type OfficeEditRequest,
   type OfficeEditResult,
@@ -21,6 +22,7 @@ export const ARCADE_SHAREPOINT_TOOL_NAMES = {
   getSite: "MicrosoftSharepoint_GetSite",
   getDriveItem: "MicrosoftSharepoint_GetDriveItem",
   getDriveItemByUrl: "MicrosoftSharepoint_GetDriveItemByUrl",
+  createPreviewUrl: "BoringSharePoint_CreatePreviewUrl",
 } as const
 
 export interface ArcadeSharePointProviderOptions {
@@ -90,12 +92,17 @@ export class ArcadeSharePointProvider implements SharePointProvider {
     return toSharePointDocumentRef({ site, item })
   }
 
-  async createOfficePreviewUrl(): Promise<CreateOfficePreviewUrlResult> {
-    throw new SharePointProviderError(
-      SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE,
-      "SharePoint Office preview URLs are not implemented in this read-only discovery slice",
-      501,
-    )
+  async createOfficePreviewUrl(input: SharePointDocumentRef | CreateOfficePreviewUrlInput, ctx: SharePointProviderContext): Promise<CreateOfficePreviewUrlResult> {
+    const response = await this.runtime.executeTool({
+      toolName: this.tools.createPreviewUrl,
+      userId: ctx.actorUserId,
+      input: {
+        drive_id: input.driveId,
+        item_id: input.driveItemId,
+        viewer: "viewer" in input && input.viewer ? input.viewer : "office",
+      },
+    })
+    return toOfficePreviewUrlResult(response, this.tools.createPreviewUrl)
   }
 
   async editOfficeDocument(_ref: SharePointDocumentRef, _request: OfficeEditRequest): Promise<OfficeEditResult> {
@@ -138,6 +145,20 @@ export class ArcadeSharePointProvider implements SharePointProvider {
     })
     return unwrapArcadeValueObject(response, this.tools.getDriveItem)
   }
+}
+
+export function toOfficePreviewUrlResult(response: unknown, toolName = ARCADE_SHAREPOINT_TOOL_NAMES.createPreviewUrl): CreateOfficePreviewUrlResult {
+  const value = unwrapArcadeValueObject(response, toolName)
+  const getUrl = optionalString(value, ["getUrl", "get_url"])
+  if (!getUrl || !isHttpsUrl(getUrl)) {
+    throw new SharePointProviderError(
+      SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE,
+      `${toolName} did not return a valid HTTPS preview URL`,
+      502,
+    )
+  }
+  const expiresAt = optionalString(value, ["expiresAt", "expires_at", "expirationDateTime", "expiration_date_time"])
+  return expiresAt ? { getUrl, expiresAt } : { getUrl }
 }
 
 export function toSharePointDocumentRef(input: { site?: Record<string, unknown>; item: Record<string, unknown> }): SharePointDocumentRef {
@@ -207,6 +228,14 @@ function officeKindFromName(name: string): "excel" | "powerpoint" | null {
   if (name.endsWith(".xlsx")) return "excel"
   if (name.endsWith(".pptx")) return "powerpoint"
   return null
+}
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:"
+  } catch {
+    return false
+  }
 }
 
 function requireString(object: Record<string, unknown> | undefined, paths: string[], label: string): string {

--- a/plugins/boring-sharepoint/src/shared/types.ts
+++ b/plugins/boring-sharepoint/src/shared/types.ts
@@ -93,6 +93,6 @@ export interface SharePointProvider {
   getStatus(ctx: SharePointProviderContext): Promise<IntegrationAuthState>
   authorize(ctx: SharePointProviderContext): Promise<IntegrationAuthState>
   resolveDriveItem(input: ResolveDriveItemInput, ctx: SharePointProviderContext): Promise<SharePointDocumentRef>
-  createOfficePreviewUrl(ref: SharePointDocumentRef, ctx: SharePointProviderContext): Promise<CreateOfficePreviewUrlResult>
+  createOfficePreviewUrl(input: SharePointDocumentRef | CreateOfficePreviewUrlInput, ctx: SharePointProviderContext): Promise<CreateOfficePreviewUrlResult>
   editOfficeDocument(ref: SharePointDocumentRef, request: OfficeEditRequest, ctx: SharePointProviderContext): Promise<OfficeEditResult>
 }


### PR DESCRIPTION
## Summary
- add custom Arcade preview tool contract via BoringSharePoint_CreatePreviewUrl
- add plugin-owned POST /api/sharepoint/preview route with ref/id validation
- fetch transient preview URLs on demand in the Office preview panel and render an iframe
- document custom Arcade tool deployment/runbook and no-persistence rule

## Validation
- pnpm --filter @hachej/boring-sharepoint test
- pnpm --filter @hachej/boring-sharepoint typecheck
- pnpm --filter @hachej/boring-sharepoint build

## Notes
- Custom Arcade tool deployment is an operator step; tests are mocked only.
- No direct Microsoft Graph calls in boring-ui code; no Office edit/import behavior.