### PR TITLE
#769 docs: route feature feedback to roadmap backlog

### DIFF
--- a/.agents/skills/ask-boring/SKILL.md
+++ b/.agents/skills/ask-boring/SKILL.md
@@ -9,7 +9,7 @@ Router only. Do not edit files, create issues, plan, implement, review, or merge
 
 ## Routes
 
-- `feedback` — user is reporting a bug, idea, UX issue, feature request, or rough observation that should become a GitHub issue.
+- `feedback` — user is reporting a bug, idea, UX issue, feature request, or rough observation. Bugs become GitHub issues; feature ideas become Project #7 backlog drafts unless work is committed.
 - `triage` — an existing issue/PR needs classification, verification, or a next state.
 - `plan` — the desired outcome needs a spec, implementation plan, slices, blockers, or proof path before coding.
 - `implement` — one issue/slice is ready for an agent to build.

--- a/.agents/skills/feedback/SKILL.md
+++ b/.agents/skills/feedback/SKILL.md
@@ -1,36 +1,34 @@
 ---
 name: feedback
-description: Create a GitHub issue from user feedback with safe context and simple labels. Never implement.
+description: Capture feedback safely: file confirmed bugs as GitHub issues and route feature ideas to the Product Backlog. Never implement.
 ---
 
 # Feedback
 
-Create the source GitHub issue and stop. Do not implement. Do not split into tickets.
+Capture the report, route it, and stop. Do not implement or split work.
 
-## Labels
+## Routing policy
 
