### PR TITLE
feat(d1): attest approved host artifacts

### DIFF
--- a/apps/full-app/scripts/d1-ingress-header-proof.ts
+++ b/apps/full-app/scripts/d1-ingress-header-proof.ts
@@ -5,10 +5,14 @@ import { request } from 'node:http'
 import path from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
 
-import { D1_CADDY_IMAGE } from '../src/server/deployment/composeAdapter.js'
+import {
+  D1_CADDY_AMD64_ID,
+  D1_CADDY_COMMAND,
+  D1_CADDY_IMAGE,
+  D1_CADDY_IMAGE_DEFAULTS,
+  D1_CADDYFILE_DIGEST,
+} from '../src/server/deployment/d1IngressArtifacts.js'
 
-export const D1_CADDY_AMD64_ID = 'sha256:af555904a0961945f16bb323a501457b13a4f7e9bde969b145b97da80b38ecbe'
-export const D1_CADDYFILE_DIGEST = 'sha256:a391f757bc9398e0dbd279e6a503fe608e6571f29c166164ff36552afd0f72c8'
 export const D1_INGRESS_PROOF_HELPER_IMAGE = 'node@sha256:c601a46abb4d2ab80a9dc3da208d50d1122642d53f17a101926ace71e5a9bf1c'
 const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..')
 const CADDYFILE = path.join(REPOSITORY_ROOT, 'deploy/d1/Caddyfile')
@@ -52,15 +56,16 @@ function records(raw: string): Record<string, any>[] {
 export function validateD1CaddyImageInspect(raw: string): void {
   const image = records(raw)[0]
   if (!image || image.Id !== D1_CADDY_AMD64_ID || !Array.isArray(image.RepoDigests) || !image.RepoDigests.includes(D1_CADDY_IMAGE)
-    || image.Config?.Entrypoint != null || JSON.stringify(image.Config?.Cmd) !== JSON.stringify(['caddy', 'run', '--config', CADDYFILE_TARGET, '--adapter', 'caddyfile'])
-    || !Array.isArray(image.Config?.Env) || !image.Config.Env.includes('CADDY_VERSION=v2.11.4')) throw new Error('image')
+    || image.Config?.Entrypoint != null || JSON.stringify(image.Config?.Cmd) !== JSON.stringify(D1_CADDY_COMMAND)
+    || !Array.isArray(image.Config?.Env) || Object.entries(D1_CADDY_IMAGE_DEFAULTS)
+      .some(([key, value]) => !image.Config.Env.includes(`${key}=${value}`))) throw new Error('image')
 }
 
 export function validateD1IngressContainerInspect(raw: string, source: string): void {
   const container = records(raw)[0]
   const mount = container?.Mounts?.filter((entry: Record<string, unknown>) => entry.Destination === CADDYFILE_TARGET)
   if (!container || container.Config?.Image !== D1_CADDY_IMAGE
-    || JSON.stringify(container.Config?.Cmd) !== JSON.stringify(['caddy', 'run', '--config', CADDYFILE_TARGET, '--adapter', 'caddyfile'])
+    || JSON.stringify(container.Config?.Cmd) !== JSON.stringify(D1_CADDY_COMMAND)
     || !Array.isArray(mount) || mount.length !== 1 || mount[0].Type !== 'bind' || mount[0].Source !== source || mount[0].RW !== false) throw new Error('container')
 }
 
@@ -134,7 +139,7 @@ async function proof(): Promise<void> {
     requireDocker(['run', '-d', '--rm', '--name', backend, '--label', label, '--network', network, '--network-alias', 'core-app',
       '--entrypoint', 'node', D1_INGRESS_PROOF_HELPER_IMAGE, '-e', ECHO])
     requireDocker(['run', '-d', '--rm', '--name', ingress, '--label', label, '--network', network, '--publish', '127.0.0.1::8080',
-      '--mount', mount, D1_CADDY_IMAGE, 'caddy', 'run', '--config', CADDYFILE_TARGET, '--adapter', 'caddyfile'])
+      '--mount', mount, D1_CADDY_IMAGE, ...D1_CADDY_COMMAND])
     validateD1IngressContainerInspect(requireDocker(['inspect', ingress]), CADDYFILE)
     const published = requireDocker(['port', ingress, '8080/tcp']).trim().match(/^127\.0\.0\.1:(\d+)$/)
     if (!published) throw new Error('port')

