### PR TITLE
Add data bridge query agent tool

### DIFF
--- a/plugins/data-bridge/README.md
+++ b/plugins/data-bridge/README.md
@@ -6,4 +6,8 @@ so dashboard/runtime callers can execute either:
 - `language: "bsl"` — a BSL/Ibis expression string evaluated by BSL `safe_eval`.
 - `language: "sql"` — read-only SQL routed through a host-registered adapter.
 
+It also exposes a `query_data` agent tool with the same two modes, so chat agents
+can answer reporting/dashboard questions without falling back to shell commands,
+database CLIs, or ad hoc scripts.
+
 This package intentionally does not define a separate dashboard JSON-to-BSL query DSL.

--- a/plugins/data-bridge/src/server/index.test.ts
+++ b/plugins/data-bridge/src/server/index.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { describe, expect, it, vi } from "vitest"
 import { createWorkspaceBridgeRegistry, type WorkspaceBridgeCallResponse } from "@hachej/boring-workspace/server"
 import type { DataBridgeTableResult } from "../shared"
-import { createClickHouseDataBridgeAdapter, createDataBridgeServerPlugin, type DataBridgeSqlAdapter } from "./index"
+import { createClickHouseDataBridgeAdapter, createDataBridgeQueryAgentTool, createDataBridgeServerPlugin, type DataBridgeSqlAdapter } from "./index"
 
 const { clickHouseQuery, clickHouseExec } = vi.hoisted(() => ({ clickHouseQuery: vi.fn(), clickHouseExec: vi.fn() }))
 
@@ -17,6 +17,10 @@ function createWorkspaceFixture() {
   const workspaceRoot = mkdtempSync(join(tmpdir(), "data-bridge-test-"))
   writeFileSync(join(workspaceRoot, "data.csv"), "id,role\n1,engineer\n2,designer\n3,engineer\n")
   return workspaceRoot
+}
+
+function toolContext() {
+  return { abortSignal: new AbortController().signal, toolCallId: "tool-call-test" }
 }
 
 async function sqlQuery(adapter: DataBridgeSqlAdapter, capabilities: string[], overrides: Record<string, unknown> = {}, format?: "json" | "arrow", pluginOptions: Parameters<typeof createDataBridgeServerPlugin>[0] = { workspaceRoot: createWorkspaceFixture() }): Promise<WorkspaceBridgeCallResponse> {
@@ -187,5 +191,79 @@ describe("data bridge SQL adapters", () => {
       connection.closeSync()
       instance.closeSync()
     }
+  })
+})
+
+describe("data bridge agent tool", () => {
+  function adapter(rows: Record<string, unknown>[] = [{ series_id: "GDP" }]): DataBridgeSqlAdapter {
+    return {
+      requiredCapabilities: ["data:macro-clickhouse"],
+      maxRows: 10,
+      execute: vi.fn(async ({ sql, params, limit }) => ({
+        kind: "data-bridge.table" as const,
+        version: 1 as const,
+        columns: [{ name: "series_id", type: "string" as const }],
+        rows,
+        rowCount: rows.length,
+        source: JSON.stringify({ sql, params, limit }),
+      })),
+    }
+  }
+
+  it("registers query_data by default", () => {
+    const plugin = createDataBridgeServerPlugin({ workspaceRoot: createWorkspaceFixture() })
+
+    expect(plugin.agentTools?.map((tool) => tool.name)).toEqual(["query_data"])
+    expect(plugin.systemPrompt).toContain("query_data")
+  })
+
+  it("can disable the agent query tool", () => {
+    const plugin = createDataBridgeServerPlugin({ workspaceRoot: createWorkspaceFixture(), agentTool: false })
+
+    expect(plugin.agentTools).toEqual([])
+  })
+
+  it("runs read-only SQL through the same adapter path as data.v1.query.run", async () => {
+    const sqlAdapter = adapter()
+    const tool = createDataBridgeQueryAgentTool({
+      workspaceRoot: createWorkspaceFixture(),
+      sqlAdapters: { macro: sqlAdapter },
+      agentTool: { capabilities: ["data:read", "data:sql-query", "data:macro-clickhouse"] },
+    })
+
+    const result = await tool.execute({
+      language: "sql",
+      source: "macro",
+      sql: " SELECT series_id FROM series_catalog;;; ",
+      params: { frequency: "monthly" },
+      limit: 2,
+    }, toolContext())
+
+    expect(result.isError).toBeUndefined()
+    expect(result.details).toMatchObject({
+      kind: "data-bridge.table",
+      rows: [{ series_id: "GDP" }],
+      source: expect.stringContaining("SELECT series_id FROM series_catalog"),
+    })
+    expect(sqlAdapter.execute).toHaveBeenCalledWith(expect.objectContaining({
+      sql: "SELECT series_id FROM series_catalog",
+      params: { frequency: "monthly" },
+      limit: 2,
+    }))
+  })
+
+  it("rejects invalid tool inputs before execution", async () => {
+    const sqlAdapter = adapter()
+    const tool = createDataBridgeQueryAgentTool({
+      workspaceRoot: createWorkspaceFixture(),
+      sqlAdapters: { macro: sqlAdapter },
+      agentTool: { capabilities: ["data:read", "data:sql-query", "data:macro-clickhouse"] },
+    })
+
+    await expect(tool.execute({ language: "bsl", query: "sm" }, toolContext()))
+      .resolves.toMatchObject({ isError: true, content: [{ text: "model is required for bsl queries" }] })
+    await expect(tool.execute({ language: "sql", sql: "SELECT 1" }, toolContext()))
+      .resolves.toMatchObject({ isError: true, content: [{ text: "source is required for sql queries" }] })
+    expect(sqlAdapter.execute).not.toHaveBeenCalled()
   })
 })

