### PR TITLE
feat(boring-mcp): createBoringMcpAppBindings factory to eliminate per-app MCP wrapper copies

### DIFF
--- a/apps/full-app/src/server/boringMcp.ts
+++ b/apps/full-app/src/server/boringMcp.ts
@@ -1,26 +1,12 @@
-import type { FastifyRequest } from 'fastify'
-import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
 import {
-  boringMcpAgentSessionNamespace,
-  createBoringMcpAppAgentTools,
-  createBoringMcpAppAgentToolsForRequest,
-  createBoringMcpManagedConnectorAdapter,
-  createBoringMcpServerPlugin,
+  createBoringMcpAppBindings,
   createManagedConnectorSecretResolver,
-  createUserSettingsMcpSourceRegistry,
-  readBoringMcpServerConfig,
-  registerBoringMcpRoutes,
-  type BoringMcpBindingConfig,
+  type BoringMcpAppBindingsConfig,
   type BoringMcpServerRuntimeConfig,
-  type ManagedConnectorAdapter,
   type ManagedConnectorConfig,
-  type ManagedConnectorProvider,
   type ManagedConnectorSecretResolver,
-  type ManagedConnectorSourceRegistry,
-  type McpActor,
   type McpTransportClient,
 } from '@hachej/boring-mcp/server'
-import type { AgentTool } from '@hachej/boring-workspace'
 
 // full-app supplies only its deployment-specific configuration; all glue lives
 // in @hachej/boring-mcp/server so tenant deployments import instead of copy.
@@ -29,88 +15,44 @@ const FULL_APP_MANAGED_CONNECTOR_CONFIGS: readonly ManagedConnectorConfig[] = [
   { provider: 'airtable', displayName: 'Airtable', toolkitId: 'airtable', connectUrlOrigins: ['https://app.composio.dev', 'https://connect.composio.dev'] },
 ]
 
