### PR TITLE
chore(workflow): activate boring v2 workspace

### DIFF
--- a/.agents/skills/ask-boring/SKILL.md
+++ b/.agents/skills/ask-boring/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: ask-boring
+description: Route a request to the right Boring v2 workflow skill without doing the work.
+---
+
+# Ask Boring
+
+Router only. Do not edit files, create issues, plan, implement, review, or merge.
+
+## Routes
+
+- `feedback` — user is reporting a bug, idea, UX issue, feature request, or rough observation that should become a GitHub issue.
+- `triage` — an existing issue/PR needs classification, verification, or a next state.
+- `plan` — the desired outcome needs a spec, implementation plan, slices, blockers, or proof path before coding.
+- `implement` — one issue/slice is ready for an agent to build.
+- `diagnose` later — hard bug without a tight repro loop.
+- `wayfinder` later — huge/foggy effort where the destination or route is not knowable in one session.
+- `human` — external access, product judgment, security/privacy, merge authority, or unavailable context is required.
+
+## Output
+
+Return one routing card:
+
+```text
+Recommended: <skill>
+Why: <one sentence>
+Input: <issue/PR/path/context to pass>
+Next: /<skill> <args>
+Caution: <optional blocker or human decision>
+```

--- a/.agents/skills/feedback/SKILL.md
+++ b/.agents/skills/feedback/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: feedback
+description: Create a GitHub issue from user feedback with safe context and simple labels. Never implement.
+---
+
+# Feedback
+
+Create the source GitHub issue and stop. Do not implement. Do not split into tickets.
+
+## Labels
+
+Apply exactly one category when possible:
+
+- `bug`
+- `enhancement`
+
+Apply exactly one state:
+
+- `needs-triage` — clear enough for triage
+- `needs-info` — clarification is needed
+
+## Process
+
+1. Capture the report: observed behavior, expected behavior, route/panel/plugin, selected item, branch/SHA if available, environment/browser/app context, safe errors, optional screenshot.
+2. Redact before publishing: no secrets, cookies, auth headers, private data, unrelated transcripts, or host-local paths. Use safe attachment names/URLs only.
+3. If unclear enough to affect routing, ask only: `Grill now, defer, or skip?`
+   - grill now: clarify before final issue body.
+   - defer: create issue with `needs-info`.
+   - skip: create issue with best-known context and `needs-triage`.
+4. Create the GitHub issue.
+5. Stop and return the issue URL plus next suggestion.
+
+## Issue Body
+
+```md
+## Summary
+
+## Observed
+
+## Expected
+
+## Context
+- Route/panel:
+- Package/plugin:
+- Branch/SHA:
+- Environment:
+
+## Artifacts
+
+## Redaction
+
+## Acceptance
+
+## Proof Ideas
+- Exact command:
+- Screenshot/demo:
+- Manual steps:
+- Waiver if proof is not possible:
+
+## Open Questions
+
+## Next
+Suggested next step: `/triage #<issue>` or `/plan #<issue>`.
+```

--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: implement
+description: Implement one ready issue or slice safely, with proof, review, and PR handoff.
+---
+
+# Implement
+
+Build one ready issue/slice. This is an implementation loop: implement → prove → review → fix → re-review as needed → hand off PR. Keep the diff small and reviewable.
+
+## Non-negotiables
+
+- Work on a branch/PR; never push directly to remote `main`.
+- Do not force push, hard reset, clean, or delete files unless explicitly asked.
+- Do not expose secrets in code, logs, commits, PRs, or comments.
+- Prefer behavior tests at public seams.
+- Proof is required before done.
+- Review is required before done.
+
+## Process
+
+1. Read `skill-library/boring-v2/MODEL-CARD.md` for proof, reviewer, and escalation policy when available.
+2. Read the issue, plan/spec, comments, linked PRs, and relevant code/docs.
+3. Confirm the target slice and proof expectation.
+4. Implement one vertical slice.
+5. Add/update tests or documented manual proof.
+6. Run relevant checks.
+7. Run review:
+   - Standards review
+   - Spec review
+   - Thermo review for broad/risky/structural changes
+8. Fix accepted findings and re-run relevant proof.
+9. Re-review when fixes are non-trivial or the first review found structural issues.
+10. Open/update PR.
+11. Post proof and handoff card.
+12. If owner review or a human decision is needed, use the `ask_user` tool when available so the request appears in the Boring UI inbox. If `ask_user` is unavailable, leave a clear GitHub/PR comment instead.
+
+## Proof Requirements
+
+Every implementation must record at least one proof path, preferring automated proof first:
+
+- **Exact command:** the precise command run, with pass/fail result and relevant output summary.
+- **Screenshot/demo:** required for visual/UI behavior when relevant; include URL/artifact and what to inspect.
+- **Manual steps:** exact reproduction/verification steps when automation is not practical.
+- **Waiver:** allowed only when proof is genuinely not possible or not worth the cost; explain why and name the residual risk.
+
+Do not say “tested” without the command, screenshot/demo, manual steps, or waiver.
+
+## Human Review Requests
+
+When asking for owner review, visual review, merge approval, or a product decision, prefer `ask_user` if the tool is available. This creates a Boring UI inbox entry and keeps the workspace as the control plane.
+
+Use a concise prompt with:
+
+- PR/issue link
+- decision needed
+- proof summary
+- concrete test steps
+- risk/rollback notes
+
+Fallback: if `ask_user` is unavailable, post the same request as a GitHub/PR comment.
+
+## PR Handoff Card
+
+```md
+## Summary
+
+## Issue / Slice
+
+## What Changed
+
+## Proof
+- Exact command:
+- Screenshot/demo:
+- Manual steps:
+- Waiver if proof is not possible:
+
+## Review
+- Standards:
+- Spec:
+- Thermo, if needed:
+- Reviewed SHA:
+
+## Risk / Rollback
+
+## Next
+- `ready-for-human` owner review, preferably via `ask_user`, or
+- merge path if explicitly approved and safe.
+```
+
+
+## Loop Exit
+
+Do not exit as done until:
+
+- PR exists or the user explicitly asked for local-only work.
+- Proof is recorded with exact command, screenshot/demo, manual steps, or waiver.
+- Standards and Spec review are clean, or accepted residual risk is documented.
+- Thermo review ran for risky/broad/structural changes.
+- The next action is clear: owner review, merge path, or blocked reason.
+- Human review/decision requests were sent through `ask_user` when available, or clearly posted as GitHub/PR comments otherwise.

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: plan
+description: Turn an issue or conversation into a spec and, when needed, tracer-bullet implementation slices with blockers and proof.
+---
+
+# Plan
+
+Plan before coding. This is a planning loop: produce the first useful spec/plan, run adversarial review when risk is non-trivial, revise once for accepted findings, and exit with a clear state. This is `to-spec` first; use `to-tickets` behavior only when the work is too large for one safe implementation slice.
+
+## Modes
+
+- Spec mode: clarify what should be built.
+- Slice mode: split the spec into tracer-bullet vertical slices with blocking edges.
+
+## Process
+
+1. Read `skill-library/boring-v2/MODEL-CARD.md` for reviewer/escalation policy when available.
+2. Read the source issue/spec/conversation, comments, related PRs, existing plan files, and relevant code/docs.
+2. Produce or update a spec/plan. Prefer issue comments for small work; use `docs/issues/<issue>/plan.md` for risky, broad, or multi-slice work.
+3. Identify test seams and proof before implementation starts.
+4. If the work is broad, split into vertical slices. Each slice must be demoable/verifiable alone.
+5. For wide mechanical refactors, do not force fake vertical slices; use expand → migrate batches → contract.
+6. Run an adversarial plan review when triggered by the model card: challenge scope, flag path, blockers, proof, review budget, and whether the plan is too broad.
+7. Revise for accepted findings.
+8. Mark the next action: `ready-for-agent`, `ready-for-human`, or `needs-info`.
+9. If the next action requires human input, use the `ask_user` tool when available so the request appears in the Boring UI inbox. If unavailable, leave a GitHub issue comment.
+
+## Plan Shape
+
+```md
+## Problem Statement
+
+## Solution
+
+## User Stories / Scenarios
+
+## Decisions
+
+## Flag / Abstraction
+- Needed?:
+- Path:
+- Rollback:
+
+## Test Seams
+- Highest public seam:
+- Existing prior art:
+- Avoid testing:
+
+## Acceptance
+
+## Proof
+- Exact command:
+- Screenshot/demo:
+- Manual steps:
+- Waiver if proof is not possible:
+
+## Slices
+
+### Slice: <name>
+**Delivers:**
+**Blocked by:** None / <slice or issue>
+**Proof:** exact command, screenshot/demo, manual steps, or waiver
+**Review budget:** inside / exceeds / why
+
+## Wide Refactor Strategy
+Expand → migrate batches → contract, if applicable.
+
+## Out of Scope
+
+## Open Questions
+```
+
+
+## Loop Exit
+
+Exit only with one of:
+
+- `ready-for-agent` — plan is clear enough for one implementation slice.
+- `ready-for-human` — human judgment/access/approval is required.
+- `needs-info` — specific unanswered questions block safe planning.
+
+Return: state, plan path/comment, slices, blockers, proof path, adversarial review result, and next action. If human input is needed, include the `ask_user` request id or the fallback GitHub comment URL.

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: triage
+description: Classify existing issues or PRs with the simple Boring state model and record the next action.
+---
+
+# Triage
+
+Classify issue/PR state. Do not implement.
+
+## Labels
+
+Category, exactly one where possible:
+
+- `bug`
+- `enhancement`
+
+State, exactly one:
+
+- `needs-triage` — not evaluated yet
+- `needs-info` — waiting for specific user/reporter answers
+- `ready-for-agent` — agent can plan or implement safely
+- `ready-for-human` — human judgment/access/approval is required
+- `wontfix` — rejected, duplicate, out of scope, or already solved
+
+## Process
+
+1. Read the issue/PR body, comments, labels, linked plans/PRs, and relevant code/docs.
+2. Verify the claim when cheap and safe. For bugs, look for a red-capable repro command or concrete manual path.
+3. Decide the first blocker:
+   - `clarity` — missing information
+   - `risk` — human judgment needed
+   - `plan` — needs spec/slices before coding
+   - `implementation` — ready to build
+   - `proof` — built but proof is missing/stale
+   - `review` — code needs review/fixes
+   - `merge` — ready but human/merge decision remains
+4. Apply simple labels.
+5. Post/update a short routing comment.
+6. If the issue needs human input, use the `ask_user` tool when available so it appears in the Boring UI inbox. If unavailable, post specific questions as a GitHub issue/PR comment.
+
+## Routing Comment
+
+```md
+## Boring Triage
+
+State: `<state>`
+Category: `<bug|enhancement>`
+Blocked by: `<clarity|risk|plan|implementation|proof|review|merge|none>`
+Next: `/<skill> <target>`
+
+Proof expected:
+- Exact command:
+- Screenshot/demo:
+- Manual steps:
+- Waiver if proof is not possible:
+
+Human request:
+- `ask_user` id or GitHub/PR comment URL, if applicable
+
+Notes:
+- ...
+```

--- a/apps/workspace-playground/README.md
+++ b/apps/workspace-playground/README.md
@@ -8,7 +8,7 @@ For the bare agent chat use [`agent-playground`](../agent-playground/README.md);
 
 `pnpm --filter workspace-playground dev` builds the workspace stack to `dist/` (`build:deps`) and starts Vite on **`http://localhost:5200`**. A Vite plugin boots `createWorkspaceAgentServer({ mode: 'local' })` in-process on **`http://127.0.0.1:5210`**; Vite proxies `/api/v1` to it. The agent owns the filesystem and the UI bridge — there is no mock API.
 
