### PR TITLE
#391 feat(mcp): enforce D1 managed-agent scope

### DIFF
--- a/apps/full-app/src/server/__tests__/managedAgentMcp.test.ts
+++ b/apps/full-app/src/server/__tests__/managedAgentMcp.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import Fastify from 'fastify'
+import Fastify, { type FastifyRequest } from 'fastify'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js'
@@ -15,7 +15,8 @@ import type {
   WorkspaceAgentDispatcherResolver,
 } from '@hachej/boring-agent/server'
 import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
-import type { WorkspaceStore } from '@hachej/boring-core/server'
+import type { CoreRequestScope, WorkspaceStore } from '@hachej/boring-core/server'
+import { ERROR_CODES } from '@hachej/boring-core/shared'
 import {
   FULL_APP_MANAGED_AGENT_MCP_PATH,
   readFullAppManagedAgentMcpConfig,
@@ -28,6 +29,7 @@ const TOKEN = 'managed-agent-token'
 const WORKSPACE_ID = 'workspace-1'
 const USER_ID = 'user-1'
 const APP_ID = 'full-app-test'
+const DEFAULT_DEPLOYMENT_ID = 'deployment-1'
 const utf8Encoder = new TextEncoder()
 const utf8Decoder = new TextDecoder('utf-8')
 
@@ -58,9 +60,11 @@ describe('full-app managed-agent MCP route', () => {
     } as NodeJS.ProcessEnv)).toThrow(/BORING_MANAGED_AGENT_MCP_USER_ID/)
   })
 
