### PR TITLE
feat(391-T1): pr3 — durable stream routes + offset replay (BBT1-003)

### DIFF
--- a/packages/agent/src/server/__tests__/stream.test.ts
+++ b/packages/agent/src/server/__tests__/stream.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent'
+import type { AgentHarnessFactoryInput } from '../../shared/harness'
+import type { Agent } from '../../shared/events'
+import { sessionStreamPath, type AgentEvent } from '../../shared/events'
+import type { PiChatEvent } from '../../shared/chat'
+import { ErrorCode } from '../../shared/error-codes'
+import type { SessionCtx, SessionDetail, SessionStore, SessionSummary } from '../../shared/session'
+import { createAgentRuntimeBridge } from '../createAgent'
+import { formatOffset, SqliteEventStreamStore, type EventStreamStore } from '../events/eventStreamStore'
+import { openDatabase } from '../events/sqlStorage'
+import type { PiAgentPromptInput, PiAgentSessionAdapter, PiAgentSessionSnapshot } from '../pi-chat/PiAgentSessionAdapter'
+
+const CTX: SessionCtx = { workspaceId: 'workspace-test', userId: 'user-test' }
+
+describe('agent.stream durable replay', () => {
+  it('replays the full log and tails from a startIndex', async () => {
+    const harness = createDurableAgent(['s1'])
+    await seedEvents(harness.store, 's1', 3)
+
+    await expect(takeEvents(harness.agent.stream('s1', { startIndex: 0, ctx: CTX }), 3))
+      .resolves.toMatchObject([
+        { eventIndex: 0, chunk: { seq: 0 } },
+        { eventIndex: 1, chunk: { seq: 1 } },
+        { eventIndex: 2, chunk: { seq: 2 } },
+      ])
+
+    await expect(takeEvents(harness.agent.stream('s1', { startIndex: 1, ctx: CTX }), 2))
+      .resolves.toMatchObject([
+        { eventIndex: 1, chunk: { seq: 1 } },
+        { eventIndex: 2, chunk: { seq: 2 } },
+      ])
+
+    harness.close()
+  })
+
+  it('yields nothing for unknown sessions', async () => {
+    const harness = createDurableAgent(['empty'])
+
+    await expect(nextEvent(harness.agent.stream('missing', { startIndex: 0, ctx: CTX }))).resolves.toEqual({
+      value: undefined,
+      done: true,
+    })
+
+    harness.close()
+  })
+
+  it('rejects durable stream startIndex values ahead of the session tail', async () => {
+    const harness = createDurableAgent(['ahead'])
+    await seedEvents(harness.store, 'ahead', 2)
+
+    await expect(nextEvent(harness.agent.stream('ahead', { startIndex: 3, ctx: CTX }))).rejects.toMatchObject({
+      code: ErrorCode.enum.CURSOR_OUT_OF_RANGE,
+      details: { startIndex: 3, latestIndex: 2 },
+    })
+
+    harness.close()
+  })
+
+  it('live tails an authorized empty session before its durable stream row exists', async () => {
+    const harness = createDurableAgent(['empty'])
+    const streamPath = sessionStreamPath('empty')
+    const iterator = harness.agent.stream('empty', { startIndex: 0, ctx: CTX })[Symbol.asyncIterator]()
+
+    const pending = nextWithTimeout(iterator.next())
+    await waitFor(async () => {
+      await expect(harness.store.getStreamMeta(streamPath)).resolves.toMatchObject({ closed: false })
+    })
+    await harness.store.appendAgentEvent('empty', piEvent(0))
+
+    await expect(pending).resolves.toMatchObject({
+      done: false,
+      value: { eventIndex: 0, chunk: { seq: 0 } },
+    })
+    await iterator.return?.()
+    harness.close()
+  })
+
+  it('live tails an open durable stream after replay reaches the tail', async () => {
+    const harness = createDurableAgent(['live'])
+    await harness.store.createStream(sessionStreamPath('live'))
+    const iterator = harness.agent.stream('live', { startIndex: 0, ctx: CTX })[Symbol.asyncIterator]()
+
+    const pending = nextWithTimeout(iterator.next())
+    await harness.store.appendAgentEvent('live', piEvent(0))
+
+    await expect(pending).resolves.toMatchObject({
+      done: false,
+      value: { eventIndex: 0, chunk: { seq: 0 } },
+    })
+    await iterator.return?.()
+    harness.close()
+  })
+
+  it('terminates durable tailers on stop and reopens the stream on the next start', async () => {
+    const adapter = new PromptingAdapter('restart')
+    const harness = createDurableAgent(['restart'], { adapter })
+    await seedEvents(harness.store, 'restart', 1)
+    const iterator = harness.agent.stream('restart', { startIndex: 1, ctx: CTX })[Symbol.asyncIterator]()
+    const pending = nextWithTimeout(iterator.next())
+
+    await harness.agent.stop('restart', CTX)
+
+    await expect(pending).resolves.toEqual({ value: undefined, done: true })
+    await expect(harness.store.getStreamMeta(sessionStreamPath('restart'))).resolves.toMatchObject({ closed: true })
+
+    const receipt = await harness.agent.start({ sessionId: 'restart', content: 'second', ctx: CTX })
+    expect(receipt.startIndex).toBe(1)
+    await expect(nextEvent(harness.agent.stream('restart', { startIndex: receipt.startIndex, ctx: CTX }))).resolves
+      .toMatchObject({
+        done: false,
+        value: {
+          eventIndex: 1,
+          chunk: { type: 'agent-start' },
+        },
+      })
+    await expect(harness.store.getStreamMeta(sessionStreamPath('restart'))).resolves.toMatchObject({ closed: false })
+    harness.close()
+  })
+
+  it('terminates durable tailers when the agent is disposed', async () => {
+    const adapter = new PromptingAdapter('dispose')
+    const harness = createDurableAgent(['dispose'], { adapter })
+    const receipt = await harness.agent.start({ sessionId: 'dispose', content: 'first', ctx: CTX })
+    const iterator = harness.agent.stream('dispose', { startIndex: receipt.startIndex + 1, ctx: CTX })[Symbol.asyncIterator]()
+    const pending = nextWithTimeout(iterator.next())
+
+    await harness.agent.dispose()
+
+    await expect(pending).resolves.toEqual({ value: undefined, done: true })
+    await expect(harness.store.getStreamMeta(sessionStreamPath('dispose'))).resolves.toMatchObject({ closed: true })
+    harness.close()
+  })
+})
+
+function createDurableAgent(seedSessions: string[], options: { adapter?: PiAgentSessionAdapter } = {}): {
+  agent: Agent
+  store: EventStreamStore
+  close(): void
+} {
+  const database = openDatabase(':memory:')
+  const store = new SqliteEventStreamStore(database.sql, database.runTransaction)
+  const sessions = new MemorySessionStore()
+  for (const sessionId of seedSessions) sessions.seed(sessionId, CTX)
+  const bridge = createAgentRuntimeBridge({
+    runtime: 'none',
+    harnessFactory: async (_input: AgentHarnessFactoryInput) => ({
+      id: 'stream-test',
+      placement: 'server',
+      sessions,
+      async getPiSessionAdapter() {
+        if (!options.adapter) throw new Error('not needed')
+        return options.adapter
+      },
+    }),
+  }, {
+    service: {
+      eventStore: store,
+    },
+  })
+
+  return {
+    agent: bridge.agent,
+    store,
+    close() {
+      database.db.close()
+    },
+  }
+}
+
+async function seedEvents(store: EventStreamStore, sessionId: string, count: number): Promise<void> {
+  await store.createStream(sessionStreamPath(sessionId))
+  for (let seq = 0; seq < count; seq++) {
+    await expect(store.appendAgentEvent(sessionId, piEvent(seq))).resolves.toBe(formatOffset(seq))
+  }
+}
+
+function piEvent(seq: number): PiChatEvent {
+  return { type: 'agent-start', seq, turnId: `turn-${seq}` }
+}
+
+class PromptingAdapter implements PiAgentSessionAdapter {
+  private readonly listeners = new Set<(event: AgentSessionEvent) => void>()
+
+  constructor(private readonly sessionId: string) {}
+
+  readSnapshot(): PiAgentSessionSnapshot {
+    return {
+      state: {},
+      messages: [],
+      isStreaming: false,
+      isRetrying: false,
+      retryAttempt: 0,
+      pendingMessageCount: 0,
+      steeringMessages: [],
+      followUpMessages: [],
+      followUpMode: 'one-at-a-time',
+      sessionId: this.sessionId,
+    }
+  }
+
+  subscribe(listener: (event: AgentSessionEvent) => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  async prompt(_input: PiAgentPromptInput): Promise<void> {
+    this.emit({ type: 'agent_start', turnId: 'turn-restarted' } as AgentSessionEvent)
+  }
+
+  async followUp(): Promise<void> {}
+
+  clearFollowUp(): void {}
+
+  async abort(): Promise<void> {}
+
+  private emit(event: AgentSessionEvent): void {
+    for (const listener of this.listeners) listener(event)
+  }
+}
+
+async function takeEvents(iterable: AsyncIterable<AgentEvent>, count: number): Promise<AgentEvent[]> {
+  const iterator = iterable[Symbol.asyncIterator]()
+  const events: AgentEvent[] = []
+  try {
+    while (events.length < count) {
+      const next = await nextWithTimeout(iterator.next())
+      if (next.done) break
+      events.push(next.value)
+    }
+    return events
+  } finally {
+    await iterator.return?.()
+  }
+}
+
+async function nextEvent(iterable: AsyncIterable<AgentEvent>): Promise<IteratorResult<AgentEvent>> {
+  const iterator = iterable[Symbol.asyncIterator]()
+  try {
+    return await nextWithTimeout(iterator.next())
+  } finally {
+    await iterator.return?.()
+  }
+}
+
+async function nextWithTimeout<T>(promise: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('timed out waiting for durable stream')), 1_000)
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+async function waitFor(assertion: () => void | Promise<void>): Promise<void> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      await assertion()
+      return
+    } catch (error) {
+      lastError = error
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+  }
+  throw lastError
+}
+
+class MemorySessionStore implements SessionStore {
+  private readonly records = new Map<string, SessionSummary>()
+  private readonly owners = new Map<string, SessionCtx>()
+
+  seed(sessionId: string, ctx: SessionCtx): void {
+    this.records.set(sessionId, {
+      id: sessionId,
+      title: sessionId,
+      createdAt: '2026-07-06T00:00:00.000Z',
+      updatedAt: '2026-07-06T00:00:00.000Z',
+      turnCount: 0,
+    })
+    this.owners.set(sessionId, ctx)
+  }
+
+  async list(ctx: SessionCtx, options?: { includeId?: string }): Promise<SessionSummary[]> {
+    const visible = [...this.records.values()].filter((record) => sameCtx(this.owners.get(record.id), ctx))
+    if (!options?.includeId || visible.some((record) => record.id === options.includeId)) return visible
+    const included = this.records.get(options.includeId)
+    return included && sameCtx(this.owners.get(included.id), ctx) ? [...visible, included] : visible
+  }
+
+  async create(ctx: SessionCtx): Promise<SessionSummary> {
+    const id = `session-${this.records.size + 1}`
+    this.seed(id, ctx)
+    return this.records.get(id) as SessionSummary
+  }
+
+  async load(ctx: SessionCtx, sessionId: string): Promise<SessionDetail> {
+    const record = this.records.get(sessionId)
+    if (!record) throw Object.assign(new Error('session not found'), { code: ErrorCode.enum.SESSION_NOT_FOUND })
+    if (!sameCtx(this.owners.get(sessionId), ctx)) {
+      throw Object.assign(new Error('session context mismatch'), { code: ErrorCode.enum.UNAUTHORIZED })
+    }
+    return record
+  }
+
+  async delete(_ctx: SessionCtx, sessionId: string): Promise<void> {
+    this.records.delete(sessionId)
+    this.owners.delete(sessionId)
+  }
+}
+
+function sameCtx(left: SessionCtx | undefined, right: SessionCtx): boolean {
+  return (left?.workspaceId ?? '') === (right.workspaceId ?? '') && (left?.userId ?? '') === (right.userId ?? '')
+}

