### PR TITLE
feat(d1): add core publication control

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/d1ProductionAuthority.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1ProductionAuthority.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { D1CollectionController } from '../bootCollection.js'
+import type { D1PendingPublicationV1 } from '../d1PublicationControl.js'
+import { createD1ProductionAuthority } from '../d1ProductionAuthority.js'
+import { D1HostErrorCode, type D1SiteBindingV1 } from '../d1Plan.js'
+import { createD1RuntimeInputsIdentity } from '../d1RuntimeInputs.js'
+import type { D1StoredCandidateV1, D1StoredCompleteV1 } from '../hostRevisionStore.js'
+
+const digest = (value: string) => `sha256:${value.repeat(64)}` as const
+const binding: D1SiteBindingV1 = { bindingId: 'one', hostname: 'one.example.test', workspaceId: 'workspace-one', defaultDeploymentId: 'deployment-one',
+  bundleRef: 'bundle-one', deploymentRef: 'deployment-one', workspaceAllocationRef: 'allocation-one', sessionAllocationRef: 'session-one',
+  ownerPrincipalRef: 'owner-one', landing: { title: 'One', summary: 'One' }, environmentRef: 'production', secretRefs: [] }
+const desired = { schemaVersion: 1, domain: 'boring-d1-desired:v1', plan: { schemaVersion: 1, hostId: 'host-1', hostAppImageDigest: digest('f'),
+  runtimeProfileRef: 'runsc', databaseRef: 'database', workspaceRootPolicyRef: 'workspaces', sessionRootPolicyRef: 'sessions', bindings: [binding] },
+resolvedBindings: [{ schemaVersion: 1, bindingId: 'one' }] } as never
+let input: Awaited<ReturnType<typeof createD1RuntimeInputsIdentity>>
+const oldActive = { schemaVersion: 1 as const, revisionId: 'r0000000001', desiredStateDigest: digest('a') }
+const targetActive = { schemaVersion: 1 as const, revisionId: 'r0000000002', desiredStateDigest: digest('b') }
+const candidate = { revisionId: targetActive.revisionId, desired, desiredStateDigest: targetActive.desiredStateDigest, secretRefs: {} } as unknown as D1StoredCandidateV1
+const complete = (active: typeof oldActive | typeof targetActive): D1StoredCompleteV1 => ({ ...candidate, revisionId: active.revisionId,
+  desiredStateDigest: active.desiredStateDigest, observation: { bindings: [{ runtimeInputs: input }] }, completion: {} } as never)
+
+beforeEach(async () => { input = await createD1RuntimeInputsIdentity(binding, { environment: { versionFingerprint: digest('1') },
+  workspaceAllocation: { versionFingerprint: digest('2') }, sessionAllocation: { versionFingerprint: digest('3') }, secrets: [] }) })
+
+function harness(start: typeof oldActive | typeof targetActive | null, initiallyServed: typeof oldActive | typeof targetActive | null = null) {
+  let durable = start; let served = initiallyServed; let pending: D1PendingPublicationV1 | null = { schemaVersion: 1, operationId: 'operation-1',
+    expectedRevision: oldActive.revisionId, expectedDigest: oldActive.desiredStateDigest, targetRevision: targetActive.revisionId,
+    targetDigest: targetActive.desiredStateDigest, runtimeInputs: [input] }
+  const preload = vi.fn(async () => ({ bindings: [] })); const serve = vi.fn(async (active: typeof oldActive) => { served = active; return active })
+  const reproduce = vi.fn(async () => desired)
+  const controller = { resolver: { resolvePlan: vi.fn(async () => desired), reproduce }, preload, serve,
+    snapshot: () => served && ({ revisionId: served.revisionId, desiredStateDigest: served.desiredStateDigest }), read: vi.fn(), readRecipe: vi.fn(),
+    settleRetirement: vi.fn(), discardPrepared: vi.fn() } as unknown as D1CollectionController
+  const store = { readActive: vi.fn(async () => durable), readCandidate: vi.fn(async () => candidate),
+    readComplete: vi.fn(async (revision: string) => complete(revision === oldActive.revisionId ? oldActive : targetActive)) } as never
+  const authority = createD1ProductionAuthority({ hostId: 'host-1', ownerUid: 0, dependencies: { store, servedCollection: controller,
+    candidatePreloader: { prepare: vi.fn() }, readPending: async () => pending } })
+  return { authority, preload, serve, reproduce, setDurable(value: typeof oldActive | typeof targetActive | null) { durable = value },
+    setPending(value: D1PendingPublicationV1 | null) { pending = value }, served: () => served }
+}
+
+describe('D1 production publication authority', () => {
+  it('prepares without changing served state, then commits only the durable target', async () => {
+    const h = harness(oldActive, oldActive)
+    await expect(h.authority.prepare('operation-1')).resolves.toMatchObject({ durableRevision: oldActive.revisionId, servedRevision: oldActive.revisionId })
+    expect(h.served()).toEqual(oldActive); expect(h.preload).toHaveBeenCalledTimes(1)
+    await expect(h.authority.commit('operation-1')).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    h.setDurable(targetActive)
+    await expect(h.authority.commit('operation-1')).resolves.toMatchObject({ durableRevision: targetActive.revisionId, servedRevision: targetActive.revisionId })
+  })
+
+  it.each([[oldActive, oldActive], [targetActive, targetActive]] as const)('converges valid pending restart tuple %#', async (durable, expectedServed) => {
+    const h = harness(durable); await h.authority.recover(); expect(h.served()).toEqual(expectedServed)
+    if (durable === oldActive) expect(h.preload).toHaveBeenCalledTimes(2)
+  })
+
+  it('recovers only an exact reproduction of the durable complete revision', async () => {
+    const h = harness(targetActive); h.setPending(null); await h.authority.recover(); expect(h.served()).toEqual(targetActive)
+    const drifted = harness(targetActive); drifted.setPending(null); drifted.reproduce.mockResolvedValueOnce({} as never)
+    await expect(drifted.authority.recover()).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+  })
+
+  it('fails closed on an unrelated durable tuple', async () => {
+    const unrelated = { schemaVersion: 1 as const, revisionId: 'r0000000009', desiredStateDigest: digest('9') }
+    await expect(harness(unrelated as never).authority.recover()).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+  })
+})

