### PR TITLE
feat(391-P1): PR A — capability-facts projection (BBP1-007)

### DIFF
--- a/packages/agent/src/__tests__/conformance/capabilitiesProjection.test.ts
+++ b/packages/agent/src/__tests__/conformance/capabilitiesProjection.test.ts
@@ -1,0 +1,199 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import Fastify from 'fastify'
+import { afterEach, expect, test } from 'vitest'
+
+import { registerAgentRoutes } from '../../server/registerAgentRoutes'
+import type { AgentHarness, AgentHarnessFactoryInput } from '../../shared/harness'
+import type { ResolvedAgentCapabilities } from '../../shared/capabilities'
+import type { SessionCtx, SessionDetail, SessionStore, SessionSummary } from '../../shared/session'
+import type { AgentTool } from '../../shared/tool'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+class TestSessionStore implements SessionStore {
+  private readonly records = new Map<string, SessionSummary>()
+  private created = 0
+
+  async list(_ctx: SessionCtx): Promise<SessionSummary[]> {
+    return [...this.records.values()]
+  }
+
+  async create(_ctx: SessionCtx, init?: { title?: string }): Promise<SessionSummary> {
+    this.created += 1
+    const now = new Date().toISOString()
+    const summary = {
+      id: `capabilities-session-${this.created}`,
+      title: init?.title ?? 'Capabilities session',
+      createdAt: now,
+      updatedAt: now,
+      turnCount: 0,
+    }
+    this.records.set(summary.id, summary)
+    return summary
+  }
+
+  async load(_ctx: SessionCtx, sessionId: string): Promise<SessionDetail> {
+    const record = this.records.get(sessionId)
+    if (!record) throw new Error(`missing session ${sessionId}`)
+    return record
+  }
+
+  async delete(_ctx: SessionCtx, sessionId: string): Promise<void> {
+    this.records.delete(sessionId)
+  }
+}
+
+function createHarnessFactory(): (input: AgentHarnessFactoryInput) => Promise<AgentHarness> {
+  const sessions = new TestSessionStore()
+  return async () => ({
+    id: 'capabilities-projection-test-harness',
+    placement: 'server',
+    sessions,
+  })
+}
+
+function createTool(name: string): AgentTool {
+  return {
+    name,
+    description: `${name} test tool.`,
+    parameters: { type: 'object', properties: {} },
+    async execute() {
+      return { content: [{ type: 'text', text: name }] }
+    },
+  }
+}
+
+async function createCapabilitiesApp() {
+  const app = Fastify({ logger: false })
+  const contributors = new Map<
+    string,
+    (ctx: { config: unknown }) => Record<string, unknown> | Promise<Record<string, unknown>>
+  >()
+
+  app.decorate(
+    'registerCapabilitiesContributor',
+    function (
+      this: unknown,
+      name: string,
+      fn: (ctx: { config: unknown }) => Record<string, unknown> | Promise<Record<string, unknown>>,
+    ) {
+      contributors.set(name, fn)
+    },
+  )
+
+  app.get('/api/v1/capabilities', async () => {
+    const merged: Record<string, unknown> = {}
+    for (const fn of contributors.values()) {
+      Object.assign(merged, await fn({ config: {} }))
+    }
+    return merged
+  })
+
+  return app
+}
+
+async function readAgentCapabilities(app: Awaited<ReturnType<typeof createCapabilitiesApp>>) {
+  const res = await app.inject({ method: 'GET', url: '/api/v1/capabilities' })
+  expect(res.statusCode).toBe(200)
+  const body = res.json() as {
+    agent?: ResolvedAgentCapabilities & { modelProviders: string[] }
+  }
+  expect(body.agent).toBeDefined()
+  return body.agent!
+}
+
+async function readCatalogToolNames(app: Awaited<ReturnType<typeof createCapabilitiesApp>>) {
+  const res = await app.inject({ method: 'GET', url: '/api/v1/agent/catalog' })
+  expect(res.statusCode).toBe(200)
+  return (res.json() as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)
+}
+
+test('capabilities projection reports honest pure-mode facts from the route seam', async () => {
+  const app = await createCapabilitiesApp()
+  const sessionRoot = await makeTempDir('boring-agent-capabilities-pure-session-')
+  const pureTool = createTool('pure_capability_echo')
+
+  await app.register(registerAgentRoutes, {
+    mode: 'none',
+    sessionRoot,
+    harnessFactory: createHarnessFactory(),
+    extraTools: [pureTool],
+  })
+  await app.ready()
+
+  try {
+    const capabilities = await readAgentCapabilities(app)
+    const catalogToolNames = await readCatalogToolNames(app)
+
+    expect(capabilities).toMatchObject({
+      v: 1,
+      runtimeMode: 'none',
+      environments: [],
+      skills: [],
+      mcpServers: [],
+    })
+    expect(capabilities.tools).toEqual(catalogToolNames)
+    expect(capabilities.tools).toEqual(['pure_capability_echo'])
+    expect(capabilities.modelProviders).toEqual(expect.any(Array))
+  } finally {
+    await app.close()
+  }
+})
+
+test('capabilities projection reports coarse filesystem-mode facts from the route seam', async () => {
+  const app = await createCapabilitiesApp()
+  const workspaceRoot = await makeTempDir('boring-agent-capabilities-direct-workspace-')
+  const directTool = createTool('direct_capability_echo')
+
+  await app.register(registerAgentRoutes, {
+    workspaceRoot,
+    mode: 'direct',
+    externalPlugins: false,
+    harnessFactory: createHarnessFactory(),
+    extraTools: [directTool],
+  })
+  await app.ready()
+
+  try {
+    const capabilities = await readAgentCapabilities(app)
+    const catalogToolNames = await readCatalogToolNames(app)
+
+    expect(capabilities).toMatchObject({
+      v: 1,
+      runtimeMode: 'direct',
+      environments: [
+        {
+          id: 'user',
+          filesystem: {
+            access: 'readwrite',
+            acceptsInputAssets: true,
+            defaultInputAssetSink: true,
+          },
+          tools: ['read', 'write', 'edit', 'find', 'grep', 'ls', 'bash'],
+          provider: 'direct',
+        },
+      ],
+      skills: [],
+      mcpServers: [],
+    })
+    expect(capabilities.tools).toEqual(catalogToolNames)
+    expect(capabilities.tools).toContain('bash')
+    expect(capabilities.tools).toContain('read')
+    expect(capabilities.tools).toContain('direct_capability_echo')
+    expect(capabilities.modelProviders).toEqual(expect.any(Array))
+  } finally {
+    await app.close()
+  }
+})

