### PR TITLE
feat(d1): load deployed agent runtime recipe

### DIFF
--- a/apps/full-app/src/server/__tests__/boringMcp.test.ts
+++ b/apps/full-app/src/server/__tests__/boringMcp.test.ts
@@ -39,6 +39,7 @@ const authenticated = { authorization: 'Bearer test' }
 const scopedRequest = {
   bindingId: 'binding-1', workspaceId: actor.workspaceId,
   defaultDeploymentId: 'deployment-1', activeRevision: 'revision-1',
+  resolvedDigest: `sha256:${'a'.repeat(64)}`,
 } as const
 const routeTestConfig: CoreConfig = {
   appId: 'full-app-test', appName: 'Test', appLogo: null, port: 0, host: '127.0.0.1', staticDir: null,

--- a/apps/full-app/src/server/__tests__/managedAgentMcp.test.ts
+++ b/apps/full-app/src/server/__tests__/managedAgentMcp.test.ts
@@ -376,6 +376,7 @@ function scopedRequest(workspaceId = WORKSPACE_ID): CoreRequestScope {
     workspaceId,
     defaultDeploymentId: DEFAULT_DEPLOYMENT_ID,
     activeRevision: 'revision-1',
+    resolvedDigest: `sha256:${'a'.repeat(64)}`,
   })
 }
 

--- a/apps/full-app/src/server/deployment/__tests__/activeCollectionReader.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/activeCollectionReader.test.ts
@@ -20,7 +20,7 @@ const OWNER_UID = process.geteuid!()
 const APP_GID = process.getegid!() || 10001
 const run = promisify(execFile)
 
