### PR TITLE
feat(391-AR1): AR1-002 — opaque ShareEntryV1 store

### DIFF
--- a/packages/agent/src/shared/__tests__/share-entry.test.ts
+++ b/packages/agent/src/shared/__tests__/share-entry.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  InMemoryShareEntryStore,
+  OpaqueShareLocatorIdSchema,
+  ShareEntryErrorCode,
+  ShareEntryV1Schema,
+  ShareEntryValidationError,
+  resolveShareEntry,
+  type CreateShareEntryInput,
+  type ShareEntryV1,
+} from '../share-entry'
+import type { Stat, Workspace } from '../workspace'
+
+function validInput(overrides: Partial<CreateShareEntryInput> = {}): CreateShareEntryInput {
+  return {
+    workspaceId: 'workspace-1',
+    path: 'reports/q1.md',
+    provenance: { producerPrincipalRef: 'agent-a' },
+    ...overrides,
+  }
+}
+
+/** Minimal fake satisfying the `Workspace` contract for `stat`-only tests. */
+function fakeWorkspace(opts: { existingPaths: Set<string> }): Workspace {
+  return {
+    root: '/workspace',
+    runtimeContext: { runtimeCwd: '/workspace' },
+    async readFile() {
+      throw new Error('not implemented')
+    },
+    async writeFile() {
+      throw new Error('not implemented')
+    },
+    async unlink() {
+      throw new Error('not implemented')
+    },
+    async readdir() {
+      return []
+    },
+    async stat(relPath: string): Promise<Stat> {
+      if (!opts.existingPaths.has(relPath)) {
+        throw new Error(`PATH_NOT_FOUND: ${relPath}`)
+      }
+      return { size: 0, mtimeMs: Date.now(), kind: 'file' }
+    },
+    async mkdir() {
+      throw new Error('not implemented')
+    },
+    async rename() {
+      throw new Error('not implemented')
+    },
+  }
+}
+
+describe('ShareEntryV1Schema', () => {
+  it('accepts a well-formed entry', () => {
+    const entry: ShareEntryV1 = {
+      schemaVersion: 1,
+      id: 'share-1',
+      workspaceId: 'workspace-1',
+      path: 'reports/q1.md',
+      provenance: { producerPrincipalRef: 'agent-a', createdAt: '2026-07-13T00:00:00.000Z' },
+    }
+    expect(ShareEntryV1Schema.safeParse(entry).success).toBe(true)
+  })
+
+  it('rejects unknown fields (schema version 1 is closed)', () => {
+    const entry = {
+      schemaVersion: 1,
+      id: 'share-1',
+      workspaceId: 'workspace-1',
+      path: 'reports/q1.md',
+      provenance: { producerPrincipalRef: 'agent-a', createdAt: '2026-07-13T00:00:00.000Z' },
+      extra: 'nope',
+    }
+    expect(ShareEntryV1Schema.safeParse(entry).success).toBe(false)
+  })
+})
+
+describe('OpaqueShareLocatorIdSchema (opacity precedent, AC1-T2)', () => {
+  it.each([
+    'share-1',
+    'a1b2c3',
+    crypto.randomUUID(),
+  ])('accepts an opaque id: %s', (value) => {
+    expect(OpaqueShareLocatorIdSchema.safeParse(value).success).toBe(true)
+  })
+
+  it.each([
+    ['/etc/passwd', 'absolute path'],
+    ['../secret', 'path traversal'],
+    ['workspace/relative', 'workspace-relative path'],
+    ['file:///etc/passwd', 'file scheme'],
+    ['https://evil.example/x', 'url scheme'],
+    ['a\\b', 'backslash'],
+    ['.', 'dot'],
+    ['..', 'dot-dot'],
+    ['', 'empty'],
+    [' share-1', 'leading whitespace'],
+  ])('rejects a non-opaque id: %s (%s)', (value) => {
+    expect(OpaqueShareLocatorIdSchema.safeParse(value).success).toBe(false)
+  })
+})
+
+describe('InMemoryShareEntryStore.create', () => {
+  it('mints an opaque id and persists {id, workspaceId, path, provenance}', async () => {
+    const store = new InMemoryShareEntryStore()
+    const entry = await store.create(validInput())
+
+    expect(entry.schemaVersion).toBe(1)
+    expect(OpaqueShareLocatorIdSchema.safeParse(entry.id).success).toBe(true)
+    expect(entry.workspaceId).toBe('workspace-1')
+    expect(entry.path).toBe('reports/q1.md')
+    expect(entry.provenance.producerPrincipalRef).toBe('agent-a')
+    expect(typeof entry.provenance.createdAt).toBe('string')
+
+    const parsed = ShareEntryV1Schema.safeParse(entry)
+    expect(parsed.success).toBe(true)
+  })
+
+  it('mints a distinct id per creation, even for identical input', async () => {
+    const store = new InMemoryShareEntryStore()
+    const a = await store.create(validInput())
+    const b = await store.create(validInput())
+    expect(a.id).not.toBe(b.id)
+  })
+
+  it('honors an explicit provenance.createdAt instead of defaulting', async () => {
+    const store = new InMemoryShareEntryStore()
+    const entry = await store.create(validInput({ provenance: { producerPrincipalRef: 'agent-a', createdAt: '2020-01-01T00:00:00.000Z' } }))
+    expect(entry.provenance.createdAt).toBe('2020-01-01T00:00:00.000Z')
+  })
+
+  it.each([
+    ['empty workspaceId', validInput({ workspaceId: '' })],
+    ['path-shaped workspaceId', validInput({ workspaceId: '/etc/passwd' })],
+    ['traversal workspaceId', validInput({ workspaceId: '../x' })],
+    ['empty path', validInput({ path: '' })],
+    ['empty producerPrincipalRef', validInput({ provenance: { producerPrincipalRef: '' } })],
+  ])('rejects invalid create input: %s', async (_label, input) => {
+    const store = new InMemoryShareEntryStore()
+    await expect(store.create(input)).rejects.toBeInstanceOf(ShareEntryValidationError)
+  })
+
+  it('validation error carries a stable code and no path leak in the message', async () => {
+    const store = new InMemoryShareEntryStore()
+    try {
+      await store.create(validInput({ workspaceId: '/etc/passwd' }))
+      expect.unreachable('expected create() to throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(ShareEntryValidationError)
+      const validationError = err as ShareEntryValidationError
+      expect(validationError.code).toBe('CONFIG_INVALID')
+      expect(validationError.field).toBe('workspaceId')
+    }
+  })
+})
+
+describe('InMemoryShareEntryStore CRUD', () => {
+  it('get returns null for an unknown id', async () => {
+    const store = new InMemoryShareEntryStore()
+    expect(await store.get('does-not-exist')).toBeNull()
+  })
+
+  it('get returns the created entry by id', async () => {
+    const store = new InMemoryShareEntryStore()
+    const created = await store.create(validInput())
+    const fetched = await store.get(created.id)
+    expect(fetched).toEqual(created)
+  })
+
+  it('delete removes the entry (deleting the entry removes the link — spec §3.2)', async () => {
+    const store = new InMemoryShareEntryStore()
+    const created = await store.create(validInput())
+    await store.delete(created.id)
+    expect(await store.get(created.id)).toBeNull()
+  })
+
+  it('delete of an unknown id is a no-op', async () => {
+    const store = new InMemoryShareEntryStore()
+    await expect(store.delete('does-not-exist')).resolves.toBeUndefined()
+  })
+
+  it('list scopes to one workspace and never leaks entries from another', async () => {
+    const store = new InMemoryShareEntryStore()
+    const a = await store.create(validInput({ workspaceId: 'workspace-a' }))
+    await store.create(validInput({ workspaceId: 'workspace-b' }))
+
+    const listed = await store.list('workspace-a')
+    expect(listed).toEqual([a])
+  })
+})
+
+describe('resolveShareEntry (live-reference + tombstone, spec §3.2/§3.3)', () => {
+  it('returns not_found for an unknown id, with no path field anywhere on the result', async () => {
+    const store = new InMemoryShareEntryStore()
+    const workspace = fakeWorkspace({ existingPaths: new Set() })
+
+    const resolution = await resolveShareEntry(store, 'does-not-exist', workspace)
+
+    expect(resolution.status).toBe('not_found')
+    expect(resolution).toEqual({
+      status: 'not_found',
+      code: ShareEntryErrorCode.enum.AR1_SHARE_NOT_FOUND,
+    })
+    expect(JSON.stringify(resolution)).not.toContain('path')
+  })
+
+  it('returns ok with the live entry when the target file stats successfully', async () => {
+    const store = new InMemoryShareEntryStore()
+    const created = await store.create(validInput())
+    const workspace = fakeWorkspace({ existingPaths: new Set([created.path]) })
+
+    const resolution = await resolveShareEntry(store, created.id, workspace)
+
+    expect(resolution).toEqual({ status: 'ok', entry: created })
+  })
+
+  it('returns tombstoned (never a bare 404) when the target file is gone, carrying provenance but never path', async () => {
+    const store = new InMemoryShareEntryStore()
+    const created = await store.create(validInput())
+    const workspace = fakeWorkspace({ existingPaths: new Set() })
+
+    const resolution = await resolveShareEntry(store, created.id, workspace)
+
+    expect(resolution.status).toBe('tombstoned')
+    if (resolution.status !== 'tombstoned') throw new Error('unreachable')
+    expect(resolution.code).toBe('AR1_SHARE_TOMBSTONED')
+    expect(resolution.tombstone).toEqual({
+      id: created.id,
+      workspaceId: created.workspaceId,
+      provenance: created.provenance,
+    })
+    // Missing-file tombstone data path: last-known metadata renders, the
+    // server-internal path never leaks into the tombstone projection.
+    expect(Object.keys(resolution.tombstone)).not.toContain('path')
+    expect(JSON.stringify(resolution.tombstone)).not.toContain(created.path)
+  })
+
+  it('is a live reference: a file that reappears resolves ok again (not pinned to the tombstone)', async () => {
+    const store = new InMemoryShareEntryStore()
+    const created = await store.create(validInput())
+    const paths = new Set<string>()
+    const workspace = fakeWorkspace({ existingPaths: paths })
+
+    const gone = await resolveShareEntry(store, created.id, workspace)
+    expect(gone.status).toBe('tombstoned')
+
+    paths.add(created.path)
+    const back = await resolveShareEntry(store, created.id, workspace)
+    expect(back).toEqual({ status: 'ok', entry: created })
+  })
+})

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -152,6 +152,23 @@ export {
   WORKSPACE_COMMAND_NOTIFY_EVENT,
 } from './agentPluginEvents'
 export type { CommandNotifyPayload } from './agentPluginEvents'
+export {
+  OpaqueShareLocatorIdSchema,
+  ShareEntryProvenanceSchema,
+  ShareEntryV1Schema,
+  ShareEntryErrorCode,
+  ShareEntryValidationError,
+  InMemoryShareEntryStore,
+  resolveShareEntry,
+} from './share-entry'
+export type {
+  ShareEntryProvenance,
+  ShareEntryV1,
+  CreateShareEntryInput,
+  ShareEntryStore,
+  ShareEntryTombstone,
+  ShareEntryResolution,
+} from './share-entry'
 
 export type {
   BoringChatMessage,

--- a/packages/agent/src/shared/share-entry.ts
+++ b/packages/agent/src/shared/share-entry.ts
@@ -1,0 +1,297 @@
+// Lane W same-workspace share-entry store (AR1-002, Decision 21-24, issue
+// #632/#636 lane split). See docs/issues/391/runtime-refactor/work/
+// AR1-shareable-artifacts/AR1-001-SPEC.md §3 and IMPLEMENTATION-GUARDRAILS.md
+// (AR1 section) for the binding contract.
+//
+// Scope (binding, per the AR1 guardrail): the share-entry store ONLY —
+// `{id, workspaceId, path, provenance}` plus the resolution helper that
+// decides ok / not-found / tombstoned. No deep-link route, no MCP resource
+// exposure, no expiry/revocation/capability-token machinery — Lane W has
+// none of that: membership IS the access boundary and membership IS
+// revocation (a later bead, AR1-003, adds the membership-gated `/a/<id>`
+// route; AR1-004 adds MCP resource exposure). This module does not perform
+// membership checks itself — a caller resolves and authorizes the
+// `Workspace` for `entry.workspaceId` before calling {@link resolveShareEntry}.
+//
+// A workspace path is SERVER-INTERNAL and MUST NEVER appear in any handle,
+// link, deep-link URL, error, or audit record (AR1-001-SPEC.md §1).
+// `resolveShareEntry`'s `not_found` and `tombstoned` outcomes below are the
+// one seam a future route/MCP resource bead consumes to render a response —
+// neither carries a `path` field, by construction.
+
+import { z } from 'zod'
+
+import { ErrorCode } from './error-codes'
+import { formatPath, type AgentSchemaIssue } from './schema-issue'
+import type { Workspace } from './workspace'
+
+const nonEmptyString = z.string().min(1)
+
+// ---------------------------------------------------------------------------
+// Opaque id
+// ---------------------------------------------------------------------------
+
+/**
+ * A platform-owned opaque locator id: a bare surrogate key with no path or
+ * scheme semantics whatsoever — no separators, no `..`, no `:`. This is what
+ * makes `file:`, `http(s):`, absolute paths, and workspace-relative paths
+ * structurally unrepresentable as a share `id`/`workspaceId`, not merely
+ * discouraged by convention (mirrors the `OpaqueRefSchema` /
+ * `isOpaqueLocatorId` precedent in `agent-definition.ts`/`agent-consumption.ts`
+ * — same opacity discipline, applied to the Lane W share entry).
+ */
+function isOpaqueLocatorId(value: string): boolean {
+  return (
+    value.trim() === value &&
+    !/[\0-\x1f\x7f]/.test(value) &&
+    !value.includes('/') &&
+    !value.includes('\\') &&
+    !value.includes(':') &&
+    value !== '.' &&
+    value !== '..'
+  )
+}
+
+export const OpaqueShareLocatorIdSchema = z
+  .string()
+  .min(1, 'must be a non-empty opaque id')
+  .max(256, 'must be at most 256 characters')
+  .refine(isOpaqueLocatorId, 'must be an opaque platform-owned id (no path separators, no scheme, no traversal)')
+
+/** Mints a fresh opaque share-entry id. Web Crypto only — no `node:*` (invariant). */
+function mintShareEntryId(): string {
+  return globalThis.crypto.randomUUID()
+}
+
+// ---------------------------------------------------------------------------
+// Record
+// ---------------------------------------------------------------------------
+
+export interface ShareEntryProvenance {
+  producerPrincipalRef: string
+  createdAt: string
+}
+
+export const ShareEntryProvenanceSchema = z
+  .object({
+    producerPrincipalRef: nonEmptyString,
+    createdAt: nonEmptyString,
+  })
+  .strict() satisfies z.ZodType<ShareEntryProvenance, z.ZodTypeDef, unknown>
+
+/**
+ * Lane W same-workspace share entry (AR1-001-SPEC.md §3.1): a live reference
+ * to a file in the SAME workspace the consumer already belongs to. No blob
+ * capture — nothing crosses a workspace boundary. `path` is SERVER-INTERNAL
+ * and MUST NOT be emitted in any URL/API/audit surface a later bead builds.
+ */
+export interface ShareEntryV1 {
+  schemaVersion: 1
+  id: string
+  workspaceId: string
+  /** SERVER-INTERNAL live path; never emitted in URL/API/audit. */
+  path: string
+  provenance: ShareEntryProvenance
+}
+
+export const ShareEntryV1Schema = z
+  .object({
+    schemaVersion: z.literal(1),
+    id: OpaqueShareLocatorIdSchema,
+    workspaceId: OpaqueShareLocatorIdSchema,
+    path: nonEmptyString,
+    provenance: ShareEntryProvenanceSchema,
+  })
+  .strict() satisfies z.ZodType<ShareEntryV1, z.ZodTypeDef, unknown>
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * Refusal codes for Lane W share resolution (AR1-001-SPEC.md §3.3/§5). Scoped
+ * like `AgentConsumptionErrorCode` — canonical, but intentionally outside the
+ * public {@link ErrorCode}/`ERROR_CODES` registry until a runtime route/MCP
+ * resource actually surfaces these over an API boundary (AR1-003/AR1-004).
+ * These are the ONLY two AR1-specific codes for Lane W: "Access denial is
+ * the existing generic membership denial, not an AR1 code" (spec §3.3) —
+ * this module does not invent a third.
+ */
+export const ShareEntryErrorCode = z.enum(['AR1_SHARE_NOT_FOUND', 'AR1_SHARE_TOMBSTONED'])
+
+export type ShareEntryErrorCode = z.infer<typeof ShareEntryErrorCode>
+
+/**
+ * Input-validation failures for {@link ShareEntryStore.create}. Deliberately
+ * NOT an `AR1_*` code (the spec's §5 table names exactly two Lane W codes for
+ * resolution outcomes; this reuses the existing generic `CONFIG_INVALID`
+ * taxonomy for malformed create-input, the same way `SchemaValidationError`
+ * subclasses elsewhere in this package do).
+ */
+const ShareEntryValidationCode = z.enum(['SHARE_ENTRY_INPUT_INVALID'])
+type ShareEntryValidationCode = z.infer<typeof ShareEntryValidationCode>
+
+export class ShareEntryValidationError extends Error {
+  readonly code = ErrorCode.enum.CONFIG_INVALID
+  readonly field: string
+
+  constructor(issue: AgentSchemaIssue<ShareEntryValidationCode>) {
+    super(issue.message)
+    this.name = 'ShareEntryValidationError'
+    this.field = issue.field
+  }
+}
+
+function assertValidCreateInput(raw: CreateShareEntryInput): void {
+  const result = CreateShareEntryInputSchema.safeParse(raw)
+  if (result.success) return
+  const issue = result.error.issues[0]
+  const field = formatPath(issue.path)
+  throw new ShareEntryValidationError({
+    code: ShareEntryValidationCode.enum.SHARE_ENTRY_INPUT_INVALID,
+    field,
+    message: field === '<root>' ? issue.message : `${field} ${issue.message}`,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+export interface CreateShareEntryInput {
+  workspaceId: string
+  /** SERVER-INTERNAL live path. Never persist/return this in a public surface. */
+  path: string
+  provenance: {
+    producerPrincipalRef: string
+    /** Defaults to the store's creation time when omitted. */
+    createdAt?: string
+  }
+}
+
+const CreateShareEntryInputSchema = z
+  .object({
+    workspaceId: OpaqueShareLocatorIdSchema,
+    path: nonEmptyString,
+    provenance: z
+      .object({
+        producerPrincipalRef: nonEmptyString,
+        createdAt: nonEmptyString.optional(),
+      })
+      .strict(),
+  })
+  .strict()
+
+export interface ShareEntryStore {
+  /** Validates `input`, mints a fresh opaque `id`, and persists the entry. */
+  create(input: CreateShareEntryInput): Promise<ShareEntryV1>
+  get(id: string): Promise<ShareEntryV1 | null>
+  delete(id: string): Promise<void>
+  /** Lists entries scoped to one workspace (never leaks across workspaces). */
+  list(workspaceId: string): Promise<ShareEntryV1[]>
+}
+
+/**
+ * In-memory reference implementation. Lane W has no durability requirement
+ * beyond "the repo's existing persistence seam" named by this bead (a simple
+ * keyed-record store, mirroring `SandboxHandleStore`/`SessionStore` in this
+ * same package) — a durable adapter is a swap-in behind the same interface
+ * when a later bead needs one; this store does not invent a new store
+ * technology.
+ */
+export class InMemoryShareEntryStore implements ShareEntryStore {
+  private readonly entries = new Map<string, ShareEntryV1>()
+
+  async create(input: CreateShareEntryInput): Promise<ShareEntryV1> {
+    assertValidCreateInput(input)
+    const entry: ShareEntryV1 = {
+      schemaVersion: 1,
+      id: mintShareEntryId(),
+      workspaceId: input.workspaceId,
+      path: input.path,
+      provenance: {
+        producerPrincipalRef: input.provenance.producerPrincipalRef,
+        createdAt: input.provenance.createdAt ?? new Date().toISOString(),
+      },
+    }
+    this.entries.set(entry.id, entry)
+    return entry
+  }
+
+  async get(id: string): Promise<ShareEntryV1 | null> {
+    return this.entries.get(id) ?? null
+  }
+
+  async delete(id: string): Promise<void> {
+    this.entries.delete(id)
+  }
+
+  async list(workspaceId: string): Promise<ShareEntryV1[]> {
+    return Array.from(this.entries.values()).filter((entry) => entry.workspaceId === workspaceId)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Resolution (live-reference + tombstone rendering, spec §3.2/§3.3)
+// ---------------------------------------------------------------------------
+
+/** Redacted, path-free projection of a tombstoned entry (spec §3.3/§1: no path in any error surface). */
+export interface ShareEntryTombstone {
+  id: string
+  workspaceId: string
+  provenance: ShareEntryProvenance
+}
+
+export type ShareEntryResolution =
+  | { status: 'ok'; entry: ShareEntryV1 }
+  | { status: 'not_found'; code: typeof ShareEntryErrorCode.enum.AR1_SHARE_NOT_FOUND }
+  | {
+      status: 'tombstoned'
+      code: typeof ShareEntryErrorCode.enum.AR1_SHARE_TOMBSTONED
+      tombstone: ShareEntryTombstone
+    }
+
+/**
+ * Resolves a share entry against the CURRENT state of the workspace file
+ * (live-reference semantics, spec §3.2 — deliberately not a snapshot). The
+ * caller must already have resolved and authorized `workspace` for
+ * `entry.workspaceId`; this function performs no membership check itself
+ * (spec §3.3: "Access denial is the existing generic membership denial, not
+ * an AR1 code").
+ *
+ * - No such entry -> `not_found` (`AR1_SHARE_NOT_FOUND`).
+ * - Entry exists but the target file is gone -> `tombstoned`
+ *   (`AR1_SHARE_TOMBSTONED`), carrying provenance + last-known metadata and
+ *   NEVER the path (never a bare 404, never source state).
+ * - Entry exists and the target file stats successfully -> `ok`, with the
+ *   full (server-internal) entry for the caller to act on.
+ *
+ * Any `workspace.stat` rejection (not just a "does not exist" error) is
+ * treated as "target gone" — the spec's fail-safe is to render a tombstone,
+ * never a bare 404; a later bead may narrow this to distinguish stat
+ * failure causes if that proves necessary.
+ */
+export async function resolveShareEntry(
+  store: ShareEntryStore,
+  id: string,
+  workspace: Workspace,
+): Promise<ShareEntryResolution> {
+  const entry = await store.get(id)
+  if (!entry) {
+    return { status: 'not_found', code: ShareEntryErrorCode.enum.AR1_SHARE_NOT_FOUND }
+  }
+  try {
+    await workspace.stat(entry.path)
+  } catch {
+    return {
+      status: 'tombstoned',
+      code: ShareEntryErrorCode.enum.AR1_SHARE_TOMBSTONED,
+      tombstone: {
+        id: entry.id,
+        workspaceId: entry.workspaceId,
+        provenance: entry.provenance,
+      },
+    }
+  }
+  return { status: 'ok', entry }
+}


### PR DESCRIPTION
## Summary

Implements bead `wt-391-forward-zyn` (AR1-002 Lane W opaque ShareEntryV1 store), per `docs/issues/391/runtime-refactor/work/AR1-shareable-artifacts/AR1-001-SPEC.md` §3 and the AR1 section of `IMPLEMENTATION-GUARDRAILS.md`.

- `packages/agent/src/shared/share-entry.ts`: `ShareEntryV1` record `{schemaVersion, id, workspaceId, path, provenance}`, an opaque-locator-id schema (mirrors the merged AC1-T2 `OpaqueLocatorIdSchema` opacity precedent so `id`/`workspaceId` cannot be path/scheme-shaped), an `InMemoryShareEntryStore` reference implementation (same seam shape as `SandboxHandleStore`/`SessionStore` — no new store technology invented), and `resolveShareEntry()`, which returns `ok` / `not_found` (`AR1_SHARE_NOT_FOUND`) / `tombstoned` (`AR1_SHARE_TOMBSTONED`) — the tombstone path renders provenance + last-known metadata and never the server-internal path (spec §1/§3.3), and never a bare 404.
- Error codes are scoped like `AgentConsumptionErrorCode` — outside the public `ErrorCode` registry until a route/MCP-resource bead actually surfaces them (AR1-003/AR1-004). Exactly the two Lane W codes named by the spec; no widening.
- `resolveShareEntry` takes an already-authorized `Workspace` for the entry's `workspaceId` and performs no membership check itself — per spec, access denial is the existing generic membership denial, not an AR1 code; wiring that check in is the route bead's job.

## Explicit exclusions (per bead scope)

No deep-link route, no MCP resource, no expiry/revocation/capability-token machinery (Lane W has none — membership IS the access boundary and membership IS revocation), no scheduler/queue/registry/control-plane.

## Test plan

- [x] `pnpm --filter @hachej/boring-agent test` — 205 files / 1926 tests passed (0 failed), including new `share-entry.test.ts` (33 tests: creation/opacity/validation, CRUD, resolve ok/not-found/tombstoned, no-path-leak assertions, live-reference re-resolution).
- [x] `pnpm --filter @hachej/boring-agent typecheck` — clean.
- [x] `pnpm run lint:invariants` (repo-level, includes `check-invariants.sh` stable-error-code-enum check) — all invariants passed.
- [x] `pnpm --filter @hachej/boring-agent build` — build-artifacts OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)