### PR TITLE
boring-governance: governance-free core admin shell (no provider = no surface)

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -290,6 +290,15 @@ Each decision has four fields:
 
 ---
 
+## 19. Company-admin front surface: single app-composed provider slot, no plugin self-registration
+
+| Field | |
+|---|---|
+| **What** | Core front exposes exactly one optional, declarative admin-surface slot: `CoreFront`'s `companyAdmin?: { loadStatus, renderContent, labels? }` prop, threaded through `CompanyAdminProvider`. The app composes it (e.g. full-app passes `createGovernanceCompanyAdmin()` from `@hachej/boring-governance/front`); plugins never register themselves into core front. With no provider configured — or a provider reporting `enabled !== true` / `admin !== true` — core renders **no trace** of the surface: no `UserMenu` entry, and the admin route navigates away. Core contains zero governance vocabulary (enforced by review grep: `grep -ri governance packages/core/src` must be empty). |
+| **Why** | Core must stay generic: it knows "an admin surface descriptor was provided", never which plugin provided it. App-side composition (props, not a registry) makes ordering and conflicts a non-problem — the app decides explicitly in readable code, matching how the server seams compose (`plugins`, `filterModels`, `metering`, `getFilesystemBindings` are also app-spread). The workspace-pane plugin system is not reused because admin surfaces are app-level routes gated on a different axis (company admin) than workspace panes (workspace membership); conflating the two lifecycles would be wrong. |
+| **Rationale** | v1 has exactly one consumer (boring-governance), so a multi-surface registry would be designed from a single example — the descriptor shape `{ loadStatus, renderContent, labels }` was instead made self-describing so pluralizing is mechanical. Designing a generic slot from one example risks wrong abstractions (composition order, deep-linking, per-section gating are unknowable without a second consumer). |
+| **Re-evaluate when** | A second plugin needs an admin/workspace-management surface. Planned evolution: `companyAdmin` becomes `adminSections: Section[]` (same descriptor shape, plus an `id` for deep-linking); the admin page hosts one tab per section whose `loadStatus` reports `admin: true`; app array order is authoritative for display order; still no dynamic registration. |
+
 ## Process
 
 1. Any PR that changes a locked decision **must** update this document.

