### PR TITLE
feat(391-T1): pr2 — envelope append at the harness tap

### DIFF
--- a/packages/agent/src/server/createAgent.ts
+++ b/packages/agent/src/server/createAgent.ts
@@ -1,4 +1,5 @@
 import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
+import type { EventStreamStore } from './events/eventStreamStore'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import type { PiSessionRequestContext } from './pi-chat/piSessionIdentity'
 import type { AgentHarness, AgentHarnessFactoryInput } from '../shared/harness'
@@ -40,6 +41,7 @@ export interface CreateAgentRuntimeBridgeOptions {
   service?: {
     workdir?: string
     workspace?: Workspace
+    eventStore?: EventStreamStore
   }
 }
 
@@ -257,6 +259,7 @@ async function createRuntime(config: AgentConfig, options: CreateAgentRuntimeBri
       sessionStore,
       workdir: options.service?.workdir ?? config.workdir ?? DEFAULT_WORKDIR,
       workspace: options.service?.workspace,
+      eventStore: options.service?.eventStore,
       metering: config.metering as AgentMeteringSink | undefined,
     }),
   }

--- a/packages/agent/src/server/events/eventStreamStore.ts
+++ b/packages/agent/src/server/events/eventStreamStore.ts
@@ -1,5 +1,6 @@
 import type { PiChatEvent } from '../../shared/chat'
 import type { AgentEvent } from '../../shared/events'
+import { sessionStreamPath } from '../../shared/events'
 import { migrateEventStreamSqlSchema } from './schemaVersion'
 import type { RunTransaction, SqlStorage } from './sqlStorage'
 
@@ -347,10 +348,6 @@ export class SqliteEventStreamStore implements EventStreamStore {
       }
     }
   }
