### PR TITLE
feat(automation): compose hosted creator-scoped execution

### DIFF
--- a/apps/full-app/src/server/dev.ts
+++ b/apps/full-app/src/server/dev.ts
@@ -94,6 +94,7 @@ startCoreWorkspaceAgentDevServer({
       ...options,
       config,
       plugins: createFullAppServerPlugins([governance.serverPlugin]),
+      defaultPluginPackages: ['@hachej/boring-automation'],
       externalPlugins: false,
       installPluginAuthoring: pluginAuthoringEnabledFromEnv(),
       metering: governance.createMeteringSink(credits.meteringSink, () => {

--- a/apps/full-app/src/server/main.ts
+++ b/apps/full-app/src/server/main.ts
@@ -36,6 +36,7 @@ async function main() {
     config,
     serveFrontend: true,
     plugins: createFullAppServerPlugins([governance.serverPlugin]),
+    defaultPluginPackages: ['@hachej/boring-automation'],
     externalPlugins: false,
     installPluginAuthoring: pluginAuthoringEnabledFromEnv(),
     metering: governance.createMeteringSink(credits.meteringSink, () => {

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -752,15 +752,20 @@ export async function createCoreWorkspaceAgentServer(
     workspaceRoot: pluginWorkspaceRoot,
     bridge: createUnavailableCorePluginBridge(),
   }
-  const trustedPluginResolveContext: WorkspaceAgentServerPluginContext = options.trustedPluginActorResolver
-    ? {
-        ...basePluginResolveContext,
-        trusted: {
-          workspaceAgentDispatcherResolver: trustedDispatcherProxy,
-          actorResolver: options.trustedPluginActorResolver,
-        },
-      }
-    : basePluginResolveContext
+  const trustedPluginActorResolver = options.trustedPluginActorResolver ?? (async (request: FastifyRequest) => {
+    const workspaceId = await resolveAuthorizedWorkspaceId(request, workspaceStore)
+    const userId = request.user?.id
+    if (!userId) throw httpError('authentication required', 401)
+    return { workspaceId, userId }
+  })
+  const trustedPluginResolveContext: WorkspaceAgentServerPluginContext = {
+    ...basePluginResolveContext,
+    trusted: {
+      workspaceAgentDispatcherResolver: trustedDispatcherProxy,
+      actorResolver: trustedPluginActorResolver,
+      sql,
+    },
+  }
   const resolvedPlugins = await Promise.all(
     pluginEntries.map(async (entry) => {
       const plugin = await resolveOnePluginEntry<CoreWorkspaceAgentServerPlugin>(

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -90,6 +90,8 @@ export interface WorkspaceAgentServerPluginContext {
   trusted?: {
     workspaceAgentDispatcherResolver: WorkspaceAgentDispatcherResolver
     actorResolver: (request: FastifyRequest) => Promise<{ workspaceId: string; userId: string }> | { workspaceId: string; userId: string }
+    /** Host-owned database connection exposed only to trusted boot-time plugins. */
+    sql?: unknown
   }
 }
 

--- a/plugins/boring-automation/src/server/index.ts
+++ b/plugins/boring-automation/src/server/index.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path"
 import type { WorkspaceAgentDispatcherResolver } from "@hachej/boring-agent/server"
 import type { FastifyRequest } from "fastify"
+import type postgres from "postgres"
 import type { WorkspaceAgentServerPluginContext } from "@hachej/boring-workspace/app/server"
 import { defineServerPlugin, type WorkspaceServerPlugin } from "@hachej/boring-workspace/server"
 import {
@@ -9,6 +10,7 @@ import {
 } from "../shared"
 import { DueRunService } from "./dueRunService"
 import { FileAutomationStore } from "./fileStore"
+import { PostgresAutomationStore } from "./postgresStore"
 import { ManualRunExecutor, type VerifiedAutomationActor } from "./manualRunExecutor"
 import { automationRoutes } from "./routes"
 import type { AutomationStore } from "./store"
@@ -18,19 +20,31 @@ export interface BoringAutomationServerPluginOptions {
   store?: AutomationStore
   dispatcherResolver?: WorkspaceAgentDispatcherResolver
   actorResolver?: (request: FastifyRequest) => Promise<VerifiedAutomationActor> | VerifiedAutomationActor
+  storeForRequest?: (request: FastifyRequest, actor: VerifiedAutomationActor) => Promise<AutomationStore> | AutomationStore
 }
 
 export function createBoringAutomationServerPlugin(options: BoringAutomationServerPluginOptions = {}): WorkspaceServerPlugin {
   const store = options.store ?? createDefaultStore(options.workspaceRoot)
   const manualRunExecutor = options.dispatcherResolver && options.actorResolver
-    ? new ManualRunExecutor({ store, dispatcherResolver: options.dispatcherResolver, actorResolver: options.actorResolver })
+    ? new ManualRunExecutor({
+        store,
+        storeForRequest: options.storeForRequest,
+        dispatcherResolver: options.dispatcherResolver,
+        actorResolver: options.actorResolver,
+      })
     : undefined
-  const dueRunService = manualRunExecutor ? new DueRunService({ store, executor: manualRunExecutor }) : undefined
+  const dueRunService = manualRunExecutor && !options.storeForRequest
+    ? new DueRunService({ store, executor: manualRunExecutor })
+    : undefined
   return defineServerPlugin({
     id: BORING_AUTOMATION_PLUGIN_ID,
     label: BORING_AUTOMATION_PLUGIN_LABEL,
     routes: async (app) => {
-      await automationRoutes(app, { store, manualRunExecutor, dueRunService })
+      await automationRoutes(app, { store, storeForRequest: options.storeForRequest ? async (request) => {
+        const actor = options.actorResolver ? await options.actorResolver(request) : undefined
+        if (!actor) throw new Error("automation actor resolver is unavailable")
+        return await options.storeForRequest!(request, actor)
+      } : undefined, manualRunExecutor, dueRunService })
     },
   })
 }
@@ -45,6 +59,17 @@ export default function defaultBoringAutomationServerPlugin(
   ctx?: Pick<WorkspaceAgentServerPluginContext, "workspaceRoot"> & Partial<Pick<WorkspaceAgentServerPluginContext, "trusted">>,
 ): WorkspaceServerPlugin {
   const trusted = ctx?.trusted
+  if (!options?.store && trusted?.sql && trusted.workspaceAgentDispatcherResolver && trusted.actorResolver) {
+    const sql = trusted.sql as postgres.Sql
+    const fallbackStore = new PostgresAutomationStore(sql, { workspaceId: "unbound", userId: "unbound" })
+    return createBoringAutomationServerPlugin({
+      ...options,
+      store: fallbackStore,
+      storeForRequest: async (_request, actor) => new PostgresAutomationStore(sql, actor),
+      dispatcherResolver: options?.dispatcherResolver ?? trusted.workspaceAgentDispatcherResolver,
+      actorResolver: options?.actorResolver ?? trusted.actorResolver,
+    })
+  }
   return createBoringAutomationServerPlugin({
     ...options,
     workspaceRoot: options?.workspaceRoot ?? ctx?.workspaceRoot,


### PR DESCRIPTION
Completes the hosted route/executor composition portion of Slice 5 for #590.

## What
- Core now supplies a verified default actor resolver for trusted internal plugins.
- Trusted plugin context receives the host-owned SQL connection.
- Full-app loads boring-automation as an internal default package in dev and production.
- The automation plugin selects actor-bound `PostgresAutomationStore` instances per request.
- Manual execution reuses the existing dispatcher and creator actor.
- Hosted composition deliberately leaves `/due` unavailable until the authenticated platform trigger slice.

Every hosted store query is scoped by verified `{workspaceId,userId}`. No raw workspace header is used for authorization.

## Proof
- `pnpm --filter @hachej/boring-automation test` — 74 passed
- `pnpm --filter @hachej/boring-automation typecheck`
- core dispatcher/plugin tests — 9 passed
- `pnpm --filter full-app typecheck`
- workspace plugin invariants
- `git diff --check`
