### PR TITLE
feat(391-P6): add stateless deployment resolver

### DIFF
--- a/packages/agent/src/server/agentDefinition/__tests__/resolveAgentDeployment.test.ts
+++ b/packages/agent/src/server/agentDefinition/__tests__/resolveAgentDeployment.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AgentDefinitionValidationError,
+  AgentDeploymentValidationError,
+  createAgentAssetDigest,
+  createAgentDefinitionDigest,
+  type AgentDefinition,
+  type AgentDeployment,
+  type CompiledAgentBundle,
+  type Sha256Digest,
+} from '../../../shared/agent-definition'
+import {
+  AgentDefinitionErrorCode,
+  AgentDeploymentErrorCode,
+  ErrorCode,
+} from '../../../shared/error-codes'
+import { resolveAgentDeployment } from '../resolveAgentDeployment'
+
+const COMPOSITION_DIGEST = `sha256:${'c'.repeat(64)}` as Sha256Digest
+const CHANGED_COMPOSITION_DIGEST = `sha256:${'d'.repeat(64)}` as Sha256Digest
+
+const definition: AgentDefinition = {
+  schemaVersion: 1,
+  definitionId: 'insurance-comparison',
+  version: '1.0.0',
+  instructionsRef: 'instructions.md',
+  capabilityRequirements: ['filesystem:read'],
+}
+
+async function makeBundle(): Promise<CompiledAgentBundle> {
+  const asset = Object.freeze({
+    path: 'instructions.md',
+    digest: await createAgentAssetDigest('Compare insurance policies.'),
+    content: 'Compare insurance policies.',
+  })
+  const assets = Object.freeze([asset])
+  const frozenDefinition = Object.freeze({
+    ...definition,
+    capabilityRequirements: Object.freeze([...definition.capabilityRequirements ?? []]),
+  })
+  return Object.freeze({
+    definition: frozenDefinition,
+    definitionDigest: await createAgentDefinitionDigest({
+      definition: frozenDefinition,
+      assets,
+    }),
+    assets,
+  })
+}
+
+function makeDeployment(bundle: CompiledAgentBundle): AgentDeployment {
+  return {
+    deploymentId: 'insurance-comparison-eu',
+    version: '2026.07.11',
+    agentId: 'default',
+    definition: {
+      definitionId: bundle.definition.definitionId,
+      version: bundle.definition.version,
+      digest: bundle.definitionDigest,
+    },
+  }
+}
+
+function binding(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    workspaceId: 'insurance-client-a',
+    defaultDeploymentId: 'insurance-comparison-eu',
+    workspaceCompositionDigest: COMPOSITION_DIGEST,
+    ...overrides,
+  }
+}
+
+const definitionError = (field: string) => ({
+  name: 'AgentDefinitionValidationError',
+  code: ErrorCode.enum.CONFIG_INVALID,
+  field,
+  validationCode: AgentDefinitionErrorCode.enum.AGENT_DEFINITION_INVALID,
+}) satisfies Partial<AgentDefinitionValidationError>
+
+const deploymentError = (field: string) => ({
+  name: 'AgentDeploymentValidationError',
+  code: ErrorCode.enum.CONFIG_INVALID,
+  field,
+  validationCode: AgentDeploymentErrorCode.enum.AGENT_DEPLOYMENT_INVALID,
+}) satisfies Partial<AgentDeploymentValidationError>
+
+describe('resolveAgentDeployment', () => {
+  it('returns a deterministic deeply immutable resolved agent', async () => {
+    const bundle = await makeBundle()
+    const deployment = makeDeployment(bundle)
+
+    const first = await resolveAgentDeployment(bundle, deployment, binding())
+    const repeated = await resolveAgentDeployment(bundle, deployment, binding())
+
+    expect(repeated).toEqual(first)
+    expect(first).toMatchObject({
+      workspace: {
+        workspaceId: 'insurance-client-a',
+        defaultDeploymentId: deployment.deploymentId,
+        compositionDigest: COMPOSITION_DIGEST,
+      },
+      deployment: {
+        deploymentId: deployment.deploymentId,
+        version: deployment.version,
+        agentId: 'default',
+      },
+      definition: {
+        definitionId: definition.definitionId,
+        version: definition.version,
+        digest: bundle.definitionDigest,
+        instructionsRef: definition.instructionsRef,
+      },
+      instructions: {
+        ref: definition.instructionsRef,
+        content: 'Compare insurance policies.',
+      },
+    })
+    expect(first.resolvedDigest).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(first.deployment.digest).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(Object.isFrozen(first)).toBe(true)
+    expect(Object.isFrozen(first.workspace)).toBe(true)
+    expect(Object.isFrozen(first.deployment)).toBe(true)
+    expect(Object.isFrozen(first.definition)).toBe(true)
+    expect(Object.isFrozen(first.instructions)).toBe(true)
+  })
+
+  it('changes only composition identity and resolved digest when composition changes', async () => {
+    const bundle = await makeBundle()
+    const deployment = makeDeployment(bundle)
+    const first = await resolveAgentDeployment(bundle, deployment, binding())
+    const changed = await resolveAgentDeployment(bundle, deployment, binding({
+      workspaceCompositionDigest: CHANGED_COMPOSITION_DIGEST,
+    }))
+
+    expect(changed.workspace).toEqual({
+      ...first.workspace,
+      compositionDigest: CHANGED_COMPOSITION_DIGEST,
+    })
+    expect(changed.definition).toEqual(first.definition)
+    expect(changed.deployment).toEqual(first.deployment)
+    expect(changed.instructions).toEqual(first.instructions)
+    expect(changed.resolvedDigest).not.toBe(first.resolvedDigest)
+  })
+
+  it('resolves independent bindings without shared object state', async () => {
+    const bundle = await makeBundle()
+    const deployment = makeDeployment(bundle)
+    const first = await resolveAgentDeployment(bundle, deployment, binding())
+    const second = await resolveAgentDeployment(bundle, deployment, binding({
+      workspaceId: 'insurance-client-b',
+    }))
+
+    expect(second.workspace.workspaceId).toBe('insurance-client-b')
+    expect(second.resolvedDigest).not.toBe(first.resolvedDigest)
+    expect(second).not.toBe(first)
+    expect(second.workspace).not.toBe(first.workspace)
+    expect(second.deployment).not.toBe(first.deployment)
+    expect(second.definition).not.toBe(first.definition)
+    expect(second.instructions).not.toBe(first.instructions)
+  })
+
+  it('rejects a bundle whose stored definition digest does not match verified content', async () => {
+    const bundle = await makeBundle()
+    const tamperedBundle = {
+      ...bundle,
+      definitionDigest: `sha256:${'f'.repeat(64)}` as Sha256Digest,
+    }
+
+    await expect(resolveAgentDeployment(
+      tamperedBundle,
+      makeDeployment(tamperedBundle),
+      binding(),
+    )).rejects.toMatchObject(definitionError('definitionDigest'))
+  })
+
+  it('re-verifies immutable asset content before resolving', async () => {
+    const bundle = await makeBundle()
+    const tamperedBundle = {
+      ...bundle,
+      assets: Object.freeze([Object.freeze({
+        ...bundle.assets[0],
+        content: 'Tampered instructions.',
+      })]),
+    }
+
+    await expect(resolveAgentDeployment(
+      tamperedBundle,
+      makeDeployment(bundle),
+      binding(),
+    )).rejects.toMatchObject(definitionError('assets.digest'))
+  })
+
+  it('rejects missing referenced instructions with the definition error contract', async () => {
+    const bundle = await makeBundle()
+    const missingInstructions = {
+      ...bundle,
+      assets: Object.freeze([]),
+    }
+
+    await expect(resolveAgentDeployment(
+      missingInstructions,
+      makeDeployment(bundle),
+      binding(),
+    )).rejects.toMatchObject(definitionError('instructionsRef'))
+  })
+
+  it.each([
+    ['definition.definitionId', (deployment: AgentDeployment) => ({
+      ...deployment,
+      definition: { ...deployment.definition, definitionId: 'other-definition' },
+    })],
+    ['definition.version', (deployment: AgentDeployment) => ({
+      ...deployment,
+      definition: { ...deployment.definition, version: '2.0.0' },
+    })],
+    ['definition.digest', (deployment: AgentDeployment) => ({
+      ...deployment,
+      definition: {
+        ...deployment.definition,
+        digest: `sha256:${'e'.repeat(64)}` as Sha256Digest,
+      },
+    })],
+    ['agentId', (deployment: AgentDeployment) => ({ ...deployment, agentId: 'alternate' })],
+  ] as const)('rejects cross-object mismatch at %s', async (field, change) => {
+    const bundle = await makeBundle()
+
+    await expect(resolveAgentDeployment(
+      bundle,
+      change(makeDeployment(bundle)),
+      binding(),
+    )).rejects.toMatchObject(deploymentError(field))
+  })
+
+  it('rejects a binding that names a different default deployment', async () => {
+    const bundle = await makeBundle()
+
+    await expect(resolveAgentDeployment(
+      bundle,
+      makeDeployment(bundle),
+      binding({ defaultDeploymentId: 'other-deployment' }),
+    )).rejects.toMatchObject(deploymentError('defaultDeploymentId'))
+  })
+
+  it('ignores surface-only binding metadata outside the resolver contract', async () => {
+    const bundle = await makeBundle()
+    const deployment = makeDeployment(bundle)
+
+    const resolved = await resolveAgentDeployment(bundle, deployment, binding())
+    const withHostname = await resolveAgentDeployment(
+      bundle,
+      deployment,
+      binding({ hostname: 'insurance-comparison.senecapp.ai' }),
+    )
+
+    expect(withHostname).toEqual(resolved)
+    expect(withHostname.resolvedDigest).toBe(resolved.resolvedDigest)
+  })
+
+  it.each([
+    ['workspaceId', ''],
+    ['workspaceId', 'a'.repeat(257)],
+    ['workspaceId', ' leading-space'],
+    ['workspaceId', 'control\u0000character'],
+    ['workspaceId', `broken-${String.fromCharCode(0xd800)}`],
+    ['defaultDeploymentId', ''],
+    ['defaultDeploymentId', 'a'.repeat(257)],
+    ['defaultDeploymentId', 'trailing-space '],
+    ['defaultDeploymentId', 'control\u007fcharacter'],
+    ['defaultDeploymentId', `broken-${String.fromCharCode(0xdc00)}`],
+    ['workspaceCompositionDigest', `sha256:${'a'.repeat(63)}`],
+    ['workspaceCompositionDigest', `sha256:${'A'.repeat(64)}`],
+    ['workspaceCompositionDigest', `sha512:${'a'.repeat(64)}`],
+  ])('rejects malformed authorized binding field %s', async (field, value) => {
+    const bundle = await makeBundle()
+
+    await expect(resolveAgentDeployment(
+      bundle,
+      makeDeployment(bundle),
+      binding({ [field]: value }),
+    )).rejects.toMatchObject(deploymentError(field))
+  })
+})