-  it('rejects an invalid bearer before agent work', async () => {
+  it('rejects an invalid bearer before scoped admission or agent work', async () => {
     const resolver = fakeResolver()
-    const app = await makeApp(enabledEnv(), resolver)
+    const app = await makeApp(enabledEnv(), resolver, {
+      requestScope: scopedRequest('workspace-foreign'),
+    })
 
     const response = await app.inject({
       method: 'POST',
@@ -73,7 +77,35 @@ describe('full-app managed-agent MCP route', () => {
     expect(response.json()).toEqual({
       error: { code: ErrorCode.enum.UNAUTHORIZED, message: 'unauthorized' },
     })
+    expect(app.workspaceStore.get).not.toHaveBeenCalled()
+    expect(app.workspaceStore.isMember).not.toHaveBeenCalled()
     expect(resolver.resolveWithWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('rejects an authenticated foreign request scope before managed-agent effects', async () => {
+    const resolver = fakeResolver()
+    const app = await makeApp(enabledEnv(), resolver, {
+      requestScope: scopedRequest('workspace-foreign'),
+    })
+
+    const response = await app.inject({
+      method: 'POST',
+      url: FULL_APP_MANAGED_AGENT_MCP_PATH,
+      headers: { authorization: `Bearer ${TOKEN}` },
+      payload: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} },
+    })
+
+    expect(response.statusCode).toBe(421)
+    expect(response.json()).toMatchObject({
+      error: ERROR_CODES.D1_HOST_SCOPE_VIOLATION,
+      code: ERROR_CODES.D1_HOST_SCOPE_VIOLATION,
+      message: ERROR_CODES.D1_HOST_SCOPE_VIOLATION,
+      requestId: expect.any(String),
+    })
+    expect(app.workspaceStore.get).not.toHaveBeenCalled()
+    expect(app.workspaceStore.isMember).not.toHaveBeenCalled()
+    expect(resolver.resolveWithWorkspace).not.toHaveBeenCalled()
+    expect(resolver.dispatcherSends).toHaveLength(0)
   })
 
   it('rejects non-member and app-mismatched config before dispatch', async () => {
@@ -134,6 +166,36 @@ describe('full-app managed-agent MCP route', () => {
     expect(JSON.stringify(result.structuredContent)).not.toMatch(/"path"|"truncated"|\/srv\/private|managed-agent-token/)
   })
 
+  it('passes matching trusted scope to the configured target without caller retargeting', async () => {
+    const resolver = fakeResolver()
+    const scope = scopedRequest()
+    const app = await makeApp(enabledEnv(), resolver, { requestScope: scope })
+
+    const result = await callDelegate(app, {
+      brief: 'make a scoped report',
+      workspaceId: 'workspace-foreign',
+      userId: 'user-foreign',
+      agentId: 'agent-foreign',
+      deploymentId: 'deployment-foreign',
+    }, {
+      'x-boring-workspace-id': 'workspace-foreign',
+      'x-boring-agent-id': 'agent-foreign',
+      'x-boring-deployment-id': 'deployment-foreign',
+    })
+
+    expect(result.isError).not.toBe(true)
+    expect(resolver.contexts).toEqual([{ workspaceId: WORKSPACE_ID, userId: USER_ID }])
+    const resolveArgs = (resolver.resolveWithWorkspace.mock.calls[0] ?? []) as unknown[]
+    const request = (resolveArgs[1] as { request?: FastifyRequest } | undefined)?.request
+    expect(request?.requestScope).toEqual(scope)
+    expect(Object.isFrozen(request?.requestScope)).toBe(true)
+    expect(request?.requestScope?.defaultDeploymentId).toBe(DEFAULT_DEPLOYMENT_ID)
+    expect(resolver.dispatcherSends[0]).toMatchObject({
+      content: 'make a scoped report',
+      originSurface: 'mcp-managed-agent',
+    })
+  })
+
   it('serves a stock SDK client a self-contained artifact without a second runtime composition', async () => {
     const artifact = '# SDK report'
     const resolver = fakeResolver({ workspace: fakeWorkspace({ 'reports/final.md': artifact }) })
@@ -171,12 +233,18 @@ function enabledEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
 async function makeApp(
   env: NodeJS.ProcessEnv,
   resolver: ReturnType<typeof fakeResolver>,
-  options: { member?: boolean; workspaceAppId?: string } = {},
+  options: { member?: boolean; workspaceAppId?: string; requestScope?: CoreRequestScope } = {},
 ): Promise<CoreWorkspaceAgentServer> {
   const app = Fastify()
   app.decorate('config', { appId: APP_ID } as never)
+  if (options.requestScope) {
+    app.decorateRequest('requestScope')
+    app.addHook('onRequest', async (request) => {
+      request.requestScope = options.requestScope
+    })
+  }
   app.decorate('workspaceStore', {
-    async get(workspaceId: string) {
+    get: vi.fn(async (workspaceId: string) => {
       if (workspaceId !== WORKSPACE_ID) return null
       return {
         id: workspaceId,
@@ -187,10 +255,10 @@ async function makeApp(
         deletedAt: null,
         isDefault: true,
       }
-    },
-    async isMember(workspaceId: string, userId: string) {
+    }),
+    isMember: vi.fn(async (workspaceId: string, userId: string) => {
       return workspaceId === WORKSPACE_ID && userId === USER_ID && options.member !== false
-    },
+    }),
   } as Partial<WorkspaceStore> as never)
   registerFullAppManagedAgentMcpRoutes(app as unknown as CoreWorkspaceAgentServer, {
     env,
@@ -204,10 +272,11 @@ async function makeApp(
 async function callDelegate(
   app: CoreWorkspaceAgentServer,
   args: Record<string, unknown>,
+  headers: Record<string, string> = {},
 ): Promise<Awaited<ReturnType<Client['callTool']>>> {
   const client = new Client({ name: 'full-app-managed-agent-test', version: '0.0.0-test' })
   try {
-    await client.connect(new FastifyInjectMcpTransport(app))
+    await client.connect(new FastifyInjectMcpTransport(app, headers))
     return await client.callTool({ name: 'delegate_task', arguments: args })
   } finally {
     await client.close().catch(() => undefined)
@@ -219,7 +288,10 @@ class FastifyInjectMcpTransport implements Transport {
   onerror?: (error: Error) => void
   onmessage?: (message: JSONRPCMessage) => void
 
-  constructor(private readonly app: CoreWorkspaceAgentServer) {}
+  constructor(
+    private readonly app: CoreWorkspaceAgentServer,
+    private readonly headers: Record<string, string> = {},
+  ) {}
 
   async start(): Promise<void> {}
 
@@ -228,6 +300,7 @@ class FastifyInjectMcpTransport implements Transport {
       method: 'POST',
       url: FULL_APP_MANAGED_AGENT_MCP_PATH,
       headers: {
+        ...this.headers,
         authorization: `Bearer ${TOKEN}`,
         accept: 'application/json, text/event-stream',
         'content-type': 'application/json',
@@ -295,6 +368,15 @@ function fakeResolver(options: {
     return { dispatcher, workspace }
   })
   return { resolve, resolveWithWorkspace, contexts, dispatcherSends }
+}
+
+function scopedRequest(workspaceId = WORKSPACE_ID): CoreRequestScope {
+  return Object.freeze({
+    bindingId: 'binding-1',
+    workspaceId,
+    defaultDeploymentId: DEFAULT_DEPLOYMENT_ID,
+    activeRevision: 'revision-1',
+  })
 }
 
 async function* fakeAgentEvents(): AsyncIterable<AgentEvent> {

--- a/apps/full-app/src/server/managedAgentMcp.ts
+++ b/apps/full-app/src/server/managedAgentMcp.ts
@@ -14,6 +14,7 @@ import {
 } from '@hachej/boring-agent/server'
 import { ErrorCode } from '@hachej/boring-agent/shared'
 import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
+import { ERROR_CODES } from '@hachej/boring-core/shared'
 
 export const FULL_APP_MANAGED_AGENT_MCP_PATH = '/mcp/managed-agent'
 
@@ -119,6 +120,14 @@ export function registerFullAppManagedAgentMcpRoutes(
             code: ErrorCode.enum.UNAUTHORIZED,
             message: 'unauthorized',
           },
+        })
+      }
+      if (request.requestScope && request.requestScope.workspaceId !== workspaceId) {
+        return reply.code(421).send({
+          error: ERROR_CODES.D1_HOST_SCOPE_VIOLATION,
+          code: ERROR_CODES.D1_HOST_SCOPE_VIOLATION,
+          message: ERROR_CODES.D1_HOST_SCOPE_VIOLATION,
+          requestId: request.id,
         })
       }
       await requestStorage.run(request, async () => {


### PR DESCRIPTION
## Summary
- keep managed-agent MCP bearer authentication first
- reject a trusted D1 scope that does not match the configured workspace before request storage, stores, controller, dispatcher, or stream effects
- pass the frozen trusted scope, including `defaultDeploymentId`, through the existing dispatcher request context without adding caller selectors
- preserve generic absent-scope behavior exactly

## Proof
- focused managed-agent MCP tests: 8/8
- full-app typecheck and production build: green
- lint, invariants, generated-artifact audit, import audit, and diff check: green
- independent adversarial review and structured autoreview: clean

## Contract
D1-004c5 per the merged D1-R0 spec. Net +91 lines, within the <=220 micro-slice cap.

Refs #391