### PR TITLE
#391 feat(D1): admit first agent effects

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { D1ActiveCollection, D1ActiveCollectionReader } from '../activeCollectionReader.js'
 import { registerD1ReadinessRoute } from '../d1Readiness.js'
-import { createD1ServerWiring } from '../d1ServerWiring.js'
+import { createD1AgentEffectAdmission, createD1ServerWiring } from '../d1ServerWiring.js'
 import { D1HostErrorCode } from '../d1Plan.js'
 import { createD1HostSurfaceResolver, D1_TRUSTED_CADDY_PEER } from '../hostSurface.js'
 
@@ -97,7 +97,7 @@ describe('D1 readiness and activation wiring', () => {
     expect(euid).not.toHaveBeenCalled()
     const wiring = createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '0' })!
     expect(Object.isFrozen(wiring)).toBe(true)
-    expect(Object.keys(wiring)).toEqual(['requestScopeResolver', 'frontendRootHandler', 'registerReadiness'])
+    expect(Object.keys(wiring)).toEqual(['requestScopeResolver', 'frontendRootHandler', 'admitAgentEffect', 'registerReadiness'])
     expect(createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '4294967294' })).toBeDefined()
 
     const source = await readFile(new URL('../d1ServerWiring.ts', import.meta.url), 'utf8')