-The frontend (`src/front/App.tsx`) mounts `WorkspaceAgentFront` with front plugins for ask-user (`@hachej/boring-ask-user`), deck (`@hachej/boring-deck`), and Diagram (`@hachej/boring-diagram`). The server registers `defaultPluginPackages`: `@hachej/boring-ask-user` and `@hachej/boring-diagram`.
+The frontend (`src/front/App.tsx`) mounts `WorkspaceAgentFront` with front plugins for ask-user/inbox (`@hachej/boring-ask-user` with `appLeftInbox: true`), tasks (`@hachej/boring-tasks`), deck (`@hachej/boring-deck`), and Diagram (`@hachej/boring-diagram`). The server registers `defaultPluginPackages`: `@hachej/boring-ask-user`, `@hachej/boring-tasks`, and `@hachej/boring-diagram`.
 
 ### Rebuild required after package edits
 
@@ -51,7 +51,7 @@ Open `http://localhost:5200`. Append `?showcase=1` for the showcase route, or vi
 
 ## Composition
 
-Depends on `@hachej/boring-workspace` (the workbench shell + `createWorkspaceAgentServer`), `@hachej/boring-agent` (the runtime), `@hachej/boring-deck`, `@hachej/boring-ask-user`, and `@hachej/boring-diagram` (plugins), and `@hachej/boring-data-catalog` / `@hachej/boring-data-explorer`. It does **not** use `@hachej/boring-core` — there is no auth or database layer.
+Depends on `@hachej/boring-workspace` (the workbench shell + `createWorkspaceAgentServer`), `@hachej/boring-agent` (the runtime), `@hachej/boring-deck`, `@hachej/boring-ask-user`, `@hachej/boring-tasks`, and `@hachej/boring-diagram` (plugins), and `@hachej/boring-data-catalog` / `@hachej/boring-data-explorer`. It does **not** use `@hachej/boring-core` — there is no auth or database layer.
 
 ## License
 