--- a/packages/agent/src/server/createAgent.ts
+++ b/packages/agent/src/server/createAgent.ts
@@ -1,5 +1,5 @@
 import { HarnessPiChatService } from './pi-chat/harnessPiChatService'
-import type { EventStreamStore } from './events/eventStreamStore'
+import { formatOffset, parseOffset, type EventStreamStore } from './events/eventStreamStore'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import type { PiSessionRequestContext } from './pi-chat/piSessionIdentity'
 import type { AgentHarness, AgentHarnessFactoryInput } from '../shared/harness'
@@ -14,7 +14,7 @@ import type {
   AgentStartReceipt,
   AgentStreamOptions,
 } from '../shared/events'
-import { AgentNotImplementedError } from '../shared/events'
+import { AgentNotImplementedError, sessionStreamPath } from '../shared/events'
 import type { SessionCtx, SessionListOptions, SessionStore } from '../shared/session'
 import type { PromptPayload } from '../shared/chat'
 import { ErrorCode } from '../shared/error-codes'
@@ -86,6 +86,7 @@ export function createAgentRuntimeBridge(
 
   const runtimeLoader = createRuntimeLoader(config, options)
   const getRuntime = runtimeLoader.get
+  const eventStore = options.service?.eventStore
   const live = new AgentLiveEventBuffer(DEFAULT_LIVE_BUFFER_SIZE)
   const sessionContexts = new Map<string, SessionCtx | undefined>()
   const startedSessions = new Map<string, { sessionId: string; ctx: SessionCtx | undefined }>()
@@ -136,9 +137,12 @@ export function createAgentRuntimeBridge(
   async function start(input: AgentSendInput): Promise<AgentStartReceipt> {
     const runtime = await getRuntime()
     const { sessionId, sessionKey, ctx } = await ensureSession(input, runtime)
+    if (eventStore) await eventStore.createStream(sessionStreamPath(sessionId), { reopenClosed: true })
     startedSessions.set(sessionKey, { sessionId, ctx })
     await ensureBridge(sessionKey, sessionId, ctx, runtime.service)
-    const startIndex = live.latestIndex(sessionKey)
+    const startIndex = eventStore
+      ? await durableNextEventIndex(eventStore, sessionId)
+      : live.latestIndex(sessionKey)
     await runtime.service.prompt(toPiRequestContext(ctx), sessionId, toPromptPayload(input))
     return { sessionId, startIndex }
   }
@@ -182,6 +186,7 @@ export function createAgentRuntimeBridge(
       const runtime = await getRuntime()
       const accessCtx = await authorizeSessionAccess(runtime, sessionId, ctx, sessionContexts)
       const receipt = await runtime.service.stop(toPiRequestContext(accessCtx), sessionId, {})
+      if (eventStore) await eventStore.closeStream(sessionStreamPath(sessionId))
       const sessionKey = sessionCacheKey(sessionId, accessCtx)
       live.close(sessionKey)
       startedSessions.delete(sessionKey)
@@ -193,9 +198,10 @@ export function createAgentRuntimeBridge(
       let stopError: unknown
       try {
         if (runtime) {
-          await Promise.all([...startedSessions.values()].map((started) =>
-            runtime.service.stop(toPiRequestContext(started.ctx), started.sessionId, {}),
+          const results = await Promise.allSettled([...startedSessions.values()].map((started) =>
+            stopAndCloseStartedSession(runtime, eventStore, started),
           ))
+          stopError = results.find((result): result is PromiseRejectedResult => result.status === 'rejected')?.reason
         }
       } catch (error) {
         stopError = error
@@ -217,9 +223,162 @@ export function createAgentRuntimeBridge(
 
   async function* authorizedStream(sessionId: string, options: AgentStreamOptions): AsyncIterable<AgentEvent> {
     const runtime = await getRuntime()
-    const accessCtx = await authorizeSessionAccess(runtime, sessionId, options.ctx, sessionContexts)
+    let accessCtx: SessionCtx | undefined
+    try {
+      accessCtx = await authorizeSessionAccess(runtime, sessionId, options.ctx, sessionContexts)
+    } catch (error) {
+      if (eventStore && (error as { code?: unknown })?.code === ErrorCode.enum.SESSION_NOT_FOUND) return
+      throw error
+    }
+    if (eventStore) {
+      await eventStore.createStream(sessionStreamPath(sessionId))
+      yield* durableAgentEventStream(eventStore, sessionId, options.startIndex)
+      return
+    }
     yield* live.stream(sessionCacheKey(sessionId, accessCtx), options.startIndex)
   }
+}
+
+async function stopAndCloseStartedSession(
+  runtime: AgentRuntime,
+  eventStore: EventStreamStore | undefined,
+  started: { sessionId: string; ctx: SessionCtx | undefined },
+): Promise<void> {
+  let stopError: unknown
+  try {
+    await runtime.service.stop(toPiRequestContext(started.ctx), started.sessionId, {})
+  } catch (error) {
+    stopError = error
+  }
+  try {
+    await eventStore?.closeStream(sessionStreamPath(started.sessionId))
+  } catch (error) {
+    stopError ??= error
+  }
+  if (stopError !== undefined) throw stopError
+}
+
+async function durableNextEventIndex(eventStore: EventStreamStore, sessionId: string): Promise<number> {
+  const meta = await eventStore.getStreamMeta(sessionStreamPath(sessionId))
+  if (!meta) return 0
+  return parseOffset(meta.nextOffset) + 1
+}
+
+function durableAgentEventStream(
+  eventStore: EventStreamStore,
+  sessionId: string,
+  startIndex: number,
+): AsyncIterable<AgentEvent> {
+  return {
+    [Symbol.asyncIterator]: () => createDurableAgentEventIterator(eventStore, sessionId, startIndex),
+  }
+}
+
+function createDurableAgentEventIterator(
+  eventStore: EventStreamStore,
+  sessionId: string,
+  startIndex: number,
+): AsyncIterator<AgentEvent> {
+  const path = sessionStreamPath(sessionId)
+  const queued: AgentEvent[] = []
+  let active = true
+  let initialized = false
+  let currentOffset: string | undefined
+  let wake: (() => void) | undefined
+
+  return {
+    async next() {
+      if (!active) return { value: undefined, done: true }
+      if (!Number.isInteger(startIndex) || startIndex < 0) {
+        throw cursorOutOfRangeError('startIndex must be a non-negative integer', { startIndex })
+      }
+      currentOffset ??= formatOffset(startIndex - 1)
+      if (!initialized) {
+        initialized = true
+        const meta = await eventStore.getStreamMeta(path)
+        if (!meta) {
+          active = false
+          return { value: undefined, done: true }
+        }
+        const latestIndex = parseOffset(meta.nextOffset) + 1
+        if (startIndex > latestIndex) {
+          throw cursorOutOfRangeError(`startIndex ${startIndex} is ahead of next eventIndex ${latestIndex}`, {
+            startIndex,
+            latestIndex,
+          })
+        }
+      }
+
+      while (active) {
+        if (queued.length > 0) return { value: queued.shift() as AgentEvent, done: false }
+
+        const result = await eventStore.readEvents(path, { offset: currentOffset })
+        currentOffset = result.nextOffset
+        queued.push(...result.events.map((event) => toAgentEvent(event.data)))
+        if (queued.length > 0) return { value: queued.shift() as AgentEvent, done: false }
+        if (result.closed && result.upToDate) {
+          active = false
+          return { value: undefined, done: true }
+        }
+        if (!result.upToDate) continue
+
+        await waitForDurableEvent(eventStore, path, () => active, () => currentOffset ?? '-1', (resolve) => {
+          wake = resolve
+        })
+      }
+
+      return { value: undefined, done: true }
+    },
+    async return() {
+      active = false
+      wake?.()
+      wake = undefined
+      return { value: undefined, done: true }
+    },
+  }
+}
+
+function waitForDurableEvent(
+  eventStore: EventStreamStore,
+  path: string,
+  isActive: () => boolean,
+  getOffset: () => string,
+  setWake: (wake: () => void) => void,
+): Promise<void> {
+  return new Promise((resolve) => {
+    if (!isActive()) {
+      resolve()
+      return
+    }
+
+    let settled = false
+    const settle = () => {
+      if (settled) return
+      settled = true
+      unsubscribe()
+      resolve()
+    }
+    const unsubscribe = eventStore.subscribe(path, settle)
+    setWake(settle)
+    void eventStore.readEvents(path, { offset: getOffset(), limit: 1 }).then((result) => {
+      if (result.events.length > 0 || (result.closed && result.upToDate)) settle()
+    }).catch(() => {})
+  })
+}
+
+function toAgentEvent(value: unknown): AgentEvent {
+  const event = value as Partial<AgentEvent> | undefined
+  if (
+    event?.v === 1 &&
+    typeof event.eventIndex === 'number' &&
+    typeof event.timestamp === 'number' &&
+    typeof event.sessionId === 'string' &&
+    typeof event.chunk === 'object' &&
+    event.chunk !== null
+  ) {
+    return event as AgentEvent
+  }
+  throw stableAgentError(ErrorCode.enum.INTERNAL_ERROR, 'stored event is not an AgentEvent envelope')
 }
 
 function createRuntimeLoader(config: AgentConfig, options: CreateAgentRuntimeBridgeOptions): {

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -21,6 +21,8 @@ import { treeRoutes } from './http/routes/tree'
 import { modelsRoutes } from './http/routes/models'
 import { skillsRoutes } from './http/routes/skills'
 import { piChatRoutes, type PiChatSessionService } from './http/routes/piChat'
+import { eventStreamRoutes } from './http/routes/eventStream'
+import { agentSessionsRoutes } from './http/routes/agentSessions'
 import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
@@ -35,6 +37,8 @@ import type { AgentMeteringSink } from './pi-chat/metering'
 import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
 import type { ReloadHookDiagnostic } from './http/routes/reload'
 import { createAgentRuntimeBridge } from './createAgent'
+import { openEventStreamStore } from './events/openEventStreamStore'
+import { resolvePiSessionDir } from './harness/pi-coding-agent/sessions'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_SESSION_ID = 'default'
@@ -211,6 +215,20 @@ export async function createAgentApp(
     sessionNamespace: opts.sessionNamespace,
     sessionDir: opts.sessionDir,
   })) as AgentCoreHarnessFactory
+  const eventStoreHandle = openEventStreamStore(resolvePiSessionDir(runtimeBundle.workspace.root, {
+    sessionDir: opts.sessionDir,
+    sessionNamespace: opts.sessionNamespace,
+    storageCwd: workspaceRoot,
+  }))
+  let eventStoreClosed = false
+  const closeEventStore = () => {
+    if (eventStoreClosed) return
+    eventStoreClosed = true
+    eventStoreHandle.close()
+  }
+  app.addHook('onClose', async () => {
+    closeEventStore()
+  })
   const coreAgent = createAgentRuntimeBridge({
     runtime: modeAdapter,
     tools,
@@ -224,9 +242,13 @@ export async function createAgentApp(
     service: {
       workdir: runtimeBundle.workspace.root,
       workspace: runtimeBundle.workspace,
+      eventStore: eventStoreHandle.store,
     },
   })
-  const agentRuntime = await coreAgent.getRuntime()
+  const agentRuntime = await coreAgent.getRuntime().catch((error) => {
+    closeEventStore()
+    throw error
+  })
   const harness = agentRuntime.harness
   harnessRef = harness
   const sessionChangesTracker = new InMemorySessionChangesTracker()
@@ -265,6 +287,13 @@ export async function createAgentApp(
   })
   await app.register(piChatRoutes, {
     service: agentRuntime.service as PiChatSessionService,
+  })
+  await app.register(eventStreamRoutes, {
+    agent: coreAgent.agent,
+    eventStore: eventStoreHandle.store,
+  })
+  await app.register(agentSessionsRoutes, {
+    agent: coreAgent.agent,
   })
   await app.register(systemPromptRoutes, { harness })
   await app.register(modelsRoutes)

--- a/packages/agent/src/server/events/eventStreamStore.ts
+++ b/packages/agent/src/server/events/eventStreamStore.ts
@@ -22,8 +22,12 @@ export interface EventStreamMeta {
   closed: boolean
 }
 
+export interface CreateStreamOptions {
+  reopenClosed?: boolean
+}
+
 export interface EventStreamStore {
-  createStream(path: string): Promise<void>
+  createStream(path: string, opts?: CreateStreamOptions): Promise<void>
   appendEvent(path: string, event: unknown): Promise<string>
   appendEventOnce(path: string, key: string, event: unknown): Promise<string>
   appendAgentEvent(sessionId: string, chunk: PiChatEvent, opts?: { idempotencyKey?: string }): Promise<string>
@@ -99,7 +103,15 @@ export class SqliteEventStreamStore implements EventStreamStore {
     })
   }
 
-  async createStream(path: string): Promise<void> {
+  async createStream(path: string, opts: CreateStreamOptions = {}): Promise<void> {
+    if (opts.reopenClosed === true) {
+      this.sql.exec(`
+        INSERT INTO boring_event_streams (path) VALUES (?)
+        ON CONFLICT(path) DO UPDATE SET closed = 0
+      `, path)
+      this.notifyListeners(path)
+      return
+    }
     this.sql.exec(`INSERT OR IGNORE INTO boring_event_streams (path) VALUES (?)`, path)
   }
 

--- a/packages/agent/src/server/events/handleStreamRoutes.ts
+++ b/packages/agent/src/server/events/handleStreamRoutes.ts
@@ -1,0 +1,445 @@
+import { ErrorCode } from '../../shared/error-codes'
+import {
+  type EventStreamReadResult,
+  type EventStreamStore,
+  formatOffset,
+  parseOffset,
+} from './eventStreamStore'
+
+const LONG_POLL_TIMEOUT_MS = 30_000
+const SSE_HEARTBEAT_MS = 15_000
+
+export const STREAM_NEXT_OFFSET = 'Stream-Next-Offset'
+export const STREAM_UP_TO_DATE = 'Stream-Up-To-Date'
+export const STREAM_CLOSED = 'Stream-Closed'
+export const STREAM_CURSOR = 'Stream-Cursor'
+
+const SECURITY_HEADERS = {
+  'X-Content-Type-Options': 'nosniff',
+  'Cross-Origin-Resource-Policy': 'cross-origin',
+}
+
+const SSE_OFFSET_FIELD = 'streamNextOffset'
+const SSE_CURSOR_FIELD = 'streamCursor'
+const SSE_CLOSED_FIELD = 'streamClosed'
+const SSE_UP_TO_DATE_FIELD = 'upToDate'
+
+const CURSOR_EPOCH_MS = 1728432000000
+const CURSOR_INTERVAL_MS = 20_000
+
+type LiveMode = 'long-poll' | 'sse'
+
+export async function handleStreamHead(store: EventStreamStore, path: string): Promise<Response> {
+  const meta = await store.getStreamMeta(path)
+  if (!meta) {
+    const error = streamErrorResponse(404, ErrorCode.enum.SESSION_NOT_FOUND, 'stream not found')
+    return new Response(null, { status: error.status, headers: error.headers })
+  }
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    ...SECURITY_HEADERS,
+    [STREAM_NEXT_OFFSET]: meta.nextOffset,
+    [STREAM_UP_TO_DATE]: 'true',
+    'cache-control': 'no-store',
+    etag: generateETag(path, '-1', meta.nextOffset, meta.closed),
+  }
+  if (meta.closed) headers[STREAM_CLOSED] = 'true'
+
+  return new Response(null, { status: 200, headers })
+}
+
+export async function handleStreamRead(
+  store: EventStreamStore,
+  path: string,
+  request: Request,
+): Promise<Response> {
+  const url = new URL(request.url)
+  const offsetValues = url.searchParams.getAll('offset')
+  const offsetParam = offsetValues[0] ?? '-1'
+  const tailValues = url.searchParams.getAll('tail')
+  const tailParam = tailValues[0]
+  const liveRaw = url.searchParams.get('live')
+  const cursor = url.searchParams.get('cursor') ?? undefined
+
+  if (offsetValues.length > 1) {
+    return invalidRequest('Duplicate offset parameters are not allowed.')
+  }
+  if (tailValues.length > 1) {
+    return invalidRequest('Duplicate tail parameters are not allowed.')
+  }
+  if (tailParam !== undefined && !/^[1-9]\d*$/.test(tailParam)) {
+    return invalidRequest('Tail must be an integer greater than or equal to 1.')
+  }
+  if (liveRaw !== null && offsetValues.length === 0) {
+    return invalidRequest('Offset is required for live mode.')
+  }
+  if (liveRaw !== null && liveRaw !== 'long-poll' && liveRaw !== 'sse') {
+    return invalidRequest('Invalid live mode. Use "long-poll" or "sse".')
+  }
+  if (offsetParam !== '-1' && offsetParam !== 'now' && !/^\d+_\d+$/.test(offsetParam)) {
+    return invalidRequest('Invalid offset format.')
+  }
+
+  const meta = await store.getStreamMeta(path)
+  if (!meta) return streamErrorResponse(404, ErrorCode.enum.SESSION_NOT_FOUND, 'stream not found')
+
+  const live = liveRaw as LiveMode | null
+  const readOffset =
+    offsetParam === 'now' && live !== null
+      ? meta.nextOffset
+      : offsetParam === '-1' && tailParam !== undefined
+        ? formatOffset(Number(maxBigInt(-1n, BigInt(parseOffset(meta.nextOffset)) - BigInt(tailParam))))
+        : offsetParam
+
+  if (live === 'sse') {
+    return handleSseMode(store, path, readOffset, request.signal)
+  }
+
+  const result = await store.readEvents(path, { offset: readOffset })
+  if (live === 'long-poll') {
+    return handleLongPollMode(store, path, readOffset, readOffset, cursor, result, request.signal)
+  }
+
+  return handleCatchUpMode(request, path, readOffset, result)
+}
+
+function maxBigInt(left: bigint, right: bigint): bigint {
+  return left > right ? left : right
+}
+
+function generateCursor(clientCursor?: string): string {
+  const currentInterval = Math.floor((Date.now() - CURSOR_EPOCH_MS) / CURSOR_INTERVAL_MS)
+  if (!clientCursor) return String(currentInterval)
+  const clientInterval = parseInt(clientCursor, 10)
+  if (!Number.isFinite(clientInterval) || clientInterval < currentInterval) return String(currentInterval)
+  return String(clientInterval + Math.floor(Math.random() * 180) + 1)
+}
+
+function generateETag(path: string, startOffset: string, endOffset: string, closed: boolean): string {
+  const pathEncoded = Buffer.from(path).toString('base64')
+  const closedSuffix = closed ? ':c' : ''
+  return `"${pathEncoded}:${startOffset}:${endOffset}${closedSuffix}"`
+}
+
+function encodeSseData(payload: string): string {
+  return `${payload.split(/\r\n|\r|\n/).map((line) => `data:${line}`).join('\n')}\n\n`
+}
+
+function eventData(result: EventStreamReadResult): unknown[] {
+  return result.events.map((event) => event.data)
+}
+
+function invalidRequest(message: string): Response {
+  return streamErrorResponse(400, ErrorCode.enum.BRIDGE_COMMAND_INVALID, message)
+}
+
+function streamErrorResponse(status: number, code: string, message: string): Response {
+  return new Response(JSON.stringify({ error: { code, message } }), {
+    status,
+    headers: {
+      'content-type': 'application/json',
+      ...SECURITY_HEADERS,
+    },
+  })
+}
+
+function handleCatchUpMode(
+  request: Request,
+  path: string,
+  offsetParam: string,
+  result: EventStreamReadResult,
+): Response {
+  const isClosed = result.closed && result.upToDate
+  const etag = offsetParam === 'now' ? undefined : generateETag(path, offsetParam, result.nextOffset, isClosed)
+  const conditional = etag ? checkConditional(request, etag) : null
+  if (conditional) return conditional
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    [STREAM_NEXT_OFFSET]: result.nextOffset,
+    'cache-control': 'no-store',
+    ...SECURITY_HEADERS,
+  }
+  if (etag) headers.etag = etag
+  if (result.upToDate) headers[STREAM_UP_TO_DATE] = 'true'
+  if (isClosed) headers[STREAM_CLOSED] = 'true'
+
+  return new Response(JSON.stringify(eventData(result)), { status: 200, headers })
+}
+
+async function handleLongPollMode(
+  store: EventStreamStore,
+  path: string,
+  readOffset: string,
+  requestOffset: string,
+  clientCursor: string | undefined,
+  result: EventStreamReadResult,
+  signal: AbortSignal,
+): Promise<Response> {
+  if (result.events.length > 0) {
+    return longPollDataResponse(result, path, requestOffset, clientCursor)
+  }
+  if (result.closed && result.upToDate) {
+    return longPollEmptyResponse(result.nextOffset, clientCursor, true)
+  }
+
+  const waitResult = await waitForStreamData(store, path, signal, async () => {
+    const reread = await store.readEvents(path, { offset: readOffset })
+    return reread.events.length > 0 || (reread.closed && reread.upToDate)
+  })
+
+  if (waitResult === 'aborted') return new Response(null, { status: 499, headers: SECURITY_HEADERS })
+  if (waitResult === 'timeout') {
+    const closed = (await store.getStreamMeta(path))?.closed ?? false
+    return longPollEmptyResponse(result.nextOffset, clientCursor, closed)
+  }
+
+  const freshResult = await store.readEvents(path, { offset: readOffset })
+  if (freshResult.events.length > 0) {
+    return longPollDataResponse(freshResult, path, requestOffset, clientCursor)
+  }
+  const closed = (await store.getStreamMeta(path))?.closed ?? false
+  return longPollEmptyResponse(result.nextOffset, clientCursor, closed)
+}
+
+function longPollDataResponse(
+  result: EventStreamReadResult,
+  path: string,
+  offsetParam: string,
+  clientCursor: string | undefined,
+): Response {
+  const isClosed = result.closed && result.upToDate
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    'cache-control': 'no-store',
+    ...SECURITY_HEADERS,
+    [STREAM_NEXT_OFFSET]: result.nextOffset,
+    [STREAM_CURSOR]: generateCursor(clientCursor),
+  }
+  if (result.upToDate) headers[STREAM_UP_TO_DATE] = 'true'
+  if (isClosed) headers[STREAM_CLOSED] = 'true'
+  if (offsetParam !== 'now') headers.etag = generateETag(path, offsetParam, result.nextOffset, isClosed)
+  return new Response(JSON.stringify(eventData(result)), { status: 200, headers })
+}
+
+function longPollEmptyResponse(nextOffset: string, clientCursor: string | undefined, closed: boolean): Response {
+  const headers: Record<string, string> = {
+    'cache-control': 'no-store',
+    ...SECURITY_HEADERS,
+    [STREAM_NEXT_OFFSET]: nextOffset,
+    [STREAM_UP_TO_DATE]: 'true',
+    [STREAM_CURSOR]: generateCursor(clientCursor),
+  }
+  if (closed) headers[STREAM_CLOSED] = 'true'
+  return new Response(null, { status: 204, headers })
+}
+
+function waitForStreamData(
+  store: EventStreamStore,
+  path: string,
+  signal: AbortSignal,
+  recheck?: () => Promise<boolean>,
+): Promise<'data' | 'timeout' | 'aborted'> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve('aborted')
+      return
+    }
+
+    let settled = false
+    const settle = (result: 'data' | 'timeout' | 'aborted') => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(result)
+    }
+
+    const unsubscribe = store.subscribe(path, () => settle('data'))
+    const timer = setTimeout(() => settle('timeout'), LONG_POLL_TIMEOUT_MS)
+    if (recheck) {
+      void recheck().then((hasData) => {
+        if (hasData) settle('data')
+      }).catch(() => {})
+    }
+    const onAbort = () => settle('aborted')
+    signal.addEventListener('abort', onAbort, { once: true })
+
+    function cleanup(): void {
+      unsubscribe()
+      clearTimeout(timer)
+      signal.removeEventListener('abort', onAbort)
+    }
+  })
+}
+
+function handleSseMode(
+  store: EventStreamStore,
+  path: string,
+  offsetParam: string,
+  signal: AbortSignal,
+): Response {
+  const encoder = new TextEncoder()
+  let isConnected = true
+  let heartbeatTimer: ReturnType<typeof setInterval> | undefined
+  let resolveCapacity: (() => void) | undefined
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      signal.addEventListener('abort', () => {
+        isConnected = false
+        resolveCapacity?.()
+        resolveCapacity = undefined
+        cleanup()
+        try {
+          controller.close()
+        } catch {
+          // Already closed.
+        }
+      }, { once: true })
+
+      heartbeatTimer = setInterval(() => {
+        if (!isConnected) return
+        try {
+          controller.enqueue(encoder.encode(': heartbeat\n\n'))
+        } catch {
+          isConnected = false
+          cleanup()
+        }
+      }, SSE_HEARTBEAT_MS)
+
+      runSseLoop(
+        store,
+        path,
+        offsetParam,
+        controller,
+        encoder,
+        signal,
+        () => isConnected,
+        () => {
+          if (controller.desiredSize === null || controller.desiredSize > 0) return Promise.resolve()
+          return new Promise<void>((resolve) => {
+            resolveCapacity = resolve
+          })
+        },
+      ).then(
+        () => {
+          cleanup()
+          try {
+            controller.close()
+          } catch {
+            // Already closed.
+          }
+        },
+        (error) => {
+          cleanup()
+          try {
+            controller.error(error)
+          } catch {
+            // Already closed.
+          }
+        },
+      )
+    },
+    pull() {
+      resolveCapacity?.()
+      resolveCapacity = undefined
+    },
+    cancel() {
+      isConnected = false
+      resolveCapacity?.()
+      resolveCapacity = undefined
+      cleanup()
+    },
+  })
+
+  function cleanup(): void {
+    if (heartbeatTimer !== undefined) clearInterval(heartbeatTimer)
+    heartbeatTimer = undefined
+  }
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      ...SECURITY_HEADERS,
+    },
+  })
+}
+
+async function runSseLoop(
+  store: EventStreamStore,
+  path: string,
+  offsetParam: string,
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+  signal: AbortSignal,
+  isConnected: () => boolean,
+  waitForCapacity: () => Promise<void>,
+): Promise<void> {
+  let currentOffset = offsetParam
+
+  while (isConnected()) {
+    await waitForCapacity()
+    if (!isConnected()) return
+    const result = await store.readEvents(path, { offset: currentOffset })
+
+    if (result.events.length > 0) {
+      const dataPayload = JSON.stringify(eventData(result))
+      try {
+        controller.enqueue(encoder.encode(`event: data\n${encodeSseData(dataPayload)}`))
+      } catch {
+        return
+      }
+    }
+
+    const clientAtTail = result.upToDate
+    const streamClosed = result.closed && clientAtTail
+    const controlData: Record<string, string | boolean> = {
+      [SSE_OFFSET_FIELD]: result.nextOffset,
+    }
+    if (streamClosed) {
+      controlData[SSE_CLOSED_FIELD] = true
+    } else {
+      controlData[SSE_CURSOR_FIELD] = generateCursor()
+      if (clientAtTail) controlData[SSE_UP_TO_DATE_FIELD] = true
+    }
+
+    try {
+      controller.enqueue(encoder.encode(`event: control\n${encodeSseData(JSON.stringify(controlData))}`))
+    } catch {
+      return
+    }
+
+    currentOffset = result.nextOffset
+    if (streamClosed) return
+    if (!clientAtTail) continue
+
+    const waitResult = await waitForStreamData(store, path, signal, async () => {
+      const reread = await store.readEvents(path, { offset: currentOffset })
+      return reread.events.length > 0 || (reread.closed && reread.upToDate)
+    })
+    if (waitResult === 'aborted') return
+    if (waitResult === 'timeout') {
+      const keepAlive: Record<string, string | boolean> = {
+        [SSE_OFFSET_FIELD]: currentOffset,
+        [SSE_CURSOR_FIELD]: generateCursor(),
+        [SSE_UP_TO_DATE_FIELD]: true,
+      }
+      try {
+        controller.enqueue(encoder.encode(`event: control\n${encodeSseData(JSON.stringify(keepAlive))}`))
+      } catch {
+        return
+      }
+    }
+  }
+}
+
+function checkConditional(request: Request, etag: string): Response | null {
+  const ifNoneMatch = request.headers.get('if-none-match')
+  if (ifNoneMatch === etag) {
+    return new Response(null, { status: 304, headers: { etag, ...SECURITY_HEADERS } })
+  }
+  return null
+}

