### PR TITLE
feat(d1): verify Caddyfile authority

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1CaddyfileAuthority.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1CaddyfileAuthority.test.ts
@@ -1,0 +1,165 @@
+import { link, mkdir, mkdtemp, readFile, rename, symlink, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  createD1CaddyfileAuthorityReaderForPolicy,
+  D1_CADDYFILE_AUTHORITY_POLICY,
+  D1_CADDYFILE_MAX_BYTES,
+  D1_CADDYFILE_PATH,
+  type D1CaddyfileAuthorityPolicy,
+} from '../d1CaddyfileAuthority.js'
+import { D1HostError, D1HostErrorCode } from '../d1Plan.js'
+
+const UID = process.geteuid!()
+const GID = process.getegid!()
+const CANARY = 'caddy-authority-canary-never-leaks'
+const CONTENT = new TextEncoder().encode('example.test {\n  reverse_proxy core-app:3000\n}\n')
+
+async function fixture() {
+  const parent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-caddy-authority-'))
+  const directoryPath = path.join(parent, 'd1')
+  await mkdir(directoryPath, { mode: 0o755 })
+  const file = path.join(directoryPath, 'Caddyfile')
+  await writeFile(file, CONTENT, { mode: 0o444 })
+  const policy: D1CaddyfileAuthorityPolicy = {
+    directoryPath,
+    directoryUid: UID,
+    directoryGid: GID,
+    directoryMode: 0o755,
+    fileUid: UID,
+    fileGid: GID,
+    fileMode: 0o444,
+    maxBytes: D1_CADDYFILE_MAX_BYTES,
+  }
+  return { directoryPath, file, policy }
+}
+
+function reader(policy: D1CaddyfileAuthorityPolicy) {
+  return createD1CaddyfileAuthorityReaderForPolicy(policy)
+}
+
+async function expectUnavailable(action: Promise<unknown>): Promise<void> {
+  const failure = await action.catch((error) => error)
+  expect(failure).toEqual(expect.objectContaining({
+    code: D1HostErrorCode.COLLECTION_NOT_READY,
+    details: { field: 'caddyfile' },
+  }))
+  expect(JSON.stringify(failure)).not.toMatch(new RegExp(`${CANARY}|boring-d1-caddy-authority-|Caddyfile`))
+}
+
+function expectUnavailableSync(action: () => unknown): void {
+  let failure: unknown
+  try { action() } catch (error) { failure = error }
+  expect(failure).toEqual(expect.objectContaining({
+    code: D1HostErrorCode.COLLECTION_NOT_READY,
+    details: { field: 'caddyfile' },
+  }))
+  expect(JSON.stringify(failure)).not.toContain(CANARY)
+}
+
+describe('D1 Caddyfile authority', () => {
+  it('reads detached bytes through a descriptor-anchored reader', async () => {
+    const h = await fixture()
+    const authorityReader = reader(h.policy)
+    const first = await authorityReader.read()
+    first[0] = 0
+    const second = await authorityReader.read()
+    expect(second).toEqual(CONTENT)
+    expect(first).not.toEqual(second)
+    expect(Object.isFrozen(authorityReader)).toBe(true)
+  })
+
+  it('hard-codes the production path and root-owned immutable policy', () => {
+    expect(D1_CADDYFILE_PATH).toBe('/opt/boring/d1/Caddyfile')
+    expect(D1_CADDYFILE_AUTHORITY_POLICY).toEqual({
+      directoryPath: '/opt/boring/d1',
+      directoryUid: 0,
+      directoryGid: 0,
+      directoryMode: 0o755,
+      fileUid: 0,
+      fileGid: 0,
+      fileMode: 0o444,
+      maxBytes: 64 * 1024,
+    })
+    expect(Object.isFrozen(D1_CADDYFILE_AUTHORITY_POLICY)).toBe(true)
+  })
+
+  it.each([
+    ['directory owner', (p: D1CaddyfileAuthorityPolicy) => ({ ...p, directoryUid: p.directoryUid + 1 })],
+    ['directory group', (p: D1CaddyfileAuthorityPolicy) => ({ ...p, directoryGid: p.directoryGid + 1 })],
+    ['directory mode', (p: D1CaddyfileAuthorityPolicy) => ({ ...p, directoryMode: 0o750 })],
+    ['file owner', (p: D1CaddyfileAuthorityPolicy) => ({ ...p, fileUid: p.fileUid + 1 })],
+    ['file group', (p: D1CaddyfileAuthorityPolicy) => ({ ...p, fileGid: p.fileGid + 1 })],
+    ['file mode', (p: D1CaddyfileAuthorityPolicy) => ({ ...p, fileMode: 0o440 })],
+  ])('rejects wrong %s metadata', async (_name, mutate) => {
+    const h = await fixture()
+    await expectUnavailable(reader(mutate(h.policy)).read())
+  })
+
+  it('rejects symlinked directories and symlinked or hard-linked files', async () => {
+    for (const mutation of ['directory-symlink', 'file-symlink', 'file-hardlink']) {
+      const h = await fixture()
+      if (mutation === 'directory-symlink') {
+        await rename(h.directoryPath, `${h.directoryPath}.target`)
+        await symlink(`${h.directoryPath}.target`, h.directoryPath)
+      } else if (mutation === 'file-symlink') {
+        await rename(h.file, `${h.file}.target`)
+        await symlink(`${h.file}.target`, h.file)
+      } else await link(h.file, `${h.file}.link`)
+      await expectUnavailable(reader(h.policy).read())
+    }
+  })
+
+  it('rejects a non-regular, missing, empty, or oversized file', async () => {
+    for (const mutation of ['directory', 'missing', 'empty', 'oversized']) {
+      const h = await fixture()
+      await rename(h.file, `${h.file}.original`)
+      if (mutation === 'directory') await mkdir(h.file, { mode: 0o444 })
+      else if (mutation !== 'missing') {
+        const contents = mutation === 'empty' ? new Uint8Array() : new Uint8Array(D1_CADDYFILE_MAX_BYTES + 1)
+        await writeFile(h.file, contents, { mode: 0o444 })
+      }
+      await expectUnavailable(reader(h.policy).read())
+    }
+  })
+
+  it('snapshots policy and ignores later caller mutation', async () => {
+    const h = await fixture()
+    const mutablePolicy = { ...h.policy }
+    const authorityReader = reader(mutablePolicy)
+    mutablePolicy.directoryPath = `${h.directoryPath}-${CANARY}`
+    mutablePolicy.fileMode = 0o600
+    expect(await authorityReader.read()).toEqual(CONTENT)
+  })
+
+  it('rejects noncanonical and hostile policy without leaking canaries', async () => {
+    const h = await fixture()
+    for (const directoryPath of ['relative', `${h.directoryPath}/`, `${h.directoryPath}\0${CANARY}`]) {
+      expectUnavailableSync(() => reader({ ...h.policy, directoryPath }))
+    }
+    const hostile = new Proxy(h.policy, {
+      get() {
+        throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: CANARY })
+      },
+    })
+    expectUnavailableSync(() => reader(hostile))
+  })
+
+  it('suppresses file contents and paths when filesystem validation fails', async () => {
+    const h = await fixture()
+    await rename(h.file, `${h.file}.${CANARY}`)
+    await writeFile(h.file, CANARY, { mode: 0o400 })
+    await expectUnavailable(reader(h.policy).read())
+  })
+
+  it('has no writer API and reads only through anchored no-follow descriptors', async () => {
+    const source = await readFile(new URL('../d1CaddyfileAuthority.ts', import.meta.url), 'utf8')
+    expect(source).toContain('/proc/self/fd/')
+    expect(source).toContain('O_NOFOLLOW')
+    expect(source).toContain('O_NONBLOCK')
+    expect(source).not.toMatch(/writeFile|rename|unlink|createWriteStream|process\.env/)
+  })
+})

