### PR TITLE
feat(d1): snapshot immutable agent artifacts

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/activeCollectionReader.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/activeCollectionReader.test.ts
@@ -4,7 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
 
-import { createAgentAssetDigest, createAgentDeploymentDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
+import { createAgentAssetDigest, createAgentDefinitionDigest, createAgentDeploymentDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
 import { createResolvedAgentDigest } from '@hachej/boring-agent/server'
 import { describe, expect, it } from 'vitest'
 
@@ -32,7 +32,10 @@ async function desired(): Promise<D1DesiredSnapshotV1> {
     policies: { externalPlugins: false, pluginAuthoring: false },
   })
   const compositionDigest = await createAgentAssetDigest(JSON.stringify(snapshot))
-  const definition = { definitionId: 'definition:insurance', version: '1.0.0', digest: digest('f'), instructionsRef: 'instructions.md' }
+  const instructions = { path: 'instructions.md', content: 'Compare policies.', digest: await createAgentAssetDigest('Compare policies.') }
+  const compiledDefinition = { schemaVersion: 1 as const, definitionId: 'definition:insurance', version: '1.0.0', instructionsRef: instructions.path }
+  const definition = { definitionId: compiledDefinition.definitionId, version: compiledDefinition.version, instructionsRef: compiledDefinition.instructionsRef,
+    digest: await createAgentDefinitionDigest({ definition: compiledDefinition, assets: [instructions] }) }
   const deploymentInput = {
     deploymentId: 'deployment:insurance', version: '2026.07.12', agentId: 'default',
     definition: { definitionId: definition.definitionId, version: definition.version, digest: definition.digest },
@@ -79,7 +82,14 @@ async function fixture(complete = true) {
   const store = createHostRevisionStore({ root, ownerUid: OWNER_UID, appGid: APP_GID })
   const value = await desired()
   const revisionId = await store.reserveRevisionId('host-1')
-  const candidate = await store.writeCandidate('host-1', revisionId, value)
+  const binding = value.plan.bindings[0]!; const definition = value.resolvedBindings[0]!.definition
+  const content = 'Compare policies.'; const asset = { path: definition.instructionsRef, content, digest: await createAgentAssetDigest(content) }
+  const bundleDefinition = { schemaVersion: 1 as const, definitionId: definition.definitionId, version: definition.version, instructionsRef: asset.path }
+  const bundle = { definition: bundleDefinition, definitionDigest: definition.digest, assets: [asset] }
+  const deployment = { deploymentId: binding.defaultDeploymentId, version: '2026.07.12', agentId: 'default',
+    definition: { definitionId: definition.definitionId, version: definition.version, digest: definition.digest } }
+  const candidate = await store.writeCandidate('host-1', revisionId, value, [{ envelope: { schemaVersion: 1, domain: 'boring-d1-agent-artifact:v1', hostId: 'host-1',
+    bindingId: binding.bindingId, bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, bundle, deployment } }])
   let active = { schemaVersion: 1 as const, revisionId, desiredStateDigest: candidate.desiredStateDigest }
   if (complete) {
     await store.writeObservation('host-1', revisionId, await observation(value))

--- a/apps/full-app/src/server/deployment/__tests__/d1AgentArtifactSnapshot.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1AgentArtifactSnapshot.test.ts
@@ -1,0 +1,89 @@
+import { chmod, link, mkdtemp, mkdir, rename, stat, symlink, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { createAgentAssetDigest, createAgentDefinitionDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
+import { describe, expect, it, vi } from 'vitest'
+
+import { loadD1AgentArtifactInputs } from '../d1AgentArtifactSnapshot.js'
+import { D1HostErrorCode, type D1SiteBindingV1 } from '../d1Plan.js'
+
+const digest = (value: string): Sha256Digest => `sha256:${value.repeat(64).slice(0, 64)}`
+const binding: D1SiteBindingV1 = { bindingId: 'insurance', hostname: 'insurance.example.test', workspaceId: 'workspace:insurance',
+  defaultDeploymentId: 'deployment:insurance', bundleRef: 'bundle@1', deploymentRef: 'deployment@1',
+  workspaceAllocationRef: 'workspace-allocation', sessionAllocationRef: 'session-allocation', ownerPrincipalRef: 'owner',
+  landing: { title: 'Insurance', summary: 'Compare policies.' }, environmentRef: 'production', secretRefs: [] }
+const limits = { maxBindings: 2, maxBundleBytes: 64 * 1024, maxTotalBundleBytes: 64 * 1024 }
+
+async function artifact(overrides: Record<string, unknown> = {}) {
+  const content = 'Compare policies.'; const asset = { path: 'instructions.md', content, digest: await createAgentAssetDigest(content) }
+  const definition = { schemaVersion: 1 as const, definitionId: 'definition:insurance', version: '1.0.0', instructionsRef: asset.path }
+  const definitionDigest = await createAgentDefinitionDigest({ definition, assets: [asset] })
+  return { schemaVersion: 1, domain: 'boring-d1-agent-artifact:v1', hostId: 'host-1', bindingId: binding.bindingId,
+    bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, bundle: { definition, definitionDigest, assets: [asset] },
+    deployment: { deploymentId: binding.defaultDeploymentId, version: '1.0.0', agentId: 'default',
+      definition: { definitionId: definition.definitionId, version: definition.version, digest: definitionDigest } }, ...overrides }
+}
+async function inbox(value?: Awaited<ReturnType<typeof artifact>>) {
+  value ??= await artifact()
+  const parent = await mkdtemp(path.join(os.tmpdir(), 'd1-agent-artifacts-')); const root = path.join(parent, 'artifacts')
+  const host = path.join(root, 'host-1'); const slot = path.join(host, binding.bindingId); const file = path.join(slot, 'artifact.json')
+  for (const directory of [root, host, slot]) { await mkdir(directory, { mode: 0o700 }); await chmod(directory, 0o700) }
+  await writeFile(file, JSON.stringify(value), { mode: 0o400 }); await chmod(file, 0o400)
+  return { parent, root, slot, file }
+}
+const load = (root: string, extra: Record<string, unknown> = {}) => loadD1AgentArtifactInputs({
+  hostId: 'host-1', ownerUid: process.geteuid!(), root, limits, inputs: [{ binding, compositionDigest: digest('c') }], ...extra,
+})
+
+describe('D1 immutable agent artifact inbox', () => {
+  it('resolves an opaque-ref binding from its fixed binding-id slot', async () => {
+    const h = await inbox(); const [loaded] = await load(h.root)
+    expect(loaded?.envelope).toMatchObject({ bindingId: 'insurance', bundleRef: 'bundle@1', deploymentRef: 'deployment@1' })
+    expect(loaded?.envelope.bundle.assets).toEqual(expect.arrayContaining([expect.objectContaining({ content: 'Compare policies.' })]))
+  })
+
+  it('canonicalizes artifact assets by path before snapshotting', async () => {
+    const value = await artifact(); const extra = { path: 'a.txt', content: 'a', digest: await createAgentAssetDigest('a') }
+    value.bundle.assets = [value.bundle.assets[0]!, extra].reverse()
+    value.bundle.definitionDigest = await createAgentDefinitionDigest({ definition: value.bundle.definition, assets: value.bundle.assets })
+    value.deployment.definition.digest = value.bundle.definitionDigest
+    const [loaded] = await load((await inbox(value)).root)
+    expect(loaded!.envelope.bundle.assets.map((asset) => asset.path)).toEqual(['a.txt', 'instructions.md'])
+  })
+
+  it('accepts the injected byte cap exactly and rejects cap plus one', async () => {
+    const h = await inbox(); const size = (await stat(h.file)).size
+    await expect(load(h.root, { limits: { ...limits, maxBundleBytes: size, maxTotalBundleBytes: size } })).resolves.toHaveLength(1)
+    await expect(load(h.root, { limits: { ...limits, maxBundleBytes: size - 1 } })).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+  })
+
+  it('rejects filesystem drift, changed reads, oversize input, and tampered identities', async () => {
+    const cases: Array<(h: Awaited<ReturnType<typeof inbox>>) => Promise<Record<string, unknown> | void>> = [
+      async ({ slot }) => { await writeFile(path.join(slot, 'extra'), 'x', { mode: 0o400 }) },
+      async ({ file }) => { await chmod(file, 0o600) },
+      async ({ parent, file }) => { await link(file, path.join(parent, 'hardlink')) },
+      async ({ parent, file }) => { const target = path.join(parent, 'target'); await rename(file, target); await symlink(target, file) },
+      async () => ({ limits: { ...limits, maxBundleBytes: 1 } }),
+      async () => ({ fault: async () => { await chmod(current!.file, 0o600); await writeFile(current!.file, '{}'); await chmod(current!.file, 0o400) } }),
+      async ({ slot }) => ({ fault: async (point: string) => { if (point === 'after-directory-open') await rename(slot, `${slot}-moved`) } }),
+      async ({ file }) => ({ fault: async (point: string) => { if (point === 'after-file-open') await rename(file, `${file}-moved`) } }),
+    ]
+    let current: Awaited<ReturnType<typeof inbox>> | undefined
+    for (const mutate of cases) {
+      current = await inbox(); const extra = await mutate(current)
+      await expect(load(current.root, extra ?? {})).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    }
+    const wrongRef = await inbox(await artifact({ bundleRef: '../bundle' }))
+    await expect(load(wrongRef.root)).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    const tampered = await artifact(); (tampered.bundle.assets[0] as { content: string }).content = 'tampered'
+    await expect(load((await inbox(tampered)).root)).rejects.toMatchObject({ validationCode: 'AGENT_DEFINITION_INVALID' })
+  })
+
+  it('rejects an input tree owned by a different uid than the command policy', async () => {
+    const h = await inbox(); const policyUid = process.geteuid!() + 1
+    const identity = vi.spyOn(process, 'geteuid').mockReturnValue(policyUid)
+    try { await expect(load(h.root, { ownerUid: policyUid })).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED }) }
+    finally { identity.mockRestore() }
+  })
+})

--- a/apps/full-app/src/server/deployment/__tests__/d1Command.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Command.test.ts
@@ -22,6 +22,7 @@ import {
 import { D1ActivePublishError, type D1HostRevisionStore, type D1StoredCandidateV1, type D1StoredCompleteV1 } from '../hostRevisionStore.js'
 import { canonicalizeWorkspaceCompositionSnapshot } from '../workspaceComposition.js'
 import { createD1RuntimeInputsIdentity, type D1RuntimeInputsAttestationV1, type D1RuntimeInputsIdentityV1 } from '../d1RuntimeInputs.js'
+import type { D1LoadedAgentArtifact } from '../d1AgentArtifactSnapshot.js'
 
 const sha = (value: string): Sha256Digest => `sha256:${value.repeat(64).slice(0, 64)}`
 const equal = (left: unknown, right: unknown) => JSON.stringify(left) === JSON.stringify(right)
@@ -91,7 +92,9 @@ class FakeStore implements D1HostRevisionStore {
   materializedVersions: RuntimeVersionSpec = {}
   fault?: 'candidate' | 'materialize' | 'preload' | 'observation' | 'completion' | 'publish-before' | 'publish-after' | 'publish-unknown-null' | 'publish-unknown-current' | 'publish-unknown-new' | 'publish-unknown-read-fail' | 'verify' | 'audit-complete' | 'audit-all'
   failReadActive = false
+  targetArtifactError?: Error
   next = 1
+  candidateArtifacts = new Map<string, readonly D1LoadedAgentArtifact[]>()
   async seed(value: D1DesiredSnapshotV1, revisionId = 'r0000000001', terminal = true, versions: RuntimeVersionSpec = {}) {
     const desiredStateDigest = await digestD1Desired(value)
     const observed = observation(value, await runtimeIdentities(value, versions))
@@ -105,11 +108,11 @@ class FakeStore implements D1HostRevisionStore {
     return { schemaVersion: 1, domain: 'boring-d1-audit:v1', revisionId: complete.revisionId, desiredStateDigest: complete.desiredStateDigest, completionDigest: complete.completion.completionDigest, at: '2026-07-12T00:00:00.000Z', operator: { uid: 1000, effectiveUser: 'julien', invocationId: 'deploy-1' }, outcome: 'COMPLETE', phase: 'AUDIT' }
   }
   async reserveRevisionId() { this.calls.push('reserve'); const revision = `r${String(this.next++).padStart(10, '0')}`; this.reserved.add(revision); return revision }
-  async writeCandidate(_host: string, revisionId: string, value: D1DesiredSnapshotV1) {
+  async writeCandidate(_host: string, revisionId: string, value: D1DesiredSnapshotV1, artifacts: readonly D1LoadedAgentArtifact[]) {
     this.calls.push('candidate'); if (this.fault === 'candidate') throw new Error('/secret/candidate')
     if (!this.reserved.has(revisionId) || this.candidates.has(revisionId)) throw new D1HostError(D1HostErrorCode.REVISION_CONFLICT, { field: 'candidate' })
     const candidate = Object.freeze({ revisionId, desired: value, desiredStateDigest: await digestD1Desired(value), secretRefs: deriveD1SecretRefsEnvelope(value) })
-    this.candidates.set(revisionId, candidate); return candidate
+    this.candidates.set(revisionId, candidate); this.candidateArtifacts.set(revisionId, artifacts); return candidate
   }
   async readCandidate(_host: string, revisionId: string) { return this.candidates.get(revisionId) ?? null }
   async writeObservation(_host: string, revisionId: string, value: D1ObservationV1) {
@@ -123,6 +126,7 @@ class FakeStore implements D1HostRevisionStore {
     const complete = Object.freeze({ ...candidate, observation: observed, completion }); this.completes.set(revisionId, complete); return complete
   }
   async readComplete(_host: string, revisionId: string) { this.calls.push(`read:${revisionId}`); return this.completes.get(revisionId) ?? null }
+  async readAgentArtifact() { return null }
   async readActive() { this.calls.push('readActive'); if (this.failReadActive) { this.failReadActive = false; throw new Error('/secret/read-active') } return this.active }
   async publishActive(_host: string, revisionId: string) {
     this.calls.push(`publish:${revisionId}`)
@@ -165,6 +169,9 @@ function harness(
   const admissionDatabaseRefs: string[] = []
   const publicationCalls: string[] = []
   const published: D1DestructivePublicationIdentity[] = []
+  const artifactCalls: string[] = []
+  const inboxArtifacts = [{ envelope: { bindingId: 'inbox' } }] as unknown as readonly D1LoadedAgentArtifact[]
+  const targetArtifacts = [{ envelope: { bindingId: 'target' } }] as unknown as readonly D1LoadedAgentArtifact[]
   const defaultPublication: D1FencedDestructivePublication = {
     async recoverPending() { publicationCalls.push(`recover:${calls.join(',')}:${store.calls.join(',')}`) },
     async publish(identity) {
@@ -179,6 +186,8 @@ function harness(
     resolver: { async resolvePlan() { calls.push('resolve'); return next }, async reproduce() { calls.push('reproduce'); return next } },
     async inspectRuntimeInputs(value) { calls.push('inspect'); if (store.adapterErrors.inspect) throw store.adapterErrors.inspect; return inspect(value) },
     effects: {
+      async loadAgentArtifacts() { artifactCalls.push('inbox'); return inboxArtifacts },
+      async loadRevisionAgentArtifacts() { artifactCalls.push('target'); if (store.targetArtifactError) throw store.targetArtifactError; return targetArtifacts },
       async loadAdmittedBindingIds(_hostId, databaseRef) { calls.push('admissions'); admissionDatabaseRefs.push(databaseRef); return admitted },
       async materialize(candidate) {
         calls.push('materialize'); if (store.adapterErrors.materialize) throw store.adapterErrors.materialize
@@ -191,7 +200,7 @@ function harness(
     mutationGuard: { assertHeld() { calls.push('guard') } }, operator: { uid: 1000, effectiveUser: 'julien', invocationId: 'deploy-1' }, clock: () => '2026-07-12T00:00:00.000Z',
     ...(publication === null ? {} : { fencedPublication: publication ?? defaultPublication }),
   }
-  return { engine: createD1CommandEngine(options), calls, admissionDatabaseRefs, publicationCalls, published }
+  return { engine: createD1CommandEngine(options), calls, admissionDatabaseRefs, publicationCalls, published, artifactCalls, targetArtifacts }
 }
 const plan = (value: D1DesiredSnapshotV1, expectedHostRevision: string | null) => ({ ...value.plan, expectedHostRevision })
 const apply = (value: D1DesiredSnapshotV1, expectedHostRevision: string | null, extra: Record<string, unknown> = {}) => ({ kind: 'apply', plan: plan(value, expectedHostRevision), ...extra })
@@ -522,7 +531,18 @@ describe('D1 command engine', () => {
     const rollingBack = harness(rollbackStore, retained)
     const rolledBack = await rollingBack.engine.execute({ kind: 'rollback', hostId: 'host-1', expectedHostRevision: 'r0000000002', targetRevision: 'r0000000001', confirmRemove: ['travel'] })
     expect(rollingBack.published[0]).toMatchObject({ operationId: 'deploy-1', expectedRevision: 'r0000000002', expectedDigest: active.desiredStateDigest, targetRevision: 'r0000000003', removalBindingIds: ['travel'] })
+    expect(rollingBack.artifactCalls).toEqual(['target'])
+    expect(rollbackStore.candidateArtifacts.get(rolledBack.revisionId!)).toBe(rollingBack.targetArtifacts)
     expect(rollbackStore.calls).not.toContain('publish:r0000000001'); expect(rollbackStore.calls).not.toContain(`publish:${rolledBack.revisionId}`)
+  })
+
+  it('fails closed before reservation when a legacy rollback target has no artifact snapshot', async () => {
+    const value = await desired(); const current = await desired([{ id: 'insurance', landing: 'Changed' }]); const store = new FakeStore()
+    await store.seed(value, 'r0000000001'); await store.seed(current, 'r0000000002')
+    store.calls = []; store.targetArtifactError = new Error('missing legacy artifact')
+    await expect(harness(store, value).engine.execute({ kind: 'rollback', hostId: 'host-1', expectedHostRevision: 'r0000000002', targetRevision: 'r0000000001' }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED, details: { field: 'agentArtifacts' } })
+    expect(store.calls).not.toContain('reserve')
   })
 
   it.each([

--- a/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
@@ -9,6 +9,7 @@ import type postgres from 'postgres'
 import { describe, expect, it, vi } from 'vitest'
 
 import { mintAttestedD1DatabaseConnection, type D1AdmissionLedger } from '../admissionLedger.js'
+import { D1_V1_COLLECTION_LIMITS } from '../bootCollection.js'
 import { createProductionD1Dependencies, runD1CommandEntry, type D1EntryContext } from '../d1CommandEntry.js'
 import { isSupportedLocalD1LockFilesystem } from '../d1CommandLockPolicy.js'
 import { D1HostErrorCode } from '../d1Plan.js'
@@ -19,6 +20,7 @@ import * as revisions from '../hostRevisionStore.js'
 
 const UID = process.geteuid!()
 const DIGEST = `sha256:${'a'.repeat(64)}`
+const LIMITS = { maxBindings: 20, maxBundleBytes: 1_000_000, maxTotalBundleBytes: 10_000_000, maxConcurrentPreloads: 4 }
 const SUCCESS = `${JSON.stringify({ ok: true, result: { kind: 'APPLY', action: 'NOOP', activeRevision: null, desiredStateDigest: DIGEST, removals: [] } })}\n`
 const SOURCE_ENTRY: D1EntryInvocation = {
   command: process.execPath,
@@ -68,7 +70,7 @@ async function collect(child: ChildProcess): Promise<{ code: number | null; stdo
 }
 async function directEntry(h: Roots, marker: string, handle?: FileHandle): Promise<{ code: number | null; stdout: string }> {
   const entryUrl = pathToFileURL(path.resolve('src/server/deployment/d1CommandEntry.ts')).href
-  const source = `import {runD1CommandEntry} from ${JSON.stringify(entryUrl)};import fs from 'node:fs';const out=await runD1CommandEntry({mode:'--locked',dependencyFactory:()=>{fs.writeFileSync(${JSON.stringify(marker)},'called');throw new Error('factory')}});process.stdout.write(out.line);process.exitCode=out.exitCode`
+  const source = `import {runD1CommandEntry} from ${JSON.stringify(entryUrl)};import fs from 'node:fs';const out=await runD1CommandEntry({mode:'--locked',collectionLimits:${JSON.stringify(LIMITS)},dependencyFactory:()=>{fs.writeFileSync(${JSON.stringify(marker)},'called');throw new Error('factory')}});process.stdout.write(out.line);process.exitCode=out.exitCode`
   const stdio: Array<'pipe' | number> = handle ? ['pipe', 'pipe', 'pipe', handle.fd] : ['pipe', 'pipe', 'pipe']
   const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '-e', source, '--'], { env: h.env, stdio })
   await handle?.close(); child.stdin!.end(validApply())
@@ -157,7 +159,7 @@ describe('D1 revision command boundary', () => {
     const prior = Object.fromEntries(keys.map((key) => [key, process.env[key]]))
     for (const key of keys) process.env[key] = h.env[key]
     try {
-      const output = await runD1CommandEntry({ stdin: Readable.from([validApply()]), mode: '--locked', dependencyFactory: factory })
+      const output = await runD1CommandEntry({ stdin: Readable.from([validApply()]), mode: '--locked', collectionLimits: LIMITS, dependencyFactory: factory })
       expect(output.exitCode).toBe(2); expect(factory).not.toHaveBeenCalled()
     } finally { for (const key of keys) prior[key] === undefined ? delete process.env[key] : process.env[key] = prior[key] }
   })
@@ -171,7 +173,7 @@ describe('D1 revision command boundary', () => {
       const output = await runD1CommandEntry({ stdin: Readable.from([JSON.stringify(command)]), mode: '--read-only', dependencyFactory: (value) => {
         context = value; throw new Error('stop after dependency construction')
       } })
-      expect(output).toMatchObject({ exitCode: 70 }); expect(context?.hostId).toBe('host-2')
+      expect(output).toMatchObject({ exitCode: 70 }); expect(context).toMatchObject({ hostId: 'host-2', collectionLimits: D1_V1_COLLECTION_LIMITS })
     } finally { for (const key of keys) prior[key] === undefined ? delete process.env[key] : process.env[key] = prior[key] }
   })
 
@@ -181,7 +183,7 @@ describe('D1 revision command boundary', () => {
     const createStore = vi.spyOn(revisions, 'createHostRevisionStore').mockReturnValue(revisionStore)
     const createJournal = vi.spyOn(journals, 'createD1DestructivePublicationJournalStore').mockReturnValue({} as ReturnType<typeof journals.createD1DestructivePublicationJournalStore>)
     const createPublication = vi.spyOn(publications, 'createD1FencedDestructivePublication').mockReturnValue(fencedPublication)
-    const context = { hostId: 'host-1', ownerUid: UID, stateRoot: '/d1-state', mutationGuard: { assertHeld: vi.fn() } }
+    const context = { hostId: 'host-1', ownerUid: UID, stateRoot: '/d1-state', collectionLimits: LIMITS, mutationGuard: { assertHeld: vi.fn() } }
     try {
       const absent = createProductionD1Dependencies(context)
       expect(absent.store).toBe(revisionStore); expect(absent.fencedPublication).toBeUndefined()
@@ -205,7 +207,7 @@ describe('D1 revision command boundary', () => {
     const command = JSON.parse(validApply().toString()) as { kind: string }; command.kind = 'plan'
     for (const key of keys) process.env[key] = h.env[key]
     try {
-      const output = await runD1CommandEntry({ stdin: Readable.from([JSON.stringify(command)]), mode: '--read-only', databaseConnection })
+      const output = await runD1CommandEntry({ stdin: Readable.from([JSON.stringify(command)]), mode: '--read-only', collectionLimits: LIMITS, databaseConnection })
       expect(output).toMatchObject({ exitCode: 4 }); expect(reserve).toHaveBeenCalledOnce(); expect(release).toHaveBeenCalledOnce(); expect(end).toHaveBeenCalledOnce()
     } finally { for (const key of keys) prior[key] === undefined ? delete process.env[key] : process.env[key] = prior[key] }
   })
@@ -241,7 +243,7 @@ describe('D1 revision command boundary', () => {
   it('rechecks same-OFD ownership when the mutation guard runs', async () => {
     const h = await roots(); const marker = path.join(h.base, 'guard-rejected')
     const entryUrl = pathToFileURL(path.resolve('src/server/deployment/d1CommandEntry.ts')).href
-    const source = `import {runD1CommandEntry} from ${JSON.stringify(entryUrl)};import fs from 'node:fs';const out=await runD1CommandEntry({mode:'--locked',dependencyFactory:ctx=>{fs.closeSync(3);if(fs.openSync(process.env.BORING_D1_LOCK_ROOT+'/host-1.lock','r+')!==3)throw new Error('fd');try{ctx.mutationGuard.assertHeld('host-1')}catch(error){fs.writeFileSync(${JSON.stringify(marker)},'rejected');throw error}fs.writeFileSync(${JSON.stringify(marker)},'accepted');throw new Error('guard')}});process.stdout.write(out.line);process.exitCode=out.exitCode`
+    const source = `import {runD1CommandEntry} from ${JSON.stringify(entryUrl)};import fs from 'node:fs';const out=await runD1CommandEntry({mode:'--locked',collectionLimits:${JSON.stringify(LIMITS)},dependencyFactory:ctx=>{fs.closeSync(3);if(fs.openSync(process.env.BORING_D1_LOCK_ROOT+'/host-1.lock','r+')!==3)throw new Error('fd');try{ctx.mutationGuard.assertHeld('host-1')}catch(error){fs.writeFileSync(${JSON.stringify(marker)},'rejected');throw error}fs.writeFileSync(${JSON.stringify(marker)},'accepted');throw new Error('guard')}});process.stdout.write(out.line);process.exitCode=out.exitCode`
     const output = await runD1RevisionWrapper({
       stdin: Readable.from([validApply()]), env: h.env,
       entry: { command: process.execPath, args: ['--import', 'tsx', '--input-type=module', '-e', source, '--'] },

--- a/apps/full-app/src/server/deployment/__tests__/d1Plan.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Plan.test.ts
@@ -81,7 +81,7 @@ describe('parseD1HostPlan', () => {
   )
 
   it('admits only binding ids whose .env filename fits NAME_MAX', () => {
-    const longest = 'a'.repeat(251)
+    const longest = 'a'.repeat(250)
     expect(parseD1HostPlan(plan({ bindings: [{ ...binding('a'), bindingId: longest }] })).bindings[0].bindingId).toBe(longest)
     expect(() => parseD1HostPlan(plan({ bindings: [{ ...binding('a'), bindingId: `${longest}a` }] })))
       .toThrow(expect.objectContaining({ code: D1HostErrorCode.PLAN_INVALID, details: { field: 'bindings[0].bindingId' } }))

--- a/apps/full-app/src/server/deployment/__tests__/d1ProductionDependencies.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1ProductionDependencies.test.ts
@@ -12,13 +12,16 @@ const seams = vi.hoisted(() => {
       throw new D1HostError(D1HostErrorCode.SECRET_UNAVAILABLE, { field: 'secret' })
     }),
   }
-  return { provider, createProvider: vi.fn(() => provider), createInspector: vi.fn(), createMaterializer: vi.fn() }
+  return { provider, createProvider: vi.fn(() => provider), createInspector: vi.fn(), createMaterializer: vi.fn(), loadArtifacts: vi.fn(async () => []) }
 })
 
 vi.mock('../d1FileRuntimeInputsProvider.js', () => ({ createD1FileRuntimeInputsProvider: seams.createProvider }))
 vi.mock('../d1SecretMaterializer.js', () => ({
   createD1RuntimeInputsInspector: seams.createInspector,
   createD1BindingSecretMaterializer: seams.createMaterializer,
+}))
+vi.mock('../d1AgentArtifactSnapshot.js', () => ({
+  loadD1AgentArtifactInputs: seams.loadArtifacts,
 }))
 
 import { createProductionD1Dependencies } from '../d1CommandEntry.js'
@@ -29,7 +32,7 @@ const binding: D1SiteBindingV1 = {
   workspaceAllocationRef: 'insurance-workspace', sessionAllocationRef: 'insurance-session', ownerPrincipalRef: 'owner',
   landing: { title: 'Insurance', summary: 'Compare policies.' }, environmentRef: 'production', secretRefs: ['credential-ref'],
 }
-const desired = { plan: { bindings: [binding] } } as unknown as D1DesiredSnapshotV1
+const desired = { plan: { bindings: [binding] }, resolvedBindings: [{ composition: { digest: `sha256:${'a'.repeat(64)}` } }] } as unknown as D1DesiredSnapshotV1
 const candidate = { desired } as D1StoredCandidateV1
 
 describe('D1 production dependency composition', () => {
@@ -48,7 +51,8 @@ describe('D1 production dependency composition', () => {
 
   it('shares one host-scoped provider while leaving unfinished dependencies fail-closed', async () => {
     const mutationGuard = { assertHeld: vi.fn() }
-    const dependencies = createProductionD1Dependencies({ hostId: 'host-1', ownerUid: process.geteuid!(), stateRoot: '/unused', mutationGuard })
+    const collectionLimits = { maxBindings: 20, maxBundleBytes: 1000, maxTotalBundleBytes: 10000, maxConcurrentPreloads: 4 }
+    const dependencies = createProductionD1Dependencies({ hostId: 'host-1', ownerUid: process.geteuid!(), stateRoot: '/unused', collectionLimits, mutationGuard })
 
     expect(seams.createProvider).toHaveBeenCalledOnce()
     expect(seams.createProvider).toHaveBeenCalledWith({ hostId: 'host-1', ownerUid: process.geteuid!() })
@@ -60,6 +64,8 @@ describe('D1 production dependency composition', () => {
     await dependencies.inspectRuntimeInputs(desired)
     expect(seams.provider.inspect).toHaveBeenCalledWith(binding)
     expect(seams.provider.resolveSecrets).not.toHaveBeenCalled()
+    await dependencies.effects.loadAgentArtifacts!(desired)
+    expect(seams.loadArtifacts).toHaveBeenCalledWith(expect.objectContaining({ hostId: 'host-1', ownerUid: process.geteuid!(), limits: collectionLimits }))
     await expect(dependencies.effects.materialize(candidate, [])).rejects.toMatchObject({
       code: D1HostErrorCode.SECRET_UNAVAILABLE, details: { field: 'secret' },
     })

--- a/apps/full-app/src/server/deployment/__tests__/hostRevisionStore.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/hostRevisionStore.test.ts
@@ -1,7 +1,7 @@
 import { access, appendFile, chmod, cp, link, mkdtemp, mkdir, readFile, readdir, rename, stat, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
-import { createAgentAssetDigest, createAgentDeploymentDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
+import { createAgentAssetDigest, createAgentDefinitionDigest, createAgentDeploymentDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
 import { createResolvedAgentDigest } from '@hachej/boring-agent/server'
 import { describe, expect, it } from 'vitest'
 
@@ -16,6 +16,7 @@ import {
 import { D1ActivePublishError, createHostRevisionStore, type D1HostRevisionStore } from '../hostRevisionStore.js'
 import { canonicalizeWorkspaceCompositionSnapshot } from '../workspaceComposition.js'
 import { createD1RuntimeInputsIdentity } from '../d1RuntimeInputs.js'
+import type { D1LoadedAgentArtifact } from '../d1AgentArtifactSnapshot.js'
 
 const digest = (value: string): Sha256Digest => `sha256:${value.repeat(64).slice(0, 64)}`
 const OWNER_UID = process.geteuid!()
@@ -40,7 +41,10 @@ async function desired(id = 'insurance'): Promise<D1DesiredSnapshotV1> {
     provisioning: [], filesystemBindings: [], policies: { externalPlugins: false, pluginAuthoring: false },
   })
   const compositionDigest = await createAgentAssetDigest(JSON.stringify(snapshot))
-  const definition = { definitionId: `definition:${id}`, version: '1.0.0', digest: digest('f'), instructionsRef: 'instructions.md' }
+  const instructions = { path: 'instructions.md', content: `Compare ${id} policies.`, digest: await createAgentAssetDigest(`Compare ${id} policies.`) }
+  const compiledDefinition = { schemaVersion: 1 as const, definitionId: `definition:${id}`, version: '1.0.0', instructionsRef: instructions.path }
+  const definition = { definitionId: compiledDefinition.definitionId, version: compiledDefinition.version, instructionsRef: compiledDefinition.instructionsRef,
+    digest: await createAgentDefinitionDigest({ definition: compiledDefinition, assets: [instructions] }) }
   const deploymentInput = {
     deploymentId: `deployment:${id}`, version: '2026.07.12', agentId: 'default',
     definition: { definitionId: definition.definitionId, version: definition.version, digest: definition.digest },
@@ -68,10 +72,26 @@ async function desired(id = 'insurance'): Promise<D1DesiredSnapshotV1> {
   }])
 }
 
+async function artifact(value: D1DesiredSnapshotV1, index = 0): Promise<D1LoadedAgentArtifact> {
+  const binding = value.plan.bindings[index]!; const expected = value.resolvedBindings[index]!
+  const content = `Compare ${binding.bindingId} policies.`
+  const asset = { path: expected.definition.instructionsRef, content, digest: await createAgentAssetDigest(content) }
+  const definition = { schemaVersion: 1 as const, definitionId: expected.definition.definitionId, version: expected.definition.version, instructionsRef: asset.path }
+  const bundle = { definition, definitionDigest: await createAgentDefinitionDigest({ definition, assets: [asset] }), assets: [asset] }
+  const deployment = { deploymentId: expected.deployment.deploymentId, version: expected.deployment.version, agentId: 'default',
+    definition: { definitionId: definition.definitionId, version: definition.version, digest: bundle.definitionDigest } }
+  return { envelope: { schemaVersion: 1, domain: 'boring-d1-agent-artifact:v1', hostId: value.plan.hostId,
+    bindingId: binding.bindingId, bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, bundle, deployment } }
+}
+
 async function harness(fault?: () => void) {
   const parent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-store-'))
   const root = path.join(parent, 'state')
-  return { parent, root, store: createHostRevisionStore({ root, ownerUid: OWNER_UID, appGid: APP_GID, fault }) }
+  const base = createHostRevisionStore({ root, ownerUid: OWNER_UID, appGid: APP_GID, fault })
+  const store = { ...base, async writeCandidate(host: string, revision: string, value: D1DesiredSnapshotV1,
+    artifacts?: readonly D1LoadedAgentArtifact[]) { return base.writeCandidate(host, revision, value,
+      artifacts ?? await Promise.all(value.plan.bindings.map((_binding, index) => artifact(value, index)))) } }
+  return { parent, root, store }
 }
 async function observation(value: D1DesiredSnapshotV1, ready = true) {
   return {
@@ -92,7 +112,7 @@ async function observation(value: D1DesiredSnapshotV1, ready = true) {
 async function complete(store: D1HostRevisionStore) {
   const value = await desired()
   const revisionId = await store.reserveRevisionId('host-1')
-  await store.writeCandidate('host-1', revisionId, value)
+  await store.writeCandidate('host-1', revisionId, value, [await artifact(value)])
   await store.writeObservation('host-1', revisionId, await observation(value))
   const completed = await store.writeComplete('host-1', revisionId)
   return { value, revisionId, completed }
@@ -107,6 +127,27 @@ function audit(completed: Awaited<ReturnType<typeof complete>>['completed'], out
 }
 
 describe('D1 host revision store', () => {
+  it('snapshots validated agent artifacts inside the atomic revision', async () => {
+    const h = await harness(); const value = await desired(); const revisionId = await h.store.reserveRevisionId('host-1')
+    const loaded = await artifact(value)
+    await h.store.writeCandidate('host-1', revisionId, value, [loaded])
+    expect(await h.store.readAgentArtifact('host-1', revisionId, 'insurance')).toEqual(loaded.envelope)
+    const file = path.join(h.root, 'host-1', 'revisions', revisionId, 'agent-artifacts', 'insurance.json')
+    expect(await stat(file)).toMatchObject({ uid: OWNER_UID, gid: APP_GID, nlink: 1 })
+    expect((await stat(file)).mode & 0o777).toBe(0o440)
+
+    const otherValue = await desired('travel'); const other = await artifact(otherValue)
+    const otherRevision = await h.store.reserveRevisionId('host-1')
+    await h.store.writeCandidate('host-1', otherRevision, otherValue, [other])
+    expect(await h.store.readAgentArtifact('host-1', revisionId, 'insurance')).toEqual(loaded.envelope)
+    expect(await h.store.readAgentArtifact('host-1', otherRevision, 'travel')).toEqual(other.envelope)
+
+    const mismatch = { ...loaded, envelope: { ...loaded.envelope, bundleRef: 'other' } }
+    const next = await h.store.reserveRevisionId('host-1')
+    await expect(h.store.writeCandidate('host-1', next, value, [mismatch])).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    await expect(access(path.join(h.root, 'host-1', 'revisions', next))).rejects.toThrow()
+  })
+
   it('round-trips canonical split envelopes without CAS, paths, prompts, or secret values', async () => {
     const h = await harness()
     const value = await desired()

--- a/apps/full-app/src/server/deployment/bootCollection.ts
+++ b/apps/full-app/src/server/deployment/bootCollection.ts
@@ -19,6 +19,9 @@ export interface D1CollectionLimits {
   readonly maxTotalBundleBytes: number
   readonly maxConcurrentPreloads: number
 }
+export const D1_V1_COLLECTION_LIMITS: D1CollectionLimits = Object.freeze({
+  maxBindings: 20, maxBundleBytes: 64 * 1024 * 1024, maxTotalBundleBytes: 1024 * 1024 * 1024, maxConcurrentPreloads: 4,
+})
 export interface D1ResolvedBundleV1 {
   readonly resolved: D1ResolvedBindingV1
   readonly bundleBytes: number

--- a/apps/full-app/src/server/deployment/d1AgentArtifactSnapshot.ts
+++ b/apps/full-app/src/server/deployment/d1AgentArtifactSnapshot.ts
@@ -1,0 +1,121 @@
+import { readdir, realpath } from 'node:fs/promises'
+import path from 'node:path'
+
+import {
+  AgentDefinitionValidationError,
+  AgentDeploymentValidationError,
+  validateAgentDefinition,
+  validateAgentDeployment,
+  type AgentDeployment,
+  type CompiledAgentBundle,
+  type Sha256Digest,
+} from '@hachej/boring-agent/shared'
+import { resolveAgentDeployment } from '@hachej/boring-agent/server'
+
+import { assertD1ExactKeys, D1HostError, D1HostErrorCode, strictD1HostId, strictD1Ref, type D1SiteBindingV1 } from './d1Plan.js'
+import { openD1SecureDirectory, openD1SecureRoot, readD1SecureFile } from './d1FileRuntimeInputsProvider.js'
+import type { D1ResolvedBindingV1 } from './d1RevisionCodec.js'
+
+export const D1_AGENT_ARTIFACT_INPUT_ROOT = '/etc/boring/d1/agent-artifacts'
+const DOMAIN = 'boring-d1-agent-artifact:v1'
+
+export interface D1AgentArtifactEnvelopeV1 {
+  readonly schemaVersion: 1
+  readonly domain: typeof DOMAIN
+  readonly hostId: string
+  readonly bindingId: string
+  readonly bundleRef: string
+  readonly deploymentRef: string
+  readonly bundle: CompiledAgentBundle
+  readonly deployment: AgentDeployment
+}
+export interface D1LoadedAgentArtifact {
+  readonly envelope: D1AgentArtifactEnvelopeV1
+}
+export interface D1AgentArtifactInput {
+  readonly binding: D1SiteBindingV1
+  readonly compositionDigest: Sha256Digest
+}
+export interface D1AgentArtifactLimits {
+  readonly maxBindings: number
+  readonly maxBundleBytes: number
+  readonly maxTotalBundleBytes: number
+}
+
+function failed(field = 'agentArtifacts'): D1HostError {
+  return new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field })
+}
+/** Internal revision-store parser; callers should use the fixed inbox/revision readers. */
+export function canonicalizeD1AgentArtifactEnvelope(raw: unknown, hostId: string, binding: D1SiteBindingV1): D1AgentArtifactEnvelopeV1 {
+  if (binding.bindingId.length > 250) throw failed()
+  assertD1ExactKeys(raw, ['schemaVersion', 'domain', 'hostId', 'bindingId', 'bundleRef', 'deploymentRef', 'bundle', 'deployment'], 'agentArtifacts')
+  if (raw.schemaVersion !== 1 || raw.domain !== DOMAIN || strictD1HostId(raw.hostId, 'hostId') !== hostId
+    || strictD1Ref(raw.bindingId, 'bindingId') !== binding.bindingId || strictD1Ref(raw.bundleRef, 'bundleRef') !== binding.bundleRef
+    || strictD1Ref(raw.deploymentRef, 'deploymentRef') !== binding.deploymentRef) throw failed()
+  assertD1ExactKeys(raw.bundle, ['definition', 'definitionDigest', 'assets'], 'agentArtifacts.bundle')
+  const definition = validateAgentDefinition(raw.bundle.definition)
+  const deployment = validateAgentDeployment(raw.deployment)
+  if (!definition.valid) throw new AgentDefinitionValidationError(definition.issues[0])
+  if (!deployment.valid) throw new AgentDeploymentValidationError(deployment.issues[0])
+  if (!Array.isArray(raw.bundle.assets)) throw failed()
+  const bundle = Object.freeze({
+    definition: Object.freeze(definition.value), definitionDigest: raw.bundle.definitionDigest as Sha256Digest,
+    assets: Object.freeze(raw.bundle.assets.map((asset) => asset as CompiledAgentBundle['assets'][number])
+      .map(({ path, digest, content }) => Object.freeze({ path, digest, content })).sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0)),
+  })
+  return Object.freeze({ schemaVersion: 1, domain: DOMAIN, hostId, bindingId: binding.bindingId, bundleRef: binding.bundleRef,
+    deploymentRef: binding.deploymentRef, bundle, deployment: Object.freeze(deployment.value) })
+}
+
+export async function validateD1AgentArtifact(envelope: D1AgentArtifactEnvelopeV1, binding: D1SiteBindingV1,
+  expected: D1ResolvedBindingV1): Promise<void> {
+  const resolved = await resolveAgentDeployment(envelope.bundle, envelope.deployment, { workspaceId: binding.workspaceId,
+    defaultDeploymentId: binding.defaultDeploymentId, workspaceCompositionDigest: expected.composition.digest })
+  if (JSON.stringify({ workspace: resolved.workspace, deployment: resolved.deployment, definition: resolved.definition, resolvedDigest: resolved.resolvedDigest })
+    !== JSON.stringify({ workspace: expected.workspace, deployment: expected.deployment, definition: expected.definition, resolvedDigest: expected.resolvedDigest })) throw failed()
+}
+
+export async function loadD1AgentArtifactInputs(options: {
+  readonly hostId: string
+  readonly ownerUid: number
+  readonly inputs: readonly D1AgentArtifactInput[]
+  readonly limits: D1AgentArtifactLimits
+  readonly root?: string
+  readonly fault?: (point: 'after-directory-open' | 'after-file-open', bindingId: string) => void | Promise<void>
+}): Promise<readonly D1LoadedAgentArtifact[]> {
+  try {
+    const hostId = strictD1HostId(options.hostId, 'hostId')
+    if (process.geteuid?.() !== options.ownerUid || !Number.isSafeInteger(options.ownerUid) || options.ownerUid < 0
+      || !Number.isSafeInteger(options.limits.maxBindings) || options.inputs.length > options.limits.maxBindings
+      || !Number.isSafeInteger(options.limits.maxBundleBytes) || options.limits.maxBundleBytes <= 0
+      || !Number.isSafeInteger(options.limits.maxTotalBundleBytes) || options.limits.maxTotalBundleBytes <= 0) throw failed()
+    const root = path.resolve(options.root ?? D1_AGENT_ARTIFACT_INPUT_ROOT)
+    const handles = []
+    try {
+      const policy = { uid: options.ownerUid, gid: process.getegid!() }
+      const rootHandle = await openD1SecureRoot(root, policy, false); handles.push(rootHandle.handle)
+      const hostHandle = await openD1SecureDirectory(path.join(rootHandle.path, hostId), rootHandle, rootHandle, policy); handles.push(hostHandle.handle)
+      let total = 0; const loaded: D1LoadedAgentArtifact[] = []
+      for (const input of options.inputs) {
+        const handle = await openD1SecureDirectory(path.join(hostHandle.path, input.binding.bindingId), hostHandle, rootHandle, policy); handles.push(handle.handle)
+        await options.fault?.('after-directory-open', input.binding.bindingId)
+        const expectedPath = path.join(root, hostId, input.binding.bindingId, 'artifact.json')
+        if (JSON.stringify((await readdir(handle.path)).sort()) !== '["artifact.json"]') throw failed()
+        const bytes = await readD1SecureFile(path.join(handle.path, 'artifact.json'), rootHandle, policy, options.limits.maxBundleBytes,
+          () => options.fault?.('after-file-open', input.binding.bindingId), expectedPath)
+        if (await realpath(handle.path) !== path.dirname(expectedPath)) throw failed()
+        total += bytes.byteLength
+        if (total > options.limits.maxTotalBundleBytes) throw failed()
+        const envelope = canonicalizeD1AgentArtifactEnvelope(JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown, hostId, input.binding)
+        await resolveAgentDeployment(envelope.bundle, envelope.deployment, { workspaceId: input.binding.workspaceId,
+          defaultDeploymentId: input.binding.defaultDeploymentId, workspaceCompositionDigest: input.compositionDigest })
+        loaded.push(Object.freeze({ envelope }))
+      }
+      return Object.freeze(loaded)
+    } finally { await Promise.allSettled(handles.map((handle) => handle.close())) }
+  } catch (error) {
+    if (error instanceof AgentDefinitionValidationError || error instanceof AgentDeploymentValidationError) throw error
+    if (error instanceof D1HostError && error.code === D1HostErrorCode.PUBLICATION_FAILED) throw error
+    throw failed()
+  }
+}

--- a/apps/full-app/src/server/deployment/d1Command.ts
+++ b/apps/full-app/src/server/deployment/d1Command.ts
@@ -1,4 +1,4 @@
-import type { Sha256Digest } from '@hachej/boring-agent/shared'
+import { AgentDefinitionValidationError, AgentDeploymentValidationError, type Sha256Digest } from '@hachej/boring-agent/shared'
 
 import {
   assertD1ExactKeys,
@@ -28,6 +28,7 @@ import {
   type D1StoredCompleteV1,
 } from './hostRevisionStore.js'
 import type { D1FencedDestructivePublication } from './fencedDestructivePublication.js'
+import type { D1LoadedAgentArtifact } from './d1AgentArtifactSnapshot.js'
 
 export interface D1DesiredResolver {
   resolvePlan(plan: D1HostPlanV1): Promise<D1DesiredSnapshotV1>
@@ -35,6 +36,8 @@ export interface D1DesiredResolver {
 }
 export interface D1ApplyEffects {
   loadAdmittedBindingIds(hostId: string, databaseRef: string): Promise<readonly string[]>
+  loadAgentArtifacts(desired: D1DesiredSnapshotV1): Promise<readonly D1LoadedAgentArtifact[]>
+  loadRevisionAgentArtifacts(target: D1StoredCompleteV1): Promise<readonly D1LoadedAgentArtifact[]>
   /** Must attest the actual provider versions consumed while materializing the expected identities. */
   materialize(candidate: D1StoredCandidateV1, expected: readonly D1RuntimeInputsIdentityV1[]): Promise<readonly D1RuntimeInputsInspectionV1[]>
   preload(candidate: D1StoredCandidateV1, runtimeInputs: readonly D1RuntimeInputsIdentityV1[]): Promise<D1ObservationV1>
@@ -280,6 +283,7 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
     prior: D1ActiveEnvelopeV1 | null,
     removals: readonly string[],
     publication: D1FencedDestructivePublication,
+    agentArtifacts: readonly D1LoadedAgentArtifact[],
   ): Promise<D1ActiveEnvelopeV1> => {
     const desiredStateDigest = await digestD1Desired(desired)
     let revisionId: string
@@ -288,7 +292,9 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
       throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'candidate' })
     }
     let candidate: D1StoredCandidateV1
-    try { candidate = await options.store.writeCandidate(hostId, revisionId, desired) } catch (error) {
+    try {
+      candidate = await options.store.writeCandidate(hostId, revisionId, desired, agentArtifacts)
+    } catch (error) {
       await appendBestEffort(hostId, revisionId, desiredStateDigest, 'FAILED', 'CANDIDATE')
       if (error instanceof D1HostError) throw new D1HostError(error.code, { field: error.details.field ?? 'candidate' })
       throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'candidate' })
@@ -352,6 +358,12 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
     }
     return active
   }
+  const loadArtifacts = async (load: () => Promise<readonly D1LoadedAgentArtifact[]>) => {
+    try { return await load() } catch (error) {
+      if (error instanceof AgentDefinitionValidationError || error instanceof AgentDeploymentValidationError) throw error
+      throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'agentArtifacts' })
+    }
+  }
 
   return Object.freeze({
     async execute(raw: unknown): Promise<D1CommandResult> {
@@ -376,7 +388,8 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
         const desiredStateDigest = await digestD1Desired(desired)
         await recover(hostId, state.active, state.complete)
         if (desiredStateDigest === state.active?.desiredStateDigest) return Object.freeze({ kind: 'ROLLBACK', action: 'NOOP', activeRevision: state.active?.revisionId ?? null, desiredStateDigest, removals })
-        const active = await create(hostId, desired, inspected, state.active, removals, publication)
+        const agentArtifacts = await loadArtifacts(() => options.effects.loadRevisionAgentArtifacts(target))
+        const active = await create(hostId, desired, inspected, state.active, removals, publication, agentArtifacts)
         return Object.freeze({ kind: 'ROLLBACK', action: 'CREATE', activeRevision: active.revisionId, revisionId: active.revisionId, desiredStateDigest, removals })
       }
       const parsedPlan = parseD1HostPlan(command.plan)
@@ -397,7 +410,8 @@ export function createD1CommandEngine(options: D1CommandEngineOptions) {
       if (command.kind === 'plan') return Object.freeze({ kind: 'PLAN', action: desiredStateDigest === state.active?.desiredStateDigest ? 'NOOP' : 'CREATE', activeRevision: state.active?.revisionId ?? null, desiredStateDigest, removals })
       await recover(hostId, state.active, state.complete)
       if (desiredStateDigest === state.active?.desiredStateDigest) return Object.freeze({ kind: 'APPLY', action: 'NOOP', activeRevision: state.active?.revisionId ?? null, desiredStateDigest, removals })
-      const active = await create(hostId, desired, inspected, state.active, removals, publication!)
+      const agentArtifacts = await loadArtifacts(() => options.effects.loadAgentArtifacts(desired))
+      const active = await create(hostId, desired, inspected, state.active, removals, publication!, agentArtifacts)
       return Object.freeze({ kind: 'APPLY', action: 'CREATE', activeRevision: active.revisionId, revisionId: active.revisionId, desiredStateDigest, removals })
     },
   })

--- a/apps/full-app/src/server/deployment/d1CommandEntry.ts
+++ b/apps/full-app/src/server/deployment/d1CommandEntry.ts
@@ -5,6 +5,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { Readable } from 'node:stream'
+import { AgentDefinitionValidationError, AgentDeploymentValidationError } from '@hachej/boring-agent/shared'
 
 import {
   closeAttestedD1DatabaseConnection,
@@ -21,14 +22,16 @@ import { createD1FencedDestructivePublication } from './fencedDestructivePublica
 import { D1HostError, D1HostErrorCode } from './d1Plan.js'
 import { createD1BindingSecretMaterializer, createD1RuntimeInputsInspector } from './d1SecretMaterializer.js'
 import { createHostRevisionStore } from './hostRevisionStore.js'
+import { loadD1AgentArtifactInputs } from './d1AgentArtifactSnapshot.js'
+import { D1_V1_COLLECTION_LIMITS, type D1CollectionLimits } from './bootCollection.js'
 
 const MAX_BYTES = 1024 * 1024
 const D1_APP_UID = 10001
 const D1_APP_GID = 10001
 export type D1EntryMode = '--read-only' | '--locked'
-export interface D1EntryContext { readonly hostId: string; readonly ownerUid: number; readonly stateRoot: string; readonly mutationGuard: D1MutationGuard; readonly admissionLedger?: D1AdmissionLedger }
+export interface D1EntryContext { readonly hostId: string; readonly ownerUid: number; readonly stateRoot: string; readonly collectionLimits: D1CollectionLimits; readonly mutationGuard: D1MutationGuard; readonly admissionLedger?: D1AdmissionLedger }
 export type D1DependencyFactory = (context: D1EntryContext) => D1CommandEngineOptions
-export interface D1EntryOptions { readonly stdin?: Readable; readonly mode: D1EntryMode; readonly dependencyFactory?: D1DependencyFactory; readonly databaseConnection?: AttestedD1DatabaseConnection }
+export interface D1EntryOptions { readonly stdin?: Readable; readonly mode: D1EntryMode; readonly collectionLimits?: D1CollectionLimits; readonly dependencyFactory?: D1DependencyFactory; readonly databaseConnection?: AttestedD1DatabaseConnection }
 export interface D1EntryOutput { readonly line: string; readonly exitCode: number }
 
 function invalid(field: string): never { throw new D1HostError(D1HostErrorCode.PLAN_INVALID, { field }) }
@@ -93,7 +96,7 @@ function assertInheritedLock(lockRoot: string, hostId: string, uid: number): voi
 }
 function unavailable(field: string): never { throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field }) }
 
-export const createProductionD1Dependencies: D1DependencyFactory = ({ hostId, ownerUid, stateRoot, mutationGuard, admissionLedger }) => {
+export const createProductionD1Dependencies: D1DependencyFactory = ({ hostId, ownerUid, stateRoot, collectionLimits, mutationGuard, admissionLedger }) => {
   const provider = createD1FileRuntimeInputsProvider({ hostId, ownerUid })
   const store = createHostRevisionStore({ root: stateRoot, ownerUid, appGid: D1_APP_GID })
   const fencedPublication = admissionLedger
@@ -103,6 +106,15 @@ export const createProductionD1Dependencies: D1DependencyFactory = ({ hostId, ow
     store,
     resolver: { resolvePlan: async () => unavailable('resolver'), reproduce: async () => unavailable('resolver') },
     effects: {
+      loadAgentArtifacts: (desired) => loadD1AgentArtifactInputs({
+        hostId, ownerUid, limits: collectionLimits,
+        inputs: desired.plan.bindings.map((binding, index) => ({ binding, compositionDigest: desired.resolvedBindings[index]!.composition.digest })),
+      }),
+      loadRevisionAgentArtifacts: async (target) => Promise.all(target.desired.plan.bindings.map(async (binding, index) => {
+        const envelope = await store.readAgentArtifact(hostId, target.revisionId, binding.bindingId)
+        if (!envelope) throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'agentArtifacts' })
+        return Object.freeze({ envelope })
+      })),
       loadAdmittedBindingIds: admissionLedger
         ? (requestedHostId, databaseRef) => admissionLedger.listBindingIds(requestedHostId, databaseRef)
         : async () => unavailable('admissions'),
@@ -140,11 +152,14 @@ export async function runD1CommandEntry(options: D1EntryOptions): Promise<D1Entr
     }
     admissionLedger = options.databaseConnection ? createD1AdmissionLedger(options.databaseConnection) : undefined
     const engine = createD1CommandEngine((options.dependencyFactory ?? createProductionD1Dependencies)({
-      hostId: command.hostId, ownerUid, stateRoot, mutationGuard: { assertHeld }, admissionLedger,
+      hostId: command.hostId, ownerUid, stateRoot, collectionLimits: options.collectionLimits ?? D1_V1_COLLECTION_LIMITS, mutationGuard: { assertHeld }, admissionLedger,
     }))
     const result = await engine.execute(raw)
     return { line: `${JSON.stringify({ ok: true, result })}\n`, exitCode: 0 }
   } catch (error) {
+    if (error instanceof AgentDefinitionValidationError || error instanceof AgentDeploymentValidationError) {
+      return failure(D1HostErrorCode.PUBLICATION_FAILED, 'agentArtifacts', 4)
+    }
     if (error instanceof D1HostError) {
       const field = typeof error.details.field === 'string' && /^[A-Za-z0-9.[\]_-]{1,80}$/.test(error.details.field) ? error.details.field : 'command'
       const exitCode = error.code === D1HostErrorCode.PLAN_INVALID ? 2 : error.code === D1HostErrorCode.REVISION_CONFLICT ? 3 : 4

--- a/apps/full-app/src/server/deployment/d1FileRuntimeInputsProvider.ts
+++ b/apps/full-app/src/server/deployment/d1FileRuntimeInputsProvider.ts
@@ -28,9 +28,9 @@ export interface D1FileRuntimeInputsProviderOptions {
   readonly valueRoot?: string
   readonly fault?: (point: 'metadata-root-open' | 'metadata-binding-open' | 'value-root-open' | 'value-binding-open') => void | Promise<void>
 }
-interface OwnerPolicy { readonly uid: number; readonly gid: number }
-interface CheckedDirectory { readonly path: string; readonly handle: FileHandle }
-interface CheckedRoot extends CheckedDirectory { readonly dev: number }
+export interface D1SecureOwnerPolicy { readonly uid: number; readonly gid: number }
+export interface D1SecureDirectory { readonly path: string; readonly handle: FileHandle }
+export interface D1SecureRoot extends D1SecureDirectory { readonly dev: number }
 interface SecretMetadata {
   readonly secretRef: string
   readonly providerVersionFingerprint: Sha256Digest
@@ -54,7 +54,7 @@ function exact(value: unknown, keys: readonly string[]): value is Record<string,
 function sameIdentity(left: Stats, right: Stats): boolean {
   return left.dev === right.dev && left.ino === right.ino
 }
-function exactMode(info: Stats, policy: OwnerPolicy, mode: number): boolean {
+function exactMode(info: Stats, policy: D1SecureOwnerPolicy, mode: number): boolean {
   return info.uid === policy.uid && info.gid === policy.gid && (info.mode & 0o7777) === mode
 }
 async function openedDirectory(directoryPath: string, requireCanonical = false): Promise<{ readonly handle: FileHandle; readonly after: Stats }> {
@@ -70,7 +70,7 @@ async function openedDirectory(directoryPath: string, requireCanonical = false):
     throw error
   }
 }
-async function checkedRoot(root: string, policy: OwnerPolicy, requireTmpfs: boolean): Promise<CheckedRoot> {
+export async function openD1SecureRoot(root: string, policy: D1SecureOwnerPolicy, requireTmpfs: boolean): Promise<D1SecureRoot> {
   if (!path.isAbsolute(root) || path.resolve(root) !== root) throw new Error('root')
   let current = path.parse(root).root; let handle: FileHandle | undefined
   try {
@@ -81,7 +81,8 @@ async function checkedRoot(root: string, policy: OwnerPolicy, requireTmpfs: bool
         if (!exactMode(opened.after, policy, 0o700)) { await opened.handle.close(); throw new Error('root policy') }
         handle = opened.handle
       } else {
-        try { if (![0, policy.uid].includes(opened.after.uid) || (opened.after.mode & 0o022) !== 0) throw new Error('ancestor policy') }
+        try { if (![0, policy.uid].includes(opened.after.uid) || ((opened.after.mode & 0o022) !== 0
+          && !(opened.after.uid === 0 && (opened.after.mode & 0o1000) !== 0))) throw new Error('ancestor policy') }
         finally { await opened.handle.close() }
       }
     }
@@ -92,13 +93,14 @@ async function checkedRoot(root: string, policy: OwnerPolicy, requireTmpfs: bool
     return Object.freeze({ path: anchored, dev: info.dev, handle })
   } catch (error) { if (handle) await handle.close(); throw error }
 }
-async function checkedDirectory(directoryPath: string, parent: CheckedDirectory, root: CheckedRoot, policy: OwnerPolicy, mode = 0o700): Promise<CheckedDirectory> {
+export async function openD1SecureDirectory(directoryPath: string, parent: D1SecureDirectory, root: D1SecureRoot, policy: D1SecureOwnerPolicy, mode = 0o700): Promise<D1SecureDirectory> {
   if (path.dirname(directoryPath) !== parent.path) throw new Error('directory root')
   const opened = await openedDirectory(directoryPath)
   if (opened.after.dev !== root.dev || !exactMode(opened.after, policy, mode)) { await opened.handle.close(); throw new Error('directory policy') }
   return Object.freeze({ path: `/proc/self/fd/${opened.handle.fd}`, handle: opened.handle })
 }
-async function checkedFile(filePath: string, root: CheckedRoot, policy: OwnerPolicy, maxBytes: number): Promise<Uint8Array> {
+export async function readD1SecureFile(filePath: string, root: D1SecureRoot, policy: D1SecureOwnerPolicy, maxBytes: number,
+  afterOpen?: () => void | Promise<void>, expectedPath?: string): Promise<Uint8Array> {
   const before = await lstat(filePath)
   if (!before.isFile() || before.isSymbolicLink()) throw new Error('file')
   const handle = await open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW)
@@ -106,9 +108,10 @@ async function checkedFile(filePath: string, root: CheckedRoot, policy: OwnerPol
   try {
     const initial = await handle.stat()
     if (!initial.isFile() || !sameIdentity(before, initial) || initial.dev !== root.dev || !exactMode(initial, policy, 0o400) || initial.nlink !== 1 || initial.size < 1 || initial.size > maxBytes) throw new Error('file policy')
-    source = await handle.readFile()
+    await afterOpen?.(); source = await handle.readFile()
     const final = await handle.stat()
     if (!sameIdentity(initial, final) || final.size !== initial.size || final.mtimeMs !== initial.mtimeMs || final.ctimeMs !== initial.ctimeMs || source.byteLength !== initial.size) throw new Error('file changed')
+    if (expectedPath && await realpath(`/proc/self/fd/${handle.fd}`) !== expectedPath) throw new Error('file slot')
     return Uint8Array.from(source)
   } finally { source?.fill(0); await handle.close() }
 }
@@ -150,7 +153,7 @@ function sameEntries(actual: readonly string[], expected: readonly string[]): bo
 }
 
 export function createD1FileRuntimeInputsProvider(options: D1FileRuntimeInputsProviderOptions): D1BindingSecretProvider {
-  let hostId: string; let policy: OwnerPolicy
+  let hostId: string; let policy: D1SecureOwnerPolicy
   try {
     if (!Number.isSafeInteger(options.ownerUid) || options.ownerUid < 0 || typeof process.geteuid !== 'function' || typeof process.getegid !== 'function' || process.geteuid() !== options.ownerUid) throw new Error('owner')
     hostId = safeSegment(options.hostId); policy = Object.freeze({ uid: options.ownerUid, gid: process.getegid() })
@@ -159,16 +162,16 @@ export function createD1FileRuntimeInputsProvider(options: D1FileRuntimeInputsPr
   const valuePath = options.valueRoot ?? D1_RUNTIME_INPUTS_VALUE_ROOT
   const loadManifest = async (binding: D1SiteBindingV1): Promise<ParsedManifest> => {
     const bindingId = safeSegment(binding.bindingId)
-    const root = await checkedRoot(metadataPath, policy, false)
+    const root = await openD1SecureRoot(metadataPath, policy, false)
     try {
       await options.fault?.('metadata-root-open')
-      const hostRoot = await checkedDirectory(path.join(root.path, hostId), root, root, policy)
+      const hostRoot = await openD1SecureDirectory(path.join(root.path, hostId), root, root, policy)
       try {
-        const bindingRoot = await checkedDirectory(path.join(hostRoot.path, bindingId), hostRoot, root, policy)
+        const bindingRoot = await openD1SecureDirectory(path.join(hostRoot.path, bindingId), hostRoot, root, policy)
         try {
           await options.fault?.('metadata-binding-open')
           if (!sameEntries(await readdir(bindingRoot.path), ['manifest.json'])) throw new Error('metadata entries')
-          const bytes = await checkedFile(path.join(bindingRoot.path, 'manifest.json'), root, policy, MAX_MANIFEST_BYTES)
+          const bytes = await readD1SecureFile(path.join(bindingRoot.path, 'manifest.json'), root, policy, MAX_MANIFEST_BYTES)
           try { return parseManifest(JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown, hostId, binding) }
           finally { bytes.fill(0) }
         } finally { await bindingRoot.handle.close() }
@@ -184,23 +187,23 @@ export function createD1FileRuntimeInputsProvider(options: D1FileRuntimeInputsPr
       try {
         const manifest = await loadManifest(binding)
         if (manifest.secrets.length === 0) return Object.freeze({ bindingId: binding.bindingId, secrets: Object.freeze([]) })
-        const root = await checkedRoot(valuePath, policy, true)
+        const root = await openD1SecureRoot(valuePath, policy, true)
         try {
           await options.fault?.('value-root-open')
-          const hostRoot = await checkedDirectory(path.join(root.path, hostId), root, root, policy)
+          const hostRoot = await openD1SecureDirectory(path.join(root.path, hostId), root, root, policy)
           try {
-            const bindingRoot = await checkedDirectory(path.join(hostRoot.path, safeSegment(binding.bindingId)), hostRoot, root, policy)
+            const bindingRoot = await openD1SecureDirectory(path.join(hostRoot.path, safeSegment(binding.bindingId)), hostRoot, root, policy)
             try {
               await options.fault?.('value-binding-open')
               if (!sameEntries(await readdir(bindingRoot.path), ['generations'])) throw new Error('value entries')
-              const generationsRoot = await checkedDirectory(path.join(bindingRoot.path, 'generations'), bindingRoot, root, policy)
+              const generationsRoot = await openD1SecureDirectory(path.join(bindingRoot.path, 'generations'), bindingRoot, root, policy)
               try {
-                const generationRoot = await checkedDirectory(path.join(generationsRoot.path, manifest.valueGeneration), generationsRoot, root, policy, 0o500)
+                const generationRoot = await openD1SecureDirectory(path.join(generationsRoot.path, manifest.valueGeneration), generationsRoot, root, policy, 0o500)
                 try {
                   if (!sameEntries(await readdir(generationRoot.path), manifest.secrets.map((secret) => secret.file))) throw new Error('value entries')
                   let total = 0; const secrets: D1ProvidedSecretV1[] = []
                   for (const metadata of manifest.secrets) {
-                    const value = await checkedFile(path.join(generationRoot.path, metadata.file), root, policy, MAX_SECRET_BYTES)
+                    const value = await readD1SecureFile(path.join(generationRoot.path, metadata.file), root, policy, MAX_SECRET_BYTES)
                     owned.push(value); total += value.byteLength
                     if (total > MAX_TOTAL_BYTES) throw new Error('value total')
                     secrets.push(Object.freeze({ secretRef: metadata.secretRef, providerVersionFingerprint: metadata.providerVersionFingerprint, value }))

--- a/apps/full-app/src/server/deployment/d1Plan.ts
+++ b/apps/full-app/src/server/deployment/d1Plan.ts
@@ -135,7 +135,7 @@ function parseBinding(value: unknown, index: number): D1SiteBindingV1 {
   unique(secretRefs, `${field}.secretRefs`)
   const hostname = strictD1Hostname(input.hostname, `${field}.hostname`)
   const bindingId = strictD1Ref(input.bindingId, `${field}.bindingId`)
-  if (bindingId.length > 251) invalidD1Field(`${field}.bindingId`)
+  if (bindingId.length > 250) invalidD1Field(`${field}.bindingId`)
 
   return Object.freeze({
     bindingId,

--- a/apps/full-app/src/server/deployment/hostRevisionStore.ts
+++ b/apps/full-app/src/server/deployment/hostRevisionStore.ts
@@ -5,7 +5,8 @@ import path from 'node:path'
 import type { Sha256Digest } from '@hachej/boring-agent/shared'
 
 import { renderD1BindingEnv, validateD1BindingEnv } from './d1BindingEnv.js'
-import { assertD1ExactKeys as exactKeys, D1HostError, D1HostErrorCode, strictD1HostId } from './d1Plan.js'
+import { canonicalizeD1AgentArtifactEnvelope, validateD1AgentArtifact, type D1AgentArtifactEnvelopeV1, type D1LoadedAgentArtifact } from './d1AgentArtifactSnapshot.js'
+import { assertD1ExactKeys as exactKeys, D1HostError, D1HostErrorCode, strictD1HostId, strictD1Ref } from './d1Plan.js'
 import {
   canonicalizeD1ActiveEnvelope,
   canonicalizeD1AuditRecord,
@@ -37,11 +38,12 @@ export interface D1StoredCompleteV1 extends D1StoredCandidateV1 {
 }
 export interface D1HostRevisionStore {
   reserveRevisionId(hostId: string): Promise<string>
-  writeCandidate(hostId: string, revisionId: string, desired: D1DesiredSnapshotV1): Promise<D1StoredCandidateV1>
+  writeCandidate(hostId: string, revisionId: string, desired: D1DesiredSnapshotV1, agentArtifacts: readonly D1LoadedAgentArtifact[]): Promise<D1StoredCandidateV1>
   readCandidate(hostId: string, revisionId: string): Promise<D1StoredCandidateV1 | null>
   writeObservation(hostId: string, revisionId: string, observation: D1ObservationV1): Promise<D1ObservationV1>
   writeComplete(hostId: string, revisionId: string): Promise<D1StoredCompleteV1>
   readComplete(hostId: string, revisionId: string): Promise<D1StoredCompleteV1 | null>
+  readAgentArtifact(hostId: string, revisionId: string, bindingId: string): Promise<D1AgentArtifactEnvelopeV1 | null>
   readActive(hostId: string): Promise<D1ActiveEnvelopeV1 | null>
   publishActive(hostId: string, revisionId: string): Promise<D1ActiveEnvelopeV1>
   readAuditRecords(hostId: string): Promise<readonly D1AuditRecordV1[]>
@@ -272,9 +274,23 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
         return `r${String(next).padStart(10, '0')}`
       } catch { mapped(D1HostErrorCode.REVISION_CONFLICT, 'sequence') }
     },
-    async writeCandidate(host, revision, rawDesired) {
+    async writeCandidate(host, revision, rawDesired, agentArtifacts) {
       const desired = await canonicalizeD1DesiredSnapshot(rawDesired)
       if (desired.plan.hostId !== hostId(host)) mapped(D1HostErrorCode.PLAN_INVALID, 'desired.plan.hostId')
+      let serializedArtifacts: readonly { readonly bindingId: string; readonly value: string }[] = []
+      try {
+        {
+          if (agentArtifacts.length !== desired.plan.bindings.length) mapped(D1HostErrorCode.PUBLICATION_FAILED, 'agentArtifacts')
+          serializedArtifacts = await Promise.all(desired.plan.bindings.map(async (binding, index) => {
+            const artifact = agentArtifacts[index]; const expected = desired.resolvedBindings[index]
+            if (artifact && expected) await validateD1AgentArtifact(artifact.envelope, binding, expected)
+            if (!artifact || artifact.envelope.hostId !== host || artifact.envelope.bindingId !== binding.bindingId
+              || artifact.envelope.bundleRef !== binding.bundleRef || artifact.envelope.deploymentRef !== binding.deploymentRef) throw new Error()
+            return { bindingId: binding.bindingId, value: JSON.stringify(artifact.envelope) }
+          }))
+        }
+      } catch { mapped(D1HostErrorCode.PUBLICATION_FAILED, 'agentArtifacts') }
+      let writingArtifacts = false
       try {
         const { hostDirectory, revisions } = await ensureHost(host)
         if ((await readRegular(path.join(hostDirectory, 'sequence'), privateFile))!.trim() !== String(Number(revisionId(revision).slice(1)))) mapped(D1HostErrorCode.REVISION_CONFLICT, 'revisionId')
@@ -299,6 +315,15 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
         }
         await syncDirectory(bindingsDirectory, 'bindings', privateDirectory)
         await finalizeDirectory(bindingsDirectory, 'bindings', privateDirectory, redactedDirectory)
+        {
+          writingArtifacts = true
+          const artifactsDirectory = path.join(temporary, 'agent-artifacts')
+          await mkdir(artifactsDirectory, { mode: 0o700 }); await directory(artifactsDirectory, 'agentArtifacts', privateDirectory)
+          for (const artifact of serializedArtifacts) await createDurable(path.join(artifactsDirectory, `${artifact.bindingId}.json`), artifact.value, redactedFile)
+          await syncDirectory(artifactsDirectory, 'agentArtifacts', privateDirectory)
+          await finalizeDirectory(artifactsDirectory, 'agentArtifacts', privateDirectory, redactedDirectory)
+          writingArtifacts = false
+        }
         await syncDirectory(temporary, 'candidate', privateDirectory)
         await finalizeDirectory(temporary, 'candidate', privateDirectory, redactedDirectory)
         await rename(temporary, target)
@@ -306,6 +331,7 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
         return Object.freeze({ revisionId: revision, desired, desiredStateDigest, secretRefs })
       } catch (error) {
         if (error instanceof D1HostError) throw error
+        if (writingArtifacts) mapped(D1HostErrorCode.PUBLICATION_FAILED, 'agentArtifacts')
         mapped(D1HostErrorCode.REVISION_CONFLICT, 'candidate')
       }
     },
@@ -348,6 +374,27 @@ export function createHostRevisionStore(options: D1HostRevisionStoreOptions): D1
     async readComplete(host, revision) {
       hostId(host); revisionId(revision)
       try { return await loadComplete(host, revision) } catch { mapped(D1HostErrorCode.ROLLBACK_TARGET_INVALID, 'targetRevision') }
+    },
+    async readAgentArtifact(host, revision, requestedBindingId) {
+      hostId(host); revisionId(revision); const safeBindingId = strictD1Ref(requestedBindingId, 'bindingId')
+      try {
+        const candidate = await loadCandidate(host, revision)
+        if (!candidate) return null
+        const binding = candidate.desired.plan.bindings.find((value) => value.bindingId === safeBindingId)
+        if (!binding) mapped(D1HostErrorCode.PUBLICATION_FAILED, 'agentArtifacts')
+        const revisionDirectoryPath = await revisionDirectory(host, revision)
+        const artifactsDirectory = path.join(revisionDirectoryPath!, 'agent-artifacts')
+        await directory(artifactsDirectory, 'agentArtifacts', redactedDirectory)
+        const raw = await readRegular(path.join(artifactsDirectory, `${safeBindingId}.json`), redactedFile, true)
+        if (raw === null) return null
+        const envelope = canonicalizeD1AgentArtifactEnvelope(json(raw), host, binding)
+        const expected = candidate.desired.resolvedBindings.find((value) => value.bindingId === safeBindingId)!
+        await validateD1AgentArtifact(envelope, binding, expected)
+        return envelope
+      } catch (error) {
+        if (error instanceof D1HostError && error.code === D1HostErrorCode.PUBLICATION_FAILED) throw error
+        mapped(D1HostErrorCode.PUBLICATION_FAILED, 'agentArtifacts')
+      }
     },
     async readActive(host) {
       hostId(host)


### PR DESCRIPTION
## Summary

Add the immutable D1 agent-artifact snapshot prerequisite for atomic collection publication. Every new candidate revision now contains an exact, validated agent recipe per binding, and rollback copies artifacts from the immutable target revision rather than the mutable inbox.

## Issue / Slice

- Bead: `wt-391-forward-vup.2.1.1.1`
- Slice: D1 immutable agent artifact snapshot prerequisite for A0
- Reviewed SHA: `370a0f95a13e37553235a850bacaa2d3a438cdb8`
- Size: 423 insertions / 52 deletions = **+371 net** (hard ceiling: 400)

## What Changed

- Load fixed-slot inbox artifacts through descriptor-anchored, same-device, owner/mode/link/race-checked filesystem reads.
- Canonicalize and validate bundle/deployment envelopes against each binding and resolved identity before candidate staging.
- Persist exact artifacts inside the revision before the existing atomic directory rename.
- Require an exact artifact array for every candidate; no artifactless writer escape exists.
- Make rollback load the target revision's immutable artifacts and forward that exact set to the replacement revision.
- Use one frozen Decision-25 v1 collection policy (`20` bindings, `64 MiB` per bundle, `1 GiB` total, concurrency `4`) for standalone production; embedding may inject the same `D1CollectionLimits` object.
- Preserve direct agent validation codes while mapping the external command boundary to `D1_PUBLICATION_FAILED / agentArtifacts`.
- Align binding IDs to the `<bindingId>.json` `NAME_MAX` constraint.

### Decision 25 exclusions

This is load-bearing core only. It does **not** extend or consume:

- `approved-host-release` / `approvedHostArtifactEvidence`
- `hostSecurityConfig`, Caddyfile, or deferred core-env authority
- `RuntimeIsolationEvidenceV1` / `VerifiedD1HostExecution`
- release-approval ceremony, `d1_proof` DB, or approved-host-release installation
- custom runsc launchers or provider attestation

Those remain deferred behind their dedicated beads.

## Proof

- Exact command:
  `pnpm exec vitest run src/server/deployment/__tests__/d1AgentArtifactSnapshot.test.ts src/server/deployment/__tests__/hostRevisionStore.test.ts src/server/deployment/__tests__/d1ProductionDependencies.test.ts src/server/deployment/__tests__/d1Command.test.ts src/server/deployment/__tests__/d1CommandCli.test.ts src/server/deployment/__tests__/d1Plan.test.ts src/server/deployment/__tests__/activeCollectionReader.test.ts src/server/deployment/__tests__/d1FileRuntimeInputsProvider.test.ts`
  - Result: **8 files, 175 tests passed**.
- Exact command: `pnpm run typecheck`
  - Result: passed (`tsc --noEmit`).
- Exact command: `git diff --check`
  - Result: passed.
- Remote proof: `git ls-remote --heads origin agent/391-d1-artifact-snapshot`
  - Result: `370a0f95a13e37553235a850bacaa2d3a438cdb8`.
- Screenshot/demo: N/A, server-side publication contract.
- Manual validation: N/A; behavior is covered at inbox, store, command, production dependency, CLI, and active-reader seams.

## Review

- Standards/spec: final P0/P1 clean. Standalone wrapper path, atomic persistence, exact rollback forwarding, fixed-slot races, stable errors, limits, and Decision-25 exclusions verified.
- Thermo: security duplication removed by reusing the landed checked-tree primitives; required artifact invariant, pre-staging validation, and rollback target selection verified. Moving the shared primitives into a separate file was consciously deferred to avoid unrelated churn in this capped leaf.
- Structured autoreview: production CLI limits regression and external error mapping were accepted and fixed.
- Inode-owner proof: resolved without privilege escalation by mocking only the process identity seam while leaving the fixture inode owned by the real UID; the test reaches and rejects the wrong-owner metadata branch.

## Risk / Rollback

- Pre-snapshot revisions cannot be rollback targets because they have no authenticated executable artifact. This intentionally fails closed as `D1_PUBLICATION_FAILED / agentArtifacts` before revision reservation.
- The standalone v1 limits are intentionally built into the load-bearing core; later root wiring may inject the same shared type/source without changing this contract.
- Filesystem validation is Linux-specific and depends on `/proc/self/fd`, matching the D1 host contract.
- Code rollback: revert `370a0f95a13e37553235a850bacaa2d3a438cdb8`. No database migration or release ceremony is introduced.

## Next

- A0: wire the revision's immutable agent artifacts into collection preload and atomic publication.
- First blocker: `merge` after CI is green; do not merge before required checks pass.