### PR TITLE
feat(d1): wire durable root publication

### DIFF
--- a/apps/full-app/src/server/deployment/__tests__/activeCollectionReader.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/activeCollectionReader.test.ts
@@ -89,7 +89,8 @@ async function fixture(complete = true, content = 'Compare policies.') {
   const deployment = { deploymentId: binding.defaultDeploymentId, version: '2026.07.12', agentId: 'default',
     definition: { definitionId: definition.definitionId, version: definition.version, digest: definition.digest } }
   const candidate = await store.writeCandidate('host-1', revisionId, value, [{ envelope: { schemaVersion: 1, domain: 'boring-d1-agent-artifact:v1', hostId: 'host-1',
-    bindingId: binding.bindingId, bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, bundle, deployment } }])
+    bindingId: binding.bindingId, bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef,
+    workspaceAllocationRef: binding.workspaceAllocationRef, workspaceCompositionDigest: value.resolvedBindings[0]!.composition.digest, bundle, deployment } }])
   let active = { schemaVersion: 1 as const, revisionId, desiredStateDigest: candidate.desiredStateDigest }
   if (complete) {
     await store.writeObservation('host-1', revisionId, await observation(value))

--- a/apps/full-app/src/server/deployment/__tests__/composeAdapter.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/composeAdapter.test.ts
@@ -38,6 +38,7 @@ const expectedEnv = {
   D1_INGRESS_IMAGE: images.ingressImage,
   D1_MATERIALIZED_HOST_ROOT: '/run/boring/d1/eu-host-1',
   D1_STATE_ROOT: '/var/lib/boring/d1/eu-host-1',
+  D1_CONTROL_ROOT: '/run/boring/d1-control',
 }
 
 function runnerWithFreshNetwork(composeResult: D1ComposeResult = { exitCode: 0 }) {
@@ -99,6 +100,10 @@ describe('D1 Compose topology', () => {
         type: 'bind', source: '${D1_MATERIALIZED_HOST_ROOT:?D1_MATERIALIZED_HOST_ROOT is required}',
         target: '/run/boring/d1', read_only: true, bind: { create_host_path: false },
       },
+      {
+        type: 'bind', source: '${D1_CONTROL_ROOT:?D1_CONTROL_ROOT is required}',
+        target: '/run/boring/d1-control', bind: { create_host_path: false },
+      },
     ])
 
     const serialized = JSON.stringify(document)
@@ -118,8 +123,9 @@ describe('D1 Compose command policy', () => {
   it.each<[D1ComposeEffect, readonly string[][]]>([
     ['initial', [
       [...base, 'run', '--rm', '--no-deps', 'core-app', 'node', 'apps/full-app/dist/server/migrate.js'],
-      [...base, 'up', '-d'],
+      [...base, 'up', '-d', '--no-deps', 'core-app'],
     ]],
+    ['start-ingress', [[...base, 'up', '-d', '--no-deps', 'ingress']]],
     ['restart-core', [[...base, 'up', '-d', '--no-deps', 'core-app']]],
     ['no-compose', []],
   ])('renders the exact %s argv matrix', async (effect, expected) => {

--- a/apps/full-app/src/server/deployment/__tests__/d1AgentArtifactSnapshot.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1AgentArtifactSnapshot.test.ts
@@ -20,7 +20,8 @@ async function artifact(overrides: Record<string, unknown> = {}) {
   const definition = { schemaVersion: 1 as const, definitionId: 'definition:insurance', version: '1.0.0', instructionsRef: asset.path }
   const definitionDigest = await createAgentDefinitionDigest({ definition, assets: [asset] })
   return { schemaVersion: 1, domain: 'boring-d1-agent-artifact:v1', hostId: 'host-1', bindingId: binding.bindingId,
-    bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, bundle: { definition, definitionDigest, assets: [asset] },
+    bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, workspaceAllocationRef: binding.workspaceAllocationRef,
+    workspaceCompositionDigest: digest('c'), bundle: { definition, definitionDigest, assets: [asset] },
     deployment: { deploymentId: binding.defaultDeploymentId, version: '1.0.0', agentId: 'default',
       definition: { definitionId: definition.definitionId, version: definition.version, digest: definitionDigest } }, ...overrides }
 }
@@ -74,8 +75,9 @@ describe('D1 immutable agent artifact inbox', () => {
       current = await inbox(); const extra = await mutate(current)
       await expect(load(current.root, extra ?? {})).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
     }
-    const wrongRef = await inbox(await artifact({ bundleRef: '../bundle' }))
-    await expect(load(wrongRef.root)).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    for (const overrides of [{ bundleRef: '../bundle' }, { workspaceAllocationRef: 'stale' }, { workspaceCompositionDigest: digest('d') }]) {
+      await expect(load((await inbox(await artifact(overrides))).root)).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
+    }
     const tampered = await artifact(); (tampered.bundle.assets[0] as { content: string }).content = 'tampered'
     await expect(load((await inbox(tampered)).root)).rejects.toMatchObject({ validationCode: 'AGENT_DEFINITION_INVALID' })
   })

--- a/apps/full-app/src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1AgentRuntimeRecipe.test.ts
@@ -23,7 +23,8 @@ async function deployed(id: string, content: string) {
   const resolved = await resolveAgentDeployment(bundle, deployment, { workspaceId: binding.workspaceId,
     defaultDeploymentId: binding.defaultDeploymentId, workspaceCompositionDigest: compositionDigest })
   const envelope = { schemaVersion: 1, domain: 'boring-d1-agent-artifact:v1', hostId: 'host-1', bindingId: binding.bindingId,
-    bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, bundle, deployment } satisfies D1AgentArtifactEnvelopeV1
+    bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, workspaceAllocationRef: binding.workspaceAllocationRef,
+    workspaceCompositionDigest: compositionDigest, bundle, deployment } satisfies D1AgentArtifactEnvelopeV1
   return { binding, envelope, resolved: { schemaVersion: 1 as const, bindingId: binding.bindingId,
     composition: { snapshot: {} as never, digest: compositionDigest }, ...resolved } }
 }

--- a/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
@@ -193,7 +193,8 @@ describe('D1 revision command boundary', () => {
       const admissionLedger = { databaseRef: 'postgres-eu' } as D1AdmissionLedger
       const present = createProductionD1Dependencies({ ...context, admissionLedger })
       expect(present.store).toBe(revisionStore); expect(present.fencedPublication).toBe(fencedPublication); expect(createStore).toHaveBeenCalledOnce()
-      expect(createPublication).toHaveBeenCalledWith({ admissionLedger, journalStore: expect.anything(), revisionStore })
+      expect(createPublication).toHaveBeenCalledWith({ admissionLedger, journalStore: expect.anything(), revisionStore,
+        publicationControl: expect.objectContaining({ preload: expect.any(Function), recover: expect.any(Function) }) })
     } finally { createStore.mockRestore(); createJournal.mockRestore(); createPublication.mockRestore() }
   })
 

--- a/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1CommandCli.test.ts
@@ -294,8 +294,8 @@ describe('D1 revision command boundary', () => {
 
   it('reports a signal latched after leader exit while group cleanup is running', async () => {
     const h = await roots(); const marker = path.join(h.base, 'late-signal-pids')
-    const descendant = `process.on('SIGTERM',()=>{});process.on('SIGINT',()=>{});setInterval(()=>{},1000)`
-    const entryCode = `const c=require('child_process').spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:'ignore'});require('fs').writeFileSync(${JSON.stringify(marker)},JSON.stringify([process.pid,c.pid]));process.stdin.resume();process.stdin.on('end',()=>process.stdout.write(${JSON.stringify(SUCCESS)},()=>process.exit(0)))`
+    const descendant = `process.on('SIGTERM',()=>{});process.on('SIGINT',()=>{});process.send('ready');setInterval(()=>{},1000)`
+    const entryCode = `let ended=false,ready=false;const done=()=>{if(ended&&ready)process.stdout.write(${JSON.stringify(SUCCESS)},()=>process.exit(0))};const c=require('child_process').spawn(process.execPath,['-e',${JSON.stringify(descendant)}],{stdio:['ignore','ignore','ignore','ipc']});c.once('message',()=>{ready=true;require('fs').writeFileSync(${JSON.stringify(marker)},JSON.stringify([process.pid,c.pid]));done()});process.stdin.resume();process.stdin.on('end',()=>{ended=true;done()})`
     const wrapperUrl = pathToFileURL(path.resolve('src/server/deployment/d1CommandWrapper.ts')).href
     const harness = `import {runD1RevisionWrapper} from ${JSON.stringify(wrapperUrl)};const out=await runD1RevisionWrapper({handleSignals:true,entry:{command:process.execPath,args:['-e',${JSON.stringify(entryCode)},'--']}});process.stdout.write(out.line);process.exitCode=out.exitCode`
     const child = spawn(process.execPath, ['--import', 'tsx', '--input-type=module', '-e', harness, '--'], { env: h.env, stdio: ['pipe', 'pipe', 'pipe'] })

--- a/apps/full-app/src/server/deployment/__tests__/d1ProductionAuthority.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1ProductionAuthority.test.ts
@@ -27,17 +27,18 @@ beforeEach(async () => { input = await createD1RuntimeInputsIdentity(binding, { 
 function harness(start: typeof oldActive | typeof targetActive | null, initiallyServed: typeof oldActive | typeof targetActive | null = null) {
   let durable = start; let served = initiallyServed; let pending: D1PendingPublicationV1 | null = { schemaVersion: 1, operationId: 'operation-1',
     expectedRevision: oldActive.revisionId, expectedDigest: oldActive.desiredStateDigest, targetRevision: targetActive.revisionId,
-    targetDigest: targetActive.desiredStateDigest, runtimeInputs: [input] }
+    targetDigest: targetActive.desiredStateDigest, runtimeInputs: [input], rollback: null, state: 'prepared' }
   const preload = vi.fn(async () => ({ bindings: [] })); const serve = vi.fn(async (active: typeof oldActive) => { served = active; return active })
   const reproduce = vi.fn(async () => desired)
+  const discardPrepared = vi.fn()
   const controller = { resolver: { resolvePlan: vi.fn(async () => desired), reproduce }, preload, serve,
     snapshot: () => served && ({ revisionId: served.revisionId, desiredStateDigest: served.desiredStateDigest }), read: vi.fn(), readRecipe: vi.fn(),
-    settleRetirement: vi.fn(), discardPrepared: vi.fn() } as unknown as D1CollectionController
+    settleRetirement: vi.fn(), discardPrepared } as unknown as D1CollectionController
   const store = { readActive: vi.fn(async () => durable), readCandidate: vi.fn(async () => candidate),
     readComplete: vi.fn(async (revision: string) => complete(revision === oldActive.revisionId ? oldActive : targetActive)) } as never
   const authority = createD1ProductionAuthority({ hostId: 'host-1', ownerUid: 0, dependencies: { store, servedCollection: controller,
     candidatePreloader: { prepare: vi.fn() }, readPending: async () => pending } })
-  return { authority, preload, serve, reproduce, setDurable(value: typeof oldActive | typeof targetActive | null) { durable = value },
+  return { authority, preload, serve, reproduce, discardPrepared, setDurable(value: typeof oldActive | typeof targetActive | null) { durable = value },
     setPending(value: D1PendingPublicationV1 | null) { pending = value }, served: () => served }
 }
 
@@ -49,6 +50,21 @@ describe('D1 production publication authority', () => {
     await expect(h.authority.commit('operation-1')).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED })
     h.setDurable(targetActive)
     await expect(h.authority.commit('operation-1')).resolves.toMatchObject({ durableRevision: targetActive.revisionId, servedRevision: targetActive.revisionId })
+  })
+
+  it('discards an exact prepared operation once across a lost acknowledgement retry', async () => {
+    const h = harness(oldActive, oldActive); await h.authority.prepare('operation-1')
+    await h.authority.discard('operation-1'); await h.authority.discard('operation-1')
+    expect(h.discardPrepared).toHaveBeenCalledTimes(1); expect(h.discardPrepared).toHaveBeenCalledWith(targetActive)
+  })
+
+  it('passes the exact root-owned rollback authorization into the atomic serve', async () => {
+    const h = harness(oldActive, oldActive); const rollback = { operationId: 'operation-1', hostId: 'host-1', expectedRevision: oldActive.revisionId,
+      expectedDigest: oldActive.desiredStateDigest, targetRevision: targetActive.revisionId, targetDigest: targetActive.desiredStateDigest,
+      removalBindingIds: ['removed'] }
+    h.setPending({ schemaVersion: 1, ...rollback, runtimeInputs: [input], rollback, state: 'prepared' })
+    await h.authority.prepare('operation-1'); h.setDurable(targetActive); await h.authority.commit('operation-1')
+    expect(h.serve).toHaveBeenLastCalledWith(targetActive, { kind: 'rollback', authorization: rollback })
   })
 
   it.each([[oldActive, oldActive], [targetActive, targetActive]] as const)('converges valid pending restart tuple %#', async (durable, expectedServed) => {

--- a/apps/full-app/src/server/deployment/__tests__/d1ProductionDependencies.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1ProductionDependencies.test.ts
@@ -12,7 +12,11 @@ const seams = vi.hoisted(() => {
       throw new D1HostError(D1HostErrorCode.SECRET_UNAVAILABLE, { field: 'secret' })
     }),
   }
-  return { provider, createProvider: vi.fn(() => provider), createInspector: vi.fn(), createMaterializer: vi.fn(), loadArtifacts: vi.fn(async () => []) }
+  const unavailable = (field: string) => async () => { throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field }) }
+  const resolver = { resolvePlan: unavailable('resolver'), reproduce: unavailable('resolver') }
+  const publication = { preload: unavailable('preload'), verifyActive: unavailable('active'), status: vi.fn(), commit: vi.fn(), discard: vi.fn(), recover: vi.fn() }
+  return { provider, resolver, publication, createProvider: vi.fn(() => provider), createInspector: vi.fn(), createMaterializer: vi.fn(),
+    loadArtifacts: vi.fn(async () => []), createResolver: vi.fn(() => resolver), createPublication: vi.fn(() => publication) }
 })
 
 vi.mock('../d1FileRuntimeInputsProvider.js', () => ({ createD1FileRuntimeInputsProvider: seams.createProvider }))
@@ -20,9 +24,9 @@ vi.mock('../d1SecretMaterializer.js', () => ({
   createD1RuntimeInputsInspector: seams.createInspector,
   createD1BindingSecretMaterializer: seams.createMaterializer,
 }))
-vi.mock('../d1AgentArtifactSnapshot.js', () => ({
-  loadD1AgentArtifactInputs: seams.loadArtifacts,
-}))
+vi.mock('../d1AgentArtifactSnapshot.js', () => ({ loadD1AgentArtifactInputs: seams.loadArtifacts }))
+vi.mock('../d1RootDesiredResolver.js', () => ({ createD1RootDesiredResolver: seams.createResolver }))
+vi.mock('../d1PublicationControl.js', () => ({ createD1RootPublicationClient: seams.createPublication }))
 
 import { createProductionD1Dependencies } from '../d1CommandEntry.js'
 

--- a/apps/full-app/src/server/deployment/__tests__/d1PublicationControl.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1PublicationControl.test.ts
@@ -70,8 +70,10 @@ describe('D1 core publication control', () => {
     const status = () => ({ durableRevision: active?.revisionId ?? null, servedRevision: active?.revisionId ?? null, pendingOperation: 'operation-1' })
     const authority = { prepare: vi.fn(async () => ({ durableRevision: null, servedRevision: null, pendingOperation: 'operation-1' })),
       commit: vi.fn(async () => status()), discard: vi.fn(async () => status()), status: vi.fn(async () => status()) } satisfies D1PublicationControlAuthority
-    const server = await startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() })
-    const startCore = vi.fn(async () => {}); const startIngress = vi.fn(async () => {
+    let started: Promise<Awaited<ReturnType<typeof startD1PublicationControlServer>>> | undefined
+    const startCore = vi.fn(async () => { started = new Promise((resolve) => setTimeout(() => {
+      startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() }).then(resolve)
+    }, 30)) }); const startIngress = vi.fn(async () => {
       expect(JSON.parse(await readFile(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), 'utf8'))).toMatchObject({ state: 'committed' })
     })
     const desired = { schemaVersion: 1, domain: 'boring-d1-desired:v1', plan: { schemaVersion: 1, hostId: 'host-1', hostAppImageDigest: digest('f'),
@@ -79,13 +81,13 @@ describe('D1 core publication control', () => {
     const candidate = { ...target, desired, secretRefs: { schemaVersion: 1, domain: 'boring-d1-secret-refs:v1', bindings: [] } } as never
     const store = { readActive: vi.fn(async () => active) } as never
     const client = createD1RootPublicationClient({ hostId: 'host-1', hostRoot, controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!(),
-      operationId: 'operation-1', revisionStore: store, startCore, startIngress })
+      operationId: 'operation-1', revisionStore: store, startCore, startIngress, startupTimeoutMs: 200 })
     try {
       await client.preload(candidate, []); expect(startCore).toHaveBeenCalledOnce()
       expect(await lstat(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE))).toMatchObject({ mode: expect.any(Number) })
       active = target; await client.verifyActive(target); expect(startIngress).toHaveBeenCalledOnce()
       await expect(lstat(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE))).rejects.toMatchObject({ code: 'ENOENT' })
-    } finally { await new Promise<void>((resolve) => server.close(() => resolve())) }
+    } finally { if (started) { const server = await started; await new Promise<void>((resolve) => server.close(() => resolve())) } }
   })
 
   it('retries exact initial core startup when pending exists before any socket', async () => {
@@ -93,15 +95,15 @@ describe('D1 core publication control', () => {
     await writeFile(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), JSON.stringify(first)); await chmod(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), 0o440)
     const status = { durableRevision: null, servedRevision: null, pendingOperation: first.operationId }
     const authority = { prepare: vi.fn(), commit: vi.fn(), discard: vi.fn(async () => status), status: vi.fn(async () => status) } as unknown as D1PublicationControlAuthority
-    let server: Awaited<ReturnType<typeof startD1PublicationControlServer>> | undefined
-    const startCore = vi.fn(async () => { server = await startD1PublicationControlServer(authority, {
-      root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!(),
-    }) })
+    let started: Promise<Awaited<ReturnType<typeof startD1PublicationControlServer>>> | undefined
+    const startCore = vi.fn(async () => { started = new Promise((resolve) => setTimeout(() => {
+      startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() }).then(resolve)
+    }, 30)) })
     const client = createD1RootPublicationClient({ hostId: 'host-1', hostRoot, controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!(),
       operationId: 'new-operation', revisionStore: { readCandidate: vi.fn(async () => ({ revisionId: first.targetRevision, desiredStateDigest: first.targetDigest })),
-        readComplete: vi.fn(async () => null) } as never, startCore, timeoutMs: 20 })
+        readComplete: vi.fn(async () => null) } as never, startCore, timeoutMs: 20, startupTimeoutMs: 200 })
     try { await client.recover(); expect(startCore).toHaveBeenCalledOnce() }
