### PR TITLE
feat(391-T1): pr1 — transactional EventStreamStore

### DIFF
--- a/packages/agent/src/server/events/__tests__/eventStreamStore.conformance.test.ts
+++ b/packages/agent/src/server/events/__tests__/eventStreamStore.conformance.test.ts
@@ -1,0 +1,219 @@
+import { mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PiChatEvent } from '../../../shared/chat'
+import type { AgentEvent } from '../../../shared/events'
+import {
+  type EventStreamStore,
+  formatOffset,
+  parseOffset,
+  SqliteEventStreamStore,
+} from '../eventStreamStore'
+import { openDatabase, type OpenDatabaseResult } from '../sqlStorage'
+
+interface StoreHarness {
+  store: EventStreamStore
+  close?: () => void | Promise<void>
+}
+
+type StoreFactory = () => StoreHarness | Promise<StoreHarness>
+
+export function runEventStreamStoreConformance(makeStore: StoreFactory): void {
+  let harness: StoreHarness | undefined
+
+  afterEach(async () => {
+    await harness?.close?.()
+    harness = undefined
+  })
+
+  async function useStore(): Promise<EventStreamStore> {
+    harness = await makeStore()
+    return harness.store
+  }
+
+  it('formats and parses Durable Streams offsets', () => {
+    expect(formatOffset(-1)).toBe('-1')
+    expect(formatOffset(0)).toBe('0000000000000000_0000000000000000')
+    expect(formatOffset(42)).toBe('0000000000000000_0000000000000042')
+    expect(parseOffset('0000000000000000_0000000000000042')).toBe(42)
+    expect(() => parseOffset('42')).toThrow(/Invalid event stream offset/)
+  })
+
+  it('appends and reads strictly after offsets with correct metadata', async () => {
+    const store = await useStore()
+    const path = 'streams/monotonic'
+    await store.createStream(path)
+
+    expect(await store.getStreamMeta(path)).toEqual({ nextOffset: '-1', closed: false })
+
+    const first = await store.appendEvent(path, { index: 0 })
+    const second = await store.appendEvent(path, { index: 1 })
+
+    expect(first).toBe(formatOffset(0))
+    expect(second).toBe(formatOffset(1))
+
+    await expect(store.readEvents(path, { offset: '-1' })).resolves.toEqual({
+      events: [
+        { data: { index: 0 }, offset: first },
+        { data: { index: 1 }, offset: second },
+      ],
+      nextOffset: second,
+      upToDate: true,
+      closed: false,
+    })
+
+    await expect(store.readEvents(path, { offset: first })).resolves.toMatchObject({
+      events: [{ data: { index: 1 }, offset: second }],
+      nextOffset: second,
+      upToDate: true,
+    })
+
+    await expect(store.readEvents(path, { offset: '-1', limit: 1 })).resolves.toMatchObject({
+      events: [{ data: { index: 0 }, offset: first }],
+      nextOffset: first,
+      upToDate: false,
+    })
+
+    await expect(store.readEvents(path, { offset: 'now' })).resolves.toEqual({
+      events: [],
+      nextOffset: second,
+      upToDate: true,
+      closed: false,
+    })
+
+    await expect(store.readEvents(path, { offset: formatOffset(100) })).resolves.toMatchObject({
+      events: [],
+      nextOffset: second,
+      upToDate: true,
+    })
+
+    const third = await store.appendEvent(path, { index: 2 })
+    await expect(store.readEvents(path, { offset: second })).resolves.toMatchObject({
+      events: [{ data: { index: 2 }, offset: third }],
+      nextOffset: third,
+    })
+  })
+
+  it('creates streams idempotently and rejects appends to missing or closed streams', async () => {
+    const store = await useStore()
+    const path = 'streams/lifecycle'
+
+    await expect(store.appendEvent(path, { beforeCreate: true })).rejects.toThrow(/does not exist/)
+    await store.createStream(path)
+    await store.createStream(path)
+    await store.closeStream(path)
+    await store.closeStream(path)
+
+    await expect(store.getStreamMeta(path)).resolves.toEqual({ nextOffset: '-1', closed: true })
+    await expect(store.appendEvent(path, { afterClose: true })).rejects.toThrow(/is closed/)
+  })
+
+  it('keeps appendEventOnce idempotent and rejects conflicting payload reuse', async () => {
+    const store = await useStore()
+    const path = 'streams/once'
+    await store.createStream(path)
+
+    const first = await store.appendEventOnce(path, 'key-1', { stable: true })
+    const retry = await store.appendEventOnce(path, 'key-1', { stable: true })
+
+    expect(retry).toBe(first)
+    await expect(store.appendEventOnce(path, 'key-1', { stable: false })).rejects.toThrow(/conflicting payload/)
+    await expect(store.readEvents(path, { offset: '-1' })).resolves.toMatchObject({
+      events: [{ data: { stable: true }, offset: first }],
+      nextOffset: first,
+    })
+  })
+
+  it('deduplicates appendAgentEvent by idempotency key without allocating another eventIndex', async () => {
+    const store = await useStore()
+    await store.createStream('sessions/session-a')
+    const chunk = piEvent(7)
+
+    const first = await store.appendAgentEvent('session-a', chunk, { idempotencyKey: String(chunk.seq) })
+    const retry = await store.appendAgentEvent('session-a', chunk, { idempotencyKey: String(chunk.seq) })
+    const [concurrentA, concurrentB] = await Promise.all([
+      store.appendAgentEvent('session-a', chunk, { idempotencyKey: String(chunk.seq) }),
+      store.appendAgentEvent('session-a', chunk, { idempotencyKey: String(chunk.seq) }),
+    ])
+
+    expect(retry).toBe(first)
+    expect(concurrentA).toBe(first)
+    expect(concurrentB).toBe(first)
+    await expect(
+      store.appendAgentEvent('session-a', piEvent(8), { idempotencyKey: String(chunk.seq) }),
+    ).rejects.toThrow(/conflicting payload/)
+
+    const result = await store.readEvents('sessions/session-a', { offset: '-1' })
+    expect(result.nextOffset).toBe(first)
+    expect(result.events).toHaveLength(1)
+    const envelope = result.events[0]?.data as AgentEvent
+    expect(envelope).toMatchObject({
+      v: 1,
+      eventIndex: 0,
+      sessionId: 'session-a',
+      chunk,
+    })
+    expect(typeof envelope.timestamp).toBe('number')
+    expect(await store.getStreamMeta('sessions/session-a')).toEqual({ nextOffset: first, closed: false })
+  })
+
+  it('rolls back appendAgentEvent when envelope serialization throws', async () => {
+    const store = await useStore()
+    await store.createStream('sessions/atomic')
+    const badChunk = { ...piEvent(1), bad: 1n } as unknown as PiChatEvent
+
+    await expect(store.appendAgentEvent('atomic', badChunk)).rejects.toThrow(/serialize a BigInt/)
+    await expect(store.getStreamMeta('sessions/atomic')).resolves.toEqual({ nextOffset: '-1', closed: false })
+    await expect(store.readEvents('sessions/atomic', { offset: '-1' })).resolves.toMatchObject({
+      events: [],
+      nextOffset: '-1',
+    })
+
+    const offset = await store.appendAgentEvent('atomic', piEvent(2))
+    expect(offset).toBe(formatOffset(0))
+    const result = await store.readEvents('sessions/atomic', { offset: '-1' })
+    expect((result.events[0]?.data as AgentEvent).eventIndex).toBe(0)
+  })
+
+  it('fires subscribers on append and stops after unsubscribe', async () => {
+    const store = await useStore()
+    const path = 'streams/subscribers'
+    const listener = vi.fn()
+    await store.createStream(path)
+    const unsubscribe = store.subscribe(path, listener)
+
+    await store.appendEvent(path, { one: true })
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    await store.appendEvent(path, { two: true })
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+}
+
+describe('SqliteEventStreamStore (:memory:)', () => {
+  runEventStreamStoreConformance(() => {
+    const db = openDatabase(':memory:')
+    return makeHarness(db)
+  })
+})
+
+describe('SqliteEventStreamStore (file)', () => {
+  runEventStreamStoreConformance(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'boring-event-stream-'))
+    const db = openDatabase(join(dir, 'events.sqlite'))
+    return makeHarness(db)
+  })
+})
+
+function makeHarness(db: OpenDatabaseResult): StoreHarness {
+  return {
+    store: new SqliteEventStreamStore(db.sql, db.runTransaction),
+    close: () => db.db.close(),
+  }
+}
+
+function piEvent(seq: number): PiChatEvent {
+  return { type: 'agent-start', seq, turnId: `turn-${seq}` }
+}