@@ -106,8 +106,47 @@ describe('D1 readiness and activation wiring', () => {
     expect(source).toContain("path.join('/var/lib/boring/d1', hostId)")
     expect(source).not.toMatch(/BORING_D1_(?:STATE_ROOT|APP_GID|ROOT)/)
     expect(main.indexOf('createD1ServerWiring(config)')).toBeLessThan(main.indexOf('createFullAppHostPluginComposition(config)'))
+    expect(main).toContain('admitEffect: d1.admitAgentEffect')
     expect(main.indexOf('d1?.registerReadiness(app)')).toBeLessThan(main.indexOf('registerFullAppBoringMcpRoutes(app)'))
     expect(main.indexOf('registerFullAppBoringMcpRoutes(app)')).toBeLessThan(main.indexOf('app.listen('))
+  })
+
+  it('derives the unique current binding for each effect and fails closed without the one ledger', async () => {
+    const current = collection()
+    const activeReader = reader({
+      ...current,
+      desired: {
+        ...current.desired,
+        plan: {
+          ...current.desired.plan,
+          hostId: 'eu-host-1',
+          bindings: current.desired.plan.bindings.map((binding) => binding.bindingId === 'a-binding'
+            ? { ...binding, workspaceId: 'workspace:a', defaultDeploymentId: 'deployment:a' }
+            : binding),
+        },
+      },
+    } as D1ActiveCollection)
+    const admit = vi.fn(async () => ({}) as never)
+    const admitEffect = createD1AgentEffectAdmission({
+      hostId: 'eu-host-1', activeReader, admissionLedger: { admit },
+    })
+
+    await admitEffect({ workspaceId: 'workspace:z', requestId: 'request-1' })
+    expect(admit).toHaveBeenCalledWith(activeReader, {
+      hostId: 'eu-host-1', bindingId: 'z-binding', workspaceId: 'workspace:z', defaultDeploymentId: 'deployment:z',
+    })
+    await expect(createD1AgentEffectAdmission({ hostId: 'eu-host-1', activeReader })({
+      workspaceId: 'workspace:z', requestId: 'request-2',
+    })).rejects.toMatchObject({ code: D1HostErrorCode.ADMISSION_RECORD_FAILED, details: { field: 'admission' } })
+    const duplicateReader = reader({
+      ...current,
+      desired: { ...current.desired, plan: { ...current.desired.plan, hostId: 'eu-host-1' } },
+    } as D1ActiveCollection)
+    await expect(createD1AgentEffectAdmission({
+      hostId: 'eu-host-1', activeReader: duplicateReader, admissionLedger: { admit },
+    })({ workspaceId: 'workspace:z', requestId: 'request-3' }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.ADMISSION_RECORD_FAILED })
+    expect(admit).toHaveBeenCalledTimes(1)
   })
 
   it('rejects noncanonical owner, identity, and proxy inputs with field-only errors', () => {

--- a/apps/full-app/src/server/deployment/d1ServerWiring.ts
+++ b/apps/full-app/src/server/deployment/d1ServerWiring.ts
@@ -1,13 +1,15 @@
 import path from 'node:path'
 
+import type { AgentEffectAdmission } from '@hachej/boring-agent/core'
 import type { CoreFrontendRootHandler } from '@hachej/boring-core/app/server'
 import type { CoreConfig } from '@hachej/boring-core/shared'
 import type { CoreRequestScopeResolver } from '@hachej/boring-core/server'
 import type { FastifyInstance } from 'fastify'
 
-import { createD1ActiveCollectionReader } from './activeCollectionReader.js'
+import { createD1ActiveCollectionReader, type D1ActiveCollectionReader } from './activeCollectionReader.js'
+import type { D1AdmissionLedger } from './admissionLedger.js'
 import { createD1LandingRootHandler } from './d1Landing.js'
-import { invalidD1Field, strictD1HostId } from './d1Plan.js'
+import { D1HostError, D1HostErrorCode, invalidD1Field, strictD1HostId } from './d1Plan.js'
 import { registerD1ReadinessRoute } from './d1Readiness.js'
 import { createD1HostSurfaceResolver, D1_TRUSTED_CADDY_PEER } from './hostSurface.js'
 
@@ -19,7 +21,40 @@ const OWNER_UID_RE = /^(?:0|[1-9][0-9]*)$/
 export interface D1ServerWiring {
   readonly requestScopeResolver: CoreRequestScopeResolver
   readonly frontendRootHandler: CoreFrontendRootHandler
+  readonly admitAgentEffect: AgentEffectAdmission
   registerReadiness(app: FastifyInstance): void
+}
+
+export interface D1ServerWiringDependencies {
+  readonly admissionLedger?: Pick<D1AdmissionLedger, 'admit'>
+}
+
+function admissionFailed(): D1HostError {
+  return new D1HostError(D1HostErrorCode.ADMISSION_RECORD_FAILED, { field: 'admission' })
+}
+
+export function createD1AgentEffectAdmission(options: {
+  readonly hostId: string
+  readonly activeReader: D1ActiveCollectionReader
+  readonly admissionLedger?: Pick<D1AdmissionLedger, 'admit'>
+}): AgentEffectAdmission {
+  return async ({ workspaceId }) => {
+    try {
+      if (!workspaceId || !options.admissionLedger) throw admissionFailed()
+      const active = await options.activeReader.read()
+      const matches = active?.desired.plan.bindings.filter((binding) => binding.workspaceId === workspaceId) ?? []
+      if (!active || active.desired.plan.hostId !== options.hostId || matches.length !== 1) throw admissionFailed()
+      const [binding] = matches
+      await options.admissionLedger.admit(options.activeReader, {
+        hostId: options.hostId,
+        bindingId: binding!.bindingId,
+        workspaceId,
+        defaultDeploymentId: binding!.defaultDeploymentId,
+      })
+    } catch {
+      throw admissionFailed()
+    }
+  }
 }
 
 function ownerUid(raw: string | undefined): number {
@@ -32,6 +67,7 @@ function ownerUid(raw: string | undefined): number {
 export function createD1ServerWiring(
   config: CoreConfig,
   env: Record<string, string | undefined> = process.env,
+  dependencies: D1ServerWiringDependencies = {},
 ): D1ServerWiring | undefined {
   if (env.BORING_D1_HOST_ID === undefined) return undefined
   const hostId = strictD1HostId(env.BORING_D1_HOST_ID, 'hostId')
@@ -48,6 +84,7 @@ export function createD1ServerWiring(
   return Object.freeze({
     requestScopeResolver: createD1HostSurfaceResolver({ activeReader, trustedPeer: D1_TRUSTED_CADDY_PEER }),
     frontendRootHandler: createD1LandingRootHandler({ activeReader }),
+    admitAgentEffect: createD1AgentEffectAdmission({ hostId, activeReader, admissionLedger: dependencies.admissionLedger }),
     registerReadiness(app: FastifyInstance) { registerD1ReadinessRoute(app, { activeReader }) },
   })
 }

--- a/apps/full-app/src/server/deployment/d1ServerWiring.ts
+++ b/apps/full-app/src/server/deployment/d1ServerWiring.ts
@@ -1,6 +1,6 @@
 import path from 'node:path'
 
-import type { AgentEffectAdmission } from '@hachej/boring-agent/core'
+import { AgentEffectAdmissionError, type AgentEffectAdmission } from '@hachej/boring-agent/core'
 import type { CoreFrontendRootHandler } from '@hachej/boring-core/app/server'
 import type { CoreConfig } from '@hachej/boring-core/shared'
 import type { CoreRequestScopeResolver } from '@hachej/boring-core/server'
@@ -9,7 +9,7 @@ import type { FastifyInstance } from 'fastify'
 import { createD1ActiveCollectionReader, type D1ActiveCollectionReader } from './activeCollectionReader.js'
 import type { D1AdmissionLedger } from './admissionLedger.js'
 import { createD1LandingRootHandler } from './d1Landing.js'
-import { D1HostError, D1HostErrorCode, invalidD1Field, strictD1HostId } from './d1Plan.js'
+import { D1HostErrorCode, invalidD1Field, strictD1HostId } from './d1Plan.js'
 import { registerD1ReadinessRoute } from './d1Readiness.js'
 import { createD1HostSurfaceResolver, D1_TRUSTED_CADDY_PEER } from './hostSurface.js'
 
@@ -29,8 +29,8 @@ export interface D1ServerWiringDependencies {
   readonly admissionLedger?: Pick<D1AdmissionLedger, 'admit'>
 }
 
-function admissionFailed(): D1HostError {
-  return new D1HostError(D1HostErrorCode.ADMISSION_RECORD_FAILED, { field: 'admission' })
+function admissionFailed(): AgentEffectAdmissionError {
+  return new AgentEffectAdmissionError(D1HostErrorCode.ADMISSION_RECORD_FAILED, { field: 'admission' })
 }
 
 export function createD1AgentEffectAdmission(options: {

--- a/apps/full-app/src/server/main.ts
+++ b/apps/full-app/src/server/main.ts
@@ -62,6 +62,7 @@ async function main() {
     ...(d1 ? {
       requestScopeResolver: d1.requestScopeResolver,
       frontendRootHandler: d1.frontendRootHandler,
+      admitEffect: d1.admitAgentEffect,
     } : {}),
   })
   appDb = app.db

--- a/packages/agent/src/core/__tests__/piChatSessionService.test.ts
+++ b/packages/agent/src/core/__tests__/piChatSessionService.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AGENT_EFFECT_METHODS,
+  type AgentCoreSessionService,
+  withAgentEffectAdmission,
+} from '../piChatSessionService'
+
+const CTX = { workspaceId: 'workspace:test', requestId: 'request:test' }
+
+describe('withAgentEffectAdmission', () => {
+  it('admits every mutation immediately before its effect and excludes reads and disposal', async () => {
+    const events: string[] = []
+    const effect = <T>(name: string, value: T) => async () => { events.push(name); return value }
+    const service = {
+      listSessions: effect('listSessions', []),
+      createSession: effect('createSession', { id: 's1' }),
+      deleteSession: effect('deleteSession', undefined),
+      readState: effect('readState', {}),
+      subscribe: effect('subscribe', { type: 'ok', unsubscribe() {} }),
+      prompt: effect('prompt', {}),
+      followUp: effect('followUp', {}),
+      clearQueue: effect('clearQueue', {}),
+      interrupt: effect('interrupt', {}),
+      stop: effect('stop', {}),
+      dispose: effect('dispose', undefined),
+    } as unknown as AgentCoreSessionService
+    let blocked = false
+    const admitted = withAgentEffectAdmission(service, async (ctx) => {
+      events.push('admit')
+      expect(ctx).toEqual(CTX)
+      if (blocked) throw new Error('blocked')
+    })
+    const mutations: Record<keyof typeof AGENT_EFFECT_METHODS, () => Promise<unknown>> = {
+      createSession: () => admitted.createSession(CTX),
+      deleteSession: () => admitted.deleteSession(CTX, 's1'),
+      prompt: () => admitted.prompt(CTX, 's1', { message: 'hi', clientNonce: 'p' }),
+      followUp: () => admitted.followUp(CTX, 's1', { message: 'next', clientNonce: 'f', clientSeq: 1 }),
+      clearQueue: () => admitted.clearQueue(CTX, 's1', {}),
+      interrupt: () => admitted.interrupt(CTX, 's1', {}),
+      stop: () => admitted.stop(CTX, 's1', {}),
+    }
+
+    for (const method of Object.keys(AGENT_EFFECT_METHODS) as Array<keyof typeof AGENT_EFFECT_METHODS>) {
+      events.length = 0
+      await mutations[method]()
+      expect(events).toEqual(['admit', method])
+    }
+    blocked = true
+    for (const method of Object.keys(AGENT_EFFECT_METHODS) as Array<keyof typeof AGENT_EFFECT_METHODS>) {
+      events.length = 0
+      await expect(mutations[method]()).rejects.toThrow('blocked')
+      expect(events).toEqual(['admit'])
+    }
+    blocked = false
+    events.length = 0
+    await admitted.listSessions?.(CTX)
+    await admitted.readState(CTX, 's1')
+    await admitted.subscribe(CTX, 's1', 0, () => {})
+    await admitted.dispose?.()
+    expect(events).toEqual(['listSessions', 'readState', 'subscribe', 'dispose'])
+  })
+})

--- a/packages/agent/src/core/createAgent.ts
+++ b/packages/agent/src/core/createAgent.ts
@@ -13,10 +13,12 @@ import type { SessionCtx, SessionListOptions, SessionStore } from '../shared/ses
 import type { PromptPayload } from '../shared/chat'
 import { ErrorCode } from '../shared/error-codes'
 import type {
+  AgentEffectAdmission,
   AgentCoreSessionService,
   PiChatEventStreamSubscription,
   PiSessionRequestContext,
 } from './piChatSessionService'
+import { withAgentEffectAdmission } from './piChatSessionService'
 
 const DEFAULT_LIVE_BUFFER_SIZE = 1_000
 
@@ -30,6 +32,7 @@ export type AgentCoreRuntimeFactory = () => AgentCoreRuntime | Promise<AgentCore
 
 export interface AgentCoreConfig {
   runtimeFactory: AgentCoreRuntimeFactory
+  admitEffect?: AgentEffectAdmission
   readiness?: AgentReadiness
   readinessRequirements?: string[]
 }
@@ -68,7 +71,12 @@ export function createAgent(config: AgentCoreConfig): Agent {
 export function createAgentRuntimeBridge(
   config: AgentCoreConfig,
 ): AgentRuntimeBridge {
-  const runtimeLoader = createRuntimeLoader(config.runtimeFactory)
+  const runtimeLoader = createRuntimeLoader(async () => {
+    const runtime = await config.runtimeFactory()
+    return config.admitEffect
+      ? { ...runtime, service: withAgentEffectAdmission(runtime.service, config.admitEffect) }
+      : runtime
+  })
   const live = new AgentLiveEventBuffer(DEFAULT_LIVE_BUFFER_SIZE)
   const sessionContexts = new Map<string, SessionCtx | undefined>()
   const startedSessions = new Map<string, { sessionId: string; ctx: SessionCtx | undefined }>()
@@ -344,7 +352,8 @@ function createFacadeSessionStore(
     },
     async create(ctx: SessionCtx, init?: { title?: string }) {
       assertActive()
-      const created = await (await store()).create(ctx, init)
+      const runtime = await getRuntime()
+      const created = await runtime.service.createSession(toPiRequestContext(ctx), init)
       assertActive()
       rememberSessionCtx(sessionContexts, created.id, ctx)
       return created

--- a/packages/agent/src/core/index.ts
+++ b/packages/agent/src/core/index.ts
@@ -6,6 +6,7 @@ export type {
   AgentCoreRuntimeView,
 } from './createAgent'
 export type {
+  AgentEffectAdmission,
   AgentCoreSessionService,
   PiChatEventStreamResult,
   PiChatEventStreamSubscription,
@@ -15,6 +16,7 @@ export type {
   PiSessionCreateInit,
   PiSessionRequestContext,
 } from './piChatSessionService'
+export { AGENT_EFFECT_METHODS, withAgentEffectAdmission } from './piChatSessionService'
 export type {
   Agent,
   AgentActor,

--- a/packages/agent/src/core/index.ts
+++ b/packages/agent/src/core/index.ts
@@ -16,7 +16,7 @@ export type {
   PiSessionCreateInit,
   PiSessionRequestContext,
 } from './piChatSessionService'
-export { AGENT_EFFECT_METHODS, withAgentEffectAdmission } from './piChatSessionService'
+export { AgentEffectAdmissionError, AGENT_EFFECT_METHODS, withAgentEffectAdmission } from './piChatSessionService'
 export type {
   Agent,
   AgentActor,

--- a/packages/agent/src/core/piChatSessionService.ts
+++ b/packages/agent/src/core/piChatSessionService.ts
@@ -62,3 +62,40 @@ export interface AgentCoreSessionService extends PiChatSessionService {
   deleteSession(ctx: PiSessionRequestContext, sessionId: string): Promise<void>
   dispose?(): Promise<void>
 }
+
+export type AgentEffectAdmission = (
+  ctx: Pick<PiSessionRequestContext, 'workspaceId' | 'requestId'>,
+) => Promise<void>
+
+type AgentEffectMethod = Exclude<keyof AgentCoreSessionService, 'listSessions' | 'readState' | 'subscribe' | 'dispose'>
+
+export const AGENT_EFFECT_METHODS = {
+  createSession: true,
+  deleteSession: true,
+  prompt: true,
+  followUp: true,
+  clearQueue: true,
+  interrupt: true,
+  stop: true,
+} as const satisfies Record<AgentEffectMethod, true>
+
+export function withAgentEffectAdmission(
+  service: AgentCoreSessionService,
+  admit: AgentEffectAdmission,
+): AgentCoreSessionService {
+  return {
+    ...(service.listSessions
+      ? { listSessions: (ctx, options) => service.listSessions!(ctx, options) }
+      : {}),
+    async createSession(ctx, init) { await admit(ctx); return service.createSession(ctx, init) },
+    async deleteSession(ctx, sessionId) { await admit(ctx); return service.deleteSession(ctx, sessionId) },
+    readState: (ctx, sessionId) => service.readState(ctx, sessionId),
+    subscribe: (ctx, sessionId, cursor, subscriber) => service.subscribe(ctx, sessionId, cursor, subscriber),
+    async prompt(ctx, sessionId, payload) { await admit(ctx); return service.prompt(ctx, sessionId, payload) },
+    async followUp(ctx, sessionId, payload) { await admit(ctx); return service.followUp(ctx, sessionId, payload) },
+    async clearQueue(ctx, sessionId, payload) { await admit(ctx); return service.clearQueue(ctx, sessionId, payload) },
+    async interrupt(ctx, sessionId, payload) { await admit(ctx); return service.interrupt(ctx, sessionId, payload) },
+    async stop(ctx, sessionId, payload) { await admit(ctx); return service.stop(ctx, sessionId, payload) },
+    ...(service.dispose ? { dispose: () => service.dispose!() } : {}),
+  }
+}

--- a/packages/agent/src/core/piChatSessionService.ts
+++ b/packages/agent/src/core/piChatSessionService.ts
@@ -67,6 +67,18 @@ export type AgentEffectAdmission = (
   ctx: Pick<PiSessionRequestContext, 'workspaceId' | 'requestId'>,
 ) => Promise<void>
 
+export class AgentEffectAdmissionError extends Error {
+  readonly statusCode = 500
+
+  constructor(
+    readonly code: string,
+    readonly details?: unknown,
+  ) {
+    super(code)
+    this.name = 'AgentEffectAdmissionError'
+  }
+}
+
 type AgentEffectMethod = Exclude<keyof AgentCoreSessionService, 'listSessions' | 'readState' | 'subscribe' | 'dispose'>
 
 export const AGENT_EFFECT_METHODS = {

--- a/packages/agent/src/server/__tests__/createAgent.test.ts
+++ b/packages/agent/src/server/__tests__/createAgent.test.ts
@@ -60,6 +60,33 @@ describe('createAgent', () => {
     await agent.dispose()
   })
 
+  it('routes facade session mutations through the admitted service before storage', async () => {
+    const events: string[] = []
+    class OrderedSessionStore extends MemorySessionStore {
+      override async create(ctx: SessionCtx, init?: { title?: string }) {
+        events.push('store.create')
+        return super.create(ctx, init)
+      }
+    }
+    const sessions = new OrderedSessionStore()
+    const service = new InjectedCorePiChatService(sessions)
+    const createSession = vi.spyOn(service, 'createSession')
+    const deleteSession = vi.spyOn(service, 'deleteSession')
+    const agent = createCoreAgent({
+      runtimeFactory: createCoreRuntimeFactory(sessions, service),
+      admitEffect: async () => { events.push('admit') },
+    })
+
+    const created = await agent.sessions.create(CTX)
+    expect(events).toEqual(['admit', 'store.create'])
+    expect(createSession).toHaveBeenCalledOnce()
+    events.length = 0
+    await agent.sessions.delete(CTX, created.id)
+    expect(events).toEqual(['admit'])
+    expect(deleteSession).toHaveBeenCalledOnce()
+    await agent.dispose()
+  })
+
   it('rejects sessions override with the default harness to avoid split persistence', () => {
     expect(() => createAgent({
       runtime: { id: 'test-runtime' },

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -404,7 +404,9 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
     await writeFile(join(skillRoot, 'SKILL.md'), `---\nname: reload-skill\ndescription: ${description}\n---\n`)
   }
   let provisionCalls = 0
-  const reloadSession = vi.fn(async () => true)
+  let blockAdmission = false
+  const events: string[] = []
+  const reloadSession = vi.fn(async () => { events.push('reloadSession'); return true })
   const app = Fastify({ logger: false })
 
   await app.register(registerAgentRoutes, {
@@ -412,6 +414,7 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
     mode: 'direct',
     provisionRuntime: async () => {
       provisionCalls += 1
+      if (provisionCalls > 1) events.push('reprovision')
       await writeReloadSkill(provisionCalls === 1 ? 'Before reload.' : 'After reload.')
       return {
         changed: true,
@@ -420,6 +423,13 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
         skillPaths: [dirname(skillRoot)],
       }
     },
+    admitEffect: async () => {
+      events.push('admit')
+      if (blockAdmission) {
+        throw Object.assign(new Error('D1_ADMISSION_RECORD_FAILED'), { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED })
+      }
+    },
+    beforeReload: async () => { events.push('beforeReload') },
     harnessFactory: async () => ({
       id: 'reload-test-harness',
       placement: 'server' as const,
@@ -454,6 +464,16 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
     expect(reload.json()).toMatchObject({ ok: true, reloaded: true })
     expect(reloadSession).toHaveBeenCalledWith('default')
     expect(provisionCalls).toBe(2)
+    expect(events).toEqual(['admit', 'reprovision', 'beforeReload', 'reloadSession'])
+
+    events.length = 0
+    blockAdmission = true
+    const rejected = await app.inject({ method: 'POST', url: '/api/v1/agent/reload', payload: {} })
+    expect(rejected.statusCode).toBe(500)
+    expect(rejected.json()).toMatchObject({ error: { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED } })
+    expect(events).toEqual(['admit'])
+    expect(provisionCalls).toBe(2)
+    expect(reloadSession).toHaveBeenCalledOnce()
 
     const after = await app.inject({ method: 'GET', url: '/api/v1/agent/skills?refresh=1' })
     expect(after.statusCode).toBe(200)

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from 'node:path'
 import { afterEach, expect, test, vi } from 'vitest'
 import Fastify, { type FastifyRequest } from 'fastify'
 
+import { AgentEffectAdmissionError } from '../../core/piChatSessionService'
 import { registerAgentRoutes } from '../registerAgentRoutes'
 import { provisionWorkspaceRuntime } from '../workspace/provisioning'
 import { ErrorCode } from '../../shared/error-codes'
@@ -12,6 +13,7 @@ import type { WorkspaceAgentDispatcherResolver } from '../workspaceAgentDispatch
 import { createDispatcherTestHarness } from './workspaceAgentDispatcherTestHarness'
 
 const tempDirs: string[] = []
+const ADMISSION_ERROR_CODE = 'D1_ADMISSION_RECORD_FAILED'
 
 async function removeDirEventually(dir: string, timeoutMs = 5000): Promise<void> {
   const startedAt = Date.now()
@@ -426,7 +428,7 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
     admitEffect: async () => {
       events.push('admit')
       if (blockAdmission) {
-        throw Object.assign(new Error('D1_ADMISSION_RECORD_FAILED'), { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED })
+        throw new AgentEffectAdmissionError(ADMISSION_ERROR_CODE)
       }
     },
     beforeReload: async () => { events.push('beforeReload') },
@@ -470,7 +472,7 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
     blockAdmission = true
     const rejected = await app.inject({ method: 'POST', url: '/api/v1/agent/reload', payload: {} })
     expect(rejected.statusCode).toBe(500)
-    expect(rejected.json()).toMatchObject({ error: { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED } })
+    expect(rejected.json()).toMatchObject({ error: { code: ADMISSION_ERROR_CODE } })
     expect(events).toEqual(['admit'])
     expect(provisionCalls).toBe(2)
     expect(reloadSession).toHaveBeenCalledOnce()

--- a/packages/agent/src/server/createAgent.ts
+++ b/packages/agent/src/server/createAgent.ts
@@ -1,5 +1,6 @@
 import { createAgentRuntimeBridge as createCoreAgentRuntimeBridge } from '../core/createAgent'
 import type { AgentCoreRuntime } from '../core/createAgent'
+import type { AgentEffectAdmission } from '../core/piChatSessionService'
 import { ErrorCode } from '../shared/error-codes'
 import type { Agent, AgentConfig } from '../shared/events'
 import type { AgentHarness, AgentHarnessFactoryInput } from '../shared/harness'
@@ -28,6 +29,7 @@ export interface CreateAgentRuntimeBridgeOptions {
     runtimeCwd?: string
   }
   service?: {
+    admitEffect?: AgentEffectAdmission
     workdir?: string
     workspace?: Workspace
     eventStore?: EventStreamStore
@@ -55,6 +57,7 @@ export function createAgentRuntimeBridge(
 
   return createCoreAgentRuntimeBridge({
     runtimeFactory: () => createRuntime(config, options),
+    admitEffect: options.service?.admitEffect,
     readiness: config.readiness,
     readinessRequirements: config.readinessRequirements,
   })

--- a/packages/agent/src/server/http/routes/__tests__/commands.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/commands.test.ts
@@ -1,8 +1,11 @@
 import Fastify from 'fastify'
 import { describe, expect, it, vi } from 'vitest'
+import { AgentEffectAdmissionError } from '../../../../core/piChatSessionService'
 import type { AgentHarness } from '../../../../shared/harness'
 import { ErrorCode } from '../../../../shared/error-codes'
 import { commandsRoutes } from '../commands'
+
+const ADMISSION_ERROR_CODE = 'D1_ADMISSION_RECORD_FAILED'
 
 function fakeHarness(overrides: Partial<AgentHarness>): AgentHarness {
   return {
@@ -66,7 +69,7 @@ describe('commandsRoutes', () => {
       defaultSessionId: 'default',
       workdir: '/tmp/commands-test',
       admitEffect: async () => {
-        throw Object.assign(new Error('D1_ADMISSION_RECORD_FAILED'), { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED })
+        throw new AgentEffectAdmissionError(ADMISSION_ERROR_CODE)
       },
     })
     try {
@@ -74,7 +77,7 @@ describe('commandsRoutes', () => {
         method: 'POST', url: '/api/v1/agent/commands/execute', payload: { name: 'plan' },
       })
       expect(response.statusCode).toBe(500)
-      expect(response.json()).toMatchObject({ error: { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED } })
+      expect(response.json()).toMatchObject({ error: { code: ADMISSION_ERROR_CODE } })
       expect(executeSlashCommand).not.toHaveBeenCalled()
     } finally {
       await app.close()

--- a/packages/agent/src/server/http/routes/__tests__/commands.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/commands.test.ts
@@ -26,7 +26,8 @@ function fakeHarness(overrides: Partial<AgentHarness>): AgentHarness {
 
 describe('commandsRoutes', () => {
   it('allows command execution when an installed metering sink is disabled', async () => {
-    const executeSlashCommand = vi.fn(async () => {})
+    const events: string[] = []
+    const executeSlashCommand = vi.fn(async () => { events.push('execute') })
     const app = Fastify({ logger: false })
     await app.register(commandsRoutes, {
       harness: fakeHarness({
@@ -36,6 +37,10 @@ describe('commandsRoutes', () => {
       defaultSessionId: 'default',
       workdir: '/tmp/commands-test',
       metering: { isEnabled: () => false },
+      admitEffect: async (ctx) => {
+        expect(ctx).toMatchObject({ workspaceId: 'default', requestId: expect.any(String) })
+        events.push('admit')
+      },
     })
 
     try {
@@ -46,7 +51,31 @@ describe('commandsRoutes', () => {
       })
       expect(execute.statusCode).toBe(200)
       expect(execute.json()).toEqual({ ok: true })
+      expect(events).toEqual(['admit', 'execute'])
       expect(executeSlashCommand).toHaveBeenCalledWith('default', 'panel', '', expect.objectContaining({ workdir: '/tmp/commands-test' }))
+    } finally {
+      await app.close()
+    }
+  })
+
+  it('fails closed before slash execution when admission rejects', async () => {
+    const executeSlashCommand = vi.fn(async () => {})
+    const app = Fastify({ logger: false })
+    await app.register(commandsRoutes, {
+      harness: fakeHarness({ executeSlashCommand }),
+      defaultSessionId: 'default',
+      workdir: '/tmp/commands-test',
+      admitEffect: async () => {
+        throw Object.assign(new Error('D1_ADMISSION_RECORD_FAILED'), { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED })
+      },
+    })
+    try {
+      const response = await app.inject({
+        method: 'POST', url: '/api/v1/agent/commands/execute', payload: { name: 'plan' },
+      })
+      expect(response.statusCode).toBe(500)
+      expect(response.json()).toMatchObject({ error: { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED } })
+      expect(executeSlashCommand).not.toHaveBeenCalled()
     } finally {
       await app.close()
     }
@@ -85,12 +114,14 @@ describe('commandsRoutes', () => {
       await piSessionPrompt()
     })
     const getSlashCommands = vi.fn(async () => [{ name: 'plan', source: 'prompt' as const }])
+    const admitEffect = vi.fn(async () => {})
     const app = Fastify({ logger: false })
     await app.register(commandsRoutes, {
       harness: fakeHarness({ getSlashCommands, executeSlashCommand }),
       defaultSessionId: 'default',
       workdir: '/tmp/commands-test',
       metering: {},
+      admitEffect,
     })
 
     try {
@@ -113,6 +144,7 @@ describe('commandsRoutes', () => {
       })
       expect(executeSlashCommand).not.toHaveBeenCalled()
       expect(piSessionPrompt).not.toHaveBeenCalled()
+      expect(admitEffect).not.toHaveBeenCalled()
     } finally {
       await app.close()
     }

--- a/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
@@ -1,5 +1,6 @@
 import Fastify from 'fastify'
 import { describe, expect, test, vi } from 'vitest'
+import { AgentEffectAdmissionError } from '../../../../core/piChatSessionService'
 import { ErrorCode } from '../../../../shared/error-codes'
 import type {
   CommandReceipt,
@@ -17,6 +18,8 @@ import type { PiSessionRequestContext } from '../../../pi-chat/piSessionIdentity
 import { PI_CHAT_CURSOR_AHEAD, PI_CHAT_REPLAY_GAP } from '../../../pi-chat/piChatReplayBuffer'
 import type { SessionListOptions } from '../../../../shared/session'
 import { piChatBusyError, piChatRoutes, PiChatRouteError, type PiChatRoutesOptions, type PiChatSessionService } from '../piChat'
+
+const ADMISSION_ERROR_CODE = 'D1_ADMISSION_RECORD_FAILED'
 
 function activeSnapshot(overrides: Partial<PiChatSnapshot> = {}): PiChatSnapshot {
   return {
@@ -452,6 +455,23 @@ describe('piChatRoutes', () => {
     expect(res.statusCode).toBe(404)
     expect(res.json()).toEqual({ error: { code: ErrorCode.enum.SESSION_NOT_FOUND, message: 'session not found' } })
 
+    await app.close()
+  })
+
+  test('effect admission errors preserve their host-owned stable code', async () => {
+    const service = new FakePiChatService()
+    service.createSession = vi.fn(async () => {
+      throw new AgentEffectAdmissionError(ADMISSION_ERROR_CODE, { field: 'admission' })
+    })
+    const { app } = await buildApp(service)
+
+    const res = await app.inject({ method: 'POST', url: '/api/v1/agent/pi-chat/sessions', payload: {} })
+
+    expect(res.statusCode).toBe(500)
+    expect(res.json()).toEqual({
+      error: { code: ADMISSION_ERROR_CODE, message: ADMISSION_ERROR_CODE, details: { field: 'admission' } },
+    })
+    expect(ErrorCode.safeParse(ADMISSION_ERROR_CODE).success).toBe(false)
     await app.close()
   })
 })

--- a/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
@@ -472,6 +472,15 @@ describe('piChatRoutes', () => {
       error: { code: ADMISSION_ERROR_CODE, message: ADMISSION_ERROR_CODE, details: { field: 'admission' } },
     })
     expect(ErrorCode.safeParse(ADMISSION_ERROR_CODE).success).toBe(false)
+
+    service.listSessions = vi.fn(async () => {
+      throw new AgentEffectAdmissionError(ADMISSION_ERROR_CODE, { field: 'should-not-leak' })
+    })
+    const list = await app.inject({ method: 'GET', url: '/api/v1/agent/pi-chat/sessions' })
+    expect(list.statusCode).toBe(500)
+    expect(list.json()).toEqual({
+      error: { code: ErrorCode.enum.INTERNAL_ERROR, message: 'list pi chat sessions failed' },
+    })
     await app.close()
   })
 })

--- a/packages/agent/src/server/http/routes/commands.ts
+++ b/packages/agent/src/server/http/routes/commands.ts
@@ -1,7 +1,7 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import type { AgentHarness, AgentSlashCommandSummary, RunContext } from '../../../shared/harness'
 import type { AgentMeteringSink } from '../../pi-chat/metering'
-import type { AgentEffectAdmission } from '../../../core/piChatSessionService'
+import { AgentEffectAdmissionError, type AgentEffectAdmission } from '../../../core/piChatSessionService'
 import { ErrorCode, type ErrorCode as ErrorCodeValue } from '../../../shared/error-codes'
 
 const DEFAULT_WORKSPACE_ID = 'default'
@@ -91,7 +91,7 @@ function meteredCommandBlocked(command: string) {
 
 function stableErrorPayload(error: unknown, message: string) {
   const code = (error as { code?: unknown } | null)?.code
-  if (!isErrorCode(code)) return undefined
+  if (!isErrorCode(code) && !(error instanceof AgentEffectAdmissionError)) return undefined
   const details = (error as { details?: unknown } | null)?.details
   return {
     error: {

--- a/packages/agent/src/server/http/routes/commands.ts
+++ b/packages/agent/src/server/http/routes/commands.ts
@@ -1,12 +1,14 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify'
 import type { AgentHarness, AgentSlashCommandSummary, RunContext } from '../../../shared/harness'
 import type { AgentMeteringSink } from '../../pi-chat/metering'
+import type { AgentEffectAdmission } from '../../../core/piChatSessionService'
 import { ErrorCode, type ErrorCode as ErrorCodeValue } from '../../../shared/error-codes'
 
 const DEFAULT_WORKSPACE_ID = 'default'
 
 type CommandsRoutesBaseOptions = {
   defaultSessionId: string
+  admitEffect?: AgentEffectAdmission
   metering?: Pick<AgentMeteringSink, 'isEnabled'>
 }
 
@@ -144,6 +146,7 @@ export function commandsRoutes(
         // Extension handlers can call captured Pi APIs that trigger turns; until command execution is metered, fail closed.
         return reply.code(409).send(meteredCommandBlocked(name))
       }
+      await opts.admitEffect?.({ workspaceId: getRequestWorkspaceId(request), requestId: request.id })
       await harness.executeSlashCommand(sessionId, name, args, runContext)
       return reply.code(200).send({ ok: true })
     } catch (error) {

--- a/packages/agent/src/server/http/routes/piChat.ts
+++ b/packages/agent/src/server/http/routes/piChat.ts
@@ -122,7 +122,7 @@ export function piChatRoutes(
       if (!service.createSession) throw unsupportedServiceMethod('create Pi chat session')
       return reply.code(201).send(await service.createSession(getRequestContext(request), body))
     } catch (err) {
-      return sendRouteError(reply, err, 'create pi chat session failed')
+      return sendRouteError(reply, err, 'create pi chat session failed', true)
     }
   })
 
@@ -135,7 +135,7 @@ export function piChatRoutes(
       await service.deleteSession(getRequestContext(request), params.sessionId)
       return reply.code(204).send()
     } catch (err) {
-      return sendRouteError(reply, err, 'delete pi chat session failed')
+      return sendRouteError(reply, err, 'delete pi chat session failed', true)
     }
   })
 
@@ -244,7 +244,7 @@ export function piChatRoutes(
       const receipt = await service.prompt(getRequestContext(request), params.sessionId, body)
       return reply.code(202).send(receipt)
     } catch (err) {
-      return sendRouteError(reply, err, 'prompt rejected')
+      return sendRouteError(reply, err, 'prompt rejected', true)
     }
   })
 
@@ -258,7 +258,7 @@ export function piChatRoutes(
       const receipt = await service.followUp(getRequestContext(request), params.sessionId, body)
       return reply.code(202).send(receipt)
     } catch (err) {
-      return sendRouteError(reply, err, 'follow-up rejected')
+      return sendRouteError(reply, err, 'follow-up rejected', true)
     }
   })
 
@@ -272,7 +272,7 @@ export function piChatRoutes(
       const receipt = await service.clearQueue(getRequestContext(request), params.sessionId, body)
       return reply.code(202).send(receipt)
     } catch (err) {
-      return sendRouteError(reply, err, 'queue clear rejected')
+      return sendRouteError(reply, err, 'queue clear rejected', true)
     }
   })
 
@@ -286,7 +286,7 @@ export function piChatRoutes(
       const receipt = await service.interrupt(getRequestContext(request), params.sessionId, body)
       return reply.code(202).send(receipt)
     } catch (err) {
-      return sendRouteError(reply, err, 'interrupt rejected')
+      return sendRouteError(reply, err, 'interrupt rejected', true)
     }
   })
 
@@ -300,7 +300,7 @@ export function piChatRoutes(
       const receipt = await service.stop(getRequestContext(request), params.sessionId, body)
       return reply.code(202).send(receipt)
     } catch (err) {
-      return sendRouteError(reply, err, 'stop rejected')
+      return sendRouteError(reply, err, 'stop rejected', true)
     }
   })
 
@@ -397,19 +397,26 @@ function sendReplayRangeError(reply: FastifyReply, error: PiChatReplayRangeError
   })
 }
 
-function sendRouteError(reply: FastifyReply, err: unknown, fallbackMessage: string): FastifyReply {
+function sendRouteError(
+  reply: FastifyReply,
+  err: unknown,
+  fallbackMessage: string,
+  preserveAdmissionError = false,
+): FastifyReply {
   const statusCode = statusCodeFromError(err)
   const parsedCode = ErrorCode.safeParse((err as { code?: unknown })?.code)
-  const code = err instanceof AgentEffectAdmissionError
+  const admissionError = preserveAdmissionError && err instanceof AgentEffectAdmissionError
+  const rejectedAdmissionError = !preserveAdmissionError && err instanceof AgentEffectAdmissionError
+  const code = admissionError
     ? err.code
     : parsedCode.success ? parsedCode.data : ErrorCode.enum.INTERNAL_ERROR
-  const message = err instanceof Error ? err.message : fallbackMessage
+  const message = !rejectedAdmissionError && err instanceof Error ? err.message : fallbackMessage
   return reply.code(statusCode).send({
     error: {
       code,
       message,
       retryable: (err as { retryable?: unknown })?.retryable === true ? true : undefined,
-      details: (err as { details?: unknown })?.details,
+      details: rejectedAdmissionError ? undefined : (err as { details?: unknown })?.details,
     },
   })
 }

--- a/packages/agent/src/server/http/routes/piChat.ts
+++ b/packages/agent/src/server/http/routes/piChat.ts
@@ -15,11 +15,12 @@ import {
 } from '../../../shared/chat'
 import { PI_CHAT_CURSOR_AHEAD, PI_CHAT_REPLAY_GAP } from '../../pi-chat/piChatReplayBuffer'
 import type { SessionListOptions } from '../../../shared/session'
-import type {
-  PiChatEventStreamSubscription,
-  PiChatReplayRangeError,
-  PiChatSessionService,
-  PiSessionRequestContext,
+import {
+  AgentEffectAdmissionError,
+  type PiChatEventStreamSubscription,
+  type PiChatReplayRangeError,
+  type PiChatSessionService,
+  type PiSessionRequestContext,
 } from '../../../core/piChatSessionService'
 
 const DEFAULT_WORKSPACE_ID = 'default'
@@ -399,7 +400,9 @@ function sendReplayRangeError(reply: FastifyReply, error: PiChatReplayRangeError
 function sendRouteError(reply: FastifyReply, err: unknown, fallbackMessage: string): FastifyReply {
   const statusCode = statusCodeFromError(err)
   const parsedCode = ErrorCode.safeParse((err as { code?: unknown })?.code)
-  const code = parsedCode.success ? parsedCode.data : ErrorCode.enum.INTERNAL_ERROR
+  const code = err instanceof AgentEffectAdmissionError
+    ? err.code
+    : parsedCode.success ? parsedCode.data : ErrorCode.enum.INTERNAL_ERROR
   const message = err instanceof Error ? err.message : fallbackMessage
   return reply.code(statusCode).send({
     error: {

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -37,7 +37,7 @@ import { treeRoutes } from './http/routes/tree'
 import { modelsRoutes, type ModelsRoutesOptions } from './http/routes/models'
 import { skillsRoutes } from './http/routes/skills'
 import { piChatRoutes } from './http/routes/piChat'
-import type { AgentEffectAdmission, PiChatSessionService } from '../core/piChatSessionService'
+import { AgentEffectAdmissionError, type AgentEffectAdmission, type PiChatSessionService } from '../core/piChatSessionService'
 import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
@@ -1349,8 +1349,8 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
-      if ((error as { code?: unknown } | null)?.code === ErrorCode.enum.D1_ADMISSION_RECORD_FAILED) {
-        return reply.status(500).send({ ok: false, error: { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED, message } })
+      if (error instanceof AgentEffectAdmissionError) {
+        return reply.status(error.statusCode).send({ ok: false, error: { code: error.code, message } })
       }
       return reply.status(422).send({ ok: false, error: message })
     }

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -37,7 +37,7 @@ import { treeRoutes } from './http/routes/tree'
 import { modelsRoutes, type ModelsRoutesOptions } from './http/routes/models'
 import { skillsRoutes } from './http/routes/skills'
 import { piChatRoutes } from './http/routes/piChat'
-import type { PiChatSessionService } from '../core/piChatSessionService'
+import type { AgentEffectAdmission, PiChatSessionService } from '../core/piChatSessionService'
 import { systemPromptRoutes } from './http/routes/systemPrompt'
 import { sessionChangesRoutes } from './http/routes/sessionChanges'
 import { catalogRoutes } from './http/routes/catalog'
@@ -341,6 +341,8 @@ export interface RegisterAgentRoutesOptions {
   sessionRoot?: string
   /** Optional best-effort telemetry sink supplied by an embedding host. */
   telemetry?: TelemetrySink
+  /** Optional host admission called immediately before each agent effect. */
+  admitEffect?: AgentEffectAdmission
   /** Generic request-aware model filtering seam. Hosts may filter per user/workspace. */
   filterModels?: ModelsRoutesOptions['filterModels']
   /** Generic per-request/per-run filesystem binding seam. Hosts may return user/session-filtered bindings. */
@@ -823,6 +825,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       workdir: root,
     }, {
       service: {
+        admitEffect: opts.admitEffect,
         workdir: runtimeBundle.workspace.root,
         workspace: runtimeBundle.workspace,
       },
@@ -1305,6 +1308,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     }
 
     try {
+      await opts.admitEffect?.({ workspaceId, requestId: request.id })
       await binding.reprovision(request)
       binding.assertActive()
       const hookResult = await opts.beforeReload?.({
@@ -1345,6 +1349,9 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       }
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
+      if ((error as { code?: unknown } | null)?.code === ErrorCode.enum.D1_ADMISSION_RECORD_FAILED) {
+        return reply.status(500).send({ ok: false, error: { code: ErrorCode.enum.D1_ADMISSION_RECORD_FAILED, message } })
+      }
       return reply.status(422).send({ ok: false, error: message })
     }
   })
@@ -1358,12 +1365,14 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
         defaultSessionId: sessionId,
         workdir: staticBinding.runtimeBundle.workspace.root,
         metering: opts.metering,
+        admitEffect: opts.admitEffect,
       }
     : {
         defaultSessionId: sessionId,
         getHarness: async (request) => (await getBindingForRequest(request)).harness,
         getWorkdir: async (request) => (await getBindingForRequest(request)).runtimeBundle.workspace.root,
         metering: opts.metering,
+        admitEffect: opts.admitEffect,
       },
   )
   await app.register(readyStatusRoutes, staticBinding

--- a/packages/agent/src/shared/error-codes.ts
+++ b/packages/agent/src/shared/error-codes.ts
@@ -19,7 +19,6 @@ export const ErrorCode = z.enum([
   'WORKSPACE_UNINITIALIZED',
   'WORKSPACE_NOT_READY',
   'D1_HOST_SCOPE_VIOLATION',
-  'D1_ADMISSION_RECORD_FAILED',
 
   // Agent runtime / provisioning
   'AGENT_RUNTIME_NOT_READY',

--- a/packages/agent/src/shared/error-codes.ts
+++ b/packages/agent/src/shared/error-codes.ts
@@ -19,6 +19,7 @@ export const ErrorCode = z.enum([
   'WORKSPACE_UNINITIALIZED',
   'WORKSPACE_NOT_READY',
   'D1_HOST_SCOPE_VIOLATION',
+  'D1_ADMISSION_RECORD_FAILED',
 
   // Agent runtime / provisioning
   'AGENT_RUNTIME_NOT_READY',

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -97,17 +97,20 @@ test('core/full-app composition forwards collected runtime provisioning plugins 
   })
 
   const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const admitEffect = vi.fn(async () => {})
   const app = await createCoreWorkspaceAgentServer({
     config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
     workspaceRoot: '/tmp/full-app-workspaces',
     serveFrontend: false,
     registerHealthRoute: false,
+    admitEffect,
   })
 
   try {
     expect(mocks.registerAgentRoutes).toHaveBeenCalledTimes(1)
     const options = (mocks.registerAgentRoutes as any).mock.calls[0]?.[1] as Record<string, unknown>
     expect(options).toHaveProperty('provisionRuntime')
+    expect(options.admitEffect).toBe(admitEffect)
     expect(options).not.toHaveProperty('runtimeProvisioningPlugins')
     expect(options).not.toHaveProperty('provisioningContributions')
 

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1016,6 +1016,7 @@ export async function createCoreWorkspaceAgentServer(
     externalPlugins: externalPluginsEnabled,
     runtimeModeAdapter: remoteWorkerModeAdapter,
     version: options.version,
+    admitEffect: options.admitEffect,
     extraTools: [
       ...(options.extraTools ?? []),
       ...(pluginCollection.agentOptions.extraTools ?? []),


### PR DESCRIPTION
## Summary
- add one optional agent-effect admission seam and decorate exactly the seven session mutations
- route facade session creation through the decorated service so create/delete cannot bypass admission
- admit slash execution after validation/support/metering rejection and immediately before execution
- admit reload after trusted binding resolution and before reprovision, hooks, or session reload
- derive one exact active D1 binding from workspace identity and call the durable ledger

## Safety properties
- list/read/subscribe/dispose remain unadmitted by contract
- absent, duplicate, or host-mismatched workspace bindings fail closed
- generic composition is byte-for-byte optional when no admission seam is supplied
- no cache; every effect revalidates the current active state and ledger tuple
- production remains intentionally fail closed until D1-005c injects the attested ledger

## Proof
- focused agent suites: 79/79
- D1 activation: 8/8; core composition: 5/5
- agent/core/full-app typechecks and agent/core builds: green
- full-app production build: green
- repo invariants and diff check: green
- independent review: clean
- structured autoreview: clean, correctness 0.93

## Contract
D1-004d2 from merged #715, on top of #717. Net +287 lines, within the <=400 cap. The two generated proof scripts are intentionally excluded.

Refs #391