### PR TITLE
feat(d1): verify core environment authority

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1CoreEnvAuthority.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1CoreEnvAuthority.test.ts
@@ -1,0 +1,202 @@
+import { link, mkdir, mkdtemp, readFile, rename, symlink, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+import {
+  createD1CoreEnvAuthorityReaderForPolicy,
+  D1_CORE_ENV_AUTHORITY_POLICY,
+  D1_CORE_ENV_MAX_BYTES,
+  D1_CORE_ENV_PATH,
+  type D1CoreEnvAuthorityPolicy,
+} from '../d1CoreEnvAuthority.js'
+import { D1HostError, D1HostErrorCode } from '../d1Plan.js'
+
+const UID = process.geteuid!()
+const GID = process.getegid!()
+const CANARY = 'core-env-secret-canary-never-leaks'
+const VALUES = Object.freeze({
+  BORING_D1_OWNER_UID: '0',
+  DATABASE_URL_FILE: '/run/boring/d1/host-secrets/database-url',
+  BETTER_AUTH_SECRET_FILE: '/run/boring/d1/host-secrets/better-auth-secret',
+  WORKSPACE_SETTINGS_ENCRYPTION_KEY_FILE: '/run/boring/d1/host-secrets/workspace-settings-encryption-key',
+  BORING_PLUGIN_AUTHORING: '0',
+  BETTER_AUTH_URL: 'https://auth.example.test',
+  CORS_ORIGINS: 'https://a.example.test,https://z.example.test',
+  CSP_ENABLED: 'true',
+  CSP_UPGRADE_INSECURE_REQUESTS: 'true',
+  SESSION_COOKIE_SECURE: 'true',
+  BORING_MCP_PROD_ENABLED: '0',
+  BORING_MANAGED_AGENT_MCP_ENABLED: '0',
+  BORING_D1_MAX_BINDINGS: '20',
+  BORING_D1_MAX_BUNDLE_BYTES: '1000000',
+  BORING_D1_MAX_TOTAL_BUNDLE_BYTES: '10000000',
+  BORING_D1_MAX_CONCURRENT_PRELOADS: '4',
+})
+const CANONICAL = Object.entries(VALUES).map(([key, value]) => `${key}=${value}`).join('\n') + '\n'
+
+async function fixture(content: string | Uint8Array = CANONICAL) {
+  const parent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-core-env-'))
+  const directoryPath = path.join(parent, 'd1')
+  await mkdir(directoryPath, { mode: 0o755 })
+  const file = path.join(directoryPath, 'core.env')
+  await writeFile(file, content, { mode: 0o444 })
+  const policy: D1CoreEnvAuthorityPolicy = {
+    directoryPath,
+    directoryUid: UID,
+    directoryGid: GID,
+    directoryMode: 0o755,
+    fileUid: UID,
+    fileGid: GID,
+    fileMode: 0o444,
+    maxBytes: D1_CORE_ENV_MAX_BYTES,
+  }
+  return { directoryPath, file, policy }
+}
+
+function reader(policy: D1CoreEnvAuthorityPolicy) {
+  return createD1CoreEnvAuthorityReaderForPolicy(policy)
+}
+
+async function expectUnavailable(action: Promise<unknown>): Promise<void> {
+  const failure = await action.catch((error) => error)
+  expect(failure).toEqual(expect.objectContaining({
+    code: D1HostErrorCode.COLLECTION_NOT_READY,
+    details: { field: 'coreEnv' },
+  }))
+  expect(`${String(failure)}${JSON.stringify(failure)}`).not.toMatch(
+    new RegExp(`${CANARY}|boring-d1-core-env-|core\\.env|/etc/boring`),
+  )
+}
+
+function expectUnavailableSync(action: () => unknown): void {
+  let failure: unknown
+  try { action() } catch (error) { failure = error }
+  expect(failure).toEqual(expect.objectContaining({
+    code: D1HostErrorCode.COLLECTION_NOT_READY,
+    details: { field: 'coreEnv' },
+  }))
+  expect(`${String(failure)}${JSON.stringify(failure)}`).not.toContain(CANARY)
+}
+
+describe('D1 core.env authority', () => {
+  it('reads a detached, deeply frozen, exact 16-key record', async () => {
+    const h = await fixture()
+    const authorityReader = reader(h.policy)
+    const result = await authorityReader.read()
+    expect(result).toEqual(VALUES)
+    expect(Object.keys(result)).toHaveLength(16)
+    expect(Object.isFrozen(result)).toBe(true)
+    expect(Object.isFrozen(authorityReader)).toBe(true)
+    expect(result).not.toHaveProperty('COMPOSIO_API_KEY')
+    expect(result).not.toHaveProperty('BORING_MANAGED_AGENT_MCP_BEARER_TOKEN')
+  })
+
+  it('hard-codes the production path and root-owned immutable policy', () => {
+    expect(D1_CORE_ENV_PATH).toBe('/etc/boring/d1/core.env')
+    expect(D1_CORE_ENV_AUTHORITY_POLICY).toEqual({
+      directoryPath: '/etc/boring/d1',
+      directoryUid: 0,
+      directoryGid: 0,
+      directoryMode: 0o755,
+      fileUid: 0,
+      fileGid: 0,
+      fileMode: 0o444,
+      maxBytes: 64 * 1024,
+    })
+    expect(Object.isFrozen(D1_CORE_ENV_AUTHORITY_POLICY)).toBe(true)
+  })
+
+  it.each([
+    ['reordered', CANONICAL.split('\n').slice(0, -1).reverse().join('\n') + '\n'],
+    ['duplicate', `${CANONICAL}BORING_D1_OWNER_UID=0\n`],
+    ['comment', `# ${CANARY}\n${CANONICAL}`],
+    ['blank', `\n${CANONICAL}`],
+    ['quoted', CANONICAL.replace('BORING_D1_OWNER_UID=0', 'BORING_D1_OWNER_UID="0"')],
+    ['export', CANONICAL.replace('BORING_D1_OWNER_UID=0', 'export BORING_D1_OWNER_UID=0')],
+    ['colon delimiter', CANONICAL.replace('BORING_D1_OWNER_UID=0', 'BORING_D1_OWNER_UID: 0')],
+    ['CRLF', CANONICAL.replaceAll('\n', '\r\n')],
+    ['missing final LF', CANONICAL.slice(0, -1)],
+    ['interpolation', CANONICAL.replace('BORING_D1_OWNER_UID=0', 'BORING_D1_OWNER_UID=$OWNER_UID')],
+    ['escape', CANONICAL.replace('BORING_D1_OWNER_UID=0', 'BORING_D1_OWNER_UID=\\0')],
+    ['unknown', `${CANONICAL}UNKNOWN_BEHAVIOR=${CANARY}\n`],
+    ['loader', `${CANONICAL}NODE_OPTIONS=${CANARY}\n`],
+    ['raw secret', `${CANONICAL}DATABASE_URL=${CANARY}\n`],
+    ['Composio secret', `${CANONICAL}COMPOSIO_API_KEY=${CANARY}\n`],
+    ['managed bearer', `${CANONICAL}BORING_MANAGED_AGENT_MCP_BEARER_TOKEN=${CANARY}\n`],
+    ['managed workspace target', `${CANONICAL}BORING_MANAGED_AGENT_MCP_WORKSPACE_ID=${CANARY}\n`],
+    ['managed user target', `${CANONICAL}BORING_MANAGED_AGENT_MCP_USER_ID=${CANARY}\n`],
+    ['managed enabled', CANONICAL.replace('BORING_MANAGED_AGENT_MCP_ENABLED=0', 'BORING_MANAGED_AGENT_MCP_ENABLED=1')],
+    ['wrong selector', CANONICAL.replace('/run/boring/d1/host-secrets/database-url', `/tmp/${CANARY}`)],
+    ['invalid UTF-8', new Uint8Array([0xff])],
+  ])('rejects noncanonical %s input with one bounded error', async (_name, content) => {
+    const h = await fixture(content)
+    await expectUnavailable(reader(h.policy).read())
+  })
+
+  it.each([
+    ['directory owner', (p: D1CoreEnvAuthorityPolicy) => ({ ...p, directoryUid: p.directoryUid + 1 })],
+    ['directory group', (p: D1CoreEnvAuthorityPolicy) => ({ ...p, directoryGid: p.directoryGid + 1 })],
+    ['directory mode', (p: D1CoreEnvAuthorityPolicy) => ({ ...p, directoryMode: 0o750 })],
+    ['file owner', (p: D1CoreEnvAuthorityPolicy) => ({ ...p, fileUid: p.fileUid + 1 })],
+    ['file group', (p: D1CoreEnvAuthorityPolicy) => ({ ...p, fileGid: p.fileGid + 1 })],
+    ['file mode', (p: D1CoreEnvAuthorityPolicy) => ({ ...p, fileMode: 0o440 })],
+  ])('rejects wrong %s metadata', async (_name, mutate) => {
+    const h = await fixture()
+    await expectUnavailable(reader(mutate(h.policy)).read())
+  })
+
+  it('rejects symlinked directories and symlinked or hard-linked files', async () => {
+    for (const mutation of ['directory-symlink', 'file-symlink', 'file-hardlink']) {
+      const h = await fixture()
+      if (mutation === 'directory-symlink') {
+        await rename(h.directoryPath, `${h.directoryPath}.target`)
+        await symlink(`${h.directoryPath}.target`, h.directoryPath)
+      } else if (mutation === 'file-symlink') {
+        await rename(h.file, `${h.file}.target`)
+        await symlink(`${h.file}.target`, h.file)
+      } else await link(h.file, `${h.file}.link`)
+      await expectUnavailable(reader(h.policy).read())
+    }
+  })
+
+  it('rejects a non-regular, missing, empty, or oversized file', async () => {
+    for (const mutation of ['directory', 'missing', 'empty', 'oversized']) {
+      const h = await fixture()
+      await rename(h.file, `${h.file}.original`)
+      if (mutation === 'directory') await mkdir(h.file, { mode: 0o444 })
+      else if (mutation !== 'missing') {
+        const contents = mutation === 'empty' ? new Uint8Array() : new Uint8Array(D1_CORE_ENV_MAX_BYTES + 1)
+        await writeFile(h.file, contents, { mode: 0o444 })
+      }
+      await expectUnavailable(reader(h.policy).read())
+    }
+  })
+
+  it('snapshots policy and rejects hostile policy without leaking its canary', async () => {
+    const h = await fixture()
+    const mutable = { ...h.policy }
+    const authorityReader = reader(mutable)
+    mutable.directoryPath = `${h.directoryPath}-${CANARY}`
+    mutable.fileMode = 0o600
+    expect(await authorityReader.read()).toEqual(VALUES)
+
+    const hostile = new Proxy(h.policy, {
+      get() { throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: CANARY }) },
+    })
+    expectUnavailableSync(() => reader(hostile))
+    for (const directoryPath of ['relative', `${h.directoryPath}/`, `${h.directoryPath}\0${CANARY}`]) {
+      expectUnavailableSync(() => reader({ ...h.policy, directoryPath }))
+    }
+  })
+
+  it('has no writer API and uses anchored no-follow descriptors', async () => {
+    const source = await readFile(new URL('../d1CoreEnvAuthority.ts', import.meta.url), 'utf8')
+    expect(source).toContain('/proc/self/fd/')
+    expect(source).toContain('O_NOFOLLOW')
+    expect(source).toContain('O_NONBLOCK')
+    expect(source).toContain("parseEnv(content)")
+    expect(source).not.toMatch(/writeFile|rename|unlink|createWriteStream|process\.env|COMPOSIO_API_KEY/)
+  })
+})

