### PR TITLE
feat(391-M1): pr1 — exposed MCP delegate server (BBM1-001)

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -73,6 +73,7 @@
   "dependencies": {
     "@hachej/boring-ui-kit": "workspace:*",
     "@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.75.5",
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@radix-ui/react-collapsible": "^1.1.14",
     "@radix-ui/react-dialog": "^1.1.17",
     "@radix-ui/react-dropdown-menu": "^2.1.18",

--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -97,6 +97,29 @@ export type {
 export { autoDetectMode, hasBwrap, resolveMode } from './runtime/resolveMode'
 export { createAgent } from './createAgent'
 export type { AgentConfig } from '../shared/events'
+export {
+  createManagedAgentMcpDelegateController,
+  createManagedAgentMcpHttpHandler,
+  createManagedAgentMcpServer,
+  MANAGED_AGENT_MCP_DELIVERY_RULE,
+  MANAGED_AGENT_MCP_ORIGIN_SURFACE,
+  ManagedAgentMcpDelegateController,
+  ManagedAgentMcpError,
+} from './mcp'
+export type {
+  ManagedAgentArtifactRef,
+  ManagedAgentCollectArtifactsInput,
+  ManagedAgentDelegateInput,
+  ManagedAgentDelegateProgress,
+  ManagedAgentDelegateRequestContext,
+  ManagedAgentDelegateResult,
+  ManagedAgentDelegateStatus,
+  ManagedAgentDelegateStatusResult,
+  ManagedAgentMcpDelegateOptions,
+  ManagedAgentMcpHttpHandlerOptions,
+  ManagedAgentMcpServerOptions,
+  ManagedAgentSafeError,
+} from './mcp'
 export { createAgentApp } from './createAgentApp'
 export type { CreateAgentAppOptions } from './createAgentApp'
 export type { AgentHarnessFactory, AgentHarnessFactoryInput } from '../shared/harness'

--- a/packages/agent/src/server/mcp/__tests__/managedAgentDelegate.test.ts
+++ b/packages/agent/src/server/mcp/__tests__/managedAgentDelegate.test.ts
@@ -1,0 +1,633 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  MANAGED_AGENT_MCP_DELIVERY_RULE,
+  MANAGED_AGENT_MCP_ORIGIN_SURFACE,
+  ManagedAgentMcpError,
+  createManagedAgentMcpDelegateController,
+  createManagedAgentMcpHttpHandler,
+  type ManagedAgentMcpDelegateOptions,
+} from '../index'
+import type {
+  Agent,
+  AgentEvent,
+  AgentReadiness,
+  AgentResolveInputResponse,
+  AgentSendInput,
+  AgentStartReceipt,
+  AgentStreamOptions,
+} from '../../../shared/events'
+import { ErrorCode, type ErrorCode as StableErrorCode } from '../../../shared/error-codes'
+import type { SessionCtx, SessionDetail, SessionListOptions, SessionStore, SessionSummary } from '../../../shared/session'
+
+const CTX: SessionCtx = { workspaceId: 'workspace-1', userId: 'user-1' }
+
+const servers: Array<{ close: () => Promise<void> }> = []
+
+afterEach(async () => {
+  while (servers.length) await servers.pop()!.close()
+})
+
+describe('ManagedAgentMcpDelegateController', () => {
+  it('starts one host-tenanted agent session per delegation and returns the amended delivery payload', async () => {
+    const agent = new FakeAgent()
+    const progressMessages: string[] = []
+    const controller = createManagedAgentMcpDelegateController(options(agent, {
+      collectArtifacts: async () => [{
+        path: 'reports/final.md',
+        mediaType: 'text/markdown',
+        title: 'Final report',
+        content: '# Final report\nDone.',
+      }],
+    }))
+
+    const first = await controller.delegateTask({
+      brief: 'write the report',
+      onProgress: (progress) => {
+        progressMessages.push(progress.message)
+      },
+    })
+    const second = await controller.delegateTask({ brief: 'write another report' })
+
+    expect(agent.starts).toHaveLength(2)
+    expect(agent.starts.map((start) => start.sessionId)).toEqual([undefined, undefined])
+    expect(agent.starts.map((start) => start.ctx)).toEqual([CTX, CTX])
+    expect(agent.starts.map((start) => start.originSurface)).toEqual([
+      MANAGED_AGENT_MCP_ORIGIN_SURFACE,
+      MANAGED_AGENT_MCP_ORIGIN_SURFACE,
+    ])
+    expect(first).toEqual({
+      delegationId: 'delegation-1',
+      status: 'completed',
+      finalAssistantText: 'Final answer',
+      artifacts: [{
+        path: 'reports/final.md',
+        mediaType: 'text/markdown',
+        title: 'Final report',
+        content: '# Final report\nDone.',
+      }],
+      deliveryRule: MANAGED_AGENT_MCP_DELIVERY_RULE,
+    })
+    expect(second.delegationId).toBe('delegation-2')
+    expect(first).not.toHaveProperty('shareUrl')
+    expect(first).not.toHaveProperty('shareLink')
+    expect(JSON.stringify(first)).not.toMatch(/\/share\//i)
+    expect(progressMessages).toContain('Agent turn started.')
+  })
+
+  it('exposes redacted polling status while a delegation is running', async () => {
+    const gate = deferred<void>()
+    const agent = new FakeAgent({ gate })
+    const controller = createManagedAgentMcpDelegateController(options(agent))
+    const running = controller.delegateTask({ brief: 'slow brief' })
+
+    await agent.waitForStreamStart()
+    const status = await waitForStatus(controller, 'delegation-1', CTX, (current) => current.eventCount > 0)
+    expect(status.status).toBe('running')
+    expect(status.eventCount).toBeGreaterThan(0)
+    expect(status.progress.map((progress) => progress.message)).toContain('Agent turn started.')
+
+    gate.resolve()
+    await expect(running).resolves.toMatchObject({
+      delegationId: 'delegation-1',
+      status: 'completed',
+      finalAssistantText: 'Final answer',
+    })
+    expect(controller.getStatus('delegation-1', CTX).status).toBe('completed')
+  })
+
+  it('expires terminal delegation records after the configured retention window', async () => {
+    let now = new Date('2026-07-06T00:00:00.000Z')
+    const controller = createManagedAgentMcpDelegateController(options(new FakeAgent(), {
+      now: () => now,
+      terminalRetentionMs: 1,
+    }))
+
+    await controller.delegateTask({ brief: 'short-lived status' })
+    expect(controller.getStatus('delegation-1', CTX).status).toBe('completed')
+
+    now = new Date('2026-07-06T00:00:00.001Z')
+    expect(() => controller.getStatus('delegation-1', CTX)).toThrow(ManagedAgentMcpError)
+    try {
+      controller.getStatus('delegation-1', CTX)
+    } catch (error) {
+      expect(error).toMatchObject({ code: ErrorCode.enum.SESSION_NOT_FOUND })
+    }
+  })
+
+  it('rejects new starts instead of evicting running delegations when capacity is full', async () => {
+    const gate = deferred<void>()
+    const agent = new FakeAgent({ gate })
+    const controller = createManagedAgentMcpDelegateController(options(agent, {
+      maxDelegations: 1,
+    }))
+    const first = controller.delegateTask({ brief: 'first slow task' })
+
+    await agent.waitForStreamStart()
+    await expect(controller.delegateTask({ brief: 'second slow task' })).rejects.toMatchObject({
+      code: ErrorCode.enum.TOOL_EXECUTION_ERROR,
+      message: 'too many running delegated tasks',
+    })
+    expect(controller.getStatus('delegation-1', CTX).status).toBe('running')
+
+    gate.resolve()
+    await expect(first).resolves.toMatchObject({ delegationId: 'delegation-1', status: 'completed' })
+  })
+
+  it('returns stable errors for unknown delegation ids', () => {
+    const controller = createManagedAgentMcpDelegateController(options(new FakeAgent()))
+
+    expect(() => controller.getStatus('missing', CTX)).toThrow(ManagedAgentMcpError)
+    try {
+      controller.getStatus('missing', CTX)
+    } catch (error) {
+      expect(error).toMatchObject({ code: ErrorCode.enum.SESSION_NOT_FOUND, message: 'delegation not found' })
+    }
+  })
+
+  it('does not expose status across SessionCtx boundaries', async () => {
+    const controller = createManagedAgentMcpDelegateController(options(new FakeAgent()))
+    await controller.delegateTask({ brief: 'scoped brief' })
+
+    expect(() => controller.getStatus('delegation-1', { workspaceId: 'workspace-2', userId: 'user-1' })).toThrow(ManagedAgentMcpError)
+    try {
+      controller.getStatus('delegation-1', { workspaceId: 'workspace-2', userId: 'user-1' })
+    } catch (error) {
+      expect(error).toMatchObject({ code: ErrorCode.enum.SESSION_NOT_FOUND, message: 'delegation not found' })
+    }
+  })
+
+  it('reports non-ok agent terminal events as failed delegations', async () => {
+    const controller = createManagedAgentMcpDelegateController(options(new FakeAgent({ terminalStatus: 'error' })))
+
+    await expect(controller.delegateTask({ brief: 'failing brief' })).rejects.toMatchObject({
+      code: ErrorCode.enum.INTERNAL_ERROR,
+      message: 'agent turn failed',
+    })
+    expect(controller.getStatus('delegation-1', CTX)).toMatchObject({
+      status: 'error',
+      error: { code: ErrorCode.enum.INTERNAL_ERROR, message: 'agent turn failed' },
+    })
+  })
+
+  it('does not expose raw agent stream error messages on failed turns', async () => {
+    const controller = createManagedAgentMcpDelegateController(options(new FakeAgent({
+      terminalStatus: 'error',
+      streamError: {
+        code: ErrorCode.enum.TOOL_EXECUTION_ERROR,
+        message: 'provider failed while reading /srv/private/tool-token',
+      },
+    })))
+
+    await expect(controller.delegateTask({ brief: 'failing brief' })).rejects.toMatchObject({
+      code: ErrorCode.enum.TOOL_EXECUTION_ERROR,
+      message: 'agent turn failed',
+    })
+    const status = controller.getStatus('delegation-1', CTX)
+    expect(status.error).toEqual({
+      code: ErrorCode.enum.TOOL_EXECUTION_ERROR,
+      message: 'agent turn failed',
+    })
+    expect(JSON.stringify(status)).not.toContain('/srv/private/tool-token')
+  })
+
+  it('stops the delegated session when the MCP request is cancelled', async () => {
+    const gate = deferred<void>()
+    const abort = new AbortController()
+    const agent = new FakeAgent({ gate })
+    const controller = createManagedAgentMcpDelegateController(options(agent))
+    const running = controller.delegateTask({ brief: 'cancel me', signal: abort.signal })
+
+    await agent.waitForStreamStart()
+    abort.abort()
+    gate.resolve()
+
+    await expect(running).rejects.toMatchObject({ code: ErrorCode.enum.ABORTED })
+    expect(agent.stops).toEqual([{ sessionId: 'session-1', ctx: CTX }])
+  })
+
+  it('does not create an unreachable delegation when cancelled before tenancy resolves', async () => {
+    const ctxGate = deferred<SessionCtx>()
+    const abort = new AbortController()
+    const agent = new FakeAgent()
+    const controller = createManagedAgentMcpDelegateController(options(agent, {
+      resolveSessionCtx: async () => ctxGate.promise,
+    }))
+    const running = controller.delegateTask({ brief: 'cancel before tenancy', signal: abort.signal })
+
+    abort.abort()
+    ctxGate.resolve(CTX)
+
+    await expect(running).rejects.toMatchObject({ code: ErrorCode.enum.ABORTED })
+    expect(agent.starts).toHaveLength(0)
+    expect(() => controller.getStatus('delegation-1', CTX)).toThrow(ManagedAgentMcpError)
+  })
+
+  it('blocks configured secret canaries from caller-visible results', async () => {
+    const agent = new FakeAgent({ finalText: 'contains SECRET_CANARY' })
+    const controller = createManagedAgentMcpDelegateController(options(agent, {
+      redactionCanaries: ['SECRET_CANARY'],
+    }))
+
+    await expect(controller.delegateTask({ brief: 'leak check' })).rejects.toMatchObject({
+      code: ErrorCode.enum.INTERNAL_ERROR,
+      message: 'MCP delegate payload failed secret redaction guard',
+    })
+    const status = controller.getStatus('delegation-1', CTX)
+    expect(JSON.stringify(status)).not.toContain('SECRET_CANARY')
+  })
+
+  it('redacts configured secret canaries from progress before notification or polling exposure', async () => {
+    const progressMessages: string[] = []
+    const controller = createManagedAgentMcpDelegateController(options(new FakeAgent({
+      toolName: 'SECRET_CANARY_tool',
+    }), {
+      redactionCanaries: ['SECRET_CANARY'],
+    }))
+
+    await controller.delegateTask({
+      brief: 'progress leak check',
+      onProgress: (progress) => {
+        progressMessages.push(progress.message)
+      },
+    })
+
+    expect(progressMessages).toContain('Agent progress updated.')
+    expect(progressMessages.join('\n')).not.toContain('SECRET_CANARY')
+    expect(JSON.stringify(controller.getStatus('delegation-1', CTX))).not.toContain('SECRET_CANARY')
+  })
+
+  it('rejects host configurations that do not resolve real workspace tenancy', async () => {
+    const controller = createManagedAgentMcpDelegateController({
+      ...options(new FakeAgent()),
+      resolveSessionCtx: () => ({}),
+    })
+
+    await expect(controller.delegateTask({ brief: 'brief' })).rejects.toMatchObject({
+      code: ErrorCode.enum.CONFIG_INVALID,
+    })
+    expect(() => controller.getStatus('delegation-1', CTX)).toThrow(ManagedAgentMcpError)
+    try {
+      controller.getStatus('delegation-1', CTX)
+    } catch (error) {
+      expect(error).toMatchObject({ code: ErrorCode.enum.SESSION_NOT_FOUND })
+    }
+  })
+
+  it('redacts status tenancy resolver errors before returning them to MCP callers', async () => {
+    const controller = createManagedAgentMcpDelegateController({
+      ...options(new FakeAgent()),
+      redactionCanaries: ['SECRET_CANARY'],
+      resolveSessionCtx: () => {
+        throw new Error('auth backend leaked SECRET_CANARY')
+      },
+    })
+
+    await expect(controller.getStatusForRequest('delegation-1', {})).rejects.toMatchObject({
+      code: ErrorCode.enum.INTERNAL_ERROR,
+      message: 'MCP delegate task failed',
+    })
+  })
+
+  it('does not expose unknown host error messages to MCP callers', async () => {
+    const controller = createManagedAgentMcpDelegateController(options(new FakeAgent(), {
+      collectArtifacts: async () => {
+        throw new Error('host filesystem failed at /srv/private/token-store')
+      },
+    }))
+
+    await expect(controller.delegateTask({ brief: 'host error' })).rejects.toMatchObject({
+      code: ErrorCode.enum.INTERNAL_ERROR,
+      message: 'MCP delegate task failed',
+    })
+    const status = controller.getStatus('delegation-1', CTX)
+    expect(status.error).toEqual({
+      code: ErrorCode.enum.INTERNAL_ERROR,
+      message: 'MCP delegate task failed',
+    })
+    expect(JSON.stringify(status)).not.toContain('/srv/private/token-store')
+  })
+})
+
+describe('createManagedAgentMcpHttpHandler', () => {
+  it('serves delegate_task to a stock MCP Streamable HTTP client', async () => {
+    const agent = new FakeAgent()
+    const handler = createManagedAgentMcpHttpHandler(options(agent, {
+      collectArtifacts: async () => [{ path: 'out/result.md', content: 'Final artifact' }],
+    }))
+    const endpoint = await listen(handler)
+    const client = new Client({ name: 'managed-agent-test-client', version: '0.0.0-test' })
+
+    await client.connect(new StreamableHTTPClientTransport(new URL(endpoint)))
+    const result = await client.callTool({ name: 'delegate_task', arguments: { brief: 'make a result' } })
+    await client.close()
+
+    expect(result.isError).not.toBe(true)
+    expect(result.structuredContent).toMatchObject({
+      delegationId: 'delegation-1',
+      status: 'completed',
+      finalAssistantText: 'Final answer',
+      artifacts: [{ path: 'out/result.md', content: 'Final artifact' }],
+      deliveryRule: MANAGED_AGENT_MCP_DELIVERY_RULE,
+    })
+    expect(JSON.stringify(result.structuredContent)).not.toMatch(/shareUrl|shareLink|\/share\//i)
+  })
+
+  it('serves delegate_task_start and delegate_task_status to a stock MCP Streamable HTTP client', async () => {
+    const gate = deferred<void>()
+    const agent = new FakeAgent({ gate })
+    const handler = createManagedAgentMcpHttpHandler(options(agent))
+    const endpoint = await listen(handler)
+    const client = new Client({ name: 'managed-agent-test-client', version: '0.0.0-test' })
+
+    await client.connect(new StreamableHTTPClientTransport(new URL(endpoint)))
+    const started = await client.callTool({ name: 'delegate_task_start', arguments: { brief: 'make a slow result' } })
+    expect(started.isError).not.toBe(true)
+    expect(started.structuredContent).toMatchObject({
+      delegationId: 'delegation-1',
+      status: 'running',
+    })
+
+    const running = await client.callTool({ name: 'delegate_task_status', arguments: { delegationId: 'delegation-1' } })
+    expect(running.isError).not.toBe(true)
+    expect(running.structuredContent).toMatchObject({
+      delegationId: 'delegation-1',
+      status: 'running',
+    })
+
+    gate.resolve()
+    const completed = await waitForClientStatus(client, 'delegation-1', (status) => status.status === 'completed')
+    await client.close()
+
+    expect(completed).toMatchObject({
+      delegationId: 'delegation-1',
+      status: 'completed',
+      result: {
+        finalAssistantText: 'Final answer',
+        deliveryRule: MANAGED_AGENT_MCP_DELIVERY_RULE,
+      },
+    })
+    expect(JSON.stringify(completed)).not.toMatch(/shareUrl|shareLink|\/share\//i)
+  })
+
+  it('uses the configured brief length limit in the MCP input schema', async () => {
+    const agent = new FakeAgent()
+    const handler = createManagedAgentMcpHttpHandler(options(agent, {
+      maxBriefChars: 12_005,
+    }))
+    const endpoint = await listen(handler)
+    const client = new Client({ name: 'managed-agent-test-client', version: '0.0.0-test' })
+
+    await client.connect(new StreamableHTTPClientTransport(new URL(endpoint)))
+    const result = await client.callTool({ name: 'delegate_task', arguments: { brief: 'x'.repeat(12_001) } })
+    await client.close()
+
+    expect(result.isError).not.toBe(true)
+    expect(result.structuredContent).toMatchObject({
+      delegationId: 'delegation-1',
+      status: 'completed',
+      finalAssistantText: 'Final answer',
+    })
+  })
+})
+
+function options(
+  agent: Agent,
+  overrides: Partial<ManagedAgentMcpDelegateOptions> = {},
+): ManagedAgentMcpDelegateOptions {
+  let ids = 0
+  return {
+    agent,
+    createDelegationId: () => {
+      ids += 1
+      return `delegation-${ids}`
+    },
+    now: () => new Date('2026-07-06T00:00:00.000Z'),
+    resolveSessionCtx: () => CTX,
+    ...overrides,
+  }
+}
+
+async function listen(
+  handler: (req: IncomingMessage, res: ServerResponse, parsedBody?: unknown) => Promise<void>,
+): Promise<string> {
+  const server = createServer(async (req, res) => {
+    const body = await readJson(req)
+    await handler(req, res, body)
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as AddressInfo
+  servers.push({
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => error ? reject(error) : resolve())
+    }),
+  })
+  return `http://127.0.0.1:${port}/mcp`
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  if (!chunks.length) return undefined
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'))
+}
+
+function event(eventIndex: number, chunk: AgentEvent['chunk']): AgentEvent {
+  return {
+    v: 1,
+    eventIndex,
+    timestamp: Date.parse('2026-07-06T00:00:00.000Z') + eventIndex,
+    sessionId: 'session-1',
+    chunk,
+  }
+}
+
+class FakeAgent implements Agent {
+  readonly starts: AgentSendInput[] = []
+  readonly stops: Array<{ sessionId: string; ctx?: SessionCtx }> = []
+  readonly sessions: SessionStore = new FakeSessionStore()
+  readonly readiness: AgentReadiness = { requirements: [], status: async () => [] }
+  private streamStarted = deferred<void>()
+  private created = 0
+
+  constructor(
+    private readonly options: {
+      finalText?: string
+      gate?: Deferred<void>
+      streamError?: { code: StableErrorCode; message: string }
+      terminalStatus?: 'ok' | 'aborted' | 'error'
+      toolName?: string
+    } = {},
+  ) {}
+
+  async start(input: AgentSendInput): Promise<AgentStartReceipt> {
+    this.starts.push(input)
+    this.created += 1
+    return { sessionId: `session-${this.created}`, startIndex: 0 }
+  }
+
+  async *stream(sessionId: string, _options: AgentStreamOptions): AsyncIterable<AgentEvent> {
+    this.streamStarted.resolve()
+    yield { ...event(0, { type: 'agent-start', seq: 0, turnId: 'turn-1' }), sessionId }
+    yield {
+      ...event(1, {
+        type: 'message-start',
+        seq: 1,
+        messageId: 'a1',
+        role: 'assistant',
+      }),
+      sessionId,
+    }
+    await this.options.gate?.promise
+    let nextEventIndex = 2
+    if (this.options.streamError) {
+      yield {
+        ...event(nextEventIndex, {
+          type: 'error',
+          seq: nextEventIndex,
+          error: this.options.streamError,
+        }),
+        sessionId,
+      }
+      nextEventIndex += 1
+    }
+    if (this.options.toolName) {
+      yield {
+        ...event(nextEventIndex, {
+          type: 'tool-call',
+          seq: nextEventIndex,
+          messageId: 'a1',
+          toolCallId: 'tool-1',
+          toolName: this.options.toolName,
+          input: {},
+        }),
+        sessionId,
+      }
+      nextEventIndex += 1
+    }
+    yield {
+      ...event(nextEventIndex, {
+        type: 'message-end',
+        seq: nextEventIndex,
+        messageId: 'a1',
+        final: {
+          id: 'a1',
+          role: 'assistant',
+          status: 'done',
+          parts: [{ type: 'text', text: this.options.finalText ?? 'Final answer' }],
+        },
+      }),
+      sessionId,
+    }
+    nextEventIndex += 1
+    yield {
+      ...event(nextEventIndex, {
+        type: 'agent-end',
+        seq: nextEventIndex,
+        turnId: 'turn-1',
+        status: this.options.terminalStatus ?? 'ok',
+      }),
+      sessionId,
+    }
+  }
+
+  async *send(input: AgentSendInput): AsyncIterable<AgentEvent> {
+    const receipt = await this.start(input)
+    yield* this.stream(receipt.sessionId, { startIndex: receipt.startIndex, ctx: input.ctx })
+  }
+
+  async resolveInput(_sessionId: string, _requestId: string, _response: AgentResolveInputResponse): Promise<never> {
+    throw new Error('not implemented') as never
+  }
+
+  async interrupt(): Promise<unknown> {
+    return undefined
+  }
+
+  async stop(sessionId: string, ctx?: SessionCtx): Promise<unknown> {
+    this.stops.push({ sessionId, ctx })
+    return undefined
+  }
+
+  async dispose(): Promise<void> {}
+
+  waitForStreamStart(): Promise<void> {
+    return this.streamStarted.promise
+  }
+}
+
+class FakeSessionStore implements SessionStore {
+  async list(_ctx: SessionCtx, _options?: SessionListOptions): Promise<SessionSummary[]> {
+    return []
+  }
+
+  async create(_ctx: SessionCtx): Promise<SessionSummary> {
+    return summary('session')
+  }
+
+  async load(_ctx: SessionCtx, sessionId: string): Promise<SessionDetail> {
+    return summary(sessionId)
+  }
+
+  async delete(): Promise<void> {}
+}
+
+function summary(id: string): SessionSummary {
+  return {
+    id,
+    title: id,
+    createdAt: '2026-07-06T00:00:00.000Z',
+    updatedAt: '2026-07-06T00:00:00.000Z',
+    turnCount: 0,
+  }
+}
+
+async function waitForStatus(
+  controller: ReturnType<typeof createManagedAgentMcpDelegateController>,
+  delegationId: string,
+  ctx: SessionCtx,
+  predicate: (status: ReturnType<typeof controller.getStatus>) => boolean,
+): Promise<ReturnType<typeof controller.getStatus>> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const status = controller.getStatus(delegationId, ctx)
+    if (predicate(status)) return status
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return controller.getStatus(delegationId, ctx)
+}
+
+async function waitForClientStatus(
+  client: Client,
+  delegationId: string,
+  predicate: (status: Record<string, unknown>) => boolean,
+): Promise<Record<string, unknown>> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const result = await client.callTool({ name: 'delegate_task_status', arguments: { delegationId } })
+    const status = result.structuredContent as Record<string, unknown>
+    if (predicate(status)) return status
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  const result = await client.callTool({ name: 'delegate_task_status', arguments: { delegationId } })
+  return result.structuredContent as Record<string, unknown>
+}
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve(value: T): void
+  reject(error: unknown): void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}

