### PR TITLE
fix: open workspace skills from skills panel

### DIFF
--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -1649,9 +1649,18 @@ test('skills endpoint discovers workspace .agents/skills when ambient skills are
 
   const res = await app.inject({ method: 'GET', url: '/api/v1/agent/skills?refresh=1' })
   expect(res.statusCode).toBe(200)
-  expect(res.json().skills).toEqual(expect.arrayContaining([
-    expect.objectContaining({ name: 'cli-project-skill' }),
-  ]))
+  const skill = res.json().skills.find((candidate: { name: string }) => candidate.name === 'cli-project-skill')
+  expect(skill).toMatchObject({
+    name: 'cli-project-skill',
+    filePath: '.agents/skills/cli-project-skill/SKILL.md',
+  })
+
+  const fileRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/files?path=${encodeURIComponent(skill.filePath)}`,
+  })
+  expect(fileRes.statusCode).toBe(200)
+  expect(fileRes.json().content).toContain('# CLI project skill')
 
   await app.close()
 })

--- a/packages/agent/src/server/http/routes/skills.ts
+++ b/packages/agent/src/server/http/routes/skills.ts
@@ -10,6 +10,7 @@
  *   { skills: [{ name: string, description: string }] }
  */
 import type { FastifyInstance, FastifyRequest } from 'fastify'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
 import {
   DefaultPackageManager,
   getAgentDir,
@@ -21,7 +22,7 @@ import { createResourceSettingsManager, withPiHarnessDefaults } from '../../harn
 export interface SkillSummary {
   name: string
   description: string
-  /** Absolute path to the resolved SKILL.md, used by workspace UIs to open it. */
+  /** Workspace-relative path when the skill lives in the workspace; otherwise its absolute source path. */
   filePath?: string
   /** Human-readable source/scope label for diagnostics and disabled rows. */
   source?: string
@@ -32,6 +33,14 @@ interface SkillsQuery {
 }
 
 const CACHE_TTL_MS = 30_000
+
+function pathForWorkspaceEditor(workspaceRoot: string, filePath: string): string {
+  const pathWithinWorkspace = relative(resolve(workspaceRoot), resolve(filePath))
+  if (pathWithinWorkspace === '' || pathWithinWorkspace === '..' || pathWithinWorkspace.startsWith(`..${sep}`) || isAbsolute(pathWithinWorkspace)) {
+    return filePath
+  }
+  return pathWithinWorkspace.split(sep).join('/')
+}
 
 export interface SkillsRoutesOptions {
   workspaceRoot: string
@@ -103,7 +112,7 @@ export function skillsRoutes(
     const skills: SkillSummary[] = (result.skills as unknown as Array<Record<string, unknown>>).map((s) => ({
       name: String(s.name),
       description: String(s.description ?? ''),
-      ...(typeof s.filePath === 'string' ? { filePath: s.filePath } : {}),
+      ...(typeof s.filePath === 'string' ? { filePath: pathForWorkspaceEditor(workspaceRoot, s.filePath) } : {}),
       ...(typeof (s.sourceInfo as { scope?: unknown } | undefined)?.scope === 'string' ? { source: (s.sourceInfo as { scope: string }).scope } : {}),
     }))
     const entry = { skills, expiresAt: now + CACHE_TTL_MS }


### PR DESCRIPTION
## What changed

Project-local Pi skills now return workspace-relative `filePath` values from the skills endpoint. The Skills panel can therefore read them through the normal workspace filesystem endpoint.

## Why

Pi discovers skills with absolute paths. Those absolute paths were rejected by the workspace filesystem boundary, causing a 403 when opening a project skill.

## Validation

- `pnpm exec vitest run src/server/__tests__/registerAgentRoutes.test.ts --testNamePattern="skills endpoint discovers workspace"`
- `pnpm exec tsc --noEmit`