### PR TITLE
feat(full-app): persist D1 binding env projections

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1BindingEnv.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1BindingEnv.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderD1BindingEnv, validateD1BindingEnv } from '../d1BindingEnv.js'
+import { D1HostErrorCode, type D1SiteBindingV1 } from '../d1Plan.js'
+
+const binding: D1SiteBindingV1 = {
+  bindingId: 'insurance', hostname: 'insurance.example.test', workspaceId: 'workspace:insurance',
+  defaultDeploymentId: 'deployment:insurance', bundleRef: 'bundle', deploymentRef: 'deployment',
+  workspaceAllocationRef: 'workspace-allocation', sessionAllocationRef: 'session-allocation',
+  ownerPrincipalRef: 'owner', landing: { title: 'Insurance', summary: 'Compare policies.' },
+  environmentRef: 'production', secretRefs: ['credential-ref'],
+}
+const canonical = [
+  'BORING_D1_BINDING_ENV_SCHEMA=1',
+  'BORING_D1_BINDING_ID=insurance',
+  'BORING_D1_ENVIRONMENT_REF=production',
+  'BORING_D1_WORKSPACE_ALLOCATION_REF=workspace-allocation',
+  'BORING_D1_SESSION_ALLOCATION_REF=session-allocation',
+].join('\n') + '\n'
+
+describe('D1 binding env projection', () => {
+  it('renders exact stable LF-terminated bytes independent of object property order', () => {
+    expect(renderD1BindingEnv(binding)).toBe(canonical)
+    expect(renderD1BindingEnv({ ...binding, environmentRef: binding.environmentRef })).toBe(canonical)
+    expect(() => validateD1BindingEnv(canonical, binding)).not.toThrow()
+  })
+
+  it.each([
+    ['reordered', canonical.split('\n').slice(0, -1).reverse().join('\n') + '\n'],
+    ['duplicate', canonical + 'BORING_D1_BINDING_ID=insurance\n'],
+    ['comment', `# generated\n${canonical}`],
+    ['quoted', canonical.replace('=insurance\n', '="insurance"\n')],
+    ['CRLF', canonical.replaceAll('\n', '\r\n')],
+    ['missing final LF', canonical.slice(0, -1)],
+    ['missing key', canonical.replace('BORING_D1_ENVIRONMENT_REF=production\n', '')],
+    ['changed value', canonical.replace('=production\n', '=staging\n')],
+    ['extra key', `${canonical}CANARY=/srv/private/raw-system-prompt\n`],
+  ])('rejects %s with a field-only error', (_name, content) => {
+    try {
+      validateD1BindingEnv(content, binding)
+      throw new Error('expected binding env rejection')
+    } catch (error) {
+      expect(error).toMatchObject({ code: D1HostErrorCode.PLAN_INVALID, details: { field: 'bindingEnv' } })
+      expect(JSON.stringify(error)).not.toMatch(/CANARY|private|prompt|insurance/)
+    }
+  })
+})

--- a/apps/full-app/src/server/deployment/__tests__/d1Plan.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Plan.test.ts
@@ -68,4 +68,11 @@ describe('parseD1HostPlan', () => {
       expect(JSON.stringify(error)).not.toContain('/srv/postgres')
     }
   })
+
+  it('admits only binding ids whose .env filename fits NAME_MAX', () => {
+    const longest = 'a'.repeat(251)
+    expect(parseD1HostPlan(plan({ bindings: [{ ...binding('a'), bindingId: longest }] })).bindings[0].bindingId).toBe(longest)
+    expect(() => parseD1HostPlan(plan({ bindings: [{ ...binding('a'), bindingId: `${longest}a` }] })))
+      .toThrow(expect.objectContaining({ code: D1HostErrorCode.PLAN_INVALID, details: { field: 'bindings[0].bindingId' } }))
+  })
 })

