### PR TITLE
feat(391): read mounted active D1 collection

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/activeCollectionReader.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/activeCollectionReader.test.ts
@@ -1,0 +1,219 @@
+import { execFile } from 'node:child_process'
+import { chmod, link, mkdtemp, readFile, rename, symlink, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+import { createAgentAssetDigest, createAgentDeploymentDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
+import { createResolvedAgentDigest } from '@hachej/boring-agent/server'
+import { describe, expect, it } from 'vitest'
+
+import { createD1ActiveCollectionReader } from '../activeCollectionReader.js'
+import { D1HostErrorCode } from '../d1Plan.js'
+import { createD1DesiredSnapshot, type D1DesiredSnapshotV1 } from '../d1RevisionCodec.js'
+import { createD1RuntimeInputsIdentity } from '../d1RuntimeInputs.js'
+import { createHostRevisionStore } from '../hostRevisionStore.js'
+import { canonicalizeWorkspaceCompositionSnapshot } from '../workspaceComposition.js'
+
+const digest = (value: string): Sha256Digest => `sha256:${value.repeat(64).slice(0, 64)}`
+const OWNER_UID = process.geteuid!()
+const APP_GID = process.getegid!() || 10001
+const run = promisify(execFile)
+
+async function desired(): Promise<D1DesiredSnapshotV1> {
+  const snapshot = canonicalizeWorkspaceCompositionSnapshot({
+    schemaVersion: 1, domain: 'boring-workspace-composition:v1', workspaceId: 'workspace:insurance',
+    runtimeProfile: {
+      ref: 'runsc-eu', id: 'runsc', version: '2026.07.12', contentDigest: digest('b'),
+      isolationAttestationDigest: digest('c'), workspaceRootPolicyRef: 'workspace-roots', sessionRootPolicyRef: 'session-roots',
+    },
+    hostAppImageDigest: digest('a'), serverPlugins: [], defaultPluginPackages: [], staticSystemPromptDigest: digest('e'),
+    inventories: { capabilities: [], tools: [], skills: null, mcpServers: null }, provisioning: [], filesystemBindings: [],
+    policies: { externalPlugins: false, pluginAuthoring: false },
+  })
+  const compositionDigest = await createAgentAssetDigest(JSON.stringify(snapshot))
+  const definition = { definitionId: 'definition:insurance', version: '1.0.0', digest: digest('f'), instructionsRef: 'instructions.md' }
+  const deploymentInput = {
+    deploymentId: 'deployment:insurance', version: '2026.07.12', agentId: 'default',
+    definition: { definitionId: definition.definitionId, version: definition.version, digest: definition.digest },
+  }
+  const deploymentDigest = await createAgentDeploymentDigest(deploymentInput)
+  const resolvedDigest = await createResolvedAgentDigest({
+    workspaceId: snapshot.workspaceId, defaultDeploymentId: deploymentInput.deploymentId,
+    workspaceCompositionDigest: compositionDigest, definitionDigest: definition.digest, deploymentDigest,
+  })
+  return createD1DesiredSnapshot({
+    schemaVersion: 1, hostId: 'host-1', expectedHostRevision: null, hostAppImageDigest: digest('a'),
+    runtimeProfileRef: 'runsc-eu', databaseRef: 'postgres-eu', workspaceRootPolicyRef: 'workspace-roots',
+    sessionRootPolicyRef: 'session-roots', bindings: [{
+      bindingId: 'insurance', hostname: 'insurance.example.test', workspaceId: snapshot.workspaceId,
+      defaultDeploymentId: deploymentInput.deploymentId, bundleRef: 'bundle', deploymentRef: 'deployment',
+      workspaceAllocationRef: 'workspace-allocation', sessionAllocationRef: 'session-allocation', ownerPrincipalRef: 'owner',
+      landing: { title: 'Insurance', summary: 'Compare policies.' }, environmentRef: 'production', secretRefs: ['credential-ref'],
+    }],
+  }, [{
+    schemaVersion: 1, bindingId: 'insurance', composition: { snapshot, digest: compositionDigest },
+    workspace: { workspaceId: snapshot.workspaceId, defaultDeploymentId: deploymentInput.deploymentId, compositionDigest },
+    deployment: { deploymentId: deploymentInput.deploymentId, version: deploymentInput.version, agentId: 'default', digest: deploymentDigest },
+    definition, resolvedDigest,
+  }])
+}
+
+async function observation(value: D1DesiredSnapshotV1, ready = true) {
+  const binding = value.plan.bindings[0]!
+  return {
+    schemaVersion: 1 as const, domain: 'boring-d1-observed:v1' as const, bindings: [{
+      bindingId: binding.bindingId, ready, resolvedDigest: value.resolvedBindings[0]!.resolvedDigest,
+      runtimeInputs: await createD1RuntimeInputsIdentity(binding, {
+        environment: { versionFingerprint: digest('6') }, workspaceAllocation: { versionFingerprint: digest('7') },
+        sessionAllocation: { versionFingerprint: digest('8') },
+        secrets: [{ secretRef: 'credential-ref', providerVersionFingerprint: digest('9') }],
+      }),
+    }],
+  }
+}
+
+async function fixture(complete = true) {
+  const parent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-active-reader-'))
+  const root = path.join(parent, 'state')
+  const store = createHostRevisionStore({ root, ownerUid: OWNER_UID, appGid: APP_GID })
+  const value = await desired()
+  const revisionId = await store.reserveRevisionId('host-1')
+  const candidate = await store.writeCandidate('host-1', revisionId, value)
+  let active = { schemaVersion: 1 as const, revisionId, desiredStateDigest: candidate.desiredStateDigest }
+  if (complete) {
+    await store.writeObservation('host-1', revisionId, await observation(value))
+    await store.writeComplete('host-1', revisionId)
+    active = await store.publishActive('host-1', revisionId)
+  } else {
+    const activeFile = path.join(root, 'host-1', 'active')
+    await writeFile(activeFile, JSON.stringify(active)); await chmod(activeFile, 0o440)
+  }
+  const hostRoot = path.join(root, 'host-1')
+  const revisionRoot = path.join(hostRoot, 'revisions', revisionId)
+  return { hostRoot, revisionRoot, revisionId, active, value }
+}
+
+function reader(hostRoot: string, overrides: Partial<Parameters<typeof createD1ActiveCollectionReader>[0]> = {}) {
+  return createD1ActiveCollectionReader({ hostRoot, hostId: 'host-1', ownerUid: OWNER_UID, appGid: APP_GID, ...overrides })
+}
+
+async function rewriteJson(file: string, mutate: (raw: Record<string, any>) => void): Promise<void> {
+  const raw = JSON.parse(await readFile(file, 'utf8')) as Record<string, any>
+  mutate(raw); await chmod(file, 0o600); await writeFile(file, JSON.stringify(raw)); await chmod(file, 0o440)
+}
+
+async function expectFailure(action: Promise<unknown>): Promise<void> {
+  const failure = await action.catch((error) => error)
+  expect(failure).toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED, details: { field: 'active' } })
+  expect(JSON.stringify(failure)).not.toMatch(/credential-ref|secret-value|private|active-reader-|desired\.json|resolved\.json/)
+}
+
+describe('D1 mounted active collection reader', () => {
+  it('returns one frozen canonical COMPLETE collection', async () => {
+    const h = await fixture()
+    const collection = await reader(h.hostRoot).read()
+    expect(collection).toMatchObject({ active: h.active, desired: h.value, observation: { bindings: [{ ready: true }] }, completion: { status: 'COMPLETE' } })
+    expect(Object.isFrozen(collection)).toBe(true)
+    expect(Object.isFrozen(collection!.desired.plan.bindings)).toBe(true)
+    expect(collection).not.toHaveProperty('secretRefs')
+  })
+
+  it('returns null only for a valid mounted host tree without active', async () => {
+    const h = await fixture()
+    await rename(path.join(h.hostRoot, 'active'), path.join(h.hostRoot, 'inactive'))
+    expect(await reader(h.hostRoot).read()).toBeNull()
+    await chmod(h.hostRoot, 0o700)
+    await expectFailure(reader(h.hostRoot).read())
+  })
+
+  it.each([
+    ['candidate/incomplete', async () => fixture(false), async () => {}],
+    ['orphan', fixture, async (h: Awaited<ReturnType<typeof fixture>>) => rewriteJson(path.join(h.hostRoot, 'active'), (raw) => { raw.revisionId = 'r9999999999' })],
+    ['host mismatch', fixture, async (h: Awaited<ReturnType<typeof fixture>>) => { await expectFailure(reader(h.hostRoot, { hostId: 'host-2' }).read()) }],
+    ['active digest mismatch', fixture, async (h: Awaited<ReturnType<typeof fixture>>) => rewriteJson(path.join(h.hostRoot, 'active'), (raw) => { raw.desiredStateDigest = digest('0') })],
+  ])('rejects %s publication state', async (name, make, mutate) => {
+    const h = await make(); await mutate(h)
+    if (name !== 'host mismatch') await expectFailure(reader(h.hostRoot).read())
+  })
+
+  it.each(['active', 'desired.json', 'resolved.json', 'secret-refs.json', 'observed.json', 'completion.json'])
+    ('rejects malformed and extra-key %s JSON', async (artifact) => {
+      for (const extra of [false, true]) {
+        const h = await fixture(); const file = artifact === 'active' ? path.join(h.hostRoot, artifact) : path.join(h.revisionRoot, artifact)
+        await chmod(file, 0o600)
+        await writeFile(file, extra ? JSON.stringify({ ...JSON.parse(await readFile(file, 'utf8')), unexpected: true }) : '{malformed')
+        await chmod(file, 0o440)
+        await expectFailure(reader(h.hostRoot).read())
+      }
+    })
+
+  it.each([
+    ['desired.json', (raw: any) => { raw.plan.hostId = 'host-2' }],
+    ['resolved.json', (raw: any) => { raw.bindings[0].resolvedDigest = digest('0') }],
+    ['secret-refs.json', (raw: any) => { raw.bindings[0].secretRefs.push('secret-value') }],
+    ['observed.json', (raw: any) => { raw.bindings[0].runtimeInputs.environment.versionFingerprint = digest('0') }],
+    ['completion.json', (raw: any) => { raw.completionDigest = digest('0') }],
+  ])('rejects tampered %s', async (artifact, mutate) => {
+    const h = await fixture(); await rewriteJson(path.join(h.revisionRoot, artifact), mutate)
+    await expectFailure(reader(h.hostRoot).read())
+  })
+
+  it('rejects tampered desired digest and binding env', async () => {
+    for (const artifact of ['desired.sha256', 'bindings/insurance.env']) {
+      const h = await fixture(); const file = path.join(h.revisionRoot, artifact)
+      await chmod(file, 0o600); await writeFile(file, 'secret-value\n'); await chmod(file, 0o440)
+      await expectFailure(reader(h.hostRoot).read())
+    }
+  })
+
+  it.each(['.', 'revisions', 'revision', 'bindings'])('rejects symlinked or wrongly-modeled %s directory', async (kind) => {
+    for (const mutation of ['symlink', 'mode']) {
+      const h = await fixture()
+      const target = kind === '.' ? h.hostRoot : kind === 'revisions' ? path.join(h.hostRoot, 'revisions')
+        : kind === 'revision' ? h.revisionRoot : path.join(h.revisionRoot, 'bindings')
+      if (mutation === 'mode') await chmod(target, 0o755)
+      else { await rename(target, `${target}.target`); await symlink(`${target}.target`, target) }
+      await expectFailure(reader(h.hostRoot).read())
+    }
+  })
+
+  it.each(['active', 'desired.json', 'resolved.json', 'secret-refs.json', 'desired.sha256', 'bindings/insurance.env', 'observed.json', 'completion.json'])
+    ('rejects linked or wrongly-modeled %s', async (artifact) => {
+      for (const mutation of ['symlink', 'hardlink', 'mode']) {
+        const h = await fixture(); const file = artifact === 'active' ? path.join(h.hostRoot, artifact) : path.join(h.revisionRoot, artifact)
+        if (mutation === 'mode') await chmod(file, 0o444)
+        else if (mutation === 'hardlink') await link(file, `${file}.link`)
+        else { await rename(file, `${file}.target`); await symlink(`${file}.target`, file) }
+        await expectFailure(reader(h.hostRoot).read())
+      }
+    })
+
+  it('rejects a FIFO substitution without blocking before fstat', async () => {
+    const h = await fixture(); const active = path.join(h.hostRoot, 'active')
+    await rename(active, `${active}.target`); await run('mkfifo', [active]); await chmod(active, 0o440)
+    const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error('FIFO open blocked')), 500))
+    await expectFailure(Promise.race([reader(h.hostRoot).read(), timeout]))
+  })
+
+  it('rejects wrong expected owner and group plus noncanonical factory inputs', async () => {
+    const h = await fixture()
+    await expectFailure(reader(h.hostRoot, { ownerUid: OWNER_UID + 1 }).read())
+    await expectFailure(reader(h.hostRoot, { appGid: APP_GID + 1 }).read())
+    for (const options of [
+      undefined, { hostRoot: 'relative', hostId: 'host-1', ownerUid: OWNER_UID, appGid: APP_GID },
+      { hostRoot: `${h.hostRoot}/`, hostId: 'host-1', ownerUid: OWNER_UID, appGid: APP_GID },
+      { hostRoot: h.hostRoot, hostId: '../host', ownerUid: OWNER_UID, appGid: APP_GID },
+      { hostRoot: h.hostRoot, hostId: 'host-1', ownerUid: -1, appGid: APP_GID },
+      { hostRoot: h.hostRoot, hostId: 'host-1', ownerUid: OWNER_UID, appGid: 0 },
+    ]) expect(() => createD1ActiveCollectionReader(options as never)).toThrow(expect.objectContaining({ code: D1HostErrorCode.PLAN_INVALID }))
+  })
+
+  it('does not inspect providers, /run, directory contents, or secret-value files', async () => {
+    const h = await fixture()
+    await writeFile(path.join(h.revisionRoot, 'secret-values.json'), 'secret-value', { mode: 0 })
+    expect(await reader(h.hostRoot).read()).not.toBeNull()
+    const source = await readFile(new URL('../activeCollectionReader.ts', import.meta.url), 'utf8')
+    expect(source).not.toMatch(/createHostRevisionStore|O_DIRECTORY|readdir|provider|['"]\/run|process\.env/)
+  })
+})