-    finally { if (server) await new Promise<void>((resolve) => server!.close(() => resolve())) }
+    finally { if (started) { const server = await started; await new Promise<void>((resolve) => server.close(() => resolve())) } }
   })
 
   it('discards a pre-journal destructive prepare without publishing its COMPLETE target', async () => {
@@ -127,9 +129,11 @@ describe('D1 core publication control', () => {
       durableRevision: null, servedRevision: null, pendingOperation: null,
     }), 50))) } as unknown as D1PublicationControlAuthority
     const server = await startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() })
-    const client = createD1RootPublicationClient({ hostId: 'host-1', hostRoot: await root(), controlRoot, ownerUid: process.geteuid!(),
-      appGid: process.getegid!(), operationId: 'operation-1', revisionStore: {} as never, timeoutMs: 20 })
-    try { await expect(client.status()).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED }) }
+    const hostRoot = await root(); const initial = { ...pending, expectedRevision: null, expectedDigest: null }
+    await writeFile(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), JSON.stringify(initial)); await chmod(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), 0o440)
+    const startCore = vi.fn(); const client = createD1RootPublicationClient({ hostId: 'host-1', hostRoot, controlRoot, ownerUid: process.geteuid!(),
+      appGid: process.getegid!(), operationId: 'operation-1', revisionStore: {} as never, startCore, timeoutMs: 20 })
+    try { await expect(client.recover()).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED }); expect(startCore).not.toHaveBeenCalled() }
     finally { await new Promise<void>((resolve) => server.close(() => resolve())) }
   })
 

