### PR TITLE
feat(d1): bind migration evidence to release image

### DIFF
--- a/.github/workflows/self-host-full-app-image.yml
+++ b/.github/workflows/self-host-full-app-image.yml
@@ -6,6 +6,9 @@ on:
       - '.github/workflows/self-host-full-app-image.yml'
       - 'apps/full-app/**'
       - 'packages/**'
+      - 'plugins/boring-automation/**'
+      - 'scripts/self-host/d1-migration-evidence.mjs'
+      - 'scripts/self-host/verify-deploy-manifest.mjs'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'package.json'
@@ -19,6 +22,9 @@ on:
       - '.github/workflows/self-host-full-app-image.yml'
       - 'apps/full-app/**'
       - 'packages/**'
+      - 'plugins/boring-automation/**'
+      - 'scripts/self-host/d1-migration-evidence.mjs'
+      - 'scripts/self-host/verify-deploy-manifest.mjs'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
       - 'package.json'
@@ -69,6 +75,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
+      - name: Compute D1 migration evidence
+        id: migration-evidence
+        run: node scripts/self-host/d1-migration-evidence.mjs --github-output >> "$GITHUB_OUTPUT"
+
       - name: Install
         run: pnpm install --frozen-lockfile
 
@@ -80,6 +90,9 @@ jobs:
 
       - name: Test production safety guards
         run: pnpm --filter full-app exec vitest run src/server/__tests__/production-safety.test.ts
+
+      - name: Test D1 migration evidence parity
+        run: pnpm --filter full-app exec vitest run src/server/deployment/__tests__/migrationEvidenceCli.test.ts
 
       - name: Normalize image name
         id: image
@@ -96,6 +109,8 @@ jobs:
             --target web-runtime \
             --build-arg REVISION="${GITHUB_SHA}" \
             --build-arg SOURCE="https://github.com/${GITHUB_REPOSITORY}" \
+            --build-arg D1_MIGRATION_SET_DIGEST="${{ steps.migration-evidence.outputs.migration_set_digest }}" \
+            --build-arg D1_DATABASE_CURRENT_EPOCH="${{ steps.migration-evidence.outputs.current_epoch }}" \
             --label org.opencontainers.image.revision="${GITHUB_SHA}" \
             --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}" \
             --label service="boring-full-app" \
@@ -142,6 +157,8 @@ jobs:
           test "$(docker inspect --format '{{ index .Config.Labels "boring.role" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "web"
           test "$(docker inspect --format '{{ index .Config.Labels "service" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "boring-full-app"
           test "$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "${GITHUB_SHA}"
+          test "$(docker inspect --format '{{ index .Config.Labels "ai.senecapp.d1.migration-set-digest" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "${{ steps.migration-evidence.outputs.migration_set_digest }}"
+          test "$(docker inspect --format '{{ index .Config.Labels "ai.senecapp.d1.database-current-epoch" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "${{ steps.migration-evidence.outputs.current_epoch }}"
 
   publish-prod-image:
     name: Publish protected prod tag image
@@ -173,6 +190,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Compute D1 migration evidence
+        id: migration-evidence
+        run: node scripts/self-host/d1-migration-evidence.mjs --github-output >> "$GITHUB_OUTPUT"
+
       - name: Normalize image name
         id: image
         shell: bash
@@ -188,12 +214,23 @@ jobs:
             --target web-runtime \
             --build-arg REVISION="${GITHUB_SHA}" \
             --build-arg SOURCE="https://github.com/${GITHUB_REPOSITORY}" \
+            --build-arg D1_MIGRATION_SET_DIGEST="${{ steps.migration-evidence.outputs.migration_set_digest }}" \
+            --build-arg D1_DATABASE_CURRENT_EPOCH="${{ steps.migration-evidence.outputs.current_epoch }}" \
             --label org.opencontainers.image.revision="${GITHUB_SHA}" \
             --label org.opencontainers.image.source="https://github.com/${GITHUB_REPOSITORY}" \
             --label service="boring-full-app" \
             --label boring.role="web" \
             --tag "${{ steps.image.outputs.name }}:${GITHUB_SHA}" \
             .
+
+      - name: Verify production web image labels
+        shell: bash
+        run: |
+          test "$(docker inspect --format '{{ index .Config.Labels "boring.role" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "web"
+          test "$(docker inspect --format '{{ index .Config.Labels "service" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "boring-full-app"
+          test "$(docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "${GITHUB_SHA}"
+          test "$(docker inspect --format '{{ index .Config.Labels "ai.senecapp.d1.migration-set-digest" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "${{ steps.migration-evidence.outputs.migration_set_digest }}"
+          test "$(docker inspect --format '{{ index .Config.Labels "ai.senecapp.d1.database-current-epoch" }}' "${{ steps.image.outputs.name }}:${GITHUB_SHA}")" = "${{ steps.migration-evidence.outputs.current_epoch }}"
 
       - name: Smoke production image /health
         shell: bash
