### PR TITLE
Fix governance company-context principal validation

### DIFF
--- a/plugins/boring-governance/src/server/__tests__/filesystemBindings.test.ts
+++ b/plugins/boring-governance/src/server/__tests__/filesystemBindings.test.ts
@@ -182,6 +182,54 @@ describe('createGovernanceFilesystemBindings', () => {
     await expect(lstat(explicitMissingRoot).catch((error: NodeJS.ErrnoException) => error.code)).resolves.toBe('ENOENT')
   })
 
+  it('does not borrow context verification for a different request user', async () => {
+    const companyRoot = await seedCompanyRoot()
+    const getBindings = createGovernanceFilesystemBindings(serviceWithPolicy(), {
+      resolveCompanyContextRoot: () => companyRoot,
+      projectionRootParent: await mkdtemp(path.join(os.tmpdir(), 'boring-company-projections-')),
+    })
+
+    const bindings = await getBindings({
+      workspaceId: 'personal-ws',
+      workspaceRoot: path.join(path.dirname(companyRoot), 'personal-ws'),
+      requestId: 'req-mismatched-user',
+      userId: 'user-allowed',
+      userEmail: 'allowed@example.com',
+      userEmailVerified: true,
+      request: {
+        id: 'req-mismatched-user',
+        user: { id: 'user-denied', email: 'denied@example.com', name: null },
+      } as any,
+    })
+
+    expect(bindings).toEqual([])
+  })
+
+  it('uses normalized context verification when request.user lacks emailVerified', async () => {
+    const companyRoot = await seedCompanyRoot()
+    const getBindings = createGovernanceFilesystemBindings(serviceWithPolicy(), {
+      resolveCompanyContextRoot: () => companyRoot,
+      projectionRootParent: await mkdtemp(path.join(os.tmpdir(), 'boring-company-projections-')),
+    })
+
+    const bindings = await getBindings({
+      workspaceId: 'personal-ws',
+      workspaceRoot: path.join(path.dirname(companyRoot), 'personal-ws'),
+      requestId: 'req-partial-user',
+      userId: 'user-allowed',
+      userEmail: 'allowed@example.com',
+      userEmailVerified: true,
+      request: {
+        id: 'req-partial-user',
+        user: { id: 'user-allowed', email: 'allowed@example.com', name: null },
+      } as any,
+    })
+
+    expect(bindings).toHaveLength(1)
+    await expect(bindings![0]!.operations.read({ filesystem: 'company_context', path: '/public/handbook.md' }))
+      .resolves.toMatchObject({ content: expect.stringContaining('Visible policy') })
+  })
+
   it('uses tool/run context identity when no HTTP request object is available', async () => {
     const companyRoot = await seedCompanyRoot()
     const getBindings = createGovernanceFilesystemBindings(serviceWithPolicy(), {

--- a/plugins/boring-governance/src/server/filesystemBindings.ts
+++ b/plugins/boring-governance/src/server/filesystemBindings.ts
@@ -17,6 +17,7 @@ import {
 } from '@hachej/boring-bash/server'
 import type { GovernanceService } from './governanceService.js'
 import type { GovernanceUserLike } from './policyTypes.js'
+import { normalizePolicyEmail } from './validatePolicy.js'
 
 const COMPANY_CONTEXT_MOUNT_PATH = '/company_context'
 const AGENT_MODE_ENV = 'BORING_AGENT_MODE'
@@ -113,7 +114,20 @@ function compileRules(rules: readonly string[]): RegExp[] {
 function userFromContext(ctx: GovernanceFilesystemBindingContext): GovernanceUserLike | null {
   const requestUser = ctx.request?.user
   if (requestUser?.email) {
-    return { id: requestUser.id, email: requestUser.email, emailVerified: requestUser.emailVerified === true }
+    const requestEmail = normalizePolicyEmail(requestUser.email)
+    const contextEmail = ctx.userEmail ? normalizePolicyEmail(ctx.userEmail) : null
+    const sameContextPrincipal =
+      contextEmail === requestEmail &&
+      (!requestUser.id || !ctx.userId || requestUser.id === ctx.userId)
+    return {
+      id: requestUser.id ?? (sameContextPrincipal ? ctx.userId : undefined),
+      email: requestUser.email,
+      // Some host auth hooks expose the principal on request.user but keep the
+      // normalized verification bit in the binding context. Trust the context
+      // bit only when it names the same principal; never combine verification
+      // from one principal with another request user's email.
+      emailVerified: requestUser.emailVerified === true || (sameContextPrincipal && ctx.userEmailVerified === true),
+    }
   }
   if (!ctx.userEmail) return null
   return { id: ctx.userId, email: ctx.userEmail, emailVerified: ctx.userEmailVerified === true }


### PR DESCRIPTION
## Summary
- prevents company-context filesystem bindings from borrowing verification from a mismatched request/context principal
- still allows hosts that put a partial user on request.user to use the normalized verified context when it names the same principal
- adds regression coverage for mismatched and partial-principal cases

## Tests
- pnpm --filter @hachej/boring-governance test

## Notes
- Stacked on #560 / fix/chat-session-stability so the PR only contains the governance principal-validation fix.