### PR TITLE
#391 feat(D1): add immutable publication journal store

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/destructivePublicationJournal.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/destructivePublicationJournal.test.ts
@@ -1,0 +1,168 @@
+import postgres from 'postgres'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { runMigrations } from '@hachej/boring-core/server'
+import type { CoreConfig } from '@hachej/boring-core/shared'
+
+import {
+  createD1DestructivePublicationJournalStore,
+  type D1DestructivePublicationIdentity,
+} from '../destructivePublicationJournal.js'
+
+const DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://ubuntu:test@localhost/boring_ui_test'
+const RUN = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+const HOST = `journal-${RUN}`
+const digest = (value: string) => `sha256:${value.repeat(64).slice(0, 64)}` as const
+const identity = (id: string, overrides: Partial<D1DestructivePublicationIdentity> = {}): D1DestructivePublicationIdentity => ({
+  operationId: `${RUN}-${id}`, hostId: HOST, expectedRevision: 'r0000000001', expectedDigest: digest('a'),
+  targetRevision: 'r0000000002', targetDigest: digest('b'), removalBindingIds: ['alpha', 'zulu'], ...overrides,
+})
+const error = { code: 'D1_DESTRUCTIVE_PUBLICATION_JOURNAL_STORE_FAILED' }
+const store = createD1DestructivePublicationJournalStore()
+let sql: postgres.Sql
+
+async function reserved<T>(operation: (connection: postgres.ReservedSql) => Promise<T>): Promise<T> {
+  const connection = await sql.reserve()
+  try { return await operation(connection) } finally { connection.release() }
+}
+
+beforeAll(async () => {
+  await runMigrations({ databaseUrl: DATABASE_URL } as CoreConfig)
+  sql = postgres(DATABASE_URL, { max: 4 })
+})
+afterAll(async () => { if (sql) await sql.end() })
+
+describe('D1 destructive publication journal store', () => {
+  it('migrates an immutable identity-sequenced event journal', async () => {
+    const columns = await sql`
+      SELECT column_name, is_identity, data_type FROM information_schema.columns
+      WHERE table_name = 'd1_destructive_publication_events' ORDER BY ordinal_position
+    `
+    expect(columns.map((column) => column.column_name)).toEqual([
+      'sequence', 'operation_id', 'state', 'host_id', 'expected_revision', 'expected_digest',
+      'target_revision', 'target_digest', 'removal_binding_ids', 'recorded_at',
+    ])
+    expect(columns[0]).toMatchObject({ is_identity: 'YES', data_type: 'bigint' })
+    expect(columns[9]).toMatchObject({ data_type: 'timestamp with time zone' })
+    expect(Object.keys(store)).toEqual(['appendPrepared', 'appendTerminal', 'readOperation', 'readPending'])
+
+    const value = identity('immutable')
+    await reserved((connection) => store.appendPrepared(connection, value))
+    await expect(sql`UPDATE d1_destructive_publication_events SET state = 'aborted' WHERE operation_id = ${value.operationId}`).rejects.toThrow(/immutable/)
+    await expect(sql`DELETE FROM d1_destructive_publication_events WHERE operation_id = ${value.operationId}`).rejects.toThrow(/immutable/)
+    await expect(sql`TRUNCATE d1_destructive_publication_events`).rejects.toThrow(/immutable/)
+    await reserved((connection) => store.appendTerminal(connection, value, 'aborted'))
+  })
+
+  it('appends ordered events idempotently and reconstructs pending operations', async () => {
+    const completed = identity('completed'); const pending = identity('pending', { targetRevision: 'r0000000003' })
+    await reserved(async (connection) => {
+      const prepared = await store.appendPrepared(connection, completed)
+      expect(await store.appendPrepared(connection, completed)).toEqual(prepared)
+      await store.appendPrepared(connection, pending)
+      expect((await store.readPending(connection, HOST)).map((event) => event.operationId)).toEqual([
+        completed.operationId, pending.operationId,
+      ])
+      const terminal = await store.appendTerminal(connection, completed, 'committed')
+      expect(await store.appendTerminal(connection, completed, 'committed')).toEqual(terminal)
+      expect(terminal.sequence).toBeGreaterThan(prepared.sequence)
+      expect(terminal.recordedAt).toBeInstanceOf(Date)
+      expect(await store.readOperation(connection, completed.operationId)).toEqual({ prepared, terminal })
+      expect((await store.readPending(connection, HOST)).map((event) => event.operationId)).toEqual([pending.operationId])
+    })
+  })
+
+  it('rejects changed repeated metadata and contradictory terminal state', async () => {
+    const value = identity('consistency')
+    await reserved(async (connection) => {
+      await store.appendPrepared(connection, value)
+      await expect(store.appendPrepared(connection, { ...value, targetDigest: digest('c') })).rejects.toMatchObject(error)
+      await store.appendTerminal(connection, value, 'aborted')
+      await expect(store.appendTerminal(connection, value, 'committed')).rejects.toMatchObject(error)
+    })
+
+    const corrupted = identity('contradictory-row')
+    await reserved((connection) => store.appendPrepared(connection, corrupted))
+    await sql`
+      INSERT INTO d1_destructive_publication_events
+        (operation_id, state, host_id, expected_revision, expected_digest, target_revision, target_digest, removal_binding_ids)
+      VALUES (${corrupted.operationId}, 'committed', ${corrupted.hostId}, ${corrupted.expectedRevision}, ${corrupted.expectedDigest},
+        ${corrupted.targetRevision}, ${digest('d')}, ${corrupted.removalBindingIds as string[]})
+    `
+    await reserved((connection) => expect(store.readOperation(connection, corrupted.operationId)).rejects.toMatchObject(error))
+    await reserved((connection) => expect(store.readPending(connection, HOST)).rejects.toMatchObject(error))
+
+    const orphan = identity('terminal-only', { hostId: `${HOST}-orphan` })
+    await sql`
+      INSERT INTO d1_destructive_publication_events
+        (operation_id, state, host_id, expected_revision, expected_digest, target_revision, target_digest, removal_binding_ids)
+      VALUES (${orphan.operationId}, 'aborted', ${orphan.hostId}, ${orphan.expectedRevision}, ${orphan.expectedDigest},
+        ${orphan.targetRevision}, ${orphan.targetDigest}, ${orphan.removalBindingIds as string[]})
+    `
+    await reserved((connection) => expect(store.readPending(connection, orphan.hostId)).rejects.toMatchObject(error))
+  })
+
+  it('converges same-event races and fails exactly one contradictory writer', async () => {
+    const samePrepare = identity('same-prepare')
+    const prepared = await Promise.all([
+      reserved((connection) => store.appendPrepared(connection, samePrepare)),
+      reserved((connection) => store.appendPrepared(connection, samePrepare)),
+    ])
+    expect(prepared[1]).toEqual(prepared[0])
+
+    const conflictingPrepare = identity('conflicting-prepare')
+    const prepareRace = await Promise.allSettled([
+      reserved((connection) => store.appendPrepared(connection, conflictingPrepare)),
+      reserved((connection) => store.appendPrepared(connection, { ...conflictingPrepare, targetDigest: digest('c') })),
+    ])
+    expect(prepareRace.map((result) => result.status).sort()).toEqual(['fulfilled', 'rejected'])
+    expect(prepareRace.find((result) => result.status === 'rejected')).toMatchObject({ reason: error })
+
+    const sameTerminal = identity('same-terminal')
+    await reserved((connection) => store.appendPrepared(connection, sameTerminal))
+    const terminals = await Promise.all([
+      reserved((connection) => store.appendTerminal(connection, sameTerminal, 'committed')),
+      reserved((connection) => store.appendTerminal(connection, sameTerminal, 'committed')),
+    ])
+    expect(terminals[1]).toEqual(terminals[0])
+
+    const conflictingTerminal = identity('conflicting-terminal')
+    await reserved((connection) => store.appendPrepared(connection, conflictingTerminal))
+    const terminalRace = await Promise.allSettled([
+      reserved((connection) => store.appendTerminal(connection, conflictingTerminal, 'committed')),
+      reserved((connection) => store.appendTerminal(connection, conflictingTerminal, 'aborted')),
+    ])
+    expect(terminalRace.map((result) => result.status).sort()).toEqual(['fulfilled', 'rejected'])
+    expect(terminalRace.find((result) => result.status === 'rejected')).toMatchObject({ reason: error })
+  })
+
+  it('fails closed for invalid input and malformed stored rows', async () => {
+    await reserved(async (connection) => {
+      for (const value of [
+        identity('empty', { removalBindingIds: [] }), identity('unsorted', { removalBindingIds: ['zulu', 'alpha'] }),
+        identity('historical', { targetRevision: 'r0000000001' }),
+      ]) await expect(store.appendPrepared(connection, value)).rejects.toMatchObject(error)
+    })
+    const malformed = identity('malformed')
+    await sql`
+      INSERT INTO d1_destructive_publication_events
+        (operation_id, state, host_id, expected_revision, expected_digest, target_revision, target_digest, removal_binding_ids)
+      VALUES (${malformed.operationId}, 'prepared', ${malformed.hostId}, ${malformed.expectedRevision}, ${malformed.expectedDigest},
+        ${malformed.targetRevision}, ${malformed.targetDigest}, ${['zulu', 'alpha']})
+    `
+    await reserved((connection) => expect(store.readOperation(connection, malformed.operationId)).rejects.toMatchObject(error))
+  })
+
+  it('translates reserved-connection failure without leaking driver details', async () => {
+    const applicationName = `d1-journal-${RUN}`
+    const owned = postgres(DATABASE_URL, { max: 1, connection: { application_name: applicationName } })
+    const connection = await owned.reserve()
+    await connection`SELECT 1`
+    const [backend] = await sql<{ pid: number }[]>`SELECT pid FROM pg_stat_activity WHERE application_name = ${applicationName}`
+    await sql`SELECT pg_terminate_backend(${backend!.pid})`
+    const caught = await store.readOperation(connection, identity('lost').operationId).catch((value) => value)
+    expect(caught).toMatchObject(error)
+    expect(JSON.stringify(caught)).not.toMatch(/CONNECTION_|ECONN|postgres:/)
+    try { connection.release() } catch {}
+    await owned.end({ timeout: 0 }).catch(() => {})
+  })
+})

