### PR TITLE
fix(core): include workspace skills for core agents

### DIFF
--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@hachej/boring-agent/server', () => ({
   compactPiPackages: (packages: unknown[]) => packages,
+  createRemoteWorkerModeAdapter: () => ({ kind: 'remote-worker-adapter' }),
   provisionWorkspaceRuntime: mocks.provisionWorkspaceRuntime,
   registerAgentRoutes: mocks.registerAgentRoutes,
 }))
@@ -251,6 +252,83 @@ test('core/full-app can enable plugin CLI provisioning for remote plugin editing
     }))
   } finally {
     await app.close()
+  }
+})
+
+test('core/full-app resolves workspace skill paths from the request workspace root', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockImplementation(({ workspaceRoot }: { workspaceRoot: string }) => ({
+    runtimePlugins: [],
+    provisioningContributions: [],
+    agentOptions: {
+      extraTools: [],
+      pi: { additionalSkillPaths: [`${workspaceRoot}/.agents/skills`], packages: [] },
+      systemPromptAppend: undefined,
+    },
+    preservedUiStateKeys: [],
+    routeContributions: [],
+  }))
+
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    workspaceRoot: '/tmp/full-app-workspaces',
+    serveFrontend: false,
+    registerHealthRoute: false,
+  })
+
+  try {
+    const options = (mocks.registerAgentRoutes as any).mock.calls[0]?.[1] as Record<string, unknown>
+    const getPi = options.getPi as (ctx: { workspaceId: string; workspaceRoot: string }) => Promise<{ additionalSkillPaths?: string[] }>
+    await expect(getPi({ workspaceId: 'workspace-a', workspaceRoot: '/tmp/full-app-workspaces/workspace-a' })).resolves.toMatchObject({
+      additionalSkillPaths: ['/tmp/full-app-workspaces/workspace-a/.agents/skills'],
+    })
+    expect(mocks.collectWorkspaceAgentServerPlugins).toHaveBeenCalledWith(expect.objectContaining({
+      workspaceRoot: '/tmp/full-app-workspaces/workspace-a',
+    }))
+  } finally {
+    await app.close()
+  }
+})
+
+test('core/full-app preserves workspace skill discovery in remote worker mode', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockImplementation(({ workspaceRoot }: { workspaceRoot: string }) => ({
+    runtimePlugins: [],
+    provisioningContributions: [],
+    agentOptions: {
+      extraTools: [],
+      pi: { additionalSkillPaths: [`${workspaceRoot}/.agents/skills`], packages: [] },
+      systemPromptAppend: undefined,
+    },
+    preservedUiStateKeys: [],
+    routeContributions: [],
+  }))
+
+  const previousWorkerBaseUrl = process.env.BORING_WORKER_BASE_URL
+  process.env.BORING_WORKER_BASE_URL = 'https://worker.example.test'
+
+  try {
+    const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+    const app = await createCoreWorkspaceAgentServer({
+      config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+      workspaceRoot: '/tmp/full-app-workspaces',
+      serveFrontend: false,
+      registerHealthRoute: false,
+    })
+
+    try {
+      const options = (mocks.registerAgentRoutes as any).mock.calls[0]?.[1] as Record<string, unknown>
+      const getPi = options.getPi as (ctx: { workspaceId: string; workspaceRoot: string }) => Promise<{ additionalSkillPaths?: string[] }>
+      const pi = await getPi({ workspaceId: 'workspace-a', workspaceRoot: '/tmp/full-app-workspaces/workspace-a' })
+      expect(pi.additionalSkillPaths).toContain('/tmp/full-app-workspaces/workspace-a/.agents/skills')
+      expect(mocks.collectWorkspaceAgentServerPlugins).not.toHaveBeenCalledWith(expect.objectContaining({
+        workspaceRoot: '/tmp/full-app-workspaces/workspace-a',
+      }))
+    } finally {
+      await app.close()
+    }
+  } finally {
+    if (previousWorkerBaseUrl === undefined) delete process.env.BORING_WORKER_BASE_URL
+    else process.env.BORING_WORKER_BASE_URL = previousWorkerBaseUrl
   }
 })
 

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -240,6 +240,12 @@ function assertCoreStaticPluginEntries(entries: readonly unknown[] | undefined):
   }
 }
 
