### PR TITLE
docs: relax PR branch freshness rule

### DIFF
--- a/docs/kanzen/boring-loop.md
+++ b/docs/kanzen/boring-loop.md
@@ -98,6 +98,7 @@ flowchart LR
 - `track:fast` forbids auth, billing, permissions, secrets, migrations, public
   API, release, deletion-heavy work, broad refactor.
 - Merge requires current review, thermo, tests, CI, proof comment, demo proof.
+- Merge does **not** require the PR branch to contain the latest `main` commit unless there is a merge conflict or stale/missing proof for the changed risk area.
 - If visual review is required: approval must match the current artifact.
 - Otherwise: `track:owner`; Julien reviews.
 

--- a/docs/kanzen/procedures/local-signoff.md
+++ b/docs/kanzen/procedures/local-signoff.md
@@ -104,4 +104,6 @@ PR Fast Summary
 signoff/local
 ```
 
+Do **not** require every PR branch to be up to date with the latest `main` commit before merge. A PR should be blocked for merge conflicts, stale or missing proof, or failed required checks — not just because `main` advanced after the branch was reviewed. Keep `main` protected by requiring the merge result checks/proof that matter.
+
 Avoid requiring path-filtered jobs directly when they may be skipped by design. Keep production deploy gates separate: protected `prod-*` tags, GHCR image build, manifest verification, attestation verification, and Kamal/deployd deploy.


### PR DESCRIPTION
## Summary
- Document that PR branches do not need latest main on every merge
- Keep blockers focused on conflicts, failed checks, or stale/missing proof

## Validation
- Docs-only change; no tests run