### PR TITLE
feat(d1): bind approved release migration evidence

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/approvedHostRelease.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/approvedHostRelease.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from 'vitest'
+
+import { D1HostErrorCode } from '../d1Plan.js'
+import {
+  createD1MigrationSetEvidence,
+  decodeApprovedD1HostReleaseRecord,
+  validateApprovedD1HostRelease,
+} from '../approvedHostRelease.js'
+
+const digest = (character: string) => `sha256:${character.repeat(64)}`
+const revision = (character: string) => character.repeat(40)
+const CANARY = 'secret-canary-never-serialize'
+
+const journal = () => ({
+  version: '7', dialect: 'postgresql', entries: [
+    { idx: 0, version: '7', when: 100, tag: '0000_first', breakpoints: true },
+    { idx: 1, version: '7', when: 200, tag: '0001_second', breakpoints: true },
+  ],
+})
+const sql = () => [
+  { file: '0000_first.sql', bytes: new TextEncoder().encode('select 1;\n') },
+  { file: '0001_second.sql', bytes: new TextEncoder().encode('select 2;\n') },
+]
+const sources = () => [
+  { file: 'apps/full-app/src/server/migrate.ts', bytes: new TextEncoder().encode('register core and automation\n') },
+  { file: 'packages/core/src/server/migrations.ts', bytes: new TextEncoder().encode('load config and invoke core migrations\n') },
+  { file: 'packages/core/src/server/db/migrate.ts', bytes: new TextEncoder().encode('lock, extension, drizzle, additional\n') },
+  { file: 'plugins/boring-automation/src/server/migrations.ts', bytes: new TextEncoder().encode('create automation tables\n') },
+]
+const release = () => ({
+  schemaVersion: 1,
+  domain: 'boring-d1-approved-host-release:v1',
+  hostAppImageDigest: digest('a'),
+  coreCommand: { entrypoint: ['/usr/local/bin/web-entrypoint'], cmd: ['node', 'apps/full-app/dist/server/main.js'] },
+  migrationProcess: { entrypoint: ['node'], cmd: ['apps/full-app/dist/server/migrate.js'], user: '10001:10001',
+    readonlyRootfs: true, privileged: false, noNewPrivileges: true, addedCapabilities: [] },
+  ingressImageDigest: digest('b'),
+  ingressCommand: { entrypoint: null, cmd: ['caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile'] },
+  caddyfileDigest: digest('c'), hostSecurityConfigDigest: digest('d'),
+  selectorInventoryRevision: revision('a'), executionPolicyRevision: revision('b'),
+  databaseSchemaCompatibility: { migrationSetDigest: digest('e'), currentEpoch: 2,
+    readableEpochRange: { min: 1, max: 2 }, readableByPreviousRelease: true },
+})
+const frozen = (value: unknown): boolean => !value || typeof value !== 'object'
+  || (Object.isFrozen(value) && Object.values(value).every(frozen))
+const rejectsRelease = (value: unknown) => expect(() => decodeApprovedD1HostReleaseRecord(value)).toThrow(expect.objectContaining({
+  code: D1HostErrorCode.COLLECTION_NOT_READY, details: { field: 'approvedHostRelease' },
+}))
+const rejectsEvidence = (journalValue: unknown, sqlValue: unknown = sql(), sourceValue: unknown = sources()) => expect(createD1MigrationSetEvidence(journalValue, sqlValue, sourceValue))
+  .rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY, details: { field: 'databaseSchemaCompatibility' } })
+
+describe('approved D1 host release', () => {
+  it('decodes the exact command and policy closure into a deeply frozen record', () => {
+    const decoded = decodeApprovedD1HostReleaseRecord(release())
+    expect(decoded).toEqual(release())
+    expect(frozen(decoded)).toBe(true)
+  })
+
+  it.each([
+    ['schema version', (value: ReturnType<typeof release>) => { value.schemaVersion = 2 }],
+    ['domain', (value: ReturnType<typeof release>) => { value.domain = 'other' }],
+    ['host digest', (value: ReturnType<typeof release>) => { value.hostAppImageDigest = digest('A') }],
+    ['core entrypoint', (value: ReturnType<typeof release>) => { value.coreCommand.entrypoint[0] = '/bin/sh' }],
+    ['core command', (value: ReturnType<typeof release>) => { value.coreCommand.cmd[1] = 'other.js' }],
+    ['migration entrypoint', (value: ReturnType<typeof release>) => { value.migrationProcess.entrypoint[0] = '/bin/sh' }],
+    ['migration command', (value: ReturnType<typeof release>) => { value.migrationProcess.cmd[0] = 'other.js' }],
+    ['migration user', (value: ReturnType<typeof release>) => { value.migrationProcess.user = '0:0' }],
+    ['migration rootfs', (value: ReturnType<typeof release>) => { value.migrationProcess.readonlyRootfs = false }],
+    ['migration privileged', (value: ReturnType<typeof release>) => { value.migrationProcess.privileged = true }],
+    ['migration privileges', (value: ReturnType<typeof release>) => { value.migrationProcess.noNewPrivileges = false }],
+    ['migration capabilities', (value: ReturnType<typeof release>) => { value.migrationProcess.addedCapabilities.push('NET_ADMIN' as never) }],
+    ['ingress digest', (value: ReturnType<typeof release>) => { value.ingressImageDigest = 'latest' }],
+    ['ingress entrypoint', (value: ReturnType<typeof release>) => { value.ingressCommand.entrypoint = [] as never }],
+    ['ingress command', (value: ReturnType<typeof release>) => { value.ingressCommand.cmd[0] = 'sh' }],
+    ['Caddy digest', (value: ReturnType<typeof release>) => { value.caddyfileDigest = digest('z') }],
+    ['security digest', (value: ReturnType<typeof release>) => { value.hostSecurityConfigDigest = digest('z') }],
+    ['selector revision', (value: ReturnType<typeof release>) => { value.selectorInventoryRevision = revision('A') }],
+    ['policy revision', (value: ReturnType<typeof release>) => { value.executionPolicyRevision = 'main' }],
+    ['migration digest', (value: ReturnType<typeof release>) => { value.databaseSchemaCompatibility.migrationSetDigest = digest('z') }],
+    ['epoch', (value: ReturnType<typeof release>) => { value.databaseSchemaCompatibility.currentEpoch = -1 }],
+    ['range minimum', (value: ReturnType<typeof release>) => { value.databaseSchemaCompatibility.readableEpochRange.min = 3 }],
+    ['range maximum', (value: ReturnType<typeof release>) => { value.databaseSchemaCompatibility.readableEpochRange.max = 1 }],
+    ['previous-release policy', (value: ReturnType<typeof release>) => { value.databaseSchemaCompatibility.readableByPreviousRelease = 1 as never }],
+  ])('rejects %s drift', (_label, mutate) => { const value = release(); mutate(value); rejectsRelease(value) })
+
+  it('rejects extras, hidden keys, symbols, accessors, prototypes, holes, and custom array properties', () => {
+    rejectsRelease({ ...release(), extra: true })
+    const hidden = release(); Object.defineProperty(hidden, 'extra', { value: CANARY }); rejectsRelease(hidden)
+    const symbol = release() as Record<PropertyKey, unknown>; symbol[Symbol('secret')] = CANARY; rejectsRelease(symbol)
+    let reads = 0
+    const accessor = release(); Object.defineProperty(accessor, 'hostAppImageDigest', { enumerable: true, get: () => { reads += 1; return digest('a') } })
+    rejectsRelease(accessor); expect(reads).toBe(0)
+    const nestedAccessor = release(); Object.defineProperty(nestedAccessor.databaseSchemaCompatibility.readableEpochRange, 'max', { enumerable: true, get: () => 2 })
+    rejectsRelease(nestedAccessor)
+    rejectsRelease(Object.assign(Object.create({ inherited: true }), release()))
+    const hole = release(); hole.coreCommand.cmd = new Array(2) as never; rejectsRelease(hole)
+    const custom = release(); Object.defineProperty(custom.ingressCommand.cmd, 'toJSON', { enumerable: true, value: () => [] }); rejectsRelease(custom)
+    const hiddenArray = release(); Object.defineProperty(hiddenArray.migrationProcess.addedCapabilities, 'secret', { value: CANARY }); rejectsRelease(hiddenArray)
+  })
+
+  it('maps malformed values to one stable redacted public failure', () => {
+    try { decodeApprovedD1HostReleaseRecord({ ...release(), hostAppImageDigest: CANARY }); throw new Error('accepted') }
+    catch (error) {
+      expect(error).toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY, message: D1HostErrorCode.COLLECTION_NOT_READY,
+        details: { field: 'approvedHostRelease' } })
+      expect(JSON.stringify(error)).not.toContain(CANARY)
+      expect(String(error)).not.toContain(CANARY)
+    }
+  })
+})
+
+describe('D1 migration-set evidence', () => {
+  it('hashes raw SQL into a deterministic journal-ordered frozen manifest', async () => {
+    const first = await createD1MigrationSetEvidence(journal(), sql(), sources())
+    const reversed = await createD1MigrationSetEvidence({ dialect: 'postgresql', entries: journal().entries, version: '7' }, sql().reverse(), sources().reverse())
+    expect(first).toEqual(reversed)
+    expect(first).toMatchObject({ schemaVersion: 1, domain: 'boring-d1-migration-set:v1', currentEpoch: 2 })
+    expect(first.migrations[0]).toMatchObject({ idx: 0, file: '0000_first.sql', breakpoints: true,
+      sqlDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/) })
+    expect(first.deploymentSources.map((source) => source.file)).toEqual([
+      'apps/full-app/src/server/migrate.ts', 'packages/core/src/server/migrations.ts',
+      'packages/core/src/server/db/migrate.ts', 'plugins/boring-automation/src/server/migrations.ts',
+    ])
+    expect(first.migrationSetDigest).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(frozen(first)).toBe(true)
+  })
+
+  it('accepts an empty migration set at epoch zero', async () => {
+    await expect(createD1MigrationSetEvidence({ version: '7', dialect: 'postgresql', entries: [] }, [], sources()))
+      .resolves.toMatchObject({ currentEpoch: 0, migrations: [] })
+  })
+
+  it.each([
+    ['gap', () => { const value = journal(); value.entries[1].idx = 2; return value }],
+    ['journal schema version drift', () => ({ ...journal(), version: '8' })],
+    ['version drift', () => { const value = journal(); value.entries[1].version = '6'; return value }],
+    ['time order', () => { const value = journal(); value.entries[1].when = 50; return value }],
+    ['duplicate time', () => { const value = journal(); value.entries[1].when = 100; return value }],
+    ['unsafe time', () => { const value = journal(); value.entries[1].when = Number.MAX_SAFE_INTEGER + 1; return value }],
+    ['unsafe tag', () => { const value = journal(); value.entries[1].tag = '../secret'; return value }],
+    ['tag/index drift', () => { const value = journal(); value.entries[1].tag = '0002_second'; return value }],
+    ['dialect drift', () => ({ ...journal(), dialect: 'sqlite' })],
+    ['journal extra', () => ({ ...journal(), extra: CANARY })],
+    ['entry extra', () => { const value = journal(); return { ...value, entries: [{ ...value.entries[0], extra: CANARY }, value.entries[1]] } }],
+  ])('rejects journal %s', async (_label, create) => rejectsEvidence(create()))
+
+  it('binds behavior-bearing breakpoint metadata into the migration identity', async () => {
+    const before = await createD1MigrationSetEvidence(journal(), sql(), sources())
+    const changed = journal(); changed.entries[1].breakpoints = false
+    const after = await createD1MigrationSetEvidence(changed, sql(), sources())
+    expect(after.migrations[1]?.breakpoints).toBe(false)
+    expect(after.migrationSetDigest).not.toBe(before.migrationSetDigest)
+  })
+
+  it('rejects missing, extra, duplicate, mismatched, and malformed SQL entries', async () => {
+    await rejectsEvidence(journal(), sql().slice(0, 1))
+    await rejectsEvidence(journal(), [...sql(), { file: 'extra.sql', bytes: new Uint8Array() }])
+    await rejectsEvidence(journal(), [sql()[0], sql()[0], sql()[1]])
+    await rejectsEvidence(journal(), [{ file: 'wrong.sql', bytes: new Uint8Array() }, sql()[1]])
+    await rejectsEvidence(journal(), [{ ...sql()[0], extra: CANARY }, sql()[1]])
+    const customBytes = sql(); Object.defineProperty(customBytes[0].bytes, 'secret', { value: CANARY })
+    await rejectsEvidence(journal(), customBytes)
+  })
+
+  it('rejects missing, extra, duplicate, and malformed deployment migration sources', async () => {
+    await rejectsEvidence(journal(), sql(), sources().slice(0, 1))
+    await rejectsEvidence(journal(), sql(), [...sources(), { file: 'other.ts', bytes: new Uint8Array() }])
+    await rejectsEvidence(journal(), sql(), [sources()[0], sources()[0], ...sources().slice(2)])
+    await rejectsEvidence(journal(), sql(), [{ ...sources()[0], extra: CANARY }, ...sources().slice(1)])
+  })
+
+  it('binds deployment migration source bytes without incrementing the Drizzle epoch', async () => {
+    const before = await createD1MigrationSetEvidence(journal(), sql(), sources())
+    const changed = sources(); changed[1].bytes[0] = 255
+    const after = await createD1MigrationSetEvidence(journal(), sql(), changed)
+    expect(after.currentEpoch).toBe(before.currentEpoch)
+    expect(after.migrationSetDigest).not.toBe(before.migrationSetDigest)
+  })
+
+  it('snapshots all SQL bytes before yielding and never retains caller input', async () => {
+    const input = sql(); const sourceInput = sources(); const journalInput = journal()
+    const baseline = await createD1MigrationSetEvidence(journal(), sql(), sources())
+    const pending = createD1MigrationSetEvidence(journalInput, input, sourceInput)
+    input[0].bytes.fill(255); input.reverse(); sourceInput[1].bytes.fill(255); sourceInput.reverse()
+    journalInput.entries[1].tag = '0001_mutated'; journalInput.entries.reverse()
+    await expect(pending).resolves.toEqual(baseline)
+  })
+
+  it('rejects journal and SQL accessors, hidden keys, symbols, holes, and custom properties', async () => {
+    let reads = 0
+    const accessor = journal(); Object.defineProperty(accessor.entries[0], 'tag', { enumerable: true, get: () => { reads += 1; return '0000_first' } })
+    await rejectsEvidence(accessor); expect(reads).toBe(0)
+    const hidden = journal(); Object.defineProperty(hidden.entries[0], 'secret', { value: CANARY }); await rejectsEvidence(hidden)
+    const symbol = journal(); (symbol.entries[0] as Record<PropertyKey, unknown>)[Symbol('secret')] = CANARY; await rejectsEvidence(symbol)
+    await rejectsEvidence({ version: '7', dialect: 'postgresql', entries: new Array(2) })
+    const custom = journal(); Object.defineProperty(custom.entries, 'toJSON', { enumerable: true, value: () => [] }); await rejectsEvidence(custom)
+    await rejectsEvidence(Object.assign(Object.create({ inherited: true }), journal()))
+  })
+
+  it('maps migration canaries to one stable redacted failure', async () => {
+    try { await createD1MigrationSetEvidence({ ...journal(), version: CANARY }, sql(), sources()); throw new Error('accepted') }
+    catch (error) {
+      expect(error).toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY, message: D1HostErrorCode.COLLECTION_NOT_READY,
+        details: { field: 'databaseSchemaCompatibility' } })
+      expect(JSON.stringify(error)).not.toContain(CANARY)
+      expect(String(error)).not.toContain(CANARY)
+    }
+  })
+})
+
+describe('approved release matching', () => {
+  it('matches independently derived migration evidence and all expected release identities', async () => {
+    const evidence = await createD1MigrationSetEvidence(journal(), sql(), sources())
+    const value = release(); value.databaseSchemaCompatibility.migrationSetDigest = evidence.migrationSetDigest
+    const expected = { hostAppImageDigest: digest('a'), ingressImageDigest: digest('b'), caddyfileDigest: digest('c'),
+      hostSecurityConfigDigest: digest('d'), selectorInventoryRevision: revision('a'), executionPolicyRevision: revision('b'), migrationEvidence: evidence }
+    await expect(validateApprovedD1HostRelease(value, expected)).resolves.toEqual(value)
+  })
+
+  it.each(['hostAppImageDigest', 'ingressImageDigest', 'caddyfileDigest', 'hostSecurityConfigDigest'] as const)
+  ('rejects expected %s mismatch as an approved-release failure', async (field) => {
+    const evidence = await createD1MigrationSetEvidence(journal(), sql(), sources()); const value = release()
+    value.databaseSchemaCompatibility.migrationSetDigest = evidence.migrationSetDigest
+    const expected = { hostAppImageDigest: digest('a'), ingressImageDigest: digest('b'), caddyfileDigest: digest('c'),
+      hostSecurityConfigDigest: digest('d'), selectorInventoryRevision: revision('a'), executionPolicyRevision: revision('b'), migrationEvidence: evidence,
+      [field]: digest('f') }
+    await expect(validateApprovedD1HostRelease(value, expected)).rejects.toMatchObject({
+      details: { field: 'approvedHostRelease' },
+    })
+  })
+
+  it.each(['selectorInventoryRevision', 'executionPolicyRevision'] as const)
+  ('rejects expected %s mismatch as an approved-release failure', async (field) => {
+    const evidence = await createD1MigrationSetEvidence(journal(), sql(), sources()); const value = release()
+    value.databaseSchemaCompatibility.migrationSetDigest = evidence.migrationSetDigest
+    const expected = { hostAppImageDigest: digest('a'), ingressImageDigest: digest('b'), caddyfileDigest: digest('c'),
+      hostSecurityConfigDigest: digest('d'), selectorInventoryRevision: revision('a'), executionPolicyRevision: revision('b'), migrationEvidence: evidence,
+      [field]: revision('c') }
+    await expect(validateApprovedD1HostRelease(value, expected)).rejects.toMatchObject({ details: { field: 'approvedHostRelease' } })
+  })
+
+  it('rejects migration digest and epoch mismatches as database compatibility failures', async () => {
+    const evidence = await createD1MigrationSetEvidence(journal(), sql(), sources())
+    const expected = { hostAppImageDigest: digest('a'), ingressImageDigest: digest('b'), caddyfileDigest: digest('c'),
+      hostSecurityConfigDigest: digest('d'), selectorInventoryRevision: revision('a'), executionPolicyRevision: revision('b'), migrationEvidence: evidence }
+    await expect(validateApprovedD1HostRelease(release(), expected)).rejects.toMatchObject({ details: { field: 'databaseSchemaCompatibility' } })
+    const value = release(); value.databaseSchemaCompatibility.migrationSetDigest = evidence.migrationSetDigest; value.databaseSchemaCompatibility.currentEpoch = 3
+    value.databaseSchemaCompatibility.readableEpochRange.max = 3
+    await expect(validateApprovedD1HostRelease(value, expected)).rejects.toMatchObject({ details: { field: 'databaseSchemaCompatibility' } })
+  })
+
+  it('rejects forged or internally inconsistent migration evidence', async () => {
+    const evidence = await createD1MigrationSetEvidence(journal(), sql(), sources())
+    const value = release(); value.databaseSchemaCompatibility.migrationSetDigest = evidence.migrationSetDigest
+    const identity = { hostAppImageDigest: digest('a'), ingressImageDigest: digest('b'), caddyfileDigest: digest('c'),
+      hostSecurityConfigDigest: digest('d'), selectorInventoryRevision: revision('a'), executionPolicyRevision: revision('b') }
+    const forged = { ...evidence, migrations: [], currentEpoch: 2 }
+    await expect(validateApprovedD1HostRelease(value, { ...identity, migrationEvidence: forged }))
+      .rejects.toMatchObject({ details: { field: 'databaseSchemaCompatibility' } })
+    const inconsistent = structuredClone(evidence); inconsistent.migrations[0]!.sqlDigest = digest('f') as never
+    await expect(validateApprovedD1HostRelease(value, { ...identity, migrationEvidence: inconsistent }))
+      .rejects.toMatchObject({ details: { field: 'databaseSchemaCompatibility' } })
+  })
+})

