### PR TITLE
docs(391-D1): accept atomic host revision spec

### DIFF
--- a/docs/issues/391/runtime-refactor/PR-PLAN.md
+++ b/docs/issues/391/runtime-refactor/PR-PLAN.md
@@ -9,15 +9,14 @@ shims) remains binding.
 
 | Order | Work package | Dispatch state | Exact next slice |
 | --- | --- | --- | --- |
-| 1 | #631 | **merged; ancestry verified** | Request-binding lifecycle is complete; do not replay the discarded recut worktree. |
-| 2 | P1 readiness recut | **ready now** | One current-main fail-closed readiness PR only; exclude #566/#568/#575 and all superseded lifecycle code. |
-| 3 | P6-R / BBP6-011 | ready after P1 | One pure binding resolver per the exact micro-contract below. |
-| 4 | D1-R0 | needs-spec after P6-R | Trace one boot-time Docker collection with two bindings, then write exact D1 implementation beads; do not dispatch historical dedicated/runsc beads. |
-| 5 | D1 composition producer -> A1-dev | blocked on D1-R0 micro-plan | Implement the one canonical redacted producer in its D1-owned bead; then recut A1 local dev against that exact host seam. A1-dev gates P8, not D1. |
-| 6 | P5a | conditional inside D1 | Add only a demonstrated secret-ref or host-readiness seam; D1 owns apply/digest/rollback. |
-| 7 | M1 -> AR1 -> M2/E2 | ordered priority 2 | Recut #549/#556 with authorized complete-byte artifact output and stable no-path rejection, accept AR1-001, then recut canonical MCP/artifact intake. |
-| 8 | T1 -> T2 | ordered priority 3 | Recut after priority-2 consumer proof. |
-| 9 | P2 -> X1 | ordered priority 4 | Sol P2 may prepare in isolation, but provider/mount work merges last. |
+| 1 | #631 + P1 readiness | **merged; ancestry verified** | Request-binding lifecycle and fail-closed readiness are complete; do not replay discarded/superseded stacks. |
+| 2 | P6-R / BBP6-011 | **merged; ancestry verified** | The pure one-binding resolver is complete; D1 obtains N agents through N independent calls. |
+| 3 | D1-R0 | **accepted; merge pending** | Merge [`D1-R0-SPEC.md`](work/D1-tenant-provisioning/D1-R0-SPEC.md), then dispatch D1-001 through D1-006 in order. Historical dedicated/runsc beads remain non-dispatchable. |
+| 4 | D1 composition producer -> A1-dev | D1-001 first | D1-001 implements the canonical redacted producer beside the real full-app composition; then recut A1 local dev against that exact host seam. A1-dev gates P8, not D1. |
+| 5 | P5a | conditional inside D1 | Add only a demonstrated secret-ref or host-readiness seam; D1 owns apply/digest/rollback. |
+| 6 | M1 -> AR1 -> M2/E2 | ordered priority 2 | Recut #549/#556 with authorized complete-byte artifact output and stable no-path rejection, accept AR1-001, then recut canonical MCP/artifact intake. |
+| 7 | T1 -> T2 | ordered priority 3 | Recut after priority-2 consumer proof. |
+| 8 | P2 -> X1 | ordered priority 4 | Sol P2 may prepare in isolation, but provider/mount work merges last. |
 
 ### P1-R readiness micro-contract — current dispatch slice
 
@@ -98,8 +97,12 @@ shims) remains binding.
 
 ### D1-R0 planning tracer
 
-After P6-R, inspect the actual host composition and produce active D1 beads with
-exact files, stable errors, proof, and review budgets. The tracer must lock:
+The accepted output of this tracer is
+[`D1-R0-SPEC.md`](work/D1-tenant-provisioning/D1-R0-SPEC.md). On merge it locks
+exact files, stable errors, proof, and review budgets. Its host-revision design
+keeps the current one-process N-binding composition: the first slice publishes
+only additive/landing-only revisions, rejects active binding replacement, and
+performs N independent P6-R calls; agents are not per-container. It also locks:
 boot-time collection only; canonical host/proxy parsing; unique hostname,
 workspace, deployment, and non-overlapping roots; explicit shared-host trust
 profile; expected host revision; atomic active-collection publication; desired
@@ -110,8 +113,9 @@ auto-provision paths; validation of definition capability/tool/skill/MCP refs
 against the final activation;
 identify the current composer inputs and specify the smallest canonical redacted
 workspace-composition identity/digest producer before claiming reproducible
-apply/rollback; and no wildcard/CRUD/hot-tenant control plane. Until that spec is accepted,
-D1 and P5a are `needs-spec`, not implementation assignments.
+apply/rollback; and no wildcard/CRUD/hot-tenant control plane. Until that spec
+is accepted, D1 implementation remains blocked. P5a remains conditional, not a
+D1 or D1-R0 gate.
 
 ---
 