-const FULL_APP_BORING_MCP_CONFIG: BoringMcpBindingConfig = {
+const FULL_APP_MCP_CONFIG: BoringMcpAppBindingsConfig = {
   connectorConfigs: FULL_APP_MANAGED_CONNECTOR_CONFIGS,
   redactionCanaries: ['cmp_full_app_canary'],
   clientName: 'boring-full-app-mcp',
   clientVersion: '0.0.0',
+  whenDisabled: 'skip',
+  systemPrompt:
+    'MCP providers are available through the app-owned boring-mcp integration. Use governed read-only MCP calls only after search/describe confirms the tool is enabled.',
+  resolveTrustedWorkspaceId: (request) => request.requestScope?.workspaceId,
 }
+
+// A single factory call replaces the nine per-app forwarding wrappers full-app
+// used to carry; the exports below preserve the names call sites already import.
+const fullAppMcpBindings = createBoringMcpAppBindings(FULL_APP_MCP_CONFIG)
 
 export type FullAppBoringMcpServerConfig = BoringMcpServerRuntimeConfig
-
-export function readFullAppBoringMcpServerConfig(env: NodeJS.ProcessEnv = process.env): FullAppBoringMcpServerConfig {
-  return readBoringMcpServerConfig(env, { secretEnvVars: FULL_APP_BORING_MCP_CONFIG.secretEnvVars })
-}
-
-export function createFullAppManagedConnectorSecretResolver(
-  env: NodeJS.ProcessEnv = process.env,
-  configs: readonly ManagedConnectorConfig[] = FULL_APP_MANAGED_CONNECTOR_CONFIGS,
-): ManagedConnectorSecretResolver {
-  return createManagedConnectorSecretResolver({ env, configs, secretEnvVars: FULL_APP_BORING_MCP_CONFIG.secretEnvVars })
-}
-
-export function createFullAppManagedConnectorAdapter(options: {
-  env?: NodeJS.ProcessEnv
-  registry: ManagedConnectorSourceRegistry
-  provider?: ManagedConnectorProvider
-}): ManagedConnectorAdapter {
-  return createBoringMcpManagedConnectorAdapter({
-    config: FULL_APP_BORING_MCP_CONFIG,
-    registry: options.registry,
-    provider: options.provider,
-    env: options.env,
-  })
-}
-
-export function fullAppAgentSessionNamespace(ctx: { workspaceId: string; request?: FastifyRequest; userId?: string }): string {
-  return boringMcpAgentSessionNamespace(ctx)
-}
-
-export function createFullAppMcpSourceRegistry(
-  app: Pick<CoreWorkspaceAgentServer, 'userStore' | 'config'>,
-  actorScope: McpActor,
-): ManagedConnectorSourceRegistry {
-  return createUserSettingsMcpSourceRegistry(app, actorScope)
-}
-
 export interface CreateFullAppBoringMcpAgentToolsOptions {
   env?: NodeJS.ProcessEnv
   transport?: McpTransportClient
 }
 
-export function createFullAppBoringMcpAgentTools(
-  app: Pick<CoreWorkspaceAgentServer, 'userStore' | 'config'>,
-  actor: McpActor,
-  options: CreateFullAppBoringMcpAgentToolsOptions = {},
-): AgentTool[] {
-  return createBoringMcpAppAgentTools(app, actor, { config: FULL_APP_BORING_MCP_CONFIG, ...options })
-}
+export const readFullAppBoringMcpServerConfig = fullAppMcpBindings.readConfig
+export const createFullAppManagedConnectorAdapter = fullAppMcpBindings.createConnectorAdapter
+export const fullAppAgentSessionNamespace = fullAppMcpBindings.agentSessionNamespace
+export const createFullAppMcpSourceRegistry = fullAppMcpBindings.createMcpSourceRegistry
+export const createFullAppBoringMcpAgentTools = fullAppMcpBindings.createAgentTools
+export const createFullAppBoringMcpAgentToolsForRequest = fullAppMcpBindings.createAgentToolsForRequest
+export const registerFullAppBoringMcpRoutes = fullAppMcpBindings.registerRoutes
+export const createFullAppBoringMcpServerPlugins = fullAppMcpBindings.createServerPlugins
 
-export function createFullAppBoringMcpAgentToolsForRequest(
-  app: Pick<CoreWorkspaceAgentServer, 'userStore' | 'config'>,
-  ctx: { workspaceId: string; authSubject?: string },
-  options: CreateFullAppBoringMcpAgentToolsOptions = {},
-): AgentTool[] {
-  return createBoringMcpAppAgentToolsForRequest(app, ctx, { config: FULL_APP_BORING_MCP_CONFIG, ...options })
-}
-
-export function registerFullAppBoringMcpRoutes(
-  app: CoreWorkspaceAgentServer,
-  options: { provider?: ManagedConnectorProvider; env?: NodeJS.ProcessEnv; transport?: McpTransportClient } = {},
-): void {
-  registerBoringMcpRoutes(app, {
-    config: FULL_APP_BORING_MCP_CONFIG,
-    resolveTrustedWorkspaceId: (request) => request.requestScope?.workspaceId,
-    ...options,
-  })
-}
-
-export function createFullAppBoringMcpServerPlugins(env: NodeJS.ProcessEnv = process.env) {
-  const config = readFullAppBoringMcpServerConfig(env)
-  if (!config.enabled) return []
-  return [createBoringMcpServerPlugin({
-    systemPrompt: 'MCP providers are available through the app-owned boring-mcp integration. Use governed read-only MCP calls only after search/describe confirms the tool is enabled.',
-  })]
+// Retains the optional `configs` override that full-app tests exercise (deriving
+// supported providers from an arbitrary connector set), which the pre-bound
+// factory member intentionally does not expose.
+export function createFullAppManagedConnectorSecretResolver(
+  env: NodeJS.ProcessEnv = process.env,
+  configs: readonly ManagedConnectorConfig[] = FULL_APP_MANAGED_CONNECTOR_CONFIGS,
+): ManagedConnectorSecretResolver {
+  return createManagedConnectorSecretResolver({ env, configs, secretEnvVars: FULL_APP_MCP_CONFIG.secretEnvVars })
 }
 
 export const boringMcpServerPlugins = createFullAppBoringMcpServerPlugins()

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -29,7 +29,7 @@ export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
 export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'boring-mcp',
   version: '0.1.84',
-  contentDigest: 'sha256:1af659b0b66cf3fc3a641e176c229b7c79c9b9444bc64d7c1ca6deea6a4340dd',
+  contentDigest: 'sha256:7474a07cfc8368b7ab558f36f981a708c71caef5291ae2dc32a9b400613ad704',
 } satisfies StableContributionDescriptor)
 
 // Freshness test: lexical tracked files -> SHA-256(bytes) per file ->

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -29,7 +29,7 @@ export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
 export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'boring-mcp',
   version: '0.1.84',
