### PR TITLE
fix(workspace): ignore invalid persisted dock layouts

### DIFF
--- a/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
+++ b/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
-import { render, screen, within } from '@testing-library/react'
+import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { act, type ReactNode } from 'react'
 import { MemoryRouter, Routes } from 'react-router-dom'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 let currentWorkspaceId: string | null = 'workspace-a'
 let routePath = '/workspace/workspace-a'
@@ -134,6 +134,10 @@ describe('CoreWorkspaceAgentFront', () => {
     window.sessionStorage.clear()
   })
 
+  afterEach(() => {
+    cleanup()
+  })
+
   it('injects the routed workspace id into workspace request headers without blocking boot gate', async () => {
     const { CoreWorkspaceAgentFront } = await importSubject()
 
@@ -161,7 +165,7 @@ describe('CoreWorkspaceAgentFront', () => {
       },
       bootPreloadPaths: ['/custom-preload'],
     })
-  })
+  }, 10_000)
 
   it('allows apps to suppress the default workspace switcher', async () => {
     const { CoreWorkspaceAgentFront } = await importSubject()

--- a/packages/workspace/src/app/front/__tests__/useWorkspaceShellCapabilitiesController.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/useWorkspaceShellCapabilitiesController.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { SurfaceOpenRequest } from '../../../shared/types/surface'
+import { useWorkspaceShellCapabilitiesController } from '../useWorkspaceShellCapabilitiesController'
+
+function Probe({ openChatPane, openSurface }: { openChatPane: (sessionId: string) => void; openSurface: (request: SurfaceOpenRequest) => void }) {
+  const [, setFloatingChatSessionId] = useState<string | null>(null)
+  const shell = useWorkspaceShellCapabilitiesController({
+    setFloatingChatSessionId,
+    openChatPane,
+    surfaceDispatch: {
+      surface: () => ({
+        openSurface,
+        openFile: vi.fn(),
+        openPanel: vi.fn(),
+        closePanel: vi.fn(),
+        navigateToLine: vi.fn(),
+        expandToFile: vi.fn(),
+        closeWorkbenchLeftPane: vi.fn(),
+        getSnapshot: () => ({ openTabs: [], activeTab: null }),
+        on: () => () => undefined,
+      }),
+      isWorkbenchOpen: () => true,
+      openWorkbench: vi.fn(),
+    },
+  })
+  return <button type="button" onClick={() => shell.openArtifact(
+    { type: 'surface', surfaceKind: 'questions', target: 'q1', params: { sessionId: 's1' } },
+    { sessionId: null, title: 'Need input', instanceId: 'ask-user:s1:q1' },
+  )}>Open question</button>
+}
+
+describe('useWorkspaceShellCapabilitiesController', () => {
+  it('opens surface artifacts with metadata params without opening chat when session option is null', async () => {
+    const user = userEvent.setup()
+    const openChatPane = vi.fn()
+    const openSurface = vi.fn()
+
+    render(<Probe openChatPane={openChatPane} openSurface={openSurface} />)
+    await user.click(screen.getByRole('button', { name: 'Open question' }))
+
+    expect(openChatPane).not.toHaveBeenCalled()
+    expect(openSurface).toHaveBeenCalledWith({
+      kind: 'questions',
+      target: 'q1',
+      filesystem: 'user',
+      meta: { sessionId: 's1' },
+    })
+  })
+})

--- a/packages/workspace/src/app/front/useWorkspaceShellCapabilitiesController.ts
+++ b/packages/workspace/src/app/front/useWorkspaceShellCapabilitiesController.ts
@@ -41,8 +41,8 @@ export function useWorkspaceShellCapabilitiesController({
           kind: artifact.surfaceKind,
           target: artifact.target,
           meta: {
+            ...(artifact.params ?? {}),
             ...(options?.sessionId ? { sessionId: options.sessionId } : {}),
-            ...(artifact.params ? { params: artifact.params } : {}),
           },
         },
       }, surfaceDispatch)

--- a/packages/workspace/src/front/chrome/artifact-surface/ArtifactSurfacePane.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/ArtifactSurfacePane.tsx
@@ -78,8 +78,15 @@ function replaceLayoutPanelId(value: unknown, from: string, to: string): unknown
   return out
 }
 