--- a/packages/agent/src/server/agentDefinition/resolveAgentDeployment.ts
+++ b/packages/agent/src/server/agentDefinition/resolveAgentDeployment.ts
@@ -1,0 +1,183 @@
+import { z } from 'zod'
+
+import {
+  AgentDefinitionValidationError,
+  AgentDeploymentValidationError,
+  OpaqueRefSchema,
+  Sha256DigestSchema,
+  createAgentAssetDigest,
+  createAgentDefinitionDigest,
+  createAgentDeploymentDigest,
+  validateAgentDeployment,
+  type AgentDeployment,
+  type CompiledAgentBundle,
+  type Sha256Digest,
+} from '../../shared/agent-definition'
+import {
+  AgentDefinitionErrorCode,
+  AgentDeploymentErrorCode,
+} from '../../shared/error-codes'
+
+const AuthorizedAgentDeploymentBindingSchema = z
+  .object({
+    workspaceId: OpaqueRefSchema,
+    defaultDeploymentId: OpaqueRefSchema,
+    workspaceCompositionDigest: Sha256DigestSchema,
+  })
+
+const RESOLVED_AGENT_DIGEST_DOMAIN = 'boring-agent/resolved-agent:v1'
+
+export interface ResolvedAgent {
+  readonly workspace: Readonly<{
+    workspaceId: string
+    defaultDeploymentId: string
+    compositionDigest: Sha256Digest
+  }>
+  readonly deployment: Readonly<{
+    deploymentId: string
+    version: string
+    agentId: string
+    digest: Sha256Digest
+  }>
+  readonly definition: Readonly<{
+    definitionId: string
+    version: string
+    digest: Sha256Digest
+    instructionsRef: string
+  }>
+  readonly instructions: Readonly<{
+    ref: string
+    content: string
+  }>
+  readonly resolvedDigest: Sha256Digest
+}
+
+function invalidDefinition(field: string, message: string): AgentDefinitionValidationError {
+  return new AgentDefinitionValidationError({
+    code: AgentDefinitionErrorCode.enum.AGENT_DEFINITION_INVALID,
+    field,
+    message,
+  })
+}
+
+function invalidDeployment(field: string, message: string): AgentDeploymentValidationError {
+  return new AgentDeploymentValidationError({
+    code: AgentDeploymentErrorCode.enum.AGENT_DEPLOYMENT_INVALID,
+    field,
+    message,
+  })
+}
+
+function parseBinding(raw: unknown): z.infer<typeof AuthorizedAgentDeploymentBindingSchema> {
+  const parsed = AuthorizedAgentDeploymentBindingSchema.safeParse(raw)
+  if (parsed.success) return parsed.data
+
+  const issue = parsed.error.issues[0]
+  const field = issue.path[0]
+  const bindingField = typeof field === 'string' ? field : 'workspaceId'
+  throw invalidDeployment(bindingField, `${bindingField} ${issue.message}`)
+}
+
+function assertEqual(
+  actual: string,
+  expected: string,
+  field: string,
+): void {
+  if (actual !== expected) {
+    throw invalidDeployment(field, `${field} does not match the compiled agent bundle`)
+  }
+}
+
+export async function resolveAgentDeployment(
+  bundle: CompiledAgentBundle,
+  deployment: AgentDeployment,
+  authorizedBinding: unknown,
+): Promise<ResolvedAgent> {
+  const binding = parseBinding(authorizedBinding)
+  const definitionDigest = await createAgentDefinitionDigest({
+    definition: bundle.definition,
+    assets: bundle.assets,
+  })
+  if (definitionDigest !== bundle.definitionDigest) {
+    throw invalidDefinition(
+      'definitionDigest',
+      'definitionDigest does not match the compiled agent bundle',
+    )
+  }
+
+  const validatedDeployment = validateAgentDeployment(deployment)
+  if (!validatedDeployment.valid) {
+    throw new AgentDeploymentValidationError(validatedDeployment.issues[0])
+  }
+  const deploymentSnapshot = validatedDeployment.value
+  const deploymentDigest = await createAgentDeploymentDigest(deploymentSnapshot)
+  assertEqual(
+    deploymentSnapshot.definition.definitionId,
+    bundle.definition.definitionId,
+    'definition.definitionId',
+  )
+  assertEqual(
+    deploymentSnapshot.definition.version,
+    bundle.definition.version,
+    'definition.version',
+  )
+  assertEqual(deploymentSnapshot.definition.digest, definitionDigest, 'definition.digest')
+  if (deploymentSnapshot.agentId !== 'default') {
+    throw invalidDeployment('agentId', 'agentId must be default in schema version 1')
+  }
+  if (binding.defaultDeploymentId !== deploymentSnapshot.deploymentId) {
+    throw invalidDeployment(
+      'defaultDeploymentId',
+      'defaultDeploymentId does not match the resolved deployment',
+    )
+  }
+
+  const instructions = bundle.assets.find(
+    (asset) => asset.path === bundle.definition.instructionsRef,
+  )
+  if (instructions === undefined) {
+    throw invalidDefinition(
+      'instructionsRef',
+      'instructionsRef must name an included verified asset',
+    )
+  }
+
+  const resolvedDigest = await createAgentAssetDigest(JSON.stringify({
+    domain: RESOLVED_AGENT_DIGEST_DOMAIN,
+    workspaceId: binding.workspaceId,
+    defaultDeploymentId: binding.defaultDeploymentId,
+    workspaceCompositionDigest: binding.workspaceCompositionDigest,
+    definitionDigest,
+    deploymentDigest,
+  }))
+
+  const workspace = Object.freeze({
+    workspaceId: binding.workspaceId,
+    defaultDeploymentId: binding.defaultDeploymentId,
+    compositionDigest: binding.workspaceCompositionDigest,
+  })
+  const resolvedDeployment = Object.freeze({
+    deploymentId: deploymentSnapshot.deploymentId,
+    version: deploymentSnapshot.version,
+    agentId: deploymentSnapshot.agentId,
+    digest: deploymentDigest,
+  })
+  const definition = Object.freeze({
+    definitionId: bundle.definition.definitionId,
+    version: bundle.definition.version,
+    digest: definitionDigest,
+    instructionsRef: bundle.definition.instructionsRef,
+  })
+  const resolvedInstructions = Object.freeze({
+    ref: bundle.definition.instructionsRef,
+    content: instructions.content,
+  })
+
+  return Object.freeze({
+    workspace,
+    deployment: resolvedDeployment,
+    definition,
+    instructions: resolvedInstructions,
+    resolvedDigest,
+  })
+}