--- a/apps/full-app/src/server/deployment/d1CoreEnvAuthority.ts
+++ b/apps/full-app/src/server/deployment/d1CoreEnvAuthority.ts
@@ -1,0 +1,218 @@
+import { constants, type Stats } from 'node:fs'
+import { lstat, open, realpath, type FileHandle } from 'node:fs/promises'
+import path from 'node:path'
+import { parseEnv } from 'node:util'
+
+import { D1HostError, D1HostErrorCode } from './d1Plan.js'
+
+export const D1_CORE_ENV_PATH = '/etc/boring/d1/core.env'
+export const D1_CORE_ENV_MAX_BYTES = 64 * 1024
+
+const CORE_ENV_NAME = 'core.env'
+const OPEN_DIRECTORY = constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW
+const OPEN_FILE = constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK
+const CORE_ENV_KEYS = [
+  'BORING_D1_OWNER_UID',
+  'DATABASE_URL_FILE',
+  'BETTER_AUTH_SECRET_FILE',
+  'WORKSPACE_SETTINGS_ENCRYPTION_KEY_FILE',
+  'BORING_PLUGIN_AUTHORING',
+  'BETTER_AUTH_URL',
+  'CORS_ORIGINS',
+  'CSP_ENABLED',
+  'CSP_UPGRADE_INSECURE_REQUESTS',
+  'SESSION_COOKIE_SECURE',
+  'BORING_MCP_PROD_ENABLED',
+  'BORING_MANAGED_AGENT_MCP_ENABLED',
+  'BORING_D1_MAX_BINDINGS',
+  'BORING_D1_MAX_BUNDLE_BYTES',
+  'BORING_D1_MAX_TOTAL_BUNDLE_BYTES',
+  'BORING_D1_MAX_CONCURRENT_PRELOADS',
+] as const
+const FIXED_VALUES = Object.freeze({
+  DATABASE_URL_FILE: '/run/boring/d1/host-secrets/database-url',
+  BETTER_AUTH_SECRET_FILE: '/run/boring/d1/host-secrets/better-auth-secret',
+  WORKSPACE_SETTINGS_ENCRYPTION_KEY_FILE: '/run/boring/d1/host-secrets/workspace-settings-encryption-key',
+  BORING_PLUGIN_AUTHORING: '0',
+  CSP_ENABLED: 'true',
+  CSP_UPGRADE_INSECURE_REQUESTS: 'true',
+  SESSION_COOKIE_SECURE: 'true',
+  BORING_MANAGED_AGENT_MCP_ENABLED: '0',
+})
+const CANONICAL_VALUE = /^[\x21-\x7e]+$/
+const FORBIDDEN_VALUE_CHARACTERS = /["'#$\\]/
+
+export type D1CoreEnvV1 = Readonly<Record<(typeof CORE_ENV_KEYS)[number], string>>
+
+export interface D1CoreEnvAuthorityReader {
+  read(): Promise<D1CoreEnvV1>
+}
+
+export interface D1CoreEnvAuthorityPolicy {
+  readonly directoryPath: string
+  readonly directoryUid: number
+  readonly directoryGid: number
+  readonly directoryMode: number
+  readonly fileUid: number
+  readonly fileGid: number
+  readonly fileMode: number
+  readonly maxBytes: number
+}
+
+export const D1_CORE_ENV_AUTHORITY_POLICY: Readonly<D1CoreEnvAuthorityPolicy> = Object.freeze({
+  directoryPath: path.dirname(D1_CORE_ENV_PATH),
+  directoryUid: 0,
+  directoryGid: 0,
+  directoryMode: 0o755,
+  fileUid: 0,
+  fileGid: 0,
+  fileMode: 0o444,
+  maxBytes: D1_CORE_ENV_MAX_BYTES,
+})
+
+function unavailable(): never {
+  throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'coreEnv' })
+}
+
+function sameIdentity(left: Stats, right: Stats): boolean {
+  return left.dev === right.dev && left.ino === right.ino
+}
+
+function sameVersion(left: Stats, right: Stats): boolean {
+  return sameIdentity(left, right) && left.size === right.size
+    && left.mtimeMs === right.mtimeMs && left.ctimeMs === right.ctimeMs
+}
+
+function exactMetadata(info: Stats, uid: number, gid: number, mode: number): boolean {
+  return info.uid === uid && info.gid === gid && (info.mode & 0o7777) === mode
+}
+
+async function closeQuietly(handle: FileHandle | undefined): Promise<void> {
+  try { await handle?.close() } catch {}
+}
+
+function validPolicy(value: unknown): Readonly<D1CoreEnvAuthorityPolicy> {
+  if (!value || typeof value !== 'object') throw new Error()
+  const input = value as D1CoreEnvAuthorityPolicy
+  const policy = {
+    directoryPath: input.directoryPath,
+    directoryUid: input.directoryUid,
+    directoryGid: input.directoryGid,
+    directoryMode: input.directoryMode,
+    fileUid: input.fileUid,
+    fileGid: input.fileGid,
+    fileMode: input.fileMode,
+    maxBytes: input.maxBytes,
+  }
+  const ids = [policy.directoryUid, policy.directoryGid, policy.fileUid, policy.fileGid]
+  const modes = [policy.directoryMode, policy.fileMode]
+  if (typeof policy.directoryPath !== 'string' || policy.directoryPath.includes('\0')
+    || !path.isAbsolute(policy.directoryPath) || path.resolve(policy.directoryPath) !== policy.directoryPath
+    || ids.some((id) => !Number.isSafeInteger(id) || id < 0)
+    || modes.some((mode) => !Number.isSafeInteger(mode) || mode < 0 || mode > 0o7777)
+    || !Number.isSafeInteger(policy.maxBytes) || policy.maxBytes < 1
+    || policy.maxBytes > D1_CORE_ENV_MAX_BYTES) throw new Error()
+  return Object.freeze(policy)
+}
+
+function parseCoreEnv(bytes: Uint8Array): D1CoreEnvV1 {
+  const content = new TextDecoder('utf-8', { fatal: true }).decode(bytes)
+  const parsed = parseEnv(content)
+  if (Object.keys(parsed).length !== CORE_ENV_KEYS.length) throw new Error()
+  const snapshot = Object.create(null) as Record<string, string>
+  for (const key of CORE_ENV_KEYS) {
+    const value = parsed[key]
+    if (typeof value !== 'string' || !CANONICAL_VALUE.test(value)
+      || FORBIDDEN_VALUE_CHARACTERS.test(value)) throw new Error()
+    snapshot[key] = value
+  }
+  for (const [key, value] of Object.entries(FIXED_VALUES)) {
+    if (snapshot[key] !== value) throw new Error()
+  }
+  if (snapshot.BORING_MCP_PROD_ENABLED !== '0' && snapshot.BORING_MCP_PROD_ENABLED !== '1') throw new Error()
+  const canonical = CORE_ENV_KEYS.map((key) => `${key}=${snapshot[key]}`).join('\n') + '\n'
+  if (content !== canonical) throw new Error()
+  return Object.freeze(snapshot) as D1CoreEnvV1
+}
+
+async function readBounded(handle: FileHandle, maxBytes: number): Promise<Uint8Array> {
+  const allocation = new Uint8Array(maxBytes + 1)
+  let offset = 0
+  while (offset < allocation.byteLength) {
+    const { bytesRead } = await handle.read(allocation, offset, allocation.byteLength - offset, offset)
+    if (bytesRead === 0) break
+    offset += bytesRead
+  }
+  if (offset > maxBytes) throw new Error()
+  return allocation.slice(0, offset)
+}
+
+async function openDirectory(policy: Readonly<D1CoreEnvAuthorityPolicy>): Promise<{ handle: FileHandle; initial: Stats }> {
+  const before = await lstat(policy.directoryPath)
+  if (!before.isDirectory() || before.isSymbolicLink()) throw new Error()
+  const handle = await open(policy.directoryPath, OPEN_DIRECTORY)
+  try {
+    const initial = await handle.stat()
+    if (!initial.isDirectory() || !sameIdentity(before, initial)
+      || !exactMetadata(initial, policy.directoryUid, policy.directoryGid, policy.directoryMode)
+      || await realpath(`/proc/self/fd/${handle.fd}`) !== policy.directoryPath) throw new Error()
+    return { handle, initial }
+  } catch (error) { await closeQuietly(handle); throw error }
+}
+
+async function readFile(directory: FileHandle, policy: Readonly<D1CoreEnvAuthorityPolicy>): Promise<D1CoreEnvV1> {
+  const expectedPath = path.join(policy.directoryPath, CORE_ENV_NAME)
+  const before = await lstat(expectedPath)
+  if (!before.isFile() || before.isSymbolicLink() || before.nlink !== 1
+    || !exactMetadata(before, policy.fileUid, policy.fileGid, policy.fileMode)
+    || before.size < 1 || before.size > policy.maxBytes) throw new Error()
+  const handle = await open(`/proc/self/fd/${directory.fd}/${CORE_ENV_NAME}`, OPEN_FILE)
+  try {
+    const initial = await handle.stat()
+    if (!initial.isFile() || !sameVersion(before, initial) || initial.nlink !== 1
+      || !exactMetadata(initial, policy.fileUid, policy.fileGid, policy.fileMode)
+      || await realpath(`/proc/self/fd/${handle.fd}`) !== expectedPath) throw new Error()
+    const bytes = await readBounded(handle, policy.maxBytes)
+    const final = await handle.stat()
+    const after = await lstat(expectedPath)
+    if (!final.isFile() || !sameVersion(initial, final) || !sameVersion(initial, after)
+      || !exactMetadata(final, policy.fileUid, policy.fileGid, policy.fileMode)
+      || !exactMetadata(after, policy.fileUid, policy.fileGid, policy.fileMode)
+      || final.nlink !== 1 || after.nlink !== 1 || bytes.byteLength !== initial.size
+      || await realpath(`/proc/self/fd/${handle.fd}`) !== expectedPath) throw new Error()
+    return parseCoreEnv(bytes)
+  } finally { await closeQuietly(handle) }
+}
+
+async function verifyDirectory(handle: FileHandle, initial: Stats, policy: Readonly<D1CoreEnvAuthorityPolicy>): Promise<void> {
+  const final = await handle.stat()
+  const after = await lstat(policy.directoryPath)
+  if (!final.isDirectory() || !sameVersion(initial, final) || !sameVersion(initial, after)
+    || !exactMetadata(final, policy.directoryUid, policy.directoryGid, policy.directoryMode)
+    || !exactMetadata(after, policy.directoryUid, policy.directoryGid, policy.directoryMode)
+    || await realpath(`/proc/self/fd/${handle.fd}`) !== policy.directoryPath) throw new Error()
+}
+
+/** Trusted policy seam for filesystem tests; the core.env basename stays fixed. */
+export function createD1CoreEnvAuthorityReaderForPolicy(input: D1CoreEnvAuthorityPolicy): D1CoreEnvAuthorityReader {
+  let policy: Readonly<D1CoreEnvAuthorityPolicy>
+  try { policy = validPolicy(input) } catch { return unavailable() }
+  return Object.freeze({
+    async read(): Promise<D1CoreEnvV1> {
+      let directory: FileHandle | undefined
+      try {
+        const opened = await openDirectory(policy)
+        directory = opened.handle
+        const env = await readFile(directory, policy)
+        await verifyDirectory(directory, opened.initial, policy)
+        return env
+      } catch { return unavailable() } finally { await closeQuietly(directory) }
+    },
+  })
+}
+
+const productionReader = createD1CoreEnvAuthorityReaderForPolicy(D1_CORE_ENV_AUTHORITY_POLICY)
+
+export async function readD1CoreEnvAuthority(): Promise<D1CoreEnvV1> {
+  return productionReader.read()
+}