-async function desired(): Promise<D1DesiredSnapshotV1> {
+async function desired(content = 'Compare policies.'): Promise<D1DesiredSnapshotV1> {
   const snapshot = canonicalizeWorkspaceCompositionSnapshot({
     schemaVersion: 1, domain: 'boring-workspace-composition:v1', workspaceId: 'workspace:insurance',
     runtimeProfile: {
@@ -32,7 +32,7 @@ async function desired(): Promise<D1DesiredSnapshotV1> {
     policies: { externalPlugins: false, pluginAuthoring: false },
   })
   const compositionDigest = await createAgentAssetDigest(JSON.stringify(snapshot))
-  const instructions = { path: 'instructions.md', content: 'Compare policies.', digest: await createAgentAssetDigest('Compare policies.') }
+  const instructions = { path: 'instructions.md', content, digest: await createAgentAssetDigest(content) }
   const compiledDefinition = { schemaVersion: 1 as const, definitionId: 'definition:insurance', version: '1.0.0', instructionsRef: instructions.path }
   const definition = { definitionId: compiledDefinition.definitionId, version: compiledDefinition.version, instructionsRef: compiledDefinition.instructionsRef,
     digest: await createAgentDefinitionDigest({ definition: compiledDefinition, assets: [instructions] }) }
@@ -76,14 +76,14 @@ async function observation(value: D1DesiredSnapshotV1, ready = true) {
   }
 }
 
-async function fixture(complete = true) {
+async function fixture(complete = true, content = 'Compare policies.') {
   const parent = await mkdtemp(path.join(os.tmpdir(), 'boring-d1-active-reader-'))
   const root = path.join(parent, 'state')
   const store = createHostRevisionStore({ root, ownerUid: OWNER_UID, appGid: APP_GID })
-  const value = await desired()
+  const value = await desired(content)
   const revisionId = await store.reserveRevisionId('host-1')
   const binding = value.plan.bindings[0]!; const definition = value.resolvedBindings[0]!.definition
-  const content = 'Compare policies.'; const asset = { path: definition.instructionsRef, content, digest: await createAgentAssetDigest(content) }
+  const asset = { path: definition.instructionsRef, content, digest: await createAgentAssetDigest(content) }
   const bundleDefinition = { schemaVersion: 1 as const, definitionId: definition.definitionId, version: definition.version, instructionsRef: asset.path }
   const bundle = { definition: bundleDefinition, definitionDigest: definition.digest, assets: [asset] }
   const deployment = { deploymentId: binding.defaultDeploymentId, version: '2026.07.12', agentId: 'default',
@@ -127,6 +127,26 @@ describe('D1 mounted active collection reader', () => {
     expect(Object.isFrozen(collection)).toBe(true)
     expect(Object.isFrozen(collection!.desired.plan.bindings)).toBe(true)
     expect(collection).not.toHaveProperty('secretRefs')
+  })
+
+  it('reads the selected artifact only while the same active revision remains current', async () => {
+    const h = await fixture(); const activeReader = reader(h.hostRoot); const collection = (await activeReader.read())!
+    const binding = collection.desired.plan.bindings[0]!
+    await expect(activeReader.readAgentArtifact(collection, binding)).resolves.toMatchObject({
+      bindingId: binding.bindingId, bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef,
+    })
+    const activeFile = path.join(h.hostRoot, 'active'); await chmod(activeFile, 0o600)
+    await writeFile(activeFile, JSON.stringify({ ...collection.active, revisionId: 'r0000000002' })); await chmod(activeFile, 0o440)
+    await expect(activeReader.readAgentArtifact(collection, binding)).rejects.toMatchObject({
+      code: D1HostErrorCode.PUBLICATION_FAILED, details: { field: 'agentArtifacts' },
+    })
+  })
+
+  it('serves a valid immutable artifact above the general revision-file cap', async () => {
+    const content = 'x'.repeat(4 * 1024 * 1024 + 1); const h = await fixture(true, content)
+    const activeReader = reader(h.hostRoot); const collection = (await activeReader.read())!
+    const artifact = await activeReader.readAgentArtifact(collection, collection.desired.plan.bindings[0]!)
+    expect(artifact.bundle.assets[0]!.content).toHaveLength(content.length)
   })
 
   it('returns null only for a valid mounted host tree without active', async () => {

--- a/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
@@ -97,7 +97,7 @@ describe('D1 readiness and activation wiring', () => {
     expect(euid).not.toHaveBeenCalled()
     const wiring = createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '0' })!
     expect(Object.isFrozen(wiring)).toBe(true)
-    expect(Object.keys(wiring)).toEqual(['requestScopeResolver', 'frontendRootHandler', 'admitAgentEffect', 'registerReadiness'])
+    expect(Object.keys(wiring)).toEqual(['requestScopeResolver', 'frontendRootHandler', 'admitAgentEffect', 'resolveAgentRuntimeIdentity', 'resolveAgentRuntimeRecipe', 'registerReadiness'])
     expect(createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '4294967294' })).toBeDefined()
 
     const source = await readFile(new URL('../d1ServerWiring.ts', import.meta.url), 'utf8')
@@ -107,6 +107,7 @@ describe('D1 readiness and activation wiring', () => {
     expect(source).not.toMatch(/BORING_D1_(?:STATE_ROOT|APP_GID|ROOT)/)
     expect(main.indexOf('createD1ServerWiring(config)')).toBeLessThan(main.indexOf('createFullAppHostPluginComposition(config)'))
     expect(main).toContain('admitEffect: d1.admitAgentEffect')
+    expect(main).toContain('getRuntimeScopeContribution: async')
     expect(main.indexOf('d1?.registerReadiness(app)')).toBeLessThan(main.indexOf('registerFullAppBoringMcpRoutes(app)'))
     expect(main.indexOf('registerFullAppBoringMcpRoutes(app)')).toBeLessThan(main.indexOf('app.listen('))
   })

--- a/apps/full-app/src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts
@@ -1,0 +1,67 @@
+import { createAgentAssetDigest, createAgentDefinitionDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
+import { resolveAgentDeployment } from '@hachej/boring-agent/server'
+import { describe, expect, it } from 'vitest'
+
+import type { D1AgentArtifactEnvelopeV1 } from '../d1AgentArtifactSnapshot.js'
+import { createD1AgentRuntimeIdentityResolver, createD1AgentRuntimeRecipeResolver } from '../d1AgentRuntimeRecipe.js'
+import type { D1ActiveCollection, D1AgentArtifactReader } from '../activeCollectionReader.js'
+import { D1HostErrorCode, type D1SiteBindingV1 } from '../d1Plan.js'
+
+const digest = (value: string): Sha256Digest => `sha256:${(value.charCodeAt(0) % 16).toString(16).repeat(64)}`
+
+async function deployed(id: string, content: string) {
+  const asset = { path: 'instructions.md', content, digest: await createAgentAssetDigest(content) }
+  const definition = { schemaVersion: 1 as const, definitionId: `definition:${id}`, version: '1.0.0', instructionsRef: asset.path }
+  const bundle = { definition, definitionDigest: await createAgentDefinitionDigest({ definition, assets: [asset] }), assets: [asset] }
+  const binding = { bindingId: id, hostname: `${id}.example.test`, workspaceId: `workspace:${id}`,
+    defaultDeploymentId: `deployment:${id}`, bundleRef: `bundle:${id}`, deploymentRef: `deployment-ref:${id}`,
+    workspaceAllocationRef: 'workspace', sessionAllocationRef: 'session', ownerPrincipalRef: 'owner',
+    landing: { title: id, summary: id }, environmentRef: 'production', secretRefs: [] } satisfies D1SiteBindingV1
+  const deployment = { deploymentId: binding.defaultDeploymentId, version: '1.0.0', agentId: 'default',
+    definition: { definitionId: definition.definitionId, version: definition.version, digest: bundle.definitionDigest } }
+  const compositionDigest = digest(id)
+  const resolved = await resolveAgentDeployment(bundle, deployment, { workspaceId: binding.workspaceId,
+    defaultDeploymentId: binding.defaultDeploymentId, workspaceCompositionDigest: compositionDigest })
+  const envelope = { schemaVersion: 1, domain: 'boring-d1-agent-artifact:v1', hostId: 'host-1', bindingId: binding.bindingId,
+    bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, bundle, deployment } satisfies D1AgentArtifactEnvelopeV1
+  return { binding, envelope, resolved: { schemaVersion: 1, bindingId: binding.bindingId,
+    composition: { snapshot: {} as never, digest: compositionDigest }, ...resolved } }
+}
+
+describe('D1 deployed-agent runtime recipe', () => {
+  it('returns exact immutable workspace recipes without sibling prompt leakage', async () => {
+    const first = await deployed('insurance', 'Compare insurance only.'); const second = await deployed('travel', 'Compare travel only.')
+    const collection = { active: { schemaVersion: 1, revisionId: 'r0000000001', desiredStateDigest: digest('a') },
+      desired: { plan: { bindings: [first.binding, second.binding] }, resolvedBindings: [first.resolved, second.resolved] } } as unknown as D1ActiveCollection
+    const artifacts = new Map([[first.binding.bindingId, first.envelope], [second.binding.bindingId, second.envelope]])
+    let artifactReads = 0
+    const reader = { async read() { return collection }, async readAgentArtifact(snapshot, binding) {
+      artifactReads += 1
+      expect(snapshot).toBe(collection); return artifacts.get(binding.bindingId)!
+    } } satisfies D1AgentArtifactReader
+    const identity = await createD1AgentRuntimeIdentityResolver(reader)(first.binding.workspaceId)
+    expect(identity).toEqual({ workspaceId: first.binding.workspaceId, defaultDeploymentId: first.binding.defaultDeploymentId,
+      resolvedDigest: first.resolved.resolvedDigest, activeRevision: collection.active.revisionId })
+    expect(artifactReads).toBe(0)
+    const resolve = createD1AgentRuntimeRecipeResolver(reader)
+    const insurance = await resolve(first.binding.workspaceId, collection.active.revisionId)
+    const travel = await resolve(second.binding.workspaceId, collection.active.revisionId)
+    expect(await resolve(first.binding.workspaceId)).toEqual(insurance)
+    expect(insurance).toEqual({ workspaceId: first.binding.workspaceId, defaultDeploymentId: first.binding.defaultDeploymentId,
+      resolvedDigest: first.resolved.resolvedDigest, instructions: { ref: 'instructions.md', content: 'Compare insurance only.' } })
+    expect(travel.instructions.content).toBe('Compare travel only.')
+    expect(JSON.stringify(insurance)).not.toContain('travel')
+    expect(Object.isFrozen(insurance)).toBe(true); expect(Object.isFrozen(insurance.instructions)).toBe(true)
+    expect(artifactReads).toBe(3)
+  })
+
+  it('fails before runtime creation on revision or persisted digest mismatch', async () => {
+    const value = await deployed('insurance', 'Compare insurance only.')
+    const collection = { active: { schemaVersion: 1, revisionId: 'r0000000001', desiredStateDigest: digest('a') },
+      desired: { plan: { bindings: [value.binding] }, resolvedBindings: [{ ...value.resolved, resolvedDigest: digest('f') }] } } as unknown as D1ActiveCollection
+    const reader = { async read() { return collection }, async readAgentArtifact() { return value.envelope } } satisfies D1AgentArtifactReader
+    const resolve = createD1AgentRuntimeRecipeResolver(reader)
+    await expect(resolve(value.binding.workspaceId, 'r0000000002')).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    await expect(resolve(value.binding.workspaceId)).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+  })
+})

--- a/apps/full-app/src/server/deployment/__tests__/d1Landing.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Landing.test.ts
@@ -10,6 +10,7 @@ import { D1HostErrorCode, type D1SiteBindingV1 } from '../d1Plan.js'
 const scope = Object.freeze({
   bindingId: 'insurance', workspaceId: 'workspace:insurance',
   defaultDeploymentId: 'deployment:insurance', activeRevision: 'r0000000042',
+  resolvedDigest: `sha256:${'b'.repeat(64)}`,
 })
 
 function binding(landing: D1SiteBindingV1['landing'] = { title: 'Insurance', summary: 'Compare policies.', ctaLabel: 'Start' }): D1SiteBindingV1 {

--- a/apps/full-app/src/server/deployment/__tests__/hostSurface.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/hostSurface.test.ts
@@ -14,6 +14,7 @@ const CLIENT = '198.51.100.7'
 const scope = {
   bindingId: 'insurance', workspaceId: 'workspace:insurance',
   defaultDeploymentId: 'deployment:insurance', activeRevision: 'r0000000042',
+  resolvedDigest: `sha256:${'b'.repeat(64)}`,
 } as const
 
 function collection(hostnames: readonly string[] = [HOST]): D1ActiveCollection {
@@ -23,7 +24,10 @@ function collection(hostnames: readonly string[] = [HOST]): D1ActiveCollection {
       hostname, bindingId: index === 0 ? scope.bindingId : `binding-${index}`,
       workspaceId: index === 0 ? scope.workspaceId : `workspace:${index}`,
       defaultDeploymentId: index === 0 ? scope.defaultDeploymentId : `deployment:${index}`,
-    })) } },
+    })) }, resolvedBindings: hostnames.map((_hostname, index) => ({
+      bindingId: index === 0 ? scope.bindingId : `binding-${index}`,
+      resolvedDigest: index === 0 ? scope.resolvedDigest : `sha256:${String(index).padStart(64, '0')}`,
+    })) },
   } as unknown as D1ActiveCollection
 }
 
