### PR TITLE
AR1-004: minimal MCP resource support for shares

### DIFF
--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -119,6 +119,8 @@ export {
   MANAGED_AGENT_MCP_ORIGIN_SURFACE,
   ManagedAgentMcpDelegateController,
   ManagedAgentMcpError,
+  registerShareEntryResources,
+  shareResourceUri,
 } from './mcp'
 export type {
   ManagedAgentArtifact,
@@ -139,6 +141,7 @@ export type {
   ManagedAgentMcpServerOptions,
   ManagedAgentSafeError,
   ManagedAgentWorkspaceResolutionInput,
+  ShareEntryMcpResourceOptions,
 } from './mcp'
 export { createAgentApp } from './createAgentApp'
 export type { CreateAgentAppOptions } from './createAgentApp'

--- a/packages/agent/src/server/mcp/__tests__/shareEntryResources.test.ts
+++ b/packages/agent/src/server/mcp/__tests__/shareEntryResources.test.ts
@@ -1,0 +1,231 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import { sha256Bytes } from '../../../shared/digest'
+import { InMemoryShareEntryStore, type ShareEntryStore } from '../../../shared/share-entry'
+import type { SessionCtx } from '../../../shared/session'
+import type { Stat, Workspace } from '../../../shared/workspace'
+import { createManagedAgentMcpHttpHandler, type ManagedAgentMcpHttpHandlerOptions } from '../managedAgentMcpServer'
+import { shareResourceUri } from '../shareEntryResources'
+
+const WORKSPACE_A: SessionCtx = { workspaceId: 'workspace-a', userId: 'user-a' }
+const WORKSPACE_B: SessionCtx = { workspaceId: 'workspace-b', userId: 'user-b' }
+
+const utf8Encoder = new TextEncoder()
+
+const servers: Array<{ close: () => Promise<void> }> = []
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((server) => server.close()))
+})
+
+describe('AR1-004 MCP share resources', () => {
+  test('lists only the authenticated workspace\'s shares', async () => {
+    const store = new InMemoryShareEntryStore()
+    const ownEntry = await store.create({
+      workspaceId: 'workspace-a',
+      path: 'notes.md',
+      provenance: { producerPrincipalRef: 'user-a' },
+    })
+    await store.create({
+      workspaceId: 'workspace-b',
+      path: 'secret.md',
+      provenance: { producerPrincipalRef: 'user-b' },
+    })
+
+    const client = await connect(store, () => WORKSPACE_A, () => fakeWorkspace({ 'notes.md': '# Notes' }))
+    const result = await client.listResources()
+    await client.close()
+
+    expect(result.resources).toHaveLength(1)
+    expect(result.resources[0]).toMatchObject({ uri: shareResourceUri(ownEntry.id), name: ownEntry.id })
+  })
+
+  test('reads a live share with exact bytes and a digest', async () => {
+    const store = new InMemoryShareEntryStore()
+    const entry = await store.create({
+      workspaceId: 'workspace-a',
+      path: 'notes.md',
+      provenance: { producerPrincipalRef: 'user-a' },
+    })
+    const workspace = fakeWorkspace({ 'notes.md': '# Notes\n\nhello' })
+
+    const client = await connect(store, () => WORKSPACE_A, () => workspace)
+    const result = await client.readResource({ uri: shareResourceUri(entry.id) })
+    await client.close()
+
+    expect(result.contents).toHaveLength(1)
+    const content = result.contents[0] as { text: string; _meta?: Record<string, unknown> }
+    expect(content.text).toBe('# Notes\n\nhello')
+    expect(content._meta?.status).toBe('ok')
+    expect(content._meta?.digest).toBe(await sha256Bytes(utf8Encoder.encode('# Notes\n\nhello')))
+    expect(content._meta?.byteSize).toBe(utf8Encoder.encode('# Notes\n\nhello').byteLength)
+    // Never leak the server-internal path.
+    expect(JSON.stringify(result)).not.toMatch(/notes\.md/)
+  })
+
+  test('renders a path-free tombstone when the target file is gone', async () => {
+    const store = new InMemoryShareEntryStore()
+    const entry = await store.create({
+      workspaceId: 'workspace-a',
+      path: 'gone.md',
+      provenance: { producerPrincipalRef: 'user-a' },
+    })
+    const workspace = fakeWorkspace({})
+
+    const client = await connect(store, () => WORKSPACE_A, () => workspace)
+    const result = await client.readResource({ uri: shareResourceUri(entry.id) })
+    await client.close()
+
+    const content = result.contents[0] as { text: string }
+    const body = JSON.parse(content.text) as { status: string; error: { code: string } }
+    expect(body.status).toBe('tombstoned')
+    expect(body.error.code).toBe('AR1_SHARE_TOMBSTONED')
+    expect(JSON.stringify(result)).not.toMatch(/gone\.md/)
+  })
+
+  test('renders AR1_SHARE_NOT_FOUND for an unknown id', async () => {
+    const store = new InMemoryShareEntryStore()
+    const client = await connect(store, () => WORKSPACE_A, () => fakeWorkspace({}))
+    const result = await client.readResource({ uri: shareResourceUri('does-not-exist') })
+    await client.close()
+
+    const content = result.contents[0] as { text: string }
+    const body = JSON.parse(content.text) as { status: string; error: { code: string } }
+    expect(body.status).toBe('not_found')
+    expect(body.error.code).toBe('AR1_SHARE_NOT_FOUND')
+  })
+
+  test('a non-member workspace sees an id as indistinguishable from not-found', async () => {
+    const store = new InMemoryShareEntryStore()
+    const entry = await store.create({
+      workspaceId: 'workspace-a',
+      path: 'notes.md',
+      provenance: { producerPrincipalRef: 'user-a' },
+    })
+
+    const memberClient = await connect(store, () => WORKSPACE_A, () => fakeWorkspace({ 'notes.md': '# Notes' }))
+    const memberResult = await memberClient.readResource({ uri: shareResourceUri(entry.id) })
+    await memberClient.close()
+
+    const otherClient = await connect(store, () => WORKSPACE_B, () => fakeWorkspace({}))
+    const otherResult = await otherClient.readResource({ uri: shareResourceUri(entry.id) })
+    const missingResult = await otherClient.readResource({ uri: shareResourceUri('totally-unknown-id') })
+    const otherList = await otherClient.listResources()
+    await otherClient.close()
+
+    const memberBody = memberResult.contents[0] as { _meta?: Record<string, unknown> }
+    expect(memberBody._meta?.status).toBe('ok')
+
+    const otherBody = JSON.parse((otherResult.contents[0] as { text: string }).text) as { status: string; error: { code: string } }
+    const missingBody = JSON.parse((missingResult.contents[0] as { text: string }).text) as { status: string; error: { code: string } }
+    expect(otherBody).toEqual(missingBody)
+    expect(otherBody.status).toBe('not_found')
+
+    // The non-member list must never include workspace-a's share.
+    expect(otherList.resources).toEqual([])
+  })
+
+  test('rejects an oversize share target with a stable code', async () => {
+    const store = new InMemoryShareEntryStore()
+    const entry = await store.create({
+      workspaceId: 'workspace-a',
+      path: 'big.md',
+      provenance: { producerPrincipalRef: 'user-a' },
+    })
+    const workspace = fakeWorkspace({ 'big.md': 'x'.repeat(256 * 1024 + 1) })
+
+    const client = await connect(store, () => WORKSPACE_A, () => workspace)
+    await expect(client.readResource({ uri: shareResourceUri(entry.id) })).rejects.toThrow(/must be 262144 bytes or fewer/)
+    await client.close()
+  })
+})
+
+async function connect(
+  store: ShareEntryStore,
+  resolveShareSessionCtx: () => SessionCtx,
+  resolveShareWorkspace: () => Workspace,
+): Promise<Client> {
+  const options: ManagedAgentMcpHttpHandlerOptions = {
+    resolveSessionCtx: () => resolveShareSessionCtx(),
+    shareEntryStore: store,
+    resolveShareSessionCtx: () => resolveShareSessionCtx(),
+    resolveShareWorkspace: () => resolveShareWorkspace(),
+  }
+  const handler = createManagedAgentMcpHttpHandler(options)
+  const endpoint = await listen(handler)
+  const client = new Client({ name: 'share-resource-test-client', version: '0.0.0-test' })
+  await client.connect(new StreamableHTTPClientTransport(new URL(endpoint)))
+  return client
+}
+
+async function listen(
+  handler: (req: IncomingMessage, res: ServerResponse, parsedBody?: unknown) => Promise<void>,
+): Promise<string> {
+  const server = createServer(async (req, res) => {
+    const body = await readJson(req)
+    await handler(req, res, body)
+  })
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+  const { port } = server.address() as AddressInfo
+  servers.push({
+    close: () => new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()))
+    }),
+  })
+  return `http://127.0.0.1:${port}/mcp`
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = []
+  for await (const chunk of req) chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+  if (!chunks.length) return undefined
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'))
+}
+
+function fakeWorkspace(files: Record<string, string>): Workspace {
+  const entries = new Map(
+    Object.entries(files).map(([path, content]) => [
+      path,
+      { bytes: utf8Encoder.encode(content), mtimeMs: Date.parse('2026-07-13T00:00:00.000Z') },
+    ]),
+  )
+  return {
+    root: '/srv/private/workspaces/fake',
+    runtimeContext: { runtimeCwd: '/workspace' },
+    async stat(path: string): Promise<Stat> {
+      const entry = entries.get(path)
+      if (!entry) throw new Error(`missing ${path}`)
+      return { kind: 'file', size: entry.bytes.byteLength, mtimeMs: entry.mtimeMs }
+    },
+    async readBinaryFile(path: string): Promise<Uint8Array> {
+      const entry = entries.get(path)
+      if (!entry) throw new Error(`missing ${path}`)
+      return entry.bytes.slice()
+    },
+    async readFile(path: string): Promise<string> {
+      const entry = entries.get(path)
+      if (!entry) throw new Error(`missing ${path}`)
+      return new TextDecoder().decode(entry.bytes)
+    },
+    async writeFile(): Promise<void> {
+      throw new Error('not implemented')
+    },
+    async unlink(): Promise<void> {
+      throw new Error('not implemented')
+    },
+    async readdir(): Promise<never[]> {
+      return []
+    },
+    async mkdir(): Promise<void> {
+      throw new Error('not implemented')
+    },
+    async rename(): Promise<void> {
+      throw new Error('not implemented')
+    },
+  }
+}

