### PR TITLE
Add generic data query batching

### DIFF
--- a/plugins/bi-dashboard/src/front/dashboardData.ts
+++ b/plugins/bi-dashboard/src/front/dashboardData.ts
@@ -1,5 +1,10 @@
 import { useEffect, useMemo, useState } from "react"
-import { DATA_BRIDGE_QUERY_RUN_OP, type DataBridgeArrowResult } from "@hachej/boring-data-bridge/shared"
+import {
+  DATA_BRIDGE_QUERY_BATCH_OP,
+  DATA_BRIDGE_QUERY_RUN_OP,
+  type DataBridgeArrowResult,
+  type DataBridgeQueryBatchOutput,
+} from "@hachej/boring-data-bridge/shared"
 import type { BslDashboardQuerySpec, BslDashboardSpec } from "../shared"
 
 export interface DashboardQueryResult {
@@ -38,6 +43,7 @@ function queryPayload(query: BslDashboardQuerySpec) {
 async function callDataBridge<T>(options: {
   apiBaseUrl: string
   workspaceId: string | undefined
+  op?: string
   input: Record<string, unknown>
 }): Promise<T> {
   const response = await fetch(`${options.apiBaseUrl}/api/v1/workspace-bridge/call`, {
@@ -47,7 +53,7 @@ async function callDataBridge<T>(options: {
       "content-type": "application/json",
       ...(options.workspaceId ? { "x-boring-workspace-id": options.workspaceId } : {}),
     },
-    body: JSON.stringify({ op: DATA_BRIDGE_QUERY_RUN_OP, input: options.input }),
+    body: JSON.stringify({ op: options.op ?? DATA_BRIDGE_QUERY_RUN_OP, input: options.input }),
   })
   const body = await response.json() as { ok?: boolean; output?: T; error?: { message?: string } }
   if (!response.ok || !body.ok || !body.output) {
@@ -76,6 +82,44 @@ export async function fetchDataBridgeQuery(options: {
     source: output.source,
     loading: false,
   }
+}
+
+export async function fetchDataBridgeQueries(options: {
+  apiBaseUrl: string
+  workspaceId: string | undefined
+  queries: Array<readonly [string, BslDashboardQuerySpec]>
+}): Promise<Record<string, DashboardQueryResult>> {
+  const output = await callDataBridge<DataBridgeQueryBatchOutput>({
+    apiBaseUrl: options.apiBaseUrl,
+    workspaceId: options.workspaceId,
+    op: DATA_BRIDGE_QUERY_BATCH_OP,
+    input: {
+      queries: options.queries.map(([queryId, query]) => ({
+        id: queryId,
+        input: { query: queryPayload(query) },
+      })),
+    },
+  })
+
+  return Object.fromEntries(output.results.map((result) => {
+    if (!result.ok) {
+      return [result.id, {
+        queryId: result.id,
+        columns: [],
+        rows: [],
+        loading: false,
+        error: result.error.message,
+      } satisfies DashboardQueryResult]
+    }
+    const rows = "rows" in result.output ? result.output.rows ?? [] : []
+    return [result.id, {
+      queryId: result.id,
+      columns: "columns" in result.output ? result.output.columns ?? inferColumns(rows) : inferColumns(rows),
+      rows,
+      source: result.output.source,
+      loading: false,
+    } satisfies DashboardQueryResult]
+  }))
 }
 
 export async function fetchArrowDataBridgeQuery(options: {
@@ -115,20 +159,17 @@ export function useDashboardQueryData(spec: BslDashboardSpec | null, apiBaseUrl:
 
     setResults(Object.fromEntries(queries.map(([queryId]) => [queryId, { queryId, columns: [], rows: [], loading: true }])))
 
-    void Promise.all(queries.map(async ([queryId, query]) => {
-      try {
-        return [queryId, await fetchDataBridgeQuery({ apiBaseUrl, workspaceId, queryId, query })] as const
-      } catch (error) {
-        return [queryId, {
-          queryId,
-          columns: [],
-          rows: [],
-          loading: false,
-          error: error instanceof Error ? error.message : String(error),
-        }] as const
-      }
-    })).then((entries) => {
-      if (!cancelled) setResults(Object.fromEntries(entries))
+    void fetchDataBridgeQueries({ apiBaseUrl, workspaceId, queries }).then((nextResults) => {
+      if (!cancelled) setResults(nextResults)
+    }).catch((error) => {
+      if (cancelled) return
+      setResults(Object.fromEntries(queries.map(([queryId]) => [queryId, {
+        queryId,
+        columns: [],
+        rows: [],
+        loading: false,
+        error: error instanceof Error ? error.message : String(error),
+      }])))
     })
 
     return () => { cancelled = true }

--- a/plugins/data-bridge/README.md
+++ b/plugins/data-bridge/README.md
@@ -11,3 +11,9 @@ can answer reporting/dashboard questions without falling back to shell commands,
 database CLIs, or ad hoc scripts.
 
 This package intentionally does not define a separate dashboard JSON-to-BSL query DSL.
+
+For dashboard-style hydration with several independent queries, use `data.v1.query.batch`.
+It accepts `{ queries: [{ id, input }] }`, where each `input` is the same shape
+as `data.v1.query.run`, and returns ordered per-item success/error results.
+BSL items in the same batch share one Python semantic-layer process so models
+are loaded once per batch instead of once per query.

--- a/plugins/data-bridge/src/server/index.test.ts
+++ b/plugins/data-bridge/src/server/index.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it, vi } from "vitest"
 import { createWorkspaceBridgeRegistry, type WorkspaceBridgeCallResponse } from "@hachej/boring-workspace/server"
-import type { DataBridgeTableResult } from "../shared"
+import { DATA_BRIDGE_QUERY_BATCH_OP, DATA_BRIDGE_QUERY_RUN_OP, type DataBridgeQueryBatchOutput, type DataBridgeTableResult } from "../shared"
 import { createClickHouseDataBridgeAdapter, createDataBridgeQueryAgentTool, createDataBridgeServerPlugin, type DataBridgeSqlAdapter } from "./index"
 
 const { clickHouseQuery, clickHouseExec } = vi.hoisted(() => ({ clickHouseQuery: vi.fn(), clickHouseExec: vi.fn() }))
@@ -33,7 +33,7 @@ async function sqlQuery(adapter: DataBridgeSqlAdapter, capabilities: string[], o
     registry.registerHandler(contribution.definition, contribution.handler)
   }
   return await registry.call({
-    op: "data.v1.query.run",
+    op: DATA_BRIDGE_QUERY_RUN_OP,
     input: {
       ...(format ? { format } : {}),
       query: {
@@ -148,6 +148,112 @@ describe("data bridge SQL adapters", () => {
     expect(clickHouseExec).toHaveBeenCalledWith(expect.objectContaining({
       query: "SELECT * FROM (SELECT series_id FROM series_catalog LIMIT 100000) AS data_bridge_query LIMIT 100 FORMAT Arrow",
     }))
+  })
+
+  it("runs SQL query batches through one bridge call", async () => {
+    const sqlAdapter = adapter()
+    const plugin = createDataBridgeServerPlugin({
+      workspaceRoot: createWorkspaceFixture(),
+      sqlAdapters: { macro: sqlAdapter },
+    })
+    const registry = createWorkspaceBridgeRegistry()
+    for (const contribution of plugin.workspaceBridgeHandlers ?? []) {
+      registry.registerHandler(contribution.definition, contribution.handler)
+    }
+
+    const res = await registry.call({
+      op: DATA_BRIDGE_QUERY_BATCH_OP,
+      input: {
+        queries: [
+          {
+            id: "gdp",
+            input: {
+              query: {
+                language: "sql",
+                source: "macro",
+                sql: "SELECT series_id FROM series_catalog WHERE series_id = 'GDP'",
+                limit: 1,
+              },
+            },
+          },
+          {
+            id: "cpi",
+            input: {
+              query: {
+                language: "sql",
+                source: "macro",
+                sql: "SELECT series_id FROM series_catalog WHERE series_id = 'CPI'",
+                limit: 2,
+              },
+            },
+          },
+        ],
+      },
+    }, {
+      callerClass: "runtime",
+      workspaceId: "workspace-test",
+      capabilities: ["data:read", "data:sql-query", "data:macro-clickhouse"],
+      actor: { actorKind: "agent", performedBy: { label: "test" } },
+    })
+
+    expect(res.ok).toBe(true)
+    const output = res.ok ? res.output as DataBridgeQueryBatchOutput : undefined
+    expect(output?.kind).toBe("data-bridge.batch")
+    expect(output?.results.map((result) => [result.id, result.ok])).toEqual([["gdp", true], ["cpi", true]])
+    expect(sqlAdapter.execute).toHaveBeenCalledTimes(2)
+  })
+
+  it("keeps batch item errors isolated", async () => {
+    const sqlAdapter = adapter([{ series_id: "GDP" }])
+    const plugin = createDataBridgeServerPlugin({
+      workspaceRoot: createWorkspaceFixture(),
+      sqlAdapters: { macro: sqlAdapter },
+    })
+    const registry = createWorkspaceBridgeRegistry()
+    for (const contribution of plugin.workspaceBridgeHandlers ?? []) {
+      registry.registerHandler(contribution.definition, contribution.handler)
+    }
+
+    const res = await registry.call({
+      op: DATA_BRIDGE_QUERY_BATCH_OP,
+      input: {
+        queries: [
+          {
+            id: "bad",
+            input: {
+              query: {
+                language: "sql",
+                source: "macro",
+                sql: "DROP TABLE series_catalog",
+                limit: 1,
+              },
+            },
+          },
+          {
+            id: "good",
+            input: {
+              query: {
+                language: "sql",
+                source: "macro",
+                sql: "SELECT series_id FROM series_catalog",
+                limit: 1,
+              },
+            },
+          },
+        ],
+      },
+    }, {
+      callerClass: "runtime",
+      workspaceId: "workspace-test",
+      capabilities: ["data:read", "data:sql-query", "data:macro-clickhouse"],
+      actor: { actorKind: "agent", performedBy: { label: "test" } },
+    })
+
+    expect(res.ok).toBe(true)
+    const output = res.ok ? res.output as DataBridgeQueryBatchOutput : undefined
+    expect(output?.results[0]).toMatchObject({ id: "bad", ok: false })
+    expect(output?.results[1]).toMatchObject({ id: "good", ok: true })
+    expect(sqlAdapter.execute).toHaveBeenCalledTimes(1)
   })
 
   it("runs an end-to-end SQL query through a DuckDB file adapter", async () => {

--- a/plugins/data-bridge/src/server/index.ts
+++ b/plugins/data-bridge/src/server/index.ts
@@ -10,12 +10,15 @@ import {
 import type {
   DataBridgeArrowResult,
   DataBridgeBslQuery,
+  DataBridgeQueryBatchInput,
+  DataBridgeQueryBatchItemResult,
+  DataBridgeQueryBatchOutput,
   DataBridgeQueryRunInput,
   DataBridgeQueryRunOutput,
   DataBridgeSqlQuery,
   DataBridgeTableResult,
 } from "../shared"
-import { DATA_BRIDGE_QUERY_RUN_OP } from "../shared"
+import { DATA_BRIDGE_QUERY_BATCH_OP, DATA_BRIDGE_QUERY_RUN_OP } from "../shared"
 
 export interface DataBridgeSqlAdapter {
   requiredCapabilities?: string[]
@@ -100,10 +103,10 @@ function truncateResult(result: DataBridgeTableResult, limit: number): DataBridg
   }
 }
 
-async function runBslQuery(options: CreateDataBridgeServerPluginOptions, input: DataBridgeQueryRunInput & { query: DataBridgeBslQuery }, signal?: AbortSignal): Promise<DataBridgeTableResult> {
+function bslPayload(options: CreateDataBridgeServerPluginOptions, input: DataBridgeQueryRunInput & { query: DataBridgeBslQuery }): Record<string, unknown> {
   const modelPath = options.bslModelPath ?? process.env.BORING_BSL_MODEL_PATH ?? process.env.BSL_MODEL_PATH
   if (!modelPath) throw new Error("BSL adapter is not configured: set BORING_BSL_MODEL_PATH")
-  const payload = {
+  return {
     modelPath,
     profile: options.bslProfile ?? process.env.BORING_BSL_PROFILE,
     profileFile: options.bslProfileFile ?? process.env.BORING_BSL_PROFILE_FILE,
@@ -111,7 +114,10 @@ async function runBslQuery(options: CreateDataBridgeServerPluginOptions, input: 
     query: input.query.query,
     limit: input.query.limit ?? 5000,
   }
-  return await runPythonBsl(payload, signal)
+}
+
+async function runBslQuery(options: CreateDataBridgeServerPluginOptions, input: DataBridgeQueryRunInput & { query: DataBridgeBslQuery }, signal?: AbortSignal): Promise<DataBridgeTableResult> {
+  return await runPythonBsl(bslPayload(options, input), signal)
 }
 
 async function runSqlQuery(options: CreateDataBridgeServerPluginOptions, input: DataBridgeQueryRunInput, capabilities: readonly string[], format: "json" | "arrow", signal?: AbortSignal): Promise<DataBridgeTableResult | DataBridgeArrowResult> {
@@ -185,6 +191,75 @@ print(json.dumps({"kind":"data-bridge.table","version":1,"columns":columns,"rows
   if (signal?.aborted) throw new Error("BSL query aborted")
   if (code !== 0) throw new Error(stderr.trim() || `BSL query failed with exit code ${code}`)
   return JSON.parse(stdout) as DataBridgeTableResult
+}
+
+async function runPythonBslBatch(payloads: Record<string, unknown>[], signal?: AbortSignal): Promise<Array<{ ok: true; output: DataBridgeTableResult } | { ok: false; error: { message: string } }>> {
+  const script = String.raw`
+import json, sys
+from pathlib import Path
+import ibis
+from ibis import _
+from returns.result import Failure, Success
+from boring_semantic_layer import from_yaml
+from boring_semantic_layer.utils import safe_eval
+payloads = json.loads(sys.stdin.read())
+model_cache = {}
+def model_cache_key(payload):
+    return json.dumps({
+        "modelPath": payload["modelPath"],
+        "profile": payload.get("profile"),
+        "profileFile": payload.get("profileFile"),
+    }, sort_keys=True)
+def table_result(payload):
+    key = model_cache_key(payload)
+    if key not in model_cache:
+        model_cache[key] = from_yaml(Path(payload["modelPath"]), profile=payload.get("profile"), profile_path=payload.get("profileFile"))
+    models = model_cache[key]
+    sm = models[payload["model"]]
+    evaluated = safe_eval(payload["query"], context={**models, "sm": sm, "ibis": ibis, "_": _})
+    if isinstance(evaluated, Failure):
+        raise evaluated.failure()
+    result = evaluated.unwrap() if isinstance(evaluated, Success) else evaluated
+    df = result.execute()
+    limit = int(payload.get("limit") or 5000)
+    rows = json.loads(df.head(limit).to_json(orient="records", date_format="iso"))
+    columns = []
+    for name in df.columns:
+        series = df[name]
+        kind = "string"
+        if str(series.dtype).startswith("int"):
+            kind = "integer"
+        elif str(series.dtype).startswith("float") or str(series.dtype).startswith("decimal"):
+            kind = "float"
+        elif str(series.dtype).startswith("bool"):
+            kind = "boolean"
+        elif "datetime" in str(series.dtype):
+            kind = "datetime"
+        columns.append({"name": str(name), "type": kind})
+    return {"kind":"data-bridge.table","version":1,"columns":columns,"rows":rows,"rowCount":len(rows),"truncated": len(df) > len(rows), "source":"bsl"}
+results = []
+for payload in payloads:
+    try:
+        results.append({"ok": True, "output": table_result(payload)})
+    except Exception as exc:
+        results.append({"ok": False, "error": {"message": str(exc) or exc.__class__.__name__}})
+print(json.dumps(results))
+`
+  if (signal?.aborted) throw new Error("BSL query aborted")
+  const child = spawn(process.env.BORING_DATA_BRIDGE_PYTHON ?? "python3", ["-c", script], { stdio: ["pipe", "pipe", "pipe"] })
+  const abort = () => child.kill("SIGKILL")
+  signal?.addEventListener("abort", abort, { once: true })
+  child.stdin.end(JSON.stringify(payloads))
+  const [stdout, stderr, code] = await new Promise<[string, string, number | null]>((resolvePromise) => {
+    let out = ""
+    let err = ""
+    child.stdout.on("data", (chunk) => { out += String(chunk) })
+    child.stderr.on("data", (chunk) => { err += String(chunk) })
+    child.on("close", (exitCode) => resolvePromise([out, err, exitCode]))
+  }).finally(() => signal?.removeEventListener("abort", abort))
+  if (signal?.aborted) throw new Error("BSL query aborted")
+  if (code !== 0) throw new Error(stderr.trim() || `BSL query batch failed with exit code ${code}`)
+  return JSON.parse(stdout) as Array<{ ok: true; output: DataBridgeTableResult } | { ok: false; error: { message: string } }>
 }
 
 async function materializeArrowSnapshot(result: DataBridgeTableResult): Promise<DataBridgeArrowResult> {
@@ -396,6 +471,77 @@ export function createDataBridgeQueryAgentTool(options: CreateDataBridgeServerPl
   }
 }
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function executeBatch(options: CreateDataBridgeServerPluginOptions, input: DataBridgeQueryBatchInput, capabilities: readonly string[], signal?: AbortSignal): Promise<DataBridgeQueryBatchOutput> {
+  if (!isRecord(input) || !Array.isArray(input.queries)) throw new Error("Invalid data bridge query batch input")
+  const results: DataBridgeQueryBatchItemResult[] = input.queries.map((query, index) => ({
+    id: isRecord(query) && typeof query.id === "string" ? query.id : String(index),
+    ok: false,
+    error: { message: "Query was not executed" },
+  }))
+  const bslItems: Array<{ index: number; id: string; input: DataBridgeQueryRunInput; format: "json" | "arrow" }> = []
+  const otherItems: Array<Promise<void>> = []
+
+  for (const [index, item] of input.queries.entries()) {
+    const id = isRecord(item) && typeof item.id === "string" ? item.id : String(index)
+    if (!isRecord(item) || !isRecord(item.input)) {
+      results[index] = { id, ok: false, error: { message: "Invalid data bridge query batch item" } }
+      continue
+    }
+    const typedInput = item.input as DataBridgeQueryRunInput
+    const executionFormat = typedInput.format === "arrow" ? "arrow" : "json"
+    if (isRecord(typedInput.query) && typedInput.query.language === "bsl") {
+      bslItems.push({ index, id, input: typedInput, format: executionFormat })
+      continue
+    }
+    otherItems.push((async () => {
+      try {
+        const output = await executeQuery(options, typedInput, capabilities, executionFormat, signal)
+        results[index] = {
+          id,
+          ok: true,
+          output: executionFormat === "arrow" && !isDataBridgeArrowResult(output) ? await materializeArrowSnapshot(output) : output,
+        }
+      } catch (error) {
+        results[index] = { id, ok: false, error: { message: errorMessage(error) } }
+      }
+    })())
+  }
+
+  await Promise.all(otherItems)
+
+  if (bslItems.length > 0) {
+    try {
+      const bslOutputs = await runPythonBslBatch(
+        bslItems.map((item) => bslPayload(options, item.input as DataBridgeQueryRunInput & { query: DataBridgeBslQuery })),
+        signal,
+      )
+      await Promise.all(bslOutputs.map(async (output, outputIndex) => {
+        const item = bslItems[outputIndex]
+        if (!item) return
+        if (!output.ok) {
+          results[item.index] = { id: item.id, ok: false, error: output.error }
+          return
+        }
+        results[item.index] = {
+          id: item.id,
+          ok: true,
+          output: item.format === "arrow" ? await materializeArrowSnapshot(output.output) : output.output,
+        }
+      }))
+    } catch (error) {
+      for (const item of bslItems) {
+        results[item.index] = { id: item.id, ok: false, error: { message: errorMessage(error) } }
+      }
+    }
+  }
+
+  return { kind: "data-bridge.batch", version: 1, results }
+}
+
 export function createDataBridgeServerPlugin(options: CreateDataBridgeServerPluginOptions): WorkspaceServerPlugin {
   const queryRun = defineTrustedDomainBridgeHandler<DataBridgeQueryRunInput, DataBridgeQueryRunOutput>({
     op: DATA_BRIDGE_QUERY_RUN_OP,
@@ -415,13 +561,28 @@ export function createDataBridgeServerPlugin(options: CreateDataBridgeServerPlug
       return result
     },
   })
+  const queryBatch = defineTrustedDomainBridgeHandler<DataBridgeQueryBatchInput, DataBridgeQueryBatchOutput>({
+    op: DATA_BRIDGE_QUERY_BATCH_OP,
+    version: 1,
+    owner: "data-bridge",
+    callerClassesAllowed: ["browser", "runtime", "server"],
+    requiredCapabilities: ["data:read"],
+    inputSchema: { type: "object" },
+    maxInputBytes: 5 * 1024 * 1024,
+    maxOutputBytes: 10 * 1024 * 1024,
+    timeoutMs: 30_000,
+    idempotencyPolicy: "none",
+    handler: async ({ input, context, signal }) => {
+      return await executeBatch(options, input as unknown as DataBridgeQueryBatchInput, context.capabilities, signal)
+    },
+  })
 
   return defineServerPlugin({
     id: "data-bridge",
     label: "Data Bridge",
     agentTools: options.agentTool === false ? [] : [createDataBridgeQueryAgentTool(options)],
-    workspaceBridgeHandlers: [queryRun as unknown as WorkspaceBridgeHandlerContribution],
-    systemPrompt: "Use query_data for dashboard/reporting data. Supported query languages are bsl and sql. Use data.v1.query.run through WorkspaceBridge for browser/runtime dashboard data; set format=arrow for BI/Perspective snapshot viewers."
+    workspaceBridgeHandlers: [queryRun as unknown as WorkspaceBridgeHandlerContribution, queryBatch as unknown as WorkspaceBridgeHandlerContribution],
+    systemPrompt: "Use query_data for dashboard/reporting data. Supported query languages are bsl and sql. Use data.v1.query.run for individual requests and data.v1.query.batch when loading multiple queries; set format=arrow for BI/Perspective snapshot viewers.",
   })
 }
 

--- a/plugins/data-bridge/src/shared/index.ts
+++ b/plugins/data-bridge/src/shared/index.ts
@@ -1,4 +1,5 @@
 export const DATA_BRIDGE_QUERY_RUN_OP = "data.v1.query.run" as const
+export const DATA_BRIDGE_QUERY_BATCH_OP = "data.v1.query.batch" as const
 
 export type DataBridgeScalarType = "string" | "integer" | "float" | "boolean" | "date" | "datetime" | "json"
 export type DataBridgeRole = "dimension" | "measure" | "time" | "unknown"
@@ -34,6 +35,15 @@ export interface DataBridgeQueryRunInput {
   format?: DataBridgeQueryFormat
 }
 
+export interface DataBridgeQueryBatchItemInput {
+  id: string
+  input: DataBridgeQueryRunInput
+}
+
+export interface DataBridgeQueryBatchInput {
+  queries: DataBridgeQueryBatchItemInput[]
+}
+
 export interface DataBridgeTableResult {
   kind: "data-bridge.table"
   version: 1
@@ -56,3 +66,21 @@ export interface DataBridgeArrowResult {
 }
 
 export type DataBridgeQueryRunOutput = DataBridgeTableResult | DataBridgeArrowResult
+
+export type DataBridgeQueryBatchItemResult =
+  | {
+    id: string
+    ok: true
+    output: DataBridgeQueryRunOutput
+  }
+  | {
+    id: string
+    ok: false
+    error: { message: string }
+  }
+
+export interface DataBridgeQueryBatchOutput {
+  kind: "data-bridge.batch"
+  version: 1
+  results: DataBridgeQueryBatchItemResult[]
+}


### PR DESCRIPTION
## Summary
- add generic data.v1.query.batch WorkspaceBridge operation in data-bridge
- batch BSL items in one Python semantic-layer process with per-item results
- hydrate BI dashboard JSON queries through the batch op instead of one bridge HTTP call per query

## Notes
- initial implementation was done from the PR563-compatible checkout, then cherry-picked onto origin/main because GitHub rejects the dependabot PR branch as a PR base
- no Healio files were read or modified

## Validation
- pnpm install
- pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-generated-pane build
- pnpm --filter @hachej/boring-data-bridge test
- pnpm --filter @hachej/boring-data-bridge typecheck
- pnpm --filter @hachej/boring-data-bridge build
- pnpm --filter @hachej/boring-bi-dashboard typecheck
- pnpm --filter @hachej/boring-bi-dashboard test

Auto-review helper was requested by local skill policy, but the helper script was not present in the expected paths in this environment.