### PR TITLE
feat(d1): wire production collection authority

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts
@@ -24,7 +24,7 @@ async function deployed(id: string, content: string) {
     defaultDeploymentId: binding.defaultDeploymentId, workspaceCompositionDigest: compositionDigest })
   const envelope = { schemaVersion: 1, domain: 'boring-d1-agent-artifact:v1', hostId: 'host-1', bindingId: binding.bindingId,
     bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, bundle, deployment } satisfies D1AgentArtifactEnvelopeV1
-  return { binding, envelope, resolved: { schemaVersion: 1, bindingId: binding.bindingId,
+  return { binding, envelope, resolved: { schemaVersion: 1 as const, bindingId: binding.bindingId,
     composition: { snapshot: {} as never, digest: compositionDigest }, ...resolved } }
 }
 

--- a/apps/full-app/src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts
@@ -3,7 +3,7 @@ import { resolveAgentDeployment } from '@hachej/boring-agent/server'
 import { describe, expect, it } from 'vitest'
 
 import type { D1AgentArtifactEnvelopeV1 } from '../d1AgentArtifactSnapshot.js'
-import { createD1AgentRuntimeIdentityResolver, createD1AgentRuntimeRecipeResolver } from '../d1AgentRuntimeRecipe.js'
+import { createD1AgentRuntimeIdentityResolver, createD1AgentRuntimeRecipeResolver, loadD1ValidatedAgentArtifactRecipe } from '../d1AgentRuntimeRecipe.js'
 import type { D1ActiveCollection, D1AgentArtifactReader } from '../activeCollectionReader.js'
 import { D1HostErrorCode, type D1SiteBindingV1 } from '../d1Plan.js'
 
@@ -53,6 +53,16 @@ describe('D1 deployed-agent runtime recipe', () => {
     expect(JSON.stringify(insurance)).not.toContain('travel')
     expect(Object.isFrozen(insurance)).toBe(true); expect(Object.isFrozen(insurance.instructions)).toBe(true)
     expect(artifactReads).toBe(3)
+  })
+
+  it('projects a candidate artifact through the same validation path', async () => {
+    const value = await deployed('insurance', 'Compare insurance only.')
+    await expect(loadD1ValidatedAgentArtifactRecipe(value.envelope, value.binding, value.resolved)).resolves.toEqual({
+      workspaceId: value.binding.workspaceId, defaultDeploymentId: value.binding.defaultDeploymentId,
+      resolvedDigest: value.resolved.resolvedDigest, instructions: { ref: 'instructions.md', content: 'Compare insurance only.' },
+    })
+    await expect(loadD1ValidatedAgentArtifactRecipe(value.envelope, value.binding, { ...value.resolved, resolvedDigest: digest('f') }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
   })
 
   it('fails before runtime creation on revision or persisted digest mismatch', async () => {

--- a/apps/full-app/src/server/deployment/bootCollection.ts
+++ b/apps/full-app/src/server/deployment/bootCollection.ts
@@ -2,6 +2,7 @@ import type { Sha256Digest } from '@hachej/boring-agent/shared'
 
 import type { D1ActiveCollection, D1ActiveCollectionReader } from './activeCollectionReader.js'
 import type { WorkspaceAgentRuntimeRecipe } from './d1AgentRuntimeRecipe.js'
+import type { D1UserNeutralCandidateInput } from './d1UserNeutralPreloader.js'
 import type { D1DesiredResolver } from './d1Command.js'
 import { D1HostError, D1HostErrorCode, type D1HostPlanV1, type D1SiteBindingV1 } from './d1Plan.js'
 import {
@@ -145,7 +146,7 @@ async function disposeCandidateOnly(collection: PreparedCollection | undefined):
 export function createD1CollectionController(options: {
   readonly limits: D1CollectionLimits
   readonly resolveBinding: (binding: D1SiteBindingV1, plan: D1PersistedPlanV1) => Promise<D1ResolvedBundleV1>
-  readonly preloadBinding: (resolved: D1ResolvedBindingV1, runtimeInputs: D1RuntimeInputsIdentityV1) => Promise<D1PreparedBindingHandle>
+  readonly preloadBinding: (input: D1UserNeutralCandidateInput & D1ResolvedBindingV1) => Promise<D1PreparedBindingHandle>
   readonly retireRemoved?: (retirement: PendingRetirement) => Promise<void>
   readonly commitRollback?: D1RollbackCommit
 }): D1CollectionController {
@@ -242,7 +243,7 @@ export function createD1CollectionController(options: {
           const input = inputs.get(binding.bindingId)
           if (!input) { failure = new Error(); return }
           try {
-            const handle = await options.preloadBinding(binding, input)
+            const handle = await options.preloadBinding(Object.freeze({ ...binding, revisionId: identity.revisionId, binding: desired.plan.bindings.find((item) => item.bindingId === binding.bindingId)!, resolved: binding, runtimeInputs: input }))
             if (!handle || typeof handle !== 'object') throw new Error()
             const dispose = dataProperty(handle, 'dispose')
             if (typeof dispose !== 'function') throw new Error()

--- a/apps/full-app/src/server/deployment/d1AgentRuntimeRecipe.ts
+++ b/apps/full-app/src/server/deployment/d1AgentRuntimeRecipe.ts
@@ -1,7 +1,7 @@
 import type { Sha256Digest } from '@hachej/boring-agent/shared'
 
 import { validateD1AgentArtifact } from './d1AgentArtifactSnapshot.js'
-import type { D1ActiveCollectionReader, D1AgentArtifactReader } from './activeCollectionReader.js'
+import type { D1ActiveCollection, D1ActiveCollectionReader, D1AgentArtifactReader } from './activeCollectionReader.js'
 import { D1HostError, D1HostErrorCode } from './d1Plan.js'
 
 export interface WorkspaceAgentRuntimeRecipe {
@@ -61,6 +61,22 @@ export function createD1AgentRuntimeIdentityResolver(
   }
 }
 
+export async function loadD1ValidatedAgentArtifactRecipe(
+  envelope: Parameters<typeof validateD1AgentArtifact>[0],
+  binding: D1ActiveCollection['desired']['plan']['bindings'][number],
+  expected: D1ActiveCollection['desired']['resolvedBindings'][number],
+): Promise<WorkspaceAgentRuntimeRecipe> {
+  await validateD1AgentArtifact(envelope, binding, expected)
+  const instructions = envelope.bundle.assets.find((asset) => asset.path === expected.definition.instructionsRef)
+  if (!instructions) unavailable()
+  return Object.freeze({
+    workspaceId: binding.workspaceId,
+    defaultDeploymentId: binding.defaultDeploymentId,
+    resolvedDigest: expected.resolvedDigest,
+    instructions: Object.freeze({ ref: instructions.path, content: instructions.content }),
+  })
+}
+
 export function createD1AgentRuntimeRecipeResolver(
   activeReader: D1AgentArtifactReader,
   source?: D1AgentRuntimeRecipeSource,
@@ -68,15 +84,6 @@ export function createD1AgentRuntimeRecipeResolver(
   return async (workspaceId, activeRevision) => {
     if (source) return source.readRecipe(workspaceId, activeRevision)
     const { collection, binding, expected } = await selectWorkspaceAgent(activeReader, workspaceId, activeRevision)
-    const envelope = await activeReader.readAgentArtifact(collection, binding)
-    await validateD1AgentArtifact(envelope, binding, expected)
-    const instructions = envelope.bundle.assets.find((asset) => asset.path === expected.definition.instructionsRef)
-    if (!instructions) unavailable()
-    return Object.freeze({
-      workspaceId: binding.workspaceId,
-      defaultDeploymentId: binding.defaultDeploymentId,
-      resolvedDigest: expected.resolvedDigest,
-      instructions: Object.freeze({ ref: instructions.path, content: instructions.content }),
-    })
+    return loadD1ValidatedAgentArtifactRecipe(await activeReader.readAgentArtifact(collection, binding), binding, expected)
   }
 }

--- a/apps/full-app/src/server/deployment/d1ProductionAuthority.ts
+++ b/apps/full-app/src/server/deployment/d1ProductionAuthority.ts
@@ -1,0 +1,117 @@
+import { assertRealPathWithinWorkspace, createNodeWorkspace, resolveWorkspaceRoot, validatePath } from '@hachej/boring-agent/server'
+
+import { createD1CollectionController, D1_V1_COLLECTION_LIMITS, type D1CollectionController } from './bootCollection.js'
+import { loadD1ValidatedAgentArtifactRecipe } from './d1AgentRuntimeRecipe.js'
+import { D1HostError, D1HostErrorCode, strictD1HostId } from './d1Plan.js'
+import { createD1UserNeutralCandidatePreloader, type D1UserNeutralCandidateInput, type D1UserNeutralCandidatePreloader } from './d1UserNeutralPreloader.js'
+import { createHostRevisionStore, type D1StoredCompleteV1 } from './hostRevisionStore.js'
+
+const APP_GID = 10001
+const STATE_ROOT = '/var/lib/boring/d1'
+
+function unavailable(field: string): never {
+  throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field })
+}
+function failed(): never {
+  throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'agentArtifacts' })
+}
+
+/**
+ * The D1 core's only retained preparation is an immutable recipe and a validated
+ * workspace allocation. It deliberately does not create a user/session runtime.
+ */
+export interface D1ProductionAuthority {
+  readonly servedCollection: D1CollectionController
+  readonly candidatePreloader: D1UserNeutralCandidatePreloader
+  recover(): Promise<void>
+}
+
+export function createD1ProductionAuthority(options: {
+  readonly hostId: string
+  readonly ownerUid: number
+  readonly appGid?: number
+}): D1ProductionAuthority {
+  const hostId = strictD1HostId(options.hostId, 'hostId')
+  const store = createHostRevisionStore({ root: STATE_ROOT, ownerUid: options.ownerUid, appGid: options.appGid ?? APP_GID })
+  let recovery: D1StoredCompleteV1 | undefined
+  const preloader = createD1UserNeutralCandidatePreloader({
+    async loadValidatedRecipe(input) {
+      try {
+        const artifact = await store.readAgentArtifact(hostId, input.revisionId, input.binding.bindingId)
+        if (!artifact) failed()
+        return await loadD1ValidatedAgentArtifactRecipe(artifact, input.binding, input.resolved)
+      } catch (error) {
+        if (error instanceof D1HostError) throw error
+        failed()
+      }
+    },
+    async prepareWorkspaceAllocation(input) {
+      try {
+        if (input.runtimeInputs.workspaceAllocation.ref !== input.binding.workspaceAllocationRef) failed()
+        const root = resolveWorkspaceRoot()
+        const allocationPath = validatePath(root, input.binding.workspaceId)
+        await assertRealPathWithinWorkspace(root, allocationPath)
+        const workspace = createNodeWorkspace(allocationPath)
+        await workspace.stat('.')
+        return Object.freeze({
+          workspaceId: input.binding.workspaceId,
+          ref: input.runtimeInputs.workspaceAllocation.ref,
+          versionFingerprint: input.runtimeInputs.workspaceAllocation.versionFingerprint,
+          async dispose() {},
+        })
+      } catch (error) {
+        if (error instanceof D1HostError) throw error
+        unavailable('workspaceAllocation')
+      }
+    },
+  })
+  const servedCollection = createD1CollectionController({
+    limits: D1_V1_COLLECTION_LIMITS,
+    // Child 2 supplies the root-controlled immutable target artifact handoff.
+    // Until then, only recovery may resolve a persisted immutable revision.
+    resolveBinding: async (binding, plan) => {
+      try {
+        const target = recovery
+        if (!target || JSON.stringify(plan) !== JSON.stringify(target.desired.plan)) unavailable('resolver')
+        const resolved = target.desired.resolvedBindings.find((value) => value.bindingId === binding.bindingId)
+        const artifact = await store.readAgentArtifact(hostId, target.revisionId, binding.bindingId)
+        if (!resolved || !artifact) failed()
+        await loadD1ValidatedAgentArtifactRecipe(artifact, binding, resolved)
+        return Object.freeze({
+          resolved,
+          bundleBytes: artifact.bundle.assets.reduce((total, asset) => total + new TextEncoder().encode(asset.content).byteLength, 0),
+        })
+      } catch (error) {
+        if (error instanceof D1HostError) throw error
+        unavailable('resolver')
+      }
+    },
+    preloadBinding: async (input: D1UserNeutralCandidateInput) => {
+      const prepared = await preloader.prepare(input)
+      return Object.freeze({ recipe: prepared.recipe, dispose: prepared.dispose })
+    },
+  })
+  return Object.freeze({
+    servedCollection,
+    candidatePreloader: preloader,
+    async recover() {
+      try {
+        const active = await store.readActive(hostId)
+        if (!active) return
+        const complete = await store.readComplete(hostId, active.revisionId)
+        if (!complete || complete.desiredStateDigest !== active.desiredStateDigest) failed()
+        const inputs = complete.observation.bindings.map((binding) => binding.runtimeInputs)
+        recovery = complete
+        try {
+          const reproduced = await servedCollection.resolver.reproduce(complete)
+          if (JSON.stringify(reproduced) !== JSON.stringify(complete.desired)) failed()
+          await servedCollection.preload(complete, inputs)
+          await servedCollection.serve(active)
+        } finally { recovery = undefined }
+      } catch (error) {
+        if (error instanceof D1HostError) throw error
+        unavailable('recovery')
+      }
+    },
+  })
+}

--- a/apps/full-app/src/server/main.ts
+++ b/apps/full-app/src/server/main.ts
@@ -19,6 +19,7 @@ import {
 import { assertProductionAgentModeIsSafe } from './productionSafety.js'
 import type { WorkspaceAgentDispatcherResolver } from '@hachej/boring-agent/server'
 import type { FastifyRequest } from 'fastify'
+import { createD1ProductionAuthority } from './deployment/d1ProductionAuthority.js'
 import { createD1ServerWiring } from './deployment/d1ServerWiring.js'
 
 function pluginAuthoringEnabledFromEnv(): boolean {
@@ -32,7 +33,12 @@ async function main() {
     allowMissingSecrets: process.env.NODE_ENV !== 'production',
     tomlPath: path.resolve(appRoot, 'boring.app.toml'),
   })
-  const d1 = createD1ServerWiring(config)
+  const authority = process.env.BORING_D1_HOST_ID === undefined ? undefined : createD1ProductionAuthority({
+    hostId: process.env.BORING_D1_HOST_ID,
+    ownerUid: Number(process.env.BORING_D1_OWNER_UID),
+  })
+  await authority?.recover()
+  const d1 = createD1ServerWiring(config, process.env, authority)
   const { governance, ...pluginComposition } = await createFullAppHostPluginComposition(config)
   // Build the metering sink up-front; the credit service attaches after the
   // server (and its db) exists.

--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -29,6 +29,8 @@ export {
 } from './sandbox/vercel-sandbox/deploymentSnapshot'
 export type { VercelDeploymentSnapshotOptions } from './sandbox/vercel-sandbox/deploymentSnapshot'
 export { createNodeWorkspace } from './workspace/createNodeWorkspace'
+export { assertRealPathWithinWorkspace, validatePath } from './workspace/paths'
+export { resolveWorkspaceRoot } from './config/workspaceRoot'
 export { createRemoteWorkerModeAdapter } from './runtime/modes/remote-worker'
 export type { RemoteWorkerModeAdapterOptions } from './runtime/modes/remote-worker'
 export { createRemoteWorkerWorkspace } from './workspace/createRemoteWorkerWorkspace'


### PR DESCRIPTION
## Summary
Wire the D1 served-collection authority from immutable revision artifacts and a user-neutral validated workspace allocation. Recover the durable active revision before listen; D1 consumers use the served authority rather than disk state.

## Issue / Slice
wt-391-forward-vup.2.4.1

## Proof
- `pnpm --filter @hachej/boring-agent typecheck` — pass.
- `cd apps/full-app && pnpm exec vitest run src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts` — pass (3 tests).
- `pnpm --filter full-app typecheck` remains blocked by pre-existing/unbuilt workspace dependencies; after building agent/core/workspace, governance fails to build because `@hachej/boring-bash/server` is unavailable.

## Review
Mandatory durable-publication security review is required before merge. No auto-merge.

## Risk / Rollback
Recovery remains fail-closed for malformed/missing immutable state. Revert this PR to restore the prior disk-backed production authority behavior.

## Next
Owner security review and sign-off; do not merge automatically.