--- a/packages/agent/src/server/events/eventStreamStore.ts
+++ b/packages/agent/src/server/events/eventStreamStore.ts
@@ -1,0 +1,361 @@
+import type { PiChatEvent } from '../../shared/chat'
+import type { AgentEvent } from '../../shared/events'
+import { migrateEventStreamSqlSchema } from './schemaVersion'
+import type { RunTransaction, SqlStorage } from './sqlStorage'
+
+const COMPONENT_PAD = 16
+const ZERO_COMPONENT = '0'.repeat(COMPONENT_PAD)
+
+export const DEFAULT_READ_LIMIT = 100
+export const MAX_READ_LIMIT = 1000
+
+export interface EventStreamReadResult {
+  events: Array<{ data: unknown; offset: string }>
+  nextOffset: string
+  upToDate: boolean
+  closed: boolean
+}
+
+export interface EventStreamMeta {
+  nextOffset: string
+  closed: boolean
+}
+
+export interface EventStreamStore {
+  createStream(path: string): Promise<void>
+  appendEvent(path: string, event: unknown): Promise<string>
+  appendEventOnce(path: string, key: string, event: unknown): Promise<string>
+  appendAgentEvent(sessionId: string, chunk: PiChatEvent, opts?: { idempotencyKey?: string }): Promise<string>
+  readEvents(path: string, opts?: { offset?: string; limit?: number }): Promise<EventStreamReadResult>
+  closeStream(path: string): Promise<void>
+  getStreamMeta(path: string): Promise<EventStreamMeta | null>
+  subscribe(path: string, listener: () => void): () => void
+}
+
+export class EventStreamStoreError extends Error {
+  readonly code = 'INTERNAL_ERROR'
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'EventStreamStoreError'
+  }
+}
+
+export function formatOffset(seq: number): string {
+  if (seq === -1) return '-1'
+  if (!Number.isInteger(seq) || seq < -1) {
+    throw new EventStreamStoreError(`Invalid event stream sequence: ${seq}.`)
+  }
+  return `${ZERO_COMPONENT}_${String(seq).padStart(COMPONENT_PAD, '0')}`
+}
+
+export function parseOffset(offset: string): number {
+  if (offset === '-1') return -1
+  const match = /^\d+_(\d+)$/.exec(offset)
+  const sequence = match?.[1]
+  if (!sequence) {
+    throw new EventStreamStoreError(`Invalid event stream offset: "${offset}".`)
+  }
+  return parseInt(sequence, 10)
+}
+
+const CREATE_STREAMS_TABLE = `
+CREATE TABLE IF NOT EXISTS boring_event_streams (
+  path TEXT PRIMARY KEY,
+  next_offset INTEGER NOT NULL DEFAULT 0,
+  closed INTEGER NOT NULL DEFAULT 0
+)`
+
+const CREATE_ENTRIES_TABLE = `
+CREATE TABLE IF NOT EXISTS boring_event_stream_entries (
+  path TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  data TEXT NOT NULL,
+  PRIMARY KEY (path, seq)
+)`
+
+const CREATE_EVENT_KEYS_TABLE = `
+CREATE TABLE IF NOT EXISTS boring_event_stream_keys (
+  path TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  data TEXT NOT NULL,
+  PRIMARY KEY (path, idempotency_key),
+  UNIQUE (path, seq)
+)`
+
+export class SqliteEventStreamStore implements EventStreamStore {
+  private readonly listeners = new Map<string, Set<() => void>>()
+
+  constructor(
+    private readonly sql: SqlStorage,
+    private readonly runTransaction: RunTransaction,
+  ) {
+    migrateEventStreamSqlSchema(sql, () => {
+      sql.exec(CREATE_STREAMS_TABLE)
+      sql.exec(CREATE_ENTRIES_TABLE)
+      sql.exec(CREATE_EVENT_KEYS_TABLE)
+    })
+  }
+
+  async createStream(path: string): Promise<void> {
+    this.sql.exec(`INSERT OR IGNORE INTO boring_event_streams (path) VALUES (?)`, path)
+  }
+
+  async appendEvent(path: string, event: unknown): Promise<string> {
+    const data = JSON.stringify(event)
+    const offset = this.runTransaction(() => this.appendSerializedEvent(path, data))
+    this.notifyListeners(path)
+    return offset
+  }
+
+  async appendEventOnce(path: string, key: string, event: unknown): Promise<string> {
+    const data = JSON.stringify(event)
+    let inserted = false
+    try {
+      const offset = this.runTransaction(() => {
+        const existing = this.readIdempotencyKey(path, key)
+        if (existing) {
+          if (existing.data !== data) {
+            throw new EventStreamStoreError(`Event key "${key}" already has a conflicting payload.`)
+          }
+          return formatOffset(existing.seq)
+        }
+
+        const seq = this.allocateSeq(path)
+        this.sql.exec(
+          `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
+          path,
+          seq,
+          data,
+        )
+        this.sql.exec(
+          `INSERT INTO boring_event_stream_keys (path, idempotency_key, seq, data) VALUES (?, ?, ?, ?)`,
+          path,
+          key,
+          seq,
+          data,
+        )
+        inserted = true
+        return formatOffset(seq)
+      })
+      if (inserted) this.notifyListeners(path)
+      return offset
+    } catch (error) {
+      const existing = this.readIdempotencyKey(path, key)
+      if (existing) {
+        if (existing.data !== data) {
+          throw new EventStreamStoreError(`Event key "${key}" already has a conflicting payload.`)
+        }
+        return formatOffset(existing.seq)
+      }
+      throw error
+    }
+  }
+
+  async appendAgentEvent(sessionId: string, chunk: PiChatEvent, opts: { idempotencyKey?: string } = {}): Promise<string> {
+    const path = sessionStreamPath(sessionId)
+    let inserted = false
+    try {
+      const offset = this.runTransaction(() => {
+        if (opts.idempotencyKey !== undefined) {
+          const existing = this.readIdempotencyKey(path, opts.idempotencyKey)
+          if (existing) {
+            this.assertSameAgentIdempotencyPayload(opts.idempotencyKey, existing.data, chunk)
+            return formatOffset(existing.seq)
+          }
+        }
+
+        const seq = this.allocateSeq(path)
+        const envelope: AgentEvent = {
+          v: 1,
+          eventIndex: seq,
+          timestamp: Date.now(),
+          sessionId,
+          chunk,
+        }
+        const data = JSON.stringify(envelope)
+        const keyData = opts.idempotencyKey === undefined ? undefined : JSON.stringify(chunk)
+        this.sql.exec(
+          `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
+          path,
+          seq,
+          data,
+        )
+        if (opts.idempotencyKey !== undefined) {
+          this.sql.exec(
+            `INSERT INTO boring_event_stream_keys (path, idempotency_key, seq, data) VALUES (?, ?, ?, ?)`,
+            path,
+            opts.idempotencyKey,
+            seq,
+            keyData,
+          )
+        }
+        inserted = true
+        return formatOffset(seq)
+      })
+      if (inserted) this.notifyListeners(path)
+      return offset
+    } catch (error) {
+      if (opts.idempotencyKey !== undefined) {
+        const existing = this.readIdempotencyKey(path, opts.idempotencyKey)
+        if (existing) {
+          this.assertSameAgentIdempotencyPayload(opts.idempotencyKey, existing.data, chunk)
+          return formatOffset(existing.seq)
+        }
+      }
+      throw error
+    }
+  }
+
+  async readEvents(path: string, opts: { offset?: string; limit?: number } = {}): Promise<EventStreamReadResult> {
+    const meta = this.getStreamMetaSync(path)
+    if (!meta) {
+      return { events: [], nextOffset: formatOffset(-1), upToDate: true, closed: false }
+    }
+
+    const rawOffset = opts.offset ?? '-1'
+    const limit = clampLimit(opts.limit, DEFAULT_READ_LIMIT, MAX_READ_LIMIT)
+    let startAfter: number
+    if (rawOffset === '-1') {
+      startAfter = -1
+    } else if (rawOffset === 'now') {
+      return {
+        events: [],
+        nextOffset: meta.nextOffset,
+        upToDate: true,
+        closed: meta.closed,
+      }
+    } else {
+      startAfter = parseOffset(rawOffset)
+    }
+    const tailSeq = parseOffset(meta.nextOffset)
+    if (startAfter > tailSeq) startAfter = tailSeq
+
+    const rows = this.sql.exec(`
+      SELECT seq, data FROM boring_event_stream_entries
+      WHERE path = ? AND seq > ?
+      ORDER BY seq ASC
+      LIMIT ?
+    `, path, startAfter, limit + 1).toArray()
+    const page = rows.slice(0, limit)
+    const events = page.map((row) => ({
+      data: JSON.parse(row.data as string) as unknown,
+      offset: formatOffset(row.seq as number),
+    }))
+    const lastRow = page.at(-1)
+    const lastSeq = lastRow ? lastRow.seq as number : startAfter
+
+    return {
+      events,
+      nextOffset: formatOffset(lastSeq),
+      upToDate: rows.length <= limit,
+      closed: meta.closed,
+    }
+  }
+
+  async closeStream(path: string): Promise<void> {
+    this.sql.exec(`UPDATE boring_event_streams SET closed = 1 WHERE path = ?`, path)
+    this.notifyListeners(path)
+  }
+
+  async getStreamMeta(path: string): Promise<EventStreamMeta | null> {
+    return this.getStreamMetaSync(path)
+  }
+
+  subscribe(path: string, listener: () => void): () => void {
+    let bucket = this.listeners.get(path)
+    if (!bucket) {
+      bucket = new Set()
+      this.listeners.set(path, bucket)
+    }
+    bucket.add(listener)
+
+    return () => {
+      bucket.delete(listener)
+      if (bucket.size === 0) this.listeners.delete(path)
+    }
+  }
+
+  private appendSerializedEvent(path: string, data: string | undefined): string {
+    const seq = this.allocateSeq(path)
+    this.sql.exec(
+      `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
+      path,
+      seq,
+      data,
+    )
+    return formatOffset(seq)
+  }
+
+  private allocateSeq(path: string): number {
+    const updated = this.sql.exec(`
+      UPDATE boring_event_streams
+      SET next_offset = next_offset + 1
+      WHERE path = ? AND closed = 0
+      RETURNING next_offset
+    `, path).toArray()
+
+    if (updated.length === 0) this.throwMissingOrClosed(path)
+    const row = updated[0]
+    if (!row) throw new EventStreamStoreError(`Event stream "${path}" could not be updated.`)
+    return (row.next_offset as number) - 1
+  }
+
+  private readIdempotencyKey(path: string, key: string): { seq: number; data: string } | null {
+    const existing = this.sql.exec(
+      `SELECT seq, data FROM boring_event_stream_keys WHERE path = ? AND idempotency_key = ?`,
+      path,
+      key,
+    ).toArray()[0]
+    if (!existing) return null
+    return { seq: existing.seq as number, data: existing.data as string }
+  }
+
+  private assertSameAgentIdempotencyPayload(key: string, existingData: string, chunk: PiChatEvent): void {
+    if (existingData !== JSON.stringify(chunk)) {
+      throw new EventStreamStoreError(`Agent event key "${key}" already has a conflicting payload.`)
+    }
+  }
+
+  private throwMissingOrClosed(path: string): never {
+    const meta = this.getStreamMetaSync(path)
+    if (!meta) throw new EventStreamStoreError(`Event stream "${path}" does not exist.`)
+    throw new EventStreamStoreError(`Event stream "${path}" is closed.`)
+  }
+
+  private getStreamMetaSync(path: string): EventStreamMeta | null {
+    const row = this.sql.exec(
+      `SELECT next_offset, closed FROM boring_event_streams WHERE path = ?`,
+      path,
+    ).toArray()[0]
+    if (!row) return null
+    return {
+      nextOffset: formatOffset((row.next_offset as number) - 1),
+      closed: (row.closed as number) === 1,
+    }
+  }
+
+  private notifyListeners(path: string): void {
+    const bucket = this.listeners.get(path)
+    if (!bucket) return
+    for (const listener of [...bucket]) {
+      try {
+        listener()
+      } catch {
+        // Listener failures must not make committed writes appear failed.
+      }
+    }
+  }
+}
+
+function sessionStreamPath(sessionId: string): string {
+  return `sessions/${sessionId}`
+}
+
+function clampLimit(value: number | undefined, defaultValue: number, maxValue: number): number {
+  if (value === undefined) return defaultValue
+  const normalized = Math.floor(value)
+  if (!Number.isFinite(normalized) || normalized < 1) return defaultValue
+  return Math.min(normalized, maxValue)
+}

--- a/packages/agent/src/server/events/schemaVersion.ts
+++ b/packages/agent/src/server/events/schemaVersion.ts
@@ -1,0 +1,58 @@
+import type { SqlStorage } from './sqlStorage'
+
+export const BORING_EVENT_STREAM_SCHEMA_VERSION = 1
+
+export class EventStreamSchemaVersionError extends Error {
+  readonly code = 'INTERNAL_ERROR'
+
+  constructor(readonly storedVersion: string, readonly supportedVersion = BORING_EVENT_STREAM_SCHEMA_VERSION) {
+    super(`Unsupported event stream schema version "${storedVersion}" (expected "${supportedVersion}").`)
+    this.name = 'EventStreamSchemaVersionError'
+  }
+}
+
+export function assertSupportedEventStreamSchemaVersion(storedVersion: string): void {
+  if (storedVersion === String(BORING_EVENT_STREAM_SCHEMA_VERSION)) return
+  throw new EventStreamSchemaVersionError(storedVersion)
+}
+
+export function migrateEventStreamSqlSchema(sql: SqlStorage, ensureCurrentSchema: () => void): void {
+  sql.exec(`
+    CREATE TABLE IF NOT EXISTS boring_event_stream_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `)
+
+  const stored = sql.exec(
+    `SELECT value FROM boring_event_stream_meta WHERE key = 'schema_version'`,
+  ).toArray()[0]?.value
+
+  if (stored !== undefined && stored !== null) {
+    assertSupportedEventStreamSchemaVersion(String(stored))
+  } else {
+    const existing = sql.exec(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'table'
+        AND name LIKE 'boring_event_stream%'
+        AND name <> 'boring_event_stream_meta'
+      LIMIT 1
+    `).toArray()[0]
+    if (existing) {
+      throw new EventStreamSchemaVersionError('unversioned')
+    }
+  }
+
+  ensureCurrentSchema()
+
+  sql.exec(`
+    INSERT INTO boring_event_stream_meta (key, value)
+    VALUES ('schema_version', ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `, String(BORING_EVENT_STREAM_SCHEMA_VERSION))
+
+  const persisted = sql.exec(
+    `SELECT value FROM boring_event_stream_meta WHERE key = 'schema_version'`,
+  ).toArray()[0]?.value
+  assertSupportedEventStreamSchemaVersion(String(persisted))
+}