--- a/apps/full-app/src/server/deployment/d1CaddyfileAuthority.ts
+++ b/apps/full-app/src/server/deployment/d1CaddyfileAuthority.ts
@@ -1,0 +1,177 @@
+import { constants, type Stats } from 'node:fs'
+import { lstat, open, realpath, type FileHandle } from 'node:fs/promises'
+import path from 'node:path'
+
+import { D1HostError, D1HostErrorCode } from './d1Plan.js'
+
+export const D1_CADDYFILE_PATH = '/opt/boring/d1/Caddyfile'
+export const D1_CADDYFILE_MAX_BYTES = 64 * 1024
+
+const CADDYFILE_NAME = 'Caddyfile'
+const OPEN_DIRECTORY = constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW
+const OPEN_FILE = constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK
+
+export interface D1CaddyfileAuthorityReader {
+  read(): Promise<Uint8Array>
+}
+
+export interface D1CaddyfileAuthorityPolicy {
+  readonly directoryPath: string
+  readonly directoryUid: number
+  readonly directoryGid: number
+  readonly directoryMode: number
+  readonly fileUid: number
+  readonly fileGid: number
+  readonly fileMode: number
+  readonly maxBytes: number
+}
+
+export const D1_CADDYFILE_AUTHORITY_POLICY: Readonly<D1CaddyfileAuthorityPolicy> = Object.freeze({
+  directoryPath: path.dirname(D1_CADDYFILE_PATH),
+  directoryUid: 0,
+  directoryGid: 0,
+  directoryMode: 0o755,
+  fileUid: 0,
+  fileGid: 0,
+  fileMode: 0o444,
+  maxBytes: D1_CADDYFILE_MAX_BYTES,
+})
+
+function unavailable(): never {
+  throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'caddyfile' })
+}
+
+function sameIdentity(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino
+}
+
+function sameVersion(left: Stats, right: Stats): boolean {
+  return sameIdentity(left, right)
+    && left.size === right.size
+    && left.mtimeMs === right.mtimeMs
+    && left.ctimeMs === right.ctimeMs
+}
+
+function exactMetadata(info: Stats, uid: number, gid: number, mode: number): boolean {
+  return info.uid === uid && info.gid === gid && (info.mode & 0o7777) === mode
+}
+
+async function closeQuietly(handle: FileHandle | undefined): Promise<void> {
+  try { await handle?.close() } catch {}
+}
+
+function validPolicy(value: unknown): Readonly<D1CaddyfileAuthorityPolicy> {
+  if (!value || typeof value !== 'object') throw new Error('policy')
+  const input = value as D1CaddyfileAuthorityPolicy
+  const directoryPath = input.directoryPath
+  const directoryUid = input.directoryUid
+  const directoryGid = input.directoryGid
+  const directoryMode = input.directoryMode
+  const fileUid = input.fileUid
+  const fileGid = input.fileGid
+  const fileMode = input.fileMode
+  const maxBytes = input.maxBytes
+  const ids = [directoryUid, directoryGid, fileUid, fileGid]
+  const modes = [directoryMode, fileMode]
+  if (typeof directoryPath !== 'string' || directoryPath.includes('\0')
+    || !path.isAbsolute(directoryPath) || path.resolve(directoryPath) !== directoryPath
+    || ids.some((id) => !Number.isSafeInteger(id) || id < 0)
+    || modes.some((mode) => !Number.isSafeInteger(mode) || mode < 0 || mode > 0o7777)
+    || !Number.isSafeInteger(maxBytes) || maxBytes < 1 || maxBytes > D1_CADDYFILE_MAX_BYTES) throw new Error('policy')
+  return Object.freeze({ directoryPath, directoryUid, directoryGid, directoryMode, fileUid, fileGid, fileMode, maxBytes })
+}
+
+async function readBounded(handle: FileHandle, maxBytes: number): Promise<Uint8Array> {
+  const allocation = new Uint8Array(maxBytes + 1)
+  let offset = 0
+  while (offset < allocation.byteLength) {
+    const { bytesRead } = await handle.read(allocation, offset, allocation.byteLength - offset, offset)
+    if (bytesRead === 0) break
+    offset += bytesRead
+  }
+  if (offset > maxBytes) throw new Error('file too large')
+  return allocation.slice(0, offset)
+}
+
+async function openDirectory(policy: Readonly<D1CaddyfileAuthorityPolicy>): Promise<{
+  handle: FileHandle
+  initial: Stats
+}> {
+  const pathBefore = await lstat(policy.directoryPath)
+  if (!pathBefore.isDirectory() || pathBefore.isSymbolicLink()) throw new Error('directory')
+  const handle = await open(policy.directoryPath, OPEN_DIRECTORY)
+  try {
+    const initial = await handle.stat()
+    if (!initial.isDirectory() || !sameIdentity(pathBefore, initial)
+      || !exactMetadata(initial, policy.directoryUid, policy.directoryGid, policy.directoryMode)
+      || await realpath(`/proc/self/fd/${handle.fd}`) !== policy.directoryPath) throw new Error('directory')
+    return { handle, initial }
+  } catch (error) {
+    await closeQuietly(handle)
+    throw error
+  }
+}
+
+async function readFile(directory: FileHandle, policy: Readonly<D1CaddyfileAuthorityPolicy>): Promise<Uint8Array> {
+  const expectedPath = path.join(policy.directoryPath, CADDYFILE_NAME)
+  const directoryAnchor = `/proc/self/fd/${directory.fd}`
+  const pathBefore = await lstat(expectedPath)
+  if (!pathBefore.isFile() || pathBefore.isSymbolicLink()
+    || !exactMetadata(pathBefore, policy.fileUid, policy.fileGid, policy.fileMode)
+    || pathBefore.nlink !== 1 || pathBefore.size < 1 || pathBefore.size > policy.maxBytes) throw new Error('file')
+  const handle = await open(path.join(directoryAnchor, CADDYFILE_NAME), OPEN_FILE)
+  try {
+    const initial = await handle.stat()
+    if (!initial.isFile() || !sameVersion(pathBefore, initial)
+      || !exactMetadata(initial, policy.fileUid, policy.fileGid, policy.fileMode)
+      || initial.nlink !== 1 || await realpath(`/proc/self/fd/${handle.fd}`) !== expectedPath) throw new Error('file')
+    const bytes = await readBounded(handle, policy.maxBytes)
+    const final = await handle.stat()
+    const pathAfter = await lstat(expectedPath)
+    if (!final.isFile() || !sameVersion(initial, final) || !sameVersion(initial, pathAfter)
+      || !exactMetadata(final, policy.fileUid, policy.fileGid, policy.fileMode)
+      || !exactMetadata(pathAfter, policy.fileUid, policy.fileGid, policy.fileMode)
+      || final.nlink !== 1 || pathAfter.nlink !== 1 || bytes.byteLength !== initial.size
+      || await realpath(`/proc/self/fd/${handle.fd}`) !== expectedPath) throw new Error('file changed')
+    return bytes
+  } finally {
+    await closeQuietly(handle)
+  }
+}
+
+async function verifyDirectoryAfter(
+  handle: FileHandle,
+  initial: Stats,
+  policy: Readonly<D1CaddyfileAuthorityPolicy>,
+): Promise<void> {
+  const final = await handle.stat()
+  const pathAfter = await lstat(policy.directoryPath)
+  if (!final.isDirectory() || !sameIdentity(initial, final) || !sameIdentity(initial, pathAfter)
+    || !exactMetadata(final, policy.directoryUid, policy.directoryGid, policy.directoryMode)
+    || !exactMetadata(pathAfter, policy.directoryUid, policy.directoryGid, policy.directoryMode)
+    || await realpath(`/proc/self/fd/${handle.fd}`) !== policy.directoryPath) throw new Error('directory changed')
+}
+
+/** Trusted policy seam for filesystem tests. It cannot change the fixed Caddyfile basename. */
+export function createD1CaddyfileAuthorityReaderForPolicy(input: D1CaddyfileAuthorityPolicy): D1CaddyfileAuthorityReader {
+  let policy: Readonly<D1CaddyfileAuthorityPolicy>
+  try { policy = validPolicy(input) } catch { return unavailable() }
+  return Object.freeze({
+    async read(): Promise<Uint8Array> {
+      let directory: FileHandle | undefined
+      try {
+        const opened = await openDirectory(policy)
+        directory = opened.handle
+        const bytes = await readFile(directory, policy)
+        await verifyDirectoryAfter(directory, opened.initial, policy)
+        return bytes
+      } catch { return unavailable() } finally { await closeQuietly(directory) }
+    },
+  })
+}
+
+const productionReader = createD1CaddyfileAuthorityReaderForPolicy(D1_CADDYFILE_AUTHORITY_POLICY)
+
+export async function readD1CaddyfileAuthority(): Promise<Uint8Array> {
+  return productionReader.read()
+}


### PR DESCRIPTION
## Contract

- read only the fixed production authority at `/opt/boring/d1/Caddyfile`
- require root-owned `0755` directory and root-owned, regular, singly linked `0444` file
- anchor reads through no-follow descriptors and verify path, descriptor, metadata, version, and directory identity before/after
- return detached bytes bounded to 64 KiB
- normalize every failure to `D1_COLLECTION_NOT_READY` with `{ field: "caddyfile" }`
- expose only a policy-based filesystem test seam; no writer or generic authority framework

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/d1CaddyfileAuthority.test.ts` - 14/14 passed after rebase
- `pnpm --filter full-app typecheck` - no errors
- `git diff --check HEAD^ HEAD` - clean
- independent review: no P0-P2; structured autoreview clean at 0.94 confidence

## Accepted residual risk

The before/after guards cover mid-read path and metadata mutation, but the race does not have a deterministic test. Adding a test-only I/O hook would expand the production seam and is a worse tradeoff for this fixed authority reader.