### PR TITLE
#859 fix: emit fs-change events for bash-tool writes in remote/vercel-sandbox mode (file tree auto-refresh)

### DIFF
--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -37,7 +37,7 @@ export type {
   WorkspaceAgentDispatcherSendInput,
 } from './workspaceAgentDispatcher'
 export type { WorkspaceRuntimeContext } from './runtime'
-export type { Workspace, Entry, Stat } from './workspace'
+export type { Workspace, Entry, Stat, WorkspaceWatchControlEvent } from './workspace'
 export type {
   Sandbox,
   SandboxCapability,

--- a/packages/agent/src/shared/workspace.ts
+++ b/packages/agent/src/shared/workspace.ts
@@ -48,6 +48,20 @@ export interface Workspace {
   watch?(): WorkspaceWatcher
 
   /**
+   * Optional control-event channel for out-of-band changes.
+   *
+   * The primary `watch()` subscription is for fine-grained file
+   * events. This is a secondary channel for coarse-grained external
+   * events that should trigger a client-side resync — e.g. a bash
+   * tool that mutates many files, or a git pull that swaps many refs.
+   *
+   * Implementations that can't observe changes (and don't
+   * want to fake it via polling) omit this method or leave it
+   * undefined.
+   */
+  notifyExternalChange?(event: WorkspaceWatchControlEvent): void
+
+  /**
    * Capability hint for hosts that want to render a UI affordance
    * ("connected"/"polling"/"manual refresh"). Optional — absence
    * means "treat as 'none' and consult `watch?` for the truth." When

--- a/packages/boring-bash/src/__tests__/dualTargetParity.contract.test.ts
+++ b/packages/boring-bash/src/__tests__/dualTargetParity.contract.test.ts
@@ -260,7 +260,7 @@ async function observeOperations(target: ParityTarget) {
     },
   })
   const chunks: string[] = []
-  const remote = target.remoteSandboxBashOps(sandbox, {
+  const remote = target.remoteSandboxBashOps(sandbox, undefined, {
     executionRuntimeEnv: { PARITY: '1' },
   })
   const remoteResult = await remote.exec('printf parity', '/workspace', {

--- a/packages/boring-bash/src/agent/tools/harness/bashToolOptions.ts
+++ b/packages/boring-bash/src/agent/tools/harness/bashToolOptions.ts
@@ -104,7 +104,7 @@ function remoteBashToolOptions(
   strategy: Extract<RuntimeBashStrategy, { kind: 'remote' }>,
 ): BashToolOptions {
   return {
-    operations: remoteSandboxBashOps(bundle.sandbox, {
+    operations: remoteSandboxBashOps(bundle.sandbox, bundle.workspace, {
       defaultPath: strategy.defaultPath,
       runtime,
       executionRuntimeEnv,

--- a/packages/boring-bash/src/agent/tools/operations/__tests__/remoteSandbox.test.ts
+++ b/packages/boring-bash/src/agent/tools/operations/__tests__/remoteSandbox.test.ts
@@ -2,92 +2,69 @@ import { vi, describe, it, expect } from 'vitest'
 import type { Sandbox, Workspace } from '@hachej/boring-agent/shared'
 import { remoteSandboxBashOps } from '../remoteSandbox'
 
+function fakeSandbox(exitCode: number): Sandbox {
+  return {
+    id: 'sandbox-test',
+    provider: 'test',
+    placement: 'remote',
+    capabilities: ['exec'],
+    runtimeContext: { runtimeCwd: '/workspace' },
+    exec: vi.fn().mockResolvedValue({ exitCode }),
+  }
+}
+
+function fakeWorkspace(overrides: Partial<Workspace> = {}): Workspace {
+  return {
+    root: '/workspace',
+    runtimeContext: { runtimeCwd: '/workspace' },
+    readFile: vi.fn(),
+    writeFile: vi.fn(),
+    readBinaryFile: vi.fn(),
+    writeBinaryFile: vi.fn(),
+    unlink: vi.fn(),
+    readdir: vi.fn(),
+    stat: vi.fn(),
+    mkdir: vi.fn(),
+    rename: vi.fn(),
+    ...overrides,
+  }
+}
+
 describe('remoteSandboxBashOps', () => {
   it('calls workspace.notifyExternalChange on successful exec', async () => {
-    const mockSandbox: Sandbox = {
-      provider: 'test',
-      placement: 'remote',
-      exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
-    }
-
-    const mockWorkspace: Workspace & { notifyExternalChange?: (e: any) => void } = {
-      root: '/workspace',
-      fsCapability: 'best-effort',
-      notifyExternalChange: vi.fn(),
-      // Add other required Workspace methods if needed for compilation
-      readFile: vi.fn(),
-      writeFile: vi.fn(),
-      readBinaryFile: vi.fn(),
-      writeBinaryFile: vi.fn(),
-      unlink: vi.fn(),
-      readdir: vi.fn(),
-      stat: vi.fn(),
-      mkdir: vi.fn(),
-      rename: vi.fn(),
-    }
+    const mockSandbox = fakeSandbox(0)
+    const notifyExternalChange = vi.fn()
+    const mockWorkspace = fakeWorkspace({ notifyExternalChange })
 
     const ops = remoteSandboxBashOps(mockSandbox, mockWorkspace)
     await ops.exec('touch /workspace/test.txt', '/workspace', { onData: () => {} })
 
     expect(mockSandbox.exec).toHaveBeenCalled()
-    expect(mockWorkspace.notifyExternalChange).toHaveBeenCalledWith({
+    expect(notifyExternalChange).toHaveBeenCalledWith({
       type: 'resync-required',
       reason: 'bash_tool_mutation',
     })
   })
 
   it('does not call workspace.notifyExternalChange on failed exec', async () => {
-    const mockSandbox: Sandbox = {
-      provider: 'test',
-      placement: 'remote',
-      exec: vi.fn().mockResolvedValue({ exitCode: 1 }),
-    }
-
-    const mockWorkspace: Workspace & { notifyExternalChange?: (e: any) => void } = {
-      root: '/workspace',
-      fsCapability: 'best-effort',
-      notifyExternalChange: vi.fn(),
-      readFile: vi.fn(),
-      writeFile: vi.fn(),
-      readBinaryFile: vi.fn(),
-      writeBinaryFile: vi.fn(),
-      unlink: vi.fn(),
-      readdir: vi.fn(),
-      stat: vi.fn(),
-      mkdir: vi.fn(),
-      rename: vi.fn(),
-    }
+    const mockSandbox = fakeSandbox(1)
+    const notifyExternalChange = vi.fn()
+    const mockWorkspace = fakeWorkspace({ notifyExternalChange })
 
     const ops = remoteSandboxBashOps(mockSandbox, mockWorkspace)
     await ops.exec('false', '/workspace', { onData: () => {} })
 
     expect(mockSandbox.exec).toHaveBeenCalled()
-    expect(mockWorkspace.notifyExternalChange).not.toHaveBeenCalled()
+    expect(notifyExternalChange).not.toHaveBeenCalled()
   })
 
   it('does not fail if workspace does not have notifyExternalChange', async () => {
-    const mockSandbox: Sandbox = {
-      provider: 'test',
-      placement: 'remote',
-      exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
-    }
-
-    const mockWorkspace: Workspace = {
-      root: '/workspace',
-      fsCapability: 'best-effort',
-      // no notifyExternalChange method
-      readFile: vi.fn(),
-      writeFile: vi.fn(),
-      readBinaryFile: vi.fn(),
-      writeBinaryFile: vi.fn(),
-      unlink: vi.fn(),
-      readdir: vi.fn(),
-      stat: vi.fn(),
-      mkdir: vi.fn(),
-      rename: vi.fn(),
-    }
+    const mockSandbox = fakeSandbox(0)
+    const mockWorkspace = fakeWorkspace()
 
     const ops = remoteSandboxBashOps(mockSandbox, mockWorkspace)
-    await expect(ops.exec('true', '/workspace', { onData: () => {} })).resolves.not.toThrow()
+    await expect(
+      ops.exec('true', '/workspace', { onData: () => {} }),
+    ).resolves.not.toThrow()
   })
 })

--- a/packages/boring-bash/src/agent/tools/operations/__tests__/remoteSandbox.test.ts
+++ b/packages/boring-bash/src/agent/tools/operations/__tests__/remoteSandbox.test.ts
@@ -1,0 +1,93 @@
+import { vi, describe, it, expect } from 'vitest'
+import type { Sandbox, Workspace } from '@hachej/boring-agent/shared'
+import { remoteSandboxBashOps } from '../remoteSandbox'
+
+describe('remoteSandboxBashOps', () => {
+  it('calls workspace.notifyExternalChange on successful exec', async () => {
+    const mockSandbox: Sandbox = {
+      provider: 'test',
+      placement: 'remote',
+      exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+    }
+
+    const mockWorkspace: Workspace & { notifyExternalChange?: (e: any) => void } = {
+      root: '/workspace',
+      fsCapability: 'best-effort',
+      notifyExternalChange: vi.fn(),
+      // Add other required Workspace methods if needed for compilation
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      readBinaryFile: vi.fn(),
+      writeBinaryFile: vi.fn(),
+      unlink: vi.fn(),
+      readdir: vi.fn(),
+      stat: vi.fn(),
+      mkdir: vi.fn(),
+      rename: vi.fn(),
+    }
+
+    const ops = remoteSandboxBashOps(mockSandbox, mockWorkspace)
+    await ops.exec('touch /workspace/test.txt', '/workspace', { onData: () => {} })
+
+    expect(mockSandbox.exec).toHaveBeenCalled()
+    expect(mockWorkspace.notifyExternalChange).toHaveBeenCalledWith({
+      type: 'resync-required',
+      reason: 'bash_tool_mutation',
+    })
+  })
+
+  it('does not call workspace.notifyExternalChange on failed exec', async () => {
+    const mockSandbox: Sandbox = {
+      provider: 'test',
+      placement: 'remote',
+      exec: vi.fn().mockResolvedValue({ exitCode: 1 }),
+    }
+
+    const mockWorkspace: Workspace & { notifyExternalChange?: (e: any) => void } = {
+      root: '/workspace',
+      fsCapability: 'best-effort',
+      notifyExternalChange: vi.fn(),
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      readBinaryFile: vi.fn(),
+      writeBinaryFile: vi.fn(),
+      unlink: vi.fn(),
+      readdir: vi.fn(),
+      stat: vi.fn(),
+      mkdir: vi.fn(),
+      rename: vi.fn(),
+    }
+
+    const ops = remoteSandboxBashOps(mockSandbox, mockWorkspace)
+    await ops.exec('false', '/workspace', { onData: () => {} })
+
+    expect(mockSandbox.exec).toHaveBeenCalled()
+    expect(mockWorkspace.notifyExternalChange).not.toHaveBeenCalled()
+  })
+
+  it('does not fail if workspace does not have notifyExternalChange', async () => {
+    const mockSandbox: Sandbox = {
+      provider: 'test',
+      placement: 'remote',
+      exec: vi.fn().mockResolvedValue({ exitCode: 0 }),
+    }
+
+    const mockWorkspace: Workspace = {
+      root: '/workspace',
+      fsCapability: 'best-effort',
+      // no notifyExternalChange method
+      readFile: vi.fn(),
+      writeFile: vi.fn(),
+      readBinaryFile: vi.fn(),
+      writeBinaryFile: vi.fn(),
+      unlink: vi.fn(),
+      readdir: vi.fn(),
+      stat: vi.fn(),
+      mkdir: vi.fn(),
+      rename: vi.fn(),
+    }
+
+    const ops = remoteSandboxBashOps(mockSandbox, mockWorkspace)
+    await expect(ops.exec('true', '/workspace', { onData: () => {} })).resolves.not.toThrow()
+  })
+})

--- a/packages/boring-bash/src/agent/tools/operations/remoteSandbox.ts
+++ b/packages/boring-bash/src/agent/tools/operations/remoteSandbox.ts
@@ -41,8 +41,8 @@ export function remoteSandboxBashOps(sandbox: Sandbox, workspace: Workspace | un
         onStdout: (chunk) => onData(Buffer.from(chunk)),
         onStderr: (chunk) => onData(Buffer.from(chunk)),
       }).then((result) => {
-        if (result.exitCode === 0 && workspace && typeof (workspace as any).notifyExternalChange === 'function') {
-          (workspace as any).notifyExternalChange({ type: 'resync-required', reason: 'bash_tool_mutation' })
+        if (result.exitCode === 0 && typeof workspace?.notifyExternalChange === 'function') {
+          workspace.notifyExternalChange({ type: 'resync-required', reason: 'bash_tool_mutation' })
         }
         return { exitCode: result.exitCode }
       })

--- a/packages/boring-bash/src/agent/tools/operations/remoteSandbox.ts
+++ b/packages/boring-bash/src/agent/tools/operations/remoteSandbox.ts
@@ -1,6 +1,6 @@
 import type { BashOperations } from '@mariozechner/pi-coding-agent'
 
-import type { Sandbox } from '@hachej/boring-agent/shared'
+import type { Sandbox, Workspace } from '@hachej/boring-agent/shared'
 import { mergeRuntimeProvisioningEnv, type RuntimeProvisioningOptions } from '../../runtime/env'
 
 export const REMOTE_SAFE_DEFAULT_PATH = '/usr/local/bin:/usr/bin:/bin'
@@ -17,7 +17,7 @@ function mergeRemoteBashRuntimeEnv(
   })
 }
 
-export function remoteSandboxBashOps(sandbox: Sandbox, opts: {
+export function remoteSandboxBashOps(sandbox: Sandbox, workspace: Workspace | undefined, opts: {
   defaultPath?: string
   mergeEnv?: (env: Record<string, string | undefined> | undefined) => Record<string, string | undefined> | undefined
   runtime?: RuntimeProvisioningOptions
@@ -40,7 +40,12 @@ export function remoteSandboxBashOps(sandbox: Sandbox, opts: {
         timeoutMs: timeout ? timeout * 1000 : undefined,
         onStdout: (chunk) => onData(Buffer.from(chunk)),
         onStderr: (chunk) => onData(Buffer.from(chunk)),
-      }).then((result) => ({ exitCode: result.exitCode }))
+      }).then((result) => {
+        if (result.exitCode === 0 && workspace && typeof (workspace as any).notifyExternalChange === 'function') {
+          (workspace as any).notifyExternalChange({ type: 'resync-required', reason: 'bash_tool_mutation' })
+        }
+        return { exitCode: result.exitCode }
+      })
     },
   }
 }

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxWorkspace.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxWorkspace.ts
@@ -4,6 +4,7 @@ import type {
   Entry,
   Stat,
   Workspace,
+  WorkspaceWatchControlEvent,
 } from '@hachej/boring-agent/shared'
 import { validatePath } from '../node-workspace/paths'
 

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxWorkspace.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxWorkspace.ts
@@ -157,6 +157,7 @@ export function disposeVercelSandboxWorkspace(workspace: Workspace): void {
 
 export interface VercelSandboxWorkspace extends Workspace {
   invalidateMetadataCache(): void
+  notifyExternalChange(event: WorkspaceWatchControlEvent): void
 }
 
 export interface VercelSandboxWorkspaceOptions {
@@ -177,31 +178,57 @@ export interface VercelSandboxWorkspaceOptions {
  */
 function createSandboxBroadcaster(): {
   emit: (e: WorkspaceChangeEvent) => void
+  emitControl: (e: WorkspaceWatchControlEvent) => void
   watcher: WorkspaceWatcher
 } {
   const listeners = new Set<(e: WorkspaceChangeEvent) => void>()
+  const controlListeners = new Set<(e: WorkspaceWatchControlEvent) => void>()
   let closed = false
 
   const emit = (event: WorkspaceChangeEvent) => {
     if (closed) return
     for (const l of [...listeners]) {
-      try { l(event) } catch { /* swallow */ }
+      try {
+        l(event)
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+
+  const emitControl = (event: WorkspaceWatchControlEvent) => {
+    if (closed) return
+    for (const l of [...controlListeners]) {
+      try {
+        l(event)
+      } catch {
+        /* swallow */
+      }
     }
   }
 
   const watcher: WorkspaceWatcher = {
-    subscribe(listener) {
+    subscribe(listener, options) {
       if (closed) return () => {}
       listeners.add(listener)
-      return () => listeners.delete(listener)
+      if (options?.onControlEvent) {
+        controlListeners.add(options.onControlEvent)
+      }
+      return () => {
+        listeners.delete(listener)
+        if (options?.onControlEvent) {
+          controlListeners.delete(options.onControlEvent)
+        }
+      }
     },
     close() {
       closed = true
       listeners.clear()
+      controlListeners.clear()
     },
   }
 
-  return { emit, watcher }
+  return { emit, emitControl, watcher }
 }
 
 export function createVercelSandboxWorkspace(
@@ -227,7 +254,7 @@ export function createVercelSandboxWorkspace(
     invalidateMetadataCache,
   )
 
-  const { emit: emitChange, watcher } = createSandboxBroadcaster()
+  const { emit: emitChange, emitControl, watcher } = createSandboxBroadcaster()
   const remote = sandbox as VercelSandboxCompat
 
   async function assertRealPathWithinSandboxRoot(sandboxPath: string): Promise<void> {
@@ -291,6 +318,7 @@ export function createVercelSandboxWorkspace(
       return watcher
     },
     invalidateMetadataCache,
+    notifyExternalChange: emitControl,
     async readFile(relPath) {
       const sandboxPath = toSandboxPath(relPath)
       if (remote.fs?.readFile) {


### PR DESCRIPTION
Fixes #859

This change addresses an issue where file tree in vercel-sandbox mode does not auto-refresh after agent creates/edits files via BASH tool.

### Plan

The goal is to emit a filesystem change event after the `bash` tool runs in a remote sandbox, so the UI file tree refreshes.

1.  **Identify the Seam:** The best place to inject the change notification is in `packages/boring-bash/src/agent/tools/operations/remoteSandbox.ts`, inside the `remoteSandboxBashOps` function. This function wraps `sandbox.exec()` and is specific to remote sandboxes.

2.  **The Problem:** The `remoteSandboxBashOps` function only has access to the `sandbox` object, not the `workspace` object which holds the event broadcaster (`emitChange`). The `workspace` object is what's needed to send the notification.

3.  **Proposed Solution:**
    *   Modify `remoteSandboxBashOps` to accept the `workspace` object as an argument.
    *   The `Workspace` interface from `@hachej/boring-agent/shared` doesn't expose the change emitter directly. The implementation in `createVercelSandboxWorkspace` has `notifyExternalChange`, which is an `emitControl` function that can be used to send a `resync-required` event. This is a good candidate, as a coarse-grained resync is acceptable.
    *   The `VercelSandboxWorkspace` interface exposes `notifyExternalChange`. I have added this to the `Workspace` interface in `packages/agent/src/shared/workspace.ts` to make it available to `remoteSandboxBashOps`. It is optional, as not all workspace implementations will have it.
    *   The `Workspace` type is available in `RuntimeBundle`. I have threaded `bundle.workspace` from `packages/boring-bash/src/agent/tools/harness/bashToolOptions.ts` down into `remoteSandboxBashOps`.
    *   After the `sandbox.exec()` call completes successfully (exit code 0) in `remoteSandboxBashOps`, it now calls `workspace.notifyExternalChange({ type: 'resync-required', reason: 'bash-tool-mutation' })`. This will trigger the SSE event and cause the file tree to refresh.

A test has been added to verify this new behavior.