### PR TITLE
feat(d1): atomically serve prepared collections

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/bootCollection.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/bootCollection.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import { createD1CollectionController, type D1PreparedBindingHandle } from '../bootCollection.js'
 import { D1HostErrorCode, type D1HostPlanV1 } from '../d1Plan.js'
-import { createD1DesiredSnapshot, deriveD1SecretRefsEnvelope, digestD1Desired, type D1DesiredSnapshotV1 } from '../d1RevisionCodec.js'
+import { createD1DesiredSnapshot, deriveD1SecretRefsEnvelope, digestD1Desired, type D1DesiredSnapshotV1, type D1ResolvedBindingV1 } from '../d1RevisionCodec.js'
 import { createD1RuntimeInputsIdentity } from '../d1RuntimeInputs.js'
 import type { D1StoredCandidateV1 } from '../hostRevisionStore.js'
 import { canonicalizeWorkspaceCompositionSnapshot } from '../workspaceComposition.js'
@@ -44,8 +44,11 @@ async function runtimeInputs(desired: D1DesiredSnapshotV1, environment = 'e') {
   })))
 }
 function plan(desired: D1DesiredSnapshotV1): D1HostPlanV1 { return { ...desired.plan, expectedHostRevision: null } }
-function handle(id: string, disposed: string[]): D1PreparedBindingHandle & { ping(): string } {
-  return { async dispose() { disposed.push(id) }, ping: () => `alive:${id}` }
+function handle(binding: D1ResolvedBindingV1, disposed: string[]): D1PreparedBindingHandle & { ping(): string } {
+  const id = binding.bindingId
+  return Object.freeze({ recipe: Object.freeze({ workspaceId: binding.workspace.workspaceId, defaultDeploymentId: binding.workspace.defaultDeploymentId,
+    resolvedDigest: binding.resolvedDigest, instructions: Object.freeze({ ref: 'instructions.md', content: id }) }),
+  async dispose() { disposed.push(id) }, ping: () => `alive:${id}` })
 }
 
 describe('D1 collection controller', () => {
@@ -53,13 +56,13 @@ describe('D1 collection controller', () => {
     const desired = await fixture(['b', 'a']); const resolved = new Map(desired.resolvedBindings.map((value) => [value.bindingId, value]))
     const calls: string[] = []; const preloads: string[] = []
     let size = 6
-    const controller = createD1CollectionController({ limits, resolveBinding: async (binding) => { calls.push(binding.bindingId); return { resolved: resolved.get(binding.bindingId)!, bundleBytes: size } }, preloadBinding: async (binding) => { preloads.push(binding.bindingId); return handle(binding.bindingId, []) } })
+    const controller = createD1CollectionController({ limits, resolveBinding: async (binding) => { calls.push(binding.bindingId); return { resolved: resolved.get(binding.bindingId)!, bundleBytes: size } }, preloadBinding: async (binding) => { preloads.push(binding.bindingId); return handle(binding, []) } })
     const output = await controller.resolver.resolvePlan(plan(desired))
     expect(calls).toEqual(['a', 'b']); expect(output.resolvedBindings.map((value) => value.bindingId)).toEqual(['a', 'b'])
     size = 7; await expect(controller.resolver.resolvePlan(plan(desired))).rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY }); size = 6
     await expect(createD1CollectionController({ limits: { ...limits, maxBindings: 1 }, resolveBinding: async () => { throw new Error('must not resolve') }, preloadBinding: async () => { throw new Error('must not preload') } }).resolver.resolvePlan(plan(desired)))
       .rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_LIMIT_EXCEEDED, details: { field: 'bindings' } })
-    const over = createD1CollectionController({ limits: { ...limits, maxTotalBundleBytes: 11 }, resolveBinding: async (binding) => ({ resolved: resolved.get(binding.bindingId)!, bundleBytes: 6 }), preloadBinding: async (binding) => { preloads.push(binding.bindingId); return handle(binding.bindingId, []) } })
+    const over = createD1CollectionController({ limits: { ...limits, maxTotalBundleBytes: 11 }, resolveBinding: async (binding) => ({ resolved: resolved.get(binding.bindingId)!, bundleBytes: 6 }), preloadBinding: async (binding) => { preloads.push(binding.bindingId); return handle(binding, []) } })
     await expect(over.resolver.resolvePlan(plan(desired))).rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_LIMIT_EXCEEDED })
     expect(preloads).toEqual([])
   })
@@ -70,7 +73,7 @@ describe('D1 collection controller', () => {
     const controller = createD1CollectionController({ limits, resolveBinding: async (binding) => ({ resolved: resolved.get(binding.bindingId)!, bundleBytes: 2 }), preloadBinding: async (binding) => {
       active++; peak = Math.max(peak, active); await new Promise((resolve) => setTimeout(resolve, 5)); active--
       if (binding.bindingId === 'c') throw new Error('/private/preload')
-      return handle(binding.bindingId, disposed)
+      return handle(binding, disposed)
     } })
     const output = await controller.resolver.resolvePlan(plan(desired)); const value = await candidate(output, 'r0000000001')
     await expect(controller.preload(value, await runtimeInputs(output))).rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY })
