### PR TITLE
feat(391): render bounded D1 landing

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1Landing.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Landing.test.ts
@@ -1,0 +1,142 @@
+import { readFile } from 'node:fs/promises'
+
+import Fastify, { type FastifyInstance } from 'fastify'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { D1ActiveCollection, D1ActiveCollectionReader } from '../activeCollectionReader.js'
+import { createD1LandingRootHandler } from '../d1Landing.js'
+import { D1HostErrorCode, type D1SiteBindingV1 } from '../d1Plan.js'
+
+const scope = Object.freeze({
+  bindingId: 'insurance', workspaceId: 'workspace:insurance',
+  defaultDeploymentId: 'deployment:insurance', activeRevision: 'r0000000042',
+})
+
+function binding(landing: D1SiteBindingV1['landing'] = { title: 'Insurance', summary: 'Compare policies.', ctaLabel: 'Start' }): D1SiteBindingV1 {
+  return {
+    bindingId: scope.bindingId, hostname: 'insurance.example.test', workspaceId: scope.workspaceId,
+    defaultDeploymentId: scope.defaultDeploymentId, bundleRef: 'bundle', deploymentRef: 'deployment',
+    workspaceAllocationRef: 'workspace-allocation', sessionAllocationRef: 'session-allocation',
+    ownerPrincipalRef: 'private-owner', landing, environmentRef: 'production', secretRefs: [],
+  }
+}
+
+function collection(overrides: { revision?: string, bindings?: readonly D1SiteBindingV1[] } = {}): D1ActiveCollection {
+  return {
+    active: { schemaVersion: 1, revisionId: overrides.revision ?? scope.activeRevision, desiredStateDigest: `sha256:${'a'.repeat(64)}` },
+    desired: { plan: { bindings: overrides.bindings ?? [binding()] } },
+  } as unknown as D1ActiveCollection
+}
+
+function reader(value: D1ActiveCollection | null = collection(), failure = false) {
+  let calls = 0
+  const activeReader: D1ActiveCollectionReader = { async read() { calls += 1; if (failure) throw new Error('/private/revision'); return value } }
+  return { activeReader, calls: () => calls }
+}
+
+let app: FastifyInstance | undefined
+afterEach(async () => { await app?.close(); app = undefined })
+
+async function build(activeReader: D1ActiveCollectionReader, rejectHost = false): Promise<FastifyInstance> {
+  const instance = Fastify()
+  instance.decorateRequest('requestScope')
+  instance.decorateRequest('user')
+  instance.addHook('onRequest', async (request, reply) => {
+    if (rejectHost) return reply.status(421).send({ code: D1HostErrorCode.HOST_SCOPE_VIOLATION })
+    request.requestScope = scope
+    request.user = request.headers.authorization ? { id: 'user', email: 'user@example.test', name: null, emailVerified: true } : null
+  })
+  const root = createD1LandingRootHandler({ activeReader })
+  instance.get('/', async (request, reply) => {
+    if (await root(request, reply)) return reply
+    return reply.type('text/html; charset=utf-8').send('<!doctype html><p>spa shell</p>')
+  })
+  await instance.ready()
+  return instance
+}
+
+describe('D1 landing root handler', () => {
+  it('renders only escaped bounded landing text with a fixed same-origin sign-in target', async () => {
+    const state = reader(collection({ bindings: [binding({
+      title: `Policies & <quotes> " ' é`, summary: '<script>safe Unicode ø</script>', ctaLabel: 'Compare & go',
+    })] }))
+    app = await build(state.activeReader)
+    const response = await app.inject({ method: 'GET', url: '/?redirect=https://evil.example', headers: { host: 'insurance.example.test' } })
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['cache-control']).toBe('no-store')
+    expect(response.headers['content-type']).toBe('text/html; charset=utf-8')
+    expect(response.body).toContain('Policies &amp; &lt;quotes&gt; &quot; &#39; é')
+    expect(response.body).toContain('&lt;script&gt;safe Unicode ø&lt;/script&gt;')
+    expect(response.body).toContain('<a href="/auth/signin?redirect=%2F">Compare &amp; go</a>')
+    expect(response.body).not.toContain('evil.example')
+    expect(response.body).not.toMatch(/<script|style=|private-owner|workspace:insurance|deployment:insurance/)
+    expect(state.calls()).toBe(1)
+  })
+
+  it('declines authenticated roots to the existing SPA without reading publication state', async () => {
+    const state = reader()
+    app = await build(state.activeReader)
+    const response = await app.inject({ method: 'GET', url: '/', headers: { authorization: 'session' } })
+    expect(response.body).toBe('<!doctype html><p>spa shell</p>')
+    expect(state.calls()).toBe(0)
+  })
+
+  it('uses the server-owned CTA default and accepts the exact landing text bounds', async () => {
+    const state = reader(collection({ bindings: [binding({ title: 'T'.repeat(120), summary: 'S'.repeat(500), ctaLabel: 'C'.repeat(80) })] }))
+    app = await build(state.activeReader)
+    expect((await app.inject({ method: 'GET', url: '/' })).body).toContain(`<a href="/auth/signin?redirect=%2F">${'C'.repeat(80)}</a>`)
+    await app.close(); app = await build(reader(collection({ bindings: [binding({ title: 'Title', summary: 'Summary' })] })).activeReader)
+    expect((await app.inject({ method: 'GET', url: '/' })).body).toContain('<a href="/auth/signin?redirect=%2F">Sign in</a>')
+  })
+
+  it.each([
+    ['title over limit', { title: 'T'.repeat(121), summary: 'Summary' }],
+    ['summary over limit', { title: 'Title', summary: 'S'.repeat(501) }],
+    ['CTA over limit', { title: 'Title', summary: 'Summary', ctaLabel: 'C'.repeat(81) }],
+    ['title control character', { title: 'Bad\nTitle', summary: 'Summary' }],
+    ['summary control character', { title: 'Title', summary: 'Bad\u0000Summary' }],
+    ['CTA control character', { title: 'Title', summary: 'Summary', ctaLabel: 'Bad\tCTA' }],
+  ])('rejects %s even when a caller bypasses the validated reader', async (_name, landing) => {
+    app = await build(reader(collection({ bindings: [binding(landing)] })).activeReader)
+    const response = await app.inject({ method: 'GET', url: '/' })
+    expect(response.statusCode).toBe(503)
+    expect(response.json()).toEqual({
+      error: D1HostErrorCode.COLLECTION_NOT_READY,
+      code: D1HostErrorCode.COLLECTION_NOT_READY,
+      message: D1HostErrorCode.COLLECTION_NOT_READY,
+    })
+  })
+
+  it.each([
+    ['missing collection', null, false],
+    ['read failure', collection(), true],
+    ['revision drift', collection({ revision: 'r0000000043' }), false],
+    ['binding drift', collection({ bindings: [{ ...binding(), bindingId: 'other' }] }), false],
+    ['workspace drift', collection({ bindings: [{ ...binding(), workspaceId: 'workspace:other' }] }), false],
+    ['deployment drift', collection({ bindings: [{ ...binding(), defaultDeploymentId: 'deployment:other' }] }), false],
+    ['duplicate binding', collection({ bindings: [binding(), binding()] }), false],
+  ])('fails closed and redacted on %s', async (_name, value, failure) => {
+    app = await build(reader(value, failure).activeReader)
+    const response = await app.inject({ method: 'GET', url: '/' })
+    expect(response.statusCode).toBe(503)
+    expect(response.headers['cache-control']).toBe('no-store')
+    expect(response.json()).toEqual({
+      error: D1HostErrorCode.COLLECTION_NOT_READY,
+      code: D1HostErrorCode.COLLECTION_NOT_READY,
+      message: D1HostErrorCode.COLLECTION_NOT_READY,
+    })
+    expect(response.body).not.toMatch(/insurance|workspace|deployment|private|revision/)
+  })
+
+  it('is not invoked when an earlier host-scope hook rejects the request', async () => {
+    const state = reader()
+    app = await build(state.activeReader, true)
+    expect((await app.inject({ method: 'GET', url: '/' })).statusCode).toBe(421)
+    expect(state.calls()).toBe(0)
+  })
+
+  it('contains no workspace, membership, request URL, or internal-id lookup', async () => {
+    const source = await readFile(new URL('../d1Landing.ts', import.meta.url), 'utf8')
+    expect(source).not.toMatch(/workspaceStore|isMember|membership|request\.url|request\.headers|ownerPrincipalRef/)
+  })
+})