--- a/apps/full-app/src/server/deployment/__tests__/approvedHostRelease.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/approvedHostRelease.test.ts
@@ -257,7 +257,8 @@ describe('approved release matching', () => {
     const forged = { ...evidence, migrations: [], currentEpoch: 2 }
     await expect(validateApprovedD1HostRelease(value, { ...identity, migrationEvidence: forged }))
       .rejects.toMatchObject({ details: { field: 'databaseSchemaCompatibility' } })
-    const inconsistent = structuredClone(evidence); inconsistent.migrations[0]!.sqlDigest = digest('f') as never
+    const inconsistent = { ...evidence, migrations: evidence.migrations.map((migration, index) => index === 0
+      ? { ...migration, sqlDigest: digest('f') } : migration) }
     await expect(validateApprovedD1HostRelease(value, { ...identity, migrationEvidence: inconsistent }))
       .rejects.toMatchObject({ details: { field: 'databaseSchemaCompatibility' } })
   })

--- a/apps/full-app/src/server/deployment/approvedHostRelease.ts
+++ b/apps/full-app/src/server/deployment/approvedHostRelease.ts
@@ -1,0 +1,264 @@
+import { createAgentAssetDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
+
+import { D1HostError, D1HostErrorCode } from './d1Plan.js'
+
+const RELEASE_DOMAIN = 'boring-d1-approved-host-release:v1' as const
+const MIGRATION_DOMAIN = 'boring-d1-migration-set:v1' as const
+const SHA256 = /^sha256:[a-f0-9]{64}$/
+const REVISION = /^[a-f0-9]{40}$/
+const MIGRATION_TAG = /^[a-z0-9][a-z0-9_]{0,127}$/
+const DEPLOYMENT_MIGRATION_SOURCES = ['apps/full-app/src/server/migrate.ts', 'packages/core/src/server/migrations.ts',
+  'packages/core/src/server/db/migrate.ts', 'plugins/boring-automation/src/server/migrations.ts'] as const
+
+const RELEASE_KEYS = ['schemaVersion', 'domain', 'hostAppImageDigest', 'coreCommand', 'migrationProcess',
+  'ingressImageDigest', 'ingressCommand', 'caddyfileDigest', 'hostSecurityConfigDigest',
+  'selectorInventoryRevision', 'executionPolicyRevision', 'databaseSchemaCompatibility'] as const
+const EXPECTED_KEYS = ['hostAppImageDigest', 'ingressImageDigest', 'caddyfileDigest', 'hostSecurityConfigDigest',
+  'selectorInventoryRevision', 'executionPolicyRevision', 'migrationEvidence'] as const
+
+export interface ApprovedD1HostReleaseRecordV1 {
+  readonly schemaVersion: 1
+  readonly domain: typeof RELEASE_DOMAIN
+  readonly hostAppImageDigest: Sha256Digest
+  readonly coreCommand: Readonly<{ entrypoint: readonly ['/usr/local/bin/web-entrypoint']; cmd: readonly ['node', 'apps/full-app/dist/server/main.js'] }>
+  readonly migrationProcess: Readonly<{ entrypoint: readonly ['node']; cmd: readonly ['apps/full-app/dist/server/migrate.js']; user: '10001:10001'; readonlyRootfs: true; privileged: false; noNewPrivileges: true; addedCapabilities: readonly [] }>
+  readonly ingressImageDigest: Sha256Digest
+  readonly ingressCommand: Readonly<{ entrypoint: null; cmd: readonly ['caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile'] }>
+  readonly caddyfileDigest: Sha256Digest
+  readonly hostSecurityConfigDigest: Sha256Digest
+  readonly selectorInventoryRevision: string
+  readonly executionPolicyRevision: string
+  readonly databaseSchemaCompatibility: Readonly<{ migrationSetDigest: Sha256Digest; currentEpoch: number; readableEpochRange: Readonly<{ min: number; max: number }>; readableByPreviousRelease: boolean }>
+}
+
+export interface D1MigrationSetEvidenceV1 {
+  readonly schemaVersion: 1
+  readonly domain: typeof MIGRATION_DOMAIN
+  readonly currentEpoch: number
+  readonly migrationSetDigest: Sha256Digest
+  readonly migrations: readonly Readonly<{ idx: number; version: string; when: number; tag: string; breakpoints: boolean; file: string; sqlDigest: Sha256Digest }>[]
+  readonly deploymentSources: readonly Readonly<{ file: string; sourceDigest: Sha256Digest }>[]
+}
+
+export interface ExpectedD1HostReleaseV1 {
+  readonly hostAppImageDigest: Sha256Digest
+  readonly ingressImageDigest: Sha256Digest
+  readonly caddyfileDigest: Sha256Digest
+  readonly hostSecurityConfigDigest: Sha256Digest
+  readonly selectorInventoryRevision: string
+  readonly executionPolicyRevision: string
+  readonly migrationEvidence: D1MigrationSetEvidenceV1
+}
+
+function fail(field: 'approvedHostRelease' | 'databaseSchemaCompatibility'): never {
+  throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field })
+}
+
+function dataRecord(value: unknown, expected: readonly string[]): Readonly<Record<string, unknown>> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error()
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) throw new Error()
+  const keys = Reflect.ownKeys(value)
+  if (keys.some((key) => typeof key !== 'string') || keys.length !== expected.length || expected.some((key) => !keys.includes(key))) throw new Error()
+  const snapshot: Record<string, unknown> = {}
+  for (const key of expected) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value')) throw new Error()
+    snapshot[key] = descriptor.value
+  }
+  return Object.freeze(snapshot)
+}
+
+function dataArray(value: unknown, maxLength = 10_000): readonly unknown[] {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) throw new Error()
+  const length = Object.getOwnPropertyDescriptor(value, 'length')
+  if (!length || !Object.hasOwn(length, 'value') || !Number.isSafeInteger(length.value) || length.value < 0 || length.value > maxLength) throw new Error()
+  const indices = Array.from({ length: length.value }, (_, index) => String(index))
+  const keys = Reflect.ownKeys(value)
+  if (keys.some((key) => typeof key !== 'string') || keys.length !== indices.length + 1 || !keys.includes('length') || indices.some((key) => !keys.includes(key))) throw new Error()
+  return Object.freeze(indices.map((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value')) throw new Error()
+    return descriptor.value
+  }))
+}
+
+function exactArray(value: unknown, expected: readonly unknown[]): readonly unknown[] {
+  const actual = dataArray(value, expected.length)
+  if (actual.length !== expected.length || actual.some((item, index) => item !== expected[index])) throw new Error()
+  return Object.freeze([...expected])
+}
+
+function digest(value: unknown): Sha256Digest {
+  if (typeof value !== 'string' || !SHA256.test(value)) throw new Error()
+  return value as Sha256Digest
+}
+
+function revision(value: unknown): string {
+  if (typeof value !== 'string' || !REVISION.test(value)) throw new Error()
+  return value
+}
+
+function epoch(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) throw new Error()
+  return value
+}
+
+function parseRelease(value: unknown): ApprovedD1HostReleaseRecordV1 {
+  const input = dataRecord(value, RELEASE_KEYS)
+  const core = dataRecord(input.coreCommand, ['entrypoint', 'cmd'])
+  const migration = dataRecord(input.migrationProcess, ['entrypoint', 'cmd', 'user', 'readonlyRootfs', 'privileged', 'noNewPrivileges', 'addedCapabilities'])
+  const ingress = dataRecord(input.ingressCommand, ['entrypoint', 'cmd'])
+  const compatibility = dataRecord(input.databaseSchemaCompatibility, ['migrationSetDigest', 'currentEpoch', 'readableEpochRange', 'readableByPreviousRelease'])
+  const range = dataRecord(compatibility.readableEpochRange, ['min', 'max'])
+  if (input.schemaVersion !== 1 || input.domain !== RELEASE_DOMAIN || migration.user !== '10001:10001'
+    || migration.readonlyRootfs !== true || migration.privileged !== false || migration.noNewPrivileges !== true
+    || ingress.entrypoint !== null || typeof compatibility.readableByPreviousRelease !== 'boolean') throw new Error()
+  const currentEpoch = epoch(compatibility.currentEpoch); const min = epoch(range.min); const max = epoch(range.max)
+  if (min > max || max !== currentEpoch) throw new Error()
+  return Object.freeze({
+    schemaVersion: 1, domain: RELEASE_DOMAIN, hostAppImageDigest: digest(input.hostAppImageDigest),
+    coreCommand: Object.freeze({ entrypoint: exactArray(core.entrypoint, ['/usr/local/bin/web-entrypoint']) as ['/usr/local/bin/web-entrypoint'],
+      cmd: exactArray(core.cmd, ['node', 'apps/full-app/dist/server/main.js']) as ['node', 'apps/full-app/dist/server/main.js'] }),
+    migrationProcess: Object.freeze({ entrypoint: exactArray(migration.entrypoint, ['node']) as ['node'],
+      cmd: exactArray(migration.cmd, ['apps/full-app/dist/server/migrate.js']) as ['apps/full-app/dist/server/migrate.js'], user: '10001:10001',
+      readonlyRootfs: true, privileged: false, noNewPrivileges: true, addedCapabilities: exactArray(migration.addedCapabilities, []) as [] }),
+    ingressImageDigest: digest(input.ingressImageDigest),
+    ingressCommand: Object.freeze({ entrypoint: null, cmd: exactArray(ingress.cmd, ['caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile']) as ['caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile'] }),
+    caddyfileDigest: digest(input.caddyfileDigest), hostSecurityConfigDigest: digest(input.hostSecurityConfigDigest),
+    selectorInventoryRevision: revision(input.selectorInventoryRevision), executionPolicyRevision: revision(input.executionPolicyRevision),
+    databaseSchemaCompatibility: Object.freeze({ migrationSetDigest: digest(compatibility.migrationSetDigest), currentEpoch,
+      readableEpochRange: Object.freeze({ min, max }), readableByPreviousRelease: compatibility.readableByPreviousRelease }),
+  })
+}
+
+export function decodeApprovedD1HostReleaseRecord(value: unknown): ApprovedD1HostReleaseRecordV1 {
+  try { return parseRelease(value) } catch { return fail('approvedHostRelease') }
+}
+
+function snapshotBytes(value: unknown): Uint8Array {
+  if (!(value instanceof Uint8Array) || Object.getPrototypeOf(value) !== Uint8Array.prototype) throw new Error()
+  const keys = Reflect.ownKeys(value); const expected = Array.from({ length: value.length }, (_, index) => String(index))
+  if (keys.some((key) => typeof key !== 'string') || keys.length !== expected.length || expected.some((key) => !keys.includes(key))) throw new Error()
+  const copy = new Uint8Array(expected.length)
+  for (const key of expected) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value') || typeof descriptor.value !== 'number') throw new Error()
+    copy[Number(key)] = descriptor.value
+  }
+  return copy
+}
+
+async function rawDigest(bytes: Uint8Array): Promise<Sha256Digest> {
+  const result = await globalThis.crypto.subtle.digest('SHA-256', bytes)
+  return `sha256:${Array.from(new Uint8Array(result), (byte) => byte.toString(16).padStart(2, '0')).join('')}`
+}
+
+async function migrationEvidence(journalValue: unknown, sqlValue: unknown, sourceValue: unknown): Promise<D1MigrationSetEvidenceV1> {
+  const journal = dataRecord(journalValue, ['version', 'dialect', 'entries'])
+  if (journal.version !== '7' || journal.dialect !== 'postgresql') throw new Error()
+  const entries = dataArray(journal.entries)
+  let previousWhen = -1
+  const parsedEntries = entries.map((value, index) => {
+    const input = dataRecord(value, ['idx', 'version', 'when', 'tag', 'breakpoints'])
+    if (input.idx !== index || input.version !== journal.version || typeof input.breakpoints !== 'boolean'
+      || typeof input.tag !== 'string' || !MIGRATION_TAG.test(input.tag)
+      || !input.tag.startsWith(`${String(index).padStart(4, '0')}_`)) throw new Error()
+    const when = epoch(input.when)
+    if (when <= previousWhen) throw new Error()
+    previousWhen = when
+    return Object.freeze({ idx: index, version: journal.version as string, when, tag: input.tag, breakpoints: input.breakpoints })
+  })
+  const sqlInputs = dataArray(sqlValue)
+  const sqlByFile = new Map<string, Uint8Array>()
+  for (const value of sqlInputs) {
+    const input = dataRecord(value, ['file', 'bytes'])
+    if (typeof input.file !== 'string' || sqlByFile.has(input.file)) throw new Error()
+    sqlByFile.set(input.file, snapshotBytes(input.bytes))
+  }
+  const sourceInputs = dataArray(sourceValue, DEPLOYMENT_MIGRATION_SOURCES.length)
+  const sourceByFile = new Map<string, Uint8Array>()
+  for (const value of sourceInputs) {
+    const input = dataRecord(value, ['file', 'bytes'])
+    if (typeof input.file !== 'string' || sourceByFile.has(input.file) || !DEPLOYMENT_MIGRATION_SOURCES.includes(input.file as never)) throw new Error()
+    sourceByFile.set(input.file, snapshotBytes(input.bytes))
+  }
+  if (sourceByFile.size !== DEPLOYMENT_MIGRATION_SOURCES.length) throw new Error()
+  const migrations: Array<{ idx: number; version: string; when: number; tag: string; breakpoints: boolean; file: string; sqlDigest: Sha256Digest }> = []
+  for (const entry of parsedEntries) {
+    const file = `${entry.tag}.sql`; const bytes = sqlByFile.get(file)
+    if (!bytes) throw new Error()
+    sqlByFile.delete(file)
+    migrations.push(Object.freeze({ ...entry, file, sqlDigest: await rawDigest(bytes) }))
+  }
+  if (sqlByFile.size !== 0 || sqlInputs.length !== entries.length) throw new Error()
+  const frozenMigrations = Object.freeze(migrations)
+  const deploymentSources = Object.freeze(await Promise.all(DEPLOYMENT_MIGRATION_SOURCES.map(async (file) => Object.freeze({
+    file, sourceDigest: await rawDigest(sourceByFile.get(file) as Uint8Array),
+  }))))
+  const manifest = Object.freeze({ schemaVersion: 1 as const, domain: MIGRATION_DOMAIN, journalVersion: journal.version,
+    dialect: journal.dialect, migrations: frozenMigrations, deploymentSources })
+  return Object.freeze({ schemaVersion: 1, domain: MIGRATION_DOMAIN, currentEpoch: entries.length,
+    migrationSetDigest: await createAgentAssetDigest(JSON.stringify(manifest)), migrations: frozenMigrations, deploymentSources })
+}
+
+export async function createD1MigrationSetEvidence(journal: unknown, sqlEntries: unknown, deploymentSources: unknown): Promise<D1MigrationSetEvidenceV1> {
+  try { return await migrationEvidence(journal, sqlEntries, deploymentSources) } catch { return fail('databaseSchemaCompatibility') }
+}
+
+async function validateMigrationEvidence(value: unknown): Promise<Readonly<{ currentEpoch: number; migrationSetDigest: Sha256Digest }>> {
+  const evidence = dataRecord(value, ['schemaVersion', 'domain', 'currentEpoch', 'migrationSetDigest', 'migrations', 'deploymentSources'])
+  if (evidence.schemaVersion !== 1 || evidence.domain !== MIGRATION_DOMAIN) throw new Error()
+  const values = dataArray(evidence.migrations); const currentEpoch = epoch(evidence.currentEpoch)
+  if (currentEpoch !== values.length) throw new Error()
+  let previousWhen = -1
+  const migrations = Object.freeze(values.map((value, index) => {
+    const input = dataRecord(value, ['idx', 'version', 'when', 'tag', 'breakpoints', 'file', 'sqlDigest'])
+    if (input.idx !== index || input.version !== '7' || typeof input.breakpoints !== 'boolean'
+      || typeof input.tag !== 'string' || !MIGRATION_TAG.test(input.tag) || !input.tag.startsWith(`${String(index).padStart(4, '0')}_`)
+      || input.file !== `${input.tag}.sql`) throw new Error()
+    const when = epoch(input.when)
+    if (when <= previousWhen) throw new Error()
+    previousWhen = when
+    return Object.freeze({ idx: index, version: '7', when, tag: input.tag, breakpoints: input.breakpoints,
+      file: input.file, sqlDigest: digest(input.sqlDigest) })
+  }))
+  const sourceValues = dataArray(evidence.deploymentSources, DEPLOYMENT_MIGRATION_SOURCES.length)
+  if (sourceValues.length !== DEPLOYMENT_MIGRATION_SOURCES.length) throw new Error()
+  const deploymentSources = Object.freeze(sourceValues.map((value, index) => {
+    const source = dataRecord(value, ['file', 'sourceDigest']); const file = DEPLOYMENT_MIGRATION_SOURCES[index]
+    if (source.file !== file) throw new Error()
+    return Object.freeze({ file, sourceDigest: digest(source.sourceDigest) })
+  }))
+  const manifest = Object.freeze({ schemaVersion: 1 as const, domain: MIGRATION_DOMAIN, journalVersion: '7',
+    dialect: 'postgresql', migrations, deploymentSources })
+  const migrationSetDigest = digest(evidence.migrationSetDigest)
+  if (await createAgentAssetDigest(JSON.stringify(manifest)) !== migrationSetDigest) throw new Error()
+  return Object.freeze({ currentEpoch, migrationSetDigest })
+}
+
+export async function validateApprovedD1HostRelease(recordValue: unknown, expectedValue: unknown): Promise<ApprovedD1HostReleaseRecordV1> {
+  const record = decodeApprovedD1HostReleaseRecord(recordValue)
+  let expected: Readonly<Record<string, unknown>>
+  try {
+    expected = dataRecord(expectedValue, EXPECTED_KEYS)
+    const releaseMatches = record.hostAppImageDigest === digest(expected.hostAppImageDigest)
+      && record.ingressImageDigest === digest(expected.ingressImageDigest) && record.caddyfileDigest === digest(expected.caddyfileDigest)
+      && record.hostSecurityConfigDigest === digest(expected.hostSecurityConfigDigest)
+      && record.selectorInventoryRevision === revision(expected.selectorInventoryRevision)
+      && record.executionPolicyRevision === revision(expected.executionPolicyRevision)
+    if (!releaseMatches) return fail('approvedHostRelease')
+  } catch (error) {
+    if (error instanceof D1HostError) throw error
+    return fail('approvedHostRelease')
+  }
+  try {
+    const evidence = await validateMigrationEvidence(expected.migrationEvidence)
+    if (record.databaseSchemaCompatibility.migrationSetDigest !== evidence.migrationSetDigest
+      || record.databaseSchemaCompatibility.currentEpoch !== evidence.currentEpoch) return fail('databaseSchemaCompatibility')
+    return record
+  } catch (error) {
+    if (error instanceof D1HostError) throw error
+    return fail('databaseSchemaCompatibility')
+  }
+}

