### PR TITLE
feat(391): derive trusted D1 host scope

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1Plan.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Plan.test.ts
@@ -69,6 +69,17 @@ describe('parseD1HostPlan', () => {
     }
   })
 
+  it.each(['192.168.1.1', '127.1', '127.0.0.01', '0127.0.0.1', '0x7f.0.0.1'])(
+    'rejects IP-like hostname %s',
+    (hostname) => {
+      expect(() => parseD1HostPlan(plan({ bindings: [binding('a', { hostname })] })))
+        .toThrow(expect.objectContaining({
+          code: D1HostErrorCode.PLAN_INVALID,
+          details: { field: 'bindings[0].hostname' },
+        }))
+    },
+  )
+
   it('admits only binding ids whose .env filename fits NAME_MAX', () => {
     const longest = 'a'.repeat(251)
     expect(parseD1HostPlan(plan({ bindings: [{ ...binding('a'), bindingId: longest }] })).bindings[0].bindingId).toBe(longest)

--- a/apps/full-app/src/server/deployment/__tests__/hostSurface.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/hostSurface.test.ts
@@ -1,0 +1,197 @@
+import { readFile } from 'node:fs/promises'
+
+import { createCoreApp, type CoreRequestScope } from '@hachej/boring-core/server'
+import type { CoreConfig } from '@hachej/boring-core/shared'
+import type { FastifyRequest } from 'fastify'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { D1ActiveCollection, D1ActiveCollectionReader } from '../activeCollectionReader.js'
+import { D1HostErrorCode } from '../d1Plan.js'
+import { createD1HostSurfaceResolver, D1_TRUSTED_CADDY_PEER } from '../hostSurface.js'
+
+const HOST = 'insurance.example.test'
+const CLIENT = '198.51.100.7'
+const scope = {
+  bindingId: 'insurance', workspaceId: 'workspace:insurance',
+  defaultDeploymentId: 'deployment:insurance', activeRevision: 'r0000000042',
+} as const
+
+function collection(hostnames: readonly string[] = [HOST]): D1ActiveCollection {
+  return {
+    active: { schemaVersion: 1, revisionId: scope.activeRevision, desiredStateDigest: `sha256:${'a'.repeat(64)}` },
+    desired: { plan: { bindings: hostnames.map((hostname, index) => ({
+      hostname, bindingId: index === 0 ? scope.bindingId : `binding-${index}`,
+      workspaceId: index === 0 ? scope.workspaceId : `workspace:${index}`,
+      defaultDeploymentId: index === 0 ? scope.defaultDeploymentId : `deployment:${index}`,
+    })) } },
+  } as unknown as D1ActiveCollection
+}
+
+function reader(value: D1ActiveCollection | null = collection(), failure = false) {
+  let calls = 0
+  const activeReader: D1ActiveCollectionReader = {
+    async read() {
+      calls += 1
+      if (failure) throw new Error('/private/host')
+      return value
+    },
+  }
+  return { activeReader, calls: () => calls }
+}
+
+function request(rawHeaders: string[], peer: string | undefined, ips: string[]): FastifyRequest {
+  return { raw: { rawHeaders, socket: { remoteAddress: peer } }, ips } as unknown as FastifyRequest
+}
+
+function resolver(activeReader: D1ActiveCollectionReader) {
+  return createD1HostSurfaceResolver({ activeReader, trustedPeer: D1_TRUSTED_CADDY_PEER })
+}
+
+async function violation(action: Promise<unknown>): Promise<void> {
+  const error = await action.catch((caught) => caught)
+  expect(error).toMatchObject({ status: 421, code: D1HostErrorCode.HOST_SCOPE_VIOLATION, message: D1HostErrorCode.HOST_SCOPE_VIOLATION })
+  expect(JSON.stringify(error)).not.toMatch(/insurance|workspace|private|host-1|198\.51/)
+}
+
+const TEST_CONFIG: CoreConfig = {
+  appId: 'test', appName: 'Test', appLogo: null, port: 0, host: '127.0.0.1', staticDir: null,
+  databaseUrl: null, stores: 'local', cors: { origins: [], credentials: true }, bodyLimit: 1024 * 1024, logLevel: 'fatal',
+  security: { trustedProxy: { cidrs: [`${D1_TRUSTED_CADDY_PEER}/32`], hops: 1 }, csp: { enabled: false } },
+  encryption: { workspaceSettingsKey: 'a'.repeat(64) },
+  auth: { secret: 's'.repeat(64), url: 'http://localhost:3000', sessionTtlSeconds: 3600, sessionCookieSecure: false },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: false, sendWelcomeEmail: false, inviteTtlDays: 7 },
+}
+
+let app: Awaited<ReturnType<typeof createCoreApp>> | undefined
+afterEach(async () => { await app?.close(); app = undefined })
+
+describe('D1 host surface resolver', () => {
+  it('resolves direct and exact-Caddy authorities per request as frozen four-key scopes', async () => {
+    const state = reader(); const resolve = resolver(state.activeReader)
+    const direct = await resolve(request(['Host', HOST], CLIENT, [CLIENT]))
+    const caddy = await resolve(request(
+      ['Host', HOST, 'X-Forwarded-Host', HOST, 'X-Forwarded-For', CLIENT],
+      D1_TRUSTED_CADDY_PEER,
+      [D1_TRUSTED_CADDY_PEER, CLIENT],
+    ))
+    for (const result of [direct, caddy]) {
+      expect(result).toEqual(scope)
+      expect(Object.keys(result)).toEqual(['bindingId', 'workspaceId', 'defaultDeploymentId', 'activeRevision'])
+      expect(Object.isFrozen(result)).toBe(true)
+    }
+    expect(state.calls()).toBe(2)
+  })
+
+  it.each([
+    ['Forwarded empty/repeated', ['Host', HOST, 'Forwarded', '', 'FORWARDED', 'for=evil'], CLIENT, [CLIENT]],
+    ['missing Host', [], CLIENT, [CLIENT]],
+    ['repeated Host', ['Host', HOST, 'host', HOST], CLIENT, [CLIENT]],
+    ['direct XFH', ['Host', HOST, 'X-Forwarded-Host', HOST], CLIENT, [CLIENT]],
+    ['direct XFF', ['Host', HOST, 'X-Forwarded-For', CLIENT], CLIENT, [CLIENT]],
+    ['direct proxy chain', ['Host', HOST], CLIENT, [CLIENT, '192.0.2.1']],
+    ['missing direct peer', ['Host', HOST], undefined, []],
+    ['Caddy missing XFH', ['Host', HOST], D1_TRUSTED_CADDY_PEER, [D1_TRUSTED_CADDY_PEER, CLIENT]],
+    ['Caddy missing XFF', ['Host', HOST, 'X-Forwarded-Host', HOST], D1_TRUSTED_CADDY_PEER, [D1_TRUSTED_CADDY_PEER, CLIENT]],
+    ['Caddy empty XFF', ['Host', HOST, 'X-Forwarded-Host', HOST, 'X-Forwarded-For', ''], D1_TRUSTED_CADDY_PEER, [D1_TRUSTED_CADDY_PEER, CLIENT]],
+    ['Caddy comma XFF', ['Host', HOST, 'X-Forwarded-Host', HOST, 'X-Forwarded-For', `${CLIENT}, 192.0.2.1`], D1_TRUSTED_CADDY_PEER, [D1_TRUSTED_CADDY_PEER, CLIENT]],
+    ['Caddy repeated XFF', ['Host', HOST, 'X-Forwarded-Host', HOST, 'X-Forwarded-For', CLIENT, 'x-forwarded-for', CLIENT], D1_TRUSTED_CADDY_PEER, [D1_TRUSTED_CADDY_PEER, CLIENT]],
+    ['Caddy mismatched XFF', ['Host', HOST, 'X-Forwarded-Host', HOST, 'X-Forwarded-For', '192.0.2.1'], D1_TRUSTED_CADDY_PEER, [D1_TRUSTED_CADDY_PEER, CLIENT]],
+    ['Caddy repeated XFH', ['Host', HOST, 'X-Forwarded-Host', HOST, 'x-forwarded-host', HOST, 'X-Forwarded-For', CLIENT], D1_TRUSTED_CADDY_PEER, [D1_TRUSTED_CADDY_PEER, CLIENT]],
+    ['Caddy mismatched XFH', ['Host', HOST, 'X-Forwarded-Host', 'other.example.test', 'X-Forwarded-For', CLIENT], D1_TRUSTED_CADDY_PEER, [D1_TRUSTED_CADDY_PEER, CLIENT]],
+    ['Caddy short chain', ['Host', HOST, 'X-Forwarded-Host', HOST, 'X-Forwarded-For', CLIENT], D1_TRUSTED_CADDY_PEER, [D1_TRUSTED_CADDY_PEER]],
+    ['Caddy wrong chain', ['Host', HOST, 'X-Forwarded-Host', HOST, 'X-Forwarded-For', CLIENT], D1_TRUSTED_CADDY_PEER, [CLIENT, D1_TRUSTED_CADDY_PEER]],
+    ['odd raw headers', ['Host'], CLIENT, [CLIENT]],
+  ])('rejects malformed %s input', async (_name, headers, peer, ips) => {
+    await violation(Promise.resolve(resolver(reader().activeReader)(request(headers, peer, ips))))
+  })
+
+  it.each([
+    'Insurance.example.test', 'insurance.example.test:443', 'insurance.example.test.', '*.example.test',
+    'https://insurance.example.test', 'example.test/path', 'user@example.test', 'éxample.test',
+    ' example.test', 'example.test ', 'example.test,evil.test', '192.168.1.1', '127.1',
+    '127.0.0.01', '0127.0.0.1', '0x7f.0.0.1', 'localhost',
+  ])('rejects noncanonical hostname %s', async (hostname) => {
+    await violation(Promise.resolve(resolver(reader().activeReader)(request(['Host', hostname], CLIENT, [CLIENT]))))
+  })
+
+  it('rejects absent, unreadable, unknown, and duplicate active bindings', async () => {
+    for (const state of [reader(null), reader(collection(), true), reader(collection(['other.example.test'])), reader(collection([HOST, HOST]))]) {
+      await violation(Promise.resolve(resolver(state.activeReader)(request(['Host', HOST], CLIENT, [CLIENT]))))
+    }
+    expect(() => createD1HostSurfaceResolver({ activeReader: reader().activeReader, trustedPeer: '192.168.255.251' }))
+      .toThrow(expect.objectContaining({ code: D1HostErrorCode.PLAN_INVALID, details: { field: 'trustedPeer' } }))
+  })
+
+  it('fails with exact generic 421 before later auth/rate/handler effects', async () => {
+    const order: string[] = []
+    app = await createCoreApp(TEST_CONFIG, { manageShutdown: false, requestScopeResolver: resolver(reader(collection(['other.example.test'])).activeReader) })
+    app.addHook('onRequest', async () => { order.push('auth') })
+    app.post('/auth/sign-in/email', async () => { order.push('handler'); return { ok: true } })
+    await app.ready()
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const response = await app.inject({ method: 'POST', url: '/auth/sign-in/email', remoteAddress: CLIENT, headers: { host: HOST } })
+      expect(response.statusCode).toBe(421)
+      expect(JSON.parse(response.body)).toMatchObject({
+        error: D1HostErrorCode.HOST_SCOPE_VIOLATION, code: D1HostErrorCode.HOST_SCOPE_VIOLATION,
+        message: D1HostErrorCode.HOST_SCOPE_VIOLATION, requestId: expect.any(String),
+      })
+      expect(response.body).not.toMatch(/insurance|workspace|other\.example/)
+    }
+    expect(order).toEqual([])
+  })
+
+  it('uses Fastify exact-proxy ordering and rejects a forwarded extra hop', async () => {
+    app = await createCoreApp(TEST_CONFIG, {
+      manageShutdown: false,
+      requestScopeResolver: resolver(reader().activeReader),
+    })
+    app.get('/scope', async (request) => request.requestScope)
+    await app.ready()
+
+    const accepted = await app.inject({
+      method: 'GET',
+      url: '/scope',
+      remoteAddress: D1_TRUSTED_CADDY_PEER,
+      headers: { host: HOST, 'x-forwarded-host': HOST, 'x-forwarded-for': CLIENT },
+    })
+    expect(accepted.statusCode).toBe(200)
+    expect(accepted.json()).toEqual(scope)
+
+    const rejected = await app.inject({
+      method: 'GET',
+      url: '/scope',
+      remoteAddress: D1_TRUSTED_CADDY_PEER,
+      headers: {
+        host: HOST,
+        'x-forwarded-host': HOST,
+        'x-forwarded-for': `${CLIENT}, 192.0.2.1`,
+      },
+    })
+    expect(rejected.statusCode).toBe(421)
+    expect(rejected.json()).toMatchObject({
+      error: D1HostErrorCode.HOST_SCOPE_VIOLATION,
+      code: D1HostErrorCode.HOST_SCOPE_VIOLATION,
+      message: D1HostErrorCode.HOST_SCOPE_VIOLATION,
+    })
+    expect(rejected.body).not.toMatch(/insurance|192\.0\.2/)
+  })
+
+  it('keeps generic apps undecorated and response bytes unchanged when absent', async () => {
+    app = await createCoreApp(TEST_CONFIG, { manageShutdown: false })
+    expect(app.hasRequestDecorator('requestScope')).toBe(false)
+    app.get('/generic', async () => ({ ok: true })); await app.ready()
+    expect((await app.inject({ method: 'GET', url: '/generic' })).body).toBe('{"ok":true}')
+  })
+
+  it('attaches only a frozen four-key scope and performs no auth or membership lookup', async () => {
+    const extra = { ...scope, ignored: 'value' } as CoreRequestScope
+    app = await createCoreApp(TEST_CONFIG, { manageShutdown: false, requestScopeResolver: async () => extra })
+    app.get('/scope', async (request) => ({ keys: Object.keys(request.requestScope!), frozen: Object.isFrozen(request.requestScope) }))
+    await app.ready()
+    expect(JSON.parse((await app.inject({ method: 'GET', url: '/scope' })).body)).toEqual({
+      keys: ['bindingId', 'workspaceId', 'defaultDeploymentId', 'activeRevision'], frozen: true,
+    })
+    const source = await readFile(new URL('../hostSurface.ts', import.meta.url), 'utf8')
+    expect(source).not.toMatch(/workspaceStore|isMember|membership|authenticate|cache|watch|landing/)
+  })
+})

