### PR TITLE
refactor(391): canonical resolvedDigest + unified digest/schema-issue plumbing

### DIFF
--- a/packages/agent/src/server/agentDefinition/__tests__/resolveAgentDeployment.test.ts
+++ b/packages/agent/src/server/agentDefinition/__tests__/resolveAgentDeployment.test.ts
@@ -264,6 +264,57 @@ describe('resolveAgentDeployment', () => {
     expect(withHostname.resolvedDigest).toBe(resolved.resolvedDigest)
   })
 
+  it('pins resolvedDigest to a golden vector for a fully-fixed fixture (canonicalStringify determinism)', async () => {
+    const goldenDefinition: AgentDefinition = {
+      schemaVersion: 1,
+      definitionId: 'golden-definition',
+      version: '1.0.0',
+      instructionsRef: 'instructions.md',
+    }
+    const asset = Object.freeze({
+      path: 'instructions.md',
+      digest: await createAgentAssetDigest('Golden fixture instructions.'),
+      content: 'Golden fixture instructions.',
+    })
+    const assets = Object.freeze([asset])
+    const goldenDefinitionDigest = await createAgentDefinitionDigest({
+      definition: goldenDefinition,
+      assets,
+    })
+    const goldenBundle: CompiledAgentBundle = Object.freeze({
+      definition: goldenDefinition,
+      definitionDigest: goldenDefinitionDigest,
+      assets,
+    })
+    const goldenDeployment: AgentDeployment = {
+      deploymentId: 'golden-deployment',
+      version: '1.0.0',
+      agentId: 'default',
+      definition: {
+        definitionId: goldenDefinition.definitionId,
+        version: goldenDefinition.version,
+        digest: goldenDefinitionDigest,
+      },
+    }
+    const goldenBinding = {
+      workspaceId: 'golden-workspace',
+      defaultDeploymentId: 'golden-deployment',
+      workspaceCompositionDigest: `sha256:${'a'.repeat(64)}` as Sha256Digest,
+    }
+
+    const resolved = await resolveAgentDeployment(goldenBundle, goldenDeployment, goldenBinding)
+
+    expect(goldenDefinitionDigest).toBe(
+      'sha256:f950bf76817802ef360873cac765adb649fb428be432fec601891b620b9593ed',
+    )
+    expect(resolved.deployment.digest).toBe(
+      'sha256:7bdfffa06038715e5a72ee2a2d5407ea75189213c2b59f090cca5c874e852c18',
+    )
+    expect(resolved.resolvedDigest).toBe(
+      'sha256:fac5e93763fadc3a69d8bd53bb84dff2fe975484662cf711b08bc65d0cefa4ce',
+    )
+  })
+
   it.each([
     ['workspaceId', ''],
     ['workspaceId', 'a'.repeat(257)],

--- a/packages/agent/src/server/agentDefinition/resolveAgentDeployment.ts
+++ b/packages/agent/src/server/agentDefinition/resolveAgentDeployment.ts
@@ -13,6 +13,7 @@ import {
   type CompiledAgentBundle,
   type Sha256Digest,
 } from '../../shared/agent-definition'
+import { canonicalStringify } from '../../shared/digest'
 import {
   AgentDefinitionErrorCode,
   AgentDeploymentErrorCode,
@@ -50,7 +51,7 @@ export async function createResolvedAgentDigest(input: ResolvedAgentDigestInput)
     const digestField = typeof field === 'string' ? field : 'workspaceId'
     throw invalidDeployment(digestField, `${digestField} is invalid`)
   }
-  return createAgentAssetDigest(JSON.stringify({ domain: RESOLVED_AGENT_DIGEST_DOMAIN, ...parsed.data }))
+  return createAgentAssetDigest(canonicalStringify({ domain: RESOLVED_AGENT_DIGEST_DOMAIN, ...parsed.data }))
 }
 
 export interface ResolvedAgent {

--- a/packages/agent/src/server/mcp/managedAgentDelegate.ts
+++ b/packages/agent/src/server/mcp/managedAgentDelegate.ts
@@ -1,8 +1,9 @@
-import { createHash, randomUUID } from 'node:crypto'
+import { randomUUID } from 'node:crypto'
 
 import type { Agent, AgentActor, AgentEvent } from '../../shared/events'
 import { ErrorCode, type ErrorCode as StableErrorCode } from '../../shared/error-codes'
 import type { BoringChatMessage, BoringChatPart } from '../../shared/chat'
+import { sha256Bytes } from '../../shared/digest'
 import type { SessionCtx } from '../../shared/session'
 import type { Stat, Workspace } from '../../shared/workspace'
 
@@ -746,7 +747,7 @@ async function resolveMarkdownArtifact(
   validateMarkdownContent(content)
   const artifact: ManagedAgentArtifact = {
     content,
-    sha256: sha256(bytes),
+    sha256: await sha256Bytes(bytes),
     byteSize,
     mediaType: MARKDOWN_MEDIA_TYPE,
     ...(candidate.title ? { title: candidate.title } : {}),
@@ -858,10 +859,6 @@ function validateMarkdownContent(content: string): void {
 
 function sameStat(left: Stat, right: Stat): boolean {
   return left.kind === right.kind && left.size === right.size && left.mtimeMs === right.mtimeMs
-}
-
-function sha256(bytes: Uint8Array): `sha256:${string}` {
-  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`
 }
 
 function safeDecodeArtifactPath(path: string): string {

--- a/packages/agent/src/shared/agent-consumption.ts
+++ b/packages/agent/src/shared/agent-consumption.ts
@@ -15,8 +15,8 @@
 
 import { z } from 'zod'
 
-import type { AgentSchemaIssue, AgentSchemaValidationResult } from './agent-definition'
-import { AgentConsumptionErrorCode, ErrorCode } from './error-codes'
+import { AgentConsumptionErrorCode } from './error-codes'
+import { SchemaValidationError, formatPath, type AgentSchemaIssue, type AgentSchemaValidationResult } from './schema-issue'
 
 const nonEmptyString = z.string().min(1)
 
@@ -201,22 +201,9 @@ export const AgentTaskSchema = z
   })
   .strict() satisfies z.ZodType<AgentTask, z.ZodTypeDef, unknown>
 
-function formatIssuePath(path: PropertyKey[]): string {
-  if (path.length === 0) return '<root>'
-  return path.reduce<string>(
-    (result, part) =>
-      typeof part === 'number'
-        ? `${result}[${part}]`
-        : result.length === 0
-          ? String(part)
-          : `${result}.${String(part)}`,
-    '',
-  )
-}
-
 function schemaMismatchIssues(issues: z.ZodIssue[]): AgentSchemaIssue<AgentConsumptionErrorCode>[] {
   return issues.map((issue) => {
-    const field = formatIssuePath(issue.path)
+    const field = formatPath(issue.path)
     return {
       code: AgentConsumptionErrorCode.enum.AGENT_CONSUMPTION_SCHEMA_MISMATCH,
       field,
@@ -235,16 +222,10 @@ export function validateAgentTask(
   return { valid: true, value: result.data }
 }
 
-export class AgentConsumptionValidationError extends Error {
-  readonly code = ErrorCode.enum.CONFIG_INVALID
-  readonly field: string
-  readonly validationCode: AgentConsumptionErrorCode
-
+export class AgentConsumptionValidationError extends SchemaValidationError<AgentConsumptionErrorCode> {
   constructor(issue: AgentSchemaIssue<AgentConsumptionErrorCode>) {
-    super(issue.message)
+    super(issue)
     this.name = 'AgentConsumptionValidationError'
-    this.field = issue.field
-    this.validationCode = issue.code
   }
 }
 

--- a/packages/agent/src/shared/agent-definition.ts
+++ b/packages/agent/src/shared/agent-definition.ts
@@ -1,12 +1,20 @@
 import { z } from 'zod'
 
+import { canonicalStringify, sha256, type Sha256Digest } from './digest'
 import {
   AgentDefinitionErrorCode,
   AgentDeploymentErrorCode,
-  ErrorCode,
 } from './error-codes'
+import {
+  SchemaValidationError,
+  formatPath,
+  mapZodIssues,
+  type AgentSchemaIssue,
+  type AgentSchemaValidationResult,
+} from './schema-issue'
 
-export type Sha256Digest = `sha256:${string}`
+export type { Sha256Digest }
+export type { AgentSchemaIssue, AgentSchemaValidationResult }
 
 export interface AgentDefinition {
   schemaVersion: 1
@@ -52,15 +60,6 @@ export interface CompiledAgentBundle {
   readonly definitionDigest: Sha256Digest
   readonly assets: readonly Readonly<AgentDefinitionDigestAsset>[]
 }
-export interface AgentSchemaIssue<Code extends string> {
-  code: Code
-  field: string
-  message: string
-}
-
-export type AgentSchemaValidationResult<T, Code extends string> =
-  | { valid: true; value: T }
-  | { valid: false; issues: AgentSchemaIssue<Code>[] }
 
 const SHA256_DIGEST_RE = /^sha256:[a-f0-9]{64}$/
 
@@ -168,42 +167,6 @@ const AgentDefinitionDigestAssetSchema = z.object({
   content: z.string().refine(hasWellFormedUnicode, 'must contain well-formed Unicode'),
 }).strict()
 
-function formatPath(path: PropertyKey[]): string {
-  if (path.length === 0) return '<root>'
-  return path.reduce<string>(
-    (result, part) =>
-      typeof part === 'number'
-        ? `${result}[${part}]`
-        : result.length === 0
-          ? String(part)
-          : `${result}.${String(part)}`,
-    '',
-  )
-}
-
-function mapZodIssues<Code extends string>(
-  issues: z.ZodIssue[],
-  invalidCode: Code,
-  unsupportedCode: Code,
-): AgentSchemaIssue<Code>[] {
-  return issues.flatMap((issue) => {
-    if (issue.code === z.ZodIssueCode.unrecognized_keys) {
-      const parent = formatPath(issue.path)
-      return [...issue.keys].sort().map((key) => ({
-        code: unsupportedCode,
-        field: parent === '<root>' ? key : `${parent}.${key}`,
-        message: `${key} is not supported by schema version 1`,
-      }))
-    }
-    const field = formatPath(issue.path)
-    return [{
-      code: invalidCode,
-      field,
-      message: field === '<root>' ? issue.message : `${field} ${issue.message}`,
-    }]
-  })
-}
-
 export function validateAgentDefinition(
   raw: unknown,
 ): AgentSchemaValidationResult<AgentDefinition, AgentDefinitionErrorCode> {
@@ -238,32 +201,6 @@ export function validateAgentDeployment(
   return { valid: true, value: result.data }
 }
 
-function canonicalStringify(value: unknown): string {
-  if (value === null || typeof value !== 'object') {
-    const encoded = JSON.stringify(value)
-    if (encoded === undefined) throw new TypeError('Cannot canonicalize undefined')
-    return encoded
-  }
-  if (Array.isArray(value)) return `[${value.map(canonicalStringify).join(',')}]`
-  const record = value as Record<string, unknown>
-  return `{${Object.keys(record)
-    .filter((key) => record[key] !== undefined)
-    .sort()
-    .map((key) => `${JSON.stringify(key)}:${canonicalStringify(record[key])}`)
-    .join(',')}}`
-}
-
-async function sha256(value: string): Promise<Sha256Digest> {
-  const hash = await globalThis.crypto.subtle.digest(
-    'SHA-256',
-    new TextEncoder().encode(value),
-  )
-  const hex = Array.from(new Uint8Array(hash), (byte) =>
-    byte.toString(16).padStart(2, '0'),
-  ).join('')
-  return `sha256:${hex}`
-}
-
 export async function createAgentAssetDigest(content: string): Promise<Sha256Digest> {
   if (!hasWellFormedUnicode(content)) {
     throw new AgentDefinitionValidationError({
@@ -275,29 +212,17 @@ export async function createAgentAssetDigest(content: string): Promise<Sha256Dig
   return sha256(content)
 }
 
-export class AgentDefinitionValidationError extends Error {
-  readonly code = ErrorCode.enum.CONFIG_INVALID
-  readonly field: string
-  readonly validationCode: AgentDefinitionErrorCode
-
+export class AgentDefinitionValidationError extends SchemaValidationError<AgentDefinitionErrorCode> {
   constructor(issue: AgentSchemaIssue<AgentDefinitionErrorCode>) {
-    super(issue.message)
+    super(issue)
     this.name = 'AgentDefinitionValidationError'
-    this.field = issue.field
-    this.validationCode = issue.code
   }
 }
 
-export class AgentDeploymentValidationError extends Error {
-  readonly code = ErrorCode.enum.CONFIG_INVALID
-  readonly field: string
-  readonly validationCode: AgentDeploymentErrorCode
-
+export class AgentDeploymentValidationError extends SchemaValidationError<AgentDeploymentErrorCode> {
   constructor(issue: AgentSchemaIssue<AgentDeploymentErrorCode>) {
-    super(issue.message)
+    super(issue)
     this.name = 'AgentDeploymentValidationError'
-    this.field = issue.field
-    this.validationCode = issue.code
   }
 }
 

--- a/packages/agent/src/shared/digest.ts
+++ b/packages/agent/src/shared/digest.ts
@@ -1,0 +1,52 @@
+// Canonical SHA-256 digest primitives shared across agent-definition,
+// agent-deployment resolution, and MCP artifact digests (audit finding #7:
+// a duplicated inline sha256 in managedAgentDelegate.ts, and a resolvedDigest
+// computation that skipped canonicalization entirely — see finding #1).
+//
+// Web Crypto (globalThis.crypto.subtle) only — no node:* built-ins, so this
+// is safe to import from src/server/** and src/shared/** alike.
+
+export type Sha256Digest = `sha256:${string}`
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
+
+async function digestBytes(bytes: Uint8Array): Promise<Sha256Digest> {
+  // Re-materialize into a plain ArrayBuffer-backed view: callers may hand us
+  // a Uint8Array<ArrayBufferLike> (e.g. from Workspace.readBinaryFile), and
+  // SubtleCrypto.digest only accepts an ArrayBuffer-backed BufferSource.
+  const hash = await globalThis.crypto.subtle.digest('SHA-256', new Uint8Array(bytes))
+  return `sha256:${toHex(new Uint8Array(hash))}`
+}
+
+/** Hashes UTF-8 encoded text. */
+export async function sha256(value: string): Promise<Sha256Digest> {
+  return digestBytes(new TextEncoder().encode(value))
+}
+
+/** Hashes raw bytes. */
+export async function sha256Bytes(bytes: Uint8Array): Promise<Sha256Digest> {
+  return digestBytes(bytes)
+}
+
+/**
+ * Deterministic JSON stringification: object keys sorted recursively,
+ * `undefined` object values omitted, arrays preserve order. Used as the
+ * canonicalization step before {@link sha256} wherever a digest must be
+ * independent of source key/insertion order.
+ */
+export function canonicalStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    const encoded = JSON.stringify(value)
+    if (encoded === undefined) throw new TypeError('Cannot canonicalize undefined')
+    return encoded
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalStringify).join(',')}]`
+  const record = value as Record<string, unknown>
+  return `{${Object.keys(record)
+    .filter((key) => record[key] !== undefined)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalStringify(record[key])}`)
+    .join(',')}}`
+}

--- a/packages/agent/src/shared/schema-issue.ts
+++ b/packages/agent/src/shared/schema-issue.ts
@@ -1,0 +1,69 @@
+// Shared zod-issue -> stable-code mapping and validation-error base class.
+//
+// Extracted from agent-definition.ts / agent-consumption.ts (audit finding
+// #4: formatPath, the zod-issue mapper, and the {code,field,validationCode}
+// error shape were each duplicated per contract module). Behavior is
+// unchanged: this module only relocates the existing logic. Public error
+// shapes (codes/messages/details) are preserved byte-for-byte.
+
+import { z } from 'zod'
+
+import { ErrorCode } from './error-codes'
+
+export interface AgentSchemaIssue<Code extends string> {
+  code: Code
+  field: string
+  message: string
+}
+
+export type AgentSchemaValidationResult<T, Code extends string> =
+  | { valid: true; value: T }
+  | { valid: false; issues: AgentSchemaIssue<Code>[] }
+
+export function formatPath(path: PropertyKey[]): string {
+  if (path.length === 0) return '<root>'
+  return path.reduce<string>(
+    (result, part) =>
+      typeof part === 'number'
+        ? `${result}[${part}]`
+        : result.length === 0
+          ? String(part)
+          : `${result}.${String(part)}`,
+    '',
+  )
+}
+
+export function mapZodIssues<Code extends string>(
+  issues: z.ZodIssue[],
+  invalidCode: Code,
+  unsupportedCode: Code,
+): AgentSchemaIssue<Code>[] {
+  return issues.flatMap((issue) => {
+    if (issue.code === z.ZodIssueCode.unrecognized_keys) {
+      const parent = formatPath(issue.path)
+      return [...issue.keys].sort().map((key) => ({
+        code: unsupportedCode,
+        field: parent === '<root>' ? key : `${parent}.${key}`,
+        message: `${key} is not supported by schema version 1`,
+      }))
+    }
+    const field = formatPath(issue.path)
+    return [{
+      code: invalidCode,
+      field,
+      message: field === '<root>' ? issue.message : `${field} ${issue.message}`,
+    }]
+  })
+}
+
+export abstract class SchemaValidationError<Code extends string> extends Error {
+  readonly code = ErrorCode.enum.CONFIG_INVALID
+  readonly field: string
+  readonly validationCode: Code
+
+  constructor(issue: AgentSchemaIssue<Code>) {
+    super(issue.message)
+    this.field = issue.field
+    this.validationCode = issue.code
+  }
+}


### PR DESCRIPTION
## Context

From an Opus maintainability audit of `packages/agent/src/server/agentDefinition` and `packages/agent/src/shared` (findings 1, 2, 4, 7).

## Fix 1 (urgent — latent cross-host bug): digest canonicalization drift

`resolveAgentDeployment.ts` computed `resolvedDigest` via plain `JSON.stringify({domain, ...})` (insertion-order keys), while every sibling digest in `agent-definition.ts` (`createAgentDefinitionDigest`, `createAgentDeploymentDigest`) uses `canonicalStringify` (recursive sorted-key JSON). Two hosts/processes that assemble the `ResolvedAgentDigestInput` object with keys in a different order would previously get a different `resolvedDigest` for identical logical input. Routed the input through the same `canonicalStringify` used everywhere else.

**⚠️ resolvedDigest VALUE CHANGE**: this is an intentional, safe, pre-D1 value change — no persisted/compared `resolvedDigest` values exist in production today. It will not be safe once D1 ships. **The in-flight D1 branch must rebase over this PR** (or this PR should land before D1 merges) so it inherits the canonical digest computation from the start.

## Fix 2: golden-vector determinism test

Added one golden-vector assertion to `resolveAgentDeployment.test.ts` pinning `definitionDigest` / `deployment.digest` / `resolvedDigest` to fixed literal sha256 values against a fully-fixed fixture, so any future canonicalization drift breaks CI immediately instead of silently.

## Fix 3/4/7: unified digest + schema-issue plumbing

- New `packages/agent/src/shared/digest.ts`: owns `Sha256Digest`, `sha256` (string), `sha256Bytes` (Uint8Array), and `canonicalStringify`. `agent-definition.ts` and `managedAgentDelegate.ts` (previously an inline `node:crypto` sha256 at ~line 863) now consume this instead of duplicating hashing logic.
- New `packages/agent/src/shared/schema-issue.ts`: owns `formatPath`, `mapZodIssues`, `AgentSchemaIssue`/`AgentSchemaValidationResult`, and a `SchemaValidationError` base class. `AgentDefinitionValidationError`, `AgentDeploymentValidationError`, and `AgentConsumptionValidationError` are now thin subclasses instead of three copy-pasted `{code, field, validationCode}` implementations.

**No public error shape change**: every subclass still sets the same `name`, `code` (`CONFIG_INVALID`), `field`, and `validationCode` — verified by the existing error-shape tests, which pass unchanged. `agent-consumption.ts`'s `schemaMismatchIssues` deliberately keeps its own issue-mapping logic (single code, no unrecognized-key splitting) rather than switching to the shared `mapZodIssues`, since that mapper's unrecognized-key handling differs and swapping it would be an unannounced shape change.

## Gates

- `pnpm -C packages/agent build` — pass (required a one-time `pnpm -C packages/ui build` first; pre-existing DTS dependency, not part of this diff)
- `pnpm -C packages/agent typecheck` — pass, 0 errors
- `pnpm -C packages/agent lint:invariants` — pass (no `node:*`/Buffer in `src/shared/**`)
- `pnpm -C packages/agent test` — 1886 passed, 6 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)