--- a/apps/full-app/src/server/deployment/destructivePublicationJournal.ts
+++ b/apps/full-app/src/server/deployment/destructivePublicationJournal.ts
@@ -1,0 +1,167 @@
+import type postgres from 'postgres'
+import type { Sha256Digest } from '@hachej/boring-agent/shared'
+
+import { d1Digest, strictD1HostId, strictD1Ref } from './d1Plan.js'
+
+const REVISION_RE = /^r\d{10}$/
+const STATES = ['prepared', 'committed', 'aborted'] as const
+export type D1DestructivePublicationState = typeof STATES[number]
+
+export interface D1DestructivePublicationIdentity {
+  readonly operationId: string
+  readonly hostId: string
+  readonly expectedRevision: string
+  readonly expectedDigest: Sha256Digest
+  readonly targetRevision: string
+  readonly targetDigest: Sha256Digest
+  readonly removalBindingIds: readonly string[]
+}
+
+export interface D1DestructivePublicationEvent extends D1DestructivePublicationIdentity {
+  readonly sequence: bigint
+  readonly state: D1DestructivePublicationState
+  readonly recordedAt: Date
+}
+
+interface JournalRow {
+  sequence: string | number | bigint
+  operationId: string
+  state: string
+  hostId: string
+  expectedRevision: string
+  expectedDigest: string
+  targetRevision: string
+  targetDigest: string
+  removalBindingIds: string[]
+  recordedAt: Date
+}
+export interface D1DestructivePublicationOperation {
+  readonly prepared: D1DestructivePublicationEvent
+  readonly terminal?: D1DestructivePublicationEvent
+}
+export interface D1DestructivePublicationJournalStore {
+  appendPrepared(sql: postgres.ReservedSql, identity: D1DestructivePublicationIdentity): Promise<D1DestructivePublicationEvent>
+  appendTerminal(sql: postgres.ReservedSql, identity: D1DestructivePublicationIdentity, state: 'committed' | 'aborted'): Promise<D1DestructivePublicationEvent>
+  readOperation(sql: postgres.ReservedSql, operationId: string): Promise<D1DestructivePublicationOperation | null>
+  readPending(sql: postgres.ReservedSql, hostId: string): Promise<readonly D1DestructivePublicationEvent[]>
+}
+const STORE_ERROR_CODE = 'D1_DESTRUCTIVE_PUBLICATION_JOURNAL_STORE_FAILED'
+class JournalStoreError extends Error { readonly code = STORE_ERROR_CODE }
+function failed(): JournalStoreError { return new JournalStoreError(STORE_ERROR_CODE) }
+function revision(value: unknown): string {
+  if (typeof value !== 'string' || !REVISION_RE.test(value)) throw failed()
+  return value
+}
+function normalize(raw: D1DestructivePublicationIdentity): D1DestructivePublicationIdentity {
+  try {
+    const expectedRevision = revision(raw.expectedRevision)
+    const targetRevision = revision(raw.targetRevision)
+    if (Number(targetRevision.slice(1)) <= Number(expectedRevision.slice(1))) throw failed()
+    if (!Array.isArray(raw.removalBindingIds) || raw.removalBindingIds.length === 0) throw failed()
+    const removalBindingIds = raw.removalBindingIds.map((value) => strictD1Ref(value, 'removalBindingIds'))
+    const sorted = [...removalBindingIds].sort()
+    if (new Set(removalBindingIds).size !== removalBindingIds.length || sorted.some((value, index) => value !== removalBindingIds[index])) throw failed()
+    return Object.freeze({
+      operationId: strictD1Ref(raw.operationId, 'operationId'), hostId: strictD1HostId(raw.hostId, 'hostId'),
+      expectedRevision, expectedDigest: d1Digest(raw.expectedDigest, 'expectedDigest'),
+      targetRevision, targetDigest: d1Digest(raw.targetDigest, 'targetDigest'),
+      removalBindingIds: Object.freeze(removalBindingIds),
+    })
+  } catch { throw failed() }
+}
+function parseRow(raw: JournalRow | undefined): D1DestructivePublicationEvent {
+  if (!raw || !STATES.includes(raw.state as D1DestructivePublicationState) || !(raw.recordedAt instanceof Date)
+    || !Number.isFinite(raw.recordedAt.getTime())) throw failed()
+  let sequence: bigint
+  try { sequence = BigInt(raw.sequence) } catch { throw failed() }
+  if (sequence <= 0n) throw failed()
+  const value = normalize(raw as D1DestructivePublicationIdentity)
+  return Object.freeze({ ...value, sequence, state: raw.state as D1DestructivePublicationState, recordedAt: new Date(raw.recordedAt) })
+}
+function same(left: D1DestructivePublicationIdentity, right: D1DestructivePublicationIdentity): boolean {
+  return left.operationId === right.operationId && left.hostId === right.hostId
+    && left.expectedRevision === right.expectedRevision && left.expectedDigest === right.expectedDigest
+    && left.targetRevision === right.targetRevision && left.targetDigest === right.targetDigest
+    && left.removalBindingIds.length === right.removalBindingIds.length
+    && left.removalBindingIds.every((value, index) => value === right.removalBindingIds[index])
+}
+function operation(events: readonly D1DestructivePublicationEvent[]): D1DestructivePublicationOperation | null {
+  if (events.length === 0) return null
+  if (events.length > 2 || events[0]?.state !== 'prepared' || events[1]?.state === 'prepared'
+    || events[1] && !same(events[0], events[1])) throw failed()
+  return Object.freeze({ prepared: events[0]!, ...(events[1] ? { terminal: events[1] } : {}) })
+}
+
+export function createD1DestructivePublicationJournalStore(): D1DestructivePublicationJournalStore {
+  const readOperation = async (sql: postgres.ReservedSql, rawOperationId: string) => {
+    try {
+      const operationId = strictD1Ref(rawOperationId, 'operationId')
+      const rows = await sql<JournalRow[]>`
+      SELECT sequence, operation_id AS "operationId", state, host_id AS "hostId",
+        expected_revision AS "expectedRevision", expected_digest AS "expectedDigest",
+        target_revision AS "targetRevision", target_digest AS "targetDigest",
+        removal_binding_ids AS "removalBindingIds", recorded_at AS "recordedAt"
+      FROM d1_destructive_publication_events WHERE operation_id = ${operationId} ORDER BY sequence
+      `
+      return operation(rows.map(parseRow))
+    } catch { throw failed() }
+  }
+  const append = async (sql: postgres.ReservedSql, value: D1DestructivePublicationIdentity, state: D1DestructivePublicationState) => {
+    await sql`
+      INSERT INTO d1_destructive_publication_events
+        (operation_id, state, host_id, expected_revision, expected_digest, target_revision, target_digest, removal_binding_ids)
+      VALUES (${value.operationId}, ${state}, ${value.hostId}, ${value.expectedRevision}, ${value.expectedDigest},
+        ${value.targetRevision}, ${value.targetDigest}, ${value.removalBindingIds as string[]})
+      ON CONFLICT DO NOTHING
+    `
+  }
+  const appendPrepared = async (sql: postgres.ReservedSql, raw: D1DestructivePublicationIdentity) => {
+    try {
+      const value = normalize(raw); await append(sql, value, 'prepared')
+      const existing = await readOperation(sql, value.operationId)
+      if (!existing || !same(existing.prepared, value)) throw failed()
+      return existing.prepared
+    } catch { throw failed() }
+  }
+  const appendTerminal = async (sql: postgres.ReservedSql, raw: D1DestructivePublicationIdentity, state: 'committed' | 'aborted') => {
+    try {
+      const value = normalize(raw); const before = await readOperation(sql, value.operationId)
+      if (!before || !same(before.prepared, value)) throw failed()
+      if (before.terminal) {
+        if (before.terminal.state !== state) throw failed()
+        return before.terminal
+      }
+      await append(sql, value, state)
+      const after = await readOperation(sql, value.operationId)
+      if (!after?.terminal || after.terminal.state !== state || !same(after.terminal, value)) throw failed()
+      return after.terminal
+    } catch { throw failed() }
+  }
+  const readPending = async (sql: postgres.ReservedSql, rawHostId: string) => {
+    try {
+      const hostId = strictD1HostId(rawHostId, 'hostId')
+      const rows = await sql<JournalRow[]>`
+        SELECT sequence, operation_id AS "operationId", state, host_id AS "hostId",
+          expected_revision AS "expectedRevision", expected_digest AS "expectedDigest",
+          target_revision AS "targetRevision", target_digest AS "targetDigest",
+          removal_binding_ids AS "removalBindingIds", recorded_at AS "recordedAt"
+        FROM d1_destructive_publication_events WHERE operation_id IN (
+          SELECT operation_id FROM d1_destructive_publication_events WHERE host_id = ${hostId}
+        ) ORDER BY sequence
+      `
+      const grouped = new Map<string, D1DestructivePublicationEvent[]>()
+      for (const row of rows) {
+        const event = parseRow(row); const events = grouped.get(event.operationId) ?? []
+        events.push(event); grouped.set(event.operationId, events)
+      }
+      const pending: D1DestructivePublicationEvent[] = []
+      for (const events of grouped.values()) {
+        const current = operation(events)
+        if (!current) throw failed()
+        if (!current.terminal) pending.push(current.prepared)
+      }
+      return Object.freeze(pending)
+    } catch { throw failed() }
+  }
+  return Object.freeze({ appendPrepared, appendTerminal, readOperation, readPending })
+}

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -12,7 +12,7 @@ const FULL_APP_DEFAULT_PLUGIN_PACKAGE_COMPOSITION = Object.freeze([{
   packageName: '@hachej/boring-automation',
   descriptor: Object.freeze({
     id: 'boring-automation',
-    version: '0.1.83',
+    version: '0.1.84',
     contentDigest: 'sha256:d6f43891e5c9c3d40beb0eb7953b53c12b92c7595c4ed54758f468687903d9ed',
   } satisfies StableContributionDescriptor),
 }])