@@ -79,50 +82,95 @@ describe('D1 collection controller', () => {
 
   it('rejects invalid observation identity before creating a runtime', async () => {
     const desired = await fixture(['a']); const resolved = desired.resolvedBindings[0]!; const loaded: string[] = []
-    const controller = createD1CollectionController({ limits, resolveBinding: async () => ({ resolved, bundleBytes: 2 }), preloadBinding: async () => { loaded.push('a'); return handle('a', []) } })
+    const controller = createD1CollectionController({ limits, resolveBinding: async () => ({ resolved, bundleBytes: 2 }), preloadBinding: async () => { loaded.push('a'); return handle(resolved, []) } })
     const output = await controller.resolver.resolvePlan(plan(desired)); const inputs = await runtimeInputs(output)
     const malformed = [{ ...inputs[0]!, environment: { ...inputs[0]!.environment, ref: 'wrong-environment' } }]
     await expect(controller.preload(await candidate(output, 'r0000000001'), malformed)).rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY })
     expect(loaded).toEqual([]); expect(controller.snapshot()).toBeNull()
+    const disposed: string[] = []
+    const invalidHandle = createD1CollectionController({ limits, resolveBinding: async () => ({ resolved, bundleBytes: 2 }),
+      preloadBinding: async (binding) => { const value = handle(binding, disposed); return Object.freeze({ ...value, recipe: Object.freeze({ ...value.recipe, workspaceId: 'workspace:wrong' }) }) } })
+    const invalidDesired = await invalidHandle.resolver.resolvePlan(plan(desired))
+    await expect(invalidHandle.preload(await candidate(invalidDesired, 'r0000000002'), await runtimeInputs(invalidDesired)))
+      .rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY })
+    expect(disposed).toEqual(['a'])
   })
 
   it('atomically serves additive candidates while retained handles and prior snapshots stay live', async () => {
     const initial = await fixture(['a']); const additive = await fixture(['a', 'b'])
     const sources = new Map(additive.resolvedBindings.map((value) => [value.bindingId, value])); const disposed: string[] = []; const preloads: string[] = []
-    const controller = createD1CollectionController({ limits, resolveBinding: async (binding) => ({ resolved: sources.get(binding.bindingId)!, bundleBytes: 4 }), preloadBinding: async (binding) => { preloads.push(binding.bindingId); return handle(binding.bindingId, disposed) } })
+    const controller = createD1CollectionController({ limits, resolveBinding: async (binding) => ({ resolved: sources.get(binding.bindingId)!, bundleBytes: 4 }), preloadBinding: async (binding) => { preloads.push(binding.bindingId); return handle(binding, disposed) } })
     const first = await controller.resolver.resolvePlan(plan(initial)); const firstCandidate = await candidate(first, 'r0000000001')
     await controller.preload(firstCandidate, await runtimeInputs(first)); await controller.serve({ schemaVersion: 1, revisionId: firstCandidate.revisionId, desiredStateDigest: firstCandidate.desiredStateDigest })
-    const before = controller.snapshot()!; const captured = before.lookup('a')!.handle as ReturnType<typeof handle>
+    const before = controller.snapshot()!; const captured = await controller.readRecipe('workspace:a', firstCandidate.revisionId)
     const ownerChanged = await createD1DesiredSnapshot({ ...plan(initial), bindings: [{ ...initial.plan.bindings[0]!, ownerPrincipalRef: 'other-owner' }] }, initial.resolvedBindings)
     const changed = await controller.resolver.resolvePlan(plan(ownerChanged)); await expect(controller.preload(await candidate(changed, 'r0000000009'), await runtimeInputs(changed))).rejects.toMatchObject({ code: D1HostErrorCode.ACTIVE_BINDING_RESTART_REQUIRED })
+    const hostChanged = await createD1DesiredSnapshot({ ...plan(initial), databaseRef: 'other-database' }, initial.resolvedBindings)
+    const changedHost = await controller.resolver.resolvePlan(plan(hostChanged)); await expect(controller.preload(await candidate(changedHost, 'r0000000010'), await runtimeInputs(changedHost))).rejects.toMatchObject({ code: D1HostErrorCode.ACTIVE_BINDING_RESTART_REQUIRED })
     const next = await controller.resolver.resolvePlan(plan(additive)); const nextCandidate = await candidate(next, 'r0000000002')
     await controller.preload(nextCandidate, await runtimeInputs(next))
     await expect(controller.serve({ schemaVersion: 1, revisionId: 'r0000000003', desiredStateDigest: nextCandidate.desiredStateDigest })).rejects.toMatchObject({ code: D1HostErrorCode.COLLECTION_NOT_READY })
-    const ack = await controller.serve({ schemaVersion: 1, revisionId: nextCandidate.revisionId, desiredStateDigest: nextCandidate.desiredStateDigest }); const after = controller.snapshot()!
+    const serving = controller.serve({ schemaVersion: 1, revisionId: nextCandidate.revisionId, desiredStateDigest: nextCandidate.desiredStateDigest })
+    expect(controller.snapshot()).toBe(before)
+    const ack = await serving; const after = controller.snapshot()!
     expect(ack).toEqual({ revisionId: 'r0000000002', desiredStateDigest: nextCandidate.desiredStateDigest }); expect(preloads).toEqual(['a', 'b'])
     expect(before.bindingIds).toEqual(['a']); expect(before.lookup('b')).toBeUndefined(); expect(after.bindingIds).toEqual(['a', 'b'])
-    expect(after.lookup('a')!.handle).toBe(captured); expect(captured.ping()).toBe('alive:a'); expect(disposed).toEqual([])
+    expect(await controller.readRecipe('workspace:a', nextCandidate.revisionId)).toBe(captured); expect(disposed).toEqual([])
   })
 
