### PR TITLE
fix(workspace): file-tree create de-dup + manual refresh control

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -1,10 +1,12 @@
 "use client"
 
 import {
+  forwardRef,
   lazy,
   Suspense,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -28,6 +30,7 @@ import {
   buildTree,
   dirKey,
   injectDraftIntoTree,
+  joinPath,
   mergeEntries,
   parentDir,
   type DraftEditing,
@@ -53,6 +56,7 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
+  IconButton,
   Input,
   Select,
   SelectContent,
@@ -60,6 +64,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@hachej/boring-ui-kit"
+import { RefreshCwIcon } from "lucide-react"
 import { cn } from "../../../../front/lib/utils"
 import { toast } from "../../../../front/toast"
 import { events, userMeta } from "../../../../front/events"
@@ -128,6 +133,15 @@ export interface FileTreeViewProps {
   className?: string
 }
 
+/** Imperative handle for hosts (e.g. `FileTreePane`'s refresh button) that need
+ * to force a re-sync of this root's listing on demand, outside the normal
+ * mutation/event-driven refresh paths. */
+export interface FileTreeViewHandle {
+  /** Re-fetch this root's top-level listing plus every currently-expanded
+   * subfolder. Resolves once all of it has settled. */
+  refetch: () => Promise<void>
+}
+
 function normalizeRevealPath(path: string): string {
   const normalized = path.trim().replace(/\\/g, "/").replace(/^\.\/+/, "").replace(/^\/+/, "").replace(/\/+/g, "/")
   const withoutTrailingSlash = normalized.replace(/\/+$/, "")
@@ -167,7 +181,7 @@ function hideEntries(
  * want a "Files" panel; `WorkbenchLeftPane` uses this primitive directly to
  * share its search input with the Data tab.
  */
-export function FileTreeView({
+export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(function FileTreeView({
   rootDir = ".",
   searchQuery,
   bridge,
@@ -176,7 +190,7 @@ export function FileTreeView({
   access = "readwrite",
   ignoreNames = DEFAULT_TREE_IGNORE,
   className,
-}: FileTreeViewProps) {
+}, ref) {
   const dataClient = useDataClient()
   const canMutate = access !== "readonly"
   const activeFilesystem = normalizeUiFilesystem(filesystem)
@@ -185,7 +199,7 @@ export function FileTreeView({
     (path: string) => requestFilesystem ? dataClient.getTree(path, undefined, requestFilesystem) : dataClient.getTree(path),
     [dataClient, requestFilesystem],
   )
-  const { data: rawFileList, error, isLoading } = useFileList(rootDir, requestFilesystem)
+  const { data: rawFileList, error, isLoading, refetch: refetchFileList } = useFileList(rootDir, requestFilesystem)
   const [optimisticEntries, setOptimisticEntries] = useState<
     Map<string, FileEntry[]>
   >(new Map())
@@ -384,6 +398,23 @@ export function FileTreeView({
   useLayoutEffect(() => {
     expandedDirsRef.current = new Set(expandedChildren.keys())
   }, [expandedChildren])
+
+  // Manual refresh (the Files-pane "Refresh" button): re-fetch this root's
+  // own listing plus every subfolder currently expanded, so a stale tree
+  // (e.g. changes made outside any signal this pane already listens for)
+  // can always be forced back in sync on demand.
+  useImperativeHandle(
+    ref,
+    () => ({
+      refetch: async () => {
+        await Promise.all([
+          refetchFileList(),
+          refreshDirs(Array.from(expandedDirsRef.current), { force: true }),
+        ])
+      },
+    }),
+    [refetchFileList, refreshDirs],
+  )
 
   useEffect(() => {
     const settledTimers = new Set<ReturnType<typeof setTimeout>>()
@@ -673,11 +704,7 @@ export function FileTreeView({
       const trimmed = value.trim()
       if (!trimmed || !canMutate) return
       const dir = current.kind === "rename" ? parentDir(current.path) : current.parentDir
-      const newPath = current.kind === "rename"
-        ? current.path
-        : dir === "." || dir === ""
-          ? trimmed
-          : `${dir}/${trimmed}`
+      const newPath = current.kind === "rename" ? current.path : joinPath(dir, trimmed)
       const trackPath = current.kind === "rename" ? current.path : newPath
       markPending(trackPath)
       let addedOptimisticPath: string | null = null
@@ -970,7 +997,8 @@ export function FileTreeView({
       </AlertDialog>
     </div>
   )
-}
+})
+FileTreeView.displayName = "FileTreeView"
 
 export { clampContextMenuPosition }
 
@@ -1058,6 +1086,34 @@ export function FileTreePane({
   const activeAccess = activeRoot?.access ?? effectiveAccess
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
+  // `FileTreeView` remounts (via the `key` below) whenever the active root
+  // changes, so this ref always targets whichever root is currently
+  // selected in the dropdown — the refresh button never needs to know
+  // which root it's pointed at.
+  const treeRef = useRef<FileTreeViewHandle>(null)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true)
+    try {
+      await treeRef.current?.refetch()
+    } finally {
+      setIsRefreshing(false)
+    }
+  }, [])
+  const refreshButton = (
+    <IconButton
+      type="button"
+      variant="ghost"
+      size="icon-xs"
+      aria-label="Refresh files"
+      disabled={isRefreshing}
+      onClick={() => void handleRefresh()}
+      className="shrink-0 text-muted-foreground hover:text-foreground"
+    >
+      <RefreshCwIcon className={cn("h-3.5 w-3.5", isRefreshing && "animate-spin")} strokeWidth={2} />
+    </IconButton>
+  )
+
   useEffect(() => {
     clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => setDebouncedQuery(searchQuery), 200)
@@ -1079,21 +1135,29 @@ export function FileTreePane({
     // `effectiveSearchQuery` above) above the tree.
     if (rootOptions.length <= 1) {
       return (
-        <FileTreeView
-          key={`${activeFilesystem}:${activeRootDir}`}
-          rootDir={activeRootDir}
-          searchQuery={effectiveSearchQuery}
-          bridge={effectiveBridge}
-          filesystem={activeFilesystem}
-          access={activeAccess}
-          revealFileTreeRequest={effectiveRevealRequest}
-          className={cn("px-1 pt-1 [&_[role=treeitem]]:!indent-0", className)}
-        />
+        <div className="flex h-full min-h-0 flex-col">
+          <div className="flex shrink-0 items-center justify-end px-1 pt-1">
+            {refreshButton}
+          </div>
+          <div className="min-h-0 flex-1">
+            <FileTreeView
+              ref={treeRef}
+              key={`${activeFilesystem}:${activeRootDir}`}
+              rootDir={activeRootDir}
+              searchQuery={effectiveSearchQuery}
+              bridge={effectiveBridge}
+              filesystem={activeFilesystem}
+              access={activeAccess}
+              revealFileTreeRequest={effectiveRevealRequest}
+              className={cn("px-1 [&_[role=treeitem]]:!indent-0", className)}
+            />
+          </div>
+        </div>
       )
     }
     return (
       <div className="flex h-full min-h-0 flex-col">
-        <div className="shrink-0 px-1 pt-1">
+        <div className="flex shrink-0 items-center gap-1 px-1 pt-1">
           <Select
             value={activeFilesystem}
             onValueChange={(value) => setSelectedFilesystem(value as FilesystemId)}
@@ -1113,9 +1177,11 @@ export function FileTreePane({
               ))}
             </SelectContent>
           </Select>
+          {refreshButton}
         </div>
         <div className="min-h-0 flex-1">
           <FileTreeView
+            ref={treeRef}
             key={`${activeFilesystem}:${activeRootDir}`}
             rootDir={activeRootDir}
             searchQuery={effectiveSearchQuery}
@@ -1155,16 +1221,20 @@ export function FileTreePane({
               </SelectContent>
             </Select>
           )}
-          <Input
-            placeholder={activeRoot?.searchPlaceholder ?? "Search files..."}
-            value={externalSearchQuery ?? searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="h-7 text-xs"
-            aria-label="Search files"
-          />
+          <div className="flex items-center gap-1">
+            <Input
+              placeholder={activeRoot?.searchPlaceholder ?? "Search files..."}
+              value={externalSearchQuery ?? searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="h-7 text-xs"
+              aria-label="Search files"
+            />
+            {refreshButton}
+          </div>
         </div>
         <div className="min-h-0 flex-1">
           <FileTreeView
+            ref={treeRef}
             key={`${activeFilesystem}:${activeRootDir}`}
             rootDir={activeRootDir}
             searchQuery={effectiveSearchQuery}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -6,6 +6,7 @@ import type React from "react"
 import { Toaster, clearToasts } from "../../../../../front/toast"
 
 const mockFileList = vi.fn()
+const mockFileListRefetch = vi.fn()
 const mockFileWrite = vi.fn()
 const mockCreateDir = vi.fn()
 const mockMoveFile = vi.fn()
@@ -229,11 +230,13 @@ afterAll(() => {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockFileListRefetch.mockResolvedValue(undefined)
   mockFileSearch.mockReturnValue({ data: undefined })
   mockFileList.mockReturnValue({
     data: sampleFiles,
     isLoading: false,
     error: undefined,
+    refetch: mockFileListRefetch,
   })
   mockGetGitUrlMetadata.mockImplementation(() => ({ data: { enabled: false } }))
 })
@@ -1724,6 +1727,186 @@ describe("FileTreePane", () => {
       await waitFor(() => expect(mockDeleteFile).toHaveBeenCalled())
       await waitFor(() => expect(mockGetTree).toHaveBeenCalledWith("src"))
       expect(mockGetTree).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("Create de-dup", () => {
+    it("creating a file at the root renders exactly one matching node", async () => {
+      mockFileWrite.mockResolvedValue(undefined)
+      render(<FileTreePane />, { wrapper })
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+      const container = screen.getByTestId("file-tree").parentElement!
+      fireEvent.contextMenu(container)
+      fireEvent.click(screen.getByRole("menuitem", { name: "New file" }))
+
+      const input = await screen.findByTestId("file-tree-edit-input")
+      fireEvent.change(input, { target: { value: "notes.md" } })
+      fireEvent.keyDown(input, { key: "Enter" })
+
+      await waitFor(() => expect(screen.getByText("notes.md")).toBeInTheDocument())
+      // Give any further optimistic-entry / refetch bookkeeping a chance to
+      // settle before asserting the node count — a regression here would
+      // show a second "notes.md" row once the confirm-and-clear machinery
+      // (or a later unrelated re-render) runs.
+      await new Promise((r) => setTimeout(r, 50))
+      expect(screen.getAllByText("notes.md")).toHaveLength(1)
+    })
+
+    it("creating a file inside a folder with a non-dot root path renders exactly one matching node", async () => {
+      // Regression guard for the "//name" double-slash join bug: a
+      // filesystem root configured as "/" (e.g. company_context) used to
+      // build a create path that didn't match what the confirmed listing
+      // would use, so the optimistic entry and the real entry never
+      // deduped by path and the row rendered twice.
+      mockFileWrite.mockResolvedValue(undefined)
+      mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
+        data: filesystem === "project_alpha" ? sampleFiles : [],
+        isLoading: false,
+        isSuccess: true,
+        error: undefined,
+        refetch: mockFileListRefetch,
+      }))
+
+      render(
+        <FileTreePane
+          roots={[
+            { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readwrite" },
+          ]}
+        />,
+        { wrapper },
+      )
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+      const container = screen.getByTestId("file-tree").parentElement!
+      fireEvent.contextMenu(container)
+      fireEvent.click(screen.getByRole("menuitem", { name: "New file" }))
+
+      const input = await screen.findByTestId("file-tree-edit-input")
+      fireEvent.change(input, { target: { value: "root-notes.md" } })
+      fireEvent.keyDown(input, { key: "Enter" })
+
+      await waitFor(() =>
+        expect(mockFileWrite).toHaveBeenCalledWith({
+          path: "root-notes.md",
+          content: "",
+          returnMtimeMs: false,
+          filesystem: "project_alpha",
+        }),
+      )
+      await waitFor(() => expect(screen.getByText("root-notes.md")).toBeInTheDocument())
+      await new Promise((r) => setTimeout(r, 50))
+      expect(screen.getAllByText("root-notes.md")).toHaveLength(1)
+    })
+  })
+
+  describe("Refresh button", () => {
+    it("shows a Refresh files button next to the search input and refetches the active root on click", async () => {
+      render(<FileTreePane />, { wrapper })
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+      const button = screen.getByRole("button", { name: "Refresh files" })
+      expect(button).toBeInTheDocument()
+
+      fireEvent.click(button)
+      await waitFor(() => expect(mockFileListRefetch).toHaveBeenCalled())
+    })
+
+    it("shows the Refresh button in single-root chromeless mode", async () => {
+      render(<FileTreePane chromeless />, { wrapper })
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+      const button = screen.getByRole("button", { name: "Refresh files" })
+      fireEvent.click(button)
+      await waitFor(() => expect(mockFileListRefetch).toHaveBeenCalled())
+    })
+
+    it("shows the Refresh button in multi-root chromeless mode and refetches whichever root is active", async () => {
+      mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
+        data: filesystem === "project_alpha"
+          ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
+          : sampleFiles,
+        isLoading: false,
+        isSuccess: true,
+        error: undefined,
+        refetch: mockFileListRefetch,
+      }))
+
+      render(
+        <FileTreePane
+          chromeless
+          roots={[
+            { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+            { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readonly" },
+          ]}
+        />,
+        { wrapper },
+      )
+
+      expect(await screen.findByRole("combobox", { name: "File root" })).toBeInTheDocument()
+      await selectRoot("Project")
+      await waitFor(() => expect(screen.getByText("handbook.md")).toBeInTheDocument())
+
+      mockFileListRefetch.mockClear()
+      fireEvent.click(screen.getByRole("button", { name: "Refresh files" }))
+      await waitFor(() => expect(mockFileListRefetch).toHaveBeenCalled())
+    })
+
+    it("disables the button and shows a busy state while the refetch is in flight", async () => {
+      let resolveRefetch!: () => void
+      mockFileListRefetch.mockImplementation(
+        () => new Promise<void>((resolve) => { resolveRefetch = resolve }),
+      )
+      render(<FileTreePane />, { wrapper })
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+      const button = screen.getByRole("button", { name: "Refresh files" })
+      fireEvent.click(button)
+
+      await waitFor(() => expect(button).toBeDisabled())
+
+      await act(async () => {
+        resolveRefetch()
+      })
+      await waitFor(() => expect(button).not.toBeDisabled())
+    })
+  })
+
+  describe("Auto-refresh on agent/remote file changes", () => {
+    it("a file created out-of-band by the agent (remote SSE cause) appears at the root without user action", async () => {
+      render(<FileTreePane />, { wrapper })
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+      expect(screen.queryByText("agent-created.md")).not.toBeInTheDocument()
+
+      // This is the same bus event `useFileEventStream` relays from the
+      // server's `/api/v1/fs/events` SSE stream when the *agent* (not this
+      // browser tab) writes a file — the existing signal this pane already
+      // listens on, wired well before this PR.
+      act(() => {
+        events.emit(filesystemEvents.created, { ...remoteMeta(), path: "agent-created.md", kind: "file" })
+      })
+
+      await waitFor(() => expect(screen.getByText("agent-created.md")).toBeInTheDocument())
+    })
+
+    it("a file the agent creates inside an already-expanded folder appears without the user re-expanding it", async () => {
+      mockGetTree.mockResolvedValue([{ name: "old.ts", kind: "file", path: "src/old.ts" }])
+      render(<FileTreePane />, { wrapper })
+      await waitFor(() => expect(screen.getByText("src")).toBeInTheDocument())
+
+      fireEvent.click(screen.getByTestId("trigger-expand-src"))
+      await screen.findByText("old.ts")
+
+      mockGetTree.mockResolvedValue([
+        { name: "old.ts", kind: "file", path: "src/old.ts" },
+        { name: "agent-new.ts", kind: "file", path: "src/agent-new.ts" },
+      ])
+      act(() => {
+        events.emit(filesystemEvents.created, { ...remoteMeta(), path: "src/agent-new.ts", kind: "file" })
+      })
+
+      await waitFor(() => expect(screen.getByText("agent-new.ts")).toBeInTheDocument())
     })
   })
 })

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/treeModel.test.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/treeModel.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest"
+import { joinPath } from "../treeModel"
+
+describe("joinPath", () => {
+  it("returns the bare name at the dot root", () => {
+    expect(joinPath(".", "notes.md")).toBe("notes.md")
+  })
+
+  it("returns the bare name at the empty-string root", () => {
+    expect(joinPath("", "notes.md")).toBe("notes.md")
+  })
+
+  it("joins a regular relative dir with a single slash", () => {
+    expect(joinPath("src", "child.ts")).toBe("src/child.ts")
+  })
+
+  it("joins a nested relative dir", () => {
+    expect(joinPath("src/lib", "child.ts")).toBe("src/lib/child.ts")
+  })
+
+  // Regression: a filesystem root configured as "/" (see company_context in
+  // `FileTreeRootConfig`) used to produce "//name" via naive `${dir}/${name}`
+  // string interpolation — a path that never matched what the server
+  // round-tripped back, so the optimistic create entry and the confirmed
+  // entry never deduped by path and the row rendered twice.
+  it("does not double the slash when dir is the filesystem root '/'", () => {
+    expect(joinPath("/", "root-notes.md")).toBe("root-notes.md")
+  })
+
+  it("strips a trailing slash from a regular dir before joining", () => {
+    expect(joinPath("src/", "child.ts")).toBe("src/child.ts")
+  })
+})

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/treeModel.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/treeModel.ts
@@ -32,6 +32,23 @@ export function dirKey(dir: string): string {
   return dir && dir !== '' ? dir : '.'
 }
 
+/**
+ * Join a directory and a leaf name into a path, the same way every path in
+ * this module is shaped: no leading "./", no doubled or trailing slashes.
+ * `dir` is normally "." (root) or a bare relative path like "src/lib" — but
+ * some hosts configure a filesystem root as "/" (see company_context in
+ * `FileTreeRootConfig`), and naively doing `${dir}/${name}` there produced
+ * "//name": a path string that doesn't match what the server round-trips
+ * back, so the optimistic entry and the server-confirmed entry never
+ * deduped by path and the row rendered twice. Stripping trailing slashes
+ * from `dir` first keeps every root shape converging on the same string.
+ */
+export function joinPath(dir: string, name: string): string {
+  const trimmedDir = dir.replace(/\/+$/, '')
+  if (trimmedDir === '' || trimmedDir === '.') return name
+  return `${trimmedDir}/${name}`
+}
+
 export function mergeEntries(
   base: FileEntry[] | undefined,
   optimistic: FileEntry[] | undefined,


### PR DESCRIPTION
## Summary
- Fix a real duplicate-path bug: creating a file at a non-dot filesystem root (e.g. `company_context` configured with `rootDir: "/"`) built the optimistic path via naive `${dir}/${trimmed}` interpolation, producing `"//name"` — a string that never matched the server-confirmed entry, so the row could render twice. Replaced with a shared `joinPath` helper that strips trailing slashes before joining.
- Add a manual "Refresh files" icon button next to the search input, in both chromeless and chromed `FileTreePane` layouts (single-root and multi-root). Wired via a new `FileTreeViewHandle` (`forwardRef` + `useImperativeHandle`) that re-fetches the active root's top-level listing plus any currently-expanded subfolders. Because `FileTreeView` remounts on root switch (existing `key` prop), the button always targets whichever root is selected in the dropdown.
- Auto-refresh on agent/out-of-band file changes was **already wired** pre-PR: the SSE stream (`/api/v1/fs/events`) relays into `filesystemEvents.created` with `cause: "remote"`, which both `useFileEventInvalidation` (query cache patch + invalidation) and `FileTreeView`'s own listeners (optimistic entry patch at root, `refreshDirs` for expanded subfolders) already handle. No new plumbing needed here — added regression tests pinning this existing behavior so it doesn't silently regress.

## Root cause note on the reported duplicate
I could not reproduce a duplicate row via `mergeEntries`'s path-keyed dedup in the common "." root path (confirmed with a throwaway repro harness exercising the real hooks + `DataProvider` + a fake in-memory backend, across root-level create, nested-folder create, and a simulated SSE echo of the user's own write — all deduped correctly). The one concrete, demonstrable defect found was the `"//name"` double-slash path for a non-dot root, which does produce two genuinely different path strings for the same file and would survive `sanitizeFileTree`'s exact-string dedup. That's the fix landed here.

## Test plan
- [x] `pnpm --filter @hachej/boring-workspace run typecheck`
- [x] `pnpm --filter @hachej/boring-workspace run test` (1717 passed)
- [x] `pnpm --filter @hachej/boring-workspace build`
- [x] `pnpm run lint:invariants`
- [x] New tests: create-dedup (root + non-dot-root), refresh button (chromeless single/multi-root + chromed, busy/disabled state, refetch wiring), agent/remote auto-refresh regression, `joinPath` unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)