### PR TITLE
#391 D1: prepare user-neutral publication candidates

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
@@ -98,6 +98,8 @@ describe('D1 readiness and activation wiring', () => {
     const wiring = createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '0' })!
     expect(Object.isFrozen(wiring)).toBe(true)
     expect(Object.keys(wiring)).toEqual(['requestScopeResolver', 'frontendRootHandler', 'admitAgentEffect', 'resolveAgentRuntimeIdentity', 'resolveAgentRuntimeRecipe', 'registerReadiness'])
+    const candidatePreloader = { prepare: vi.fn() } as never
+    expect(createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '0' }, { candidatePreloader })?.candidatePreloader).toBe(candidatePreloader)
     expect(createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '4294967294' })).toBeDefined()
 
     const source = await readFile(new URL('../d1ServerWiring.ts', import.meta.url), 'utf8')

--- a/apps/full-app/src/server/deployment/__tests__/d1UserNeutralPreloader.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1UserNeutralPreloader.test.ts
@@ -1,0 +1,89 @@
+import type { Sha256Digest } from '@hachej/boring-agent/shared'
+import { describe, expect, it, vi } from 'vitest'
+
+import { D1HostErrorCode, type D1SiteBindingV1 } from '../d1Plan.js'
+import type { D1ResolvedBindingV1 } from '../d1RevisionCodec.js'
+import { createD1RuntimeInputsIdentity } from '../d1RuntimeInputs.js'
+import { createD1UserNeutralCandidatePreloader, type D1UserNeutralCandidateInput } from '../d1UserNeutralPreloader.js'
+
+const sha = (value: string): Sha256Digest => `sha256:${value.repeat(64).slice(0, 64)}`
+const binding = { bindingId: 'insurance', hostname: 'insurance.example.test', workspaceId: 'workspace:insurance',
+  defaultDeploymentId: 'deployment:insurance', bundleRef: 'bundle', deploymentRef: 'deployment',
+  workspaceAllocationRef: 'allocation', sessionAllocationRef: 'sessions', ownerPrincipalRef: 'owner',
+  landing: { title: 'Insurance', summary: 'Compare policies.' }, environmentRef: 'production', secretRefs: [] } satisfies D1SiteBindingV1
+const resolved = { schemaVersion: 1, bindingId: binding.bindingId, resolvedDigest: sha('a'),
+  workspace: { workspaceId: binding.workspaceId, defaultDeploymentId: binding.defaultDeploymentId, compositionDigest: sha('b') },
+  deployment: { deploymentId: binding.defaultDeploymentId, version: '1', agentId: 'default', digest: sha('c') },
+  definition: { definitionId: 'definition', version: '1', digest: sha('d'), instructionsRef: 'instructions.md' },
+  composition: { snapshot: {}, digest: sha('b') } } as unknown as D1ResolvedBindingV1
+
+async function input(site = binding) {
+  return { revisionId: 'r0000000001', binding: site, resolved, runtimeInputs: await createD1RuntimeInputsIdentity(site, {
+    environment: { versionFingerprint: sha('e') }, workspaceAllocation: { versionFingerprint: sha('f') },
+    sessionAllocation: { versionFingerprint: sha('1') }, secrets: [],
+  }) }
+}
+
+describe('D1 user-neutral candidate preloader', () => {
+  it('shares exact preparation and releases once after the final disposable holder', async () => {
+    let mutate = () => {}; const release = vi.fn(async () => {}); const load = vi.fn(async () => { mutate(); return Object.freeze({
+      workspaceId: binding.workspaceId, defaultDeploymentId: binding.defaultDeploymentId,
+      resolvedDigest: resolved.resolvedDigest, instructions: Object.freeze({ ref: 'instructions.md', content: 'Compare.' }),
+    }) })
+    const allocate = vi.fn(async (value: D1UserNeutralCandidateInput) => Object.freeze({
+      workspaceId: value.binding.workspaceId, ref: value.runtimeInputs.workspaceAllocation.ref,
+      versionFingerprint: value.runtimeInputs.workspaceAllocation.versionFingerprint, dispose: release,
+    }))
+    const preloader = createD1UserNeutralCandidatePreloader({ loadValidatedRecipe: load, prepareWorkspaceAllocation: allocate })
+    const value = { ...await input(), resolved: { ...resolved } }; mutate = () => Object.assign(value.resolved, { resolvedDigest: sha('9') })
+    const first = await preloader.prepare(value); Object.assign(value.resolved, { resolvedDigest: resolved.resolvedDigest })
+    const second = await preloader.prepare(value)
+    expect(load).toHaveBeenCalledOnce(); expect(allocate).toHaveBeenCalledOnce()
+    expect(first.recipe).toBe(second.recipe); expect(first.workspaceAllocation).toBe(second.workspaceAllocation)
+    expect('dispose' in first.workspaceAllocation).toBe(false)
+    expect(() => Object.assign(first.recipe.instructions, { content: 'mutated' })).toThrow()
+    Object.assign(value.binding.landing, { title: 'Mutated' }); expect(first.binding.landing.title).toBe('Insurance')
+    await first.dispose(); await first.dispose(); expect(release).not.toHaveBeenCalled()
+    await second.dispose(); await second.dispose(); expect(release).toHaveBeenCalledOnce()
+  })
+
+  it('rejects conflicting aliases and releases failed candidate-owned allocation before retry', async () => {
+    const release = vi.fn(async () => {}); let fail = false
+    const preloader = createD1UserNeutralCandidatePreloader({
+      loadValidatedRecipe: async () => {
+        if (fail) throw new Error('artifact')
+        return { workspaceId: binding.workspaceId, defaultDeploymentId: binding.defaultDeploymentId,
+          resolvedDigest: resolved.resolvedDigest, instructions: { ref: 'instructions.md', content: 'Compare.' } }
+      },
+      prepareWorkspaceAllocation: async (value) => ({ workspaceId: value.binding.workspaceId,
+        ref: value.runtimeInputs.workspaceAllocation.ref, versionFingerprint: value.runtimeInputs.workspaceAllocation.versionFingerprint, dispose: release }),
+    })
+    const value = await input(); const retained = await preloader.prepare(value)
+    await expect(preloader.prepare({ ...value, binding: { ...binding, hostname: 'changed.example.test' } }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    await retained.dispose(); fail = true
+    await expect(preloader.prepare(value)).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    expect(release).toHaveBeenCalledTimes(2)
+    fail = false; await (await preloader.prepare(value)).dispose(); expect(release).toHaveBeenCalledTimes(3)
+    const unavailable = createD1UserNeutralCandidatePreloader({ loadValidatedRecipe: async () => { throw new Error() },
+      prepareWorkspaceAllocation: async () => { throw new Error('allocation') } })
+    await expect(unavailable.prepare(value)).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    await expect(unavailable.prepare(value)).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+  })
+
+  it('blocks reacquisition until failed final cleanup retries successfully', async () => {
+    let allocations = 0; let releases = 0
+    const preloader = createD1UserNeutralCandidatePreloader({
+      loadValidatedRecipe: async () => ({ workspaceId: binding.workspaceId, defaultDeploymentId: binding.defaultDeploymentId,
+        resolvedDigest: resolved.resolvedDigest, instructions: { ref: 'instructions.md', content: 'Compare.' } }),
+      prepareWorkspaceAllocation: async (value) => { allocations += 1; return { workspaceId: value.binding.workspaceId,
+        ref: value.runtimeInputs.workspaceAllocation.ref, versionFingerprint: value.runtimeInputs.workspaceAllocation.versionFingerprint,
+        async dispose() { releases += 1; if (releases === 1) throw new Error('busy') } } },
+    })
+    const value = await input(); const first = await preloader.prepare(value)
+    await expect(first.dispose()).rejects.toThrow('busy'); expect(allocations).toBe(1)
+    const replacement = await preloader.prepare(value)
+    expect(releases).toBe(2); expect(allocations).toBe(2)
+    await replacement.dispose(); expect(releases).toBe(3)
+  })
+})

--- a/apps/full-app/src/server/deployment/d1ServerWiring.ts
+++ b/apps/full-app/src/server/deployment/d1ServerWiring.ts
@@ -17,6 +17,7 @@ import {
 } from './d1AgentRuntimeRecipe.js'
 import { D1HostError, D1HostErrorCode, invalidD1Field, strictD1HostId } from './d1Plan.js'
 import { registerD1ReadinessRoute } from './d1Readiness.js'
+import type { D1UserNeutralCandidatePreloader } from './d1UserNeutralPreloader.js'
 import { createD1HostSurfaceResolver, D1_TRUSTED_CADDY_PEER } from './hostSurface.js'
 
 const APP_UID = 10001
@@ -30,11 +31,13 @@ export interface D1ServerWiring {
   readonly admitAgentEffect: AgentEffectAdmission
   readonly resolveAgentRuntimeIdentity: D1AgentRuntimeIdentityResolver
   readonly resolveAgentRuntimeRecipe: D1AgentRuntimeRecipeResolver
+  readonly candidatePreloader?: D1UserNeutralCandidatePreloader
   registerReadiness(app: FastifyInstance): void
 }
 
 export interface D1ServerWiringDependencies {
   readonly admissionLedger?: Pick<D1AdmissionLedger, 'admit'>
+  readonly candidatePreloader?: D1UserNeutralCandidatePreloader
 }
 
 function admissionFailed(): AgentEffectAdmissionError {
@@ -98,6 +101,7 @@ export function createD1ServerWiring(
     admitAgentEffect: createD1AgentEffectAdmission({ hostId, activeReader, admissionLedger: dependencies.admissionLedger }),
     resolveAgentRuntimeIdentity: createD1AgentRuntimeIdentityResolver(activeReader),
     resolveAgentRuntimeRecipe: createD1AgentRuntimeRecipeResolver(activeReader),
+    ...(dependencies.candidatePreloader ? { candidatePreloader: dependencies.candidatePreloader } : {}),
     registerReadiness(app: FastifyInstance) { registerD1ReadinessRoute(app, { activeReader }) },
   })
 }

--- a/apps/full-app/src/server/deployment/d1UserNeutralPreloader.ts
+++ b/apps/full-app/src/server/deployment/d1UserNeutralPreloader.ts
@@ -1,0 +1,122 @@
+import type { Sha256Digest } from '@hachej/boring-agent/shared'
+
+import type { WorkspaceAgentRuntimeRecipe } from './d1AgentRuntimeRecipe.js'
+import { D1HostError, D1HostErrorCode, strictD1Ref, type D1SiteBindingV1 } from './d1Plan.js'
+import type { D1ResolvedBindingV1 } from './d1RevisionCodec.js'
+import { canonicalizeD1RuntimeInputsIdentity, type D1RuntimeInputsIdentityV1 } from './d1RuntimeInputs.js'
+
+export interface D1PreparedWorkspaceAllocation {
+  readonly workspaceId: string
+  readonly ref: string
+  readonly versionFingerprint: Sha256Digest
+  dispose(): Promise<void>
+}
+export interface D1UserNeutralCandidateInput {
+  readonly revisionId: string
+  readonly binding: D1SiteBindingV1
+  readonly resolved: D1ResolvedBindingV1
+  readonly runtimeInputs: D1RuntimeInputsIdentityV1
+}
+export interface D1PreparedUserNeutralCandidate extends D1UserNeutralCandidateInput {
+  readonly recipe: WorkspaceAgentRuntimeRecipe
+  readonly workspaceAllocation: Readonly<Pick<D1PreparedWorkspaceAllocation, 'workspaceId' | 'ref' | 'versionFingerprint'>>
+  dispose(): Promise<void>
+}
+export interface D1UserNeutralCandidatePreloader {
+  prepare(input: D1UserNeutralCandidateInput): Promise<D1PreparedUserNeutralCandidate>
+}
+
+interface RetainedPreparation {
+  readonly signature: string
+  holders: number
+  prepared: Promise<Readonly<{ recipe: WorkspaceAgentRuntimeRecipe; workspaceAllocation: Readonly<Pick<D1PreparedWorkspaceAllocation, 'workspaceId' | 'ref' | 'versionFingerprint'>> }>>
+  workspaceAllocation?: D1PreparedWorkspaceAllocation
+  release?: Promise<void>
+}
+
+function failed(): never {
+  throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'preload' })
+}
+function immutableCopy<T>(value: T): T {
+  const copy = structuredClone(value)
+  const freeze = (item: unknown): void => {
+    if (typeof item !== 'object' || item === null || Object.isFrozen(item)) return
+    for (const child of Object.values(item)) freeze(child)
+    Object.freeze(item)
+  }
+  freeze(copy); return copy
+}
+
+export function createD1UserNeutralCandidatePreloader(options: {
+  readonly loadValidatedRecipe: (input: D1UserNeutralCandidateInput) => Promise<WorkspaceAgentRuntimeRecipe>
+  readonly prepareWorkspaceAllocation: (input: D1UserNeutralCandidateInput) => Promise<D1PreparedWorkspaceAllocation>
+}): D1UserNeutralCandidatePreloader {
+  const retained = new Map<string, RetainedPreparation>()
+  const release = async (key: string, entry: RetainedPreparation): Promise<void> => {
+    if (!entry.workspaceAllocation) return
+    entry.release ??= entry.workspaceAllocation.dispose().then(() => {
+      if (retained.get(key) === entry) retained.delete(key)
+    }, (error) => { entry.release = undefined; throw error })
+    await entry.release
+  }
+  const prepare = async (raw: D1UserNeutralCandidateInput): Promise<D1PreparedUserNeutralCandidate> => {
+      const snapshot = immutableCopy(raw)
+      const revisionId = strictD1Ref(snapshot.revisionId, 'preload.revisionId')
+      const runtimeInputs = await canonicalizeD1RuntimeInputsIdentity(snapshot.runtimeInputs, snapshot.binding)
+      if (snapshot.resolved.bindingId !== snapshot.binding.bindingId
+        || snapshot.resolved.workspace.workspaceId !== snapshot.binding.workspaceId
+        || snapshot.resolved.workspace.defaultDeploymentId !== snapshot.binding.defaultDeploymentId
+        || snapshot.resolved.deployment.deploymentId !== snapshot.binding.defaultDeploymentId
+        || runtimeInputs.workspaceAllocation.ref !== snapshot.binding.workspaceAllocationRef) failed()
+      const input = immutableCopy({ ...snapshot, revisionId, runtimeInputs })
+      const key = [revisionId, input.binding.workspaceId, input.binding.defaultDeploymentId, input.resolved.resolvedDigest,
+        input.runtimeInputs.digest, input.runtimeInputs.workspaceAllocation.ref, input.runtimeInputs.workspaceAllocation.versionFingerprint].join('\0')
+      const signature = JSON.stringify(input)
+      let entry = retained.get(key)
+      if (entry && entry.signature !== signature) failed()
+      if (entry?.holders === 0 && entry.workspaceAllocation) {
+        await release(key, entry).catch(() => failed())
+        return prepare(raw)
+      }
+      if (!entry) {
+        entry = { signature, holders: 0, prepared: undefined as never }
+        const created = entry
+        entry.prepared = (async () => {
+          let owned: D1PreparedWorkspaceAllocation | undefined
+          try {
+            owned = await options.prepareWorkspaceAllocation(input)
+            const recipe = await options.loadValidatedRecipe(input)
+            if (owned.workspaceId !== input.binding.workspaceId
+              || owned.ref !== input.runtimeInputs.workspaceAllocation.ref
+              || owned.versionFingerprint !== input.runtimeInputs.workspaceAllocation.versionFingerprint
+              || recipe.workspaceId !== input.binding.workspaceId
+              || recipe.defaultDeploymentId !== input.binding.defaultDeploymentId
+              || recipe.resolvedDigest !== input.resolved.resolvedDigest) failed()
+            const workspaceAllocation = Object.freeze({ workspaceId: owned.workspaceId, ref: owned.ref, versionFingerprint: owned.versionFingerprint })
+            created.workspaceAllocation = Object.freeze({ ...workspaceAllocation, dispose: () => owned!.dispose() })
+            return Object.freeze({ recipe: immutableCopy(recipe), workspaceAllocation })
+          } catch {
+            if (owned && !created.workspaceAllocation) created.workspaceAllocation = Object.freeze({ workspaceId: owned.workspaceId,
+              ref: owned.ref, versionFingerprint: owned.versionFingerprint, dispose: () => owned!.dispose() })
+            await release(key, created).catch(() => {})
+            failed()
+          }
+        })()
+        retained.set(key, entry)
+      }
+      entry.holders += 1
+      let prepared: Awaited<typeof entry.prepared>
+      try { prepared = await entry.prepared } catch (error) {
+        entry.holders -= 1
+        if (entry.holders === 0 && entry.workspaceAllocation) await release(key, entry).catch(() => {})
+        else if (entry.holders === 0 && retained.get(key) === entry) retained.delete(key)
+        throw error
+      }
+      let disposed = false
+      return Object.freeze({ ...input, ...prepared, async dispose() {
+        if (!disposed) { disposed = true; entry!.holders -= 1 }
+        if (entry!.holders === 0 && retained.get(key) === entry) await release(key, entry!)
+      } })
+  }
+  return Object.freeze({ prepare })
+}