--- a/apps/full-app/src/server/deployment/activeCollectionReader.ts
+++ b/apps/full-app/src/server/deployment/activeCollectionReader.ts
@@ -1,0 +1,136 @@
+import { constants, type Stats } from 'node:fs'
+import { lstat, open, realpath } from 'node:fs/promises'
+import path from 'node:path'
+
+import { validateD1BindingEnv } from './d1BindingEnv.js'
+import { assertD1ExactKeys as exactKeys, D1HostError, D1HostErrorCode, strictD1HostId } from './d1Plan.js'
+import {
+  canonicalizeD1ActiveEnvelope,
+  canonicalizeD1CompleteEnvelope,
+  canonicalizeD1DesiredSnapshot,
+  canonicalizeD1Observation,
+  canonicalizeD1SecretRefsEnvelope,
+  digestD1Desired,
+  type D1ActiveEnvelopeV1,
+  type D1CompleteEnvelopeV1,
+  type D1DesiredSnapshotV1,
+  type D1ObservationV1,
+} from './d1RevisionCodec.js'
+
+const PLAN_DOMAIN = 'boring-d1-plan:v1'
+const RESOLVED_DOMAIN = 'boring-d1-resolved:v1'
+const DIRECTORY_MODE = 0o710
+const FILE_MODE = 0o440
+const NOFOLLOW_READ = constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK
+const FILE_LIMIT = 4 * 1024 * 1024
+
+export interface D1ActiveCollection {
+  readonly active: D1ActiveEnvelopeV1
+  readonly desired: D1DesiredSnapshotV1
+  readonly observation: D1ObservationV1
+  readonly completion: D1CompleteEnvelopeV1
+}
+
+export interface D1ActiveCollectionReader {
+  read(): Promise<D1ActiveCollection | null>
+}
+
+export interface D1ActiveCollectionReaderOptions {
+  readonly hostRoot: string
+  readonly hostId: string
+  readonly ownerUid: number
+  readonly appGid: number
+}
+
+interface FsPolicy { readonly uid: number, readonly gid: number }
+
+function invalid(field: string): never {
+  throw new D1HostError(D1HostErrorCode.PLAN_INVALID, { field })
+}
+
+function publicationFailed(): never {
+  throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'active' })
+}
+
+function exactMetadata(info: Stats, policy: FsPolicy, mode: number, links = false): boolean {
+  return info.uid === policy.uid && info.gid === policy.gid && (info.mode & 0o7777) === mode && (!links || info.nlink === 1)
+}
+
+async function assertDirectory(directory: string, policy: FsPolicy): Promise<void> {
+  // The trusted publication owner keeps named revisions immutable; lstat preserves app-group traversal of 0710 directories without requiring read access.
+  const info = await lstat(directory)
+  if (!info.isDirectory() || !exactMetadata(info, policy, DIRECTORY_MODE)) throw new Error('invalid directory')
+}
+
+async function readFile(file: string, policy: FsPolicy, optional = false, limit = FILE_LIMIT): Promise<string | null> {
+  let handle
+  try { handle = await open(file, NOFOLLOW_READ) } catch (error) {
+    if (optional && (error as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw error
+  }
+  try {
+    const info = await handle.stat()
+    if (!info.isFile() || !exactMetadata(info, policy, FILE_MODE, true) || info.size < 0 || info.size > limit) throw new Error('invalid file')
+    return await handle.readFile('utf8')
+  } finally { await handle.close() }
+}
+
+function json(content: string): unknown {
+  return JSON.parse(content) as unknown
+}
+
+export function createD1ActiveCollectionReader(options: D1ActiveCollectionReaderOptions): D1ActiveCollectionReader {
+  if (typeof options?.hostRoot !== 'string' || options.hostRoot.includes('\0') || !path.isAbsolute(options.hostRoot)
+    || path.resolve(options.hostRoot) !== options.hostRoot) invalid('hostRoot')
+  let hostId: string
+  try { hostId = strictD1HostId(options.hostId, 'hostId') } catch { invalid('hostId') }
+  if (!Number.isSafeInteger(options.ownerUid) || options.ownerUid < 0) invalid('ownerUid')
+  if (!Number.isSafeInteger(options.appGid) || options.appGid <= 0) invalid('appGid')
+  const hostRoot = options.hostRoot
+  const policy = Object.freeze({ uid: options.ownerUid, gid: options.appGid })
+
+  return Object.freeze({
+    async read(): Promise<D1ActiveCollection | null> {
+      try {
+        if (await realpath(hostRoot) !== hostRoot) throw new Error('non-canonical host root')
+        await assertDirectory(hostRoot, policy)
+        const revisionsRoot = path.join(hostRoot, 'revisions')
+        await assertDirectory(revisionsRoot, policy)
+        const activeContent = await readFile(path.join(hostRoot, 'active'), policy, true, 16 * 1024)
+        if (activeContent === null) return null
+        const active = canonicalizeD1ActiveEnvelope(json(activeContent))
+        const revisionRoot = path.join(revisionsRoot, active.revisionId)
+        await assertDirectory(revisionRoot, policy)
+
+        const desiredFile = json((await readFile(path.join(revisionRoot, 'desired.json'), policy))!)
+        const resolvedFile = json((await readFile(path.join(revisionRoot, 'resolved.json'), policy))!)
+        exactKeys(desiredFile, ['schemaVersion', 'domain', 'plan'], 'desiredFile')
+        exactKeys(resolvedFile, ['schemaVersion', 'domain', 'bindings'], 'resolvedFile')
+        if (desiredFile.schemaVersion !== 1 || desiredFile.domain !== PLAN_DOMAIN
+          || resolvedFile.schemaVersion !== 1 || resolvedFile.domain !== RESOLVED_DOMAIN) throw new Error('invalid split snapshot')
+        const desired = await canonicalizeD1DesiredSnapshot({
+          schemaVersion: 1, domain: 'boring-d1-desired:v1', plan: desiredFile.plan, resolvedBindings: resolvedFile.bindings,
+        })
+        if (desired.plan.hostId !== hostId) throw new Error('host mismatch')
+        const desiredStateDigest = await digestD1Desired(desired)
+        if (active.desiredStateDigest !== desiredStateDigest
+          || await readFile(path.join(revisionRoot, 'desired.sha256'), policy, false, 256) !== `${desiredStateDigest}\n`) throw new Error('digest mismatch')
+
+        canonicalizeD1SecretRefsEnvelope(json((await readFile(path.join(revisionRoot, 'secret-refs.json'), policy, false, FILE_LIMIT))!), desired)
+        const bindingsRoot = path.join(revisionRoot, 'bindings')
+        await assertDirectory(bindingsRoot, policy)
+        for (const binding of desired.plan.bindings) {
+          validateD1BindingEnv((await readFile(path.join(bindingsRoot, `${binding.bindingId}.env`), policy, false, 64 * 1024))!, binding)
+        }
+        const observation = await canonicalizeD1Observation(
+          json((await readFile(path.join(revisionRoot, 'observed.json'), policy))!), desired,
+        )
+        const completion = await canonicalizeD1CompleteEnvelope(
+          json((await readFile(path.join(revisionRoot, 'completion.json'), policy, false, 16 * 1024))!), desired, observation,
+        )
+        if (completion.revisionId !== active.revisionId || completion.desiredStateDigest !== active.desiredStateDigest) throw new Error('completion mismatch')
+        return Object.freeze({ active, desired, observation, completion })
+      } catch { publicationFailed() }
+    },
+  })
+}


### PR DESCRIPTION
## Summary
- read one mounted active pointer and its immutable COMPLETE revision through existing D1 codecs
- enforce exact owner/group DAC on the 0710 directory chain and O_NOFOLLOW/O_NONBLOCK 0440 regular files
- validate split desired/resolved state, digest, secret refs, binding env, observation, and completion without store mutation or secret-value access

## Boundaries
- no `createHostRevisionStore`, writes, audit, cache, watcher, P6-R, provider, `/run`, startup/env wiring, or directory enumeration
- trusted publication owner and immutable named revisions are the pathname-stability boundary; final files remain no-follow and single-link

## Proof
- recut patch ID equals reviewed source commit
- 33 focused tests, including FIFO nonblocking, symlink/hardlink/DAC/tamper/redaction cases
- full-app typecheck clean
- structured autoreview clean; independent security review clean

Issue: #391