### PR TITLE
fix(release): include boring-automation in publish cohort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,7 +641,7 @@ jobs:
 
       - name: Publish packages with ci dist-tag
         run: |
-          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core packages/cli plugins/deck plugins/diagram plugins/ask-user plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-sandbox plugins/boring-mcp packages/boring-bash plugins/boring-governance; do
+          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core packages/cli plugins/deck plugins/diagram plugins/tasks plugins/ask-user plugins/boring-automation plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-sandbox plugins/boring-mcp packages/boring-bash plugins/boring-governance; do
             tarball=$(cd $pkg && pnpm pack 2>&1 | tail -1)
             if ! npm publish "$pkg/$tarball" --access public --tag ci --provenance; then
               echo "::warning::CI package publish failed for $pkg; continuing because release publishing is handled by release.yml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,9 @@ jobs:
             --filter @hachej/boring-core \
             --filter @hachej/boring-deck \
             --filter @hachej/boring-ask-user \
+            --filter @hachej/boring-diagram \
+            --filter @hachej/boring-tasks \
+            --filter @hachej/boring-automation \
             --filter @hachej/boring-data-explorer \
             --filter @hachej/boring-data-catalog \
             --filter @hachej/boring-generated-pane \
@@ -68,7 +71,7 @@ jobs:
 
       - name: Publish
         run: |
-          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core plugins/deck plugins/ask-user packages/cli plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-sandbox plugins/boring-mcp packages/boring-bash plugins/boring-governance; do
+          for pkg in packages/ui packages/agent packages/plugin-cli packages/workspace packages/core plugins/deck plugins/ask-user plugins/diagram plugins/tasks plugins/boring-automation packages/cli plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-sandbox plugins/boring-mcp packages/boring-bash plugins/boring-governance; do
             name=$(node -p "require('./$pkg/package.json').name")
             version=$(node -p "require('./$pkg/package.json').version")
             if npm view "$name@$version" version >/dev/null 2>&1; then

--- a/plugins/boring-automation/package.json
+++ b/plugins/boring-automation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-automation",
-  "version": "0.1.71",
+  "version": "0.1.78",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/scripts/audit-publish-manifests.mjs
+++ b/scripts/audit-publish-manifests.mjs
@@ -25,6 +25,7 @@ const PUBLISHABLE_PACKAGES = [
   "plugins/ask-user",
   "plugins/diagram",
   "plugins/tasks",
+  "plugins/boring-automation",
   "packages/cli",
   "plugins/data-explorer",
   "plugins/data-catalog",

--- a/scripts/check-release-staging.mjs
+++ b/scripts/check-release-staging.mjs
@@ -16,6 +16,7 @@ const allowed = new Set([
   "plugins/ask-user/package.json",
   "plugins/diagram/package.json",
   "plugins/tasks/package.json",
+  "plugins/boring-automation/package.json",
   "plugins/data-explorer/package.json",
   "plugins/data-catalog/package.json",
   "plugins/generated-pane/package.json",

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -59,6 +59,7 @@ release_files=(
   plugins/ask-user/package.json
   plugins/diagram/package.json
   plugins/tasks/package.json
+  plugins/boring-automation/package.json
   plugins/data-explorer/package.json
   plugins/data-catalog/package.json
   plugins/generated-pane/package.json

--- a/scripts/set-ci-package-version.mjs
+++ b/scripts/set-ci-package-version.mjs
@@ -25,6 +25,7 @@ const PUBLISHABLE = [
   "plugins/ask-user",
   "plugins/diagram",
   "plugins/tasks",
+  "plugins/boring-automation",
   "plugins/data-explorer",
   "plugins/data-catalog",
   "plugins/generated-pane",

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -20,6 +20,7 @@ const PUBLISHABLE = [
   "plugins/ask-user",
   "plugins/diagram",
   "plugins/tasks",
+  "plugins/boring-automation",
   "packages/cli", // @hachej/boring-ui-cli
   "plugins/data-explorer",
   "plugins/data-catalog",


### PR DESCRIPTION
## Summary
- `packages/cli` gained a runtime dependency on `@hachej/boring-automation` (commit 36b3da993) but `plugins/boring-automation` was never added to the release scripts' publish cohort, so `pnpm audit:publish-manifests` fails with `@hachej/boring-automation@0.1.71 is not published on npm`.
- Adds `plugins/boring-automation` to every cohort touchpoint (`version.mjs`, `audit-publish-manifests.mjs`, `set-ci-package-version.mjs`, `check-release-staging.mjs`, `cut-release.sh`, `release.yml` build filter + publish loop, `ci.yml` ci-tag publish loop), positioned before `packages/cli` so it publishes first — mirrors the `boring-mcp` cohort addition at v0.1.78. Aligns its version to the current cohort baseline (0.1.78) so `version.mjs`'s alignment check passes.
- Also closes the same latent gap for `plugins/diagram` and `plugins/tasks`: they were added to the version/audit/staging cohort in a prior fix (`dc1d53d27`) but never added to `release.yml`'s actual publish loop. As a result `@hachej/boring-ui-cli@0.1.78` (currently on npm) depends on `@hachej/boring-tasks` (never published at all) and `@hachej/boring-diagram@0.1.78` (only 0.1.67 is on npm) — i.e. `npm install @hachej/boring-ui-cli` is broken today. Adds both to `release.yml`'s publish loop before `packages/cli`, and adds `plugins/tasks` to `ci.yml`'s ci-tag loop to match `diagram`.

## Test plan
- [x] `pnpm --filter @hachej/boring-automation build` succeeds (after rebuilding stale `boring-agent`/`boring-workspace` dist locally)
- [x] `pnpm --filter @hachej/boring-automation test` — 73 tests pass
- [x] `pnpm pack` on `plugins/boring-automation` produces a manifest with no `workspace:*` leaks
- [x] `pnpm audit:publish-manifests` passes clean for all 19 cohort packages including boring-automation, diagram, and tasks
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)