--- a/apps/full-app/src/server/deployment/__tests__/d1PublicationControl.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1PublicationControl.test.ts
@@ -1,0 +1,79 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createConnection } from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  D1_PENDING_PUBLICATION_FILE,
+  D1_PUBLICATION_SOCKET_FILE,
+  parseD1PendingPublication,
+  readD1PendingPublication,
+  startD1PublicationControlServer,
+  type D1PublicationControlAuthority,
+} from '../d1PublicationControl.js'
+import { D1HostErrorCode } from '../d1Plan.js'
+
+const digest = (value: string) => `sha256:${value.repeat(64)}` as const
+const roots: string[] = []
+const pending = { schemaVersion: 1, operationId: 'operation-1', expectedRevision: 'r0000000001', expectedDigest: digest('a'),
+  targetRevision: 'r0000000002', targetDigest: digest('b'), runtimeInputs: [] }
+
+afterEach(async () => { await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))) })
+async function root() {
+  const value = await mkdtemp(path.join(os.tmpdir(), 'd1-control-')); roots.push(value); await chmod(value, 0o710); return value
+}
+async function exchange(socketPath: string, frame: string | readonly string[]): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(socketPath); let output = ''
+    socket.setEncoding('utf8'); socket.on('connect', () => {
+      if (typeof frame === 'string') socket.end(frame)
+      else { socket.write(frame[0]); setImmediate(() => socket.end(frame[1])) }
+    }); socket.on('data', (chunk) => { output += chunk })
+    socket.on('end', () => resolve(JSON.parse(output) as Record<string, unknown>)); socket.on('error', reject)
+  })
+}
+
+describe('D1 core publication control', () => {
+  it('accepts only the canonical root-owned pending identity', async () => {
+    expect(parseD1PendingPublication(pending)).toEqual(pending)
+    expect(() => parseD1PendingPublication({ ...pending, path: '/private' })).toThrow()
+    expect(() => parseD1PendingPublication({ ...pending, expectedDigest: null })).toThrow()
+    const controlRoot = await root(); const file = path.join(controlRoot, D1_PENDING_PUBLICATION_FILE)
+    await writeFile(file, JSON.stringify(pending)); await chmod(file, 0o440)
+    await expect(readD1PendingPublication({ root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() })).resolves.toEqual(pending)
+    await chmod(file, 0o644)
+    await expect(readD1PendingPublication({ root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() }))
+      .rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+  })
+
+  it('dispatches one bounded fixed-action frame and returns redacted status', async () => {
+    const controlRoot = await root(); await chmod(controlRoot, 0o730); const status = { durableRevision: 'r0000000002', servedRevision: 'r0000000001', pendingOperation: 'operation-1' }
+    const authority = { prepare: vi.fn(async () => status), commit: vi.fn(async () => status), status: vi.fn(async () => status) } satisfies D1PublicationControlAuthority
+    const server = await startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() })
+    try {
+      const socket = path.join(controlRoot, D1_PUBLICATION_SOCKET_FILE)
+      await expect(exchange(socket, '{"action":"prepare","operationId":"operation-1"}\n')).resolves.toEqual({ ok: true, status })
+      expect(authority.prepare).toHaveBeenCalledWith('operation-1')
+      await expect(exchange(socket, '{"action":"status"}\n')).resolves.toEqual({ ok: true, status })
+      expect(JSON.stringify(await exchange(socket, '{"action":"commit","operationId":"operation-1","path":"/private"}\n')))
+        .not.toContain('/private')
+    } finally { await new Promise<void>((resolve) => server.close(() => resolve())) }
+  })
+
+  it.each([
+    '{"action":"status"}\n{"action":"status"}\n',
+    ['{"action":"status"}\n', '{"action":"status"}\n'],
+    `${JSON.stringify({ action: 'prepare', operationId: 'x'.repeat(600) })}\n`,
+    '{"action":"prepare","operationId":"operation-1","digest":"sha256:x"}\n',
+  ])('rejects multiple, oversized, or caller-selected identity frames', async (frame) => {
+    const controlRoot = await root(); await chmod(controlRoot, 0o730); const authority = { prepare: vi.fn(), commit: vi.fn(), status: vi.fn() } as unknown as D1PublicationControlAuthority
+    const server = await startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() })
+    try {
+      const result = await exchange(path.join(controlRoot, D1_PUBLICATION_SOCKET_FILE), frame)
+      expect(result).toMatchObject({ ok: false, error: { code: D1HostErrorCode.PUBLICATION_FAILED } })
+      expect(authority.prepare).not.toHaveBeenCalled()
+    } finally { await new Promise<void>((resolve) => server.close(() => resolve())) }
+  })
+})