--- a/apps/full-app/src/server/deployment/__tests__/d1PublicationControl.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/d1PublicationControl.test.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { chmod, lstat, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { createConnection } from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   D1_PENDING_PUBLICATION_FILE,
   D1_PUBLICATION_SOCKET_FILE,
+  createD1RootPublicationClient,
   parseD1PendingPublication,
   readD1PendingPublication,
   startD1PublicationControlServer,
@@ -18,7 +19,7 @@ import { D1HostErrorCode } from '../d1Plan.js'
 const digest = (value: string) => `sha256:${value.repeat(64)}` as const
 const roots: string[] = []
 const pending = { schemaVersion: 1, operationId: 'operation-1', expectedRevision: 'r0000000001', expectedDigest: digest('a'),
-  targetRevision: 'r0000000002', targetDigest: digest('b'), runtimeInputs: [] }
+  targetRevision: 'r0000000002', targetDigest: digest('b'), runtimeInputs: [], rollback: null, state: 'prepared' as const }
 
 afterEach(async () => { await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))) })
 async function root() {
@@ -50,7 +51,7 @@ describe('D1 core publication control', () => {
 
   it('dispatches one bounded fixed-action frame and returns redacted status', async () => {
     const controlRoot = await root(); await chmod(controlRoot, 0o730); const status = { durableRevision: 'r0000000002', servedRevision: 'r0000000001', pendingOperation: 'operation-1' }
-    const authority = { prepare: vi.fn(async () => status), commit: vi.fn(async () => status), status: vi.fn(async () => status) } satisfies D1PublicationControlAuthority
+    const authority = { prepare: vi.fn(async () => status), commit: vi.fn(async () => status), discard: vi.fn(async () => status), status: vi.fn(async () => status) } satisfies D1PublicationControlAuthority
     const server = await startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() })
     try {
       const socket = path.join(controlRoot, D1_PUBLICATION_SOCKET_FILE)
@@ -60,6 +61,76 @@ describe('D1 core publication control', () => {
       expect(JSON.stringify(await exchange(socket, '{"action":"commit","operationId":"operation-1","path":"/private"}\n')))
         .not.toContain('/private')
     } finally { await new Promise<void>((resolve) => server.close(() => resolve())) }
+  })
+
+  it('publishes pending before prepare and removes it only after exact served commit', async () => {
+    const hostRoot = await root(); const controlRoot = await root(); await chmod(controlRoot, 0o730)
+    let active: { schemaVersion: 1; revisionId: string; desiredStateDigest: ReturnType<typeof digest> } | null = null
+    const target = { schemaVersion: 1 as const, revisionId: 'r0000000002', desiredStateDigest: digest('b') }
+    const status = () => ({ durableRevision: active?.revisionId ?? null, servedRevision: active?.revisionId ?? null, pendingOperation: 'operation-1' })
+    const authority = { prepare: vi.fn(async () => ({ durableRevision: null, servedRevision: null, pendingOperation: 'operation-1' })),
+      commit: vi.fn(async () => status()), discard: vi.fn(async () => status()), status: vi.fn(async () => status()) } satisfies D1PublicationControlAuthority
+    const server = await startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() })
+    const startCore = vi.fn(async () => {}); const startIngress = vi.fn(async () => {
+      expect(JSON.parse(await readFile(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), 'utf8'))).toMatchObject({ state: 'committed' })
+    })
+    const desired = { schemaVersion: 1, domain: 'boring-d1-desired:v1', plan: { schemaVersion: 1, hostId: 'host-1', hostAppImageDigest: digest('f'),
+      runtimeProfileRef: 'runsc', databaseRef: 'database', workspaceRootPolicyRef: 'workspaces', sessionRootPolicyRef: 'sessions', bindings: [] }, resolvedBindings: [] }
+    const candidate = { ...target, desired, secretRefs: { schemaVersion: 1, domain: 'boring-d1-secret-refs:v1', bindings: [] } } as never
+    const store = { readActive: vi.fn(async () => active) } as never
+    const client = createD1RootPublicationClient({ hostId: 'host-1', hostRoot, controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!(),
+      operationId: 'operation-1', revisionStore: store, startCore, startIngress })
+    try {
+      await client.preload(candidate, []); expect(startCore).toHaveBeenCalledOnce()
+      expect(await lstat(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE))).toMatchObject({ mode: expect.any(Number) })
+      active = target; await client.verifyActive(target); expect(startIngress).toHaveBeenCalledOnce()
+      await expect(lstat(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE))).rejects.toMatchObject({ code: 'ENOENT' })
+    } finally { await new Promise<void>((resolve) => server.close(() => resolve())) }
+  })
+
+  it('retries exact initial core startup when pending exists before any socket', async () => {
+    const hostRoot = await root(); const controlRoot = await root(); const first = { ...pending, expectedRevision: null, expectedDigest: null }
+    await writeFile(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), JSON.stringify(first)); await chmod(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), 0o440)
+    const status = { durableRevision: null, servedRevision: null, pendingOperation: first.operationId }
+    const authority = { prepare: vi.fn(), commit: vi.fn(), discard: vi.fn(async () => status), status: vi.fn(async () => status) } as unknown as D1PublicationControlAuthority
+    let server: Awaited<ReturnType<typeof startD1PublicationControlServer>> | undefined
+    const startCore = vi.fn(async () => { server = await startD1PublicationControlServer(authority, {
+      root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!(),
+    }) })
+    const client = createD1RootPublicationClient({ hostId: 'host-1', hostRoot, controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!(),
+      operationId: 'new-operation', revisionStore: { readCandidate: vi.fn(async () => ({ revisionId: first.targetRevision, desiredStateDigest: first.targetDigest })),
+        readComplete: vi.fn(async () => null) } as never, startCore, timeoutMs: 20 })
+    try { await client.recover(); expect(startCore).toHaveBeenCalledOnce() }
+    finally { if (server) await new Promise<void>((resolve) => server!.close(() => resolve())) }
+  })
+
+  it('discards a pre-journal destructive prepare without publishing its COMPLETE target', async () => {
+    const hostRoot = await root(); const controlRoot = await root(); await chmod(controlRoot, 0o730)
+    const rollback = { operationId: 'operation-1', hostId: 'host-1', expectedRevision: 'r0000000001', expectedDigest: digest('a'),
+      targetRevision: 'r0000000002', targetDigest: digest('b'), removalBindingIds: ['removed'] }
+    await writeFile(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), JSON.stringify({ schemaVersion: 1, operationId: rollback.operationId,
+      expectedRevision: rollback.expectedRevision, expectedDigest: rollback.expectedDigest, targetRevision: rollback.targetRevision,
+      targetDigest: rollback.targetDigest, runtimeInputs: [], rollback, state: 'prepared' }));
+    await chmod(path.join(hostRoot, D1_PENDING_PUBLICATION_FILE), 0o440)
+    const status = { durableRevision: rollback.expectedRevision, servedRevision: rollback.expectedRevision, pendingOperation: rollback.operationId }
+    const authority = { prepare: vi.fn(), commit: vi.fn(), discard: vi.fn(async () => status), status: vi.fn(async () => status) } as unknown as D1PublicationControlAuthority
+    const server = await startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() })
+    const publishActive = vi.fn(); const client = createD1RootPublicationClient({ hostId: 'host-1', hostRoot, controlRoot,
+      ownerUid: process.geteuid!(), appGid: process.getegid!(), operationId: 'new-operation', revisionStore: { publishActive } as never })
+    try { await client.recover(); expect(publishActive).not.toHaveBeenCalled() }
+    finally { await new Promise<void>((resolve) => server.close(() => resolve())) }
+  })
+
+  it('bounds a silent control response', async () => {
+    const controlRoot = await root(); await chmod(controlRoot, 0o730)
+    const authority = { prepare: vi.fn(), commit: vi.fn(), status: vi.fn(() => new Promise((resolve) => setTimeout(() => resolve({
+      durableRevision: null, servedRevision: null, pendingOperation: null,
+    }), 50))) } as unknown as D1PublicationControlAuthority
+    const server = await startD1PublicationControlServer(authority, { root: controlRoot, ownerUid: process.geteuid!(), appGid: process.getegid!() })
+    const client = createD1RootPublicationClient({ hostId: 'host-1', hostRoot: await root(), controlRoot, ownerUid: process.geteuid!(),
+      appGid: process.getegid!(), operationId: 'operation-1', revisionStore: {} as never, timeoutMs: 20 })
+    try { await expect(client.status()).rejects.toMatchObject({ code: D1HostErrorCode.PUBLICATION_FAILED }) }
+    finally { await new Promise<void>((resolve) => server.close(() => resolve())) }
   })
 
   it.each([

--- a/apps/full-app/src/server/deployment/__tests__/fencedDestructivePublication.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/fencedDestructivePublication.test.ts
@@ -1,5 +1,5 @@
 import postgres from 'postgres'
-import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 import { createAgentAssetDigest, createAgentDeploymentDigest, type Sha256Digest } from '@hachej/boring-agent/shared'
 import { createResolvedAgentDigest } from '@hachej/boring-agent/server'
 import { runMigrations } from '@hachej/boring-core/server'
@@ -138,10 +138,11 @@ describe('D1 fenced destructive publication', () => {
       events.push(`publish:transaction=${state!.assigned}`)
     }
     const value = identity(h.revisions)
-    await createD1FencedDestructivePublication({ admissionLedger: ledger, journalStore: journal, revisionStore: h.revisions.store }).publish(value)
+    const publicationControl = { commit: vi.fn(async () => { events.push('served') }), status: vi.fn(async () => ({ durableRevision: value.expectedRevision, servedRevision: value.expectedRevision, pendingOperation: value.operationId })), discard: vi.fn(), recover: vi.fn() }
+    await createD1FencedDestructivePublication({ admissionLedger: ledger, journalStore: journal, revisionStore: h.revisions.store, publicationControl }).publish(value)
     expect(events).toEqual([
       'locked', 'active', 'complete:r0000000001', 'complete:r0000000002', 'admission-clear', 'prepared',
-      'publish:transaction=false', 'publish', 'terminal:committed', 'unlocking',
+      'publish:transaction=false', 'publish', 'served', 'terminal:committed', 'unlocking',
     ])
     expect((await operation(h.journal, value))?.terminal?.state).toBe('committed')
     expect(h.revisions.active.revisionId).toBe('r0000000002'); await h.close()

--- a/apps/full-app/src/server/deployment/__tests__/fencedDestructivePublication.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/fencedDestructivePublication.test.ts
@@ -169,9 +169,9 @@ describe('D1 fenced destructive publication', () => {
       h.revisions.onReadActive = async () => { entered.resolve(); await release.promise }
       const value = identity(h.revisions); const publisher = createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store })
       const published = publisher.publish(value); await entered.promise
-      const admitted = h.ledger.admit(reader(h.revisions), target(h.hostId, bindingId)); await Promise.resolve(); release.resolve()
+      const admitted = h.ledger.admit(reader(h.revisions), target(h.hostId, bindingId)).catch((error) => error); await Promise.resolve(); release.resolve()
       await published
-      await expect(admitted).rejects.toMatchObject({ code: D1HostErrorCode.ADMISSION_RECORD_FAILED })
+      expect(await admitted).toMatchObject({ code: D1HostErrorCode.ADMISSION_RECORD_FAILED })
       expect(await h.ledger.listBindingIds(h.hostId, 'postgres-eu')).not.toContain(bindingId); await h.close()
     }
   })
@@ -447,8 +447,8 @@ describe('D1 fenced destructive publication', () => {
       const h = await harness(); const value = identity(h.revisions); await prepare(h.journal, value)
       const entered = deferred(); const release = deferred(); h.revisions.onReadActive = async () => { entered.resolve(); await release.promise }
       const recovering = createD1FencedDestructivePublication({ admissionLedger: h.ledger, journalStore: h.journal, revisionStore: h.revisions.store }).recoverPending(h.hostId)
-      await entered.promise; const admission = h.ledger.admit(reader(h.revisions), target(h.hostId, bindingId)); await Promise.resolve(); release.resolve()
-      await recovering; await expect(admission).rejects.toMatchObject({ code: D1HostErrorCode.ADMISSION_RECORD_FAILED })
+      await entered.promise; const admission = h.ledger.admit(reader(h.revisions), target(h.hostId, bindingId)).catch((error) => error); await Promise.resolve(); release.resolve()
+      await recovering; expect(await admission).toMatchObject({ code: D1HostErrorCode.ADMISSION_RECORD_FAILED })
       expect((await operation(h.journal, value))?.terminal?.state).toBe('committed'); await h.close()
     }
   })

