### PR TITLE
#391 feat(mcp): enforce D1 workspace scope

### DIFF
--- a/apps/full-app/src/server/__tests__/boringMcp.test.ts
+++ b/apps/full-app/src/server/__tests__/boringMcp.test.ts
@@ -31,8 +31,22 @@ import {
 } from '../boringMcp'
 import { serverPlugins } from '../plugins'
 import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
+import { createCoreApp } from '@hachej/boring-core/server'
+import { ERROR_CODES, HttpError, type CoreConfig } from '@hachej/boring-core/shared'
 
 const actor: McpActor = { workspaceId: 'workspace-1', userId: 'user-1' }
+const authenticated = { authorization: 'Bearer test' }
+const scopedRequest = {
+  bindingId: 'binding-1', workspaceId: actor.workspaceId,
+  defaultDeploymentId: 'deployment-1', activeRevision: 'revision-1',
+} as const
+const routeTestConfig: CoreConfig = {
+  appId: 'full-app-test', appName: 'Test', appLogo: null, port: 0, host: '127.0.0.1', staticDir: null,
+  databaseUrl: null, stores: 'local', cors: { origins: [], credentials: true }, bodyLimit: 1024 * 1024, logLevel: 'fatal',
+  security: { csp: { enabled: false } }, encryption: { workspaceSettingsKey: 'a'.repeat(64) },
+  auth: { secret: 's'.repeat(64), url: 'http://localhost:3000', sessionTtlSeconds: 3600, sessionCookieSecure: false },
+  features: { githubOauth: false, googleOauth: false, invitesEnabled: false, sendWelcomeEmail: false, inviteTtlDays: 7 },
+}
 const source: McpSource = {
   id: 'source:notion:user-1',
   workspaceId: actor.workspaceId,
@@ -114,6 +128,60 @@ function makeRouteHarness(
   })
   registerFullAppBoringMcpRoutes(app as unknown as CoreWorkspaceAgentServer, { provider, env, transport })
   return app
