### PR TITLE
#747 Prove Pi native session identity compatibility

### DIFF
--- a/docs/issues/709/slice-0-compatibility.md
+++ b/docs/issues/709/slice-0-compatibility.md
@@ -1,0 +1,164 @@
+# #709 Slice 0 — Pi SDK native-ID compatibility
+
+Issue: #747  
+Date: 2026-07-14
+
+## Final gate decision
+
+`supported-native-id`
+
+The resolved Pi SDK consumed by `packages/agent` is `@earendil-works/pi-coding-agent@0.80.3` through the `@mariozechner/pi-coding-agent` alias. This version supports the required native-ID path for later slices:
+
+- `SessionManager.create(cwd, sessionDir, { id })` creates a native session handle with a chosen ID before materialization.
+- `SessionManager.getSessionId()` exposes that chosen ID before and after materialization.
+- `SessionManager.appendCustomEntry(customType, data)` queues a SDK-supported operation/prompt correlation marker before materialization and persists it when the transcript materializes.
+- `SessionManager.appendSessionInfo(name)` / `AgentSession.setSessionName(name)` queue/retain a title before native materialization and persist exactly one native `session_info` when the transcript materializes.
+- `SessionManager.open(path, sessionDir, cwdOverride)` recreates a materialized native session with the same ID/title/entries.
+- Standalone `pi --session-dir "$nativeSessionDir" --resume` scans the same explicit session directory and cwd and shows the materialized native title/transcript.
+
+No wrapper/native-identity migration behavior is implemented in this slice.
+
+## Current Boring harness observation
+
+The current Pi harness (`packages/agent/src/server/harness/pi-coding-agent/createHarness.ts`) still creates wrapper-backed Boring sessions for product behavior. It already uses the SDK primitives proven here: `SessionManager.create(runtimeCwd, nativeSessionDir)` for new native handles, `SessionManager.open(savedPiFile, undefined, runtimeCwd)` for existing native files, `sessionManager.getSessionFile()` to learn the materialized native path, and `renameLivePendingPiSession(...)` -> `AgentSession.setSessionName(title)` to queue a title while the native file is still absent. This slice only proves compatibility and aligns the package declaration; it does not switch the product identity model.
+
+## Required checklist
+
+- [x] **Exact package decision:** `@mariozechner/pi-coding-agent` resolves to `@earendil-works/pi-coding-agent@0.80.3` for `@hachej/boring-agent`.
+- [x] **Dependency reconciliation decision:** `packages/agent/package.json`, root override, and `pnpm-lock.yaml` are aligned to `npm:@earendil-works/pi-coding-agent@0.80.3`.
+- [x] **Native ID API decision:** use `SessionManager.create(cwd, sessionDir, { id })`; rejected fallback not needed.
+- [x] **Session ID observation decision:** use `SessionManager.getSessionId()` before materialization and after `SessionManager.open(...)`.
+- [x] **Prompt intent/correlation marker decision:** use `SessionManager.appendCustomEntry("boring.compat.prompt_intent", data)` before first prompt/materialization; it persists through SDK materialization.
+- [x] **Title API decision:** use `SessionManager.appendSessionInfo(name)` directly on `SessionManager`; existing live `AgentSession.setSessionName(name)` delegates to the same native title path.
+- [x] **Fallback decision:** no fallback required for this package pin; primary API is supported.
+- [x] **Real SDK proof:** `piSdkCompatibility.test.ts` imports and exercises the real resolved SDK.
+- [x] **Real CLI proof:** `pi --session-dir "$nativeSessionDir" --resume` was run against the same explicit native session directory/cwd and showed the title.
+- [x] **Final gate decision:** `supported-native-id`.
+
+## Version and dependency evidence
+
+Version declarations after this slice:
+
+- Root `package.json` override: `"@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.80.3"`.
+- `packages/agent/package.json` dependency: `"@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.80.3"`.
+- `pnpm-lock.yaml` importer entries use specifier `npm:@earendil-works/pi-coding-agent@0.80.3` and version `@earendil-works/pi-coding-agent@0.80.3(...)`.
+
+Command:
+
+```bash
+pnpm why @mariozechner/pi-coding-agent --filter @hachej/boring-agent
+```
+
+Observed output:
+
+```text
+@earendil-works/pi-coding-agent@0.80.3
+└── @hachej/boring-agent@0.1.78 (dependencies)
+
+Found 1 version of @earendil-works/pi-coding-agent
+```
+
+Command:
+
+```bash
+pnpm --filter @hachej/boring-agent exec node --input-type=module - <<'NODE'
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+const root = dirname(dirname(new URL(import.meta.resolve('@mariozechner/pi-coding-agent')).pathname));
+const pkg = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+console.log(JSON.stringify({ resolvedEntrypoint: import.meta.resolve('@mariozechner/pi-coding-agent'), packageRoot: root, version: pkg.version }, null, 2));
+NODE
+```
+
+Observed output:
+
+```json
+{
+  "resolvedEntrypoint": "file:///home/ubuntu/projects/boring-ui-v2-747/node_modules/.pnpm/@earendil-works+pi-coding-agent@0.80.3_@modelcontextprotocol+sdk@1.29.0_zod@3.25.76__ws@8.21.0_zod@3.25.76/node_modules/@earendil-works/pi-coding-agent/dist/index.js",
+  "packageRoot": "/home/ubuntu/projects/boring-ui-v2-747/node_modules/.pnpm/@earendil-works+pi-coding-agent@0.80.3_@modelcontextprotocol+sdk@1.29.0_zod@3.25.76__ws@8.21.0_zod@3.25.76/node_modules/@earendil-works/pi-coding-agent",
+  "version": "0.80.3"
+}
+```
+
+## SDK API evidence
+
+Documented installed declarations from `dist/core/session-manager.d.ts` include:
+
+```ts
+export interface NewSessionOptions {
+  id?: string;
+  parentSession?: string;
+}
+
+class SessionManager {
+  static create(cwd: string, sessionDir?: string, options?: NewSessionOptions): SessionManager;
+  static open(path: string, sessionDir?: string, cwdOverride?: string): SessionManager;
+  getSessionId(): string;
+  getSessionFile(): string | undefined;
+  appendCustomEntry(customType: string, data?: unknown): string;
+  appendSessionInfo(name: string): string;
+  getSessionName(): string | undefined;
+}
+```
+
+Executable proof command:
+
+```bash
+pnpm --filter @hachej/boring-agent exec vitest run \
+  src/server/harness/pi-coding-agent/__tests__/piSdkCompatibility.test.ts
+```
+
+Observed result:
+
+```text
+Test Files  1 passed (1)
+Tests       3 passed (3)
+Type Errors no errors
+```
+
+The test proves real SDK behavior:
+
+1. Reads the resolved package version from the installed package root.
+2. Builds Boring's native session directory via `PiSessionStore(runtimeCwd, { sessionRoot, storageCwd: runtimeCwd }).getSessionDir()`.
+3. Calls `SessionManager.create(runtimeCwd, nativeSessionDir, { id: "compat_747_native_id" })` before any file exists and observes the chosen ID with `getSessionId()`.
+4. Recreates a handle with the same chosen ID before materialization.
+5. Queues a prompt/correlation marker with `appendCustomEntry(...)` and a title with `appendSessionInfo(...)` before materialization; `getSessionName()` returns the title while the native file is still absent.
+6. Appends a user message; native file remains absent.
+7. Appends an assistant message; Pi SDK materializes one native JSONL containing the chosen header ID, custom marker, title, user message, and assistant message.
+8. Reopens with `SessionManager.open(...)`; ID/title/custom marker are retained.
+9. Lists with `SessionManager.list(runtimeCwd, nativeSessionDir)`; one session is returned with the chosen ID/title/path and two messages.
+
+## Standalone Pi CLI proof
+
+Proof command shape for later slices:
+
+```bash
+cd "$runtimeCwd"
+pi --offline --session-dir "$nativeSessionDir" --resume
+```
+
+Observed local proof used a temporary `runtimeCwd`, an explicit `nativeSessionDir`, and one SDK-materialized native session:
+
+```json
+{
+  "id": "compat_747_doc_cli",
+  "title": "Boring #747 CLI proof title",
+  "nativeSessionDir": "<temp>/session-root/<cwd-derived-or-explicit-native-dir>",
+  "file": "<nativeSessionDir>/2026-07-14T04-27-09-038Z_compat_747_doc_cli.jsonl"
+}
+```
+
+Sanitized `pi --resume` output included:
+
+```text
+Resume Session (Current Fold ◉ Current Folder | ○ All  Name: All  Sort: Threaded
+› Boring #747 CLI proof title                                              2 now
+```
+
+The executable Vitest proof repeats this with the real `pi` CLI (`dist/cli.js` from the resolved package), waits until the TUI resume scanner prints `Boring #747 native title`, and then terminates the selector. This is intentionally not Boring's filtered list.
+
+## Decision notes for later slices
+
+- Later #709 slices may use native Pi IDs directly for local direct Pi-backed sessions on this package pin.
+- No product wrapper removal, native identity migration, private metadata index, or draft/materialize endpoint was implemented in this slice.
+- If later slices require stronger prompt-intent semantics than a persisted `custom` entry before first prompt submission, they must validate that exact higher-level contract separately; this slice proves the SDK-supported durable marker primitive exists and survives materialization/reopen/list.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -72,7 +72,7 @@
   },
   "dependencies": {
     "@hachej/boring-ui-kit": "workspace:*",
-    "@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.75.5",
+    "@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.80.3",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@radix-ui/react-collapsible": "^1.1.14",
     "@radix-ui/react-dialog": "^1.1.17",

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/piSdkCompatibility.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/piSdkCompatibility.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawn } from "node:child_process";
+import {
+  parseSessionEntries,
+  SessionManager,
+  type CustomEntry,
+  type SessionInfoEntry,
+  type SessionMessageEntry,
+} from "@mariozechner/pi-coding-agent";
+import { PiSessionStore } from "../sessions.js";
+
+const EXPECTED_PI_PACKAGE_VERSION = "0.80.3";
+const COMPAT_TITLE = "Boring #747 native title";
+const FILE_NOT_FOUND_CODE = "ENOENT";
+
+function piPackageRoot(): string {
+  const entrypoint = new URL(import.meta.resolve("@mariozechner/pi-coding-agent"));
+  return dirname(dirname(entrypoint.pathname));
+}
+
+async function readResolvedPiPackageVersion(): Promise<{ packageRoot: string; version: string }> {
+  const packageRoot = piPackageRoot();
+  const packageJson = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf-8")) as { version?: string };
+  return { packageRoot, version: packageJson.version ?? "" };
+}
+
+async function readSessionEntries(path: string) {
+  return parseSessionEntries(await readFile(path, "utf-8"));
+}
+
+async function runPiResumeUntilOutputContains(args: {
+  cwd: string;
+  sessionDir: string;
+  expected: string;
+}): Promise<{ output: string; exitCode: number | null; signal: NodeJS.Signals | null }> {
+  const cliPath = join(piPackageRoot(), "dist", "cli.js");
+  const child = spawn(process.execPath, [cliPath, "--offline", "--session-dir", args.sessionDir, "--resume"], {
+    cwd: args.cwd,
+    env: {
+      ...process.env,
+      PI_OFFLINE: "1",
+      TERM: process.env.TERM || "xterm-256color",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  child.stdin.end();
+
+  let output = "";
+  let settled = false;
+  const maybeStop = () => {
+    if (!settled && output.includes(args.expected)) {
+      settled = true;
+      child.kill("SIGTERM");
+    }
+  };
+  child.stdout.on("data", (chunk) => {
+    output += chunk.toString("utf-8");
+    maybeStop();
+  });
+  child.stderr.on("data", (chunk) => {
+    output += chunk.toString("utf-8");
+    maybeStop();
+  });
+
+  const timeout = setTimeout(() => {
+    if (!settled) {
+      settled = true;
+      child.kill("SIGTERM");
+    }
+  }, 5_000);
+
+  const result = await new Promise<{ exitCode: number | null; signal: NodeJS.Signals | null }>((resolve) => {
+    child.on("close", (exitCode, signal) => resolve({ exitCode, signal }));
+  });
+  clearTimeout(timeout);
+  return { output, ...result };
+}
+
+describe("Pi SDK native session compatibility (#747)", () => {
+  it("uses the resolved Pi SDK version declared for packages/agent", async () => {
+    const resolved = await readResolvedPiPackageVersion();
+    expect(resolved.packageRoot).toContain("@earendil-works+pi-coding-agent@0.80.3");
+    expect(resolved.version).toBe(EXPECTED_PI_PACKAGE_VERSION);
+  });
+
+  it("creates/recreates a chosen native ID, retains pre-materialization metadata, and materializes one native transcript", async () => {
+    const runtimeCwd = await mkdtemp(join(tmpdir(), "boring-pi-runtime-"));
+    const sessionRoot = await mkdtemp(join(tmpdir(), "boring-pi-session-root-"));
+    const store = new PiSessionStore(runtimeCwd, { sessionRoot, storageCwd: runtimeCwd });
+    const nativeSessionDir = store.getSessionDir();
+    const chosenId = "compat_747_native_id";
+
+    try {
+      const firstHandle = SessionManager.create(runtimeCwd, nativeSessionDir, { id: chosenId });
+      expect(firstHandle.getSessionId()).toBe(chosenId);
+      expect(firstHandle.getSessionFile()).toContain(chosenId);
+      await expect(stat(firstHandle.getSessionFile()!)).rejects.toMatchObject({ code: FILE_NOT_FOUND_CODE });
+
+      const sessionManager = SessionManager.create(runtimeCwd, nativeSessionDir, { id: chosenId });
+      expect(sessionManager.getSessionId()).toBe(chosenId);
+      expect(sessionManager.getSessionFile()).toContain(chosenId);
+
+      const markerId = sessionManager.appendCustomEntry("boring.compat.prompt_intent", {
+        issue: 747,
+        operationId: "op-compat-747",
+        idempotencyKey: "idem-compat-747",
+        promptHash: "sha256:compat-747",
+      });
+      const titleId = sessionManager.appendSessionInfo(COMPAT_TITLE);
+      expect(sessionManager.getSessionName()).toBe(COMPAT_TITLE);
+      await expect(stat(sessionManager.getSessionFile()!)).rejects.toMatchObject({ code: FILE_NOT_FOUND_CODE });
+
+      sessionManager.appendMessage({ role: "user", content: [{ type: "text", text: "hello from #747" }] } as any);
+      await expect(stat(sessionManager.getSessionFile()!)).rejects.toMatchObject({ code: FILE_NOT_FOUND_CODE });
+      sessionManager.appendMessage({ role: "assistant", content: [{ type: "text", text: "materialized for #747" }] } as any);
+
+      const sessionFile = sessionManager.getSessionFile()!;
+      const entries = await readSessionEntries(sessionFile);
+      const header = entries.find((entry) => entry.type === "session");
+      const marker = entries.find(
+        (entry): entry is CustomEntry => entry.type === "custom" && entry.id === markerId,
+      );
+      const title = entries.find(
+        (entry): entry is SessionInfoEntry => entry.type === "session_info" && entry.id === titleId,
+      );
+      const messages = entries.filter((entry): entry is SessionMessageEntry => entry.type === "message");
+
+      expect(header).toEqual(expect.objectContaining({ id: chosenId, cwd: runtimeCwd }));
+      expect(marker).toEqual(expect.objectContaining({
+        customType: "boring.compat.prompt_intent",
+        data: expect.objectContaining({ operationId: "op-compat-747" }),
+      }));
+      expect(title).toEqual(expect.objectContaining({ name: COMPAT_TITLE }));
+      expect(messages.map((entry) => entry.message.role)).toEqual(["user", "assistant"]);
+
+      const reopened = SessionManager.open(sessionFile, nativeSessionDir, runtimeCwd);
+      expect(reopened.getSessionId()).toBe(chosenId);
+      expect(reopened.getSessionName()).toBe(COMPAT_TITLE);
+      expect(reopened.getEntries().some((entry) => entry.type === "custom" && entry.id === markerId)).toBe(true);
+
+      const listed = await SessionManager.list(runtimeCwd, nativeSessionDir);
+      expect(listed).toEqual([
+        expect.objectContaining({
+          id: chosenId,
+          name: COMPAT_TITLE,
+          cwd: runtimeCwd,
+          path: sessionFile,
+          messageCount: 2,
+        }),
+      ]);
+    } finally {
+      await rm(runtimeCwd, { recursive: true, force: true });
+      await rm(sessionRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("lets the standalone Pi CLI resume scanner see the same cwd/session directory", async () => {
+    const runtimeCwd = await mkdtemp(join(tmpdir(), "boring-pi-cli-runtime-"));
+    const sessionRoot = await mkdtemp(join(tmpdir(), "boring-pi-cli-session-root-"));
+    const store = new PiSessionStore(runtimeCwd, { sessionRoot, storageCwd: runtimeCwd });
+    const nativeSessionDir = store.getSessionDir();
+    const chosenId = "compat_747_cli_id";
+
+    try {
+      const sessionManager = SessionManager.create(runtimeCwd, nativeSessionDir, { id: chosenId });
+      sessionManager.appendSessionInfo(COMPAT_TITLE);
+      sessionManager.appendMessage({ role: "user", content: [{ type: "text", text: "cli sees this" }] } as any);
+      sessionManager.appendMessage({ role: "assistant", content: [{ type: "text", text: "cli materialized this" }] } as any);
+
+      const listed = await SessionManager.list(runtimeCwd, nativeSessionDir);
+      expect(listed).toEqual([expect.objectContaining({ id: chosenId, name: COMPAT_TITLE })]);
+
+      const result = await runPiResumeUntilOutputContains({
+        cwd: runtimeCwd,
+        sessionDir: nativeSessionDir,
+        expected: COMPAT_TITLE,
+      });
+      expect(result.output).toContain(COMPAT_TITLE);
+    } finally {
+      await rm(runtimeCwd, { recursive: true, force: true });
+      await rm(sessionRoot, { recursive: true, force: true });
+    }
+  }, 10_000);
+});


### PR DESCRIPTION
## Summary
Hard compatibility gate for #709's wrapper-free native Pi session migration.

## Issue / Slice
Closes #747. Stacked on #615.

## What Changed
- Aligns the agent Pi SDK alias to the tested `0.80.3` API.
- Adds a real SDK/CLI compatibility test for chosen native IDs, pre-materialization title/marker behavior, one native transcript, and standalone resume discovery.
- Records the accepted API/version decision in `docs/issues/709/slice-0-compatibility.md`.
- Does not migrate product session behavior yet.

## Proof
- `pnpm --filter @hachej/boring-agent exec vitest run src/server/harness/pi-coding-agent/__tests__/piSdkCompatibility.test.ts`
- `pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-agent typecheck`
- `pnpm --filter @hachej/boring-agent run lint:invariants`

## Review
- Terra: READY.
- Sol: READY.
- Reviewed SHA: `e5310f9ec`.

## Next
Unblocks #748. #615 remains blocked on the wrapper replacement, not on this compatibility gate.