--- a/packages/agent/src/server/events/openEventStreamStore.ts
+++ b/packages/agent/src/server/events/openEventStreamStore.ts
@@ -1,0 +1,18 @@
+import { join } from 'node:path'
+import { SqliteEventStreamStore, type EventStreamStore } from './eventStreamStore'
+import { openDatabase, type OpenDatabaseResult } from './sqlStorage'
+
+export interface EventStreamStoreHandle {
+  store: EventStreamStore
+  close(): void
+}
+
+export function openEventStreamStore(rootDir: string): EventStreamStoreHandle {
+  const database: OpenDatabaseResult = openDatabase(join(rootDir, 'events.db'))
+  return {
+    store: new SqliteEventStreamStore(database.sql, database.runTransaction),
+    close() {
+      database.db.close()
+    },
+  }
+}

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
@@ -9,7 +9,7 @@ import {
   mergePiPackageSources,
 } from "../createHarness.js";
 import { adaptToolsForPi } from "../tool-adapter.js";
-import { PiSessionStore } from "../sessions.js";
+import { PiSessionStore, resolvePiSessionDir } from "../sessions.js";
 import type { AgentTool } from "../../../../shared/tool.js";
 
 const ENOENT_CODE = "ENOENT";
@@ -414,6 +414,13 @@ describe("PiSessionStore", () => {
     expect(store.getSessionDir()).toBe(tmpDir);
     const firstLine = (await readFile(join(tmpDir, `${session.id}.jsonl`), "utf-8")).split("\n")[0];
     expect(JSON.parse(firstLine)).toEqual(expect.objectContaining({ cwd: "/workspace" }));
+  });
+
+  it("derives default storage directories from host storage cwd, not runtime cwd", () => {
+    expect(resolvePiSessionDir("/workspace", {
+      sessionRoot: tmpDir,
+      storageCwd: "/tmp/host-storage-root",
+    })).toBe(join(tmpDir, "--tmp-host-storage-root--"));
   });
 
   it("creates and lists sessions", async () => {

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -100,6 +100,13 @@ export interface PiSessionStoreOptions {
   storageCwd?: string;
 }
 
+export function resolvePiSessionDir(cwd: string, options: PiSessionStoreOptions = {}): string {
+  return options.sessionDir
+    ?? (options.sessionNamespace
+      ? sessionDirForNamespace(options.sessionNamespace, options.sessionRoot)
+      : defaultSessionDir(options.storageCwd ?? cwd, options.sessionRoot));
+}
+
 export class PiSessionStore implements SessionStore {
   private cwd: string;
   private sessionDir: string;
@@ -115,10 +122,7 @@ export class PiSessionStore implements SessionStore {
       return;
     }
     this.allowLegacyUnscopedAccess = true;
-    this.sessionDir = options?.sessionDir
-      ?? (options?.sessionNamespace
-        ? sessionDirForNamespace(options.sessionNamespace, options.sessionRoot)
-        : defaultSessionDir(options?.storageCwd ?? cwd, options?.sessionRoot));
+    this.sessionDir = resolvePiSessionDir(cwd, options);
   }
 
   getSessionDir(): string {

--- a/packages/agent/src/server/http/routes/__tests__/agentSessions.route.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/agentSessions.route.test.ts
@@ -1,0 +1,176 @@
+import Fastify, { type FastifyInstance } from 'fastify'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Agent, AgentSendInput } from '../../../../shared/events'
+import { ErrorCode } from '../../../../shared/error-codes'
+import { agentSessionsRoutes } from '../agentSessions'
+
+const apps: FastifyInstance[] = []
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.close()))
+})
+
+describe('agentSessionsRoutes', () => {
+  it('maps canonical write routes to the Agent facade', async () => {
+    const agent = fakeAgent()
+    const app = await createApp(agent)
+
+    const created = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/default/sessions',
+      payload: { content: 'hello', model: { provider: 'test', id: 'model-a' } },
+    })
+    expect(created.statusCode).toBe(201)
+    expect(created.json()).toEqual({ sessionId: 'created-session', startIndex: 0 })
+    expect(agent.start).toHaveBeenLastCalledWith({
+      content: 'hello',
+      model: { provider: 'test', id: 'model-a' },
+      ctx: { workspaceId: 'workspace-a', userId: 'user-a' },
+    })
+
+    const prompt = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/default/sessions/existing/prompt',
+      payload: { content: [{ type: 'text', text: 'again' }] },
+    })
+    expect(prompt.statusCode).toBe(202)
+    expect(agent.start).toHaveBeenLastCalledWith({
+      sessionId: 'existing',
+      content: [{ type: 'text', text: 'again' }],
+      ctx: { workspaceId: 'workspace-a', userId: 'user-a' },
+    })
+
+    const interrupt = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/default/sessions/existing/interrupt',
+    })
+    expect(interrupt.statusCode).toBe(202)
+    expect(agent.interrupt).toHaveBeenCalledWith('existing', { workspaceId: 'workspace-a', userId: 'user-a' })
+
+    const stop = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/default/sessions/existing/stop',
+    })
+    expect(stop.statusCode).toBe(202)
+    expect(agent.stop).toHaveBeenCalledWith('existing', { workspaceId: 'workspace-a', userId: 'user-a' })
+  })
+
+  it('requires the explicit default agent segment', async () => {
+    const app = await createApp(fakeAgent())
+
+    const nonDefault = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/reviewer/sessions',
+      payload: { content: 'hello' },
+    })
+    expect(nonDefault.statusCode).toBe(404)
+    expect(nonDefault.json()).toEqual({
+      error: {
+        code: ErrorCode.enum.SESSION_NOT_FOUND,
+        message: 'agent not found',
+      },
+    })
+
+    const absent = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/sessions',
+      payload: { content: 'hello' },
+    })
+    expect(absent.statusCode).toBe(404)
+  })
+
+  it('rejects blank canonical start and prompt bodies', async () => {
+    const agent = fakeAgent()
+    const app = await createApp(agent)
+
+    const missing = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/default/sessions',
+      payload: {},
+    })
+    expect(missing.statusCode).toBe(400)
+    expect(missing.json()).toMatchObject({
+      error: {
+        code: ErrorCode.enum.BRIDGE_COMMAND_INVALID,
+        field: 'body.message',
+      },
+    })
+
+    const empty = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/default/sessions/existing/prompt',
+      payload: { message: '' },
+    })
+    expect(empty.statusCode).toBe(400)
+    expect(empty.json()).toMatchObject({
+      error: {
+        code: ErrorCode.enum.BRIDGE_COMMAND_INVALID,
+        field: 'body.message',
+      },
+    })
+
+    const emptyContent = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/default/sessions/existing/prompt',
+      payload: { content: [{ type: 'text', text: '' }] },
+    })
+    expect(emptyContent.statusCode).toBe(400)
+    expect(emptyContent.json()).toMatchObject({
+      error: {
+        code: ErrorCode.enum.BRIDGE_COMMAND_INVALID,
+        field: 'body.content',
+      },
+    })
+
+    expect(agent.start).not.toHaveBeenCalled()
+  })
+})
+
+async function createApp(agent: Agent): Promise<FastifyInstance> {
+  const app = Fastify({ logger: false })
+  app.addHook('onRequest', async (request) => {
+    request.workspaceContext = { workspaceId: 'workspace-a', authenticated: true }
+    ;(request as unknown as { user: { id: string } }).user = { id: 'user-a' }
+  })
+  await app.register(agentSessionsRoutes, { agent })
+  await app.ready()
+  apps.push(app)
+  return app
+}
+
+function fakeAgent(): Agent & {
+  start: ReturnType<typeof vi.fn>
+  interrupt: ReturnType<typeof vi.fn>
+  stop: ReturnType<typeof vi.fn>
+} {
+  const start = vi.fn(async (input: AgentSendInput) => ({
+    sessionId: input.sessionId ?? 'created-session',
+    startIndex: input.sessionId ? 10 : 0,
+  }))
+  const interrupt = vi.fn(async (_sessionId: string, _ctx?: { workspaceId?: string; userId?: string }) => ({ accepted: true }))
+  const stop = vi.fn(async (_sessionId: string, _ctx?: { workspaceId?: string; userId?: string }) => ({ accepted: true, stopped: true }))
+
+  return {
+    start,
+    stream: vi.fn(),
+    send: vi.fn(),
+    resolveInput: vi.fn(),
+    interrupt,
+    stop,
+    sessions: {
+      list: vi.fn(),
+      create: vi.fn(),
+      load: vi.fn(),
+      delete: vi.fn(),
+    },
+    readiness: {
+      requirements: [],
+      status: vi.fn(async () => []),
+    },
+    dispose: vi.fn(),
+  } as unknown as Agent & {
+    start: ReturnType<typeof vi.fn>
+    interrupt: ReturnType<typeof vi.fn>
+    stop: ReturnType<typeof vi.fn>
+  }
+}

