### PR TITLE
feat(workspace): multi-root filesystem support in Files tree

### DIFF
--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -71,6 +71,51 @@ do not set `lazy: true`.
 | `@hachej/boring-workspace/app/server` | Node | App composition: `createWorkspaceAgentServer` |
 | `@hachej/boring-workspace/globals.css` | Browser | Global CSS for the workspace chrome |
 
+## Files panel: multi-root filesystems
+
+The built-in `FileTreePane` shows a single filesystem root by default (today's
+behavior — no dropdown, no extra chrome). Host apps that expose additional
+governed filesystems (e.g. a shared `company_context`) can pass a `roots` list;
+the panel then renders a **dropdown** at the top to switch the active filesystem
+and shows one root's tree at a time.
+
+```tsx
+import { FileTreePane, type FileTreeRootConfig } from "@hachej/boring-workspace"
+
+const roots: FileTreeRootConfig[] = [
+  { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+  { filesystem: "company_context", label: "Company", rootDir: "/", access: "readonly" },
+]
+
+<FileTreePane roots={roots} />
+```
+
+`FileTreeRootConfig`:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `filesystem` | yes | Filesystem id threaded to the file routes (`?filesystem=…`). `"user"` is the default workspace root. |
+| `label` | yes | Text shown in the switcher dropdown. |
+| `rootDir` | no | Root directory for the tree (defaults to `.` for `user`, `/` otherwise). |
+| `access` | no | `"readonly"` hides all mutating affordances (new/rename/delete/drag) for that root; defaults to `"readwrite"`. |
+| `searchPlaceholder` | no | Per-root placeholder for the search input. |
+
+Notes:
+
+- **Additive & backward-compatible.** Omitting `roots` (or passing a single
+  entry) preserves the exact single-root UI — the switcher is hidden.
+- **Governance-agnostic.** The workspace package never imports governance. The
+  host supplies the roots list — a governed app (e.g. via
+  `boring-governance` bindings or a tenant `…/governance/usage` response) maps
+  its per-user filesystem access into `FileTreeRootConfig[]`.
+- **Isolated errors.** A `403`/`404` on one root renders an inline "Failed to
+  load files" state inside the pane while the dropdown stays usable to switch
+  to another root — it never blanks the whole panel.
+
+See the multi-filesystem playground fixture in
+`apps/workspace-playground/src/front/App.tsx` (guarded by
+`VITE_PLAYGROUND_MULTI_FS=1`) for a working consumer.
+
 ## Documentation
 
 See [`docs/README.md`](./docs/README.md) for the architecture overview, key

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -211,6 +211,8 @@ export {
 } from "./plugins/filesystemPlugin/front/file-tree/FileTreeView"
 export type {
   FileTreePaneProps,
+  FileTreePaneParams,
+  FileTreeRootConfig,
   FileTreeViewProps,
 } from "./plugins/filesystemPlugin/front/file-tree/FileTreeView"
 export { MarkdownEditorPane } from "./plugins/filesystemPlugin/front/markdown-editor/MarkdownEditorPane"

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -54,6 +54,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@hachej/boring-ui-kit"
 import { cn } from "../../../../front/lib/utils"
 import { toast } from "../../../../front/toast"
