### PR TITLE
docs(391): implementation guardrails + GTM strategy

### DIFF
--- a/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
+++ b/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
@@ -28,9 +28,10 @@ Compliance sensitivity is a qualifier, not a blocker.
 ## Motion 1 — Lighthouse retainers (NOW; fits the 1–2h/day operating mode)
 
 1. Outreach (existing LGM machinery) with ONE artifact: a recorded
-   **golden-path demo** — a real agent for a recognizable workflow, built and
-   deployed in ≤ 15 minutes. The P8 timing bead is therefore GTM-critical,
-   not engineering vanity.
+   **golden-path demo**. The ≤ 15-minute build-and-deploy claim is GATED on
+   P8's recorded evidence — until golden-path.json exists, demos show a
+   pre-built agent walkthrough and make no live-build promise. The P8 timing
+   bead is therefore GTM-critical, not engineering vanity.
 2. Offer: free 30-min call where THEIR workflow becomes a running agent in
    their own workspace before the call ends.
 3. Convert to a 4–6 week paid pilot (fixed fee) → managed retainer.
@@ -43,7 +44,9 @@ Target sectors where "EU-only processing" shortcuts procurement: legal,
 health-adjacent admin, public-sector suppliers. Content: one page per
 sector — "what an EU-sovereign agent setup looks like", the dedicated-VM
 variant (Decision 23 variant 2) as the premium tier. No code work required;
-this is packaging of what exists.
+this is FUTURE packaging, conditional on D1 landing and the runsc EU
+validation spike proving the isolation claims (#628 is not productionReady
+yet) — write the one-pagers, date the availability honestly.
 
 ## Motion 3 — Demo-as-content flywheel (cheap, compounding)
 

--- a/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
+++ b/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
@@ -32,8 +32,9 @@ Compliance sensitivity is a qualifier, not a blocker.
    P8's recorded evidence — until golden-path.json exists, demos show a
    pre-built agent walkthrough and make no live-build promise. The P8 timing
    bead is therefore GTM-critical, not engineering vanity.
-2. Offer: free 30-min call where THEIR workflow becomes a running agent in
-   their own workspace before the call ends.
+2. Offer: free 30-min call walking THEIR workflow through a pre-built
+   agent in a demo workspace. The "running agent before the call ends"
+   promise activates only after P8's golden-path evidence exists.
 3. Convert to a 4–6 week paid pilot (fixed fee) → managed retainer.
 4. Cap: 3 concurrent lighthouse clients. Each phase of the build plan must
    have a named lighthouse consumer; no client, no phase.
@@ -67,9 +68,11 @@ it. Success = first paid consumer conversation, not listings count.
 
 Ship named niche agents as products, not services: e.g. the **accounting
 pre-close agent** (fetch/categorize invoices, prep VAT for expert-comptables)
-or the **insurance-comparison agent**. Decision 23 already gives every
-deployed agent an exact hostname — each vertical agent gets a product
-storefront (`agent-x.domain.eu`) with zero new infrastructure. The factory
+or the **insurance-comparison agent**. Decision 23's exact-hostname landing (once D1 lands) gives each vertical
+agent a product entry point — but a storefront still means real work: DNS/
+TLS, signup wiring, and landing content, which stays HOST-OWNED config
+unless the AgentDefinition schema is deliberately amended (owner decision;
+the schema has no presentation fields today). The factory
 becomes the backend story; the vertical agent is what the market sees and
 searches for. Selection matrix (pick ≤ 2): document-heavy repetitive
 workflow · reachable niche community · EU/French regulatory angle · owner
