### PR TITLE
fix(workspace): no empty context menu on read-only file-tree roots; keep read actions

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -590,6 +590,11 @@ export function FileTreeView({
       if (target.closest("[role=treeitem]") || target.closest("[data-path]"))
         return
       event.preventDefault()
+      // The background menu only ever offers New file / New folder, both
+      // mutating actions gated by canMutate. On a read-only root there is
+      // nothing to show — opening it would render an empty menu shell.
+      // Suppress the trigger entirely rather than pop an empty box.
+      if (!canMutate) return
       setCtxMenu({
         node: { name: rootDir, kind: "dir", path: rootDir },
         x: event.clientX,
@@ -597,7 +602,7 @@ export function FileTreeView({
         isBackground: true,
       })
     },
-    [rootDir],
+    [rootDir, canMutate],
   )
 
   const handleDragDrop = useCallback(
@@ -808,6 +813,13 @@ export function FileTreeView({
   const effectiveQuery =
     (!useServerSearch || filesystem !== "user") && (searchQuery?.length ?? 0) > 0 ? searchQuery : undefined
 
+  // Mirrors the item-visibility rules rendered below: the background menu
+  // only offers mutating actions (New file/folder), while a node menu always
+  // has at least "Copy path". Used as a belt-and-suspenders guard so an
+  // empty item set never renders as a blank menu shell, even if a future
+  // change to the rules above misses a trigger-side check.
+  const ctxMenuHasItems = ctxMenu ? canMutate || !ctxMenu.isBackground : false
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       {error && (
@@ -874,7 +886,7 @@ export function FileTreeView({
         )}
       </div>
 
-      {ctxMenu && createPortal(
+      {ctxMenu && ctxMenuHasItems && createPortal(
         <div
           ref={menuRef}
           role="menu"

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -305,8 +305,13 @@ describe("FileTreePane", () => {
     })
 
     fireEvent.contextMenu(screen.getByText("handbook.md"))
+    // Mutating actions are gated by read-only access...
+    expect(screen.queryByRole("menuitem", { name: "New file" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("menuitem", { name: "New folder" })).not.toBeInTheDocument()
     expect(screen.queryByRole("menuitem", { name: "Rename" })).not.toBeInTheDocument()
     expect(screen.queryByRole("menuitem", { name: "Delete" })).not.toBeInTheDocument()
+    // ...but read actions remain available so the menu is still useful.
+    expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeInTheDocument()
   })
 
   it("remounts the tree when switching configured filesystems so expanded path state cannot leak", async () => {
@@ -950,6 +955,81 @@ describe("FileTreePane", () => {
     expect(screen.queryByRole("menuitem", { name: "Rename" })).not.toBeInTheDocument()
     expect(screen.queryByRole("menuitem", { name: "Delete" })).not.toBeInTheDocument()
     expect(screen.queryByRole("menuitem", { name: "Copy path" })).not.toBeInTheDocument()
+  })
+
+  describe("Read-only root context menu", () => {
+    it("background right-click on a read-only root does not open an empty menu", async () => {
+      render(
+        <FileTreePane
+          roots={[
+            { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+            { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readonly" },
+          ]}
+        />,
+        { wrapper },
+      )
+
+      expect(await screen.findByRole("combobox", { name: "File root" })).toBeInTheDocument()
+      await selectRoot("Project")
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+      // Background right-click on a read-only root has zero applicable
+      // items (New file/New folder are mutating actions) — the menu must
+      // not render at all, not render as an empty box.
+      const container = screen.getByTestId("file-tree").parentElement!
+      fireEvent.contextMenu(container)
+
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+      expect(screen.queryByRole("menuitem", { name: "New file" })).not.toBeInTheDocument()
+      expect(screen.queryByRole("menuitem", { name: "New folder" })).not.toBeInTheDocument()
+    })
+
+    it("right-click on a read-only root's file still opens a menu with read actions", async () => {
+      mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
+        data: filesystem === "project_alpha"
+          ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
+          : sampleFiles,
+        isLoading: false,
+        isSuccess: true,
+        error: undefined,
+      }))
+
+      render(
+        <FileTreePane
+          roots={[
+            { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+            { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readonly" },
+          ]}
+        />,
+        { wrapper },
+      )
+
+      expect(await screen.findByRole("combobox", { name: "File root" })).toBeInTheDocument()
+      await selectRoot("Project")
+      await waitFor(() => expect(screen.getByText("handbook.md")).toBeInTheDocument())
+
+      fireEvent.contextMenu(screen.getByText("handbook.md"))
+
+      expect(screen.getByRole("menu")).toBeInTheDocument()
+      expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeInTheDocument()
+      expect(screen.queryByRole("menuitem", { name: "New file" })).not.toBeInTheDocument()
+      expect(screen.queryByRole("menuitem", { name: "Rename" })).not.toBeInTheDocument()
+      expect(screen.queryByRole("menuitem", { name: "Delete" })).not.toBeInTheDocument()
+    })
+
+    it("leaves the default read-write root's background menu unchanged", async () => {
+      render(<FileTreePane />, { wrapper })
+
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+      const container = screen.getByTestId("file-tree").parentElement!
+      fireEvent.contextMenu(container)
+
+      await waitFor(() => {
+        expect(screen.getByRole("menuitem", { name: "New file" })).toBeInTheDocument()
+      })
+      expect(screen.getByRole("menuitem", { name: "New folder" })).toBeInTheDocument()
+    })
   })
 
   describe("Inline edit", () => {


### PR DESCRIPTION
## Problem

Right-clicking inside a **read-only** filesystem root in the Files tree (e.g. the tenant's read-only \`company_context\` root) could open an **empty context-menu shell** — a bordered popover box with no items.

Two failure modes:

1. **Background (empty-space) right-click on a read-only root** — the background menu only ever offers `New file` / `New folder`, both mutating actions gated by `canMutate`. On a read-only root that left **zero items**, so the menu rendered as an empty box.
2. **Node (file/folder) right-click on a read-only root** — mutating actions (Rename/Delete) were correctly hidden, but the read action (`Copy path`) already survived, so this menu was not empty. The trigger-side guard added here makes that invariant explicit and crash-proof against future drift.

## Fix

- **Never render an empty menu**: the background context-menu trigger is now suppressed entirely when `canMutate === false`, so no empty box appears. A belt-and-suspenders `ctxMenuHasItems` guard on the portal render ensures an empty item set can never render as a blank menu even if the per-item rules drift later.
- **Read-only roots still offer read actions**: `Copy path` (and `Copy Git URL` when available) remain available on read-only roots; only mutating actions (New / Rename / Delete / drag-move) stay gated by `access !== 'readwrite'`.
- Default single-root read-write behavior is **byte-identical**.

## Tests

Extended `FileTreePane.test.tsx`:
1. Read-only root's file right-click → menu shows `Copy path`, **no** New/Rename/Delete.
2. Read-only background right-click → **no menu renders at all** (`role="menu"` absent).
3. Read-write background menu unchanged (New file / New folder present).

## Gates

- workspace typecheck: clean
- workspace tests: 1700 passed / 10 skipped
- plugin invariants: ok (414 files)
- build:packages: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)