### PR TITLE
refactor(workspace): export app-shell stylesheet so apps import instead of copy

### DIFF
--- a/apps/full-app/src/front/main.tsx
+++ b/apps/full-app/src/front/main.tsx
@@ -15,7 +15,6 @@ import {
   WorkspaceSwitcher,
 } from '@hachej/boring-core/front'
 import '@hachej/boring-core/app/front/styles.css'
-import './app.css'
 import { GovernanceUsagePanel, createGovernanceCompanyAdmin } from '@hachej/boring-governance/front'
 import { BoringMcpSourcesOverlay } from '@hachej/boring-mcp/front'
 import { PublicHeroDescription } from './PublicHeroDescription'

--- a/packages/core/src/app/front/publicLaunchPages.css
+++ b/packages/core/src/app/front/publicLaunchPages.css
@@ -1,16 +1,10 @@
-html,
-body,
-#root {
-  height: 100%;
-  margin: 0;
-  overflow: hidden;
-}
-
-/* NOTE: the chat-first public no-auth shell styling (hero, teaching arrows,
-   sign-in card, suggestion grid, footer) now ships from the core package
-   (`@hachej/boring-core/app/front/styles.css` → chatFirst/chatFirstPublicShell.css)
-   so every consumer inherits it. Only full-app-specific PublicLaunchPages tab
-   styling remains below. */
+/*
+ * Styling for `PublicLaunchPages` — the tab strip + preview pane apps use to
+ * showcase artifact/calendly/HTML demo pages on the public (no-auth) launch
+ * screen. Brand-agnostic and token-driven so every consumer inherits it
+ * without re-copying the sheet. Imported via the package's `styles.css`
+ * entry.
+ */
 
 .public-pages-pane {
   display: flex;

--- a/packages/core/src/app/front/styles.css
+++ b/packages/core/src/app/front/styles.css
@@ -9,6 +9,23 @@
    its plain rules sit after Tailwind's utilities in the cascade. */
 @import "./chatFirst/chatFirstPublicShell.css";
 
+/* Styling for PublicLaunchPages (artifact/calendly/HTML demo tabs on the
+   public launch screen). Imported last for the same cascade-ordering reason
+   as chatFirstPublicShell.css above. */
+@import "./publicLaunchPages.css";
+
+/* Full-bleed app shell: the React root fills the viewport with no scroll
+   chrome of its own (panes manage their own overflow). Every app-shell
+   consumer needs this, so it ships from the package instead of being
+   copy-pasted per app. */
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
 /* Credit notice CTA renders inside the agent subtree. Keep this selector after
    Tailwind + agent globals so it beats both the Button variant colors and
    [data-boring-agent] button color reset. */

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -14,6 +14,7 @@ const CSS_ASSETS = [
   'front/theme.css',
   'app/front/styles.css',
   'app/front/chatFirst/chatFirstPublicShell.css',
+  'app/front/publicLaunchPages.css',
 ]
 
 export default defineConfig([


### PR DESCRIPTION
## Summary

- `apps/full-app/src/front/app.css` (~294 lines) was byte-for-byte identical across tenant app repos (verified in the Constellation tenant). Its rules were the generic full-bleed app-shell layout (`html`/`body`/`#root`) plus `PublicLaunchPages` tab styling — both brand-agnostic and token-driven, no per-app customization.
- Hoisted the stylesheet into `packages/core/src/app/front/publicLaunchPages.css`, imported from the package's existing `@hachej/boring-core/app/front/styles.css` entry (same pattern as `chatFirst/chatFirstPublicShell.css`), and added it to `tsup.config.ts`'s `CSS_ASSETS` copy list so it ships in `dist/`.
- The app-shell `html/body/#root` rules were folded directly into `styles.css` next to the other hand-authored rules.
- `apps/full-app/src/front/main.tsx` no longer imports the local `./app.css` (deleted) — it only needs `import '@hachej/boring-core/app/front/styles.css'`, which now carries these rules too.
- Eliminates the tenant-copy: any consumer app that already imports the package stylesheet gets this styling for free instead of hand-copying `app.css` into every new app repo.

## Test plan

- [x] `pnpm --filter @hachej/boring-core run typecheck`
- [x] `pnpm --filter @hachej/boring-core run build` (tsup + `build:assert` — confirms 4 stylesheets with resolvable `@import`s, including the new one)
- [x] `pnpm --filter full-app run typecheck`
- [x] `pnpm --filter full-app run build` — built CSS output contains `.public-pages-pane`/`.artifact-header`/`.calendly-frame` rules
- [x] `pnpm pack` on `packages/core` + manual tarball inspection — `dist/app/front/publicLaunchPages.css` ships and `styles.css`'s `@import "./publicLaunchPages.css"` resolves relative to the packaged file
- [x] `pnpm run lint:invariants` — all invariant checks pass
- [x] `pnpm --filter @hachej/boring-core run test` — pre-existing failures only (Postgres-migration tests requiring a live DB not available in this sandbox), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)