--- a/packages/agent/src/server/mcp/index.ts
+++ b/packages/agent/src/server/mcp/index.ts
@@ -31,3 +31,5 @@ export type {
   ManagedAgentMcpHttpHandlerOptions,
   ManagedAgentMcpServerOptions,
 } from './managedAgentMcpServer'
+export { registerShareEntryResources, shareResourceUri } from './shareEntryResources'
+export type { ShareEntryMcpResourceOptions } from './shareEntryResources'

--- a/packages/agent/src/server/mcp/managedAgentMcpServer.ts
+++ b/packages/agent/src/server/mcp/managedAgentMcpServer.ts
@@ -15,12 +15,29 @@ import {
   type ManagedAgentDelegateStatusResult,
   type ManagedAgentMcpDelegateOptions,
 } from './managedAgentDelegate'
+import { registerShareEntryResources } from './shareEntryResources'
 import { ErrorCode, type ErrorCode as StableErrorCode } from '../../shared/error-codes'
+import type { ShareEntryStore } from '../../shared/share-entry'
+import type { SessionCtx } from '../../shared/session'
+import type { Workspace } from '../../shared/workspace'
 
 interface ManagedAgentMcpPresentationOptions {
   name?: string
   version?: string
   maxBriefChars?: number
+  /**
+   * Optional Lane W (AR1-002/AR1-004) share-entry store. When supplied
+   * together with `resolveShareSessionCtx`/`resolveShareWorkspace`, the
+   * server exposes `listResources`/`readResource` scoped to the
+   * authenticated workspace's share entries, on this SAME MCP server
+   * process (no second MCP runtime owner). Hosts that omit any of the
+   * three leave Lane W unmounted — no widening.
+   */
+  shareEntryStore?: ShareEntryStore
+  /** Resolves the authenticated SessionCtx for a share resource request. */
+  resolveShareSessionCtx?: (request: ManagedAgentDelegateRequestContext) => SessionCtx | Promise<SessionCtx>
+  /** Resolves the authorized Workspace to read share targets from, for a given SessionCtx. */
+  resolveShareWorkspace?: (ctx: SessionCtx) => Workspace | Promise<Workspace>
 }
 
 export interface ManagedAgentMcpServerOptions extends ManagedAgentMcpDelegateOptions, ManagedAgentMcpPresentationOptions {}
