### PR TITLE
Add aggregate governance user budgets

### DIFF
--- a/packages/core/drizzle/0017_user_budget_reservations.sql
+++ b/packages/core/drizzle/0017_user_budget_reservations.sql
@@ -1,0 +1,15 @@
+ALTER TABLE "boring_model_budget_reservations" RENAME TO "boring_budget_reservations";--> statement-breakpoint
+ALTER TABLE "boring_budget_reservations" RENAME CONSTRAINT "boring_model_budget_reservations_amount_check" TO "boring_budget_reservations_amount_check";--> statement-breakpoint
+ALTER TABLE "boring_budget_reservations" RENAME CONSTRAINT "boring_model_budget_reservations_status_check" TO "boring_budget_reservations_status_check";--> statement-breakpoint
+ALTER TABLE "boring_budget_reservations" ADD COLUMN "scope" text DEFAULT 'model' NOT NULL;--> statement-breakpoint
+ALTER TABLE "boring_budget_reservations" ALTER COLUMN "provider" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "boring_budget_reservations" ALTER COLUMN "model" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "boring_budget_reservations" ADD CONSTRAINT "boring_budget_reservations_scope_check" CHECK ("scope" IN ('model', 'user'));--> statement-breakpoint
+ALTER TABLE "boring_budget_reservations" ADD CONSTRAINT "boring_budget_reservations_scope_shape_check" CHECK (("scope" = 'model' AND "provider" IS NOT NULL AND length(btrim("provider")) > 0 AND "model" IS NOT NULL AND length(btrim("model")) > 0) OR ("scope" = 'user' AND "provider" IS NULL AND "model" IS NULL));--> statement-breakpoint
+DROP INDEX IF EXISTS "boring_model_budget_reservations_active_user_run_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "boring_model_budget_reservations_budget_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "boring_model_budget_reservations_stale_idx";--> statement-breakpoint
+CREATE UNIQUE INDEX "boring_budget_reservations_active_user_run_idx" ON "boring_budget_reservations" USING btree ("scope","user_id","run_id") WHERE "boring_budget_reservations"."status" = 'active';--> statement-breakpoint
+CREATE INDEX "boring_budget_reservations_budget_idx" ON "boring_budget_reservations" USING btree ("scope","user_id","provider","model","period","status");--> statement-breakpoint
+CREATE INDEX "boring_budget_reservations_user_budget_idx" ON "boring_budget_reservations" USING btree ("scope","user_id","period","status");--> statement-breakpoint
+CREATE INDEX "boring_budget_reservations_stale_idx" ON "boring_budget_reservations" USING btree ("status","expires_at");

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1783123200000,
       "tag": "0016_workspace_managed_by",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1783497600000,
+      "tag": "0017_user_budget_reservations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/server/auth/deleteUserCompletely.ts
+++ b/packages/core/src/server/auth/deleteUserCompletely.ts
@@ -12,6 +12,7 @@ import {
   creditGrants,
   usageLedger,
   usageReservations,
+  modelBudgetReservations,
   creditPurchases,
 } from '../db/schema.js'
 
