### PR TITLE
#769 docs: route feature feedback to roadmap backlog

### DIFF
--- a/.agents/skills/ask-boring/SKILL.md
+++ b/.agents/skills/ask-boring/SKILL.md
@@ -9,7 +9,7 @@ Router only. Do not edit files, create issues, plan, implement, review, or merge
 
 ## Routes
 
-- `feedback` — user is reporting a bug, idea, UX issue, feature request, or rough observation that should become a GitHub issue.
+- `feedback` — user is reporting a bug, idea, UX issue, feature request, or rough observation. Bugs become GitHub issues; feature ideas become Project #7 backlog drafts unless work is committed.
 - `triage` — an existing issue/PR needs classification, verification, or a next state.
 - `plan` — the desired outcome needs a spec, implementation plan, slices, blockers, or proof path before coding.
 - `implement` — one issue/slice is ready for an agent to build.

--- a/.agents/skills/feedback/SKILL.md
+++ b/.agents/skills/feedback/SKILL.md
@@ -1,36 +1,34 @@
 ---
 name: feedback
-description: Create a GitHub issue from user feedback with safe context and simple labels. Never implement.
+description: Capture feedback safely: file confirmed bugs as GitHub issues and route feature ideas to the Product Backlog. Never implement.
 ---
 
 # Feedback
 
-Create the source GitHub issue and stop. Do not implement. Do not split into tickets.
+Capture the report, route it, and stop. Do not implement or split work.
 
-## Labels
+## Routing policy
 
-Apply exactly one category when possible:
-
-- `bug`
-- `enhancement`
-
-Apply exactly one state:
-
-- `needs-triage` — clear enough for triage
-- `needs-info` — clarification is needed
+- **Confirmed bug or regression:** create a GitHub issue. GitHub Issues are the operational queue for bugs and active work.
+- **Feature request, idea, UX wish, or future work:** create a **draft item** in [Project #7 — Boring Roadmap](https://github.com/users/hachej/projects/7), with Status `Backlog` and Type `Feature`. Do **not** create a GitHub issue.
+- **Already reported / already shipped:** link the existing issue, PR, or backlog item; do not create another item.
+- Create a GitHub issue for a feature only when the owner explicitly commits it to current work. Move the corresponding Project draft to `Doing`.
 
 ## Process
 
 1. Capture the report: observed behavior, expected behavior, route/panel/plugin, selected item, branch/SHA if available, environment/browser/app context, safe errors, optional screenshot.
 2. Redact before publishing: no secrets, cookies, auth headers, private data, unrelated transcripts, or host-local paths. Use safe attachment names/URLs only.
-3. If unclear enough to affect routing, ask only: `Grill now, defer, or skip?`
-   - grill now: clarify before final issue body.
-   - defer: create issue with `needs-info`.
-   - skip: create issue with best-known context and `needs-triage`.
-4. Create the GitHub issue.
-5. Stop and return the issue URL plus next suggestion.
+3. Search open GitHub Issues, relevant merged/closed PRs, and Project #7 before creating anything. Prefer the existing canonical item when the overlap is material.
+4. If unclear enough to decide bug vs. idea, ask only: `Grill now, defer, or skip?`
+   - grill now: clarify before routing.
+   - defer: create the best matching item with explicit open questions.
+   - skip: route using the best-known context.
+5. Create exactly one canonical item:
+   - **Bug issue:** apply `bug` and exactly one state label: `needs-triage` when clear enough, otherwise `needs-info`.
+   - **Feature draft:** add it to Project #7 with the original context and a link back to any relevant discussion. Set Status `Backlog`, Type `Feature`.
+6. Stop and return the issue or Project item URL plus the next suggestion.
 
-## Issue Body
+## Bug issue body
 
 ```md
 ## Summary
@@ -60,5 +58,24 @@ Apply exactly one state:
 ## Open Questions
 
 ## Next
-Suggested next step: `/triage #<issue>` or `/plan #<issue>`.
+Suggested next step: `/triage #<issue>`.
+```
+
+## Feature draft body
+
+```md
+## Summary
+
+## User value
+
+## Context
+- Route/panel:
+- Package/plugin:
+- Related issue/PR/discussion:
+
+## Acceptance signals
+
+## Open questions
+
+Promote this draft to a GitHub issue only when work is committed.
 ```


### PR DESCRIPTION
Closes #769

## Summary
- route feature feedback to Project #7 draft backlog items
- retain GitHub Issues for bugs and explicitly committed active work
- add duplicate/completed-work lookup before creating a canonical item
- align `/ask-boring` routing language

## Proof
- `git diff --check`