--- a/plugins/data-bridge/src/server/index.ts
+++ b/plugins/data-bridge/src/server/index.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process"
 import type { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config"
+import type { AgentTool, ToolResult } from "@hachej/boring-workspace"
 import {
   defineServerPlugin,
   defineTrustedDomainBridgeHandler,
@@ -40,12 +41,18 @@ export interface ClickHouseDataBridgeAdapterOptions {
   clientConfig?: NodeClickHouseClientConfigOptions
 }
 
-interface CreateDataBridgeServerPluginOptions {
+export interface DataBridgeAgentToolOptions {
+  name?: string
+  capabilities?: string[]
+}
+
+export interface CreateDataBridgeServerPluginOptions {
   workspaceRoot: string
   bslModelPath?: string
   bslProfile?: string
   bslProfileFile?: string
   sqlAdapters?: Record<string, DataBridgeSqlAdapter>
+  agentTool?: false | DataBridgeAgentToolOptions
 }
 
 const SQL_DEFAULT_LIMIT = 1000
@@ -289,6 +296,106 @@ async function executeQuery(options: CreateDataBridgeServerPluginOptions, input:
   return await runBslQuery(options, input as DataBridgeQueryRunInput & { query: DataBridgeBslQuery }, signal)
 }
 
+function textResult(text: string, details?: unknown): ToolResult {
+  return { content: [{ type: "text", text }], details }
+}
+
+function errorResult(text: string): ToolResult {
+  return { content: [{ type: "text", text }], isError: true }
+}
+
+function normalizeToolLanguage(value: unknown): "bsl" | "sql" | undefined {
+  return value === "bsl" || value === "sql" ? value : undefined
+}
+
+function normalizeToolLimit(value: unknown): number {
+  return normalizeLimit(value, SQL_MAX_LIMIT)
+}
+
+function createDataBridgeToolInput(params: Record<string, unknown>): DataBridgeQueryRunInput | string {
+  const language = normalizeToolLanguage(params.language)
+  if (!language) return "language must be either bsl or sql"
+  const limit = normalizeToolLimit(params.limit)
+
+  if (language === "bsl") {
+    const model = String(params.model ?? "").trim()
+    const query = String(params.query ?? "").trim()
+    if (!model) return "model is required for bsl queries"
+    if (!query) return "query is required for bsl queries"
+    return { format: "json", query: { language, model, query, limit } }
+  }
+
+  const source = String(params.source ?? "").trim()
+  const sql = String(params.sql ?? "").trim()
+  if (!source) return "source is required for sql queries"
+  if (!sql) return "sql is required for sql queries"
+  const query: DataBridgeSqlQuery = { language, source, sql, limit }
+  if (isRecord(params.params)) query.params = params.params
+  return { format: "json", query }
+}
+
+export function createDataBridgeQueryAgentTool(options: CreateDataBridgeServerPluginOptions): AgentTool {
+  const name = options.agentTool && typeof options.agentTool === "object" && options.agentTool.name
+    ? options.agentTool.name
+    : "query_data"
+  const capabilities = options.agentTool && typeof options.agentTool === "object" && options.agentTool.capabilities
+    ? options.agentTool.capabilities
+    : ["data:read", "data:sql-query"]
+
+  return {
+    name,
+    description: "Run a small read-only data query through Boring Data Bridge. Use language=bsl for semantic-layer queries or language=sql for configured read-only SQL sources. Prefer this over shell, database clients, or ad hoc scripts for dashboard/reporting data.",
+    parameters: {
+      type: "object",
+      properties: {
+        language: {
+          type: "string",
+          enum: ["bsl", "sql"],
+          description: "Query mode. Use bsl for semantic-layer/Ibis expressions, sql for configured read-only SQL adapters.",
+        },
+        model: {
+          type: "string",
+          description: "BSL model name. Required when language=bsl.",
+        },
+        query: {
+          type: "string",
+          description: "BSL/Ibis expression. Required when language=bsl.",
+        },
+        source: {
+          type: "string",
+          description: "Configured SQL source name. Required when language=sql.",
+        },
+        sql: {
+          type: "string",
+          description: "Read-only SQL statement. Required when language=sql.",
+        },
+        params: {
+          type: "object",
+          description: "Optional SQL query parameters when language=sql.",
+        },
+        limit: {
+          type: "number",
+          description: `Maximum rows to return. Default ${SQL_DEFAULT_LIMIT}, max ${SQL_MAX_LIMIT}.`,
+          minimum: 1,
+          maximum: SQL_MAX_LIMIT,
+        },
+      },
+      required: ["language"],
+      additionalProperties: false,
+    },
+    async execute(params, ctx) {
+      const input = createDataBridgeToolInput(params)
+      if (typeof input === "string") return errorResult(input)
+      try {
+        const result = await executeQuery(options, input, capabilities, "json", ctx.abortSignal)
+        return textResult(JSON.stringify(result, null, 2), result)
+      } catch (error) {
+        return errorResult(error instanceof Error ? error.message : String(error))
+      }
+    },
+  }
+}
+
 export function createDataBridgeServerPlugin(options: CreateDataBridgeServerPluginOptions): WorkspaceServerPlugin {
   const queryRun = defineTrustedDomainBridgeHandler<DataBridgeQueryRunInput, DataBridgeQueryRunOutput>({
     op: DATA_BRIDGE_QUERY_RUN_OP,
@@ -312,8 +419,9 @@ export function createDataBridgeServerPlugin(options: CreateDataBridgeServerPlug
   return defineServerPlugin({
     id: "data-bridge",
     label: "Data Bridge",
+    agentTools: options.agentTool === false ? [] : [createDataBridgeQueryAgentTool(options)],
     workspaceBridgeHandlers: [queryRun as unknown as WorkspaceBridgeHandlerContribution],
-    systemPrompt: "Use data.v1.query.run through WorkspaceBridge for dashboard data. Supported query languages are bsl and sql; set format=arrow for BI/Perspective snapshot viewers."
+    systemPrompt: "Use query_data for dashboard/reporting data. Supported query languages are bsl and sql. Use data.v1.query.run through WorkspaceBridge for browser/runtime dashboard data; set format=arrow for BI/Perspective snapshot viewers."
   })
 }
 


### PR DESCRIPTION
## Summary

Adds a generic `query_data` agent tool to `@hachej/boring-data-bridge`.

The data bridge already exposed the generic `data.v1.query.run` WorkspaceBridge operation with `bsl` and `sql` modes, but chat agents could not call it directly. This wires the same execution path into the server plugin as an `AgentTool`, so agents can query reporting/dashboard data without falling back to shell commands, database CLIs, or ad hoc scripts.

## Details

- Adds `createDataBridgeQueryAgentTool()` exported from the server entry.
- Registers `query_data` by default from `createDataBridgeServerPlugin()`.
- Supports `language: "bsl"` with `model` + `query`.
- Supports `language: "sql"` with `source` + read-only `sql` + optional `params`.
- Allows hosts to disable the tool with `agentTool: false` or pass tool name/capabilities via `agentTool` options.
- Keeps browser/runtime dashboard traffic on `data.v1.query.run`.

## Validation

- `pnpm --dir plugins/data-bridge test`
- `pnpm --dir plugins/data-bridge typecheck`
- `pnpm --dir plugins/data-bridge build`
