### PR TITLE
feat(391-P8): golden-path timing + invariant gates (pull-forward slice)

### DIFF
--- a/.github/workflows/invariants.yml
+++ b/.github/workflows/invariants.yml
@@ -19,3 +19,32 @@ jobs:
 
       - name: Assert workflow actions are pinned to commit SHAs
         run: bash scripts/check-action-pins.sh
+
+  runtime-refactor-p8:
+    name: Runtime Refactor P8
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22.19.0
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Run package invariant scripts
+        run: pnpm lint:invariants
+
+      - name: Run P8 golden-path and remaining repository invariants
+        run: pnpm check:golden-path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,9 @@ jobs:
         run: |
           tag="${{ github.event.release.tag_name }}"
           expected="${tag#v}"
-          actual=$(node -p "require('./packages/cli/package.json').version")
+          actual=$(node -p "require('./package.json').version")
           if [ "$expected" != "$actual" ]; then
-            echo "Tag $tag (=> $expected) does not match package version $actual"
+            echo "Tag $tag (=> $expected) does not match root package version $actual"
             echo "Bump packages with: node scripts/version.mjs <patch|minor|major>"
             exit 1
           fi

--- a/agents/golden-path/agent.json
+++ b/agents/golden-path/agent.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": 1,
+  "definitionId": "golden-path",
+  "version": "1.0.0",
+  "label": "Golden path timing fixture",
+  "instructionsRef": "instructions.md",
+  "capabilityRequirements": [
+    "filesystem:read"
+  ],
+  "toolRefs": [
+    "workspace.inspect"
+  ],
+  "skillRefs": [
+    "golden-path"
+  ]
+}

--- a/agents/golden-path/instructions.md
+++ b/agents/golden-path/instructions.md
@@ -1,0 +1,3 @@
+You are the checked-in fixture agent for the #391 P8 golden-path timing slice.
+Keep responses short and inspect the authorized workspace context before making
+changes.

