### PR TITLE
#fix(release): exempt peerDependencies from publish-order audit; order sandbox/bash before agent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Publish
         run: |
-          for pkg in packages/ui packages/boring-bash packages/agent packages/plugin-cli packages/workspace packages/core plugins/deck plugins/ask-user plugins/diagram plugins/tasks plugins/boring-automation packages/cli plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard packages/boring-sandbox plugins/boring-mcp plugins/boring-governance; do
+          for pkg in packages/ui packages/boring-bash packages/boring-sandbox packages/agent packages/plugin-cli packages/workspace packages/core plugins/deck plugins/ask-user plugins/diagram plugins/tasks plugins/boring-automation packages/cli plugins/data-explorer plugins/data-catalog plugins/generated-pane plugins/data-bridge plugins/bi-dashboard plugins/boring-mcp plugins/boring-governance; do
             name=$(node -p "require('./$pkg/package.json').name")
             version=$(node -p "require('./$pkg/package.json').version")
             if npm view "$name@$version" version >/dev/null 2>&1; then

--- a/scripts/audit-publish-manifests.mjs
+++ b/scripts/audit-publish-manifests.mjs
@@ -18,6 +18,7 @@ const root = resolve(__dirname, "..")
 const PUBLISHABLE_PACKAGES = [
   "packages/ui",
   "packages/boring-bash",
+  "packages/boring-sandbox",
   "packages/agent",
   "packages/plugin-cli",
   "packages/workspace",
@@ -33,7 +34,6 @@ const PUBLISHABLE_PACKAGES = [
   "plugins/generated-pane",
   "plugins/data-bridge",
   "plugins/bi-dashboard",
-  "packages/boring-sandbox",
   "plugins/boring-mcp",
   "plugins/boring-governance",
 ]
@@ -141,15 +141,21 @@ function main() {
           }
           if (!name.startsWith("@hachej/")) continue
 
+          // peerDependencies and devDependencies are not installed by consumers
+          // at publish time, so declaring a peer/dev range on a workspace package
+          // that is not yet published (or is published later in the release order)
+          // is valid. Only runtime dependencies/optionalDependencies must resolve
+          // at install time, so only those gate publish order. This lets the
+          // boring-agent <-> boring-sandbox / boring-bash cycles (agent depends on
+          // them at runtime; they peer-depend back on agent for shared types)
+          // publish sandbox/bash before agent without the peer-back-edges failing.
+          if (section === "peerDependencies" || section === "devDependencies") continue
+
           if (npmHasVersion(name, spec)) continue
 
           const planned = releasePlan.get(name)
           const isEarlierInRelease = planned && planned.version === spec && planned.index < sourcePkg.index
-          const isBashAgentTypeOnlyEdge = sourcePkg.name === "@hachej/boring-bash"
-            && name === "@hachej/boring-agent"
-            && planned?.version === spec
-            && (section === "peerDependencies" || section === "devDependencies")
-          if (isEarlierInRelease || isBashAgentTypeOnlyEdge) continue
+          if (isEarlierInRelease) continue
 
           if (planned && planned.version === spec) {
             fail(


### PR DESCRIPTION
## Problem

The #838 / #839 extraction swaps (consume `@hachej/boring-sandbox` / `@hachej/boring-bash`, delete the in-agent copies) introduced a **publish-order cycle** that makes the release workflow's pre-publish gate (`pnpm audit:publish-manifests`, run only in `release.yml`, never in CI) fail for any new version:

- `boring-agent` (and `boring-workspace`, `boring-ui-cli`) now have **runtime `dependencies`** on `@hachej/boring-sandbox` and `@hachej/boring-bash` → those must publish **before** agent.
- `boring-sandbox` and `boring-bash` declare **`peerDependencies`** back on `@hachej/boring-agent` (shared types) → the audit treated peers like runtime deps, forcing agent **before** sandbox/bash.

No linear publish order satisfies both. Cutting v0.1.90 today aborts at the audit step:

```
- @hachej/boring-agent@0.1.90 dependencies.@hachej/boring-sandbox@0.1.90 is not published yet and appears later/same in release order
- @hachej/boring-workspace@0.1.90 dependencies.@hachej/boring-sandbox@0.1.90 ...
- @hachej/boring-ui-cli@0.1.90 dependencies.@hachej/boring-sandbox@0.1.90 ...
```

## Fix (Option A)

- **Exempt `peerDependencies` and `devDependencies` from the publish-order / already-published check.** Peers and dev deps are not installed by consumers at install time, so declaring a peer/dev range on a not-yet-published (or later-ordered) workspace package is valid. Only runtime `dependencies` / `optionalDependencies` gate publish order. This generalizes (and removes) the previous narrow hardcoded `boring-bash → agent` special case, and now also covers `boring-sandbox → agent`. Workspace/file/link leak checks remain enforced for all sections.
- **Order `packages/boring-sandbox` before `packages/agent`** in both the audit's `PUBLISHABLE_PACKAGES` and `release.yml`'s publish loop (`boring-bash` was already ordered first), so agent's runtime deps resolve at publish time.

## Verification

Simulated a 0.1.90 bump (`node scripts/version.mjs patch`) and ran `pnpm audit:publish-manifests`:

```
✓ ... all manifests ok
All publish manifests are safe to publish.
```

(Bump reverted; this PR contains only the audit + workflow fix.)

## Follow-up

Option A unblocks the release by relaxing the audit. The cleaner structural fix — hoisting the shared types into a small third package so the peer-back-edges disappear — is filed as a separate tech-debt issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uy8snWzDKyjZBhsFco4Du5