### PR TITLE
#391 D1-004b2b: guard managed owner account deletion atomically

### DIFF
--- a/packages/core/src/server/app/__tests__/routes.test.ts
+++ b/packages/core/src/server/app/__tests__/routes.test.ts
@@ -11,6 +11,7 @@ import { runMigrations } from '../../db/migrate'
 import { PostgresUserStore } from '../../db/stores/PostgresUserStore'
 import { PostgresWorkspaceStore } from '../../db/stores/PostgresWorkspaceStore'
 import type { CoreConfig } from '../../../shared/types'
+import { ERROR_CODES } from '../../../shared/errors'
 import postgres from 'postgres'
 
 const TEST_DB_URL = process.env.DATABASE_URL ?? 'postgres://ubuntu:test@localhost/boring_ui_test'
@@ -96,6 +97,15 @@ beforeAll(async () => {
   app = Fastify({ logger: false })
   app.decorate('config', config)
   app.decorate('auth', auth)
+  app.addHook('onRequest', async (request) => {
+    const workspaceId = request.headers['x-test-scope']
+    if (typeof workspaceId === 'string') {
+      request.requestScope = Object.freeze({
+        bindingId: 'binding-test', workspaceId,
+        defaultDeploymentId: 'deployment-test', activeRevision: 'revision-test',
+      })
+    }
+  })
 
   registerErrorHandler(app)
   registerCapabilities(app)
@@ -493,6 +503,60 @@ describe('DELETE /api/v1/me', () => {
     })
     expect(res.statusCode).toBe(400)
     expect(res.json().code).toBe('validation_failed')
+  })
+
+  it('blocks scoped co-owner account deletion before mutation', async () => {
+    const owner = await createSessionUser('scoped-owner-delete')
+    const peer = await createSessionUser('scoped-owner-peer')
+    const [workspace] = await rawSql`
+      INSERT INTO workspaces (app_id, name, created_by, is_default)
+      VALUES ('test-app', 'Scoped Owner Workspace', ${owner.id}, false)
+      RETURNING id
+    `
+    await rawSql`
+      INSERT INTO workspace_members (workspace_id, user_id, role)
+      VALUES (${workspace.id as string}, ${owner.id}, 'owner'), (${workspace.id as string}, ${peer.id}, 'owner')
+    `
+
+    const res = await app.inject({
+      method: 'DELETE', url: '/api/v1/me',
+      headers: { cookie: owner.cookie, 'x-test-scope': workspace.id as string },
+      payload: { confirm: owner.email },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.json().code).toBe(ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN)
+    expect(res.headers['set-cookie']).toBeUndefined()
+    expect((await rawSql`SELECT COUNT(*)::int AS count FROM users WHERE id = ${owner.id}`)[0].count).toBe(1)
+    expect((await rawSql`SELECT role FROM workspace_members WHERE workspace_id = ${workspace.id as string} AND user_id = ${owner.id}`)[0].role).toBe('owner')
+    const me = await app.inject({ method: 'GET', url: '/api/v1/me', headers: { cookie: owner.cookie } })
+    expect(me.statusCode).toBe(200)
+    expect(me.json().user.id).toBe(owner.id)
+  })
+
+  it('allows scoped non-owner account deletion without deleting the workspace', async () => {
+    const owner = await createSessionUser('scoped-member-owner')
+    const member = await createSessionUser('scoped-member-delete')
+    const [workspace] = await rawSql`
+      INSERT INTO workspaces (app_id, name, created_by, is_default)
+      VALUES ('test-app', 'Scoped Member Workspace', ${owner.id}, false)
+      RETURNING id
+    `
+    await rawSql`
+      INSERT INTO workspace_members (workspace_id, user_id, role)
+      VALUES (${workspace.id as string}, ${owner.id}, 'owner'), (${workspace.id as string}, ${member.id}, 'editor')
+    `
+
+    const res = await app.inject({
+      method: 'DELETE', url: '/api/v1/me',
+      headers: { cookie: member.cookie, 'x-test-scope': workspace.id as string },
+      payload: { confirm: member.email },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect((await rawSql`SELECT COUNT(*)::int AS count FROM users WHERE id = ${member.id}`)[0].count).toBe(0)
+    expect((await rawSql`SELECT COUNT(*)::int AS count FROM workspaces WHERE id = ${workspace.id as string}`)[0].count).toBe(1)
+    expect((await rawSql`SELECT COUNT(*)::int AS count FROM workspace_members WHERE workspace_id = ${workspace.id as string} AND user_id = ${member.id}`)[0].count).toBe(0)
   })
 
   it('deletes sole-owner user by deleting no-editor workspaces', async () => {

--- a/packages/core/src/server/app/routes.ts
+++ b/packages/core/src/server/app/routes.ts
@@ -190,7 +190,7 @@ const routesPlugin: FastifyPluginAsync<RoutesOptions> = async (app, opts) => {
       'user.delete.start',
     )
 
-    await deleteUserCompletely(user.id, { db })
+    await deleteUserCompletely(user.id, { db, protectedWorkspaceId: request.requestScope?.workspaceId })
 
     const signOutResponse = await (app.auth.api.signOut as (input: {
       headers: Headers

--- a/packages/core/src/server/auth/__tests__/deleteUserCompletely.test.ts
+++ b/packages/core/src/server/auth/__tests__/deleteUserCompletely.test.ts
@@ -70,6 +70,56 @@ async function seedWorkspace(ownerId: string, name: string): Promise<string> {
   return workspaceId
 }
 
+async function waitForLockWaiter(blockerPid: number): Promise<number> {
+  for (let attempt = 0; attempt < 300; attempt += 1) {
+    const [row] = await sqlClient`
+      SELECT pid FROM pg_stat_activity
+      WHERE datname = current_database() AND wait_event_type = 'Lock'
+        AND ${blockerPid} = ANY(pg_blocking_pids(pid))
+      ORDER BY pid LIMIT 1
+    `
+    if (row) return Number(row.pid)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(`Timed out waiting for account-deletion waiter behind PID ${blockerPid}`)
+}
+
+async function runQueuedAccountOperations(
+  lock: 'user' | 'membership',
+  workspaceId: string,
+  userId: string,
+  first: () => Promise<unknown>,
+  second: () => Promise<unknown>,
+): Promise<[PromiseSettledResult<unknown>, PromiseSettledResult<unknown>]> {
+  let locked!: (pid: number) => void
+  let release!: () => void
+  const lockedPromise = new Promise<number>((resolve) => { locked = resolve })
+  const releasePromise = new Promise<void>((resolve) => { release = resolve })
+  const blocker = sqlClient.begin(async (tx) => {
+    if (lock === 'user') await tx`SELECT id FROM users WHERE id = ${userId} FOR UPDATE`
+    else await tx`SELECT user_id FROM workspace_members WHERE workspace_id = ${workspaceId} AND user_id = ${userId} FOR UPDATE`
+    const [connection] = await tx`SELECT pg_backend_pid()::int AS pid`
+    locked(Number(connection.pid))
+    await releasePromise
+  })
+  try {
+    const blockerPid = await Promise.race([
+      lockedPromise,
+      blocker.then(() => { throw new Error('Account-deletion lock blocker exited early') }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Account-deletion lock blocker timed out')), 6_000)),
+    ])
+    const firstResult = first()
+    const firstWaiterPid = await waitForLockWaiter(blockerPid)
+    const secondResult = second()
+    await waitForLockWaiter(firstWaiterPid)
+    release()
+    return await Promise.allSettled([firstResult, secondResult]) as [PromiseSettledResult<unknown>, PromiseSettledResult<unknown>]
+  } finally {
+    release()
+    await blocker
+  }
+}
+
 beforeAll(async () => {
   await runMigrations(BASE_CONFIG)
   sqlClient = postgres(TEST_DB_URL, { max: 4 })
@@ -152,6 +202,65 @@ beforeEach(async () => {
 })
 
 describe('deleteUserCompletely', () => {
+  it('blocks a protected co-owner before account or membership mutation', async () => {
+    const owner = await seedUser('protected-owner')
+    const peer = await seedUser('protected-peer')
+    const workspaceId = await seedWorkspace(owner.id, 'Protected Workspace')
+    await workspaceStore.upsertMember(workspaceId, peer.id, 'owner')
+    await sqlClient`INSERT INTO boring_credit_grants (user_id, reason, amount_micros) VALUES (${owner.id}, 'signup_grant', 1000000)`
+
+    await expect(deleteUserCompletely(owner.id, {
+      db: drizzle(sqlClient), protectedWorkspaceId: workspaceId,
+    })).rejects.toMatchObject({
+      status: 403,
+      code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN,
+    })
+
+    expect(await userStore.getById(owner.id)).not.toBeNull()
+    expect(await workspaceStore.getMemberRole(workspaceId, owner.id)).toBe('owner')
+    expect(await workspaceStore.getMemberRole(workspaceId, peer.id)).toBe('owner')
+    expect((await sqlClient`SELECT created_by FROM workspaces WHERE id = ${workspaceId}`)[0].created_by).toBe(owner.id)
+    expect((await sqlClient`SELECT COUNT(*)::int AS count FROM boring_credit_grants WHERE user_id = ${owner.id}`)[0].count).toBe(1)
+  })
+
+  it.each([
+    ['first owner insertion', 'user', false],
+    ['existing editor promotion', 'membership', true],
+  ] as const)('serializes %s against protected account deletion in both orders', async (_case, lock, seedEditor) => {
+    for (const promotionFirst of [true, false]) {
+      const workspaceOwner = await seedUser(`race-owner-${lock}-${promotionFirst}`)
+      const target = await seedUser(`race-target-${lock}-${promotionFirst}`)
+      const workspaceId = await seedWorkspace(workspaceOwner.id, `Race ${lock}`)
+      if (seedEditor) await workspaceStore.upsertMember(workspaceId, target.id, 'editor')
+      const promote = () => workspaceStore.upsertMember(workspaceId, target.id, 'owner')
+      const deleteAccount = () => deleteUserCompletely(target.id, {
+        db: drizzle(sqlClient), protectedWorkspaceId: workspaceId,
+      })
+
+      const [first, second] = await runQueuedAccountOperations(
+        lock, workspaceId, target.id,
+        promotionFirst ? promote : deleteAccount,
+        promotionFirst ? deleteAccount : promote,
+      )
+      const promotion = promotionFirst ? first : second
+      const deletion = promotionFirst ? second : first
+      if (promotionFirst) {
+        expect(promotion.status).toBe('fulfilled')
+        expect(deletion).toMatchObject({
+          status: 'rejected',
+          reason: { status: 403, code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN },
+        })
+        expect(await userStore.getById(target.id)).not.toBeNull()
+        expect(await workspaceStore.getMemberRole(workspaceId, target.id)).toBe('owner')
+      } else {
+        expect(deletion.status).toBe('fulfilled')
+        expect(promotion.status).toBe('rejected')
+        expect(await userStore.getById(target.id)).toBeNull()
+        expect(await workspaceStore.getMemberRole(workspaceId, target.id)).toBeNull()
+      }
+    }
+  })
+
   it('completes for a user with no memberships and deletes auth-owned records', async () => {
     const user = await seedUser('no-memberships')
 

--- a/packages/core/src/server/auth/deleteUserCompletely.ts
+++ b/packages/core/src/server/auth/deleteUserCompletely.ts
@@ -1,5 +1,6 @@
 import { and, eq, isNotNull, isNull, sql } from 'drizzle-orm'
 
+import { ERROR_CODES, HttpError } from '../../shared/errors.js'
 import type { Database } from '../db/connection.js'
 import {
   users,
@@ -17,16 +18,19 @@ import {
 } from '../db/schema.js'
 
 const RETRYABLE_TX_ERROR_CODES = new Set(['40001', '40P01'])
+const MEMBERSHIP_USER_FK = 'workspace_members_user_id_users_id_fk'
 const SERIALIZATION_RETRY_LIMIT = 5
 const BASE_RETRY_DELAY_MS = 25
 
-function isRetryableTxFailure(error: unknown): boolean {
-  return (
-    typeof error === 'object'
-    && error !== null
-    && 'code' in error
-    && RETRYABLE_TX_ERROR_CODES.has(String((error as { code?: unknown }).code))
-  )
+function isRetryableTxFailure(error: unknown, retryMembershipUserFk: boolean): boolean {
+  let candidate = error
+  for (let depth = 0; depth < 4 && typeof candidate === 'object' && candidate !== null; depth += 1) {
+    const details = candidate as { code?: unknown; constraint_name?: unknown; cause?: unknown }
+    if (RETRYABLE_TX_ERROR_CODES.has(String(details.code))) return true
+    if (retryMembershipUserFk && details.code === '23503' && details.constraint_name === MEMBERSHIP_USER_FK) return true
+    candidate = details.cause
+  }
+  return false
 }
 
 function sleep(ms: number): Promise<void> {
@@ -35,6 +39,7 @@ function sleep(ms: number): Promise<void> {
 
 export interface DeleteUserCompletelyDeps {
   db: Database
+  protectedWorkspaceId?: string
 }
 
 export async function deleteUserCompletely(
@@ -45,6 +50,26 @@ export async function deleteUserCompletely(
     try {
       await deps.db.transaction(async (tx) => {
         await tx.execute(sql`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`)
+
+        let protectedUser: { email: string } | undefined
+        if (deps.protectedWorkspaceId) {
+          const [lockedUser] = await tx.select({ email: users.email }).from(users)
+            .where(eq(users.id, userId)).limit(1).for('update')
+          protectedUser = lockedUser
+          await tx.execute(sql`
+            SELECT user_id FROM workspace_members
+            WHERE workspace_id = ${deps.protectedWorkspaceId} AND user_id = ${userId}
+            FOR UPDATE
+          `)
+          const [membership] = await tx.select({ role: workspaceMembers.role }).from(workspaceMembers).where(and(
+            eq(workspaceMembers.workspaceId, deps.protectedWorkspaceId), eq(workspaceMembers.userId, userId),
+          )).limit(1)
+          if (membership?.role === 'owner') throw new HttpError({
+            status: 403,
+            code: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN,
+            message: ERROR_CODES.D1_MANAGED_WORKSPACE_MUTATION_FORBIDDEN,
+          })
+        }
 
         const ownerWorkspaces = await tx
           .select({ id: workspaces.id })
@@ -203,11 +228,8 @@ export async function deleteUserCompletely(
             .where(eq(workspaces.id, workspace.id))
         }
 
-        const [userRow] = await tx
-          .select({ email: users.email })
-          .from(users)
-          .where(eq(users.id, userId))
-          .limit(1)
+        const userRow = protectedUser ?? (await tx.select({ email: users.email }).from(users)
+          .where(eq(users.id, userId)).limit(1))[0]
 
         if (userRow?.email) {
           await tx
@@ -231,7 +253,7 @@ export async function deleteUserCompletely(
 
       return
     } catch (error) {
-      if (attempt < SERIALIZATION_RETRY_LIMIT && isRetryableTxFailure(error)) {
+      if (attempt < SERIALIZATION_RETRY_LIMIT && isRetryableTxFailure(error, Boolean(deps.protectedWorkspaceId))) {
         await sleep(BASE_RETRY_DELAY_MS * attempt)
         continue
       }


### PR DESCRIPTION
## Summary
- pass only the trusted scoped workspace id into account deletion
- lock user then scoped membership inside the existing serializable retry transaction
- reject every current scoped owner before any delete/transfer/ledger effect or sign-out
- preserve scoped non-owner deletion and generic deletion behavior
- prove first-owner insertion and existing-editor promotion races in both orders

## Contract
Implements merged #699 D1-004b2b on top of merged b2a/#700. No mutex, route SQL, schema/migration, or lifecycle policy abstraction.

## Proof
- remote-verified head `cac225ddca6d05b64f9cbecb099e3960f0b71cdd`
- patch ID `4057125741b323f7b8cb97f009e5dd2dada2f483`
- isolated PostgreSQL b2b proof 30/30
- combined b2a interaction proof 87/87
- core typecheck, build/assert, import audit, diff check green
- structured branch autoreview clean
- independent atomic/security review clean

The real proof narrowed exact FK `23503` retry handling to scoped D1 deletion only; generic retry behavior remains unchanged.