@@ -92,7 +96,7 @@ describe('D1 host surface resolver', () => {
     await violation(Promise.resolve(resolver(reader().activeReader)(request(headers, peer, [peer], method, url))))
   })
 
-  it('resolves direct and exact-Caddy authorities per request as frozen four-key scopes', async () => {
+  it('resolves direct and exact-Caddy authorities per request as frozen scopes', async () => {
     const state = reader(); const resolve = resolver(state.activeReader)
     const direct = await resolve(request(['Host', HOST], CLIENT, [CLIENT]))
     const caddy = await resolve(request(
@@ -103,7 +107,7 @@ describe('D1 host surface resolver', () => {
     for (const result of [direct, caddy]) {
       expect(result).toEqual(scope)
       if (result === undefined) throw new Error('expected resolved D1 request scope')
-      expect(Object.keys(result)).toEqual(['bindingId', 'workspaceId', 'defaultDeploymentId', 'activeRevision'])
+      expect(Object.keys(result)).toEqual(['bindingId', 'workspaceId', 'defaultDeploymentId', 'activeRevision', 'resolvedDigest'])
       expect(Object.isFrozen(result)).toBe(true)
     }
     expect(state.calls()).toBe(2)
@@ -210,13 +214,13 @@ describe('D1 host surface resolver', () => {
     expect((await app.inject({ method: 'GET', url: '/generic' })).body).toBe('{"ok":true}')
   })
 
-  it('attaches only a frozen four-key scope and performs no auth or membership lookup', async () => {
+  it('attaches only the frozen deployment scope and performs no auth or membership lookup', async () => {
     const extra = { ...scope, ignored: 'value' } as CoreRequestScope
     app = await createCoreApp(TEST_CONFIG, { manageShutdown: false, requestScopeResolver: async () => extra })
     app.get('/scope', async (request) => ({ keys: Object.keys(request.requestScope!), frozen: Object.isFrozen(request.requestScope) }))
     await app.ready()
     expect(JSON.parse((await app.inject({ method: 'GET', url: '/scope' })).body)).toEqual({
-      keys: ['bindingId', 'workspaceId', 'defaultDeploymentId', 'activeRevision'], frozen: true,
+      keys: ['bindingId', 'workspaceId', 'defaultDeploymentId', 'activeRevision', 'resolvedDigest'], frozen: true,
     })
     const source = await readFile(new URL('../hostSurface.ts', import.meta.url), 'utf8')
     expect(source).not.toMatch(/workspaceStore|isMember|membership|authenticate|cache|watch|landing/)

--- a/apps/full-app/src/server/deployment/activeCollectionReader.ts
+++ b/apps/full-app/src/server/deployment/activeCollectionReader.ts
@@ -2,8 +2,10 @@ import { constants, type Stats } from 'node:fs'
 import { lstat, open, realpath } from 'node:fs/promises'
 import path from 'node:path'
 
+import { D1_V1_COLLECTION_LIMITS } from './bootCollection.js'
 import { validateD1BindingEnv } from './d1BindingEnv.js'
-import { assertD1ExactKeys as exactKeys, D1HostError, D1HostErrorCode, strictD1HostId } from './d1Plan.js'
+import { canonicalizeD1AgentArtifactEnvelope, type D1AgentArtifactEnvelopeV1 } from './d1AgentArtifactSnapshot.js'
+import { assertD1ExactKeys as exactKeys, D1HostError, D1HostErrorCode, strictD1HostId, type D1SiteBindingV1 } from './d1Plan.js'
 import {
   canonicalizeD1ActiveEnvelope,
   canonicalizeD1CompleteEnvelope,
@@ -34,6 +36,9 @@ export interface D1ActiveCollection {
 export interface D1ActiveCollectionReader {
   read(): Promise<D1ActiveCollection | null>
 }
+export interface D1AgentArtifactReader extends D1ActiveCollectionReader {
+  readAgentArtifact(collection: D1ActiveCollection, binding: D1SiteBindingV1): Promise<D1AgentArtifactEnvelopeV1>
+}
 
 export interface D1ActiveCollectionReaderOptions {
   readonly hostRoot: string
@@ -48,8 +53,8 @@ function invalid(field: string): never {
   throw new D1HostError(D1HostErrorCode.PLAN_INVALID, { field })
 }
 
-function publicationFailed(): never {
-  throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'active' })
+function publicationFailed(field = 'active'): never {
+  throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field })
 }
 
 function exactMetadata(info: Stats, policy: FsPolicy, mode: number, links = false): boolean {
@@ -79,7 +84,7 @@ function json(content: string): unknown {
   return JSON.parse(content) as unknown
 }
 
-export function createD1ActiveCollectionReader(options: D1ActiveCollectionReaderOptions): D1ActiveCollectionReader {
+export function createD1ActiveCollectionReader(options: D1ActiveCollectionReaderOptions): D1AgentArtifactReader {
   if (typeof options?.hostRoot !== 'string' || options.hostRoot.includes('\0') || !path.isAbsolute(options.hostRoot)
     || path.resolve(options.hostRoot) !== options.hostRoot) invalid('hostRoot')
   let hostId: string
@@ -90,6 +95,21 @@ export function createD1ActiveCollectionReader(options: D1ActiveCollectionReader
   const policy = Object.freeze({ uid: options.ownerUid, gid: options.appGid })
 
   return Object.freeze({
+    async readAgentArtifact(collection: D1ActiveCollection, binding: D1SiteBindingV1) {
+      try {
+        const planned = collection.desired.plan.bindings.find((value) => value.bindingId === binding.bindingId)
+        if (planned !== binding) throw new Error('binding is not from active snapshot')
+        const revisionRoot = path.join(hostRoot, 'revisions', collection.active.revisionId)
+        const artifactsRoot = path.join(revisionRoot, 'agent-artifacts')
+        await assertDirectory(revisionRoot, policy); await assertDirectory(artifactsRoot, policy)
+        const envelope = canonicalizeD1AgentArtifactEnvelope(
+          json((await readFile(path.join(artifactsRoot, `${binding.bindingId}.json`), policy, false, D1_V1_COLLECTION_LIMITS.maxBundleBytes))!), hostId, binding,
+        )
+        const active = canonicalizeD1ActiveEnvelope(json((await readFile(path.join(hostRoot, 'active'), policy, false, 16 * 1024))!))
+        if (JSON.stringify(active) !== JSON.stringify(collection.active)) throw new Error('active revision changed')
+        return envelope
+      } catch { publicationFailed('agentArtifacts') }
+    },
     async read(): Promise<D1ActiveCollection | null> {
       try {
         if (await realpath(hostRoot) !== hostRoot) throw new Error('non-canonical host root')

--- a/apps/full-app/src/server/deployment/d1AgentRuntimeRecipe.ts
+++ b/apps/full-app/src/server/deployment/d1AgentRuntimeRecipe.ts
@@ -1,0 +1,76 @@
+import type { Sha256Digest } from '@hachej/boring-agent/shared'
+
+import { validateD1AgentArtifact } from './d1AgentArtifactSnapshot.js'
+import type { D1AgentArtifactReader } from './activeCollectionReader.js'
+import { D1HostError, D1HostErrorCode } from './d1Plan.js'
+
+export interface WorkspaceAgentRuntimeRecipe {
+  readonly workspaceId: string
+  readonly defaultDeploymentId: string
+  readonly resolvedDigest: Sha256Digest
+  readonly instructions: Readonly<{ ref: string; content: string }>
+}
+
+export interface WorkspaceAgentRuntimeIdentity {
+  readonly workspaceId: string
+  readonly defaultDeploymentId: string
+  readonly resolvedDigest: Sha256Digest
+  readonly activeRevision: string
+}
+
+export type D1AgentRuntimeIdentityResolver = (
+  workspaceId: string,
+  activeRevision?: string,
+) => Promise<WorkspaceAgentRuntimeIdentity>
+
+export type D1AgentRuntimeRecipeResolver = (
+  workspaceId: string,
+  activeRevision?: string,
+) => Promise<WorkspaceAgentRuntimeRecipe>
+
+function unavailable(): never {
+  throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'agentArtifacts' })
+}
+
+async function selectWorkspaceAgent(activeReader: D1AgentArtifactReader, workspaceId: string, activeRevision?: string) {
+  const collection = await activeReader.read()
+  if (!collection || (activeRevision !== undefined && collection.active.revisionId !== activeRevision)) unavailable()
+  const matches = collection.desired.plan.bindings.filter((binding) => binding.workspaceId === workspaceId)
+  if (matches.length !== 1) unavailable()
+  const binding = matches[0]!
+  const expected = collection.desired.resolvedBindings.find((value) => value.bindingId === binding.bindingId)
+  if (!expected) unavailable()
+  return { collection, binding, expected }
+}
+
+export function createD1AgentRuntimeIdentityResolver(
+  activeReader: D1AgentArtifactReader,
+): D1AgentRuntimeIdentityResolver {
+  return async (workspaceId, activeRevision) => {
+    const selected = await selectWorkspaceAgent(activeReader, workspaceId, activeRevision)
+    return Object.freeze({
+      workspaceId: selected.binding.workspaceId,
+      defaultDeploymentId: selected.binding.defaultDeploymentId,
+      resolvedDigest: selected.expected.resolvedDigest,
+      activeRevision: selected.collection.active.revisionId,
+    })
+  }
+}
+
+export function createD1AgentRuntimeRecipeResolver(
+  activeReader: D1AgentArtifactReader,
+): D1AgentRuntimeRecipeResolver {
+  return async (workspaceId, activeRevision) => {
+    const { collection, binding, expected } = await selectWorkspaceAgent(activeReader, workspaceId, activeRevision)
+    const envelope = await activeReader.readAgentArtifact(collection, binding)
+    await validateD1AgentArtifact(envelope, binding, expected)
+    const instructions = envelope.bundle.assets.find((asset) => asset.path === expected.definition.instructionsRef)
+    if (!instructions) unavailable()
+    return Object.freeze({
+      workspaceId: binding.workspaceId,
+      defaultDeploymentId: binding.defaultDeploymentId,
+      resolvedDigest: expected.resolvedDigest,
+      instructions: Object.freeze({ ref: instructions.path, content: instructions.content }),
+    })
+  }
+}

--- a/apps/full-app/src/server/deployment/d1ServerWiring.ts
+++ b/apps/full-app/src/server/deployment/d1ServerWiring.ts
@@ -9,6 +9,12 @@ import type { FastifyInstance } from 'fastify'
 import { createD1ActiveCollectionReader, type D1ActiveCollectionReader } from './activeCollectionReader.js'
 import type { D1AdmissionLedger } from './admissionLedger.js'
 import { createD1LandingRootHandler } from './d1Landing.js'
+import {
+  createD1AgentRuntimeIdentityResolver,
+  createD1AgentRuntimeRecipeResolver,
+  type D1AgentRuntimeIdentityResolver,
+  type D1AgentRuntimeRecipeResolver,
+} from './d1AgentRuntimeRecipe.js'
 import { D1HostError, D1HostErrorCode, invalidD1Field, strictD1HostId } from './d1Plan.js'
 import { registerD1ReadinessRoute } from './d1Readiness.js'
 import { createD1HostSurfaceResolver, D1_TRUSTED_CADDY_PEER } from './hostSurface.js'
@@ -22,6 +28,8 @@ export interface D1ServerWiring {
   readonly requestScopeResolver: CoreRequestScopeResolver
   readonly frontendRootHandler: CoreFrontendRootHandler
   readonly admitAgentEffect: AgentEffectAdmission
+  readonly resolveAgentRuntimeIdentity: D1AgentRuntimeIdentityResolver
+  readonly resolveAgentRuntimeRecipe: D1AgentRuntimeRecipeResolver
   registerReadiness(app: FastifyInstance): void
 }
 
@@ -88,6 +96,8 @@ export function createD1ServerWiring(
     requestScopeResolver: createD1HostSurfaceResolver({ activeReader, trustedPeer: D1_TRUSTED_CADDY_PEER }),
     frontendRootHandler: createD1LandingRootHandler({ activeReader }),
     admitAgentEffect: createD1AgentEffectAdmission({ hostId, activeReader, admissionLedger: dependencies.admissionLedger }),
+    resolveAgentRuntimeIdentity: createD1AgentRuntimeIdentityResolver(activeReader),
+    resolveAgentRuntimeRecipe: createD1AgentRuntimeRecipeResolver(activeReader),
     registerReadiness(app: FastifyInstance) { registerD1ReadinessRoute(app, { activeReader }) },
   })
 }

--- a/apps/full-app/src/server/deployment/hostSurface.ts
+++ b/apps/full-app/src/server/deployment/hostSurface.ts
@@ -118,11 +118,14 @@ export function createD1HostSurfaceResolver(options: D1HostSurfaceOptions): Core
     const matches = collection.desired.plan.bindings.filter((binding) => binding.hostname === authority)
     if (matches.length !== 1) violation()
     const binding = matches[0]!
+    const resolved = collection.desired.resolvedBindings.filter((value) => value.bindingId === binding.bindingId)
+    if (resolved.length !== 1) violation()
     return Object.freeze({
       bindingId: binding.bindingId,
       workspaceId: binding.workspaceId,
       defaultDeploymentId: binding.defaultDeploymentId,
       activeRevision: collection.active.revisionId,
+      resolvedDigest: resolved[0]!.resolvedDigest,
     })
   }
 }

--- a/apps/full-app/src/server/main.ts
+++ b/apps/full-app/src/server/main.ts
@@ -18,6 +18,7 @@ import {
 } from './managedAgentMcp.js'
 import { assertProductionAgentModeIsSafe } from './productionSafety.js'
 import type { WorkspaceAgentDispatcherResolver } from '@hachej/boring-agent/server'
+import type { FastifyRequest } from 'fastify'
 import { createD1ServerWiring } from './deployment/d1ServerWiring.js'
 
 function pluginAuthoringEnabledFromEnv(): boolean {
@@ -63,6 +64,19 @@ async function main() {
       requestScopeResolver: d1.requestScopeResolver,
       frontendRootHandler: d1.frontendRootHandler,
       admitEffect: d1.admitAgentEffect,
+      getRuntimeScopeContribution: async ({ workspaceId, request }: { workspaceId: string; request?: FastifyRequest }) => {
+        const scoped = request?.requestScope
+        const identity = scoped?.workspaceId === workspaceId
+          ? Object.freeze({ workspaceId: scoped.workspaceId, defaultDeploymentId: scoped.defaultDeploymentId,
+              resolvedDigest: scoped.resolvedDigest, activeRevision: scoped.activeRevision })
+          : await d1.resolveAgentRuntimeIdentity(workspaceId)
+        return Object.freeze({
+          identity: identity.resolvedDigest,
+          loadSystemPromptAppend: async () => (
+            await d1.resolveAgentRuntimeRecipe(workspaceId, identity.activeRevision)
+          ).instructions.content,
+        })
+      },
     } : {}),
   })
   appDb = app.db

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.lifecycle.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.lifecycle.test.ts
@@ -606,6 +606,56 @@ test('request-scoped binding recreation awaits local retirement without disposin
   expect(disposeAdapter).toHaveBeenCalledOnce()
 })
 
+test('one request pins one runtime recipe while a later identity creates a new binding', async () => {
+  const workspaceRoot = await makeTempDir('boring-agent-runtime-recipe-lease-')
+  const app = Fastify({ logger: false })
+  const harness = createDispatcherTestHarness()
+  const evictCachedRuntime = vi.fn()
+  const createRuntime = vi.fn((root: string, sessionId: string) => createDirectRuntimeBundle(root, sessionId))
+  const resolveContribution = vi.fn(async () => Object.freeze({ identity: activeIdentity }))
+  let activeIdentity = 'digest-1'
+  let releaseCommands!: () => void
+  const commandsGate = new Promise<void>((resolve) => { releaseCommands = resolve })
+  let markCommandsStarted!: () => void
+  const commandsStarted = new Promise<void>((resolve) => { markCommandsStarted = resolve })
+
+  await app.register(registerAgentRoutes, {
+    workspaceRoot,
+    externalPlugins: false,
+    getWorkspaceId: () => 'workspace-recipe',
+    getWorkspaceRoot: async () => workspaceRoot,
+    getRuntimeScopeContribution: resolveContribution,
+    runtimeModeAdapter: {
+      id: 'runtime-recipe-lease-test', workspaceFsCapability: 'strong', evictCachedRuntime,
+      create: (ctx) => createRuntime(ctx.workspaceRoot, ctx.sessionId),
+    },
+    harnessFactory: async (input) => ({
+      ...await harness.factory(input),
+      async getSlashCommands() { markCommandsStarted(); await commandsGate; return [] },
+    }),
+  })
+  await app.ready()
+
+  const oldRequest = app.inject({ method: 'GET', url: '/api/v1/agent/commands' })
+  await commandsStarted
+  expect(resolveContribution).toHaveBeenCalledTimes(1)
+  expect(createRuntime).toHaveBeenCalledTimes(1)
+
+  activeIdentity = 'digest-2'
+  expect((await app.inject({ method: 'GET', url: '/api/v1/agent/catalog' })).statusCode).toBe(200)
+  expect(resolveContribution).toHaveBeenCalledTimes(2)
+  expect(createRuntime).toHaveBeenCalledTimes(2)
+
+  const closing = app.close()
+  expect(evictCachedRuntime).not.toHaveBeenCalled()
+  releaseCommands()
+  expect((await oldRequest).statusCode).toBe(200)
+  expect(resolveContribution).toHaveBeenCalledTimes(2)
+  await closing
+  expect(resolveContribution).toHaveBeenCalledTimes(2)
+  expect(evictCachedRuntime).toHaveBeenCalledTimes(2)
+})
+
 test('requestless dispatcher send leases its binding until iteration completes', async () => {
   const workspaceRoot = await makeTempDir('boring-agent-dispatcher-operation-lease-')
   const app = Fastify({ logger: false })

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -238,6 +238,38 @@ test('registerAgentRoutes dispatcher reuses a dynamic runtime with trusted reque
   }
 })
 
+test('runtime scope contribution pins prompt content to its identity and workspace', async () => {
+  const workspaceRoot = await makeTempDir('boring-agent-runtime-recipe-')
+  const harness = createDispatcherTestHarness(); const app = Fastify({ logger: false })
+  const loadPrompt = vi.fn(async (workspaceId: string, identity: string) => `${workspaceId}:${identity}`)
+  const resolveContribution = vi.fn(async (workspaceId: string, identity: string) => Object.freeze({
+    identity, loadSystemPromptAppend: async () => loadPrompt(workspaceId, identity),
+  }))
+  await app.register(registerAgentRoutes, {
+    mode: 'direct', externalPlugins: false, workspaceRoot,
+    getWorkspaceId: async (request) => String(request.headers['x-workspace'] ?? ''),
+    getWorkspaceRoot: async () => workspaceRoot,
+    getRuntimeScopeContribution: async ({ workspaceId, request }) => {
+      const identity = String(request?.headers['x-recipe'] ?? 'recipe-1')
+      return resolveContribution(workspaceId, identity)
+    },
+    harnessFactory: harness.factory,
+  })
+  const request = (workspaceId: string, identity: string) => app.inject({ method: 'GET', url: '/api/v1/agent/catalog',
+    headers: { 'x-workspace': workspaceId, 'x-recipe': identity } })
+  try {
+    expect((await request('workspace-a', 'digest-a')).statusCode).toBe(200)
+    expect((await request('workspace-a', 'digest-a')).statusCode).toBe(200)
+    expect((await request('workspace-a', 'digest-b')).statusCode).toBe(200)
+    expect((await request('workspace-b', 'digest-c')).statusCode).toBe(200)
+    expect(harness.factoryInputs.map((input) => input.systemPromptAppend)).toEqual([
+      'workspace-a:digest-a', 'workspace-a:digest-b', 'workspace-b:digest-c',
+    ])
+    expect(resolveContribution).toHaveBeenCalledTimes(4)
+    expect(loadPrompt).toHaveBeenCalledTimes(3)
+  } finally { await app.close() }
+})
+
 test('registerAgentRoutes provisions embedded runtime plugins before host app routes are ready', async () => {
   const workspaceRoot = await makeTempDir('boring-agent-embed-provision-')
   const packageRoot = await createDummyNodeSdkPackage()

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -172,6 +172,7 @@ interface RuntimeScope {
   templatePath?: string
   pi: ResolvedPiHarnessOptions
   sessionNamespace?: string
+  loadSystemPromptAppend?: () => Promise<string | undefined>
 }
 
 interface SkillScope {
@@ -329,6 +330,13 @@ export interface RegisterAgentRoutesOptions {
     workspaceId: string
     workspaceRoot: string
   }) => string | undefined | Promise<string | undefined>
+  /** Immutable host contribution captured once in the runtime binding scope. */
+  getRuntimeScopeContribution?: (ctx: {
+    workspaceId: string
+    workspaceRoot: string
+    request?: FastifyRequest
+  }) => Readonly<{ identity: string; loadSystemPromptAppend?: () => Promise<string | undefined> }>
+    | Promise<Readonly<{ identity: string; loadSystemPromptAppend?: () => Promise<string | undefined> }>>
   /** Override the default pi-backed harness with a custom agent runtime. */
   harnessFactory?: AgentHarnessFactory
   /** Optional pi adapter/runtime knobs used by the default harness. */
@@ -471,7 +479,9 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     typeof opts.getExtraTools === 'function' ||
     typeof opts.getSessionNamespace === 'function' ||
     typeof opts.getSystemPromptDynamic === 'function' ||
+    typeof opts.getRuntimeScopeContribution === 'function' ||
     typeof opts.getTrustedWorkspaceRoot === 'function'
+  const runtimeScopeByRequest = new WeakMap<FastifyRequest, Map<string, Promise<RuntimeScope>>>()
   const sessionChangesTracker = new InMemorySessionChangesTracker()
   const externalPluginsEnabled = opts.externalPlugins !== false
 
@@ -514,11 +524,13 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       ? await opts.getSessionNamespace({ workspaceId, workspaceRoot: root, request, userId: trustedCtx?.userId })
       : opts.sessionNamespace)
     const extraToolsAuthSubject = opts.getExtraTools ? trustedCtx?.userId ?? getRequestAuthSubject(request) : undefined
+    const contribution = await opts.getRuntimeScopeContribution?.({ workspaceId, workspaceRoot: root, request })
     return {
       root,
       templatePath: scopedTemplatePath,
       pi,
       sessionNamespace,
+      loadSystemPromptAppend: contribution?.loadSystemPromptAppend,
       key: JSON.stringify([
         resolvedMode,
         workspaceId,
@@ -527,8 +539,29 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
         pi,
         sessionNamespace ?? null,
         extraToolsAuthSubject ?? null,
+        contribution?.identity ?? null,
       ]),
     }
+  }
+
+  function getRuntimeScope(
+    workspaceId: string,
+    request?: FastifyRequest,
+    trustedCtx?: WorkspaceAgentDispatcherContext,
+  ): Promise<RuntimeScope> {
+    if (!request) return resolveRuntimeScope(workspaceId, undefined, trustedCtx)
+    let scopes = runtimeScopeByRequest.get(request)
+    if (!scopes) {
+      scopes = new Map()
+      runtimeScopeByRequest.set(request, scopes)
+    }
+    const identity = JSON.stringify([workspaceId, trustedCtx?.userId ?? null])
+    let promise = scopes.get(identity)
+    if (!promise) {
+      promise = resolveRuntimeScope(workspaceId, request, trustedCtx)
+      scopes.set(identity, promise)
+    }
+    return promise
   }
 
   async function resolveSkillScope(
@@ -594,6 +627,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     trustedCtx?: WorkspaceAgentDispatcherContext,
   ): Promise<RuntimeBinding> {
     const root = scope.root
+    const scopedSystemPromptAppend = await scope.loadSystemPromptAppend?.()
     const modeCtx = {
       workspaceRoot: root,
       sessionId: workspaceId,
@@ -827,7 +861,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
         checkReadiness,
       }),
       harnessFactory,
-      systemPromptAppend: opts.systemPromptAppend,
+      systemPromptAppend: [opts.systemPromptAppend, scopedSystemPromptAppend].filter(Boolean).join('\n\n') || undefined,
       systemPromptDynamic,
       telemetry: opts.telemetry,
       metering: opts.metering,
@@ -897,7 +931,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     options: { failIfPending?: boolean; trustedCtx?: WorkspaceAgentDispatcherContext } = {},
   ): Promise<RuntimeBinding> {
     bindingLifecycle.assertAdmission(workspaceId, request)
-    const scope = await resolveRuntimeScope(workspaceId, request, options.trustedCtx)
+    const scope = await getRuntimeScope(workspaceId, request, options.trustedCtx)
     bindingLifecycle.assertAdmission(workspaceId, request)
     const existing = bindingLifecycle.getEntry(scope.key)
     if (existing) {

--- a/packages/cli/src/server/pluginFrontRuntime.ts
+++ b/packages/cli/src/server/pluginFrontRuntime.ts
@@ -1382,6 +1382,16 @@ export async function createPluginFrontRuntimeHost(
   const trackedWorkspaces = new Map<string, Map<string, TrackedPluginRecord>>()
   const trackedPluginRevisions = new Map<string, Map<string, Map<number, TrackedPluginRecord>>>()
   const transformCache = new Map<string, TransformCacheEntry>()
+  // Bumped by disposeWorkspace() so an in-flight serve() (e.g. the
+  // fire-and-forget warmupWorkspace() call kicked off right after a plugin
+  // list loads) can detect it validated against a workspace that has since
+  // been evicted, even though its own validateRequest() check ran and
+  // passed *before* the eviction landed. Without this, a concurrent
+  // disposeWorkspace() can run its point-in-time transformCache cleanup
+  // before the in-flight serve() call reaches its own transformCache.set(),
+  // leaving a fresh, unreachable-by-cleanup cache entry behind that lets a
+  // later request for the evicted workspace's runtime target succeed.
+  const workspaceDisposalEpoch = new Map<string, number>()
   const mintedSupportPathsByCacheKey = new Map<string, string[]>()
   const mintedSupportPathRefCounts = new Map<string, number>()
   const limiter = new TransformLimiter(Math.max(1, options.maxTransformConcurrency ?? DEFAULT_MAX_TRANSFORM_CONCURRENCY))
@@ -1717,6 +1727,7 @@ export async function createPluginFrontRuntimeHost(
     try {
       const resolved = await validateRequest(request)
       validated = resolved
+      const epochAtValidation = workspaceDisposalEpoch.get(resolved.workspaceId) ?? 0
       const cached = transformCache.get(resolved.cacheKey)
       if (cached) {
         emit({
@@ -1812,7 +1823,25 @@ export async function createPluginFrontRuntimeHost(
           )
         }
       })
+      // Swallow rejections here so an epoch-stale discard below (which never
+      // awaits `promise`) can't surface as an unhandled promise rejection;
+      // the real result/error is still surfaced via the `await promise`
+      // (or re-thrown) path when we do use it.
+      promise.catch(() => {})
 
+      // Re-check the workspace's disposal epoch right before publishing to
+      // the cache. validateRequest() above proved the plugin was tracked at
+      // *that* instant, but disposeWorkspace() can run its point-in-time
+      // transformCache cleanup in the gap between that check and this line
+      // (e.g. a fire-and-forget warmupWorkspace() call racing a concurrent
+      // workspace eviction). If the epoch moved, the workspace was evicted
+      // mid-flight — don't resurrect a cache entry cleanup already ran past.
+      if ((workspaceDisposalEpoch.get(runtimeRequest.workspaceId) ?? 0) !== epochAtValidation) {
+        throw new PluginFrontRuntimeError(ErrorCode.enum.PATH_NOT_FOUND, 404, "validate", "plugin runtime workspace was evicted while serving", {
+          workspaceId: runtimeRequest.workspaceId,
+          pluginId: runtimeRequest.pluginId,
+        })
+      }
       transformCache.set(runtimeRequest.cacheKey, { runtimeId: runtimeRequest.runtimeId, promise })
       const response = await promise
       emit({
@@ -1993,6 +2022,13 @@ export async function createPluginFrontRuntimeHost(
   }
 
   async function disposeWorkspace(workspaceId: string): Promise<void> {
+    // Bump first (synchronously, before the two deletes below or the async
+    // invalidateMatching sweep) so any serve() call whose validateRequest()
+    // already passed for this workspace — but hasn't reached its own
+    // transformCache.set() yet — observes the moved epoch and discards its
+    // result instead of resurrecting a tracked/cached entry this eviction
+    // is about to clear.
+    workspaceDisposalEpoch.set(workspaceId, (workspaceDisposalEpoch.get(workspaceId) ?? 0) + 1)
     trackedWorkspaces.delete(workspaceId)
     trackedPluginRevisions.delete(workspaceId)
     await invalidateMatching((entry) => entry.workspaceId === workspaceId)

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.telemetry.test.ts
@@ -323,6 +323,7 @@ describe('createCoreWorkspaceAgentServer telemetry wiring', () => {
         workspaceId: 'workspace-保险',
         defaultDeploymentId: 'deployment-bound',
         activeRevision: 'revision-bound',
+        resolvedDigest: `sha256:${'a'.repeat(64)}`,
       }),
     })
     const handler = vi.fn(async (_request: Request) => new Response('ok'))

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
@@ -301,6 +301,7 @@ describe('createCoreWorkspaceAgentServer workspace bridge wiring', () => {
         workspaceId: 'workspace-1',
         defaultDeploymentId: 'deployment-1',
         activeRevision: 'revision-1',
+        resolvedDigest: `sha256:${'a'.repeat(64)}`,
       },
     }
     await expect(resolveWorkspaceId!(scoped)).resolves.toBe('workspace-1')
@@ -348,6 +349,7 @@ describe('createCoreWorkspaceAgentServer workspace bridge wiring', () => {
         workspaceId: 'workspace-1',
         defaultDeploymentId: 'deployment-1',
         activeRevision: 'revision-1',
+        resolvedDigest: `sha256:${'a'.repeat(64)}`,
       }),
       workspaceBridge: { runtimeTokenSecret: '12345678901234567890123456789012' },
     })

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1041,6 +1041,7 @@ export async function createCoreWorkspaceAgentServer(
     systemPromptAppend: pluginCollection.agentOptions.systemPromptAppend,
     pi: pluginCollection.agentOptions.pi,
     getPi: resolvePiOptions,
+    getRuntimeScopeContribution: options.getRuntimeScopeContribution,
     sessionRoot,
     getSessionNamespace: resolveSessionNamespace,
     getExtraTools: async (ctx) => {

--- a/packages/core/src/server/app/__tests__/routes.test.ts
+++ b/packages/core/src/server/app/__tests__/routes.test.ts
@@ -103,6 +103,7 @@ beforeAll(async () => {
       request.requestScope = Object.freeze({
         bindingId: 'binding-test', workspaceId,
         defaultDeploymentId: 'deployment-test', activeRevision: 'revision-test',
+        resolvedDigest: `sha256:${'a'.repeat(64)}`,
       })
     }
   })

--- a/packages/core/src/server/app/createCoreApp.ts
+++ b/packages/core/src/server/app/createCoreApp.ts
@@ -319,6 +319,7 @@ export async function createCoreApp(
         workspaceId: scope.workspaceId,
         defaultDeploymentId: scope.defaultDeploymentId,
         activeRevision: scope.activeRevision,
+        resolvedDigest: scope.resolvedDigest,
       })
     })
   }

--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -100,6 +100,7 @@ export interface CoreRequestScope {
   readonly workspaceId: string
   readonly defaultDeploymentId: string
   readonly activeRevision: string
+  readonly resolvedDigest: string
 }
 
 export type CoreRequestScopeResolver = (request: FastifyRequest) => CoreRequestScope | undefined | Promise<CoreRequestScope | undefined>

--- a/packages/core/src/server/routes/__tests__/invites.test.ts
+++ b/packages/core/src/server/routes/__tests__/invites.test.ts
@@ -235,6 +235,7 @@ beforeAll(async () => {
         workspaceId: scopedWorkspaceId,
         defaultDeploymentId: 'deployment-test',
         activeRevision: 'revision-test',
+        resolvedDigest: `sha256:${'a'.repeat(64)}`,
       })
     }
   })

--- a/packages/core/src/server/routes/__tests__/members.test.ts
+++ b/packages/core/src/server/routes/__tests__/members.test.ts
@@ -145,6 +145,7 @@ beforeAll(async () => {
       request.requestScope = Object.freeze({
         bindingId: 'binding-test', workspaceId,
         defaultDeploymentId: 'deployment-test', activeRevision: 'revision-test',
+        resolvedDigest: `sha256:${'a'.repeat(64)}`,
       })
     }
   })

--- a/packages/core/src/server/routes/__tests__/workspaces.test.ts
+++ b/packages/core/src/server/routes/__tests__/workspaces.test.ts
@@ -105,6 +105,7 @@ beforeAll(async () => {
         workspaceId,
         defaultDeploymentId: 'deployment-test',
         activeRevision: 'revision-test',
+        resolvedDigest: `sha256:${'a'.repeat(64)}`,
       })
     }
   })


### PR DESCRIPTION
## Bead

wt-391-forward-vup.2.1.1 - D1-005c A0 deployed-agent runtime recipe

## What changed

- resolves exactly one workspace binding from the active D1 collection and its immutable agent artifact
- exposes frozen runtime identity and recipe resolvers through D1 server wiring
- contributes the selected instructions and resolved digest to the core/agent runtime scope
- memoizes the runtime contribution per request so identity and prompt content cannot drift during one admitted request
- preserves binding-lifecycle admission and cleanup across the new request-scoped contribution

## Decision 25 boundary

This is load-bearing core only. It does not consume or extend RuntimeIsolationEvidenceV1, VerifiedD1HostExecution, approved-host-release, approvedHostArtifactEvidence, hostSecurityConfig, Caddyfile/core-env authority, d1_proof, or any host-artifact attestation ceremony. It does not implement the durable active-pointer publication/recovery half of vup.2.

## Proof

- 37 active-collection reader/runtime-recipe tests passed
- 56 agent register/lifecycle tests passed
- packages/core typecheck passed
- apps/full-app typecheck passed
- packages/agent build passed
- packages/core build passed
- git diff --check passed
- patch size: 358 additions, 17 deletions, 341 net

hostSurface.test.ts / d1Activation.test.ts could not start in this sparse worktree because Vitest module resolution failed on react/jsx-dev-runtime while importing core mail templates; 0 tests executed, so this is recorded as a local environment gap and CI is the gate. NODE_PATH/symlink retry did not change resolver behavior.

## Review findings resolved

- active revision is rechecked after artifact loading to reject mixed-revision reads
- workspace selection fails closed unless exactly one active binding matches
- runtime identity includes the resolved digest and is frozen into request scope
- request-level memoization prevents repeated contribution resolution from changing identity or prompt within one request
- lifecycle tests prove admitted creation and cleanup still use the same scoped runtime

## Risk and rollback

Primary risk is binding a request to stale or mismatched collection data. The resolver fails closed on absent, duplicate, changed-revision, or digest-invalid artifacts, and request-scoped identity prevents mid-request drift. Rollback is a normal revert of this commit; no on-disk publication format or active pointer is changed by this slice.

## Next

A1: add the disposable runtime preloader on top of this stable deployed-agent recipe seam.

## Merge gate

Do not enable auto-merge. This PR requires the mandatory Opus security review before merge.