### PR TITLE
fix(workspace): align file refresh with explorer chrome

### DIFF
--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -1126,19 +1126,23 @@ export function FileTreePane({
       : debouncedQuery || undefined
 
   if (effectiveChromeless) {
-    // Single-root chromeless hosts (the common case: a plain "Files" tab with
-    // no alternate filesystem) render exactly as before — no wrapper, no
-    // switcher. Multi-root hosts still need a way to pick the active
-    // filesystem even though the pane itself owns no title/search chrome —
-    // that's the shell's job here. Render just the root switcher (no title,
-    // no per-root filter input — the shell's own search box covers that, see
-    // `effectiveSearchQuery` above) above the tree.
+    // Single-root chromeless hosts put refresh in the shell's existing header
+    // action slot when one is available, avoiding a toolbar row whose only
+    // content is one icon. Standalone hosts without that slot retain the local
+    // fallback. Multi-root hosts keep refresh beside the root selector so the
+    // action's active-filesystem scope remains visually explicit. The shell's
+    // search box continues to drive `effectiveSearchQuery` for either shape.
     if (rootOptions.length <= 1) {
+      const chromeActionsElement = params?.chromeActionsElement
       return (
         <div className="flex h-full min-h-0 flex-col">
-          <div className="flex shrink-0 items-center justify-end px-1 pt-1">
-            {refreshButton}
-          </div>
+          {chromeActionsElement
+            ? createPortal(refreshButton, chromeActionsElement)
+            : (
+                <div className="flex shrink-0 items-center justify-end px-1 pt-1">
+                  {refreshButton}
+                </div>
+              )}
           <div className="min-h-0 flex-1">
             <FileTreeView
               ref={treeRef}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest"
-import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor, act, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type React from "react"
@@ -1819,6 +1819,38 @@ describe("FileTreePane", () => {
       const button = screen.getByRole("button", { name: "Refresh files" })
       fireEvent.click(button)
       await waitFor(() => expect(mockFileListRefetch).toHaveBeenCalled())
+    })
+
+    it("portals single-root refresh into the shell chrome actions instead of adding a toolbar row", async () => {
+      const chromeActionsElement = document.createElement("div")
+      render(
+        <FileTreePane params={{ chromeless: true, chromeActionsElement }} />,
+        { wrapper },
+      )
+      await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
+
+      const button = within(chromeActionsElement).getByRole("button", { name: "Refresh files" })
+      fireEvent.click(button)
+      await waitFor(() => expect(mockFileListRefetch).toHaveBeenCalled())
+    })
+
+    it("keeps multi-root refresh beside the active-root selector instead of portaling it", async () => {
+      const chromeActionsElement = document.createElement("div")
+      render(
+        <FileTreePane
+          params={{ chromeless: true, chromeActionsElement }}
+          roots={[
+            { filesystem: "user", label: "Workspace", rootDir: ".", access: "readwrite" },
+            { filesystem: "project_alpha", label: "Project", rootDir: "/", access: "readonly" },
+          ]}
+        />,
+        { wrapper },
+      )
+
+      const selector = await screen.findByRole("combobox", { name: "File root" })
+      const button = screen.getByRole("button", { name: "Refresh files" })
+      expect(chromeActionsElement).toBeEmptyDOMElement()
+      expect(selector.parentElement).toContainElement(button)
     })
 
     it("shows the Refresh button in multi-root chromeless mode and refetches whichever root is active", async () => {


### PR DESCRIPTION
## Summary

- place single-filesystem refresh in the existing Files header action slot
- preserve the standalone chromeless fallback when no shell slot exists
- keep multi-filesystem refresh beside the active-root selector so its scope remains explicit

## Proof

- `pnpm --filter @hachej/boring-ui-kit build` ✅
- `pnpm --filter @hachej/boring-agent build` ✅
- `pnpm --filter @hachej/boring-workspace exec vitest run src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx` ✅ — 80/80
- `pnpm --filter @hachej/boring-workspace typecheck` ✅
- `git diff --check` ✅
- structured Codex autoreview ✅ — no actionable findings, confidence 0.95

## Visual intent

Single filesystem: refresh joins Files header actions beside search; no empty one-button row.

Multiple filesystems: selector and refresh stay together in the pane so refresh clearly applies to the selected root.