### PR TITLE
#391: recut core boundary invariants

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -116,6 +116,7 @@
     "@types/react-dom": "^19.1.3",
     "@vitejs/plugin-react": "^4.7.0",
     "ajv": "^8.20.0",
+    "esbuild": "^0.25.12",
     "postcss": "^8.5.15",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/agent/scripts/assert-build-artifacts.mjs
+++ b/packages/agent/scripts/assert-build-artifacts.mjs
@@ -4,6 +4,7 @@ import { constants } from 'node:fs'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
+import { build as esbuild } from 'esbuild'
 import ts from 'typescript'
 
 const packageRoot = path.resolve(
@@ -14,9 +15,7 @@ const packageRoot = path.resolve(
 const requiredFiles = [
   'dist/shared/index.js',
   'dist/shared/index.d.ts',
-  'dist/core/index.js',
   'dist/core/index.d.ts',
-  'dist/server/index.js',
   'dist/server/index.d.ts',
   'dist/front/index.js',
   'dist/front/index.d.ts',
@@ -27,6 +26,26 @@ const requiredFiles = [
 
 function resolveFromPackage(relPath) {
   return path.resolve(packageRoot, relPath)
+}
+
+function resolvePublishedJsExport(packageJson, exportName) {
+  const entry = packageJson.exports?.[exportName]?.import
+  if (typeof entry !== 'string' || entry.trim().length === 0) {
+    throw new Error(`package export ${exportName} must define a nonempty import path`)
+  }
+  const distRoot = resolveFromPackage('dist')
+  const absolutePath = resolveFromPackage(entry)
+  const fromDist = path.relative(distRoot, absolutePath)
+  if (fromDist.length === 0
+    || fromDist === '..'
+    || fromDist.startsWith(`..${path.sep}`)
+    || path.isAbsolute(fromDist)) {
+    throw new Error(`package export ${exportName} import must stay under published dist: ${entry}`)
+  }
+  return {
+    absolutePath,
+    displayPath: path.relative(packageRoot, absolutePath),
+  }
 }
 
 async function assertExists(relPath) {
@@ -81,14 +100,105 @@ function assertConsumerSafeCss(relPath) {
   }
 }
 
+function isFastifySpecifier(specifier) {
+  return specifier === 'fastify'
+    || specifier.startsWith('fastify/')
+    || specifier.startsWith('@fastify/')
+}
+
+function findFastifyClosureViolations(metafile) {
+  const inputPaths = Object.keys(metafile.inputs)
+    .filter((inputPath) => {
+      const normalized = inputPath.replaceAll('\\', '/')
+      return normalized.includes('node_modules/fastify/')
+        || normalized.includes('node_modules/@fastify/')
+    })
+    .sort()
+  const externalSpecifiers = Array.from(new Set(
+    Object.values(metafile.outputs)
+      .flatMap((output) => output.imports)
+      .filter((entry) => entry.external && isFastifySpecifier(entry.path))
+      .map((entry) => entry.path),
+  )).sort()
+  return { externalSpecifiers, inputPaths }
+}
+
+function assertFastifyDetectorFixture() {
+  const fastifyInput = 'node_modules/.pnpm/fastify@5.10.0/node_modules/fastify/fastify.js'
+  const fixture = {
+    inputs: {
+      'dist/core/index.js': { bytes: 1, imports: [] },
+      [fastifyInput]: { bytes: 1, imports: [] },
+    },
+    outputs: {
+      'fixture.js': {
+        bytes: 1,
+        exports: [],
+        imports: [
+          { external: true, kind: 'import-statement', path: '@fastify/static' },
+          { external: true, kind: 'dynamic-import', path: 'fastify' },
+        ],
+        inputs: {},
+      },
+    },
+  }
+  const actual = findFastifyClosureViolations(fixture)
+  const expected = {
+    externalSpecifiers: ['@fastify/static', 'fastify'],
+    inputPaths: [fastifyInput],
+  }
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(`Fastify closure detector fixture mismatch: ${JSON.stringify(actual)}`)
+  }
+}
+
+async function analyzeFastifyClosure(entryPoint) {
+  const result = await esbuild({
+    absWorkingDir: packageRoot,
+    bundle: true,
+    entryPoints: [entryPoint],
+    format: 'esm',
+    logLevel: 'silent',
+    metafile: true,
+    packages: 'bundle',
+    platform: 'node',
+    target: 'node22',
+    write: false,
+  })
+  return findFastifyClosureViolations(result.metafile)
+}
+
+async function assertCoreFastifyFree(entryPoint) {
+  const violations = await analyzeFastifyClosure(entryPoint)
+  if (violations.inputPaths.length > 0 || violations.externalSpecifiers.length > 0) {
+    throw new Error(`dist/core Fastify closure violation: ${JSON.stringify(violations)}`)
+  }
+}
+
+async function assertServerDetectsFastify(entryPoint) {
+  const violations = await analyzeFastifyClosure(entryPoint)
+  if (violations.inputPaths.length === 0 && violations.externalSpecifiers.length === 0) {
+    throw new Error('Fastify closure negative proof did not detect the published server entry')
+  }
+}
+
 async function main() {
+  const packageJson = JSON.parse(readFileSync(resolveFromPackage('package.json'), 'utf8'))
+  if (!packageJson.files?.includes('dist')) {
+    throw new Error('package files must publish dist')
+  }
+  const coreEntry = resolvePublishedJsExport(packageJson, './core')
+  const serverEntry = resolvePublishedJsExport(packageJson, './server')
+
   for (const relPath of requiredFiles) {
     await assertExists(relPath)
   }
+  await assertExists(coreEntry.displayPath)
+  await assertExists(serverEntry.displayPath)
 
   assertNodeParsable('dist/shared/index.js')
-  assertNodeParsable('dist/core/index.js')
-  assertNodeParsable('dist/server/index.js')
+  assertNodeParsable(coreEntry.displayPath)
+  assertNodeParsable(serverEntry.displayPath)
   assertNodeParsable('dist/front/index.js')
   assertNodeParsable('dist/eval/index.js')
 
@@ -98,6 +208,9 @@ async function main() {
   assertTsParsable('dist/front/index.d.ts')
   assertTsParsable('dist/eval/index.d.ts')
   assertConsumerSafeCss('dist/front/styles.css')
+  assertFastifyDetectorFixture()
+  await assertCoreFastifyFree(coreEntry.absolutePath)
+  await assertServerDetectsFastify(serverEntry.absolutePath)
 
   process.stdout.write('build-artifacts: OK\n')
 }

--- a/packages/boring-bash/scripts/check-invariants.mjs
+++ b/packages/boring-bash/scripts/check-invariants.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
-import { readFileSync, readdirSync, statSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { extname, join, relative, resolve } from "node:path";
+import ts from "typescript";
 
 const repoRoot = resolve(import.meta.dirname, "../../..");
 const packageRoot = resolve(import.meta.dirname, "..");
@@ -8,6 +10,8 @@ const packageJsonPath = join(packageRoot, "package.json");
 const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
 
 const requiredExports = [".", "./shared", "./server"];
+const sourceFilePattern = /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
+const negativeFixturesOnly = process.argv.includes("--negative-fixtures-only");
 const pass = (message) => console.log(`[boring-bash invariant] PASS ${message}`);
 const fail = (message) => {
   console.error(`[boring-bash invariant] FAIL ${message}`);
@@ -32,55 +36,319 @@ const walk = (dir) => {
     const path = join(dir, name);
     const stat = statSync(path);
     if (stat.isDirectory()) entries.push(...walk(path));
-    else if (/\.(ts|tsx|mts|cts|js|mjs|cjs)$/.test(name)) entries.push(path);
+    else if (sourceFilePattern.test(name)) entries.push(path);
   }
   return entries;
 };
 
-const srcFiles = walk(join(packageRoot, "src"));
-const sharedFiles = srcFiles.filter((file) => file.includes(`${join("src", "shared")}${"/"}`) || file.endsWith(join("src", "shared", "index.ts")));
+function scriptKindFor(file) {
+  switch (extname(file)) {
+    case ".tsx": return ts.ScriptKind.TSX;
+    case ".jsx": return ts.ScriptKind.JSX;
+    case ".js":
+    case ".mjs":
+    case ".cjs": return ts.ScriptKind.JS;
+    default: return ts.ScriptKind.TS;
+  }
+}
 
-const scan = (files, patterns, label) => {
-  let hit = false;
-  for (const file of files) {
-    const text = readFileSync(file, "utf8");
-    for (const [name, pattern] of patterns) {
-      if (pattern.test(text)) {
-        hit = true;
-        fail(`${label}: ${name} found in ${relative(repoRoot, file)}`);
+function isTypeOnlyImport(node) {
+  const clause = node.importClause;
+  if (!clause) return false;
+  if (clause.isTypeOnly) return true;
+  if (clause.name || !clause.namedBindings || ts.isNamespaceImport(clause.namedBindings)) return false;
+  return clause.namedBindings.elements.length > 0
+    && clause.namedBindings.elements.every((element) => element.isTypeOnly);
+}
+
+function isTypeOnlyExport(node) {
+  if (node.isTypeOnly) return true;
+  if (!node.exportClause || !ts.isNamedExports(node.exportClause)) return false;
+  return node.exportClause.elements.length > 0
+    && node.exportClause.elements.every((element) => element.isTypeOnly);
+}
+
+function unwrapTransparentExpression(node) {
+  let current = node;
+  while (current
+    && (ts.isParenthesizedExpression(current)
+      || ts.isAsExpression(current)
+      || ts.isTypeAssertionExpression(current)
+      || ts.isSatisfiesExpression(current)
+      || ts.isNonNullExpression(current))) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function parseModuleReferences(file, text) {
+  const sourceFile = ts.createSourceFile(
+    file,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKindFor(file),
+  );
+  const parseErrors = (sourceFile.parseDiagnostics ?? []).map((diagnostic) => {
+    const { line } = sourceFile.getLineAndCharacterOfPosition(diagnostic.start ?? 0);
+    return {
+      file,
+      line: line + 1,
+      message: ts.flattenDiagnosticMessageText(diagnostic.messageText, " "),
+    };
+  });
+  const references = [];
+  const add = (node, specifier, kind, typeOnly = false) => {
+    const { line } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+    references.push({ file, line: line + 1, kind, specifier, typeOnly });
+  };
+  const literalText = (node) => {
+    const expression = unwrapTransparentExpression(node);
+    return expression && ts.isStringLiteralLike(expression) ? expression.text : undefined;
+  };
+
+  const visit = (node) => {
+    if (ts.isImportDeclaration(node)) {
+      const specifier = literalText(node.moduleSpecifier);
+      if (specifier) add(node, specifier, "import", isTypeOnlyImport(node));
+    } else if (ts.isExportDeclaration(node) && node.moduleSpecifier) {
+      const specifier = literalText(node.moduleSpecifier);
+      if (specifier) add(node, specifier, "export", isTypeOnlyExport(node));
+    } else if (ts.isImportEqualsDeclaration(node)
+      && ts.isExternalModuleReference(node.moduleReference)
+      && node.moduleReference.expression) {
+      const specifier = literalText(node.moduleReference.expression);
+      if (specifier) add(node, specifier, "import equals", node.isTypeOnly);
+    } else if (ts.isCallExpression(node)) {
+      const expression = unwrapTransparentExpression(node.expression);
+      const dynamicImport = expression?.kind === ts.SyntaxKind.ImportKeyword;
+      const requireCall = expression && ts.isIdentifier(expression) && expression.text === "require";
+      if (dynamicImport || requireCall) {
+        const kind = dynamicImport ? "dynamic import" : "require";
+        const specifier = node.arguments[0] ? literalText(node.arguments[0]) : undefined;
+        if (specifier) {
+          add(node, specifier, kind);
+        }
       }
     }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return { parseErrors, references };
+}
+
+function isForbiddenAgentRuntimeSpecifier(specifier) {
+  return specifier === "@hachej/boring-bash"
+    || specifier.startsWith("@hachej/boring-bash/")
+    || specifier === "@hachej/boring-sandbox"
+    || specifier.startsWith("@hachej/boring-sandbox/");
+}
+
+function findAgentRuntimeValueImports(file, text) {
+  const parsed = parseModuleReferences(file, text);
+  return {
+    parseErrors: parsed.parseErrors,
+    violations: parsed.references.filter(({ specifier, typeOnly }) =>
+      !typeOnly && isForbiddenAgentRuntimeSpecifier(specifier)),
+  };
+}
+
+function ensureFreshAgentDist() {
+  const result = spawnSync("pnpm", ["--filter", "@hachej/boring-agent...", "--workspace-concurrency=4", "run", "build"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+    shell: false,
+    timeout: 10 * 60 * 1000,
+  });
+
+  if (result.status === 0) {
+    pass("agent build and build-artifact invariants completed");
+    return true;
   }
-  if (!hit) pass(`${label}: no forbidden patterns in ${files.length} file(s)`);
-};
 
-scan(sharedFiles, [["node import", /from\s+["']node:|import\s+["']node:/], ["Buffer", /\bBuffer\b/]], "shared/front-safe scan");
+  fail("could not build and verify @hachej/boring-agent artifacts");
+  if (result.error) console.error(result.error.message);
+  if (result.stdout) console.error(result.stdout.trimEnd());
+  if (result.stderr) console.error(result.stderr.trimEnd());
+  return false;
+}
 
-const agentSrc = join(repoRoot, "packages", "agent", "src");
-const agentFiles = readdirSync(join(repoRoot, "packages", "agent"), { withFileTypes: true }).length
-  ? walk(agentSrc)
-  : [];
-scan(
-  agentFiles,
-  [
-    ["agent -> boring-bash value import", /import\s+(?!type\b)[\s\S]*?from\s+["']@hachej\/boring-bash(?:\/[^"']*)?["']/],
-    ["agent -> boring-bash require", /require\(\s*["']@hachej\/boring-bash(?:\/[^"']*)?["']\s*\)/],
-  ],
-  "agent import-cycle scan",
-);
-
-const docs = [
-  "docs/issues/391/runtime-refactor/02-boring-bash-environment.md",
-  "docs/issues/391/runtime-refactor/07-tests-review-acceptance.md",
-];
-for (const doc of docs) {
-  const text = readFileSync(join(repoRoot, doc), "utf8");
-  if (/named filesystem bindings?/.test(text) && /\(filesystem, path\)/.test(text)) {
-    pass(`${doc} mentions named filesystem bindings and (filesystem, path) identity`);
+function assertNegativeFixtures() {
+  const agentValueFixture = findAgentRuntimeValueImports(
+    "fixture.ts",
+    [
+      "import type { FilesystemBinding } from '@hachej/boring-bash/shared'",
+      "import { type FilesystemPath } from '@hachej/boring-bash/shared'",
+      "export { type FilesystemBinding } from '@hachej/boring-bash/shared'",
+      "import type { Sandbox } from '@hachej/boring-sandbox/shared'",
+      "import { type ProviderCapabilities } from '@hachej/boring-sandbox/shared'",
+      "export { type SandboxProvider } from '@hachej/boring-sandbox/providers'",
+      "import { createBashAgentFeature } from '@hachej/boring-bash/server'",
+      "export { createBashAgentFeature } from '@hachej/boring-bash/server'",
+      "import '@hachej/boring-bash/server'",
+      "const loaded = await import('@hachej/boring-bash')",
+      "const required = require('@hachej/boring-bash')",
+      "import { createBwrapSandbox } from '@hachej/boring-sandbox/providers'",
+      "export { createBwrapSandbox } from '@hachej/boring-sandbox/providers'",
+      "import '@hachej/boring-sandbox/providers'",
+      "const sandboxLoaded = await import('@hachej/boring-sandbox')",
+      "const sandboxRequired = require('@hachej/boring-sandbox')",
+    ].join("\n"),
+  );
+  const agentValueActual = agentValueFixture.violations.map(({ kind, line, specifier }) =>
+    ({ kind, line, specifier }));
+  const agentValueExpected = [
+    { kind: "import", line: 7, specifier: "@hachej/boring-bash/server" },
+    { kind: "export", line: 8, specifier: "@hachej/boring-bash/server" },
+    { kind: "import", line: 9, specifier: "@hachej/boring-bash/server" },
+    { kind: "dynamic import", line: 10, specifier: "@hachej/boring-bash" },
+    { kind: "require", line: 11, specifier: "@hachej/boring-bash" },
+    { kind: "import", line: 12, specifier: "@hachej/boring-sandbox/providers" },
+    { kind: "export", line: 13, specifier: "@hachej/boring-sandbox/providers" },
+    { kind: "import", line: 14, specifier: "@hachej/boring-sandbox/providers" },
+    { kind: "dynamic import", line: 15, specifier: "@hachej/boring-sandbox" },
+    { kind: "require", line: 16, specifier: "@hachej/boring-sandbox" },
+  ];
+  if (agentValueFixture.parseErrors.length === 0
+    && JSON.stringify(agentValueActual) === JSON.stringify(agentValueExpected)) {
+    pass("agent runtime-package fixture rejects bash/sandbox static/dynamic/require values and allows type-only imports");
   } else {
-    fail(`${doc} is missing named filesystem binding / (filesystem, path) wording`);
+    fail(`agent runtime-package fixture mismatch: ${JSON.stringify({
+      parseErrors: agentValueFixture.parseErrors,
+      violations: agentValueActual,
+    })}`);
+  }
+
+  const jsxValueFixture = findAgentRuntimeValueImports(
+    "fixture.jsx",
+    [
+      "import { createBashAgentFeature } from '@hachej/boring-bash/server'",
+      "import { createBwrapSandbox } from '@hachej/boring-sandbox/providers'",
+      "export const View = () => <div />",
+    ].join("\n"),
+  );
+  const jsxViolations = jsxValueFixture.violations.map(({ kind, line, specifier }) =>
+    ({ kind, line, specifier }));
+  const jsxExpected = [
+    { kind: "import", line: 1, specifier: "@hachej/boring-bash/server" },
+    { kind: "import", line: 2, specifier: "@hachej/boring-sandbox/providers" },
+  ];
+  if (jsxValueFixture.parseErrors.length === 0
+    && JSON.stringify(jsxViolations) === JSON.stringify(jsxExpected)) {
+    pass("agent runtime-package fixture rejects bash and sandbox JSX value imports");
+  } else {
+    fail(`agent runtime-package JSX fixture mismatch: ${JSON.stringify(jsxValueFixture)}`);
+  }
+
+  const transparentExpressionFixture = findAgentRuntimeValueImports(
+    "fixture.ts",
+    [
+      "const bashParenthesizedArgument = require(('@hachej/boring-bash'))",
+      "const sandboxAsArgument = require('@hachej/boring-sandbox' as string)",
+      "const bashParenthesizedCallee = (require)('@hachej/boring-bash/server')",
+      "const sandboxAssertedArgument = require(<string>'@hachej/boring-sandbox/providers')",
+      "const bashSatisfiesImport = await import('@hachej/boring-bash/shared' satisfies string)",
+      "const sandboxNonNullImport = await import(('@hachej/boring-sandbox/shared')!)",
+    ].join("\n"),
+  );
+  const transparentExpressionActual = transparentExpressionFixture.violations.map(
+    ({ kind, line, specifier }) => ({ kind, line, specifier }),
+  );
+  const transparentExpressionExpected = [
+    { kind: "require", line: 1, specifier: "@hachej/boring-bash" },
+    { kind: "require", line: 2, specifier: "@hachej/boring-sandbox" },
+    { kind: "require", line: 3, specifier: "@hachej/boring-bash/server" },
+    { kind: "require", line: 4, specifier: "@hachej/boring-sandbox/providers" },
+    { kind: "dynamic import", line: 5, specifier: "@hachej/boring-bash/shared" },
+    { kind: "dynamic import", line: 6, specifier: "@hachej/boring-sandbox/shared" },
+  ];
+  if (transparentExpressionFixture.parseErrors.length === 0
+    && JSON.stringify(transparentExpressionActual) === JSON.stringify(transparentExpressionExpected)) {
+    pass("agent runtime-package fixture rejects transparent expression wrappers");
+  } else {
+    fail(`agent runtime-package transparent-expression fixture mismatch: ${JSON.stringify({
+      parseErrors: transparentExpressionFixture.parseErrors,
+      violations: transparentExpressionActual,
+    })}`);
+  }
+}
+
+assertNegativeFixtures();
+
+if (!negativeFixturesOnly) {
+  const srcFiles = walk(join(packageRoot, "src"));
+  const sharedFiles = srcFiles.filter((file) => file.includes(`${join("src", "shared")}${"/"}`) || file.endsWith(join("src", "shared", "index.ts")));
+
+  const scan = (files, patterns, label) => {
+    let hit = false;
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      for (const [name, pattern] of patterns) {
+        if (pattern.test(text)) {
+          hit = true;
+          fail(`${label}: ${name} found in ${relative(repoRoot, file)}`);
+        }
+      }
+    }
+    if (!hit) pass(`${label}: no forbidden patterns in ${files.length} file(s)`);
+  };
+
+  scan(sharedFiles, [["node import", /from\s+["']node:|import\s+["']node:/], ["Buffer", /\bBuffer\b/]], "shared/front-safe scan");
+
+  const agentSrc = join(repoRoot, "packages", "agent", "src");
+  const agentFiles = existsSync(agentSrc) ? walk(agentSrc) : [];
+  if (agentFiles.length === 0) fail("agent runtime-package scan: agent source tree is missing or empty");
+  {
+    const parseErrors = [];
+    const violations = [];
+    for (const file of agentFiles) {
+      const result = findAgentRuntimeValueImports(file, readFileSync(file, "utf8"));
+      parseErrors.push(...result.parseErrors);
+      violations.push(...result.violations);
+    }
+    for (const error of parseErrors) {
+      fail(`agent runtime-package scan: could not parse ${relative(repoRoot, error.file)}:${error.line}: ${error.message}`);
+    }
+    for (const violation of violations) {
+      fail(`agent runtime-package scan: ${violation.kind} ${violation.specifier} found in ${relative(repoRoot, violation.file)}:${violation.line}`);
+    }
+    if (parseErrors.length === 0 && violations.length === 0) {
+      pass(`agent runtime-package scan: no boring-bash or boring-sandbox value imports in ${agentFiles.length} file(s)`);
+    }
+  }
+
+  {
+    const agentPackageRoot = join(repoRoot, "packages", "agent");
+    const agentPackageJson = JSON.parse(readFileSync(join(agentPackageRoot, "package.json"), "utf8"));
+    const coreExport = agentPackageJson.exports?.["./core"];
+    const coreImport = typeof coreExport?.import === "string" ? coreExport.import : undefined;
+    if (coreExport?.types && coreImport?.startsWith("./dist/")) {
+      pass(`agent export ./core -> types=${coreExport.types} import=${coreImport}`);
+    } else {
+      fail("agent package missing complete dist-backed ./core export");
+    }
+    if (!agentPackageJson.files?.includes("dist")) {
+      fail("agent package files must publish dist for the ./core closure proof");
+    }
+    if (coreImport) ensureFreshAgentDist();
+  }
+
+  const docs = [
+    "docs/issues/391/runtime-refactor/02-boring-bash-environment.md",
+    "docs/issues/391/runtime-refactor/07-tests-review-acceptance.md",
+  ];
+  for (const doc of docs) {
+    const text = readFileSync(join(repoRoot, doc), "utf8");
+    if (/named filesystem bindings?/.test(text) && /\(filesystem, path\)/.test(text)) {
+      pass(`${doc} mentions named filesystem bindings and (filesystem, path) identity`);
+    } else {
+      fail(`${doc} is missing named filesystem binding / (filesystem, path) wording`);
+    }
   }
 }
 
 if (process.exitCode) process.exit(process.exitCode);
-pass("all PR1 boring-bash invariant checks completed");
+pass(negativeFixturesOnly
+  ? "all negative invariant fixtures completed"
+  : "all PR1 boring-bash invariant checks completed");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,6 +365,9 @@ importers:
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
+      esbuild:
+        specifier: ^0.25.12
+        version: 0.25.12
       postcss:
         specifier: ^8.5.15
         version: 8.5.16


### PR DESCRIPTION
## Summary

- recuts the valid tooling-only boundary from #547 on current main
- proves the published `@hachej/boring-agent/core` closure is Fastify-free, with the server export as a negative control
- rejects agent value imports from both `@hachej/boring-bash` and `@hachej/boring-sandbox` using a parse-failing AST scan
- adds only the direct esbuild dev dependency and lockfile importer entry needed by the artifact proof

## Scope boundary

No production source or pure/no-environment behavior is changed. The later mechanical core source relocation remains #575 work after the workspace-first production correction.

## Proof

- `git diff --check`
- two independent static reviews plus final structured autoreview: clean
- local tests/build/typecheck intentionally not run per owner direction; GitHub CI owns executable proof

## Review focus

1. published-export resolution and Fastify closure/negative-control semantics
2. type-only allowance versus value-import rejection across TS/JS/JSX forms
3. fresh-build ordering before artifact inspection

Estimated review time: 20-30 minutes.

Issue: #391
Supersedes the obsolete stacked implementation in #547.