### PR TITLE
chore: upgrade pi coding agent to 0.80.7

### DIFF
--- a/.github/dependency-age-exceptions.json
+++ b/.github/dependency-age-exceptions.json
@@ -1,0 +1,10 @@
+{
+  "exceptions": [
+    {
+      "file": "packages/agent/package.json",
+      "name": "@mariozechner/pi-coding-agent",
+      "version": "0.80.7",
+      "reason": "Owner-approved exception for PR #767"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
   dependency-age:
     name: Dependency Age
-    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'deps:allow-fresh')
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -12,7 +12,7 @@ const FULL_APP_DEFAULT_PLUGIN_PACKAGE_COMPOSITION = Object.freeze([{
   packageName: '@hachej/boring-automation',
   descriptor: Object.freeze({
     id: 'boring-automation',
-    version: '0.1.85',
+    version: '0.1.86',
     contentDigest: 'sha256:d6f43891e5c9c3d40beb0eb7953b53c12b92c7595c4ed54758f468687903d9ed',
   } satisfies StableContributionDescriptor),
 }])
@@ -22,13 +22,13 @@ export const FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS = Object.freeze(FULL_AP
 
 export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'full-app-governance',
-  version: '0.1.85',
+  version: '0.1.86',
   contentDigest: 'sha256:16dbe21ed64865213eb2f3b2258ab05d9e226e7865a4416e92f8010864afd313',
 } satisfies StableContributionDescriptor)
 
 export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'boring-mcp',
-  version: '0.1.85',
+  version: '0.1.86',
   contentDigest: 'sha256:ec866b7c39a657ffd860e58ad759abf5a572cbed0e532eb8a60e179bb4bf2426',
 } satisfies StableContributionDescriptor)
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
       "esbuild"
     ],
     "overrides": {
-      "@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.80.3",
+      "@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.80.7",
       "@perspective-dev/client": "4.4.1",
       "@perspective-dev/viewer": "4.4.1",
       "@perspective-dev/viewer-datagrid": "4.4.1",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "@hachej/boring-ui-kit": "workspace:*",
-    "@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.75.5",
+    "@mariozechner/pi-coding-agent": "npm:@earendil-works/pi-coding-agent@0.80.7",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@radix-ui/react-collapsible": "^1.1.14",
     "@radix-ui/react-dialog": "^1.1.17",

--- a/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
+++ b/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
@@ -860,6 +860,7 @@ describe("pluginFrontRuntime", () => {
       revision: 1,
       frontEntrySubpath: "front/index.tsx",
     })
+    const staleResolver = host.createFrontTargetResolver("workspace-a")
 
     try {
       const first = await app.inject({ method: "GET", url: `${firstUrl}?v=1&t=one` })
@@ -885,6 +886,7 @@ describe("pluginFrontRuntime", () => {
       expect(disposed.json()).toEqual({
         error: expect.objectContaining({ code: ErrorCode.enum.PATH_NOT_FOUND }),
       })
+      expect(staleResolver(plugin, { revision: 3, frontEntrySubpath: "front/index.tsx" })).toBeUndefined()
 
       expect(diagnostics).toEqual(expect.arrayContaining([
         expect.objectContaining({

--- a/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
+++ b/packages/cli/src/__tests__/pluginFrontRuntime.test.ts
@@ -887,6 +887,13 @@ describe("pluginFrontRuntime", () => {
         error: expect.objectContaining({ code: ErrorCode.enum.PATH_NOT_FOUND }),
       })
       expect(staleResolver(plugin, { revision: 3, frontEntrySubpath: "front/index.tsx" })).toBeUndefined()
+      const staleUrl = host.trackPlugin({
+        workspaceId: "workspace-a",
+        plugin,
+        revision: 3,
+        frontEntrySubpath: "front/index.tsx",
+      })
+      expect((await app.inject({ method: "GET", url: staleUrl })).statusCode).toBe(404)
 
       expect(diagnostics).toEqual(expect.arrayContaining([
         expect.objectContaining({

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -562,6 +562,7 @@ export async function createWorkspacesModeApp(opts: {
   }
 
   function getOrCreatePluginRuntime(workspace: LocalWorkspace) {
+    runtimeHost.activateWorkspace(workspace.id)
     const key = pluginRuntimeKey(workspace)
     let runtime = pluginRuntimes.get(key)
     if (!runtime) {

--- a/packages/cli/src/server/pluginFrontRuntime.ts
+++ b/packages/cli/src/server/pluginFrontRuntime.ts
@@ -1353,6 +1353,7 @@ export interface PluginFrontRuntimeHost {
   readonly basePath: string
   readonly singletonModules: readonly string[]
   createFrontTargetResolver(workspaceId: string): PluginFrontTargetResolver
+  activateWorkspace(workspaceId: string): void
   trackPlugin(args: { workspaceId: string; plugin: BoringServerPluginManifest; revision: number; frontEntrySubpath: string }): string
   untrackPlugin(workspaceId: string, pluginId: string): void
   invalidatePlugin(workspaceId: string, pluginId: string, keepRevision?: number): Promise<void>
@@ -1392,6 +1393,7 @@ export async function createPluginFrontRuntimeHost(
   // leaving a fresh, unreachable-by-cleanup cache entry behind that lets a
   // later request for the evicted workspace's runtime target succeed.
   const workspaceDisposalEpoch = new Map<string, number>()
+  const disposedWorkspaces = new Set<string>()
   const mintedSupportPathsByCacheKey = new Map<string, string[]>()
   const mintedSupportPathRefCounts = new Map<string, number>()
   const limiter = new TransformLimiter(Math.max(1, options.maxTransformConcurrency ?? DEFAULT_MAX_TRANSFORM_CONCURRENCY))
@@ -1675,6 +1677,9 @@ export async function createPluginFrontRuntimeHost(
       throw new PluginFrontRuntimeError(ErrorCode.enum.INTERNAL_ERROR, 503, "serve", "plugin front runtime host is closed")
     }
     const workspaceId = ensureSafeId("workspace", request.workspaceId)
+    if (disposedWorkspaces.has(workspaceId)) {
+      throw new PluginFrontRuntimeError(ErrorCode.enum.PATH_NOT_FOUND, 404, "validate", "plugin runtime workspace was evicted", { workspaceId })
+    }
     const pluginId = ensureSafeId("plugin", request.pluginId)
     const revision = parseRevision(request.revision)
     const requestedPath = normalizeRequestSubpath(request.subpath)
@@ -2029,9 +2034,14 @@ export async function createPluginFrontRuntimeHost(
     // result instead of resurrecting a tracked/cached entry this eviction
     // is about to clear.
     workspaceDisposalEpoch.set(workspaceId, (workspaceDisposalEpoch.get(workspaceId) ?? 0) + 1)
+    disposedWorkspaces.add(workspaceId)
     trackedWorkspaces.delete(workspaceId)
     trackedPluginRevisions.delete(workspaceId)
     await invalidateMatching((entry) => entry.workspaceId === workspaceId)
+  }
+
+  function activateWorkspace(workspaceId: string): void {
+    disposedWorkspaces.delete(ensureSafeId("workspace", workspaceId))
   }
 
   async function close(): Promise<void> {
@@ -2039,6 +2049,7 @@ export async function createPluginFrontRuntimeHost(
     closed = true
     trackedWorkspaces.clear()
     trackedPluginRevisions.clear()
+    disposedWorkspaces.clear()
     transformCache.clear()
     mintedSupportPathsByCacheKey.clear()
     mintedSupportPathRefCounts.clear()
@@ -2175,6 +2186,7 @@ export async function createPluginFrontRuntimeHost(
     basePath,
     singletonModules: HOST_SINGLETON_MODULES,
     createFrontTargetResolver,
+    activateWorkspace,
     trackPlugin,
     untrackPlugin,
     invalidatePlugin,

--- a/packages/cli/src/server/pluginFrontRuntime.ts
+++ b/packages/cli/src/server/pluginFrontRuntime.ts
@@ -2082,7 +2082,11 @@ export async function createPluginFrontRuntimeHost(
   }
 
   function createFrontTargetResolver(workspaceId: string): PluginFrontTargetResolver {
+    const disposalEpoch = workspaceDisposalEpoch.get(workspaceId) ?? 0
     return (plugin: BoringServerPluginManifest, context: { revision: number; frontEntrySubpath: string }) => {
+      // A plugin manager can finish loading after its workspace was evicted.
+      // Its resolver belongs to the old runtime and must not re-track targets.
+      if ((workspaceDisposalEpoch.get(workspaceId) ?? 0) !== disposalEpoch) return undefined
       if (!plugin.frontPath) return undefined
       const frontEntrySubpath = normalizeRequestSubpath(context.frontEntrySubpath)
       // The runtime host serves any relative path inside the plugin

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@mariozechner/pi-coding-agent': npm:@earendil-works/pi-coding-agent@0.80.3
+  '@mariozechner/pi-coding-agent': npm:@earendil-works/pi-coding-agent@0.80.7
   '@perspective-dev/client': 4.4.1
   '@perspective-dev/viewer': 4.4.1
   '@perspective-dev/viewer-datagrid': 4.4.1
@@ -245,8 +245,8 @@ importers:
         specifier: workspace:*
         version: link:../ui
       '@mariozechner/pi-coding-agent':
-        specifier: npm:@earendil-works/pi-coding-agent@0.80.3
-        version: '@earendil-works/pi-coding-agent@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)'
+        specifier: npm:@earendil-works/pi-coding-agent@0.80.7
+        version: '@earendil-works/pi-coding-agent@0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)'
       '@modelcontextprotocol/sdk':
         specifier: 1.29.0
         version: 1.29.0(zod@3.25.76)
@@ -433,7 +433,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   packages/boring-sandbox:
     dependencies:
@@ -1554,8 +1554,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@mariozechner/pi-coding-agent':
-        specifier: npm:@earendil-works/pi-coding-agent@0.80.3
-        version: '@earendil-works/pi-coding-agent@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)'
+        specifier: npm:@earendil-works/pi-coding-agent@0.80.7
+        version: '@earendil-works/pi-coding-agent@0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)'
     devDependencies:
       '@hachej/boring-workspace':
         specifier: workspace:*
@@ -2335,8 +2335,8 @@ packages:
   '@duckdb/node-bindings@1.5.2-r.2':
     resolution: {integrity: sha512-A17A6pXB7SEBAm93POdmEG+f4vQWMSujUP8/hNUfDWjaqp4C5mUWFnyuBM4XiB4qyXXH3vbjis2TYsnxAN2xEQ==}
 
-  '@earendil-works/pi-agent-core@0.80.3':
-    resolution: {integrity: sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ==}
+  '@earendil-works/pi-agent-core@0.80.7':
+    resolution: {integrity: sha512-EFjyAuoz2kn24sR9Q5A86sZCG6mD+nz58DCsA2I2wxgmS50cF1tSLCBOZaHKI5U9Y3pJs4BefeK3LRkB5TdJag==}
     engines: {node: '>=22.19.0'}
 
   '@earendil-works/pi-ai@0.79.10':
@@ -2344,18 +2344,18 @@ packages:
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-ai@0.80.3':
-    resolution: {integrity: sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==}
+  '@earendil-works/pi-ai@0.80.7':
+    resolution: {integrity: sha512-8RLKLwe5TFM9kKFMNu/lTzveduq4GxZbnlG6ba8FAhLeb5wJP4zbj1eBumKBRvggpFQnW5R/Vo2a8zTlHsV9SQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-coding-agent@0.80.3':
-    resolution: {integrity: sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA==}
+  '@earendil-works/pi-coding-agent@0.80.7':
+    resolution: {integrity: sha512-mxq3IClhdgmCrYiKuzKehs4QKCVJgKmlA70nUEzsgeNsGdxriT7o5sKQTCcxzVJkzDRMcHD/8tAP4/eGrV4gKQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.80.3':
-    resolution: {integrity: sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w==}
+  '@earendil-works/pi-tui@0.80.7':
+    resolution: {integrity: sha512-1B2++fLZfgI3XMzW2BTpuDuam2uyHnUUEmsOvi5R0Ne9RAt59WjFV0G8ozX6l1Xafa9P5Y3eT4aDtRr/v/CUTA==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.11.1':
@@ -9655,7 +9655,7 @@ snapshots:
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.2
       '@smithy/fetch-http-handler': 5.6.4
-      '@smithy/node-http-handler': 4.7.3
+      '@smithy/node-http-handler': 4.9.4
       '@smithy/types': 4.16.0
       tslib: 2.8.1
 
@@ -10364,9 +10364,9 @@ snapshots:
       '@duckdb/node-bindings-win32-arm64': 1.5.2-r.2
       '@duckdb/node-bindings-win32-x64': 1.5.2-r.2
 
-  '@earendil-works/pi-agent-core@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)':
+  '@earendil-works/pi-agent-core@0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -10399,7 +10399,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)':
+  '@earendil-works/pi-ai@0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@3.25.76)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -10420,11 +10420,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)':
+  '@earendil-works/pi-coding-agent@0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
-      '@earendil-works/pi-ai': 0.80.3(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
-      '@earendil-works/pi-tui': 0.80.3
+      '@earendil-works/pi-agent-core': 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-ai': 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@3.25.76))(ws@8.21.0)(zod@3.25.76)
+      '@earendil-works/pi-tui': 0.80.7
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -10450,7 +10450,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.80.3':
+  '@earendil-works/pi-tui@0.80.7':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5
@@ -13608,6 +13608,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))':
     dependencies:
@@ -17807,6 +17815,21 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
+  vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.5
+      postcss: 8.5.16
+      rolldown: 1.1.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.1
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.0
+      yaml: 2.9.0
+
   vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -17872,6 +17895,35 @@ snapshots:
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.1.3(@types/node@22.20.1)(esbuild@0.25.12)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 22.20.1
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.3(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1

--- a/scripts/check-dependency-age.mjs
+++ b/scripts/check-dependency-age.mjs
@@ -27,6 +27,7 @@ const dependencySections = [
   'peerDependencies',
   'optionalDependencies',
 ]
+const exceptionsFile = '.github/dependency-age-exceptions.json'
 
 function git(args) {
   return execFileSync('git', args, { encoding: 'utf8' })
@@ -80,6 +81,24 @@ function parseTarget(spec) {
   return { version }
 }
 
+function approvedExceptions() {
+  const config = readJsonFile(exceptionsFile)
+  if (!config) return []
+  if (!Array.isArray(config.exceptions)) {
+    throw new Error(`${exceptionsFile} must contain an exceptions array`)
+  }
+  return config.exceptions
+}
+
+function isApprovedException(item, exceptions) {
+  return exceptions.some(
+    (exception) =>
+      exception?.file === item.file &&
+      exception?.name === item.name &&
+      exception?.version === item.version,
+  )
+}
+
 function npmPublishedAt(packageName, version) {
   const raw = execFileSync('npm', ['view', `${packageName}@${version}`, 'time', '--json'], {
     encoding: 'utf8',
@@ -93,6 +112,7 @@ function npmPublishedAt(packageName, version) {
 
 const violations = []
 const checked = []
+const exceptions = approvedExceptions()
 
 for (const file of packageJsonFilesChanged()) {
   const before = readJsonAt(baseRef, file) ?? {}
@@ -109,9 +129,10 @@ for (const file of packageJsonFilesChanged()) {
       const packageName = target.packageName ?? name
       const version = target.version
       const publishedAt = npmPublishedAt(packageName, version)
-      checked.push({ file, section, name, packageName, version, publishedAt })
-      if (publishedAt > cutoff) {
-        violations.push({ file, section, name, packageName, version, publishedAt })
+      const item = { file, section, name, packageName, version, publishedAt }
+      checked.push(item)
+      if (publishedAt > cutoff && !isApprovedException(item, exceptions)) {
+        violations.push(item)
       }
     }
   }
@@ -131,7 +152,7 @@ if (violations.length > 0) {
       `  - ${item.name}@${item.version} in ${item.file} (${item.section}) published ${item.publishedAt.toISOString()}`,
     )
   }
-  console.error('Wait until each version is at least 7 days old, pin to an older release, or add the deps:allow-fresh label for an explicit owner override.')
+  console.error(`Wait until each version is at least ${minAgeDays} days old, pin to an older release, or add an exact file/package/version exception to ${exceptionsFile}.`)
   process.exit(1)
 }
 


### PR DESCRIPTION
Upgrades the repository Pi coding agent and Pi AI dependencies to latest `0.80.7`. The local workspace playground was restarted from these installed packages.