### PR TITLE
feat(391): prove canonical D1 ingress headers

### DIFF
--- a/apps/full-app/package.json
+++ b/apps/full-app/package.json
@@ -19,6 +19,7 @@
     "smoke:post-deploy": "tsx scripts/post-deploy-smoke.ts",
     "smoke:remote-worker": "node scripts/remote-worker-smoke.mjs",
     "proof:d1-docker-boundary": "node --import tsx scripts/d1-docker-boundary-proof.ts",
+    "proof:d1-ingress-headers": "node --import tsx scripts/d1-ingress-header-proof.ts",
     "backup:fly-worker-volume": "node scripts/fly-worker-volume-backup.mjs"
   },
   "dependencies": {

--- a/apps/full-app/scripts/d1-ingress-header-proof.ts
+++ b/apps/full-app/scripts/d1-ingress-header-proof.ts
@@ -1,0 +1,151 @@
+import { spawnSync } from 'node:child_process'
+import { createHash, randomUUID } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { request } from 'node:http'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+import { D1_CADDY_IMAGE } from '../src/server/deployment/composeAdapter.js'
+
+export const D1_CADDY_AMD64_ID = 'sha256:af555904a0961945f16bb323a501457b13a4f7e9bde969b145b97da80b38ecbe'
+export const D1_CADDYFILE_DIGEST = 'sha256:a391f757bc9398e0dbd279e6a503fe608e6571f29c166164ff36552afd0f72c8'
+export const D1_INGRESS_PROOF_HELPER_IMAGE = 'node@sha256:c601a46abb4d2ab80a9dc3da208d50d1122642d53f17a101926ace71e5a9bf1c'
+const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
+const CADDYFILE = path.join(REPOSITORY_ROOT, 'deploy/d1/Caddyfile')
+const CADDYFILE_TARGET = '/etc/caddy/Caddyfile'
+const AUTHORITY = 'insurance.example.test:8443'
+const MAX_OUTPUT = 1024 * 1024
+const FAILURE = `${JSON.stringify({ status: 'fail', proof: 'd1-ingress-headers', error: 'D1_INGRESS_HEADER_PROOF_FAILED' })}\n`
+const ECHO = "require('node:http').createServer((req,res)=>{res.setHeader('content-type','application/json');res.end(JSON.stringify({host:req.headers.host,distinct:req.headersDistinct,raw:req.rawHeaders}))}).listen(3000,'0.0.0.0')"
+
+export const D1_INGRESS_PROOF_CASES = Object.freeze([
+  { name: 'forwarded-absent', forwarded: [], xfh: [] },
+  { name: 'forwarded-single', forwarded: ['for=192.0.2.1;host=evil.example'], xfh: [] },
+  { name: 'forwarded-empty', forwarded: [''], xfh: [] },
+  { name: 'forwarded-repeated', forwarded: ['for=192.0.2.1', 'for=192.0.2.2'], xfh: [] },
+  { name: 'forwarded-comma', forwarded: ['for=192.0.2.1, for=192.0.2.2'], xfh: [] },
+  { name: 'xfh-absent', forwarded: [], xfh: [] },
+  { name: 'xfh-hostile', forwarded: [], xfh: ['evil.example'] },
+  { name: 'xfh-repeated', forwarded: [], xfh: ['evil.example', 'second.example'] },
+  { name: 'xfh-comma', forwarded: [], xfh: ['evil.example, second.example'] },
+] as const)
+
+interface DockerResult { readonly ok: boolean, readonly stdout: string }
+
+function docker(args: readonly string[]): DockerResult {
+  const result = spawnSync('docker', args, { encoding: 'utf8', maxBuffer: MAX_OUTPUT, timeout: 120_000, shell: false })
+  return { ok: result.status === 0, stdout: result.stdout ?? '' }
+}
+
+function requireDocker(args: readonly string[]): string {
+  const result = docker(args)
+  if (!result.ok || new TextEncoder().encode(result.stdout).byteLength > MAX_OUTPUT) throw new Error('docker')
+  return result.stdout
+}
+
+function records(raw: string): Record<string, any>[] {
+  const value: unknown = JSON.parse(raw)
+  if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'object' || entry === null)) throw new Error('inspect')
+  return value as Record<string, any>[]
+}
+
+export function validateD1CaddyImageInspect(raw: string): void {
+  const image = records(raw)[0]
+  if (!image || image.Id !== D1_CADDY_AMD64_ID || !Array.isArray(image.RepoDigests) || !image.RepoDigests.includes(D1_CADDY_IMAGE)
+    || image.Config?.Entrypoint != null || JSON.stringify(image.Config?.Cmd) !== JSON.stringify(['caddy', 'run', '--config', CADDYFILE_TARGET, '--adapter', 'caddyfile'])
+    || !Array.isArray(image.Config?.Env) || !image.Config.Env.includes('CADDY_VERSION=v2.11.4')) throw new Error('image')
+}
+
+export function validateD1IngressContainerInspect(raw: string, source: string): void {
+  const container = records(raw)[0]
+  const mount = container?.Mounts?.filter((entry: Record<string, unknown>) => entry.Destination === CADDYFILE_TARGET)
+  if (!container || container.Config?.Image !== D1_CADDY_IMAGE
+    || JSON.stringify(container.Config?.Cmd) !== JSON.stringify(['caddy', 'run', '--config', CADDYFILE_TARGET, '--adapter', 'caddyfile'])
+    || !Array.isArray(mount) || mount.length !== 1 || mount[0].Type !== 'bind' || mount[0].Source !== source || mount[0].RW !== false) throw new Error('container')
+}
+
+function rawValues(raw: unknown, name: string): string[] {
+  if (!Array.isArray(raw) || raw.some((value) => typeof value !== 'string') || raw.length % 2 !== 0) throw new Error('headers')
+  const values: string[] = []
+  for (let index = 0; index < raw.length; index += 2) if (raw[index]!.toLowerCase() === name) values.push(raw[index + 1]!)
+  return values
+}
+
+export function assertD1IngressEcho(raw: unknown, authority = AUTHORITY): void {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) throw new Error('echo')
+  const echo = raw as Record<string, any>
+  if (echo.host !== authority || rawValues(echo.raw, 'host').join('\0') !== authority
+    || rawValues(echo.raw, 'x-forwarded-host').join('\0') !== authority || rawValues(echo.raw, 'forwarded').length !== 0
+    || JSON.stringify(echo.distinct?.['x-forwarded-host']) !== JSON.stringify([authority])
+    || Object.hasOwn(echo.distinct ?? {}, 'forwarded')) throw new Error('echo')
+}
+
+async function echoRequest(port: number, forwarded: readonly string[], xfh: readonly string[]): Promise<unknown> {
+  const headers = ['Host', AUTHORITY]
+  for (const value of forwarded) headers.push('Forwarded', value)
+  for (const value of xfh) headers.push('X-Forwarded-Host', value)
+  return new Promise((resolve, reject) => {
+    const call = request({ host: '127.0.0.1', port, path: '/proof', headers, method: 'GET', timeout: 2_000 }, (response) => {
+      const chunks: Buffer[] = []; let size = 0
+      response.on('data', (chunk: Buffer) => { size += chunk.length; if (size > 64 * 1024) response.destroy(); else chunks.push(chunk) })
+      response.on('error', reject)
+      response.on('end', () => {
+        if (response.statusCode !== 200) reject(new Error('status'))
+        else { try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown) } catch { reject(new Error('json')) } }
+      })
+    })
+    call.on('timeout', () => call.destroy(new Error('timeout'))); call.on('error', reject); call.end()
+  })
+}
+
+async function waitForEcho(port: number, forwarded: readonly string[], xfh: readonly string[]): Promise<unknown> {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try { return await echoRequest(port, forwarded, xfh) } catch { await new Promise((resolve) => setTimeout(resolve, 100)) }
+  }
+  throw new Error('readiness')
+}
+
+function cleanup(names: readonly string[], network: string, label: string): void {
+  for (const name of names) docker(['rm', '-f', name])
+  docker(['network', 'rm', network])
+  const containers = docker(['container', 'ls', '-a', '--filter', `label=${label}`, '--format', '{{.Names}}'])
+  const networks = docker(['network', 'ls', '--filter', `label=${label}`, '--format', '{{.Name}}'])
+  if (!containers.ok || !networks.ok || containers.stdout.trim() !== '' || networks.stdout.trim() !== '') throw new Error('cleanup')
+}
+
+async function proof(): Promise<void> {
+  const token = randomUUID(); const label = `ai.senecapp.d1-ingress-proof=${token}`
+  const network = `d1-ingress-${token}`; const backend = `${network}-backend`; const ingress = `${network}-caddy`; const validator = `${network}-validate`
+  const names = [backend, ingress, validator]; let cleaned = false
+  const clean = () => { if (!cleaned) { cleaned = true; cleanup(names, network, label) } }
+  const onSignal = () => { try { clean() } finally { process.stdout.write(FAILURE); process.exit(1) } }
+  process.once('SIGINT', onSignal); process.once('SIGTERM', onSignal)
+  try {
+    const config = await readFile(CADDYFILE)
+    if (`sha256:${createHash('sha256').update(config).digest('hex')}` !== D1_CADDYFILE_DIGEST) throw new Error('configDigest')
+    requireDocker(['pull', D1_CADDY_IMAGE]); requireDocker(['pull', D1_INGRESS_PROOF_HELPER_IMAGE])
+    validateD1CaddyImageInspect(requireDocker(['image', 'inspect', D1_CADDY_IMAGE]))
+    const helper = records(requireDocker(['image', 'inspect', D1_INGRESS_PROOF_HELPER_IMAGE]))[0]
+    if (!helper?.RepoDigests?.includes(D1_INGRESS_PROOF_HELPER_IMAGE)) throw new Error('helperImage')
+    const mount = `type=bind,src=${CADDYFILE},dst=${CADDYFILE_TARGET},readonly`
+    requireDocker(['run', '--rm', '--name', validator, '--label', label, '--mount', mount, D1_CADDY_IMAGE,
+      'caddy', 'validate', '--config', CADDYFILE_TARGET, '--adapter', 'caddyfile'])
+    requireDocker(['network', 'create', '--label', label, network])
+    requireDocker(['run', '-d', '--rm', '--name', backend, '--label', label, '--network', network, '--network-alias', 'core-app',
+      '--entrypoint', 'node', D1_INGRESS_PROOF_HELPER_IMAGE, '-e', ECHO])
+    requireDocker(['run', '-d', '--rm', '--name', ingress, '--label', label, '--network', network, '--publish', '127.0.0.1::8080',
+      '--mount', mount, D1_CADDY_IMAGE, 'caddy', 'run', '--config', CADDYFILE_TARGET, '--adapter', 'caddyfile'])
+    validateD1IngressContainerInspect(requireDocker(['inspect', ingress]), CADDYFILE)
+    const published = requireDocker(['port', ingress, '8080/tcp']).trim().match(/^127\.0\.0\.1:(\d+)$/)
+    if (!published) throw new Error('port')
+    for (const testCase of D1_INGRESS_PROOF_CASES) assertD1IngressEcho(await waitForEcho(Number(published[1]), testCase.forwarded, testCase.xfh))
+  } finally {
+    try { clean() } finally { process.off('SIGINT', onSignal); process.off('SIGTERM', onSignal) }
+  }
+  process.stdout.write(`${JSON.stringify({ status: 'pass', proof: 'd1-ingress-headers', caddyImage: D1_CADDY_IMAGE,
+    caddyImageId: D1_CADDY_AMD64_ID, caddyfileDigest: D1_CADDYFILE_DIGEST, cases: D1_INGRESS_PROOF_CASES.length })}\n`)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  proof().catch(() => { process.stdout.write(FAILURE); process.exitCode = 1 })
+}