--- a/apps/full-app/src/server/deployment/d1Landing.ts
+++ b/apps/full-app/src/server/deployment/d1Landing.ts
@@ -1,0 +1,54 @@
+import type { CoreFrontendRootHandler } from '@hachej/boring-core/app/server'
+
+import type { D1ActiveCollectionReader } from './activeCollectionReader.js'
+import { D1HostErrorCode, type D1SiteBindingV1 } from './d1Plan.js'
+
+const SIGN_IN_PATH = '/auth/signin?redirect=%2F'
+
+export interface D1LandingOptions {
+  readonly activeReader: D1ActiveCollectionReader
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+  })[character]!)
+}
+
+function validText(value: unknown, max: number): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= max && !/[\0-\x1f\x7f]/.test(value)
+}
+
+function renderLanding(binding: D1SiteBindingV1): string | null {
+  const { title, summary, ctaLabel } = binding.landing
+  if (!validText(title, 120) || !validText(summary, 500) || (ctaLabel !== undefined && !validText(ctaLabel, 80))) return null
+  const cta = escapeHtml(ctaLabel ?? 'Sign in')
+  return '<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>'
+    + `${escapeHtml(title)}</title></head><body><main><h1>${escapeHtml(title)}</h1><p>${escapeHtml(summary)}</p>`
+    + `<a href="${SIGN_IN_PATH}">${cta}</a></main></body></html>`
+}
+
+function unavailable(reply: Parameters<CoreFrontendRootHandler>[1]): true {
+  const code = D1HostErrorCode.COLLECTION_NOT_READY
+  reply.status(503).header('cache-control', 'no-store').send({ error: code, code, message: code })
+  return true
+}
+
+export function createD1LandingRootHandler(options: D1LandingOptions): CoreFrontendRootHandler {
+  return async (request, reply) => {
+    if (request.user) return false
+    const scope = request.requestScope
+    if (!scope) return unavailable(reply)
+    let collection
+    try { collection = await options.activeReader.read() } catch { return unavailable(reply) }
+    if (!collection || collection.active.revisionId !== scope.activeRevision) return unavailable(reply)
+    const matches = collection.desired.plan.bindings.filter((binding) => binding.bindingId === scope.bindingId)
+    if (matches.length !== 1) return unavailable(reply)
+    const binding = matches[0]!
+    if (binding.workspaceId !== scope.workspaceId || binding.defaultDeploymentId !== scope.defaultDeploymentId) return unavailable(reply)
+    const html = renderLanding(binding)
+    if (html === null) return unavailable(reply)
+    reply.header('cache-control', 'no-store').type('text/html; charset=utf-8').send(html)
+    return true
+  }
+}

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from 'vitest'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { resolve } from 'node:path'
+import Fastify from 'fastify'
+import { describe, expect, it, vi } from 'vitest'
+import { noopTelemetry } from '../../../shared/telemetry.js'
 import {
   createCoreWorkspaceAgentServer,
+  registerFrontendFallback,
   resolveCoreLoadConfigOptions,
+  type CoreFrontendRootHandler,
 } from '../createCoreWorkspaceAgentServer.js'
 
 describe('resolveCoreLoadConfigOptions', () => {
@@ -43,5 +49,29 @@ describe('createCoreWorkspaceAgentServer', () => {
     await expect(createCoreWorkspaceAgentServer({
       plugins: [{ dir: '/tmp/core-plugin', hotReload: true as false }],
     })).rejects.toThrow(/directory plugin entries must omit hotReload or set hotReload: false/)
+  })
+
+  it('preserves root SPA bytes when the optional root handler is absent or declines', async () => {
+    const appRoot = await mkdtemp(`${tmpdir()}/boring-core-root-`)
+    await mkdir(resolve(appRoot, 'dist/front'), { recursive: true })
+    await writeFile(resolve(appRoot, 'dist/front/index.html'), '<!doctype html><p>spa shell</p>')
+
+    const requestPath = async (rootHandler?: CoreFrontendRootHandler, url = '/') => {
+      const app = Fastify()
+      await registerFrontendFallback(app, appRoot, noopTelemetry, rootHandler)
+      const response = await app.inject({ method: 'GET', url })
+      await app.close()
+      return { body: response.body, contentType: response.headers['content-type'], cache: response.headers['cache-control'] }
+    }
+    const baseline = await requestPath()
+    const declining = vi.fn<CoreFrontendRootHandler>(async () => false)
+    expect(await requestPath(declining)).toEqual(baseline)
+    expect(declining).toHaveBeenCalledOnce()
+    const handling = vi.fn<CoreFrontendRootHandler>(async (_request, reply) => { reply.send('landing'); return true })
+    expect((await requestPath(handling)).body).toBe('landing')
+    const rootOnly = vi.fn<CoreFrontendRootHandler>(async () => false)
+    expect(await requestPath(rootOnly, '/workspace')).toEqual(baseline)
+    expect(rootOnly).not.toHaveBeenCalled()
+    expect(baseline).toEqual({ body: '<!doctype html><p>spa shell</p>', contentType: 'text/html; charset=utf-8', cache: 'no-store' })
   })
 })

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -37,7 +37,7 @@ import {
   type WorkspaceServerPlugin,
 } from '@hachej/boring-workspace/server'
 import { createCoreWorkspaceBridge } from './coreWorkspaceBridge.js'
