### PR TITLE
feat(skills): add explicit skill management router

### DIFF
--- a/.agent/skills/skill-management/references/matt-pocock-writing-great-skills/GLOSSARY.md
+++ b/.agent/skills/skill-management/references/matt-pocock-writing-great-skills/GLOSSARY.md
@@ -1,0 +1,201 @@
+# Glossary — Building Great Skills
+
+The domain model for what makes a skill great. A skill exists to wrangle determinism out of a stochastic system; the root virtue is **Predictability**, and every term below is a lever on it. This is the disclosed reference for [`writing-great-skills`](SKILL.md).
+
+The terms are grouped by axis: **Invocation** (how a skill is reached), **Information Hierarchy** (how its content is arranged), **Steering** (how the agent's runtime behaviour is shaped), and **Pruning** (how it is kept lean). Each **failure mode** lives beside the lever that cures it, tagged _failure mode_.
+
+**Bold terms** in any definition are themselves defined in this glossary; find them by their heading.
+
+## Predictability
+
+The degree to which a skill makes the agent behave the same _way_ on every run — the same process, not the same output (a brainstorming skill should _predictably_ diverge; its tokens vary, its behaviour doesn't). The root virtue every other term serves — cost and maintainability are symptoms of it, not rivals.
+
+_Avoid_: consistency, reliability, robustness, output-determinism
+
+## Invocation
+
+How a skill is reached — and the two loads you pay for the choice.
+
+### Model-Invoked
+
+A skill that keeps its **description** field, so the agent can see it and fire it autonomously — and the human can still type its name, so model-invocation always _includes_ user reach. There is no model-only state: a description only ever _adds_ agent discovery, never removes the human's. Pays a permanent **context load** on every turn in exchange for that discoverability. Reachable by other skills, because the description that makes it agent-discoverable makes it invocable. A model-invoked skill whose content is all **reference** is also one home for shared reference: another skill can invoke it, so reference needed by several skills lives in one place. Pick model-invocation only when the agent must reach the skill on its own; if it never fires except by hand, drop the description and pay no context load.
+
+_Avoid_: ability, tool, capability
+
+### User-Invoked
+
+A skill with its **description** stripped — invisible to the agent and reachable only by the human typing its name (user-_only_, where **model-invoked** is user-_and-agent_). Trades agent-discoverability for zero **context load**. Because it has no description, nothing but the human can reach it: no other skill can fire it.
+
+_Avoid_: procedure, workflow, command
+
+### Description
+
+The skill's machine-readable trigger, and the one **context pointer** a **model-invoked** skill is forced to keep loaded at all times. Its mere presence _is_ the invocation axis: keep it and the skill is model-invoked (and reachable by other skills); delete it and the skill is **user-invoked**, reachable only by the human. The source of a model-invoked skill's **context load**.
+
+_Avoid_: frontmatter, summary
+
+### Context Pointer
+
+A reference held in the agent's context that names some out-of-context material and encodes the condition for reaching it. The **description** is the top-level context pointer (context window → skill); pointers to disclosed files are the same object one level down. Its wording, not the target, decides _when_ the agent reaches — and _how reliably_. A must-have target behind a weakly worded pointer is a variance bug: fix the wording first, and inline the material only if sharpening fails.
+
+_Avoid_: link, reference, import
+
+### Context Load
+
+The cost a **model-invoked** skill imposes on the agent's context window — its **description**, always loaded, spending both tokens and attention. What **user-invoked** skills escape by having no description, and the brake on splitting into more model-invoked skills.
+
+_Avoid_: token cost, context bloat
+
+### Cognitive Load
+
+The cost a **user-invoked** skill imposes on the human — what they must hold in their head: which skills exist and when to reach for each (the human is the index). What **model-invocation** removes by being agent-discoverable, and the brake on splitting into more user-invoked skills. Not a cost to minimise: it is the price of human agency, the reason some skills stay user-invoked. Spend it where human judgement matters; remove it where it does not.
+
+_Avoid_: human index, burden, overhead
+
+### Router Skill
+
+A **user-invoked** skill whose job is to point at your other user-invoked skills — naming each and when to reach for it — so the human has one skill to remember instead of many. It can only hint, never fire them: user-invoked skills have no **description**, so nothing but the human can reach them. The cure for **cognitive load** when user-invoked skills multiply.
+
+_Avoid_: dispatcher, menu, registry, index, router procedure
+
+### Granularity
+
+How finely you divide skills. Finer division spends one of the two loads: more **model-invoked** skills spend **context load** (more descriptions crowding the window and competing for attention); more **user-invoked** skills spend **cognitive load** (more for the human to remember and reach for). Two cuts guide the division. By **invocation**, split off a model-invoked skill where you have a distinct **leading word** to trigger it — a trigger word you actually use in your prompts. By **sequence**, split a run of **steps** where a step's **post-completion steps** need hiding, since isolating it in its own context clears what follows. Beware the reverse: merging sequences exposes each step's post-completion steps to what follows, inviting premature completion.
+
+_Avoid_: chunking, modularity
+
+## Information Hierarchy
+
+How a skill's content is arranged, and how far down the ladder each piece sits.
+
+### Information Hierarchy
+
+A skill's content ranked by how immediately the agent needs it — a single ladder, produced by two cuts: in-file or behind a pointer, and step or reference. The rungs:
+
+- **Steps** — in-file, primary
+- **Reference**, in-file — secondary
+- **Reference**, disclosed — behind a **context pointer**
+
+A skill with no **steps** uses just the bottom two rungs — often a legitimately flat peer-set (e.g. every rule of a review on one rung), which is a fine arrangement, not a smell. The hierarchy is independent of invocation: a skill can be model- or user-invoked whether it is all steps, all reference, or both. When a skill has steps, in-file reference that should be disclosed buries them and turns attending to them into a coin-flip — a variance lever, not just a legibility one. Keep the top of the ladder legible; push down it whatever you can.
+
+_Avoid_: structure, organization, layout
+
+### Steps
+
+The ordered actions the agent performs — when a skill has them, the primary tier of its content, and the part that earns its place in SKILL.md. Not every skill has steps: a skill can be all steps (`tdd`), all **reference** (a review), or both, independent of invocation. Every step ends on a **completion criterion**, clear or vague.
+
+_Avoid_: workflow, instructions, choreography
+
+### Reference
+
+Material the agent refers to on demand — definitions, facts, parameters, examples, conditional instructions. When a skill has **steps** it is secondary to them; when a skill has none it is the entire content; or it lives outside any skill entirely — see **External Reference**. Reached via **context pointers**, and the prime candidate for **progressive disclosure**.
+
+_Avoid_: supporting material, docs, background
+
+### External Reference
+
+**Reference** that lives outside the skill system — a plain file, no **description**, no **steps**, not invocable — that any skill can point at. The home for shared reference that needn't fire on its own, and the only shared home two **user-invoked** skills can use, since neither has a description and so neither can fire the other.
+
+_Avoid_: doc, resource, knowledge base
+
+### Progressive Disclosure
+
+Moving **reference** down the ladder — out of SKILL.md and behind a **context pointer** — so the top stays legible. Not primarily a token optimisation; it is how the **information hierarchy** is protected. Licensed by **branching**: disclose what only some branches need, inline what every path needs, and if a pointer fires unreliably on must-have material, sharpen its wording, and pull it back inline only if that fails.
+
+_Avoid_: lazy loading, chunking
+
+### Co-location
+
+Keeping the material an agent needs at once in one place — a concept's definition, rules, and caveats under a single heading, not scattered across the file — so reading one part brings its neighbours with it. The within-file companion to the **Information Hierarchy**: the hierarchy ranks _how far down_ a piece sits; co-location decides _what sits beside it_ once there. There is no formula for the right format of a body of **reference**; the test is that a skill should read like documentation written for the agent, and grouped material reads that way where scattered material does not. Distinct from **Duplication**: that repeats one meaning in two places, where scattering fragments a single meaning across many.
+
+_Avoid_: grouping, clustering, cohesion
+
+### Sprawl
+
+_Failure mode._ A skill that is simply too long — too many lines in SKILL.md — independent of whether they are stale or repeated. Even an all-live, all-unique skill can sprawl. It costs readability (the agent wades through more before it can act, and attention thins across the excess), maintainability (every extra line is one more to keep **relevant**), and tokens. The cure is the **information hierarchy**: push **reference** down behind **context pointers**, and split by **branch** or sequence so each path carries only what it needs. Distinct from **sediment** (length from stale accumulation) and **duplication** (length from repeated meaning) — sprawl is length itself, whatever its cause.
+
+_Avoid_: bloat, length, size, verbosity
+
+## Steering
+
+The levers that shape the agent's runtime behaviour toward **Predictability**.
+
+### Branch
+
+A distinct way a skill can be invoked — a case the skill handles — so different runs take different paths through it. A skill with many steps may carry many branches; a linear one has none.
+
+_Avoid_: path, case, fork
+
+### Leading Word
+
+A compact concept — also called a _Leitwort_ — already living in the model's pretraining, that the agent thinks with while running the skill. It encodes a behavioural principle in the fewest possible tokens by invoking priors the model already holds (e.g. _lesson_, _proximal zone of development_, _fog of war_, _tracer bullets_). Repeated as a token, never as a sentence, it accumulates a distributed definition across the skill and anchors a whole region of behaviour. Coining your own works if you define it clearly, but a made-up word recruits no priors — you pay in definition tokens what a pretrained word gives free. Reach for an existing word first.
+
+A leading word serves **predictability** twice. In the body it anchors **execution** — the agent reaches for the same behaviour every time the concept appears, and inside flat reference it focuses attention on a class of thing to look for, recruiting the right checks each run. In the **description** it anchors **invocation** — and not only within the skill: when the same word lives in your prompts, your docs, and your codebase, the agent links that shared language to the skill and fires it more reliably. Word a description with the leading words you actually use when you want the skill.
+
+_Avoid_: keyword, term, motif
+
+### Completion Criterion
+
+The condition that tells the agent a unit of work is done — the target it judges against. Two properties make it a lever, not just a quality. Its **clarity** (can the agent tell done from not-done?) resists **premature completion** — a vague bound ("understanding reached") lets the agent declare done and slip to the next step; this axis needs _steps_ to bite, since premature completion is a between-steps failure. Its **demand** (how much it requires) sets **legwork** — "every modified model accounted for" forces thorough work where "produce a change list" does not — and this axis is _not_ step-bound: it can bind a body of flat reference too, which is how a skill with no steps still carries an exhaustiveness bar ("every rule applied"). The strongest criteria are both checkable and exhaustive.
+
+_Avoid_: done condition, exit condition, stopping rule
+
+### Legwork
+
+The work an agent does behind the scenes within a single step — reading files, exploring the codebase, making changes, digging up what it needs rather than offloading to the user. It lives below the step structure: never written as its own step, latent in the wording, controlled by the agent rather than the skill. The within-step counterpart to **post-completion steps**' across-step pull. Raised by a **leading word** (_comprehensive_, _thorough_) or a **completion criterion** that demands the work be exhaustive — including the demand axis applied to flat reference, which is what drives a skill of flat reference to cover all its rungs. Goes thin either when that demand is missing or when **premature completion** cuts the step short.
+
+_Avoid_: scope, effort, diligence, coverage
+
+### Post-Completion Steps
+
+The **steps** that follow the current step. Visible, they pull the agent forward into **premature completion** — the more it sees, the stronger the tug; the defence is to hide them by splitting the sequence of steps into two.
+
+_Avoid_: horizon, fog of war, lookahead
+
+### Premature Completion
+
+_Failure mode._ Ending the current step before it is genuinely done, because the agent's attention slips to being done rather than to the work. A between-steps failure: it needs **steps** to occur — a skill with no steps that quits early isn't premature completion but thin **legwork** under an unmet demand. A tug-of-war between two forces: visible **post-completion steps** (the pull forward) and the **completion criterion**'s clarity (the resistance — a sharp, checkable bar holds; a vague one gives way). Fuzziness is the necessary condition: a sharp bound resists the pull no matter how many later steps are visible, so a step that never rushes needs no defending. Two levers hold a step that does, but reach for them in order: **sharpen the bound first** — it is local and cheap. Only when the criterion is irreducibly fuzzy _and_ you actually observe the rush do you **hide the later steps** — and hiding only works across a real context boundary (a user-invoked hand-off or a subagent dispatch; an inline model-invoked call leaves the later steps in context and clears nothing). One cause of thin legwork, but distinct from it: legwork can be thin even when a step runs to full completion.
+
+_Avoid_: premature closure, the rush, rushing, shortcutting
+
+### Negation
+
+_Failure mode._ Steering by prohibition — telling the agent what _not_ to do — which drags the forbidden behaviour into context and makes it _more_ available, not less. _Don't think of an elephant_, and the elephant is all there is; _never write verbose comments_, and verbosity is the pattern the agent has just read. The negation is a weak modifier the strongly-activated concept overruns, so the ban half-reads as an instruction to do the thing. Its **leading word** is the _elephant_: whatever a prohibition names into the frame. Cure: prompt the **positive** — describe the target behaviour ("write one-line comments") so the banned one is never spoken. A prohibition earns its place only as a hard guardrail on a behaviour you cannot phrase positively; even then, pair it with the positive target so attention lands on what to do.
+
+_Avoid_: ironic rebound, don't-prompting, the pink elephant
+
+## Pruning
+
+Keeping a skill lean — each remedy paired with the failure it cures.
+
+### Single Source of Truth
+
+The desired state where each meaning lives in exactly one authoritative place, so a change to the skill's behaviour is a change in one place. **Duplication** is its violation.
+
+_Avoid_: home, canonical location
+
+### Duplication
+
+_Failure mode._ The same meaning given more than one **single source of truth**. It costs maintenance (change one place, you must change the others), costs tokens, and inflates prominence — repeating a meaning weights it on the ladder past its real rank. The accidental inverse of a **leading word**, which raises attention on purpose by repeating a token, never the meaning.
+
+_Avoid_: repetition, redundancy
+
+### Relevance
+
+Whether a line still bears on what the skill does — the lens for what to keep. A line loses relevance either by never bearing on the task (mere exposition, or a **branch** that should be disclosed) or by going stale: drifting out of date as the behaviour or world it describes changes. Shorter skills are easier to keep relevant, because each line is cheaper to check. Distinct from **no-op**: relevance asks whether a line bears on the task, not whether it changes behaviour.
+
+_Avoid_: load-bearing, staleness, freshness
+
+### Sediment
+
+_Failure mode._ Layers of old content that settle in a skill and are never cleared, because adding feels safe and removing feels risky — so stale and irrelevant lines accumulate and you must core down through them to find what is still live. The default fate of any skill without a pruning discipline; the slow erosion of **relevance**, as opposed to **duplication**'s repeated meaning.
+
+_Avoid_: accretion, bloat, cruft, rot
+
+### No-Op
+
+_Failure mode._ An instruction that changes nothing because the model already does it by default — you pay load to tell the agent what it would do anyway. The test: does a line change behaviour versus the default? A line can be perfectly **relevant** and still be a no-op. The same priors that make a **leading word** free make a no-op worthless.
+
+A leading word is a _technique_; No-Op is a _verdict_ on a line — and they cross. A leading word too weak to beat the default is a no-op (_be thorough_ when the agent is already thorough-ish), and the fix is a stronger word that passes the verdict (_relentless_), not a different technique. So the No-Op test — does it change behaviour versus the default? — is also how you grade whether a leading word is earning its repetitions. This is model-relative, not reader-relative: two people disagreeing over whether a line is a no-op disagree about the default, and settle it by running the skill, not by debate.
+
+_Avoid_: redundant instruction, restating the obvious, belaboring

--- a/.agent/skills/skill-management/references/matt-pocock-writing-great-skills/LICENSE.txt
+++ b/.agent/skills/skill-management/references/matt-pocock-writing-great-skills/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.agent/skills/skill-management/references/matt-pocock-writing-great-skills/SKILL.md
+++ b/.agent/skills/skill-management/references/matt-pocock-writing-great-skills/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: writing-great-skills
+description: Reference for writing and editing skills well — the vocabulary and principles that make a skill predictable.
+disable-model-invocation: true
+---
+
+A skill exists to wrangle determinism out of a stochastic system. **Predictability** — the agent taking the same _process_ every run, not producing the same output — is the root virtue; every lever below serves it.
+
+**Bold terms** are defined in [`GLOSSARY.md`](GLOSSARY.md); look them up there for the full meaning.
+
+## Invocation
+
+Two choices, trading different costs:
+
+- A **model-invoked** skill keeps a **description**, so the agent can fire it autonomously _and_ other skills can reach it (you can still type its name too). It contributes to **context load** — the description sits in the window every turn. Mechanics: omit `disable-model-invocation`, and write a model-facing description with rich trigger phrasing ("Use when the user wants…, mentions…").
+- A **user-invoked** skill strips the description from the agent's reach: only you, typing its name, can invoke it — and no other skill can. Zero context load, but it spends **cognitive load**: _you_ are the index that must remember it exists. Mechanics: set `disable-model-invocation: true`; the `description` becomes human-facing — a one-line summary, trigger lists stripped.
+
+Pick model-invocation only when the agent must reach the skill on its own, or another skill must. If it only ever fires by hand, make it user-invoked and pay no context load.
+
+When user-invoked skills multiply past what you can remember, that piled-up cognitive load is cured by a **router skill**: one user-invoked skill that names the others and when to reach for each.
+
+## Writing the description
+
+A model-invoked **description** does two jobs — state what the skill is, and list the **branches** that should trigger it. Every word increases **context load**, so a description earns even harder pruning than the body:
+
+- **Front-load the skill's leading word** — the description is where it does its invocation work.
+- **One trigger per branch.** Synonyms that rename a single branch are **duplication** — "build features using TDD … asks for test-first development" is one branch written twice. Collapse them; keep only genuinely distinct branches.
+- **Cut identity that's already in the body.** Keep the description to triggers, plus any "when another skill needs…" reach clause.
+
+## Information hierarchy
+
+A skill is built from two content types — **steps** and **reference** — that mix freely: a skill can be all steps, all reference, or both. The core decision is which to use and where each sits on the **information hierarchy**, a ladder ranked by how immediately the agent needs the material:
+
+1. **In-skill step** — an ordered action in `SKILL.md`, the primary tier: what the agent does, in order. Each step ends on a **completion criterion**, the condition that tells the agent the work is done. Make it _checkable_ (can the agent tell done from not-done?) and, where it matters, _exhaustive_ ("every modified model accounted for", not "produce a change list") — a vague criterion invites **premature completion**.
+2. **In-skill reference** — a definition, rule, or fact in `SKILL.md`, consulted on demand. Often a legitimately flat peer-set (every rule of a review on one rung) — a fine arrangement, not a smell. _This skill is all reference._
+3. **External reference** — reference pushed out of `SKILL.md` into a separate file, reached by a **context pointer**, loaded only when the pointer fires. (Spans _disclosed_ reference — a sibling file like `GLOSSARY.md`, still part of the skill — through fully **external reference** that lives outside the skill system and any skill can point at.)
+
+A demanding completion criterion drives thorough **legwork** — the digging the agent does within the work — whether the skill has steps or not, since "every rule applied" binds flat reference just as "every step done" binds a sequence.
+
+Push too little down and the top bloats; push too much and you hide material the agent actually needs. That tension is the whole decision.
+
+**Progressive disclosure** is the move down the ladder — out of `SKILL.md` into a linked file — so the top stays legible. Mechanics: a linked `.md` file in the skill folder, named for what it holds (this skill discloses its full definitions to `GLOSSARY.md`). Some skills are used in more than one way, and each distinct way is a **branch** — different runs taking different paths through the skill. Branching is the cleanest disclosure test: inline what every branch needs, and push behind a pointer what only some branches reach. A **context pointer**'s _wording_, not its target, decides when and how reliably the agent reaches the material.
+
+Where the ladder decides _how far down_ a piece sits, **co-location** decides _what sits beside it_ once there: keep a concept's definition, rules, and caveats under one heading rather than scattered, so reading one part brings its neighbours with it.
+
+## When to split
+
+**Granularity** is how finely you divide skills, and each cut spends one of the two loads, so split only when the cut earns it. Two cuts:
+
+- **By invocation** — split off a **model-invoked** skill when you have a distinct **leading word** that should trigger it on its own, or another skill must reach it. You pay **context load** for the new always-loaded **description**, so that independent reach has to be worth it.
+- **By sequence** — split a run of **steps** when the steps still ahead (a step's **post-completion steps**) tempt the agent to rush the one in front of it (**premature completion**). Keeping them out of view encourages the agent to do more **legwork** on the current task.
+
+## Pruning
+
+Keep each meaning in a **single source of truth**: one authoritative place, so changing the behaviour is a one-place edit.
+
+Check every line for **relevance**: does it still bear on what the skill does?
+
+Then hunt **no-ops** sentence by sentence, not just line by line: run the no-op test on each sentence in isolation, and when one fails, delete the whole sentence rather than trim words from it. Be aggressive — most prose that fails should go, not be rewritten.
+
+## Leading words
+
+A **leading word** is a compact concept already living in the model's pretraining that the agent thinks with while running the skill (e.g. _lesson_, _fog of war_, _tracer bullets_). Repeated throughout the text (though not necessarily - a strong leading word might only be needed once), it accumulates a distributed definition and anchors a whole region of behaviour in the fewest tokens, by recruiting priors the model already holds.
+
+It serves predictability twice. In the body it anchors _execution_: the agent reaches for the same behaviour every time the word appears. In the description it anchors _invocation_: when the same word lives in your prompts, docs, and code, the agent links that shared language to the skill and fires it more reliably.
+
+Hunt for opportunities to refactor skills to use leading words. A triad spelled out at three sites (**duplication**), a description spending a sentence to gesture at one idea — each is a passage begging to **collapse** into a single token. Examples include:
+
+- "fast, deterministic, low-overhead" -> _tight_ — one quality restated across a phase — into a single pretrained word (a _tight_ loop).
+- "a loop you believe in" -> _red_ — converts a fuzzy gate into a binary observable state (the loop goes _red_ on the bug, or it doesn't).
+
+You win twice over: fewer tokens, _and_ a sharper hook for the agent to hang its thinking on. Assume every skill is carrying restatements that leading words retire — go find them.
+
+## Failure modes
+
+Use these to diagnose issues the user may be having with the skill.
+
+- **Premature completion** — ending a step before it's genuinely done, attention slipping to _being done_. Defence, in order: sharpen the completion criterion first (cheap, local); only if it is irreducibly fuzzy _and_ you observe the rush, hide the post-completion steps by splitting (the sequence cut).
+- **Duplication** — the same meaning in more than one place. Costs maintenance and tokens, and inflates a meaning's prominence on the ladder past its real rank.
+- **Sediment** — stale layers that settle because adding feels safe and removing feels risky. The default fate of any skill without a pruning discipline.
+- **Sprawl** — a skill simply too long, even when every line is live and unique. Hurts readability and maintainability and wastes tokens. The cure is the ladder: disclose **reference** behind pointers, and split by **branch** or sequence so each path carries only what it needs.
+- **No-op** — a line the model already obeys by default, so you pay load to say nothing. The test: does it change behaviour versus the default? A weak leading word (_be thorough_ when the agent is already thorough-ish) is a no-op; the fix is a stronger word (_relentless_), not a different technique.
+- **Negation** — steering by prohibition backfires: _don't think of an elephant_ names the elephant and makes it more available, not less. Prompt the **positive** — state the target behaviour so the banned one is never spoken; keep a prohibition only as a hard guardrail you can't phrase positively, and even then pair it with what to do instead.

--- a/.agent/skills/skill-management/references/matt-pocock-writing-great-skills/SOURCE.md
+++ b/.agent/skills/skill-management/references/matt-pocock-writing-great-skills/SOURCE.md
@@ -1,0 +1,15 @@
+# Matt Pocock — `writing-great-skills`
+
+Pinned external reference used by `/skill:skill-management create`.
+
+- Source repository: <https://github.com/mattpocock/skills>
+- Source path: `skills/productivity/writing-great-skills/`
+- Pinned commit: `9603c1cc8118d08bc1b3bf34cf714f62178dea3b`
+- Retrieved: 2026-07-19
+- License: MIT; see [`LICENSE.txt`](LICENSE.txt)
+- `SKILL.md` SHA-256: `4d6ccbc3760b1bd4107c495a79872286ea69494003f3b0a719fc95b147457061`
+- `GLOSSARY.md` SHA-256: `cccd684c73fb7a06f523497b0121765f92d2b33d6ef9c51602294849233451d6`
+
+The files are preserved verbatim. They are reference material, not a discovered
+project skill. Boring policy and Pi compatibility live in
+`docs/kanzen/procedures/skill-authoring.md`.

--- a/.agents/skills/ask-boring/SKILL.md
+++ b/.agents/skills/ask-boring/SKILL.md
@@ -14,6 +14,7 @@ Route only; do not modify files or trackers.
 | Existing issue/PR needs classification or next action | `triage` |
 | Outcome needs clarification, a spec, slices, or proof path | `plan` |
 | TODO, small plan, or Beads epic is executable | `exec` |
+| Create a skill or reduce an existing skill's active context size | `skill-management` |
 | Product judgment, access, privacy/security, or merge authority is required | `ask_user` (GitHub fallback) |
 
 Return:

--- a/.agents/skills/skill-management/SKILL.md
+++ b/.agents/skills/skill-management/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: skill-management
+description: Explicit router for creating a skill or reducing an existing skill's active context size.
+disable-model-invocation: true
+---
+
+# Skill Management
+
+Route exactly one explicit subskill; load only its procedure.
+
+| Subskill | Procedure |
+| --- | --- |
+| `reduce-size <skill-path>` | Read `docs/kanzen/procedures/skill-size-reduction.md`, then preserve behavior while shrinking active context. |
+| `create <name-or-goal>` | Read `docs/kanzen/procedures/skill-authoring.md`, including its pinned Matt Pocock reference, then create and validate the skill. |
+
+Invocation:
+
+```text
+/skill:skill-management reduce-size <skill-path>
+/skill:skill-management create <name-or-goal>
+```
+
+For missing or unknown branches, return this usage and stop. Do not load both
+procedures unless the user explicitly requests both operations.

--- a/docs/kanzen/README.md
+++ b/docs/kanzen/README.md
@@ -17,5 +17,6 @@ Active explicit-only skills live in `.agents/skills/`. Invoke with
 | issue intake | [`procedures/well-documented-issue.md`](procedures/well-documented-issue.md) |
 | plans | [`procedures/issue-plans.md`](procedures/issue-plans.md) |
 | worktree agents | [`procedures/worktree-agent.md`](procedures/worktree-agent.md) |
+| skill authoring and size reduction | [`procedures/skill-authoring.md`](procedures/skill-authoring.md), [`procedures/skill-size-reduction.md`](procedures/skill-size-reduction.md) |
 
 Use `ask_user` for human decisions; use a GitHub issue/PR comment when unavailable.

--- a/docs/kanzen/procedures/README.md
+++ b/docs/kanzen/procedures/README.md
@@ -7,6 +7,8 @@ Additional focused procedures:
 - [`coding-rules.md`](coding-rules.md)
 - [`coding-invariants.md`](coding-invariants.md)
 - [`repo-commands.md`](repo-commands.md)
+- [`skill-authoring.md`](skill-authoring.md)
+- [`skill-size-reduction.md`](skill-size-reduction.md)
 - [`trunk-flags-review-budget.md`](trunk-flags-review-budget.md)
 
 Compatibility/reference only: `agent-workflow.md`, `branch-worktree.md`,

--- a/docs/kanzen/procedures/skill-authoring.md
+++ b/docs/kanzen/procedures/skill-authoring.md
@@ -1,0 +1,52 @@
+# Skill Authoring
+
+Use for `/skill:skill-management create <name-or-goal>`.
+
+Before drafting, read the pinned Matt Pocock `writing-great-skills` source and
+its glossary in:
+
+- `.agent/skills/skill-management/references/matt-pocock-writing-great-skills/SKILL.md`
+- `.agent/skills/skill-management/references/matt-pocock-writing-great-skills/GLOSSARY.md`
+- source and license metadata in the same directory
+
+Treat that material as an external method. Boring repository policy, Pi's skill
+contract, and the user's request take precedence.
+
+## Method
+
+1. **Define predictability.** State the process the skill must repeat, its
+   invocation branches, and a checkable completion criterion for every step.
+2. **Choose invocation first.** Project workflow/meta skills default to explicit
+   invocation: include `disable-model-invocation: true` so Pi hides them from
+   the system prompt. Use model invocation only when the user requests it or
+   autonomous discovery is necessary and its permanent context load is
+   justified.
+3. **Design the hierarchy.** Keep always-needed steps in `SKILL.md`; disclose
+   branch-only reference behind precise pointers. Split only for independent
+   invocation or when hiding later steps prevents premature completion. A
+   router may expose argument-selected branches without creating independently
+   discovered nested skills.
+4. **Place ownership correctly.** Active project skills live in
+   `.agents/skills/<name>/SKILL.md`. Boring policy lives in `docs/kanzen/`. Raw
+   third-party references live under `.agent/skills/*/references/` with pinned
+   source, hashes, attribution, and license. Keep active policy on canonical
+   project paths.
+5. **Write tightly.** Give the description one human-facing summary for an
+   explicit skill, or distinct trigger branches for a model-invoked skill.
+   Remove duplication, sediment, and no-ops; use leading words where they make
+   behavior more predictable.
+6. **Validate.** Confirm lowercase-hyphenated name (maximum 64 characters), a
+   non-empty description, intended discovery/invocation behavior, resolving
+   relative paths, complete external attribution, and no accidental nested
+   discovery. Run available skill validation, `git diff --check`, and relevant
+   repository checks.
+7. **Review.** Independently review determinism, context load, branch routing,
+   completion criteria, safety/policy ownership, and source fidelity. Integrate
+   material findings and re-run proof.
+
+## Completion criterion
+
+Finish only when invocation behavior is intentional, each branch reaches all
+and only the context it needs, every step has a checkable bound, references and
+licenses resolve, validation and independent review are green, and the handoff
+shows exact invocation examples.

--- a/docs/kanzen/procedures/skill-size-reduction.md
+++ b/docs/kanzen/procedures/skill-size-reduction.md
@@ -1,0 +1,43 @@
+# Skill Size Reduction
+
+Use for `/skill:skill-management reduce-size <skill-path>`. The goal is lower
+active context load with the same predictable process—not a smaller file at the
+cost of behavior.
+
+## Method
+
+1. **Baseline.** Record the target `SKILL.md` word and byte counts. Use an
+   existing tokenizer when available; do not add a dependency only to estimate
+   tokens.
+2. **Inventory.** Read the full skill, every context pointer it requires, and
+   canonical project policy. List invocation branches, commands, hard
+   guardrails, authority boundaries, numeric bounds, completion criteria, and
+   proof/handoff requirements.
+3. **Shape.** Keep `SKILL.md` as the smallest reliable router. Inline what every
+   branch needs; move branch-only reference behind a precise pointer. Keep each
+   meaning in one canonical owner:
+   - Boring policy in `docs/kanzen/`;
+   - raw external methods in `.agent/skills/*/references/`;
+   - active discovery skills in `.agents/skills/`.
+4. **Prune.** Remove duplication, stale sediment, and sentence-level no-ops.
+   Prefer strong leading words and positive target behavior. Retain hard
+   prohibitions where safety or authority requires them.
+5. **Compare.** Diff the result against the inventory. Check every load-bearing
+   item, invocation mode, pointer, relative path, and completion criterion.
+   Size reduction never changes an explicit-only skill into a model-invoked
+   skill or hides must-read material behind a conditional pointer.
+6. **Prove.** Run skill/frontmatter validation when available, reference-path
+   checks, `git diff --check`, and the repository's active-policy checks.
+7. **Review.** Obtain an independent before/after policy-preservation review;
+   integrate material findings and re-review non-trivial fixes.
+
+No file deletion or replacement of external source material is implied by this
+method; follow repository safety rules.
+
+## Completion criterion
+
+Finish only when active words/bytes are lower (or the exception is explained),
+every safety/authority rule and user-visible behavior is preserved, all pointers
+resolve, proof is green, and independent review is clean. Any other behavior
+change requires explicit user approval and must be listed in the handoff. Report
+before/after counts plus the canonical destinations of moved policy.


### PR DESCRIPTION
Refs #842

## Summary

- add explicit-only `/skill:skill-management` with two argument-selected subskills:
  - `reduce-size <skill-path>`
  - `create <name-or-goal>`
- keep the router at 107 words and progressively disclose branch-only procedures
- add the proven policy-preserving skill-size reduction method
- add the Pi-compatible skill-authoring method grounded in Matt Pocock's pinned `writing-great-skills`
- preserve the upstream source and glossary byte-for-byte with SHA-256 hashes, attribution, and MIT license
- route skill work through `/skill:ask-boring` without exposing this skill to normal model context

## Invocation

```text
/skill:skill-management reduce-size .agents/skills/<name>/SKILL.md
/skill:skill-management create <name-or-goal>
```

## Context boundary

`disable-model-invocation: true` is set. Proof through Pi's actual `loadSkillsFromDir` and `formatSkillsForPrompt` APIs:

```json
{"discovered":"skill-management","disableModelInvocation":true,"promptBytes":0}
```

There is one discovered `SKILL.md`; the two subskills are argument-selected branches, not extra system-visible skills.

## Proof

- Pi discovery/frontmatter diagnostics ✅
- system-prompt contribution: 0 bytes ✅
- staged diff whitespace: `git diff --cached --check` ✅
- all procedure/reference paths resolve ✅
- no active-policy retired-tree references ✅
- pinned source hashes and byte-for-byte comparisons ✅
- `pnpm check:action-pins` ✅

## Review

- independent structure/invocation review: CLEAN
- independent policy/source review: one behavior-disposition high integrated
- focused re-review: CLEAN
- code thermo: not applicable; docs/skill configuration only

## Risk / rollback

Low. This adds an explicit command and documentation only. Removing the discovery router would disable the capability; no runtime or persisted data changes.

## Owner review

1. Confirm `/skill:skill-management` is absent from normal model-visible skills.
2. Invoke each command above and confirm it loads only its selected procedure.
3. Confirm the raw Matt Pocock reference remains under `.agent/.../references/` and is not independently discovered.
