### PR TITLE
sharepoint-plug: add Office edit route

### DIFF
--- a/plugins/boring-sharepoint/README.md
+++ b/plugins/boring-sharepoint/README.md
@@ -2,7 +2,7 @@
 
 App/internal plugin shell for SharePoint / Microsoft 365 Office document support in boring-ui.
 
-This package is intentionally a trusted app/internal plugin, not a runtime-generated `.pi/extensions` plugin. The current stack includes the plugin shell, Office cloud-ref display wiring, Arcade runtime primitives, read-only SharePoint discovery/status, and on-demand Office preview. Future PRs will add Office agent edits and import flows behind these contracts.
+This package is intentionally a trusted app/internal plugin, not a runtime-generated `.pi/extensions` plugin. The current stack includes the plugin shell, Office cloud-ref display wiring, Arcade runtime primitives, read-only SharePoint discovery/status, on-demand Office preview, and V1 Office agent edit primitives. Future PRs will add import flows behind these contracts.
 
 ## Trust boundary
 
@@ -41,7 +41,8 @@ This workbook will become the operator guide as implementation PRs land.
 5. **Validate V1 flows**
    - Open in SharePoint using `webUrl`.
    - Preview in boring-ui through `POST /api/sharepoint/preview`, which requests a transient preview URL on demand.
-   - Agent-edit Excel and PowerPoint once edit providers land.
+   - Agent-edit Excel via `POST /api/sharepoint/edit` with `{ kind: "excel.add-worksheet", worksheetName }`.
+   - Agent-edit PowerPoint via `POST /api/sharepoint/edit` with `{ kind: "powerpoint.create-slide", title, body?, layout? }`.
 6. **Troubleshooting**
    - Auth required: reconnect SharePoint/Microsoft 365.
    - Admin consent required: tenant admin must approve Microsoft scopes.
@@ -75,17 +76,19 @@ The app-left action and command open the SharePoint / Microsoft 365 status surfa
 
 ## Current scope
 
-This PR adds on-demand Office preview on top of the shell/display/runtime/discovery stack:
+This PR adds V1 Office agent edit primitives on top of the shell/display/runtime/discovery/preview stack:
 
 - `ArcadeSharePointProvider.createOfficePreviewUrl()` calls the plugin-owned custom Arcade tool `BoringSharePoint_CreatePreviewUrl` with `{ drive_id, item_id, viewer: "office" }` and normalizes `{ getUrl, expiresAt? }`.
 - `POST /api/sharepoint/preview` accepts either `{ ref }` with a canonical SharePoint document ref or `{ driveId, driveItemId }` durable identity and returns the transient preview result only.
-- The preview route validates canonical refs and rejects token-bearing ref input before calling the provider.
-- The Office preview panel requests the preview URL only while rendering and stores it only in React component state.
+- `ArcadeSharePointProvider.editOfficeDocument()` supports V1 edit requests:
+  - Excel: `excel.add-worksheet` calls `MicrosoftSharepoint_AddWorksheet` with `{ drive_id, item_id, worksheet_name }`, then `MicrosoftSharepoint_GetWorkbookMetadata` with `{ drive_id, item_id, session_id? }` when a workbook session id is available.
+  - PowerPoint: `powerpoint.create-slide` calls assumed Arcade SharePoint tool `MicrosoftSharepoint_CreateSlide` with `{ drive_id, item_id, title, body?, layout? }`.
+- `POST /api/sharepoint/edit` accepts `{ ref, request }`, validates the canonical ref and edit request, and returns a stable `OfficeEditResult` without raw backend metadata or preview URLs.
+- Edit request validation rejects ref/kind mismatches, empty/oversized worksheet or slide fields, and credential-like text before provider calls.
 - Preview `getUrl` values are never stored in cloud-ref metadata, route logs, route errors, or session storage.
-- The custom Arcade tool deploy/register step remains an operator runbook task; this repo contains the contract/runtime call and mocked tests only.
+- PowerPoint tool shape is inferred for this mocked slice; confirm against live Arcade tool metadata before promoting from draft.
 - Tests use mocked Arcade/provider calls only.
 - no Microsoft Graph direct calls in boring-ui code
 - no Claude MCP/local MCP gateway dependency