--- a/packages/core/src/front/CompanyAdminProvider.tsx
+++ b/packages/core/src/front/CompanyAdminProvider.tsx
@@ -10,12 +10,19 @@ export interface CompanyAdminStatus {
 export type LoadCompanyAdminStatus = () => Promise<CompanyAdminStatus | null>
 export type RenderCompanyAdminContent = (status: CompanyAdminStatus) => ReactNode
 
+export interface CompanyAdminLabels {
+  menuLabel?: string
+  pageTitle?: string
+  deniedMessage?: string
+}
+
 interface CompanyAdminContextValue {
   configured: boolean
   loading: boolean
   status: CompanyAdminStatus | null
   error: string | null
   renderContent: RenderCompanyAdminContent | null
+  labels: CompanyAdminLabels
   refresh(): Promise<void>
 }
 
@@ -25,6 +32,7 @@ const CompanyAdminContext = createContext<CompanyAdminContextValue>({
   status: null,
   error: null,
   renderContent: null,
+  labels: {},
   refresh: async () => {},
 })
 
@@ -32,6 +40,7 @@ export interface CompanyAdminProviderProps {
   children: ReactNode
   loadStatus?: LoadCompanyAdminStatus
   renderContent?: RenderCompanyAdminContent
+  labels?: CompanyAdminLabels
   /**
    * Optional authenticated-user cache key. When null, status is cleared and no
    * request is made. When it changes, status is refetched.
@@ -39,7 +48,7 @@ export interface CompanyAdminProviderProps {
   identityKey?: string | null
 }
 
-export function CompanyAdminProvider({ children, loadStatus, renderContent, identityKey }: CompanyAdminProviderProps) {
+export function CompanyAdminProvider({ children, loadStatus, renderContent, labels, identityKey }: CompanyAdminProviderProps) {
   const [status, setStatus] = useState<CompanyAdminStatus | null>(null)
   const [loading, setLoading] = useState(Boolean(loadStatus && identityKey !== null))
   const [error, setError] = useState<string | null>(null)
@@ -87,13 +96,14 @@ export function CompanyAdminProvider({ children, loadStatus, renderContent, iden
   }, [identityKey, loadStatus])
 
   const value = useMemo<CompanyAdminContextValue>(() => ({
-    configured: Boolean(loadStatus),
+    configured: Boolean(loadStatus && renderContent),
     loading,
     status,
     error,
     renderContent: renderContent ?? null,
+    labels: labels ?? {},
     refresh,
-  }), [error, loadStatus, loading, renderContent, status])
+  }), [error, labels, loadStatus, loading, renderContent, status])
 
   return <CompanyAdminContext.Provider value={value}>{children}</CompanyAdminContext.Provider>
 }

--- a/packages/core/src/front/CoreFront.tsx
+++ b/packages/core/src/front/CoreFront.tsx
@@ -9,7 +9,7 @@ import { ConfigProvider, useConfig } from './ConfigProvider.js'
 import { ThemeProvider } from './ThemeProvider.js'
 import { AuthProvider, useSession } from './auth/AuthProvider.js'
 import { UserIdentityProvider } from './auth/UserIdentityProvider.js'
-import { CompanyAdminProvider, type LoadCompanyAdminStatus, type RenderCompanyAdminContent } from './CompanyAdminProvider.js'
+import { CompanyAdminProvider, type CompanyAdminLabels, type LoadCompanyAdminStatus, type RenderCompanyAdminContent } from './CompanyAdminProvider.js'
 import { WorkspaceAuthProvider } from './WorkspaceAuthProvider.js'
 import { AuthGate } from './AuthGate.js'
 import { TopBarSlotProvider, UserMenu } from './components/index.js'
@@ -41,6 +41,7 @@ export interface CoreFrontAuthPagesOverride {
 export interface CoreFrontCompanyAdminOptions {
   loadStatus?: LoadCompanyAdminStatus
   renderContent?: RenderCompanyAdminContent
+  labels?: CompanyAdminLabels
 }
 
 export interface CoreFrontProps {
@@ -84,6 +85,7 @@ function CompanyAdminScopedProvider({ children, companyAdmin }: { children: Reac
     <CompanyAdminProvider
       loadStatus={companyAdmin?.loadStatus}
       renderContent={companyAdmin?.renderContent}
+      labels={companyAdmin?.labels}
       identityKey={identityKey}
     >
       {children}

--- a/packages/core/src/front/__tests__/CompanyAdminPage.test.tsx
+++ b/packages/core/src/front/__tests__/CompanyAdminPage.test.tsx
@@ -1,6 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from '@testing-library/react'
-import userEvent from '@testing-library/user-event'
+import { render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -9,15 +8,15 @@ import { CompanyAdminProvider, type CompanyAdminStatus } from '../CompanyAdminPr
 import { CompanyAdminPage } from '../workspace/CompanyAdminPage'
 
 const mockUseCurrentWorkspace = vi.fn()
-const mockUseWorkspaceRole = vi.fn()
 const mockUseWorkspaceRouteStatus = vi.fn()
+
+const renderEmptyAdminContent = () => null
 
 vi.mock('../WorkspaceAuthProvider', async () => {
   const actual = await vi.importActual<typeof import('../WorkspaceAuthProvider')>('../WorkspaceAuthProvider')
   return {
     ...actual,
     useCurrentWorkspace: () => mockUseCurrentWorkspace(),
-    useWorkspaceRole: () => mockUseWorkspaceRole(),
     useWorkspaceRouteStatus: () => mockUseWorkspaceRouteStatus(),
   }
 })
@@ -26,6 +25,7 @@ function renderPage(path = '/w/ws-a/admin', wrapper?: (children: ReactNode) => R
   const page = (
     <MemoryRouter initialEntries={[path]}>
       <Routes>
+        <Route path="/" element={<div data-testid="home-page">Home</div>} />
         <Route path="/w/:id/admin" element={<CompanyAdminPage />} />
       </Routes>
     </MemoryRouter>
@@ -35,7 +35,6 @@ function renderPage(path = '/w/ws-a/admin', wrapper?: (children: ReactNode) => R
 
 beforeEach(() => {
   mockUseCurrentWorkspace.mockReturnValue({ id: 'ws-a', name: 'Workspace A' })
-  mockUseWorkspaceRole.mockReturnValue('owner')
   mockUseWorkspaceRouteStatus.mockReturnValue({
     status: 'matched',
     workspaceId: 'ws-a',
@@ -44,65 +43,14 @@ beforeEach(() => {
 })
 
 describe('CompanyAdminPage', () => {
-  it('renders owner admin shell with context and model tabs', async () => {
-    const user = userEvent.setup()
+  it('redirects away when no provider is configured', async () => {
     renderPage()
 
-    expect(screen.getByRole('heading', { name: 'Workspace A' })).toBeInTheDocument()
-    expect(screen.getByRole('tab', { name: 'Context access' })).toHaveAttribute('aria-selected', 'true')
-    expect(screen.getByRole('tab', { name: 'Model control' })).toHaveAttribute('aria-selected', 'false')
-    expect(screen.getByRole('heading', { name: 'Context access' })).toBeInTheDocument()
-
-    await user.click(screen.getByRole('tab', { name: 'Model control' }))
-
-    await waitFor(() => {
-      expect(screen.getByRole('tab', { name: 'Model control' })).toHaveAttribute('aria-selected', 'true')
-    })
-    expect(screen.getByRole('heading', { name: 'Model control' })).toBeInTheDocument()
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument()
+    expect(screen.queryByText('Loading admin status…')).toBeNull()
   })
 
-  it('shows loading state while workspace role is resolving', () => {
-    mockUseWorkspaceRole.mockReturnValue(null)
-    mockUseWorkspaceRouteStatus.mockReturnValue({ status: 'loading', workspaceId: 'ws-a' })
-
-    renderPage()
-
-    expect(screen.getByText('Loading company admin…')).toBeInTheDocument()
-    expect(screen.queryByText('Owner access required')).toBeNull()
-  })
-
-  it('shows not-found route errors instead of hanging on loading', () => {
-    mockUseWorkspaceRole.mockReturnValue(null)
-    mockUseWorkspaceRouteStatus.mockReturnValue({
-      status: 'not-found',
-      workspaceId: 'missing-ws',
-      message: 'Workspace not found',
-    })
-
-    renderPage('/w/missing-ws/admin')
-
-    expect(screen.getByText('Workspace unavailable')).toBeInTheDocument()
-    expect(screen.getByText('Workspace not found')).toBeInTheDocument()
-    expect(screen.queryByText('Loading company admin…')).toBeNull()
-  })
-
-  it('shows forbidden route errors instead of hanging on loading', () => {
-    mockUseWorkspaceRole.mockReturnValue(null)
-    mockUseWorkspaceRouteStatus.mockReturnValue({
-      status: 'forbidden',
-      workspaceId: 'ws-a',
-      message: 'Forbidden',
-    })
-
-    renderPage()
-
-    expect(screen.getByText('Owner access required')).toBeInTheDocument()
-    expect(screen.getByText(/Only workspace owners can manage/)).toBeInTheDocument()
-    expect(screen.queryByText('Loading company admin…')).toBeNull()
-  })
-
-  it('renders app-owned content for governance admins through the generic seam', async () => {
-    mockUseWorkspaceRole.mockReturnValue('viewer')
+  it('renders app-owned content for provider admins through the generic seam', async () => {
     const status: CompanyAdminStatus = { enabled: true, role: 'admin', admin: true, details: { source: 'test' } }
 
     renderPage('/w/ws-a/admin', (children) => (
@@ -115,26 +63,118 @@ describe('CompanyAdminPage', () => {
     ))
 
     expect(await screen.findByText('App-owned admin content: test')).toBeInTheDocument()
-    expect(screen.queryByText('YAML-managed in v1')).toBeNull()
   })
 
-  it('blocks governance-enabled non-admins even when they own the workspace', async () => {
+  it('redirects away when the provider reports the surface is disabled', async () => {
+    const status: CompanyAdminStatus = { enabled: false, role: 'admin', admin: true }
+
+    renderPage('/w/ws-a/admin', (children) => (
+      <CompanyAdminProvider loadStatus={async () => status} renderContent={renderEmptyAdminContent}>{children}</CompanyAdminProvider>
+    ))
+
+    expect(await screen.findByTestId('home-page')).toBeInTheDocument()
+  })
+
+  it('shows the provider error view when status loading fails', async () => {
+    renderPage('/w/ws-a/admin', (children) => (
+      <CompanyAdminProvider
+        loadStatus={async () => { throw new Error('Status check failed') }}
+        renderContent={renderEmptyAdminContent}
+        labels={{ pageTitle: 'Team Admin' }}
+      >
+        {children}
+      </CompanyAdminProvider>
+    ))
+
+    expect(await screen.findByText('Admin unavailable')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Team Admin' })).toBeInTheDocument()
+    expect(screen.getByText('Status check failed')).toBeInTheDocument()
+  })
+
+  it('blocks provider non-admin users with default labels', async () => {
     const status: CompanyAdminStatus = { enabled: true, role: 'user', admin: false }
 
     renderPage('/w/ws-a/admin', (children) => (
-      <CompanyAdminProvider loadStatus={async () => status}>{children}</CompanyAdminProvider>
+      <CompanyAdminProvider loadStatus={async () => status} renderContent={renderEmptyAdminContent}>{children}</CompanyAdminProvider>
     ))
 
-    expect(await screen.findByText('Company admin access required')).toBeInTheDocument()
-    expect(screen.getByText(/do not have access/)).toBeInTheDocument()
+    expect(await screen.findByText('Access required')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Admin' })).toBeInTheDocument()
+    expect(screen.getByText('You do not have access to this page.')).toBeInTheDocument()
   })
 
-  it('blocks non-owner members in the client shell', () => {
-    mockUseWorkspaceRole.mockReturnValue('viewer')
+  it('uses provider labels in the denied state', async () => {
+    const status: CompanyAdminStatus = { enabled: true, role: 'user', admin: false }
 
-    renderPage()
+    renderPage('/w/ws-a/admin', (children) => (
+      <CompanyAdminProvider
+        loadStatus={async () => status}
+        renderContent={renderEmptyAdminContent}
+        labels={{ pageTitle: 'Team Admin', deniedMessage: 'Ask your team owner for access.' }}
+      >
+        {children}
+      </CompanyAdminProvider>
+    ))
 
-    expect(screen.getByText('Owner access required')).toBeInTheDocument()
-    expect(screen.getByText(/Only workspace owners can manage/)).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Team Admin' })).toBeInTheDocument()
+    expect(screen.getByText('Ask your team owner for access.')).toBeInTheDocument()
+  })
+
+  it('shows loading state while workspace route status is resolving', () => {
+    mockUseWorkspaceRouteStatus.mockReturnValue({ status: 'loading', workspaceId: 'ws-a' })
+
+    renderPage('/w/ws-a/admin', (children) => (
+      <CompanyAdminProvider
+        loadStatus={async () => new Promise<CompanyAdminStatus | null>(() => {})}
+        renderContent={renderEmptyAdminContent}
+      >
+        {children}
+      </CompanyAdminProvider>
+    ))
+
+    expect(screen.getByText('Loading admin…')).toBeInTheDocument()
+    expect(screen.queryByTestId('home-page')).toBeNull()
+  })
+
+  it('shows route errors after a provider enables the surface', async () => {
+    mockUseWorkspaceRouteStatus.mockReturnValue({
+      status: 'not-found',
+      workspaceId: 'missing-ws',
+      message: 'Workspace not found',
+    })
+    const status: CompanyAdminStatus = { enabled: true, role: 'admin', admin: true }
+
+    renderPage('/w/missing-ws/admin', (children) => (
+      <CompanyAdminProvider loadStatus={async () => status} renderContent={renderEmptyAdminContent} labels={{ pageTitle: 'Team Admin' }}>
+        {children}
+      </CompanyAdminProvider>
+    ))
+
+    expect(await screen.findByText('Workspace unavailable')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Team Admin' })).toBeInTheDocument()
+    expect(screen.getByText('Workspace not found')).toBeInTheDocument()
+  })
+
+  it('shows forbidden route errors as generic access denial', async () => {
+    mockUseWorkspaceRouteStatus.mockReturnValue({
+      status: 'forbidden',
+      workspaceId: 'ws-a',
+      message: 'Forbidden',
+    })
+    const status: CompanyAdminStatus = { enabled: true, role: 'admin', admin: true }
+
+    renderPage('/w/ws-a/admin', (children) => (
+      <CompanyAdminProvider
+        loadStatus={async () => status}
+        renderContent={renderEmptyAdminContent}
+        labels={{ pageTitle: 'Team Admin', deniedMessage: 'You do not have access to this admin surface.' }}
+      >
+        {children}
+      </CompanyAdminProvider>
+    ))
+
+    expect(await screen.findByText('Access required')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Team Admin' })).toBeInTheDocument()
+    expect(screen.getByText('You do not have access to this admin surface.')).toBeInTheDocument()
   })
 })

--- a/packages/core/src/front/__tests__/userNavComponents.test.tsx
+++ b/packages/core/src/front/__tests__/userNavComponents.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -64,6 +64,8 @@ vi.mock('@hachej/boring-ui-kit', async () => {
     useToast: () => ({ toast: mockToast }),
   }
 })
+
+const renderEmptyAdminContent = () => null
 
 const WORKSPACES: Workspace[] = [
   {
@@ -199,6 +201,16 @@ afterEach(() => {
 })
 
 describe('UserMenu', () => {
+  async function settleLoadStatus(loadStatus: ReturnType<typeof vi.fn>) {
+    await waitFor(() => expect(loadStatus).toHaveBeenCalledTimes(1))
+    const result = loadStatus.mock.results[0]
+    if (result?.type === 'return') {
+      await act(async () => {
+        await (result.value as Promise<unknown>).catch(() => undefined)
+      })
+    }
+  }
+
   it(
     'renders signed-in user name/email and signs out to /auth/signin',
     withBeadId(BEAD_ID, async ({ assertionPassed }) => {
@@ -210,7 +222,7 @@ describe('UserMenu', () => {
       expect(screen.getByText('menu-user@boring.dev')).toBeInTheDocument()
       expect(screen.getByRole('menuitem', { name: 'Light' })).toHaveAttribute('data-current', 'true')
       expect(screen.getByRole('menuitem', { name: 'User settings' })).toBeInTheDocument()
-      expect(screen.getByRole('menuitem', { name: 'Company admin' })).toBeInTheDocument()
+      expect(screen.queryByRole('menuitem', { name: 'Admin' })).toBeNull()
       expect(screen.queryByRole('menuitem', { name: 'Create workspace' })).toBeNull()
       expect(screen.queryByRole('menuitem', { name: 'Workspace settings' })).toBeNull()
       assertionPassed('user-menu-renders-user')
@@ -225,65 +237,111 @@ describe('UserMenu', () => {
     }),
   )
 
-  it('hides company admin for non-owner workspace members', async () => {
+  it('shows the default admin entry for provider admins even when they are not workspace owners', async () => {
     mockUseWorkspaceRole.mockReturnValue('editor')
-    renderWithProviders(<UserMenu />)
+    const status: CompanyAdminStatus = { enabled: true, role: 'admin', admin: true }
+    const loadStatus = vi.fn(async () => status)
+    renderWithProviders(
+      <CompanyAdminProvider loadStatus={loadStatus} renderContent={renderEmptyAdminContent}>
+        <UserMenu />
+      </CompanyAdminProvider>,
+    )
+    await settleLoadStatus(loadStatus)
 
     fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
 
-    expect(await screen.findByRole('menuitem', { name: 'User settings' })).toBeInTheDocument()
-    expect(screen.queryByRole('menuitem', { name: 'Company admin' })).toBeNull()
+    expect(await screen.findByRole('menuitem', { name: 'Admin' })).toBeInTheDocument()
   })
 
-  it('navigates owners to company admin', async () => {
-    renderWithProviders(<UserMenu />)
+  it('uses provider menu labels and navigates provider admins to the admin route', async () => {
+    const status: CompanyAdminStatus = { enabled: true, role: 'admin', admin: true }
+    const loadStatus = vi.fn(async () => status)
+    renderWithProviders(
+      <CompanyAdminProvider loadStatus={loadStatus} renderContent={renderEmptyAdminContent} labels={{ menuLabel: 'Company Admin' }}>
+        <UserMenu />
+      </CompanyAdminProvider>,
+    )
+    await settleLoadStatus(loadStatus)
 
     fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
-    fireEvent.click(await screen.findByRole('menuitem', { name: 'Company admin' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Company Admin' }))
 
     expect(mockNavigate).toHaveBeenCalledWith('/w/ws-a/admin')
   })
 
-  it('shows company admin for governance admins even when they are not workspace owners', async () => {
-    mockUseWorkspaceRole.mockReturnValue('editor')
-    const status: CompanyAdminStatus = { enabled: true, role: 'admin', admin: true }
+  it('hides the admin entry when the provider reports a disabled surface', async () => {
+    const status: CompanyAdminStatus = { enabled: false, role: 'admin', admin: true }
+    const loadStatus = vi.fn(async () => status)
     renderWithProviders(
-      <CompanyAdminProvider loadStatus={async () => status}>
+      <CompanyAdminProvider loadStatus={loadStatus} renderContent={renderEmptyAdminContent}>
         <UserMenu />
       </CompanyAdminProvider>,
     )
+    await settleLoadStatus(loadStatus)
 
-    await waitFor(() => expect(screen.getByRole('button', { name: 'User menu' })).toBeInTheDocument())
-    fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
-
-    expect(await screen.findByRole('menuitem', { name: 'Company admin' })).toBeInTheDocument()
-  })
-
-  it('hides company admin for governance non-admins even when they own the workspace', async () => {
-    const status: CompanyAdminStatus = { enabled: true, role: 'user', admin: false }
-    renderWithProviders(
-      <CompanyAdminProvider loadStatus={async () => status}>
-        <UserMenu />
-      </CompanyAdminProvider>,
-    )
-
-    await waitFor(() => expect(screen.getByRole('button', { name: 'User menu' })).toBeInTheDocument())
     fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
 
     expect(await screen.findByRole('menuitem', { name: 'User settings' })).toBeInTheDocument()
-    expect(screen.queryByRole('menuitem', { name: 'Company admin' })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: 'Admin' })).toBeNull()
   })
 
-  it('falls back to owner visibility when governance status is disabled or absent', async () => {
+  it('hides the admin entry when the provider reports a non-admin user', async () => {
+    const status: CompanyAdminStatus = { enabled: true, role: 'user', admin: false }
+    const loadStatus = vi.fn(async () => status)
     renderWithProviders(
-      <CompanyAdminProvider loadStatus={async () => null}>
+      <CompanyAdminProvider loadStatus={loadStatus} renderContent={renderEmptyAdminContent}>
+        <UserMenu />
+      </CompanyAdminProvider>,
+    )
+    await settleLoadStatus(loadStatus)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'User settings' })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Admin' })).toBeNull()
+  })
+
+  it('hides the admin entry when the provider resolves without a status', async () => {
+    const loadStatus = vi.fn(async () => null)
+    renderWithProviders(
+      <CompanyAdminProvider loadStatus={loadStatus} renderContent={renderEmptyAdminContent}>
+        <UserMenu />
+      </CompanyAdminProvider>,
+    )
+    await settleLoadStatus(loadStatus)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'User settings' })).toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: 'Admin' })).toBeNull()
+  })
+
+  it('shows the admin entry while provider status is pending', async () => {
+    const loadStatus = vi.fn(() => new Promise<CompanyAdminStatus | null>(() => {}))
+    renderWithProviders(
+      <CompanyAdminProvider loadStatus={loadStatus} renderContent={renderEmptyAdminContent}>
         <UserMenu />
       </CompanyAdminProvider>,
     )
 
+    await waitFor(() => expect(loadStatus).toHaveBeenCalledTimes(1))
     fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
 
-    expect(await screen.findByRole('menuitem', { name: 'Company admin' })).toBeInTheDocument()
+    expect(await screen.findByRole('menuitem', { name: 'Admin' })).toBeInTheDocument()
+  })
+
+  it('shows the admin entry when the provider status check fails', async () => {
+    const loadStatus = vi.fn(async () => { throw new Error('Status check failed') })
+    renderWithProviders(
+      <CompanyAdminProvider loadStatus={loadStatus} renderContent={renderEmptyAdminContent}>
+        <UserMenu />
+      </CompanyAdminProvider>,
+    )
+    await settleLoadStatus(loadStatus)
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'User menu' }))
+
+    expect(await screen.findByRole('menuitem', { name: 'Admin' })).toBeInTheDocument()
   })
 })
 

--- a/packages/core/src/front/components/UserMenu.tsx
+++ b/packages/core/src/front/components/UserMenu.tsx
@@ -23,7 +23,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { useSignOut, useUser } from '../auth/index.js'
 import { useCompanyAdminStatus } from '../CompanyAdminProvider.js'
-import { useCurrentWorkspace, useWorkspaceRole } from '../WorkspaceAuthProvider.js'
+import { useCurrentWorkspace } from '../WorkspaceAuthProvider.js'
 import { useTheme } from '../hooks/index.js'
 import { routeHref, routes } from '../utils.js'
 
@@ -74,18 +74,17 @@ export function UserMenu({ contentSide = 'bottom', contentAlign = 'end', variant
   const navigate = useNavigate()
   const { preference, setTheme } = useTheme()
   const workspace = useCurrentWorkspace()
-  const workspaceRole = useWorkspaceRole()
   const companyAdmin = useCompanyAdminStatus()
   const [isSigningOut, setIsSigningOut] = useState(false)
 
   const user = identity?.user
-  const governanceEnabled = companyAdmin.status?.enabled === true
+  const adminMenuLabel = companyAdmin.labels.menuLabel ?? 'Admin'
   const companyAdminStatusPending = companyAdmin.configured && companyAdmin.loading && !companyAdmin.status
-  const canOpenCompanyAdmin = companyAdminStatusPending || companyAdmin.error
-    ? false
-    : governanceEnabled
-      ? companyAdmin.status?.admin === true
-      : workspaceRole === 'owner'
+  const canOpenCompanyAdmin = companyAdmin.configured && (
+    companyAdminStatusPending
+    || Boolean(companyAdmin.error)
+    || (companyAdmin.status?.enabled === true && companyAdmin.status.admin === true)
+  )
   const companyAdminWorkspaceId = canOpenCompanyAdmin ? workspace?.id ?? null : null
 
   const userName = user?.name ?? 'Unknown user'
@@ -197,14 +196,14 @@ export function UserMenu({ contentSide = 'bottom', contentAlign = 'end', variant
 
         {companyAdminWorkspaceId ? (
           <DropdownMenuItem
-            aria-label="Company admin"
+            aria-label={adminMenuLabel}
             onSelect={() => navigate(routeHref('companyAdmin', { id: companyAdminWorkspaceId }))}
             className="gap-3 rounded-md py-2 text-[13px] focus:bg-foreground/[0.06] focus:text-foreground"
           >
             <ShieldCheck className="h-4 w-4" aria-hidden="true" />
             <span className="flex min-w-0 flex-col">
-              <span>Company admin</span>
-              <span className="text-xs text-muted-foreground">Context and model controls</span>
+              <span>{adminMenuLabel}</span>
+              <span className="text-xs text-muted-foreground">Admin controls</span>
             </span>
           </DropdownMenuItem>
         ) : null}

--- a/packages/core/src/front/index.ts
+++ b/packages/core/src/front/index.ts
@@ -5,6 +5,7 @@ export { ThemeProvider } from './ThemeProvider.js'
 export type { ThemeApi, ThemeProviderProps } from './ThemeProvider.js'
 export { CompanyAdminProvider, useCompanyAdminStatus } from './CompanyAdminProvider.js'
 export type {
+  CompanyAdminLabels,
   CompanyAdminProviderProps,
   CompanyAdminStatus,
   LoadCompanyAdminStatus,

--- a/packages/core/src/front/workspace/CompanyAdminPage.tsx
+++ b/packages/core/src/front/workspace/CompanyAdminPage.tsx
@@ -1,39 +1,66 @@
 import { Navigate } from 'react-router-dom'
-import { Button, Tabs, TabsContent, TabsList, TabsTrigger } from '@hachej/boring-ui-kit'
+import { Button } from '@hachej/boring-ui-kit'
 import { useCompanyAdminStatus } from '../CompanyAdminProvider.js'
-import { useCurrentWorkspace, useWorkspaceRole, useWorkspaceRouteStatus } from '../WorkspaceAuthProvider.js'
+import { useCurrentWorkspace, useWorkspaceRouteStatus } from '../WorkspaceAuthProvider.js'
 import { routeHref } from '../utils.js'
 
-type AdminTab = 'context' | 'models'
-
-const TABS: Array<{ id: AdminTab; label: string; description: string }> = [
-  {
-    id: 'context',
-    label: 'Context access',
-    description: 'Control which company context paths each user can read with simple regex allow rules.',
-  },
-  {
-    id: 'models',
-    label: 'Model control',
-    description: 'Control which models each user can select and the budget allowed per model.',
-  },
-]
+const DEFAULT_PAGE_TITLE = 'Admin'
+const DEFAULT_DENIED_MESSAGE = 'You do not have access to this page.'
 
 export function CompanyAdminPage() {
   const currentWorkspace = useCurrentWorkspace()
-  const role = useWorkspaceRole()
   const routeStatus = useWorkspaceRouteStatus()
   const companyAdmin = useCompanyAdminStatus()
+  const pageTitle = companyAdmin.labels.pageTitle ?? DEFAULT_PAGE_TITLE
+  const deniedMessage = companyAdmin.labels.deniedMessage ?? DEFAULT_DENIED_MESSAGE
+
+  if (!companyAdmin.configured) return <Navigate to="/" replace />
 
   if (routeStatus.status === 'loading') {
     return (
       <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
         <section className="rounded-xl border border-border bg-card p-6 shadow-sm" aria-busy="true">
-          <p className="text-sm text-muted-foreground">Loading company admin…</p>
+          <p className="text-sm text-muted-foreground">Loading admin…</p>
         </section>
       </main>
     )
   }
+
+  if (companyAdmin.configured && companyAdmin.loading && !companyAdmin.status) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
+        <section className="rounded-xl border border-border bg-card p-6 shadow-sm" aria-busy="true">
+          <p className="text-sm text-muted-foreground">Loading admin status…</p>
+        </section>
+      </main>
+    )
+  }
+
+  if (companyAdmin.error) {
+    const workspace = routeStatus.status === 'matched' ? routeStatus.workspace : currentWorkspace
+    const workspaceId = routeStatus.workspaceId ?? workspace?.id ?? null
+
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
+        <section className="rounded-xl border border-border bg-card p-6 shadow-sm">
+          <p className="text-sm font-medium text-destructive">Admin unavailable</p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">{pageTitle}</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{companyAdmin.error}</p>
+          {workspaceId ? (
+            <Button asChild className="mt-5">
+              <a href={routeHref('workspaceSettings', { id: workspaceId })}>Back to workspace settings</a>
+            </Button>
+          ) : (
+            <Button asChild className="mt-5">
+              <a href="/">Back to workspace</a>
+            </Button>
+          )}
+        </section>
+      </main>
+    )
+  }
+
+  if (!companyAdmin.status || companyAdmin.status.enabled !== true) return <Navigate to="/" replace />
 
   if (routeStatus.status === 'not-found' || routeStatus.status === 'switch-failed' || routeStatus.status === 'mismatched') {
     const message = routeStatus.status === 'mismatched'
@@ -43,7 +70,7 @@ export function CompanyAdminPage() {
       <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
         <section className="rounded-xl border border-border bg-card p-6 shadow-sm">
           <p className="text-sm font-medium text-destructive">Workspace unavailable</p>
-          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">Company admin</h1>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">{pageTitle}</h1>
           <p className="mt-2 text-sm text-muted-foreground">{message}</p>
           <Button asChild className="mt-5">
             <a href="/">Back to workspace</a>
@@ -55,29 +82,16 @@ export function CompanyAdminPage() {
 
   const workspace = routeStatus.status === 'matched' ? routeStatus.workspace : currentWorkspace
   const workspaceId = routeStatus.workspaceId ?? workspace?.id ?? null
-  const workspaceName = workspace?.name ?? 'Current workspace'
 
   if (!workspaceId) return <Navigate to="/" replace />
 
-  const governanceEnabled = companyAdmin.status?.enabled === true
-
-  if (companyAdmin.configured && companyAdmin.loading && !companyAdmin.status) {
-    return (
-      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
-        <section className="rounded-xl border border-border bg-card p-6 shadow-sm" aria-busy="true">
-          <p className="text-sm text-muted-foreground">Loading company admin policy…</p>
-        </section>
-      </main>
-    )
-  }
-
-  if (companyAdmin.error) {
+  if (routeStatus.status === 'forbidden' || companyAdmin.status.admin !== true) {
     return (
       <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
         <section className="rounded-xl border border-border bg-card p-6 shadow-sm">
-          <p className="text-sm font-medium text-destructive">Company admin unavailable</p>
-          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">Company admin</h1>
-          <p className="mt-2 text-sm text-muted-foreground">{companyAdmin.error}</p>
+          <p className="text-sm font-medium text-destructive">Access required</p>
+          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">{pageTitle}</h1>
+          <p className="mt-2 text-sm text-muted-foreground">{deniedMessage}</p>
           <Button asChild className="mt-5">
             <a href={routeHref('workspaceSettings', { id: workspaceId })}>Back to workspace settings</a>
           </Button>
@@ -86,73 +100,9 @@ export function CompanyAdminPage() {
     )
   }
 
-  if (routeStatus.status === 'forbidden' || (governanceEnabled ? companyAdmin.status?.admin !== true : role !== 'owner')) {
-    return (
-      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center px-6 py-12">
-        <section className="rounded-xl border border-border bg-card p-6 shadow-sm">
-          <p className="text-sm font-medium text-destructive">{governanceEnabled ? 'Company admin access required' : 'Owner access required'}</p>
-          <h1 className="mt-2 text-2xl font-semibold tracking-tight text-foreground">Company admin</h1>
-          <p className="mt-2 text-sm text-muted-foreground">
-            {governanceEnabled
-              ? 'You do not have access to this company admin surface.'
-              : 'Only workspace owners can manage company context and model access controls.'}
-          </p>
-          <Button asChild className="mt-5">
-            <a href={routeHref('workspaceSettings', { id: workspaceId })}>Back to workspace settings</a>
-          </Button>
-        </section>
-      </main>
-    )
-  }
-
-  const renderedAppContent = governanceEnabled && companyAdmin.status && companyAdmin.renderContent
+  const renderedAppContent = companyAdmin.renderContent
     ? companyAdmin.renderContent(companyAdmin.status)
     : null
 
-  if (renderedAppContent) return <>{renderedAppContent}</>
-
-  return (
-    <main className="min-h-screen bg-background px-4 py-8 text-foreground sm:px-6 lg:px-8">
-      <div className="mx-auto flex max-w-6xl flex-col gap-6">
-        <header className="rounded-2xl border border-border bg-card p-6 shadow-sm">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">Company admin</p>
-          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-            <div>
-              <h1 className="text-3xl font-semibold tracking-tight">{workspaceName}</h1>
-              <p className="mt-2 max-w-2xl text-sm text-muted-foreground">
-                Manage user access to company context and model budgets for this workspace.
-              </p>
-            </div>
-            <Button asChild variant="outline">
-              <a href={routeHref('workspaceSettings', { id: workspaceId })}>Workspace settings</a>
-            </Button>
-          </div>
-        </header>
-
-        <section className="rounded-2xl border border-border bg-card p-4 shadow-sm sm:p-6">
-          <Tabs defaultValue="context" className="gap-4">
-            <TabsList aria-label="Company admin tabs" variant="line" className="flex-wrap justify-start">
-              {TABS.map((tab) => (
-                <TabsTrigger key={tab.id} value={tab.id}>
-                  {tab.label}
-                </TabsTrigger>
-              ))}
-            </TabsList>
-
-            {TABS.map((tab) => (
-              <TabsContent key={tab.id} value={tab.id}>
-                <div className="rounded-xl border border-dashed border-border bg-muted/20 p-6">
-                  <h2 className="text-xl font-semibold tracking-tight">{tab.label}</h2>
-                  <p className="mt-2 max-w-2xl text-sm text-muted-foreground">{tab.description}</p>
-                  <p className="mt-5 text-sm text-muted-foreground">
-                    Configuration controls will land in the next stacked PR. This shell establishes the owner-only admin surface and navigation entry point.
-                  </p>
-                </div>
-              </TabsContent>
-            ))}
-          </Tabs>
-        </section>
-      </div>
-    </main>
-  )
+  return renderedAppContent ? <>{renderedAppContent}</> : null
 }

--- a/packages/core/src/server/routes/workspaces.ts
+++ b/packages/core/src/server/routes/workspaces.ts
@@ -192,7 +192,7 @@ const workspaceRoutesPlugin: FastifyPluginAsync = async (app) => {
         throw new HttpError({
           status: 403,
           code: ERROR_CODES.FORBIDDEN,
-          message: 'Company Context workspace is managed by governance and cannot be deleted',
+          message: 'Managed workspace cannot be deleted',
           requestId: request.id,
         })
       }

--- a/plugins/boring-governance/src/front/index.tsx
+++ b/plugins/boring-governance/src/front/index.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type {
+  CompanyAdminLabels,
   CompanyAdminStatus,
   LoadCompanyAdminStatus,
   RenderCompanyAdminContent,
@@ -9,12 +10,6 @@ import { GovernanceAdminView, type GovernanceMeResponse } from './GovernanceAdmi
 
 export interface CreateGovernanceCompanyAdminOptions {
   fetchImpl?: typeof fetch
-}
-
-interface CompanyAdminLabels {
-  menuLabel?: string
-  pageTitle?: string
-  deniedMessage?: string
 }
 
 export interface GovernanceCompanyAdminProvider {

--- a/plugins/boring-governance/src/front/index.tsx
+++ b/plugins/boring-governance/src/front/index.tsx
@@ -11,9 +11,16 @@ export interface CreateGovernanceCompanyAdminOptions {
   fetchImpl?: typeof fetch
 }
 
+interface CompanyAdminLabels {
+  menuLabel?: string
+  pageTitle?: string
+  deniedMessage?: string
+}
+
 export interface GovernanceCompanyAdminProvider {
   loadStatus: LoadCompanyAdminStatus
   renderContent: RenderCompanyAdminContent
+  labels: CompanyAdminLabels
 }
 
 export function createGovernanceCompanyAdmin({ fetchImpl = fetch }: CreateGovernanceCompanyAdminOptions = {}): GovernanceCompanyAdminProvider {
@@ -37,7 +44,13 @@ export function createGovernanceCompanyAdmin({ fetchImpl = fetch }: CreateGovern
     <GovernanceAdminView status={status.details as GovernanceMeResponse} />
   )
 
-  return { loadStatus, renderContent }
+  const labels: CompanyAdminLabels = {
+    menuLabel: 'Company Admin',
+    pageTitle: 'Company Admin',
+    deniedMessage: 'You do not have access to Company Admin.',
+  }
+
+  return { loadStatus, renderContent, labels }
 }
 
 type GovernanceFrontPlugin = ((api: unknown) => void) & { pluginId: string; pluginLabel?: string }


### PR DESCRIPTION
## Intent
- Keep `packages/core` generic: no governance vocabulary or fallback admin content.
- Treat Company Admin as a provider-backed socket; no configured provider, null/disabled status, or missing renderer leaves no visible surface.
- Let the governance plugin supply Company Admin labels/copy via the provider seam.

## Notes
- `scripts/check-invariants.sh packages/core` still fails only on pre-existing console/process.env/raw error-code violations outside this diff; no invariant-only patterns were added by this patch.
- `grep -ri governance packages/core/src` intentionally has no output (grep exits 1 when there are no matches).

## Quality gates
### `pnpm --filter @hachej/boring-core run typecheck`
```

> @hachej/boring-core@0.1.63 typecheck /home/ubuntu/projects/boring-ui-v2-475-fixes/packages/core
> tsc --noEmit

__EXIT_CODE__=0
```

### `TMPDIR=/tmp/claude-1000 pnpm --filter @hachej/boring-core exec vitest run src/front/__tests__/CompanyAdminPage.test.tsx src/front/__tests__/userNavComponents.test.tsx --no-file-parallelism`
```

 RUN  v3.2.6 /home/ubuntu/projects/boring-ui-v2-475-fixes/packages/core

 ✓ src/front/__tests__/userNavComponents.test.tsx (14 tests) 3174ms
   ✓ UserMenu > renders signed-in user name/email and signs out to /auth/signin  714ms
   ✓ WorkspaceSwitcher > creates workspace, invalidates query, closes modal, and navigates to new workspace  430ms
   ✓ WorkspaceSwitcher > validates name, disables empty submit, and toasts on 400 create error  467ms
 ✓ src/front/__tests__/CompanyAdminPage.test.tsx (9 tests) 454ms

 Test Files  2 passed (2)
      Tests  23 passed (23)
   Start at  07:31:43
   Duration  10.05s (transform 946ms, setup 370ms, collect 2.38s, tests 3.63s, environment 2.56s, prepare 294ms)

__EXIT_CODE__=0
```

### `pnpm --filter @hachej/boring-governance run typecheck`
```

> @hachej/boring-governance@0.0.0 typecheck /home/ubuntu/projects/boring-ui-v2-475-fixes/plugins/boring-governance
> tsc --noEmit

__EXIT_CODE__=0
```

### `pnpm --filter full-app run typecheck`
```

> full-app@0.0.1 typecheck /home/ubuntu/projects/boring-ui-v2-475-fixes/apps/full-app
> tsc --noEmit

__EXIT_CODE__=0
```

### `bash scripts/check-invariants.sh packages/core`
```
[invariants] ERR src/server/mail/transport.ts:199:    console.info('[mail:console]', JSON.stringify(logEntry))
[invariants] ERR src/server/mail/transport.ts:221:    console.info('[mail:console-capture]', JSON.stringify(logEntry))
[invariants] ERR src/server/app/__tests__/fixtures/shutdownHarness.ts:36:    console.log('db-closed')
[invariants] ERR src/server/app/__tests__/fixtures/shutdownHarness.ts:42:    console.log('inflight-started')
[invariants] ERR src/server/app/__tests__/fixtures/shutdownHarness.ts:49:console.log(`ready:${address}`)
[invariants] ERR src/server/telemetry/posthog.ts:41:    console.warn('PostHog telemetry is enabled but POSTHOG_KEY is missing; using noop telemetry.')
[invariants] ERR src/server/telemetry/posthog.ts:78:  console.warn('BORING_TELEMETRY_PROJECT must be a lowercase slug; telemetry project prefix disabled.')
[invariants] ERR src/server/__tests__/_setup.ts:76:  console.error(`[core-test-log] ${key}`)
[invariants] ERR src/server/__tests__/_setup.ts:78:    console.error(line)
[invariants] ERR src/server/db/stores/PostgresWorkspaceStore.ts:772:      console.error(`[workspace-store] decryptSetting failed for key="${key}" workspace="${workspaceId}": ${code}`)
[invariants] ERR src/server/config/loadConfig.ts:136:    console.warn(
  Invariant: No console.* calls in src/server/**
  Fix: Use the standard logger abstraction (createLogger from src/server/logging.ts).
[invariants] ERR src/server/routes/invites.ts:16:  const env = process.env.NODE_ENV === 'production'
[invariants] ERR src/server/routes/invites.ts:18:    : process.env.NODE_ENV === 'test'
[invariants] ERR src/server/auth/schema-config.ts:10:  process.env.DATABASE_URL ?? 'postgres://ubuntu:test@localhost/boring_ui_test'
[invariants] ERR src/server/auth/schema-config.ts:12:  process.env.BETTER_AUTH_SCHEMA_GEN === '1' ||
[invariants] ERR src/server/auth/schema-config.ts:13:  process.env.VITEST === 'true' ||
[invariants] ERR src/server/auth/schema-config.ts:14:  process.env.NODE_ENV === 'test'
[invariants] ERR src/server/auth/schema-config.ts:58:  baseURL: process.env.BETTER_AUTH_URL ?? 'http://localhost:3000',
[invariants] ERR src/server/auth/createAuth.ts:52:  const env = process.env.NODE_ENV === 'production'
[invariants] ERR src/server/auth/createAuth.ts:54:    : process.env.NODE_ENV === 'test'
[invariants] ERR src/server/db/stores/PostgresWorkspaceStore.ts:145:    private readonly workspaceSettingsKey: string = process.env.WORKSPACE_SETTINGS_ENCRYPTION_KEY ?? '',
  Invariant: No process.env reads outside src/server/config/**
  Fix: Centralize env reads in src/server/config/**.
[invariants] ERR src/front/utils.ts:110:    return { code: 'internal_error', message: err.message }
[invariants] ERR src/front/utils.ts:112:  return { code: 'internal_error', message: String(err) }
[invariants] ERR src/server/security/__tests__/rateLimit.test.ts:106:    code: 'rate_limited',
[invariants] ERR src/server/routes/__tests__/members.test.ts:61:      if (!wsMembers?.has(userId)) return { code: 'not_member' as const }
[invariants] ERR src/server/routes/__tests__/members.test.ts:65:        if (ownerCount <= 1) return { code: 'last_owner' as const }
[invariants] ERR src/server/routes/__tests__/members.test.ts:79:      if (!wsMembers?.has(userId)) return { removed: false, code: 'not_member' as const }
[invariants] ERR src/server/routes/__tests__/members.test.ts:83:        if (ownerCount <= 1) return { removed: false, code: 'last_owner' as const }
[invariants] ERR src/server/routes/__tests__/workspaceAuthAudit.test.ts:129:      if (!m?.has(userId)) return { removed: false, code: 'not_member' as const }
[invariants] ERR src/server/routes/__tests__/workspaceAuthAudit.test.ts:278:          code: 'unauthorized',
[invariants] ERR src/server/auth/createAuth.ts:236:              code: 'WEAK_PASSWORD',
[invariants] ERR src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts:76:        if (!registered) return { ok: false, error: { code: 'BRIDGE_OP_NOT_FOUND' } }
[invariants] ERR src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts:124:        error: { code: 'BRIDGE_IDEMPOTENCY_REQUIRED', message: 'WorkspaceBridge operation requires an idempotency key' },
[invariants] ERR src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts:420:      details: { ok: false, error: { code: 'BRIDGE_IDEMPOTENCY_REQUIRED' } },
[invariants] ERR src/front/__tests__/InvitesPage.test.tsx:373:                code: 'validation_failed',
[invariants] ERR src/front/__tests__/InviteAcceptPage.test.tsx:147:            JSON.stringify({ code: 'invite_not_found', message: 'Invite not found' }),
[invariants] ERR src/front/__tests__/InviteAcceptPage.test.tsx:177:            JSON.stringify({ code: 'invite_expired', message: 'Invite expired' }),
[invariants] ERR src/front/__tests__/InviteAcceptPage.test.tsx:207:            JSON.stringify({ code: 'invite_locked', message: 'Invite token is locked' }),
[invariants] ERR src/front/__tests__/InviteAcceptPage.test.tsx:299:              code: 'invite_email_mismatch',
[invariants] ERR src/server/app/errorHandler.ts:8:      code: 'not_found',
[invariants] ERR src/server/app/errorHandler.ts:30:        code: 'validation_failed',
[invariants] ERR src/server/app/errorHandler.ts:41:        code: 'rate_limited',
[invariants] ERR src/server/app/errorHandler.ts:64:      code: 'internal_error',
[invariants] ERR src/front/__tests__/userNavComponents.test.tsx:443:            code: 'validation_failed',
[invariants] ERR src/front/__tests__/UserSettingsPage.test.tsx:397:              code: 'last_owner',
[invariants] ERR src/server/db/stores/__tests__/PostgresMeteringStore.test.ts:333:    expect(error).toMatchObject({ statusCode: 402, code: 'PAYMENT_REQUIRED', availableMicros: 100, requiredMicros: 1_000 })
[invariants] ERR src/front/__tests__/AuthProvider.test.tsx:124:      code: 'unauthorized',
[invariants] ERR src/front/__tests__/WorkspaceSettingsPage.test.tsx:75:        return new Response(JSON.stringify({ code: 'not_found', message: 'Not found' }), {
[invariants] ERR src/front/__tests__/WorkspaceSettingsPage.test.tsx:463:            JSON.stringify({ code: 'destroy_failed', message: 'Volume still attached' }),
[invariants] ERR src/front/__tests__/utils.test.ts:92:          code: 'unauthorized',
[invariants] ERR src/front/__tests__/utils.test.ts:158:        JSON.stringify({ code: 'forbidden', message: 'Access denied' }),
[invariants] ERR src/front/__tests__/utils.test.ts:172:      code: 'not_found',
[invariants] ERR src/front/__tests__/utils.test.ts:177:      code: 'not_found',
[invariants] ERR src/front/__tests__/utils.test.ts:186:      code: 'internal_error',
[invariants] ERR src/front/__tests__/utils.test.ts:193:      code: 'internal_error',
[invariants] ERR src/front/__tests__/MembersPage.test.tsx:205:            JSON.stringify({ code: 'last_owner', message: 'Cannot demote the last owner' }),
[invariants] ERR src/front/__tests__/MembersPage.test.tsx:346:            JSON.stringify({ code: 'last_owner', message: 'Cannot remove the last owner' }),
[invariants] ERR src/front/auth/AuthProvider.tsx:90:      ? { status: session.error.status ?? 0, code: 'unauthorized' as const, message: session.error.message ?? 'Session error' }
[invariants] ERR src/front/__tests__/useCapabilities.hook.test.tsx:138:            code: 'db_unavailable',
[invariants] ERR src/server/credits/meteringSink.ts:15:  return Object.assign(new Error('authentication required'), { statusCode: 401, code: 'UNAUTHORIZED' })
[invariants] ERR src/server/credits/__tests__/creditsService.test.ts:134:    expect(err).toMatchObject({ statusCode: 402, code: 'PAYMENT_REQUIRED', details: { balance: expect.objectContaining({ currency: 'credits' }) } })
[invariants] ERR src/server/credits/__tests__/meteringSink.test.ts:48:    await expect(sink.reserveRun({ ...BASE, kind: 'prompt', message: 'hi' })).rejects.toMatchObject({ statusCode: 401, code: 'UNAUTHORIZED' })
[invariants] ERR src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx:104:        error: { code: 'FULL_PAGE_PANEL_MISSING_COMPONENT', message: 'Missing full-page panel component id.' },
[invariants] ERR src/server/app/__tests__/errorHandler.test.ts:44:        code: 'forbidden',
[invariants] ERR src/server/app/__tests__/errorHandler.test.ts:111:        code: 'not_found',
  Invariant: Use stable error-code enum imports (no raw string codes)
  Fix: Import canonical constants from shared error-codes.
[invariants] FAIL one or more invariants were violated
__EXIT_CODE__=1
```

### `grep -ri governance packages/core/src`
```
__EXIT_CODE__=1
```

### Autoreview
`/home/ubuntu/.agents/skills/coding-autoreview/scripts/autoreview --mode local --prompt-file /tmp/claude-1000/review-context-475.md`

```
autoreview clean: no accepted/actionable findings reported
overall: patch is correct (0.88)
```
