### PR TITLE
feat(391): activate D1 host collection

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/composeAdapter.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/composeAdapter.test.ts
@@ -74,6 +74,11 @@ describe('D1 Compose topology', () => {
     expect(ingress.restart).toBe('unless-stopped')
     expect(core.restart).toBe('unless-stopped')
     expect(core.env_file).toEqual(['/etc/boring/d1/core.env'])
+    expect(core.environment).not.toHaveProperty('BORING_D1_OWNER_UID')
+    expect(core.healthcheck).toEqual({
+      test: ['CMD', 'node', '-e', "fetch('http://127.0.0.1:3000/health').then(r=>{if(!r.ok)throw r.status}).catch(()=>process.exit(1))"],
+      interval: '30s', timeout: '5s', start_period: '10s', retries: 3,
+    })
     expect(core.environment).toMatchObject({
       BORING_D1_HOST_ID: '${D1_HOST_ID:?D1_HOST_ID is required}',
       TRUST_PROXY_CIDRS: '192.168.255.250/32',

--- a/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
@@ -1,10 +1,10 @@
 import { readFile } from 'node:fs/promises'
 
+import { createCoreApp } from '@hachej/boring-core/server'
 import type { CoreConfig } from '@hachej/boring-core/shared'
 import Fastify from 'fastify'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { createCoreApp } from '../../../../../../packages/core/src/server/app/createCoreApp.js'
 import type { D1ActiveCollection, D1ActiveCollectionReader } from '../activeCollectionReader.js'
 import { registerD1ReadinessRoute } from '../d1Readiness.js'
 import { createD1ServerWiring } from '../d1ServerWiring.js'

--- a/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
@@ -1,0 +1,129 @@
+import { readFile } from 'node:fs/promises'
+
+import type { CoreConfig } from '@hachej/boring-core/shared'
+import Fastify from 'fastify'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createCoreApp } from '../../../../../../packages/core/src/server/app/createCoreApp.js'
+import type { D1ActiveCollection, D1ActiveCollectionReader } from '../activeCollectionReader.js'
+import { registerD1ReadinessRoute } from '../d1Readiness.js'
+import { createD1ServerWiring } from '../d1ServerWiring.js'
+import { D1HostErrorCode } from '../d1Plan.js'
+import { createD1HostSurfaceResolver, D1_TRUSTED_CADDY_PEER } from '../hostSurface.js'
+
+const HOST = 'insurance.example.test'
+const DIGEST = `sha256:${'a'.repeat(64)}`
+const CONFIG = {
+  appId: 'test', appName: 'Test', appLogo: null, port: 0, host: '127.0.0.1', staticDir: null,
+  databaseUrl: null, stores: 'local', cors: { origins: [], credentials: true }, bodyLimit: 1024, logLevel: 'fatal',
+  security: { csp: { enabled: false }, trustedProxy: { cidrs: [`${D1_TRUSTED_CADDY_PEER}/32`], hops: 1 } },
+  encryption: { workspaceSettingsKey: 'a'.repeat(64) },
+  auth: { secret: 's'.repeat(64), url: 'http://localhost', sessionTtlSeconds: 3600, sessionCookieSecure: false },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: false, sendWelcomeEmail: false, inviteTtlDays: 7 },
+} satisfies CoreConfig
+
+function collection(ready = true): D1ActiveCollection {
+  const binding = { bindingId: 'z-binding', hostname: HOST, workspaceId: 'workspace:z', defaultDeploymentId: 'deployment:z' }
+  return {
+    active: { schemaVersion: 1, revisionId: 'r0000000042', desiredStateDigest: DIGEST },
+    desired: { plan: { bindings: [binding, { ...binding, bindingId: 'a-binding', hostname: 'other.example.test' }] } },
+    observation: { bindings: [{ bindingId: 'a-binding', ready: true }, { bindingId: 'z-binding', ready }] },
+  } as unknown as D1ActiveCollection
+}
+
+function reader(value: D1ActiveCollection | null, rejects = false): D1ActiveCollectionReader {
+  return { async read() { if (rejects) throw new Error('/private/revision'); return value } }
+}
+
+let app: Awaited<ReturnType<typeof createCoreApp>> | undefined
+afterEach(async () => { await app?.close(); app = undefined; vi.restoreAllMocks() })
+
+async function build(activeReader: D1ActiveCollectionReader) {
+  app = await createCoreApp(CONFIG, {
+    manageShutdown: false,
+    requestScopeResolver: createD1HostSurfaceResolver({ activeReader, trustedPeer: D1_TRUSTED_CADDY_PEER }),
+  })
+  app.get('/health', async () => ({ ok: true }))
+  registerD1ReadinessRoute(app, { activeReader })
+  await app.ready()
+  return app
+}
+
+describe('D1 readiness and activation wiring', () => {
+  it('keeps literal-IPv4 health available before publication while readiness is redacted', async () => {
+    const instance = await build(reader(null))
+    expect((await instance.inject({ method: 'GET', url: '/health', remoteAddress: '127.0.0.1' })).body).toBe('{"ok":true}')
+    const response = await instance.inject({ method: 'GET', url: '/internal/d1/readiness', remoteAddress: '127.0.0.1' })
+    expect(response.statusCode).toBe(503)
+    expect(response.headers['cache-control']).toBe('no-store')
+    expect(response.json()).toEqual({
+      error: D1HostErrorCode.COLLECTION_NOT_READY, code: D1HostErrorCode.COLLECTION_NOT_READY,
+      message: D1HostErrorCode.COLLECTION_NOT_READY, requestId: expect.any(String),
+    })
+  })
+
+  it('returns only the sorted ready collection projection and rechecks local scope', async () => {
+    const instance = await build(reader(collection()))
+    const response = await instance.inject({ method: 'GET', url: '/internal/d1/readiness', remoteAddress: '127.0.0.1' })
+    expect(response.headers['cache-control']).toBe('no-store')
+    expect(response.json()).toEqual({
+      schemaVersion: 1, activeRevision: 'r0000000042', desiredStateDigest: DIGEST,
+      bindings: [{ bindingId: 'a-binding', ready: true }, { bindingId: 'z-binding', ready: true }],
+    })
+    const remote = await instance.inject({ method: 'GET', url: '/internal/d1/readiness', remoteAddress: '198.51.100.7', headers: { host: HOST } })
+    expect(remote.statusCode).toBe(421)
+    expect(remote.json()).toMatchObject({ code: D1HostErrorCode.HOST_SCOPE_VIOLATION, requestId: expect.any(String) })
+
+    await instance.close(); app = Fastify(); app.decorateRequest('requestScope')
+    app.addHook('onRequest', async (request) => { request.requestScope = {} as never })
+    registerD1ReadinessRoute(app, { activeReader: reader(collection()) }); await app.ready()
+    const independentlyRejected = await app.inject({ method: 'GET', url: '/internal/d1/readiness', remoteAddress: '127.0.0.1' })
+    expect(independentlyRejected.statusCode).toBe(421)
+    expect(independentlyRejected.json()).toMatchObject({ code: D1HostErrorCode.HOST_SCOPE_VIOLATION, requestId: expect.any(String) })
+  })
+
+  it.each([[null, false], [collection(), true], [collection(false), false]] as const)(
+    'fails closed on absent, corrupt, or incomplete state', async (value, rejects) => {
+      const response = await (await build(reader(value, rejects))).inject({ method: 'GET', url: '/internal/d1/readiness', remoteAddress: '127.0.0.1' })
+      expect(response.statusCode).toBe(503)
+      expect(response.body).not.toMatch(/private|workspace|deployment|revision/)
+    },
+  )
+
+  it('constructs exact D1 wiring early and leaves generic mode untouched', async () => {
+    const euid = vi.spyOn(process, 'geteuid').mockReturnValue(10001)
+    vi.spyOn(process, 'getegid').mockReturnValue(10001)
+    expect(createD1ServerWiring(CONFIG, {})).toBeUndefined()
+    expect(euid).not.toHaveBeenCalled()
+    const wiring = createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '0' })!
+    expect(Object.isFrozen(wiring)).toBe(true)
+    expect(Object.keys(wiring)).toEqual(['requestScopeResolver', 'frontendRootHandler', 'registerReadiness'])
+    expect(createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '4294967294' })).toBeDefined()
+
+    const source = await readFile(new URL('../d1ServerWiring.ts', import.meta.url), 'utf8')
+    const main = await readFile(new URL('../../main.ts', import.meta.url), 'utf8')
+    expect(source.match(/createD1ActiveCollectionReader\(/g)).toHaveLength(1)
+    expect(source).toContain("path.join('/var/lib/boring/d1', hostId)")
+    expect(source).not.toMatch(/BORING_D1_(?:STATE_ROOT|APP_GID|ROOT)/)
+    expect(main.indexOf('createD1ServerWiring(config)')).toBeLessThan(main.indexOf('createFullAppHostPluginComposition(config)'))
+    expect(main.indexOf('d1?.registerReadiness(app)')).toBeLessThan(main.indexOf('registerFullAppBoringMcpRoutes(app)'))
+    expect(main.indexOf('registerFullAppBoringMcpRoutes(app)')).toBeLessThan(main.indexOf('app.listen('))
+  })
+
+  it('rejects noncanonical owner, identity, and proxy inputs with field-only errors', () => {
+    const euid = vi.spyOn(process, 'geteuid').mockReturnValue(10001)
+    const egid = vi.spyOn(process, 'getegid').mockReturnValue(10001)
+    const env = { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '0' }
+    const invalid = (change: Record<string, string | undefined>, field: string, config: CoreConfig = CONFIG) => {
+      expect(() => createD1ServerWiring(config, { ...env, ...change })).toThrow(expect.objectContaining({ details: { field } }))
+    }
+    for (const owner of [undefined, '00', '+1', '10001', '1.0', ' 1', '4294967295', '9007199254740991']) {
+      invalid({ BORING_D1_OWNER_UID: owner }, 'ownerUid')
+    }
+    invalid({ BORING_D1_HOST_ID: '../host' }, 'hostId')
+    expect(() => createD1ServerWiring({ ...CONFIG, security: { ...CONFIG.security, trustedProxy: null } }, env))
+      .toThrow(expect.objectContaining({ details: { field: 'trustedProxy' } }))
+    euid.mockReturnValue(0); invalid({}, 'processUid')
+    euid.mockReturnValue(10001); egid.mockReturnValue(0); invalid({}, 'processGid')
+  })
+})

