### PR TITLE
fix(cli): show inbox by default

### DIFF
--- a/packages/cli/src/front/App.test.tsx
+++ b/packages/cli/src/front/App.test.tsx
@@ -19,8 +19,9 @@ vi.mock("@hachej/boring-agent", () => ({
 }))
 
 vi.mock("@hachej/boring-ask-user/front", () => {
-  const askUserPlugin = { pluginId: "ask-user", pluginLabel: "Questions" }
-  return { askUserPlugin, default: askUserPlugin }
+  const createAskUserPlugin = (options?: Record<string, unknown>) => ({ pluginId: "ask-user", pluginLabel: "Questions", options })
+  const askUserPlugin = createAskUserPlugin()
+  return { askUserPlugin, createAskUserPlugin, default: askUserPlugin }
 })
 
 vi.mock("@hachej/boring-workspace/app/front", () => ({
@@ -169,7 +170,7 @@ describe("CliWorkspaceShell", () => {
       workspaceLayout: "plugin-tabs",
       workspaceSectionTitle: "Project",
       appTitle: "Folder Workspace",
-      plugins: [expect.objectContaining({ pluginId: "ask-user" })],
+      plugins: [expect.objectContaining({ pluginId: "ask-user", options: { appLeftInbox: true } })],
     })
 
     expect(screen.getByText("v1.2.3")).not.toBeNull()

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -4,7 +4,7 @@ import * as ReactDomClient from "react-dom/client"
 import * as ReactJsxDevRuntime from "react/jsx-dev-runtime"
 import * as ReactJsxRuntime from "react/jsx-runtime"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { askUserPlugin } from "@hachej/boring-ask-user/front"
+import { createAskUserPlugin } from "@hachej/boring-ask-user/front"
 import * as WorkspaceSingleton from "@hachej/boring-workspace"
 import * as WorkspaceEventsSingleton from "@hachej/boring-workspace/events"
 import * as WorkspacePluginSingleton from "@hachej/boring-workspace/plugin"
@@ -306,7 +306,7 @@ export function CliWorkspaceShell() {
 
   // CLI-default plugins are app code: statically imported, composed once.
   // Keep in sync with CLI_DEFAULT_PLUGIN_PACKAGES in server/pluginDiscovery.ts.
-  const plugins = useMemo(() => [askUserPlugin], [])
+  const plugins = useMemo(() => [createAskUserPlugin({ appLeftInbox: true })], [])
   const activeWorkspaceRequestHeaders = useMemo(
     () => activeWorkspaceId ? { "x-boring-workspace-id": activeWorkspaceId } : null,
     [activeWorkspaceId],


### PR DESCRIPTION
## Summary
- enables the ask-user app-left Inbox in the CLI default plugin composition
- updates the CLI shell test to assert the Inbox-enabled ask-user factory path

## Test
- pnpm --filter @hachej/boring-ui-cli exec vitest run src/front/App.test.tsx