### PR TITLE
sharepoint-plug: add local Office import route

### DIFF
--- a/plugins/boring-sharepoint/README.md
+++ b/plugins/boring-sharepoint/README.md
@@ -2,7 +2,7 @@
 
 App/internal plugin shell for SharePoint / Microsoft 365 Office document support in boring-ui.
 
-This package is intentionally a trusted app/internal plugin, not a runtime-generated `.pi/extensions` plugin. The current stack includes the plugin shell, Office cloud-ref display wiring, Arcade runtime primitives, read-only SharePoint discovery/status, on-demand Office preview, and V1 Office agent edit primitives. Future PRs will add import flows behind these contracts.
+This package is intentionally a trusted app/internal plugin, not a runtime-generated `.pi/extensions` plugin. The current stack includes the plugin shell, Office cloud-ref display wiring, Arcade runtime primitives, read-only SharePoint discovery/status, on-demand Office preview, V1 Office agent edit primitives, and route/provider primitives for importing local Office files to SharePoint canonical refs.
 
 ## Trust boundary
 
@@ -28,6 +28,7 @@ This workbook will become the operator guide as implementation PRs land.
      - `BORING_SHAREPOINT_ARCADE_PROVIDER_ID` — optional provider id, defaults to `microsoft`.
      - `BORING_SHAREPOINT_ARCADE_BASE_URL` — optional Arcade API base URL override.
    - Deploy/register the plugin-owned custom Arcade tool `BoringSharePoint_CreatePreviewUrl` in the operator's Arcade project. The tool wraps Microsoft Graph `driveItem:preview` using Arcade-managed Microsoft auth and returns only `{ getUrl, expiresAt? }`.
+   - Deploy/register the plugin-owned upload/import Arcade tool assumed by this slice: `BoringSharePoint_UploadOfficeDocument`. It should accept `{ source_path, content_handle, name, mime_type, site_url?, drive_id?, folder_item_id?, folder_web_url? }`, use Arcade-managed Microsoft auth to upload the staged `.xlsx`/`.pptx`, and return SharePoint drive item metadata only.
    - Confirm Microsoft scopes needed by each capability.
    - Confirm tenant/admin consent requirements.
 3. **boring-ui workspace connection**
@@ -43,6 +44,7 @@ This workbook will become the operator guide as implementation PRs land.
    - Preview in boring-ui through `POST /api/sharepoint/preview`, which requests a transient preview URL on demand.
    - Agent-edit Excel via `POST /api/sharepoint/edit` with `{ kind: "excel.add-worksheet", worksheetName }`.
    - Agent-edit PowerPoint via `POST /api/sharepoint/edit` with `{ kind: "powerpoint.create-slide", title, body?, layout? }`.
+   - Import a local staged `.xlsx` or `.pptx` via `POST /api/sharepoint/import` with `{ sourcePath, contentHandle, target }`. The route returns `{ ref, cloudRefPath }`; a host/workspace follow-up can write that JSON to the suggested `*.cloud.json` path.
 6. **Troubleshooting**
    - Auth required: reconnect SharePoint/Microsoft 365.
    - Admin consent required: tenant admin must approve Microsoft scopes.
@@ -76,19 +78,18 @@ The app-left action and command open the SharePoint / Microsoft 365 status surfa
 
 ## Current scope
 
-This PR adds V1 Office agent edit primitives on top of the shell/display/runtime/discovery/preview stack:
+This PR adds local Office import route/provider primitives on top of the shell/display/runtime/discovery/preview/edit stack:
 
-- `ArcadeSharePointProvider.createOfficePreviewUrl()` calls the plugin-owned custom Arcade tool `BoringSharePoint_CreatePreviewUrl` with `{ drive_id, item_id, viewer: "office" }` and normalizes `{ getUrl, expiresAt? }`.
-- `POST /api/sharepoint/preview` accepts either `{ ref }` with a canonical SharePoint document ref or `{ driveId, driveItemId }` durable identity and returns the transient preview result only.
-- `ArcadeSharePointProvider.editOfficeDocument()` supports V1 edit requests:
-  - Excel: `excel.add-worksheet` calls `MicrosoftSharepoint_AddWorksheet` with `{ drive_id, item_id, worksheet_name }`, then `MicrosoftSharepoint_GetWorkbookMetadata` with `{ drive_id, item_id, session_id? }` when a workbook session id is available.
-  - PowerPoint: `powerpoint.create-slide` calls assumed Arcade SharePoint tool `MicrosoftSharepoint_CreateSlide` with `{ drive_id, item_id, title, body?, layout? }`.
-- `POST /api/sharepoint/edit` accepts `{ ref, request }`, validates the canonical ref and edit request, and returns a stable `OfficeEditResult` without raw backend metadata or preview URLs.
-- Edit request validation rejects ref/kind mismatches, empty/oversized worksheet or slide fields, and credential-like text before provider calls.
-- Preview `getUrl` values are never stored in cloud-ref metadata, route logs, route errors, or session storage.
-- PowerPoint tool shape is inferred for this mocked slice; confirm against live Arcade tool metadata before promoting from draft.
+- `ArcadeSharePointProvider.importLocalOfficeDocument()` calls the assumed plugin-owned upload tool `BoringSharePoint_UploadOfficeDocument` with normalized snake_case input kept inside the server/provider adapter.
+- `POST /api/sharepoint/import` accepts `{ sourcePath, contentHandle, target }`, validates it, and returns canonical `{ ref, cloudRefPath }` metadata only.
+- `sourcePath` must be workspace-relative, use forward slashes, avoid traversal/dot/empty segments, and end in `.xlsx` or `.pptx`.
+- `contentHandle` is an opaque host/workspace upload-staging handle. This plugin does not read local files or accept absolute filesystem paths.
+- `target` can include `siteUrl`, `driveId`, `folderDriveItemId`, or `folderWebUrl`; IDs/URLs are validated for credential-like data before provider calls.
+- The returned `cloudRefPath` is a suggestion such as `reports/forecast.xlsx.cloud.json`; writing that ref into the workspace file tree is intentionally left to a host/workspace integration follow-up because this plugin slice has no safe workspace file IO surface.
+- Returned refs are validated and contain only SharePoint metadata. Preview URLs, tokens, raw upload metadata, and absolute paths are not returned or stored.
+- Upload tool shape is inferred for this mocked slice; confirm against deployed Arcade tool metadata before promoting from draft.
 - Tests use mocked Arcade/provider calls only.
 - no Microsoft Graph direct calls in boring-ui code
 - no Claude MCP/local MCP gateway dependency