@@ -69,6 +86,14 @@ function createManagedAgentMcpServerWithController(
     name: options.name ?? 'boring-managed-agent',
     version: options.version ?? '0.0.0',
   })
+
+  if (options.shareEntryStore && options.resolveShareSessionCtx && options.resolveShareWorkspace) {
+    registerShareEntryResources(server, {
+      store: options.shareEntryStore,
+      resolveSessionCtx: options.resolveShareSessionCtx,
+      resolveWorkspace: options.resolveShareWorkspace,
+    })
+  }
   const registerTool = server.registerTool.bind(server) as ManagedAgentRegisterTool
   const delegateTaskInputSchema = createDelegateTaskInputSchema(options.maxBriefChars ?? DEFAULT_MAX_BRIEF_SCHEMA_CHARS)
 

--- a/packages/agent/src/server/mcp/shareEntryResources.ts
+++ b/packages/agent/src/server/mcp/shareEntryResources.ts
@@ -1,0 +1,244 @@
+// AR1-004: minimal MCP server resource support for Lane W share entries.
+//
+// This is the first `listResources`/`readResource` surface in this package
+// (`managedAgentMcpServer.ts` otherwise only registers tools) and it is
+// mounted on the SAME managed-agent MCP server/transport process — no
+// second MCP runtime owner is introduced (AR1-001-SPEC.md §3.4, bead
+// wt-391-forward-eq8). Resources exposed = share entries for the
+// AUTHENTICATED workspace only, reusing the same session/workspace
+// resolution seam the tools already use; there is no separate auth
+// mechanism here.
+//
+// Outcome discipline mirrors the AR1-003 deep-link route: `readResource`
+// NEVER throws a protocol-level error for the three Lane W outcomes
+// (ok / not_found / tombstoned) — all three are returned as an in-band
+// `ReadResourceResult` so a stable, path-free, non-member-indistinguishable
+// outcome is always observable by the caller. Only genuinely exceptional
+// conditions (oversize target, non-UTF-8 content, a read race) surface as a
+// thrown `ManagedAgentMcpError`, reusing the existing generic
+// `MCP_AGENT_ARTIFACT_*` codes — Lane W does not invent a third AR1 code
+// (spec §3.3: "Access denial is the existing generic membership denial, not
+// an AR1 code").
+
+import type { McpServer, ReadResourceTemplateCallback } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { ListResourcesResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js'
+
+import { sha256Bytes } from '../../shared/digest'
+import { ErrorCode } from '../../shared/error-codes'
+import { resolveShareEntry, type ShareEntryStore, type ShareEntryV1 } from '../../shared/share-entry'
+import type { SessionCtx } from '../../shared/session'
+import type { Stat, Workspace } from '../../shared/workspace'
+import { ManagedAgentMcpError, type ManagedAgentDelegateRequestContext } from './managedAgentDelegate'
+
+/** Byte cap for a single share resource read, mirroring the delegate-artifact delivery cap. */
+const MAX_SHARE_READ_BYTES = 256 * 1024
+
+const SHARE_RESOURCE_URI_TEMPLATE = 'share:///{id}'
+
+const strictUtf8Decoder = new TextDecoder('utf-8', { fatal: true })
+
+export interface ShareEntryMcpResourceOptions {
+  /** Lane W (AR1-002) opaque share-entry store — the single source of truth for entries. */
+  store: ShareEntryStore
+  /** Resolves the authenticated SessionCtx for a resource request (list or read). */
+  resolveSessionCtx(request: ManagedAgentDelegateRequestContext): SessionCtx | Promise<SessionCtx>
+  /** Resolves the authorized Workspace to read share targets from, for a given SessionCtx. */
+  resolveWorkspace(ctx: SessionCtx): Workspace | Promise<Workspace>
+}
+
+interface McpResourceExtra {
+  sessionId?: string
+  authInfo?: unknown
+}
+
+/** Builds the opaque share resource URI for a given share-entry id. */
+export function shareResourceUri(id: string): string {
+  return `share:///${encodeURIComponent(id)}`
+}
+
+/**
+ * Registers `listResources`/`readResource` for Lane W share entries on an
+ * already-constructed managed-agent `McpServer`. A no-op call site (host
+ * omits `shareEntryStore`) leaves Lane W unmounted — see
+ * `managedAgentMcpServer.ts`'s optional wiring.
+ */
+export function registerShareEntryResources(server: McpServer, options: ShareEntryMcpResourceOptions): void {
+  const template = new ResourceTemplate(SHARE_RESOURCE_URI_TEMPLATE, {
+    list: async (extra) => listShareResources(options, requestContextFromResourceExtra(extra)),
+  })
+
+  const readCallback: ReadResourceTemplateCallback = async (uri, variables, extra) =>
+    readShareResource(options, variables.id, requestContextFromResourceExtra(extra))
+
+  server.registerResource(
+    'share',
+    template,
+    {
+      title: 'Lane W share entry',
+      description: 'Same-workspace shareable file reference (AR1). Resolves live, never a blob snapshot.',
+    },
+    readCallback,
+  )
+}
+
+function requestContextFromResourceExtra(extra: McpResourceExtra | undefined): ManagedAgentDelegateRequestContext {
+  return {
+    sessionId: extra?.sessionId,
+    authInfo: extra?.authInfo,
+  }
+}
+
+async function listShareResources(
+  options: ShareEntryMcpResourceOptions,
+  request: ManagedAgentDelegateRequestContext,
+): Promise<ListResourcesResult> {
+  const ctx = await options.resolveSessionCtx(request)
+  if (!ctx.workspaceId) return { resources: [] }
+  const entries = await options.store.list(ctx.workspaceId)
+  return {
+    resources: entries.map((entry) => ({
+      uri: shareResourceUri(entry.id),
+      name: entry.id,
+    })),
+  }
+}
+
+async function readShareResource(
+  options: ShareEntryMcpResourceOptions,
+  rawId: string | string[] | undefined,
+  request: ManagedAgentDelegateRequestContext,
+): Promise<ReadResourceResult> {
+  const id = typeof rawId === 'string' ? rawId : Array.isArray(rawId) ? rawId[0] : undefined
+  if (!id) return notFoundResult(shareResourceUri(''))
+
+  const uri = shareResourceUri(id)
+  const ctx = await options.resolveSessionCtx(request)
+  if (!ctx.workspaceId) return notFoundResult(uri)
+
+  // Membership check happens BEFORE any workspace stat/read: a non-member
+  // request must be indistinguishable from a nonexistent id (no existence
+  // oracle across workspaces), and must never stat a path string against
+  // the wrong workspace.
+  const entry = await options.store.get(id)
+  if (!entry || entry.workspaceId !== ctx.workspaceId) {
+    return notFoundResult(uri)
+  }
+
+  const workspace = await options.resolveWorkspace(ctx)
+  const resolution = await resolveShareEntry(options.store, id, workspace)
+  if (resolution.status === 'not_found') return notFoundResult(uri)
+  if (resolution.status === 'tombstoned') {
+    return tombstoneResult(uri, resolution.tombstone)
+  }
+  return readShareEntryContents(uri, resolution.entry, workspace)
+}
+
+function notFoundResult(uri: string): ReadResourceResult {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: 'application/json',
+        text: JSON.stringify({
+          status: 'not_found',
+          error: { code: ErrorCode.enum.AR1_SHARE_NOT_FOUND, message: 'share not found' },
+        }),
+      },
+    ],
+  }
+}
+
+function tombstoneResult(uri: string, tombstone: { id: string; workspaceId: string; provenance: ShareEntryV1['provenance'] }): ReadResourceResult {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: 'application/json',
+        text: JSON.stringify({
+          status: 'tombstoned',
+          error: { code: ErrorCode.enum.AR1_SHARE_TOMBSTONED, message: 'share target is gone' },
+          id: tombstone.id,
+          workspaceId: tombstone.workspaceId,
+          provenance: tombstone.provenance,
+        }),
+      },
+    ],
+  }
+}
+
+async function readShareEntryContents(uri: string, entry: ShareEntryV1, workspace: Workspace): Promise<ReadResourceResult> {
+  const before = await statShareTarget(workspace, entry.path)
+  assertShareTargetStat(before)
+  assertWithinCap(before.size)
+  if (!workspace.readBinaryFile) {
+    throw new ManagedAgentMcpError(
+      ErrorCode.enum.MCP_AGENT_ARTIFACT_UNAVAILABLE,
+      'share target bytes are unavailable through the authorized workspace',
+    )
+  }
+  const bytes = await workspace.readBinaryFile(entry.path)
+  const after = await statShareTarget(workspace, entry.path)
+  assertShareTargetStat(after)
+  if (!sameStat(before, after) || bytes.byteLength !== before.size) {
+    throw new ManagedAgentMcpError(ErrorCode.enum.MCP_AGENT_ARTIFACT_UNAVAILABLE, 'share target changed while it was being read')
+  }
+  assertWithinCap(bytes.byteLength)
+
+  const text = decodeUtf8(bytes)
+  const digest = await sha256Bytes(bytes)
+
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: 'text/plain',
+        text,
+        _meta: {
+          status: 'ok',
+          digest,
+          byteSize: bytes.byteLength,
+          provenance: entry.provenance,
+        },
+      },
+    ],
+  }
+}
+
+async function statShareTarget(workspace: Workspace, path: string): Promise<Stat> {
+  try {
+    return await workspace.stat(path)
+  } catch {
+    throw new ManagedAgentMcpError(ErrorCode.enum.MCP_AGENT_ARTIFACT_UNAVAILABLE, 'share target is unavailable')
+  }
+}
+
+function assertShareTargetStat(stat: Stat): void {
+  if (stat.kind !== 'file') {
+    throw new ManagedAgentMcpError(ErrorCode.enum.MCP_AGENT_ARTIFACT_INVALID, 'share target must be a file')
+  }
+  if (!Number.isFinite(stat.size) || stat.size < 0) {
+    throw new ManagedAgentMcpError(ErrorCode.enum.MCP_AGENT_ARTIFACT_INVALID, 'share target size is invalid')
+  }
+}
+
+function assertWithinCap(byteSize: number): void {
+  if (byteSize > MAX_SHARE_READ_BYTES) {
+    throw new ManagedAgentMcpError(
+      ErrorCode.enum.MCP_AGENT_ARTIFACT_TOO_LARGE,
+      `share target must be ${MAX_SHARE_READ_BYTES} bytes or fewer`,
+    )
+  }
+}
+
+function sameStat(left: Stat, right: Stat): boolean {
+  return left.kind === right.kind && left.size === right.size && left.mtimeMs === right.mtimeMs
+}
+
+function decodeUtf8(bytes: Uint8Array): string {
+  try {
+    return strictUtf8Decoder.decode(bytes)
+  } catch {
+    throw new ManagedAgentMcpError(ErrorCode.enum.MCP_AGENT_ARTIFACT_INVALID, 'share target must be well-formed UTF-8')
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the first `listResources`/`readResource` surface on the existing managed-agent MCP server/transport (`packages/agent/src/server/mcp/managedAgentMcpServer.ts`) — no second MCP runtime owner, per the bead's explicit constraint.
- New module `packages/agent/src/server/mcp/shareEntryResources.ts` registers a `share:///{id}` resource template backed by the merged AR1-002 `ShareEntryV1` store + `resolveShareEntry` seam (`packages/agent/src/shared/share-entry.ts`).
- Resources exposed = share entries for the AUTHENTICATED workspace only (`store.list(ctx.workspaceId)` for listing); `readResource` performs the membership check (`entry.workspaceId === ctx.workspaceId`) BEFORE ever calling `resolveShareEntry`/`workspace.stat`, so a non-member request never stats a path against the wrong workspace and is byte-for-byte indistinguishable from a nonexistent id.
- `readResource` never throws for the three Lane W outcomes (`ok`/`not_found`/`tombstoned`) — always an in-band `ReadResourceResult`, mirroring the AR1-003 deep-link route's discipline (path-free tombstone/not-found bodies, no existence oracle).
- Graduates `AR1_SHARE_NOT_FOUND`/`AR1_SHARE_TOMBSTONED` from `share-entry.ts`'s local enum into the public `ErrorCode` registry (`error-codes.ts` + `docs/ERROR_CODES.md`), since this is the first runtime surface to expose them over an API boundary (mirrors the `MCP_AGENT_ARTIFACT_*` graduation precedent).
- Oversize/read-race/non-UTF-8 rejections reuse the existing generic `MCP_AGENT_ARTIFACT_*` codes rather than inventing a third AR1 code (spec §3.3: "Access denial is the existing generic membership denial, not an AR1 code").
- Wiring is fully optional (`shareEntryStore`/`resolveShareSessionCtx`/`resolveShareWorkspace` on `ManagedAgentMcpServerOptions`) — a host that omits any of the three leaves Lane W unmounted (no widening).

## Base branch choice
Based on `main` — AR1-003 (`/a` deep-link route, PR #741) is not yet merged, but this bead only needs the AR1-002 `ShareEntryV1` store/`resolveShareEntry` seam, which is already on `main` (PR #735, merged). No stacking needed.

## Test plan
- [x] `packages/agent/src/server/mcp/__tests__/shareEntryResources.test.ts` (new, 6 tests, real MCP `Client`/`StreamableHTTPClientTransport` over HTTP, mirroring the existing `managedAgentDelegate.test.ts` harness): list scoped to workspace, read ok with exact bytes + digest, tombstone rendering (path-free), not-found rendering, non-member workspace's share indistinguishable from not-found (and invisible from list), oversize rejection.
- [x] `error-codes.test.ts` updated for the two graduated codes; docs/enum parity test passes.
- [x] `pnpm --filter @hachej/boring-agent run lint:invariants` — OK.
- [x] `pnpm --filter @hachej/boring-agent exec vitest run` — 1767 passed, 0 failed.
- [x] `pnpm --filter @hachej/boring-agent run typecheck` — no new errors (pre-existing front-end `@hachej/boring-ui-kit` resolution gaps only, confirmed present with/without this diff).
- [x] `pnpm --filter @hachej/boring-agent run build` — OK (after building the `@hachej/boring-ui-kit` dependency).

Ref: bead `wt-391-forward-eq8` (AR1-004), spec `docs/issues/391/runtime-refactor/work/AR1-shareable-artifacts/AR1-001-SPEC.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)