--- a/apps/full-app/src/server/deployment/d1Plan.ts
+++ b/apps/full-app/src/server/deployment/d1Plan.ts
@@ -1,3 +1,4 @@
+import { isIP } from 'node:net'
 import { OpaqueRefSchema, type Sha256Digest } from '@hachej/boring-agent/shared'
 
 export const D1HostErrorCode = {
@@ -11,6 +12,7 @@ export const D1HostErrorCode = {
   COLLECTION_NOT_READY: 'D1_COLLECTION_NOT_READY',
   PUBLICATION_FAILED: 'D1_PUBLICATION_FAILED',
   ROLLBACK_TARGET_INVALID: 'D1_ROLLBACK_TARGET_INVALID',
+  HOST_SCOPE_VIOLATION: 'D1_HOST_SCOPE_VIOLATION',
 } as const
 
 export type D1HostErrorCode = typeof D1HostErrorCode[keyof typeof D1HostErrorCode]
@@ -58,6 +60,7 @@ const LANDING_KEYS = ['title', 'summary', 'ctaLabel'] as const
 const REF_RE = /^[A-Za-z0-9][A-Za-z0-9._@-]{0,255}$/
 const DIGEST_RE = /^sha256:[a-f0-9]{64}$/
 const HOST_RE = /^(?=.{1,253}$)(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/
+const LEGACY_IPV4_COMPONENT_RE = /^(?:0x[0-9a-f]+|0[0-7]*|[1-9][0-9]*)$/
 
 export function invalidD1Field(field: string): never {
   throw new D1HostError(D1HostErrorCode.PLAN_INVALID, { field })
@@ -89,6 +92,14 @@ export function strictD1HostId(value: unknown, field: string): string {
   return hostId
 }
 
+export function strictD1Hostname(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !HOST_RE.test(value)) invalidD1Field(field)
+  const parts = value.split('.')
+  const isLegacyIpv4 = parts.length <= 4 && parts.every((part) => LEGACY_IPV4_COMPONENT_RE.test(part))
+  if (isIP(value) !== 0 || isLegacyIpv4) invalidD1Field(field)
+  return value
+}
+
 function agentRef(value: unknown, field: string): string {
   const parsed = OpaqueRefSchema.safeParse(value)
   if (!parsed.success) invalidD1Field(field)
@@ -118,13 +129,13 @@ function parseBinding(value: unknown, index: number): D1SiteBindingV1 {
   if (!Array.isArray(input.secretRefs)) invalidD1Field(`${field}.secretRefs`)
   const secretRefs = input.secretRefs.map((value, secretIndex) => strictD1Ref(value, `${field}.secretRefs[${secretIndex}]`)).sort()
   unique(secretRefs, `${field}.secretRefs`)
-  if (typeof input.hostname !== 'string' || !HOST_RE.test(input.hostname)) invalidD1Field(`${field}.hostname`)
+  const hostname = strictD1Hostname(input.hostname, `${field}.hostname`)
   const bindingId = strictD1Ref(input.bindingId, `${field}.bindingId`)
   if (bindingId.length > 251) invalidD1Field(`${field}.bindingId`)
 
   return Object.freeze({
     bindingId,
-    hostname: input.hostname,
+    hostname,
     workspaceId: agentRef(input.workspaceId, `${field}.workspaceId`),
     defaultDeploymentId: agentRef(input.defaultDeploymentId, `${field}.defaultDeploymentId`),
     bundleRef: strictD1Ref(input.bundleRef, `${field}.bundleRef`),

--- a/apps/full-app/src/server/deployment/hostSurface.ts
+++ b/apps/full-app/src/server/deployment/hostSurface.ts
@@ -1,0 +1,89 @@
+import { isIP } from 'node:net'
+
+import { ERROR_CODES, HttpError } from '@hachej/boring-core/shared'
+import type { CoreRequestScopeResolver } from '@hachej/boring-core/server'
+
+import type { D1ActiveCollectionReader } from './activeCollectionReader.js'
+import { D1HostErrorCode, invalidD1Field, strictD1Hostname } from './d1Plan.js'
+
+export const D1_TRUSTED_CADDY_PEER = '192.168.255.250'
+
+export interface D1HostSurfaceOptions {
+  readonly activeReader: D1ActiveCollectionReader
+  readonly trustedPeer: string
+}
+
+function violation(): never {
+  throw new HttpError({
+    status: 421,
+    code: ERROR_CODES.D1_HOST_SCOPE_VIOLATION,
+    message: D1HostErrorCode.HOST_SCOPE_VIOLATION,
+  })
+}
+
+function rawValues(rawHeaders: readonly string[], name: string): readonly string[] {
+  if (rawHeaders.length % 2 !== 0) violation()
+  const values: string[] = []
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    if (rawHeaders[index]!.toLowerCase() === name) values.push(rawHeaders[index + 1]!)
+  }
+  return values
+}
+
+export function createD1HostSurfaceResolver(options: D1HostSurfaceOptions): CoreRequestScopeResolver {
+  if (options.trustedPeer !== D1_TRUSTED_CADDY_PEER) invalidD1Field('trustedPeer')
+  return async (request) => {
+    const forwarded = rawValues(request.raw.rawHeaders, 'forwarded')
+    const hosts = rawValues(request.raw.rawHeaders, 'host')
+    const forwardedFor = rawValues(request.raw.rawHeaders, 'x-forwarded-for')
+    const forwardedHosts = rawValues(request.raw.rawHeaders, 'x-forwarded-host')
+    if (forwarded.length !== 0 || hosts.length !== 1) violation()
+    const peer = request.raw.socket.remoteAddress
+    const ips = request.ips
+    if (!ips) violation()
+    let authority: string
+    if (peer === options.trustedPeer) {
+      if (
+        ips.length !== 2
+        || ips[0] !== options.trustedPeer
+        || forwardedFor.length !== 1
+        || isIP(forwardedFor[0]!) === 0
+        || forwardedFor[0] !== forwardedFor[0]!.trim()
+        || forwardedFor[0] !== ips[1]
+        || forwardedHosts.length !== 1
+        || hosts[0] !== forwardedHosts[0]
+      ) violation()
+      authority = forwardedHosts[0]!
+    } else {
+      if (
+        typeof peer !== 'string'
+        || ips.length !== 1
+        || ips[0] !== peer
+        || forwardedFor.length !== 0
+        || forwardedHosts.length !== 0
+      ) violation()
+      authority = hosts[0]!
+    }
+    try {
+      strictD1Hostname(authority, 'hostname')
+    } catch {
+      violation()
+    }
+    let collection
+    try {
+      collection = await options.activeReader.read()
+    } catch {
+      violation()
+    }
+    if (!collection) violation()
+    const matches = collection.desired.plan.bindings.filter((binding) => binding.hostname === authority)
+    if (matches.length !== 1) violation()
+    const binding = matches[0]!
+    return Object.freeze({
+      bindingId: binding.bindingId,
+      workspaceId: binding.workspaceId,
+      defaultDeploymentId: binding.defaultDeploymentId,
+      activeRevision: collection.active.revisionId,
+    })
+  }
+}

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -52,6 +52,7 @@ import {
   registerRoutes,
   type UserStore,
   type WorkspaceStore,
+  type CoreRequestScopeResolver,
 } from '../../server/app/index.js'
 import {
   registerInviteRoutes,
@@ -181,6 +182,7 @@ export interface CreateCoreWorkspaceAgentServerOptions
   telemetry?: TelemetrySink
   /** Verified actor resolver exposed only to boot-time internal plugins. */
   trustedPluginActorResolver?: NonNullable<WorkspaceAgentServerPluginContext['trusted']>['actorResolver']
+  requestScopeResolver?: CoreRequestScopeResolver
 }
 
 type AgentPiOptions = RegisterAgentRoutesOptions['pi']
@@ -617,7 +619,7 @@ async function registerFrontendFallback(
   })
 }
 
-async function createCoreRuntime(config: CoreConfig, customTelemetry?: TelemetrySink): Promise<{
+async function createCoreRuntime(config: CoreConfig, customTelemetry?: TelemetrySink, requestScopeResolver?: CoreRequestScopeResolver): Promise<{
   app: CoreWorkspaceAgentServer
   sql: postgres.Sql
   db: Database
@@ -637,7 +639,7 @@ async function createCoreRuntime(config: CoreConfig, customTelemetry?: Telemetry
     config.encryption.workspaceSettingsKey,
   )
 
-  const app = await createCoreApp(config) as CoreWorkspaceAgentServer
+  const app = await createCoreApp(config, { requestScopeResolver }) as CoreWorkspaceAgentServer
   // Resolve the telemetry sink here (db exists now) so the auth hooks get a plain sink.
   const telemetry = customTelemetry ?? createDatabaseTelemetryFromEnv(db, { appId: config.appId }, process.env)
   const telemetrySource = customTelemetry
@@ -699,7 +701,7 @@ export async function createCoreWorkspaceAgentServer(
   assertCoreStaticPluginEntries(options.plugins)
 
   const config = options.config ?? (await loadConfig(resolveCoreLoadConfigOptions(options)))
-  const { app, sql, db, userStore, workspaceStore, telemetry } = await createCoreRuntime(config, options.telemetry)
+  const { app, sql, db, userStore, workspaceStore, telemetry } = await createCoreRuntime(config, options.telemetry, options.requestScopeResolver)
   const appRoot = options.appRoot
   const serveFrontend =
     options.serveFrontend ?? (process.env.NODE_ENV !== 'development' && Boolean(appRoot))

--- a/packages/core/src/app/server/index.ts
+++ b/packages/core/src/app/server/index.ts
@@ -4,6 +4,7 @@ export {
   type CoreWorkspaceAgentServerPlugin,
   type CreateCoreWorkspaceAgentServerOptions,
 } from './createCoreWorkspaceAgentServer.js'
+export type { CoreRequestScope, CoreRequestScopeResolver } from '../../server/app/index.js'
 export {
   startCoreWorkspaceAgentDevServer,
   startCoreWorkspaceAgentDevServerFromMeta,

--- a/packages/core/src/server/app/createCoreApp.ts
+++ b/packages/core/src/server/app/createCoreApp.ts
@@ -5,6 +5,7 @@ import helmet from '@fastify/helmet'
 import proxyAddr from '@fastify/proxy-addr'
 import type { IncomingMessage } from 'node:http'
 import { randomBytes, randomUUID } from 'node:crypto'
+import { ERROR_CODES, HttpError } from '../../shared/errors.js'
 import type { CoreConfig } from '../../shared/types.js'
 import type { CreateCoreAppOptions } from './types.js'
 import { registerErrorHandler } from './errorHandler.js'
@@ -290,6 +291,36 @@ export async function createCoreApp(
   })
 
   registerErrorHandler(app)
+  if (options?.requestScopeResolver) {
+    const resolveRequestScope = options.requestScopeResolver
+    app.decorateRequest('requestScope')
+    app.addHook('onRequest', async (request) => {
+      let scope
+      try {
+        scope = await resolveRequestScope(request)
+      } catch (error) {
+        if (
+          typeof error === 'object'
+          && error !== null
+          && 'code' in error
+          && error.code === ERROR_CODES.D1_HOST_SCOPE_VIOLATION
+        ) {
+          throw new HttpError({
+            status: 421,
+            code: ERROR_CODES.D1_HOST_SCOPE_VIOLATION,
+            message: ERROR_CODES.D1_HOST_SCOPE_VIOLATION,
+          })
+        }
+        throw error
+      }
+      request.requestScope = Object.freeze({
+        bindingId: scope.bindingId,
+        workspaceId: scope.workspaceId,
+        defaultDeploymentId: scope.defaultDeploymentId,
+        activeRevision: scope.activeRevision,
+      })
+    })
+  }
   registerCapabilities(app)
   await registerRateLimits(app)
 

--- a/packages/core/src/server/app/index.ts
+++ b/packages/core/src/server/app/index.ts
@@ -9,4 +9,6 @@ export type {
   WorkspaceStore,
   AuthProvider,
   CapabilitiesContributor,
+  CoreRequestScope,
+  CoreRequestScopeResolver,
 } from './types.js'

--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -1,4 +1,4 @@
-import type { FastifyInstance } from 'fastify'
+import type { FastifyInstance, FastifyRequest } from 'fastify'
 import type {
   CoreConfig,
   CapabilitiesResponse,
@@ -94,12 +94,22 @@ export type CapabilitiesContributor = (ctx: {
   config: CoreConfig
 }) => Partial<CapabilitiesResponse> | Promise<Partial<CapabilitiesResponse>>
 
+export interface CoreRequestScope {
+  readonly bindingId: string
+  readonly workspaceId: string
+  readonly defaultDeploymentId: string
+  readonly activeRevision: string
+}
+
+export type CoreRequestScopeResolver = (request: FastifyRequest) => CoreRequestScope | Promise<CoreRequestScope>
+
 export interface CreateCoreAppOptions {
   authProvider?: AuthProvider
   userStore?: UserStore
   workspaceStore?: WorkspaceStore
   provisioner?: WorkspaceProvisioner
   manageShutdown?: boolean
+  requestScopeResolver?: CoreRequestScopeResolver
 }
 
 declare module 'fastify' {
@@ -117,5 +127,6 @@ declare module 'fastify' {
   interface FastifyRequest {
     user?: { id: string; email: string; name: string | null; emailVerified: boolean } | null
     cspNonce?: string
+    requestScope?: CoreRequestScope
   }
 }

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -9,7 +9,7 @@ export type { LoadConfigOptions } from './config/index.js'
 export { safeRedirect } from './security/index.js'
 
 export { createCoreApp, registerRoutes, withUserSettingsWriteLock } from './app/index.js'
-export type { CreateCoreAppOptions, RoutesOptions, UserStore, WorkspaceStore, AuthProvider, CapabilitiesContributor } from './app/index.js'
+export type { CreateCoreAppOptions, RoutesOptions, UserStore, WorkspaceStore, AuthProvider, CapabilitiesContributor, CoreRequestScope, CoreRequestScopeResolver } from './app/index.js'
 
 export { createMailTransport, MailDeliveryError } from './mail/index.js'
 export type { MailTransport, RenderedEmail } from './mail/index.js'

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -32,6 +32,7 @@ export const ERROR_CODES = {
   MAIL_DISABLED: 'mail_disabled',
   DB_UNAVAILABLE: 'db_unavailable',
   INTERNAL_ERROR: 'internal_error',
+  D1_HOST_SCOPE_VIOLATION: 'D1_HOST_SCOPE_VIOLATION',
 
   // Credits + purchases
   PAYMENT_REQUIRED: 'payment_required',


### PR DESCRIPTION
## Summary

Add the D1-004a3b trusted host-scope boundary: exact raw authority/proxy validation, per-request active binding resolution, and a narrow optional pre-auth core scope hook.

## Issue / Slice

#391 — D1-004a3b only. Production reader construction and `main.ts` activation remain explicitly owned by D1-004a4.

## What Changed

- resolves one direct authority or exact Caddy peer/XFH/XFF chain against the active collection
- rejects RFC Forwarded, duplicate/ambiguous headers, hidden proxy hops, unknown hosts, IP and legacy numeric-IP host aliases
- attaches a frozen four-field scope before rate limits/auth
- returns only stable generic `D1_HOST_SCOPE_VIOLATION` / HTTP 421
- preserves generic app behavior when the optional resolver is absent

## Proof

- `pnpm run build:packages` — pass; artifact assertions pass (existing workspace declaration-bundler warning only)
- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/d1Plan.test.ts src/server/deployment/__tests__/hostSurface.test.ts` — 54/54 pass
- `pnpm --filter @hachej/boring-core exec vitest run src/server/app/__tests__/createCoreApp.test.ts src/server/app/__tests__/errorHandler.test.ts` — 23/23 pass
- `pnpm --filter full-app run typecheck` — pass
- `pnpm --filter @hachej/boring-core run typecheck` — pass
- `git diff --check HEAD^ HEAD` — pass

## Review

- independent security review found and fixed raw-XFF hop truncation plus legacy IPv4 aliases; re-review CLEAN
- structured autoreview command: `/home/ubuntu/.agents/skills/coding-autoreview/scripts/autoreview --mode commit --commit HEAD`
- autoreview repeated one finding: wire the resolver in `main.ts`; rejected because the binding D1-R0 contract assigns owner UID/GID reader construction, loopback readiness bypass, and production activation atomically to D1-004a4. Activating in a3b would break initial Compose health before an active pointer exists.
- reviewed source patch ID and recut patch ID: `cb3bfa8ba6baa45dfbda2ad94ec9cc17eabfbf88`
- reviewed/pushed SHA: `f79b487ba54b4500b31f19f9a904221307bcee74`

## Risk / Rollback

The core seam is optional and inactive unless supplied. Revert the single commit to remove it. The D1 resolver is deliberately not production-active until D1-004a4 completes its required construction and health bypass.

## Next

D1-004a4a: bounded root-handler seam and escaped landing; then D1-004a4b: loopback readiness, exact owner UID/GID reader construction, and `main.ts` activation.