@@ -246,7 +283,7 @@ jobs:
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
           cat > deploy-manifest.json <<EOF
           {
-            "schemaVersion": 1,
+            "schemaVersion": 2,
             "repository": "${GITHUB_REPOSITORY}",
             "ref": "${GITHUB_REF}",
             "tag": "${tag}",
@@ -259,7 +296,9 @@ jobs:
             "role": "web",
             "migration": {
               "classification": "none",
-              "rollbackCompatible": true
+              "rollbackCompatible": true,
+              "migrationSetDigest": "${{ steps.migration-evidence.outputs.migration_set_digest }}",
+              "currentEpoch": ${{ steps.migration-evidence.outputs.current_epoch }}
             }
           }
           EOF

--- a/apps/full-app/Dockerfile
+++ b/apps/full-app/Dockerfile
@@ -61,9 +61,13 @@ FROM node:22-slim AS runtime
 WORKDIR /app
 ARG REVISION=unknown
 ARG SOURCE=https://github.com/hachej/boring-ui-v2
+ARG D1_MIGRATION_SET_DIGEST=unapproved
+ARG D1_DATABASE_CURRENT_EPOCH=unapproved
 LABEL org.opencontainers.image.source=$SOURCE \
   org.opencontainers.image.revision=$REVISION \
   org.opencontainers.image.title="boring-ui full-app" \
+  ai.senecapp.d1.migration-set-digest=$D1_MIGRATION_SET_DIGEST \
+  ai.senecapp.d1.database-current-epoch=$D1_DATABASE_CURRENT_EPOCH \
   boring.role="web"
 RUN apt-get update \
   && apt-get install -y --no-install-recommends bubblewrap ca-certificates util-linux \

--- a/apps/full-app/src/server/deployment/__tests__/migrationEvidenceCli.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/migrationEvidenceCli.test.ts
@@ -1,0 +1,49 @@
+import { execFile } from 'node:child_process'
+import { readFile, readdir } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { promisify } from 'node:util'
+import { describe, expect, it } from 'vitest'
+
+import { createD1MigrationSetEvidence } from '../approvedHostRelease.js'
+
+const execFileAsync = promisify(execFile)
+const REPOSITORY_ROOT = resolve(import.meta.dirname, '../../../../../..')
+const DRIZZLE_ROOT = resolve(REPOSITORY_ROOT, 'packages/core/drizzle')
+const EVIDENCE_SCRIPT = resolve(REPOSITORY_ROOT, 'scripts/self-host/d1-migration-evidence.mjs')
+const DEPLOYMENT_SOURCES = [
+  'apps/full-app/src/server/migrate.ts',
+  'packages/core/src/server/migrations.ts',
+  'packages/core/src/server/db/migrate.ts',
+  'plugins/boring-automation/src/server/migrations.ts',
+] as const
+
+const bytes = async (file: string) => new Uint8Array(await readFile(file))
+
+describe('D1 build migration evidence', () => {
+  it('matches the application codec for the exact real migration closure', async () => {
+    const journal = JSON.parse(await readFile(resolve(DRIZZLE_ROOT, 'meta/_journal.json'), 'utf8'))
+    const sqlFiles = (await readdir(DRIZZLE_ROOT)).filter((file) => file.endsWith('.sql')).sort()
+    const applicationEvidence = await createD1MigrationSetEvidence(
+      journal,
+      await Promise.all(sqlFiles.map(async (file) => ({ file, bytes: await bytes(resolve(DRIZZLE_ROOT, file)) }))),
+      await Promise.all(DEPLOYMENT_SOURCES.map(async (file) => ({ file, bytes: await bytes(resolve(REPOSITORY_ROOT, file)) }))),
+    )
+    const { stdout, stderr } = await execFileAsync(process.execPath, [EVIDENCE_SCRIPT], { cwd: REPOSITORY_ROOT })
+    const buildEvidence = JSON.parse(stdout)
+
+    expect(stderr).toBe('')
+    expect(buildEvidence).toEqual(applicationEvidence)
+    expect(buildEvidence.deploymentSources.map((source: { file: string }) => source.file)).toEqual(DEPLOYMENT_SOURCES)
+    expect(buildEvidence.currentEpoch).toBe(sqlFiles.length)
+  })
+
+  it('emits only bounded digest and epoch GitHub outputs', async () => {
+    const { stdout, stderr } = await execFileAsync(process.execPath, [EVIDENCE_SCRIPT, '--github-output'], { cwd: REPOSITORY_ROOT })
+    const lines = stdout.trim().split('\n')
+
+    expect(stderr).toBe('')
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toMatch(/^migration_set_digest=sha256:[a-f0-9]{64}$/)
+    expect(lines[1]).toMatch(/^current_epoch=[0-9]+$/)
+  })
+})

