### PR TITLE
feat(391-D1): add plan and composition identity

### DIFF
--- a/apps/full-app/src/server/__tests__/boringMcp.test.ts
+++ b/apps/full-app/src/server/__tests__/boringMcp.test.ts
@@ -29,7 +29,7 @@ import {
   readFullAppBoringMcpServerConfig,
   registerFullAppBoringMcpRoutes,
 } from '../boringMcp'
-import { createFullAppServerPluginComposition } from '../plugins'
+import { serverPlugins } from '../plugins'
 import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
 
 const actor: McpActor = { workspaceId: 'workspace-1', userId: 'user-1' }
@@ -168,7 +168,8 @@ function evaluateTestBoringMcpLaunchGate() {
 describe('full-app boring-mcp binding', () => {
   it('registers the boring-mcp server plugin in app composition', () => {
     expect(boringMcpServerPlugins.map((plugin) => plugin.id)).toContain(BORING_MCP_PLUGIN_ID)
-    expect(createFullAppServerPluginComposition().plugins.map((plugin) => plugin.id)).toContain(BORING_MCP_PLUGIN_ID)
+    expect(serverPlugins.map((plugin) => plugin.id)).toContain(BORING_MCP_PLUGIN_ID)
+    expect(Object.isFrozen(serverPlugins)).toBe(true)
   })
 
   it('uses a pure server plugin factory for enabled/disabled config', () => {

--- a/apps/full-app/src/server/__tests__/boringMcp.test.ts
+++ b/apps/full-app/src/server/__tests__/boringMcp.test.ts
@@ -29,7 +29,7 @@ import {
   readFullAppBoringMcpServerConfig,
   registerFullAppBoringMcpRoutes,
 } from '../boringMcp'
-import { serverPlugins } from '../plugins'
+import { createFullAppServerPluginComposition } from '../plugins'
 import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
 
 const actor: McpActor = { workspaceId: 'workspace-1', userId: 'user-1' }
@@ -168,7 +168,7 @@ function evaluateTestBoringMcpLaunchGate() {
 describe('full-app boring-mcp binding', () => {
   it('registers the boring-mcp server plugin in app composition', () => {
     expect(boringMcpServerPlugins.map((plugin) => plugin.id)).toContain(BORING_MCP_PLUGIN_ID)
-    expect(serverPlugins.map((plugin) => plugin.id)).toContain(BORING_MCP_PLUGIN_ID)
+    expect(createFullAppServerPluginComposition().plugins.map((plugin) => plugin.id)).toContain(BORING_MCP_PLUGIN_ID)
   })
 
   it('uses a pure server plugin factory for enabled/disabled config', () => {

--- a/apps/full-app/src/server/deployment/__tests__/d1Plan.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Plan.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import { D1HostErrorCode, parseD1HostPlan } from '../d1Plan.js'
+
+const digest = `sha256:${'a'.repeat(64)}`
+
+function binding(id: string, overrides: Record<string, unknown> = {}) {
+  return {
+    bindingId: id,
+    hostname: `${id}.example.test`,
+    workspaceId: `workspace-${id}`,
+    defaultDeploymentId: `deployment-${id}`,
+    bundleRef: `bundle-${id}`,
+    deploymentRef: `deployment-ref-${id}`,
+    workspaceAllocationRef: `workspace-allocation-${id}`,
+    sessionAllocationRef: `session-allocation-${id}`,
+    ownerPrincipalRef: `owner-${id}`,
+    landing: { title: `Agent ${id}`, summary: 'A bounded landing.' },
+    environmentRef: `environment-${id}`,
+    secretRefs: [`secret-${id}-z`, `secret-${id}-a`],
+    ...overrides,
+  }
+}
+
+function plan(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    hostId: 'eu-host-1',
+    expectedHostRevision: null,
+    hostAppImageDigest: digest,
+    runtimeProfileRef: 'runsc-eu-1',
+    databaseRef: 'postgres-eu-1',
+    workspaceRootPolicyRef: 'workspace-roots-eu-1',
+    sessionRootPolicyRef: 'session-roots-eu-1',
+    bindings: [binding('z'), binding('a')],
+    ...overrides,
+  }
+}
+
+describe('parseD1HostPlan', () => {
+  it('strictly validates and freezes a canonical lexical plan', () => {
+    const parsed = parseD1HostPlan(plan({ bindings: [
+      binding('z'),
+      binding('a', { workspaceId: 'espace:éclair', defaultDeploymentId: 'assurance:eu' }),
+    ] }))
+
+    expect(parsed.bindings.map((entry) => entry.bindingId)).toEqual(['a', 'z'])
+    expect(parsed.bindings[0].secretRefs).toEqual(['secret-a-a', 'secret-a-z'])
+    expect(parsed.bindings[0]).toMatchObject({ workspaceId: 'espace:éclair', defaultDeploymentId: 'assurance:eu' })
+    expect(Object.isFrozen(parsed)).toBe(true)
+    expect(Object.isFrozen(parsed.bindings)).toBe(true)
+    expect(Object.isFrozen(parsed.bindings[0].landing)).toBe(true)
+  })
+
+  it.each([
+    ['raw path ref', plan({ databaseRef: '/srv/postgres' }), 'databaseRef'],
+    ['URL ref', plan({ runtimeProfileRef: 'https://profiles.test/runsc' }), 'runtimeProfileRef'],
+    ['environment assignment', plan({ databaseRef: 'TOKEN=value' }), 'databaseRef'],
+    ['unknown secret field', { ...plan(), databasePassword: 'do-not-echo' }, 'databasePassword'],
+    ['duplicate workspace', plan({ bindings: [binding('a'), binding('b', { workspaceId: 'workspace-a' })] }), 'bindings.workspaceId'],
+  ])('rejects %s without echoing input', (_name, input, field) => {
+    try {
+      parseD1HostPlan(input)
+      throw new Error('expected plan rejection')
+    } catch (error) {
+      expect(error).toMatchObject({ code: D1HostErrorCode.PLAN_INVALID, details: { field } })
+      expect(JSON.stringify(error)).not.toContain('do-not-echo')
+      expect(JSON.stringify(error)).not.toContain('/srv/postgres')
+    }
+  })
+})

--- a/apps/full-app/src/server/deployment/__tests__/workspaceComposition.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/workspaceComposition.test.ts
@@ -1,0 +1,268 @@
+import {
+  createAgentAssetDigest,
+  createAgentDefinitionDigest,
+  type AgentDefinition,
+  type AgentDeployment,
+  type CompiledAgentBundle,
+  type Sha256Digest,
+} from '@hachej/boring-agent/shared'
+import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { beforeAll, describe, expect, it } from 'vitest'
+
+import { D1HostErrorCode, parseD1HostPlan } from '../d1Plan.js'
+import {
+  createFullAppServerPluginComposition,
+  FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR,
+  FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS,
+  FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR,
+} from '../../plugins.js'
+import {
+  createWorkspaceCompositionSnapshot,
+  resolveWorkspaceAgentDeployment,
+  type StableContributionDescriptor,
+  type WorkspaceCompositionInputV1,
+} from '../workspaceComposition.js'
+
+const hashes = {
+  app: `sha256:${'a'.repeat(64)}` as Sha256Digest,
+  profile: `sha256:${'b'.repeat(64)}` as Sha256Digest,
+  attestation: `sha256:${'c'.repeat(64)}` as Sha256Digest,
+  prompt: `sha256:${'d'.repeat(64)}` as Sha256Digest,
+  pluginA: `sha256:${'e'.repeat(64)}` as Sha256Digest,
+  pluginB: `sha256:${'f'.repeat(64)}` as Sha256Digest,
+}
+
+const definition: AgentDefinition = {
+  schemaVersion: 1,
+  definitionId: 'assurance-éclair',
+  version: '1.0.0',
+  instructionsRef: 'instructions.md',
+  capabilityRequirements: ['filesystem:read'],
+  toolRefs: ['quotes.compare'],
+}
+
+let compiledBundle: CompiledAgentBundle
+const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim()
+
+function descriptor(id: string, contentDigest: Sha256Digest): StableContributionDescriptor {
+  return { id, version: '1.0.0', contentDigest }
+}
+
+function input(workspaceId = 'workspace-a'): WorkspaceCompositionInputV1 {
+  return {
+    workspaceId,
+    bundle: compiledBundle,
+    runtimeProfile: {
+      ref: 'runsc-eu',
+      id: 'runsc',
+      version: '2026.07.11',
+      contentDigest: hashes.profile,
+      isolationAttestationDigest: hashes.attestation,
+      workspaceRootPolicyRef: 'workspace-roots-eu',
+      sessionRootPolicyRef: 'session-roots-eu',
+    },
+    hostAppImageDigest: hashes.app,
+    serverPlugins: [descriptor('plugin-b', hashes.pluginB), descriptor('plugin-a', hashes.pluginA)],
+    defaultPluginPackages: [descriptor('automation', hashes.pluginA)],
+    staticSystemPromptDigest: hashes.prompt,
+    inventories: {
+      capabilities: ['filesystem:write', 'filesystem:read'],
+      tools: ['quotes.compare'],
+      skills: null,
+      mcpServers: null,
+    },
+    provisioning: [descriptor('python-runtime', hashes.pluginB)],
+    filesystemBindings: [
+      { id: 'user', access: 'readwrite', policy: 'workspace-only' },
+      { id: 'company-context', access: 'readonly', policy: 'policy-filtered' },
+    ],
+    externalPlugins: false,
+    pluginAuthoring: false,
+  }
+}
+
+async function bundle(sourceDefinition: AgentDefinition = definition): Promise<CompiledAgentBundle> {
+  const asset = Object.freeze({
+    path: 'instructions.md',
+    content: 'Compare policies.',
+    digest: await createAgentAssetDigest('Compare policies.'),
+  })
+  const compiledDefinition = Object.freeze({
+    ...sourceDefinition,
+    capabilityRequirements: Object.freeze([...sourceDefinition.capabilityRequirements ?? []]),
+    toolRefs: Object.freeze([...sourceDefinition.toolRefs ?? []]),
+  })
+  return Object.freeze({
+    definition: compiledDefinition,
+    assets: Object.freeze([asset]),
+    definitionDigest: await createAgentDefinitionDigest({ definition: compiledDefinition, assets: [asset] }),
+  })
+}
+
+function sourceDigest(manifest: readonly string[]): Sha256Digest {
+  const files = execFileSync('git', ['ls-files', '--', ...manifest], { cwd: repoRoot, encoding: 'utf8' })
+    .trim().split('\n').filter(Boolean).sort()
+  const blobDigests = files.map((file) =>
+    createHash('sha256').update(readFileSync(path.join(repoRoot, file))).digest('hex'))
+  return `sha256:${createHash('sha256').update(`${blobDigests.join('\n')}\n`).digest('hex')}`
+}
+
+function parsedResolverBinding(defaultDeploymentId: string) {
+  return parseD1HostPlan({
+    schemaVersion: 1,
+    hostId: 'eu-host-1',
+    expectedHostRevision: null,
+    hostAppImageDigest: hashes.app,
+    runtimeProfileRef: 'runsc-eu',
+    databaseRef: 'postgres-eu',
+    workspaceRootPolicyRef: 'workspace-roots-eu',
+    sessionRootPolicyRef: 'session-roots-eu',
+    bindings: [{
+      bindingId: 'insurance', hostname: 'insurance.example.test',
+      workspaceId: 'espace:éclair', defaultDeploymentId,
+      bundleRef: 'insurance-bundle', deploymentRef: 'insurance-deployment',
+      workspaceAllocationRef: 'workspace-allocation', sessionAllocationRef: 'session-allocation',
+      ownerPrincipalRef: 'owner', environmentRef: 'production', secretRefs: [],
+      landing: { title: 'Insurance', summary: 'Compare policies.' },
+    }],
+  }).bindings[0]
+}
+
+describe('createWorkspaceCompositionSnapshot', () => {
+  beforeAll(async () => {
+    compiledBundle = await bundle()
+  })
+
+  it('couples live contribution ids to their descriptors', () => {
+    const composition = createFullAppServerPluginComposition()
+    expect(composition.plugins.map((plugin) => plugin.id))
+      .toEqual(composition.descriptors.map((descriptor) => descriptor.id))
+  })
+
+  it('keeps contribution descriptors fresh against owned tracked sources', () => {
+    expect(sourceDigest(['apps/full-app/src/server/boringMcp.ts', 'plugins/boring-mcp/src']))
+      .toBe(FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR.contentDigest)
+    expect(sourceDigest(['plugins/boring-governance/src']))
+      .toBe(FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR.contentDigest)
+    expect(sourceDigest(['plugins/boring-automation/src']))
+      .toBe(FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS[0].contentDigest)
+    expect(JSON.parse(readFileSync(path.join(repoRoot, 'plugins/boring-mcp/package.json'), 'utf8')).version)
+      .toBe(FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR.version)
+    expect(JSON.parse(readFileSync(path.join(repoRoot, 'plugins/boring-governance/package.json'), 'utf8')).version)
+      .toBe(FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR.version)
+    expect(JSON.parse(readFileSync(path.join(repoRoot, 'plugins/boring-automation/package.json'), 'utf8')).version)
+      .toBe(FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS[0].version)
+  })
+
+  it('is order-stable, deeply frozen, canonical, and redacted', async () => {
+    const firstInput = input()
+    const reversedBase = input()
+    const reversed: WorkspaceCompositionInputV1 = {
+      ...reversedBase,
+      serverPlugins: [...reversedBase.serverPlugins].reverse(),
+      inventories: {
+        ...reversedBase.inventories,
+        capabilities: [...reversedBase.inventories.capabilities!].reverse(),
+      },
+      filesystemBindings: [...reversedBase.filesystemBindings].reverse(),
+    }
+
+    const first = await createWorkspaceCompositionSnapshot(firstInput)
+    const second = await createWorkspaceCompositionSnapshot(reversed)
+
+    expect(second).toEqual(first)
+    expect(first.digest).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(Object.isFrozen(first.snapshot)).toBe(true)
+    expect(Object.isFrozen(first.snapshot.runtimeProfile)).toBe(true)
+    expect(Object.isFrozen(first.snapshot.serverPlugins[0])).toBe(true)
+    const serialized = JSON.stringify(first.snapshot)
+    expect(serialized).not.toMatch(/\/srv\/|secret|prompt text/i)
+  })
+
+  it('changes the digest when trusted composition identity changes', async () => {
+    const first = await createWorkspaceCompositionSnapshot(input())
+    const changedInput: WorkspaceCompositionInputV1 = {
+      ...input(),
+      serverPlugins: [descriptor('plugin-a', hashes.pluginB), descriptor('plugin-b', hashes.pluginB)],
+    }
+    const changed = await createWorkspaceCompositionSnapshot(changedInput)
+    const sameCompositionOtherDefinition = await createWorkspaceCompositionSnapshot({
+      ...input(),
+      bundle: await bundle({ ...definition, definitionId: 'other:agent' }),
+    })
+
+    expect(changed.digest).not.toBe(first.digest)
+    expect(sameCompositionOtherDefinition.digest).toBe(first.digest)
+  })
+
+  it.each([
+    ['unavailable', null],
+    ['available but missing', []],
+  ])('fails closed when a required capability is %s', async (_name, capabilities) => {
+    const candidate: WorkspaceCompositionInputV1 = {
+      ...input(),
+      inventories: { ...input().inventories, capabilities },
+    }
+    await expect(createWorkspaceCompositionSnapshot(candidate)).rejects.toMatchObject({
+      code: D1HostErrorCode.REQUIREMENT_UNSATISFIED,
+      details: {
+        definitionId: 'assurance-éclair',
+        field: 'capabilityRequirements',
+        ref: 'filesystem:read',
+      },
+    })
+  })
+
+  it('rejects duplicate inventory ids and undescribed path-bearing fields', async () => {
+    const duplicate: WorkspaceCompositionInputV1 = {
+      ...input(),
+      inventories: { ...input().inventories, tools: ['quotes.compare', 'quotes.compare'] },
+    }
+    await expect(createWorkspaceCompositionSnapshot(duplicate)).rejects.toMatchObject({
+      code: D1HostErrorCode.PLAN_INVALID,
+      details: { field: 'inventories.tools' },
+    })
+
+    const extra = { ...input(), sourcePath: '/srv/private/composition' } as WorkspaceCompositionInputV1
+    await expect(createWorkspaceCompositionSnapshot(extra)).rejects.toMatchObject({
+      code: D1HostErrorCode.PLAN_INVALID,
+      details: { field: 'composition.sourcePath' },
+    })
+    await expect(createWorkspaceCompositionSnapshot({ ...input(), bundle: null } as unknown as WorkspaceCompositionInputV1))
+      .rejects.toMatchObject({ code: D1HostErrorCode.PLAN_INVALID, details: { field: 'bundle' } })
+  })
+
+  it('produces independent exact P6-R binding inputs for two workspaces', async () => {
+    const compiled = compiledBundle
+    const deployment: AgentDeployment = {
+      deploymentId: 'insurance:eu',
+      version: '2026.07.12',
+      agentId: 'default',
+      definition: {
+        definitionId: compiled.definition.definitionId,
+        version: compiled.definition.version,
+        digest: compiled.definitionDigest,
+      },
+    }
+    const planned = parsedResolverBinding(deployment.deploymentId)
+    const firstIdentity = await createWorkspaceCompositionSnapshot(input(planned.workspaceId))
+    const secondIdentity = await createWorkspaceCompositionSnapshot(input('workspace-b'))
+    const first = await resolveWorkspaceAgentDeployment(firstIdentity, compiled, deployment, planned.defaultDeploymentId)
+    const second = await resolveWorkspaceAgentDeployment(secondIdentity, compiled, deployment, deployment.deploymentId)
+
+    expect(first.workspace.workspaceId).toBe('espace:éclair')
+    expect(second.workspace.workspaceId).toBe('workspace-b')
+    expect(first.workspace.compositionDigest).not.toBe(second.workspace.compositionDigest)
+    expect(first.resolvedDigest).not.toBe(second.resolvedDigest)
+    const otherBundle = await bundle({ ...definition, definitionId: 'other:agent' })
+    expect(() => resolveWorkspaceAgentDeployment(firstIdentity, otherBundle, deployment, planned.defaultDeploymentId))
+      .toThrow(expect.objectContaining({ code: D1HostErrorCode.PLAN_INVALID }))
+    expect(() => resolveWorkspaceAgentDeployment({
+      snapshot: firstIdentity.snapshot,
+      digest: hashes.app,
+    }, compiled, deployment, planned.defaultDeploymentId)).toThrow(expect.objectContaining({ code: D1HostErrorCode.PLAN_INVALID }))
+  })
+})

--- a/apps/full-app/src/server/deployment/d1Plan.ts
+++ b/apps/full-app/src/server/deployment/d1Plan.ts
@@ -1,0 +1,157 @@
+import { OpaqueRefSchema, type Sha256Digest } from '@hachej/boring-agent/shared'
+
+export const D1HostErrorCode = {
+  PLAN_INVALID: 'D1_PLAN_INVALID',
+  REQUIREMENT_UNSATISFIED: 'AGENT_COMPOSITION_REQUIREMENT_UNSATISFIED',
+} as const
+
+export type D1HostErrorCode = typeof D1HostErrorCode[keyof typeof D1HostErrorCode]
+
+export class D1HostError extends Error {
+  readonly details: Readonly<Record<string, string>>
+
+  constructor(readonly code: D1HostErrorCode, details: Record<string, string>) {
+    super(code)
+    this.name = 'D1HostError'
+    this.details = Object.freeze({ ...details })
+  }
+}
+
+export interface D1SiteBindingV1 {
+  readonly bindingId: string
+  readonly hostname: string
+  readonly workspaceId: string
+  readonly defaultDeploymentId: string
+  readonly bundleRef: string
+  readonly deploymentRef: string
+  readonly workspaceAllocationRef: string
+  readonly sessionAllocationRef: string
+  readonly ownerPrincipalRef: string
+  readonly landing: Readonly<{ title: string; summary: string; ctaLabel?: string }>
+  readonly environmentRef: string
+  readonly secretRefs: readonly string[]
+}
+
+export interface D1HostPlanV1 {
+  readonly schemaVersion: 1
+  readonly hostId: string
+  readonly expectedHostRevision: string | null
+  readonly hostAppImageDigest: Sha256Digest
+  readonly runtimeProfileRef: string
+  readonly databaseRef: string
+  readonly workspaceRootPolicyRef: string
+  readonly sessionRootPolicyRef: string
+  readonly bindings: readonly D1SiteBindingV1[]
+}
+
+const PLAN_KEYS = ['schemaVersion', 'hostId', 'expectedHostRevision', 'hostAppImageDigest', 'runtimeProfileRef', 'databaseRef', 'workspaceRootPolicyRef', 'sessionRootPolicyRef', 'bindings'] as const
+const BINDING_KEYS = ['bindingId', 'hostname', 'workspaceId', 'defaultDeploymentId', 'bundleRef', 'deploymentRef', 'workspaceAllocationRef', 'sessionAllocationRef', 'ownerPrincipalRef', 'landing', 'environmentRef', 'secretRefs'] as const
+const LANDING_KEYS = ['title', 'summary', 'ctaLabel'] as const
+const REF_RE = /^[A-Za-z0-9][A-Za-z0-9._@-]{0,255}$/
+const DIGEST_RE = /^sha256:[a-f0-9]{64}$/
+const HOST_RE = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+
+export function invalidD1Field(field: string): never {
+  throw new D1HostError(D1HostErrorCode.PLAN_INVALID, { field })
+}
+
+export function assertD1Record(value: unknown, field: string): asserts value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) invalidD1Field(field)
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) invalidD1Field(field)
+}
+
+export function assertD1ExactKeys(value: unknown, keys: readonly string[], field: string, optional: readonly string[] = []): asserts value is Record<string, unknown> {
+  assertD1Record(value, field)
+  const allowed = new Set(keys)
+  const unexpected = Object.keys(value).find((key) => !allowed.has(key))
+  if (unexpected) invalidD1Field(field ? `${field}.${unexpected}` : unexpected)
+  const missing = keys.find((key) => !optional.includes(key) && !Object.hasOwn(value, key))
+  if (missing) invalidD1Field(field ? `${field}.${missing}` : missing)
+}
+
+export function strictD1Ref(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !REF_RE.test(value)) invalidD1Field(field)
+  return value
+}
+
+function agentRef(value: unknown, field: string): string {
+  const parsed = OpaqueRefSchema.safeParse(value)
+  if (!parsed.success) invalidD1Field(field)
+  return parsed.data
+}
+
+export function d1Digest(value: unknown, field: string): Sha256Digest {
+  if (typeof value !== 'string' || !DIGEST_RE.test(value)) invalidD1Field(field)
+  return value as Sha256Digest
+}
+
+function text(value: unknown, field: string, max: number): string {
+  if (typeof value !== 'string' || value.length === 0 || value.length > max || /[\0-\x1f\x7f]/.test(value)) invalidD1Field(field)
+  return value
+}
+
+function unique(values: readonly string[], field: string): void {
+  if (new Set(values).size !== values.length) invalidD1Field(field)
+}
+
+function parseBinding(value: unknown, index: number): D1SiteBindingV1 {
+  const field = `bindings[${index}]`
+  assertD1ExactKeys(value, BINDING_KEYS, field)
+  const input = value
+  assertD1ExactKeys(input.landing, LANDING_KEYS, `${field}.landing`, ['ctaLabel'])
+  const landing = input.landing
+  if (!Array.isArray(input.secretRefs)) invalidD1Field(`${field}.secretRefs`)
+  const secretRefs = input.secretRefs.map((value, secretIndex) => strictD1Ref(value, `${field}.secretRefs[${secretIndex}]`)).sort()
+  unique(secretRefs, `${field}.secretRefs`)
+  if (typeof input.hostname !== 'string' || !HOST_RE.test(input.hostname)) invalidD1Field(`${field}.hostname`)
+
+  return Object.freeze({
+    bindingId: strictD1Ref(input.bindingId, `${field}.bindingId`),
+    hostname: input.hostname,
+    workspaceId: agentRef(input.workspaceId, `${field}.workspaceId`),
+    defaultDeploymentId: agentRef(input.defaultDeploymentId, `${field}.defaultDeploymentId`),
+    bundleRef: strictD1Ref(input.bundleRef, `${field}.bundleRef`),
+    deploymentRef: strictD1Ref(input.deploymentRef, `${field}.deploymentRef`),
+    workspaceAllocationRef: strictD1Ref(input.workspaceAllocationRef, `${field}.workspaceAllocationRef`),
+    sessionAllocationRef: strictD1Ref(input.sessionAllocationRef, `${field}.sessionAllocationRef`),
+    ownerPrincipalRef: strictD1Ref(input.ownerPrincipalRef, `${field}.ownerPrincipalRef`),
+    landing: Object.freeze({
+      title: text(landing.title, `${field}.landing.title`, 120),
+      summary: text(landing.summary, `${field}.landing.summary`, 500),
+      ...(landing.ctaLabel === undefined ? {} : { ctaLabel: text(landing.ctaLabel, `${field}.landing.ctaLabel`, 80) }),
+    }),
+    environmentRef: strictD1Ref(input.environmentRef, `${field}.environmentRef`),
+    secretRefs: Object.freeze(secretRefs),
+  })
+}
+
+export function parseD1HostPlan(raw: unknown): D1HostPlanV1 {
+  assertD1ExactKeys(raw, PLAN_KEYS, '')
+  const input = raw
+  if (input.schemaVersion !== 1) invalidD1Field('schemaVersion')
+  if (input.expectedHostRevision !== null) strictD1Ref(input.expectedHostRevision, 'expectedHostRevision')
+  const hostAppImageDigest = d1Digest(input.hostAppImageDigest, 'hostAppImageDigest')
+  if (!Array.isArray(input.bindings) || input.bindings.length === 0) invalidD1Field('bindings')
+  const bindings = input.bindings.map(parseBinding).sort((left, right) => left.bindingId < right.bindingId ? -1 : left.bindingId > right.bindingId ? 1 : 0)
+  for (const [field, values] of [
+    ['bindings.bindingId', bindings.map((binding) => binding.bindingId)],
+    ['bindings.hostname', bindings.map((binding) => binding.hostname)],
+    ['bindings.workspaceId', bindings.map((binding) => binding.workspaceId)],
+    ['bindings.defaultDeploymentId', bindings.map((binding) => binding.defaultDeploymentId)],
+    ['bindings.workspaceAllocationRef', bindings.map((binding) => binding.workspaceAllocationRef)],
+    ['bindings.sessionAllocationRef', bindings.map((binding) => binding.sessionAllocationRef)],
+  ] as const) unique(values, field)
+
+  return Object.freeze({
+    schemaVersion: 1,
+    hostId: strictD1Ref(input.hostId, 'hostId'),
+    expectedHostRevision: input.expectedHostRevision as string | null,
+    hostAppImageDigest,
+    runtimeProfileRef: strictD1Ref(input.runtimeProfileRef, 'runtimeProfileRef'),
+    databaseRef: strictD1Ref(input.databaseRef, 'databaseRef'),
+    workspaceRootPolicyRef: strictD1Ref(input.workspaceRootPolicyRef, 'workspaceRootPolicyRef'),
+    sessionRootPolicyRef: strictD1Ref(input.sessionRootPolicyRef, 'sessionRootPolicyRef'),
+    bindings: Object.freeze(bindings),
+  })
+}

--- a/apps/full-app/src/server/deployment/workspaceComposition.ts
+++ b/apps/full-app/src/server/deployment/workspaceComposition.ts
@@ -1,0 +1,227 @@
+import {
+  createAgentAssetDigest,
+  createAgentDefinitionDigest,
+  OpaqueRefSchema,
+  type AgentDeployment,
+  type CompiledAgentBundle,
+  type Sha256Digest,
+} from '@hachej/boring-agent/shared'
+import { resolveAgentDeployment, type ResolvedAgent } from '@hachej/boring-agent/server'
+
+import {
+  assertD1ExactKeys as exactKeys,
+  assertD1Record as assertRecord,
+  d1Digest as checkedDigest,
+  D1HostError,
+  D1HostErrorCode,
+  invalidD1Field as fail,
+  strictD1Ref as checkedRef,
+} from './d1Plan.js'
+
+export interface StableContributionDescriptor {
+  readonly id: string
+  readonly version: string
+  readonly contentDigest: Sha256Digest
+}
+
+export interface WorkspaceCompositionInputV1 {
+  readonly workspaceId: string
+  readonly bundle: CompiledAgentBundle
+  readonly runtimeProfile: Readonly<{
+    ref: string
+    id: string
+    version: string
+    contentDigest: Sha256Digest
+    isolationAttestationDigest: Sha256Digest
+    workspaceRootPolicyRef: string
+    sessionRootPolicyRef: string
+  }>
+  readonly hostAppImageDigest: Sha256Digest
+  readonly serverPlugins: readonly StableContributionDescriptor[]
+  readonly defaultPluginPackages: readonly StableContributionDescriptor[]
+  readonly staticSystemPromptDigest: Sha256Digest
+  readonly inventories: Readonly<{
+    capabilities: readonly string[] | null
+    tools: readonly string[] | null
+    skills: readonly string[] | null
+    mcpServers: readonly string[] | null
+  }>
+  readonly provisioning: readonly StableContributionDescriptor[]
+  readonly filesystemBindings: readonly Readonly<{ id: string; access: string; policy: string }>[]
+  readonly externalPlugins: boolean
+  readonly pluginAuthoring: boolean
+}
+
+export interface WorkspaceCompositionSnapshotV1 {
+  readonly schemaVersion: 1
+  readonly domain: 'boring-workspace-composition:v1'
+  readonly workspaceId: string
+  readonly runtimeProfile: WorkspaceCompositionInputV1['runtimeProfile']
+  readonly hostAppImageDigest: Sha256Digest
+  readonly serverPlugins: readonly StableContributionDescriptor[]
+  readonly defaultPluginPackages: readonly StableContributionDescriptor[]
+  readonly staticSystemPromptDigest: Sha256Digest
+  readonly inventories: WorkspaceCompositionInputV1['inventories']
+  readonly provisioning: readonly StableContributionDescriptor[]
+  readonly filesystemBindings: WorkspaceCompositionInputV1['filesystemBindings']
+  readonly policies: Readonly<{ externalPlugins: boolean; pluginAuthoring: boolean }>
+}
+
+export interface WorkspaceCompositionIdentityV1 {
+  readonly snapshot: WorkspaceCompositionSnapshotV1
+  readonly digest: Sha256Digest
+}
+
+type BundleDefinitionIdentity = Readonly<{ definitionId: string; version: string; digest: Sha256Digest }>
+const issuedCompositionIdentities = new WeakMap<WorkspaceCompositionIdentityV1, BundleDefinitionIdentity>()
+
+const INPUT_KEYS = ['workspaceId', 'bundle', 'runtimeProfile', 'hostAppImageDigest', 'serverPlugins', 'defaultPluginPackages', 'staticSystemPromptDigest', 'inventories', 'provisioning', 'filesystemBindings', 'externalPlugins', 'pluginAuthoring'] as const
+const PROFILE_KEYS = ['ref', 'id', 'version', 'contentDigest', 'isolationAttestationDigest', 'workspaceRootPolicyRef', 'sessionRootPolicyRef'] as const
+const INVENTORY_KEYS = ['capabilities', 'tools', 'skills', 'mcpServers'] as const
+
+function compareId(left: { id: string }, right: { id: string }): number {
+  return left.id < right.id ? -1 : left.id > right.id ? 1 : 0
+}
+
+function opaqueRef(value: unknown, field: string): string {
+  const parsed = OpaqueRefSchema.safeParse(value)
+  if (!parsed.success) fail(field)
+  return parsed.data
+}
+
+function sortedUnique(values: unknown, field: string): readonly string[] {
+  if (!Array.isArray(values)) fail(field)
+  const sorted = [...values].map((value, index) => opaqueRef(value, `${field}[${index}]`)).sort()
+  if (new Set(sorted).size !== sorted.length) fail(field)
+  return Object.freeze(sorted)
+}
+
+function descriptors(values: readonly StableContributionDescriptor[], field: string): readonly StableContributionDescriptor[] {
+  if (!Array.isArray(values)) fail(field)
+  const sorted = values.map((value, index) => {
+    exactKeys(value, ['id', 'version', 'contentDigest'], `${field}[${index}]`)
+    return Object.freeze({
+      id: checkedRef(value.id, `${field}[${index}].id`),
+      version: checkedRef(value.version, `${field}[${index}].version`),
+      contentDigest: checkedDigest(value.contentDigest, `${field}[${index}].contentDigest`),
+    })
+  }).sort(compareId)
+  if (new Set(sorted.map((value) => value.id)).size !== sorted.length) fail(field)
+  return Object.freeze(sorted)
+}
+
+function inventory(values: readonly string[] | null, field: string): readonly string[] | null {
+  return values === null ? null : sortedUnique(values, field)
+}
+
+function verifyRequirements(
+  bundle: CompiledAgentBundle,
+  inventories: WorkspaceCompositionSnapshotV1['inventories'],
+): void {
+  const definition = bundle.definition
+  const definitionId = opaqueRef(definition.definitionId, 'bundle.definition.definitionId')
+  for (const [field, required, available] of [
+    ['capabilityRequirements', definition.capabilityRequirements, inventories.capabilities],
+    ['toolRefs', definition.toolRefs, inventories.tools],
+    ['skillRefs', definition.skillRefs, inventories.skills],
+    ['mcpServerRefs', definition.mcpServerRefs, inventories.mcpServers],
+  ] as const) {
+    if (required !== undefined && !Array.isArray(required)) fail(`bundle.definition.${field}`)
+    for (const [index, rawRef] of (required ?? []).entries()) {
+      const ref = opaqueRef(rawRef, `bundle.definition.${field}[${index}]`)
+      if (available === null || !available.includes(ref)) {
+        throw new D1HostError(D1HostErrorCode.REQUIREMENT_UNSATISFIED, {
+          definitionId,
+          field,
+          ref,
+        })
+      }
+    }
+  }
+}
+
+export async function createWorkspaceCompositionSnapshot(
+  input: WorkspaceCompositionInputV1,
+): Promise<WorkspaceCompositionIdentityV1> {
+  exactKeys(input, INPUT_KEYS, 'composition')
+  exactKeys(input.bundle, ['definition', 'definitionDigest', 'assets'], 'bundle')
+  assertRecord(input.bundle.definition, 'bundle.definition')
+  exactKeys(input.runtimeProfile, PROFILE_KEYS, 'runtimeProfile')
+  exactKeys(input.inventories, INVENTORY_KEYS, 'inventories')
+  if (!Array.isArray(input.filesystemBindings)) fail('filesystemBindings')
+  if (typeof input.externalPlugins !== 'boolean') fail('externalPlugins')
+  if (typeof input.pluginAuthoring !== 'boolean') fail('pluginAuthoring')
+  const definitionDigest = await createAgentDefinitionDigest({
+    definition: input.bundle.definition,
+    assets: input.bundle.assets,
+  }).catch(() => fail('bundle'))
+  if (definitionDigest !== input.bundle.definitionDigest) fail('bundle.definitionDigest')
+  const inventories = Object.freeze({
+    capabilities: inventory(input.inventories.capabilities, 'inventories.capabilities'),
+    tools: inventory(input.inventories.tools, 'inventories.tools'),
+    skills: inventory(input.inventories.skills, 'inventories.skills'),
+    mcpServers: inventory(input.inventories.mcpServers, 'inventories.mcpServers'),
+  })
+  verifyRequirements(input.bundle, inventories)
+  const filesystemBindings = input.filesystemBindings.map((binding, index) => {
+    exactKeys(binding, ['id', 'access', 'policy'], `filesystemBindings[${index}]`)
+    return Object.freeze({
+      id: checkedRef(binding.id, `filesystemBindings[${index}].id`),
+      access: checkedRef(binding.access, `filesystemBindings[${index}].access`),
+      policy: checkedRef(binding.policy, `filesystemBindings[${index}].policy`),
+    })
+  }).sort(compareId)
+  if (new Set(filesystemBindings.map((binding) => binding.id)).size !== filesystemBindings.length) fail('filesystemBindings')
+
+  const snapshot: WorkspaceCompositionSnapshotV1 = Object.freeze({
+    schemaVersion: 1,
+    domain: 'boring-workspace-composition:v1',
+    workspaceId: opaqueRef(input.workspaceId, 'workspaceId'),
+    runtimeProfile: Object.freeze({
+      ref: checkedRef(input.runtimeProfile.ref, 'runtimeProfile.ref'),
+      id: checkedRef(input.runtimeProfile.id, 'runtimeProfile.id'),
+      version: checkedRef(input.runtimeProfile.version, 'runtimeProfile.version'),
+      contentDigest: checkedDigest(input.runtimeProfile.contentDigest, 'runtimeProfile.contentDigest'),
+      isolationAttestationDigest: checkedDigest(input.runtimeProfile.isolationAttestationDigest, 'runtimeProfile.isolationAttestationDigest'),
+      workspaceRootPolicyRef: checkedRef(input.runtimeProfile.workspaceRootPolicyRef, 'runtimeProfile.workspaceRootPolicyRef'),
+      sessionRootPolicyRef: checkedRef(input.runtimeProfile.sessionRootPolicyRef, 'runtimeProfile.sessionRootPolicyRef'),
+    }),
+    hostAppImageDigest: checkedDigest(input.hostAppImageDigest, 'hostAppImageDigest'),
+    serverPlugins: descriptors(input.serverPlugins, 'serverPlugins'),
+    defaultPluginPackages: descriptors(input.defaultPluginPackages, 'defaultPluginPackages'),
+    staticSystemPromptDigest: checkedDigest(input.staticSystemPromptDigest, 'staticSystemPromptDigest'),
+    inventories,
+    provisioning: descriptors(input.provisioning, 'provisioning'),
+    filesystemBindings: Object.freeze(filesystemBindings),
+    policies: Object.freeze({ externalPlugins: input.externalPlugins, pluginAuthoring: input.pluginAuthoring }),
+  })
+  const identity = Object.freeze({ snapshot, digest: await createAgentAssetDigest(JSON.stringify(snapshot)) })
+  issuedCompositionIdentities.set(identity, Object.freeze({
+    definitionId: opaqueRef(input.bundle.definition.definitionId, 'bundle.definition.definitionId'),
+    version: opaqueRef(input.bundle.definition.version, 'bundle.definition.version'),
+    digest: definitionDigest,
+  }))
+  return identity
+}
+
+export function resolveWorkspaceAgentDeployment(
+  identity: WorkspaceCompositionIdentityV1,
+  bundle: CompiledAgentBundle,
+  deployment: AgentDeployment,
+  configuredDefaultDeploymentId: string,
+): Promise<ResolvedAgent> {
+  const issuedDefinition = issuedCompositionIdentities.get(identity)
+  if (!issuedDefinition) fail('workspaceCompositionIdentity')
+  exactKeys(bundle, ['definition', 'definitionDigest', 'assets'], 'bundle')
+  assertRecord(bundle.definition, 'bundle.definition')
+  if (
+    bundle.definition.definitionId !== issuedDefinition.definitionId ||
+    bundle.definition.version !== issuedDefinition.version ||
+    bundle.definitionDigest !== issuedDefinition.digest
+  ) fail('bundle.definition')
+  return resolveAgentDeployment(bundle, deployment, {
+    workspaceId: identity.snapshot.workspaceId,
+    defaultDeploymentId: opaqueRef(configuredDefaultDeploymentId, 'defaultDeploymentId'),
+    workspaceCompositionDigest: identity.digest,
+  })
+}

--- a/apps/full-app/src/server/dev.ts
+++ b/apps/full-app/src/server/dev.ts
@@ -5,8 +5,9 @@ import {
   startCoreWorkspaceAgentDevServer,
 } from '@hachej/boring-core/app/server'
 import { loadConfig } from '@hachej/boring-core/server'
-import { createFullAppServerPlugins } from './plugins.js'
-import { createGovernance } from '@hachej/boring-governance/server'
+import {
+  createFullAppHostPluginComposition,
+} from './plugins.js'
 import { buildCreditsWiring } from './credits.js'
 import {
   createFullAppBoringMcpAgentToolsForRequest,
@@ -90,7 +91,7 @@ startCoreWorkspaceAgentDevServer({
       allowMissingSecrets: process.env.NODE_ENV !== 'production',
       tomlPath: path.resolve(appRoot, 'boring.app.toml'),
     })
-    const governance = await createGovernance(config)
+    const { governance, ...pluginComposition } = await createFullAppHostPluginComposition(config)
     const credits = buildCreditsWiring()
     let appDb: unknown
     let appRef: Awaited<ReturnType<typeof createCoreWorkspaceAgentServer>> | undefined
@@ -98,8 +99,8 @@ startCoreWorkspaceAgentDevServer({
     const app = await createCoreWorkspaceAgentServer({
       ...options,
       config,
-      plugins: createFullAppServerPlugins([governance.serverPlugin]),
-      defaultPluginPackages: ['@hachej/boring-automation'],
+      plugins: [...pluginComposition.plugins],
+      defaultPluginPackages: [...pluginComposition.defaultPluginPackages],
       externalPlugins: false,
       installPluginAuthoring: pluginAuthoringEnabledFromEnv(),
       metering: governance.createMeteringSink(credits.meteringSink, () => {

--- a/apps/full-app/src/server/main.ts
+++ b/apps/full-app/src/server/main.ts
@@ -3,9 +3,10 @@ import {
   appRootFromImportMeta,
   createCoreWorkspaceAgentServer,
 } from '@hachej/boring-core/app/server'
-import { createGovernance } from '@hachej/boring-governance/server'
 import { loadConfig } from '@hachej/boring-core/server'
-import { createFullAppServerPlugins } from './plugins.js'
+import {
+  createFullAppHostPluginComposition,
+} from './plugins.js'
 import { buildCreditsWiring } from './credits.js'
 import {
   createFullAppBoringMcpAgentToolsForRequest,
@@ -29,7 +30,7 @@ async function main() {
     allowMissingSecrets: process.env.NODE_ENV !== 'production',
     tomlPath: path.resolve(appRoot, 'boring.app.toml'),
   })
-  const governance = await createGovernance(config)
+  const { governance, ...pluginComposition } = await createFullAppHostPluginComposition(config)
   // Build the metering sink up-front; the credit service attaches after the
   // server (and its db) exists.
   const credits = buildCreditsWiring()
@@ -40,8 +41,8 @@ async function main() {
     appRoot,
     config,
     serveFrontend: true,
-    plugins: createFullAppServerPlugins([governance.serverPlugin]),
-    defaultPluginPackages: ['@hachej/boring-automation'],
+    plugins: [...pluginComposition.plugins],
+    defaultPluginPackages: [...pluginComposition.defaultPluginPackages],
     externalPlugins: false,
     installPluginAuthoring: pluginAuthoringEnabledFromEnv(),
     metering: governance.createMeteringSink(credits.meteringSink, () => {

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -67,6 +67,12 @@ export function createFullAppServerPluginComposition() {
   return composeServerPlugins(createBoringMcpContributions())
 }
 
+// Build tooling discovers static plugin assets through this named export.
+export const serverPlugins: CoreWorkspaceAgentServerPlugin[] = [
+  ...createFullAppServerPluginComposition().plugins,
+]
+Object.freeze(serverPlugins)
+
 export async function createFullAppHostPluginComposition(config: CoreConfig) {
   const governance = await createGovernance(config)
   const composition = composeServerPlugins([

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -1,11 +1,82 @@
 import type { CoreWorkspaceAgentServerPlugin } from '@hachej/boring-core/app/server'
+import type { CoreConfig } from '@hachej/boring-core/shared'
+import { createGovernance } from '@hachej/boring-governance/server'
 import { createFullAppBoringMcpServerPlugins } from './boringMcp.js'
+import {
+  D1HostError,
+  D1HostErrorCode,
+} from './deployment/d1Plan.js'
+import type { StableContributionDescriptor } from './deployment/workspaceComposition.js'
 
-export function createFullAppServerPlugins(extra: CoreWorkspaceAgentServerPlugin[] = []): CoreWorkspaceAgentServerPlugin[] {
-  return [
-    ...createFullAppBoringMcpServerPlugins(),
-    ...extra,
-  ]
+const FULL_APP_DEFAULT_PLUGIN_PACKAGE_COMPOSITION = Object.freeze([{
+  packageName: '@hachej/boring-automation',
+  descriptor: Object.freeze({
+    id: 'boring-automation',
+    version: '0.1.80',
+    contentDigest: 'sha256:7945996f13db2da138909c651755bf5daf950630096e9337dbd3611ea4fca854',
+  } satisfies StableContributionDescriptor),
+}])
+
+const FULL_APP_DEFAULT_PLUGIN_PACKAGES = Object.freeze(FULL_APP_DEFAULT_PLUGIN_PACKAGE_COMPOSITION.map((entry) => entry.packageName))
+export const FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS = Object.freeze(FULL_APP_DEFAULT_PLUGIN_PACKAGE_COMPOSITION.map((entry) => entry.descriptor))
+
+export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
+  id: 'full-app-governance',
+  version: '0.1.80',
+  contentDigest: 'sha256:1320434bc428d5f7f987a555e274d48e35ba6127e2f9ea6f353af04b4b1f7ccf',
+} satisfies StableContributionDescriptor)
+
+export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({
+  id: 'boring-mcp',
+  version: '0.1.80',
+  contentDigest: 'sha256:a2dae3c8e2d785152c011829cab20884164cbda2552db33aa9fd9fcd87aace37',
+} satisfies StableContributionDescriptor)
+
+// Freshness test: lexical tracked files -> SHA-256(bytes) per file ->
+// SHA-256(each lowercase blob digest plus "\n"). Paths select files only.
+interface LiveServerPluginContribution {
+  readonly plugin: CoreWorkspaceAgentServerPlugin
+  readonly descriptor: StableContributionDescriptor
 }
 
-export const serverPlugins = createFullAppServerPlugins()
+function issueContribution(
+  plugin: CoreWorkspaceAgentServerPlugin,
+  descriptor: StableContributionDescriptor,
+): LiveServerPluginContribution {
+  if (plugin.id !== descriptor.id) {
+    throw new D1HostError(D1HostErrorCode.PLAN_INVALID, { field: 'serverPlugins.descriptor.id' })
+  }
+  return Object.freeze({ plugin, descriptor })
+}
+
+function createBoringMcpContributions(): LiveServerPluginContribution[] {
+  return createFullAppBoringMcpServerPlugins().map((plugin) =>
+    issueContribution(plugin, FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR))
+}
+
+function composeServerPlugins(
+  contributions: readonly LiveServerPluginContribution[],
+): Readonly<{ plugins: readonly CoreWorkspaceAgentServerPlugin[]; descriptors: readonly StableContributionDescriptor[] }> {
+  return Object.freeze({
+    plugins: Object.freeze(contributions.map((contribution) => contribution.plugin)),
+    descriptors: Object.freeze(contributions.map((contribution) => contribution.descriptor)),
+  })
+}
+
+export function createFullAppServerPluginComposition() {
+  return composeServerPlugins(createBoringMcpContributions())
+}
+
+export async function createFullAppHostPluginComposition(config: CoreConfig) {
+  const governance = await createGovernance(config)
+  const composition = composeServerPlugins([
+    ...createBoringMcpContributions(),
+    issueContribution(governance.serverPlugin, FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR),
+  ])
+  return Object.freeze({
+    governance,
+    ...composition,
+    defaultPluginPackages: FULL_APP_DEFAULT_PLUGIN_PACKAGES,
+    defaultPluginPackageDescriptors: FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS,
+  })
+}


### PR DESCRIPTION
## Summary

- add strict, canonical D1 host-plan parsing
- produce deep-frozen redacted workspace-composition snapshots and digests
- fail closed on unavailable or unsatisfied definition requirements
- bind requirement validation to the exact compiled bundle passed directly to P6-R
- expose full-app plugin/default-package contribution descriptors with deterministic source/version freshness proof

## Issue / Slice

#391 — D1-001 from the merged D1-R0 contract (#649). This slice is pure identity/validation work: no filesystem mutation, Compose, routing, CLI, or publication.

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/d1Plan.test.ts src/server/deployment/__tests__/workspaceComposition.test.ts src/server/__tests__/boringMcp.test.ts` — PASS, 3 files / 27 tests
- `pnpm --dir apps/full-app typecheck` — PASS
- `git diff --check origin/main...HEAD` — PASS

## Review

- standards/spec review: clean after fixing canonical ref compatibility, exact-bundle P6 coupling, and descriptor provenance
- thermo review: clean
- reviewed SHA: `e5d1031e9e725cdfb97c8ecb0f3a13e993db9498`

## Risk / Rollback

- opaque allocation refs remain identity-only here; resolved containment/overlap/symlink proof belongs to the later host adapter before effects
- production diff is +457 versus the 400-line review target; independent thermo review accepted the 57-line excess because it is the required provenance and exact-bundle trust boundary
- rollback is a normal revert; no persisted state or runtime behavior is activated by this slice

## Next

`ready-for-human`: merge D1-001, then dispatch D1-002 (immutable revision store and OS-local CLI).