### PR TITLE
#391 feat(D1): integrate recoverable destructive publication

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1Command.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Command.test.ts
@@ -3,6 +3,8 @@ import { createResolvedAgentDigest } from '@hachej/boring-agent/server'
 import { describe, expect, it } from 'vitest'
 
 import { createD1CommandEngine, type D1CommandEngineOptions, type D1RuntimeInputsInspectionV1 } from '../d1Command.js'
+import type { D1DestructivePublicationIdentity } from '../destructivePublicationJournal.js'
+import type { D1FencedDestructivePublication } from '../fencedDestructivePublication.js'
 import { D1HostError, D1HostErrorCode } from '../d1Plan.js'
 import {
   canonicalizeD1AuditRecord,
@@ -157,9 +159,21 @@ function harness(
   admitted: readonly string[] = [],
   inspect: (value: D1DesiredSnapshotV1) => Promise<readonly D1RuntimeInputsInspectionV1[]> = async () => attestations(next),
   preload?: (candidate: D1StoredCandidateV1, identities: readonly D1RuntimeInputsIdentityV1[]) => Promise<D1ObservationV1>,
+  publication?: D1FencedDestructivePublication | null,
 ) {
   const calls: string[] = []
   const admissionDatabaseRefs: string[] = []
+  const publicationCalls: string[] = []
+  const published: D1DestructivePublicationIdentity[] = []
+  const defaultPublication: D1FencedDestructivePublication = {
+    async recoverPending() { publicationCalls.push(`recover:${calls.join(',')}:${store.calls.join(',')}`) },
+    async publish(identity) {
+      publicationCalls.push(`publish:${store.completes.has(identity.targetRevision)}`); published.push(identity)
+      const complete = store.completes.get(identity.targetRevision)
+      if (!complete) throw new Error('missing COMPLETE')
+      store.active = Object.freeze({ schemaVersion: 1, revisionId: identity.targetRevision, desiredStateDigest: complete.desiredStateDigest })
+    },
+  }
   const options: D1CommandEngineOptions = {
     store,
     resolver: { async resolvePlan() { calls.push('resolve'); return next }, async reproduce() { calls.push('reproduce'); return next } },
@@ -175,8 +189,9 @@ function harness(
       async verifyActive() { calls.push('verify'); if (store.fault === 'verify') throw new Error('/secret/verify') },
     },
     mutationGuard: { assertHeld() { calls.push('guard') } }, operator: { uid: 1000, effectiveUser: 'julien', invocationId: 'deploy-1' }, clock: () => '2026-07-12T00:00:00.000Z',
+    ...(publication === null ? {} : { fencedPublication: publication ?? defaultPublication }),
   }
-  return { engine: createD1CommandEngine(options), calls, admissionDatabaseRefs }
+  return { engine: createD1CommandEngine(options), calls, admissionDatabaseRefs, publicationCalls, published }
 }
 const plan = (value: D1DesiredSnapshotV1, expectedHostRevision: string | null) => ({ ...value.plan, expectedHostRevision })
 const apply = (value: D1DesiredSnapshotV1, expectedHostRevision: string | null, extra: Record<string, unknown> = {}) => ({ kind: 'apply', plan: plan(value, expectedHostRevision), ...extra })
@@ -190,12 +205,41 @@ describe('D1 command engine', () => {
   })
 
   it('keeps plan read-only and rejects a CAS loser before resolve, recovery, reservation, or effects', async () => {
-    const next = await desired(); const planStore = new FakeStore(); const planned = harness(planStore, next)
+    const next = await desired(); const planStore = new FakeStore(); const planned = harness(planStore, next, [], undefined, undefined, null)
     await planned.engine.execute({ ...apply(next, null), kind: 'plan' })
-    expect(planned.calls).toEqual(['admissions', 'resolve', 'inspect']); expect(planStore.calls).toEqual(['readActive'])
+    expect(planned.calls).toEqual(['admissions', 'resolve', 'inspect']); expect(planStore.calls).toEqual(['readActive']); expect(planned.publicationCalls).toEqual([])
     const store = new FakeStore(); await store.seed(next); store.calls = []; const lost = harness(store, next)
     await expect(lost.engine.execute(apply(next, 'r0000000009'))).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
     expect(lost.calls).toEqual(['guard']); expect(store.calls).toEqual(['readActive', 'read:r0000000001'])
+  })
+
+  it('requires and recovers the journal immediately after the mutation guard', async () => {
+    const next = await desired(); const store = new FakeStore(); const h = harness(store, next)
+    await h.engine.execute(apply(next, null))
+    expect(h.publicationCalls[0]).toBe('recover:guard:'); expect(store.calls[0]).toBe('readActive')
+
+    const missingStore = new FakeStore(); const missing = harness(missingStore, next, [], undefined, undefined, null)
+    await expect(missing.engine.execute(apply(next, null))).rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED, details: { field: 'rollbackJournal' } })
+    expect(missing.calls).toEqual(['guard']); expect(missingStore.calls).toEqual([])
+
+    const rollbackStore = new FakeStore(); await rollbackStore.seed(next)
+    const missingRollback = harness(rollbackStore, next, [], undefined, undefined, null); rollbackStore.calls = []
+    await expect(missingRollback.engine.execute({ kind: 'rollback', hostId: 'host-1', expectedHostRevision: 'r0000000001', targetRevision: 'r0000000001' }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED })
+    expect(missingRollback.calls).toEqual(['guard']); expect(rollbackStore.calls).toEqual([])
+  })
+
+  it('fails closed on recovery and rechecks CAS against any recovered pointer', async () => {
+    const next = await desired(); const failedStore = new FakeStore()
+    const failed = harness(failedStore, next, [], undefined, undefined, { recoverPending: async () => { throw new Error('/secret') }, publish: async () => {} })
+    await expect(failed.engine.execute(apply(next, null))).rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED, details: { field: 'rollbackJournal' } })
+    expect(failed.calls).toEqual(['guard']); expect(failedStore.calls).toEqual([])
+
+    const current = await desired(); const advanced = await desired([{ id: 'insurance', landing: 'advanced' }]); const store = new FakeStore()
+    await store.seed(current, 'r0000000001'); await store.seed(advanced, 'r0000000002'); store.active = { schemaVersion: 1, revisionId: 'r0000000001', desiredStateDigest: await digestD1Desired(current) }; store.calls = []
+    const recovered = harness(store, current, [], undefined, undefined, { recoverPending: async () => { store.active = { schemaVersion: 1, revisionId: 'r0000000002', desiredStateDigest: await digestD1Desired(advanced) } }, publish: async () => {} })
+    await expect(recovered.engine.execute(apply(current, 'r0000000001'))).rejects.toMatchObject({ code: D1HostErrorCode.REVISION_CONFLICT })
+    expect(recovered.calls).toEqual(['guard']); expect(store.calls).toEqual(['readActive', 'read:r0000000002'])
   })
 
   it('requires duplicate-free exact sorted removal confirmations and blocks admitted removals', async () => {
@@ -242,16 +286,19 @@ describe('D1 command engine', () => {
     expect(result).toMatchObject({ kind: 'PLAN', removals: ['travel'] }); expect(h.calls).not.toContain('guard'); expect(store.calls).not.toContain('reserve')
   })
 
-  it('permits additive, landing-only, and confirmed non-admitted removal changes', async () => {
+  it('recovers every mutation, directly publishes zero-removal changes, and fences removals', async () => {
     const cases = [
+      { current: null, next: await desired(), confirmRemove: undefined },
       { current: await desired(), next: await desired([{ id: 'insurance' }, { id: 'travel' }]), confirmRemove: undefined },
       { current: await desired(), next: await desired([{ id: 'insurance', landing: 'New title' }]), confirmRemove: undefined },
       { current: await desired([{ id: 'insurance' }, { id: 'travel' }]), next: await desired(), confirmRemove: ['travel'] },
     ]
     for (const { current, next, confirmRemove } of cases) {
-      const store = new FakeStore(); await store.seed(current); const h = harness(store, next)
-      const result = await h.engine.execute(apply(next, 'r0000000001', confirmRemove ? { confirmRemove } : {}))
-      expect(result.action).toBe('CREATE')
+      const store = new FakeStore(); if (current) await store.seed(current); const h = harness(store, next)
+      const result = await h.engine.execute(apply(next, current ? 'r0000000001' : null, confirmRemove ? { confirmRemove } : {}))
+      expect(result.action).toBe('CREATE'); expect(h.publicationCalls[0]).toMatch(/^recover:/)
+      if (confirmRemove) { expect(h.published).toHaveLength(1); expect(store.calls).not.toContain(`publish:${result.revisionId}`) }
+      else { expect(h.published).toEqual([]); expect(store.calls).toContain(`publish:${result.revisionId}`) }
     }
   })
 
@@ -462,6 +509,32 @@ describe('D1 command engine', () => {
     await expect(store.publishActive('host-1', firstResult.revisionId!)).rejects.toMatchObject({ committed: false })
     expect(await store.hasTerminalAudit('host-1', { ...firstActive, desiredStateDigest: sha('9') })).toBe(false)
     await expect(store.appendAudit('host-1', store.record(store.completes.get(firstResult.revisionId!)!))).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+  })
+
+  it('publishes exact APPLY and ROLLBACK removal identities only after the new COMPLETE exists', async () => {
+    const retained = await desired(); const expanded = await desired([{ id: 'insurance' }, { id: 'travel' }])
+    const applyStore = new FakeStore(); const prior = await applyStore.seed(expanded); applyStore.calls = []; const applying = harness(applyStore, retained)
+    const applied = await applying.engine.execute(apply(retained, 'r0000000001', { confirmRemove: ['travel'] }))
+    expect(applying.published).toEqual([{ operationId: 'deploy-1', hostId: 'host-1', expectedRevision: 'r0000000001', expectedDigest: prior.desiredStateDigest, targetRevision: 'r0000000002', targetDigest: await digestD1Desired(retained), removalBindingIds: ['travel'] }])
+    expect(applying.publicationCalls.at(-1)).toBe('publish:true'); expect(applyStore.calls).not.toContain(`publish:${applied.revisionId}`)
+
+    const rollbackStore = new FakeStore(); await rollbackStore.seed(retained, 'r0000000001'); const active = await rollbackStore.seed(expanded, 'r0000000002'); rollbackStore.calls = []
+    const rollingBack = harness(rollbackStore, retained)
+    const rolledBack = await rollingBack.engine.execute({ kind: 'rollback', hostId: 'host-1', expectedHostRevision: 'r0000000002', targetRevision: 'r0000000001', confirmRemove: ['travel'] })
+    expect(rollingBack.published[0]).toMatchObject({ operationId: 'deploy-1', expectedRevision: 'r0000000002', expectedDigest: active.desiredStateDigest, targetRevision: 'r0000000003', removalBindingIds: ['travel'] })
+    expect(rollbackStore.calls).not.toContain('publish:r0000000001'); expect(rollbackStore.calls).not.toContain(`publish:${rolledBack.revisionId}`)
+  })
+
+  it.each([
+    ['unknown', new Error('/secret/publish'), D1HostErrorCode.ROLLBACK_JOURNAL_FAILED],
+    ['admitted', new D1HostError(D1HostErrorCode.BINDING_ADMITTED, { bindingId: 'travel' }), D1HostErrorCode.BINDING_ADMITTED],
+    ['journal', new D1HostError(D1HostErrorCode.ROLLBACK_JOURNAL_FAILED, { field: 'rollbackJournal' }), D1HostErrorCode.ROLLBACK_JOURNAL_FAILED],
+  ])('maps or preserves fenced publication failure: %s, with no fallback or success', async (_label, failure, code) => {
+    const retained = await desired(); const expanded = await desired([{ id: 'insurance' }, { id: 'travel' }]); const store = new FakeStore(); await store.seed(expanded); store.calls = []
+    const h = harness(store, retained, [], undefined, undefined, { recoverPending: async () => {}, publish: async () => { throw failure } })
+    const error = await h.engine.execute(apply(retained, 'r0000000001', { confirmRemove: ['travel'] })).catch((caught) => caught)
+    expect(error).toMatchObject({ code }); expect(JSON.stringify(error)).not.toMatch(/secret/)
+    expect(store.active?.revisionId).toBe('r0000000001'); expect(store.calls).not.toContain('publish:r0000000002'); expect(h.calls).not.toContain('verify'); expect(store.calls).not.toContain('audit:COMPLETE:AUDIT')
   })
 
   it('rolls back from a freshly reproduced target into a new higher revision, never the old revision', async () => {

--- a/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
@@ -8,11 +8,14 @@ import { pathToFileURL } from 'node:url'
 import type postgres from 'postgres'
 import { describe, expect, it, vi } from 'vitest'
 
-import { mintAttestedD1DatabaseConnection } from '../admissionLedger.js'
-import { runD1CommandEntry, type D1EntryContext } from '../d1CommandEntry.js'
+import { mintAttestedD1DatabaseConnection, type D1AdmissionLedger } from '../admissionLedger.js'
+import { createProductionD1Dependencies, runD1CommandEntry, type D1EntryContext } from '../d1CommandEntry.js'
 import { isSupportedLocalD1LockFilesystem } from '../d1CommandLockPolicy.js'
 import { D1HostErrorCode } from '../d1Plan.js'
 import { resolveD1EntryInvocation, runD1RevisionWrapper, type D1EntryInvocation } from '../d1CommandWrapper.js'
+import * as journals from '../destructivePublicationJournal.js'
+import * as publications from '../fencedDestructivePublication.js'
+import * as revisions from '../hostRevisionStore.js'
 
 const UID = process.geteuid!()
 const DIGEST = `sha256:${'a'.repeat(64)}`
@@ -141,10 +144,10 @@ describe('D1 revision command boundary', () => {
     expect(externallyLocked(path.join(h.lockRoot, 'host-1.lock'))).toBe(false)
   })
 
-  it('uses the real entry lock proof and fails closed adapters before creating revision state', async () => {
+  it('uses the real entry lock proof and fails closed without a publication ledger before creating revision state', async () => {
     const h = await roots(); const output = await runD1RevisionWrapper({ stdin: Readable.from([validApply()]), env: h.env, entry: SOURCE_ENTRY })
     expect(output.exitCode).toBe(4)
-    expect(JSON.parse(output.line)).toEqual({ ok: false, error: { code: D1HostErrorCode.PUBLICATION_FAILED, details: { field: 'admissions' } } })
+    expect(JSON.parse(output.line)).toEqual({ ok: false, error: { code: D1HostErrorCode.ROLLBACK_JOURNAL_FAILED, details: { field: 'rollbackJournal' } } })
     await expect(access(h.stateRoot)).rejects.toMatchObject({ code: 'ENOENT' })
   })
 
@@ -170,6 +173,26 @@ describe('D1 revision command boundary', () => {
       } })
       expect(output).toMatchObject({ exitCode: 70 }); expect(context?.hostId).toBe('host-2')
     } finally { for (const key of keys) prior[key] === undefined ? delete process.env[key] : process.env[key] = prior[key] }
+  })
+
+  it('constructs fenced publication only from an injected ledger and shares one revision store', () => {
+    const revisionStore = {} as ReturnType<typeof revisions.createHostRevisionStore>
+    const fencedPublication = { recoverPending: vi.fn(async () => {}), publish: vi.fn(async () => {}) }
+    const createStore = vi.spyOn(revisions, 'createHostRevisionStore').mockReturnValue(revisionStore)
+    const createJournal = vi.spyOn(journals, 'createD1DestructivePublicationJournalStore').mockReturnValue({} as ReturnType<typeof journals.createD1DestructivePublicationJournalStore>)
+    const createPublication = vi.spyOn(publications, 'createD1FencedDestructivePublication').mockReturnValue(fencedPublication)
+    const context = { hostId: 'host-1', ownerUid: UID, stateRoot: '/d1-state', mutationGuard: { assertHeld: vi.fn() } }
+    try {
+      const absent = createProductionD1Dependencies(context)
+      expect(absent.store).toBe(revisionStore); expect(absent.fencedPublication).toBeUndefined()
+      expect(createStore).toHaveBeenCalledOnce(); expect(createJournal).not.toHaveBeenCalled(); expect(createPublication).not.toHaveBeenCalled()
+
+      createStore.mockClear()
+      const admissionLedger = { databaseRef: 'postgres-eu' } as D1AdmissionLedger
+      const present = createProductionD1Dependencies({ ...context, admissionLedger })
+      expect(present.store).toBe(revisionStore); expect(present.fencedPublication).toBe(fencedPublication); expect(createStore).toHaveBeenCalledOnce()
+      expect(createPublication).toHaveBeenCalledWith({ admissionLedger, journalStore: expect.anything(), revisionStore })
+    } finally { createStore.mockRestore(); createJournal.mockRestore(); createPublication.mockRestore() }
   })
 
   it('uses and closes an injected attested database connection', async () => {
@@ -302,7 +325,7 @@ describe('D1 revision command boundary', () => {
     const wrapper = path.resolve('src/server/deployment/d1CommandWrapper.ts')
     const child = spawn(path.resolve('../../node_modules/.bin/tsx'), [wrapper], { cwd, env: h.env, stdio: ['pipe', 'pipe', 'pipe'] })
     child.stdin!.end(validApply()); const result = await collect(child)
-    expect(result.code).toBe(4); expect(result.stdout).toContain(D1HostErrorCode.PUBLICATION_FAILED)
+    expect(result.code).toBe(4); expect(result.stdout).toContain(D1HostErrorCode.ROLLBACK_JOURNAL_FAILED)
     await expect(access(path.join(cwd, '3'))).rejects.toMatchObject({ code: 'ENOENT' })
   }, 15_000)
 })

--- a/apps/full-app/src/server/deployment/d1Command.ts
+++ b/apps/full-app/src/server/deployment/d1Command.ts
@@ -27,6 +27,7 @@ import {
   type D1StoredCandidateV1,
   type D1StoredCompleteV1,
 } from './hostRevisionStore.js'
+import type { D1FencedDestructivePublication } from './fencedDestructivePublication.js'
 
 export interface D1DesiredResolver {
   resolvePlan(plan: D1HostPlanV1): Promise<D1DesiredSnapshotV1>
@@ -48,6 +49,7 @@ export interface D1CommandEngineOptions {
   readonly effects: D1ApplyEffects
   readonly inspectRuntimeInputs: (desired: D1DesiredSnapshotV1) => Promise<readonly D1RuntimeInputsInspectionV1[]>
   readonly mutationGuard: D1MutationGuard
+  readonly fencedPublication?: D1FencedDestructivePublication
   readonly operator: D1CommandOperator
   readonly clock: () => string
 }
@@ -122,6 +124,10 @@ function byBinding<T extends { readonly bindingId: string }>(values: readonly T[
   return new Map(values.map((value) => [value.bindingId, value]))
 }
 const ADAPTER_CODES = new Set<string>([D1HostErrorCode.SECRET_UNAVAILABLE, D1HostErrorCode.ACTIVE_BINDING_RESTART_REQUIRED, D1HostErrorCode.COLLECTION_NOT_READY])
+const FENCED_PUBLICATION_CODES = new Set<D1HostErrorCode>([
+  D1HostErrorCode.REVISION_CONFLICT, D1HostErrorCode.ROLLBACK_TARGET_INVALID, D1HostErrorCode.BINDING_ADMITTED,
+  D1HostErrorCode.ADMISSION_RECORD_FAILED, D1HostErrorCode.ROLLBACK_JOURNAL_FAILED,
+])
 function adapterError(error: unknown, field: string): D1HostError {
   const code = error instanceof D1HostError && ADAPTER_CODES.has(error.code) ? error.code : D1HostErrorCode.COLLECTION_NOT_READY
   const safeField = code === D1HostErrorCode.SECRET_UNAVAILABLE ? 'secret' : code === D1HostErrorCode.ACTIVE_BINDING_RESTART_REQUIRED ? 'runtimeInputs' : field
@@ -248,6 +254,15 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
   const appendBestEffort = async (hostId: string, revisionId: string, desiredStateDigest: string, outcome: string, phase: string, completionDigest?: string) => {
     try { await options.store.appendAudit(hostId, audit(revisionId, desiredStateDigest, outcome, phase, completionDigest)) } catch {}
   }
+  const requireFencedPublication = (): D1FencedDestructivePublication => {
+    if (!options.fencedPublication) throw new D1HostError(D1HostErrorCode.ROLLBACK_JOURNAL_FAILED, { field: 'rollbackJournal' })
+    return options.fencedPublication
+  }
+  const recoverPublications = async (publication: D1FencedDestructivePublication, hostId: string) => {
+    try { await publication.recoverPending(hostId) } catch {
+      throw new D1HostError(D1HostErrorCode.ROLLBACK_JOURNAL_FAILED, { field: 'rollbackJournal' })
+    }
+  }
   const recover = async (hostId: string, active: D1ActiveEnvelopeV1 | null, complete: D1StoredCompleteV1 | null) => {
     if (!active || !complete) return
     let terminal: boolean
@@ -258,7 +273,14 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
       }
     }
   }
-  const create = async (hostId: string, desired: D1DesiredSnapshotV1, inspected: readonly D1RuntimeInputsIdentityV1[]): Promise<D1ActiveEnvelopeV1> => {
+  const create = async (
+    hostId: string,
+    desired: D1DesiredSnapshotV1,
+    inspected: readonly D1RuntimeInputsIdentityV1[],
+    prior: D1ActiveEnvelopeV1 | null,
+    removals: readonly string[],
+    publication: D1FencedDestructivePublication,
+  ): Promise<D1ActiveEnvelopeV1> => {
     const desiredStateDigest = await digestD1Desired(desired)
     let revisionId: string
     try { revisionId = await options.store.reserveRevisionId(hostId) } catch (error) {
@@ -298,7 +320,21 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
       throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'completion' })
     }
     let active: D1ActiveEnvelopeV1
-    try { active = await options.store.publishActive(hostId, revisionId) } catch (error) {
+    if (removals.length > 0) {
+      if (!prior) throw new D1HostError(D1HostErrorCode.ROLLBACK_JOURNAL_FAILED, { field: 'rollbackJournal' })
+      try {
+        await publication.publish({
+          operationId: options.operator.invocationId, hostId,
+          expectedRevision: prior.revisionId, expectedDigest: prior.desiredStateDigest,
+          targetRevision: revisionId, targetDigest: complete.desiredStateDigest,
+          removalBindingIds: removals,
+        })
+      } catch (error) {
+        if (error instanceof D1HostError && FENCED_PUBLICATION_CODES.has(error.code)) throw error
+        throw new D1HostError(D1HostErrorCode.ROLLBACK_JOURNAL_FAILED, { field: 'rollbackJournal' })
+      }
+      active = Object.freeze({ schemaVersion: 1, revisionId, desiredStateDigest: complete.desiredStateDigest })
+    } else try { active = await options.store.publishActive(hostId, revisionId) } catch (error) {
       let committed = error instanceof D1ActivePublishError && error.committed
       if (!(error instanceof D1ActivePublishError)) {
         try { committed = (await options.store.readActive(hostId))?.revisionId === revisionId } catch { committed = true }
@@ -326,6 +362,8 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
       if (command.kind === 'rollback') {
         hostId = command.hostId; expectedHostRevision = command.expectedHostRevision
         try { options.mutationGuard.assertHeld(hostId) } catch { throw new D1HostError(D1HostErrorCode.REVISION_CONFLICT, { field: 'hostLock' }) }
+        const publication = requireFencedPublication()
+        await recoverPublications(publication, hostId)
         const state = await loadActive(hostId); assertCas(state.active, expectedHostRevision)
         let target: D1StoredCompleteV1 | null
         try { target = await options.store.readComplete(hostId, command.targetRevision) } catch { target = null }
@@ -338,13 +376,16 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
         const desiredStateDigest = await digestD1Desired(desired)
         await recover(hostId, state.active, state.complete)
         if (desiredStateDigest === state.active?.desiredStateDigest) return Object.freeze({ kind: 'ROLLBACK', action: 'NOOP', activeRevision: state.active?.revisionId ?? null, desiredStateDigest, removals })
-        const active = await create(hostId, desired, inspected)
+        const active = await create(hostId, desired, inspected, state.active, removals, publication)
         return Object.freeze({ kind: 'ROLLBACK', action: 'CREATE', activeRevision: active.revisionId, revisionId: active.revisionId, desiredStateDigest, removals })
       }
       const parsedPlan = parseD1HostPlan(command.plan)
       hostId = parsedPlan.hostId; expectedHostRevision = parsedPlan.expectedHostRevision
+      let publication: D1FencedDestructivePublication | undefined
       if (command.kind === 'apply') {
         try { options.mutationGuard.assertHeld(hostId) } catch { throw new D1HostError(D1HostErrorCode.REVISION_CONFLICT, { field: 'hostLock' }) }
+        publication = requireFencedPublication()
+        await recoverPublications(publication, hostId)
       }
       const state = await loadActive(hostId); assertCas(state.active, expectedHostRevision)
       const removals = await preflightPlan(hostId, state.complete, persistedPlan(parsedPlan), command.confirmRemove ?? [], command.kind === 'apply')
@@ -356,7 +397,7 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
       if (command.kind === 'plan') return Object.freeze({ kind: 'PLAN', action: desiredStateDigest === state.active?.desiredStateDigest ? 'NOOP' : 'CREATE', activeRevision: state.active?.revisionId ?? null, desiredStateDigest, removals })
       await recover(hostId, state.active, state.complete)
       if (desiredStateDigest === state.active?.desiredStateDigest) return Object.freeze({ kind: 'APPLY', action: 'NOOP', activeRevision: state.active?.revisionId ?? null, desiredStateDigest, removals })
-      const active = await create(hostId, desired, inspected)
+      const active = await create(hostId, desired, inspected, state.active, removals, publication!)
       return Object.freeze({ kind: 'APPLY', action: 'CREATE', activeRevision: active.revisionId, revisionId: active.revisionId, desiredStateDigest, removals })
     },
   })

--- a/apps/full-app/src/server/deployment/d1CommandEntry.ts
+++ b/apps/full-app/src/server/deployment/d1CommandEntry.ts
@@ -15,7 +15,9 @@ import {
 import { createD1CommandEngine, type D1CommandEngineOptions, type D1MutationGuard } from './d1Command.js'
 import { parseD1CliInput } from './d1CommandCliProtocol.js'
 import { isSupportedLocalD1LockFilesystem } from './d1CommandLockPolicy.js'
+import { createD1DestructivePublicationJournalStore } from './destructivePublicationJournal.js'
 import { createD1FileRuntimeInputsProvider } from './d1FileRuntimeInputsProvider.js'
+import { createD1FencedDestructivePublication } from './fencedDestructivePublication.js'
 import { D1HostError, D1HostErrorCode } from './d1Plan.js'
 import { createD1BindingSecretMaterializer, createD1RuntimeInputsInspector } from './d1SecretMaterializer.js'
 import { createHostRevisionStore } from './hostRevisionStore.js'
@@ -93,8 +95,12 @@ function unavailable(field: string): never { throw new D1HostError(D1HostErrorCo
 
 export const createProductionD1Dependencies: D1DependencyFactory = ({ hostId, ownerUid, stateRoot, mutationGuard, admissionLedger }) => {
   const provider = createD1FileRuntimeInputsProvider({ hostId, ownerUid })
+  const store = createHostRevisionStore({ root: stateRoot, ownerUid, appGid: D1_APP_GID })
+  const fencedPublication = admissionLedger
+    ? createD1FencedDestructivePublication({ admissionLedger, journalStore: createD1DestructivePublicationJournalStore(), revisionStore: store })
+    : undefined
   return {
-    store: createHostRevisionStore({ root: stateRoot, ownerUid, appGid: D1_APP_GID }),
+    store,
     resolver: { resolvePlan: async () => unavailable('resolver'), reproduce: async () => unavailable('resolver') },
     effects: {
       loadAdmittedBindingIds: admissionLedger
@@ -106,6 +112,7 @@ export const createProductionD1Dependencies: D1DependencyFactory = ({ hostId, ow
     },
     inspectRuntimeInputs: createD1RuntimeInputsInspector(provider),
     mutationGuard,
+    ...(fencedPublication ? { fencedPublication } : {}),
     operator: { uid: ownerUid, effectiveUser: os.userInfo().username, invocationId: randomUUID() },
     clock: () => new Date().toISOString(),
   }


### PR DESCRIPTION
## Summary

- require and recover the D1 destructive-publication journal immediately after the locked mutation guard and before fresh active/CAS reads
- route APPLY and ROLLBACK removals through the fenced publisher using exact prior/target identities
- retain direct atomic publication for initial, additive, and landing-only revisions
- construct the journal/publisher only from the injected attested admission ledger and share one revision-store instance

## Issue / Slice

D1-004e2 command integration. This completes the recoverable rollback-fence command path; D1-005a is next.

## Proof

- `pnpm --dir apps/full-app exec vitest run src/server/deployment/__tests__/d1Command.test.ts src/server/deployment/__tests__/d1CommandCli.test.ts` - 2 files, 95/95 passed
- `pnpm --dir apps/full-app build` - passed
- `pnpm --filter @hachej/boring-automation build` - passed to restore the ignored declaration artifact used by package-local typecheck
- `pnpm --dir apps/full-app typecheck` - passed
- `pnpm audit:imports` - passed
- `pnpm lint:invariants` - passed
- `pnpm check:generated-artifacts` - passed
- `git diff --check HEAD^ HEAD` - passed

## Review

- Structured commit review on `56e792328cc66a4a17fbd15834ea64fe4745a73e`: clean, no actionable findings, 0.96
- Independent adversarial review: clean; exact focused tests rerun green
- Cumulative slice: 4 files, +161/-17 (+144 net; under the <=250 contract)

## Risk / Rollback

Mutation commands fail closed when the publication capability or recovery is unavailable. Destructive publication never falls back to direct pointer publication; stable fenced error codes are preserved. Revert this PR to restore pre-integration command routing.

## Next

D1-005a approved host release and intended-policy capability.