--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -104,6 +104,10 @@ export type {
   AgentDirectoryCompilerErrorCode,
   AgentDirectoryCompilerPublicErrorCode,
 } from './agentDefinition/compileAgentDirectory'
+export {
+  resolveAgentDeployment,
+  type ResolvedAgent,
+} from './agentDefinition/resolveAgentDeployment'
 export type { AgentConfig } from '../shared/events'
 export {
   createManagedAgentMcpDelegateController,

--- a/packages/agent/src/shared/__tests__/agent-definition.test.ts
+++ b/packages/agent/src/shared/__tests__/agent-definition.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   AgentDefinitionValidationError,
+  OpaqueRefSchema,
+  Sha256DigestSchema,
   createAgentAssetDigest,
   createAgentDefinitionDigest,
   createAgentDeploymentDigest,
@@ -46,6 +48,24 @@ const deployment: AgentDeployment = {
     digest: `sha256:${'2'.repeat(64)}`,
   },
 }
+
+describe('exported identity validators', () => {
+  it('preserves opaque reference length and Unicode rules', () => {
+    expect(OpaqueRefSchema.safeParse('a'.repeat(256)).success).toBe(true)
+    expect(OpaqueRefSchema.safeParse('a'.repeat(257)).success).toBe(false)
+    expect(OpaqueRefSchema.safeParse('agent-🛡️').success).toBe(true)
+    expect(OpaqueRefSchema.safeParse(`agent-${String.fromCharCode(0xd800)}`).success).toBe(false)
+    expect(OpaqueRefSchema.safeParse(' agent').success).toBe(false)
+    expect(OpaqueRefSchema.safeParse('agent\u0000').success).toBe(false)
+  })
+
+  it('accepts only canonical lowercase SHA-256 digests', () => {
+    expect(Sha256DigestSchema.safeParse(`sha256:${'a'.repeat(64)}`).success).toBe(true)
+    expect(Sha256DigestSchema.safeParse(`sha256:${'A'.repeat(64)}`).success).toBe(false)
+    expect(Sha256DigestSchema.safeParse(`sha256:${'a'.repeat(63)}`).success).toBe(false)
+    expect(Sha256DigestSchema.safeParse(`sha512:${'a'.repeat(64)}`).success).toBe(false)
+  })
+})
 
 describe('validateAgentDefinition', () => {
   it('accepts the behavior-only v1 definition', () => {

--- a/packages/agent/src/shared/agent-definition.ts
+++ b/packages/agent/src/shared/agent-definition.ts
@@ -101,7 +101,7 @@ function isSafeAssetPath(value: string): boolean {
   )
 }
 
-const OpaqueRefSchema = z
+export const OpaqueRefSchema = z
   .string()
   .min(1, 'must be a non-empty reference')
   .max(256, 'must be at most 256 characters')
@@ -126,7 +126,7 @@ const SafeAssetPathSchema = z
   .min(1)
   .refine(isSafeAssetPath, 'must be a safe relative asset path')
 
-const Sha256DigestSchema = z
+export const Sha256DigestSchema = z
   .string()
   .regex(SHA256_DIGEST_RE, 'must be a lowercase sha256 digest')
   .transform((value) => value as Sha256Digest)

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -92,6 +92,8 @@ export type { AgentRuntimeCapabilities } from './capabilities'
 export {
   AgentDefinitionValidationError,
   AgentDeploymentValidationError,
+  OpaqueRefSchema,
+  Sha256DigestSchema,
   createAgentAssetDigest,
   createAgentDefinitionDigest,
   createAgentDeploymentDigest,


### PR DESCRIPTION
## Summary

- adds BBP6-011 as one stateless resolver from a verified compiled bundle, validated deployment, and host-authorized workspace/default binding
- re-verifies definition/assets/deployment and enforces the fixed cross-object error matrix
- returns a deeply frozen `ResolvedAgent` with exact instructions and a deterministic domain-separated digest
- exports the existing opaque-ref and SHA-256 validators for the module-local binding schema

## Boundaries

- one call resolves one already-authorized binding; D1 obtains N agents with N calls
- hostname remains surface mapping only and is stripped from resolver-owned input
- no router, registry, cache, pointer, persistence, lifecycle, readiness, policy, plugin/environment catalog, P2, or P5a dependency
- P6-R binds the opaque workspace composition digest but does not claim to reproduce or verify the host composition

## Proof

- `git diff --check origin/main...HEAD` — pass
- pre/post-rebase stable patch IDs match
- independent spec audit — clean after deployment snapshot and asset-content revalidation fixes
- structured spec/standards autoreview — clean
- thermo maintainability autoreview — clean
- no local executable tests/typecheck run per owner direction; GitHub CI is the executable proof

## Risk / rollback

Narrow additive server API and value-validator exports only. No existing route or runtime behavior changes. Rollback is this single commit.

## Next

After merge, D1-R0 inventories the real host composer and defines the canonical redacted workspace-composition producer. P2/P5a do not gate this resolver.