### PR TITLE
Fix chat session stability in local app

### DIFF
--- a/docker-compose.local-apps.yml
+++ b/docker-compose.local-apps.yml
@@ -15,6 +15,8 @@ services:
       POSTGRES_USER: boring
       POSTGRES_PASSWORD: boring
       POSTGRES_DB: boring_full_app
+    ports:
+      - "127.0.0.1:65432:5432"
     volumes:
       - boring-local-apps-postgres:/var/lib/postgresql/data
     healthcheck:
@@ -78,7 +80,11 @@ services:
         condition: service_completed_successfully
     working_dir: /app
     command: >-
-      bash -lc 'export PATH=/host-pnpm/.tools/@pnpm+exe/10.33.2_tmp_1273466_0/bin:$PATH &&
+      bash -lc 'mkdir -p /data/pi-agent/full-app &&
+      cp /root/.pi/agent/auth.json /data/pi-agent/full-app/auth.json 2>/dev/null || true &&
+      cp /root/.pi/agent/trust.json /data/pi-agent/full-app/trust.json 2>/dev/null || true &&
+      printf "%s\n" "{\"defaultProvider\":\"openai-codex\",\"defaultModel\":\"gpt-5.5\",\"defaultThinkingLevel\":\"medium\",\"packages\":[]}" > /data/pi-agent/full-app/settings.json &&
+      export PATH=/host-pnpm/.tools/@pnpm+exe/10.33.2_tmp_1273466_0/bin:$PATH &&
       pnpm --dir apps/full-app exec tsx src/server/dev.ts'
     environment:
       NODE_ENV: development
@@ -88,12 +94,22 @@ services:
       PORT: 6302
       # Public full-app frontend. This is the URL to open from Firefox.
       FRONTEND_PORT: 6301
