### PR TITLE
Fix app-left new chat and active states

### DIFF
--- a/apps/workspace-playground/vite.config.ts
+++ b/apps/workspace-playground/vite.config.ts
@@ -119,6 +119,10 @@ export default defineConfig({
   server: {
     port: VITE_PORT,
     host: true,
+    hmr: {
+      host: process.env.VITE_HMR_HOST ?? "100.68.199.114",
+      clientPort: Number(process.env.VITE_HMR_CLIENT_PORT ?? VITE_PORT),
+    },
     fs: {
       allow: fsAllow,
     },

--- a/apps/workspace-playground/vite.config.ts
+++ b/apps/workspace-playground/vite.config.ts
@@ -11,7 +11,14 @@ const externalWorkspaceRoot = process.env.BORING_AGENT_WORKSPACE_ROOT?.trim()
 const externalRuntimeExtensionsRoot = externalWorkspaceRoot
   ? resolve(externalWorkspaceRoot, ".pi", "extensions")
   : undefined
-const fsAllow = externalRuntimeExtensionsRoot ? [repoRoot, externalRuntimeExtensionsRoot] : [repoRoot]
+const legacyWorkspaceRoot = process.env.BORING_AGENT_WORKSPACE_ROOT?.includes("/.worktrees/")
+  ? resolve(repoRoot, "../..")
+  : undefined
+const fsAllow = [
+  repoRoot,
+  ...(legacyWorkspaceRoot ? [legacyWorkspaceRoot] : []),
+  ...(externalRuntimeExtensionsRoot ? [externalRuntimeExtensionsRoot] : []),
+]
 // The playground is the standalone dev surface for the workspace
 // package — its src/ contains `@/` (workspace-src-rooted) imports that
 // the standard helper doesn't cover. Add those alongside the shared

--- a/packages/agent/src/core/piChatSessionService.ts
+++ b/packages/agent/src/core/piChatSessionService.ts
@@ -44,10 +44,17 @@ export type PiChatEventStreamResult = PiChatEventStreamSubscription | PiChatRepl
 
 export type PiChatEventSubscriber = (event: PiChatEvent) => void
 
+export interface PiChatAttachmentResult {
+  data: Uint8Array
+  mediaType: string
+  filename?: string
+}
+
 export interface PiChatSessionService {
   listSessions?(ctx: PiSessionRequestContext, options?: SessionListOptions): Promise<SessionSummary[]>
   createSession?(ctx: PiSessionRequestContext, init?: PiSessionCreateInit): Promise<SessionSummary>
   deleteSession?(ctx: PiSessionRequestContext, sessionId: string): Promise<void>
+  readAttachment?(ctx: PiSessionRequestContext, sessionId: string, messageId: string, index: number): Promise<PiChatAttachmentResult>
   readState(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot>
   subscribe(ctx: PiSessionRequestContext, sessionId: string, cursor: number, subscriber: PiChatEventSubscriber): Promise<PiChatEventStreamResult>
   prompt(ctx: PiSessionRequestContext, sessionId: string, payload: PromptPayload): Promise<PromptReceipt>
@@ -79,7 +86,7 @@ export class AgentEffectAdmissionError extends Error {
   }
 }
 
-type AgentEffectMethod = Exclude<keyof AgentCoreSessionService, 'listSessions' | 'readState' | 'subscribe' | 'dispose'>
+type AgentEffectMethod = Exclude<keyof AgentCoreSessionService, 'listSessions' | 'readAttachment' | 'readState' | 'subscribe' | 'dispose'>
 
 export const AGENT_EFFECT_METHODS = {
   createSession: true,
@@ -101,6 +108,9 @@ export function withAgentEffectAdmission(
       : {}),
     async createSession(ctx, init) { await admit(ctx); return service.createSession(ctx, init) },
     async deleteSession(ctx, sessionId) { await admit(ctx); return service.deleteSession(ctx, sessionId) },
+    ...(service.readAttachment
+      ? { readAttachment: (ctx, sessionId, messageId, index) => service.readAttachment!(ctx, sessionId, messageId, index) }
+      : {}),
     readState: (ctx, sessionId) => service.readState(ctx, sessionId),
     subscribe: (ctx, sessionId, cursor, subscriber) => service.subscribe(ctx, sessionId, cursor, subscriber),
     async prompt(ctx, sessionId, payload) { await admit(ctx); return service.prompt(ctx, sessionId, payload) },

--- a/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
+++ b/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
@@ -84,11 +84,15 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
           >
             {fileParts.map((file, index) => {
               const openPath = file.path ?? attachmentSummaryPaths[index]
-              const canOpen = Boolean(openArtifact && openPath)
+              const openUrl = file.url && !openPath ? file.url : undefined
+              const canOpen = Boolean((openArtifact && openPath) || openUrl)
               const openAttachment = () => {
-                if (!openPath) return
-                if (file.filesystem) openArtifact?.(openPath, { filesystem: file.filesystem })
-                else openArtifact?.(openPath)
+                if (openPath) {
+                  if (file.filesystem) openArtifact?.(openPath, { filesystem: file.filesystem })
+                  else openArtifact?.(openPath)
+                  return
+                }
+                if (openUrl) window.open(openUrl, '_blank', 'noopener,noreferrer')
               }
               const openAttachmentFromKeyboard = (event: ReactKeyboardEvent<HTMLDivElement>) => {
                 if (event.key !== 'Enter' && event.key !== ' ') return
@@ -104,9 +108,9 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
                     ? {
                         role: 'button',
                         tabIndex: 0,
-                        title: `Open ${openPath} in workspace`,
-                        'aria-label': `Open ${file.filename ?? openPath} in workspace`,
-                        'data-workspace-path': openPath,
+                        title: openPath ? `Open ${openPath} in workspace` : `Open ${file.filename ?? 'attachment'}`,
+                        'aria-label': openPath ? `Open ${file.filename ?? openPath} in workspace` : `Open ${file.filename ?? 'attachment'}`,
+                        ...(openPath ? { 'data-workspace-path': openPath } : {}),
                         onClick: openAttachment,
                         onKeyDown: openAttachmentFromKeyboard,
                       }

--- a/packages/agent/src/front/chat/components/__tests__/PiTimelineMessage.test.tsx
+++ b/packages/agent/src/front/chat/components/__tests__/PiTimelineMessage.test.tsx
@@ -170,6 +170,24 @@ describe('PiTimelineMessage', () => {
     expect(onOpenArtifact).toHaveBeenCalledWith('assets/images/image.png')
   })
 
+  test('opens lazy history attachment chips by URL when no workspace path is available', () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null)
+    const message: BoringChatMessage = {
+      id: 'u-lazy-url',
+      role: 'user',
+      status: 'done',
+      parts: [
+        { type: 'file', id: 'u-lazy-url:file', filename: 'image.png', mediaType: 'image/png', url: '/api/v1/agent/pi-chat/pi-1/attachments/m-user-image/1' },
+      ],
+    }
+
+    render(<PiTimelineMessage message={message} isLast={false} isStreaming={false} showThoughts={false} toolRenderers={{}} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open image.png' }))
+    expect(open).toHaveBeenCalledWith('/api/v1/agent/pi-chat/pi-1/attachments/m-user-image/1', '_blank', 'noopener,noreferrer')
+    open.mockRestore()
+  })
+
   test('opens recovered history attachment chips using the stripped workspace path note', () => {
     const onOpenArtifact = vi.fn()
     const message: BoringChatMessage = {

--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/sessions.load.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/sessions.load.test.ts
@@ -116,6 +116,52 @@ describe("PiSessionStore.loadEntries transcript reconstruction", () => {
     await expect(store.list(ctx)).resolves.toEqual([]);
   });
 
+  it("serves historical image attachment bytes from the raw transcript without requiring /state to inline them", async () => {
+    const sessionId = "sess-image-history";
+    const filepath = join(tmpDir, `${sessionId}.jsonl`);
+    const imageBase64 = Buffer.from("tiny-png-bytes").toString("base64");
+    const lines = [
+      {
+        type: "session",
+        version: 1,
+        id: sessionId,
+        timestamp: "2026-05-01T00:00:00.000Z",
+        cwd: "/workspace",
+      },
+      {
+        type: "message",
+        id: "m-user-image",
+        parentId: null,
+        timestamp: "2026-05-01T00:00:01.000Z",
+        message: {
+          role: "user",
+          content: [
+            { type: "text", text: "attached" },
+            { type: "image", mimeType: "image/png", filename: "image.png", data: imageBase64 },
+          ],
+        },
+      },
+    ];
+    await writeFile(filepath, `${lines.map((line) => JSON.stringify(line)).join("\n")}\n`, "utf-8");
+
+    const store = new PiSessionStore("/workspace", tmpDir);
+    const { id, messages } = await store.loadEntries(ctx, sessionId);
+    const history = buildPiChatHistory(messages, {
+      sessionId: id,
+      attachmentUrl: ({ messageId, index }) => `/api/v1/agent/pi-chat/${id}/attachments/${messageId}/${index}`,
+    });
+    const attachment = await store.loadAttachment(ctx, sessionId, "m-user-image", 1);
+
+    expect(history[0].id).toBe("m-user-image");
+    expect(history[0].parts).toEqual([
+      { type: "text", id: "m-user-image:text:0", text: "attached" },
+      { type: "file", id: "m-user-image:file:1", filename: "image.png", mediaType: "image/png", url: `/api/v1/agent/pi-chat/${sessionId}/attachments/m-user-image/1` },
+    ]);
+    expect(attachment.mediaType).toBe("image/png");
+    expect(attachment.filename).toBe("image.png");
+    expect(Buffer.from(attachment.data).toString()).toBe("tiny-png-bytes");
+  });
+
   it("drops empty assistant turns out of the rebuilt history", async () => {
     const sessionId = "sess-empty-assistant";
     const filepath = join(tmpDir, `${sessionId}.jsonl`);

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -38,6 +38,12 @@ export interface PiSessionEntries {
   messages: unknown[];
 }
 
+export interface PiSessionAttachment {
+  data: Buffer;
+  mediaType: string;
+  filename?: string;
+}
+
 function sessionBaseDir(explicitRoot?: string): string {
   const explicit = explicitRoot?.trim();
   if (explicit) return resolve(explicit);
@@ -244,8 +250,24 @@ export class PiSessionStore implements SessionStore {
     const resolved = await this.resolveSessionTranscript(ctx, sessionId);
     const messages = resolved.transcriptEntries
       .filter((entry): entry is SessionMessageEntry => entry.type === "message")
-      .map((entry) => entry.message);
+      .map((entry) => withStableMessageId(entry.message, entry.id));
     return { id: resolved.resolvedSessionId, messages };
+  }
+
+  async loadAttachment(ctx: SessionCtx, sessionId: string, messageId: string, index: number): Promise<PiSessionAttachment> {
+    const resolved = await this.resolveSessionTranscript(ctx, sessionId);
+    const entry = resolved.transcriptEntries
+      .filter((item): item is SessionMessageEntry => item.type === "message")
+      .find((item) => item.id === messageId || messageIdFromPiMessage(item.message) === messageId);
+    const part = entry ? piImagePartAt(entry.message, index) : null;
+    if (!part) throw new Error(`Session attachment not found: ${sessionId}`);
+    const data = imagePartBuffer(part);
+    if (!data) throw new Error(`Session attachment not found: ${sessionId}`);
+    return {
+      data,
+      mediaType: part.mimeType ?? "application/octet-stream",
+      ...(part.filename ? { filename: part.filename } : {}),
+    };
   }
 
   private async resolveSessionTranscript(ctx: SessionCtx, sessionId: string): Promise<{
@@ -972,4 +994,44 @@ function textFromPiContent(content: unknown): string {
       return item?.type === "text" && typeof item.text === "string" ? item.text : "";
     })
     .join("");
+}
+
+function withStableMessageId(message: unknown, entryId: string | undefined): unknown {
+  if (!entryId || !message || typeof message !== "object" || Array.isArray(message)) return message;
+  if (typeof (message as { id?: unknown }).id === "string") return message;
+  return { ...message, id: entryId };
+}
+
+function messageIdFromPiMessage(message: unknown): string | undefined {
+  if (!message || typeof message !== "object" || Array.isArray(message)) return undefined;
+  const id = (message as { id?: unknown }).id;
+  return typeof id === "string" && id.length > 0 ? id : undefined;
+}
+
+function piImagePartAt(message: unknown, index: number): { type: "image"; data?: string; mimeType?: string; filename?: string } | null {
+  if (!Number.isInteger(index) || index < 0) return null;
+  if (!message || typeof message !== "object" || Array.isArray(message)) return null;
+  const content = (message as { content?: unknown }).content;
+  if (!Array.isArray(content)) return null;
+  const part = content[index];
+  if (!part || typeof part !== "object" || Array.isArray(part)) return null;
+  const record = part as { type?: unknown; data?: unknown; mimeType?: unknown; filename?: unknown };
+  if (record.type !== "image") return null;
+  return {
+    type: "image",
+    ...(typeof record.data === "string" ? { data: record.data } : {}),
+    ...(typeof record.mimeType === "string" && record.mimeType.length > 0 ? { mimeType: record.mimeType } : {}),
+    ...(typeof record.filename === "string" && record.filename.length > 0 ? { filename: record.filename } : {}),
+  };
+}
+
+function imagePartBuffer(part: { data?: string }): Buffer | null {
+  const raw = part.data;
+  if (!raw) return null;
+  const match = raw.match(/^data:[^;]+;base64,(.+)$/);
+  try {
+    return Buffer.from(match ? match[1] : raw, "base64");
+  } catch {
+    return null;
+  }
 }

--- a/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
@@ -52,8 +52,9 @@ class FakePiChatService implements PiChatSessionService {
   ]
   events: PiChatEvent[] = []
   subscriptionResult: Awaited<ReturnType<PiChatSessionService['subscribe']>> | undefined
+  attachment = { data: Buffer.from('image-bytes'), mediaType: 'image/png', filename: 'image.png' }
   readonly unsubscribe = vi.fn()
-  readonly calls: Array<{ method: string; ctx: PiSessionRequestContext; sessionId?: string; payload?: unknown; cursor?: number; options?: SessionListOptions }> = []
+  readonly calls: Array<{ method: string; ctx: PiSessionRequestContext; sessionId?: string; messageId?: string; index?: number; payload?: unknown; cursor?: number; options?: SessionListOptions }> = []
 
   async listSessions(ctx: PiSessionRequestContext, options?: SessionListOptions) {
     this.calls.push({ method: 'listSessions', ctx, options })
@@ -75,6 +76,11 @@ class FakePiChatService implements PiChatSessionService {
   async readState(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot> {
     this.calls.push({ method: 'readState', ctx, sessionId })
     return this.snapshot
+  }
+
+  async readAttachment(ctx: PiSessionRequestContext, sessionId: string, messageId: string, index: number) {
+    this.calls.push({ method: 'readAttachment', ctx, sessionId, messageId, index })
+    return this.attachment
   }
 
   async subscribe(ctx: PiSessionRequestContext, sessionId: string, cursor: number, subscriber: (event: PiChatEvent) => void) {
@@ -224,6 +230,30 @@ describe('piChatRoutes', () => {
     expect(service.calls[0]).toMatchObject({
       method: 'readState',
       sessionId: 'pi-1',
+      ctx: { workspaceId: 'workspace-a', storageScope: 'scope-a', authSubject: 'user-a', requestId: expect.any(String) },
+    })
+
+    await app.close()
+  })
+
+  test('GET /attachments streams a scoped historical Pi image attachment', async () => {
+    const { app, service } = await buildApp()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/agent/pi-chat/pi-1/attachments/m-user-image/1',
+      headers: { 'x-boring-storage-scope': 'scope-a' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.headers['content-type']).toContain('image/png')
+    expect(res.headers['x-content-type-options']).toBe('nosniff')
+    expect(res.body).toBe('image-bytes')
+    expect(service.calls[0]).toMatchObject({
+      method: 'readAttachment',
+      sessionId: 'pi-1',
+      messageId: 'm-user-image',
+      index: 1,
       ctx: { workspaceId: 'workspace-a', storageScope: 'scope-a', authSubject: 'user-a', requestId: expect.any(String) },
     })
 

--- a/packages/agent/src/server/http/routes/piChat.ts
+++ b/packages/agent/src/server/http/routes/piChat.ts
@@ -33,6 +33,14 @@ const SessionParamsSchema = z.object({
   sessionId: z.string().min(1).max(128),
 })
 
+const AttachmentParamsSchema = SessionParamsSchema.extend({
+  messageId: z.string().min(1).max(512),
+  index: z.preprocess((value) => {
+    if (typeof value === 'string' && value.length > 0) return Number(value)
+    return value
+  }, z.number().int().nonnegative()),
+})
+
 const CursorValueSchema: z.ZodType<number, z.ZodTypeDef, unknown> = z.preprocess((value) => {
   if (value === undefined) return 0
   if (typeof value === 'string' && value.length > 0) return Number(value)
@@ -149,6 +157,27 @@ export function piChatRoutes(
       return reply.send(PiChatSnapshotSchema.parse(snapshot))
     } catch (err) {
       return sendRouteError(reply, err, 'read pi chat state failed')
+    }
+  })
+
+  app.get('/api/v1/agent/pi-chat/:sessionId/attachments/:messageId/:index', async (request, reply) => {
+    const params = parseWithSchema(AttachmentParamsSchema, request.params, reply, 'params')
+    if (!params) return
+
+    try {
+      const service = await resolveService(opts, request)
+      if (!service.readAttachment) throw unsupportedServiceMethod('read Pi chat attachment')
+      const attachment = await service.readAttachment(getRequestContext(request), params.sessionId, params.messageId, params.index)
+      if (!attachment.mediaType.startsWith('image/')) {
+        throw new PiChatRouteError({ statusCode: 404, code: ErrorCode.enum.SESSION_NOT_FOUND, message: 'attachment not found' })
+      }
+      return reply
+        .header('Content-Type', attachment.mediaType)
+        .header('Cache-Control', 'private, max-age=300')
+        .header('X-Content-Type-Options', 'nosniff')
+        .send(Buffer.from(attachment.data))
+    } catch (err) {
+      return sendRouteError(reply, err, 'read pi chat attachment failed')
     }
   })
 

--- a/packages/agent/src/server/pi-chat/__tests__/piChatHistory.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/piChatHistory.test.ts
@@ -66,6 +66,38 @@ describe('buildPiChatHistory', () => {
     expect(history[3]?.parts).toEqual([{ type: 'text', id: 'entry-notice:text:0', text: 'custom notice' }])
   })
 
+  it('can map persisted image parts to lazy attachment URLs instead of inlining base64 into /state', () => {
+    const history = buildPiChatHistory(
+      [
+        {
+          id: 'entry-user',
+          message: {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'see image' },
+              { type: 'image', data: 'base64-bytes', mimeType: 'image/png', filename: 'image.png' },
+            ],
+          },
+        },
+      ],
+      {
+        sessionId: 'session-1',
+        attachmentUrl: ({ messageId, index }) => `/api/v1/agent/pi-chat/session-1/attachments/${messageId}/${index}`,
+      },
+    )
+
+    expect(history[0]?.parts).toEqual([
+      { type: 'text', id: 'entry-user:text:0', text: 'see image' },
+      {
+        type: 'file',
+        id: 'entry-user:file:1',
+        filename: 'image.png',
+        mediaType: 'image/png',
+        url: '/api/v1/agent/pi-chat/session-1/attachments/entry-user/1',
+      },
+    ])
+  })
+
   it('attaches tool results to the owning assistant tool part by toolCallId', () => {
     const history = buildPiChatHistory(
       [

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -34,6 +34,7 @@ const PROMPT_IMAGE_EXTENSIONS = new Set(['.avif', '.gif', '.jpg', '.jpeg', '.png
  * as the live event path. */
 type PiSessionStoreLike = SessionStore & {
   loadEntries?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string) => Promise<{ id: string; messages: unknown[] }>
+  loadAttachment?: (ctx: { workspaceId?: string; userId?: string }, sessionId: string, messageId: string, index: number) => Promise<{ data: Uint8Array; mediaType: string; filename?: string }>
 }
 
 interface LiveSessionChannel {
@@ -211,6 +212,17 @@ export class HarnessPiChatService implements PiChatSessionService {
     if (teardownError) throw teardownError
   }
 
+  async readAttachment(ctx: PiSessionRequestContext, sessionId: string, messageId: string, index: number) {
+    return this.lifecycle.run(async () => {
+      if (!this.sessionStore.loadAttachment) throw Object.assign(new Error('session attachment not found'), { code: ErrorCode.enum.SESSION_NOT_FOUND })
+      try {
+        return await this.sessionStore.loadAttachment(toSessionCtx(ctx), sessionId, messageId, index)
+      } catch {
+        throw Object.assign(new Error('attachment not found'), { code: ErrorCode.enum.SESSION_NOT_FOUND })
+      }
+    })
+  }
+
   async readState(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot> {
     return this.lifecycle.run(() => this.readStateBeforeDispose(ctx, sessionId))
   }
@@ -248,7 +260,10 @@ export class HarnessPiChatService implements PiChatSessionService {
         sessionId: id,
         seq: await this.readDurableLatestPiChatSeq(sessionStreamPath(this.sessionKey(ctx, id))),
         status: 'idle',
-        messages: buildPiChatHistory(messages, { sessionId: id }),
+        messages: buildPiChatHistory(messages, {
+          sessionId: id,
+          attachmentUrl: ({ messageId, index }) => `/api/v1/agent/pi-chat/${encodeURIComponent(id)}/attachments/${encodeURIComponent(messageId)}/${index}`,
+        }),
         queue: { followUps: [] },
         followUpMode: 'one-at-a-time',
       }

--- a/packages/agent/src/server/pi-chat/piChatHistory.ts
+++ b/packages/agent/src/server/pi-chat/piChatHistory.ts
@@ -10,6 +10,7 @@ export interface BuildPiChatHistoryOptions {
   sessionId: string
   turnId?: string
   messageTurnIds?: ReadonlyMap<string, string>
+  attachmentUrl?: (attachment: { messageId: string; index: number }) => string | undefined
 }
 
 type RecordLike = Record<string, unknown>
@@ -59,18 +60,19 @@ function textFromContent(content: unknown): string | undefined {
   return text.length > 0 ? text : undefined
 }
 
-function filePartsFromContent(content: unknown, messageId: string): BoringChatPart[] {
+function filePartsFromContent(content: unknown, messageId: string, options?: Pick<BuildPiChatHistoryOptions, 'attachmentUrl'>): BoringChatPart[] {
   if (!Array.isArray(content)) return []
   return content.flatMap((part, index): BoringChatPart[] => {
     if (!isRecord(part) || part.type !== 'image') return []
     const mediaType = optionalString(part.mimeType)
+    const url = options?.attachmentUrl?.({ messageId, index }) ?? imagePartUrl(part, mediaType)
     return [
       {
         type: 'file',
         id: `${messageId}:file:${index}`,
         ...(optionalString(part.filename) ? { filename: optionalString(part.filename) } : {}),
         ...(mediaType ? { mediaType } : {}),
-        ...(imagePartUrl(part, mediaType) ? { url: imagePartUrl(part, mediaType) } : {}),
+        ...(url ? { url } : {}),
         ...(optionalString(part.path) ? { path: optionalString(part.path) } : {}),
       },
     ]
@@ -91,11 +93,11 @@ function imagePartUrl(part: RecordLike, mediaType: string | undefined): string |
   return `data:${mediaType ?? 'application/octet-stream'};base64,${data}`
 }
 
-function userParts(message: RecordLike, messageId: string): BoringChatPart[] {
+function userParts(message: RecordLike, messageId: string, options?: Pick<BuildPiChatHistoryOptions, 'attachmentUrl'>): BoringChatPart[] {
   const parts: BoringChatPart[] = []
   const text = textFromContent(message.content)
   if (text !== undefined) parts.push({ type: 'text', id: `${messageId}:text:0`, text })
-  parts.push(...filePartsFromContent(message.content, messageId))
+  parts.push(...filePartsFromContent(message.content, messageId, options))
   return parts
 }
 
@@ -220,7 +222,7 @@ export function buildPiChatHistory(entries: readonly unknown[], options: BuildPi
     }
 
     if (role === 'user') {
-      messages.push({ ...base, role: 'user', status: 'done', parts: userParts(entry.message, id) })
+      messages.push({ ...base, role: 'user', status: 'done', parts: userParts(entry.message, id, options) })
       return
     }
 

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1637,6 +1637,7 @@ export function WorkspaceAgentFront<
   })
   const createChatSessionInPopover = useCallback(() => {
     setLeftOverlay(null)
+    const previousActiveId = effectiveActiveSessionId ?? activeChatPaneId
     const created = resolvedCreate()
     void Promise.resolve(created).then((session) => {
       const id = createdSessionId(session)
@@ -1645,12 +1646,15 @@ export function WorkspaceAgentFront<
         title: defaultSessionTitle,
         composingEnabled: true,
       })
+      // Quick chat is an auxiliary popover: creating it must not steal the
+      // selected/full chat from the main stage or left session list.
+      if (previousActiveId && previousActiveId !== id) rawSwitch(previousActiveId)
     }).catch(() => {
       // Creation errors are surfaced by the session API/chat layer; the menu
       // should not leave a stale detached chat behind.
     })
     return created
-  }, [defaultSessionTitle, resolvedCreate, shellCapabilitiesHost.shellCapabilities])
+  }, [activeChatPaneId, defaultSessionTitle, effectiveActiveSessionId, rawSwitch, resolvedCreate, shellCapabilitiesHost.shellCapabilities])
   const providerPanels = baseProviderPanels
   const pluginAppLeftActions = usePluginAppLeftActions({ plugins: capturedPlugins, activeOverlay: leftOverlay, setActiveOverlay: setLeftOverlay })
   const chatTopOverlayActions = useMemo(() => {

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -118,6 +118,7 @@ export interface WorkspaceAgentAppLeftAction {
   onClick: () => void
   trailing?: ReactNode
   emphasis?: boolean
+  active?: boolean
 }
 
 export interface WorkspaceAgentAppLeftOverlayRenderProps {
@@ -386,6 +387,22 @@ function pluginReloadMessage(payload: { reloaded?: boolean; diagnostics?: Array<
   return diagnosticMessages.length > 0
     ? `${base}\n\nWarnings:\n${diagnosticMessages.join("\n")}`
     : base
+}
+
+function focusActiveAgentComposer(): void {
+  if (typeof document === "undefined") return
+  const activePane = document.querySelector<HTMLElement>('[data-boring-workspace-part="chat-pane"][data-boring-state="active"]')
+  const root: Document | HTMLElement = activePane ?? document
+  const textarea = root.querySelector<HTMLTextAreaElement>('[data-boring-agent] textarea[name="message"], textarea[name="message"]')
+  textarea?.focus()
+}
+
+function scheduleActiveAgentComposerFocus(): void {
+  if (typeof window === "undefined") return
+  window.requestAnimationFrame(() => {
+    focusActiveAgentComposer()
+    window.setTimeout(focusActiveAgentComposer, 320)
+  })
 }
 
 function readStoredSessionId(storageKey: string): string | null {
@@ -1283,10 +1300,16 @@ export function WorkspaceAgentFront<
   }, [chatPaneState, chatSessionId, rawSwitch, workspaceId])
 
   const createChatSession = useCallback(() => {
+    const pendingCreatePane = {
+      afterId: activeChatPaneId,
+      knownIds: new Set(resolvedSessions.map((session) => session.id)),
+    }
+    pendingCreatePaneRef.current = pendingCreatePane
     const created = resolvedCreate()
     void Promise.resolve(created).then((session) => {
       const id = createdSessionId(session)
       if (!id) return
+      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = { ...pendingCreatePane, createdId: id }
       setChatPaneState((previous) => {
         const current = previous.workspaceId === workspaceId
           ? previous
@@ -1299,13 +1322,18 @@ export function WorkspaceAgentFront<
           activeId: id,
         }
       })
-      rawSwitch(id)
+      // The remote session API's create() already selects/persists the new
+      // session. Calling switch() immediately after create races against its
+      // stale sessionsRef and can snap back to the previous session.
+      if (!sessionApi) rawSwitch(id)
+      scheduleActiveAgentComposerFocus()
     }).catch(() => {
+      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
       // Creation errors are surfaced by the session API/chat layer; the left
       // action should not leave stale optimistic panes behind.
     })
     return created
-  }, [chatSessionId, rawSwitch, resolvedCreate, workspaceId])
+  }, [activeChatPaneId, chatSessionId, rawSwitch, resolvedCreate, resolvedSessions, sessionApi, workspaceId])
 
   const createChatPaneAfter = useCallback((afterId: string) => {
     const pendingCreatePane = {
@@ -1328,11 +1356,13 @@ export function WorkspaceAgentFront<
           activeId: id,
         }
       })
+      if (!sessionApi) rawSwitch(id)
+      scheduleActiveAgentComposerFocus()
     }).catch(() => {
       if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
     })
     return created
-  }, [chatSessionId, resolvedCreate, resolvedSessions, workspaceId])
+  }, [chatSessionId, rawSwitch, resolvedCreate, resolvedSessions, sessionApi, workspaceId])
 
   const deleteSessionAndPane = useCallback((sessionId: string) => {
     const current = chatPaneState.workspaceId === workspaceId
@@ -1605,6 +1635,22 @@ export function WorkspaceAgentFront<
     surfaceDispatch,
     onDockOverlay: () => setLeftOverlay(null),
   })
+  const createChatSessionInPopover = useCallback(() => {
+    setLeftOverlay(null)
+    const created = resolvedCreate()
+    void Promise.resolve(created).then((session) => {
+      const id = createdSessionId(session)
+      if (!id) return
+      shellCapabilitiesHost.shellCapabilities.openDetachedChat(id, {
+        title: defaultSessionTitle,
+        composingEnabled: true,
+      })
+    }).catch(() => {
+      // Creation errors are surfaced by the session API/chat layer; the menu
+      // should not leave a stale detached chat behind.
+    })
+    return created
+  }, [defaultSessionTitle, resolvedCreate, shellCapabilitiesHost.shellCapabilities])
   const providerPanels = baseProviderPanels
   const pluginAppLeftActions = usePluginAppLeftActions({ plugins: capturedPlugins, activeOverlay: leftOverlay, setActiveOverlay: setLeftOverlay })
   const chatTopOverlayActions = useMemo(() => {
@@ -1645,6 +1691,7 @@ export function WorkspaceAgentFront<
         icon: action.icon,
         trailing: action.trailing,
         emphasis: action.emphasis,
+        active: leftOverlay === action.id,
         onClick: () => setLeftOverlay((cur) => cur === action.id ? null : action.id),
       })
     }
@@ -1653,6 +1700,7 @@ export function WorkspaceAgentFront<
         id: "plugins",
         label: "Plugins",
         icon: <Plug className="h-4 w-4" strokeWidth={1.75} />,
+        active: leftOverlay === "plugins",
         onClick: () => setLeftOverlay((cur) => cur === "plugins" ? null : "plugins"),
       })
     }
@@ -1661,12 +1709,13 @@ export function WorkspaceAgentFront<
         id: "skills",
         label: "Skills",
         icon: <Sparkles className="h-4 w-4" strokeWidth={1.75} />,
+        active: leftOverlay === "skills",
         onClick: () => setLeftOverlay((cur) => cur === "skills" ? null : "skills"),
       })
     }
     assertUniqueAppLeftActionIds(actions)
     return actions
-  }, [appLeftActions, appLeftOverlayActions, pluginAppLeftActions, pluginsActionEnabled, skillsActionEnabled])
+  }, [appLeftActions, appLeftOverlayActions, leftOverlay, pluginAppLeftActions, pluginsActionEnabled, skillsActionEnabled])
 
   const pluginLeftOverlayNode = PluginAppLeftOverlayHost({
     plugins: capturedPlugins,
@@ -1796,12 +1845,18 @@ export function WorkspaceAgentFront<
           bottomSlot={showThemeToggle || topBarRight != null ? <div className="flex w-full min-w-0 items-center gap-2">{topBarRightContent}</div> : undefined}
           sessions={resolvedSessions}
           activeSessionId={activeChatPaneId}
+          muteActiveSession={Boolean(leftOverlay)}
           openSessionIds={chatPaneIds}
           pinnedSessionIds={pinnedIds}
           onCreateSession={() => {
             setLeftOverlay(null)
-            void createChatSessionPreferNewPane()
+            void createChatSession()
           }}
+          onCreateSplitSession={() => {
+            setLeftOverlay(null)
+            void createChatPaneAfter(activeChatPaneId)
+          }}
+          onCreatePopoverSession={createChatSessionInPopover}
           onOpenCommandPalette={openCommandPalette}
           onSwitchSession={switchToChatPane}
           onOpenSessionAsPane={openChatPane}

--- a/packages/workspace/src/front/detached/DetachedPanelPopover.tsx
+++ b/packages/workspace/src/front/detached/DetachedPanelPopover.tsx
@@ -21,7 +21,7 @@ export function DetachedPanelPopover({
   return (
     <div
       data-boring-workspace-part="detached-panel-popover"
-      className="absolute z-[90] flex max-h-[calc(100vh-2rem)] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl border border-border/70 bg-background shadow-2xl"
+      className="absolute z-[120] flex max-h-[calc(100vh-2rem)] max-w-[calc(100vw-2rem)] flex-col overflow-hidden rounded-2xl border border-border/70 bg-background shadow-2xl"
       style={{
         left: position.left,
         top: position.top,

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react"
 import { Plus, Search } from "lucide-react"
 import { AppLeftPaneHeader } from "./AppLeftPaneHeader"
-import { PrimaryAction, KbdHint } from "./AppLeftPaneActions"
+import { PrimaryAction, NewChatAction, KbdHint } from "./AppLeftPaneActions"
 import { ProjectOverview, usePinnedProjectIds } from "./AppLeftPaneProjects"
 import { AppSessionRow, type AppSessionRowState } from "./AppLeftPaneSessionRow"
 import { SessionSubSection } from "./AppLeftPaneSections"
@@ -70,9 +70,13 @@ export interface AppLeftPaneProps {
   headerMode?: AppLeftPaneHeaderMode
   sessions: AppLeftPaneSession[]
   activeSessionId?: string | null
+  /** When an app-left overlay is active, the overlay owns the selected nav state. */
+  muteActiveSession?: boolean
   openSessionIds: readonly string[]
   pinnedSessionIds: readonly string[]
   onCreateSession: () => void
+  onCreateSplitSession?: () => void
+  onCreatePopoverSession?: () => void
   onOpenCommandPalette: () => void
   onSwitchSession: (id: string) => void
   onOpenSessionAsPane: (id: string) => void
@@ -131,9 +135,12 @@ export function AppLeftPane({
   headerMode = "full",
   sessions,
   activeSessionId,
+  muteActiveSession = false,
   openSessionIds,
   pinnedSessionIds,
   onCreateSession,
+  onCreateSplitSession,
+  onCreatePopoverSession,
   onOpenCommandPalette,
   onSwitchSession,
   onOpenSessionAsPane,
@@ -213,7 +220,7 @@ export function AppLeftPane({
   const headerShowsBrand = headerMode === "full" && layoutMode !== "multi-project"
   const renderSession = (session: AppLeftPaneSession, pinned: boolean, projectId = activeProjectId ?? undefined) => {
     const isActiveProjectSession = !projectId || projectId === activeProjectId
-    const state: SessionRowState = isActiveProjectSession && session.id === activeSessionId
+    const state: SessionRowState = isActiveProjectSession && session.id === activeSessionId && !muteActiveSession
       ? "active"
       : isActiveProjectSession && openSet.has(session.id)
         ? "open"
@@ -284,7 +291,6 @@ export function AppLeftPane({
       )}
 
       <nav className="shrink-0 space-y-0.5 px-2 pb-1 pt-1" aria-label="Primary workspace actions">
-        <PrimaryAction icon={<Plus className="h-4 w-4" strokeWidth={2} />} label="New chat" onClick={onCreateSession} emphasis />
         <PrimaryAction icon={<Search className="h-4 w-4" strokeWidth={1.75} />} label="Search" onClick={onOpenCommandPalette} trailing={<KbdHint keys="⌘K" />} />
         {actions.map((action) => (
           <PrimaryAction
@@ -300,6 +306,9 @@ export function AppLeftPane({
       </nav>
 
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        <div className="pb-2">
+          <NewChatAction icon={<Plus className="h-4 w-4" strokeWidth={2} />} onCreateSession={onCreateSession} onCreateSplitSession={onCreateSplitSession} onCreatePopoverSession={onCreatePopoverSession} />
+        </div>
         {/* Multi-project (PR2): the Workspaces/projects tree. Single-project
             shows no projects section — the workspace lives in the header above
             and the body is just the session list. */}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type { ReactNode } from "react"
+import { Columns2, Zap } from "lucide-react"
 import { cn } from "../../lib/utils"
 
 export function PrimaryAction({
@@ -22,21 +23,82 @@ export function PrimaryAction({
     <button
       type="button"
       onClick={onClick}
+      data-active={active ? "true" : undefined}
       className={cn(
-        "flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+        "relative flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
         active
-          ? "bg-foreground/[0.08] text-foreground shadow-sm ring-1 ring-border/60"
+          // When an overlay is open, it owns the selected nav state.
+          ? "bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-foreground hover:bg-[color:oklch(from_var(--accent)_l_c_h/0.18)]"
           : emphasis
-            // Primary CTA: a solid (borderless) filled surface so it reads as a
-            // button, not an input field.
-            ? "bg-foreground/[0.06] text-foreground hover:bg-foreground/[0.1]"
+            ? "text-foreground hover:bg-foreground/[0.045]"
             : "text-foreground/82 hover:bg-foreground/[0.055] hover:text-foreground",
       )}
     >
-      <span className={cn("grid size-5 shrink-0 place-items-center", active || emphasis ? "text-foreground/90" : "text-muted-foreground")} aria-hidden="true">{icon}</span>
+      <span className={cn("grid size-5 shrink-0 place-items-center", active ? "text-[color:var(--accent)]" : emphasis ? "text-foreground/90" : "text-muted-foreground")} aria-hidden="true">{icon}</span>
       <span className="min-w-0 flex-1 truncate">{label}</span>
+      {active ? <span aria-hidden="true" className="size-1.5 shrink-0 rounded-full bg-[color:var(--accent)]" /> : null}
       {trailing ? <span className="shrink-0">{trailing}</span> : null}
     </button>
+  )
+}
+
+export function NewChatAction({
+  icon,
+  onCreateSession,
+  onCreateSplitSession,
+  onCreatePopoverSession,
+}: {
+  icon: ReactNode
+  onCreateSession: () => void
+  onCreateSplitSession?: () => void
+  onCreatePopoverSession?: () => void
+}) {
+  return (
+    <div className="group flex h-8 w-full items-center rounded-md text-[13px] font-medium text-foreground transition-colors hover:bg-foreground/[0.045] focus-within:ring-2 focus-within:ring-ring/40">
+      <button
+        type="button"
+        onClick={(event) => {
+          onCreateSession()
+          event.currentTarget.blur()
+        }}
+        className="flex min-w-0 flex-1 items-center gap-2 px-2 text-left focus-visible:outline-none"
+      >
+        <span className="grid size-5 shrink-0 place-items-center text-foreground/90" aria-hidden="true">{icon}</span>
+        <span className="min-w-0 flex-1 truncate">New chat</span>
+      </button>
+      <span className="mr-1 flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity] group-hover:w-auto group-hover:opacity-100 group-focus-within:w-auto group-focus-within:opacity-100">
+        {onCreateSplitSession ? (
+          <button
+            type="button"
+            aria-label="New chat in split pane"
+            title="New chat in split pane"
+            onClick={(event) => {
+              event.stopPropagation()
+              onCreateSplitSession()
+              event.currentTarget.blur()
+            }}
+            className="grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          >
+            <Columns2 className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
+          </button>
+        ) : null}
+        {onCreatePopoverSession ? (
+          <button
+            type="button"
+            aria-label="New chat in popover"
+            title="New chat in popover"
+            onClick={(event) => {
+              event.stopPropagation()
+              onCreatePopoverSession()
+              event.currentTarget.blur()
+            }}
+            className="grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          >
+            <Zap className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
+          </button>
+        ) : null}
+      </span>
+    </div>
   )
 }
 

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -85,8 +85,8 @@ export function NewChatAction({
         {onCreatePopoverSession ? (
           <button
             type="button"
-            aria-label="New chat in popover"
-            title="New chat in popover"
+            aria-label="Quick chat"
+            title="Quick chat"
             onClick={(event) => {
               event.stopPropagation()
               onCreatePopoverSession()

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -43,6 +43,81 @@ describe("AppLeftPane", () => {
     expect(badge?.closest('[data-boring-workspace-part="app-session-row"]')).toHaveTextContent("Second session")
   })
 
+  it("shows a hover action for creating a quick popover chat", () => {
+    const onCreateSession = vi.fn()
+    const onCreatePopoverSession = vi.fn()
+    render(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane
+          appTitle="Test"
+          sessions={sessions}
+          activeSessionId="s1"
+          openSessionIds={["s1"]}
+          pinnedSessionIds={[]}
+          onCreateSession={onCreateSession}
+          onCreatePopoverSession={onCreatePopoverSession}
+          onOpenCommandPalette={vi.fn()}
+          onSwitchSession={vi.fn()}
+          onOpenSessionAsPane={vi.fn()}
+          onToggleSessionPinned={vi.fn()}
+        />
+      </WorkspaceAttentionProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "New chat in popover" }))
+
+    expect(onCreatePopoverSession).toHaveBeenCalledTimes(1)
+    expect(onCreateSession).not.toHaveBeenCalled()
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+  })
+
+  it("keeps the main New chat button as an action, not an active item", () => {
+    const onCreateSession = vi.fn()
+    render(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane
+          appTitle="Test"
+          sessions={sessions}
+          activeSessionId="s1"
+          openSessionIds={["s1"]}
+          pinnedSessionIds={[]}
+          onCreateSession={onCreateSession}
+          onCreatePopoverSession={vi.fn()}
+          onOpenCommandPalette={vi.fn()}
+          onSwitchSession={vi.fn()}
+          onOpenSessionAsPane={vi.fn()}
+          onToggleSessionPinned={vi.fn()}
+        />
+      </WorkspaceAttentionProvider>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "New chat" }))
+    expect(onCreateSession).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole("button", { name: "New chat" })).not.toHaveAttribute("data-active")
+  })
+
+  it("mutes the active session row when an overlay owns nav selection", () => {
+    render(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane
+          appTitle="Test"
+          sessions={sessions}
+          activeSessionId="s1"
+          muteActiveSession
+          openSessionIds={["s1"]}
+          pinnedSessionIds={[]}
+          onCreateSession={vi.fn()}
+          onOpenCommandPalette={vi.fn()}
+          onSwitchSession={vi.fn()}
+          onOpenSessionAsPane={vi.fn()}
+          onToggleSessionPinned={vi.fn()}
+        />
+      </WorkspaceAttentionProvider>,
+    )
+
+    expect(screen.getByText("First session").closest('[data-boring-workspace-part="app-session-row"]')).toHaveAttribute("data-boring-session-state", "open")
+  })
+
   it("calls onSwitchSession when reselecting the active session", () => {
     const onSwitchSession = vi.fn()
     render(

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -64,7 +64,7 @@ describe("AppLeftPane", () => {
       </WorkspaceAttentionProvider>,
     )
 
-    fireEvent.click(screen.getByRole("button", { name: "New chat in popover" }))
+    fireEvent.click(screen.getByRole("button", { name: "Quick chat" }))
 
     expect(onCreatePopoverSession).toHaveBeenCalledTimes(1)
     expect(onCreateSession).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- Move New chat above the session/history list and make it an action row with hover actions.
- Add split-pane and quick/popover chat creation from New chat.
- Keep newly-created chats selected and focus the composer.
- Make app-left overlays own the orange active state while muting the active session row.
- Allow the playground worktree/original repo CSS paths for remote review.

## Proof
- pnpm --filter @hachej/boring-ui-kit build
- pnpm --filter @hachej/boring-agent build
- pnpm --filter @hachej/boring-workspace typecheck
- NODE_ENV=test pnpm --filter @hachej/boring-workspace exec vitest run src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
- pnpm --filter @hachej/boring-workspace build
- pnpm --filter workspace-playground typecheck
- Manual/Playwright smoke: normal New chat auto-selected + focused composer; split-pane icon created a second pane and selected new chat.

## Review
- Final solution review: No blockers.