+function cloneSerializableLayout(layout: SerializedLayout): SerializedLayout {
+  return JSON.parse(JSON.stringify(layout, (_key, value) => {
+    if (typeof value === "function" || typeof value === "symbol") return undefined
+    return value
+  })) as SerializedLayout
+}
+
 function normalizePersistedFilePanelIdentity(layout: SerializedLayout): SerializedLayout {
-  const clone = structuredClone(layout) as { panels?: Record<string, unknown> }
+  const clone = cloneSerializableLayout(layout) as { panels?: Record<string, unknown> }
   const panels = clone.panels
   if (!panels || typeof panels !== "object") return clone as SerializedLayout
 

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/ArtifactSurfacePane.persistence.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/ArtifactSurfacePane.persistence.test.tsx
@@ -109,6 +109,20 @@ describe("ArtifactSurfacePane — layout persistence", () => {
     expect(parsed).toEqual({ v: 1, layout })
   })
 
+  it("drops non-serializable panel params instead of crashing persistence", () => {
+    renderPane(<ArtifactSurfacePane storageKey={KEY} />)
+    const layout = buildLayout([{ id: "p1", component: "empty", params: { path: "README.md", onDone: () => undefined } }])
+
+    expect(() => {
+      act(() => {
+        capturedProps.onLayoutChange?.(layout)
+      })
+    }).not.toThrow()
+
+    const parsed = JSON.parse(localStorage.getItem(KEY) as string)
+    expect(parsed.layout.panels.p1.params).toEqual({ path: "README.md", filesystem: "user" })
+  })
+
   it("migrates legacy persisted file panels to explicit user filesystem identity", () => {
     const layout = buildLayout([{ id: "file:README.md", component: "empty", params: { path: "README.md" } }])
     localStorage.setItem(KEY, envelope(layout))

--- a/packages/workspace/src/front/dock/DockviewShell.tsx
+++ b/packages/workspace/src/front/dock/DockviewShell.tsx
@@ -235,9 +235,17 @@ function initializeDockview(
   const api = event.api
   apiRef.current = api
 
+  let shouldAddDefaultPanels = true
   if (persistedLayout) {
-    api.fromJSON(persistedLayout)
-  } else {
+    try {
+      api.fromJSON(persistedLayout)
+      shouldAddDefaultPanels = false
+    } catch (error) {
+      console.warn("[DockviewShell] Ignoring invalid persisted layout", error)
+    }
+  }
+
+  if (shouldAddDefaultPanels) {
     let firstPanelAdded = false
     for (const group of layout.groups) {
       if (!group.panel) continue

--- a/packages/workspace/src/front/dock/__tests__/dock.test.tsx
+++ b/packages/workspace/src/front/dock/__tests__/dock.test.tsx
@@ -95,6 +95,28 @@ describe("DockviewShell", () => {
     }))
   })
 
+  it("falls back to default panels when a persisted layout is invalid", async () => {
+    const { panelRegistry, commandRegistry } = setupStoreAndRegistry()
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+    render(
+      <RegistryProvider panelRegistry={panelRegistry} commandRegistry={commandRegistry}>
+        <DockviewShell
+          layout={simpleLayout}
+          persistedLayout={{ panels: { broken: undefined } } as never}
+        />
+      </RegistryProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId("dummy-panel").length).toBeGreaterThan(0)
+    })
+    expect(warn).toHaveBeenCalledWith(
+      "[DockviewShell] Ignoring invalid persisted layout",
+      expect.anything(),
+    )
+  })
+
   it("hot-swaps an already-mounted panel when its registry entry is replaced", async () => {
     const { panelRegistry, commandRegistry } = setupStoreAndRegistry()
     panelRegistry.register("hot", { title: "Hot", component: HotPanelOne })

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -3,6 +3,12 @@
 /* @hachej/boring-ui-kit styles imported as a regular package. */
 @import "@hachej/boring-ui-kit/styles.css";
 
+/* Dockview chrome is part of the workspace global surface contract. Apps such
+ * as workspace-playground alias this file to source for HMR, so these imports
+ * must live here rather than only in component TS imports or dist CSS. */
+@import "./front/dock/dockview-overrides.css";
+@import "./front/layout/chat-pane-stage.css";
+
 /* Workspace's own components — every consumer that imports this CSS file
  * gets the utility classes used by workspace chrome, panes, ui-shadcn
  * primitives, etc. */

--- a/plugins/ask-user/src/front/inbox/WorkspaceInboxShellContext.tsx
+++ b/plugins/ask-user/src/front/inbox/WorkspaceInboxShellContext.tsx
@@ -8,7 +8,10 @@ export function useWorkspaceInboxShell(): WorkspaceInboxShellApi {
   const shell = useWorkspaceShellCapabilities()
   return useMemo<WorkspaceInboxShellApi>(() => ({
     openInboxArtifact: (item) => shell.openArtifact(item.artifact, {
-      sessionId: item.chatAvailable ? item.sessionId : null,
+      // Row clicks open the workspace artifact/question only. The explicit chat
+      // icon owns chat opening; otherwise ask-user inbox rows jump to chat
+      // instead of showing the Questions form.
+      sessionId: null,
       title: item.title,
       instanceId: item.id,
     }),

--- a/plugins/ask-user/src/front/inbox/__tests__/WorkspaceInboxShellContext.test.tsx
+++ b/plugins/ask-user/src/front/inbox/__tests__/WorkspaceInboxShellContext.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { useWorkspaceInboxShell } from '../WorkspaceInboxShellContext'
+import type { WorkspaceInboxItem } from '../inboxItemModel'
+
+const shellMock = vi.hoisted(() => ({
+  openArtifact: vi.fn(() => ({ success: true as const })),
+  openDetachedChat: vi.fn(() => ({ success: true as const })),
+}))
+
+vi.mock('@hachej/boring-workspace', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@hachej/boring-workspace')>()
+  return {
+    ...actual,
+    useWorkspaceShellCapabilities: () => shellMock,
+  }
+})
+
+const item: WorkspaceInboxItem = {
+  id: 'ask-user:s1:q1',
+  kind: 'question',
+  status: 'open',
+  title: 'Need input',
+  description: 'ask-user.question',
+  source: { type: 'plugin', pluginId: 'ask-user.question', label: 'question' },
+  sessionId: 's1',
+  chatAvailable: true,
+  targetLabel: 'q1',
+  artifact: { type: 'surface', surfaceKind: 'questions', target: 'q1', params: { sessionId: 's1' } },
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  priority: 10,
+  actions: [],
+}
+
+function Probe() {
+  const shell = useWorkspaceInboxShell()
+  return <>
+    <button type="button" onClick={() => shell.openInboxArtifact(item)}>Open artifact</button>
+    <button type="button" onClick={() => shell.openDetachedChat('s1', { title: item.title })}>Open chat</button>
+  </>
+}
+
+describe('useWorkspaceInboxShell', () => {
+  it('opens inbox artifacts without also requesting a chat pane', async () => {
+    const user = userEvent.setup()
+    shellMock.openArtifact.mockClear()
+    shellMock.openDetachedChat.mockClear()
+
+    render(<Probe />)
+    await user.click(screen.getByRole('button', { name: 'Open artifact' }))
+
+    expect(shellMock.openArtifact).toHaveBeenCalledWith(item.artifact, {
+      sessionId: null,
+      title: item.title,
+      instanceId: item.id,
+    })
+    expect(shellMock.openDetachedChat).not.toHaveBeenCalled()
+  })
+
+  it('keeps explicit chat opening separate from artifact opening', async () => {
+    const user = userEvent.setup()
+    shellMock.openArtifact.mockClear()
+    shellMock.openDetachedChat.mockClear()
+
+    render(<Probe />)
+    await user.click(screen.getByRole('button', { name: 'Open chat' }))
+
+    expect(shellMock.openDetachedChat).toHaveBeenCalledWith('s1', { title: item.title })
+    expect(shellMock.openArtifact).not.toHaveBeenCalled()
+  })
+})

--- a/plugins/ask-user/src/front/inbox/__tests__/inboxItemModel.test.ts
+++ b/plugins/ask-user/src/front/inbox/__tests__/inboxItemModel.test.ts
@@ -42,7 +42,7 @@ describe('inbox item model', () => {
       priority: 5,
       chatAvailable: true,
     })
-    expect(inbox.artifact).toEqual({ type: 'surface', surfaceKind: 'file', target: 'file.ts' })
+    expect(inbox.artifact).toEqual({ type: 'surface', surfaceKind: 'file', target: 'file.ts', params: { sessionId: 's1' } })
     expect(inbox.actions).toEqual([{ id: 'open', label: 'Open' }])
   })
 

--- a/plugins/ask-user/src/front/inbox/attentionBlockerAdapter.ts
+++ b/plugins/ask-user/src/front/inbox/attentionBlockerAdapter.ts
@@ -44,7 +44,12 @@ export function attentionBlockerToInboxItem(blocker: WorkspaceAttentionBlocker):
     sessionId: blocker.sessionId ?? null,
     chatAvailable: blocker.pruneWhenSessionMissing === true && !!blocker.sessionId,
     targetLabel: blocker.target ?? "",
-    artifact: blocker.surfaceKind ? { type: "surface", surfaceKind: blocker.surfaceKind, target: blocker.target } : null,
+    artifact: blocker.surfaceKind ? {
+      type: "surface",
+      surfaceKind: blocker.surfaceKind,
+      target: blocker.target,
+      params: blocker.sessionId ? { sessionId: blocker.sessionId } : undefined,
+    } : null,
     createdAt: dateValue(blocker.inbox?.createdAt) ?? updatedAt,
     updatedAt,
     priority: blocker.inbox?.priority ?? workspaceAttentionSessionBadgeForBlocker(blocker)?.priority ?? 0,


### PR DESCRIPTION
## Summary
- Catch invalid Dockview persisted-layout hydration and fall back to default panels
- Prevent stale localStorage layouts from crashing artifact-surface panels
- Add regression coverage for invalid persisted layouts

## Validation
- pnpm --filter @hachej/boring-workspace run test src/front/dock/__tests__/dock.test.tsx src/front/chrome/artifact-surface/__tests__/ArtifactSurfacePane.persistence.test.tsx src/front/attention/__tests__/WorkspaceInbox.test.tsx
- pnpm --dir apps/workspace-playground exec playwright test e2e/inbox-demo.spec.ts --config playwright.config.ts
- Manual smoke on :5380/:5390
- Poisoned localStorage browser smoke: no panelData/artifact-surface page error