### PR TITLE
feat(391-P1): recut binding-local readiness reporting

### DIFF
--- a/packages/agent/src/core/createAgent.ts
+++ b/packages/agent/src/core/createAgent.ts
@@ -30,6 +30,7 @@ export type AgentCoreRuntimeFactory = () => AgentCoreRuntime | Promise<AgentCore
 
 export interface AgentCoreConfig {
   runtimeFactory: AgentCoreRuntimeFactory
+  readiness?: AgentReadiness
   readinessRequirements?: string[]
 }
 
@@ -305,16 +306,22 @@ function createRuntimeLoader(runtimeFactory: AgentCoreRuntimeFactory): {
 }
 
 function createReadiness(config: AgentCoreConfig, assertActive: () => void): AgentReadiness {
-  const requirements = [...(config.readinessRequirements ?? [])]
+  const reporter = config.readiness
+  const requirements = [...(reporter?.requirements ?? config.readinessRequirements ?? [])]
   return {
     requirements,
     async status() {
       assertActive()
-      return requirements.map((key) => ({
-        key,
-        ready: false,
-        message: 'readiness status is not available in the core facade',
-      }))
+      if (!reporter) {
+        return requirements.map((key) => ({
+          key,
+          ready: false,
+          message: 'readiness status is not available in the core facade',
+        }))
+      }
+      const statuses = await reporter.status()
+      assertActive()
+      return statuses
     },
   }
 }

