### PR TITLE
fix(governance): release per-run hold on user-initiated stop instead of charging it

### DIFF
--- a/packages/agent/src/server/pi-chat/__tests__/metering.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/metering.test.ts
@@ -276,6 +276,28 @@ describe('pi chat metering', () => {
     ])
   })
 
+  it('releases the hold on a voluntary /stop even when pi reports the aborted run as a no-usage success', async () => {
+    const adapter = createAdapter()
+    const { sink, calls } = createSink()
+    const { service } = createService(adapter, sink)
+
+    await service.prompt(ctx, 's1', { message: 'hi', clientNonce: 'nonce-stop' })
+    adapter.emit({ type: 'agent_start', turnId: 'turn-1' } as unknown as AgentSessionEvent)
+    // The user clicks /stop: the service marks the active run stopped before the
+    // abort. The fake adapter's abort is a no-op, so pi's aborted agent-end is
+    // emitted next — here mis-reported as a plain no-usage success (status 'ok').
+    await service.stop(ctx, 's1', {})
+    adapter.emit(agentEnd('stop'))
+    await service.flushMetering()
+
+    // No paid work → the worst-case hold is RELEASED, not fallback-charged.
+    expect(calls.usage).toEqual([])
+    expect(calls.settled).toEqual([])
+    expect(calls.released).toEqual([
+      expect.objectContaining({ runId: 'pi-run:s1:prompt:nonce-stop', reason: 'cancelled' }),
+    ])
+  })
+
   it('does NOT settle for free when usage arrives with all-zero tokens', async () => {
     const adapter = createAdapter()
     const { sink, calls } = createSink()
@@ -1185,6 +1207,79 @@ describe('PiChatMeteringCoordinator promoted follow-up failure', () => {
     expect(isNewRun).toBe('cancelled')
     expect(calls.released).toEqual([
       expect.objectContaining({ runId: 'pi-run:s1:prompt:n', reason: 'cancelled' }),
+    ])
+  })
+
+  // A voluntary user stop (the /stop button) marks the active run stopped before
+  // the abort. Even if pi reports the aborted run as a no-usage SUCCESS (agent-end
+  // status 'ok'), the hold must be RELEASED, never charged via the fallback.
+  it('releases (not fallback-charges) the hold when a user stop yields no usage, even if pi reports status ok', async () => {
+    const { sink, calls } = coordinatorSink()
+    const coordinator = new PiChatMeteringCoordinator(sink, () => {})
+    await coordinator.reservePrompt({ ...scope, clientNonce: 'n', message: 'a' })
+    coordinator.observe('s1', { type: 'agent_start', turnId: 't' }, [
+      { type: 'agent-start', seq: 1, turnId: 't' } as never,
+    ])
+    // User clicks stop: mark the active run before the abort lands.
+    coordinator.markActiveStopped('s1')
+    // pi mis-reports the aborted run as a plain no-usage completion.
+    coordinator.observe('s1', { type: 'agent_end', messages: [{ role: 'assistant', stopReason: 'stop' }] }, [
+      { type: 'agent-end', seq: 2, turnId: 't', status: 'ok' } as never,
+    ])
+    await coordinator.flush()
+
+    expect(calls.settled).toEqual([])
+    expect(calls.released).toEqual([
+      expect.objectContaining({ runId: 'pi-run:s1:prompt:n', reason: 'cancelled' }),
+    ])
+  })
+
+  // A stop AFTER real usage settles only the actual recorded usage; the unused
+  // remainder of the hold is released (settleRun releases the governance hold).
+  it('settles actual usage and does not fallback-charge when a user stop follows real usage', async () => {
+    const { sink, calls } = coordinatorSink()
+    const coordinator = new PiChatMeteringCoordinator(sink, () => {})
+    await coordinator.reservePrompt({ ...scope, clientNonce: 'n', message: 'a' })
+    coordinator.observe('s1', { type: 'agent_start', turnId: 't' }, [
+      { type: 'agent-start', seq: 1, turnId: 't' } as never,
+    ])
+    coordinator.observe('s1', { type: 'message_end', message: { id: 'a1', role: 'assistant', usage: USAGE } }, [])
+    coordinator.markActiveStopped('s1')
+    coordinator.observe('s1', { type: 'agent_end', messages: [{ role: 'assistant', stopReason: 'stop' }] }, [
+      { type: 'agent-end', seq: 2, turnId: 't', status: 'ok' } as never,
+    ])
+    await coordinator.flush()
+
+    expect(calls.usage).toHaveLength(1)
+    expect(calls.settled).toEqual([expect.objectContaining({ runId: 'pi-run:s1:prompt:n', status: 'ok' })])
+    expect(calls.released).toEqual([])
+  })
+
+  // A genuine usage-write failure keeps the conservative full-hold charge even if
+  // the run was also user-stopped: real tokens were spent but no ledger row persisted.
+  it('still charges usage-write-failed on a stopped run whose usage write failed', async () => {
+    const calls: SinkCalls = { reserved: [], usage: [], settled: [], released: [] }
+    const sink: AgentMeteringSink = {
+      reserveRun: async (input) => { calls.reserved.push(input); return {} },
+      recordUsage: async (input) => { calls.usage.push(input); throw new Error('ledger write failed') },
+      settleRun: async (input) => { calls.settled.push(input) },
+      releaseRun: async (input) => { calls.released.push(input) },
+    }
+    const coordinator = new PiChatMeteringCoordinator(sink, () => {})
+    await coordinator.reservePrompt({ ...scope, clientNonce: 'n', message: 'a' })
+    coordinator.observe('s1', { type: 'agent_start', turnId: 't' }, [
+      { type: 'agent-start', seq: 1, turnId: 't' } as never,
+    ])
+    coordinator.observe('s1', { type: 'message_end', message: { id: 'a1', role: 'assistant', usage: USAGE } }, [])
+    coordinator.markActiveStopped('s1')
+    coordinator.observe('s1', { type: 'agent_end', messages: [{ role: 'assistant', stopReason: 'stop' }] }, [
+      { type: 'agent-end', seq: 2, turnId: 't', status: 'ok' } as never,
+    ])
+    await coordinator.flush()
+
+    expect(calls.settled).toEqual([])
+    expect(calls.released).toEqual([
+      expect.objectContaining({ runId: 'pi-run:s1:prompt:n', reason: 'usage-write-failed' }),
     ])
   })
 

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -424,7 +424,11 @@ export class HarnessPiChatService implements PiChatSessionService {
     const clearedQueue = this.clearAllFollowUps(adapter, sessionId, sessionKey)
     // The active run settles/releases via the native aborted agent-end; queued
     // and not-yet-started prompt reservations are released here so they don't
-    // hold the user's balance until TTL.
+    // hold the user's balance until TTL. Mark the active run user-stopped BEFORE
+    // the abort so its terminal accounting releases the hold (voluntary cancel is
+    // never charged the fallback), even if pi reports the aborted run as a no-usage
+    // success. Real usage recorded before the stop is still settled.
+    this.metering?.markActiveStopped(sessionKey)
     this.metering?.releaseQueued(sessionKey)
     this.metering?.releasePending(sessionKey)
     await adapter.abort()

--- a/packages/agent/src/server/pi-chat/metering.ts
+++ b/packages/agent/src/server/pi-chat/metering.ts
@@ -161,6 +161,11 @@ interface MeteringRun {
   /** Set when a recordUsage sink call rejected — at least one ledger row for
    * this run is missing, so the run must not falsely settle. */
   usageWriteFailed: boolean
+  /** Set when the user voluntarily stopped this run (the /stop button). A stop
+   * is not paid work: even if pi reports the aborted run as a no-usage success
+   * (agent-end status 'ok'), the hold must be RELEASED, never charged via the
+   * fallback. Real usage recorded before the stop is still settled. */
+  userStopped: boolean
   /** Present on queued follow-up runs; matched against clear/consume selectors. */
   followUp?: FollowUpSelector
   /** Resolves/rejects when the host reservation settles. Awaited by concurrent
@@ -437,6 +442,20 @@ export class PiChatMeteringCoordinator {
   }
 
   /**
+   * Mark the currently-active run as voluntarily user-stopped (the /stop button),
+   * so its terminal accounting RELEASES the hold instead of charging the fallback.
+   * Must be called before the abort so the flag is set when the native aborted
+   * agent-end is observed. Runs with real usage recorded before the stop still
+   * settle that usage; only the unused remainder of the hold is released. No-op if
+   * there is no active run (e.g. the stop landed before agent-start — releasePending
+   * handles that case).
+   */
+  markActiveStopped(sessionId: string): void {
+    const active = this.sessions.get(sessionId)?.active
+    if (active && !active.terminal) active.userStopped = true
+  }
+
+  /**
    * Release prompt runs reserved but not yet bound to an agent-start —
    * e.g. a stop/interrupt landing in the window between acceptance and the
    * native agent_start. Without this they would sit `active` in the store
@@ -685,6 +704,7 @@ export class PiChatMeteringCoordinator {
       recordedMessageIds: new Set(),
       lastIdlessUsageKey: undefined,
       usageWriteFailed: false,
+      userStopped: false,
       reservation: Promise.resolve(),
       terminal: false,
       ops: Promise.resolve(),
@@ -755,7 +775,11 @@ export class PiChatMeteringCoordinator {
       // over-charge a failed run that consumed nothing. (Residual: a provider that
       // billed for a failed call whose usage Pi never reported at all goes free — a
       // narrow under-charge, the symmetric cost of not over-charging config failures.)
-      const didPaidWork = status === 'ok'
+      // A VOLUNTARY user stop is never charged the fallback hold: the user cancelled
+      // before any billable usage, so the worst-case hold must be released, not billed.
+      // This holds even if pi reports the aborted run as a no-usage success (status
+      // 'ok') instead of 'aborted' — the explicit stop signal is authoritative.
+      const didPaidWork = status === 'ok' && !run.userStopped
       if (didPaidWork) {
         return this.sink.releaseRun({ ...run.scope, reservationId: run.reservationId, reason: 'fallback-hold-charge' })
       }


### PR DESCRIPTION
## Symptom (field-diagnosed, Constellation tenant)

When a user clicks **STOP** mid-generation (a voluntary `/stop` of an agent run), the metering fallback charged the **full per-run hold** (`perRunHoldEur`) against the user's budget instead of releasing it. A single Stop wasted a whole hold — this over-charged a €2-capped user after one Stop.

## Mechanism

A `/stop` aborts the active run, but pi can report the aborted run as a **no-usage success** (`agent-end` status `ok`, no billable usage). The metering coordinator (`PiChatMeteringCoordinator.finishRun`) then took the `didPaidWork = status === 'ok'` branch and released with reason `fallback-hold-charge`. Both the governance metering sink (`releaseConsumesBudget` → reservation `settled` → full hold counted as used) **and** the credits delegate (`chargeFallbackUsage`) treat that reason as a full-hold charge.

## Fix (root cause, at the coordinator)

A voluntary `/stop` now marks the active run **user-stopped** before the abort (`markActiveStopped`, wired from `stopBeforeDispose`). In `finishRun`, `didPaidWork` is now `status === 'ok' && !run.userStopped`, so a stopped run with no usage releases with reason `cancelled` (hold released) instead of `fallback-hold-charge` — even when pi mislabels the aborted run as an `ok` completion.

- Real usage recorded before the stop is still **settled** against the ledger (only the unused remainder of the hold is released).
- A genuine **`usage-write-failed`** still charges the conservative full hold (highest precedence, unchanged) — even on a stopped run, because real tokens were spent but no ledger row persisted.
- The **successful-but-no-usage** fallback charge is preserved for non-stopped runs.
- Fixing the coordinator corrects **both** the governance hold and the credits delegate at once; no change to budgets/policy or the store's status transitions.

## Tests

Coordinator (`packages/agent/.../pi-chat/__tests__/metering.test.ts`):
- (a) user-stop, no usage, pi reports `ok` → hold released (`cancelled`), not charged.
- (b) user-stop after real usage → actual usage settled, no fallback charge.
- (c) user-stop whose usage write failed → still `usage-write-failed` full-hold charge.
- (d) normal completion → settles actual usage (existing, unchanged).
- Service-level: `service.stop(...)` wiring → release reason `cancelled`.

## Gates

- Typecheck: governance + core + agent — pass
- Agent tests: 1950 passed, no type errors
- Governance tests: 65 passed
- Core tests: pass except pre-existing DB-integration failures in `migrate.test.ts` (require a live Postgres; unrelated to this change, which touches no schema/migration)
- Build + check-invariants — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)