### PR TITLE
feat(cli): enable workspace-scoped automations

### DIFF
--- a/docs/issues/590/todo.md
+++ b/docs/issues/590/todo.md
@@ -86,6 +86,7 @@ Canonical plan: [`plan.md`](./plan.md)
 - [x] Enable the workspace-scoped automation plugin in CLI workspaces mode.
 - [x] Add the Automations sidebar entry, composer model/effort controls, and compact editor.
 - [ ] Verify that the saved provider/model is exactly the provider/model dispatched for a manual run, and display the resolved selection in run history.
+- [ ] Make automation-created Pi sessions discoverable/loadable through the normal session list and detached-chat surface; current run `sessionId` resolves to a session facade record but Pi chat history lookup returns 404.
 - [ ] Replace separate Cron and Timezone controls with a single schedule block.
 - [ ] Add natural-language schedule input: agent proposes cron plus IANA timezone, validates it, then lets the user apply it.
 - [ ] Add Pause / Resume controls to automation cards.

--- a/docs/issues/590/todo.md
+++ b/docs/issues/590/todo.md
@@ -81,6 +81,18 @@ Canonical plan: [`plan.md`](./plan.md)
 - [x] Loading, empty, validation, and error states.
 - [x] Screenshot and component/integration proof.
 
+## CLI workspaces follow-up
+
+- [x] Enable the workspace-scoped automation plugin in CLI workspaces mode.
+- [x] Add the Automations sidebar entry, composer model/effort controls, and compact editor.
+- [ ] Verify that the saved provider/model is exactly the provider/model dispatched for a manual run, and display the resolved selection in run history.
+- [ ] Replace separate Cron and Timezone controls with a single schedule block.
+- [ ] Add natural-language schedule input: agent proposes cron plus IANA timezone, validates it, then lets the user apply it.
+- [ ] Add Pause / Resume controls to automation cards.
+- [ ] Consolidate UI and agent operations behind one workspace-scoped automation command/service contract.
+- [ ] Expose that contract as an agent tool for creation, update, pause, resume, and manual run.
+- [ ] Add end-to-end coverage for model selection, effort, pause/resume, and agent-created automations.
+
 ## Next execution/hosted slices
 
 - [x] Slice 3A: generic trusted workspace agent dispatcher.

--- a/docs/issues/590/todo.md
+++ b/docs/issues/590/todo.md
@@ -86,7 +86,7 @@ Canonical plan: [`plan.md`](./plan.md)
 - [x] Enable the workspace-scoped automation plugin in CLI workspaces mode.
 - [x] Add the Automations sidebar entry, composer model/effort controls, and compact editor.
 - [ ] Verify that the saved provider/model is exactly the provider/model dispatched for a manual run, and display the resolved selection in run history.
-- [ ] Make automation-created Pi sessions discoverable/loadable through the normal session list and detached-chat surface; current run `sessionId` resolves to a session facade record but Pi chat history lookup returns 404.
+- [x] Make automation-created Pi sessions discoverable/loadable through the normal session list and detached-chat surface.
 - [ ] Replace separate Cron and Timezone controls with a single schedule block.
 - [ ] Add natural-language schedule input: agent proposes cron plus IANA timezone, validates it, then lets the user apply it.
 - [ ] Add Pause / Resume controls to automation cards.

--- a/docs/plans/cli-workspaces-automation-plan.md
+++ b/docs/plans/cli-workspaces-automation-plan.md
@@ -1,0 +1,98 @@
+# CLI workspaces-mode automation plan
+
+## Problem Statement
+
+`@hachej/boring-automation` is shipped by `@hachej/boring-ui-cli` and works in single-folder CLI mode, but the local workspaces hub deliberately excludes it. The hub serves multiple workspace roots through one Fastify process; the automation plugin's fixed HTTP route prefix and fixed file store cannot be registered once per workspace without an explicit request-to-workspace dispatch seam.
+
+The user wants Automations available for the local `boring-ui-v2` project in the systemd-managed workspaces hub, without losing the hub or risking cross-workspace runs.
+
+## Solution
+
+Add a CLI-owned, request-scoped automation adapter for workspaces mode. It registers the automation HTTP prefix once, resolves the target local workspace using the established hub workspace-id resolver, and creates/selects that workspace's file-backed automation store and agent dispatcher. Then expose the existing automation front plugin in workspaces mode.
+
+Do not change the automation plugin's public route contract or add a background scheduler.
+
+## User Stories / Scenarios
+
+1. In the hub, selecting `boring-ui-v2` shows the Automations tab.
+2. Creating/listing prompts and automations affects only `<selected-workspace>/.pi/automation`.
+3. Manual **Run now** uses the selected workspace's agent runtime and records its resulting Pi session/run in that workspace's store.
+4. Requests with a missing, unavailable, or unknown workspace id fail before touching an automation store.
+5. The local due endpoint requires an explicit workspace selection and runs only that workspace's due automations; it never sweeps all hub workspaces.
+6. Folder mode remains behaviorally unchanged.
+
+## Decisions
+
+- Reuse `automationRoutes`, `FileAutomationStore`, and `ManualRunExecutor`; do not fork plugin route behavior into the CLI.
+- Register one hub route set with per-request store/actor/dispatcher resolution rather than mounting duplicate plugin routes per workspace.
+- Capture the existing trusted `onWorkspaceAgentDispatcher` callback from `registerAgentRoutes`; wrap it only after `requireWorkspace` has validated the request-selected workspace and use the local CLI actor for that workspace.
+- File stores live at `<workspaceRoot>/.pi/automation`, as they do in folder mode.
+- Extend the automation route seam with a request-scoped due-run resolver. Today `storeForRequest` intentionally disables `DueRunService`, because it has no request-scoped store/executor factory; a hub must create it after resolving the selected workspace.
+- Preserve the existing loopback-only guard on `POST /api/v1/boring-automation/due`; additionally require the normal hub workspace selector.
+- No autonomous timer or cross-workspace scheduler sweep. A cron caller must send the target workspace id.
+
+## Flag / Abstraction
+
+- Needed?: No runtime feature flag. The existing `workspacesMode` composition boundary is the rollout seam.
+- Path: CLI workspaces-mode automation adapter, consumed only when the hub is running.
+- Rollback: remove the automation front composition and adapter from a patch release; existing per-workspace automation files remain inert and untouched.
+
+## Test Seams
+
+- Highest public seam: `createWorkspacesModeApp` via Fastify injection with `x-boring-workspace-id`.
+- Existing prior art: folder-mode automation coverage in `packages/cli/src/__tests__/folderModeRuntimePlugins.test.ts`; request-scoped stores in `plugins/boring-automation/src/server/index.ts`.
+- Avoid testing: real provider/model execution and system cron. Stub the workspace dispatcher and assert actor/store selection.
+
+## Acceptance
+
+- Workspaces-mode plugin list includes `boring-automation` and its front target serves.
+- Automation CRUD for workspace A is absent from workspace B and is persisted under only workspace A's `.pi/automation` root.
+- A manual run resolves the dispatcher for workspace A, never B.
+- Due requests without a workspace selector fail; a loopback request for A evaluates only A.
+- Existing folder-mode automation tests remain green.
+- The CLI front no longer hides `boringAutomationPlugin` when `workspacesMode` is true.
+
+## Proof
+
+- Exact command: `pnpm --filter @hachej/boring-ui-cli test`
+- Exact command: `pnpm --filter @hachej/boring-ui-cli typecheck`
+- Screenshot/demo: hub on port 5213, select `boring-ui-v2`, verify the Automations tab; create a draft and verify `.pi/automation` exists only in that workspace.
+- Manual steps: send an authenticated/local hub request with the workspace header to list/create/run an automation, then repeat with another workspace and verify isolation.
+- Waiver: no live scheduled/provider execution is required for this slice; dispatcher behavior is exercised with a deterministic test double.
+
+## Slices
+
+### Slice: Request-scoped hub automation adapter
+
+**Delivers:** A single registered automation route surface that resolves workspace store and manual dispatcher per request, plus explicit-target due behavior.
+
+**Blocked by:** None. `registerAgentRoutes` already exposes `onWorkspaceAgentDispatcher`; the CLI hub can capture it and guard it with `requireWorkspace` before use.
+
+**Proof:** Fastify workspaces-mode integration tests cover A/B store isolation, missing-selector rejection, dispatcher selection, and due targeting.
+
+**Review budget:** Exceeds a trivial change but inside one focused PR; it changes local execution routing and needs security/spec review.
+
+### Slice: Hub front composition and release rollout
+
+**Delivers:** Automations tab visible in workspaces mode; package/release proof and systemd hub rollout after the implementation PR lands.
+
+**Blocked by:** Request-scoped adapter slice.
+
+**Proof:** CLI front composition test plus local 5213 screenshot/manual proof after release.
+
+**Review budget:** Inside a focused follow-up or may be combined with Slice 1 if the diff remains small.
+
+## Wide Refactor Strategy
+
+Not a wide mechanical refactor. Keep the adapter at the CLI hub boundary; do not migrate the automation plugin's existing folder/full-app paths.
+
+## Out of Scope
+
+- Background scheduler, all-workspace due sweep, missed-run backfill.
+- Hosted/Postgres automation changes.
+- Authentication model changes beyond existing local CLI policy.
+- Changing existing automation API paths or automation file format.
+
+## Open Questions
+
+1. Should the hub's loopback cron invoke the due route with `x-boring-workspace-id`, or should a dedicated query parameter be documented for non-browser callers? Default proposal: support the existing header/query workspace selector consistently.

