### PR TITLE
Move company context mutations into governance

### DIFF
--- a/docs/plans/governance-architecture-cleanup.md
+++ b/docs/plans/governance-architecture-cleanup.md
@@ -1,0 +1,50 @@
+# Governance architecture cleanup
+
+## Goal
+
+Make `@hachej/boring-governance` the sole owner of company-context policy and storage capabilities, keep `@hachej/boring-agent` as the sole filesystem HTTP implementation, and reduce Constellation to composition and deployment configuration.
+
+## Phase 1 — canonical mutable binding
+
+- [x] Add a typed `companyContextAccessForUser()` decision to `GovernanceService`.
+- [x] Add a canonical `CompanyContextStore` with contained, symlink-safe, atomic writes.
+- [x] Return `readwrite` company-context bindings for verified tenant admins.
+- [x] Keep ordinary policy users on filtered readonly projections.
+- [x] Add bound-read `mtimeMs` to the generic agent filesystem contract and HTTP response.
+- [x] Add governance store/binding tests for admin, readonly, unknown, traversal, symlink, conflict, write, delete, move, and mkdir.
+- [x] Add canonical agent route and tool tests for mutable binding reads, writes, edits, and conflicts.
+
+## Phase 2 — remove Constellation fork
+
+- [ ] Publish the fixed governance/agent/core packages.
+- [ ] Replace Constellation adapters with `governance.getFilesystemBindings()`.
+- [ ] Delete `src/server/governance/httpFiles.ts`.
+- [ ] Delete `src/server/governance/filesystemBindings.ts`.
+- [ ] Remove `beforeAgentRoutes` and `patches/@hachej__boring-core@0.1.71.patch`.
+- [ ] Remove patch-only `pnpm-workspace.yaml` and Docker patch copying.
+- [ ] Run the full deployed access matrix through generic agent routes.
+
+## Phase 3 — matrix maintainability
+
+- [ ] Split the matrix into config, scenarios, transport, runner, and reporter modules.
+- [ ] Keep the executable wrapper below roughly 30 lines.
+- [ ] Resolve actor, target workspace, observer, and cleanup identity once per case.
+- [ ] Use an idempotent cleanup registry.
+- [ ] Add deterministic unit tests for configuration, timeouts, side-effect checks, cleanup, partial sign-in, and sign-out.
+
+## Phase 4 — runtime isolation
+
+- [ ] Run Bubblewrap only in the secret-minimized worker container.
+- [ ] Keep the credential-bearing web process unprivileged.
+- [ ] Commit the exact seccomp, namespace, PID, CPU, memory, network, and concurrency limits used in production.
+- [ ] Add a built-container remote-worker write/read smoke.
+
+## Release gate
+
+- [ ] Clean registry install with no local tarballs or patched dependencies.
+- [ ] Governance, agent, core, and Constellation tests green.
+- [ ] Full access matrix green.
+- [ ] Admin stale-write conflict verified.
+- [ ] Admin delete/move/mkdir verified.
+- [ ] Web and worker image digests match the deployment manifest.
+- [ ] Rollback image retained until the compatibility bridge is removed successfully.

--- a/packages/agent/src/server/http/routes/__tests__/file.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/file.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest'
 import type { Workspace } from '../../../../shared/workspace'
 import type { RuntimeFilesystemBindingOperations } from '../../../runtime/mode'
 import { createNodeWorkspace } from '../../../workspace/createNodeWorkspace'
+import { ERROR_CODE_CONFLICT } from '../../middleware'
 import { ERROR_CODE_NOT_FOUND_OR_DENIED, ERROR_CODE_READONLY, fileRoutes } from '../file'
 
 const tempRoots: string[] = []