--- a/apps/full-app/src/server/deployment/__tests__/approvedHostArtifactEvidence.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/approvedHostArtifactEvidence.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from 'vitest'
+
+import { createD1ApprovedHostArtifactEvidence } from '../approvedHostArtifactEvidence.js'
+import {
+  D1_CADDY_AMD64_ID,
+  D1_CADDY_COMMAND,
+  D1_CADDY_IMAGE,
+  D1_CADDY_IMAGE_DEFAULTS,
+  D1_CADDYFILE_DIGEST,
+} from '../d1IngressArtifacts.js'
+import { D1HostError, D1HostErrorCode } from '../d1Plan.js'
+
+const CANARY = 'artifact-evidence-canary-never-leaks'
+const digest = (character: string) => `sha256:${character.repeat(64)}`
+const revision = (character: string) => character.repeat(40)
+const CORE_DIGEST = digest('a')
+const CORE_REF = `ghcr.io/hachej/boring-ui@${CORE_DIGEST}`
+const CORE_ID = digest('f')
+const CADDY_BYTES = new TextEncoder().encode(':8080 {\n\treverse_proxy core-app:3000 {\n\t\theader_up -Forwarded\n\t\theader_up Host {hostport}\n\t\theader_up X-Forwarded-Host {hostport}\n\t}\n}\n')
+
+const release = () => ({
+  schemaVersion: 1,
+  domain: 'boring-d1-approved-host-release:v1',
+  hostAppImageDigest: CORE_DIGEST,
+  coreCommand: { entrypoint: ['/usr/local/bin/web-entrypoint'], cmd: ['node', 'apps/full-app/dist/server/main.js'] },
+  migrationProcess: { entrypoint: ['node'], cmd: ['apps/full-app/dist/server/migrate.js'], user: '10001:10001',
+    readonlyRootfs: true, privileged: false, noNewPrivileges: true, addedCapabilities: [] },
+  ingressImageDigest: D1_CADDY_IMAGE.split('@')[1],
+  ingressCommand: { entrypoint: null, cmd: [...D1_CADDY_COMMAND] },
+  caddyfileDigest: D1_CADDYFILE_DIGEST,
+  hostSecurityConfigDigest: digest('d'),
+  selectorInventoryRevision: revision('a'),
+  executionPolicyRevision: revision('b'),
+  databaseSchemaCompatibility: { migrationSetDigest: digest('e'), currentEpoch: 2,
+    readableEpochRange: { min: 1, max: 2 }, readableByPreviousRelease: true },
+})
+
+const coreImage = () => [{
+  Id: CORE_ID,
+  RepoDigests: [CORE_REF],
+  Architecture: 'amd64',
+  Os: 'linux',
+  Config: {
+    Entrypoint: ['/usr/local/bin/web-entrypoint'],
+    Cmd: ['node', 'apps/full-app/dist/server/main.js'],
+    WorkingDir: '/app',
+    Env: [
+      'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+      'NODE_VERSION=22.23.1',
+      'YARN_VERSION=1.22.22',
+      'NODE_ENV=production',
+      'BORING_AGENT_MODE=vercel-sandbox',
+      'BORING_AGENT_WORKSPACE_ROOT=/data/workspaces',
+      'BORING_AGENT_SESSION_ROOT=/data/pi-sessions',
+    ],
+    Labels: {
+      'boring.role': 'web',
+      'org.opencontainers.image.revision': revision('b'),
+      'ai.senecapp.d1.migration-set-digest': digest('e'),
+      'ai.senecapp.d1.database-current-epoch': '2',
+      'org.opencontainers.image.title': 'boring-ui full-app',
+    },
+  },
+  RepoTags: ['ignored:latest'],
+}]
+
+const ingressImage = () => [{
+  Id: D1_CADDY_AMD64_ID,
+  RepoDigests: [
+    `caddy@${digest('9')}`,
+    D1_CADDY_IMAGE,
+  ],
+  Architecture: 'amd64',
+  Os: 'linux',
+  Config: {
+    Cmd: [...D1_CADDY_COMMAND],
+    WorkingDir: '/srv',
+    Env: Object.entries(D1_CADDY_IMAGE_DEFAULTS).map(([key, value]) => `${key}=${value}`),
+    Labels: { 'org.opencontainers.image.version': 'v2.11.4' },
+  },
+}]
+
+type Field = 'approvedHostRelease' | 'coreImage' | 'ingressImage' | 'caddyfile' | 'databaseSchemaCompatibility'
+
+function create(
+  recordValue: unknown = release(),
+  coreRef: unknown = CORE_REF,
+  coreInspect: unknown = coreImage(),
+  ingressInspect: unknown = ingressImage(),
+  bytes: unknown = CADDY_BYTES.slice(),
+) {
+  return createD1ApprovedHostArtifactEvidence(recordValue as never, coreRef, coreInspect, ingressInspect, bytes)
+}
+
+function expectUnavailable(field: Field, action: () => unknown): Error {
+  let failure: unknown
+  try { action(); throw new Error('accepted invalid evidence') } catch (error) { failure = error }
+  expect(failure).toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY, details: { field } })
+  expect(String(failure)).not.toContain(CANARY)
+  expect(JSON.stringify(failure)).not.toContain(CANARY)
+  return failure as Error
+}
+
+function deeplyFrozen(value: unknown): boolean {
+  return !value || typeof value !== 'object' || (Object.isFrozen(value) && Object.values(value).every(deeplyFrozen))
+}
+
+describe('D1 approved host artifact evidence', () => {
+  it('projects actual pinned Dockerfile and Caddy artifacts into minimal deeply frozen evidence', () => {
+    const result = create()
+    expect(result).toEqual({
+      coreImageId: CORE_ID,
+      ingressImageId: D1_CADDY_AMD64_ID,
+      imageDefaults: {
+        path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        nodeVersion: '22.23.1',
+        yarnVersion: '1.22.22',
+      },
+      executionPolicyRevision: revision('b'),
+      migrationSetDigest: digest('e'),
+      currentEpoch: 2,
+      caddyfileDigest: D1_CADDYFILE_DIGEST,
+    })
+    expect(Object.keys(result).sort()).toEqual([
+      'caddyfileDigest', 'coreImageId', 'currentEpoch', 'executionPolicyRevision', 'imageDefaults',
+      'ingressImageId', 'migrationSetDigest',
+    ])
+    expect(deeplyFrozen(result)).toBe(true)
+  })
+
+  it.each([
+    ['host digest', 'coreImage', (value: any) => { value.hostAppImageDigest = digest('1') }],
+    ['core command', 'approvedHostRelease', (value: any) => { value.coreCommand.cmd = ['node', 'other.js'] }],
+    ['ingress digest', 'ingressImage', (value: any) => { value.ingressImageDigest = digest('2') }],
+    ['ingress command', 'approvedHostRelease', (value: any) => { value.ingressCommand.cmd = ['caddy', 'reverse-proxy'] }],
+    ['Caddyfile digest', 'caddyfile', (value: any) => { value.caddyfileDigest = digest('3') }],
+    ['execution revision', 'coreImage', (value: any) => { value.executionPolicyRevision = revision('c') }],
+    ['migration digest', 'databaseSchemaCompatibility', (value: any) => { value.databaseSchemaCompatibility.migrationSetDigest = digest('4') }],
+    ['migration epoch', 'databaseSchemaCompatibility', (value: any) => { value.databaseSchemaCompatibility.currentEpoch = 3; value.databaseSchemaCompatibility.readableEpochRange.max = 3 }],
+  ] as const)('rejects record %s drift', (_name, field, mutate) => {
+    const value: any = release(); mutate(value)
+    expectUnavailable(field, () => create(value))
+  })
+
+  it.each([
+    ['image id', (value: any) => { value[0].Id = digest('z') }],
+    ['repository digest', (value: any) => { value[0].RepoDigests = [`other@${CORE_DIGEST}`] }],
+    ['architecture', (value: any) => { value[0].Architecture = 'arm64' }],
+    ['OS', (value: any) => { value[0].Os = 'windows' }],
+    ['entrypoint', (value: any) => { value[0].Config.Entrypoint = ['node'] }],
+    ['command', (value: any) => { value[0].Config.Cmd = ['node', 'other.js'] }],
+    ['working directory', (value: any) => { value[0].Config.WorkingDir = '/tmp' }],
+    ['image user', (value: any) => { value[0].Config.User = '10001:10001' }],
+    ['role label', (value: any) => { value[0].Config.Labels['boring.role'] = 'worker' }],
+    ['revision label', (value: any) => { value[0].Config.Labels['org.opencontainers.image.revision'] = revision('c') }],
+  ] as const)('rejects core %s drift', (_name, mutate) => {
+    const value: any = coreImage(); mutate(value)
+    expectUnavailable('coreImage', () => create(release(), CORE_REF, value))
+  })
+
+  it.each([
+    ['migration digest label', (value: any) => { value[0].Config.Labels['ai.senecapp.d1.migration-set-digest'] = digest('1') }],
+    ['migration epoch label', (value: any) => { value[0].Config.Labels['ai.senecapp.d1.database-current-epoch'] = '3' }],
+  ] as const)('rejects core %s as database compatibility drift', (_name, mutate) => {
+    const value: any = coreImage(); mutate(value)
+    expectUnavailable('databaseSchemaCompatibility', () => create(release(), CORE_REF, value))
+  })
+
+  it.each([
+    ['image id', (value: any) => { value[0].Id = digest('1') }],
+    ['repository digest', (value: any) => { value[0].RepoDigests = [`caddy@${digest('9')}`] }],
+    ['architecture', (value: any) => { value[0].Architecture = 'arm64' }],
+    ['OS', (value: any) => { value[0].Os = 'windows' }],
+    ['entrypoint', (value: any) => { value[0].Config.Entrypoint = ['caddy'] }],
+    ['command', (value: any) => { value[0].Config.Cmd = ['caddy', 'reverse-proxy'] }],
+    ['working directory', (value: any) => { value[0].Config.WorkingDir = '/tmp' }],
+    ['image user', (value: any) => { value[0].Config.User = '10001:10001' }],
+    ['Caddy version', (value: any) => { value[0].Config.Env[1] = 'CADDY_VERSION=v2.11.3' }],
+  ] as const)('rejects ingress %s drift', (_name, mutate) => {
+    const value: any = ingressImage(); mutate(value)
+    expectUnavailable('ingressImage', () => create(release(), CORE_REF, coreImage(), value))
+  })
+
+  it('requires the exact unique core environment and rejects loader or secret-bearing names', () => {
+    for (const entry of [
+      'NODE_ENV=development',
+      'NODE_VERSION=latest',
+      'PATH=',
+      `NODE_OPTIONS=${CANARY}`,
+      `OPENAI_API_KEY=${CANARY}`,
+      `DATABASE_URL=${CANARY}`,
+    ]) {
+      const image: any = coreImage()
+      const key = entry.slice(0, entry.indexOf('='))
+      const index = image[0].Config.Env.findIndex((value: string) => value.startsWith(`${key}=`))
+      if (index < 0) image[0].Config.Env.push(entry); else image[0].Config.Env[index] = entry
+      expectUnavailable('coreImage', () => create(release(), CORE_REF, image))
+    }
+    const duplicate: any = coreImage(); duplicate[0].Config.Env.push('NODE_ENV=production')
+    expectUnavailable('coreImage', () => create(release(), CORE_REF, duplicate))
+  })
+
+  it('rejects zero or multiple inspect results and malformed inspect shapes', () => {
+    for (const value of [null, {}, [], [coreImage()[0], coreImage()[0]]]) {
+      expectUnavailable('coreImage', () => create(release(), CORE_REF, value))
+    }
+    for (const value of [null, {}, [], [ingressImage()[0], ingressImage()[0]]]) {
+      expectUnavailable('ingressImage', () => create(release(), CORE_REF, coreImage(), value))
+    }
+  })
+
+  it('rejects accessors, hidden or symbol keys, custom prototypes, holes, and custom array properties without invoking getters', () => {
+    let reads = 0
+    const accessor: any = coreImage()
+    Object.defineProperty(accessor[0].Config, 'Cmd', { enumerable: true, get: () => { reads += 1; return ['node'] } })
+    expectUnavailable('coreImage', () => create(release(), CORE_REF, accessor)); expect(reads).toBe(0)
+
+    const hidden: any = coreImage(); Object.defineProperty(hidden[0], CANARY, { enumerable: false, value: CANARY })
+    expectUnavailable('coreImage', () => create(release(), CORE_REF, hidden))
+    const symbol: any = ingressImage(); symbol[0].Config[Symbol(CANARY)] = CANARY
+    expectUnavailable('ingressImage', () => create(release(), CORE_REF, coreImage(), symbol))
+    const prototype: any = coreImage(); Object.setPrototypeOf(prototype[0].Config.Labels, { [CANARY]: CANARY })
+    expectUnavailable('coreImage', () => create(release(), CORE_REF, prototype))
+    const hole: any = coreImage(); hole[0].Config.Env = new Array(7)
+    expectUnavailable('coreImage', () => create(release(), CORE_REF, hole))
+    const custom: any = ingressImage(); Object.defineProperty(custom[0].RepoDigests, 'toJSON', { enumerable: true, value: () => [D1_CADDY_IMAGE] })
+    expectUnavailable('ingressImage', () => create(release(), CORE_REF, coreImage(), custom))
+
+    const recordAccessor: any = release()
+    Object.defineProperty(recordAccessor, 'hostAppImageDigest', { enumerable: true, get: () => { reads += 1; return CORE_DIGEST } })
+    expectUnavailable('approvedHostRelease', () => create(recordAccessor)); expect(reads).toBe(0)
+  })
+
+  it('hashes a byte snapshot, rejects Caddyfile drift, and retains neither bytes nor inspect objects', () => {
+    const bytes = CADDY_BYTES.slice(); const core: any = coreImage()
+    const result = create(release(), CORE_REF, core, ingressImage(), bytes)
+    bytes.fill(0); core[0].Config.Env[0] = `PATH=${CANARY}`; core[0].Id = digest('1')
+    expect(result.caddyfileDigest).toBe(D1_CADDYFILE_DIGEST)
+    expect(result.coreImageId).toBe(CORE_ID)
+    expect(result.imageDefaults.path).not.toContain(CANARY)
+    const drifted = CADDY_BYTES.slice(); drifted[0] ^= 1
+    expectUnavailable('caddyfile', () => create(release(), CORE_REF, coreImage(), ingressImage(), drifted))
+    expectUnavailable('caddyfile', () => create(release(), CORE_REF, coreImage(), ingressImage(), Buffer.from(CADDY_BYTES)))
+  })
+
+  it('redacts raw attacker values from stable failures', () => {
+    const image: any = coreImage(); image[0].Config.Env.push(`OPENAI_API_KEY=${CANARY}`)
+    const failure = expectUnavailable('coreImage', () => create(release(), CORE_REF, image))
+    expect(failure.message).toBe(D1HostErrorCode.COLLECTION_NOT_READY)
+    expect(failure.stack).not.toContain(CANARY)
+
+    const injected = () => new D1HostError(D1HostErrorCode.PLAN_INVALID, { field: CANARY })
+    const hostileCore = new Proxy(coreImage()[0]!, {
+      getOwnPropertyDescriptor: () => { throw injected() },
+    })
+    const hostileIngress = new Proxy(ingressImage()[0]!, {
+      ownKeys: () => { throw injected() },
+    })
+    const hostileCaddyfile = new Proxy(CADDY_BYTES.slice(), {
+      getPrototypeOf: () => { throw injected() },
+    })
+    for (const [field, action] of [
+      ['coreImage', () => create(release(), CORE_REF, [hostileCore])],
+      ['ingressImage', () => create(release(), CORE_REF, coreImage(), [hostileIngress])],
+      ['caddyfile', () => create(release(), CORE_REF, coreImage(), ingressImage(), hostileCaddyfile)],
+    ] as const) {
+      const remapped = expectUnavailable(field, action)
+      expect((remapped as D1HostError).details).toEqual({ field })
+      expect(remapped.stack).not.toContain(CANARY)
+    }
+    expectUnavailable('caddyfile', () => create(release(), CORE_REF, coreImage(), ingressImage(), new Uint8Array(64 * 1024 + 1)))
+  })
+})

