### PR TITLE
#637 fix(workspace): close overlays on active session click

### DIFF
--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -696,6 +696,40 @@ describe("WorkspaceAgentFront", () => {
     expect(visibleChatSessionIds()).toEqual(["s2"])
   })
 
+  it("closes an app-left overlay when reselecting the active session", async () => {
+    const user = userEvent.setup()
+    const onSwitchSession = vi.fn()
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes("/api/v1/tree")) return new Response(JSON.stringify({ entries: [] }), { status: 200 })
+      if (url.includes("/api/v1/ready-status")) return new Response(null, { status: 200 })
+      if (url.includes("/api/v1/agent-plugins")) return new Response(JSON.stringify([]), { status: 200 })
+      if (url.includes("/api/v1/ui/commands/next")) return new Response(JSON.stringify([]), { status: 200 })
+      return new Response(null, { status: 204 })
+    }))
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="plugin-tabs-active-session-closes-overlay"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        sessions={[{ id: "s1", title: "First session" }]}
+        activeSessionId="s1"
+        onSwitchSession={onSwitchSession}
+        persistenceEnabled={false}
+      />,
+    )
+
+    const appNav = screen.getByLabelText("App navigation")
+    await user.click(within(appNav).getByRole("button", { name: "Plugins" }))
+    await waitFor(() => expect(document.querySelector('[data-boring-workspace-part="plugins-overlay"]')).not.toBeNull())
+
+    await user.click(within(appNav).getByText("First session"))
+
+    expect(onSwitchSession).toHaveBeenCalledWith("s1")
+    expect(document.querySelector('[data-boring-workspace-part="plugins-overlay"]')).toBeNull()
+  })
+
   it("opens Skills as a chat overlay and uses the UI bridge to open a skill", async () => {
     const user = userEvent.setup()
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -54,9 +54,10 @@ export function AppSessionRow({
   onDelete?: (id: string) => void
 }) {
   const title = session.title || "Untitled"
-  const activate = () => {
-    if (state !== "active") onSwitch(session.id)
-  }
+  // Re-selecting the active chat is intentional: the shell uses this callback
+  // to dismiss transient app-left overlays (Tasks, Skills, Plugins) even when
+  // no session switch is needed.
+  const activate = () => onSwitch(session.id)
 
   return (
     <div
@@ -97,8 +98,8 @@ export function AppSessionRow({
           event.stopPropagation()
           activate()
         }}
-        disabled={state === "active"}
-        className="min-w-0 flex-1 truncate rounded text-left text-[13px] font-medium leading-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-default"
+        aria-current={state === "active" ? "page" : undefined}
+        className="min-w-0 flex-1 truncate rounded text-left text-[13px] font-medium leading-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
         title={title}
       >
         {title}

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -43,6 +43,29 @@ describe("AppLeftPane", () => {
     expect(badge?.closest('[data-boring-workspace-part="app-session-row"]')).toHaveTextContent("Second session")
   })
 
+  it("calls onSwitchSession when reselecting the active session", () => {
+    const onSwitchSession = vi.fn()
+    render(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane
+          appTitle="Test"
+          sessions={sessions}
+          activeSessionId="s1"
+          openSessionIds={["s1"]}
+          pinnedSessionIds={[]}
+          onCreateSession={vi.fn()}
+          onOpenCommandPalette={vi.fn()}
+          onSwitchSession={onSwitchSession}
+          onOpenSessionAsPane={vi.fn()}
+          onToggleSessionPinned={vi.fn()}
+        />
+      </WorkspaceAttentionProvider>,
+    )
+
+    fireEvent.click(screen.getByText("First session"))
+    expect(onSwitchSession).toHaveBeenCalledWith("s1")
+  })
+
   it("keeps the status badge area clickable for switching sessions", () => {
     const onSwitchSession = vi.fn()
     render(


### PR DESCRIPTION
## Summary

Reselecting the active session now dismisses app-left overlays such as Tasks, Skills, and Plugins.

## Issue / Slice

Closes #637.

## What Changed

- Active session rows are no longer disabled/no-op targets.
- Reselecting any session invokes the existing session-activation callback, which closes the active overlay.
- Adds row-level and integrated overlay regression coverage.

## Proof

`pnpm --filter @hachej/boring-workspace exec vitest run src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx src/app/front/__tests__/WorkspaceAgentFront.test.tsx`

Passed: 2 files, 64 tests.

## Risk / Rollback

Small interaction change: reselecting an active session now re-dispatches its existing activation callback. Revert this commit to restore the previous no-op behavior.