--- a/packages/agent/src/server/http/routes/__tests__/eventStream.route.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/eventStream.route.test.ts
@@ -1,0 +1,235 @@
+import Fastify, { type FastifyInstance } from 'fastify'
+import { afterEach, describe, expect, it } from 'vitest'
+import { sessionStreamPath, type Agent, type AgentEvent } from '../../../../shared/events'
+import type { PiChatEvent } from '../../../../shared/chat'
+import { ErrorCode } from '../../../../shared/error-codes'
+import type { SessionCtx, SessionDetail } from '../../../../shared/session'
+import { formatOffset, SqliteEventStreamStore, type EventStreamStore } from '../../../events/eventStreamStore'
+import { openDatabase, type OpenDatabaseResult } from '../../../events/sqlStorage'
+import { eventStreamRoutes } from '../eventStream'
+
+const apps: FastifyInstance[] = []
+const databases: OpenDatabaseResult[] = []
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.close()))
+  for (const database of databases.splice(0)) database.db.close()
+})
+
+describe('eventStreamRoutes', () => {
+  it('serves DS catch-up reads, HEAD metadata, and If-None-Match caching', async () => {
+    const { app, store } = await createApp()
+    const offsets = await seedEvents(store, 's1', 3)
+
+    const full = await app.inject({
+      method: 'GET',
+      url: '/api/v1/agents/default/sessions/s1/events/stream?offset=-1',
+    })
+    expect(full.statusCode).toBe(200)
+    expect(full.headers['stream-next-offset']).toBe(offsets[2])
+    expect(full.headers['stream-up-to-date']).toBe('true')
+    expect(full.headers['x-accel-buffering']).toBe('no')
+    expect((full.json() as AgentEvent[]).map((event) => event.eventIndex)).toEqual([0, 1, 2])
+
+    const tail = await app.inject({
+      method: 'GET',
+      url: `/api/v1/agents/default/sessions/s1/events/stream?offset=${offsets[0]}`,
+    })
+    expect(tail.statusCode).toBe(200)
+    expect((tail.json() as AgentEvent[]).map((event) => event.eventIndex)).toEqual([1, 2])
+
+    const head = await app.inject({
+      method: 'HEAD',
+      url: '/api/v1/agents/default/sessions/s1/events/stream',
+    })
+    expect(head.statusCode).toBe(200)
+    expect(head.body).toBe('')
+    expect(head.headers['stream-next-offset']).toBe(offsets[2])
+    expect(head.headers.etag).toBeTruthy()
+
+    const cached = await app.inject({
+      method: 'GET',
+      url: '/api/v1/agents/default/sessions/s1/events/stream?offset=-1',
+      headers: { 'if-none-match': full.headers.etag as string },
+    })
+    expect(cached.statusCode).toBe(304)
+    expect(cached.body).toBe('')
+  })
+
+  it('fails closed when registered without a session authorizer', async () => {
+    const database = openDatabase(':memory:')
+    databases.push(database)
+    const store = new SqliteEventStreamStore(database.sql, database.runTransaction)
+    await seedEvents(store, 's1', 1)
+    const app = Fastify({ logger: false })
+    await app.register(eventStreamRoutes, { eventStore: store } as never)
+    await app.ready()
+    apps.push(app)
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/agents/default/sessions/s1/events/stream?offset=-1',
+    })
+
+    expect(response.statusCode).toBe(500)
+    expect(response.json()).toMatchObject({
+      error: {
+        code: ErrorCode.enum.INTERNAL_ERROR,
+        message: 'event stream route requires agent or getAgent',
+      },
+    })
+  })
+
+  it('marks empty long-poll responses as non-cacheable', async () => {
+    const { app, store } = await createApp()
+    await store.createStream(sessionStreamPath('s1'))
+    await store.closeStream(sessionStreamPath('s1'))
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/api/v1/agents/default/sessions/s1/events/stream?offset=-1&live=long-poll',
+    })
+
+    expect(response.statusCode).toBe(204)
+    expect(response.headers['cache-control']).toBe('no-store')
+    expect(response.headers['stream-up-to-date']).toBe('true')
+    expect(response.headers['stream-closed']).toBe('true')
+  })
+
+  it('rejects non-default agent ids while preserving absent-agentId 404 behavior', async () => {
+    const { app } = await createApp()
+
+    const nonDefault = await app.inject({
+      method: 'GET',
+      url: '/api/v1/agents/reviewer/sessions/s1/events/stream?offset=-1',
+    })
+    expect(nonDefault.statusCode).toBe(404)
+    expect(nonDefault.json()).toEqual({
+      error: {
+        code: ErrorCode.enum.SESSION_NOT_FOUND,
+        message: 'agent not found',
+      },
+    })
+
+    const absent = await app.inject({
+      method: 'GET',
+      url: '/api/v1/agents/sessions/s1/events/stream?offset=-1',
+    })
+    expect(absent.statusCode).toBe(404)
+  })
+
+  it('streams SSE data/control events and replays missed events after disconnect', async () => {
+    const { app, store } = await createApp()
+    const [firstOffset] = await seedEvents(store, 'sse-1', 1)
+
+    await app.listen({ port: 0, host: '127.0.0.1' })
+    const address = app.server.address()
+    if (typeof address !== 'object' || !address) throw new Error('no address')
+
+    const controller = new AbortController()
+    const response = await fetch(
+      `http://127.0.0.1:${address.port}/api/v1/agents/default/sessions/sse-1/events/stream?offset=-1&live=sse`,
+      { signal: controller.signal },
+    )
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toContain('text/event-stream')
+    expect(response.headers.get('x-accel-buffering')).toBe('no')
+
+    const reader = response.body!.getReader()
+    const sse = await readUntil(reader, (text) =>
+      text.includes('event: data') &&
+      text.includes('event: control') &&
+      text.includes(firstOffset),
+    )
+    expect(sse).toContain('event: data')
+    expect(sse).toContain('event: control')
+    expect(sse).toContain('"streamNextOffset"')
+    controller.abort()
+    await reader.cancel().catch(() => {})
+
+    const secondOffset = await store.appendAgentEvent('sse-1', piEvent(1))
+    const replay = await app.inject({
+      method: 'GET',
+      url: `/api/v1/agents/default/sessions/sse-1/events/stream?offset=${firstOffset}`,
+    })
+
+    expect(replay.statusCode).toBe(200)
+    expect(replay.headers['stream-next-offset']).toBe(secondOffset)
+    expect((replay.json() as AgentEvent[]).map((event) => event.eventIndex)).toEqual([1])
+  }, 15_000)
+})
+
+async function createApp(): Promise<{ app: FastifyInstance; store: EventStreamStore }> {
+  const database = openDatabase(':memory:')
+  databases.push(database)
+  const store = new SqliteEventStreamStore(database.sql, database.runTransaction)
+  const app = Fastify({ logger: false })
+  await app.register(eventStreamRoutes, { eventStore: store, agent: authorizeAllAgent() })
+  await app.ready()
+  apps.push(app)
+  return { app, store }
+}
+
+function authorizeAllAgent(): Agent {
+  return {
+    start: async () => ({ sessionId: 'unused', startIndex: 0 }),
+    stream: () => ({ async *[Symbol.asyncIterator]() {} }),
+    send: async function* () {},
+    resolveInput: async () => {
+      throw new Error('not used')
+    },
+    interrupt: async () => ({ accepted: true }),
+    stop: async () => ({ accepted: true, stopped: true }),
+    sessions: {
+      list: async () => [],
+      create: async () => sessionDetail('created'),
+      load: async (_ctx: SessionCtx, sessionId: string) => sessionDetail(sessionId),
+      delete: async () => {},
+    },
+    readiness: {
+      requirements: [],
+      status: async () => [],
+    },
+    dispose: async () => {},
+  } as Agent
+}
+
+function sessionDetail(sessionId: string): SessionDetail {
+  return {
+    id: sessionId,
+    title: sessionId,
+    createdAt: '2026-07-06T00:00:00.000Z',
+    updatedAt: '2026-07-06T00:00:00.000Z',
+    turnCount: 0,
+  }
+}
+
+async function seedEvents(store: EventStreamStore, sessionId: string, count: number): Promise<string[]> {
+  await store.createStream(sessionStreamPath(sessionId))
+  const offsets: string[] = []
+  for (let seq = 0; seq < count; seq++) {
+    offsets.push(await store.appendAgentEvent(sessionId, piEvent(seq)))
+  }
+  expect(offsets).toEqual(Array.from({ length: count }, (_, index) => formatOffset(index)))
+  return offsets
+}
+
+function piEvent(seq: number): PiChatEvent {
+  return { type: 'agent-start', seq, turnId: `turn-${seq}` }
+}
+
+async function readUntil(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  predicate: (text: string) => boolean,
+): Promise<string> {
+  const decoder = new TextDecoder()
+  let text = ''
+  const deadline = Date.now() + 2_000
+  while (Date.now() < deadline) {
+    const { value, done } = await reader.read()
+    if (done) break
+    text += decoder.decode(value, { stream: true })
+    if (predicate(text)) return text
+  }
+  throw new Error(`timed out waiting for SSE data; received: ${text}`)
+}

