### PR TITLE
Fix governance metering database type

### DIFF
--- a/packages/core/src/server/db/stores/BudgetSpendAttribution.ts
+++ b/packages/core/src/server/db/stores/BudgetSpendAttribution.ts
@@ -3,6 +3,8 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
 import { budgetReservations, usageLedger } from '../schema.js'
 import type { ReserveBudgetInput } from './PostgresBudgetReservationStore.js'
 
+type BudgetDatabase = PostgresJsDatabase<Record<string, unknown>>
+
 export interface BudgetSpendTotals {
   usedMicros: number
   heldMicros: number
@@ -11,7 +13,7 @@ export interface BudgetSpendTotals {
 type SpendTotals = (input: ReserveBudgetInput, usageMicros: number) => Promise<BudgetSpendTotals>
 
 interface BudgetSpendAttributionStrategy<S extends ReserveBudgetInput['scope']> {
-  usageMicros(tx: PostgresJsDatabase, input: Extract<ReserveBudgetInput, { scope: S }>, period: string, start: Date, end: Date, eligibleLegacySources: readonly string[]): Promise<number>
+  usageMicros(tx: BudgetDatabase, input: Extract<ReserveBudgetInput, { scope: S }>, period: string, start: Date, end: Date, eligibleLegacySources: readonly string[]): Promise<number>
 }
 
 const budgetSpendAttributionStrategies: { [S in ReserveBudgetInput['scope']]: BudgetSpendAttributionStrategy<S> } = {
@@ -20,7 +22,7 @@ const budgetSpendAttributionStrategies: { [S in ReserveBudgetInput['scope']]: Bu
 }
 
 export async function computeBudgetSpend<S extends ReserveBudgetInput['scope']>(
-  tx: PostgresJsDatabase,
+  tx: BudgetDatabase,
   input: Extract<ReserveBudgetInput, { scope: S }>,
   period: string,
   start: Date,
@@ -32,7 +34,7 @@ export async function computeBudgetSpend<S extends ReserveBudgetInput['scope']>(
   return totals(input, await strategy.usageMicros(tx, input, period, start, end, eligibleLegacySources))
 }
 
-async function modelUsageMicros(tx: PostgresJsDatabase, input: Extract<ReserveBudgetInput, { scope: 'model' }>, period: string, start: Date, end: Date): Promise<number> {
+async function modelUsageMicros(tx: BudgetDatabase, input: Extract<ReserveBudgetInput, { scope: 'model' }>, period: string, start: Date, end: Date): Promise<number> {
   const periodStartIso = start.toISOString()
   const periodEndIso = end.toISOString()
   const metadataExpr = sql`${usageLedger.metadata}->>'modelBudgetReservationId'`
@@ -89,7 +91,7 @@ async function modelUsageMicros(tx: PostgresJsDatabase, input: Extract<ReserveBu
   return Number(usageRows[0]?.total ?? 0)
 }
 
-async function userUsageMicros(tx: PostgresJsDatabase, input: Extract<ReserveBudgetInput, { scope: 'user' }>, period: string, start: Date, end: Date, eligibleLegacySources: readonly string[]): Promise<number> {
+async function userUsageMicros(tx: BudgetDatabase, input: Extract<ReserveBudgetInput, { scope: 'user' }>, period: string, start: Date, end: Date, eligibleLegacySources: readonly string[]): Promise<number> {
   const periodStartIso = start.toISOString()
   const periodEndIso = end.toISOString()
   const metadataExpr = sql`${usageLedger.metadata}->>'userBudgetReservationId'`

--- a/packages/core/src/server/db/stores/PostgresBudgetReservationStore.ts
+++ b/packages/core/src/server/db/stores/PostgresBudgetReservationStore.ts
@@ -1,5 +1,7 @@
 import { and, eq, inArray, lt, or, sql } from 'drizzle-orm'
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+
+type BudgetDatabase = PostgresJsDatabase<Record<string, unknown>>
 import { budgetReservations, usageLedger } from '../schema.js'
 import { assertPositiveSafeInteger, chunkIds, lockBudgetTargets, monthPeriodUtc } from './BudgetReservationSupport.js'
 import { computeBudgetSpend } from './BudgetSpendAttribution.js'
@@ -185,7 +187,10 @@ function assertReserveInput(input: ReserveBudgetInput): void {
 }
 
 export class PostgresBudgetReservationStore {
-  constructor(private db: PostgresJsDatabase, private readonly options: { eligibleLegacySources?: readonly string[] } = {}) {}
+  constructor(
+    private db: BudgetDatabase,
+    private readonly options: { eligibleLegacySources?: readonly string[] } = {},
+  ) {}
 
   static monthPeriodUtc(now = new Date()): string {
     return monthPeriodUtc(now).period
@@ -244,7 +249,7 @@ export class PostgresBudgetReservationStore {
     })
   }
 
-  private async reserveInTransaction(tx: PostgresJsDatabase, input: ReserveBudgetInput, now: Date): Promise<ReserveBudgetResult> {
+  private async reserveInTransaction(tx: BudgetDatabase, input: ReserveBudgetInput, now: Date): Promise<ReserveBudgetResult> {
     const period = monthPeriodUtc(now)
     const expiresAt = new Date(now.getTime() + input.ttlSeconds * 1000)
     const expired = await tx
@@ -382,7 +387,7 @@ export class PostgresBudgetReservationStore {
   }
 
   private async reservationTotal(
-    tx: PostgresJsDatabase,
+    tx: BudgetDatabase,
     input: ReserveBudgetInput,
     period: string,
     status: 'active' | 'settled',
@@ -396,7 +401,7 @@ export class PostgresBudgetReservationStore {
     return Number(rows[0]?.total ?? 0)
   }
 
-  private async spend(tx: PostgresJsDatabase, input: ReserveBudgetInput, period: string, start: Date, end: Date) {
+  private async spend(tx: BudgetDatabase, input: ReserveBudgetInput, period: string, start: Date, end: Date) {
     return computeBudgetSpend(
       tx,
       input,
@@ -408,7 +413,7 @@ export class PostgresBudgetReservationStore {
     )
   }
 
-  private async spendTotals(tx: PostgresJsDatabase, input: ReserveBudgetInput, period: string, usageMicros: number) {
+  private async spendTotals(tx: BudgetDatabase, input: ReserveBudgetInput, period: string, usageMicros: number) {
     const heldMicros = await this.reservationTotal(tx, input, period, 'active')
     const settledFallbackMicros = await this.reservationTotal(tx, input, period, 'settled')
     return { usedMicros: usageMicros + settledFallbackMicros, heldMicros }
@@ -418,7 +423,7 @@ export class PostgresBudgetReservationStore {
     await this.db.transaction((tx) => this.finishInTransaction(tx, input, status))
   }
 
-  private async finishInTransaction(tx: PostgresJsDatabase, input: FinishReservationInput, status: Exclude<BudgetReservationStatus, 'active' | 'expired'>): Promise<void> {
+  private async finishInTransaction(tx: BudgetDatabase, input: FinishReservationInput, status: Exclude<BudgetReservationStatus, 'active' | 'expired'>): Promise<void> {
     const scope = input.scope
     const active = await tx.select({
       id: budgetReservations.id,


### PR DESCRIPTION
Widen the budget database schema generic so the published governance metering callback accepts the core server database type.\n\nValidated core and governance typechecks.