--- a/packages/agent/src/server/__tests__/agentReadiness.test.ts
+++ b/packages/agent/src/server/__tests__/agentReadiness.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'vitest'
+
+import { ErrorCode } from '../../shared/error-codes'
+import type { AgentTool, ToolReadinessRequirement } from '../../shared/tool'
+import { collectToolReadinessRequirements, createAgentReadinessFromTracker } from '../agentReadiness'
+import { ReadyStatusTracker } from '../runtime/readyStatus'
+
+describe('agent readiness', () => {
+  test('preserves first-surviving requirement order and reports only owned facts as ready', async () => {
+    const tools: AgentTool[] = [
+      makeTool('read', ['workspace-fs']),
+      makeTool('bash', ['sandbox-exec', 'runtime:python']),
+      makeTool('grep', ['workspace-fs', 'ui-bridge']),
+    ]
+    const requirements = collectToolReadinessRequirements(tools)
+    const tracker = new ReadyStatusTracker({
+      sandboxReady: false,
+      harnessReady: true,
+      capabilities: {
+        workspace: {
+          state: 'failed',
+          errorCode: ErrorCode.enum.WORKSPACE_NOT_READY,
+          causeCode: 'WORKSPACE_MOUNT_FAILED',
+          message: 'Workspace mount failed.',
+          retryable: false,
+        },
+        runtimeDependencies: { state: 'not-started' },
+      },
+    })
+    const readiness = createAgentReadinessFromTracker({
+      requirements,
+      tracker,
+      checkReadiness: (requirement) => ({
+        ready: false,
+        state: 'not-started',
+        workspaceId: 'workspace-a',
+        message: `${requirement} has not started.`,
+        retryable: true,
+      }),
+    })
+
+    expect(requirements).toEqual(['workspace-fs', 'sandbox-exec', 'runtime:python', 'ui-bridge'])
+    await expect(readiness.status()).resolves.toEqual([
+      {
+        key: 'workspace-fs',
+        ready: false,
+        state: 'failed',
+        errorCode: ErrorCode.enum.WORKSPACE_NOT_READY,
+        causeCode: 'WORKSPACE_MOUNT_FAILED',
+        message: 'Workspace mount failed.',
+        retryable: false,
+      },
+      {
+        key: 'sandbox-exec',
+        ready: false,
+        state: 'preparing',
+        errorCode: ErrorCode.enum.SANDBOX_NOT_READY,
+        retryable: true,
+      },
+      {
+        key: 'runtime:python',
+        ready: false,
+        state: 'not-started',
+        errorCode: ErrorCode.enum.AGENT_RUNTIME_NOT_READY,
+        workspaceId: 'workspace-a',
+        message: 'runtime:python has not started.',
+        retryable: true,
+      },
+      { key: 'ui-bridge', ready: false },
+    ])
+  })
+
+  test.each([
+    ['not-started', false, ErrorCode.enum.AGENT_RUNTIME_NOT_READY],
+    ['preparing', false, ErrorCode.enum.AGENT_RUNTIME_NOT_READY],
+    ['failed', false, ErrorCode.enum.RUNTIME_PROVISIONING_FAILED],
+    ['ready', true, undefined],
+  ] as const)('reports runtime dependency state %s as ready=%s', async (state, ready, errorCode) => {
+    const tracker = new ReadyStatusTracker({
+      capabilities: { runtimeDependencies: { state } },
+    })
+    const readiness = createAgentReadinessFromTracker({
+      requirements: ['runtime-dependencies'],
+      tracker,
+    })
+
+    await expect(readiness.status()).resolves.toEqual([{
+      key: 'runtime-dependencies',
+      ready,
+      state,
+      ...(errorCode ? { errorCode } : {}),
+    }])
+  })
+
+  test('keeps tracker runtime state authoritative when a legacy check returns ready', async () => {
+    const tracker = new ReadyStatusTracker({
+      capabilities: { runtimeDependencies: { state: 'not-started' } },
+    })
+    const readiness = createAgentReadinessFromTracker({
+      requirements: ['runtime:python'],
+      tracker,
+      checkReadiness: () => true,
+    })
+
+    await expect(readiness.status()).resolves.toEqual([{
+      key: 'runtime:python',
+      ready: false,
+      state: 'not-started',
+      errorCode: ErrorCode.enum.AGENT_RUNTIME_NOT_READY,
+    }])
+  })
+
+  test('keeps tracker and runtime facts isolated between bindings', async () => {
+    const trackerA = new ReadyStatusTracker({
+      sandboxReady: true,
+      capabilities: {
+        workspace: { state: 'ready' },
+        runtimeDependencies: { state: 'ready' },
+      },
+    })
+    const trackerB = new ReadyStatusTracker({
+      sandboxReady: false,
+      capabilities: {
+        workspace: { state: 'preparing', message: 'Workspace B is preparing.' },
+        runtimeDependencies: { state: 'failed' },
+      },
+    })
+    const requirements: ToolReadinessRequirement[] = ['workspace-fs', 'sandbox-exec', 'runtime:node']
+    const readinessA = createAgentReadinessFromTracker({
+      requirements,
+      tracker: trackerA,
+      checkReadiness: () => true,
+    })
+    const readinessB = createAgentReadinessFromTracker({
+      requirements,
+      tracker: trackerB,
+      checkReadiness: () => ({ ready: false, state: 'failed', workspaceId: 'workspace-b' }),
+    })
+
+    await expect(readinessA.status()).resolves.toEqual([
+      { key: 'workspace-fs', ready: true, state: 'ready' },
+      { key: 'sandbox-exec', ready: true, state: 'ready' },
+      { key: 'runtime:node', ready: true, state: 'ready' },
+    ])
+    await expect(readinessB.status()).resolves.toEqual([
+      {
+        key: 'workspace-fs',
+        ready: false,
+        state: 'preparing',
+        errorCode: ErrorCode.enum.WORKSPACE_NOT_READY,
+        message: 'Workspace B is preparing.',
+      },
+      {
+        key: 'sandbox-exec',
+        ready: false,
+        state: 'preparing',
+        errorCode: ErrorCode.enum.SANDBOX_NOT_READY,
+        retryable: true,
+      },
+      {
+        key: 'runtime:node',
+        ready: false,
+        state: 'failed',
+        errorCode: ErrorCode.enum.RUNTIME_PROVISIONING_FAILED,
+        workspaceId: 'workspace-b',
+        retryable: true,
+      },
+    ])
+  })
+})
+
+function makeTool(name: string, readinessRequirements: ToolReadinessRequirement[]): AgentTool {
+  return {
+    name,
+    description: `${name} test tool.`,
+    readinessRequirements,
+    parameters: { type: 'object', properties: {} },
+    async execute() {
+      return { content: [{ type: 'text', text: name }] }
+    },
+  }
+}

--- a/packages/agent/src/server/__tests__/createAgent.test.ts
+++ b/packages/agent/src/server/__tests__/createAgent.test.ts
@@ -110,6 +110,76 @@ describe('createAgent', () => {
     }])
   })
 