--- a/packages/agent/src/server/events/sqlStorage.ts
+++ b/packages/agent/src/server/events/sqlStorage.ts
@@ -1,0 +1,78 @@
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+export interface SqlResult {
+  toArray(): Array<Record<string, unknown>>
+}
+
+export interface SqlStorage {
+  exec(query: string, ...bindings: unknown[]): SqlResult
+}
+
+export type RunTransaction = <T>(fn: () => T) => T
+
+export interface OpenDatabaseResult {
+  db: DatabaseSync
+  sql: SqlStorage
+  runTransaction: RunTransaction
+}
+
+export function createNodeSqlStorage(db: DatabaseSync): SqlStorage {
+  return {
+    exec(query: string, ...bindings: unknown[]): SqlResult {
+      const stmt = db.prepare(query)
+      const expectsRows = queryExpectsRows(query)
+      const rows = expectsRows
+        ? stmt.all(...(bindings as never[])) as Array<Record<string, unknown>>
+        : []
+      if (!expectsRows) {
+        stmt.run(...(bindings as never[]))
+      }
+      return {
+        toArray() {
+          return rows
+        },
+      }
+    },
+  }
+}
+
+export function createNodeTransactionSync(db: DatabaseSync): RunTransaction {
+  return <T>(fn: () => T): T => runTransaction(db, fn)
+}
+
+export function runTransaction<T>(db: DatabaseSync, fn: () => T): T {
+  db.exec('BEGIN')
+  try {
+    const result = fn()
+    db.exec('COMMIT')
+    return result
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
+  }
+}
+
+export function openDatabase(path: string): OpenDatabaseResult {
+  if (path !== ':memory:') {
+    mkdirSync(dirname(path), { recursive: true })
+  }
+
+  const db = new DatabaseSync(path)
+  if (path !== ':memory:') {
+    db.exec('PRAGMA journal_mode=WAL')
+  }
+
+  return {
+    db,
+    sql: createNodeSqlStorage(db),
+    runTransaction: createNodeTransactionSync(db),
+  }
+}
+
+function queryExpectsRows(query: string): boolean {
+  const trimmed = query.trimStart().toUpperCase()
+  if (trimmed.startsWith('SELECT') || trimmed.startsWith('WITH') || trimmed.startsWith('PRAGMA')) return true
+  return /\bRETURNING\b/i.test(query)
+}


### PR DESCRIPTION
T1 stack 1/N (BBT1-001), stacked on the P1 chain (#530). The Durable-Streams event store: append-only SQLite, seq+envelope committed in one transaction (fixes Flue's non-transactional append), schema-versioned, 14-test conformance suite. The replay authority everything in the T-lane builds on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)