-- no local import/upload
+- no broad filesystem access or absolute-path upload handling
 - no SharePoint-specific workspace chrome branches

--- a/plugins/boring-sharepoint/src/__tests__/arcadeBoundary.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/arcadeBoundary.test.ts
@@ -16,6 +16,17 @@ describe("Arcade package boundaries", () => {
     expect(forbiddenMatches).toEqual([])
   })
 
+  it("keeps direct network APIs out of the server provider", () => {
+    const forbiddenMatches = listSourceFiles("src/server")
+      .filter((path) => !path.includes("/__tests__/"))
+      .flatMap((path) => {
+        const source = readFileSync(path, "utf8")
+        return /\bfetch\s*\(|XMLHttpRequest|graph\.microsoft\.com/i.test(source) ? [relative(packageRoot.pathname, path)] : []
+      })
+
+    expect(forbiddenMatches).toEqual([])
+  })
+
   it("does not call Microsoft Graph directly from plugin source", () => {
     const forbiddenMatches = listSourceFiles("src")
       .filter((path) => !path.includes("/__tests__/"))

--- a/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointProvider.test.ts
@@ -257,6 +257,87 @@ describe("ArcadeSharePointProvider", () => {
     expect(executeTool).not.toHaveBeenCalled()
   })
 
+  it("imports local Excel and PowerPoint documents through the Arcade upload tool", async () => {
+    const executeTool = vi
+      .fn()
+      .mockResolvedValueOnce({ success: true, output: { value: xlsxItemValue } })
+      .mockResolvedValueOnce({ success: true, output: { value: pptxItemValue } })
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    await expect(
+      provider.importLocalOfficeDocument(
+        {
+          sourcePath: "reports/forecast.xlsx",
+          contentHandle: "staged-upload-1",
+          target: { siteUrl: siteValue.webUrl, driveId: xlsxRef.driveId, folderDriveItemId: "folder-1" },
+        },
+        ctx,
+      ),
+    ).resolves.toEqual({
+      ref: { ...xlsxRef, createdFrom: { type: "local-import", originalPath: "reports/forecast.xlsx" } },
+      cloudRefPath: "reports/forecast.xlsx.cloud.json",
+    })
+
+    await expect(
+      provider.importLocalOfficeDocument(
+        {
+          sourcePath: "decks/roadmap.pptx",
+          contentHandle: "staged-upload-2",
+          target: { folderWebUrl: "https://sumeo662.sharepoint.com/sites/sumeotest/Shared%20Documents" },
+        },
+        ctx,
+      ),
+    ).resolves.toEqual({
+      ref: { ...pptxRef, createdFrom: { type: "local-import", originalPath: "decks/roadmap.pptx" } },
+      cloudRefPath: "decks/roadmap.pptx.cloud.json",
+    })
+
+    expect(executeTool).toHaveBeenNthCalledWith(1, {
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.uploadOfficeDocument,
+      userId: ctx.actorUserId,
+      input: {
+        source_path: "reports/forecast.xlsx",
+        content_handle: "staged-upload-1",
+        name: "forecast.xlsx",
+        mime_type: EXCEL_MIME_TYPE,
+        site_url: siteValue.webUrl,
+        drive_id: xlsxRef.driveId,
+        folder_item_id: "folder-1",
+      },
+    })
+    expect(executeTool).toHaveBeenNthCalledWith(2, {
+      toolName: ARCADE_SHAREPOINT_TOOL_NAMES.uploadOfficeDocument,
+      userId: ctx.actorUserId,
+      input: {
+        source_path: "decks/roadmap.pptx",
+        content_handle: "staged-upload-2",
+        name: "roadmap.pptx",
+        mime_type: POWERPOINT_MIME_TYPE,
+        folder_web_url: "https://sumeo662.sharepoint.com/sites/sumeotest/Shared%20Documents",
+      },
+    })
+  })
+
+  it("rejects unsafe local import requests before Arcade calls", async () => {
+    const executeTool = vi.fn()
+    const provider = new ArcadeSharePointProvider({ runtime: { executeTool, startAuthorization: vi.fn() } })
+
+    const invalidRequests = [
+      { sourcePath: "/tmp/forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: xlsxRef.driveId } },
+      { sourcePath: "../forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: xlsxRef.driveId } },
+      { sourcePath: "reports/notes.docx", contentHandle: "staged-upload-1", target: { driveId: xlsxRef.driveId } },
+      { sourcePath: "reports/token-secret.xlsx", contentHandle: "staged-upload-1", target: { driveId: xlsxRef.driveId } },
+      { sourcePath: "reports/forecast.xlsx", contentHandle: "Bearer secret", target: { driveId: xlsxRef.driveId } },
+      { sourcePath: "reports/forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: `${xlsxRef.driveId}?access_token=secret` } },
+      { sourcePath: "reports/forecast.xlsx", contentHandle: "staged-upload-1", target: {} },
+    ]
+
+    for (const request of invalidRequests) {
+      await expect(provider.importLocalOfficeDocument(request, ctx)).rejects.toBeInstanceOf(SharePointProviderError)
+    }
+    expect(executeTool).not.toHaveBeenCalled()
+  })
+
   it("rejects mismatched Office extension and MIME metadata with a stable code", async () => {
     const providerWithItem = (item: Record<string, unknown>) =>
       new ArcadeSharePointProvider({

--- a/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
@@ -254,6 +254,86 @@ describe("SharePoint routes", () => {
     expect(conflict.body).not.toMatch(/previewUrl|access_token/)
   })
 
+  it("imports local Office files and returns canonical ref metadata only", async () => {
+    const importedExcelRef = { ...ref, createdFrom: { type: "local-import" as const, originalPath: "reports/forecast.xlsx" } }
+    const importedPptxRef = { ...pptxRef, createdFrom: { type: "local-import" as const, originalPath: "decks/roadmap.pptx" } }
+    const provider = fakeProvider({
+      importLocalOfficeDocument: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ref: importedExcelRef,
+          cloudRefPath: "reports/forecast.xlsx.cloud.json",
+          previewUrl: "https://tenant/preview?access_token=secret",
+        } as never)
+        .mockResolvedValueOnce({ ref: importedPptxRef, cloudRefPath: "decks/roadmap.pptx.cloud.json" }),
+    })
+    const app = await testApp(provider)
+
+    const excelResponse = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.import,
+      payload: { sourcePath: "reports/forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: ref.driveId, folderDriveItemId: "folder-1" } },
+    })
+    const pptxResponse = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.import,
+      payload: { sourcePath: "decks/roadmap.pptx", contentHandle: "staged-upload-2", target: { folderWebUrl: "https://tenant.sharepoint.com/sites/team/docs" } },
+    })
+
+    expect(excelResponse.statusCode).toBe(200)
+    expect(excelResponse.json()).toEqual({ ref: importedExcelRef, cloudRefPath: "reports/forecast.xlsx.cloud.json" })
+    expect(excelResponse.body).not.toMatch(/previewUrl|getUrl|access_token|Bearer|\/home\/|\/tmp\//i)
+    expect(pptxResponse.statusCode).toBe(200)
+    expect(pptxResponse.json()).toEqual({ ref: importedPptxRef, cloudRefPath: "decks/roadmap.pptx.cloud.json" })
+    expect(provider.importLocalOfficeDocument).toHaveBeenNthCalledWith(
+      1,
+      { sourcePath: "reports/forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: ref.driveId, folderDriveItemId: "folder-1", folderWebUrl: undefined, siteUrl: undefined } },
+      { workspaceId: "default", actorUserId: "anonymous" },
+    )
+  })
+
+  it("rejects unsafe import route inputs before provider calls", async () => {
+    const provider = fakeProvider({ importLocalOfficeDocument: vi.fn() })
+    const app = await testApp(provider)
+
+    const invalidPayloads = [
+      { sourcePath: "/home/user/forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: ref.driveId } },
+      { sourcePath: "reports/../forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: ref.driveId } },
+      { sourcePath: "reports/notes.docx", contentHandle: "staged-upload-1", target: { driveId: ref.driveId } },
+      { sourcePath: "reports/token-secret.xlsx", contentHandle: "staged-upload-1", target: { driveId: ref.driveId } },
+      { sourcePath: "reports/forecast.xlsx", contentHandle: "Bearer secret-token", target: { driveId: ref.driveId } },
+      { sourcePath: "reports/forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: `${ref.driveId}?access_token=secret` } },
+      { sourcePath: "reports/forecast.xlsx", contentHandle: "staged-upload-1", target: { folderWebUrl: "http://tenant.sharepoint.com/sites/team/docs" } },
+    ]
+
+    for (const payload of invalidPayloads) {
+      const response = await app.inject({ method: "POST", url: SHAREPOINT_ROUTE_PATHS.import, payload })
+      expect(response.statusCode).toBe(400)
+      expect(response.body).not.toMatch(/secret-token|access_token=secret|Bearer|\/home\/user/)
+    }
+    expect(provider.importLocalOfficeDocument).not.toHaveBeenCalled()
+  })
+
+  it("rejects unsafe import provider results", async () => {
+    const provider = fakeProvider({
+      importLocalOfficeDocument: vi.fn().mockResolvedValue({
+        ref: { ...ref, previewUrl: "https://tenant/preview?access_token=secret" },
+        cloudRefPath: "/tmp/forecast.xlsx.cloud.json",
+      }),
+    })
+    const app = await testApp(provider)
+
+    const response = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.import,
+      payload: { sourcePath: "reports/forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: ref.driveId } },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect(response.json()).toMatchObject({ error: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET })
+    expect(response.body).not.toMatch(/preview|access_token|\/tmp/)
+  })
+
   it("rejects token-bearing edit refs before provider calls", async () => {
     const provider = fakeProvider({ editOfficeDocument: vi.fn() })
     const app = await testApp(provider)
@@ -298,6 +378,7 @@ function fakeProvider(overrides: Partial<SharePointProvider>): SharePointProvide
     resolveDriveItem: vi.fn(),
     createOfficePreviewUrl: vi.fn(),
     editOfficeDocument: vi.fn(),
+    importLocalOfficeDocument: vi.fn(),
     ...overrides,
   }
 }

--- a/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
+++ b/plugins/boring-sharepoint/src/__tests__/sharePointRoutes.test.ts
@@ -316,10 +316,16 @@ describe("SharePoint routes", () => {
 
   it("rejects unsafe import provider results", async () => {
     const provider = fakeProvider({
-      importLocalOfficeDocument: vi.fn().mockResolvedValue({
-        ref: { ...ref, previewUrl: "https://tenant/preview?access_token=secret" },
-        cloudRefPath: "/tmp/forecast.xlsx.cloud.json",
-      }),
+      importLocalOfficeDocument: vi
+        .fn()
+        .mockResolvedValueOnce({
+          ref: { ...ref, previewUrl: "https://tenant/preview?access_token=secret" },
+          cloudRefPath: "/tmp/forecast.xlsx.cloud.json",
+        })
+        .mockResolvedValueOnce({
+          ref: { ...ref, createdFrom: { type: "local-import", originalPath: "reports/forecast.xlsx" } },
+          cloudRefPath: "C:\\tmp\\forecast.xlsx.cloud.json",
+        }),
     })
     const app = await testApp(provider)
 
@@ -332,6 +338,16 @@ describe("SharePoint routes", () => {
     expect(response.statusCode).toBe(400)
     expect(response.json()).toMatchObject({ error: SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET })
     expect(response.body).not.toMatch(/preview|access_token|\/tmp/)
+
+    const windowsPathResponse = await app.inject({
+      method: "POST",
+      url: SHAREPOINT_ROUTE_PATHS.import,
+      payload: { sourcePath: "reports/forecast.xlsx", contentHandle: "staged-upload-1", target: { driveId: ref.driveId } },
+    })
+
+    expect(windowsPathResponse.statusCode).toBe(502)
+    expect(windowsPathResponse.json()).toEqual({ error: SHAREPOINT_ERROR_CODES.INVALID_REF, message: "import returned an unsafe cloud ref path" })
+    expect(windowsPathResponse.body).not.toMatch(/C:\\tmp|forecast\.xlsx\.cloud\.json/)
   })
 
   it("rejects token-bearing edit refs before provider calls", async () => {

--- a/plugins/boring-sharepoint/src/server/index.ts
+++ b/plugins/boring-sharepoint/src/server/index.ts
@@ -38,7 +38,9 @@ export {
   ARCADE_SHAREPOINT_TOOL_NAMES,
   ArcadeSharePointProvider,
   SharePointProviderError,
+  fileNameFromPath,
   toOfficePreviewUrlResult,
   toSharePointDocumentRef,
+  validateLocalOfficeImportRequest,
   type ArcadeSharePointProviderOptions,
 } from "./sharePointProvider"

--- a/plugins/boring-sharepoint/src/server/routes.ts
+++ b/plugins/boring-sharepoint/src/server/routes.ts
@@ -7,6 +7,8 @@ import {
   type CreateOfficePreviewUrlInput,
   type CreateOfficePreviewUrlResult,
   type IntegrationAuthState,
+  type LocalOfficeImportRequest,
+  type LocalOfficeImportResult,
   type OfficeEditRequest,
   type OfficeEditResult,
   type ResolveDriveItemInput,
@@ -14,7 +16,7 @@ import {
   type SharePointProvider,
   type SharePointProviderContext,
 } from "../shared"
-import { SharePointProviderError, validateOfficeEditRequestForRef } from "./sharePointProvider"
+import { SharePointProviderError, validateLocalOfficeImportRequest, validateOfficeEditRequestForRef } from "./sharePointProvider"
 
 const SHAREPOINT_DURABLE_ID_PATTERN = /^[A-Za-z0-9._~!$'(),;=:@+-]{1,512}$/
 const SECRET_LIKE_ID_PATTERN = /([?&#](access_token|refresh_token|id_token|authorization|cookie)=)|Bearer\s+|token|secret|cookie|authorization/i
@@ -24,6 +26,7 @@ export const SHAREPOINT_ROUTE_PATHS = {
   resolve: "/api/sharepoint/resolve",
   preview: "/api/sharepoint/preview",
   edit: "/api/sharepoint/edit",
+  import: "/api/sharepoint/import",
 } as const
 
 export interface SharePointRoutesOptions {
@@ -73,6 +76,16 @@ export function sharePointRoutes(app: FastifyInstance, opts: SharePointRoutesOpt
     }
   })
 
+  app.post(SHAREPOINT_ROUTE_PATHS.import, async (request, reply) => {
+    try {
+      const input = parseImportBody(request.body)
+      const ctx = await resolveContext(request, opts)
+      return safeLocalOfficeImportResultForRoute(await opts.provider.importLocalOfficeDocument(input, ctx))
+    } catch (error) {
+      return sendSharePointRouteError(reply, error)
+    }
+  })
+
   done()
 }
 
@@ -89,6 +102,20 @@ function safePreviewResultForRoute(result: CreateOfficePreviewUrlResult): Create
   return result.expiresAt ? { getUrl: result.getUrl, expiresAt: result.expiresAt } : { getUrl: result.getUrl }
 }
 
+function safeLocalOfficeImportResultForRoute(result: LocalOfficeImportResult): LocalOfficeImportResult {
+  const ref = parseSharePointDocumentRef(result.ref)
+  assertSharePointDocumentRefSafeForStorage(ref)
+  if (
+    SECRET_LIKE_ID_PATTERN.test(result.cloudRefPath) ||
+    result.cloudRefPath.startsWith("/") ||
+    result.cloudRefPath.includes("..") ||
+    (!result.cloudRefPath.endsWith(".xlsx.cloud.json") && !result.cloudRefPath.endsWith(".pptx.cloud.json"))
+  ) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "import returned an unsafe cloud ref path", 502)
+  }
+  return { ref, cloudRefPath: result.cloudRefPath }
+}
+
 function safeOfficeEditResultForRoute(result: OfficeEditResult): OfficeEditResult {
   if (result.status === "succeeded") {
     return result.sessionId
@@ -102,6 +129,33 @@ function safeOfficeEditResultForRoute(result: OfficeEditResult): OfficeEditResul
     return { status: "conflict", code: result.code, message: safeRouteMessage(result.message, "SharePoint Office edit conflict") }
   }
   return { status: "failed", code: result.code, message: safeRouteMessage(result.message, "SharePoint Office edit failed") }
+}
+
+function parseImportBody(body: unknown): LocalOfficeImportRequest {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "import request body must be an object")
+  }
+  const candidate = body as Record<string, unknown>
+  const request: LocalOfficeImportRequest = {
+    sourcePath: requireBodyString(candidate.sourcePath, "sourcePath"),
+    contentHandle: requireBodyString(candidate.contentHandle, "contentHandle"),
+    target: parseImportTarget(candidate.target),
+  }
+  validateLocalOfficeImportRequest(request)
+  return request
+}
+
+function parseImportTarget(value: unknown): LocalOfficeImportRequest["target"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "import target must be an object")
+  }
+  const candidate = value as Record<string, unknown>
+  return {
+    siteUrl: optionalString(candidate.siteUrl),
+    driveId: optionalString(candidate.driveId),
+    folderDriveItemId: optionalString(candidate.folderDriveItemId),
+    folderWebUrl: optionalString(candidate.folderWebUrl),
+  }
 }
 
 function parseEditBody(body: unknown): { ref: SharePointDocumentRef; editRequest: OfficeEditRequest } {

--- a/plugins/boring-sharepoint/src/server/routes.ts
+++ b/plugins/boring-sharepoint/src/server/routes.ts
@@ -4,6 +4,7 @@ import {
   SharePointRefValidationError,
   assertSharePointDocumentRefSafeForStorage,
   parseSharePointDocumentRef,
+  validateLocalOfficeSourcePath,
   type CreateOfficePreviewUrlInput,
   type CreateOfficePreviewUrlResult,
   type IntegrationAuthState,
@@ -105,15 +106,27 @@ function safePreviewResultForRoute(result: CreateOfficePreviewUrlResult): Create
 function safeLocalOfficeImportResultForRoute(result: LocalOfficeImportResult): LocalOfficeImportResult {
   const ref = parseSharePointDocumentRef(result.ref)
   assertSharePointDocumentRefSafeForStorage(ref)
-  if (
-    SECRET_LIKE_ID_PATTERN.test(result.cloudRefPath) ||
-    result.cloudRefPath.startsWith("/") ||
-    result.cloudRefPath.includes("..") ||
-    (!result.cloudRefPath.endsWith(".xlsx.cloud.json") && !result.cloudRefPath.endsWith(".pptx.cloud.json"))
-  ) {
+  if (SECRET_LIKE_ID_PATTERN.test(result.cloudRefPath)) {
     throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "import returned an unsafe cloud ref path", 502)
   }
+  validateCloudRefPathForRoute(result.cloudRefPath)
   return { ref, cloudRefPath: result.cloudRefPath }
+}
+
+function validateCloudRefPathForRoute(cloudRefPath: string): void {
+  try {
+    if (cloudRefPath.endsWith(".xlsx.cloud.json")) {
+      validateLocalOfficeSourcePath(`${cloudRefPath.slice(0, -".xlsx.cloud.json".length)}.xlsx`)
+      return
+    }
+    if (cloudRefPath.endsWith(".pptx.cloud.json")) {
+      validateLocalOfficeSourcePath(`${cloudRefPath.slice(0, -".pptx.cloud.json".length)}.pptx`)
+      return
+    }
+  } catch {
+    // Fall through to the provider-output error below without echoing the unsafe path.
+  }
+  throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "import returned an unsafe cloud ref path", 502)
 }
 
 function safeOfficeEditResultForRoute(result: OfficeEditResult): OfficeEditResult {

--- a/plugins/boring-sharepoint/src/server/serverPlugin.ts
+++ b/plugins/boring-sharepoint/src/server/serverPlugin.ts
@@ -6,6 +6,8 @@ import {
   SHAREPOINT_ERROR_CODES,
   type CreateOfficePreviewUrlResult,
   type IntegrationAuthState,
+  type LocalOfficeImportRequest,
+  type LocalOfficeImportResult,
   type OfficeEditRequest,
   type OfficeEditResult,
   type ResolveDriveItemInput,
@@ -34,7 +36,7 @@ export function createSharePointServerPlugin(options: SharePointServerPluginOpti
     id: BORING_SHAREPOINT_PLUGIN_ID,
     label: BORING_SHAREPOINT_PLUGIN_LABEL,
     systemPrompt:
-      "SharePoint / Microsoft 365 integration is installed. It can resolve SharePoint-hosted Excel and PowerPoint documents into cloud refs and request transient Office preview URLs on demand; Office edits are not enabled yet.",
+      "SharePoint / Microsoft 365 integration is installed. It can resolve SharePoint-hosted Excel and PowerPoint documents into cloud refs, request transient Office preview URLs on demand, run V1 Office edits, and import staged local Office files into canonical SharePoint refs.",
     routes,
   })
 }
@@ -69,6 +71,10 @@ class UnconfiguredSharePointProvider implements SharePointProvider {
   }
 
   async editOfficeDocument(_ref: SharePointDocumentRef, _request: OfficeEditRequest): Promise<OfficeEditResult> {
-    return { status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: "SharePoint Office edits are not implemented yet" }
+    return { status: "failed", code: SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, message: this.message }
+  }
+
+  async importLocalOfficeDocument(_request: LocalOfficeImportRequest): Promise<LocalOfficeImportResult> {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.PROVIDER_UNAVAILABLE, this.message, 503)
   }
 }

--- a/plugins/boring-sharepoint/src/server/sharePointProvider.ts
+++ b/plugins/boring-sharepoint/src/server/sharePointProvider.ts
@@ -1,10 +1,14 @@
 import {
   SHAREPOINT_ERROR_CODES,
   SharePointRefValidationError,
+  buildLocalOfficeImportRef,
   expectedMimeTypeForOfficeKind,
   parseSharePointDocumentRef,
+  validateLocalOfficeSourcePath,
   type CreateOfficePreviewUrlInput,
   type IntegrationAuthState,
+  type LocalOfficeImportRequest,
+  type LocalOfficeImportResult,
   type OfficeEditRequest,
   type OfficeEditResult,
   type SharePointDocumentRef,
@@ -26,6 +30,7 @@ export const ARCADE_SHAREPOINT_TOOL_NAMES = {
   addWorksheet: "MicrosoftSharepoint_AddWorksheet",
   getWorkbookMetadata: "MicrosoftSharepoint_GetWorkbookMetadata",
   createSlide: "MicrosoftSharepoint_CreateSlide",
+  uploadOfficeDocument: "BoringSharePoint_UploadOfficeDocument",
 } as const
 
 export interface ArcadeSharePointProviderOptions {
@@ -157,6 +162,26 @@ export class ArcadeSharePointProvider implements SharePointProvider {
     return { status: "succeeded", summary: `Created PowerPoint slide in ${ref.name}` }
   }
 
+  async importLocalOfficeDocument(request: LocalOfficeImportRequest, ctx: SharePointProviderContext): Promise<LocalOfficeImportResult> {
+    const officeKind = validateLocalOfficeImportRequest(request)
+    const response = await this.runtime.executeTool({
+      toolName: this.tools.uploadOfficeDocument,
+      userId: ctx.actorUserId,
+      input: {
+        source_path: request.sourcePath,
+        content_handle: request.contentHandle,
+        name: fileNameFromPath(request.sourcePath),
+        mime_type: expectedMimeTypeForOfficeKind(officeKind),
+        ...(request.target.siteUrl ? { site_url: request.target.siteUrl } : {}),
+        ...(request.target.driveId ? { drive_id: request.target.driveId } : {}),
+        ...(request.target.folderDriveItemId ? { folder_item_id: request.target.folderDriveItemId } : {}),
+        ...(request.target.folderWebUrl ? { folder_web_url: request.target.folderWebUrl } : {}),
+      },
+    })
+    const uploadedItem = toSharePointDocumentRef({ item: unwrapArcadeValueObject(response, this.tools.uploadOfficeDocument) })
+    return buildLocalOfficeImportRef({ request, uploadedItem })
+  }
+
   private async getSite(siteUrl: string, ctx: SharePointProviderContext): Promise<Record<string, unknown>> {
     const response = await this.runtime.executeTool({
       toolName: this.tools.getSite,
@@ -192,6 +217,58 @@ export class ArcadeSharePointProvider implements SharePointProvider {
 }
 
 const EDIT_SECRET_LIKE_PATTERN = /([?&#](access_token|refresh_token|id_token|authorization|cookie)=)|Bearer\s+|token|secret|cookie|authorization/i
+const IMPORT_ID_PATTERN = /^[A-Za-z0-9._~!$'(),;=:@+-]{1,512}$/
+const IMPORT_HANDLE_PATTERN = /^[A-Za-z0-9._~!$'(),;=:@+-]{1,512}$/
+
+export function validateLocalOfficeImportRequest(request: LocalOfficeImportRequest): "excel" | "powerpoint" {
+  let officeKind: "excel" | "powerpoint"
+  try {
+    officeKind = validateLocalOfficeSourcePath(request.sourcePath)
+  } catch (error) {
+    if (error instanceof SharePointRefValidationError) {
+      throw new SharePointProviderError(error.code, error.message)
+    }
+    throw error
+  }
+  validateOpaqueImportValue(request.contentHandle, "contentHandle", IMPORT_HANDLE_PATTERN)
+  const target = request.target
+  if (!target || typeof target !== "object") {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "import target is required")
+  }
+  if (!target.siteUrl && !target.driveId && !target.folderWebUrl) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, "import target requires siteUrl, driveId, or folderWebUrl")
+  }
+  if (target.siteUrl !== undefined) validateImportHttpsUrl(target.siteUrl, "siteUrl")
+  if (target.folderWebUrl !== undefined) validateImportHttpsUrl(target.folderWebUrl, "folderWebUrl")
+  if (target.driveId !== undefined) validateOpaqueImportValue(target.driveId, "driveId", IMPORT_ID_PATTERN)
+  if (target.folderDriveItemId !== undefined) validateOpaqueImportValue(target.folderDriveItemId, "folderDriveItemId", IMPORT_ID_PATTERN)
+  return officeKind
+}
+
+export function fileNameFromPath(path: string): string {
+  return path.slice(path.lastIndexOf("/") + 1)
+}
+
+function validateOpaqueImportValue(value: string, label: string, pattern: RegExp): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} must be a non-empty string`)
+  }
+  if (EDIT_SECRET_LIKE_PATTERN.test(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET, `${label} contains forbidden credential-like data`)
+  }
+  if (!pattern.test(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} is not a valid SharePoint import identifier`)
+  }
+}
+
+function validateImportHttpsUrl(value: string, label: string): void {
+  if (EDIT_SECRET_LIKE_PATTERN.test(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET, `${label} contains forbidden credential-like data`)
+  }
+  if (!isHttpsUrl(value)) {
+    throw new SharePointProviderError(SHAREPOINT_ERROR_CODES.INVALID_REF, `${label} must be an https URL`)
+  }
+}
 
 export function validateOfficeEditRequestForRef(ref: SharePointDocumentRef, request: OfficeEditRequest): void {
   if (request.kind === "excel.add-worksheet") {

--- a/plugins/boring-sharepoint/src/shared/import.ts
+++ b/plugins/boring-sharepoint/src/shared/import.ts
@@ -1,0 +1,59 @@
+import { EXCEL_CLOUD_REF_SUFFIX, POWERPOINT_CLOUD_REF_SUFFIX } from "./constants"
+import { SHAREPOINT_ERROR_CODES, SharePointRefValidationError } from "./errors"
+import { expectedMimeTypeForOfficeKind, parseSharePointDocumentRef } from "./ref"
+import type { LocalOfficeImportRequest, OfficeDocumentSubtype, SharePointDocumentRef } from "./types"
+
+const ABSOLUTE_PATH_PATTERN = /^(?:[A-Za-z]:[\\/]|\\\\|\/)/
+const FORBIDDEN_PATH_PATTERN = /([?&#](access_token|refresh_token|id_token|authorization|cookie)=)|Bearer\s+|token|secret|cookie|authorization/i
+
+export function officeKindForLocalOfficePath(path: string): OfficeDocumentSubtype | null {
+  if (path.endsWith(".xlsx")) return "excel"
+  if (path.endsWith(".pptx")) return "powerpoint"
+  return null
+}
+
+export function cloudRefPathForLocalOfficePath(path: string): string {
+  const officeKind = validateLocalOfficeSourcePath(path)
+  return officeKind === "excel" ? `${path}${EXCEL_CLOUD_REF_SUFFIX.slice(".xlsx".length)}` : `${path}${POWERPOINT_CLOUD_REF_SUFFIX.slice(".pptx".length)}`
+}
+
+export function validateLocalOfficeSourcePath(path: string): OfficeDocumentSubtype {
+  if (typeof path !== "string" || path.length === 0) {
+    throw new SharePointRefValidationError(SHAREPOINT_ERROR_CODES.INVALID_REF, "sourcePath must be a non-empty workspace-relative path")
+  }
+  if (ABSOLUTE_PATH_PATTERN.test(path)) {
+    throw new SharePointRefValidationError(SHAREPOINT_ERROR_CODES.INVALID_REF, "sourcePath must be workspace-relative, not absolute")
+  }
+  if (path.includes("\\")) {
+    throw new SharePointRefValidationError(SHAREPOINT_ERROR_CODES.INVALID_REF, "sourcePath must use forward slashes")
+  }
+  if (path.split("/").some((segment) => segment === "" || segment === "." || segment === "..")) {
+    throw new SharePointRefValidationError(SHAREPOINT_ERROR_CODES.INVALID_REF, "sourcePath must not contain empty, dot, or traversal segments")
+  }
+  if (FORBIDDEN_PATH_PATTERN.test(path)) {
+    throw new SharePointRefValidationError(SHAREPOINT_ERROR_CODES.REF_CONTAINS_SECRET, "sourcePath contains forbidden credential-like data")
+  }
+  const officeKind = officeKindForLocalOfficePath(path)
+  if (!officeKind) {
+    throw new SharePointRefValidationError(SHAREPOINT_ERROR_CODES.INVALID_REF, "sourcePath must end with .xlsx or .pptx")
+  }
+  return officeKind
+}
+
+export function buildLocalOfficeImportRef(input: {
+  request: LocalOfficeImportRequest
+  uploadedItem: SharePointDocumentRef
+}): { ref: SharePointDocumentRef; cloudRefPath: string } {
+  const officeKind = validateLocalOfficeSourcePath(input.request.sourcePath)
+  const cloudRefPath = cloudRefPathForLocalOfficePath(input.request.sourcePath)
+  const ref: SharePointDocumentRef = {
+    ...input.uploadedItem,
+    officeKind,
+    mimeType: expectedMimeTypeForOfficeKind(officeKind),
+    createdFrom: {
+      type: "local-import",
+      originalPath: input.request.sourcePath,
+    },
+  }
+  return { ref: parseSharePointDocumentRef(ref), cloudRefPath }
+}

--- a/plugins/boring-sharepoint/src/shared/index.ts
+++ b/plugins/boring-sharepoint/src/shared/index.ts
@@ -14,6 +14,7 @@ export {
 } from "./constants"
 export { officeCloudRefDisplayMetadataForPath } from "./display"
 export type { OfficeCloudRefDisplayMetadata } from "./display"
+export { buildLocalOfficeImportRef, cloudRefPathForLocalOfficePath, officeKindForLocalOfficePath, validateLocalOfficeSourcePath } from "./import"
 export { SHAREPOINT_ERROR_CODES, SharePointRefValidationError } from "./errors"
 export type { SharePointErrorCode } from "./errors"
 export {
@@ -30,6 +31,9 @@ export type {
   CreateOfficePreviewUrlInput,
   CreateOfficePreviewUrlResult,
   IntegrationAuthState,
+  LocalOfficeImportRequest,
+  LocalOfficeImportResult,
+  LocalOfficeImportTarget,
   OfficeDocumentSubtype,
   OfficeEditRequest,
   OfficeEditResult,

--- a/plugins/boring-sharepoint/src/shared/types.ts
+++ b/plugins/boring-sharepoint/src/shared/types.ts
@@ -55,6 +55,26 @@ export interface CreateOfficePreviewUrlResult {
   expiresAt?: string
 }
 
+export interface LocalOfficeImportTarget {
+  siteUrl?: string
+  driveId?: string
+  folderDriveItemId?: string
+  folderWebUrl?: string
+}
+
+export interface LocalOfficeImportRequest {
+  /** Workspace-relative .xlsx/.pptx source path. Never absolute. */
+  sourcePath: string
+  /** Opaque upload handle produced by the host/workspace upload staging layer. */
+  contentHandle: string
+  target: LocalOfficeImportTarget
+}
+
+export interface LocalOfficeImportResult {
+  ref: SharePointDocumentRef
+  cloudRefPath: string
+}
+
 export type OfficeEditRequest =
   | {
       kind: "excel.add-worksheet"
@@ -95,4 +115,5 @@ export interface SharePointProvider {
   resolveDriveItem(input: ResolveDriveItemInput, ctx: SharePointProviderContext): Promise<SharePointDocumentRef>
   createOfficePreviewUrl(input: SharePointDocumentRef | CreateOfficePreviewUrlInput, ctx: SharePointProviderContext): Promise<CreateOfficePreviewUrlResult>
   editOfficeDocument(ref: SharePointDocumentRef, request: OfficeEditRequest, ctx: SharePointProviderContext): Promise<OfficeEditResult>
+  importLocalOfficeDocument(request: LocalOfficeImportRequest, ctx: SharePointProviderContext): Promise<LocalOfficeImportResult>
 }


### PR DESCRIPTION
## Summary

- adds plugin-owned local Office import contracts/helpers for staged .xlsx/.pptx uploads
- wires ArcadeSharePointProvider to assumed custom upload tool BoringSharePoint_UploadOfficeDocument
- adds POST /api/sharepoint/import returning canonical SharePoint refs and suggested *.cloud.json paths only
- documents upload tool assumptions and file-tree write limitation

## Validation

- pnpm --filter @hachej/boring-sharepoint test
- pnpm --filter @hachej/boring-sharepoint typecheck
- pnpm --filter @hachej/boring-sharepoint build

## Notes

No direct Graph calls or broad workspace filesystem access were added. The route requires an opaque contentHandle from a future host/workspace staging layer; writing the suggested cloud ref file remains a follow-up integration step.