--- a/apps/workspace-playground/package.json
+++ b/apps/workspace-playground/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:deps": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-ui-plugin-cli build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-deck build && pnpm --filter @hachej/boring-ask-user build && pnpm --filter @hachej/boring-diagram build && pnpm --filter @hachej/boring-data-explorer build && pnpm --filter @hachej/boring-data-catalog build",
+    "build:deps": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-ui-plugin-cli build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-deck build && pnpm --filter @hachej/boring-ask-user build && pnpm --filter @hachej/boring-tasks build && pnpm --filter @hachej/boring-diagram build && pnpm --filter @hachej/boring-data-explorer build && pnpm --filter @hachej/boring-data-catalog build",
     "dev": "pnpm run build:deps && vite",
     "build": "pnpm run build:deps && vite build",
     "typecheck": "tsc --noEmit",
@@ -20,6 +20,7 @@
     "@hachej/boring-workspace": "workspace:*",
     "@hachej/boring-deck": "workspace:*",
     "@hachej/boring-ask-user": "workspace:*",
+    "@hachej/boring-tasks": "workspace:*",
     "@hachej/boring-diagram": "workspace:*",
     "@duckdb/node-api": "1.5.2-r.2",
     "react": "^19.2.7",

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -6,6 +6,7 @@ import { WorkspaceAgentFront, WorkspaceFullPagePanel, parseFullPagePanelLocation
 import { definePlugin, type WorkspaceSourceProps } from "@hachej/boring-workspace/plugin"
 import { createAskUserPlugin } from "@hachej/boring-ask-user/front"
 import { diagramPlugin } from "@hachej/boring-diagram/front"
+import { createTasksPlugin } from "@hachej/boring-tasks/front"
 import { SHOWCASE_SESSION_ID, seedShowcase } from "./showcaseMessages"
 
 function isShowcaseRoute(): boolean {
@@ -89,8 +90,9 @@ const multiFilesystemPlaygroundPlugin = definePlugin({
 })
 
 const askUserPlugin = createAskUserPlugin({ appLeftInbox: true })
-const workspacePlugins = [askUserPlugin, playgroundDeckPlugin, diagramPlugin]
-const multiFilesystemWorkspacePlugins = [askUserPlugin, playgroundDeckPlugin, diagramPlugin, multiFilesystemPlaygroundPlugin]
+const tasksPlugin = createTasksPlugin()
+const workspacePlugins = [askUserPlugin, tasksPlugin, playgroundDeckPlugin, diagramPlugin]
+const multiFilesystemWorkspacePlugins = [askUserPlugin, tasksPlugin, playgroundDeckPlugin, diagramPlugin, multiFilesystemPlaygroundPlugin]
 const externalPluginsEnabled = (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_BORING_EXTERNAL_PLUGINS === "1"
 
 function resetPlaygroundStorageIfRequested(): void {

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -75,7 +75,7 @@ export async function startPlaygroundServer(): Promise<void> {
       runtimeModeAdapter: remoteWorkerModeAdapter,
       logger: true,
       externalPlugins: EXTERNAL_PLUGINS_ENABLED,
-      defaultPluginPackages: ["@hachej/boring-ask-user", "@hachej/boring-diagram"],
+      defaultPluginPackages: ["@hachej/boring-ask-user", "@hachej/boring-tasks", "@hachej/boring-diagram"],
       runtimeProvisioner: multiFilesystemPlayground
         ? async ({ runtimeBundle }) => {
             const bundle = runtimeBundle as typeof runtimeBundle & { filesystemBindings?: unknown[] }

--- a/docs/kanzen/README.md
+++ b/docs/kanzen/README.md
@@ -8,7 +8,7 @@ ask-boring -> feedback -> triage -> plan -> implement
 
 ## Skills
 
-Draft skills live in `skill-library/boring-v2/skills/`. They are not active until copied into `.agents/skills/`.
+Active skills live in `.agents/skills/`. Draft/reference copies live in `skill-library/boring-v2/skills/`.
 
 | Skill | Job |
 | --- | --- |

--- a/docs/kanzen/procedures/agent-workflow.md
+++ b/docs/kanzen/procedures/agent-workflow.md
@@ -10,7 +10,7 @@ Current workflow:
 ask-boring -> feedback -> triage -> plan -> implement
 ```
 
-Draft skills live in [`../../../skill-library/boring-v2/skills/`](../../../skill-library/boring-v2/skills/). They are not active until copied into `.agents/skills/`.
+Active skills live in [`../../../.agents/skills/`](../../../.agents/skills/). Draft/reference copies live in [`../../../skill-library/boring-v2/skills/`](../../../skill-library/boring-v2/skills/).
 
 Use focused procedures for how-to details:
 

--- a/packages/core/SIZE.md
+++ b/packages/core/SIZE.md
@@ -2,21 +2,21 @@
 
 | Entry  | Gzip (KB) |
 |--------|-----------|
-| front  |     34.97 |
-| server |     59.66 |
+| front  |     34.61 |
+| server |     65.78 |
 
 ### Chunk breakdown
 
 **front**
+- `chunk-3B7LU76T.js`: 33.78 KB
 - `chunk-HYNKZSTF.js`: 0.24 KB
-- `chunk-NKJO5ASV.js`: 34.14 KB
 - `front/index.js`: 0.60 KB
 
 **server**
 - `chunk-AQBXNPMD.js`: 0.17 KB
-- `chunk-BVZ2YT3M.js`: 19.56 KB
+- `chunk-DSENO5O4.js`: 21.68 KB
+- `chunk-JBEKMYST.js`: 24.51 KB
 - `chunk-QZGYKLXB.js`: 0.89 KB
-- `chunk-ZMS6O4CY.js`: 20.62 KB
-- `server/index.js`: 18.42 KB
+- `server/index.js`: 18.53 KB
 
-_Updated: 2026-07-03_
+_Updated: 2026-07-09_

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -186,6 +186,9 @@ importers:
       '@hachej/boring-diagram':
         specifier: workspace:*
         version: link:../../plugins/diagram
+      '@hachej/boring-tasks':
+        specifier: workspace:*
+        version: link:../../plugins/tasks
       '@hachej/boring-workspace':
         specifier: workspace:*
         version: link:../../packages/workspace


### PR DESCRIPTION
## Summary
- activate the five Boring v2 workflow skills under `.agents/skills`
- enable ask-user inbox + tasks in workspace-playground front/server composition
- update workspace-playground docs and dependency graph
- point Kanzen docs at active skills instead of draft-only copies
- update the core bundle-size baseline to current measured output

## Verification
- `pnpm install` ✅ updates local TypeScript to lockfile version
- `pnpm --filter workspace-playground build:deps` ✅
- `pnpm --filter workspace-playground typecheck` ✅
- `pnpm --filter workspace-playground test` ✅
- local playground smoke ✅ at `http://127.0.0.1:5220` with API `:5230`
- plugin registry smoke ✅ includes `ask-user`, `tasks`, and `diagram`

## GitHub label migration
- created/updated Boring v2 labels
- migrated open issues/PRs to category + state labels
- deleted old open-workflow routing labels: `state:*`, `phase:*`, `track:*`, `status:*`, `source:feedback`, `gate:intake`, etc.
