### PR TITLE
#391 feat(D1): recover pending destructive publication

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
@@ -175,8 +175,9 @@ describe('D1 revision command boundary', () => {
   it('uses and closes an injected attested database connection', async () => {
     const h = await roots(); const keys = ['BORING_D1_OWNER_UID', 'BORING_D1_STATE_ROOT', 'BORING_D1_LOCK_ROOT'] as const
     const prior = Object.fromEntries(keys.map((key) => [key, process.env[key]])); const release = vi.fn(); const end = vi.fn(async () => {})
-    const reserved = Object.assign(vi.fn(async () => []), { release }) as unknown as postgres.ReservedSql
-    const reserve = vi.fn(async () => reserved); const sql = { reserve, end } as unknown as postgres.Sql
+    const options = { debug: false as boolean | ((connectionId: number, query: string, parameters: unknown[], types: unknown[]) => void), onclose: undefined as undefined | ((connectionId: number) => void) }
+    const reserved = Object.assign(vi.fn(async (strings: TemplateStringsArray, ...values: unknown[]) => { const query = strings.join('$'); if (typeof options.debug === 'function') options.debug(7, query, values, []); return query.includes('::text AS token') ? [{ token: values[0] }] : [] }), { release }) as unknown as postgres.ReservedSql
+    const reserve = vi.fn(async () => reserved); const sql = { reserve, end, options } as unknown as postgres.Sql
     const databaseConnection = mintAttestedD1DatabaseConnection('postgres-eu', sql, { ownsClient: true })
     const command = JSON.parse(validApply().toString()) as { kind: string }; command.kind = 'plan'
     for (const key of keys) process.env[key] = h.env[key]

--- a/apps/full-app/src/server/deployment/__tests__/fencedDestructivePublication.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/fencedDestructivePublication.test.ts
@@ -1,47 +1,71 @@
 import postgres from 'postgres'
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { createAgentAssetDigest, createAgentDeploymentDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
+import { createResolvedAgentDigest } from '@hachej/boring-agent/server'
 import { runMigrations } from '@hachej/boring-core/server'
 import type { CoreConfig } from '@hachej/boring-core/shared'
 
 import { createD1AdmissionLedger, mintAttestedD1DatabaseConnection, type D1AdmissionLedger } from '../admissionLedger.js'
 import type { D1ActiveCollection } from '../activeCollectionReader.js'
-import {
-  createD1DestructivePublicationJournalStore,
-  type D1DestructivePublicationIdentity,
-  type D1DestructivePublicationJournalStore,
-} from '../destructivePublicationJournal.js'
+import { createD1DestructivePublicationJournalStore, type D1DestructivePublicationIdentity, type D1DestructivePublicationJournalStore } from '../destructivePublicationJournal.js'
 import { D1HostErrorCode } from '../d1Plan.js'
+import { canonicalizeD1Observation, createD1CompleteEnvelope, createD1DesiredSnapshot, deriveD1SecretRefsEnvelope, digestD1Desired, type D1DesiredSnapshotV1 } from '../d1RevisionCodec.js'
+import { createD1RuntimeInputsIdentity } from '../d1RuntimeInputs.js'
 import { createD1FencedDestructivePublication } from '../fencedDestructivePublication.js'
 import { D1ActivePublishError, type D1HostRevisionStore, type D1StoredCompleteV1 } from '../hostRevisionStore.js'
+import { canonicalizeWorkspaceCompositionSnapshot } from '../workspaceComposition.js'
 
 const DATABASE_URL = process.env.DATABASE_URL ?? 'postgres://ubuntu:test@localhost/boring_ui_test'
 const RUN = `${Date.now()}-${Math.random().toString(36).slice(2)}`
-const digest = (value: string) => `sha256:${value.repeat(64).slice(0, 64)}` as const
+const digest = (value: string): Sha256Digest => `sha256:${value.repeat(64).slice(0, 64)}`
 let admin: postgres.Sql; let serial = 0
 const host = () => `fenced-${RUN}-${++serial}`
 const deferred = () => { let resolve!: () => void; return { promise: new Promise<void>((done) => { resolve = done }), resolve } }
 
-function stored(hostId: string, revisionId: string, desiredStateDigest: `sha256:${string}`, bindings: readonly string[], databaseRef = 'postgres-eu') {
-  return {
-    revisionId, desiredStateDigest,
-    completion: { revisionId, desiredStateDigest },
-    desired: { plan: { hostId, databaseRef, bindings: bindings.map((bindingId) => ({ bindingId })) } },
-  } as unknown as D1StoredCompleteV1
+async function desired(hostId: string, bindingIds: readonly string[], databaseRef: string): Promise<D1DesiredSnapshotV1> {
+  const planBindings = []; const resolvedBindings = []
+  for (const bindingId of bindingIds) {
+    const workspaceId = `workspace:${bindingId}`; const deploymentId = `deployment:${bindingId}`
+    const snapshot = canonicalizeWorkspaceCompositionSnapshot({
+      schemaVersion: 1, domain: 'boring-workspace-composition:v1', workspaceId, runtimeProfile: { ref: 'runsc-eu', id: 'runsc', version: '2026.07.12', contentDigest: digest('1'), isolationAttestationDigest: digest('2'), workspaceRootPolicyRef: 'workspace-roots', sessionRootPolicyRef: 'session-roots' },
+      hostAppImageDigest: digest('a'), serverPlugins: [], defaultPluginPackages: [], staticSystemPromptDigest: digest('3'),
+      inventories: { capabilities: [], tools: [], skills: null, mcpServers: null }, provisioning: [], filesystemBindings: [], policies: { externalPlugins: false, pluginAuthoring: false },
+    })
+    const compositionDigest = await createAgentAssetDigest(JSON.stringify(snapshot))
+    const definition = { definitionId: `definition:${bindingId}`, version: '1.0.0', digest: digest('4'), instructionsRef: 'instructions.md' }
+    const deploymentInput = { deploymentId, version: '2026.07.12', agentId: 'default', definition: { definitionId: definition.definitionId, version: definition.version, digest: definition.digest } }
+    const deploymentDigest = await createAgentDeploymentDigest(deploymentInput)
+    const resolvedDigest = await createResolvedAgentDigest({ workspaceId, defaultDeploymentId: deploymentId, workspaceCompositionDigest: compositionDigest, definitionDigest: definition.digest, deploymentDigest })
+    planBindings.push({ bindingId, hostname: `${bindingId}.example.test`, workspaceId, defaultDeploymentId: deploymentId, bundleRef: 'bundle', deploymentRef: 'deployment', workspaceAllocationRef: `workspace-${bindingId}`, sessionAllocationRef: `session-${bindingId}`, ownerPrincipalRef: 'owner', landing: { title: bindingId, summary: 'Summary.' }, environmentRef: 'production', secretRefs: [`credential-${bindingId}`] })
+    resolvedBindings.push({ schemaVersion: 1, bindingId, composition: { snapshot, digest: compositionDigest }, workspace: { workspaceId, defaultDeploymentId: deploymentId, compositionDigest }, deployment: { deploymentId, version: deploymentInput.version, agentId: 'default', digest: deploymentDigest }, definition, resolvedDigest })
+  }
+  return createD1DesiredSnapshot({ schemaVersion: 1, hostId, expectedHostRevision: null, hostAppImageDigest: digest('a'), runtimeProfileRef: 'runsc-eu', databaseRef, workspaceRootPolicyRef: 'workspace-roots', sessionRootPolicyRef: 'session-roots', bindings: planBindings }, resolvedBindings)
+}
+async function stored(hostId: string, revisionId: string, bindings: readonly string[], databaseRef = 'postgres-eu'): Promise<D1StoredCompleteV1> {
+  const value = await desired(hostId, bindings, databaseRef)
+  const observation = await canonicalizeD1Observation({
+    schemaVersion: 1, domain: 'boring-d1-observed:v1', bindings: await Promise.all(value.resolvedBindings.map(async (binding) => {
+      const planned = value.plan.bindings.find((entry) => entry.bindingId === binding.bindingId)!
+      return { bindingId: binding.bindingId, ready: true, resolvedDigest: binding.resolvedDigest, runtimeInputs: await createD1RuntimeInputsIdentity(planned, {
+        environment: { versionFingerprint: digest('5') }, workspaceAllocation: { versionFingerprint: digest('6') }, sessionAllocation: { versionFingerprint: digest('7') },
+        secrets: planned.secretRefs.map((secretRef) => ({ secretRef, providerVersionFingerprint: digest('8') })), }) }
+    })) }, value)
+  const desiredStateDigest = await digestD1Desired(value)
+  return Object.freeze({ revisionId, desired: value, desiredStateDigest, secretRefs: deriveD1SecretRefsEnvelope(value), observation, completion: await createD1CompleteEnvelope(revisionId, value, observation) })
 }
 class Revisions {
-  readonly completes = new Map<string, D1StoredCompleteV1>(); events: string[] = []
+  readonly completes = new Map<string, D1StoredCompleteV1>(); events: string[] = []; publishCount = 0
   active: { schemaVersion: 1; revisionId: string; desiredStateDigest: `sha256:${string}` }
   onReadActive?: () => Promise<void>; onPublish?: () => Promise<'before' | 'after' | void>
-  constructor(readonly hostId: string) {
-    this.active = { schemaVersion: 1, revisionId: 'r0000000001', desiredStateDigest: digest('a') }
-    this.completes.set('r0000000001', stored(hostId, 'r0000000001', digest('a'), ['alpha', 'bravo', 'zulu']))
-    this.completes.set('r0000000002', stored(hostId, 'r0000000002', digest('b'), ['bravo']))
-    this.completes.set('r0000000003', stored(hostId, 'r0000000003', digest('c'), ['alpha']))
+  constructor(readonly hostId: string, completes: readonly D1StoredCompleteV1[]) {
+    for (const complete of completes) this.completes.set(complete.revisionId, complete)
+    this.active = { schemaVersion: 1, revisionId: 'r0000000001', desiredStateDigest: this.completes.get('r0000000001')!.desiredStateDigest }
   }
   store = {
     readActive: async () => { this.events.push('active'); await this.onReadActive?.(); return this.active },
     readComplete: async (_hostId: string, revisionId: string) => { this.events.push(`complete:${revisionId}`); return this.completes.get(revisionId) ?? null },
     publishActive: async (_hostId: string, revisionId: string) => {
+      this.publishCount += 1
       const fault = await this.onPublish?.(); this.events.push('publish')
       if (fault === 'before') throw new D1ActivePublishError(false)
       const complete = this.completes.get(revisionId)!
@@ -51,15 +75,18 @@ class Revisions {
     },
   } as unknown as D1HostRevisionStore
 }
-function identity(hostId: string, overrides: Partial<D1DestructivePublicationIdentity> = {}): D1DestructivePublicationIdentity {
-  return { operationId: `${RUN}-${++serial}`, hostId, expectedRevision: 'r0000000001', expectedDigest: digest('a'),
-    targetRevision: 'r0000000002', targetDigest: digest('b'), removalBindingIds: ['alpha', 'zulu'], ...overrides }
+function identity(revisions: Revisions, overrides: Partial<D1DestructivePublicationIdentity> = {}): D1DestructivePublicationIdentity {
+  const expectedRevision = overrides.expectedRevision ?? 'r0000000001'; const targetRevision = overrides.targetRevision ?? 'r0000000002'
+  return { operationId: `${RUN}-${++serial}`, hostId: revisions.hostId, expectedRevision,
+    expectedDigest: revisions.completes.get(expectedRevision)!.desiredStateDigest, targetRevision,
+    targetDigest: revisions.completes.get(targetRevision)!.desiredStateDigest, removalBindingIds: ['alpha', 'zulu'], ...overrides }
 }
-async function harness() {
-  const hostId = host(); const client = postgres(DATABASE_URL, { max: 8 })
+async function harness(onclose?: (connectionId: number) => void, max = 8) {
+  const hostId = host(); const client = postgres(DATABASE_URL, { max, onclose })
   const ledger = createD1AdmissionLedger(mintAttestedD1DatabaseConnection('postgres-eu', client, { ownsClient: true }))
-  const revisions = new Revisions(hostId); const journal = createD1DestructivePublicationJournalStore()
-  return { hostId, ledger, revisions, journal, close: () => ledger.close() }
+  const revisions = new Revisions(hostId, await Promise.all([stored(hostId, 'r0000000001', ['alpha', 'bravo', 'zulu']),
+    stored(hostId, 'r0000000002', ['bravo']), stored(hostId, 'r0000000003', ['alpha'])])); const journal = createD1DestructivePublicationJournalStore()
+  return { hostId, client, ledger, revisions, journal, close: () => ledger.close() }
 }
 const reader = (revisions: Revisions): { read(): Promise<D1ActiveCollection | null> } => ({
   async read() {
@@ -75,6 +102,9 @@ const reader = (revisions: Revisions): { read(): Promise<D1ActiveCollection | nu
 const target = (hostId: string, bindingId: string) => ({ hostId, bindingId, workspaceId: `workspace:${bindingId}`, defaultDeploymentId: `deployment:${bindingId}` })
 async function operation(journal: D1DestructivePublicationJournalStore, value: D1DestructivePublicationIdentity) {
   const sql = await admin.reserve(); try { return await journal.readOperation(sql, value.operationId) } finally { sql.release() }
+}
+async function prepare(journal: D1DestructivePublicationJournalStore, value: D1DestructivePublicationIdentity) {
+  const sql = await admin.reserve(); try { await journal.appendPrepared(sql, value) } finally { sql.release() }
 }
 
 beforeAll(async () => { await runMigrations({ databaseUrl: DATABASE_URL } as CoreConfig); admin = postgres(DATABASE_URL, { max: 8 }) })
@@ -106,7 +136,7 @@ describe('D1 fenced destructive publication', () => {
       const [state] = await reserved!<{ assigned: boolean }[]>`SELECT txid_current_if_assigned() IS NOT NULL AS assigned`
       events.push(`publish:transaction=${state!.assigned}`)
     }
-    const value = identity(h.hostId)
+    const value = identity(h.revisions)
     await createD1FencedDestructivePublication({ admissionLedger: ledger, journalStore: journal, revisionStore: h.revisions.store }).publish(value)
     expect(events).toEqual([
       'locked', 'active', 'complete:r0000000001', 'complete:r0000000002', 'admission-clear', 'prepared',
@@ -117,14 +147,14 @@ describe('D1 fenced destructive publication', () => {
   })
 
   it('blocks an admitted removal before journal or pointer effects', async () => {
-    const h = await harness(); await h.ledger.admit(reader(h.revisions), target(h.hostId, 'zulu')); const value = identity(h.hostId)
+    const h = await harness(); await h.ledger.admit(reader(h.revisions), target(h.hostId, 'zulu')); const value = identity(h.revisions)
     await expect(createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store }).publish(value))
       .rejects.toMatchObject({ code: D1HostErrorCode.BINDING_ADMITTED, details: { bindingId: 'zulu' } })
     expect(await operation(h.journal, value)).toBeNull(); expect(h.revisions.active.revisionId).toBe('r0000000001'); await h.close()
   })
 
   it('never republishes an operation that already has a terminal event', async () => {
-    const h = await harness(); const value = identity(h.hostId); const sql = await admin.reserve()
+    const h = await harness(); const value = identity(h.revisions); const sql = await admin.reserve()
     try { await h.journal.appendPrepared(sql, value); await h.journal.appendTerminal(sql, value, 'aborted') } finally { sql.release() }
     await expect(createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store }).publish(value))
       .rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED })
@@ -135,7 +165,7 @@ describe('D1 fenced destructive publication', () => {
     for (const bindingId of ['alpha', 'zulu']) {
       const h = await harness(); const entered = deferred(); const release = deferred()
       h.revisions.onReadActive = async () => { entered.resolve(); await release.promise }
-      const value = identity(h.hostId); const publisher = createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store })
+      const value = identity(h.revisions); const publisher = createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store })
       const published = publisher.publish(value); await entered.promise
       const admitted = h.ledger.admit(reader(h.revisions), target(h.hostId, bindingId)); await Promise.resolve(); release.resolve()
       await published
@@ -148,8 +178,8 @@ describe('D1 fenced destructive publication', () => {
     const h = await harness(); const entered = deferred(); const release = deferred(); let reads = 0
     h.revisions.onReadActive = async () => { if (++reads === 1) { entered.resolve(); await release.promise } }
     const publisher = createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store })
-    const first = publisher.publish(identity(h.hostId)); await entered.promise
-    const second = publisher.publish(identity(h.hostId, { targetRevision: 'r0000000003', targetDigest: digest('c'), removalBindingIds: ['bravo', 'zulu'] }))
+    const first = publisher.publish(identity(h.revisions)); await entered.promise
+    const second = publisher.publish(identity(h.revisions, { targetRevision: 'r0000000003', removalBindingIds: ['bravo', 'zulu'] }))
     release.resolve(); await expect(first).resolves.toBeUndefined()
     await expect(second).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
     expect(h.revisions.active.revisionId).toBe('r0000000002'); await h.close()
@@ -157,7 +187,7 @@ describe('D1 fenced destructive publication', () => {
 
   it('leaves no false terminal across prepare, publication, terminal, and connection failures', async () => {
     for (const fault of ['prepare', 'prepare-rollback', 'prepare-commit', 'publish-before', 'publish-after', 'terminal', 'connection'] as const) {
-      const h = await harness(); const value = identity(h.hostId); let reserved: postgres.ReservedSql | undefined; let internalError: unknown
+      const h = await harness(); const value = identity(h.revisions); let reserved: postgres.ReservedSql | undefined; let internalError: unknown
       const ledger = { ...h.ledger, withBindingFences: <T>(keys: Parameters<D1AdmissionLedger['withBindingFences']>[0], run: (sql: postgres.ReservedSql) => Promise<T>) =>
         h.ledger.withBindingFences(keys, async (sql) => {
           reserved = sql
@@ -191,7 +221,7 @@ describe('D1 fenced destructive publication', () => {
         if (fault === 'publish-after') return 'after'
         if (fault === 'connection') {
           const [backend] = await reserved!<{ pid: number }[]>`SELECT pg_backend_pid() AS pid`
-          h.revisions.active = { schemaVersion: 1, revisionId: 'r0000000002', desiredStateDigest: digest('b') }
+          h.revisions.active = { schemaVersion: 1, revisionId: 'r0000000002', desiredStateDigest: h.revisions.completes.get('r0000000002')!.desiredStateDigest }
           await admin`SELECT pg_terminate_backend(${backend!.pid})`
         }
       }
@@ -210,10 +240,28 @@ describe('D1 fenced destructive publication', () => {
   }, 30_000)
 
   it('rejects artifact and database drift before prepare', async () => {
-    for (const fault of ['expected-digest', 'target-digest', 'expected-completion-revision', 'target-completion-revision', 'missing-target', 'incomplete-target', 'expected-database-ref', 'target-database-ref'] as const) {
-      const h = await harness(); const value = identity(h.hostId)
-      if (fault === 'expected-digest') h.revisions.completes.set('r0000000001', stored(h.hostId, 'r0000000001', digest('d'), ['alpha', 'bravo', 'zulu']))
-      if (fault === 'target-digest') h.revisions.completes.set('r0000000002', stored(h.hostId, 'r0000000002', digest('d'), ['bravo']))
+    for (const fault of ['expected-digest', 'target-digest', 'desired-content', 'observation-content', 'secret-refs', 'expected-completion-revision', 'target-completion-revision', 'missing-target', 'incomplete-target', 'incomplete-digest', 'expected-database-ref', 'target-database-ref'] as const) {
+      const h = await harness(); let value = identity(h.revisions)
+      if (fault === 'expected-digest') h.revisions.completes.set('r0000000001', { ...h.revisions.completes.get('r0000000001')!, desiredStateDigest: digest('d') })
+      if (fault === 'target-digest') h.revisions.completes.set('r0000000002', { ...h.revisions.completes.get('r0000000002')!, desiredStateDigest: digest('d') })
+      if (fault === 'desired-content') {
+        const target = h.revisions.completes.get('r0000000002')!
+        h.revisions.completes.set('r0000000002', { ...target, desired: { ...target.desired, plan: { ...target.desired.plan,
+          bindings: target.desired.plan.bindings.map((binding) => ({ ...binding, landing: { ...binding.landing, title: `${binding.landing.title}-tampered` } })),
+        } } })
+      }
+      if (fault === 'observation-content') {
+        const target = h.revisions.completes.get('r0000000002')!
+        h.revisions.completes.set('r0000000002', { ...target, observation: { ...target.observation,
+          bindings: target.observation.bindings.map((binding) => ({ ...binding, ready: false })),
+        } })
+      }
+      if (fault === 'secret-refs') {
+        const target = h.revisions.completes.get('r0000000002')!
+        h.revisions.completes.set('r0000000002', { ...target, secretRefs: { ...target.secretRefs,
+          bindings: target.secretRefs.bindings.map((binding) => ({ ...binding, secretRefs: ['credential-tampered'] })),
+        } })
+      }
       if (fault === 'expected-completion-revision') {
         const expected = h.revisions.completes.get('r0000000001')!
         h.revisions.completes.set('r0000000001', { ...expected, completion: { ...expected.completion, revisionId: 'r0000000002' } })
@@ -222,13 +270,184 @@ describe('D1 fenced destructive publication', () => {
         const target = h.revisions.completes.get('r0000000002')!
         h.revisions.completes.set('r0000000002', { ...target, completion: { ...target.completion, revisionId: 'r0000000001' } })
       }
-      if (fault === 'missing-target' || fault === 'incomplete-target') h.revisions.completes.delete('r0000000002')
-      if (fault === 'expected-database-ref') h.revisions.completes.set('r0000000001', stored(h.hostId, 'r0000000001', digest('a'), ['alpha', 'bravo', 'zulu'], 'postgres-other'))
-      if (fault === 'target-database-ref') h.revisions.completes.set('r0000000002', stored(h.hostId, 'r0000000002', digest('b'), ['bravo'], 'postgres-other'))
+      if (fault === 'missing-target') h.revisions.completes.delete('r0000000002')
+      if (fault === 'incomplete-target') {
+        const target = h.revisions.completes.get('r0000000002')!
+        h.revisions.completes.set('r0000000002', { ...target, completion: undefined } as unknown as D1StoredCompleteV1)
+      }
+      if (fault === 'incomplete-digest') {
+        const target = h.revisions.completes.get('r0000000002')!
+        h.revisions.completes.set('r0000000002', { ...target, completion: { ...target.completion, completionDigest: undefined } } as unknown as D1StoredCompleteV1)
+      }
+      if (fault === 'expected-database-ref') {
+        const replacement = await stored(h.hostId, 'r0000000001', ['alpha', 'bravo', 'zulu'], 'postgres-other')
+        h.revisions.completes.set('r0000000001', replacement); value = { ...value, expectedDigest: replacement.desiredStateDigest }
+        h.revisions.active = { ...h.revisions.active, desiredStateDigest: replacement.desiredStateDigest }
+      }
+      if (fault === 'target-database-ref') {
+        const replacement = await stored(h.hostId, 'r0000000002', ['bravo'], 'postgres-other')
+        h.revisions.completes.set('r0000000002', replacement); value = { ...value, targetDigest: replacement.desiredStateDigest }
+      }
       await expect(createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store }).publish(value)).rejects.toMatchObject({
         code: D1HostErrorCode.ROLLBACK_TARGET_INVALID,
       })
       expect(await operation(h.journal, value)).toBeNull(); expect(h.revisions.active.revisionId).toBe('r0000000001'); await h.close()
+    }
+    const h = await harness(); const value = identity(h.revisions)
+    const revisionStore = { ...h.revisions.store, readComplete: async () => { throw new Error('private read failure') } } as D1HostRevisionStore
+    const caught = await createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore }).publish(value).catch((error) => error)
+    expect(caught).toMatchObject({ code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED }); expect(JSON.stringify(caught)).not.toMatch(/private/)
+    expect(await operation(h.journal, value)).toBeNull(); await h.close()
+  })
+
+  it('recovers a committed prepare under exact fences with no SQL transaction open during publication', async () => {
+    const h = await harness(); const value = identity(h.revisions); await prepare(h.journal, value)
+    let reserved: postgres.ReservedSql | undefined; let transactionOpen = true
+    const ledger = { ...h.ledger, withBindingFences: <T>(keys: Parameters<D1AdmissionLedger['withBindingFences']>[0], run: (sql: postgres.ReservedSql) => Promise<T>) =>
+      h.ledger.withBindingFences(keys, async (sql) => { reserved = sql; return run(sql) }) } as D1AdmissionLedger
+    h.revisions.onPublish = async () => {
+      const [state] = await reserved!<{ assigned: boolean }[]>`SELECT txid_current_if_assigned() IS NOT NULL AS assigned`
+      transactionOpen = state!.assigned
+    }
+    await createD1FencedDestructivePublication({ admissionLedger: ledger, journalStore: h.journal, revisionStore: h.revisions.store }).recoverPending(h.hostId)
+    expect(transactionOpen).toBe(false); expect(h.revisions.active.revisionId).toBe('r0000000002')
+    expect((await operation(h.journal, value))?.terminal?.state).toBe('committed'); await h.close()
+  })
+
+  it('preserves the client close callback, bounds a killed publisher, and lets recovery converge', async () => {
+    let closeCount = 0; const h = await harness(() => { closeCount += 1 }, 2); const value = identity(h.revisions); let reserved: postgres.ReservedSql | undefined; let backendPid = 0
+    const entered = deferred(); const release = deferred()
+    const publishingLedger = { ...h.ledger,
+      withBindingFences: <T>(keys: Parameters<D1AdmissionLedger['withBindingFences']>[0], run: (sql: postgres.ReservedSql) => Promise<T>) =>
+        h.ledger.withBindingFences(keys, async (sql) => { reserved = sql; return run(sql) }),
+    } as D1AdmissionLedger
+    const recoveryLedger = createD1AdmissionLedger(mintAttestedD1DatabaseConnection('postgres-eu', postgres(DATABASE_URL), { ownsClient: true }))
+    h.revisions.onPublish = async () => {
+      const [backend] = await reserved!<{ pid: number }[]>`SELECT pg_backend_pid() AS pid`
+      backendPid = backend!.pid; entered.resolve(); await release.promise
+    }
+    const publisher = createD1FencedDestructivePublication({ admissionLedger: publishingLedger, journalStore: h.journal, revisionStore: h.revisions.store }); const publishing = publisher.publish(value).catch((error) => error); await entered.promise
+    const unrelated = await h.client.reserve(); const [other] = await unrelated<{ pid: number }[]>`SELECT pg_backend_pid() AS pid`; await admin`SELECT pg_terminate_backend(${other!.pid})`; unrelated.release()
+    await expect(reserved!`SELECT 1 AS healthy`).resolves.toHaveLength(1)
+    let admissionError: unknown
+    try {
+      await admin`SELECT pg_terminate_backend(${backendPid})`
+      admissionError = await recoveryLedger.admit(reader(h.revisions), target(h.hostId, 'alpha')).catch((error) => error)
+    } finally { release.resolve() }
+    const publishError = await publishing
+    expect(publishError).toMatchObject({ code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED }); expect(admissionError).toMatchObject({ code: D1HostErrorCode.ADMISSION_RECORD_FAILED }); expect(closeCount).toBeGreaterThan(0)
+    expect(await admin`SELECT 1 FROM d1_binding_admissions WHERE host_id = ${h.hostId} AND binding_id = 'alpha'`).toHaveLength(0)
+    expect((await operation(h.journal, value))?.terminal).toBeUndefined()
+    expect(h.revisions.active.revisionId).toBe(value.targetRevision)
+    h.revisions.onPublish = undefined
+    await createD1FencedDestructivePublication({ admissionLedger: recoveryLedger, journalStore: h.journal, revisionStore: h.revisions.store }).recoverPending(h.hostId)
+    expect((await operation(h.journal, value))?.terminal?.state).toBe('committed')
+    expect(h.revisions.publishCount).toBe(1)
+    await recoveryLedger.close(); await h.close()
+  }, 30_000)
+
+  it('finalizes an already-published target without republishing', async () => {
+    const h = await harness(); const value = identity(h.revisions); await prepare(h.journal, value)
+    h.revisions.active = { schemaVersion: 1, revisionId: value.targetRevision, desiredStateDigest: value.targetDigest }
+    await createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store }).recoverPending(h.hostId)
+    expect(h.revisions.publishCount).toBe(0); expect((await operation(h.journal, value))?.terminal?.state).toBe('committed'); await h.close()
+  })
+
+  it('rejects admission behind a durable prepare and aborts recovery for an already-persisted admission', async () => {
+    const h = await harness(); const value = identity(h.revisions); h.revisions.onPublish = async () => 'before'
+    const publisher = createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store })
+    await expect(publisher.publish(value)).rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED })
+    h.revisions.onPublish = undefined
+    await expect(h.ledger.admit(reader(h.revisions), target(h.hostId, 'alpha'))).rejects.toMatchObject({ code: D1HostErrorCode.ADMISSION_RECORD_FAILED })
+    await admin`INSERT INTO d1_binding_admissions (host_id, binding_id, active_revision) VALUES (${h.hostId}, 'alpha', ${value.expectedRevision})`
+    await publisher.recoverPending(h.hostId)
+    expect(h.revisions.active.revisionId).toBe(value.expectedRevision)
+    expect((await operation(h.journal, value))?.terminal?.state).toBe('aborted'); await h.close()
+  })
+
+  it('processes stale discovery in journal sequence, skips new terminals, and requests sorted operation fences', async () => {
+    const h = await harness(); const first = identity(h.revisions); const second = identity(h.revisions, {
+      targetRevision: 'r0000000003', removalBindingIds: ['bravo', 'zulu'],
+    })
+    await prepare(h.journal, first); await prepare(h.journal, second)
+    const calls: string[][] = []; const readOrder: string[] = []
+    const ledger = { ...h.ledger, withBindingFences: <T>(keys: Parameters<D1AdmissionLedger['withBindingFences']>[0], run: (sql: postgres.ReservedSql) => Promise<T>) => {
+      calls.push(keys.map((key) => key.bindingId)); return h.ledger.withBindingFences(keys, run)
+    } } as D1AdmissionLedger
+    const journal = { ...h.journal,
+      readPending: async (sql: postgres.ReservedSql, hostId: string) => {
+        const pending = await h.journal.readPending(sql, hostId)
+        const other = await admin.reserve()
+        try { await h.journal.appendTerminal(other, first, 'aborted'); await h.journal.appendTerminal(other, second, 'aborted') } finally { other.release() }
+        return pending
+      },
+      readOperation: async (sql: postgres.ReservedSql, operationId: string) => { readOrder.push(operationId); return h.journal.readOperation(sql, operationId) },
+    }
+    await createD1FencedDestructivePublication({ admissionLedger: ledger, journalStore: journal, revisionStore: h.revisions.store }).recoverPending(h.hostId)
+    expect(readOrder).toEqual([first.operationId, second.operationId])
+    expect(calls.slice(1)).toEqual([['alpha', 'zulu'], ['bravo', 'zulu']]); expect(h.revisions.publishCount).toBe(0); await h.close()
+  })
+
+  it('fails closed for artifact, history, and active-pointer drift without fabricating a terminal', async () => {
+    for (const fault of ['wrapper', 'wrapper-incomplete', 'embedded', 'digest', 'foreign-host', 'foreign-database', 'missing', 'incomplete', 'bindings', 'third-pointer', 'history'] as const) {
+      const h = await harness(); const value = identity(h.revisions); await prepare(h.journal, value)
+      const expected = h.revisions.completes.get(value.expectedRevision)!; const targetRevision = h.revisions.completes.get(value.targetRevision)!
+      if (fault === 'wrapper') h.revisions.completes.set(value.targetRevision, { ...targetRevision, revisionId: value.expectedRevision })
+      if (fault === 'wrapper-incomplete') h.revisions.completes.set(value.targetRevision, { ...targetRevision, observation: undefined } as unknown as D1StoredCompleteV1)
+      if (fault === 'embedded') h.revisions.completes.set(value.targetRevision, { ...targetRevision, completion: { ...targetRevision.completion, status: 'BROKEN' } } as unknown as D1StoredCompleteV1)
+      if (fault === 'digest') h.revisions.completes.set(value.expectedRevision, { ...expected, completion: { ...expected.completion, desiredStateDigest: digest('d') } })
+      if (fault === 'foreign-host') h.revisions.completes.set(value.expectedRevision, await stored(`${h.hostId}-foreign`, value.expectedRevision, ['alpha', 'bravo', 'zulu']))
+      if (fault === 'foreign-database') h.revisions.completes.set(value.targetRevision, await stored(h.hostId, value.targetRevision, ['bravo'], 'postgres-other'))
+      if (fault === 'missing') h.revisions.completes.delete(value.expectedRevision)
+      if (fault === 'incomplete') h.revisions.completes.set(value.targetRevision, {
+        ...targetRevision, completion: { ...targetRevision.completion, completionDigest: undefined },
+      } as unknown as D1StoredCompleteV1)
+      if (fault === 'bindings') h.revisions.completes.set(value.targetRevision, {
+        ...targetRevision, desired: { ...targetRevision.desired, plan: { ...targetRevision.desired.plan, bindings: undefined } },
+      } as unknown as D1StoredCompleteV1)
+      if (fault === 'third-pointer') h.revisions.active = { schemaVersion: 1, revisionId: 'r0000000003', desiredStateDigest: h.revisions.completes.get('r0000000003')!.desiredStateDigest }
+      const journal = fault === 'history' ? { ...h.journal, readOperation: async () => null } : h.journal
+      const caught = await createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: journal, revisionStore: h.revisions.store }).recoverPending(h.hostId).catch((error) => error)
+      expect(caught).toMatchObject({ code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED })
+      expect(JSON.stringify(caught)).not.toMatch(/postgres:|private|CONNECTION_/)
+      expect((await operation(h.journal, value))?.terminal).toBeUndefined(); await h.close()
+    }
+  })
+
+  it('keeps publication and terminal ambiguity retryable until recovery converges', async () => {
+    for (const fault of ['publication-before', 'publication-after', 'terminal', 'lost-terminal-response'] as const) {
+      const h = await harness(); const value = identity(h.revisions); await prepare(h.journal, value); let failed = true
+      if (fault.startsWith('publication')) h.revisions.onPublish = async () => fault === 'publication-before' ? 'before' : 'after'
+      const journal = fault === 'terminal' ? { ...h.journal, appendTerminal: async () => { throw new Error('private terminal') } }
+        : h.journal
+      const ledger = fault === 'lost-terminal-response' ? { ...h.ledger,
+        withBindingFences: <T>(keys: Parameters<D1AdmissionLedger['withBindingFences']>[0], run: (sql: postgres.ReservedSql) => Promise<T>) => h.ledger.withBindingFences(keys, (sql) => run(new Proxy(sql, {
+          async apply(target, thisArg, args: [TemplateStringsArray, ...unknown[]]) {
+            const result = await Reflect.apply(target, thisArg, args)
+            if (failed && args[0].join('').trim() === 'COMMIT') { failed = false; throw Object.assign(new Error('private response'), { code: 'CONNECTION_CLOSED' }) }
+            return result
+          },
+        }) as postgres.ReservedSql)),
+      } as D1AdmissionLedger : h.ledger
+      const recovering = createD1FencedDestructivePublication({ admissionLedger: ledger, journalStore: journal, revisionStore: h.revisions.store })
+      await expect(recovering.recoverPending(h.hostId)).rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED })
+      h.revisions.onPublish = undefined
+      const retryLedger = fault === 'lost-terminal-response'
+        ? createD1AdmissionLedger(mintAttestedD1DatabaseConnection('postgres-eu', postgres(DATABASE_URL), { ownsClient: true })) : h.ledger
+      await createD1FencedDestructivePublication({ admissionLedger: retryLedger, journalStore: h.journal, revisionStore: h.revisions.store }).recoverPending(h.hostId)
+      expect((await operation(h.journal, value))?.terminal?.state).toBe('committed'); expect(h.revisions.active.revisionId).toBe(value.targetRevision)
+      if (retryLedger !== h.ledger) await retryLedger.close(); await h.close().catch(() => {})
+    }
+  })
+
+  it('makes first- and last-key admissions lose against recovered removal fences', async () => {
+    for (const bindingId of ['alpha', 'zulu']) {
+      const h = await harness(); const value = identity(h.revisions); await prepare(h.journal, value)
+      const entered = deferred(); const release = deferred(); h.revisions.onReadActive = async () => { entered.resolve(); await release.promise }
+      const recovering = createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store }).recoverPending(h.hostId)
+      await entered.promise; const admission = h.ledger.admit(reader(h.revisions), target(h.hostId, bindingId)); await Promise.resolve(); release.resolve()
+      await recovering; await expect(admission).rejects.toMatchObject({ code: D1HostErrorCode.ADMISSION_RECORD_FAILED })
+      expect((await operation(h.journal, value))?.terminal?.state).toBe('committed'); await h.close()
     }
   })
 })

--- a/apps/full-app/src/server/deployment/admissionLedger.ts
+++ b/apps/full-app/src/server/deployment/admissionLedger.ts
@@ -5,6 +5,9 @@ import { D1HostError, D1HostErrorCode, strictD1HostId, strictD1Ref } from './d1P
 
 const attestedBrand: unique symbol = Symbol('AttestedD1DatabaseConnection')
 const liveConnections = new WeakMap<AttestedD1DatabaseConnection, LiveConnection>()
+interface ReservedConnectionState { connectionId: number | null; lost: boolean }
+const reservedConnectionStates = new WeakMap<postgres.ReservedSql, ReservedConnectionState>()
+let nextReservationClaim = 0
 const REVISION_RE = /^r\d{10}$/
 interface LiveConnection {
   readonly databaseRef: string
@@ -89,6 +92,10 @@ function take(connection: AttestedD1DatabaseConnection): LiveConnection {
   return live
 }
 
+export function isD1ReservedConnectionLost(sql: postgres.ReservedSql): boolean {
+  return reservedConnectionStates.get(sql)?.lost ?? false
+}
+
 /** D1-005c is the sole production caller after it proves this client. */
 export function mintAttestedD1DatabaseConnection(
   databaseRef: string,
@@ -110,7 +117,22 @@ export async function closeAttestedD1DatabaseConnection(connection: AttestedD1Da
 async function insertOrRead(sql: postgres.ReservedSql, target: D1AdmissionTarget, activeRevision: string): Promise<D1BindingAdmission> {
   let transaction = false
   try {
+    if (isD1ReservedConnectionLost(sql)) throw failed()
     await sql`BEGIN`; transaction = true
+    const [pendingRemoval] = await sql<{ pending: boolean }[]>`
+      SELECT EXISTS (
+        SELECT 1 FROM d1_destructive_publication_events AS prepared
+        WHERE prepared.host_id = ${target.hostId}
+          AND prepared.state = 'prepared'
+          AND ${target.bindingId} = ANY(prepared.removal_binding_ids)
+          AND NOT EXISTS (
+            SELECT 1 FROM d1_destructive_publication_events AS terminal
+            WHERE terminal.operation_id = prepared.operation_id
+              AND terminal.state IN ('committed', 'aborted')
+          )
+      ) AS pending
+    `
+    if (!pendingRemoval || typeof pendingRemoval.pending !== 'boolean' || pendingRemoval.pending) throw failed()
     const inserted = await sql<AdmissionRow[]>`
       INSERT INTO d1_binding_admissions (host_id, binding_id, active_revision)
       VALUES (${target.hostId}, ${target.bindingId}, ${activeRevision})
@@ -137,9 +159,33 @@ export function createD1AdmissionLedger(
   connection: AttestedD1DatabaseConnection,
 ): D1AdmissionLedger {
   const live = take(connection)
-  let closed = false
+  let closed = false; let closing = false
+  const claims = new Map<string, ReservedConnectionState>(); const reservations = new Map<number, Set<ReservedConnectionState>>()
+  const previousOnClose = live.sql.options.onclose; const previousDebug = live.sql.options.debug
+  const debug = (connectionId: number, query: string, parameters: unknown[], types: unknown[]) => {
+    if (typeof previousDebug === 'function') previousDebug(connectionId, query, parameters, types); const state = parameters.map(String).map((value) => claims.get(value)).find(Boolean)
+    if (state) { state.connectionId = connectionId; const active = reservations.get(connectionId) ?? new Set(); active.add(state); reservations.set(connectionId, active) }
+  }
+  const onclose = (connectionId: number) => {
+    try { if (typeof previousOnClose === 'function') previousOnClose(connectionId) } finally {
+      if (!closing) for (const state of reservations.get(connectionId) ?? []) state.lost = true; reservations.delete(connectionId)
+    }
+  }
+  live.sql.options.debug = debug; live.sql.options.onclose = onclose
+  const restoreHooks = () => {
+    if (live.sql.options.debug === debug) live.sql.options.debug = previousDebug; if (live.sql.options.onclose === onclose) live.sql.options.onclose = previousOnClose
+  }
   const available = () => { if (closed) throw failed() }
-  const abandon = async () => { closed = true; await live.sql.end({ timeout: 0 }).catch(() => {}) }
+  const abandon = async () => {
+    closed = true; closing = true; restoreHooks(); await live.sql.end({ timeout: 0 }).catch(() => {})
+  }
+  const claim = async (sql: postgres.ReservedSql) => {
+    const state: ReservedConnectionState = { connectionId: null, lost: false }; const token = `boring-d1-reservation:${++nextReservationClaim}`
+    reservedConnectionStates.set(sql, state); claims.set(token, state); try { const [row] = await sql<{ token: string }[]>`SELECT ${token}::text AS token`; if (row?.token !== token || state.connectionId === null) throw failed() } finally { claims.delete(token) }
+  }
+  const releaseState = (sql: postgres.ReservedSql) => {
+    const state = reservedConnectionStates.get(sql); if (state?.connectionId === null || state?.connectionId === undefined) return; const active = reservations.get(state.connectionId); active?.delete(state); if (active?.size === 0) reservations.delete(state.connectionId)
+  }
   const key = (raw: D1AdmissionFenceKey): D1AdmissionFenceKey => Object.freeze({
     hostId: strictD1HostId(raw.hostId, 'hostId'), bindingId: strictD1Ref(raw.bindingId, 'bindingId'),
   })
@@ -152,22 +198,24 @@ export function createD1AdmissionLedger(
     const sql = await live.sql.reserve().catch(() => { throw failed() })
     const locked: string[] = []; let result: T | undefined; let complete = false; let operationStarted = false; let unsafe = false; let error: unknown
     try {
+      await claim(sql)
       for (const name of keys.map(lockName)) {
+        if (isD1ReservedConnectionLost(sql)) throw failed()
         await sql`SELECT pg_advisory_lock(hashtextextended(${name}, 0::bigint))`; locked.push(name)
       }
       operationStarted = true; result = await operation(sql); complete = true
-    } catch (caught) { unsafe = connectionLost(caught); error = operationStarted ? caught : failed() }
+    } catch (caught) { unsafe = isD1ReservedConnectionLost(sql) || connectionLost(caught); error = operationStarted ? caught : failed() }
     finally {
-      let lost = unsafe || connectionLost(error)
+      let connectionUnsafe = isD1ReservedConnectionLost(sql) || unsafe || connectionLost(error)
       for (const name of locked.reverse()) try {
-        if (lost) break
+        if (connectionUnsafe) break
         const unlocked = await bounded(sql<{ unlocked: boolean }[]>`SELECT pg_advisory_unlock(hashtextextended(${name}, 0::bigint)) AS unlocked`)
-        if (!unlocked) { lost = true; break }
+        if (!unlocked) { connectionUnsafe = true; break }
         const [unlock] = unlocked
-        if (unlock?.unlocked !== true) { lost = true; error ??= failed() }
-      } catch { lost = true; error ??= failed() }
-      if (!lost) try { sql.release() } catch { lost = true; error ??= failed() }
-      if (lost) { await abandon(); error = failed() }
+        if (unlock?.unlocked !== true) { connectionUnsafe = true; error ??= failed() }
+      } catch { connectionUnsafe = true; error ??= failed() }
+      if (!connectionUnsafe) try { releaseState(sql); sql.release() } catch { connectionUnsafe = true; error ??= failed() }
+      if (connectionUnsafe) { await abandon(); error = failed() }
     }
     if (error || !complete) throw error ?? failed()
     return result as T
@@ -179,12 +227,13 @@ export function createD1AdmissionLedger(
     if (strictD1Ref(databaseRef, 'databaseRef') !== live.databaseRef) throw failed()
     const sql = await live.sql.reserve().catch(() => { throw failed() })
     try {
+      await claim(sql)
       const rows = await sql<{ bindingId: string }[]>`
         SELECT binding_id AS "bindingId" FROM d1_binding_admissions
         WHERE host_id = ${expectedHost} ORDER BY binding_id
       `
       return Object.freeze(rows.map((entry) => strictD1Ref(entry.bindingId, 'admission.bindingId')))
-    } catch (caught) { if (connectionLost(caught)) await abandon(); throw failed() } finally { if (!closed) try { sql.release() } catch { await abandon(); throw failed() } }
+    } catch (caught) { if (isD1ReservedConnectionLost(sql) || connectionLost(caught)) await abandon(); throw failed() } finally { if (!closed) try { releaseState(sql); sql.release() } catch { await abandon(); throw failed() } }
   }
 
   const admit = async (activeReader: D1ActiveCollectionReader, rawTarget: D1AdmissionTarget): Promise<D1BindingAdmission> => {
@@ -207,6 +256,10 @@ export function createD1AdmissionLedger(
 
   return Object.freeze({
     databaseRef: live.databaseRef, listBindingIds, admit, withBindingFences,
-    async close() { if (closed) return; closed = true; if (live.ownsClient) await live.sql.end() },
+    async close() {
+      if (closed) return
+      closed = true; closing = true; restoreHooks()
+      if (live.ownsClient) await live.sql.end()
+    },
   })
 }

--- a/apps/full-app/src/server/deployment/fencedDestructivePublication.ts
+++ b/apps/full-app/src/server/deployment/fencedDestructivePublication.ts
@@ -1,17 +1,25 @@
 import type postgres from 'postgres'
-
-import type { D1AdmissionLedger } from './admissionLedger.js'
+import { isD1ReservedConnectionLost, type D1AdmissionLedger } from './admissionLedger.js'
 import {
   normalizeD1DestructivePublicationIdentity,
   type D1DestructivePublicationIdentity,
   type D1DestructivePublicationJournalStore,
 } from './destructivePublicationJournal.js'
 import { D1HostError, D1HostErrorCode } from './d1Plan.js'
+import {
+  canonicalizeD1CompleteEnvelope,
+  canonicalizeD1DesiredSnapshot,
+  canonicalizeD1Observation,
+  canonicalizeD1SecretRefsEnvelope,
+  digestD1Desired,
+} from './d1RevisionCodec.js'
 import type { D1HostRevisionStore } from './hostRevisionStore.js'
 
 export interface D1FencedDestructivePublication {
   /** The caller holds the D1 per-host OS mutation lock for this entire operation. */
   publish(identity: D1DestructivePublicationIdentity): Promise<void>
+  /** The caller holds the D1 per-host OS mutation lock before discovery starts. */
+  recoverPending(hostId: string): Promise<void>
 }
 
 const preserved = new Set<D1HostErrorCode>([
@@ -33,6 +41,13 @@ function connectionLost(error: unknown): boolean {
 function internalConnectionLost(): Error {
   return Object.assign(new Error('D1_RESERVED_CONNECTION_LOST'), { code: 'CONNECTION_CLOSED' })
 }
+function sameIdentity(left: D1DestructivePublicationIdentity, right: D1DestructivePublicationIdentity): boolean {
+  return left.operationId === right.operationId && left.hostId === right.hostId
+    && left.expectedRevision === right.expectedRevision && left.expectedDigest === right.expectedDigest
+    && left.targetRevision === right.targetRevision && left.targetDigest === right.targetDigest
+    && left.removalBindingIds.length === right.removalBindingIds.length
+    && left.removalBindingIds.every((value, index) => value === right.removalBindingIds[index])
+}
 async function bounded(value: PromiseLike<unknown>): Promise<boolean> {
   const pending = Promise.resolve(value); let timer: ReturnType<typeof setTimeout> | undefined
   try { return await Promise.race([pending.then(() => true), new Promise<false>((resolve) => { timer = setTimeout(() => resolve(false), 5_000) })]) }
@@ -41,9 +56,11 @@ async function bounded(value: PromiseLike<unknown>): Promise<boolean> {
 async function transaction(sql: postgres.ReservedSql, operation: () => Promise<unknown>): Promise<void> {
   let open = false
   try {
-    await sql`BEGIN`; open = true
+    if (isD1ReservedConnectionLost(sql) || !await bounded(sql`BEGIN`)) throw internalConnectionLost()
+    open = true
     await operation()
-    await sql`COMMIT`; open = false
+    if (isD1ReservedConnectionLost(sql) || !await bounded(sql`COMMIT`)) throw internalConnectionLost()
+    open = false
   } catch (error) {
     if (connectionLost(error)) throw internalConnectionLost()
     if (open) try { if (!await bounded(sql`ROLLBACK`)) throw internalConnectionLost() } catch { throw internalConnectionLost() }
@@ -56,6 +73,55 @@ export function createD1FencedDestructivePublication(input: {
   readonly journalStore: D1DestructivePublicationJournalStore
   readonly revisionStore: D1HostRevisionStore
 }): D1FencedDestructivePublication {
+  const validateArtifacts = async (identity: D1DestructivePublicationIdentity, invalid: (field: string) => D1HostError) => {
+    const [expected, target] = await Promise.all([
+      input.revisionStore.readComplete(identity.hostId, identity.expectedRevision),
+      input.revisionStore.readComplete(identity.hostId, identity.targetRevision),
+    ])
+    const exactComplete = async (value: typeof expected, revision: string, digest: string): Promise<boolean> => {
+      if (!value || Object.keys(value).sort().join(',') !== 'completion,desired,desiredStateDigest,observation,revisionId,secretRefs'
+        || !value.observation || typeof value.observation !== 'object' || !value.secretRefs || typeof value.secretRefs !== 'object'
+        || !value.completion) return false
+      try {
+        const desired = await canonicalizeD1DesiredSnapshot(value.desired)
+        const secretRefs = canonicalizeD1SecretRefsEnvelope(value.secretRefs, desired)
+        const observation = await canonicalizeD1Observation(value.observation, desired)
+        const completion = await canonicalizeD1CompleteEnvelope(value.completion, desired, observation)
+        return value.revisionId === revision
+          && value.desiredStateDigest === digest
+          && await digestD1Desired(desired) === digest
+          && completion.revisionId === revision
+          && completion.desiredStateDigest === digest
+          && desired.plan.hostId === identity.hostId
+          && desired.plan.databaseRef === input.admissionLedger.databaseRef
+          && JSON.stringify(desired) === JSON.stringify(value.desired)
+          && JSON.stringify(secretRefs) === JSON.stringify(value.secretRefs)
+          && JSON.stringify(observation) === JSON.stringify(value.observation)
+          && JSON.stringify(completion) === JSON.stringify(value.completion)
+      } catch { return false }
+    }
+    if (!await exactComplete(expected, identity.expectedRevision, identity.expectedDigest)) throw invalid('expectedRevision')
+    if (!await exactComplete(target, identity.targetRevision, identity.targetDigest)) throw invalid('targetRevision')
+    const bindingIds = (value: typeof expected): readonly string[] | null => {
+      if (!value) return null
+      return value.desired.plan.bindings.map((binding) => binding.bindingId)
+    }
+    const expectedIds = bindingIds(expected); const targetBindingIds = bindingIds(target)
+    if (!expectedIds || !targetBindingIds) throw invalid('bindings')
+    const targetIds = new Set(targetBindingIds)
+    const removals = expectedIds.filter((id) => !targetIds.has(id))
+    if (removals.length !== identity.removalBindingIds.length
+      || removals.some((id, index) => id !== identity.removalBindingIds[index])) throw invalid('removalBindingIds')
+  }
+  const readAdmissions = async (sql: postgres.ReservedSql, identity: D1DestructivePublicationIdentity) => {
+    try {
+      return await sql<{ bindingId: string }[]>`
+        SELECT binding_id AS "bindingId" FROM d1_binding_admissions
+        WHERE host_id = ${identity.hostId} AND binding_id = ANY(${identity.removalBindingIds as string[]})
+        ORDER BY binding_id LIMIT 1
+      `
+    } catch { throw new D1HostError(D1HostErrorCode.ADMISSION_RECORD_FAILED, { field: 'admission' }) }
+  }
   const publish = async (raw: D1DestructivePublicationIdentity): Promise<void> => {
     let identity: D1DestructivePublicationIdentity
     let journalStarted = false
@@ -71,30 +137,8 @@ export function createD1FencedDestructivePublication(input: {
           if (!active || active.revisionId !== identity.expectedRevision || active.desiredStateDigest !== identity.expectedDigest) {
             throw new D1HostError(D1HostErrorCode.REVISION_CONFLICT, { field: 'expectedHostRevision' })
           }
-          const [expected, target] = await Promise.all([
-            input.revisionStore.readComplete(identity.hostId, identity.expectedRevision),
-            input.revisionStore.readComplete(identity.hostId, identity.targetRevision),
-          ])
-          if (!expected || expected.revisionId !== identity.expectedRevision || expected.desiredStateDigest !== identity.expectedDigest
-            || expected.completion.revisionId !== identity.expectedRevision || expected.completion.desiredStateDigest !== identity.expectedDigest
-            || expected.desired.plan.hostId !== identity.hostId
-            || expected.desired.plan.databaseRef !== input.admissionLedger.databaseRef) throw targetInvalid('expectedRevision')
-          if (!target || target.revisionId !== identity.targetRevision || target.desiredStateDigest !== identity.targetDigest
-            || target.completion.revisionId !== identity.targetRevision || target.completion.desiredStateDigest !== identity.targetDigest
-            || target.desired.plan.hostId !== identity.hostId
-            || target.desired.plan.databaseRef !== input.admissionLedger.databaseRef) throw targetInvalid('targetRevision')
-          const targetIds = new Set(target.desired.plan.bindings.map((binding) => binding.bindingId))
-          const removals = expected.desired.plan.bindings.map((binding) => binding.bindingId).filter((id) => !targetIds.has(id)).sort()
-          if (removals.length !== identity.removalBindingIds.length
-            || removals.some((id, index) => id !== identity.removalBindingIds[index])) throw targetInvalid('removalBindingIds')
-          let rows: { bindingId: string }[]
-          try {
-            rows = await sql<{ bindingId: string }[]>`
-              SELECT binding_id AS "bindingId" FROM d1_binding_admissions
-              WHERE host_id = ${identity.hostId} AND binding_id = ANY(${identity.removalBindingIds as string[]})
-              ORDER BY binding_id LIMIT 1
-            `
-          } catch { throw new D1HostError(D1HostErrorCode.ADMISSION_RECORD_FAILED, { field: 'admission' }) }
+          await validateArtifacts(identity, targetInvalid)
+          const rows = await readAdmissions(sql, identity)
           if (rows[0]) throw new D1HostError(D1HostErrorCode.BINDING_ADMITTED, { bindingId: rows[0].bindingId })
           journalStarted = true
           await transaction(sql, async () => {
@@ -111,5 +155,38 @@ export function createD1FencedDestructivePublication(input: {
       throw failed()
     }
   }
-  return Object.freeze({ publish })
+  const recoverPending = async (hostId: string): Promise<void> => {
+    try {
+      // Discovery needs a reserved handle but no operation lock; the OS host lock serializes callers.
+      const pending = await input.admissionLedger.withBindingFences(
+        [{ hostId, bindingId: 'd1-publication-recovery' }],
+        (sql) => input.journalStore.readPending(sql, hostId),
+      )
+      for (const discovered of [...pending].sort((left, right) => left.sequence < right.sequence ? -1 : left.sequence > right.sequence ? 1 : 0)) {
+        await input.admissionLedger.withBindingFences(
+          discovered.removalBindingIds.map((bindingId) => ({ hostId: discovered.hostId, bindingId })),
+          async (sql) => {
+            const operation = await input.journalStore.readOperation(sql, discovered.operationId)
+            if (operation?.terminal) return
+            if (!operation || !sameIdentity(operation.prepared, discovered)) throw failed()
+            const identity = operation.prepared
+            await validateArtifacts(identity, () => failed())
+            const active = await input.revisionStore.readActive(identity.hostId).catch(() => { throw failed() })
+            if (active?.revisionId === identity.targetRevision && active.desiredStateDigest === identity.targetDigest) {
+              await transaction(sql, () => input.journalStore.appendTerminal(sql, identity, 'committed'))
+              return
+            }
+            if (active?.revisionId !== identity.expectedRevision || active.desiredStateDigest !== identity.expectedDigest) throw failed()
+            if ((await readAdmissions(sql, identity))[0]) {
+              await transaction(sql, () => input.journalStore.appendTerminal(sql, identity, 'aborted'))
+              return
+            }
+            await input.revisionStore.publishActive(identity.hostId, identity.targetRevision).catch(() => { throw failed() })
+            await transaction(sql, () => input.journalStore.appendTerminal(sql, identity, 'committed'))
+          },
+        )
+      }
+    } catch { throw failed() }
+  }
+  return Object.freeze({ publish, recoverPending })
 }


### PR DESCRIPTION
## Summary

- recover immutable pending destructive-publication journal entries under the exact sorted removal fences
- validate desired, secret-ref, observation, completion, active-pointer, and removal identities before recovery acts
- keep a durable PREPARED removal as a first-use fence after PostgreSQL session-lock loss
- correlate postgres-js reserved handles to their exact physical pool member so unrelated closes do not poison a healthy publisher

## Issue / Slice

D1-004e1c recovery only. Root-command integration remains the next D1-004e2 slice.

## Proof

- `cd apps/full-app && DATABASE_URL=postgres://ubuntu:test@localhost/boring_ui_d1_journal_v2 pnpm exec vitest run src/server/deployment/__tests__/admissionLedger.test.ts src/server/deployment/__tests__/destructivePublicationJournal.test.ts src/server/deployment/__tests__/fencedDestructivePublication.test.ts` - 3 files, 26/26 passed
- `cd apps/full-app && pnpm exec vitest run src/server/deployment/__tests__/d1CommandCli.test.ts` - 20/20 passed
- `cd apps/full-app && pnpm exec tsc --noEmit --pretty false` - passed
- `pnpm audit:imports` - passed
- `pnpm lint:invariants` - passed
- `pnpm check:generated-artifacts` - passed
- `git diff --check` - passed

## Review

- Independent adversarial review found and fixed canonical-artifact and session-lock-loss races
- Structured reviews on reviewed tree `28d8cd59ec07fe04e9a92e86ef4739da8ca62e9a`: clean, including the CI test-double correction
- Remote head `2439f2f087d76cd3fc9ef6f17750bdc15b1ce4c9` is a no-force reconciliation merge whose tree exactly equals the reviewed tree
- Cumulative slice: 4 files, +433/-83 (+350 net; within the <=350 contract)

## Risk / Rollback

Fail-closed behavior is deliberate: an unresolved PREPARED removal rejects first use until locked recovery appends COMMITTED or ABORTED. Rollback is the PR revert; journal and admission rows remain append/insert-only.

## Next

D1-004e2 wires locked recovery and removal publication into APPLY/ROLLBACK commands; additive and landing-only publication keep the direct path.