### PR TITLE
#611 Project-wide session activity read model

### DIFF
--- a/packages/agent/src/core/piChatSessionService.ts
+++ b/packages/agent/src/core/piChatSessionService.ts
@@ -53,6 +53,32 @@ export interface ManageSessionsOptions {
   executingSessionId?: string
 }
 
+export type SessionActivityStatus = 'idle' | 'queued' | 'working' | 'error'
+export type SessionActivitySource = 'live-runtime' | 'persisted'
+
+export interface SessionActivityInput {
+  /** Context-authorized explicit session IDs. Missing/unauthorized IDs are omitted and reported. */
+  sessionIds?: string[]
+  /** Inventory-page mode when sessionIds is omitted. */
+  limit?: number
+  offset?: number
+}
+
+export interface SessionActivityEntry {
+  sessionId: string
+  status: SessionActivityStatus
+  source: SessionActivitySource
+  updatedAt?: string
+}
+
+export interface SessionActivityResult {
+  activities: SessionActivityEntry[]
+  omittedSessionIds: string[]
+  limit: number
+  offset: number
+  count: number
+}
+
 export interface PiChatEventStreamSubscription {
   type: 'ok'
   unsubscribe: () => void
@@ -70,6 +96,7 @@ export interface PiChatSessionService {
   renameSession?(ctx: PiSessionRequestContext, sessionId: string, title: string): Promise<SessionSummary>
   deleteSession?(ctx: PiSessionRequestContext, sessionId: string): Promise<void>
   manageSessions?(ctx: PiSessionRequestContext, input: ManageSessionsInput, options?: ManageSessionsOptions): Promise<ManageSessionsResult>
+  readSessionActivity?(ctx: PiSessionRequestContext, input: SessionActivityInput): Promise<SessionActivityResult>
   readState(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot>
   subscribe(ctx: PiSessionRequestContext, sessionId: string, cursor: number, subscriber: PiChatEventSubscriber): Promise<PiChatEventStreamResult>
   prompt(ctx: PiSessionRequestContext, sessionId: string, payload: PromptPayload): Promise<PromptReceipt>

--- a/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
@@ -13,7 +13,7 @@ import type {
   QueueClearReceipt,
   StopReceipt,
 } from '../../../../shared/chat'
-import type { ManageSessionsInput, ManageSessionsOptions, ManageSessionsResult } from '../../../../core/piChatSessionService'
+import type { ManageSessionsInput, ManageSessionsOptions, ManageSessionsResult, SessionActivityInput, SessionActivityResult } from '../../../../core/piChatSessionService'
 import type { PiSessionRequestContext } from '../../../pi-chat/piSessionIdentity'
 import { PI_CHAT_CURSOR_AHEAD, PI_CHAT_REPLAY_GAP } from '../../../pi-chat/piChatReplayBuffer'
 import type { SessionListOptions } from '../../../../shared/session'
@@ -77,6 +77,17 @@ class FakePiChatService implements PiChatSessionService {
   async deleteSession(ctx: PiSessionRequestContext, sessionId: string) {
     this.calls.push({ method: 'deleteSession', ctx, sessionId })
     this.sessions = this.sessions.filter((session) => session.id !== sessionId)
+  }
+
+  async readSessionActivity(ctx: PiSessionRequestContext, input: SessionActivityInput): Promise<SessionActivityResult> {
+    this.calls.push({ method: 'readSessionActivity', ctx, payload: input })
+    return {
+      activities: this.sessions.map((session) => ({ sessionId: session.id, status: 'idle' as const, source: 'persisted' as const, updatedAt: session.updatedAt })),
+      omittedSessionIds: [],
+      limit: input.limit ?? 50,
+      offset: input.offset ?? 0,
+      count: this.sessions.length,
+    }
   }
 
   async manageSessions(ctx: PiSessionRequestContext, input: ManageSessionsInput, options?: ManageSessionsOptions): Promise<ManageSessionsResult> {
@@ -202,6 +213,47 @@ describe('piChatRoutes', () => {
       method: 'listSessions',
       options: { limit: 100, offset: 25, includeId: 'pi-older' },
     })
+
+    await app.close()
+  })
+
+  test('POST /sessions/activity forwards authenticated context and bounded activity input to the service', async () => {
+    const { app, service } = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/pi-chat/sessions/activity',
+      headers: { 'x-boring-storage-scope': 'scope-a' },
+      payload: { sessionIds: ['pi-1'] },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toMatchObject({
+      activities: [{ sessionId: 'pi-1', status: 'idle', source: 'persisted' }],
+      omittedSessionIds: [],
+    })
+    expect(service.calls[0]).toMatchObject({
+      method: 'readSessionActivity',
+      ctx: { workspaceId: 'workspace-a', storageScope: 'scope-a', authSubject: 'user-a', requestId: expect.any(String) },
+      payload: { sessionIds: ['pi-1'] },
+    })
+
+    await app.close()
+  })
+
+  test('POST /sessions/activity rejects invalid mixed modes before service invocation', async () => {
+    const { app, service } = await buildApp()
+    const readSessionActivity = vi.spyOn(service, 'readSessionActivity')
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/pi-chat/sessions/activity',
+      payload: { sessionIds: ['pi-1'], limit: 10 },
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.json().error).toMatchObject({ code: ErrorCode.enum.BRIDGE_COMMAND_INVALID })
+    expect(readSessionActivity).not.toHaveBeenCalled()
 
     await app.close()
   })

--- a/packages/agent/src/server/http/routes/piChat.ts
+++ b/packages/agent/src/server/http/routes/piChat.ts
@@ -16,8 +16,10 @@ import {
 import { PI_CHAT_CURSOR_AHEAD, PI_CHAT_REPLAY_GAP } from '../../pi-chat/piChatReplayBuffer'
 import type { SessionListOptions } from '../../../shared/session'
 import { ManageSessionsInputSchema } from '../../sessionManagement'
+import { SessionActivityInputSchema } from '../../sessionActivity'
 import type {
   ManageSessionsInput,
+  SessionActivityInput,
   PiChatEventStreamSubscription,
   PiChatReplayRangeError,
   PiChatSessionService,
@@ -153,6 +155,18 @@ export function piChatRoutes(
       return reply.code(204).send()
     } catch (err) {
       return sendRouteError(reply, err, 'delete pi chat session failed')
+    }
+  })
+
+  app.post('/api/v1/agent/pi-chat/sessions/activity', async (request, reply) => {
+    const body = parseWithSchema<SessionActivityInput>(SessionActivityInputSchema, request.body ?? {}, reply, 'body')
+    if (!body) return
+    try {
+      const service = await resolveService(opts, request)
+      if (!service.readSessionActivity) throw unsupportedServiceMethod('read Pi chat session activity')
+      return reply.send(await service.readSessionActivity(getRequestContext(request), body))
+    } catch (err) {
+      return sendRouteError(reply, err, 'read pi chat session activity failed')
     }
   })
 

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -253,6 +253,113 @@ describe('HarnessPiChatService', () => {
     expect(harness.getPiSessionAdapter).not.toHaveBeenCalled()
   })
 
+  it('readSessionActivity reports persisted idle without cold-starting an adapter, even when a nonlocal Pi session may exist', async () => {
+    const adapter = createAdapter()
+    const harness = createHarness(adapter)
+    harness.hasPiSession = vi.fn(() => true)
+    const sessions = [{ id: 's1', title: 'Persisted', createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:10:00.000Z', turnCount: 1 }]
+    const list = vi.fn(async () => sessions)
+    const service = new HarnessPiChatService({
+      harness,
+      sessionStore: { ...sessionStore, list },
+      workdir: '/workspace',
+    })
+
+    const result = await service.readSessionActivity(ctx, { limit: 25, offset: 2 })
+
+    expect(result).toEqual({
+      activities: [{ sessionId: 's1', status: 'idle', source: 'persisted', updatedAt: '2026-07-01T00:10:00.000Z' }],
+      omittedSessionIds: [],
+      limit: 25,
+      offset: 2,
+      count: 1,
+    })
+    expect(list).toHaveBeenCalledWith({ workspaceId: 'workspace-a', userId: 'user-a' }, { limit: 25, offset: 2 })
+    expect(harness.getPiSessionAdapter).not.toHaveBeenCalled()
+  })
+
+  it('readSessionActivity omits unauthorized or missing requested sessions with stable IDs', async () => {
+    const load = vi.fn(async (_ctx: { workspaceId?: string; userId?: string }, sessionId: string) => {
+      if (sessionId === 'missing') throw Object.assign(new Error('session not found'), { code: ErrorCode.enum.SESSION_NOT_FOUND })
+      return { id: sessionId, title: sessionId, createdAt: '2026-07-01T00:00:00.000Z', updatedAt: '2026-07-01T00:10:00.000Z', turnCount: 1 }
+    })
+    const adapter = createAdapter()
+    const harness = createHarness(adapter)
+    const service = new HarnessPiChatService({
+      harness,
+      sessionStore: { ...sessionStore, load },
+      workdir: '/workspace',
+    })
+
+    const result = await service.readSessionActivity(ctx, { sessionIds: ['s1', 'missing', 's1'] })
+
+    expect(result).toEqual({
+      activities: [{ sessionId: 's1', status: 'idle', source: 'persisted', updatedAt: '2026-07-01T00:10:00.000Z' }],
+      omittedSessionIds: ['missing'],
+      limit: 50,
+      offset: 0,
+      count: 1,
+    })
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(load).toHaveBeenCalledWith({ workspaceId: 'workspace-a', userId: 'user-a' }, 's1')
+    expect(harness.getPiSessionAdapter).not.toHaveBeenCalled()
+  })
+
+  it('readSessionActivity reports mounted and closed-pane Boring live sessions as working', async () => {
+    const { service, adapter } = createService()
+    const subscription = await service.subscribe(ctx, 's1', 0, () => {})
+    expect(subscription.type).toBe('ok')
+
+    await expect(service.readSessionActivity(ctx, { sessionIds: ['s1'] })).resolves.toMatchObject({
+      activities: [{ sessionId: 's1', status: 'working', source: 'live-runtime' }],
+    })
+
+    if (subscription.type === 'ok') subscription.unsubscribe()
+    await expect(service.readSessionActivity(ctx, { sessionIds: ['s1'] })).resolves.toMatchObject({
+      activities: [{ sessionId: 's1', status: 'working', source: 'live-runtime' }],
+    })
+    expect(adapter.listenerCount()).toBe(1)
+  })
+
+  it('readSessionActivity reports queued waiting work before a run becomes working', async () => {
+    const adapter = createAdapter()
+    const run = deferred<void>()
+    adapter.readSnapshot().isStreaming = false
+    adapter.prompt = vi.fn(() => run.promise)
+    const { service } = createService(adapter)
+
+    await expect(service.prompt(ctx, 's1', { message: 'wait', clientNonce: 'nonce-wait' })).resolves.toMatchObject({ accepted: true })
+    await expect(service.readSessionActivity(ctx, { sessionIds: ['s1'] })).resolves.toMatchObject({
+      activities: [{ sessionId: 's1', status: 'queued', source: 'live-runtime' }],
+    })
+
+    adapter.readSnapshot().isStreaming = true
+    await expect(service.readSessionActivity(ctx, { sessionIds: ['s1'] })).resolves.toMatchObject({
+      activities: [{ sessionId: 's1', status: 'working', source: 'live-runtime' }],
+    })
+    run.resolve()
+  })
+
+  it('readSessionActivity reports live retrying and error states', async () => {
+    const retrying = createAdapter()
+    retrying.readSnapshot().isStreaming = false
+    retrying.readSnapshot().isRetrying = true
+    const retryService = createService(retrying).service
+    await retryService.subscribe(ctx, 's1', 0, () => {})
+    await expect(retryService.readSessionActivity(ctx, { sessionIds: ['s1'] })).resolves.toMatchObject({
+      activities: [{ sessionId: 's1', status: 'working', source: 'live-runtime' }],
+    })
+
+    const errored = createAdapter()
+    errored.readSnapshot().isStreaming = false
+    errored.readSnapshot().state = { errorMessage: 'model failed' }
+    const errorService = createService(errored).service
+    await errorService.subscribe(ctx, 's1', 0, () => {})
+    await expect(errorService.readSessionActivity(ctx, { sessionIds: ['s1'] })).resolves.toMatchObject({
+      activities: [{ sessionId: 's1', status: 'error', source: 'live-runtime' }],
+    })
+  })
+
   it('manageSessions defaults rename to the executing session and authorizes explicit IDs through rename', async () => {
     const rename = vi.fn(async (_ctx, sessionId: string, title: string) => ({
       id: sessionId,

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -9,6 +9,9 @@ import type {
   ManageSessionsInput,
   ManageSessionsOptions,
   ManageSessionsResult,
+  SessionActivityEntry,
+  SessionActivityInput,
+  SessionActivityResult,
   PiChatEventStreamResult,
   PiChatEventSubscriber,
   PiChatSessionService,
@@ -32,6 +35,7 @@ import {
   parseManageSessionsInput,
   sessionManagementInvalidError,
 } from '../sessionManagement'
+import { normalizeSessionActivityInput } from '../sessionActivity'
 
 type PiNativeHarness = AgentHarness & {
   getPiSessionAdapter?: (input: AgentSendInput, ctx: RunContext) => Promise<PiAgentSessionAdapter>
@@ -215,6 +219,30 @@ export class HarnessPiChatService implements PiChatSessionService {
     return this.lifecycle.run(() => this.deleteSessionBeforeDispose(ctx, sessionId))
   }
 
+  async readSessionActivity(
+    ctx: PiSessionRequestContext,
+    input: SessionActivityInput = {},
+  ): Promise<SessionActivityResult> {
+    return this.lifecycle.run(async () => {
+      const normalized = normalizeSessionActivityInput(input)
+      const sessionCtx = toSessionCtx(ctx)
+      const activityScope = normalized.sessionIds
+        ? await this.loadRequestedActivitySessions(sessionCtx, normalized.sessionIds)
+        : {
+            sessions: await this.sessionStore.list(sessionCtx, { limit: normalized.limit, offset: normalized.offset }),
+            omittedSessionIds: [],
+          }
+
+      return {
+        activities: activityScope.sessions.map((session) => this.activityForSession(ctx, session)),
+        omittedSessionIds: activityScope.omittedSessionIds,
+        limit: normalized.limit,
+        offset: normalized.offset,
+        count: activityScope.sessions.length,
+      }
+    })
+  }
+
   async manageSessions(
     ctx: PiSessionRequestContext,
     input: ManageSessionsInput,
@@ -301,6 +329,57 @@ export class HarnessPiChatService implements PiChatSessionService {
 
   async readState(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot> {
     return this.lifecycle.run(() => this.readStateBeforeDispose(ctx, sessionId))
+  }
+
+  private async loadRequestedActivitySessions(
+    ctx: SessionCtx,
+    sessionIds: string[],
+  ): Promise<{ sessions: SessionSummary[]; omittedSessionIds: string[] }> {
+    const loaded = await Promise.all(sessionIds.map(async (sessionId) => {
+      try {
+        return { session: await this.sessionStore.load(ctx, sessionId) }
+      } catch (error) {
+        if (isSessionAccessDeniedOrMissing(error, sessionId)) return { omittedSessionId: sessionId }
+        throw error
+      }
+    }))
+    return {
+      sessions: loaded.flatMap((entry) => entry.session ? [entry.session] : []),
+      omittedSessionIds: loaded.flatMap((entry) => entry.omittedSessionId ? [entry.omittedSessionId] : []),
+    }
+  }
+
+  private activityForSession(ctx: PiSessionRequestContext, session: SessionSummary): SessionActivityEntry {
+    const sessionKey = this.sessionKey(ctx, session.id)
+    const channel = this.channels.get(sessionKey)
+    if (!channel) {
+      // In hosted/multi-runtime deployments there is no shared live registry in
+      // this service. A session not owned by this process is therefore reported
+      // as persisted idle instead of claiming to detect standalone Pi activity.
+      return { sessionId: session.id, status: 'idle', source: 'persisted', updatedAt: session.updatedAt }
+    }
+    return {
+      sessionId: session.id,
+      status: this.activityStatusForLiveChannel(sessionKey, channel),
+      source: 'live-runtime',
+      updatedAt: session.updatedAt,
+    }
+  }
+
+  private activityStatusForLiveChannel(sessionKey: string, channel: LiveSessionChannel): SessionActivityEntry['status'] {
+    if (this.activeSyntheticPromptErrors.has(sessionKey)) return 'error'
+    const snapshot = channel.adapter.readSnapshot()
+    const state = snapshot.state
+    if (
+      typeof state === 'object' &&
+      state !== null &&
+      'errorMessage' in state &&
+      typeof (state as { errorMessage?: unknown }).errorMessage === 'string' &&
+      (state as { errorMessage?: string }).errorMessage!.length > 0
+    ) return 'error'
+    if (snapshot.isStreaming || snapshot.isRetrying) return 'working'
+    if (this.activePromptRuns.has(sessionKey) || snapshot.pendingMessageCount > 0 || snapshot.followUpMessages.length > 0) return 'queued'
+    return 'idle'
   }
 
   private async readStateBeforeDispose(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot> {
@@ -920,12 +999,16 @@ function rejectedReasons(results: PromiseSettledResult<unknown>[]): unknown[] {
 }
 
 function normalizeSessionAccessError(error: unknown, sessionId: string): unknown {
-  if ((error as { code?: unknown })?.code === ErrorCode.enum.SESSION_NOT_FOUND || isPlainSessionNotFound(error, sessionId)) {
+  if (isSessionAccessDeniedOrMissing(error, sessionId)) {
     return Object.assign(new Error('session not found'), {
       code: ErrorCode.enum.SESSION_NOT_FOUND,
     })
   }
   return error
+}
+
+function isSessionAccessDeniedOrMissing(error: unknown, sessionId: string): boolean {
+  return (error as { code?: unknown })?.code === ErrorCode.enum.SESSION_NOT_FOUND || isPlainSessionNotFound(error, sessionId)
 }
 
 function isPlainSessionNotFound(error: unknown, sessionId: string): boolean {

--- a/packages/agent/src/server/sessionActivity.ts
+++ b/packages/agent/src/server/sessionActivity.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod'
+import { ErrorCode } from '../shared/error-codes'
+import type { SessionActivityInput } from '../core/piChatSessionService'
+
+export const SESSION_ACTIVITY_MAX_LIMIT = 100
+export const SESSION_ACTIVITY_DEFAULT_LIMIT = 50
+export const SESSION_ACTIVITY_MAX_IDS = 100
+
+const SessionActivityIdSchema = z.string().min(1).max(128).regex(/^[a-zA-Z0-9_-]+$/)
+
+export const SessionActivityInputSchema: z.ZodType<SessionActivityInput, z.ZodTypeDef, unknown> = z.object({
+  sessionIds: z.array(SessionActivityIdSchema).min(1).max(SESSION_ACTIVITY_MAX_IDS).optional(),
+  limit: z.number().int().min(1).max(SESSION_ACTIVITY_MAX_LIMIT).optional(),
+  offset: z.number().int().nonnegative().optional(),
+}).strict().superRefine((input, ctx) => {
+  if (input.sessionIds && (input.limit !== undefined || input.offset !== undefined)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'sessionIds cannot be combined with limit or offset',
+      path: ['sessionIds'],
+    })
+  }
+})
+
+export function normalizeSessionActivityInput(input: SessionActivityInput): Required<Pick<SessionActivityInput, 'limit' | 'offset'>> & { sessionIds?: string[] } {
+  const parsed = SessionActivityInputSchema.safeParse(input)
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0]
+    throw Object.assign(new Error(issue?.message ?? 'invalid session activity request'), {
+      code: ErrorCode.enum.BRIDGE_COMMAND_INVALID,
+      statusCode: 400,
+      retryable: false,
+      ...(issue?.path.length ? { field: issue.path.map(String).join('.') } : {}),
+    })
+  }
+  return {
+    ...(parsed.data.sessionIds ? { sessionIds: dedupeSessionIds(parsed.data.sessionIds) } : {}),
+    limit: parsed.data.limit ?? SESSION_ACTIVITY_DEFAULT_LIMIT,
+    offset: parsed.data.offset ?? 0,
+  }
+}
+
+function dedupeSessionIds(sessionIds: string[]): string[] {
+  return [...new Set(sessionIds)]
+}


### PR DESCRIPTION
## Summary
Adds bounded, authorized project-session activity reads without cold-starting Pi sessions.

## Issue / Slice
Closes #611. Stacked on #659.

## What Changed
- Authenticated bulk activity endpoint for explicit IDs or bounded inventory pages.
- Stable `idle | queued | working | error` status and `live-runtime | persisted` source.
- Existing local Boring runtime channels report live activity even when panes are closed.
- Persisted/no-local/nonlocal hosted and standalone Pi sessions safely return `idle` / `persisted`; no false active claim.

## Proof
- Exact command: `pnpm --filter @hachej/boring-agent exec vitest run src/server/pi-chat/__tests__/harnessPiChatService.test.ts src/server/http/routes/__tests__/piChat.test.ts` — 69 tests passed; no type errors.
- Exact command: `pnpm --filter @hachej/boring-agent typecheck` — passed.
- Exact command: `bash scripts/check-invariants.sh packages/agent` — passed.

## Review
- Standards (Terra): READY.
- Spec/security (Sol): READY.
- Reviewed SHA: `aa8b45b1e`.

## Risk / Rollback
Live activity is intentionally process-local. Hosted activity owned by another runtime is safely `persisted`/`idle` until a shared registry or enforced affinity exists. Roll back this stacked PR to remove the endpoint.

## Next
Depends on #659 and #615; ready for review after its base lands.