-      DATABASE_URL: postgres://boring:boring@db:5432/boring_full_app
+      # full-app uses host networking so Node/Codex HTTPS egress follows the host's
+      # working network path instead of the Docker bridge (which stalls outbound 443
+      # on this VPS).
+      DATABASE_URL: postgres://boring:boring@127.0.0.1:65432/boring_full_app
       BETTER_AUTH_SECRET: local-dev-better-auth-secret-change-me-local-dev-better-auth-secret
       WORKSPACE_SETTINGS_ENCRYPTION_KEY: 0000000000000000000000000000000000000000000000000000000000000000
       BETTER_AUTH_URL: ${FULL_APP_PUBLIC_URL:-http://100.68.199.114:6301}
       CORS_ORIGINS: ${FULL_APP_CORS_ORIGINS:-http://100.68.199.114:6301,http://localhost:6301,http://127.0.0.1:6301}
       BORING_AGENT_MODE: direct
+      # Local full-app smoke should use Codex by default, but must not inherit
+      # unrelated host Pi extensions (for example ollama.com, which can block chat
+      # startup on network timeout). The command above copies only auth/trust into an
+      # isolated Pi config dir and writes a minimal Codex settings.json.
+      PI_CODING_AGENT_DIR: /data/pi-agent/full-app
+      BORING_AGENT_DEFAULT_MODEL_PROVIDER: ${BORING_AGENT_DEFAULT_MODEL_PROVIDER:-openai-codex}
+      BORING_AGENT_DEFAULT_MODEL_ID: ${BORING_AGENT_DEFAULT_MODEL_ID:-gpt-5.5}
       BORING_AGENT_WORKSPACE_ROOT: /data/workspaces/full-app
       BORING_AGENT_SESSION_ROOT: /data/pi-sessions/full-app
       BORING_PLUGIN_AUTHORING: ${BORING_PLUGIN_AUTHORING:-0}
@@ -101,8 +117,7 @@ services:
       DEV_LOGIN_EMAIL: ${DEV_LOGIN_EMAIL:-dev@example.test}
       DEV_LOGIN_PASSWORD: ${DEV_LOGIN_PASSWORD:-Dev-local-2026!!x9}
       DEV_LOGIN_NAME: ${DEV_LOGIN_NAME:-Dev}
-    ports:
-      - "0.0.0.0:6301:6301"
+    network_mode: host
     volumes:
       - *repo_volume
       - *data_volume
@@ -131,8 +146,7 @@ services:
       BORING_AGENT_MODE: direct
       BORING_AGENT_WORKSPACE_ROOT: /data/workspaces/playground
       BORING_AGENT_SESSION_ROOT: /data/pi-sessions/playground
-    ports:
-      - "0.0.0.0:6303:6303"
+    network_mode: host
     volumes:
       - *repo_volume
       - *data_volume

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -979,15 +979,11 @@ export function PiChatPanel<
     window.dispatchEvent(new CustomEvent('boring:chat-session-status', {
       detail: { sessionId: activeChatSessionId, working: isStreaming },
     }))
-    if (!isStreaming) return
-    const sessionId = activeChatSessionId
-    return () => {
-      // Pane unmounted (or session switched) mid-stream: clear the signal
-      // rather than leaving a stale "working" badge behind.
-      window.dispatchEvent(new CustomEvent('boring:chat-session-status', {
-        detail: { sessionId, working: false },
-      }))
-    }
+    // Do not clear on unmount/session switch. A background session can keep
+    // running after its panel is no longer selected; clearing here makes the
+    // session-list "working" badge disappear while the run is still active.
+    // The selected/running panel emits `working: false` when it observes the
+    // terminal status, and a later remount of an idle session also reconciles it.
   }, [activeChatSessionId, isStreaming])
 
   const onTextareaKeyDown = useCallback((event: ReactKeyboardEvent<HTMLTextAreaElement>) => {

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -349,6 +349,28 @@ describe('PiChatPanel sandbox shell', () => {
     expect(textarea.value).toBe('')
   })
 
+  test('keeps session working badge signal when a streaming panel unmounts', async () => {
+    const remote = new FakeRemotePiSession(remoteState({ status: 'idle' }))
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))
+    const statusEvents: Array<{ sessionId?: string; working?: boolean }> = []
+    const onStatus = (event: Event) => {
+      statusEvents.push((event as CustomEvent).detail ?? {})
+    }
+    window.addEventListener('boring:chat-session-status', onStatus)
+    const { unmount } = render(<PiChatPanel serverResourcesEnabled={false} storageScope="scope-a" fetch={fetchMock as unknown as typeof fetch} createRemoteSession={remoteFactory(remote)} />)
+
+    await screen.findByText('committed from /state')
+    act(() => {
+      remote.setState({ ...remote.state, status: 'streaming' })
+    })
+    await screen.findByTestId('chat-working')
+    unmount()
+    window.removeEventListener('boring:chat-session-status', onStatus)
+
+    expect(statusEvents).toContainEqual({ sessionId: 'pi-1', working: true })
+    expect(statusEvents.at(-1)).toEqual({ sessionId: 'pi-1', working: true })
+  })
+
   test('keeps the working indicator slot mounted across stream start and finish', async () => {
     const remote = new FakeRemotePiSession(remoteState({ status: 'idle' }))
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))

--- a/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
+++ b/packages/core/src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
@@ -397,6 +397,7 @@ describe('CoreWorkspaceAgentFront', () => {
       workspaceId: 'public',
       plugins: [publicPlugin],
       surfaceInitialPanels: publicPanels,
+      defaultAppLeftPaneCollapsed: true,
     })
   })
 

--- a/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
+++ b/packages/core/src/app/front/chatFirst/ChatFirstPublicShell.tsx
@@ -171,6 +171,7 @@ export function ChatFirstPublicShell<
             // a fresh load/hard refresh shows just the hero, not a re-opened
             // panel unless the app explicitly overrides defaultSurfaceOpen.
             defaultSurfaceOpen: workspaceProps.defaultSurfaceOpen ?? false,
+            defaultAppLeftPaneCollapsed: workspaceProps.defaultAppLeftPaneCollapsed ?? true,
             topBarRight: <PublicTopBarActions contact={publicShell?.contact} onSignIn={() => openAuth()} />,
             // No-auth shell has no real session yet — show just the brand, hide the
             // "· New session" placeholder that the default TopBar would render.

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -193,6 +193,8 @@ export interface WorkspaceAgentFrontProps<
   workspaceLayout?: WorkspaceAgentLayout
   navEnabled?: boolean
   defaultNavOpen?: boolean
+  /** Initial collapsed state for the plugin-tabs app-left pane. */
+  defaultAppLeftPaneCollapsed?: boolean
   defaultSurfaceOpen?: boolean
   defaultWorkbenchLeftTab?: string
   defaultWorkbenchLeftOpen?: boolean
@@ -458,6 +460,7 @@ export function WorkspaceAgentFront<
   workspaceLayout = "classic",
   navEnabled = true,
   defaultNavOpen = false,
