### PR TITLE
fix: package boring-automation in full-app runtime image

### DIFF
--- a/apps/full-app/Dockerfile
+++ b/apps/full-app/Dockerfile
@@ -11,6 +11,7 @@ COPY packages/agent/package.json packages/agent/package.json
 COPY packages/boring-bash/package.json packages/boring-bash/package.json
 COPY plugins/boring-mcp/package.json plugins/boring-mcp/package.json
 COPY plugins/boring-governance/package.json plugins/boring-governance/package.json
+COPY plugins/boring-automation/package.json plugins/boring-automation/package.json
 COPY apps/full-app/package.json apps/full-app/package.json
 RUN pnpm install --frozen-lockfile
 
@@ -19,6 +20,7 @@ ENV NODE_OPTIONS=--max-old-space-size=4096
 COPY packages/ packages/
 COPY plugins/boring-mcp/ plugins/boring-mcp/
 COPY plugins/boring-governance/ plugins/boring-governance/
+COPY plugins/boring-automation/ plugins/boring-automation/
 COPY apps/full-app/ apps/full-app/
 
 # Build packages in dependency order.
@@ -45,6 +47,8 @@ RUN pnpm --filter @hachej/boring-workspace exec tsup --no-dts \
 RUN pnpm --filter @hachej/boring-mcp exec tsup --no-dts
 
 RUN pnpm --filter @hachej/boring-governance exec tsup --no-dts
+
+RUN pnpm --filter @hachej/boring-automation exec tsup --no-dts
 
 # BORING_USE_LOCAL_PACKAGES=1 lets Vite resolve @hachej/* from source so
 # Tailwind scans the actual TSX files instead of compiled dist JS. Without
@@ -104,6 +108,10 @@ COPY --from=build /app/plugins/boring-mcp/node_modules/ plugins/boring-mcp/node_
 COPY --from=build /app/plugins/boring-governance/dist/ plugins/boring-governance/dist/
 COPY --from=build /app/plugins/boring-governance/package.json plugins/boring-governance/package.json
 COPY --from=build /app/plugins/boring-governance/node_modules/ plugins/boring-governance/node_modules/
+
+COPY --from=build /app/plugins/boring-automation/dist/ plugins/boring-automation/dist/
+COPY --from=build /app/plugins/boring-automation/package.json plugins/boring-automation/package.json
+COPY --from=build /app/plugins/boring-automation/node_modules/ plugins/boring-automation/node_modules/
 
 COPY --from=build /app/apps/full-app/dist/ apps/full-app/dist/
 COPY --from=build /app/apps/full-app/boring.app.toml apps/full-app/boring.app.toml


### PR DESCRIPTION
## Problem

Release workflow run [29154321773](https://github.com/hachej/boring-ui/actions/runs/29154321773) — job "Deploy full-app to Fly.io" fails. The Fly release command `node apps/full-app/dist/server/migrate.js` crashes with:

```
ERR_MODULE_NOT_FOUND: Cannot find package '@hachej/boring-automation'
imported from /app/apps/full-app/dist/server/migrate.js
```

## Root cause

The automation merge (36b3da993, PR #606 stream) made full-app's server import `@hachej/boring-automation` (`migrate.ts` calls `runBoringAutomationMigrations`), but `apps/full-app/Dockerfile` never packaged the plugin: it was missing from the `deps` stage (package.json for pnpm install), the `build` stage (source copy + tsup build), and the `runtime` stage (dist/package.json/node_modules copy). The pnpm workspace symlink under `node_modules/` therefore dangled in the image.

## Fix

Add `plugins/boring-automation` to all three stages, following the exact pattern used for `boring-mcp` and `boring-governance`. Checked `plugins/tasks` / `plugins/diagram`: not imported by full-app (only by packages/cli, which is not in this image), so no further gaps.

## Verification

- Local `docker build` of the default (`runtime`) target succeeds.
- Inside the image: `import('@hachej/boring-automation/server')` resolves (exports incl. `runBoringAutomationMigrations`).
- Inside the image: `import('./apps/full-app/dist/server/migrate.js')` now loads fully and fails only on missing runtime secrets (config validation), i.e. the module-resolution crash is gone.
- Gates: full-app `typecheck` clean, `vitest run` 37/37 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)