-  contentDigest: 'sha256:7474a07cfc8368b7ab558f36f981a708c71caef5291ae2dc32a9b400613ad704',
+  contentDigest: 'sha256:ec866b7c39a657ffd860e58ad759abf5a572cbed0e532eb8a60e179bb4bf2426',
 } satisfies StableContributionDescriptor)
 
 // Freshness test: lexical tracked files -> SHA-256(bytes) per file ->

--- a/plugins/boring-mcp/src/server/__tests__/appServerBinding.test.ts
+++ b/plugins/boring-mcp/src/server/__tests__/appServerBinding.test.ts
@@ -2,11 +2,14 @@ import Fastify from 'fastify'
 import { describe, expect, it } from 'vitest'
 import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
 import {
+  createBoringMcpAppBindings,
   createManagedConnectorSecretResolver,
   readBoringMcpServerConfig,
   registerBoringMcpRoutes,
+  type BoringMcpAppBindingsConfig,
   type BoringMcpBindingConfig,
 } from '../appServerBinding'
+import { BORING_MCP_PLUGIN_ID } from '../../shared'
 import type { ManagedConnectorConfig } from '../managedConnectorAdapter'
 
 const CONFIGS: readonly ManagedConnectorConfig[] = [
@@ -72,6 +75,78 @@ describe('registerBoringMcpRoutes disabled behavior', () => {
     await app.ready()
     const res = await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources', headers: { 'x-boring-workspace-id': 'w1' } })
     expect(res.statusCode).toBe(503)
+    await app.close()
+  })
+})
+
+describe('createBoringMcpAppBindings', () => {
+  const APP_CONFIG: BoringMcpAppBindingsConfig = {
+    connectorConfigs: CONFIGS,
+    secretEnvVars: ['COMPOSIO_API_KEY', 'ALT_KEY'],
+    clientName: 'boring-mcp-app-test',
+    systemPrompt: 'stub system prompt',
+    whenDisabled: 'serve-503',
+  }
+
+  it('pre-binds readConfig secret env vars and resolves in configured order', async () => {
+    const bindings = createBoringMcpAppBindings(APP_CONFIG)
+    // secretEnvVars from config drive both the runtime config and the resolver.
+    expect(bindings.readConfig({ ALT_KEY: 'k' } as NodeJS.ProcessEnv).composioApiKeyConfigured).toBe(true)
+    expect(bindings.readConfig({} as NodeJS.ProcessEnv).composioApiKeyConfigured).toBe(false)
+
+    const resolver = bindings.createSecretResolver({ ALT_KEY: 'from-alt' } as NodeJS.ProcessEnv)
+    await expect(resolver.resolveSecret('notion')).resolves.toEqual({ storage: 'server-env', value: 'from-alt' })
+    // Primary env var wins over the fallback when both are present.
+    const primary = bindings.createSecretResolver({ COMPOSIO_API_KEY: 'primary', ALT_KEY: 'alt' } as NodeJS.ProcessEnv)
+    await expect(primary.resolveSecret('notion')).resolves.toEqual({ storage: 'server-env', value: 'primary' })
+    await expect(resolver.resolveSecret('airtable')).rejects.toThrow('Unsupported MCP provider: airtable')
+  })
+
+  it('contributes an enabled server plugin only when boring-mcp is enabled', () => {
+    const bindings = createBoringMcpAppBindings(APP_CONFIG)
+    expect(bindings.createServerPlugins({ BORING_MCP_ENABLED: '0' } as NodeJS.ProcessEnv)).toEqual([])
+    expect(bindings.createServerPlugins({ BORING_MCP_ENABLED: '1' } as NodeJS.ProcessEnv).map((plugin) => plugin.id))
+      .toEqual([BORING_MCP_PLUGIN_ID])
+  })
+
+  it('honors the config whenDisabled when registering routes', async () => {
+    const bindings = createBoringMcpAppBindings(APP_CONFIG)
+    const app = Fastify()
+    app.setErrorHandler((error: unknown, _request, reply) => {
+      const err = error as { status?: number; statusCode?: number; code?: string; message?: string }
+      reply.code(err.status ?? err.statusCode ?? 500).send({ code: err.code ?? 'internal', message: err.message })
+    })
+    bindings.registerRoutes(app as unknown as CoreWorkspaceAgentServer, { env: { NODE_ENV: 'production' } as NodeJS.ProcessEnv })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources', headers: { 'x-boring-workspace-id': 'w1' } })
+    expect(res.statusCode).toBe(503)
+    await app.close()
+  })
+
+  it('registers working per-user source routes from a stub app', async () => {
+    const bindings = createBoringMcpAppBindings({ ...APP_CONFIG, whenDisabled: 'skip' })
+    const settings = new Map<string, Record<string, unknown>>([['user-1', {}]])
+    const app = Fastify()
+    app.decorate('config', { appId: 'app-test' } as never)
+    app.decorate('userStore', {
+      async getUserSettings(userId: string) { return { displayName: '', email: '', settings: settings.get(userId) ?? {} } },
+      async putUserSettings(userId: string, _appId: string, updates: { settings?: Record<string, unknown> }) {
+        settings.set(userId, updates.settings ?? {})
+        return { displayName: '', email: '', settings: updates.settings ?? {} }
+      },
+    } as never)
+    app.decorate('workspaceStore', {
+      async get(workspaceId: string) { return workspaceId === 'w1' ? { id: 'w1', appId: 'app-test', name: 'W', createdBy: 'user-1', createdAt: '', deletedAt: null, isDefault: true } : null },
+      async getMemberRole(workspaceId: string, userId: string) { return workspaceId === 'w1' && userId === 'user-1' ? 'owner' : null },
+    } as never)
+    app.addHook('onRequest', async (request) => {
+      request.user = { id: 'user-1', email: 'd@e.com', name: 'D', emailVerified: true }
+    })
+    bindings.registerRoutes(app as unknown as CoreWorkspaceAgentServer, { env: { COMPOSIO_API_KEY: 'k' } as NodeJS.ProcessEnv })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/api/v1/boring-mcp/sources', headers: { 'x-boring-workspace-id': 'w1' } })
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({ sourceStatuses: [] })
     await app.close()
   })
 })

