### PR TITLE
feat(governance): full GovernanceUsagePanel (role + caps + context + usage meters)

### DIFF
--- a/apps/full-app/scripts/d1-docker-boundary-proof.js
+++ b/apps/full-app/scripts/d1-docker-boundary-proof.js
@@ -1,0 +1,220 @@
+import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { rmdirSync } from 'node:fs';
+import { lstat, mkdtemp, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+const DESTINATION = '/run/boring/d1';
+const LABEL = 'ai.senecapp.d1-boundary-proof=true';
+const APP_ID = 10001;
+const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const SETUP = String.raw `
+const fs = require('fs'), crypto = require('crypto'), path = require('path')
+const root = '/fixture', owner = Number(process.env.PROOF_OWNER_UID)
+fs.chmodSync(root, 0o700)
+let control
+for (const hostId of ['host-a', 'host-b']) {
+  const raw = 'raw-' + crypto.randomBytes(24).toString('hex')
+  const ref = 'ref-' + crypto.randomBytes(24).toString('hex')
+  const revision = path.join(root, hostId, 'revisions/r0000000001')
+  const binding = path.join(revision, 'bindings/insurance')
+  fs.mkdirSync(binding, { recursive: true })
+  const manifest = { schemaVersion: 1, domain: 'boring-d1-binding-secrets:v1', hostId, revisionId: 'r0000000001', desiredStateDigest: 'sha256:' + 'a'.repeat(64), bindings: [{ bindingId: 'insurance', runtimeInputsDigest: 'sha256:' + 'b'.repeat(64), secrets: [{ secretRef: ref, providerVersionFingerprint: 'sha256:' + 'c'.repeat(64), file: 'bindings/insurance/0000' }] }] }
+  const secret = path.join(binding, '0000'), manifestFile = path.join(revision, 'manifest.json')
+  fs.writeFileSync(secret, raw); fs.writeFileSync(manifestFile, JSON.stringify(manifest))
+  for (const directory of [path.join(root, hostId), path.join(root, hostId, 'revisions'), revision, path.join(revision, 'bindings'), binding]) {
+    fs.chownSync(directory, owner, 10001); fs.chmodSync(directory, 0o710)
+  }
+  fs.chownSync(secret, 10001, 10001); fs.chmodSync(secret, 0o400)
+  fs.chownSync(manifestFile, owner, 10001); fs.chmodSync(manifestFile, 0o440)
+  if (hostId === 'host-a') control = { raw, ref }
+}
+const controlFile = path.join(root, 'proof-control.json')
+fs.writeFileSync(controlFile, JSON.stringify(control)); fs.chownSync(controlFile, owner, owner); fs.chmodSync(controlFile, 0o600)
+`;
+const CLEANUP = String.raw `
+const fs = require('fs'), path = require('path')
+for (const entry of fs.readdirSync('/fixture')) fs.rmSync(path.join('/fixture', entry), { recursive: true, force: true })
+`;
+const TARGET = String.raw `
+const fs = require('fs')
+const revision = '/run/boring/d1/revisions/r0000000001', secret = revision + '/bindings/insurance/0000'
+const raw = fs.readFileSync(secret), secretStat = fs.statSync(secret)
+const manifest = JSON.parse(fs.readFileSync(revision + '/manifest.json', 'utf8'))
+const ref = Buffer.from(manifest.bindings[0].secrets[0].secretRef)
+const status = fs.readFileSync('/proc/1/status', 'utf8')
+const ids = key => status.match(new RegExp('^' + key + ':\\s+(\\d+)\\s+(\\d+)', 'm')).slice(1).map(Number)
+const ownedDirectory = value => { const stat = fs.statSync(value); return stat.isDirectory() && stat.uid === 10001 && stat.gid === 10001 }
+const denied = {}
+for (const [key, operation] of Object.entries({ write: () => fs.writeFileSync(secret, Buffer.from('x')), chmod: () => fs.chmodSync(secret, 0o600), unlink: () => fs.unlinkSync(secret) })) {
+  try { operation(); denied[key] = false } catch { denied[key] = true }
+}
+const absent = value => { try { fs.accessSync(value); return false } catch { return true } }
+const environ = fs.readFileSync('/proc/1/environ'), cmdline = fs.readFileSync('/proc/1/cmdline')
+const procClean = !environ.includes(raw) && !environ.includes(ref) && !cmdline.includes(raw) && !cmdline.includes(ref)
+console.log(JSON.stringify({ status: 'pass', uid: ids('Uid').slice(0, 2), gid: ids('Gid').slice(0, 2), rootsReady: ownedDirectory(process.env.BORING_AGENT_WORKSPACE_ROOT) && ownedDirectory(process.env.BORING_AGENT_SESSION_ROOT), read: raw.length > 0, canaryMode: secretStat.uid === 10001 && secretStat.gid === 10001 && (secretStat.mode & 0o777) === 0o400, denied, hostBAbsent: absent('/run/boring/d1/host-b'), baseAbsent: absent('/run/boring/d1/proof-control.json'), procClean }))
+setInterval(() => {}, 2147483647)
+`;
+function docker(args) {
+    const result = spawnSync('docker', args, { encoding: 'utf8', maxBuffer: 1024 * 1024, shell: false });
+    return { ok: result.status === 0, stdout: result.stdout ?? '' };
+}
+function requireDocker(args) {
+    const result = docker(args);
+    if (!result.ok)
+        throw new Error('docker');
+    return result.stdout;
+}
+function mount(source) { return `type=bind,src=${source},dst=${DESTINATION},readonly`; }
+export function parsePinnedImage(argv, env) {
+    const args = argv[0] === '--' ? argv.slice(1) : argv;
+    const image = args.length === 0 ? env.D1_DOCKER_PROOF_IMAGE : args.length === 2 && args[0] === '--image' ? args[1] : undefined;
+    if (!image || !/^(?:sha256:[a-f0-9]{64}|[^\s]+@sha256:[a-f0-9]{64})$/.test(image))
+        throw new Error('image');
+    return image;
+}
+export function targetRunArgs(image, name, source) {
+    return ['run', '-d', '--rm', '--name', name, '--label', LABEL,
+        '--env', `BORING_AGENT_WORKSPACE_ROOT=/tmp/${name}-workspaces`, '--env', `BORING_AGENT_SESSION_ROOT=/tmp/${name}-sessions`,
+        '--mount', mount(source), image, 'node', '-e', TARGET];
+}
+export function assertContainersAbsent(names, run = docker) {
+    for (const name of names) {
+        const result = run(['container', 'ls', '-a', '--filter', `name=^/${name}$`, '--format', '{{.Names}}']);
+        if (!result.ok || result.stdout.trim() !== '')
+            throw new Error('containerCleanup');
+    }
+}
+export function validateInspect(raw, source, secrets, repositoryRoot) {
+    const record = JSON.parse(raw)[0];
+    const mounts = record?.Mounts;
+    if (!record || !Array.isArray(mounts) || mounts.length !== 1)
+        throw new Error('inspect');
+    const actual = mounts[0];
+    if (actual?.Type !== 'bind' || actual.Source !== source || actual.Destination !== DESTINATION || actual.RW !== false)
+        throw new Error('mount');
+    const relative = path.relative(repositoryRoot, source);
+    if (relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative)))
+        throw new Error('repositoryMount');
+    const serialized = JSON.stringify({ Config: record.Config, Mounts: record.Mounts });
+    if (secrets.some((secret) => serialized.includes(secret)))
+        throw new Error('secret');
+}
+function assertTargetResult(raw) {
+    const result = JSON.parse(raw.trim());
+    if (result.status !== 'pass' || JSON.stringify(result.uid) !== `[${APP_ID},${APP_ID}]` || JSON.stringify(result.gid) !== `[${APP_ID},${APP_ID}]`
+        || result.rootsReady !== true || result.read !== true || result.canaryMode !== true || result.hostBAbsent !== true || result.baseAbsent !== true || result.procClean !== true
+        || result.denied?.write !== true || result.denied?.chmod !== true || result.denied?.unlink !== true)
+        throw new Error('target');
+}
+async function waitForResult(name) {
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+        const result = docker(['logs', name]);
+        if (result.ok && result.stdout.trim())
+            return result.stdout;
+        await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    throw new Error('targetTimeout');
+}
+function cleanupResources(image, root, names, cleanupName) {
+    for (const name of names)
+        docker(['rm', '-f', name]);
+    assertContainersAbsent(names);
+    const cleaned = docker(['run', '--rm', '--name', cleanupName, '--label', LABEL, '--user', '0:0', '--mount', `type=bind,src=${root},dst=/fixture`, '--entrypoint', 'node', image, '-e', CLEANUP]);
+    if (!cleaned.ok) {
+        try {
+            rmdirSync(root);
+        }
+        catch { }
+        ;
+        throw new Error('cleanupHelper');
+    }
+    assertContainersAbsent([...names, cleanupName]);
+    try {
+        rmdirSync(root);
+    }
+    catch {
+        throw new Error('cleanup');
+    }
+}
+async function proof(image) {
+    const token = randomUUID();
+    const root = await mkdtemp('/dev/shm/boring-d1-boundary-');
+    const hostA = path.join(root, 'host-a');
+    const hostB = path.join(root, 'host-b');
+    const missing = path.join(root, 'missing');
+    const target = `d1-boundary-${token}`;
+    const missingName = `${target}-missing`;
+    const helper = `${target}-helper`;
+    const cleanup = `${target}-cleanup`;
+    const names = [target, missingName, helper];
+    let cleanupStarted = false;
+    let interrupted;
+    const clean = () => { if (!cleanupStarted) {
+        cleanupStarted = true;
+        cleanupResources(image, root, names, cleanup);
+    } };
+    const onSignal = (signal) => {
+        interrupted = signal;
+        if (cleanupStarted)
+            return;
+        try {
+            clean();
+        }
+        finally {
+            process.exit(signal === 'SIGINT' ? 130 : 143);
+        }
+    };
+    const onSigint = () => onSignal('SIGINT');
+    const onSigterm = () => onSignal('SIGTERM');
+    process.once('SIGINT', onSigint);
+    process.once('SIGTERM', onSigterm);
+    try {
+        const imageInspect = JSON.parse(requireDocker(['image', 'inspect', image]))[0];
+        if (JSON.stringify(imageInspect?.Config?.Entrypoint) !== JSON.stringify(['/usr/local/bin/web-entrypoint']))
+            throw new Error('entrypoint');
+        if (![undefined, '', '0', '0:0', 'root', 'root:root'].includes(imageInspect?.Config?.User))
+            throw new Error('imageUser');
+        requireDocker(['run', '--rm', '--name', helper, '--label', LABEL, '--user', '0:0', '-e', `PROOF_OWNER_UID=${process.getuid?.() ?? -1}`, '--mount', `type=bind,src=${root},dst=/fixture`, '--entrypoint', 'node', image, '-e', SETUP]);
+        const control = JSON.parse(await readFile(path.join(root, 'proof-control.json'), 'utf8'));
+        const missingResult = docker(['run', '--rm', '--name', missingName, '--label', LABEL, '--mount', mount(missing), image, 'node', '-e', 'process.exit(0)']);
+        try {
+            await lstat(missing);
+            throw new Error('missingCreated');
+        }
+        catch (error) {
+            if (error.code !== 'ENOENT')
+                throw error;
+        }
+        if (missingResult.ok)
+            throw new Error('missingSource');
+        requireDocker(targetRunArgs(image, target, hostA));
+        const targetOutput = await waitForResult(target);
+        assertTargetResult(targetOutput);
+        const inspected = requireDocker(['inspect', target]);
+        validateInspect(inspected, hostA, [control.raw, control.ref], REPOSITORY_ROOT);
+        const record = JSON.parse(inspected)[0];
+        if (JSON.stringify(record).includes(hostB) || record.Mounts.some((entry) => entry.Source === root))
+            throw new Error('siblingMount');
+    }
+    finally {
+        try {
+            clean();
+        }
+        finally {
+            process.off('SIGINT', onSigint);
+            process.off('SIGTERM', onSigterm);
+        }
+    }
+    if (interrupted) {
+        process.exitCode = interrupted === 'SIGINT' ? 130 : 143;
+        return;
+    }
+    process.stdout.write(`${JSON.stringify({ status: 'pass', proof: 'd1-docker-uid-dac', checks: { missingSource: true, exactHostMount: true, entrypointSetup: true, uidDrop: true, read0400: true, mutationsDenied: true, metadataRedacted: true, repositoryMountAbsent: true } })}\n`);
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    Promise.resolve().then(() => proof(parsePinnedImage(process.argv.slice(2), process.env))).catch(() => {
+        process.stdout.write(`${JSON.stringify({ status: 'fail', proof: 'd1-docker-uid-dac', error: 'D1_DOCKER_PROOF_FAILED' })}\n`);
+        process.exitCode = 1;
+    });
+}