--- a/apps/full-app/src/server/deployment/__tests__/hostSurface.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/hostSurface.test.ts
@@ -39,8 +39,8 @@ function reader(value: D1ActiveCollection | null = collection(), failure = false
   return { activeReader, calls: () => calls }
 }
 
-function request(rawHeaders: string[], peer: string | undefined, ips: string[]): FastifyRequest {
-  return { raw: { rawHeaders, socket: { remoteAddress: peer } }, ips } as unknown as FastifyRequest
+function request(rawHeaders: string[], peer: string | undefined, ips: string[], method = 'GET', url = '/'): FastifyRequest {
+  return { raw: { rawHeaders, socket: { remoteAddress: peer }, method, url }, ips } as unknown as FastifyRequest
 }
 
 function resolver(activeReader: D1ActiveCollectionReader) {
@@ -66,6 +66,32 @@ let app: Awaited<ReturnType<typeof createCoreApp>> | undefined
 afterEach(async () => { await app?.close(); app = undefined })
 
 describe('D1 host surface resolver', () => {
+  it('bypasses scope only for exact unforwarded loopback bootstrap requests', async () => {
+    const state = reader(null); const resolve = resolver(state.activeReader)
+    for (const url of ['/health', '/internal/d1/readiness']) {
+      expect(await resolve(request(['Host', 'ignored'], '127.0.0.1', ['127.0.0.1'], 'GET', url))).toBeUndefined()
+    }
+    expect(state.calls()).toBe(0)
+  })
+
+  it.each([
+    ['query', '127.0.0.1', 'GET', '/health?probe=1', ['Host', HOST]],
+    ['encoded', '127.0.0.1', 'GET', '/he%61lth', ['Host', HOST]],
+    ['double encoded', '127.0.0.1', 'GET', '/internal/d1/read%2569ness', ['Host', HOST]],
+    ['deep encoded', '127.0.0.1', 'GET', '/he%252525252561lth', ['Host', HOST]],
+    ['malformed encoded', '127.0.0.1', 'GET', '/health%ZZ', ['Host', HOST]],
+    ['suffix', '127.0.0.1', 'GET', '/health/more', ['Host', HOST]],
+    ['prefix', '127.0.0.1', 'GET', '/private/health', ['Host', HOST]],
+    ['HEAD', '127.0.0.1', 'HEAD', '/health', ['Host', HOST]],
+    ['POST', '127.0.0.1', 'POST', '/internal/d1/readiness', ['Host', HOST]],
+    ['IPv6', '::1', 'GET', '/health', ['Host', HOST]],
+    ['mapped IPv6', '::ffff:127.0.0.1', 'GET', '/health', ['Host', HOST]],
+    ['Caddy', D1_TRUSTED_CADDY_PEER, 'GET', '/health', ['Host', HOST]],
+    ['forwarding spoof', '127.0.0.1', 'GET', '/health', ['Host', HOST, 'X-Forwarded-Proto', 'https']],
+  ])('rejects non-exact local bootstrap variant %s', async (_name, peer, method, url, headers) => {
+    await violation(Promise.resolve(resolver(reader().activeReader)(request(headers, peer, [peer], method, url))))
+  })
+
   it('resolves direct and exact-Caddy authorities per request as frozen four-key scopes', async () => {
     const state = reader(); const resolve = resolver(state.activeReader)
     const direct = await resolve(request(['Host', HOST], CLIENT, [CLIENT]))

--- a/apps/full-app/src/server/deployment/__tests__/hostSurface.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/hostSurface.test.ts
@@ -102,6 +102,7 @@ describe('D1 host surface resolver', () => {
     ))
     for (const result of [direct, caddy]) {
       expect(result).toEqual(scope)
+      if (result === undefined) throw new Error('expected resolved D1 request scope')
       expect(Object.keys(result)).toEqual(['bindingId', 'workspaceId', 'defaultDeploymentId', 'activeRevision'])
       expect(Object.isFrozen(result)).toBe(true)
     }

--- a/apps/full-app/src/server/deployment/d1Readiness.ts
+++ b/apps/full-app/src/server/deployment/d1Readiness.ts
@@ -1,0 +1,36 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify'
+
+import type { D1ActiveCollectionReader } from './activeCollectionReader.js'
+import { D1HostErrorCode } from './d1Plan.js'
+
+export interface D1ReadinessOptions {
+  readonly activeReader: D1ActiveCollectionReader
+}
+
+function failure(request: FastifyRequest, reply: FastifyReply, status: 421 | 503, code: string): FastifyReply {
+  return reply.status(status).header('cache-control', 'no-store').send({ error: code, code, message: code, requestId: request.id })
+}
+
+export function registerD1ReadinessRoute(app: FastifyInstance, options: D1ReadinessOptions): void {
+  app.get('/internal/d1/readiness', async (request, reply) => {
+    if (request.raw.socket.remoteAddress !== '127.0.0.1' || request.requestScope !== undefined) {
+      return failure(request, reply, 421, D1HostErrorCode.HOST_SCOPE_VIOLATION)
+    }
+    let collection
+    try { collection = await options.activeReader.read() } catch { collection = null }
+    if (!collection) return failure(request, reply, 503, D1HostErrorCode.COLLECTION_NOT_READY)
+    const ready = new Map(collection.observation.bindings.map((binding) => [binding.bindingId, binding.ready]))
+    const bindings = collection.desired.plan.bindings
+      .map(({ bindingId }) => ({ bindingId, ready: ready.get(bindingId) === true }))
+      .sort((left, right) => left.bindingId < right.bindingId ? -1 : left.bindingId > right.bindingId ? 1 : 0)
+    if (bindings.some((binding) => !binding.ready) || ready.size !== bindings.length) {
+      return failure(request, reply, 503, D1HostErrorCode.COLLECTION_NOT_READY)
+    }
+    return reply.header('cache-control', 'no-store').send({
+      schemaVersion: 1,
+      activeRevision: collection.active.revisionId,
+      desiredStateDigest: collection.active.desiredStateDigest,
+      bindings,
+    })
+  })
+}

--- a/apps/full-app/src/server/deployment/d1ServerWiring.ts
+++ b/apps/full-app/src/server/deployment/d1ServerWiring.ts
@@ -1,0 +1,53 @@
+import path from 'node:path'
+
+import type { CoreFrontendRootHandler } from '@hachej/boring-core/app/server'
+import type { CoreConfig } from '@hachej/boring-core/shared'
+import type { CoreRequestScopeResolver } from '@hachej/boring-core/server'
+import type { FastifyInstance } from 'fastify'
+
+import { createD1ActiveCollectionReader } from './activeCollectionReader.js'
+import { createD1LandingRootHandler } from './d1Landing.js'
+import { invalidD1Field, strictD1HostId } from './d1Plan.js'
+import { registerD1ReadinessRoute } from './d1Readiness.js'
+import { createD1HostSurfaceResolver, D1_TRUSTED_CADDY_PEER } from './hostSurface.js'
+
+const APP_UID = 10001
+const APP_GID = 10001
+const MAX_LINUX_UID = 0xffff_fffe
+const OWNER_UID_RE = /^(?:0|[1-9][0-9]*)$/
+
+export interface D1ServerWiring {
+  readonly requestScopeResolver: CoreRequestScopeResolver
+  readonly frontendRootHandler: CoreFrontendRootHandler
+  registerReadiness(app: FastifyInstance): void
+}
+
+function ownerUid(raw: string | undefined): number {
+  if (raw === undefined || !OWNER_UID_RE.test(raw)) invalidD1Field('ownerUid')
+  const value = Number(raw)
+  if (!Number.isSafeInteger(value) || value > MAX_LINUX_UID || value === APP_UID) invalidD1Field('ownerUid')
+  return value
+}
+
+export function createD1ServerWiring(
+  config: CoreConfig,
+  env: Record<string, string | undefined> = process.env,
+): D1ServerWiring | undefined {
+  if (env.BORING_D1_HOST_ID === undefined) return undefined
+  const hostId = strictD1HostId(env.BORING_D1_HOST_ID, 'hostId')
+  const publicationOwnerUid = ownerUid(env.BORING_D1_OWNER_UID)
+  if (process.geteuid?.() !== APP_UID) invalidD1Field('processUid')
+  if (process.getegid?.() !== APP_GID) invalidD1Field('processGid')
+  const proxy = config.security?.trustedProxy
+  if (typeof proxy !== 'object' || proxy === null || proxy.hops !== 1 || !Array.isArray(proxy.cidrs)
+    || proxy.cidrs.length !== 1 || proxy.cidrs[0] !== `${D1_TRUSTED_CADDY_PEER}/32`) invalidD1Field('trustedProxy')
+  const activeReader = createD1ActiveCollectionReader({
+    hostRoot: path.join('/var/lib/boring/d1', hostId), hostId,
+    ownerUid: publicationOwnerUid, appGid: APP_GID,
+  })
+  return Object.freeze({
+    requestScopeResolver: createD1HostSurfaceResolver({ activeReader, trustedPeer: D1_TRUSTED_CADDY_PEER }),
+    frontendRootHandler: createD1LandingRootHandler({ activeReader }),
+    registerReadiness(app: FastifyInstance) { registerD1ReadinessRoute(app, { activeReader }) },
+  })
+}

--- a/apps/full-app/src/server/deployment/hostSurface.ts
+++ b/apps/full-app/src/server/deployment/hostSurface.ts
@@ -7,6 +7,8 @@ import type { D1ActiveCollectionReader } from './activeCollectionReader.js'
 import { D1HostErrorCode, invalidD1Field, strictD1Hostname } from './d1Plan.js'
 
 export const D1_TRUSTED_CADDY_PEER = '192.168.255.250'
+const LOOPBACK = '127.0.0.1'
+const LOCAL_PATHS = new Set(['/health', '/internal/d1/readiness'])
 
 export interface D1HostSurfaceOptions {
   readonly activeReader: D1ActiveCollectionReader
@@ -30,9 +32,46 @@ function rawValues(rawHeaders: readonly string[], name: string): readonly string
   return values
 }
 
+function hasForwardingHeader(rawHeaders: readonly string[]): boolean {
+  if (rawHeaders.length % 2 !== 0) violation()
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index]!.toLowerCase()
+    if (name === 'forwarded' || name.startsWith('x-forwarded-')) return true
+  }
+  return false
+}
+
+function isLocalSurfaceAttempt(rawUrl: string | undefined): boolean {
+  if (rawUrl === undefined) return false
+  let decoded = rawUrl.split('?', 1)[0]!
+  const matches = (value: string) => [...LOCAL_PATHS]
+    .some((pathname) => value.startsWith(pathname) || value.endsWith(pathname))
+  for (let depth = 0; depth < 4; depth += 1) {
+    if (matches(decoded)) return true
+    if (!decoded.includes('%')) return false
+    try {
+      const next = decodeURIComponent(decoded)
+      if (next === decoded) return true
+      decoded = next
+    } catch { return true }
+  }
+  return decoded.includes('%') || matches(decoded)
+}
+
 export function createD1HostSurfaceResolver(options: D1HostSurfaceOptions): CoreRequestScopeResolver {
   if (options.trustedPeer !== D1_TRUSTED_CADDY_PEER) invalidD1Field('trustedPeer')
   return async (request) => {
+    const rawUrl = request.raw.url
+    if (
+      request.raw.socket.remoteAddress === LOOPBACK
+      && request.raw.method === 'GET'
+      && rawUrl !== undefined
+      && LOCAL_PATHS.has(rawUrl)
+    ) {
+      if (hasForwardingHeader(request.raw.rawHeaders)) violation()
+      return undefined
+    }
+    if (isLocalSurfaceAttempt(rawUrl)) violation()
     const forwarded = rawValues(request.raw.rawHeaders, 'forwarded')
     const hosts = rawValues(request.raw.rawHeaders, 'host')
     const forwardedFor = rawValues(request.raw.rawHeaders, 'x-forwarded-for')

--- a/apps/full-app/src/server/main.ts
+++ b/apps/full-app/src/server/main.ts
@@ -18,6 +18,7 @@ import {
 } from './managedAgentMcp.js'
 import { assertProductionAgentModeIsSafe } from './productionSafety.js'
 import type { WorkspaceAgentDispatcherResolver } from '@hachej/boring-agent/server'
+import { createD1ServerWiring } from './deployment/d1ServerWiring.js'
 
 function pluginAuthoringEnabledFromEnv(): boolean {
   return process.env.BORING_PLUGIN_AUTHORING === '1'
@@ -30,6 +31,7 @@ async function main() {
     allowMissingSecrets: process.env.NODE_ENV !== 'production',
     tomlPath: path.resolve(appRoot, 'boring.app.toml'),
   })
+  const d1 = createD1ServerWiring(config)
   const { governance, ...pluginComposition } = await createFullAppHostPluginComposition(config)
   // Build the metering sink up-front; the credit service attaches after the
   // server (and its db) exists.
@@ -57,10 +59,15 @@ async function main() {
     onWorkspaceAgentDispatcher: (resolver) => {
       managedAgentDispatcherResolver = resolver
     },
+    ...(d1 ? {
+      requestScopeResolver: d1.requestScopeResolver,
+      frontendRootHandler: d1.frontendRootHandler,
+    } : {}),
   })
   appDb = app.db
   appRef = app
   credits.attach(app)
+  d1?.registerReadiness(app)
   registerFullAppBoringMcpRoutes(app)
   registerFullAppManagedAgentMcpRoutes(app, { dispatcherResolver: managedAgentDispatcherResolver })
   const address = await app.listen({ host: app.config.host, port: app.config.port })

--- a/deploy/d1/compose.yml
+++ b/deploy/d1/compose.yml
@@ -54,7 +54,7 @@ services:
         bind:
           create_host_path: false
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/health').then(r=>{if(!r.ok)throw r.status}).catch(()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/health').then(r=>{if(!r.ok)throw r.status}).catch(()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
       start_period: 10s

--- a/packages/core/src/server/app/__tests__/createCoreApp.test.ts
+++ b/packages/core/src/server/app/__tests__/createCoreApp.test.ts
@@ -54,6 +54,13 @@ describe('createCoreApp', () => {
     expect(app.config.appId).toBe('test-app')
   })
 
+  it('leaves request scope unset when the optional resolver declines', async () => {
+    app = await createCoreApp(TEST_CONFIG, { manageShutdown: false, requestScopeResolver: async () => undefined })
+    app.get('/scope', async (request) => ({ hasScope: request.requestScope !== undefined }))
+    await app.ready()
+    expect((await app.inject({ method: 'GET', url: '/scope' })).body).toBe('{"hasScope":false}')
+  })
+
   it('echoes x-request-id from incoming request', async () => {
     app = await createCoreApp(TEST_CONFIG, { manageShutdown: false })
     app.get('/test', async () => ({ ok: true }))

--- a/packages/core/src/server/app/createCoreApp.ts
+++ b/packages/core/src/server/app/createCoreApp.ts
@@ -313,6 +313,7 @@ export async function createCoreApp(
         }
         throw error
       }
+      if (scope === undefined) return
       request.requestScope = Object.freeze({
         bindingId: scope.bindingId,
         workspaceId: scope.workspaceId,

--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -101,7 +101,7 @@ export interface CoreRequestScope {
   readonly activeRevision: string
 }
 
-export type CoreRequestScopeResolver = (request: FastifyRequest) => CoreRequestScope | Promise<CoreRequestScope>
+export type CoreRequestScopeResolver = (request: FastifyRequest) => CoreRequestScope | undefined | Promise<CoreRequestScope | undefined>
 
 export interface CreateCoreAppOptions {
   authProvider?: AuthProvider


### PR DESCRIPTION
## Summary

Complete D1-004a4b: strict D1 process wiring, one shared active reader, exact loopback health/readiness bypass, redacted readiness, and production activation before other host effects.

## Issue / Slice

#391 — D1-004a4b, following merged a4a #694 and binding split #693.

## What Changed

- validates D1 host ID, owner UID, process `10001:10001`, and exact `.250/32` one-hop proxy policy before plugin/DB effects
- reads `BORING_D1_OWNER_UID` through the existing process-level `core.env`; uses fixed `/var/lib/boring/d1/<hostId>`
- constructs one exact-DAC reader reused by host scope, landing, and readiness
- permits scope bypass only for unforwarded raw `127.0.0.1` exact GET `/health` or `/internal/d1/readiness`
- fails query/encoded/deep-encoded/malformed/prefix/suffix/method/IPv6/remote/Caddy/spoof variants closed
- switches Compose health to literal `127.0.0.1` and proves health works before an active pointer while readiness is generic 503
- exposes only sorted binding readiness, active revision, and desired digest locally
- preserves generic mode when `BORING_D1_HOST_ID` is absent

## Proof

- `pnpm run build:packages` — pass; core/workspace/agent/plugin artifact assertions pass (existing workspace declaration-bundler warning only)
- `pnpm --filter full-app run typecheck` — pass on fresh recut/current package links
- `pnpm --filter @hachej/boring-core run typecheck` — pass
- full-app focused tests — 3 files / 80 tests pass
- core scope-hook tests — 16/16 pass
- total focused proof — 96/96 pass
- `git diff --check origin/main HEAD` — pass

## Review

- independent security/spec review found and fixed two P1s: malformed/deep-encoded control paths and owner UID values outside Linux `uid_t`
- decoding is now fixed-depth/fail-closed; UID range is canonical `0..4294967294`, excluding app UID
- re-review: CLEAN
- structured review: `/home/ubuntu/.agents/skills/coding-autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no actionable findings
- original runtime patch ID: `176249b99a21448bfadf66c8441dab91b6a5348d`
- follow-up test-narrowing patch ID: `8627fbe86028648bb9ea223526b45b8f0b98ab94`
- combined reviewed branch patch ID: `34060f0b03d63f8a004acb16aedb62c1cb075d0c`
- remote-verified head: `5125688348807d1a8ceb2340aa8a700239c4d1c6`

## Risk / Rollback

D1 activation is opt-in through `BORING_D1_HOST_ID`; generic hosts remain unchanged. Startup fails field-only before plugin/DB effects on invalid D1 identity/proxy configuration. Revert this PR to return to inactive a4a seams.

## Next

D1-004b1 workspace authority/signup fences, then D1-004b2 destructive ownership/account guards.