### PR TITLE
feat(automation): add hosted persistence foundation

### DIFF
--- a/apps/full-app/package.json
+++ b/apps/full-app/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@hachej/boring-agent": "workspace:*",
+    "@hachej/boring-automation": "workspace:*",
     "@hachej/boring-bash": "workspace:*",
     "@hachej/boring-core": "workspace:*",
     "@hachej/boring-governance": "workspace:*",

--- a/apps/full-app/src/server/migrate.ts
+++ b/apps/full-app/src/server/migrate.ts
@@ -1,7 +1,8 @@
 import { runCoreMigrationsFromEnv } from '@hachej/boring-core/server'
+import { runBoringAutomationMigrations } from '@hachej/boring-automation/server'
 
 async function main() {
-  await runCoreMigrationsFromEnv({ log: console })
+  await runCoreMigrationsFromEnv({ log: console, additionalMigrations: [runBoringAutomationMigrations] })
 }
 
 main().catch((err) => {

--- a/docs/issues/590/plan.md
+++ b/docs/issues/590/plan.md
@@ -326,16 +326,16 @@ Confirmed by Slice 0:
 - hosted orchestration stays on the public host while sandbox/worker executes workspace operations;
 - first-pass token totals come from live usage events, not direct billing-ledger queries.
 
-Owner decisions still required before Slice 5:
+Owner decisions recorded before Slice 5:
 
-1. Should hosted migrations use app-owned explicit registration (recommended first) or a generic trusted-plugin migration contribution?
-2. Is scheduled usage billed to the automation owner (recommended) or a future workspace billing account?
-3. Which roles may create, edit, disable, delete, or reassign hosted automations?
+1. The deployment layer owns explicit app-registered plugin migrations.
+2. Scheduled usage is attributed to the automation creator.
+3. Hosted runs execute as and remain owned by the creator; if creator authorization is unavailable, execution fails closed.
 
 ## Loop Exit
 
 - Slice 0 state: complete; see `docs/issues/590/seam-spike.md`.
 - `ready-for-agent`: Slice 2 UI, Slice 3A generic dispatcher, then Slice 3B local manual executor.
-- `ready-for-human`: Slice 5 hosted migration/billing/role decisions.
-- First hosted blockers: owner decisions on migration registration, scheduled billing identity, and hosted automation role policy.
-- Next recommended work: Slice 2 can proceed independently; execution should start with Slice 3A.
+- `ready-for-human`: hosted actor composition and authenticated platform trigger design.
+- First remaining hosted blocker: compose the verified creator actor/store into full-app routes and executor, then design the service-principal trigger.
+- Next recommended work: finish hosted actor composition, then implement Slice 6 trigger authentication.

--- a/docs/issues/590/seam-spike.md
+++ b/docs/issues/590/seam-spike.md
@@ -257,9 +257,11 @@ Build CRUD + read-only history UI against Slice 1 routes. This does not depend o
 
 ### Slice 5 — Hosted persistence and actor composition
 
-**Status:** `ready-for-human`.
+**Status:** owner decisions recorded; implementation is split into hosted persistence infrastructure and actor composition.
 
-**Delivers after decision:** plugin-backed Postgres store, migration registration, verified actor resolver, owner reassignment/fail-closed behavior, and scheduled-occurrence lease.
+**Owner decisions:** deployment-owned explicit migration registration; scheduled usage is attributed to the automation creator; hosted runs execute as and remain owned by the creator and fail closed if creator authorization is unavailable.
+
+**Delivers:** plugin-backed Postgres store, migration registration, verified actor resolver, owner reassignment/fail-closed behavior, and scheduled-occurrence lease.
 
 ### Slice 6 — Hosted platform trigger
 
@@ -292,12 +294,12 @@ Manual validation for the next execution slice:
 - `Agent.send()` currently generates the Pi client nonce internally, so billing-ledger run correlation is not available to the plugin.
 - Live usage aggregation can remain incomplete after host crash.
 - Hosted migration registration has no current plugin precedent.
-- Scheduled-owner billing/reassignment needs owner approval.
+- Creator authorization must be re-checked at execution time; ownership changes must fail closed rather than silently impersonate a new user.
 - External trigger authentication must be designed before public deployment.
 
 ## Loop exit
 
 - `ready-for-agent`: Slice 2 UI, Slice 3A generic dispatcher, and then Slice 3B local manual executor.
-- `ready-for-human`: hosted migration registration choice, scheduled billing principal, and hosted automation role policy.
-- First blockers for hosted work: owner decisions on migration registration, billing identity, and hosted automation role policy.
+- `ready-for-human`: hosted actor composition and authenticated platform trigger design.
+- First remaining hosted blocker: compose the verified creator actor/store into full-app routes and executor, then design the service-principal trigger.
 - Next recommended implementation: Slice 2 UI can proceed independently; for execution, start Slice 3A.

--- a/docs/issues/590/todo.md
+++ b/docs/issues/590/todo.md
@@ -67,9 +67,9 @@ Canonical plan: [`plan.md`](./plan.md)
 - [x] Confirm first-pass token attribution from live Pi usage events.
 - [x] Record decisions in `docs/issues/590/seam-spike.md`.
 - [x] Re-plan execution and hosted slices from those findings.
-- [ ] Owner decision: app-owned explicit plugin migration registration vs generic trusted-plugin migrations.
-- [ ] Owner decision: scheduled usage billing owner vs future workspace billing account.
-- [ ] Owner decision: hosted automation role policy and reassignment permissions.
+- [x] Owner decision: deployment-owned explicit plugin migration registration.
+- [x] Owner decision: scheduled usage is attributed to the automation creator.
+- [x] Owner decision: hosted automation executes as and remains owned by the creator; fail closed if creator authorization is unavailable.
 
 ## Slice 2 — front UI
 
@@ -88,6 +88,8 @@ Canonical plan: [`plan.md`](./plan.md)
 - [x] Slice 4: pure five-field cron/IANA timezone due policy with current-minute/no-backfill and DST coverage.
 - [x] Externally invoked loopback-only folder-mode trigger; no hidden timer or hosted scheduling.
 - [x] Atomic scheduled-occurrence deduplication, overlap skips, restart reconciliation, safe result DTOs, and per-item failure isolation.
-- [ ] Slice 5: hosted persistence, verified actor composition, and duplicate-run lease after owner decisions.
+- [ ] Slice 5: hosted persistence, verified actor composition, and duplicate-run lease.
+  - [x] Deployment-owned migration callback and hosted Postgres schema/store with creator ownership columns.
+  - [ ] Compose verified creator actor resolver and hosted store into full-app routes/executor.
 - [ ] Slice 6: authenticated hosted platform trigger.
 - [ ] Final UI polish.

--- a/packages/core/src/server/db/migrate.ts
+++ b/packages/core/src/server/db/migrate.ts
@@ -28,8 +28,12 @@ function defaultMigrationsFolder(): string {
   return candidates[0]
 }
 
+export type CoreMigrationSql = postgres.Sql
+
 export interface RunMigrationsOptions {
   migrationsFolder?: string
+  /** Explicit app-owned migrations run under the same deployment lock. */
+  additionalMigrations?: Array<(sql: CoreMigrationSql) => Promise<void>>
 }
 
 export async function runMigrations(
@@ -51,6 +55,9 @@ export async function runMigrations(
 
       const migrationsFolder = options?.migrationsFolder ?? defaultMigrationsFolder()
       await migrate(db, { migrationsFolder })
+      for (const migration of options?.additionalMigrations ?? []) {
+        await migration(migrationClient)
+      }
     } finally {
       await db.execute(sql.raw(`SELECT pg_advisory_unlock(${ADVISORY_LOCK_ID})`))
     }

--- a/packages/core/src/server/migrations.ts
+++ b/packages/core/src/server/migrations.ts
@@ -1,7 +1,7 @@
 import { loadConfig, type LoadConfigOptions } from './config/index.js'
-import { runMigrations } from './db/index.js'
+import { runMigrations, type RunMigrationsOptions } from './db/index.js'
 
-export interface RunCoreMigrationsFromEnvOptions {
+export interface RunCoreMigrationsFromEnvOptions extends RunMigrationsOptions {
   loadConfigOptions?: LoadConfigOptions
   log?: Pick<Console, 'log'>
 }
@@ -10,6 +10,6 @@ export async function runCoreMigrationsFromEnv(
   options: RunCoreMigrationsFromEnvOptions = {},
 ): Promise<void> {
   const config = await loadConfig(options.loadConfigOptions)
-  await runMigrations(config)
+  await runMigrations(config, options)
   options.log?.log('migrations complete')
 }

--- a/plugins/boring-automation/README.md
+++ b/plugins/boring-automation/README.md
@@ -13,4 +13,6 @@ Current local CLI support includes:
 
 Executable model values use explicit `provider:model-id` syntax. Legacy unqualified values remain editable but fail safely when run until corrected.
 
-Execution is currently composed only for trusted local CLI folder mode. Scheduling has no background timer: user-owned cron/systemd may invoke `POST /api/v1/boring-automation/due` once per minute while the CLI server is running. Missed minutes are not backfilled. Hosted actor policy, hosted persistence, and hosted triggers remain intentionally unavailable pending later issue #590 slices.
+Execution is currently composed for trusted local CLI folder mode. Scheduling has no background timer: user-owned cron/systemd may invoke `POST /api/v1/boring-automation/due` once per minute while the CLI server is running. Missed minutes are not backfilled.
+
+Hosted persistence infrastructure is now available as an explicit deployment migration callback (`runBoringAutomationMigrations`) and an actor-bound `PostgresAutomationStore`. Full-app route/executor composition and authenticated hosted triggers remain separate follow-up work; hosted execution is not activated by this infrastructure alone.

--- a/plugins/boring-automation/package.json
+++ b/plugins/boring-automation/package.json
@@ -56,6 +56,7 @@
     "@hachej/boring-ui-kit": "workspace:*",
     "croner": "^10.0.1",
     "lucide-react": "^1.21.0",
+    "postgres": "^3.4.7",
     "zod": "^3.23.0"
   },
   "devDependencies": {

--- a/plugins/boring-automation/src/server/__tests__/migrations.test.ts
+++ b/plugins/boring-automation/src/server/__tests__/migrations.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it, vi } from "vitest"
+import { runBoringAutomationMigrations } from "../migrations"
+
+describe("runBoringAutomationMigrations", () => {
+  it("registers hosted automation tables and atomic lease indexes through deployment SQL", async () => {
+    const unsafe = vi.fn(async () => [])
+    await runBoringAutomationMigrations({ unsafe } as never)
+
+    const statements = unsafe.mock.calls.map((call) => String((call as unknown[])[0]))
+    expect(statements.some((statement) => statement.includes("CREATE TABLE IF NOT EXISTS boring_automation_automations"))).toBe(true)
+    expect(statements.some((statement) => statement.includes("owner_user_id text NOT NULL"))).toBe(true)
+    expect(statements.some((statement) => statement.includes("boring_automation_runs_active_once_idx"))).toBe(true)
+    expect(statements.some((statement) => statement.includes("boring_automation_runs_scheduled_once_idx"))).toBe(true)
+  })
+})

--- a/plugins/boring-automation/src/server/index.ts
+++ b/plugins/boring-automation/src/server/index.ts
@@ -56,6 +56,8 @@ export default function defaultBoringAutomationServerPlugin(
 export * from "./dueRunService"
 export * from "./fileStore"
 export * from "./manualRunExecutor"
+export * from "./migrations"
+export * from "./postgresStore"
 export * from "./routes"
 export * from "./store"
 export * from "../shared"

--- a/plugins/boring-automation/src/server/manualRunExecutor.ts
+++ b/plugins/boring-automation/src/server/manualRunExecutor.ts
@@ -13,6 +13,7 @@ export interface VerifiedAutomationActor {
 
 export interface ManualRunExecutorOptions {
   store: AutomationStore
+  storeForRequest?: (request: FastifyRequest, actor: VerifiedAutomationActor) => Promise<AutomationStore> | AutomationStore
   dispatcherResolver: WorkspaceAgentDispatcherResolver
   actorResolver: (request: FastifyRequest) => Promise<VerifiedAutomationActor> | VerifiedAutomationActor
   clock?: () => Date
@@ -45,11 +46,12 @@ export class ManualRunExecutor {
 
   async run(input: ManualRunInput): Promise<AutomationRun> {
     const actor = await this.options.actorResolver(input.request)
-    const automation = await this.options.store.getAutomation(input.automationId)
+    const store = await this.options.storeForRequest?.(input.request, actor) ?? this.options.store
+    const automation = await store.getAutomation(input.automationId)
     if (!automation) {
       throw new AutomationStoreError(BORING_AUTOMATION_ERROR_CODES.AUTOMATION_NOT_FOUND, `automation ${input.automationId} not found`)
     }
-    const promptSnapshot = await this.options.store.getPrompt(input.automationId)
+    const promptSnapshot = await store.getPrompt(input.automationId)
     const modelSnapshot = automation.model
     const model = parseAutomationModel(modelSnapshot)
     const createdAt = this.nowIso()
@@ -58,7 +60,7 @@ export class ManualRunExecutor {
     if (trigger === "scheduled" && !scheduledFor) {
       throw new AutomationStoreError(BORING_AUTOMATION_ERROR_CODES.INVALID_BODY, "scheduled runs require scheduledFor")
     }
-    const run = await this.options.store.beginRun({
+    const run = await store.beginRun({
       automationId: automation.id,
       trigger,
       scheduledFor,
@@ -77,7 +79,7 @@ export class ManualRunExecutor {
     try {
       const dispatcher = await this.options.dispatcherResolver.resolve(actor, { request: input.request })
       startedAt = this.nowIso()
-      current = await this.options.store.updateRunLifecycle(run.id, {
+      current = await store.updateRunLifecycle(run.id, {
         status: "running",
         startedAt,
         sessionId: null,
@@ -92,7 +94,7 @@ export class ManualRunExecutor {
         const eventSessionId = sessionIdFromEvent(event)
         if (!sessionId && eventSessionId) {
           sessionId = eventSessionId
-          current = await this.options.store.updateRunLifecycle(run.id, { sessionId })
+          current = await store.updateRunLifecycle(run.id, { sessionId })
         }
         aggregateUsage(usage, event)
         const outcome = terminalOutcomeFromEvent(event)
@@ -103,7 +105,7 @@ export class ManualRunExecutor {
       }
 
       const completedAt = this.nowIso()
-      return await this.finalizeRun(run.id, {
+      return await this.finalizeRun(store, run.id, {
         current,
         sessionId,
         startedAt,
@@ -116,7 +118,7 @@ export class ManualRunExecutor {
       const completedAt = this.nowIso()
       const cancelled = isCancellationError(error)
       const status = terminalStatus ?? (cancelled ? "cancelled" : "failed")
-      return await this.finalizeRun(run.id, {
+      return await this.finalizeRun(store, run.id, {
         current,
         sessionId,
         startedAt,
@@ -128,7 +130,7 @@ export class ManualRunExecutor {
     }
   }
 
-  private async finalizeRun(runId: string, input: {
+  private async finalizeRun(store: AutomationStore, runId: string, input: {
     current: AutomationRun
     sessionId: string | null
     startedAt: string | null
@@ -137,7 +139,7 @@ export class ManualRunExecutor {
     error: string | null
     usage: UsageAccumulator
   }): Promise<AutomationRun> {
-    return await this.options.store.updateRunLifecycle(runId, {
+    return await store.updateRunLifecycle(runId, {
       status: input.status,
       completedAt: input.completedAt,
       durationMs: durationMs(input.startedAt ?? input.current.createdAt, input.completedAt),

--- a/plugins/boring-automation/src/server/migrations.ts
+++ b/plugins/boring-automation/src/server/migrations.ts
@@ -1,0 +1,63 @@
+import type postgres from "postgres"
+
+/** Deployment-owned hosted schema registration for the automation plugin. */
+export async function runBoringAutomationMigrations(sql: postgres.Sql): Promise<void> {
+  await sql.unsafe(`
+    CREATE TABLE IF NOT EXISTS boring_automation_automations (
+      id uuid PRIMARY KEY,
+      workspace_id text NOT NULL,
+      owner_user_id text NOT NULL,
+      title text NOT NULL,
+      enabled boolean NOT NULL DEFAULT true,
+      cron text NOT NULL,
+      timezone text NOT NULL,
+      model text NOT NULL,
+      prompt text NOT NULL DEFAULT '',
+      created_at timestamptz NOT NULL,
+      updated_at timestamptz NOT NULL
+    )
+  `)
+  await sql.unsafe(`
+    CREATE INDEX IF NOT EXISTS boring_automation_automations_owner_idx
+      ON boring_automation_automations (workspace_id, owner_user_id)
+  `)
+  await sql.unsafe(`
+    CREATE TABLE IF NOT EXISTS boring_automation_runs (
+      id uuid PRIMARY KEY,
+      automation_id uuid NOT NULL REFERENCES boring_automation_automations(id) ON DELETE CASCADE,
+      workspace_id text NOT NULL,
+      owner_user_id text NOT NULL,
+      session_id text,
+      status text NOT NULL,
+      trigger text NOT NULL,
+      scheduled_for timestamptz,
+      started_at timestamptz,
+      completed_at timestamptz,
+      duration_ms integer,
+      input_tokens integer,
+      output_tokens integer,
+      total_tokens integer,
+      prompt_snapshot text NOT NULL,
+      model_snapshot text NOT NULL,
+      error text,
+      created_at timestamptz NOT NULL,
+      updated_at timestamptz NOT NULL,
+      CONSTRAINT boring_automation_runs_status_check CHECK (status IN ('queued', 'running', 'succeeded', 'failed', 'cancelled')),
+      CONSTRAINT boring_automation_runs_trigger_check CHECK (trigger IN ('manual', 'scheduled'))
+    )
+  `)
+  await sql.unsafe(`
+    CREATE INDEX IF NOT EXISTS boring_automation_runs_automation_idx
+      ON boring_automation_runs (automation_id, created_at DESC)
+  `)
+  await sql.unsafe(`
+    CREATE UNIQUE INDEX IF NOT EXISTS boring_automation_runs_active_once_idx
+      ON boring_automation_runs (automation_id)
+      WHERE status IN ('queued', 'running')
+  `)
+  await sql.unsafe(`
+    CREATE UNIQUE INDEX IF NOT EXISTS boring_automation_runs_scheduled_once_idx
+      ON boring_automation_runs (automation_id, scheduled_for)
+      WHERE trigger = 'scheduled' AND scheduled_for IS NOT NULL
+  `)
+}

--- a/plugins/boring-automation/src/server/postgresStore.ts
+++ b/plugins/boring-automation/src/server/postgresStore.ts
@@ -1,0 +1,173 @@
+import { randomUUID } from "node:crypto"
+import type postgres from "postgres"
+import type { Automation, AutomationCreate, AutomationPatch, AutomationRun, AutomationRunBegin, AutomationRunLifecyclePatch } from "../shared/types"
+import { automationNotFound, runAlreadyActive, runAlreadyRecorded, runNotFound, type AutomationStore } from "./store"
+
+export interface HostedAutomationActor {
+  workspaceId: string
+  userId: string
+}
+
+type Sql = postgres.Sql
+
+type AutomationRow = {
+  id: string; title: string; enabled: boolean; cron: string; timezone: string; model: string; prompt: string; created_at: Date | string; updated_at: Date | string
+}
+type RunRow = {
+  id: string; automation_id: string; session_id: string | null; status: AutomationRun["status"]; trigger: AutomationRun["trigger"]; scheduled_for: Date | string | null; started_at: Date | string | null; completed_at: Date | string | null; duration_ms: number | null; input_tokens: number | null; output_tokens: number | null; total_tokens: number | null; prompt_snapshot: string; model_snapshot: string; error: string | null; created_at: Date | string; updated_at: Date | string
+}
+
+/** Hosted store bound to a verified workspace/user pair; every query is scoped by both. */
+export class PostgresAutomationStore implements AutomationStore {
+  constructor(private readonly sql: Sql, private readonly actor: HostedAutomationActor, private readonly clock = () => new Date()) {}
+
+  async listAutomations(): Promise<Automation[]> {
+    const rows = await this.sql<AutomationRow[]>`
+      SELECT id, title, enabled, cron, timezone, model, prompt, created_at, updated_at
+      FROM boring_automation_automations
+      WHERE workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId}
+      ORDER BY created_at, id
+    `
+    return rows.map(toAutomation)
+  }
+
+  async getAutomation(id: string): Promise<Automation | null> {
+    const rows = await this.sql<AutomationRow[]>`
+      SELECT id, title, enabled, cron, timezone, model, prompt, created_at, updated_at
+      FROM boring_automation_automations
+      WHERE id = ${id} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId}
+    `
+    return rows[0] ? toAutomation(rows[0]) : null
+  }
+
+  async createAutomation(input: AutomationCreate): Promise<Automation> {
+    const now = this.clock().toISOString()
+    const id = randomUUID()
+    const prompt = input.prompt ?? ""
+    const rows = await this.sql<AutomationRow[]>`
+      INSERT INTO boring_automation_automations (id, workspace_id, owner_user_id, title, enabled, cron, timezone, model, prompt, created_at, updated_at)
+      VALUES (${id}, ${this.actor.workspaceId}, ${this.actor.userId}, ${input.title}, ${input.enabled ?? true}, ${input.cron}, ${input.timezone}, ${input.model}, ${prompt}, ${now}, ${now})
+      RETURNING id, title, enabled, cron, timezone, model, prompt, created_at, updated_at
+    `
+    return toAutomation(rows[0]!)
+  }
+
+  async updateAutomation(id: string, patch: AutomationPatch): Promise<Automation> {
+    const current = await this.getAutomation(id)
+    if (!current) throw automationNotFound(id)
+    const next = { ...current, ...patch, updatedAt: this.clock().toISOString() }
+    const rows = await this.sql<AutomationRow[]>`
+      UPDATE boring_automation_automations
+      SET title = ${next.title}, enabled = ${next.enabled}, cron = ${next.cron}, timezone = ${next.timezone}, model = ${next.model}, updated_at = ${next.updatedAt}
+      WHERE id = ${id} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId}
+      RETURNING id, title, enabled, cron, timezone, model, prompt, created_at, updated_at
+    `
+    if (!rows[0]) throw automationNotFound(id)
+    return toAutomation(rows[0])
+  }
+
+  async deleteAutomation(id: string): Promise<void> {
+    const result = await this.sql`
+      DELETE FROM boring_automation_automations
+      WHERE id = ${id} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId}
+    `
+    if (result.count === 0) throw automationNotFound(id)
+  }
+
+  async getPrompt(automationId: string): Promise<string> {
+    const automation = await this.getAutomation(automationId)
+    if (!automation) throw automationNotFound(automationId)
+    const rows = await this.sql<{ prompt: string }[]>`
+      SELECT prompt FROM boring_automation_automations
+      WHERE id = ${automationId} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId}
+    `
+    return rows[0]?.prompt ?? ""
+  }
+
+  async updatePrompt(automationId: string, body: string): Promise<void> {
+    const result = await this.sql`
+      UPDATE boring_automation_automations SET prompt = ${body}, updated_at = ${this.clock().toISOString()}
+      WHERE id = ${automationId} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId}
+    `
+    if (result.count === 0) throw automationNotFound(automationId)
+  }
+
+  async reconcileOrphanedRuns(automationId: string): Promise<void> {
+    await this.sql`
+      UPDATE boring_automation_runs
+      SET status = 'failed', completed_at = ${this.clock().toISOString()}, error = 'Automation host restarted before the run completed', updated_at = ${this.clock().toISOString()}
+      WHERE automation_id = ${automationId} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId} AND status IN ('queued', 'running')
+    `
+  }
+
+  async beginRun(input: AutomationRunBegin): Promise<AutomationRun> {
+    const automation = await this.getAutomation(input.automationId)
+    if (!automation) throw automationNotFound(input.automationId)
+    const active = await this.sql<{ id: string }[]>`
+      SELECT id FROM boring_automation_runs
+      WHERE automation_id = ${input.automationId} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId} AND status IN ('queued', 'running')
+      LIMIT 1
+    `
+    if (active[0]) throw runAlreadyActive(input.automationId)
+    try {
+      const now = input.createdAt ?? this.clock().toISOString()
+      const id = randomUUID()
+      const rows = await this.sql<RunRow[]>`
+        INSERT INTO boring_automation_runs (id, automation_id, workspace_id, owner_user_id, session_id, status, trigger, scheduled_for, started_at, completed_at, duration_ms, input_tokens, output_tokens, total_tokens, prompt_snapshot, model_snapshot, error, created_at, updated_at)
+        VALUES (${id}, ${input.automationId}, ${this.actor.workspaceId}, ${this.actor.userId}, NULL, 'queued', ${input.trigger}, ${input.scheduledFor ?? null}, NULL, NULL, NULL, NULL, NULL, NULL, ${input.promptSnapshot}, ${input.modelSnapshot}, NULL, ${now}, ${now})
+        RETURNING *
+      `
+      return toRun(rows[0]!)
+    } catch (error) {
+      if (isUniqueViolation(error)) {
+        if (constraintName(error) === "boring_automation_runs_active_once_idx") throw runAlreadyActive(input.automationId)
+        if (input.trigger === "scheduled" && input.scheduledFor) throw runAlreadyRecorded(input.automationId, input.scheduledFor)
+      }
+      throw error
+    }
+  }
+
+  async updateRunLifecycle(runId: string, patch: AutomationRunLifecyclePatch): Promise<AutomationRun> {
+    const current = await this.findRun(runId)
+    if (!current) throw runNotFound(runId)
+    const next = { ...current, ...patch, updatedAt: this.clock().toISOString() }
+    const rows = await this.sql<RunRow[]>`
+      UPDATE boring_automation_runs
+      SET session_id = ${next.sessionId}, status = ${next.status}, started_at = ${next.startedAt}, completed_at = ${next.completedAt}, duration_ms = ${next.durationMs}, input_tokens = ${next.inputTokens}, output_tokens = ${next.outputTokens}, total_tokens = ${next.totalTokens}, error = ${next.error}, updated_at = ${next.updatedAt}
+      WHERE id = ${runId} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId}
+      RETURNING *
+    `
+    if (!rows[0]) throw runNotFound(runId)
+    return toRun(rows[0])
+  }
+
+  async listRuns(automationId: string): Promise<AutomationRun[]> {
+    const rows = await this.sql<RunRow[]>`
+      SELECT * FROM boring_automation_runs
+      WHERE automation_id = ${automationId} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId}
+      ORDER BY created_at DESC, id DESC
+    `
+    return rows.map(toRun)
+  }
+
+  private async findRun(runId: string): Promise<AutomationRun | null> {
+    const rows = await this.sql<RunRow[]>`
+      SELECT * FROM boring_automation_runs
+      WHERE id = ${runId} AND workspace_id = ${this.actor.workspaceId} AND owner_user_id = ${this.actor.userId}
+    `
+    return rows[0] ? toRun(rows[0]) : null
+  }
+}
+
+function toAutomation(row: AutomationRow): Automation {
+  return { id: row.id, title: row.title, enabled: row.enabled, cron: row.cron, timezone: row.timezone, model: row.model, promptRef: `hosted:${row.id}`, createdAt: iso(row.created_at), updatedAt: iso(row.updated_at) }
+}
+
+function toRun(row: RunRow): AutomationRun {
+  return { id: row.id, automationId: row.automation_id, sessionId: row.session_id, status: row.status, trigger: row.trigger, scheduledFor: nullableIso(row.scheduled_for), startedAt: nullableIso(row.started_at), completedAt: nullableIso(row.completed_at), durationMs: row.duration_ms, inputTokens: row.input_tokens, outputTokens: row.output_tokens, totalTokens: row.total_tokens, promptSnapshot: row.prompt_snapshot, modelSnapshot: row.model_snapshot, error: row.error, createdAt: iso(row.created_at), updatedAt: iso(row.updated_at) }
+}
+
+function iso(value: Date | string): string { return value instanceof Date ? value.toISOString() : new Date(value).toISOString() }
+function nullableIso(value: Date | string | null): string | null { return value === null ? null : iso(value) }
+function isUniqueViolation(error: unknown): boolean { return Boolean(error && typeof error === "object" && "code" in error && (error as { code?: unknown }).code === "23505") }
+function constraintName(error: unknown): string | undefined { return error && typeof error === "object" && "constraint_name" in error ? String((error as { constraint_name?: unknown }).constraint_name) : undefined }

--- a/plugins/boring-automation/src/server/routes.ts
+++ b/plugins/boring-automation/src/server/routes.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance, FastifyReply } from "fastify"
+import type { FastifyInstance, FastifyReply, FastifyRequest } from "fastify"
 import { ZodError, type ZodSchema } from "zod"
 import {
   AutomationCreateSchema,
@@ -14,6 +14,7 @@ import { AutomationStoreError, automationNotFound, type AutomationStore } from "
 
 export interface AutomationRoutesOptions {
   store: AutomationStore
+  storeForRequest?: (request: FastifyRequest) => Promise<AutomationStore> | AutomationStore
   manualRunExecutor?: Pick<ManualRunExecutor, "run">
   dueRunService?: Pick<DueRunService, "runDue">
 }
@@ -21,7 +22,7 @@ export interface AutomationRoutesOptions {
 export async function automationRoutes(app: FastifyInstance, opts: AutomationRoutesOptions): Promise<void> {
   app.get(`${BORING_AUTOMATION_ROUTE_PREFIX}/automations`, async (_request, reply) => {
     try {
-      return { ok: true, automations: await opts.store.listAutomations() }
+      return { ok: true, automations: await (await resolveStore(opts, _request)).listAutomations() }
     } catch (cause) {
       return sendError(reply, cause)
     }
@@ -29,7 +30,7 @@ export async function automationRoutes(app: FastifyInstance, opts: AutomationRou
 
   app.post(`${BORING_AUTOMATION_ROUTE_PREFIX}/automations`, async (request, reply) => {
     try {
-      const automation = await opts.store.createAutomation(parseBody(AutomationCreateSchema, request.body))
+      const automation = await (await resolveStore(opts, request)).createAutomation(parseBody(AutomationCreateSchema, request.body))
       return reply.status(201).send({ ok: true, automation })
     } catch (cause) {
       return sendError(reply, cause)
@@ -39,7 +40,7 @@ export async function automationRoutes(app: FastifyInstance, opts: AutomationRou
   app.get(`${BORING_AUTOMATION_ROUTE_PREFIX}/automations/:id`, async (request, reply) => {
     try {
       const { id } = parseParams(IdParamsSchema, request.params)
-      const automation = await opts.store.getAutomation(id)
+      const automation = await (await resolveStore(opts, request)).getAutomation(id)
       if (!automation) throw automationNotFound(id)
       return { ok: true, automation }
     } catch (cause) {
@@ -50,7 +51,7 @@ export async function automationRoutes(app: FastifyInstance, opts: AutomationRou
   app.patch(`${BORING_AUTOMATION_ROUTE_PREFIX}/automations/:id`, async (request, reply) => {
     try {
       const { id } = parseParams(IdParamsSchema, request.params)
-      const automation = await opts.store.updateAutomation(id, parseBody(AutomationPatchSchema, request.body))
+      const automation = await (await resolveStore(opts, request)).updateAutomation(id, parseBody(AutomationPatchSchema, request.body))
       return { ok: true, automation }
     } catch (cause) {
       return sendError(reply, cause)
@@ -60,7 +61,7 @@ export async function automationRoutes(app: FastifyInstance, opts: AutomationRou
   app.delete(`${BORING_AUTOMATION_ROUTE_PREFIX}/automations/:id`, async (request, reply) => {
     try {
       const { id } = parseParams(IdParamsSchema, request.params)
-      await opts.store.deleteAutomation(id)
+      await (await resolveStore(opts, request)).deleteAutomation(id)
       return reply.status(204).send()
     } catch (cause) {
       return sendError(reply, cause)
@@ -70,7 +71,7 @@ export async function automationRoutes(app: FastifyInstance, opts: AutomationRou
   app.get(`${BORING_AUTOMATION_ROUTE_PREFIX}/automations/:id/prompt`, async (request, reply) => {
     try {
       const { id } = parseParams(IdParamsSchema, request.params)
-      return { ok: true, prompt: await opts.store.getPrompt(id) }
+      return { ok: true, prompt: await (await resolveStore(opts, request)).getPrompt(id) }
     } catch (cause) {
       return sendError(reply, cause)
     }
@@ -80,7 +81,7 @@ export async function automationRoutes(app: FastifyInstance, opts: AutomationRou
     try {
       const { id } = parseParams(IdParamsSchema, request.params)
       const { prompt } = parseBody(PromptUpdateSchema, request.body)
-      await opts.store.updatePrompt(id, prompt)
+      await (await resolveStore(opts, request)).updatePrompt(id, prompt)
       return { ok: true }
     } catch (cause) {
       return sendError(reply, cause)
@@ -126,11 +127,15 @@ export async function automationRoutes(app: FastifyInstance, opts: AutomationRou
   app.get(`${BORING_AUTOMATION_ROUTE_PREFIX}/automations/:id/runs`, async (request, reply) => {
     try {
       const { id } = parseParams(IdParamsSchema, request.params)
-      return { ok: true, runs: await opts.store.listRuns(id) }
+      return { ok: true, runs: await (await resolveStore(opts, request)).listRuns(id) }
     } catch (cause) {
       return sendError(reply, cause)
     }
   })
+}
+
+async function resolveStore(opts: AutomationRoutesOptions, request: FastifyRequest): Promise<AutomationStore> {
+  return await opts.storeForRequest?.(request) ?? opts.store
 }
 
 function parseBody<T>(schema: ZodSchema<T>, body: unknown): T {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@hachej/boring-agent':
         specifier: workspace:*
         version: link:../../packages/agent
+      '@hachej/boring-automation':
+        specifier: workspace:*
+        version: link:../../plugins/boring-automation
       '@hachej/boring-bash':
         specifier: workspace:*
         version: link:../../packages/boring-bash
@@ -361,7 +364,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
@@ -388,10 +391,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.2
-        version: 8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+        version: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/agent/examples/with-custom-tool:
     devDependencies:
@@ -1141,6 +1144,9 @@ importers:
       lucide-react:
         specifier: ^1.21.0
         version: 1.23.0(react@19.2.7)
+      postgres:
+        specifier: ^3.4.7
+        version: 3.4.9
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -1165,7 +1171,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
-        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       fastify:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1186,7 +1192,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   plugins/boring-governance:
     dependencies:
@@ -13540,7 +13546,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vitejs/plugin-react@4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -13548,7 +13554,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13580,13 +13586,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -17786,21 +17792,6 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.16
-      rolldown: 1.1.5
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 22.20.1
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.23.0
-      yaml: 2.9.0
-
   vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -17845,10 +17836,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -17865,7 +17856,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
Implements the first hosted portion of issue #590 using the owner decisions recorded on the issue.

## Decisions applied
- Deployment layer owns explicit plugin migration registration.
- Scheduled usage is attributed to the automation creator.
- Hosted execution must remain creator-owned and fail closed if creator authorization is unavailable.

## What changed
- Core migration runner accepts explicit app-owned callbacks under the existing advisory lock.
- Full-app deployment migration entrypoint registers `runBoringAutomationMigrations`.
- Hosted automation tables persist workspace/creator ownership and run snapshots.
- `PostgresAutomationStore` scopes every query to verified `{workspaceId,userId}` and uses unique active/scheduled occurrence indexes.
- Routes and manual executor now support request-scoped store resolution.
- Updated issue plan/checklist and README.

This PR intentionally does not activate hosted routes/execution or add a platform trigger. Verified creator actor composition remains the next Slice 5 step.

## Proof
- `pnpm --filter @hachej/boring-automation typecheck`
- `pnpm --filter @hachej/boring-automation test` — 74 tests passed
- `pnpm --filter @hachej/boring-core typecheck`
- `pnpm --filter @hachej/boring-core build`
- `pnpm --filter @hachej/boring-automation build`
- `pnpm --filter full-app typecheck`
- `git diff --check`

Note: agent/workspace rebuild required first to refresh local workspace artifacts; the final package/core/full-app checks passed. CI is the authoritative full build.