--- a/apps/full-app/scripts/d1-ingress-header-proof.js
+++ b/apps/full-app/scripts/d1-ingress-header-proof.js
@@ -1,0 +1,192 @@
+import { spawnSync } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { request } from 'node:http';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { D1_CADDY_AMD64_ID, D1_CADDY_COMMAND, D1_CADDY_IMAGE, D1_CADDY_IMAGE_DEFAULTS, D1_CADDYFILE_DIGEST, } from '../src/server/deployment/d1IngressArtifacts.js';
+export const D1_INGRESS_PROOF_HELPER_IMAGE = 'node@sha256:c601a46abb4d2ab80a9dc3da208d50d1122642d53f17a101926ace71e5a9bf1c';
+const REPOSITORY_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const CADDYFILE = path.join(REPOSITORY_ROOT, 'deploy/d1/Caddyfile');
+const CADDYFILE_TARGET = '/etc/caddy/Caddyfile';
+const AUTHORITY = 'insurance.example.test:8443';
+const MAX_OUTPUT = 1024 * 1024;
+const FAILURE = `${JSON.stringify({ status: 'fail', proof: 'd1-ingress-headers', error: 'D1_INGRESS_HEADER_PROOF_FAILED' })}\n`;
+const ECHO = "require('node:http').createServer((req,res)=>{res.setHeader('content-type','application/json');res.end(JSON.stringify({host:req.headers.host,distinct:req.headersDistinct,raw:req.rawHeaders}))}).listen(3000,'0.0.0.0')";
+export const D1_INGRESS_PROOF_CASES = Object.freeze([
+    { name: 'forwarded-absent', forwarded: [], xfh: [] },
+    { name: 'forwarded-single', forwarded: ['for=192.0.2.1;host=evil.example'], xfh: [] },
+    { name: 'forwarded-empty', forwarded: [''], xfh: [] },
+    { name: 'forwarded-repeated', forwarded: ['for=192.0.2.1', 'for=192.0.2.2'], xfh: [] },
+    { name: 'forwarded-comma', forwarded: ['for=192.0.2.1, for=192.0.2.2'], xfh: [] },
+    { name: 'xfh-absent', forwarded: [], xfh: [] },
+    { name: 'xfh-hostile', forwarded: [], xfh: ['evil.example'] },
+    { name: 'xfh-repeated', forwarded: [], xfh: ['evil.example', 'second.example'] },
+    { name: 'xfh-comma', forwarded: [], xfh: ['evil.example, second.example'] },
+]);
+function docker(args) {
+    const result = spawnSync('docker', args, { encoding: 'utf8', maxBuffer: MAX_OUTPUT, timeout: 120_000, shell: false });
+    return { ok: result.status === 0, stdout: result.stdout ?? '' };
+}
+function requireDocker(args) {
+    const result = docker(args);
+    if (!result.ok || new TextEncoder().encode(result.stdout).byteLength > MAX_OUTPUT)
+        throw new Error('docker');
+    return result.stdout;
+}
+function records(raw) {
+    const value = JSON.parse(raw);
+    if (!Array.isArray(value) || value.some((entry) => typeof entry !== 'object' || entry === null))
+        throw new Error('inspect');
+    return value;
+}
+export function validateD1CaddyImageInspect(raw) {
+    const image = records(raw)[0];
+    if (!image || image.Id !== D1_CADDY_AMD64_ID || !Array.isArray(image.RepoDigests) || !image.RepoDigests.includes(D1_CADDY_IMAGE)
+        || image.Config?.Entrypoint != null || JSON.stringify(image.Config?.Cmd) !== JSON.stringify(D1_CADDY_COMMAND)
+        || !Array.isArray(image.Config?.Env) || Object.entries(D1_CADDY_IMAGE_DEFAULTS)
+        .some(([key, value]) => !image.Config.Env.includes(`${key}=${value}`)))
+        throw new Error('image');
+}
+export function validateD1IngressContainerInspect(raw, source) {
+    const container = records(raw)[0];
+    const mount = container?.Mounts?.filter((entry) => entry.Destination === CADDYFILE_TARGET);
+    if (!container || container.Config?.Image !== D1_CADDY_IMAGE
+        || JSON.stringify(container.Config?.Cmd) !== JSON.stringify(D1_CADDY_COMMAND)
+        || !Array.isArray(mount) || mount.length !== 1 || mount[0].Type !== 'bind' || mount[0].Source !== source || mount[0].RW !== false)
+        throw new Error('container');
+}
+function rawValues(raw, name) {
+    if (!Array.isArray(raw) || raw.some((value) => typeof value !== 'string') || raw.length % 2 !== 0)
+        throw new Error('headers');
+    const values = [];
+    for (let index = 0; index < raw.length; index += 2)
+        if (raw[index].toLowerCase() === name)
+            values.push(raw[index + 1]);
+    return values;
+}
+export function assertD1IngressEcho(raw, authority = AUTHORITY) {
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw))
+        throw new Error('echo');
+    const echo = raw;
+    if (echo.host !== authority || rawValues(echo.raw, 'host').join('\0') !== authority
+        || rawValues(echo.raw, 'x-forwarded-host').join('\0') !== authority || rawValues(echo.raw, 'forwarded').length !== 0
+        || JSON.stringify(echo.distinct?.['x-forwarded-host']) !== JSON.stringify([authority])
+        || Object.hasOwn(echo.distinct ?? {}, 'forwarded'))
+        throw new Error('echo');
+}
+async function echoRequest(port, forwarded, xfh) {
+    const headers = ['Host', AUTHORITY];
+    for (const value of forwarded)
+        headers.push('Forwarded', value);
+    for (const value of xfh)
+        headers.push('X-Forwarded-Host', value);
+    return new Promise((resolve, reject) => {
+        const call = request({ host: '127.0.0.1', port, path: '/proof', headers, method: 'GET', timeout: 2_000 }, (response) => {
+            const chunks = [];
+            let size = 0;
+            response.on('data', (chunk) => { size += chunk.length; if (size > 64 * 1024)
+                response.destroy();
+            else
+                chunks.push(chunk); });
+            response.on('error', reject);
+            response.on('end', () => {
+                if (response.statusCode !== 200)
+                    reject(new Error('status'));
+                else {
+                    try {
+                        resolve(JSON.parse(Buffer.concat(chunks).toString('utf8')));
+                    }
+                    catch {
+                        reject(new Error('json'));
+                    }
+                }
+            });
+        });
+        call.on('timeout', () => call.destroy(new Error('timeout')));
+        call.on('error', reject);
+        call.end();
+    });
+}
+async function waitForEcho(port, forwarded, xfh) {
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+        try {
+            return await echoRequest(port, forwarded, xfh);
+        }
+        catch {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+        }
+    }
+    throw new Error('readiness');
+}
+function cleanup(names, network, label) {
+    for (const name of names)
+        docker(['rm', '-f', name]);
+    docker(['network', 'rm', network]);
+    const containers = docker(['container', 'ls', '-a', '--filter', `label=${label}`, '--format', '{{.Names}}']);
+    const networks = docker(['network', 'ls', '--filter', `label=${label}`, '--format', '{{.Name}}']);
+    if (!containers.ok || !networks.ok || containers.stdout.trim() !== '' || networks.stdout.trim() !== '')
+        throw new Error('cleanup');
+}
+async function proof() {
+    const token = randomUUID();
+    const label = `ai.senecapp.d1-ingress-proof=${token}`;
+    const network = `d1-ingress-${token}`;
+    const backend = `${network}-backend`;
+    const ingress = `${network}-caddy`;
+    const validator = `${network}-validate`;
+    const names = [backend, ingress, validator];
+    let cleaned = false;
+    const clean = () => { if (!cleaned) {
+        cleaned = true;
+        cleanup(names, network, label);
+    } };
+    const onSignal = () => { try {
+        clean();
+    }
+    finally {
+        process.stdout.write(FAILURE);
+        process.exit(1);
+    } };
+    process.once('SIGINT', onSignal);
+    process.once('SIGTERM', onSignal);
+    try {
+        const config = await readFile(CADDYFILE);
+        if (`sha256:${createHash('sha256').update(config).digest('hex')}` !== D1_CADDYFILE_DIGEST)
+            throw new Error('configDigest');
+        requireDocker(['pull', D1_CADDY_IMAGE]);
+        requireDocker(['pull', D1_INGRESS_PROOF_HELPER_IMAGE]);
+        validateD1CaddyImageInspect(requireDocker(['image', 'inspect', D1_CADDY_IMAGE]));
+        const helper = records(requireDocker(['image', 'inspect', D1_INGRESS_PROOF_HELPER_IMAGE]))[0];
+        if (!helper?.RepoDigests?.includes(D1_INGRESS_PROOF_HELPER_IMAGE))
+            throw new Error('helperImage');
+        const mount = `type=bind,src=${CADDYFILE},dst=${CADDYFILE_TARGET},readonly`;
+        requireDocker(['run', '--rm', '--name', validator, '--label', label, '--mount', mount, D1_CADDY_IMAGE,
+            'caddy', 'validate', '--config', CADDYFILE_TARGET, '--adapter', 'caddyfile']);
+        requireDocker(['network', 'create', '--label', label, network]);
+        requireDocker(['run', '-d', '--rm', '--name', backend, '--label', label, '--network', network, '--network-alias', 'core-app',
+            '--entrypoint', 'node', D1_INGRESS_PROOF_HELPER_IMAGE, '-e', ECHO]);
+        requireDocker(['run', '-d', '--rm', '--name', ingress, '--label', label, '--network', network, '--publish', '127.0.0.1::8080',
+            '--mount', mount, D1_CADDY_IMAGE, ...D1_CADDY_COMMAND]);
+        validateD1IngressContainerInspect(requireDocker(['inspect', ingress]), CADDYFILE);
+        const published = requireDocker(['port', ingress, '8080/tcp']).trim().match(/^127\.0\.0\.1:(\d+)$/);
+        if (!published)
+            throw new Error('port');
+        for (const testCase of D1_INGRESS_PROOF_CASES)
+            assertD1IngressEcho(await waitForEcho(Number(published[1]), testCase.forwarded, testCase.xfh));
+    }
+    finally {
+        try {
+            clean();
+        }
+        finally {
+            process.off('SIGINT', onSignal);
+            process.off('SIGTERM', onSignal);
+        }
+    }
+    process.stdout.write(`${JSON.stringify({ status: 'pass', proof: 'd1-ingress-headers', caddyImage: D1_CADDY_IMAGE,
+        caddyImageId: D1_CADDY_AMD64_ID, caddyfileDigest: D1_CADDYFILE_DIGEST, cases: D1_INGRESS_PROOF_CASES.length })}\n`);
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    proof().catch(() => { process.stdout.write(FAILURE); process.exitCode = 1; });
+}