@@ -22,13 +22,13 @@ export const FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS = Object.freeze(FULL_AP
 
 export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'full-app-governance',
-  version: '0.1.83',
+  version: '0.1.84',
   contentDigest: 'sha256:ebc7e5b2cb8d83b158b8bed4ed8a118368765ff68817c81b5f98463a72e19f7f',
 } satisfies StableContributionDescriptor)
 
 export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'boring-mcp',
-  version: '0.1.83',
+  version: '0.1.84',
   contentDigest: 'sha256:1af659b0b66cf3fc3a641e176c229b7c79c9b9444bc64d7c1ca6deea6a4340dd',
 } satisfies StableContributionDescriptor)
 

--- a/packages/core/drizzle/0019_d1_destructive_publication_events.sql
+++ b/packages/core/drizzle/0019_d1_destructive_publication_events.sql
@@ -1,0 +1,36 @@
+CREATE TABLE "d1_destructive_publication_events" (
+	"sequence" bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+	"operation_id" text NOT NULL,
+	"state" text NOT NULL,
+	"host_id" text NOT NULL,
+	"expected_revision" text NOT NULL,
+	"expected_digest" text NOT NULL,
+	"target_revision" text NOT NULL,
+	"target_digest" text NOT NULL,
+	"removal_binding_ids" text[] NOT NULL,
+	"recorded_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "d1_destructive_publication_state_check" CHECK ("state" IN ('prepared', 'committed', 'aborted')),
+	CONSTRAINT "d1_destructive_publication_expected_revision_check" CHECK ("expected_revision" ~ '^r[0-9]{10}$'),
+	CONSTRAINT "d1_destructive_publication_target_revision_check" CHECK ("target_revision" ~ '^r[0-9]{10}$'),
+	CONSTRAINT "d1_destructive_publication_expected_digest_check" CHECK ("expected_digest" ~ '^sha256:[a-f0-9]{64}$'),
+	CONSTRAINT "d1_destructive_publication_target_digest_check" CHECK ("target_digest" ~ '^sha256:[a-f0-9]{64}$'),
+	CONSTRAINT "d1_destructive_publication_removals_check" CHECK (cardinality("removal_binding_ids") > 0)
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "d1_destructive_publication_prepared_unique" ON "d1_destructive_publication_events" ("operation_id") WHERE "state" = 'prepared';
+--> statement-breakpoint
+CREATE UNIQUE INDEX "d1_destructive_publication_terminal_unique" ON "d1_destructive_publication_events" ("operation_id") WHERE "state" IN ('committed', 'aborted');
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION d1_reject_destructive_publication_event_mutation() RETURNS trigger AS $$
+BEGIN
+	RAISE EXCEPTION 'd1 destructive publication events are immutable';
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+CREATE TRIGGER d1_destructive_publication_events_immutable
+BEFORE UPDATE OR DELETE ON "d1_destructive_publication_events"
+FOR EACH ROW EXECUTE FUNCTION d1_reject_destructive_publication_event_mutation();
+--> statement-breakpoint
+CREATE TRIGGER d1_destructive_publication_events_truncate_immutable
+BEFORE TRUNCATE ON "d1_destructive_publication_events"
+FOR EACH STATEMENT EXECUTE FUNCTION d1_reject_destructive_publication_event_mutation();

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1783900800000,
       "tag": "0018_d1_binding_admissions",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1783987200000,
+      "tag": "0019_d1_destructive_publication_events",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/server/db/schema.ts
+++ b/packages/core/src/server/db/schema.ts
@@ -482,3 +482,29 @@ export const d1BindingAdmissions = pgTable(
     check('d1_binding_admissions_revision_check', sql`${table.activeRevision} ~ '^r[0-9]{10}$'`),
   ],
 )