--- a/packages/agent/src/server/http/routes/agentSessions.ts
+++ b/packages/agent/src/server/http/routes/agentSessions.ts
@@ -1,0 +1,239 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import { z } from 'zod'
+import type { Agent, AgentSendInput } from '../../../shared/events'
+import { ErrorCode } from '../../../shared/error-codes'
+
+const DEFAULT_AGENT_ID = 'default'
+const MAX_PROMPT_MESSAGE_LENGTH = 1_000_000
+const MAX_PROMPT_ATTACHMENTS = 20
+
+const AgentParamsSchema = z.object({
+  agentId: z.string().min(1),
+})
+
+const SessionParamsSchema = z.object({
+  agentId: z.string().min(1),
+  sessionId: z.string().min(1).max(128),
+})
+
+const AgentMessagePartSchema = z.object({
+  type: z.string().min(1),
+  text: z.string().max(MAX_PROMPT_MESSAGE_LENGTH).optional(),
+}).catchall(z.unknown())
+
+const AgentMessageContentSchema = z.union([
+  z.string().min(1).max(MAX_PROMPT_MESSAGE_LENGTH),
+  z.array(AgentMessagePartSchema).min(1).refine(
+    (parts) => parts.some((part) => typeof part.text === 'string' && part.text.length > 0),
+    { message: 'content must include text' },
+  ),
+])
+
+const MessageAttachmentSchema = z.object({
+  filename: z.string().min(1).optional(),
+  mediaType: z.string().min(1).optional(),
+  url: z.string().min(1),
+}).passthrough()
+
+const AgentActorSchema = z.object({
+  id: z.string().min(1).optional(),
+  name: z.string().min(1).optional(),
+}).passthrough()
+
+const AgentModelSchema = z.object({
+  provider: z.string().min(1),
+  id: z.string().min(1),
+})
+
+const StartBodySchema = z.preprocess((value) => value ?? {}, z.object({
+  content: AgentMessageContentSchema.optional(),
+  message: z.string().min(1).max(MAX_PROMPT_MESSAGE_LENGTH).optional(),
+  attachments: z.array(MessageAttachmentSchema).max(MAX_PROMPT_ATTACHMENTS).optional(),
+  actor: AgentActorSchema.optional(),
+  originSurface: z.string().min(1).optional(),
+  thinkingLevel: z.enum(['off', 'low', 'medium', 'high']).optional(),
+  model: AgentModelSchema.optional(),
+}).passthrough().superRefine((body, ctx) => {
+  if (body.content === undefined && body.message === undefined) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'message or content is required',
+      path: ['message'],
+    })
+  }
+}))
+
+const EmptyBodySchema = z.preprocess((value) => value ?? {}, z.object({}).passthrough())
+
+export interface AgentSessionsRoutesOptions {
+  agent?: Agent
+  getAgent?: (request: FastifyRequest) => Agent | Promise<Agent>
+}
+
+export function agentSessionsRoutes(
+  app: FastifyInstance,
+  opts: AgentSessionsRoutesOptions,
+  done: (err?: Error) => void,
+): void {
+  app.post('/api/v1/agents/:agentId/sessions', async (request, reply) => {
+    const params = parseAgentParams(request, reply)
+    if (!params) return
+    if (!assertDefaultAgent(params.agentId, reply)) return
+    const body = parseWithSchema(StartBodySchema, request.body, reply, 'body')
+    if (!body) return
+
+    try {
+      const agent = await resolveAgent(opts, request)
+      const input = toAgentSendInput(body, request)
+      return reply.code(201).send(await agent.start(input))
+    } catch (error) {
+      return sendRouteError(reply, error, 'create agent session failed')
+    }
+  })
+
+  app.post('/api/v1/agents/:agentId/sessions/:sessionId/prompt', async (request, reply) => {
+    const params = parseSessionParams(request, reply)
+    if (!params) return
+    if (!assertDefaultAgent(params.agentId, reply)) return
+    const body = parseWithSchema(StartBodySchema, request.body, reply, 'body')
+    if (!body) return
+
+    try {
+      const agent = await resolveAgent(opts, request)
+      const input = { ...toAgentSendInput(body, request), sessionId: params.sessionId }
+      return reply.code(202).send(await agent.start(input))
+    } catch (error) {
+      return sendRouteError(reply, error, 'prompt rejected')
+    }
+  })
+
+  app.post('/api/v1/agents/:agentId/sessions/:sessionId/interrupt', async (request, reply) => {
+    const params = parseSessionParams(request, reply)
+    if (!params) return
+    if (!assertDefaultAgent(params.agentId, reply)) return
+    const body = parseWithSchema(EmptyBodySchema, request.body, reply, 'body')
+    if (!body) return
+
+    try {
+      const agent = await resolveAgent(opts, request)
+      return reply.code(202).send(await agent.interrupt(params.sessionId, sessionCtxFromRequest(request)))
+    } catch (error) {
+      return sendRouteError(reply, error, 'interrupt rejected')
+    }
+  })
+
+  app.post('/api/v1/agents/:agentId/sessions/:sessionId/stop', async (request, reply) => {
+    const params = parseSessionParams(request, reply)
+    if (!params) return
+    if (!assertDefaultAgent(params.agentId, reply)) return
+    const body = parseWithSchema(EmptyBodySchema, request.body, reply, 'body')
+    if (!body) return
+
+    try {
+      const agent = await resolveAgent(opts, request)
+      return reply.code(202).send(await agent.stop(params.sessionId, sessionCtxFromRequest(request)))
+    } catch (error) {
+      return sendRouteError(reply, error, 'stop rejected')
+    }
+  })
+
+  done()
+}
+
+function toAgentSendInput(body: z.infer<typeof StartBodySchema>, request: FastifyRequest): AgentSendInput {
+  return {
+    ...(body.content !== undefined ? { content: body.content } : {}),
+    ...(body.message !== undefined ? { message: body.message } : {}),
+    ...(body.attachments !== undefined ? { attachments: body.attachments } : {}),
+    ...(body.actor !== undefined ? { actor: body.actor } : {}),
+    ...(body.originSurface !== undefined ? { originSurface: body.originSurface } : {}),
+    ...(body.thinkingLevel !== undefined ? { thinkingLevel: body.thinkingLevel } : {}),
+    ...(body.model !== undefined ? { model: body.model } : {}),
+    ctx: sessionCtxFromRequest(request),
+  }
+}
+
+function parseAgentParams(request: FastifyRequest, reply: FastifyReply): { agentId: string } | undefined {
+  return parseWithSchema(AgentParamsSchema, request.params, reply, 'params')
+}
+
+function parseSessionParams(request: FastifyRequest, reply: FastifyReply): { agentId: string; sessionId: string } | undefined {
+  return parseWithSchema(SessionParamsSchema, request.params, reply, 'params')
+}
+
+function assertDefaultAgent(agentId: string, reply: FastifyReply): boolean {
+  if (agentId === DEFAULT_AGENT_ID) return true
+  reply.code(404).send({
+    error: {
+      code: ErrorCode.enum.SESSION_NOT_FOUND,
+      message: 'agent not found',
+    },
+  })
+  return false
+}
+
+async function resolveAgent(opts: AgentSessionsRoutesOptions, request: FastifyRequest): Promise<Agent> {
+  const agent = opts.getAgent ? await opts.getAgent(request) : opts.agent
+  if (!agent) {
+    throw Object.assign(new Error('agent session route requires agent or getAgent'), {
+      code: ErrorCode.enum.INTERNAL_ERROR,
+      statusCode: 500,
+    })
+  }
+  return agent
+}
+
+function sessionCtxFromRequest(request: FastifyRequest): { workspaceId?: string; userId?: string } {
+  const userId = (request as { user?: { id?: unknown } }).user?.id
+  return {
+    workspaceId: request.workspaceContext?.workspaceId,
+    userId: typeof userId === 'string' && userId.trim() ? userId.trim() : undefined,
+  }
+}
+
+function parseWithSchema<T>(
+  schema: z.ZodType<T, z.ZodTypeDef, unknown>,
+  value: unknown,
+  reply: FastifyReply,
+  scope: 'body' | 'params',
+): T | undefined {
+  const parsed = schema.safeParse(value)
+  if (parsed.success) return parsed.data
+  const firstIssue = parsed.error.issues[0]
+  const path = firstIssue?.path.length ? `${scope}.${firstIssue.path.map(String).join('.')}` : scope
+  reply.code(400).send({
+    error: {
+      code: ErrorCode.enum.BRIDGE_COMMAND_INVALID,
+      message: firstIssue?.message ?? 'invalid request',
+      field: path,
+    },
+  })
+  return undefined
+}
+
+function sendRouteError(reply: FastifyReply, err: unknown, fallbackMessage: string): FastifyReply {
+  const statusCode = statusCodeFromError(err)
+  const parsedCode = ErrorCode.safeParse((err as { code?: unknown })?.code)
+  const code = parsedCode.success ? parsedCode.data : ErrorCode.enum.INTERNAL_ERROR
+  const message = err instanceof Error ? err.message : fallbackMessage
+  return reply.code(statusCode).send({
+    error: {
+      code,
+      message,
+      retryable: (err as { retryable?: unknown })?.retryable === true ? true : undefined,
+      details: (err as { details?: unknown })?.details,
+    },
+  })
+}
+
+function statusCodeFromError(err: unknown): number {
+  const statusCode = (err as { statusCode?: unknown })?.statusCode
+  if (typeof statusCode === 'number' && Number.isInteger(statusCode) && statusCode >= 400 && statusCode < 600) {
+    return statusCode
+  }
+  const parsedCode = ErrorCode.safeParse((err as { code?: unknown })?.code)
+  if (parsedCode.success && parsedCode.data === ErrorCode.enum.SESSION_NOT_FOUND) return 404
+  if (parsedCode.success && parsedCode.data === ErrorCode.enum.UNAUTHORIZED) return 403
+  if (parsedCode.success && parsedCode.data === ErrorCode.enum.PAYMENT_REQUIRED) return 402
+  return 500
+}