--- a/apps/full-app/src/front/main.tsx
+++ b/apps/full-app/src/front/main.tsx
@@ -16,7 +16,7 @@ import {
 } from '@hachej/boring-core/front'
 import '@hachej/boring-core/app/front/styles.css'
 import './app.css'
-import { GovernanceUsageMeters, createGovernanceCompanyAdmin } from '@hachej/boring-governance/front'
+import { GovernanceUsagePanel, createGovernanceCompanyAdmin } from '@hachej/boring-governance/front'
 import { BoringMcpSourcesOverlay } from '@hachej/boring-mcp/front'
 import { PublicHeroDescription } from './PublicHeroDescription'
 import { fullAppBoringMcpOptions } from './boringMcp'
@@ -61,14 +61,15 @@ const AccountSettingsPage = () => {
   return (
     <UserSettingsPage
       extraSections={[
-        // Governed model-usage meters. The component self-fetches from the
+        // Full governed-usage panel (role + aggregate cap + company-context
+        // access + per-model usage meters + context paths). Self-fetches from the
         // governance usage-summary route and renders nothing when governance is
         // disabled, so this section is inert on non-governed deployments.
         {
           id: 'usage',
-          navLabel: 'Model usage',
-          navDescription: 'Consumption vs. caps',
-          content: <GovernanceUsageMeters className="max-w-xl" />,
+          navLabel: 'Usage limits',
+          navDescription: 'Role, caps, and consumption',
+          content: <GovernanceUsagePanel className="max-w-xl" />,
         },
         ...(hidden
           ? []

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -23,7 +23,7 @@ export const FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS = Object.freeze(FULL_AP
 export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'full-app-governance',
   version: '0.1.84',
-  contentDigest: 'sha256:ebc7e5b2cb8d83b158b8bed4ed8a118368765ff68817c81b5f98463a72e19f7f',
+  contentDigest: 'sha256:6cc6c0ae067e5b78bd172a1831dd87fd89a9d3a0af3b6dcd47fdddb3bd041647',
 } satisfies StableContributionDescriptor)
 
 export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({

--- a/plugins/boring-governance/src/front/GovernanceUsagePanel.tsx
+++ b/plugins/boring-governance/src/front/GovernanceUsagePanel.tsx
@@ -1,0 +1,177 @@
+"use client"
+
+import * as React from 'react'
+import type { ReactNode } from 'react'
+import { Button, Chip, ErrorState, LoadingState } from '@hachej/boring-ui-kit'
+import type { GovernanceUsageSummary } from '../usageContract.js'
+import { GovernanceUsageMeters } from './GovernanceUsageMeters.js'
+
+export type { GovernanceUsageSummary }
+
+const DEFAULT_ENDPOINT = '/api/v1/governance/usage-summary'
+const DEFAULT_CONTEXT_LABEL = 'Company context'
+const DEFAULT_DESCRIPTION = 'This deployment uses admin-managed monthly model budgets, not prepaid credits.'
+const MICROS_PER_EUR = 1_000_000
+
+export interface GovernanceUsagePanelProps {
+  /**
+   * Label for the company-context box heading, its "(read/write)" line, and the
+   * "… context paths" heading. Tenants pass their own name (e.g. "Constellation
+   * context"). Defaults to "Company context".
+   */
+  contextLabel?: string
+  /** Intro copy under the panel heading. Defaults to the credits-free budget line. */
+  description?: ReactNode
+  /** Route to fetch the usage summary from. Defaults to the governance plugin route. */
+  endpoint?: string
+  /** Override the fetch implementation (tests / non-browser hosts). */
+  fetchImpl?: typeof fetch
+  /** Fully override data loading; takes precedence over `endpoint`/`fetchImpl`. */
+  fetchUsageSummary?: () => Promise<GovernanceUsageSummary>
+  /** Section heading. */
+  title?: string
+  className?: string
+}
+
+type LoadState =
+  | { status: 'loading' }
+  | { status: 'error'; message: string }
+  | { status: 'ready'; summary: GovernanceUsageSummary }
+
+function formatEurMicros(micros: number | null): string {
+  if (micros === null) return 'No aggregate cap'
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency: 'EUR', maximumFractionDigits: 2 }).format(micros / MICROS_PER_EUR)
+}
+
+function contextAccessLabel(summary: GovernanceUsageSummary, contextLabel: string): string {
+  if (summary.companyContextRules.length === 0) return 'Not enabled'
+  return summary.companyContextAccess === 'readwrite' ? `${contextLabel} (read/write)` : 'Read-only allowed paths'
+}
+
+/**
+ * Complete governed-usage settings panel: role, aggregate monthly cap,
+ * company-context access, the per-model usage meters (reusing
+ * `GovernanceUsageMeters`), and the company-context allow-rule chips. Self-fetches
+ * the summary once and hands the resolved data to the embedded meters so there is
+ * a single network round-trip. Renders nothing when governance is disabled.
+ */
+export function GovernanceUsagePanel({
+  contextLabel = DEFAULT_CONTEXT_LABEL,
+  description = DEFAULT_DESCRIPTION,
+  endpoint = DEFAULT_ENDPOINT,
+  fetchImpl,
+  fetchUsageSummary,
+  title = 'Usage limits',
+  className,
+}: GovernanceUsagePanelProps) {
+  const [state, setState] = React.useState<LoadState>({ status: 'loading' })
+
+  const load = React.useCallback(async (signal?: AbortSignal) => {
+    setState({ status: 'loading' })
+    try {
+      const summary = fetchUsageSummary
+        ? await fetchUsageSummary()
+        : await fetchSummary(endpoint, fetchImpl, signal)
+      if (signal?.aborted) return
+      setState({ status: 'ready', summary })
+    } catch (error) {
+      if (signal?.aborted) return
+      setState({ status: 'error', message: error instanceof Error ? error.message : 'Failed to load usage' })
+    }
+  }, [endpoint, fetchImpl, fetchUsageSummary])
+
+  React.useEffect(() => {
+    const controller = new AbortController()
+    void load(controller.signal)
+    return () => controller.abort()
+  }, [load])
+
+  if (state.status === 'loading') {
+    return (
+      <PanelShell title={title} description={description} className={className}>
+        <LoadingState label="Loading governed model limits…" />
+      </PanelShell>
+    )
+  }
+
+  if (state.status === 'error') {
+    return (
+      <PanelShell title={title} description={description} className={className}>
+        <ErrorState
+          title="Couldn’t load usage limits"
+          description={state.message}
+          actions={<Button variant="outline" size="sm" onClick={() => void load()}>Retry</Button>}
+        />
+      </PanelShell>
+    )
+  }
+
+  const { summary } = state
+  if (!summary.enabled) return null
+
+  // Reuse the shared meters component without a second fetch by handing it the
+  // already-resolved summary.
+  const metersSummary = summary
+  return (
+    <PanelShell title={title} description={description} className={className}>
+      <div className="mt-5 grid gap-3 sm:grid-cols-3">
+        <StatCard label="Role" value={summary.role ?? 'Not governed'} />
+        <StatCard label="Aggregate monthly cap" value={formatEurMicros(summary.aggregateCapMicros)} />
+        <StatCard label={contextLabel} value={contextAccessLabel(summary, contextLabel)} />
+      </div>
+
+      <div className="mt-6">
+        <GovernanceUsageMeters fetchUsageSummary={async () => metersSummary} />
+      </div>
+
+      {summary.companyContextRules.length > 0 ? (
+        <div className="mt-6">
+          <h3 className="text-sm font-medium text-foreground">{contextLabel} paths</h3>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {summary.companyContextRules.map((rule) => (
+              <Chip key={rule} className="font-mono text-muted-foreground">{rule}</Chip>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </PanelShell>
+  )
+}
+
+function PanelShell({
+  title,
+  description,
+  className,
+  children,
+}: {
+  title: string
+  description: ReactNode
+  className?: string
+  children: ReactNode
+}) {
+  return (
+    <section data-slot="governance-usage-panel" className={className}>
+      <header>
+        <h2 className="text-lg font-semibold text-foreground">{title}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+      </header>
+      {children}
+    </section>
+  )
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{label}</div>
+      <div className="mt-2 text-base font-medium text-foreground">{value}</div>
+    </div>
+  )
+}
+
+async function fetchSummary(endpoint: string, fetchImpl: typeof fetch | undefined, signal?: AbortSignal): Promise<GovernanceUsageSummary> {
+  const doFetch = fetchImpl ?? fetch
+  const response = await doFetch(endpoint, { credentials: 'include', signal })
+  if (!response.ok) throw new Error(`Usage summary failed: HTTP ${response.status}`)
+  return await response.json() as GovernanceUsageSummary
+}

--- a/plugins/boring-governance/src/front/__tests__/GovernanceUsageMeters.test.tsx
+++ b/plugins/boring-governance/src/front/__tests__/GovernanceUsageMeters.test.tsx
@@ -10,6 +10,10 @@ function summary(overrides: Partial<GovernanceUsageSummary> = {}): GovernanceUsa
   return {
     enabled: true,
     currency: 'EUR',
+    role: 'user',
+    aggregateCapMicros: 20_000_000,
+    companyContextAccess: 'none',
+    companyContextRules: [],
     aggregate: {
       provider: '', id: '__all__', label: 'All models',
       usedMicros: 2_500_000, heldMicros: 0, budgetMicros: 20_000_000,

--- a/plugins/boring-governance/src/front/__tests__/GovernanceUsagePanel.test.tsx
+++ b/plugins/boring-governance/src/front/__tests__/GovernanceUsagePanel.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { GovernanceUsagePanel } from '../GovernanceUsagePanel.js'
+import type { GovernanceUsageSummary } from '../../usageContract.js'
+
+const RESETS_AT = '2026-08-01T00:00:00.000Z'
+
+function summary(overrides: Partial<GovernanceUsageSummary> = {}): GovernanceUsageSummary {
+  return {
+    enabled: true,
+    currency: 'EUR',
+    role: 'user',
+    aggregateCapMicros: 20_000_000,
+    companyContextAccess: 'readonly',
+    companyContextRules: ['company/**', 'shared/handbook.md'],
+    aggregate: {
+      provider: '', id: '__all__', label: 'All models',
+      usedMicros: 2_500_000, heldMicros: 0, budgetMicros: 20_000_000,
+      remainingMicros: 17_500_000, pctUsed: 13, resetsAt: RESETS_AT,
+    },
+    models: [
+      { provider: 'infomaniak', id: 'qwen', label: 'qwen', usedMicros: 2_000_000, heldMicros: 500_000, budgetMicros: 5_000_000, remainingMicros: 2_500_000, pctUsed: 50, resetsAt: RESETS_AT },
+    ],
+    ...overrides,
+  }
+}
+
+describe('GovernanceUsagePanel', () => {
+  it('renders role, aggregate cap, context access, embedded meters, and context path chips', async () => {
+    render(<GovernanceUsagePanel fetchUsageSummary={async () => summary()} />)
+
+    await waitFor(() => expect(screen.getByText('Usage limits')).toBeInTheDocument())
+
+    // Role + aggregate cap stat cards.
+    expect(screen.getByText('Role')).toBeInTheDocument()
+    expect(screen.getByText('user')).toBeInTheDocument()
+    expect(screen.getByText('Aggregate monthly cap')).toBeInTheDocument()
+    expect(screen.getByText('€20.00')).toBeInTheDocument()
+
+    // Read-only context access (rules present, not readwrite).
+    expect(screen.getByText('Read-only allowed paths')).toBeInTheDocument()
+
+    // Embedded meters reused from GovernanceUsageMeters.
+    expect(screen.getByText('Model usage')).toBeInTheDocument()
+    expect(screen.getByText('qwen')).toBeInTheDocument()
+    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+
+    // Context-path chips.
+    expect(screen.getByText('company/**')).toBeInTheDocument()
+    expect(screen.getByText('shared/handbook.md')).toBeInTheDocument()
+  })
+
+  it('applies the contextLabel override to heading, access line, and paths heading', async () => {
+    render(
+      <GovernanceUsagePanel
+        contextLabel="Constellation context"
+        fetchUsageSummary={async () => summary({ companyContextAccess: 'readwrite' })}
+      />,
+    )
+
+    await waitFor(() => expect(screen.getByText('Constellation context (read/write)')).toBeInTheDocument())
+    // Stat card heading + "… paths" heading both use the label.
+    expect(screen.getByText('Constellation context')).toBeInTheDocument()
+    expect(screen.getByText('Constellation context paths')).toBeInTheDocument()
+  })
+
+  it('applies a custom description', async () => {
+    render(<GovernanceUsagePanel description="Custom budget copy." fetchUsageSummary={async () => summary()} />)
+    await waitFor(() => expect(screen.getByText('Custom budget copy.')).toBeInTheDocument())
+  })
+
+  it('shows "No aggregate cap" and "Not enabled" when caps/rules are absent', async () => {
+    render(
+      <GovernanceUsagePanel
+        fetchUsageSummary={async () => summary({ aggregateCapMicros: null, companyContextAccess: 'none', companyContextRules: [] })}
+      />,
+    )
+    await waitFor(() => expect(screen.getByText('No aggregate cap')).toBeInTheDocument())
+    expect(screen.getByText('Not enabled')).toBeInTheDocument()
+  })
+
+  it('renders nothing when governance is disabled', async () => {
+    const { container } = render(
+      <GovernanceUsagePanel fetchUsageSummary={async () => summary({ enabled: false })} />,
+    )
+    await waitFor(() => expect(container.querySelector('[data-slot="governance-usage-panel"]')).toBeNull())
+  })
+
+  it('shows a loading state before data resolves', () => {
+    render(<GovernanceUsagePanel fetchUsageSummary={() => new Promise<GovernanceUsageSummary>(() => {})} />)
+    expect(screen.getByText('Loading governed model limits…')).toBeInTheDocument()
+  })
+
+  it('shows an error state when loading fails', async () => {
+    render(<GovernanceUsagePanel fetchUsageSummary={vi.fn(async () => { throw new Error('boom') })} />)
+    await waitFor(() => expect(screen.getByText('Couldn’t load usage limits')).toBeInTheDocument())
+    expect(screen.getByText('boom')).toBeInTheDocument()
+  })
+})

--- a/plugins/boring-governance/src/front/__tests__/GovernanceUsagePanel.test.tsx
+++ b/plugins/boring-governance/src/front/__tests__/GovernanceUsagePanel.test.tsx
@@ -30,7 +30,10 @@ describe('GovernanceUsagePanel', () => {
   it('renders role, aggregate cap, context access, embedded meters, and context path chips', async () => {
     render(<GovernanceUsagePanel fetchUsageSummary={async () => summary()} />)
 
-    await waitFor(() => expect(screen.getByText('Usage limits')).toBeInTheDocument())
+    // Panel header renders immediately; the embedded meters resolve async, so
+    // wait on their content (qwen) to guarantee the whole panel has settled.
+    await waitFor(() => expect(screen.getByText('qwen')).toBeInTheDocument())
+    expect(screen.getByText('Usage limits')).toBeInTheDocument()
 
     // Role + aggregate cap stat cards.
     expect(screen.getByText('Role')).toBeInTheDocument()
@@ -43,8 +46,8 @@ describe('GovernanceUsagePanel', () => {
 
     // Embedded meters reused from GovernanceUsageMeters.
     expect(screen.getByText('Model usage')).toBeInTheDocument()
-    expect(screen.getByText('qwen')).toBeInTheDocument()
-    expect(screen.getByRole('progressbar')).toBeInTheDocument()
+    // Aggregate + per-model meter rows each render a progressbar.
+    expect(screen.getAllByRole('progressbar').length).toBeGreaterThan(0)
 
     // Context-path chips.
     expect(screen.getByText('company/**')).toBeInTheDocument()

--- a/plugins/boring-governance/src/front/index.tsx
+++ b/plugins/boring-governance/src/front/index.tsx
@@ -58,4 +58,10 @@ export default governanceFrontPlugin
 export { GovernanceAdminView }
 export type { GovernanceMeResponse, GovernancePolicyStatus } from './GovernanceAdminView.js'
 export { GovernanceUsageMeters, type GovernanceUsageMetersProps } from './GovernanceUsageMeters.js'
-export type { GovernanceUsageEntry, GovernanceUsageSummary } from '../usageContract.js'
+export { GovernanceUsagePanel, type GovernanceUsagePanelProps } from './GovernanceUsagePanel.js'
+export type {
+  GovernanceUsageEntry,
+  GovernanceUsageSummary,
+  GovernanceUsageRole,
+  GovernanceCompanyContextAccess,
+} from '../usageContract.js'

--- a/plugins/boring-governance/src/server/__tests__/usageSummary.test.ts
+++ b/plugins/boring-governance/src/server/__tests__/usageSummary.test.ts
@@ -107,12 +107,35 @@ describe('GovernanceService.getUsageSummary', () => {
 
   it('returns an empty summary when governance is disabled', async () => {
     const summary = await service(userPolicy(), false).getUsageSummary(user, reader({}))
-    expect(summary).toEqual({ enabled: false, currency: 'EUR', models: [], aggregate: null })
+    expect(summary).toEqual({
+      enabled: false, currency: 'EUR', models: [], aggregate: null,
+      role: null, aggregateCapMicros: null, companyContextAccess: 'none', companyContextRules: [],
+    })
   })
 
   it('returns an empty enabled summary for an unknown / unverified caller', async () => {
     const summary = await service().getUsageSummary({ id: 'x', email: 'nobody@example.com', emailVerified: true }, reader({}))
-    expect(summary).toEqual({ enabled: true, currency: 'EUR', models: [], aggregate: null })
+    expect(summary).toEqual({
+      enabled: true, currency: 'EUR', models: [], aggregate: null,
+      role: null, aggregateCapMicros: null, companyContextAccess: 'none', companyContextRules: [],
+    })
+  })
+
+  it('includes role, aggregate cap, and context access + rules for a governed user', async () => {
+    const policy = userPolicy({ companyContext: { allow: ['company/**', 'shared/handbook.md'] } })
+    const summary = await service(policy).getUsageSummary(user, reader({}))
+    expect(summary.role).toBe('user')
+    expect(summary.aggregateCapMicros).toBe(20_000_000)
+    expect(summary.companyContextAccess).toBe('readonly')
+    expect(summary.companyContextRules).toEqual(['company/**', 'shared/handbook.md'])
+  })
+
+  it('reports readwrite context access for an admin and null aggregate cap when unset', async () => {
+    const policy = userPolicy({ role: 'admin', budgets: { monthlyEur: null, monthlyMicros: null } })
+    const summary = await service(policy).getUsageSummary(user, reader({}))
+    expect(summary.role).toBe('admin')
+    expect(summary.aggregateCapMicros).toBeNull()
+    expect(summary.companyContextAccess).toBe('readwrite')
   })
 
   it('derives resetsAt from the reader period boundary (not hardcoded)', async () => {

--- a/plugins/boring-governance/src/server/governanceService.ts
+++ b/plugins/boring-governance/src/server/governanceService.ts
@@ -144,10 +144,10 @@ export class GovernanceService {
     user: GovernanceUserLike | null | undefined,
     reader: GovernanceUsageSpendReader,
   ): Promise<GovernanceUsageSummary> {
-    if (!this.loaded.enabled) return { enabled: false, currency: 'EUR', models: [], aggregate: null }
+    if (!this.loaded.enabled) return { ...this.usageSummaryMeta(user), currency: 'EUR', models: [], aggregate: null }
     const userPolicy = this.userPolicy(user)
     const userId = user?.id
-    if (!userPolicy || !userId) return { enabled: true, currency: 'EUR', models: [], aggregate: null }
+    if (!userPolicy || !userId) return { ...this.usageSummaryMeta(user), currency: 'EUR', models: [], aggregate: null }
 
     const models: GovernanceUsageEntry[] = []
     for (const grant of userPolicy.models) {
@@ -174,7 +174,29 @@ export class GovernanceService {
       })
     }
 
-    return { enabled: true, currency: 'EUR', models, aggregate }
+    return { ...this.usageSummaryMeta(user), currency: 'EUR', models, aggregate }
+  }
+
+  /**
+   * Non per-model summary fields (role, aggregate cap, company-context access +
+   * rules) shared by every getUsageSummary return path and by the plugin route's
+   * empty fallback. Reuses the existing policy accessors so the panel and the
+   * admission path can never disagree.
+   */
+  usageSummaryMeta(user: GovernanceUserLike | null | undefined): {
+    enabled: boolean
+    role: TenantRole | null
+    aggregateCapMicros: number | null
+    companyContextAccess: CompanyContextAccess
+    companyContextRules: string[]
+  } {
+    return {
+      enabled: this.loaded.enabled,
+      role: this.roleForUser(user),
+      aggregateCapMicros: user ? this.userMonthlyBudgetMicros(user) : null,
+      companyContextAccess: this.companyContextAccessForUser(user),
+      companyContextRules: user ? this.companyContextRules(user) : [],
+    }
   }
 
   me(user: GovernanceUserLike | null | undefined): GovernanceMeResponse {

--- a/plugins/boring-governance/src/server/routes.ts
+++ b/plugins/boring-governance/src/server/routes.ts
@@ -20,7 +20,7 @@ export function governanceRoutes(service: GovernanceService, options: Governance
       const user = request.user ?? null
       const reader = options.getUsageReader?.()
       if (!user || !reader) {
-        return { enabled: service.isEnabled(), currency: 'EUR' as const, models: [], aggregate: null }
+        return { ...service.usageSummaryMeta(user), currency: 'EUR' as const, models: [], aggregate: null }
       }
       return service.getUsageSummary({ id: user.id, email: user.email, emailVerified: user.emailVerified }, reader)
     })

--- a/plugins/boring-governance/src/usageContract.ts
+++ b/plugins/boring-governance/src/usageContract.ts
@@ -23,6 +23,12 @@ export interface GovernanceUsageEntry {
   resetsAt: string
 }
 
+/** Caller's governance role, or null when the caller is not governed. */
+export type GovernanceUsageRole = 'admin' | 'user' | null
+
+/** Caller's access to the company-context workspace. */
+export type GovernanceCompanyContextAccess = 'none' | 'readonly' | 'readwrite'
+
 export interface GovernanceUsageSummary {
   /** Whether governance is enabled for this host. */
   enabled: boolean
@@ -32,4 +38,12 @@ export interface GovernanceUsageSummary {
   models: GovernanceUsageEntry[]
   /** Aggregate ("All models") row when an aggregate cap is configured, else null. */
   aggregate: GovernanceUsageEntry | null
+  /** Caller's governance role, or null when not governed. */
+  role: GovernanceUsageRole
+  /** Aggregate monthly cap in micros, or null when no aggregate cap is configured. */
+  aggregateCapMicros: number | null
+  /** Caller's access to the company-context workspace. */
+  companyContextAccess: GovernanceCompanyContextAccess
+  /** Company-context allow-rule patterns granted to the caller. */
+  companyContextRules: string[]
 }


### PR DESCRIPTION
## What

Promotes the complete governed-usage settings panel into a reusable export so tenant apps stop hand-rolling it. We already shipped `GovernanceUsageMeters` (per-model bars) in 0.1.82; this wraps it into a **`GovernanceUsagePanel`** that also renders Role, the aggregate monthly cap, company-context access, and context-path chips — matching what the Constellation tenant currently hand-rolls in its 127-line `GovernanceUsageSettings.tsx`.

## Server — one reusable route serves everything

`GovernanceUsageSummary` (types-only shared contract) gains:
- `role: 'admin' | 'user' | null`
- `aggregateCapMicros: number | null`
- `companyContextAccess: 'none' | 'readonly' | 'readwrite'`
- `companyContextRules: string[]`

`GovernanceService.usageSummaryMeta()` derives these by **reusing existing policy accessors** (`roleForUser`, `userMonthlyBudgetMicros`, `companyContextAccessForUser`, `companyContextRules`) so the panel and the admission path can never disagree. All `getUsageSummary` return paths and the `/api/v1/governance/usage-summary` empty-fallback share the helper. Per-model meter data is unchanged.

## Front — `GovernanceUsagePanel`

Exported from `@hachej/boring-governance/front`. Self-fetches the summary **once** and hands the resolved data to the embedded `GovernanceUsageMeters` (single network round-trip). Renders role, aggregate cap, context-access box, model-usage meters, and context-path chips. Theme-aware boring-ui-kit primitives with loading/empty/error states.

Props (the key to letting tenants shrink to config):
- `contextLabel?: string` (default "Company context") — drives the context-box heading, the "(read/write)" line, and the "… context paths" heading. Constellation passes `"Constellation context"`.
- `description?: ReactNode` — intro copy (default the credits-free budget line).
- `endpoint?: string` — fetch-route override (default the plugin route).

## Tenant-shrink goal

Constellation can replace its 127-line `GovernanceUsageSettings.tsx` with:

```tsx
<GovernanceUsagePanel contextLabel="Constellation context" />
```

(Release + tenant consume handled by the orchestrator — not in this PR.)

## Consumer proof

full-app account settings "Usage limits" section now renders `<GovernanceUsagePanel>` instead of the bare meters.

## Tests / gates

- Server: summary fields (role / aggregate cap / context access + rules), incl. admin readwrite + null-cap cases.
- Front: panel renders all sections, `contextLabel` override applied, embedded meters, empty/loading/error states.
- Green locally: governance plugin vitest (17 pass), typecheck (governance/core/full-app), plugin-invariants, package build, full-app build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)