### PR TITLE
#613 Task active-agent indicators

### DIFF
--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { BoringTaskCard, BoringTaskSessionBinding } from "../shared"
 import { TaskCard } from "./TaskCard"
+import { TaskSessionActivityProvider } from "./taskSessionActivity"
 
 const postJson = vi.fn()
 const getJson = vi.fn()
@@ -49,14 +50,15 @@ beforeEach(() => {
 })
 
 describe("TaskCard task chat sessions", () => {
-  it("orders all activity priorities before idle and applies recency within a priority", async () => {
+  it("orders active sessions by priority, then all non-active sessions by recency", async () => {
     const workingOld = link({ id: "working-old", sessionId: "pi-working-old", title: "Working old", createdAt: "2026-07-01T00:00:00.000Z" })
     const workingNew = link({ id: "working-new", sessionId: "pi-working-new", title: "Working new", createdAt: "2026-07-01T00:00:00.000Z" })
     const queued = link({ id: "queued", sessionId: "pi-queued", title: "Queued", createdAt: "2026-07-04T00:00:00.000Z" })
     const errored = link({ id: "error", sessionId: "pi-error", title: "Errored", createdAt: "2026-07-05T00:00:00.000Z" })
     const idle = link({ id: "idle", sessionId: "pi-idle", title: "Idle", createdAt: "2026-07-06T00:00:00.000Z" })
+    const missing = link({ id: "missing", sessionId: "pi-missing", title: "Missing", createdAt: "2026-07-10T00:00:00.000Z" })
     postJson.mockImplementation(async (path: string) => {
-      if (path === "/api/boring-tasks/sessions/list") return { links: [idle, errored, queued, workingOld, workingNew] }
+      if (path === "/api/boring-tasks/sessions/list") return { links: [idle, missing, errored, queued, workingOld, workingNew] }
       if (path === "/api/v1/agent/pi-chat/sessions/activity") return {
         activities: [
           { sessionId: "pi-working-old", status: "working", source: "live-runtime", updatedAt: "2026-07-02T00:00:00.000Z" },
@@ -65,7 +67,7 @@ describe("TaskCard task chat sessions", () => {
           { sessionId: "pi-error", status: "error", source: "live-runtime", updatedAt: "2026-07-08T00:00:00.000Z" },
           { sessionId: "pi-idle", status: "idle", source: "persisted", updatedAt: "2026-07-09T00:00:00.000Z" },
         ],
-        omittedSessionIds: [],
+        omittedSessionIds: ["pi-missing"],
       }
       throw new Error(`unexpected post ${path}`)
     })
@@ -75,12 +77,13 @@ describe("TaskCard task chat sessions", () => {
     fireEvent.click(screen.getByRole("button", { name: /open chat/i }))
 
     const rows = await screen.findAllByRole("listitem")
-    expect(rows.map((row) => row.textContent)).toEqual(expect.arrayContaining([expect.stringContaining("Working new"), expect.stringContaining("Working old"), expect.stringContaining("Queued"), expect.stringContaining("Errored"), expect.stringContaining("Idle")]))
+    expect(rows.map((row) => row.textContent)).toEqual(expect.arrayContaining([expect.stringContaining("Working new"), expect.stringContaining("Working old"), expect.stringContaining("Queued"), expect.stringContaining("Missing"), expect.stringContaining("Idle"), expect.stringContaining("Errored")]))
     expect(rows[0]).toHaveTextContent("Working new")
     expect(rows[1]).toHaveTextContent("Working old")
     expect(rows[2]).toHaveTextContent("Queued")
-    expect(rows[3]).toHaveTextContent("Errored")
+    expect(rows[3]).toHaveTextContent("Missing")
     expect(rows[4]).toHaveTextContent("Idle")
+    expect(rows[5]).toHaveTextContent("Errored")
   })
 
   it("opens the one working linked session directly and keeps persisted standalone sessions idle", async () => {
@@ -296,6 +299,65 @@ describe("TaskCard task chat sessions", () => {
     expect(activityRequests).toHaveLength(2)
     expect(activityRequests.map((ids) => ids.length)).toEqual([100, 1])
     expect(activityRequests[1]).toEqual(["pi-100"])
+  })
+
+  it("does not erase a shared session's activity from another task after unlink", async () => {
+    const sharedA = link({ id: "shared-a", taskId: "task-1", sessionId: "pi-shared", title: "Shared" })
+    const uniqueA = link({ id: "unique-a", taskId: "task-1", sessionId: "pi-unique-a", title: "Unique A" })
+    const sharedB = link({ id: "shared-b", taskId: "task-2", sessionId: "pi-shared", title: "Shared" })
+    const uniqueB = link({ id: "unique-b", taskId: "task-2", sessionId: "pi-unique-b", title: "Unique B" })
+    const otherTask = { ...task, id: "task-2", number: "#613", title: "Other task" }
+    postJson.mockImplementation(async (path: string, body: { taskId?: string; sessionIds?: string[]; bindingId?: string }) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: body.taskId === "task-2" ? [sharedB, uniqueB] : [sharedA, uniqueA] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return {
+        activities: (body.sessionIds ?? []).map((sessionId) => ({ sessionId, status: "working", source: "live-runtime" })),
+        omittedSessionIds: [],
+      }
+      if (path === "/api/boring-tasks/sessions/unlink") {
+        expect(body.bindingId).toBe("shared-a")
+        return { ok: true }
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    render(
+      <TaskSessionActivityProvider>
+        <TaskCard task={task} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />
+        <TaskCard task={otherTask} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />
+      </TaskSessionActivityProvider>,
+    )
+    expect(await screen.findAllByLabelText("2 working linked chats")).toHaveLength(2)
+    fireEvent.click(screen.getAllByRole("button", { name: /2 working/i })[0])
+    const sharedRow = (await screen.findByText("Shared")).closest("li")
+    expect(sharedRow).not.toBeNull()
+    fireEvent.click(within(sharedRow!).getByRole("button", { name: "Unlink" }))
+
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/boring-tasks/sessions/unlink", { bindingId: "shared-a" }))
+    await waitFor(() => expect(screen.getAllByLabelText("2 working linked chats")).toHaveLength(1))
+  })
+
+  it("retains activity when unlink fails and the optimistic removal is restored", async () => {
+    const shared = link({ id: "shared", sessionId: "pi-shared", title: "Shared" })
+    const other = link({ id: "other", sessionId: "pi-other", title: "Other" })
+    postJson.mockImplementation(async (path: string, body: { sessionIds?: string[]; bindingId?: string }) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [shared, other] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return {
+        activities: (body.sessionIds ?? []).map((sessionId) => ({ sessionId, status: "working", source: "live-runtime" })),
+        omittedSessionIds: [],
+      }
+      if (path === "/api/boring-tasks/sessions/unlink") throw new Error("unlink failed")
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    expect(await screen.findByLabelText("2 working linked chats")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /2 working/i }))
+    const sharedRow = (await screen.findByText("Shared")).closest("li")
+    expect(sharedRow).not.toBeNull()
+    fireEvent.click(within(sharedRow!).getByRole("button", { name: "Unlink" }))
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("unlink failed")
+    expect(await screen.findByLabelText("2 working linked chats")).toBeInTheDocument()
   })
 
   it("creates, binds, and opens a chat when the task has no prior session", async () => {

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -532,6 +532,38 @@ describe("TaskCard task chat sessions", () => {
     expect(await screen.findByLabelText("2 working linked chats")).toBeInTheDocument()
   })
 
+  it("ignores a stale mount-time list after creating and binding a chat", async () => {
+    const mountList = deferred<TaskSessionListResponse>()
+    const created = link({ id: "link-new", sessionId: "pi-new" })
+    let listCalls = 0
+    postJson.mockImplementation((path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") {
+        listCalls += 1
+        return listCalls === 1 ? mountList.promise : Promise.resolve({ links: [] })
+      }
+      if (path === "/api/v1/agent/pi-chat/sessions") return Promise.resolve({ id: "pi-new" })
+      if (path === "/api/boring-tasks/sessions/link") return Promise.resolve({ link: created })
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return Promise.resolve({ activities: [{ sessionId: "pi-new", status: "idle", source: "persisted" }], omittedSessionIds: [] })
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/boring-tasks/sessions/list", { adapterId: "github", taskId: "task-1" }))
+    fireEvent.click(screen.getByRole("button", { name: /open chat/i }))
+
+    await waitFor(() => expect(openDetachedChat).toHaveBeenCalledWith("pi-new", expect.objectContaining({ title: "#612: Wire sessions" })))
+    await act(async () => {
+      mountList.resolve({ links: [] })
+      await mountList.promise
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByLabelText("1 linked chats")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /open chat for #612/i }))
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toHaveTextContent("#612: Wire sessions")
+    expect(postJson.mock.calls.filter(([path]) => path === "/api/v1/agent/pi-chat/sessions")).toHaveLength(1)
+  })
+
   it("creates, binds, and opens a chat when the task has no prior session", async () => {
     postJson.mockImplementation(async (path: string, body: unknown) => {
       if (path === "/api/boring-tasks/sessions/list") return { links: [] }

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -43,6 +43,16 @@ function link(overrides: Partial<BoringTaskSessionBinding> = {}): BoringTaskSess
   }
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
 beforeEach(() => {
   postJson.mockReset()
   getJson.mockReset()
@@ -232,6 +242,82 @@ describe("TaskCard task chat sessions", () => {
       })
       expect(screen.getByLabelText("1 linked chats")).toBeInTheDocument()
       expect(screen.queryByLabelText("1 working linked chats")).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("opens the linked-session panel immediately with pending feedback while activity refresh is in flight", async () => {
+    const existing = link()
+    const pendingActivity = deferred<{ activities?: []; omittedSessionIds?: string[] }>()
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [existing] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return pendingActivity.promise
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    fireEvent.click(screen.getByRole("button", { name: /open chat/i }))
+
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    expect(await screen.findByText("Checking chat activity…")).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole("button", { name: /checking activity/i })).toHaveAttribute("aria-busy", "true"))
+
+    await act(async () => {
+      pendingActivity.resolve({ activities: [], omittedSessionIds: ["pi-1"] })
+      await pendingActivity.promise
+    })
+  })
+
+  it("does not open a chat from superseded activity returned to openTaskChat", async () => {
+    vi.useFakeTimers()
+    const working = link({ id: "working", sessionId: "pi-working", title: "Working chat" })
+    const activityRequests: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<{ activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted" }>; omittedSessionIds?: string[] }>> }> = []
+    postJson.mockImplementation((path: string, body: { sessionIds?: string[] }) => {
+      if (path === "/api/boring-tasks/sessions/list") return Promise.resolve({ links: [working] })
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") {
+        const request = deferred<{ activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted" }>; omittedSessionIds?: string[] }>()
+        activityRequests.push({ sessionIds: body.sessionIds ?? [], request })
+        return request.promise
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockResolvedValue([{ id: "pi-working", title: "Working chat" }])
+
+    try {
+      renderCard()
+      await act(async () => { await Promise.resolve(); await Promise.resolve() })
+      await act(async () => { vi.advanceTimersByTime(25); await Promise.resolve() })
+      expect(activityRequests.map((entry) => entry.sessionIds)).toEqual([["pi-working"]])
+      await act(async () => {
+        activityRequests[0].request.resolve({ activities: [{ sessionId: "pi-working", status: "working", source: "live-runtime" }], omittedSessionIds: [] })
+        await activityRequests[0].request.promise
+        await Promise.resolve()
+      })
+      expect(screen.getByLabelText("1 working linked chats")).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole("button", { name: /1 working/i }))
+      await act(async () => { await Promise.resolve(); await Promise.resolve() })
+      expect(activityRequests).toHaveLength(2)
+      await act(async () => { vi.advanceTimersByTime(15_000); await Promise.resolve() })
+      expect(activityRequests).toHaveLength(3)
+
+      await act(async () => {
+        activityRequests[1].request.resolve({ activities: [{ sessionId: "pi-working", status: "working", source: "live-runtime" }], omittedSessionIds: [] })
+        await activityRequests[1].request.promise
+        await Promise.resolve()
+      })
+
+      expect(openDetachedChat).not.toHaveBeenCalled()
+      expect(screen.getByRole("alert")).toHaveTextContent("changed while opening")
+      expect(screen.getByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+
+      await act(async () => {
+        activityRequests[2].request.resolve({ activities: [{ sessionId: "pi-working", status: "idle", source: "persisted" }], omittedSessionIds: [] })
+        await activityRequests[2].request.promise
+        await Promise.resolve()
+      })
+      expect(openDetachedChat).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -547,6 +547,120 @@ describe("TaskCard task chat sessions", () => {
     expect(openDetachedChat).toHaveBeenCalledWith("pi-new", expect.objectContaining({ title: "#612: Wire sessions", initialDraft: expect.stringContaining("Task ID: task-1") }))
   })
 
+  it("does not navigate when a linked-row Open resolves after the panel closes", async () => {
+    const existing = link()
+    const pendingSessionLookup = deferred<Array<{ id: string; title: string }>>()
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [existing] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return { activities: [{ sessionId: "pi-1", status: "idle", source: "persisted" }], omittedSessionIds: [] }
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockReturnValue(pendingSessionLookup.promise)
+
+    renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    fireEvent.click(await screen.findByRole("button", { name: "Open" }))
+    fireEvent.click(screen.getByRole("button", { name: "Close task chats" }))
+
+    await act(async () => {
+      pendingSessionLookup.resolve([{ id: "pi-1", title: "#612: Wire sessions" }])
+      await pendingSessionLookup.promise
+      await Promise.resolve()
+    })
+
+    expect(openDetachedChat).not.toHaveBeenCalled()
+    expect(screen.queryByRole("region", { name: /linked chat sessions/i })).not.toBeInTheDocument()
+  })
+
+  it("does not navigate when a linked-row Open resolves after unlink", async () => {
+    const existing = link()
+    const pendingSessionLookup = deferred<Array<{ id: string; title: string }>>()
+    postJson.mockImplementation(async (path: string, body: { bindingId?: string }) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [existing] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return { activities: [{ sessionId: "pi-1", status: "idle", source: "persisted" }], omittedSessionIds: [] }
+      if (path === "/api/boring-tasks/sessions/unlink") {
+        expect(body.bindingId).toBe("link-1")
+        return { ok: true }
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockReturnValue(pendingSessionLookup.promise)
+
+    renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    fireEvent.click(await screen.findByRole("button", { name: "Open" }))
+    fireEvent.click(screen.getByRole("button", { name: "Unlink" }))
+
+    await act(async () => {
+      pendingSessionLookup.resolve([{ id: "pi-1", title: "#612: Wire sessions" }])
+      await pendingSessionLookup.promise
+      await Promise.resolve()
+    })
+
+    expect(openDetachedChat).not.toHaveBeenCalled()
+    expect(await screen.findByText("No linked chats yet.")).toBeInTheDocument()
+  })
+
+  it("does not open a Start new chat navigation after the panel closes", async () => {
+    const existing = link()
+    const pendingCreate = deferred<{ id: string }>()
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [existing] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return { activities: [{ sessionId: "pi-1", status: "idle", source: "persisted" }], omittedSessionIds: [] }
+      if (path === "/api/v1/agent/pi-chat/sessions") return pendingCreate.promise
+      if (path === "/api/boring-tasks/sessions/link") return { link: link({ id: "link-new", sessionId: "pi-new" }) }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    fireEvent.click(await screen.findByRole("button", { name: "Start new chat" }))
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/v1/agent/pi-chat/sessions", { title: "#612: Wire sessions" }))
+    fireEvent.click(screen.getByRole("button", { name: "Close task chats" }))
+
+    await act(async () => {
+      pendingCreate.resolve({ id: "pi-new" })
+      await pendingCreate.promise
+      await Promise.resolve()
+    })
+
+    expect(postJson).not.toHaveBeenCalledWith("/api/boring-tasks/sessions/link", expect.anything())
+    expect(openDetachedChat).not.toHaveBeenCalled()
+  })
+
+  it("does not open a Start new chat navigation after the task is removed from the card", async () => {
+    const existing = link()
+    const replacementTask = { ...task, id: "task-removed", number: "#613", title: "Replacement" }
+    const pendingCreate = deferred<{ id: string }>()
+    const onDragStart = vi.fn()
+    const onDragEnd = vi.fn()
+    postJson.mockImplementation(async (path: string, body: { taskId?: string } = {}) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: body.taskId === "task-removed" ? [] : [existing] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return { activities: [{ sessionId: "pi-1", status: "idle", source: "persisted" }], omittedSessionIds: [] }
+      if (path === "/api/v1/agent/pi-chat/sessions") return pendingCreate.promise
+      if (path === "/api/boring-tasks/sessions/link") return { link: link({ id: "link-new", sessionId: "pi-new" }) }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    const { rerender } = render(<TaskCard task={task} draggable={false} onDragStart={onDragStart} onDragEnd={onDragEnd} />)
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    fireEvent.click(await screen.findByRole("button", { name: "Start new chat" }))
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/v1/agent/pi-chat/sessions", { title: "#612: Wire sessions" }))
+    await act(async () => {
+      rerender(<TaskCard task={replacementTask} draggable={false} onDragStart={onDragStart} onDragEnd={onDragEnd} />)
+      await Promise.resolve()
+    })
+
+    await act(async () => {
+      pendingCreate.resolve({ id: "pi-new" })
+      await pendingCreate.promise
+      await Promise.resolve()
+    })
+
+    expect(postJson).not.toHaveBeenCalledWith("/api/boring-tasks/sessions/link", expect.anything())
+    expect(openDetachedChat).not.toHaveBeenCalled()
+  })
+
   it("shows linked sessions, reopens an available session, and unlinks", async () => {
     const existing = link()
     postJson.mockImplementation(async (path: string, body: { bindingId?: string }) => {

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { BoringTaskCard, BoringTaskSessionBinding } from "../shared"
 import { TaskCard } from "./TaskCard"
@@ -49,15 +49,21 @@ beforeEach(() => {
 })
 
 describe("TaskCard task chat sessions", () => {
-  it("sorts active linked sessions before idle sessions and shows queued rollup accessibly", async () => {
-    const queued = link({ id: "link-queued", sessionId: "pi-queued", title: "Queued chat", createdAt: "2026-07-01T00:00:00.000Z" })
-    const idle = link({ id: "link-idle", sessionId: "pi-idle", title: "Idle chat", createdAt: "2026-07-02T00:00:00.000Z" })
+  it("orders all activity priorities before idle and applies recency within a priority", async () => {
+    const workingOld = link({ id: "working-old", sessionId: "pi-working-old", title: "Working old", createdAt: "2026-07-01T00:00:00.000Z" })
+    const workingNew = link({ id: "working-new", sessionId: "pi-working-new", title: "Working new", createdAt: "2026-07-01T00:00:00.000Z" })
+    const queued = link({ id: "queued", sessionId: "pi-queued", title: "Queued", createdAt: "2026-07-04T00:00:00.000Z" })
+    const errored = link({ id: "error", sessionId: "pi-error", title: "Errored", createdAt: "2026-07-05T00:00:00.000Z" })
+    const idle = link({ id: "idle", sessionId: "pi-idle", title: "Idle", createdAt: "2026-07-06T00:00:00.000Z" })
     postJson.mockImplementation(async (path: string) => {
-      if (path === "/api/boring-tasks/sessions/list") return { links: [idle, queued] }
+      if (path === "/api/boring-tasks/sessions/list") return { links: [idle, errored, queued, workingOld, workingNew] }
       if (path === "/api/v1/agent/pi-chat/sessions/activity") return {
         activities: [
-          { sessionId: "pi-idle", status: "idle", source: "persisted", updatedAt: "2026-07-02T00:00:00.000Z" },
-          { sessionId: "pi-queued", status: "queued", source: "live-runtime", updatedAt: "2026-07-01T00:00:00.000Z" },
+          { sessionId: "pi-working-old", status: "working", source: "live-runtime", updatedAt: "2026-07-02T00:00:00.000Z" },
+          { sessionId: "pi-working-new", status: "working", source: "live-runtime", updatedAt: "2026-07-03T00:00:00.000Z" },
+          { sessionId: "pi-queued", status: "queued", source: "live-runtime", updatedAt: "2026-07-07T00:00:00.000Z" },
+          { sessionId: "pi-error", status: "error", source: "live-runtime", updatedAt: "2026-07-08T00:00:00.000Z" },
+          { sessionId: "pi-idle", status: "idle", source: "persisted", updatedAt: "2026-07-09T00:00:00.000Z" },
         ],
         omittedSessionIds: [],
       }
@@ -65,15 +71,16 @@ describe("TaskCard task chat sessions", () => {
     })
 
     renderCard()
-    expect(await screen.findByRole("button", { name: /queued/i })).toBeInTheDocument()
+    expect(await screen.findByLabelText("2 working linked chats")).toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: /open chat/i }))
 
     const rows = await screen.findAllByRole("listitem")
-    expect(rows[0]).toHaveTextContent("Queued chat")
-    expect(rows[0]).toHaveTextContent("Queued")
-    expect(rows[1]).toHaveTextContent("Idle chat")
-    expect(rows[1]).toHaveTextContent("Idle")
-    expect(openDetachedChat).not.toHaveBeenCalled()
+    expect(rows.map((row) => row.textContent)).toEqual(expect.arrayContaining([expect.stringContaining("Working new"), expect.stringContaining("Working old"), expect.stringContaining("Queued"), expect.stringContaining("Errored"), expect.stringContaining("Idle")]))
+    expect(rows[0]).toHaveTextContent("Working new")
+    expect(rows[1]).toHaveTextContent("Working old")
+    expect(rows[2]).toHaveTextContent("Queued")
+    expect(rows[3]).toHaveTextContent("Errored")
+    expect(rows[4]).toHaveTextContent("Idle")
   })
 
   it("opens the one working linked session directly and keeps persisted standalone sessions idle", async () => {
@@ -100,33 +107,75 @@ describe("TaskCard task chat sessions", () => {
     expect(screen.queryByRole("region", { name: /linked chat sessions/i })).not.toBeInTheDocument()
   })
 
-  it("treats browser status events as optimistic until polling reconciles activity", async () => {
-    const existing = link()
+  it("keeps native keyboard focus on the disclosure trigger and uses motion-safe activity animation", async () => {
+    const working = link({ id: "working", sessionId: "pi-working", title: "Working" })
+    const workingSecond = link({ id: "working-second", sessionId: "pi-working-second", title: "Working second" })
+    const queued = link({ id: "queued", sessionId: "pi-queued", title: "Queued" })
     postJson.mockImplementation(async (path: string) => {
-      if (path === "/api/boring-tasks/sessions/list") return { links: [existing] }
-      if (path === "/api/v1/agent/pi-chat/sessions/activity") return { activities: [{ sessionId: "pi-1", status: "idle", source: "persisted" }], omittedSessionIds: [] }
+      if (path === "/api/boring-tasks/sessions/list") return { links: [working, workingSecond, queued] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return {
+        activities: [
+          { sessionId: "pi-working", status: "working", source: "live-runtime" },
+          { sessionId: "pi-working-second", status: "working", source: "live-runtime" },
+          { sessionId: "pi-queued", status: "queued", source: "live-runtime" },
+        ],
+        omittedSessionIds: [],
+      }
       throw new Error(`unexpected post ${path}`)
     })
 
-    renderCard()
-    expect(await screen.findByLabelText("1 linked chats")).toBeInTheDocument()
-    window.dispatchEvent(new CustomEvent("boring:chat-session-status", { detail: { sessionId: "pi-1", working: true } }))
-    expect(await screen.findByLabelText("1 working linked chats")).toBeInTheDocument()
+    const { container } = renderCard()
+    const trigger = await screen.findByRole("button", { name: /open chat.*working/i })
+    expect(trigger).toHaveAttribute("type", "button")
+    trigger.focus()
+    expect(trigger).toHaveFocus()
+    fireEvent.click(trigger)
+    const close = await screen.findByRole("button", { name: "Close task chats" })
+    expect(container.querySelector("[class*='motion-safe:animate-pulse']")).toBeInTheDocument()
+    expect(container.querySelector("[class*='motion-safe:animate-pulse']")?.classList.contains("animate-pulse")).toBe(false)
+    close.focus()
+    fireEvent.click(close)
+    expect(trigger).toHaveFocus()
+  })
 
-    fireEvent.click(screen.getByRole("button", { name: /1 working/i }))
-    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
-    expect(screen.getByText("persisted")).toBeInTheDocument()
-    expect(openDetachedChat).not.toHaveBeenCalled()
+  it("uses optimistic status events only until fake-timer polling reconciles a standalone session as persisted idle", async () => {
+    vi.useFakeTimers()
+    const standalone = link({ id: "standalone", sessionId: "pi-standalone", title: "Standalone Pi" })
+    let activityCalls = 0
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [standalone] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") {
+        activityCalls += 1
+        return { activities: [{ sessionId: "pi-standalone", status: "idle", source: "persisted" }], omittedSessionIds: [] }
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    try {
+      renderCard()
+      await act(async () => { await Promise.resolve(); await Promise.resolve() })
+      expect(screen.getByLabelText("1 linked chats")).toBeInTheDocument()
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("boring:chat-session-status", { detail: { sessionId: "pi-standalone", working: true } }))
+      })
+      expect(screen.getByLabelText("1 working linked chats")).toBeInTheDocument()
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(15_000) })
+      expect(activityCalls).toBeGreaterThanOrEqual(2)
+      expect(screen.getByLabelText("1 linked chats")).toBeInTheDocument()
+      expect(screen.queryByLabelText("1 working linked chats")).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("keeps the disclosure open on activity failure, supports retry, and shows missing activity", async () => {
     const existing = link()
-    let activityCalls = 0
+    let mode: "fail" | "missing" = "fail"
     postJson.mockImplementation(async (path: string) => {
       if (path === "/api/boring-tasks/sessions/list") return { links: [existing] }
       if (path === "/api/v1/agent/pi-chat/sessions/activity") {
-        activityCalls += 1
-        if (activityCalls <= 2) throw new Error("activity down")
+        if (mode === "fail") throw new Error("activity down")
         return { activities: [], omittedSessionIds: ["pi-1"] }
       }
       throw new Error(`unexpected post ${path}`)
@@ -137,24 +186,29 @@ describe("TaskCard task chat sessions", () => {
     expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
     expect(screen.getByText("Activity refresh failed.")).toBeInTheDocument()
 
+    mode = "missing"
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
     expect(await screen.findByText("Activity unavailable")).toBeInTheDocument()
   })
 
-  it("caps activity polling requests to the bounded session-id contract", async () => {
-    const manyLinks = Array.from({ length: 101 }, (_, index) => link({ id: `link-${index}`, sessionId: `pi-${index}` }))
+  it("covers every linked session through bounded chunks and rolls up activity beyond the first chunk", async () => {
+    const manyLinks = Array.from({ length: 101 }, (_, index) => link({ id: `link-${index}`, sessionId: `pi-${index}`, title: `Chat ${index}` }))
+    const activityRequests: string[][] = []
     postJson.mockImplementation(async (path: string, body: { sessionIds?: string[] }) => {
       if (path === "/api/boring-tasks/sessions/list") return { links: manyLinks }
       if (path === "/api/v1/agent/pi-chat/sessions/activity") {
-        expect(body.sessionIds).toHaveLength(100)
-        expect(body.sessionIds).not.toContain("pi-100")
-        return { activities: [], omittedSessionIds: [] }
+        const ids = body.sessionIds ?? []
+        activityRequests.push(ids)
+        return { activities: ids.includes("pi-100") ? [{ sessionId: "pi-100", status: "working", source: "live-runtime" }] : [], omittedSessionIds: [] }
       }
       throw new Error(`unexpected post ${path}`)
     })
 
     renderCard()
-    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/v1/agent/pi-chat/sessions/activity", expect.objectContaining({ sessionIds: expect.any(Array) })))
+    expect(await screen.findByLabelText("1 working linked chats")).toBeInTheDocument()
+    expect(activityRequests).toHaveLength(2)
+    expect(activityRequests.map((ids) => ids.length)).toEqual([100, 1])
+    expect(activityRequests[1]).toEqual(["pi-100"])
   })
 
   it("creates, binds, and opens a chat when the task has no prior session", async () => {

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -18,6 +18,8 @@ vi.mock("@hachej/boring-workspace/plugin", () => ({
   useWorkspaceShellCapabilities: () => ({ openArtifact: vi.fn(), openDetachedChat }),
 }))
 
+interface TaskSessionListResponse { links?: BoringTaskSessionBinding[] }
+
 const task: BoringTaskCard = {
   id: "task-1",
   number: "#612",
@@ -658,6 +660,63 @@ describe("TaskCard task chat sessions", () => {
     })
 
     expect(postJson).not.toHaveBeenCalledWith("/api/boring-tasks/sessions/link", expect.anything())
+    expect(openDetachedChat).not.toHaveBeenCalled()
+  })
+
+  it("clears stale active top-level chat action while replacement links load", async () => {
+    const working = link({ id: "working", sessionId: "pi-working", title: "Working chat" })
+    const replacementTask = { ...task, id: "task-replacement", number: "#613", title: "Replacement" }
+    const replacementList = deferred<TaskSessionListResponse>()
+    postJson.mockImplementation((path: string, body: { taskId?: string; sessionIds?: string[] } = {}) => {
+      if (path === "/api/boring-tasks/sessions/list") return body.taskId === "task-replacement" ? replacementList.promise : Promise.resolve({ links: [working] })
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return Promise.resolve({ activities: [{ sessionId: "pi-working", status: "working", source: "live-runtime" }], omittedSessionIds: [] })
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockResolvedValue([{ id: "pi-working", title: "Working chat" }])
+
+    const { rerender } = render(<TaskCard task={task} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+    expect(await screen.findByLabelText("1 working linked chats")).toBeInTheDocument()
+
+    await act(async () => {
+      rerender(<TaskCard task={replacementTask} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByLabelText("1 working linked chats")).not.toBeInTheDocument()
+    const replacementChatButton = screen.getByRole("button", { name: /open chat for #613\. checking activity/i })
+    expect(replacementChatButton).toHaveAttribute("aria-busy", "true")
+    fireEvent.click(replacementChatButton)
+    await act(async () => { await Promise.resolve(); await Promise.resolve() })
+
+    expect(getJson).not.toHaveBeenCalled()
+    expect(openDetachedChat).not.toHaveBeenCalled()
+  })
+
+  it("clears stale linked-row chat actions while replacement links load", async () => {
+    const existing = link({ title: "Old row chat" })
+    const replacementTask = { ...task, id: "task-replacement", number: "#613", title: "Replacement" }
+    const replacementList = deferred<TaskSessionListResponse>()
+    postJson.mockImplementation((path: string, body: { taskId?: string; sessionIds?: string[] } = {}) => {
+      if (path === "/api/boring-tasks/sessions/list") return body.taskId === "task-replacement" ? replacementList.promise : Promise.resolve({ links: [existing] })
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return Promise.resolve({ activities: (body.sessionIds ?? []).map((sessionId) => ({ sessionId, status: "idle", source: "persisted" })), omittedSessionIds: [] })
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockResolvedValue([{ id: "pi-1", title: "Old row chat" }])
+
+    const { rerender } = render(<TaskCard task={task} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Open" })).toBeInTheDocument()
+
+    await act(async () => {
+      rerender(<TaskCard task={replacementTask} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByRole("region", { name: /linked chat sessions/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Open" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /open chat for #613\. checking activity/i })).toHaveAttribute("aria-busy", "true")
+    expect(getJson).not.toHaveBeenCalled()
     expect(openDetachedChat).not.toHaveBeenCalled()
   })
 

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -322,7 +322,7 @@ describe("TaskCard task chat sessions", () => {
     expect(openDetachedChat).not.toHaveBeenCalled()
   })
 
-  it("does not open a chat from superseded activity returned to openTaskChat", async () => {
+  it("does not open a chat or render an obsolete error from superseded activity returned to openTaskChat", async () => {
     vi.useFakeTimers()
     const working = link({ id: "working", sessionId: "pi-working", title: "Working chat" })
     const activityRequests: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<{ activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted" }>; omittedSessionIds?: string[] }>> }> = []
@@ -362,7 +362,7 @@ describe("TaskCard task chat sessions", () => {
       })
 
       expect(openDetachedChat).not.toHaveBeenCalled()
-      expect(screen.getByRole("alert")).toHaveTextContent("changed while opening")
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
       expect(screen.getByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
 
       await act(async () => {
@@ -767,6 +767,108 @@ describe("TaskCard task chat sessions", () => {
       sessionId: "pi-standalone",
       title: "Standalone",
     }))
+  })
+
+  it("ignores stale search results after the card rerenders for another task", async () => {
+    const taskB = { ...task, id: "task-b", number: "#613", title: "Replacement" }
+    const linkA = link({ id: "link-a", title: "Task A chat" })
+    const linkB = link({ id: "link-b", taskId: "task-b", sessionId: "pi-b", title: "Task B chat" })
+    const pendingSearch = deferred<{ sessions?: Array<{ id: string; title?: string }> }>()
+    postJson.mockImplementation((path: string, body: { taskId?: string; sessionIds?: string[] } = {}) => {
+      if (path === "/api/boring-tasks/sessions/list") return Promise.resolve({ links: body.taskId === "task-b" ? [linkB] : [linkA] })
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return Promise.resolve({ activities: (body.sessionIds ?? []).map((sessionId) => ({ sessionId, status: "idle", source: "persisted" })), omittedSessionIds: [] })
+      if (path === "/api/boring-tasks/sessions/search") return pendingSearch.promise
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    const { rerender } = render(<TaskCard task={task} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    fireEvent.change(await screen.findByPlaceholderText("Search chats"), { target: { value: "stale" } })
+    fireEvent.click(screen.getByRole("button", { name: /link existing/i }))
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/boring-tasks/sessions/search", { query: "stale" }))
+
+    await act(async () => {
+      rerender(<TaskCard task={taskB} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+      await Promise.resolve()
+    })
+    await act(async () => {
+      pendingSearch.resolve({ sessions: [{ id: "pi-stale", title: "Stale search result" }] })
+      await pendingSearch.promise
+      await Promise.resolve()
+    })
+
+    fireEvent.click(await screen.findByRole("button", { name: /open chat for #613/i }))
+    expect(await screen.findByText("Task B chat")).toBeInTheDocument()
+    expect(screen.queryByText("Stale search result")).not.toBeInTheDocument()
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
+  it("ignores stale link errors after the card rerenders for another task", async () => {
+    const taskB = { ...task, id: "task-b", number: "#613", title: "Replacement" }
+    const linkA = link({ id: "link-a", title: "Task A chat" })
+    const linkB = link({ id: "link-b", taskId: "task-b", sessionId: "pi-b", title: "Task B chat" })
+    const pendingLink = deferred<{ link?: BoringTaskSessionBinding }>()
+    postJson.mockImplementation((path: string, body: { taskId?: string; sessionIds?: string[]; sessionId?: string } = {}) => {
+      if (path === "/api/boring-tasks/sessions/list") return Promise.resolve({ links: body.taskId === "task-b" ? [linkB] : [linkA] })
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return Promise.resolve({ activities: (body.sessionIds ?? []).map((sessionId) => ({ sessionId, status: "idle", source: "persisted" })), omittedSessionIds: [] })
+      if (path === "/api/boring-tasks/sessions/search") return Promise.resolve({ sessions: [{ id: "pi-stale", title: "Stale standalone" }] })
+      if (path === "/api/boring-tasks/sessions/link" && body.sessionId === "pi-stale") return pendingLink.promise
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    const { rerender } = render(<TaskCard task={task} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    fireEvent.click(await screen.findByRole("button", { name: /link existing/i }))
+    fireEvent.click(await screen.findByRole("button", { name: "Link" }))
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/boring-tasks/sessions/link", expect.objectContaining({ taskId: "task-1", sessionId: "pi-stale" })))
+
+    await act(async () => {
+      rerender(<TaskCard task={taskB} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+      await Promise.resolve()
+    })
+    await act(async () => {
+      pendingLink.reject(new Error("stale link failed"))
+      await pendingLink.promise.catch(() => undefined)
+      await Promise.resolve()
+    })
+
+    fireEvent.click(await screen.findByRole("button", { name: /open chat for #613/i }))
+    expect(await screen.findByText("Task B chat")).toBeInTheDocument()
+    expect(screen.queryByText("stale link failed")).not.toBeInTheDocument()
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+  })
+
+  it("ignores stale unlink errors after the card rerenders for another task", async () => {
+    const taskB = { ...task, id: "task-b", number: "#613", title: "Replacement" }
+    const linkA = link({ id: "link-a", title: "Task A chat" })
+    const linkB = link({ id: "link-b", taskId: "task-b", sessionId: "pi-b", title: "Task B chat" })
+    const pendingUnlink = deferred<{ ok: boolean }>()
+    postJson.mockImplementation((path: string, body: { taskId?: string; sessionIds?: string[]; bindingId?: string } = {}) => {
+      if (path === "/api/boring-tasks/sessions/list") return Promise.resolve({ links: body.taskId === "task-b" ? [linkB] : [linkA] })
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return Promise.resolve({ activities: (body.sessionIds ?? []).map((sessionId) => ({ sessionId, status: "idle", source: "persisted" })), omittedSessionIds: [] })
+      if (path === "/api/boring-tasks/sessions/unlink" && body.bindingId === "link-a") return pendingUnlink.promise
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    const { rerender } = render(<TaskCard task={task} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    fireEvent.click(await screen.findByRole("button", { name: "Unlink" }))
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/boring-tasks/sessions/unlink", { bindingId: "link-a" }))
+
+    await act(async () => {
+      rerender(<TaskCard task={taskB} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />)
+      await Promise.resolve()
+    })
+    await act(async () => {
+      pendingUnlink.reject(new Error("stale unlink failed"))
+      await pendingUnlink.promise.catch(() => undefined)
+      await Promise.resolve()
+    })
+
+    fireEvent.click(await screen.findByRole("button", { name: /open chat for #613/i }))
+    expect(await screen.findByText("Task B chat")).toBeInTheDocument()
+    expect(screen.queryByText("stale unlink failed")).not.toBeInTheDocument()
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument()
   })
 
   it("renders the linked-session disclosure and actions in compact cards", async () => {

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -49,6 +49,114 @@ beforeEach(() => {
 })
 
 describe("TaskCard task chat sessions", () => {
+  it("sorts active linked sessions before idle sessions and shows queued rollup accessibly", async () => {
+    const queued = link({ id: "link-queued", sessionId: "pi-queued", title: "Queued chat", createdAt: "2026-07-01T00:00:00.000Z" })
+    const idle = link({ id: "link-idle", sessionId: "pi-idle", title: "Idle chat", createdAt: "2026-07-02T00:00:00.000Z" })
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [idle, queued] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return {
+        activities: [
+          { sessionId: "pi-idle", status: "idle", source: "persisted", updatedAt: "2026-07-02T00:00:00.000Z" },
+          { sessionId: "pi-queued", status: "queued", source: "live-runtime", updatedAt: "2026-07-01T00:00:00.000Z" },
+        ],
+        omittedSessionIds: [],
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    expect(await screen.findByRole("button", { name: /queued/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /open chat/i }))
+
+    const rows = await screen.findAllByRole("listitem")
+    expect(rows[0]).toHaveTextContent("Queued chat")
+    expect(rows[0]).toHaveTextContent("Queued")
+    expect(rows[1]).toHaveTextContent("Idle chat")
+    expect(rows[1]).toHaveTextContent("Idle")
+    expect(openDetachedChat).not.toHaveBeenCalled()
+  })
+
+  it("opens the one working linked session directly and keeps persisted standalone sessions idle", async () => {
+    const working = link({ id: "link-working", sessionId: "pi-working", title: "Working chat" })
+    const standalone = link({ id: "link-standalone", sessionId: "pi-standalone", title: "Standalone chat" })
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [standalone, working] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return {
+        activities: [
+          { sessionId: "pi-working", status: "working", source: "live-runtime", updatedAt: "2026-07-03T00:00:00.000Z" },
+          { sessionId: "pi-standalone", status: "idle", source: "persisted", updatedAt: "2026-07-04T00:00:00.000Z" },
+        ],
+        omittedSessionIds: [],
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockResolvedValue([{ id: "pi-working", title: "Working chat" }])
+
+    renderCard()
+    expect(await screen.findByLabelText("1 working linked chats")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /1 working/i }))
+
+    await waitFor(() => expect(openDetachedChat).toHaveBeenCalledWith("pi-working", expect.objectContaining({ title: "Working chat" })))
+    expect(screen.queryByRole("region", { name: /linked chat sessions/i })).not.toBeInTheDocument()
+  })
+
+  it("treats browser status events as optimistic until polling reconciles activity", async () => {
+    const existing = link()
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [existing] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return { activities: [{ sessionId: "pi-1", status: "idle", source: "persisted" }], omittedSessionIds: [] }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    expect(await screen.findByLabelText("1 linked chats")).toBeInTheDocument()
+    window.dispatchEvent(new CustomEvent("boring:chat-session-status", { detail: { sessionId: "pi-1", working: true } }))
+    expect(await screen.findByLabelText("1 working linked chats")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: /1 working/i }))
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    expect(screen.getByText("persisted")).toBeInTheDocument()
+    expect(openDetachedChat).not.toHaveBeenCalled()
+  })
+
+  it("keeps the disclosure open on activity failure, supports retry, and shows missing activity", async () => {
+    const existing = link()
+    let activityCalls = 0
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [existing] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") {
+        activityCalls += 1
+        if (activityCalls <= 2) throw new Error("activity down")
+        return { activities: [], omittedSessionIds: ["pi-1"] }
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    expect(screen.getByText("Activity refresh failed.")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+    expect(await screen.findByText("Activity unavailable")).toBeInTheDocument()
+  })
+
+  it("caps activity polling requests to the bounded session-id contract", async () => {
+    const manyLinks = Array.from({ length: 101 }, (_, index) => link({ id: `link-${index}`, sessionId: `pi-${index}` }))
+    postJson.mockImplementation(async (path: string, body: { sessionIds?: string[] }) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: manyLinks }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") {
+        expect(body.sessionIds).toHaveLength(100)
+        expect(body.sessionIds).not.toContain("pi-100")
+        return { activities: [], omittedSessionIds: [] }
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/v1/agent/pi-chat/sessions/activity", expect.objectContaining({ sessionIds: expect.any(Array) })))
+  })
+
   it("creates, binds, and opens a chat when the task has no prior session", async () => {
     postJson.mockImplementation(async (path: string, body: unknown) => {
       if (path === "/api/boring-tasks/sessions/list") return { links: [] }
@@ -102,7 +210,7 @@ describe("TaskCard task chat sessions", () => {
 
     renderCard()
     fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
-    fireEvent.change(screen.getByPlaceholderText("Search chats"), { target: { value: "standalone" } })
+    fireEvent.change(await screen.findByPlaceholderText("Search chats"), { target: { value: "standalone" } })
     fireEvent.click(screen.getByRole("button", { name: /link existing/i }))
     expect(await screen.findByText("Standalone")).toBeInTheDocument()
     fireEvent.click(screen.getByRole("button", { name: "Link" }))

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -256,6 +256,28 @@ describe("TaskCard task chat sessions", () => {
     expect(await screen.findByText("Activity unavailable")).toBeInTheDocument()
   })
 
+  it("rolls up authoritative idle ahead of unavailable activity", async () => {
+    const idle = link({ id: "idle", sessionId: "pi-idle", title: "Idle chat" })
+    const missing = link({ id: "missing", sessionId: "pi-missing", title: "Missing chat" })
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [missing, idle] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return {
+        activities: [{ sessionId: "pi-idle", status: "idle", source: "persisted" }],
+        omittedSessionIds: ["pi-missing"],
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    const trigger = await screen.findByRole("button", { name: /Idle/i })
+    expect(trigger).toBeInTheDocument()
+    expect(screen.queryByText("Activity unavailable")).not.toBeInTheDocument()
+
+    fireEvent.click(trigger)
+    expect(await screen.findByText("Idle")).toBeInTheDocument()
+    expect(await screen.findByText("Activity unavailable")).toBeInTheDocument()
+  })
+
   it("covers every linked session through bounded chunks and rolls up activity beyond the first chunk", async () => {
     const manyLinks = Array.from({ length: 101 }, (_, index) => link({ id: `link-${index}`, sessionId: `pi-${index}`, title: `Chat ${index}` }))
     const activityRequests: string[][] = []

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -107,6 +107,73 @@ describe("TaskCard task chat sessions", () => {
     expect(screen.queryByRole("region", { name: /linked chat sessions/i })).not.toBeInTheDocument()
   })
 
+  it("merges action refreshes without erasing other linked activity statuses", async () => {
+    const workingA = link({ id: "working-a", sessionId: "pi-working-a", title: "Working A" })
+    const workingB = link({ id: "working-b", sessionId: "pi-working-b", title: "Working B" })
+    postJson.mockImplementation(async (path: string, body: { sessionIds?: string[] }) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [workingA, workingB] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") {
+        const ids = body.sessionIds ?? []
+        if (ids.length === 1) return { activities: [{ sessionId: ids[0], status: "idle", source: "persisted" }], omittedSessionIds: [] }
+        return {
+          activities: ids.map((sessionId) => ({ sessionId, status: "working", source: "live-runtime" })),
+          omittedSessionIds: [],
+        }
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockResolvedValue([{ id: "pi-working-a", title: "Working A" }, { id: "pi-working-b", title: "Working B" }])
+
+    renderCard()
+    expect(await screen.findByLabelText("2 working linked chats")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /2 working/i }))
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    fireEvent.click(screen.getAllByRole("button", { name: "Open" })[0])
+
+    await waitFor(() => expect(openDetachedChat).toHaveBeenCalled())
+    expect(await screen.findByLabelText("1 working linked chats")).toBeInTheDocument()
+  })
+
+  it("uses error semantics without emerald active styling and opens one queued session as active", async () => {
+    const errored = link({ id: "errored", sessionId: "pi-error", title: "Errored" })
+    const queued = link({ id: "queued", sessionId: "pi-queued", title: "Queued" })
+    postJson.mockImplementation(async (path: string, body: { sessionIds?: string[] }) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [errored, queued] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return {
+        activities: (body.sessionIds ?? []).map((sessionId) => ({
+          sessionId,
+          status: sessionId === "pi-error" ? "error" : "queued",
+          source: "live-runtime",
+        })),
+        omittedSessionIds: [],
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockResolvedValue([{ id: "pi-queued", title: "Queued" }])
+
+    const firstRender = renderCard()
+    const activeBadge = await screen.findByLabelText("1 active linked chats")
+    expect(activeBadge).toHaveClass("bg-emerald-500")
+    expect(screen.queryByLabelText("2 active linked chats")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /queued/i }))
+    await waitFor(() => expect(openDetachedChat).toHaveBeenCalledWith("pi-queued", expect.objectContaining({ title: "Queued" })))
+
+    firstRender.unmount()
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [errored] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return { activities: [{ sessionId: "pi-error", status: "error", source: "live-runtime" }], omittedSessionIds: [] }
+      throw new Error(`unexpected post ${path}`)
+    })
+    openDetachedChat.mockReset()
+    renderCard()
+    const errorBadge = await screen.findByLabelText("1 linked chats need attention")
+    expect(errorBadge).toHaveClass("bg-destructive")
+    expect(screen.queryByLabelText("1 active linked chats")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: /need attention/i }))
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    expect(openDetachedChat).not.toHaveBeenCalled()
+  })
+
   it("keeps native keyboard focus on the disclosure trigger and uses motion-safe activity animation", async () => {
     const working = link({ id: "working", sessionId: "pi-working", title: "Working" })
     const workingSecond = link({ id: "working-second", sessionId: "pi-working-second", title: "Working second" })
@@ -138,7 +205,7 @@ describe("TaskCard task chat sessions", () => {
     expect(trigger).toHaveFocus()
   })
 
-  it("uses optimistic status events only until fake-timer polling reconciles a standalone session as persisted idle", async () => {
+  it("ignores arbitrary standalone status events and waits for authoritative activity", async () => {
     vi.useFakeTimers()
     const standalone = link({ id: "standalone", sessionId: "pi-standalone", title: "Standalone Pi" })
     let activityCalls = 0
@@ -154,14 +221,12 @@ describe("TaskCard task chat sessions", () => {
     try {
       renderCard()
       await act(async () => { await Promise.resolve(); await Promise.resolve() })
+      await act(async () => { await vi.advanceTimersByTimeAsync(25) })
+      expect(activityCalls).toBe(1)
       expect(screen.getByLabelText("1 linked chats")).toBeInTheDocument()
       await act(async () => {
         window.dispatchEvent(new CustomEvent("boring:chat-session-status", { detail: { sessionId: "pi-standalone", working: true } }))
       })
-      expect(screen.getByLabelText("1 working linked chats")).toBeInTheDocument()
-
-      await act(async () => { await vi.advanceTimersByTimeAsync(15_000) })
-      expect(activityCalls).toBeGreaterThanOrEqual(2)
       expect(screen.getByLabelText("1 linked chats")).toBeInTheDocument()
       expect(screen.queryByLabelText("1 working linked chats")).not.toBeInTheDocument()
     } finally {

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -269,6 +269,57 @@ describe("TaskCard task chat sessions", () => {
     })
   })
 
+  it("does not navigate when open activity resolves after the session panel closes", async () => {
+    const working = link({ id: "working", sessionId: "pi-working", title: "Working chat" })
+    const pendingActivity = deferred<{ activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted" }>; omittedSessionIds?: string[] }>()
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [working] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return pendingActivity.promise
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockResolvedValue([{ id: "pi-working", title: "Working chat" }])
+
+    renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Close task chats" }))
+
+    await act(async () => {
+      pendingActivity.resolve({ activities: [{ sessionId: "pi-working", status: "working", source: "live-runtime" }], omittedSessionIds: [] })
+      await pendingActivity.promise
+      await Promise.resolve()
+    })
+
+    expect(getJson).not.toHaveBeenCalled()
+    expect(openDetachedChat).not.toHaveBeenCalled()
+    expect(screen.queryByRole("region", { name: /linked chat sessions/i })).not.toBeInTheDocument()
+  })
+
+  it("does not navigate when open activity resolves after the card unmounts", async () => {
+    const working = link({ id: "working", sessionId: "pi-working", title: "Working chat" })
+    const pendingActivity = deferred<{ activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted" }>; omittedSessionIds?: string[] }>()
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: [working] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return pendingActivity.promise
+      throw new Error(`unexpected post ${path}`)
+    })
+    getJson.mockResolvedValue([{ id: "pi-working", title: "Working chat" }])
+
+    const { unmount } = renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: /open chat/i }))
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    unmount()
+
+    await act(async () => {
+      pendingActivity.resolve({ activities: [{ sessionId: "pi-working", status: "working", source: "live-runtime" }], omittedSessionIds: [] })
+      await pendingActivity.promise
+      await Promise.resolve()
+    })
+
+    expect(getJson).not.toHaveBeenCalled()
+    expect(openDetachedChat).not.toHaveBeenCalled()
+  })
+
   it("does not open a chat from superseded activity returned to openTaskChat", async () => {
     vi.useFakeTimers()
     const working = link({ id: "working", sessionId: "pi-working", title: "Working chat" })
@@ -343,6 +394,39 @@ describe("TaskCard task chat sessions", () => {
     mode = "missing"
     fireEvent.click(screen.getByRole("button", { name: "Retry" }))
     expect(await screen.findByText("Activity unavailable")).toBeInTheDocument()
+  })
+
+  it("keeps activity retry errors scoped to the task sessions that failed", async () => {
+    const taskA = { ...task, id: "task-a", number: "#613A", title: "Task A" }
+    const taskB = { ...task, id: "task-b", number: "#613B", title: "Task B" }
+    const linkA = link({ id: "link-a", taskId: "task-a", sessionId: "pi-a", title: "Chat A" })
+    const linkB = link({ id: "link-b", taskId: "task-b", sessionId: "pi-b", title: "Chat B" })
+    postJson.mockImplementation(async (path: string, body: { taskId?: string; sessionIds?: string[] }) => {
+      if (path === "/api/boring-tasks/sessions/list") return { links: body.taskId === "task-b" ? [linkB] : [linkA] }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") {
+        const ids = body.sessionIds ?? []
+        if (ids.includes("pi-a")) throw new Error("A activity down")
+        return { activities: ids.map((sessionId) => ({ sessionId, status: "idle", source: "persisted" })), omittedSessionIds: [] }
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    render(
+      <TaskSessionActivityProvider>
+        <TaskCard task={taskA} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />
+        <TaskCard task={taskB} draggable={false} onDragStart={vi.fn()} onDragEnd={vi.fn()} />
+      </TaskSessionActivityProvider>,
+    )
+
+    const triggers = await screen.findAllByRole("button", { name: /open chat/i })
+    fireEvent.click(triggers[0])
+    expect(await screen.findByText("Activity refresh failed.")).toBeInTheDocument()
+
+    fireEvent.click(triggers[1])
+    await waitFor(() => expect(screen.getAllByRole("region", { name: /linked chat sessions/i })).toHaveLength(2))
+    expect(screen.getAllByText("Activity refresh failed.")).toHaveLength(1)
+    expect(screen.getByText("Chat A").closest("section")).toHaveTextContent("Activity refresh failed.")
+    expect(screen.getByText("Chat B").closest("section")).not.toHaveTextContent("Activity refresh failed.")
   })
 
   it("rolls up authoritative idle ahead of unavailable activity", async () => {

--- a/plugins/tasks/src/front/TaskCard.test.tsx
+++ b/plugins/tasks/src/front/TaskCard.test.tsx
@@ -322,7 +322,7 @@ describe("TaskCard task chat sessions", () => {
     expect(openDetachedChat).not.toHaveBeenCalled()
   })
 
-  it("does not open a chat or render an obsolete error from superseded activity returned to openTaskChat", async () => {
+  it("opens from an action refresh even when a later board poll overlaps", async () => {
     vi.useFakeTimers()
     const working = link({ id: "working", sessionId: "pi-working", title: "Working chat" })
     const activityRequests: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<{ activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted" }>; omittedSessionIds?: string[] }>> }> = []
@@ -361,19 +361,80 @@ describe("TaskCard task chat sessions", () => {
         await Promise.resolve()
       })
 
-      expect(openDetachedChat).not.toHaveBeenCalled()
+      await act(async () => { await Promise.resolve(); await Promise.resolve() })
+      expect(openDetachedChat).toHaveBeenCalledWith("pi-working", expect.objectContaining({ title: "Working chat" }))
       expect(screen.queryByRole("alert")).not.toBeInTheDocument()
-      expect(screen.getByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
 
       await act(async () => {
         activityRequests[2].request.resolve({ activities: [{ sessionId: "pi-working", status: "idle", source: "persisted" }], omittedSessionIds: [] })
         await activityRequests[2].request.promise
         await Promise.resolve()
       })
-      expect(openDetachedChat).not.toHaveBeenCalled()
+      expect(openDetachedChat).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it("keeps session-list failure visible and blocks creating duplicate chats until retry succeeds", async () => {
+    let listMode: "fail" | "empty" = "fail"
+    postJson.mockImplementation(async (path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") {
+        if (listMode === "fail") throw new Error("session list down")
+        return { links: [] }
+      }
+      if (path === "/api/v1/agent/pi-chat/sessions") return { id: "pi-new" }
+      if (path === "/api/boring-tasks/sessions/link") return { link: link({ id: "link-new", sessionId: "pi-new" }) }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") return { activities: [{ sessionId: "pi-new", status: "idle", source: "persisted" }], omittedSessionIds: [] }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: /chat links unavailable/i }))
+
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    expect(screen.getByRole("alert")).toHaveTextContent("Linked chat sessions failed to load.")
+    expect(screen.queryByText("No linked chats yet.")).not.toBeInTheDocument()
+    const startNew = screen.getByRole("button", { name: "Start new chat" })
+    expect(startNew).toBeDisabled()
+    fireEvent.click(startNew)
+    expect(postJson.mock.calls.filter(([path]) => path === "/api/v1/agent/pi-chat/sessions")).toHaveLength(0)
+
+    listMode = "empty"
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+    await waitFor(() => expect(screen.queryByRole("alert")).not.toBeInTheDocument())
+    expect(screen.getByText("No linked chats yet.")).toBeInTheDocument()
+    expect(startNew).not.toBeDisabled()
+    fireEvent.click(startNew)
+
+    await waitFor(() => expect(postJson).toHaveBeenCalledWith("/api/v1/agent/pi-chat/sessions", { title: "#612: Wire sessions" }))
+  })
+
+  it("does not reopen the session panel when a retry fails after close", async () => {
+    const retryList = deferred<TaskSessionListResponse>()
+    let listCalls = 0
+    postJson.mockImplementation((path: string) => {
+      if (path === "/api/boring-tasks/sessions/list") {
+        listCalls += 1
+        if (listCalls <= 2) return Promise.reject(new Error("session list down"))
+        return retryList.promise
+      }
+      throw new Error(`unexpected post ${path}`)
+    })
+
+    renderCard()
+    fireEvent.click(await screen.findByRole("button", { name: /chat links unavailable/i }))
+    expect(await screen.findByRole("region", { name: /linked chat sessions/i })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }))
+    fireEvent.click(screen.getByRole("button", { name: "Close task chats" }))
+
+    await act(async () => {
+      retryList.reject(new Error("retry failed late"))
+      await retryList.promise.catch(() => undefined)
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByRole("region", { name: /linked chat sessions/i })).not.toBeInTheDocument()
   })
 
   it("keeps the disclosure open on activity failure, supports retry, and shows missing activity", async () => {

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -111,6 +111,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const chatButtonRef = useRef<HTMLButtonElement>(null)
   const mountedRef = useRef(false)
   const navigationGenerationRef = useRef(0)
+  const taskAsyncGenerationRef = useRef(0)
   const taskScopeKeyRef = useRef(taskScopeKey)
   const shell = useWorkspaceShellCapabilities()
   const pluginClient = useWorkspacePluginClient()
@@ -165,6 +166,16 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     navigationGenerationRef.current += 1
   }, [])
 
+  const invalidatePendingTaskAsync = useCallback(() => {
+    taskAsyncGenerationRef.current += 1
+  }, [])
+
+  const beginTaskAsync = useCallback(() => {
+    const generation = taskAsyncGenerationRef.current
+    const expectedTaskScopeKey = taskScopeKeyRef.current
+    return () => mountedRef.current && taskAsyncGenerationRef.current === generation && taskScopeKeyRef.current === expectedTaskScopeKey
+  }, [])
+
   const beginNavigation = useCallback(() => {
     const generation = navigationGenerationRef.current + 1
     navigationGenerationRef.current = generation
@@ -181,12 +192,14 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     return () => {
       mountedRef.current = false
       invalidatePendingNavigation()
+      invalidatePendingTaskAsync()
     }
-  }, [invalidatePendingNavigation])
+  }, [invalidatePendingNavigation, invalidatePendingTaskAsync])
 
   useLayoutEffect(() => {
     taskScopeKeyRef.current = taskScopeKey
     invalidatePendingNavigation()
+    invalidatePendingTaskAsync()
     setMenuOpen(false)
     setOpeningChat(false)
     setCheckingChatActivity(false)
@@ -199,7 +212,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     setSessionLinkState((current) => current.taskScopeKey === taskScopeKey && current.links.length === 0 && !current.loaded
       ? current
       : { taskScopeKey, links: [], loaded: false })
-  }, [invalidatePendingNavigation, taskScopeKey])
+  }, [invalidatePendingNavigation, invalidatePendingTaskAsync, taskScopeKey])
 
   const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<TaskSessionActivityRefreshResult> => {
     return await sessionActivity.refreshSessionIds(links.map((link) => link.sessionId))
@@ -326,10 +339,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
         return
       }
       if (!shouldContinue()) return
-      if (refreshResult.status === "stale") {
-        setSessionError("Chat activity changed while opening. Try again.")
-        return
-      }
+      if (refreshResult.status === "stale") return
       const active = links.filter((link) => {
         const status = refreshResult.activities[link.sessionId]?.status
         return status === "working" || status === "queued"
@@ -359,8 +369,10 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       next.delete(link.sessionId)
       return next
     })
+    const shouldApply = beginTaskAsync()
     void pluginClient.postJson("/api/boring-tasks/sessions/unlink", { bindingId: link.id })
       .catch((error) => {
+        if (!shouldApply()) return
         updateCurrentSessionLinks((current) => current.some((candidate) => candidate.id === link.id) ? current : [link, ...current])
         setSessionError(error instanceof Error ? error.message : "Failed to unlink session")
       })
@@ -368,16 +380,24 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
 
   const searchExistingSessions = (event: MouseEvent<HTMLButtonElement>) => {
     stopCardAction(event)
+    const shouldApply = beginTaskAsync()
     setLinkSearchLoading(true)
     setSessionError(null)
     void pluginClient.postJson<ManageSessionsSearchResponse>("/api/boring-tasks/sessions/search", { query: linkQuery })
-      .then((body) => setLinkSearchResults(body.sessions ?? []))
-      .catch((error) => setSessionError(error instanceof Error ? error.message : "Failed to search sessions"))
-      .finally(() => setLinkSearchLoading(false))
+      .then((body) => {
+        if (shouldApply()) setLinkSearchResults(body.sessions ?? [])
+      })
+      .catch((error) => {
+        if (shouldApply()) setSessionError(error instanceof Error ? error.message : "Failed to search sessions")
+      })
+      .finally(() => {
+        if (shouldApply()) setLinkSearchLoading(false)
+      })
   }
 
   const linkExistingSession = (event: MouseEvent<HTMLButtonElement>, session: PiSessionSummary) => {
     stopCardAction(event)
+    const shouldApply = beginTaskAsync()
     setSessionError(null)
     void pluginClient.postJson<TaskSessionLinkResponse>("/api/boring-tasks/sessions/link", {
       adapterId: task.adapterId,
@@ -385,10 +405,13 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       sessionId: session.id,
       title: session.title ?? chatTitle,
     }).then((body) => {
+      if (!shouldApply()) return
       if (!body.link) throw new Error("Task session binding was not created.")
       updateCurrentSessionLinks((current) => current.some((candidate) => candidate.id === body.link!.id) ? current : [body.link!, ...current])
       void refreshSessionActivity([body.link!]).catch(() => undefined)
-    }).catch((error) => setSessionError(error instanceof Error ? error.message : "Failed to link session"))
+    }).catch((error) => {
+      if (shouldApply()) setSessionError(error instanceof Error ? error.message : "Failed to link session")
+    })
   }
 
   const deleteTask = (event: MouseEvent<HTMLButtonElement>) => {

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -74,6 +74,12 @@ function activityRank(status: TaskSessionActivityStatus): number {
   return 0
 }
 
+function activitySortRank(status: TaskSessionActivityStatus): number {
+  if (status === "working") return 2
+  if (status === "queued") return 1
+  return 0
+}
+
 function activityLabel(activity: TaskSessionActivity | undefined, loading: boolean): string {
   if (!activity) return loading ? "Checking activity" : "Activity pending"
   if (activity.status === "working") return "Working"
@@ -119,7 +125,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     return [...sessionLinks].sort((a, b) => {
       const aActivity = sessionActivities[a.sessionId]
       const bActivity = sessionActivities[b.sessionId]
-      const rankDelta = activityRank(bActivity?.status ?? "idle") - activityRank(aActivity?.status ?? "idle")
+      const rankDelta = activitySortRank(bActivity?.status ?? "idle") - activitySortRank(aActivity?.status ?? "idle")
       if (rankDelta !== 0) return rankDelta
       return newestTimestampMs(b, bActivity) - newestTimestampMs(a, aActivity)
     })
@@ -272,7 +278,6 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       next.delete(link.sessionId)
       return next
     })
-    sessionActivity.clearSessionActivity(link.sessionId)
     void pluginClient.postJson("/api/boring-tasks/sessions/unlink", { bindingId: link.id })
       .catch((error) => {
         setSessionLinks((current) => current.some((candidate) => candidate.id === link.id) ? current : [link, ...current])

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type DragEvent, type MouseEvent } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent, type MouseEvent } from "react"
 import { AlertCircle, CircleDot, Link2, MessageSquare, MoreHorizontal, Trash2, X } from "lucide-react"
 import { useWorkspacePluginClient } from "@hachej/boring-workspace"
 import { useWorkspaceShellCapabilities, type WorkspaceShellAnchorRect } from "@hachej/boring-workspace/plugin"
@@ -44,6 +44,14 @@ interface SessionActivityResponse {
 
 const TASK_SESSION_ACTIVITY_POLL_MS = 15_000
 const TASK_SESSION_ACTIVITY_MAX_IDS = 100
+
+function chunkSessionIds(sessionIds: string[]): string[][] {
+  const chunks: string[][] = []
+  for (let index = 0; index < sessionIds.length; index += TASK_SESSION_ACTIVITY_MAX_IDS) {
+    chunks.push(sessionIds.slice(index, index + TASK_SESSION_ACTIVITY_MAX_IDS))
+  }
+  return chunks
+}
 
 function taskDisplayRef(task: BoringTaskCard): string {
   return task.number || task.id
@@ -110,6 +118,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const [sessionActivities, setSessionActivities] = useState<Record<string, TaskSessionActivity>>({})
   const [activityLoading, setActivityLoading] = useState(false)
   const [activityError, setActivityError] = useState<string | null>(null)
+  const chatButtonRef = useRef<HTMLButtonElement>(null)
   const shell = useWorkspaceShellCapabilities()
   const pluginClient = useWorkspacePluginClient()
   const tags = task.tags?.slice(0, 4) ?? []
@@ -118,7 +127,6 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const hiddenPullRequestCount = Math.max((task.pullRequests?.length ?? 0) - pullRequests.length, 0)
   const chatTitle = taskChatTitle(task)
   const linkedSessionIds = useMemo(() => new Set(sessionLinks.map((link) => link.sessionId)), [sessionLinks])
-  const visibleActivityLinks = useMemo(() => sessionLinks.slice(0, TASK_SESSION_ACTIVITY_MAX_IDS), [sessionLinks])
   const sortedSessionLinks = useMemo(() => {
     return [...sessionLinks].sort((a, b) => {
       const aActivity = sessionActivities[a.sessionId]
@@ -143,7 +151,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const stopCardAction = (event: MouseEvent<HTMLElement>) => event.stopPropagation()
 
   const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<Record<string, TaskSessionActivity>> => {
-    const sessionIds = [...new Set(links.map((link) => link.sessionId))].slice(0, TASK_SESSION_ACTIVITY_MAX_IDS)
+    const sessionIds = [...new Set(links.map((link) => link.sessionId))]
     if (sessionIds.length === 0) {
       setSessionActivities({})
       setActivityError(null)
@@ -151,13 +159,19 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     }
     setActivityLoading(true)
     try {
-      const body = await pluginClient.postJson<SessionActivityResponse>("/api/v1/agent/pi-chat/sessions/activity", { sessionIds })
       const next: Record<string, TaskSessionActivity> = {}
-      for (const entry of body.activities ?? []) {
-        next[entry.sessionId] = { status: entry.status, source: entry.source, updatedAt: entry.updatedAt }
+      // The activity contract deliberately caps each call at 100 IDs. Read every
+      // bound session in bounded chunks so an active late binding cannot be
+      // silently shown as idle or sorted below it.
+      for (const chunk of chunkSessionIds(sessionIds)) {
+        const body = await pluginClient.postJson<SessionActivityResponse>("/api/v1/agent/pi-chat/sessions/activity", { sessionIds: chunk })
+        for (const entry of body.activities ?? []) {
+          next[entry.sessionId] = { status: entry.status, source: entry.source, updatedAt: entry.updatedAt }
+        }
+        for (const sessionId of body.omittedSessionIds ?? []) next[sessionId] = { status: "missing" }
+        for (const sessionId of chunk) next[sessionId] ??= { status: "missing" }
       }
-      for (const sessionId of body.omittedSessionIds ?? []) next[sessionId] = { status: "missing" }
-      setSessionActivities((current) => ({ ...current, ...next }))
+      setSessionActivities(next)
       setActivityError(null)
       return next
     } catch (error) {
@@ -194,10 +208,10 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   }, [pluginClient, refreshSessionActivity, task.adapterId, task.id])
 
   useEffect(() => {
-    if (!sessionLinksLoaded || visibleActivityLinks.length === 0) return
-    const interval = window.setInterval(() => { void refreshSessionActivity(visibleActivityLinks).catch(() => undefined) }, TASK_SESSION_ACTIVITY_POLL_MS)
+    if (!sessionLinksLoaded || sessionLinks.length === 0) return
+    const interval = window.setInterval(() => { void refreshSessionActivity(sessionLinks).catch(() => undefined) }, TASK_SESSION_ACTIVITY_POLL_MS)
     return () => window.clearInterval(interval)
-  }, [refreshSessionActivity, sessionLinksLoaded, visibleActivityLinks])
+  }, [refreshSessionActivity, sessionLinks, sessionLinksLoaded])
 
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -330,8 +344,13 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     onDelete?.(task)
   }
 
+  const closeSessionPanel = () => {
+    setSessionPanelOpen(false)
+    chatButtonRef.current?.focus()
+  }
+
   const chatButton = (
-    <button type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}. ${rollupText}${workingCount > 0 ? `, ${workingCount} working` : ""}.`} title={workingCount === 1 ? "Open working task chat" : "Open task chats"} disabled={openingChat} aria-expanded={sessionPanelOpen}>
+    <button ref={chatButtonRef} type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}. ${rollupText}${workingCount > 0 ? `, ${workingCount} working` : ""}.`} title={workingCount === 1 ? "Open working task chat" : "Open task chats"} disabled={openingChat} aria-expanded={sessionPanelOpen}>
       <MessageSquare className={["size-3.5", openingChat ? "motion-safe:animate-pulse" : ""].join(" ")} strokeWidth={1.75} />
       {activeCount > 0 ? <CircleDot className="absolute -bottom-0.5 -right-0.5 size-2.5 text-emerald-500 motion-safe:animate-pulse" aria-hidden="true" /> : null}
       {sessionLinks.length > 0 ? <span className={["absolute -right-1 -top-1 grid min-w-4 place-items-center rounded-full px-1 text-[9px] font-bold leading-4", workingCount > 0 ? "bg-emerald-500 text-white" : "bg-primary text-primary-foreground"].join(" ")} aria-label={workingCount > 0 ? `${workingCount} working linked chats` : `${sessionLinks.length} linked chats`}>{workingCount > 0 ? workingCount : sessionLinks.length}</span> : null}
@@ -343,17 +362,16 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     <section className="mt-3 w-full rounded-xl border border-border bg-muted/20 p-2 text-xs" aria-label={`Linked chat sessions for ${taskDisplayRef(task)}`} onClick={(event) => event.stopPropagation()}>
       <div className="mb-2 flex items-center justify-between gap-2">
         <span className="font-semibold text-foreground">Task chats</span>
-        <button type="button" className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground" aria-label="Close task chats" onClick={() => setSessionPanelOpen(false)}><X className="size-3" /></button>
+        <button type="button" className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground" aria-label="Close task chats" onClick={closeSessionPanel}><X className="size-3" /></button>
       </div>
       {sessionError ? <p className="mb-2 rounded-lg border border-destructive/30 bg-destructive/10 px-2 py-1 text-destructive" role="alert">{sessionError}</p> : null}
       {activityError ? (
         <div className="mb-2 flex items-center justify-between gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-amber-700 dark:text-amber-200" role="status">
           <span className="inline-flex min-w-0 items-center gap-1"><AlertCircle className="size-3 shrink-0" /> Activity refresh failed.</span>
-          <button type="button" className="rounded-md px-2 py-0.5 font-medium hover:bg-amber-500/15" onClick={(event) => { stopCardAction(event); void refreshSessionActivity(visibleActivityLinks).catch(() => undefined) }}>Retry</button>
+          <button type="button" className="rounded-md px-2 py-0.5 font-medium hover:bg-amber-500/15" onClick={(event) => { stopCardAction(event); void refreshSessionActivity(sessionLinks).catch(() => undefined) }}>Retry</button>
         </div>
       ) : null}
       {activityLoading && sessionLinks.length > 0 ? <p className="mb-2 text-[10px] text-muted-foreground" role="status">Checking chat activity…</p> : null}
-      {sessionLinks.length > TASK_SESSION_ACTIVITY_MAX_IDS ? <p className="mb-2 text-[10px] text-muted-foreground">Activity is shown for the first {TASK_SESSION_ACTIVITY_MAX_IDS} linked chats.</p> : null}
       {sessionLinks.length > 0 ? (
         <ul className="space-y-1">
           {sortedSessionLinks.map((link) => {

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, type DragEvent, type MouseEvent } from "react"
-import { Link2, MessageSquare, MoreHorizontal, Trash2, X } from "lucide-react"
+import { useCallback, useEffect, useMemo, useState, type DragEvent, type MouseEvent } from "react"
+import { AlertCircle, CircleDot, Link2, MessageSquare, MoreHorizontal, Trash2, X } from "lucide-react"
 import { useWorkspacePluginClient } from "@hachej/boring-workspace"
 import { useWorkspaceShellCapabilities, type WorkspaceShellAnchorRect } from "@hachej/boring-workspace/plugin"
 import type { BoringTaskCard, BoringTaskSessionBinding } from "../shared"
@@ -35,6 +35,16 @@ interface TaskSessionLinkResponse { link?: BoringTaskSessionBinding }
 interface PiSessionSummary { id: string; title?: string; updatedAt?: string; createdAt?: string }
 interface ManageSessionsSearchResponse { action?: string; sessions?: PiSessionSummary[] }
 
+type TaskSessionActivityStatus = "idle" | "queued" | "working" | "error" | "missing"
+interface TaskSessionActivity { status: TaskSessionActivityStatus; source?: "live-runtime" | "persisted"; updatedAt?: string }
+interface SessionActivityResponse {
+  activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted"; updatedAt?: string }>
+  omittedSessionIds?: string[]
+}
+
+const TASK_SESSION_ACTIVITY_POLL_MS = 15_000
+const TASK_SESSION_ACTIVITY_MAX_IDS = 100
+
 function taskDisplayRef(task: BoringTaskCard): string {
   return task.number || task.id
 }
@@ -65,6 +75,28 @@ function relativeTime(iso: string): string {
   return `${days}d ago`
 }
 
+function activityRank(status: TaskSessionActivityStatus): number {
+  if (status === "working") return 4
+  if (status === "queued") return 3
+  if (status === "error") return 2
+  return 1
+}
+
+function activityLabel(activity: TaskSessionActivity | undefined, loading: boolean): string {
+  if (!activity) return loading ? "Checking activity" : "Activity pending"
+  if (activity.status === "working") return "Working"
+  if (activity.status === "queued") return "Queued"
+  if (activity.status === "error") return "Needs attention"
+  if (activity.status === "missing") return "Activity unavailable"
+  return "Idle"
+}
+
+function newestTimestampMs(link: BoringTaskSessionBinding, activity: TaskSessionActivity | undefined): number {
+  const activityMs = activity?.updatedAt ? new Date(activity.updatedAt).getTime() : Number.NaN
+  const linkMs = new Date(link.createdAt).getTime()
+  return Math.max(Number.isFinite(activityMs) ? activityMs : 0, Number.isFinite(linkMs) ? linkMs : 0)
+}
+
 export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = false, compact = false, onDelete, onDragStart, onDragEnd }: TaskCardProps) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [openingChat, setOpeningChat] = useState(false)
@@ -75,6 +107,9 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const [linkQuery, setLinkQuery] = useState("")
   const [linkSearchResults, setLinkSearchResults] = useState<PiSessionSummary[]>([])
   const [linkSearchLoading, setLinkSearchLoading] = useState(false)
+  const [sessionActivities, setSessionActivities] = useState<Record<string, TaskSessionActivity>>({})
+  const [activityLoading, setActivityLoading] = useState(false)
+  const [activityError, setActivityError] = useState<string | null>(null)
   const shell = useWorkspaceShellCapabilities()
   const pluginClient = useWorkspacePluginClient()
   const tags = task.tags?.slice(0, 4) ?? []
@@ -82,30 +117,102 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const pullRequests = task.pullRequests?.slice(0, 2) ?? []
   const hiddenPullRequestCount = Math.max((task.pullRequests?.length ?? 0) - pullRequests.length, 0)
   const chatTitle = taskChatTitle(task)
+  const linkedSessionIds = useMemo(() => new Set(sessionLinks.map((link) => link.sessionId)), [sessionLinks])
+  const visibleActivityLinks = useMemo(() => sessionLinks.slice(0, TASK_SESSION_ACTIVITY_MAX_IDS), [sessionLinks])
+  const sortedSessionLinks = useMemo(() => {
+    return [...sessionLinks].sort((a, b) => {
+      const aActivity = sessionActivities[a.sessionId]
+      const bActivity = sessionActivities[b.sessionId]
+      const rankDelta = activityRank(bActivity?.status ?? "idle") - activityRank(aActivity?.status ?? "idle")
+      if (rankDelta !== 0) return rankDelta
+      return newestTimestampMs(b, bActivity) - newestTimestampMs(a, aActivity)
+    })
+  }, [sessionActivities, sessionLinks])
+  const rollupStatus = useMemo<TaskSessionActivityStatus>(() => sortedSessionLinks.reduce<TaskSessionActivityStatus>((status, link) => {
+    const candidate = sessionActivities[link.sessionId]?.status ?? "idle"
+    return activityRank(candidate) > activityRank(status) ? candidate : status
+  }, "idle"), [sessionActivities, sortedSessionLinks])
+  const workingLinks = useMemo(() => sessionLinks.filter((link) => sessionActivities[link.sessionId]?.status === "working"), [sessionActivities, sessionLinks])
+  const workingCount = workingLinks.length
+  const activeCount = sessionLinks.filter((link) => {
+    const status = sessionActivities[link.sessionId]?.status
+    return status === "working" || status === "queued" || status === "error"
+  }).length
+  const rollupText = activityLabel({ status: rollupStatus }, activityLoading)
 
   const stopCardAction = (event: MouseEvent<HTMLElement>) => event.stopPropagation()
 
-  const loadSessionLinks = async (): Promise<BoringTaskSessionBinding[]> => {
+  const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<Record<string, TaskSessionActivity>> => {
+    const sessionIds = [...new Set(links.map((link) => link.sessionId))].slice(0, TASK_SESSION_ACTIVITY_MAX_IDS)
+    if (sessionIds.length === 0) {
+      setSessionActivities({})
+      setActivityError(null)
+      return {}
+    }
+    setActivityLoading(true)
+    try {
+      const body = await pluginClient.postJson<SessionActivityResponse>("/api/v1/agent/pi-chat/sessions/activity", { sessionIds })
+      const next: Record<string, TaskSessionActivity> = {}
+      for (const entry of body.activities ?? []) {
+        next[entry.sessionId] = { status: entry.status, source: entry.source, updatedAt: entry.updatedAt }
+      }
+      for (const sessionId of body.omittedSessionIds ?? []) next[sessionId] = { status: "missing" }
+      setSessionActivities((current) => ({ ...current, ...next }))
+      setActivityError(null)
+      return next
+    } catch (error) {
+      setActivityError(error instanceof Error ? error.message : "Failed to load chat activity")
+      throw error
+    } finally {
+      setActivityLoading(false)
+    }
+  }, [pluginClient])
+
+  const loadSessionLinks = useCallback(async (): Promise<BoringTaskSessionBinding[]> => {
     const body = await pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
     const links = body.links ?? []
     setSessionLinks(links)
     setSessionLinksLoaded(true)
+    if (links.length > 0) void refreshSessionActivity(links).catch(() => undefined)
     return links
-  }
+  }, [pluginClient, refreshSessionActivity, task.adapterId, task.id])
 
   useEffect(() => {
     let cancelled = false
     void pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
       .then((body) => {
         if (cancelled) return
-        setSessionLinks(body.links ?? [])
+        const links = body.links ?? []
+        setSessionLinks(links)
         setSessionLinksLoaded(true)
+        if (links.length > 0) void refreshSessionActivity(links).catch(() => undefined)
       })
       .catch(() => {
         if (!cancelled) setSessionLinksLoaded(true)
       })
     return () => { cancelled = true }
-  }, [pluginClient, task.adapterId, task.id])
+  }, [pluginClient, refreshSessionActivity, task.adapterId, task.id])
+
+  useEffect(() => {
+    if (!sessionLinksLoaded || visibleActivityLinks.length === 0) return
+    const interval = window.setInterval(() => { void refreshSessionActivity(visibleActivityLinks).catch(() => undefined) }, TASK_SESSION_ACTIVITY_POLL_MS)
+    return () => window.clearInterval(interval)
+  }, [refreshSessionActivity, sessionLinksLoaded, visibleActivityLinks])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const onSessionStatus = (event: Event) => {
+      const detail = (event as CustomEvent<{ sessionId?: unknown; working?: unknown }>).detail
+      const sessionId = typeof detail?.sessionId === "string" ? detail.sessionId : null
+      if (!sessionId || !linkedSessionIds.has(sessionId)) return
+      setSessionActivities((current) => ({
+        ...current,
+        [sessionId]: { status: detail.working ? "working" : "idle", source: "live-runtime", updatedAt: new Date().toISOString() },
+      }))
+    }
+    window.addEventListener("boring:chat-session-status", onSessionStatus)
+    return () => window.removeEventListener("boring:chat-session-status", onSessionStatus)
+  }, [linkedSessionIds])
 
   const openLinkedChat = async (link: BoringTaskSessionBinding, anchor?: WorkspaceShellAnchorRect) => {
     const sessions = await pluginClient.getJson<PiSessionSummary[]>(`/api/v1/agent/pi-chat/sessions?limit=1&activeSessionId=${encodeURIComponent(link.sessionId)}`)
@@ -118,6 +225,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     const title = session.title ?? link.title ?? chatTitle
     shell.openDetachedChat(link.sessionId, { anchor, title, composingEnabled: true })
     window.dispatchEvent(new CustomEvent("boring-workspace:open-detached-chat", { detail: { sessionId: link.sessionId, title, composingEnabled: true } }))
+    void refreshSessionActivity([link]).catch(() => undefined)
   }
 
   const createAndLinkChat = async (anchor?: WorkspaceShellAnchorRect) => {
@@ -143,6 +251,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       }
       setSessionLinks((current) => current.some((candidate) => candidate.id === linked.id) ? current : [linked, ...current])
       setSessionLinksLoaded(true)
+      void refreshSessionActivity([linked]).catch(() => undefined)
       const initialDraft = taskChatDraft(task)
       shell.openDetachedChat(session.id, { anchor, title: chatTitle, initialDraft, composingEnabled: true })
       window.dispatchEvent(new CustomEvent("boring-workspace:open-detached-chat", { detail: { sessionId: session.id, title: chatTitle, initialDraft, composingEnabled: true } }))
@@ -163,7 +272,13 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
         await createAndLinkChat(anchor)
         return
       }
-      setSessionPanelOpen((current) => !current)
+      const activity = await refreshSessionActivity(links).catch(() => sessionActivities)
+      const working = links.filter((link) => activity[link.sessionId]?.status === "working")
+      if (working.length === 1) {
+        await openLinkedChat(working[0], anchor)
+        return
+      }
+      setSessionPanelOpen((current) => working.length > 1 ? true : !current)
     })().catch((error) => setSessionError(error instanceof Error ? error.message : "Failed to open task chat"))
   }
 
@@ -171,6 +286,11 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     stopCardAction(event)
     setSessionError(null)
     setSessionLinks((current) => current.filter((candidate) => candidate.id !== link.id))
+    setSessionActivities((current) => {
+      const next = { ...current }
+      delete next[link.sessionId]
+      return next
+    })
     void pluginClient.postJson("/api/boring-tasks/sessions/unlink", { bindingId: link.id })
       .catch((error) => {
         setSessionLinks((current) => current.some((candidate) => candidate.id === link.id) ? current : [link, ...current])
@@ -200,6 +320,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       if (!body.link) throw new Error("Task session binding was not created.")
       setSessionLinks((current) => current.some((candidate) => candidate.id === body.link!.id) ? current : [body.link!, ...current])
       setSessionLinksLoaded(true)
+      void refreshSessionActivity([body.link!]).catch(() => undefined)
     }).catch((error) => setSessionError(error instanceof Error ? error.message : "Failed to link session"))
   }
 
@@ -210,9 +331,11 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   }
 
   const chatButton = (
-    <button type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}`} title="Open task chat" disabled={openingChat} aria-expanded={sessionPanelOpen}>
-      <MessageSquare className={["size-3.5", openingChat ? "animate-pulse" : ""].join(" ")} strokeWidth={1.75} />
-      {sessionLinks.length > 0 ? <span className="absolute -right-1 -top-1 grid min-w-4 place-items-center rounded-full bg-primary px-1 text-[9px] font-bold leading-4 text-primary-foreground" aria-label={`${sessionLinks.length} linked chats`}>{sessionLinks.length}</span> : null}
+    <button type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}. ${rollupText}${workingCount > 0 ? `, ${workingCount} working` : ""}.`} title={workingCount === 1 ? "Open working task chat" : "Open task chats"} disabled={openingChat} aria-expanded={sessionPanelOpen}>
+      <MessageSquare className={["size-3.5", openingChat ? "motion-safe:animate-pulse" : ""].join(" ")} strokeWidth={1.75} />
+      {activeCount > 0 ? <CircleDot className="absolute -bottom-0.5 -right-0.5 size-2.5 text-emerald-500 motion-safe:animate-pulse" aria-hidden="true" /> : null}
+      {sessionLinks.length > 0 ? <span className={["absolute -right-1 -top-1 grid min-w-4 place-items-center rounded-full px-1 text-[9px] font-bold leading-4", workingCount > 0 ? "bg-emerald-500 text-white" : "bg-primary text-primary-foreground"].join(" ")} aria-label={workingCount > 0 ? `${workingCount} working linked chats` : `${sessionLinks.length} linked chats`}>{workingCount > 0 ? workingCount : sessionLinks.length}</span> : null}
+      <span className="sr-only" aria-live="polite">Task chat activity: {rollupText}</span>
     </button>
   )
 
@@ -223,18 +346,38 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
         <button type="button" className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground" aria-label="Close task chats" onClick={() => setSessionPanelOpen(false)}><X className="size-3" /></button>
       </div>
       {sessionError ? <p className="mb-2 rounded-lg border border-destructive/30 bg-destructive/10 px-2 py-1 text-destructive" role="alert">{sessionError}</p> : null}
+      {activityError ? (
+        <div className="mb-2 flex items-center justify-between gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-amber-700 dark:text-amber-200" role="status">
+          <span className="inline-flex min-w-0 items-center gap-1"><AlertCircle className="size-3 shrink-0" /> Activity refresh failed.</span>
+          <button type="button" className="rounded-md px-2 py-0.5 font-medium hover:bg-amber-500/15" onClick={(event) => { stopCardAction(event); void refreshSessionActivity(visibleActivityLinks).catch(() => undefined) }}>Retry</button>
+        </div>
+      ) : null}
+      {activityLoading && sessionLinks.length > 0 ? <p className="mb-2 text-[10px] text-muted-foreground" role="status">Checking chat activity…</p> : null}
+      {sessionLinks.length > TASK_SESSION_ACTIVITY_MAX_IDS ? <p className="mb-2 text-[10px] text-muted-foreground">Activity is shown for the first {TASK_SESSION_ACTIVITY_MAX_IDS} linked chats.</p> : null}
       {sessionLinks.length > 0 ? (
         <ul className="space-y-1">
-          {sessionLinks.map((link) => (
-            <li key={link.id} className="flex items-center gap-2 rounded-lg bg-background/70 px-2 py-1.5">
-              <div className="min-w-0 flex-1">
-                <div className="truncate font-medium text-foreground">{link.title ?? link.sessionId}</div>
-                <div className="text-[10px] text-muted-foreground">{relativeTime(link.createdAt)}</div>
-              </div>
-              <button type="button" className="rounded-md px-2 py-1 font-medium text-primary hover:bg-primary/10" onClick={(event) => { stopCardAction(event); void openLinkedChat(link, rectFromElement(event.currentTarget)) }}>Open</button>
-              <button type="button" className="rounded-md px-2 py-1 text-muted-foreground hover:bg-muted hover:text-destructive" onClick={(event) => unlinkSession(event, link)}>Unlink</button>
-            </li>
-          ))}
+          {sortedSessionLinks.map((link) => {
+            const activity = sessionActivities[link.sessionId]
+            const statusText = activityLabel(activity, activityLoading)
+            const isWorking = activity?.status === "working"
+            return (
+              <li key={link.id} className="flex items-center gap-2 rounded-lg bg-background/70 px-2 py-1.5">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-medium text-foreground">{link.title ?? link.sessionId}</div>
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-muted-foreground">
+                    <span>{relativeTime(activity?.updatedAt ?? link.createdAt)}</span>
+                    <span className={["inline-flex items-center gap-1 font-medium", isWorking ? "text-emerald-600 dark:text-emerald-300" : activity?.status === "error" ? "text-destructive" : ""].join(" ")}>
+                      <CircleDot className={["size-2", isWorking ? "motion-safe:animate-pulse" : ""].join(" ")} aria-hidden="true" />
+                      {statusText}
+                    </span>
+                    {activity?.source === "persisted" ? <span>persisted</span> : null}
+                  </div>
+                </div>
+                <button type="button" className="rounded-md px-2 py-1 font-medium text-primary hover:bg-primary/10" onClick={(event) => { stopCardAction(event); void openLinkedChat(link, rectFromElement(event.currentTarget)) }}>Open</button>
+                <button type="button" className="rounded-md px-2 py-1 text-muted-foreground hover:bg-muted hover:text-destructive" onClick={(event) => unlinkSession(event, link)}>Unlink</button>
+              </li>
+            )
+          })}
         </ul>
       ) : <p className="text-muted-foreground">No linked chats yet.</p>}
       <div className="mt-2 flex flex-wrap items-center gap-2">

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -108,6 +108,8 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const [linkSearchLoading, setLinkSearchLoading] = useState(false)
   const [optimisticSessionIds, setOptimisticSessionIds] = useState<ReadonlySet<string>>(new Set())
   const chatButtonRef = useRef<HTMLButtonElement>(null)
+  const mountedRef = useRef(false)
+  const openChatRequestSeqRef = useRef(0)
   const shell = useWorkspaceShellCapabilities()
   const pluginClient = useWorkspacePluginClient()
   const sessionActivity = useTaskSessionActivity()
@@ -120,7 +122,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const linkedSessionIdKey = linkedSessionIdList.join("\u0000")
   const linkedSessionIds = useMemo(() => new Set(linkedSessionIdList), [linkedSessionIdKey])
   const sessionActivities = sessionActivity.activities
-  const activityError = sessionActivity.error
+  const activityError = sessionActivity.getError(linkedSessionIdList)
   const activityLoading = sessionActivity.isLoading(linkedSessionIdList)
   const chatActivityPending = checkingChatActivity || activityLoading
   const sortedSessionLinks = useMemo(() => {
@@ -153,15 +155,29 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
 
   const stopCardAction = (event: MouseEvent<HTMLElement>) => event.stopPropagation()
 
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      openChatRequestSeqRef.current += 1
+    }
+  }, [])
+
+  useEffect(() => {
+    openChatRequestSeqRef.current += 1
+  }, [task.adapterId, task.id])
+
   const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<TaskSessionActivityRefreshResult> => {
     return await sessionActivity.refreshSessionIds(links.map((link) => link.sessionId))
   }, [sessionActivity.refreshSessionIds])
 
-  const loadSessionLinks = useCallback(async (): Promise<BoringTaskSessionBinding[]> => {
+  const loadSessionLinks = useCallback(async (shouldApply: () => boolean = () => mountedRef.current): Promise<BoringTaskSessionBinding[]> => {
     const body = await pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
     const links = body.links ?? []
-    setSessionLinks(links)
-    setSessionLinksLoaded(true)
+    if (shouldApply()) {
+      setSessionLinks(links)
+      setSessionLinksLoaded(true)
+    }
     return links
   }, [pluginClient, task.adapterId, task.id])
 
@@ -197,8 +213,9 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     return () => window.removeEventListener("boring:chat-session-status", onSessionStatus)
   }, [linkedSessionIds, optimisticSessionIds, sessionActivity.setOptimisticActivity])
 
-  const openLinkedChat = async (link: BoringTaskSessionBinding, anchor?: WorkspaceShellAnchorRect): Promise<boolean> => {
+  const openLinkedChat = async (link: BoringTaskSessionBinding, anchor?: WorkspaceShellAnchorRect, shouldContinue: () => boolean = () => mountedRef.current): Promise<boolean> => {
     const sessions = await pluginClient.getJson<PiSessionSummary[]>(`/api/v1/agent/pi-chat/sessions?limit=1&activeSessionId=${encodeURIComponent(link.sessionId)}`)
+    if (!shouldContinue()) return false
     const session = sessions.find((candidate) => candidate.id === link.sessionId)
     if (!session) {
       setSessionPanelOpen(true)
@@ -213,11 +230,12 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     return true
   }
 
-  const createAndLinkChat = async (anchor?: WorkspaceShellAnchorRect) => {
+  const createAndLinkChat = async (anchor?: WorkspaceShellAnchorRect, shouldContinue: () => boolean = () => mountedRef.current) => {
     setOpeningChat(true)
     setSessionError(null)
     try {
       const session = await pluginClient.postJson<CreatedPiChatSession>("/api/v1/agent/pi-chat/sessions", { title: chatTitle })
+      if (!shouldContinue()) return
       if (typeof session.id !== "string" || session.id.length === 0) throw new Error("Chat session was not created.")
       const sessionId = session.id
       let linked: BoringTaskSessionBinding
@@ -228,13 +246,16 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
           sessionId,
           title: chatTitle,
         })
+        if (!shouldContinue()) return
         if (!response.link) throw new Error("Task session binding was not created.")
         linked = response.link
       } catch (error) {
+        if (!shouldContinue()) return
         setSessionPanelOpen(true)
         setSessionError(`Created chat ${sessionId}, but failed to bind it to this task. Use Link existing to attach it before opening. ${error instanceof Error ? error.message : ""}`.trim())
         return
       }
+      if (!shouldContinue()) return
       setSessionLinks((current) => current.some((candidate) => candidate.id === linked.id) ? current : [linked, ...current])
       setSessionLinksLoaded(true)
       void refreshSessionActivity([linked]).catch(() => undefined)
@@ -243,9 +264,9 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       shell.openDetachedChat(sessionId, { anchor, title: chatTitle, initialDraft, composingEnabled: true })
       window.dispatchEvent(new CustomEvent("boring-workspace:open-detached-chat", { detail: { sessionId, title: chatTitle, initialDraft, composingEnabled: true } }))
     } catch (error) {
-      setSessionError(error instanceof Error ? error.message : "Failed to open task chat")
+      if (shouldContinue()) setSessionError(error instanceof Error ? error.message : "Failed to open task chat")
     } finally {
-      setOpeningChat(false)
+      if (shouldContinue()) setOpeningChat(false)
     }
   }
 
@@ -254,12 +275,16 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     if (checkingChatActivity) return
     const anchor = rectFromElement(event.currentTarget)
     const panelWasOpen = sessionPanelOpen
+    const requestId = openChatRequestSeqRef.current + 1
+    openChatRequestSeqRef.current = requestId
+    const shouldContinue = () => mountedRef.current && openChatRequestSeqRef.current === requestId
     setSessionError(null)
     setCheckingChatActivity(true)
     void (async () => {
-      const links = sessionLinksLoaded ? sessionLinks : await loadSessionLinks()
+      const links = sessionLinksLoaded ? sessionLinks : await loadSessionLinks(shouldContinue)
+      if (!shouldContinue()) return
       if (links.length === 0) {
-        await createAndLinkChat(anchor)
+        await createAndLinkChat(anchor, shouldContinue)
         return
       }
       setSessionPanelOpen(true)
@@ -267,9 +292,10 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       try {
         refreshResult = await refreshSessionActivity(links)
       } catch (error) {
-        setSessionError(error instanceof Error ? error.message : "Activity refresh failed")
+        if (shouldContinue()) setSessionError(error instanceof Error ? error.message : "Activity refresh failed")
         return
       }
+      if (!shouldContinue()) return
       if (refreshResult.status === "stale") {
         setSessionError("Chat activity changed while opening. Try again.")
         return
@@ -279,13 +305,16 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
         return status === "working" || status === "queued"
       })
       if (active.length === 1) {
-        const opened = await openLinkedChat(active[0], anchor)
-        if (opened && !panelWasOpen) setSessionPanelOpen(false)
+        const opened = await openLinkedChat(active[0], anchor, shouldContinue)
+        if (opened && shouldContinue() && !panelWasOpen) setSessionPanelOpen(false)
         return
       }
-      setSessionPanelOpen(true)
-    })().catch((error) => setSessionError(error instanceof Error ? error.message : "Failed to open task chat"))
-      .finally(() => setCheckingChatActivity(false))
+      if (shouldContinue()) setSessionPanelOpen(true)
+    })().catch((error) => {
+      if (shouldContinue()) setSessionError(error instanceof Error ? error.message : "Failed to open task chat")
+    }).finally(() => {
+      if (shouldContinue()) setCheckingChatActivity(false)
+    })
   }
 
   const unlinkSession = (event: MouseEvent<HTMLButtonElement>, link: BoringTaskSessionBinding) => {
@@ -337,6 +366,8 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   }
 
   const closeSessionPanel = () => {
+    openChatRequestSeqRef.current += 1
+    setCheckingChatActivity(false)
     setSessionPanelOpen(false)
     chatButtonRef.current?.focus()
   }

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type DragEvent, type MouseEvent } from "react"
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type DragEvent, type MouseEvent } from "react"
 import { AlertCircle, CircleDot, Link2, MessageSquare, MoreHorizontal, Trash2, X } from "lucide-react"
 import { useWorkspacePluginClient } from "@hachej/boring-workspace"
 import { useWorkspaceShellCapabilities, type WorkspaceShellAnchorRect } from "@hachej/boring-workspace/plugin"
@@ -35,6 +35,7 @@ interface TaskSessionListResponse { links?: BoringTaskSessionBinding[] }
 interface TaskSessionLinkResponse { link?: BoringTaskSessionBinding }
 interface PiSessionSummary { id: string; title?: string; updatedAt?: string; createdAt?: string }
 interface ManageSessionsSearchResponse { action?: string; sessions?: PiSessionSummary[] }
+interface TaskSessionLinkState { taskScopeKey: string; links: BoringTaskSessionBinding[]; loaded: boolean }
 
 function taskDisplayRef(task: BoringTaskCard): string {
   return task.number || task.id
@@ -96,12 +97,12 @@ function newestTimestampMs(link: BoringTaskSessionBinding, activity: TaskSession
 }
 
 export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = false, compact = false, onDelete, onDragStart, onDragEnd }: TaskCardProps) {
+  const taskScopeKey = `${task.adapterId}\u0000${task.id}`
   const [menuOpen, setMenuOpen] = useState(false)
   const [openingChat, setOpeningChat] = useState(false)
   const [checkingChatActivity, setCheckingChatActivity] = useState(false)
   const [sessionPanelOpen, setSessionPanelOpen] = useState(false)
-  const [sessionLinks, setSessionLinks] = useState<BoringTaskSessionBinding[]>([])
-  const [sessionLinksLoaded, setSessionLinksLoaded] = useState(false)
+  const [sessionLinkState, setSessionLinkState] = useState<TaskSessionLinkState>(() => ({ taskScopeKey, links: [], loaded: false }))
   const [sessionError, setSessionError] = useState<string | null>(null)
   const [linkQuery, setLinkQuery] = useState("")
   const [linkSearchResults, setLinkSearchResults] = useState<PiSessionSummary[]>([])
@@ -110,9 +111,14 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const chatButtonRef = useRef<HTMLButtonElement>(null)
   const mountedRef = useRef(false)
   const navigationGenerationRef = useRef(0)
+  const taskScopeKeyRef = useRef(taskScopeKey)
   const shell = useWorkspaceShellCapabilities()
   const pluginClient = useWorkspacePluginClient()
   const sessionActivity = useTaskSessionActivity()
+  const sessionLinkStateMatchesTask = sessionLinkState.taskScopeKey === taskScopeKey
+  const sessionLinks = sessionLinkStateMatchesTask ? sessionLinkState.links : []
+  const sessionLinksLoaded = sessionLinkStateMatchesTask ? sessionLinkState.loaded : false
+  const visibleSessionPanelOpen = sessionPanelOpen && sessionLinkStateMatchesTask
   const tags = task.tags?.slice(0, 4) ?? []
   const hiddenTagCount = Math.max((task.tags?.length ?? 0) - tags.length, 0)
   const pullRequests = task.pullRequests?.slice(0, 2) ?? []
@@ -124,7 +130,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const sessionActivities = sessionActivity.activities
   const activityError = sessionActivity.getError(linkedSessionIdList)
   const activityLoading = sessionActivity.isLoading(linkedSessionIdList)
-  const chatActivityPending = checkingChatActivity || activityLoading
+  const chatActivityPending = checkingChatActivity || activityLoading || !sessionLinksLoaded
   const sortedSessionLinks = useMemo(() => {
     return [...sessionLinks].sort((a, b) => {
       const aActivity = sessionActivities[a.sessionId]
@@ -151,7 +157,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const workingCount = workingLinks.length
   const activeNavigationCount = activeNavigationLinks.length
   const errorCount = sessionLinks.filter((link) => sessionActivities[link.sessionId]?.status === "error").length
-  const rollupText = checkingChatActivity ? "Checking activity" : sessionLinks.length === 0 && sessionLinksLoaded ? "No linked chats" : activityLabel(rollupActivity, activityLoading)
+  const rollupText = checkingChatActivity || !sessionLinksLoaded ? "Checking activity" : sessionLinks.length === 0 ? "No linked chats" : activityLabel(rollupActivity, activityLoading)
 
   const stopCardAction = (event: MouseEvent<HTMLElement>) => event.stopPropagation()
 
@@ -162,8 +168,13 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const beginNavigation = useCallback(() => {
     const generation = navigationGenerationRef.current + 1
     navigationGenerationRef.current = generation
-    return () => mountedRef.current && navigationGenerationRef.current === generation
+    const expectedTaskScopeKey = taskScopeKeyRef.current
+    return () => mountedRef.current && navigationGenerationRef.current === generation && taskScopeKeyRef.current === expectedTaskScopeKey
   }, [])
+
+  const updateCurrentSessionLinks = useCallback((updater: (current: BoringTaskSessionBinding[]) => BoringTaskSessionBinding[], loaded = true) => {
+    setSessionLinkState((current) => current.taskScopeKey === taskScopeKey ? { taskScopeKey, links: updater(current.links), loaded } : current)
+  }, [taskScopeKey])
 
   useEffect(() => {
     mountedRef.current = true
@@ -173,11 +184,22 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     }
   }, [invalidatePendingNavigation])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
+    taskScopeKeyRef.current = taskScopeKey
     invalidatePendingNavigation()
+    setMenuOpen(false)
     setOpeningChat(false)
     setCheckingChatActivity(false)
-  }, [invalidatePendingNavigation, task.adapterId, task.id])
+    setSessionPanelOpen(false)
+    setSessionError(null)
+    setLinkQuery("")
+    setLinkSearchResults([])
+    setLinkSearchLoading(false)
+    setOptimisticSessionIds(new Set())
+    setSessionLinkState((current) => current.taskScopeKey === taskScopeKey && current.links.length === 0 && !current.loaded
+      ? current
+      : { taskScopeKey, links: [], loaded: false })
+  }, [invalidatePendingNavigation, taskScopeKey])
 
   const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<TaskSessionActivityRefreshResult> => {
     return await sessionActivity.refreshSessionIds(links.map((link) => link.sessionId))
@@ -186,27 +208,26 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const loadSessionLinks = useCallback(async (shouldApply: () => boolean = () => mountedRef.current): Promise<BoringTaskSessionBinding[]> => {
     const body = await pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
     const links = body.links ?? []
-    if (shouldApply()) {
-      setSessionLinks(links)
-      setSessionLinksLoaded(true)
-    }
+    if (shouldApply()) setSessionLinkState({ taskScopeKey, links, loaded: true })
     return links
-  }, [pluginClient, task.adapterId, task.id])
+  }, [pluginClient, task.adapterId, task.id, taskScopeKey])
 
   useEffect(() => {
     let cancelled = false
+    setSessionLinkState((current) => current.taskScopeKey === taskScopeKey && current.links.length === 0 && !current.loaded
+      ? current
+      : { taskScopeKey, links: [], loaded: false })
     void pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
       .then((body) => {
         if (cancelled) return
         const links = body.links ?? []
-        setSessionLinks(links)
-        setSessionLinksLoaded(true)
+        setSessionLinkState({ taskScopeKey, links, loaded: true })
       })
       .catch(() => {
-        if (!cancelled) setSessionLinksLoaded(true)
+        if (!cancelled) setSessionLinkState({ taskScopeKey, links: [], loaded: true })
       })
     return () => { cancelled = true }
-  }, [pluginClient, task.adapterId, task.id])
+  }, [pluginClient, task.adapterId, task.id, taskScopeKey])
 
   useEffect(() => {
     if (!sessionLinksLoaded || linkedSessionIdList.length === 0) return
@@ -268,8 +289,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
         return
       }
       if (!shouldContinue()) return
-      setSessionLinks((current) => current.some((candidate) => candidate.id === linked.id) ? current : [linked, ...current])
-      setSessionLinksLoaded(true)
+      updateCurrentSessionLinks((current) => current.some((candidate) => candidate.id === linked.id) ? current : [linked, ...current])
       void refreshSessionActivity([linked]).catch(() => undefined)
       const initialDraft = taskChatDraft(task)
       setOptimisticSessionIds((current) => new Set(current).add(sessionId))
@@ -286,7 +306,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     stopCardAction(event)
     if (checkingChatActivity) return
     const anchor = rectFromElement(event.currentTarget)
-    const panelWasOpen = sessionPanelOpen
+    const panelWasOpen = visibleSessionPanelOpen
     const shouldContinue = beginNavigation()
     setSessionError(null)
     setCheckingChatActivity(true)
@@ -333,7 +353,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     setOpeningChat(false)
     setCheckingChatActivity(false)
     setSessionError(null)
-    setSessionLinks((current) => current.filter((candidate) => candidate.id !== link.id))
+    updateCurrentSessionLinks((current) => current.filter((candidate) => candidate.id !== link.id))
     setOptimisticSessionIds((current) => {
       const next = new Set(current)
       next.delete(link.sessionId)
@@ -341,7 +361,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     })
     void pluginClient.postJson("/api/boring-tasks/sessions/unlink", { bindingId: link.id })
       .catch((error) => {
-        setSessionLinks((current) => current.some((candidate) => candidate.id === link.id) ? current : [link, ...current])
+        updateCurrentSessionLinks((current) => current.some((candidate) => candidate.id === link.id) ? current : [link, ...current])
         setSessionError(error instanceof Error ? error.message : "Failed to unlink session")
       })
   }
@@ -366,8 +386,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       title: session.title ?? chatTitle,
     }).then((body) => {
       if (!body.link) throw new Error("Task session binding was not created.")
-      setSessionLinks((current) => current.some((candidate) => candidate.id === body.link!.id) ? current : [body.link!, ...current])
-      setSessionLinksLoaded(true)
+      updateCurrentSessionLinks((current) => current.some((candidate) => candidate.id === body.link!.id) ? current : [body.link!, ...current])
       void refreshSessionActivity([body.link!]).catch(() => undefined)
     }).catch((error) => setSessionError(error instanceof Error ? error.message : "Failed to link session"))
   }
@@ -400,7 +419,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       ? "bg-destructive text-destructive-foreground"
       : "bg-primary text-primary-foreground"
   const chatButton = (
-    <button ref={chatButtonRef} type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}. ${rollupText}${workingCount > 0 ? `, ${workingCount} working` : errorCount > 0 ? `, ${errorCount} need attention` : ""}.`} title={activeNavigationCount === 1 ? "Open active task chat" : "Open task chats"} disabled={openingChat} aria-expanded={sessionPanelOpen} aria-busy={chatActivityPending || undefined}>
+    <button ref={chatButtonRef} type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}. ${rollupText}${workingCount > 0 ? `, ${workingCount} working` : errorCount > 0 ? `, ${errorCount} need attention` : ""}.`} title={activeNavigationCount === 1 ? "Open active task chat" : "Open task chats"} disabled={openingChat} aria-expanded={visibleSessionPanelOpen} aria-busy={chatActivityPending || undefined}>
       <MessageSquare className={["size-3.5", openingChat || checkingChatActivity ? "motion-safe:animate-pulse" : ""].join(" ")} strokeWidth={1.75} />
       {checkingChatActivity ? <CircleDot className="absolute -bottom-0.5 -right-0.5 size-2.5 text-primary motion-safe:animate-pulse" aria-hidden="true" /> : activeNavigationCount > 0 ? <CircleDot className="absolute -bottom-0.5 -right-0.5 size-2.5 text-emerald-500 motion-safe:animate-pulse" aria-hidden="true" /> : errorCount > 0 ? <AlertCircle className="absolute -bottom-0.5 -right-0.5 size-2.5 text-destructive" aria-hidden="true" /> : null}
       {sessionLinks.length > 0 ? <span className={["absolute -right-1 -top-1 grid min-w-4 place-items-center rounded-full px-1 text-[9px] font-bold leading-4", badgeClass].join(" ")} aria-label={badgeLabel}>{badgeText}</span> : null}
@@ -408,7 +427,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     </button>
   )
 
-  const taskSessionPanel = sessionPanelOpen ? (
+  const taskSessionPanel = visibleSessionPanelOpen ? (
     <section className="mt-3 w-full rounded-xl border border-border bg-muted/20 p-2 text-xs" aria-label={`Linked chat sessions for ${taskDisplayRef(task)}`} onClick={(event) => event.stopPropagation()}>
       <div className="mb-2 flex items-center justify-between gap-2">
         <span className="font-semibold text-foreground">Task chats</span>

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -109,7 +109,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const [optimisticSessionIds, setOptimisticSessionIds] = useState<ReadonlySet<string>>(new Set())
   const chatButtonRef = useRef<HTMLButtonElement>(null)
   const mountedRef = useRef(false)
-  const openChatRequestSeqRef = useRef(0)
+  const navigationGenerationRef = useRef(0)
   const shell = useWorkspaceShellCapabilities()
   const pluginClient = useWorkspacePluginClient()
   const sessionActivity = useTaskSessionActivity()
@@ -155,17 +155,29 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
 
   const stopCardAction = (event: MouseEvent<HTMLElement>) => event.stopPropagation()
 
+  const invalidatePendingNavigation = useCallback(() => {
+    navigationGenerationRef.current += 1
+  }, [])
+
+  const beginNavigation = useCallback(() => {
+    const generation = navigationGenerationRef.current + 1
+    navigationGenerationRef.current = generation
+    return () => mountedRef.current && navigationGenerationRef.current === generation
+  }, [])
+
   useEffect(() => {
     mountedRef.current = true
     return () => {
       mountedRef.current = false
-      openChatRequestSeqRef.current += 1
+      invalidatePendingNavigation()
     }
-  }, [])
+  }, [invalidatePendingNavigation])
 
   useEffect(() => {
-    openChatRequestSeqRef.current += 1
-  }, [task.adapterId, task.id])
+    invalidatePendingNavigation()
+    setOpeningChat(false)
+    setCheckingChatActivity(false)
+  }, [invalidatePendingNavigation, task.adapterId, task.id])
 
   const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<TaskSessionActivityRefreshResult> => {
     return await sessionActivity.refreshSessionIds(links.map((link) => link.sessionId))
@@ -213,7 +225,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     return () => window.removeEventListener("boring:chat-session-status", onSessionStatus)
   }, [linkedSessionIds, optimisticSessionIds, sessionActivity.setOptimisticActivity])
 
-  const openLinkedChat = async (link: BoringTaskSessionBinding, anchor?: WorkspaceShellAnchorRect, shouldContinue: () => boolean = () => mountedRef.current): Promise<boolean> => {
+  const openLinkedChat = async (link: BoringTaskSessionBinding, anchor?: WorkspaceShellAnchorRect, shouldContinue: () => boolean = beginNavigation()): Promise<boolean> => {
     const sessions = await pluginClient.getJson<PiSessionSummary[]>(`/api/v1/agent/pi-chat/sessions?limit=1&activeSessionId=${encodeURIComponent(link.sessionId)}`)
     if (!shouldContinue()) return false
     const session = sessions.find((candidate) => candidate.id === link.sessionId)
@@ -230,7 +242,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     return true
   }
 
-  const createAndLinkChat = async (anchor?: WorkspaceShellAnchorRect, shouldContinue: () => boolean = () => mountedRef.current) => {
+  const createAndLinkChat = async (anchor?: WorkspaceShellAnchorRect, shouldContinue: () => boolean = beginNavigation()) => {
     setOpeningChat(true)
     setSessionError(null)
     try {
@@ -275,9 +287,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     if (checkingChatActivity) return
     const anchor = rectFromElement(event.currentTarget)
     const panelWasOpen = sessionPanelOpen
-    const requestId = openChatRequestSeqRef.current + 1
-    openChatRequestSeqRef.current = requestId
-    const shouldContinue = () => mountedRef.current && openChatRequestSeqRef.current === requestId
+    const shouldContinue = beginNavigation()
     setSessionError(null)
     setCheckingChatActivity(true)
     void (async () => {
@@ -319,6 +329,9 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
 
   const unlinkSession = (event: MouseEvent<HTMLButtonElement>, link: BoringTaskSessionBinding) => {
     stopCardAction(event)
+    invalidatePendingNavigation()
+    setOpeningChat(false)
+    setCheckingChatActivity(false)
     setSessionError(null)
     setSessionLinks((current) => current.filter((candidate) => candidate.id !== link.id))
     setOptimisticSessionIds((current) => {
@@ -366,7 +379,8 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   }
 
   const closeSessionPanel = () => {
-    openChatRequestSeqRef.current += 1
+    invalidatePendingNavigation()
+    setOpeningChat(false)
     setCheckingChatActivity(false)
     setSessionPanelOpen(false)
     chatButtonRef.current?.focus()

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -112,6 +112,8 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const mountedRef = useRef(false)
   const navigationGenerationRef = useRef(0)
   const taskAsyncGenerationRef = useRef(0)
+  const sessionListRequestGenerationRef = useRef(0)
+  const sessionLinkMutationGenerationRef = useRef(0)
   const taskScopeKeyRef = useRef(taskScopeKey)
   const shell = useWorkspaceShellCapabilities()
   const pluginClient = useWorkspacePluginClient()
@@ -183,9 +185,25 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     return () => mountedRef.current && navigationGenerationRef.current === generation && taskScopeKeyRef.current === expectedTaskScopeKey
   }, [])
 
+  const beginSessionListRequest = useCallback(() => {
+    const requestGeneration = sessionListRequestGenerationRef.current + 1
+    sessionListRequestGenerationRef.current = requestGeneration
+    const mutationGeneration = sessionLinkMutationGenerationRef.current
+    const expectedTaskScopeKey = taskScopeKeyRef.current
+    return () => mountedRef.current
+      && taskScopeKeyRef.current === expectedTaskScopeKey
+      && sessionListRequestGenerationRef.current === requestGeneration
+      && sessionLinkMutationGenerationRef.current === mutationGeneration
+  }, [])
+
+  const invalidatePendingSessionLists = useCallback(() => {
+    sessionLinkMutationGenerationRef.current += 1
+  }, [])
+
   const updateCurrentSessionLinks = useCallback((updater: (current: BoringTaskSessionBinding[]) => BoringTaskSessionBinding[], loaded = true) => {
+    invalidatePendingSessionLists()
     setSessionLinkState((current) => current.taskScopeKey === taskScopeKey ? { taskScopeKey, links: updater(current.links), loaded } : current)
-  }, [taskScopeKey])
+  }, [invalidatePendingSessionLists, taskScopeKey])
 
   useEffect(() => {
     mountedRef.current = true
@@ -193,13 +211,15 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       mountedRef.current = false
       invalidatePendingNavigation()
       invalidatePendingTaskAsync()
+      invalidatePendingSessionLists()
     }
-  }, [invalidatePendingNavigation, invalidatePendingTaskAsync])
+  }, [invalidatePendingNavigation, invalidatePendingSessionLists, invalidatePendingTaskAsync])
 
   useLayoutEffect(() => {
     taskScopeKeyRef.current = taskScopeKey
     invalidatePendingNavigation()
     invalidatePendingTaskAsync()
+    invalidatePendingSessionLists()
     setMenuOpen(false)
     setOpeningChat(false)
     setCheckingChatActivity(false)
@@ -212,35 +232,38 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     setSessionLinkState((current) => current.taskScopeKey === taskScopeKey && current.links.length === 0 && !current.loaded
       ? current
       : { taskScopeKey, links: [], loaded: false })
-  }, [invalidatePendingNavigation, invalidatePendingTaskAsync, taskScopeKey])
+  }, [invalidatePendingNavigation, invalidatePendingSessionLists, invalidatePendingTaskAsync, taskScopeKey])
 
   const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<TaskSessionActivityRefreshResult> => {
     return await sessionActivity.refreshSessionIds(links.map((link) => link.sessionId))
   }, [sessionActivity.refreshSessionIds])
 
-  const loadSessionLinks = useCallback(async (shouldApply: () => boolean = () => mountedRef.current): Promise<BoringTaskSessionBinding[]> => {
+  const loadSessionLinks = useCallback(async (shouldApply: () => boolean = () => mountedRef.current): Promise<BoringTaskSessionBinding[] | null> => {
+    const shouldApplyList = beginSessionListRequest()
     const body = await pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
     const links = body.links ?? []
-    if (shouldApply()) setSessionLinkState({ taskScopeKey, links, loaded: true })
+    if (!shouldApply() || !shouldApplyList()) return null
+    setSessionLinkState({ taskScopeKey, links, loaded: true })
     return links
-  }, [pluginClient, task.adapterId, task.id, taskScopeKey])
+  }, [beginSessionListRequest, pluginClient, task.adapterId, task.id, taskScopeKey])
 
   useEffect(() => {
     let cancelled = false
     setSessionLinkState((current) => current.taskScopeKey === taskScopeKey && current.links.length === 0 && !current.loaded
       ? current
       : { taskScopeKey, links: [], loaded: false })
+    const shouldApplyList = beginSessionListRequest()
     void pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
       .then((body) => {
-        if (cancelled) return
+        if (cancelled || !shouldApplyList()) return
         const links = body.links ?? []
         setSessionLinkState({ taskScopeKey, links, loaded: true })
       })
       .catch(() => {
-        if (!cancelled) setSessionLinkState({ taskScopeKey, links: [], loaded: true })
+        if (!cancelled && shouldApplyList()) setSessionLinkState({ taskScopeKey, links: [], loaded: true })
       })
     return () => { cancelled = true }
-  }, [pluginClient, task.adapterId, task.id, taskScopeKey])
+  }, [beginSessionListRequest, pluginClient, task.adapterId, task.id, taskScopeKey])
 
   useEffect(() => {
     if (!sessionLinksLoaded || linkedSessionIdList.length === 0) return
@@ -325,7 +348,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     setCheckingChatActivity(true)
     void (async () => {
       const links = sessionLinksLoaded ? sessionLinks : await loadSessionLinks(shouldContinue)
-      if (!shouldContinue()) return
+      if (!shouldContinue() || links === null) return
       if (links.length === 0) {
         await createAndLinkChat(anchor, shouldContinue)
         return

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -104,6 +104,8 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const [sessionPanelOpen, setSessionPanelOpen] = useState(false)
   const [sessionLinkState, setSessionLinkState] = useState<TaskSessionLinkState>(() => ({ taskScopeKey, links: [], loaded: false }))
   const [sessionError, setSessionError] = useState<string | null>(null)
+  const [sessionListError, setSessionListError] = useState<string | null>(null)
+  const [sessionListLoading, setSessionListLoading] = useState(false)
   const [linkQuery, setLinkQuery] = useState("")
   const [linkSearchResults, setLinkSearchResults] = useState<PiSessionSummary[]>([])
   const [linkSearchLoading, setLinkSearchLoading] = useState(false)
@@ -133,7 +135,9 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const sessionActivities = sessionActivity.activities
   const activityError = sessionActivity.getError(linkedSessionIdList)
   const activityLoading = sessionActivity.isLoading(linkedSessionIdList)
-  const chatActivityPending = checkingChatActivity || activityLoading || !sessionLinksLoaded
+  const sessionListPending = !sessionLinksLoaded && !sessionListError
+  const sessionListBlocked = sessionListLoading || !sessionLinksLoaded || Boolean(sessionListError)
+  const chatActivityPending = checkingChatActivity || activityLoading || sessionListLoading || sessionListPending
   const sortedSessionLinks = useMemo(() => {
     return [...sessionLinks].sort((a, b) => {
       const aActivity = sessionActivities[a.sessionId]
@@ -160,7 +164,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const workingCount = workingLinks.length
   const activeNavigationCount = activeNavigationLinks.length
   const errorCount = sessionLinks.filter((link) => sessionActivities[link.sessionId]?.status === "error").length
-  const rollupText = checkingChatActivity || !sessionLinksLoaded ? "Checking activity" : sessionLinks.length === 0 ? "No linked chats" : activityLabel(rollupActivity, activityLoading)
+  const rollupText = sessionListError ? "Chat links unavailable" : checkingChatActivity || sessionListLoading || sessionListPending ? "Checking activity" : sessionLinks.length === 0 ? "No linked chats" : activityLabel(rollupActivity, activityLoading)
 
   const stopCardAction = (event: MouseEvent<HTMLElement>) => event.stopPropagation()
 
@@ -225,6 +229,8 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     setCheckingChatActivity(false)
     setSessionPanelOpen(false)
     setSessionError(null)
+    setSessionListError(null)
+    setSessionListLoading(false)
     setLinkQuery("")
     setLinkSearchResults([])
     setLinkSearchLoading(false)
@@ -235,16 +241,33 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   }, [invalidatePendingNavigation, invalidatePendingSessionLists, invalidatePendingTaskAsync, taskScopeKey])
 
   const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<TaskSessionActivityRefreshResult> => {
-    return await sessionActivity.refreshSessionIds(links.map((link) => link.sessionId))
+    return await sessionActivity.refreshSessionIds(links.map((link) => link.sessionId), { priority: "action" })
   }, [sessionActivity.refreshSessionIds])
 
-  const loadSessionLinks = useCallback(async (shouldApply: () => boolean = () => mountedRef.current): Promise<BoringTaskSessionBinding[] | null> => {
+  const loadSessionLinks = useCallback(async (
+    shouldApply: () => boolean = () => mountedRef.current,
+    options: { showPanelOnError?: boolean } = {},
+  ): Promise<BoringTaskSessionBinding[] | null> => {
     const shouldApplyList = beginSessionListRequest()
-    const body = await pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
-    const links = body.links ?? []
-    if (!shouldApply() || !shouldApplyList()) return null
-    setSessionLinkState({ taskScopeKey, links, loaded: true })
-    return links
+    setSessionListLoading(true)
+    setSessionListError(null)
+    try {
+      const body = await pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
+      const links = body.links ?? []
+      if (!shouldApply() || !shouldApplyList()) return null
+      setSessionLinkState({ taskScopeKey, links, loaded: true })
+      setSessionListError(null)
+      return links
+    } catch (error) {
+      if (shouldApply() && shouldApplyList()) {
+        setSessionLinkState((current) => current.taskScopeKey === taskScopeKey ? { ...current, loaded: false } : current)
+        setSessionListError(error instanceof Error ? error.message : "Failed to load linked chat sessions")
+        if (options.showPanelOnError) setSessionPanelOpen(true)
+      }
+      return null
+    } finally {
+      if (mountedRef.current && shouldApplyList()) setSessionListLoading(false)
+    }
   }, [beginSessionListRequest, pluginClient, task.adapterId, task.id, taskScopeKey])
 
   useEffect(() => {
@@ -253,14 +276,23 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       ? current
       : { taskScopeKey, links: [], loaded: false })
     const shouldApplyList = beginSessionListRequest()
+    setSessionListLoading(true)
+    setSessionListError(null)
     void pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
       .then((body) => {
         if (cancelled || !shouldApplyList()) return
         const links = body.links ?? []
         setSessionLinkState({ taskScopeKey, links, loaded: true })
+        setSessionListError(null)
       })
-      .catch(() => {
-        if (!cancelled && shouldApplyList()) setSessionLinkState({ taskScopeKey, links: [], loaded: true })
+      .catch((error) => {
+        if (!cancelled && shouldApplyList()) {
+          setSessionLinkState((current) => current.taskScopeKey === taskScopeKey ? { ...current, loaded: false } : current)
+          setSessionListError(error instanceof Error ? error.message : "Failed to load linked chat sessions")
+        }
+      })
+      .finally(() => {
+        if (!cancelled && shouldApplyList()) setSessionListLoading(false)
       })
     return () => { cancelled = true }
   }, [beginSessionListRequest, pluginClient, task.adapterId, task.id, taskScopeKey])
@@ -299,7 +331,16 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     return true
   }
 
-  const createAndLinkChat = async (anchor?: WorkspaceShellAnchorRect, shouldContinue: () => boolean = beginNavigation()) => {
+  const createAndLinkChat = async (
+    anchor?: WorkspaceShellAnchorRect,
+    shouldContinue: () => boolean = beginNavigation(),
+    options: { sessionListResolved?: boolean } = {},
+  ) => {
+    if (!options.sessionListResolved && sessionListBlocked) {
+      setSessionPanelOpen(true)
+      setSessionError("Retry linked chat sessions before starting a new chat.")
+      return
+    }
     setOpeningChat(true)
     setSessionError(null)
     try {
@@ -347,10 +388,10 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     setSessionError(null)
     setCheckingChatActivity(true)
     void (async () => {
-      const links = sessionLinksLoaded ? sessionLinks : await loadSessionLinks(shouldContinue)
+      const links = sessionLinksLoaded ? sessionLinks : await loadSessionLinks(shouldContinue, { showPanelOnError: true })
       if (!shouldContinue() || links === null) return
       if (links.length === 0) {
-        await createAndLinkChat(anchor, shouldContinue)
+        await createAndLinkChat(anchor, shouldContinue, { sessionListResolved: true })
         return
       }
       setSessionPanelOpen(true)
@@ -403,6 +444,11 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
 
   const searchExistingSessions = (event: MouseEvent<HTMLButtonElement>) => {
     stopCardAction(event)
+    if (sessionListBlocked) {
+      setSessionPanelOpen(true)
+      setSessionError("Retry linked chat sessions before linking another chat.")
+      return
+    }
     const shouldApply = beginTaskAsync()
     setLinkSearchLoading(true)
     setSessionError(null)
@@ -420,6 +466,11 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
 
   const linkExistingSession = (event: MouseEvent<HTMLButtonElement>, session: PiSessionSummary) => {
     stopCardAction(event)
+    if (sessionListBlocked) {
+      setSessionPanelOpen(true)
+      setSessionError("Retry linked chat sessions before linking another chat.")
+      return
+    }
     const shouldApply = beginTaskAsync()
     setSessionError(null)
     void pluginClient.postJson<TaskSessionLinkResponse>("/api/boring-tasks/sessions/link", {
@@ -445,10 +496,17 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
 
   const closeSessionPanel = () => {
     invalidatePendingNavigation()
+    invalidatePendingSessionLists()
     setOpeningChat(false)
     setCheckingChatActivity(false)
+    setSessionListLoading(false)
     setSessionPanelOpen(false)
     chatButtonRef.current?.focus()
+  }
+
+  const retrySessionLinks = (event: MouseEvent<HTMLButtonElement>) => {
+    stopCardAction(event)
+    void loadSessionLinks(() => mountedRef.current, { showPanelOnError: true })
   }
 
   const badgeLabel = workingCount > 0
@@ -480,6 +538,12 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
         <button type="button" className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground" aria-label="Close task chats" onClick={closeSessionPanel}><X className="size-3" /></button>
       </div>
       {sessionError ? <p className="mb-2 rounded-lg border border-destructive/30 bg-destructive/10 px-2 py-1 text-destructive" role="alert">{sessionError}</p> : null}
+      {sessionListError ? (
+        <div className="mb-2 flex items-center justify-between gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-2 py-1 text-destructive" role="alert">
+          <span className="inline-flex min-w-0 items-center gap-1"><AlertCircle className="size-3 shrink-0" /> Linked chat sessions failed to load.</span>
+          <button type="button" className="rounded-md px-2 py-0.5 font-medium hover:bg-destructive/15" onClick={retrySessionLinks}>Retry</button>
+        </div>
+      ) : null}
       {activityError ? (
         <div className="mb-2 flex items-center justify-between gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2 py-1 text-amber-700 dark:text-amber-200" role="status">
           <span className="inline-flex min-w-0 items-center gap-1"><AlertCircle className="size-3 shrink-0" /> Activity refresh failed.</span>
@@ -487,6 +551,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
         </div>
       ) : null}
       {activityLoading && sessionLinks.length > 0 ? <p className="mb-2 text-[10px] text-muted-foreground" role="status">Checking chat activity…</p> : null}
+      {sessionListLoading ? <p className="mb-2 text-[10px] text-muted-foreground" role="status">Loading linked chats…</p> : null}
       {sessionLinks.length > 0 ? (
         <ul className="space-y-1">
           {sortedSessionLinks.map((link) => {
@@ -515,21 +580,21 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
             )
           })}
         </ul>
-      ) : <p className="text-muted-foreground">No linked chats yet.</p>}
+      ) : sessionLinksLoaded && !sessionListLoading && !sessionListError ? <p className="text-muted-foreground">No linked chats yet.</p> : null}
       <div className="mt-2 flex flex-wrap items-center gap-2">
-        <button type="button" className="rounded-lg border border-border bg-background px-2 py-1 font-medium hover:bg-muted" disabled={openingChat} onClick={(event) => { stopCardAction(event); void createAndLinkChat(rectFromElement(event.currentTarget)) }}>Start new chat</button>
+        <button type="button" className="rounded-lg border border-border bg-background px-2 py-1 font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50" disabled={openingChat || sessionListBlocked} onClick={(event) => { stopCardAction(event); void createAndLinkChat(rectFromElement(event.currentTarget)) }}>Start new chat</button>
         <label className="flex min-w-0 flex-1 items-center gap-1">
           <span className="sr-only">Search existing chats</span>
-          <input className="min-w-24 flex-1 rounded-lg border border-border bg-background px-2 py-1 text-foreground" value={linkQuery} onChange={(event) => setLinkQuery(event.target.value)} placeholder="Search chats" />
+          <input className="min-w-24 flex-1 rounded-lg border border-border bg-background px-2 py-1 text-foreground disabled:cursor-not-allowed disabled:opacity-50" value={linkQuery} onChange={(event) => setLinkQuery(event.target.value)} placeholder="Search chats" disabled={sessionListBlocked} />
         </label>
-        <button type="button" className="inline-flex items-center gap-1 rounded-lg border border-border bg-background px-2 py-1 font-medium hover:bg-muted" disabled={linkSearchLoading} onClick={searchExistingSessions}><Link2 className="size-3" /> Link existing</button>
+        <button type="button" className="inline-flex items-center gap-1 rounded-lg border border-border bg-background px-2 py-1 font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50" disabled={linkSearchLoading || sessionListBlocked} onClick={searchExistingSessions}><Link2 className="size-3" /> Link existing</button>
       </div>
       {linkSearchResults.length > 0 ? (
         <ul className="mt-2 space-y-1" aria-label="Session search results">
           {linkSearchResults.map((session) => (
             <li key={session.id} className="flex items-center gap-2 rounded-lg bg-background/70 px-2 py-1.5">
               <span className="min-w-0 flex-1 truncate">{session.title ?? session.id}</span>
-              <button type="button" className="rounded-md px-2 py-1 font-medium text-primary hover:bg-primary/10" disabled={sessionLinks.some((link) => link.sessionId === session.id)} onClick={(event) => linkExistingSession(event, session)}>Link</button>
+              <button type="button" className="rounded-md px-2 py-1 font-medium text-primary hover:bg-primary/10 disabled:cursor-not-allowed disabled:opacity-50" disabled={sessionListBlocked || sessionLinks.some((link) => link.sessionId === session.id)} onClick={(event) => linkExistingSession(event, session)}>Link</button>
             </li>
           ))}
         </ul>

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -3,7 +3,7 @@ import { AlertCircle, CircleDot, Link2, MessageSquare, MoreHorizontal, Trash2, X
 import { useWorkspacePluginClient } from "@hachej/boring-workspace"
 import { useWorkspaceShellCapabilities, type WorkspaceShellAnchorRect } from "@hachej/boring-workspace/plugin"
 import type { BoringTaskCard, BoringTaskSessionBinding } from "../shared"
-import { useTaskSessionActivity, type TaskSessionActivity, type TaskSessionActivityStatus } from "./taskSessionActivity"
+import { useTaskSessionActivity, type TaskSessionActivity, type TaskSessionActivityRefreshResult, type TaskSessionActivityStatus } from "./taskSessionActivity"
 
 interface TaskCardProps {
   task: BoringTaskCard
@@ -98,6 +98,7 @@ function newestTimestampMs(link: BoringTaskSessionBinding, activity: TaskSession
 export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = false, compact = false, onDelete, onDragStart, onDragEnd }: TaskCardProps) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [openingChat, setOpeningChat] = useState(false)
+  const [checkingChatActivity, setCheckingChatActivity] = useState(false)
   const [sessionPanelOpen, setSessionPanelOpen] = useState(false)
   const [sessionLinks, setSessionLinks] = useState<BoringTaskSessionBinding[]>([])
   const [sessionLinksLoaded, setSessionLinksLoaded] = useState(false)
@@ -121,6 +122,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const sessionActivities = sessionActivity.activities
   const activityError = sessionActivity.error
   const activityLoading = sessionActivity.isLoading(linkedSessionIdList)
+  const chatActivityPending = checkingChatActivity || activityLoading
   const sortedSessionLinks = useMemo(() => {
     return [...sessionLinks].sort((a, b) => {
       const aActivity = sessionActivities[a.sessionId]
@@ -147,11 +149,11 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const workingCount = workingLinks.length
   const activeNavigationCount = activeNavigationLinks.length
   const errorCount = sessionLinks.filter((link) => sessionActivities[link.sessionId]?.status === "error").length
-  const rollupText = sessionLinks.length === 0 && sessionLinksLoaded ? "No linked chats" : activityLabel(rollupActivity, activityLoading)
+  const rollupText = checkingChatActivity ? "Checking activity" : sessionLinks.length === 0 && sessionLinksLoaded ? "No linked chats" : activityLabel(rollupActivity, activityLoading)
 
   const stopCardAction = (event: MouseEvent<HTMLElement>) => event.stopPropagation()
 
-  const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<Record<string, TaskSessionActivity>> => {
+  const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<TaskSessionActivityRefreshResult> => {
     return await sessionActivity.refreshSessionIds(links.map((link) => link.sessionId))
   }, [sessionActivity.refreshSessionIds])
 
@@ -195,19 +197,20 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     return () => window.removeEventListener("boring:chat-session-status", onSessionStatus)
   }, [linkedSessionIds, optimisticSessionIds, sessionActivity.setOptimisticActivity])
 
-  const openLinkedChat = async (link: BoringTaskSessionBinding, anchor?: WorkspaceShellAnchorRect) => {
+  const openLinkedChat = async (link: BoringTaskSessionBinding, anchor?: WorkspaceShellAnchorRect): Promise<boolean> => {
     const sessions = await pluginClient.getJson<PiSessionSummary[]>(`/api/v1/agent/pi-chat/sessions?limit=1&activeSessionId=${encodeURIComponent(link.sessionId)}`)
     const session = sessions.find((candidate) => candidate.id === link.sessionId)
     if (!session) {
       setSessionPanelOpen(true)
       setSessionError("That linked chat session is no longer available. You can unlink it or link another session.")
-      return
+      return false
     }
     const title = session.title ?? link.title ?? chatTitle
     setOptimisticSessionIds((current) => new Set(current).add(link.sessionId))
     shell.openDetachedChat(link.sessionId, { anchor, title, composingEnabled: true })
     window.dispatchEvent(new CustomEvent("boring-workspace:open-detached-chat", { detail: { sessionId: link.sessionId, title, composingEnabled: true } }))
     void refreshSessionActivity([link]).catch(() => undefined)
+    return true
   }
 
   const createAndLinkChat = async (anchor?: WorkspaceShellAnchorRect) => {
@@ -248,25 +251,41 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
 
   const openTaskChat = (event: MouseEvent<HTMLButtonElement>) => {
     stopCardAction(event)
+    if (checkingChatActivity) return
     const anchor = rectFromElement(event.currentTarget)
+    const panelWasOpen = sessionPanelOpen
     setSessionError(null)
+    setCheckingChatActivity(true)
     void (async () => {
       const links = sessionLinksLoaded ? sessionLinks : await loadSessionLinks()
       if (links.length === 0) {
         await createAndLinkChat(anchor)
         return
       }
-      const activity = await refreshSessionActivity(links).catch(() => sessionActivities)
+      setSessionPanelOpen(true)
+      let refreshResult: TaskSessionActivityRefreshResult
+      try {
+        refreshResult = await refreshSessionActivity(links)
+      } catch (error) {
+        setSessionError(error instanceof Error ? error.message : "Activity refresh failed")
+        return
+      }
+      if (refreshResult.status === "stale") {
+        setSessionError("Chat activity changed while opening. Try again.")
+        return
+      }
       const active = links.filter((link) => {
-        const status = activity[link.sessionId]?.status
+        const status = refreshResult.activities[link.sessionId]?.status
         return status === "working" || status === "queued"
       })
       if (active.length === 1) {
-        await openLinkedChat(active[0], anchor)
+        const opened = await openLinkedChat(active[0], anchor)
+        if (opened && !panelWasOpen) setSessionPanelOpen(false)
         return
       }
-      setSessionPanelOpen((current) => active.length > 1 ? true : !current)
+      setSessionPanelOpen(true)
     })().catch((error) => setSessionError(error instanceof Error ? error.message : "Failed to open task chat"))
+      .finally(() => setCheckingChatActivity(false))
   }
 
   const unlinkSession = (event: MouseEvent<HTMLButtonElement>, link: BoringTaskSessionBinding) => {
@@ -336,9 +355,9 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       ? "bg-destructive text-destructive-foreground"
       : "bg-primary text-primary-foreground"
   const chatButton = (
-    <button ref={chatButtonRef} type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}. ${rollupText}${workingCount > 0 ? `, ${workingCount} working` : errorCount > 0 ? `, ${errorCount} need attention` : ""}.`} title={activeNavigationCount === 1 ? "Open active task chat" : "Open task chats"} disabled={openingChat} aria-expanded={sessionPanelOpen}>
-      <MessageSquare className={["size-3.5", openingChat ? "motion-safe:animate-pulse" : ""].join(" ")} strokeWidth={1.75} />
-      {activeNavigationCount > 0 ? <CircleDot className="absolute -bottom-0.5 -right-0.5 size-2.5 text-emerald-500 motion-safe:animate-pulse" aria-hidden="true" /> : errorCount > 0 ? <AlertCircle className="absolute -bottom-0.5 -right-0.5 size-2.5 text-destructive" aria-hidden="true" /> : null}
+    <button ref={chatButtonRef} type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}. ${rollupText}${workingCount > 0 ? `, ${workingCount} working` : errorCount > 0 ? `, ${errorCount} need attention` : ""}.`} title={activeNavigationCount === 1 ? "Open active task chat" : "Open task chats"} disabled={openingChat} aria-expanded={sessionPanelOpen} aria-busy={chatActivityPending || undefined}>
+      <MessageSquare className={["size-3.5", openingChat || checkingChatActivity ? "motion-safe:animate-pulse" : ""].join(" ")} strokeWidth={1.75} />
+      {checkingChatActivity ? <CircleDot className="absolute -bottom-0.5 -right-0.5 size-2.5 text-primary motion-safe:animate-pulse" aria-hidden="true" /> : activeNavigationCount > 0 ? <CircleDot className="absolute -bottom-0.5 -right-0.5 size-2.5 text-emerald-500 motion-safe:animate-pulse" aria-hidden="true" /> : errorCount > 0 ? <AlertCircle className="absolute -bottom-0.5 -right-0.5 size-2.5 text-destructive" aria-hidden="true" /> : null}
       {sessionLinks.length > 0 ? <span className={["absolute -right-1 -top-1 grid min-w-4 place-items-center rounded-full px-1 text-[9px] font-bold leading-4", badgeClass].join(" ")} aria-label={badgeLabel}>{badgeText}</span> : null}
       <span className="sr-only" aria-live="polite">Task chat activity: {rollupText}</span>
     </button>

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -3,6 +3,7 @@ import { AlertCircle, CircleDot, Link2, MessageSquare, MoreHorizontal, Trash2, X
 import { useWorkspacePluginClient } from "@hachej/boring-workspace"
 import { useWorkspaceShellCapabilities, type WorkspaceShellAnchorRect } from "@hachej/boring-workspace/plugin"
 import type { BoringTaskCard, BoringTaskSessionBinding } from "../shared"
+import { useTaskSessionActivity, type TaskSessionActivity, type TaskSessionActivityStatus } from "./taskSessionActivity"
 
 interface TaskCardProps {
   task: BoringTaskCard
@@ -34,24 +35,6 @@ interface TaskSessionListResponse { links?: BoringTaskSessionBinding[] }
 interface TaskSessionLinkResponse { link?: BoringTaskSessionBinding }
 interface PiSessionSummary { id: string; title?: string; updatedAt?: string; createdAt?: string }
 interface ManageSessionsSearchResponse { action?: string; sessions?: PiSessionSummary[] }
-
-type TaskSessionActivityStatus = "idle" | "queued" | "working" | "error" | "missing"
-interface TaskSessionActivity { status: TaskSessionActivityStatus; source?: "live-runtime" | "persisted"; updatedAt?: string }
-interface SessionActivityResponse {
-  activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted"; updatedAt?: string }>
-  omittedSessionIds?: string[]
-}
-
-const TASK_SESSION_ACTIVITY_POLL_MS = 15_000
-const TASK_SESSION_ACTIVITY_MAX_IDS = 100
-
-function chunkSessionIds(sessionIds: string[]): string[][] {
-  const chunks: string[][] = []
-  for (let index = 0; index < sessionIds.length; index += TASK_SESSION_ACTIVITY_MAX_IDS) {
-    chunks.push(sessionIds.slice(index, index + TASK_SESSION_ACTIVITY_MAX_IDS))
-  }
-  return chunks
-}
 
 function taskDisplayRef(task: BoringTaskCard): string {
   return task.number || task.id
@@ -115,18 +98,22 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
   const [linkQuery, setLinkQuery] = useState("")
   const [linkSearchResults, setLinkSearchResults] = useState<PiSessionSummary[]>([])
   const [linkSearchLoading, setLinkSearchLoading] = useState(false)
-  const [sessionActivities, setSessionActivities] = useState<Record<string, TaskSessionActivity>>({})
-  const [activityLoading, setActivityLoading] = useState(false)
-  const [activityError, setActivityError] = useState<string | null>(null)
+  const [optimisticSessionIds, setOptimisticSessionIds] = useState<ReadonlySet<string>>(new Set())
   const chatButtonRef = useRef<HTMLButtonElement>(null)
   const shell = useWorkspaceShellCapabilities()
   const pluginClient = useWorkspacePluginClient()
+  const sessionActivity = useTaskSessionActivity()
   const tags = task.tags?.slice(0, 4) ?? []
   const hiddenTagCount = Math.max((task.tags?.length ?? 0) - tags.length, 0)
   const pullRequests = task.pullRequests?.slice(0, 2) ?? []
   const hiddenPullRequestCount = Math.max((task.pullRequests?.length ?? 0) - pullRequests.length, 0)
   const chatTitle = taskChatTitle(task)
-  const linkedSessionIds = useMemo(() => new Set(sessionLinks.map((link) => link.sessionId)), [sessionLinks])
+  const linkedSessionIdList = useMemo(() => [...new Set(sessionLinks.map((link) => link.sessionId))], [sessionLinks])
+  const linkedSessionIdKey = linkedSessionIdList.join("\u0000")
+  const linkedSessionIds = useMemo(() => new Set(linkedSessionIdList), [linkedSessionIdKey])
+  const sessionActivities = sessionActivity.activities
+  const activityError = sessionActivity.error
+  const activityLoading = sessionActivity.isLoading(linkedSessionIdList)
   const sortedSessionLinks = useMemo(() => {
     return [...sessionLinks].sort((a, b) => {
       const aActivity = sessionActivities[a.sessionId]
@@ -136,60 +123,37 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       return newestTimestampMs(b, bActivity) - newestTimestampMs(a, aActivity)
     })
   }, [sessionActivities, sessionLinks])
-  const rollupStatus = useMemo<TaskSessionActivityStatus>(() => sortedSessionLinks.reduce<TaskSessionActivityStatus>((status, link) => {
-    const candidate = sessionActivities[link.sessionId]?.status ?? "idle"
-    return activityRank(candidate) > activityRank(status) ? candidate : status
-  }, "idle"), [sessionActivities, sortedSessionLinks])
+  const rollupActivity = useMemo<TaskSessionActivity | undefined>(() => {
+    if (sessionLinks.length === 0) return undefined
+    const knownActivities = sessionLinks.map((link) => sessionActivities[link.sessionId]).filter((activity): activity is TaskSessionActivity => Boolean(activity))
+    if (knownActivities.length === 0) return undefined
+    if (knownActivities.length === sessionLinks.length && knownActivities.every((activity) => activity.status === "missing")) return { status: "missing" }
+    return knownActivities.reduce<TaskSessionActivity>((best, candidate) => activityRank(candidate.status) > activityRank(best.status) ? candidate : best, { status: "missing" })
+  }, [sessionActivities, sessionLinks])
+  const rollupStatus = rollupActivity?.status
   const workingLinks = useMemo(() => sessionLinks.filter((link) => sessionActivities[link.sessionId]?.status === "working"), [sessionActivities, sessionLinks])
-  const workingCount = workingLinks.length
-  const activeCount = sessionLinks.filter((link) => {
+  const activeNavigationLinks = useMemo(() => sessionLinks.filter((link) => {
     const status = sessionActivities[link.sessionId]?.status
-    return status === "working" || status === "queued" || status === "error"
-  }).length
-  const rollupText = activityLabel({ status: rollupStatus }, activityLoading)
+    return status === "working" || status === "queued"
+  }), [sessionActivities, sessionLinks])
+  const workingCount = workingLinks.length
+  const activeNavigationCount = activeNavigationLinks.length
+  const errorCount = sessionLinks.filter((link) => sessionActivities[link.sessionId]?.status === "error").length
+  const rollupText = sessionLinks.length === 0 && sessionLinksLoaded ? "No linked chats" : activityLabel(rollupActivity, activityLoading)
 
   const stopCardAction = (event: MouseEvent<HTMLElement>) => event.stopPropagation()
 
   const refreshSessionActivity = useCallback(async (links: BoringTaskSessionBinding[]): Promise<Record<string, TaskSessionActivity>> => {
-    const sessionIds = [...new Set(links.map((link) => link.sessionId))]
-    if (sessionIds.length === 0) {
-      setSessionActivities({})
-      setActivityError(null)
-      return {}
-    }
-    setActivityLoading(true)
-    try {
-      const next: Record<string, TaskSessionActivity> = {}
-      // The activity contract deliberately caps each call at 100 IDs. Read every
-      // bound session in bounded chunks so an active late binding cannot be
-      // silently shown as idle or sorted below it.
-      for (const chunk of chunkSessionIds(sessionIds)) {
-        const body = await pluginClient.postJson<SessionActivityResponse>("/api/v1/agent/pi-chat/sessions/activity", { sessionIds: chunk })
-        for (const entry of body.activities ?? []) {
-          next[entry.sessionId] = { status: entry.status, source: entry.source, updatedAt: entry.updatedAt }
-        }
-        for (const sessionId of body.omittedSessionIds ?? []) next[sessionId] = { status: "missing" }
-        for (const sessionId of chunk) next[sessionId] ??= { status: "missing" }
-      }
-      setSessionActivities(next)
-      setActivityError(null)
-      return next
-    } catch (error) {
-      setActivityError(error instanceof Error ? error.message : "Failed to load chat activity")
-      throw error
-    } finally {
-      setActivityLoading(false)
-    }
-  }, [pluginClient])
+    return await sessionActivity.refreshSessionIds(links.map((link) => link.sessionId))
+  }, [sessionActivity.refreshSessionIds])
 
   const loadSessionLinks = useCallback(async (): Promise<BoringTaskSessionBinding[]> => {
     const body = await pluginClient.postJson<TaskSessionListResponse>("/api/boring-tasks/sessions/list", { adapterId: task.adapterId, taskId: task.id })
     const links = body.links ?? []
     setSessionLinks(links)
     setSessionLinksLoaded(true)
-    if (links.length > 0) void refreshSessionActivity(links).catch(() => undefined)
     return links
-  }, [pluginClient, refreshSessionActivity, task.adapterId, task.id])
+  }, [pluginClient, task.adapterId, task.id])
 
   useEffect(() => {
     let cancelled = false
@@ -199,34 +163,29 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
         const links = body.links ?? []
         setSessionLinks(links)
         setSessionLinksLoaded(true)
-        if (links.length > 0) void refreshSessionActivity(links).catch(() => undefined)
       })
       .catch(() => {
         if (!cancelled) setSessionLinksLoaded(true)
       })
     return () => { cancelled = true }
-  }, [pluginClient, refreshSessionActivity, task.adapterId, task.id])
+  }, [pluginClient, task.adapterId, task.id])
 
   useEffect(() => {
-    if (!sessionLinksLoaded || sessionLinks.length === 0) return
-    const interval = window.setInterval(() => { void refreshSessionActivity(sessionLinks).catch(() => undefined) }, TASK_SESSION_ACTIVITY_POLL_MS)
-    return () => window.clearInterval(interval)
-  }, [refreshSessionActivity, sessionLinks, sessionLinksLoaded])
+    if (!sessionLinksLoaded || linkedSessionIdList.length === 0) return
+    return sessionActivity.registerSessionIds(linkedSessionIdList)
+  }, [linkedSessionIdKey, sessionActivity.registerSessionIds, sessionLinksLoaded])
 
   useEffect(() => {
     if (typeof window === "undefined") return
     const onSessionStatus = (event: Event) => {
       const detail = (event as CustomEvent<{ sessionId?: unknown; working?: unknown }>).detail
       const sessionId = typeof detail?.sessionId === "string" ? detail.sessionId : null
-      if (!sessionId || !linkedSessionIds.has(sessionId)) return
-      setSessionActivities((current) => ({
-        ...current,
-        [sessionId]: { status: detail.working ? "working" : "idle", source: "live-runtime", updatedAt: new Date().toISOString() },
-      }))
+      if (!sessionId || !linkedSessionIds.has(sessionId) || !optimisticSessionIds.has(sessionId)) return
+      sessionActivity.setOptimisticActivity(sessionId, { status: detail.working ? "working" : "idle", source: "live-runtime", updatedAt: new Date().toISOString() })
     }
     window.addEventListener("boring:chat-session-status", onSessionStatus)
     return () => window.removeEventListener("boring:chat-session-status", onSessionStatus)
-  }, [linkedSessionIds])
+  }, [linkedSessionIds, optimisticSessionIds, sessionActivity.setOptimisticActivity])
 
   const openLinkedChat = async (link: BoringTaskSessionBinding, anchor?: WorkspaceShellAnchorRect) => {
     const sessions = await pluginClient.getJson<PiSessionSummary[]>(`/api/v1/agent/pi-chat/sessions?limit=1&activeSessionId=${encodeURIComponent(link.sessionId)}`)
@@ -237,6 +196,7 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
       return
     }
     const title = session.title ?? link.title ?? chatTitle
+    setOptimisticSessionIds((current) => new Set(current).add(link.sessionId))
     shell.openDetachedChat(link.sessionId, { anchor, title, composingEnabled: true })
     window.dispatchEvent(new CustomEvent("boring-workspace:open-detached-chat", { detail: { sessionId: link.sessionId, title, composingEnabled: true } }))
     void refreshSessionActivity([link]).catch(() => undefined)
@@ -248,27 +208,29 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     try {
       const session = await pluginClient.postJson<CreatedPiChatSession>("/api/v1/agent/pi-chat/sessions", { title: chatTitle })
       if (typeof session.id !== "string" || session.id.length === 0) throw new Error("Chat session was not created.")
+      const sessionId = session.id
       let linked: BoringTaskSessionBinding
       try {
         const response = await pluginClient.postJson<TaskSessionLinkResponse>("/api/boring-tasks/sessions/link", {
           adapterId: task.adapterId,
           taskId: task.id,
-          sessionId: session.id,
+          sessionId,
           title: chatTitle,
         })
         if (!response.link) throw new Error("Task session binding was not created.")
         linked = response.link
       } catch (error) {
         setSessionPanelOpen(true)
-        setSessionError(`Created chat ${session.id}, but failed to bind it to this task. Use Link existing to attach it before opening. ${error instanceof Error ? error.message : ""}`.trim())
+        setSessionError(`Created chat ${sessionId}, but failed to bind it to this task. Use Link existing to attach it before opening. ${error instanceof Error ? error.message : ""}`.trim())
         return
       }
       setSessionLinks((current) => current.some((candidate) => candidate.id === linked.id) ? current : [linked, ...current])
       setSessionLinksLoaded(true)
       void refreshSessionActivity([linked]).catch(() => undefined)
       const initialDraft = taskChatDraft(task)
-      shell.openDetachedChat(session.id, { anchor, title: chatTitle, initialDraft, composingEnabled: true })
-      window.dispatchEvent(new CustomEvent("boring-workspace:open-detached-chat", { detail: { sessionId: session.id, title: chatTitle, initialDraft, composingEnabled: true } }))
+      setOptimisticSessionIds((current) => new Set(current).add(sessionId))
+      shell.openDetachedChat(sessionId, { anchor, title: chatTitle, initialDraft, composingEnabled: true })
+      window.dispatchEvent(new CustomEvent("boring-workspace:open-detached-chat", { detail: { sessionId, title: chatTitle, initialDraft, composingEnabled: true } }))
     } catch (error) {
       setSessionError(error instanceof Error ? error.message : "Failed to open task chat")
     } finally {
@@ -287,12 +249,15 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
         return
       }
       const activity = await refreshSessionActivity(links).catch(() => sessionActivities)
-      const working = links.filter((link) => activity[link.sessionId]?.status === "working")
-      if (working.length === 1) {
-        await openLinkedChat(working[0], anchor)
+      const active = links.filter((link) => {
+        const status = activity[link.sessionId]?.status
+        return status === "working" || status === "queued"
+      })
+      if (active.length === 1) {
+        await openLinkedChat(active[0], anchor)
         return
       }
-      setSessionPanelOpen((current) => working.length > 1 ? true : !current)
+      setSessionPanelOpen((current) => active.length > 1 ? true : !current)
     })().catch((error) => setSessionError(error instanceof Error ? error.message : "Failed to open task chat"))
   }
 
@@ -300,11 +265,12 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     stopCardAction(event)
     setSessionError(null)
     setSessionLinks((current) => current.filter((candidate) => candidate.id !== link.id))
-    setSessionActivities((current) => {
-      const next = { ...current }
-      delete next[link.sessionId]
+    setOptimisticSessionIds((current) => {
+      const next = new Set(current)
+      next.delete(link.sessionId)
       return next
     })
+    sessionActivity.clearSessionActivity(link.sessionId)
     void pluginClient.postJson("/api/boring-tasks/sessions/unlink", { bindingId: link.id })
       .catch((error) => {
         setSessionLinks((current) => current.some((candidate) => candidate.id === link.id) ? current : [link, ...current])
@@ -349,11 +315,24 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     chatButtonRef.current?.focus()
   }
 
+  const badgeLabel = workingCount > 0
+    ? `${workingCount} working linked chats`
+    : activeNavigationCount > 0
+      ? `${activeNavigationCount} active linked chats`
+      : errorCount > 0
+        ? `${errorCount} linked chats need attention`
+        : `${sessionLinks.length} linked chats`
+  const badgeText = workingCount > 0 ? workingCount : activeNavigationCount > 0 ? activeNavigationCount : errorCount > 0 ? errorCount : sessionLinks.length
+  const badgeClass = workingCount > 0 || activeNavigationCount > 0
+    ? "bg-emerald-500 text-white"
+    : errorCount > 0
+      ? "bg-destructive text-destructive-foreground"
+      : "bg-primary text-primary-foreground"
   const chatButton = (
-    <button ref={chatButtonRef} type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}. ${rollupText}${workingCount > 0 ? `, ${workingCount} working` : ""}.`} title={workingCount === 1 ? "Open working task chat" : "Open task chats"} disabled={openingChat} aria-expanded={sessionPanelOpen}>
+    <button ref={chatButtonRef} type="button" draggable={false} onClick={openTaskChat} className="relative grid size-7 place-items-center rounded-lg text-muted-foreground opacity-80 hover:bg-muted hover:text-foreground group-hover:opacity-100" aria-label={`Open chat for ${taskDisplayRef(task)}. ${rollupText}${workingCount > 0 ? `, ${workingCount} working` : errorCount > 0 ? `, ${errorCount} need attention` : ""}.`} title={activeNavigationCount === 1 ? "Open active task chat" : "Open task chats"} disabled={openingChat} aria-expanded={sessionPanelOpen}>
       <MessageSquare className={["size-3.5", openingChat ? "motion-safe:animate-pulse" : ""].join(" ")} strokeWidth={1.75} />
-      {activeCount > 0 ? <CircleDot className="absolute -bottom-0.5 -right-0.5 size-2.5 text-emerald-500 motion-safe:animate-pulse" aria-hidden="true" /> : null}
-      {sessionLinks.length > 0 ? <span className={["absolute -right-1 -top-1 grid min-w-4 place-items-center rounded-full px-1 text-[9px] font-bold leading-4", workingCount > 0 ? "bg-emerald-500 text-white" : "bg-primary text-primary-foreground"].join(" ")} aria-label={workingCount > 0 ? `${workingCount} working linked chats` : `${sessionLinks.length} linked chats`}>{workingCount > 0 ? workingCount : sessionLinks.length}</span> : null}
+      {activeNavigationCount > 0 ? <CircleDot className="absolute -bottom-0.5 -right-0.5 size-2.5 text-emerald-500 motion-safe:animate-pulse" aria-hidden="true" /> : errorCount > 0 ? <AlertCircle className="absolute -bottom-0.5 -right-0.5 size-2.5 text-destructive" aria-hidden="true" /> : null}
+      {sessionLinks.length > 0 ? <span className={["absolute -right-1 -top-1 grid min-w-4 place-items-center rounded-full px-1 text-[9px] font-bold leading-4", badgeClass].join(" ")} aria-label={badgeLabel}>{badgeText}</span> : null}
       <span className="sr-only" aria-live="polite">Task chat activity: {rollupText}</span>
     </button>
   )
@@ -378,14 +357,17 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
             const activity = sessionActivities[link.sessionId]
             const statusText = activityLabel(activity, activityLoading)
             const isWorking = activity?.status === "working"
+            const isQueued = activity?.status === "queued"
+            const isError = activity?.status === "error"
+            const statusClass = isWorking || isQueued ? "text-emerald-600 dark:text-emerald-300" : isError ? "text-destructive" : ""
             return (
               <li key={link.id} className="flex items-center gap-2 rounded-lg bg-background/70 px-2 py-1.5">
                 <div className="min-w-0 flex-1">
                   <div className="truncate font-medium text-foreground">{link.title ?? link.sessionId}</div>
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[10px] text-muted-foreground">
                     <span>{relativeTime(activity?.updatedAt ?? link.createdAt)}</span>
-                    <span className={["inline-flex items-center gap-1 font-medium", isWorking ? "text-emerald-600 dark:text-emerald-300" : activity?.status === "error" ? "text-destructive" : ""].join(" ")}>
-                      <CircleDot className={["size-2", isWorking ? "motion-safe:animate-pulse" : ""].join(" ")} aria-hidden="true" />
+                    <span className={["inline-flex items-center gap-1 font-medium", statusClass].join(" ")}>
+                      {isError ? <AlertCircle className="size-2.5" aria-hidden="true" /> : <CircleDot className={["size-2", isWorking || isQueued ? "motion-safe:animate-pulse" : ""].join(" ")} aria-hidden="true" />}
                       {statusText}
                     </span>
                     {activity?.source === "persisted" ? <span>persisted</span> : null}

--- a/plugins/tasks/src/front/TaskCard.tsx
+++ b/plugins/tasks/src/front/TaskCard.tsx
@@ -70,7 +70,8 @@ function activityRank(status: TaskSessionActivityStatus): number {
   if (status === "working") return 4
   if (status === "queued") return 3
   if (status === "error") return 2
-  return 1
+  if (status === "idle") return 1
+  return 0
 }
 
 function activityLabel(activity: TaskSessionActivity | undefined, loading: boolean): string {
@@ -127,8 +128,9 @@ export function TaskCard({ task, draggable, unmapped = false, deleteEnabled = fa
     if (sessionLinks.length === 0) return undefined
     const knownActivities = sessionLinks.map((link) => sessionActivities[link.sessionId]).filter((activity): activity is TaskSessionActivity => Boolean(activity))
     if (knownActivities.length === 0) return undefined
-    if (knownActivities.length === sessionLinks.length && knownActivities.every((activity) => activity.status === "missing")) return { status: "missing" }
-    return knownActivities.reduce<TaskSessionActivity>((best, candidate) => activityRank(candidate.status) > activityRank(best.status) ? candidate : best, { status: "missing" })
+    const nonMissingActivities = knownActivities.filter((activity) => activity.status !== "missing")
+    if (nonMissingActivities.length === 0) return knownActivities.length === sessionLinks.length ? { status: "missing" } : undefined
+    return nonMissingActivities.slice(1).reduce<TaskSessionActivity>((best, candidate) => activityRank(candidate.status) > activityRank(best.status) ? candidate : best, nonMissingActivities[0])
   }, [sessionActivities, sessionLinks])
   const rollupStatus = rollupActivity?.status
   const workingLinks = useMemo(() => sessionLinks.filter((link) => sessionActivities[link.sessionId]?.status === "working"), [sessionActivities, sessionLinks])

--- a/plugins/tasks/src/front/TaskKanbanBoard.test.tsx
+++ b/plugins/tasks/src/front/TaskKanbanBoard.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { act, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { BoringTaskAdapter } from "../shared"
+import { TaskKanbanBoard } from "./TaskKanbanBoard"
+
+const postJson = vi.fn()
+const getJson = vi.fn()
+const openDetachedChat = vi.fn()
+const pluginClient = { postJson, getJson }
+
+vi.mock("@hachej/boring-workspace", () => ({
+  useWorkspacePluginClient: () => pluginClient,
+}))
+
+vi.mock("@hachej/boring-workspace/plugin", () => ({
+  useWorkspaceShellCapabilities: () => ({ openArtifact: vi.fn(), openDetachedChat }),
+}))
+
+function adapter(): BoringTaskAdapter {
+  return {
+    id: "github",
+    label: "GitHub",
+    capabilities: { move: false, delete: false },
+    getBoardConfig: async () => ({ adapterId: "github", columns: [{ id: "ready", title: "Ready" }] }),
+    listTasks: async () => [
+      { id: "task-a", number: "#1", title: "Task A", statusId: "ready", adapterId: "github" },
+      { id: "task-b", number: "#2", title: "Task B", statusId: "ready", adapterId: "github" },
+    ],
+  }
+}
+
+beforeEach(() => {
+  postJson.mockReset()
+  getJson.mockReset()
+  openDetachedChat.mockReset()
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("TaskKanbanBoard task session activity", () => {
+  it("pools card activity polling into one board-level request and does not overlap intervals", async () => {
+    vi.useFakeTimers()
+    const activityRequests: string[][] = []
+    let resolveActivity: ((value: unknown) => void) | undefined
+    postJson.mockImplementation((path: string, body: { taskId?: string; sessionIds?: string[] }) => {
+      if (path === "/api/boring-tasks/sessions/list") {
+        return Promise.resolve({
+          links: [{
+            id: `link-${body.taskId}`,
+            workspaceId: "workspace-a",
+            adapterId: "github",
+            taskId: body.taskId,
+            sessionId: body.taskId === "task-a" ? "pi-a" : "pi-b",
+            title: body.taskId === "task-a" ? "Chat A" : "Chat B",
+            createdAt: "2026-07-01T00:00:00.000Z",
+          }],
+        })
+      }
+      if (path === "/api/v1/agent/pi-chat/sessions/activity") {
+        activityRequests.push(body.sessionIds ?? [])
+        return new Promise((resolve) => { resolveActivity = resolve })
+      }
+      return Promise.reject(new Error(`unexpected post ${path}`))
+    })
+
+    const view = render(<TaskKanbanBoard adapters={[adapter()]} />)
+    for (let index = 0; index < 5; index += 1) {
+      await act(async () => { await Promise.resolve() })
+    }
+    expect(screen.getByText("Task A")).toBeInTheDocument()
+    expect(screen.getByText("Task B")).toBeInTheDocument()
+    expect(postJson.mock.calls.filter(([path]) => path === "/api/boring-tasks/sessions/list")).toHaveLength(2)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(25) })
+    expect(activityRequests).toEqual([["pi-a", "pi-b"]])
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(60_000) })
+    expect(activityRequests).toHaveLength(1)
+
+    view.unmount()
+    resolveActivity?.({ activities: [{ sessionId: "pi-a", status: "working", source: "live-runtime" }], omittedSessionIds: [] })
+    await act(async () => { await Promise.resolve(); await vi.advanceTimersByTimeAsync(60_000) })
+    expect(activityRequests).toHaveLength(1)
+  })
+})

--- a/plugins/tasks/src/front/TaskKanbanBoard.tsx
+++ b/plugins/tasks/src/front/TaskKanbanBoard.tsx
@@ -4,6 +4,7 @@ import type { BoringTaskAdapter, BoringTaskBoardConfig, BoringTaskCard, BoringTa
 import { groupTasksByColumn } from "./taskBoardModel"
 import { TaskCard } from "./TaskCard"
 import { TaskKanbanColumn } from "./TaskKanbanColumn"
+import { TaskSessionActivityProvider } from "./taskSessionActivity"
 
 interface TaskKanbanBoardProps {
   adapters: readonly BoringTaskAdapter[]
@@ -352,7 +353,8 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
   const totalCount = allColumns.length
 
   return (
-    <div className="flex h-full min-h-0 flex-col gap-3 p-3">
+    <TaskSessionActivityProvider>
+      <div className="flex h-full min-h-0 flex-col gap-3 p-3">
       <div ref={toolbarRef} className="flex flex-wrap items-center gap-2 rounded-xl border border-border bg-card/70 p-2 shadow-sm">
         <div className="relative">
           <button
@@ -546,6 +548,7 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
           </div>
         )}
       </div>
-    </div>
+      </div>
+    </TaskSessionActivityProvider>
   )
 }

--- a/plugins/tasks/src/front/taskSessionActivity.test.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.test.tsx
@@ -36,6 +36,7 @@ function Probe() {
   return (
     <div>
       <button type="button" onClick={() => { void activity.refreshSessionIds(["board-a"]) }}>Refresh A</button>
+      <button type="button" onClick={() => activity.setOptimisticActivity("board-a", { status: "working", source: "live-runtime" })}>Optimistic A working</button>
       <span data-testid="activity-a">{activity.activities["board-a"]?.status ?? "none"}</span>
       <span data-testid="activity-b">{activity.activities["board-b"]?.status ?? "none"}</span>
     </div>
@@ -92,5 +93,39 @@ describe("TaskSessionActivityProvider request scoping", () => {
 
     expect(screen.getByTestId("activity-a")).toHaveTextContent("idle")
     expect(screen.getByTestId("activity-b")).toHaveTextContent("working")
+  })
+
+  it("lets an in-flight authoritative poll reconcile after an optimistic browser update", async () => {
+    const pending: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<ActivityResponse>> }> = []
+    postJson.mockImplementation((path: string, body: { sessionIds?: string[] }) => {
+      if (path !== "/api/v1/agent/pi-chat/sessions/activity") throw new Error(`unexpected post ${path}`)
+      const request = deferred<ActivityResponse>()
+      pending.push({ sessionIds: body.sessionIds ?? [], request })
+      return request.promise
+    })
+
+    render(<TaskSessionActivityProvider><Probe /></TaskSessionActivityProvider>)
+
+    await act(async () => { await Promise.resolve() })
+    await act(async () => { await vi.advanceTimersByTimeAsync(25) })
+    expect(pending.map((entry) => entry.sessionIds)).toEqual([["board-a", "board-b"]])
+
+    fireEvent.click(screen.getByRole("button", { name: "Optimistic A working" }))
+    expect(screen.getByTestId("activity-a")).toHaveTextContent("working")
+
+    await act(async () => {
+      pending[0].request.resolve({
+        activities: [
+          { sessionId: "board-a", status: "idle", source: "persisted" },
+          { sessionId: "board-b", status: "queued", source: "live-runtime" },
+        ],
+        omittedSessionIds: [],
+      })
+      await pending[0].request.promise
+      await Promise.resolve()
+    })
+
+    expect(screen.getByTestId("activity-a")).toHaveTextContent("idle")
+    expect(screen.getByTestId("activity-b")).toHaveTextContent("queued")
   })
 })

--- a/plugins/tasks/src/front/taskSessionActivity.test.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { act, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { TaskSessionActivityProvider, useTaskSessionActivity } from "./taskSessionActivity"
@@ -43,6 +43,21 @@ function Probe() {
   )
 }
 
+function ResultProbe() {
+  const activity = useTaskSessionActivity()
+  const [slowStatus, setSlowStatus] = useState("none")
+  const [fastStatus, setFastStatus] = useState("none")
+
+  return (
+    <div>
+      <button type="button" onClick={() => { void activity.refreshSessionIds(["board-a"]).then((result) => setSlowStatus(result.status)) }}>Slow refresh</button>
+      <button type="button" onClick={() => { void activity.refreshSessionIds(["board-a"]).then((result) => setFastStatus(result.status)) }}>Fast refresh</button>
+      <span data-testid="slow-status">{slowStatus}</span>
+      <span data-testid="fast-status">{fastStatus}</span>
+    </div>
+  )
+}
+
 beforeEach(() => {
   vi.useFakeTimers()
   postJson.mockReset()
@@ -53,6 +68,35 @@ afterEach(() => {
 })
 
 describe("TaskSessionActivityProvider request scoping", () => {
+  it("returns an explicit stale result when a refresh is superseded", async () => {
+    const pending: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<ActivityResponse>> }> = []
+    postJson.mockImplementation((path: string, body: { sessionIds?: string[] }) => {
+      if (path !== "/api/v1/agent/pi-chat/sessions/activity") throw new Error(`unexpected post ${path}`)
+      const request = deferred<ActivityResponse>()
+      pending.push({ sessionIds: body.sessionIds ?? [], request })
+      return request.promise
+    })
+
+    render(<TaskSessionActivityProvider><ResultProbe /></TaskSessionActivityProvider>)
+    fireEvent.click(screen.getByRole("button", { name: "Slow refresh" }))
+    fireEvent.click(screen.getByRole("button", { name: "Fast refresh" }))
+    expect(pending.map((entry) => entry.sessionIds)).toEqual([["board-a"], ["board-a"]])
+
+    await act(async () => {
+      pending[0].request.resolve({ activities: [{ sessionId: "board-a", status: "working", source: "live-runtime" }], omittedSessionIds: [] })
+      await pending[0].request.promise
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId("slow-status")).toHaveTextContent("stale")
+
+    await act(async () => {
+      pending[1].request.resolve({ activities: [{ sessionId: "board-a", status: "idle", source: "persisted" }], omittedSessionIds: [] })
+      await pending[1].request.promise
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId("fast-status")).toHaveTextContent("fresh")
+  })
+
   it("keeps unrelated board poll results when a single-session refresh supersedes one session", async () => {
     const pending: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<ActivityResponse>> }> = []
     postJson.mockImplementation((path: string, body: { sessionIds?: string[] }) => {

--- a/plugins/tasks/src/front/taskSessionActivity.test.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.test.tsx
@@ -35,10 +35,13 @@ function Probe() {
 
   return (
     <div>
-      <button type="button" onClick={() => { void activity.refreshSessionIds(["board-a"]) }}>Refresh A</button>
+      <button type="button" onClick={() => { void activity.refreshSessionIds(["board-a"]).catch(() => undefined) }}>Refresh A</button>
+      <button type="button" onClick={() => { void activity.refreshSessionIds(["board-b"]).catch(() => undefined) }}>Refresh B</button>
       <button type="button" onClick={() => activity.setOptimisticActivity("board-a", { status: "working", source: "live-runtime" })}>Optimistic A working</button>
       <span data-testid="activity-a">{activity.activities["board-a"]?.status ?? "none"}</span>
       <span data-testid="activity-b">{activity.activities["board-b"]?.status ?? "none"}</span>
+      <span data-testid="error-a">{activity.getError(["board-a"]) ?? "none"}</span>
+      <span data-testid="error-b">{activity.getError(["board-b"]) ?? "none"}</span>
     </div>
   )
 }
@@ -95,6 +98,51 @@ describe("TaskSessionActivityProvider request scoping", () => {
       await Promise.resolve()
     })
     expect(screen.getByTestId("fast-status")).toHaveTextContent("fresh")
+  })
+
+  it("scopes refresh errors to requested sessions and clears only successful sessions", async () => {
+    const pending: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<ActivityResponse>> }> = []
+    postJson.mockImplementation((path: string, body: { sessionIds?: string[] }) => {
+      if (path !== "/api/v1/agent/pi-chat/sessions/activity") throw new Error(`unexpected post ${path}`)
+      const request = deferred<ActivityResponse>()
+      pending.push({ sessionIds: body.sessionIds ?? [], request })
+      return request.promise
+    })
+
+    render(<TaskSessionActivityProvider><Probe /></TaskSessionActivityProvider>)
+
+    await act(async () => { await Promise.resolve() })
+    await act(async () => { await vi.advanceTimersByTimeAsync(25) })
+    expect(pending.map((entry) => entry.sessionIds)).toEqual([["board-a", "board-b"]])
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh A" }))
+    fireEvent.click(screen.getByRole("button", { name: "Refresh B" }))
+    expect(pending.map((entry) => entry.sessionIds)).toEqual([["board-a", "board-b"], ["board-a"], ["board-b"]])
+
+    await act(async () => {
+      pending[1].request.reject(new Error("A activity down"))
+      await pending[1].request.promise.catch(() => undefined)
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId("error-a")).toHaveTextContent("A activity down")
+    expect(screen.getByTestId("error-b")).toHaveTextContent("none")
+
+    await act(async () => {
+      pending[2].request.resolve({ activities: [{ sessionId: "board-b", status: "idle", source: "persisted" }], omittedSessionIds: [] })
+      await pending[2].request.promise
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId("error-a")).toHaveTextContent("A activity down")
+    expect(screen.getByTestId("error-b")).toHaveTextContent("none")
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh A" }))
+    expect(pending.map((entry) => entry.sessionIds)).toEqual([["board-a", "board-b"], ["board-a"], ["board-b"], ["board-a"]])
+    await act(async () => {
+      pending[3].request.resolve({ activities: [{ sessionId: "board-a", status: "idle", source: "persisted" }], omittedSessionIds: [] })
+      await pending[3].request.promise
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId("error-a")).toHaveTextContent("none")
   })
 
   it("keeps unrelated board poll results when a single-session refresh supersedes one session", async () => {

--- a/plugins/tasks/src/front/taskSessionActivity.test.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.test.tsx
@@ -100,6 +100,35 @@ describe("TaskSessionActivityProvider request scoping", () => {
     expect(screen.getByTestId("fast-status")).toHaveTextContent("fresh")
   })
 
+  it("returns stale instead of throwing when a superseded refresh fails", async () => {
+    const pending: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<ActivityResponse>> }> = []
+    postJson.mockImplementation((path: string, body: { sessionIds?: string[] }) => {
+      if (path !== "/api/v1/agent/pi-chat/sessions/activity") throw new Error(`unexpected post ${path}`)
+      const request = deferred<ActivityResponse>()
+      pending.push({ sessionIds: body.sessionIds ?? [], request })
+      return request.promise
+    })
+
+    render(<TaskSessionActivityProvider><ResultProbe /></TaskSessionActivityProvider>)
+    fireEvent.click(screen.getByRole("button", { name: "Slow refresh" }))
+    fireEvent.click(screen.getByRole("button", { name: "Fast refresh" }))
+    expect(pending.map((entry) => entry.sessionIds)).toEqual([["board-a"], ["board-a"]])
+
+    await act(async () => {
+      pending[0].request.reject(new Error("obsolete activity failure"))
+      await pending[0].request.promise.catch(() => undefined)
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId("slow-status")).toHaveTextContent("stale")
+
+    await act(async () => {
+      pending[1].request.resolve({ activities: [{ sessionId: "board-a", status: "idle", source: "persisted" }], omittedSessionIds: [] })
+      await pending[1].request.promise
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId("fast-status")).toHaveTextContent("fresh")
+  })
+
   it("scopes refresh errors to requested sessions and clears only successful sessions", async () => {
     const pending: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<ActivityResponse>> }> = []
     postJson.mockImplementation((path: string, body: { sessionIds?: string[] }) => {

--- a/plugins/tasks/src/front/taskSessionActivity.test.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { useEffect } from "react"
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { TaskSessionActivityProvider, useTaskSessionActivity } from "./taskSessionActivity"
+
+const postJson = vi.fn()
+const pluginClient = { postJson }
+
+vi.mock("@hachej/boring-workspace", () => ({
+  useWorkspacePluginClient: () => pluginClient,
+}))
+
+type ActivityResponse = {
+  activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted"; updatedAt?: string }>
+  omittedSessionIds?: string[]
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+  return { promise, resolve, reject }
+}
+
+function Probe() {
+  const activity = useTaskSessionActivity()
+
+  useEffect(() => {
+    return activity.registerSessionIds(["board-a", "board-b"])
+  }, [activity.registerSessionIds])
+
+  return (
+    <div>
+      <button type="button" onClick={() => { void activity.refreshSessionIds(["board-a"]) }}>Refresh A</button>
+      <span data-testid="activity-a">{activity.activities["board-a"]?.status ?? "none"}</span>
+      <span data-testid="activity-b">{activity.activities["board-b"]?.status ?? "none"}</span>
+    </div>
+  )
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  postJson.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("TaskSessionActivityProvider request scoping", () => {
+  it("keeps unrelated board poll results when a single-session refresh supersedes one session", async () => {
+    const pending: Array<{ sessionIds: string[]; request: ReturnType<typeof deferred<ActivityResponse>> }> = []
+    postJson.mockImplementation((path: string, body: { sessionIds?: string[] }) => {
+      if (path !== "/api/v1/agent/pi-chat/sessions/activity") throw new Error(`unexpected post ${path}`)
+      const request = deferred<ActivityResponse>()
+      pending.push({ sessionIds: body.sessionIds ?? [], request })
+      return request.promise
+    })
+
+    render(<TaskSessionActivityProvider><Probe /></TaskSessionActivityProvider>)
+
+    await act(async () => { await Promise.resolve() })
+    await act(async () => { await vi.advanceTimersByTimeAsync(25) })
+    expect(pending.map((entry) => entry.sessionIds)).toEqual([["board-a", "board-b"]])
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh A" }))
+    expect(pending.map((entry) => entry.sessionIds)).toEqual([["board-a", "board-b"], ["board-a"]])
+
+    await act(async () => {
+      pending[1].request.resolve({ activities: [{ sessionId: "board-a", status: "idle", source: "persisted" }], omittedSessionIds: [] })
+      await pending[1].request.promise
+      await Promise.resolve()
+    })
+    expect(screen.getByTestId("activity-a")).toHaveTextContent("idle")
+    expect(screen.getByTestId("activity-b")).toHaveTextContent("none")
+
+    await act(async () => {
+      pending[0].request.resolve({
+        activities: [
+          { sessionId: "board-a", status: "working", source: "live-runtime" },
+          { sessionId: "board-b", status: "working", source: "live-runtime" },
+        ],
+        omittedSessionIds: [],
+      })
+      await pending[0].request.promise
+      await Promise.resolve()
+    })
+
+    expect(screen.getByTestId("activity-a")).toHaveTextContent("idle")
+    expect(screen.getByTestId("activity-b")).toHaveTextContent("working")
+  })
+})

--- a/plugins/tasks/src/front/taskSessionActivity.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.tsx
@@ -189,9 +189,6 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
   }, [enabled, refreshSessionIds, registeredIdKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const setOptimisticActivity = useCallback((sessionId: string, activity: TaskSessionActivity) => {
-    const requestId = requestSeqRef.current + 1
-    requestSeqRef.current = requestId
-    latestRequestBySessionIdRef.current.set(sessionId, requestId)
     setActivities((current) => ({ ...current, [sessionId]: activity }))
   }, [])
 

--- a/plugins/tasks/src/front/taskSessionActivity.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.tsx
@@ -1,0 +1,221 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from "react"
+import { useWorkspacePluginClient } from "@hachej/boring-workspace"
+
+export type TaskSessionActivityStatus = "idle" | "queued" | "working" | "error" | "missing"
+export interface TaskSessionActivity { status: TaskSessionActivityStatus; source?: "live-runtime" | "persisted"; updatedAt?: string }
+
+interface SessionActivityResponse {
+  activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted"; updatedAt?: string }>
+  omittedSessionIds?: string[]
+}
+
+type WorkspacePluginClient = ReturnType<typeof useWorkspacePluginClient>
+
+export const TASK_SESSION_ACTIVITY_POLL_MS = 15_000
+export const TASK_SESSION_ACTIVITY_MAX_IDS = 100
+const TASK_SESSION_ACTIVITY_REGISTER_DEBOUNCE_MS = 25
+
+export interface TaskSessionActivityController {
+  activities: Record<string, TaskSessionActivity>
+  error: string | null
+  registerSessionIds(sessionIds: readonly string[]): () => void
+  refreshSessionIds(sessionIds: readonly string[]): Promise<Record<string, TaskSessionActivity>>
+  setOptimisticActivity(sessionId: string, activity: TaskSessionActivity): void
+  clearSessionActivity(sessionId: string): void
+  isLoading(sessionIds: readonly string[]): boolean
+}
+
+const TaskSessionActivityContext = createContext<TaskSessionActivityController | null>(null)
+
+function uniqueSessionIds(sessionIds: readonly string[]): string[] {
+  return [...new Set(sessionIds.filter((sessionId) => sessionId.length > 0))]
+}
+
+function chunkSessionIds(sessionIds: readonly string[]): string[][] {
+  const chunks: string[][] = []
+  for (let index = 0; index < sessionIds.length; index += TASK_SESSION_ACTIVITY_MAX_IDS) {
+    chunks.push(sessionIds.slice(index, index + TASK_SESSION_ACTIVITY_MAX_IDS))
+  }
+  return chunks
+}
+
+async function fetchSessionActivities(pluginClient: WorkspacePluginClient, sessionIds: readonly string[]): Promise<Record<string, TaskSessionActivity>> {
+  const next: Record<string, TaskSessionActivity> = {}
+  for (const chunk of chunkSessionIds(sessionIds)) {
+    const body = await pluginClient.postJson<SessionActivityResponse>("/api/v1/agent/pi-chat/sessions/activity", { sessionIds: chunk })
+    for (const entry of body.activities ?? []) {
+      next[entry.sessionId] = { status: entry.status, source: entry.source, updatedAt: entry.updatedAt }
+    }
+    for (const sessionId of body.omittedSessionIds ?? []) next[sessionId] = { status: "missing" }
+    for (const sessionId of chunk) next[sessionId] ??= { status: "missing" }
+  }
+  return next
+}
+
+function useTaskSessionActivityController(enabled: boolean): TaskSessionActivityController {
+  const pluginClient = useWorkspacePluginClient()
+  const [activities, setActivities] = useState<Record<string, TaskSessionActivity>>({})
+  const [error, setError] = useState<string | null>(null)
+  const [registeredSessionIds, setRegisteredSessionIds] = useState<ReadonlySet<string>>(new Set())
+  const [loadingSessionIds, setLoadingSessionIds] = useState<ReadonlySet<string>>(new Set())
+  const registrationsRef = useRef(new Map<number, string[]>())
+  const nextRegistrationIdRef = useRef(0)
+  const requestSeqRef = useRef(0)
+  const pollingGenerationRef = useRef(0)
+  const pollingInFlightRef = useRef<Promise<void> | null>(null)
+  const mountedRef = useRef(false)
+  const loadingCountsRef = useRef(new Map<string, number>())
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      requestSeqRef.current += 1
+      pollingGenerationRef.current += 1
+      registrationsRef.current.clear()
+      loadingCountsRef.current.clear()
+      pollingInFlightRef.current = null
+    }
+  }, [])
+
+  const publishRegisteredSessionIds = useCallback(() => {
+    const next = new Set<string>()
+    for (const sessionIds of registrationsRef.current.values()) {
+      for (const sessionId of sessionIds) next.add(sessionId)
+    }
+    setRegisteredSessionIds(next)
+  }, [])
+
+  const registerSessionIds = useCallback((sessionIds: readonly string[]) => {
+    if (!enabled) return () => undefined
+    const id = nextRegistrationIdRef.current + 1
+    nextRegistrationIdRef.current = id
+    registrationsRef.current.set(id, uniqueSessionIds(sessionIds))
+    publishRegisteredSessionIds()
+    return () => {
+      registrationsRef.current.delete(id)
+      publishRegisteredSessionIds()
+    }
+  }, [enabled, publishRegisteredSessionIds])
+
+  const addLoading = useCallback((sessionIds: readonly string[]) => {
+    for (const sessionId of sessionIds) loadingCountsRef.current.set(sessionId, (loadingCountsRef.current.get(sessionId) ?? 0) + 1)
+    if (mountedRef.current) setLoadingSessionIds(new Set(loadingCountsRef.current.keys()))
+  }, [])
+
+  const removeLoading = useCallback((sessionIds: readonly string[]) => {
+    for (const sessionId of sessionIds) {
+      const next = (loadingCountsRef.current.get(sessionId) ?? 0) - 1
+      if (next > 0) loadingCountsRef.current.set(sessionId, next)
+      else loadingCountsRef.current.delete(sessionId)
+    }
+    if (mountedRef.current) setLoadingSessionIds(new Set(loadingCountsRef.current.keys()))
+  }, [])
+
+  const refreshSessionIds = useCallback(async (
+    rawSessionIds: readonly string[],
+    options: { pollingGeneration?: number } = {},
+  ): Promise<Record<string, TaskSessionActivity>> => {
+    const sessionIds = uniqueSessionIds(rawSessionIds)
+    if (sessionIds.length === 0) return {}
+    const requestId = requestSeqRef.current + 1
+    requestSeqRef.current = requestId
+    addLoading(sessionIds)
+    try {
+      const next = await fetchSessionActivities(pluginClient, sessionIds)
+      if (
+        mountedRef.current
+        && requestSeqRef.current === requestId
+        && (options.pollingGeneration === undefined || pollingGenerationRef.current === options.pollingGeneration)
+      ) {
+        setActivities((current) => ({ ...current, ...next }))
+        setError(null)
+      }
+      return next
+    } catch (cause) {
+      if (
+        mountedRef.current
+        && requestSeqRef.current === requestId
+        && (options.pollingGeneration === undefined || pollingGenerationRef.current === options.pollingGeneration)
+      ) {
+        setError(cause instanceof Error ? cause.message : "Failed to load chat activity")
+      }
+      throw cause
+    } finally {
+      removeLoading(sessionIds)
+    }
+  }, [addLoading, pluginClient, removeLoading])
+
+  const registeredIdList = useMemo(() => [...registeredSessionIds], [registeredSessionIds])
+  const registeredIdKey = registeredIdList.join("\u0000")
+
+  useEffect(() => {
+    if (!enabled || registeredIdList.length === 0) return
+    let cancelled = false
+    let timer: number | undefined
+    const pollingGeneration = pollingGenerationRef.current + 1
+    pollingGenerationRef.current = pollingGeneration
+    const schedule = (delayMs: number) => {
+      timer = window.setTimeout(() => {
+        if (cancelled) return
+        if (pollingInFlightRef.current) {
+          void pollingInFlightRef.current.finally(() => {
+            if (!cancelled) schedule(0)
+          })
+          return
+        }
+        const polling = refreshSessionIds(registeredIdList, { pollingGeneration })
+          .then(() => undefined, () => undefined)
+          .finally(() => {
+            if (pollingInFlightRef.current === polling) pollingInFlightRef.current = null
+            if (!cancelled) schedule(TASK_SESSION_ACTIVITY_POLL_MS)
+          })
+        pollingInFlightRef.current = polling
+      }, delayMs)
+    }
+    schedule(TASK_SESSION_ACTIVITY_REGISTER_DEBOUNCE_MS)
+    return () => {
+      cancelled = true
+      pollingGenerationRef.current += 1
+      if (timer !== undefined) window.clearTimeout(timer)
+    }
+  }, [enabled, refreshSessionIds, registeredIdKey]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const setOptimisticActivity = useCallback((sessionId: string, activity: TaskSessionActivity) => {
+    setActivities((current) => ({ ...current, [sessionId]: activity }))
+  }, [])
+
+  const clearSessionActivity = useCallback((sessionId: string) => {
+    setActivities((current) => {
+      if (!(sessionId in current)) return current
+      const next = { ...current }
+      delete next[sessionId]
+      return next
+    })
+  }, [])
+
+  const isLoading = useCallback((sessionIds: readonly string[]) => {
+    return uniqueSessionIds(sessionIds).some((sessionId) => loadingSessionIds.has(sessionId))
+  }, [loadingSessionIds])
+
+  return useMemo(() => ({
+    activities,
+    error,
+    registerSessionIds,
+    refreshSessionIds,
+    setOptimisticActivity,
+    clearSessionActivity,
+    isLoading,
+  }), [activities, clearSessionActivity, error, isLoading, refreshSessionIds, registerSessionIds, setOptimisticActivity])
+}
+
+export function TaskSessionActivityProvider({ children }: { children: ReactNode }) {
+  const controller = useTaskSessionActivityController(true)
+  return <TaskSessionActivityContext.Provider value={controller}>{children}</TaskSessionActivityContext.Provider>
+}
+
+export function useTaskSessionActivity(): TaskSessionActivityController {
+  const context = useContext(TaskSessionActivityContext)
+  const fallback = useTaskSessionActivityController(context === null)
+  return context ?? fallback
+}

--- a/plugins/tasks/src/front/taskSessionActivity.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.tsx
@@ -61,6 +61,7 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
   const registrationsRef = useRef(new Map<number, string[]>())
   const nextRegistrationIdRef = useRef(0)
   const requestSeqRef = useRef(0)
+  const latestRequestBySessionIdRef = useRef(new Map<string, number>())
   const pollingGenerationRef = useRef(0)
   const pollingInFlightRef = useRef<Promise<void> | null>(null)
   const mountedRef = useRef(false)
@@ -71,6 +72,7 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
     return () => {
       mountedRef.current = false
       requestSeqRef.current += 1
+      latestRequestBySessionIdRef.current.clear()
       pollingGenerationRef.current += 1
       registrationsRef.current.clear()
       loadingCountsRef.current.clear()
@@ -120,24 +122,29 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
     if (sessionIds.length === 0) return {}
     const requestId = requestSeqRef.current + 1
     requestSeqRef.current = requestId
+    for (const sessionId of sessionIds) latestRequestBySessionIdRef.current.set(sessionId, requestId)
+    const isGenerationCurrent = () => options.pollingGeneration === undefined || pollingGenerationRef.current === options.pollingGeneration
+    const currentSessionIdsForRequest = () => sessionIds.filter((sessionId) => latestRequestBySessionIdRef.current.get(sessionId) === requestId)
     addLoading(sessionIds)
     try {
       const next = await fetchSessionActivities(pluginClient, sessionIds)
-      if (
-        mountedRef.current
-        && requestSeqRef.current === requestId
-        && (options.pollingGeneration === undefined || pollingGenerationRef.current === options.pollingGeneration)
-      ) {
-        setActivities((current) => ({ ...current, ...next }))
-        setError(null)
+      if (mountedRef.current && isGenerationCurrent()) {
+        const currentSessionIds = currentSessionIdsForRequest()
+        if (currentSessionIds.length > 0) {
+          setActivities((current) => {
+            const merged = { ...current }
+            for (const sessionId of currentSessionIds) {
+              const activity = next[sessionId]
+              if (activity) merged[sessionId] = activity
+            }
+            return merged
+          })
+          setError(null)
+        }
       }
       return next
     } catch (cause) {
-      if (
-        mountedRef.current
-        && requestSeqRef.current === requestId
-        && (options.pollingGeneration === undefined || pollingGenerationRef.current === options.pollingGeneration)
-      ) {
+      if (mountedRef.current && isGenerationCurrent() && currentSessionIdsForRequest().length > 0) {
         setError(cause instanceof Error ? cause.message : "Failed to load chat activity")
       }
       throw cause
@@ -182,10 +189,16 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
   }, [enabled, refreshSessionIds, registeredIdKey]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const setOptimisticActivity = useCallback((sessionId: string, activity: TaskSessionActivity) => {
+    const requestId = requestSeqRef.current + 1
+    requestSeqRef.current = requestId
+    latestRequestBySessionIdRef.current.set(sessionId, requestId)
     setActivities((current) => ({ ...current, [sessionId]: activity }))
   }, [])
 
   const clearSessionActivity = useCallback((sessionId: string) => {
+    const requestId = requestSeqRef.current + 1
+    requestSeqRef.current = requestId
+    latestRequestBySessionIdRef.current.set(sessionId, requestId)
     setActivities((current) => {
       if (!(sessionId in current)) return current
       const next = { ...current }

--- a/plugins/tasks/src/front/taskSessionActivity.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.tsx
@@ -6,6 +6,11 @@ export interface TaskSessionActivity { status: TaskSessionActivityStatus; source
 export type TaskSessionActivityRefreshResult =
   | { status: "fresh"; activities: Record<string, TaskSessionActivity> }
   | { status: "stale" }
+export type TaskSessionActivityRefreshPriority = "poll" | "action"
+export interface TaskSessionActivityRefreshOptions {
+  pollingGeneration?: number
+  priority?: TaskSessionActivityRefreshPriority
+}
 
 interface SessionActivityResponse {
   activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted"; updatedAt?: string }>
@@ -21,7 +26,7 @@ const TASK_SESSION_ACTIVITY_REGISTER_DEBOUNCE_MS = 25
 export interface TaskSessionActivityController {
   activities: Record<string, TaskSessionActivity>
   registerSessionIds(sessionIds: readonly string[]): () => void
-  refreshSessionIds(sessionIds: readonly string[]): Promise<TaskSessionActivityRefreshResult>
+  refreshSessionIds(sessionIds: readonly string[], options?: TaskSessionActivityRefreshOptions): Promise<TaskSessionActivityRefreshResult>
   setOptimisticActivity(sessionId: string, activity: TaskSessionActivity): void
   clearSessionActivity(sessionId: string): void
   isLoading(sessionIds: readonly string[]): boolean
@@ -40,6 +45,16 @@ function chunkSessionIds(sessionIds: readonly string[]): string[][] {
     chunks.push(sessionIds.slice(index, index + TASK_SESSION_ACTIVITY_MAX_IDS))
   }
   return chunks
+}
+
+function priorityRank(priority: TaskSessionActivityRefreshPriority): number {
+  return priority === "action" ? 1 : 0
+}
+
+interface LatestActivityRequest {
+  requestId: number
+  priority: TaskSessionActivityRefreshPriority
+  inFlight: boolean
 }
 
 async function fetchSessionActivities(pluginClient: WorkspacePluginClient, sessionIds: readonly string[]): Promise<Record<string, TaskSessionActivity>> {
@@ -64,7 +79,7 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
   const registrationsRef = useRef(new Map<number, string[]>())
   const nextRegistrationIdRef = useRef(0)
   const requestSeqRef = useRef(0)
-  const latestRequestBySessionIdRef = useRef(new Map<string, number>())
+  const latestRequestBySessionIdRef = useRef(new Map<string, LatestActivityRequest>())
   const pollingGenerationRef = useRef(0)
   const pollingInFlightRef = useRef<Promise<void> | null>(null)
   const mountedRef = useRef(false)
@@ -119,15 +134,20 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
 
   const refreshSessionIds = useCallback(async (
     rawSessionIds: readonly string[],
-    options: { pollingGeneration?: number } = {},
+    options: TaskSessionActivityRefreshOptions = {},
   ): Promise<TaskSessionActivityRefreshResult> => {
     const sessionIds = uniqueSessionIds(rawSessionIds)
     if (sessionIds.length === 0) return { status: "fresh", activities: {} }
+    const priority = options.priority ?? "action"
     const requestId = requestSeqRef.current + 1
     requestSeqRef.current = requestId
-    for (const sessionId of sessionIds) latestRequestBySessionIdRef.current.set(sessionId, requestId)
+    for (const sessionId of sessionIds) {
+      const current = latestRequestBySessionIdRef.current.get(sessionId)
+      if (current?.inFlight && priorityRank(current.priority) > priorityRank(priority)) continue
+      latestRequestBySessionIdRef.current.set(sessionId, { requestId, priority, inFlight: true })
+    }
     const isGenerationCurrent = () => options.pollingGeneration === undefined || pollingGenerationRef.current === options.pollingGeneration
-    const currentSessionIdsForRequest = () => sessionIds.filter((sessionId) => latestRequestBySessionIdRef.current.get(sessionId) === requestId)
+    const currentSessionIdsForRequest = () => sessionIds.filter((sessionId) => latestRequestBySessionIdRef.current.get(sessionId)?.requestId === requestId)
     addLoading(sessionIds)
     try {
       const next = await fetchSessionActivities(pluginClient, sessionIds)
@@ -165,6 +185,10 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
       })
       throw cause
     } finally {
+      for (const sessionId of sessionIds) {
+        const current = latestRequestBySessionIdRef.current.get(sessionId)
+        if (current?.requestId === requestId) latestRequestBySessionIdRef.current.set(sessionId, { ...current, inFlight: false })
+      }
       removeLoading(sessionIds)
     }
   }, [addLoading, pluginClient, removeLoading])
@@ -187,7 +211,7 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
           })
           return
         }
-        const polling = refreshSessionIds(registeredIdList, { pollingGeneration })
+        const polling = refreshSessionIds(registeredIdList, { pollingGeneration, priority: "poll" })
           .then(() => undefined, () => undefined)
           .finally(() => {
             if (pollingInFlightRef.current === polling) pollingInFlightRef.current = null
@@ -211,7 +235,7 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
   const clearSessionActivity = useCallback((sessionId: string) => {
     const requestId = requestSeqRef.current + 1
     requestSeqRef.current = requestId
-    latestRequestBySessionIdRef.current.set(sessionId, requestId)
+    latestRequestBySessionIdRef.current.set(sessionId, { requestId, priority: "action", inFlight: false })
     setActivities((current) => {
       if (!(sessionId in current)) return current
       const next = { ...current }

--- a/plugins/tasks/src/front/taskSessionActivity.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.tsx
@@ -20,12 +20,12 @@ const TASK_SESSION_ACTIVITY_REGISTER_DEBOUNCE_MS = 25
 
 export interface TaskSessionActivityController {
   activities: Record<string, TaskSessionActivity>
-  error: string | null
   registerSessionIds(sessionIds: readonly string[]): () => void
   refreshSessionIds(sessionIds: readonly string[]): Promise<TaskSessionActivityRefreshResult>
   setOptimisticActivity(sessionId: string, activity: TaskSessionActivity): void
   clearSessionActivity(sessionId: string): void
   isLoading(sessionIds: readonly string[]): boolean
+  getError(sessionIds: readonly string[]): string | null
 }
 
 const TaskSessionActivityContext = createContext<TaskSessionActivityController | null>(null)
@@ -58,7 +58,7 @@ async function fetchSessionActivities(pluginClient: WorkspacePluginClient, sessi
 function useTaskSessionActivityController(enabled: boolean): TaskSessionActivityController {
   const pluginClient = useWorkspacePluginClient()
   const [activities, setActivities] = useState<Record<string, TaskSessionActivity>>({})
-  const [error, setError] = useState<string | null>(null)
+  const [errorsBySessionId, setErrorsBySessionId] = useState<Record<string, string>>({})
   const [registeredSessionIds, setRegisteredSessionIds] = useState<ReadonlySet<string>>(new Set())
   const [loadingSessionIds, setLoadingSessionIds] = useState<ReadonlySet<string>>(new Set())
   const registrationsRef = useRef(new Map<number, string[]>())
@@ -141,12 +141,28 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
           }
           return merged
         })
-        setError(null)
+        setErrorsBySessionId((current) => {
+          let changed = false
+          const merged = { ...current }
+          for (const sessionId of currentSessionIds) {
+            if (sessionId in merged) {
+              delete merged[sessionId]
+              changed = true
+            }
+          }
+          return changed ? merged : current
+        })
       }
       return currentSessionIds.length === sessionIds.length ? { status: "fresh", activities: next } : { status: "stale" }
     } catch (cause) {
-      if (mountedRef.current && isGenerationCurrent() && currentSessionIdsForRequest().length > 0) {
-        setError(cause instanceof Error ? cause.message : "Failed to load chat activity")
+      const currentSessionIds = mountedRef.current && isGenerationCurrent() ? currentSessionIdsForRequest() : []
+      if (currentSessionIds.length > 0) {
+        const message = cause instanceof Error ? cause.message : "Failed to load chat activity"
+        setErrorsBySessionId((current) => {
+          const merged = { ...current }
+          for (const sessionId of currentSessionIds) merged[sessionId] = message
+          return merged
+        })
       }
       throw cause
     } finally {
@@ -203,21 +219,35 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
       delete next[sessionId]
       return next
     })
+    setErrorsBySessionId((current) => {
+      if (!(sessionId in current)) return current
+      const next = { ...current }
+      delete next[sessionId]
+      return next
+    })
   }, [])
 
   const isLoading = useCallback((sessionIds: readonly string[]) => {
     return uniqueSessionIds(sessionIds).some((sessionId) => loadingSessionIds.has(sessionId))
   }, [loadingSessionIds])
 
+  const getError = useCallback((sessionIds: readonly string[]) => {
+    for (const sessionId of uniqueSessionIds(sessionIds)) {
+      const message = errorsBySessionId[sessionId]
+      if (message) return message
+    }
+    return null
+  }, [errorsBySessionId])
+
   return useMemo(() => ({
     activities,
-    error,
     registerSessionIds,
     refreshSessionIds,
     setOptimisticActivity,
     clearSessionActivity,
     isLoading,
-  }), [activities, clearSessionActivity, error, isLoading, refreshSessionIds, registerSessionIds, setOptimisticActivity])
+    getError,
+  }), [activities, clearSessionActivity, getError, isLoading, refreshSessionIds, registerSessionIds, setOptimisticActivity])
 }
 
 export function TaskSessionActivityProvider({ children }: { children: ReactNode }) {

--- a/plugins/tasks/src/front/taskSessionActivity.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.tsx
@@ -156,14 +156,13 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
       return currentSessionIds.length === sessionIds.length ? { status: "fresh", activities: next } : { status: "stale" }
     } catch (cause) {
       const currentSessionIds = mountedRef.current && isGenerationCurrent() ? currentSessionIdsForRequest() : []
-      if (currentSessionIds.length > 0) {
-        const message = cause instanceof Error ? cause.message : "Failed to load chat activity"
-        setErrorsBySessionId((current) => {
-          const merged = { ...current }
-          for (const sessionId of currentSessionIds) merged[sessionId] = message
-          return merged
-        })
-      }
+      if (currentSessionIds.length === 0) return { status: "stale" }
+      const message = cause instanceof Error ? cause.message : "Failed to load chat activity"
+      setErrorsBySessionId((current) => {
+        const merged = { ...current }
+        for (const sessionId of currentSessionIds) merged[sessionId] = message
+        return merged
+      })
       throw cause
     } finally {
       removeLoading(sessionIds)

--- a/plugins/tasks/src/front/taskSessionActivity.tsx
+++ b/plugins/tasks/src/front/taskSessionActivity.tsx
@@ -3,6 +3,9 @@ import { useWorkspacePluginClient } from "@hachej/boring-workspace"
 
 export type TaskSessionActivityStatus = "idle" | "queued" | "working" | "error" | "missing"
 export interface TaskSessionActivity { status: TaskSessionActivityStatus; source?: "live-runtime" | "persisted"; updatedAt?: string }
+export type TaskSessionActivityRefreshResult =
+  | { status: "fresh"; activities: Record<string, TaskSessionActivity> }
+  | { status: "stale" }
 
 interface SessionActivityResponse {
   activities?: Array<{ sessionId: string; status: "idle" | "queued" | "working" | "error"; source: "live-runtime" | "persisted"; updatedAt?: string }>
@@ -19,7 +22,7 @@ export interface TaskSessionActivityController {
   activities: Record<string, TaskSessionActivity>
   error: string | null
   registerSessionIds(sessionIds: readonly string[]): () => void
-  refreshSessionIds(sessionIds: readonly string[]): Promise<Record<string, TaskSessionActivity>>
+  refreshSessionIds(sessionIds: readonly string[]): Promise<TaskSessionActivityRefreshResult>
   setOptimisticActivity(sessionId: string, activity: TaskSessionActivity): void
   clearSessionActivity(sessionId: string): void
   isLoading(sessionIds: readonly string[]): boolean
@@ -117,9 +120,9 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
   const refreshSessionIds = useCallback(async (
     rawSessionIds: readonly string[],
     options: { pollingGeneration?: number } = {},
-  ): Promise<Record<string, TaskSessionActivity>> => {
+  ): Promise<TaskSessionActivityRefreshResult> => {
     const sessionIds = uniqueSessionIds(rawSessionIds)
-    if (sessionIds.length === 0) return {}
+    if (sessionIds.length === 0) return { status: "fresh", activities: {} }
     const requestId = requestSeqRef.current + 1
     requestSeqRef.current = requestId
     for (const sessionId of sessionIds) latestRequestBySessionIdRef.current.set(sessionId, requestId)
@@ -128,21 +131,19 @@ function useTaskSessionActivityController(enabled: boolean): TaskSessionActivity
     addLoading(sessionIds)
     try {
       const next = await fetchSessionActivities(pluginClient, sessionIds)
-      if (mountedRef.current && isGenerationCurrent()) {
-        const currentSessionIds = currentSessionIdsForRequest()
-        if (currentSessionIds.length > 0) {
-          setActivities((current) => {
-            const merged = { ...current }
-            for (const sessionId of currentSessionIds) {
-              const activity = next[sessionId]
-              if (activity) merged[sessionId] = activity
-            }
-            return merged
-          })
-          setError(null)
-        }
+      const currentSessionIds = mountedRef.current && isGenerationCurrent() ? currentSessionIdsForRequest() : []
+      if (currentSessionIds.length > 0) {
+        setActivities((current) => {
+          const merged = { ...current }
+          for (const sessionId of currentSessionIds) {
+            const activity = next[sessionId]
+            if (activity) merged[sessionId] = activity
+          }
+          return merged
+        })
+        setError(null)
       }
-      return next
+      return currentSessionIds.length === sessionIds.length ? { status: "fresh", activities: next } : { status: "stale" }
     } catch (cause) {
       if (mountedRef.current && isGenerationCurrent() && currentSessionIdsForRequest().length > 0) {
         setError(cause instanceof Error ? cause.message : "Failed to load chat activity")


### PR DESCRIPTION
## Summary
Adds authoritative, board-scoped linked-session activity to task cards.

## Issue / Slice
Closes #613. Stacked on #663.

## What Changed
- Board-level bounded activity polling, chunked across all linked sessions.
- Accurate working/queued/error/idle rollups, active-first navigation and non-active recency ordering.
- Race-safe authoritative activity reconciliation, scoped lifecycle/error/list/action state, and stale navigation cancellation.
- Accessible loading, retry, unavailable, error, focus, and reduced-motion behavior.

## Proof
- `pnpm --filter @hachej/boring-tasks test` — 9 files / 58 tests passed.
- `pnpm --filter @hachej/boring-tasks lint && pnpm --filter @hachej/boring-tasks typecheck && pnpm --filter @hachej/boring-tasks build` — passed.
- `pnpm lint:invariants && git diff --check` — passed.

## Review
- Terra: READY.
- Sol: READY.
- Reviewed SHA: `b276ae6cc`.

## Risk / Rollback
Polling is board-scoped and bounded; rollback removes task-card indicators without affecting persisted bindings.

## Next
Depends on #663 and preceding stack PRs.
