### PR TITLE
feat(d1): isolate approved release authority file

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/approvedHostReleaseFile.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/approvedHostReleaseFile.test.ts
@@ -1,0 +1,158 @@
+import { execFile } from 'node:child_process'
+import { chmod, link, mkdtemp, mkdir, readFile, rename, symlink, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  createD1ApprovedHostReleaseFileReaderForPolicy,
+  D1_APPROVED_HOST_RELEASE_AUTHORITY_POLICY,
+  D1_APPROVED_HOST_RELEASE_MAX_BYTES,
+  D1_APPROVED_HOST_RELEASE_ROOT,
+  type D1ApprovedHostReleaseFilePolicy,
+} from '../approvedHostReleaseFile.js'
+import { D1HostErrorCode } from '../d1Plan.js'
+
+const run = promisify(execFile)
+const UID = process.geteuid!()
+const GID = process.getegid!()
+const HOST_ID = 'eu-host-1'
+const CANARY = 'authority-file-canary-never-leaks'
+const digest = (character: string) => `sha256:${character.repeat(64)}`
+const revision = (character: string) => character.repeat(40)
+
+const release = () => ({
+  schemaVersion: 1,
+  domain: 'boring-d1-approved-host-release:v1',
+  hostAppImageDigest: digest('a'),
+  coreCommand: { entrypoint: ['/usr/local/bin/web-entrypoint'], cmd: ['node', 'apps/full-app/dist/server/main.js'] },
+  migrationProcess: { entrypoint: ['node'], cmd: ['apps/full-app/dist/server/migrate.js'], user: '10001:10001',
+    readonlyRootfs: true, privileged: false, noNewPrivileges: true, addedCapabilities: [] },
+  ingressImageDigest: digest('b'),
+  ingressCommand: { entrypoint: null, cmd: ['caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile'] },
+  caddyfileDigest: digest('c'),
+  hostSecurityConfigDigest: digest('d'),
+  selectorInventoryRevision: revision('a'),
+  executionPolicyRevision: revision('b'),
+  databaseSchemaCompatibility: { migrationSetDigest: digest('e'), currentEpoch: 2,
+    readableEpochRange: { min: 1, max: 2 }, readableByPreviousRelease: true },
+})
+
+async function fixture() {
+  const parent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-approved-release-'))
+  const directoryPath = path.join(parent, 'approved-host-releases')
+  await mkdir(directoryPath, { mode: 0o755 })
+  const file = path.join(directoryPath, `${HOST_ID}.json`)
+  await writeFile(file, JSON.stringify(release()), { mode: 0o444 })
+  const policy: D1ApprovedHostReleaseFilePolicy = {
+    directoryPath, directoryUid: UID, directoryGid: GID, directoryMode: 0o755,
+    fileUid: UID, fileGid: GID, fileMode: 0o444, maxBytes: D1_APPROVED_HOST_RELEASE_MAX_BYTES,
+  }
+  return { directoryPath, file, policy }
+}
+
+function reader(policy: D1ApprovedHostReleaseFilePolicy) {
+  return createD1ApprovedHostReleaseFileReaderForPolicy(policy)
+}
+
+function deeplyFrozen(value: unknown): boolean {
+  return !value || typeof value !== 'object' || (Object.isFrozen(value) && Object.values(value).every(deeplyFrozen))
+}
+
+async function expectUnavailable(action: Promise<unknown>): Promise<void> {
+  const failure = await action.catch((error) => error)
+  expect(failure).toMatchObject({
+    code: D1HostErrorCode.COLLECTION_NOT_READY,
+    details: { field: 'approvedHostRelease' },
+  })
+  expect(JSON.stringify(failure)).not.toMatch(new RegExp(`${CANARY}|approved-release-|approved-host-releases|eu-host-1\\.json`))
+}
+
+describe('D1 approved host release authority file', () => {
+  it('reads one descriptor-anchored, deeply frozen approved record', async () => {
+    const h = await fixture()
+    const record = await reader(h.policy).read(HOST_ID)
+    expect(record).toEqual(release())
+    expect(deeplyFrozen(record)).toBe(true)
+  })
+
+  it('hard-codes the production root and root-owned immutable metadata policy', () => {
+    expect(D1_APPROVED_HOST_RELEASE_ROOT).toBe('/etc/boring/d1/approved-host-releases')
+    expect(D1_APPROVED_HOST_RELEASE_AUTHORITY_POLICY).toEqual({
+      directoryPath: '/etc/boring/d1/approved-host-releases',
+      directoryUid: 0, directoryGid: 0, directoryMode: 0o755,
+      fileUid: 0, fileGid: 0, fileMode: 0o444, maxBytes: 64 * 1024,
+    })
+    expect(Object.isFrozen(D1_APPROVED_HOST_RELEASE_AUTHORITY_POLICY)).toBe(true)
+  })
+
+  it.each([
+    ['directory owner', (p: D1ApprovedHostReleaseFilePolicy) => ({ ...p, directoryUid: p.directoryUid + 1 })],
+    ['directory group', (p: D1ApprovedHostReleaseFilePolicy) => ({ ...p, directoryGid: p.directoryGid + 1 })],
+    ['directory mode', (p: D1ApprovedHostReleaseFilePolicy) => ({ ...p, directoryMode: 0o750 })],
+    ['file owner', (p: D1ApprovedHostReleaseFilePolicy) => ({ ...p, fileUid: p.fileUid + 1 })],
+    ['file group', (p: D1ApprovedHostReleaseFilePolicy) => ({ ...p, fileGid: p.fileGid + 1 })],
+    ['file mode', (p: D1ApprovedHostReleaseFilePolicy) => ({ ...p, fileMode: 0o440 })],
+  ])('rejects wrong %s metadata', async (_name, mutate) => {
+    const h = await fixture()
+    await expectUnavailable(reader(mutate(h.policy)).read(HOST_ID))
+  })
+
+  it('rejects a symlinked authority directory and symlinked or hard-linked record', async () => {
+    for (const mutation of ['directory-symlink', 'file-symlink', 'file-hardlink']) {
+      const h = await fixture()
+      if (mutation === 'directory-symlink') {
+        await rename(h.directoryPath, `${h.directoryPath}.target`)
+        await symlink(`${h.directoryPath}.target`, h.directoryPath)
+      } else if (mutation === 'file-symlink') {
+        await rename(h.file, `${h.file}.target`)
+        await symlink(`${h.file}.target`, h.file)
+      } else await link(h.file, `${h.file}.link`)
+      await expectUnavailable(reader(h.policy).read(HOST_ID))
+    }
+  })
+
+  it('rejects a FIFO without blocking', async () => {
+    const h = await fixture()
+    await rename(h.file, `${h.file}.original`)
+    await run('mkfifo', [h.file])
+    await chmod(h.file, 0o444)
+    const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error('FIFO open blocked')), 500))
+    await expectUnavailable(Promise.race([reader(h.policy).read(HOST_ID), timeout]))
+  })
+
+  it('rejects missing, empty, oversized, malformed, invalid UTF-8, and drifted records', async () => {
+    for (const mutation of ['missing', 'empty', 'oversized', 'malformed', 'utf8', 'drift']) {
+      const h = await fixture()
+      await chmod(h.file, 0o600)
+      if (mutation === 'missing') await rename(h.file, `${h.file}.missing`)
+      else if (mutation === 'empty') await writeFile(h.file, '')
+      else if (mutation === 'oversized') await writeFile(h.file, new Uint8Array(D1_APPROVED_HOST_RELEASE_MAX_BYTES + 1))
+      else if (mutation === 'malformed') await writeFile(h.file, `{ "${CANARY}":`)
+      else if (mutation === 'utf8') await writeFile(h.file, new Uint8Array([0xc3, 0x28]))
+      else await writeFile(h.file, JSON.stringify({ ...release(), hostAppImageDigest: CANARY }))
+      if (mutation !== 'missing') await chmod(h.file, 0o444)
+      await expectUnavailable(reader(h.policy).read(HOST_ID))
+    }
+  })
+
+  it('rejects noncanonical policy and host-id input without exposing their values', async () => {
+    const h = await fixture()
+    for (const directoryPath of ['relative', `${h.directoryPath}/`, `${h.directoryPath}\0${CANARY}`]) {
+      expect(() => reader({ ...h.policy, directoryPath })).toThrow(expect.objectContaining({
+        code: D1HostErrorCode.COLLECTION_NOT_READY, details: { field: 'approvedHostRelease' },
+      }))
+    }
+    await expectUnavailable(reader(h.policy).read(`../${CANARY}`))
+  })
+
+  it('has no writer API and only reads the record through anchored descriptors', async () => {
+    const source = await readFile(new URL('../approvedHostReleaseFile.ts', import.meta.url), 'utf8')
+    expect(source).toContain('/proc/self/fd/')
+    expect(source).toContain('O_NOFOLLOW')
+    expect(source).toContain('O_NONBLOCK')
+    expect(source).not.toMatch(/writeFile|rename|unlink|createWriteStream|process\.env/)
+  })
+})