+const WORKSPACE_SKILLS_RELATIVE_PATH = path.join('.agents', 'skills')
+
+function workspaceSkillPiOptions(workspaceRoot: string): AgentPiOptions {
+  return { additionalSkillPaths: [path.join(workspaceRoot, WORKSPACE_SKILLS_RELATIVE_PATH)] }
+}
+
 function mergePiOptions(
   base?: AgentPiOptions,
   override?: AgentPiOptions,
@@ -971,12 +977,13 @@ export async function createCoreWorkspaceAgentServer(
     return scopedPluginCollection.agentOptions.pi
   }
   const resolvePiOptions: NonNullable<RegisterAgentRoutesOptions['getPi']> = async (ctx) => {
-    // In remote-worker mode the workspace filesystem lives on the worker. Do
-    // not scan per-workspace Pi skills/plugins from the public host path — it
-    // can be stale after volume cutover and would reintroduce split-brain. Keep
-    // only static app/plugin Pi config plus explicit caller overrides.
+    // Workspace skills are part of the user's workspace contract. In local
+    // modes, collect the full per-workspace plugin/Pi surface from the request
+    // root. In remote-worker mode, keep plugin/extension collection static to
+    // avoid host/worker split-brain, but still include the canonical workspace
+    // skill directory so `.agents/skills` remains discoverable.
     const pluginOptions = remoteWorkerModeAdapter
-      ? pluginCollection.agentOptions.pi
+      ? mergePiOptions(pluginCollection.agentOptions.pi, workspaceSkillPiOptions(ctx.workspaceRoot))
       : getPluginPiOptions(ctx.workspaceRoot)
     const bridgePiOptions = options.getWorkspaceBridgePi
       ? await options.getWorkspaceBridgePi({


### PR DESCRIPTION
## Summary

Clean replacement for #795. Implements #784 Slice 1 only: restores workspace skill discovery for core/full-app agents using canonical `.agents/skills`.

## Issue / Slice

- Fixes part of #784
- Slice: Restore and prove `feedback` skill discovery from `.agents/skills`
- Supersedes #795, which accidentally inherited attachment/history changes from its parent branch.

## What Changed

- Core agent Pi options now include the request workspace's `.agents/skills` path.
- Local/full-app mode still resolves the full per-workspace plugin/Pi surface from the request workspace root.
- Remote-worker mode preserves split-brain safeguards by not scanning per-workspace plugins/extensions from the host, but explicitly includes the canonical workspace skill directory.
- Added regression coverage for local request-root skill paths and remote-worker skill-path preservation.

## Proof

Previously passed on the same cherry-picked commit before creating this clean branch:
- `pnpm --dir packages/core exec vitest run src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts --no-file-parallelism` — passed, 1 file / 7 tests.
- `pnpm --filter @hachej/boring-core typecheck` — passed.

Clean-branch verification:
- `git diff --name-only origin/main...HEAD` shows only:
  - `packages/core/src/app/server/createCoreWorkspaceAgentServer.ts`
  - `packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts`
- Attempting to run tests inside the separate clean worktree failed because that worktree has no installed `vitest` binary/node_modules; no code failure was observed.

## Review

- Standards: reviewer pass after re-review on the same diff.
- Spec: reviewer pass after re-review on the same diff.
- Thermo: not run; slice is small, localized skill-path plumbing with targeted tests.
- Reviewed SHA from original branch: `5a099fb`
- Clean branch SHA: `c53bd71`

## Risk / Rollback

- Risk: remote-worker skill loading now depends on the canonical workspace skills path being readable/available in that runtime context. The implementation deliberately avoids scanning remote per-workspace plugins/extensions to preserve the prior split-brain safeguard.
- Rollback: revert this PR to restore previous core remote-worker Pi option behavior.

## Next

- Owner review / merge this clean PR.
- Close #795 as superseded.
- Attachment/history changes should live in their own PR/branch.
