### PR TITLE
feat(391-AC1): consumption contract types + lifecycle validators (types-only slice)

### DIFF
--- a/packages/agent/src/shared/__tests__/agent-consumption.test.ts
+++ b/packages/agent/src/shared/__tests__/agent-consumption.test.ts
@@ -58,12 +58,15 @@ function validTask(overrides: Partial<AgentTask> = {}): AgentTask {
 describe('task lifecycle transitions', () => {
   const LEGAL_PAIRS = new Set([
     'submitted->working',
+    'submitted->rejected',
+    'submitted->canceled',
     'working->input-required',
     'working->completed',
     'working->failed',
     'working->canceled',
     'working->rejected',
     'input-required->working',
+    'input-required->canceled',
   ])
 
   for (const from of TASK_STATES) {
@@ -91,9 +94,19 @@ describe('task lifecycle transitions', () => {
     }
   }
 
-  it('covers exactly the documented legal-pair count (7 legal edges over 49 pairs)', () => {
-    expect(LEGAL_PAIRS.size).toBe(7)
+  it('covers exactly the documented legal-pair count (10 legal edges over 49 pairs)', () => {
+    expect(LEGAL_PAIRS.size).toBe(10)
     expect(TASK_STATES.length).toBe(7)
+  })
+
+  it('permits intake-stage refusal/withdrawal before work starts (A2A v1.0)', () => {
+    expect(isValidTaskTransition('submitted', 'rejected')).toBe(true)
+    expect(isValidTaskTransition('submitted', 'canceled')).toBe(true)
+  })
+
+  it('permits input-required to settle into canceled (inputRequiredTimeoutMs outcome)', () => {
+    expect(isValidTaskTransition('input-required', 'canceled')).toBe(true)
+    expect(() => assertValidTransition('input-required', 'canceled')).not.toThrow()
   })
 
   it('treats every terminal state as final (no outgoing edges)', () => {

--- a/packages/agent/src/shared/__tests__/agent-consumption.test.ts
+++ b/packages/agent/src/shared/__tests__/agent-consumption.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AgentConsumptionValidationError,
+  AgentMessageSchema,
+  AgentRefSchema,
+  AgentTaskSchema,
+  ArtifactRefSchema,
+  ConsumptionGuardsSchema,
+  PartSchema,
+  PrincipalRefSchema,
+  TASK_STATES,
+  TaskStateSchema,
+  agentRefEquals,
+  assertNoConsumptionCycle,
+  assertValidTransition,
+  assertWithinConsumptionDepth,
+  detectConsumptionCycle,
+  isValidTaskTransition,
+  isWithinConsumptionDepth,
+  validateAgentTask,
+  validateConsumptionGuards,
+  type AgentRef,
+  type AgentTask,
+  type ConsumptionGuards,
+} from '../agent-consumption'
+import { AgentConsumptionErrorCode, ERROR_CODES } from '../error-codes'
+
+const AGENT_A: AgentRef = { agentId: 'agent-a', deploymentId: 'deploy-1' }
+const AGENT_B: AgentRef = { agentId: 'agent-b', deploymentId: 'deploy-1' }
+const AGENT_C: AgentRef = { agentId: 'agent-c' }
+
+function validTask(overrides: Partial<AgentTask> = {}): AgentTask {
+  return {
+    id: 'task-1',
+    contextId: 'ctx-1',
+    state: 'submitted',
+    messages: [
+      {
+        role: 'consumer',
+        parts: [{ type: 'text', text: 'hello' }],
+        ts: '2026-07-12T00:00:00.000Z',
+      },
+    ],
+    artifacts: [],
+    principal: { userId: 'user-1', workspaceId: 'workspace-1' },
+    schemaVersion: '1',
+    createdAt: '2026-07-12T00:00:00.000Z',
+    updatedAt: '2026-07-12T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Task lifecycle state machine — exhaustive over all 7x7 (from, to) pairs
+// ---------------------------------------------------------------------------
+
+describe('task lifecycle transitions', () => {
+  const LEGAL_PAIRS = new Set([
+    'submitted->working',
+    'working->input-required',
+    'working->completed',
+    'working->failed',
+    'working->canceled',
+    'working->rejected',
+    'input-required->working',
+  ])
+
+  for (const from of TASK_STATES) {
+    for (const to of TASK_STATES) {
+      const key = `${from}->${to}`
+      const legal = LEGAL_PAIRS.has(key)
+
+      it(`${legal ? 'allows' : 'refuses'} ${key}`, () => {
+        expect(isValidTaskTransition(from, to)).toBe(legal)
+        if (legal) {
+          expect(() => assertValidTransition(from, to)).not.toThrow()
+        } else {
+          expect(() => assertValidTransition(from, to)).toThrow(AgentConsumptionValidationError)
+          try {
+            assertValidTransition(from, to)
+            throw new Error('expected assertValidTransition to throw')
+          } catch (error) {
+            expect(error).toBeInstanceOf(AgentConsumptionValidationError)
+            expect((error as AgentConsumptionValidationError).validationCode).toBe(
+              AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_INVALID_TRANSITION,
+            )
+          }
+        }
+      })
+    }
+  }
+
+  it('covers exactly the documented legal-pair count (7 legal edges over 49 pairs)', () => {
+    expect(LEGAL_PAIRS.size).toBe(7)
+    expect(TASK_STATES.length).toBe(7)
+  })
+
+  it('treats every terminal state as final (no outgoing edges)', () => {
+    for (const terminal of ['completed', 'failed', 'canceled', 'rejected'] as const) {
+      for (const to of TASK_STATES) {
+        expect(isValidTaskTransition(terminal, to)).toBe(false)
+      }
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Cycle guard
+// ---------------------------------------------------------------------------
+
+describe('detectConsumptionCycle', () => {
+  it('reports no cycle for an empty chain', () => {
+    expect(detectConsumptionCycle([], AGENT_A)).toBe(false)
+  })
+
+  it('reports no cycle when next is a genuinely new agent', () => {
+    expect(detectConsumptionCycle([AGENT_A, AGENT_B], AGENT_C)).toBe(false)
+  })
+
+  it('detects an immediate self-loop (A -> A)', () => {
+    expect(detectConsumptionCycle([AGENT_A], AGENT_A)).toBe(true)
+  })
+
+  it('detects a same-pair oscillation (A -> B -> A)', () => {
+    expect(detectConsumptionCycle([AGENT_A, AGENT_B], AGENT_A)).toBe(true)
+  })
+
+  it('detects a same-pair oscillation the other direction (A -> B, next B)', () => {
+    expect(detectConsumptionCycle([AGENT_A, AGENT_B], AGENT_B)).toBe(true)
+  })
+
+  it('does not conflate two deployments of the same agentId', () => {
+    const otherDeployment: AgentRef = { agentId: 'agent-a', deploymentId: 'deploy-2' }
+    expect(detectConsumptionCycle([AGENT_A], otherDeployment)).toBe(false)
+    expect(agentRefEquals(AGENT_A, otherDeployment)).toBe(false)
+  })
+
+  it('treats two undefined deploymentIds as equal (agentId-only identity)', () => {
+    const first: AgentRef = { agentId: 'agent-x' }
+    const second: AgentRef = { agentId: 'agent-x' }
+    expect(agentRefEquals(first, second)).toBe(true)
+    expect(detectConsumptionCycle([first], second)).toBe(true)
+  })
+
+  it('assertNoConsumptionCycle throws with the stable cycle code, and passes through otherwise', () => {
+    expect(() => assertNoConsumptionCycle([AGENT_A, AGENT_B], AGENT_C)).not.toThrow()
+    try {
+      assertNoConsumptionCycle([AGENT_A, AGENT_B], AGENT_A)
+      throw new Error('expected assertNoConsumptionCycle to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentConsumptionValidationError)
+      expect((error as AgentConsumptionValidationError).validationCode).toBe(
+        AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_CYCLE_DETECTED,
+      )
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Depth guard
+// ---------------------------------------------------------------------------
+
+describe('consumption depth guard', () => {
+  const guards: ConsumptionGuards = { maxDepth: 2, inputRequiredTimeoutMs: 60_000 }
+
+  it('allows a hop while under the max depth', () => {
+    expect(isWithinConsumptionDepth([], guards)).toBe(true)
+    expect(isWithinConsumptionDepth([AGENT_A], guards)).toBe(true)
+    expect(() => assertWithinConsumptionDepth([AGENT_A], guards)).not.toThrow()
+  })
+
+  it('refuses a hop once the chain reaches max depth', () => {
+    expect(isWithinConsumptionDepth([AGENT_A, AGENT_B], guards)).toBe(false)
+    try {
+      assertWithinConsumptionDepth([AGENT_A, AGENT_B], guards)
+      throw new Error('expected assertWithinConsumptionDepth to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentConsumptionValidationError)
+      expect((error as AgentConsumptionValidationError).validationCode).toBe(
+        AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_DEPTH_EXCEEDED,
+      )
+    }
+  })
+
+  it('refuses a chain that has already exceeded max depth', () => {
+    expect(isWithinConsumptionDepth([AGENT_A, AGENT_B, AGENT_C], guards)).toBe(false)
+  })
+
+  it('validateConsumptionGuards accepts a well-formed config and rejects a malformed one', () => {
+    expect(validateConsumptionGuards({ maxDepth: 3, inputRequiredTimeoutMs: 86_400_000 })).toEqual({
+      valid: true,
+      value: { maxDepth: 3, inputRequiredTimeoutMs: 86_400_000 },
+    })
+
+    const invalid = validateConsumptionGuards({ maxDepth: 0, inputRequiredTimeoutMs: -1 })
+    expect(invalid.valid).toBe(false)
+    if (!invalid.valid) {
+      expect(invalid.issues.length).toBeGreaterThan(0)
+      for (const issue of invalid.issues) {
+        expect(issue.code).toBe(AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_SCHEMA_MISMATCH)
+      }
+    }
+  })
+
+  it('validateConsumptionGuards rejects extra/unknown fields (strict schema)', () => {
+    expect(validateConsumptionGuards({ maxDepth: 1, inputRequiredTimeoutMs: 1, extra: true }).valid).toBe(
+      false,
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Schema round-trips
+// ---------------------------------------------------------------------------
+
+describe('schema round-trips', () => {
+  it('TaskStateSchema parses every declared state and rejects unknowns', () => {
+    for (const state of TASK_STATES) {
+      expect(TaskStateSchema.parse(state)).toBe(state)
+    }
+    expect(TaskStateSchema.safeParse('done').success).toBe(false)
+    expect(TaskStateSchema.safeParse('SUBMITTED').success).toBe(false)
+  })
+
+  it('PrincipalRefSchema round-trips and rejects unknown fields', () => {
+    const ref = { userId: 'user-1', workspaceId: 'workspace-1' }
+    expect(PrincipalRefSchema.parse(ref)).toEqual(ref)
+    expect(PrincipalRefSchema.safeParse({ ...ref, extra: 1 }).success).toBe(false)
+    expect(PrincipalRefSchema.safeParse({ userId: 'user-1' }).success).toBe(false)
+  })
+
+  it('AgentRefSchema round-trips with and without deploymentId', () => {
+    expect(AgentRefSchema.parse(AGENT_A)).toEqual(AGENT_A)
+    expect(AgentRefSchema.parse(AGENT_C)).toEqual(AGENT_C)
+    expect(AgentRefSchema.safeParse({}).success).toBe(false)
+  })
+
+  it('ArtifactRefSchema round-trips', () => {
+    const artifact = { artifactId: 'artifact-1', mimeType: 'text/markdown', uri: 'artifact://artifact-1' }
+    expect(ArtifactRefSchema.parse(artifact)).toEqual(artifact)
+    expect(ArtifactRefSchema.safeParse({ ...artifact, mimeType: '' }).success).toBe(false)
+  })
+
+  it('PartSchema round-trips text, file, and data parts', () => {
+    const text = { type: 'text', text: 'hi' } as const
+    const file = {
+      type: 'file',
+      file: { artifactId: 'a1', mimeType: 'image/png', uri: 'artifact://a1' },
+    } as const
+    const data = { type: 'data', mimeType: 'application/json', data: { foo: 'bar' } } as const
+
+    expect(PartSchema.parse(text)).toEqual(text)
+    expect(PartSchema.parse(file)).toEqual(file)
+    expect(PartSchema.parse(data)).toEqual(data)
+    expect(PartSchema.safeParse({ type: 'unknown' }).success).toBe(false)
+  })
+
+  it('AgentMessageSchema round-trips', () => {
+    const message = {
+      role: 'agent' as const,
+      parts: [{ type: 'text' as const, text: 'ack' }],
+      ts: '2026-07-12T00:00:00.000Z',
+    }
+    expect(AgentMessageSchema.parse(message)).toEqual(message)
+    expect(AgentMessageSchema.safeParse({ ...message, role: 'system' }).success).toBe(false)
+  })
+
+  it('AgentTaskSchema round-trips a full valid task', () => {
+    const task = validTask()
+    expect(AgentTaskSchema.parse(task)).toEqual(task)
+    expect(validateAgentTask(task)).toEqual({ valid: true, value: task })
+  })
+
+  it('AgentTaskSchema round-trips with actor and artifacts populated', () => {
+    const task = validTask({
+      state: 'completed',
+      actor: AGENT_A,
+      artifacts: [{ artifactId: 'a1', mimeType: 'text/plain', uri: 'artifact://a1' }],
+    })
+    expect(AgentTaskSchema.parse(task)).toEqual(task)
+  })
+
+  it('requires schemaVersion and rejects any value other than the literal "1"', () => {
+    const { schemaVersion: _drop, ...withoutVersion } = validTask()
+    expect(AgentTaskSchema.safeParse(withoutVersion).success).toBe(false)
+
+    const withWrongVersion = { ...validTask(), schemaVersion: '2' }
+    expect(AgentTaskSchema.safeParse(withWrongVersion).success).toBe(false)
+
+    const withNumericVersion = { ...validTask(), schemaVersion: 1 }
+    expect(AgentTaskSchema.safeParse(withNumericVersion).success).toBe(false)
+  })
+
+  it('rejects unknown top-level fields (strict schema)', () => {
+    expect(AgentTaskSchema.safeParse({ ...validTask(), extra: true }).success).toBe(false)
+  })
+
+  it('validateAgentTask reports the stable schema-mismatch code on invalid input', () => {
+    const result = validateAgentTask({ ...validTask(), state: 'bogus-state' })
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.issues.length).toBeGreaterThan(0)
+      for (const issue of result.issues) {
+        expect(issue.code).toBe(AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_SCHEMA_MISMATCH)
+      }
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error-code registry hygiene
+// ---------------------------------------------------------------------------
+
+describe('AgentConsumptionErrorCode', () => {
+  it('is canonical but stays outside the public ERROR_CODES registry', () => {
+    expect(AgentConsumptionErrorCode.options).toEqual([
+      'AGENT_CONSUMPTION_INVALID_TRANSITION',
+      'AGENT_CONSUMPTION_CYCLE_DETECTED',
+      'AGENT_CONSUMPTION_DEPTH_EXCEEDED',
+      'AGENT_CONSUMPTION_SCHEMA_MISMATCH',
+    ])
+    for (const code of AgentConsumptionErrorCode.options) {
+      expect(ERROR_CODES).not.toContain(code)
+    }
+  })
+})

--- a/packages/agent/src/shared/agent-consumption.ts
+++ b/packages/agent/src/shared/agent-consumption.ts
@@ -40,15 +40,17 @@ export const TaskStateSchema = z.enum(TASK_STATES)
 
 /**
  * Legal task-state transitions. Mirrors A2A v1.0 task lifecycle semantics:
- * `submitted` starts work; `working` is the only state that can settle into
- * a terminal outcome or pause for input; `input-required` always resumes
- * back into `working`; every terminal state (`completed`/`failed`/
+ * `submitted` starts work, or is refused/withdrawn at intake (`rejected`/
+ * `canceled`) before work begins; `working` settles into a terminal outcome
+ * or pauses for input; `input-required` resumes into `working`, or is
+ * `canceled` — the outcome the `inputRequiredTimeoutMs` guard drives when
+ * the consumer never answers; every terminal state (`completed`/`failed`/
  * `canceled`/`rejected`) is final.
  */
 const TASK_TRANSITIONS: Readonly<Record<TaskState, readonly TaskState[]>> = {
-  submitted: ['working'],
+  submitted: ['working', 'rejected', 'canceled'],
   working: ['input-required', 'completed', 'failed', 'canceled', 'rejected'],
-  'input-required': ['working'],
+  'input-required': ['working', 'canceled'],
   completed: [],
   failed: [],
   canceled: [],

--- a/packages/agent/src/shared/agent-consumption.ts
+++ b/packages/agent/src/shared/agent-consumption.ts
@@ -1,0 +1,325 @@
+// Agent-consumption contract types (AC1, Decision 22, issue #636).
+//
+// Types + zod schemas + pure validators for the task lifecycle that lets one
+// agent be consumed by another (or by a human, via a binding). Semantics
+// deliberately mirror A2A v1.0 so a future A2A binding is a thin adapter —
+// see docs/DECISIONS.md #22 and
+// docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md (AC1
+// section) for the binding contract.
+//
+// Scope (binding, per the AC1 guardrail): types + validators ONLY. No
+// dispatcher, no persistence, no routes, no task queue/broker. Concrete
+// guard values (depth limit, input-required timeout) are NOT frozen here —
+// they are ratified in the AC1 consumer-backed spec; this module exposes a
+// configurable `ConsumptionGuards` type and a validator, not constants.
+
+import { z } from 'zod'
+
+import type { AgentSchemaIssue, AgentSchemaValidationResult } from './agent-definition'
+import { AgentConsumptionErrorCode, ErrorCode } from './error-codes'
+
+const nonEmptyString = z.string().min(1)
+
+// ---------------------------------------------------------------------------
+// Task lifecycle
+// ---------------------------------------------------------------------------
+
+export const TASK_STATES = [
+  'submitted',
+  'working',
+  'input-required',
+  'completed',
+  'failed',
+  'canceled',
+  'rejected',
+] as const
+
+export type TaskState = (typeof TASK_STATES)[number]
+
+export const TaskStateSchema = z.enum(TASK_STATES)
+
+/**
+ * Legal task-state transitions. Mirrors A2A v1.0 task lifecycle semantics:
+ * `submitted` starts work; `working` is the only state that can settle into
+ * a terminal outcome or pause for input; `input-required` always resumes
+ * back into `working`; every terminal state (`completed`/`failed`/
+ * `canceled`/`rejected`) is final.
+ */
+const TASK_TRANSITIONS: Readonly<Record<TaskState, readonly TaskState[]>> = {
+  submitted: ['working'],
+  working: ['input-required', 'completed', 'failed', 'canceled', 'rejected'],
+  'input-required': ['working'],
+  completed: [],
+  failed: [],
+  canceled: [],
+  rejected: [],
+}
+
+export function isValidTaskTransition(from: TaskState, to: TaskState): boolean {
+  return TASK_TRANSITIONS[from].includes(to)
+}
+
+/** Throws {@link AgentConsumptionValidationError} (AGENT_CONSUMPTION_INVALID_TRANSITION) when illegal. */
+export function assertValidTransition(from: TaskState, to: TaskState): void {
+  if (!isValidTaskTransition(from, to)) {
+    throw new AgentConsumptionValidationError({
+      code: AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_INVALID_TRANSITION,
+      field: 'state',
+      message: `invalid task state transition: '${from}' -> '${to}'`,
+    })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Refs
+// ---------------------------------------------------------------------------
+
+/** The originating user + workspace a task is scoped to (audit: who asked). */
+export interface PrincipalRef {
+  userId: string
+  workspaceId: string
+}
+
+export const PrincipalRefSchema = z
+  .object({
+    userId: nonEmptyString,
+    workspaceId: nonEmptyString,
+  })
+  .strict() satisfies z.ZodType<PrincipalRef, z.ZodTypeDef, unknown>
+
+/** An acting agent identity, recorded as `actor` for audit/provenance (who did it). */
+export interface AgentRef {
+  agentId: string
+  deploymentId?: string
+}
+
+export const AgentRefSchema = z
+  .object({
+    agentId: nonEmptyString,
+    deploymentId: nonEmptyString.optional(),
+  })
+  .strict() satisfies z.ZodType<AgentRef, z.ZodTypeDef, unknown>
+
+export function agentRefEquals(a: AgentRef, b: AgentRef): boolean {
+  return a.agentId === b.agentId && (a.deploymentId ?? null) === (b.deploymentId ?? null)
+}
+
+/** A reference to an artifact produced by a task (bytes live elsewhere; this is the pointer). */
+export interface ArtifactRef {
+  artifactId: string
+  name?: string
+  mimeType: string
+  uri: string
+}
+
+export const ArtifactRefSchema = z
+  .object({
+    artifactId: nonEmptyString,
+    name: z.string().optional(),
+    mimeType: nonEmptyString,
+    uri: nonEmptyString,
+  })
+  .strict() satisfies z.ZodType<ArtifactRef, z.ZodTypeDef, unknown>
+
+// ---------------------------------------------------------------------------
+// Messages / parts
+// ---------------------------------------------------------------------------
+
+export interface TextPart {
+  type: 'text'
+  text: string
+}
+
+export interface FilePart {
+  type: 'file'
+  file: ArtifactRef
+}
+
+export interface DataPart {
+  type: 'data'
+  mimeType: string
+  // `z.unknown()` infers as `unknown | undefined` on an object field, so this
+  // stays optional to match the schema's inferred type exactly.
+  data?: unknown
+}
+
+export type Part = TextPart | FilePart | DataPart
+
+export const PartSchema: z.ZodType<Part, z.ZodTypeDef, unknown> = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('text'), text: z.string() }).strict(),
+  z.object({ type: z.literal('file'), file: ArtifactRefSchema }).strict(),
+  z.object({ type: z.literal('data'), mimeType: nonEmptyString, data: z.unknown() }).strict(),
+])
+
+export interface AgentMessage {
+  role: 'consumer' | 'agent'
+  parts: Part[]
+  ts: string
+}
+
+export const AgentMessageSchema = z
+  .object({
+    role: z.enum(['consumer', 'agent']),
+    parts: z.array(PartSchema),
+    ts: nonEmptyString,
+  })
+  .strict() satisfies z.ZodType<AgentMessage, z.ZodTypeDef, unknown>
+
+// ---------------------------------------------------------------------------
+// Task
+// ---------------------------------------------------------------------------
+
+export interface AgentTask {
+  id: string
+  contextId: string
+  state: TaskState
+  messages: AgentMessage[]
+  artifacts: ArtifactRef[]
+  /** Originating user + workspace this task is scoped to. */
+  principal: PrincipalRef
+  /** Acting agent, recorded for audit/provenance. Absent for a human-driven task. */
+  actor?: AgentRef
+  schemaVersion: '1'
+  createdAt: string
+  updatedAt: string
+}
+
+export const AgentTaskSchema = z
+  .object({
+    id: nonEmptyString,
+    contextId: nonEmptyString,
+    state: TaskStateSchema,
+    messages: z.array(AgentMessageSchema),
+    artifacts: z.array(ArtifactRefSchema),
+    principal: PrincipalRefSchema,
+    actor: AgentRefSchema.optional(),
+    schemaVersion: z.literal('1'),
+    createdAt: nonEmptyString,
+    updatedAt: nonEmptyString,
+  })
+  .strict() satisfies z.ZodType<AgentTask, z.ZodTypeDef, unknown>
+
+function formatIssuePath(path: PropertyKey[]): string {
+  if (path.length === 0) return '<root>'
+  return path.reduce<string>(
+    (result, part) =>
+      typeof part === 'number'
+        ? `${result}[${part}]`
+        : result.length === 0
+          ? String(part)
+          : `${result}.${String(part)}`,
+    '',
+  )
+}
+
+function schemaMismatchIssues(issues: z.ZodIssue[]): AgentSchemaIssue<AgentConsumptionErrorCode>[] {
+  return issues.map((issue) => {
+    const field = formatIssuePath(issue.path)
+    return {
+      code: AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_SCHEMA_MISMATCH,
+      field,
+      message: field === '<root>' ? issue.message : `${field} ${issue.message}`,
+    }
+  })
+}
+
+export function validateAgentTask(
+  raw: unknown,
+): AgentSchemaValidationResult<AgentTask, AgentConsumptionErrorCode> {
+  const result = AgentTaskSchema.safeParse(raw)
+  if (!result.success) {
+    return { valid: false, issues: schemaMismatchIssues(result.error.issues) }
+  }
+  return { valid: true, value: result.data }
+}
+
+export class AgentConsumptionValidationError extends Error {
+  readonly code = ErrorCode.enum.CONFIG_INVALID
+  readonly field: string
+  readonly validationCode: AgentConsumptionErrorCode
+
+  constructor(issue: AgentSchemaIssue<AgentConsumptionErrorCode>) {
+    super(issue.message)
+    this.name = 'AgentConsumptionValidationError'
+    this.field = issue.field
+    this.validationCode = issue.code
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Consumption guards (depth + cycle + input-required timeout)
+// ---------------------------------------------------------------------------
+
+/**
+ * Configurable guard values. Deliberately NOT frozen as constants here —
+ * per Decision 22 / the AC1 guardrail, concrete numbers (suggested: depth 3,
+ * 24h input-required timeout) are ratified in the AC1 consumer-backed spec,
+ * not in the contracts layer.
+ */
+export interface ConsumptionGuards {
+  /** Max delegation chain length before a further hop is refused. */
+  maxDepth: number
+  /** How long a task may sit in `input-required` before it is canceled. */
+  inputRequiredTimeoutMs: number
+}
+
+export const ConsumptionGuardsSchema = z
+  .object({
+    maxDepth: z.number().int().positive(),
+    inputRequiredTimeoutMs: z.number().int().positive(),
+  })
+  .strict() satisfies z.ZodType<ConsumptionGuards, z.ZodTypeDef, unknown>
+
+export function validateConsumptionGuards(
+  raw: unknown,
+): AgentSchemaValidationResult<ConsumptionGuards, AgentConsumptionErrorCode> {
+  const result = ConsumptionGuardsSchema.safeParse(raw)
+  if (!result.success) {
+    return { valid: false, issues: schemaMismatchIssues(result.error.issues) }
+  }
+  return { valid: true, value: result.data }
+}
+
+/**
+ * True when appending `next` to `chain` would revisit an agent (deployment)
+ * already present in the delegation chain — including the same-pair
+ * oscillation case (A -> B -> A), which is caught because A already
+ * appears in the chain by the time B considers delegating back to it.
+ */
+export function detectConsumptionCycle(chain: readonly AgentRef[], next: AgentRef): boolean {
+  return chain.some((ref) => agentRefEquals(ref, next))
+}
+
+/** Throws {@link AgentConsumptionValidationError} (AGENT_CONSUMPTION_CYCLE_DETECTED) when a cycle is detected. */
+export function assertNoConsumptionCycle(chain: readonly AgentRef[], next: AgentRef): void {
+  if (detectConsumptionCycle(chain, next)) {
+    const label = next.deploymentId ? `${next.agentId}@${next.deploymentId}` : next.agentId
+    throw new AgentConsumptionValidationError({
+      code: AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_CYCLE_DETECTED,
+      field: 'actor',
+      message: `consumption cycle detected: agent '${label}' already present in the delegation chain`,
+    })
+  }
+}
+
+/** True when the chain has room for one more hop under `guards.maxDepth`. */
+export function isWithinConsumptionDepth(
+  chain: readonly AgentRef[],
+  guards: ConsumptionGuards,
+): boolean {
+  return chain.length < guards.maxDepth
+}
+
+/** Throws {@link AgentConsumptionValidationError} (AGENT_CONSUMPTION_DEPTH_EXCEEDED) when the depth guard is exceeded. */
+export function assertWithinConsumptionDepth(
+  chain: readonly AgentRef[],
+  guards: ConsumptionGuards,
+): void {
+  if (!isWithinConsumptionDepth(chain, guards)) {
+    throw new AgentConsumptionValidationError({
+      code: AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_DEPTH_EXCEEDED,
+      field: 'depth',
+      message: `consumption depth exceeded: chain length ${chain.length} >= max depth ${guards.maxDepth}`,
+    })
+  }
+}

--- a/packages/agent/src/shared/error-codes.ts
+++ b/packages/agent/src/shared/error-codes.ts
@@ -104,6 +104,22 @@ export const AgentDeploymentErrorCode = z.enum([
 
 export type AgentDeploymentErrorCode = z.infer<typeof AgentDeploymentErrorCode>
 
+/**
+ * Refusal codes for the agent-consumption contract (AC1, Decision 22,
+ * issue #636). Scoped like {@link AgentDeploymentErrorCode} — canonical,
+ * but intentionally outside the public {@link ErrorCode} / {@link
+ * ERROR_CODES} registry (and `docs/ERROR_CODES.md`) until a runtime
+ * dispatcher actually surfaces these over an API boundary.
+ */
+export const AgentConsumptionErrorCode = z.enum([
+  'AGENT_CONSUMPTION_INVALID_TRANSITION',
+  'AGENT_CONSUMPTION_CYCLE_DETECTED',
+  'AGENT_CONSUMPTION_DEPTH_EXCEEDED',
+  'AGENT_CONSUMPTION_SCHEMA_MISMATCH',
+])
+
+export type AgentConsumptionErrorCode = z.infer<typeof AgentConsumptionErrorCode>
+
 export const ApiErrorPayloadSchema = z.object({
   code: ErrorCode,
   message: z.string().min(1),

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -71,6 +71,7 @@ export {
 } from './config-schema'
 export type { RuntimeModeId, AgentConfig, AgentEnv } from './config-schema'
 export {
+  AgentConsumptionErrorCode,
   AgentDefinitionErrorCode,
   AgentDeploymentErrorCode,
   ErrorCode,
@@ -112,6 +113,40 @@ export type {
   Sha256Digest,
 } from './agent-definition'
 export { validateTool } from './validateTool'
+export {
+  TASK_STATES,
+  TaskStateSchema,
+  PrincipalRefSchema,
+  AgentRefSchema,
+  ArtifactRefSchema,
+  PartSchema,
+  AgentMessageSchema,
+  AgentTaskSchema,
+  ConsumptionGuardsSchema,
+  AgentConsumptionValidationError,
+  agentRefEquals,
+  isValidTaskTransition,
+  assertValidTransition,
+  validateAgentTask,
+  validateConsumptionGuards,
+  detectConsumptionCycle,
+  assertNoConsumptionCycle,
+  isWithinConsumptionDepth,
+  assertWithinConsumptionDepth,
+} from './agent-consumption'
+export type {
+  TaskState,
+  PrincipalRef,
+  AgentRef,
+  ArtifactRef,
+  TextPart,
+  FilePart,
+  DataPart,
+  Part,
+  AgentMessage,
+  AgentTask,
+  ConsumptionGuards,
+} from './agent-consumption'
 export {
   WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT,
   WORKSPACE_COMMAND_NOTIFY_EVENT,


### PR DESCRIPTION
## Summary

AC1 types-only slice (issue #636, refs Decision 22 in `docs/DECISIONS.md`, guardrails in `docs/issues/391/runtime-refactor/IMPLEMENTATION-GUARDRAILS.md`).

Adds the agent-consumption contract to `packages/agent/src/shared/` (contracts layer):

- `agent-consumption.ts`: `TaskState` + lifecycle state machine, `AgentTask`/`AgentMessage`/`Part` (text/file/data)/`ArtifactRef`/`PrincipalRef`/`AgentRef` types + zod schemas mirroring A2A v1.0 semantics; a configurable (unfrozen) `ConsumptionGuards` type + `validateConsumptionGuards`; pure helpers `assertValidTransition`, `detectConsumptionCycle`/`assertNoConsumptionCycle`, `isWithinConsumptionDepth`/`assertWithinConsumptionDepth`.
- `error-codes.ts`: scoped `AgentConsumptionErrorCode` (invalid transition / cycle detected / depth exceeded / schema mismatch), following the `AgentDeploymentErrorCode` pattern from #647 — canonical but intentionally outside the public `ErrorCode`/`ERROR_CODES` registry and `docs/ERROR_CODES.md` until a runtime dispatcher surfaces these over an API.
- `index.ts`: barrel exports only.

**Scope, per the AC1 guardrail: types + validators only.** No dispatcher, no persistence, no routes, no exports beyond the shared barrel.

## Test plan

- [x] `pnpm -C packages/agent build`
- [x] `pnpm --filter @hachej/boring-agent run typecheck`
- [x] `pnpm --filter @hachej/boring-agent run lint:invariants`
- [x] `pnpm -C packages/agent exec vitest run src/shared/__tests__/agent-consumption.test.ts src/shared/__tests__/error-codes.test.ts src/shared/__tests__/agent-definition.test.ts` — 125 passed
- [x] Full package suite (`pnpm -C packages/agent test`) — 1882 passed, 6 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)