--- a/plugins/boring-mcp/src/server/appServerBinding.ts
+++ b/plugins/boring-mcp/src/server/appServerBinding.ts
@@ -39,6 +39,7 @@ import { createComposioManagedConnectorProvider, createComposioMcpTransport } fr
 import { createMcpSourceStatusPayload } from './sourceAccess'
 import { createBoringMcpSourceHandlers } from './sourceHandlers'
 import { createBoringMcpAgentTools } from './agentTools'
+import { createBoringMcpServerPlugin } from './serverPlugin'
 
 const DEFAULT_MAX_READONLY_INPUT_BYTES = 64 * 1024
 const MAX_READONLY_INPUT_BYTES = 1024 * 1024
@@ -638,4 +639,103 @@ export function registerBoringMcpRoutes(app: BoringMcpAppServer, options: Regist
     }))
     return { tools: result.tools }
   })
+}
+
+/**
+ * Full per-app configuration for {@link createBoringMcpAppBindings}. Extends the
+ * connector/secret binding config with the two remaining knobs a host used to
+ * hardcode: how routes behave while disabled, and the agent system prompt.
+ */
+export interface BoringMcpAppBindingsConfig extends BoringMcpBindingConfig {
+  /**
+   * Behavior when boring-mcp is disabled for this deployment. Forwarded to
+   * {@link registerBoringMcpRoutes}. Defaults to `skip`.
+   */
+  whenDisabled?: 'skip' | 'serve-503'
+  /** System prompt applied to the boring-mcp server plugin this host contributes. */
+  systemPrompt?: string
+  /**
+   * Default trusted-workspace resolver applied to every route registration for
+   * this deployment (e.g. D1 host request scoping). A per-call
+   * `resolveTrustedWorkspaceId` passed to `registerRoutes` overrides it.
+   */
+  resolveTrustedWorkspaceId?: (request: FastifyRequest) => string | undefined
+}
+
+export interface BoringMcpAppBindingsAgentToolsOptions {
+  env?: NodeJS.ProcessEnv
+  transport?: McpTransportClient
+}
+
+export interface BoringMcpAppBindingsRoutesOptions {
+  provider?: ManagedConnectorProvider
+  env?: NodeJS.ProcessEnv
+  transport?: McpTransportClient
+  resolveTrustedWorkspaceId?: (request: FastifyRequest) => string | undefined
+}
+
+/**
+ * The complete set of per-app boring-mcp bindings, each pre-bound to a single
+ * {@link BoringMcpAppBindingsConfig}. Host apps expose these members instead of
+ * copying the ~110 lines of forwarding glue they used to hand-write.
+ */
+export interface BoringMcpAppBindings {
+  readConfig(env?: NodeJS.ProcessEnv): BoringMcpServerRuntimeConfig
+  createSecretResolver(env?: NodeJS.ProcessEnv): ManagedConnectorSecretResolver
+  createConnectorAdapter(options: {
+    registry: ManagedConnectorSourceRegistry
+    env?: NodeJS.ProcessEnv
+    provider?: ManagedConnectorProvider
+  }): ManagedConnectorAdapter
+  agentSessionNamespace(ctx: { workspaceId: string; request?: FastifyRequest; userId?: string }): string
+  createMcpSourceRegistry(
+    app: Pick<BoringMcpAppServer, 'userStore' | 'config'>,
+    actorScope: McpActor,
+  ): ManagedConnectorSourceRegistry
+  createAgentTools(
+    app: Pick<BoringMcpAppServer, 'userStore' | 'config'>,
+    actor: McpActor,
+    options?: BoringMcpAppBindingsAgentToolsOptions,
+  ): AgentTool[]
+  createAgentToolsForRequest(
+    app: Pick<BoringMcpAppServer, 'userStore' | 'config'>,
+    ctx: { workspaceId: string; authSubject?: string },
+    options?: BoringMcpAppBindingsAgentToolsOptions,
+  ): AgentTool[]
+  registerRoutes(app: BoringMcpAppServer, options?: BoringMcpAppBindingsRoutesOptions): void
+  createServerPlugins(env?: NodeJS.ProcessEnv): ReturnType<typeof createBoringMcpServerPlugin>[]
+}
+
+/**
+ * Build the full set of boring-mcp server bindings for a host app from a single
+ * config object. Every member is pre-bound to `config`, so a host wires MCP with
+ * ~15 lines of configuration instead of re-copying the forwarding glue.
+ */
+export function createBoringMcpAppBindings(config: BoringMcpAppBindingsConfig): BoringMcpAppBindings {
+  return {
+    readConfig: (env) => readBoringMcpServerConfig(env, { secretEnvVars: config.secretEnvVars }),
+    createSecretResolver: (env) =>
+      createManagedConnectorSecretResolver({ env, configs: config.connectorConfigs, secretEnvVars: config.secretEnvVars }),
+    createConnectorAdapter: (options) =>
+      createBoringMcpManagedConnectorAdapter({ config, registry: options.registry, env: options.env, provider: options.provider }),
+    agentSessionNamespace: boringMcpAgentSessionNamespace,
+    createMcpSourceRegistry: createUserSettingsMcpSourceRegistry,
+    createAgentTools: (app, actor, options = {}) =>
+      createBoringMcpAppAgentTools(app, actor, { config, env: options.env, transport: options.transport }),
+    createAgentToolsForRequest: (app, ctx, options = {}) =>
+      createBoringMcpAppAgentToolsForRequest(app, ctx, { config, env: options.env, transport: options.transport }),
+    registerRoutes: (app, options = {}) =>
+      registerBoringMcpRoutes(app, {
+        config,
+        whenDisabled: config.whenDisabled,
+        provider: options.provider,
+        env: options.env,
+        transport: options.transport,
+        resolveTrustedWorkspaceId: options.resolveTrustedWorkspaceId ?? config.resolveTrustedWorkspaceId,
+      }),
+    createServerPlugins: (env = process.env) => {
+      if (!readBoringMcpServerConfig(env, { secretEnvVars: config.secretEnvVars }).enabled) return []
+      return [createBoringMcpServerPlugin({ systemPrompt: config.systemPrompt })]
+    },
+  }
 }

