### PR TITLE
feat(391-P1): PR D — honest readiness + dispose-on-eviction

### DIFF
--- a/packages/agent/src/core/createAgent.ts
+++ b/packages/agent/src/core/createAgent.ts
@@ -40,6 +40,7 @@ export interface AgentCoreConfig {
   runtimeFactory: AgentCoreRuntimeFactory
   environments?: readonly ResolvedEnvironment[]
   providerDirectInputAssets?: boolean
+  readiness?: AgentReadiness
   readinessRequirements?: string[]
   sessions?: SessionStore
 }
@@ -234,16 +235,13 @@ function createRuntimeLoader(runtimeFactory: AgentCoreRuntimeFactory, inputAsset
   }
 }
 
-function createReadiness(config: Pick<AgentCoreConfig, 'readinessRequirements'>): AgentReadiness {
+function createReadiness(config: Pick<AgentCoreConfig, 'readiness' | 'readinessRequirements'>): AgentReadiness {
+  if (config.readiness) return config.readiness
   const requirements = [...(config.readinessRequirements ?? [])]
   return {
     requirements,
     async status() {
-      return requirements.map((key) => ({
-        key,
-        ready: false,
-        message: 'readiness status is not available in the core facade',
-      }))
+      return []
     },
   }
 }

--- a/packages/agent/src/server/__tests__/agentReadiness.test.ts
+++ b/packages/agent/src/server/__tests__/agentReadiness.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest'
+
+import { collectToolReadinessRequirements, createAgentReadinessFromTracker } from '../agentReadiness'
+import { ReadyStatusTracker } from '../runtime/readyStatus'
+import type { AgentTool } from '../../shared/tool'
+
+describe('agent readiness data', () => {
+  test('reports tracker and tool readiness by requirement', async () => {
+    const tracker = new ReadyStatusTracker({
+      sandboxReady: true,
+      harnessReady: true,
+      capabilities: {
+        runtimeDependencies: {
+          state: 'preparing',
+          requirement: 'runtime:python',
+          message: 'Installing Python dependencies.',
+          retryable: true,
+        },
+      },
+    })
+    const readiness = createAgentReadinessFromTracker({
+      tracker,
+      requirements: ['workspace-fs', 'sandbox-exec', 'runtime:python'],
+      checkReadiness: (requirement) => requirement === 'runtime:python'
+        ? {
+            ready: false,
+            state: 'preparing',
+            message: 'Installing Python dependencies.',
+            workspaceId: 'workspace-a',
+            retryable: true,
+          }
+        : true,
+    })
+
+    await expect(readiness.status()).resolves.toEqual([
+      { key: 'workspace-fs', ready: true, state: 'ready' },
+      { key: 'sandbox-exec', ready: true, state: 'ready' },
+      {
+        key: 'runtime:python',
+        ready: false,
+        state: 'preparing',
+        message: 'Installing Python dependencies.',
+        workspaceId: 'workspace-a',
+        retryable: true,
+      },
+    ])
+  })
+
+  test('derives requirements from actual tool metadata', () => {
+    const tools: AgentTool[] = [
+      makeTool('read', ['workspace-fs']),
+      makeTool('bash', ['sandbox-exec']),
+      makeTool('python_macro', ['runtime:python']),
+      makeTool('grep', ['workspace-fs']),
+    ]
+
+    expect(collectToolReadinessRequirements(tools)).toEqual([
+      'workspace-fs',
+      'sandbox-exec',
+      'runtime:python',
+    ])
+  })
+})
+
+function makeTool(name: string, readinessRequirements: AgentTool['readinessRequirements']): AgentTool {
+  return {
+    name,
+    description: `${name} test tool.`,
+    readinessRequirements,
+    parameters: { type: 'object', properties: {} },
+    async execute() {
+      return { content: [{ type: 'text', text: name }] }
+    },
+  }
+}

--- a/packages/agent/src/server/__tests__/createAgent.test.ts
+++ b/packages/agent/src/server/__tests__/createAgent.test.ts
@@ -67,17 +67,42 @@ describe('createAgent', () => {
     expect(agent.readiness.requirements).toEqual([])
   })
 
-  it('does not report configured readiness requirements as ready without a tracker', async () => {
+  it('reports an explicit empty readiness status without an injected tracker', async () => {
     const agent = createAgent({
       runtime: 'none',
       harnessFactory: createFakeHarnessFactory(),
       readinessRequirements: ['workspace-fs'],
     })
 
+    expect(agent.readiness.requirements).toEqual(['workspace-fs'])
+    await expect(agent.readiness.status()).resolves.toEqual([])
+  })
+
+  it('reports injected readiness status as data', async () => {
+    const agent = createAgent({
+      runtime: 'none',
+      harnessFactory: createFakeHarnessFactory(),
+      readiness: {
+        requirements: ['runtime:python'],
+        async status() {
+          return [{
+            key: 'runtime:python',
+            ready: false,
+            state: 'preparing',
+            message: 'Python runtime dependencies are still installing.',
+            retryable: true,
+          }]
+        },
+      },
+    })
+
+    expect(agent.readiness.requirements).toEqual(['runtime:python'])
     await expect(agent.readiness.status()).resolves.toEqual([{
-      key: 'workspace-fs',
+      key: 'runtime:python',
       ready: false,
-      message: 'readiness status is not available in the core facade',
+      state: 'preparing',
+      message: 'Python runtime dependencies are still installing.',
+      retryable: true,
     }])
   })
 

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -783,6 +783,57 @@ test('registerAgentRoutes mode none evicts old request-scoped pure bindings', as
   }
 })
 
+test('registerAgentRoutes tears down evicted request-scoped runtime bindings without disposing the shared adapter', async () => {
+  const workspaceRoot = await makeTempDir('boring-agent-embed-runtime-evict-')
+  const app = Fastify({ logger: false })
+  const dispose = vi.fn(async () => {})
+  const evictCachedRuntime = vi.fn()
+  const customAdapter: RuntimeModeAdapter = {
+    id: 'runtime-eviction-test',
+    workspaceFsCapability: 'strong',
+    evictCachedRuntime,
+    dispose,
+    async create(ctx) {
+      const { createNodeWorkspace } = await import('../workspace/createNodeWorkspace')
+      const { createDirectSandbox } = await import('../sandbox/direct/createDirectSandbox')
+      const { createServerFileSearch } = await import('../runtime/createServerFileSearch')
+      const workspace = createNodeWorkspace(ctx.workspaceRoot)
+      const sandbox = createDirectSandbox()
+      await sandbox.init?.({ workspace, sessionId: ctx.sessionId })
+      return { workspace, sandbox, fileSearch: createServerFileSearch(workspace, sandbox) }
+    },
+  }
+
+  await app.register(registerAgentRoutes, {
+    workspaceRoot,
+    runtimeModeAdapter: customAdapter,
+    externalPlugins: false,
+    harnessFactory: createNoopHarnessFactory().factory,
+    getWorkspaceId: async (request) => String(request.headers['x-boring-workspace-id'] ?? 'default'),
+  })
+  await app.ready()
+
+  let closed = false
+  try {
+    for (let i = 0; i < 257; i += 1) {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/api/v1/agent/catalog',
+        headers: { 'x-boring-workspace-id': `workspace-${i}` },
+      })
+      expect(res.statusCode).toBe(200)
+    }
+
+    expect(evictCachedRuntime).toHaveBeenCalledWith({ workspaceId: 'workspace-0' })
+    expect(dispose).not.toHaveBeenCalled()
+    await app.close()
+    closed = true
+    expect(dispose).toHaveBeenCalledTimes(1)
+  } finally {
+    if (!closed) await app.close()
+  }
+})
+
 test('registerAgentRoutes mode none retries after scoped binding creation fails', async () => {
   const sessionRoot = await makeTempDir('boring-agent-routes-pure-retry-session-root-')
   const harness = createNoopHarnessFactory()

--- a/packages/agent/src/server/agentReadiness.ts
+++ b/packages/agent/src/server/agentReadiness.ts
@@ -1,0 +1,112 @@
+import type { AgentReadiness, AgentReadinessStatus } from '../shared/events'
+import type { AgentTool, ToolReadinessRequirement } from '../shared/tool'
+import type { ToolReadinessCheck, ToolReadinessState } from './catalog/toolReadiness'
+import type { CapabilityReadinessDetail, ReadyStatusTracker } from './runtime/readyStatus'
+
+const READINESS_PROBE_TOOL: AgentTool = {
+  name: 'agent_readiness_probe',
+  description: 'Internal readiness probe.',
+  parameters: { type: 'object', properties: {} },
+  async execute() {
+    return { content: [] }
+  },
+}
+
+export function collectToolReadinessRequirements(tools: readonly AgentTool[]): ToolReadinessRequirement[] {
+  const requirements = new Set<ToolReadinessRequirement>()
+  for (const tool of tools) {
+    for (const requirement of tool.readinessRequirements ?? []) {
+      requirements.add(requirement)
+    }
+  }
+  return [...requirements]
+}
+
+export function createAgentReadinessFromTracker(options: {
+  requirements: readonly ToolReadinessRequirement[]
+  tracker: ReadyStatusTracker
+  checkReadiness?: ToolReadinessCheck
+}): AgentReadiness {
+  const requirements = [...new Set(options.requirements)]
+  return {
+    requirements,
+    async status() {
+      return requirements.map((requirement) => readinessStatusForRequirement(requirement, options))
+    },
+  }
+}
+
+function readinessStatusForRequirement(
+  requirement: ToolReadinessRequirement,
+  options: {
+    tracker: ReadyStatusTracker
+    checkReadiness?: ToolReadinessCheck
+  },
+): AgentReadinessStatus {
+  if (requirement === 'workspace-fs') {
+    return statusFromCapability(requirement, options.tracker.getReadiness().capabilities.workspace)
+  }
+  if (requirement === 'sandbox-exec') {
+    const snapshot = options.tracker.getReadiness()
+    return {
+      key: requirement,
+      ready: snapshot.sandboxReady,
+      state: snapshot.sandboxReady ? 'ready' : 'preparing',
+    }
+  }
+  if (options.checkReadiness) {
+    return statusFromToolReadiness(
+      requirement,
+      options.checkReadiness(requirement, READINESS_PROBE_TOOL),
+    )
+  }
+  if (isRuntimeReadinessRequirement(requirement)) {
+    return statusFromCapability(
+      requirement,
+      options.tracker.getReadiness().capabilities.runtimeDependencies,
+      { readyWhenNotStarted: true },
+    )
+  }
+  return { key: requirement, ready: true, state: 'ready' }
+}
+
+function statusFromToolReadiness(
+  key: ToolReadinessRequirement,
+  state: ToolReadinessState,
+): AgentReadinessStatus {
+  if (state === true || (typeof state === 'object' && state !== null && state.ready === true)) {
+    return { key, ready: true, state: 'ready' }
+  }
+  if (state === false) return { key, ready: false, state: 'preparing', retryable: true }
+  return {
+    key,
+    ready: false,
+    state: state.state ?? 'preparing',
+    ...(state.errorCode ? { errorCode: state.errorCode } : {}),
+    ...(state.causeCode ? { causeCode: state.causeCode } : {}),
+    ...(state.message ? { message: state.message } : {}),
+    ...(state.workspaceId ? { workspaceId: state.workspaceId } : {}),
+    ...(state.retryable !== undefined ? { retryable: state.retryable } : {}),
+  }
+}
+
+function statusFromCapability(
+  key: ToolReadinessRequirement,
+  detail: CapabilityReadinessDetail,
+  options: { readyWhenNotStarted?: boolean } = {},
+): AgentReadinessStatus {
+  const ready = detail.state === 'ready' || (options.readyWhenNotStarted === true && detail.state === 'not-started')
+  return {
+    key,
+    ready,
+    state: ready ? 'ready' : detail.state,
+    ...(detail.errorCode ? { errorCode: detail.errorCode } : {}),
+    ...(detail.causeCode ? { causeCode: detail.causeCode } : {}),
+    ...(detail.message ? { message: detail.message } : {}),
+    ...(detail.retryable !== undefined ? { retryable: detail.retryable } : {}),
+  }
+}
+
+function isRuntimeReadinessRequirement(requirement: ToolReadinessRequirement): boolean {
+  return requirement === 'runtime-dependencies' || requirement.startsWith('runtime:')
+}

--- a/packages/agent/src/server/createAgent.ts
+++ b/packages/agent/src/server/createAgent.ts
@@ -28,6 +28,12 @@ export interface AgentRuntimeAdapterView {
 }
 
 export interface CreateAgentRuntimeBridgeOptions {
+  /**
+   * RuntimeModeAdapter.dispose() is adapter-global. Request-scoped route
+   * bindings dispose their facade per binding and close the shared adapter once
+   * from the profile onClose hook.
+   */
+  disposeRuntime?: boolean
   harness?: {
     runtimeCwd?: string
   }
@@ -99,7 +105,9 @@ async function createRuntime(
     ? await config.harnessFactory(harnessInput)
     : await createDefaultPiHarness(config, harnessInput)
   const sessionStore = config.sessions ?? harness.sessions
-  const runtimeDispose = config.runtime !== 'none' ? config.runtime.dispose?.bind(config.runtime) : undefined
+  const runtimeDispose = config.runtime !== 'none' && options.disposeRuntime !== false
+    ? config.runtime.dispose?.bind(config.runtime)
+    : undefined
   return {
     harness,
     sessionStore,

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -29,6 +29,7 @@ import {
   toolNames,
   type AgentRouteBindingProfile,
 } from './agentRouteBindingProfile'
+import { collectToolReadinessRequirements, createAgentReadinessFromTracker } from './agentReadiness'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_SESSION_ID = 'default'
@@ -155,10 +156,15 @@ async function createPureAgentAppProfile(
   })) as AgentCoreHarnessFactory
   const tools = opts.extraTools ?? []
   const capabilities = createPureAgentCapabilities(resolvedMode, toolNames(tools))
+  const readyTracker = new ReadyStatusTracker({ sandboxReady: true, harnessReady: true })
   const coreAgent = createAgentRuntimeBridge({
     runtime: 'none',
     environments: capabilities.environments,
     tools,
+    readiness: createAgentReadinessFromTracker({
+      requirements: collectToolReadinessRequirements(tools),
+      tracker: readyTracker,
+    }),
     harnessFactory,
     systemPromptAppend: opts.systemPromptAppend,
     systemPromptDynamic: opts.systemPromptDynamic,
@@ -167,7 +173,6 @@ async function createPureAgentAppProfile(
     sessionStorageRoot: opts.sessionRoot,
   })
   const agentRuntime = await coreAgent.getRuntime()
-  const readyTracker = new ReadyStatusTracker({ sandboxReady: true, harnessReady: true })
   return {
     runtimeMode: resolvedMode,
     capabilities,
@@ -281,10 +286,17 @@ async function createWorkspaceAgentAppProfile(
     sessionDir: opts.sessionDir ?? input.sessionDir,
   })) as AgentCoreHarnessFactory
   const capabilities = createWorkspaceAgentCapabilities(resolvedMode, toolNames(tools))
+  const readyTracker = createRuntimeReadyStatusTracker(modeAdapter, {
+    harnessReady: true,
+  })
   const coreAgent = createAgentRuntimeBridge({
     runtime: modeAdapter,
     environments: capabilities.environments,
     tools,
+    readiness: createAgentReadinessFromTracker({
+      requirements: collectToolReadinessRequirements(tools),
+      tracker: readyTracker,
+    }),
     harnessFactory,
     systemPromptAppend: opts.systemPromptAppend,
     systemPromptDynamic: opts.systemPromptDynamic,
@@ -301,9 +313,6 @@ async function createWorkspaceAgentAppProfile(
   const agentRuntime = await coreAgent.getRuntime()
   const harness = agentRuntime.harness
   harnessRef = harness
-  const readyTracker = createRuntimeReadyStatusTracker(modeAdapter, {
-    harnessReady: true,
-  })
 
   return {
     runtimeMode: resolvedMode,

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -43,6 +43,7 @@ import {
   toolNames,
   type AgentRouteBindingProfile,
 } from './agentRouteBindingProfile'
+import { collectToolReadinessRequirements, createAgentReadinessFromTracker } from './agentReadiness'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_WORKSPACE_ID = 'default'
@@ -143,6 +144,7 @@ interface RuntimeBinding {
 interface RuntimeBindingEntry {
   promise: Promise<RuntimeBinding>
   state: 'pending' | 'ready' | 'failed'
+  workspaceId: string
   error?: unknown
 }
 
@@ -462,10 +464,15 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
           sessionDir: input.sessionDir,
         })) as AgentCoreHarnessFactory
         const capabilities = createPureAgentCapabilities(resolvedMode, toolNames(tools))
+        const readyTracker = new ReadyStatusTracker({ sandboxReady: true, harnessReady: true })
         const coreAgent = createAgentRuntimeBridge({
           runtime: 'none',
           environments: capabilities.environments,
           tools,
+          readiness: createAgentReadinessFromTracker({
+            requirements: collectToolReadinessRequirements(tools),
+            tracker: readyTracker,
+          }),
           harnessFactory,
           systemPromptAppend: opts.systemPromptAppend,
           systemPromptDynamic,
@@ -477,7 +484,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
         return {
           agent: coreAgent.agent,
           tools,
-          readyTracker: new ReadyStatusTracker({ sandboxReady: true, harnessReady: true }),
+          readyTracker,
           piChatService: agentRuntime.service as PiChatSessionService,
         }
       })()
@@ -585,11 +592,28 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
   const externalPluginsEnabled = opts.externalPlugins !== false
   const runtimeBindings = new Map<string, RuntimeBindingEntry>()
   const MAX_RUNTIME_BINDINGS = 256
+
+  async function disposeRuntimeBindingEntry(entry: RuntimeBindingEntry | undefined): Promise<void> {
+    if (!entry) return
+    const binding = await entry.promise
+    await binding.agent.dispose()
+  }
+
+  function disposeEvictedRuntimeBinding(entry: RuntimeBindingEntry | undefined): void {
+    if (!entry) return
+    modeAdapter.evictCachedRuntime?.({ workspaceId: entry.workspaceId })
+    disposeRuntimeBindingEntry(entry).catch(() => {})
+  }
+
   function evictRuntimeBindings(): void {
     if (runtimeBindings.size <= MAX_RUNTIME_BINDINGS) return
     const keys = Array.from(runtimeBindings.keys())
     for (let i = 0; i < keys.length - MAX_RUNTIME_BINDINGS; i++) {
-      runtimeBindings.delete(keys[i])
+      const key = keys[i]
+      if (!key) continue
+      const entry = runtimeBindings.get(key)
+      runtimeBindings.delete(key)
+      disposeEvictedRuntimeBinding(entry)
     }
   }
 
@@ -896,6 +920,11 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       runtime: modeAdapter,
       environments: capabilities.environments,
       tools,
+      readiness: createAgentReadinessFromTracker({
+        requirements: collectToolReadinessRequirements(tools),
+        tracker: readyTracker,
+        checkReadiness,
+      }),
       harnessFactory,
       systemPromptAppend: opts.systemPromptAppend,
       systemPromptDynamic,
@@ -904,6 +933,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       sessionStorageRoot: opts.sessionRoot,
       workdir: root,
     }, {
+      disposeRuntime: false,
       service: {
         workdir: runtimeBundle.workspace.root,
         workspace: runtimeBundle.workspace,
@@ -939,6 +969,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
   ): RuntimeBindingEntry {
     const entry: RuntimeBindingEntry = {
       state: 'pending',
+      workspaceId,
       promise: Promise.resolve(null as unknown as RuntimeBinding),
     }
     entry.promise = createRuntimeBinding(workspaceId, scope, request).then(
@@ -1004,7 +1035,9 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
     scope: RuntimeScope,
     request?: FastifyRequest,
   ): Promise<RuntimeBinding> {
+    const previous = runtimeBindings.get(scope.key)
     runtimeBindings.delete(scope.key)
+    disposeRuntimeBindingEntry(previous).catch(() => {})
     modeAdapter.evictCachedRuntime?.({ workspaceId })
 
     const created = createRuntimeBindingEntry(workspaceId, scope, request)
@@ -1236,6 +1269,14 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
       ? { tracker: staticBinding.readyTracker }
       : { getTracker: async (request) => (await getBindingForRequest(request)).readyTracker },
     dispose: async () => {
+      const entries = [...runtimeBindings.values()]
+      runtimeBindings.clear()
+      const disposed = await Promise.allSettled(entries.map((entry) => disposeRuntimeBindingEntry(entry)))
+      for (const result of disposed) {
+        if (result.status === 'rejected') {
+          app.log.warn({ err: result.reason }, '[agent] failed to dispose runtime binding')
+        }
+      }
       await modeAdapter.dispose?.()
     },
     beforeRegister: (profileApp) => {

--- a/packages/agent/src/shared/events.ts
+++ b/packages/agent/src/shared/events.ts
@@ -81,6 +81,11 @@ export interface AgentRuntimeAdapter {
 export interface AgentReadinessStatus {
   key: string
   ready: boolean
+  state?: 'not-started' | 'preparing' | 'ready' | 'failed'
+  errorCode?: string
+  causeCode?: string
+  retryable?: boolean
+  workspaceId?: string
   message?: string
 }
 
@@ -100,6 +105,7 @@ export interface AgentConfig {
   /** Provider + host-policy fact for direct model input assets. */
   providerDirectInputAssets?: boolean
   tools?: AgentTool[]
+  readiness?: AgentReadiness
   readinessRequirements?: string[]
   sessions?: SessionStore
   systemPromptAppend?: string


### PR DESCRIPTION
Final purity slice (stacked on #575). Fixes two placeholders the P1 rewrite flagged: (1) agent.readiness returned a hardcoded ready:false — now it surfaces the real per-requirement status from createRuntimeReadyStatusTracker + mergeTools({checkReadiness}), or an explicit empty view when no runtime is attached. (2) the runtime-binding LRU evicted entries WITHOUT disposing them (leaked runtimes) — eviction now tears down the evicted binding + cached runtime handle, without globally disposing the shared adapter. Behavior-frozen otherwise; tests for both. Gates: agent typecheck/test (1626), build, lint:invariants, audit:imports, check:isolation, boring-bash check:invariants, autoreview clean. LOC +187/-13 prod, +154 tests. Review ~10 min. **This closes the reopened-P1 purity chain (A/B/C/D).** 🤖 Generated with Claude Code