--- a/docs/plans/cli-workspaces-automation-todo.md
+++ b/docs/plans/cli-workspaces-automation-todo.md
@@ -1,0 +1,21 @@
+# CLI workspace automations — follow-up TODO
+
+## Done
+
+- [x] Workspace-scoped automation routes and stores in CLI workspaces mode.
+- [x] Visible Automations sidebar entry.
+- [x] Composer model picker and effort menu in the automation editor.
+- [x] Persist and pass effort to local CLI automation runs.
+- [x] Close the editor after a successful save.
+- [x] Compact the editor popup.
+- [x] Keep the effort trigger neutral (not accent/orange).
+
+## Next
+
+- [ ] Verify saved model selection is the exact provider/model sent to each run; show the resolved model in run history.
+- [ ] Replace raw Cron + Timezone fields with one schedule block.
+- [ ] Add natural-language schedule input that asks an agent to propose cron + IANA timezone, validates the result, and lets the user apply it.
+- [ ] Add Pause / Resume directly on automation cards.
+- [ ] Consolidate UI and agent operations behind one workspace-scoped automation command/service contract.
+- [ ] Expose that contract through an agent tool so an agent can create, update, pause, resume, and run automations.
+- [ ] Add end-to-end coverage for model selection, effort, pause/resume, and agent-created automations.