--- a/plugins/boring-mcp/src/server/index.ts
+++ b/plugins/boring-mcp/src/server/index.ts
@@ -1,37 +1,6 @@
-import { defineServerPlugin } from "@hachej/boring-workspace/server"
-import { BORING_MCP_PLUGIN_ID, type McpProviderTemplate, type McpSourceRegistry, type McpTransportClient } from "../shared"
-import type { McpProviderHardeningOptions } from "./hardening"
-import type { McpReadonlyCallAuditSink } from "./readonlyCall"
-import { createBoringMcpAgentTools, type BoringMcpAgentToolActorResolver } from "./agentTools"
+import { createBoringMcpServerPlugin } from "./serverPlugin"
 
-export interface CreateBoringMcpServerPluginOptions {
-  systemPrompt?: string
-  registry?: McpSourceRegistry
-  transport?: McpTransportClient
-  resolveActor?: BoringMcpAgentToolActorResolver
-  templates?: readonly McpProviderTemplate[]
-  maxReadonlyInputBytes?: number
-  audit?: McpReadonlyCallAuditSink
-  hardening?: McpProviderHardeningOptions
-}
-
-export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPluginOptions = {}) {
-  const hasAgentToolWiring = Boolean(options.registry && options.transport && options.resolveActor)
-  return defineServerPlugin({
-    id: BORING_MCP_PLUGIN_ID,
-    label: "Sources",
-    systemPrompt: options.systemPrompt ?? "Use boring-mcp bridge tools only when an app has enabled them. Treat MCP sources as read-only unless a tool is explicitly allowed.",
-    agentTools: hasAgentToolWiring ? createBoringMcpAgentTools({
-      registry: options.registry!,
-      transport: options.transport!,
-      resolveActor: options.resolveActor!,
-      templates: options.templates,
-      maxReadonlyInputBytes: options.maxReadonlyInputBytes,
-      audit: options.audit,
-      hardening: options.hardening,
-    }) : undefined,
-  })
-}
+export * from "./serverPlugin"
 
 export default createBoringMcpServerPlugin()
 export * from "./appServerBinding"

