### PR TITLE
#391 D1-004b2a: make managed member mutations atomic

### DIFF
--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -51,8 +51,9 @@ export interface WorkspaceStore {
   getMemberRole(workspaceId: string, userId: string): Promise<MemberRole | null>
   listMembers(workspaceId: string): Promise<Array<WorkspaceMember & { user: Pick<User, 'id' | 'email' | 'name' | 'image'> }>>
   upsertMember(workspaceId: string, userId: string, role: MemberRole): Promise<WorkspaceMember>
-  updateMemberRole(workspaceId: string, userId: string, role: MemberRole): Promise<{ member?: WorkspaceMember; code?: typeof ERROR_CODES.LAST_OWNER | typeof ERROR_CODES.NOT_MEMBER }>
-  removeMember(workspaceId: string, userId: string, opts?: { allowLastOwner?: boolean }): Promise<{ removed: boolean; code?: typeof ERROR_CODES.LAST_OWNER | typeof ERROR_CODES.NOT_MEMBER }>
+  createMemberIfAbsent(workspaceId: string, userId: string, role: MemberRole): Promise<WorkspaceMember | null>
+  updateMemberRole(workspaceId: string, userId: string, role: MemberRole, opts?: { forbidExistingOwnerMutation?: boolean }): Promise<{ member?: WorkspaceMember; code?: typeof ERROR_CODES.LAST_OWNER | typeof ERROR_CODES.NOT_MEMBER | typeof ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }>
+  removeMember(workspaceId: string, userId: string, opts?: { allowLastOwner?: boolean; forbidExistingOwnerMutation?: boolean }): Promise<{ removed: boolean; code?: typeof ERROR_CODES.LAST_OWNER | typeof ERROR_CODES.NOT_MEMBER | typeof ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }>
   listInvites(workspaceId: string): Promise<WorkspaceInvite[]>
   createInvite(workspaceId: string, email: string, role: MemberRole, invitedBy: string | null, opts?: { ttlDays?: number }): Promise<{ invite: WorkspaceInvite; rawToken: string }>
   getInvite(workspaceId: string, inviteId: string): Promise<WorkspaceInvite | null>

--- a/packages/core/src/server/db/__tests__/storeConformance.ts
+++ b/packages/core/src/server/db/__tests__/storeConformance.ts
@@ -363,6 +363,35 @@ export function describeWorkspaceStoreConformance(
     )
 
     it(
+      'managed member operations preserve concurrent owner promotion',
+      withTaskId(TASK_ID, async ({ assertionPassed }) => {
+        const { workspaceStore, appId, users } = await setup()
+        const ws = await workspaceStore.create(users.owner.id, 'Managed Members', appId)
+
+        await Promise.all([
+          workspaceStore.createMemberIfAbsent(ws.id, users.member.id, 'editor'),
+          workspaceStore.upsertMember(ws.id, users.member.id, 'owner'),
+        ])
+        expect(await workspaceStore.getMemberRole(ws.id, users.member.id)).toBe('owner')
+
+        await workspaceStore.upsertMember(ws.id, users.other.id, 'editor')
+        await Promise.all([
+          workspaceStore.updateMemberRole(ws.id, users.other.id, 'viewer', { forbidExistingOwnerMutation: true }),
+          workspaceStore.upsertMember(ws.id, users.other.id, 'owner'),
+        ])
+        expect(await workspaceStore.getMemberRole(ws.id, users.other.id)).toBe('owner')
+
+        await workspaceStore.upsertMember(ws.id, users.member.id, 'editor')
+        await Promise.all([
+          workspaceStore.removeMember(ws.id, users.member.id, { forbidExistingOwnerMutation: true }),
+          workspaceStore.upsertMember(ws.id, users.member.id, 'owner'),
+        ])
+        expect(await workspaceStore.getMemberRole(ws.id, users.member.id)).toBe('owner')
+        assertionPassed('managed-member-owner-races')
+      }),
+    )
+
+    it(
       'removeMember removes members and reports not_member for missing',
       withTaskId(TASK_ID, async ({ assertionPassed }) => {
         const { workspaceStore, appId, users } = await setup()

--- a/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
@@ -181,10 +181,16 @@ export class LocalWorkspaceStore implements WorkspaceStore {
     return member
   }
 
-  async updateMemberRole(workspaceId: string, userId: string, role: MemberRole): Promise<{ member?: WorkspaceMember; code?: typeof ERROR_CODES.LAST_OWNER | typeof ERROR_CODES.NOT_MEMBER }> {
+  async createMemberIfAbsent(workspaceId: string, userId: string, role: MemberRole): Promise<WorkspaceMember | null> {
+    if (this.members.has(`${workspaceId}:${userId}`)) return null
+    return this.upsertMember(workspaceId, userId, role)
+  }
+
+  async updateMemberRole(workspaceId: string, userId: string, role: MemberRole, opts?: { forbidExistingOwnerMutation?: boolean }): Promise<{ member?: WorkspaceMember; code?: typeof ERROR_CODES.LAST_OWNER | typeof ERROR_CODES.NOT_MEMBER | typeof ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }> {
     const key = `${workspaceId}:${userId}`
     const membership = this.members.get(key)
     if (!membership) return { code: ERROR_CODES.NOT_MEMBER }
+    if (opts?.forbidExistingOwnerMutation && membership.role === 'owner' && role !== 'owner') return { code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }
     if (membership.role === 'owner' && role !== 'owner') {
       let otherOwnerExists = false
       for (const m of this.members.values()) {
@@ -200,10 +206,11 @@ export class LocalWorkspaceStore implements WorkspaceStore {
     return { member: updated }
   }
 
-  async removeMember(workspaceId: string, userId: string, opts?: { allowLastOwner?: boolean }): Promise<{ removed: boolean; code?: typeof ERROR_CODES.LAST_OWNER | typeof ERROR_CODES.NOT_MEMBER }> {
+  async removeMember(workspaceId: string, userId: string, opts?: { allowLastOwner?: boolean; forbidExistingOwnerMutation?: boolean }): Promise<{ removed: boolean; code?: typeof ERROR_CODES.LAST_OWNER | typeof ERROR_CODES.NOT_MEMBER | typeof ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }> {
     const key = `${workspaceId}:${userId}`
     const membership = this.members.get(key)
     if (!membership) return { removed: false, code: ERROR_CODES.NOT_MEMBER }
+    if (opts?.forbidExistingOwnerMutation && membership.role === 'owner') return { removed: false, code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }
     if (!opts?.allowLastOwner && membership.role === 'owner') {
       let otherOwnerExists = false
       for (const m of this.members.values()) {

--- a/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
@@ -381,15 +381,22 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
     return toWorkspaceMember(row)
   }
 
+  async createMemberIfAbsent(workspaceId: string, userId: string, role: MemberRole): Promise<WorkspaceMember | null> {
+    const [row] = await this.db.insert(workspaceMembers).values({ workspaceId, userId, role }).onConflictDoNothing().returning()
+    return row ? toWorkspaceMember(row) : null
+  }
+
   async updateMemberRole(
     workspaceId: string,
     userId: string,
     role: MemberRole,
+    opts?: { forbidExistingOwnerMutation?: boolean },
   ): Promise<{
     member?: WorkspaceMember
     code?:
       | typeof ERROR_CODES.LAST_OWNER
       | typeof ERROR_CODES.NOT_MEMBER
+      | typeof ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN
   }> {
     return this.db.transaction(async (tx) => {
       await tx.execute(sql`
@@ -411,6 +418,7 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
         .limit(1)
       const currentRole = memberRows[0]?.role as MemberRole | undefined
       if (!currentRole) return { code: ERROR_CODES.NOT_MEMBER }
+      if (opts?.forbidExistingOwnerMutation && currentRole === 'owner' && role !== 'owner') return { code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }
 
       if (currentRole === 'owner' && role !== 'owner') {
         const [{ count }] = await tx
@@ -444,19 +452,20 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
   async removeMember(
     workspaceId: string,
     userId: string,
-    opts?: { allowLastOwner?: boolean },
+    opts?: { allowLastOwner?: boolean; forbidExistingOwnerMutation?: boolean },
   ): Promise<{
     removed: boolean
     code?:
       | typeof ERROR_CODES.LAST_OWNER
       | typeof ERROR_CODES.NOT_MEMBER
+      | typeof ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN
   }> {
     return this.db.transaction(async (tx) => {
       await tx.execute(sql`
         SELECT user_id
         FROM workspace_members
         WHERE workspace_id = ${workspaceId}
-          AND role = 'owner'
+          ${opts?.forbidExistingOwnerMutation ? sql`` : sql`AND role = 'owner'`}
         FOR UPDATE
       `)
 
@@ -472,6 +481,7 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
         .limit(1)
       const role = memberRows[0]?.role as MemberRole | undefined
       if (!role) return { removed: false, code: ERROR_CODES.NOT_MEMBER }
+      if (opts?.forbidExistingOwnerMutation && role === 'owner') return { removed: false, code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }
 
       if (!opts?.allowLastOwner && role === 'owner') {
         const [{ count }] = await tx

--- a/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
@@ -62,6 +62,54 @@ async function seedWorkspace(appId = 'orm1-app') {
   }
 }
 
+async function waitForMemberLockWaiters(blockerPid: number, expected: number): Promise<void> {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    const [row] = await sqlClient`
+      SELECT COUNT(*)::int AS count FROM pg_stat_activity
+      WHERE datname = current_database() AND wait_event_type = 'Lock'
+        AND query ILIKE '%workspace_members%'
+        AND ${blockerPid} = ANY(pg_blocking_pids(pid))
+    `
+    if (Number(row.count) >= expected) return
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(`Timed out waiting for ${expected} membership lock waiters`)
+}
+
+async function runQueuedMemberOperations(
+  workspaceId: string,
+  userId: string,
+  first: () => Promise<unknown>,
+  second: () => Promise<unknown>,
+): Promise<[unknown, unknown]> {
+  let locked!: (pid: number) => void
+  let release!: () => void
+  const lockedPromise = new Promise<number>((resolve) => { locked = resolve })
+  const releasePromise = new Promise<void>((resolve) => { release = resolve })
+  const blocker = sqlClient.begin(async (tx) => {
+    await tx`SELECT user_id FROM workspace_members WHERE workspace_id = ${workspaceId} AND user_id = ${userId} FOR UPDATE`
+    const [connection] = await tx`SELECT pg_backend_pid()::int AS pid`
+    locked(Number(connection.pid))
+    await releasePromise
+  })
+  try {
+    const blockerPid = await Promise.race([
+      lockedPromise,
+      blocker.then(() => { throw new Error('Membership lock blocker exited early') }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Membership lock blocker timed out')), 6_000)),
+    ])
+    const firstResult = first()
+    await waitForMemberLockWaiters(blockerPid, 1)
+    const secondResult = second()
+    await waitForMemberLockWaiters(blockerPid, 2)
+    release()
+    return await Promise.all([firstResult, secondResult])
+  } finally {
+    release()
+    await blocker
+  }
+}
+
 beforeAll(async () => {
   await runMigrations(BASE_CONFIG)
   sqlClient = postgres(TEST_DB_URL, { max: 4 })
@@ -106,6 +154,31 @@ beforeEach(async () => {
 })
 
 describe('PostgresWorkspaceStore Sub-PR3', () => {
+  it.each(['update', 'remove'] as const)('serializes managed %s against owner promotion in both orders', async (operation) => {
+    const { workspaceId } = await seedWorkspace()
+    const [target] = await sqlClient`
+      INSERT INTO users (name, email, email_verified)
+      VALUES ('Race Target', ${`race-${randomUUID()}@orm1-test.dev`}, true) RETURNING id
+    `
+    const userId = target.id as string
+    const protect = () => operation === 'update'
+      ? store.updateMemberRole(workspaceId, userId, 'viewer', { forbidExistingOwnerMutation: true })
+      : store.removeMember(workspaceId, userId, { forbidExistingOwnerMutation: true })
+    const promote = () => store.upsertMember(workspaceId, userId, 'owner')
+
+    await store.upsertMember(workspaceId, userId, 'editor')
+    const [, protectedAfterPromotion] = await runQueuedMemberOperations(workspaceId, userId, promote, protect)
+    expect(protectedAfterPromotion).toMatchObject({ code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN })
+    expect(await store.getMemberRole(workspaceId, userId)).toBe('owner')
+
+    await store.upsertMember(workspaceId, userId, 'editor')
+    const [protectedBeforePromotion] = await runQueuedMemberOperations(workspaceId, userId, protect, promote)
+    expect(protectedBeforePromotion).toMatchObject(operation === 'update'
+      ? { member: { role: 'viewer' } }
+      : { removed: true })
+    expect(await store.getMemberRole(workspaceId, userId)).toBe('owner')
+  })
+
   describe('workspace settings', () => {
     it('putWorkspaceSettings stores encrypted values and getWorkspaceSettings returns metadata only', async () => {
       const { workspaceId } = await seedWorkspace()

--- a/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
+++ b/packages/core/src/server/db/stores/__tests__/PostgresWorkspaceStore.test.ts
@@ -62,18 +62,19 @@ async function seedWorkspace(appId = 'orm1-app') {
   }
 }
 
-async function waitForMemberLockWaiters(blockerPid: number, expected: number): Promise<void> {
+async function waitForMemberLockWaiter(blockerPid: number): Promise<number> {
   for (let attempt = 0; attempt < 300; attempt += 1) {
     const [row] = await sqlClient`
-      SELECT COUNT(*)::int AS count FROM pg_stat_activity
+      SELECT pid FROM pg_stat_activity
       WHERE datname = current_database() AND wait_event_type = 'Lock'
         AND query ILIKE '%workspace_members%'
         AND ${blockerPid} = ANY(pg_blocking_pids(pid))
+      ORDER BY pid LIMIT 1
     `
-    if (Number(row.count) >= expected) return
+    if (row) return Number(row.pid)
     await new Promise((resolve) => setTimeout(resolve, 20))
   }
-  throw new Error(`Timed out waiting for ${expected} membership lock waiters`)
+  throw new Error(`Timed out waiting for membership waiter behind PID ${blockerPid}`)
 }
 
 async function runQueuedMemberOperations(
@@ -99,9 +100,9 @@ async function runQueuedMemberOperations(
       new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Membership lock blocker timed out')), 6_000)),
     ])
     const firstResult = first()
-    await waitForMemberLockWaiters(blockerPid, 1)
+    const firstWaiterPid = await waitForMemberLockWaiter(blockerPid)
     const secondResult = second()
-    await waitForMemberLockWaiters(blockerPid, 2)
+    await waitForMemberLockWaiter(firstWaiterPid)
     release()
     return await Promise.all([firstResult, secondResult])
   } finally {

--- a/packages/core/src/server/routes/__tests__/members.test.ts
+++ b/packages/core/src/server/routes/__tests__/members.test.ts
@@ -5,6 +5,7 @@ import { registerMemberRoutes } from '../members'
 import { registerErrorHandler } from '../../app/errorHandler'
 import type { WorkspaceStore } from '../../app/types'
 import type { MemberRole, Workspace, WorkspaceMember, User } from '../../../shared/types'
+import { ERROR_CODES } from '../../../shared/errors'
 
 const OWNER_ID = '00000000-0000-0000-0000-000000000001'
 const EDITOR_ID = '00000000-0000-0000-0000-000000000002'
@@ -16,11 +17,13 @@ const APP_ID = 'test-app'
 let nextWsId = 1
 const workspaces = new Map<string, Workspace>()
 const memberDb = new Map<string, Map<string, MemberRole>>()
+const memberEffects: string[] = []
 
 function resetState() {
   nextWsId = 1
   workspaces.clear()
   memberDb.clear()
+  memberEffects.length = 0
 }
 
 const fakeUsers: Record<string, Pick<User, 'id' | 'email' | 'name' | 'image'>> = {
@@ -56,10 +59,19 @@ function mockWorkspaceStore(): WorkspaceStore {
       memberDb.set(wsId, wsMembers)
       return { workspaceId: wsId, userId, role, createdAt: new Date().toISOString() }
     },
-    updateMemberRole: async (wsId: string, userId: string, role: MemberRole) => {
+    createMemberIfAbsent: async (wsId: string, userId: string, role: MemberRole) => {
+      if (memberDb.get(wsId)?.has(userId)) return null
+      const wsMembers = memberDb.get(wsId) ?? new Map()
+      wsMembers.set(userId, role)
+      memberDb.set(wsId, wsMembers)
+      return { workspaceId: wsId, userId, role, createdAt: new Date().toISOString() }
+    },
+    updateMemberRole: async (wsId: string, userId: string, role: MemberRole, opts?: { forbidExistingOwnerMutation?: boolean }) => {
       const wsMembers = memberDb.get(wsId)
       if (!wsMembers?.has(userId)) return { code: 'not_member' as const }
       const currentRole = wsMembers.get(userId)!
+      if (opts?.forbidExistingOwnerMutation && currentRole === 'owner' && role !== 'owner') return { code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }
+      memberEffects.push(`update:${wsId}:${userId}`)
       if (currentRole === 'owner' && role !== 'owner') {
         const ownerCount = [...wsMembers.values()].filter((r) => r === 'owner').length
         if (ownerCount <= 1) return { code: 'last_owner' as const }
@@ -74,10 +86,12 @@ function mockWorkspaceStore(): WorkspaceStore {
         },
       }
     },
-    removeMember: async (wsId: string, userId: string) => {
+    removeMember: async (wsId: string, userId: string, opts?: { forbidExistingOwnerMutation?: boolean }) => {
       const wsMembers = memberDb.get(wsId)
       if (!wsMembers?.has(userId)) return { removed: false, code: 'not_member' as const }
       const role = wsMembers.get(userId)!
+      if (opts?.forbidExistingOwnerMutation && role === 'owner') return { removed: false, code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN }
+      memberEffects.push(`remove:${wsId}:${userId}`)
       if (role === 'owner') {
         const ownerCount = [...wsMembers.values()].filter((r) => r === 'owner').length
         if (ownerCount <= 1) return { removed: false, code: 'last_owner' as const }
@@ -126,6 +140,13 @@ beforeAll(async () => {
     } else {
       request.user = null
     }
+    const workspaceId = request.headers['x-test-scope']
+    if (typeof workspaceId === 'string') {
+      request.requestScope = Object.freeze({
+        bindingId: 'binding-test', workspaceId,
+        defaultDeploymentId: 'deployment-test', activeRevision: 'revision-test',
+      })
+    }
   })
 
   await app.register(registerMemberRoutes)
@@ -140,9 +161,10 @@ beforeEach(() => {
   resetState()
 })
 
-function inject(method: string, url: string, userId?: string, payload?: unknown) {
+function inject(method: string, url: string, userId?: string, payload?: unknown, scopeWorkspaceId?: string) {
   const req: any = { method, url }
   if (userId) req.headers = { 'x-test-user': userId }
+  if (scopeWorkspaceId) req.headers = { ...req.headers, 'x-test-scope': scopeWorkspaceId }
   if (payload !== undefined) req.payload = payload
   return app.inject(req)
 }
@@ -332,5 +354,53 @@ describe('DELETE /api/v1/workspaces/:id/members/:userId', () => {
     const res = await inject('DELETE', `/api/v1/workspaces/${ws.id}/members/${EDITOR_ID}`, EDITOR_ID)
     expect(res.statusCode).toBe(200)
     expect(res.json()).toEqual({ removed: true })
+  })
+})
+
+describe('request-scoped owner guards', () => {
+  it('blocks demoting an existing co-owner before update', async () => {
+    const ws = seedWorkspace(OWNER_ID, { [EDITOR_ID]: 'owner' })
+
+    const res = await inject('PATCH', `/api/v1/workspaces/${ws.id}/members/${EDITOR_ID}/role`, OWNER_ID, { role: 'editor' }, ws.id)
+
+    expect(res.statusCode).toBe(403)
+    expect(res.json().code).toBe(ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN)
+    expect(memberEffects).toEqual([])
+    expect(memberDb.get(ws.id)?.get(EDITOR_ID)).toBe('owner')
+  })
+
+  it.each([
+    ['self', OWNER_ID, OWNER_ID],
+    ['other', OWNER_ID, EDITOR_ID],
+  ])('blocks removing an existing co-owner (%s) before removal', async (_case, callerId, targetId) => {
+    const ws = seedWorkspace(OWNER_ID, { [EDITOR_ID]: 'owner' })
+
+    const res = await inject('DELETE', `/api/v1/workspaces/${ws.id}/members/${targetId}`, callerId, undefined, ws.id)
+
+    expect(res.statusCode).toBe(403)
+    expect(res.json().code).toBe(ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN)
+    expect(memberEffects).toEqual([])
+    expect(memberDb.get(ws.id)?.get(targetId)).toBe('owner')
+  })
+
+  it('preserves scoped owner promotion and non-owner removal', async () => {
+    const ws = seedWorkspace(OWNER_ID, { [EDITOR_ID]: 'editor', [VIEWER_ID]: 'viewer' })
+
+    const promote = await inject('PATCH', `/api/v1/workspaces/${ws.id}/members/${VIEWER_ID}/role`, OWNER_ID, { role: 'owner' }, ws.id)
+    const remove = await inject('DELETE', `/api/v1/workspaces/${ws.id}/members/${EDITOR_ID}`, OWNER_ID, undefined, ws.id)
+
+    expect(promote.statusCode).toBe(200)
+    expect(remove.statusCode).toBe(200)
+    expect(memberDb.get(ws.id)?.get(VIEWER_ID)).toBe('owner')
+    expect(memberDb.get(ws.id)?.has(EDITOR_ID)).toBe(false)
+  })
+
+  it('preserves scoped owner addition', async () => {
+    const ws = seedWorkspace(OWNER_ID)
+
+    const res = await inject('POST', `/api/v1/workspaces/${ws.id}/members`, OWNER_ID, { userId: TARGET_ID, role: 'owner' }, ws.id)
+
+    expect(res.statusCode).toBe(201)
+    expect(memberDb.get(ws.id)?.get(TARGET_ID)).toBe('owner')
   })
 })

--- a/packages/core/src/server/routes/members.ts
+++ b/packages/core/src/server/routes/members.ts
@@ -32,8 +32,11 @@ const memberRoutesPlugin: FastifyPluginAsync = async (app) => {
         })
       }
 
-      const existing = await store.getMemberRole(id, parsed.data.userId)
-      if (existing) {
+      const existing = request.requestScope ? null : await store.getMemberRole(id, parsed.data.userId)
+      const member = request.requestScope
+        ? await store.createMemberIfAbsent(id, parsed.data.userId, parsed.data.role)
+        : existing ? null : await store.upsertMember(id, parsed.data.userId, parsed.data.role)
+      if (!member) {
         throw new HttpError({
           status: 409,
           code: ERROR_CODES.VALIDATION_FAILED,
@@ -42,7 +45,6 @@ const memberRoutesPlugin: FastifyPluginAsync = async (app) => {
         })
       }
 
-      const member = await store.upsertMember(id, parsed.data.userId, parsed.data.role)
       reply.status(201)
       return { member }
     },
@@ -63,7 +65,9 @@ const memberRoutesPlugin: FastifyPluginAsync = async (app) => {
         })
       }
 
-      const result = await store.updateMemberRole(id, userId, parsed.data.role)
+      const result = await store.updateMemberRole(id, userId, parsed.data.role, request.requestScope
+        ? { forbidExistingOwnerMutation: true }
+        : undefined)
 
       if (result.member) {
         return { member: result.member }
@@ -83,6 +87,15 @@ const memberRoutesPlugin: FastifyPluginAsync = async (app) => {
           status: 404,
           code: ERROR_CODES.NOT_MEMBER,
           message: 'User is not a member of this workspace',
+          requestId: request.id,
+        })
+      }
+
+      if (result.code === ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN) {
+        throw new HttpError({
+          status: 403,
+          code: result.code,
+          message: result.code,
           requestId: request.id,
         })
       }
@@ -115,7 +128,9 @@ const memberRoutesPlugin: FastifyPluginAsync = async (app) => {
         }
       }
 
-      const result = await store.removeMember(id, userId)
+      const result = await store.removeMember(id, userId, request.requestScope
+        ? { forbidExistingOwnerMutation: true }
+        : undefined)
 
       if (result.removed) {
         return { removed: true }
@@ -135,6 +150,15 @@ const memberRoutesPlugin: FastifyPluginAsync = async (app) => {
           status: 404,
           code: ERROR_CODES.NOT_MEMBER,
           message: 'User is not a member of this workspace',
+          requestId: request.id,
+        })
+      }
+
+      if (result.code === ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN) {
+        throw new HttpError({
+          status: 403,
+          code: result.code,
+          message: result.code,
           requestId: request.id,
         })
       }


### PR DESCRIPTION
## Summary
- add scoped atomic create-if-absent so concurrent owner creation cannot be overwritten
- evaluate scoped owner demotion/removal inside the same Local/Postgres store mutation seam
- preserve generic store/route behavior and allowed owner promotion/editor-viewer mutation
- add controlled PostgreSQL interleaving proof for both linearization orders

## Contract
Implements merged #699 D1-004b2a. Route-level role reads are not authority; no mutex, route SQL, schema/migration, fault hook, or policy framework.

## Proof
- remote-verified head `3b0396fcf0842917bafdf65fcb0a540801b64921`
- patch ID `6a897fbbdac82e07ce76247cd9a8875a0191caf6`
- 83 local member/Local-store/conformance tests passed
- core typecheck, import audit, core build/assert, diff check passed
- independent atomic/spec review clean
- structured autoreview clean (0.94)

## CI-required proof
The controlled Postgres race tests are committed but could not execute locally because the default `ubuntu:test` database credential is unavailable. CI with its Postgres service must pass before merge.