--- a/packages/agent/src/front/chatPanelComposerControls.tsx
+++ b/packages/agent/src/front/chatPanelComposerControls.tsx
@@ -372,6 +372,7 @@ export function ModelSelect({
   disabled,
   trigger = 'button',
   openSignal,
+  className,
 }: {
   value: ModelSelection | null
   onChange: (next: ModelSelection | null) => void
@@ -379,6 +380,7 @@ export function ModelSelect({
   disabled?: boolean
   trigger?: SelectorTrigger
   openSignal?: unknown
+  className?: string
 }) {
   const [open, setOpen] = useState(false)
   const previousOpenSignalRef = useRef(openSignal)
@@ -402,6 +404,7 @@ export function ModelSelect({
           disabled={disabled}
           trigger={trigger}
           open={open}
+          className={className}
         />
       </PopoverTrigger>
       <PopoverContent
@@ -431,12 +434,14 @@ export function ThinkingSelect({
   disabled,
   trigger = 'button',
   openSignal,
+  className,
 }: {
   value: ThinkingLevel
   onChange: (next: ThinkingLevel) => void
   disabled?: boolean
   trigger?: SelectorTrigger
   openSignal?: unknown
+  className?: string
 }) {
   const [open, setOpen] = useState(false)
   const previousOpenSignalRef = useRef(openSignal)
@@ -460,6 +465,7 @@ export function ThinkingSelect({
           disabled={disabled}
           trigger={trigger}
           open={open}
+          className={className}
         />
       </PopoverTrigger>
       <PopoverContent

--- a/packages/agent/src/front/index.ts
+++ b/packages/agent/src/front/index.ts
@@ -19,8 +19,8 @@ export {
 } from './ArtifactOpenContext'
 export { ChatEmptyState, defaultChatSuggestions } from './ChatEmptyState'
 export type { ChatEmptyStateProps, ChatSuggestion } from './ChatEmptyState'
-export { ModelSelect, ModelPickerMenu, ModelSelectTrigger } from './chatPanelComposerControls'
-export type { AvailableModel, ModelSelection } from './chatPanelSettings'
+export { ModelSelect, ModelPickerMenu, ModelSelectTrigger, ThinkingSelect } from './chatPanelComposerControls'
+export type { AvailableModel, ModelSelection, ThinkingLevel } from './chatPanelSettings'
 export { getAgentCommands } from './commands'
 export type { AgentCommandContribution, AgentCommandOptions } from './commands'
 

--- a/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
+++ b/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
@@ -195,7 +195,7 @@ describe("workspaces mode runtime plugin wiring", () => {
 
       const listA = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${registeredA.id}` })
       const pluginsA = listA.json() as Array<{ id: string; frontTarget?: { entryUrl?: string } }>
-      expect(pluginsA.map((plugin) => plugin.id).sort()).toEqual(["ask-user", "diagram", "global-plugin", "local-a", "tasks"])
+      expect(pluginsA.map((plugin) => plugin.id).sort()).toEqual(["ask-user", "boring-automation", "diagram", "global-plugin", "local-a", "tasks"])
       for (const plugin of pluginsA) {
         expect(plugin.frontTarget?.entryUrl).toBeTruthy()
         const runtime = await app.inject({ method: "GET", url: plugin.frontTarget!.entryUrl! })
@@ -203,7 +203,21 @@ describe("workspaces mode runtime plugin wiring", () => {
       }
 
       const listB = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${registeredB.id}` })
-      expect((listB.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "diagram", "global-plugin", "local-b", "tasks"])
+      expect((listB.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "boring-automation", "diagram", "global-plugin", "local-b", "tasks"])
+
+      const automationA = await app.inject({
+        method: "POST",
+        url: "/api/v1/boring-automation/automations",
+        headers: { "x-boring-workspace-id": registeredA.id },
+        payload: { title: "Workspace A", cron: "0 0 1 1 *", timezone: "UTC", model: "openai:gpt-5" },
+      })
+      expect(automationA.statusCode).toBe(201)
+      const automationB = await app.inject({
+        method: "GET",
+        url: "/api/v1/boring-automation/automations",
+        headers: { "x-boring-workspace-id": registeredB.id },
+      })
+      expect(automationB.json()).toMatchObject({ ok: true, automations: [] })
     } finally {
       await sse.close()
       await app.close()
@@ -383,12 +397,12 @@ describe("workspaces mode runtime plugin wiring", () => {
       // workspaces. The fixture only writes `later-plugin` mid-test, so the
       // pre-reload list should contain exactly the bundled defaults.
       const before = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${workspace.id}` })
-      expect((before.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "diagram", "tasks"])
+      expect((before.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "boring-automation", "diagram", "tasks"])
 
       await writePlugin(join(workspaceRoot, ".pi", "extensions", "later-plugin"), "later-plugin")
 
       const stillBeforeReload = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${workspace.id}` })
-      expect((stillBeforeReload.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "diagram", "tasks"])
+      expect((stillBeforeReload.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "boring-automation", "diagram", "tasks"])
 
       const reload = await app.inject({
         method: "POST",
@@ -418,7 +432,7 @@ describe("workspaces mode runtime plugin wiring", () => {
     try {
       // Boot the workspace runtime with only the CLI default plugins.
       const before = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${workspace.id}` })
-      expect((before.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "diagram", "tasks"])
+      expect((before.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "boring-automation", "diagram", "tasks"])
 
       // Simulate `boring-ui-plugin install ../some-plugin`: a package source
       // dir outside .pi/extensions, registered in .pi/settings.json packages.
@@ -437,7 +451,7 @@ describe("workspaces mode runtime plugin wiring", () => {
       expect(reload.statusCode).toBe(200)
 
       const afterReload = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${workspace.id}` })
-      expect((afterReload.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "diagram", "settings-plugin", "tasks"])
+      expect((afterReload.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "boring-automation", "diagram", "settings-plugin", "tasks"]) 
     } finally {
       await app.close()
     }

--- a/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
+++ b/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
@@ -413,7 +413,7 @@ describe("workspaces mode runtime plugin wiring", () => {
       expect(reload.json()).toMatchObject({ ok: true, sessionId: expect.any(String), reloaded: expect.any(Boolean) })
 
       const afterReload = await app.inject({ method: "GET", url: `/api/v1/agent-plugins?workspaceId=${workspace.id}` })
-      expect((afterReload.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "diagram", "later-plugin", "tasks"])
+      expect((afterReload.json() as Array<{ id: string }>).map((plugin) => plugin.id).sort()).toEqual(["ask-user", "boring-automation", "diagram", "later-plugin", "tasks"])
     } finally {
       await sse.close()
       await app.close()

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -311,7 +311,7 @@ export function CliWorkspaceShell() {
   // Keep in sync with CLI_DEFAULT_PLUGIN_PACKAGES in server/pluginDiscovery.ts.
   const plugins = useMemo(() => [
     createAskUserPlugin({ appLeftInbox: true }),
-    ...(!workspacesMode ? [boringAutomationPlugin] : []),
+    boringAutomationPlugin,
     diagramPlugin,
     createTasksPlugin(),
   ], [workspacesMode])

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -1,9 +1,10 @@
-import type { FastifyInstance } from "fastify"
+import type { FastifyInstance, FastifyRequest } from "fastify"
 import type {
   BoringAgentRuntimePaths,
   ProvisionWorkspaceRuntimeOptions,
   RuntimeModeAdapter,
   RuntimeModeId,
+  WorkspaceAgentDispatcherResolver,
   WorkspaceProvisioningAdapter,
   WorkspaceProvisioningResult,
 } from "@hachej/boring-agent/server"
@@ -441,13 +442,14 @@ export async function createWorkspacesModeApp(opts: {
   registryPath?: string
   provisionWorkspace?: boolean
 }): Promise<FastifyInstance> {
-  const [workspaceAppServer, workspaceServer, agentServer, agentShared, fastifyModule, { createPluginFrontRuntimeHost }, pluginDiscovery] = await Promise.all([
+  const [workspaceAppServer, workspaceServer, agentServer, agentShared, fastifyModule, { createPluginFrontRuntimeHost }, { automationRoutes, DueRunService, FileAutomationStore, ManualRunExecutor }, pluginDiscovery] = await Promise.all([
     import("@hachej/boring-workspace/app/server"),
     import("@hachej/boring-workspace/server"),
     import("@hachej/boring-agent/server"),
     import("@hachej/boring-agent/shared"),
     import("fastify"),
     import("./pluginFrontRuntime.js"),
+    import("@hachej/boring-automation/server"),
     import("./pluginDiscovery.js"),
   ])
   const registry = createLocalWorkspaceRegistry(opts.registryPath)
@@ -503,6 +505,8 @@ export async function createWorkspacesModeApp(opts: {
   }>()
   const pluginPiSnapshots = new Map<string, CliPluginPiSnapshot>()
   const runtimeProvisioningByWorkspace = new Map<string, WorkspaceProvisioningResult | undefined>()
+  const automationStores = new Map<string, InstanceType<typeof FileAutomationStore>>()
+  let workspaceAgentDispatcher: WorkspaceAgentDispatcherResolver | undefined
 
   function getBridge(workspaceId: string) {
     let bridge = bridges.get(workspaceId)
@@ -553,6 +557,26 @@ export async function createWorkspacesModeApp(opts: {
     return await requireWorkspace(resolveWorkspaceIdFromRequest(request))
   }
 
+  function automationStore(workspace: LocalWorkspace) {
+    const key = pluginRuntimeKey(workspace)
+    let store = automationStores.get(key)
+    if (!store) {
+      store = new FileAutomationStore(join(workspace.path, ".pi", "automation"))
+      automationStores.set(key, store)
+    }
+    return store
+  }
+
+  async function automationExecutorForRequest(request: FastifyRequest) {
+    const workspace = await workspaceFromRequest(request)
+    if (!workspaceAgentDispatcher) throw httpError("workspace agent dispatcher is unavailable", 503)
+    return new ManualRunExecutor({
+      store: automationStore(workspace),
+      dispatcherResolver: workspaceAgentDispatcher,
+      actorResolver: () => ({ workspaceId: workspace.id, userId: "local" }),
+    })
+  }
+
   function pluginRuntimeKey(workspace: LocalWorkspace): string {
     return `${workspace.id}:${workspace.path}`
   }
@@ -568,6 +592,7 @@ export async function createWorkspacesModeApp(opts: {
     if (!runtime) {
       const manager = pluginDiscovery.createCliPluginAssetManager(workspace.path, {
         frontTargetResolver: runtimeHost.createFrontTargetResolver(workspace.id),
+        includeFolderModeAutomation: true,
       })
       const backendRegistry = new workspaceServer.RuntimeBackendRegistry()
       runtime = {
@@ -618,6 +643,7 @@ export async function createWorkspacesModeApp(opts: {
     pluginRuntimes.delete(runtimeKey)
     pluginPiSnapshots.delete(runtimeKey)
     runtimeProvisioningByWorkspace.delete(workspace.id)
+    automationStores.delete(runtimeKey)
     workspaceBridgeCores.delete(workspace.id)
     bridges.delete(workspace.id)
     diagnosticsStore.disposeWorkspace(workspace.id)
@@ -714,7 +740,7 @@ export async function createWorkspacesModeApp(opts: {
       // install), but the manager's dirs were resolved once when this
       // workspace runtime was created. Without this, newly installed plugin
       // sources stay invisible until a full process restart.
-      runtime.manager.setPluginDirs(pluginDiscovery.resolveCliBoringPluginDirs(workspace.path))
+      runtime.manager.setPluginDirs(pluginDiscovery.resolveCliBoringPluginDirs(workspace.path, { includeFolderModeAutomation: true }))
       const scan = await runtime.manager.load()
       syncLoadedPluginPiSnapshot(workspace, runtime.manager)
       syncRuntimeHostFromPluginEvents(runtimeHost, workspaceId, scan.events)
@@ -768,12 +794,28 @@ export async function createWorkspacesModeApp(opts: {
         getHotReloadableResources: () => getLoadedPluginPiSnapshot(workspace),
       }
     },
+    onWorkspaceAgentDispatcher: (resolver) => {
+      workspaceAgentDispatcher = resolver
+    },
     getExtraTools: async ({ workspaceId, workspaceRoot, workspaceFsCapability }) => [
       ...workspaceServer.createWorkspaceUiTools(getBridge(workspaceId), {
         workspaceRoot: workspaceFsCapability === "strong" ? workspaceRoot : undefined,
       }),
       ...(await getWorkspaceBridgeCore(await requireWorkspace(workspaceId))).extraTools,
     ],
+  })
+
+  await automationRoutes(app, {
+    store: new FileAutomationStore(join(process.cwd(), ".pi", "automation-unused")),
+    storeForRequest: async (request) => automationStore(await workspaceFromRequest(request)),
+    manualRunExecutorForRequest: automationExecutorForRequest,
+    dueRunServiceForRequest: async (request) => {
+      const workspace = await workspaceFromRequest(request)
+      return new DueRunService({
+        store: automationStore(workspace),
+        executor: await automationExecutorForRequest(request),
+      })
+    },
   })
 
   await app.register(workspaceServer.uiRoutes, {

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -454,6 +454,12 @@ export async function createWorkspacesModeApp(opts: {
   ])
   const registry = createLocalWorkspaceRegistry(opts.registryPath)
   const app = fastifyModule.default({ logger: false, bodyLimit: 16 * 1024 * 1024 })
+  // CLI workspaces mode has one trusted local actor. Pi chat routes use this
+  // identity to read the same scoped session records created by automation runs.
+  app.addHook("onRequest", async (request) => {
+    const localRequest = request as FastifyRequest & { user?: { id: string } }
+    localRequest.user ??= { id: "local" }
+  })
   const diagnosticsStore = createRuntimePluginDiagnosticsStore()
   const runtimeHost = await createPluginFrontRuntimeHost({
     onDiagnostic: (diagnostic) => diagnosticsStore.record(diagnostic),

--- a/plugins/boring-automation/package.json
+++ b/plugins/boring-automation/package.json
@@ -53,6 +53,7 @@
     "react-dom": "^18.0.0 || ^19.0.0"
   },
   "dependencies": {
+    "@hachej/boring-agent": "workspace:*",
     "@hachej/boring-ui-kit": "workspace:*",
     "croner": "^10.0.1",
     "lucide-react": "^1.21.0",

--- a/plugins/boring-automation/src/front/AutomationForm.tsx
+++ b/plugins/boring-automation/src/front/AutomationForm.tsx
@@ -162,6 +162,7 @@ export function AutomationForm({
           <ModelSelect
             value={parseModel(draft.model)}
             options={availableModels}
+            className="w-full max-w-none justify-between"
             onChange={(model) => setDraft((current) => ({ ...current, model: model ? `${model.provider}:${model.id}` : "" }))}
           />
           <FieldDescription id="automation-model-description">Uses the same available-model picker as the composer.</FieldDescription>
@@ -172,6 +173,7 @@ export function AutomationForm({
           <FieldLabel>Effort</FieldLabel>
           <ThinkingSelect
             value={draft.thinkingLevel}
+            className="w-full justify-between"
             onChange={(thinkingLevel) => setDraft((current) => ({ ...current, thinkingLevel }))}
           />
           <FieldDescription>Uses the same reasoning-effort menu as the composer.</FieldDescription>

--- a/plugins/boring-automation/src/front/AutomationForm.tsx
+++ b/plugins/boring-automation/src/front/AutomationForm.tsx
@@ -143,7 +143,7 @@ export function AutomationForm({
   }
 
   return (
-    <form className="space-y-4" onSubmit={submit} noValidate aria-label={`${mode === "create" ? "Create" : "Edit"} automation form`}>
+    <form className="space-y-3" onSubmit={submit} noValidate aria-label={`${mode === "create" ? "Create" : "Edit"} automation form`}>
       <div className="grid gap-3 md:grid-cols-2">
         <Field>
           <FieldLabel htmlFor="automation-title">Title</FieldLabel>
@@ -221,12 +221,12 @@ export function AutomationForm({
           id="automation-prompt"
           value={draft.prompt}
           onChange={(event) => setDraft((current) => ({ ...current, prompt: event.target.value }))}
-          rows={12}
+          rows={6}
           spellCheck={false}
-          className="min-h-64 resize-y font-mono text-[13px] leading-5"
+          className="min-h-36 resize-y font-mono text-[13px] leading-5"
           aria-describedby="automation-prompt-description"
         />
-        <FieldDescription id="automation-prompt-description">Saved through the canonical prompt route; local CLI mode writes the Markdown prompt file.</FieldDescription>
+        <FieldDescription id="automation-prompt-description">Saved to the workspace prompt file.</FieldDescription>
       </Field>
 
       <div className="flex flex-wrap justify-end gap-2">

--- a/plugins/boring-automation/src/front/AutomationForm.tsx
+++ b/plugins/boring-automation/src/front/AutomationForm.tsx
@@ -173,7 +173,7 @@ export function AutomationForm({
           <FieldLabel>Effort</FieldLabel>
           <ThinkingSelect
             value={draft.thinkingLevel}
-            className="w-full justify-between"
+            className="w-full justify-between border-border/60 bg-transparent text-muted-foreground"
             onChange={(thinkingLevel) => setDraft((current) => ({ ...current, thinkingLevel }))}
           />
           <FieldDescription>Uses the same reasoning-effort menu as the composer.</FieldDescription>

--- a/plugins/boring-automation/src/front/AutomationForm.tsx
+++ b/plugins/boring-automation/src/front/AutomationForm.tsx
@@ -143,7 +143,7 @@ export function AutomationForm({
   }
 
   return (
-    <form className="space-y-3" onSubmit={submit} noValidate aria-label={`${mode === "create" ? "Create" : "Edit"} automation form`}>
+    <form className="space-y-4" onSubmit={submit} noValidate aria-label={`${mode === "create" ? "Create" : "Edit"} automation form`}>
       <div className="grid gap-3 md:grid-cols-2">
         <Field>
           <FieldLabel htmlFor="automation-title">Title</FieldLabel>
@@ -162,7 +162,6 @@ export function AutomationForm({
           <ModelSelect
             value={parseModel(draft.model)}
             options={availableModels}
-            className="w-full max-w-none justify-between"
             onChange={(model) => setDraft((current) => ({ ...current, model: model ? `${model.provider}:${model.id}` : "" }))}
           />
           <FieldDescription id="automation-model-description">Uses the same available-model picker as the composer.</FieldDescription>
@@ -173,7 +172,6 @@ export function AutomationForm({
           <FieldLabel>Effort</FieldLabel>
           <ThinkingSelect
             value={draft.thinkingLevel}
-            className="w-full justify-between border-border/60 bg-transparent text-muted-foreground"
             onChange={(thinkingLevel) => setDraft((current) => ({ ...current, thinkingLevel }))}
           />
           <FieldDescription>Uses the same reasoning-effort menu as the composer.</FieldDescription>
@@ -221,12 +219,12 @@ export function AutomationForm({
           id="automation-prompt"
           value={draft.prompt}
           onChange={(event) => setDraft((current) => ({ ...current, prompt: event.target.value }))}
-          rows={6}
+          rows={12}
           spellCheck={false}
-          className="min-h-36 resize-y font-mono text-[13px] leading-5"
+          className="min-h-64 resize-y font-mono text-[13px] leading-5"
           aria-describedby="automation-prompt-description"
         />
-        <FieldDescription id="automation-prompt-description">Saved to the workspace prompt file.</FieldDescription>
+        <FieldDescription id="automation-prompt-description">Saved through the canonical prompt route; local CLI mode writes the Markdown prompt file.</FieldDescription>
       </Field>
 
       <div className="flex flex-wrap justify-end gap-2">

--- a/plugins/boring-automation/src/front/AutomationForm.tsx
+++ b/plugins/boring-automation/src/front/AutomationForm.tsx
@@ -1,8 +1,10 @@
 "use client"
 
+import { ModelSelect, ThinkingSelect, type AvailableModel, type ModelSelection, type ThinkingLevel } from "@hachej/boring-agent/front"
 import { useEffect, useMemo, useState, type FormEvent } from "react"
 import { Button, Checkbox, Field, FieldDescription, FieldError, FieldLabel, Input, Textarea } from "@hachej/boring-ui-kit"
 import { validateAutomationSchedule, type Automation, type AutomationCreate, type AutomationPatch } from "../shared"
+import { useAutomationRuntime } from "./AutomationRuntimeContext"
 
 export interface AutomationDraft {
   title: string
@@ -10,6 +12,7 @@ export interface AutomationDraft {
   cron: string
   timezone: string
   model: string
+  thinkingLevel: ThinkingLevel
   prompt: string
 }
 
@@ -21,6 +24,7 @@ const DEFAULT_DRAFT: AutomationDraft = {
   cron: "0 9 * * *",
   timezone: "UTC",
   model: "",
+  thinkingLevel: "medium",
   prompt: "",
 }
 
@@ -31,6 +35,7 @@ export function draftFromAutomation(automation: Automation, prompt: string): Aut
     cron: automation.cron,
     timezone: automation.timezone,
     model: automation.model,
+    thinkingLevel: automation.thinkingLevel ?? "medium",
     prompt,
   }
 }
@@ -63,6 +68,7 @@ export function toAutomationCreate(draft: AutomationDraft): AutomationCreate {
     cron: draft.cron.trim(),
     timezone: draft.timezone.trim(),
     model: draft.model.trim(),
+    thinkingLevel: draft.thinkingLevel,
     prompt: draft.prompt,
   }
 }
@@ -74,7 +80,29 @@ export function toAutomationPatch(draft: AutomationDraft): AutomationPatch {
     cron: draft.cron.trim(),
     timezone: draft.timezone.trim(),
     model: draft.model.trim(),
+    thinkingLevel: draft.thinkingLevel,
   }
+}
+
+function parseModel(model: string): ModelSelection | null {
+  const separator = model.indexOf(":")
+  return separator > 0 && separator < model.length - 1
+    ? { provider: model.slice(0, separator), id: model.slice(separator + 1) }
+    : null
+}
+
+function useAutomationModels(): AvailableModel[] {
+  const { apiBaseUrl, authHeaders } = useAutomationRuntime()
+  const [models, setModels] = useState<AvailableModel[]>([])
+  useEffect(() => {
+    let cancelled = false
+    void fetch(`${apiBaseUrl.replace(/\/$/, "")}/api/v1/agent/models`, { headers: authHeaders })
+      .then((response) => response.ok ? response.json() : null)
+      .then((payload: { models?: AvailableModel[] } | null) => { if (!cancelled) setModels(payload?.models ?? []) })
+      .catch(() => { if (!cancelled) setModels([]) })
+    return () => { cancelled = true }
+  }, [apiBaseUrl, authHeaders])
+  return models
 }
 
 export function AutomationForm({
@@ -94,6 +122,7 @@ export function AutomationForm({
 }) {
   const [draft, setDraft] = useState<AutomationDraft>(() => automation ? draftFromAutomation(automation, prompt) : emptyAutomationDraft())
   const [submitted, setSubmitted] = useState(false)
+  const availableModels = useAutomationModels()
 
   useEffect(() => {
     setDraft(automation ? draftFromAutomation(automation, prompt) : emptyAutomationDraft())
@@ -129,17 +158,23 @@ export function AutomationForm({
         </Field>
 
         <Field>
-          <FieldLabel htmlFor="automation-model">Model</FieldLabel>
-          <Input
-            id="automation-model"
-            value={draft.model}
-            placeholder="provider:model-id"
-            onChange={(event) => setDraft((current) => ({ ...current, model: event.target.value }))}
-            aria-invalid={submitted && !!errors.model}
-            aria-describedby={modelDescriptionIds}
+          <FieldLabel>Model</FieldLabel>
+          <ModelSelect
+            value={parseModel(draft.model)}
+            options={availableModels}
+            onChange={(model) => setDraft((current) => ({ ...current, model: model ? `${model.provider}:${model.id}` : "" }))}
           />
-          <FieldDescription id="automation-model-description">Explicit provider and model ID, for example anthropic:claude-sonnet-4-5.</FieldDescription>
+          <FieldDescription id="automation-model-description">Uses the same available-model picker as the composer.</FieldDescription>
           {submitted && errors.model ? <FieldError id="automation-model-error">{errors.model}</FieldError> : null}
+        </Field>
+
+        <Field>
+          <FieldLabel>Effort</FieldLabel>
+          <ThinkingSelect
+            value={draft.thinkingLevel}
+            onChange={(thinkingLevel) => setDraft((current) => ({ ...current, thinkingLevel }))}
+          />
+          <FieldDescription>Uses the same reasoning-effort menu as the composer.</FieldDescription>
         </Field>
 
         <Field>

--- a/plugins/boring-automation/src/front/AutomationPanel.tsx
+++ b/plugins/boring-automation/src/front/AutomationPanel.tsx
@@ -325,10 +325,10 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
           {shellError ? <Notice tone="destructive" className="mb-3" role="alert">{shellError}</Notice> : null}
           {saveNotice ? <Notice tone={saveNotice.tone} className="mb-3" role="status">{saveNotice.message}</Notice> : null}
           <Dialog modal={false} open={editor.mode !== "closed"} onOpenChange={(open) => { if (!open) setEditor({ mode: "closed" }) }}>
-            <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+            <DialogContent className="max-h-[82vh] max-w-xl overflow-y-auto">
               <DialogHeader>
                 <DialogTitle>{editor.mode === "create" ? "New automation" : "Edit automation"}</DialogTitle>
-                <DialogDescription>Define the schedule, model, effort, and canonical Markdown prompt.</DialogDescription>
+                <DialogDescription>Schedule a prompt with its model and effort.</DialogDescription>
               </DialogHeader>
               <div aria-label="Automation editor">
             {editor.mode === "closed" ? (
@@ -339,24 +339,12 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
                 </div>
               </div>
             ) : editor.mode === "create" ? (
-              <>
-                <div className="mb-4">
-                  <h3 className="font-semibold text-foreground">New automation</h3>
-                  <p className="mt-1 text-xs text-muted-foreground">Define the schedule and canonical Markdown prompt.</p>
-                </div>
-                <AutomationForm mode="create" prompt="" saving={saving} onCancel={() => setEditor({ mode: "closed" })} onSubmit={(draft) => void saveDraft(draft)} />
-              </>
+              <AutomationForm mode="create" prompt="" saving={saving} onCancel={() => setEditor({ mode: "closed" })} onSubmit={(draft) => void saveDraft(draft)} />
             ) : selectedAutomation ? (
               editorLoading ? (
                 <div className="flex min-h-80 items-center justify-center gap-2 text-muted-foreground"><Spinner className="size-4" /> Loading prompt…</div>
               ) : (
-                <>
-                  <div className="mb-4">
-                    <h3 className="font-semibold text-foreground">Edit automation</h3>
-                    <p className="mt-1 text-xs text-muted-foreground">{selectedAutomation.id}</p>
-                  </div>
-                  <AutomationForm automation={selectedAutomation} mode="edit" prompt={editorPrompt} saving={saving} onCancel={() => setEditor({ mode: "closed" })} onSubmit={(draft) => void saveDraft(draft)} />
-                </>
+                <AutomationForm automation={selectedAutomation} mode="edit" prompt={editorPrompt} saving={saving} onCancel={() => setEditor({ mode: "closed" })} onSubmit={(draft) => void saveDraft(draft)} />
               )
             ) : (
               <Notice tone="destructive">Automation not found.</Notice>

--- a/plugins/boring-automation/src/front/AutomationPanel.tsx
+++ b/plugins/boring-automation/src/front/AutomationPanel.tsx
@@ -249,7 +249,7 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
 
   function openRun(run: AutomationRun) {
     if (!run.sessionId) return
-    const result = shell.openDetachedChat(run.sessionId, { title: run.modelSnapshot || "Automation run" })
+    const result = shell.openDetachedChat(run.sessionId, { title: run.modelSnapshot || "Automation run", composingEnabled: true })
     setShellError(result.success ? null : result.message)
   }
 

--- a/plugins/boring-automation/src/front/AutomationPanel.tsx
+++ b/plugins/boring-automation/src/front/AutomationPanel.tsx
@@ -172,7 +172,7 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
         setAutomations((current) => [created, ...current])
         setDetails((current) => patchDetail(current, created.id, { prompt: draft.prompt, promptLoading: false, runs: [], runsLoading: false }))
         setExpandedId(created.id)
-        setEditor({ mode: "edit", automationId: created.id })
+        setEditor({ mode: "closed" })
         setSaveNotice({ tone: "success", message: "Automation created." })
         return
       }
@@ -185,6 +185,7 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
         try {
           const updated = await client.updateAutomation(automationId, toAutomationPatch(draft))
           setAutomations((current) => current.map((automation) => automation.id === updated.id ? updated : automation))
+          setEditor({ mode: "closed" })
           setSaveNotice({ tone: "success", message: "Automation saved." })
         } catch (metadataError) {
           try {

--- a/plugins/boring-automation/src/front/AutomationPanel.tsx
+++ b/plugins/boring-automation/src/front/AutomationPanel.tsx
@@ -1,9 +1,9 @@
 "use client"
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { CalendarClock, Plus, RefreshCw } from "lucide-react"
-import { Button, EmptyState, Notice, Spinner, type NoticeTone } from "@hachej/boring-ui-kit"
-import { useWorkspaceShellCapabilities } from "@hachej/boring-workspace/plugin"
+import { CalendarClock, Plus, RefreshCw, X } from "lucide-react"
+import { Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, EmptyState, IconButton, Notice, Spinner, type NoticeTone } from "@hachej/boring-ui-kit"
+import { useWorkspaceShellCapabilities, type PaneProps } from "@hachej/boring-workspace/plugin"
 import { BORING_AUTOMATION_PLUGIN_LABEL, type Automation, type AutomationRun } from "../shared"
 import { AutomationCard } from "./AutomationCard"
 import { AutomationForm, emptyAutomationDraft, toAutomationCreate, toAutomationPatch, type AutomationDraft } from "./AutomationForm"
@@ -57,7 +57,9 @@ function isCurrentGeneration(generations: { current: Record<string, number> }, a
   return !signal?.aborted && generations.current[automationId] === generation
 }
 
-export function AutomationPanel() {
+export function AutomationPanel(props: { onClose?: () => void }): React.JSX.Element
+export function AutomationPanel(props: PaneProps & { onClose?: () => void }): React.JSX.Element
+export function AutomationPanel({ onClose }: { onClose?: () => void }) {
   const client = useAutomationClient()
   const shell = useWorkspaceShellCapabilities()
   const [automations, setAutomations] = useState<Automation[]>([])
@@ -274,11 +276,12 @@ export function AutomationPanel() {
             <Plus className="size-4" aria-hidden="true" />
             New
           </Button>
+          {onClose ? <IconButton type="button" variant="ghost" size="icon-xs" onClick={onClose} aria-label="Close automations" title="Close"><X className="size-3" /></IconButton> : null}
         </div>
       </header>
 
       <div className="min-h-0 flex-1 overflow-y-auto bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)]">
-        <div className="mx-auto grid w-full max-w-6xl gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(360px,440px)]">
+        <div className="mx-auto w-full max-w-6xl p-4">
           <section className="min-w-0 overflow-hidden rounded-xl border border-border/70 bg-card/60" aria-label="Automation list">
             {loading ? (
               <div className="flex min-h-48 items-center justify-center gap-2 text-sm text-muted-foreground"><Spinner className="size-4" /> Loading automations…</div>
@@ -317,11 +320,16 @@ export function AutomationPanel() {
             )}
           </section>
 
-          <aside className="min-w-0 rounded-xl border border-border/70 bg-card/80 p-4" aria-label="Automation editor">
-            {routeError ? <Notice tone="destructive" className="mb-3" role="alert">{routeError}</Notice> : null}
-            {shellError ? <Notice tone="destructive" className="mb-3" role="alert">{shellError}</Notice> : null}
-            {saveNotice ? <Notice tone={saveNotice.tone} className="mb-3" role="status">{saveNotice.message}</Notice> : null}
-
+          {routeError ? <Notice tone="destructive" className="mb-3" role="alert">{routeError}</Notice> : null}
+          {shellError ? <Notice tone="destructive" className="mb-3" role="alert">{shellError}</Notice> : null}
+          {saveNotice ? <Notice tone={saveNotice.tone} className="mb-3" role="status">{saveNotice.message}</Notice> : null}
+          <Dialog modal={false} open={editor.mode !== "closed"} onOpenChange={(open) => { if (!open) setEditor({ mode: "closed" }) }}>
+            <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
+              <DialogHeader>
+                <DialogTitle>{editor.mode === "create" ? "New automation" : "Edit automation"}</DialogTitle>
+                <DialogDescription>Define the schedule, model, effort, and canonical Markdown prompt.</DialogDescription>
+              </DialogHeader>
+              <div aria-label="Automation editor">
             {editor.mode === "closed" ? (
               <div className="flex min-h-80 items-center justify-center px-4 text-center text-sm text-muted-foreground">
                 <div>
@@ -352,7 +360,9 @@ export function AutomationPanel() {
             ) : (
               <Notice tone="destructive">Automation not found.</Notice>
             )}
-          </aside>
+              </div>
+            </DialogContent>
+          </Dialog>
         </div>
       </div>
     </div>

--- a/plugins/boring-automation/src/front/AutomationPanel.tsx
+++ b/plugins/boring-automation/src/front/AutomationPanel.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { CalendarClock, Plus, RefreshCw, X } from "lucide-react"
 import { Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, EmptyState, IconButton, Notice, Spinner, type NoticeTone } from "@hachej/boring-ui-kit"
-import { useWorkspaceShellCapabilities, type PaneProps } from "@hachej/boring-workspace/plugin"
+import { useWorkspaceShellCapabilities } from "@hachej/boring-workspace/plugin"
 import { BORING_AUTOMATION_PLUGIN_LABEL, type Automation, type AutomationRun } from "../shared"
 import { AutomationCard } from "./AutomationCard"
 import { AutomationForm, emptyAutomationDraft, toAutomationCreate, toAutomationPatch, type AutomationDraft } from "./AutomationForm"
@@ -57,8 +57,6 @@ function isCurrentGeneration(generations: { current: Record<string, number> }, a
   return !signal?.aborted && generations.current[automationId] === generation
 }
 
-export function AutomationPanel(props: { onClose?: () => void }): React.JSX.Element
-export function AutomationPanel(props: PaneProps & { onClose?: () => void }): React.JSX.Element
 export function AutomationPanel({ onClose }: { onClose?: () => void }) {
   const client = useAutomationClient()
   const shell = useWorkspaceShellCapabilities()

--- a/plugins/boring-automation/src/front/AutomationPanel.tsx
+++ b/plugins/boring-automation/src/front/AutomationPanel.tsx
@@ -172,7 +172,7 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
         setAutomations((current) => [created, ...current])
         setDetails((current) => patchDetail(current, created.id, { prompt: draft.prompt, promptLoading: false, runs: [], runsLoading: false }))
         setExpandedId(created.id)
-        setEditor({ mode: "closed" })
+        setEditor({ mode: "edit", automationId: created.id })
         setSaveNotice({ tone: "success", message: "Automation created." })
         return
       }
@@ -185,7 +185,6 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
         try {
           const updated = await client.updateAutomation(automationId, toAutomationPatch(draft))
           setAutomations((current) => current.map((automation) => automation.id === updated.id ? updated : automation))
-          setEditor({ mode: "closed" })
           setSaveNotice({ tone: "success", message: "Automation saved." })
         } catch (metadataError) {
           try {
@@ -325,10 +324,10 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
           {shellError ? <Notice tone="destructive" className="mb-3" role="alert">{shellError}</Notice> : null}
           {saveNotice ? <Notice tone={saveNotice.tone} className="mb-3" role="status">{saveNotice.message}</Notice> : null}
           <Dialog modal={false} open={editor.mode !== "closed"} onOpenChange={(open) => { if (!open) setEditor({ mode: "closed" }) }}>
-            <DialogContent className="max-h-[82vh] max-w-xl overflow-y-auto">
+            <DialogContent className="max-h-[90vh] max-w-3xl overflow-y-auto">
               <DialogHeader>
                 <DialogTitle>{editor.mode === "create" ? "New automation" : "Edit automation"}</DialogTitle>
-                <DialogDescription>Schedule a prompt with its model and effort.</DialogDescription>
+                <DialogDescription>Define the schedule, model, effort, and canonical Markdown prompt.</DialogDescription>
               </DialogHeader>
               <div aria-label="Automation editor">
             {editor.mode === "closed" ? (
@@ -339,12 +338,24 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
                 </div>
               </div>
             ) : editor.mode === "create" ? (
-              <AutomationForm mode="create" prompt="" saving={saving} onCancel={() => setEditor({ mode: "closed" })} onSubmit={(draft) => void saveDraft(draft)} />
+              <>
+                <div className="mb-4">
+                  <h3 className="font-semibold text-foreground">New automation</h3>
+                  <p className="mt-1 text-xs text-muted-foreground">Define the schedule and canonical Markdown prompt.</p>
+                </div>
+                <AutomationForm mode="create" prompt="" saving={saving} onCancel={() => setEditor({ mode: "closed" })} onSubmit={(draft) => void saveDraft(draft)} />
+              </>
             ) : selectedAutomation ? (
               editorLoading ? (
                 <div className="flex min-h-80 items-center justify-center gap-2 text-muted-foreground"><Spinner className="size-4" /> Loading prompt…</div>
               ) : (
-                <AutomationForm automation={selectedAutomation} mode="edit" prompt={editorPrompt} saving={saving} onCancel={() => setEditor({ mode: "closed" })} onSubmit={(draft) => void saveDraft(draft)} />
+                <>
+                  <div className="mb-4">
+                    <h3 className="font-semibold text-foreground">Edit automation</h3>
+                    <p className="mt-1 text-xs text-muted-foreground">{selectedAutomation.id}</p>
+                  </div>
+                  <AutomationForm automation={selectedAutomation} mode="edit" prompt={editorPrompt} saving={saving} onCancel={() => setEditor({ mode: "closed" })} onSubmit={(draft) => void saveDraft(draft)} />
+                </>
               )
             ) : (
               <Notice tone="destructive">Automation not found.</Notice>

--- a/plugins/boring-automation/src/front/AutomationRuntimeContext.tsx
+++ b/plugins/boring-automation/src/front/AutomationRuntimeContext.tsx
@@ -4,22 +4,31 @@ import { createContext, useContext, useMemo, type ReactNode } from "react"
 import type { PluginProviderProps } from "@hachej/boring-workspace"
 import { createAutomationClient, type AutomationClient } from "./client"
 
-const AutomationClientContext = createContext<AutomationClient | null>(null)
+type AutomationRuntime = { client: AutomationClient; apiBaseUrl: string; authHeaders?: Record<string, string> }
+
+const AutomationClientContext = createContext<AutomationRuntime | null>(null)
 
 export function AutomationRuntimeProvider({ apiBaseUrl, authHeaders, onAuthError, apiTimeout, children }: PluginProviderProps) {
   const client = useMemo(
     () => createAutomationClient({ apiBaseUrl, headers: authHeaders, onAuthError, apiTimeout }),
     [apiBaseUrl, authHeaders, onAuthError, apiTimeout],
   )
-  return <AutomationClientContext.Provider value={client}>{children}</AutomationClientContext.Provider>
+  const runtime = useMemo(() => ({ client, apiBaseUrl, authHeaders }), [apiBaseUrl, authHeaders, client])
+  return <AutomationClientContext.Provider value={runtime}>{children}</AutomationClientContext.Provider>
+}
+
+export function useAutomationRuntime(): AutomationRuntime {
+  const runtime = useContext(AutomationClientContext)
+  if (!runtime) throw new Error("useAutomationRuntime must be used within AutomationRuntimeProvider")
+  return runtime
 }
 
 export function useAutomationClient(): AutomationClient {
-  const client = useContext(AutomationClientContext)
-  if (!client) throw new Error("useAutomationClient must be used within AutomationRuntimeProvider")
-  return client
+  const runtime = useContext(AutomationClientContext)
+  if (!runtime) throw new Error("useAutomationClient must be used within AutomationRuntimeProvider")
+  return runtime.client
 }
 
 export function AutomationClientProvider({ value, children }: { value: AutomationClient; children: ReactNode }) {
-  return <AutomationClientContext.Provider value={value}>{children}</AutomationClientContext.Provider>
+  return <AutomationClientContext.Provider value={{ client: value, apiBaseUrl: "" }}>{children}</AutomationClientContext.Provider>
 }

--- a/plugins/boring-automation/src/front/RunHistory.tsx
+++ b/plugins/boring-automation/src/front/RunHistory.tsx
@@ -36,11 +36,11 @@ export function RunHistory({
           <li key={run.id} className="group flex min-h-12 items-center gap-2 px-4 py-2 text-left text-[12px] focus-within:bg-muted/40 hover:bg-muted/40 motion-reduce:transition-none">
             <span className={cn("shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium", statusTone(run.status))}>{statusLabel(run.status)}</span>
             <div className="min-w-0 flex-1">
-              <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-foreground">
-                <span className="font-medium">{run.trigger === "scheduled" ? "Scheduled" : "Manual"}</span>
-                <span className="text-muted-foreground">Start {formatDateTime(startedOrScheduled)}</span>
-                <span className="text-muted-foreground">Duration {formatDuration(run)}</span>
-                {tokens != null ? <span className="text-muted-foreground">Tokens {tokens.toLocaleString()}</span> : null}
+              <div className="flex min-w-0 flex-wrap items-center gap-y-1 text-foreground">
+                <span className="mr-2 font-medium">{run.trigger === "scheduled" ? "Scheduled" : "Manual"}</span>
+                <span className="mr-2 text-muted-foreground">Start {formatDateTime(startedOrScheduled)}</span>
+                <span className="mr-2 text-muted-foreground">Duration {formatDuration(run)}</span>
+                {tokens != null ? <span className="mr-2 text-muted-foreground">Tokens {tokens.toLocaleString()}</span> : null}
               </div>
               {run.error ? <div className="mt-1 line-clamp-2 text-destructive">{run.error}</div> : null}
             </div>

--- a/plugins/boring-automation/src/front/__tests__/AutomationPanel.test.tsx
+++ b/plugins/boring-automation/src/front/__tests__/AutomationPanel.test.tsx
@@ -274,7 +274,7 @@ describe("AutomationPanel", () => {
     expect(await screen.findByLabelText("Run has no session")).toBeDisabled()
     fireEvent.click(screen.getByLabelText("Open session session-1"))
 
-    expect(shellState.current!.openDetachedChat).toHaveBeenCalledWith("session-1", { title: "gpt-5.5" })
+    expect(shellState.current!.openDetachedChat).toHaveBeenCalledWith("session-1", { title: "gpt-5.5", composingEnabled: true })
     expect(await screen.findByRole("alert")).toHaveTextContent("Could not open chat.")
   })
 })

--- a/plugins/boring-automation/src/front/index.tsx
+++ b/plugins/boring-automation/src/front/index.tsx
@@ -1,10 +1,36 @@
 "use client"
 
-import { definePlugin, type BoringFrontFactoryWithId } from "@hachej/boring-workspace/plugin"
-import { CalendarClock } from "lucide-react"
+import { IconButton } from "@hachej/boring-ui-kit"
+import { definePlugin, useAppLeftOverlayChrome, type BoringFrontAppLeftOverlayProps, type BoringFrontFactoryWithId } from "@hachej/boring-workspace/plugin"
+import { CalendarClock, X } from "lucide-react"
 import { BORING_AUTOMATION_PLUGIN_ID, BORING_AUTOMATION_PLUGIN_LABEL } from "../shared"
 import { AutomationPanel } from "./AutomationPanel"
 import { AutomationRuntimeProvider } from "./AutomationRuntimeContext"
+
+function AutomationOverlay({ onClose }: BoringFrontAppLeftOverlayProps) {
+  const { headerInsetStart, headerInsetEnd } = useAppLeftOverlayChrome()
+  return (
+    <div data-boring-workspace-part="automation-overlay" className="flex h-full min-h-0 flex-col bg-background">
+      <header className={[
+        "flex h-12 shrink-0 items-center justify-between border-b border-border/60",
+        headerInsetStart ? "pl-12" : "pl-4",
+        headerInsetEnd ? "pr-16" : "pr-4",
+      ].join(" ")}
+      >
+        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+          <CalendarClock className="size-4 text-primary" />
+          {BORING_AUTOMATION_PLUGIN_LABEL}
+        </div>
+        <IconButton type="button" variant="ghost" size="icon-xs" onClick={onClose} aria-label="Close automations" title="Close">
+          <X className="size-3" strokeWidth={1.75} />
+        </IconButton>
+      </header>
+      <div className="min-h-0 flex-1 overflow-auto">
+        <AutomationPanel />
+      </div>
+    </div>
+  )
+}
 
 export const boringAutomationPlugin: BoringFrontFactoryWithId = definePlugin({
   id: BORING_AUTOMATION_PLUGIN_ID,
@@ -13,6 +39,15 @@ export const boringAutomationPlugin: BoringFrontFactoryWithId = definePlugin({
     {
       id: `${BORING_AUTOMATION_PLUGIN_ID}.runtime`,
       component: AutomationRuntimeProvider,
+    },
+  ],
+  appLeftActions: [
+    {
+      id: "automations",
+      label: BORING_AUTOMATION_PLUGIN_LABEL,
+      icon: CalendarClock,
+      overlay: AutomationOverlay,
+      order: 45,
     },
   ],
   panels: [

--- a/plugins/boring-automation/src/front/index.tsx
+++ b/plugins/boring-automation/src/front/index.tsx
@@ -1,35 +1,13 @@
 "use client"
 
-import { IconButton } from "@hachej/boring-ui-kit"
-import { definePlugin, useAppLeftOverlayChrome, type BoringFrontAppLeftOverlayProps, type BoringFrontFactoryWithId } from "@hachej/boring-workspace/plugin"
-import { CalendarClock, X } from "lucide-react"
+import { definePlugin, type BoringFrontAppLeftOverlayProps, type BoringFrontFactoryWithId, type PaneProps } from "@hachej/boring-workspace/plugin"
+import { CalendarClock } from "lucide-react"
 import { BORING_AUTOMATION_PLUGIN_ID, BORING_AUTOMATION_PLUGIN_LABEL } from "../shared"
 import { AutomationPanel } from "./AutomationPanel"
 import { AutomationRuntimeProvider } from "./AutomationRuntimeContext"
 
 function AutomationOverlay({ onClose }: BoringFrontAppLeftOverlayProps) {
-  const { headerInsetStart, headerInsetEnd } = useAppLeftOverlayChrome()
-  return (
-    <div data-boring-workspace-part="automation-overlay" className="flex h-full min-h-0 flex-col bg-background">
-      <header className={[
-        "flex h-12 shrink-0 items-center justify-between border-b border-border/60",
-        headerInsetStart ? "pl-12" : "pl-4",
-        headerInsetEnd ? "pr-16" : "pr-4",
-      ].join(" ")}
-      >
-        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-          <CalendarClock className="size-4 text-primary" />
-          {BORING_AUTOMATION_PLUGIN_LABEL}
-        </div>
-        <IconButton type="button" variant="ghost" size="icon-xs" onClick={onClose} aria-label="Close automations" title="Close">
-          <X className="size-3" strokeWidth={1.75} />
-        </IconButton>
-      </header>
-      <div className="min-h-0 flex-1 overflow-auto">
-        <AutomationPanel />
-      </div>
-    </div>
-  )
+  return <div data-boring-workspace-part="automation-overlay" className="h-full min-h-0"><AutomationPanel {...({ onClose } as PaneProps & { onClose: () => void })} /></div>
 }
 
 export const boringAutomationPlugin: BoringFrontFactoryWithId = definePlugin({

--- a/plugins/boring-automation/src/front/index.tsx
+++ b/plugins/boring-automation/src/front/index.tsx
@@ -1,13 +1,17 @@
 "use client"
 
-import { definePlugin, type BoringFrontAppLeftOverlayProps, type BoringFrontFactoryWithId, type PaneProps } from "@hachej/boring-workspace/plugin"
+import { definePlugin, type BoringFrontAppLeftOverlayProps, type BoringFrontFactoryWithId } from "@hachej/boring-workspace/plugin"
 import { CalendarClock } from "lucide-react"
 import { BORING_AUTOMATION_PLUGIN_ID, BORING_AUTOMATION_PLUGIN_LABEL } from "../shared"
 import { AutomationPanel } from "./AutomationPanel"
 import { AutomationRuntimeProvider } from "./AutomationRuntimeContext"
 
 function AutomationOverlay({ onClose }: BoringFrontAppLeftOverlayProps) {
-  return <div data-boring-workspace-part="automation-overlay" className="h-full min-h-0"><AutomationPanel {...({ onClose } as PaneProps & { onClose: () => void })} /></div>
+  return <div data-boring-workspace-part="automation-overlay" className="h-full min-h-0"><AutomationPanel onClose={onClose} /></div>
+}
+
+function AutomationCenterPanel() {
+  return <AutomationPanel />
 }
 
 export const boringAutomationPlugin: BoringFrontFactoryWithId = definePlugin({
@@ -33,7 +37,7 @@ export const boringAutomationPlugin: BoringFrontFactoryWithId = definePlugin({
       id: `${BORING_AUTOMATION_PLUGIN_ID}.panel`,
       label: BORING_AUTOMATION_PLUGIN_LABEL,
       icon: CalendarClock,
-      component: AutomationPanel,
+      component: AutomationCenterPanel,
       placement: "center",
       source: "builtin",
     },

--- a/plugins/boring-automation/src/server/fileStore.ts
+++ b/plugins/boring-automation/src/server/fileStore.ts
@@ -72,6 +72,7 @@ export class FileAutomationStore implements AutomationStore {
       cron: input.cron,
       timezone: input.timezone,
       model: input.model,
+      ...(input.thinkingLevel ? { thinkingLevel: input.thinkingLevel } : {}),
       promptRef: promptRefForId(id),
       createdAt: now,
       updatedAt: now,

--- a/plugins/boring-automation/src/server/manualRunExecutor.ts
+++ b/plugins/boring-automation/src/server/manualRunExecutor.ts
@@ -89,6 +89,7 @@ export class ManualRunExecutor {
       for await (const event of dispatcher.send({
         content: promptSnapshot,
         model,
+        ...(automation.thinkingLevel ? { thinkingLevel: automation.thinkingLevel } : {}),
         actor: { id: actor.userId },
         originSurface: "boring-automation",
       })) {

--- a/plugins/boring-automation/src/server/routes.ts
+++ b/plugins/boring-automation/src/server/routes.ts
@@ -18,7 +18,9 @@ export interface AutomationRoutesOptions {
   store: AutomationStore
   storeForRequest?: (request: FastifyRequest) => Promise<AutomationStore> | AutomationStore
   manualRunExecutor?: Pick<ManualRunExecutor, "run">
+  manualRunExecutorForRequest?: (request: FastifyRequest) => Promise<Pick<ManualRunExecutor, "run">> | Pick<ManualRunExecutor, "run">
   dueRunService?: Pick<DueRunService, "runDue">
+  dueRunServiceForRequest?: (request: FastifyRequest) => Promise<Pick<DueRunService, "runDue">> | Pick<DueRunService, "runDue">
   hostedDueRunService?: Pick<HostedDueRunService, "runDue">
   hostedTriggerToken?: string
 }
@@ -111,13 +113,14 @@ export async function automationRoutes(app: FastifyInstance, opts: AutomationRou
           "automation due trigger is limited to loopback callers",
         )
       }
-      if (!opts.dueRunService) {
+      const dueRunService = await opts.dueRunServiceForRequest?.(request) ?? opts.dueRunService
+      if (!dueRunService) {
         throw new AutomationStoreError(
           BORING_AUTOMATION_ERROR_CODES.RUN_EXECUTOR_UNAVAILABLE,
           "automation due executor is unavailable",
         )
       }
-      return { ok: true, ...(await opts.dueRunService.runDue(request)) }
+      return { ok: true, ...(await dueRunService.runDue(request)) }
     } catch (cause) {
       return sendError(reply, cause)
     }
@@ -126,13 +129,14 @@ export async function automationRoutes(app: FastifyInstance, opts: AutomationRou
   app.post(`${BORING_AUTOMATION_ROUTE_PREFIX}/automations/:id/run`, async (request, reply) => {
     try {
       const { id } = parseParams(IdParamsSchema, request.params)
-      if (!opts.manualRunExecutor) {
+      const manualRunExecutor = await opts.manualRunExecutorForRequest?.(request) ?? opts.manualRunExecutor
+      if (!manualRunExecutor) {
         throw new AutomationStoreError(
           BORING_AUTOMATION_ERROR_CODES.RUN_EXECUTOR_UNAVAILABLE,
           "automation run executor is unavailable",
         )
       }
-      const run = await opts.manualRunExecutor.run({ automationId: id, request })
+      const run = await manualRunExecutor.run({ automationId: id, request })
       return reply.status(201).send({ ok: true, run })
     } catch (cause) {
       return sendError(reply, cause)

--- a/plugins/boring-automation/src/shared/schema.ts
+++ b/plugins/boring-automation/src/shared/schema.ts
@@ -14,6 +14,7 @@ export const AutomationCreateSchema = z.object({
   cron: nonEmptyString,
   timezone: nonEmptyString,
   model: nonEmptyString,
+  thinkingLevel: z.enum(["off", "low", "medium", "high"]).optional(),
   prompt: z.string().optional(),
 }).strict().superRefine((value, ctx) => {
   addScheduleIssues(ctx, value)
@@ -25,6 +26,7 @@ export const AutomationPatchSchema = z.object({
   cron: nonEmptyString.optional(),
   timezone: nonEmptyString.optional(),
   model: nonEmptyString.optional(),
+  thinkingLevel: z.enum(["off", "low", "medium", "high"]).optional(),
 }).strict()
   .refine((value) => Object.keys(value).length > 0, "at least one field must be provided")
   .superRefine((value, ctx) => {

--- a/plugins/boring-automation/src/shared/types.ts
+++ b/plugins/boring-automation/src/shared/types.ts
@@ -8,6 +8,7 @@ export interface Automation {
   cron: string
   timezone: string
   model: string
+  thinkingLevel?: "off" | "low" | "medium" | "high"
   promptRef: string
   createdAt: string
   updatedAt: string
@@ -19,6 +20,7 @@ export interface AutomationCreate {
   cron: string
   timezone: string
   model: string
+  thinkingLevel?: "off" | "low" | "medium" | "high"
   prompt?: string
 }
 
@@ -28,6 +30,7 @@ export interface AutomationPatch {
   cron?: string
   timezone?: string
   model?: string
+  thinkingLevel?: "off" | "low" | "medium" | "high"
 }
 
 export interface AutomationRun {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1147,6 +1147,9 @@ importers:
 
   plugins/boring-automation:
     dependencies:
+      '@hachej/boring-agent':
+        specifier: workspace:*
+        version: link:../../packages/agent
       '@hachej/boring-ui-kit':
         specifier: workspace:*
         version: link:../../packages/ui


### PR DESCRIPTION
## Summary
Enable the Automations plugin in CLI workspaces mode with request-scoped file stores and dispatchers.

## Proof
- `pnpm --filter @hachej/boring-automation typecheck`
- `pnpm --filter @hachej/boring-ui-cli typecheck`
- `pnpm --filter @hachej/boring-ui-cli exec vitest run src/__tests__/workspacesModeRuntimePlugins.test.ts --testNamePattern="first SSE connect"`

The focused hub test proves workspace A automation creation remains absent from workspace B.