--- a/plugins/boring-mcp/src/server/serverPlugin.ts
+++ b/plugins/boring-mcp/src/server/serverPlugin.ts
@@ -1,0 +1,34 @@
+import { defineServerPlugin } from "@hachej/boring-workspace/server"
+import { BORING_MCP_PLUGIN_ID, type McpProviderTemplate, type McpSourceRegistry, type McpTransportClient } from "../shared"
+import type { McpProviderHardeningOptions } from "./hardening"
+import type { McpReadonlyCallAuditSink } from "./readonlyCall"
+import { createBoringMcpAgentTools, type BoringMcpAgentToolActorResolver } from "./agentTools"
+
+export interface CreateBoringMcpServerPluginOptions {
+  systemPrompt?: string
+  registry?: McpSourceRegistry
+  transport?: McpTransportClient
+  resolveActor?: BoringMcpAgentToolActorResolver
+  templates?: readonly McpProviderTemplate[]
+  maxReadonlyInputBytes?: number
+  audit?: McpReadonlyCallAuditSink
+  hardening?: McpProviderHardeningOptions
+}
+
+export function createBoringMcpServerPlugin(options: CreateBoringMcpServerPluginOptions = {}) {
+  const hasAgentToolWiring = Boolean(options.registry && options.transport && options.resolveActor)
+  return defineServerPlugin({
+    id: BORING_MCP_PLUGIN_ID,
+    label: "Sources",
+    systemPrompt: options.systemPrompt ?? "Use boring-mcp bridge tools only when an app has enabled them. Treat MCP sources as read-only unless a tool is explicitly allowed.",
+    agentTools: hasAgentToolWiring ? createBoringMcpAgentTools({
+      registry: options.registry!,
+      transport: options.transport!,
+      resolveActor: options.resolveActor!,
+      templates: options.templates,
+      maxReadonlyInputBytes: options.maxReadonlyInputBytes,
+      audit: options.audit,
+      hardening: options.hardening,
+    }) : undefined,
+  })
+}