--- a/docs/issues/391/runtime-refactor/FORWARD-PLAN.md
+++ b/docs/issues/391/runtime-refactor/FORWARD-PLAN.md
@@ -562,6 +562,7 @@ bead below:
 - **Why / workflow.** This is where the multi-agent host actually comes alive and
   where N+1 continuity is proven: adding a binding must not interrupt in-flight
   sessions of the others.
+- **v1 preload boundary.** Retain user-neutral artifact/recipe/runtime-input/workspace-allocation facts only; actor runtimes stay lazy per authorized user, with no warm-runtime claim.
 - **Build.** `bootCollection.ts` + `preloadSignal.ts`; integrate D1-001/002/003/
   004 seams through the root command wrapper + `main.ts`. Require D1-005b's live
   `VerifiedD1HostExecution`; read one immutable **revision**; perform N


### PR DESCRIPTION
## Summary

Adds the owner-approved v1 user-neutral candidate preparation seam for D1-005c. It retains an immutable validated recipe, canonical runtime-input identity, and workspace-allocation identity without constructing an actor-bound Agent Runtime, harness, session, MCP tools, request, or user. Actor runtimes remain lazy per authorized user; this PR makes no warm-runtime claim.

## Issue / Slice

- Bead: `wt-391-forward-vup.2.3.1`
- Stacked split: vup.2.3a preparation + forwarding
- Mandatory Fable/Opus security review before merge