-- no Office edit calls
 - no local import/upload
 - no SharePoint-specific workspace chrome branches

--- a/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
@@ -25,6 +25,19 @@ const xlsxItemValue = {
   file: { mimeType: EXCEL_MIME_TYPE },
 }
 
+const xlsxRef = {
+  kind: "office-cloud-document" as const,
+  provider: "sharepoint" as const,
+  version: 1 as const,
+  name: xlsxItemValue.name,
+  officeKind: "excel" as const,
+  mimeType: EXCEL_MIME_TYPE,
+  webUrl: xlsxItemValue.webUrl,
+  siteId: siteValue.id,
+  driveId: xlsxItemValue.parentReference.driveId,
+  driveItemId: xlsxItemValue.id,
+}
+
 const pptxItemValue = {
   id: "01ROJOXDM7345DEYRHSFE2K7NEHOW6X3P2",
   name: "tttt.pptx",
@@ -34,6 +47,19 @@ const pptxItemValue = {
     site_id: siteValue.id,
   },
   file: { mime_type: POWERPOINT_MIME_TYPE },
+}
+
+const pptxRef = {
+  kind: "office-cloud-document" as const,
+  provider: "sharepoint" as const,
+  version: 1 as const,
+  name: pptxItemValue.name,
+  officeKind: "powerpoint" as const,
+  mimeType: POWERPOINT_MIME_TYPE,
+  webUrl: pptxItemValue.web_url,
+  siteId: siteValue.id,
+  driveId: pptxItemValue.parent_reference.drive_id,
+  driveItemId: pptxItemValue.id,
 }
 
 describe("ArcadeSharePointProvider", () => {
@@ -149,6 +175,83 @@ describe("ArcadeSharePointProvider", () => {
       code: SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE,
       message: expect.not.stringContaining("http://tenant/preview"),
     })
+  })
+
+  it("adds an Excel worksheet through Arcade and returns a sanitized edit result", async () => {
+    const executeTool = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: { value: { session_id: "session-123" } } })
+      .mockResolvedValueOnce({ success: true, output: { value: { workbook: { worksheets: ["Forecast"] }, getUrl: "https://tenant/preview?token=raw" } } })
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    await expect(provider.editOfficeDocument(xlsxRef, { kind: "excel.add-worksheet", worksheetName: "Forecast" }, ctx)).resolves.toEqual({
+      status: "succeeded",
+      summary: "Added worksheet Forecast to tttt.xlsx",
+      sessionId: "session-123",
+    })
+    expect(executeTool).toHaveBeenNthCalledWith(1, {
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.addWorksheet,
+      userId: ctx.actorUserId,
+      input: { drive_id: xlsxRef.driveId, item_id: xlsxRef.driveItemId, worksheet_name: "Forecast" },
+    })
+    expect(executeTool).toHaveBeenNthCalledWith(2, {
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.getWorkbookMetadata,
+      userId: ctx.actorUserId,
+      input: { drive_id: xlsxRef.driveId, item_id: xlsxRef.driveItemId, session_id: "session-123" },
+    })
+  })
+
+  it("creates a PowerPoint slide through the assumed Arcade SharePoint tool", async () => {
+    const executeTool = vi.fn().mockResolvedValue({ success: true, output: { value: { slideId: "slide-1", previewUrl: "https://tenant/preview?token=raw" } } })
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    await expect(
+      provider.editOfficeDocument(
+        pptxRef,
+        { kind: "powerpoint.create-slide", title: "Q3 update", body: "Revenue improved.", layout: "TITLE_AND_CONTENT" },
+        ctx,
+      ),
+    ).resolves.toEqual({ status: "succeeded", summary: "Created PowerPoint slide in tttt.pptx" })
+    expect(executeTool).toHaveBeenCalledWith({
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.createSlide,
+      userId: ctx.actorUserId,
+      input: {
+        drive_id: pptxRef.driveId,
+        item_id: pptxRef.driveItemId,
+        title: "Q3 update",
+        body: "Revenue improved.",
+        layout: "TITLE_AND_CONTENT",
+      },
+    })
+  })
+
+  it("rejects Office edit kind/ref mismatches before Arcade calls", async () => {
+    const executeTool = vi.fn()
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    await expect(provider.editOfficeDocument(xlsxRef, { kind: "powerpoint.create-slide", title: "Wrong file" }, ctx)).rejects.toMatchObject({
+      code: SHAREPOINT_ERROR_CODES.EDIT_CONFLICT,
+    } satisfies Partial<SharePointProviderError>)
+    await expect(provider.editOfficeDocument(pptxRef, { kind: "excel.add-worksheet", worksheetName: "Wrong" }, ctx)).rejects.toMatchObject({
+      code: SHAREPOINT_ERROR_CODES.EDIT_CONFLICT,
+    } satisfies Partial<SharePointProviderError>)
+    expect(executeTool).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid Office edit fields before Arcade calls", async () => {
+    const executeTool = vi.fn()
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    await expect(provider.editOfficeDocument(xlsxRef, { kind: "excel.add-worksheet", worksheetName: "" }, ctx)).rejects.toMatchObject({
+      code: SHAREPOINT_ERROR_CODES.INVALID_REF,
+    } satisfies Partial<SharePointProviderError>)
+    await expect(provider.editOfficeDocument(xlsxRef, { kind: "excel.add-worksheet", worksheetName: "x".repeat(32) }, ctx)).rejects.toMatchObject({
+      code: SHAREPOINT_ERROR_CODES.INVALID_REF,
+    } satisfies Partial<SharePointProviderError>)
+    await expect(provider.editOfficeDocument(pptxRef, { kind: "powerpoint.create-slide", title: "Bearer secret-token" }, ctx)).rejects.toMatchObject({
+      code: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET,
+    } satisfies Partial<SharePointProviderError>)
+    expect(executeTool).not.toHaveBeenCalled()
   })
 
   it("rejects mismatched Office extension and MIME metadata with a stable code", async () => {

--- a/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
@@ -248,6 +248,9 @@ describe("ArcadeSharePointProvider", () => {
     await expect(provider.editOfficeDocument(xlsxRef, { kind: "excel.add-worksheet", worksheetName: "x".repeat(32) }, ctx)).rejects.toMatchObject({
       code: SHAREPOINT_ERROR_CODES.INVALID_REF,
     } satisfies Partial<SharePointProviderError>)
+    await expect(provider.editOfficeDocument(xlsxRef, { kind: "excel.add-worksheet", worksheetName: ` ${"x".repeat(31)} ` }, ctx)).rejects.toMatchObject({
+      code: SHAREPOINT_ERROR_CODES.INVALID_REF,
+    } satisfies Partial<SharePointProviderError>)
     await expect(provider.editOfficeDocument(pptxRef, { kind: "powerpoint.create-slide", title: "Bearer secret-token" }, ctx)).rejects.toMatchObject({
       code: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET,
     } satisfies Partial<SharePointProviderError>)

--- a/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
@@ -1,6 +1,6 @@
 import Fastify from "fastify"
 import { afterEach, describe, expect, it, vi } from "vitest"
-import { EXCEL_MIME_TYPE, SHAREPOINT_ERROR_CODES, type SharePointProvider } from "../shared"
+import { EXCEL_MIME_TYPE, POWERPOINT_MIME_TYPE, SHAREPOINT_ERROR_CODES, type SharePointProvider } from "../shared"
 import { SHAREPOINT_ROUTE_PATHS, sharePointRoutes } from "../server/routes"
 import { SharePointProviderError } from "../server/sharePointProvider"
 
@@ -18,6 +18,15 @@ const ref = {
   driveId: "b!IDAE6E137UaSbPUsBzFAoT8qRJKUqM5LnmuJVVDbAnUI5HkM_PyuQovkEHDyaz3G",
   driveItemId: "01ROJOXDN53PWGVAWEJREZKIIY4VGYDIZ5",
   createdFrom: { type: "sharepoint" as const },
+}
+
+const pptxRef = {
+  ...ref,
+  name: "tttt.pptx",
+  officeKind: "powerpoint" as const,
+  mimeType: POWERPOINT_MIME_TYPE,
+  webUrl: "https://sumeo662.sharepoint.com/sites/sumeotest/Shared%20Documents/tttt.pptx",
+  driveItemId: "01ROJOXDM7345DEYRHSFE2K7NEHOW6X3P2",
 }
 
 afterEach(async () => {
@@ -135,6 +144,87 @@ describe("SharePoint routes", () => {
     expect(response.statusCode).toBe(400)
     expect(response.json()).toMatchObject({ error: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET })
     expect(provider.createOfficePreviewUrl).not.toHaveBeenCalled()
+  })
+
+  it("returns sanitized Office edit results from the edit route", async () => {
+    const provider = fakeProvider({
+      editOfficeDocument: vi.fn().mockResolvedValue({
+        status: "succeeded",
+        summary: "Added worksheet Forecast to tttt.xlsx",
+        sessionId: "session-123",
+        metadata: { raw: { previewUrl: "https://tenant/preview?access_token=secret" } },
+      }),
+    })
+    const app = await testApp(provider)
+
+    const response = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.edit,
+      payload: { ref, request: { kind: "excel.add-worksheet", worksheetName: "Forecast" } },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({ status: "succeeded", summary: "Added worksheet Forecast to tttt.xlsx", sessionId: "session-123" })
+    expect(response.body).not.toMatch(/previewUrl|access_token|metadata|Bearer/i)
+    expect(provider.editOfficeDocument).toHaveBeenCalledWith(ref, { kind: "excel.add-worksheet", worksheetName: "Forecast" }, { workspaceId: "default", actorUserId: "anonymous" })
+  })
+
+  it("accepts PowerPoint edit requests through the edit route", async () => {
+    const provider = fakeProvider({ editOfficeDocument: vi.fn().mockResolvedValue({ status: "succeeded", summary: "Created PowerPoint slide in tttt.pptx" }) })
+    const app = await testApp(provider)
+
+    const response = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.edit,
+      payload: { ref: pptxRef, request: { kind: "powerpoint.create-slide", title: "Q3 update", body: "Revenue improved.", layout: "TITLE_AND_CONTENT" } },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toEqual({ status: "succeeded", summary: "Created PowerPoint slide in tttt.pptx" })
+    expect(provider.editOfficeDocument).toHaveBeenCalledWith(
+      pptxRef,
+      { kind: "powerpoint.create-slide", title: "Q3 update", body: "Revenue improved.", layout: "TITLE_AND_CONTENT" },
+      { workspaceId: "default", actorUserId: "anonymous" },
+    )
+  })
+
+  it("rejects mismatched or invalid edit route input before provider calls", async () => {
+    const provider = fakeProvider({ editOfficeDocument: vi.fn() })
+    const app = await testApp(provider)
+
+    const mismatch = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.edit,
+      payload: { ref, request: { kind: "powerpoint.create-slide", title: "Wrong file" } },
+    })
+    expect(mismatch.statusCode).toBe(400)
+    expect(mismatch.json()).toMatchObject({ error: SHAREPOINT_ERROR_CODES.EDIT_CONFLICT })
+
+    const invalid = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.edit,
+      payload: { ref, request: { kind: "excel.add-worksheet", worksheetName: "Bearer secret-token" } },
+    })
+    expect(invalid.statusCode).toBe(400)
+    expect(invalid.json()).toMatchObject({ error: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET })
+    expect(invalid.body).not.toMatch(/secret-token|Bearer/i)
+    expect(provider.editOfficeDocument).not.toHaveBeenCalled()
+  })
+
+  it("rejects token-bearing edit refs before provider calls", async () => {
+    const provider = fakeProvider({ editOfficeDocument: vi.fn() })
+    const app = await testApp(provider)
+
+    const response = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.edit,
+      payload: { ref: { ...ref, previewUrl: "https://tenant/preview?access_token=secret" }, request: { kind: "excel.add-worksheet", worksheetName: "Forecast" } },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toMatchObject({ error: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET })
+    expect(response.body).not.toMatch(/access_token=secret|previewUrl/)
+    expect(provider.editOfficeDocument).not.toHaveBeenCalled()
   })
 
   it("rejects route errors with stable JSON", async () => {

--- a/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
@@ -211,6 +211,49 @@ describe("SharePoint routes", () => {
     expect(provider.editOfficeDocument).not.toHaveBeenCalled()
   })
 
+  it("allow-lists failed and conflict edit route results", async () => {
+    const app = await testApp(
+      fakeProvider({
+        editOfficeDocument: vi.fn().mockResolvedValueOnce({
+          status: "failed",
+          code: SHAREPOINT_ERROR_CODES.PROVIDER_TOOL_FAILED,
+          message: "backend failed with previewUrl https://tenant/preview?access_token=secret",
+          metadata: { raw: "secret" },
+          getUrl: "https://tenant/preview?access_token=secret",
+          authorizationUrl: "https://arcade.dev/auth?token=secret",
+        } as never),
+      }),
+    )
+
+    const failed = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.edit,
+      payload: { ref, request: { kind: "excel.add-worksheet", worksheetName: "Forecast" } },
+    })
+
+    expect(failed.statusCode).toBe(200)
+    expect(failed.json()).toEqual({ status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_TOOL_FAILED, message: "SharePoint Office edit failed" })
+    expect(failed.body).not.toMatch(/metadata|getUrl|authorizationUrl|access_token|previewUrl|secret/i)
+
+    const conflictProvider = fakeProvider({
+      editOfficeDocument: vi.fn().mockResolvedValue({
+        status: "conflict",
+        code: SHAREPOINT_ERROR_CODES.EDIT_CONFLICT,
+        message: "edit conflict",
+        previewUrl: "https://tenant/preview?access_token=secret",
+      } as never),
+    })
+    const conflictApp = await testApp(conflictProvider)
+    const conflict = await conflictApp.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.edit,
+      payload: { ref, request: { kind: "excel.add-worksheet", worksheetName: "Forecast" } },
+    })
+
+    expect(conflict.json()).toEqual({ status: "conflict", code: SHAREPOINT_ERROR_CODES.EDIT_CONFLICT, message: "edit conflict" })
+    expect(conflict.body).not.toMatch(/previewUrl|access_token/)
+  })
+
   it("rejects token-bearing edit refs before provider calls", async () => {
     const provider = fakeProvider({ editOfficeDocument: vi.fn() })
     const app = await testApp(provider)

--- a/plugins/boring-sharepoint/src/server/routes.ts
+++ b/plugins/boring-sharepoint/src/server/routes.ts
@@ -7,12 +7,14 @@ import {
   type CreateOfficePreviewUrlInput,
   type CreateOfficePreviewUrlResult,
   type IntegrationAuthState,
+  type OfficeEditRequest,
+  type OfficeEditResult,
   type ResolveDriveItemInput,
   type SharePointDocumentRef,
   type SharePointProvider,
   type SharePointProviderContext,
 } from "../shared"
-import { SharePointProviderError } from "./sharePointProvider"
+import { SharePointProviderError, validateOfficeEditRequestForRef } from "./sharePointProvider"
 
 const SHAREPOINT_DURABLE_ID_PATTERN = /^[A-Za-z0-9._~!$'(),;=:@+-]{1,512}$/
 const SECRET_LIKE_ID_PATTERN = /([?&#](access_token|refresh_token|id_token|authorization|cookie)=)|Bearer\s+|token|secret|cookie|authorization/i
@@ -21,6 +23,7 @@ export const SHAREPOINT_ROUTE_PATHS = {
   status: "/api/sharepoint/status",
   resolve: "/api/sharepoint/resolve",
   preview: "/api/sharepoint/preview",
+  edit: "/api/sharepoint/edit",
 } as const
 
 export interface SharePointRoutesOptions {
@@ -60,6 +63,16 @@ export function sharePointRoutes(app: FastifyInstance, opts: SharePointRoutesOpt
     }
   })
 
+  app.post(SHAREPOINT_ROUTE_PATHS.edit, async (request, reply) => {
+    try {
+      const { ref, editRequest } = parseEditBody(request.body)
+      const ctx = await resolveContext(request, opts)
+      return safeOfficeEditResultForRoute(await opts.provider.editOfficeDocument(ref, editRequest, ctx))
+    } catch (error) {
+      return sendSharePointRouteError(reply, error)
+    }
+  })
+
   done()
 }
 
@@ -74,6 +87,65 @@ function safePreviewResultForRoute(result: CreateOfficePreviewUrlResult): Create
     throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.PREVIEW_UNAVAILABLE, "SharePoint preview provider returned an invalid preview URL", 502)
   }
   return result.expiresAt ? { getUrl: result.getUrl, expiresAt: result.expiresAt } : { getUrl: result.getUrl }
+}
+
+function safeOfficeEditResultForRoute(result: OfficeEditResult): OfficeEditResult {
+  if (result.status === "succeeded") {
+    return result.sessionId
+      ? { status: "succeeded", summary: safeRouteMessage(result.summary, "Office edit succeeded"), sessionId: safeRouteMessage(result.sessionId, "session-redacted") }
+      : { status: "succeeded", summary: safeRouteMessage(result.summary, "Office edit succeeded") }
+  }
+  if (result.status === "needs_auth") {
+    return { status: "failed", code: SHAREPOINT_ERROR_CODES.AUTH_REQUIRED, message: "SharePoint authorization is required" }
+  }
+  return { ...result, message: safeRouteMessage(result.message, "SharePoint Office edit failed") }
+}
+
+function parseEditBody(body: unknown): { ref: SharePointDocumentRef; editRequest: OfficeEditRequest } {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "edit request body must be an object")
+  }
+  const candidate = body as Record<string, unknown>
+  const ref = parseSharePointDocumentRef(candidate.ref)
+  assertSharePointDocumentRefSafeForStorage(ref)
+  const editRequest = parseOfficeEditRequest(candidate.request)
+  validateOfficeEditRequestForRef(ref, editRequest)
+  return { ref, editRequest }
+}
+
+function parseOfficeEditRequest(value: unknown): OfficeEditRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "edit request must be an object")
+  }
+  const candidate = value as Record<string, unknown>
+  if (candidate.kind === "excel.add-worksheet") {
+    return { kind: "excel.add-worksheet", worksheetName: requireBodyString(candidate.worksheetName, "worksheetName") }
+  }
+  if (candidate.kind === "powerpoint.create-slide") {
+    return {
+      kind: "powerpoint.create-slide",
+      title: requireBodyString(candidate.title, "title"),
+      ...(candidate.body !== undefined ? { body: requireBodyString(candidate.body, "body") } : {}),
+      ...(candidate.layout !== undefined ? { layout: parsePowerPointLayout(candidate.layout) } : {}),
+    }
+  }
+  throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "unsupported Office edit request kind")
+}
+
+function parsePowerPointLayout(value: unknown): "TITLE_AND_CONTENT" | "TITLE_ONLY" | "BLANK" | "TWO_CONTENT" {
+  if (value === "TITLE_AND_CONTENT" || value === "TITLE_ONLY" || value === "BLANK" || value === "TWO_CONTENT") return value
+  throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "PowerPoint slide layout is not supported")
+}
+
+function requireBodyString(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} must be a string`)
+  }
+  return value
+}
+
+function safeRouteMessage(value: string, fallback: string): string {
+  return SECRET_LIKE_ID_PATTERN.test(value) || /preview|getUrl|access_token|refresh_token|id_token/i.test(value) ? fallback : value
 }
 
 function parsePreviewBody(body: unknown): SharePointDocumentRef | CreateOfficePreviewUrlInput {
@@ -137,7 +209,10 @@ function sendSharePointRouteError(reply: FastifyReply, error: unknown) {
     return reply.code(error.statusCode).send({ error: error.code, message: error.message })
   }
   if (error instanceof SharePointRefValidationError) {
-    return reply.code(400).send({ error: error.code, message: error.message })
+    return reply.code(400).send({
+      error: error.code,
+      message: error.code === SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET ? "SharePoint request contains forbidden credential-like data" : error.message,
+    })
   }
   return reply.code(500).send({ error: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: "SharePoint provider request failed" })
 }

--- a/plugins/boring-sharepoint/src/server/routes.ts
+++ b/plugins/boring-sharepoint/src/server/routes.ts
@@ -98,7 +98,10 @@ function safeOfficeEditResultForRoute(result: OfficeEditResult): OfficeEditResul
   if (result.status === "needs_auth") {
     return { status: "failed", code: SHAREPOINT_ERROR_CODES.AUTH_REQUIRED, message: "SharePoint authorization is required" }
   }
-  return { ...result, message: safeRouteMessage(result.message, "SharePoint Office edit failed") }
+  if (result.status === "conflict") {
+    return { status: "conflict", code: result.code, message: safeRouteMessage(result.message, "SharePoint Office edit conflict") }
+  }
+  return { status: "failed", code: result.code, message: safeRouteMessage(result.message, "SharePoint Office edit failed") }
 }
 
 function parseEditBody(body: unknown): { ref: SharePointDocumentRef; editRequest: OfficeEditRequest } {

--- a/plugins/boring-sharepoint/src/server/sharePointProvider.ts
+++ b/plugins/boring-sharepoint/src/server/sharePointProvider.ts
@@ -214,7 +214,7 @@ function validateEditText(value: string, label: string, maxLength: number): void
   if (trimmed.length === 0) {
     throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} must be a non-empty string`)
   }