--- a/apps/full-app/src/server/deployment/__tests__/composeAdapter.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/composeAdapter.test.ts
@@ -4,6 +4,7 @@ import { parse } from 'yaml'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
+  D1_CADDY_IMAGE,
   renderD1ComposeCommands,
   runD1ComposeAction,
   type D1ComposeEffect,
@@ -13,13 +14,12 @@ import {
 import { D1HostErrorCode, parseD1HostPlan } from '../d1Plan.js'
 
 const digest = `sha256:${'a'.repeat(64)}`
-const ingressDigest = `sha256:${'b'.repeat(64)}`
 const composeUrl = new URL('../../../../../../deploy/d1/compose.yml', import.meta.url)
 const collectionUrl = new URL('../../../../../../deploy/d1/collection.example.json', import.meta.url)
 
 const images = {
   schemaVersion: 1,
-  ingressImage: `caddy@${ingressDigest}`,
+  ingressImage: D1_CADDY_IMAGE,
   coreAppImage: `ghcr.io/hachej/boring-ui@${digest}`,
 } as const
 
@@ -62,8 +62,11 @@ describe('D1 Compose topology', () => {
     expect(Object.keys(document.services)).toEqual(['ingress', 'core-app'])
     expect(Object.keys(document.volumes)).toEqual(['d1-workspaces', 'd1-sessions'])
     expect(ingress.image).toBe('${D1_INGRESS_IMAGE:?D1_INGRESS_IMAGE is required}')
-    expect(ingress.command).toEqual(['reverse-proxy', '--from', ':8080', '--to', 'core-app:3000'])
-    expect(JSON.stringify(ingress.command)).not.toMatch(/\$\{|forwarded|header/i)
+    expect(ingress.command).toEqual(['caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile'])
+    expect(ingress.volumes).toEqual([{
+      type: 'bind', source: './Caddyfile', target: '/etc/caddy/Caddyfile', read_only: true, bind: { create_host_path: false },
+    }])
+    expect(JSON.stringify(ingress.command)).not.toMatch(/\$\{|forwarded|header|\/bin\/sh/i)
     expect(ingress).not.toHaveProperty('environment')
     expect(core.image).toBe('${D1_CORE_APP_IMAGE:?D1_CORE_APP_IMAGE is required}')
     expect(ingress.ports).toEqual(['80:8080'])
@@ -134,6 +137,8 @@ describe('D1 Compose command policy', () => {
     ['core digest mismatch', { ...images, coreAppImage: `ghcr.io/hachej/boring-ui@sha256:${'c'.repeat(64)}` }],
     ['tagged core image', { ...images, coreAppImage: 'ghcr.io/hachej/boring-ui:latest' }],
     ['tagged ingress image', { ...images, ingressImage: 'caddy:2' }],
+    ['other pinned ingress image', { ...images, ingressImage: `caddy@sha256:${'b'.repeat(64)}` }],
+    ['other ingress repository', { ...images, ingressImage: D1_CADDY_IMAGE.replace('caddy@', 'registry.example/caddy@') }],
     ['caller-supplied project drift', { ...images, projectName: 'old-project' }],
     ['caller-supplied compose drift', { ...images, composeFile: '/old/compose.yml' }],
     ['caller-supplied state drift', { ...images, stateRoot: '/old/state' }],

--- a/apps/full-app/src/server/deployment/__tests__/d1IngressHeaderProof.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1IngressHeaderProof.test.ts
@@ -1,0 +1,79 @@
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  assertD1IngressEcho,
+  D1_CADDY_AMD64_ID,
+  D1_CADDYFILE_DIGEST,
+  D1_INGRESS_PROOF_CASES,
+  D1_INGRESS_PROOF_HELPER_IMAGE,
+  validateD1CaddyImageInspect,
+  validateD1IngressContainerInspect,
+} from '../../../../scripts/d1-ingress-header-proof.js'
+import { D1_CADDY_IMAGE } from '../composeAdapter.js'
+
+const source = '/repo/deploy/d1/Caddyfile'
+const command = ['caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile']
+const caddyImage = [{
+  Id: D1_CADDY_AMD64_ID, RepoDigests: [D1_CADDY_IMAGE],
+  Config: { Cmd: command, Env: ['CADDY_VERSION=v2.11.4'] },
+}]
+const container = [{
+  Config: { Image: D1_CADDY_IMAGE, Cmd: command },
+  Mounts: [{ Type: 'bind', Source: source, Destination: '/etc/caddy/Caddyfile', RW: false }],
+}]
+const echo = {
+  host: 'insurance.example.test:8443',
+  distinct: { host: ['insurance.example.test:8443'], 'x-forwarded-host': ['insurance.example.test:8443'] },
+  raw: ['Host', 'insurance.example.test:8443', 'X-Forwarded-Host', 'insurance.example.test:8443'],
+}
+
+describe('D1 ingress Docker proof contract', () => {
+  it('pins the exact official image, selected image ID, helper, and config bytes', async () => {
+    expect(D1_CADDY_IMAGE).toBe('caddy@sha256:af5fdcd76f2db5e4e974ee92f96ee8c0fc3edb55bd4ba5032547cbf3f65e486d')
+    expect(D1_CADDY_AMD64_ID).toBe('sha256:af555904a0961945f16bb323a501457b13a4f7e9bde969b145b97da80b38ecbe')
+    expect(D1_INGRESS_PROOF_HELPER_IMAGE).toMatch(/^node@sha256:[a-f0-9]{64}$/)
+    const config = await readFile(new URL('../../../../../../deploy/d1/Caddyfile', import.meta.url))
+    expect(`sha256:${createHash('sha256').update(config).digest('hex')}`).toBe(D1_CADDYFILE_DIGEST)
+    expect(config.toString()).toBe(':8080 {\n\treverse_proxy core-app:3000 {\n\t\theader_up -Forwarded\n\t\theader_up Host {hostport}\n\t\theader_up X-Forwarded-Host {hostport}\n\t}\n}\n')
+  })
+
+  it('covers the exact hostile header matrix', () => {
+    expect(D1_INGRESS_PROOF_CASES.map((entry) => entry.name)).toEqual([
+      'forwarded-absent', 'forwarded-single', 'forwarded-empty', 'forwarded-repeated', 'forwarded-comma',
+      'xfh-absent', 'xfh-hostile', 'xfh-repeated', 'xfh-comma',
+    ])
+  })
+
+  it('requires one original Host/XFH value and no Forwarded value', () => {
+    expect(() => assertD1IngressEcho(echo)).not.toThrow()
+    for (const invalid of [
+      { ...echo, host: 'evil.example' },
+      { ...echo, raw: [...echo.raw, 'Forwarded', 'for=evil'] },
+      { ...echo, raw: [...echo.raw, 'X-Forwarded-Host', 'evil.example'] },
+      { ...echo, distinct: { ...echo.distinct, 'x-forwarded-host': ['insurance.example.test:8443', 'evil.example'] } },
+      { ...echo, distinct: { ...echo.distinct, forwarded: [''] } },
+    ]) expect(() => assertD1IngressEcho(invalid)).toThrow('echo')
+  })
+
+  it('rejects image, argv, repository, and mount drift', () => {
+    expect(() => validateD1CaddyImageInspect(JSON.stringify(caddyImage))).not.toThrow()
+    expect(() => validateD1IngressContainerInspect(JSON.stringify(container), source)).not.toThrow()
+    for (const invalid of [
+      [{ ...container[0], Config: { ...container[0].Config, Image: `caddy@sha256:${'0'.repeat(64)}` } }],
+      [{ ...container[0], Config: { ...container[0].Config, Cmd: ['caddy', 'reverse-proxy'] } }],
+      [{ ...container[0], Mounts: [{ ...container[0].Mounts[0], Source: '/other/Caddyfile' }] }],
+      [{ ...container[0], Mounts: [{ ...container[0].Mounts[0], RW: true }] }],
+    ]) expect(() => validateD1IngressContainerInspect(JSON.stringify(invalid), source)).toThrow('container')
+    expect(() => validateD1CaddyImageInspect(JSON.stringify([{ ...caddyImage[0], RepoDigests: ['other@sha256:bad'] }]))).toThrow('image')
+  })
+
+  it('uses structured bounded Docker execution without a shell', async () => {
+    const proofSource = await readFile(new URL('../../../../scripts/d1-ingress-header-proof.ts', import.meta.url), 'utf8')
+    expect(proofSource).toMatch(/spawnSync\('docker'/)
+    expect(proofSource).toMatch(/shell: false/)
+    expect(proofSource).not.toMatch(/execSync|execFileSync|\/bin\/sh|shell: true/)
+  })
+})

--- a/apps/full-app/src/server/deployment/__tests__/edgeNetworkPreflight.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/edgeNetworkPreflight.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { runD1ComposeAction, type D1ComposeProcess, type D1ComposeResult } from '../composeAdapter.js'
+import { D1_CADDY_IMAGE, runD1ComposeAction, type D1ComposeProcess, type D1ComposeResult } from '../composeAdapter.js'
 import { preflightD1EdgeNetwork } from '../edgeNetworkPreflight.js'
 import { D1HostErrorCode } from '../d1Plan.js'
 
@@ -128,7 +128,7 @@ describe('D1 edge-network command ordering', () => {
       environmentRef: 'environment@1', secretRefs: [],
     }],
   }
-  const images = { schemaVersion: 1, ingressImage: `caddy@sha256:${'b'.repeat(64)}`, coreAppImage: `ghcr.io/hachej/boring-ui@${digest}` }
+  const images = { schemaVersion: 1, ingressImage: D1_CADDY_IMAGE, coreAppImage: `ghcr.io/hachej/boring-ui@${digest}` }
 
   it.each(['initial', 'restart-core'] as const)('runs preflight before the %s Compose effect', async (effect) => {
     const runner = preflightRunner()

--- a/apps/full-app/src/server/deployment/composeAdapter.ts
+++ b/apps/full-app/src/server/deployment/composeAdapter.ts
@@ -14,6 +14,7 @@ import {
 
 const CONTROL_KEYS = ['schemaVersion', 'ingressImage', 'coreAppImage'] as const
 const IMAGE_RE = /^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*@sha256:[a-f0-9]{64}$/
+export const D1_CADDY_IMAGE = 'caddy@sha256:af5fdcd76f2db5e4e974ee92f96ee8c0fc3edb55bd4ba5032547cbf3f65e486d'
 const COMPOSE_DIRECTORY = '/opt/boring/d1'
 const COMPOSE_FILE = `${COMPOSE_DIRECTORY}/compose.yml`
 const PROJECT_NAME = 'boring-d1'
@@ -49,7 +50,7 @@ function parseImages(raw: unknown, plan: D1HostPlanV1): D1ComposeImagesV1 {
 
   return Object.freeze({
     schemaVersion: 1,
-    ingressImage: pinnedImage(raw.ingressImage, 'compose.ingressImage'),
+    ingressImage: raw.ingressImage === D1_CADDY_IMAGE ? D1_CADDY_IMAGE : invalid('compose.ingressImage'),
     coreAppImage,
   })
 }

--- a/deploy/d1/Caddyfile
+++ b/deploy/d1/Caddyfile
@@ -1,0 +1,7 @@
+:8080 {
+	reverse_proxy core-app:3000 {
+		header_up -Forwarded
+		header_up Host {hostport}
+		header_up X-Forwarded-Host {hostport}
+	}
+}

--- a/deploy/d1/compose.yml
+++ b/deploy/d1/compose.yml
@@ -1,7 +1,7 @@
 services:
   ingress:
     image: "${D1_INGRESS_IMAGE:?D1_INGRESS_IMAGE is required}"
-    command: ["reverse-proxy", "--from", ":8080", "--to", "core-app:3000"]
+    command: ["caddy", "run", "--config", "/etc/caddy/Caddyfile", "--adapter", "caddyfile"]
     ports:
       - "80:8080"
     depends_on:
@@ -10,6 +10,13 @@ services:
     networks:
       d1-edge:
         ipv4_address: 192.168.255.250
+    volumes:
+      - type: bind
+        source: ./Caddyfile
+        target: /etc/caddy/Caddyfile
+        read_only: true
+        bind:
+          create_host_path: false
     restart: unless-stopped
 
   core-app:


### PR DESCRIPTION
## Summary
- pin D1 ingress to the exact official Caddy 2.11.4 multi-arch digest and reject all other image identities before effects
- replace the broken no-entrypoint command with explicit `caddy run` and mount a repo-owned Caddyfile read-only
- strip RFC Forwarded and replace Host/X-Forwarded-Host with the original direct authority

## Real proof
`{"status":"pass","proof":"d1-ingress-headers","caddyImage":"caddy@sha256:af5fdcd76f2db5e4e974ee92f96ee8c0fc3edb55bd4ba5032547cbf3f65e486d","caddyImageId":"sha256:af555904a0961945f16bb323a501457b13a4f7e9bde969b145b97da80b38ecbe","caddyfileDigest":"sha256:a391f757bc9398e0dbd279e6a503fe608e6571f29c166164ff36552afd0f72c8","cases":9}`

The proof validates the mounted config, exact image/argv/mount, Forwarded absence, one raw canonical XFH, exact Host, bounded structured Docker execution, and zero residual labeled resources.

## Verification
- recut patch ID equals reviewed source commit
- exact-image `caddy validate`
- 50 focused tests
- full-app typecheck
- Compose config validation
- structured autoreview clean; independent security review clean

Issue: #391