@@ -88,6 +91,10 @@ B2B price tolerance. Their methodology ships as a contracted agent
 (rev-share); the golden path is their onboarding ("your expertise, running
 as an agent, in one afternoon"); their channel is the distribution.
 
+**Gates (LATER):** Motion 2b delivery to third parties requires ID1 + AC1
+contracted mode + BL1 billing + Decision 22's contractor-data-hygiene policy
+— it is sequenced behind them, not beside them.
+
 **Convergence law:** every vertical agent (M5) and expert agent (M2b) is
 simultaneously a template in the future MK1 catalog — the marketplace
 cold-start solves itself as a by-product of revenue work. Do not build
@@ -98,9 +105,12 @@ complete.
 
 Stock-client connector directories (Claude, ChatGPT) are opening. Each
 vertical agent listed there is free niche distribution with a first-mover
-window ("the accounting agent" in the directory before anyone else). The
-MCP-first architecture makes listing nearly free once ID1 exists. Zero build
-beyond ID1; pure packaging + submission work.
+window ("the accounting agent" in the directory before anyone else). The MCP-first
+architecture keeps the integration side cheap once ID1 exists — but listing
+is NOT zero work: directories require metadata, testing, privacy/support
+docs, safety review, tool annotations, and ongoing per-listing maintenance
+(OpenAI and Anthropic directory policies), and serving directory users needs
+the AC1 consumption path. Cheap versus building distribution; not free.
 
 ## Motion 7 — The audit trojan (zero build)
 
@@ -108,6 +118,8 @@ Paid "where do agents fit in your company" discovery engagements, delivered
 AS a boring workspace: findings, transcripts, and prototype agents live in
 the client's workspace from day one. The deliverable onboards the client
 into the product; the upsell is turning one finding into a running agent.
+(If transcripts/findings are promised as living in the client workspace,
+they must be covered by the backup set and exportable.)
 
 **Demo-door note (Motion 1 correction):** lead lighthouse demos with the web
 UI — MCP connector setup is still fiddly for non-technical buyers. "It's

--- a/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
+++ b/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
@@ -60,6 +60,35 @@ engaged audience, revenue-share deal, their channel (Telegram first — CH1)
 as the distribution. The catalog (MK1) follows the audience, never precedes
 it. Success = first paid consumer conversation, not listings count.
 
+## Motion 5 — Vertical agent products (STRONG candidate; owner-sparked 2026-07-11)
+
+Ship named niche agents as products, not services: e.g. the **accounting
+pre-close agent** (fetch/categorize invoices, prep VAT for expert-comptables)
+or the **insurance-comparison agent**. Decision 23 already gives every
+deployed agent an exact hostname — each vertical agent gets a product
+storefront (`agent-x.domain.eu`) with zero new infrastructure. The factory
+becomes the backend story; the vertical agent is what the market sees and
+searches for. Selection matrix (pick ≤ 2): document-heavy repetitive
+workflow · reachable niche community · EU/French regulatory angle · owner
+domain proximity. Accounting scores highest (data background, reachable
+networks, sovereignty synergy); insurance second (higher search demand,
+sharper regulated-advice liability). Pricing: per-workspace monthly, plus a
+free budget-capped lead-magnet tier (caps only — no feature-flag system).
+
+## Motion 2b — Expert-in-a-box (the realistic creator wedge)
+
+The first creators are not influencers; they are **B2B niche experts** (RGPD
+consultant, tax advisor, HR compliance) with existing paying audiences and
+B2B price tolerance. Their methodology ships as a contracted agent
+(rev-share); the golden path is their onboarding ("your expertise, running
+as an agent, in one afternoon"); their channel is the distribution.
+
+**Convergence law:** every vertical agent (M5) and expert agent (M2b) is
+simultaneously a template in the future MK1 catalog — the marketplace
+cold-start solves itself as a by-product of revenue work. Do not build
+catalog features for this; just keep AgentDefinition presentation metadata
+complete.
+
 ## Pricing placeholder (reversible; owner may override)
 
 - **Setup per agent** (authoring + deployment): fixed fee.

--- a/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
+++ b/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
@@ -1,0 +1,82 @@
+# GTM Strategy — boring agent factory
+
+Drafted 2026-07-11 (Fable final session). Companion to MARKETPLACE-PATH.md
+(owner ruling: B2B revenue now, marketplace demand-gated) and
+FABLE-FINAL-REVIEW Part 1. These are strategies to run, measure, and kill —
+not commitments.
+
+## Positioning
+
+**"Your agents, your data, EU-hosted."** boring is the system of record for
+agentic work: agents are compiled artifacts, workspaces are the durable vault
+of context and results, governance and audit are built in, and no US-hosted
+dependency is required. Model-neutral by construction.
+
+- Against DIY (LangChain/agent frameworks): you ship an operated product in
+  days, not an internal platform project in quarters.
+- Against US platforms (GPTs/Claude connectors/Copilot): sovereignty,
+  governance, workspace persistence, and the ability to switch models.
+- Against agencies: the retainer includes a running system, not a report.
+
+## ICP (initial)
+
+EU mid-market companies (20–500 FTE) with document/ops-heavy workflows —
+finance/legal/compliance-adjacent, professional services, industrial back
+office — plus the consultancies that serve them. Buyer: COO/Head of Ops/CTO.
+Compliance sensitivity is a qualifier, not a blocker.
+
+## Motion 1 — Lighthouse retainers (NOW; fits the 1–2h/day operating mode)
+
+1. Outreach (existing LGM machinery) with ONE artifact: a recorded
+   **golden-path demo** — a real agent for a recognizable workflow, built and
+   deployed in ≤ 15 minutes. The P8 timing bead is therefore GTM-critical,
+   not engineering vanity.
+2. Offer: free 30-min call where THEIR workflow becomes a running agent in
+   their own workspace before the call ends.
+3. Convert to a 4–6 week paid pilot (fixed fee) → managed retainer.
+4. Cap: 3 concurrent lighthouse clients. Each phase of the build plan must
+   have a named lighthouse consumer; no client, no phase.
+
+## Motion 2 — Sovereignty wedge (parallel, messaging-level)
+
+Target sectors where "EU-only processing" shortcuts procurement: legal,
+health-adjacent admin, public-sector suppliers. Content: one page per
+sector — "what an EU-sovereign agent setup looks like", the dedicated-VM
+variant (Decision 23 variant 2) as the premium tier. No code work required;
+this is packaging of what exists.
+
+## Motion 3 — Demo-as-content flywheel (cheap, compounding)
+
+Every lighthouse build produces: a recorded golden-path run, an anonymized
+template agent, a short writeup. Templates accumulate into a gallery —
+which quietly becomes MK1's seed catalog the day the marketplace opens.
+Distribution: LinkedIn (founder-led), the LGM outreach sequences.
+
+## Motion 4 — Creator-led marketplace pilot (LATER; demand-gated)
+
+Per owner ruling: only when factory revenue or a flagship creator forces it.
+The cold-start is creator-led: ONE flagship creator (e.g. fitness) with an
+engaged audience, revenue-share deal, their channel (Telegram first — CH1)
+as the distribution. The catalog (MK1) follows the audience, never precedes
+it. Success = first paid consumer conversation, not listings count.
+
+## Pricing placeholder (reversible; owner may override)
+
+- **Setup per agent** (authoring + deployment): fixed fee.
+- **Managed retainer per hosted agent-workspace / month**: includes hosting,
+  governance, updates. LLM usage passed through at cost + margin.
+- **Dedicated VM variant**: infrastructure premium on top.
+- Marketplace era (later): per-engagement pricing set by creator, platform
+  take-rate — decision deferred with BL1.
+
+## Metrics that matter (weekly)
+
+demos recorded · demo→pilot conversion · time-to-new-agent (golden path) ·
+retainer MRR · agents live per host · churned agents. Ignore vanity counts
+(signups, stars) until Motion 4 opens.
+
+## Kill criteria
+
+Any motion that produces zero pilots in 6 weeks of honest effort gets
+rewritten or killed at the weekly review — motions are experiments, the
+vault and the factory are the constants.

--- a/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
+++ b/docs/issues/391/runtime-refactor/GTM-STRATEGY.md
@@ -71,8 +71,10 @@ becomes the backend story; the vertical agent is what the market sees and
 searches for. Selection matrix (pick ≤ 2): document-heavy repetitive
 workflow · reachable niche community · EU/French regulatory angle · owner
 domain proximity. Accounting scores highest (data background, reachable
-networks, sovereignty synergy); insurance second (higher search demand,
-sharper regulated-advice liability). Pricing: per-workspace monthly, plus a
+networks, sovereignty synergy); the **analytics agent** (on the client's
+existing warehouse/dbt stack — the owner's unfair-authority vertical) is a
+strong second; insurance third (higher search demand, sharper
+regulated-advice liability). Pricing: per-workspace monthly, plus a
 free budget-capped lead-magnet tier (caps only — no feature-flag system).
 
 ## Motion 2b — Expert-in-a-box (the realistic creator wedge)
@@ -88,6 +90,25 @@ simultaneously a template in the future MK1 catalog — the marketplace
 cold-start solves itself as a by-product of revenue work. Do not build
 catalog features for this; just keep AgentDefinition presentation metadata
 complete.
+
+## Motion 6 — MCP connector directories as app stores (post-ID1)
+
+Stock-client connector directories (Claude, ChatGPT) are opening. Each
+vertical agent listed there is free niche distribution with a first-mover
+window ("the accounting agent" in the directory before anyone else). The
+MCP-first architecture makes listing nearly free once ID1 exists. Zero build
+beyond ID1; pure packaging + submission work.
+
+## Motion 7 — The audit trojan (zero build)
+
+Paid "where do agents fit in your company" discovery engagements, delivered
+AS a boring workspace: findings, transcripts, and prototype agents live in
+the client's workspace from day one. The deliverable onboards the client
+into the product; the upsell is turning one finding into a running agent.
+
+**Demo-door note (Motion 1 correction):** lead lighthouse demos with the web
+UI — MCP connector setup is still fiddly for non-technical buyers. "It's
+also in your ChatGPT" is the closer, not the opener.
 
 ## Pricing placeholder (reversible; owner may override)
 

--- a/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
+++ b/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
@@ -33,16 +33,19 @@ that mean you are over-engineering, and the acceptance that means you are done.
 
 ## P6-R — deployment resolver
 
-- **Build:** a pure, deterministic function: deployment record (digest-pinned
-  `AgentDeployment`) → composed runtime configuration, consumed in-process at
-  server boot and workspace binding. Digest verification; refusal on mismatch.
+- **Build:** a pure, deterministic function per BBP6-011 (PR-PLAN.md is the
+  binding contract): input = bundle + deployment + authorized binding; output
+  = composed runtime configuration with NO runtime handles. One call resolves
+  ONE binding; D1 gets N agents by N independent calls. Digest verification;
+  refusal on mismatch.
 - **Do NOT build:** a resolver service, a registry daemon, hot-reload
   watchers, bundle caches, remote fetch. Bundles are local files in v1.
 - **Stop signs:** adding a network listener; adding a watch loop; "registry"
   appearing in a type name.
-- **Accept:** boot resolves 3 distinct bundles; unknown/invalid/mismatched
-  digest fails with a stable code before any workspace mutation; same input →
-  byte-identical resolution (golden test).
+- **Accept:** one call resolves one authorized binding; unknown/invalid/
+  mismatched digest fails with a stable code before any workspace mutation;
+  same input → deep-equal output (golden test). The 3-bundle/boot proof
+  belongs to D1, not here.
 
 ## D1 — multi-agent Docker host (Decision 23)
 
@@ -55,11 +58,14 @@ that mean you are over-engineering, and the acceptance that means you are done.
   explicitly post-v1).
 - **Stop signs:** helm charts; a "provisioner" process; templating engines
   beyond envsubst-level.
+- **Gate:** D1 is non-dispatchable until D1-R0 (atomic active-collection
+  publication, immutable rollback-as-new-revision) is accepted in PR-PLAN.md.
 - **Accept:** 3 distinct agents on 1 EU host, each bound to its workspace;
-  golden-path timing recorded; rollback = previous compose file boots green;
-  **adding agent N+1 does not restart or interrupt agents 1..N** (per-service
-  compose granularity — this criterion exists so onboarding a client never
-  bounces existing clients). (This IS phase-2 exit.)
+  golden-path timing recorded; rollback = reapply a prior COMPLETE immutable
+  revision snapshot (never just an old compose file over new volumes/secrets),
+  published only after all bindings report ready; **adding agent N+1 does not
+  restart or interrupt agents 1..N** (per-service compose granularity — so
+  onboarding a client never bounces existing clients). (This IS phase-2 exit.)
 
 ## P5a — provisioning/secrets (narrow)
 
@@ -77,7 +83,10 @@ that mean you are over-engineering, and the acceptance that means you are done.
 - **Do NOT build:** new MCP tools "while we're here", resources beyond the
   agreed payload, sampling/elicitation features.
 - **Accept:** an unmodified stock MCP client (Claude/ChatGPT) completes one
-  task against a hosted agent, artifacts included.
+  task against a hosted agent, receiving COMPLETE authorized artifact bytes
+  (no host paths, no truncation) within the documented size caps, with stable
+  rejection codes for path-shaped and oversize outputs (per PR-PLAN's M1
+  contract).
 
 ## ID1 — agent-driven identity
 
@@ -99,10 +108,14 @@ that mean you are over-engineering, and the acceptance that means you are done.
 
 ## AR1 — shareable artifacts (v1 lane, post-#640 lane split)
 
-- **Build (4 beads, in order):** (1) share-entry store
+- **Spec gate:** AR1 stays spec-blocked until AR1-001 is accepted
+  (PR-PLAN.md). The beads below are the SAME-WORKSPACE lane sketch as input
+  to that spec — not a dispatch contract. The cross-workspace pinned-copy
+  exit in INDEX.md remains the authoritative AR1 exit criterion.
+- **Same-workspace lane beads (post-AR1-001):** (1) share-entry store
   `{id, workspaceId, path, provenance}`; (2) deep-link route `/a/<id>` with
   membership auth + tombstone rendering; (3) MCP resource exposing the same
-  entry; (4) NOTHING ELSE.
+  entry; (4) nothing else in this lane.
 - **Do NOT build:** the cross-workspace `ArtifactTransferHandle` blob lane
   until the first contracted-mode engagement exists (#640 spec is ready when
   needed); expiry/revocation machinery (membership IS revocation); preview
@@ -117,15 +130,17 @@ that mean you are over-engineering, and the acceptance that means you are done.
   versioned schema — sketch in FABLE-FINAL-REVIEW Part 2) in the contracts
   layer; an in-process dispatcher for SUBAGENT mode reusing pi session
   machinery for the loop and T1's event store if durability is needed.