@@ -166,7 +167,7 @@ describe('file routes (NodeWorkspace integration)', () => {
     const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-file-routes-'))
     tempRoots.push(workspaceRoot)
     const operations: RuntimeFilesystemBindingOperations = {
-      read: vi.fn(async ({ path }) => ({ content: `company:${path}` })),
+      read: vi.fn(async ({ path }) => ({ content: `company:${path}`, mtimeMs: 456 })),
       list: vi.fn(),
       find: vi.fn(),
       grep: vi.fn(),
@@ -187,7 +188,7 @@ describe('file routes (NodeWorkspace integration)', () => {
     })
 
     expect(res.statusCode).toBe(200)
-    expect(res.json()).toEqual({ content: 'company:/company/curated.md', access: 'readwrite' })
+    expect(res.json()).toEqual({ content: 'company:/company/curated.md', mtimeMs: 456, access: 'readwrite' })
 
     const writeRes = await app.inject({
       method: 'POST',
@@ -197,6 +198,27 @@ describe('file routes (NodeWorkspace integration)', () => {
     expect(writeRes.statusCode).toBe(200)
     expect(writeRes.json()).toEqual({ ok: true, mtimeMs: 789 })
     expect(operations.write).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/curated.md', content: 'updated' })
+
+    const conflict = Object.assign(new Error('file has been modified since last read'), {
+      statusCode: 409,
+      code: ERROR_CODE_CONFLICT,
+      details: { currentMtimeMs: 789, expectedMtimeMs: 456 },
+    })
+    vi.mocked(operations.write!).mockRejectedValueOnce(conflict)
+    const conflictRes = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files',
+      payload: { filesystem: 'company_context', path: '/company/curated.md', content: 'stale', expectedMtimeMs: 456 },
+    })
+    expect(conflictRes.statusCode).toBe(409)
+    expect(conflictRes.json()).toEqual({
+      error: {
+        code: ERROR_CODE_CONFLICT,
+        message: 'file has been modified since last read',
+        currentMtimeMs: 789,
+        expectedMtimeMs: 456,
+      },
+    })
 
     const deleteRes = await app.inject({ method: 'DELETE', url: '/api/v1/files?filesystem=company_context&path=%2Fcompany%2Fcurated.md' })
     expect(deleteRes.statusCode).toBe(200)

--- a/packages/agent/src/server/http/routes/file.ts
+++ b/packages/agent/src/server/http/routes/file.ts
@@ -111,11 +111,20 @@ function classifyError(
   const statusCode = (err as { statusCode?: unknown })?.statusCode
   const stableCode = (err as { code?: unknown })?.code
   if (typeof statusCode === 'number' && statusCode >= 400 && statusCode < 600) {
+    const details = (err as { details?: unknown })?.details
+    const conflictDetails = stableCode === ERROR_CODE_CONFLICT && details && typeof details === 'object' && !Array.isArray(details)
+      ? details as Record<string, unknown>
+      : null
     return reply.code(statusCode).send({
       error: {
         code: typeof stableCode === 'string' ? stableCode : ERROR_CODE_INTERNAL,
         message,
-        details: (err as { details?: unknown })?.details,
+        ...(conflictDetails
+          ? {
+              currentMtimeMs: conflictDetails.currentMtimeMs,
+              expectedMtimeMs: conflictDetails.expectedMtimeMs,
+            }
+          : { details }),
       },
     })
   }
@@ -386,7 +395,7 @@ export function fileRoutes(
         const binding = await resolveFilesystemBinding(request, filesystem)
         if (!binding) return sendNotFoundOrDenied(reply)
         const result = await binding.operations.read({ filesystem, path })
-        return { content: result.content, access: binding.access }
+        return { content: result.content, mtimeMs: result.mtimeMs, access: binding.access }
       } catch {
         return sendNotFoundOrDenied(reply)
       }

--- a/packages/agent/src/server/runtime/mode.ts
+++ b/packages/agent/src/server/runtime/mode.ts
@@ -69,7 +69,7 @@ export interface ModeContext {
 }
 
 export interface RuntimeFilesystemBindingOperations {
-  read(descriptor: { filesystem: string; path: string }): Promise<{ content: string; metadata?: unknown }>
+  read(descriptor: { filesystem: string; path: string }): Promise<{ content: string; mtimeMs?: number; metadata?: unknown }>
   list(descriptor: { filesystem: string; path: string }): Promise<{ entries: string[]; metadata?: unknown }>
   find(descriptor: { filesystem: string; path: string }, pattern: string, options?: { limit?: number; offset?: number }): Promise<{ paths: string[]; metadata?: unknown }>
   grep(descriptor: { filesystem: string; path: string }, pattern: string, options?: { limit?: number; offset?: number }): Promise<{ matches: Array<{ path: string; line: number; text: string }>; metadata?: unknown }>

--- a/packages/agent/src/server/tools/filesystem/__tests__/filesystem.test.ts
+++ b/packages/agent/src/server/tools/filesystem/__tests__/filesystem.test.ts
@@ -98,12 +98,16 @@ function mockBundle(provider: string, root = '/workspace', storageRoot?: string)
   }
 }
 
-function withFilesystemBinding(bundle: RuntimeBundle, operations = mockReadonlyBindingOperations()): RuntimeBundle {
+function withFilesystemBinding(
+  bundle: RuntimeBundle,
+  operations = mockReadonlyBindingOperations(),
+  access: 'readonly' | 'readwrite' = 'readonly',
+): RuntimeBundle {
   return {
     ...bundle,
     filesystemBindings: [{
       filesystem: 'company_context',
-      access: 'readonly',
+      access,
       operations,
     }],
   }
@@ -252,7 +256,7 @@ describe('buildFilesystemAgentTools', () => {
     expect(present.promptSnippet).toContain('Named filesystem bindings')
     expect(present.promptSnippet).toContain('company_context')
     expect(present.promptSnippet).toContain('default to the user workspace')
-    expect(present.promptSnippet).toContain('Readonly filesystem bindings reject writes')
+    expect(present.promptSnippet).toContain('A binding may be readonly or readwrite')
     expect(present.promptSnippet).toContain('do not use path prefixes')
   })
 
@@ -368,6 +372,65 @@ describe('buildFilesystemAgentTools', () => {
     expect(operations.read).not.toHaveBeenCalledWith({ filesystem: 'company_context', path: 'company_context:/company/hr/policy.md' })
     logToolE2e({ tool: 'write', filesystem: 'company_context', path: '/company/hr/policy.md', expectedBinding: 'company_context-readonly', resultSummary: 'mutation rejected' })
     logToolE2e({ tool: 'read', filesystem: 'company_context', path: '<spoof>', expectedBinding: 'none', resultSummary: 'path spoof rejected before company read' })
+  })
+
+  test('company_context mutation tools use readwrite binding operations', async () => {
+    const operations = mockReadonlyBindingOperations()
+    operations.read = vi.fn(async () => ({ content: 'before target middle final after', mtimeMs: 123 }))
+    operations.write = vi.fn(async () => ({ mtimeMs: 456 }))
+    operations.mkdir = vi.fn(async () => ({}))
+    const tools = buildFilesystemAgentTools(withFilesystemBinding(mockBundle('direct'), operations, 'readwrite'))
+    const write = tools.find((tool) => tool.name === 'write')!
+    const edit = tools.find((tool) => tool.name === 'edit')!
+
+    await expect(write.execute(
+      { filesystem: 'company_context', path: '/company/new.md', content: 'new content' },
+      { abortSignal: new AbortController().signal, toolCallId: 'company-write' },
+    )).resolves.toMatchObject({ content: [{ text: 'Wrote /company/new.md' }] })
+    expect(operations.mkdir).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company', recursive: true })
+    expect(operations.write).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/company/new.md', content: 'new content' })
+
+    await expect(edit.execute(
+      {
+        filesystem: 'company_context',
+        path: '/company/existing.md',
+        edits: [
+          { oldText: 'target', newText: 'updated' },
+          { oldText: 'final', newText: 'done' },
+        ],
+      },
+      { abortSignal: new AbortController().signal, toolCallId: 'company-edit' },
+    )).resolves.toMatchObject({ content: [{ text: 'Edited /company/existing.md' }] })
+    expect(operations.write).toHaveBeenCalledWith({
+      filesystem: 'company_context',
+      path: '/company/existing.md',
+      content: 'before updated middle done after',
+      expectedMtimeMs: 123,
+    })
+    expect(operations.rejectMutation).not.toHaveBeenCalled()
+
+    vi.mocked(operations.read).mockResolvedValueOnce({ content: 'a', mtimeMs: 456 })
+    await expect(edit.execute(
+      {
+        filesystem: 'company_context',
+        path: '/company/existing.md',
+        edits: [
+          { oldText: 'a', newText: 'b' },
+          { oldText: 'b', newText: 'c' },
+        ],
+      },
+      { abortSignal: new AbortController().signal, toolCallId: 'company-edit-invalid-chain' },
+    )).rejects.toThrow('found 0')
+
+    vi.mocked(operations.read).mockResolvedValueOnce({ content: 'aaa', mtimeMs: 789 })
+    await expect(edit.execute(
+      {
+        filesystem: 'company_context',
+        path: '/company/existing.md',
+        edits: [{ oldText: 'aa', newText: 'x' }],
+      },
+      { abortSignal: new AbortController().signal, toolCallId: 'company-edit-overlapping-match' },
+    )).rejects.toThrow('found 2')
   })
 
   test('remote filesystem tools also accept company_context without bypassing workspace user default', async () => {

--- a/packages/agent/src/server/tools/filesystem/index.ts
+++ b/packages/agent/src/server/tools/filesystem/index.ts
@@ -8,7 +8,7 @@ import {
 } from '@mariozechner/pi-coding-agent'
 
 import type { AgentTool, ToolExecContext } from '../../../shared/tool'
-import { getRuntimeBundleStorageRoot, type RuntimeBundle, type RuntimeFilesystemBindingOperations, type RuntimeFilesystemStrategy } from '../../runtime/mode'
+import { getRuntimeBundleStorageRoot, type RuntimeBundle, type RuntimeFilesystemBinding, type RuntimeFilesystemStrategy } from '../../runtime/mode'
 import { boundFs } from '../operations/bound'
 import { buildRemoteWorkspaceFilesystemAgentTools } from './remoteWorkspaceTools'
 
@@ -59,7 +59,7 @@ function withFilesystemParameter(parameters: unknown, filesystemIds: readonly st
       filesystem: {
         type: 'string',
         description: filesystemIds.length > 0
-          ? 'Logical filesystem to use. Omit or use user for workspace files; use an advertised named filesystem for bound readonly context.'
+          ? 'Logical filesystem to use. Omit or use user for workspace files; use an advertised named filesystem for bound context.'
           : 'Logical filesystem to use. Omit or use user for workspace files.',
         ...(dynamicBindings ? {} : { enum: ['user', ...filesystemIds] }),
       },
@@ -89,14 +89,10 @@ function assertNotFilesystemPathSpoof(path: string, filesystemIds: readonly stri
   }
 }
 
-function filesystemBinding(bindings: readonly { filesystem: string; operations: RuntimeFilesystemBindingOperations }[], filesystem: string) {
-  return bindings.find((binding) => binding.filesystem === filesystem)
-}
-
-function boundOperations(bindings: readonly { filesystem: string; operations: RuntimeFilesystemBindingOperations }[], filesystem: string): RuntimeFilesystemBindingOperations {
-  const binding = filesystemBinding(bindings, filesystem)
+function filesystemBinding(bindings: readonly RuntimeFilesystemBinding[], filesystem: string): RuntimeFilesystemBinding {
+  const binding = bindings.find((entry) => entry.filesystem === filesystem)
   if (!binding) throw new Error(`No filesystem binding is available for ${filesystem}`)
-  return binding.operations
+  return binding
 }
 
 function formatBoundRead(content: string): PiToolResultLike {
@@ -115,15 +111,45 @@ function formatBoundGrep(matches: Array<{ path: string; line: number; text: stri
   return { content: [{ type: 'text', text: matches.map((match) => `${match.path}:${match.line}:${match.text}`).join('\n') }] }
 }
 
+interface ExactEdit {
+  oldText: string
+  newText: string
+}
+
+function applyExactEdits(original: string, edits: readonly ExactEdit[]): string {
+  if (edits.length === 0) throw new Error('edit requires at least one edit')
+  const ranges = edits.map((edit) => {
+    if (!edit.oldText) throw new Error('edit oldText must not be empty')
+    const start = original.indexOf(edit.oldText)
+    const duplicate = start >= 0 ? original.indexOf(edit.oldText, start + 1) : -1
+    if (start < 0 || duplicate >= 0) {
+      const occurrences = start < 0 ? 0 : 2
+      throw new Error(`edit requires oldText to match exactly once; found ${occurrences}`)
+    }
+    return { ...edit, start, end: start + edit.oldText.length }
+  }).sort((left, right) => left.start - right.start)
+
+  for (let index = 1; index < ranges.length; index += 1) {
+    if (ranges[index]!.start < ranges[index - 1]!.end) throw new Error('edit ranges must not overlap')
+  }
+
+  let output = original
+  for (const range of ranges.reverse()) {
+    output = `${output.slice(0, range.start)}${range.newText}${output.slice(range.end)}`
+  }
+  return output
+}
+
 async function executeBoundFilesystemTool(
   toolName: string,
   filesystem: string,
   params: Record<string, unknown>,
-  bindings: readonly { filesystem: string; operations: RuntimeFilesystemBindingOperations }[],
+  bindings: readonly RuntimeFilesystemBinding[],
 ): Promise<PiToolResultLike> {
   const path = boundFilesystemPath(params)
   assertNotFilesystemPathSpoof(path, bindings.map((binding) => binding.filesystem))
-  const operations = boundOperations(bindings, filesystem)
+  const binding = filesystemBinding(bindings, filesystem)
+  const operations = binding.operations
 
   if (toolName === 'read') {
     const result = await operations.read({ filesystem, path })
@@ -145,8 +171,39 @@ async function executeBoundFilesystemTool(
     const result = await operations.grep({ filesystem, path }, pattern, { limit })
     return { ...formatBoundGrep(result.matches), details: { metadata: result.metadata } }
   }
-  if (toolName === 'write' || toolName === 'edit') {
-    operations.rejectMutation(toolName, { filesystem, path })
+  if (toolName === 'write') {
+    if (binding.access !== 'readwrite' || !operations.write) operations.rejectMutation(toolName, { filesystem, path })
+    const write = operations.write
+    if (!write) throw new Error(`Tool ${toolName} does not support filesystem ${filesystem}`)
+    const content = typeof params.content === 'string' ? params.content : ''
+    const parent = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) || '/' : null
+    if (parent && operations.mkdir) await operations.mkdir({ filesystem, path: parent, recursive: true })
+    const result = await write({ filesystem, path, content })
+    return { content: [{ type: 'text', text: `Wrote ${path}` }], details: { metadata: result.metadata, mtimeMs: result.mtimeMs } }
+  }
+  if (toolName === 'edit') {
+    if (binding.access !== 'readwrite' || !operations.write) operations.rejectMutation(toolName, { filesystem, path })
+    const write = operations.write
+    if (!write) throw new Error(`Tool ${toolName} does not support filesystem ${filesystem}`)
+    const edits = Array.isArray(params.edits)
+      ? params.edits.map((edit) => {
+          if (!edit || typeof edit !== 'object') throw new Error('edit entries must be objects')
+          const record = edit as Record<string, unknown>
+          if (typeof record.oldText !== 'string' || typeof record.newText !== 'string') {
+            throw new Error('edit entries require string oldText and newText')
+          }
+          return { oldText: record.oldText, newText: record.newText }
+        })
+      : []
+    const current = await operations.read({ filesystem, path })
+    const content = applyExactEdits(current.content, edits)
+    const result = await write({
+      filesystem,
+      path,
+      content,
+      ...(current.mtimeMs !== undefined ? { expectedMtimeMs: current.mtimeMs } : {}),
+    })
+    return { content: [{ type: 'text', text: `Edited ${path}` }], details: { metadata: result.metadata, mtimeMs: result.mtimeMs } }
   }
   throw new Error(`Tool ${toolName} does not support filesystem ${filesystem}`)
 }
@@ -156,8 +213,8 @@ function withBoundFilesystemPromptGuidance(promptSnippet: string | undefined, fi
   const target = filesystemIds.length > 0 ? ` (${filesystemIds.join(', ')})` : ''
   const guidance = [
     'Named filesystem bindings: file tools default to the user workspace when filesystem is omitted.',
-    `Use the filesystem parameter explicitly for bound readonly context${target}, and start browsing at / unless told otherwise.`,
-    'Readonly filesystem bindings reject writes; do not use path prefixes like filesystem:/x to switch filesystem.',
+    `Use the filesystem parameter explicitly for named context${target}, and start browsing at / unless told otherwise.`,
+    'A binding may be readonly or readwrite; do not use path prefixes like filesystem:/x to switch filesystem.',
   ].join('\n')
   return [promptSnippet, guidance].filter(Boolean).join('\n')
 }

--- a/plugins/boring-governance/README.md
+++ b/plugins/boring-governance/README.md
@@ -30,7 +30,7 @@ const governanceCompanyAdmin = createGovernanceCompanyAdmin()
 <CoreWorkspaceAgentFront companyAdmin={governanceCompanyAdmin} />
 ```
 
-Policy source is configured with `BORING_GOVERNANCE_POLICY_PATH`. Company context source roots use `BORING_GOVERNANCE_COMPANY_CONTEXT_ROOT` or the default workspace root resolver outside sandbox mode.
+Policy source is configured with `BORING_GOVERNANCE_POLICY_PATH`. Company context source roots use `BORING_GOVERNANCE_COMPANY_CONTEXT_ROOT` or the default workspace root resolver outside sandbox mode. When an explicit, governance-owned company-context root is configured, verified tenant admins receive a tenant-wide read/write `company_context` binding; ordinary policy users receive only their regex-filtered readonly projection. Custom resolvers must opt into admin mutations with `allowAdminMutations: true` only when no other actor can mutate the root outside the governance store.
 
 ## Policy budgets
 

--- a/plugins/boring-governance/package.json
+++ b/plugins/boring-governance/package.json
@@ -56,6 +56,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
+    "proper-lockfile": "^4.1.2",
     "yaml": "^2.9.0"
   },
   "devDependencies": {
@@ -66,6 +67,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^22.0.0",
+    "@types/proper-lockfile": "^4.1.4",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",

--- a/plugins/boring-governance/src/server/__tests__/companyContextStore.test.ts
+++ b/plugins/boring-governance/src/server/__tests__/companyContextStore.test.ts
@@ -1,0 +1,139 @@
+import { lstat, mkdir, mkdtemp, readFile, symlink, utimes, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+import { CompanyContextConflictError, CompanyContextStore } from '../companyContextStore.js'
+
+async function createStore() {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'boring-company-store-'))
+  await mkdir(path.join(root, 'public'))
+  await writeFile(path.join(root, 'public', 'handbook.md'), 'v1', 'utf8')
+  return { root, store: await CompanyContextStore.open(root) }
+}
+
+async function runContendingWriter(root: string, expectedMtimeMs: number, content: string): Promise<number | null> {
+  const moduleUrl = new URL('../companyContextStore.ts', import.meta.url).href
+  const script = `
+    const { CompanyContextStore } = await import(${JSON.stringify(moduleUrl)})
+    const store = await CompanyContextStore.open(process.env.COMPANY_ROOT)
+    try {
+      await store.write('/public/handbook.md', process.env.COMPANY_CONTENT, Number(process.env.COMPANY_MTIME))
+      process.exit(0)
+    } catch (error) {
+      process.exit(error?.code === 'conflict' ? 2 : 3)
+    }
+  `
+  const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '--eval', script], {
+    env: {
+      ...process.env,
+      COMPANY_ROOT: root,
+      COMPANY_CONTENT: content,
+      COMPANY_MTIME: String(expectedMtimeMs),
+    },
+    stdio: 'ignore',
+  })
+  return await new Promise((resolve, reject) => {
+    child.once('error', reject)
+    child.once('exit', resolve)
+  })
+}
+
+describe('CompanyContextStore', () => {
+  it('atomically writes and rejects stale versions', async () => {
+    const { root, store } = await createStore()
+    const initial = await store.read('/public/handbook.md')
+    const updated = await store.write('/public/handbook.md', 'v2', initial.mtimeMs)
+    expect(updated.mtimeMs).toEqual(expect.any(Number))
+    expect(await readFile(path.join(root, 'public', 'handbook.md'), 'utf8')).toBe('v2')
+
+    await expect(store.write('/public/handbook.md', 'stale', initial.mtimeMs))
+      .rejects.toBeInstanceOf(CompanyContextConflictError)
+    expect(await readFile(path.join(root, 'public', 'handbook.md'), 'utf8')).toBe('v2')
+    expect((await lstat(path.join(root, 'public'))).isDirectory()).toBe(true)
+  })
+
+  it('recovers a lock left by a terminated process in the same runtime host', async () => {
+    const { root, store } = await createStore()
+    const lockRoot = path.join(root, '.boring-governance', 'mutation.lock')
+    await mkdir(lockRoot, { recursive: true })
+    const stale = new Date(Date.now() - 60_000)
+    await utimes(lockRoot, stale, stale)
+
+    await expect(store.write('/public/handbook.md', 'recovered')).resolves.toMatchObject({ mtimeMs: expect.any(Number) })
+    expect(await readFile(path.join(root, 'public', 'handbook.md'), 'utf8')).toBe('recovered')
+  })
+
+  it('serializes stale-lock recovery and conditional writes across processes', async () => {
+    const { root, store } = await createStore()
+    const initial = await store.read('/public/handbook.md')
+    const lockRoot = path.join(root, '.boring-governance', 'mutation.lock')
+    await mkdir(lockRoot, { recursive: true })
+    const stale = new Date(Date.now() - 60_000)
+    await utimes(lockRoot, stale, stale)
+
+    const exitCodes = await Promise.all([
+      runContendingWriter(root, initial.mtimeMs, 'child-one'),
+      runContendingWriter(root, initial.mtimeMs, 'child-two'),
+    ])
+    expect(exitCodes.sort()).toEqual([0, 2])
+    expect(['child-one', 'child-two']).toContain(await readFile(path.join(root, 'public', 'handbook.md'), 'utf8'))
+  })
+
+  it('serializes conditional writes across store instances', async () => {
+    const { root, store } = await createStore()
+    const secondStore = await CompanyContextStore.open(root)
+    const initial = await store.read('/public/handbook.md')
+    const results = await Promise.allSettled([
+      store.write('/public/handbook.md', 'first', initial.mtimeMs),
+      secondStore.write('/public/handbook.md', 'second', initial.mtimeMs),
+    ])
+    expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+    expect(results.filter((result) => result.status === 'rejected')).toHaveLength(1)
+    expect(['first', 'second']).toContain(await readFile(path.join(root, 'public', 'handbook.md'), 'utf8'))
+  })
+
+  it('treats a missing expected file as a conflict', async () => {
+    const { store } = await createStore()
+    await expect(store.write('/public/missing.md', 'new', 123))
+      .rejects.toMatchObject({
+        code: 'conflict',
+        details: { currentMtimeMs: undefined, expectedMtimeMs: 123 },
+      })
+  })
+
+  it('supports contained create, move, mkdir, and delete operations', async () => {
+    const { root, store } = await createStore()
+    await store.mkdir('/managed/nested', true)
+    await store.write('/managed/nested/note.md', 'note')
+    await store.move('/managed/nested/note.md', '/managed/note.md')
+    expect((await store.read('/managed/note.md')).content).toBe('note')
+    await store.delete('/managed/note.md')
+    await expect(store.read('/managed/note.md')).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await readFile(path.join(root, 'public', 'handbook.md'), 'utf8')).toBe('v1')
+  })
+
+  it('rejects a symlinked internal state directory', async () => {
+    const { root, store } = await createStore()
+    const outside = await mkdtemp(path.join(os.tmpdir(), 'boring-company-state-outside-'))
+    await symlink(outside, path.join(root, '.boring-governance'))
+    await expect(store.write('/public/handbook.md', 'bad')).rejects.toMatchObject({ code: 'EPERM' })
+    expect(await readFile(path.join(root, 'public', 'handbook.md'), 'utf8')).toBe('v1')
+    await expect(readFile(path.join(outside, 'mutation.lock', 'owner'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('rejects traversal and symlink ancestors without mutating outside the root', async () => {
+    const { root, store } = await createStore()
+    const outside = await mkdtemp(path.join(os.tmpdir(), 'boring-company-outside-'))
+    await symlink(outside, path.join(root, 'linked'))
+    await symlink(path.join(outside, 'outside.md'), path.join(root, 'public', 'leaf-link.md'))
+
+    await expect(store.write('../outside.md', 'bad')).rejects.toMatchObject({ code: 'EPERM' })
+    await expect(store.write('/team/.boring-governance/note.md', 'bad')).rejects.toMatchObject({ code: 'EPERM' })
+    await expect(store.write('/linked/outside.md', 'bad')).rejects.toMatchObject({ code: 'EPERM' })
+    await expect(store.write('/public/leaf-link.md', 'bad')).rejects.toMatchObject({ code: 'EPERM' })
+    await expect(store.delete('/public/leaf-link.md')).rejects.toMatchObject({ code: 'EPERM' })
+    await expect(store.move('/public/leaf-link.md', '/public/moved.md')).rejects.toMatchObject({ code: 'EPERM' })
+    await expect(readFile(path.join(outside, 'outside.md'), 'utf8')).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})

--- a/plugins/boring-governance/src/server/__tests__/filesystemBindings.test.ts
+++ b/plugins/boring-governance/src/server/__tests__/filesystemBindings.test.ts
@@ -32,6 +32,11 @@ function serviceWithPolicy(allow: string[] = ['^/public/.*']) {
       },
       users: [
         {
+          email: 'admin@example.com',
+          role: 'admin',
+          companyContext: { allow: [] },
+        },
+        {
           email: 'allowed@example.com',
           role: 'user',
           companyContext: { allow },
@@ -100,6 +105,47 @@ describe('createGovernanceFilesystemBindings', () => {
       } as any,
     })
     expect(unverified).toEqual([])
+  })
+
+  it('gives verified admins a mutable tenant-wide company_context binding', async () => {
+    const companyRoot = await seedCompanyRoot()
+    const getBindings = createGovernanceFilesystemBindings(serviceWithPolicy(), {
+      resolveCompanyContextRoot: () => companyRoot,
+      allowAdminMutations: true,
+      projectionRootParent: await mkdtemp(path.join(os.tmpdir(), 'boring-company-projections-')),
+    })
+
+    const bindings = await getBindings({
+      workspaceId: 'personal-ws',
+      workspaceRoot: path.join(path.dirname(companyRoot), 'personal-ws'),
+      requestId: 'req-admin',
+      userId: 'user-admin',
+      userEmail: 'admin@example.com',
+      userEmailVerified: true,
+    })
+
+    expect(bindings).toHaveLength(1)
+    expect(bindings?.[0]).toMatchObject({ filesystem: 'company_context', access: 'readwrite' })
+    const binding = bindings![0]!
+    const original = await binding.operations.read({ filesystem: 'company_context', path: '/finance/secret.md' })
+    expect(original).toMatchObject({ content: expect.stringContaining('FORBIDDEN_FINANCE_SECRET_123'), mtimeMs: expect.any(Number) })
+
+    const written = await binding.operations.write!({ filesystem: 'company_context', path: '/public/admin-note.md', content: 'admin note' })
+    expect(written.mtimeMs).toEqual(expect.any(Number))
+    await expect(binding.operations.find({ filesystem: 'company_context', path: '/' }, '*.md'))
+      .resolves.toMatchObject({ paths: expect.arrayContaining(['/finance/secret.md', '/public/admin-note.md']) })
+    await expect(binding.operations.grep({ filesystem: 'company_context', path: '/' }, 'admin note'))
+      .resolves.toMatchObject({ matches: [expect.objectContaining({ path: '/public/admin-note.md' })] })
+    await expect(binding.operations.read({ filesystem: 'company_context', path: '/public/admin-note.md' }))
+      .resolves.toMatchObject({ content: 'admin note', mtimeMs: written.mtimeMs })
+
+    await binding.operations.mkdir!({ filesystem: 'company_context', path: '/managed', recursive: false })
+    await binding.operations.move!({ filesystem: 'company_context', from: '/public/admin-note.md', to: '/managed/admin-note.md' })
+    await expect(binding.operations.read({ filesystem: 'company_context', path: '/managed/admin-note.md' }))
+      .resolves.toMatchObject({ content: 'admin note' })
+    await binding.operations.delete!({ filesystem: 'company_context', path: '/managed/admin-note.md' })
+    await expect(binding.operations.read({ filesystem: 'company_context', path: '/managed/admin-note.md' }))
+      .rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('omits company_context when no explicit source root resolver is configured', async () => {

--- a/plugins/boring-governance/src/server/companyContextStore.ts
+++ b/plugins/boring-governance/src/server/companyContextStore.ts
@@ -1,0 +1,273 @@
+import { constants } from 'node:fs'
+import { lstat, mkdir, open, readdir, readFile, realpath, rename, rm, stat } from 'node:fs/promises'
+import path from 'node:path'
+import { randomUUID } from 'node:crypto'
+import lockfile from 'proper-lockfile'
+
+export const COMPANY_CONTEXT_CONFLICT_CODE = 'conflict'
+
+export class CompanyContextConflictError extends Error {
+  readonly statusCode = 409
+  readonly code = COMPANY_CONTEXT_CONFLICT_CODE
+
+  constructor(readonly details: { currentMtimeMs?: number; expectedMtimeMs: number }) {
+    super(details.currentMtimeMs === undefined ? 'file no longer exists' : 'file has been modified since last read')
+    this.name = 'CompanyContextConflictError'
+  }
+}
+
+interface ResolvedTarget {
+  root: string
+  target: string
+}
+
+export const COMPANY_CONTEXT_STATE_DIR = '.boring-governance'
+
+const mutationQueues = new Map<string, Promise<void>>()
+
+function normalizeCompanyPath(value: string): string {
+  const normalized = value.replace(/\\/g, '/')
+  if (normalized.includes('\0')) throw Object.assign(new Error('invalid company path'), { code: 'EPERM' })
+  const withRoot = normalized.startsWith('/') ? normalized : `/${normalized}`
+  const parts = withRoot.split('/').filter(Boolean)
+  if (parts.some((part) => part === '.' || part === '..' || part === COMPANY_CONTEXT_STATE_DIR)) {
+    throw Object.assign(new Error('company path traversal is not allowed'), { code: 'EPERM' })
+  }
+  return `/${parts.join('/')}`
+}
+
+function assertContained(root: string, candidate: string): void {
+  const relative = path.relative(root, candidate)
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw Object.assign(new Error('path escapes company context root'), { code: 'EPERM' })
+  }
+}
+
+async function inspectExistingPath(root: string, target: string, allowMissingLeaf: boolean): Promise<void> {
+  assertContained(root, target)
+  const relative = path.relative(root, target)
+  let current = root
+  const parts = relative.split(path.sep).filter(Boolean)
+  for (let index = 0; index < parts.length; index += 1) {
+    current = path.join(current, parts[index]!)
+    try {
+      const entry = await lstat(current)
+      if (entry.isSymbolicLink()) throw Object.assign(new Error('company context symlinks are not allowed'), { code: 'EPERM' })
+      if (index < parts.length - 1 && !entry.isDirectory()) {
+        throw Object.assign(new Error('company context parent is not a directory'), { code: 'ENOTDIR' })
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT' && allowMissingLeaf && index === parts.length - 1) return
+      throw error
+    }
+  }
+}
+
+async function acquireFilesystemLock(root: string): Promise<() => Promise<void>> {
+  const stateRoot = path.join(root, COMPANY_CONTEXT_STATE_DIR)
+  const lockPath = path.join(stateRoot, 'mutation.lock')
+  await mkdir(stateRoot, { recursive: true, mode: 0o700 })
+  const stateStat = await lstat(stateRoot)
+  if (stateStat.isSymbolicLink() || !stateStat.isDirectory()) {
+    throw Object.assign(new Error('unsafe company context state directory'), { code: 'EPERM' })
+  }
+
+  return await lockfile.lock(root, {
+    lockfilePath: lockPath,
+    realpath: false,
+    stale: 30_000,
+    update: 5_000,
+    retries: { retries: 100, minTimeout: 25, maxTimeout: 100 },
+  })
+}
+
+async function withMutationLock<T>(key: string, operation: () => Promise<T>): Promise<T> {
+  const previous = mutationQueues.get(key) ?? Promise.resolve()
+  let releaseProcessLock!: () => void
+  const current = new Promise<void>((resolve) => { releaseProcessLock = resolve })
+  const queued = previous.then(() => current)
+  mutationQueues.set(key, queued)
+  await previous
+  let releaseFilesystemLock: (() => Promise<void>) | null = null
+  try {
+    releaseFilesystemLock = await acquireFilesystemLock(key)
+    return await operation()
+  } finally {
+    await releaseFilesystemLock?.().catch(() => {})
+    releaseProcessLock()
+    if (mutationQueues.get(key) === queued) mutationQueues.delete(key)
+  }
+}
+
+export class CompanyContextStore {
+  private constructor(private readonly root: string) {}
+
+  static async open(root: string): Promise<CompanyContextStore> {
+    const canonicalRoot = await realpath(path.resolve(root))
+    const rootStat = await stat(canonicalRoot)
+    if (!rootStat.isDirectory()) throw new Error('company context root is not a directory')
+    return new CompanyContextStore(canonicalRoot)
+  }
+
+  private resolve(companyPath: string): ResolvedTarget {
+    const normalized = normalizeCompanyPath(companyPath)
+    const target = path.resolve(this.root, `.${normalized}`)
+    assertContained(this.root, target)
+    return { root: this.root, target }
+  }
+
+  async read(companyPath: string): Promise<{ content: string; mtimeMs: number }> {
+    const { target } = this.resolve(companyPath)
+    await inspectExistingPath(this.root, target, false)
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const before = await stat(target)
+      if (!before.isFile()) throw Object.assign(new Error('company context path is not a file'), { code: 'EISDIR' })
+      const content = await readFile(target, 'utf8')
+      const after = await stat(target)
+      if (before.mtimeMs === after.mtimeMs && before.size === after.size) return { content, mtimeMs: after.mtimeMs }
+    }
+    throw Object.assign(new Error('company context changed while reading'), { statusCode: 409, code: COMPANY_CONTEXT_CONFLICT_CODE })
+  }
+
+  async list(companyPath: string): Promise<{ entries: string[] }> {
+    const { target } = this.resolve(companyPath)
+    await inspectExistingPath(this.root, target, false)
+    const entries = await readdir(target, { withFileTypes: true })
+    return {
+      entries: entries
+        .filter((entry) => !entry.isSymbolicLink() && entry.name !== COMPANY_CONTEXT_STATE_DIR)
+        .map((entry) => entry.name),
+    }
+  }
+
+  private async walk(companyPath: string): Promise<string[]> {
+    const normalized = normalizeCompanyPath(companyPath)
+    const pending = [normalized]
+    const files: string[] = []
+    while (pending.length > 0) {
+      const current = pending.shift()!
+      const listed = await this.list(current)
+      for (const name of listed.entries) {
+        const child = current === '/' ? `/${name}` : `${current}/${name}`
+        const childStat = await this.stat(child)
+        if (childStat.isDirectory) pending.push(child)
+        else files.push(child)
+      }
+    }
+    return files
+  }
+
+  async find(companyPath: string, pattern: string, options: { limit?: number; offset?: number } = {}): Promise<{ paths: string[] }> {
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*\*/g, '\u0000').replace(/\*/g, '[^/]*').replace(/\?/g, '[^/]').replace(/\u0000/g, '.*')
+    const matcher = new RegExp(`^${escaped}$`)
+    const paths = (await this.walk(companyPath)).filter((entry) => matcher.test(path.posix.basename(entry)) || matcher.test(entry))
+    const offset = Math.max(0, options.offset ?? 0)
+    return { paths: paths.slice(offset, options.limit === undefined ? undefined : offset + Math.max(0, options.limit)) }
+  }
+
+  async grep(companyPath: string, pattern: string, options: { limit?: number; offset?: number } = {}): Promise<{ matches: Array<{ path: string; line: number; text: string }> }> {
+    const matcher = new RegExp(pattern)
+    const matches: Array<{ path: string; line: number; text: string }> = []
+    for (const file of await this.walk(companyPath)) {
+      const { content } = await this.read(file)
+      for (const [index, line] of content.split(/\r?\n/).entries()) {
+        matcher.lastIndex = 0
+        if (matcher.test(line)) matches.push({ path: file, line: index + 1, text: line })
+      }
+    }
+    const offset = Math.max(0, options.offset ?? 0)
+    return { matches: matches.slice(offset, options.limit === undefined ? undefined : offset + Math.max(0, options.limit)) }
+  }
+
+  async stat(companyPath: string): Promise<{ isDirectory: boolean; mtimeMs: number }> {
+    const { target } = this.resolve(companyPath)
+    await inspectExistingPath(this.root, target, false)
+    const entry = await stat(target)
+    return { isDirectory: entry.isDirectory(), mtimeMs: entry.mtimeMs }
+  }
+
+  async write(companyPath: string, content: string, expectedMtimeMs?: number): Promise<{ mtimeMs: number }> {
+    const { target } = this.resolve(companyPath)
+    return withMutationLock(this.root, async () => {
+      await inspectExistingPath(this.root, path.dirname(target), false)
+      let currentMtimeMs: number | undefined
+      try {
+        await inspectExistingPath(this.root, target, false)
+        currentMtimeMs = (await stat(target)).mtimeMs
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      }
+      if (expectedMtimeMs !== undefined && currentMtimeMs !== expectedMtimeMs) {
+        throw new CompanyContextConflictError({ currentMtimeMs, expectedMtimeMs })
+      }
+
+      const temporary = path.join(path.dirname(target), `.${path.basename(target)}.${randomUUID()}.tmp`)
+      let promoted = false
+      try {
+        const handle = await open(temporary, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600)
+        try {
+          await handle.writeFile(content, 'utf8')
+          await handle.sync()
+        } finally {
+          await handle.close()
+        }
+        await rename(temporary, target)
+        promoted = true
+        return { mtimeMs: (await stat(target)).mtimeMs }
+      } finally {
+        if (!promoted) await rm(temporary, { force: true }).catch(() => {})
+      }
+    })
+  }
+
+  async delete(companyPath: string): Promise<void> {
+    const { target } = this.resolve(companyPath)
+    await withMutationLock(this.root, async () => {
+      await inspectExistingPath(this.root, target, false)
+      const entry = await lstat(target)
+      if (!entry.isFile()) throw Object.assign(new Error('company context path is not a file'), { code: 'EPERM' })
+      await rm(target)
+    })
+  }
+
+  async mkdir(companyPath: string, recursive = false): Promise<void> {
+    const { target } = this.resolve(companyPath)
+    await withMutationLock(this.root, async () => {
+      if (!recursive) {
+        await inspectExistingPath(this.root, path.dirname(target), false)
+        await mkdir(target)
+        return
+      }
+      const relative = path.relative(this.root, target)
+      let current = this.root
+      for (const segment of relative.split(path.sep).filter(Boolean)) {
+        current = path.join(current, segment)
+        try {
+          const entry = await lstat(current)
+          if (entry.isSymbolicLink() || !entry.isDirectory()) {
+            throw Object.assign(new Error('unsafe company context directory'), { code: 'EPERM' })
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+          await mkdir(current)
+        }
+      }
+    })
+  }
+
+  async move(fromPath: string, toPath: string): Promise<void> {
+    const from = this.resolve(fromPath).target
+    const to = this.resolve(toPath).target
+    await withMutationLock(this.root, async () => {
+      await inspectExistingPath(this.root, from, false)
+      await inspectExistingPath(this.root, path.dirname(to), false)
+      try {
+        await inspectExistingPath(this.root, to, false)
+        throw Object.assign(new Error('destination already exists'), { code: 'EEXIST' })
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+      }
+      await rename(from, to)
+    })
+  }
+}

--- a/plugins/boring-governance/src/server/filesystemBindings.ts
+++ b/plugins/boring-governance/src/server/filesystemBindings.ts
@@ -15,6 +15,7 @@ import {
   type PreparedFilesystemBinding,
   type ReadonlyProjectionOperations,
 } from '@hachej/boring-bash/server'
+import { COMPANY_CONTEXT_STATE_DIR, CompanyContextStore } from './companyContextStore.js'
 import type { GovernanceService } from './governanceService.js'
 import type { GovernanceUserLike } from './policyTypes.js'
 import { normalizePolicyEmail } from './validatePolicy.js'
@@ -49,6 +50,8 @@ export type CompanyContextRootResolver = (
 export interface CreateGovernanceFilesystemBindingsOptions {
   /** Explicit source root resolver for the tenant company-context workspace. */
   resolveCompanyContextRoot?: CompanyContextRootResolver
+  /** Enable admin mutations only when the resolved root is exclusively managed by the governance service. */
+  allowAdminMutations?: boolean
   projectionRootParent?: string
 }
 
@@ -78,6 +81,7 @@ async function walkFiles(root: string, current = root): Promise<string[]> {
   const entries = await readdir(current, { withFileTypes: true })
   const out: string[] = []
   for (const entry of entries) {
+    if (current === root && entry.name === COMPANY_CONTEXT_STATE_DIR) continue
     const absolutePath = path.join(current, entry.name)
     const entryStat = await lstat(absolutePath)
     if (entryStat.isSymbolicLink()) continue
@@ -270,13 +274,38 @@ export function createGovernanceFilesystemBindings(
     if (!service.isEnabled()) return undefined
     const user = userFromContext(ctx)
     if (!user?.id) return []
-    const rules = service.companyContextRules(user)
+    const policyAccess = service.companyContextAccessForUser(user)
+    const accessMode = policyAccess === 'readwrite' && options.allowAdminMutations !== true ? 'readonly' : policyAccess
     const companyContextWorkspaceId = service.companyContextWorkspaceId()
-    if (!companyContextWorkspaceId || rules.length === 0) return []
+    if (!companyContextWorkspaceId || accessMode === 'none') return []
     if (ctx.workspaceId === companyContextWorkspaceId) return []
 
     const sourceRoot = await resolveCompanyContextSourceRoot(ctx, companyContextWorkspaceId, options.resolveCompanyContextRoot)
     if (!sourceRoot) return []
+
+    if (accessMode === 'readwrite') {
+      const store = await CompanyContextStore.open(sourceRoot)
+      const operations: RuntimeFilesystemBindingOperations = {
+        read: (descriptor) => store.read(descriptor.path),
+        list: (descriptor) => store.list(descriptor.path),
+        find: (descriptor, pattern, opOptions) => store.find(descriptor.path, pattern, opOptions),
+        grep: (descriptor, pattern, opOptions) => store.grep(descriptor.path, pattern, opOptions),
+        stat: async (descriptor) => {
+          const result = await store.stat(descriptor.path)
+          return { isDirectory: result.isDirectory, metadata: { mtimeMs: result.mtimeMs } }
+        },
+        write: (descriptor) => store.write(descriptor.path, descriptor.content, descriptor.expectedMtimeMs),
+        delete: async (descriptor) => { await store.delete(descriptor.path); return {} },
+        move: async (descriptor) => { await store.move(descriptor.from, descriptor.to); return {} },
+        mkdir: async (descriptor) => { await store.mkdir(descriptor.path, descriptor.recursive); return {} },
+        rejectMutation(operation): never {
+          throw new Error(`company_context ${operation} operation is unavailable`)
+        },
+      }
+      return [{ filesystem: COMPANY_CONTEXT_FILESYSTEM_ID, access: 'readwrite', operations } satisfies RuntimeFilesystemBinding]
+    }
+
+    const rules = service.companyContextRules(user)
     const projectionRootParent = options.projectionRootParent ?? os.tmpdir()
     const binding: FilesystemBinding = {
       filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,

--- a/plugins/boring-governance/src/server/governanceService.ts
+++ b/plugins/boring-governance/src/server/governanceService.ts
@@ -11,6 +11,7 @@ import type {
 import { normalizePolicyEmail } from './validatePolicy.js'
 
 export type GovernancePolicyErrorCode = 'disabled' | 'invalid' | 'denied' | 'not_allowed'
+export type CompanyContextAccess = 'none' | 'readonly' | 'readwrite'
 
 export class GovernancePolicyError extends Error {
   constructor(message: string, readonly code: GovernancePolicyErrorCode) {
@@ -105,6 +106,14 @@ export class GovernanceService {
   companyContextRules(user: GovernanceUserLike): string[] {
     if (!this.loaded.enabled) return []
     return this.userPolicy(user)?.companyContext.allow ?? []
+  }
+
+  companyContextAccessForUser(user: GovernanceUserLike | null | undefined): CompanyContextAccess {
+    if (!this.loaded.enabled) return 'none'
+    const policy = this.userPolicy(user)
+    if (!policy) return 'none'
+    if (policy.role === 'admin') return 'readwrite'
+    return policy.companyContext.allow.length > 0 ? 'readonly' : 'none'
   }
 
   companyContextWorkspaceId(): string | null {

--- a/plugins/boring-governance/src/server/index.ts
+++ b/plugins/boring-governance/src/server/index.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import type { FastifyRequest } from 'fastify'
 import type { AgentMeteringSink, RegisterAgentRoutesOptions } from '@hachej/boring-agent/server'
 import type { CoreConfig } from '@hachej/boring-core/shared'
@@ -60,6 +61,16 @@ export interface CreateGovernanceResult {
   pi: { strictModelResolution: boolean }
 }
 
+function defaultAdminMutationsAllowed(options: CreateGovernanceFilesystemBindingsOptions): boolean {
+  if (options.resolveCompanyContextRoot) return false
+  const companyRoot = process.env.BORING_GOVERNANCE_COMPANY_CONTEXT_ROOT?.trim()
+  if (!companyRoot) return false
+  const workspaceRoot = path.resolve(process.env.BORING_AGENT_WORKSPACE_ROOT?.trim() || process.cwd())
+  const resolvedCompanyRoot = path.resolve(companyRoot)
+  const relative = path.relative(workspaceRoot, resolvedCompanyRoot)
+  return relative.startsWith('..') || path.isAbsolute(relative)
+}
+
 export async function createGovernance(config: CoreConfig): Promise<CreateGovernanceResult> {
   const service = await buildGovernanceService({ config })
   return {
@@ -69,8 +80,9 @@ export async function createGovernance(config: CoreConfig): Promise<CreateGovern
     filterModels: createGovernanceModelFilter(service),
     createMeteringSink: (delegate, getDb) => createGovernanceMeteringSink({ service, delegate, getDb }),
     getFilesystemBindings: (options = {}) => createGovernanceFilesystemBindings(service, {
-      resolveCompanyContextRoot: createDefaultCompanyContextRootResolver(),
       ...options,
+      resolveCompanyContextRoot: options.resolveCompanyContextRoot ?? createDefaultCompanyContextRootResolver(),
+      allowAdminMutations: options.allowAdminMutations ?? defaultAdminMutationsAllowed(options),
     }),
     pi: { strictModelResolution: service.isEnabled() },
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,7 +361,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
@@ -385,10 +385,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.2
-        version: 8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+        version: 8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/agent/examples/with-custom-tool:
     devDependencies:
@@ -1119,6 +1119,9 @@ importers:
 
   plugins/boring-governance:
     dependencies:
+      proper-lockfile:
+        specifier: ^4.1.2
+        version: 4.1.2
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -1144,6 +1147,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.20.1
+      '@types/proper-lockfile':
+        specifier: ^4.1.4
+        version: 4.1.4
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.17
@@ -1152,7 +1158,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
-        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       fastify:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1176,7 +1182,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   plugins/boring-mcp:
     dependencies:
@@ -5426,6 +5432,9 @@ packages:
 
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
+
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -13378,6 +13387,10 @@ snapshots:
       '@types/node': 22.20.1
 
   '@types/prismjs@1.26.6': {}
+
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:


### PR DESCRIPTION
## Summary
- make governance the canonical owner of mutable company-context storage
- return readwrite bindings for verified admins on an explicit governance-owned root
- keep generic agent HTTP/tool routing as the sole filesystem surface
- add atomic writes, conflict versions, locking, containment checks, and mutation/search operations
- add architecture cleanup plan for removing the Constellation route fork after package publication

## Validation
- governance: 44 tests passed
- agent focused: 52 tests passed
- agent + governance typecheck passed
- repository invariants passed
- thermo-nuclear review: green