--- a/packages/agent/src/server/http/routes/eventStream.ts
+++ b/packages/agent/src/server/http/routes/eventStream.ts
@@ -1,0 +1,196 @@
+import { Readable } from 'node:stream'
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web'
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import { z } from 'zod'
+import type { Agent } from '../../../shared/events'
+import { sessionStreamPath } from '../../../shared/events'
+import { ErrorCode } from '../../../shared/error-codes'
+import type { EventStreamStore } from '../../events/eventStreamStore'
+import { handleStreamHead, handleStreamRead } from '../../events/handleStreamRoutes'
+
+const DEFAULT_AGENT_ID = 'default'
+
+const StreamParamsSchema = z.object({
+  agentId: z.string().min(1),
+  sessionId: z.string().min(1).max(128),
+})
+
+export interface EventStreamRoutesOptions {
+  eventStore?: EventStreamStore
+  getEventStore?: (request: FastifyRequest) => EventStreamStore | Promise<EventStreamStore>
+}
+
+export type AuthorizedEventStreamRoutesOptions = EventStreamRoutesOptions & (
+  | { agent: Agent; getAgent?: never }
+  | { agent?: never; getAgent: (request: FastifyRequest) => Agent | Promise<Agent> }
+)
+
+export function eventStreamRoutes(
+  app: FastifyInstance,
+  opts: AuthorizedEventStreamRoutesOptions,
+  done: (err?: Error) => void,
+): void {
+  app.route({
+    method: 'GET',
+    url: '/api/v1/agents/:agentId/sessions/:sessionId/events/stream',
+    exposeHeadRoute: false,
+    handler: async (request, reply) => {
+      return handleEventStreamRequest('GET', opts, request, reply)
+    },
+  })
+
+  app.head('/api/v1/agents/:agentId/sessions/:sessionId/events/stream', async (request, reply) => {
+    return handleEventStreamRequest('HEAD', opts, request, reply)
+  })
+
+  done()
+}
+
+async function handleEventStreamRequest(
+  method: 'GET' | 'HEAD',
+  opts: AuthorizedEventStreamRoutesOptions,
+  request: FastifyRequest,
+  reply: FastifyReply,
+): Promise<FastifyReply | void> {
+  const params = parseParams(request, reply)
+  if (!params) return
+  if (!assertDefaultAgent(params.agentId, reply)) return
+
+  try {
+    await authorizeSession(opts, request, params.sessionId)
+    const store = await resolveEventStore(opts, request)
+    const streamPath = sessionStreamPath(params.sessionId)
+    const abortController = new AbortController()
+    const abort = () => abortController.abort()
+    reply.raw.once('close', abort)
+    request.raw.once('aborted', abort)
+    const webRequest = fastifyToWebRequest(request, abortController.signal)
+    const webResponse = method === 'HEAD'
+      ? await handleStreamHead(store, streamPath)
+      : await handleStreamRead(store, streamPath, webRequest)
+    return webResponseToFastify(webResponse, reply)
+  } catch (error) {
+    return sendRouteError(reply, error, 'event stream request failed')
+  }
+}
+
+export function fastifyToWebRequest(request: FastifyRequest, signal?: AbortSignal): Request {
+  const headers = new Headers()
+  for (const [key, value] of Object.entries(request.headers)) {
+    if (value === undefined) continue
+    if (Array.isArray(value)) {
+      for (const item of value) headers.append(key, item)
+      continue
+    }
+    headers.set(key, String(value))
+  }
+
+  const rawUrl = request.raw.url ?? request.url
+  const hostHeader = request.headers.host
+  const host = Array.isArray(hostHeader) ? hostHeader[0] : hostHeader
+  const url = rawUrl.startsWith('http')
+    ? rawUrl
+    : `${request.protocol}://${host ?? 'localhost'}${rawUrl}`
+
+  return new Request(url, {
+    method: request.method,
+    headers,
+    signal,
+  })
+}
+
+export async function webResponseToFastify(response: Response, reply: FastifyReply): Promise<FastifyReply> {
+  reply.code(response.status)
+  response.headers.forEach((value, key) => {
+    reply.header(key, value)
+  })
+  reply.header('X-Accel-Buffering', 'no')
+
+  if (response.body === null || response.status === 204 || response.status === 304) {
+    return reply.send()
+  }
+
+  return reply.send(Readable.fromWeb(response.body as NodeReadableStream<Uint8Array>))
+}
+
+function parseParams(request: FastifyRequest, reply: FastifyReply): { agentId: string; sessionId: string } | undefined {
+  const parsed = StreamParamsSchema.safeParse(request.params)
+  if (parsed.success) return parsed.data
+  reply.code(404).send({
+    error: {
+      code: ErrorCode.enum.SESSION_NOT_FOUND,
+      message: 'event stream route not found',
+    },
+  })
+  return undefined
+}
+
+function assertDefaultAgent(agentId: string, reply: FastifyReply): boolean {
+  if (agentId === DEFAULT_AGENT_ID) return true
+  reply.code(404).send({
+    error: {
+      code: ErrorCode.enum.SESSION_NOT_FOUND,
+      message: 'agent not found',
+    },
+  })
+  return false
+}
+
+async function authorizeSession(
+  opts: AuthorizedEventStreamRoutesOptions,
+  request: FastifyRequest,
+  sessionId: string,
+): Promise<void> {
+  const agent = opts.getAgent ? await opts.getAgent(request) : opts.agent
+  if (!agent) {
+    throw Object.assign(new Error('event stream route requires agent or getAgent'), {
+      code: ErrorCode.enum.INTERNAL_ERROR,
+      statusCode: 500,
+    })
+  }
+  await agent.sessions.load(sessionCtxFromRequest(request), sessionId)
+}
+
+async function resolveEventStore(opts: EventStreamRoutesOptions, request: FastifyRequest): Promise<EventStreamStore> {
+  const store = opts.getEventStore ? await opts.getEventStore(request) : opts.eventStore
+  if (!store) {
+    throw Object.assign(new Error('event stream route requires eventStore or getEventStore'), {
+      code: ErrorCode.enum.INTERNAL_ERROR,
+      statusCode: 500,
+    })
+  }
+  return store
+}
+
+function sessionCtxFromRequest(request: FastifyRequest): { workspaceId?: string; userId?: string } {
+  const userId = (request as { user?: { id?: unknown } }).user?.id
+  return {
+    workspaceId: request.workspaceContext?.workspaceId,
+    userId: typeof userId === 'string' && userId.trim() ? userId.trim() : undefined,
+  }
+}
+
+function sendRouteError(reply: FastifyReply, err: unknown, fallbackMessage: string): FastifyReply {
+  const statusCode = statusCodeFromError(err)
+  const parsedCode = ErrorCode.safeParse((err as { code?: unknown })?.code)
+  const code = parsedCode.success ? parsedCode.data : ErrorCode.enum.INTERNAL_ERROR
+  const message = err instanceof Error ? err.message : fallbackMessage
+  return reply.code(statusCode).send({
+    error: {
+      code,
+      message,
+      details: (err as { details?: unknown })?.details,
+    },
+  })
+}
+
+function statusCodeFromError(err: unknown): number {
+  const statusCode = (err as { statusCode?: unknown })?.statusCode
+  if (typeof statusCode === 'number' && Number.isInteger(statusCode) && statusCode >= 400 && statusCode < 600) {
+    return statusCode
+  }
+  const parsedCode = ErrorCode.safeParse((err as { code?: unknown })?.code)
+  if (parsedCode.success && parsedCode.data === ErrorCode.enum.SESSION_NOT_FOUND) return 404
+  if (parsedCode.success && parsedCode.data === ErrorCode.enum.UNAUTHORIZED) return 403
+  return 500
+}

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.eventStore.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.eventStore.test.ts
@@ -140,8 +140,53 @@ describe('HarnessPiChatService event store tap', () => {
       await flushAsync()
       expect(live).toEqual([])
       await expect(inner.readEvents(sessionStreamPath('s1'), { offset: '-1' })).resolves.toMatchObject({ events: [] })
+      await expect(inner.getStreamMeta(sessionStreamPath('s1'))).resolves.toMatchObject({ closed: true })
 
       if (subscription.type === 'ok') subscription.unsubscribe()
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('closes the durable stream when deleting a cold session', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const store = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      const streamPath = sessionStreamPath('s1')
+      await store.createStream(streamPath)
+      let notifications = 0
+      const unsubscribe = store.subscribe(streamPath, () => {
+        notifications += 1
+      })
+      const { service } = createService(store)
+
+      await service.deleteSession(ctx, 's1')
+
+      await expect(store.getStreamMeta(streamPath)).resolves.toMatchObject({ closed: true })
+      expect(notifications).toBeGreaterThan(0)
+      unsubscribe()
+    } finally {
+      db.db.close()
+    }
+  })
+
+  it('leaves the durable stream open when session deletion fails', async () => {
+    const db = openDatabase(':memory:')
+    try {
+      const store = new SqliteEventStreamStore(db.sql, db.runTransaction)
+      const streamPath = sessionStreamPath('s1')
+      await store.createStream(streamPath)
+      const failingStore: SessionStore = {
+        ...sessionStore,
+        delete: vi.fn(async () => {
+          throw new Error('delete failed')
+        }),
+      }
+      const { service } = createService(store, createAdapter(), failingStore)
+
+      await expect(service.deleteSession(ctx, 's1')).rejects.toThrow('delete failed')
+
+      await expect(store.getStreamMeta(streamPath)).resolves.toMatchObject({ closed: false })
     } finally {
       db.db.close()
     }

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -129,11 +129,12 @@ export class HarnessPiChatService implements PiChatSessionService {
     }
     channel?.unsubscribe()
     this.channels.delete(sessionKey)
+    await this.sessionStore.delete(sessionCtx, sessionId)
+    await this.eventStore?.closeStream(channel?.streamPath ?? sessionStreamPath(sessionId))
     this.metering?.releaseSession(sessionKey)
     this.messageMetadata.clearSession(sessionKey)
     this.syntheticPromptFailures.delete(sessionKey)
     this.activeSyntheticPromptErrors.delete(sessionKey)
-    await this.sessionStore.delete(sessionCtx, sessionId)
   }
 
   async readState(ctx: PiSessionRequestContext, sessionId: string) {
@@ -452,7 +453,8 @@ export class HarnessPiChatService implements PiChatSessionService {
         this.publishChannelEventSync(channel, enriched)
       }
       afterPublish?.(publishedEvents)
-    }).catch((error) => {
+    }).catch(async (error) => {
+      await this.eventStore?.closeStream(channel.streamPath).catch(() => {})
       channel.rejectClosed(error)
       throw error
     })

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -16,7 +16,7 @@ import type { Workspace } from '../shared/workspace'
 import { ErrorCode } from '../shared/error-codes'
 import { resolveMode, autoDetectMode } from './runtime/resolveMode'
 import { createPiCodingAgentHarness, withPiHarnessDefaults } from './harness/pi-coding-agent/createHarness'