+}
+
+async function makeScopedRouteHarness(scoped = true) {
+  let member = true
+  const settings = { settings: {}, displayName: '', email: '' }
+  const calls = {
+    getWorkspace: vi.fn(async (workspaceId: string) => workspaceId === actor.workspaceId
+      ? { id: workspaceId, appId: routeTestConfig.appId, name: 'Workspace', createdBy: actor.userId, createdAt: '', deletedAt: null, isDefault: true }
+      : null),
+    getMemberRole: vi.fn(async (workspaceId: string, userId: string) => member && workspaceId === actor.workspaceId && userId === actor.userId ? 'owner' : null),
+    getUserSettings: vi.fn(async () => settings),
+    putUserSettings: vi.fn(async () => settings),
+    startConnect: vi.fn(async () => ({
+      connectorRef: { provider: 'notion', toolkitId: 'notion', sessionId: 'session-1' },
+      status: 'unconfigured' as const,
+      connectUrl: 'https://app.composio.dev/connect/fake',
+    })),
+    refreshStatus: vi.fn(),
+    revoke: vi.fn(),
+  }
+  const app = await createCoreApp(routeTestConfig, {
+    manageShutdown: false,
+    ...(scoped ? { requestScopeResolver: async () => scopedRequest } : {}),
+  })
+  app.decorate('workspaceStore', { get: calls.getWorkspace, getMemberRole: calls.getMemberRole } as never)
+  app.decorate('userStore', { getUserSettings: calls.getUserSettings, putUserSettings: calls.putUserSettings } as never)
+  app.addHook('onRequest', async (request) => {
+    request.user = null
+    if (request.headers.authorization !== authenticated.authorization) {
+      throw new HttpError({ status: 401, code: ERROR_CODES.UNAUTHORIZED, message: 'Authentication required', requestId: request.id })
+    }
+    request.user = { id: actor.userId, email: 'demo@example.com', name: 'Demo', emailVerified: true }
+  })
+  const provider: ManagedConnectorProvider = {
+    startConnect: calls.startConnect,
+    refreshStatus: calls.refreshStatus,
+    probe: vi.fn(),
+    revoke: calls.revoke,
+  }
+  const transport = fakeTransport()
+  await app.register(async (routeApp) => {
+    routeApp.setErrorHandler((error, _request, reply) => {
+      const status = (error as { status?: number; statusCode?: number }).status ?? (error as { statusCode?: number }).statusCode
+      const code = status === 429 ? ERROR_CODES.RATE_LIMITED : (error as { code?: string }).code
+      return reply.status(status ?? 500).send({ code: code ?? ERROR_CODES.INTERNAL_ERROR })
+    })
+    registerFullAppBoringMcpRoutes(routeApp as unknown as CoreWorkspaceAgentServer, {
+      provider,
+      env: { COMPOSIO_API_KEY: 'test-key' } as NodeJS.ProcessEnv,
+      transport,
+    })
+  })
+  await app.ready()
+  return { app, calls, transport, setMember: (value: boolean) => { member = value } }
 }
 
 function evaluateTestBoringMcpLaunchGate() {
@@ -287,6 +355,117 @@ describe('full-app boring-mcp binding', () => {
     expect(disconnected.json()).toMatchObject({ status: { source: { status: 'revoked' }, canDisconnect: false } })
     expect(provider.revoke).toHaveBeenCalled()
 
+    await app.close()
+  })
+
+  it('derives trusted scope and accepts every matching selector before MCP effects', async () => {
+    const { app, calls } = await makeScopedRouteHarness()
+    const absent = await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources', headers: authenticated })
+    expect(absent.statusCode).toBe(200)
+
+    const matching = await app.inject({
+      method: 'POST',
+      url: `/api/v1/boring-mcp/connect?workspaceId=${actor.workspaceId}&workspaceId=${actor.workspaceId}`,
+      headers: { ...authenticated, 'x-boring-workspace-id': `${actor.workspaceId}, ${actor.workspaceId}` },
+      payload: { workspaceId: actor.workspaceId, provider: 'notion' },
+    })
+    expect(matching.statusCode).toBe(201)
+    expect(calls.getWorkspace).toHaveBeenCalledWith(actor.workspaceId)
+    expect(calls.startConnect).toHaveBeenCalledOnce()
+    await app.close()
+  })
+
+  it('rejects every malformed, conflicting, or foreign scoped selector before downstream work', async () => {
+    const { app, calls, transport } = await makeScopedRouteHarness()
+    const requests = [
+      { method: 'GET' as const, url: '/api/v1/boring-mcp/sources', headers: { ...authenticated, 'x-boring-workspace-id': 'foreign-workspace' } },
+      { method: 'GET' as const, url: '/api/v1/boring-mcp/sources', headers: { ...authenticated, 'x-boring-workspace-id': `${actor.workspaceId},foreign-workspace` } },
+      { method: 'GET' as const, url: '/api/v1/boring-mcp/sources?workspaceId=../bad', headers: authenticated },
+      { method: 'GET' as const, url: `/api/v1/boring-mcp/sources?workspaceId=${actor.workspaceId}&workspaceId=foreign-workspace`, headers: authenticated },
+      { method: 'POST' as const, url: '/api/v1/boring-mcp/connect', headers: authenticated, payload: { workspaceId: 42, provider: 'notion' } },
+      { method: 'POST' as const, url: '/api/v1/boring-mcp/connect', headers: authenticated, payload: { workspaceId: [], provider: 'notion' } },
+      { method: 'POST' as const, url: '/api/v1/boring-mcp/refresh', headers: { ...authenticated, 'x-boring-workspace-id': 'foreign-workspace' }, payload: { sourceId: 'source-1' } },
+      { method: 'POST' as const, url: '/api/v1/boring-mcp/disconnect?workspaceId=../bad', headers: authenticated, payload: { sourceId: 'source-1' } },
+      { method: 'POST' as const, url: '/api/v1/boring-mcp/tools', headers: authenticated, payload: { workspaceId: 'foreign-workspace', sourceId: 'source-1' } },
+    ]
+    for (const request of requests) {
+      const response = await app.inject(request)
+      expect(response.statusCode, response.body).toBe(421)
+      expect(response.json()).toMatchObject({ code: ERROR_CODES.D1_HOST_SCOPE_VIOLATION })
+    }
+    expect(calls.getWorkspace).not.toHaveBeenCalled()
+    expect(calls.getMemberRole).not.toHaveBeenCalled()
+    expect(calls.getUserSettings).not.toHaveBeenCalled()
+    expect(calls.startConnect).not.toHaveBeenCalled()
+    expect(calls.refreshStatus).not.toHaveBeenCalled()
+    expect(calls.revoke).not.toHaveBeenCalled()
+    expect(transport.listTools).not.toHaveBeenCalled()
+    await app.close()
+  })
+
+  it('charges scoped POST selector failures and nonmembers to one trusted bucket', async () => {
+    const { app, calls, setMember } = await makeScopedRouteHarness()
+    for (let index = 0; index < 9; index += 1) {
+      const denied = await app.inject({
+        method: 'POST', url: '/api/v1/boring-mcp/connect',
+        headers: { ...authenticated, 'x-boring-workspace-id': `foreign-${index}` }, payload: { provider: 'notion' },
+      })
+      expect(denied.statusCode).toBe(421)
+    }
+    setMember(false)
+    const nonmember = await app.inject({ method: 'POST', url: '/api/v1/boring-mcp/connect', headers: authenticated, payload: { provider: 'notion' } })
+    expect(nonmember.statusCode).toBe(403)
+    setMember(true)
+    const limited = await app.inject({ method: 'POST', url: '/api/v1/boring-mcp/connect', headers: authenticated, payload: { provider: 'notion' } })
+    expect(limited.statusCode).toBe(429)
+    expect(limited.json()).toMatchObject({ code: ERROR_CODES.RATE_LIMITED })
+    expect(calls.startConnect).not.toHaveBeenCalled()
+    await app.close()
+  })
+
+  it('bounds scoped GET traffic through the shared Fastify route limiter', async () => {
+    const { app, calls } = await makeScopedRouteHarness()
+    for (let index = 0; index < 60; index += 1) {
+      const denied = await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources', headers: { ...authenticated, 'x-boring-workspace-id': `foreign-${index}` } })
+      expect(denied.statusCode).toBe(421)
+    }
+    const limited = await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources', headers: authenticated })
+    expect(limited.statusCode).toBe(429)
+    expect(calls.getWorkspace).not.toHaveBeenCalled()
+    expect(calls.getUserSettings).not.toHaveBeenCalled()
+    await app.close()
+  })
+
+  it('keeps global unauthenticated 401 ahead of the scoped POST limiter', async () => {
+    const { app } = await makeScopedRouteHarness()
+    const unauthenticated = await app.inject({ method: 'POST', url: '/api/v1/boring-mcp/connect', payload: { provider: 'notion' } })
+    expect(unauthenticated.statusCode).toBe(401)
+    for (let index = 0; index < 10; index += 1) {
+      const denied = await app.inject({
+        method: 'POST', url: '/api/v1/boring-mcp/connect',
+        headers: { ...authenticated, 'x-boring-workspace-id': `foreign-${index}` }, payload: { provider: 'notion' },
+      })
+      expect(denied.statusCode).toBe(421)
+    }
+    const limited = await app.inject({ method: 'POST', url: '/api/v1/boring-mcp/connect', headers: authenticated, payload: { provider: 'notion' } })
+    expect(limited.statusCode).toBe(429)
+    await app.close()
+  })
+
+  it('preserves unscoped GET bypass and POST raw-selector buckets', async () => {
+    const { app, setMember } = await makeScopedRouteHarness(false)
+    expect((await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources' })).statusCode).toBe(401)
+    for (let index = 0; index < 61; index += 1) {
+      expect((await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources', headers: authenticated })).statusCode).toBe(400)
+    }
+    for (let index = 0; index < 10; index += 1) {
+      expect((await app.inject({ method: 'POST', url: '/api/v1/boring-mcp/connect', headers: { ...authenticated, 'x-boring-workspace-id': 'workspace-2' }, payload: { provider: 'notion' } })).statusCode).toBe(404)
+    }
+    expect((await app.inject({ method: 'POST', url: '/api/v1/boring-mcp/connect', headers: { ...authenticated, 'x-boring-workspace-id': 'workspace-3' }, payload: { provider: 'notion' } })).statusCode).toBe(404)
+    expect((await app.inject({ method: 'POST', url: '/api/v1/boring-mcp/connect', headers: { ...authenticated, 'x-boring-workspace-id': 'workspace-2' }, payload: { provider: 'notion' } })).statusCode).toBe(429)
+    setMember(false)
+    expect((await app.inject({ method: 'POST', url: '/api/v1/boring-mcp/connect', headers: { ...authenticated, 'x-boring-workspace-id': actor.workspaceId }, payload: { provider: 'notion' } })).statusCode).toBe(403)
+    expect((await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources?workspaceId=../bad', headers: authenticated })).statusCode).toBe(400)
     await app.close()
   })
 

--- a/apps/full-app/src/server/boringMcp.ts
+++ b/apps/full-app/src/server/boringMcp.ts
@@ -98,7 +98,11 @@ export function registerFullAppBoringMcpRoutes(
   app: CoreWorkspaceAgentServer,
   options: { provider?: ManagedConnectorProvider; env?: NodeJS.ProcessEnv; transport?: McpTransportClient } = {},
 ): void {
-  registerBoringMcpRoutes(app, { config: FULL_APP_BORING_MCP_CONFIG, ...options })
+  registerBoringMcpRoutes(app, {
+    config: FULL_APP_BORING_MCP_CONFIG,
+    resolveTrustedWorkspaceId: (request) => request.requestScope?.workspaceId,
+    ...options,
+  })
 }
 
 export function createFullAppBoringMcpServerPlugins(env: NodeJS.ProcessEnv = process.env) {

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -12,7 +12,7 @@ const FULL_APP_DEFAULT_PLUGIN_PACKAGE_COMPOSITION = Object.freeze([{
   packageName: '@hachej/boring-automation',
   descriptor: Object.freeze({
     id: 'boring-automation',
-    version: '0.1.81',
+    version: '0.1.82',
     contentDigest: 'sha256:d6f43891e5c9c3d40beb0eb7953b53c12b92c7595c4ed54758f468687903d9ed',
   } satisfies StableContributionDescriptor),
 }])
@@ -22,13 +22,13 @@ export const FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS = Object.freeze(FULL_AP
 
 export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'full-app-governance',
-  version: '0.1.81',
+  version: '0.1.82',
   contentDigest: 'sha256:ebc7e5b2cb8d83b158b8bed4ed8a118368765ff68817c81b5f98463a72e19f7f',
 } satisfies StableContributionDescriptor)
 
 export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'boring-mcp',
-  version: '0.1.81',
+  version: '0.1.82',
   contentDigest: 'sha256:1af659b0b66cf3fc3a641e176c229b7c79c9b9444bc64d7c1ca6deea6a4340dd',
 } satisfies StableContributionDescriptor)
 

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -29,7 +29,7 @@ export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
 export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'boring-mcp',
   version: '0.1.81',
-  contentDigest: 'sha256:a2dae3c8e2d785152c011829cab20884164cbda2552db33aa9fd9fcd87aace37',
+  contentDigest: 'sha256:1af659b0b66cf3fc3a641e176c229b7c79c9b9444bc64d7c1ca6deea6a4340dd',
 } satisfies StableContributionDescriptor)
 
 // Freshness test: lexical tracked files -> SHA-256(bytes) per file ->

--- a/plugins/boring-mcp/src/server/appServerBinding.ts
+++ b/plugins/boring-mcp/src/server/appServerBinding.ts
@@ -443,10 +443,14 @@ export function createBoringMcpAppAgentToolsForRequest(
   return createBoringMcpAppAgentTools(app, { workspaceId: ctx.workspaceId, userId }, options)
 }
 
-async function requireBoringMcpActor(app: BoringMcpAppServer, request: FastifyRequest): Promise<McpActor> {
+async function requireBoringMcpActor(
+  app: BoringMcpAppServer,
+  request: FastifyRequest,
+  admittedWorkspaceId?: string,
+): Promise<McpActor> {
   const body = asRecord(request.body)
   const query = asRecord(request.query)
-  const workspaceId = validateWorkspaceId(
+  const workspaceId = admittedWorkspaceId ?? validateWorkspaceId(
     request.headers['x-boring-workspace-id'] ?? body.workspaceId ?? query.workspaceId,
     request.id,
   )
@@ -466,6 +470,37 @@ function sourceActionRateLimitKey(request: FastifyRequest): string {
   return `${request.user?.id ?? request.ip}:${workspaceId}`
 }
 
+function d1HostScopeViolation(request: FastifyRequest): never {
+  throw routeError(421, ERROR_CODES.D1_HOST_SCOPE_VIOLATION, ERROR_CODES.D1_HOST_SCOPE_VIOLATION, request.id)
+}
+
+function presentedWorkspaceIds(request: FastifyRequest): unknown[] {
+  const presented: unknown[] = []
+  const append = (value: unknown) => {
+    if (Array.isArray(value)) presented.push(...(value.length > 0 ? value : [value]))
+    else presented.push(value)
+  }
+
+  let foundRawHeader = false
+  for (let index = 0; index < request.raw.rawHeaders.length; index += 2) {
+    if (request.raw.rawHeaders[index]?.toLowerCase() !== 'x-boring-workspace-id') continue
+    foundRawHeader = true
+    append(request.raw.rawHeaders[index + 1]?.split(','))
+  }
+  if (!foundRawHeader) {
+    for (const [key, value] of Object.entries(request.headers)) {
+      if (key.toLowerCase() === 'x-boring-workspace-id') append(value)
+    }
+  }
+
+  for (const value of [request.query, request.body]) {
+    if (value && typeof value === 'object' && !Array.isArray(value) && Object.prototype.hasOwnProperty.call(value, 'workspaceId')) {
+      append((value as Record<string, unknown>).workspaceId)
+    }
+  }
+  return presented
+}
+
 function sourceIdFromBody(body: unknown, requestId: string): string {
   const sourceId = parseString(asRecord(body).sourceId)
   if (!sourceId) throw routeError(400, ERROR_CODES.VALIDATION_FAILED, 'sourceId is required', requestId)
@@ -483,6 +518,7 @@ export interface RegisterBoringMcpRoutesOptions {
   provider?: ManagedConnectorProvider
   env?: NodeJS.ProcessEnv
   transport?: McpTransportClient
+  resolveTrustedWorkspaceId?: (request: FastifyRequest) => string | undefined
   /**
    * Behavior when boring-mcp is disabled for this deployment.
    * - `skip` (default): do not register the routes at all (client sees 404).
@@ -502,6 +538,29 @@ export function registerBoringMcpRoutes(app: BoringMcpAppServer, options: Regist
 
   const routeTransport = options.transport ?? createComposioMcpTransportFor(options.config, options.env)
   const routeGate = new InMemoryMcpRateBudgetGate({ maxCalls: 100, maxToolCalls: 10, windowMs: 60_000 })
+  const admittedWorkspaceIds = new WeakMap<FastifyRequest, string>()
+  const trustedWorkspaceId = (request: FastifyRequest) => options.resolveTrustedWorkspaceId?.(request)
+  const sourceRouteRateLimitKey = (request: FastifyRequest) => {
+    const trusted = trustedWorkspaceId(request)
+    if (trusted === undefined) return sourceActionRateLimitKey(request)
+    const userId = request.user?.id
+    if (!userId) throw routeError(401, ERROR_CODES.UNAUTHORIZED, 'Authentication required', request.id)
+    return `${userId}:${trusted}`
+  }
+  const admitTrustedWorkspace = async (request: FastifyRequest) => {
+    const trusted = trustedWorkspaceId(request)
+    if (trusted === undefined) return
+    for (const presented of presentedWorkspaceIds(request)) {
+      let normalized: string
+      try {
+        normalized = validateWorkspaceId(presented, request.id)
+      } catch {
+        d1HostScopeViolation(request)
+      }
+      if (normalized !== trusted) d1HostScopeViolation(request)
+    }
+    admittedWorkspaceIds.set(request, trusted)
+  }
 
   function adapterFor(actor: McpActor) {
     const registry = createUserSettingsMcpSourceRegistry(app, actor)
@@ -520,19 +579,23 @@ export function registerBoringMcpRoutes(app: BoringMcpAppServer, options: Regist
     })
   }
 
-  app.get('/api/v1/boring-mcp/sources', async (request) => {
+  app.get('/api/v1/boring-mcp/sources', {
+    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceRouteRateLimitKey, allowList: (request: FastifyRequest) => trustedWorkspaceId(request) === undefined } },
+    preHandler: admitTrustedWorkspace,
+  }, async (request) => {
     assertEnabled(request.id)
-    const actor = await requireBoringMcpActor(app, request)
+    const actor = await requireBoringMcpActor(app, request, admittedWorkspaceIds.get(request))
     const { registry } = adapterFor(actor)
     const sources = await registry.listSources(actor)
     return { sourceStatuses: sources.map(createMcpSourceStatusPayload) }
   })
 
   app.post('/api/v1/boring-mcp/connect', {
-    config: { rateLimit: { ...SOURCE_CONNECT_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
+    config: { rateLimit: { ...SOURCE_CONNECT_RATE_LIMIT, keyGenerator: sourceRouteRateLimitKey } },
+    preHandler: admitTrustedWorkspace,
   }, async (request, reply) => {
     assertEnabled(request.id)
-    const actor = await requireBoringMcpActor(app, request)
+    const actor = await requireBoringMcpActor(app, request, admittedWorkspaceIds.get(request))
     const { adapter } = adapterFor(actor)
     const provider = providerFromBody(request.body, request.id)
     const result = await withMcpHttpErrors(request.id, () => adapter.startConnect(actor, { provider }))
@@ -542,29 +605,32 @@ export function registerBoringMcpRoutes(app: BoringMcpAppServer, options: Regist
   })
 
   app.post('/api/v1/boring-mcp/refresh', {
-    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
+    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceRouteRateLimitKey } },
+    preHandler: admitTrustedWorkspace,
   }, async (request) => {
     assertEnabled(request.id)
-    const actor = await requireBoringMcpActor(app, request)
+    const actor = await requireBoringMcpActor(app, request, admittedWorkspaceIds.get(request))
     const { adapter } = adapterFor(actor)
     const result = await withMcpHttpErrors(request.id, () => adapter.refreshStatus(actor, sourceIdFromBody(request.body, request.id)))
     return { status: result }
   })
 
   app.post('/api/v1/boring-mcp/disconnect', {
-    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
+    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceRouteRateLimitKey } },
+    preHandler: admitTrustedWorkspace,
   }, async (request) => {
     assertEnabled(request.id)
-    const actor = await requireBoringMcpActor(app, request)
+    const actor = await requireBoringMcpActor(app, request, admittedWorkspaceIds.get(request))
     const status = await withMcpHttpErrors(request.id, () => adapterFor(actor).adapter.disconnectSource(actor, sourceIdFromBody(request.body, request.id)))
     return { status }
   })
 
   app.post('/api/v1/boring-mcp/tools', {
-    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceActionRateLimitKey } },
+    config: { rateLimit: { ...SOURCE_ACTION_RATE_LIMIT, keyGenerator: sourceRouteRateLimitKey } },
+    preHandler: admitTrustedWorkspace,
   }, async (request) => {
     assertEnabled(request.id)
-    const actor = await requireBoringMcpActor(app, request)
+    const actor = await requireBoringMcpActor(app, request, admittedWorkspaceIds.get(request))
     const body = asRecord(request.body)
     const result = await withMcpHttpErrors(request.id, () => handlersFor(actor).searchTools(actor, {
       sourceId: sourceIdFromBody(request.body, request.id),


### PR DESCRIPTION
## D1-004c3

Fence all Boring MCP HTTP routes to the trusted D1 workspace while preserving generic behavior.

- Global auth and unauthenticated 401 remain first.
- Scoped route budgets key only on authenticated user plus frozen workspace scope; caller selectors never key or bypass them.
- The four POST actions keep their existing limiters. Scoped GET `/sources` uses the same Fastify limiter; unscoped GET remains allowlisted.
- One shared first preHandler admits every raw header/query/body workspace selector before workspace, membership, user-store, provider, transport, source, or tool effects.
- Absent selectors derive trusted scope; malformed, conflicting, or foreign selectors return stable 421.

## Proof

- Boring MCP binding: 5/5
- Full-app MCP routes: 19/19
- Composition descriptor freshness: 1/1
- Plugin and full-app typechecks
- Full-app production build
- Lint, invariants, and diff check
- Independent review: clean
- Exact-commit autoreview: clean, confidence 0.97

249 net lines, under the D1-004c3 280-line cap. Build-generated untracked proof scripts were excluded from the commit.