-Apply exactly one category when possible:
-
-- `bug`
-- `enhancement`
-
-Apply exactly one state:
-
-- `needs-triage` — clear enough for triage
-- `needs-info` — clarification is needed
+- **Confirmed bug or regression:** create a GitHub issue. GitHub Issues are the operational queue for bugs and active work.
+- **Feature request, idea, UX wish, or future work:** create a **draft item** in [Project #7 — Boring Roadmap](https://github.com/users/hachej/projects/7), with Status `Backlog` and Type `Feature`. Do **not** create a GitHub issue.
+- **Already reported / already shipped:** link the existing issue, PR, or backlog item; do not create another item.
+- Create a GitHub issue for a feature only when the owner explicitly commits it to current work. Move the corresponding Project draft to `Doing`.
 
 ## Process
 
 1. Capture the report: observed behavior, expected behavior, route/panel/plugin, selected item, branch/SHA if available, environment/browser/app context, safe errors, optional screenshot.
 2. Redact before publishing: no secrets, cookies, auth headers, private data, unrelated transcripts, or host-local paths. Use safe attachment names/URLs only.
-3. If unclear enough to affect routing, ask only: `Grill now, defer, or skip?`
-   - grill now: clarify before final issue body.
-   - defer: create issue with `needs-info`.
-   - skip: create issue with best-known context and `needs-triage`.
-4. Create the GitHub issue.
-5. Stop and return the issue URL plus next suggestion.
+3. Search open GitHub Issues, relevant merged/closed PRs, and Project #7 before creating anything. Prefer the existing canonical item when the overlap is material.
+4. If unclear enough to decide bug vs. idea, ask only: `Grill now, defer, or skip?`
+   - grill now: clarify before routing.
+   - defer: create the best matching item with explicit open questions.
+   - skip: route using the best-known context.
+5. Create exactly one canonical item:
+   - **Bug issue:** apply `bug` and exactly one state label: `needs-triage` when clear enough, otherwise `needs-info`.
+   - **Feature draft:** add it to Project #7 with the original context and a link back to any relevant discussion. Set Status `Backlog`, Type `Feature`.
+6. Stop and return the issue or Project item URL plus the next suggestion.
 
-## Issue Body
+## Bug issue body
 
 ```md
 ## Summary
@@ -60,5 +58,24 @@ Apply exactly one state:
 ## Open Questions
 
 ## Next
-Suggested next step: `/triage #<issue>` or `/plan #<issue>`.
+Suggested next step: `/triage #<issue>`.
+```
+
+## Feature draft body
+
+```md
+## Summary
+
+## User value
+
+## Context
+- Route/panel:
+- Package/plugin:
+- Related issue/PR/discussion:
+
+## Acceptance signals
+
+## Open questions
+
+Promote this draft to a GitHub issue only when work is committed.
 ```

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -1649,9 +1649,18 @@ test('skills endpoint discovers workspace .agents/skills when ambient skills are
 
   const res = await app.inject({ method: 'GET', url: '/api/v1/agent/skills?refresh=1' })
   expect(res.statusCode).toBe(200)
-  expect(res.json().skills).toEqual(expect.arrayContaining([
-    expect.objectContaining({ name: 'cli-project-skill' }),
-  ]))
+  const skill = res.json().skills.find((candidate: { name: string }) => candidate.name === 'cli-project-skill')
+  expect(skill).toMatchObject({
+    name: 'cli-project-skill',
+    filePath: '.agents/skills/cli-project-skill/SKILL.md',
+  })
+
+  const fileRes = await app.inject({
+    method: 'GET',
+    url: `/api/v1/files?path=${encodeURIComponent(skill.filePath)}`,
+  })
+  expect(fileRes.statusCode).toBe(200)
+  expect(fileRes.json().content).toContain('# CLI project skill')
 
   await app.close()
 })

--- a/packages/agent/src/server/http/routes/skills.ts
+++ b/packages/agent/src/server/http/routes/skills.ts
@@ -10,6 +10,7 @@
  *   { skills: [{ name: string, description: string }] }
  */
 import type { FastifyInstance, FastifyRequest } from 'fastify'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
 import {
   DefaultPackageManager,
   getAgentDir,
@@ -21,7 +22,7 @@ import { createResourceSettingsManager, withPiHarnessDefaults } from '../../harn
 export interface SkillSummary {
   name: string
   description: string
-  /** Absolute path to the resolved SKILL.md, used by workspace UIs to open it. */
+  /** Workspace-relative path when the skill lives in the workspace; otherwise its absolute source path. */
   filePath?: string
   /** Human-readable source/scope label for diagnostics and disabled rows. */
   source?: string
@@ -32,6 +33,14 @@ interface SkillsQuery {
 }
 
 const CACHE_TTL_MS = 30_000
+
+function pathForWorkspaceEditor(workspaceRoot: string, filePath: string): string {
+  const pathWithinWorkspace = relative(resolve(workspaceRoot), resolve(filePath))
+  if (pathWithinWorkspace === '' || pathWithinWorkspace === '..' || pathWithinWorkspace.startsWith(`..${sep}`) || isAbsolute(pathWithinWorkspace)) {
+    return filePath
+  }
+  return pathWithinWorkspace.split(sep).join('/')
+}
 
 export interface SkillsRoutesOptions {
   workspaceRoot: string
@@ -103,7 +112,7 @@ export function skillsRoutes(
     const skills: SkillSummary[] = (result.skills as unknown as Array<Record<string, unknown>>).map((s) => ({
       name: String(s.name),
       description: String(s.description ?? ''),
-      ...(typeof s.filePath === 'string' ? { filePath: s.filePath } : {}),
+      ...(typeof s.filePath === 'string' ? { filePath: pathForWorkspaceEditor(workspaceRoot, s.filePath) } : {}),
       ...(typeof (s.sourceInfo as { scope?: unknown } | undefined)?.scope === 'string' ? { source: (s.sourceInfo as { scope: string }).scope } : {}),
     }))
     const entry = { skills, expiresAt: now + CACHE_TTL_MS }


### PR DESCRIPTION
Closes #769

## Summary
- route feature feedback to Project #7 draft backlog items
- retain GitHub Issues for bugs and explicitly committed active work
- add duplicate/completed-work lookup before creating a canonical item
- align `/ask-boring` routing language

## Proof
- `git diff --check`