--- a/docs/issues/391/runtime-refactor/plan-navigator.html
+++ b/docs/issues/391/runtime-refactor/plan-navigator.html
@@ -1387,22 +1387,22 @@
         docs: [["Plan", "work/P5-provisioning-secrets/PLAN.md"], ["TODO", "work/P5-provisioning-secrets/TODO.md"], ["V1 handoff", "work/P5-provisioning-secrets/P5A-HANDOFF.md"]]
       },
       {
-        id: "p6r", phase: "P6-R", title: "Workspace-backed resolution", category: "critical", status: "deferred",
+        id: "p6r", phase: "P6-R", title: "Workspace-backed resolution", category: "critical", status: "merged",
         subtitle: "Bind definition plus host deployment to one authorized host-attested composition identity.",
         starts: "P6-D + P1 lifecycle/readiness",
         outcome: "One immutable resolved value over a verified bundle/deployment plus a host-attested composition digest and explicit default binding.",
         boundary: "No generation store, environment registry, plugin loader, per-agent plugin selection, or new workspace bundle schema.",
-        gate: "P6-R is deterministic over its inputs; D1-R0 must specify the missing canonical redacted composition-digest producer before D1 claims reproducible rollback.",
+        gate: "P6-R is deterministic over its inputs; D1-001 owns the missing canonical redacted composition-digest producer before D1 claims reproducible rollback.",
         docs: [["Plan", "work/P6-plugin-child-app/PLAN.md"], ["TODO", "work/P6-plugin-child-app/TODO.md"], ["V1 handoff", "work/P6-plugin-child-app/P6-V1-HANDOFF.md"]]
       },
       {
-        id: "d1", phase: "D1", title: "Multi-agent EU Docker delivery", category: "critical", status: "needs-spec",
-        subtitle: "Needs-spec after P6-R; only the D1-R0 host-collection tracer is dispatchable.",
-        starts: "D1-R0 needs-spec after the A1 compiler and P6-R; narrow P5a only if demonstrated",
-        outcome: "One Docker host, N exact-host landings, member auth, authorized workspace/default bindings, idempotent collection apply, and complete host rollback.",
+        id: "d1", phase: "D1", title: "Multi-agent EU Docker delivery", category: "critical", status: "active",
+        subtitle: "D1-R0 passed adversarial review; micro-beads dispatch after the spec merges.",
+        starts: "Merge D1-R0-SPEC, then D1-001; P2/runsc and P5a are not gates",
+        outcome: "One Docker host, N exact-host landings, member auth, authorized workspace/default bindings, uninterrupted additive apply, and rollback as a new revision.",
         boundary: "Host mutation is an OS-authorized local CLI only. Bound hostnames fence existing workspace list/create/switch/delete/default-auto-create paths; no app management API.",
-        gate: "Two bindings, final-activation requirement validation, ordinary-member host-mutation denial, workspace lifecycle fences, shared-host sibling isolation, cross-binding denial, reapply/rollback, and no-secret proof. Dedicated VM is documentation/config-render only.",
-        docs: [["Plan", "work/D1-tenant-provisioning/PLAN.md"], ["TODO", "work/D1-tenant-provisioning/TODO.md"], ["Handoff", "work/D1-tenant-provisioning/HANDOFF.md"]]
+        gate: "Three bindings, final-activation requirement validation, ordinary-member host-mutation denial, workspace lifecycle fences, stable-process N+1 continuity, active-replacement refusal, shared-host sibling isolation, cross-binding denial, rollback-as-new-revision, and no-secret proof. Dedicated VM is documentation/config-render only.",
+        docs: [["R0 spec", "work/D1-tenant-provisioning/D1-R0-SPEC.md"], ["Plan", "work/D1-tenant-provisioning/PLAN.md"], ["TODO", "work/D1-tenant-provisioning/TODO.md"], ["Handoff", "work/D1-tenant-provisioning/HANDOFF.md"]]
       },
       {
         id: "p8", phase: "P8", title: "V1 verification", category: "critical", status: "deferred",

--- a/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/D1-R0-SPEC.md
+++ b/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/D1-R0-SPEC.md
@@ -1,0 +1,535 @@
+# D1-R0 — atomic multi-agent host revisions
+
+Status: **accepted by adversarial plan review; binding on merge**. This
+specification replaces the active D1-R0 planning tracer. It does not revive the
+historical dedicated-site design later in this work package.
+
+## 1. Decision and scope
+
+D1 v1 runs one Docker Compose deployment on one EU host. It has one ingress,
+one stable `core-app` process, and shared durable database/storage. The current
+full app already hosts N lazy workspace bindings in one process. D1 preserves
+that composition and invokes stateless P6-R independently for every binding.
+**Agents are not containers.**
+
+D1-S1 does not implement concurrent core-process replacement. Current request leases do
+not prove that a disconnected accepted producer has finished, so an in-flight
+counter cannot safely retire an old process or decide reconnect affinity. A
+generic dual-process claim would risk two processes writing the same session. The
+first slice instead publishes immutable **additive** binding revisions to the
+one stable process. Existing binding runtime/composition/secret/root fields must
+remain byte-identical. A revision may add a binding or change bounded landing
+copy; replacement of an admitted binding, runtime/secret rotation, or removal
+fails closed with `D1_ACTIVE_BINDING_RESTART_REQUIRED`.
+
+This makes the continuity guarantee mechanical: applying N+1 never moves or
+restarts the process serving bindings 1..N, and their resolved identities do not
+change. A reconnect reaches the same process and durable session root. An
+online rollback may remove only a binding with no durable admission row
+(landing views do not count) and restore landing-only values. Any binding that
+has admitted an agent request requires an explicit maintenance-window restart;
+D1-S1 never infers idleness from connection state. Rollback still materializes
+a new immutable COMPLETE revision and never moves the active pointer backward.
+
+The hostname is a surface lookup only:
+
+```txt
+trusted ingress Host -> active revision site map -> landing/auth handoff
+                                           |
+                                           +-> configured workspace id
+                                               + existing membership check
+                                               + configured default deployment
+                                               + one P6-R call
+```
+
+Possessing or supplying a hostname, workspace id, bearer token, deployment id,
+or operator-ref string grants no workspace or host authority. Membership is the
+workspace authority. Only the local CLI process admitted by host OS permissions
+may plan, apply, publish, or roll back a host revision. D1 adds no management
+HTTP route, tenant CRUD API, wildcard router, scheduler, reconciler, queue,
+provider registry, or secret service.
+
+P2/runsc and P5a are not D1 gates. The real non-mocked `preflightRunsc`
+execution passed all seven structural probes on the EU host. The runsc
+production lock remains open until the privileged execution model and the
+remaining lifecycle/security proofs land. D1 consumes the currently approved
+isolated runtime composition; a trusted-direct runtime is valid only for local
+development or a single-workspace dedicated composition, never this shared
+N-workspace host.
+
+## 2. Compose and apply rules
+
+The production file is `deploy/d1/compose.yml`. It defines ingress and one
+`core-app`; `databaseRef` resolves to an external, already-provisioned database,
+not a D1 Compose database service. The core uses one pinned host-app image
+digest and durable workspace/session volumes. The core mounts the revision tree
+read-only; only the root-owned local CLI writes revisions and the atomic active
+pointer on the host. The core writes admission state through the external
+database, not through that mount. Direct core ports bind loopback or an
+internal-only network; clients cannot bypass ingress.
+
+Compose operations obey the verified EU-host spike rules:
+
+- use one compose file for plan/apply/rollback;
+- run idempotent `docker compose up -d`, never `--force-recreate`;
+- use service-specific `up -d --no-deps core-app` only for initial boot or an
+  explicit maintenance-window restart; additive revisions do not invoke Compose;
+- change or roll back only the named service with `--no-deps`; never run a
+  blanket old compose file over newer volumes, secrets, or services;
+- keep process-level Compose environment in one core env file;
+- keep each agent/workspace binding in its own redacted env file and secret-ref
+  directory, mounted under the immutable revision directory and parsed by the
+  app. Do not merge agent values into process-global environment variables.
+
+The core reads one atomic active-revision pointer when deriving a new trusted
+host scope; it never mutates an already-admitted request's scope. Ingress has a
+static trusted hop to the same core process, so additive publication needs no
+upstream cutover. The proof starts a request on binding 1, atomically adds
+binding 4, and shows the existing request and reconnect continue in the same
+process while binding 4 becomes available. No disconnected-producer retirement
+claim is made.
+
+## 3. Canonical inputs
+
+### 3.1 Desired host plan
+
+`D1HostPlanV1` is strict, versioned input:
+
+```ts
+interface D1HostPlanV1 {
+  schemaVersion: 1
+  hostId: string
+  expectedHostRevision: string | null
+  hostAppImageDigest: `sha256:${string}`
+  runtimeProfileRef: string
+  databaseRef: string
+  workspaceRootPolicyRef: string
+  sessionRootPolicyRef: string
+  bindings: D1SiteBindingV1[]
+}
+
+interface D1SiteBindingV1 {
+  bindingId: string
+  hostname: string
+  workspaceId: string
+  defaultDeploymentId: string
+  bundleRef: string
+  deploymentRef: string
+  workspaceAllocationRef: string
+  sessionAllocationRef: string
+  ownerPrincipalRef: string
+  landing: { title: string; summary: string; ctaLabel?: string }
+  environmentRef: string
+  secretRefs: string[]
+}
+```
+
+`operatorRef`, readiness, timestamps, container ids, ports, resolved secret
+versions, and health are not desired inputs. The CLI records the OS principal
+(`uid`, effective user, invocation id) plus an optional operator note in the
+audit record; neither is accepted as authorization material.
+
+Hostname parsing accepts a lower-case ASCII exact DNS name with no wildcard,
+scheme, path, userinfo, port, trailing dot, or ambiguous Unicode. Generic
+`trustProxy: true` is forbidden. Configuration names an exact trusted proxy CIDR
+and hop count; the server accepts a forwarded host only when the direct peer and
+chain length match, rejects multiple/ambiguous forwarded-host values, and
+otherwise uses the direct authority. Ingress strips inbound forwarding headers
+before emitting one canonical value. The app still matches it to the active
+revision map. Unknown, duplicate, or mismatched hosts fail before auth.
+
+`workspaceRootPolicyRef` and `sessionRootPolicyRef` identify host-approved base
+root policies: each resolves to one canonical parent path plus its ownership and
+mount rules. The two approved parents must be distinct and non-overlapping.
+Each binding allocation ref resolves to one concrete durable child under the
+matching approved parent. Allocation roots across all bindings and both kinds
+must be distinct, non-nested, and non-symlink-aliased; each allocation belongs
+only to its matching root policy. The plan contains opaque refs, not paths.
+
+Before effects, plan validation rejects duplicate binding ids, hostnames,
+workspace ids, deployment ids, or default bindings; an allocation outside its
+approved parent; equal, nested, or symlink-aliased allocation roots; secret
+values; missing refs; and an unknown runtime profile ref. The host resolves
+`runtimeProfileRef` from its approved immutable profile store and verifies its
+content digest plus sibling filesystem/process-denial attestation. The plan
+cannot self-assert an isolation literal. Root/profile refs are opaque plan
+identities resolved by the local host adapter; public output never contains raw
+host paths.
+
+### 3.2 Canonical workspace-composition identity
+
+D1 owns one producer, `createWorkspaceCompositionSnapshot`, beside the full-app
+host composition. It receives concrete values already selected for one
+workspace and returns a frozen `WorkspaceCompositionSnapshotV1` plus its
+canonical SHA-256 digest. P6-R consumes that digest; callers cannot supply an
+arbitrary digest.
+
+The snapshot contains, sorted by stable id:
+
+- schema/domain version and workspace id;
+- runtime-profile ref plus host-resolved immutable profile/version/content digest,
+  isolation-attestation digest, and redacted root policy refs;
+- host-app image digest;
+- explicit server/plugin contribution ids, versions, and content digests from
+  `createFullAppServerPlugins` and `defaultPluginPackages`;
+- static system-prompt input digest;
+- final activated capability, tool, skill, and MCP-server inventories where the
+  current host has a trustworthy enumerator;
+- provisioning contribution ids/versions and governance filesystem-binding
+  ids/policies, excluding handles and paths;
+- explicit external-plugin and plugin-authoring policy booleans.
+
+It excludes functions, object identity, order of discovery, filesystem paths,
+raw prompts, secret values, health, timestamps, process/container ids, and
+other observations. Canonical JSON uses fixed keys and lexically sorted arrays;
+duplicate inventory ids fail. Every contribution must expose a stable
+descriptor at the current host composition seam. Current capability, skill, and
+MCP inventories are incomplete: D1-001 must not invent them. An undescribed
+contribution or non-empty requirement whose trustworthy inventory is unavailable
+fails closed; D1 must not hash `Function#toString`, package paths, or a caller
+label.
+
+Before digest production, D1 compares `capabilityRequirements`, `toolRefs`,
+`skillRefs`, and `mcpServerRefs` from the verified definition against the final
+activated inventories. Requirements grant nothing. A missing item throws
+`AGENT_COMPOSITION_REQUIREMENT_UNSATISFIED` with only redacted
+`{ definitionId, field, ref }` details. D1 then passes the resulting digest,
+workspace id, and configured default deployment id to one P6-R call. The
+resolved digest is recorded in the candidate snapshot.
+
+## 4. Revision model
+
+Host state lives under one root-owned directory outside the app container:
+
+```txt
+/var/lib/boring/d1/<hostId>/
+  active                         # atomic pointer: revision id + digest
+  revisions/<revisionId>/
+    desired.json                 # canonical redacted plan
+    desired.sha256
+    bindings/<bindingId>.env     # non-secret, one binding per file
+    secret-refs.json             # identities only, no values
+    resolved.json                # N P6-R identities/digests, no handles
+    observed.json                # redacted readiness for this attempt
+    completion.json              # COMPLETE record and completion digest
+  audit.jsonl
+```
+
+Admission state is deliberately not part of an immutable revision. The same
+external database selected by `databaseRef` owns a durable
+`d1_binding_admissions` ledger keyed by `(hostId, bindingId)`, with a database-
+allocated monotonic sequence, `activeRevision`, and server timestamp. The core
+has insert/read access; the OS-authorized CLI has read access for diff and
+rollback validation. D1 exposes no update/delete operation, and migrations,
+backups, and host recovery preserve the table independently of revision cleanup.
+
+`desired.json`, binding env files, `secret-refs.json`, `resolved.json`, and
+`completion.json` become immutable before publication. Revisions store secret
+refs only. The root-owned adapter materializes raw mode-0400 values in external
+tmpfs under `/run/boring/d1/`; values never enter the revision tree, JSON, logs,
+plan output, Compose output, or git. Their values are excluded from desired and
+completion digests; secret ref identity is included. Boot and rollback resolve
+refs afresh and record only a redacted version/fingerprint observation. A
+changed value behind an unchanged secret ref is a
+runtime replacement in D1-S1 and returns
+`D1_ACTIVE_BINDING_RESTART_REQUIRED`; it is never mistaken for an idempotent
+no-op.
+
+The CLI holds one non-stealable OS file lock for the entire mutation. It checks
+`expectedHostRevision` against the active pointer while holding the lock. A
+different value fails before materialization. It writes a new revision in a
+temporary sibling directory, fsyncs files/directories, renames it into
+`revisions/`, and records observed readiness. For an active host it proves the
+candidate is additive: all admitted bindings retain identical runtime,
+composition, root, deployment, and secret identities. Only after every retained
+and new binding reports ready does it append the COMPLETE record and atomically
+replace `active`. Failed candidates remain inspectable with no COMPLETE record,
+are never selected by the host map, and may be removed only by an explicit
+cleanup command.
+
+Desired state and observed state never share a digest. `desiredStateDigest`
+covers the complete redacted plan, composition snapshots, and N P6-R results.
+`completionDigest` covers desired digest plus this attempt's redacted observed
+attestations. Same desired state is an idempotent no-op only after the CLI
+re-resolves all N bindings and reproduces their P6-R digests.
+
+### Rollback
+
+`rollback --to <completeRevision> --expected <activeRevision>` loads the prior
+COMPLETE desired snapshot, re-resolves secret refs and all N P6-R calls, and
+materializes it as a **new** monotonically allocated revision. It never changes
+the active pointer to the old revision id and never replays old observations.
+An online rollback may remove only bindings introduced after the target for
+which no durable admission row exists; it may also restore landing-only fields.
+Before the first agent effect for a binding, the core commits an idempotent
+insert into `d1_binding_admissions`; the unique key makes concurrent first
+requests converge on one database-allocated sequence. The effect proceeds only
+after that transaction commits. A database error fails closed. The row is never
+updated or cleared. At boot and before every destructive diff, the core/CLI
+reloads the ledger from the database rather than trusting cached readiness or
+revision files. A single accepted request therefore makes the binding
+non-removable online forever, even if its connection closed. Other runtime/
+composition/root/deployment/secret
+replacement fails `D1_ACTIVE_BINDING_RESTART_REQUIRED`. A full runtime rollback
+therefore requires an explicit maintenance-window stop and reapply in D1-S1.
+
+Every permitted removal also requires `--confirm-remove <bindingId>` for the
+exact sorted set. Extra, missing, or stale confirmations fail. CAS is not
+destructive consent, and confirmation never bypasses the admission/restart
+guard.
+
+## 5. Publication state machine
+
+Only this finite command flow exists; there is no background reconciler:
+
+1. acquire host lock and authenticate through OS permissions;
+2. parse the complete plan, normalize hosts/refs, verify expected revision and
+   destructive confirmations;
+3. build each canonical composition snapshot, validate definition requirements,
+   and execute N independent P6-R calls;
+4. write one immutable candidate revision and materialize secret refs;
+5. on initial boot only, run backward-compatible migrations and idempotent
+   `docker compose up -d`; on an active host, prove the additive/landing-only
+   diff and reject every replacement before publication;
+6. write the candidate revision id/digest to the root-owned atomic pending
+   pointer under `/run/boring/d1/`, then send the core process its dedicated
+   preload signal; the process reads only that fixed pointer/revision root,
+   instantiates/verifies every new logical binding, and writes an all-binding
+   readiness ack without changing the active host map;
+7. write COMPLETE, atomically replace the active revision pointer, and verify
+   the new hostname map while an already-admitted request on a retained binding
+   completes in the same process;
+8. append the redacted operator/revision audit result and release the lock.
+
+Pre-publication failure retains only the inactive candidate files and leaves the
+prior active pointer unchanged. Failure after pointer publication completes
+forward by recording audit/recovery state; it never silently switches backward.
+No Compose service is restarted during an online additive publication.
+
+Candidate preload is not HTTP and is not a general mutation protocol. Only the
+root-owned CLI can atomically write `{ schemaVersion, revisionId,
+desiredDigest }` to the fixed pending pointer and signal the core PID. The
+payload accepts no path or caller binding. The core cross-checks the fixed-root
+immutable files/digest and writes a revision-scoped ack. A failed preload
+discards candidate logical bindings and cannot alter the active pointer.
+Ordinary app credentials and members cannot trigger it; the HTTP route table
+contains no deployment mutation endpoint.
+
+The loopback/internal readiness surface reports active revision id, desired
+digest, and binding readiness only. The separate durable admission row commits
+before the first agent effect and is used only to forbid online removal; it is
+not an in-flight/producer lease. Neither surface contains secrets, raw paths,
+owner identities, instructions, or tool content.
+
+## 6. Bound-host workspace fences
+
+The active site binding becomes a server-derived `D1WorkspaceScope` only after
+trusted host parsing. It contains `{ bindingId, workspaceId,
+defaultDeploymentId, activeRevision }` and is never built from request
+workspace/agent fields.
+
+The first D1 delivery stack must fence these current seams:
+
+- `packages/core/src/server/routes/workspaces.ts`: on a bound host, list only
+  the bound workspace after membership; do not call default auto-provision;
+  reject create, foreign detail/update, and ordinary delete;
+- `packages/core/src/server/auth/postSignupHook.ts`: without an accepted invite,
+  do not create a personal default workspace under bound-host signup;
+- `packages/core/src/server/routes/members.ts` and account deletion ownership
+  paths: do not orphan/delete/transfer the D1-managed workspace outside the
+  local operator lifecycle;
+- `packages/core/src/app/server/createCoreWorkspaceAgentServer.ts` and
+  `apps/full-app/src/server/main.ts`: inject the trusted scope and configured
+  default deployment into existing route/runtime composition;
+- full-app MCP, agent, plugin-front/runtime, pane-status, and WorkspaceBridge
+  workspace selectors: intersect any path/query/body/header/token workspace id
+  with the same scope before lookup or effects.
+
+Membership checks remain existing core checks. A member of another workspace
+does not gain the bound workspace. A non-member sees a generic denial before
+default creation, provisioning, workspace lookup detail, or agent resolution.
+The front may hide create/switch/delete, but server fences are acceptance.
+
+## 7. Stable failures
+
+The D1 implementation adds one typed host error carrying these stable codes:
+
+| Code | Meaning |
+| --- | --- |
+| `D1_PLAN_INVALID` | schema, hostname, ref, duplicate, or root-overlap failure |
+| `D1_HOST_SCOPE_VIOLATION` | untrusted/unknown host or cross-binding selector |
+| `D1_RUNTIME_PROFILE_UNAPPROVED` | shared-host isolation proof is absent |
+| `D1_REVISION_CONFLICT` | expected active revision or host lock is stale/busy |
+| `D1_DESTRUCTIVE_CONFIRMATION_REQUIRED` | exact removal set was not confirmed |
+| `D1_SECRET_UNAVAILABLE` | a named secret ref cannot be securely materialized |
+| `AGENT_COMPOSITION_REQUIREMENT_UNSATISFIED` | final activation lacks a declared ref |
+| `D1_COLLECTION_NOT_READY` | any binding/host readiness check failed |
+| `D1_PUBLICATION_FAILED` | atomic ingress/pointer publication failed |
+| `D1_ROLLBACK_TARGET_INVALID` | target is absent, incomplete, or fails reproduction |
+| `D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN` | app/user lifecycle tried to mutate a managed binding |
+| `D1_ACTIVE_BINDING_RESTART_REQUIRED` | an online revision replaces/removes an admitted runtime binding or rotates its runtime inputs |
+| `D1_BINDING_ADMITTED` | rollback tried to remove a binding with a durable admission row |
+| `D1_ADMISSION_RECORD_FAILED` | the durable admission row did not commit before the first agent effect |
+
+Errors expose no raw paths, secret values, landing-private metadata, or foreign
+workspace/deployment ids. Tests assert codes, not messages.
+
+## 8. Implementation beads
+
+The user-facing D1-S1 vertical slice is the ordered stack D1-001 through
+D1-006. Each PR stays dark/additive until its own acceptance; no PR claims the
+three-agent exit early. P2/P5a do not gate any bead.
+
+### D1-001 — plan and composition identity (<= 400 net lines; 25 minutes)
+
+Files: new `apps/full-app/src/server/deployment/d1Plan.ts`,
+`workspaceComposition.ts`, and focused tests; minimal descriptor exports from
+`apps/full-app/src/server/plugins.ts` and host composition wiring only.
+
+Deliver: strict plan validation, canonical redacted composition snapshot/digest,
+final requirement inventory validation, and exact stable errors. Prove sort
+stability, secret/path exclusion, digest sensitivity, unknown inventory refusal,
+and two workspaces producing independent P6-R inputs. No filesystem mutation,
+Compose, routing, or CLI yet.
+
+### D1-002 — immutable revision store and local CLI (<= 400 net lines; 25 minutes)
+
+Files: new `apps/full-app/src/server/deployment/hostRevisionStore.ts`,
+`apps/full-app/src/server/deployment/cli.ts`, tests, and one private script entry
+in `apps/full-app/package.json`.
+
+Deliver: plan/apply dry-run, OS lock, expected-revision CAS, immutable candidate/
+COMPLETE records, atomic pointer, audit, exact destructive confirmation, and
+rollback-as-new-revision using injected materialize/readiness/publish adapters.
+Prove concurrency, pre/post-publication fault boundaries, idempotence, and no
+secret/path output. No HTTP management route.
+
+### D1-003 — stable-process Compose adapter (<= 400 net lines; 25 minutes)
+
+Files: new `deploy/d1/compose.yml`, `deploy/d1/collection.example.json`,
+`apps/full-app/src/server/deployment/composeAdapter.ts`, and focused tests. Raw
+secret files and generated revision material stay outside the checkout; secret
+values exist only in the external tmpfs materialization root.
+
+Deliver: one ingress plus one full-collection core process; pinned image,
+external `databaseRef`, durable workspace/session roots, per-binding env plus
+external tmpfs secret inputs; `up -d` and maintenance-only service-specific
+`--no-deps`. Prove additive publication does not invoke Compose, no database
+service is created, and generated commands never contain `--force-recreate`,
+blanket rollback, secret values, or source-checkout mounts.
+
+### D1-004a — trusted host surface (<= 400 net lines; 25 minutes)
+
+Files: new `apps/full-app/src/server/deployment/hostSurface.ts`, landing handler,
+focused tests, minimal `apps/full-app/src/server/main.ts` wiring, and surgical
+trusted-proxy configuration in `packages/core/src/server/app/createCoreApp.ts`,
+`packages/core/src/server/config/{schema,loadConfig}.ts`, and shared config types.
+
+Deliver: explicit proxy CIDR/hop parsing (never generic `trustProxy: true`),
+active-revision site map, bounded escaped landing, fixed same-origin auth return,
+scope derivation, and internal readiness. Hostname grants nothing; ambiguous,
+unknown, or untrusted forwarded hosts fail before auth.
+
+### D1-004b — workspace authority fences (<= 400 net lines; 30 minutes)
+
+Files: one shared optional scope contract in core app server types; surgical
+updates/tests in `workspaces.ts`, `postSignupHook.ts`, managed-workspace
+membership/account-deletion paths.
+
+Deliver: member-only bound list; create/foreign switch/delete/default auto-
+provision denial; operator-owned managed lifecycle. Preserve generic-host
+behavior byte-for-byte at the public contract.
+
+### D1-004c — remaining selector conformance (<= 400 net lines per PR; 25 minutes)
+
+Inventory full-app agent/MCP/plugin/pane/WorkspaceBridge selectors first. Split
+one PR per route family if the diff exceeds the budget. Every selector rejects
+a foreign caller value before lookup/effects and derives default deployment
+from scope. Do not introduce a generic policy framework.
+
+### D1-004d — durable admission ledger (<= 300 net lines; 20 minutes)
+
+Files: one new core Drizzle migration plus the matching export in
+`packages/core/src/server/db/schema.ts`; new
+`apps/full-app/src/server/deployment/admissionLedger.ts`; focused schema/store
+tests; and a narrow first-effect hook through the D1 host scope.
+
+Deliver: insert/read-only `(hostId, bindingId)` admission rows with a database-
+allocated monotonic sequence; transaction commit before the first agent effect;
+idempotent concurrent admission; restart recovery and CLI destructive-diff
+reads from the database; no update/delete API. Prove a failed commit produces
+`D1_ADMISSION_RECORD_FAILED` and no agent effect, and an admitted binding remains
+non-removable after process restart and revision-directory cleanup.
+
+### D1-005 — collection boot and atomic publication (<= 400 net lines; 30 minutes)
+
+Files: new `apps/full-app/src/server/deployment/{bootCollection,preloadSignal}.ts`,
+integrate the D1-001/002/003/004 seams in `main.ts`, and focused integration
+tests. The fixed pending-pointer/signal handler is the only local candidate-
+activation seam.
+
+Deliver: read one immutable revision, perform N independent P6-R calls, preload
+all logical bindings through the root-owned pending pointer and signal, wait for
+its all-ready ack, and atomically publish an additive/landing-only pointer in the stable
+process. Prove invalid pending payload/path/digest and one failed binding leave the old
+collection active, a running request and reconnect survive N+1 publication in
+the same process, and replacement/removal/secret rotation rejects before effects.
+
+### D1-006 — EU-host proof and runbook (<= 300 net lines; 20 minutes)
+
+Files: `docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/RUNBOOK.md`,
+a narrow proof script under `scripts/`, and the generated `golden-path.json`
+evidence path already assigned to P8 (do not duplicate its version contract).
+
+Deliver: boot/add-agent/apply/rollback/cleanup commands and a documented
+maintenance-restart boundary for every runtime/secret replacement;
+three distinct agents/workspaces/hostnames in one EU deployment; three
+independent P6-R digests; setup-to-first-success timing and per-stage breakdown;
+idempotent additive apply; N+1 continuity; exact rollback as a new revision;
+cross-host/workspace and sibling filesystem/process denial; secret canary;
+dedicated-VM configuration render. Record actual commands and redacted results.
+
+## 9. D1-S1 acceptance
+
+D1-S1 is complete only when all of the following are CI- or EU-host-provable:
+
+1. Three distinct verified bundles resolve through three independent P6-R calls
+   and run in one core process/host revision, each as its workspace default.
+2. Three exact hostnames serve distinct bounded landings; hostname alone grants
+   no data or workspace authority.
+3. Existing-member auth reaches only the configured workspace; non-members and
+   cross-binding selectors fail before effects; generic-host behavior remains.
+4. Apply N+1 adds a fourth binding while an admitted request on binding 1
+   completes and reconnects in the same process; retained binding identities
+   are byte-identical and no Compose service restarts.
+5. Binding replacement, admitted-binding removal, and secret/runtime/root
+   rotation reject before effects with stable restart/admission codes. Compose
+   uses no force-recreate or blanket rollback.
+6. Rollback creates N+2 from a prior COMPLETE full snapshot, removes only the
+   unadmitted fourth binding with exact confirmation, reproduces the prior
+   desired/composition/P6-R digests, and records fresh observations. A
+   maintenance-window full runtime rollback is documented, not claimed online.
+7. Stale CAS, duplicate bindings, root overlap, proxy confusion, unavailable
+   secret, unsatisfied definition requirement, partial readiness, and active
+   binding replacement/removal fail with their stable codes.
+8. No secret value/raw host path appears in git, JSON snapshots, Compose
+   rendering, logs, errors, or audit. Workspace and session roots are durable
+   siblings, not container home/root.
+9. The shared runtime profile proves sibling filesystem and process denial.
+   D1-001 through D1-005 do not wait for a provider lock, but D1-006 cannot
+   claim the EU production exit until one host-approved EU profile supplies
+   the required real lifecycle/security evidence. The real runsc structural
+   preflight passed; the privileged execution decision and remaining security
+   proofs still block the runsc production lock unless another approved EU
+   profile satisfies the same proof.
+10. The golden path records wall-clock setup-to-first-agent success and stages;
+    the 15-minute figure remains a measured target, not an assertion.
+
+## 10. Non-goals and stop signs
+
+Stop and re-review if implementation adds a per-agent container, provisioning
+service, registry daemon, watcher, queue, scheduler, retry framework, secrets
+backend, Kubernetes/Terraform layer, wildcard host/tenant API, app management
+route, cross-host fleet control, or P6 generation store. D2 owns runtime tenant
+lifecycle/control-plane work. P2 owns later provider extraction. P5a receives a
+narrow follow-up only if a real D1 secret/readiness gap remains after D1-001.

--- a/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/HANDOFF.md
+++ b/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/HANDOFF.md
@@ -6,8 +6,10 @@
 
 - [ ] P6-D + A1 compile are complete.
 - [ ] P1 lifecycle/readiness and stateless P6-R are complete.
-- [ ] D1-R0 produced accepted, dispatchable micro-beads with exact files,
-      stable errors, proof, rollback, and review budgets.
+- [ ] [`D1-R0-SPEC.md`](./D1-R0-SPEC.md) is accepted; dispatch uses D1-001
+      through D1-006 and not the historical dedicated/runsc beads.
+- [ ] One ingress plus one stable full-collection core process is implemented;
+      it performs N independent P6-R calls and agents are not containers.
 - [ ] D1-R0 identified the current composer inputs and specified a canonical
       redacted workspace-composition identity/digest producer; the host no
       longer supplies an unverifiable arbitrary digest.
@@ -19,9 +21,19 @@
 
 ### Active proof
 
-- [ ] One command plans/applies one Docker host with at least two exact-host
+- [ ] One command plans/applies one Docker host with at least three exact-host
       bindings, distinct deployed agents, managed workspaces/defaults, and
       durable workspace/session roots.
+- [ ] Applying additive N+1 leaves retained bindings byte-identical while an
+      in-flight request and reconnect complete in the same process. Active
+      binding replacement/removal and runtime-input rotation fail before effects.
+- [ ] The root-owned pending-pointer/signal preload verifies every candidate
+      binding and returns all-ready before the active pointer changes; app HTTP
+      credentials cannot trigger candidate activation.
+- [ ] Compose uses one file, idempotent `up -d`, service-specific `--no-deps`,
+      an external database ref, per-binding env plus external tmpfs secret
+      inputs, and never `--force-recreate` or blanket old-file rollback.
+      Additive publication does not invoke Compose.
 - [ ] Existing-member auth and membership are the only workspace authority;
       landing content grants none.
 - [ ] On a bound hostname, existing workspace list/create/switch/delete and
@@ -38,7 +50,8 @@
 - [ ] Canonical trusted-proxy/Host parsing and uniqueness reject duplicate or
       ambiguous hostname/workspace/deployment/default bindings and overlapping
       workspace/session roots before effects.
-- [ ] An isolated runtime profile proves sibling-root/process denial. Trusted-
+- [ ] A host-resolved immutable runtime-profile ref/content/attestation digest
+      proves sibling-root/process denial; plan input cannot self-assert it. Trusted-
       direct is allowed only for local development or a single-workspace
       dedicated composition; it is never valid for the shared N-workspace
       host, regardless of operator trust. Otherwise apply fails or uses
@@ -62,20 +75,25 @@
       exact ids against the current revision; CAS alone is not preservation.
 - [ ] Fresh observed readiness/secret status gates publication but is not part
       of desired digest, rollback identity, or P6-R input.
-- [ ] After collection values change, rollback rematerializes every prior
-      binding, matches the prior host snapshot/digest, and reproduces every
-      P6-R digest without a P6 generation registry.
+- [ ] Online rollback removes only an added binding with no durable admission
+      row, matches the prior host snapshot/digest, and reproduces every P6-R
+      digest without a P6 generation registry. Other runtime rollback is an
+      explicit maintenance stop/reapply, never an online continuity claim.
+- [ ] The external database stores the insert/read-only admission ledger; its
+      transaction commits before first agent effect, survives process/revision
+      cleanup, and is reloaded before destructive diff or restart recovery.
 - [ ] DNS/TLS publication occurs only after workspace/default-agent/runtime/
       secret readiness; partial state is not externally reachable.
 - [ ] Proof records setup-to-first-run time and stage breakdown against the
-      provisional 15-minute target, plus both hostnames, definition/deployment
+      provisional 15-minute target, plus all three hostnames, definition/deployment
       digests, workspace/default bindings, reapply, collection mutation/full
       restoration, rollback digests, selector denials, and secret canary.
 
 ### Exit
 
-- [ ] Two exact hosts -> landing -> existing-member sign-in -> distinct managed
-      workspaces -> their deployed `default` agents succeed in one EU Docker host.
+- [ ] Three exact hosts -> landing -> existing-member sign-in -> distinct
+      managed workspaces -> their deployed `default` agents succeed in one EU
+      Docker host.
 - [ ] Reapply, rollback, cross-binding denial, shared-host sibling isolation,
       and no-secret proofs pass. The dedicated-VM variant has a documented
       configuration render but does not require a second live host.

--- a/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/PLAN.md
+++ b/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/PLAN.md
@@ -1,9 +1,9 @@
 # D1-tenant-provisioning — Plan
 
-Status: priority-1/v1 multi-agent Docker delivery gate; **needs-spec after
-P6-R**. Only D1-R0 in `TODO.md` is dispatchable until it produces accepted
-micro-beads. The active contract below supersedes the historical dedicated-site
-design.
+Status: priority-1/v1 multi-agent Docker delivery gate; **D1-R0 spec accepted,
+merge pending**. After merge, dispatch only the ordered micro-beads in
+[`D1-R0-SPEC.md`](./D1-R0-SPEC.md) and `TODO.md`. The active contract and R0
+spec supersede the historical dedicated-site design.
 
 ## Active owner-reframed v1 plan (2026-07-11)
 
@@ -30,6 +30,15 @@ apply/redeploy and rollback. D1 adds no wildcard router, runtime tenant CRUD or
 list API, hot tenant lifecycle, cross-tenant administration, billing, or fleet
 control plane. Those are D2/S3 concerns. Adding or changing a binding requires
 a new apply, not an in-process control-plane mutation.
+
+Container granularity is settled by D1-R0: one ingress fronts the current one
+core-app process, which hosts the entire N-binding collection and calls P6-R
+once per binding; agents are not per-container. Because current request leases
+cannot prove disconnected producer completion, the first slice publishes only
+additive/landing-only revisions in that stable process and rejects active
+binding replacement/removal or runtime-input rotation before effects. See
+[`D1-R0-SPEC.md`](./D1-R0-SPEC.md) for the immutable revision, rollback, Compose,
+and session-continuity contracts.
 
 Host mutation is operator-only. V1 exposes no application HTTP management
 endpoint for plan/apply/publish/rollback. A local deployment CLI running with

--- a/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/TODO.md
+++ b/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/TODO.md
@@ -2,39 +2,42 @@
 
 ## Active multi-agent Docker v1 work order (2026-07-11)
 
-**Dispatch state: needs-spec after P6-R.** The numbered outcomes below are not
-implementation beads. Dispatch only D1-R0, then replace them with exact
-implementation beads before code work begins.
+**Dispatch state: D1-R0 spec accepted, merge pending.** After merge, the exact
+implementation beads in [`D1-R0-SPEC.md`](./D1-R0-SPEC.md) are dispatchable in
+order. Never dispatch the historical section below.
 
 ### D1-R0 — Host collection tracer and micro-plan (spec, S)
 
-- Inspect the actual post-P6-R host composition and identify exact files/owners;
-  do not create a parallel host or provisioning framework.
-- Trace two compiled bundles through two independent P6-R calls into one
-  boot-time Docker configuration, two exact-host landings, and two authorized
-  workspace/default bindings using current seams.
-- Inventory the real composer inputs and specify the smallest canonical,
-  redacted workspace-composition identity/digest producer. Current code has no
-  such producer; until this closes, P6-R's composition digest is only a host
-  attestation and D1 cannot claim reproducible apply/rollback.
-- Specify stable errors and public proof for canonical trusted-proxy/Host
-  parsing; duplicate hostname/workspace/deployment/default; overlapping roots;
-  stale revision/apply/rollback; unapproved runtime profile; cross-binding
-  selector and sibling-root/process access; partial publication; and secrets.
-- Identify the existing workspace list/create/switch/delete and default-
-  workspace auto-provision seams. Specify the exact bound-host fence so only a
-  member can see the configured workspace and no user action can create,
-  switch to, or delete a sibling/unbound workspace.
-- Fix host mutation at an OS-authorized local deployment CLI: no application
-  management endpoint. Specify operator audit identity and ordinary-member/
-  bearer/hostname-holder denial proof for plan/apply/publish/rollback.
-- Split implementation into PRs with exact files, <=25 minute review budgets,
-  rollback, and CI proof. Lock `expectedHostRevision`, atomic active-collection
-  publication, rollback-as-new-revision, desired digest vs observed readiness,
-  destructive-diff confirmation, and the operator-trusted/direct vs isolated-
-  profile boundary.
-- Acceptance: an adversarial plan review can dispatch each resulting bead
-  without consulting the historical dedicated/runsc section below.
+- [ ] Accept [`D1-R0-SPEC.md`](./D1-R0-SPEC.md).
+- [ ] Confirm the stable one-process N-binding composition preserves in-flight
+      work by allowing only additive/landing-only online revisions and rejecting
+      active binding replacement/removal.
+- [ ] Confirm agents are not per-container and no P2/runsc or P5a gate remains.
+- [ ] Confirm D1-001 through D1-006 name exact files, stable errors, proof,
+      rollback behavior, <=400-line PR budgets, and current-code owners.
+
+### Active implementation order after D1-R0 acceptance
+
+1. **D1-001 — plan and canonical composition identity.** Strict host plan,
+   trustworthy final inventories, redacted canonical digest, requirement
+   refusal, independent P6-R inputs. No mutation or routing.
+2. **D1-002 — revision store and OS-local CLI.** Lock/CAS, immutable candidate
+   and COMPLETE records, atomic pointer, exact destructive confirmation,
+   rollback-as-new-revision. No app management API.
+3. **D1-003 — one stable-process Compose file.** Ingress, one full-collection
+   core process, external `databaseRef`, per-binding env plus external tmpfs
+   secret mounts, durable roots, maintenance-only service-specific `--no-deps`,
+   and no force-recreate.
+4. **D1-004a/b/c/d — host surface, authority fences, and admission.** Trusted
+   exact-host landing grants nothing; member-only bound workspace and all
+   selectors fail closed; the database admission row commits before first
+   agent effect and survives process/revision cleanup.
+5. **D1-005 — N-binding boot/additive publication.** N independent P6-R calls,
+   root-owned pending-pointer/signal preload, all-ready ack, atomic active
+   pointer, stable-process continuity, and fail-closed active replacement/removal.
+6. **D1-006 — runbook and EU proof.** Three agents/workspaces/hostnames, timing,
+   idempotence, N+1 continuity, rollback reproduction, isolation and secret
+   canary. Dedicated VM is configuration render only.
 
 ### Prerequisites — stop if false
 
@@ -46,14 +49,16 @@ implementation beads before code work begins.
 - P1 lifecycle/readiness and stateless P6-R exist.
 - The Docker host uses the existing approved workspace/runtime composition;
   P2 provider extraction and runsc validation are not prerequisites.
-- The shared N-workspace host has an existing production-approved profile that
-  proves sibling filesystem and process denial. Trusted-direct is only a local
+- The shared N-workspace host resolves an immutable production-approved
+  `runtimeProfileRef` and verifies its content/attestation digest proving sibling
+  filesystem and process denial. The plan cannot self-assert this fact.
+  Trusted-direct is only a local
   development or single-workspace dedicated composition; it cannot satisfy
   this shared-host prerequisite regardless of operator trust.
 - P5a is optional until D1-R0 demonstrates a missing host-readiness or secret-
   reference seam; D1 owns apply, digest, and rollback.
 
-### Required D1 outcomes for D1-R0 to slice
+### Required D1 outcomes locked by D1-R0
 
 1. Define one redacted Docker-host plan/apply input containing a collection of
    site bindings. Each binding carries bundle/deployment refs, exact hostname,
@@ -77,7 +82,7 @@ implementation beads before code work begins.
    over the full site-binding collection. Never persist secret values.
    Rollback rematerializes the prior collection and reproduces every P6-R
    digest. Do not create a P6 generation store.
-6. Prove at least two agents/workspaces/hostnames in one deployment, including
+6. Prove at least three agents/workspaces/hostnames in one deployment, including
    sibling filesystem/process denial, cross-binding selector denial,
    setup-to-first-run timing, changed collection values, complete rollback,
    and secret canary. Document dedicated VM as a second composition of the


### PR DESCRIPTION
## Summary

- accept D1-R0 as the binding multi-agent Docker host contract
- keep one stable core process with N logical bindings and N independent P6-R calls
- publish additive/landing-only revisions atomically and roll back as a new immutable revision
- lock Compose, root allocation, secret, admission-ledger, trusted-host, and workspace-authority contracts
- split delivery into D1-001 through D1-006 with exact proof and review budgets

## Key decision

Agents are not per-container. One ingress fronts one stable `core-app` process. D1-S1 rejects active runtime/root/composition/secret replacement online because current lifecycle leases cannot prove disconnected accepted producers have retired.

## Evidence consumed

- `IMPLEMENTATION-GUARDRAILS.md`
- `SPIKE-EVIDENCE-2026-07-11.md`, including the successful real `preflightRunsc` run
- `GTM-STRATEGY.md`
- Compose spike rules: per-binding env, idempotent `up -d`, no `--force-recreate`, service-specific `--no-deps`

## Proof

- adversarial architecture review: revised for stable-process continuity, fail-closed requirements, proxy trust, and immutable rollback
- final delegated review: revised for durable external-DB admission storage and unambiguous root-policy/allocation semantics; clean on re-review
- `git diff --check origin/main...HEAD`
- docs-only diff confined to `docs/issues/391/runtime-refactor/`

## State

`ready-for-human`

First blocker: `merge`. D1-001 dispatches after this contract merges. The runsc production lock remains open for the privileged execution-model decision and remaining lifecycle/security proofs; it does not gate D1-001 through D1-005.