### PR TITLE
#590 fix(automation): use configured prompt files and models

### DIFF
--- a/packages/agent/src/core/createAgent.ts
+++ b/packages/agent/src/core/createAgent.ts
@@ -114,7 +114,7 @@ export function createAgentRuntimeBridge(
     }
     const service = runtime.service
     const created = await service.createSession(toPiRequestContext(input.ctx), {
-      title: contentToText(input.content ?? input.message).slice(0, 80) || undefined,
+      title: input.sessionTitle?.trim().slice(0, 80) || contentToText(input.content ?? input.message).slice(0, 80) || undefined,
     })
     rememberSessionCtx(sessionContexts, created.id, input.ctx)
     return { sessionId: created.id, sessionKey: sessionCacheKey(created.id, input.ctx), ctx: input.ctx }

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -318,7 +318,7 @@ async function applyRequestedSessionOptions(
   input: AgentSendInput,
   options: { strictModelResolution?: boolean } = {},
 ): Promise<void> {
-  const requestedModel = resolveRequestedModel(handle.modelRegistry, input, { strict: options.strictModelResolution });
+  const requestedModel = resolveRequestedModel(handle.modelRegistry, input, { strict: options.strictModelResolution || input.strictModel });
   if (requestedModel) {
     const current = handle.piSession.model;
     if (
@@ -601,7 +601,7 @@ export function createPiCodingAgentHarness(opts: {
       isNewPiSession = true;
     }
 
-    const resolvedModel = resolveRequestedModel(modelRegistry, input, { strict: pi.strictModelResolution });
+    const resolvedModel = resolveRequestedModel(modelRegistry, input, { strict: pi.strictModelResolution || input.strictModel });
     // Prefer an explicit available UI selection; otherwise use configured
     // Boring/Pi default if present. Undefined is intentional: Pi/session owns
     // the final fallback model selection.

--- a/packages/agent/src/shared/__tests__/harness.test.ts
+++ b/packages/agent/src/shared/__tests__/harness.test.ts
@@ -27,6 +27,8 @@ test('AgentSendInput contract', () => {
     actor?: { id?: string; name?: string }
     ctx?: { workspaceId?: string; userId?: string }
     originSurface?: string
+    sessionTitle?: string
+    strictModel?: boolean
   }>()
 
   expectTypeOf<AgentSendInput['thinkingLevel']>().toEqualTypeOf<

--- a/packages/agent/src/shared/events.ts
+++ b/packages/agent/src/shared/events.ts
@@ -36,6 +36,10 @@ export interface AgentSendInput {
   actor?: AgentActor
   ctx?: SessionCtx
   originSurface?: string
+  /** Used only when creating a new session; otherwise the first prompt becomes its title. */
+  sessionTitle?: string
+  /** Reject an unavailable explicit model instead of falling back to the Pi default. */
+  strictModel?: boolean
   thinkingLevel?: 'off' | 'low' | 'medium' | 'high'
   model?: {
     provider: string

--- a/plugins/boring-automation/src/front/AutomationCard.tsx
+++ b/plugins/boring-automation/src/front/AutomationCard.tsx
@@ -20,6 +20,7 @@ export function AutomationCard({
   onDeleteCancel,
   onDeleteConfirm,
   onOpenRun,
+  onOpenPrompt,
 }: {
   automation: Automation
   expanded: boolean
@@ -34,6 +35,7 @@ export function AutomationCard({
   onDeleteCancel: () => void
   onDeleteConfirm: () => void
   onOpenRun: (run: AutomationRun) => void
+  onOpenPrompt: (automation: Automation) => void
 }) {
   const historyId = `automation-runs-${automation.id}`
   const deleteTitleId = `automation-delete-title-${automation.id}`
@@ -60,6 +62,15 @@ export function AutomationCard({
           {runningNow ? "Running…" : "Run now"}
         </Button>
         <Button type="button" variant="ghost" size="sm" onClick={onEdit}>Edit</Button>
+        {automation.promptRef.startsWith(".pi/") ? (
+          <a
+            href={`#${automation.promptRef}`}
+            className="shrink-0 text-xs font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            onClick={(event) => { event.preventDefault(); onOpenPrompt(automation) }}
+          >
+            Prompt
+          </a>
+        ) : null}
         <Button type="button" variant="ghost" size="icon-sm" aria-label={`Delete ${automation.title}`} title="Delete" onClick={onDeleteRequest}>
           <Trash2 className="size-4" aria-hidden="true" />
         </Button>

--- a/plugins/boring-automation/src/front/AutomationCountBadge.tsx
+++ b/plugins/boring-automation/src/front/AutomationCountBadge.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useAutomationClient } from "./AutomationRuntimeContext"
+
+const REFRESH_INTERVAL_MS = 15_000
+
+export function AutomationCountBadge() {
+  const client = useAutomationClient()
+  const [{ total, running }, setCounts] = useState({ total: 0, running: 0 })
+
+  useEffect(() => {
+    let cancelled = false
+    const refresh = async () => {
+      try {
+        const automations = await client.listAutomations()
+        const runs = await Promise.all(automations.map(async (automation) => client.listRuns(automation.id)))
+        if (cancelled) return
+        setCounts({
+          total: automations.length,
+          running: runs.filter((automationRuns) => automationRuns.some((run) => run.status === "queued" || run.status === "running")).length,
+        })
+      } catch {
+        // The list panel owns request errors; a count failure must not hide its trigger.
+      }
+    }
+    void refresh()
+    const interval = window.setInterval(() => void refresh(), REFRESH_INTERVAL_MS)
+    return () => {
+      cancelled = true
+      window.clearInterval(interval)
+    }
+  }, [client])
+
+  if (total === 0) return null
+  return (
+    <span
+      data-boring-workspace-part="app-left-automation-count"
+      aria-label={`${running} running automation${running === 1 ? "" : "s"}, ${total} automation${total === 1 ? "" : "s"} created`}
+      className="inline-flex min-w-5 items-center justify-center rounded-full bg-[color:var(--accent)] px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm"
+    >
+      {running}/{total}
+    </span>
+  )
+}

--- a/plugins/boring-automation/src/front/AutomationForm.tsx
+++ b/plugins/boring-automation/src/front/AutomationForm.tsx
@@ -165,7 +165,6 @@ export function AutomationForm({
             className="w-full max-w-none justify-between"
             onChange={(model) => setDraft((current) => ({ ...current, model: model ? `${model.provider}:${model.id}` : "" }))}
           />
-          <FieldDescription id="automation-model-description">Uses the same available-model picker as the composer.</FieldDescription>
           {submitted && errors.model ? <FieldError id="automation-model-error">{errors.model}</FieldError> : null}
         </Field>
 
@@ -176,7 +175,6 @@ export function AutomationForm({
             className="w-full justify-between border-border/60 bg-transparent text-muted-foreground"
             onChange={(thinkingLevel) => setDraft((current) => ({ ...current, thinkingLevel }))}
           />
-          <FieldDescription>Uses the same reasoning-effort menu as the composer.</FieldDescription>
         </Field>
 
         <Field>

--- a/plugins/boring-automation/src/front/AutomationPanel.tsx
+++ b/plugins/boring-automation/src/front/AutomationPanel.tsx
@@ -251,6 +251,11 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
     setShellError(result.success ? null : result.message)
   }
 
+  function openPrompt(automation: Automation) {
+    const result = shell.openArtifact({ type: "surface", surfaceKind: "workspace.open.path", target: automation.promptRef, params: { mode: "edit" } })
+    setShellError(result.success ? null : result.message)
+  }
+
   const editorPrompt = selectedAutomation ? details[selectedAutomation.id]?.prompt ?? "" : emptyAutomationDraft().prompt
   const editorLoading = editor.mode === "edit" && selectedAutomation ? details[selectedAutomation.id]?.promptLoading === true : false
 
@@ -312,6 +317,7 @@ export function AutomationPanel({ onClose }: { onClose?: () => void }) {
                       onDeleteCancel={() => setDeleteId(null)}
                       onDeleteConfirm={() => void deleteAutomation(automation.id)}
                       onOpenRun={openRun}
+                      onOpenPrompt={openPrompt}
                     />
                   )
                 })}

--- a/plugins/boring-automation/src/front/__tests__/AutomationPanel.test.tsx
+++ b/plugins/boring-automation/src/front/__tests__/AutomationPanel.test.tsx
@@ -1,6 +1,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { Automation, AutomationRun } from "../../shared"
+import { AutomationCountBadge } from "../AutomationCountBadge"
 import { AutomationPanel } from "../AutomationPanel"
 import { AutomationClientProvider } from "../AutomationRuntimeContext"
 import type { AutomationClient } from "../client"
@@ -115,6 +116,21 @@ describe("AutomationPanel", () => {
     expect(await screen.findByText("No automations yet")).toBeInTheDocument()
   })
 
+  it("shows a prompt link that opens the canonical workspace Markdown file", async () => {
+    const existing = automation()
+    renderPanel(createClient({ listAutomations: vi.fn(async () => [existing]) }))
+
+    const prompt = await screen.findByRole("link", { name: "Prompt" })
+    expect(prompt).toHaveAttribute("href", `#${existing.promptRef}`)
+    fireEvent.click(prompt)
+    expect(shellState.current!.openArtifact).toHaveBeenCalledWith({
+      type: "surface",
+      surfaceKind: "workspace.open.path",
+      target: existing.promptRef,
+      params: { mode: "edit" },
+    })
+  })
+
   it("shows accessible route errors", async () => {
     const client = createClient({ listAutomations: vi.fn(async () => { throw new Error("list failed") }) })
 
@@ -140,6 +156,18 @@ describe("AutomationPanel", () => {
     expect(screen.getByLabelText("Timezone")).toHaveAttribute("aria-describedby", "automation-timezone-description automation-timezone-error")
     expect(screen.getByLabelText("Markdown prompt")).toHaveAttribute("aria-describedby", "automation-prompt-description")
     expect(client.createAutomation).not.toHaveBeenCalled()
+  })
+
+  it("shows running and total automation counts in the app-left badge", async () => {
+    const existing = automation()
+    const client = createClient({
+      listAutomations: vi.fn(async () => [existing, automation({ id: "auto-2" })]),
+      listRuns: vi.fn(async (id) => id === existing.id ? [automationRun({ status: "running" })] : []),
+    })
+
+    render(<AutomationClientProvider value={client}><AutomationCountBadge /></AutomationClientProvider>)
+
+    expect(await screen.findByLabelText("1 running automation, 2 automations created")).toHaveTextContent("1/2")
   })
 
   it("keeps dirty editor drafts by disabling refresh while the editor is open", async () => {

--- a/plugins/boring-automation/src/front/index.tsx
+++ b/plugins/boring-automation/src/front/index.tsx
@@ -3,6 +3,7 @@
 import { definePlugin, type BoringFrontAppLeftOverlayProps, type BoringFrontFactoryWithId } from "@hachej/boring-workspace/plugin"
 import { CalendarClock } from "lucide-react"
 import { BORING_AUTOMATION_PLUGIN_ID, BORING_AUTOMATION_PLUGIN_LABEL } from "../shared"
+import { AutomationCountBadge } from "./AutomationCountBadge"
 import { AutomationPanel } from "./AutomationPanel"
 import { AutomationRuntimeProvider } from "./AutomationRuntimeContext"
 
@@ -28,6 +29,7 @@ export const boringAutomationPlugin: BoringFrontFactoryWithId = definePlugin({
       id: "automations",
       label: BORING_AUTOMATION_PLUGIN_LABEL,
       icon: CalendarClock,
+      trailing: AutomationCountBadge,
       overlay: AutomationOverlay,
       order: 45,
     },

--- a/plugins/boring-automation/src/server/__tests__/automationStoreConformance.ts
+++ b/plugins/boring-automation/src/server/__tests__/automationStoreConformance.ts
@@ -21,7 +21,7 @@ export function runFileAutomationStoreBehaviorTests(createStore: () => FileAutom
       model: "anthropic/claude-sonnet-4",
     })
     expect(created).not.toHaveProperty("workspaceId")
-    expect(created.promptRef).toBe(`prompts/${created.id}.md`)
+    expect(created.promptRef).toBe(`.pi/automation/prompts/${created.id}.md`)
     await expect(store.getPrompt(created.id)).resolves.toBe("Summarize the repo.")
 
     await expect(store.listAutomations()).resolves.toHaveLength(1)

--- a/plugins/boring-automation/src/server/__tests__/fileStore.test.ts
+++ b/plugins/boring-automation/src/server/__tests__/fileStore.test.ts
@@ -43,7 +43,7 @@ describe("FileAutomationStore persistence", () => {
     await expect(reloaded.listRuns(automation.id)).resolves.toEqual([expect.objectContaining({ id: run.id })])
 
     const raw = JSON.parse(await readFile(join(dir, "store.json"), "utf8"))
-    expect(raw.automations[automation.id]).toMatchObject({ promptRef: `prompts/${automation.id}.md` })
+    expect(raw.automations[automation.id]).toMatchObject({ promptRef: `.pi/automation/prompts/${automation.id}.md` })
     expect(raw.automations[automation.id]).not.toHaveProperty("workspaceId")
     expect(raw.runs[run.id]).toMatchObject({
       sessionId: null,

--- a/plugins/boring-automation/src/server/__tests__/manualRunExecutor.test.ts
+++ b/plugins/boring-automation/src/server/__tests__/manualRunExecutor.test.ts
@@ -41,6 +41,22 @@ describe("ManualRunExecutor", () => {
     }))
   })
 
+  it("materializes the canonical prompt file before dispatching through a workspace binding", async () => {
+    const workspace = { mkdir: vi.fn(async () => undefined), writeFile: vi.fn(async () => undefined) }
+    const dispatcher = createDispatcher([event(0, { type: "agent-end", seq: 1, turnId: "turn-1", status: "ok" })], undefined)
+    const resolver = {
+      resolve: vi.fn(async () => dispatcher),
+      resolveWithWorkspace: vi.fn(async () => ({ dispatcher, workspace })),
+    } as unknown as WorkspaceAgentDispatcherResolver
+    const harness = createHarness({ resolver, prompt: "# Canonical prompt" })
+
+    await harness.executor.run({ automationId: harness.automation.id, request: harness.request })
+
+    expect(workspace.mkdir).toHaveBeenCalledWith(".pi/automation/prompts", { recursive: true })
+    expect(workspace.writeFile).toHaveBeenCalledWith(`.pi/automation/prompts/${harness.automation.id}.md`, "# Canonical prompt")
+    expect(resolver.resolve).not.toHaveBeenCalled()
+  })
+
   it("allows a trusted in-process caller to dispatch a fresh child session without a Fastify request", async () => {
     const harness = createHarness()
 
@@ -65,8 +81,10 @@ describe("ManualRunExecutor", () => {
       status: "succeeded",
     })
     expect(harness.dispatcher.send).toHaveBeenCalledWith(expect.objectContaining({
-      content: "canonical prompt",
+      content: "Read and carry out the automation prompt in .pi/automation/prompts/automation-1.md. Treat that Markdown file as the full user request.",
       model: { provider: "anthropic", id: "claude-sonnet" },
+      strictModel: true,
+      sessionTitle: "autom: Daily summary 2026-07-10T00:00:01.000Z",
     }))
   })
 

--- a/plugins/boring-automation/src/server/fileStore.ts
+++ b/plugins/boring-automation/src/server/fileStore.ts
@@ -265,7 +265,7 @@ export class FileAutomationStore implements AutomationStore {
 }
 
 function promptRefForId(id: string): string {
-  return `prompts/${id}.md`
+  return `.pi/automation/prompts/${id}.md`
 }
 
 function reconcileOrphanedRuns(

--- a/plugins/boring-automation/src/server/manualRunExecutor.ts
+++ b/plugins/boring-automation/src/server/manualRunExecutor.ts
@@ -83,10 +83,16 @@ export class ManualRunExecutor {
     let startedAt: string | null = null
 
     try {
-      const dispatcher = await this.options.dispatcherResolver.resolve(
-        actor,
-        input.request ? { request: input.request } : undefined,
-      )
+      const resolveOptions = input.request ? { request: input.request } : undefined
+      const binding = this.options.dispatcherResolver.resolveWithWorkspace
+        ? await this.options.dispatcherResolver.resolveWithWorkspace(actor, resolveOptions)
+        : undefined
+      const promptPath = automationPromptFilePath(automation.id)
+      if (binding) {
+        await binding.workspace.mkdir(".pi/automation/prompts", { recursive: true })
+        await binding.workspace.writeFile(promptPath, promptSnapshot)
+      }
+      const dispatcher = binding?.dispatcher ?? await this.options.dispatcherResolver.resolve(actor, resolveOptions)
       startedAt = this.nowIso()
       current = await store.updateRunLifecycle(run.id, {
         status: "running",
@@ -95,8 +101,10 @@ export class ManualRunExecutor {
       })
 
       for await (const event of dispatcher.send({
-        content: promptSnapshot,
+        content: automationPromptInstruction(promptPath),
         model,
+        strictModel: true,
+        sessionTitle: automationSessionTitle(automation.title, createdAt),
         ...(automation.thinkingLevel ? { thinkingLevel: automation.thinkingLevel } : {}),
         actor: { id: actor.userId },
         originSurface: "boring-automation",
@@ -162,6 +170,18 @@ export class ManualRunExecutor {
   private nowIso(): string {
     return this.clock().toISOString()
   }
+}
+
+export function automationPromptInstruction(path: string): string {
+  return `Read and carry out the automation prompt in ${path}. Treat that Markdown file as the full user request.`
+}
+
+export function automationPromptFilePath(automationId: string): string {
+  return `.pi/automation/prompts/${automationId}.md`
+}
+
+export function automationSessionTitle(title: string, startedAt: string): string {
+  return `autom: ${title} ${startedAt}`
 }
 
 export function parseAutomationModel(value: string): { provider: string; id: string } {


### PR DESCRIPTION
## Summary
- Remove redundant automation form copy and expose prompt Markdown links.
- Show running/total automation counts in the app-left action.
- Materialize prompt files before execution, require configured models, and name sessions predictably.

## Proof
- `pnpm --filter @hachej/boring-automation test` — 120 passed.
- `pnpm --filter @hachej/boring-automation typecheck`
- `pnpm --filter @hachej/boring-agent typecheck`
- `pnpm --filter @hachej/boring-workspace typecheck`

## Risk / rollback
- Automation runs now fail rather than silently falling back when their configured model is unavailable; this is intentional. Revert `ff7b8ab` to roll back.