--- a/apps/full-app/src/server/deployment/__tests__/hostRevisionStore.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/hostRevisionStore.test.ts
@@ -81,7 +81,8 @@ async function artifact(value: D1DesiredSnapshotV1, index = 0): Promise<D1Loaded
   const deployment = { deploymentId: expected.deployment.deploymentId, version: expected.deployment.version, agentId: 'default',
     definition: { definitionId: definition.definitionId, version: definition.version, digest: bundle.definitionDigest } }
   return { envelope: { schemaVersion: 1, domain: 'boring-d1-agent-artifact:v1', hostId: value.plan.hostId,
-    bindingId: binding.bindingId, bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef, bundle, deployment } }
+    bindingId: binding.bindingId, bundleRef: binding.bundleRef, deploymentRef: binding.deploymentRef,
+    workspaceAllocationRef: binding.workspaceAllocationRef, workspaceCompositionDigest: expected.composition.digest, bundle, deployment } }
 }
 
 async function harness(fault?: () => void) {

--- a/apps/full-app/src/server/deployment/__tests__/workspaceComposition.test.ts
+++ b/apps/full-app/src/server/deployment/__tests__/workspaceComposition.test.ts
@@ -13,6 +13,7 @@ import path from 'node:path'
 import { beforeAll, describe, expect, it } from 'vitest'
 
 import { D1HostErrorCode, parseD1HostPlan } from '../d1Plan.js'
+import { canonicalizeD1WorkspaceAllocation } from '../d1RootDesiredResolver.js'
 import {
   createFullAppServerPluginComposition,
   FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR,
@@ -156,6 +157,15 @@ describe('createWorkspaceCompositionSnapshot', () => {
       .toBe(FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR.version)
     expect(JSON.parse(readFileSync(path.join(repoRoot, 'plugins/boring-automation/package.json'), 'utf8')).version)
       .toBe(FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS[0].version)
+  })
+
+  it('independently pins live composition bytes to the exact allocation revision', async () => {
+    const binding = parsedResolverBinding('insurance:eu'); const identity = await createWorkspaceCompositionSnapshot(input(binding.workspaceId))
+    const allocation = { schemaVersion: 1, domain: 'boring-d1-workspace-allocation:v1', hostId: 'eu-host-1', bindingId: binding.bindingId,
+      workspaceAllocationRef: binding.workspaceAllocationRef, composition: { snapshot: identity.snapshot, workspaceCompositionDigest: identity.digest } }
+    await expect(canonicalizeD1WorkspaceAllocation(allocation, 'eu-host-1', binding)).resolves.toEqual(identity)
+    await expect(canonicalizeD1WorkspaceAllocation({ ...allocation, workspaceAllocationRef: 'stale' }, 'eu-host-1', binding)).rejects.toThrow()
+    await expect(canonicalizeD1WorkspaceAllocation({ ...allocation, composition: { ...allocation.composition, workspaceCompositionDigest: hashes.app } }, 'eu-host-1', binding)).rejects.toThrow()
   })
 
   it('is order-stable, deeply frozen, canonical, and redacted', async () => {

--- a/apps/full-app/src/server/deployment/composeAdapter.ts
+++ b/apps/full-app/src/server/deployment/composeAdapter.ts
@@ -22,8 +22,9 @@ const COMPOSE_FILE = `${COMPOSE_DIRECTORY}/compose.yml`
 const PROJECT_NAME = 'boring-d1'
 const STATE_ROOT = '/var/lib/boring/d1'
 const MATERIALIZED_ROOT = '/run/boring/d1'
+const CONTROL_ROOT = '/run/boring/d1-control'
 
-export type D1ComposeEffect = 'initial' | 'no-compose' | 'restart-core'
+export type D1ComposeEffect = 'initial' | 'start-ingress' | 'no-compose' | 'restart-core'
 
 export interface D1ComposeImagesV1 {
   readonly schemaVersion: 1
@@ -69,6 +70,7 @@ function process(args: readonly string[], plan: D1HostPlanV1, images: D1ComposeI
       D1_INGRESS_IMAGE: images.ingressImage,
       D1_MATERIALIZED_HOST_ROOT: `${MATERIALIZED_ROOT}/${plan.hostId}`,
       D1_STATE_ROOT: `${STATE_ROOT}/${plan.hostId}`,
+      D1_CONTROL_ROOT: CONTROL_ROOT,
     }),
     shell: false,
   })
@@ -80,8 +82,9 @@ export function renderD1ComposeCommands(effect: D1ComposeEffect, rawPlan: unknow
   const base = ['compose', '--file', COMPOSE_FILE, '--project-directory', COMPOSE_DIRECTORY, '--project-name', PROJECT_NAME]
   if (effect === 'initial') return Object.freeze([
     process([...base, 'run', '--rm', '--no-deps', 'core-app', 'node', 'apps/full-app/dist/server/migrate.js'], plan, images),
-    process([...base, 'up', '-d'], plan, images),
+    process([...base, 'up', '-d', '--no-deps', 'core-app'], plan, images),
   ])
+  if (effect === 'start-ingress') return Object.freeze([process([...base, 'up', '-d', '--no-deps', 'ingress'], plan, images)])
   if (effect === 'restart-core') {
     return Object.freeze([process([...base, 'up', '-d', '--no-deps', 'core-app'], plan, images)])
   }

--- a/apps/full-app/src/server/deployment/d1AgentArtifactSnapshot.ts
+++ b/apps/full-app/src/server/deployment/d1AgentArtifactSnapshot.ts
@@ -12,7 +12,7 @@ import {
 } from '@hachej/boring-agent/shared'
 import { resolveAgentDeployment } from '@hachej/boring-agent/server'
 
-import { assertD1ExactKeys, D1HostError, D1HostErrorCode, strictD1HostId, strictD1Ref, type D1SiteBindingV1 } from './d1Plan.js'
+import { assertD1ExactKeys, d1Digest, D1HostError, D1HostErrorCode, strictD1HostId, strictD1Ref, type D1SiteBindingV1 } from './d1Plan.js'
 import { openD1SecureDirectory, openD1SecureRoot, readD1SecureFile } from './d1FileRuntimeInputsProvider.js'
 import type { D1ResolvedBindingV1 } from './d1RevisionCodec.js'
 
@@ -26,6 +26,8 @@ export interface D1AgentArtifactEnvelopeV1 {
   readonly bindingId: string
   readonly bundleRef: string
   readonly deploymentRef: string
+  readonly workspaceAllocationRef: string
+  readonly workspaceCompositionDigest: Sha256Digest
   readonly bundle: CompiledAgentBundle
   readonly deployment: AgentDeployment
 }
@@ -48,10 +50,11 @@ function failed(field = 'agentArtifacts'): D1HostError {
 /** Internal revision-store parser; callers should use the fixed inbox/revision readers. */
 export function canonicalizeD1AgentArtifactEnvelope(raw: unknown, hostId: string, binding: D1SiteBindingV1): D1AgentArtifactEnvelopeV1 {
   if (binding.bindingId.length > 250) throw failed()
-  assertD1ExactKeys(raw, ['schemaVersion', 'domain', 'hostId', 'bindingId', 'bundleRef', 'deploymentRef', 'bundle', 'deployment'], 'agentArtifacts')
+  assertD1ExactKeys(raw, ['schemaVersion', 'domain', 'hostId', 'bindingId', 'bundleRef', 'deploymentRef', 'workspaceAllocationRef', 'workspaceCompositionDigest', 'bundle', 'deployment'], 'agentArtifacts')
   if (raw.schemaVersion !== 1 || raw.domain !== DOMAIN || strictD1HostId(raw.hostId, 'hostId') !== hostId
     || strictD1Ref(raw.bindingId, 'bindingId') !== binding.bindingId || strictD1Ref(raw.bundleRef, 'bundleRef') !== binding.bundleRef
-    || strictD1Ref(raw.deploymentRef, 'deploymentRef') !== binding.deploymentRef) throw failed()
+    || strictD1Ref(raw.deploymentRef, 'deploymentRef') !== binding.deploymentRef
+    || strictD1Ref(raw.workspaceAllocationRef, 'workspaceAllocationRef') !== binding.workspaceAllocationRef) throw failed()
   assertD1ExactKeys(raw.bundle, ['definition', 'definitionDigest', 'assets'], 'agentArtifacts.bundle')
   const definition = validateAgentDefinition(raw.bundle.definition)
   const deployment = validateAgentDeployment(raw.deployment)
@@ -64,11 +67,13 @@ export function canonicalizeD1AgentArtifactEnvelope(raw: unknown, hostId: string
       .map(({ path, digest, content }) => Object.freeze({ path, digest, content })).sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0)),
   })
   return Object.freeze({ schemaVersion: 1, domain: DOMAIN, hostId, bindingId: binding.bindingId, bundleRef: binding.bundleRef,
-    deploymentRef: binding.deploymentRef, bundle, deployment: Object.freeze(deployment.value) })
+    deploymentRef: binding.deploymentRef, workspaceAllocationRef: binding.workspaceAllocationRef,
+    workspaceCompositionDigest: d1Digest(raw.workspaceCompositionDigest, 'workspaceCompositionDigest'), bundle, deployment: Object.freeze(deployment.value) })
 }
 
 export async function validateD1AgentArtifact(envelope: D1AgentArtifactEnvelopeV1, binding: D1SiteBindingV1,
   expected: D1ResolvedBindingV1): Promise<void> {
+  if (envelope.workspaceAllocationRef !== binding.workspaceAllocationRef || envelope.workspaceCompositionDigest !== expected.composition.digest) throw failed()
   const resolved = await resolveAgentDeployment(envelope.bundle, envelope.deployment, { workspaceId: binding.workspaceId,
     defaultDeploymentId: binding.defaultDeploymentId, workspaceCompositionDigest: expected.composition.digest })
   if (JSON.stringify({ workspace: resolved.workspace, deployment: resolved.deployment, definition: resolved.definition, resolvedDigest: resolved.resolvedDigest })
@@ -107,6 +112,7 @@ export async function loadD1AgentArtifactInputs(options: {
         total += bytes.byteLength
         if (total > options.limits.maxTotalBundleBytes) throw failed()
         const envelope = canonicalizeD1AgentArtifactEnvelope(JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown, hostId, input.binding)
+        if (envelope.workspaceCompositionDigest !== input.compositionDigest) throw failed()
         await resolveAgentDeployment(envelope.bundle, envelope.deployment, { workspaceId: input.binding.workspaceId,
           defaultDeploymentId: input.binding.defaultDeploymentId, workspaceCompositionDigest: input.compositionDigest })
         loaded.push(Object.freeze({ envelope }))

--- a/apps/full-app/src/server/deployment/d1CommandEntry.ts
+++ b/apps/full-app/src/server/deployment/d1CommandEntry.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { closeSync, constants, fstatSync, lstatSync, openSync, realpathSync, statfsSync, type Stats } from 'node:fs'
 import os from 'node:os'
@@ -14,12 +14,15 @@ import {
   type D1AdmissionLedger,
 } from './admissionLedger.js'
 import { createD1CommandEngine, type D1CommandEngineOptions, type D1MutationGuard } from './d1Command.js'
+import { runD1ComposeAction, type D1ComposeProcess } from './composeAdapter.js'
 import { parseD1CliInput } from './d1CommandCliProtocol.js'
 import { isSupportedLocalD1LockFilesystem } from './d1CommandLockPolicy.js'
 import { createD1DestructivePublicationJournalStore } from './destructivePublicationJournal.js'
 import { createD1FileRuntimeInputsProvider } from './d1FileRuntimeInputsProvider.js'
 import { createD1FencedDestructivePublication } from './fencedDestructivePublication.js'
 import { D1HostError, D1HostErrorCode } from './d1Plan.js'
+import { createD1RootPublicationClient } from './d1PublicationControl.js'
+import { createD1RootDesiredResolver } from './d1RootDesiredResolver.js'
 import { createD1BindingSecretMaterializer, createD1RuntimeInputsInspector } from './d1SecretMaterializer.js'
 import { createHostRevisionStore } from './hostRevisionStore.js'
 import { loadD1AgentArtifactInputs } from './d1AgentArtifactSnapshot.js'
@@ -95,16 +98,33 @@ function assertInheritedLock(lockRoot: string, hostId: string, uid: number): voi
   if (acquired.error || acquired.status !== 0) invalid('hostLock')
 }
 function unavailable(field: string): never { throw new D1HostError(D1HostErrorCode.COLLECTION_NOT_READY, { field }) }
+function composeImages() {
+  const ingressImage = process.env.D1_INGRESS_IMAGE; const coreAppImage = process.env.D1_CORE_APP_IMAGE
+  if (!ingressImage || !coreAppImage) invalid('composeImages')
+  return Object.freeze({ schemaVersion: 1 as const, ingressImage, coreAppImage })
+}
+const runComposeProcess = (value: D1ComposeProcess) => new Promise<{ exitCode: number; stdout: string; stderr: string }>((resolve, reject) => {
+  const child = spawn(value.command, value.args, { cwd: value.cwd, env: { ...process.env, ...value.env }, shell: false, stdio: ['ignore', 'pipe', 'pipe'] })
+  let stdout = ''; let stderr = ''; child.stdout.setEncoding('utf8'); child.stderr.setEncoding('utf8')
+  child.stdout.on('data', (chunk: string) => { if ((stdout += chunk).length > 1024 * 1024) child.kill() })
+  child.stderr.on('data', (chunk: string) => { if ((stderr += chunk).length > 1024 * 1024) child.kill() })
+  child.once('error', reject); child.once('close', (code) => resolve({ exitCode: code ?? 70, stdout, stderr }))
+})
 
 export const createProductionD1Dependencies: D1DependencyFactory = ({ hostId, ownerUid, stateRoot, collectionLimits, mutationGuard, admissionLedger }) => {
   const provider = createD1FileRuntimeInputsProvider({ hostId, ownerUid })
-  const store = createHostRevisionStore({ root: stateRoot, ownerUid, appGid: D1_APP_GID })
+  const store = createHostRevisionStore({ root: stateRoot, ownerUid, appGid: D1_APP_GID }); const invocationId = randomUUID()
+  const publication = createD1RootPublicationClient({ hostId, hostRoot: path.join(stateRoot, hostId), ownerUid, appGid: D1_APP_GID,
+    operationId: invocationId, revisionStore: store,
+    startCore: (candidate) => runD1ComposeAction('initial', { ...candidate.desired.plan, expectedHostRevision: null }, composeImages(), runComposeProcess),
+    startIngress: (candidate) => runD1ComposeAction('start-ingress', { ...candidate.desired.plan, expectedHostRevision: null }, composeImages(), runComposeProcess),
+  })
   const fencedPublication = admissionLedger
-    ? createD1FencedDestructivePublication({ admissionLedger, journalStore: createD1DestructivePublicationJournalStore(), revisionStore: store })
+    ? createD1FencedDestructivePublication({ admissionLedger, journalStore: createD1DestructivePublicationJournalStore(), revisionStore: store, publicationControl: publication })
     : undefined
   return {
     store,
-    resolver: { resolvePlan: async () => unavailable('resolver'), reproduce: async () => unavailable('resolver') },
+    resolver: createD1RootDesiredResolver({ hostId, ownerUid, limits: collectionLimits, revisionStore: store }),
     effects: {
       loadAgentArtifacts: (desired) => loadD1AgentArtifactInputs({
         hostId, ownerUid, limits: collectionLimits,
@@ -119,13 +139,13 @@ export const createProductionD1Dependencies: D1DependencyFactory = ({ hostId, ow
         ? (requestedHostId, databaseRef) => admissionLedger.listBindingIds(requestedHostId, databaseRef)
         : async () => unavailable('admissions'),
       materialize: createD1BindingSecretMaterializer({ root: '/run/boring/d1', ownerUid, appUid: D1_APP_UID, appGid: D1_APP_GID, provider }),
-      preload: async () => unavailable('preload'),
-      verifyActive: async () => unavailable('active'),
+      preload: publication.preload,
+      verifyActive: publication.verifyActive,
     },
     inspectRuntimeInputs: createD1RuntimeInputsInspector(provider),
     mutationGuard,
     ...(fencedPublication ? { fencedPublication } : {}),
-    operator: { uid: ownerUid, effectiveUser: os.userInfo().username, invocationId: randomUUID() },
+    operator: { uid: ownerUid, effectiveUser: os.userInfo().username, invocationId },
     clock: () => new Date().toISOString(),
   }
 }

--- a/apps/full-app/src/server/deployment/d1ProductionAuthority.ts
+++ b/apps/full-app/src/server/deployment/d1ProductionAuthority.ts
@@ -48,7 +48,7 @@ export function createD1ProductionAuthority(options: {
   const readPending = options.dependencies?.readPending ?? (() => readD1PendingPublication({
     root: options.pendingRoot ?? path.join(options.stateRoot ?? STATE_ROOT, hostId), ownerUid: options.ownerUid, appGid,
   }))
-  let target: D1StoredCandidateV1 | undefined; let controlTail: Promise<unknown> = Promise.resolve()
+  let target: D1StoredCandidateV1 | undefined; let discardedOperation: string | undefined; let controlTail: Promise<unknown> = Promise.resolve()
   const serialized = <T>(operation: () => Promise<T>): Promise<T> => {
     const result = controlTail.then(operation, operation); controlTail = result.then(() => undefined, () => undefined); return result
   }
@@ -108,6 +108,8 @@ export function createD1ProductionAuthority(options: {
       const prepared = await preloader.prepare(input)
       return Object.freeze({ recipe: prepared.recipe, dispose: prepared.dispose })
     },
+    commitRollback: async (_authorization, commit) => commit(),
+    retireRemoved: async ({ removals }) => { for (const removal of removals) await removal.dispose() },
   })
   const same = (revision: string | null, digest: string | null, actual = servedCollection.snapshot()) =>
     (actual?.revisionId ?? null) === revision && (actual?.desiredStateDigest ?? null) === digest
@@ -159,8 +161,16 @@ export function createD1ProductionAuthority(options: {
     commit: (operationId: string) => serialized(async () => {
       const pending = await pendingFor(operationId); const durable = await store.readActive()
       if (!durable || durable.revisionId !== pending.targetRevision || durable.desiredStateDigest !== pending.targetDigest) failed()
-      if (!same(pending.targetRevision, pending.targetDigest)) await servedCollection.serve(durable)
+      if (!same(pending.targetRevision, pending.targetDigest)) await servedCollection.serve(durable,
+        pending.rollback ? { kind: 'rollback', authorization: pending.rollback } : undefined)
       return status(pending)
+    }),
+    discard: (operationId: string) => serialized(async () => {
+      const pending = await pendingFor(operationId)
+      if (!same(pending.expectedRevision, pending.expectedDigest)) failed()
+      if (discardedOperation === operationId) return status(pending)
+      await servedCollection.discardPrepared({ schemaVersion: 1, revisionId: pending.targetRevision, desiredStateDigest: pending.targetDigest })
+      discardedOperation = operationId; return status(pending)
     }),
     status: () => serialized(async () => status(await readPending())),
     recover: () => serialized(async () => {

--- a/apps/full-app/src/server/deployment/d1PublicationControl.ts
+++ b/apps/full-app/src/server/deployment/d1PublicationControl.ts
@@ -1,9 +1,16 @@
+import { randomUUID } from 'node:crypto'
 import { constants, type Stats } from 'node:fs'
-import { chmod, lstat, open, realpath, unlink } from 'node:fs/promises'
-import { createServer, type Server, type Socket } from 'node:net'
+import { chmod, lstat, mkdir, open, realpath, rename, unlink } from 'node:fs/promises'
+import { createConnection, createServer, type Server, type Socket } from 'node:net'
 import path from 'node:path'
 
 import type { Sha256Digest } from '@hachej/boring-agent/shared'
+
+import type { D1ApplyEffects } from './d1Command.js'
+import { canonicalizeD1Observation, type D1ActiveEnvelopeV1 } from './d1RevisionCodec.js'
+import type { D1RuntimeInputsIdentityV1 } from './d1RuntimeInputs.js'
+import { normalizeD1DestructivePublicationIdentity, type D1DestructivePublicationIdentity } from './destructivePublicationJournal.js'
+import type { D1HostRevisionStore, D1StoredCandidateV1 } from './hostRevisionStore.js'
 
 import { assertD1ExactKeys, d1Digest, D1HostError, D1HostErrorCode, strictD1Ref } from './d1Plan.js'
 
@@ -22,6 +29,8 @@ export interface D1PendingPublicationV1 {
   readonly targetRevision: string
   readonly targetDigest: Sha256Digest
   readonly runtimeInputs: readonly unknown[]
+  readonly rollback: D1DestructivePublicationIdentity | null
+  readonly state: 'prepared' | 'committed'
 }
 export interface D1PublicationStatusV1 {
   readonly durableRevision: string | null
@@ -31,6 +40,7 @@ export interface D1PublicationStatusV1 {
 export interface D1PublicationControlAuthority {
   prepare(operationId: string): Promise<D1PublicationStatusV1>
   commit(operationId: string): Promise<D1PublicationStatusV1>
+  discard(operationId: string): Promise<D1PublicationStatusV1>
   status(operationId?: string): Promise<D1PublicationStatusV1>
 }
 
@@ -41,14 +51,16 @@ function revision(value: unknown, field: string): string {
 }
 export function parseD1PendingPublication(raw: unknown): D1PendingPublicationV1 {
   try {
-    assertD1ExactKeys(raw, ['schemaVersion', 'operationId', 'expectedRevision', 'expectedDigest', 'targetRevision', 'targetDigest', 'runtimeInputs'], 'pending')
-    if (raw.schemaVersion !== 1 || (raw.expectedRevision === null) !== (raw.expectedDigest === null)
+    assertD1ExactKeys(raw, ['schemaVersion', 'operationId', 'expectedRevision', 'expectedDigest', 'targetRevision', 'targetDigest', 'runtimeInputs', 'rollback', 'state'], 'pending')
+    if (raw.schemaVersion !== 1 || raw.state !== 'prepared' && raw.state !== 'committed' || (raw.expectedRevision === null) !== (raw.expectedDigest === null)
       || !Array.isArray(raw.runtimeInputs) || raw.runtimeInputs.length > 20) failed('pending')
+    const rollback = raw.rollback
     return Object.freeze({ schemaVersion: 1, operationId: strictD1Ref(raw.operationId, 'operationId'),
       expectedRevision: raw.expectedRevision === null ? null : revision(raw.expectedRevision, 'expectedRevision'),
       expectedDigest: raw.expectedDigest === null ? null : d1Digest(raw.expectedDigest, 'expectedDigest'),
       targetRevision: revision(raw.targetRevision, 'targetRevision'), targetDigest: d1Digest(raw.targetDigest, 'targetDigest'),
-      runtimeInputs: Object.freeze(structuredClone(raw.runtimeInputs)) })
+      runtimeInputs: Object.freeze(structuredClone(raw.runtimeInputs)),
+      rollback: rollback === null ? null : normalizeD1DestructivePublicationIdentity(rollback as D1DestructivePublicationIdentity), state: raw.state })
   } catch { failed('pending') }
 }
 function exact(info: Stats, uid: number, gid: number, mode: number): boolean {
@@ -72,14 +84,14 @@ export async function readD1PendingPublication(options: {
   } catch (error) { if (error instanceof D1HostError) throw error; return failed('pending') }
   finally { await handle?.close() }
 }
-function request(raw: unknown): Readonly<{ action: 'prepare' | 'commit' | 'status'; operationId?: string }> {
+function request(raw: unknown): Readonly<{ action: 'prepare' | 'commit' | 'discard' | 'status'; operationId?: string }> {
   try {
     if (typeof raw !== 'object' || raw === null) failed('request')
     const action = (raw as { action?: unknown }).action
     if (action === 'status') {
       assertD1ExactKeys(raw, ['action'], 'request'); return Object.freeze({ action })
     }
-    if (action !== 'prepare' && action !== 'commit') failed('request')
+    if (action !== 'prepare' && action !== 'commit' && action !== 'discard') failed('request')
     assertD1ExactKeys(raw, ['action', 'operationId'], 'request')
     return Object.freeze({ action, operationId: strictD1Ref((raw as { operationId?: unknown }).operationId, 'operationId') })
   } catch { failed('request') }
@@ -98,7 +110,8 @@ function serveSocket(socket: Socket, authority: D1PublicationControlAuthority): 
       try {
         const value = request(JSON.parse(frame.slice(0, -1)) as unknown)
         const status = value.action === 'prepare' ? await authority.prepare(value.operationId!)
-          : value.action === 'commit' ? await authority.commit(value.operationId!) : await authority.status()
+          : value.action === 'commit' ? await authority.commit(value.operationId!)
+            : value.action === 'discard' ? await authority.discard(value.operationId!) : await authority.status()
         socket.end(`${JSON.stringify({ ok: true, status })}\n`)
       } catch { socket.end(`${JSON.stringify({ ok: false, error: { code: D1HostErrorCode.PUBLICATION_FAILED, details: { field: 'request' } } })}\n`) }
     })()
@@ -120,4 +133,122 @@ export async function startD1PublicationControlServer(authority: D1PublicationCo
   await new Promise<void>((resolve, reject) => { server.once('error', reject); server.listen(socketPath, resolve) })
   try { await chmod(socketPath, 0o660); server.unref(); return server }
   catch (error) { server.close(); throw error }
+}
+
+export interface D1RootPublicationClient extends Pick<D1ApplyEffects, 'preload' | 'verifyActive'> {
+  status(): Promise<D1PublicationStatusV1>
+  commit(operationId: string, target: D1ActiveEnvelopeV1): Promise<void>
+  discard(operationId: string): Promise<void>
+  recover(): Promise<void>
+}
+function exactStatus(raw: unknown): D1PublicationStatusV1 {
+  try {
+    assertD1ExactKeys(raw, ['durableRevision', 'servedRevision', 'pendingOperation'], 'status')
+    const value = (item: unknown, field: string) => item === null ? null : revision(item, field)
+    return Object.freeze({ durableRevision: value(raw.durableRevision, 'durableRevision'), servedRevision: value(raw.servedRevision, 'servedRevision'),
+      pendingOperation: raw.pendingOperation === null ? null : strictD1Ref(raw.pendingOperation, 'pendingOperation') })
+  } catch { failed('status') }
+}
+export function createD1RootPublicationClient(options: {
+  readonly hostId: string; readonly hostRoot: string; readonly ownerUid: number; readonly appGid: number; readonly operationId: string
+  readonly revisionStore: D1HostRevisionStore; readonly controlRoot?: string; readonly socketPath?: string; readonly timeoutMs?: number
+  readonly startCore?: (candidate: D1StoredCandidateV1) => Promise<void>; readonly startIngress?: (candidate: D1StoredCandidateV1) => Promise<void>
+}): D1RootPublicationClient {
+  let pending: D1PendingPublicationV1 | undefined; let candidate: D1StoredCandidateV1 | undefined
+  const controlRoot = options.controlRoot ?? D1_CONTROL_ROOT
+  const ensureControlRoot = async () => {
+    await mkdir(controlRoot, { mode: 0o730 }).catch((error) => { if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error })
+    const handle = await open(controlRoot, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW)
+    try {
+      const info = await handle.stat(); if (!info.isDirectory() || await realpath(`/proc/self/fd/${handle.fd}`) !== controlRoot) failed('controlRoot')
+      await handle.chown(options.ownerUid, options.appGid); await handle.chmod(0o730); await handle.sync()
+      if (!exact(await handle.stat(), options.ownerUid, options.appGid, 0o730)) failed('controlRoot')
+    } finally { await handle.close() }
+  }
+  const call = async (action: 'prepare' | 'commit' | 'discard' | 'status', operationId?: string) => new Promise<D1PublicationStatusV1>((resolve, reject) => {
+    const socket = createConnection(options.socketPath ?? path.join(controlRoot, D1_PUBLICATION_SOCKET_FILE)); let output = ''; let size = 0; let settled = false
+    const failCall = () => { if (!settled) { settled = true; reject(new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'response' })) } }
+    socket.setTimeout(options.timeoutMs ?? 5_000, () => socket.destroy()); socket.setEncoding('utf8')
+    socket.on('connect', () => socket.end(`${JSON.stringify(operationId ? { action, operationId } : { action })}\n`))
+    socket.on('data', (chunk: string) => { size += Buffer.byteLength(chunk); if (size > 2048) socket.destroy(); else output += chunk })
+    socket.on('error', failCall); socket.on('close', failCall); socket.on('end', () => {
+      if (settled) return
+      try {
+        if (!output.endsWith('\n') || output.slice(0, -1).includes('\n')) return failCall()
+        const raw = JSON.parse(output) as { ok?: unknown; status?: unknown }
+        if (raw.ok !== true || Object.keys(raw).sort().join(',') !== 'ok,status') return failCall()
+        const status = exactStatus(raw.status); settled = true; resolve(status)
+      } catch { failCall() }
+    })
+  })
+  const syncRoot = async () => { const root = await open(options.hostRoot, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW); try { await root.sync() } finally { await root.close() } }
+  const install = async (value: D1PendingPublicationV1) => {
+    const stage = path.join(options.hostRoot, `.pending.${randomUUID()}`); const target = path.join(options.hostRoot, D1_PENDING_PUBLICATION_FILE)
+    const handle = await open(stage, constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW, 0o600)
+    try { await handle.writeFile(JSON.stringify(value)); await handle.chown(options.ownerUid, options.appGid); await handle.chmod(0o440); await handle.sync() }
+    finally { await handle.close() }
+    await rename(stage, target); await syncRoot()
+  }
+  const requireStatus = (status: D1PublicationStatusV1, durable: string | null, served: string | null, operationId: string) => {
+    if (status.durableRevision !== durable || status.servedRevision !== served || status.pendingOperation !== operationId) failed('status')
+  }
+  const commit = async (operationId: string, target: D1ActiveEnvelopeV1) => requireStatus(await call('commit', operationId), target.revisionId, target.revisionId, operationId)
+  const discard = async (operationId: string) => {
+    const value = await readD1PendingPublication({ root: options.hostRoot, ownerUid: options.ownerUid, appGid: options.appGid }); if (!value) return
+    if (value.operationId !== operationId) failed('pending')
+    requireStatus(await call('discard', operationId), value.expectedRevision, value.expectedRevision, operationId)
+    await unlink(path.join(options.hostRoot, D1_PENDING_PUBLICATION_FILE)); await syncRoot()
+  }
+  return Object.freeze({
+    async preload(value: D1StoredCandidateV1, runtimeInputs: readonly D1RuntimeInputsIdentityV1[]) {
+      candidate = value; const active = await options.revisionStore.readActive(options.hostId)
+      const prior = active ? await options.revisionStore.readComplete(options.hostId, active.revisionId) : null
+      if (active && (!prior || prior.desiredStateDigest !== active.desiredStateDigest)) failed('active')
+      const nextIds = new Set(value.desired.plan.bindings.map((binding) => binding.bindingId))
+      const removals = prior?.desired.plan.bindings.map((binding) => binding.bindingId).filter((bindingId) => !nextIds.has(bindingId)).sort() ?? []
+      const rollback = active && removals.length > 0 ? normalizeD1DestructivePublicationIdentity({ operationId: options.operationId, hostId: options.hostId,
+        expectedRevision: active.revisionId, expectedDigest: active.desiredStateDigest, targetRevision: value.revisionId,
+        targetDigest: value.desiredStateDigest, removalBindingIds: removals }) : null
+      pending = parseD1PendingPublication({ schemaVersion: 1, operationId: options.operationId, expectedRevision: active?.revisionId ?? null,
+        expectedDigest: active?.desiredStateDigest ?? null, targetRevision: value.revisionId, targetDigest: value.desiredStateDigest,
+        runtimeInputs, rollback, state: 'prepared' })
+      await ensureControlRoot(); await install(pending); if (!active) await options.startCore?.(value)
+      requireStatus(await call('prepare', pending.operationId), active?.revisionId ?? null, active?.revisionId ?? null, pending.operationId)
+      return canonicalizeD1Observation({ schemaVersion: 1, domain: 'boring-d1-observed:v1', bindings: value.desired.resolvedBindings.map((binding) => ({
+        bindingId: binding.bindingId, ready: true, resolvedDigest: binding.resolvedDigest,
+        runtimeInputs: runtimeInputs.find((input) => input.bindingId === binding.bindingId),
+      })) }, value.desired)
+    },
+    async verifyActive(active: D1ActiveEnvelopeV1) {
+      if (!pending || !candidate || pending.targetRevision !== active.revisionId) failed('pending')
+      await commit(pending.operationId, active); pending = parseD1PendingPublication({ ...pending, state: 'committed' }); await install(pending)
+      if (pending.expectedRevision === null) await options.startIngress?.(candidate)
+      await unlink(path.join(options.hostRoot, D1_PENDING_PUBLICATION_FILE)); await syncRoot(); pending = undefined; candidate = undefined
+    },
+    status: () => call('status'), commit, discard,
+    async recover() {
+      const value = await readD1PendingPublication({ root: options.hostRoot, ownerUid: options.ownerUid, appGid: options.appGid }); if (!value) return
+      let status: D1PublicationStatusV1
+      try { status = await call('status') } catch (error) {
+        if (value.expectedRevision !== null) throw error
+        const staged = await options.revisionStore.readCandidate(options.hostId, value.targetRevision)
+        if (!staged || staged.desiredStateDigest !== value.targetDigest) throw error
+        await ensureControlRoot(); await options.startCore?.(staged); status = await call('status')
+      }
+      if (status.pendingOperation !== value.operationId) failed('status')
+      if (value.rollback && status.durableRevision === value.expectedRevision && status.servedRevision === value.expectedRevision) return discard(value.operationId)
+      if (value.rollback && status.durableRevision === value.expectedRevision) failed('status')
+      const complete = await options.revisionStore.readComplete(options.hostId, value.targetRevision)
+      if (status.durableRevision === value.expectedRevision && status.servedRevision === value.expectedRevision && !complete) return discard(value.operationId)
+      if (!complete || complete.desiredStateDigest !== value.targetDigest) failed('status')
+      if (status.durableRevision === value.expectedRevision && status.servedRevision === value.expectedRevision) {
+        const active = await options.revisionStore.publishActive(options.hostId, value.targetRevision); await commit(value.operationId, active)
+      } else if (status.durableRevision === value.targetRevision && status.servedRevision === value.expectedRevision) {
+        await commit(value.operationId, { schemaVersion: 1, revisionId: value.targetRevision, desiredStateDigest: value.targetDigest })
+      } else if (status.durableRevision !== value.targetRevision || status.servedRevision !== value.targetRevision) failed('status')
+      const committed = value.state === 'committed' ? value : parseD1PendingPublication({ ...value, state: 'committed' }); if (committed !== value) await install(committed)
+      if (value.expectedRevision === null && complete) await options.startIngress?.(complete)
+      await unlink(path.join(options.hostRoot, D1_PENDING_PUBLICATION_FILE)); await syncRoot()
+    },
+  })
 }

--- a/apps/full-app/src/server/deployment/d1PublicationControl.ts
+++ b/apps/full-app/src/server/deployment/d1PublicationControl.ts
@@ -3,6 +3,7 @@ import { constants, type Stats } from 'node:fs'
 import { chmod, lstat, mkdir, open, realpath, rename, unlink } from 'node:fs/promises'
 import { createConnection, createServer, type Server, type Socket } from 'node:net'
 import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
 
 import type { Sha256Digest } from '@hachej/boring-agent/shared'
 
@@ -151,7 +152,7 @@ function exactStatus(raw: unknown): D1PublicationStatusV1 {
 }
 export function createD1RootPublicationClient(options: {
   readonly hostId: string; readonly hostRoot: string; readonly ownerUid: number; readonly appGid: number; readonly operationId: string
-  readonly revisionStore: D1HostRevisionStore; readonly controlRoot?: string; readonly socketPath?: string; readonly timeoutMs?: number
+  readonly revisionStore: D1HostRevisionStore; readonly controlRoot?: string; readonly socketPath?: string; readonly timeoutMs?: number; readonly startupTimeoutMs?: number
   readonly startCore?: (candidate: D1StoredCandidateV1) => Promise<void>; readonly startIngress?: (candidate: D1StoredCandidateV1) => Promise<void>
 }): D1RootPublicationClient {
   let pending: D1PendingPublicationV1 | undefined; let candidate: D1StoredCandidateV1 | undefined
@@ -167,11 +168,11 @@ export function createD1RootPublicationClient(options: {
   }
   const call = async (action: 'prepare' | 'commit' | 'discard' | 'status', operationId?: string) => new Promise<D1PublicationStatusV1>((resolve, reject) => {
     const socket = createConnection(options.socketPath ?? path.join(controlRoot, D1_PUBLICATION_SOCKET_FILE)); let output = ''; let size = 0; let settled = false
-    const failCall = () => { if (!settled) { settled = true; reject(new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'response' })) } }
+    const failCall = (error?: Error) => { if (!settled) { settled = true; reject(error ?? new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'response' })) } }
     socket.setTimeout(options.timeoutMs ?? 5_000, () => socket.destroy()); socket.setEncoding('utf8')
     socket.on('connect', () => socket.end(`${JSON.stringify(operationId ? { action, operationId } : { action })}\n`))
     socket.on('data', (chunk: string) => { size += Buffer.byteLength(chunk); if (size > 2048) socket.destroy(); else output += chunk })
-    socket.on('error', failCall); socket.on('close', failCall); socket.on('end', () => {
+    socket.on('error', (error: NodeJS.ErrnoException) => failCall(error.code === 'ENOENT' || error.code === 'ECONNREFUSED' ? error : undefined)); socket.on('close', () => failCall()); socket.on('end', () => {
       if (settled) return
       try {
         if (!output.endsWith('\n') || output.slice(0, -1).includes('\n')) return failCall()
@@ -181,6 +182,14 @@ export function createD1RootPublicationClient(options: {
       } catch { failCall() }
     })
   })
+  const callWhenStarted = async (action: 'prepare' | 'status', operationId?: string) => {
+    const deadline = Date.now() + (options.startupTimeoutMs ?? 10_000)
+    for (;;) { try { return await call(action, operationId) } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if ((code !== 'ENOENT' && code !== 'ECONNREFUSED') || Date.now() >= deadline) throw error
+      await delay(50)
+    } }
+  }
   const syncRoot = async () => { const root = await open(options.hostRoot, constants.O_RDONLY | constants.O_DIRECTORY | constants.O_NOFOLLOW); try { await root.sync() } finally { await root.close() } }
   const install = async (value: D1PendingPublicationV1) => {
     const stage = path.join(options.hostRoot, `.pending.${randomUUID()}`); const target = path.join(options.hostRoot, D1_PENDING_PUBLICATION_FILE)
@@ -213,7 +222,7 @@ export function createD1RootPublicationClient(options: {
         expectedDigest: active?.desiredStateDigest ?? null, targetRevision: value.revisionId, targetDigest: value.desiredStateDigest,
         runtimeInputs, rollback, state: 'prepared' })
       await ensureControlRoot(); await install(pending); if (!active) await options.startCore?.(value)
-      requireStatus(await call('prepare', pending.operationId), active?.revisionId ?? null, active?.revisionId ?? null, pending.operationId)
+      requireStatus(await callWhenStarted('prepare', pending.operationId), active?.revisionId ?? null, active?.revisionId ?? null, pending.operationId)
       return canonicalizeD1Observation({ schemaVersion: 1, domain: 'boring-d1-observed:v1', bindings: value.desired.resolvedBindings.map((binding) => ({
         bindingId: binding.bindingId, ready: true, resolvedDigest: binding.resolvedDigest,
         runtimeInputs: runtimeInputs.find((input) => input.bindingId === binding.bindingId),
@@ -230,10 +239,11 @@ export function createD1RootPublicationClient(options: {
       const value = await readD1PendingPublication({ root: options.hostRoot, ownerUid: options.ownerUid, appGid: options.appGid }); if (!value) return
       let status: D1PublicationStatusV1
       try { status = await call('status') } catch (error) {
-        if (value.expectedRevision !== null) throw error
+        const code = (error as NodeJS.ErrnoException).code
+        if (value.expectedRevision !== null || code !== 'ENOENT' && code !== 'ECONNREFUSED') throw error
         const staged = await options.revisionStore.readCandidate(options.hostId, value.targetRevision)
         if (!staged || staged.desiredStateDigest !== value.targetDigest) throw error
-        await ensureControlRoot(); await options.startCore?.(staged); status = await call('status')
+        await ensureControlRoot(); await options.startCore?.(staged); status = await callWhenStarted('status')
       }
       if (status.pendingOperation !== value.operationId) failed('status')
       if (value.rollback && status.durableRevision === value.expectedRevision && status.servedRevision === value.expectedRevision) return discard(value.operationId)

--- a/apps/full-app/src/server/deployment/d1RootDesiredResolver.ts
+++ b/apps/full-app/src/server/deployment/d1RootDesiredResolver.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+
+import { validateD1AgentArtifact } from './d1AgentArtifactSnapshot.js'
+import { loadD1AgentArtifactInputs } from './d1AgentArtifactSnapshot.js'
+import type { D1CollectionLimits } from './bootCollection.js'
+import type { D1DesiredResolver } from './d1Command.js'
+import { D1HostError, D1HostErrorCode, type D1HostPlanV1 } from './d1Plan.js'
+import { openD1SecureRoot, readD1SecureFile } from './d1FileRuntimeInputsProvider.js'
+import { canonicalizeD1DesiredSnapshot, type D1DesiredSnapshotV1 } from './d1RevisionCodec.js'
+import type { D1HostRevisionStore, D1StoredCompleteV1 } from './hostRevisionStore.js'
+
+export const D1_RESOLVED_INPUT_ROOT = '/etc/boring/d1/resolved-hosts'
+function failed(): never { throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'resolver' }) }
+function persisted(plan: D1HostPlanV1) { const { expectedHostRevision: _expected, ...value } = plan; return value }
+function same(left: unknown, right: unknown): boolean { return JSON.stringify(left) === JSON.stringify(right) }
+
+export function createD1RootDesiredResolver(options: {
+  readonly hostId: string; readonly ownerUid: number; readonly limits: D1CollectionLimits; readonly root?: string
+  readonly revisionStore: Pick<D1HostRevisionStore, 'readAgentArtifact'>
+}): D1DesiredResolver {
+  const validate = async (desired: D1DesiredSnapshotV1, storedRevision?: string) => {
+    const artifacts = storedRevision ? await Promise.all(desired.plan.bindings.map(async (binding) => {
+      const envelope = await options.revisionStore.readAgentArtifact(options.hostId, storedRevision, binding.bindingId); if (!envelope) failed(); return { envelope }
+    })) : await loadD1AgentArtifactInputs({ hostId: options.hostId, ownerUid: options.ownerUid, limits: options.limits,
+      inputs: desired.plan.bindings.map((binding, index) => ({ binding, compositionDigest: desired.resolvedBindings[index]!.composition.digest })) })
+    if (artifacts.length !== desired.plan.bindings.length) failed()
+    await Promise.all(artifacts.map(({ envelope }, index) => validateD1AgentArtifact(envelope, desired.plan.bindings[index]!, desired.resolvedBindings[index]!)))
+    return desired
+  }
+  const load = async () => {
+    let root
+    try {
+      root = await openD1SecureRoot(options.root ?? D1_RESOLVED_INPUT_ROOT, { uid: options.ownerUid, gid: process.getegid!() }, false)
+      const bytes = await readD1SecureFile(path.join(root.path, `${options.hostId}.json`), root, { uid: options.ownerUid, gid: process.getegid!() }, 4 * 1024 * 1024)
+      try { return await canonicalizeD1DesiredSnapshot(JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown) }
+      finally { bytes.fill(0) }
+    } catch { failed() } finally { await root?.handle.close() }
+  }
+  return Object.freeze({
+    async resolvePlan(plan: D1HostPlanV1) { const desired = await load(); if (!same(desired.plan, persisted(plan))) failed(); return validate(desired) },
+    async reproduce(target: D1StoredCompleteV1) { return validate(await canonicalizeD1DesiredSnapshot(target.desired), target.revisionId) },
+  })
+}

--- a/apps/full-app/src/server/deployment/d1RootDesiredResolver.ts
+++ b/apps/full-app/src/server/deployment/d1RootDesiredResolver.ts
@@ -1,18 +1,30 @@
+import { createHash } from 'node:crypto'
 import path from 'node:path'
 
-import { validateD1AgentArtifact } from './d1AgentArtifactSnapshot.js'
-import { loadD1AgentArtifactInputs } from './d1AgentArtifactSnapshot.js'
+import { createAgentAssetDigest } from '@hachej/boring-agent/shared'
+import { resolveAgentDeployment } from '@hachej/boring-agent/server'
+
+import { loadD1AgentArtifactInputs, validateD1AgentArtifact } from './d1AgentArtifactSnapshot.js'
 import type { D1CollectionLimits } from './bootCollection.js'
 import type { D1DesiredResolver } from './d1Command.js'
-import { D1HostError, D1HostErrorCode, type D1HostPlanV1 } from './d1Plan.js'
+import { D1HostError, D1HostErrorCode, assertD1ExactKeys, strictD1HostId, strictD1Ref, type D1HostPlanV1, type D1SiteBindingV1 } from './d1Plan.js'
 import { openD1SecureRoot, readD1SecureFile } from './d1FileRuntimeInputsProvider.js'
-import { canonicalizeD1DesiredSnapshot, type D1DesiredSnapshotV1 } from './d1RevisionCodec.js'
+import { createD1DesiredSnapshot, type D1DesiredSnapshotV1, type D1ResolvedBindingV1 } from './d1RevisionCodec.js'
+import { canonicalizeWorkspaceCompositionSnapshot } from './workspaceComposition.js'
 import type { D1HostRevisionStore, D1StoredCompleteV1 } from './hostRevisionStore.js'
 
-export const D1_RESOLVED_INPUT_ROOT = '/etc/boring/d1/resolved-hosts'
+export const D1_ALLOCATION_INPUT_ROOT = '/etc/boring/d1/workspace-allocations'
+export const d1AllocationFileName = (hostId: string, bindingId: string) => `${createHash('sha256').update(`${hostId}\0${bindingId}`).digest('hex')}.json`
 function failed(): never { throw new D1HostError(D1HostErrorCode.PUBLICATION_FAILED, { field: 'resolver' }) }
-function persisted(plan: D1HostPlanV1) { const { expectedHostRevision: _expected, ...value } = plan; return value }
-function same(left: unknown, right: unknown): boolean { return JSON.stringify(left) === JSON.stringify(right) }
+export async function canonicalizeD1WorkspaceAllocation(raw: unknown, hostId: string, binding: D1SiteBindingV1, index = 0): Promise<D1ResolvedBindingV1['composition']> {
+  assertD1ExactKeys(raw, ['schemaVersion', 'domain', 'hostId', 'bindingId', 'workspaceAllocationRef', 'composition'], `allocations[${index}]`)
+  if (raw.schemaVersion !== 1 || raw.domain !== 'boring-d1-workspace-allocation:v1' || strictD1HostId(raw.hostId, 'hostId') !== hostId
+    || strictD1Ref(raw.bindingId, 'bindingId') !== binding.bindingId || strictD1Ref(raw.workspaceAllocationRef, 'workspaceAllocationRef') !== binding.workspaceAllocationRef) failed()
+  assertD1ExactKeys(raw.composition, ['snapshot', 'workspaceCompositionDigest'], `allocations[${index}].composition`)
+  const snapshot = canonicalizeWorkspaceCompositionSnapshot(raw.composition.snapshot); const digest = await createAgentAssetDigest(JSON.stringify(snapshot))
+  if (raw.composition.workspaceCompositionDigest !== digest || snapshot.workspaceId !== binding.workspaceId) failed()
+  return Object.freeze({ snapshot, digest })
+}
 
 export function createD1RootDesiredResolver(options: {
   readonly hostId: string; readonly ownerUid: number; readonly limits: D1CollectionLimits; readonly root?: string
@@ -23,21 +35,33 @@ export function createD1RootDesiredResolver(options: {
       const envelope = await options.revisionStore.readAgentArtifact(options.hostId, storedRevision, binding.bindingId); if (!envelope) failed(); return { envelope }
     })) : await loadD1AgentArtifactInputs({ hostId: options.hostId, ownerUid: options.ownerUid, limits: options.limits,
       inputs: desired.plan.bindings.map((binding, index) => ({ binding, compositionDigest: desired.resolvedBindings[index]!.composition.digest })) })
-    if (artifacts.length !== desired.plan.bindings.length) failed()
     await Promise.all(artifacts.map(({ envelope }, index) => validateD1AgentArtifact(envelope, desired.plan.bindings[index]!, desired.resolvedBindings[index]!)))
     return desired
   }
-  const load = async () => {
+  const resolve = async (plan: D1HostPlanV1) => {
     let root
     try {
-      root = await openD1SecureRoot(options.root ?? D1_RESOLVED_INPUT_ROOT, { uid: options.ownerUid, gid: process.getegid!() }, false)
-      const bytes = await readD1SecureFile(path.join(root.path, `${options.hostId}.json`), root, { uid: options.ownerUid, gid: process.getegid!() }, 4 * 1024 * 1024)
-      try { return await canonicalizeD1DesiredSnapshot(JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)) as unknown) }
-      finally { bytes.fill(0) }
+      root = await openD1SecureRoot(options.root ?? D1_ALLOCATION_INPUT_ROOT, { uid: options.ownerUid, gid: process.getegid!() }, false)
+      const allocations = await Promise.all(plan.bindings.map(async (binding, index): Promise<{ composition: D1ResolvedBindingV1['composition'] }> => {
+        const bytes = await readD1SecureFile(path.join(root!.path, d1AllocationFileName(options.hostId, binding.bindingId)), root!,
+          { uid: options.ownerUid, gid: process.getegid!() }, 1024 * 1024)
+        try {
+          return { composition: await canonicalizeD1WorkspaceAllocation(JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(bytes)), options.hostId, binding, index) }
+        } finally { bytes.fill(0) }
+      }))
+      const artifacts = await loadD1AgentArtifactInputs({ hostId: options.hostId, ownerUid: options.ownerUid, limits: options.limits,
+        inputs: plan.bindings.map((binding, index) => ({ binding, compositionDigest: allocations[index]!.composition.digest })) })
+      const resolved = await Promise.all(artifacts.map(async ({ envelope }, index) => {
+        const binding = plan.bindings[index]!; const composition = allocations[index]!.composition
+        const value = await resolveAgentDeployment(envelope.bundle, envelope.deployment, { workspaceId: binding.workspaceId,
+          defaultDeploymentId: binding.defaultDeploymentId, workspaceCompositionDigest: composition.digest })
+        return Object.freeze({ schemaVersion: 1 as const, bindingId: binding.bindingId, composition, workspace: value.workspace,
+          deployment: value.deployment, definition: value.definition, resolvedDigest: value.resolvedDigest })
+      }))
+      return createD1DesiredSnapshot(plan, resolved)
     } catch { failed() } finally { await root?.handle.close() }
   }
-  return Object.freeze({
-    async resolvePlan(plan: D1HostPlanV1) { const desired = await load(); if (!same(desired.plan, persisted(plan))) failed(); return validate(desired) },
-    async reproduce(target: D1StoredCompleteV1) { return validate(await canonicalizeD1DesiredSnapshot(target.desired), target.revisionId) },
-  })
+  return Object.freeze({ resolvePlan: resolve, async reproduce(target: D1StoredCompleteV1) {
+    return validate(await createD1DesiredSnapshot({ ...target.desired.plan, expectedHostRevision: null }, target.desired.resolvedBindings), target.revisionId)
+  } })
 }

--- a/apps/full-app/src/server/deployment/fencedDestructivePublication.ts
+++ b/apps/full-app/src/server/deployment/fencedDestructivePublication.ts
@@ -6,6 +6,7 @@ import {
   type D1DestructivePublicationJournalStore,
 } from './destructivePublicationJournal.js'
 import { D1HostError, D1HostErrorCode } from './d1Plan.js'
+import type { D1RootPublicationClient } from './d1PublicationControl.js'
 import {
   canonicalizeD1CompleteEnvelope,
   canonicalizeD1DesiredSnapshot,
@@ -72,6 +73,7 @@ export function createD1FencedDestructivePublication(input: {
   readonly admissionLedger: D1AdmissionLedger
   readonly journalStore: D1DestructivePublicationJournalStore
   readonly revisionStore: D1HostRevisionStore
+  readonly publicationControl?: Pick<D1RootPublicationClient, 'status' | 'commit' | 'discard' | 'recover'>
 }): D1FencedDestructivePublication {
   const validateArtifacts = async (identity: D1DestructivePublicationIdentity, invalid: (field: string) => D1HostError) => {
     const [expected, target] = await Promise.all([
@@ -122,6 +124,11 @@ export function createD1FencedDestructivePublication(input: {
       `
     } catch { throw new D1HostError(D1HostErrorCode.ADMISSION_RECORD_FAILED, { field: 'admission' }) }
   }
+  const requirePrepared = async (identity: D1DestructivePublicationIdentity) => {
+    const status = await input.publicationControl?.status()
+    if (status && (status.durableRevision !== identity.expectedRevision || status.servedRevision !== identity.expectedRevision
+      || status.pendingOperation !== identity.operationId)) throw failed()
+  }
   const publish = async (raw: D1DestructivePublicationIdentity): Promise<void> => {
     let identity: D1DestructivePublicationIdentity
     let journalStarted = false
@@ -145,7 +152,10 @@ export function createD1FencedDestructivePublication(input: {
             if ((await input.journalStore.readOperation(sql, identity.operationId))?.terminal) throw failed()
             await input.journalStore.appendPrepared(sql, identity)
           })
-          try { await input.revisionStore.publishActive(identity.hostId, identity.targetRevision) } catch { throw failed() }
+          await requirePrepared(identity)
+          let targetActive
+          try { targetActive = await input.revisionStore.publishActive(identity.hostId, identity.targetRevision) } catch { throw failed() }
+          try { await input.publicationControl?.commit(identity.operationId, targetActive) } catch { throw failed() }
           await transaction(sql, () => input.journalStore.appendTerminal(sql, identity, 'committed'))
         },
       )
@@ -173,19 +183,27 @@ export function createD1FencedDestructivePublication(input: {
             await validateArtifacts(identity, () => failed())
             const active = await input.revisionStore.readActive(identity.hostId).catch(() => { throw failed() })
             if (active?.revisionId === identity.targetRevision && active.desiredStateDigest === identity.targetDigest) {
+              const status = await input.publicationControl?.status()
+              if (status && (status.durableRevision !== identity.targetRevision || status.pendingOperation !== identity.operationId)) throw failed()
+              if (status?.servedRevision === identity.expectedRevision) await input.publicationControl!.commit(identity.operationId, active)
+              else if (status && status.servedRevision !== identity.targetRevision) throw failed()
               await transaction(sql, () => input.journalStore.appendTerminal(sql, identity, 'committed'))
               return
             }
             if (active?.revisionId !== identity.expectedRevision || active.desiredStateDigest !== identity.expectedDigest) throw failed()
             if ((await readAdmissions(sql, identity))[0]) {
+              await input.publicationControl?.discard(identity.operationId)
               await transaction(sql, () => input.journalStore.appendTerminal(sql, identity, 'aborted'))
               return
             }
-            await input.revisionStore.publishActive(identity.hostId, identity.targetRevision).catch(() => { throw failed() })
+            await requirePrepared(identity)
+            const target = await input.revisionStore.publishActive(identity.hostId, identity.targetRevision).catch(() => { throw failed() })
+            try { await input.publicationControl?.commit(identity.operationId, target) } catch { throw failed() }
             await transaction(sql, () => input.journalStore.appendTerminal(sql, identity, 'committed'))
           },
         )
       }
+      await input.publicationControl?.recover()
     } catch { throw failed() }
   }
   return Object.freeze({ publish, recoverPending })

--- a/apps/full-app/src/server/plugins.ts
+++ b/apps/full-app/src/server/plugins.ts
@@ -12,7 +12,7 @@ const FULL_APP_DEFAULT_PLUGIN_PACKAGE_COMPOSITION = Object.freeze([{
   packageName: '@hachej/boring-automation',
   descriptor: Object.freeze({
     id: 'boring-automation',
-    version: '0.1.85',
+    version: '0.1.86',
     contentDigest: 'sha256:d6f43891e5c9c3d40beb0eb7953b53c12b92c7595c4ed54758f468687903d9ed',
   } satisfies StableContributionDescriptor),
 }])
@@ -22,13 +22,13 @@ export const FULL_APP_DEFAULT_PLUGIN_PACKAGE_DESCRIPTORS = Object.freeze(FULL_AP
 
 export const FULL_APP_GOVERNANCE_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'full-app-governance',
-  version: '0.1.85',
+  version: '0.1.86',
   contentDigest: 'sha256:16dbe21ed64865213eb2f3b2258ab05d9e226e7865a4416e92f8010864afd313',
 } satisfies StableContributionDescriptor)
 
 export const FULL_APP_BORING_MCP_PLUGIN_DESCRIPTOR = Object.freeze({
   id: 'boring-mcp',
-  version: '0.1.85',
+  version: '0.1.86',
   contentDigest: 'sha256:ec866b7c39a657ffd860e58ad759abf5a572cbed0e532eb8a60e179bb4bf2426',
 } satisfies StableContributionDescriptor)
 

--- a/deploy/d1/compose.yml
+++ b/deploy/d1/compose.yml
@@ -53,6 +53,11 @@ services:
         read_only: true
         bind:
           create_host_path: false
+      - type: bind
+        source: "${D1_CONTROL_ROOT:?D1_CONTROL_ROOT is required}"
+        target: /run/boring/d1-control
+        bind:
+          create_host_path: false
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/health').then(r=>{if(!r.ok)throw r.status}).catch(()=>process.exit(1))"]
       interval: 30s


### PR DESCRIPTION
## Summary
- resolve root-owned desired/artifact inputs through independent P6-R validation
- atomically fsync pending publication state and drive bounded Unix prepare/commit/discard/status
- gate pointer/journal recovery and first ingress on exact served acknowledgement
- start migration/core first and ingress as an exact separate service; additive N+1 runs no Compose

## Issue / Slice
`wt-391-forward-vup.2.4.2`

## Proof
- focused non-Postgres suites: 111 passed
- isolated real-Postgres fenced publication suite: 15 passed
- final authority/control regression suite: 17 passed
- `pnpm --filter full-app typecheck` — pass
- `git diff --cached --check` — pass before commit
- net diff: +328, within <=400

## Review
Independent review found and verified fixes for destructive unjournaled recovery, exact rollback authorization, committed-before-ingress state, bounded client settlement, anchored control-root DAC, initial-core retry, and operation-bound prepared-resource discard. Final re-review: no blockers.

## Risk / Rollback
Every malformed/unrelated tuple fails closed. Destructive expected-state recovery discards rather than publishes without a D1-004e journal. Revert this PR to restore the prior unwired root command/Compose behavior.

## Next
Mandatory Fable Opus security review. **Do not arm auto-merge or merge before owner sign-off.**