### PR TITLE
feat(391-P1): PR B — de-mode input-asset intake (BBP1-002/007 follow-up)

### DIFF
--- a/packages/agent/src/server/__tests__/createAgent.test.ts
+++ b/packages/agent/src/server/__tests__/createAgent.test.ts
@@ -15,6 +15,7 @@ import type { AgentHarness, AgentHarnessFactoryInput, AgentSendInput, RunContext
 import type { SessionCtx, SessionDetail, SessionStore, SessionSummary } from '../../shared/session'
 import type { PiAgentPromptInput, PiAgentSessionAdapter, PiAgentSessionSnapshot } from '../pi-chat/PiAgentSessionAdapter'
 import { ErrorCode } from '../../shared/error-codes'
+import { decideInputAssetIntake } from '../inputAssetIntake'
 
 const CTX: SessionCtx = { workspaceId: 'workspace-test', userId: 'user-test' }
 
@@ -125,7 +126,45 @@ describe('createAgent', () => {
     await agent.dispose()
   })
 
-  it('rejects attachments in runtime none before creating sessions or harness adapters', async () => {
+  it('derives input-asset intake from environment sinks and provider-direct facts', () => {
+    expect(decideInputAssetIntake({ environments: [] })).toEqual({
+      strategy: 'stable-rejection',
+      reason: 'no-writable-env-sink',
+    })
+    expect(decideInputAssetIntake({
+      environments: [{
+        id: 'user',
+        filesystem: { access: 'readwrite', acceptsInputAssets: true },
+        tools: [],
+      }],
+    })).toEqual({
+      strategy: 'writable-env-sink',
+      environmentId: 'user',
+    })
+    expect(decideInputAssetIntake({
+      environments: [
+        {
+          id: 'scratch',
+          filesystem: { access: 'readwrite', acceptsInputAssets: true },
+          tools: [],
+        },
+        {
+          id: 'user',
+          filesystem: { access: 'readwrite', acceptsInputAssets: true, defaultInputAssetSink: true },
+          tools: [],
+        },
+      ],
+    })).toEqual({
+      strategy: 'writable-env-sink',
+      environmentId: 'user',
+    })
+    expect(decideInputAssetIntake({
+      environments: [],
+      providerDirectInputAssets: true,
+    })).toEqual({ strategy: 'provider-direct-asset' })
+  })
+
+  it('rejects input assets without a writable environment sink before creating sessions or harness adapters', async () => {
     const fake = createFakeHarnessFactory()
     const agent = createAgent({
       runtime: 'none',
@@ -147,6 +186,51 @@ describe('createAgent', () => {
     })
     expect(fake.sessions.createContexts).toEqual([])
     expect(fake.contexts('session-1')).toEqual([])
+    await agent.dispose()
+  })
+
+  it('does not treat a non-none runtime id as input-asset support', async () => {
+    const fake = createFakeHarnessFactory()
+    const agent = createAgent({
+      runtime: { id: 'test-runtime' },
+      harnessFactory: fake.factory,
+    })
+    const input = {
+      content: 'look at this',
+      attachments: [{ filename: 'chart.png', mediaType: 'image/png', url: '/api/v1/files/raw?path=chart.png' }],
+    }
+
+    await expect(agent.start(input)).rejects.toMatchObject({
+      code: AGENT_NO_FILESYSTEM_FOR_ATTACHMENTS,
+    })
+    expect(fake.sessions.createContexts).toEqual([])
+    expect(fake.contexts('session-1')).toEqual([])
+    await agent.dispose()
+  })
+
+  it('accepts input assets when a writable environment sink exists', async () => {
+    const fake = createFakeHarnessFactory({ autoCompletePrompt: true })
+    const agent = createAgent({
+      runtime: { id: 'test-runtime' },
+      environments: [{
+        id: 'user',
+        filesystem: {
+          access: 'readwrite',
+          acceptsInputAssets: true,
+          defaultInputAssetSink: true,
+        },
+        tools: ['read', 'write'],
+      }],
+      harnessFactory: fake.factory,
+    })
+
+    await expect(agent.start({
+      content: 'look at this',
+      attachments: [{ filename: 'chart.png', mediaType: 'image/png', url: '/api/v1/files/raw?path=chart.png' }],
+      ctx: CTX,
+    })).resolves.toMatchObject({ sessionId: 'session-1', startIndex: 0 })
+    expect(fake.sessions.createContexts).toHaveLength(1)
+    expect(fake.contexts('session-1').length).toBeGreaterThan(0)
     await agent.dispose()
   })
 

--- a/packages/agent/src/server/createAgent.ts
+++ b/packages/agent/src/server/createAgent.ts
@@ -14,11 +14,12 @@ import type {
   AgentStartReceipt,
   AgentStreamOptions,
 } from '../shared/events'
-import { AgentFilesystemRequiredError, AgentNotImplementedError } from '../shared/events'
+import { AgentNotImplementedError } from '../shared/events'
 import type { SessionCtx, SessionListOptions, SessionStore } from '../shared/session'
 import type { PromptPayload } from '../shared/chat'
 import { ErrorCode } from '../shared/error-codes'
 import { createPureRuntimeCwd } from './runtime/pureRuntime'
+import { assertInputAssetsAccepted, decideInputAssetIntake } from './inputAssetIntake'
 
 const DEFAULT_WORKDIR = ''
 const DEFAULT_LIVE_BUFFER_SIZE = 1_000
@@ -88,6 +89,7 @@ export function createAgentRuntimeBridge(
   const runtimeLoader = createRuntimeLoader(config, options)
   const getRuntime = runtimeLoader.get
   const live = new AgentLiveEventBuffer(DEFAULT_LIVE_BUFFER_SIZE)
+  const inputAssetIntake = decideInputAssetIntake(config)
   const sessionContexts = new Map<string, SessionCtx | undefined>()
   const startedSessions = new Map<string, { sessionId: string; ctx: SessionCtx | undefined }>()
   const sendLocks = new Map<string, Promise<void>>()
@@ -135,7 +137,7 @@ export function createAgentRuntimeBridge(
   }
 
   async function start(input: AgentSendInput): Promise<AgentStartReceipt> {
-    assertFilesystemAttachmentsAllowed(config, input)
+    assertInputAssetsAccepted(inputAssetIntake, input)
     const runtime = await getRuntime()
     const { sessionId, sessionKey, ctx } = await ensureSession(input, runtime)
     startedSessions.set(sessionKey, { sessionId, ctx })
@@ -241,6 +243,7 @@ function createRuntimeLoader(config: AgentConfig, options: CreateAgentRuntimeBri
 }
 
 async function createRuntime(config: AgentConfig, options: CreateAgentRuntimeBridgeOptions): Promise<AgentRuntime> {
+  const inputAssetIntake = decideInputAssetIntake(config)
   const pureRuntimeCwd = config.runtime === 'none'
     ? await createPureRuntimeCwd(config.sessionStorageRoot)
     : undefined
@@ -267,7 +270,7 @@ async function createRuntime(config: AgentConfig, options: CreateAgentRuntimeBri
       workdir: pureRuntimeCwd ?? options.service?.workdir ?? config.workdir ?? DEFAULT_WORKDIR,
       workspace: options.service?.workspace,
       eventStore: options.service?.eventStore,
-      allowAttachments: config.runtime !== 'none',
+      inputAssetIntake,
       metering: config.metering as AgentMeteringSink | undefined,
     }),
   }
@@ -281,14 +284,6 @@ async function createDefaultPiHarness(config: AgentConfig, input: AgentHarnessFa
       ? { pi: piHarness.withPurePiHarnessDefaults() }
       : {}),
   })
-}
-
-function assertFilesystemAttachmentsAllowed(config: AgentConfig, input: AgentSendInput): void {
-  if (config.runtime !== 'none' || !input.attachments || input.attachments.length === 0) return
-  // TEMPORARY(BBT2-007): split attachment capability into none|direct|workspace.
-  // Until then pure mode rejects every non-empty attachment, including inline
-  // data URLs, so fs-free mode has no attachment side channel.
-  throw new AgentFilesystemRequiredError()
 }
 
 function createReadiness(config: AgentConfig): AgentReadiness {

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -154,8 +154,10 @@ async function createPureAgentAppProfile(
     sessionDir: opts.sessionDir ?? input.sessionDir,
   })) as AgentCoreHarnessFactory
   const tools = opts.extraTools ?? []
+  const capabilities = createPureAgentCapabilities(resolvedMode, toolNames(tools))
   const coreAgent = createAgentRuntimeBridge({
     runtime: 'none',
+    environments: capabilities.environments,
     tools,
     harnessFactory,
     systemPromptAppend: opts.systemPromptAppend,
@@ -168,7 +170,7 @@ async function createPureAgentAppProfile(
   const readyTracker = new ReadyStatusTracker({ sandboxReady: true, harnessReady: true })
   return {
     runtimeMode: resolvedMode,
-    capabilities: createPureAgentCapabilities(resolvedMode, toolNames(tools)),
+    capabilities,
     sessionChangesTracker: new InMemorySessionChangesTracker(),
     health: {
       version: opts.version ?? DEFAULT_VERSION,
@@ -278,8 +280,10 @@ async function createWorkspaceAgentAppProfile(
     sessionRoot: opts.sessionRoot,
     sessionDir: opts.sessionDir ?? input.sessionDir,
   })) as AgentCoreHarnessFactory
+  const capabilities = createWorkspaceAgentCapabilities(resolvedMode, toolNames(tools))
   const coreAgent = createAgentRuntimeBridge({
     runtime: modeAdapter,
+    environments: capabilities.environments,
     tools,
     harnessFactory,
     systemPromptAppend: opts.systemPromptAppend,
@@ -303,7 +307,7 @@ async function createWorkspaceAgentAppProfile(
 
   return {
     runtimeMode: resolvedMode,
-    capabilities: createWorkspaceAgentCapabilities(resolvedMode, toolNames(tools)),
+    capabilities,
     sessionChangesTracker: new InMemorySessionChangesTracker(),
     health: {
       version: opts.version ?? DEFAULT_VERSION,

--- a/packages/agent/src/server/inputAssetIntake.ts
+++ b/packages/agent/src/server/inputAssetIntake.ts
@@ -1,0 +1,56 @@
+import type { ResolvedEnvironment } from '../shared/capabilities'
+import type { AgentConfig, AgentSendInput } from '../shared/events'
+import { AgentFilesystemRequiredError } from '../shared/events'
+
+export type InputAssetIntakeDecision =
+  | { strategy: 'writable-env-sink'; environmentId: string }
+  | { strategy: 'provider-direct-asset' }
+  | { strategy: 'stable-rejection'; reason: 'no-writable-env-sink' | 'ambiguous-writable-env-sink' }
+
+export const LEGACY_WRITABLE_ENV_INPUT_ASSET_INTAKE: InputAssetIntakeDecision = {
+  strategy: 'writable-env-sink',
+  environmentId: 'legacy',
+}
+
+export function decideInputAssetIntake(
+  config: Pick<AgentConfig, 'environments' | 'providerDirectInputAssets'>,
+): InputAssetIntakeDecision {
+  const sinks = inputAssetEnvironmentSinks(config.environments ?? [])
+  if (sinks.length === 1) {
+    return { strategy: 'writable-env-sink', environmentId: sinks[0].id }
+  }
+  if (sinks.length > 1) {
+    const defaults = sinks.filter((env) => env.filesystem?.defaultInputAssetSink === true)
+    if (defaults.length === 1) {
+      return { strategy: 'writable-env-sink', environmentId: defaults[0].id }
+    }
+    return { strategy: 'stable-rejection', reason: 'ambiguous-writable-env-sink' }
+  }
+  if (config.providerDirectInputAssets === true) {
+    return { strategy: 'provider-direct-asset' }
+  }
+  return { strategy: 'stable-rejection', reason: 'no-writable-env-sink' }
+}
+
+export function assertInputAssetsAccepted(
+  decision: InputAssetIntakeDecision,
+  payload: Pick<AgentSendInput, 'attachments'>,
+): void {
+  if (!payload.attachments || payload.attachments.length === 0) return
+  if (decision.strategy !== 'stable-rejection') return
+  throw new AgentFilesystemRequiredError(inputAssetRejectionMessage(decision))
+}
+
+function inputAssetEnvironmentSinks(environments: readonly ResolvedEnvironment[]): ResolvedEnvironment[] {
+  return environments.filter((env) =>
+    env.filesystem?.access === 'readwrite' &&
+    env.filesystem.acceptsInputAssets === true,
+  )
+}
+
+function inputAssetRejectionMessage(decision: Extract<InputAssetIntakeDecision, { strategy: 'stable-rejection' }>): string {
+  if (decision.reason === 'ambiguous-writable-env-sink') {
+    return 'Input assets require exactly one default writable environment sink.'
+  }
+  return 'Input assets require a writable environment sink.'
+}

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -2,9 +2,14 @@ import type { AgentHarness, RunContext, AgentSendInput } from '../../shared/harn
 import type { SessionCtx, SessionListOptions, SessionStore } from '../../shared/session'
 import type { Workspace } from '../../shared/workspace'
 import type { BoringChatMessage, BoringChatPart, ChatError, FollowUpPayload, FollowUpReceipt, InterruptPayload, PiChatEvent, PiChatSnapshot, PromptPayload, PromptReceipt, QueuedUserMessage, QueueClearPayload, QueueClearReceipt, StopPayload, StopReceipt } from '../../shared/chat'
-import { AgentFilesystemRequiredError, sessionStreamPath, type AgentEvent } from '../../shared/events'
+import { sessionStreamPath, type AgentEvent } from '../../shared/events'
 import { ErrorCode } from '../../shared/error-codes'
 import { formatOffset, parseOffset, type EventStreamStore } from '../events/eventStreamStore'
+import {
+  assertInputAssetsAccepted,
+  LEGACY_WRITABLE_ENV_INPUT_ASSET_INTAKE,
+  type InputAssetIntakeDecision,
+} from '../inputAssetIntake'
 import type { PiChatSessionService, PiChatEventSubscriber, PiChatEventStreamResult } from '../http/routes/piChat'
 import type { PiSessionCreateInit, PiSessionRequestContext } from './piSessionIdentity'
 import type { PiAgentPromptInput, PiAgentSessionAdapter } from './PiAgentSessionAdapter'
@@ -64,8 +69,8 @@ export interface HarnessPiChatServiceOptions {
   metering?: AgentMeteringSink
   /** Receives non-fatal metering pipeline failures (default: console.warn). */
   meteringLogger?: MeteringErrorLogger
-  /** Filesystem-less runtimes cannot resolve attachment URLs/paths. */
-  allowAttachments?: boolean
+  /** Legacy `attachments` payloads are input assets; intake is derived upstream from environment/provider facts. */
+  inputAssetIntake?: InputAssetIntakeDecision
 }
 
 export class HarnessPiChatService implements PiChatSessionService {
@@ -74,7 +79,7 @@ export class HarnessPiChatService implements PiChatSessionService {
   private readonly workdir: string
   private readonly workspace?: Workspace
   private readonly eventStore?: EventStreamStore
-  private readonly allowAttachments: boolean
+  private readonly inputAssetIntake: InputAssetIntakeDecision
   private readonly channels = new Map<string, LiveSessionChannel>()
   // Single-flight guard so concurrent cold callers (e.g. two browser tabs each
   // opening /events while the session is still being created) converge on one
@@ -93,7 +98,7 @@ export class HarnessPiChatService implements PiChatSessionService {
     this.workdir = options.workdir
     this.workspace = options.workspace
     this.eventStore = options.eventStore
-    this.allowAttachments = options.allowAttachments !== false
+    this.inputAssetIntake = options.inputAssetIntake ?? LEGACY_WRITABLE_ENV_INPUT_ASSET_INTAKE
     this.metering = options.metering
       ? new PiChatMeteringCoordinator(options.metering, options.meteringLogger)
       : undefined
@@ -190,7 +195,7 @@ export class HarnessPiChatService implements PiChatSessionService {
   }
 
   async prompt(ctx: PiSessionRequestContext, sessionId: string, payload: PromptPayload): Promise<PromptReceipt> {
-    this.assertAttachmentsAllowed(payload)
+    this.assertPromptInputAssetsAccepted(payload)
     const sessionKey = this.sessionKey(ctx, sessionId)
     const adapter = await this.getAdapter(ctx, sessionId, payload)
     const channel = await this.ensureChannel(ctx, sessionId, adapter)
@@ -237,11 +242,8 @@ export class HarnessPiChatService implements PiChatSessionService {
     return { accepted: true, cursor: receiptCursor, clientNonce: payload.clientNonce }
   }
 
-  private assertAttachmentsAllowed(payload: PromptPayload): void {
-    if (this.allowAttachments || !payload.attachments || payload.attachments.length === 0) return
-    // TEMPORARY(BBT2-007): split attachment capability into none|direct|workspace.
-    // Until then pure runtime rejects all attachments, even inline data URLs.
-    throw new AgentFilesystemRequiredError()
+  private assertPromptInputAssetsAccepted(payload: PromptPayload): void {
+    assertInputAssetsAccepted(this.inputAssetIntake, payload)
   }
 
   async followUp(ctx: PiSessionRequestContext, sessionId: string, payload: FollowUpPayload): Promise<FollowUpReceipt> {

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -461,8 +461,10 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
           sessionRoot: opts.sessionRoot,
           sessionDir: input.sessionDir,
         })) as AgentCoreHarnessFactory
+        const capabilities = createPureAgentCapabilities(resolvedMode, toolNames(tools))
         const coreAgent = createAgentRuntimeBridge({
           runtime: 'none',
+          environments: capabilities.environments,
           tools,
           harnessFactory,
           systemPromptAppend: opts.systemPromptAppend,
@@ -889,8 +891,10 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       sessionNamespace: scope.sessionNamespace,
       sessionRoot: opts.sessionRoot,
     })) as AgentCoreHarnessFactory
+    const capabilities = createWorkspaceAgentCapabilities(resolvedMode, toolNames(tools))
     const coreAgent = createAgentRuntimeBridge({
       runtime: modeAdapter,
+      environments: capabilities.environments,
       tools,
       harnessFactory,
       systemPromptAppend: opts.systemPromptAppend,

--- a/packages/agent/src/shared/events.ts
+++ b/packages/agent/src/shared/events.ts
@@ -1,4 +1,5 @@
 import type { PiChatEvent } from './chat'
+import type { ResolvedEnvironment } from './capabilities'
 import type { ErrorCode } from './error-codes'
 import type { AgentCoreHarnessFactory } from './harness'
 import type { SessionCtx, SessionStore } from './session'
@@ -91,6 +92,13 @@ export interface AgentReadiness {
 export interface AgentConfig {
   harnessFactory?: AgentCoreHarnessFactory
   runtime: AgentRuntimeAdapter | 'none'
+  /**
+   * Resolved environment facts used by core behavior checks. runtimeMode is
+   * intentionally not part of this core input; it remains diagnostic.
+   */
+  environments?: readonly ResolvedEnvironment[]
+  /** Provider + host-policy fact for direct model input assets. */
+  providerDirectInputAssets?: boolean
   tools?: AgentTool[]
   readinessRequirements?: string[]
   sessions?: SessionStore


### PR DESCRIPTION
Second purity slice (stacked on #566). Removes runtimeMode FEATURE gating: attachment allow/reject is now decideInputAssetIntake() over environment facts — writable-env-sink | provider-direct-asset | stable-rejection — not config.runtime!==none. runtimeMode stays diagnostic-only (facts/labels). This supersedes BBT2-007 none|direct|workspace: intake is derived, not a declared axis; ERR_NO_FILESYSTEM_FOR_ATTACHMENTS kept for the no-sink case. Excluded: resolver engine, core split (PR C), readiness (PR D). Behavior-frozen — fs modes accept attachments exactly as today; pure rejects because no writable sink. Gates: agent typecheck/test (1621), lint:invariants, audit:imports, check:isolation, autoreview clean (0.85). LOC +93 prod / +85 tests. Review ~10 min: inputAssetIntake.ts + the two call sites in createAgent.ts/harnessPiChatService.ts. **With A+B merged, the mode-label semantics are gone — T2/P3 can safely consume facts.** 🤖 Generated with Claude Code