### PR TITLE
fix(workspace): render fs root switcher in chromeless Files pane; chrome search filters active root

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -1058,17 +1058,63 @@ export function FileTreePane({
       : debouncedQuery || undefined
 
   if (effectiveChromeless) {
+    // Single-root chromeless hosts (the common case: a plain "Files" tab with
+    // no alternate filesystem) render exactly as before — no wrapper, no
+    // switcher. Multi-root hosts still need a way to pick the active
+    // filesystem even though the pane itself owns no title/search chrome —
+    // that's the shell's job here. Render just the root switcher (no title,
+    // no per-root filter input — the shell's own search box covers that, see
+    // `effectiveSearchQuery` above) above the tree.
+    if (rootOptions.length <= 1) {
+      return (
+        <FileTreeView
+          key={`${activeFilesystem}:${activeRootDir}`}
+          rootDir={activeRootDir}
+          searchQuery={effectiveSearchQuery}
+          bridge={effectiveBridge}
+          filesystem={activeFilesystem}
+          access={activeAccess}
+          revealFileTreeRequest={effectiveRevealRequest}
+          className={cn("px-1 pt-1 [&_[role=treeitem]]:!indent-0", className)}
+        />
+      )
+    }
     return (
-      <FileTreeView
-        key={`${activeFilesystem}:${activeRootDir}`}
-        rootDir={activeRootDir}
-        searchQuery={effectiveSearchQuery}
-        bridge={effectiveBridge}
-        filesystem={activeFilesystem}
-        access={activeAccess}
-        revealFileTreeRequest={effectiveRevealRequest}
-        className={cn("px-1 pt-1 [&_[role=treeitem]]:!indent-0", className)}
-      />
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="shrink-0 px-1 pt-1">
+          <Select
+            value={activeFilesystem}
+            onValueChange={(value) => setSelectedFilesystem(value as FilesystemId)}
+          >
+            <SelectTrigger
+              size="sm"
+              className="h-7 w-full text-xs"
+              aria-label="File root"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {rootOptions.map((root) => (
+                <SelectItem key={root.filesystem} value={root.filesystem} className="text-xs">
+                  {root.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="min-h-0 flex-1">
+          <FileTreeView
+            key={`${activeFilesystem}:${activeRootDir}`}
+            rootDir={activeRootDir}
+            searchQuery={effectiveSearchQuery}
+            bridge={effectiveBridge}
+            filesystem={activeFilesystem}
+            access={activeAccess}
+            revealFileTreeRequest={effectiveRevealRequest}
+            className={cn("px-1 pt-1 [&_[role=treeitem]]:!indent-0", className)}
+          />
+        </div>
+      </div>
     )
   }
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -383,6 +383,86 @@ describe("FileTreePane", () => {
     expect(screen.queryByText(/Failed to load files/)).not.toBeInTheDocument()
   })
 
+  describe("chromeless mode", () => {
+    it("single-root chromeless renders only the tree — no switcher, no title, no filter input", async () => {
+      render(<FileTreePane chromeless />, { wrapper })
+
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+      expect(screen.queryByTestId("panel-chrome")).not.toBeInTheDocument()
+      expect(screen.queryByRole("combobox", { name: "File root" })).not.toBeInTheDocument()
+      expect(screen.queryByLabelText("Search files")).not.toBeInTheDocument()
+    })
+
+    it("multi-root chromeless renders the fs root dropdown without a duplicate title or per-root filter input", async () => {
+      mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
+        data: filesystem === "project_alpha"
+          ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
+          : sampleFiles,
+        isLoading: false,
+        isSuccess: true,
+        error: undefined,
+      }))
+
+      render(
+        <FileTreePane
+          chromeless
+          roots={[
+            { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+            { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readonly", searchPlaceholder: "Filter project files..." },
+          ]}
+        />,
+        { wrapper },
+      )
+
+      expect(await screen.findByRole("combobox", { name: "File root" })).toBeInTheDocument()
+      expect(screen.queryByTestId("panel-chrome")).not.toBeInTheDocument()
+      expect(screen.queryByLabelText("Search files")).not.toBeInTheDocument()
+      expect(screen.queryByPlaceholderText("Filter project files...")).not.toBeInTheDocument()
+
+      await selectRoot("Project")
+      await waitFor(() => expect(screen.getByText("handbook.md")).toBeInTheDocument())
+    })
+
+    it("forwards the chrome search query to whichever root is active, including after switching roots", async () => {
+      mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
+        data: filesystem === "project_alpha"
+          ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
+          : sampleFiles,
+        isLoading: false,
+        isSuccess: true,
+        error: undefined,
+      }))
+
+      render(
+        <FileTreePane
+          chromeless
+          searchQuery="index"
+          roots={[
+            { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+            { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readonly" },
+          ]}
+        />,
+        { wrapper },
+      )
+
+      // Default active root is "user" — the chrome query drives server search there.
+      await waitFor(() =>
+        expect(mockFileSearch).toHaveBeenCalledWith("*[Ii][Nn][Dd][Ee][Xx]*", 50),
+      )
+
+      // Switch to the "project_alpha" root while the same chrome search text stays set —
+      // this is the shell's own search box, which lives above the pane and is
+      // untouched by which root is selected inside it.
+      await selectRoot("Project")
+      await waitFor(() => expect(screen.getByText("handbook.md")).toBeInTheDocument())
+
+      // Non-"user" filesystems have no server search — the chrome query is forwarded
+      // straight to the tree's client-side filter, proving it targets whichever root
+      // is now active rather than staying stuck on the default root.
+      expect(screen.getByTestId("file-tree").getAttribute("data-search")).toBe("index")
+    })
+  })
+
   it("hides .boring-agent from the default tree view", async () => {
     mockFileList.mockReturnValue({
       data: [


### PR DESCRIPTION
## Summary
- The Files panel in chromeless hosts (e.g. Constellation) only exposed the
  multi-filesystem root dropdown (PR #651) in `FileTreePane`'s
  non-chromeless branch. Consumers with >1 root had to pass
  `chromeless: false` to get the dropdown, which also turned on the pane's
  own "Files" title + search input — duplicating the shell's chrome.
- `FileTreePane` now renders the root dropdown in chromeless mode too
  (only when `rootOptions.length > 1`), with no title bar and no per-root
  filter input. Single-root chromeless usage is byte-for-byte unchanged.
- The shell's own chrome search already flowed into `FileTreeView` via
  `activeFilesystem`/`activeRootDir`, which are driven by the same
  `selectedFilesystem` state the dropdown controls — so it already filters
  whichever root is active; added a regression test covering this
  (switch root, confirm the chrome query still applies).

## Test plan
- [x] `pnpm --filter @hachej/boring-workspace exec vitest run src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx` (67 passed, 3 new)
- [x] `pnpm --filter @hachej/boring-workspace run typecheck`
- [x] `pnpm --filter @hachej/boring-workspace run test` (full suite; 1 pre-existing unrelated jiti/plugin-loading flake in `createWorkspaceAgentServer.test.ts`, untouched by this diff)
- [x] `pnpm --filter @hachej/boring-workspace run build`
- [x] `pnpm run lint:invariants`

🤖 Generated with [Claude Code](https://claude.com/claude-code)