### PR TITLE
feat(governance): add governed files roots plugin

### DIFF
--- a/plugins/boring-governance/package.json
+++ b/plugins/boring-governance/package.json
@@ -52,6 +52,7 @@
     "@hachej/boring-bash": "workspace:*",
     "@hachej/boring-core": "workspace:*",
     "@hachej/boring-ui-kit": "workspace:*",
+    "@hachej/boring-workspace": "workspace:*",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
@@ -64,6 +65,7 @@
     "@hachej/boring-bash": "workspace:*",
     "@hachej/boring-core": "workspace:*",
     "@hachej/boring-ui-kit": "workspace:*",
+    "@hachej/boring-workspace": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^22.0.0",

--- a/plugins/boring-governance/src/front/GovernanceFilesRoots.tsx
+++ b/plugins/boring-governance/src/front/GovernanceFilesRoots.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import * as React from 'react'
+import {
+  FileTreePane,
+  type FileTreePaneParams,
+  type FileTreeRootConfig,
+  type WorkspaceSourceProps,
+} from '@hachej/boring-workspace'
+import { definePlugin } from '@hachej/boring-workspace/plugin'
+
+const DEFAULT_ENDPOINT = '/api/v1/governance/usage-summary'
+
+export interface GovernanceCompanyContextRootOptions {
+  label?: string
+  rootDir?: string
+  searchPlaceholder?: string
+}
+
+export interface CreateGovernanceFilesRootsPluginOptions {
+  id?: string
+  label?: string
+  endpoint?: string
+  fetchImpl?: typeof fetch
+  workspaceRoot?: FileTreeRootConfig
+  companyContext?: GovernanceCompanyContextRootOptions
+}
+
+interface GovernanceUsageSummary {
+  companyContextAccess?: 'none' | 'readonly' | 'readwrite'
+}
+
+/**
+ * Creates a Files source that always exposes the personal workspace and adds
+ * the governed `company_context` root when the authenticated user can access it.
+ */
+export function createGovernanceFilesRootsPlugin({
+  id = 'governance-files-roots',
+  label = 'Governed Files',
+  endpoint = DEFAULT_ENDPOINT,
+  fetchImpl = fetch,
+  workspaceRoot = {
+    filesystem: 'user',
+    label: 'Workspace',
+    rootDir: '.',
+    access: 'readwrite',
+    searchPlaceholder: 'Search workspace files...',
+  },
+  companyContext = {},
+}: CreateGovernanceFilesRootsPluginOptions = {}) {
+  function useRoots(): FileTreeRootConfig[] {
+    const [roots, setRoots] = React.useState<FileTreeRootConfig[]>([workspaceRoot])
+
+    React.useEffect(() => {
+      const controller = new AbortController()
+      void fetchImpl(endpoint, { credentials: 'include', signal: controller.signal })
+        .then(async (response) => {
+          if (!response.ok) throw new Error(`Governance usage status failed (${response.status})`)
+          return response.json() as Promise<GovernanceUsageSummary>
+        })
+        .then((summary) => {
+          if (controller.signal.aborted) return
+          const access = summary.companyContextAccess ?? 'none'
+          if (access === 'none') return
+          setRoots([
+            workspaceRoot,
+            {
+              filesystem: 'company_context',
+              label: companyContext.label ?? 'Company context',
+              rootDir: companyContext.rootDir ?? '/',
+              access,
+              searchPlaceholder: companyContext.searchPlaceholder ?? 'Search company context files...',
+            },
+          ])
+        })
+        .catch((error: unknown) => {
+          if (!controller.signal.aborted) console.error('Failed to resolve company_context file root access', error)
+        })
+      return () => controller.abort()
+    }, [])
+
+    return roots
+  }
+
+  function GovernanceFilesRootsSource(props: WorkspaceSourceProps<FileTreePaneParams>) {
+    const roots = useRoots()
+    return <FileTreePane {...props} params={{ ...props.params, roots }} />
+  }
+
+  return definePlugin({
+    id,
+    label,
+    workspaceSources: [{
+      id: 'files',
+      label: 'Files',
+      source: 'app',
+      component: GovernanceFilesRootsSource,
+    }],
+  })
+}

--- a/plugins/boring-governance/src/front/index.tsx
+++ b/plugins/boring-governance/src/front/index.tsx
@@ -57,3 +57,8 @@ Object.defineProperty(governanceFrontPlugin, 'pluginLabel', { value: 'Governance
 export default governanceFrontPlugin
 export { GovernanceAdminView }
 export type { GovernanceMeResponse, GovernancePolicyStatus } from './GovernanceAdminView.js'
+export {
+  createGovernanceFilesRootsPlugin,
+  type CreateGovernanceFilesRootsPluginOptions,
+  type GovernanceCompanyContextRootOptions,
+} from './GovernanceFilesRoots.js'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1215,6 +1215,9 @@ importers:
       '@hachej/boring-ui-kit':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@hachej/boring-workspace':
+        specifier: workspace:*
+        version: link:../../packages/workspace
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1


### PR DESCRIPTION
Adds a reusable governance frontend plugin that exposes the personal workspace root and conditionally adds company_context from the authenticated user's governance usage summary.\n\nStacked on #? / feat/files-tree-filesystem-roots because FileTreeRootConfig support is required.