### PR TITLE
re-land: #530 + #531 + #535 (stacked merges never reached main)

### DIFF
--- a/packages/agent/src/server/createAgent.ts
+++ b/packages/agent/src/server/createAgent.ts
@@ -1,4 +1,5 @@
 import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
+import type { EventStreamStore } from './events/eventStreamStore'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import type { PiSessionRequestContext } from './pi-chat/piSessionIdentity'
 import type { AgentHarness, AgentHarnessFactoryInput } from '../shared/harness'
@@ -40,6 +41,7 @@ export interface CreateAgentRuntimeBridgeOptions {
   service?: {
     workdir?: string
     workspace?: Workspace
+    eventStore?: EventStreamStore
   }
 }
 
@@ -257,6 +259,7 @@ async function createRuntime(config: AgentConfig, options: CreateAgentRuntimeBri
       sessionStore,
       workdir: options.service?.workdir ?? config.workdir ?? DEFAULT_WORKDIR,
       workspace: options.service?.workspace,
+      eventStore: options.service?.eventStore,
       metering: config.metering as AgentMeteringSink | undefined,
     }),
   }

--- a/packages/agent/src/server/createAgent.ts
+++ b/packages/agent/src/server/createAgent.ts
@@ -1,8 +1,8 @@
 import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import type { PiSessionRequestContext } from './pi-chat/piSessionIdentity'
-import type { PiChatEventStreamSubscription } from './http/routes/piChat'
 import type { AgentHarness, AgentHarnessFactoryInput } from '../shared/harness'
