### PR TITLE
feat(d1): attest migration compatibility

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/approvedHostArtifactEvidence.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/approvedHostArtifactEvidence.test.ts
@@ -22,6 +22,7 @@ const release = () => ({
   schemaVersion: 1,
   domain: 'boring-d1-approved-host-release:v1',
   hostAppImageDigest: CORE_DIGEST,
+  previousCoreImageRef: `ghcr.io/hachej/boring-ui@${digest('9')}`,
   coreCommand: { entrypoint: ['/usr/local/bin/web-entrypoint'], cmd: ['node', 'apps/full-app/dist/server/main.js'] },
   migrationProcess: { entrypoint: ['node'], cmd: ['apps/full-app/dist/server/migrate.js'], user: '10001:10001',
     readonlyRootfs: true, privileged: false, noNewPrivileges: true, addedCapabilities: [] },
@@ -32,7 +33,7 @@ const release = () => ({
   selectorInventoryRevision: revision('a'),
   executionPolicyRevision: revision('b'),
   databaseSchemaCompatibility: { migrationSetDigest: digest('e'), currentEpoch: 2,
-    readableEpochRange: { min: 1, max: 2 }, readableByPreviousRelease: true },
+    readableEpochRange: { min: 1, max: 2 }, readableByPreviousRelease: true, rehearsalEvidenceDigest: digest('8') },
 })
 
 const coreImage = () => [{

--- a/apps/full-app/src/server/deployment/__tests__/approvedHostRelease.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/approvedHostRelease.test.ts
@@ -31,6 +31,7 @@ const release = () => ({
   schemaVersion: 1,
   domain: 'boring-d1-approved-host-release:v1',
   hostAppImageDigest: digest('a'),
+  previousCoreImageRef: `ghcr.io/hachej/boring-ui@${digest('f')}`,
   coreCommand: { entrypoint: ['/usr/local/bin/web-entrypoint'], cmd: ['node', 'apps/full-app/dist/server/main.js'] },
   migrationProcess: { entrypoint: ['node'], cmd: ['apps/full-app/dist/server/migrate.js'], user: '10001:10001',
     readonlyRootfs: true, privileged: false, noNewPrivileges: true, addedCapabilities: [] },
@@ -39,7 +40,7 @@ const release = () => ({
   caddyfileDigest: digest('c'), hostSecurityConfigDigest: digest('d'),
   selectorInventoryRevision: revision('a'), executionPolicyRevision: revision('b'),
   databaseSchemaCompatibility: { migrationSetDigest: digest('e'), currentEpoch: 2,
-    readableEpochRange: { min: 1, max: 2 }, readableByPreviousRelease: true },
+    readableEpochRange: { min: 1, max: 2 }, readableByPreviousRelease: true, rehearsalEvidenceDigest: digest('9') },
 })
 const frozen = (value: unknown): boolean => !value || typeof value !== 'object'
   || (Object.isFrozen(value) && Object.values(value).every(frozen))
@@ -60,6 +61,8 @@ describe('approved D1 host release', () => {
     ['schema version', (value: ReturnType<typeof release>) => { value.schemaVersion = 2 }],
     ['domain', (value: ReturnType<typeof release>) => { value.domain = 'other' }],
     ['host digest', (value: ReturnType<typeof release>) => { value.hostAppImageDigest = digest('A') }],
+    ['previous image', (value: ReturnType<typeof release>) => { value.previousCoreImageRef = 'image:latest' }],
+    ['same previous image', (value: ReturnType<typeof release>) => { value.previousCoreImageRef = `other@${digest('a')}` }],
     ['core entrypoint', (value: ReturnType<typeof release>) => { value.coreCommand.entrypoint[0] = '/bin/sh' }],
     ['core command', (value: ReturnType<typeof release>) => { value.coreCommand.cmd[1] = 'other.js' }],
     ['migration entrypoint', (value: ReturnType<typeof release>) => { value.migrationProcess.entrypoint[0] = '/bin/sh' }],
@@ -81,7 +84,14 @@ describe('approved D1 host release', () => {
     ['range minimum', (value: ReturnType<typeof release>) => { value.databaseSchemaCompatibility.readableEpochRange.min = 3 }],
     ['range maximum', (value: ReturnType<typeof release>) => { value.databaseSchemaCompatibility.readableEpochRange.max = 1 }],
     ['previous-release policy', (value: ReturnType<typeof release>) => { value.databaseSchemaCompatibility.readableByPreviousRelease = 1 as never }],
+    ['rehearsal digest', (value: ReturnType<typeof release>) => { value.databaseSchemaCompatibility.rehearsalEvidenceDigest = digest('z') }],
   ])('rejects %s drift', (_label, mutate) => { const value = release(); mutate(value); rejectsRelease(value) })
+
+  it('accepts a first boot only when no previous release is declared', () => {
+    const value = release(); value.previousCoreImageRef = null as never
+    value.databaseSchemaCompatibility.readableByPreviousRelease = false
+    expect(decodeApprovedD1HostReleaseRecord(value).previousCoreImageRef).toBeNull()
+  })
 
   it('rejects extras, hidden keys, symbols, accessors, prototypes, holes, and custom array properties', () => {
     rejectsRelease({ ...release(), extra: true })

--- a/apps/full-app/src/server/deployment/__tests__/approvedHostReleaseCapability.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/approvedHostReleaseCapability.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createAgentAssetDigest } from '@hachej/boring-agent/shared'
 
 import { createD1HostSecurityConfig } from '../hostSecurityConfig.js'
 import { D1_SELECTOR_INVENTORY_REVISION } from '../approvedHostRelease.js'
@@ -21,6 +22,8 @@ vi.mock('../d1CaddyfileAuthority.js', () => ({
 }))
 
 import { approveD1HostRelease, isApprovedD1HostRelease, revalidateApprovedD1HostReleaseDatabase } from '../approvedHostReleaseCapability.js'
+import { approveD1MigrationCompatibility, createD1StoppedMigrationSpec, isD1StoppedMigrationSpec, isVerifiedD1MigrationCompatibility,
+  verifyD1PreviousReleaseInspect, verifyD1StoppedMigrationInspect } from '../migrationCompatibilityEvidence.js'
 
 const CANARY = 'approval-canary-never-leaks'
 const digest = (character: string) => `sha256:${character.repeat(64)}`
@@ -28,8 +31,12 @@ const revision = (character: string) => character.repeat(40)
 const CORE_DIGEST = digest('a')
 const CORE_REF = `ghcr.io/hachej/boring-ui@${CORE_DIGEST}`
 const CORE_ID = digest('f')
+const PREVIOUS_REF = `ghcr.io/hachej/boring-ui@${digest('9')}`
+const PREVIOUS_ID = digest('8')
 const HOST = 'eu-host-1'
 const OWNER = 1000
+const migrationProcess = { entrypoint: ['node'], cmd: ['apps/full-app/dist/server/migrate.js'], user: '10001:10001',
+  readonlyRootfs: true, privileged: false, noNewPrivileges: true, addedCapabilities: [] }
 const CADDY_BYTES = new TextEncoder().encode(
   ':8080 {\n\treverse_proxy core-app:3000 {\n\t\theader_up -Forwarded\n\t\theader_up Host {hostport}\n\t\theader_up X-Forwarded-Host {hostport}\n\t}\n}\n',
 )
@@ -148,29 +155,34 @@ const ledger = (epoch = 1, events?: string[]) =>
     },
   }) as never
 const reservedSql = (epoch: number) => vi.fn(() => Promise.resolve([{ epoch }])) as never
+async function compatibilityIdentity(previousImageId: string | null = PREVIOUS_ID, rehearsal: 'first-boot' | 'cross-version-read-write' = 'cross-version-read-write') {
+  const policyDigest = await createAgentAssetDigest(JSON.stringify({ schemaVersion: 1, domain: 'boring-d1-migration-compatibility:v1',
+    hostId: HOST, imageId: CORE_ID, imageRef: CORE_REF, command: migrationProcess, runtime: 'runsc', network: 'boring-d1_migration-db',
+    databaseSecret: 'approved-host-database-url-file', mounts: ['database-secret:ro'] }))
+  const observation = { schemaVersion: 1 as const, domain: 'boring-d1-migration-compatibility:v1' as const, hostId: HOST,
+    currentImageId: CORE_ID, previousImageId, migrationSetDigest: digest('e'), currentEpoch: 2, policyDigest, rehearsal }
+  return { observation, evidenceDigest: await createAgentAssetDigest(JSON.stringify(observation)) }
+}
+const approved = () => approveD1HostRelease({ hostId: HOST, ownerUid: OWNER, coreImageRef: CORE_REF,
+  runner: async (process) => ({ exitCode: 0, stdout: JSON.stringify(process.args.at(-1) === CORE_REF ? coreImage() : ingressImage()) }),
+  admissionLedger: ledger() })
 let record: Record<string, unknown>
 
 describe('D1 approved host release capability', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     const security = await createD1HostSecurityConfig(rawEnv(), effective())
+    const compatibility = await compatibilityIdentity()
     record = Object.freeze({
       schemaVersion: 1,
       domain: 'boring-d1-approved-host-release:v1',
       hostAppImageDigest: CORE_DIGEST,
+      previousCoreImageRef: PREVIOUS_REF,
       coreCommand: {
         entrypoint: ['/usr/local/bin/web-entrypoint'],
         cmd: ['node', 'apps/full-app/dist/server/main.js'],
       },
-      migrationProcess: {
-        entrypoint: ['node'],
-        cmd: ['apps/full-app/dist/server/migrate.js'],
-        user: '10001:10001',
-        readonlyRootfs: true,
-        privileged: false,
-        noNewPrivileges: true,
-        addedCapabilities: [],
-      },
+      migrationProcess,
       ingressImageDigest: D1_CADDY_IMAGE.split('@')[1],
       ingressCommand: { entrypoint: null, cmd: [...D1_CADDY_COMMAND] },
       caddyfileDigest: D1_CADDYFILE_DIGEST,
@@ -182,6 +194,7 @@ describe('D1 approved host release capability', () => {
         currentEpoch: 2,
         readableEpochRange: { min: 1, max: 2 },
         readableByPreviousRelease: true,
+        rehearsalEvidenceDigest: compatibility.evidenceDigest,
       },
     })
     mocks.release.mockResolvedValue(record)
@@ -303,5 +316,75 @@ describe('D1 approved host release capability', () => {
       })
     }
     expect(runner).not.toHaveBeenCalled()
+  })
+
+  it('binds a stopped least-privilege migration container to approved cross-version rehearsal evidence', async () => {
+    const capability = await approved(); const spec = await createD1StoppedMigrationSpec(capability)
+    expect(isD1StoppedMigrationSpec(spec)).toBe(true)
+    expect(isD1StoppedMigrationSpec(JSON.parse(JSON.stringify(spec)))).toBe(false)
+    expect(JSON.stringify(spec)).not.toContain(`/run/boring/d1/${HOST}`)
+    const inspect = [{ Name: `/${spec.containerName}`, Image: CORE_ID, State: { Status: 'created', Running: false },
+      Config: { Image: CORE_REF, User: '10001:10001', Entrypoint: ['node'], Cmd: ['apps/full-app/dist/server/migrate.js'],
+        Env: coreImage()[0].Config.Env.concat('DATABASE_URL_FILE=/run/boring/d1/host-secrets/database-url') },
+      HostConfig: { ReadonlyRootfs: true, Privileged: false, Runtime: 'runsc', NetworkMode: 'boring-d1_migration-db', PortBindings: {},
+        CapDrop: ['ALL'], CapAdd: [], SecurityOpt: ['no-new-privileges:true'], PidMode: '', IpcMode: 'private', UTSMode: '', UsernsMode: '',
+        Devices: [], DeviceRequests: null },
+      NetworkSettings: { Networks: { 'boring-d1_migration-db': {} }, Ports: { '3000/tcp': null } },
+      Mounts: [{ Type: 'bind', Source: `/run/boring/d1/${HOST}/host-secrets/database-url`,
+        Destination: '/run/boring/d1/host-secrets/database-url', RW: false }] }]
+    expect(() => verifyD1StoppedMigrationInspect(capability, spec, JSON.stringify(inspect))).not.toThrow()
+    const otherApproval = await approved()
+    expect(() => verifyD1StoppedMigrationInspect(otherApproval, spec, JSON.stringify(inspect))).toThrow()
+    const previousInspect = [{ Id: PREVIOUS_ID, RepoDigests: [PREVIOUS_REF], Architecture: 'amd64', Os: 'linux' }]
+    const previous = verifyD1PreviousReleaseInspect(capability, JSON.stringify(previousInspect))
+    const { observation } = await compatibilityIdentity(); const evidence = await approveD1MigrationCompatibility(capability, observation, previous)
+    expect(isVerifiedD1MigrationCompatibility(evidence)).toBe(true)
+    expect(isVerifiedD1MigrationCompatibility(JSON.parse(JSON.stringify(evidence)))).toBe(false)
+    for (const drift of [
+      { ...observation, currentImageId: digest('0') }, { ...observation, policyDigest: digest('0') },
+      { ...observation, rehearsal: 'first-boot' },
+    ]) await expect(approveD1MigrationCompatibility(capability, drift, previous)).rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY,
+      details: { field: 'migrationCompatibility' } })
+    await expect(approveD1MigrationCompatibility(capability, observation, JSON.parse(JSON.stringify(previous)))).rejects.toMatchObject({
+      code: D1HostErrorCode.COLLECTION_NOT_READY, details: { field: 'migrationCompatibility' } })
+    const wrongPrevious = verifyD1PreviousReleaseInspect(capability, JSON.stringify([{ ...previousInspect[0], Id: digest('7') }]))
+    await expect(approveD1MigrationCompatibility(capability, observation, wrongPrevious)).rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY })
+    expect(() => verifyD1PreviousReleaseInspect(capability, JSON.stringify([{ ...previousInspect[0], RepoDigests: [`other@${digest('9')}`] }]))).toThrow(expect.objectContaining({
+      code: D1HostErrorCode.COLLECTION_NOT_READY, details: { field: 'migrationCompatibility' } }))
+    for (const mutate of [
+      (value: any) => { value[0].HostConfig.Privileged = true }, (value: any) => { value[0].Config.User = '0:0' },
+      (value: any) => { value[0].HostConfig.Runtime = 'runc' }, (value: any) => { value[0].Config.Env[0] = 'PATH=/tmp' },
+      (value: any) => { value[0].NetworkSettings.Networks.bridge = {} }, (value: any) => { value[0].HostConfig.PortBindings = { '3000/tcp': [{}] } },
+      (value: any) => { value[0].NetworkSettings.Ports['3000/tcp'] = [{ HostPort: '3000' }] },
+      (value: any) => { value[0].HostConfig.PidMode = 'host' }, (value: any) => { value[0].HostConfig.IpcMode = 'host' },
+      (value: any) => { value[0].HostConfig.UTSMode = 'host' }, (value: any) => { value[0].HostConfig.UsernsMode = 'host' },
+      (value: any) => { value[0].HostConfig.Devices = [{}] }, (value: any) => { value[0].HostConfig.DeviceRequests = [{}] },
+      (value: any) => { value[0].Mounts.push({ Type: 'bind', Source: '/tmp', Destination: '/state', RW: false }) },
+      (value: any) => { value[0].Config.Env.push(`SECRET=${CANARY}`) },
+    ]) {
+      const value = structuredClone(inspect); mutate(value)
+      const failure = (() => { try { verifyD1StoppedMigrationInspect(capability, spec, JSON.stringify(value)) } catch (error) { return error } })()
+      expect(failure).toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY, details: { field: 'migrationCompatibility' } })
+      expect(JSON.stringify(failure)).not.toContain(CANARY)
+    }
+    expect(() => verifyD1StoppedMigrationInspect(capability, JSON.parse(JSON.stringify(spec)), JSON.stringify(inspect))).toThrow()
+    expect(() => verifyD1StoppedMigrationInspect(capability, spec, ' '.repeat(512 * 1024 + 1))).toThrow()
+    expect(() => verifyD1PreviousReleaseInspect(capability, ' '.repeat(512 * 1024 + 1))).toThrow()
+  })
+
+  it('mints first-boot evidence only without a previous release identity', async () => {
+    const crossCapability = await approved(); const previous = verifyD1PreviousReleaseInspect(crossCapability,
+      JSON.stringify([{ Id: PREVIOUS_ID, RepoDigests: [PREVIOUS_REF], Architecture: 'amd64', Os: 'linux' }]))
+    const first = await compatibilityIdentity(null, 'first-boot')
+    record = Object.freeze({ ...record, previousCoreImageRef: null, databaseSchemaCompatibility: {
+      ...(record.databaseSchemaCompatibility as object), readableByPreviousRelease: false, rehearsalEvidenceDigest: first.evidenceDigest,
+    } }); mocks.release.mockResolvedValue(record)
+    const capability = await approved()
+    const evidence = await approveD1MigrationCompatibility(capability, first.observation)
+    expect(isVerifiedD1MigrationCompatibility(evidence)).toBe(true)
+    await expect(approveD1MigrationCompatibility(capability, first.observation, previous)).rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY })
+    await expect(approveD1MigrationCompatibility(capability, { ...first.observation, previousImageId: PREVIOUS_ID })).rejects.toMatchObject({
+      code: D1HostErrorCode.COLLECTION_NOT_READY, details: { field: 'migrationCompatibility' },
+    })
   })
 })