--- a/apps/full-app/src/server/deployment/approvedHostReleaseFile.ts
+++ b/apps/full-app/src/server/deployment/approvedHostReleaseFile.ts
@@ -1,0 +1,166 @@
+import { constants, type Stats } from 'node:fs'
+import { lstat, open, realpath, type FileHandle } from 'node:fs/promises'
+import path from 'node:path'
+
+import { decodeApprovedD1HostReleaseRecord, type ApprovedD1HostReleaseRecordV1 } from './approvedHostRelease.js'
+import { D1HostError, D1HostErrorCode, strictD1HostId } from './d1Plan.js'
+
+export const D1_APPROVED_HOST_RELEASE_ROOT = '/etc/boring/d1/approved-host-releases'
+export const D1_APPROVED_HOST_RELEASE_MAX_BYTES = 64 * 1024
+
+const DIRECTORY_MODE = 0o755
+const FILE_MODE = 0o444
+const ROOT_UID = 0
+const ROOT_GID = 0
+const OPEN_DIRECTORY = constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW
+const OPEN_FILE = constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK
+
+export interface D1ApprovedHostReleaseFileReader {
+  read(hostId: string): Promise<ApprovedD1HostReleaseRecordV1>
+}
+
+export interface D1ApprovedHostReleaseFilePolicy {
+  readonly directoryPath: string
+  readonly directoryUid: number
+  readonly directoryGid: number
+  readonly directoryMode: number
+  readonly fileUid: number
+  readonly fileGid: number
+  readonly fileMode: number
+  readonly maxBytes: number
+}
+
+export const D1_APPROVED_HOST_RELEASE_AUTHORITY_POLICY: Readonly<D1ApprovedHostReleaseFilePolicy> = Object.freeze({
+  directoryPath: D1_APPROVED_HOST_RELEASE_ROOT,
+  directoryUid: ROOT_UID,
+  directoryGid: ROOT_GID,
+  directoryMode: DIRECTORY_MODE,
+  fileUid: ROOT_UID,
+  fileGid: ROOT_GID,
+  fileMode: FILE_MODE,
+  maxBytes: D1_APPROVED_HOST_RELEASE_MAX_BYTES,
+})
+
+function unavailable(): never {
+  throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'approvedHostRelease' })
+}
+
+function sameIdentity(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino
+}
+
+function exactMetadata(info: Stats, uid: number, gid: number, mode: number): boolean {
+  return info.uid === uid && info.gid === gid && (info.mode & 0o7777) === mode
+}
+
+async function closeQuietly(handle: FileHandle | undefined): Promise<void> {
+  try { await handle?.close() } catch {}
+}
+
+async function readBounded(handle: FileHandle, maxBytes: number): Promise<Uint8Array> {
+  const bytes = new Uint8Array(maxBytes + 1)
+  let offset = 0
+  while (offset < bytes.byteLength) {
+    const result = await handle.read(bytes, offset, bytes.byteLength - offset, offset)
+    if (result.bytesRead === 0) break
+    offset += result.bytesRead
+  }
+  if (offset > maxBytes) throw new Error('file too large')
+  return bytes.slice(0, offset)
+}
+
+function validPolicy(value: unknown): Readonly<D1ApprovedHostReleaseFilePolicy> {
+  if (!value || typeof value !== 'object') throw new Error('policy')
+  const input = value as D1ApprovedHostReleaseFilePolicy
+  const directoryPath = input.directoryPath
+  const directoryUid = input.directoryUid
+  const directoryGid = input.directoryGid
+  const directoryMode = input.directoryMode
+  const fileUid = input.fileUid
+  const fileGid = input.fileGid
+  const fileMode = input.fileMode
+  const maxBytes = input.maxBytes
+  const ids = [directoryUid, directoryGid, fileUid, fileGid]
+  const modes = [directoryMode, fileMode]
+  if (typeof directoryPath !== 'string' || directoryPath.includes('\0') || !path.isAbsolute(directoryPath)
+    || path.resolve(directoryPath) !== directoryPath || ids.some((id) => !Number.isSafeInteger(id) || id < 0)
+    || modes.some((mode) => !Number.isSafeInteger(mode) || mode < 0 || mode > 0o7777)
+    || !Number.isSafeInteger(maxBytes) || maxBytes < 1 || maxBytes > D1_APPROVED_HOST_RELEASE_MAX_BYTES) throw new Error('policy')
+  return Object.freeze({ directoryPath, directoryUid, directoryGid, directoryMode, fileUid, fileGid, fileMode, maxBytes })
+}
+
+async function openVerifiedDirectory(policy: Readonly<D1ApprovedHostReleaseFilePolicy>): Promise<FileHandle> {
+  const before = await lstat(policy.directoryPath)
+  if (!before.isDirectory() || before.isSymbolicLink()) throw new Error('directory')
+  const handle = await open(policy.directoryPath, OPEN_DIRECTORY)
+  try {
+    const after = await handle.stat()
+    const anchored = `/proc/self/fd/${handle.fd}`
+    if (!after.isDirectory() || !sameIdentity(before, after)
+      || !exactMetadata(after, policy.directoryUid, policy.directoryGid, policy.directoryMode)
+      || await realpath(anchored) !== policy.directoryPath) throw new Error('directory')
+    return handle
+  } catch (error) {
+    await closeQuietly(handle)
+    throw error
+  }
+}
+
+async function readVerifiedRecord(
+  directory: FileHandle,
+  hostId: string,
+  policy: Readonly<D1ApprovedHostReleaseFilePolicy>,
+): Promise<ApprovedD1HostReleaseRecordV1> {
+  const fileName = `${hostId}.json`
+  const expectedPath = path.join(policy.directoryPath, fileName)
+  const directoryAnchor = `/proc/self/fd/${directory.fd}`
+  const initialDirectory = await directory.stat()
+  if (!initialDirectory.isDirectory()
+    || !exactMetadata(initialDirectory, policy.directoryUid, policy.directoryGid, policy.directoryMode)) throw new Error('directory')
+  const handle = await open(path.join(directoryAnchor, fileName), OPEN_FILE)
+  try {
+    const initial = await handle.stat()
+    if (!initial.isFile() || !exactMetadata(initial, policy.fileUid, policy.fileGid, policy.fileMode)
+      || initial.nlink !== 1 || initial.size < 1 || initial.size > policy.maxBytes
+      || await realpath(`/proc/self/fd/${handle.fd}`) !== expectedPath) throw new Error('file')
+    const bytes = await readBounded(handle, policy.maxBytes)
+    const final = await handle.stat()
+    const finalDirectory = await directory.stat()
+    if (!final.isFile() || !sameIdentity(initial, final)
+      || !exactMetadata(final, policy.fileUid, policy.fileGid, policy.fileMode)
+      || final.nlink !== 1 || final.size !== initial.size || final.mtimeMs !== initial.mtimeMs
+      || final.ctimeMs !== initial.ctimeMs || bytes.byteLength !== initial.size
+      || !finalDirectory.isDirectory() || !sameIdentity(initialDirectory, finalDirectory)
+      || !exactMetadata(finalDirectory, policy.directoryUid, policy.directoryGid, policy.directoryMode)
+      || await realpath(directoryAnchor) !== policy.directoryPath
+      || await realpath(`/proc/self/fd/${handle.fd}`) !== expectedPath) throw new Error('file changed')
+    const raw = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown
+    return decodeApprovedD1HostReleaseRecord(raw)
+  } finally {
+    await closeQuietly(handle)
+  }
+}
+
+/** Trusted policy seam for filesystem tests. It reads a record and never mints release authority. */
+export function createD1ApprovedHostReleaseFileReaderForPolicy(
+  input: D1ApprovedHostReleaseFilePolicy,
+): D1ApprovedHostReleaseFileReader {
+  let policy: Readonly<D1ApprovedHostReleaseFilePolicy>
+  try { policy = validPolicy(input) } catch { return unavailable() }
+  return Object.freeze({
+    async read(rawHostId: string): Promise<ApprovedD1HostReleaseRecordV1> {
+      let directory: FileHandle | undefined
+      try {
+        const hostId = strictD1HostId(rawHostId, 'hostId')
+        directory = await openVerifiedDirectory(policy)
+        return await readVerifiedRecord(directory, hostId, policy)
+      } catch { return unavailable() } finally { await closeQuietly(directory) }
+    },
+  })
+}
+
+const productionReader = createD1ApprovedHostReleaseFileReaderForPolicy(D1_APPROVED_HOST_RELEASE_AUTHORITY_POLICY)
+
+export async function readApprovedD1HostReleaseFile(hostId: string): Promise<ApprovedD1HostReleaseRecordV1> {
+  return productionReader.read(hostId)
+}