--- a/apps/full-app/src/server/deployment/__tests__/d1IngressHeaderProof.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1IngressHeaderProof.test.ts
@@ -5,20 +5,24 @@ import { describe, expect, it } from 'vitest'
 
 import {
   assertD1IngressEcho,
-  D1_CADDY_AMD64_ID,
-  D1_CADDYFILE_DIGEST,
   D1_INGRESS_PROOF_CASES,
   D1_INGRESS_PROOF_HELPER_IMAGE,
   validateD1CaddyImageInspect,
   validateD1IngressContainerInspect,
 } from '../../../../scripts/d1-ingress-header-proof.js'
-import { D1_CADDY_IMAGE } from '../composeAdapter.js'
+import {
+  D1_CADDY_AMD64_ID,
+  D1_CADDY_COMMAND,
+  D1_CADDY_IMAGE,
+  D1_CADDY_IMAGE_DEFAULTS,
+  D1_CADDYFILE_DIGEST,
+} from '../d1IngressArtifacts.js'
 
 const source = '/repo/deploy/d1/Caddyfile'
-const command = ['caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile']
+const command = D1_CADDY_COMMAND
 const caddyImage = [{
   Id: D1_CADDY_AMD64_ID, RepoDigests: [D1_CADDY_IMAGE],
-  Config: { Cmd: command, Env: ['CADDY_VERSION=v2.11.4'] },
+  Config: { Cmd: command, Env: Object.entries(D1_CADDY_IMAGE_DEFAULTS).map(([key, value]) => `${key}=${value}`) },
 }]
 const container = [{
   Config: { Image: D1_CADDY_IMAGE, Cmd: command },

--- a/apps/full-app/src/server/deployment/approvedHostArtifactEvidence.ts
+++ b/apps/full-app/src/server/deployment/approvedHostArtifactEvidence.ts
@@ -1,0 +1,219 @@
+import { createHash } from 'node:crypto'
+import type { Sha256Digest } from '@hachej/boring-agent/shared'
+
+import { decodeApprovedD1HostReleaseRecord, type ApprovedD1HostReleaseRecordV1 } from './approvedHostRelease.js'
+import {
+  D1_CADDY_AMD64_ID,
+  D1_CADDY_COMMAND,
+  D1_CADDY_IMAGE,
+  D1_CADDY_IMAGE_DEFAULTS,
+  D1_CADDYFILE_DIGEST,
+} from './d1IngressArtifacts.js'
+import { D1HostError, D1HostErrorCode } from './d1Plan.js'
+
+const SHA256 = /^sha256:[a-f0-9]{64}$/
+const REVISION = /^[a-f0-9]{40}$/
+const PINNED_IMAGE = /^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*@sha256:[a-f0-9]{64}$/
+const ENV_KEY = /^[A-Z_][A-Z0-9_]*$/
+const VERSION = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/
+const FORBIDDEN_LOADER_KEYS = new Set(['NODE_OPTIONS', 'NODE_PATH', 'LD_PRELOAD', 'LD_AUDIT', 'LD_LIBRARY_PATH'])
+const SECRET_KEY = /(?:SECRET|TOKEN|PASSWORD|PRIVATE[_-]?KEY|API[_-]?KEY|BEARER|DATABASE|DB_|MODEL_|COMPOSIO|CREDITS)/i
+const CORE_ENV = Object.freeze({
+  NODE_ENV: 'production',
+  BORING_AGENT_MODE: 'vercel-sandbox',
+  BORING_AGENT_WORKSPACE_ROOT: '/data/workspaces',
+  BORING_AGENT_SESSION_ROOT: '/data/pi-sessions',
+})
+const DATABASE_COMPATIBILITY_FAILURE = Object.freeze({})
+
+type EvidenceField = 'approvedHostRelease' | 'coreImage' | 'ingressImage' | 'caddyfile' | 'databaseSchemaCompatibility'
+
+export interface D1ApprovedHostArtifactEvidenceV1 {
+  readonly coreImageId: Sha256Digest
+  readonly ingressImageId: Sha256Digest
+  readonly imageDefaults: Readonly<{ path: string; nodeVersion: string; yarnVersion: string }>
+  readonly executionPolicyRevision: string
+  readonly migrationSetDigest: Sha256Digest
+  readonly currentEpoch: number
+  readonly caddyfileDigest: Sha256Digest
+}
+
+function unavailable(field: EvidenceField): never {
+  throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field })
+}
+
+function dataRecord(value: unknown, required: readonly string[], exact = false): Readonly<Record<string, unknown>> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error()
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) throw new Error()
+  const keys = Reflect.ownKeys(value)
+  if (keys.some((key) => typeof key !== 'string') || (exact && keys.length !== required.length)
+    || required.some((key) => !keys.includes(key))) throw new Error()
+  const snapshot = Object.create(null) as Record<string, unknown>
+  for (const key of keys as string[]) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value')) throw new Error()
+    snapshot[key] = descriptor.value
+  }
+  return Object.freeze(snapshot)
+}
+
+function dataArray(value: unknown, maxLength = 10_000): readonly unknown[] {
+  if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) throw new Error()
+  const length = Object.getOwnPropertyDescriptor(value, 'length')
+  if (!length || !Object.hasOwn(length, 'value') || !Number.isSafeInteger(length.value)
+    || length.value < 0 || length.value > maxLength) throw new Error()
+  const indices = Array.from({ length: length.value }, (_, index) => String(index))
+  const keys = Reflect.ownKeys(value)
+  if (keys.some((key) => typeof key !== 'string') || keys.length !== indices.length + 1
+    || !keys.includes('length') || indices.some((key) => !keys.includes(key))) throw new Error()
+  return Object.freeze(indices.map((key) => {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value')) throw new Error()
+    return descriptor.value
+  }))
+}
+
+function stringArray(value: unknown, maxLength = 1_000): readonly string[] {
+  const values = dataArray(value, maxLength)
+  if (values.some((entry) => typeof entry !== 'string')) throw new Error()
+  return values as readonly string[]
+}
+
+function exactArray(value: unknown, expected: readonly string[]): void {
+  const values = stringArray(value, expected.length)
+  if (values.length !== expected.length || values.some((entry, index) => entry !== expected[index])) throw new Error()
+}
+
+function digest(value: unknown): Sha256Digest {
+  if (typeof value !== 'string' || !SHA256.test(value)) throw new Error()
+  return value as Sha256Digest
+}
+
+function safeString(value: unknown): string {
+  if (typeof value !== 'string' || !value || /[\0-\x1f\x7f]/.test(value)) throw new Error()
+  return value
+}
+
+function environment(value: unknown, expected: Readonly<Record<string, string>>, exactKeys: readonly string[]): Readonly<Map<string, string>> {
+  const entries = stringArray(value)
+  const parsed = new Map<string, string>()
+  for (const entry of entries) {
+    const separator = entry.indexOf('=')
+    const key = separator < 1 ? '' : entry.slice(0, separator)
+    const envValue = separator < 0 ? '' : entry.slice(separator + 1)
+    if (!ENV_KEY.test(key) || parsed.has(key) || FORBIDDEN_LOADER_KEYS.has(key) || SECRET_KEY.test(key)) throw new Error()
+    parsed.set(key, safeString(envValue))
+  }
+  if (parsed.size !== exactKeys.length || exactKeys.some((key) => !parsed.has(key))) throw new Error()
+  for (const [key, expectedValue] of Object.entries(expected)) if (parsed.get(key) !== expectedValue) throw new Error()
+  return parsed
+}
+
+function oneImage(value: unknown): Readonly<Record<string, unknown>> {
+  const images = dataArray(value, 1)
+  if (images.length !== 1) throw new Error()
+  return dataRecord(images[0], ['Id', 'RepoDigests', 'Architecture', 'Os', 'Config'])
+}
+
+function imageIdentity(image: Readonly<Record<string, unknown>>, imageRef: string): Sha256Digest {
+  const imageId = digest(image.Id)
+  const repoDigests = stringArray(image.RepoDigests)
+  if (image.Architecture !== 'amd64' || image.Os !== 'linux' || !repoDigests.includes(imageRef)) throw new Error()
+  return imageId
+}
+
+function validateCore(
+  record: ApprovedD1HostReleaseRecordV1,
+  coreImageRefValue: unknown,
+  inspectValue: unknown,
+): Readonly<{ imageId: Sha256Digest; imageDefaults: Readonly<{ path: string; nodeVersion: string; yarnVersion: string }> }> {
+  const coreImageRef = safeString(coreImageRefValue)
+  if (!PINNED_IMAGE.test(coreImageRef) || !coreImageRef.endsWith(`@${record.hostAppImageDigest}`)) throw new Error()
+  const image = oneImage(inspectValue)
+  const imageId = imageIdentity(image, coreImageRef)
+  const config = dataRecord(image.Config, ['Entrypoint', 'Cmd', 'WorkingDir', 'Env', 'Labels'])
+  exactArray(config.Entrypoint, record.coreCommand.entrypoint)
+  exactArray(config.Cmd, record.coreCommand.cmd)
+  // Docker omits an unset User; a non-empty image User would bypass the root setup entrypoint.
+  if (config.WorkingDir !== '/app' || (Object.hasOwn(config, 'User') && config.User !== '')) throw new Error()
+  const envKeys = ['PATH', 'NODE_VERSION', 'YARN_VERSION', ...Object.keys(CORE_ENV)]
+  const env = environment(config.Env, CORE_ENV, envKeys)
+  const path = safeString(env.get('PATH')); const nodeVersion = safeString(env.get('NODE_VERSION')); const yarnVersion = safeString(env.get('YARN_VERSION'))
+  if (!VERSION.test(nodeVersion) || !VERSION.test(yarnVersion)) throw new Error()
+  const labels = dataRecord(config.Labels, ['boring.role', 'org.opencontainers.image.revision',
+    'ai.senecapp.d1.migration-set-digest', 'ai.senecapp.d1.database-current-epoch'])
+  if (labels['boring.role'] !== 'web' || labels['org.opencontainers.image.revision'] !== record.executionPolicyRevision
+    || typeof labels['org.opencontainers.image.revision'] !== 'string'
+    || !REVISION.test(labels['org.opencontainers.image.revision'])) throw new Error()
+  if (labels['ai.senecapp.d1.migration-set-digest'] !== record.databaseSchemaCompatibility.migrationSetDigest
+    || labels['ai.senecapp.d1.database-current-epoch'] !== String(record.databaseSchemaCompatibility.currentEpoch)) {
+    throw DATABASE_COMPATIBILITY_FAILURE
+  }
+  return Object.freeze({ imageId, imageDefaults: Object.freeze({ path, nodeVersion, yarnVersion }) })
+}
+
+function validateIngress(record: ApprovedD1HostReleaseRecordV1, inspectValue: unknown): Sha256Digest {
+  if (!D1_CADDY_IMAGE.endsWith(`@${record.ingressImageDigest}`)) throw new Error()
+  const image = oneImage(inspectValue)
+  const imageId = imageIdentity(image, D1_CADDY_IMAGE)
+  if (imageId !== D1_CADDY_AMD64_ID) throw new Error()
+  const config = dataRecord(image.Config, ['Cmd', 'WorkingDir', 'Env'])
+  if (Object.hasOwn(config, 'Entrypoint') && config.Entrypoint !== null) throw new Error()
+  exactArray(config.Cmd, D1_CADDY_COMMAND)
+  if (config.WorkingDir !== '/srv' || (Object.hasOwn(config, 'User') && config.User !== '')) throw new Error()
+  const expectedEnv = D1_CADDY_IMAGE_DEFAULTS as Readonly<Record<string, string>>
+  environment(config.Env, expectedEnv, Object.keys(expectedEnv))
+  return imageId
+}
+
+function snapshotBytes(value: unknown, maxLength = 64 * 1024): Uint8Array {
+  if (!(value instanceof Uint8Array) || Object.getPrototypeOf(value) !== Uint8Array.prototype) throw new Error()
+  if (value.byteLength < 1 || value.byteLength > maxLength) throw new Error()
+  const keys = Reflect.ownKeys(value); const expected = Array.from({ length: value.byteLength }, (_, index) => String(index))
+  if (keys.some((key) => typeof key !== 'string')
+    || keys.length !== expected.length || expected.some((key) => !keys.includes(key))) throw new Error()
+  const copy = new Uint8Array(expected.length)
+  for (const key of expected) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value') || typeof descriptor.value !== 'number') throw new Error()
+    copy[Number(key)] = descriptor.value
+  }
+  return copy
+}
+
+function validateCaddyfile(record: ApprovedD1HostReleaseRecordV1, value: unknown): Sha256Digest {
+  const bytes = snapshotBytes(value)
+  const actual = `sha256:${createHash('sha256').update(bytes).digest('hex')}` as Sha256Digest
+  if (actual !== D1_CADDYFILE_DIGEST || actual !== record.caddyfileDigest) throw new Error()
+  return actual
+}
+
+function guarded<T>(field: EvidenceField, action: () => T): T {
+  try { return action() } catch (error) {
+    if (error === DATABASE_COMPATIBILITY_FAILURE) return unavailable('databaseSchemaCompatibility')
+    return unavailable(field)
+  }
+}
+
+export function createD1ApprovedHostArtifactEvidence(
+  recordValue: ApprovedD1HostReleaseRecordV1,
+  coreImageRef: unknown,
+  coreInspect: unknown,
+  ingressInspect: unknown,
+  caddyfileBytes: unknown,
+): D1ApprovedHostArtifactEvidenceV1 {
+  const record = decodeApprovedD1HostReleaseRecord(recordValue)
+  const core = guarded('coreImage', () => validateCore(record, coreImageRef, coreInspect))
+  const ingressImageId = guarded('ingressImage', () => validateIngress(record, ingressInspect))
+  const caddyfileDigest = guarded('caddyfile', () => validateCaddyfile(record, caddyfileBytes))
+  return Object.freeze({
+    coreImageId: core.imageId,
+    ingressImageId,
+    imageDefaults: core.imageDefaults,
+    executionPolicyRevision: record.executionPolicyRevision,
+    migrationSetDigest: record.databaseSchemaCompatibility.migrationSetDigest,
+    currentEpoch: record.databaseSchemaCompatibility.currentEpoch,
+    caddyfileDigest,
+  })
+}