--- a/packages/agent/src/server/mcp/index.ts
+++ b/packages/agent/src/server/mcp/index.ts
@@ -1,0 +1,27 @@
+export {
+  MANAGED_AGENT_MCP_DELIVERY_RULE,
+  MANAGED_AGENT_MCP_ORIGIN_SURFACE,
+  ManagedAgentMcpDelegateController,
+  ManagedAgentMcpError,
+  createManagedAgentMcpDelegateController,
+} from './managedAgentDelegate'
+export type {
+  ManagedAgentArtifactRef,
+  ManagedAgentCollectArtifactsInput,
+  ManagedAgentDelegateInput,
+  ManagedAgentDelegateProgress,
+  ManagedAgentDelegateRequestContext,
+  ManagedAgentDelegateResult,
+  ManagedAgentDelegateStatus,
+  ManagedAgentDelegateStatusResult,
+  ManagedAgentMcpDelegateOptions,
+  ManagedAgentSafeError,
+} from './managedAgentDelegate'
+export {
+  createManagedAgentMcpHttpHandler,
+  createManagedAgentMcpServer,
+} from './managedAgentMcpServer'
+export type {
+  ManagedAgentMcpHttpHandlerOptions,
+  ManagedAgentMcpServerOptions,
+} from './managedAgentMcpServer'