--- a/docs/issues/391/runtime-refactor/FORWARD-PLAN.md
+++ b/docs/issues/391/runtime-refactor/FORWARD-PLAN.md
@@ -494,17 +494,23 @@ bead below:
   agentMode, workspaceRoot:"/data/workspaces", sessionRoot:"/data/pi-sessions",
   trustedProxy:{cidrs:["192.168.255.250/32"],hops:1}, externalPlugins:false,
   pluginAuthoring:false, betterAuthUrl, corsOrigins, cspEnabled, ...,
-  managedAgentMcp:{enabled,workspaceId?,userId?},
+  managedAgentMcp:{enabled:false},
   collectionPolicy:{maxBindings,maxBundleBytes,maxTotalBundleBytes,
-  maxConcurrentPreloads} }` (the policy is part of the approved digest).
+  maxConcurrentPreloads} }` (the policy is part of the approved digest). D1 R0
+  hard-pins managed-agent MCP disabled and intentionally cannot serve managed
+  MCP. A named post-R0 **M1-D1H managed-MCP deployment-hardening** bead, owned
+  by M1, must add bearer `*_FILE` resolution/materialization/rotation/restart
+  plus conditional workspace/user target enablement. P5a participates only if
+  shared secret brokerage is required; this host-approval slice does not.
 - **Do NOT / stop-signs.** No container create/start, P6-R, admission, preload,
   pointer, or ingress op in this bead; the release record is never caller-
   supplied, persisted-by-app, mounted, or reconstructed from app self-report.
 - **Dependencies.** D1-004c1–c5 (the static selector inventory it freezes),
   D1-003a ingress constants.
 - **Acceptance.** Unknown/secret-bearing keys and drift in owner UID, mode,
