### PR TITLE
Fix shared Files updates after agent changes

### DIFF
--- a/packages/agent/src/server/pi-chat/__tests__/piChatEvents.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/piChatEvents.test.ts
@@ -255,7 +255,7 @@ describe('PiChatEventMapper', () => {
       assistantMessageEvent: {
         type: 'toolcall_end',
         contentIndex: 2,
-        toolCall: { id: 'tool-1', name: 'write', arguments: { path: 'a.ts' }, ui: { rendererId: 'fs.write', extra: 'ignored' } },
+        toolCall: { id: 'tool-1', name: 'write', arguments: { path: 'a.ts', filesystem: 'company_context' }, ui: { rendererId: 'fs.write', extra: 'ignored' } },
       },
     } as unknown as AgentSessionEvent)
     const toolResult = mapper.map({
@@ -276,12 +276,12 @@ describe('PiChatEventMapper', () => {
         messageId: 'assistant-1',
         toolCallId: 'tool-1',
         toolName: 'write',
-        input: { path: 'a.ts' },
+        input: { path: 'a.ts', filesystem: 'company_context' },
         ui: { rendererId: 'fs.write' },
       },
     ])
     expect(toolResult).toMatchObject([
-      { type: 'file-changed', seq: 3, path: 'a.ts', changeType: 'write' },
+      { type: 'file-changed', seq: 3, path: 'a.ts', changeType: 'write', filesystem: 'company_context' },
       { type: 'tool-result', seq: 4, messageId: 'assistant-1', toolCallId: 'tool-1', isError: false, ui: { rendererId: 'fs.write.result' } },
     ])
   })

--- a/packages/agent/src/server/pi-chat/piChatEvents.ts
+++ b/packages/agent/src/server/pi-chat/piChatEvents.ts
@@ -11,6 +11,7 @@ type FileChangeOp = 'write' | 'edit' | 'unlink' | 'rename' | 'mkdir'
 interface FileChangeData {
   op: FileChangeOp
   path: string
+  filesystem?: string
 }
 
 const FILE_CHANGE_OPS = new Set<FileChangeOp>(['write', 'edit', 'unlink', 'rename', 'mkdir'])
@@ -27,6 +28,7 @@ export class PiChatEventMapper {
   private activeAssistantMessageId: string | undefined
   private readonly pendingUserStarts: Array<{ messageId: string; text?: string }> = []
   private readonly toolCallMessageIds = new Map<string, string>()
+  private readonly toolCallInputs = new Map<string, unknown>()
   private readonly endedMessageIds = new Set<string>()
   private readonly endedAssistantTurnIds = new Set<string>()
   private readonly errorEmittedTurnIds = new Set<string>()
@@ -70,6 +72,7 @@ export class PiChatEventMapper {
         ]
         this.activeAssistantMessageId = undefined
         this.toolCallMessageIds.clear()
+        this.toolCallInputs.clear()
         if (status !== 'error') this.activeTurnId = undefined
         return mapped
       }
