### PR TITLE
feat(391-P1): pr3 — adapters thin over the core bridge

### DIFF
--- a/packages/agent/src/server/createAgent.ts
+++ b/packages/agent/src/server/createAgent.ts
@@ -1,8 +1,8 @@
 import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import type { PiSessionRequestContext } from './pi-chat/piSessionIdentity'
-import type { PiChatEventStreamSubscription } from './http/routes/piChat'
 import type { AgentHarness, AgentHarnessFactoryInput } from '../shared/harness'
+import type { Workspace } from '../shared/workspace'
 import type {
   Agent,
   AgentConfig,
@@ -27,8 +27,30 @@ interface AgentRuntime {
   service: HarnessPiChatService
 }
 
+export interface AgentRuntimeAdapterView {
+  harness: AgentHarness
+  sessionStore: SessionStore
+  service: unknown
+}
+
+export interface CreateAgentRuntimeBridgeOptions {
+  harness?: {
+    runtimeCwd?: string
+  }
+  service?: {
+    workdir?: string
+    workspace?: Workspace
+  }
+}
+
+export interface AgentRuntimeBridge {
+  agent: Agent
+  getRuntime(): Promise<AgentRuntimeAdapterView>
+  currentRuntime(): Promise<AgentRuntimeAdapterView> | undefined
+}
+
 interface AgentSessionLiveState {
-  bridge?: PiChatEventStreamSubscription
+  bridge?: AgentPiChatEventStreamSubscription
   bridgePromise?: Promise<AgentSessionLiveState>
   events: AgentEvent[]
   subscribers: Set<StreamSubscriber>
@@ -42,12 +64,25 @@ interface StreamSubscriber {
   close(): void
 }
 
+interface AgentPiChatEventStreamSubscription {
+  type: 'ok'
+  unsubscribe(): void
+  closed?: Promise<void>
+}
+
 export function createAgent(config: AgentConfig): Agent {
+  return createAgentRuntimeBridge(config).agent
+}
+
+export function createAgentRuntimeBridge(
+  config: AgentConfig,
+  options: CreateAgentRuntimeBridgeOptions = {},
+): AgentRuntimeBridge {
   if (config.sessions && !config.harnessFactory) {
     throw new Error('createAgent sessions override requires a harnessFactory that uses the same SessionStore')
   }
 
-  const runtimeLoader = createRuntimeLoader(config)
+  const runtimeLoader = createRuntimeLoader(config, options)
   const getRuntime = runtimeLoader.get
   const live = new AgentLiveEventBuffer(DEFAULT_LIVE_BUFFER_SIZE)
   const sessionContexts = new Map<string, SessionCtx | undefined>()
@@ -106,7 +141,7 @@ export function createAgent(config: AgentConfig): Agent {
     return { sessionId, startIndex }
   }
 
-  return {
+  const agent: Agent = {
     sessions,
     readiness,
 
@@ -172,6 +207,12 @@ export function createAgent(config: AgentConfig): Agent {
     },
   }
 
+  return {
+    agent,
+    getRuntime,
+    currentRuntime: runtimeLoader.current,
+  }
+
   async function* authorizedStream(sessionId: string, options: AgentStreamOptions): AsyncIterable<AgentEvent> {
     const runtime = await getRuntime()
     const accessCtx = await authorizeSessionAccess(runtime, sessionId, options.ctx, sessionContexts)
@@ -179,14 +220,14 @@ export function createAgent(config: AgentConfig): Agent {
   }
 }
 
-function createRuntimeLoader(config: AgentConfig): {
+function createRuntimeLoader(config: AgentConfig, options: CreateAgentRuntimeBridgeOptions): {
   get(): Promise<AgentRuntime>
   current(): Promise<AgentRuntime> | undefined
 } {
   let runtimePromise: Promise<AgentRuntime> | undefined
   return {
     get() {
-      runtimePromise ??= createRuntime(config)
+      runtimePromise ??= createRuntime(config, options)
       return runtimePromise
     },
     current() {
@@ -195,12 +236,12 @@ function createRuntimeLoader(config: AgentConfig): {
   }
 }
 
-async function createRuntime(config: AgentConfig): Promise<AgentRuntime> {
+async function createRuntime(config: AgentConfig, options: CreateAgentRuntimeBridgeOptions): Promise<AgentRuntime> {
   const harnessFactory = config.harnessFactory ?? (await import('./harness/pi-coding-agent/createHarness')).createPiCodingAgentHarness
   const harnessInput: AgentHarnessFactoryInput = {
     tools: config.tools ?? [],
     cwd: config.workdir ?? DEFAULT_WORKDIR,
-    runtimeCwd: config.workdir,
+    runtimeCwd: options.harness?.runtimeCwd ?? options.service?.workdir ?? config.workdir,
     systemPromptAppend: config.systemPromptAppend,
     systemPromptDynamic: config.systemPromptDynamic,
     sessionRoot: config.sessionStorageRoot,
@@ -214,7 +255,8 @@ async function createRuntime(config: AgentConfig): Promise<AgentRuntime> {
     service: new HarnessPiChatService({
       harness,
       sessionStore,
-      workdir: config.workdir ?? DEFAULT_WORKDIR,
+      workdir: options.service?.workdir ?? config.workdir ?? DEFAULT_WORKDIR,
+      workspace: options.service?.workspace,
       metering: config.metering as AgentMeteringSink | undefined,
     }),
   }

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -1,7 +1,9 @@
 import Fastify, { type FastifyInstance } from 'fastify'
 import type { AgentTool } from '../shared/tool'
-import type { AgentHarness, AgentHarnessFactory } from '../shared/harness'
+import type { AgentCoreHarnessFactory, AgentHarness, AgentHarnessFactory } from '../shared/harness'
 import type { TelemetrySink } from '../shared/telemetry'
+import type { PiChatSnapshot } from '../shared/chat'
+import { ErrorCode } from '../shared/error-codes'
 import { getEnv } from './config/env'
 import type { RuntimeBundle, RuntimeModeAdapter, RuntimeModeId } from './runtime/mode'
 import { getOptionalRuntimeBundleStorageRoot } from './runtime/mode'
@@ -20,7 +22,7 @@ import { fsEventsRoutes } from './http/routes/fsEvents'
 import { treeRoutes } from './http/routes/tree'
 import { modelsRoutes } from './http/routes/models'
 import { skillsRoutes } from './http/routes/skills'
-import { piChatRoutes } from './http/routes/piChat'
+import { piChatRoutes, type PiChatSessionService } from './http/routes/piChat'
 import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
@@ -31,10 +33,10 @@ import { searchRoutes } from './http/routes/search'
 import { gitRoutes } from './http/routes/git'
 import { InMemorySessionChangesTracker } from './http/sessionChangesTracker'
 import { createRuntimeReadyStatusTracker } from './runtime/modeReadiness'
-import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
 import type { ReloadHookDiagnostic } from './http/routes/reload'
+import { createAgentRuntimeBridge } from './createAgent'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_SESSION_ID = 'default'
@@ -202,19 +204,32 @@ export async function createAgentApp(
     })] : []),
   ]
 
-  const harnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
+  const baseHarnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
     ...input,
     pi: runtimePi,
   }))
-  const harness = await harnessFactory({
-    tools,
-    cwd: workspaceRoot,
+  const harnessFactory = ((input) => baseHarnessFactory({
+    ...input,
     sessionNamespace: opts.sessionNamespace,
     sessionDir: opts.sessionDir,
+  })) as AgentCoreHarnessFactory
+  const coreAgent = createAgentRuntimeBridge({
+    runtime: modeAdapter,
+    tools,
+    harnessFactory,
     systemPromptAppend: opts.systemPromptAppend,
     systemPromptDynamic: opts.systemPromptDynamic,
     telemetry: opts.telemetry,
+    metering: opts.metering,
+    workdir: workspaceRoot,
+  }, {
+    service: {
+      workdir: runtimeBundle.workspace.root,
+      workspace: runtimeBundle.workspace,
+    },
   })
+  const agentRuntime = await coreAgent.getRuntime()
+  const harness = agentRuntime.harness
   harnessRef = harness
   const sessionChangesTracker = new InMemorySessionChangesTracker()
 
@@ -250,14 +265,9 @@ export async function createAgentApp(
   await app.register(gitRoutes, {
     getWorkspaceRoot: () => getOptionalRuntimeBundleStorageRoot(runtimeBundle),
   })
-  const piChatService = new HarnessPiChatService({
-    harness,
-    sessionStore: harness.sessions,
-    workdir: runtimeBundle.workspace.root,
-    workspace: runtimeBundle.workspace,
-    metering: opts.metering,
+  await app.register(piChatRoutes, {
+    service: createHttpCompatiblePiChatService(agentRuntime.service as PiChatSessionService),
   })
-  await app.register(piChatRoutes, { service: piChatService })
   await app.register(systemPromptRoutes, { harness })
   await app.register(modelsRoutes)
   await app.register(skillsRoutes, {
@@ -289,4 +299,53 @@ export async function createAgentApp(
   await app.register(readyStatusRoutes, { tracker: readyTracker })
 
   return app
+}
+
+function createHttpCompatiblePiChatService(service: PiChatSessionService): PiChatSessionService {
+  return new Proxy(service, {
+    get(target, prop, receiver) {
+      if (prop === 'readState') {
+        return async (...args: Parameters<PiChatSessionService['readState']>) => {
+          try {
+            return await target.readState(...args)
+          } catch (error) {
+            if (isSessionNotFoundError(error)) return emptyPiChatSnapshot(args[1])
+            throw error
+          }
+        }
+      }
+      if (prop === 'deleteSession' && typeof target.deleteSession === 'function') {
+        return async (...args: Parameters<NonNullable<PiChatSessionService['deleteSession']>>) => {
+          try {
+            return await target.deleteSession!(...args)
+          } catch (error) {
+            if (isSessionNotFoundError(error)) return
+            throw error
+          }
+        }
+      }
+      const value = Reflect.get(target, prop, receiver)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  }) as PiChatSessionService
+}
+
+function isSessionNotFoundError(error: unknown): boolean {
+  if ((error as { code?: unknown })?.code === ErrorCode.enum.SESSION_NOT_FOUND) return true
+  return error instanceof Error && (
+    error.message === 'session not found' ||
+    error.message.startsWith('Session not found:')
+  )
+}
+
+function emptyPiChatSnapshot(sessionId: string): PiChatSnapshot {
+  return {
+    protocolVersion: 1,
+    sessionId,
+    seq: 0,
+    status: 'idle',
+    messages: [],
+    queue: { followUps: [] },
+    followUpMode: 'one-at-a-time',
+  }
 }

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -1,8 +1,10 @@
 import type { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify'
 import { basename } from 'node:path'
 import type { AgentTool, ToolReadinessRequirement } from '../shared/tool'
-import type { AgentHarnessFactory } from '../shared/harness'
+import type { AgentCoreHarnessFactory, AgentHarnessFactory } from '../shared/harness'
 import type { SessionStore } from '../shared/session'
+import type { Agent } from '../shared/events'
+import type { PiChatSnapshot } from '../shared/chat'
 import type { SandboxHandleStore } from '../shared/sandbox-handle-store'
 import type { TelemetrySink } from '../shared/telemetry'
 import { AuthStorage, ModelRegistry } from '@mariozechner/pi-coding-agent'
@@ -30,7 +32,7 @@ import { fsEventsRoutes } from './http/routes/fsEvents'
 import { treeRoutes } from './http/routes/tree'
 import { modelsRoutes } from './http/routes/models'
 import { skillsRoutes } from './http/routes/skills'
-import { piChatRoutes } from './http/routes/piChat'
+import { piChatRoutes, type PiChatSessionService } from './http/routes/piChat'
 import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
@@ -44,9 +46,9 @@ import type { ReadyStatusTracker } from './runtime/readyStatus'
 import { createRuntimeReadyStatusTracker } from './runtime/modeReadiness'
 import { withRuntimeEnvContributions, type RuntimeEnvContribution } from './runtimeEnvContributions'
 import type { AgentHarness } from '../shared/harness'
-import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
+import { createAgentRuntimeBridge } from './createAgent'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_WORKSPACE_ID = 'default'
@@ -108,10 +110,11 @@ interface RuntimeBinding {
   runtimeDependencies: RuntimeDependencyReadiness
   runtimeProvisioningTask?: Promise<WorkspaceProvisioningResult | undefined>
   reprovision: (request?: FastifyRequest) => Promise<WorkspaceProvisioningResult | undefined>
+  agent: Agent
   harness: AgentHarness
   tools: AgentTool[]
   readyTracker: ReadyStatusTracker
-  piChatService?: HarnessPiChatService
+  piChatService: PiChatSessionService
   lastHealthCheckMs?: number
   /**
    * Diagnostics from the most recent /api/v1/agent/reload (merged hook +
@@ -648,7 +651,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       logger: app.log,
       checkReadiness,
     })
-    const harnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
+    const baseHarnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
       ...input,
       pi: {
         // scope.pi is already defaulted at the resolveScopePi chokepoint.
@@ -668,17 +671,32 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
         },
       },
     }))
-    const harness = await harnessFactory({
-      tools,
-      cwd: root,
+    const systemPromptDynamic = opts.getSystemPromptDynamic
+      ? () => opts.getSystemPromptDynamic?.({ workspaceId, workspaceRoot: root })
+      : opts.systemPromptDynamic
+    const harnessFactory = ((input) => baseHarnessFactory({
+      ...input,
       sessionNamespace: scope.sessionNamespace,
       sessionRoot: opts.sessionRoot,
+    })) as AgentCoreHarnessFactory
+    const coreAgent = createAgentRuntimeBridge({
+      runtime: modeAdapter,
+      tools,
+      harnessFactory,
       systemPromptAppend: opts.systemPromptAppend,
-      systemPromptDynamic: opts.getSystemPromptDynamic
-        ? () => opts.getSystemPromptDynamic?.({ workspaceId, workspaceRoot: root })
-        : opts.systemPromptDynamic,
+      systemPromptDynamic,
       telemetry: opts.telemetry,
+      metering: opts.metering,
+      sessionStorageRoot: opts.sessionRoot,
+      workdir: root,
+    }, {
+      service: {
+        workdir: runtimeBundle.workspace.root,
+        workspace: runtimeBundle.workspace,
+      },
     })
+    const agentRuntime = await coreAgent.getRuntime()
+    const harness = agentRuntime.harness
     readyTracker.markHarnessReady()
 
     binding = {
@@ -690,9 +708,11 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
         const result = await startRuntimeProvisioning(reloadRequest)
         return await result
       },
+      agent: coreAgent.agent,
       harness,
       tools,
       readyTracker,
+      piChatService: createHttpCompatiblePiChatService(agentRuntime.service as PiChatSessionService),
     }
     startRuntimeProvisioning(request)
     return binding
@@ -949,13 +969,6 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
   await app.register(piChatRoutes, {
     getService: async (request) => {
       const binding = await getBindingForRequest(request)
-      binding.piChatService ??= new HarnessPiChatService({
-        harness: binding.harness,
-        sessionStore: binding.harness.sessions,
-        workdir: binding.runtimeBundle.workspace.root,
-        workspace: binding.runtimeBundle.workspace,
-        metering: opts.metering,
-      })
       return binding.piChatService
     },
   })
@@ -1063,4 +1076,53 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
     ? { tracker: staticBinding.readyTracker }
     : { getTracker: async (request) => (await getBindingForRequest(request)).readyTracker },
   )
+}
+
+function createHttpCompatiblePiChatService(service: PiChatSessionService): PiChatSessionService {
+  return new Proxy(service, {
+    get(target, prop, receiver) {
+      if (prop === 'readState') {
+        return async (...args: Parameters<PiChatSessionService['readState']>) => {
+          try {
+            return await target.readState(...args)
+          } catch (error) {
+            if (isSessionNotFoundError(error)) return emptyPiChatSnapshot(args[1])
+            throw error
+          }
+        }
+      }
+      if (prop === 'deleteSession' && typeof target.deleteSession === 'function') {
+        return async (...args: Parameters<NonNullable<PiChatSessionService['deleteSession']>>) => {
+          try {
+            return await target.deleteSession!(...args)
+          } catch (error) {
+            if (isSessionNotFoundError(error)) return
+            throw error
+          }
+        }
+      }
+      const value = Reflect.get(target, prop, receiver)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  }) as PiChatSessionService
+}
+
+function isSessionNotFoundError(error: unknown): boolean {
+  if ((error as { code?: unknown })?.code === ErrorCode.enum.SESSION_NOT_FOUND) return true
+  return error instanceof Error && (
+    error.message === 'session not found' ||
+    error.message.startsWith('Session not found:')
+  )
+}
+
+function emptyPiChatSnapshot(sessionId: string): PiChatSnapshot {
+  return {
+    protocolVersion: 1,
+    sessionId,
+    seq: 0,
+    status: 'idle',
+    messages: [],
+    queue: { followUps: [] },
+    followUpMode: 'one-at-a-time',
+  }
 }


### PR DESCRIPTION
P1 stack 3/N (BBP1-003), stacked on #529. HTTP adapters become thin composition over createAgent()'s core bridge — no behavior change (empty-state/idempotent-delete preserved adapter-side). Gates: 1,579 tests · invariants clean · e2e green (CI-serialized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)