@@ -1072,13 +1077,25 @@ export function FileTreePane({
       <div className="flex h-full flex-col">
         <div className="space-y-1.5 border-b border-border px-2 py-1.5">
           {rootOptions.length > 1 && (
-            <div className="grid gap-1 rounded-md bg-muted/45 p-0.5" style={{ gridTemplateColumns: `repeat(${rootOptions.length}, minmax(0, 1fr))` }} role="tablist" aria-label="File roots">
-              {rootOptions.map((root) => (
-                <Button key={root.filesystem} type="button" role="tab" aria-selected={activeFilesystem === root.filesystem} variant={activeFilesystem === root.filesystem ? "secondary" : "ghost"} size="sm" className="h-6 text-xs" onClick={() => setSelectedFilesystem(root.filesystem)}>
-                  {root.label}
-                </Button>
-              ))}
-            </div>
+            <Select
+              value={activeFilesystem}
+              onValueChange={(value) => setSelectedFilesystem(value as FilesystemId)}
+            >
+              <SelectTrigger
+                size="sm"
+                className="h-7 w-full text-xs"
+                aria-label="File root"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {rootOptions.map((root) => (
+                  <SelectItem key={root.filesystem} value={root.filesystem} className="text-xs">
+                    {root.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           )}
           <Input
             placeholder={activeRoot?.searchPlaceholder ?? "Search files..."}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest"
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type React from "react"
 import { Toaster, clearToasts } from "../../../../../front/toast"
@@ -179,7 +180,21 @@ function wrapper({ children }: { children: React.ReactNode }) {
 const originalInnerWidth = window.innerWidth
 const originalInnerHeight = window.innerHeight
 
+// Radix Select drives its trigger through pointer-capture + scrollIntoView,
+// neither of which jsdom implements. Stub them so the root switcher opens.
 beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => undefined
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => undefined
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => undefined
+  }
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
     writable: true,
@@ -191,6 +206,13 @@ beforeAll(() => {
     value: 420,
   })
 })
+
+/** Open the file-root dropdown and pick a root by its visible label. */
+async function selectRoot(label: string): Promise<void> {
+  const user = userEvent.setup()
+  await user.click(screen.getByRole("combobox", { name: "File root" }))
+  await user.click(await screen.findByRole("option", { name: label }))
+}
 
 afterAll(() => {
   Object.defineProperty(window, "innerWidth", {
@@ -272,8 +294,8 @@ describe("FileTreePane", () => {
       ]}
     />, { wrapper })
 
-    expect(await screen.findByRole("tab", { name: "Workspace" })).toBeInTheDocument()
-    fireEvent.click(screen.getByRole("tab", { name: "Project" }))
+    expect(await screen.findByRole("combobox", { name: "File root" })).toBeInTheDocument()
+    await selectRoot("Project")
 
     await waitFor(() => expect(screen.getByText("handbook.md")).toBeInTheDocument())
     fireEvent.click(screen.getByText("handbook.md"))
@@ -311,7 +333,7 @@ describe("FileTreePane", () => {
     fireEvent.click(screen.getByTestId("trigger-expand-src"))
     await waitFor(() => expect(screen.getByText("user-only.ts")).toBeInTheDocument())
 
-    fireEvent.click(screen.getByRole("tab", { name: "Project" }))
+    await selectRoot("Project")
     await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
     expect(screen.queryByText("user-only.ts")).not.toBeInTheDocument()
     fireEvent.click(screen.getByTestId("trigger-expand-src"))
@@ -329,8 +351,36 @@ describe("FileTreePane", () => {
     render(<FileTreePane />, { wrapper })
 
     await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
-    expect(screen.queryByRole("tab", { name: "Workspace" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("tab", { name: "Project" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("combobox", { name: "File root" })).not.toBeInTheDocument()
+  })
+
+  it("isolates a load failure to the selected root and recovers on switch", async () => {
+    mockFileList.mockImplementation((_dir: string, filesystem?: string) => (
+      filesystem === "project_alpha"
+        ? { data: undefined, isLoading: false, error: new Error("Forbidden") }
+        : { data: sampleFiles, isLoading: false, error: undefined }
+    ))
+
+    render(<FileTreePane
+      roots={[
+        { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+        { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readonly" },
+      ]}
+    />, { wrapper })
+
+    // Healthy default root renders its tree.
+    await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+    // Switching to the failing root shows an inline error, not a blank pane,
+    // and the switcher stays available to move away.
+    await selectRoot("Project")
+    await waitFor(() => expect(screen.getByText(/Failed to load files/)).toBeInTheDocument())
+    expect(screen.getByRole("combobox", { name: "File root" })).toBeInTheDocument()
+
+    // Switching back to the healthy root recovers the tree.
+    await selectRoot("Workspace")
+    await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+    expect(screen.queryByText(/Failed to load files/)).not.toBeInTheDocument()
   })
 
   it("hides .boring-agent from the default tree view", async () => {


### PR DESCRIPTION
## Summary

Adds a **host-supplied, governance-agnostic multi-root switcher** to the workspace Files tree so host apps can surface additional governed filesystems (e.g. a shared `company_context`) alongside the user's workspace root.

Per the owner's UX decision, the switcher is a **dropdown** at the top of the Files panel (kit `Select`), not a tab strip. The tree shows one filesystem at a time. When only one root is configured (the default), the dropdown is hidden entirely, preserving today's exact single-root appearance.

> Note: the server seam (`?filesystem=` on the file/tree routes) and the front `roots`/`FileTreeRootConfig` plumbing already landed on `main` via the earlier `company-fs` epic — this PR converts the existing tab-strip UI to the requested dropdown, exports the config type, and fills the docs/test gaps.

## API shape

`FileTreePane` accepts an optional, additive `roots` prop:

```ts
interface FileTreeRootConfig {
  filesystem: FilesystemId          // threaded to routes as ?filesystem=…; "user" = workspace root
  label: string                     // shown in the dropdown
  rootDir?: string                  // default "." for user, "/" otherwise
  access?: "readonly" | "readwrite" // readonly hides all mutating affordances
  searchPlaceholder?: string
}

<FileTreePane roots={roots} />
```

`FileTreeRootConfig` and `FileTreePaneParams` are now exported from `@hachej/boring-workspace`.

## Where roots come from

The workspace package never imports governance. The **host** maps its per-user filesystem access into `FileTreeRootConfig[]` — e.g. a governed app derives it from `boring-governance` bindings or a tenant `…/governance/usage` response. Default (no `roots`) = today's single-root tree, zero behavior change.

## Behavior

- **Dropdown switcher**, hidden when `rootOptions.length <= 1`.
- **Read-only roots** keep hiding new/rename/delete/drag affordances (existing `canMutate`).
- **Isolated errors**: a 403/404 on the selected root renders an inline "Failed to load files" state while the dropdown stays usable to switch away — never blanks the panel.

## Files touched (workspace only)

- `packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx` — tab strip → `Select` dropdown.
- `packages/workspace/src/index.ts` — export `FileTreeRootConfig`, `FileTreePaneParams`.
- `packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx` — drive the Radix dropdown; new per-root error-isolation + recovery test.
- `packages/workspace/README.md` — document the `roots` option.

## Consumption proof

`apps/workspace-playground/src/front/App.tsx` already wires a two-root multi-filesystem source (`user` + `company_context`) behind `VITE_PLAYGROUND_MULTI_FS=1`, exercising the dropdown live.

## Gates

- workspace typecheck ✓ · plugin-invariants ✓ (414 files) · full test suite ✓ (1693 passed) · build ✓ (19 artifacts)
- playground typecheck ✓ · full-app typecheck ✓ · full-app tests ✓ (37 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)