### PR TITLE
feat(full-app): harden D1 revision permissions

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/composeAdapter.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/composeAdapter.test.ts
@@ -57,10 +57,15 @@ describe('D1 Compose topology', () => {
     expect(ingress.restart).toBe('unless-stopped')
     expect(core.restart).toBe('unless-stopped')
     expect(core.env_file).toEqual(['/etc/boring/d1/core.env'])
+    expect(core.environment).toMatchObject({ BORING_D1_HOST_ID: '${D1_HOST_ID:?D1_HOST_ID is required}' })
     expect(mounts).toEqual([
       { type: 'volume', source: 'd1-workspaces', target: '/data/workspaces' },
       { type: 'volume', source: 'd1-sessions', target: '/data/pi-sessions' },
-      { type: 'bind', source: '${D1_STATE_ROOT:?D1_STATE_ROOT is required}', target: '/var/lib/boring/d1/${D1_HOST_ID:?D1_HOST_ID is required}', read_only: true },
+      {
+        type: 'bind', source: '${D1_STATE_ROOT:?D1_STATE_ROOT is required}',
+        target: '/var/lib/boring/d1/${D1_HOST_ID:?D1_HOST_ID is required}', read_only: true,
+        bind: { create_host_path: false },
+      },
       { type: 'bind', source: '/run/boring/d1', target: '/run/boring/d1', read_only: true },
     ])
 

--- a/apps/full-app/src/server/deployment/__tests__/hostRevisionStore.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/hostRevisionStore.test.ts
@@ -19,6 +19,8 @@ import { createD1RuntimeInputsIdentity } from '../d1RuntimeInputs.js'
 
 const digest = (value: string): Sha256Digest => `sha256:${value.repeat(64).slice(0, 64)}`
 const OWNER_UID = process.geteuid!()
+const OWNER_GID = process.getegid!()
+const APP_GID = OWNER_GID || 10001
 
 async function desired(id = 'insurance'): Promise<D1DesiredSnapshotV1> {
   const refSuffix = id === 'insurance' ? '' : `-${id}`
@@ -69,7 +71,7 @@ async function desired(id = 'insurance'): Promise<D1DesiredSnapshotV1> {
 async function harness(fault?: () => void) {
   const parent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-store-'))
   const root = path.join(parent, 'state')
-  return { parent, root, store: createHostRevisionStore({ root, ownerUid: OWNER_UID, fault }) }
+  return { parent, root, store: createHostRevisionStore({ root, ownerUid: OWNER_UID, appGid: APP_GID, fault }) }
 }
 async function observation(value: D1DesiredSnapshotV1, ready = true) {
   return {
@@ -129,14 +131,19 @@ describe('D1 host revision store', () => {
       'BORING_D1_SESSION_ALLOCATION_REF=session-allocation',
     ].join('\n') + '\n')
     expect(await readFile(bindingFile, 'utf8')).not.toMatch(/credential-ref|secret-value|\/srv\/|prompt/)
-    for (const managed of [h.root, path.join(h.root, 'host-1'), path.join(h.root, 'host-1', 'revisions'), directory]) {
-      expect((await stat(managed)).mode & 0o777).toBe(0o700)
+    expect(await stat(h.root)).toMatchObject({ uid: OWNER_UID, gid: OWNER_GID })
+    expect((await stat(h.root)).mode & 0o777).toBe(0o700)
+    for (const managed of [path.join(h.root, 'host-1'), path.join(h.root, 'host-1', 'revisions'), directory, bindingsDirectory]) {
+      expect(await stat(managed)).toMatchObject({ uid: OWNER_UID, gid: APP_GID })
+      expect((await stat(managed)).mode & 0o777).toBe(0o710)
     }
-    expect((await stat(bindingsDirectory)).mode & 0o777).toBe(0o700)
-    for (const artifact of ['desired.json', 'resolved.json', 'secret-refs.json', 'desired.sha256']) {
-      expect((await stat(path.join(directory, artifact))).mode & 0o777).toBe(0o400)
+    for (const artifact of ['desired.json', 'resolved.json', 'secret-refs.json', 'desired.sha256', 'bindings/insurance.env']) {
+      expect(await stat(path.join(directory, artifact))).toMatchObject({ uid: OWNER_UID, gid: APP_GID, nlink: 1 })
+      expect((await stat(path.join(directory, artifact))).mode & 0o777).toBe(0o440)
     }
-    expect((await stat(bindingFile)).mode & 0o777).toBe(0o400)
+    const sequence = await stat(path.join(h.root, 'host-1', 'sequence'))
+    expect(sequence).toMatchObject({ uid: OWNER_UID, gid: OWNER_GID, nlink: 1 })
+    expect(sequence.mode & 0o777).toBe(0o400)
   })
 
   it('writes the exact lexical filename set from out-of-order bindings', async () => {
@@ -163,12 +170,13 @@ describe('D1 host revision store', () => {
     }
     for (const mutate of [
       async ({ file }: Awaited<ReturnType<typeof written>>) => { await rename(file, `${file}.missing`) },
-      async ({ directory }: Awaited<ReturnType<typeof written>>) => { await writeFile(path.join(directory, 'extra.env'), 'EXTRA=1\n', { mode: 0o400 }) },
+      async ({ directory }: Awaited<ReturnType<typeof written>>) => { await writeFile(path.join(directory, 'extra.env'), 'EXTRA=1\n', { mode: 0o440 }) },
       async ({ h, file }: Awaited<ReturnType<typeof written>>) => { const backing = path.join(h.root, 'binding.backing'); await rename(file, backing); await symlink(backing, file) },
       async ({ h, file }: Awaited<ReturnType<typeof written>>) => { await link(file, path.join(h.root, 'binding.hardlink')) },
       async ({ file }: Awaited<ReturnType<typeof written>>) => { await chmod(file, 0o600) },
+      async ({ file }: Awaited<ReturnType<typeof written>>) => { await chmod(file, 0o2440) },
       async ({ directory }: Awaited<ReturnType<typeof written>>) => { await chmod(directory, 0o755) },
-      async ({ file }: Awaited<ReturnType<typeof written>>) => { const content = await readFile(file, 'utf8'); await chmod(file, 0o600); await writeFile(file, `# noncanonical\n${content}`); await chmod(file, 0o400) },
+      async ({ file }: Awaited<ReturnType<typeof written>>) => { const content = await readFile(file, 'utf8'); await chmod(file, 0o600); await writeFile(file, `# noncanonical\n${content}`); await chmod(file, 0o440) },
     ]) {
       const target = await written(); await mutate(target)
       const error = await target.h.store.readCandidate('host-1', target.revisionId).catch((caught) => caught)
@@ -202,22 +210,22 @@ describe('D1 host revision store', () => {
     const target = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-target-'))
     const parent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-parent-'))
     const rootLink = path.join(parent, 'root-link'); await symlink(target, rootLink)
-    await expect(createHostRevisionStore({ root: rootLink, ownerUid: OWNER_UID }).reserveRevisionId('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
+    await expect(createHostRevisionStore({ root: rootLink, ownerUid: OWNER_UID, appGid: APP_GID }).reserveRevisionId('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
     const parentLink = path.join(parent, 'parent-link'); await symlink(target, parentLink)
-    await expect(createHostRevisionStore({ root: path.join(parentLink, 'root'), ownerUid: OWNER_UID }).reserveRevisionId('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
+    await expect(createHostRevisionStore({ root: path.join(parentLink, 'root'), ownerUid: OWNER_UID, appGid: APP_GID }).reserveRevisionId('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
     await expect(access(path.join(target, 'root'))).rejects.toMatchObject({ code: 'ENOENT' })
     const ancestorTarget = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-ancestor-target-'))
     const ancestorParent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-ancestor-parent-'))
     await mkdir(path.join(ancestorTarget, 'nested'), { mode: 0o700 })
     await symlink(ancestorTarget, path.join(ancestorParent, 'alias'))
-    await expect(createHostRevisionStore({ root: path.join(ancestorParent, 'alias', 'nested', 'root'), ownerUid: OWNER_UID }).reserveRevisionId('host-1'))
+    await expect(createHostRevisionStore({ root: path.join(ancestorParent, 'alias', 'nested', 'root'), ownerUid: OWNER_UID, appGid: APP_GID }).reserveRevisionId('host-1'))
       .rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
     await expect(access(path.join(ancestorTarget, 'nested', 'root'))).rejects.toMatchObject({ code: 'ENOENT' })
 
     const host = await harness(); await mkdir(host.root, { mode: 0o700 }); await symlink(target, path.join(host.root, 'host-1'))
     await expect(host.store.reserveRevisionId('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
     await expect(host.store.readActive('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
-    const revisionsLink = await harness(); await mkdir(revisionsLink.root, { mode: 0o700 }); await mkdir(path.join(revisionsLink.root, 'host-1'), { mode: 0o700 })
+    const revisionsLink = await harness(); await mkdir(revisionsLink.root, { mode: 0o700 }); await mkdir(path.join(revisionsLink.root, 'host-1'), { mode: 0o710 })
     await symlink(target, path.join(revisionsLink.root, 'host-1', 'revisions'))
     await expect(revisionsLink.store.readCandidate('host-1', 'r0000000001')).rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_TARGET_INVALID })
     const revision = await harness(); const value = await desired(); await revision.store.reserveRevisionId('host-1')
@@ -249,7 +257,7 @@ describe('D1 host revision store', () => {
 
   it('rejects a valid revision tree copied under a different host identity', async () => {
     const h = await harness(); const done = await complete(h.store)
-    const host2 = path.join(h.root, 'host-2'); await mkdir(host2, { mode: 0o700 }); await mkdir(path.join(host2, 'revisions'), { mode: 0o700 })
+    const host2 = path.join(h.root, 'host-2'); await mkdir(host2, { mode: 0o710 }); await mkdir(path.join(host2, 'revisions'), { mode: 0o710 })
     await cp(path.join(h.root, 'host-1', 'revisions', done.revisionId), path.join(host2, 'revisions', done.revisionId), { recursive: true })
     await expect(h.store.readCandidate('host-2', done.revisionId)).rejects.toMatchObject({
       code: D1HostErrorCode.ROLLBACK_TARGET_INVALID, details: { field: 'targetRevision' },
@@ -273,7 +281,9 @@ describe('D1 host revision store', () => {
     const observedFile = path.join(h.root, 'host-1', 'revisions', done.revisionId, 'observed.json')
     expect(await readFile(observedFile, 'utf8')).not.toMatch(/secret-value|\/srv\/private|raw-version|runtimeHandle/)
     for (const artifact of ['observed.json', 'completion.json']) {
-      expect((await stat(path.join(h.root, 'host-1', 'revisions', done.revisionId, artifact))).mode & 0o777).toBe(0o400)
+      const info = await stat(path.join(h.root, 'host-1', 'revisions', done.revisionId, artifact))
+      expect(info).toMatchObject({ uid: OWNER_UID, gid: APP_GID, nlink: 1 })
+      expect(info.mode & 0o777).toBe(0o440)
     }
     type MutableObservation = { bindings: Array<{ runtimeInputs: { environment: { versionFingerprint: string }; secrets: Array<{ providerVersionFingerprint: string }> } }> }
     for (const mutate of [
@@ -283,11 +293,11 @@ describe('D1 host revision store', () => {
       const tampered = await harness(); const tamperedDone = await complete(tampered.store)
       const file = path.join(tampered.root, 'host-1', 'revisions', tamperedDone.revisionId, 'observed.json')
       const raw = JSON.parse(await readFile(file, 'utf8')) as MutableObservation; mutate(raw)
-      await chmod(file, 0o600); await writeFile(file, JSON.stringify(raw)); await chmod(file, 0o400)
+      await chmod(file, 0o600); await writeFile(file, JSON.stringify(raw)); await chmod(file, 0o440)
       await expect(tampered.store.readComplete('host-1', tamperedDone.revisionId)).rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_TARGET_INVALID })
     }
     const digestFile = path.join(h.root, 'host-1', 'revisions', done.revisionId, 'desired.sha256')
-    await chmod(digestFile, 0o600); await writeFile(digestFile, `${digest('0')}\n`)
+    await chmod(digestFile, 0o600); await writeFile(digestFile, `${digest('0')}\n`); await chmod(digestFile, 0o440)
     await expect(h.store.readComplete('host-1', done.revisionId)).rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_TARGET_INVALID })
     const missing = await harness(); const missingDone = await complete(missing.store)
     const resolved = path.join(missing.root, 'host-1', 'revisions', missingDone.revisionId, 'resolved.json')
@@ -304,7 +314,7 @@ describe('D1 host revision store', () => {
     const mismatch = await harness(); const mismatchDone = await complete(mismatch.store)
     const completionFile = path.join(mismatch.root, 'host-1', 'revisions', mismatchDone.revisionId, 'completion.json')
     const completionJson = JSON.parse(await readFile(completionFile, 'utf8'))
-    await chmod(completionFile, 0o600); await writeFile(completionFile, JSON.stringify({ ...completionJson, desiredStateDigest: digest('0') }))
+    await chmod(completionFile, 0o600); await writeFile(completionFile, JSON.stringify({ ...completionJson, desiredStateDigest: digest('0') })); await chmod(completionFile, 0o440)
     await expect(mismatch.store.publishActive('host-1', mismatchDone.revisionId)).rejects.toMatchObject({ committed: false })
     expect(await mismatch.store.readActive('host-1')).toBeNull()
 
@@ -314,7 +324,9 @@ describe('D1 host revision store', () => {
     expect(error).toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED, committed: true, details: { field: 'active' } })
     expect(JSON.stringify(error)).not.toMatch(/private|secret-value/)
     expect(await after.store.readActive('host-1')).toEqual({ schemaVersion: 1, revisionId: done.revisionId, desiredStateDigest: done.completed.desiredStateDigest })
-    expect((await stat(path.join(after.root, 'host-1', 'active'))).mode & 0o777).toBe(0o400)
+    const activeInfo = await stat(path.join(after.root, 'host-1', 'active'))
+    expect(activeInfo).toMatchObject({ uid: OWNER_UID, gid: APP_GID, nlink: 1 })
+    expect(activeInfo.mode & 0o777).toBe(0o440)
     expect(Object.keys(JSON.parse(await readFile(path.join(after.root, 'host-1', 'active'), 'utf8'))).sort())
       .toEqual(['desiredStateDigest', 'revisionId', 'schemaVersion'])
   })
@@ -336,12 +348,12 @@ describe('D1 host revision store', () => {
     const orphan = await harness(); await orphan.store.reserveRevisionId('host-1')
     const file = path.join(orphan.root, 'host-1', 'active')
     await writeFile(file, JSON.stringify({ schemaVersion: 1, revisionId: 'r0000000001', desiredStateDigest: digest('a') }))
-    await chmod(file, 0o400)
+    await chmod(file, 0o440)
     await expect(orphan.store.readActive('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
     const extra = await harness(); await extra.store.reserveRevisionId('host-1')
     const extraFile = path.join(extra.root, 'host-1', 'active')
     await writeFile(extraFile, JSON.stringify({ schemaVersion: 1, revisionId: 'r0000000001', desiredStateDigest: digest('a'), extra: true }))
-    await chmod(extraFile, 0o400)
+    await chmod(extraFile, 0o440)
     await expect(extra.store.readActive('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
   })
 
@@ -367,7 +379,9 @@ describe('D1 host revision store', () => {
     expect(await readFile(auditFile, 'utf8')).toBe(tornBytes)
     await h.store.appendAudit('host-1', audit(done.completed))
     expect(await readFile(auditFile, 'utf8')).not.toContain('"torn"')
-    expect((await stat(auditFile)).mode & 0o777).toBe(0o600)
+    const auditInfo = await stat(auditFile)
+    expect(auditInfo).toMatchObject({ uid: OWNER_UID, gid: OWNER_GID, nlink: 1 })
+    expect(auditInfo.mode & 0o777).toBe(0o600)
     expect(await h.store.hasTerminalAudit('host-1', active)).toBe(true)
 
     const corrupt = await harness(); await corrupt.store.reserveRevisionId('host-1')
@@ -397,30 +411,43 @@ describe('D1 host revision store', () => {
   })
 
   it('requires an explicit safe owner policy before filesystem side effects', async () => {
-    expect(() => createHostRevisionStore({ root: '/unused', ownerUid: -1 })).toThrow(expect.objectContaining({ code: D1HostErrorCode.PLAN_INVALID }))
+    expect(() => createHostRevisionStore({ root: '/unused', ownerUid: -1, appGid: APP_GID })).toThrow(expect.objectContaining({ code: D1HostErrorCode.PLAN_INVALID }))
+    expect(() => createHostRevisionStore({ root: '/unused', ownerUid: OWNER_UID, appGid: 0 })).toThrow(expect.objectContaining({ code: D1HostErrorCode.PLAN_INVALID }))
     const wrongParent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-wrong-owner-'))
     const wrongRoot = path.join(wrongParent, 'state')
-    const wrongOwner = createHostRevisionStore({ root: wrongRoot, ownerUid: OWNER_UID + 1 })
+    const wrongOwner = createHostRevisionStore({ root: wrongRoot, ownerUid: OWNER_UID + 1, appGid: APP_GID })
     await expect(wrongOwner.reserveRevisionId('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
     await expect(access(wrongRoot)).rejects.toMatchObject({ code: 'ENOENT' })
 
     const writableParent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-writable-parent-'))
     await chmod(writableParent, 0o770)
     const writableRoot = path.join(writableParent, 'state')
-    await expect(createHostRevisionStore({ root: writableRoot, ownerUid: OWNER_UID }).reserveRevisionId('host-1'))
+    await expect(createHostRevisionStore({ root: writableRoot, ownerUid: OWNER_UID, appGid: APP_GID }).reserveRevisionId('host-1'))
       .rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
     await expect(access(writableRoot)).rejects.toMatchObject({ code: 'ENOENT' })
 
     const h = await harness(); const done = await complete(h.store)
-    const wrongReader = createHostRevisionStore({ root: h.root, ownerUid: OWNER_UID + 1 })
+    const wrongReader = createHostRevisionStore({ root: h.root, ownerUid: OWNER_UID + 1, appGid: APP_GID })
     await expect(wrongReader.readCandidate('host-1', done.revisionId)).rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_TARGET_INVALID })
     await expect(wrongReader.readActive('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+
+    const hostRoot = path.join(h.root, 'host-1'); const before = await stat(hostRoot)
+    const wrongAppReader = createHostRevisionStore({ root: h.root, ownerUid: OWNER_UID, appGid: APP_GID + 1 })
+    await expect(wrongAppReader.readCandidate('host-1', done.revisionId)).rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_TARGET_INVALID })
+    expect(await stat(hostRoot)).toMatchObject({ uid: before.uid, gid: before.gid, mode: before.mode })
+
+    const oldParent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-old-tree-')); const oldRoot = path.join(oldParent, 'state')
+    await mkdir(oldRoot, { mode: 0o700 }); await mkdir(path.join(oldRoot, 'host-1'), { mode: 0o700 }); await mkdir(path.join(oldRoot, 'host-1', 'revisions'), { mode: 0o700 })
+    const oldStore = createHostRevisionStore({ root: oldRoot, ownerUid: OWNER_UID, appGid: APP_GID })
+    await expect(oldStore.reserveRevisionId('host-1')).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
+    expect((await stat(path.join(oldRoot, 'host-1'))).mode & 0o777).toBe(0o700)
+    await expect(access(path.join(oldRoot, 'host-1', 'sequence'))).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
   it('redacts OS failures even when configured paths contain secret-like text', async () => {
     const parent = await mkdtemp(path.join(os.tmpdir(), 'secret-value-root-'))
     const root = path.join(parent, 'private-root'); await writeFile(root, 'not-a-directory')
-    const error = await createHostRevisionStore({ root, ownerUid: OWNER_UID }).reserveRevisionId('host-1').catch((caught) => caught)
+    const error = await createHostRevisionStore({ root, ownerUid: OWNER_UID, appGid: APP_GID }).reserveRevisionId('host-1').catch((caught) => caught)
     expect(error).toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
     expect(JSON.stringify(error)).not.toMatch(/secret-value|private-root|ENOTDIR/)
   })

--- a/apps/full-app/src/server/deployment/d1CommandEntry.ts
+++ b/apps/full-app/src/server/deployment/d1CommandEntry.ts
@@ -13,6 +13,7 @@ import { D1HostError, D1HostErrorCode } from './d1Plan.js'
 import { createHostRevisionStore } from './hostRevisionStore.js'
 
 const MAX_BYTES = 1024 * 1024
+const D1_APP_GID = 10001
 export type D1EntryMode = '--read-only' | '--locked'
 export interface D1EntryContext { readonly ownerUid: number; readonly stateRoot: string; readonly mutationGuard: D1MutationGuard }
 export type D1DependencyFactory = (context: D1EntryContext) => D1CommandEngineOptions
@@ -82,7 +83,7 @@ function assertInheritedLock(lockRoot: string, hostId: string, uid: number): voi
 function unavailable(field: string): never { throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field }) }
 
 export const createProductionD1Dependencies: D1DependencyFactory = ({ ownerUid, stateRoot, mutationGuard }) => ({
-  store: createHostRevisionStore({ root: stateRoot, ownerUid }),
+  store: createHostRevisionStore({ root: stateRoot, ownerUid, appGid: D1_APP_GID }),
   resolver: { resolvePlan: async () => unavailable('resolver'), reproduce: async () => unavailable('resolver') },
   effects: {
     loadAdmittedBindingIds: async () => unavailable('admissions'),

--- a/apps/full-app/src/server/deployment/hostRevisionStore.ts
+++ b/apps/full-app/src/server/deployment/hostRevisionStore.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { constants } from 'node:fs'
+import { constants, type Stats } from 'node:fs'
 import { lstat, mkdir, open, readdir, realpath, rename } from 'node:fs/promises'
 import path from 'node:path'
 import type { Sha256Digest } from '@hachej/boring-agent/shared'
@@ -57,6 +57,7 @@ export class D1ActivePublishError extends D1HostError {
 export interface D1HostRevisionStoreOptions {
   readonly root: string
   readonly ownerUid: number
+  readonly appGid: number
   readonly fault?: (point: 'after-active-rename') => void | Promise<void>
 }
 
@@ -64,6 +65,7 @@ const REVISION_RE = /^r\d{10}$/
 const PLAN_DOMAIN = 'boring-d1-plan:v1'
 const RESOLVED_DOMAIN = 'boring-d1-resolved:v1'
 const NOFOLLOW_READ = constants.O_RDONLY | constants.O_NOFOLLOW
+interface ExactFsPolicy { readonly uid: number; readonly gid: number; readonly mode: number }
 
 function hostId(value: string): string { return strictD1Ref(value, 'hostId') }
 function revisionId(value: string): string {
@@ -74,30 +76,42 @@ function mapped(code: D1HostErrorCode, field: string): never { throw new D1HostE
 function json(content: string): unknown {
   try { return JSON.parse(content) as unknown } catch { mapped(D1HostErrorCode.PLAN_INVALID, 'json') }
 }
-async function openDirectory(directory: string, field: string, ownerUid: number, parent = false) {
+function exactMetadata(info: Stats, policy: ExactFsPolicy, links = false): boolean {
+  return info.uid === policy.uid && info.gid === policy.gid && (info.mode & 0o7777) === policy.mode && (!links || info.nlink === 1)
+}
+async function openDirectory(directory: string, field: string, policy: ExactFsPolicy, parent = false) {
   const handle = await open(directory, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW)
   const info = await handle.stat()
-  if (!info.isDirectory() || info.uid !== ownerUid || (parent ? (info.mode & 0o022) !== 0 : (info.mode & 0o777) !== 0o700)) {
+  if (!info.isDirectory() || (parent ? info.uid !== policy.uid || (info.mode & 0o022) !== 0 : !exactMetadata(info, policy))) {
     await handle.close(); mapped(D1HostErrorCode.PLAN_INVALID, field)
   }
   return handle
 }
-async function directory(directory: string, field: string, ownerUid: number, parent = false): Promise<void> {
-  await (await openDirectory(directory, field, ownerUid, parent)).close()
+async function directory(directory: string, field: string, policy: ExactFsPolicy, parent = false): Promise<void> {
+  await (await openDirectory(directory, field, policy, parent)).close()
 }
-async function syncDirectory(directory: string, field: string, ownerUid: number, parent = false): Promise<void> {
-  const handle = await openDirectory(directory, field, ownerUid, parent)
+async function syncDirectory(directory: string, field: string, policy: ExactFsPolicy, parent = false): Promise<void> {
+  const handle = await openDirectory(directory, field, policy, parent)
   try { await handle.sync() } finally { await handle.close() }
 }
-async function ensureDirectory(directoryPath: string, parent: string, field: string, ownerUid: number, trustedParent = false): Promise<void> {
+async function finalizeDirectory(directoryPath: string, field: string, from: ExactFsPolicy, to: ExactFsPolicy): Promise<void> {
+  const handle = await openDirectory(directoryPath, field, from)
+  try {
+    await handle.chown(to.uid, to.gid); await handle.chmod(to.mode)
+    if (!exactMetadata(await handle.stat(), to)) mapped(D1HostErrorCode.PLAN_INVALID, field)
+    await handle.sync()
+  } finally { await handle.close() }
+}
+async function ensureDirectory(directoryPath: string, parent: string, field: string, policy: ExactFsPolicy, privatePolicy: ExactFsPolicy, parentPolicy: ExactFsPolicy, trustedParent = false): Promise<void> {
   let created = false
   try { await mkdir(directoryPath, { mode: 0o700 }); created = true } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error
   }
-  await directory(directoryPath, field, ownerUid)
-  if (created) await syncDirectory(parent, trustedParent ? 'storeParent' : 'managedParent', ownerUid, trustedParent)
+  if (created) await finalizeDirectory(directoryPath, field, privatePolicy, policy)
+  else await directory(directoryPath, field, policy)
+  if (created) await syncDirectory(parent, trustedParent ? 'storeParent' : 'managedParent', parentPolicy, trustedParent)
 }
-async function readRegular(file: string, ownerUid: number, optional = false, mode = 0o400): Promise<string | null> {
+async function readRegular(file: string, policy: ExactFsPolicy, optional = false): Promise<string | null> {
   let handle
   try { handle = await open(file, NOFOLLOW_READ) } catch (error) {
     if (optional && (error as NodeJS.ErrnoException).code === 'ENOENT') return null
@@ -105,22 +119,33 @@ async function readRegular(file: string, ownerUid: number, optional = false, mod
   }
   try {
     const info = await handle.stat()
-    if (!info.isFile() || info.nlink !== 1 || info.uid !== ownerUid || (info.mode & 0o777) !== mode) throw new Error('not regular')
+    if (!info.isFile() || !exactMetadata(info, policy, true)) throw new Error('not regular')
     return await handle.readFile('utf8')
   } finally { await handle.close() }
 }
-async function createDurable(file: string, content: string, ownerUid: number, mode = 0o400): Promise<void> {
+async function createDurable(file: string, content: string, policy: ExactFsPolicy): Promise<void> {
   const handle = await open(file, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600)
   try {
-    if ((await handle.stat()).uid !== ownerUid) throw new Error('wrong owner')
-    await handle.writeFile(content, 'utf8'); await handle.chmod(mode); await handle.sync()
+    const initial = await handle.stat()
+    if (!initial.isFile() || initial.uid !== policy.uid || initial.nlink !== 1) throw new Error('wrong owner')
+    await handle.writeFile(content, 'utf8'); await handle.chown(policy.uid, policy.gid); await handle.chmod(policy.mode)
+    if (!exactMetadata(await handle.stat(), policy, true)) throw new Error('wrong metadata')
+    await handle.sync()
   } finally { await handle.close() }
 }
 
 /** Mutations require the caller to hold the host's external OS lock. */
 export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1HostRevisionStore {
   if (!Number.isSafeInteger(options.ownerUid) || options.ownerUid < 0) throw new D1HostError(D1HostErrorCode.PLAN_INVALID, { field: 'ownerUid' })
+  if (!Number.isSafeInteger(options.appGid) || options.appGid <= 0) throw new D1HostError(D1HostErrorCode.PLAN_INVALID, { field: 'appGid' })
+  if (typeof process.getegid !== 'function') throw new D1HostError(D1HostErrorCode.PLAN_INVALID, { field: 'ownerGid' })
   const ownerUid = options.ownerUid
+  const ownerGid = process.getegid()
+  const privateDirectory = Object.freeze({ uid: ownerUid, gid: ownerGid, mode: 0o700 })
+  const redactedDirectory = Object.freeze({ uid: ownerUid, gid: options.appGid, mode: 0o710 })
+  const privateFile = Object.freeze({ uid: ownerUid, gid: ownerGid, mode: 0o400 })
+  const auditFile = Object.freeze({ uid: ownerUid, gid: ownerGid, mode: 0o600 })
+  const redactedFile = Object.freeze({ uid: ownerUid, gid: options.appGid, mode: 0o440 })
   const root = path.resolve(options.root)
   const hostRoot = (host: string) => path.join(root, hostId(host))
   const revisionsRoot = (host: string) => path.join(hostRoot(host), 'revisions')
@@ -131,22 +156,22 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
   const ensureHost = async (host: string) => {
     assertMutationOwner()
     const parent = path.dirname(root)
-    await directory(parent, 'storeParent', ownerUid, true)
+    await directory(parent, 'storeParent', privateDirectory, true)
     if (await realpath(parent) !== path.resolve(parent)) mapped(D1HostErrorCode.PLAN_INVALID, 'storeParent')
-    await ensureDirectory(root, parent, 'storeRoot', ownerUid, true)
+    await ensureDirectory(root, parent, 'storeRoot', privateDirectory, privateDirectory, privateDirectory, true)
     if (await realpath(root) !== root) mapped(D1HostErrorCode.PLAN_INVALID, 'storeRoot')
     const hostDirectory = hostRoot(host)
-    await ensureDirectory(hostDirectory, root, 'hostRoot', ownerUid)
+    await ensureDirectory(hostDirectory, root, 'hostRoot', redactedDirectory, privateDirectory, privateDirectory)
     const revisions = revisionsRoot(host)
-    await ensureDirectory(revisions, hostDirectory, 'revisions', ownerUid)
+    await ensureDirectory(revisions, hostDirectory, 'revisions', redactedDirectory, privateDirectory, redactedDirectory)
     return { hostDirectory, revisions }
   }
   const existingHost = async (host: string, includeRevisions: boolean, optional: boolean) => {
     try {
-      await directory(root, 'storeRoot', ownerUid)
+      await directory(root, 'storeRoot', privateDirectory)
       if (await realpath(root) !== root) mapped(D1HostErrorCode.PLAN_INVALID, 'storeRoot')
-      await directory(hostRoot(host), 'hostRoot', ownerUid)
-      if (includeRevisions) await directory(revisionsRoot(host), 'revisions', ownerUid)
+      await directory(hostRoot(host), 'hostRoot', redactedDirectory)
+      if (includeRevisions) await directory(revisionsRoot(host), 'revisions', redactedDirectory)
       return true
     } catch (error) {
       if (optional && (error as NodeJS.ErrnoException).code === 'ENOENT') return false
@@ -156,7 +181,7 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
   const revisionDirectory = async (host: string, revision: string, optional = false) => {
     if (!await existingHost(host, true, optional)) return null
     const target = revisionRoot(host, revision)
-    try { await directory(target, 'revision', ownerUid) } catch (error) {
+    try { await directory(target, 'revision', redactedDirectory) } catch (error) {
       if (optional && (error as NodeJS.ErrnoException).code === 'ENOENT') return null
       throw error
     }
@@ -165,8 +190,8 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
   const loadCandidate = async (host: string, revision: string): Promise<D1StoredCandidateV1 | null> => {
     const target = await revisionDirectory(host, revision, true)
     if (!target) return null
-    const desiredRaw = json((await readRegular(path.join(target, 'desired.json'), ownerUid))!)
-    const resolvedRaw = json((await readRegular(path.join(target, 'resolved.json'), ownerUid))!)
+    const desiredRaw = json((await readRegular(path.join(target, 'desired.json'), redactedFile))!)
+    const resolvedRaw = json((await readRegular(path.join(target, 'resolved.json'), redactedFile))!)
     exactKeys(desiredRaw, ['schemaVersion', 'domain', 'plan'], 'desiredFile')
     exactKeys(resolvedRaw, ['schemaVersion', 'domain', 'bindings'], 'resolvedFile')
     if (desiredRaw.schemaVersion !== 1 || desiredRaw.domain !== PLAN_DOMAIN) mapped(D1HostErrorCode.PLAN_INVALID, 'desiredFile')
@@ -174,33 +199,33 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
     const desired = await canonicalizeD1DesiredSnapshot({ schemaVersion: 1, domain: 'boring-d1-desired:v1', plan: desiredRaw.plan, resolvedBindings: resolvedRaw.bindings })
     if (desired.plan.hostId !== hostId(host)) mapped(D1HostErrorCode.PLAN_INVALID, 'desired.plan.hostId')
     const bindingsDirectory = path.join(target, 'bindings')
-    await directory(bindingsDirectory, 'bindings', ownerUid)
+    await directory(bindingsDirectory, 'bindings', redactedDirectory)
     const expectedBindingFiles = desired.plan.bindings.map((binding) => `${binding.bindingId}.env`).sort()
     const actualBindingFiles = (await readdir(bindingsDirectory)).sort()
     if (JSON.stringify(actualBindingFiles) !== JSON.stringify(expectedBindingFiles)) mapped(D1HostErrorCode.PLAN_INVALID, 'bindings')
     for (const binding of desired.plan.bindings) {
-      const content = await readRegular(path.join(bindingsDirectory, `${binding.bindingId}.env`), ownerUid)
+      const content = await readRegular(path.join(bindingsDirectory, `${binding.bindingId}.env`), redactedFile)
       validateD1BindingEnv(content!, binding)
     }
-    const secretRefs = canonicalizeD1SecretRefsEnvelope(json((await readRegular(path.join(target, 'secret-refs.json'), ownerUid))!), desired)
+    const secretRefs = canonicalizeD1SecretRefsEnvelope(json((await readRegular(path.join(target, 'secret-refs.json'), redactedFile))!), desired)
     const desiredStateDigest = await digestD1Desired(desired)
-    if ((await readRegular(path.join(target, 'desired.sha256'), ownerUid))!.trim() !== desiredStateDigest) mapped(D1HostErrorCode.PLAN_INVALID, 'desiredDigest')
+    if ((await readRegular(path.join(target, 'desired.sha256'), redactedFile))!.trim() !== desiredStateDigest) mapped(D1HostErrorCode.PLAN_INVALID, 'desiredDigest')
     return Object.freeze({ revisionId: revision, desired, desiredStateDigest, secretRefs })
   }
   const loadComplete = async (host: string, revision: string): Promise<D1StoredCompleteV1 | null> => {
     const target = await revisionDirectory(host, revision, true)
     if (!target) return null
-    const rawCompletion = await readRegular(path.join(target, 'completion.json'), ownerUid, true)
+    const rawCompletion = await readRegular(path.join(target, 'completion.json'), redactedFile, true)
     if (rawCompletion === null) return null
     const candidate = await loadCandidate(host, revision)
     if (!candidate) mapped(D1HostErrorCode.PLAN_INVALID, 'candidate')
-    const observation = await canonicalizeD1Observation(json((await readRegular(path.join(target, 'observed.json'), ownerUid))!), candidate.desired)
+    const observation = await canonicalizeD1Observation(json((await readRegular(path.join(target, 'observed.json'), redactedFile))!), candidate.desired)
     const completion = await canonicalizeD1CompleteEnvelope(json(rawCompletion), candidate.desired, observation)
     return Object.freeze({ ...candidate, observation, completion })
   }
   const loadActive = async (host: string): Promise<D1ActiveEnvelopeV1 | null> => {
     if (!await existingHost(host, false, true)) return null
-    const raw = await readRegular(path.join(hostRoot(host), 'active'), ownerUid, true)
+    const raw = await readRegular(path.join(hostRoot(host), 'active'), redactedFile, true)
     if (raw === null) return null
     const active = canonicalizeD1ActiveEnvelope(json(raw))
     const complete = await loadComplete(host, active.revisionId)
@@ -211,7 +236,7 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
     if (!repair && !await existingHost(host, false, true)) return Object.freeze([]) as readonly D1AuditRecordV1[]
     const hostDirectory = repair ? (await ensureHost(host)).hostDirectory : hostRoot(host)
     const file = path.join(hostDirectory, 'audit.jsonl')
-    const content = await readRegular(file, ownerUid, true, 0o600)
+    const content = await readRegular(file, auditFile, true)
     if (content === null || content === '') return Object.freeze([]) as readonly D1AuditRecordV1[]
     let durable = content
     if (!content.endsWith('\n')) {
@@ -223,10 +248,10 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
       const handle = await open(file, constants.O_RDWR | constants.O_NOFOLLOW)
       try {
         const info = await handle.stat()
-        if (!info.isFile() || info.uid !== ownerUid || (info.mode & 0o777) !== 0o600) throw new Error('wrong audit owner')
+        if (!info.isFile() || !exactMetadata(info, auditFile, true)) throw new Error('wrong audit owner')
         await handle.truncate(new TextEncoder().encode(durable).byteLength); await handle.sync()
       } finally { await handle.close() }
-      await syncDirectory(hostDirectory, 'hostRoot', ownerUid)
+      await syncDirectory(hostDirectory, 'hostRoot', redactedDirectory)
     }
     return records
   }
@@ -236,14 +261,14 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
       try {
         const { hostDirectory } = await ensureHost(host)
         const sequence = path.join(hostDirectory, 'sequence')
-        const raw = await readRegular(sequence, ownerUid, true)
+        const raw = await readRegular(sequence, privateFile, true)
         const current = raw === null ? 0 : Number(raw.trim())
         if (!Number.isSafeInteger(current) || current < 0 || current >= 9_999_999_999 || (raw !== null && raw.trim() !== String(current))) mapped(D1HostErrorCode.REVISION_CONFLICT, 'sequence')
         const next = current + 1
         const temporary = path.join(hostDirectory, `.sequence.${randomUUID()}`)
-        await createDurable(temporary, `${next}\n`, ownerUid)
+        await createDurable(temporary, `${next}\n`, privateFile)
         await rename(temporary, sequence)
-        await syncDirectory(hostDirectory, 'hostRoot', ownerUid)
+        await syncDirectory(hostDirectory, 'hostRoot', redactedDirectory)
         return `r${String(next).padStart(10, '0')}`
       } catch { mapped(D1HostErrorCode.REVISION_CONFLICT, 'sequence') }
     },
@@ -252,30 +277,32 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
       if (desired.plan.hostId !== hostId(host)) mapped(D1HostErrorCode.PLAN_INVALID, 'desired.plan.hostId')
       try {
         const { hostDirectory, revisions } = await ensureHost(host)
-        if ((await readRegular(path.join(hostDirectory, 'sequence'), ownerUid))!.trim() !== String(Number(revisionId(revision).slice(1)))) mapped(D1HostErrorCode.REVISION_CONFLICT, 'revisionId')
+        if ((await readRegular(path.join(hostDirectory, 'sequence'), privateFile))!.trim() !== String(Number(revisionId(revision).slice(1)))) mapped(D1HostErrorCode.REVISION_CONFLICT, 'revisionId')
         const target = revisionRoot(host, revision)
         try { await lstat(target); mapped(D1HostErrorCode.REVISION_CONFLICT, 'revisionId') } catch (error) {
           if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
         }
         const temporary = path.join(revisions, `.${revision}.${randomUUID()}`)
         await mkdir(temporary, { mode: 0o700 })
-        await directory(temporary, 'candidate', ownerUid)
+        await directory(temporary, 'candidate', privateDirectory)
         const desiredStateDigest = await digestD1Desired(desired)
         const secretRefs = deriveD1SecretRefsEnvelope(desired)
-        await createDurable(path.join(temporary, 'desired.json'), JSON.stringify({ schemaVersion: 1, domain: PLAN_DOMAIN, plan: desired.plan }), ownerUid)
-        await createDurable(path.join(temporary, 'resolved.json'), JSON.stringify({ schemaVersion: 1, domain: RESOLVED_DOMAIN, bindings: desired.resolvedBindings }), ownerUid)
-        await createDurable(path.join(temporary, 'secret-refs.json'), JSON.stringify(secretRefs), ownerUid)
-        await createDurable(path.join(temporary, 'desired.sha256'), `${desiredStateDigest}\n`, ownerUid)
+        await createDurable(path.join(temporary, 'desired.json'), JSON.stringify({ schemaVersion: 1, domain: PLAN_DOMAIN, plan: desired.plan }), redactedFile)
+        await createDurable(path.join(temporary, 'resolved.json'), JSON.stringify({ schemaVersion: 1, domain: RESOLVED_DOMAIN, bindings: desired.resolvedBindings }), redactedFile)
+        await createDurable(path.join(temporary, 'secret-refs.json'), JSON.stringify(secretRefs), redactedFile)
+        await createDurable(path.join(temporary, 'desired.sha256'), `${desiredStateDigest}\n`, redactedFile)
         const bindingsDirectory = path.join(temporary, 'bindings')
         await mkdir(bindingsDirectory, { mode: 0o700 })
-        await directory(bindingsDirectory, 'bindings', ownerUid)
+        await directory(bindingsDirectory, 'bindings', privateDirectory)
         for (const binding of desired.plan.bindings) {
-          await createDurable(path.join(bindingsDirectory, `${binding.bindingId}.env`), renderD1BindingEnv(binding), ownerUid)
+          await createDurable(path.join(bindingsDirectory, `${binding.bindingId}.env`), renderD1BindingEnv(binding), redactedFile)
         }
-        await syncDirectory(bindingsDirectory, 'bindings', ownerUid)
-        await syncDirectory(temporary, 'candidate', ownerUid)
+        await syncDirectory(bindingsDirectory, 'bindings', privateDirectory)
+        await finalizeDirectory(bindingsDirectory, 'bindings', privateDirectory, redactedDirectory)
+        await syncDirectory(temporary, 'candidate', privateDirectory)
+        await finalizeDirectory(temporary, 'candidate', privateDirectory, redactedDirectory)
         await rename(temporary, target)
-        await syncDirectory(revisions, 'revisions', ownerUid)
+        await syncDirectory(revisions, 'revisions', redactedDirectory)
         return Object.freeze({ revisionId: revision, desired, desiredStateDigest, secretRefs })
       } catch (error) {
         if (error instanceof D1HostError) throw error
@@ -295,8 +322,8 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
       const observation = await canonicalizeD1Observation(rawObservation, candidate.desired)
       try {
         const target = revisionRoot(host, revision)
-        await createDurable(path.join(target, 'observed.json'), JSON.stringify(observation), ownerUid)
-        await syncDirectory(target, 'revision', ownerUid)
+        await createDurable(path.join(target, 'observed.json'), JSON.stringify(observation), redactedFile)
+        await syncDirectory(target, 'revision', redactedDirectory)
         return observation
       } catch { mapped(D1HostErrorCode.COLLECTION_NOT_READY, 'observation') }
     },
@@ -308,10 +335,10 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
       if (!candidate) mapped(D1HostErrorCode.ROLLBACK_TARGET_INVALID, 'targetRevision')
       try {
         const target = revisionRoot(host, revision)
-        const observation = await canonicalizeD1Observation(json((await readRegular(path.join(target, 'observed.json'), ownerUid))!), candidate.desired)
+        const observation = await canonicalizeD1Observation(json((await readRegular(path.join(target, 'observed.json'), redactedFile))!), candidate.desired)
         const completion = await createD1CompleteEnvelope(revision, candidate.desired, observation)
-        await createDurable(path.join(target, 'completion.json'), JSON.stringify(completion), ownerUid)
-        await syncDirectory(target, 'revision', ownerUid)
+        await createDurable(path.join(target, 'completion.json'), JSON.stringify(completion), redactedFile)
+        await syncDirectory(target, 'revision', redactedDirectory)
         return Object.freeze({ ...candidate, observation, completion })
       } catch (error) {
         if (error instanceof D1HostError && error.details.field === 'completion.observation.ready') throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'observation' })
@@ -340,11 +367,11 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
           if (Number(active.revisionId.slice(1)) <= Number(current.revisionId.slice(1))) throw new Error('non-monotonic')
         }
         const temporary = path.join(hostDirectory, `.active.${randomUUID()}`)
-        await createDurable(temporary, JSON.stringify(active), ownerUid)
+        await createDurable(temporary, JSON.stringify(active), redactedFile)
         await rename(temporary, path.join(hostDirectory, 'active'))
         committed = true
         await options.fault?.('after-active-rename')
-        await syncDirectory(hostDirectory, 'hostRoot', ownerUid)
+        await syncDirectory(hostDirectory, 'hostRoot', redactedDirectory)
         if (JSON.stringify(await loadActive(host)) !== JSON.stringify(active)) throw new Error('verification')
         return active
       } catch { throw new D1ActivePublishError(committed) }
@@ -368,14 +395,14 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
         const { hostDirectory } = await ensureHost(host)
         await auditRecords(host, true)
         const file = path.join(hostDirectory, 'audit.jsonl')
-        const existed = await readRegular(file, ownerUid, true, 0o600) !== null
+        const existed = await readRegular(file, auditFile, true) !== null
         const handle = await open(file, constants.O_WRONLY | constants.O_APPEND | constants.O_CREAT | constants.O_NOFOLLOW, 0o600)
         try {
           const info = await handle.stat()
-          if (!info.isFile() || info.uid !== ownerUid || (info.mode & 0o777) !== 0o600) throw new Error('wrong audit owner')
+          if (!info.isFile() || !exactMetadata(info, auditFile, true)) throw new Error('wrong audit owner')
           await handle.writeFile(`${JSON.stringify(record)}\n`); await handle.sync()
         } finally { await handle.close() }
-        if (!existed) await syncDirectory(hostDirectory, 'hostRoot', ownerUid)
+        if (!existed) await syncDirectory(hostDirectory, 'hostRoot', redactedDirectory)
       } catch { mapped(D1HostErrorCode.PUBLICATION_FAILED, 'audit') }
     },
     async hasTerminalAudit(host, rawActive) {

--- a/deploy/d1/compose.yml
+++ b/deploy/d1/compose.yml
@@ -17,6 +17,7 @@ services:
     environment:
       HOST: "0.0.0.0"
       PORT: "3000"
+      BORING_D1_HOST_ID: "${D1_HOST_ID:?D1_HOST_ID is required}"
       BORING_AGENT_WORKSPACE_ROOT: "/data/workspaces"
       BORING_AGENT_SESSION_ROOT: "/data/pi-sessions"
     expose:
@@ -32,6 +33,8 @@ services:
         source: "${D1_STATE_ROOT:?D1_STATE_ROOT is required}"
         target: "/var/lib/boring/d1/${D1_HOST_ID:?D1_HOST_ID is required}"
         read_only: true
+        bind:
+          create_host_path: false
       - type: bind
         source: /run/boring/d1
         target: /run/boring/d1


### PR DESCRIPTION
## Summary

- enforce one canonical DAC split: private owner-only store root, sequence, audit, and temporary state; owner/app-group traverse-only revision directories plus group-readable redacted artifacts
- finalize and descriptor-verify UID, GID, full mode bits, and file link count before publication
- pin production app GID 10001 without widening the dependency-factory API
- expose the strict D1 host id to the core service and harden the exact host-subtree mount as read-only with `bind.create_host_path: false`

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/hostRevisionStore.test.ts src/server/deployment/__tests__/composeAdapter.test.ts src/server/deployment/__tests__/d1CommandCli.test.ts` - 3 files / 48 tests passed
- `pnpm --filter full-app typecheck` - passed
- `pnpm --filter full-app exec tsc -p tsconfig.server.json --noCheck` - server emit passed
- remote head verified as `ffccb9a61d33d6a91ee45aed204e6928d4cddcb8`

## Review

Structured autoreview raised one migration concern for interim `0700`/`0400` trees. This is consciously rejected under the accepted D1-R0 contract: there is no persisted production v1 state, old partial trees must fail closed, and immutable/security metadata must not be silently repaired with chmod/chgrp.

Final independent spec and maintainability reviews were clean after full-mode special-bit rejection and root-runner test portability were added.

## Handoff

D1-003b3 still owns the real container proof for UID/GID 10001 DAC behavior and tmpfs secret materialization. This PR adds no reader API, raw secret bytes, tmpfs writer, or activation wiring.