### PR TITLE
#791 fix(agent): use structured extension reload results

### DIFF
--- a/apps/agent-playground/src/front/App.tsx
+++ b/apps/agent-playground/src/front/App.tsx
@@ -1,6 +1,6 @@
 import './app.css'
 import { useCallback, useEffect, useState } from 'react'
-import { ChatPanel as PiChatPanel } from '@hachej/boring-agent/front'
+import { ChatPanel as PiChatPanel, type AgentPluginReloadResult } from '@hachej/boring-agent/front'
 import { WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT } from '@hachej/boring-agent/shared'
 import { Showcase } from '../Showcase'
 
@@ -16,16 +16,20 @@ function readStoredTheme(): Theme {
 type PluginReloadPayload = { reloaded?: boolean }
 
 function useStandalonePluginReload() {
-  return useCallback(async () => {
+  return useCallback(async (): Promise<AgentPluginReloadResult> => {
     const response = await fetch('/api/v1/agent/reload', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({}),
     })
-    if (!response.ok) return `reload failed (${response.status})`
+    if (!response.ok) throw new Error(`reload failed (${response.status})`)
     const payload = await response.json().catch(() => ({})) as PluginReloadPayload
     window.dispatchEvent(new CustomEvent(WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT, { detail: payload }))
-    return payload.reloaded ? 'Agent plugins reloaded.' : 'Agent plugins will reload on the next message.'
+    const reloaded = payload.reloaded === true
+    return {
+      message: reloaded ? 'Agent plugins reloaded.' : 'Agent plugins will reload on the next message.',
+      reloaded,
+    }
   }, [])
 }
 

--- a/apps/agent-playground/src/front/App.tsx
+++ b/apps/agent-playground/src/front/App.tsx
@@ -1,6 +1,6 @@
 import './app.css'
 import { useCallback, useEffect, useState } from 'react'
-import { ChatPanel as PiChatPanel, type AgentPluginReloadResult } from '@hachej/boring-agent/front'
+import { ChatPanel as PiChatPanel } from '@hachej/boring-agent/front'
 import { WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT } from '@hachej/boring-agent/shared'
 import { Showcase } from '../Showcase'
 
@@ -16,20 +16,16 @@ function readStoredTheme(): Theme {
 type PluginReloadPayload = { reloaded?: boolean }
 
 function useStandalonePluginReload() {
-  return useCallback(async (): Promise<AgentPluginReloadResult> => {
+  return useCallback(async () => {
     const response = await fetch('/api/v1/agent/reload', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({}),
     })
-    if (!response.ok) throw new Error(`reload failed (${response.status})`)
+    if (!response.ok) return `reload failed (${response.status})`
     const payload = await response.json().catch(() => ({})) as PluginReloadPayload
     window.dispatchEvent(new CustomEvent(WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT, { detail: payload }))
-    const reloaded = payload.reloaded === true
-    return {
-      message: reloaded ? 'Agent plugins reloaded.' : 'Agent plugins will reload on the next message.',
-      reloaded,
-    }
+    return payload.reloaded ? 'Agent plugins reloaded.' : 'Agent plugins will reload on the next message.'
   }, [])
 }
 

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -59,7 +59,6 @@ import {
   isPiBusyStatus,
   normalizedHeadersFromContentKey,
   parseBrowserPluginReloadDetail,
-  pluginReloadFailureMessage,
   resolveModelSlashSelection,
   resolveThinkingSlashSelection,
   shouldHoldLocalSubmitted,
@@ -103,6 +102,21 @@ export interface ChatPanelEmptyState {
   description?: ReactNode
   /** Optional content rendered below the suggestion grid (e.g. a footer link). */
   footer?: ReactNode
+}
+
+export interface AgentPluginReloadResult {
+  message: string
+  reloaded: boolean
+}
+
+function normalizeAgentPluginReloadResult(result: AgentPluginReloadResult | string): AgentPluginReloadResult {
+  if (typeof result !== 'string') return result
+
+  // Compatibility for hosts using the original string-returning callback contract.
+  const firstLine = result.trim().split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? ''
+  if (/^(?:agent plugins|extensions) reloaded\.?$/i.test(firstLine)) return { message: result, reloaded: true }
+  if (/^(?:agent plugins|extensions) will reload on the next message\.?$/i.test(firstLine)) return { message: result, reloaded: false }
+  throw new Error(result)
 }
 
 export interface PiChatPanelProps<
@@ -153,7 +167,7 @@ export interface PiChatPanelProps<
   workspaceWarmupStatus?: ChatPanelWorkspaceWarmupStatus
   onSessionReset?: () => void | Promise<void>
   onBeforeSubmit?: (draft: string, context: ChatSubmitContext) => false | void | boolean | Promise<false | void | boolean>
-  onReloadAgentPlugins?: () => Promise<string>
+  onReloadAgentPlugins?: () => Promise<AgentPluginReloadResult | string>
   onCommandResult?: (message: string) => void
   onComposerWarning?: (message: string) => void
   onMentionedFilesConsumed?: () => void
@@ -533,21 +547,16 @@ export function PiChatPanel<
 
   const reloadAgentPlugins = useCallback(async () => {
     if (!onReloadAgentPlugins) throw new Error('Agent plugin reload is not configured.')
-    return await onReloadAgentPlugins()
+    return normalizeAgentPluginReloadResult(await onReloadAgentPlugins())
   }, [onReloadAgentPlugins])
 
   const runPluginUpdate = useCallback(async () => {
     setPluginUpdateState({ kind: 'running' })
     try {
-      const message = await reloadAgentPlugins()
-      const failureMessage = pluginReloadFailureMessage(message)
-      if (failureMessage) {
-        setPluginUpdateState({ kind: 'error', message: failureMessage })
-        return `Extension update failed: ${failureMessage}`
-      }
-      setPluginUpdateState({ kind: 'success', reloaded: !/will reload on the next message/i.test(message) })
+      const result = await reloadAgentPlugins()
+      setPluginUpdateState({ kind: 'success', reloaded: result.reloaded })
       setServerSkillsRefreshKey((key) => key + 1)
-      return message
+      return result.message
     } catch (error) {
       const message = errorMessage(error, 'Extension reload failed.')
       setPluginUpdateState({ kind: 'error', message })
@@ -721,7 +730,7 @@ export function PiChatPanel<
         }),
         resetSession,
         listCommands: () => registry.list(),
-        reloadAgentPlugins,
+        reloadAgentPlugins: async () => (await reloadAgentPlugins()).message,
         pluginUpdate: { run: runPluginUpdate },
         openModelPicker,
         selectComposerModel,

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -1632,7 +1632,10 @@ describe('PiChatPanel sandbox shell', () => {
       if (url.endsWith('/api/v1/agent/pi-chat/sessions')) return jsonResponse([session('pi-1')])
       throw new Error(`unexpected fetch ${url}`)
     })
-    const onReloadAgentPlugins = vi.fn(async () => 'Agent plugins reloaded.\n\nWarnings:\nplugin front failed once but recovered')
+    const onReloadAgentPlugins = vi.fn(async () => ({
+      message: 'Extensions reloaded.\n\nWarnings:\nplugin front failed once but recovered',
+      reloaded: true,
+    }))
     const onCommandResult = vi.fn()
 
     render(
@@ -1651,7 +1654,7 @@ describe('PiChatPanel sandbox shell', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
 
     await waitFor(() => expect(onReloadAgentPlugins).toHaveBeenCalledTimes(1))
-    expect(onCommandResult).toHaveBeenCalledWith(expect.stringContaining('Agent plugins reloaded.'))
+    expect(onCommandResult).toHaveBeenCalledWith(expect.stringContaining('Extensions reloaded.'))
     expect(onCommandResult).toHaveBeenCalledWith(expect.stringContaining('plugin front failed once but recovered'))
     expect(remote.prompt).not.toHaveBeenCalled()
   })
@@ -1741,7 +1744,7 @@ describe('PiChatPanel sandbox shell', () => {
     expect(remote.prompt).not.toHaveBeenCalled()
   })
 
-  test('reports unknown plugin reload result strings as errors', async () => {
+  test('reports unknown legacy plugin reload results as errors', async () => {
     const remote = new FakeRemotePiSession(remoteState())
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)

--- a/packages/agent/src/front/chat/piChatPanelUtils.ts
+++ b/packages/agent/src/front/chat/piChatPanelUtils.ts
@@ -122,13 +122,6 @@ export function parseBrowserPluginReloadDetail(detail: unknown): BrowserPluginRe
   }
 }
 
-export function pluginReloadFailureMessage(message: string): string | null {
-  const firstLine = message.trim().split(/\r?\n/).find((line) => line.trim().length > 0)?.trim() ?? ''
-  if (/^agent plugins reloaded\.?$/i.test(firstLine)) return null
-  if (/^agent plugins will reload on the next message\.?$/i.test(firstLine)) return null
-  return message
-}
-
 export function shouldRefreshSessionListAfterEvent(event: PiChatEvent): boolean {
   return event.type === 'agent-end'
 }

--- a/packages/agent/src/front/index.ts
+++ b/packages/agent/src/front/index.ts
@@ -5,6 +5,7 @@ export type { UploadFileOptions, UploadFileResult } from './upload/uploadFile'
 
 export { PiChatPanel, PiChatPanel as ChatPanel } from './chat/PiChatPanel'
 export type {
+  AgentPluginReloadResult,
   ComposerBlocker,
   ComposerBlockerAction,
   PiChatPanelProps,

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1403,23 +1403,27 @@ export function WorkspaceAgentFront<
   const workbenchOverlay = workbenchBlocked ? <WorkbenchWarmupOverlay status={workspaceWarmupStatus} /> : undefined
   const reloadAgentPluginsForSession = useCallback(async (sessionId: string) => {
     const endpoint = `${apiBaseUrl?.replace(/\/$/, "") ?? ""}/api/v1/agent/reload`
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { ...resolvedRequestHeaders, "content-type": "application/json" },
+      body: JSON.stringify({ sessionId }),
+    })
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({})) as { error?: string }
+      throw new Error(payload.error || `reload failed (${response.status})`)
+    }
+    const payload = await response.json().catch(() => ({})) as { reloaded?: boolean; diagnostics?: Array<{ message?: string }> }
+    window.dispatchEvent(new CustomEvent(WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT, { detail: payload }))
+    return { message: pluginReloadMessage(payload), reloaded: payload.reloaded === true }
+  }, [apiBaseUrl, resolvedRequestHeaders])
+
+  const reloadAgentPluginsMessageForSession = useCallback(async (sessionId: string) => {
     try {
-      const response = await fetch(endpoint, {
-        method: "POST",
-        headers: { ...resolvedRequestHeaders, "content-type": "application/json" },
-        body: JSON.stringify({ sessionId }),
-      })
-      if (!response.ok) {
-        const payload = await response.json().catch(() => ({})) as { error?: string }
-        return payload.error || `reload failed (${response.status})`
-      }
-      const payload = await response.json().catch(() => ({})) as { reloaded?: boolean; diagnostics?: Array<{ message?: string }> }
-      window.dispatchEvent(new CustomEvent(WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT, { detail: payload }))
-      return pluginReloadMessage(payload)
+      return (await reloadAgentPluginsForSession(sessionId)).message
     } catch (error) {
       return error instanceof Error ? error.message : "Agent plugin reload failed."
     }
-  }, [apiBaseUrl, resolvedRequestHeaders])
+  }, [reloadAgentPluginsForSession])
 
   const chatRemoteSessionOptions = useMemo(() => {
     const base = (chatParams?.remoteSessionOptions && typeof chatParams.remoteSessionOptions === "object")
@@ -1531,7 +1535,7 @@ export function WorkspaceAgentFront<
     defaultLeftTab: defaultWorkbenchLeftTab,
     initialPanels: surfaceInitialPanels,
     extraPanels: shellExtraPanels,
-    onReloadAgentPlugins: () => reloadAgentPluginsForSession(effectiveActiveSessionId ?? chatSessionId),
+    onReloadAgentPlugins: () => reloadAgentPluginsMessageForSession(effectiveActiveSessionId ?? chatSessionId),
     onReady: handleSurfaceReady,
     onChange: handleSurfaceChange,
     onClose: closeWorkbench,
@@ -1540,7 +1544,7 @@ export function WorkspaceAgentFront<
     closeWorkbench,
     defaultWorkbenchLeftTab,
     surfaceInitialPanels,
-    reloadAgentPluginsForSession,
+    reloadAgentPluginsMessageForSession,
     effectiveActiveSessionId,
     chatSessionId,
     handleSurfaceChange,
@@ -1695,7 +1699,7 @@ export function WorkspaceAgentFront<
   ) : leftOverlay === "plugins" && pluginsActionEnabled ? (
     <PluginsOverlay
       onClose={() => setLeftOverlay(null)}
-      onReloadExternalPlugins={() => reloadAgentPluginsForSession(effectiveActiveSessionId ?? chatSessionId)}
+      onReloadExternalPlugins={() => reloadAgentPluginsMessageForSession(effectiveActiveSessionId ?? chatSessionId)}
       headerInsetStart={appLeftPaneCollapsed}
       headerInsetEnd={!surfaceOpen}
     />

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -2036,7 +2036,7 @@ describe("WorkspaceAgentFront", () => {
         expect(init?.method).toBe("POST")
         expect(init?.headers).toMatchObject({ "x-boring-workspace-id": "reload-workspace", "content-type": "application/json" })
         expect(JSON.parse(String(init?.body))).toEqual({ sessionId: "pi-reload" })
-        return new Response(JSON.stringify({ reloaded: true, diagnostics: [{ message: "rebuilt plugin front" }] }), { status: 200 })
+        return new Response(JSON.stringify({ reloaded: false, diagnostics: [{ message: "rebuilt plugin front" }] }), { status: 200 })
       }
       return new Response(JSON.stringify([]), { status: 200 })
     })
@@ -2068,11 +2068,13 @@ describe("WorkspaceAgentFront", () => {
       )
 
       await waitFor(() => expect(typeof capturedChatProps?.onReloadAgentPlugins).toBe("function"))
-      const message = await (capturedChatProps?.onReloadAgentPlugins as () => Promise<string>)()
-      expect(message).toContain("Extensions reloaded.")
-      expect(message).toContain("rebuilt plugin front")
+      const result = await (capturedChatProps?.onReloadAgentPlugins as () => Promise<{ message: string; reloaded: boolean }>)()
+      expect(result).toEqual({
+        message: "Extensions will reload on the next message.\n\nWarnings:\nrebuilt plugin front",
+        reloaded: false,
+      })
       expect(fetchMock).toHaveBeenCalledWith("/agent/api/v1/agent/reload", expect.objectContaining({ method: "POST" }))
-      expect(reloadEvents).toContainEqual({ reloaded: true, diagnostics: [{ message: "rebuilt plugin front" }] })
+      expect(reloadEvents).toContainEqual({ reloaded: false, diagnostics: [{ message: "rebuilt plugin front" }] })
     } finally {
       window.removeEventListener(WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT, listener)
     }


### PR DESCRIPTION
## Summary

- replace presentation-copy parsing on the canonical reload path with a typed `{ message, reloaded }` result
- preserve the published string-returning callback contract through an isolated compatibility adapter
- keep fire-and-forget workspace reload surfaces non-throwing
- cover both immediate `Extensions reloaded.` and deferred reload behavior

Closes #791

## Proof

- `pnpm --filter @hachej/boring-agent exec vitest run src/front/chat/__tests__/PiChatPanel.test.tsx` — 59 passed
- `pnpm --filter @hachej/boring-workspace exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx` — 60 passed
- `pnpm --filter @hachej/boring-agent run lint` — passed
- `pnpm --filter @hachej/boring-workspace run lint` — passed
- thermo-nuclear autoreview against `origin/main` — clean, no accepted/actionable findings