+  it('snapshots and delegates an injected readiness reporter', async () => {
+    const reporterRequirements = ['runtime:python']
+    const agent = createCoreAgent({
+      runtimeFactory: createCoreRuntimeFactory(),
+      readiness: {
+        requirements: reporterRequirements,
+        async status() {
+          return [{
+            key: 'runtime:python',
+            ready: false,
+            state: 'preparing',
+            errorCode: ErrorCode.enum.AGENT_RUNTIME_NOT_READY,
+            retryable: true,
+          }]
+        },
+      },
+    })
+    reporterRequirements.push('workspace-fs')
+
+    expect(agent.readiness.requirements).toEqual(['runtime:python'])
+    await expect(agent.readiness.status()).resolves.toEqual([{
+      key: 'runtime:python',
+      ready: false,
+      state: 'preparing',
+      errorCode: ErrorCode.enum.AGENT_RUNTIME_NOT_READY,
+      retryable: true,
+    }])
+    await agent.dispose()
+  })
+
+  it('does not invoke an injected readiness probe after binding disposal', async () => {
+    const status = vi.fn(async () => [{ key: 'workspace-fs', ready: true }])
+    const agent = createCoreAgent({
+      runtimeFactory: createCoreRuntimeFactory(),
+      readiness: { requirements: ['workspace-fs'], status },
+    })
+
+    await agent.dispose()
+
+    await expect(agent.readiness.status()).rejects.toMatchObject({
+      code: ErrorCode.enum.AGENT_BINDING_DISPOSED,
+    })
+    expect(status).not.toHaveBeenCalled()
+  })
+
+  it('rejects an injected readiness result when disposal wins the awaited probe', async () => {
+    let markProbeStarted!: () => void
+    const probeStarted = new Promise<void>((resolve) => { markProbeStarted = resolve })
+    let resolveProbe!: (statuses: Array<{ key: string; ready: boolean }>) => void
+    const agent = createCoreAgent({
+      runtimeFactory: createCoreRuntimeFactory(),
+      readiness: {
+        requirements: ['workspace-fs'],
+        status() {
+          markProbeStarted()
+          return new Promise<Array<{ key: string; ready: boolean }>>((resolve) => { resolveProbe = resolve })
+        },
+      },
+    })
+
+    const pendingStatus = agent.readiness.status()
+    await probeStarted
+    await agent.dispose()
+    resolveProbe([{ key: 'workspace-fs', ready: true }])
+
+    await expect(pendingStatus).rejects.toMatchObject({
+      code: ErrorCode.enum.AGENT_BINDING_DISPOSED,
+    })
+  })
+
   it('start returns an accepted receipt and send live-tails a harness turn', async () => {
     const agent = createAgent({
       runtime: createTestRuntime(),

--- a/packages/agent/src/server/agentReadiness.ts
+++ b/packages/agent/src/server/agentReadiness.ts
@@ -1,0 +1,119 @@
+import { ErrorCode } from '../shared/error-codes'
+import type { AgentReadiness, AgentReadinessStatus } from '../shared/events'
+import type { AgentTool, ToolReadinessRequirement } from '../shared/tool'
+import type { ToolReadinessCheck, ToolReadinessState } from './catalog/toolReadiness'
+import type { CapabilityReadinessDetail, ReadyStatusTracker } from './runtime/readyStatus'
+
+const READINESS_PROBE_TOOL: AgentTool = {
+  name: 'agent_readiness_probe',
+  description: 'Internal readiness probe.',
+  parameters: { type: 'object', properties: {} },
+  async execute() {
+    return { content: [] }
+  },
+}
+
+export function collectToolReadinessRequirements(tools: readonly AgentTool[]): ToolReadinessRequirement[] {
+  const requirements = new Set<ToolReadinessRequirement>()
+  for (const tool of tools) {
+    for (const requirement of tool.readinessRequirements ?? []) requirements.add(requirement)
+  }
+  return [...requirements]
+}
+
+export function createAgentReadinessFromTracker(options: {
+  requirements: readonly string[]
+  tracker: ReadyStatusTracker
+  checkReadiness?: ToolReadinessCheck
+}): AgentReadiness {
+  const requirements = [...new Set(options.requirements)]
+  return {
+    requirements,
+    async status() {
+      return requirements.map((requirement) => readinessStatusForRequirement(requirement, options))
+    },
+  }
+}
+
+function readinessStatusForRequirement(
+  requirement: string,
+  options: {
+    tracker: ReadyStatusTracker
+    checkReadiness?: ToolReadinessCheck
+  },
+): AgentReadinessStatus {
+  const snapshot = options.tracker.getReadiness()
+  if (requirement === 'workspace-fs') {
+    return statusFromCapability(requirement, snapshot.capabilities.workspace, ErrorCode.enum.WORKSPACE_NOT_READY)
+  }
+  if (requirement === 'sandbox-exec') {
+    return snapshot.sandboxReady
+      ? { key: requirement, ready: true, state: 'ready' }
+      : {
+          key: requirement,
+          ready: false,
+          state: 'preparing',
+          errorCode: ErrorCode.enum.SANDBOX_NOT_READY,
+          retryable: true,
+        }
+  }
+  if (isRuntimeReadinessRequirement(requirement)) {
+    const status = statusFromCapability(
+      requirement,
+      snapshot.capabilities.runtimeDependencies,
+      ErrorCode.enum.AGENT_RUNTIME_NOT_READY,
+    )
+    if (status.ready || !options.checkReadiness) return status
+    return enrichRuntimeStatus(
+      status,
+      options.checkReadiness(requirement, READINESS_PROBE_TOOL),
+    )
+  }
+  return { key: requirement, ready: false }
+}
+
+function enrichRuntimeStatus(
+  status: AgentReadinessStatus,
+  readiness: ToolReadinessState,
+): AgentReadinessStatus {
+  if (readiness === true || (typeof readiness === 'object' && readiness !== null && readiness.ready === true)) {
+    return status
+  }
+  if (readiness === false) {
+    return { ...status, retryable: status.retryable ?? true }
+  }
+  return {
+    ...status,
+    ...(readiness.errorCode ? { errorCode: readiness.errorCode } : {}),
+    ...(readiness.causeCode ? { causeCode: readiness.causeCode } : {}),
+    ...(readiness.message ? { message: readiness.message } : {}),
+    ...(readiness.workspaceId ? { workspaceId: readiness.workspaceId } : {}),
+    retryable: readiness.retryable ?? status.retryable ?? true,
+  }
+}
+
+function statusFromCapability(
+  key: string,
+  detail: CapabilityReadinessDetail,
+  fallbackErrorCode: string,
+): AgentReadinessStatus {
+  const ready = detail.state === 'ready'
+  const errorCode = detail.errorCode ?? (
+    detail.state === 'failed' && isRuntimeReadinessRequirement(key)
+      ? ErrorCode.enum.RUNTIME_PROVISIONING_FAILED
+      : fallbackErrorCode
+  )
+  return {
+    key,
+    ready,
+    state: detail.state,
+    ...(!ready ? { errorCode } : {}),
+    ...(detail.causeCode ? { causeCode: detail.causeCode } : {}),
+    ...(detail.message ? { message: detail.message } : {}),
+    ...(detail.retryable !== undefined ? { retryable: detail.retryable } : {}),
+  }
+}
+
+function isRuntimeReadinessRequirement(requirement: string): requirement is ToolReadinessRequirement {
+  return requirement === 'runtime-dependencies' || requirement.startsWith('runtime:')
+}

--- a/packages/agent/src/server/createAgent.ts
+++ b/packages/agent/src/server/createAgent.ts
@@ -55,6 +55,7 @@ export function createAgentRuntimeBridge(
 
   return createCoreAgentRuntimeBridge({
     runtimeFactory: () => createRuntime(config, options),
+    readiness: config.readiness,
     readinessRequirements: config.readinessRequirements,
   })
 }

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -35,6 +35,7 @@ import {
   type WorkspaceAgentDispatcherResolver,
 } from './workspaceAgentDispatcher'
 import { ErrorCode } from '../shared/error-codes'
+import { collectToolReadinessRequirements, createAgentReadinessFromTracker } from './agentReadiness'
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_SESSION_ID = 'default'
@@ -310,9 +311,16 @@ async function createWorkspaceAgentAppProfile(
     sessionRoot: opts.sessionRoot,
     sessionDir: opts.sessionDir ?? input.sessionDir,
   })) as AgentCoreHarnessFactory
+  const readyTracker = createRuntimeReadyStatusTracker(modeAdapter, {
+    harnessReady: true,
+  })
   const coreAgent = createAgentRuntimeBridge({
     runtime: modeAdapter,
     tools,
+    readiness: createAgentReadinessFromTracker({
+      requirements: collectToolReadinessRequirements(tools),
+      tracker: readyTracker,
+    }),
     harnessFactory,
     systemPromptAppend: opts.systemPromptAppend,
     systemPromptDynamic: opts.systemPromptDynamic,
@@ -330,9 +338,6 @@ async function createWorkspaceAgentAppProfile(
   opts.onWorkspaceAgentDispatcher?.(createStaticWorkspaceAgentDispatcherResolver(coreAgent.agent, sessionId))
   const harness = agentRuntime.harness
   harnessRef = harness
-  const readyTracker = createRuntimeReadyStatusTracker(modeAdapter, {
-    harnessReady: true,
-  })
 
   const filesystemBindingsForRequest = opts.getFilesystemBindings
     ? (request: FastifyRequest) => {

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -13,6 +13,7 @@ import { getBoringAgentRuntimePaths, type BoringAgentRuntimePaths } from './work
 import type { WorkspaceProvisioningAdapter, WorkspaceProvisioningResult } from './workspace/provisioning'
 import type { Workspace } from '../shared/workspace'
 import { ErrorCode } from '../shared/error-codes'
+import { collectToolReadinessRequirements, createAgentReadinessFromTracker } from './agentReadiness'
 import { resolveMode, autoDetectMode } from './runtime/resolveMode'
 import { createPiCodingAgentHarness, withPiHarnessDefaults } from './harness/pi-coding-agent/createHarness'
 import type { PiHarnessOptions, ResolvedPiHarnessOptions } from './harness/pi-coding-agent/createHarness'
@@ -802,6 +803,11 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     const coreAgent = createAgentRuntimeBridge({
       runtime: modeAdapter,
       tools,
+      readiness: createAgentReadinessFromTracker({
+        requirements: collectToolReadinessRequirements(tools),
+        tracker: readyTracker,
+        checkReadiness,
+      }),
       harnessFactory,
       systemPromptAppend: opts.systemPromptAppend,
       systemPromptDynamic,

--- a/packages/agent/src/shared/events.ts
+++ b/packages/agent/src/shared/events.ts
@@ -79,6 +79,11 @@ export interface AgentRuntimeAdapter {
 export interface AgentReadinessStatus {
   key: string
   ready: boolean
+  state?: 'not-started' | 'preparing' | 'ready' | 'failed'
+  errorCode?: string
+  causeCode?: string
+  retryable?: boolean
+  workspaceId?: string
   message?: string
 }
 
@@ -91,6 +96,7 @@ export interface AgentConfig {
   harnessFactory?: AgentCoreHarnessFactory
   runtime: AgentRuntimeAdapter
   tools?: AgentTool[]
+  readiness?: AgentReadiness
   readinessRequirements?: string[]
   sessions?: SessionStore
   systemPromptAppend?: string


### PR DESCRIPTION
## Summary

- recuts the only live readiness semantics from #566/#568/#575/#576 onto current main
- reports readiness from each adapter's final surviving tool requirements and binding-local `ReadyStatusTracker`
- keeps runtime `not-started`/`preparing`/`failed`, workspace non-ready, sandbox non-ready, UI, and unknown requirements fail-closed
- guards delegated readiness probes before and after await so terminal disposal remains authoritative

## Reconciliation

This is intentionally not a literal squash or cherry-pick. #626/#627/#630/#631 already replaced the old relocation, lifecycle, eviction, and teardown work. This PR excludes pure mode, input-asset changes, cache/eviction, provisioning ownership, tool-gating behavior, HTTP readiness routes, and old lifecycle code.

## Proof

- `git diff --check` — pass
- structured spec/standards autoreview — clean
- thermo maintainability autoreview — clean
- independent current-main vs old-stack audit — clean after correcting optimistic `not-started` handling and restoring unchanged tool gating
- no local executable tests/typecheck run per owner direction; GitHub CI is the executable proof

## Risk / rollback

Additive status fields and reporter injection only. Missing reporters preserve the existing conservative false rows. Rollback is this single commit.

## Next

After merge, dispatch P6-R / BBP6-011 from Decision 23. P2 draft #641 remains parked.