+
+export const d1DestructivePublicationEvents = pgTable(
+  'd1_destructive_publication_events',
+  {
+    sequence: bigint('sequence', { mode: 'bigint' }).generatedAlwaysAsIdentity().primaryKey(),
+    operationId: text('operation_id').notNull(),
+    state: text('state').notNull(),
+    hostId: text('host_id').notNull(),
+    expectedRevision: text('expected_revision').notNull(),
+    expectedDigest: text('expected_digest').notNull(),
+    targetRevision: text('target_revision').notNull(),
+    targetDigest: text('target_digest').notNull(),
+    removalBindingIds: text('removal_binding_ids').array().notNull(),
+    recordedAt: timestamp('recorded_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex('d1_destructive_publication_prepared_unique').on(table.operationId).where(sql`${table.state} = 'prepared'`),
+    uniqueIndex('d1_destructive_publication_terminal_unique').on(table.operationId).where(sql`${table.state} IN ('committed', 'aborted')`),
+    check('d1_destructive_publication_state_check', sql`${table.state} IN ('prepared', 'committed', 'aborted')`),
+    check('d1_destructive_publication_expected_revision_check', sql`${table.expectedRevision} ~ '^r[0-9]{10}$'`),
+    check('d1_destructive_publication_target_revision_check', sql`${table.targetRevision} ~ '^r[0-9]{10}$'`),
+    check('d1_destructive_publication_expected_digest_check', sql`${table.expectedDigest} ~ '^sha256:[a-f0-9]{64}$'`),
+    check('d1_destructive_publication_target_digest_check', sql`${table.targetDigest} ~ '^sha256:[a-f0-9]{64}$'`),
+    check('d1_destructive_publication_removals_check', sql`cardinality(${table.removalBindingIds}) > 0`),
+  ],
+)


### PR DESCRIPTION
## Summary
- add migration 0019 and Drizzle schema for immutable destructive-publication events
- add a narrow reserved-SQL store for prepared/terminal append, operation reconstruction, and pending reads
- validate exact host/revision/digest/removal identity and require sorted, unique, nonempty removals
- make repeated appends converge while contradictory metadata or terminal state fails closed

## Safety properties
- database-allocated event sequence and server timestamp
- no update/delete API, and database triggers reject UPDATE, DELETE, and TRUNCATE
- one SQL snapshot validates complete histories before deriving pending operations
- terminal-only, malformed, inconsistent, or cross-event metadata fails closed
- concurrent same-state writes converge; conflicting prepare or terminal races produce exactly one winner
- reserved connection ownership remains with the caller for the later fenced-publication slices

## Proof
- real PostgreSQL suite: 6/6, including two-session prepare/terminal races
- full-app and core typechecks: green
- generated artifacts, import audit, repo invariants, and diff check: green
- independent review findings fixed: TRUNCATE guard and concurrent convergence proof
- structured autoreview findings fixed: single-snapshot full-history validation; final rerun clean

## Contract
D1-004e1a, recut from the #715-permitted 004e split. This storage-only slice is +404 lines; the accepted overage is proof code for immutability and real database concurrency. Fenced publication, recovery, and command wiring remain separate e1b/e1c/e2 slices.

Refs #391