--- a/docs/issues/391/runtime-refactor/FORWARD-PLAN.md
+++ b/docs/issues/391/runtime-refactor/FORWARD-PLAN.md
@@ -465,9 +465,11 @@ bead below:
   a secret-bearing env key past review.
 - **Build.** `approvedHostRelease.ts` + `hostSecurityConfig.ts`; reuse landed
   core/ingress identity constants. The release record lives at
-  `<host-state>/approved-host-release.json` **outside** immutable revision
-  directories, installed only by the maintenance release procedure — the app
-  cannot write it and the apply command exposes no mutation for it. It binds
+  `/etc/boring/d1/approved-host-releases/<hostId>.json`, outside D1 host-state
+  and immutable revision mounts, installed only by the root maintenance release
+  procedure — it is not mounted into the app, the app cannot write it, and the
+  apply command exposes no mutation for it. The authority directory is
+  root:root `0755`; each exact `<hostId>.json` record is root:root `0444`. It binds
   `{ hostAppImageDigest, coreCommand, migrationProcess, ingressImageDigest,
   ingressCommand, caddyfileDigest, hostSecurityConfigDigest,
   selectorInventoryRevision, executionPolicyRevision,

--- a/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/D1-R0-SPEC.md
+++ b/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/D1-R0-SPEC.md
@@ -836,9 +836,12 @@ MCP and managed-agent MCP families remain inside c3/c5 respectively.
 The sole D1 web entrypoint is the approved full-app Docker web runtime invoking
 `apps/full-app/dist/server/main.js`; generic `runCoreWorkspaceAgentServer` and
 command overrides are not D1 launchers. A root-owned approved-host-release
-record at `<host-state>/approved-host-release.json`, outside immutable revision
-directories, is installed only by the maintenance release procedure. The app
-cannot write it and the D1 apply command exposes no mutation for it. It binds
+record at `/etc/boring/d1/approved-host-releases/<hostId>.json`, outside D1
+host-state and immutable revision mounts, is installed only by the root
+maintenance release procedure and is not mounted into the app. The app cannot
+write it and the D1 apply command exposes no mutation for it. The authority
+directory is root:root `0755`; each exact `<hostId>.json` record is root:root
+`0444`, regular, singly linked, and at most 64 KiB. It binds
 `{ hostAppImageDigest, coreCommand, migrationProcess, ingressImageDigest, ingressCommand,
 caddyfileDigest, hostSecurityConfigDigest,
 selectorInventoryRevision, executionPolicyRevision }`; both revisions are


### PR DESCRIPTION
## Summary

- resolves the mounted-authority contradiction by moving the approved release record out of D1 host state to `/etc/boring/d1/approved-host-releases/<hostId>.json`
- enforces root:root `0755` authority-directory and root:root `0444`, regular, singly linked, <=64 KiB record metadata through descriptor-anchored `O_NOFOLLOW | O_NONBLOCK` reads
- maps every read/decode failure to redacted `D1_COLLECTION_NOT_READY` / `approvedHostRelease` and returns the deeply frozen approved record

## Boundary

This slice provides no writer API and performs no Docker, image, Caddy, Compose, database, or capability work. Root maintenance installs records with temp + fsync + atomic rename outside the app. D1-005a2b2b remains downstream and must consume only the fixed production reader when it mints authority.

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/approvedHostReleaseFile.test.ts` (13/13)
- `pnpm --filter full-app typecheck`
- `pnpm check:generated-artifacts`
- `pnpm audit:imports`
- `git diff --check HEAD^ HEAD`
- structured local autoreview clean (0.91)