--- a/apps/full-app/src/server/deployment/activeCollectionReader.ts
+++ b/apps/full-app/src/server/deployment/activeCollectionReader.ts
@@ -6,6 +6,7 @@ import { D1_V1_COLLECTION_LIMITS } from './bootCollection.js'
 import { validateD1BindingEnv } from './d1BindingEnv.js'
 import { canonicalizeD1AgentArtifactEnvelope, type D1AgentArtifactEnvelopeV1 } from './d1AgentArtifactSnapshot.js'
 import { assertD1ExactKeys as exactKeys, D1HostError, D1HostErrorCode, strictD1HostId, type D1SiteBindingV1 } from './d1Plan.js'
+import type { D1StoredCandidateV1, D1StoredCompleteV1 } from './hostRevisionStore.js'
 import {
   canonicalizeD1ActiveEnvelope,
   canonicalizeD1CompleteEnvelope,
@@ -38,6 +39,12 @@ export interface D1ActiveCollectionReader {
 }
 export interface D1AgentArtifactReader extends D1ActiveCollectionReader {
   readAgentArtifact(collection: D1ActiveCollection, binding: D1SiteBindingV1): Promise<D1AgentArtifactEnvelopeV1>
+}
+export interface D1ImmutableRevisionReader extends D1AgentArtifactReader {
+  readActive(): Promise<D1ActiveEnvelopeV1 | null>
+  readCandidate(revisionId: string): Promise<D1StoredCandidateV1 | null>
+  readComplete(revisionId: string): Promise<D1StoredCompleteV1 | null>
+  readRevisionAgentArtifact(revisionId: string, binding: D1SiteBindingV1): Promise<D1AgentArtifactEnvelopeV1>
 }
 
 export interface D1ActiveCollectionReaderOptions {
@@ -84,7 +91,7 @@ function json(content: string): unknown {
   return JSON.parse(content) as unknown
 }
 
-export function createD1ActiveCollectionReader(options: D1ActiveCollectionReaderOptions): D1AgentArtifactReader {
+export function createD1ActiveCollectionReader(options: D1ActiveCollectionReaderOptions): D1ImmutableRevisionReader {
   if (typeof options?.hostRoot !== 'string' || options.hostRoot.includes('\0') || !path.isAbsolute(options.hostRoot)
     || path.resolve(options.hostRoot) !== options.hostRoot) invalid('hostRoot')
   let hostId: string
@@ -94,63 +101,60 @@ export function createD1ActiveCollectionReader(options: D1ActiveCollectionReader
   const hostRoot = options.hostRoot
   const policy = Object.freeze({ uid: options.ownerUid, gid: options.appGid })
 
+  const readActive = async () => {
+    const content = await readFile(path.join(hostRoot, 'active'), policy, true, 16 * 1024)
+    return content === null ? null : canonicalizeD1ActiveEnvelope(json(content))
+  }
+  const readCandidate = async (revisionId: string): Promise<D1StoredCandidateV1 | null> => {
+    const revisionRoot = path.join(hostRoot, 'revisions', revisionId)
+    try { await assertDirectory(revisionRoot, policy) } catch (error) { if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null; throw error }
+    const desiredFile = json((await readFile(path.join(revisionRoot, 'desired.json'), policy))!)
+    const resolvedFile = json((await readFile(path.join(revisionRoot, 'resolved.json'), policy))!)
+    exactKeys(desiredFile, ['schemaVersion', 'domain', 'plan'], 'desiredFile'); exactKeys(resolvedFile, ['schemaVersion', 'domain', 'bindings'], 'resolvedFile')
+    if (desiredFile.schemaVersion !== 1 || desiredFile.domain !== PLAN_DOMAIN || resolvedFile.schemaVersion !== 1 || resolvedFile.domain !== RESOLVED_DOMAIN) throw new Error()
+    const desired = await canonicalizeD1DesiredSnapshot({ schemaVersion: 1, domain: 'boring-d1-desired:v1', plan: desiredFile.plan, resolvedBindings: resolvedFile.bindings })
+    if (desired.plan.hostId !== hostId) throw new Error()
+    const desiredStateDigest = await digestD1Desired(desired)
+    if (await readFile(path.join(revisionRoot, 'desired.sha256'), policy, false, 256) !== `${desiredStateDigest}\n`) throw new Error()
+    const secretRefs = canonicalizeD1SecretRefsEnvelope(json((await readFile(path.join(revisionRoot, 'secret-refs.json'), policy, false, FILE_LIMIT))!), desired)
+    const bindingsRoot = path.join(revisionRoot, 'bindings'); await assertDirectory(bindingsRoot, policy)
+    for (const binding of desired.plan.bindings) validateD1BindingEnv((await readFile(path.join(bindingsRoot, `${binding.bindingId}.env`), policy, false, 64 * 1024))!, binding)
+    return Object.freeze({ revisionId, desired, desiredStateDigest, secretRefs })
+  }
+  const readComplete = async (revisionId: string): Promise<D1StoredCompleteV1 | null> => {
+    const candidate = await readCandidate(revisionId); if (!candidate) return null
+    const root = path.join(hostRoot, 'revisions', revisionId)
+    const observation = await canonicalizeD1Observation(json((await readFile(path.join(root, 'observed.json'), policy))!), candidate.desired)
+    const completion = await canonicalizeD1CompleteEnvelope(json((await readFile(path.join(root, 'completion.json'), policy, false, 16 * 1024))!), candidate.desired, observation)
+    if (completion.revisionId !== revisionId || completion.desiredStateDigest !== candidate.desiredStateDigest) throw new Error()
+    return Object.freeze({ ...candidate, observation, completion })
+  }
+  const readRevisionAgentArtifact = async (revisionId: string, binding: D1SiteBindingV1) => {
+    const root = path.join(hostRoot, 'revisions', revisionId); await assertDirectory(root, policy); await assertDirectory(path.join(root, 'agent-artifacts'), policy)
+    return canonicalizeD1AgentArtifactEnvelope(json((await readFile(path.join(root, 'agent-artifacts', `${binding.bindingId}.json`), policy, false, D1_V1_COLLECTION_LIMITS.maxBundleBytes))!), hostId, binding)
+  }
+  const guarded = async <T>(operation: () => Promise<T>, field = 'active'): Promise<T> => {
+    try { if (await realpath(hostRoot) !== hostRoot) throw new Error(); await assertDirectory(hostRoot, policy); await assertDirectory(path.join(hostRoot, 'revisions'), policy); return await operation() }
+    catch { publicationFailed(field) }
+  }
   return Object.freeze({
+    readActive: () => guarded(readActive), readCandidate: (revisionId: string) => guarded(() => readCandidate(revisionId)),
+    readComplete: (revisionId: string) => guarded(() => readComplete(revisionId)),
+    readRevisionAgentArtifact: (revisionId: string, binding: D1SiteBindingV1) => guarded(() => readRevisionAgentArtifact(revisionId, binding), 'agentArtifacts'),
     async readAgentArtifact(collection: D1ActiveCollection, binding: D1SiteBindingV1) {
-      try {
-        const planned = collection.desired.plan.bindings.find((value) => value.bindingId === binding.bindingId)
-        if (planned !== binding) throw new Error('binding is not from active snapshot')
-        const revisionRoot = path.join(hostRoot, 'revisions', collection.active.revisionId)
-        const artifactsRoot = path.join(revisionRoot, 'agent-artifacts')
-        await assertDirectory(revisionRoot, policy); await assertDirectory(artifactsRoot, policy)
-        const envelope = canonicalizeD1AgentArtifactEnvelope(
-          json((await readFile(path.join(artifactsRoot, `${binding.bindingId}.json`), policy, false, D1_V1_COLLECTION_LIMITS.maxBundleBytes))!), hostId, binding,
-        )
-        const active = canonicalizeD1ActiveEnvelope(json((await readFile(path.join(hostRoot, 'active'), policy, false, 16 * 1024))!))
-        if (JSON.stringify(active) !== JSON.stringify(collection.active)) throw new Error('active revision changed')
-        return envelope
-      } catch { publicationFailed('agentArtifacts') }
+      const planned = collection.desired.plan.bindings.find((value: D1SiteBindingV1) => value.bindingId === binding.bindingId)
+      if (planned !== binding) publicationFailed('agentArtifacts')
+      const envelope = await guarded(() => readRevisionAgentArtifact(collection.active.revisionId, binding), 'agentArtifacts')
+      if (JSON.stringify(await guarded(readActive)) !== JSON.stringify(collection.active)) publicationFailed('agentArtifacts')
+      return envelope
     },
-    async read(): Promise<D1ActiveCollection | null> {
-      try {
-        if (await realpath(hostRoot) !== hostRoot) throw new Error('non-canonical host root')
-        await assertDirectory(hostRoot, policy)
-        const revisionsRoot = path.join(hostRoot, 'revisions')
-        await assertDirectory(revisionsRoot, policy)
-        const activeContent = await readFile(path.join(hostRoot, 'active'), policy, true, 16 * 1024)
-        if (activeContent === null) return null
-        const active = canonicalizeD1ActiveEnvelope(json(activeContent))
-        const revisionRoot = path.join(revisionsRoot, active.revisionId)
-        await assertDirectory(revisionRoot, policy)
-
-        const desiredFile = json((await readFile(path.join(revisionRoot, 'desired.json'), policy))!)
-        const resolvedFile = json((await readFile(path.join(revisionRoot, 'resolved.json'), policy))!)
-        exactKeys(desiredFile, ['schemaVersion', 'domain', 'plan'], 'desiredFile')
-        exactKeys(resolvedFile, ['schemaVersion', 'domain', 'bindings'], 'resolvedFile')
-        if (desiredFile.schemaVersion !== 1 || desiredFile.domain !== PLAN_DOMAIN
-          || resolvedFile.schemaVersion !== 1 || resolvedFile.domain !== RESOLVED_DOMAIN) throw new Error('invalid split snapshot')
-        const desired = await canonicalizeD1DesiredSnapshot({
-          schemaVersion: 1, domain: 'boring-d1-desired:v1', plan: desiredFile.plan, resolvedBindings: resolvedFile.bindings,
-        })
-        if (desired.plan.hostId !== hostId) throw new Error('host mismatch')
-        const desiredStateDigest = await digestD1Desired(desired)
-        if (active.desiredStateDigest !== desiredStateDigest
-          || await readFile(path.join(revisionRoot, 'desired.sha256'), policy, false, 256) !== `${desiredStateDigest}\n`) throw new Error('digest mismatch')
-
-        canonicalizeD1SecretRefsEnvelope(json((await readFile(path.join(revisionRoot, 'secret-refs.json'), policy, false, FILE_LIMIT))!), desired)
-        const bindingsRoot = path.join(revisionRoot, 'bindings')
-        await assertDirectory(bindingsRoot, policy)
-        for (const binding of desired.plan.bindings) {
-          validateD1BindingEnv((await readFile(path.join(bindingsRoot, `${binding.bindingId}.env`), policy, false, 64 * 1024))!, binding)
-        }
-        const observation = await canonicalizeD1Observation(
-          json((await readFile(path.join(revisionRoot, 'observed.json'), policy))!), desired,
-        )
-        const completion = await canonicalizeD1CompleteEnvelope(
-          json((await readFile(path.join(revisionRoot, 'completion.json'), policy, false, 16 * 1024))!), desired, observation,
-        )
-        if (completion.revisionId !== active.revisionId || completion.desiredStateDigest !== active.desiredStateDigest) throw new Error('completion mismatch')
-        return Object.freeze({ active, desired, observation, completion })
-      } catch { publicationFailed() }
+    async read() {
+      return guarded(async () => {
+        const active = await readActive(); if (!active) return null
+        const complete = await readComplete(active.revisionId)
+        if (!complete || complete.desiredStateDigest !== active.desiredStateDigest) throw new Error()
+        return Object.freeze({ active, desired: complete.desired, observation: complete.observation, completion: complete.completion })
+      })
     },
   })
 }

--- a/apps/full-app/src/server/deployment/d1ProductionAuthority.ts
+++ b/apps/full-app/src/server/deployment/d1ProductionAuthority.ts
@@ -1,10 +1,15 @@
+import path from 'node:path'
+
 import { assertRealPathWithinWorkspace, createNodeWorkspace, resolveWorkspaceRoot, validatePath } from '@hachej/boring-agent/server'
 
+import { createD1ActiveCollectionReader, type D1ImmutableRevisionReader } from './activeCollectionReader.js'
 import { createD1CollectionController, D1_V1_COLLECTION_LIMITS, type D1CollectionController } from './bootCollection.js'
 import { loadD1ValidatedAgentArtifactRecipe } from './d1AgentRuntimeRecipe.js'
 import { D1HostError, D1HostErrorCode, strictD1HostId } from './d1Plan.js'
+import { readD1PendingPublication, type D1PendingPublicationV1, type D1PublicationControlAuthority, type D1PublicationStatusV1 } from './d1PublicationControl.js'
+import { canonicalizeD1RuntimeInputsIdentity } from './d1RuntimeInputs.js'
 import { createD1UserNeutralCandidatePreloader, type D1UserNeutralCandidateInput, type D1UserNeutralCandidatePreloader } from './d1UserNeutralPreloader.js'
-import { createHostRevisionStore, type D1StoredCompleteV1 } from './hostRevisionStore.js'
+import type { D1StoredCandidateV1 } from './hostRevisionStore.js'
 
 const APP_GID = 10001
 const STATE_ROOT = '/var/lib/boring/d1'
@@ -20,7 +25,7 @@ function failed(): never {
  * The D1 core's only retained preparation is an immutable recipe and a validated
  * workspace allocation. It deliberately does not create a user/session runtime.
  */
-export interface D1ProductionAuthority {
+export interface D1ProductionAuthority extends D1PublicationControlAuthority {
   readonly servedCollection: D1CollectionController
   readonly candidatePreloader: D1UserNeutralCandidatePreloader
   recover(): Promise<void>
@@ -30,14 +35,27 @@ export function createD1ProductionAuthority(options: {
   readonly hostId: string
   readonly ownerUid: number
   readonly appGid?: number
+  readonly stateRoot?: string
+  readonly pendingRoot?: string
+  /** Trusted test seam; production always constructs the fixed adapters below. */
+  readonly dependencies?: Readonly<{ store: D1ImmutableRevisionReader; servedCollection: D1CollectionController
+    candidatePreloader: D1UserNeutralCandidatePreloader; readPending(): Promise<D1PendingPublicationV1 | null> }>
 }): D1ProductionAuthority {
-  const hostId = strictD1HostId(options.hostId, 'hostId')
-  const store = createHostRevisionStore({ root: STATE_ROOT, ownerUid: options.ownerUid, appGid: options.appGid ?? APP_GID })
-  let recovery: D1StoredCompleteV1 | undefined
-  const preloader = createD1UserNeutralCandidatePreloader({
+  const hostId = strictD1HostId(options.hostId, 'hostId'); const appGid = options.appGid ?? APP_GID
+  const store = options.dependencies?.store ?? createD1ActiveCollectionReader({
+    hostRoot: path.join(options.stateRoot ?? STATE_ROOT, hostId), hostId, ownerUid: options.ownerUid, appGid,
+  })
+  const readPending = options.dependencies?.readPending ?? (() => readD1PendingPublication({
+    root: options.pendingRoot ?? path.join(options.stateRoot ?? STATE_ROOT, hostId), ownerUid: options.ownerUid, appGid,
+  }))
+  let target: D1StoredCandidateV1 | undefined; let controlTail: Promise<unknown> = Promise.resolve()
+  const serialized = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = controlTail.then(operation, operation); controlTail = result.then(() => undefined, () => undefined); return result
+  }
+  const preloader = options.dependencies?.candidatePreloader ?? createD1UserNeutralCandidatePreloader({
     async loadValidatedRecipe(input) {
       try {
-        const artifact = await store.readAgentArtifact(hostId, input.revisionId, input.binding.bindingId)
+        const artifact = await store.readRevisionAgentArtifact(input.revisionId, input.binding)
         if (!artifact) failed()
         return await loadD1ValidatedAgentArtifactRecipe(artifact, input.binding, input.resolved)
       } catch (error) {
@@ -65,16 +83,16 @@ export function createD1ProductionAuthority(options: {
       }
     },
   })
-  const servedCollection = createD1CollectionController({
+  const servedCollection = options.dependencies?.servedCollection ?? createD1CollectionController({
     limits: D1_V1_COLLECTION_LIMITS,
     // Child 2 supplies the root-controlled immutable target artifact handoff.
     // Until then, only recovery may resolve a persisted immutable revision.
     resolveBinding: async (binding, plan) => {
       try {
-        const target = recovery
-        if (!target || JSON.stringify(plan) !== JSON.stringify(target.desired.plan)) unavailable('resolver')
-        const resolved = target.desired.resolvedBindings.find((value) => value.bindingId === binding.bindingId)
-        const artifact = await store.readAgentArtifact(hostId, target.revisionId, binding.bindingId)
+        const selected = target
+        if (!selected || JSON.stringify(plan) !== JSON.stringify(selected.desired.plan)) unavailable('resolver')
+        const resolved = selected.desired.resolvedBindings.find((value) => value.bindingId === binding.bindingId)
+        const artifact = await store.readRevisionAgentArtifact(selected.revisionId, binding)
         if (!resolved || !artifact) failed()
         await loadD1ValidatedAgentArtifactRecipe(artifact, binding, resolved)
         return Object.freeze({
@@ -91,27 +109,68 @@ export function createD1ProductionAuthority(options: {
       return Object.freeze({ recipe: prepared.recipe, dispose: prepared.dispose })
     },
   })
+  const same = (revision: string | null, digest: string | null, actual = servedCollection.snapshot()) =>
+    (actual?.revisionId ?? null) === revision && (actual?.desiredStateDigest ?? null) === digest
+  const pendingFor = async (operationId?: string) => {
+    const pending = await readPending()
+    if (!pending || operationId !== undefined && pending.operationId !== operationId) failed()
+    return pending
+  }
+  const status = async (pending?: D1PendingPublicationV1 | null): Promise<D1PublicationStatusV1> => {
+    const durable = await store.readActive(); const served = servedCollection.snapshot()
+    return Object.freeze({ durableRevision: durable?.revisionId ?? null, servedRevision: served?.revisionId ?? null,
+      pendingOperation: pending?.operationId ?? null })
+  }
+  const prepare = async (pending: D1PendingPublicationV1) => {
+    if (same(pending.targetRevision, pending.targetDigest)) return status(pending)
+    if (!same(pending.expectedRevision, pending.expectedDigest)) failed()
+    const candidate = await store.readCandidate(pending.targetRevision)
+    if (!candidate || candidate.desiredStateDigest !== pending.targetDigest) failed()
+    target = candidate
+    try {
+      const desired = await servedCollection.resolver.resolvePlan({ ...candidate.desired.plan, expectedHostRevision: pending.expectedRevision })
+      if (JSON.stringify(desired) !== JSON.stringify(candidate.desired)) failed()
+      const inputs = await Promise.all(pending.runtimeInputs.map((value, index) => {
+        const binding = candidate.desired.plan.bindings[index]
+        if (!binding) unavailable('runtimeInputs')
+        return canonicalizeD1RuntimeInputsIdentity(value, binding)
+      }))
+      if (inputs.length !== candidate.desired.plan.bindings.length) unavailable('runtimeInputs')
+      await servedCollection.preload(candidate, inputs)
+      return status(pending)
+    } finally { target = undefined }
+  }
+  const recoverActive = async () => {
+    const active = await store.readActive()
+    if (!active) return
+    const complete = await store.readComplete(active.revisionId)
+    if (!complete || complete.desiredStateDigest !== active.desiredStateDigest) failed()
+    target = complete
+    try {
+      const reproduced = await servedCollection.resolver.reproduce(complete)
+      if (JSON.stringify(reproduced) !== JSON.stringify(complete.desired)) failed()
+      await servedCollection.preload(complete, complete.observation.bindings.map((binding) => binding.runtimeInputs))
+      await servedCollection.serve(active)
+    } finally { target = undefined }
+  }
   return Object.freeze({
-    servedCollection,
-    candidatePreloader: preloader,
-    async recover() {
+    servedCollection, candidatePreloader: preloader,
+    prepare: (operationId: string) => serialized(async () => prepare(await pendingFor(operationId))),
+    commit: (operationId: string) => serialized(async () => {
+      const pending = await pendingFor(operationId); const durable = await store.readActive()
+      if (!durable || durable.revisionId !== pending.targetRevision || durable.desiredStateDigest !== pending.targetDigest) failed()
+      if (!same(pending.targetRevision, pending.targetDigest)) await servedCollection.serve(durable)
+      return status(pending)
+    }),
+    status: () => serialized(async () => status(await readPending())),
+    recover: () => serialized(async () => {
       try {
-        const active = await store.readActive(hostId)
-        if (!active) return
-        const complete = await store.readComplete(hostId, active.revisionId)
-        if (!complete || complete.desiredStateDigest !== active.desiredStateDigest) failed()
-        const inputs = complete.observation.bindings.map((binding) => binding.runtimeInputs)
-        recovery = complete
-        try {
-          const reproduced = await servedCollection.resolver.reproduce(complete)
-          if (JSON.stringify(reproduced) !== JSON.stringify(complete.desired)) failed()
-          await servedCollection.preload(complete, inputs)
-          await servedCollection.serve(active)
-        } finally { recovery = undefined }
-      } catch (error) {
-        if (error instanceof D1HostError) throw error
-        unavailable('recovery')
-      }
-    },
+        const pending = await readPending(); const durable = await store.readActive()
+        if (pending && !((durable?.revisionId ?? null) === pending.expectedRevision && (durable?.desiredStateDigest ?? null) === pending.expectedDigest)
+          && !(durable?.revisionId === pending.targetRevision && durable.desiredStateDigest === pending.targetDigest)) failed()
+        await recoverActive()
+        if (pending && (durable?.revisionId ?? null) === pending.expectedRevision) await prepare(pending)
+      } catch (error) { if (error instanceof D1HostError) throw error; unavailable('recovery') }
+    }),
   })
 }

--- a/apps/full-app/src/server/deployment/d1PublicationControl.ts
+++ b/apps/full-app/src/server/deployment/d1PublicationControl.ts
@@ -1,0 +1,123 @@
+import { constants, type Stats } from 'node:fs'
+import { chmod, lstat, open, realpath, unlink } from 'node:fs/promises'
+import { createServer, type Server, type Socket } from 'node:net'
+import path from 'node:path'
+
+import type { Sha256Digest } from '@hachej/boring-agent/shared'
+
+import { assertD1ExactKeys, d1Digest, D1HostError, D1HostErrorCode, strictD1Ref } from './d1Plan.js'
+
+export const D1_CONTROL_ROOT = '/run/boring/d1-control'
+export const D1_PENDING_PUBLICATION_FILE = 'pending'
+export const D1_PUBLICATION_SOCKET_FILE = 'publication.sock'
+const MAX_FRAME_BYTES = 512
+const MAX_PENDING_BYTES = 512 * 1024
+const REVISION_RE = /^r\d{10}$/
+
+export interface D1PendingPublicationV1 {
+  readonly schemaVersion: 1
+  readonly operationId: string
+  readonly expectedRevision: string | null
+  readonly expectedDigest: Sha256Digest | null
+  readonly targetRevision: string
+  readonly targetDigest: Sha256Digest
+  readonly runtimeInputs: readonly unknown[]
+}
+export interface D1PublicationStatusV1 {
+  readonly durableRevision: string | null
+  readonly servedRevision: string | null
+  readonly pendingOperation: string | null
+}
+export interface D1PublicationControlAuthority {
+  prepare(operationId: string): Promise<D1PublicationStatusV1>
+  commit(operationId: string): Promise<D1PublicationStatusV1>
+  status(operationId?: string): Promise<D1PublicationStatusV1>
+}
+
+function failed(field = 'publication'): never { throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field }) }
+function revision(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !REVISION_RE.test(value)) failed(field)
+  return value
+}
+export function parseD1PendingPublication(raw: unknown): D1PendingPublicationV1 {
+  try {
+    assertD1ExactKeys(raw, ['schemaVersion', 'operationId', 'expectedRevision', 'expectedDigest', 'targetRevision', 'targetDigest', 'runtimeInputs'], 'pending')
+    if (raw.schemaVersion !== 1 || (raw.expectedRevision === null) !== (raw.expectedDigest === null)
+      || !Array.isArray(raw.runtimeInputs) || raw.runtimeInputs.length > 20) failed('pending')
+    return Object.freeze({ schemaVersion: 1, operationId: strictD1Ref(raw.operationId, 'operationId'),
+      expectedRevision: raw.expectedRevision === null ? null : revision(raw.expectedRevision, 'expectedRevision'),
+      expectedDigest: raw.expectedDigest === null ? null : d1Digest(raw.expectedDigest, 'expectedDigest'),
+      targetRevision: revision(raw.targetRevision, 'targetRevision'), targetDigest: d1Digest(raw.targetDigest, 'targetDigest'),
+      runtimeInputs: Object.freeze(structuredClone(raw.runtimeInputs)) })
+  } catch { failed('pending') }
+}
+function exact(info: Stats, uid: number, gid: number, mode: number): boolean {
+  return info.uid === uid && info.gid === gid && (info.mode & 0o7777) === mode
+}
+export async function readD1PendingPublication(options: {
+  readonly root?: string; readonly ownerUid: number; readonly appGid: number
+}): Promise<D1PendingPublicationV1 | null> {
+  const root = options.root ?? D1_CONTROL_ROOT; const file = path.join(root, D1_PENDING_PUBLICATION_FILE)
+  let handle
+  try {
+    const rootInfo = await lstat(root)
+    if (!rootInfo.isDirectory() || rootInfo.isSymbolicLink() || !exact(rootInfo, options.ownerUid, options.appGid, 0o710)
+      || await realpath(root) !== root) failed('controlRoot')
+    try { handle = await open(file, constants.O_RDONLY | constants.O_NOFOLLOW) }
+    catch (error) { if ((error as NodeJS.ErrnoException).code === 'ENOENT') return null; throw error }
+    const info = await handle.stat()
+    if (!info.isFile() || !exact(info, options.ownerUid, options.appGid, 0o440) || info.nlink !== 1 || info.size < 1 || info.size > MAX_PENDING_BYTES) failed('pending')
+    const bytes = await handle.readFile()
+    return parseD1PendingPublication(JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown)
+  } catch (error) { if (error instanceof D1HostError) throw error; return failed('pending') }
+  finally { await handle?.close() }
+}
+function request(raw: unknown): Readonly<{ action: 'prepare' | 'commit' | 'status'; operationId?: string }> {
+  try {
+    if (typeof raw !== 'object' || raw === null) failed('request')
+    const action = (raw as { action?: unknown }).action
+    if (action === 'status') {
+      assertD1ExactKeys(raw, ['action'], 'request'); return Object.freeze({ action })
+    }
+    if (action !== 'prepare' && action !== 'commit') failed('request')
+    assertD1ExactKeys(raw, ['action', 'operationId'], 'request')
+    return Object.freeze({ action, operationId: strictD1Ref((raw as { operationId?: unknown }).operationId, 'operationId') })
+  } catch { failed('request') }
+}
+function serveSocket(socket: Socket, authority: D1PublicationControlAuthority): void {
+  let bytes = 0; let frame = ''; let finished = false
+  const reject = () => { if (!finished) { finished = true; socket.end(`${JSON.stringify({ ok: false, error: { code: D1HostErrorCode.PUBLICATION_FAILED, details: { field: 'request' } } })}\n`) } }
+  socket.setEncoding('utf8'); socket.on('data', (chunk: string) => {
+    if (finished) return
+    bytes += Buffer.byteLength(chunk); frame += chunk
+    if (bytes > MAX_FRAME_BYTES || frame.indexOf('\n') !== frame.lastIndexOf('\n')) reject()
+  }); socket.on('end', () => {
+    if (finished || !frame.endsWith('\n')) return reject()
+    finished = true
+    void (async () => {
+      try {
+        const value = request(JSON.parse(frame.slice(0, -1)) as unknown)
+        const status = value.action === 'prepare' ? await authority.prepare(value.operationId!)
+          : value.action === 'commit' ? await authority.commit(value.operationId!) : await authority.status()
+        socket.end(`${JSON.stringify({ ok: true, status })}\n`)
+      } catch { socket.end(`${JSON.stringify({ ok: false, error: { code: D1HostErrorCode.PUBLICATION_FAILED, details: { field: 'request' } } })}\n`) }
+    })()
+  }); socket.on('error', () => {})
+}
+export async function startD1PublicationControlServer(authority: D1PublicationControlAuthority, options: {
+  readonly root?: string; readonly ownerUid: number; readonly appUid?: number; readonly appGid: number
+}): Promise<Server> {
+  const root = options.root ?? D1_CONTROL_ROOT; const socketPath = path.join(root, D1_PUBLICATION_SOCKET_FILE)
+  const rootInfo = await lstat(root)
+  if (!rootInfo.isDirectory() || rootInfo.isSymbolicLink() || !exact(rootInfo, options.ownerUid, options.appGid, 0o730)
+    || await realpath(root) !== root) failed('controlRoot')
+  try {
+    const existing = await lstat(socketPath)
+    if (!existing.isSocket() || existing.uid !== (options.appUid ?? process.geteuid?.())) failed('socket')
+    await unlink(socketPath)
+  } catch (error) { if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error }
+  const server = createServer({ allowHalfOpen: true }, (socket) => serveSocket(socket, authority))
+  await new Promise<void>((resolve, reject) => { server.once('error', reject); server.listen(socketPath, resolve) })
+  try { await chmod(socketPath, 0o660); server.unref(); return server }
+  catch (error) { server.close(); throw error }
+}

--- a/apps/full-app/src/server/main.ts
+++ b/apps/full-app/src/server/main.ts
@@ -19,6 +19,7 @@ import {
 import { assertProductionAgentModeIsSafe } from './productionSafety.js'
 import type { WorkspaceAgentDispatcherResolver } from '@hachej/boring-agent/server'
 import type { FastifyRequest } from 'fastify'
+import { startD1PublicationControlServer } from './deployment/d1PublicationControl.js'
 import { createD1ProductionAuthority } from './deployment/d1ProductionAuthority.js'
 import { createD1ServerWiring } from './deployment/d1ServerWiring.js'
 
@@ -38,6 +39,9 @@ async function main() {
     ownerUid: Number(process.env.BORING_D1_OWNER_UID),
   })
   await authority?.recover()
+  if (authority) await startD1PublicationControlServer(authority, {
+    ownerUid: Number(process.env.BORING_D1_OWNER_UID), appGid: process.getegid!(),
+  })
   const d1 = createD1ServerWiring(config, process.env, authority)
   const { governance, ...pluginComposition } = await createFullAppHostPluginComposition(config)
   // Build the metering sink up-front; the credit service attaches after the


### PR DESCRIPTION
## Summary
- add the fixed, bounded Unix `prepare|commit|status` control protocol
- read root-owned pending state and immutable revisions through app-readable DAC validation
- recover exact durable/pending tuples before either control or HTTP ingress listens

## Issue / Slice
`wt-391-forward-vup.2.4.1`

## Proof
- `cd apps/full-app && pnpm exec vitest run src/server/deployment/__tests__/activeCollectionReader.test.ts src/server/deployment/__tests__/d1PublicationControl.test.ts src/server/deployment/__tests__/d1ProductionAuthority.test.ts src/server/deployment/__tests__/bootCollection.test.ts src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts` — 56 passed
- `pnpm --filter full-app typecheck` — pass
- `git diff --cached --check` — pass before commit
- net diff: +338, within the <=400 limit

## Review
Independent structured review found three issues; all fixed and re-reviewed clean:
- replaced owner-only mutation store with app-readable immutable revision reader
- buffer until EOF and reject split-write multiple frames
- require exact durable reproduction during recovery

## Risk / Rollback
Fail-closed on malformed DAC, pending identity, revision/digest, runtime inputs, or unrelated recovery tuples. Revert this PR to remove the control listener and retain #766 recovery behavior.

## Next
Mandatory Fable Opus security review. **Do not arm auto-merge or merge before owner sign-off.**