--- a/apps/full-app/src/server/deployment/__tests__/hostRevisionStore.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/hostRevisionStore.test.ts
@@ -1,4 +1,4 @@
-import { access, appendFile, chmod, cp, mkdtemp, mkdir, readFile, rename, stat, symlink, writeFile } from 'node:fs/promises'
+import { access, appendFile, chmod, cp, link, mkdtemp, mkdir, readFile, readdir, rename, stat, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { createAgentAssetDigest, createAgentDeploymentDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
@@ -8,6 +8,7 @@ import { describe, expect, it } from 'vitest'
 import { D1HostErrorCode } from '../d1Plan.js'
 import {
   canonicalizeD1AuditRecord,
+  canonicalizeD1DesiredSnapshot,
   createD1DesiredSnapshot,
   type D1AuditRecordV1,
   type D1DesiredSnapshotV1,
@@ -19,11 +20,12 @@ import { createD1RuntimeInputsIdentity } from '../d1RuntimeInputs.js'
 const digest = (value: string): Sha256Digest => `sha256:${value.repeat(64).slice(0, 64)}`
 const OWNER_UID = process.geteuid!()
 
-async function desired(): Promise<D1DesiredSnapshotV1> {
+async function desired(id = 'insurance'): Promise<D1DesiredSnapshotV1> {
+  const refSuffix = id === 'insurance' ? '' : `-${id}`
   const snapshot = canonicalizeWorkspaceCompositionSnapshot({
     schemaVersion: 1,
     domain: 'boring-workspace-composition:v1',
-    workspaceId: 'workspace:eclair',
+    workspaceId: `workspace:${id}`,
     runtimeProfile: {
       ref: 'runsc-eu', id: 'runsc', version: '2026.07.12', contentDigest: digest('b'),
       isolationAttestationDigest: digest('c'), workspaceRootPolicyRef: 'workspace-roots',
@@ -36,9 +38,9 @@ async function desired(): Promise<D1DesiredSnapshotV1> {
     provisioning: [], filesystemBindings: [], policies: { externalPlugins: false, pluginAuthoring: false },
   })
   const compositionDigest = await createAgentAssetDigest(JSON.stringify(snapshot))
-  const definition = { definitionId: 'definition:eclair', version: '1.0.0', digest: digest('f'), instructionsRef: 'instructions.md' }
+  const definition = { definitionId: `definition:${id}`, version: '1.0.0', digest: digest('f'), instructionsRef: 'instructions.md' }
   const deploymentInput = {
-    deploymentId: 'deployment:eclair', version: '2026.07.12', agentId: 'default',
+    deploymentId: `deployment:${id}`, version: '2026.07.12', agentId: 'default',
     definition: { definitionId: definition.definitionId, version: definition.version, digest: definition.digest },
   }
   const deploymentDigest = await createAgentDeploymentDigest(deploymentInput)
@@ -50,14 +52,14 @@ async function desired(): Promise<D1DesiredSnapshotV1> {
     schemaVersion: 1, hostId: 'host-1', expectedHostRevision: 'r0000000042', hostAppImageDigest: digest('a'),
     runtimeProfileRef: 'runsc-eu', databaseRef: 'postgres-eu', workspaceRootPolicyRef: 'workspace-roots',
     sessionRootPolicyRef: 'session-roots', bindings: [{
-      bindingId: 'insurance', hostname: 'insurance.example.test', workspaceId: snapshot.workspaceId,
+      bindingId: id, hostname: `${id}.example.test`, workspaceId: snapshot.workspaceId,
       defaultDeploymentId: deploymentInput.deploymentId, bundleRef: 'bundle', deploymentRef: 'deployment',
-      workspaceAllocationRef: 'workspace-allocation', sessionAllocationRef: 'session-allocation',
+      workspaceAllocationRef: `workspace-allocation${refSuffix}`, sessionAllocationRef: `session-allocation${refSuffix}`,
       ownerPrincipalRef: 'owner', landing: { title: 'Insurance', summary: 'Compare policies.' },
       environmentRef: 'production', secretRefs: ['credential-ref'],
     }],
   }, [{
-    schemaVersion: 1, bindingId: 'insurance', composition: { snapshot, digest: compositionDigest },
+    schemaVersion: 1, bindingId: id, composition: { snapshot, digest: compositionDigest },
     workspace: { workspaceId: snapshot.workspaceId, defaultDeploymentId: deploymentInput.deploymentId, compositionDigest },
     deployment: { deploymentId: deploymentInput.deploymentId, version: deploymentInput.version, agentId: 'default', digest: deploymentDigest },
     definition, resolvedDigest,
@@ -119,11 +121,59 @@ describe('D1 host revision store', () => {
     expect(JSON.parse(files[0])).toMatchObject({ schemaVersion: 1, domain: 'boring-d1-plan:v1' })
     expect(JSON.parse(files[1])).toMatchObject({ schemaVersion: 1, domain: 'boring-d1-resolved:v1' })
     expect(JSON.parse(files[2])).toMatchObject({ bindings: [{ secretRefs: ['credential-ref'] }] })
+    const bindingsDirectory = path.join(directory, 'bindings')
+    const bindingFile = path.join(bindingsDirectory, 'insurance.env')
+    expect(await readFile(bindingFile, 'utf8')).toBe([
+      'BORING_D1_BINDING_ENV_SCHEMA=1', 'BORING_D1_BINDING_ID=insurance',
+      'BORING_D1_ENVIRONMENT_REF=production', 'BORING_D1_WORKSPACE_ALLOCATION_REF=workspace-allocation',
+      'BORING_D1_SESSION_ALLOCATION_REF=session-allocation',
+    ].join('\n') + '\n')
+    expect(await readFile(bindingFile, 'utf8')).not.toMatch(/credential-ref|secret-value|\/srv\/|prompt/)
     for (const managed of [h.root, path.join(h.root, 'host-1'), path.join(h.root, 'host-1', 'revisions'), directory]) {
       expect((await stat(managed)).mode & 0o777).toBe(0o700)
     }
+    expect((await stat(bindingsDirectory)).mode & 0o777).toBe(0o700)
     for (const artifact of ['desired.json', 'resolved.json', 'secret-refs.json', 'desired.sha256']) {
       expect((await stat(path.join(directory, artifact))).mode & 0o777).toBe(0o400)
+    }
+    expect((await stat(bindingFile)).mode & 0o777).toBe(0o400)
+  })
+
+  it('writes the exact lexical filename set from out-of-order bindings', async () => {
+    const insurance = await desired('insurance'); const claims = await desired('claims')
+    const shuffled = await canonicalizeD1DesiredSnapshot({
+      schemaVersion: 1, domain: 'boring-d1-desired:v1',
+      plan: { ...insurance.plan, bindings: [insurance.plan.bindings[0], claims.plan.bindings[0]] },
+      resolvedBindings: [insurance.resolvedBindings[0], claims.resolvedBindings[0]],
+    })
+    const h = await harness(); const revisionId = await h.store.reserveRevisionId('host-1')
+    await h.store.writeCandidate('host-1', revisionId, shuffled)
+    const files = (await readdir(path.join(h.root, 'host-1', 'revisions', revisionId, 'bindings'))).sort()
+    expect(files).toEqual(['claims.env', 'insurance.env'])
+    expect((await h.store.readCandidate('host-1', revisionId))?.desired.plan.bindings.map((entry) => entry.bindingId))
+      .toEqual(['claims', 'insurance'])
+  })
+
+  it('rejects missing, extra, linked, non-private, and noncanonical binding artifacts', async () => {
+    async function written() {
+      const h = await harness(); const value = await desired(); const revisionId = await h.store.reserveRevisionId('host-1')
+      await h.store.writeCandidate('host-1', revisionId, value)
+      const directory = path.join(h.root, 'host-1', 'revisions', revisionId, 'bindings')
+      return { h, revisionId, directory, file: path.join(directory, 'insurance.env') }
+    }
+    for (const mutate of [
+      async ({ file }: Awaited<ReturnType<typeof written>>) => { await rename(file, `${file}.missing`) },
+      async ({ directory }: Awaited<ReturnType<typeof written>>) => { await writeFile(path.join(directory, 'extra.env'), 'EXTRA=1\n', { mode: 0o400 }) },
+      async ({ h, file }: Awaited<ReturnType<typeof written>>) => { const backing = path.join(h.root, 'binding.backing'); await rename(file, backing); await symlink(backing, file) },
+      async ({ h, file }: Awaited<ReturnType<typeof written>>) => { await link(file, path.join(h.root, 'binding.hardlink')) },
+      async ({ file }: Awaited<ReturnType<typeof written>>) => { await chmod(file, 0o600) },
+      async ({ directory }: Awaited<ReturnType<typeof written>>) => { await chmod(directory, 0o755) },
+      async ({ file }: Awaited<ReturnType<typeof written>>) => { const content = await readFile(file, 'utf8'); await chmod(file, 0o600); await writeFile(file, `# noncanonical\n${content}`); await chmod(file, 0o400) },
+    ]) {
+      const target = await written(); await mutate(target)
+      const error = await target.h.store.readCandidate('host-1', target.revisionId).catch((caught) => caught)
+      expect(error).toMatchObject({ code: D1HostErrorCode.ROLLBACK_TARGET_INVALID, details: { field: 'targetRevision' } })
+      expect(JSON.stringify(error)).not.toMatch(/binding\.backing|noncanonical|EXTRA/)
     }
   })
 

--- a/apps/full-app/src/server/deployment/d1BindingEnv.ts
+++ b/apps/full-app/src/server/deployment/d1BindingEnv.ts
@@ -1,0 +1,31 @@
+import { parseEnv } from 'node:util'
+
+import { invalidD1Field, type D1SiteBindingV1 } from './d1Plan.js'
+
+const BINDING_ENV_KEYS = [
+  'BORING_D1_BINDING_ENV_SCHEMA',
+  'BORING_D1_BINDING_ID',
+  'BORING_D1_ENVIRONMENT_REF',
+  'BORING_D1_WORKSPACE_ALLOCATION_REF',
+  'BORING_D1_SESSION_ALLOCATION_REF',
+] as const
+
+export function renderD1BindingEnv(binding: D1SiteBindingV1): string {
+  return [
+    'BORING_D1_BINDING_ENV_SCHEMA=1',
+    `BORING_D1_BINDING_ID=${binding.bindingId}`,
+    `BORING_D1_ENVIRONMENT_REF=${binding.environmentRef}`,
+    `BORING_D1_WORKSPACE_ALLOCATION_REF=${binding.workspaceAllocationRef}`,
+    `BORING_D1_SESSION_ALLOCATION_REF=${binding.sessionAllocationRef}`,
+  ].join('\n') + '\n'
+}
+
+export function validateD1BindingEnv(content: string, binding: D1SiteBindingV1): void {
+  let parsed: NodeJS.Dict<string>
+  try { parsed = parseEnv(content) } catch { invalidD1Field('bindingEnv') }
+  const canonical = renderD1BindingEnv(binding)
+  const expected = parseEnv(canonical)
+  if (Object.keys(parsed).length !== BINDING_ENV_KEYS.length
+    || BINDING_ENV_KEYS.some((key) => parsed[key] !== expected[key])
+    || content !== canonical) invalidD1Field('bindingEnv')
+}

--- a/apps/full-app/src/server/deployment/d1Plan.ts
+++ b/apps/full-app/src/server/deployment/d1Plan.ts
@@ -113,9 +113,11 @@ function parseBinding(value: unknown, index: number): D1SiteBindingV1 {
   const secretRefs = input.secretRefs.map((value, secretIndex) => strictD1Ref(value, `${field}.secretRefs[${secretIndex}]`)).sort()
   unique(secretRefs, `${field}.secretRefs`)
   if (typeof input.hostname !== 'string' || !HOST_RE.test(input.hostname)) invalidD1Field(`${field}.hostname`)
+  const bindingId = strictD1Ref(input.bindingId, `${field}.bindingId`)
+  if (bindingId.length > 251) invalidD1Field(`${field}.bindingId`)
 
   return Object.freeze({
-    bindingId: strictD1Ref(input.bindingId, `${field}.bindingId`),
+    bindingId,
     hostname: input.hostname,
     workspaceId: agentRef(input.workspaceId, `${field}.workspaceId`),
     defaultDeploymentId: agentRef(input.defaultDeploymentId, `${field}.defaultDeploymentId`),

--- a/apps/full-app/src/server/deployment/hostRevisionStore.ts
+++ b/apps/full-app/src/server/deployment/hostRevisionStore.ts
@@ -1,9 +1,10 @@
 import { randomUUID } from 'node:crypto'
 import { constants } from 'node:fs'
-import { lstat, mkdir, open, realpath, rename } from 'node:fs/promises'
+import { lstat, mkdir, open, readdir, realpath, rename } from 'node:fs/promises'
 import path from 'node:path'
 import type { Sha256Digest } from '@hachej/boring-agent/shared'
 
+import { renderD1BindingEnv, validateD1BindingEnv } from './d1BindingEnv.js'
 import { assertD1ExactKeys as exactKeys, D1HostError, D1HostErrorCode, strictD1Ref } from './d1Plan.js'
 import {
   canonicalizeD1ActiveEnvelope,
@@ -104,7 +105,7 @@ async function readRegular(file: string, ownerUid: number, optional = false, mod
   }
   try {
     const info = await handle.stat()
-    if (!info.isFile() || info.uid !== ownerUid || (info.mode & 0o777) !== mode) throw new Error('not regular')
+    if (!info.isFile() || info.nlink !== 1 || info.uid !== ownerUid || (info.mode & 0o777) !== mode) throw new Error('not regular')
     return await handle.readFile('utf8')
   } finally { await handle.close() }
 }
@@ -172,6 +173,15 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
     if (resolvedRaw.schemaVersion !== 1 || resolvedRaw.domain !== RESOLVED_DOMAIN) mapped(D1HostErrorCode.PLAN_INVALID, 'resolvedFile')
     const desired = await canonicalizeD1DesiredSnapshot({ schemaVersion: 1, domain: 'boring-d1-desired:v1', plan: desiredRaw.plan, resolvedBindings: resolvedRaw.bindings })
     if (desired.plan.hostId !== hostId(host)) mapped(D1HostErrorCode.PLAN_INVALID, 'desired.plan.hostId')
+    const bindingsDirectory = path.join(target, 'bindings')
+    await directory(bindingsDirectory, 'bindings', ownerUid)
+    const expectedBindingFiles = desired.plan.bindings.map((binding) => `${binding.bindingId}.env`).sort()
+    const actualBindingFiles = (await readdir(bindingsDirectory)).sort()
+    if (JSON.stringify(actualBindingFiles) !== JSON.stringify(expectedBindingFiles)) mapped(D1HostErrorCode.PLAN_INVALID, 'bindings')
+    for (const binding of desired.plan.bindings) {
+      const content = await readRegular(path.join(bindingsDirectory, `${binding.bindingId}.env`), ownerUid)
+      validateD1BindingEnv(content!, binding)
+    }
     const secretRefs = canonicalizeD1SecretRefsEnvelope(json((await readRegular(path.join(target, 'secret-refs.json'), ownerUid))!), desired)
     const desiredStateDigest = await digestD1Desired(desired)
     if ((await readRegular(path.join(target, 'desired.sha256'), ownerUid))!.trim() !== desiredStateDigest) mapped(D1HostErrorCode.PLAN_INVALID, 'desiredDigest')
@@ -256,6 +266,13 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
         await createDurable(path.join(temporary, 'resolved.json'), JSON.stringify({ schemaVersion: 1, domain: RESOLVED_DOMAIN, bindings: desired.resolvedBindings }), ownerUid)
         await createDurable(path.join(temporary, 'secret-refs.json'), JSON.stringify(secretRefs), ownerUid)
         await createDurable(path.join(temporary, 'desired.sha256'), `${desiredStateDigest}\n`, ownerUid)
+        const bindingsDirectory = path.join(temporary, 'bindings')
+        await mkdir(bindingsDirectory, { mode: 0o700 })
+        await directory(bindingsDirectory, 'bindings', ownerUid)
+        for (const binding of desired.plan.bindings) {
+          await createDurable(path.join(bindingsDirectory, `${binding.bindingId}.env`), renderD1BindingEnv(binding), ownerUid)
+        }
+        await syncDirectory(bindingsDirectory, 'bindings', ownerUid)
         await syncDirectory(temporary, 'candidate', ownerUid)
         await rename(temporary, target)
         await syncDirectory(revisions, 'revisions', ownerUid)


### PR DESCRIPTION
## Summary

- materialize one deterministic, private five-line descriptor at `revisions/<revisionId>/bindings/<bindingId>.env`
- validate the exact filename set, owner/modes, link count, and canonical LF-terminated bytes on candidate reads
- constrain binding ids so `<bindingId>.env` fits `NAME_MAX`, without changing candidate schemas or desired-state digests

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/d1BindingEnv.test.ts src/server/deployment/__tests__/d1Plan.test.ts src/server/deployment/__tests__/hostRevisionStore.test.ts` - 3 files / 33 tests passed
- `pnpm --filter full-app typecheck` - passed
- `pnpm --filter full-app exec tsc -p tsconfig.server.json --noCheck` - server emit passed
- remote head verified as `05a5d54b1f94665f139de3c238b2a6d06668971c`

## Review

Structured autoreview raised one compatibility concern: revisions written by the interim dark D1 store lack mandatory binding descriptors. This is consciously rejected under the accepted D1-R0 contract: there is no persisted production v1 state, immutable revisions must not be backfilled, and partial pre-v1 revisions fail closed.

Two final independent spec/thermo review passes were clean after removing the ambiguous secret-manifest path and making the filename-order proof independent of filesystem enumeration order.

## Handoff

D1-003b2b still owns the permission transition needed before runtime consumption. This PR does not add Compose wiring, tmpfs materialization, or a descriptor reader.