### PR TITLE
chore: drop Python 3.10 support and require lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,7 +401,6 @@ jobs:
 
   invariants:
     name: Invariants
-    if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'ci:full') || contains(github.event.pull_request.labels.*.name, 'release-candidate') || startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -539,7 +538,7 @@ jobs:
     name: PR Fast Summary
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    needs: [action-pins, lint, typecheck, unit-summary, bundle-budget, core-bundle-budget, e2e, remote-worker-smoke]
+    needs: [action-pins, lint, typecheck, unit-summary, invariants, bundle-budget, core-bundle-budget, e2e, remote-worker-smoke]
     steps:
       - name: Verify PR checks
         run: |
@@ -548,6 +547,7 @@ jobs:
             "lint=${{ needs.lint.result }}" \
             "typecheck=${{ needs.typecheck.result }}" \
             "unit=${{ needs.unit-summary.result }}" \
+            "invariants=${{ needs.invariants.result }}" \
             "bundle=${{ needs.bundle-budget.result }}" \
             "core-bundle=${{ needs.core-bundle-budget.result }}" \
             "e2e=${{ needs.e2e.result }}" \

--- a/apps/full-app/src/plugins/demo/sdk/pyproject.toml
+++ b/apps/full-app/src/plugins/demo/sdk/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "boring-demo-sdk"
 version = "0.1.0"
 description = "Dummy demo CLI for boring-ui full-app provisioning demo/testing"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = []
 
 [project.scripts]

--- a/packages/agent/fixtures/provisioning/test-sdk/pyproject.toml
+++ b/packages/agent/fixtures/provisioning/test-sdk/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "boring-agent-provisioning-test-sdk"
 version = "0.1.0"
 description = "Fixture SDK used by @boring/agent provisioning evals"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = []
 
 [project.scripts]

--- a/packages/agent/scripts/smoke-capability-readiness-vercel.mts
+++ b/packages/agent/scripts/smoke-capability-readiness-vercel.mts
@@ -40,7 +40,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "boring-agent-readiness-smoke"
 version = "0.0.0"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = ["pandas"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- raise local Python SDK/package metadata to require Python >=3.11
- run invariants on every CI event instead of only full/release/main paths
- include invariants in the PR fast summary gate so lint/invariant failures block PRs

## Proof
- `pnpm check:generated-artifacts`
- `pnpm audit:imports`
- `pnpm lint:invariants`
- `git diff --check`

Note: direct `pnpm lint` in this harness exited with `[warn] Linter process terminated abnormally (possibly out of memory)`, so I ran its two component commands above successfully.