### PR TITLE
feat(workspace): add multi-root Files tree support

### DIFF
--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -23,7 +23,7 @@ export const FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS = Object.freeze(FULL_AP
 export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'full-app-governance',
   version: '0.1.85',
-  contentDigest: 'sha256:6cc6c0ae067e5b78bd172a1831dd87fd89a9d3a0af3b6dcd47fdddb3bd041647',
+  contentDigest: 'sha256:16dbe21ed64865213eb2f3b2258ab05d9e226e7865a4416e92f8010864afd313',
 } satisfies StableContributionDescriptor)
 
 export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({

--- a/plugins/boring-governance/package.json
+++ b/plugins/boring-governance/package.json
@@ -52,6 +52,7 @@
     "@hachej/boring-bash": "workspace:*",
     "@hachej/boring-core": "workspace:*",
     "@hachej/boring-ui-kit": "workspace:*",
+    "@hachej/boring-workspace": "workspace:*",
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0"
   },
@@ -64,6 +65,7 @@
     "@hachej/boring-bash": "workspace:*",
     "@hachej/boring-core": "workspace:*",
     "@hachej/boring-ui-kit": "workspace:*",
+    "@hachej/boring-workspace": "workspace:*",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@types/node": "^22.0.0",

--- a/plugins/boring-governance/src/front/GovernanceFilesRoots.tsx
+++ b/plugins/boring-governance/src/front/GovernanceFilesRoots.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import * as React from 'react'
+import {
+  FileTreePane,
+  type FileTreePaneParams,
+  type FileTreeRootConfig,
+  type WorkspaceSourceProps,
+} from '@hachej/boring-workspace'
+import { definePlugin } from '@hachej/boring-workspace/plugin'
+
+const DEFAULT_ENDPOINT = '/api/v1/governance/usage-summary'
+
+export interface GovernanceCompanyContextRootOptions {
+  label?: string
+  rootDir?: string
+  searchPlaceholder?: string
+}
+
+export interface CreateGovernanceFilesRootsPluginOptions {
+  id?: string
+  label?: string
+  endpoint?: string
+  fetchImpl?: typeof fetch
+  workspaceRoot?: FileTreeRootConfig
+  companyContext?: GovernanceCompanyContextRootOptions
+}
+
+interface GovernanceUsageSummary {
+  companyContextAccess?: 'none' | 'readonly' | 'readwrite'
+}
+
+/**
+ * Creates a Files source that always exposes the personal workspace and adds
+ * the governed `company_context` root when the authenticated user can access it.
+ */
+export function createGovernanceFilesRootsPlugin({
+  id = 'governance-files-roots',
+  label = 'Governed Files',
+  endpoint = DEFAULT_ENDPOINT,
+  fetchImpl = fetch,
+  workspaceRoot = {
+    filesystem: 'user',
+    label: 'Workspace',
+    rootDir: '.',
+    access: 'readwrite',
+    searchPlaceholder: 'Search workspace files...',
+  },
+  companyContext = {},
+}: CreateGovernanceFilesRootsPluginOptions = {}) {
+  function useRoots(): FileTreeRootConfig[] {
+    const [roots, setRoots] = React.useState<FileTreeRootConfig[]>([workspaceRoot])
+
+    React.useEffect(() => {
+      const controller = new AbortController()
+      void fetchImpl(endpoint, { credentials: 'include', signal: controller.signal })
+        .then(async (response) => {
+          if (!response.ok) throw new Error(`Governance usage status failed (${response.status})`)
+          return response.json() as Promise<GovernanceUsageSummary>
+        })
+        .then((summary) => {
+          if (controller.signal.aborted) return
+          const access = summary.companyContextAccess ?? 'none'
+          if (access === 'none') return
+          setRoots([
+            workspaceRoot,
+            {
+              filesystem: 'company_context',
+              label: companyContext.label ?? 'Company context',
+              rootDir: companyContext.rootDir ?? '/',
+              access,
+              searchPlaceholder: companyContext.searchPlaceholder ?? 'Search company context files...',
+            },
+          ])
+        })
+        .catch((error: unknown) => {
+          if (!controller.signal.aborted) console.error('Failed to resolve company_context file root access', error)
+        })
+      return () => controller.abort()
+    }, [])
+
+    return roots
+  }
+
+  function GovernanceFilesRootsSource(props: WorkspaceSourceProps<FileTreePaneParams>) {
+    const roots = useRoots()
+    return <FileTreePane {...props} params={{ ...props.params, roots }} />
+  }
+
+  return definePlugin({
+    id,
+    label,
+    workspaceSources: [{
+      id: 'files',
+      label: 'Files',
+      source: 'app',
+      component: GovernanceFilesRootsSource,
+    }],
+  })
+}

--- a/plugins/boring-governance/src/front/index.tsx
+++ b/plugins/boring-governance/src/front/index.tsx
@@ -59,6 +59,11 @@ export { GovernanceAdminView }
 export type { GovernanceMeResponse, GovernancePolicyStatus } from './GovernanceAdminView.js'
 export { GovernanceUsageMeters, type GovernanceUsageMetersProps } from './GovernanceUsageMeters.js'
 export { GovernanceUsagePanel, type GovernanceUsagePanelProps } from './GovernanceUsagePanel.js'
+export {
+  createGovernanceFilesRootsPlugin,
+  type CreateGovernanceFilesRootsPluginOptions,
+  type GovernanceCompanyContextRootOptions,
+} from './GovernanceFilesRoots.js'
 export type {
   GovernanceUsageEntry,
   GovernanceUsageSummary,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1224,6 +1224,9 @@ importers:
       '@hachej/boring-ui-kit':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@hachej/boring-workspace':
+        specifier: workspace:*
+        version: link:../../packages/workspace
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1


### PR DESCRIPTION
Introduces multi-root Files tree support, including the governance Files-roots plugin merged in #772. This enables tenant apps to use governed company_context roots without local FilesRootsSource plumbing.