## What Changed

- Added candidate-scoped, concurrent-idempotent preparation keyed by exact revision/workspace/deployment/resolved/runtime/allocation identity.
- Deep-snapshots retained authority facts before awaits and rejects conflicting aliases.
- Keeps allocation disposal private; candidate handles own retryable ref-counted release, and reacquisition waits for cleanup.
- Forwards the exact same preloader instance through trusted `D1ServerWiring` dependencies.
- Records the v1 user-neutral/lazy-per-user/no-warm-runtime decision in `FORWARD-PLAN.md`.

## Proof

- Exact command: `/home/ubuntu/projects/wt-391-d1-005c-core-publication/node_modules/.bin/vitest run --root /home/ubuntu/projects/wt-391-d1-005c-user-neutral-preload/apps/full-app --config /home/ubuntu/projects/wt-391-d1-005c-core-publication/apps/full-app/vitest.config.ts src/server/deployment/__tests__/d1UserNeutralPreloader.test.ts src/server/deployment/__tests__/d1Activation.test.ts`
- Result: 2 files, 11 tests passed.
- `git diff --check`: passed.
- Diff: 218 net lines, under the 220-line cap.
- Local full-app typecheck was not authoritative because this fresh worktree could not complete package declaration generation; GitHub CI is the typecheck/build gate.

## Review

- Standards/spec: CLEAN after fixing mutable retained metadata and post-await caller-input TOCTOU.
- Thermo/security: CLEAN after making cleanup retryable/acquisition-blocking and removing nested allocation disposal authority.
- Reviewed SHA: `a7e3d371b6633a0e6a6c10b5c5d5675881c1dec5`

## Risk / Rollback

The new preloader is inert until a trusted D1 candidate loader/allocation preparer is injected. Revision-local transport/loading and served-collection authority remain explicitly owned by the following slices. Rollback is removal of this isolated seam.

## Next

Stop for mandatory Fable/Opus security review. No auto-merge is armed.