-  roots, proxy, auth URL, CORS, CSP, cookie security, MCP enablement, or managed
-  target all reject; changing any allowed behavior-bearing value changes the
+  roots, proxy, auth URL, CORS, CSP, cookie security, or MCP enablement all
+  reject; managed-agent MCP enablement or target keys also reject in D1 R0.
+  Changing any allowed behavior-bearing value changes the
   approved digest and rejects even when the value is output-redacted; a
   materialized secret canary proves no secret bytes enter Docker
   config/identity/failure output.

--- a/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/D1-R0-SPEC.md
+++ b/docs/issues/391/runtime-refactor/work/D1-tenant-provisioning/D1-R0-SPEC.md
@@ -864,13 +864,20 @@ agentMode, workspaceRoot: "/data/workspaces", sessionRoot: "/data/pi-sessions",
 trustedProxy: { cidrs: ["192.168.255.250/32"], hops: 1 }, externalPlugins: false,
 pluginAuthoring: false, betterAuthUrl, corsOrigins, cspEnabled,
 cspUpgradeInsecureRequests, sessionCookieSecure, boringMcpEnabled,
-managedAgentMcp: { enabled, workspaceId?, userId? } }`. Effective values come
+managedAgentMcp: { enabled: false } }`. D1 R0 hard-pins managed-agent MCP
+disabled and intentionally cannot serve managed MCP. A named post-R0
+**M1-D1H managed-MCP deployment-hardening** bead, owned by M1, must add bearer
+`*_FILE` resolution/materialization/rotation/restart plus conditional
+workspace/user target enablement. P5a participates only if shared secret
+brokerage is required; this host-approval slice does not.
+Effective values come
 from the same production readers used by the app. Bearer/API/auth/database/model
 secret refs bind through the existing approved plan identity, never env. Any new environment
 key or route/auth/browser/trust-boundary config reader requires a schema/policy
 revision, renewed review, and new approved record before production use. Prove
 unknown/secret-bearing keys and drift in owner UID, mode, roots, proxy, auth URL,