-import type { FastifyInstance, FastifyRequest } from 'fastify'
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
 import type postgres from 'postgres'
 import type { CoreConfig } from '../../shared/types.js'
 import { ERROR_CODES } from '../../shared/errors.js'
@@ -183,7 +183,13 @@ export interface CreateCoreWorkspaceAgentServerOptions
   /** Verified actor resolver exposed only to boot-time internal plugins. */
   trustedPluginActorResolver?: NonNullable<WorkspaceAgentServerPluginContext['trusted']>['actorResolver']
   requestScopeResolver?: CoreRequestScopeResolver
+  frontendRootHandler?: CoreFrontendRootHandler
 }
+
+export type CoreFrontendRootHandler = (
+  request: FastifyRequest,
+  reply: FastifyReply,
+) => boolean | Promise<boolean>
 
 type AgentPiOptions = RegisterAgentRoutesOptions['pi']
 
@@ -578,15 +584,23 @@ async function registerFrontendAuthPages(
   }
 }
 
-async function registerFrontendFallback(
-  app: CoreWorkspaceAgentServer,
+export async function registerFrontendFallback(
+  app: FastifyInstance,
   appRoot: string,
   telemetry: TelemetrySink,
+  rootHandler?: CoreFrontendRootHandler,
 ) {
   const frontDistDir = path.resolve(appRoot, 'dist/front')
   const indexPath = path.resolve(frontDistDir, 'index.html')
 
-  app.get('/', async (request, reply) => serveFrontendShell(request, reply, indexPath, telemetry))
+  if (rootHandler) {
+    app.get('/', async (request, reply) => {
+      if (await rootHandler(request, reply)) return reply
+      return serveFrontendShell(request, reply, indexPath, telemetry)
+    })
+  } else {
+    app.get('/', async (request, reply) => serveFrontendShell(request, reply, indexPath, telemetry))
+  }
 
   app.get('/*', async (request, reply) => {
     const pathname = request.url.split('?')[0] ?? '/'
@@ -996,7 +1010,7 @@ export async function createCoreWorkspaceAgentServer(
   }
 
   if (serveFrontend && appRoot) {
-    await registerFrontendFallback(app, appRoot, telemetry)
+    await registerFrontendFallback(app, appRoot, telemetry, options.frontendRootHandler)
   }
 
   return app

--- a/packages/core/src/app/server/index.ts
+++ b/packages/core/src/app/server/index.ts
@@ -2,6 +2,7 @@ export {
   createCoreWorkspaceAgentServer,
   type CoreWorkspaceAgentServer,
   type CoreWorkspaceAgentServerPlugin,
+  type CoreFrontendRootHandler,
   type CreateCoreWorkspaceAgentServerOptions,
 } from './createCoreWorkspaceAgentServer.js'
 export type { CoreRequestScope, CoreRequestScopeResolver } from '../../server/app/index.js'


### PR DESCRIPTION
## Summary

Implement D1-004a4a only: a narrow optional root-handler seam and a bounded, revalidated D1 landing renderer. Production activation remains D1-004a4b per the binding split in #693.

## Issue / Slice

#391 — D1-004a4a.

## What Changed

- optional root handler preserves existing SPA bytes when absent or declining
- unauthenticated bound root renders only escaped validated landing text
- fixed same-origin `/auth/signin?redirect=%2F` CTA; no request-derived URL
- re-reads active collection and requires exact revision/binding/workspace/default-deployment tuple
- drift/read/invalid landing fails generic `D1_COLLECTION_NOT_READY` 503 with no-store
- authenticated root delegates to the unchanged SPA shell

## Proof

- source review branch: 97 related tests across root seam, landing, host scope, and active reader — pass
- final recut: landing + active-reader tests 51/51 — pass
- final recut: core root-seam tests 5/5 — pass
- `pnpm --filter full-app run typecheck` — pass
- `pnpm --filter @hachej/boring-core run typecheck` — pass
- core build/artifact assertion — pass
- `git diff --check HEAD^ HEAD` — pass

## Review

- independent security review: CLEAN
- independent spec/maintainability review: CLEAN
- structured autoreview command: `/home/ubuntu/.agents/skills/coding-autoreview/scripts/autoreview --mode commit --commit HEAD`
- autoreview requested production wiring; intentionally rejected because #693 binds reader construction, loopback health/readiness bypass, exact process identity, and `main.ts` activation atomically to D1-004a4b. Activating a4a alone would break initial health before an active pointer exists.
- original/final stable patch ID: `e9edefcc6990bc16d9470df5c8dffa8c957af026`
- pushed SHA: `9c5cc34dbaaf85b144e831704e819eb161d3de1e`

## Risk / Rollback

The seam is optional and inactive unless supplied. Revert the single commit to remove it. No env, Compose, membership, or production bootstrap changes are included.

## Next

D1-004a4b activates this with the shared exact-DAC reader, literal-IPv4 health/readiness boundary, and strict D1 process inputs.