@@ -220,6 +221,7 @@ export async function deleteUserCompletely(
         // rows with the account. (Refund-before-grant tombstones in credit_purchases
         // have a NULL user_id and are intentionally left as cross-store/mode guards.)
         await tx.delete(usageReservations).where(eq(usageReservations.userId, userId))
+        await tx.delete(modelBudgetReservations).where(eq(modelBudgetReservations.userId, userId))
         await tx.delete(usageLedger).where(eq(usageLedger.userId, userId))
         await tx.delete(creditGrants).where(eq(creditGrants.userId, userId))
         await tx.delete(creditPurchases).where(eq(creditPurchases.userId, userId))

--- a/packages/core/src/server/db/index.ts
+++ b/packages/core/src/server/db/index.ts
@@ -7,7 +7,8 @@ export { LocalWorkspaceStore } from './stores/index.js'
 export { PostgresWorkspaceStore } from './stores/index.js'
 export { PostgresUserStore } from './stores/index.js'
 export { PostgresMeteringStore, InsufficientCreditError } from './stores/index.js'
-export { PostgresModelBudgetStore, ModelBudgetExceededError } from './stores/index.js'
+export { PostgresBudgetReservationStore, PostgresModelBudgetStore, ModelBudgetExceededError, UserBudgetExceededError } from './stores/index.js'
+export type { BudgetReservationAdmission, BudgetReservationAdmissionInput, ReserveBudgetInput, ReserveBudgetResult, FinishBudgetReservationInput, BudgetReservationScope } from './stores/index.js'
 export type {
   MeteringBalance,
   GrantOnceInput,

--- a/packages/core/src/server/db/schema.ts
+++ b/packages/core/src/server/db/schema.ts
@@ -375,8 +375,8 @@ export const usageReservations = pgTable(
   ],
 )
 
-export const modelBudgetReservations = pgTable(
-  'boring_model_budget_reservations',
+export const budgetReservations = pgTable(
+  'boring_budget_reservations',
   {
     id: uuid('id')
       .default(sql`gen_random_uuid()`)
@@ -385,8 +385,9 @@ export const modelBudgetReservations = pgTable(
     workspaceId: text('workspace_id'),
     sessionId: text('session_id'),
     runId: text('run_id').notNull(),
-    provider: text('provider').notNull(),
-    model: text('model').notNull(),
+    scope: text('scope').notNull().default('model'),
+    provider: text('provider'),
+    model: text('model'),
     period: text('period').notNull(),
     amountMicros: bigint('amount_micros', { mode: 'number' }).notNull(),
     status: text('status').notNull().default('active'),
@@ -394,18 +395,25 @@ export const modelBudgetReservations = pgTable(
     expiresAt: timestamp('expires_at').notNull(),
   },
   (table) => [
-    uniqueIndex('boring_model_budget_reservations_active_user_run_idx')
-      .on(table.userId, table.runId)
+    uniqueIndex('boring_budget_reservations_active_user_run_idx')
+      .on(table.scope, table.userId, table.runId)
       .where(sql`${table.status} = 'active'`),
-    index('boring_model_budget_reservations_budget_idx').on(table.userId, table.provider, table.model, table.period, table.status),
-    index('boring_model_budget_reservations_stale_idx').on(table.status, table.expiresAt),
-    check('boring_model_budget_reservations_amount_check', sql`${table.amountMicros} > 0`),
+    index('boring_budget_reservations_budget_idx').on(table.scope, table.userId, table.provider, table.model, table.period, table.status),
+    index('boring_budget_reservations_user_budget_idx').on(table.scope, table.userId, table.period, table.status),
+    index('boring_budget_reservations_stale_idx').on(table.status, table.expiresAt),
+    check('boring_budget_reservations_amount_check', sql`${table.amountMicros} > 0`),
+    check('boring_budget_reservations_scope_check', sql`${table.scope} IN ('model', 'user')`),
     check(
-      'boring_model_budget_reservations_status_check',
+      'boring_budget_reservations_scope_shape_check',
+      sql`(${table.scope} = 'model' AND ${table.provider} IS NOT NULL AND length(btrim(${table.provider})) > 0 AND ${table.model} IS NOT NULL AND length(btrim(${table.model})) > 0) OR (${table.scope} = 'user' AND ${table.provider} IS NULL AND ${table.model} IS NULL)`,
+    ),
+    check(
+      'boring_budget_reservations_status_check',
       sql`${table.status} IN ('active', 'settled', 'released', 'expired')`,
     ),
   ],
 )
+export const modelBudgetReservations = budgetReservations
 
 export const usageLedger = pgTable(
   'boring_usage_ledger',

--- a/packages/core/src/server/db/stores/BudgetReservationSupport.ts
+++ b/packages/core/src/server/db/stores/BudgetReservationSupport.ts
@@ -1,0 +1,39 @@
+import { sql } from 'drizzle-orm'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+
+export type BudgetReservationStatus = 'active' | 'settled' | 'released' | 'expired'
+
+export interface BudgetPeriodUtc {
+  period: string
+  start: Date
+  end: Date
+}
+
+export function assertPositiveSafeInteger(name: string, value: number): void {
+  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${name} must be a positive safe integer`)
+}
+
+export function monthPeriodUtc(now: Date): BudgetPeriodUtc {
+  const year = now.getUTCFullYear()
+  const month = now.getUTCMonth()
+  return {
+    period: `${year}-${String(month + 1).padStart(2, '0')}`,
+    start: new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)),
+    end: new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0)),
+  }
+}
+
+export function chunkIds(ids: string[], size = 1_000): string[][] {
+  const chunks: string[][] = []
+  for (let index = 0; index < ids.length; index += size) chunks.push(ids.slice(index, index + size))
+  return chunks
+}
+
+export async function lockBudgetTargets<TTarget>(
+  executor: Pick<PostgresJsDatabase, 'execute'>,
+  targets: readonly TTarget[],
+  keyForTarget: (target: TTarget) => string,
+): Promise<void> {
+  const keys = Array.from(new Set(targets.map(keyForTarget))).sort()
+  for (const key of keys) await executor.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${key}))`)
+}

--- a/packages/core/src/server/db/stores/BudgetSpendAttribution.ts
+++ b/packages/core/src/server/db/stores/BudgetSpendAttribution.ts
@@ -1,0 +1,147 @@
+import { inArray, sql } from 'drizzle-orm'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+import { budgetReservations, usageLedger } from '../schema.js'
+import type { ReserveBudgetInput } from './PostgresBudgetReservationStore.js'
+
+export interface BudgetSpendTotals {
+  usedMicros: number
+  heldMicros: number
+}
+
+type SpendTotals = (input: ReserveBudgetInput, usageMicros: number) => Promise<BudgetSpendTotals>
+
+interface BudgetSpendAttributionStrategy<S extends ReserveBudgetInput['scope']> {
+  usageMicros(tx: PostgresJsDatabase, input: Extract<ReserveBudgetInput, { scope: S }>, period: string, start: Date, end: Date, eligibleLegacySources: readonly string[]): Promise<number>
+}
+
+const budgetSpendAttributionStrategies: { [S in ReserveBudgetInput['scope']]: BudgetSpendAttributionStrategy<S> } = {
+  model: { usageMicros: modelUsageMicros },
+  user: { usageMicros: userUsageMicros },
+}
+
+export async function computeBudgetSpend<S extends ReserveBudgetInput['scope']>(
+  tx: PostgresJsDatabase,
+  input: Extract<ReserveBudgetInput, { scope: S }>,
+  period: string,
+  start: Date,
+  end: Date,
+  eligibleLegacySources: readonly string[],
+  totals: SpendTotals,
+): Promise<BudgetSpendTotals> {
+  const strategy = budgetSpendAttributionStrategies[input.scope] as BudgetSpendAttributionStrategy<S>
+  return totals(input, await strategy.usageMicros(tx, input, period, start, end, eligibleLegacySources))
+}
+
+async function modelUsageMicros(tx: PostgresJsDatabase, input: Extract<ReserveBudgetInput, { scope: 'model' }>, period: string, start: Date, end: Date): Promise<number> {
+  const periodStartIso = start.toISOString()
+  const periodEndIso = end.toISOString()
+  const metadataExpr = sql`${usageLedger.metadata}->>'modelBudgetReservationId'`
+  const usageRows = await tx.execute(sql<{ total: string | number | null }>`
+    SELECT COALESCE(SUM(${usageLedger.billedCostMicros}), 0)::text AS total
+    FROM ${usageLedger}
+    WHERE ${usageLedger.userId} = ${input.userId}
+      AND ${usageLedger.provider} = ${input.provider}
+      AND ${usageLedger.model} = ${input.model}
+      AND (
+        EXISTS (
+          SELECT 1 FROM ${budgetReservations} r
+          WHERE r.scope = 'model'
+            AND r.user_id = ${usageLedger.userId}
+            AND r.provider = ${usageLedger.provider}
+            AND r.model = ${usageLedger.model}
+            AND r.run_id = ${usageLedger.runId}
+            AND r.period = ${period}
+            AND r.status NOT IN ('active', 'settled')
+            AND (
+              ${metadataExpr} = r.id::text
+              OR (
+                ${metadataExpr} IS NULL
+                AND r.created_at <= ${usageLedger.createdAt}
+                AND NOT EXISTS (
+                  SELECT 1 FROM ${budgetReservations} newer
+                  WHERE newer.scope = 'model'
+                    AND newer.user_id = r.user_id
+                    AND newer.provider = r.provider
+                    AND newer.model = r.model
+                    AND newer.run_id = r.run_id
+                    AND newer.created_at <= ${usageLedger.createdAt}
+                    AND (newer.created_at > r.created_at OR (newer.created_at = r.created_at AND newer.id > r.id))
+                )
+              )
+            )
+        )
+        OR (
+          ${metadataExpr} IS NULL
+          AND ${usageLedger.createdAt} >= ${periodStartIso}::timestamp
+          AND ${usageLedger.createdAt} < ${periodEndIso}::timestamp
+          AND NOT EXISTS (
+            SELECT 1 FROM ${budgetReservations} r
+            WHERE r.scope = 'model'
+              AND r.user_id = ${usageLedger.userId}
+              AND r.provider = ${usageLedger.provider}
+              AND r.model = ${usageLedger.model}
+              AND r.run_id = ${usageLedger.runId}
+              AND r.created_at <= ${usageLedger.createdAt}
+          )
+        )
+      )
+  `)
+  return Number(usageRows[0]?.total ?? 0)
+}
+
+async function userUsageMicros(tx: PostgresJsDatabase, input: Extract<ReserveBudgetInput, { scope: 'user' }>, period: string, start: Date, end: Date, eligibleLegacySources: readonly string[]): Promise<number> {
+  const periodStartIso = start.toISOString()
+  const periodEndIso = end.toISOString()
+  const metadataExpr = sql`${usageLedger.metadata}->>'userBudgetReservationId'`
+  const legacySourcePredicate = inArray(usageLedger.source, [...eligibleLegacySources])
+  const usageRows = await tx.execute(sql<{ total: string | number | null }>`
+    SELECT COALESCE(SUM(${usageLedger.billedCostMicros}), 0)::text AS total
+    FROM ${usageLedger}
+    WHERE ${usageLedger.userId} = ${input.userId}
+      AND (
+        EXISTS (
+          SELECT 1 FROM ${budgetReservations} r
+          WHERE r.scope = 'user'
+            AND r.id::text = ${metadataExpr}
+            AND r.user_id = ${usageLedger.userId}
+            AND r.period = ${period}
+            AND r.status NOT IN ('active', 'settled')
+        )
+        OR (
+          ${legacySourcePredicate}
+          AND ${metadataExpr} IS NULL
+          AND EXISTS (
+            SELECT 1 FROM ${budgetReservations} r
+            WHERE r.scope = 'user'
+              AND r.user_id = ${usageLedger.userId}
+              AND r.run_id = ${usageLedger.runId}
+              AND r.period = ${period}
+              AND r.status NOT IN ('active', 'settled')
+              AND r.created_at <= ${usageLedger.createdAt}
+              AND NOT EXISTS (
+                SELECT 1 FROM ${budgetReservations} newer
+                WHERE newer.scope = 'user'
+                  AND newer.user_id = r.user_id
+                  AND newer.run_id = r.run_id
+                  AND newer.created_at <= ${usageLedger.createdAt}
+                  AND (newer.created_at > r.created_at OR (newer.created_at = r.created_at AND newer.id > r.id))
+              )
+          )
+        )
+        OR (
+          ${legacySourcePredicate}
+          AND ${metadataExpr} IS NULL
+          AND ${usageLedger.createdAt} >= ${periodStartIso}::timestamp
+          AND ${usageLedger.createdAt} < ${periodEndIso}::timestamp
+          AND NOT EXISTS (
+            SELECT 1 FROM ${budgetReservations} r
+            WHERE r.scope = 'user'
+              AND r.user_id = ${usageLedger.userId}
+              AND r.run_id = ${usageLedger.runId}
+              AND r.created_at <= ${usageLedger.createdAt}
+          )
+        )
+      )
+  `)
+  return Number(usageRows[0]?.total ?? 0)
+}

--- a/packages/core/src/server/db/stores/PostgresBudgetReservationStore.ts
+++ b/packages/core/src/server/db/stores/PostgresBudgetReservationStore.ts
@@ -1,0 +1,439 @@
+import { and, eq, inArray, lt, or, sql } from 'drizzle-orm'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+import { budgetReservations, usageLedger } from '../schema.js'
+import { assertPositiveSafeInteger, chunkIds, lockBudgetTargets, monthPeriodUtc } from './BudgetReservationSupport.js'
+import { computeBudgetSpend } from './BudgetSpendAttribution.js'
+
+export type BudgetReservationStatus = 'active' | 'settled' | 'released' | 'expired'
+export type BudgetReservationScope = 'model' | 'user'
+
+export class ModelBudgetExceededError extends Error {
+  readonly statusCode = 402
+  readonly code = 'MODEL_BUDGET_EXCEEDED'
+
+  constructor(
+    readonly usedMicros: number,
+    readonly heldMicros: number,
+    readonly budgetMicros: number,
+    readonly requestedMicros: number,
+  ) {
+    super('Budget reached for this model.')
+    this.name = 'ModelBudgetExceededError'
+  }
+}
+
+export class UserBudgetExceededError extends Error {
+  readonly statusCode = 402
+  readonly code = 'MODEL_BUDGET_EXCEEDED'
+
+  constructor(
+    readonly usedMicros: number,
+    readonly heldMicros: number,
+    readonly budgetMicros: number,
+    readonly requestedMicros: number,
+  ) {
+    super('Budget reached for this user.')
+    this.name = 'UserBudgetExceededError'
+  }
+}
+
+interface ReserveBudgetBaseInput {
+  userId: string
+  workspaceId?: string
+  sessionId?: string
+  runId: string
+  budgetMicros: number
+  holdMicros: number
+  ttlSeconds: number
+  now?: Date
+}
+
+export type ReserveBudgetInput =
+  | (ReserveBudgetBaseInput & { scope: 'user'; provider?: never; model?: never })
+  | (ReserveBudgetBaseInput & { scope: 'model'; provider: string; model: string })
+
+export interface ReserveModelBudgetInput extends ReserveBudgetBaseInput {
+  provider: string
+  model: string
+}
+
+export interface ReserveBudgetResult {
+  scope: BudgetReservationScope
+  reservationId: string
+  created: boolean
+  period: string
+}
+
+export interface BudgetReservationAdmissionInput {
+  user?: Extract<ReserveBudgetInput, { scope: 'user' }>
+  model: Extract<ReserveBudgetInput, { scope: 'model' }>
+}
+
+export interface BudgetReservationAdmission {
+  user?: ReserveBudgetResult & { scope: 'user' }
+  model: ReserveBudgetResult & { scope: 'model' }
+}
+
+export type ReserveModelBudgetResult = ReserveBudgetResult
+
+export interface FinishReservationInput {
+  scope: BudgetReservationScope
+  reservationId?: string
+  runId?: string
+  userId?: string
+}
+
+export interface FinishModelBudgetReservationInput {
+  scope?: 'model'
+  reservationId?: string
+  runId?: string
+  userId?: string
+}
+
+type BudgetLockTarget = { scope: BudgetReservationScope; userId: string; provider?: string | null; model?: string | null; period: string }
+type BudgetReservationRow = BudgetLockTarget & { id: string }
+
+function toBudgetReservationRow(row: { id: string; scope: string; userId: string; provider?: string | null; model?: string | null; period: string }): BudgetReservationRow {
+  if (row.scope !== 'model' && row.scope !== 'user') throw new Error(`invalid budget reservation scope: ${row.scope}`)
+  return { id: row.id, scope: row.scope, userId: row.userId, provider: row.provider ?? null, model: row.model ?? null, period: row.period }
+}
+
+interface BudgetScopePolicy {
+  metadataKey: 'modelBudgetReservationId' | 'userBudgetReservationId'
+  lockKey(target: BudgetLockTarget): string
+  assertInput(input: ReserveBudgetInput): void
+  sameReservation(existing: { provider: string | null; model: string | null; period: string }, input: ReserveBudgetInput, period: string): boolean
+  exceededError: typeof ModelBudgetExceededError | typeof UserBudgetExceededError
+  totalFilter(input: ReserveBudgetInput, period: string): ReturnType<typeof sql>
+  scopeBudgetWhere(input: ReserveBudgetInput): Array<ReturnType<typeof eq>>
+}
+
+function requireModelBudgetInput(input: ReserveBudgetInput): Extract<ReserveBudgetInput, { scope: 'model' }> {
+  if (input.scope !== 'model') throw new Error('expected model budget input')
+  return input
+}
+
+const budgetScopePolicies: Record<BudgetReservationScope, BudgetScopePolicy> = {
+  model: {
+    metadataKey: 'modelBudgetReservationId',
+    lockKey: (target) => `model-budget:${target.userId}:${target.provider ?? ''}:${target.model ?? ''}:${target.period}`,
+    assertInput: (input) => {
+      const modelInput = requireModelBudgetInput(input)
+      if (!modelInput.provider.trim() || !modelInput.model.trim()) throw new Error('reserve requires provider/model')
+    },
+    sameReservation: (existing, input, period) => {
+      const modelInput = requireModelBudgetInput(input)
+      return existing.period === period && existing.provider === modelInput.provider && existing.model === modelInput.model
+    },
+    exceededError: ModelBudgetExceededError,
+    totalFilter: (input, period) => {
+      const modelInput = requireModelBudgetInput(input)
+      return sql`scope = 'model' AND user_id = ${modelInput.userId} AND provider = ${modelInput.provider} AND model = ${modelInput.model} AND period = ${period}`
+    },
+    scopeBudgetWhere: (input) => {
+      const modelInput = requireModelBudgetInput(input)
+      return [eq(budgetReservations.provider, modelInput.provider), eq(budgetReservations.model, modelInput.model)]
+    },
+  },
+  user: {
+    metadataKey: 'userBudgetReservationId',
+    lockKey: (target) => `user-budget:${target.userId}:${target.period}`,
+    assertInput: () => {},
+    sameReservation: (existing, _input, period) => existing.period === period,
+    exceededError: UserBudgetExceededError,
+    totalFilter: (input, period) => sql`scope = 'user' AND user_id = ${input.userId} AND period = ${period}`,
+    scopeBudgetWhere: () => [],
+  },
+}
+
+function scopePolicy(scope: BudgetReservationScope): BudgetScopePolicy {
+  return budgetScopePolicies[scope]
+}
+
+function budgetLockKey(target: BudgetLockTarget): string {
+  return scopePolicy(target.scope).lockKey(target)
+}
+
+function requireFinishKey(input: FinishReservationInput) {
+  if (input.reservationId) return and(eq(budgetReservations.id, input.reservationId), eq(budgetReservations.scope, input.scope))
+  if (!input.runId || !input.userId) throw new Error('finish requires reservationId or runId+userId')
+  return and(eq(budgetReservations.runId, input.runId), eq(budgetReservations.userId, input.userId), eq(budgetReservations.scope, input.scope))
+}
+
+function metadataKey(scope: BudgetReservationScope): 'modelBudgetReservationId' | 'userBudgetReservationId' {
+  return scopePolicy(scope).metadataKey
+}
+
+function admissionFromResults(results: ReserveBudgetResult[]): BudgetReservationAdmission {
+  const user = results.find((result): result is ReserveBudgetResult & { scope: 'user' } => result.scope === 'user')
+  const model = results.find((result): result is ReserveBudgetResult & { scope: 'model' } => result.scope === 'model')
+  if (!model) throw new Error('budget admission requires a model reservation')
+  const handles = user ? [user, model] : [model]
+  return { user, model }
+}
+
+function normalizeTarget(input: ReserveBudgetInput, period: string): BudgetLockTarget {
+  return { scope: input.scope, userId: input.userId, provider: input.provider ?? null, model: input.model ?? null, period }
+}
+
+function assertReserveInput(input: ReserveBudgetInput): void {
+  if (!input.userId) throw new Error('reserve requires userId')
+  scopePolicy(input.scope).assertInput(input)
+  assertPositiveSafeInteger('budgetMicros', input.budgetMicros)
+  assertPositiveSafeInteger('holdMicros', input.holdMicros)
+  if (!Number.isSafeInteger(input.ttlSeconds) || input.ttlSeconds <= 0) throw new Error('ttlSeconds must be a positive safe integer')
+}
+
+export class PostgresBudgetReservationStore {
+  constructor(private db: PostgresJsDatabase, private readonly options: { eligibleLegacySources?: readonly string[] } = {}) {}
+
+  static monthPeriodUtc(now = new Date()): string {
+    return monthPeriodUtc(now).period
+  }
+
+  async sweepExpired(now = new Date()): Promise<number> {
+    return this.db.transaction(async (tx) => {
+      const expired = await tx
+        .select({
+          id: budgetReservations.id,
+          scope: budgetReservations.scope,
+          userId: budgetReservations.userId,
+          provider: budgetReservations.provider,
+          model: budgetReservations.model,
+          period: budgetReservations.period,
+        })
+        .from(budgetReservations)
+        .where(and(eq(budgetReservations.status, 'active'), lt(budgetReservations.expiresAt, now)))
+      if (expired.length === 0) return 0
+      await lockBudgetTargets(tx, expired.map(toBudgetReservationRow), budgetLockKey)
+      let count = 0
+      for (const ids of chunkIds(expired.map((row) => row.id))) {
+        const rows = await tx.update(budgetReservations).set({ status: 'expired' }).where(and(
+          inArray(budgetReservations.id, ids),
+          eq(budgetReservations.status, 'active'),
+          lt(budgetReservations.expiresAt, now),
+        )).returning({ id: budgetReservations.id })
+        count += rows.length
+      }
+      return count
+    })
+  }
+
+  async reserve(input: ReserveBudgetInput): Promise<ReserveBudgetResult> {
+    assertReserveInput(input)
+    const now = input.now ?? new Date()
+    return this.db.transaction((tx) => this.reserveInTransaction(tx, input, now))
+  }
+
+  async reserveAdmission(input: BudgetReservationAdmissionInput): Promise<BudgetReservationAdmission> {
+    return admissionFromResults(await this.reserveMany(input.user ? [input.user, input.model] : [input.model]))
+  }
+
+  async reserveMany(inputs: readonly ReserveBudgetInput[]): Promise<ReserveBudgetResult[]> {
+    const now = inputs[0]?.now ?? new Date()
+    const period = monthPeriodUtc(now).period
+    for (const input of inputs) {
+      assertReserveInput(input)
+      if (input.now && input.now.getTime() !== now.getTime()) throw new Error('reserveMany requires all item clocks to match')
+    }
+    return this.db.transaction(async (tx) => {
+      await lockBudgetTargets(tx, inputs.map((input) => normalizeTarget(input, period)), budgetLockKey)
+      const results: ReserveBudgetResult[] = []
+      for (const input of inputs) results.push(await this.reserveInTransaction(tx, { ...input, now }, now))
+      return results
+    })
+  }
+
+  private async reserveInTransaction(tx: PostgresJsDatabase, input: ReserveBudgetInput, now: Date): Promise<ReserveBudgetResult> {
+    const period = monthPeriodUtc(now)
+    const expiresAt = new Date(now.getTime() + input.ttlSeconds * 1000)
+    const expired = await tx
+      .select({
+        id: budgetReservations.id,
+        scope: budgetReservations.scope,
+        userId: budgetReservations.userId,
+        provider: budgetReservations.provider,
+        model: budgetReservations.model,
+        period: budgetReservations.period,
+      })
+      .from(budgetReservations)
+      .where(and(
+        eq(budgetReservations.status, 'active'),
+        lt(budgetReservations.expiresAt, now),
+        or(
+          this.scopeBudgetWhere(input, period.period),
+          and(eq(budgetReservations.scope, input.scope), eq(budgetReservations.userId, input.userId), eq(budgetReservations.runId, input.runId)),
+        ),
+      ))
+    await lockBudgetTargets(tx, [normalizeTarget(input, period.period), ...expired.map(toBudgetReservationRow)], budgetLockKey)
+
+    for (const ids of chunkIds(expired.map((row) => row.id))) {
+      await tx.update(budgetReservations).set({ status: 'expired' }).where(and(
+        inArray(budgetReservations.id, ids),
+        eq(budgetReservations.status, 'active'),
+        lt(budgetReservations.expiresAt, now),
+      ))
+    }
+
+    const existing = await tx.select({
+      id: budgetReservations.id,
+      provider: budgetReservations.provider,
+      model: budgetReservations.model,
+      period: budgetReservations.period,
+    }).from(budgetReservations).where(and(
+      eq(budgetReservations.status, 'active'),
+      eq(budgetReservations.scope, input.scope),
+      eq(budgetReservations.userId, input.userId),
+      eq(budgetReservations.runId, input.runId),
+    )).limit(1)
+    const prior = existing[0]
+    if (prior) {
+      if (!scopePolicy(input.scope).sameReservation(prior, input, period.period)) throw new Error(`active ${input.scope} budget reservation for run ${input.runId} has conflicting target`)
+      return { scope: input.scope, reservationId: prior.id, created: false, period: period.period }
+    }
+
+    const { usedMicros, heldMicros } = await this.spend(tx, input, period.period, period.start, period.end)
+    if (usedMicros + heldMicros + input.holdMicros > input.budgetMicros) {
+      const ErrorCtor = scopePolicy(input.scope).exceededError
+      throw new ErrorCtor(usedMicros, heldMicros, input.budgetMicros, input.holdMicros)
+    }
+
+    const inserted = await tx.insert(budgetReservations).values({
+      userId: input.userId,
+      workspaceId: input.workspaceId ?? null,
+      sessionId: input.sessionId ?? null,
+      runId: input.runId,
+      scope: input.scope,
+      provider: input.provider ?? null,
+      model: input.model ?? null,
+      period: period.period,
+      amountMicros: input.holdMicros,
+      expiresAt,
+    }).returning({ id: budgetReservations.id })
+    return { scope: input.scope, reservationId: inserted[0]!.id, created: true, period: period.period }
+  }
+
+  async settle(input: FinishReservationInput): Promise<void> {
+    await this.finish(input, 'settled')
+  }
+
+  async release(input: FinishReservationInput): Promise<void> {
+    await this.finish(input, 'released')
+  }
+
+  metadataForAdmission(admission: BudgetReservationAdmission): Record<string, string> {
+    return Object.fromEntries(this.handlesForAdmission(admission).map((result) => [metadataKey(result.scope), result.reservationId]))
+  }
+
+  async releaseCreated(admission: BudgetReservationAdmission): Promise<void> {
+    const created = this.handlesForAdmission(admission)
+      .filter((handle) => handle.created)
+      .map((handle) => ({ scope: handle.scope, reservationId: handle.reservationId }))
+    if (created.length > 0) await this.finishMany(created, 'released')
+  }
+
+  async finishAdmission(admission: BudgetReservationAdmission, status: Exclude<BudgetReservationStatus, 'active' | 'expired'>): Promise<void> {
+    await this.finishMany(this.handlesForAdmission(admission).map((handle) => ({ scope: handle.scope, reservationId: handle.reservationId })), status)
+  }
+
+  private handlesForAdmission(admission: BudgetReservationAdmission): ReserveBudgetResult[] {
+    return admission.user ? [admission.user, admission.model] : [admission.model]
+  }
+
+  async finishRun(input: { userId: string; runId: string }, status: Exclude<BudgetReservationStatus, 'active' | 'expired'>): Promise<void> {
+    await this.finishMany((['model', 'user'] as const).map((scope) => ({ scope, runId: input.runId, userId: input.userId })), status)
+  }
+
+  async finishMany(inputs: readonly FinishReservationInput[], status: Exclude<BudgetReservationStatus, 'active' | 'expired'>): Promise<void> {
+    await this.db.transaction(async (tx) => {
+      const active: BudgetReservationRow[] = []
+      for (const input of inputs) {
+        const scope = input.scope
+        const rows = await tx.select({
+          id: budgetReservations.id,
+          scope: budgetReservations.scope,
+          userId: budgetReservations.userId,
+          provider: budgetReservations.provider,
+          model: budgetReservations.model,
+          period: budgetReservations.period,
+        }).from(budgetReservations).where(and(requireFinishKey({ ...input, scope }), eq(budgetReservations.status, 'active')))
+        active.push(...rows.map(toBudgetReservationRow))
+      }
+      if (active.length === 0) return
+      await lockBudgetTargets(tx, active, budgetLockKey)
+      for (const ids of chunkIds(active.map((row) => row.id))) {
+        await tx.update(budgetReservations).set({ status }).where(and(
+          inArray(budgetReservations.id, ids),
+          eq(budgetReservations.status, 'active'),
+        ))
+      }
+    })
+  }
+
+  private scopeBudgetWhere(input: ReserveBudgetInput, period: string) {
+    const base = [
+      eq(budgetReservations.scope, input.scope),
+      eq(budgetReservations.status, 'active'),
+      eq(budgetReservations.userId, input.userId),
+      eq(budgetReservations.period, period),
+    ]
+    base.push(...scopePolicy(input.scope).scopeBudgetWhere(input))
+    return and(...base)
+  }
+
+  private async reservationTotal(
+    tx: PostgresJsDatabase,
+    input: ReserveBudgetInput,
+    period: string,
+    status: 'active' | 'settled',
+  ): Promise<number> {
+    const scopeFilter = scopePolicy(input.scope).totalFilter(input, period)
+    const rows = await tx.execute(sql<{ total: string | number | null }>`
+      SELECT COALESCE(SUM(amount_micros), 0)::text AS total
+      FROM ${budgetReservations}
+      WHERE status = ${status} AND ${scopeFilter}
+    `)
+    return Number(rows[0]?.total ?? 0)
+  }
+
+  private async spend(tx: PostgresJsDatabase, input: ReserveBudgetInput, period: string, start: Date, end: Date) {
+    return computeBudgetSpend(
+      tx,
+      input,
+      period,
+      start,
+      end,
+      this.options.eligibleLegacySources ?? [],
+      (budgetInput, usageMicros) => this.spendTotals(tx, budgetInput, period, usageMicros),
+    )
+  }
+
+  private async spendTotals(tx: PostgresJsDatabase, input: ReserveBudgetInput, period: string, usageMicros: number) {
+    const heldMicros = await this.reservationTotal(tx, input, period, 'active')
+    const settledFallbackMicros = await this.reservationTotal(tx, input, period, 'settled')
+    return { usedMicros: usageMicros + settledFallbackMicros, heldMicros }
+  }
+
+  private async finish(input: FinishReservationInput, status: Exclude<BudgetReservationStatus, 'active' | 'expired'>): Promise<void> {
+    await this.db.transaction((tx) => this.finishInTransaction(tx, input, status))
+  }
+
+  private async finishInTransaction(tx: PostgresJsDatabase, input: FinishReservationInput, status: Exclude<BudgetReservationStatus, 'active' | 'expired'>): Promise<void> {
+    const scope = input.scope
+    const active = await tx.select({
+      id: budgetReservations.id,
+      scope: budgetReservations.scope,
+      userId: budgetReservations.userId,
+      provider: budgetReservations.provider,
+      model: budgetReservations.model,
+      period: budgetReservations.period,
+    }).from(budgetReservations).where(and(requireFinishKey({ ...input, scope }), eq(budgetReservations.status, 'active')))
+    if (active.length === 0) return
+    await lockBudgetTargets(tx, active.map(toBudgetReservationRow), budgetLockKey)
+    await tx.update(budgetReservations).set({ status }).where(and(
+      inArray(budgetReservations.id, active.map((row) => row.id)),
+      eq(budgetReservations.status, 'active'),
+    ))
+  }
+}
+

--- a/packages/core/src/server/db/stores/PostgresMeteringStore.ts
+++ b/packages/core/src/server/db/stores/PostgresMeteringStore.ts
@@ -643,12 +643,37 @@ export class PostgresMeteringStore {
           billedCostMicros: usageLedger.billedCostMicros,
           stopReason: usageLedger.stopReason,
           reservationId: sql<string | null>`${usageLedger.metadata}->>'reservationId'`,
+          modelBudgetReservationId: sql<string | null>`${usageLedger.metadata}->>'modelBudgetReservationId'`,
+          userBudgetReservationId: sql<string | null>`${usageLedger.metadata}->>'userBudgetReservationId'`,
         })
         .from(usageLedger)
         .where(eq(usageLedger.id, input.usageId))
         .limit(1)
       const e = existing[0]
+      if (!e) throw new Error(`usage ledger id collision for ${input.usageId}: conflicting row disappeared before idempotency check`)
       const incomingReservationId = (input.metadata?.reservationId as string | undefined) ?? null
+      const incomingModelBudgetReservationId = (input.metadata?.modelBudgetReservationId as string | undefined) ?? null
+      const incomingUserBudgetReservationId = (input.metadata?.userBudgetReservationId as string | undefined) ?? null
+      const legacyMetadataCanBeBackfilled = (existing: string | null, incoming: string | null) => existing === null && incoming !== null
+      const retryMetadataIsAbsent = (existing: string | null, incoming: string | null) => existing !== null && incoming === null
+      const metadataFieldIsIdempotent = (existing: string | null, incoming: string | null) =>
+        existing === incoming || legacyMetadataCanBeBackfilled(existing, incoming) || retryMetadataIsAbsent(existing, incoming)
+      const exactBudgetMetadataMatch =
+        e.modelBudgetReservationId === incomingModelBudgetReservationId &&
+        e.userBudgetReservationId === incomingUserBudgetReservationId
+      const backfillableBudgetMetadata =
+        !exactBudgetMetadataMatch &&
+        (legacyMetadataCanBeBackfilled(e.modelBudgetReservationId, incomingModelBudgetReservationId) ||
+          legacyMetadataCanBeBackfilled(e.userBudgetReservationId, incomingUserBudgetReservationId)) &&
+        metadataFieldIsIdempotent(e.modelBudgetReservationId, incomingModelBudgetReservationId) &&
+        metadataFieldIsIdempotent(e.userBudgetReservationId, incomingUserBudgetReservationId)
+      const budgetMetadataIsIdempotent =
+        exactBudgetMetadataMatch ||
+        backfillableBudgetMetadata ||
+        ((retryMetadataIsAbsent(e.modelBudgetReservationId, incomingModelBudgetReservationId) ||
+          retryMetadataIsAbsent(e.userBudgetReservationId, incomingUserBudgetReservationId)) &&
+          metadataFieldIsIdempotent(e.modelBudgetReservationId, incomingModelBudgetReservationId) &&
+          metadataFieldIsIdempotent(e.userBudgetReservationId, incomingUserBudgetReservationId))
       const matches =
         e &&
         e.userId === input.userId &&
@@ -664,9 +689,20 @@ export class PostgresMeteringStore {
         e.providerCostMicros === (input.providerCostMicros ?? 0) &&
         e.billedCostMicros === input.billedCostMicros &&
         e.stopReason === (input.stopReason ?? null) &&
-        e.reservationId === incomingReservationId
+        e.reservationId === incomingReservationId &&
+        budgetMetadataIsIdempotent
       if (!matches) {
         throw new Error(`usage ledger id collision for ${input.usageId}: existing row does not match this usage (refusing to silently drop the debit or corrupt the audit trail)`)
+      }
+      if (!exactBudgetMetadataMatch && backfillableBudgetMetadata) {
+        const metadataPatch: Record<string, string> = {}
+        if (legacyMetadataCanBeBackfilled(e.modelBudgetReservationId, incomingModelBudgetReservationId)) metadataPatch.modelBudgetReservationId = incomingModelBudgetReservationId!
+        if (legacyMetadataCanBeBackfilled(e.userBudgetReservationId, incomingUserBudgetReservationId)) metadataPatch.userBudgetReservationId = incomingUserBudgetReservationId!
+        await tx.update(usageLedger)
+          .set({
+            metadata: sql`COALESCE(${usageLedger.metadata}, '{}'::jsonb) || ${JSON.stringify(metadataPatch)}::jsonb`,
+          })
+          .where(eq(usageLedger.id, input.usageId))
       }
       return { inserted: false }
     })

--- a/packages/core/src/server/db/stores/PostgresModelBudgetStore.ts
+++ b/packages/core/src/server/db/stores/PostgresModelBudgetStore.ts
@@ -1,23 +1,8 @@
-import { and, eq, inArray, lt, or, sql } from 'drizzle-orm'
+import { PostgresBudgetReservationStore } from './PostgresBudgetReservationStore.js'
+import type { FinishReservationInput, ReserveBudgetInput, ReserveBudgetResult } from './PostgresBudgetReservationStore.js'
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
-import { modelBudgetReservations, usageLedger } from '../schema.js'
 
-export type ModelBudgetReservationStatus = 'active' | 'settled' | 'released' | 'expired'
-
-export class ModelBudgetExceededError extends Error {
-  readonly statusCode = 402
-  readonly code = 'MODEL_BUDGET_EXCEEDED'
-
-  constructor(
-    readonly usedMicros: number,
-    readonly heldMicros: number,
-    readonly budgetMicros: number,
-    readonly requestedMicros: number,
-  ) {
-    super('Budget reached for this model.')
-    this.name = 'ModelBudgetExceededError'
-  }
-}
+export { ModelBudgetExceededError } from './PostgresBudgetReservationStore.js'
 
 export interface ReserveModelBudgetInput {
   userId: string
@@ -32,314 +17,37 @@ export interface ReserveModelBudgetInput {
   now?: Date
 }
 
-export interface ReserveModelBudgetResult {
-  reservationId: string
-  created: boolean
-  period: string
-}
+export type ReserveModelBudgetResult = Omit<ReserveBudgetResult, 'scope'>
 
-export interface FinishModelBudgetReservationInput {
-  reservationId?: string
-  runId?: string
-  userId?: string
-}
-
-const UPDATE_ID_BATCH_SIZE = 1_000
-
-function assertPositiveSafeInteger(name: string, value: number): void {
-  if (!Number.isSafeInteger(value) || value <= 0) throw new Error(`${name} must be a positive safe integer`)
-}
-
-function monthPeriodUtc(now: Date): { period: string; start: Date; end: Date } {
-  const year = now.getUTCFullYear()
-  const month = now.getUTCMonth()
-  return {
-    period: `${year}-${String(month + 1).padStart(2, '0')}`,
-    start: new Date(Date.UTC(year, month, 1, 0, 0, 0, 0)),
-    end: new Date(Date.UTC(year, month + 1, 1, 0, 0, 0, 0)),
-  }
-}
-
-function requireFinishKey(input: FinishModelBudgetReservationInput) {
-  if (input.reservationId) return eq(modelBudgetReservations.id, input.reservationId)
-  if (!input.runId || !input.userId) throw new Error('finish requires reservationId or runId+userId')
-  return and(eq(modelBudgetReservations.runId, input.runId), eq(modelBudgetReservations.userId, input.userId))
-}
-
-function chunkIds(ids: string[]): string[][] {
-  const chunks: string[][] = []
-  for (let index = 0; index < ids.length; index += UPDATE_ID_BATCH_SIZE) {
-    chunks.push(ids.slice(index, index + UPDATE_ID_BATCH_SIZE))
-  }
-  return chunks
-}
-
-type ModelBudgetLockTarget = {
-  userId: string
-  provider: string
-  model: string
-  period: string
-}
-
-function modelBudgetAdvisoryLockKey(target: ModelBudgetLockTarget): string {
-  return `model-budget:${target.userId}:${target.provider}:${target.model}:${target.period}`
-}
-
-async function lockModelBudgetTargets(
-  executor: Pick<PostgresJsDatabase, 'execute'>,
-  targets: readonly ModelBudgetLockTarget[],
-): Promise<void> {
-  const keys = Array.from(new Set(targets.map(modelBudgetAdvisoryLockKey))).sort()
-  for (const key of keys) {
-    await executor.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${key}))`)
-  }
+export interface FinishModelBudgetReservationInput extends Omit<FinishReservationInput, 'scope'> {
+  scope?: 'model'
 }
 
 export class PostgresModelBudgetStore {
-  constructor(private db: PostgresJsDatabase) {}
+  private readonly store: PostgresBudgetReservationStore
 
-  static monthPeriodUtc(now = new Date()): string {
-    return monthPeriodUtc(now).period
+  constructor(db: PostgresJsDatabase) {
+    this.store = new PostgresBudgetReservationStore(db)
   }
 
-  async sweepExpired(now = new Date()): Promise<number> {
-    return this.db.transaction(async (tx) => {
-      const expired = await tx
-        .select({
-          id: modelBudgetReservations.id,
-          userId: modelBudgetReservations.userId,
-          provider: modelBudgetReservations.provider,
-          model: modelBudgetReservations.model,
-          period: modelBudgetReservations.period,
-        })
-        .from(modelBudgetReservations)
-        .where(and(eq(modelBudgetReservations.status, 'active'), lt(modelBudgetReservations.expiresAt, now)))
-      if (expired.length === 0) return 0
-      await lockModelBudgetTargets(tx, expired)
-      let count = 0
-      for (const ids of chunkIds(expired.map((row) => row.id))) {
-        const rows = await tx
-          .update(modelBudgetReservations)
-          .set({ status: 'expired' })
-          .where(and(
-            inArray(modelBudgetReservations.id, ids),
-            eq(modelBudgetReservations.status, 'active'),
-            lt(modelBudgetReservations.expiresAt, now),
-          ))
-          .returning({ id: modelBudgetReservations.id })
-        count += rows.length
-      }
-      return count
-    })
+  static monthPeriodUtc(now = new Date()): string {
+    return PostgresBudgetReservationStore.monthPeriodUtc(now)
+  }
+
+  sweepExpired(now = new Date()): Promise<number> {
+    return this.store.sweepExpired(now)
   }
 
   async reserve(input: ReserveModelBudgetInput): Promise<ReserveModelBudgetResult> {
-    if (!input.userId) throw new Error('reserve requires userId')
-    if (!input.provider || !input.model) throw new Error('reserve requires provider/model')
-    assertPositiveSafeInteger('budgetMicros', input.budgetMicros)
-    assertPositiveSafeInteger('holdMicros', input.holdMicros)
-    if (!Number.isSafeInteger(input.ttlSeconds) || input.ttlSeconds <= 0) throw new Error('ttlSeconds must be a positive safe integer')
-
-    const now = input.now ?? new Date()
-    const period = monthPeriodUtc(now)
-    const expiresAt = new Date(now.getTime() + input.ttlSeconds * 1000)
-
-    return this.db.transaction(async (tx) => {
-      const expired = await tx
-        .select({
-          id: modelBudgetReservations.id,
-          userId: modelBudgetReservations.userId,
-          provider: modelBudgetReservations.provider,
-          model: modelBudgetReservations.model,
-          period: modelBudgetReservations.period,
-        })
-        .from(modelBudgetReservations)
-        .where(and(
-          eq(modelBudgetReservations.status, 'active'),
-          lt(modelBudgetReservations.expiresAt, now),
-          or(
-            and(
-              eq(modelBudgetReservations.userId, input.userId),
-              eq(modelBudgetReservations.provider, input.provider),
-              eq(modelBudgetReservations.model, input.model),
-              eq(modelBudgetReservations.period, period.period),
-            ),
-            and(
-              eq(modelBudgetReservations.userId, input.userId),
-              eq(modelBudgetReservations.runId, input.runId),
-            ),
-          ),
-        ))
-      await lockModelBudgetTargets(tx, [
-        { userId: input.userId, provider: input.provider, model: input.model, period: period.period },
-        ...expired,
-      ])
-
-      for (const ids of chunkIds(expired.map((row) => row.id))) {
-        await tx
-          .update(modelBudgetReservations)
-          .set({ status: 'expired' })
-          .where(and(
-            inArray(modelBudgetReservations.id, ids),
-            eq(modelBudgetReservations.status, 'active'),
-            lt(modelBudgetReservations.expiresAt, now),
-          ))
-      }
-
-      const existing = await tx
-        .select({
-          id: modelBudgetReservations.id,
-          provider: modelBudgetReservations.provider,
-          model: modelBudgetReservations.model,
-          period: modelBudgetReservations.period,
-        })
-        .from(modelBudgetReservations)
-        .where(and(
-          eq(modelBudgetReservations.status, 'active'),
-          eq(modelBudgetReservations.userId, input.userId),
-          eq(modelBudgetReservations.runId, input.runId),
-        ))
-        .limit(1)
-      const prior = existing[0]
-      if (prior) {
-        if (prior.provider !== input.provider || prior.model !== input.model || prior.period !== period.period) {
-          throw new Error(`active model budget reservation for run ${input.runId} has conflicting tuple`)
-        }
-        return { reservationId: prior.id, created: false, period: period.period }
-      }
-
-      const periodStartIso = period.start.toISOString()
-      const periodEndIso = period.end.toISOString()
-      // Reserved-run spend is attributed to the reservation's period, not the
-      // ledger row's created_at, so a run reserved before a UTC month boundary
-      // and settled after it counts exactly once (in the reserved period).
-      // Ledger rows stamped with modelBudgetReservationId map directly; legacy
-      // rows without the stamp fall back to the newest reservation created at
-      // or before the row (run ids can be reused across periods). Unreserved
-      // legacy rows are counted by created_at month.
-      const usageRows = await tx.execute(sql<{ total: string | number | null }>`
-        SELECT COALESCE(SUM(${usageLedger.billedCostMicros}), 0)::text AS total
-        FROM ${usageLedger}
-        WHERE ${usageLedger.userId} = ${input.userId}
-          AND ${usageLedger.provider} = ${input.provider}
-          AND ${usageLedger.model} = ${input.model}
-          AND (
-            (
-              EXISTS (
-                SELECT 1 FROM ${modelBudgetReservations} r
-                WHERE r.user_id = ${usageLedger.userId}
-                  AND r.provider = ${usageLedger.provider}
-                  AND r.model = ${usageLedger.model}
-                  AND r.run_id = ${usageLedger.runId}
-                  AND r.period = ${period.period}
-                  AND r.status NOT IN ('active', 'settled')
-                  AND (
-                    ${usageLedger.metadata}->>'modelBudgetReservationId' = r.id::text
-                    OR (
-                      ${usageLedger.metadata}->>'modelBudgetReservationId' IS NULL
-                      AND r.created_at <= ${usageLedger.createdAt}
-                      AND NOT EXISTS (
-                        SELECT 1 FROM ${modelBudgetReservations} newer
-                        WHERE newer.user_id = r.user_id
-                          AND newer.provider = r.provider
-                          AND newer.model = r.model
-                          AND newer.run_id = r.run_id
-                          AND newer.created_at <= ${usageLedger.createdAt}
-                          AND (
-                            newer.created_at > r.created_at
-                            OR (newer.created_at = r.created_at AND newer.id > r.id)
-                          )
-                      )
-                    )
-                  )
-              )
-            )
-            OR (
-              ${usageLedger.createdAt} >= ${periodStartIso}::timestamp
-              AND ${usageLedger.createdAt} < ${periodEndIso}::timestamp
-              AND ${usageLedger.metadata}->>'modelBudgetReservationId' IS NULL
-              AND NOT EXISTS (
-                SELECT 1 FROM ${modelBudgetReservations} r
-                WHERE r.user_id = ${usageLedger.userId}
-                  AND r.provider = ${usageLedger.provider}
-                  AND r.model = ${usageLedger.model}
-                  AND r.run_id = ${usageLedger.runId}
-                  AND r.created_at <= ${usageLedger.createdAt}
-              )
-            )
-          )
-      `)
-      const heldRows = await tx.execute(sql<{ total: string | number | null }>`
-        SELECT COALESCE(SUM(amount_micros), 0)::text AS total
-        FROM ${modelBudgetReservations}
-        WHERE status = 'active'
-          AND user_id = ${input.userId}
-          AND provider = ${input.provider}
-          AND model = ${input.model}
-          AND period = ${period.period}
-      `)
-      const settledFallbackRows = await tx.execute(sql<{ total: string | number | null }>`
-        SELECT COALESCE(SUM(amount_micros), 0)::text AS total
-        FROM ${modelBudgetReservations}
-        WHERE status = 'settled'
-          AND user_id = ${input.userId}
-          AND provider = ${input.provider}
-          AND model = ${input.model}
-          AND period = ${period.period}
-      `)
-      const usedMicros = Number(usageRows[0]?.total ?? 0) + Number(settledFallbackRows[0]?.total ?? 0)
-      const heldMicros = Number(heldRows[0]?.total ?? 0)
-      if (usedMicros + heldMicros + input.holdMicros > input.budgetMicros) {
-        throw new ModelBudgetExceededError(usedMicros, heldMicros, input.budgetMicros, input.holdMicros)
-      }
-
-      const inserted = await tx
-        .insert(modelBudgetReservations)
-        .values({
-          userId: input.userId,
-          workspaceId: input.workspaceId ?? null,
-          sessionId: input.sessionId ?? null,
-          runId: input.runId,
-          provider: input.provider,
-          model: input.model,
-          period: period.period,
-          amountMicros: input.holdMicros,
-          expiresAt,
-        })
-        .returning({ id: modelBudgetReservations.id })
-      return { reservationId: inserted[0]!.id, created: true, period: period.period }
-    })
+    const { scope: _scope, ...result } = await this.store.reserve({ ...input, scope: 'model' } satisfies ReserveBudgetInput)
+    return result
   }
 
-  async settle(input: FinishModelBudgetReservationInput): Promise<void> {
-    await this.finish(input, 'settled')
+  settle(input: FinishModelBudgetReservationInput): Promise<void> {
+    return this.store.settle({ ...input, scope: 'model' })
   }
 
-  async release(input: FinishModelBudgetReservationInput): Promise<void> {
-    await this.finish(input, 'released')
-  }
-
-  private async finish(input: FinishModelBudgetReservationInput, status: Exclude<ModelBudgetReservationStatus, 'active' | 'expired'>): Promise<void> {
-    await this.db.transaction(async (tx) => {
-      const active = await tx
-        .select({
-          id: modelBudgetReservations.id,
-          userId: modelBudgetReservations.userId,
-          provider: modelBudgetReservations.provider,
-          model: modelBudgetReservations.model,
-          period: modelBudgetReservations.period,
-        })
-        .from(modelBudgetReservations)
-        .where(and(requireFinishKey(input), eq(modelBudgetReservations.status, 'active')))
-      if (active.length === 0) return
-      await lockModelBudgetTargets(tx, active)
-      await tx
-        .update(modelBudgetReservations)
-        .set({ status })
-        .where(and(
-          inArray(modelBudgetReservations.id, active.map((row) => row.id)),
-          eq(modelBudgetReservations.status, 'active'),
-        ))
-    })
+  release(input: FinishModelBudgetReservationInput): Promise<void> {
+    return this.store.release({ ...input, scope: 'model' })
   }
 }

--- a/packages/core/src/server/db/stores/__tests__/PostgresModelBudgetStore.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/PostgresModelBudgetStore.test.ts
@@ -3,6 +3,7 @@ import postgres from 'postgres'
 import { drizzle } from 'drizzle-orm/postgres-js'
 import { runMigrations } from '../../migrate'
 import { ModelBudgetExceededError, PostgresModelBudgetStore } from '../PostgresModelBudgetStore'
+import { PostgresBudgetReservationStore, UserBudgetExceededError } from '../PostgresBudgetReservationStore'
 import type { CoreConfig } from '../../../../shared/types'
 
 const TEST_DB_URL_CANDIDATES = [
@@ -101,12 +102,14 @@ const TEST_DB = await resolveTestDb()
 
 let sqlClient: postgres.Sql
 let store: PostgresModelBudgetStore
+let budgetStore: PostgresBudgetReservationStore
 
 beforeAll(async () => {
   if (!TEST_DB) return
   await runMigrations(baseConfig(TEST_DB.databaseUrl))
   sqlClient = postgres(TEST_DB.databaseUrl, { max: 5 })
   store = new PostgresModelBudgetStore(drizzle(sqlClient))
+  budgetStore = new PostgresBudgetReservationStore(drizzle(sqlClient))
 })
 
 afterAll(async () => {
@@ -115,7 +118,7 @@ afterAll(async () => {
 })
 
 beforeEach(async () => {
-  await sqlClient`DELETE FROM boring_model_budget_reservations WHERE user_id IN (${USER}, ${OTHER_USER})`
+  await sqlClient`DELETE FROM boring_budget_reservations WHERE user_id IN (${USER}, ${OTHER_USER})`
   await sqlClient`DELETE FROM boring_usage_ledger WHERE user_id IN (${USER}, ${OTHER_USER})`
 })
 
@@ -127,12 +130,12 @@ describe.runIf(TEST_DB)('PostgresModelBudgetStore', () => {
 
     expect(second).toEqual({ ...first, created: false })
     await store.settle({ reservationId: first.reservationId })
-    const settled = await sqlClient`SELECT status FROM boring_model_budget_reservations WHERE id = ${first.reservationId}`
+    const settled = await sqlClient`SELECT status FROM boring_budget_reservations WHERE id = ${first.reservationId}`
     expect(settled[0]?.status).toBe('settled')
 
     const released = await store.reserve({ userId: USER, runId: 'run-2', provider: 'infomaniak', model: 'qwen', budgetMicros: 2_000_000, holdMicros: 1_000_000, ttlSeconds: 60, now })
     await store.release({ reservationId: released.reservationId })
-    const rows = await sqlClient`SELECT status FROM boring_model_budget_reservations WHERE id = ${released.reservationId}`
+    const rows = await sqlClient`SELECT status FROM boring_budget_reservations WHERE id = ${released.reservationId}`
     expect(rows[0]?.status).toBe('released')
   })
 
@@ -164,13 +167,13 @@ describe.runIf(TEST_DB)('PostgresModelBudgetStore', () => {
 
       release = store.release({ reservationId: first.reservationId })
       await expectStillPending(release)
-      const rows = await sqlClient`SELECT status FROM boring_model_budget_reservations WHERE id = ${first.reservationId}`
+      const rows = await sqlClient`SELECT status FROM boring_budget_reservations WHERE id = ${first.reservationId}`
       expect(rows[0]?.status).toBe('active')
     })
 
     await expect(overReserve).rejects.toBeInstanceOf(ModelBudgetExceededError)
     await expect(release).resolves.toBeUndefined()
-    const rows = await sqlClient`SELECT status FROM boring_model_budget_reservations WHERE id = ${first.reservationId}`
+    const rows = await sqlClient`SELECT status FROM boring_budget_reservations WHERE id = ${first.reservationId}`
     expect(rows[0]?.status).toBe('released')
   })
 
@@ -205,11 +208,11 @@ describe.runIf(TEST_DB)('PostgresModelBudgetStore', () => {
     const afterDelayedUsage = new Date('2026-08-01T00:06:00Z')
 
     const exact = await store.reserve({ userId: USER, runId: 'boundary-ledger', provider: 'infomaniak', model: 'qwen', budgetMicros: 1_500_000, holdMicros: 1_000_000, ttlSeconds: 60, now: beforeBoundary })
-    await sqlClient`UPDATE boring_model_budget_reservations SET created_at = ${beforeBoundary.toISOString()}::timestamp WHERE id = ${exact.reservationId}`
+    await sqlClient`UPDATE boring_budget_reservations SET created_at = ${beforeBoundary.toISOString()}::timestamp WHERE id = ${exact.reservationId}`
     await store.release({ reservationId: exact.reservationId })
 
     const reused = await store.reserve({ userId: USER, runId: 'boundary-ledger', provider: 'infomaniak', model: 'qwen', budgetMicros: 1_000_000, holdMicros: 1_000_000, ttlSeconds: 60, now: afterReuse })
-    await sqlClient`UPDATE boring_model_budget_reservations SET created_at = ${afterReuse.toISOString()}::timestamp WHERE id = ${reused.reservationId}`
+    await sqlClient`UPDATE boring_budget_reservations SET created_at = ${afterReuse.toISOString()}::timestamp WHERE id = ${reused.reservationId}`
     await store.release({ reservationId: reused.reservationId })
     await sqlClient`
       INSERT INTO boring_usage_ledger (id, user_id, run_id, provider, model, billed_cost_micros, created_at, metadata)
@@ -225,7 +228,7 @@ describe.runIf(TEST_DB)('PostgresModelBudgetStore', () => {
     await expect(store.reserve({ userId: USER, runId: 'boundary-jul-over', provider: 'infomaniak', model: 'qwen', budgetMicros: 1_500_000, holdMicros: 500_001, ttlSeconds: 60, now: beforeBoundary })).rejects.toBeInstanceOf(ModelBudgetExceededError)
 
     const fallback = await store.reserve({ userId: OTHER_USER, runId: 'boundary-fallback', provider: 'infomaniak', model: 'qwen', budgetMicros: 1_500_000, holdMicros: 1_000_000, ttlSeconds: 60, now: beforeBoundary })
-    await sqlClient`UPDATE boring_model_budget_reservations SET created_at = ${beforeBoundary.toISOString()}::timestamp WHERE id = ${fallback.reservationId}`
+    await sqlClient`UPDATE boring_budget_reservations SET created_at = ${beforeBoundary.toISOString()}::timestamp WHERE id = ${fallback.reservationId}`
     await sqlClient`
       INSERT INTO boring_usage_ledger (id, user_id, run_id, provider, model, billed_cost_micros, created_at)
       VALUES ('usage-budget-boundary-fallback', ${OTHER_USER}, 'boundary-fallback', 'infomaniak', 'qwen', 200000, ${afterBoundary.toISOString()}::timestamp)
@@ -237,6 +240,26 @@ describe.runIf(TEST_DB)('PostgresModelBudgetStore', () => {
     await expect(store.reserve({ userId: OTHER_USER, runId: 'boundary-fallback-jul-ok', provider: 'infomaniak', model: 'qwen', budgetMicros: 1_500_000, holdMicros: 500_000, ttlSeconds: 60, now: beforeBoundary })).resolves.toMatchObject({ created: true })
     await store.release({ runId: 'boundary-fallback-jul-ok', userId: OTHER_USER })
     await expect(store.reserve({ userId: OTHER_USER, runId: 'boundary-fallback-jul-over', provider: 'infomaniak', model: 'qwen', budgetMicros: 1_500_000, holdMicros: 500_001, ttlSeconds: 60, now: beforeBoundary })).rejects.toBeInstanceOf(ModelBudgetExceededError)
+  })
+
+  it('enforces user-scope aggregate budgets with active holds and fallback rows', async () => {
+    const now = new Date('2026-07-15T12:00:00Z')
+    const userHold = await budgetStore.reserve({ scope: 'user', userId: USER, runId: 'user-active', budgetMicros: 2_000_000, holdMicros: 1_000_000, ttlSeconds: 60, now })
+    await sqlClient`
+      INSERT INTO boring_usage_ledger (id, user_id, run_id, source, provider, model, billed_cost_micros, created_at, metadata)
+      VALUES ('usage-user-active', ${USER}, 'user-active', 'pi-chat', 'infomaniak', 'qwen', 900000, ${now.toISOString()}::timestamp, ${JSON.stringify({ userBudgetReservationId: userHold.reservationId })}::jsonb)
+    `
+
+    await expect(budgetStore.reserve({ scope: 'user', userId: USER, runId: 'user-next-ok', budgetMicros: 2_000_000, holdMicros: 1_000_000, ttlSeconds: 60, now })).resolves.toMatchObject({ created: true })
+    await budgetStore.release({ scope: 'user', runId: 'user-next-ok', userId: USER })
+
+    const fallback = await budgetStore.reserve({ scope: 'user', userId: OTHER_USER, runId: 'user-fallback', budgetMicros: 1_500_000, holdMicros: 1_000_000, ttlSeconds: 60, now })
+    await sqlClient`
+      INSERT INTO boring_usage_ledger (id, user_id, run_id, source, billed_cost_micros, created_at, metadata)
+      VALUES ('usage-user-fallback', ${OTHER_USER}, 'user-fallback', 'pi-chat-fallback', 1000000, ${now.toISOString()}::timestamp, ${JSON.stringify({ userBudgetReservationId: fallback.reservationId })}::jsonb)
+    `
+    await budgetStore.release({ scope: 'user', reservationId: fallback.reservationId })
+    await expect(budgetStore.reserve({ scope: 'user', userId: OTHER_USER, runId: 'user-over', budgetMicros: 1_500_000, holdMicros: 600_000, ttlSeconds: 60, now })).rejects.toBeInstanceOf(UserBudgetExceededError)
   })
 
   it('does not double-count ledger rows for runs with active holds', async () => {

--- a/packages/core/src/server/db/stores/index.ts
+++ b/packages/core/src/server/db/stores/index.ts
@@ -3,7 +3,9 @@ export { LocalWorkspaceStore } from './LocalWorkspaceStore.js'
 export { PostgresWorkspaceStore } from './PostgresWorkspaceStore.js'
 export { PostgresUserStore } from './PostgresUserStore.js'
 export { PostgresMeteringStore, InsufficientCreditError } from './PostgresMeteringStore.js'
-export { PostgresModelBudgetStore, ModelBudgetExceededError } from './PostgresModelBudgetStore.js'
+export { PostgresBudgetReservationStore, ModelBudgetExceededError, UserBudgetExceededError } from './PostgresBudgetReservationStore.js'
+export type { BudgetReservationAdmission, BudgetReservationAdmissionInput, ReserveBudgetInput, ReserveBudgetResult, FinishReservationInput as FinishBudgetReservationInput, BudgetReservationScope } from './PostgresBudgetReservationStore.js'
+export { PostgresModelBudgetStore } from './PostgresModelBudgetStore.js'
 export type {
   MeteringBalance,
   GrantOnceInput,

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -24,7 +24,8 @@ export {
 
 export { createDatabase, runMigrations } from './db/index.js'
 export type { Database } from './db/index.js'
-export { PostgresMeteringStore, InsufficientCreditError, PostgresModelBudgetStore, ModelBudgetExceededError } from './db/index.js'
+export { PostgresMeteringStore, InsufficientCreditError, PostgresBudgetReservationStore, PostgresModelBudgetStore, ModelBudgetExceededError, UserBudgetExceededError } from './db/index.js'
+export type { BudgetReservationAdmission, BudgetReservationAdmissionInput, ReserveBudgetInput, ReserveBudgetResult, FinishBudgetReservationInput, BudgetReservationScope } from './db/index.js'
 export type {
   MeteringBalance,
   GrantOnceInput,

--- a/plugins/boring-governance/README.md
+++ b/plugins/boring-governance/README.md
@@ -31,3 +31,21 @@ const governanceCompanyAdmin = createGovernanceCompanyAdmin()
 ```
 
 Policy source is configured with `BORING_GOVERNANCE_POLICY_PATH`. Company context source roots use `BORING_GOVERNANCE_COMPANY_CONTEXT_ROOT` or the default workspace root resolver outside sandbox mode.
+
+## Policy budgets
+
+Model grants remain the model picker allowlist. Optional user budgets cap aggregate monthly spend across all allowed models; optional per-model budgets cap individual models.
+
+```yaml
+users:
+  - email: readonly@example.com
+    role: user
+    budgets:
+      monthlyEur: 10
+    models:
+      - provider: infomaniak
+        id: Qwen/Qwen3.5-122B-A10B-FP8
+        monthlyBudgetEur: 2
+```
+
+A run is admitted only when the user is allowed to use the selected model, the aggregate user budget has remaining monthly capacity, and the selected model budget has remaining monthly capacity.

--- a/plugins/boring-governance/src/front/GovernanceAdminView.tsx
+++ b/plugins/boring-governance/src/front/GovernanceAdminView.tsx
@@ -23,6 +23,7 @@ export interface GovernanceMeResponse {
   users?: Array<{
     email: string
     role: 'admin' | 'user'
+    monthlyBudgetEur: number | null
     modelCount: number
     contextRuleCount: number
   }>
@@ -133,17 +134,18 @@ export function GovernanceAdminView({ status }: { status: GovernanceMeResponse }
                 <div className="mt-5 overflow-hidden rounded-lg border border-border bg-background">
                   <table className="w-full text-left text-sm">
                     <thead className="bg-muted/60 text-xs uppercase tracking-[0.12em] text-muted-foreground">
-                      <tr><th className="px-3 py-2 font-medium">User</th><th className="px-3 py-2 font-medium">Role</th><th className="px-3 py-2 font-medium">Models</th><th className="px-3 py-2 font-medium">Context rules</th></tr>
+                      <tr><th className="px-3 py-2 font-medium">User</th><th className="px-3 py-2 font-medium">Role</th><th className="px-3 py-2 font-medium">Monthly budget</th><th className="px-3 py-2 font-medium">Models</th><th className="px-3 py-2 font-medium">Context rules</th></tr>
                     </thead>
                     <tbody>
                       {(status.users ?? []).length > 0 ? status.users!.map((user) => (
                         <tr key={user.email} className="border-t border-border">
                           <td className="px-3 py-2 font-medium">{user.email}</td>
                           <td className="px-3 py-2">{user.role}</td>
+                          <td className="px-3 py-2">{user.monthlyBudgetEur == null ? '—' : `€${user.monthlyBudgetEur}`}</td>
                           <td className="px-3 py-2">{user.modelCount}</td>
                           <td className="px-3 py-2">{user.contextRuleCount}</td>
                         </tr>
-                      )) : <tr><td colSpan={4} className="px-3 py-4 text-muted-foreground">No users in policy.</td></tr>}
+                      )) : <tr><td colSpan={5} className="px-3 py-4 text-muted-foreground">No users in policy.</td></tr>}
                     </tbody>
                   </table>
                 </div>

--- a/plugins/boring-governance/src/server/__tests__/companyContextBootstrap.test.ts
+++ b/plugins/boring-governance/src/server/__tests__/companyContextBootstrap.test.ts
@@ -14,8 +14,8 @@ function service() {
     policy: {
       tenant: { id: 'company', companyContextWorkspaceId: WORKSPACE_ID, defaultMonthlyModelBudgetEur: 0, perRunHoldEur: 1, perRunHoldMicros: 1_000_000 },
       users: [
-        { email: 'admin@example.com', role: 'admin', models: [], companyContext: { allow: ['^/.*'] } },
-        { email: 'user@example.com', role: 'user', models: [], companyContext: { allow: ['^/public/.*'] } },
+        { email: 'admin@example.com', role: 'admin', budgets: { monthlyEur: null, monthlyMicros: null }, models: [], companyContext: { allow: ['^/.*'] } },
+        { email: 'user@example.com', role: 'user', budgets: { monthlyEur: null, monthlyMicros: null }, models: [], companyContext: { allow: ['^/public/.*'] } },
       ],
       usersByEmail: new Map(),
     },

--- a/plugins/boring-governance/src/server/__tests__/governance.test.ts
+++ b/plugins/boring-governance/src/server/__tests__/governance.test.ts
@@ -85,6 +85,21 @@ describe('governance policy loader', () => {
     })).rejects.toThrow()
   })
 
+  it('loads per-user monthly budgets independently from model grant budgets', () => {
+    const policy = validateGovernancePolicy({
+      tenant: { id: 'company', defaultMonthlyModelBudgetEur: 7, perRunHoldEur: 1 },
+      users: [{
+        email: 'a@example.com',
+        role: 'user',
+        budgets: { monthlyEur: 20 },
+        models: [{ provider: 'p', id: 'm', monthlyBudgetEur: 3 }],
+      }],
+    })
+
+    expect(policy.users[0]?.budgets).toEqual({ monthlyEur: 20, monthlyMicros: 20_000_000 })
+    expect(policy.users[0]?.models[0]).toMatchObject({ monthlyBudgetEur: 3, monthlyBudgetMicros: 3_000_000 })
+  })
+
   it('applies tenant defaultMonthlyModelBudgetEur to model grants that omit a budget', () => {
     const policy = validateGovernancePolicy({
       tenant: { id: 'company', defaultMonthlyModelBudgetEur: 7, perRunHoldEur: 1 },
@@ -166,6 +181,11 @@ describe('governance policy loader', () => {
 
     expect(() => validateGovernancePolicy({
       tenant: { id: 'company', perRunHoldEur: 1 },
+      users: [{ email: 'a@example.com', role: 'user', budgets: { monthlyEur: -1 } }],
+    })).toThrow(/budgets\.monthlyEur/)
+
+    expect(() => validateGovernancePolicy({
+      tenant: { id: 'company', perRunHoldEur: 1 },
       users: [{ email: 'a@example.com', role: 'user', models: [{ provider: 'p', id: 'm', monthlyBudgetEur: -1 }] }],
     })).toThrow(/monthlyBudgetEur/)
 
@@ -208,6 +228,7 @@ describe('governance service and route', () => {
     expect(service.isAdmin(user)).toBe(false)
     expect(service.allowedModelsForUser(user, [{ provider: 'infomaniak', id: 'qwen' }])).toEqual([])
     expect(service.monthlyBudgetMicros(user, { provider: 'infomaniak', id: 'qwen' })).toBeNull()
+    expect(service.userMonthlyBudgetMicros(user)).toBeNull()
     expect(service.companyContextRules(user)).toEqual([])
   })
 

--- a/plugins/boring-governance/src/server/__tests__/metering.test.ts
+++ b/plugins/boring-governance/src/server/__tests__/metering.test.ts
@@ -3,9 +3,10 @@ import type { AgentMeteringSink } from '@hachej/boring-agent/server'
 import { ErrorCode } from '@hachej/boring-agent/shared'
 import { createGovernanceService } from '../governanceService.js'
 
-const reserve = vi.fn()
-const release = vi.fn()
-const settle = vi.fn()
+const reserveAdmission = vi.fn()
+const releaseCreated = vi.fn()
+const finishAdmission = vi.fn()
+const finishRun = vi.fn()
 
 vi.mock('@hachej/boring-core/server', async () => ({
   ModelBudgetExceededError: class ModelBudgetExceededError extends Error {
@@ -13,10 +14,20 @@ vi.mock('@hachej/boring-core/server', async () => ({
     code = 'MODEL_BUDGET_EXCEEDED'
     constructor() { super('Budget reached for this model.') }
   },
-  PostgresModelBudgetStore: class PostgresModelBudgetStore {
-    reserve = reserve
-    release = release
-    settle = settle
+  PostgresBudgetReservationStore: class PostgresBudgetReservationStore {
+    reserveAdmission = reserveAdmission
+    releaseCreated = releaseCreated
+    finishAdmission = finishAdmission
+    finishRun = finishRun
+    metadataForAdmission = (input: { user?: { reservationId: string }; model: { reservationId: string } }) => ({
+      ...(input.user ? { userBudgetReservationId: input.user.reservationId } : {}),
+      modelBudgetReservationId: input.model.reservationId,
+    })
+  },
+  UserBudgetExceededError: class UserBudgetExceededError extends Error {
+    statusCode = 402
+    code = 'MODEL_BUDGET_EXCEEDED'
+    constructor() { super('Budget reached for this user.') }
   },
 }))
 
@@ -31,12 +42,14 @@ function service() {
       users: [{
         email: 'user@example.com',
         role: 'user',
+        budgets: { monthlyEur: 10, monthlyMicros: 10_000_000 },
         models: [{ provider: 'infomaniak', id: 'qwen', monthlyBudgetEur: 5, monthlyBudgetMicros: 5_000_000 }],
         companyContext: { allow: [] },
       }],
       usersByEmail: new Map([['user@example.com', {
         email: 'user@example.com',
         role: 'user',
+        budgets: { monthlyEur: 10, monthlyMicros: 10_000_000 },
         models: [{ provider: 'infomaniak', id: 'qwen', monthlyBudgetEur: 5, monthlyBudgetMicros: 5_000_000 }],
         companyContext: { allow: [] },
       }]]),
@@ -66,24 +79,37 @@ function reserveInput(input: Record<string, unknown>) {
   return input as never
 }
 
+function db() {
+  return {} as never
+}
+
+function admission(userReservationId: string, modelReservationId: string) {
+  return {
+    user: { scope: 'user', reservationId: userReservationId, created: true },
+    model: { scope: 'model', reservationId: modelReservationId, created: true },
+  }
+}
+
 describe('createGovernanceMeteringSink', () => {
   beforeEach(() => {
-    reserve.mockReset()
-    release.mockReset()
-    settle.mockReset()
-    reserve.mockResolvedValue({ reservationId: 'gov-res' })
-    release.mockResolvedValue(undefined)
-    settle.mockResolvedValue(undefined)
+    reserveAdmission.mockReset()
+    releaseCreated.mockReset()
+    finishAdmission.mockReset()
+    finishRun.mockReset()
+    reserveAdmission.mockResolvedValue(admission('gov-user-res', 'gov-model-res'))
+    releaseCreated.mockResolvedValue(undefined)
+    finishAdmission.mockResolvedValue(undefined)
+    finishRun.mockResolvedValue(undefined)
   })
 
   it('reports metering active unless both governance and delegated metering are disabled', () => {
-    expect(createGovernanceMeteringSink({ service: disabledService(), delegate: delegate(), getDb: () => ({}) }).isEnabled?.()).toBe(true)
-    expect(createGovernanceMeteringSink({ service: disabledService(), delegate: delegate({ isEnabled: () => false }), getDb: () => ({}) }).isEnabled?.()).toBe(false)
+    expect(createGovernanceMeteringSink({ service: disabledService(), delegate: delegate(), getDb: db }).isEnabled?.()).toBe(true)
+    expect(createGovernanceMeteringSink({ service: disabledService(), delegate: delegate({ isEnabled: () => false }), getDb: db }).isEnabled?.()).toBe(false)
   })
 
   it('reserves governance budget before delegating to credits', async () => {
     const credits = delegate()
-    const sink = createGovernanceMeteringSink({ service: service(), delegate: credits, getDb: () => ({}) })
+    const sink = createGovernanceMeteringSink({ service: service(), delegate: credits, getDb: db })
 
     await expect(sink.reserveRun(reserveInput({
       workspaceId: 'ws', userId: 'user-1', userEmail: 'user@example.com', userEmailVerified: true,
@@ -91,15 +117,16 @@ describe('createGovernanceMeteringSink', () => {
       model: { provider: 'infomaniak', id: 'qwen' },
     }))).resolves.toEqual({ reservationId: 'credits-res' })
 
-    expect(reserve).toHaveBeenCalledWith(expect.objectContaining({
-      userId: 'user-1', provider: 'infomaniak', model: 'qwen', budgetMicros: 5_000_000, holdMicros: 1_000_000,
-    }))
+    expect(reserveAdmission).toHaveBeenCalledWith({
+      user: expect.objectContaining({ scope: 'user', userId: 'user-1', budgetMicros: 10_000_000, holdMicros: 1_000_000 }),
+      model: expect.objectContaining({ scope: 'model', userId: 'user-1', provider: 'infomaniak', model: 'qwen', budgetMicros: 5_000_000, holdMicros: 1_000_000 }),
+    })
     expect(credits.reserveRun).toHaveBeenCalled()
   })
 
   it('tags delegated usage with the governance reservation id', async () => {
     const credits = delegate()
-    const sink = createGovernanceMeteringSink({ service: service(), delegate: credits, getDb: () => ({}) })
+    const sink = createGovernanceMeteringSink({ service: service(), delegate: credits, getDb: db })
     const base = { workspaceId: 'ws', userId: 'user-1', userEmail: 'user@example.com', userEmailVerified: true, sessionId: 's1', runId: 'run-usage', source: 'pi-chat' as const }
 
     await sink.reserveRun(reserveInput({ ...base, kind: 'prompt', message: 'hi', model: { provider: 'infomaniak', id: 'qwen' } }))
@@ -112,15 +139,31 @@ describe('createGovernanceMeteringSink', () => {
     })
 
     expect(credits.recordUsage).toHaveBeenCalledWith(expect.objectContaining({
-      metadata: { existing: true, modelBudgetReservationId: 'gov-res' },
+      metadata: { existing: true, modelBudgetReservationId: 'gov-model-res', userBudgetReservationId: 'gov-user-res' },
     }))
+  })
+
+  it('returns stable user budget error and does not reserve model budget or delegate when user budget is exceeded', async () => {
+    const error = Object.assign(new Error('Budget reached for this user.'), { statusCode: 402, code: ErrorCode.enum.MODEL_BUDGET_EXCEEDED })
+    reserveAdmission.mockRejectedValueOnce(error)
+    const credits = delegate()
+    const sink = createGovernanceMeteringSink({ service: service(), delegate: credits, getDb: db })
+
+    await expect(sink.reserveRun(reserveInput({
+      workspaceId: 'ws', userId: 'user-1', userEmail: 'user@example.com', userEmailVerified: true,
+      sessionId: 's1', runId: 'run-user-over', source: 'pi-chat', kind: 'prompt', message: 'hi',
+      model: { provider: 'infomaniak', id: 'qwen' },
+    }))).rejects.toMatchObject({ code: ErrorCode.enum.MODEL_BUDGET_EXCEEDED, message: 'Budget reached for this user.' })
+    expect(reserveAdmission).toHaveBeenCalledTimes(1)
+    expect(reserveAdmission).toHaveBeenCalledWith(expect.objectContaining({ user: expect.objectContaining({ scope: 'user' }) }))
+    expect(credits.reserveRun).not.toHaveBeenCalled()
   })
 
   it('returns stable model budget error and does not delegate when budget is exceeded', async () => {
     const error = Object.assign(new Error('Budget reached for this model.'), { statusCode: 402, code: ErrorCode.enum.MODEL_BUDGET_EXCEEDED })
-    reserve.mockRejectedValue(error)
+    reserveAdmission.mockRejectedValueOnce(error)
     const credits = delegate()
-    const sink = createGovernanceMeteringSink({ service: service(), delegate: credits, getDb: () => ({}) })
+    const sink = createGovernanceMeteringSink({ service: service(), delegate: credits, getDb: db })
 
     await expect(sink.reserveRun(reserveInput({
       workspaceId: 'ws', userId: 'user-1', userEmail: 'user@example.com', userEmailVerified: true,
@@ -132,7 +175,7 @@ describe('createGovernanceMeteringSink', () => {
 
   it('releases governance hold when delegated credits reserve fails', async () => {
     const credits = delegate({ reserveRun: vi.fn(async () => { throw new Error('credits down') }) })
-    const sink = createGovernanceMeteringSink({ service: service(), delegate: credits, getDb: () => ({}) })
+    const sink = createGovernanceMeteringSink({ service: service(), delegate: credits, getDb: db })
 
     await expect(sink.reserveRun(reserveInput({
       workspaceId: 'ws', userId: 'user-1', userEmail: 'user@example.com', userEmailVerified: true,
@@ -140,25 +183,37 @@ describe('createGovernanceMeteringSink', () => {
       model: { provider: 'infomaniak', id: 'qwen' },
     }))).rejects.toThrow('credits down')
 
-    expect(release).toHaveBeenCalledWith({ reservationId: 'gov-res' })
+    expect(releaseCreated).toHaveBeenCalledWith(expect.objectContaining({
+      user: expect.objectContaining({ reservationId: 'gov-user-res' }),
+      model: expect.objectContaining({ reservationId: 'gov-model-res' }),
+    }))
   })
 
   it('settles and releases tracked governance holds with run lifecycle', async () => {
-    const sink = createGovernanceMeteringSink({ service: service(), delegate: delegate(), getDb: () => ({}) })
+    const sink = createGovernanceMeteringSink({ service: service(), delegate: delegate(), getDb: db })
     const base = { workspaceId: 'ws', userId: 'user-1', userEmail: 'user@example.com', userEmailVerified: true, sessionId: 's1', source: 'pi-chat' as const }
 
     await sink.reserveRun(reserveInput({ ...base, runId: 'run-4', kind: 'prompt', message: 'hi', model: { provider: 'infomaniak', id: 'qwen' } }))
     await sink.settleRun({ ...base, runId: 'run-4', status: 'ok' })
-    expect(release).toHaveBeenCalledWith(expect.objectContaining({ reservationId: 'gov-res' }))
+    expect(finishAdmission).toHaveBeenCalledWith(expect.objectContaining({
+      user: expect.objectContaining({ reservationId: 'gov-user-res' }),
+      model: expect.objectContaining({ reservationId: 'gov-model-res' }),
+    }), 'released')
 
-    reserve.mockResolvedValueOnce({ reservationId: 'gov-res-2' })
+    reserveAdmission.mockResolvedValueOnce(admission('gov-user-res-2', 'gov-model-res-2'))
     await sink.reserveRun(reserveInput({ ...base, runId: 'run-5', kind: 'prompt', message: 'hi', model: { provider: 'infomaniak', id: 'qwen' } }))
     await sink.releaseRun({ ...base, runId: 'run-5', reason: 'cancelled' })
-    expect(release).toHaveBeenCalledWith(expect.objectContaining({ reservationId: 'gov-res-2' }))
+    expect(finishAdmission).toHaveBeenCalledWith(expect.objectContaining({
+      user: expect.objectContaining({ reservationId: 'gov-user-res-2' }),
+      model: expect.objectContaining({ reservationId: 'gov-model-res-2' }),
+    }), 'released')
 
-    reserve.mockResolvedValueOnce({ reservationId: 'gov-res-3' })
+    reserveAdmission.mockResolvedValueOnce(admission('gov-user-res-3', 'gov-model-res-3'))
     await sink.reserveRun(reserveInput({ ...base, runId: 'run-6', kind: 'prompt', message: 'hi', model: { provider: 'infomaniak', id: 'qwen' } }))
     await sink.releaseRun({ ...base, runId: 'run-6', reason: 'fallback-hold-charge' })
-    expect(settle).toHaveBeenCalledWith(expect.objectContaining({ reservationId: 'gov-res-3' }))
+    expect(finishAdmission).toHaveBeenCalledWith(expect.objectContaining({
+      user: expect.objectContaining({ reservationId: 'gov-user-res-3' }),
+      model: expect.objectContaining({ reservationId: 'gov-model-res-3' }),
+    }), 'settled')
   })
 })

--- a/plugins/boring-governance/src/server/governanceService.ts
+++ b/plugins/boring-governance/src/server/governanceService.ts
@@ -34,6 +34,7 @@ export interface GovernanceMeResponse {
     email: string
     role: TenantRole
     modelCount: number
+    monthlyBudgetEur: number | null
     contextRuleCount: number
   }>
   models?: Array<GovernanceModelGrant & { email: string }>
@@ -96,6 +97,11 @@ export class GovernanceService {
     return grant?.monthlyBudgetMicros ?? null
   }
 
+  userMonthlyBudgetMicros(user: GovernanceUserLike): number | null {
+    if (!this.loaded.enabled) return null
+    return this.userPolicy(user)?.budgets.monthlyMicros ?? null
+  }
+
   companyContextRules(user: GovernanceUserLike): string[] {
     if (!this.loaded.enabled) return []
     return this.userPolicy(user)?.companyContext.allow ?? []
@@ -132,6 +138,7 @@ export class GovernanceService {
         email: entry.email,
         role: entry.role,
         modelCount: entry.models.length,
+        monthlyBudgetEur: entry.budgets.monthlyEur,
         contextRuleCount: entry.companyContext.allow.length,
       })),
       models: policy.users.flatMap((entry) => entry.models.map((model) => ({ ...model, email: entry.email }))),

--- a/plugins/boring-governance/src/server/index.ts
+++ b/plugins/boring-governance/src/server/index.ts
@@ -86,6 +86,8 @@ export function createGovernanceModelFilter(service: GovernanceService): Registe
     const user = governanceUserFromRequest(request)
     if (!service.isEnabled()) return { models, defaultModel }
     if (!user) return { models: [] }
+    const aggregateBudgetMicros = service.userMonthlyBudgetMicros(user)
+    if (aggregateBudgetMicros !== null && aggregateBudgetMicros <= 0) return { models: [], defaultModel: undefined }
     const allowedModels = service
       .allowedModelsForUser(user, models)
       .filter((model) => (service.monthlyBudgetMicros(user, model) ?? 0) > 0)

--- a/plugins/boring-governance/src/server/metering.ts
+++ b/plugins/boring-governance/src/server/metering.ts
@@ -7,20 +7,11 @@ import type {
   MeteringUsageInput,
 } from '@hachej/boring-agent/server'
 import { ErrorCode } from '@hachej/boring-agent/shared'
-import * as coreServer from '@hachej/boring-core/server'
+import { ModelBudgetExceededError, PostgresBudgetReservationStore, UserBudgetExceededError } from '@hachej/boring-core/server'
+import type { BudgetReservationAdmission, ReserveBudgetInput } from '@hachej/boring-core/server'
 import type { GovernanceService } from './governanceService.js'
 
-const PostgresModelBudgetStore = (coreServer as unknown as {
-  PostgresModelBudgetStore: new (db: unknown) => {
-    reserve(input: unknown): Promise<{ reservationId: string }>
-    settle(input: unknown): Promise<void>
-    release(input: unknown): Promise<void>
-  }
-}).PostgresModelBudgetStore
-const ModelBudgetExceededError = (coreServer as unknown as { ModelBudgetExceededError: new (usedMicros: number, heldMicros: number, budgetMicros: number, requestedMicros: number) => Error }).ModelBudgetExceededError
-
-type ModelBudgetDb = ConstructorParameters<typeof PostgresModelBudgetStore>[0]
-
+type BudgetDb = ConstructorParameters<typeof PostgresBudgetReservationStore>[0]
 const DEFAULT_HOLD_TTL_SECONDS = 60 * 60
 
 function authRequiredError(): Error {
@@ -46,16 +37,16 @@ function runKey(input: { userId?: string; runId: string }): string | null {
 
 export function createGovernanceMeteringSink(options: {
   service: GovernanceService
-  getDb: () => ModelBudgetDb
+  getDb: () => BudgetDb
   delegate: AgentMeteringSink
   holdTtlSeconds?: number
 }): AgentMeteringSink {
-  let store: InstanceType<typeof PostgresModelBudgetStore> | undefined
-  const getStore = () => (store ??= new PostgresModelBudgetStore(options.getDb()))
-  const reservationsByRun = new Map<string, string>()
+  let store: InstanceType<typeof PostgresBudgetReservationStore> | undefined
+  const getStore = () => (store ??= new PostgresBudgetReservationStore(options.getDb(), { eligibleLegacySources: ['pi-chat', 'pi-chat-fallback', 'pi-chat-expired'] }))
+  const admissionsByRun = new Map<string, BudgetReservationAdmission>()
   const holdTtlSeconds = options.holdTtlSeconds ?? DEFAULT_HOLD_TTL_SECONDS
 
-  async function reserveGovernance(input: MeteringReserveInput): Promise<string | undefined> {
+  async function reserveGovernance(input: MeteringReserveInput): Promise<BudgetReservationAdmission | undefined> {
     if (!options.service.isEnabled()) return undefined
     const identity = input as MeteringReserveInput & { userEmail?: string; userEmailVerified?: boolean }
     if (!input.userId || !identity.userEmail) throw authRequiredError()
@@ -66,36 +57,59 @@ export function createGovernanceMeteringSink(options: {
     } catch {
       throw policyDeniedError()
     }
-    const budgetMicros = options.service.monthlyBudgetMicros(user, { provider: input.model.provider, id: input.model.id })
-    if (budgetMicros === null || budgetMicros <= 0) throw new ModelBudgetExceededError(0, 0, budgetMicros ?? 0, 0)
+
+    const modelBudgetMicros = options.service.monthlyBudgetMicros(user, { provider: input.model.provider, id: input.model.id })
+    if (modelBudgetMicros === null || modelBudgetMicros <= 0) throw new ModelBudgetExceededError(0, 0, modelBudgetMicros ?? 0, 0)
     const policy = options.service.policy()
-    // Governance budgets and the core usage ledger both use credit micros, with
-    // the existing convention 1 EUR = 1_000_000 credit micros.
     const holdMicros = policy?.tenant.perRunHoldMicros ?? 1_000_000
-    const result = await getStore().reserve({
+    const now = new Date()
+    let userReservationInput: Extract<ReserveBudgetInput, { scope: 'user' }> | undefined
+    const userBudgetMicros = options.service.userMonthlyBudgetMicros(user)
+    if (userBudgetMicros !== null) {
+      if (userBudgetMicros <= 0) throw new (UserBudgetExceededError ?? ModelBudgetExceededError)(0, 0, userBudgetMicros, 0)
+      userReservationInput = {
+        scope: 'user',
+        userId: input.userId,
+        workspaceId: input.workspaceId,
+        sessionId: input.sessionId,
+        runId: input.runId,
+        budgetMicros: userBudgetMicros,
+        holdMicros,
+        ttlSeconds: holdTtlSeconds,
+        now,
+      }
+    }
+    const modelReservationInput: Extract<ReserveBudgetInput, { scope: 'model' }> = {
+      scope: 'model',
       userId: input.userId,
       workspaceId: input.workspaceId,
       sessionId: input.sessionId,
       runId: input.runId,
       provider: input.model.provider,
       model: input.model.id,
-      budgetMicros,
+      budgetMicros: modelBudgetMicros,
       holdMicros,
       ttlSeconds: holdTtlSeconds,
-    }).catch((error: unknown) => { throw budgetError(error) })
+      now,
+    }
+    const admission = await getStore().reserveAdmission({ user: userReservationInput, model: modelReservationInput }).catch((error: unknown) => { throw budgetError(error) })
     const key = runKey(input)
-    if (key) reservationsByRun.set(key, result.reservationId)
-    return result.reservationId
+    if (key) admissionsByRun.set(key, admission)
+    return admission
   }
 
   async function finishGovernance(input: MeteringSettleInput | MeteringReleaseInput, action: 'settle' | 'release'): Promise<void> {
     if (!options.service.isEnabled()) return
     const key = runKey(input)
-    const reservationId = key ? reservationsByRun.get(key) : undefined
-    if (!reservationId && (!input.userId || !input.runId)) return
-    if (action === 'settle') await getStore().settle({ reservationId, runId: input.runId, userId: input.userId })
-    else await getStore().release({ reservationId, runId: input.runId, userId: input.userId })
-    if (key) reservationsByRun.delete(key)
+    const admission = key ? admissionsByRun.get(key) : undefined
+    const status = action === 'settle' ? 'settled' : 'released'
+    if (admission) {
+      await getStore().finishAdmission(admission, status)
+      if (key) admissionsByRun.delete(key)
+      return
+    }
+    if (!input.userId || !input.runId) return
+    await getStore().finishRun({ runId: input.runId, userId: input.userId }, status)
   }
 
   function releaseConsumesBudget(input: MeteringReleaseInput): boolean {
@@ -106,22 +120,29 @@ export function createGovernanceMeteringSink(options: {
     isEnabled: () => options.service.isEnabled() || options.delegate.isEnabled?.() !== false,
 
     async reserveRun(input: MeteringReserveInput): Promise<MeteringReservationResult> {
-      const governanceReservationId = await reserveGovernance(input)
+      const admission = await reserveGovernance(input)
       try {
         return await options.delegate.reserveRun(input)
       } catch (error) {
-        if (governanceReservationId) await getStore().release({ reservationId: governanceReservationId }).catch(() => {})
-        const key = runKey(input)
-        if (key) reservationsByRun.delete(key)
+        try {
+          // Only release holds created by this reserve attempt; existing idempotent
+          // handles may belong to an already-admitted run whose delegate retry failed.
+          if (admission) await getStore().releaseCreated(admission)
+        } catch {
+          // Preserve the delegated reservation failure; budget cleanup remains idempotent and retryable.
+        } finally {
+          const key = runKey(input)
+          if (key) admissionsByRun.delete(key)
+        }
         throw error
       }
     },
 
     recordUsage(input: MeteringUsageInput) {
       const key = runKey(input)
-      const reservationId = key ? reservationsByRun.get(key) : undefined
-      return options.delegate.recordUsage(reservationId
-        ? { ...input, metadata: { ...(input.metadata ?? {}), modelBudgetReservationId: reservationId } }
+      const admission = key ? admissionsByRun.get(key) : undefined
+      return options.delegate.recordUsage(admission
+        ? { ...input, metadata: { ...(input.metadata ?? {}), ...getStore().metadataForAdmission(admission) } }
         : input)
     },
 
@@ -129,19 +150,12 @@ export function createGovernanceMeteringSink(options: {
       try {
         await options.delegate.settleRun(input)
       } finally {
-        // Normal successful runs write provider/model ledger rows; release the
-        // admission hold so future budget checks count exact ledger spend, not
-        // the conservative per-run hold.
         await finishGovernance(input, 'release')
       }
     },
 
     async releaseRun(input: MeteringReleaseInput): Promise<void> {
       if (releaseConsumesBudget(input)) {
-        // Fallback-charge releases may have no provider/model ledger row, or
-        // only a partial provider/model ledger row. Settle the governance hold
-        // before delegating so model-budget accounting remains durable even if
-        // the credit fallback write is transiently unavailable.
         await finishGovernance(input, 'settle')
         await options.delegate.releaseRun(input)
         return

--- a/plugins/boring-governance/src/server/policyTypes.ts
+++ b/plugins/boring-governance/src/server/policyTypes.ts
@@ -17,9 +17,15 @@ export interface GovernanceModelGrant {
   monthlyBudgetMicros: number
 }
 
+export interface GovernanceUserBudgets {
+  monthlyEur: number | null
+  monthlyMicros: number | null
+}
+
 export interface GovernanceUserPolicy {
   email: string
   role: TenantRole
+  budgets: GovernanceUserBudgets
   models: GovernanceModelGrant[]
   companyContext: {
     allow: string[]

--- a/plugins/boring-governance/src/server/validatePolicy.ts
+++ b/plugins/boring-governance/src/server/validatePolicy.ts
@@ -173,6 +173,18 @@ function validateModels(value: unknown, userPath: string, defaultMonthlyModelBud
   })
 }
 
+function validateUserBudgets(value: unknown, userPath: string): { monthlyEur: number | null; monthlyMicros: number | null } {
+  if (value === undefined) return { monthlyEur: null, monthlyMicros: null }
+  if (!isRecord(value)) fail(`${userPath}.budgets must be an object`)
+  const monthlyEur = value.monthlyEur === undefined
+    ? null
+    : finiteNumber(value.monthlyEur, `${userPath}.budgets.monthlyEur`, { min: 0, allowZero: true })
+  return {
+    monthlyEur,
+    monthlyMicros: monthlyEur === null ? null : Math.round(monthlyEur * MICROS_PER_EUR),
+  }
+}
+
 function validateCompanyContext(value: unknown, userPath: string): { allow: string[] } {
   if (value === undefined) return { allow: [] }
   if (!isRecord(value)) fail(`${userPath}.companyContext must be an object`)
@@ -219,6 +231,7 @@ export function validateGovernancePolicy(input: unknown): GovernancePolicy {
     const user: GovernanceUserPolicy = {
       email,
       role: validateRole(entry.role, `${path}.role`),
+      budgets: validateUserBudgets(entry.budgets, path),
       models: validateModels(entry.models, path, defaultMonthlyModelBudgetEur),
       companyContext: validateCompanyContext(entry.companyContext, path),
     }


### PR DESCRIPTION
## Summary
- adds optional per-user aggregate monthly budgets to governance policy (`users[].budgets.monthlyEur`)
- enforces user monthly budget alongside existing model allowlist and per-model budget reservations
- records user-budget reservation metadata through governance metering and adds a dedicated DB reservation table/migration
- keeps model picker filtering model-allowlist based, while metering checks both user and model budgets

## Tests
- `pnpm --filter @hachej/boring-governance test` ✅
- correctness autoreview ✅
- thermo-nuclear maintainability review found structural concerns; keeping this PR draft until addressed/accepted

## Thermo review findings to resolve before merge
1. `PostgresUserBudgetStore` duplicates much of `PostgresModelBudgetStore` reservation lifecycle/accounting. Consider extracting a scope-aware reservation lifecycle helper/store.
2. Governance metering now manages parallel model/user reservation maps. Consider replacing them with one per-run reservation state/handle list to reduce branchy cleanup logic.

## Notes
- Core/governance build currently hits existing repo DTS/typecheck issues around TypeScript `ignoreDeprecations`/dist declarations; governance focused tests pass.



// approved-growth: governance aggregate user budgets add server-only reservation accounting, attribution, and migration support; +10.3% gzip is accepted for this release.