-CORS, CSP, cookie security, MCP enablement, or managed target reject. A
+CORS, CSP, cookie security, or MCP enablement reject. Managed-agent MCP
+enablement or target keys also reject in D1 R0. A
 materialized canary proves no secret bytes enter Docker config, identity, or
 failure output.
 


### PR DESCRIPTION
## Summary

- Add the fixed root-owned `/etc/boring/d1/core.env` authority reader.
- Return only a detached frozen canonical 16-key record; raw bytes never escape.
- Reality-sync D1 R0 to hard-pin managed MCP disabled and assign secure hosted enablement to the post-R0 M1-owned `M1-D1H` bead.

## Contract

- Root:root directory `0755`; root:root file `0444`, regular, singly linked, nonempty, max 64 KiB.
- Descriptor-anchored no-follow/nonblocking read with before/after identity, version, metadata, and path checks.
- Node `parseEnv` followed by exact fixed-order `KEY=VALUE\n` byte equality.
- Exact three file-secret selectors; managed MCP exactly disabled; unknown, loader, raw-secret, managed bearer/target, interpolation, quoting, comments, duplicate, reordered, or noncanonical input rejects as bounded `D1_COLLECTION_NOT_READY {field: coreEnv}`.
- No Compose semantics/version change and no host fact or capability minting in this slice.

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/d1CoreEnvAuthority.test.ts src/server/deployment/__tests__/composeAdapter.test.ts` - 2 files, 51 tests passed.
- `pnpm --dir apps/full-app run typecheck` - passed.
- `git diff --check HEAD^ HEAD` - passed.
- Structured Codex autoreview - clean, no accepted/actionable findings, confidence 0.93.
- Rebase patch identity preserved: `fb069f699df82fd96f4b04e48032148f419c48b9`.

## M1-D1H decision

D1 R0 intentionally cannot serve managed MCP. M1 owns the post-R0 `M1-D1H` deployment-hardening bead for bearer `*_FILE` resolution, materialization, rotation/restart, and conditional workspace/user targeting. P5a participates only if shared secret brokerage is required.