-  Guards: depth ≤ 3, same-pair cycle refusal, 24h input-required timeout →
-  canceled (resumable context).
+  Guards REQUIRED, values NOT frozen here: consumption depth limit,
+  same-pair cycle refusal, input-required timeout → canceled (resumable
+  context). Concrete numbers (suggested: depth 3, 24h) are ratified in the
+  AC1 consumer-backed spec, not in this file.
 - **Do NOT build:** a task queue/broker, contracted mode before a real
   contracting consumer exists, A2A wire transport, persistence beyond
   existing stores.
 - **Stop signs:** a `TaskScheduler`; a state machine library; retry policies.
 - **Accept:** agent A delegates to subagent B in A's workspace; B asks back
-  via input-required; A answers; task completes with artifacts; depth-4
-  attempt refused with stable code.
+  via input-required; A answers; task completes with artifacts; exceeding
+  the ratified depth limit is refused with a stable code.
 
 ## P8 — verification (pull-forward slice)
 
@@ -133,7 +148,10 @@ that mean you are over-engineering, and the acceptance that means you are done.
   wall-clock, recorded in repo); CI greps for `runtime:'none'` residue and
   the standing invariants.
 - **Do NOT build:** a test platform, dashboards, synthetic monitoring.
-- **Accept:** golden-path number exists in-repo and updates per release.
+- **Accept:** a named script (e.g. `scripts/golden-path-timing`) writes
+  `docs/issues/391/runtime-refactor/golden-path.json` {version, seconds, date};
+  CI fails when the recorded version differs from the released version —
+  staleness is machine-detected, not remembered.
 
 ## Ops beads (paper-first; the vault claim demands them)
 
