### PR TITLE
fix(full-app): repair Fly session volume ownership

### DIFF
--- a/apps/full-app/Dockerfile
+++ b/apps/full-app/Dockerfile
@@ -55,7 +55,7 @@ LABEL org.opencontainers.image.source=$SOURCE \
   org.opencontainers.image.title="boring-ui full-app" \
   boring.role="web"
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends bubblewrap ca-certificates \
+  && apt-get install -y --no-install-recommends bubblewrap ca-certificates util-linux \
   && rm -rf /var/lib/apt/lists/* \
   && corepack enable \
   && groupadd --system --gid 10001 boring \
@@ -94,6 +94,8 @@ COPY --from=build /app/apps/full-app/dist/ apps/full-app/dist/
 COPY --from=build /app/apps/full-app/boring.app.toml apps/full-app/boring.app.toml
 COPY --from=build /app/apps/full-app/package.json apps/full-app/package.json
 COPY --from=build /app/apps/full-app/node_modules/ apps/full-app/node_modules/
+COPY apps/full-app/docker/web-entrypoint.sh /usr/local/bin/web-entrypoint
+RUN chmod 0755 /usr/local/bin/web-entrypoint
 
 # BORING_AGENT_MODE=vercel-sandbox: even on Fly.io the server itself runs here
 # but agent tool execution (bash/files) runs in remote Vercel sandbox containers.
@@ -108,7 +110,7 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "fetch('http://localhost:3000/health').then(r=>{if(!r.ok)throw r.status}).catch(()=>process.exit(1))"
 
-USER boring
+ENTRYPOINT ["/usr/local/bin/web-entrypoint"]
 CMD ["node", "apps/full-app/dist/server/main.js"]
 
 FROM node:22-slim AS worker-runtime

--- a/apps/full-app/README.md
+++ b/apps/full-app/README.md
@@ -95,7 +95,8 @@ http://100.68.199.114:6301/dev-login
 - **Fly.io**: `fly.toml` (app `boring-full-app`, region `cdg`, `/health` checks, `release_command` runs `migrate.js`, mounted `workspace_data` volume at `/data`). Secrets via `fly secrets set`.
 - **Docker**: `Dockerfile` builds the app; run with `-p 3000:3000 --env-file apps/full-app/.env`.
 
-In the production Docker image, `BORING_AGENT_MODE=vercel-sandbox` splits storage:
+In the production Docker image, `BORING_AGENT_MODE=vercel-sandbox` splits storage. The image starts through `apps/full-app/docker/web-entrypoint.sh`, which repairs ownership of the mounted `/data/workspaces` and `/data/pi-sessions` roots before dropping to the unprivileged app user.
+
 
 ```txt
 Fly volume:
@@ -108,7 +109,8 @@ Vercel sandbox:
 
 Do not debug missing sandbox files by looking under `/data/workspaces/<id>`; inspect
 the Vercel sandbox `/workspace` instead. Do inspect `/data/pi-sessions/<id>` when
-checking whether chat history survives Fly deploy/restart.
+checking whether chat history survives Fly deploy/restart. If session creation fails
+with `EACCES mkdir /data/pi-sessions/...`, see `docs/FIXES.md`.
 
 After deploy, run `pnpm --filter full-app smoke:post-deploy` (with `DEPLOY_URL` set) to verify the live instance.
 

--- a/apps/full-app/docker/web-entrypoint.sh
+++ b/apps/full-app/docker/web-entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -eu
+
+app_uid="10001"
+app_gid="10001"
+workspace_root="${BORING_AGENT_WORKSPACE_ROOT:-/data/workspaces}"
+session_root="${BORING_AGENT_SESSION_ROOT:-/data/pi-sessions}"
+
+# Fly mounts the volume over /data at runtime, so Dockerfile-time chown does
+# not apply to the mounted filesystem. Repair the writable agent roots before
+# dropping privileges; otherwise Pi session creation fails with EACCES.
+mkdir -p "$workspace_root" "$session_root"
+chown -R "$app_uid:$app_gid" "$workspace_root" "$session_root"
+
+exec setpriv --no-new-privs --reuid="$app_uid" --regid="$app_gid" --clear-groups "$@"

--- a/apps/full-app/src/server/__tests__/production-safety.test.ts
+++ b/apps/full-app/src/server/__tests__/production-safety.test.ts
@@ -35,12 +35,13 @@ describe('production full-app safety guards', () => {
     ).not.toThrow()
   })
 
-  it('keeps the full-app web image as the default non-root Docker target', () => {
+  it('keeps the full-app web image as the default privilege-dropping Docker target', () => {
     const dockerfile = readFileSync(dockerfilePath, 'utf8')
 
     expect(dockerfile).toMatch(/FROM node:22-slim AS runtime/)
     expect(dockerfile).toMatch(/boring\.role="web"/)
-    expect(dockerfile).toMatch(/USER boring\nCMD \["node", "apps\/full-app\/dist\/server\/main\.js"\]/)
+    expect(dockerfile).toMatch(/COPY apps\/full-app\/docker\/web-entrypoint\.sh \/usr\/local\/bin\/web-entrypoint/)
+    expect(dockerfile).toMatch(/ENTRYPOINT \["\/usr\/local\/bin\/web-entrypoint"\]\nCMD \["node", "apps\/full-app\/dist\/server\/main\.js"\]/)
     expect(dockerfile.trimEnd()).toMatch(/FROM runtime AS web-runtime$/)
   })
 

--- a/docs/FIXES.md
+++ b/docs/FIXES.md
@@ -1,0 +1,47 @@
+# Fix ledger
+
+Append production/runtime fixes here so recurring incidents have one searchable home. Keep each entry short: symptom, cause, fix, files, and verification.
+
+## 2026-07-06 — Fly full-app `EACCES` creating `/data/pi-sessions/*`
+
+**Symptom**
+
+```txt
+EACCES: permission denied, mkdir '/data/pi-sessions/<workspace>_<user>'
+```
+
+Seen on `app.enecaapi.ai` when opening/creating an agent chat session.
+
+**Cause**
+
+This path is the host-side Pi session transcript store, not the Vercel sandbox workspace. In `BORING_AGENT_MODE=vercel-sandbox`, shell/files run in the Vercel sandbox, but chat transcripts remain host app user data under `BORING_AGENT_SESSION_ROOT` (normally `/data/pi-sessions`).
+
+On Fly, the volume mounted at `/data` hides Dockerfile build-time ownership. The app process runs as uid/gid `10001`, so a root-owned mounted `/data/pi-sessions` causes `mkdir` to fail with `EACCES`.
+
+**Fix**
+
+Add a web entrypoint that starts as root, creates/chowns the writable host roots, then drops privileges before starting Node:
+
+- `apps/full-app/docker/web-entrypoint.sh`
+- `apps/full-app/Dockerfile`
+
+The entrypoint repairs:
+
+```txt
+BORING_AGENT_WORKSPACE_ROOT=/data/workspaces
+BORING_AGENT_SESSION_ROOT=/data/pi-sessions
+```
+
+and then runs the app as uid/gid `10001`.
+
+**Verification**
+
+```bash
+sh -n apps/full-app/docker/web-entrypoint.sh
+```
+
+After deploy, create/open an agent chat session and confirm no `EACCES mkdir /data/pi-sessions/...` appears in logs.
+
+**Do not confuse with**
+
+Missing files under `/data/workspaces/<workspaceId>` in `vercel-sandbox` mode. That host path is only the control-plane anchor; actual agent cwd/files are inside the Vercel sandbox at `/workspace`.

--- a/docs/FIXES.md
+++ b/docs/FIXES.md
@@ -16,7 +16,14 @@ Seen on `app.enecaapi.ai` when opening/creating an agent chat session.
 
 This path is the host-side Pi session transcript store, not the Vercel sandbox workspace. In `BORING_AGENT_MODE=vercel-sandbox`, shell/files run in the Vercel sandbox, but chat transcripts remain host app user data under `BORING_AGENT_SESSION_ROOT` (normally `/data/pi-sessions`).
 
-On Fly, the volume mounted at `/data` hides Dockerfile build-time ownership. The app process runs as uid/gid `10001`, so a root-owned mounted `/data/pi-sessions` causes `mkdir` to fail with `EACCES`.
+The regression was caused by a deployment-hardening/storage interaction:
+
+1. Older images either stored sessions under the container user's home or ran the web process as root, so session directory creation did not hit a mounted-volume ownership boundary.
+2. Durable-session work moved Pi transcripts to the Fly volume (`BORING_AGENT_SESSION_ROOT=/data/pi-sessions`) so chat history survives restarts/redeploys.
+3. The self-host/Fly image hardening then changed the web image to run as the unprivileged `boring` user (uid/gid `10001`) and attempted `chown -R boring:boring /data` at Docker build time.
+4. On Fly, the runtime volume is mounted over `/data`, hiding the build-time `/data` directory and its ownership. The actual mounted volume can still be root-owned, so the unprivileged app cannot create `/data/pi-sessions/<namespace>`.
+
+Per-user session namespaces such as `<workspace>_user_<hash>` made the failure visible at first chat/session creation, but they were not the underlying permission cause.
 
 **Fix**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ standalone (`createAgentApp`) with zero core dependency.
 - [`WORKSPACE_CONTRACT.md`](WORKSPACE_CONTRACT.md) — the agent ↔ workspace integration contract: HTTP routes, component exports, UiBridge/UiCommand semantics, import boundaries.
 - [`TAILWIND-V4-STYLE-ISOLATION.md`](TAILWIND-V4-STYLE-ISOLATION.md) — how packages share Tailwind v4 tokens: workspace owns `--boring-*` `:root` tokens; agent inherits them scoped to `[data-boring-agent]` (test-enforced).
 - [`PERFORMANCE.md`](PERFORMANCE.md) — historical Vercel-sandbox vs local FS latency benchmarks (harness removed; kept for reference).
+- [`FIXES.md`](FIXES.md) — production/runtime fix ledger for recurring incidents and deploy bugs.
 - [`kanzen/`](kanzen/) — agent workflow, maintainer loop, coding practices,
   review history, procedures, proof gates, owner decisions, and budgeted
   autonomy.

--- a/docs/web/reference/troubleshooting.md
+++ b/docs/web/reference/troubleshooting.md
@@ -12,6 +12,7 @@ Use it as a fast triage map, then jump into the canonical package docs.
 - Vercel sandbox mode works locally but not in the deployed full app
 
 **Look here first**
+- `docs/FIXES.md` for recent production/runtime fix entries
 - `apps/full-app/README.md`
 - `packages/core/docs/DEPLOYMENT_WORKFLOW.md`
 
@@ -19,6 +20,7 @@ Use it as a fast triage map, then jump into the canonical package docs.
 - Today, `apps/full-app/fly.toml` runs `migrate.js` as the release command.
 - `release.js` and deployment snapshots are target-shape docs unless a specific app has wired them.
 - Fly uses `BORING_AGENT_MODE=vercel-sandbox` and `BORING_AGENT_WORKSPACE_ROOT=/data/workspaces`; Vercel sandbox credentials still need to be configured as secrets.
+- Pi chat transcripts still live on the Fly host volume at `BORING_AGENT_SESSION_ROOT` (normally `/data/pi-sessions`), even in `vercel-sandbox` mode. If you see `EACCES mkdir /data/pi-sessions/...`, check the fix ledger entry for mounted-volume ownership repair.
 - Post-deploy validation runs through `pnpm --filter full-app smoke:post-deploy` with `DEPLOY_URL` and `SMOKE_*` vars.
 
 ## 1. Workspace never finishes booting


### PR DESCRIPTION
## Summary
- add a full-app web entrypoint that creates/chowns Fly-mounted workspace and Pi session roots before dropping privileges
- keep Vercel sandbox execution unchanged while ensuring host-side Pi transcripts can be created under /data/pi-sessions
- add docs/FIXES.md as a central runtime fix ledger and link this incident from troubleshooting/full-app docs

## Verification
- `sh -n apps/full-app/docker/web-entrypoint.sh` ✅
- `git diff --check -- apps/full-app/Dockerfile apps/full-app/docker/web-entrypoint.sh apps/full-app/README.md docs/FIXES.md docs/README.md docs/web/reference/troubleshooting.md` ✅

## Notes
- Did not run a full Docker/Fly deploy locally.
- Existing unrelated local changes were not included: `.claude/scheduled_tasks.lock`, `.beads/`.