### PR TITLE
refactor(core): expose security config projection

### DIFF
--- a/packages/core/src/server/config/__tests__/coreSecurityConfigProjection.test.ts
+++ b/packages/core/src/server/config/__tests__/coreSecurityConfigProjection.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../fileSecrets', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../fileSecrets')>()
+  return {
+    ...actual,
+    resolveConfigFileSecrets: vi.fn(actual.resolveConfigFileSecrets),
+  }
+})
+
+import {
+  loadConfig,
+  readCoreSecurityConfigProjection,
+} from '../index.js'
+import { resolveConfigFileSecrets } from '../fileSecrets.js'
+import { ConfigValidationError } from '../../../shared/errors.js'
+
+const REQUIRED_SECRETS = Object.freeze({
+  DATABASE_URL: 'postgres://user:pass@localhost:5432/testdb',
+  BETTER_AUTH_SECRET: 'a'.repeat(64),
+  WORKSPACE_SETTINGS_ENCRYPTION_KEY: 'b'.repeat(64),
+})
+
+function selectSecurityConfig(config: Awaited<ReturnType<typeof loadConfig>>) {
+  return {
+    host: config.host,
+    port: config.port,
+    betterAuthUrl: config.auth.url,
+    corsOrigins: config.cors.origins,
+    cspEnabled: config.security?.csp.enabled,
+    cspUpgradeInsecureRequests:
+      config.security?.csp.upgradeInsecureRequests,
+    sessionCookieSecure: config.auth.sessionCookieSecure,
+    trustedProxy: config.security?.trustedProxy,
+  }
+}
+
+describe('readCoreSecurityConfigProjection', () => {
+  it.each([
+    ['defaults', {}],
+    [
+      'representative overrides',
+      {
+        HOST: '127.0.0.1',
+        PORT: '4100',
+        BETTER_AUTH_URL: 'https://app.example.test',
+        CORS_ORIGINS:
+          'https://app.example.test, https://admin.example.test',
+        CSP_ENABLED: 'false',
+        CSP_UPGRADE_INSECURE_REQUESTS: 'false',
+        SESSION_COOKIE_SECURE: 'false',
+        TRUST_PROXY_LEGACY_UNSAFE: '1',
+      },
+    ],
+    [
+      'D1 production policy',
+      {
+        NODE_ENV: 'production',
+        BORING_D1_HOST_ID: 'eu-host-1',
+        HOST: '0.0.0.0',
+        PORT: '3000',
+        BETTER_AUTH_URL: 'https://insurance.example.test',
+        CORS_ORIGINS: 'https://insurance.example.test',
+        CSP_ENABLED: 'true',
+        CSP_UPGRADE_INSECURE_REQUESTS: 'true',
+        SESSION_COOKIE_SECURE: 'true',
+        TRUST_PROXY_CIDRS: '192.168.255.250/32',
+        TRUST_PROXY_HOPS: '1',
+      },
+    ],
+  ] as const)('matches loadConfig for %s', async (_name, overrides) => {
+    const env = { ...REQUIRED_SECRETS, ...overrides }
+
+    const projection = readCoreSecurityConfigProjection(env)
+    const config = await loadConfig({
+      env,
+      tomlPath: '/projection-test-does-not-exist.toml',
+    })
+
+    expect(projection).toEqual(selectSecurityConfig(config))
+    expect(Object.isFrozen(projection)).toBe(true)
+    expect(Object.isFrozen(projection.corsOrigins)).toBe(true)
+    if (
+      projection.trustedProxy &&
+      projection.trustedProxy !== 'legacy-unsafe'
+    ) {
+      expect(Object.isFrozen(projection.trustedProxy)).toBe(true)
+      expect(Object.isFrozen(projection.trustedProxy.cidrs)).toBe(true)
+    }
+  })
+
+  it('preserves pre-schema proxy parsing while loadConfig rejects invalid input', async () => {
+    const env = {
+      ...REQUIRED_SECRETS,
+      TRUST_PROXY_CIDRS: 'not-a-cidr',
+      TRUST_PROXY_HOPS: '9',
+    }
+
+    const projection = readCoreSecurityConfigProjection(env)
+
+    expect(projection.trustedProxy).toMatchObject({
+      cidrs: ['not-a-cidr'],
+      hops: Number.NaN,
+    })
+    await expect(
+      loadConfig({
+        env,
+        tomlPath: '/projection-test-does-not-exist.toml',
+      }),
+    ).rejects.toBeInstanceOf(ConfigValidationError)
+  })
+
+  it('keeps proxy policy errors identical to loadConfig', async () => {
+    const env = {
+      ...REQUIRED_SECRETS,
+      BORING_D1_HOST_ID: 'eu-host-1',
+    }
+
+    expect(() => readCoreSecurityConfigProjection(env)).toThrow(
+      ConfigValidationError,
+    )
+    await expect(
+      loadConfig({
+        env,
+        tomlPath: '/projection-test-does-not-exist.toml',
+      }),
+    ).rejects.toBeInstanceOf(ConfigValidationError)
+  })
+
+  it('returns detached values that do not follow later input mutation', () => {
+    const env: Record<string, string | undefined> = {
+      BETTER_AUTH_URL: 'https://app.example.test',
+      CORS_ORIGINS: 'https://app.example.test,https://admin.example.test',
+      TRUST_PROXY_CIDRS: '192.168.255.250/32',
+      TRUST_PROXY_HOPS: '1',
+    }
+
+    const projection = readCoreSecurityConfigProjection(env)
+    env.BETTER_AUTH_URL = 'http://mutated.invalid'
+    env.CORS_ORIGINS = 'http://mutated.invalid'
+    env.TRUST_PROXY_CIDRS = '10.0.0.0/8'
+
+    expect(projection.betterAuthUrl).toBe('https://app.example.test')
+    expect(projection.corsOrigins).toEqual([
+      'https://app.example.test',
+      'https://admin.example.test',
+    ])
+    expect(projection.trustedProxy).toEqual({
+      cidrs: ['192.168.255.250/32'],
+      hops: 1,
+    })
+  })
+
+  it('reads only the explicit nonsecret projection env allowlist', () => {
+    vi.mocked(resolveConfigFileSecrets).mockClear()
+    const accessed: string[] = []
+    const projectionEnvKeys = [
+      'BETTER_AUTH_URL',
+      'BORING_D1_HOST_ID',
+      'CORS_ORIGINS',
+      'CSP_ENABLED',
+      'CSP_UPGRADE_INSECURE_REQUESTS',
+      'HOST',
+      'PORT',
+      'SESSION_COOKIE_SECURE',
+      'TRUST_PROXY_CIDRS',
+      'TRUST_PROXY_HOPS',
+      'TRUST_PROXY_LEGACY_UNSAFE',
+    ].sort()
+    const envCanaries = {
+      DATABASE_URL: 'inline-database-canary',
+      DATABASE_URL_FILE: '/secret-file-canary/database-url',
+      BETTER_AUTH_SECRET: 'inline-auth-canary',
+      BETTER_AUTH_SECRET_FILE: '/secret-file-canary/auth-secret',
+      WORKSPACE_SETTINGS_ENCRYPTION_KEY: 'inline-encryption-canary',
+      WORKSPACE_SETTINGS_ENCRYPTION_KEY_FILE:
+        '/secret-file-canary/encryption-key',
+      GITHUB_CLIENT_ID: 'github-client-canary',
+      GITHUB_CLIENT_SECRET: 'github-secret-canary',
+      GOOGLE_CLIENT_ID: 'google-client-canary',
+      GOOGLE_CLIENT_SECRET: 'google-secret-canary',
+      MAIL_FROM: 'mail-from-canary@example.test',
+      MAIL_TRANSPORT_URL: 'smtp://mail-transport-canary',
+      BETTER_AUTH_URL: 'https://app.example.test',
+    }
+    const env = new Proxy(envCanaries, {
+      get(target, property, receiver) {
+        if (typeof property === 'string') accessed.push(property)
+        return Reflect.get(target, property, receiver)
+      },
+    })
+
+    expect(readCoreSecurityConfigProjection(env).betterAuthUrl).toBe(
+      'https://app.example.test',
+    )
+    expect([...new Set(accessed)].sort()).toEqual(projectionEnvKeys)
+    expect(resolveConfigFileSecrets).not.toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/server/config/index.ts
+++ b/packages/core/src/server/config/index.ts
@@ -1,7 +1,12 @@
 export {
   loadConfig,
+  readCoreSecurityConfigProjection,
   validateConfig,
   buildRuntimeConfigPayload,
 } from './loadConfig.js'
-export type { LoadConfigOptions } from './loadConfig.js'
+export type {
+  CoreSecurityConfigProjection,
+  CoreTrustedProxyPolicyInput,
+  LoadConfigOptions,
+} from './loadConfig.js'
 export { coreConfigSchema } from './schema.js'

--- a/packages/core/src/server/config/loadConfig.ts
+++ b/packages/core/src/server/config/loadConfig.ts
@@ -22,6 +22,26 @@ export interface LoadConfigOptions {
   allowMissingSecrets?: boolean
 }
 
+export type CoreTrustedProxyPolicyInput =
+  | undefined
+  | 'legacy-unsafe'
+  | Readonly<{
+      cidrs: readonly string[]
+      hops: number
+    }>
+
+export interface CoreSecurityConfigProjection {
+  readonly host: string
+  readonly port: number
+  readonly betterAuthUrl: string
+  readonly corsOrigins: readonly string[]
+  readonly cspEnabled: boolean
+  readonly cspUpgradeInsecureRequests: boolean
+  readonly sessionCookieSecure: boolean
+  /** Parsed input only; whole-config schema validation still establishes validity. */
+  readonly trustedProxy: CoreTrustedProxyPolicyInput
+}
+
 interface TomlAppConfig {
   app?: { id?: string }
   frontend?: {
@@ -83,7 +103,9 @@ function parseRateLimitOverrides(
   }
 }
 
-function parseTrustedProxyPolicy(env: Record<string, string | undefined>): unknown {
+function parseTrustedProxyPolicy(
+  env: Readonly<Record<string, string | undefined>>,
+): CoreTrustedProxyPolicyInput {
   const cidrs = env.TRUST_PROXY_CIDRS
   const hops = env.TRUST_PROXY_HOPS
   const legacy = env.TRUST_PROXY_LEGACY_UNSAFE
@@ -102,10 +124,47 @@ function parseTrustedProxyPolicy(env: Record<string, string | undefined>): unkno
     }
     return undefined
   }
-  return {
-    cidrs: (cidrs ?? '').split(',').map((value) => value.trim()),
+  return Object.freeze({
+    cidrs: Object.freeze(
+      (cidrs ?? '').split(',').map((value) => value.trim()),
+    ),
     hops: hops !== undefined && /^[1-8]$/.test(hops) ? Number(hops) : Number.NaN,
-  }
+  })
+}
+
+export function readCoreSecurityConfigProjection(
+  env: Readonly<Record<string, string | undefined>>,
+): CoreSecurityConfigProjection {
+  const betterAuthUrl =
+    env.BETTER_AUTH_URL ?? `http://localhost:${env.PORT ?? '3000'}`
+  const corsOriginsRaw = env.CORS_ORIGINS ?? ''
+  const corsOrigins = Object.freeze(
+    corsOriginsRaw
+      ? corsOriginsRaw
+          .split(',')
+          .map((origin) => origin.trim())
+          .filter(Boolean)
+      : ['http://localhost:3000', 'http://localhost:5173'],
+  )
+  const cspUpgradeInsecureRequests =
+    env.CSP_UPGRADE_INSECURE_REQUESTS !== undefined
+      ? env.CSP_UPGRADE_INSECURE_REQUESTS === 'true'
+      : betterAuthUrl.startsWith('https://')
+  const sessionCookieSecure =
+    env.SESSION_COOKIE_SECURE !== undefined
+      ? env.SESSION_COOKIE_SECURE === 'true'
+      : betterAuthUrl.startsWith('https://')
+
+  return Object.freeze({
+    host: env.HOST ?? '0.0.0.0',
+    port: parseInt(env.PORT ?? '3000', 10),
+    betterAuthUrl,
+    corsOrigins,
+    cspEnabled: env.CSP_ENABLED !== 'false',
+    cspUpgradeInsecureRequests,
+    sessionCookieSecure,
+    trustedProxy: parseTrustedProxyPolicy(env),
+  })
 }
 
 export async function loadConfig(
@@ -169,24 +228,6 @@ export async function loadConfig(
     )
   }
 
-  const authUrl = env.BETTER_AUTH_URL ?? `http://localhost:${env.PORT ?? '3000'}`
-
-  const corsOriginsRaw = env.CORS_ORIGINS ?? ''
-  const corsOrigins = corsOriginsRaw
-    ? corsOriginsRaw.split(',').map((s) => s.trim()).filter(Boolean)
-    : ['http://localhost:3000', 'http://localhost:5173']
-  const cspEnabled = env.CSP_ENABLED !== 'false'
-  const cspUpgradeInsecureRequests =
-    env.CSP_UPGRADE_INSECURE_REQUESTS !== undefined
-      ? env.CSP_UPGRADE_INSECURE_REQUESTS === 'true'
-      : authUrl.startsWith('https://')
-
-  const sessionCookieSecureOverride = env.SESSION_COOKIE_SECURE
-  const sessionCookieSecure =
-    sessionCookieSecureOverride !== undefined
-      ? sessionCookieSecureOverride === 'true'
-      : authUrl.startsWith('https://')
-
   const githubOauth =
     toml.features?.github_oauth ?? env.GITHUB_OAUTH === 'true'
   const github =
@@ -212,33 +253,36 @@ export async function loadConfig(
     mailFrom && mailTransportUrl
       ? { from: mailFrom, transportUrl: mailTransportUrl }
       : undefined
+  const rateLimit = parseRateLimitOverrides(env.RATE_LIMIT_OVERRIDES_JSON)
+  const securityConfig = readCoreSecurityConfigProjection(env)
 
   const raw: unknown = {
     appId,
     appName,
     appLogo,
 
-    port: parseInt(env.PORT ?? '3000', 10),
-    host: env.HOST ?? '0.0.0.0',
+    port: securityConfig.port,
+    host: securityConfig.host,
     staticDir: env.STATIC_DIR ?? null,
 
     databaseUrl,
     stores,
 
     cors: {
-      origins: corsOrigins,
+      origins: securityConfig.corsOrigins,
       credentials: true as const,
     },
 
     bodyLimit: parseInt(env.BODY_LIMIT_BYTES ?? String(SIXTEEN_MB), 10),
     logLevel: env.LOG_LEVEL ?? 'info',
-    rateLimit: parseRateLimitOverrides(env.RATE_LIMIT_OVERRIDES_JSON),
+    rateLimit,
     security: {
       csp: {
-        enabled: cspEnabled,
-        upgradeInsecureRequests: cspUpgradeInsecureRequests,
+        enabled: securityConfig.cspEnabled,
+        upgradeInsecureRequests:
+          securityConfig.cspUpgradeInsecureRequests,
       },
-      trustedProxy: parseTrustedProxyPolicy(env),
+      trustedProxy: securityConfig.trustedProxy,
     },
 
     encryption: {
@@ -247,7 +291,7 @@ export async function loadConfig(
 
     auth: {
       secret: authSecret,
-      url: authUrl,
+      url: securityConfig.betterAuthUrl,
       github,
       google,
       mail,
@@ -255,7 +299,7 @@ export async function loadConfig(
         env.SESSION_TTL_SECONDS ?? String(THIRTY_DAYS_SECONDS),
         10,
       ),
-      sessionCookieSecure,
+      sessionCookieSecure: securityConfig.sessionCookieSecure,
     },
 
     features: {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,10 +1,15 @@
 export {
   loadConfig,
+  readCoreSecurityConfigProjection,
   validateConfig,
   buildRuntimeConfigPayload,
   coreConfigSchema,
 } from './config/index.js'
-export type { LoadConfigOptions } from './config/index.js'
+export type {
+  CoreSecurityConfigProjection,
+  CoreTrustedProxyPolicyInput,
+  LoadConfigOptions,
+} from './config/index.js'
 
 export { safeRedirect } from './security/index.js'
 


### PR DESCRIPTION
## Summary

- expose one pure, secret-free projection for core host/auth/browser security config
- make `loadConfig` consume the same derivation without changing validation or runtime behavior
- export the projection through the core server surface for the D1 intended-policy adapter

## Safety

The projection reads only its explicit nonsecret environment allowlist. It does not read `process.env` implicitly, TOML, the filesystem, secret files, inline secrets, OAuth/mail secrets, or D1/full-app code. Composite output is detached and frozen. Trusted-proxy data remains explicitly pre-schema input and the existing whole-config schema remains the sole validator.

## Proof

- `pnpm --filter @hachej/boring-core exec vitest run src/server/config/__tests__/coreSecurityConfigProjection.test.ts src/server/config/__tests__/loadConfig.test.ts` (53/53 passed)
- `pnpm --filter @hachej/boring-core run typecheck` (passed)
- `git diff --check origin/main..HEAD` (passed)
- structured autoreview (clean, 0.97 confidence; no accepted/actionable findings)

## Risk / Rollback

Narrow refactor with parity coverage. Squash revert restores the prior inline derivation.