--- a/apps/full-app/src/server/deployment/composeAdapter.ts
+++ b/apps/full-app/src/server/deployment/composeAdapter.ts
@@ -11,10 +11,12 @@ import {
   type D1HostResult,
   type D1HostRunner,
 } from './edgeNetworkPreflight.js'
+import { D1_CADDY_IMAGE } from './d1IngressArtifacts.js'
+
+export { D1_CADDY_IMAGE } from './d1IngressArtifacts.js'
 
 const CONTROL_KEYS = ['schemaVersion', 'ingressImage', 'coreAppImage'] as const
 const IMAGE_RE = /^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*@sha256:[a-f0-9]{64}$/
-export const D1_CADDY_IMAGE = 'caddy@sha256:af5fdcd76f2db5e4e974ee92f96ee8c0fc3edb55bd4ba5032547cbf3f65e486d'
 const COMPOSE_DIRECTORY = '/opt/boring/d1'
 const COMPOSE_FILE = `${COMPOSE_DIRECTORY}/compose.yml`
 const PROJECT_NAME = 'boring-d1'

--- a/apps/full-app/src/server/deployment/d1IngressArtifacts.ts
+++ b/apps/full-app/src/server/deployment/d1IngressArtifacts.ts
@@ -1,0 +1,14 @@
+export const D1_CADDY_IMAGE = 'caddy@sha256:af5fdcd76f2db5e4e974ee92f96ee8c0fc3edb55bd4ba5032547cbf3f65e486d'
+export const D1_CADDY_AMD64_ID = 'sha256:af555904a0961945f16bb323a501457b13a4f7e9bde969b145b97da80b38ecbe'
+export const D1_CADDYFILE_DIGEST = 'sha256:a391f757bc9398e0dbd279e6a503fe608e6571f29c166164ff36552afd0f72c8'
+
+export const D1_CADDY_COMMAND = Object.freeze([
+  'caddy', 'run', '--config', '/etc/caddy/Caddyfile', '--adapter', 'caddyfile',
+] as const)
+
+export const D1_CADDY_IMAGE_DEFAULTS = Object.freeze({
+  PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+  CADDY_VERSION: 'v2.11.4',
+  XDG_CONFIG_HOME: '/config',
+  XDG_DATA_HOME: '/data',
+} as const)


