### PR TITLE
fix(agent): provider apiKey env references use pi-supported syntax

### DIFF
--- a/packages/agent/src/server/models/__tests__/modelConfig.test.ts
+++ b/packages/agent/src/server/models/__tests__/modelConfig.test.ts
@@ -80,7 +80,7 @@ describe('agent model env config', () => {
     expect(registered[0]?.provider).toBe('infomaniak')
     expect(registered[0]?.config).toMatchObject({
       baseUrl: 'https://api.infomaniak.com/2/ai/108321/openai/v1',
-      apiKey: '$INFOMANIAK_API_TOKEN',
+      apiKey: 'INFOMANIAK_API_TOKEN',
       api: 'openai-completions',
       models: [
         {
@@ -108,6 +108,37 @@ describe('agent model env config', () => {
       provider: 'infomaniak',
       id: 'Qwen/Qwen3.5-122B-A10B-FP8',
     })
+  })
+
+  it('registers provider apiKey values that resolve from env under pi-coding-agent\'s contract', () => {
+    // Mirrors @mariozechner/pi-coding-agent@0.75.5's resolveConfigValue:
+    // `config.startsWith('!') ? runCommand(config) : (process.env[config] ?? config)`.
+    // It does NOT strip a leading "$" — a `$`-prefixed apiKey value resolves
+    // to nothing and falls back to being sent as the literal Bearer token.
+    // This test would have caught the INFOMANIAK_API_TOKEN 401 regression.
+    function resolveLikePiCodingAgent(config: string, env: NodeJS.ProcessEnv): string {
+      if (config.startsWith('!')) throw new Error('command-form apiKey not exercised by this test')
+      return env[config] ?? config
+    }
+
+    process.env.BORING_AGENT_INFOMANIAK_PRODUCT_ID = '108321'
+    process.env.BORING_AGENT_INFOMANIAK_MODEL = 'Qwen/Qwen3.5-122B-A10B-FP8'
+    process.env.INFOMANIAK_API_TOKEN = 'super-secret-token'
+
+    const registered: Array<{ provider: string; config: { apiKey?: string } }> = []
+    const registry = {
+      registerProvider(provider: string, config: unknown) {
+        registered.push({ provider, config: config as { apiKey?: string } })
+      },
+    }
+
+    registerConfiguredModelProviders(registry as never)
+
+    const apiKeyConfig = registered[0]?.config.apiKey
+    expect(apiKeyConfig).toBeDefined()
+    const resolved = resolveLikePiCodingAgent(apiKeyConfig!, process.env)
+    expect(resolved).toBe('super-secret-token')
+    expect(resolved).not.toBe(apiKeyConfig) // sanity: value actually came from env, not passed through
   })
 
   it('supports encoded default model ids that contain colons', () => {

--- a/packages/agent/src/server/models/modelConfig.ts
+++ b/packages/agent/src/server/models/modelConfig.ts
@@ -97,7 +97,14 @@ function buildOpenAICompatibleProviderConfig(opts: {
 }): ProviderConfigInput {
   return {
     baseUrl: opts.baseUrl,
-    apiKey: `$${opts.apiKeyEnv}`,
+    // pi-coding-agent's resolveConfigValue (packages/agent's pinned
+    // @mariozechner/pi-coding-agent@0.75.5) resolves a provider apiKey by
+    // looking up `process.env[config]` directly — it does NOT strip a `$`
+    // prefix. A `$`-prefixed value (e.g. "$INFOMANIAK_API_TOKEN") misses the
+    // env lookup and falls back to sending the literal string as the Bearer
+    // token, causing provider 401s. The supported syntax is the bare env var
+    // name.
+    apiKey: opts.apiKeyEnv,
     api: 'openai-completions',
     models: opts.models.map((model) => ({
       id: model.id,


### PR DESCRIPTION
## Summary

- Live symptom on the Constellation VPS: the Infomaniak provider returned 401s because `@mariozechner/pi-coding-agent@0.75.5`'s `resolveConfigValue` resolves an `apiKey` string via `process.env[config]` directly — it does **not** strip a leading `$`. Our `buildOpenAICompatibleProviderConfig` registered `apiKey: \`$${apiKeyEnv}\`` (a `$`-prefixed env reference), so the env lookup missed and the literal string `$INFOMANIAK_API_TOKEN` was sent as the Bearer token.
- Confirmed by pulling and reading the actual 0.75.5 `resolve-config-value.js` source: unlike newer pi-coding-agent releases (0.80.x adds `$VAR`/`${VAR}`/`!cmd` template support), 0.75.5 — the version `packages/agent/package.json` pins exactly — only supports a bare env var name or a `!`-prefixed shell command.
- Fixed `buildOpenAICompatibleProviderConfig` in `packages/agent/src/server/models/modelConfig.ts` to register the bare env var name. This function is shared by both the Infomaniak provider and the generic custom-model provider (`BORING_AGENT_CUSTOM_MODEL_*`), so both are fixed. Repo-wide grep for other `$`-prefixed `apiKey`/env references in provider wiring turned up no other instances.
- Updated the existing test's stale assertion (it had been asserting the buggy `$INFOMANIAK_API_TOKEN` value) and added a new test that resolves the registered `apiKey` using pi-coding-agent's actual 0.75.5 resolution algorithm, asserting it yields the real token from env rather than the literal placeholder — this test would have caught the regression.

## Test plan

- [x] `pnpm -C packages/agent typecheck`
- [x] `pnpm -C packages/agent test` (full suite, 1885 passed / 6 skipped)
- [x] `pnpm -C packages/agent build`
- [x] `pnpm lint:invariants`

🤖 Generated with [Claude Code](https://claude.com/claude-code)