--- a/apps/full-app/src/server/deployment/__tests__/approvedHostReleaseFile.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/approvedHostReleaseFile.test.ts
@@ -27,6 +27,7 @@ const release = () => ({
   schemaVersion: 1,
   domain: 'boring-d1-approved-host-release:v1',
   hostAppImageDigest: digest('a'),
+  previousCoreImageRef: `ghcr.io/hachej/boring-ui@${digest('f')}`,
   coreCommand: { entrypoint: ['/usr/local/bin/web-entrypoint'], cmd: ['node', 'apps/full-app/dist/server/main.js'] },
   migrationProcess: { entrypoint: ['node'], cmd: ['apps/full-app/dist/server/migrate.js'], user: '10001:10001',
     readonlyRootfs: true, privileged: false, noNewPrivileges: true, addedCapabilities: [] },
@@ -37,7 +38,7 @@ const release = () => ({
   selectorInventoryRevision: revision('a'),
   executionPolicyRevision: revision('b'),
   databaseSchemaCompatibility: { migrationSetDigest: digest('e'), currentEpoch: 2,
-    readableEpochRange: { min: 1, max: 2 }, readableByPreviousRelease: true },
+    readableEpochRange: { min: 1, max: 2 }, readableByPreviousRelease: true, rehearsalEvidenceDigest: digest('9') },
 })
 
 async function fixture() {

--- a/apps/full-app/src/server/deployment/approvedHostRelease.ts
+++ b/apps/full-app/src/server/deployment/approvedHostRelease.ts
@@ -8,12 +8,13 @@ const MIGRATION_DOMAIN = 'boring-d1-migration-set:v1' as const
 // Complete reviewed c1-c5 selector closure landed in #713 (squash e45df544).
 export const D1_SELECTOR_INVENTORY_REVISION = 'e45df54400a4f4dd2db561f11c5a9cc38698ed7d'
 const SHA256 = /^sha256:[a-f0-9]{64}$/
+const PINNED_IMAGE = /^(?:[a-z0-9]+(?:[._-][a-z0-9]+)*\/)*[a-z0-9]+(?:[._-][a-z0-9]+)*@sha256:[a-f0-9]{64}$/
 const REVISION = /^[a-f0-9]{40}$/
 const MIGRATION_TAG = /^[a-z0-9][a-z0-9_]{0,127}$/
 const DEPLOYMENT_MIGRATION_SOURCES = ['apps/full-app/src/server/migrate.ts', 'packages/core/src/server/migrations.ts',
   'packages/core/src/server/db/migrate.ts', 'plugins/boring-automation/src/server/migrations.ts'] as const
 
-const RELEASE_KEYS = ['schemaVersion', 'domain', 'hostAppImageDigest', 'coreCommand', 'migrationProcess',
+const RELEASE_KEYS = ['schemaVersion', 'domain', 'hostAppImageDigest', 'previousCoreImageRef', 'coreCommand', 'migrationProcess',
   'ingressImageDigest', 'ingressCommand', 'caddyfileDigest', 'hostSecurityConfigDigest',
   'selectorInventoryRevision', 'executionPolicyRevision', 'databaseSchemaCompatibility'] as const
 const EXPECTED_KEYS = ['hostAppImageDigest', 'ingressImageDigest', 'caddyfileDigest', 'hostSecurityConfigDigest',
@@ -23,6 +24,7 @@ export interface ApprovedD1HostReleaseRecordV1 {
   readonly schemaVersion: 1
   readonly domain: typeof RELEASE_DOMAIN
   readonly hostAppImageDigest: Sha256Digest
+  readonly previousCoreImageRef: string | null
   readonly coreCommand: Readonly<{ entrypoint: readonly ['/usr/local/bin/web-entrypoint']; cmd: readonly ['node', 'apps/full-app/dist/server/main.js'] }>
   readonly migrationProcess: Readonly<{ entrypoint: readonly ['node']; cmd: readonly ['apps/full-app/dist/server/migrate.js']; user: '10001:10001'; readonlyRootfs: true; privileged: false; noNewPrivileges: true; addedCapabilities: readonly [] }>
   readonly ingressImageDigest: Sha256Digest
@@ -31,7 +33,7 @@ export interface ApprovedD1HostReleaseRecordV1 {
   readonly hostSecurityConfigDigest: Sha256Digest
   readonly selectorInventoryRevision: string
   readonly executionPolicyRevision: string
-  readonly databaseSchemaCompatibility: Readonly<{ migrationSetDigest: Sha256Digest; currentEpoch: number; readableEpochRange: Readonly<{ min: number; max: number }>; readableByPreviousRelease: boolean }>
+  readonly databaseSchemaCompatibility: Readonly<{ migrationSetDigest: Sha256Digest; currentEpoch: number; readableEpochRange: Readonly<{ min: number; max: number }>; readableByPreviousRelease: boolean; rehearsalEvidenceDigest: Sha256Digest }>
 }
 
 export interface D1MigrationSetEvidenceV1 {
@@ -112,15 +114,18 @@ function parseRelease(value: unknown): ApprovedD1HostReleaseRecordV1 {
   const core = dataRecord(input.coreCommand, ['entrypoint', 'cmd'])
   const migration = dataRecord(input.migrationProcess, ['entrypoint', 'cmd', 'user', 'readonlyRootfs', 'privileged', 'noNewPrivileges', 'addedCapabilities'])
   const ingress = dataRecord(input.ingressCommand, ['entrypoint', 'cmd'])
-  const compatibility = dataRecord(input.databaseSchemaCompatibility, ['migrationSetDigest', 'currentEpoch', 'readableEpochRange', 'readableByPreviousRelease'])
+  const compatibility = dataRecord(input.databaseSchemaCompatibility, ['migrationSetDigest', 'currentEpoch', 'readableEpochRange', 'readableByPreviousRelease', 'rehearsalEvidenceDigest'])
   const range = dataRecord(compatibility.readableEpochRange, ['min', 'max'])
   if (input.schemaVersion !== 1 || input.domain !== RELEASE_DOMAIN || migration.user !== '10001:10001'
     || migration.readonlyRootfs !== true || migration.privileged !== false || migration.noNewPrivileges !== true
     || ingress.entrypoint !== null || typeof compatibility.readableByPreviousRelease !== 'boolean') throw new Error()
   const currentEpoch = epoch(compatibility.currentEpoch); const min = epoch(range.min); const max = epoch(range.max)
-  if (min > max || max !== currentEpoch) throw new Error()
+  const hostAppImageDigest = digest(input.hostAppImageDigest); const previousCoreImageRef = input.previousCoreImageRef
+  if (min > max || max !== currentEpoch || (previousCoreImageRef !== null && (typeof previousCoreImageRef !== 'string'
+    || !PINNED_IMAGE.test(previousCoreImageRef) || previousCoreImageRef.endsWith(`@${hostAppImageDigest}`)))
+    || (previousCoreImageRef !== null) !== compatibility.readableByPreviousRelease) throw new Error()
   return Object.freeze({
-    schemaVersion: 1, domain: RELEASE_DOMAIN, hostAppImageDigest: digest(input.hostAppImageDigest),
+    schemaVersion: 1, domain: RELEASE_DOMAIN, hostAppImageDigest, previousCoreImageRef,
     coreCommand: Object.freeze({ entrypoint: exactArray(core.entrypoint, ['/usr/local/bin/web-entrypoint']) as ['/usr/local/bin/web-entrypoint'],
       cmd: exactArray(core.cmd, ['node', 'apps/full-app/dist/server/main.js']) as ['node', 'apps/full-app/dist/server/main.js'] }),
     migrationProcess: Object.freeze({ entrypoint: exactArray(migration.entrypoint, ['node']) as ['node'],
@@ -131,7 +136,8 @@ function parseRelease(value: unknown): ApprovedD1HostReleaseRecordV1 {
     caddyfileDigest: digest(input.caddyfileDigest), hostSecurityConfigDigest: digest(input.hostSecurityConfigDigest),
     selectorInventoryRevision: revision(input.selectorInventoryRevision), executionPolicyRevision: revision(input.executionPolicyRevision),
     databaseSchemaCompatibility: Object.freeze({ migrationSetDigest: digest(compatibility.migrationSetDigest), currentEpoch,
-      readableEpochRange: Object.freeze({ min, max }), readableByPreviousRelease: compatibility.readableByPreviousRelease }),
+      readableEpochRange: Object.freeze({ min, max }), readableByPreviousRelease: compatibility.readableByPreviousRelease,
+      rehearsalEvidenceDigest: digest(compatibility.rehearsalEvidenceDigest) }),
   })
 }
 

--- a/apps/full-app/src/server/deployment/approvedHostReleaseCapability.ts
+++ b/apps/full-app/src/server/deployment/approvedHostReleaseCapability.ts
@@ -19,6 +19,7 @@ const approvedCapabilities = new WeakSet<object>()
 
 export interface ApprovedD1HostRelease {
   readonly hostId: string
+  readonly coreImageRef: string
   readonly databaseRef: string
   readonly observedDatabaseEpoch: number
   readonly record: ApprovedD1HostReleaseRecordV1
@@ -166,6 +167,7 @@ export async function approveD1HostRelease(input: D1HostReleaseApprovalInput): P
   if (security.digest !== record.hostSecurityConfigDigest) unavailable('hostSecurityConfig')
   const capability = Object.freeze({
     hostId,
+    coreImageRef,
     databaseRef: input.admissionLedger.databaseRef,
     observedDatabaseEpoch: databaseEpoch,
     record,

--- a/apps/full-app/src/server/deployment/migrationCompatibilityEvidence.ts
+++ b/apps/full-app/src/server/deployment/migrationCompatibilityEvidence.ts
@@ -1,0 +1,125 @@
+import { createHash } from 'node:crypto'
+import { createAgentAssetDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
+import { isApprovedD1HostRelease, type ApprovedD1HostRelease } from './approvedHostReleaseCapability.js'
+import { d1Digest, D1HostError, D1HostErrorCode } from './d1Plan.js'
+import type { D1HostProcess } from './edgeNetworkPreflight.js'
+
+const DOMAIN = 'boring-d1-migration-compatibility:v1' as const
+const DIRECTORY = '/opt/boring/d1'; const NETWORK = 'boring-d1_migration-db'
+const SECRET_TARGET = '/run/boring/d1/host-secrets/database-url'
+const MAX_INSPECT_BYTES = 512 * 1024
+const OBSERVATION_KEYS = ['schemaVersion', 'domain', 'hostId', 'currentImageId', 'previousImageId', 'migrationSetDigest', 'currentEpoch', 'policyDigest', 'rehearsal'] as const
+const verifiedEvidence = new WeakSet<object>()
+const stoppedSpecs = new WeakSet<object>(); const stoppedProcesses = new WeakMap<object, D1HostProcess>()
+const stoppedApprovals = new WeakMap<object, ApprovedD1HostRelease>(); const previousImages = new WeakMap<object, ApprovedD1HostRelease>()
+
+export interface D1StoppedMigrationSpec { readonly containerName: string; readonly policyDigest: Sha256Digest }
+export interface VerifiedD1PreviousReleaseImage { readonly imageRef: string; readonly imageId: Sha256Digest }
+export interface D1MigrationCompatibilityObservationV1 {
+  readonly schemaVersion: 1; readonly domain: typeof DOMAIN; readonly hostId: string
+  readonly currentImageId: Sha256Digest; readonly previousImageId: Sha256Digest | null
+  readonly migrationSetDigest: Sha256Digest; readonly currentEpoch: number; readonly policyDigest: Sha256Digest
+  readonly rehearsal: 'first-boot' | 'cross-version-read-write'
+}
+export interface VerifiedD1MigrationCompatibility extends D1MigrationCompatibilityObservationV1 {}
+
+function unavailable(): never { throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'migrationCompatibility' }) }
+function record(value: unknown): Readonly<Record<string, unknown>> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error()
+  const prototype = Object.getPrototypeOf(value); const keys = Reflect.ownKeys(value)
+  if ((prototype !== Object.prototype && prototype !== null) || keys.some((key) => typeof key !== 'string')
+    || keys.length !== OBSERVATION_KEYS.length || OBSERVATION_KEYS.some((key) => !keys.includes(key))) throw new Error()
+  const output: Record<string, unknown> = {}
+  for (const key of OBSERVATION_KEYS) { const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor?.enumerable || !Object.hasOwn(descriptor, 'value')) throw new Error(); output[key] = descriptor.value }
+  return output
+}
+function array(value: unknown): readonly unknown[] { if (value === null) return []; if (!Array.isArray(value) || Object.getPrototypeOf(value) !== Array.prototype) throw new Error(); return value }
+function plain(value: unknown): Readonly<Record<string, unknown>> { if (!value || typeof value !== 'object' || Array.isArray(value)
+  || (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null)) throw new Error(); return value as Readonly<Record<string, unknown>> }
+function exactStrings(value: unknown, expected: readonly string[]): boolean { const actual = array(value); return actual.length === expected.length && actual.every((entry, index) => entry === expected[index]) }
+function parseInspect(raw: unknown): unknown { if (typeof raw !== 'string' || new TextEncoder().encode(raw).byteLength > MAX_INSPECT_BYTES) throw new Error(); return JSON.parse(raw) }
+function migrationSource(hostId: string): string { return `/run/boring/d1/${hostId}/host-secrets/database-url` }
+function name(approved: ApprovedD1HostRelease): string { return `boring-d1-migration-${createHash('sha256').update(`${approved.hostId}\0${approved.coreImageRef}`).digest('hex').slice(0, 24)}` }
+function policy(approved: ApprovedD1HostRelease): Readonly<Record<string, unknown>> { return Object.freeze({
+  schemaVersion: 1, domain: DOMAIN, hostId: approved.hostId, imageId: approved.artifacts.coreImageId, imageRef: approved.coreImageRef,
+  command: approved.record.migrationProcess, runtime: 'runsc', network: NETWORK, databaseSecret: 'approved-host-database-url-file', mounts: ['database-secret:ro'],
+}) }
+
+export async function createD1StoppedMigrationSpec(approved: ApprovedD1HostRelease): Promise<D1StoppedMigrationSpec> {
+  if (!isApprovedD1HostRelease(approved)) return unavailable()
+  const containerName = name(approved); const source = migrationSource(approved.hostId)
+  const args = ['create', '--name', containerName, '--runtime', 'runsc', '--network', NETWORK, '--read-only', '--user', '10001:10001',
+    '--cap-drop', 'ALL', '--security-opt', 'no-new-privileges:true', '--mount', `type=bind,src=${source},dst=${SECRET_TARGET},readonly`,
+    '--env', `DATABASE_URL_FILE=${SECRET_TARGET}`, '--entrypoint', 'node', approved.coreImageRef, 'apps/full-app/dist/server/migrate.js']
+  const process = Object.freeze({
+    command: 'docker', args: Object.freeze(args), cwd: DIRECTORY, env: Object.freeze({}), shell: false, maxStdoutBytes: 512 * 1024,
+  }); const spec = Object.freeze({ containerName, policyDigest: await createAgentAssetDigest(JSON.stringify(policy(approved))) })
+  stoppedSpecs.add(spec); stoppedProcesses.set(spec, process); stoppedApprovals.set(spec, approved); return spec
+}
+
+export function isD1StoppedMigrationSpec(value: unknown): value is D1StoppedMigrationSpec { return typeof value === 'object' && value !== null && stoppedSpecs.has(value) }
+function expectedEnvironment(approved: ApprovedD1HostRelease): readonly string[] { const defaults = approved.artifacts.imageDefaults; return [
+  `PATH=${defaults.path}`, `NODE_VERSION=${defaults.nodeVersion}`, `YARN_VERSION=${defaults.yarnVersion}`, 'NODE_ENV=production',
+  'BORING_AGENT_MODE=vercel-sandbox', 'BORING_AGENT_WORKSPACE_ROOT=/data/workspaces', 'BORING_AGENT_SESSION_ROOT=/data/pi-sessions',
+  `DATABASE_URL_FILE=${SECRET_TARGET}`,
+] }
+
+export function verifyD1StoppedMigrationInspect(approved: ApprovedD1HostRelease, spec: D1StoppedMigrationSpec, raw: string): void {
+  try {
+    const parsed: unknown = parseInspect(raw)
+    if (!isApprovedD1HostRelease(approved) || !isD1StoppedMigrationSpec(spec) || !stoppedProcesses.has(spec)
+      || stoppedApprovals.get(spec) !== approved || !Array.isArray(parsed) || parsed.length !== 1) throw new Error()
+    const value = parsed[0] as Record<string, unknown>; const config = value.Config as Record<string, unknown>
+    const host = value.HostConfig as Record<string, unknown>; const state = value.State as Record<string, unknown>; const mounts = array(value.Mounts); const mount = mounts[0] as Record<string, unknown>
+    const network = plain(value.NetworkSettings); const networks = plain(network.Networks); const ports = plain(network.Ports)
+    const bindings = host.PortBindings === null ? {} : plain(host.PortBindings)
+    if (value.Name !== `/${spec.containerName}` || value.Image !== approved.artifacts.coreImageId || state.Status !== 'created' || state.Running !== false
+      || config.Image !== approved.coreImageRef || config.User !== '10001:10001' || !exactStrings(config.Entrypoint, ['node'])
+      || !exactStrings(config.Cmd, ['apps/full-app/dist/server/migrate.js']) || !exactStrings(config.Env, expectedEnvironment(approved))
+      || host.ReadonlyRootfs !== true || host.Privileged !== false || host.Runtime !== 'runsc' || host.NetworkMode !== NETWORK || !exactStrings(host.CapDrop, ['ALL'])
+      || !exactStrings(host.CapAdd, []) || !exactStrings(host.SecurityOpt, ['no-new-privileges:true']) || host.PidMode !== '' || host.IpcMode !== 'private'
+      || host.UTSMode !== '' || host.UsernsMode !== '' || array(host.Devices).length !== 0 || array(host.DeviceRequests).length !== 0 || mounts.length !== 1
+      || Object.keys(networks).length !== 1 || !Object.hasOwn(networks, NETWORK) || Object.keys(bindings).length !== 0
+      || Object.values(ports).some((port) => port !== null) || mount.Type !== 'bind' || mount.Source !== migrationSource(approved.hostId)
+      || mount.Destination !== SECRET_TARGET || mount.RW !== false) throw new Error()
+  } catch { return unavailable() }
+}
+
+export function verifyD1PreviousReleaseInspect(approved: ApprovedD1HostRelease, raw: string): VerifiedD1PreviousReleaseImage {
+  try {
+    const parsed = parseInspect(raw); if (!isApprovedD1HostRelease(approved) || approved.record.previousCoreImageRef === null
+      || !Array.isArray(parsed) || parsed.length !== 1) throw new Error()
+    const image = parsed[0] as Record<string, unknown>; const imageId = d1Digest(image.Id, 'previousImageId')
+    if (image.Architecture !== 'amd64' || image.Os !== 'linux' || !array(image.RepoDigests).includes(approved.record.previousCoreImageRef)) throw new Error()
+    const evidence = Object.freeze({ imageRef: approved.record.previousCoreImageRef, imageId }); previousImages.set(evidence, approved); return evidence
+  } catch { return unavailable() }
+}
+
+function observation(approved: ApprovedD1HostRelease, raw: unknown): D1MigrationCompatibilityObservationV1 {
+  const value = record(raw); const previous = value.previousImageId === null ? null : d1Digest(value.previousImageId, 'previousImageId')
+  const expectedRehearsal = approved.record.previousCoreImageRef === null ? 'first-boot' : 'cross-version-read-write'
+  if (value.schemaVersion !== 1 || value.domain !== DOMAIN || value.hostId !== approved.hostId || value.currentImageId !== approved.artifacts.coreImageId
+    || (previous === null) !== (approved.record.previousCoreImageRef === null) || value.migrationSetDigest !== approved.artifacts.migrationSetDigest
+    || value.currentEpoch !== approved.artifacts.currentEpoch || !Number.isSafeInteger(value.currentEpoch) || value.rehearsal !== expectedRehearsal) throw new Error()
+  return Object.freeze({ schemaVersion: 1, domain: DOMAIN, hostId: approved.hostId, currentImageId: approved.artifacts.coreImageId,
+    previousImageId: previous, migrationSetDigest: approved.artifacts.migrationSetDigest, currentEpoch: approved.artifacts.currentEpoch,
+    policyDigest: d1Digest(value.policyDigest, 'policyDigest'), rehearsal: expectedRehearsal })
+}
+export async function digestD1MigrationCompatibilityObservation(approved: ApprovedD1HostRelease, raw: unknown): Promise<Sha256Digest> {
+  try { if (!isApprovedD1HostRelease(approved)) throw new Error(); const parsed = observation(approved, raw)
+    if (parsed.policyDigest !== await createAgentAssetDigest(JSON.stringify(policy(approved)))) throw new Error()
+    return await createAgentAssetDigest(JSON.stringify(parsed)) } catch { return unavailable() }
+}
+export async function approveD1MigrationCompatibility(approved: ApprovedD1HostRelease, raw: unknown, previousImage: unknown = null): Promise<VerifiedD1MigrationCompatibility> {
+  let parsed: D1MigrationCompatibilityObservationV1
+  try { if (!isApprovedD1HostRelease(approved)) throw new Error(); parsed = observation(approved, raw) } catch { return unavailable() }
+  if (approved.record.previousCoreImageRef === null ? previousImage !== null
+    : previousImages.get(previousImage as object) !== approved || (previousImage as VerifiedD1PreviousReleaseImage).imageRef !== approved.record.previousCoreImageRef
+      || (previousImage as VerifiedD1PreviousReleaseImage).imageId !== parsed.previousImageId) unavailable()
+  if (await digestD1MigrationCompatibilityObservation(approved, parsed) !== approved.record.databaseSchemaCompatibility.rehearsalEvidenceDigest) unavailable()
+  const evidence = Object.freeze({ ...parsed }); verifiedEvidence.add(evidence); return evidence
+}
+export function isVerifiedD1MigrationCompatibility(value: unknown): value is VerifiedD1MigrationCompatibility {
+  return typeof value === 'object' && value !== null && verifiedEvidence.has(value)
+}


### PR DESCRIPTION
## Summary
- extend the root-approved host release authority with predecessor and rehearsal identities
- derive an opaque, approval-bound stopped migration spec and verify exact runsc/DB-only/least-privilege Docker inspect state
- bind cross-version compatibility evidence to a bounded Docker inspect of the pinned predecessor image, with a distinct first-boot path

## Bead
- wt-391-forward-3k7.1 (D1-005b1)
- child 1 of 2; live migration start/wait and execution proof remain in wt-391-forward-3k7.2

## Proof
- pnpm run build:packages
- focused Vitest: 4 files, 114 tests passed
- pnpm --filter full-app run typecheck
- git diff --cached --check
- 246 additions / 18 deletions (228 net; below the 390-line stop)

## Review
Structured review findings on inherited Docker env, previous-image identity, spec secrecy/branding, inspect bounds, network/port isolation, approval identity, first-boot behavior, and namespace/device isolation were addressed. The final bounded review was stopped by the orchestrator after emitting no new finding; focused proof and manual inspection are green.

## Deferred evidence
No live EU Docker mutation is performed in this authority/evidence slice. D1-005b2 owns migration start/wait, stopped core/ingress attestation, and live execution evidence.