### PR TITLE
fix(agent): confine read-only skill-file reads to caller workspace (cross-workspace read)

### DIFF
--- a/packages/agent/src/server/http/readonlySkillFiles.ts
+++ b/packages/agent/src/server/http/readonlySkillFiles.ts
@@ -1,4 +1,7 @@
 import { readFile, stat } from 'node:fs/promises'
+import { isAbsolute, relative, resolve } from 'node:path'
+
+import { assertRealPathWithinWorkspace } from '../workspace/paths'
 
 export interface ReadonlySkillFileStat {
   kind: 'file' | 'directory'
@@ -6,17 +9,68 @@ export interface ReadonlySkillFileStat {
   mtimeMs: number
 }
 
+interface ReadonlySkillConfinementError extends Error {
+  statusCode: number
+  reason: string
+  requestedPath: string
+}
+
 export function isReadonlySkillFilePath(path: string): boolean {
   if (!path.startsWith('/')) return false
   if (path.includes('\0')) return false
   if (!path.endsWith('/SKILL.md')) return false
+  // Defensive: never accept traversal segments. `resolve()` would collapse
+  // them, but keeping them out means the accepted set is only literal,
+  // already-normalized absolute paths — no surprising `..` rewrites.
+  if (path.split('/').some((segment) => segment === '..')) return false
   // Narrow absolute-path exception: discovered pi skills may live outside the
-  // workspace root (for example /root/.pi/agent/skills/... in containers).
-  // Let the editor read those actual skill files, but never write/delete/move.
+  // workspace root (for example <agentDir>/skills/... — a shared, read-only
+  // global skills location). Confinement to the caller's allowed roots is
+  // enforced separately by `assertReadonlySkillFileConfined` before any read.
   return path.includes('/.pi/agent/') && path.includes('/skills/')
 }
 
-export async function readReadonlySkillFile(path: string): Promise<{ content: string; stat: ReadonlySkillFileStat }> {
+function isLexicallyInside(root: string, resolvedPath: string): boolean {
+  if (!root) return false
+  const rel = relative(resolve(root), resolvedPath)
+  return !rel.startsWith('..') && !isAbsolute(rel)
+}
+
+/**
+ * Confine a read-only skill-file path to the caller's authorized roots.
+ *
+ * The route bypasses the normal workspace-relative confinement so it can read
+ * discovered global skills that live outside the workspace root, but that
+ * bypass must never reach the whole host filesystem. `allowedRoots` is the
+ * caller's workspace root plus the explicitly-shared global skills root
+ * (pi's agent dir). We reuse the workspace adapter's realpath boundary check
+ * (`assertRealPathWithinWorkspace`) so symlink escapes are rejected exactly
+ * as they are for every other `user`-filesystem read.
+ */
+export async function assertReadonlySkillFileConfined(
+  path: string,
+  allowedRoots: readonly string[],
+): Promise<void> {
+  const resolved = resolve(path)
+  const lexicalRoot = allowedRoots.find((root) => isLexicallyInside(root, resolved))
+  if (!lexicalRoot) {
+    throw Object.assign(new Error('read-only skill file escapes allowed roots'), {
+      statusCode: 403,
+      reason: 'path-escape',
+      requestedPath: path,
+    }) as ReadonlySkillConfinementError
+  }
+  // Realpath boundary: a symlink under an allowed root must not escape it.
+  // A missing file surfaces as ENOENT here → classified as 404, matching the
+  // normal `user`-fs read path.
+  await assertRealPathWithinWorkspace(lexicalRoot, resolved)
+}
+
+export async function readReadonlySkillFile(
+  path: string,
+  allowedRoots: readonly string[],
+): Promise<{ content: string; stat: ReadonlySkillFileStat }> {
+  await assertReadonlySkillFileConfined(path, allowedRoots)
   const [content, fsStat] = await Promise.all([
     readFile(path, 'utf-8'),
     stat(path),
@@ -31,7 +85,11 @@ export async function readReadonlySkillFile(path: string): Promise<{ content: st
   }
 }
 
-export async function statReadonlySkillFile(path: string): Promise<ReadonlySkillFileStat> {
+export async function statReadonlySkillFile(
+  path: string,
+  allowedRoots: readonly string[],
+): Promise<ReadonlySkillFileStat> {
+  await assertReadonlySkillFileConfined(path, allowedRoots)
   const fsStat = await stat(path)
   return {
     kind: fsStat.isDirectory() ? 'directory' : 'file',

--- a/packages/agent/src/server/http/routes/__tests__/file.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/file.test.ts
@@ -1033,4 +1033,58 @@ describe('file routes (NodeWorkspace integration)', () => {
     expect(res.statusCode).toBe(403)
     expect(res.json().error.code).toBe('path_rejected')
   })
+
+  test('reads an in-workspace read-only skill file matching the SKILL.md pattern', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-skill-in-'))
+    tempRoots.push(workspaceRoot)
+    const skillDir = join(workspaceRoot, '.pi', 'agent', 'skills', 'demo')
+    await mkdir(skillDir, { recursive: true })
+    await writeFile(join(skillDir, 'SKILL.md'), '# demo skill', 'utf-8')
+
+    const app = await createTestAppWithWorkspace(createNodeWorkspace(workspaceRoot))
+    const abs = join(skillDir, 'SKILL.md')
+
+    const readRes = await app.inject({
+      method: 'GET',
+      url: `/api/v1/files?path=${encodeURIComponent(abs)}`,
+    })
+    expect(readRes.statusCode).toBe(200)
+    expect(readRes.json().content).toBe('# demo skill')
+
+    const statRes = await app.inject({
+      method: 'GET',
+      url: `/api/v1/stat?path=${encodeURIComponent(abs)}`,
+    })
+    expect(statRes.statusCode).toBe(200)
+    expect(statRes.json().kind).toBe('file')
+  })
+
+  test('rejects a SKILL.md path resolving outside the caller workspace root', async () => {
+    const workspaceRoot = await mkdtemp(join(tmpdir(), 'boring-ui-skill-caller-'))
+    const otherRoot = await mkdtemp(join(tmpdir(), 'boring-ui-skill-other-'))
+    tempRoots.push(workspaceRoot, otherRoot)
+
+    // A cross-tenant skill file: matches the read-only SKILL.md pattern but
+    // lives under a different workspace root. Must never be readable.
+    const otherSkillDir = join(otherRoot, '.pi', 'agent', 'skills', 'secret')
+    await mkdir(otherSkillDir, { recursive: true })
+    await writeFile(join(otherSkillDir, 'SKILL.md'), 'TENANT_B_SECRET_123', 'utf-8')
+
+    const app = await createTestAppWithWorkspace(createNodeWorkspace(workspaceRoot))
+    const abs = join(otherSkillDir, 'SKILL.md')
+
+    const readRes = await app.inject({
+      method: 'GET',
+      url: `/api/v1/files?path=${encodeURIComponent(abs)}`,
+    })
+    expect([403, 404]).toContain(readRes.statusCode)
+    expect(readRes.body).not.toContain('TENANT_B_SECRET_123')
+
+    const statRes = await app.inject({
+      method: 'GET',
+      url: `/api/v1/stat?path=${encodeURIComponent(abs)}`,
+    })
+    expect([403, 404]).toContain(statRes.statusCode)
+    expect(statRes.body).not.toContain('TENANT_B_SECRET_123')
+  })
 })

--- a/packages/agent/src/server/http/routes/file.ts
+++ b/packages/agent/src/server/http/routes/file.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify'
 import { dirname, extname, relative } from 'node:path/posix'
+import { getAgentDir } from '@mariozechner/pi-coding-agent'
 import type { Workspace } from '../../../shared/workspace'
 import type { RuntimeFilesystemBinding } from '../../runtime/mode'
 import {
@@ -136,6 +137,17 @@ function classifyError(
 
 function requestedFilesystem(value: unknown): string {
   return typeof value === 'string' && value.length > 0 ? value : USER_FILESYSTEM_ID
+}
+
+/**
+ * Roots the read-only skill-file bypass is allowed to reach: the caller's own
+ * workspace root, plus pi's shared global agent dir (the read-only global
+ * skills location the skills route discovers). Anything else — notably another
+ * tenant's workspace root — is rejected, keeping the bypass from becoming a
+ * cross-workspace host-filesystem read.
+ */
+function readonlySkillRoots(workspace: Workspace): string[] {
+  return [workspace.root, getAgentDir()]
 }
 
 function sendNotFoundOrDenied(reply: FastifyReply): FastifyReply {
@@ -402,8 +414,9 @@ export function fileRoutes(
     }
 
     try {
+      const workspace = await resolveWorkspace(request)
       if (isReadonlySkillFilePath(path)) {
-        const { content, stat } = await readReadonlySkillFile(path)
+        const { content, stat } = await readReadonlySkillFile(path, readonlySkillRoots(workspace))
         if (stat.kind !== 'file') {
           return reply.code(400).send({
             error: { code: ERROR_CODE_VALIDATION_ERROR, message: 'path is not a file', field: 'path' },
@@ -411,7 +424,6 @@ export function fileRoutes(
         }
         return { content, mtimeMs: stat.mtimeMs }
       }
-      const workspace = await resolveWorkspace(request)
       if (workspace.readFileWithStat) {
         const { content, stat } = await workspace.readFileWithStat(path)
         return { content, mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined, access: 'readwrite' }
@@ -730,10 +742,10 @@ if (filesystem !== USER_FILESYSTEM_ID) {
     }
 
     try {
-      if (isReadonlySkillFilePath(path)) {
-        return await statReadonlySkillFile(path)
-      }
       const workspace = await resolveWorkspace(request)
+      if (isReadonlySkillFilePath(path)) {
+        return await statReadonlySkillFile(path, readonlySkillRoots(workspace))
+      }
       const stat = await workspace.stat(path)
       return stat
     } catch (err) {


### PR DESCRIPTION
## Boundary issue

The `user`-filesystem branch of the file HTTP routes (`GET /api/v1/files`, `GET /api/v1/stat`) has a read-only skill-file exception (`readonlySkillFiles.ts` / `isReadonlySkillFilePath`). Any absolute path shaped like `/.../.pi/agent/.../skills/.../SKILL.md` was read **directly off the host filesystem**, bypassing the workspace-root confinement that every other `user`-fs read enforces via the workspace adapter.

Consequence: in a governed multi-tenant deployment, an authenticated member of **any** workspace could read **any** `SKILL.md` anywhere on the host — including other tenants/workspaces skill files. It is not arbitrary-filename LFI (the target must literally be `SKILL.md`, and `..` did not yield arbitrary files), but it crosses the workspace/tenant boundary, which is unacceptable for a governed multi-tenant product.

## Fix

Confine the resolved absolute skill path to the caller's authorized roots:

- the caller's **own workspace root** (`workspace.root`), plus
- pi's shared **global agent dir** (`getAgentDir()`) — the read-only global-skills location the skills route already discovers.

Confinement reuses the workspace adapter's realpath boundary check (`assertRealPathWithinWorkspace` from `server/workspace/paths.ts`) — the same validation the normal `user`-fs read uses — so symlink escapes are rejected exactly as for any other read. A path outside the allowed roots (notably another tenant's workspace root) now `403`s; a missing file `404`s. The gate also defensively rejects `..` segments.

Per invariants: routes receive a `Workspace` (#3); path validation stays in the adapter module (#4).

## Preserved feature

Reading discovered **global / out-of-workspace pi skills** (e.g. `<agentDir>/skills/.../SKILL.md`) read-only in the editor still works — that was the legitimate reason for the absolute-path exception (see the original comment citing `/root/.pi/agent/skills/...` in containers). All boring-agent provisioned skill paths resolve inside the workspace root; global/default/package skills resolve under `getAgentDir()`; both remain readable.

### Scope note (fail-safe)

Host-configured `additionalSkillPaths` that point **outside** both the workspace root and `getAgentDir()` are no longer inline-readable through this bypass. This is intentional fail-safe behavior: the skill still appears in the skills list, it just is not read via the host-fs bypass. Closing the cross-tenant hole takes priority over that edge case.

## Tests

Added regression tests in `file.test.ts`:
- a `SKILL.md` resolving **outside** the caller workspace root is rejected (`403`/`404`) and its content is never returned (both `/files` and `/stat`);
- a legit **in-workspace** skill file matching the pattern still reads (`200`).

## Gates

`packages/agent`: check-invariants OK, typecheck OK, build OK, full test suite 1887 passed / 6 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)