-  it('rejects replacement/removal and discards only an unused candidate addition', async () => {
-    const initial = await fixture(['a']); const additive = await fixture(['a', 'b']); const replacement = await fixture(['a'], '3'); const removal = await fixture(['b'])
+  it('captures provider recipe and disposal data before publication', async () => {
+    const initial = await fixture(['a']); const additive = await fixture(['a', 'b']); const sources = new Map(additive.resolvedBindings.map((value) => [value.bindingId, value]))
+    const providers = new Map<string, D1PreparedBindingHandle>(); const disposed: string[] = []
+    const controller = createD1CollectionController({ limits, resolveBinding: async (binding) => ({ resolved: sources.get(binding.bindingId)!, bundleBytes: 2 }),
+      preloadBinding: async (binding) => { const value = { ...handle(binding, disposed) }; providers.set(binding.bindingId, value); return value } })
+    const first = await controller.resolver.resolvePlan(plan(initial)); const one = await candidate(first, 'r0000000001'); await controller.preload(one, await runtimeInputs(first))
+    Object.defineProperty(providers.get('a')!, 'recipe', { value: Object.freeze({ ...providers.get('a')!.recipe, workspaceId: 'workspace:sibling' }) })
+    await controller.serve({ schemaVersion: 1, revisionId: one.revisionId, desiredStateDigest: one.desiredStateDigest })
+    expect((await controller.readRecipe('workspace:a')).workspaceId).toBe('workspace:a')
+    const next = await controller.resolver.resolvePlan(plan(additive)); const two = await candidate(next, 'r0000000002'); await controller.preload(two, await runtimeInputs(next))
+    Object.defineProperty(providers.get('b')!, 'dispose', { value: async () => { throw new Error('mutated') } })
+    await controller.discardPrepared({ schemaVersion: 1, revisionId: two.revisionId, desiredStateDigest: two.desiredStateDigest })
+    expect(disposed).toEqual(['b'])
+  })
+
+  it('rejects replacement or unauthorized removal and disposes only detached user-neutral handles', async () => {
+    const initial = await fixture(['a']); const additive = await fixture(['a', 'b', 'c']); const replacement = await fixture(['a'], '3'); const removal = await fixture(['a'])
     let sources = new Map(additive.resolvedBindings.map((value) => [value.bindingId, value])); const disposed: string[] = []
-    const loaded: string[] = []; const controller = createD1CollectionController({ limits, resolveBinding: async (binding) => ({ resolved: sources.get(binding.bindingId)!, bundleBytes: 4 }), preloadBinding: async (binding) => { loaded.push(binding.bindingId); return handle(binding.bindingId, disposed) } })
+    let commitEnabled = false; let retireAttempts = 0; let retirementSaw: readonly string[] = []; let controller!: ReturnType<typeof createD1CollectionController>
+    const loaded: string[] = []; controller = createD1CollectionController({ limits, resolveBinding: async (binding) => ({ resolved: sources.get(binding.bindingId)!, bundleBytes: 4 }), preloadBinding: async (binding) => { loaded.push(binding.bindingId); return handle(binding, disposed) },
+      commitRollback: async (_authorization, commit) => { if (commitEnabled) commit() },
+      retireRemoved: async ({ removals }) => { retirementSaw = controller.snapshot()!.bindingIds; if (++retireAttempts === 1) { await removals[0]!.dispose(); throw new Error('drain failed') } for (const removal of removals) await removal.dispose() } })
     const first = await controller.resolver.resolvePlan(plan(initial)); const one = await candidate(first, 'r0000000001'); await controller.preload(one, await runtimeInputs(first)); await controller.serve({ schemaVersion: 1, revisionId: one.revisionId, desiredStateDigest: one.desiredStateDigest })
     const unchanged = await controller.resolver.resolvePlan(plan(initial)); await expect(controller.preload(await candidate(unchanged, 'r0000000002'), await runtimeInputs(unchanged, '9'))).rejects.toMatchObject({ code: D1HostErrorCode.ACTIVE_BINDING_RESTART_REQUIRED }); expect(loaded).toEqual(['a'])
     sources = new Map(replacement.resolvedBindings.map((value) => [value.bindingId, value])); const changed = await controller.resolver.resolvePlan(plan(replacement))
     await expect(controller.preload(await candidate(changed, 'r0000000002'), await runtimeInputs(changed))).rejects.toMatchObject({ code: D1HostErrorCode.ACTIVE_BINDING_RESTART_REQUIRED })
     sources = new Map(additive.resolvedBindings.map((value) => [value.bindingId, value])); const next = await controller.resolver.resolvePlan(plan(additive)); const pending = await candidate(next, 'r0000000003')
     await controller.preload(pending, await runtimeInputs(next)); await controller.discardPrepared({ schemaVersion: 1, revisionId: pending.revisionId, desiredStateDigest: pending.desiredStateDigest })
-    expect(disposed).toEqual(['b']); expect(controller.snapshot()!.bindingIds).toEqual(['a'])
-    sources = new Map(removal.resolvedBindings.map((value) => [value.bindingId, value])); const removed = await controller.resolver.resolvePlan(plan(removal)); await expect(controller.preload(await candidate(removed, 'r0000000004'), await runtimeInputs(removed))).rejects.toMatchObject({ code: D1HostErrorCode.ACTIVE_BINDING_RESTART_REQUIRED })
-    expect(disposed).toEqual(['b'])
+    expect(disposed.sort()).toEqual(['b', 'c']); expect(controller.snapshot()!.bindingIds).toEqual(['a'])
+    const republish = await candidate(next, 'r0000000004'); await controller.preload(republish, await runtimeInputs(next)); await controller.serve({ schemaVersion: 1, revisionId: republish.revisionId, desiredStateDigest: republish.desiredStateDigest })
+    sources = new Map(removal.resolvedBindings.map((value) => [value.bindingId, value])); const removed = await controller.resolver.resolvePlan(plan(removal)); const rollback = await candidate(removed, 'r0000000005')
+    await controller.preload(rollback, await runtimeInputs(removed))
+    await expect(controller.serve({ schemaVersion: 1, revisionId: rollback.revisionId, desiredStateDigest: rollback.desiredStateDigest }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_TARGET_INVALID })
+    const authorization = { operationId: 'rollback-1', hostId: 'host-1', expectedRevision: republish.revisionId,
+      expectedDigest: republish.desiredStateDigest, targetRevision: rollback.revisionId, targetDigest: rollback.desiredStateDigest, removalBindingIds: ['b', 'c'] }
+    await expect(controller.serve({ schemaVersion: 1, revisionId: rollback.revisionId, desiredStateDigest: rollback.desiredStateDigest }, { kind: 'rollback', authorization: { ...authorization, expectedRevision: one.revisionId } }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_TARGET_INVALID })
+    await expect(controller.serve({ schemaVersion: 1, revisionId: rollback.revisionId, desiredStateDigest: rollback.desiredStateDigest }, { kind: 'rollback', authorization: { ...authorization, removalBindingIds: ['c', 'b'] } }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.ROLLBACK_TARGET_INVALID })
+    await expect(controller.serve({ schemaVersion: 1, revisionId: rollback.revisionId, desiredStateDigest: rollback.desiredStateDigest }, { kind: 'rollback', authorization }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    expect(controller.snapshot()!.bindingIds).toEqual(['a', 'b', 'c']); commitEnabled = true
+    await expect(controller.serve({ schemaVersion: 1, revisionId: rollback.revisionId, desiredStateDigest: rollback.desiredStateDigest }, { kind: 'rollback', authorization }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    expect(retirementSaw).toEqual(['a']); expect(controller.snapshot()!.bindingIds).toEqual(['a']); expect(disposed.sort()).toEqual(['b', 'b', 'c'])
+    await controller.settleRetirement(); expect(retireAttempts).toBe(2); expect(disposed.sort()).toEqual(['b', 'b', 'c', 'c'])
   })
 
   it('serializes preload with serve and retains failed cleanup for retry', async () => {
     const initial = await fixture(['a']); const additive = await fixture(['a', 'b']); let sources = new Map(initial.resolvedBindings.map((value) => [value.bindingId, value]))
     let release!: () => void; const gate = new Promise<void>((resolve) => { release = resolve }); let disposeAttempts = 0
-    const controller = createD1CollectionController({ limits, resolveBinding: async (binding) => ({ resolved: sources.get(binding.bindingId)!, bundleBytes: 2 }), preloadBinding: async (binding) => { if (binding.bindingId === 'a') await gate; return { async dispose() { if (binding.bindingId === 'b' && ++disposeAttempts === 1) throw new Error('dispose failed') } } } })
+    const controller = createD1CollectionController({ limits, resolveBinding: async (binding) => ({ resolved: sources.get(binding.bindingId)!, bundleBytes: 2 }), preloadBinding: async (binding) => { if (binding.bindingId === 'a') await gate; return { ...handle(binding, []), async dispose() { if (binding.bindingId === 'b' && ++disposeAttempts === 1) throw new Error('dispose failed') } } } })
     const first = await controller.resolver.resolvePlan(plan(initial)); const one = await candidate(first, 'r0000000001'); const preparing = controller.preload(one, await runtimeInputs(first)); const serving = controller.serve({ schemaVersion: 1, revisionId: one.revisionId, desiredStateDigest: one.desiredStateDigest })
     await Promise.resolve(); expect(controller.snapshot()).toBeNull(); release(); await preparing; await serving
     sources = new Map(additive.resolvedBindings.map((value) => [value.bindingId, value])); const next = await controller.resolver.resolvePlan(plan(additive)); const pending = await candidate(next, 'r0000000002'); await controller.preload(pending, await runtimeInputs(next))

--- a/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1Activation.test.ts
@@ -6,6 +6,7 @@ import Fastify from 'fastify'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { D1ActiveCollection, D1ActiveCollectionReader } from '../activeCollectionReader.js'
+import type { D1ServedCollectionAuthority } from '../bootCollection.js'
 import { registerD1ReadinessRoute } from '../d1Readiness.js'
 import { createD1AgentEffectAdmission, createD1ServerWiring } from '../d1ServerWiring.js'
 import { D1HostError, D1HostErrorCode } from '../d1Plan.js'
@@ -112,6 +113,36 @@ describe('D1 readiness and activation wiring', () => {
     expect(main).toContain('getRuntimeScopeContribution: async')
     expect(main.indexOf('d1?.registerReadiness(app)')).toBeLessThan(main.indexOf('registerFullAppBoringMcpRoutes(app)'))
     expect(main.indexOf('registerFullAppBoringMcpRoutes(app)')).toBeLessThan(main.indexOf('app.listen('))
+  })
+
+  it('routes every live consumer and the ledger reread through one served authority', async () => {
+    vi.spyOn(process, 'geteuid').mockReturnValue(10001); vi.spyOn(process, 'getegid').mockReturnValue(10001)
+    const binding = { bindingId: 'insurance', hostname: HOST, workspaceId: 'workspace:insurance', defaultDeploymentId: 'deployment:insurance',
+      bundleRef: 'bundle', deploymentRef: 'deployment', workspaceAllocationRef: 'workspace', sessionAllocationRef: 'session',
+      ownerPrincipalRef: 'owner', landing: { title: 'Insurance', summary: 'Compare policies.' }, environmentRef: 'production', secretRefs: [] }
+    const current = { active: { schemaVersion: 1 as const, revisionId: 'r0000000042', desiredStateDigest: DIGEST },
+      desired: { plan: { hostId: 'eu-host-1', bindings: [binding] }, resolvedBindings: [{ bindingId: binding.bindingId, resolvedDigest: DIGEST }] },
+      observation: { bindings: [{ bindingId: binding.bindingId, ready: true }] } } as unknown as D1ActiveCollection
+    const recipe = Object.freeze({ workspaceId: binding.workspaceId, defaultDeploymentId: binding.defaultDeploymentId,
+      resolvedDigest: DIGEST, instructions: Object.freeze({ ref: 'instructions.md', content: 'trusted' }) })
+    const read = vi.fn(async () => current); const readRecipe = vi.fn(async () => recipe)
+    const authority = { read, readRecipe } as D1ServedCollectionAuthority
+    const ledgerRead = vi.fn(async (source: D1ActiveCollectionReader) => { expect(source).toBe(authority); await source.read(); return {} as never })
+    const wiring = createD1ServerWiring(CONFIG, { BORING_D1_HOST_ID: 'eu-host-1', BORING_D1_OWNER_UID: '0' },
+      { servedCollection: authority, admissionLedger: { admit: ledgerRead } })!
+
+    await wiring.requestScopeResolver({ raw: { rawHeaders: ['Host', HOST, 'X-Forwarded-Host', HOST, 'X-Forwarded-For', '198.51.100.7'],
+      socket: { remoteAddress: D1_TRUSTED_CADDY_PEER }, method: 'GET', url: '/' }, ips: [D1_TRUSTED_CADDY_PEER, '198.51.100.7'] } as never)
+    const reply = { status() { return this }, header() { return this }, type() { return this }, send() { return this } }
+    await wiring.frontendRootHandler({ user: null, requestScope: { bindingId: binding.bindingId, workspaceId: binding.workspaceId,
+      defaultDeploymentId: binding.defaultDeploymentId, activeRevision: current.active.revisionId, resolvedDigest: DIGEST } } as never, reply as never)
+    await wiring.admitAgentEffect({ workspaceId: binding.workspaceId, requestId: 'request-1' })
+    await expect(wiring.resolveAgentRuntimeIdentity(binding.workspaceId)).resolves.toMatchObject({ activeRevision: current.active.revisionId })
+    await expect(wiring.resolveAgentRuntimeRecipe(binding.workspaceId)).resolves.toBe(recipe)
+    const readiness = Fastify(); readiness.decorateRequest('requestScope'); wiring.registerReadiness(readiness); await readiness.ready()
+    await expect(readiness.inject({ method: 'GET', url: '/internal/d1/readiness', remoteAddress: '127.0.0.1' })).resolves.toMatchObject({ statusCode: 200 })
+    await readiness.close()
+    expect(read).toHaveBeenCalledTimes(6); expect(readRecipe).toHaveBeenCalledOnce(); expect(ledgerRead).toHaveBeenCalledOnce()
   })
 
   it('derives the unique current binding for each effect and fails closed without the one ledger', async () => {

--- a/apps/full-app/src/server/deployment/bootCollection.ts
+++ b/apps/full-app/src/server/deployment/bootCollection.ts
@@ -271,7 +271,7 @@ export function createD1CollectionController(options: {
   }
   return Object.freeze({
     resolver, preload: (candidate: D1StoredCandidateV1, runtimeInputs: readonly D1RuntimeInputsIdentityV1[]) => {
-      let capturedCandidate: D1StoredCandidateV1; let capturedInputs: D1RuntimeInputsIdentityV1[]
+      let capturedCandidate: D1StoredCandidateV1; let capturedInputs: readonly D1RuntimeInputsIdentityV1[]
       try { capturedCandidate = structuredClone(candidate); capturedInputs = structuredClone(runtimeInputs) }
       catch { return Promise.reject(new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'collection' })) }
       return serialized(() => preload(capturedCandidate, capturedInputs))

--- a/apps/full-app/src/server/deployment/bootCollection.ts
+++ b/apps/full-app/src/server/deployment/bootCollection.ts
@@ -1,10 +1,15 @@
 import type { Sha256Digest } from '@hachej/boring-agent/shared'
 
+import type { D1ActiveCollection, D1ActiveCollectionReader } from './activeCollectionReader.js'
+import type { WorkspaceAgentRuntimeRecipe } from './d1AgentRuntimeRecipe.js'
 import type { D1DesiredResolver } from './d1Command.js'
 import { D1HostError, D1HostErrorCode, type D1HostPlanV1, type D1SiteBindingV1 } from './d1Plan.js'
 import {
+  canonicalizeD1ActiveEnvelope,
   canonicalizeD1DesiredSnapshot,
   canonicalizeD1Observation,
+  createD1CompleteEnvelope,
+  digestD1Desired,
   type D1ActiveEnvelopeV1,
   type D1ObservationV1,
   type D1PersistedPlanV1,
@@ -12,6 +17,7 @@ import {
 } from './d1RevisionCodec.js'
 import type { D1RuntimeInputsIdentityV1 } from './d1RuntimeInputs.js'
 import type { D1StoredCandidateV1, D1StoredCompleteV1 } from './hostRevisionStore.js'
+import { normalizeD1DestructivePublicationIdentity, type D1DestructivePublicationIdentity } from './destructivePublicationJournal.js'
 
 export interface D1CollectionLimits {
   readonly maxBindings: number
@@ -26,10 +32,12 @@ export interface D1ResolvedBundleV1 {
   readonly resolved: D1ResolvedBindingV1
   readonly bundleBytes: number
 }
-export interface D1PreparedBindingHandle { dispose(): Promise<void> }
+export interface D1PreparedBindingHandle {
+  readonly recipe: WorkspaceAgentRuntimeRecipe
+  dispose(): Promise<void>
+}
 export interface D1ServedBinding {
   readonly resolvedDigest: Sha256Digest
-  readonly handle: D1PreparedBindingHandle
 }
 export interface D1ServedCollectionSnapshot {
   readonly revisionId: string
@@ -37,15 +45,22 @@ export interface D1ServedCollectionSnapshot {
   readonly bindingIds: readonly string[]
   lookup(bindingId: string): D1ServedBinding | undefined
 }
-export interface D1CollectionController {
+export interface D1ServedCollectionAuthority extends D1ActiveCollectionReader {
+  readRecipe(workspaceId: string, activeRevision?: string): Promise<WorkspaceAgentRuntimeRecipe>
+}
+export interface D1CollectionController extends D1ServedCollectionAuthority {
   readonly resolver: D1DesiredResolver
   preload(candidate: D1StoredCandidateV1, runtimeInputs: readonly D1RuntimeInputsIdentityV1[]): Promise<D1ObservationV1>
-  serve(active: D1ActiveEnvelopeV1): Promise<Readonly<{ revisionId: string; desiredStateDigest: Sha256Digest }>>
+  serve(active: D1ActiveEnvelopeV1, transition?: Readonly<{ kind: 'rollback'; authorization: D1DestructivePublicationIdentity }>): Promise<Readonly<{ revisionId: string; desiredStateDigest: Sha256Digest }>>
+  settleRetirement(): Promise<void>
   discardPrepared(active: D1ActiveEnvelopeV1): Promise<void>
   snapshot(): D1ServedCollectionSnapshot | null
 }
+type D1RollbackTransition = Readonly<{ kind: 'rollback'; authorization: D1DestructivePublicationIdentity }>
 
 interface PreparedBinding extends D1ServedBinding {
+  readonly recipe?: WorkspaceAgentRuntimeRecipe
+  readonly dispose: () => Promise<void>
   readonly candidateOnly: boolean
   readonly runtimeInputs: D1RuntimeInputsIdentityV1
   readonly binding: D1SiteBindingV1
@@ -55,10 +70,34 @@ interface PreparedCollection {
   readonly revisionId: string
   readonly desiredStateDigest: Sha256Digest
   readonly bindings: ReadonlyMap<string, PreparedBinding>
+  readonly removed: ReadonlyMap<string, PreparedBinding>
+  readonly desired: D1StoredCandidateV1['desired']
+  readonly observation: D1ObservationV1
 }
+interface ServedState {
+  readonly collection: D1ActiveCollection
+  readonly bindings: ReadonlyMap<string, PreparedBinding>
+  readonly snapshot: D1ServedCollectionSnapshot
+}
+interface PendingRetirement {
+  readonly prior: D1ActiveEnvelopeV1
+  readonly next: D1ActiveEnvelopeV1
+  readonly removals: readonly Readonly<{ bindingId: string; dispose(): Promise<void> }>[]
+}
+type D1RollbackCommit = (authorization: D1DestructivePublicationIdentity, commitOnce: () => void) => Promise<void>
 
 function fail(code: D1HostErrorCode = D1HostErrorCode.COLLECTION_NOT_READY, field = 'collection'): never {
   throw new D1HostError(code, { field })
+}
+function captureTransition(raw: D1RollbackTransition | undefined): D1RollbackTransition | undefined {
+  if (raw === undefined) return undefined
+  try {
+    if (typeof raw !== 'object' || raw === null || Object.keys(raw).sort().join(',') !== 'authorization,kind') throw new Error()
+    const kind = Object.getOwnPropertyDescriptor(raw, 'kind'); const authorization = Object.getOwnPropertyDescriptor(raw, 'authorization')
+    if (!kind || !('value' in kind) || kind.value !== 'rollback' || !authorization || !('value' in authorization)) throw new Error()
+    return Object.freeze({ kind: 'rollback' as const, authorization: normalizeD1DestructivePublicationIdentity(authorization.value) })
+  }
+  catch { fail(D1HostErrorCode.ROLLBACK_TARGET_INVALID, 'publicationIdentity') }
 }
 function positiveInteger(value: number, field: string): number {
   if (!Number.isSafeInteger(value) || value <= 0) fail(D1HostErrorCode.PLAN_INVALID, field)
@@ -75,10 +114,30 @@ function sameExecutionBinding(left: D1SiteBindingV1, right: D1SiteBindingV1): bo
     && left.ownerPrincipalRef === right.ownerPrincipalRef && left.environmentRef === right.environmentRef
     && left.secretRefs.length === right.secretRefs.length && left.secretRefs.every((value, index) => value === right.secretRefs[index])
 }
+function sameHostExecution(left: D1PersistedPlanV1, right: D1PersistedPlanV1): boolean {
+  return left.hostId === right.hostId && left.hostAppImageDigest === right.hostAppImageDigest
+    && left.runtimeProfileRef === right.runtimeProfileRef && left.databaseRef === right.databaseRef
+    && left.workspaceRootPolicyRef === right.workspaceRootPolicyRef && left.sessionRootPolicyRef === right.sessionRootPolicyRef
+}
+function dataProperty(value: object, key: string): unknown {
+  const descriptor = Object.getOwnPropertyDescriptor(value, key)
+  if (!descriptor || !('value' in descriptor)) fail()
+  return descriptor.value
+}
+function captureRecipe(raw: unknown, binding: D1ResolvedBindingV1): WorkspaceAgentRuntimeRecipe {
+  if (typeof raw !== 'object' || raw === null || Object.keys(raw).sort().join(',') !== 'defaultDeploymentId,instructions,resolvedDigest,workspaceId') fail()
+  const instructions = dataProperty(raw, 'instructions')
+  if (typeof instructions !== 'object' || instructions === null || Object.keys(instructions).sort().join(',') !== 'content,ref') fail()
+  const recipe = Object.freeze({ workspaceId: dataProperty(raw, 'workspaceId'), defaultDeploymentId: dataProperty(raw, 'defaultDeploymentId'),
+    resolvedDigest: dataProperty(raw, 'resolvedDigest'), instructions: Object.freeze({ ref: dataProperty(instructions, 'ref'), content: dataProperty(instructions, 'content') }) })
+  if (recipe.workspaceId !== binding.workspace.workspaceId || recipe.defaultDeploymentId !== binding.workspace.defaultDeploymentId
+    || recipe.resolvedDigest !== binding.resolvedDigest || typeof recipe.instructions.ref !== 'string' || typeof recipe.instructions.content !== 'string') fail()
+  return recipe as WorkspaceAgentRuntimeRecipe
+}
 async function disposeCandidateOnly(collection: PreparedCollection | undefined): Promise<PreparedCollection | undefined> {
   if (!collection) return undefined
   const candidates = [...collection.bindings].filter(([, value]) => value.candidateOnly)
-  const results = await Promise.allSettled(candidates.map(([, value]) => value.handle.dispose()))
+  const results = await Promise.allSettled(candidates.map(([, value]) => value.dispose()))
   const failed = new Map(candidates.filter((_, index) => results[index]!.status === 'rejected'))
   return failed.size === 0 ? undefined : { ...collection, state: 'cleanup', bindings: failed }
 }
@@ -87,6 +146,8 @@ export function createD1CollectionController(options: {
   readonly limits: D1CollectionLimits
   readonly resolveBinding: (binding: D1SiteBindingV1, plan: D1PersistedPlanV1) => Promise<D1ResolvedBundleV1>
   readonly preloadBinding: (resolved: D1ResolvedBindingV1, runtimeInputs: D1RuntimeInputsIdentityV1) => Promise<D1PreparedBindingHandle>
+  readonly retireRemoved?: (retirement: PendingRetirement) => Promise<void>
+  readonly commitRollback?: D1RollbackCommit
 }): D1CollectionController {
   const limits = Object.freeze({
     maxBindings: positiveInteger(options.limits.maxBindings, 'limits.maxBindings'),
@@ -96,8 +157,8 @@ export function createD1CollectionController(options: {
   })
   let bundleSizes = new Map<Sha256Digest, number>()
   let prepared: PreparedCollection | undefined
-  let served: D1ServedCollectionSnapshot | null = null
-  let activeBindings: ReadonlyMap<string, PreparedBinding> = new Map()
+  let served: ServedState | null = null
+  let retirement: PendingRetirement | undefined
   let tail: Promise<unknown> = Promise.resolve()
 
   const serialized = <T>(operation: () => Promise<T>): Promise<T> => {
@@ -108,6 +169,13 @@ export function createD1CollectionController(options: {
   const clearPrepared = async (): Promise<void> => {
     prepared = await disposeCandidateOnly(prepared)
     if (prepared) fail()
+  }
+  const settleRetirement = async (): Promise<void> => {
+    if (!retirement) return
+    if (!options.retireRemoved) fail(D1HostErrorCode.PUBLICATION_FAILED, 'retirement')
+    const pending = retirement
+    try { await options.retireRemoved(pending) } catch { fail(D1HostErrorCode.PUBLICATION_FAILED, 'retirement') }
+    if (retirement === pending) retirement = undefined
   }
 
   const resolve = async (plan: D1PersistedPlanV1) => {
@@ -136,7 +204,10 @@ export function createD1CollectionController(options: {
 
   const preload = async (candidate: D1StoredCandidateV1, runtimeInputs: readonly D1RuntimeInputsIdentityV1[]): Promise<D1ObservationV1> => {
     try {
-      const desired = candidate.desired
+      if (retirement) fail(D1HostErrorCode.PUBLICATION_FAILED, 'retirement')
+      const identity = canonicalizeD1ActiveEnvelope({ schemaVersion: 1, revisionId: candidate.revisionId, desiredStateDigest: candidate.desiredStateDigest })
+      const desired = await canonicalizeD1DesiredSnapshot(candidate.desired)
+      if (await digestD1Desired(desired) !== identity.desiredStateDigest) fail()
       if (desired.plan.bindings.length > limits.maxBindings || desired.resolvedBindings.some((value) => !bundleSizes.has(value.resolvedDigest))) fail()
       const total = desired.resolvedBindings.reduce((sum, value) => sum + bundleSizes.get(value.resolvedDigest)!, 0)
       if (desired.resolvedBindings.some((value) => bundleSizes.get(value.resolvedDigest)! > limits.maxBundleBytes) || total > limits.maxTotalBundleBytes) fail(D1HostErrorCode.COLLECTION_LIMIT_EXCEEDED, 'bundleBytes')
@@ -148,15 +219,21 @@ export function createD1CollectionController(options: {
       }, desired).catch(() => fail())
       if (runtimeInputs.length !== observation.bindings.length || new Set(runtimeInputs.map((value) => value.bindingId)).size !== observation.bindings.length) fail()
       const inputs = new Map(observation.bindings.map((value) => [value.bindingId, value.runtimeInputs]))
+      const activeBindings = served?.bindings ?? new Map<string, PreparedBinding>()
+      if (served && !sameHostExecution(desired.plan, served.collection.desired.plan)) fail(D1HostErrorCode.ACTIVE_BINDING_RESTART_REQUIRED, 'plan')
+      const removed = new Map<string, PreparedBinding>()
       for (const [bindingId, value] of activeBindings) {
         const next = desired.resolvedBindings.find((binding) => binding.bindingId === bindingId)
         const binding = desired.plan.bindings.find((candidate) => candidate.bindingId === bindingId)
-        if (!next || !binding || next.resolvedDigest !== value.resolvedDigest || !sameExecutionBinding(binding, value.binding)
+        if (!next || !binding) { removed.set(bindingId, value); continue }
+        if (next.resolvedDigest !== value.resolvedDigest || !sameExecutionBinding(binding, value.binding)
           || inputs.get(bindingId)?.digest !== value.runtimeInputs.digest) fail(D1HostErrorCode.ACTIVE_BINDING_RESTART_REQUIRED, 'bindingId')
       }
       await clearPrepared()
       const bindings = new Map<string, PreparedBinding>()
-      for (const [bindingId, value] of activeBindings) bindings.set(bindingId, { ...value, candidateOnly: false })
+      for (const [bindingId, value] of activeBindings) {
+        if (!removed.has(bindingId)) bindings.set(bindingId, { ...value, candidateOnly: false })
+      }
       const additions = desired.resolvedBindings.filter((value) => !bindings.has(value.bindingId))
       let cursor = 0; let failure: unknown
       const workers = Array.from({ length: Math.min(limits.maxConcurrentPreloads, additions.length) }, async () => {
@@ -166,17 +243,22 @@ export function createD1CollectionController(options: {
           if (!input) { failure = new Error(); return }
           try {
             const handle = await options.preloadBinding(binding, input)
-            if (!handle || typeof handle.dispose !== 'function') throw new Error()
-            bindings.set(binding.bindingId, { resolvedDigest: binding.resolvedDigest, runtimeInputs: input, binding: desired.plan.bindings.find((value) => value.bindingId === binding.bindingId)!, handle, candidateOnly: true })
+            if (!handle || typeof handle !== 'object') throw new Error()
+            const dispose = dataProperty(handle, 'dispose')
+            if (typeof dispose !== 'function') throw new Error()
+            const capturedDispose = dispose.bind(handle) as () => Promise<void>
+            const value = { resolvedDigest: binding.resolvedDigest, runtimeInputs: input, binding: desired.plan.bindings.find((item) => item.bindingId === binding.bindingId)!, dispose: capturedDispose, candidateOnly: true }
+            bindings.set(binding.bindingId, value)
+            bindings.set(binding.bindingId, { ...value, recipe: captureRecipe(dataProperty(handle, 'recipe'), binding) })
           } catch (error) { failure = error }
         }
       })
       await Promise.all(workers)
       if (failure || bindings.size !== desired.resolvedBindings.length) {
-        prepared = { state: 'cleanup', revisionId: candidate.revisionId, desiredStateDigest: candidate.desiredStateDigest, bindings }
+        prepared = { state: 'cleanup', revisionId: identity.revisionId, desiredStateDigest: identity.desiredStateDigest, bindings, removed, desired, observation }
         await clearPrepared(); fail()
       }
-      prepared = { state: 'ready', revisionId: candidate.revisionId, desiredStateDigest: candidate.desiredStateDigest, bindings }
+      prepared = { state: 'ready', revisionId: identity.revisionId, desiredStateDigest: identity.desiredStateDigest, bindings, removed, desired, observation }
       return observation
     } catch (error) {
       if (error instanceof D1HostError) throw error
@@ -188,25 +270,86 @@ export function createD1CollectionController(options: {
     return prepared
   }
   return Object.freeze({
-    resolver, preload: (candidate: D1StoredCandidateV1, runtimeInputs: readonly D1RuntimeInputsIdentityV1[]) => serialized(() => preload(candidate, runtimeInputs)),
-    serve: (active: D1ActiveEnvelopeV1) => serialized(async () => {
+    resolver, preload: (candidate: D1StoredCandidateV1, runtimeInputs: readonly D1RuntimeInputsIdentityV1[]) => {
+      let capturedCandidate: D1StoredCandidateV1; let capturedInputs: D1RuntimeInputsIdentityV1[]
+      try { capturedCandidate = structuredClone(candidate); capturedInputs = structuredClone(runtimeInputs) }
+      catch { return Promise.reject(new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field: 'collection' })) }
+      return serialized(() => preload(capturedCandidate, capturedInputs))
+    },
+    serve: (rawActive: D1ActiveEnvelopeV1, rawTransition: D1RollbackTransition | undefined) => {
+      let active: D1ActiveEnvelopeV1; let transition: D1RollbackTransition | undefined
+      try { active = canonicalizeD1ActiveEnvelope(rawActive); transition = captureTransition(rawTransition) }
+      catch (error) { return Promise.reject(error) }
+      return serialized(async () => {
       if (prepared?.state === 'cleanup') { await clearPrepared(); fail() }
       const next = exactPrepared(active)
-      const bindings = new Map([...next.bindings].map(([id, value]) => [id, Object.freeze({ resolvedDigest: value.resolvedDigest, handle: value.handle })]))
-      activeBindings = next.bindings
-      served = Object.freeze({
+      const removalBindingIds = [...next.removed.keys()].sort()
+      if (removalBindingIds.length > 0) {
+        const authorization = transition?.authorization
+        if (transition?.kind !== 'rollback' || !authorization || !served || !options.retireRemoved || !options.commitRollback
+          || authorization.hostId !== next.desired.plan.hostId
+          || authorization.expectedRevision !== served.collection.active.revisionId
+          || authorization.expectedDigest !== served.collection.active.desiredStateDigest
+          || authorization.targetRevision !== active.revisionId || authorization.targetDigest !== active.desiredStateDigest
+          || authorization.removalBindingIds.length !== removalBindingIds.length
+          || authorization.removalBindingIds.some((id, index) => id !== removalBindingIds[index])
+          || [...next.bindings.values()].some((value) => value.candidateOnly)) {
+          fail(D1HostErrorCode.ROLLBACK_TARGET_INVALID, 'removalBindingIds')
+        }
+      } else if (transition !== undefined) fail(D1HostErrorCode.ROLLBACK_TARGET_INVALID, 'removalBindingIds')
+      const completion = await createD1CompleteEnvelope(active.revisionId, next.desired, next.observation)
+      if (completion.desiredStateDigest !== active.desiredStateDigest) fail(D1HostErrorCode.PUBLICATION_FAILED, 'completion')
+      const bindings = new Map([...next.bindings].map(([id, value]) => [id, Object.freeze({ resolvedDigest: value.resolvedDigest })]))
+      const snapshot = Object.freeze({
         revisionId: active.revisionId, desiredStateDigest: active.desiredStateDigest,
         bindingIds: Object.freeze([...bindings.keys()].sort()), lookup: (bindingId: string) => bindings.get(bindingId),
       })
-      prepared = undefined
+      const state = Object.freeze({
+        collection: Object.freeze({ active: Object.freeze({ ...active }), desired: next.desired, observation: next.observation, completion }),
+        bindings: next.bindings, snapshot,
+      })
+      const prior = served
+      if (next.removed.size > 0) {
+        const pending = Object.freeze({ prior: prior!.collection.active, next: state.collection.active,
+          removals: Object.freeze([...next.removed].map(([bindingId, value]) => {
+            let disposed = false
+            return Object.freeze({ bindingId, async dispose() { if (!disposed) { await value.dispose(); disposed = true } } })
+          })) })
+        let open = true; let committed = false; let coordinatorFailed = false
+        try {
+          await options.commitRollback!(transition!.authorization, () => {
+            if (!open || committed) fail(D1HostErrorCode.PUBLICATION_FAILED, 'rollbackCommit')
+            retirement = pending; served = state; committed = true
+          })
+        } catch { coordinatorFailed = true } finally { open = false }
+        if (!committed) fail(D1HostErrorCode.PUBLICATION_FAILED, 'rollbackCommit')
+        prepared = undefined
+        await settleRetirement()
+        if (coordinatorFailed) fail(D1HostErrorCode.PUBLICATION_FAILED, 'rollbackCommit')
+      } else {
+        served = state
+        prepared = undefined
+      }
       return Object.freeze({ revisionId: active.revisionId, desiredStateDigest: active.desiredStateDigest })
-    }),
+      })
+    },
+    settleRetirement: () => serialized(settleRetirement),
     discardPrepared: (active: D1ActiveEnvelopeV1) => serialized(async () => {
       if (prepared?.state === 'cleanup') {
         if (prepared.revisionId !== active.revisionId || prepared.desiredStateDigest !== active.desiredStateDigest) fail()
       } else exactPrepared(active)
       await clearPrepared()
     }),
-    snapshot: () => served,
+    snapshot: () => served?.snapshot ?? null,
+    async read() { return served?.collection ?? null },
+    async readRecipe(workspaceId: string, activeRevision?: string) {
+      const current = served
+      if (!current || activeRevision !== undefined && current.collection.active.revisionId !== activeRevision) fail(D1HostErrorCode.PUBLICATION_FAILED, 'agentArtifacts')
+      const matches = [...current.bindings.values()].filter((value) => value.binding.workspaceId === workspaceId)
+      if (matches.length !== 1) fail(D1HostErrorCode.PUBLICATION_FAILED, 'agentArtifacts')
+      const recipe = matches[0]!.recipe
+      if (!recipe) fail(D1HostErrorCode.PUBLICATION_FAILED, 'agentArtifacts')
+      return recipe
+    },
   })
 }

--- a/apps/full-app/src/server/deployment/d1AgentRuntimeRecipe.ts
+++ b/apps/full-app/src/server/deployment/d1AgentRuntimeRecipe.ts
@@ -1,7 +1,7 @@
 import type { Sha256Digest } from '@hachej/boring-agent/shared'
 
 import { validateD1AgentArtifact } from './d1AgentArtifactSnapshot.js'
-import type { D1AgentArtifactReader } from './activeCollectionReader.js'
+import type { D1ActiveCollectionReader, D1AgentArtifactReader } from './activeCollectionReader.js'
 import { D1HostError, D1HostErrorCode } from './d1Plan.js'
 
 export interface WorkspaceAgentRuntimeRecipe {
@@ -32,7 +32,11 @@ function unavailable(): never {
   throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'agentArtifacts' })
 }
 
-async function selectWorkspaceAgent(activeReader: D1AgentArtifactReader, workspaceId: string, activeRevision?: string) {
+export interface D1AgentRuntimeRecipeSource extends D1ActiveCollectionReader {
+  readRecipe(workspaceId: string, activeRevision?: string): Promise<WorkspaceAgentRuntimeRecipe>
+}
+
+async function selectWorkspaceAgent(activeReader: D1ActiveCollectionReader, workspaceId: string, activeRevision?: string) {
   const collection = await activeReader.read()
   if (!collection || (activeRevision !== undefined && collection.active.revisionId !== activeRevision)) unavailable()
   const matches = collection.desired.plan.bindings.filter((binding) => binding.workspaceId === workspaceId)
@@ -44,7 +48,7 @@ async function selectWorkspaceAgent(activeReader: D1AgentArtifactReader, workspa
 }
 
 export function createD1AgentRuntimeIdentityResolver(
-  activeReader: D1AgentArtifactReader,
+  activeReader: D1ActiveCollectionReader,
 ): D1AgentRuntimeIdentityResolver {
   return async (workspaceId, activeRevision) => {
     const selected = await selectWorkspaceAgent(activeReader, workspaceId, activeRevision)
@@ -59,8 +63,10 @@ export function createD1AgentRuntimeIdentityResolver(
 
 export function createD1AgentRuntimeRecipeResolver(
   activeReader: D1AgentArtifactReader,
+  source?: D1AgentRuntimeRecipeSource,
 ): D1AgentRuntimeRecipeResolver {
   return async (workspaceId, activeRevision) => {
+    if (source) return source.readRecipe(workspaceId, activeRevision)
     const { collection, binding, expected } = await selectWorkspaceAgent(activeReader, workspaceId, activeRevision)
     const envelope = await activeReader.readAgentArtifact(collection, binding)
     await validateD1AgentArtifact(envelope, binding, expected)

--- a/apps/full-app/src/server/deployment/d1ServerWiring.ts
+++ b/apps/full-app/src/server/deployment/d1ServerWiring.ts
@@ -8,6 +8,7 @@ import type { FastifyInstance } from 'fastify'
 
 import { createD1ActiveCollectionReader, type D1ActiveCollectionReader } from './activeCollectionReader.js'
 import type { D1AdmissionLedger } from './admissionLedger.js'
+import type { D1ServedCollectionAuthority } from './bootCollection.js'
 import { createD1LandingRootHandler } from './d1Landing.js'
 import {
   createD1AgentRuntimeIdentityResolver,
@@ -38,6 +39,7 @@ export interface D1ServerWiring {
 export interface D1ServerWiringDependencies {
   readonly admissionLedger?: Pick<D1AdmissionLedger, 'admit'>
   readonly candidatePreloader?: D1UserNeutralCandidatePreloader
+  readonly servedCollection?: D1ServedCollectionAuthority
 }
 
 function admissionFailed(): AgentEffectAdmissionError {
@@ -91,16 +93,17 @@ export function createD1ServerWiring(
   const proxy = config.security?.trustedProxy
   if (typeof proxy !== 'object' || proxy === null || proxy.hops !== 1 || !Array.isArray(proxy.cidrs)
     || proxy.cidrs.length !== 1 || proxy.cidrs[0] !== `${D1_TRUSTED_CADDY_PEER}/32`) invalidD1Field('trustedProxy')
-  const activeReader = createD1ActiveCollectionReader({
+  const diskReader = createD1ActiveCollectionReader({
     hostRoot: path.join('/var/lib/boring/d1', hostId), hostId,
     ownerUid: publicationOwnerUid, appGid: APP_GID,
   })
+  const activeReader = dependencies.servedCollection ?? diskReader
   return Object.freeze({
     requestScopeResolver: createD1HostSurfaceResolver({ activeReader, trustedPeer: D1_TRUSTED_CADDY_PEER }),
     frontendRootHandler: createD1LandingRootHandler({ activeReader }),
     admitAgentEffect: createD1AgentEffectAdmission({ hostId, activeReader, admissionLedger: dependencies.admissionLedger }),
     resolveAgentRuntimeIdentity: createD1AgentRuntimeIdentityResolver(activeReader),
-    resolveAgentRuntimeRecipe: createD1AgentRuntimeRecipeResolver(activeReader),
+    resolveAgentRuntimeRecipe: createD1AgentRuntimeRecipeResolver(diskReader, dependencies.servedCollection),
     ...(dependencies.candidatePreloader ? { candidatePreloader: dependencies.candidatePreloader } : {}),
     registerReadiness(app: FastifyInstance) { registerD1ReadinessRoute(app, { activeReader }) },
   })


### PR DESCRIPTION
## Summary

Adds the single in-process served-collection authority for D1. Prepared collections remain invisible until one synchronous immutable reference swap; additive publication retains existing user-neutral handles and rollback requires the exact normalized D1-004e active-to-target identity plus an injected trusted commit coordinator.

## Issue / Slice

- Bead: `wt-391-forward-vup.2.3.2`
- D1-005c2a2 served-collection authority + exact rollback

## What Changed

- Routes host surface, landing, readiness, effect admission, admission-ledger rereads, A0 identity, and A0 recipe through one injected served authority.
- Recanonicalizes and digest-binds candidate state before staging; rejects host or retained-binding execution drift.
- Captures validated immutable recipe data and exact disposal callables before commit, preventing provider-handle TOCTOU.
- Commits additive state with one synchronous `served = state`; retained entries and prior snapshots remain live.
- Requires normalized exact rollback identity and an injected `commitRollback(identity, commitOnce)` coordinator; raw structural input alone cannot swap state.
- Retires removed user-neutral preparations only after commit, with explicit retry and per-removal idempotence.

## Proof

- `pnpm --filter full-app exec vitest run src/server/deployment/__tests__/bootCollection.test.ts src/server/deployment/__tests__/d1Activation.test.ts src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts` — 3 files, 18 tests passed.
- `git diff --check` — passed.
- Net diff: +231 lines, below the 400-line hard cap.
- Full deployment-directory run was attempted; unrelated sparse-worktree omissions (`plugins/boring-automation`, self-host scripts, and built governance/MCP package exports) prevent those suites/typecheck from starting locally. Changed-file focused tests and transforms are green; CI is the authoritative complete gate.

## Review

- Standards/spec/security: CLEAN, no P0-P2 findings after fixes.
- Thermo/security: CLEAN, no P0-P2 findings.
- Reviewed SHA: `f776031`.

## Risk / Rollback

- Mandatory Opus security gate: no auto-merge is armed.
- Revert this commit to restore disk-reader-only serving behavior.
- No actor-runtime lease-drain claim is made. The injected coordinator owns the D1-004e fence/drain boundary; this slice retires only user-neutral preparations after the swap.

## Next / Explicit Residual

- vup.2.4 must instantiate and inject this authority in production, provide the sole fenced D1-004e `commitRollback` adapter, and fix the current durable pointer/journal terminal ordering before admission safety is claimed.
- Durable pointer/socket transport, restart convergence, ingress-last ordering, and recovery remain vup.2.4.
- No warm-runtime, attestation, or end-to-end durable-publication claim is made here.