-import { PiSessionStore } from './harness/pi-coding-agent/sessions'
+import { PiSessionStore, resolvePiSessionDir } from './harness/pi-coding-agent/sessions'
 import type { PiHarnessOptions, ResolvedPiHarnessOptions } from './harness/pi-coding-agent/createHarness'
 import { loadPlugins } from './harness/pi-coding-agent/pluginLoader'
 import { registerConfiguredModelProviders } from './models/modelConfig'
@@ -32,6 +32,8 @@ import { treeRoutes } from './http/routes/tree'
 import { modelsRoutes } from './http/routes/models'
 import { skillsRoutes } from './http/routes/skills'
 import { piChatRoutes, type PiChatSessionService } from './http/routes/piChat'
+import { eventStreamRoutes } from './http/routes/eventStream'
+import { agentSessionsRoutes } from './http/routes/agentSessions'
 import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
@@ -48,6 +50,8 @@ import type { AgentHarness } from '../shared/harness'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
 import { createAgentRuntimeBridge } from './createAgent'
+import { openEventStreamStore, type EventStreamStoreHandle } from './events/openEventStreamStore'
+import type { EventStreamStore } from './events/eventStreamStore'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_WORKSPACE_ID = 'default'
@@ -114,6 +118,8 @@ interface RuntimeBinding {
   tools: AgentTool[]
   readyTracker: ReadyStatusTracker
   piChatService: PiChatSessionService
+  eventStore: EventStreamStore
+  closeEventStore: () => void
   lastHealthCheckMs?: number
   /**
    * Diagnostics from the most recent /api/v1/agent/reload (merged hook +
@@ -357,7 +363,10 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
 
   const resolvedMode = opts.runtimeModeAdapter?.id ?? opts.mode ?? autoDetectMode()
   const modeAdapter = opts.runtimeModeAdapter ?? resolveMode(resolvedMode, { sandboxHandleStore: opts.sandboxHandleStore })
+  const eventStoreClosers = new Set<() => void>()
   app.addHook('onClose', async () => {
+    for (const closeEventStore of eventStoreClosers) closeEventStore()
+    eventStoreClosers.clear()
     await modeAdapter.dispose?.()
   })
   const requestScopedRuntime =
@@ -372,11 +381,37 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
   const externalPluginsEnabled = opts.externalPlugins !== false
   const runtimeBindings = new Map<string, RuntimeBindingEntry>()
   const MAX_RUNTIME_BINDINGS = 256
+  function trackEventStoreHandle(handle: EventStreamStoreHandle): EventStreamStoreHandle {
+    let closed = false
+    const close = () => {
+      if (closed) return
+      closed = true
+      eventStoreClosers.delete(close)
+      handle.close()
+    }
+    eventStoreClosers.add(close)
+    return { store: handle.store, close }
+  }
+
+  function closeRuntimeBindingEntry(entry: RuntimeBindingEntry | undefined): void {
+    if (!entry) return
+    void entry.promise.then(
+      (binding) => binding.closeEventStore(),
+      () => {},
+    )
+  }
+
+  function deleteRuntimeBinding(key: string): void {
+    const entry = runtimeBindings.get(key)
+    closeRuntimeBindingEntry(entry)
+    runtimeBindings.delete(key)
+  }
+
   function evictRuntimeBindings(): void {
     if (runtimeBindings.size <= MAX_RUNTIME_BINDINGS) return
     const keys = Array.from(runtimeBindings.keys())
     for (let i = 0; i < keys.length - MAX_RUNTIME_BINDINGS; i++) {
-      runtimeBindings.delete(keys[i])
+      deleteRuntimeBinding(keys[i] as string)
     }
   }
 
@@ -678,43 +713,56 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       sessionNamespace: scope.sessionNamespace,
       sessionRoot: opts.sessionRoot,
     })) as AgentCoreHarnessFactory
-    const coreAgent = createAgentRuntimeBridge({
-      runtime: modeAdapter,
-      tools,
-      harnessFactory,
-      systemPromptAppend: opts.systemPromptAppend,
-      systemPromptDynamic,
-      telemetry: opts.telemetry,
-      metering: opts.metering,
-      sessionStorageRoot: opts.sessionRoot,
-      workdir: root,
-    }, {
-      service: {
-        workdir: runtimeBundle.workspace.root,
-        workspace: runtimeBundle.workspace,
-      },
-    })
-    const agentRuntime = await coreAgent.getRuntime()
-    const harness = agentRuntime.harness
-    readyTracker.markHarnessReady()
+    const eventStoreHandle = trackEventStoreHandle(openEventStreamStore(resolvePiSessionDir(runtimeBundle.workspace.root, {
+      sessionNamespace: scope.sessionNamespace,
+      sessionRoot: opts.sessionRoot,
+      storageCwd: root,
+    })))
+    try {
+      const coreAgent = createAgentRuntimeBridge({
+        runtime: modeAdapter,
+        tools,
+        harnessFactory,
+        systemPromptAppend: opts.systemPromptAppend,
+        systemPromptDynamic,
+        telemetry: opts.telemetry,
+        metering: opts.metering,
+        sessionStorageRoot: opts.sessionRoot,
+        workdir: root,
+      }, {
+        service: {
+          workdir: runtimeBundle.workspace.root,
+          workspace: runtimeBundle.workspace,
+          eventStore: eventStoreHandle.store,
+        },
+      })
+      const agentRuntime = await coreAgent.getRuntime()
+      const harness = agentRuntime.harness
+      readyTracker.markHarnessReady()
 
-    binding = {
-      runtimeBundle,
-      runtimeProvisioning,
-      runtimeDependencies,
-      runtimeProvisioningTask: undefined,
-      reprovision: async (reloadRequest?: FastifyRequest) => {
-        const result = await startRuntimeProvisioning(reloadRequest)
-        return await result
-      },
-      agent: coreAgent.agent,
-      harness,
-      tools,
-      readyTracker,
-      piChatService: agentRuntime.service as PiChatSessionService,
+      binding = {
+        runtimeBundle,
+        runtimeProvisioning,
+        runtimeDependencies,
+        runtimeProvisioningTask: undefined,
+        reprovision: async (reloadRequest?: FastifyRequest) => {
+          const result = await startRuntimeProvisioning(reloadRequest)
+          return await result
+        },
+        agent: coreAgent.agent,
+        harness,
+        tools,
+        readyTracker,
+        piChatService: agentRuntime.service as PiChatSessionService,
+        eventStore: eventStoreHandle.store,
+        closeEventStore: eventStoreHandle.close,
+      }
+      startRuntimeProvisioning(request)
+      return binding
+    } catch (error) {
+      eventStoreHandle.close()
+      throw error
     }
-    startRuntimeProvisioning(request)
-    return binding
   }
 
   function createRuntimeBindingEntry(
@@ -754,7 +802,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       }
       if (existing.state === 'failed') {
         if (options.failIfPending) throw createRuntimeProvisioningFailedError(workspaceId, existing.error)
-        runtimeBindings.delete(scope.key)
+        deleteRuntimeBinding(scope.key)
       } else {
         return await ensureRuntimeBindingReady(
           workspaceId,
@@ -779,7 +827,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
         request,
       )
     } catch (error) {
-      if (runtimeBindings.get(scope.key) === created) runtimeBindings.delete(scope.key)
+      if (runtimeBindings.get(scope.key) === created) deleteRuntimeBinding(scope.key)
       throw error
     }
   }
@@ -789,7 +837,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
     scope: RuntimeScope,
     request?: FastifyRequest,
   ): Promise<RuntimeBinding> {
-    runtimeBindings.delete(scope.key)
+    deleteRuntimeBinding(scope.key)
     modeAdapter.evictCachedRuntime?.({ workspaceId })
 
     const created = createRuntimeBindingEntry(workspaceId, scope, request)
@@ -800,7 +848,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       binding.lastHealthCheckMs = Date.now()
       return binding
     } catch (error) {
-      if (runtimeBindings.get(scope.key) === created) runtimeBindings.delete(scope.key)
+      if (runtimeBindings.get(scope.key) === created) deleteRuntimeBinding(scope.key)
       throw error
     }
   }
@@ -971,6 +1019,17 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       return binding.piChatService
     },
   })
+  await app.register(eventStreamRoutes, staticBinding
+    ? { agent: staticBinding.agent, eventStore: staticBinding.eventStore }
+    : {
+        getAgent: async (request) => (await getBindingForRequest(request)).agent,
+        getEventStore: async (request) => (await getBindingForRequest(request)).eventStore,
+      },
+  )
+  await app.register(agentSessionsRoutes, staticBinding
+    ? { agent: staticBinding.agent }
+    : { getAgent: async (request) => (await getBindingForRequest(request)).agent },
+  )
   await app.register(systemPromptRoutes, {
     getHarness: async (request) => (await getBindingForRequest(request)).harness,
   })


### PR DESCRIPTION
Third T1 slice: the durable-streams HTTP surface over the merged `EventStreamStore` (#531) + envelope tap (#535).

## What
- Canonical agent routes under `/api/v1/agents/:agentId/...` — only the explicit `default` segment is accepted; absent or unknown agent ids 404 (the P7 multi-agent namespace rule, enforced from day one)
- `agent.stream(sessionId, { startIndex })` now replays from the durable store by per-session `eventIndex`, then live-tails — the T1 upgrade of the P1 live-tail contract, same signature
- DS wire route (`eventStream.ts`): catch-up reads, HEAD, 304, SSE, long-poll, `Stream-*` headers, replay after SSE disconnect
- Lifecycle hardening: event-stream route **fails closed without a session authorizer**; `stop()`/`dispose()` close durable streams so tailers terminate; `start()` reopens a closed stream for later turns; session delete closes the stream only after store delete succeeds
- Existing pi-chat HTTP routes are untouched — additive only

## Review guide (~15 min)
1. `src/server/http/routes/eventStream.ts` — the DS route; check the authorizer requirement and the 404-on-non-default rule
2. `createAgent.ts` — stream replay + lifecycle (stop/dispose/reopen)
3. `agentSessions.ts` — delete ordering
4. Regression tests for each hardening point

## Gates (all PASS)
agent typecheck / test (194 files, 1617 passed) / `check:isolation`; repo `lint:invariants` + `audit:imports`; autoreview clean (0.78).

## LOC
Production +1163 net-new (cap 2k ✅) / tests +782.

Work order: `docs/issues/391/runtime-refactor/work/T1-durable-events/TODO.md` bead BBT1-003 (PR-PLAN `pr3-ds-routes-stream`). Based on main, not stacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)