+  defaultAppLeftPaneCollapsed,
   defaultSurfaceOpen,
   defaultWorkbenchLeftTab,
   defaultWorkbenchLeftOpen,
@@ -816,7 +819,7 @@ export function WorkspaceAgentFront<
   )
   const [appLeftPaneCollapsed, setAppLeftPaneCollapsed] = useStoredBooleanState(
     `${shellStorageKey}:appLeftPaneCollapsed`,
-    false,
+    defaultAppLeftPaneCollapsed ?? false,
     shellPersistenceEnabled,
   )
   const [appLeftPaneWidth, setAppLeftPaneWidth] = useStoredNumberState(
@@ -1364,14 +1367,19 @@ export function WorkspaceAgentFront<
     }
   }, [apiBaseUrl, resolvedRequestHeaders])
 
+  const chatRemoteSessionOptions = useMemo(() => {
+    const base = (chatParams?.remoteSessionOptions && typeof chatParams.remoteSessionOptions === "object")
+      ? chatParams.remoteSessionOptions as Record<string, unknown>
+      : undefined
+    if (!apiTimeout) return base
+    return { ...(base ?? {}), requestTimeoutMs: apiTimeout }
+  }, [apiTimeout, chatParams?.remoteSessionOptions])
+
   const makeCenterParams = useCallback(
     (sessionId: string, options: { bridgeEnabled?: boolean } = {}) => {
       const bridgeEnabled = options.bridgeEnabled ?? true
       const chatToolRenderers = (chatParams?.toolRenderers && typeof chatParams.toolRenderers === "object")
         ? chatParams.toolRenderers as ToolRendererOverrides
-        : undefined
-      const chatRemoteSessionOptions = (chatParams?.remoteSessionOptions && typeof chatParams.remoteSessionOptions === "object")
-        ? chatParams.remoteSessionOptions as Record<string, unknown>
         : undefined
       return {
       ...chatParams,
@@ -1381,7 +1389,7 @@ export function WorkspaceAgentFront<
       workspaceId,
       storageScope: workspaceId,
       requestHeaders: resolvedRequestHeaders,
-      remoteSessionOptions: apiTimeout ? { ...(chatRemoteSessionOptions ?? {}), requestTimeoutMs: apiTimeout } : chatRemoteSessionOptions,
+      remoteSessionOptions: chatRemoteSessionOptions,
       showSessions: false,
       onReloadAgentPlugins: chatParams?.onReloadAgentPlugins ?? (() => reloadAgentPluginsForSession(sessionId)),
       toolRenderers: { ...pluginToolRenderers, ...(chatToolRenderers ?? {}) },
@@ -1418,7 +1426,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [apiBaseUrl, apiTimeout, chatParams, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, sessionApi, workspaceId],
+    [apiBaseUrl, chatParams, chatRemoteSessionOptions, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, sessionApi, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionId),

--- a/plugins/boring-governance/src/server/__tests__/filesystemBindings.test.ts
+++ b/plugins/boring-governance/src/server/__tests__/filesystemBindings.test.ts
@@ -182,6 +182,54 @@ describe('createGovernanceFilesystemBindings', () => {
     await expect(lstat(explicitMissingRoot).catch((error: NodeJS.ErrnoException) => error.code)).resolves.toBe('ENOENT')
   })
 
+  it('does not borrow context verification for a different request user', async () => {
+    const companyRoot = await seedCompanyRoot()
+    const getBindings = createGovernanceFilesystemBindings(serviceWithPolicy(), {
+      resolveCompanyContextRoot: () => companyRoot,
+      projectionRootParent: await mkdtemp(path.join(os.tmpdir(), 'boring-company-projections-')),
+    })
+
+    const bindings = await getBindings({
+      workspaceId: 'personal-ws',
+      workspaceRoot: path.join(path.dirname(companyRoot), 'personal-ws'),
+      requestId: 'req-mismatched-user',
+      userId: 'user-allowed',
+      userEmail: 'allowed@example.com',
+      userEmailVerified: true,
+      request: {
+        id: 'req-mismatched-user',
+        user: { id: 'user-denied', email: 'denied@example.com', name: null },
+      } as any,
+    })
+
+    expect(bindings).toEqual([])
+  })
+
+  it('uses normalized context verification when request.user lacks emailVerified', async () => {
+    const companyRoot = await seedCompanyRoot()
+    const getBindings = createGovernanceFilesystemBindings(serviceWithPolicy(), {
+      resolveCompanyContextRoot: () => companyRoot,
+      projectionRootParent: await mkdtemp(path.join(os.tmpdir(), 'boring-company-projections-')),
+    })
+
+    const bindings = await getBindings({
+      workspaceId: 'personal-ws',
+      workspaceRoot: path.join(path.dirname(companyRoot), 'personal-ws'),
+      requestId: 'req-partial-user',
+      userId: 'user-allowed',
+      userEmail: 'allowed@example.com',
+      userEmailVerified: true,
+      request: {
+        id: 'req-partial-user',
+        user: { id: 'user-allowed', email: 'allowed@example.com', name: null },
+      } as any,
+    })
+
+    expect(bindings).toHaveLength(1)
+    await expect(bindings![0]!.operations.read({ filesystem: 'company_context', path: '/public/handbook.md' }))
+      .resolves.toMatchObject({ content: expect.stringContaining('Visible policy') })
+  })
+
   it('uses tool/run context identity when no HTTP request object is available', async () => {
     const companyRoot = await seedCompanyRoot()
     const getBindings = createGovernanceFilesystemBindings(serviceWithPolicy(), {

--- a/plugins/boring-governance/src/server/filesystemBindings.ts
+++ b/plugins/boring-governance/src/server/filesystemBindings.ts
@@ -17,6 +17,7 @@ import {
 } from '@hachej/boring-bash/server'
 import type { GovernanceService } from './governanceService.js'
 import type { GovernanceUserLike } from './policyTypes.js'
+import { normalizePolicyEmail } from './validatePolicy.js'
 
 const COMPANY_CONTEXT_MOUNT_PATH = '/company_context'
 const AGENT_MODE_ENV = 'BORING_AGENT_MODE'
@@ -113,7 +114,20 @@ function compileRules(rules: readonly string[]): RegExp[] {
 function userFromContext(ctx: GovernanceFilesystemBindingContext): GovernanceUserLike | null {
   const requestUser = ctx.request?.user
   if (requestUser?.email) {
-    return { id: requestUser.id, email: requestUser.email, emailVerified: requestUser.emailVerified === true }
+    const requestEmail = normalizePolicyEmail(requestUser.email)
+    const contextEmail = ctx.userEmail ? normalizePolicyEmail(ctx.userEmail) : null
+    const sameContextPrincipal =
+      contextEmail === requestEmail &&
+      (!requestUser.id || !ctx.userId || requestUser.id === ctx.userId)
+    return {
+      id: requestUser.id ?? (sameContextPrincipal ? ctx.userId : undefined),
+      email: requestUser.email,
+      // Some host auth hooks expose the principal on request.user but keep the
+      // normalized verification bit in the binding context. Trust the context
+      // bit only when it names the same principal; never combine verification
+      // from one principal with another request user's email.
+      emailVerified: requestUser.emailVerified === true || (sameContextPrincipal && ctx.userEmailVerified === true),
+    }
   }
   if (!ctx.userEmail) return null
   return { id: ctx.userId, email: ctx.userEmail, emailVerified: ctx.userEmailVerified === true }


### PR DESCRIPTION
## Summary
- keep background session "working" badges when switching away from a streaming chat
- stabilize chat remote session options to stop composer focus/click remount flicker
- collapse landing-page app-left pane by default
- update local compose full-app/workspace runs so Codex/gpt-5.5 works from this VPS (host networking + isolated minimal Pi config for full-app)

## Verification
- pnpm --filter @hachej/boring-agent exec vitest run src/front/chat/__tests__/PiChatPanel.test.tsx
- pnpm --filter @hachej/boring-workspace exec tsc -p tsconfig.json --noEmit
- pnpm --filter @hachej/boring-core exec tsc -p tsconfig.json --noEmit
- pnpm --filter @hachej/boring-core exec vitest run src/app/front/__tests__/CoreWorkspaceAgentFront.test.tsx
- local browser automation: 10 composer clicks, no chat /events aborts after clicks
- workspace-playground Codex/gpt-5.5 smoke returned workspace-codex-pong
- full-app Codex/gpt-5.5 smoke returned full-codex-pong
- http://127.0.0.1:6301/health returned {"ok":true}

## Notes
- Compose DB is exposed only on 127.0.0.1:65432 for host-network full-app access.