-  if (trimmed.length > maxLength) {
+  if (value.length > maxLength) {
     throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} must be ${maxLength} characters or fewer`)
   }
   if (EDIT_SECRET_LIKE_PATTERN.test(value)) {

--- a/plugins/boring-sharepoint/src/server/sharePointProvider.ts
+++ b/plugins/boring-sharepoint/src/server/sharePointProvider.ts
@@ -23,6 +23,9 @@ export const ARCADE_SHAREPOINT_TOOL_NAMES = {
   getDriveItem: "MicrosoftSharepoint_GetDriveItem",
   getDriveItemByUrl: "MicrosoftSharepoint_GetDriveItemByUrl",
   createPreviewUrl: "BoringSharePoint_CreatePreviewUrl",
+  addWorksheet: "MicrosoftSharepoint_AddWorksheet",
+  getWorkbookMetadata: "MicrosoftSharepoint_GetWorkbookMetadata",
+  createSlide: "MicrosoftSharepoint_CreateSlide",
 } as const
 
 export interface ArcadeSharePointProviderOptions {
@@ -105,12 +108,53 @@ export class ArcadeSharePointProvider implements SharePointProvider {
     return toOfficePreviewUrlResult(response, this.tools.createPreviewUrl)
   }
 
-  async editOfficeDocument(_ref: SharePointDocumentRef, _request: OfficeEditRequest): Promise<OfficeEditResult> {
-    return {
-      status: "failed",
-      code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE,
-      message: "SharePoint Office edits are not implemented in this read-only discovery slice",
+  async editOfficeDocument(ref: SharePointDocumentRef, request: OfficeEditRequest, ctx: SharePointProviderContext): Promise<OfficeEditResult> {
+    validateOfficeEditRequestForRef(ref, request)
+
+    if (request.kind === "excel.add-worksheet") {
+      const addResponse = await this.runtime.executeTool({
+        toolName: this.tools.addWorksheet,
+        userId: ctx.actorUserId,
+        input: {
+          drive_id: ref.driveId,
+          item_id: ref.driveItemId,
+          worksheet_name: request.worksheetName,
+        },
+      })
+      const addValue = unwrapArcadeValueObject(addResponse, this.tools.addWorksheet)
+      const sessionId = optionalString(addValue, ["sessionId", "session_id", "workbookSessionId", "workbook_session_id"])
+
+      const metadataInput: Record<string, unknown> = {
+        drive_id: ref.driveId,
+        item_id: ref.driveItemId,
+      }
+      if (sessionId) metadataInput.session_id = sessionId
+      const metadataResponse = await this.runtime.executeTool({
+        toolName: this.tools.getWorkbookMetadata,
+        userId: ctx.actorUserId,
+        input: metadataInput,
+      })
+      const metadataValue = unwrapArcadeValueObject(metadataResponse, this.tools.getWorkbookMetadata)
+      const normalizedSessionId = sessionId ?? optionalString(metadataValue, ["sessionId", "session_id", "workbookSessionId", "workbook_session_id"])
+
+      return normalizedSessionId
+        ? { status: "succeeded", summary: `Added worksheet ${request.worksheetName} to ${ref.name}`, sessionId: normalizedSessionId }
+        : { status: "succeeded", summary: `Added worksheet ${request.worksheetName} to ${ref.name}` }
     }
+
+    const response = await this.runtime.executeTool({
+      toolName: this.tools.createSlide,
+      userId: ctx.actorUserId,
+      input: {
+        drive_id: ref.driveId,
+        item_id: ref.driveItemId,
+        title: request.title,
+        ...(request.body ? { body: request.body } : {}),
+        ...(request.layout ? { layout: request.layout } : {}),
+      },
+    })
+    unwrapArcadeValueObject(response, this.tools.createSlide)
+    return { status: "succeeded", summary: `Created PowerPoint slide in ${ref.name}` }
   }
 
   private async getSite(siteUrl: string, ctx: SharePointProviderContext): Promise<Record<string, unknown>> {
@@ -144,6 +188,37 @@ export class ArcadeSharePointProvider implements SharePointProvider {
       input: { drive_id: input.driveId, item_id: input.driveItemId },
     })
     return unwrapArcadeValueObject(response, this.tools.getDriveItem)
+  }
+}
+
+const EDIT_SECRET_LIKE_PATTERN = /([?&#](access_token|refresh_token|id_token|authorization|cookie)=)|Bearer\s+|token|secret|cookie|authorization/i
+
+export function validateOfficeEditRequestForRef(ref: SharePointDocumentRef, request: OfficeEditRequest): void {
+  if (request.kind === "excel.add-worksheet") {
+    if (ref.officeKind !== "excel") {
+      throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.EDIT_CONFLICT, "Excel edit requests require an Excel SharePoint document ref")
+    }
+    validateEditText(request.worksheetName, "worksheetName", 31)
+    return
+  }
+
+  if (ref.officeKind !== "powerpoint") {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.EDIT_CONFLICT, "PowerPoint edit requests require a PowerPoint SharePoint document ref")
+  }
+  validateEditText(request.title, "title", 200)
+  if (request.body !== undefined) validateEditText(request.body, "body", 2_000)
+}
+
+function validateEditText(value: string, label: string, maxLength: number): void {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} must be a non-empty string`)
+  }
+  if (trimmed.length > maxLength) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} must be ${maxLength} characters or fewer`)
+  }
+  if (EDIT_SECRET_LIKE_PATTERN.test(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET, `${label} contains forbidden credential-like data`)
   }
 }
 


### PR DESCRIPTION
## Summary

- adds V1 Office edit execution through Arcade-backed SharePoint provider tools
- adds plugin-owned POST /api/sharepoint/edit route
- validates refs/edit requests and strips raw backend metadata from route results
- documents Excel and PowerPoint edit tool assumptions in the SharePoint runbook

## Validation

- pnpm --filter @hachej/boring-sharepoint test
- pnpm --filter @hachej/boring-sharepoint typecheck
- pnpm --filter @hachej/boring-sharepoint build

## Notes

PowerPoint create-slide tool shape is inferred/mocked as MicrosoftSharepoint_CreateSlide with { drive_id, item_id, title, body?, layout? }. Confirm against live Arcade tool metadata before undrafting.