### PR TITLE
#610 Agent session management

### DIFF
--- a/packages/agent/docs/tools.md
+++ b/packages/agent/docs/tools.md
@@ -26,6 +26,7 @@ selected runtime mode (see [runtime.md](./runtime.md)):
 | `execute_isolated_code` | Run code in an isolated sandbox capability |
 | `upload_file` | Upload a workspace file to blob storage |
 | `plugin_diagnostics` | Report loaded plugins and any load errors |
+| `manage_sessions` | Search authorized sessions, rename the current/authorized session, or delete another session with explicit confirmation |
 
 ## UI-bridge tools (workspace-owned)
 

--- a/packages/agent/src/core/piChatSessionService.ts
+++ b/packages/agent/src/core/piChatSessionService.ts
@@ -33,6 +33,26 @@ export type PiChatReplayRangeError =
   | { type: 'replay_gap'; latestSeq: number; minReplaySeq: number }
   | { type: 'cursor_ahead'; latestSeq: number; minReplaySeq: number }
 
+export type ManageSessionsInput =
+  | { action: 'search'; query?: string; limit?: number; offset?: number }
+  | { action: 'rename'; sessionId?: string; title: string }
+  | { action: 'delete'; sessionId: string; confirm: true }
+
+export type ManageSessionsResult =
+  | {
+      action: 'search'
+      sessions: SessionSummary[]
+      limit: number
+      offset: number
+      count: number
+    }
+  | { action: 'rename'; session: SessionSummary }
+  | { action: 'delete'; sessionId: string; deleted: true }
+
+export interface ManageSessionsOptions {
+  executingSessionId?: string
+}
+
 export interface PiChatEventStreamSubscription {
   type: 'ok'
   unsubscribe: () => void
@@ -49,6 +69,7 @@ export interface PiChatSessionService {
   createSession?(ctx: PiSessionRequestContext, init?: PiSessionCreateInit): Promise<SessionSummary>
   renameSession?(ctx: PiSessionRequestContext, sessionId: string, title: string): Promise<SessionSummary>
   deleteSession?(ctx: PiSessionRequestContext, sessionId: string): Promise<void>
+  manageSessions?(ctx: PiSessionRequestContext, input: ManageSessionsInput, options?: ManageSessionsOptions): Promise<ManageSessionsResult>
   readState(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot>
   subscribe(ctx: PiSessionRequestContext, sessionId: string, cursor: number, subscriber: PiChatEventSubscriber): Promise<PiChatEventStreamResult>
   prompt(ctx: PiSessionRequestContext, sessionId: string, payload: PromptPayload): Promise<PromptReceipt>

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -20,6 +20,7 @@ import { InMemorySessionChangesTracker } from './http/sessionChangesTracker'
 import { createRuntimeReadyStatusTracker } from './runtime/modeReadiness'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
+import { createManageSessionsTool } from './tools/manageSessions'
 import type { ReloadHookDiagnostic } from './http/routes/reload'
 import { createAgentRuntimeBridge } from './createAgent'
 import {
@@ -264,6 +265,7 @@ async function createWorkspaceAgentAppProfile(
   // plugin_diagnostics tool is added to the tool catalog before the harness
   // exists, and diagnostics accumulate on each /reload.
   let harnessRef: AgentHarness | undefined
+  let piChatServiceRef: PiChatSessionService | undefined
   let lastReloadDiagnostics: ReloadHookDiagnostic[] = []
 
   const tools: AgentTool[] = [
@@ -286,6 +288,7 @@ async function createWorkspaceAgentAppProfile(
           })
         : undefined,
     })),
+    createManageSessionsTool({ getService: () => piChatServiceRef }),
     ...(opts.extraTools ?? []),
     ...pluginTools,
     ...(externalPluginsEnabled ? [createPluginDiagnosticsTool({
@@ -330,6 +333,7 @@ async function createWorkspaceAgentAppProfile(
   opts.onWorkspaceAgentDispatcher?.(createStaticWorkspaceAgentDispatcherResolver(coreAgent.agent, sessionId))
   const harness = agentRuntime.harness
   harnessRef = harness
+  piChatServiceRef = agentRuntime.service as PiChatSessionService
   const readyTracker = createRuntimeReadyStatusTracker(modeAdapter, {
     harnessReady: true,
   })

--- a/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
@@ -13,6 +13,7 @@ import type {
   QueueClearReceipt,
   StopReceipt,
 } from '../../../../shared/chat'
+import type { ManageSessionsInput, ManageSessionsOptions, ManageSessionsResult } from '../../../../core/piChatSessionService'
 import type { PiSessionRequestContext } from '../../../pi-chat/piSessionIdentity'
 import { PI_CHAT_CURSOR_AHEAD, PI_CHAT_REPLAY_GAP } from '../../../pi-chat/piChatReplayBuffer'
 import type { SessionListOptions } from '../../../../shared/session'
@@ -50,7 +51,7 @@ class FakePiChatService implements PiChatSessionService {
   events: PiChatEvent[] = []
   subscriptionResult: Awaited<ReturnType<PiChatSessionService['subscribe']>> | undefined
   readonly unsubscribe = vi.fn()
-  readonly calls: Array<{ method: string; ctx: PiSessionRequestContext; sessionId?: string; payload?: unknown; cursor?: number; options?: SessionListOptions }> = []
+  readonly calls: Array<{ method: string; ctx: PiSessionRequestContext; sessionId?: string; payload?: unknown; cursor?: number; options?: SessionListOptions | ManageSessionsOptions }> = []
 
   async listSessions(ctx: PiSessionRequestContext, options?: SessionListOptions) {
     this.calls.push({ method: 'listSessions', ctx, options })
@@ -76,6 +77,21 @@ class FakePiChatService implements PiChatSessionService {
   async deleteSession(ctx: PiSessionRequestContext, sessionId: string) {
     this.calls.push({ method: 'deleteSession', ctx, sessionId })
     this.sessions = this.sessions.filter((session) => session.id !== sessionId)
+  }
+
+  async manageSessions(ctx: PiSessionRequestContext, input: ManageSessionsInput, options?: ManageSessionsOptions): Promise<ManageSessionsResult> {
+    this.calls.push({ method: 'manageSessions', ctx, payload: input, options })
+    if (input.action === 'search') {
+      return { action: 'search', sessions: this.sessions, limit: input.limit ?? 10, offset: input.offset ?? 0, count: this.sessions.length }
+    }
+    if (input.action === 'rename') {
+      const sessionId = input.sessionId ?? options?.executingSessionId
+      if (!sessionId) throw Object.assign(new Error('sessionId is required'), { code: ErrorCode.enum.BRIDGE_COMMAND_INVALID, statusCode: 400 })
+      const session = await this.renameSession(ctx, sessionId, input.title)
+      return { action: 'rename', session }
+    }
+    await this.deleteSession(ctx, input.sessionId)
+    return { action: 'delete', sessionId: input.sessionId, deleted: true }
   }
 
   async readState(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot> {
@@ -186,6 +202,54 @@ describe('piChatRoutes', () => {
       method: 'listSessions',
       options: { limit: 100, offset: 25, includeId: 'pi-older' },
     })
+
+    await app.close()
+  })
+
+  test('POST /sessions/manage forwards authenticated context and bounded input to the service', async () => {
+    const { app, service } = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/pi-chat/sessions/manage',
+      headers: { 'x-boring-storage-scope': 'scope-a' },
+      payload: { action: 'search', query: 'running', limit: 20, offset: 1 },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({ action: 'search', limit: 20, offset: 1 })
+    expect(service.calls[0]).toMatchObject({
+      method: 'manageSessions',
+      ctx: { workspaceId: 'workspace-a', storageScope: 'scope-a', authSubject: 'user-a', requestId: expect.any(String) },
+      payload: { action: 'search', query: 'running', limit: 20, offset: 1 },
+    })
+
+    await app.close()
+  })
+
+  test('POST /sessions/manage rejects invalid schema and maps stable service errors', async () => {
+    const service = new FakePiChatService()
+    const manageSessions = vi.spyOn(service, 'manageSessions').mockRejectedValue(Object.assign(new Error('session not found'), {
+      code: ErrorCode.enum.SESSION_NOT_FOUND,
+    }))
+    const { app } = await buildApp(service)
+
+    const invalid = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/pi-chat/sessions/manage',
+      payload: { action: 'delete', sessionId: 'pi-1', confirm: false },
+    })
+    expect(invalid.statusCode).toBe(400)
+    expect(invalid.json().error).toMatchObject({ code: ErrorCode.enum.BRIDGE_COMMAND_INVALID })
+    expect(manageSessions).not.toHaveBeenCalled()
+
+    const missing = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/pi-chat/sessions/manage',
+      payload: { action: 'rename', sessionId: 'missing', title: 'New title' },
+    })
+    expect(missing.statusCode).toBe(404)
+    expect(missing.json().error).toMatchObject({ code: ErrorCode.enum.SESSION_NOT_FOUND, message: 'session not found' })
 
     await app.close()
   })

--- a/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
@@ -243,6 +243,15 @@ describe('piChatRoutes', () => {
     expect(invalid.json().error).toMatchObject({ code: ErrorCode.enum.BRIDGE_COMMAND_INVALID })
     expect(manageSessions).not.toHaveBeenCalled()
 
+    const whitespaceTitle = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/pi-chat/sessions/manage',
+      payload: { action: 'rename', title: ' \r\n ' },
+    })
+    expect(whitespaceTitle.statusCode).toBe(400)
+    expect(whitespaceTitle.json().error).toMatchObject({ code: ErrorCode.enum.BRIDGE_COMMAND_INVALID })
+    expect(manageSessions).not.toHaveBeenCalled()
+
     const missing = await app.inject({
       method: 'POST',
       url: '/api/v1/agent/pi-chat/sessions/manage',

--- a/packages/agent/src/server/http/routes/piChat.ts
+++ b/packages/agent/src/server/http/routes/piChat.ts
@@ -15,7 +15,9 @@ import {
 } from '../../../shared/chat'
 import { PI_CHAT_CURSOR_AHEAD, PI_CHAT_REPLAY_GAP } from '../../pi-chat/piChatReplayBuffer'
 import type { SessionListOptions } from '../../../shared/session'
+import { ManageSessionsInputSchema } from '../../sessionManagement'
 import type {
+  ManageSessionsInput,
   PiChatEventStreamSubscription,
   PiChatReplayRangeError,
   PiChatSessionService,
@@ -151,6 +153,18 @@ export function piChatRoutes(
       return reply.code(204).send()
     } catch (err) {
       return sendRouteError(reply, err, 'delete pi chat session failed')
+    }
+  })
+
+  app.post('/api/v1/agent/pi-chat/sessions/manage', async (request, reply) => {
+    const body = parseWithSchema<ManageSessionsInput>(ManageSessionsInputSchema, request.body, reply, 'body')
+    if (!body) return
+    try {
+      const service = await resolveService(opts, request)
+      if (!service.manageSessions) throw unsupportedServiceMethod('manage Pi chat sessions')
+      return reply.send(await service.manageSessions(getRequestContext(request), body))
+    } catch (err) {
+      return sendRouteError(reply, err, 'manage pi chat sessions failed')
     }
   })
 

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent'
 import type { AgentHarness, RunContext, AgentSendInput } from '../../../shared/harness'
-import type { SessionStore } from '../../../shared/session'
+import type { SessionListOptions, SessionStore } from '../../../shared/session'
 import type { PiChatEvent } from '../../../shared/chat'
 import type { Workspace } from '../../../shared/workspace'
 import { ErrorCode } from '../../../shared/error-codes'
@@ -219,13 +219,20 @@ describe('HarnessPiChatService', () => {
     await expect(closed).resolves.toBeUndefined()
   })
 
-  it('manageSessions caps authorized search and filters compact results without opening a Pi adapter', async () => {
+  it('manageSessions filters a bounded authorized scan before paginating matches without opening a Pi adapter', async () => {
     const adapter = createAdapter()
-    const sessions = [
-      { id: 's1', title: 'Feature work', createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:10:00.000Z', turnCount: 1 },
-      { id: 's2', title: 'Bug triage', createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:09:00.000Z', turnCount: 2 },
-    ]
-    const list = vi.fn(async () => sessions)
+    const sessions = Array.from({ length: 22 }, (_, index) => ({
+      id: `s${index + 1}`,
+      title: `Session ${index + 1}`,
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:10:00.000Z',
+      turnCount: 1,
+    }))
+    const firstMatch = { ...sessions[20]!, title: 'Needle one' }
+    const secondMatch = { ...sessions[21]!, title: 'Needle two' }
+    sessions[20] = firstMatch
+    sessions[21] = secondMatch
+    const list = vi.fn(async (_ctx: { workspaceId?: string; userId?: string }, options?: SessionListOptions) => sessions.slice(options?.offset ?? 0, (options?.offset ?? 0) + (options?.limit ?? sessions.length)))
     const harness = createHarness(adapter)
     const service = new HarnessPiChatService({
       harness,
@@ -233,16 +240,16 @@ describe('HarnessPiChatService', () => {
       workdir: '/workspace',
     })
 
-    const result = await service.manageSessions(ctx, { action: 'search', query: 'feature', limit: 500, offset: 2 })
+    const result = await service.manageSessions(ctx, { action: 'search', query: 'needle', limit: 1, offset: 1 })
 
     expect(result).toEqual({
       action: 'search',
-      sessions: [sessions[0]],
-      limit: 20,
-      offset: 2,
-      count: 1,
+      sessions: [secondMatch],
+      limit: 1,
+      offset: 1,
+      count: 2,
     })
-    expect(list).toHaveBeenCalledWith({ workspaceId: 'workspace-a', userId: 'user-a' }, { limit: 20, offset: 2 })
+    expect(list).toHaveBeenCalledWith({ workspaceId: 'workspace-a', userId: 'user-a' }, { limit: 100, offset: 0 })
     expect(harness.getPiSessionAdapter).not.toHaveBeenCalled()
   })
 
@@ -264,9 +271,12 @@ describe('HarnessPiChatService', () => {
       .resolves.toMatchObject({ action: 'rename', session: { id: 'current-session', title: 'Current title' } })
     await expect(service.manageSessions(ctx, { action: 'rename', sessionId: 'explicit-session', title: 'Explicit title' }, { executingSessionId: 'current-session' }))
       .resolves.toMatchObject({ action: 'rename', session: { id: 'explicit-session', title: 'Explicit title' } })
+    await expect(service.manageSessions(ctx, { action: 'rename', title: ' \r\n ' }, { executingSessionId: 'current-session' }))
+      .rejects.toMatchObject({ code: ErrorCode.enum.BRIDGE_COMMAND_INVALID, statusCode: 400 })
 
     expect(rename).toHaveBeenNthCalledWith(1, { workspaceId: 'workspace-a', userId: 'user-a' }, 'current-session', 'Current title')
     expect(rename).toHaveBeenNthCalledWith(2, { workspaceId: 'workspace-a', userId: 'user-a' }, 'explicit-session', 'Explicit title')
+    expect(rename).toHaveBeenCalledTimes(2)
   })
 
   it('manageSessions delete requires a non-current explicit session and preserves live delete cleanup', async () => {

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -219,6 +219,76 @@ describe('HarnessPiChatService', () => {
     await expect(closed).resolves.toBeUndefined()
   })
 
+  it('manageSessions caps authorized search and filters compact results without opening a Pi adapter', async () => {
+    const adapter = createAdapter()
+    const sessions = [
+      { id: 's1', title: 'Feature work', createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:10:00.000Z', turnCount: 1 },
+      { id: 's2', title: 'Bug triage', createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:09:00.000Z', turnCount: 2 },
+    ]
+    const list = vi.fn(async () => sessions)
+    const harness = createHarness(adapter)
+    const service = new HarnessPiChatService({
+      harness,
+      sessionStore: { ...sessionStore, list },
+      workdir: '/workspace',
+    })
+
+    const result = await service.manageSessions(ctx, { action: 'search', query: 'feature', limit: 500, offset: 2 })
+
+    expect(result).toEqual({
+      action: 'search',
+      sessions: [sessions[0]],
+      limit: 20,
+      offset: 2,
+      count: 1,
+    })
+    expect(list).toHaveBeenCalledWith({ workspaceId: 'workspace-a', userId: 'user-a' }, { limit: 20, offset: 2 })
+    expect(harness.getPiSessionAdapter).not.toHaveBeenCalled()
+  })
+
+  it('manageSessions defaults rename to the executing session and authorizes explicit IDs through rename', async () => {
+    const rename = vi.fn(async (_ctx, sessionId: string, title: string) => ({
+      id: sessionId,
+      title,
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:11:00.000Z',
+      turnCount: 0,
+    }))
+    const service = new HarnessPiChatService({
+      harness: createHarness(createAdapter()),
+      sessionStore: { ...sessionStore, rename },
+      workdir: '/workspace',
+    })
+
+    await expect(service.manageSessions(ctx, { action: 'rename', title: 'Current title' }, { executingSessionId: 'current-session' }))
+      .resolves.toMatchObject({ action: 'rename', session: { id: 'current-session', title: 'Current title' } })
+    await expect(service.manageSessions(ctx, { action: 'rename', sessionId: 'explicit-session', title: 'Explicit title' }, { executingSessionId: 'current-session' }))
+      .resolves.toMatchObject({ action: 'rename', session: { id: 'explicit-session', title: 'Explicit title' } })
+
+    expect(rename).toHaveBeenNthCalledWith(1, { workspaceId: 'workspace-a', userId: 'user-a' }, 'current-session', 'Current title')
+    expect(rename).toHaveBeenNthCalledWith(2, { workspaceId: 'workspace-a', userId: 'user-a' }, 'explicit-session', 'Explicit title')
+  })
+
+  it('manageSessions delete requires a non-current explicit session and preserves live delete cleanup', async () => {
+    const adapter = createAdapter()
+    const deleteSession = vi.fn(async () => {})
+    const service = new HarnessPiChatService({
+      harness: createHarness(adapter),
+      sessionStore: { ...sessionStore, delete: deleteSession },
+      workdir: '/workspace',
+    })
+    const subscription = await service.subscribe(ctx, 'other-session', 0, () => {})
+    expect(subscription.type).toBe('ok')
+
+    await expect(service.manageSessions(ctx, { action: 'delete', sessionId: 'current-session', confirm: true }, { executingSessionId: 'current-session' }))
+      .rejects.toMatchObject({ code: ErrorCode.enum.BRIDGE_COMMAND_INVALID })
+    await expect(service.manageSessions(ctx, { action: 'delete', sessionId: 'other-session', confirm: true }, { executingSessionId: 'current-session' }))
+      .resolves.toEqual({ action: 'delete', sessionId: 'other-session', deleted: true })
+
+    expect(adapter.abort).toHaveBeenCalledOnce()
+    expect(deleteSession).toHaveBeenCalledWith({ workspaceId: 'workspace-a', userId: 'user-a' }, 'other-session')
+  })
+
   it('aborts an interrupt-triggered replacement run before draining the interrupt', async () => {
     const adapter = createAdapter(['queued follow-up'])
     const replacement = deferred<void>()

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -6,6 +6,9 @@ import { sessionStreamPath, type AgentEvent } from '../../shared/events'
 import { ErrorCode } from '../../shared/error-codes'
 import { formatOffset, parseOffset, type EventStreamStore } from '../events/eventStreamStore'
 import type {
+  ManageSessionsInput,
+  ManageSessionsOptions,
+  ManageSessionsResult,
   PiChatEventStreamResult,
   PiChatEventSubscriber,
   PiChatSessionService,
@@ -21,6 +24,12 @@ import { buildPiChatHistory } from './piChatHistory'
 import { PiChatMeteringCoordinator, type AgentMeteringSink, type MeteringErrorLogger } from './metering'
 import { HarnessPiChatServiceLifecycle } from './piChatServiceLifecycle'
 import { normalizeSessionTitle } from '../sessionTitle'
+import {
+  normalizeManageSessionsLimit,
+  normalizeManageSessionsOffset,
+  normalizeManageSessionsQuery,
+  sessionManagementInvalidError,
+} from '../sessionManagement'
 
 type PiNativeHarness = AgentHarness & {
   getPiSessionAdapter?: (input: AgentSendInput, ctx: RunContext) => Promise<PiAgentSessionAdapter>
@@ -202,6 +211,53 @@ export class HarnessPiChatService implements PiChatSessionService {
 
   async deleteSession(ctx: PiSessionRequestContext, sessionId: string): Promise<void> {
     return this.lifecycle.run(() => this.deleteSessionBeforeDispose(ctx, sessionId))
+  }
+
+  async manageSessions(
+    ctx: PiSessionRequestContext,
+    input: ManageSessionsInput,
+    options: ManageSessionsOptions = {},
+  ): Promise<ManageSessionsResult> {
+    return this.lifecycle.run(async () => {
+      switch (input.action) {
+        case 'search': {
+          const limit = normalizeManageSessionsLimit(input.limit)
+          const offset = normalizeManageSessionsOffset(input.offset)
+          const query = normalizeManageSessionsQuery(input.query)
+          const sessions = await this.sessionStore.list(toSessionCtx(ctx), { limit, offset })
+          const filtered = query
+            ? sessions.filter((session) =>
+                session.id.toLowerCase().includes(query) ||
+                session.title.toLowerCase().includes(query),
+              )
+            : sessions
+          return {
+            action: 'search',
+            sessions: filtered,
+            limit,
+            offset,
+            count: filtered.length,
+          }
+        }
+        case 'rename': {
+          const sessionId = input.sessionId ?? options.executingSessionId
+          if (!sessionId) {
+            throw sessionManagementInvalidError('sessionId is required when no executing session is available', 'sessionId')
+          }
+          return { action: 'rename', session: await this.renameSession(ctx, sessionId, input.title) }
+        }
+        case 'delete': {
+          if (input.confirm !== true) {
+            throw sessionManagementInvalidError('confirm must be true to delete a session', 'confirm')
+          }
+          if (input.sessionId === options.executingSessionId) {
+            throw sessionManagementInvalidError('manage_sessions cannot delete the session that is currently executing', 'sessionId')
+          }
+          await this.deleteSession(ctx, input.sessionId)
+          return { action: 'delete', sessionId: input.sessionId, deleted: true }
+        }
+      }
+    })
   }
 
   private async deleteSessionBeforeDispose(ctx: PiSessionRequestContext, sessionId: string): Promise<void> {

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -25,9 +25,11 @@ import { PiChatMeteringCoordinator, type AgentMeteringSink, type MeteringErrorLo
 import { HarnessPiChatServiceLifecycle } from './piChatServiceLifecycle'
 import { normalizeSessionTitle } from '../sessionTitle'
 import {
+  MANAGE_SESSIONS_MAX_SEARCH_SCAN,
   normalizeManageSessionsLimit,
   normalizeManageSessionsOffset,
   normalizeManageSessionsQuery,
+  parseManageSessionsInput,
   sessionManagementInvalidError,
 } from '../sessionManagement'
 
@@ -219,13 +221,19 @@ export class HarnessPiChatService implements PiChatSessionService {
     options: ManageSessionsOptions = {},
   ): Promise<ManageSessionsResult> {
     return this.lifecycle.run(async () => {
-      switch (input.action) {
+      // Tool and HTTP callers parse this schema too, but service callers are a
+      // public seam as well. Keep title normalization and validation stable
+      // even when a typed internal caller bypasses those adapters.
+      const parsedInput = parseManageSessionsInput(input)
+      switch (parsedInput.action) {
         case 'search': {
-          const limit = normalizeManageSessionsLimit(input.limit)
-          const offset = normalizeManageSessionsOffset(input.offset)
-          const query = normalizeManageSessionsQuery(input.query)
-          const sessions = await this.sessionStore.list(toSessionCtx(ctx), { limit, offset })
-          const filtered = query
+          const limit = normalizeManageSessionsLimit(parsedInput.limit)
+          const offset = normalizeManageSessionsOffset(parsedInput.offset)
+          const query = normalizeManageSessionsQuery(parsedInput.query)
+          const sessions = await this.sessionStore.list(toSessionCtx(ctx), query
+            ? { limit: MANAGE_SESSIONS_MAX_SEARCH_SCAN, offset: 0 }
+            : { limit, offset })
+          const matches = query
             ? sessions.filter((session) =>
                 session.id.toLowerCase().includes(query) ||
                 session.title.toLowerCase().includes(query),
@@ -233,28 +241,28 @@ export class HarnessPiChatService implements PiChatSessionService {
             : sessions
           return {
             action: 'search',
-            sessions: filtered,
+            sessions: query ? matches.slice(offset, offset + limit) : matches,
             limit,
             offset,
-            count: filtered.length,
+            count: matches.length,
           }
         }
         case 'rename': {
-          const sessionId = input.sessionId ?? options.executingSessionId
+          const sessionId = parsedInput.sessionId ?? options.executingSessionId
           if (!sessionId) {
             throw sessionManagementInvalidError('sessionId is required when no executing session is available', 'sessionId')
           }
-          return { action: 'rename', session: await this.renameSession(ctx, sessionId, input.title) }
+          return { action: 'rename', session: await this.renameSession(ctx, sessionId, parsedInput.title) }
         }
         case 'delete': {
-          if (input.confirm !== true) {
+          if (parsedInput.confirm !== true) {
             throw sessionManagementInvalidError('confirm must be true to delete a session', 'confirm')
           }
-          if (input.sessionId === options.executingSessionId) {
+          if (parsedInput.sessionId === options.executingSessionId) {
             throw sessionManagementInvalidError('manage_sessions cannot delete the session that is currently executing', 'sessionId')
           }
-          await this.deleteSession(ctx, input.sessionId)
-          return { action: 'delete', sessionId: input.sessionId, deleted: true }
+          await this.deleteSession(ctx, parsedInput.sessionId)
+          return { action: 'delete', sessionId: parsedInput.sessionId, deleted: true }
         }
       }
     })

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -48,6 +48,7 @@ import { withRuntimeEnvContributions, type RuntimeEnvContribution } from './runt
 import type { AgentHarness } from '../shared/harness'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import { createPluginDiagnosticsTool } from './tools/pluginDiagnostics'
+import { createManageSessionsTool } from './tools/manageSessions'
 import { createAgentRuntimeBridge } from './createAgent'
 import {
   registerAgentRouteBindingProfile,
@@ -65,7 +66,7 @@ import type { WorkspaceAgentDispatcherContext } from '../shared/workspaceAgentDi
 
 const DEFAULT_VERSION = '0.1.0-dev'
 const DEFAULT_WORKSPACE_ID = 'default'
-const STANDARD_AGENT_TOOL_NAMES = ['bash', 'read', 'write', 'edit', 'find', 'grep', 'ls']
+const STANDARD_AGENT_TOOL_NAMES = ['bash', 'read', 'write', 'edit', 'find', 'grep', 'ls', 'manage_sessions']
 
 type AgentCapabilities = {
   agent: {
@@ -681,6 +682,7 @@ let runtimeProvisioning: WorkspaceProvisioningResult | undefined
           : undefined,
       }),
       ...buildUploadAgentTools(runtimeBundle),
+      createManageSessionsTool({ getService: () => binding?.piChatService }),
       ...(externalPluginsEnabled ? [createPluginDiagnosticsTool({
         // `binding` is assigned later in this function; read through thunks.
         getLastReloadDiagnostics: () => binding?.lastReloadDiagnostics ?? [],

--- a/packages/agent/src/server/sessionManagement.ts
+++ b/packages/agent/src/server/sessionManagement.ts
@@ -4,7 +4,13 @@ import type { ManageSessionsInput } from '../core/piChatSessionService'
 
 export const MANAGE_SESSIONS_DEFAULT_LIMIT = 10
 export const MANAGE_SESSIONS_MAX_LIMIT = 20
+/** Maximum authorized records inspected for one text search; never unbounded. */
+export const MANAGE_SESSIONS_MAX_SEARCH_SCAN = 100
 export const MANAGE_SESSIONS_MAX_QUERY_LENGTH = 200
+
+const ManageSessionTitleSchema = z.string()
+  .transform((title) => title.replace(/[\r\n]+/g, ' ').trim())
+  .pipe(z.string().min(1).max(200))
 
 export const ManageSessionsInputSchema: z.ZodType<ManageSessionsInput, z.ZodTypeDef, unknown> = z.discriminatedUnion('action', [
   z.object({
@@ -16,7 +22,7 @@ export const ManageSessionsInputSchema: z.ZodType<ManageSessionsInput, z.ZodType
   z.object({
     action: z.literal('rename'),
     sessionId: z.string().min(1).max(128).optional(),
-    title: z.string().min(1).max(200),
+    title: ManageSessionTitleSchema,
   }).strict(),
   z.object({
     action: z.literal('delete'),

--- a/packages/agent/src/server/sessionManagement.ts
+++ b/packages/agent/src/server/sessionManagement.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+import { ErrorCode } from '../shared/error-codes'
+import type { ManageSessionsInput } from '../core/piChatSessionService'
+
+export const MANAGE_SESSIONS_DEFAULT_LIMIT = 10
+export const MANAGE_SESSIONS_MAX_LIMIT = 20
+export const MANAGE_SESSIONS_MAX_QUERY_LENGTH = 200
+
+export const ManageSessionsInputSchema: z.ZodType<ManageSessionsInput, z.ZodTypeDef, unknown> = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('search'),
+    query: z.string().max(MANAGE_SESSIONS_MAX_QUERY_LENGTH).optional(),
+    limit: z.number().int().min(1).max(MANAGE_SESSIONS_MAX_LIMIT).optional(),
+    offset: z.number().int().nonnegative().optional(),
+  }).strict(),
+  z.object({
+    action: z.literal('rename'),
+    sessionId: z.string().min(1).max(128).optional(),
+    title: z.string().min(1).max(200),
+  }).strict(),
+  z.object({
+    action: z.literal('delete'),
+    sessionId: z.string().min(1).max(128),
+    confirm: z.literal(true),
+  }).strict(),
+])
+
+export function parseManageSessionsInput(value: unknown): ManageSessionsInput {
+  const parsed = ManageSessionsInputSchema.safeParse(value)
+  if (parsed.success) return parsed.data
+  const issue = parsed.error.issues[0]
+  const field = issue?.path.length ? issue.path.map(String).join('.') : undefined
+  throw sessionManagementInvalidError(
+    field ? `${field}: ${issue?.message ?? 'invalid manage_sessions input'}` : issue?.message ?? 'invalid manage_sessions input',
+    field,
+  )
+}
+
+export function normalizeManageSessionsLimit(limit: number | undefined): number {
+  return Math.min(MANAGE_SESSIONS_MAX_LIMIT, Math.max(1, limit ?? MANAGE_SESSIONS_DEFAULT_LIMIT))
+}
+
+export function normalizeManageSessionsOffset(offset: number | undefined): number {
+  return Math.max(0, offset ?? 0)
+}
+
+export function normalizeManageSessionsQuery(query: string | undefined): string | undefined {
+  const trimmed = query?.trim()
+  return trimmed ? trimmed.toLowerCase() : undefined
+}
+
+export function sessionManagementInvalidError(message: string, field?: string): Error & { code: string; statusCode: number; details?: { field: string } } {
+  return Object.assign(new Error(message), {
+    code: ErrorCode.enum.BRIDGE_COMMAND_INVALID,
+    statusCode: 400,
+    ...(field ? { details: { field } } : {}),
+  })
+}

--- a/packages/agent/src/server/tools/__tests__/manageSessions.test.ts
+++ b/packages/agent/src/server/tools/__tests__/manageSessions.test.ts
@@ -73,6 +73,18 @@ describe('manage_sessions tool', () => {
     expect(result.details).toMatchObject({ code: ErrorCode.enum.BRIDGE_COMMAND_INVALID })
   })
 
+  test('rejects whitespace-only rename title with a stable validation error before reaching the service', async () => {
+    const service = new FakeManageService()
+    const manageSessions = vi.spyOn(service, 'manageSessions')
+    const tool = createManageSessionsTool({ getService: () => service as unknown as PiChatSessionService })
+
+    const result = await tool.execute({ action: 'rename', title: ' \r\n ' }, toolCtx())
+
+    expect(result.isError).toBe(true)
+    expect(manageSessions).not.toHaveBeenCalled()
+    expect(result.details).toMatchObject({ code: ErrorCode.enum.BRIDGE_COMMAND_INVALID })
+  })
+
   test('returns stable service errors without using loopback HTTP', async () => {
     const service = new FakeManageService()
     vi.spyOn(service, 'manageSessions').mockRejectedValue(Object.assign(new Error('session not found'), {

--- a/packages/agent/src/server/tools/__tests__/manageSessions.test.ts
+++ b/packages/agent/src/server/tools/__tests__/manageSessions.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test, vi } from 'vitest'
+import { ErrorCode } from '../../../shared/error-codes'
+import type { ManageSessionsInput, ManageSessionsOptions, ManageSessionsResult, PiChatSessionService, PiSessionRequestContext } from '../../../core/piChatSessionService'
+import { createManageSessionsTool } from '../manageSessions'
+
+const abortSignal = new AbortController().signal
+
+function toolCtx(overrides: Record<string, unknown> = {}) {
+  return {
+    abortSignal,
+    toolCallId: 'tool-1',
+    sessionId: 'current-session',
+    workspaceId: 'workspace-a',
+    userId: 'user-a',
+    requestId: 'request-a',
+    ...overrides,
+  } as any
+}
+
+class FakeManageService implements Partial<PiChatSessionService> {
+  readonly calls: Array<{ ctx: PiSessionRequestContext; input: ManageSessionsInput; options?: ManageSessionsOptions }> = []
+  result: ManageSessionsResult = {
+    action: 'search',
+    sessions: [],
+    limit: 10,
+    offset: 0,
+    count: 0,
+  }
+
+  async manageSessions(ctx: PiSessionRequestContext, input: ManageSessionsInput, options?: ManageSessionsOptions): Promise<ManageSessionsResult> {
+    this.calls.push({ ctx, input, options })
+    return this.result
+  }
+}
+
+describe('manage_sessions tool', () => {
+  test('uses the shared service with auth context and current-session default for rename', async () => {
+    const service = new FakeManageService()
+    service.result = {
+      action: 'rename',
+      session: { id: 'current-session', title: 'Renamed', createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:00:00.000Z', turnCount: 0 },
+    }
+    const tool = createManageSessionsTool({ getService: () => service as unknown as PiChatSessionService })
+
+    const result = await tool.execute({ action: 'rename', title: 'Renamed' }, toolCtx())
+
+    expect(result.isError).toBeUndefined()
+    expect(service.calls).toEqual([
+      {
+        ctx: {
+          workspaceId: 'workspace-a',
+          authSubject: 'user-a',
+          authEmail: undefined,
+          authEmailVerified: undefined,
+          requestId: 'request-a',
+        },
+        input: { action: 'rename', title: 'Renamed' },
+        options: { executingSessionId: 'current-session' },
+      },
+    ])
+    expect(JSON.parse(result.content[0]!.text)).toMatchObject({ action: 'rename', session: { id: 'current-session' } })
+  })
+
+  test('rejects invalid delete input before reaching the service', async () => {
+    const service = new FakeManageService()
+    const manageSessions = vi.spyOn(service, 'manageSessions')
+    const tool = createManageSessionsTool({ getService: () => service as unknown as PiChatSessionService })
+
+    const result = await tool.execute({ action: 'delete', sessionId: 'other-session', confirm: false }, toolCtx())
+
+    expect(result.isError).toBe(true)
+    expect(manageSessions).not.toHaveBeenCalled()
+    expect(result.details).toMatchObject({ code: ErrorCode.enum.BRIDGE_COMMAND_INVALID })
+  })
+
+  test('returns stable service errors without using loopback HTTP', async () => {
+    const service = new FakeManageService()
+    vi.spyOn(service, 'manageSessions').mockRejectedValue(Object.assign(new Error('session not found'), {
+      code: ErrorCode.enum.SESSION_NOT_FOUND,
+    }))
+    const tool = createManageSessionsTool({ getService: () => service as unknown as PiChatSessionService })
+
+    const result = await tool.execute({ action: 'rename', sessionId: 'missing', title: 'New' }, toolCtx())
+
+    expect(result.isError).toBe(true)
+    expect(result.details).toMatchObject({ code: ErrorCode.enum.SESSION_NOT_FOUND, message: 'session not found' })
+  })
+})

--- a/packages/agent/src/server/tools/manageSessions.ts
+++ b/packages/agent/src/server/tools/manageSessions.ts
@@ -1,0 +1,106 @@
+import { ErrorCode } from '../../shared/error-codes'
+import type { AgentTool, ToolExecContext, ToolResult } from '../../shared/tool'
+import type { PiChatSessionService, PiSessionRequestContext } from '../../core/piChatSessionService'
+import {
+  MANAGE_SESSIONS_DEFAULT_LIMIT,
+  MANAGE_SESSIONS_MAX_LIMIT,
+  parseManageSessionsInput,
+} from '../sessionManagement'
+
+export interface ManageSessionsToolOptions {
+  getService: () => PiChatSessionService | Promise<PiChatSessionService | undefined> | undefined
+}
+
+export function createManageSessionsTool(options: ManageSessionsToolOptions): AgentTool {
+  return {
+    name: 'manage_sessions',
+    description: 'Search authorized Pi sessions, rename the current or an authorized session, or delete an authorized session with confirmation.',
+    promptSnippet: 'Use manage_sessions to search sessions, rename this session, or delete another session when explicitly confirmed.',
+    parameters: {
+      type: 'object',
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            action: { const: 'search' },
+            query: { type: 'string', maxLength: 200 },
+            limit: { type: 'integer', minimum: 1, maximum: MANAGE_SESSIONS_MAX_LIMIT, default: MANAGE_SESSIONS_DEFAULT_LIMIT },
+            offset: { type: 'integer', minimum: 0, default: 0 },
+          },
+          required: ['action'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            action: { const: 'rename' },
+            sessionId: { type: 'string', minLength: 1, maxLength: 128, description: 'Optional; defaults to the current executing session.' },
+            title: { type: 'string', minLength: 1, maxLength: 200 },
+          },
+          required: ['action', 'title'],
+          additionalProperties: false,
+        },
+        {
+          type: 'object',
+          properties: {
+            action: { const: 'delete' },
+            sessionId: { type: 'string', minLength: 1, maxLength: 128, description: 'Required; the current executing session is rejected.' },
+            confirm: { const: true },
+          },
+          required: ['action', 'sessionId', 'confirm'],
+          additionalProperties: false,
+        },
+      ],
+    },
+    async execute(params, ctx) {
+      try {
+        const service = await options.getService()
+        if (!service?.manageSessions) {
+          throw Object.assign(new Error('session management service is unavailable'), {
+            code: ErrorCode.enum.AGENT_RUNTIME_NOT_READY,
+            retryable: true,
+          })
+        }
+        const input = parseManageSessionsInput(params)
+        const result = await service.manageSessions(toSessionRequestContext(ctx), input, {
+          executingSessionId: ctx.sessionId,
+        })
+        return jsonToolResult(result)
+      } catch (error) {
+        return errorToolResult(error)
+      }
+    },
+  }
+}
+
+function toSessionRequestContext(ctx: ToolExecContext): PiSessionRequestContext {
+  return {
+    workspaceId: ctx.workspaceId,
+    authSubject: ctx.userId,
+    authEmail: ctx.userEmail,
+    authEmailVerified: ctx.userEmailVerified,
+    requestId: ctx.requestId ?? ctx.toolCallId,
+  }
+}
+
+function jsonToolResult(value: unknown): ToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(value) }],
+    details: value,
+  }
+}
+
+function errorToolResult(error: unknown): ToolResult {
+  const code = ErrorCode.safeParse((error as { code?: unknown })?.code)
+  const details = {
+    code: code.success ? code.data : ErrorCode.enum.TOOL_EXECUTION_ERROR,
+    message: error instanceof Error ? error.message : 'manage_sessions failed',
+    retryable: (error as { retryable?: unknown })?.retryable === true ? true : undefined,
+    details: (error as { details?: unknown })?.details,
+  }
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: details }) }],
+    isError: true,
+    details,
+  }
+}


### PR DESCRIPTION
## Summary
Adds the bounded `manage_sessions` agent capability and authenticated session-management route.

## Issue / Slice
Closes #610. Stacked on #615.

## What Changed
- Compact authorized session search (bounded authorized scan: 100; return cap: 20).
- Rename defaults to the executing session; explicit IDs are context-authorized.
- Guarded delete requires an explicit ID and `confirm: true`; self-delete is rejected and live runtime cleanup remains safe.
- Shared canonical title validation and stable errors across tool, service, and HTTP seams.

## Proof
- Exact command: `pnpm --filter @hachej/boring-agent test -- --runInBand src/server/tools/__tests__/manageSessions.test.ts src/server/pi-chat/__tests__/harnessPiChatService.test.ts src/server/http/routes/__tests__/piChat.test.ts` — 201 files passed, 1,751 tests passed, 6 skipped; no type errors.
- Exact command: `pnpm --filter @hachej/boring-agent typecheck` — passed.
- Exact command: `bash scripts/check-invariants.sh packages/agent` — passed.

## Review
- Standards (Terra): READY.
- Spec/security (Sol): READY.
- Reviewed SHA: `383e8102e`.

## Risk / Rollback
Search intentionally covers only the newest 100 authorized sessions; a future indexed capability can expand that scope. Roll back this stacked PR to remove the capability.

## Next
Depends on #615; ready for review after its base lands.