-}
-
-function sessionStreamPath(sessionId: string): string {
-  return `sessions/${sessionId}`
 }
 
 function clampLimit(value: number | undefined, defaultValue: number, maxValue: number): number {

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.eventStore.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.eventStore.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent'
+import type { AgentHarness, AgentSendInput, RunContext } from '../../../shared/harness'
+import type { PiChatEvent } from '../../../shared/chat'
+import { sessionStreamPath, type AgentEvent } from '../../../shared/events'
+import type { SessionStore } from '../../../shared/session'
+import {
+  type EventStreamMeta,
+  type EventStreamReadResult,
+  type EventStreamStore,
+  SqliteEventStreamStore,
+} from '../../events/eventStreamStore'
+import { openDatabase } from '../../events/sqlStorage'
+import type { PiAgentSessionAdapter, PiAgentSessionSnapshot } from '../PiAgentSessionAdapter'
+import { HarnessPiChatService } from '../harnessPiChatService'
+import type { PiSessionRequestContext } from '../piSessionIdentity'
+
+const ctx: PiSessionRequestContext = {
+  workspaceId: 'workspace-a',
+  storageScope: 'scope-a',
+  authSubject: 'user-a',
+  requestId: 'request-a',
+}
+
+const sessionStore: SessionStore = {
+  list: vi.fn(async () => []),
+  create: vi.fn(async () => ({ id: 's1', title: 'New session', createdAt: '', updatedAt: '', turnCount: 0 })),
+  load: vi.fn(async () => ({ id: 's1', title: 'New session', createdAt: '', updatedAt: '', turnCount: 0 })),
+  delete: vi.fn(async () => {}),
+}
+
+type FakeAdapter = PiAgentSessionAdapter & { emit(event: AgentSessionEvent): void }
+
+function createAdapter(): FakeAdapter {
+  const listeners = new Set<(event: AgentSessionEvent) => void>()
+  const snapshot: PiAgentSessionSnapshot = {
+    state: {},
+    messages: [],
+    isStreaming: false,
+    isRetrying: false,
+    retryAttempt: 0,
+    pendingMessageCount: 0,
+    steeringMessages: [],
+    followUpMessages: [],
+    followUpMode: 'one-at-a-time',
+    sessionId: 's1',
+  }
+  return {
+    readSnapshot: vi.fn(() => snapshot),
+    subscribe: vi.fn((listener: (event: AgentSessionEvent) => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }),
+    prompt: vi.fn(async () => {}),
+    followUp: vi.fn(async () => {}),
+    clearFollowUp: vi.fn(),
+    abort: vi.fn(async () => {}),
+    abortRetry: vi.fn(),
+    emit(event: AgentSessionEvent) {
+      for (const listener of listeners) listener(event)
+    },
+  }
+}
+
+function createHarness(adapter: PiAgentSessionAdapter): AgentHarness & {
+  getPiSessionAdapter(input: AgentSendInput, ctx: RunContext): Promise<PiAgentSessionAdapter>
+  hasPiSession(sessionId: string): boolean
+} {
+  return {
+    id: 'fake-pi',
+    placement: 'server',
+    sessions: sessionStore,
+    hasPiSession: vi.fn(() => false),
+    getPiSessionAdapter: vi.fn(async () => adapter),
+  }
+}
+
+function createService(eventStore: EventStreamStore, adapter = createAdapter(), store: SessionStore = sessionStore) {
+  const service = new HarnessPiChatService({
+    harness: createHarness(adapter),
+    sessionStore: store,
+    workdir: '/workspace',
+    eventStore,
+  })
+  return { service, adapter }
+}
+
+describe('HarnessPiChatService event store tap', () => {
+  it('appends AgentEvent envelopes before live delivery and preserves contiguous eventIndex order', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const inner = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      const gate = deferred<void>()
+      const store = new DelayedEventStreamStore(inner, new Map([[1, gate.promise]]))
+      const { service, adapter } = createService(store)
+      const live: PiChatEvent[] = []
+      const subscription = await service.subscribe(ctx, 's1', 0, (event) => live.push(event))
+      expect(subscription.type).toBe('ok')
+      if (subscription.type !== 'ok' || !subscription.closed) throw new Error('expected closed hook')
+
+      adapter.emit({ type: 'agent_start', turnId: 'turn-1' } as unknown as AgentSessionEvent)
+      adapter.emit({ type: 'queue_update', followUp: ['next'] } as unknown as AgentSessionEvent)
+      adapter.emit({ type: 'agent_end', status: 'ok', messages: [], willRetry: false } as unknown as AgentSessionEvent)
+
+      await waitFor(() => expect(store.appendStarted).toEqual([1]))
+      expect(live).toHaveLength(0)
+      await expect(inner.readEvents(sessionStreamPath('s1'), { offset: '-1' })).resolves.toMatchObject({ events: [] })
+
+      gate.resolve()
+      await waitFor(() => expect(live).toHaveLength(3))
+      expect(store.appendStarted).toEqual([1, 2, 3])
+
+      const result = await inner.readEvents(sessionStreamPath('s1'), { offset: '-1' })
+      const envelopes = result.events.map((event) => event.data as AgentEvent)
+      expect(envelopes.map((event) => event.eventIndex)).toEqual([0, 1, 2])
+      expect(envelopes.map((event) => event.sessionId)).toEqual(['s1', 's1', 's1'])
+      expect(envelopes.map((event) => event.chunk)).toEqual(live)
+
+      if (subscription.type === 'ok') subscription.unsubscribe()
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('does not fan out an event when the durable append fails', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const inner = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      const store = new DelayedEventStreamStore(inner, new Map(), new Set([1]))
+      const { service, adapter } = createService(store)
+      const live: PiChatEvent[] = []
+      const subscription = await service.subscribe(ctx, 's1', 0, (event) => live.push(event))
+      if (subscription.type !== 'ok' || !subscription.closed) throw new Error('expected ok subscription with closed hook')
+      const closed = subscription.closed
+
+      adapter.emit({ type: 'agent_start', turnId: 'turn-1' } as unknown as AgentSessionEvent)
+
+      await waitFor(() => expect(store.appendStarted).toEqual([1]))
+      await expect(closed).rejects.toThrow('append failed for seq 1')
+      await flushAsync()
+      expect(live).toEqual([])
+      await expect(inner.readEvents(sessionStreamPath('s1'), { offset: '-1' })).resolves.toMatchObject({ events: [] })
+
+      if (subscription.type === 'ok') subscription.unsubscribe()
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('serializes metadata enrichment with durable publishing', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const inner = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      const gate = deferred<void>()
+      const store = new DelayedEventStreamStore(inner, new Map([[1, gate.promise]]))
+      const { service, adapter } = createService(store)
+      const live: PiChatEvent[] = []
+      const subscription = await service.subscribe(ctx, 's1', 0, (event) => live.push(event))
+      expect(subscription.type).toBe('ok')
+
+      await service.prompt(ctx, 's1', {
+        message: 'same text',
+        clientNonce: 'prompt-nonce',
+      })
+      adapter.emit({
+        type: 'message_start',
+        message: { id: 'u1', role: 'user', content: [{ type: 'text', text: 'same text' }] },
+      } as unknown as AgentSessionEvent)
+
+      const followUp = service.followUp(ctx, 's1', {
+        message: 'same text',
+        clientNonce: 'follow-nonce',
+        clientSeq: 7,
+      })
+      await waitFor(() => expect(adapter.followUp).toHaveBeenCalledTimes(1))
+      adapter.emit({
+        type: 'message_start',
+        message: { id: 'u2', role: 'user', content: [{ type: 'text', text: 'same text' }] },
+      } as unknown as AgentSessionEvent)
+
+      await waitFor(() => expect(store.appendStarted).toEqual([1]))
+      expect(live).toHaveLength(0)
+      gate.resolve()
+      await waitFor(() => expect(live).toHaveLength(2))
+      await followUp
+
+      expect(live[0]).toMatchObject({ type: 'message-start', messageId: 'u1', clientNonce: 'prompt-nonce' })
+      expect(live[1]).toMatchObject({ type: 'message-start', messageId: 'u2', clientNonce: 'follow-nonce', clientSeq: 7 })
+
+      if (subscription.type === 'ok') subscription.unsubscribe()
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('continues PiChatEvent seq from the durable tail after service restart', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const store = new SqliteEventStreamStore(db.sql, db.runTransaction)
+
+      const first = createService(store)
+      const firstLive: PiChatEvent[] = []
+      const firstSub = await first.service.subscribe(ctx, 's1', 0, (event) => firstLive.push(event))
+      emitSimpleTurn(first.adapter)
+      await waitFor(() => expect(firstLive).toHaveLength(2))
+      if (firstSub.type === 'ok') firstSub.unsubscribe()
+
+      const second = createService(store)
+      const secondLive: PiChatEvent[] = []
+      const secondSub = await second.service.subscribe(ctx, 's1', 2, (event) => secondLive.push(event))
+      emitSimpleTurn(second.adapter, 'turn-2')
+      await waitFor(() => expect(secondLive).toHaveLength(2))
+      if (secondSub.type === 'ok') secondSub.unsubscribe()
+
+      const result = await store.readEvents(sessionStreamPath('s1'), { offset: '-1' })
+      const envelopes = result.events.map((event) => event.data as AgentEvent)
+      expect(envelopes).toHaveLength(4)
+      expect(envelopes.map((event) => event.eventIndex)).toEqual([0, 1, 2, 3])
+      expect(envelopes.map((event) => event.chunk.seq)).toEqual([1, 2, 3, 4])
+      expect(envelopes.slice(0, 2).map((event) => event.chunk)).toEqual(firstLive)
+      expect(envelopes.slice(2).map((event) => event.chunk)).toEqual(secondLive)
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('seeds restart PiChatEvent seq from the durable tail chunk instead of eventIndex', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const store = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      await store.createStream(sessionStreamPath('s1'))
+      await store.appendAgentEvent('s1', { type: 'agent-start', seq: 9, turnId: 'old-turn' })
+
+      const restarted = createService(store)
+      const live: PiChatEvent[] = []
+      const subscription = await restarted.service.subscribe(ctx, 's1', 9, (event) => live.push(event))
+      expect(subscription.type).toBe('ok')
+      emitSimpleTurn(restarted.adapter, 'turn-10')
+      await waitFor(() => expect(live).toHaveLength(2))
+      if (subscription.type === 'ok') subscription.unsubscribe()
+
+      const result = await store.readEvents(sessionStreamPath('s1'), { offset: '-1' })
+      const envelopes = result.events.map((event) => event.data as AgentEvent)
+      expect(envelopes.map((event) => event.eventIndex)).toEqual([0, 1, 2])
+      expect(envelopes.map((event) => event.chunk.seq)).toEqual([9, 10, 11])
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('reports durable latest seq from cold persisted state', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const store = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      await store.createStream(sessionStreamPath('s1'))
+      await store.appendAgentEvent('s1', { type: 'agent-start', seq: 9, turnId: 'old-turn' })
+
+      const persistedStore: SessionStore & {
+        loadEntries(ctx: { workspaceId?: string; userId?: string }, sessionId: string): Promise<{ id: string; messages: unknown[] }>
+      } = {
+        ...sessionStore,
+        loadEntries: vi.fn(async () => ({ id: 's1', messages: [] })),
+      }
+      const { service } = createService(store, createAdapter(), persistedStore)
+
+      await expect(service.readState(ctx, 's1')).resolves.toMatchObject({
+        sessionId: 's1',
+        seq: 9,
+      })
+    } finally {
+      db.db.close()
+    }
+  })
+})
+
+class DelayedEventStreamStore implements EventStreamStore {
+  readonly appendStarted: number[] = []
+
+  constructor(
+    private readonly inner: EventStreamStore,
+    private readonly gates: Map<number, Promise<void>>,
+    private readonly failingSeqs = new Set<number>(),
+  ) {}
+
+  createStream(path: string): Promise<void> {
+    return this.inner.createStream(path)
+  }
+
+  appendEvent(path: string, event: unknown): Promise<string> {
+    return this.inner.appendEvent(path, event)
+  }
+
+  appendEventOnce(path: string, key: string, event: unknown): Promise<string> {
+    return this.inner.appendEventOnce(path, key, event)
+  }
+
+  async appendAgentEvent(sessionId: string, chunk: PiChatEvent, opts?: { idempotencyKey?: string }): Promise<string> {
+    this.appendStarted.push(chunk.seq)
+    await this.gates.get(chunk.seq)
+    if (this.failingSeqs.has(chunk.seq)) throw new Error(`append failed for seq ${chunk.seq}`)
+    return this.inner.appendAgentEvent(sessionId, chunk, opts)
+  }
+
+  readEvents(path: string, opts?: { offset?: string; limit?: number }): Promise<EventStreamReadResult> {
+    return this.inner.readEvents(path, opts)
+  }
+
+  closeStream(path: string): Promise<void> {
+    return this.inner.closeStream(path)
+  }
+
+  getStreamMeta(path: string): Promise<EventStreamMeta | null> {
+    return this.inner.getStreamMeta(path)
+  }
+
+  subscribe(path: string, listener: () => void): () => void {
+    return this.inner.subscribe(path, listener)
+  }
+}
+
+function emitSimpleTurn(adapter: FakeAdapter, turnId = 'turn-1'): void {
+  adapter.emit({ type: 'agent_start', turnId } as unknown as AgentSessionEvent)
+  adapter.emit({ type: 'agent_end', status: 'ok', messages: [], willRetry: false } as unknown as AgentSessionEvent)
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
+async function waitFor(assertion: () => void | Promise<void>): Promise<void> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await flushAsync()
+    }
+  }
+  throw lastError
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -2,7 +2,9 @@ import type { AgentHarness, RunContext, AgentSendInput } from '../../shared/harn
 import type { SessionCtx, SessionListOptions, SessionStore } from '../../shared/session'
 import type { Workspace } from '../../shared/workspace'
 import type { BoringChatMessage, BoringChatPart, ChatError, FollowUpPayload, FollowUpReceipt, InterruptPayload, PiChatEvent, PiChatSnapshot, PromptPayload, PromptReceipt, QueuedUserMessage, QueueClearPayload, QueueClearReceipt, StopPayload, StopReceipt } from '../../shared/chat'
+import { sessionStreamPath, type AgentEvent } from '../../shared/events'
 import { ErrorCode } from '../../shared/error-codes'
+import { formatOffset, parseOffset, type EventStreamStore } from '../events/eventStreamStore'
 import type { PiChatSessionService, PiChatEventSubscriber, PiChatEventStreamResult } from '../http/routes/piChat'
 import type { PiSessionCreateInit, PiSessionRequestContext } from './piSessionIdentity'
 import type { PiAgentPromptInput, PiAgentSessionAdapter } from './PiAgentSessionAdapter'
@@ -30,10 +32,14 @@ type PiSessionStoreLike = SessionStore & {
 
 interface LiveSessionChannel {
   sessionKey: string
+  streamPath: string
   buffer: PiChatReplayBuffer
   adapter: PiAgentSessionAdapter
   unsubscribe: () => void
   mapper: PiChatEventMapper
+  publishQueue: Promise<void>
+  closed: Promise<void>
+  rejectClosed: (error: unknown) => void
   activeTurnId?: string
   messageTurnIds: Map<string, string>
 }
@@ -48,6 +54,7 @@ export interface HarnessPiChatServiceOptions {
   sessionStore: SessionStore
   workdir: string
   workspace?: Workspace
+  eventStore?: EventStreamStore
   /**
    * Optional host billing sink. When set, accepted prompts/follow-ups reserve
    * before execution (a rejecting sink blocks the request), native assistant
@@ -64,6 +71,7 @@ export class HarnessPiChatService implements PiChatSessionService {
   private readonly sessionStore: PiSessionStoreLike
   private readonly workdir: string
   private readonly workspace?: Workspace
+  private readonly eventStore?: EventStreamStore
   private readonly channels = new Map<string, LiveSessionChannel>()
   // Single-flight guard so concurrent cold callers (e.g. two browser tabs each
   // opening /events while the session is still being created) converge on one
@@ -81,6 +89,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     this.sessionStore = options.sessionStore
     this.workdir = options.workdir
     this.workspace = options.workspace
+    this.eventStore = options.eventStore
     this.metering = options.metering
       ? new PiChatMeteringCoordinator(options.metering, options.meteringLogger)
       : undefined
@@ -158,7 +167,7 @@ export class HarnessPiChatService implements PiChatSessionService {
       return {
         protocolVersion: 1,
         sessionId: id,
-        seq: 0,
+        seq: await this.readDurableLatestPiChatSeq(sessionStreamPath(id)),
         status: 'idle',
         messages: buildPiChatHistory(messages, { sessionId: id }),
         queue: { followUps: [] },
@@ -173,13 +182,13 @@ export class HarnessPiChatService implements PiChatSessionService {
     const channel = await this.getChannel(ctx, sessionId)
     const result = channel.buffer.subscribe(cursor, subscriber)
     if (result.type !== 'ok') return result
-    return { type: 'ok', unsubscribe: result.unsubscribe }
+    return { type: 'ok', unsubscribe: result.unsubscribe, closed: channel.closed }
   }
 
   async prompt(ctx: PiSessionRequestContext, sessionId: string, payload: PromptPayload): Promise<PromptReceipt> {
     const sessionKey = this.sessionKey(ctx, sessionId)
     const adapter = await this.getAdapter(ctx, sessionId, payload)
-    await this.ensureChannel(ctx, sessionId, adapter)
+    const channel = await this.ensureChannel(ctx, sessionId, adapter)
     // Reserve before execution. The coordinator is the single source of dedup
     // truth: it awaits the owning run's reservation, so a concurrent duplicate
     // sees the same accept/reject (a rejecting sink — e.g. credits exhausted —
@@ -206,11 +215,10 @@ export class HarnessPiChatService implements PiChatSessionService {
     }
     if (outcome === 'cancelled') throw promptCancelledError()
     this.messageMetadata.recordPrompt(sessionKey, payload)
-    const channel = this.channels.get(sessionKey)
     const receiptCursor = nextPromptReceiptCursor(channel)
     try {
       const input = await toPiPromptInput(payload, this.workspace)
-      const run = this.trackActiveRun(sessionKey, adapter.prompt(input))
+      const run = this.trackActiveRun(sessionKey, this.runAndDrainPublishQueue(channel, adapter.prompt(input)))
       run.catch((error) => {
         this.metering?.failPromptRun(sessionId, payload.clientNonce, sessionKey)
         if (!this.messageMetadata.hasPrompt(sessionKey, { clientNonce: payload.clientNonce, displayText: payload.displayMessage ?? payload.message })) return
@@ -227,7 +235,7 @@ export class HarnessPiChatService implements PiChatSessionService {
   async followUp(ctx: PiSessionRequestContext, sessionId: string, payload: FollowUpPayload): Promise<FollowUpReceipt> {
     const sessionKey = this.sessionKey(ctx, sessionId)
     const adapter = await this.getAdapter(ctx, sessionId, payload.message)
-    await this.ensureChannel(ctx, sessionId, adapter)
+    const channel = await this.ensureChannel(ctx, sessionId, adapter)
     // Reserve before enqueuing; the coordinator awaits the owner's reservation
     // and dedups concurrent/consumed retries (so a duplicate doesn't take a
     // second hold or queue a second native follow-up).
@@ -263,6 +271,7 @@ export class HarnessPiChatService implements PiChatSessionService {
       this.messageMetadata.removeFollowUp(sessionKey, payload)
       throw err
     }
+    await this.drainPublishQueue(channel)
     return { accepted: true, queued: true, cursor: this.channels.get(sessionKey)?.buffer.latestSeq ?? 0, clientNonce: payload.clientNonce, clientSeq: payload.clientSeq }
   }
 
@@ -272,6 +281,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     if (hasFollowUpSelector(payload)) {
       const before = adapter.readSnapshot().followUpMessages.length
       adapter.clearFollowUp(payload)
+      await this.drainPublishQueue(this.channels.get(sessionKey))
       const after = adapter.readSnapshot().followUpMessages.length
       if (after < before) {
         this.messageMetadata.removeFollowUp(sessionKey, payload)
@@ -280,6 +290,7 @@ export class HarnessPiChatService implements PiChatSessionService {
       return { accepted: true, cursor: this.channels.get(sessionKey)?.buffer.latestSeq ?? 0, cleared: Math.max(0, before - after) }
     }
     const clearedQueue = this.clearAllFollowUps(adapter, sessionId, sessionKey)
+    await this.drainPublishQueue(this.channels.get(sessionKey))
     this.metering?.releaseQueued(sessionKey)
     return { accepted: true, cursor: this.channels.get(sessionKey)?.buffer.latestSeq ?? 0, cleared: clearedQueue.length }
   }
@@ -293,6 +304,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     const activeRun = this.activePromptRuns.get(sessionKey)
     adapter.abortRetry?.()
     if (wasActive) await adapter.abort()
+    await this.drainPublishQueue(this.channels.get(sessionKey))
     await activeRun?.catch(() => {})
     // Release prompt reservations stranded before agent-start. Safe before
     // auto-post: the next follow-up is still in the queue (released only when
@@ -312,6 +324,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     this.metering?.releaseQueued(sessionKey)
     this.metering?.releasePending(sessionKey)
     await adapter.abort()
+    await this.drainPublishQueue(this.channels.get(sessionKey))
     return { accepted: true, stopped: true, cursor: this.channels.get(sessionKey)?.buffer.latestSeq ?? 0, clearedQueue: buildPiChatQueuedFollowUps(sessionId, clearedQueue) }
   }
 
@@ -341,7 +354,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     this.messageMetadata.recordConsumingFollowUp(sessionKey, followUp, metadata?.serverText)
     if (adapter.continueQueuedFollowUp) {
       try {
-        await this.trackActiveRun(sessionKey, adapter.continueQueuedFollowUp())
+        await this.trackActiveRun(sessionKey, this.runAndDrainPublishQueue(this.channels.get(sessionKey), adapter.continueQueuedFollowUp()))
       } catch (err) {
         // Rejected before Pi consumed the follow-up; release its reservation.
         // A no-op if it was already consumed (the run left the queue).
@@ -368,7 +381,7 @@ export class HarnessPiChatService implements PiChatSessionService {
   }
 
   private async runPrompt(sessionKey: string, adapter: PiAgentSessionAdapter, input: PiAgentPromptInput): Promise<void> {
-    await this.trackActiveRun(sessionKey, adapter.prompt(input))
+    await this.trackActiveRun(sessionKey, this.runAndDrainPublishQueue(this.channels.get(sessionKey), adapter.prompt(input)))
   }
 
   private async trackActiveRun(sessionKey: string, run: Promise<void>): Promise<void> {
@@ -413,7 +426,44 @@ export class HarnessPiChatService implements PiChatSessionService {
     }
   }
 
-  private publishChannelEvent(sessionId: string, channel: LiveSessionChannel, event: PiChatEvent): void {
+  private publishChannelEvents(
+    sessionId: string,
+    channel: LiveSessionChannel,
+    events: PiChatEvent[],
+    afterPublish?: (publishedEvents: PiChatEvent[]) => void,
+  ): void {
+    if (!this.eventStore) {
+      const publishedEvents: PiChatEvent[] = []
+      for (const event of events) {
+        const enriched = this.messageMetadata.enrichEvent(channel.sessionKey, event)
+        publishedEvents.push(enriched)
+        this.publishChannelEventSync(channel, enriched)
+      }
+      afterPublish?.(publishedEvents)
+      return
+    }
+
+    const next = channel.publishQueue.then(async () => {
+      const publishedEvents: PiChatEvent[] = []
+      for (const event of events) {
+        const enriched = this.messageMetadata.enrichEvent(channel.sessionKey, event)
+        publishedEvents.push(enriched)
+        await this.eventStore?.appendAgentEvent(sessionId, enriched, { idempotencyKey: String(enriched.seq) })
+        this.publishChannelEventSync(channel, enriched)
+      }
+      afterPublish?.(publishedEvents)
+    }).catch((error) => {
+      channel.rejectClosed(error)
+      throw error
+    })
+    // A failed durable append intentionally poisons this live channel: later
+    // chunks cannot skip the failed PiChatEvent seq and still satisfy replay
+    // authority, so callers that await the queue must see the same failure.
+    channel.publishQueue = next
+    next.catch(() => {})
+  }
+
+  private publishChannelEventSync(channel: LiveSessionChannel, event: PiChatEvent): void {
     const sessionKey = channel.sessionKey
     if (event.type === 'agent-start') {
       channel.activeTurnId = event.turnId
@@ -436,15 +486,15 @@ export class HarnessPiChatService implements PiChatSessionService {
     const createdAt = new Date().toISOString()
     const messageId = `prompt-error:${payload.clientNonce}:user`
     const message = promptPayloadMessage(payload, messageId, createdAt, channel.activeTurnId)
-    this.publishChannelEvent(sessionId, channel, channel.mapper.mapSynthetic({
+    const messageEvent = channel.mapper.mapSynthetic({
       type: 'message-start',
       messageId,
-      role: 'user',
+      role: 'user' as const,
       clientNonce: payload.clientNonce,
       text: payload.displayMessage ?? payload.message,
       files: promptPayloadFileParts(payload, messageId),
       createdAt,
-    }))
+    })
     const promptError: ChatError = {
       code: ErrorCode.enum.INTERNAL_ERROR,
       message: error instanceof Error && error.message ? error.message : 'Prompt failed before the agent run completed.',
@@ -456,12 +506,34 @@ export class HarnessPiChatService implements PiChatSessionService {
       retryable: false,
       error: promptError,
     })
-    this.publishChannelEvent(sessionId, channel, errorEvent)
-    const failures = this.syntheticPromptFailures.get(sessionKey) ?? []
-    failures.push({ message, error: promptError })
-    this.syntheticPromptFailures.set(sessionKey, failures)
-    this.activeSyntheticPromptErrors.set(sessionKey, promptError)
-    channel.activeTurnId = undefined
+    this.publishChannelEvents(sessionId, channel, [messageEvent, errorEvent], () => {
+      const failures = this.syntheticPromptFailures.get(sessionKey) ?? []
+      failures.push({ message, error: promptError })
+      this.syntheticPromptFailures.set(sessionKey, failures)
+      this.activeSyntheticPromptErrors.set(sessionKey, promptError)
+      channel.activeTurnId = undefined
+    })
+  }
+
+  private async runAndDrainPublishQueue(channel: LiveSessionChannel | undefined, run: Promise<void>): Promise<void> {
+    let runError: unknown
+    try {
+      await run
+    } catch (error) {
+      runError = error
+    }
+
+    try {
+      await this.drainPublishQueue(channel)
+    } catch (error) {
+      if (runError === undefined) throw error
+    }
+
+    if (runError !== undefined) throw runError
+  }
+
+  private async drainPublishQueue(channel: LiveSessionChannel | undefined): Promise<void> {
+    await channel?.publishQueue
   }
 
   private async getAdapter(
@@ -530,29 +602,56 @@ export class HarnessPiChatService implements PiChatSessionService {
     }
   }
 
-  private buildChannel(sessionKey: string, sessionId: string, adapter: PiAgentSessionAdapter): LiveSessionChannel {
+  private async buildChannel(sessionKey: string, sessionId: string, adapter: PiAgentSessionAdapter): Promise<LiveSessionChannel> {
     const existing = this.channels.get(sessionKey)
     if (existing) return existing
-    const buffer = new PiChatReplayBuffer()
+    const streamPath = sessionStreamPath(sessionId)
+    await this.eventStore?.createStream(streamPath)
+    const initialSeq = await this.readDurableLatestPiChatSeq(streamPath)
+    const buffer = new PiChatReplayBuffer({ initialLatestSeq: initialSeq })
     const mapper = new PiChatEventMapper({ sessionId, initialSeq: buffer.latestSeq })
-    const channel: LiveSessionChannel = { sessionKey, buffer, adapter, unsubscribe: () => {}, mapper, messageTurnIds: new Map() }
+    const closed = deferred<void>()
+    closed.promise.catch(() => {})
+    const channel: LiveSessionChannel = {
+      sessionKey,
+      streamPath,
+      buffer,
+      adapter,
+      unsubscribe: () => {},
+      mapper,
+      publishQueue: Promise.resolve(),
+      closed: closed.promise,
+      rejectClosed: closed.reject,
+      messageTurnIds: new Map(),
+    }
     const unsubscribe = adapter.subscribe((event) => {
       const mappedEvents = mapper.map(event)
       // Metering observes the ENRICHED events: in production the native Pi
       // message for a consumed follow-up carries no clientNonce/clientSeq —
       // those selectors are recovered here by enrichEvent, and the metering
       // coordinator needs them to attribute the follow-up's usage correctly.
-      const enrichedEvents: PiChatEvent[] = []
-      for (const mapped of mappedEvents) {
-        const enriched = this.messageMetadata.enrichEvent(sessionKey, mapped)
-        enrichedEvents.push(enriched)
-        this.publishChannelEvent(sessionId, channel, enriched)
-      }
-      this.metering?.observe(sessionKey, event, enrichedEvents)
+      this.publishChannelEvents(sessionId, channel, mappedEvents, (enrichedEvents) => {
+        this.metering?.observe(sessionKey, event, enrichedEvents)
+      })
     })
     channel.unsubscribe = unsubscribe
     this.channels.set(sessionKey, channel)
     return channel
+  }
+
+  private async readDurableLatestPiChatSeq(streamPath: string): Promise<number> {
+    if (!this.eventStore) return 0
+    const meta = await this.eventStore.getStreamMeta(streamPath)
+    if (!meta) return 0
+    const tailIndex = parseOffset(meta.nextOffset)
+    if (tailIndex < 0) return 0
+    const tail = await this.eventStore.readEvents(streamPath, {
+      offset: formatOffset(tailIndex - 1),
+      limit: 1,
+    })
+    const envelope = tail.events[0]?.data as Partial<AgentEvent> | undefined
+    const seq = envelope?.chunk?.seq
+    return typeof seq === 'number' && Number.isInteger(seq) && seq >= 0 ? seq : tailIndex + 1
   }
 
   private async assertCanAccessSession(ctx: PiSessionRequestContext, sessionId: string): Promise<void> {
@@ -580,6 +679,16 @@ function promptCancelledError(): Error {
     code: ErrorCode.enum.ABORTED,
     retryable: true,
   })
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: unknown) => void } {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, resolve, reject }
 }
 
 function normalizeSessionAccessError(error: unknown, sessionId: string): unknown {

--- a/packages/agent/src/shared/events.ts
+++ b/packages/agent/src/shared/events.ts
@@ -61,6 +61,10 @@ export interface AgentEvent {
   chunk: PiChatEvent
 }
 
+export function sessionStreamPath(sessionId: string): string {
+  return `sessions/${sessionId}`
+}
+
 export interface AgentResolveInputResponse {
   approved?: boolean
   content?: string

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -29,6 +29,7 @@ export type {
 export {
   AGENT_NOT_IMPLEMENTED_UNTIL_T1,
   AgentNotImplementedError,
+  sessionStreamPath,
 } from './events'
 export type { WorkspaceRuntimeContext } from './runtime'
 export type { Workspace, Entry, Stat } from './workspace'


### PR DESCRIPTION
T1 stack 2/N (BBT1-002), stacked on #531. Every harness event is enveloped and durably appended (append-before-fanout) to the per-session EventStreamStore before live delivery — the replay authority goes live. Gates: 1,599 tests · invariants clean. Review ~10 min: the tap in harnessPiChatService + the 6 new store-integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)