@@ -166,5 +184,6 @@ that mean you are over-engineering, and the acceptance that means you are done.
 
 BL1 / MK1 / CH1 / M2 / E2 / T2 / X1 / P3 / P4 / P5b / D2 / S3 / S4: demand-
 gated or post-v1. Starting any of these without a named consumer recorded in
-INDEX.md is itself an over-engineering failure. P2 (#641) finishes review
-then merges after P1-era conflicts resolve — no scope growth during rebase.
+INDEX.md is itself an over-engineering failure. P2 (#641) may finish
+review and stay rebased in isolation, but per INDEX.md it merges LAST — after
+the priority-1..3 proofs — and grows no scope during rebases.

--- a/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
+++ b/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
@@ -56,8 +56,10 @@ that mean you are over-engineering, and the acceptance that means you are done.
 - **Stop signs:** helm charts; a "provisioner" process; templating engines
   beyond envsubst-level.
 - **Accept:** 3 distinct agents on 1 EU host, each bound to its workspace;
-  golden-path timing recorded; rollback = previous compose file boots green.
-  (This IS phase-2 exit.)
+  golden-path timing recorded; rollback = previous compose file boots green;
+  **adding agent N+1 does not restart or interrupt agents 1..N** (per-service
+  compose granularity — this criterion exists so onboarding a client never
+  bounces existing clients). (This IS phase-2 exit.)
 
 ## P5a — provisioning/secrets (narrow)
 
@@ -132,6 +134,18 @@ that mean you are over-engineering, and the acceptance that means you are done.
   the standing invariants.
 - **Do NOT build:** a test platform, dashboards, synthetic monitoring.
 - **Accept:** golden-path number exists in-repo and updates per release.
+
+## Ops beads (paper-first; the vault claim demands them)
+
+- **Backup/restore:** nightly workspace-volume snapshot (borgmatic/rsync
+  level — NOT a backup platform) + a restore runbook that has been executed
+  once for real. "Your data is backed up and restorable" is B2B table stakes
+  if the workspace vault is the moat.
+- **Support playbook (doc only):** log locations, event-store query
+  one-liners, per-agent restart, compose rollback. The 2am answer sheet.
+  Do NOT build dashboards for this (P8 guardrail stands).
+- **Upgrade discipline:** backward-compatible migrations rule for the core
+  app while tenant workspaces are live + an upgrade/rollback runbook.
 
 ## Vertical-GTM beads (only if Motion 5 is activated)
 

--- a/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
+++ b/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
@@ -133,6 +133,21 @@ that mean you are over-engineering, and the acceptance that means you are done.
 - **Do NOT build:** a test platform, dashboards, synthetic monitoring.
 - **Accept:** golden-path number exists in-repo and updates per release.
 
+## Vertical-GTM beads (only if Motion 5 is activated)
+
+- **Public agent landing page:** ONE static page per deployed agent rendered
+  from AgentDefinition presentation metadata + a signup link. Do NOT build a
+  CMS, theming, or a page builder. Stop sign: a `templates/` directory with
+  more than one layout.
+- **Template workspaces:** provisioning may seed a new workspace by copying
+  one template directory. Do NOT build a template registry or versioning.
+- **Freemium gating = budget caps only** (the ID1 tripwire machinery). A
+  feature-flag system is the over-engineering trap here — refuse it.
+- **Regulated-domain gate (BLOCKING):** before any insurance/accounting/legal
+  vertical launches publicly: disclaimers in the agent definition,
+  human-in-loop default for advice-shaped outputs, and an owner review of
+  the regulatory exposure. Record the review in DECISIONS.md.
+
 ## Deferred WPs — do not start
 
 BL1 / MK1 / CH1 / M2 / E2 / T2 / X1 / P3 / P4 / P5b / D2 / S3 / S4: demand-

--- a/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
+++ b/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
@@ -63,9 +63,11 @@ that mean you are over-engineering, and the acceptance that means you are done.
 - **Accept:** 3 distinct agents on 1 EU host, each bound to its workspace;
   golden-path timing recorded; rollback = reapply a prior COMPLETE immutable
   revision snapshot (never just an old compose file over new volumes/secrets),
-  published only after all bindings report ready; **adding agent N+1 does not
-  restart or interrupt agents 1..N** (per-service compose granularity — so
-  onboarding a client never bounces existing clients). (This IS phase-2 exit.)
+  published only after all bindings report ready; **applying revision N+1
+  must not interrupt in-flight sessions of agents 1..N** — via D1-R0's atomic
+  immutable-revision apply with graceful cutover. The mechanism (in-process
+  rebind vs process granularity) is D1-R0's decision, NOT this file's; do not
+  assume one-container-per-agent. (This IS phase-2 exit.)
 
 ## P5a — provisioning/secrets (narrow)
 
@@ -120,9 +122,13 @@ that mean you are over-engineering, and the acceptance that means you are done.
   until the first contracted-mode engagement exists (#640 spec is ready when
   needed); expiry/revocation machinery (membership IS revocation); preview
   renderers per file type.
-- **Accept:** agent returns a link; owner opens it logged-in and lands
-  focused on the file; deleted file shows provenance tombstone, never a bare
-  404; non-member gets a clean denial.
+- **Accept (same-workspace lane):** agent returns a link; owner opens it
+  logged-in and lands focused on the file; deleted file shows provenance
+  tombstone, never a bare 404; non-member gets a clean denial.
+- **Accept (workpackage exit):** AR1 as a whole is done only when INDEX.md's
+  authoritative cross-workspace exit also holds — a consumer materializes a
+  pinned immutable copy in its authorized destination workspace per the
+  AR1-001 spec. The deferral above delays that lane's build, not the exit.
 
 ## AC1 — agent consumption contract (issue #636)
 
@@ -148,17 +154,20 @@ that mean you are over-engineering, and the acceptance that means you are done.
   wall-clock, recorded in repo); CI greps for `runtime:'none'` residue and
   the standing invariants.
 - **Do NOT build:** a test platform, dashboards, synthetic monitoring.
-- **Accept:** a named script (e.g. `scripts/golden-path-timing`) writes
+- **Accept:** `scripts/golden-path-timing.mjs` (this exact path) writes
   `docs/issues/391/runtime-refactor/golden-path.json` {version, seconds, date};
-  CI fails when the recorded version differs from the released version —
+  version source of truth = root `package.json` version at the release tag;
+  a CI job fails when golden-path.json's version differs from it —
   staleness is machine-detected, not remembered.
 
 ## Ops beads (paper-first; the vault claim demands them)
 
-- **Backup/restore:** nightly workspace-volume snapshot (borgmatic/rsync
-  level — NOT a backup platform) + a restore runbook that has been executed
-  once for real. "Your data is backed up and restorable" is B2B table stakes
-  if the workspace vault is the moat.
+- **Backup/restore:** nightly encrypted OFF-HOST snapshot of ONE defined
+  consistent set: workspace volumes + `BORING_AGENT_SESSION_ROOT` +
+  membership/app state (`agent.db`) + D1 revision store + config/secret refs
+  (borgmatic-level — NOT a backup platform), plus a restore runbook executed
+  for real on a recurring schedule. A workspace-volumes-only backup is a
+  false sense of safety — sessions and membership are part of the vault.
 - **Support playbook (doc only):** log locations, event-store query
   one-liners, per-agent restart, compose rollback. The 2am answer sheet.
   Do NOT build dashboards for this (P8 guardrail stands).
@@ -171,10 +180,16 @@ that mean you are over-engineering, and the acceptance that means you are done.
   from AgentDefinition presentation metadata + a signup link. Do NOT build a
   CMS, theming, or a page builder. Stop sign: a `templates/` directory with
   more than one layout.
-- **Template workspaces:** provisioning may seed a new workspace by copying
-  one template directory. Do NOT build a template registry or versioning.
-- **Freemium gating = budget caps only** (the ID1 tripwire machinery). A
-  feature-flag system is the over-engineering trap here — refuse it.
+- **Template workspaces:** provisioning may seed a new workspace from ONE
+  sanitized, immutable template (digest + provenance + licensing note
+  recorded — a frozen snapshot, never a live directory that can drift or
+  leak customer material). Do NOT build a template registry.
+- **Freemium gating = budget caps only** for features (no feature-flag
+  system) — but PUBLIC exposure additionally requires authenticated
+  abuse/rate admission controls (per-principal request limits at the door;
+  caps alone do not stop abuse), and regulated-domain launches require a
+  VERSIONED legal/risk sign-off document (kept outside DECISIONS.md — it is
+  a compliance record, not an architecture decision).
 - **Regulated-domain gate (BLOCKING):** before any insurance/accounting/legal
   vertical launches publicly: disclaimers in the agent definition,
   human-in-loop default for advice-shaped outputs, and an owner review of

--- a/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
+++ b/docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md
@@ -1,0 +1,141 @@
+# Implementation Guardrails — per-workpackage build contracts
+
+Written 2026-07-11 (Fable final session). Audience: every downstream agent or
+human implementing a #391 workpackage. Purpose: **reduce the risk of bad or
+over-engineered implementations** now that the strategic context holder is
+gone. Each section states what to build, what NOT to build, the stop signs
+that mean you are over-engineering, and the acceptance that means you are done.
+
+## Global doctrine (applies to every WP)
+
+1. **Reuse-first checklist.** Before writing a new mechanism, check the
+   existing seams: governance `createMeteringSink` (metering/budgets),
+   governance `filesystemBindings` (path-filtered readonly projections),
+   T1 `eventStreamStore` (durable events), the workspace membership model
+   (all authorization), pi session machinery (conversation state). If a seam
+   does 80% of the job, extend it — do not build a sibling.
+2. **Boring by default.** One process, one compose file, YAML/JSON config,
+   env/file secrets. No queues, no brokers, no reconciler loops, no caches,
+   no microservices — until a measured problem demands one, recorded in
+   DECISIONS.md first.
+3. **No new package until a second consumer exists** (standing invariant).
+4. **Every error carries a stable code; every route receives a Workspace,
+   never a raw path** (standing invariants — CI greps enforce).
+5. **Vertical slices, small PRs.** Prefer a working end-to-end sliver
+   (≤ ~400 net lines) over a complete layer. A slice that boots beats a
+   framework that might.
+6. **The universal stop sign:** if you are writing a scheduler, a retry
+   framework, a plugin system, a config DSL, an abstraction with one
+   implementation, or a cross-cutting "manager" class — stop, re-read this
+   file, and ship the dumb version.
+
+---
+
+## P6-R — deployment resolver
+
+- **Build:** a pure, deterministic function: deployment record (digest-pinned
+  `AgentDeployment`) → composed runtime configuration, consumed in-process at
+  server boot and workspace binding. Digest verification; refusal on mismatch.
+- **Do NOT build:** a resolver service, a registry daemon, hot-reload
+  watchers, bundle caches, remote fetch. Bundles are local files in v1.
+- **Stop signs:** adding a network listener; adding a watch loop; "registry"
+  appearing in a type name.
+- **Accept:** boot resolves 3 distinct bundles; unknown/invalid/mismatched
+  digest fails with a stable code before any workspace mutation; same input →
+  byte-identical resolution (golden test).
+
+## D1 — multi-agent Docker host (Decision 23)
+
+- **Build:** one compose file (core app + identity server later + N resolved
+  bundles); hostname→landing map in plain config (hostname grants nothing);
+  per-workspace env/secret files; a short ops runbook (boot, add-agent,
+  rotate-secret, rollback).
+- **Do NOT build:** Kubernetes, Terraform modules, autoscaling, multi-region,
+  a secrets service, an admin UI, tenant lifecycle automation (that is D2,
+  explicitly post-v1).
+- **Stop signs:** helm charts; a "provisioner" process; templating engines
+  beyond envsubst-level.
+- **Accept:** 3 distinct agents on 1 EU host, each bound to its workspace;
+  golden-path timing recorded; rollback = previous compose file boots green.
+  (This IS phase-2 exit.)
+
+## P5a — provisioning/secrets (narrow)
+
+- **Build:** only what the D1 slice consumes: secret refs resolved from
+  env/file mounts; readiness = boot-time check with stable failure codes.
+- **Do NOT build:** Vault/KMS integration, rotation machinery, a provisioning
+  API. "Zero P5a code" is a valid outcome if D1's slice needs none (per
+  PR-PLAN).
+
+## M1 — MCP managed agent (recut #549/#556 content)
+
+- **Build:** delivery v0 payload exactly as scoped; stock-client smoke test
+  as the proof. Keep the MCP tool surface minimal — the delegate server's
+  existing shape.
+- **Do NOT build:** new MCP tools "while we're here", resources beyond the
+  agreed payload, sampling/elicitation features.
+- **Accept:** an unmodified stock MCP client (Claude/ChatGPT) completes one
+  task against a hosted agent, artifacts included.
+
+## ID1 — agent-driven identity
+
+- **Build:** BUY-not-build: evaluate Ory Hydra vs Keycloak (0.5-day bead;
+  criteria: OAuth 2.1 + PKCE, RFC 8707/9728, CIMD or DCR, container footprint
+  on the D1 host, EU self-host). Integrate via standard OIDC middleware.
+  Idempotent auto-provision hook (subject claim → account + personal
+  workspace). API keys issued from the same store.
+- **Do NOT build:** hand-rolled token/JWT code, a user-admin UI beyond
+  minimum, roles/permissions beyond the existing admin|user + membership
+  model, SSO federation.
+- **Stop signs:** writing JWT validation by hand; a `permissions` table.
+- **Tripwire (blocking):** per-workspace spend budgets ship BEFORE or WITH
+  ID1's public exposure (decorate `createMeteringSink`; do not build a
+  billing system for this — a hard cap + stable refusal code suffices).
+- **Accept:** stock MCP client completes OAuth against a fresh email; account
+  + workspace exist; second connect is a no-op; capped workspace refuses
+  over-budget calls with a stable code.
+
+## AR1 — shareable artifacts (v1 lane, post-#640 lane split)
+
+- **Build (4 beads, in order):** (1) share-entry store
+  `{id, workspaceId, path, provenance}`; (2) deep-link route `/a/<id>` with
+  membership auth + tombstone rendering; (3) MCP resource exposing the same
+  entry; (4) NOTHING ELSE.
+- **Do NOT build:** the cross-workspace `ArtifactTransferHandle` blob lane
+  until the first contracted-mode engagement exists (#640 spec is ready when
+  needed); expiry/revocation machinery (membership IS revocation); preview
+  renderers per file type.
+- **Accept:** agent returns a link; owner opens it logged-in and lands
+  focused on the file; deleted file shows provenance tombstone, never a bare
+  404; non-member gets a clean denial.
+
+## AC1 — agent consumption contract (issue #636)
+
+- **Build:** the types (Task/Message/Part, `contextId`, `input-required`,
+  versioned schema — sketch in FABLE-FINAL-REVIEW Part 2) in the contracts
+  layer; an in-process dispatcher for SUBAGENT mode reusing pi session
+  machinery for the loop and T1's event store if durability is needed.
+  Guards: depth ≤ 3, same-pair cycle refusal, 24h input-required timeout →
+  canceled (resumable context).
+- **Do NOT build:** a task queue/broker, contracted mode before a real
+  contracting consumer exists, A2A wire transport, persistence beyond
+  existing stores.
+- **Stop signs:** a `TaskScheduler`; a state machine library; retry policies.
+- **Accept:** agent A delegates to subagent B in A's workspace; B asks back
+  via input-required; A answers; task completes with artifacts; depth-4
+  attempt refused with stable code.
+
+## P8 — verification (pull-forward slice)
+
+- **Build now (cheap):** golden-path timing script (idea → deployed agent,
+  wall-clock, recorded in repo); CI greps for `runtime:'none'` residue and
+  the standing invariants.
+- **Do NOT build:** a test platform, dashboards, synthetic monitoring.
+- **Accept:** golden-path number exists in-repo and updates per release.
+
+## Deferred WPs — do not start
+
+BL1 / MK1 / CH1 / M2 / E2 / T2 / X1 / P3 / P4 / P5b / D2 / S3 / S4: demand-
+gated or post-v1. Starting any of these without a named consumer recorded in
+INDEX.md is itself an over-engineering failure. P2 (#641) finishes review
+then merges after P1-era conflicts resolve — no scope growth during rebase.

--- a/docs/issues/391/runtime-refactor/SPIKE-EVIDENCE-2026-07-11.md
+++ b/docs/issues/391/runtime-refactor/SPIKE-EVIDENCE-2026-07-11.md
@@ -1,0 +1,46 @@
+# Spike Evidence — 2026-07-11
+
+Three behavior spikes run on the production-candidate EU VM (Ubuntu, kernel
+6.14, cgroup v2) to de-risk D1 and ID1 before dispatch. Raw agent reports
+summarized; no repo or system-level changes were made (user-scope runsc
+binary left at ~/bin/runsc).
+
+## 1. runsc/gVisor structural validation (D1 provider lock input)
+
+Facts on a real EU host: kernel 6.14 + unified cgroup v2 with full
+controller delegation; `unprivileged_userns_clone=1`; netns and nftables
+operations work (root); `runsc` release-20260706.0 installs user-scope and
+**runs sandboxes successfully with sudo** (`runsc do echo ok`); rootless
+fails on veth creation (CAP_NET_ADMIN); /dev/kvm present. Repo preflight
+tests (28) pass but are 100% mocked. **Verdict: MORE NEEDED before lock —**
+(a) one real, non-mocked `preflightRunsc` run against this host,
+(b) an explicit privileged-execution-model decision (rootless is not
+currently viable), (c) Docker daemon runtime registration untested by
+design. Structural risk: LOW; the contract's assumptions hold on real EU
+hardware.
+
+## 2. Compose apply granularity (D1 runbook input)
+
+Proven: adding a service does NOT restart existing ones; per-service env
+changes recreate only that service. Rules required to keep it true:
+one env file per agent (never shared), idempotent `up -d` only, never
+`--force-recreate`, rollback per-service with `--no-deps` (a blanket
+old-file `up -d` after recent modifications triggers state-correction
+restarts). **Caveat:** whether agents are per-container at all is D1-R0's
+decision (the binding model is a shared host process with atomic revision
+applies) — these rules bind whatever container granularity D1-R0 picks.
+
+## 3. Ory Hydra OAuth 2.1/PKCE (ID1 selection input)
+
+Hydra v2.2.0: full auth-code + PKCE flow completed via curl (admin-API
+login/consent accept); introspection works; wrong verifier → invalid_grant;
+codes single-use even on failed exchange. Footprint: 41.8 MB image,
+~21 MiB idle RSS — trivially hostable in the D1 compose. Gotchas: one-shot
+`migrate sql` init step; token_endpoint_auth_method must match call style;
+prod needs a real login/consent UI + Postgres. RFC status: PKCE yes; DCR
+(7591) present but disabled by default; RFC 8707 exposed as `audience`, not
+`resource=` (spec conformance unconfirmed); RFC 9728 absent — **which is
+expected**: protected-resource metadata is served by the RESOURCE server
+(boring's MCP endpoint), not the auth server. **Verdict: VIABLE for ID1;**
+selection bead must still compare Keycloak on 8707 semantics + DCR, and
+boring owns the 9728 endpoint either way.


### PR DESCRIPTION
Two durable docs from the Fable final session. IMPLEMENTATION-GUARDRAILS.md: per-WP build contracts (build / do-NOT-build / stop signs / acceptance) for P6-R, D1, P5a, M1, ID1, AR1, AC1, P8 plus global anti-over-engineering doctrine — written so downstream agents hit the simplicity/robustness middle ground without the strategic context holder present. GTM-STRATEGY.md: positioning, ICP, four motions (lighthouse retainers, sovereignty wedge, demo-as-content, creator-led marketplace pilot), pricing placeholder, metrics, kill criteria. Additive; no pack files modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)