--- a/apps/full-app/src/server/deployment/approvedHostRelease.ts
+++ b/apps/full-app/src/server/deployment/approvedHostRelease.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { createAgentAssetDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
 
 import { D1HostError, D1HostErrorCode } from './d1Plan.js'
@@ -149,9 +150,8 @@ function snapshotBytes(value: unknown): Uint8Array {
   return copy
 }
 
-async function rawDigest(bytes: Uint8Array): Promise<Sha256Digest> {
-  const result = await globalThis.crypto.subtle.digest('SHA-256', bytes)
-  return `sha256:${Array.from(new Uint8Array(result), (byte) => byte.toString(16).padStart(2, '0')).join('')}`
+function rawDigest(bytes: Uint8Array): Sha256Digest {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`
 }
 
 async function migrationEvidence(journalValue: unknown, sqlValue: unknown, sourceValue: unknown): Promise<D1MigrationSetEvidenceV1> {


### PR DESCRIPTION
## D1-005a2a boundary

Adds the pure, read-only approved host release record codec and canonical migration-set evidence. This slice performs no filesystem reads, Docker/image inspection, OCI-label checks, database queries, container/Compose mutation, capability minting, or publication/admission work.

## Migration closure

The migration-set digest binds the Drizzle v7 PostgreSQL journal, every raw SQL migration byte sequence, and the exact fixed source closure in canonical order:

- `apps/full-app/src/server/migrate.ts`
- `packages/core/src/server/migrations.ts`
- `packages/core/src/server/db/migrate.ts`
- `plugins/boring-automation/src/server/migrations.ts`

Programmatic/runner sources change the migration-set digest but do not increment the Drizzle epoch. The matcher strictly decodes and recomputes the manifest rather than trusting record-declared evidence.

## Downstream

- D1-005a2b owns root-owned approved-record loading, exact image revision plus OCI migration-label binding, Caddy/image inspection, and the non-serializable same-attempt capability.
- D1-005b owns the actual prior/new-release database compatibility rehearsal and observed execution attestation.

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/approvedHostRelease.test.ts` (56/56)
- `pnpm --filter full-app typecheck`
- `git diff --check origin/main..HEAD`
- reviewed patch identity preserved across rebase: `24147c335ac15c853bff8ff839bb092afc38fcd6`
- autoreview: codec/evidence findings resolved; remaining capability and live-compatibility comments are explicitly assigned to D1-005a2b/D1-005b above.