--- a/packages/agent/src/server/mcp/managedAgentDelegate.ts
+++ b/packages/agent/src/server/mcp/managedAgentDelegate.ts
@@ -1,0 +1,563 @@
+import { randomUUID } from 'node:crypto'
+
+import type { Agent, AgentActor, AgentEvent } from '../../shared/events'
+import { ErrorCode, type ErrorCode as StableErrorCode } from '../../shared/error-codes'
+import type { BoringChatMessage, BoringChatPart } from '../../shared/chat'
+import type { SessionCtx } from '../../shared/session'
+
+export const MANAGED_AGENT_MCP_ORIGIN_SURFACE = 'mcp-managed-agent'
+export const MANAGED_AGENT_MCP_DELIVERY_RULE =
+  'M1-pr1 DELIVERY v0: delegate_task returns final assistant text and artifact file references only; share-link delivery is gated on PR #424.'
+
+export type ManagedAgentDelegationStatus = 'running' | 'completed' | 'error'
+export type ManagedAgentDelegateStatus = ManagedAgentDelegationStatus
+
+export interface ManagedAgentArtifactRef {
+  path: string
+  mediaType?: string
+  title?: string
+  content?: string
+  truncated?: boolean
+}
+
+export interface ManagedAgentDelegateProgress {
+  at: string
+  eventIndex: number
+  kind: string
+  message: string
+}
+
+export interface ManagedAgentDelegateResult {
+  delegationId: string
+  status: 'completed'
+  finalAssistantText: string
+  artifacts: ManagedAgentArtifactRef[]
+  deliveryRule: typeof MANAGED_AGENT_MCP_DELIVERY_RULE
+}
+
+export interface ManagedAgentDelegateStatusResult {
+  delegationId: string
+  status: ManagedAgentDelegationStatus
+  progress: ManagedAgentDelegateProgress[]
+  lastEventIndex?: number
+  eventCount: number
+  result?: ManagedAgentDelegateResult
+  error?: ManagedAgentSafeError
+}
+
+export interface ManagedAgentSafeError {
+  code: StableErrorCode
+  message: string
+}
+
+export interface ManagedAgentDelegateRequestContext {
+  sessionId?: string
+  authInfo?: unknown
+}
+
+export interface ManagedAgentDelegateInput {
+  brief: string
+  request?: ManagedAgentDelegateRequestContext
+  onDelegationCreated?: (status: ManagedAgentDelegateStatusResult) => void | Promise<void>
+  onProgress?: (progress: ManagedAgentDelegateProgress) => void | Promise<void>
+  signal?: AbortSignal
+}
+
+export interface ManagedAgentCollectArtifactsInput {
+  delegationId: string
+  sessionId: string
+  ctx: SessionCtx
+  finalAssistantText: string
+  events: readonly AgentEvent[]
+}
+
+export interface ManagedAgentMcpDelegateOptions {
+  agent: Agent
+  resolveSessionCtx(input: { brief: string; request: ManagedAgentDelegateRequestContext }): SessionCtx | Promise<SessionCtx>
+  resolveActor?(input: { brief: string; ctx: SessionCtx; request: ManagedAgentDelegateRequestContext }): AgentActor | Promise<AgentActor>
+  collectArtifacts?(input: ManagedAgentCollectArtifactsInput): ManagedAgentArtifactRef[] | Promise<ManagedAgentArtifactRef[]>
+  createDelegationId?: () => string
+  now?: () => Date
+  maxBriefChars?: number
+  maxInlineArtifactContentChars?: number
+  terminalRetentionMs?: number
+  maxDelegations?: number
+  redactionCanaries?: readonly string[]
+}
+
+interface DelegationRecord {
+  delegationId: string
+  status: ManagedAgentDelegationStatus
+  createdAt: string
+  updatedAt: string
+  progress: ManagedAgentDelegateProgress[]
+  eventCount: number
+  ownerCtx?: SessionCtx
+  expiresAtMs?: number
+  lastEventIndex?: number
+  result?: ManagedAgentDelegateResult
+  error?: ManagedAgentSafeError
+}
+
+type AgentEndEvent = AgentEvent & { chunk: Extract<AgentEvent['chunk'], { type: 'agent-end' }> }
+
+const DEFAULT_MAX_BRIEF_CHARS = 12_000
+const DEFAULT_MAX_INLINE_ARTIFACT_CONTENT_CHARS = 8_000
+const DEFAULT_TERMINAL_RETENTION_MS = 15 * 60_000
+const DEFAULT_MAX_DELEGATIONS = 100
+const MAX_RETAINED_PROGRESS = 100
+
+export class ManagedAgentMcpError extends Error {
+  readonly code: StableErrorCode
+
+  constructor(code: StableErrorCode, message: string) {
+    super(message)
+    this.name = 'ManagedAgentMcpError'
+    this.code = code
+  }
+}
+
+export class ManagedAgentMcpDelegateController {
+  private readonly delegations = new Map<string, DelegationRecord>()
+  private readonly createDelegationId: () => string
+  private readonly now: () => Date
+  private readonly maxBriefChars: number
+  private readonly maxInlineArtifactContentChars: number
+  private readonly terminalRetentionMs: number
+  private readonly maxDelegations: number
+  private readonly redactionCanaries: readonly string[]
+
+  constructor(private readonly options: ManagedAgentMcpDelegateOptions) {
+    this.createDelegationId = options.createDelegationId ?? randomUUID
+    this.now = options.now ?? (() => new Date())
+    this.maxBriefChars = options.maxBriefChars ?? DEFAULT_MAX_BRIEF_CHARS
+    this.maxInlineArtifactContentChars =
+      options.maxInlineArtifactContentChars ?? DEFAULT_MAX_INLINE_ARTIFACT_CONTENT_CHARS
+    this.terminalRetentionMs = Math.max(0, options.terminalRetentionMs ?? DEFAULT_TERMINAL_RETENTION_MS)
+    this.maxDelegations = Math.max(1, Math.floor(options.maxDelegations ?? DEFAULT_MAX_DELEGATIONS))
+    this.redactionCanaries = options.redactionCanaries ?? []
+  }
+
+  async delegateTask(input: ManagedAgentDelegateInput): Promise<ManagedAgentDelegateResult> {
+    const brief = this.parseBrief(input.brief)
+    const request = input.request ?? {}
+    let record: DelegationRecord | undefined
+
+    try {
+      this.assertNotAborted(input.signal)
+      const ctx = await this.resolveSessionCtx(brief, request)
+      this.assertNotAborted(input.signal)
+      const delegationId = this.createDelegationId()
+      record = this.createRecord(delegationId)
+      record.ownerCtx = ctx
+      this.delegations.set(delegationId, record)
+      this.pruneDelegations()
+      await input.onDelegationCreated?.(this.getStatus(delegationId, ctx))
+      this.assertNotAborted(input.signal)
+      const actor = await this.resolveActor(brief, ctx, request)
+      const receipt = await this.options.agent.start({
+        content: brief,
+        actor,
+        ctx,
+        originSurface: MANAGED_AGENT_MCP_ORIGIN_SURFACE,
+      })
+      if (input.signal?.aborted) {
+        await this.stopDelegatedSession(receipt.sessionId, ctx)
+        throw new ManagedAgentMcpError(ErrorCode.enum.ABORTED, 'delegation was cancelled')
+      }
+      let abortStopPromise: Promise<void> | undefined
+      const abortListener = () => {
+        abortStopPromise ??= this.stopDelegatedSession(receipt.sessionId, ctx)
+      }
+      input.signal?.addEventListener('abort', abortListener, { once: true })
+      await this.pushProgress(record, 'agent-started', 'Agent session accepted for delegated task.', input.onProgress)
+
+      const events: AgentEvent[] = []
+      let terminal = false
+      let terminalStatus: 'ok' | 'aborted' | 'error' | undefined
+      try {
+        for await (const event of this.options.agent.stream(receipt.sessionId, { startIndex: receipt.startIndex, ctx })) {
+          if (input.signal?.aborted) {
+            await abortStopPromise
+            throw new ManagedAgentMcpError(ErrorCode.enum.ABORTED, 'delegation was cancelled')
+          }
+          events.push(event)
+          await this.observeEvent(record, event, input.onProgress)
+          if (isTerminalAgentEvent(event)) {
+            terminal = true
+            terminalStatus = event.chunk.status
+            break
+          }
+        }
+      } finally {
+        input.signal?.removeEventListener('abort', abortListener)
+      }
+
+      if (input.signal?.aborted) {
+        await abortStopPromise
+        throw new ManagedAgentMcpError(ErrorCode.enum.ABORTED, 'delegation was cancelled')
+      }
+      if (!terminal) {
+        throw new ManagedAgentMcpError(ErrorCode.enum.INTERNAL_ERROR, 'agent stream ended before task completion')
+      }
+      if (terminalStatus !== 'ok') {
+        throw terminalError(terminalStatus, events)
+      }
+
+      const finalAssistantText = extractFinalAssistantText(events)
+      const artifacts = await this.collectArtifacts({
+        delegationId,
+        sessionId: receipt.sessionId,
+        ctx,
+        finalAssistantText,
+        events,
+      })
+      const result: ManagedAgentDelegateResult = {
+        delegationId,
+        status: 'completed',
+        finalAssistantText,
+        artifacts,
+        deliveryRule: MANAGED_AGENT_MCP_DELIVERY_RULE,
+      }
+      this.assertPublicPayloadSafe(result)
+      record.result = result
+      this.markTerminal(record, 'completed')
+      return result
+    } catch (error) {
+      const safe = this.toSafeError(error)
+      if (record) {
+        record.error = safe
+        this.markTerminal(record, 'error')
+      }
+      throw new ManagedAgentMcpError(safe.code, safe.message)
+    }
+  }
+
+  async getStatusForRequest(
+    delegationId: string,
+    request: ManagedAgentDelegateRequestContext,
+  ): Promise<ManagedAgentDelegateStatusResult> {
+    try {
+      const ctx = await this.resolveSessionCtx('', request)
+      return this.getStatus(delegationId, ctx)
+    } catch (error) {
+      const safe = this.toSafeError(error)
+      throw new ManagedAgentMcpError(safe.code, safe.message)
+    }
+  }
+
+  getStatus(delegationId: string, ctx: SessionCtx): ManagedAgentDelegateStatusResult {
+    this.pruneDelegations()
+    const record = this.delegations.get(parseDelegationId(delegationId))
+    if (!record) throw new ManagedAgentMcpError(ErrorCode.enum.SESSION_NOT_FOUND, 'delegation not found')
+    if (!record.ownerCtx || !sameSessionCtx(record.ownerCtx, ctx)) {
+      throw new ManagedAgentMcpError(ErrorCode.enum.SESSION_NOT_FOUND, 'delegation not found')
+    }
+    const result: ManagedAgentDelegateStatusResult = {
+      delegationId: record.delegationId,
+      status: record.status,
+      progress: [...record.progress],
+      lastEventIndex: record.lastEventIndex,
+      eventCount: record.eventCount,
+      result: record.result,
+      error: record.error,
+    }
+    this.assertPublicPayloadSafe(result)
+    return result
+  }
+
+  private createRecord(delegationId: string): DelegationRecord {
+    this.pruneDelegations()
+    const runningCount = [...this.delegations.values()].filter((record) => record.status === 'running').length
+    if (runningCount >= this.maxDelegations) {
+      throw new ManagedAgentMcpError(ErrorCode.enum.TOOL_EXECUTION_ERROR, 'too many running delegated tasks')
+    }
+    const now = this.timestamp()
+    return {
+      delegationId,
+      status: 'running',
+      createdAt: now,
+      updatedAt: now,
+      progress: [],
+      eventCount: 0,
+    }
+  }
+
+  private markTerminal(record: DelegationRecord, status: 'completed' | 'error'): void {
+    record.status = status
+    record.updatedAt = this.timestamp()
+    record.expiresAtMs = this.now().getTime() + this.terminalRetentionMs
+    this.pruneDelegations()
+  }
+
+  private pruneDelegations(): void {
+    const nowMs = this.now().getTime()
+    for (const [delegationId, record] of this.delegations) {
+      if (record.expiresAtMs !== undefined && record.expiresAtMs <= nowMs) {
+        this.delegations.delete(delegationId)
+      }
+    }
+    while (this.delegations.size > this.maxDelegations) {
+      const terminal = [...this.delegations].find(([, record]) => record.status !== 'running')
+      if (!terminal) return
+      this.delegations.delete(terminal[0])
+    }
+  }
+
+  private parseBrief(value: string): string {
+    if (typeof value !== 'string') throw new ManagedAgentMcpError(ErrorCode.enum.TOOL_INVALID_INPUT, 'brief must be a string')
+    const brief = value.trim()
+    if (!brief) throw new ManagedAgentMcpError(ErrorCode.enum.TOOL_INVALID_INPUT, 'brief is required')
+    if (brief.length > this.maxBriefChars) {
+      throw new ManagedAgentMcpError(ErrorCode.enum.TOOL_INVALID_INPUT, `brief must be ${this.maxBriefChars} characters or fewer`)
+    }
+    return brief
+  }
+
+  private async resolveSessionCtx(brief: string, request: ManagedAgentDelegateRequestContext): Promise<SessionCtx> {
+    const ctx = await this.options.resolveSessionCtx({ brief, request })
+    if (!ctx || typeof ctx.workspaceId !== 'string' || !ctx.workspaceId.trim()) {
+      throw new ManagedAgentMcpError(ErrorCode.enum.CONFIG_INVALID, 'MCP delegate requires a host-resolved SessionCtx with a real workspaceId')
+    }
+    if (ctx.userId !== undefined && (typeof ctx.userId !== 'string' || !ctx.userId.trim())) {
+      throw new ManagedAgentMcpError(ErrorCode.enum.CONFIG_INVALID, 'MCP delegate SessionCtx userId must be a non-empty string when provided')
+    }
+    return { workspaceId: ctx.workspaceId, userId: ctx.userId }
+  }
+
+  private assertNotAborted(signal: AbortSignal | undefined): void {
+    if (signal?.aborted) throw new ManagedAgentMcpError(ErrorCode.enum.ABORTED, 'delegation was cancelled')
+  }
+
+  private async stopDelegatedSession(sessionId: string, ctx: SessionCtx): Promise<void> {
+    await this.options.agent.stop(sessionId, ctx).catch(() => undefined)
+  }
+
+  private async resolveActor(
+    brief: string,
+    ctx: SessionCtx,
+    request: ManagedAgentDelegateRequestContext,
+  ): Promise<AgentActor> {
+    const actor = await this.options.resolveActor?.({ brief, ctx, request })
+    return actor ?? { id: 'mcp-managed-agent', name: 'MCP managed agent' }
+  }
+
+  private async observeEvent(
+    record: DelegationRecord,
+    event: AgentEvent,
+    onProgress: ManagedAgentDelegateInput['onProgress'],
+  ): Promise<void> {
+    record.eventCount += 1
+    record.lastEventIndex = event.eventIndex
+    const message = progressMessageForEvent(event)
+    if (message) await this.pushProgress(record, event.chunk.type, message, onProgress, event.eventIndex)
+  }
+
+  private async pushProgress(
+    record: DelegationRecord,
+    kind: string,
+    message: string,
+    onProgress: ManagedAgentDelegateInput['onProgress'],
+    eventIndex = record.lastEventIndex ?? -1,
+  ): Promise<void> {
+    const safeMessage = this.containsSecret(message) ? 'Agent progress updated.' : message
+    const progress: ManagedAgentDelegateProgress = {
+      at: this.timestamp(),
+      eventIndex,
+      kind,
+      message: safeMessage,
+    }
+    record.progress.push(progress)
+    if (record.progress.length > MAX_RETAINED_PROGRESS) record.progress.shift()
+    record.updatedAt = progress.at
+    try {
+      await onProgress?.(progress)
+    } catch {
+      // MCP progress notifications are best-effort; polling remains the fallback.
+    }
+  }
+
+  private async collectArtifacts(input: ManagedAgentCollectArtifactsInput): Promise<ManagedAgentArtifactRef[]> {
+    const supplied = await this.options.collectArtifacts?.(input)
+    const artifacts = (supplied ?? extractArtifactRefs(input.events)).map((artifact) =>
+      normalizeArtifactRef(artifact, this.maxInlineArtifactContentChars),
+    )
+    this.assertPublicPayloadSafe(artifacts)
+    return artifacts
+  }
+
+  private toSafeError(error: unknown): ManagedAgentSafeError {
+    if (error instanceof ManagedAgentMcpError) {
+      return {
+        code: error.code,
+        message: this.containsSecret(error.message) ? 'MCP delegate task failed' : error.message,
+      }
+    }
+    return { code: parseStableErrorCode(error), message: 'MCP delegate task failed' }
+  }
+
+  private assertPublicPayloadSafe(payload: unknown): void {
+    const serialized = JSON.stringify(payload)
+    if (this.containsSecret(serialized)) {
+      throw new ManagedAgentMcpError(ErrorCode.enum.INTERNAL_ERROR, 'MCP delegate payload failed secret redaction guard')
+    }
+  }
+
+  private containsSecret(value: string): boolean {
+    return this.redactionCanaries.some((canary) => canary.length > 0 && value.includes(canary))
+  }
+
+  private timestamp(): string {
+    return this.now().toISOString()
+  }
+}
+
+export function createManagedAgentMcpDelegateController(
+  options: ManagedAgentMcpDelegateOptions,
+): ManagedAgentMcpDelegateController {
+  return new ManagedAgentMcpDelegateController(options)
+}
+
+function parseDelegationId(value: string): string {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new ManagedAgentMcpError(ErrorCode.enum.TOOL_INVALID_INPUT, 'delegationId is required')
+  }
+  return value.trim()
+}
+
+function parseStableErrorCode(error: unknown): StableErrorCode {
+  const parsed = ErrorCode.safeParse((error as { code?: unknown } | undefined)?.code)
+  return parsed.success ? parsed.data : ErrorCode.enum.INTERNAL_ERROR
+}
+
+function isTerminalAgentEvent(event: AgentEvent): event is AgentEndEvent {
+  return event.chunk.type === 'agent-end' && event.chunk.willRetry !== true
+}
+
+function terminalError(
+  terminalStatus: 'aborted' | 'error' | undefined,
+  events: readonly AgentEvent[],
+): ManagedAgentMcpError {
+  if (terminalStatus === 'aborted') return new ManagedAgentMcpError(ErrorCode.enum.ABORTED, 'agent turn was aborted')
+  const errorEvent = [...events].reverse().find((event) => event.chunk.type === 'error')
+  if (errorEvent?.chunk.type === 'error') {
+    const parsed = ErrorCode.safeParse(errorEvent.chunk.error.code)
+    return new ManagedAgentMcpError(parsed.success ? parsed.data : ErrorCode.enum.INTERNAL_ERROR, 'agent turn failed')
+  }
+  return new ManagedAgentMcpError(ErrorCode.enum.INTERNAL_ERROR, 'agent turn failed')
+}
+
+function progressMessageForEvent(event: AgentEvent): string | undefined {
+  switch (event.chunk.type) {
+    case 'agent-start':
+      return 'Agent turn started.'
+    case 'message-start':
+      return event.chunk.role === 'assistant' ? 'Assistant response started.' : 'Delegated brief was recorded.'
+    case 'message-delta':
+    case 'message-part-end':
+      return event.chunk.kind === 'text' ? 'Assistant text updated.' : 'Assistant reasoning updated.'
+    case 'tool-call':
+      return `Tool call started: ${event.chunk.toolName}.`
+    case 'tool-result':
+      return 'Tool call finished.'
+    case 'agent-end':
+      return event.chunk.status === 'ok' ? 'Agent turn completed.' : `Agent turn ended with status ${event.chunk.status}.`
+    case 'error':
+      return 'Agent stream reported an error.'
+    default:
+      return undefined
+  }
+}
+
+function extractFinalAssistantText(events: readonly AgentEvent[]): string {
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const chunk = events[index]?.chunk
+    if (chunk?.type !== 'message-end' || chunk.final.role !== 'assistant') continue
+    const text = textFromMessage(chunk.final)
+    if (text) return text
+  }
+  const endedText = events
+    .filter((event) => event.chunk.type === 'message-part-end' && event.chunk.kind === 'text')
+    .map((event) => event.chunk.type === 'message-part-end' ? event.chunk.text : '')
+    .filter(Boolean)
+  if (endedText.length) return endedText.at(-1) ?? ''
+  return ''
+}
+
+function textFromMessage(message: BoringChatMessage): string {
+  return message.parts
+    .filter((part): part is Extract<BoringChatPart, { type: 'text' }> => part.type === 'text')
+    .map((part) => part.text)
+    .filter(Boolean)
+    .join('\n')
+}
+
+function extractArtifactRefs(events: readonly AgentEvent[]): ManagedAgentArtifactRef[] {
+  const artifacts: ManagedAgentArtifactRef[] = []
+  const seen = new Set<string>()
+  for (const event of events) {
+    if (event.chunk.type !== 'message-end') continue
+    for (const part of event.chunk.final.parts) {
+      if (part.type !== 'file' || !part.path) continue
+      const key = `${part.filesystem ?? ''}:${part.path}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      artifacts.push({
+        path: part.path,
+        mediaType: part.mediaType,
+        title: part.filename,
+      })
+    }
+  }
+  return artifacts
+}
+
+function normalizeArtifactRef(
+  artifact: ManagedAgentArtifactRef,
+  maxInlineArtifactContentChars: number,
+): ManagedAgentArtifactRef {
+  const path = normalizeArtifactPath(artifact.path)
+  const normalized: ManagedAgentArtifactRef = {
+    path,
+    mediaType: optionalNonEmptyString(artifact.mediaType),
+    title: optionalNonEmptyString(artifact.title),
+  }
+  if (artifact.content !== undefined) {
+    if (typeof artifact.content !== 'string') {
+      throw new ManagedAgentMcpError(ErrorCode.enum.INTERNAL_ERROR, 'artifact content must be text')
+    }
+    if (artifact.content.length <= maxInlineArtifactContentChars) {
+      normalized.content = artifact.content
+    } else {
+      normalized.truncated = true
+    }
+  }
+  if (artifact.truncated === true) normalized.truncated = true
+  return normalized
+}
+
+function normalizeArtifactPath(path: string): string {
+  if (typeof path !== 'string') throw new ManagedAgentMcpError(ErrorCode.enum.INTERNAL_ERROR, 'artifact path must be a string')
+  const trimmed = path.trim()
+  if (!trimmed) throw new ManagedAgentMcpError(ErrorCode.enum.INTERNAL_ERROR, 'artifact path is required')
+  if (trimmed.includes('\0')) throw new ManagedAgentMcpError(ErrorCode.enum.INTERNAL_ERROR, 'artifact path is invalid')
+  if (trimmed.startsWith('/') || /^[A-Za-z]:[\\/]/.test(trimmed)) {
+    throw new ManagedAgentMcpError(ErrorCode.enum.INTERNAL_ERROR, 'artifact path must be workspace-relative')
+  }
+  const parts = trimmed.split(/[\\/]+/)
+  if (parts.some((part) => part === '..')) {
+    throw new ManagedAgentMcpError(ErrorCode.enum.INTERNAL_ERROR, 'artifact path must stay within the workspace')
+  }
+  return parts.filter((part) => part && part !== '.').join('/')
+}
+
+function optionalNonEmptyString(value: string | undefined): string | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function sameSessionCtx(a: SessionCtx, b: SessionCtx): boolean {
+  return (a.workspaceId ?? '') === (b.workspaceId ?? '') && (a.userId ?? '') === (b.userId ?? '')
+}

--- a/packages/agent/src/server/mcp/managedAgentMcpServer.ts
+++ b/packages/agent/src/server/mcp/managedAgentMcpServer.ts
@@ -1,0 +1,225 @@
+import type { IncomingMessage, ServerResponse } from 'node:http'
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import type { CallToolResult, ServerNotification } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
+
+import {
+  MANAGED_AGENT_MCP_DELIVERY_RULE,
+  ManagedAgentMcpDelegateController,
+  ManagedAgentMcpError,
+  createManagedAgentMcpDelegateController,
+  type ManagedAgentDelegateRequestContext,
+  type ManagedAgentDelegateResult,
+  type ManagedAgentDelegateStatusResult,
+  type ManagedAgentMcpDelegateOptions,
+} from './managedAgentDelegate'
+import { ErrorCode, type ErrorCode as StableErrorCode } from '../../shared/error-codes'
+
+export interface ManagedAgentMcpServerOptions extends ManagedAgentMcpDelegateOptions {
+  name?: string
+  version?: string
+}
+
+export interface ManagedAgentMcpHttpHandlerOptions extends ManagedAgentMcpServerOptions {
+  controller?: ManagedAgentMcpDelegateController
+}
+
+type McpToolExtra = {
+  _meta?: {
+    progressToken?: string | number
+  }
+  sessionId?: string
+  authInfo?: unknown
+  signal?: AbortSignal
+  sendNotification(notification: ServerNotification): Promise<void>
+}
+
+type ManagedAgentRegisterTool = (
+  name: string,
+  config: {
+    title?: string
+    description?: string
+    inputSchema?: Record<string, unknown>
+  },
+  cb: (input: Record<string, unknown>, extra: unknown) => Promise<CallToolResult>,
+) => unknown
+
+const DEFAULT_MAX_BRIEF_CHARS = 12_000
+
+const delegateTaskStatusInputSchema: Record<string, unknown> = {
+  delegationId: z.string().min(1),
+}
+
+export function createManagedAgentMcpServer(
+  options: ManagedAgentMcpServerOptions,
+  controller = createManagedAgentMcpDelegateController(options),
+): McpServer {
+  const server = new McpServer({
+    name: options.name ?? 'boring-managed-agent',
+    version: options.version ?? '0.0.0',
+  })
+  const registerTool = server.registerTool.bind(server) as ManagedAgentRegisterTool
+  const delegateTaskInputSchema = createDelegateTaskInputSchema(options.maxBriefChars ?? DEFAULT_MAX_BRIEF_CHARS)
+
+  registerTool(
+    'delegate_task',
+    {
+      title: 'Delegate task',
+      description: `${MANAGED_AGENT_MCP_DELIVERY_RULE} Starts one fresh boring-agent session for the supplied brief and streams it to completion.`,
+      inputSchema: delegateTaskInputSchema,
+    },
+    async ({ brief }, extra): Promise<CallToolResult> => {
+      try {
+        const result = await controller.delegateTask({
+          brief: typeof brief === 'string' ? brief : '',
+          request: requestContextFromExtra(extra as McpToolExtra | undefined),
+          signal: (extra as McpToolExtra | undefined)?.signal,
+          onProgress: async (progress) => {
+            await sendMcpProgress(extra as McpToolExtra | undefined, progress.eventIndex + 2, progress.message)
+          },
+        })
+        return resultTool(result)
+      } catch (error) {
+        return errorTool(error)
+      }
+    },
+  )
+
+  registerTool(
+    'delegate_task_start',
+    {
+      title: 'Start delegated task',
+      description: `${MANAGED_AGENT_MCP_DELIVERY_RULE} Starts one fresh boring-agent session and immediately returns a delegation id for polling.`,
+      inputSchema: delegateTaskInputSchema,
+    },
+    async ({ brief }, extra): Promise<CallToolResult> => {
+      const created = deferred<ManagedAgentDelegateStatusResult>()
+      let createdResolved = false
+      const completion = controller.delegateTask({
+        brief: typeof brief === 'string' ? brief : '',
+        request: requestContextFromExtra(extra as McpToolExtra | undefined),
+        signal: (extra as McpToolExtra | undefined)?.signal,
+        onDelegationCreated: (status) => {
+          createdResolved = true
+          created.resolve(status)
+        },
+      })
+      void completion.catch((error) => {
+        if (!createdResolved) created.reject(error)
+      })
+      try {
+        return resultTool(await created.promise)
+      } catch (error) {
+        return errorTool(error)
+      }
+    },
+  )
+
+  registerTool(
+    'delegate_task_status',
+    {
+      title: 'Delegate task status',
+      description: 'Returns redacted progress and the final M1-pr1 delivery payload for a server-side delegation id.',
+      inputSchema: delegateTaskStatusInputSchema,
+    },
+    async ({ delegationId }, extra): Promise<CallToolResult> => {
+      try {
+        return resultTool(await controller.getStatusForRequest(
+          typeof delegationId === 'string' ? delegationId : '',
+          requestContextFromExtra(extra as McpToolExtra | undefined),
+        ))
+      } catch (error) {
+        return errorTool(error)
+      }
+    },
+  )
+
+  return server
+}
+
+export function createManagedAgentMcpHttpHandler(options: ManagedAgentMcpHttpHandlerOptions): (
+  req: IncomingMessage,
+  res: ServerResponse,
+  parsedBody?: unknown,
+) => Promise<void> {
+  const controller = options.controller ?? createManagedAgentMcpDelegateController(options)
+  return async (req, res, parsedBody) => {
+    const server = createManagedAgentMcpServer(options, controller)
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: false,
+    })
+    res.on('close', () => {
+      void transport.close().catch(() => undefined)
+      void server.close().catch(() => undefined)
+    })
+    await server.connect(transport)
+    await transport.handleRequest(req, res, parsedBody)
+  }
+}
+
+function requestContextFromExtra(extra: McpToolExtra | undefined): ManagedAgentDelegateRequestContext {
+  return {
+    sessionId: extra?.sessionId,
+    authInfo: extra?.authInfo,
+  }
+}
+
+function createDelegateTaskInputSchema(maxBriefChars: number): Record<string, unknown> {
+  return {
+    brief: z.string().min(1).max(maxBriefChars),
+  }
+}
+
+async function sendMcpProgress(extra: McpToolExtra | undefined, progress: number, message: string): Promise<void> {
+  const progressToken = extra?._meta?.progressToken
+  if (progressToken === undefined) return
+  if (typeof extra?.sendNotification !== 'function') return
+  await extra.sendNotification({
+    method: 'notifications/progress',
+    params: { progressToken, progress, message },
+  })
+}
+
+function resultTool(result: ManagedAgentDelegateResult | ManagedAgentDelegateStatusResult): CallToolResult {
+  return {
+    structuredContent: result as unknown as Record<string, unknown>,
+    content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+  }
+}
+
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve(value: T): void
+  reject(error: unknown): void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+function errorTool(error: unknown): CallToolResult {
+  const safe = safeError(error)
+  return {
+    isError: true,
+    structuredContent: { error: safe },
+    content: [{ type: 'text', text: JSON.stringify({ error: safe }) }],
+  }
+}
+
+function safeError(error: unknown): { code: StableErrorCode; message: string } {
+  if (error instanceof ManagedAgentMcpError) return { code: error.code, message: error.message }
+  const parsed = ErrorCode.safeParse((error as { code?: unknown } | undefined)?.code)
+  return {
+    code: parsed.success ? parsed.data : ErrorCode.enum.INTERNAL_ERROR,
+    message: 'MCP delegate tool failed',
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       '@mariozechner/pi-coding-agent':
         specifier: npm:@earendil-works/pi-coding-agent@0.75.5
         version: '@earendil-works/pi-coding-agent@0.75.5(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)'
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@3.25.76)
       '@radix-ui/react-collapsible':
         specifier: ^1.1.14
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -6296,10 +6299,6 @@ packages:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
 
-  eventsource-parser@3.0.8:
-    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
-    engines: {node: '>=18.0.0'}
-
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -10664,7 +10663,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.12.27
@@ -10676,7 +10675,6 @@ snapshots:
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
@@ -10687,7 +10685,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.8
+      eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
       hono: 4.12.27
@@ -14090,8 +14088,6 @@ snapshots:
 
   events@3.3.0: {}
 
-  eventsource-parser@3.0.8: {}
-
   eventsource-parser@3.1.0: {}
 
   eventsource@3.0.7:
@@ -14139,7 +14135,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.3
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1


### PR DESCRIPTION
First PR of the **M1 outreach-demo sidecar**: expose a configured boring agent over MCP.

## What
Additive MCP delegate surface under `packages/agent/src/server/mcp/`, exported from the server barrel:
- `delegate_task(brief)` — one fresh façade session per delegation via `createAgent().start`, streamed to completion over the P1 live tail (no T1 dependency)
- `delegate_task_start` / `delegate_task_status` — async start + polling fallback when the client path doesn't support MCP progress notifications
- Host-resolved `SessionCtx` tenancy — callers cannot supply tenant authority
- Redacted caller payloads: no internal session paths, workspace roots, or secrets

Delivery v0 per the amended work order (#534): result = final text + artifact refs; **share links deferred to the #424-gated BBM1-004 slice**.

Note the duality: `plugins/boring-mcp` *consumes* external MCP servers; this *exposes* a boring agent as one.

## Review guide (~15 min)
1. `src/server/mcp/index.ts` — the delegate surface; check SessionCtx is host-composed, session-per-delegation, and the redaction of caller-visible results
2. Cancellation path in `delegate_task_start` — autoreview caught a bug here (request signal not forwarded); fixed with pre-start cancellation checks + tests
3. Tests: `src/server/mcp/__tests__/managedAgentDelegate.test.ts` (18 tests: fake MCP client + fake façade, secret-canary check, unknown-delegation error)

## Gates (all PASS, verbatim in work log)
agent build/typecheck/test (192 files, 1617 passed), `lint:invariants` (repo-wide), `audit:imports`, `check:isolation`, autoreview clean (overall 0.86).

## LOC
Production +845 net-new (cap 2k ✅) / tests +633.

Behavior-frozen: purely additive, nothing existing changes; the live demo app is untouched until a host mounts this.

Work order: `docs/issues/391/runtime-refactor/work/M1-mcp-managed-agent/TODO.md` (`pr1-exposed-mcp-delegate`). Not stacked — based on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)