### PR TITLE
fix(workspace): reconcile session list activity

### DIFF
--- a/packages/agent/src/core/__tests__/piChatSessionService.test.ts
+++ b/packages/agent/src/core/__tests__/piChatSessionService.test.ts
@@ -14,6 +14,7 @@ describe('withAgentEffectAdmission', () => {
     const effect = <T>(name: string, value: T) => async () => { events.push(name); return value }
     const service = {
       listSessions: effect('listSessions', []),
+      listSessionActivity: effect('listSessionActivity', []),
       createSession: effect('createSession', { id: 's1' }),
       deleteSession: effect('deleteSession', undefined),
       readState: effect('readState', {}),
@@ -55,9 +56,10 @@ describe('withAgentEffectAdmission', () => {
     blocked = false
     events.length = 0
     await admitted.listSessions?.(CTX)
+    await admitted.listSessionActivity?.(CTX, { sessionIds: ['s1'] })
     await admitted.readState(CTX, 's1')
     await admitted.subscribe(CTX, 's1', 0, () => {})
     await admitted.dispose?.()
-    expect(events).toEqual(['listSessions', 'readState', 'subscribe', 'dispose'])
+    expect(events).toEqual(['listSessions', 'listSessionActivity', 'readState', 'subscribe', 'dispose'])
   })
 })

--- a/packages/agent/src/core/piChatSessionService.ts
+++ b/packages/agent/src/core/piChatSessionService.ts
@@ -13,7 +13,7 @@ import type {
   StopPayload,
   StopReceipt,
 } from '../shared/chat'
-import type { SessionListOptions, SessionSummary } from '../shared/session'
+import type { SessionActivity, SessionActivityOptions, SessionListOptions, SessionSummary } from '../shared/session'
 
 export interface PiSessionRequestContext {
   workspaceId?: string
@@ -52,6 +52,7 @@ export interface PiChatAttachmentResult {
 
 export interface PiChatSessionService {
   listSessions?(ctx: PiSessionRequestContext, options?: SessionListOptions): Promise<SessionSummary[]>
+  listSessionActivity?(ctx: PiSessionRequestContext, options: SessionActivityOptions): Promise<SessionActivity[]>
   createSession?(ctx: PiSessionRequestContext, init?: PiSessionCreateInit): Promise<SessionSummary>
   deleteSession?(ctx: PiSessionRequestContext, sessionId: string): Promise<void>
   readAttachment?(ctx: PiSessionRequestContext, sessionId: string, messageId: string, index: number): Promise<PiChatAttachmentResult>
@@ -86,7 +87,7 @@ export class AgentEffectAdmissionError extends Error {
   }
 }
 
-type AgentEffectMethod = Exclude<keyof AgentCoreSessionService, 'listSessions' | 'readAttachment' | 'readState' | 'subscribe' | 'dispose'>
+type AgentEffectMethod = Exclude<keyof AgentCoreSessionService, 'listSessions' | 'listSessionActivity' | 'readAttachment' | 'readState' | 'subscribe' | 'dispose'>
 
 export const AGENT_EFFECT_METHODS = {
   createSession: true,
@@ -105,6 +106,9 @@ export function withAgentEffectAdmission(
   return {
     ...(service.listSessions
       ? { listSessions: (ctx, options) => service.listSessions!(ctx, options) }
+      : {}),
+    ...(service.listSessionActivity
+      ? { listSessionActivity: (ctx, options) => service.listSessionActivity!(ctx, options) }
       : {}),
     async createSession(ctx, init) { await admit(ctx); return service.createSession(ctx, init) },
     async deleteSession(ctx, sessionId) { await admit(ctx); return service.deleteSession(ctx, sessionId) },

--- a/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
+++ b/packages/agent/src/server/http/routes/__tests__/piChat.test.ts
@@ -16,7 +16,7 @@ import type {
 } from '../../../../shared/chat'
 import type { PiSessionRequestContext } from '../../../pi-chat/piSessionIdentity'
 import { PI_CHAT_CURSOR_AHEAD, PI_CHAT_REPLAY_GAP } from '../../../pi-chat/piChatReplayBuffer'
-import type { SessionListOptions } from '../../../../shared/session'
+import type { SessionActivity, SessionActivityOptions, SessionListOptions } from '../../../../shared/session'
 import { piChatBusyError, piChatRoutes, PiChatRouteError, type PiChatRoutesOptions, type PiChatSessionService } from '../piChat'
 
 const ADMISSION_ERROR_CODE = 'AGENT_HOST_ADMISSION_RECORD_FAILED'
@@ -54,11 +54,16 @@ class FakePiChatService implements PiChatSessionService {
   subscriptionResult: Awaited<ReturnType<PiChatSessionService['subscribe']>> | undefined
   attachment = { data: Buffer.from('image-bytes'), mediaType: 'image/png', filename: 'image.png' }
   readonly unsubscribe = vi.fn()
-  readonly calls: Array<{ method: string; ctx: PiSessionRequestContext; sessionId?: string; messageId?: string; index?: number; payload?: unknown; cursor?: number; options?: SessionListOptions }> = []
+  readonly calls: Array<{ method: string; ctx: PiSessionRequestContext; sessionId?: string; messageId?: string; index?: number; payload?: unknown; cursor?: number; options?: SessionListOptions | SessionActivityOptions }> = []
 
   async listSessions(ctx: PiSessionRequestContext, options?: SessionListOptions) {
     this.calls.push({ method: 'listSessions', ctx, options })
     return this.sessions
+  }
+
+  async listSessionActivity(ctx: PiSessionRequestContext, options: SessionActivityOptions): Promise<SessionActivity[]> {
+    this.calls.push({ method: 'listSessionActivity', ctx, options })
+    return options.sessionIds.map((sessionId) => ({ sessionId, working: sessionId === 'pi-1', status: sessionId === 'pi-1' ? 'streaming' : 'idle', source: sessionId === 'pi-1' ? 'live-runtime' : 'persisted' }))
   }
 
   async createSession(ctx: PiSessionRequestContext, init?: { title?: string }) {
@@ -176,6 +181,33 @@ describe('piChatRoutes', () => {
     expect(service.calls[0]).toMatchObject({
       method: 'listSessions',
       options: { limit: 100, offset: 25, includeId: 'pi-older' },
+    })
+
+    await app.close()
+  })
+
+  test('POST /sessions/activity forwards deduped session ids to the Pi-native service', async () => {
+    const { app, service } = await buildApp()
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/pi-chat/sessions/activity',
+      headers: { 'x-boring-storage-scope': 'scope-a' },
+      payload: { sessionIds: ['pi-1', 'pi-1', 'pi-2'] },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.json()).toEqual({
+      ok: true,
+      sessions: [
+        { sessionId: 'pi-1', working: true, status: 'streaming', source: 'live-runtime' },
+        { sessionId: 'pi-2', working: false, status: 'idle', source: 'persisted' },
+      ],
+    })
+    expect(service.calls[0]).toMatchObject({
+      method: 'listSessionActivity',
+      ctx: { workspaceId: 'workspace-a', storageScope: 'scope-a', authSubject: 'user-a' },
+      options: { sessionIds: ['pi-1', 'pi-2'] },
     })
 
     await app.close()

--- a/packages/agent/src/server/http/routes/piChat.ts
+++ b/packages/agent/src/server/http/routes/piChat.ts
@@ -59,6 +59,9 @@ const EmptyBodySchema = z.preprocess((value) => value ?? {}, z.object({}).strict
 const CreateSessionBodySchema = z.preprocess((value) => value ?? {}, z.object({
   title: z.string().min(1).max(200).optional(),
 }).strict())
+const SessionActivityBodySchema = z.object({
+  sessionIds: z.array(z.string().regex(SAFE_SESSION_LIST_INCLUDE_ID)).max(MAX_SESSION_LIST_LIMIT),
+}).strict()
 
 export type {
   PiChatEventStreamResult,
@@ -119,6 +122,18 @@ export function piChatRoutes(
       return reply.send(await service.listSessions(getRequestContext(request), sessionListOptions(request)))
     } catch (err) {
       return sendRouteError(reply, err, 'list pi chat sessions failed')
+    }
+  })
+
+  app.post('/api/v1/agent/pi-chat/sessions/activity', async (request, reply) => {
+    const body = parseWithSchema(SessionActivityBodySchema, request.body, reply, 'body')
+    if (!body) return
+    try {
+      const service = await resolveService(opts, request)
+      if (!service.listSessionActivity) throw unsupportedServiceMethod('list Pi chat session activity')
+      return reply.send({ ok: true, sessions: await service.listSessionActivity(getRequestContext(request), { sessionIds: [...new Set(body.sessionIds)] }) })
+    } catch (err) {
+      return sendRouteError(reply, err, 'list pi chat session activity failed')
     }
   })
 

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -133,6 +133,38 @@ function renderMessagesFromEvents(events: PiChatEvent[]) {
 }
 
 describe('HarnessPiChatService', () => {
+  it('reports live session activity from an existing channel without creating another adapter', async () => {
+    const { service, harness } = createService()
+
+    await service.prompt(ctx, 's1', { message: 'hello', clientNonce: 'nonce-activity' })
+    const activity = await service.listSessionActivity(ctx, { sessionIds: ['s1'] })
+
+    expect(activity).toEqual([
+      { sessionId: 's1', working: true, status: 'streaming', source: 'live-runtime' },
+    ])
+    expect(harness.getPiSessionAdapter).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports persisted sessions as idle without cold-instantiating an adapter', async () => {
+    const adapter = createAdapter()
+    const harness = createHarness(adapter)
+    const store: SessionStore = {
+      list: vi.fn(async () => []),
+      create: vi.fn(async () => ({ id: 's1', title: 'New session', createdAt: '', updatedAt: '', turnCount: 0 })),
+      load: vi.fn(async () => ({ id: 's1', title: 'New session', createdAt: '', updatedAt: '', turnCount: 0 })),
+      delete: vi.fn(async () => {}),
+    }
+    const service = new HarnessPiChatService({ harness, sessionStore: store, workdir: '/workspace' })
+
+    const activity = await service.listSessionActivity(ctx, { sessionIds: ['s1'] })
+
+    expect(activity).toEqual([
+      { sessionId: 's1', working: false, status: 'idle', source: 'persisted' },
+    ])
+    expect(store.load).toHaveBeenCalledWith({ workspaceId: 'workspace-a', userId: 'user-a' }, 's1')
+    expect(harness.getPiSessionAdapter).not.toHaveBeenCalled()
+  })
+
   it('disposes a receipt-only prompt, native channel, and metering exactly once', async () => {
     const adapter = createAdapter()
     const run = deferred<void>()

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -1,5 +1,5 @@
 import type { AgentHarness, RunContext, AgentSendInput } from '../../shared/harness'
-import type { SessionCtx, SessionListOptions, SessionStore } from '../../shared/session'
+import type { SessionActivity, SessionActivityOptions, SessionActivityStatus, SessionCtx, SessionListOptions, SessionStore } from '../../shared/session'
 import type { Workspace } from '../../shared/workspace'
 import type { BoringChatMessage, BoringChatPart, ChatError, FollowUpPayload, FollowUpReceipt, InterruptPayload, PiChatEvent, PiChatSnapshot, PromptPayload, PromptReceipt, QueuedUserMessage, QueueClearPayload, QueueClearReceipt, StopPayload, StopReceipt } from '../../shared/chat'
 import { sessionStreamPath, type AgentEvent } from '../../shared/events'
@@ -171,6 +171,44 @@ export class HarnessPiChatService implements PiChatSessionService {
 
   async listSessions(ctx: PiSessionRequestContext, options?: SessionListOptions) {
     return this.lifecycle.run(() => this.sessionStore.list(toSessionCtx(ctx), options))
+  }
+
+  async listSessionActivity(ctx: PiSessionRequestContext, options: SessionActivityOptions): Promise<SessionActivity[]> {
+    return this.lifecycle.run(async () => {
+      const sessionCtx = toSessionCtx(ctx)
+      const uniqueIds = [...new Set(options.sessionIds)].filter((id) => id.length > 0)
+      const activities = await Promise.all(uniqueIds.map(async (sessionId): Promise<SessionActivity | undefined> => {
+        try {
+          await this.sessionStore.load(sessionCtx, sessionId)
+        } catch {
+          return undefined
+        }
+        const sessionKey = sessionCacheKey(sessionId, sessionCtx)
+        const channel = this.channels.get(sessionKey)
+        const activeRun = this.activePromptRuns.has(sessionKey)
+        const activeError = this.activeSyntheticPromptErrors.has(sessionKey)
+        if (!channel) {
+          return { sessionId, working: false, status: activeError ? 'error' : 'idle', source: 'persisted' }
+        }
+        const snapshot = channel.adapter.readSnapshot()
+        const queuedCount = snapshot.followUpMessages.length
+        const status: SessionActivityStatus = activeError
+          ? 'error'
+          : snapshot.isStreaming || snapshot.isRetrying
+            ? 'streaming'
+            : activeRun
+              ? 'submitted'
+              : 'idle'
+        return {
+          sessionId,
+          working: status === 'streaming' || status === 'submitted',
+          status,
+          queuedCount: queuedCount > 0 ? queuedCount : undefined,
+          source: 'live-runtime',
+        }
+      }))
+      return activities.filter((activity): activity is SessionActivity => Boolean(activity))
+    })
   }
 
   async createSession(ctx: PiSessionRequestContext, init?: PiSessionCreateInit) {

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -54,6 +54,9 @@ export type {
   SessionStore,
   SessionCtx,
   SessionSummary,
+  SessionActivity,
+  SessionActivityOptions,
+  SessionActivityStatus,
   SessionDetail,
 } from './session'
 export type { FileSearch } from './file-search'

--- a/packages/agent/src/shared/session.ts
+++ b/packages/agent/src/shared/session.ts
@@ -24,4 +24,18 @@ export interface SessionSummary {
   turnCount: number
 }
 
+export type SessionActivityStatus = 'idle' | 'submitted' | 'streaming' | 'aborting' | 'error'
+
+export interface SessionActivity {
+  sessionId: string
+  working: boolean
+  status: SessionActivityStatus
+  queuedCount?: number
+  source: 'live-runtime' | 'persisted'
+}
+
+export interface SessionActivityOptions {
+  sessionIds: string[]
+}
+
 export type SessionDetail = SessionSummary

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -349,6 +349,110 @@ function useStoredNullableStringState(
 }
 
 const EMPTY_HEADERS: Record<string, string> = {}
+const CHAT_SESSION_STATUS_EVENT = "boring:chat-session-status"
+const SESSION_ACTIVITY_POLL_MS = 3_000
+const SESSION_ACTIVITY_MAX_IDS = 100
+const SESSION_ACTIVITY_OPTIMISTIC_GRACE_MS = 5_000
+
+interface WorkspaceSessionActivityIndicator {
+  working: boolean
+  optimisticUntil?: number
+}
+
+type WorkspaceSessionActivityById = Record<string, WorkspaceSessionActivityIndicator | undefined>
+
+function useWorkspaceSessionActivity(options: {
+  enabled: boolean
+  apiBaseUrl?: string
+  requestHeaders?: Record<string, string>
+  sessionIds: readonly string[]
+}): WorkspaceSessionActivityById | undefined {
+  const { enabled, apiBaseUrl = "", requestHeaders, sessionIds } = options
+  const [activityById, setActivityById] = useState<WorkspaceSessionActivityById>({})
+  const idsKey = useMemo(() => [...new Set(sessionIds)].sort().join("\n"), [sessionIds])
+
+  useEffect(() => {
+    if (!enabled || typeof window === "undefined") return
+    const onStatus = (event: Event) => {
+      const detail = (event as CustomEvent).detail as { sessionId?: unknown; working?: unknown } | undefined
+      if (typeof detail?.sessionId !== "string") return
+      const sessionId = detail.sessionId
+      setActivityById((current) => ({
+        ...current,
+        [sessionId]: detail.working === true
+          ? { working: true, optimisticUntil: Date.now() + SESSION_ACTIVITY_OPTIMISTIC_GRACE_MS }
+          : { working: false },
+      }))
+    }
+    window.addEventListener(CHAT_SESSION_STATUS_EVENT, onStatus)
+    return () => window.removeEventListener(CHAT_SESSION_STATUS_EVENT, onStatus)
+  }, [enabled])
+
+  useEffect(() => {
+    if (!enabled) {
+      setActivityById({})
+      return
+    }
+    const sessionIdsToFetch = idsKey ? idsKey.split("\n").filter(Boolean) : []
+    if (sessionIdsToFetch.length === 0) {
+      setActivityById({})
+      return
+    }
+    let cancelled = false
+    let inFlight = false
+    let requestSeq = 0
+    const fetchActivity = async () => {
+      if (inFlight) return
+      inFlight = true
+      const seq = ++requestSeq
+      try {
+        const next: WorkspaceSessionActivityById = {}
+        for (let index = 0; index < sessionIdsToFetch.length; index += SESSION_ACTIVITY_MAX_IDS) {
+          const chunk = sessionIdsToFetch.slice(index, index + SESSION_ACTIVITY_MAX_IDS)
+          const response = await fetch(`${apiBaseUrl.replace(/\/$/, "")}/api/v1/agent/pi-chat/sessions/activity`, {
+            method: "POST",
+            headers: { "content-type": "application/json", ...(requestHeaders ?? {}) },
+            body: JSON.stringify({ sessionIds: chunk }),
+          })
+          if (!response.ok) return
+          const body = await response.json() as { sessions?: Array<{ sessionId?: unknown; working?: unknown }> }
+          if (cancelled || seq !== requestSeq || !Array.isArray(body.sessions)) return
+          for (const session of body.sessions) {
+            if (typeof session.sessionId === "string") next[session.sessionId] = { working: session.working === true }
+          }
+        }
+        const now = Date.now()
+        setActivityById((current) => {
+          const merged: WorkspaceSessionActivityById = {}
+          for (const id of sessionIdsToFetch) {
+            const authoritative = next[id] ?? { working: false }
+            const currentEntry = current[id]
+            merged[id] = currentEntry?.working === true
+              && currentEntry.optimisticUntil !== undefined
+              && currentEntry.optimisticUntil > now
+              && authoritative.working === false
+                ? currentEntry
+                : authoritative
+          }
+          return merged
+        })
+      } catch {
+        // Keep the optimistic overlay during transient backend failures.
+      } finally {
+        inFlight = false
+      }
+    }
+    void fetchActivity()
+    const interval = globalThis.setInterval(fetchActivity, SESSION_ACTIVITY_POLL_MS)
+    return () => {
+      cancelled = true
+      globalThis.clearInterval(interval)
+    }
+  }, [apiBaseUrl, enabled, idsKey, requestHeaders])
+
+  return enabled ? activityById : undefined
+}
+
 const EMPTY_STRING_LIST: string[] = []
 const PREPARING_WARMUP_STATUS: WorkspaceWarmupStatus = { status: "preparing" }
 
@@ -789,6 +893,12 @@ export function WorkspaceAgentFront<
       : hasExplicitSessionProps
         ? activeSessionId ?? null
         : localSessions.activeId
+  const sessionActivityById = useWorkspaceSessionActivity({
+    enabled: Boolean(sessionApi && !remoteSessionsPending),
+    apiBaseUrl,
+    requestHeaders: resolvedRequestHeaders,
+    sessionIds: resolvedSessions.map((session) => session.id),
+  })
   const requestedAutoSubmitInitialDraft = chatParams?.autoSubmitInitialDraft === true
   const needsFreshRemoteSessionForAutoSubmit = requestedAutoSubmitInitialDraft && shouldUseRemoteSessions && !hasExplicitSessionProps
   const [autoSubmitSessionId, setAutoSubmitSessionId] = useState<string | null | undefined>(() => (
@@ -1613,6 +1723,7 @@ export function WorkspaceAgentFront<
     onLoadMore: sessionApi?.loadMore,
     hasMore: sessionApi?.hasMore,
     loadingMore: sessionApi?.loadingMore,
+    sessionActivityById,
     onClose: () => setNavOpen(false),
   }
   const canDeleteSessions = Boolean(sessionApi || onDeleteSession || !hasExplicitSessionProps)
@@ -1871,6 +1982,7 @@ export function WorkspaceAgentFront<
           onToggleSessionPinned={toggleSessionPinned}
           onDeleteSession={canDeleteSessions ? deleteSessionAndPane : undefined}
           actions={managementActions}
+          sessionActivityById={sessionActivityById}
         />
       )}
     >

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -2260,9 +2260,12 @@ describe("WorkspaceAgentFront", () => {
 
     // And the chat must NOT have given up by auto-creating a brand-new empty
     // session as if none existed (no POST to the sessions endpoint).
-    expect(fetchMock.mock.calls.some(([input, init]) =>
-      String(input).includes("/api/v1/agent/pi-chat/sessions") && (init?.method ?? "GET") === "POST",
-    )).toBe(false)
+    expect(fetchMock.mock.calls.some(([input, init]) => {
+      const url = String(input)
+      return url.includes("/api/v1/agent/pi-chat/sessions")
+        && !url.includes("/api/v1/agent/pi-chat/sessions/activity")
+        && (init?.method ?? "GET") === "POST"
+    })).toBe(false)
   })
 
   it("creates the first remote session when a sessions hook loads empty", async () => {

--- a/packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx
+++ b/packages/workspace/src/front/chrome/session-list/SessionBrowser.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { ChevronLeft, ChevronRight, ExternalLink, Pin, Plus } from "lucide-react"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
@@ -10,6 +10,12 @@ import { CHAT_SESSION_DRAG_TYPE } from "../../layout/ChatPaneStage"
 import type { SessionItem } from "../../components/SessionList"
 
 const CHAT_SESSION_STATUS_EVENT = "boring:chat-session-status"
+
+export interface SessionActivityIndicator {
+  working: boolean
+}
+
+export type SessionActivityById = Record<string, SessionActivityIndicator | undefined>
 
 /**
  * Session ids whose chat panel is currently streaming. Fed by the
@@ -53,6 +59,7 @@ export interface SessionBrowserProps {
   onLoadMore?: () => void
   hasMore?: boolean
   loadingMore?: boolean
+  sessionActivityById?: SessionActivityById
   onClose?: () => void
   className?: string
 }
@@ -163,6 +170,7 @@ export function SessionBrowser({
   onLoadMore,
   hasMore = false,
   loadingMore = false,
+  sessionActivityById,
   onClose,
   className,
 }: SessionBrowserProps) {
@@ -200,7 +208,11 @@ export function SessionBrowser({
   const [historyCollapsed, setHistoryCollapsed] = useState(
     () => (openIds?.length ?? 0) > 0 || (pinnedIds?.length ?? 0) > 0,
   )
-  const workingSessionIds = useWorkingSessionIds()
+  const optimisticWorkingSessionIds = useWorkingSessionIds()
+  const isSessionWorking = useCallback((sessionId: string) => {
+    const activity = sessionActivityById?.[sessionId]
+    return activity ? activity.working : optimisticWorkingSessionIds.has(sessionId)
+  }, [optimisticWorkingSessionIds, sessionActivityById])
   const { blockers } = useWorkspaceAttention()
   const sessionBadges = useMemo(() => {
     const badges = new Map<string, WorkspaceAttentionSessionBadge>()
@@ -275,7 +287,7 @@ export function SessionBrowser({
                     active={session.id === activeId}
                     open={openSet.has(session.id)}
                     pinned
-                    working={workingSessionIds.has(session.id)}
+                    working={isSessionWorking(session.id)}
                     attentionBadge={sessionBadges.get(session.id)}
                     onSwitch={onSwitch}
                     onOpenAsTab={onOpenAsTab}
@@ -306,7 +318,7 @@ export function SessionBrowser({
                     active={session.id === activeId}
                     open
                     pinned={pinnedSet.has(session.id)}
-                    working={workingSessionIds.has(session.id)}
+                    working={isSessionWorking(session.id)}
                     attentionBadge={sessionBadges.get(session.id)}
                     onSwitch={onSwitch}
                     onOpenAsTab={onOpenAsTab}
@@ -347,7 +359,7 @@ export function SessionBrowser({
                           active={session.id === activeId}
                           open={false}
                           pinned={pinnedSet.has(session.id)}
-                          working={workingSessionIds.has(session.id)}
+                          working={isSessionWorking(session.id)}
                           attentionBadge={sessionBadges.get(session.id)}
                           onSwitch={onSwitch}
                           onOpenAsTab={onOpenAsTab}

--- a/packages/workspace/src/front/chrome/session-list/__tests__/SessionBrowser.test.tsx
+++ b/packages/workspace/src/front/chrome/session-list/__tests__/SessionBrowser.test.tsx
@@ -173,6 +173,20 @@ describe("SessionBrowser", () => {
     expect(document.querySelector('[data-boring-badge="working"]')).toBeNull()
   })
 
+  it("lets authoritative activity clear an optimistic working badge", () => {
+    const { rerender } = render(<SessionBrowser sessions={sample} activeId="s1" />)
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("boring:chat-session-status", {
+        detail: { sessionId: "s2", working: true },
+      }))
+    })
+    expect(document.querySelector('[data-boring-badge="working"]')).toBeInTheDocument()
+
+    rerender(<SessionBrowser sessions={sample} activeId="s1" sessionActivityById={{ s2: { working: false } }} />)
+    expect(document.querySelector('[data-boring-badge="working"]')).toBeNull()
+  })
+
   it("shows a needs-input badge for older waiting-for-input blockers", () => {
     function BlockSession({ sessionId }: { sessionId: string }) {
       const { addBlocker, removeBlocker } = useWorkspaceAttention()

--- a/packages/workspace/src/front/chrome/session-list/definition.ts
+++ b/packages/workspace/src/front/chrome/session-list/definition.ts
@@ -1,7 +1,7 @@
 import { createElement } from "react"
 import type { PaneProps } from "../../registry/types"
 import type { SessionItem } from "../../components/SessionList"
-import { SessionBrowser } from "./SessionBrowser"
+import { SessionBrowser, type SessionActivityById } from "./SessionBrowser"
 
 interface SessionListPaneParams {
   sessions?: SessionItem[]
@@ -16,6 +16,7 @@ interface SessionListPaneParams {
   onLoadMore?: () => void
   hasMore?: boolean
   loadingMore?: boolean
+  sessionActivityById?: SessionActivityById
   onClose?: () => void
 }
 
@@ -33,6 +34,7 @@ function SessionListPane({ params }: PaneProps<SessionListPaneParams | undefined
     onLoadMore: params?.onLoadMore,
     hasMore: params?.hasMore,
     loadingMore: params?.loadingMore,
+    sessionActivityById: params?.sessionActivityById,
     onClose: params?.onClose,
   })
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState, type ReactNode } from "react"
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react"
 import { Plus, Search } from "lucide-react"
 import { AppLeftPaneHeader } from "./AppLeftPaneHeader"
 import { PrimaryAction, NewChatAction, KbdHint } from "./AppLeftPaneActions"
@@ -84,6 +84,7 @@ export interface AppLeftPaneProps {
   onDeleteSession?: (id: string) => void
   /** Primary app-left actions supplied by the host/app/plugin shell after New chat/Search. */
   actions?: readonly AppLeftPaneAction[]
+  sessionActivityById?: AppLeftPaneSessionActivityById
   /**
    * single-project: workspace shown below the app-title logo, no Workspaces
    * section — just the session list. multi-project: the Workspaces/projects
@@ -95,6 +96,12 @@ export interface AppLeftPaneProps {
 type SessionRowState = AppSessionRowState
 
 const CHAT_SESSION_STATUS_EVENT = "boring:chat-session-status"
+
+export interface AppLeftPaneSessionActivityIndicator {
+  working: boolean
+}
+
+export type AppLeftPaneSessionActivityById = Record<string, AppLeftPaneSessionActivityIndicator | undefined>
 
 function useWorkingSessionIds(): ReadonlySet<string> {
   const [working, setWorking] = useState<ReadonlySet<string>>(() => new Set())
@@ -148,10 +155,15 @@ export function AppLeftPane({
   onDeleteSession,
   actions = [],
   layoutMode = "single-project",
+  sessionActivityById,
 }: AppLeftPaneProps) {
   const openSet = useMemo(() => new Set(openSessionIds), [openSessionIds])
   const pinnedSet = useMemo(() => new Set(pinnedSessionIds), [pinnedSessionIds])
-  const workingSessionIds = useWorkingSessionIds()
+  const optimisticWorkingSessionIds = useWorkingSessionIds()
+  const isSessionWorking = useCallback((sessionId: string) => {
+    const activity = sessionActivityById?.[sessionId]
+    return activity ? activity.working : optimisticWorkingSessionIds.has(sessionId)
+  }, [optimisticWorkingSessionIds, sessionActivityById])
   const { blockers } = useWorkspaceAttention()
   const sessionBadges = useMemo(() => {
     const badges = new Map<string, WorkspaceAttentionSessionBadge>()
@@ -236,7 +248,7 @@ export function AppLeftPane({
         // A session from another project switches to that workspace instead.
         canSplit={isActiveProjectSession}
         canPin={isActiveProjectSession}
-        working={isActiveProjectSession && workingSessionIds.has(session.id)}
+        working={isActiveProjectSession && isSessionWorking(session.id)}
         attentionBadge={isActiveProjectSession ? sessionBadges.get(session.id) : undefined}
         onSwitch={isActiveProjectSession ? onSwitchSession : () => onOpenProjectSession?.(projectId, session.id)}
         onOpenAsPane={isActiveProjectSession ? onOpenSessionAsPane : () => onOpenProjectSession?.(projectId, session.id)}

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -9,7 +9,7 @@ const sessions = [
   { id: "s2", title: "Second session" },
 ]
 
-function renderPane() {
+function renderPane(props: Partial<Parameters<typeof AppLeftPane>[0]> = {}) {
   return render(
     <WorkspaceAttentionProvider>
       <AppLeftPane
@@ -23,6 +23,7 @@ function renderPane() {
         onSwitchSession={vi.fn()}
         onOpenSessionAsPane={vi.fn()}
         onToggleSessionPinned={vi.fn()}
+        {...props}
       />
     </WorkspaceAttentionProvider>,
   )
@@ -41,6 +42,36 @@ describe("AppLeftPane", () => {
     const badge = document.querySelector('[data-boring-badge="working"]')
     expect(badge).toBeInTheDocument()
     expect(badge?.closest('[data-boring-workspace-part="app-session-row"]')).toHaveTextContent("Second session")
+  })
+
+  it("lets authoritative activity clear an optimistic working badge", () => {
+    const { rerender } = renderPane()
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("boring:chat-session-status", {
+        detail: { sessionId: "s2", working: true },
+      }))
+    })
+    expect(document.querySelector('[data-boring-badge="working"]')).toBeInTheDocument()
+
+    rerender(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane
+          appTitle="Test"
+          sessions={sessions}
+          activeSessionId="s1"
+          openSessionIds={["s1"]}
+          pinnedSessionIds={[]}
+          onCreateSession={vi.fn()}
+          onOpenCommandPalette={vi.fn()}
+          onSwitchSession={vi.fn()}
+          onOpenSessionAsPane={vi.fn()}
+          onToggleSessionPinned={vi.fn()}
+          sessionActivityById={{ s2: { working: false } }}
+        />
+      </WorkspaceAttentionProvider>,
+    )
+    expect(document.querySelector('[data-boring-badge="working"]')).toBeNull()
   })
 
   it("shows a hover action for creating a quick popover chat", () => {


### PR DESCRIPTION
## Summary
- Add a read-only session activity endpoint for live Pi chat runtime state.
- Poll loaded session IDs from the workspace session list so working/question badges reconcile without reopening a session.
- Keep existing optimistic browser events, with backend activity clearing stale working state.

## Proof
- `pnpm --filter @hachej/boring-agent exec vitest run src/server/http/routes/__tests__/piChat.test.ts src/core/__tests__/piChatSessionService.test.ts src/server/pi-chat/__tests__/harnessPiChatService.test.ts`
- `NODE_ENV=test pnpm --filter @hachej/boring-workspace exec vitest run src/front/chrome/session-list/__tests__/SessionBrowser.test.tsx src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx src/app/front/__tests__/WorkspaceAgentFront.test.tsx`
- `pnpm --filter @hachej/boring-agent typecheck && pnpm --filter @hachej/boring-workspace typecheck`

## Notes
- Separate direct-to-main version of the session working-status fix from issue #781.
- No DB/storage change: activity is read from live runtime state plus existing session files for access/existence.