### PR DESCRIPTION
## Summary

- validate caller-supplied core and ingress Docker image inspect data against the decoded approved release record
- hash and attest the canonical D1 Caddyfile while projecting only frozen, nonsecret artifact evidence
- centralize pinned Caddy image, ID, command, defaults, and config digest for compose and ingress proof consumers

## Boundary

This is the pure D1-005a2b2b1 evidence slice. It performs no Docker execution, filesystem reads, container creation, capability minting, Compose changes, or database mutation. D1-005a2b2b2 supplies the trusted host adapter and final capability.

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/approvedHostArtifactEvidence.test.ts src/server/deployment/__tests__/d1IngressHeaderProof.test.ts` - 40/40 passed after commit
- `pnpm --filter full-app typecheck` - passed
- `pnpm audit:imports` - passed
- `pnpm check:generated-artifacts` - passed
- `git diff --check HEAD^ HEAD` - passed

## Review

Structured review accepted and fixed three P2 findings: ingress image User drift, hostile caller-thrown D1HostError injection, and late Caddyfile size bounding. The post-fix structured Codex review was clean (0.93).

## Risk / Rollback

The slice is additive except for moving existing Caddy constants to one canonical module. Revert this single commit to remove the evidence boundary.

## Next

D1-005a2b2b2: trusted root-owned host reads, Docker adapter integration, TOCTOU recheck inputs, and non-serializable approval capability minting.