--- a/scripts/self-host/d1-migration-evidence.mjs
+++ b/scripts/self-host/d1-migration-evidence.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import { createHash } from 'node:crypto'
+import { readFileSync, readdirSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const MIGRATION_DOMAIN = 'boring-d1-migration-set:v1'
+const MIGRATION_TAG = /^[a-z0-9][a-z0-9_]{0,127}$/
+const INVALID_EVIDENCE = 'D1 migration evidence is invalid'
+
+export const D1_DEPLOYMENT_MIGRATION_SOURCES = Object.freeze([
+  'apps/full-app/src/server/migrate.ts',
+  'packages/core/src/server/migrations.ts',
+  'packages/core/src/server/db/migrate.ts',
+  'plugins/boring-automation/src/server/migrations.ts',
+])
+
+function fail() {
+  throw new Error(INVALID_EVIDENCE)
+}
+
+function dataRecord(value, expected) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) fail()
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) fail()
+  const keys = Reflect.ownKeys(value)
+  if (keys.some((key) => typeof key !== 'string') || keys.length !== expected.length
+    || expected.some((key) => !keys.includes(key))) fail()
+  const snapshot = {}
+  for (const key of expected) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value')) fail()
+    snapshot[key] = descriptor.value
+  }
+  return snapshot
+}
+
+function dataArray(value, maxLength = 10_000) {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) fail()
+  const length = Object.getOwnPropertyDescriptor(value, 'length')
+  if (!length || !Object.hasOwn(length, 'value') || !Number.isSafeInteger(length.value)
+    || length.value < 0 || length.value > maxLength) fail()
+  const indices = Array.from({ length: length.value }, (_, index) => String(index))
+  const keys = Reflect.ownKeys(value)
+  if (keys.some((key) => typeof key !== 'string') || keys.length !== indices.length + 1
+    || !keys.includes('length') || indices.some((key) => !keys.includes(key))) fail()
+  return indices.map((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value')) fail()
+    return descriptor.value
+  })
+}
+
+function epoch(value) {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) fail()
+  return value
+}
+
+function rawDigest(bytes) {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`
+}
+
+function createEvidence(journalValue, sqlEntries, deploymentSourceEntries) {
+  const journal = dataRecord(journalValue, ['version', 'dialect', 'entries'])
+  if (journal.version !== '7' || journal.dialect !== 'postgresql') fail()
+  const entries = dataArray(journal.entries)
+  let previousWhen = -1
+  const parsedEntries = entries.map((value, index) => {
+    const input = dataRecord(value, ['idx', 'version', 'when', 'tag', 'breakpoints'])
+    if (input.idx !== index || input.version !== journal.version || typeof input.breakpoints !== 'boolean'
+      || typeof input.tag !== 'string' || !MIGRATION_TAG.test(input.tag)
+      || !input.tag.startsWith(`${String(index).padStart(4, '0')}_`)) fail()
+    const when = epoch(input.when)
+    if (when <= previousWhen) fail()
+    previousWhen = when
+    return { idx: index, version: journal.version, when, tag: input.tag, breakpoints: input.breakpoints }
+  })
+
+  const sqlByFile = new Map()
+  for (const input of sqlEntries) {
+    if (typeof input.file !== 'string' || sqlByFile.has(input.file)) fail()
+    sqlByFile.set(input.file, input.bytes)
+  }
+  const sourceByFile = new Map()
+  for (const input of deploymentSourceEntries) {
+    if (typeof input.file !== 'string' || sourceByFile.has(input.file)
+      || !D1_DEPLOYMENT_MIGRATION_SOURCES.includes(input.file)) fail()
+    sourceByFile.set(input.file, input.bytes)
+  }
+  if (sourceByFile.size !== D1_DEPLOYMENT_MIGRATION_SOURCES.length) fail()
+
+  const migrations = parsedEntries.map((entry) => {
+    const file = `${entry.tag}.sql`
+    const bytes = sqlByFile.get(file)
+    if (!bytes) fail()
+    sqlByFile.delete(file)
+    return { ...entry, file, sqlDigest: rawDigest(bytes) }
+  })
+  if (sqlByFile.size !== 0 || sqlEntries.length !== entries.length) fail()
+  const deploymentSources = D1_DEPLOYMENT_MIGRATION_SOURCES.map((file) => ({
+    file,
+    sourceDigest: rawDigest(sourceByFile.get(file)),
+  }))
+  const manifest = {
+    schemaVersion: 1,
+    domain: MIGRATION_DOMAIN,
+    journalVersion: journal.version,
+    dialect: journal.dialect,
+    migrations,
+    deploymentSources,
+  }
+  return {
+    schemaVersion: 1,
+    domain: MIGRATION_DOMAIN,
+    currentEpoch: entries.length,
+    migrationSetDigest: rawDigest(JSON.stringify(manifest)),
+    migrations,
+    deploymentSources,
+  }
+}
+
+export function createD1MigrationSetEvidenceFromRepository(repositoryRoot) {
+  try {
+    const drizzleRoot = resolve(repositoryRoot, 'packages/core/drizzle')
+    const journal = JSON.parse(readFileSync(resolve(drizzleRoot, 'meta/_journal.json'), 'utf8'))
+    const sqlEntries = readdirSync(drizzleRoot)
+      .filter((file) => file.endsWith('.sql'))
+      .sort()
+      .map((file) => ({ file, bytes: readFileSync(resolve(drizzleRoot, file)) }))
+    const deploymentSources = D1_DEPLOYMENT_MIGRATION_SOURCES.map((file) => ({
+      file,
+      bytes: readFileSync(resolve(repositoryRoot, file)),
+    }))
+    return createEvidence(journal, sqlEntries, deploymentSources)
+  } catch {
+    fail()
+  }
+}
+
+function parseArgs(argv) {
+  if (argv.length === 0) return {}
+  if (argv.length === 1 && argv[0] === '--github-output') return { githubOutput: true }
+  fail()
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv)
+  const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..')
+  const evidence = createD1MigrationSetEvidenceFromRepository(repositoryRoot)
+  if (args.githubOutput) {
+    process.stdout.write(`migration_set_digest=${evidence.migrationSetDigest}\ncurrent_epoch=${evidence.currentEpoch}\n`)
+  } else {
+    process.stdout.write(`${JSON.stringify(evidence)}\n`)
+  }
+  return 0
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    process.exitCode = main()
+  } catch {
+    console.error(`ERR ${INVALID_EVIDENCE}`)
+    process.exitCode = 1
+  }
+}

--- a/scripts/self-host/verify-deploy-manifest.mjs
+++ b/scripts/self-host/verify-deploy-manifest.mjs
@@ -37,7 +37,7 @@ export function validateDeployManifest(manifest, options) {
   if (errors.length > 0) return { ok: false, errors }
 
   check(() => {
-    if (manifest.schemaVersion !== 1) fail('schemaVersion must be 1')
+    if (manifest.schemaVersion !== 1 && manifest.schemaVersion !== 2) fail('schemaVersion must be 1 or 2')
   })
 
   const fields = ['repository', 'ref', 'tag', 'commit', 'workflow', 'workflowRunId', 'image', 'digest', 'target', 'role']
@@ -108,10 +108,24 @@ export function validateDeployManifest(manifest, options) {
       fail('migration.classification must be a non-empty string')
     }
   })
+  if (manifest.schemaVersion === 2) {
+    check(() => {
+      if (!DIGEST_RE.test(manifest.migration?.migrationSetDigest)) {
+        fail('migration.migrationSetDigest must be a sha256 digest')
+      }
+    })
+    check(() => {
+      if (!Number.isSafeInteger(manifest.migration?.currentEpoch) || manifest.migration.currentEpoch < 0) {
+        fail('migration.currentEpoch must be a non-negative safe integer')
+      }
+    })
+  }
 
-  return errors.length === 0
-    ? { ok: true, image, digest, tag, commit, repository, workflow, workflowRunId }
-    : { ok: false, errors }
+  if (errors.length > 0) return { ok: false, errors }
+  const result = { ok: true, image, digest, tag, commit, repository, workflow, workflowRunId }
+  return manifest.schemaVersion === 2
+    ? { ...result, migrationSetDigest: manifest.migration.migrationSetDigest, currentEpoch: manifest.migration.currentEpoch }
+    : result
 }
 
 function parseArgs(argv) {

--- a/scripts/self-host/verify-deploy-manifest.test.mjs
+++ b/scripts/self-host/verify-deploy-manifest.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict'
 import { validateDeployManifest } from './verify-deploy-manifest.mjs'
 
 const validManifest = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   repository: 'hachej/boring-ui',
   ref: 'refs/tags/prod-2026-06-21-001',
   tag: 'prod-2026-06-21-001',
@@ -17,6 +17,8 @@ const validManifest = {
   migration: {
     classification: 'none',
     rollbackCompatible: true,
+    migrationSetDigest: 'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    currentEpoch: 20,
   },
 }
 
@@ -26,10 +28,24 @@ const options = {
   workflow: 'Self-host full-app image',
 }
 
-test('accepts a valid deploy manifest', () => {
+test('accepts a valid v2 deploy manifest and returns migration evidence', () => {
   const result = validateDeployManifest(validManifest, options)
   assert.equal(result.ok, true)
   assert.equal(result.digest, validManifest.digest)
+  assert.equal(result.migrationSetDigest, validManifest.migration.migrationSetDigest)
+  assert.equal(result.currentEpoch, validManifest.migration.currentEpoch)
+})
+
+test('retains the v1 manifest contract without requiring migration evidence', () => {
+  const manifest = {
+    ...validManifest,
+    schemaVersion: 1,
+    migration: { classification: 'none', rollbackCompatible: true },
+  }
+  const result = validateDeployManifest(manifest, options)
+  assert.equal(result.ok, true)
+  assert.equal('migrationSetDigest' in result, false)
+  assert.equal('currentEpoch' in result, false)
 })
 
 test('rejects non-prod tags and mismatched refs', () => {
@@ -58,13 +74,13 @@ test('rejects repository image and digest mismatches', () => {
   assert.match(result.errors.join('\n'), /digest must be a sha256 digest/)
 })
 
-test('rejects unsafe target role or migration policy', () => {
+test('rejects unsafe target role or v2 migration policy', () => {
   const result = validateDeployManifest(
     {
       ...validManifest,
       target: 'worker-runtime',
       role: 'worker',
-      migration: { classification: '', rollbackCompatible: false },
+      migration: { classification: '', rollbackCompatible: false, migrationSetDigest: 'not-a-digest', currentEpoch: -1 },
     },
     options,
   )
@@ -73,4 +89,6 @@ test('rejects unsafe target role or migration policy', () => {
   assert.match(result.errors.join('\n'), /role must be web/)
   assert.match(result.errors.join('\n'), /rollbackCompatible must be true/)
   assert.match(result.errors.join('\n'), /classification must be a non-empty string/)
+  assert.match(result.errors.join('\n'), /migrationSetDigest must be a sha256 digest/)
+  assert.match(result.errors.join('\n'), /currentEpoch must be a non-negative safe integer/)
 })


### PR DESCRIPTION
## Summary

Binds the exact D1 migration closure to protected web-image builds, OCI labels, and deploy-manifest v2. The stdlib build evidence is parity-tested against the application codec and emits only the aggregate digest and epoch to GitHub Actions.

## Boundary

- Includes migration evidence derivation, protected workflow binding, web OCI labels, and version-aware deploy-manifest validation.
- Preserves schemaVersion 1 manifest verification under its existing rules.
- Preserves migration classification `none` and `rollbackCompatible: true`; this bead does not infer compatibility from structural evidence.
- Excludes approved-host-release filesystem/capability minting, runtime Docker/Caddy inspection, Compose/container/DB mutation, and compatibility execution proof.

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/migrationEvidenceCli.test.ts src/server/deployment/__tests__/approvedHostRelease.test.ts` - 58 passed.
- `node --test scripts/self-host/verify-deploy-manifest.test.mjs` - 5 passed, including v1 regression and v2 evidence validation.
- `pnpm --filter full-app run typecheck` - passed.
- `pnpm check:action-pins` - passed.
- `git diff --check 5765fd8d1c87d70d72dca4ba896e1a475151fec1..HEAD` - passed.

## Review

Structured review found the protected workflow was not running the parity proof; fixed. Independent HIGH review required manifest v2 with retained v1 verification and rejected inferring expand-only compatibility here; fixed. Final child diff was reviewed against those accepted rulings.

## Risk / Rollback

Aggregate labels are trusted only with the protected checkout build, image digest/revision provenance, and downstream root-approved comparison. Rollback is the single child commit.

## Next

D1-005a2b2 compares these labels and revision to the root-approved release and mints the nonserializable capability. D1-005b performs actual database compatibility and observed execution proof.