--- a/docs/issues/391/runtime-refactor/golden-path.json
+++ b/docs/issues/391/runtime-refactor/golden-path.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.1.80",
+  "date": "2026-07-12T11:15:19.117Z",
+  "seconds": {
+    "compileAgentDirectory": 0.017525,
+    "resolveAgentDeployment": 0.003937,
+    "total": 0.021486
+  },
+  "stagesCovered": [
+    "A1 compileAgentDirectory (#624)",
+    "P6-R resolveAgentDeployment (#647)"
+  ],
+  "stagesPending": [
+    "host-publication (D1)",
+    "live-binding"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "name": "boring-ui-v2",
+  "version": "0.1.80",
   "type": "module",
   "scripts": {
     "build": "pnpm -r --workspace-concurrency=4 run build",
@@ -13,6 +14,8 @@
     "lint": "pnpm check:generated-artifacts && pnpm audit:imports",
     "lint:invariants": "pnpm --dir packages/agent run lint:invariants && pnpm --filter @hachej/boring-bash run check:invariants && pnpm --filter @hachej/boring-sandbox run check:invariants && pnpm lint:workspace-plugin-invariants",
     "lint:workspace-plugin-invariants": "pnpm --filter @hachej/boring-workspace run lint:plugin-invariants",
+    "golden-path:timing": "pnpm --filter @hachej/boring-agent exec tsx ../../scripts/golden-path-timing.mjs",
+    "check:golden-path": "node scripts/check-golden-path-invariants.mjs",
     "audit:imports": "pnpm tsx scripts/audit-imports.ts",
     "audit:publish-manifests": "node scripts/audit-publish-manifests.mjs",
     "audit:release-staging": "node scripts/check-release-staging.mjs",

--- a/packages/agent/src/server/__tests__/createAgent.test.ts
+++ b/packages/agent/src/server/__tests__/createAgent.test.ts
@@ -70,7 +70,7 @@ describe('createAgent', () => {
   it('rejects a missing or non-adapter runtime with a stable config error', () => {
     const invalidConfigs = [
       {},
-      { runtime: 'none' },
+      { runtime: 'invalid-runtime' },
       { runtime: { id: '' } },
       { runtime: { id: 'test-runtime', dispose: true } },
     ]

--- a/packages/agent/src/server/createAgentApp.ts
+++ b/packages/agent/src/server/createAgentApp.ts
@@ -4,13 +4,19 @@ import type { AgentTool } from '../shared/tool'
 import type { AgentCoreHarnessFactory, AgentHarness, AgentHarnessFactory } from '../shared/harness'
 import type { TelemetrySink } from '../shared/telemetry'
 import { getEnv } from './config/env'
-import type { RuntimeBundle, RuntimeFilesystemBinding, RuntimeModeAdapter, RuntimeModeId } from './runtime/mode'
-import { getOptionalRuntimeBundleStorageRoot } from './runtime/mode'
+import {
+  getOptionalRuntimeBundleStorageRoot,
+  type RuntimeBundle,
+  type RuntimeFilesystemBinding,
+  type RuntimeModeAdapter,
+  type RuntimeModeId,
+} from './runtime/mode'
 import { withRuntimeEnvContributions, type RuntimeEnvContribution } from './runtimeEnvContributions'
 import { resolveMode, autoDetectMode } from './runtime/resolveMode'
 import { createPiCodingAgentHarness, withPiHarnessDefaults } from './harness/pi-coding-agent/createHarness'
 import type { PiHarnessOptions } from './harness/pi-coding-agent/createHarness'
 import type { WorkspaceProvisioningResult } from './workspace/provisioning'
+import { createNodeWorkspace } from './workspace/createNodeWorkspace'
 import { loadPlugins } from './harness/pi-coding-agent/pluginLoader'
 import { buildFilesystemAgentTools } from './tools/filesystem'
 import { buildHarnessAgentTools } from './tools/harness'
@@ -353,6 +359,10 @@ async function createWorkspaceAgentAppProfile(
         })
       }
     : undefined
+  const gitStorageRoot = getOptionalRuntimeBundleStorageRoot(runtimeBundle)
+  const gitWorkspace = gitStorageRoot === undefined
+    ? runtimeBundle.workspace
+    : createNodeWorkspace(gitStorageRoot)
 
   return {
     runtimeMode: resolvedMode,
@@ -377,12 +387,12 @@ async function createWorkspaceAgentAppProfile(
       // File search shares the same bound implementation as the model tool.
       search: { fileSearch: runtimeBundle.fileSearch },
       // Git metadata resolves against host storage, not a sandbox-internal cwd.
-      git: { getWorkspaceRoot: () => getOptionalRuntimeBundleStorageRoot(runtimeBundle) },
+      git: { workspace: gitWorkspace },
     },
     chat: { service: agentRuntime.service as PiChatSessionService },
     systemPrompt: { harness },
     skills: {
-      workspaceRoot,
+      workspace: createNodeWorkspace(workspaceRoot),
       additionalSkillPaths: runtimePi.additionalSkillPaths,
       piPackages: runtimePi.packages,
       noSkills: runtimePi.noSkills,

--- a/packages/agent/src/server/http/routes/__tests__/git.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/git.test.ts
@@ -2,6 +2,7 @@ import Fastify from 'fastify'
 import { afterEach, expect, test, vi } from 'vitest'
 import { gitRoutes } from '../git'
 import { __gitTestUtils } from '../../../git/gitFileUrl'
+import { createNodeWorkspace } from '../../../workspace/createNodeWorkspace'
 
 afterEach(() => {
   vi.restoreAllMocks()
@@ -10,7 +11,7 @@ afterEach(() => {
 function buildApp(workspaceRoot?: string) {
   const app = Fastify({ logger: false })
   app.register(gitRoutes, {
-    getWorkspaceRoot: workspaceRoot === undefined ? undefined : () => workspaceRoot,
+    workspace: workspaceRoot === undefined ? undefined : createNodeWorkspace(workspaceRoot),
   })
   return app
 }

--- a/packages/agent/src/server/http/routes/__tests__/skills.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/skills.test.ts
@@ -1,6 +1,7 @@
 import Fastify from 'fastify'
 import { describe, test, expect } from 'vitest'
 import { skillsRoutes } from '../skills'
+import { createNodeWorkspace } from '../../../workspace/createNodeWorkspace'
 
 function buildApp(opts: Parameters<typeof skillsRoutes>[1]) {
   const app = Fastify({ logger: false })
@@ -10,7 +11,7 @@ function buildApp(opts: Parameters<typeof skillsRoutes>[1]) {
 
 describe('GET /api/v1/agent/skills', () => {
   test('returns skills array (possibly empty) for a workspace root', async () => {
-    const app = await buildApp({ workspaceRoot: process.cwd(), noSkills: true })
+    const app = await buildApp({ workspace: createNodeWorkspace(process.cwd()), noSkills: true })
 
     const res = await app.inject({ method: 'GET', url: '/api/v1/agent/skills' })
 
@@ -26,8 +27,8 @@ describe('GET /api/v1/agent/skills', () => {
 
   test('surfaces an error field instead of silently swallowing failures', async () => {
     const app = await buildApp({
-      workspaceRoot: process.cwd(),
-      getWorkspaceRoot: () => {
+      workspace: createNodeWorkspace(process.cwd()),
+      getWorkspace: () => {
         throw new Error('boom resolving workspace root')
       },
     })

--- a/packages/agent/src/server/http/routes/git.ts
+++ b/packages/agent/src/server/http/routes/git.ts
@@ -1,5 +1,7 @@
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+import type { Workspace } from '../../../shared/workspace'
 import { resolveGitFileUrl } from '../../git/gitFileUrl'
+import { getNodeWorkspaceHostRoot } from '../../workspace/createNodeWorkspace'
 import {
   ERROR_CODE_INTERNAL,
   ERROR_CODE_INVALID_PATH,
@@ -7,9 +9,10 @@ import {
 } from '../middleware'
 
 export interface GitRouteOptions {
-  // Resolve the workspace root per-request. Called lazily inside the handler so
+  workspace?: Workspace
+  // Resolve the workspace per-request. Called lazily inside the handler so
   // unrelated routes don't pay the cost of provisioning the runtime binding.
-  getWorkspaceRoot?: (request: FastifyRequest) => string | undefined | Promise<string | undefined>
+  getWorkspace?: (request: FastifyRequest) => Workspace | Promise<Workspace>
 }
 
 function requirePath(value: unknown, reply: FastifyReply): string | null {
@@ -34,8 +37,10 @@ export function gitRoutes(
   done: (err?: Error) => void,
 ): void {
   async function resolveWorkspaceRoot(request: FastifyRequest): Promise<string | undefined> {
-    if (opts.getWorkspaceRoot) return await opts.getWorkspaceRoot(request)
-    return (request as { workspaceRoot?: string }).workspaceRoot
+    const workspace = opts.getWorkspace
+      ? await opts.getWorkspace(request)
+      : opts.workspace
+    return workspace === undefined ? undefined : getNodeWorkspaceHostRoot(workspace)
   }
 
   app.get('/api/v1/git/file-url', async (request, reply) => {

--- a/packages/agent/src/server/http/routes/skills.ts
+++ b/packages/agent/src/server/http/routes/skills.ts
@@ -17,6 +17,7 @@ import {
   loadSkills,
 } from '@mariozechner/pi-coding-agent'
 import type { PiPackageSource } from '../../piPackages'
+import type { Workspace } from '../../../shared/workspace'
 import { createResourceSettingsManager, withPiHarnessDefaults } from '../../harness/pi-coding-agent/createHarness'
 
 export interface SkillSummary {
@@ -43,11 +44,11 @@ function pathForWorkspaceEditor(workspaceRoot: string, filePath: string): string
 }
 
 export interface SkillsRoutesOptions {
-  workspaceRoot: string
+  workspace?: Workspace
   additionalSkillPaths?: string[]
   piPackages?: PiPackageSource[]
   noSkills?: boolean
-  getWorkspaceRoot?: (request: FastifyRequest) => string | Promise<string>
+  getWorkspace?: (request: FastifyRequest) => Workspace | Promise<Workspace>
   getAdditionalSkillPaths?: (request: FastifyRequest) => string[] | undefined | Promise<string[] | undefined>
   getPiPackages?: (request: FastifyRequest) => PiPackageSource[] | undefined | Promise<PiPackageSource[] | undefined>
   getNoSkills?: (request: FastifyRequest) => boolean | undefined | Promise<boolean | undefined>
@@ -61,9 +62,11 @@ export function skillsRoutes(
   const cached = new Map<string, { skills: SkillSummary[]; expiresAt: number }>()
 
   async function resolveSkillsForRequest(request: FastifyRequest, refresh = false) {
-    const workspaceRoot = opts.getWorkspaceRoot
-      ? await opts.getWorkspaceRoot(request)
-      : opts.workspaceRoot
+    const workspace = opts.getWorkspace
+      ? await opts.getWorkspace(request)
+      : opts.workspace
+    if (!workspace) throw new Error('skills route requires workspace or getWorkspace')
+    const workspaceRoot = workspace.root
     const additionalSkillPaths = opts.getAdditionalSkillPaths
       ? await opts.getAdditionalSkillPaths(request)
       : opts.additionalSkillPaths

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -7,9 +7,15 @@ import type { SandboxHandleStore } from '../shared/sandbox-handle-store'
 import type { TelemetrySink } from '../shared/telemetry'
 import { AuthStorage, ModelRegistry } from '@mariozechner/pi-coding-agent'
 import { getEnv } from './config/env'
-import type { RuntimeBundle, RuntimeFilesystemBinding, RuntimeModeAdapter, RuntimeModeId } from './runtime/mode'
-import { getOptionalRuntimeBundleStorageRoot } from './runtime/mode'
+import {
+  getOptionalRuntimeBundleStorageRoot,
+  type RuntimeBundle,
+  type RuntimeFilesystemBinding,
+  type RuntimeModeAdapter,
+  type RuntimeModeId,
+} from './runtime/mode'
 import { getBoringAgentRuntimePaths, type BoringAgentRuntimePaths } from './workspace/runtimeLayout'
+import { createNodeWorkspace } from './workspace/createNodeWorkspace'
 import type { WorkspaceProvisioningAdapter, WorkspaceProvisioningResult } from './workspace/provisioning'
 import type { Workspace } from '../shared/workspace'
 import { ErrorCode } from '../shared/error-codes'
@@ -1228,7 +1234,13 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     getFileSearch: async (request) => (await getBindingForRequest(request)).runtimeBundle.fileSearch,
   })
   await app.register(gitRoutes, {
-    getWorkspaceRoot: async (request) => getOptionalRuntimeBundleStorageRoot((await getBindingForRequest(request)).runtimeBundle),
+    getWorkspace: async (request) => {
+      const runtimeBundle = (await getBindingForRequest(request)).runtimeBundle
+      const storageRoot = getOptionalRuntimeBundleStorageRoot(runtimeBundle)
+      return storageRoot === undefined
+        ? runtimeBundle.workspace
+        : createNodeWorkspace(storageRoot)
+    },
   })
   await app.register(piChatRoutes, {
     getService: async (request) => {
@@ -1244,7 +1256,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     filterModels: opts.filterModels,
   })
   await app.register(skillsRoutes, {
-    workspaceRoot,
+    workspace: staticBinding ? createNodeWorkspace(workspaceRoot) : undefined,
     additionalSkillPaths: [
       ...(staticBinding?.runtimeProvisioning?.skillPaths ?? []),
       ...(opts.pi?.additionalSkillPaths ?? []),
@@ -1253,9 +1265,9 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     // Undefined is fine: skillsRoutes resolves it through the canonical
     // harness policy (withPiHarnessDefaults), same as the factory above.
     noSkills: opts.pi?.noSkills,
-    getWorkspaceRoot: staticBinding
+    getWorkspace: staticBinding
       ? undefined
-      : async (request) => (await getSkillsScopeForRequest(request)).root,
+      : async (request) => createNodeWorkspace((await getSkillsScopeForRequest(request)).root),
     getAdditionalSkillPaths: staticBinding && !hasRuntimeProvisioningInput
       ? undefined
       : async (request) => {

--- a/scripts/check-golden-path-invariants.mjs
+++ b/scripts/check-golden-path-invariants.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { spawnSync } from "node:child_process"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const goldenPath = resolve(repoRoot, "docs/issues/391/runtime-refactor/golden-path.json")
+const expectedPending = ["host-publication (D1)", "live-binding"]
+let failed = false
+
+function fail(message) {
+  failed = true
+  console.error(`[p8] FAIL ${message}`)
+}
+
+function pass(message) {
+  console.log(`[p8] PASS ${message}`)
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"))
+}
+
+function assertGoldenPathJson() {
+  const rootPackage = readJson(resolve(repoRoot, "package.json"))
+  const golden = readJson(goldenPath)
+
+  if (typeof rootPackage.version !== "string" || rootPackage.version.length === 0) {
+    fail("root package.json must declare version")
+  } else if (golden.version !== rootPackage.version) {
+    fail(`golden-path.json version ${golden.version} differs from root package.json ${rootPackage.version}`)
+  } else {
+    pass(`golden-path version matches root package.json (${rootPackage.version})`)
+  }
+
+  const pending = Array.isArray(golden.stagesPending) ? golden.stagesPending : null
+  if (JSON.stringify(pending) !== JSON.stringify(expectedPending)) {
+    fail(`stagesPending must be exactly ${JSON.stringify(expectedPending)}`)
+  } else {
+    pass("stagesPending records D1/live-binding as pending")
+  }
+
+  const seconds = golden.seconds && typeof golden.seconds === "object" ? golden.seconds : null
+  for (const key of ["compileAgentDirectory", "resolveAgentDeployment", "total"]) {
+    if (typeof seconds?.[key] !== "number" || seconds[key] < 0) {
+      fail(`seconds.${key} must be a non-negative number`)
+    }
+  }
+  if (seconds) pass("golden-path seconds include compile, resolve, and total")
+}
+
+function runRg(label, pattern, paths, globs = [], options = {}) {
+  const result = spawnSync("rg", [
+    "-n",
+    "--no-heading",
+    "--color",
+    "never",
+    ...(options.multiline ? ["-U"] : []),
+    "-e",
+    pattern,
+    ...paths,
+    ...globs.flatMap((glob) => ["-g", glob]),
+  ], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  })
+
+  if (result.status === 0) {
+    fail(`${label}:\n${result.stdout.trimEnd()}`)
+  } else if (result.status === 1) {
+    pass(label)
+  } else {
+    failed = true
+    console.error(result.stderr || result.error?.message || `[p8] rg failed for ${label}`)
+  }
+}
+
+assertGoldenPathJson()
+
+runRg(
+  "no public runtime none residue outside historical docs",
+  "runtime\\s*:\\s*['\"]none['\"]|runtime\\s*:\\s*none",
+  ["."],
+  [
+    "!docs/issues/391/runtime-refactor/**",
+    "!docs/DECISIONS.md",
+    "!docs/plans/archive/**",
+    "!packages/**/docs/plans/archive/**",
+    "!**/node_modules/**",
+    "!**/dist/**",
+    "!**/.git/**",
+  ],
+)
+
+runRg(
+  "no node:* imports in src/shared/** not covered by package invariant scripts",
+  "from\\s+['\"]node:|import\\s+['\"]node:|import\\s*\\(\\s*['\"]node:|require\\(\\s*['\"]node:",
+  ["packages", "apps", "plugins"],
+  [
+    "**/src/shared/**",
+    "!packages/agent/src/shared/**",
+    "!packages/boring-bash/src/shared/**",
+    "!packages/boring-sandbox/src/shared/**",
+    "!**/__tests__/**",
+    "!packages/agent/test-fixtures/invariants-bad/**",
+    "!**/node_modules/**",
+    "!**/dist/**",
+  ],
+)
+
+runRg(
+  "no Buffer references in src/shared/** not covered by package invariant scripts",
+  "\\bBuffer\\b",
+  ["packages", "apps", "plugins"],
+  [
+    "**/src/shared/**",
+    "!packages/agent/src/shared/**",
+    "!packages/boring-bash/src/shared/**",
+    "!packages/boring-sandbox/src/shared/**",
+    "!**/__tests__/**",
+    "!packages/agent/test-fixtures/invariants-bad/**",
+    "!**/node_modules/**",
+    "!**/dist/**",
+  ],
+)
+
+runRg(
+  "no raw-path HTTP route module signatures",
+  "^\\s*(getWorkspaceRoot|workspaceRoot|workspacePath|rootDir|rootPath|baseDir|cwd)\\??\\s*:\\s*[^\\n]*\\bstring\\b",
+  ["packages", "apps"],
+  [
+    "**/src/server/http/routes/**",
+    "**/src/server/routes/**",
+    "**/src/server/**/routes.ts",
+    "**/src/server/**/*Routes.ts",
+    "!**/registerAgentRoutes.ts",
+    "!**/__tests__/**",
+    "!**/node_modules/**",
+    "!**/dist/**",
+  ],
+)
+
+if (failed) process.exit(1)

--- a/scripts/check-release-staging.mjs
+++ b/scripts/check-release-staging.mjs
@@ -2,6 +2,8 @@
 import { execFileSync } from "node:child_process"
 
 const allowed = new Set([
+  "package.json",
+  "docs/issues/391/runtime-refactor/golden-path.json",
   "packages/core/package.json",
   "packages/plugin-cli/package.json",
   "packages/workspace/package.json",

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -19,7 +19,7 @@ case "$bump" in patch|minor|major) ;; *)
 esac
 
 # Refuse to bump from a dirty tree — the release commit must contain only
-# the version bumps so the tag points at a known state.
+# version markers and required generated release evidence.
 if ! git diff --quiet || ! git diff --cached --quiet; then
   echo "Working tree is dirty. Commit or stash first." >&2
   exit 1
@@ -38,13 +38,17 @@ if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
   exit 1
 fi
 
-before=$(node -p "require('./packages/cli/package.json').version")
+before=$(node -p "require('./package.json').version")
 node scripts/version.mjs "$bump"
-after=$(node -p "require('./packages/cli/package.json').version")
+after=$(node -p "require('./package.json').version")
 node scripts/version.mjs --check
+pnpm golden-path:timing
+pnpm check:golden-path
 pnpm audit:publish-manifests
 
 release_files=(
+  package.json
+  docs/issues/391/runtime-refactor/golden-path.json
   packages/core/package.json
   packages/plugin-cli/package.json
   packages/workspace/package.json

--- a/scripts/golden-path-timing.mjs
+++ b/scripts/golden-path-timing.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import { performance } from "node:perf_hooks"
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(scriptDir, "..")
+const outputPath = resolve(repoRoot, "docs/issues/391/runtime-refactor/golden-path.json")
+const sampleAgentDir = resolve(repoRoot, "agents/golden-path")
+const compositionDigest = `sha256:${"a".repeat(64)}`
+const stagesCovered = [
+  "A1 compileAgentDirectory (#624)",
+  "P6-R resolveAgentDeployment (#647)",
+]
+const stagesPending = ["host-publication (D1)", "live-binding"]
+
+function seconds(startMs, endMs) {
+  return Number(((endMs - startMs) / 1000).toFixed(6))
+}
+
+async function readRootVersion() {
+  const rootPackage = JSON.parse(await readFile(resolve(repoRoot, "package.json"), "utf8"))
+  if (typeof rootPackage.version !== "string" || rootPackage.version.length === 0) {
+    throw new Error("root package.json must declare version for golden-path timing")
+  }
+  return rootPackage.version
+}
+
+async function loadAgentDefinitionApi() {
+  const compiler = await import(pathToFileURL(resolve(
+    repoRoot,
+    "packages/agent/src/server/agentDefinition/compileAgentDirectory.ts",
+  )).href)
+  const resolver = await import(pathToFileURL(resolve(
+    repoRoot,
+    "packages/agent/src/server/agentDefinition/resolveAgentDeployment.ts",
+  )).href)
+  return {
+    compileAgentDirectory: compiler.compileAgentDirectory,
+    resolveAgentDeployment: resolver.resolveAgentDeployment,
+  }
+}
+
+async function main() {
+  const version = await readRootVersion()
+  const {
+    compileAgentDirectory,
+    resolveAgentDeployment,
+  } = await loadAgentDefinitionApi()
+
+  const totalStart = performance.now()
+  const compileStart = performance.now()
+  const bundle = await compileAgentDirectory(sampleAgentDir)
+  const compileEnd = performance.now()
+
+  const fixtureDeployment = {
+    deploymentId: "golden-path-eu",
+    version,
+    agentId: "default",
+    definition: {
+      definitionId: bundle.definition.definitionId,
+      version: bundle.definition.version,
+      digest: bundle.definitionDigest,
+    },
+  }
+  const fixtureBinding = {
+    workspaceId: "golden-path-workspace",
+    defaultDeploymentId: fixtureDeployment.deploymentId,
+    workspaceCompositionDigest: compositionDigest,
+  }
+
+  const resolveStart = performance.now()
+  await resolveAgentDeployment(bundle, fixtureDeployment, fixtureBinding)
+  const resolveEnd = performance.now()
+  const totalEnd = performance.now()
+
+  const payload = {
+    version,
+    date: new Date().toISOString(),
+    seconds: {
+      compileAgentDirectory: seconds(compileStart, compileEnd),
+      resolveAgentDeployment: seconds(resolveStart, resolveEnd),
+      total: seconds(totalStart, totalEnd),
+    },
+    stagesCovered,
+    stagesPending,
+  }
+
+  await mkdir(dirname(outputPath), { recursive: true })
+  await writeFile(outputPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8")
+  console.log(`wrote ${outputPath}`)
+  console.log(JSON.stringify(payload.seconds))
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error))
+  process.exit(1)
+})

--- a/scripts/version.mjs
+++ b/scripts/version.mjs
@@ -1,5 +1,5 @@
 /**
- * Bump version across all publishable packages.
+ * Bump version across the root release marker and all publishable packages.
  * Usage: node scripts/version.mjs [patch|minor|major]
  */
 import { readFileSync, writeFileSync } from "node:fs"
@@ -33,6 +33,11 @@ const PUBLISHABLE = [
   "plugins/boring-governance",
 ]
 
+const VERSIONED_PACKAGES = [
+  ".",
+  ...PUBLISHABLE,
+]
+
 function readJson(path) {
   return JSON.parse(readFileSync(path, "utf8"))
 }
@@ -48,26 +53,26 @@ function bumpVersion(version, type) {
   return `${major}.${minor}.${patch + 1}`
 }
 
-function readPublishableVersions() {
-  return PUBLISHABLE.map((pkg) => {
+function readVersionedPackages() {
+  return VERSIONED_PACKAGES.map((pkg) => {
     const json = readJson(resolve(root, pkg, "package.json"))
     return { dir: pkg, name: json.name, version: json.version }
   })
 }
 
 function assertAlignedVersions() {
-  const versions = readPublishableVersions()
+  const versions = readVersionedPackages()
   const unique = new Set(versions.map((pkg) => pkg.version))
   if (unique.size === 1) return versions[0].version
 
-  console.error("Publishable package versions are not aligned:")
+  console.error("Root and publishable package versions are not aligned:")
   for (const pkg of versions) console.error(`  ${pkg.name} (${pkg.dir}) ${pkg.version}`)
   process.exit(1)
 }
 
 if (process.argv[2] === "--check") {
   const current = assertAlignedVersions()
-  console.log(`Publishable package versions are aligned at ${current}`)
+  console.log(`Root and publishable package versions are aligned at ${current}`)
   process.exit(0)
 }
 
@@ -82,7 +87,7 @@ const next = bumpVersion(current, type)
 
 console.log(`${current} → ${next} (${type})`)
 
-for (const pkg of PUBLISHABLE) {
+for (const pkg of VERSIONED_PACKAGES) {
   const path = resolve(root, pkg, "package.json")
   const json = readJson(path)
   json.version = next


### PR DESCRIPTION
## Summary
- add a checked-in sample agent and real wall-clock timing for A1 compilation plus P6-R resolution
- record honest partial coverage in golden-path.json, with D1 host publication and live binding pending
- extend the existing invariants workflow with version-staleness and runtime/shared/route gates
- keep the root release version and generated timing evidence fresh during release cuts
- replace raw workspace-root route seams with Workspace adapters while preserving host storage behavior

## Scope
Issue #391, P8 pull-forward slice. No dashboards, test platform, synthetic monitoring, or plan-file edits.

## Proof
- pnpm golden-path:timing — generated committed 0.021486s total measurement
- pnpm check:golden-path — pass
- pnpm lint:invariants — pass
- pnpm --filter @hachej/boring-ui-kit build — pass
- pnpm --filter @hachej/boring-agent test — 203 files, 1884 tests passed; 6 skipped; no type errors
- pnpm --filter @hachej/boring-agent run typecheck — pass
- pnpm lint — pass
- pnpm check:action-pins — pass
- node scripts/version.mjs --check — pass at 0.1.80
- bash -n scripts/cut-release.sh — pass
- node scripts/check-release-staging.mjs — pass
- git diff --check — pass

A broader pnpm test run built all workspace packages, then stopped in unrelated packages/core PostgreSQL suites because the local server rejected ambient ubuntu credentials. Before that environment failure, 85 core test files and 930 tests passed. The changed agent package was rerun separately and is fully green.

## Review
- claude-opus-4-8 blocking review: correct against the P8 guardrails; two low hardening notes were reviewed and intentionally not expanded because the slice requires cheap greps and forbids a test platform, and broad path-string matching would flag legitimate relative request paths
- final author review: no actionable findings

## Risk / rollback
Low-to-moderate. Timing and CI/release changes are additive. Route signatures move to Workspace while retaining host storage-root semantics. Roll back this single commit if needed.

## Handoff
Ready for human review. Please focus on invariant coverage boundaries, release-version freshness, and the Workspace route adapter seams.