--- a/packages/agent/src/server/agentRouteBindingProfile.ts
+++ b/packages/agent/src/server/agentRouteBindingProfile.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify'
 import type { RuntimeModeId } from './runtime/mode'
+import type { ResolvedAgentCapabilities } from '../shared/capabilities'
 import type { AgentTool } from '../shared/tool'
 import { fileRoutes } from './http/routes/file'
 import { fsEventsRoutes } from './http/routes/fsEvents'
@@ -18,6 +19,8 @@ import { gitRoutes } from './http/routes/git'
 import { healthRoutes, type HealthRouteOptions } from './http/routes/health'
 import type { InMemorySessionChangesTracker } from './http/sessionChangesTracker'
 
+const COMPATIBILITY_ENVIRONMENT_TOOL_NAMES = ['read', 'write', 'edit', 'find', 'grep', 'ls', 'bash']
+
 type RouteOptions<T> = T extends (
   app: FastifyInstance,
   opts: infer Options,
@@ -33,9 +36,7 @@ type RouteRegistrar = (app: FastifyInstance) => void | Promise<void>
  */
 export interface AgentRouteBindingProfile {
   runtimeMode: RuntimeModeId
-  capabilities: {
-    tools: string[]
-  }
+  capabilities: ResolvedAgentCapabilities
   sessionChangesTracker: InMemorySessionChangesTracker
   health: HealthRouteOptions & { register?: boolean }
   chat: PiChatRoutesOptions
@@ -58,6 +59,45 @@ export interface AgentRouteBindingProfile {
 
 export function toolNames(tools: readonly AgentTool[]): string[] {
   return tools.map((tool) => tool.name)
+}
+
+export function createPureAgentCapabilities(
+  runtimeMode: RuntimeModeId,
+  tools: readonly string[],
+): ResolvedAgentCapabilities {
+  return {
+    v: 1,
+    runtimeMode,
+    environments: [],
+    tools: [...tools],
+    skills: [],
+    mcpServers: [],
+  }
+}
+
+export function createWorkspaceAgentCapabilities(
+  runtimeMode: RuntimeModeId,
+  tools: readonly string[],
+): ResolvedAgentCapabilities {
+  return {
+    v: 1,
+    runtimeMode,
+    environments: [
+      {
+        id: 'user',
+        filesystem: {
+          access: 'readwrite',
+          acceptsInputAssets: true,
+          defaultInputAssetSink: true,
+        },
+        tools: COMPATIBILITY_ENVIRONMENT_TOOL_NAMES,
+        provider: runtimeMode,
+      },
+    ],
+    tools: [...tools],
+    skills: [],
+    mcpServers: [],
+  }
 }
 
 export async function registerAgentRouteBindingProfile(

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -23,6 +23,8 @@ import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
 import type { ReloadHookDiagnostic } from './http/routes/reload'
 import { createAgentRuntimeBridge } from './createAgent'
 import {
+  createPureAgentCapabilities,
+  createWorkspaceAgentCapabilities,
   registerAgentRouteBindingProfile,
   toolNames,
   type AgentRouteBindingProfile,
@@ -166,7 +168,7 @@ async function createPureAgentAppProfile(
   const readyTracker = new ReadyStatusTracker({ sandboxReady: true, harnessReady: true })
   return {
     runtimeMode: resolvedMode,
-    capabilities: { tools: toolNames(tools) },
+    capabilities: createPureAgentCapabilities(resolvedMode, toolNames(tools)),
     sessionChangesTracker: new InMemorySessionChangesTracker(),
     health: {
       version: opts.version ?? DEFAULT_VERSION,
@@ -301,7 +303,7 @@ async function createWorkspaceAgentAppProfile(
 
   return {
     runtimeMode: resolvedMode,
-    capabilities: { tools: toolNames(tools) },
+    capabilities: createWorkspaceAgentCapabilities(resolvedMode, toolNames(tools)),
     sessionChangesTracker: new InMemorySessionChangesTracker(),
     health: {
       version: opts.version ?? DEFAULT_VERSION,

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -37,6 +37,8 @@ import type { AgentMeteringSink } from './pi-chat/metering'
 import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
 import { createAgentRuntimeBridge } from './createAgent'
 import {
+  createPureAgentCapabilities,
+  createWorkspaceAgentCapabilities,
   registerAgentRouteBindingProfile,
   toolNames,
   type AgentRouteBindingProfile,
@@ -49,9 +51,7 @@ const MAX_PURE_BINDINGS = 256
 const STANDARD_AGENT_TOOL_NAMES = ['bash', 'read', 'write', 'edit', 'find', 'grep', 'ls']
 
 type AgentCapabilities = {
-  agent: {
-    runtimeMode: RuntimeModeId
-    tools: string[]
+  agent: AgentRouteBindingProfile['capabilities'] & {
     modelProviders: string[]
   }
 }
@@ -100,8 +100,7 @@ function registerAgentCapabilitiesContributor(
     'agent',
     () => ({
       agent: {
-        runtimeMode: profile.runtimeMode,
-        tools: profile.capabilities.tools,
+        ...profile.capabilities,
         modelProviders: getAvailableModelProviders(),
       },
     }),
@@ -504,9 +503,10 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
 
     profile = {
       runtimeMode: resolvedMode,
-      capabilities: {
-        tools: staticBinding ? toolNames(staticBinding.tools) : toolNames(opts.extraTools ?? []),
-      },
+      capabilities: createPureAgentCapabilities(
+        resolvedMode,
+        staticBinding ? toolNames(staticBinding.tools) : toolNames(opts.extraTools ?? []),
+      ),
       sessionChangesTracker,
       health: {
         register: opts.registerHealthRoute ?? true,
@@ -1088,14 +1088,15 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
 
   profile = {
     runtimeMode: resolvedMode,
-    capabilities: {
-      tools: staticBinding
+    capabilities: createWorkspaceAgentCapabilities(
+      resolvedMode,
+      staticBinding
         ? toolNames(staticBinding.tools)
         : [
             ...STANDARD_AGENT_TOOL_NAMES,
             ...toolNames(opts.extraTools ?? []),
           ],
-    },
+    ),
     sessionChangesTracker,
     health: {
       register: opts.registerHealthRoute ?? true,

--- a/packages/agent/src/shared/capabilities.ts
+++ b/packages/agent/src/shared/capabilities.ts
@@ -3,6 +3,34 @@ export interface AgentRuntimeCapabilities {
   aiSdkOwnsHistory: boolean
 }
 
+export interface ResolvedEnvironment {
+  /**
+   * Model/manifest-visible id, e.g. user, company_context, scratch.
+   * This is a methodless projection of runtime authority.
+   */
+  readonly id: string
+  readonly filesystem?: {
+    readonly access: 'read' | 'readwrite'
+    readonly acceptsInputAssets?: boolean
+    readonly defaultInputAssetSink?: boolean
+  }
+  readonly tools: readonly string[]
+  /** Diagnostic only; consumers must not use this as a feature gate. */
+  readonly provider?: string
+  readonly label?: string
+}
+
+export interface ResolvedAgentCapabilities {
+  readonly v: 1
+  /** Diagnostic only; consumers must derive behavior from environments/tools. */
+  readonly runtimeMode?: string
+  /** Source of truth for filesystem/bash/environment authority. */
+  readonly environments: readonly ResolvedEnvironment[]
+  readonly tools: readonly string[]
+  readonly skills: readonly string[]
+  readonly mcpServers: readonly string[]
+}
+
 export const DEFAULT_AGENT_RUNTIME_CAPABILITIES: AgentRuntimeCapabilities = {
   nativeFollowUp: false,
   aiSdkOwnsHistory: true,

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -83,7 +83,11 @@ export {
   DEFAULT_AGENT_RUNTIME_CAPABILITIES,
   PI_AGENT_RUNTIME_CAPABILITIES,
 } from './capabilities'
-export type { AgentRuntimeCapabilities } from './capabilities'
+export type {
+  AgentRuntimeCapabilities,
+  ResolvedAgentCapabilities,
+  ResolvedEnvironment,
+} from './capabilities'
 export { validateTool } from './validateTool'
 export {
   WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT,

--- a/packages/core/src/front/__tests__/useCapabilities.hook.test.tsx
+++ b/packages/core/src/front/__tests__/useCapabilities.hook.test.tsx
@@ -78,8 +78,12 @@ describe('useCapabilities hook', () => {
           },
         },
         agent: {
+          v: 1,
           runtimeMode: 'local',
+          environments: [],
           tools: ['terminal'],
+          skills: [],
+          mcpServers: [],
           modelProviders: ['anthropic'],
         },
       }

--- a/packages/core/src/server/app/__tests__/capabilities.test.ts
+++ b/packages/core/src/server/app/__tests__/capabilities.test.ts
@@ -161,8 +161,12 @@ describe('capabilities contributor API', () => {
 
     app.registerCapabilitiesContributor('agent', () => ({
       agent: {
+        v: 1,
         runtimeMode: 'local' as const,
+        environments: [],
         tools: ['shell', 'browser'],
+        skills: [],
+        mcpServers: [],
         modelProviders: ['anthropic'],
       },
     }))

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -220,13 +220,31 @@ export type CoreCapabilities = {
   }
 }
 
+export type AgentResolvedEnvironment = {
+  id: string
+  filesystem?: {
+    access: 'read' | 'readwrite'
+    acceptsInputAssets?: boolean
+    defaultInputAssetSink?: boolean
+  }
+  tools: string[]
+  provider?: string
+  label?: string
+}
+
+export type AgentResolvedCapabilities = {
+  v: 1
+  runtimeMode?: string
+  environments: AgentResolvedEnvironment[]
+  tools: string[]
+  skills: string[]
+  mcpServers: string[]
+  modelProviders: string[]
+}
+
 export type CapabilitiesResponse = {
   core: CoreCapabilities
-  agent?: {
-    runtimeMode: 'direct' | 'local' | 'vercel-sandbox'
-    tools: string[]
-    modelProviders: string[]
-  }
+  agent?: AgentResolvedCapabilities
   workspace?: { panels: string[] }
-  [contributorName: string]: JsonValue | CoreCapabilities | undefined
+  [contributorName: string]: JsonValue | CoreCapabilities | AgentResolvedCapabilities | undefined
 }


### PR DESCRIPTION
First slice of the reopened-P1 purity chain (owner ruling: foundation first), per the rewritten P1 pack (#565). **Stacked on #547** — merge the P1 stack first; I retarget after. Facts shape {v:1, runtimeMode diagnostic-only, environments[], tools, skills, mcpServers} exposed through the existing /api/v1/capabilities seam; AgentRouteBindingProfile carries it as plumbing (not a registry); pure mode = honest minimal facts (environments:[], real tool names); direct/local/vercel = documented coarse projection until P2/P3 real bundles. Day-one reader: conformance test consumes the endpoint and asserts honesty for pure + direct, so the surface cannot drift unread. Deliberately excluded: resolver engine, de-mode gating (PR B), core split (PR C), readiness (PR D). Gates: agent typecheck/test (1618), lint:invariants, audit:imports, check:isolation, autoreview clean (0.83). LOC +116 production / +207 tests. Review ~10 min: shared/capabilities.ts, the contributor emission in registerAgentRoutes.ts, the conformance test. 🤖 Generated with Claude Code