### PR TITLE
feat: export tenant worker runtime and MCP server glue from packages

### DIFF
--- a/apps/full-app/Dockerfile
+++ b/apps/full-app/Dockerfile
@@ -155,7 +155,6 @@ COPY --from=build /app/packages/agent/dist/ packages/agent/dist/
 COPY --from=build /app/packages/agent/package.json packages/agent/package.json
 COPY --from=build /app/packages/agent/node_modules/ packages/agent/node_modules/
 COPY --from=build /app/apps/full-app/dist/server/agent-worker.js worker/agent-worker.js
-COPY --from=build /app/apps/full-app/dist/server/worker/ worker/worker/
 COPY apps/full-app/docker/worker-entrypoint.sh /usr/local/bin/worker-entrypoint
 RUN chmod 0755 /usr/local/bin/worker-entrypoint
 

--- a/apps/full-app/package.json
+++ b/apps/full-app/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-mcp build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-governance build && NODE_ENV=development tsx src/server/dev.ts",
-    "build": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-mcp build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-governance build && tsx ../../packages/workspace/scripts/build-app.mts",
+    "dev": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-mcp build && pnpm --filter @hachej/boring-governance build && NODE_ENV=development tsx src/server/dev.ts",
+    "build": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-mcp build && pnpm --filter @hachej/boring-governance build && tsx ../../packages/workspace/scripts/build-app.mts",
     "start": "NODE_ENV=production node dist/server/main.js",
     "start:worker": "NODE_ENV=production node dist/server/agent-worker.js",
     "migrate": "tsx src/server/migrate.ts",

--- a/apps/full-app/src/server/agent-worker.ts
+++ b/apps/full-app/src/server/agent-worker.ts
@@ -1,13 +1,7 @@
-import Fastify from 'fastify'
-
-import { loadWorkerConfig } from './worker/config.js'
-import { registerWorkerRoutes } from './worker/routes.js'
+import { createWorkerServer } from '@hachej/boring-agent/server/worker'
 
 export async function createAgentWorkerApp() {
-  const config = loadWorkerConfig()
-  const app = Fastify({ logger: true, bodyLimit: 20 * 1024 * 1024 })
-  await registerWorkerRoutes(app, config)
-  return { app, config }
+  return createWorkerServer()
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/apps/full-app/src/server/boringMcp.ts
+++ b/apps/full-app/src/server/boringMcp.ts
@@ -1,340 +1,76 @@
-import { createHash } from 'node:crypto'
 import type { FastifyRequest } from 'fastify'
-import { HttpError, ERROR_CODES, type ErrorCode } from '@hachej/boring-core/shared'
 import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
-import { withUserSettingsWriteLock } from '@hachej/boring-core/server'
 import {
-  BORING_MCP_PLUGIN_ID,
-  DEFAULT_MCP_PROVIDER_TEMPLATES,
-  InMemoryMcpRateBudgetGate,
-  MCP_ERROR_CODES,
-  McpError,
-  createBoringMcpAgentTools,
+  boringMcpAgentSessionNamespace,
+  createBoringMcpAppAgentTools,
+  createBoringMcpAppAgentToolsForRequest,
+  createBoringMcpManagedConnectorAdapter,
   createBoringMcpServerPlugin,
-  createBoringMcpSourceHandlers,
-  createComposioManagedConnectorProvider,
-  createComposioMcpTransport,
-  createLegacyManagedConnectorSourceId,
-  createManagedConnectorAdapter,
-  createManagedConnectorSourceId,
-  createMcpSourceStatusPayload,
+  createManagedConnectorSecretResolver,
+  createUserSettingsMcpSourceRegistry,
+  readBoringMcpServerConfig,
+  registerBoringMcpRoutes,
+  type BoringMcpBindingConfig,
+  type BoringMcpServerRuntimeConfig,
   type ManagedConnectorAdapter,
   type ManagedConnectorConfig,
   type ManagedConnectorProvider,
-  type ManagedConnectorSecret,
   type ManagedConnectorSecretResolver,
   type ManagedConnectorSourceRegistry,
   type McpActor,
-  type McpProviderId,
-  type McpSource,
   type McpTransportClient,
 } from '@hachej/boring-mcp/server'
 import type { AgentTool } from '@hachej/boring-workspace'
 
-const DEFAULT_MAX_READONLY_INPUT_BYTES = 64 * 1024
-const MAX_READONLY_INPUT_BYTES = 1024 * 1024
-const SOURCE_CONNECT_RATE_LIMIT = { max: 10, timeWindow: '1 minute' } as const
-const SOURCE_ACTION_RATE_LIMIT = { max: 60, timeWindow: '1 minute' } as const
-
-export interface FullAppBoringMcpServerConfig {
-  enabled: boolean
-  composioApiKeyConfigured: boolean
-  maxReadonlyInputBytes: number
-}
-
-function parseReadonlyInputLimit(value: string | undefined): number {
-  if (!value) return DEFAULT_MAX_READONLY_INPUT_BYTES
-  const parsed = Number(value)
-  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_READONLY_INPUT_BYTES) return DEFAULT_MAX_READONLY_INPUT_BYTES
-  return parsed
-}
-
-export function readFullAppBoringMcpServerConfig(env: NodeJS.ProcessEnv = process.env): FullAppBoringMcpServerConfig {
-  const productionEnabled = env.BORING_MCP_PROD_ENABLED === '1'
-  const nonProductionEnabled = env.BORING_MCP_ENABLED !== '0'
-  return {
-    enabled: env.NODE_ENV === 'production' ? productionEnabled : nonProductionEnabled,
-    composioApiKeyConfigured: Boolean(env.COMPOSIO_API_KEY?.trim()),
-    maxReadonlyInputBytes: parseReadonlyInputLimit(env.BORING_MCP_MAX_READONLY_INPUT_BYTES),
-  }
-}
-
+// full-app supplies only its deployment-specific configuration; all glue lives
+// in @hachej/boring-mcp/server so tenant deployments import instead of copy.
 const FULL_APP_MANAGED_CONNECTOR_CONFIGS: readonly ManagedConnectorConfig[] = [
   { provider: 'notion', displayName: 'Notion', toolkitId: 'notion', connectUrlOrigins: ['https://app.composio.dev', 'https://connect.composio.dev'] },
   { provider: 'airtable', displayName: 'Airtable', toolkitId: 'airtable', connectUrlOrigins: ['https://app.composio.dev', 'https://connect.composio.dev'] },
 ]
 
+const FULL_APP_BORING_MCP_CONFIG: BoringMcpBindingConfig = {
+  connectorConfigs: FULL_APP_MANAGED_CONNECTOR_CONFIGS,
+  redactionCanaries: ['cmp_full_app_canary'],
+  clientName: 'boring-full-app-mcp',
+  clientVersion: '0.0.0',
+}
+
+export type FullAppBoringMcpServerConfig = BoringMcpServerRuntimeConfig
+
+export function readFullAppBoringMcpServerConfig(env: NodeJS.ProcessEnv = process.env): FullAppBoringMcpServerConfig {
+  return readBoringMcpServerConfig(env, { secretEnvVars: FULL_APP_BORING_MCP_CONFIG.secretEnvVars })
+}
+
 export function createFullAppManagedConnectorSecretResolver(
   env: NodeJS.ProcessEnv = process.env,
   configs: readonly ManagedConnectorConfig[] = FULL_APP_MANAGED_CONNECTOR_CONFIGS,
 ): ManagedConnectorSecretResolver {
-  const supportedProviders = new Set<McpProviderId>(configs.map((config) => config.provider))
-  return {
-    async resolveSecret(provider: McpProviderId): Promise<ManagedConnectorSecret> {
-      if (!supportedProviders.has(provider)) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, `Unsupported MCP provider: ${provider}`, { reason: 'unsupported_provider' })
-      const value = env.COMPOSIO_API_KEY?.trim()
-      if (!value) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, 'COMPOSIO_API_KEY is not configured')
-      return { storage: 'server-env', value }
-    },
-  }
+  return createManagedConnectorSecretResolver({ env, configs, secretEnvVars: FULL_APP_BORING_MCP_CONFIG.secretEnvVars })
 }