### PR DESCRIPTION
## What

Adds a single `createBoringMcpAppBindings(config)` factory to `@hachej/boring-mcp/server` that returns **all nine** server bindings — `readConfig`, `createSecretResolver`, `createConnectorAdapter`, `agentSessionNamespace`, `createMcpSourceRegistry`, `createAgentTools`, `createAgentToolsForRequest`, `registerRoutes`, `createServerPlugins` — each **pre-bound to one deployment config**.

The factory config (`BoringMcpAppBindingsConfig`) extends `BoringMcpBindingConfig` with the last knobs a host used to hardcode:
- `whenDisabled?: 'skip' | 'serve-503'`
- `systemPrompt?` (server plugin prompt)
- `resolveTrustedWorkspaceId?` (default D1 host request scoping; per-call override still honored)

## full-app consumption proof

`apps/full-app/src/server/boringMcp.ts` previously carried nine per-app forwarding wrappers. It now declares one `FULL_APP_MCP_CONFIG` object, calls the factory once, and re-exports the members under the existing names. **No call-site changes** in `app.ts`/`main.ts`/`dev.ts`/`plugins.ts` — the exported symbol names are preserved. The only retained wrapper is `createFullAppManagedConnectorSecretResolver`, which keeps an optional `configs` override that full-app tests exercise and the pre-bound member intentionally does not expose.

## Behavior preservation

whenDisabled default (`skip`), secret env resolution order, session namespace hashing, tool hardening limits (100 calls / 10 tool-calls / 60s, 30s timeout), and D1 trusted-workspace scoping are all unchanged. Verified by the existing full-app boringMcp suite (unchanged assertions) plus the workspace-composition freshness digest, which was refreshed to match the new source bytes.

## Notes

- Extracted `createBoringMcpServerPlugin` into `serverPlugin.ts` to avoid an `index` ↔ `appServerBinding` import cycle.
- New factory unit tests: routes register from a stub app, disabled → configured 503, secret resolution order across env-var fallbacks, enabled server-plugin contribution.

## Tenant follow-up

Constellation's ~110-line `src/server/boringMcp.ts` copy can collapse to the same shape: one `createBoringMcpAppBindings({ connectorConfigs, secretEnvVars: ['COMPOSIO_API_KEY','CONDUKTOR_API_KEY'], clientName: '<tenant>', whenDisabled: 'serve-503', systemPrompt, ... })` call plus re-exports. Not touched in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)