@@ -230,6 +233,7 @@ export class PiChatEventMapper {
     const toolCall = assistantEvent.toolCall
     const toolCallId = optionalString(toolCall.id) ?? `${messageId}:tool:${partIdFromAssistantEvent(assistantEvent)}`
     this.toolCallMessageIds.set(toolCallId, messageId)
+    this.toolCallInputs.set(toolCallId, toolCall.arguments)
     return [
       this.event({
         type: 'tool-call',
@@ -336,9 +340,17 @@ export class PiChatEventMapper {
     const result = event.result
     const mapped: PiChatEvent[] = []
 
+    const toolFilesystem = filesystemFromToolInput(this.toolCallInputs.get(toolCallId))
     for (const fileChange of extractFileChanges(isRecord(result) ? result.details : undefined)) {
-      mapped.push(this.event({ type: 'file-changed', path: fileChange.path, changeType: fileChange.op }))
+      const filesystem = fileChange.filesystem ?? toolFilesystem
+      mapped.push(this.event({
+        type: 'file-changed',
+        path: fileChange.path,
+        changeType: fileChange.op,
+        ...(filesystem ? { filesystem } : {}),
+      }))
     }
+    this.toolCallInputs.delete(toolCallId)
 
     mapped.push(
       this.event({
@@ -523,13 +535,22 @@ function errorMessageFromAssistantError(assistantEvent: RecordLike): string {
   return assistantEvent.reason === 'aborted' ? 'Aborted' : 'Unknown error'
 }
 
+function filesystemFromToolInput(input: unknown): string | undefined {
+  return isRecord(input) ? optionalString(input.filesystem) : undefined
+}
+
 function normalizeFileChangeEntry(value: unknown): FileChangeData | null {
   if (!isRecord(value)) return null
   const op = value.op
   const path = value.path
   if (typeof op !== 'string' || !FILE_CHANGE_OPS.has(op as FileChangeOp)) return null
   if (typeof path !== 'string' || path.length === 0) return null
-  return { op: op as FileChangeOp, path }
+  const filesystem = optionalString(value.filesystem)
+  return {
+    op: op as FileChangeOp,
+    path,
+    ...(filesystem ? { filesystem } : {}),
+  }
 }
 
 function extractFileChanges(details: unknown): FileChangeData[] {

--- a/packages/agent/src/shared/chat/__tests__/piChatSchemas.test.ts
+++ b/packages/agent/src/shared/chat/__tests__/piChatSchemas.test.ts
@@ -134,8 +134,15 @@ describe('Pi chat shared schemas', () => {
       createdAt: '2026-06-06T10:00:00.000Z',
     })).toMatchObject({ type: 'message-start', createdAt: '2026-06-06T10:00:00.000Z' })
     expect(PiChatEventSchema.parse({
-      type: 'message-start',
+      type: 'file-changed',
       seq: 7,
+      path: '/company/handbook.md',
+      changeType: 'write',
+      filesystem: 'company_context',
+    })).toMatchObject({ filesystem: 'company_context' })
+    expect(PiChatEventSchema.parse({
+      type: 'message-start',
+      seq: 8,
       messageId: 'u-company',
       role: 'user',
       files: [{ type: 'file', path: '/company/hr/policy.md', filesystem: 'company_context' }],

--- a/packages/agent/src/shared/chat/piChatEvent.ts
+++ b/packages/agent/src/shared/chat/piChatEvent.ts
@@ -35,7 +35,7 @@ export type PiChatEvent =
     }
   | { type: 'queue-updated'; seq: number; queue: { followUps: QueuedUserMessage[] } }
   | { type: 'followup-consumed'; seq: number; clientNonce?: string; clientSeq?: number; messageId: string }
-  | { type: 'file-changed'; seq: number; path: string; changeType: string }
+  | { type: 'file-changed'; seq: number; path: string; changeType: string; filesystem?: string }
   | { type: 'ui-command'; seq: number; command: unknown; displayOnly: true }
   | { type: 'usage'; seq: number; usage: unknown }
   | { type: 'auto-retry-start'; seq: number; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }

--- a/packages/agent/src/shared/chat/piChatSchemas.ts
+++ b/packages/agent/src/shared/chat/piChatSchemas.ts
@@ -183,7 +183,7 @@ export const PiChatEventSchema = z.discriminatedUnion('type', [
     clientSeq: z.number().int().nonnegative().optional(),
     messageId: nonEmptyString,
   }),
-  baseEvent.extend({ type: z.literal('file-changed'), path: nonEmptyString, changeType: nonEmptyString }),
+  baseEvent.extend({ type: z.literal('file-changed'), path: nonEmptyString, changeType: nonEmptyString, filesystem: nonEmptyString.optional() }),
   baseEvent.extend({ type: z.literal('ui-command'), command: ShallowPayloadSchema, displayOnly: z.literal(true) }),
   baseEvent.extend({ type: z.literal('usage'), usage: ShallowPayloadSchema }),
   baseEvent.extend({

--- a/packages/workspace/src/front/chrome/chat/ChatPanelHost.tsx
+++ b/packages/workspace/src/front/chrome/chat/ChatPanelHost.tsx
@@ -47,6 +47,9 @@ function workspaceAgentDataPart(part: unknown): unknown {
       op: typeof event.changeType === "string" ? event.changeType : "edit",
       path: event.path,
       toolCallId: typeof event.seq === "number" ? `pi:${event.seq}` : "pi:file-changed",
+      ...(typeof event.filesystem === "string" && event.filesystem.length > 0
+        ? { filesystem: event.filesystem }
+        : {}),
     },
   }
 }

--- a/packages/workspace/src/front/chrome/chat/__tests__/ChatPanelHost.test.tsx
+++ b/packages/workspace/src/front/chrome/chat/__tests__/ChatPanelHost.test.tsx
@@ -29,7 +29,7 @@ function FakeChatPanel({ onData, onOpenArtifact, composerBlockers, onComposerSto
       </button>
       <button
         type="button"
-        onClick={() => onData?.({ type: "file-changed", seq: 7, changeType: "write", path: "src/pi.ts" })}
+        onClick={() => onData?.({ type: "file-changed", seq: 7, changeType: "write", path: "/company/pi.ts", filesystem: "company_context" })}
       >
         emit pi file event
       </button>
@@ -108,7 +108,12 @@ describe("ChatPanelHost", () => {
     fireEvent.click(screen.getByRole("button", { name: "emit pi file event" }))
 
     expect(changed).toHaveBeenCalledWith(
-      expect.objectContaining({ path: "src/pi.ts", cause: "agent", toolCallId: "pi:7" }),
+      expect.objectContaining({
+        path: "/company/pi.ts",
+        filesystem: "company_context",
+        cause: "agent",
+        toolCallId: "pi:7",
+      }),
     )
   })
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/agentFileBridge.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/agentFileBridge.test.tsx
@@ -72,6 +72,15 @@ describe("filesystem agent file bridge", () => {
     )
   })
 
+  it("preserves the filesystem identity on agent file events", () => {
+    const fn = vi.fn()
+    events.on(filesystemEvents.created, fn)
+    emitFilesystemAgentFileChange(chunk("write", { existsBefore: false, filesystem: "company_context" }))
+    expect(fn).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "src/x.ts", filesystem: "company_context", cause: "agent" }),
+    )
+  })
+
   it.each([
     ["wrong type", { type: "data-other", data: { foo: "bar" } }],
     ["non-object", "not even an object"],
@@ -87,6 +96,10 @@ describe("filesystem agent file bridge", () => {
     [
       "missing toolCallId",
       { type: "data-file-changed", data: { op: "unlink", path: "x" } },
+    ],
+    [
+      "invalid filesystem",
+      { type: "data-file-changed", data: { op: "unlink", path: "x", toolCallId: "tc", filesystem: 42 } },
     ],
   ])("rejects %s", (_label, input) => {
     const moved = vi.fn()

--- a/packages/workspace/src/plugins/filesystemPlugin/front/agentFileBridge.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/agentFileBridge.tsx
@@ -6,6 +6,7 @@ import { useEvent } from "../../../front/events/useEvent"
 import { postUiCommand } from "../../../front/bridge"
 import { filesystemEvents } from "../shared/events"
 import type { FilesystemEventMeta } from "../shared/events"
+import type { FilesystemId } from "../../../shared/types/filesystem"
 
 type Op = "write" | "edit" | "unlink" | "rename" | "mkdir"
 
@@ -15,6 +16,7 @@ interface AgentFileChangedChunkData {
   oldPath?: string
   toolCallId: string
   existsBefore?: boolean
+  filesystem?: FilesystemId
 }
 
 const VALID_OPS: ReadonlySet<Op> = new Set([
@@ -48,13 +50,19 @@ function parseChunk(part: unknown): AgentFileChangedChunkData | null {
   ) {
     return null
   }
+  if (d.filesystem !== undefined && (typeof d.filesystem !== "string" || d.filesystem.length === 0)) {
+    return null
+  }
   return d as unknown as AgentFileChangedChunkData
 }
 
 export function emitFilesystemAgentFileChange(part: unknown): void {
   const data = parseChunk(part)
   if (!data) return
-  const meta = agentMeta(data.toolCallId)
+  const meta = {
+    ...agentMeta(data.toolCallId),
+    ...(data.filesystem ? { filesystem: data.filesystem } : {}),
+  }
 
   switch (data.op) {
     case "rename":


### PR DESCRIPTION
## Summary
- preserve the filesystem identity from a filesystem tool call through the Pi chat file-change event
- forward that identity through the workspace chat host and filesystem-event bridge
- let the active `company_context` Files tree refresh when an agent creates, edits, moves, or deletes a shared file

## Validation
- `pnpm --filter @hachej/boring-agent typecheck`
- `pnpm --filter @hachej/boring-workspace typecheck`
- focused Pi event/schema tests (25 passing)
- focused workspace chat/filesystem-bridge tests (27 passing)