### PR TITLE
chore: publish @hachej/boring-governance + boring-bash to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -632,12 +632,14 @@ jobs:
           pnpm --filter @hachej/boring-generated-pane build
           pnpm --filter @hachej/boring-data-bridge build
           pnpm --filter @hachej/boring-bi-dashboard build
+          pnpm --filter @hachej/boring-bash build
+          pnpm --filter @hachej/boring-governance build
         env:
           NODE_OPTIONS: --max-old-space-size=4096
 
       - name: Publish packages with ci dist-tag
         run: |
-          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core packages/cli plugins/deck plugins/ask-user plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard; do
+          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core packages/cli plugins/deck plugins/ask-user plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-bash plugins/boring-governance; do
             tarball=$(cd $pkg && pnpm pack 2>&1 | tail -1)
             if ! npm publish "$pkg/$tarball" --access public --tag ci --provenance; then
               echo "::warning::CI package publish failed for $pkg; continuing because release publishing is handled by release.yml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,8 @@ jobs:
             --filter @hachej/boring-generated-pane \
             --filter @hachej/boring-data-bridge \
             --filter @hachej/boring-bi-dashboard \
+            --filter @hachej/boring-bash \
+            --filter @hachej/boring-governance \
             --workspace-concurrency=4 \
             run build
           pnpm --filter @hachej/boring-ui-cli build:full
@@ -64,7 +66,7 @@ jobs:
 
       - name: Publish
         run: |
-          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core plugins/deck plugins/ask-user packages/cli plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard; do
+          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core plugins/deck plugins/ask-user packages/cli plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-bash plugins/boring-governance; do
             name=$(node -p "require('./$pkg/package.json').name")
             version=$(node -p "require('./$pkg/package.json').version")
             if npm view "$name@$version" version >/dev/null 2>&1; then

--- a/packages/boring-bash/package.json
+++ b/packages/boring-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-bash",
-  "version": "0.1.61",
+  "version": "0.1.64",
   "type": "module",
   "license": "MIT",
   "description": "Filesystem and shell binding contracts for Boring runtimes.",

--- a/plugins/boring-governance/package.json
+++ b/plugins/boring-governance/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@hachej/boring-governance",
-  "version": "0.0.0",
+  "version": "0.1.64",
   "type": "module",
