### PR TITLE
Publish Diagram package from main CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,6 +625,7 @@ jobs:
           pnpm --filter @hachej/boring-workspace build
           pnpm --filter @hachej/boring-core build
           pnpm --filter @hachej/boring-deck build
+          pnpm --filter @hachej/boring-diagram build
           pnpm --filter @hachej/boring-ui-cli build:full
           pnpm --filter @hachej/boring-ask-user build
           pnpm --filter @hachej/boring-data-explorer build
@@ -639,7 +640,7 @@ jobs:
 
       - name: Publish packages with ci dist-tag
         run: |
-          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core packages/cli plugins/deck plugins/ask-user plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-bash plugins/boring-governance; do
+          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core packages/cli plugins/deck plugins/diagram plugins/ask-user plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-bash plugins/boring-governance; do
             tarball=$(cd $pkg && pnpm pack 2>&1 | tail -1)
             if ! npm publish "$pkg/$tarball" --access public --tag ci --provenance; then
               echo "::warning::CI package publish failed for $pkg; continuing because release publishing is handled by release.yml"


### PR DESCRIPTION
Adds @hachej/boring-diagram to the main CI publish job so the ci dist-tag package is built and published alongside other first-party packages.\n\nValidation:\n- pnpm --filter @hachej/boring-diagram build