-
-const FULL_APP_MCP_REDACTION_CANARIES = ['cmp_full_app_canary'] as const
 
 export function createFullAppManagedConnectorAdapter(options: {
   env?: NodeJS.ProcessEnv
   registry: ManagedConnectorSourceRegistry
   provider?: ManagedConnectorProvider
 }): ManagedConnectorAdapter {
-  return createManagedConnectorAdapter({
+  return createBoringMcpManagedConnectorAdapter({
+    config: FULL_APP_BORING_MCP_CONFIG,
     registry: options.registry,
-    provider: options.provider ?? createComposioManagedConnectorProvider(),
-    secretResolver: createFullAppManagedConnectorSecretResolver(options.env, FULL_APP_MANAGED_CONNECTOR_CONFIGS),
-    templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
-    redactionCanaries: FULL_APP_MCP_REDACTION_CANARIES,
-    configs: FULL_APP_MANAGED_CONNECTOR_CONFIGS,
+    provider: options.provider,
+    env: options.env,
   })
-}
-
-const USER_SETTINGS_MCP_SOURCES_KEY = '__serverBoringMcpSourcesV1'
-const WORKSPACE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
-
-function requestUserId(request: FastifyRequest | undefined): string | undefined {
-  const user = request?.user
-  return typeof user?.id === 'string' && user.id.trim() ? user.id : undefined
-}
-
-function shortHash(value: string): string {
-  return createHash('sha256').update(value).digest('hex').slice(0, 16)
-}
-
-function safeSessionNamespaceSegment(value: string): string {
-  return value.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 80) || 'workspace'
 }
 
 export function fullAppAgentSessionNamespace(ctx: { workspaceId: string; request?: FastifyRequest; userId?: string }): string {
-  const workspaceSegment = safeSessionNamespaceSegment(ctx.workspaceId)
-  const userId = ctx.userId?.trim() || requestUserId(ctx.request)
-  return `${workspaceSegment}_user_${userId ? shortHash(userId) : 'anonymous'}`
+  return boringMcpAgentSessionNamespace(ctx)
 }
 
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
-}
-
-function parseString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined
-}
-
-function validateWorkspaceId(value: unknown, requestId: string): string {
-  const workspaceId = parseString(value)
-  if (!workspaceId || !WORKSPACE_ID_PATTERN.test(workspaceId)) {
-    throw new HttpError({ status: 400, code: ERROR_CODES.VALIDATION_FAILED, message: 'Invalid workspace id', requestId })
-  }
-  return workspaceId
-}
-
-function routeError(status: number, code: ErrorCode, message: string, requestId: string): HttpError {
-  return new HttpError({ status, code, message, requestId })
-}
-
-function mcpHttpStatus(error: McpError): { status: number; code: ErrorCode } {
-  switch (error.code) {
-    case MCP_ERROR_CODES.SOURCE_NOT_FOUND:
-    case MCP_ERROR_CODES.TOOL_NOT_FOUND:
-      return { status: 404, code: ERROR_CODES.NOT_FOUND }
-    case MCP_ERROR_CODES.SOURCE_FORBIDDEN:
-      return { status: 403, code: ERROR_CODES.FORBIDDEN }
-    case MCP_ERROR_CODES.INPUT_INVALID:
-    case MCP_ERROR_CODES.RESOURCE_URI_INVALID:
-    case MCP_ERROR_CODES.PROVIDER_TOOL_DRIFT:
-    case MCP_ERROR_CODES.TOOL_NOT_ALLOWED:
-      return { status: 400, code: ERROR_CODES.VALIDATION_FAILED }
-    case MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID:
-      return asRecord(error.details).reason === 'unsupported_provider'
-        ? { status: 400, code: ERROR_CODES.VALIDATION_FAILED }
-        : { status: 503, code: ERROR_CODES.CONFIG_VALIDATION_FAILED }
-    case MCP_ERROR_CODES.SOURCE_UNAVAILABLE:
-      return { status: 409, code: ERROR_CODES.VALIDATION_FAILED }
-    case MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED:
-      return { status: 413, code: ERROR_CODES.VALIDATION_FAILED }
-    case MCP_ERROR_CODES.PROVIDER_TIMEOUT:
-      return { status: 504, code: ERROR_CODES.INTERNAL_ERROR }
-    case MCP_ERROR_CODES.PROVIDER_ERROR:
-      return { status: 502, code: ERROR_CODES.INTERNAL_ERROR }
-    case MCP_ERROR_CODES.SECRET_LEAK_GUARD:
-      return { status: 500, code: ERROR_CODES.INTERNAL_ERROR }
-    default:
-      return { status: 500, code: ERROR_CODES.INTERNAL_ERROR }
-  }
-}
-
-async function withMcpHttpErrors<T>(requestId: string, fn: () => Promise<T>): Promise<T> {
-  try {
-    return await fn()
-  } catch (error) {
-    if (error instanceof McpError) {
-      const mapped = mcpHttpStatus(error)
-      throw routeError(mapped.status, mapped.code, error.message, requestId)
-    }
-    throw error
-  }
-}
-
-function sourceFromUnknown(value: unknown): McpSource | undefined {
-  const record = asRecord(value)
-  const id = parseString(record.id)
-  const workspaceId = parseString(record.workspaceId)
-  const userId = parseString(record.userId)
-  const provider = parseString(record.provider)
-  const displayName = parseString(record.displayName)
-  const status = parseString(record.status)
-  const ownerKind = parseString(record.ownerKind)
-  const credentialProvider = parseString(record.credentialProvider)
-  if (!id || !workspaceId || !userId || !provider || !displayName || !status || !ownerKind || !credentialProvider) return undefined
-  if (!['connected', 'expired', 'revoked', 'error', 'unconfigured'].includes(status)) return undefined
-  return {
-    id,
-    workspaceId,
-    userId,
-    provider,
-    displayName,
-    status: status as McpSource['status'],
-    ownerKind: ownerKind as McpSource['ownerKind'],
-    credentialProvider: credentialProvider as McpSource['credentialProvider'],
-    scopes: Array.isArray(record.scopes) ? record.scopes.filter((item): item is string => typeof item === 'string') : undefined,
-    providerAccountLabel: parseString(record.providerAccountLabel),
-    connectorRef: asRecord(record.connectorRef) as unknown as McpSource['connectorRef'],
-    lastVerifiedAt: parseString(record.lastVerifiedAt),
-    createdAt: parseString(record.createdAt),
-    updatedAt: parseString(record.updatedAt),
-  }
-}
-
-function readRawStoredSources(settings: Record<string, unknown>, actor: McpActor): McpSource[] {
-  const root = asRecord(settings[USER_SETTINGS_MCP_SOURCES_KEY])
-  const workspaceSources = asRecord(root[actor.workspaceId])
-  return Object.values(workspaceSources)
-    .map(sourceFromUnknown)
-    .filter((source): source is McpSource => Boolean(source && source.workspaceId === actor.workspaceId && source.userId === actor.userId))
-}
-
-function normalizeStoredSourceId(actor: McpActor, source: McpSource): McpSource {
-  try {
-    const legacyId = createLegacyManagedConnectorSourceId(actor, source.provider)
-    return source.id === legacyId ? { ...source, id: createManagedConnectorSourceId(actor, source.provider) } : source
-  } catch {
-    return source
-  }
-}
-
-function sourceStatusRank(source: McpSource): number {
-  switch (source.status) {
-    case 'connected': return 5
-    case 'expired':
-    case 'error': return 4
-    case 'unconfigured': return 3
-    case 'revoked': return 1
-    default: return 0
-  }
-}
-
-function dedupeStoredSources(sources: McpSource[]): McpSource[] {
-  const byId = new Map<string, McpSource>()
-  for (const source of sources) {
-    const current = byId.get(source.id)
-    if (!current || sourceStatusRank(source) >= sourceStatusRank(current)) byId.set(source.id, source)
-  }
-  return [...byId.values()]
-}
-
-function readStoredSources(settings: Record<string, unknown>, actor: McpActor): McpSource[] {
-  return dedupeStoredSources(readRawStoredSources(settings, actor).map((source) => normalizeStoredSourceId(actor, source)))
-}
-
-function existingLegacySourceIdFor(actor: McpActor, source: McpSource, rawSources: readonly McpSource[]): string | undefined {
-  try {
-    const legacyId = createLegacyManagedConnectorSourceId(actor, source.provider)
-    return legacyId !== source.id && rawSources.some((item) => item.id === legacyId) ? legacyId : undefined
-  } catch {
-    return undefined
-  }
-}
-
-async function saveStoredSource(
+export function createFullAppMcpSourceRegistry(
   app: Pick<CoreWorkspaceAgentServer, 'userStore' | 'config'>,
-  actor: McpActor,
-  source: McpSource,
-  removeSourceIds: readonly string[] = [],
-): Promise<McpSource[]> {
-  const patch = app.userStore.patchUserSettingsJsonPath
-  if (patch && removeSourceIds.length === 0) {
-    const updated = await patch.call(
-      app.userStore,
-      actor.userId,
-      app.config.appId,
-      [USER_SETTINGS_MCP_SOURCES_KEY, actor.workspaceId, source.id],
-      source,
-    )
-    return readStoredSources(updated.settings, actor)
-  }
-
-  return await withUserSettingsWriteLock(actor.userId, app.config.appId, async () => {
-    const current = await app.userStore.getUserSettings(actor.userId, app.config.appId)
-    const root = asRecord(current.settings[USER_SETTINGS_MCP_SOURCES_KEY])
-    const removeIds = new Set([source.id, ...removeSourceIds])
-    const sources = readRawStoredSources(current.settings, actor)
-    const nextSources = [...sources.filter((item) => !removeIds.has(item.id)), source]
-    const nextSettings = {
-      ...current.settings,
-      [USER_SETTINGS_MCP_SOURCES_KEY]: {
-        ...root,
-        [actor.workspaceId]: Object.fromEntries(nextSources.map((item) => [item.id, item])),
-      },
-    }
-    await app.userStore.putUserSettings(actor.userId, app.config.appId, { settings: nextSettings })
-    return readStoredSources(nextSettings, actor)
-  })
-}
-
-export function createFullAppMcpSourceRegistry(app: Pick<CoreWorkspaceAgentServer, 'userStore' | 'config'>, actorScope: McpActor): ManagedConnectorSourceRegistry {
-  return {
-    async listSources(actor) {
-      const current = await app.userStore.getUserSettings(actor.userId, app.config.appId)
-      return readStoredSources(current.settings, actor)
-    },
-    async getSource(sourceId) {
-      const current = await app.userStore.getUserSettings(actorScope.userId, app.config.appId)
-      const source = readStoredSources(current.settings, actorScope).find((item) => item.id === sourceId)
-      if (source) return source
-      const legacySource = readRawStoredSources(current.settings, actorScope).find((item) => item.id === sourceId)
-      return legacySource ? normalizeStoredSourceId(actorScope, legacySource) : undefined
-    },
-    async upsertSource(actor, source) {
-      const now = new Date().toISOString()
-      const currentSettings = await app.userStore.getUserSettings(actor.userId, app.config.appId)
-      const current = readStoredSources(currentSettings.settings, actor)
-      const rawSources = readRawStoredSources(currentSettings.settings, actor)
-      const existing = current.find((item) => item.id === source.id)
-      const next = { ...source, updatedAt: now, createdAt: source.createdAt ?? existing?.createdAt ?? now }
-      const legacyId = existingLegacySourceIdFor(actor, next, rawSources)
-      await saveStoredSource(app, actor, next, legacyId ? [legacyId] : [])
-      return next
-    },
-    async disconnectSource(actor, sourceId) {
-      const currentSettings = await app.userStore.getUserSettings(actor.userId, app.config.appId)
-      const source = readStoredSources(currentSettings.settings, actor).find((item) => item.id === sourceId)
-        ?? (() => {
-          const legacySource = readRawStoredSources(currentSettings.settings, actor).find((item) => item.id === sourceId)
-          return legacySource ? normalizeStoredSourceId(actor, legacySource) : undefined
-        })()
-      if (!source) return undefined
-      const disconnected = { ...source, status: 'revoked' as const, updatedAt: new Date().toISOString() }
-      const legacyId = existingLegacySourceIdFor(actor, disconnected, readRawStoredSources(currentSettings.settings, actor))
-      await saveStoredSource(app, actor, disconnected, legacyId ? [legacyId] : [])
-      return disconnected
-    },
-  }
+  actorScope: McpActor,
+): ManagedConnectorSourceRegistry {
+  return createUserSettingsMcpSourceRegistry(app, actorScope)
 }
 
 export interface CreateFullAppBoringMcpAgentToolsOptions {
@@ -342,32 +78,12 @@ export interface CreateFullAppBoringMcpAgentToolsOptions {
   transport?: McpTransportClient
 }
 
-function createFullAppComposioMcpTransport(env?: NodeJS.ProcessEnv): McpTransportClient {
-  return createComposioMcpTransport({
-    secretResolver: createFullAppManagedConnectorSecretResolver(env, FULL_APP_MANAGED_CONNECTOR_CONFIGS),
-    configs: FULL_APP_MANAGED_CONNECTOR_CONFIGS,
-    clientName: 'boring-full-app-mcp',
-    clientVersion: '0.0.0',
-  })
-}
-
 export function createFullAppBoringMcpAgentTools(
   app: Pick<CoreWorkspaceAgentServer, 'userStore' | 'config'>,
   actor: McpActor,
   options: CreateFullAppBoringMcpAgentToolsOptions = {},
 ): AgentTool[] {
-  const config = readFullAppBoringMcpServerConfig(options.env)
-  if (!config.enabled) return []
-  const registry = createFullAppMcpSourceRegistry(app, actor)
-  const transport = options.transport ?? createFullAppComposioMcpTransport(options.env)
-  return createBoringMcpAgentTools({
-    registry,
-    transport,
-    resolveActor: () => actor,
-    templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
-    hardening: { gate: new InMemoryMcpRateBudgetGate({ maxCalls: 100, maxToolCalls: 10, windowMs: 60_000 }), timeoutMs: 30_000 },
-    maxReadonlyInputBytes: config.maxReadonlyInputBytes,
-  })
+  return createBoringMcpAppAgentTools(app, actor, { config: FULL_APP_BORING_MCP_CONFIG, ...options })
 }
 
 export function createFullAppBoringMcpAgentToolsForRequest(
@@ -375,113 +91,14 @@ export function createFullAppBoringMcpAgentToolsForRequest(
   ctx: { workspaceId: string; authSubject?: string },
   options: CreateFullAppBoringMcpAgentToolsOptions = {},
 ): AgentTool[] {
-  const userId = typeof ctx.authSubject === 'string' && ctx.authSubject.trim() ? ctx.authSubject.trim() : undefined
-  if (!userId) return []
-  return createFullAppBoringMcpAgentTools(app, { workspaceId: ctx.workspaceId, userId }, options)
+  return createBoringMcpAppAgentToolsForRequest(app, ctx, { config: FULL_APP_BORING_MCP_CONFIG, ...options })
 }
 
-async function requireBoringMcpActor(app: CoreWorkspaceAgentServer, request: FastifyRequest): Promise<McpActor> {
-  const body = asRecord(request.body)
-  const query = asRecord(request.query)
-  const workspaceId = validateWorkspaceId(
-    request.headers['x-boring-workspace-id'] ?? body.workspaceId ?? query.workspaceId,
-    request.id,
-  )
-  const user = request.user
-  if (!user) throw routeError(401, ERROR_CODES.UNAUTHORIZED, 'Authentication required', request.id)
-  const workspace = await app.workspaceStore.get(workspaceId)
-  if (!workspace || workspace.appId !== app.config.appId) throw routeError(404, ERROR_CODES.NOT_FOUND, 'Workspace not found', request.id)
-  const role = await app.workspaceStore.getMemberRole(workspaceId, user.id)
-  if (!role) throw routeError(403, ERROR_CODES.NOT_MEMBER, 'Not a member of this workspace', request.id)
-  return { workspaceId, userId: user.id }
-}
-
-function sourceActionRateLimitKey(request: FastifyRequest): string {
-  const workspaceId = typeof request.headers['x-boring-workspace-id'] === 'string'
-    ? request.headers['x-boring-workspace-id']
-    : 'unknown-workspace'
-  return `${request.user?.id ?? request.ip}:${workspaceId}`
-}
-
-function sourceIdFromBody(body: unknown, requestId: string): string {
-  const sourceId = parseString(asRecord(body).sourceId)
-  if (!sourceId) throw routeError(400, ERROR_CODES.VALIDATION_FAILED, 'sourceId is required', requestId)
-  return sourceId
-}
-
-function providerFromBody(body: unknown, requestId: string): McpProviderId {
-  const provider = parseString(asRecord(body).provider)
-  if (!provider) throw routeError(400, ERROR_CODES.VALIDATION_FAILED, 'provider is required', requestId)
-  return provider
-}
-
-export function registerFullAppBoringMcpRoutes(app: CoreWorkspaceAgentServer, options: { provider?: ManagedConnectorProvider; env?: NodeJS.ProcessEnv; transport?: McpTransportClient } = {}): void {
-  if (!readFullAppBoringMcpServerConfig(options.env).enabled) return
-
-  const routeTransport = options.transport ?? createFullAppComposioMcpTransport(options.env)
-  const routeGate = new InMemoryMcpRateBudgetGate({ maxCalls: 100, maxToolCalls: 10, windowMs: 60_000 })
-
-  function adapterFor(actor: McpActor) {
-    const registry = createFullAppMcpSourceRegistry(app, actor)
-    return { registry, adapter: createFullAppManagedConnectorAdapter({ registry, provider: options.provider, env: options.env }) }
-  }
-
-  function handlersFor(actor: McpActor) {
-    return createBoringMcpSourceHandlers({
-      registry: createFullAppMcpSourceRegistry(app, actor),
-      transport: routeTransport,
-      templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
-      hardening: { gate: routeGate, timeoutMs: 30_000 },
-    })
-  }
-
-  app.get('/api/v1/boring-mcp/sources', async (request) => {
-    const actor = await requireBoringMcpActor(app, request)
-    const { registry } = adapterFor(actor)
-    const sources = await registry.listSources(actor)
-    return { sourceStatuses: sources.map(createMcpSourceStatusPayload) }
-  })
-
-  app.post('/api/v1/boring-mcp/connect', {
-    config: { rateLimit: { ...SOURCE_CONNECT_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
-  }, async (request, reply) => {
-    const actor = await requireBoringMcpActor(app, request)
-    const { adapter } = adapterFor(actor)
-    const provider = providerFromBody(request.body, request.id)
-    const result = await withMcpHttpErrors(request.id, () => adapter.startConnect(actor, { provider }))
-    const { connectUrl, ...status } = result
-    reply.status(201)
-    return { status, connectUrl }
-  })
-
-  app.post('/api/v1/boring-mcp/refresh', {
-    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
-  }, async (request) => {
-    const actor = await requireBoringMcpActor(app, request)
-    const { adapter } = adapterFor(actor)
-    const result = await withMcpHttpErrors(request.id, () => adapter.refreshStatus(actor, sourceIdFromBody(request.body, request.id)))
-    return { status: result }
-  })
-
-  app.post('/api/v1/boring-mcp/disconnect', {
-    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
-  }, async (request) => {
-    const actor = await requireBoringMcpActor(app, request)
-    const status = await withMcpHttpErrors(request.id, () => adapterFor(actor).adapter.disconnectSource(actor, sourceIdFromBody(request.body, request.id)))
-    return { status }
-  })
-
-  app.post('/api/v1/boring-mcp/tools', {
-    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
-  }, async (request) => {
-    const actor = await requireBoringMcpActor(app, request)
-    const body = asRecord(request.body)
-    const result = await withMcpHttpErrors(request.id, () => handlersFor(actor).searchTools(actor, {
-      sourceId: sourceIdFromBody(request.body, request.id),
-      refresh: body.refresh === true,
-    }))
-    return { tools: result.tools }
-  })
+export function registerFullAppBoringMcpRoutes(
+  app: CoreWorkspaceAgentServer,
+  options: { provider?: ManagedConnectorProvider; env?: NodeJS.ProcessEnv; transport?: McpTransportClient } = {},
+): void {
+  registerBoringMcpRoutes(app, { config: FULL_APP_BORING_MCP_CONFIG, ...options })
 }
 
 export function createFullAppBoringMcpServerPlugins(env: NodeJS.ProcessEnv = process.env) {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -27,6 +27,11 @@
       "import": "./dist/server/index.js",
       "default": "./dist/server/index.js"
     },
+    "./server/worker": {
+      "types": "./dist/server/worker/index.d.ts",
+      "import": "./dist/server/worker/index.js",
+      "default": "./dist/server/worker/index.js"
+    },
     "./front": {
       "types": "./dist/front/index.d.ts",
       "import": "./dist/front/index.js"

--- a/packages/agent/scripts/assert-build-artifacts.mjs
+++ b/packages/agent/scripts/assert-build-artifacts.mjs
@@ -17,6 +17,8 @@ const requiredFiles = [
   'dist/shared/index.d.ts',
   'dist/core/index.d.ts',
   'dist/server/index.d.ts',
+  'dist/server/worker/index.js',
+  'dist/server/worker/index.d.ts',
   'dist/front/index.js',
   'dist/front/index.d.ts',
   'dist/front/styles.css',

--- a/packages/agent/src/front/__tests__/publicExports.test.ts
+++ b/packages/agent/src/front/__tests__/publicExports.test.ts
@@ -30,6 +30,7 @@ describe('@hachej/boring-agent/front public exports', () => {
       './front',
       './front/styles.css',
       './server',
+      './server/worker',
       './shared',
     ])
   })

--- a/packages/agent/src/server/config/workerConfig.ts
+++ b/packages/agent/src/server/config/workerConfig.ts
@@ -1,4 +1,4 @@
-import type { BwrapResourceLimits } from '@hachej/boring-agent/server'
+import type { BwrapResourceLimits } from '../sandbox/bwrap/createBwrapSandbox'
 
 const FILE_SIZE_BLOCKS_PER_MIB = 2048
 const KIB_PER_MIB = 1024

--- a/packages/agent/src/server/worker/__tests__/worker.test.ts
+++ b/packages/agent/src/server/worker/__tests__/worker.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createWorkerServer, WORKER_ERROR_CODES, type WorkerConfig } from '../index'
+import { WORKER_INTERNAL_TOKEN_HEADER } from '../../index'
+
+const INTERNAL_TOKEN = 'test-internal-token'
+const WORKSPACE_ID = '11111111-1111-4111-8111-111111111111'
+
+async function stubConfig(): Promise<WorkerConfig> {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-worker-'))
+  return {
+    workspaceRoot,
+    internalToken: INTERNAL_TOKEN,
+    port: 0,
+    host: '127.0.0.1',
+    execConcurrency: 2,
+    bwrapNetwork: 'isolated',
+    resourceLimits: {
+      cpuSeconds: 30,
+      fileSizeBlocks: 2048,
+      maxProcesses: 512,
+      openFiles: 256,
+      virtualMemoryKb: 1024,
+    },
+  }
+}
+
+describe('createWorkerServer', () => {
+  let close: (() => Promise<void>) | undefined
+
+  afterEach(async () => {
+    await close?.()
+    close = undefined
+  })
+
+  it('boots from a stub config and serves an unauthenticated health check', async () => {
+    const config = await stubConfig()
+    const { app, config: returned } = await createWorkerServer({ config, fastify: { logger: false } })
+    close = () => app.close()
+    expect(returned).toBe(config)
+
+    const health = await app.inject({ method: 'GET', url: '/health' })
+    expect(health.statusCode).toBe(200)
+    expect(health.json()).toEqual({ ok: true })
+  })
+
+  it('rejects internal routes without a valid internal token', async () => {
+    const config = await stubConfig()
+    const { app } = await createWorkerServer({ config, fastify: { logger: false } })
+    close = () => app.close()
+
+    const unauthorized = await app.inject({
+      method: 'POST',
+      url: `/internal/workspaces/${WORKSPACE_ID}/fs`,
+      payload: { op: 'stat', path: '.' },
+    })
+    expect(unauthorized.statusCode).toBe(401)
+    expect(unauthorized.json()).toMatchObject({ error: { code: WORKER_ERROR_CODES.AUTH_INVALID } })
+
+    const badWorkspace = await app.inject({
+      method: 'POST',
+      url: '/internal/workspaces/not-a-uuid/fs',
+      headers: { [WORKER_INTERNAL_TOKEN_HEADER]: INTERNAL_TOKEN },
+      payload: { op: 'stat', path: '.' },
+    })
+    expect(badWorkspace.statusCode).toBe(400)
+    expect(badWorkspace.json()).toMatchObject({ error: { code: WORKER_ERROR_CODES.INVALID_WORKSPACE_ID } })
+  })
+})

--- a/packages/agent/src/server/worker/auth.ts
+++ b/packages/agent/src/server/worker/auth.ts
@@ -1,5 +1,6 @@
 import type { FastifyReply, FastifyRequest } from 'fastify'
-import { constantTimeTokenEqual, WORKER_INTERNAL_TOKEN_HEADER } from '@hachej/boring-agent/server'
+import { constantTimeTokenEqual, WORKER_INTERNAL_TOKEN_HEADER } from '../index'
+import { WORKER_ERROR_CODES } from './error-codes'
 
 export function verifyInternalToken(
   request: FastifyRequest,
@@ -11,7 +12,7 @@ export function verifyInternalToken(
   if (typeof token !== 'string' || !constantTimeTokenEqual(token, expectedToken)) {
     reply.code(401).send({
       error: {
-        code: 'auth_invalid',
+        code: WORKER_ERROR_CODES.AUTH_INVALID,
         message: 'invalid internal token',
         statusCode: 401,
       },

--- a/packages/agent/src/server/worker/error-codes.ts
+++ b/packages/agent/src/server/worker/error-codes.ts
@@ -1,0 +1,13 @@
+// Stable error-code constants for the remote worker HTTP wire protocol.
+// Kept in a dedicated error-codes module so call sites reference the enum
+// instead of raw string literals (grep-enforced invariant).
+export const WORKER_ERROR_CODES = {
+  AUTH_INVALID: 'auth_invalid',
+  VALIDATION_ERROR: 'validation_error',
+  INVALID_WORKSPACE_ID: 'invalid_workspace_id',
+  NOT_IMPLEMENTED: 'not_implemented',
+  EXEC_CONCURRENCY_LIMIT: 'exec_concurrency_limit',
+  UNSUPPORTED_WORKSPACE_OP: 'unsupported_workspace_op',
+} as const
+
+export type WorkerErrorCode = (typeof WORKER_ERROR_CODES)[keyof typeof WORKER_ERROR_CODES]

--- a/packages/agent/src/server/worker/exec.ts
+++ b/packages/agent/src/server/worker/exec.ts
@@ -1,3 +1,5 @@
+import { WORKER_ERROR_CODES } from './error-codes'
+
 export class ExecSemaphore {
   private active = 0
 
@@ -7,7 +9,7 @@ export class ExecSemaphore {
     if (this.active >= this.limit) {
       throw Object.assign(new Error('worker exec concurrency limit reached'), {
         statusCode: 429,
-        code: 'exec_concurrency_limit',
+        code: WORKER_ERROR_CODES.EXEC_CONCURRENCY_LIMIT,
       })
     }
     this.active += 1

--- a/packages/agent/src/server/worker/index.ts
+++ b/packages/agent/src/server/worker/index.ts
@@ -1,0 +1,46 @@
+// @hachej/boring-agent — remote bwrap worker runtime (Node-only) public API.
+//
+// This is the self-contained Fastify server that a tenant deployment runs as
+// its internal worker process. Host apps only need to supply configuration
+// (usually via environment) and start the returned Fastify instance.
+import Fastify, { type FastifyInstance, type FastifyServerOptions } from 'fastify'
+
+import { loadWorkerConfig, type WorkerConfig } from '../config/workerConfig'
+import { registerWorkerRoutes } from './routes'
+
+export { loadWorkerConfig, type WorkerConfig } from '../config/workerConfig'
+export { registerWorkerRoutes } from './routes'
+export { WORKER_ERROR_CODES, type WorkerErrorCode } from './error-codes'
+export {
+  assertSafeWorkspaceId,
+  createWorkerRuntime,
+  runWorkspaceOp,
+  type WorkerRuntime,
+} from './workspace'
+export { ExecSemaphore, buildExecEnv } from './exec'
+export { verifyInternalToken } from './auth'
+
+const DEFAULT_BODY_LIMIT = 20 * 1024 * 1024
+
+export interface CreateWorkerServerOptions {
+  /** Worker configuration. Defaults to {@link loadWorkerConfig} (reads env). */
+  config?: WorkerConfig
+  /** Extra Fastify server options merged over the worker defaults. */
+  fastify?: FastifyServerOptions
+}
+
+export interface WorkerServer {
+  app: FastifyInstance
+  config: WorkerConfig
+}
+
+/**
+ * Build the internal worker Fastify server with worker routes registered.
+ * Callers own listening/lifecycle.
+ */
+export async function createWorkerServer(options: CreateWorkerServerOptions = {}): Promise<WorkerServer> {
+  const config = options.config ?? loadWorkerConfig()
+  const app = Fastify({ logger: true, bodyLimit: DEFAULT_BODY_LIMIT, ...options.fastify })
+  await registerWorkerRoutes(app, config)
+  return { app, config }
+}

--- a/packages/agent/src/server/worker/routes.ts
+++ b/packages/agent/src/server/worker/routes.ts
@@ -3,13 +3,14 @@ import {
   type RemoteWorkerExecRequest,
   type RemoteWorkerExecResponse,
   type RemoteWorkerWorkspaceOp,
-} from '@hachej/boring-agent/server'
-import type { ExecResult } from '@hachej/boring-agent/shared'
+} from '../index'
+import type { ExecResult } from '../../shared/index'
 
-import type { WorkerConfig } from './config.js'
-import { verifyInternalToken } from './auth.js'
-import { buildExecEnv, ExecSemaphore } from './exec.js'
-import { assertSafeWorkspaceId, createWorkerRuntime, runWorkspaceOp, type WorkerRuntime } from './workspace.js'
+import type { WorkerConfig } from '../config/workerConfig'
+import { WORKER_ERROR_CODES } from './error-codes'
+import { verifyInternalToken } from './auth'
+import { buildExecEnv, ExecSemaphore } from './exec'
+import { assertSafeWorkspaceId, createWorkerRuntime, runWorkspaceOp, type WorkerRuntime } from './workspace'
 
 interface WorkspaceParams {
   workspaceId: string
@@ -87,7 +88,7 @@ export async function registerWorkerRoutes(app: FastifyInstance, config: WorkerC
       try {
         const runtime = await getRuntime(request.params.workspaceId)
         if (!request.body || typeof request.body.op !== 'string') {
-          throw Object.assign(new Error('workspace op is required'), { statusCode: 400, code: 'validation_error' })
+          throw Object.assign(new Error('workspace op is required'), { statusCode: 400, code: WORKER_ERROR_CODES.VALIDATION_ERROR })
         }
         return await runWorkspaceOp(runtime.workspace, request.body)
       } catch (error) {
@@ -103,7 +104,7 @@ export async function registerWorkerRoutes(app: FastifyInstance, config: WorkerC
         const runtime = await getRuntime(request.params.workspaceId)
         const body = request.body
         if (!body || typeof body.cmd !== 'string' || body.cmd.length === 0) {
-          throw Object.assign(new Error('cmd is required'), { statusCode: 400, code: 'validation_error' })
+          throw Object.assign(new Error('cmd is required'), { statusCode: 400, code: WORKER_ERROR_CODES.VALIDATION_ERROR })
         }
         const abortController = new AbortController()
         const abort = () => abortController.abort()
@@ -143,7 +144,7 @@ export async function registerWorkerRoutes(app: FastifyInstance, config: WorkerC
           reply.raw.write(`event: change\ndata: ${JSON.stringify(payload)}\n\n`)
         }
         if (!runtime.workspace.watch) {
-          throw Object.assign(new Error('workspace events unsupported'), { statusCode: 501, code: 'not_implemented' })
+          throw Object.assign(new Error('workspace events unsupported'), { statusCode: 501, code: WORKER_ERROR_CODES.NOT_IMPLEMENTED })
         }
         unsubscribe = runtime.workspace.watch().subscribe((event) => send({ event }))
         heartbeat = setInterval(() => reply.raw.write(': heartbeat\n\n'), 15_000)

--- a/packages/agent/src/server/worker/workspace.ts
+++ b/packages/agent/src/server/worker/workspace.ts
@@ -8,9 +8,9 @@ import {
   type BwrapResourceLimits,
   type RemoteWorkerWorkspaceOp,
   type RemoteWorkerWorkspaceResult,
-} from '@hachej/boring-agent/server'
-import type { Sandbox } from '@hachej/boring-agent/shared'
-import type { Workspace } from '@hachej/boring-agent/shared'
+} from '../index'
+import type { Sandbox, Workspace } from '../../shared/index'
+import { WORKER_ERROR_CODES } from './error-codes'
 
 export interface WorkerRuntime {
   workspace: Workspace
@@ -22,7 +22,7 @@ const WORKSPACE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]
 export function assertSafeWorkspaceId(workspaceId: string): string {
   const normalized = workspaceId.trim().toLowerCase()
   if (!WORKSPACE_UUID.test(normalized)) {
-    throw Object.assign(new Error('workspace id must be a uuid'), { statusCode: 400, code: 'invalid_workspace_id' })
+    throw Object.assign(new Error('workspace id must be a uuid'), { statusCode: 400, code: WORKER_ERROR_CODES.INVALID_WORKSPACE_ID })
   }
   return normalized
 }
@@ -52,13 +52,13 @@ export async function runWorkspaceOp(workspace: Workspace, op: RemoteWorkerWorks
     case 'readFile':
       return { content: await workspace.readFile(op.path) }
     case 'readBinaryFile':
-      if (!workspace.readBinaryFile) throw Object.assign(new Error('binary read unsupported'), { statusCode: 501, code: 'not_implemented' })
+      if (!workspace.readBinaryFile) throw Object.assign(new Error('binary read unsupported'), { statusCode: 501, code: WORKER_ERROR_CODES.NOT_IMPLEMENTED })
       return { dataBase64: Buffer.from(await workspace.readBinaryFile(op.path)).toString('base64') }
     case 'writeFile':
       await workspace.writeFile(op.path, op.data)
       return { ok: true }
     case 'writeBinaryFile':
-      if (!workspace.writeBinaryFile) throw Object.assign(new Error('binary write unsupported'), { statusCode: 501, code: 'not_implemented' })
+      if (!workspace.writeBinaryFile) throw Object.assign(new Error('binary write unsupported'), { statusCode: 501, code: WORKER_ERROR_CODES.NOT_IMPLEMENTED })
       await workspace.writeBinaryFile(op.path, new Uint8Array(Buffer.from(op.dataBase64, 'base64')))
       return { ok: true }
     case 'readFileWithStat':
@@ -73,7 +73,7 @@ export async function runWorkspaceOp(workspace: Workspace, op: RemoteWorkerWorks
       }
       return { stat: await workspace.writeFileWithStat(op.path, op.data) }
     case 'writeBinaryFileWithStat':
-      if (!workspace.writeBinaryFile) throw Object.assign(new Error('binary write unsupported'), { statusCode: 501, code: 'not_implemented' })
+      if (!workspace.writeBinaryFile) throw Object.assign(new Error('binary write unsupported'), { statusCode: 501, code: WORKER_ERROR_CODES.NOT_IMPLEMENTED })
       if (!workspace.writeBinaryFileWithStat) {
         await workspace.writeBinaryFile(op.path, new Uint8Array(Buffer.from(op.dataBase64, 'base64')))
         return { stat: await workspace.stat(op.path) }
@@ -96,7 +96,7 @@ export async function runWorkspaceOp(workspace: Workspace, op: RemoteWorkerWorks
       const _never: never = op
       throw Object.assign(new Error(`unsupported workspace op ${(op as { op?: string }).op ?? 'unknown'}`), {
         statusCode: 400,
-        code: 'unsupported_workspace_op',
+        code: WORKER_ERROR_CODES.UNSUPPORTED_WORKSPACE_OP,
         details: _never,
       })
     }

--- a/packages/agent/tsup.config.ts
+++ b/packages/agent/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     "shared/index": "src/shared/index.ts",
     "core/index": "src/core/index.ts",
     "server/index": "src/server/index.ts",
+    "server/worker/index": "src/server/worker/index.ts",
     "front/index": "src/front/index.ts",
     "eval/index": "src/eval/index.ts",
   },

--- a/plugins/boring-mcp/package.json
+++ b/plugins/boring-mcp/package.json
@@ -53,12 +53,16 @@
     "clean": "rm -rf dist .tsbuildinfo"
   },
   "peerDependencies": {
+    "@hachej/boring-core": "workspace:*",
     "@hachej/boring-workspace": "workspace:*",
+    "fastify": "^5.9.0",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
+    "@hachej/boring-core": "workspace:*",
     "@hachej/boring-workspace": "workspace:*",
+    "fastify": "^5.9.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^22.20.0",

--- a/plugins/boring-mcp/src/server/__tests__/appServerBinding.test.ts
+++ b/plugins/boring-mcp/src/server/__tests__/appServerBinding.test.ts
@@ -1,0 +1,77 @@
+import Fastify from 'fastify'
+import { describe, expect, it } from 'vitest'
+import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
+import {
+  createManagedConnectorSecretResolver,
+  readBoringMcpServerConfig,
+  registerBoringMcpRoutes,
+  type BoringMcpBindingConfig,
+} from '../appServerBinding'
+import type { ManagedConnectorConfig } from '../managedConnectorAdapter'
+
+const CONFIGS: readonly ManagedConnectorConfig[] = [
+  { provider: 'notion', displayName: 'Notion', toolkitId: 'notion' },
+]
+
+const BINDING: BoringMcpBindingConfig = {
+  connectorConfigs: CONFIGS,
+  clientName: 'boring-mcp-test',
+}
+
+describe('readBoringMcpServerConfig', () => {
+  it('enables outside production and honors the disable flag', () => {
+    expect(readBoringMcpServerConfig({} as NodeJS.ProcessEnv).enabled).toBe(true)
+    expect(readBoringMcpServerConfig({ BORING_MCP_ENABLED: '0' } as NodeJS.ProcessEnv).enabled).toBe(false)
+    expect(readBoringMcpServerConfig({ NODE_ENV: 'production' } as NodeJS.ProcessEnv).enabled).toBe(false)
+    expect(readBoringMcpServerConfig({ NODE_ENV: 'production', BORING_MCP_PROD_ENABLED: '1' } as NodeJS.ProcessEnv).enabled).toBe(true)
+  })
+
+  it('reports the composio key across the configured env var fallbacks', () => {
+    expect(readBoringMcpServerConfig({ COMPOSIO_API_KEY: 'k' } as NodeJS.ProcessEnv).composioApiKeyConfigured).toBe(true)
+    expect(readBoringMcpServerConfig({ ALT_KEY: 'k' } as NodeJS.ProcessEnv, { secretEnvVars: ['COMPOSIO_API_KEY', 'ALT_KEY'] }).composioApiKeyConfigured).toBe(true)
+    expect(readBoringMcpServerConfig({} as NodeJS.ProcessEnv).composioApiKeyConfigured).toBe(false)
+  })
+})
+
+describe('createManagedConnectorSecretResolver', () => {
+  it('resolves from the first configured env var and rejects unsupported providers', async () => {
+    const resolver = createManagedConnectorSecretResolver({
+      env: { ALT_KEY: 'secret-value' } as NodeJS.ProcessEnv,
+      configs: CONFIGS,
+      secretEnvVars: ['COMPOSIO_API_KEY', 'ALT_KEY'],
+    })
+    await expect(resolver.resolveSecret('notion')).resolves.toEqual({ storage: 'server-env', value: 'secret-value' })
+    await expect(resolver.resolveSecret('airtable')).rejects.toThrow('Unsupported MCP provider: airtable')
+    await expect(
+      createManagedConnectorSecretResolver({ env: {} as NodeJS.ProcessEnv, configs: CONFIGS }).resolveSecret('notion'),
+    ).rejects.toThrow('COMPOSIO_API_KEY is not configured')
+  })
+})
+
+describe('registerBoringMcpRoutes disabled behavior', () => {
+  const disabledEnv = { NODE_ENV: 'production' } as NodeJS.ProcessEnv
+
+  it('skips route registration by default (client sees 404)', async () => {
+    const app = Fastify()
+    registerBoringMcpRoutes(app as unknown as CoreWorkspaceAgentServer, { config: BINDING, env: disabledEnv })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources', headers: { 'x-boring-workspace-id': 'w1' } })
+    expect(res.statusCode).toBe(404)
+    await app.close()
+  })
+
+  it('serves a stable 503 when whenDisabled is serve-503', async () => {
+    const app = Fastify()
+    // The core host maps HttpError.status to the HTTP status; mirror that here.
+    app.setErrorHandler((error: unknown, _request, reply) => {
+      const err = error as { status?: number; statusCode?: number; code?: string; message?: string }
+      const status = err.status ?? err.statusCode ?? 500
+      reply.code(status).send({ code: err.code ?? 'internal', message: err.message })
+    })
+    registerBoringMcpRoutes(app as unknown as CoreWorkspaceAgentServer, { config: BINDING, env: disabledEnv, whenDisabled: 'serve-503' })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources', headers: { 'x-boring-workspace-id': 'w1' } })
+    expect(res.statusCode).toBe(503)
+    await app.close()
+  })
+})

--- a/plugins/boring-mcp/src/server/appServerBinding.ts
+++ b/plugins/boring-mcp/src/server/appServerBinding.ts
@@ -1,0 +1,575 @@
+// Reusable server binding that wires the generic boring-mcp foundation to a
+// boring-core host app (per-user source persistence, HTTP route surface, agent
+// tools, and the Composio-managed connector transport).
+//
+// Host apps (full-app and tenant deployments) previously copied this glue
+// verbatim, differing only in configuration (which managed connectors are
+// exposed, which env var holds the Composio key, redaction canaries, and the
+// MCP client identity). This module accepts that configuration so hosts import
+// it instead of copying it.
+import { createHash } from 'node:crypto'
+import type { FastifyRequest } from 'fastify'
+import { HttpError, ERROR_CODES, type ErrorCode } from '@hachej/boring-core/shared'
+import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
+import { withUserSettingsWriteLock } from '@hachej/boring-core/server'
+import type { AgentTool } from '@hachej/boring-workspace'
+
+import {
+  DEFAULT_MCP_PROVIDER_TEMPLATES,
+  MCP_ERROR_CODES,
+  McpError,
+  type McpActor,
+  type McpProviderId,
+  type McpSource,
+  type McpTransportClient,
+} from '../shared'
+import { InMemoryMcpRateBudgetGate } from './hardening'
+import {
+  createLegacyManagedConnectorSourceId,
+  createManagedConnectorAdapter,
+  createManagedConnectorSourceId,
+  type ManagedConnectorAdapter,
+  type ManagedConnectorConfig,
+  type ManagedConnectorProvider,
+  type ManagedConnectorSecret,
+  type ManagedConnectorSecretResolver,
+  type ManagedConnectorSourceRegistry,
+} from './managedConnectorAdapter'
+import { createComposioManagedConnectorProvider, createComposioMcpTransport } from './composioManagedConnector'
+import { createMcpSourceStatusPayload } from './sourceAccess'
+import { createBoringMcpSourceHandlers } from './sourceHandlers'
+import { createBoringMcpAgentTools } from './agentTools'
+
+const DEFAULT_MAX_READONLY_INPUT_BYTES = 64 * 1024
+const MAX_READONLY_INPUT_BYTES = 1024 * 1024
+const SOURCE_CONNECT_RATE_LIMIT = { max: 10, timeWindow: '1 minute' } as const
+const SOURCE_ACTION_RATE_LIMIT = { max: 60, timeWindow: '1 minute' } as const
+const DEFAULT_SECRET_ENV_VARS = ['COMPOSIO_API_KEY'] as const
+
+/** App server surface the boring-mcp binding depends on. */
+export type BoringMcpAppServer = CoreWorkspaceAgentServer
+
+/**
+ * Per-deployment configuration for the boring-mcp server binding. Everything a
+ * host used to hardcode when copying the glue lives here.
+ */
+export interface BoringMcpBindingConfig {
+  /** Managed connector providers this deployment exposes. */
+  connectorConfigs: readonly ManagedConnectorConfig[]
+  /**
+   * Env var names checked (in order) for the Composio managed-connector API
+   * key. Defaults to `['COMPOSIO_API_KEY']`.
+   */
+  secretEnvVars?: readonly string[]
+  /** Redaction canary tokens forwarded to the managed connector adapter. */
+  redactionCanaries?: readonly string[]
+  /** Composio MCP transport client identity. */
+  clientName?: string
+  clientVersion?: string
+}
+
+export interface BoringMcpServerRuntimeConfig {
+  enabled: boolean
+  composioApiKeyConfigured: boolean
+  maxReadonlyInputBytes: number
+}
+
+function resolveSecretEnvVars(config: Pick<BoringMcpBindingConfig, 'secretEnvVars'>): readonly string[] {
+  return config.secretEnvVars && config.secretEnvVars.length > 0 ? config.secretEnvVars : DEFAULT_SECRET_ENV_VARS
+}
+
+function resolveComposioSecret(env: NodeJS.ProcessEnv, secretEnvVars: readonly string[]): string | undefined {
+  for (const name of secretEnvVars) {
+    const value = env[name]?.trim()
+    if (value) return value
+  }
+  return undefined
+}
+
+function parseReadonlyInputLimit(value: string | undefined): number {
+  if (!value) return DEFAULT_MAX_READONLY_INPUT_BYTES
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > MAX_READONLY_INPUT_BYTES) return DEFAULT_MAX_READONLY_INPUT_BYTES
+  return parsed
+}
+
+export function readBoringMcpServerConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  options: { secretEnvVars?: readonly string[] } = {},
+): BoringMcpServerRuntimeConfig {
+  const productionEnabled = env.BORING_MCP_PROD_ENABLED === '1'
+  const nonProductionEnabled = env.BORING_MCP_ENABLED !== '0'
+  const secretEnvVars = resolveSecretEnvVars(options)
+  return {
+    enabled: env.NODE_ENV === 'production' ? productionEnabled : nonProductionEnabled,
+    composioApiKeyConfigured: Boolean(resolveComposioSecret(env, secretEnvVars)),
+    maxReadonlyInputBytes: parseReadonlyInputLimit(env.BORING_MCP_MAX_READONLY_INPUT_BYTES),
+  }
+}
+
+export interface CreateManagedConnectorSecretResolverOptions {
+  env?: NodeJS.ProcessEnv
+  configs: readonly ManagedConnectorConfig[]
+  secretEnvVars?: readonly string[]
+}
+
+export function createManagedConnectorSecretResolver(
+  options: CreateManagedConnectorSecretResolverOptions,
+): ManagedConnectorSecretResolver {
+  const env = options.env ?? process.env
+  const secretEnvVars = resolveSecretEnvVars(options)
+  const supportedProviders = new Set<McpProviderId>(options.configs.map((config) => config.provider))
+  return {
+    async resolveSecret(provider: McpProviderId): Promise<ManagedConnectorSecret> {
+      if (!supportedProviders.has(provider)) {
+        throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, `Unsupported MCP provider: ${provider}`, { reason: 'unsupported_provider' })
+      }
+      const value = resolveComposioSecret(env, secretEnvVars)
+      if (!value) {
+        throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, `${secretEnvVars.join('/')} is not configured`)
+      }
+      return { storage: 'server-env', value }
+    },
+  }
+}
+
+export interface CreateManagedConnectorAdapterOptions {
+  config: BoringMcpBindingConfig
+  registry: ManagedConnectorSourceRegistry
+  env?: NodeJS.ProcessEnv
+  provider?: ManagedConnectorProvider
+}
+
+export function createBoringMcpManagedConnectorAdapter(options: CreateManagedConnectorAdapterOptions): ManagedConnectorAdapter {
+  return createManagedConnectorAdapter({
+    registry: options.registry,
+    provider: options.provider ?? createComposioManagedConnectorProvider(),
+    secretResolver: createManagedConnectorSecretResolver({
+      env: options.env,
+      configs: options.config.connectorConfigs,
+      secretEnvVars: options.config.secretEnvVars,
+    }),
+    templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
+    redactionCanaries: options.config.redactionCanaries,
+    configs: options.config.connectorConfigs,
+  })
+}
+
+const USER_SETTINGS_MCP_SOURCES_KEY = '__serverBoringMcpSourcesV1'
+const WORKSPACE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/
+
+function requestUserId(request: FastifyRequest | undefined): string | undefined {
+  const user = request?.user
+  return typeof user?.id === 'string' && user.id.trim() ? user.id : undefined
+}
+
+function shortHash(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16)
+}
+
+function safeSessionNamespaceSegment(value: string): string {
+  return value.replace(/[^A-Za-z0-9_-]/g, '_').slice(0, 80) || 'workspace'
+}
+
+export function boringMcpAgentSessionNamespace(ctx: { workspaceId: string; request?: FastifyRequest; userId?: string }): string {
+  const workspaceSegment = safeSessionNamespaceSegment(ctx.workspaceId)
+  const userId = ctx.userId?.trim() || requestUserId(ctx.request)
+  return `${workspaceSegment}_user_${userId ? shortHash(userId) : 'anonymous'}`
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {}
+}
+
+function parseString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function validateWorkspaceId(value: unknown, requestId: string): string {
+  const workspaceId = parseString(value)
+  if (!workspaceId || !WORKSPACE_ID_PATTERN.test(workspaceId)) {
+    throw new HttpError({ status: 400, code: ERROR_CODES.VALIDATION_FAILED, message: 'Invalid workspace id', requestId })
+  }
+  return workspaceId
+}
+
+function routeError(status: number, code: ErrorCode, message: string, requestId: string): HttpError {
+  return new HttpError({ status, code, message, requestId })
+}
+
+function mcpHttpStatus(error: McpError): { status: number; code: ErrorCode } {
+  switch (error.code) {
+    case MCP_ERROR_CODES.SOURCE_NOT_FOUND:
+    case MCP_ERROR_CODES.TOOL_NOT_FOUND:
+      return { status: 404, code: ERROR_CODES.NOT_FOUND }
+    case MCP_ERROR_CODES.SOURCE_FORBIDDEN:
+      return { status: 403, code: ERROR_CODES.FORBIDDEN }
+    case MCP_ERROR_CODES.INPUT_INVALID:
+    case MCP_ERROR_CODES.RESOURCE_URI_INVALID:
+    case MCP_ERROR_CODES.PROVIDER_TOOL_DRIFT:
+    case MCP_ERROR_CODES.TOOL_NOT_ALLOWED:
+      return { status: 400, code: ERROR_CODES.VALIDATION_FAILED }
+    case MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID:
+      return asRecord(error.details).reason === 'unsupported_provider'
+        ? { status: 400, code: ERROR_CODES.VALIDATION_FAILED }
+        : { status: 503, code: ERROR_CODES.CONFIG_VALIDATION_FAILED }
+    case MCP_ERROR_CODES.SOURCE_UNAVAILABLE:
+      return { status: 409, code: ERROR_CODES.VALIDATION_FAILED }
+    case MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED:
+      return { status: 413, code: ERROR_CODES.VALIDATION_FAILED }
+    case MCP_ERROR_CODES.PROVIDER_TIMEOUT:
+      return { status: 504, code: ERROR_CODES.INTERNAL_ERROR }
+    case MCP_ERROR_CODES.PROVIDER_ERROR:
+      return { status: 502, code: ERROR_CODES.INTERNAL_ERROR }
+    case MCP_ERROR_CODES.SECRET_LEAK_GUARD:
+      return { status: 500, code: ERROR_CODES.INTERNAL_ERROR }
+    default:
+      return { status: 500, code: ERROR_CODES.INTERNAL_ERROR }
+  }
+}
+
+async function withMcpHttpErrors<T>(requestId: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn()
+  } catch (error) {
+    if (error instanceof McpError) {
+      const mapped = mcpHttpStatus(error)
+      throw routeError(mapped.status, mapped.code, error.message, requestId)
+    }
+    throw error
+  }
+}
+
+function sourceFromUnknown(value: unknown): McpSource | undefined {
+  const record = asRecord(value)
+  const id = parseString(record.id)
+  const workspaceId = parseString(record.workspaceId)
+  const userId = parseString(record.userId)
+  const provider = parseString(record.provider)
+  const displayName = parseString(record.displayName)
+  const status = parseString(record.status)
+  const ownerKind = parseString(record.ownerKind)
+  const credentialProvider = parseString(record.credentialProvider)
+  if (!id || !workspaceId || !userId || !provider || !displayName || !status || !ownerKind || !credentialProvider) return undefined
+  if (!['connected', 'expired', 'revoked', 'error', 'unconfigured'].includes(status)) return undefined
+  return {
+    id,
+    workspaceId,
+    userId,
+    provider,
+    displayName,
+    status: status as McpSource['status'],
+    ownerKind: ownerKind as McpSource['ownerKind'],
+    credentialProvider: credentialProvider as McpSource['credentialProvider'],
+    scopes: Array.isArray(record.scopes) ? record.scopes.filter((item): item is string => typeof item === 'string') : undefined,
+    providerAccountLabel: parseString(record.providerAccountLabel),
+    connectorRef: asRecord(record.connectorRef) as unknown as McpSource['connectorRef'],
+    lastVerifiedAt: parseString(record.lastVerifiedAt),
+    createdAt: parseString(record.createdAt),
+    updatedAt: parseString(record.updatedAt),
+  }
+}
+
+function readRawStoredSources(settings: Record<string, unknown>, actor: McpActor): McpSource[] {
+  const root = asRecord(settings[USER_SETTINGS_MCP_SOURCES_KEY])
+  const workspaceSources = asRecord(root[actor.workspaceId])
+  return Object.values(workspaceSources)
+    .map(sourceFromUnknown)
+    .filter((source): source is McpSource => Boolean(source && source.workspaceId === actor.workspaceId && source.userId === actor.userId))
+}
+
+function normalizeStoredSourceId(actor: McpActor, source: McpSource): McpSource {
+  try {
+    const legacyId = createLegacyManagedConnectorSourceId(actor, source.provider)
+    return source.id === legacyId ? { ...source, id: createManagedConnectorSourceId(actor, source.provider) } : source
+  } catch {
+    return source
+  }
+}
+
+function sourceStatusRank(source: McpSource): number {
+  switch (source.status) {
+    case 'connected': return 5
+    case 'expired':
+    case 'error': return 4
+    case 'unconfigured': return 3
+    case 'revoked': return 1
+    default: return 0
+  }
+}
+
+function dedupeStoredSources(sources: McpSource[]): McpSource[] {
+  const byId = new Map<string, McpSource>()
+  for (const source of sources) {
+    const current = byId.get(source.id)
+    if (!current || sourceStatusRank(source) >= sourceStatusRank(current)) byId.set(source.id, source)
+  }
+  return [...byId.values()]
+}
+
+function readStoredSources(settings: Record<string, unknown>, actor: McpActor): McpSource[] {
+  return dedupeStoredSources(readRawStoredSources(settings, actor).map((source) => normalizeStoredSourceId(actor, source)))
+}
+
+function existingLegacySourceIdFor(actor: McpActor, source: McpSource, rawSources: readonly McpSource[]): string | undefined {
+  try {
+    const legacyId = createLegacyManagedConnectorSourceId(actor, source.provider)
+    return legacyId !== source.id && rawSources.some((item) => item.id === legacyId) ? legacyId : undefined
+  } catch {
+    return undefined
+  }
+}
+
+async function saveStoredSource(
+  app: Pick<BoringMcpAppServer, 'userStore' | 'config'>,
+  actor: McpActor,
+  source: McpSource,
+  removeSourceIds: readonly string[] = [],
+): Promise<McpSource[]> {
+  const patch = app.userStore.patchUserSettingsJsonPath
+  if (patch && removeSourceIds.length === 0) {
+    const updated = await patch.call(
+      app.userStore,
+      actor.userId,
+      app.config.appId,
+      [USER_SETTINGS_MCP_SOURCES_KEY, actor.workspaceId, source.id],
+      source,
+    )
+    return readStoredSources(updated.settings, actor)
+  }
+
+  return await withUserSettingsWriteLock(actor.userId, app.config.appId, async () => {
+    const current = await app.userStore.getUserSettings(actor.userId, app.config.appId)
+    const root = asRecord(current.settings[USER_SETTINGS_MCP_SOURCES_KEY])
+    const removeIds = new Set([source.id, ...removeSourceIds])
+    const sources = readRawStoredSources(current.settings, actor)
+    const nextSources = [...sources.filter((item) => !removeIds.has(item.id)), source]
+    const nextSettings = {
+      ...current.settings,
+      [USER_SETTINGS_MCP_SOURCES_KEY]: {
+        ...root,
+        [actor.workspaceId]: Object.fromEntries(nextSources.map((item) => [item.id, item])),
+      },
+    }
+    await app.userStore.putUserSettings(actor.userId, app.config.appId, { settings: nextSettings })
+    return readStoredSources(nextSettings, actor)
+  })
+}
+
+export function createUserSettingsMcpSourceRegistry(
+  app: Pick<BoringMcpAppServer, 'userStore' | 'config'>,
+  actorScope: McpActor,
+): ManagedConnectorSourceRegistry {
+  return {
+    async listSources(actor) {
+      const current = await app.userStore.getUserSettings(actor.userId, app.config.appId)
+      return readStoredSources(current.settings, actor)
+    },
+    async getSource(sourceId) {
+      const current = await app.userStore.getUserSettings(actorScope.userId, app.config.appId)
+      const source = readStoredSources(current.settings, actorScope).find((item) => item.id === sourceId)
+      if (source) return source
+      const legacySource = readRawStoredSources(current.settings, actorScope).find((item) => item.id === sourceId)
+      return legacySource ? normalizeStoredSourceId(actorScope, legacySource) : undefined
+    },
+    async upsertSource(actor, source) {
+      const now = new Date().toISOString()
+      const currentSettings = await app.userStore.getUserSettings(actor.userId, app.config.appId)
+      const current = readStoredSources(currentSettings.settings, actor)
+      const rawSources = readRawStoredSources(currentSettings.settings, actor)
+      const existing = current.find((item) => item.id === source.id)
+      const next = { ...source, updatedAt: now, createdAt: source.createdAt ?? existing?.createdAt ?? now }
+      const legacyId = existingLegacySourceIdFor(actor, next, rawSources)
+      await saveStoredSource(app, actor, next, legacyId ? [legacyId] : [])
+      return next
+    },
+    async disconnectSource(actor, sourceId) {
+      const currentSettings = await app.userStore.getUserSettings(actor.userId, app.config.appId)
+      const source = readStoredSources(currentSettings.settings, actor).find((item) => item.id === sourceId)
+        ?? (() => {
+          const legacySource = readRawStoredSources(currentSettings.settings, actor).find((item) => item.id === sourceId)
+          return legacySource ? normalizeStoredSourceId(actor, legacySource) : undefined
+        })()
+      if (!source) return undefined
+      const disconnected = { ...source, status: 'revoked' as const, updatedAt: new Date().toISOString() }
+      const legacyId = existingLegacySourceIdFor(actor, disconnected, readRawStoredSources(currentSettings.settings, actor))
+      await saveStoredSource(app, actor, disconnected, legacyId ? [legacyId] : [])
+      return disconnected
+    },
+  }
+}
+
+export interface CreateBoringMcpAppAgentToolsOptions {
+  config: BoringMcpBindingConfig
+  env?: NodeJS.ProcessEnv
+  transport?: McpTransportClient
+}
+
+function createComposioMcpTransportFor(config: BoringMcpBindingConfig, env?: NodeJS.ProcessEnv): McpTransportClient {
+  return createComposioMcpTransport({
+    secretResolver: createManagedConnectorSecretResolver({ env, configs: config.connectorConfigs, secretEnvVars: config.secretEnvVars }),
+    configs: config.connectorConfigs,
+    clientName: config.clientName ?? 'boring-mcp',
+    clientVersion: config.clientVersion ?? '0.0.0',
+  })
+}
+
+export function createBoringMcpAppAgentTools(
+  app: Pick<BoringMcpAppServer, 'userStore' | 'config'>,
+  actor: McpActor,
+  options: CreateBoringMcpAppAgentToolsOptions,
+): AgentTool[] {
+  const runtimeConfig = readBoringMcpServerConfig(options.env, { secretEnvVars: options.config.secretEnvVars })
+  if (!runtimeConfig.enabled) return []
+  const registry = createUserSettingsMcpSourceRegistry(app, actor)
+  const transport = options.transport ?? createComposioMcpTransportFor(options.config, options.env)
+  return createBoringMcpAgentTools({
+    registry,
+    transport,
+    resolveActor: () => actor,
+    templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
+    hardening: { gate: new InMemoryMcpRateBudgetGate({ maxCalls: 100, maxToolCalls: 10, windowMs: 60_000 }), timeoutMs: 30_000 },
+    maxReadonlyInputBytes: runtimeConfig.maxReadonlyInputBytes,
+  })
+}
+
+export function createBoringMcpAppAgentToolsForRequest(
+  app: Pick<BoringMcpAppServer, 'userStore' | 'config'>,
+  ctx: { workspaceId: string; authSubject?: string },
+  options: CreateBoringMcpAppAgentToolsOptions,
+): AgentTool[] {
+  const userId = typeof ctx.authSubject === 'string' && ctx.authSubject.trim() ? ctx.authSubject.trim() : undefined
+  if (!userId) return []
+  return createBoringMcpAppAgentTools(app, { workspaceId: ctx.workspaceId, userId }, options)
+}
+
+async function requireBoringMcpActor(app: BoringMcpAppServer, request: FastifyRequest): Promise<McpActor> {
+  const body = asRecord(request.body)
+  const query = asRecord(request.query)
+  const workspaceId = validateWorkspaceId(
+    request.headers['x-boring-workspace-id'] ?? body.workspaceId ?? query.workspaceId,
+    request.id,
+  )
+  const user = request.user
+  if (!user) throw routeError(401, ERROR_CODES.UNAUTHORIZED, 'Authentication required', request.id)
+  const workspace = await app.workspaceStore.get(workspaceId)
+  if (!workspace || workspace.appId !== app.config.appId) throw routeError(404, ERROR_CODES.NOT_FOUND, 'Workspace not found', request.id)
+  const role = await app.workspaceStore.getMemberRole(workspaceId, user.id)
+  if (!role) throw routeError(403, ERROR_CODES.NOT_MEMBER, 'Not a member of this workspace', request.id)
+  return { workspaceId, userId: user.id }
+}
+
+function sourceActionRateLimitKey(request: FastifyRequest): string {
+  const workspaceId = typeof request.headers['x-boring-workspace-id'] === 'string'
+    ? request.headers['x-boring-workspace-id']
+    : 'unknown-workspace'
+  return `${request.user?.id ?? request.ip}:${workspaceId}`
+}
+
+function sourceIdFromBody(body: unknown, requestId: string): string {
+  const sourceId = parseString(asRecord(body).sourceId)
+  if (!sourceId) throw routeError(400, ERROR_CODES.VALIDATION_FAILED, 'sourceId is required', requestId)
+  return sourceId
+}
+
+function providerFromBody(body: unknown, requestId: string): McpProviderId {
+  const provider = parseString(asRecord(body).provider)
+  if (!provider) throw routeError(400, ERROR_CODES.VALIDATION_FAILED, 'provider is required', requestId)
+  return provider
+}
+
+export interface RegisterBoringMcpRoutesOptions {
+  config: BoringMcpBindingConfig
+  provider?: ManagedConnectorProvider
+  env?: NodeJS.ProcessEnv
+  transport?: McpTransportClient
+  /**
+   * Behavior when boring-mcp is disabled for this deployment.
+   * - `skip` (default): do not register the routes at all (client sees 404).
+   * - `serve-503`: always register; handlers reject with 503 while disabled.
+   */
+  whenDisabled?: 'skip' | 'serve-503'
+}
+
+export function registerBoringMcpRoutes(app: BoringMcpAppServer, options: RegisterBoringMcpRoutesOptions): void {
+  const whenDisabled = options.whenDisabled ?? 'skip'
+  const enabled = readBoringMcpServerConfig(options.env, { secretEnvVars: options.config.secretEnvVars }).enabled
+  if (!enabled && whenDisabled === 'skip') return
+
+  const assertEnabled = (requestId: string): void => {
+    if (!enabled) throw routeError(503, ERROR_CODES.INTERNAL_ERROR, 'MCP source routes are disabled for this deployment', requestId)
+  }
+
+  const routeTransport = options.transport ?? createComposioMcpTransportFor(options.config, options.env)
+  const routeGate = new InMemoryMcpRateBudgetGate({ maxCalls: 100, maxToolCalls: 10, windowMs: 60_000 })
+
+  function adapterFor(actor: McpActor) {
+    const registry = createUserSettingsMcpSourceRegistry(app, actor)
+    return {
+      registry,
+      adapter: createBoringMcpManagedConnectorAdapter({ config: options.config, registry, provider: options.provider, env: options.env }),
+    }
+  }
+
+  function handlersFor(actor: McpActor) {
+    return createBoringMcpSourceHandlers({
+      registry: createUserSettingsMcpSourceRegistry(app, actor),
+      transport: routeTransport,
+      templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
+      hardening: { gate: routeGate, timeoutMs: 30_000 },
+    })
+  }
+
+  app.get('/api/v1/boring-mcp/sources', async (request) => {
+    assertEnabled(request.id)
+    const actor = await requireBoringMcpActor(app, request)
+    const { registry } = adapterFor(actor)
+    const sources = await registry.listSources(actor)
+    return { sourceStatuses: sources.map(createMcpSourceStatusPayload) }
+  })
+
+  app.post('/api/v1/boring-mcp/connect', {
+    config: { rateLimit: { ...SOURCE_CONNECT_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
+  }, async (request, reply) => {
+    assertEnabled(request.id)
+    const actor = await requireBoringMcpActor(app, request)
+    const { adapter } = adapterFor(actor)
+    const provider = providerFromBody(request.body, request.id)
+    const result = await withMcpHttpErrors(request.id, () => adapter.startConnect(actor, { provider }))
+    const { connectUrl, ...status } = result
+    reply.status(201)
+    return { status, connectUrl }
+  })
+
+  app.post('/api/v1/boring-mcp/refresh', {
+    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
+  }, async (request) => {
+    assertEnabled(request.id)
+    const actor = await requireBoringMcpActor(app, request)
+    const { adapter } = adapterFor(actor)
+    const result = await withMcpHttpErrors(request.id, () => adapter.refreshStatus(actor, sourceIdFromBody(request.body, request.id)))
+    return { status: result }
+  })
+
+  app.post('/api/v1/boring-mcp/disconnect', {
+    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
+  }, async (request) => {
+    assertEnabled(request.id)
+    const actor = await requireBoringMcpActor(app, request)
+    const status = await withMcpHttpErrors(request.id, () => adapterFor(actor).adapter.disconnectSource(actor, sourceIdFromBody(request.body, request.id)))
+    return { status }
+  })
+
+  app.post('/api/v1/boring-mcp/tools', {
+    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
+  }, async (request) => {
+    assertEnabled(request.id)
+    const actor = await requireBoringMcpActor(app, request)
+    const body = asRecord(request.body)
+    const result = await withMcpHttpErrors(request.id, () => handlersFor(actor).searchTools(actor, {
+      sourceId: sourceIdFromBody(request.body, request.id),
+      refresh: body.refresh === true,
+    }))
+    return { tools: result.tools }
+  })
+}

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -34,6 +34,7 @@ export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPlugin
 }
 
 export default createBoringMcpServerPlugin()
+export * from "./appServerBinding"
 export * from "./agentBridge"
 export * from "./agentTools"
 export * from "./composioManagedConnector"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,7 +361,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.7.0
-        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
@@ -388,10 +388,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: ^8.1.2
-        version: 8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+        version: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/agent/examples/with-custom-tool:
     devDependencies:
@@ -1165,7 +1165,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^4.0.0
-        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       fastify:
         specifier: ^5.9.0
         version: 5.10.0
@@ -1186,7 +1186,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   plugins/boring-governance:
     dependencies:
@@ -1261,6 +1261,9 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
     devDependencies:
+      '@hachej/boring-core':
+        specifier: workspace:*
+        version: link:../../packages/core
       '@hachej/boring-workspace':
         specifier: workspace:*
         version: link:../../packages/workspace
@@ -1282,6 +1285,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      fastify:
+        specifier: ^5.9.0
+        version: 5.10.0
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)
@@ -13540,7 +13546,7 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vitejs/plugin-react@4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@4.7.0(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -13548,7 +13554,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13580,13 +13586,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -17786,21 +17792,6 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.5
-      postcss: 8.5.16
-      rolldown: 1.1.5
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 22.20.1
-      esbuild: 0.27.7
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      tsx: 4.23.0
-      yaml: 2.9.0
-
   vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -17845,10 +17836,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -17865,7 +17856,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
## Why

Tenant deployment repos are forks of `apps/full-app`. An audit found two blocks of server code copied **byte-for-byte** (modulo renames) into tenants, forcing every tenant to hand-maintain host runtime code:

1. `apps/full-app/src/server/worker/{auth,config,exec,routes,workspace}.ts` + `agent-worker.ts` — the internal bwrap worker Fastify server (copied 0-diff).
2. `apps/full-app/src/server/boringMcp.ts` (~495 lines) — MCP source registry, HTTP error mapping, route registration over `@hachej/boring-mcp/server` (copied with only renames + a couple of config tweaks).

This PR relocates both into the published packages so a tenant needs only an import plus a few lines of config.

## What moved where

**Worker runtime → `@hachej/boring-agent/server/worker`**
- `apps/full-app/src/server/worker/*.ts` → `packages/agent/src/server/worker/*` behind a new `./server/worker` subpath export, exposing `createWorkerServer()`, `registerWorkerRoutes`, `loadWorkerConfig`, `createWorkerRuntime`, etc.
- Env reads centralized in `src/server/config/workerConfig.ts` and wire-protocol codes moved to a `WORKER_ERROR_CODES` enum to satisfy the agent package invariants (grep-enforced).
- `apps/full-app/src/server/agent-worker.ts` is now a thin entry over `createWorkerServer()`; local `worker/` copies **deleted**; Dockerfile no longer copies `dist/server/worker/`.

**MCP server glue → `@hachej/boring-mcp/server`**
- New `appServerBinding.ts` with config-driven factories: `readBoringMcpServerConfig`, `createManagedConnectorSecretResolver`, `createBoringMcpManagedConnectorAdapter`, `createUserSettingsMcpSourceRegistry`, `createBoringMcpAppAgentTools(ForRequest)`, `registerBoringMcpRoutes`, `boringMcpAgentSessionNamespace`.
- All previously-hardcoded, tenant-varying values are parameters via `BoringMcpBindingConfig`: `connectorConfigs`, `secretEnvVars`, `redactionCanaries`, `clientName/Version`, and a `whenDisabled: skip | serve-503` policy.
- `boring-mcp` gains a dependency on `@hachej/boring-core`; full-app build order updated so core builds before mcp (no cycle: core does not depend on mcp).

## Consumption proof (full-app)

`apps/full-app/src/server/boringMcp.ts` shrank from ~495 lines to thin wrappers that keep the same public names and inject only full-app's config (Notion/Airtable connectors, `boring-full-app-mcp` client, `COMPOSIO_API_KEY`). The existing full-app `boringMcp.test.ts` (17 tests) passes unchanged through those wrappers, demonstrating the exports are sufficient for a tenant.

## Generalizations (design forks)

- The full-app disabled-route behavior (skip → 404) and the tenant variant (always-registered → 503) are unified behind `whenDisabled` (default `skip`, preserving full-app behavior).
- Composio secret lookup now accepts an ordered `secretEnvVars` list so tenants can add their own env var fallback without re-copying.

## Tests / gates

- `packages/agent`: added `worker.test.ts` (boots `createWorkerServer` from a stub config; 401/400 auth+validation). Typecheck, build, `check-invariants.sh`, and full vitest suite pass.
- `plugins/boring-mcp`: added `appServerBinding.test.ts` (config read, secret-env fallback, skip/serve-503). Typecheck, build, 95 tests pass.
- `apps/full-app`: typecheck + full vitest suite (37 tests) pass; `production-safety` Dockerfile check still green.

Does **not** modify the tenant repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