-  "private": true,
+  "private": false,
   "license": "MIT",
   "description": "Reusable boring-ui tenant governance plugin: YAML policy loading, model filtering, budget metering, company-context bindings, and Company Admin UI.",
   "repository": {

--- a/scripts/audit-publish-manifests.mjs
+++ b/scripts/audit-publish-manifests.mjs
@@ -29,6 +29,8 @@ const PUBLISHABLE_PACKAGES = [
   "plugins/generated-pane",
   "plugins/data-bridge",
   "plugins/bi-dashboard",
+  "packages/boring-bash",
+  "plugins/boring-governance",
 ]
 
 const DEP_SECTIONS = [

--- a/scripts/set-ci-package-version.mjs
+++ b/scripts/set-ci-package-version.mjs
@@ -28,6 +28,8 @@ const PUBLISHABLE = [
   "plugins/generated-pane",
   "plugins/data-bridge",
   "plugins/bi-dashboard",
+  "packages/boring-bash",
+  "plugins/boring-governance",
 ]
 
 function readJson(path) {

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -24,6 +24,8 @@ const PUBLISHABLE = [
   "plugins/generated-pane",
   "plugins/data-bridge",
   "plugins/bi-dashboard",
+  "packages/boring-bash",
+  "plugins/boring-governance",
 ]
 
 function readJson(path) {


### PR DESCRIPTION
## Summary
- Constellation (external repo) needs `@hachej/boring-governance` installable from npm.
- Governance peer-depends on `@hachej/boring-bash`, so this adds both packages to all five publish lists: manifest audit, version bumping, CI versioning, CI publish, and release publish.
- Keeps `packages/boring-bash` ordered before `plugins/boring-governance` everywhere because governance depends on boring-bash.
- Sets both packages to the current cohort version `0.1.64`; governance is now publishable (`private: false`).
- Leaves governance peer dependencies as `workspace:*`; pnpm rewrites them at pack time.

## Verification
### `pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-governance build`
```
> @hachej/boring-bash@0.1.64 build /home/ubuntu/projects/boring-ui-v2-475-fixes/packages/boring-bash
> tsup

CLI Building entry: {"index":"src/index.ts","shared/index":"src/shared/index.ts","server/index":"src/server/index.ts"}
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /home/ubuntu/projects/boring-ui-v2-475-fixes/packages/boring-bash/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
ESM dist/shared/index.js 0 B
ESM dist/index.js        0 B
ESM dist/server/index.js 29.32 KB
ESM ⚡️ Build success in 39ms
DTS Build start
DTS ⚡️ Build success in 6440ms
DTS dist/server/index.d.ts 11.02 KB
DTS dist/shared/index.d.ts 2.06 KB
DTS dist/index.d.ts        234.00 B

> @hachej/boring-governance@0.1.64 build /home/ubuntu/projects/boring-ui-v2-475-fixes/plugins/boring-governance
> tsup

CLI Building entry: {"front/index":"src/front/index.tsx","server/index":"src/server/index.ts"}
CLI Using tsconfig: tsconfig.json
CLI tsup v8.5.1
CLI Using tsup config: /home/ubuntu/projects/boring-ui-v2-475-fixes/plugins/boring-governance/tsup.config.ts
CLI Target: es2022
CLI Cleaning output folder
ESM Build start
ESM dist/front/index.js  10.94 KB
ESM dist/server/index.js 36.58 KB
ESM ⚡️ Build success in 65ms
DTS Build start
DTS ⚡️ Build success in 11900ms
DTS dist/front/index.d.ts  1.91 KB
DTS dist/server/index.d.ts 7.34 KB
```

### `pnpm --filter @hachej/boring-governance run typecheck && pnpm --filter full-app run typecheck`
```
> @hachej/boring-governance@0.1.64 typecheck /home/ubuntu/projects/boring-ui-v2-475-fixes/plugins/boring-governance
> tsc --noEmit


> full-app@0.0.1 typecheck /home/ubuntu/projects/boring-ui-v2-475-fixes/apps/full-app
> tsc --noEmit
```

### `pnpm audit:publish-manifests`
```
> boring-ui-v2@ audit:publish-manifests /home/ubuntu/projects/boring-ui-v2-475-fixes
> node scripts/audit-publish-manifests.mjs

✓ @hachej/boring-ui-kit@0.1.64 manifest ok
✓ @hachej/boring-agent@0.1.64 manifest ok
✓ @hachej/boring-ui-plugin-cli@0.1.64 manifest ok
✓ @hachej/boring-workspace@0.1.64 manifest ok
✓ @hachej/boring-core@0.1.64 manifest ok
✓ @hachej/boring-deck@0.1.64 manifest ok
✓ @hachej/boring-ask-user@0.1.64 manifest ok
✓ @hachej/boring-ui-cli@0.1.64 manifest ok
✓ @hachej/boring-data-explorer@0.1.64 manifest ok
✓ @hachej/boring-data-catalog@0.1.64 manifest ok
✓ @hachej/boring-generated-pane@0.1.64 manifest ok
✓ @hachej/boring-data-bridge@0.1.64 manifest ok
✓ @hachej/boring-bi-dashboard@0.1.64 manifest ok
✓ @hachej/boring-bash@0.1.64 manifest ok
✓ @hachej/boring-governance@0.1.64 manifest ok

All publish manifests are safe to publish.
```

### `grep -n "boring-bash\|boring-governance" scripts/audit-publish-manifests.mjs scripts/version.mjs scripts/set-ci-package-version.mjs .github/workflows/ci.yml .github/workflows/release.yml`
```
scripts/audit-publish-manifests.mjs:32:  "packages/boring-bash",
scripts/audit-publish-manifests.mjs:33:  "plugins/boring-governance",
scripts/version.mjs:27:  "packages/boring-bash",
scripts/version.mjs:28:  "plugins/boring-governance",
scripts/set-ci-package-version.mjs:31:  "packages/boring-bash",
scripts/set-ci-package-version.mjs:32:  "plugins/boring-governance",
.github/workflows/ci.yml:635:          pnpm --filter @hachej/boring-bash build
.github/workflows/ci.yml:636:          pnpm --filter @hachej/boring-governance build
.github/workflows/ci.yml:642:          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core packages/cli plugins/deck plugins/ask-user plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-bash plugins/boring-governance; do
.github/workflows/release.yml:58:            --filter @hachej/boring-bash \
.github/workflows/release.yml:59:            --filter @hachej/boring-governance \
.github/workflows/release.yml:69:          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core plugins/deck plugins/ask-user packages/cli plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-bash plugins/boring-governance; do
```