+import type { Workspace } from '../shared/workspace'
 import type {
   Agent,
   AgentConfig,
@@ -27,8 +27,30 @@ interface AgentRuntime {
   service: HarnessPiChatService
 }
 
+export interface AgentRuntimeAdapterView {
+  harness: AgentHarness
+  sessionStore: SessionStore
+  service: unknown
+}
+
+export interface CreateAgentRuntimeBridgeOptions {
+  harness?: {
+    runtimeCwd?: string
+  }
+  service?: {
+    workdir?: string
+    workspace?: Workspace
+  }
+}
+
+export interface AgentRuntimeBridge {
+  agent: Agent
+  getRuntime(): Promise<AgentRuntimeAdapterView>
+  currentRuntime(): Promise<AgentRuntimeAdapterView> | undefined
+}
+
 interface AgentSessionLiveState {
-  bridge?: PiChatEventStreamSubscription
+  bridge?: AgentPiChatEventStreamSubscription
   bridgePromise?: Promise<AgentSessionLiveState>
   events: AgentEvent[]
   subscribers: Set<StreamSubscriber>
@@ -42,12 +64,25 @@ interface StreamSubscriber {
   close(): void
 }
 
+interface AgentPiChatEventStreamSubscription {
+  type: 'ok'
+  unsubscribe(): void
+  closed?: Promise<void>
+}
+
 export function createAgent(config: AgentConfig): Agent {
+  return createAgentRuntimeBridge(config).agent
+}
+
+export function createAgentRuntimeBridge(
+  config: AgentConfig,
+  options: CreateAgentRuntimeBridgeOptions = {},
+): AgentRuntimeBridge {
   if (config.sessions && !config.harnessFactory) {
     throw new Error('createAgent sessions override requires a harnessFactory that uses the same SessionStore')
   }
 
-  const runtimeLoader = createRuntimeLoader(config)
+  const runtimeLoader = createRuntimeLoader(config, options)
   const getRuntime = runtimeLoader.get
   const live = new AgentLiveEventBuffer(DEFAULT_LIVE_BUFFER_SIZE)
   const sessionContexts = new Map<string, SessionCtx | undefined>()
@@ -106,7 +141,7 @@ export function createAgent(config: AgentConfig): Agent {
     return { sessionId, startIndex }
   }
 
-  return {
+  const agent: Agent = {
     sessions,
     readiness,
 
@@ -172,6 +207,12 @@ export function createAgent(config: AgentConfig): Agent {
     },
   }
 
+  return {
+    agent,
+    getRuntime,
+    currentRuntime: runtimeLoader.current,
+  }
+
   async function* authorizedStream(sessionId: string, options: AgentStreamOptions): AsyncIterable<AgentEvent> {
     const runtime = await getRuntime()
     const accessCtx = await authorizeSessionAccess(runtime, sessionId, options.ctx, sessionContexts)
@@ -179,14 +220,14 @@ export function createAgent(config: AgentConfig): Agent {
   }
 }
 
-function createRuntimeLoader(config: AgentConfig): {
+function createRuntimeLoader(config: AgentConfig, options: CreateAgentRuntimeBridgeOptions): {
   get(): Promise<AgentRuntime>
   current(): Promise<AgentRuntime> | undefined
 } {
   let runtimePromise: Promise<AgentRuntime> | undefined
   return {
     get() {
-      runtimePromise ??= createRuntime(config)
+      runtimePromise ??= createRuntime(config, options)
       return runtimePromise
     },
     current() {
@@ -195,12 +236,12 @@ function createRuntimeLoader(config: AgentConfig): {
   }
 }
 
-async function createRuntime(config: AgentConfig): Promise<AgentRuntime> {
+async function createRuntime(config: AgentConfig, options: CreateAgentRuntimeBridgeOptions): Promise<AgentRuntime> {
   const harnessFactory = config.harnessFactory ?? (await import('./harness/pi-coding-agent/createHarness')).createPiCodingAgentHarness
   const harnessInput: AgentHarnessFactoryInput = {
     tools: config.tools ?? [],
     cwd: config.workdir ?? DEFAULT_WORKDIR,
-    runtimeCwd: config.workdir,
+    runtimeCwd: options.harness?.runtimeCwd ?? options.service?.workdir ?? config.workdir,
     systemPromptAppend: config.systemPromptAppend,
     systemPromptDynamic: config.systemPromptDynamic,
     sessionRoot: config.sessionStorageRoot,
@@ -214,7 +255,8 @@ async function createRuntime(config: AgentConfig): Promise<AgentRuntime> {
     service: new HarnessPiChatService({
       harness,
       sessionStore,
-      workdir: config.workdir ?? DEFAULT_WORKDIR,
+      workdir: options.service?.workdir ?? config.workdir ?? DEFAULT_WORKDIR,
+      workspace: options.service?.workspace,
       metering: config.metering as AgentMeteringSink | undefined,
     }),
   }

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -1,7 +1,9 @@
 import Fastify, { type FastifyInstance } from 'fastify'
 import type { AgentTool } from '../shared/tool'
-import type { AgentHarness, AgentHarnessFactory } from '../shared/harness'
+import type { AgentCoreHarnessFactory, AgentHarness, AgentHarnessFactory } from '../shared/harness'
 import type { TelemetrySink } from '../shared/telemetry'
+import type { PiChatSnapshot } from '../shared/chat'
+import { ErrorCode } from '../shared/error-codes'
 import { getEnv } from './config/env'
 import type { RuntimeBundle, RuntimeModeAdapter, RuntimeModeId } from './runtime/mode'
 import { getOptionalRuntimeBundleStorageRoot } from './runtime/mode'
@@ -20,7 +22,7 @@ import { fsEventsRoutes } from './http/routes/fsEvents'
 import { treeRoutes } from './http/routes/tree'
 import { modelsRoutes } from './http/routes/models'
 import { skillsRoutes } from './http/routes/skills'
-import { piChatRoutes } from './http/routes/piChat'
+import { piChatRoutes, type PiChatSessionService } from './http/routes/piChat'
 import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
@@ -31,10 +33,10 @@ import { searchRoutes } from './http/routes/search'
 import { gitRoutes } from './http/routes/git'
 import { InMemorySessionChangesTracker } from './http/sessionChangesTracker'
 import { createRuntimeReadyStatusTracker } from './runtime/modeReadiness'
-import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
 import type { ReloadHookDiagnostic } from './http/routes/reload'
+import { createAgentRuntimeBridge } from './createAgent'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_SESSION_ID = 'default'
@@ -202,19 +204,32 @@ export async function createAgentApp(
     })] : []),
   ]
 
-  const harnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
+  const baseHarnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
     ...input,
     pi: runtimePi,
   }))
-  const harness = await harnessFactory({
-    tools,
-    cwd: workspaceRoot,
+  const harnessFactory = ((input) => baseHarnessFactory({
+    ...input,
     sessionNamespace: opts.sessionNamespace,
     sessionDir: opts.sessionDir,
+  })) as AgentCoreHarnessFactory
+  const coreAgent = createAgentRuntimeBridge({
+    runtime: modeAdapter,
+    tools,
+    harnessFactory,
     systemPromptAppend: opts.systemPromptAppend,
     systemPromptDynamic: opts.systemPromptDynamic,
     telemetry: opts.telemetry,
+    metering: opts.metering,
+    workdir: workspaceRoot,
+  }, {
+    service: {
+      workdir: runtimeBundle.workspace.root,
+      workspace: runtimeBundle.workspace,
+    },
   })
+  const agentRuntime = await coreAgent.getRuntime()
+  const harness = agentRuntime.harness
   harnessRef = harness
   const sessionChangesTracker = new InMemorySessionChangesTracker()
 
@@ -250,14 +265,9 @@ export async function createAgentApp(
   await app.register(gitRoutes, {
     getWorkspaceRoot: () => getOptionalRuntimeBundleStorageRoot(runtimeBundle),
   })
-  const piChatService = new HarnessPiChatService({
-    harness,
-    sessionStore: harness.sessions,
-    workdir: runtimeBundle.workspace.root,
-    workspace: runtimeBundle.workspace,
-    metering: opts.metering,
+  await app.register(piChatRoutes, {
+    service: createHttpCompatiblePiChatService(agentRuntime.service as PiChatSessionService),
   })
-  await app.register(piChatRoutes, { service: piChatService })
   await app.register(systemPromptRoutes, { harness })
   await app.register(modelsRoutes)
   await app.register(skillsRoutes, {
@@ -289,4 +299,53 @@ export async function createAgentApp(
   await app.register(readyStatusRoutes, { tracker: readyTracker })
 
   return app
+}
+
+function createHttpCompatiblePiChatService(service: PiChatSessionService): PiChatSessionService {
+  return new Proxy(service, {
+    get(target, prop, receiver) {
+      if (prop === 'readState') {
+        return async (...args: Parameters<PiChatSessionService['readState']>) => {
+          try {
+            return await target.readState(...args)
+          } catch (error) {
+            if (isSessionNotFoundError(error)) return emptyPiChatSnapshot(args[1])
+            throw error
+          }
+        }
+      }
+      if (prop === 'deleteSession' && typeof target.deleteSession === 'function') {
+        return async (...args: Parameters<NonNullable<PiChatSessionService['deleteSession']>>) => {
+          try {
+            return await target.deleteSession!(...args)
+          } catch (error) {
+            if (isSessionNotFoundError(error)) return
+            throw error
+          }
+        }
+      }
+      const value = Reflect.get(target, prop, receiver)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  }) as PiChatSessionService
+}
+
+function isSessionNotFoundError(error: unknown): boolean {
+  if ((error as { code?: unknown })?.code === ErrorCode.enum.SESSION_NOT_FOUND) return true
+  return error instanceof Error && (
+    error.message === 'session not found' ||
+    error.message.startsWith('Session not found:')
+  )
+}
+
+function emptyPiChatSnapshot(sessionId: string): PiChatSnapshot {
+  return {
+    protocolVersion: 1,
+    sessionId,
+    seq: 0,
+    status: 'idle',
+    messages: [],
+    queue: { followUps: [] },
+    followUpMode: 'one-at-a-time',
+  }
 }

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -2,8 +2,6 @@ import Fastify, { type FastifyInstance } from 'fastify'
 import type { AgentTool } from '../shared/tool'
 import type { AgentCoreHarnessFactory, AgentHarness, AgentHarnessFactory } from '../shared/harness'
 import type { TelemetrySink } from '../shared/telemetry'
-import type { PiChatSnapshot } from '../shared/chat'
-import { ErrorCode } from '../shared/error-codes'
 import { getEnv } from './config/env'
 import type { RuntimeBundle, RuntimeModeAdapter, RuntimeModeId } from './runtime/mode'
 import { getOptionalRuntimeBundleStorageRoot } from './runtime/mode'
@@ -266,7 +264,7 @@ export async function createAgentApp(
     getWorkspaceRoot: () => getOptionalRuntimeBundleStorageRoot(runtimeBundle),
   })
   await app.register(piChatRoutes, {
-    service: createHttpCompatiblePiChatService(agentRuntime.service as PiChatSessionService),
+    service: agentRuntime.service as PiChatSessionService,
   })
   await app.register(systemPromptRoutes, { harness })
   await app.register(modelsRoutes)
@@ -299,53 +297,4 @@ export async function createAgentApp(
   await app.register(readyStatusRoutes, { tracker: readyTracker })
 
   return app
-}
-
-function createHttpCompatiblePiChatService(service: PiChatSessionService): PiChatSessionService {
-  return new Proxy(service, {
-    get(target, prop, receiver) {
-      if (prop === 'readState') {
-        return async (...args: Parameters<PiChatSessionService['readState']>) => {
-          try {
-            return await target.readState(...args)
-          } catch (error) {
-            if (isSessionNotFoundError(error)) return emptyPiChatSnapshot(args[1])
-            throw error
-          }
-        }
-      }
-      if (prop === 'deleteSession' && typeof target.deleteSession === 'function') {
-        return async (...args: Parameters<NonNullable<PiChatSessionService['deleteSession']>>) => {
-          try {
-            return await target.deleteSession!(...args)
-          } catch (error) {
-            if (isSessionNotFoundError(error)) return
-            throw error
-          }
-        }
-      }
-      const value = Reflect.get(target, prop, receiver)
-      return typeof value === 'function' ? value.bind(target) : value
-    },
-  }) as PiChatSessionService
-}
-
-function isSessionNotFoundError(error: unknown): boolean {
-  if ((error as { code?: unknown })?.code === ErrorCode.enum.SESSION_NOT_FOUND) return true
-  return error instanceof Error && (
-    error.message === 'session not found' ||
-    error.message.startsWith('Session not found:')
-  )
-}
-
-function emptyPiChatSnapshot(sessionId: string): PiChatSnapshot {
-  return {
-    protocolVersion: 1,
-    sessionId,
-    seq: 0,
-    status: 'idle',
-    messages: [],
-    queue: { followUps: [] },
-    followUpMode: 'one-at-a-time',
-  }
 }

--- a/packages/agent/src/server/events/__tests__/eventStreamStore.conformance.test.ts
+++ b/packages/agent/src/server/events/__tests__/eventStreamStore.conformance.test.ts
@@ -1,0 +1,219 @@
+import { mkdtempSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PiChatEvent } from '../../../shared/chat'
+import type { AgentEvent } from '../../../shared/events'
+import {
+  type EventStreamStore,
+  formatOffset,
+  parseOffset,
+  SqliteEventStreamStore,
+} from '../eventStreamStore'
+import { openDatabase, type OpenDatabaseResult } from '../sqlStorage'
+
+interface StoreHarness {
+  store: EventStreamStore
+  close?: () => void | Promise<void>
+}
+
+type StoreFactory = () => StoreHarness | Promise<StoreHarness>
+
+export function runEventStreamStoreConformance(makeStore: StoreFactory): void {
+  let harness: StoreHarness | undefined
+
+  afterEach(async () => {
+    await harness?.close?.()
+    harness = undefined
+  })
+
+  async function useStore(): Promise<EventStreamStore> {
+    harness = await makeStore()
+    return harness.store
+  }
+
+  it('formats and parses Durable Streams offsets', () => {
+    expect(formatOffset(-1)).toBe('-1')
+    expect(formatOffset(0)).toBe('0000000000000000_0000000000000000')
+    expect(formatOffset(42)).toBe('0000000000000000_0000000000000042')
+    expect(parseOffset('0000000000000000_0000000000000042')).toBe(42)
+    expect(() => parseOffset('42')).toThrow(/Invalid event stream offset/)
+  })
+
+  it('appends and reads strictly after offsets with correct metadata', async () => {
+    const store = await useStore()
+    const path = 'streams/monotonic'
+    await store.createStream(path)
+
+    expect(await store.getStreamMeta(path)).toEqual({ nextOffset: '-1', closed: false })
+
+    const first = await store.appendEvent(path, { index: 0 })
+    const second = await store.appendEvent(path, { index: 1 })
+
+    expect(first).toBe(formatOffset(0))
+    expect(second).toBe(formatOffset(1))
+
+    await expect(store.readEvents(path, { offset: '-1' })).resolves.toEqual({
+      events: [
+        { data: { index: 0 }, offset: first },
+        { data: { index: 1 }, offset: second },
+      ],
+      nextOffset: second,
+      upToDate: true,
+      closed: false,
+    })
+
+    await expect(store.readEvents(path, { offset: first })).resolves.toMatchObject({
+      events: [{ data: { index: 1 }, offset: second }],
+      nextOffset: second,
+      upToDate: true,
+    })
+
+    await expect(store.readEvents(path, { offset: '-1', limit: 1 })).resolves.toMatchObject({
+      events: [{ data: { index: 0 }, offset: first }],
+      nextOffset: first,
+      upToDate: false,
+    })
+
+    await expect(store.readEvents(path, { offset: 'now' })).resolves.toEqual({
+      events: [],
+      nextOffset: second,
+      upToDate: true,
+      closed: false,
+    })
+
+    await expect(store.readEvents(path, { offset: formatOffset(100) })).resolves.toMatchObject({
+      events: [],
+      nextOffset: second,
+      upToDate: true,
+    })
+
+    const third = await store.appendEvent(path, { index: 2 })
+    await expect(store.readEvents(path, { offset: second })).resolves.toMatchObject({
+      events: [{ data: { index: 2 }, offset: third }],
+      nextOffset: third,
+    })
+  })
+
+  it('creates streams idempotently and rejects appends to missing or closed streams', async () => {
+    const store = await useStore()
+    const path = 'streams/lifecycle'
+
+    await expect(store.appendEvent(path, { beforeCreate: true })).rejects.toThrow(/does not exist/)
+    await store.createStream(path)
+    await store.createStream(path)
+    await store.closeStream(path)
+    await store.closeStream(path)
+
+    await expect(store.getStreamMeta(path)).resolves.toEqual({ nextOffset: '-1', closed: true })
+    await expect(store.appendEvent(path, { afterClose: true })).rejects.toThrow(/is closed/)
+  })
+
+  it('keeps appendEventOnce idempotent and rejects conflicting payload reuse', async () => {
+    const store = await useStore()
+    const path = 'streams/once'
+    await store.createStream(path)
+
+    const first = await store.appendEventOnce(path, 'key-1', { stable: true })
+    const retry = await store.appendEventOnce(path, 'key-1', { stable: true })
+
+    expect(retry).toBe(first)
+    await expect(store.appendEventOnce(path, 'key-1', { stable: false })).rejects.toThrow(/conflicting payload/)
+    await expect(store.readEvents(path, { offset: '-1' })).resolves.toMatchObject({
+      events: [{ data: { stable: true }, offset: first }],
+      nextOffset: first,
+    })
+  })
+
+  it('deduplicates appendAgentEvent by idempotency key without allocating another eventIndex', async () => {
+    const store = await useStore()
+    await store.createStream('sessions/session-a')
+    const chunk = piEvent(7)
+
+    const first = await store.appendAgentEvent('session-a', chunk, { idempotencyKey: String(chunk.seq) })
+    const retry = await store.appendAgentEvent('session-a', chunk, { idempotencyKey: String(chunk.seq) })
+    const [concurrentA, concurrentB] = await Promise.all([
+      store.appendAgentEvent('session-a', chunk, { idempotencyKey: String(chunk.seq) }),
+      store.appendAgentEvent('session-a', chunk, { idempotencyKey: String(chunk.seq) }),
+    ])
+
+    expect(retry).toBe(first)
+    expect(concurrentA).toBe(first)
+    expect(concurrentB).toBe(first)
+    await expect(
+      store.appendAgentEvent('session-a', piEvent(8), { idempotencyKey: String(chunk.seq) }),
+    ).rejects.toThrow(/conflicting payload/)
+
+    const result = await store.readEvents('sessions/session-a', { offset: '-1' })
+    expect(result.nextOffset).toBe(first)
+    expect(result.events).toHaveLength(1)
+    const envelope = result.events[0]?.data as AgentEvent
+    expect(envelope).toMatchObject({
+      v: 1,
+      eventIndex: 0,
+      sessionId: 'session-a',
+      chunk,
+    })
+    expect(typeof envelope.timestamp).toBe('number')
+    expect(await store.getStreamMeta('sessions/session-a')).toEqual({ nextOffset: first, closed: false })
+  })
+
+  it('rolls back appendAgentEvent when envelope serialization throws', async () => {
+    const store = await useStore()
+    await store.createStream('sessions/atomic')
+    const badChunk = { ...piEvent(1), bad: 1n } as unknown as PiChatEvent
+
+    await expect(store.appendAgentEvent('atomic', badChunk)).rejects.toThrow(/serialize a BigInt/)
+    await expect(store.getStreamMeta('sessions/atomic')).resolves.toEqual({ nextOffset: '-1', closed: false })
+    await expect(store.readEvents('sessions/atomic', { offset: '-1' })).resolves.toMatchObject({
+      events: [],
+      nextOffset: '-1',
+    })
+
+    const offset = await store.appendAgentEvent('atomic', piEvent(2))
+    expect(offset).toBe(formatOffset(0))
+    const result = await store.readEvents('sessions/atomic', { offset: '-1' })
+    expect((result.events[0]?.data as AgentEvent).eventIndex).toBe(0)
+  })
+
+  it('fires subscribers on append and stops after unsubscribe', async () => {
+    const store = await useStore()
+    const path = 'streams/subscribers'
+    const listener = vi.fn()
+    await store.createStream(path)
+    const unsubscribe = store.subscribe(path, listener)
+
+    await store.appendEvent(path, { one: true })
+    expect(listener).toHaveBeenCalledTimes(1)
+
+    unsubscribe()
+    await store.appendEvent(path, { two: true })
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+}
+
+describe('SqliteEventStreamStore (:memory:)', () => {
+  runEventStreamStoreConformance(() => {
+    const db = openDatabase(':memory:')
+    return makeHarness(db)
+  })
+})
+
+describe('SqliteEventStreamStore (file)', () => {
+  runEventStreamStoreConformance(() => {
+    const dir = mkdtempSync(join(tmpdir(), 'boring-event-stream-'))
+    const db = openDatabase(join(dir, 'events.sqlite'))
+    return makeHarness(db)
+  })
+})
+
+function makeHarness(db: OpenDatabaseResult): StoreHarness {
+  return {
+    store: new SqliteEventStreamStore(db.sql, db.runTransaction),
+    close: () => db.db.close(),
+  }
+}
+
+function piEvent(seq: number): PiChatEvent {
+  return { type: 'agent-start', seq, turnId: `turn-${seq}` }
+}

--- a/packages/agent/src/server/events/eventStreamStore.ts
+++ b/packages/agent/src/server/events/eventStreamStore.ts
@@ -1,0 +1,361 @@
+import type { PiChatEvent } from '../../shared/chat'
+import type { AgentEvent } from '../../shared/events'
+import { migrateEventStreamSqlSchema } from './schemaVersion'
+import type { RunTransaction, SqlStorage } from './sqlStorage'
+
+const COMPONENT_PAD = 16
+const ZERO_COMPONENT = '0'.repeat(COMPONENT_PAD)
+
+export const DEFAULT_READ_LIMIT = 100
+export const MAX_READ_LIMIT = 1000
+
+export interface EventStreamReadResult {
+  events: Array<{ data: unknown; offset: string }>
+  nextOffset: string
+  upToDate: boolean
+  closed: boolean
+}
+
+export interface EventStreamMeta {
+  nextOffset: string
+  closed: boolean
+}
+
+export interface EventStreamStore {
+  createStream(path: string): Promise<void>
+  appendEvent(path: string, event: unknown): Promise<string>
+  appendEventOnce(path: string, key: string, event: unknown): Promise<string>
+  appendAgentEvent(sessionId: string, chunk: PiChatEvent, opts?: { idempotencyKey?: string }): Promise<string>
+  readEvents(path: string, opts?: { offset?: string; limit?: number }): Promise<EventStreamReadResult>
+  closeStream(path: string): Promise<void>
+  getStreamMeta(path: string): Promise<EventStreamMeta | null>
+  subscribe(path: string, listener: () => void): () => void
+}
+
+export class EventStreamStoreError extends Error {
+  readonly code = 'INTERNAL_ERROR'
+
+  constructor(message: string) {
+    super(message)
+    this.name = 'EventStreamStoreError'
+  }
+}
+
+export function formatOffset(seq: number): string {
+  if (seq === -1) return '-1'
+  if (!Number.isInteger(seq) || seq < -1) {
+    throw new EventStreamStoreError(`Invalid event stream sequence: ${seq}.`)
+  }
+  return `${ZERO_COMPONENT}_${String(seq).padStart(COMPONENT_PAD, '0')}`
+}
+
+export function parseOffset(offset: string): number {
+  if (offset === '-1') return -1
+  const match = /^\d+_(\d+)$/.exec(offset)
+  const sequence = match?.[1]
+  if (!sequence) {
+    throw new EventStreamStoreError(`Invalid event stream offset: "${offset}".`)
+  }
+  return parseInt(sequence, 10)
+}
+
+const CREATE_STREAMS_TABLE = `
+CREATE TABLE IF NOT EXISTS boring_event_streams (
+  path TEXT PRIMARY KEY,
+  next_offset INTEGER NOT NULL DEFAULT 0,
+  closed INTEGER NOT NULL DEFAULT 0
+)`
+
+const CREATE_ENTRIES_TABLE = `
+CREATE TABLE IF NOT EXISTS boring_event_stream_entries (
+  path TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  data TEXT NOT NULL,
+  PRIMARY KEY (path, seq)
+)`
+
+const CREATE_EVENT_KEYS_TABLE = `
+CREATE TABLE IF NOT EXISTS boring_event_stream_keys (
+  path TEXT NOT NULL,
+  idempotency_key TEXT NOT NULL,
+  seq INTEGER NOT NULL,
+  data TEXT NOT NULL,
+  PRIMARY KEY (path, idempotency_key),
+  UNIQUE (path, seq)
+)`
+
+export class SqliteEventStreamStore implements EventStreamStore {
+  private readonly listeners = new Map<string, Set<() => void>>()
+
+  constructor(
+    private readonly sql: SqlStorage,
+    private readonly runTransaction: RunTransaction,
+  ) {
+    migrateEventStreamSqlSchema(sql, () => {
+      sql.exec(CREATE_STREAMS_TABLE)
+      sql.exec(CREATE_ENTRIES_TABLE)
+      sql.exec(CREATE_EVENT_KEYS_TABLE)
+    })
+  }
+
+  async createStream(path: string): Promise<void> {
+    this.sql.exec(`INSERT OR IGNORE INTO boring_event_streams (path) VALUES (?)`, path)
+  }
+
+  async appendEvent(path: string, event: unknown): Promise<string> {
+    const data = JSON.stringify(event)
+    const offset = this.runTransaction(() => this.appendSerializedEvent(path, data))
+    this.notifyListeners(path)
+    return offset
+  }
+
+  async appendEventOnce(path: string, key: string, event: unknown): Promise<string> {
+    const data = JSON.stringify(event)
+    let inserted = false
+    try {
+      const offset = this.runTransaction(() => {
+        const existing = this.readIdempotencyKey(path, key)
+        if (existing) {
+          if (existing.data !== data) {
+            throw new EventStreamStoreError(`Event key "${key}" already has a conflicting payload.`)
+          }
+          return formatOffset(existing.seq)
+        }
+
+        const seq = this.allocateSeq(path)
+        this.sql.exec(
+          `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
+          path,
+          seq,
+          data,
+        )
+        this.sql.exec(
+          `INSERT INTO boring_event_stream_keys (path, idempotency_key, seq, data) VALUES (?, ?, ?, ?)`,
+          path,
+          key,
+          seq,
+          data,
+        )
+        inserted = true
+        return formatOffset(seq)
+      })
+      if (inserted) this.notifyListeners(path)
+      return offset
+    } catch (error) {
+      const existing = this.readIdempotencyKey(path, key)
+      if (existing) {
+        if (existing.data !== data) {
+          throw new EventStreamStoreError(`Event key "${key}" already has a conflicting payload.`)
+        }
+        return formatOffset(existing.seq)
+      }
+      throw error
+    }
+  }
+
+  async appendAgentEvent(sessionId: string, chunk: PiChatEvent, opts: { idempotencyKey?: string } = {}): Promise<string> {
+    const path = sessionStreamPath(sessionId)
+    let inserted = false
+    try {
+      const offset = this.runTransaction(() => {
+        if (opts.idempotencyKey !== undefined) {
+          const existing = this.readIdempotencyKey(path, opts.idempotencyKey)
+          if (existing) {
+            this.assertSameAgentIdempotencyPayload(opts.idempotencyKey, existing.data, chunk)
+            return formatOffset(existing.seq)
+          }
+        }
+
+        const seq = this.allocateSeq(path)
+        const envelope: AgentEvent = {
+          v: 1,
+          eventIndex: seq,
+          timestamp: Date.now(),
+          sessionId,
+          chunk,
+        }
+        const data = JSON.stringify(envelope)
+        const keyData = opts.idempotencyKey === undefined ? undefined : JSON.stringify(chunk)
+        this.sql.exec(
+          `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
+          path,
+          seq,
+          data,
+        )
+        if (opts.idempotencyKey !== undefined) {
+          this.sql.exec(
+            `INSERT INTO boring_event_stream_keys (path, idempotency_key, seq, data) VALUES (?, ?, ?, ?)`,
+            path,
+            opts.idempotencyKey,
+            seq,
+            keyData,
+          )
+        }
+        inserted = true
+        return formatOffset(seq)
+      })
+      if (inserted) this.notifyListeners(path)
+      return offset
+    } catch (error) {
+      if (opts.idempotencyKey !== undefined) {
+        const existing = this.readIdempotencyKey(path, opts.idempotencyKey)
+        if (existing) {
+          this.assertSameAgentIdempotencyPayload(opts.idempotencyKey, existing.data, chunk)
+          return formatOffset(existing.seq)
+        }
+      }
+      throw error
+    }
+  }
+
+  async readEvents(path: string, opts: { offset?: string; limit?: number } = {}): Promise<EventStreamReadResult> {
+    const meta = this.getStreamMetaSync(path)
+    if (!meta) {
+      return { events: [], nextOffset: formatOffset(-1), upToDate: true, closed: false }
+    }
+
+    const rawOffset = opts.offset ?? '-1'
+    const limit = clampLimit(opts.limit, DEFAULT_READ_LIMIT, MAX_READ_LIMIT)
+    let startAfter: number
+    if (rawOffset === '-1') {
+      startAfter = -1
+    } else if (rawOffset === 'now') {
+      return {
+        events: [],
+        nextOffset: meta.nextOffset,
+        upToDate: true,
+        closed: meta.closed,
+      }
+    } else {
+      startAfter = parseOffset(rawOffset)
+    }
+    const tailSeq = parseOffset(meta.nextOffset)
+    if (startAfter > tailSeq) startAfter = tailSeq
+
+    const rows = this.sql.exec(`
+      SELECT seq, data FROM boring_event_stream_entries
+      WHERE path = ? AND seq > ?
+      ORDER BY seq ASC
+      LIMIT ?
+    `, path, startAfter, limit + 1).toArray()
+    const page = rows.slice(0, limit)
+    const events = page.map((row) => ({
+      data: JSON.parse(row.data as string) as unknown,
+      offset: formatOffset(row.seq as number),
+    }))
+    const lastRow = page.at(-1)
+    const lastSeq = lastRow ? lastRow.seq as number : startAfter
+
+    return {
+      events,
+      nextOffset: formatOffset(lastSeq),
+      upToDate: rows.length <= limit,
+      closed: meta.closed,
+    }
+  }
+
+  async closeStream(path: string): Promise<void> {
+    this.sql.exec(`UPDATE boring_event_streams SET closed = 1 WHERE path = ?`, path)
+    this.notifyListeners(path)
+  }
+
+  async getStreamMeta(path: string): Promise<EventStreamMeta | null> {
+    return this.getStreamMetaSync(path)
+  }
+
+  subscribe(path: string, listener: () => void): () => void {
+    let bucket = this.listeners.get(path)
+    if (!bucket) {
+      bucket = new Set()
+      this.listeners.set(path, bucket)
+    }
+    bucket.add(listener)
+
+    return () => {
+      bucket.delete(listener)
+      if (bucket.size === 0) this.listeners.delete(path)
+    }
+  }
+
+  private appendSerializedEvent(path: string, data: string | undefined): string {
+    const seq = this.allocateSeq(path)
+    this.sql.exec(
+      `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
+      path,
+      seq,
+      data,
+    )
+    return formatOffset(seq)
+  }
+
+  private allocateSeq(path: string): number {
+    const updated = this.sql.exec(`
+      UPDATE boring_event_streams
+      SET next_offset = next_offset + 1
+      WHERE path = ? AND closed = 0
+      RETURNING next_offset
+    `, path).toArray()
+
+    if (updated.length === 0) this.throwMissingOrClosed(path)
+    const row = updated[0]
+    if (!row) throw new EventStreamStoreError(`Event stream "${path}" could not be updated.`)
+    return (row.next_offset as number) - 1
+  }
+
+  private readIdempotencyKey(path: string, key: string): { seq: number; data: string } | null {
+    const existing = this.sql.exec(
+      `SELECT seq, data FROM boring_event_stream_keys WHERE path = ? AND idempotency_key = ?`,
+      path,
+      key,
+    ).toArray()[0]
+    if (!existing) return null
+    return { seq: existing.seq as number, data: existing.data as string }
+  }
+
+  private assertSameAgentIdempotencyPayload(key: string, existingData: string, chunk: PiChatEvent): void {
+    if (existingData !== JSON.stringify(chunk)) {
+      throw new EventStreamStoreError(`Agent event key "${key}" already has a conflicting payload.`)
+    }
+  }
+
+  private throwMissingOrClosed(path: string): never {
+    const meta = this.getStreamMetaSync(path)
+    if (!meta) throw new EventStreamStoreError(`Event stream "${path}" does not exist.`)
+    throw new EventStreamStoreError(`Event stream "${path}" is closed.`)
+  }
+
+  private getStreamMetaSync(path: string): EventStreamMeta | null {
+    const row = this.sql.exec(
+      `SELECT next_offset, closed FROM boring_event_streams WHERE path = ?`,
+      path,
+    ).toArray()[0]
+    if (!row) return null
+    return {
+      nextOffset: formatOffset((row.next_offset as number) - 1),
+      closed: (row.closed as number) === 1,
+    }
+  }
+
+  private notifyListeners(path: string): void {
+    const bucket = this.listeners.get(path)
+    if (!bucket) return
+    for (const listener of [...bucket]) {
+      try {
+        listener()
+      } catch {
+        // Listener failures must not make committed writes appear failed.
+      }
+    }
+  }
+}
+
+function sessionStreamPath(sessionId: string): string {
+  return `sessions/${sessionId}`
+}
+
+function clampLimit(value: number | undefined, defaultValue: number, maxValue: number): number {
+  if (value === undefined) return defaultValue
+  const normalized = Math.floor(value)
+  if (!Number.isFinite(normalized) || normalized < 1) return defaultValue
+  return Math.min(normalized, maxValue)
+}

--- a/packages/agent/src/server/events/eventStreamStore.ts
+++ b/packages/agent/src/server/events/eventStreamStore.ts
@@ -1,5 +1,6 @@
 import type { PiChatEvent } from '../../shared/chat'
 import type { AgentEvent } from '../../shared/events'
+import { sessionStreamPath } from '../../shared/events'
 import { migrateEventStreamSqlSchema } from './schemaVersion'
 import type { RunTransaction, SqlStorage } from './sqlStorage'
 
@@ -347,10 +348,6 @@ export class SqliteEventStreamStore implements EventStreamStore {
       }
     }
   }
-}
-
-function sessionStreamPath(sessionId: string): string {
-  return `sessions/${sessionId}`
 }
 
 function clampLimit(value: number | undefined, defaultValue: number, maxValue: number): number {

--- a/packages/agent/src/server/events/schemaVersion.ts
+++ b/packages/agent/src/server/events/schemaVersion.ts
@@ -1,0 +1,58 @@
+import type { SqlStorage } from './sqlStorage'
+
+export const BORING_EVENT_STREAM_SCHEMA_VERSION = 1
+
+export class EventStreamSchemaVersionError extends Error {
+  readonly code = 'INTERNAL_ERROR'
+
+  constructor(readonly storedVersion: string, readonly supportedVersion = BORING_EVENT_STREAM_SCHEMA_VERSION) {
+    super(`Unsupported event stream schema version "${storedVersion}" (expected "${supportedVersion}").`)
+    this.name = 'EventStreamSchemaVersionError'
+  }
+}
+
+export function assertSupportedEventStreamSchemaVersion(storedVersion: string): void {
+  if (storedVersion === String(BORING_EVENT_STREAM_SCHEMA_VERSION)) return
+  throw new EventStreamSchemaVersionError(storedVersion)
+}
+
+export function migrateEventStreamSqlSchema(sql: SqlStorage, ensureCurrentSchema: () => void): void {
+  sql.exec(`
+    CREATE TABLE IF NOT EXISTS boring_event_stream_meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )
+  `)
+
+  const stored = sql.exec(
+    `SELECT value FROM boring_event_stream_meta WHERE key = 'schema_version'`,
+  ).toArray()[0]?.value
+
+  if (stored !== undefined && stored !== null) {
+    assertSupportedEventStreamSchemaVersion(String(stored))
+  } else {
+    const existing = sql.exec(`
+      SELECT name FROM sqlite_master
+      WHERE type = 'table'
+        AND name LIKE 'boring_event_stream%'
+        AND name <> 'boring_event_stream_meta'
+      LIMIT 1
+    `).toArray()[0]
+    if (existing) {
+      throw new EventStreamSchemaVersionError('unversioned')
+    }
+  }
+
+  ensureCurrentSchema()
+
+  sql.exec(`
+    INSERT INTO boring_event_stream_meta (key, value)
+    VALUES ('schema_version', ?)
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value
+  `, String(BORING_EVENT_STREAM_SCHEMA_VERSION))
+
+  const persisted = sql.exec(
+    `SELECT value FROM boring_event_stream_meta WHERE key = 'schema_version'`,
+  ).toArray()[0]?.value
+  assertSupportedEventStreamSchemaVersion(String(persisted))
+}

--- a/packages/agent/src/server/events/sqlStorage.ts
+++ b/packages/agent/src/server/events/sqlStorage.ts
@@ -1,0 +1,78 @@
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+export interface SqlResult {
+  toArray(): Array<Record<string, unknown>>
+}
+
+export interface SqlStorage {
+  exec(query: string, ...bindings: unknown[]): SqlResult
+}
+
+export type RunTransaction = <T>(fn: () => T) => T
+
+export interface OpenDatabaseResult {
+  db: DatabaseSync
+  sql: SqlStorage
+  runTransaction: RunTransaction
+}
+
+export function createNodeSqlStorage(db: DatabaseSync): SqlStorage {
+  return {
+    exec(query: string, ...bindings: unknown[]): SqlResult {
+      const stmt = db.prepare(query)
+      const expectsRows = queryExpectsRows(query)
+      const rows = expectsRows
+        ? stmt.all(...(bindings as never[])) as Array<Record<string, unknown>>
+        : []
+      if (!expectsRows) {
+        stmt.run(...(bindings as never[]))
+      }
+      return {
+        toArray() {
+          return rows
+        },
+      }
+    },
+  }
+}
+
+export function createNodeTransactionSync(db: DatabaseSync): RunTransaction {
+  return <T>(fn: () => T): T => runTransaction(db, fn)
+}
+
+export function runTransaction<T>(db: DatabaseSync, fn: () => T): T {
+  db.exec('BEGIN')
+  try {
+    const result = fn()
+    db.exec('COMMIT')
+    return result
+  } catch (error) {
+    db.exec('ROLLBACK')
+    throw error
+  }
+}
+
+export function openDatabase(path: string): OpenDatabaseResult {
+  if (path !== ':memory:') {
+    mkdirSync(dirname(path), { recursive: true })
+  }
+
+  const db = new DatabaseSync(path)
+  if (path !== ':memory:') {
+    db.exec('PRAGMA journal_mode=WAL')
+  }
+
+  return {
+    db,
+    sql: createNodeSqlStorage(db),
+    runTransaction: createNodeTransactionSync(db),
+  }
+}
+
+function queryExpectsRows(query: string): boolean {
+  const trimmed = query.trimStart().toUpperCase()
+  if (trimmed.startsWith('SELECT') || trimmed.startsWith('WITH') || trimmed.startsWith('PRAGMA')) return true
+  return /\bRETURNING\b/i.test(query)
+}

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.eventStore.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.eventStore.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent'
+import type { AgentHarness, AgentSendInput, RunContext } from '../../../shared/harness'
+import type { PiChatEvent } from '../../../shared/chat'
+import { sessionStreamPath, type AgentEvent } from '../../../shared/events'
+import type { SessionStore } from '../../../shared/session'
+import {
+  type EventStreamMeta,
+  type EventStreamReadResult,
+  type EventStreamStore,
+  SqliteEventStreamStore,
+} from '../../events/eventStreamStore'
+import { openDatabase } from '../../events/sqlStorage'
+import type { PiAgentSessionAdapter, PiAgentSessionSnapshot } from '../PiAgentSessionAdapter'
+import { HarnessPiChatService } from '../harnessPiChatService'
+import type { PiSessionRequestContext } from '../piSessionIdentity'
+
+const ctx: PiSessionRequestContext = {
+  workspaceId: 'workspace-a',
+  storageScope: 'scope-a',
+  authSubject: 'user-a',
+  requestId: 'request-a',
+}
+
+const sessionStore: SessionStore = {
+  list: vi.fn(async () => []),
+  create: vi.fn(async () => ({ id: 's1', title: 'New session', createdAt: '', updatedAt: '', turnCount: 0 })),
+  load: vi.fn(async () => ({ id: 's1', title: 'New session', createdAt: '', updatedAt: '', turnCount: 0 })),
+  delete: vi.fn(async () => {}),
+}
+
+type FakeAdapter = PiAgentSessionAdapter & { emit(event: AgentSessionEvent): void }
+
+function createAdapter(): FakeAdapter {
+  const listeners = new Set<(event: AgentSessionEvent) => void>()
+  const snapshot: PiAgentSessionSnapshot = {
+    state: {},
+    messages: [],
+    isStreaming: false,
+    isRetrying: false,
+    retryAttempt: 0,
+    pendingMessageCount: 0,
+    steeringMessages: [],
+    followUpMessages: [],
+    followUpMode: 'one-at-a-time',
+    sessionId: 's1',
+  }
+  return {
+    readSnapshot: vi.fn(() => snapshot),
+    subscribe: vi.fn((listener: (event: AgentSessionEvent) => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }),
+    prompt: vi.fn(async () => {}),
+    followUp: vi.fn(async () => {}),
+    clearFollowUp: vi.fn(),
+    abort: vi.fn(async () => {}),
+    abortRetry: vi.fn(),
+    emit(event: AgentSessionEvent) {
+      for (const listener of listeners) listener(event)
+    },
+  }
+}
+
+function createHarness(adapter: PiAgentSessionAdapter): AgentHarness & {
+  getPiSessionAdapter(input: AgentSendInput, ctx: RunContext): Promise<PiAgentSessionAdapter>
+  hasPiSession(sessionId: string): boolean
+} {
+  return {
+    id: 'fake-pi',
+    placement: 'server',
+    sessions: sessionStore,
+    hasPiSession: vi.fn(() => false),
+    getPiSessionAdapter: vi.fn(async () => adapter),
+  }
+}
+
+function createService(eventStore: EventStreamStore, adapter = createAdapter(), store: SessionStore = sessionStore) {
+  const service = new HarnessPiChatService({
+    harness: createHarness(adapter),
+    sessionStore: store,
+    workdir: '/workspace',
+    eventStore,
+  })
+  return { service, adapter }
+}
+
+describe('HarnessPiChatService event store tap', () => {
+  it('appends AgentEvent envelopes before live delivery and preserves contiguous eventIndex order', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const inner = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      const gate = deferred<void>()
+      const store = new DelayedEventStreamStore(inner, new Map([[1, gate.promise]]))
+      const { service, adapter } = createService(store)
+      const live: PiChatEvent[] = []
+      const subscription = await service.subscribe(ctx, 's1', 0, (event) => live.push(event))
+      expect(subscription.type).toBe('ok')
+      if (subscription.type !== 'ok' || !subscription.closed) throw new Error('expected closed hook')
+
+      adapter.emit({ type: 'agent_start', turnId: 'turn-1' } as unknown as AgentSessionEvent)
+      adapter.emit({ type: 'queue_update', followUp: ['next'] } as unknown as AgentSessionEvent)
+      adapter.emit({ type: 'agent_end', status: 'ok', messages: [], willRetry: false } as unknown as AgentSessionEvent)
+
+      await waitFor(() => expect(store.appendStarted).toEqual([1]))
+      expect(live).toHaveLength(0)
+      await expect(inner.readEvents(sessionStreamPath('s1'), { offset: '-1' })).resolves.toMatchObject({ events: [] })
+
+      gate.resolve()
+      await waitFor(() => expect(live).toHaveLength(3))
+      expect(store.appendStarted).toEqual([1, 2, 3])
+
+      const result = await inner.readEvents(sessionStreamPath('s1'), { offset: '-1' })
+      const envelopes = result.events.map((event) => event.data as AgentEvent)
+      expect(envelopes.map((event) => event.eventIndex)).toEqual([0, 1, 2])
+      expect(envelopes.map((event) => event.sessionId)).toEqual(['s1', 's1', 's1'])
+      expect(envelopes.map((event) => event.chunk)).toEqual(live)
+
+      if (subscription.type === 'ok') subscription.unsubscribe()
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('does not fan out an event when the durable append fails', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const inner = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      const store = new DelayedEventStreamStore(inner, new Map(), new Set([1]))
+      const { service, adapter } = createService(store)
+      const live: PiChatEvent[] = []
+      const subscription = await service.subscribe(ctx, 's1', 0, (event) => live.push(event))
+      if (subscription.type !== 'ok' || !subscription.closed) throw new Error('expected ok subscription with closed hook')
+      const closed = subscription.closed
+
+      adapter.emit({ type: 'agent_start', turnId: 'turn-1' } as unknown as AgentSessionEvent)
+
+      await waitFor(() => expect(store.appendStarted).toEqual([1]))
+      await expect(closed).rejects.toThrow('append failed for seq 1')
+      await flushAsync()
+      expect(live).toEqual([])
+      await expect(inner.readEvents(sessionStreamPath('s1'), { offset: '-1' })).resolves.toMatchObject({ events: [] })
+
+      if (subscription.type === 'ok') subscription.unsubscribe()
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('serializes metadata enrichment with durable publishing', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const inner = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      const gate = deferred<void>()
+      const store = new DelayedEventStreamStore(inner, new Map([[1, gate.promise]]))
+      const { service, adapter } = createService(store)
+      const live: PiChatEvent[] = []
+      const subscription = await service.subscribe(ctx, 's1', 0, (event) => live.push(event))
+      expect(subscription.type).toBe('ok')
+
+      await service.prompt(ctx, 's1', {
+        message: 'same text',
+        clientNonce: 'prompt-nonce',
+      })
+      adapter.emit({
+        type: 'message_start',
+        message: { id: 'u1', role: 'user', content: [{ type: 'text', text: 'same text' }] },
+      } as unknown as AgentSessionEvent)
+
+      const followUp = service.followUp(ctx, 's1', {
+        message: 'same text',
+        clientNonce: 'follow-nonce',
+        clientSeq: 7,
+      })
+      await waitFor(() => expect(adapter.followUp).toHaveBeenCalledTimes(1))
+      adapter.emit({
+        type: 'message_start',
+        message: { id: 'u2', role: 'user', content: [{ type: 'text', text: 'same text' }] },
+      } as unknown as AgentSessionEvent)
+
+      await waitFor(() => expect(store.appendStarted).toEqual([1]))
+      expect(live).toHaveLength(0)
+      gate.resolve()
+      await waitFor(() => expect(live).toHaveLength(2))
+      await followUp
+
+      expect(live[0]).toMatchObject({ type: 'message-start', messageId: 'u1', clientNonce: 'prompt-nonce' })
+      expect(live[1]).toMatchObject({ type: 'message-start', messageId: 'u2', clientNonce: 'follow-nonce', clientSeq: 7 })
+
+      if (subscription.type === 'ok') subscription.unsubscribe()
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('continues PiChatEvent seq from the durable tail after service restart', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const store = new SqliteEventStreamStore(db.sql, db.runTransaction)
+
+      const first = createService(store)
+      const firstLive: PiChatEvent[] = []
+      const firstSub = await first.service.subscribe(ctx, 's1', 0, (event) => firstLive.push(event))
+      emitSimpleTurn(first.adapter)
+      await waitFor(() => expect(firstLive).toHaveLength(2))
+      if (firstSub.type === 'ok') firstSub.unsubscribe()
+
+      const second = createService(store)
+      const secondLive: PiChatEvent[] = []
+      const secondSub = await second.service.subscribe(ctx, 's1', 2, (event) => secondLive.push(event))
+      emitSimpleTurn(second.adapter, 'turn-2')
+      await waitFor(() => expect(secondLive).toHaveLength(2))
+      if (secondSub.type === 'ok') secondSub.unsubscribe()
+
+      const result = await store.readEvents(sessionStreamPath('s1'), { offset: '-1' })
+      const envelopes = result.events.map((event) => event.data as AgentEvent)
+      expect(envelopes).toHaveLength(4)
+      expect(envelopes.map((event) => event.eventIndex)).toEqual([0, 1, 2, 3])
+      expect(envelopes.map((event) => event.chunk.seq)).toEqual([1, 2, 3, 4])
+      expect(envelopes.slice(0, 2).map((event) => event.chunk)).toEqual(firstLive)
+      expect(envelopes.slice(2).map((event) => event.chunk)).toEqual(secondLive)
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('seeds restart PiChatEvent seq from the durable tail chunk instead of eventIndex', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const store = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      await store.createStream(sessionStreamPath('s1'))
+      await store.appendAgentEvent('s1', { type: 'agent-start', seq: 9, turnId: 'old-turn' })
+
+      const restarted = createService(store)
+      const live: PiChatEvent[] = []
+      const subscription = await restarted.service.subscribe(ctx, 's1', 9, (event) => live.push(event))
+      expect(subscription.type).toBe('ok')
+      emitSimpleTurn(restarted.adapter, 'turn-10')
+      await waitFor(() => expect(live).toHaveLength(2))
+      if (subscription.type === 'ok') subscription.unsubscribe()
+
+      const result = await store.readEvents(sessionStreamPath('s1'), { offset: '-1' })
+      const envelopes = result.events.map((event) => event.data as AgentEvent)
+      expect(envelopes.map((event) => event.eventIndex)).toEqual([0, 1, 2])
+      expect(envelopes.map((event) => event.chunk.seq)).toEqual([9, 10, 11])
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('reports durable latest seq from cold persisted state', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const store = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      await store.createStream(sessionStreamPath('s1'))
+      await store.appendAgentEvent('s1', { type: 'agent-start', seq: 9, turnId: 'old-turn' })
+
+      const persistedStore: SessionStore & {
+        loadEntries(ctx: { workspaceId?: string; userId?: string }, sessionId: string): Promise<{ id: string; messages: unknown[] }>
+      } = {
+        ...sessionStore,
+        loadEntries: vi.fn(async () => ({ id: 's1', messages: [] })),
+      }
+      const { service } = createService(store, createAdapter(), persistedStore)
+
+      await expect(service.readState(ctx, 's1')).resolves.toMatchObject({
+        sessionId: 's1',
+        seq: 9,
+      })
+    } finally {
+      db.db.close()
+    }
+  })
+})
+
+class DelayedEventStreamStore implements EventStreamStore {
+  readonly appendStarted: number[] = []
+
+  constructor(
+    private readonly inner: EventStreamStore,
+    private readonly gates: Map<number, Promise<void>>,
+    private readonly failingSeqs = new Set<number>(),
+  ) {}
+
+  createStream(path: string): Promise<void> {
+    return this.inner.createStream(path)
+  }
+
+  appendEvent(path: string, event: unknown): Promise<string> {
+    return this.inner.appendEvent(path, event)
+  }
+
+  appendEventOnce(path: string, key: string, event: unknown): Promise<string> {
+    return this.inner.appendEventOnce(path, key, event)
+  }
+
+  async appendAgentEvent(sessionId: string, chunk: PiChatEvent, opts?: { idempotencyKey?: string }): Promise<string> {
+    this.appendStarted.push(chunk.seq)
+    await this.gates.get(chunk.seq)
+    if (this.failingSeqs.has(chunk.seq)) throw new Error(`append failed for seq ${chunk.seq}`)
+    return this.inner.appendAgentEvent(sessionId, chunk, opts)
+  }
+
+  readEvents(path: string, opts?: { offset?: string; limit?: number }): Promise<EventStreamReadResult> {
+    return this.inner.readEvents(path, opts)
+  }
+
+  closeStream(path: string): Promise<void> {
+    return this.inner.closeStream(path)
+  }
+
+  getStreamMeta(path: string): Promise<EventStreamMeta | null> {
+    return this.inner.getStreamMeta(path)
+  }
+
+  subscribe(path: string, listener: () => void): () => void {
+    return this.inner.subscribe(path, listener)
+  }
+}
+
+function emitSimpleTurn(adapter: FakeAdapter, turnId = 'turn-1'): void {
+  adapter.emit({ type: 'agent_start', turnId } as unknown as AgentSessionEvent)
+  adapter.emit({ type: 'agent_end', status: 'ok', messages: [], willRetry: false } as unknown as AgentSessionEvent)
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
+async function waitFor(assertion: () => void | Promise<void>): Promise<void> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await flushAsync()
+    }
+  }
+  throw lastError
+}
+
+async function flushAsync(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -2,7 +2,9 @@ import type { AgentHarness, RunContext, AgentSendInput } from '../../shared/harn
 import type { SessionCtx, SessionListOptions, SessionStore } from '../../shared/session'
 import type { Workspace } from '../../shared/workspace'
 import type { BoringChatMessage, BoringChatPart, ChatError, FollowUpPayload, FollowUpReceipt, InterruptPayload, PiChatEvent, PiChatSnapshot, PromptPayload, PromptReceipt, QueuedUserMessage, QueueClearPayload, QueueClearReceipt, StopPayload, StopReceipt } from '../../shared/chat'
+import { sessionStreamPath, type AgentEvent } from '../../shared/events'
 import { ErrorCode } from '../../shared/error-codes'
+import { formatOffset, parseOffset, type EventStreamStore } from '../events/eventStreamStore'
 import type { PiChatSessionService, PiChatEventSubscriber, PiChatEventStreamResult } from '../http/routes/piChat'
 import type { PiSessionCreateInit, PiSessionRequestContext } from './piSessionIdentity'
 import type { PiAgentPromptInput, PiAgentSessionAdapter } from './PiAgentSessionAdapter'
@@ -30,10 +32,14 @@ type PiSessionStoreLike = SessionStore & {
 
 interface LiveSessionChannel {
   sessionKey: string
+  streamPath: string
   buffer: PiChatReplayBuffer
   adapter: PiAgentSessionAdapter
   unsubscribe: () => void
   mapper: PiChatEventMapper
+  publishQueue: Promise<void>
+  closed: Promise<void>
+  rejectClosed: (error: unknown) => void
   activeTurnId?: string
   messageTurnIds: Map<string, string>
 }
@@ -48,6 +54,7 @@ export interface HarnessPiChatServiceOptions {
   sessionStore: SessionStore
   workdir: string
   workspace?: Workspace
+  eventStore?: EventStreamStore
   /**
    * Optional host billing sink. When set, accepted prompts/follow-ups reserve
    * before execution (a rejecting sink blocks the request), native assistant
@@ -64,6 +71,7 @@ export class HarnessPiChatService implements PiChatSessionService {
   private readonly sessionStore: PiSessionStoreLike
   private readonly workdir: string
   private readonly workspace?: Workspace
+  private readonly eventStore?: EventStreamStore
   private readonly channels = new Map<string, LiveSessionChannel>()
   // Single-flight guard so concurrent cold callers (e.g. two browser tabs each
   // opening /events while the session is still being created) converge on one
@@ -81,6 +89,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     this.sessionStore = options.sessionStore
     this.workdir = options.workdir
     this.workspace = options.workspace
+    this.eventStore = options.eventStore
     this.metering = options.metering
       ? new PiChatMeteringCoordinator(options.metering, options.meteringLogger)
       : undefined
@@ -158,7 +167,7 @@ export class HarnessPiChatService implements PiChatSessionService {
       return {
         protocolVersion: 1,
         sessionId: id,
-        seq: 0,
+        seq: await this.readDurableLatestPiChatSeq(sessionStreamPath(id)),
         status: 'idle',
         messages: buildPiChatHistory(messages, { sessionId: id }),
         queue: { followUps: [] },
@@ -173,13 +182,13 @@ export class HarnessPiChatService implements PiChatSessionService {
     const channel = await this.getChannel(ctx, sessionId)
     const result = channel.buffer.subscribe(cursor, subscriber)
     if (result.type !== 'ok') return result
-    return { type: 'ok', unsubscribe: result.unsubscribe }
+    return { type: 'ok', unsubscribe: result.unsubscribe, closed: channel.closed }
   }
 
   async prompt(ctx: PiSessionRequestContext, sessionId: string, payload: PromptPayload): Promise<PromptReceipt> {
     const sessionKey = this.sessionKey(ctx, sessionId)
     const adapter = await this.getAdapter(ctx, sessionId, payload)
-    await this.ensureChannel(ctx, sessionId, adapter)
+    const channel = await this.ensureChannel(ctx, sessionId, adapter)
     // Reserve before execution. The coordinator is the single source of dedup
     // truth: it awaits the owning run's reservation, so a concurrent duplicate
     // sees the same accept/reject (a rejecting sink — e.g. credits exhausted —
@@ -206,11 +215,10 @@ export class HarnessPiChatService implements PiChatSessionService {
     }
     if (outcome === 'cancelled') throw promptCancelledError()
     this.messageMetadata.recordPrompt(sessionKey, payload)
-    const channel = this.channels.get(sessionKey)
     const receiptCursor = nextPromptReceiptCursor(channel)
     try {
       const input = await toPiPromptInput(payload, this.workspace)
-      const run = this.trackActiveRun(sessionKey, adapter.prompt(input))
+      const run = this.trackActiveRun(sessionKey, this.runAndDrainPublishQueue(channel, adapter.prompt(input)))
       run.catch((error) => {
         this.metering?.failPromptRun(sessionId, payload.clientNonce, sessionKey)
         if (!this.messageMetadata.hasPrompt(sessionKey, { clientNonce: payload.clientNonce, displayText: payload.displayMessage ?? payload.message })) return
@@ -227,7 +235,7 @@ export class HarnessPiChatService implements PiChatSessionService {
   async followUp(ctx: PiSessionRequestContext, sessionId: string, payload: FollowUpPayload): Promise<FollowUpReceipt> {
     const sessionKey = this.sessionKey(ctx, sessionId)
     const adapter = await this.getAdapter(ctx, sessionId, payload.message)
-    await this.ensureChannel(ctx, sessionId, adapter)
+    const channel = await this.ensureChannel(ctx, sessionId, adapter)
     // Reserve before enqueuing; the coordinator awaits the owner's reservation
     // and dedups concurrent/consumed retries (so a duplicate doesn't take a
     // second hold or queue a second native follow-up).
@@ -263,6 +271,7 @@ export class HarnessPiChatService implements PiChatSessionService {
       this.messageMetadata.removeFollowUp(sessionKey, payload)
       throw err
     }
+    await this.drainPublishQueue(channel)
     return { accepted: true, queued: true, cursor: this.channels.get(sessionKey)?.buffer.latestSeq ?? 0, clientNonce: payload.clientNonce, clientSeq: payload.clientSeq }
   }
 
@@ -272,6 +281,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     if (hasFollowUpSelector(payload)) {
       const before = adapter.readSnapshot().followUpMessages.length
       adapter.clearFollowUp(payload)
+      await this.drainPublishQueue(this.channels.get(sessionKey))
       const after = adapter.readSnapshot().followUpMessages.length
       if (after < before) {
         this.messageMetadata.removeFollowUp(sessionKey, payload)
@@ -280,6 +290,7 @@ export class HarnessPiChatService implements PiChatSessionService {
       return { accepted: true, cursor: this.channels.get(sessionKey)?.buffer.latestSeq ?? 0, cleared: Math.max(0, before - after) }
     }
     const clearedQueue = this.clearAllFollowUps(adapter, sessionId, sessionKey)
+    await this.drainPublishQueue(this.channels.get(sessionKey))
     this.metering?.releaseQueued(sessionKey)
     return { accepted: true, cursor: this.channels.get(sessionKey)?.buffer.latestSeq ?? 0, cleared: clearedQueue.length }
   }
@@ -293,6 +304,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     const activeRun = this.activePromptRuns.get(sessionKey)
     adapter.abortRetry?.()
     if (wasActive) await adapter.abort()
+    await this.drainPublishQueue(this.channels.get(sessionKey))
     await activeRun?.catch(() => {})
     // Release prompt reservations stranded before agent-start. Safe before
     // auto-post: the next follow-up is still in the queue (released only when
@@ -312,6 +324,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     this.metering?.releaseQueued(sessionKey)
     this.metering?.releasePending(sessionKey)
     await adapter.abort()
+    await this.drainPublishQueue(this.channels.get(sessionKey))
     return { accepted: true, stopped: true, cursor: this.channels.get(sessionKey)?.buffer.latestSeq ?? 0, clearedQueue: buildPiChatQueuedFollowUps(sessionId, clearedQueue) }
   }
 
@@ -341,7 +354,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     this.messageMetadata.recordConsumingFollowUp(sessionKey, followUp, metadata?.serverText)
     if (adapter.continueQueuedFollowUp) {
       try {
-        await this.trackActiveRun(sessionKey, adapter.continueQueuedFollowUp())
+        await this.trackActiveRun(sessionKey, this.runAndDrainPublishQueue(this.channels.get(sessionKey), adapter.continueQueuedFollowUp()))
       } catch (err) {
         // Rejected before Pi consumed the follow-up; release its reservation.
         // A no-op if it was already consumed (the run left the queue).
@@ -368,7 +381,7 @@ export class HarnessPiChatService implements PiChatSessionService {
   }
 
   private async runPrompt(sessionKey: string, adapter: PiAgentSessionAdapter, input: PiAgentPromptInput): Promise<void> {
-    await this.trackActiveRun(sessionKey, adapter.prompt(input))
+    await this.trackActiveRun(sessionKey, this.runAndDrainPublishQueue(this.channels.get(sessionKey), adapter.prompt(input)))
   }
 
   private async trackActiveRun(sessionKey: string, run: Promise<void>): Promise<void> {
@@ -413,7 +426,44 @@ export class HarnessPiChatService implements PiChatSessionService {
     }
   }
 
-  private publishChannelEvent(sessionId: string, channel: LiveSessionChannel, event: PiChatEvent): void {
+  private publishChannelEvents(
+    sessionId: string,
+    channel: LiveSessionChannel,
+    events: PiChatEvent[],
+    afterPublish?: (publishedEvents: PiChatEvent[]) => void,
+  ): void {
+    if (!this.eventStore) {
+      const publishedEvents: PiChatEvent[] = []
+      for (const event of events) {
+        const enriched = this.messageMetadata.enrichEvent(channel.sessionKey, event)
+        publishedEvents.push(enriched)
+        this.publishChannelEventSync(channel, enriched)
+      }
+      afterPublish?.(publishedEvents)
+      return
+    }
+
+    const next = channel.publishQueue.then(async () => {
+      const publishedEvents: PiChatEvent[] = []
+      for (const event of events) {
+        const enriched = this.messageMetadata.enrichEvent(channel.sessionKey, event)
+        publishedEvents.push(enriched)
+        await this.eventStore?.appendAgentEvent(sessionId, enriched, { idempotencyKey: String(enriched.seq) })
+        this.publishChannelEventSync(channel, enriched)
+      }
+      afterPublish?.(publishedEvents)
+    }).catch((error) => {
+      channel.rejectClosed(error)
+      throw error
+    })
+    // A failed durable append intentionally poisons this live channel: later
+    // chunks cannot skip the failed PiChatEvent seq and still satisfy replay
+    // authority, so callers that await the queue must see the same failure.
+    channel.publishQueue = next
+    next.catch(() => {})
+  }
+
+  private publishChannelEventSync(channel: LiveSessionChannel, event: PiChatEvent): void {
     const sessionKey = channel.sessionKey
     if (event.type === 'agent-start') {
       channel.activeTurnId = event.turnId
@@ -436,15 +486,15 @@ export class HarnessPiChatService implements PiChatSessionService {
     const createdAt = new Date().toISOString()
     const messageId = `prompt-error:${payload.clientNonce}:user`
     const message = promptPayloadMessage(payload, messageId, createdAt, channel.activeTurnId)
-    this.publishChannelEvent(sessionId, channel, channel.mapper.mapSynthetic({
+    const messageEvent = channel.mapper.mapSynthetic({
       type: 'message-start',
       messageId,
-      role: 'user',
+      role: 'user' as const,
       clientNonce: payload.clientNonce,
       text: payload.displayMessage ?? payload.message,
       files: promptPayloadFileParts(payload, messageId),
       createdAt,
-    }))
+    })
     const promptError: ChatError = {
       code: ErrorCode.enum.INTERNAL_ERROR,
       message: error instanceof Error && error.message ? error.message : 'Prompt failed before the agent run completed.',
@@ -456,12 +506,34 @@ export class HarnessPiChatService implements PiChatSessionService {
       retryable: false,
       error: promptError,
     })
-    this.publishChannelEvent(sessionId, channel, errorEvent)
-    const failures = this.syntheticPromptFailures.get(sessionKey) ?? []
-    failures.push({ message, error: promptError })
-    this.syntheticPromptFailures.set(sessionKey, failures)
-    this.activeSyntheticPromptErrors.set(sessionKey, promptError)
-    channel.activeTurnId = undefined
+    this.publishChannelEvents(sessionId, channel, [messageEvent, errorEvent], () => {
+      const failures = this.syntheticPromptFailures.get(sessionKey) ?? []
+      failures.push({ message, error: promptError })
+      this.syntheticPromptFailures.set(sessionKey, failures)
+      this.activeSyntheticPromptErrors.set(sessionKey, promptError)
+      channel.activeTurnId = undefined
+    })
+  }
+
+  private async runAndDrainPublishQueue(channel: LiveSessionChannel | undefined, run: Promise<void>): Promise<void> {
+    let runError: unknown
+    try {
+      await run
+    } catch (error) {
+      runError = error
+    }
+
+    try {
+      await this.drainPublishQueue(channel)
+    } catch (error) {
+      if (runError === undefined) throw error
+    }
+
+    if (runError !== undefined) throw runError
+  }
+
+  private async drainPublishQueue(channel: LiveSessionChannel | undefined): Promise<void> {
+    await channel?.publishQueue
   }
 
   private async getAdapter(
@@ -530,29 +602,56 @@ export class HarnessPiChatService implements PiChatSessionService {
     }
   }
 
-  private buildChannel(sessionKey: string, sessionId: string, adapter: PiAgentSessionAdapter): LiveSessionChannel {
+  private async buildChannel(sessionKey: string, sessionId: string, adapter: PiAgentSessionAdapter): Promise<LiveSessionChannel> {
     const existing = this.channels.get(sessionKey)
     if (existing) return existing
-    const buffer = new PiChatReplayBuffer()
+    const streamPath = sessionStreamPath(sessionId)
+    await this.eventStore?.createStream(streamPath)
+    const initialSeq = await this.readDurableLatestPiChatSeq(streamPath)
+    const buffer = new PiChatReplayBuffer({ initialLatestSeq: initialSeq })
     const mapper = new PiChatEventMapper({ sessionId, initialSeq: buffer.latestSeq })
-    const channel: LiveSessionChannel = { sessionKey, buffer, adapter, unsubscribe: () => {}, mapper, messageTurnIds: new Map() }
+    const closed = deferred<void>()
+    closed.promise.catch(() => {})
+    const channel: LiveSessionChannel = {
+      sessionKey,
+      streamPath,
+      buffer,
+      adapter,
+      unsubscribe: () => {},
+      mapper,
+      publishQueue: Promise.resolve(),
+      closed: closed.promise,
+      rejectClosed: closed.reject,
+      messageTurnIds: new Map(),
+    }
     const unsubscribe = adapter.subscribe((event) => {
       const mappedEvents = mapper.map(event)
       // Metering observes the ENRICHED events: in production the native Pi
       // message for a consumed follow-up carries no clientNonce/clientSeq —
       // those selectors are recovered here by enrichEvent, and the metering
       // coordinator needs them to attribute the follow-up's usage correctly.
-      const enrichedEvents: PiChatEvent[] = []
-      for (const mapped of mappedEvents) {
-        const enriched = this.messageMetadata.enrichEvent(sessionKey, mapped)
-        enrichedEvents.push(enriched)
-        this.publishChannelEvent(sessionId, channel, enriched)
-      }
-      this.metering?.observe(sessionKey, event, enrichedEvents)
+      this.publishChannelEvents(sessionId, channel, mappedEvents, (enrichedEvents) => {
+        this.metering?.observe(sessionKey, event, enrichedEvents)
+      })
     })
     channel.unsubscribe = unsubscribe
     this.channels.set(sessionKey, channel)
     return channel
+  }
+
+  private async readDurableLatestPiChatSeq(streamPath: string): Promise<number> {
+    if (!this.eventStore) return 0
+    const meta = await this.eventStore.getStreamMeta(streamPath)
+    if (!meta) return 0
+    const tailIndex = parseOffset(meta.nextOffset)
+    if (tailIndex < 0) return 0
+    const tail = await this.eventStore.readEvents(streamPath, {
+      offset: formatOffset(tailIndex - 1),
+      limit: 1,
+    })
+    const envelope = tail.events[0]?.data as Partial<AgentEvent> | undefined
+    const seq = envelope?.chunk?.seq
+    return typeof seq === 'number' && Number.isInteger(seq) && seq >= 0 ? seq : tailIndex + 1
   }
 
   private async assertCanAccessSession(ctx: PiSessionRequestContext, sessionId: string): Promise<void> {
@@ -580,6 +679,16 @@ function promptCancelledError(): Error {
     code: ErrorCode.enum.ABORTED,
     retryable: true,
   })
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: unknown) => void } {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, resolve, reject }
 }
 
 function normalizeSessionAccessError(error: unknown, sessionId: string): unknown {

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -4,7 +4,6 @@ import type { AgentTool, ToolReadinessRequirement } from '../shared/tool'
 import type { AgentCoreHarnessFactory, AgentHarnessFactory } from '../shared/harness'
 import type { SessionStore } from '../shared/session'
 import type { Agent } from '../shared/events'
-import type { PiChatSnapshot } from '../shared/chat'
 import type { SandboxHandleStore } from '../shared/sandbox-handle-store'
 import type { TelemetrySink } from '../shared/telemetry'
 import { AuthStorage, ModelRegistry } from '@mariozechner/pi-coding-agent'
@@ -712,7 +711,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       harness,
       tools,
       readyTracker,
-      piChatService: createHttpCompatiblePiChatService(agentRuntime.service as PiChatSessionService),
+      piChatService: agentRuntime.service as PiChatSessionService,
     }
     startRuntimeProvisioning(request)
     return binding
@@ -1076,53 +1075,4 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
     ? { tracker: staticBinding.readyTracker }
     : { getTracker: async (request) => (await getBindingForRequest(request)).readyTracker },
   )
-}
-
-function createHttpCompatiblePiChatService(service: PiChatSessionService): PiChatSessionService {
-  return new Proxy(service, {
-    get(target, prop, receiver) {
-      if (prop === 'readState') {
-        return async (...args: Parameters<PiChatSessionService['readState']>) => {
-          try {
-            return await target.readState(...args)
-          } catch (error) {
-            if (isSessionNotFoundError(error)) return emptyPiChatSnapshot(args[1])
-            throw error
-          }
-        }
-      }
-      if (prop === 'deleteSession' && typeof target.deleteSession === 'function') {
-        return async (...args: Parameters<NonNullable<PiChatSessionService['deleteSession']>>) => {
-          try {
-            return await target.deleteSession!(...args)
-          } catch (error) {
-            if (isSessionNotFoundError(error)) return
-            throw error
-          }
-        }
-      }
-      const value = Reflect.get(target, prop, receiver)
-      return typeof value === 'function' ? value.bind(target) : value
-    },
-  }) as PiChatSessionService
-}
-
-function isSessionNotFoundError(error: unknown): boolean {
-  if ((error as { code?: unknown })?.code === ErrorCode.enum.SESSION_NOT_FOUND) return true
-  return error instanceof Error && (
-    error.message === 'session not found' ||
-    error.message.startsWith('Session not found:')
-  )
-}
-
-function emptyPiChatSnapshot(sessionId: string): PiChatSnapshot {
-  return {
-    protocolVersion: 1,
-    sessionId,
-    seq: 0,
-    status: 'idle',
-    messages: [],
-    queue: { followUps: [] },
-    followUpMode: 'one-at-a-time',
-  }
 }

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -1,8 +1,10 @@
 import type { FastifyInstance, FastifyPluginAsync, FastifyRequest } from 'fastify'
 import { basename } from 'node:path'
 import type { AgentTool, ToolReadinessRequirement } from '../shared/tool'
-import type { AgentHarnessFactory } from '../shared/harness'
+import type { AgentCoreHarnessFactory, AgentHarnessFactory } from '../shared/harness'
 import type { SessionStore } from '../shared/session'
+import type { Agent } from '../shared/events'
+import type { PiChatSnapshot } from '../shared/chat'
 import type { SandboxHandleStore } from '../shared/sandbox-handle-store'
 import type { TelemetrySink } from '../shared/telemetry'
 import { AuthStorage, ModelRegistry } from '@mariozechner/pi-coding-agent'
@@ -30,7 +32,7 @@ import { fsEventsRoutes } from './http/routes/fsEvents'
 import { treeRoutes } from './http/routes/tree'
 import { modelsRoutes } from './http/routes/models'
 import { skillsRoutes } from './http/routes/skills'
-import { piChatRoutes } from './http/routes/piChat'
+import { piChatRoutes, type PiChatSessionService } from './http/routes/piChat'
 import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
@@ -44,9 +46,9 @@ import type { ReadyStatusTracker } from './runtime/readyStatus'
 import { createRuntimeReadyStatusTracker } from './runtime/modeReadiness'
 import { withRuntimeEnvContributions, type RuntimeEnvContribution } from './runtimeEnvContributions'
 import type { AgentHarness } from '../shared/harness'
-import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
+import { createAgentRuntimeBridge } from './createAgent'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_WORKSPACE_ID = 'default'
@@ -108,10 +110,11 @@ interface RuntimeBinding {
   runtimeDependencies: RuntimeDependencyReadiness
   runtimeProvisioningTask?: Promise<WorkspaceProvisioningResult | undefined>
   reprovision: (request?: FastifyRequest) => Promise<WorkspaceProvisioningResult | undefined>
+  agent: Agent
   harness: AgentHarness
   tools: AgentTool[]
   readyTracker: ReadyStatusTracker
-  piChatService?: HarnessPiChatService
+  piChatService: PiChatSessionService
   lastHealthCheckMs?: number
   /**
    * Diagnostics from the most recent /api/v1/agent/reload (merged hook +
@@ -648,7 +651,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       logger: app.log,
       checkReadiness,
     })
-    const harnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
+    const baseHarnessFactory = opts.harnessFactory ?? ((input) => createPiCodingAgentHarness({
       ...input,
       pi: {
         // scope.pi is already defaulted at the resolveScopePi chokepoint.
@@ -668,17 +671,32 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
         },
       },
     }))
-    const harness = await harnessFactory({
-      tools,
-      cwd: root,
+    const systemPromptDynamic = opts.getSystemPromptDynamic
+      ? () => opts.getSystemPromptDynamic?.({ workspaceId, workspaceRoot: root })
+      : opts.systemPromptDynamic
+    const harnessFactory = ((input) => baseHarnessFactory({
+      ...input,
       sessionNamespace: scope.sessionNamespace,
       sessionRoot: opts.sessionRoot,
+    })) as AgentCoreHarnessFactory
+    const coreAgent = createAgentRuntimeBridge({
+      runtime: modeAdapter,
+      tools,
+      harnessFactory,
       systemPromptAppend: opts.systemPromptAppend,
-      systemPromptDynamic: opts.getSystemPromptDynamic
-        ? () => opts.getSystemPromptDynamic?.({ workspaceId, workspaceRoot: root })
-        : opts.systemPromptDynamic,
+      systemPromptDynamic,
       telemetry: opts.telemetry,
+      metering: opts.metering,
+      sessionStorageRoot: opts.sessionRoot,
+      workdir: root,
+    }, {
+      service: {
+        workdir: runtimeBundle.workspace.root,
+        workspace: runtimeBundle.workspace,
+      },
     })
+    const agentRuntime = await coreAgent.getRuntime()
+    const harness = agentRuntime.harness
     readyTracker.markHarnessReady()
 
     binding = {
@@ -690,9 +708,11 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
         const result = await startRuntimeProvisioning(reloadRequest)
         return await result
       },
+      agent: coreAgent.agent,
       harness,
       tools,
       readyTracker,
+      piChatService: createHttpCompatiblePiChatService(agentRuntime.service as PiChatSessionService),
     }
     startRuntimeProvisioning(request)
     return binding
@@ -949,13 +969,6 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
   await app.register(piChatRoutes, {
     getService: async (request) => {
       const binding = await getBindingForRequest(request)
-      binding.piChatService ??= new HarnessPiChatService({
-        harness: binding.harness,
-        sessionStore: binding.harness.sessions,
-        workdir: binding.runtimeBundle.workspace.root,
-        workspace: binding.runtimeBundle.workspace,
-        metering: opts.metering,
-      })
       return binding.piChatService
     },
   })
@@ -1063,4 +1076,53 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
     ? { tracker: staticBinding.readyTracker }
     : { getTracker: async (request) => (await getBindingForRequest(request)).readyTracker },
   )
+}
+
+function createHttpCompatiblePiChatService(service: PiChatSessionService): PiChatSessionService {
+  return new Proxy(service, {
+    get(target, prop, receiver) {
+      if (prop === 'readState') {
+        return async (...args: Parameters<PiChatSessionService['readState']>) => {
+          try {
+            return await target.readState(...args)
+          } catch (error) {
+            if (isSessionNotFoundError(error)) return emptyPiChatSnapshot(args[1])
+            throw error
+          }
+        }
+      }
+      if (prop === 'deleteSession' && typeof target.deleteSession === 'function') {
+        return async (...args: Parameters<NonNullable<PiChatSessionService['deleteSession']>>) => {
+          try {
+            return await target.deleteSession!(...args)
+          } catch (error) {
+            if (isSessionNotFoundError(error)) return
+            throw error
+          }
+        }
+      }
+      const value = Reflect.get(target, prop, receiver)
+      return typeof value === 'function' ? value.bind(target) : value
+    },
+  }) as PiChatSessionService
+}
+
+function isSessionNotFoundError(error: unknown): boolean {
+  if ((error as { code?: unknown })?.code === ErrorCode.enum.SESSION_NOT_FOUND) return true
+  return error instanceof Error && (
+    error.message === 'session not found' ||
+    error.message.startsWith('Session not found:')
+  )
+}
+
+function emptyPiChatSnapshot(sessionId: string): PiChatSnapshot {
+  return {
+    protocolVersion: 1,
+    sessionId,
+    seq: 0,
+    status: 'idle',
+    messages: [],
+    queue: { followUps: [] },
+    followUpMode: 'one-at-a-time',
+  }
 }

--- a/packages/agent/src/shared/events.ts
+++ b/packages/agent/src/shared/events.ts
@@ -61,6 +61,10 @@ export interface AgentEvent {
   chunk: PiChatEvent
 }
 
+export function sessionStreamPath(sessionId: string): string {
+  return `sessions/${sessionId}`
+}
+
 export interface AgentResolveInputResponse {
   approved?: boolean
   content?: string

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -29,6 +29,7 @@ export type {
 export {
   AGENT_NOT_IMPLEMENTED_UNTIL_T1,
   AgentNotImplementedError,
+  sessionStreamPath,
 } from './events'
 export type { WorkspaceRuntimeContext } from './runtime'
 export type { Workspace, Entry, Stat } from './workspace'


### PR DESCRIPTION
## Why this PR exists

The stacked PRs #530 (P1 pr3 thin adapters), #531 (T1 pr1 EventStreamStore), and #535 (T1 pr2 envelope tap) were each merged into their **stack-base branch**, not into main — the bottom of the stack (#529) merged first, and the ones above then landed on the now-orphaned branches. GitHub shows them MERGED but none of their code is on main.

This PR cherry-picks the three squash commits, **byte-identical to the diffs you already reviewed and approved**, onto current main in the same order:

1. `feat(391-P1): pr3 — HTTP adapters thin over the core bridge` (#530)
2. `feat(391-T1): pr1 — transactional SQLite EventStreamStore` (#531)
3. `feat(391-T1): pr2 — AgentEvent envelope append at the harness tap` (#535)

All three applied with zero conflicts.

## Review (~2 min)
Content is already reviewed — just sanity-check the commit list matches the three PR titles. No new changes of any kind.

## Gates (all PASS on this branch)
`build:packages`, agent typecheck, agent tests (191 files / 1599 passed), `lint:invariants`, `audit:imports`.

## Going forward
To avoid a repeat: merge stacks bottom-up, and I now retarget each stacked PR to main immediately after its base merges (already done for #536).

🤖 Generated with [Claude Code](https://claude.com/claude-code)