### PR TITLE
#806 feat(mcp): Step 1B MCP ingress first slice — two-tier auth (hosted / local-trusted) + typed-workspace routing

### DIFF
--- a/apps/full-app/src/server/__tests__/managedAgentMcp.test.ts
+++ b/apps/full-app/src/server/__tests__/managedAgentMcp.test.ts
@@ -25,9 +25,12 @@ import type { AgentEvent, AgentSendInput } from '@hachej/boring-agent/shared'
 import type { Workspace, Stat } from '@hachej/boring-agent/shared'
 
 const TOKEN = 'managed-agent-token'
+const LOCAL_TOKEN = 'local-trusted-token'
 const WORKSPACE_ID = 'workspace-1'
 const USER_ID = 'user-1'
 const APP_ID = 'full-app-test'
+const WORKSPACE_TYPE_ID = 'default'
+const NON_LOOPBACK_ADDRESS = '203.0.113.5'
 const utf8Encoder = new TextEncoder()
 const utf8Decoder = new TextDecoder('utf-8')
 
@@ -158,6 +161,100 @@ describe('full-app managed-agent MCP route', () => {
     expect(resolver.resolveWithWorkspace).toHaveBeenCalledTimes(1)
     expect(resolver.resolve).not.toHaveBeenCalled()
   })
+
+  it('denies a workspace whose persisted type does not match the configured type', async () => {
+    const resolver = fakeResolver()
+    const app = await makeApp(enabledEnv(), resolver, { workspaceTypeId: 'other-type' })
+
+    const result = await callDelegate(app, { brief: 'make a report' })
+
+    expect(result.isError).toBe(true)
+    expect(result.structuredContent).toMatchObject({ error: { code: ErrorCode.enum.UNAUTHORIZED } })
+    expect(resolver.resolveWithWorkspace).not.toHaveBeenCalled()
+  })
+})
+
+describe('full-app managed-agent MCP two-tier auth modes', () => {
+  it('requires the local token when local-trusted is enabled', () => {
+    expect(() => readFullAppManagedAgentMcpConfig({
+      BORING_MANAGED_AGENT_MCP_ENABLED: '1',
+      BORING_MANAGED_AGENT_MCP_AUTH_MODE: 'local-trusted',
+      BORING_MANAGED_AGENT_MCP_WORKSPACE_ID: WORKSPACE_ID,
+      BORING_MANAGED_AGENT_MCP_USER_ID: USER_ID,
+    } as NodeJS.ProcessEnv)).toThrow(/BORING_MANAGED_AGENT_MCP_LOCAL_TOKEN/)
+  })
+
+  it('rejects an unknown auth mode', () => {
+    expect(() => readFullAppManagedAgentMcpConfig({
+      BORING_MANAGED_AGENT_MCP_ENABLED: '1',
+      BORING_MANAGED_AGENT_MCP_AUTH_MODE: 'oauth',
+      BORING_MANAGED_AGENT_MCP_BEARER_TOKEN: TOKEN,
+      BORING_MANAGED_AGENT_MCP_WORKSPACE_ID: WORKSPACE_ID,
+      BORING_MANAGED_AGENT_MCP_USER_ID: USER_ID,
+    } as NodeJS.ProcessEnv)).toThrow(/hosted.*local-trusted|AUTH_MODE/)
+  })
+
+  it('accepts a loopback local-trusted caller and reaches the bound dispatcher', async () => {
+    const resolver = fakeResolver()
+    const app = await makeApp(localTrustedEnv(), resolver)
+
+    const result = await callDelegate(app, { brief: 'make a report' }, { token: LOCAL_TOKEN })
+
+    expect(result.isError).not.toBe(true)
+    expect(resolver.resolveWithWorkspace).toHaveBeenCalledOnce()
+    expect(resolver.contexts).toEqual([{ workspaceId: WORKSPACE_ID, userId: USER_ID }])
+  })
+
+  it('denies a local-trusted caller presenting the wrong local token', async () => {
+    const resolver = fakeResolver()
+    const app = await makeApp(localTrustedEnv(), resolver)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: FULL_APP_MANAGED_AGENT_MCP_PATH,
+      headers: { authorization: 'Bearer wrong-local-token' },
+      payload: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} },
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({ error: { code: ErrorCode.enum.UNAUTHORIZED, message: 'unauthorized' } })
+    expect(resolver.resolveWithWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('denies a non-loopback caller even with the correct local token', async () => {
+    const resolver = fakeResolver()
+    const app = await makeApp(localTrustedEnv(), resolver)
+
+    const response = await app.inject({
+      method: 'POST',
+      url: FULL_APP_MANAGED_AGENT_MCP_PATH,
+      remoteAddress: NON_LOOPBACK_ADDRESS,
+      headers: { authorization: `Bearer ${LOCAL_TOKEN}` },
+      payload: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} },
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(response.json()).toEqual({ error: { code: ErrorCode.enum.UNAUTHORIZED, message: 'unauthorized' } })
+    expect(resolver.resolveWithWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('does not accept the hosted bearer as a local-trusted credential shape when non-loopback', async () => {
+    const resolver = fakeResolver()
+    const app = await makeApp(localTrustedEnv(), resolver)
+
+    // A hosted bearer is a bearer just like the local token; loopback is what
+    // gates the local-trusted mode. Prove a non-loopback peer is denied.
+    const response = await app.inject({
+      method: 'POST',
+      url: FULL_APP_MANAGED_AGENT_MCP_PATH,
+      remoteAddress: NON_LOOPBACK_ADDRESS,
+      headers: { authorization: `Bearer ${LOCAL_TOKEN}` },
+      payload: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} },
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(resolver.resolveWithWorkspace).not.toHaveBeenCalled()
+  })
 })
 
 function enabledEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
@@ -170,10 +267,21 @@ function enabledEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
   } as NodeJS.ProcessEnv
 }
 
+function localTrustedEnv(extra: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return {
+    BORING_MANAGED_AGENT_MCP_ENABLED: '1',
+    BORING_MANAGED_AGENT_MCP_AUTH_MODE: 'local-trusted',
+    BORING_MANAGED_AGENT_MCP_LOCAL_TOKEN: LOCAL_TOKEN,
+    BORING_MANAGED_AGENT_MCP_WORKSPACE_ID: WORKSPACE_ID,
+    BORING_MANAGED_AGENT_MCP_USER_ID: USER_ID,
+    ...extra,
+  } as NodeJS.ProcessEnv
+}
+
 async function makeApp(
   env: NodeJS.ProcessEnv,
   resolver: ReturnType<typeof fakeResolver>,
-  options: { member?: boolean; workspaceAppId?: string } = {},
+  options: { member?: boolean; workspaceAppId?: string; workspaceTypeId?: string } = {},
 ): Promise<CoreWorkspaceAgentServer> {
   const app = Fastify()
   app.decorate('config', { appId: APP_ID } as never)
@@ -183,6 +291,7 @@ async function makeApp(
       return {
         id: workspaceId,
         appId: options.workspaceAppId ?? APP_ID,
+        workspaceTypeId: options.workspaceTypeId ?? WORKSPACE_TYPE_ID,
         name: 'Managed workspace',
         createdBy: USER_ID,
         createdAt: '2026-07-11T00:00:00.000Z',
@@ -206,11 +315,11 @@ async function makeApp(
 async function callDelegate(
   app: CoreWorkspaceAgentServer,
   args: Record<string, unknown>,
-  headers: Record<string, string> = {},
+  options: { headers?: Record<string, string>; token?: string } = {},
 ): Promise<Awaited<ReturnType<Client['callTool']>>> {
   const client = new Client({ name: 'full-app-managed-agent-test', version: '0.0.0-test' })
   try {
-    await client.connect(new FastifyInjectMcpTransport(app, headers))
+    await client.connect(new FastifyInjectMcpTransport(app, options.headers ?? {}, options.token ?? TOKEN))
     return await client.callTool({ name: 'delegate_task', arguments: args })
   } finally {
     await client.close().catch(() => undefined)
@@ -225,6 +334,7 @@ class FastifyInjectMcpTransport implements Transport {
   constructor(
     private readonly app: CoreWorkspaceAgentServer,
     private readonly headers: Record<string, string> = {},
+    private readonly token: string = TOKEN,
   ) {}
 
   async start(): Promise<void> {}
@@ -235,7 +345,7 @@ class FastifyInjectMcpTransport implements Transport {
       url: FULL_APP_MANAGED_AGENT_MCP_PATH,
       headers: {
         ...this.headers,
-        authorization: `Bearer ${TOKEN}`,
+        authorization: `Bearer ${this.token}`,
         accept: 'application/json, text/event-stream',
         'content-type': 'application/json',
       },

--- a/apps/full-app/src/server/__tests__/managedAgentMcp.test.ts
+++ b/apps/full-app/src/server/__tests__/managedAgentMcp.test.ts
@@ -238,6 +238,27 @@ describe('full-app managed-agent MCP two-tier auth modes', () => {
     expect(resolver.resolveWithWorkspace).not.toHaveBeenCalled()
   })
 
+  it('denies a spoofed X-Forwarded-For loopback header from a non-loopback socket', async () => {
+    const resolver = fakeResolver()
+    const app = await makeApp(localTrustedEnv(), resolver)
+
+    // The raw socket peer is remote; only a spoofable proxy header claims
+    // loopback. Auth must ignore the header and deny.
+    const response = await app.inject({
+      method: 'POST',
+      url: FULL_APP_MANAGED_AGENT_MCP_PATH,
+      remoteAddress: NON_LOOPBACK_ADDRESS,
+      headers: {
+        authorization: `Bearer ${LOCAL_TOKEN}`,
+        'x-forwarded-for': '127.0.0.1',
+      },
+      payload: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} },
+    })
+
+    expect(response.statusCode).toBe(401)
+    expect(resolver.resolveWithWorkspace).not.toHaveBeenCalled()
+  })
+
   it('does not accept the hosted bearer as a local-trusted credential shape when non-loopback', async () => {
     const resolver = fakeResolver()
     const app = await makeApp(localTrustedEnv(), resolver)

--- a/apps/full-app/src/server/managedAgentMcp.ts
+++ b/apps/full-app/src/server/managedAgentMcp.ts
@@ -1,5 +1,3 @@
-import { timingSafeEqual } from 'node:crypto'
-import type { IncomingMessage } from 'node:http'
 import { AsyncLocalStorage } from 'node:async_hooks'
 
 import type { FastifyReply, FastifyRequest } from 'fastify'
@@ -14,16 +12,27 @@ import {
 } from '@hachej/boring-agent/server'
 import { ErrorCode } from '@hachej/boring-agent/shared'
 import type { CoreWorkspaceAgentServer } from '@hachej/boring-core/app/server'
+import { DEFAULT_WORKSPACE_TYPE_ID, isWorkspaceTypeId } from '@hachej/boring-core/shared'
+
+import {
+  createHostedBearerAuthenticator,
+  createLocalTrustedAuthenticator,
+  isMcpIngressAuthMode,
+  type McpIngressAuthMode,
+  type McpIngressAuthenticator,
+} from './mcpIngressAuth'
 
 export const FULL_APP_MANAGED_AGENT_MCP_PATH = '/mcp/managed-agent'
 
-const BEARER_PREFIX = 'Bearer '
-
 export interface FullAppManagedAgentMcpConfig {
   enabled: boolean
+  authMode: McpIngressAuthMode
   bearerToken?: string
+  localToken?: string
   workspaceId?: string
   userId?: string
+  /** Expected persisted workspace type revalidated on every request. */
+  workspaceTypeId: string
   redactionCanaries: readonly string[]
 }
 
@@ -36,12 +45,22 @@ export function readFullAppManagedAgentMcpConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): FullAppManagedAgentMcpConfig {
   const enabled = env.BORING_MANAGED_AGENT_MCP_ENABLED === '1'
+  const authMode = resolveAuthMode(env.BORING_MANAGED_AGENT_MCP_AUTH_MODE)
   const bearerToken = trimOptional(env.BORING_MANAGED_AGENT_MCP_BEARER_TOKEN)
+  const localToken = trimOptional(env.BORING_MANAGED_AGENT_MCP_LOCAL_TOKEN)
   const workspaceId = trimOptional(env.BORING_MANAGED_AGENT_MCP_WORKSPACE_ID)
   const userId = trimOptional(env.BORING_MANAGED_AGENT_MCP_USER_ID)
+  const workspaceTypeId = resolveExpectedWorkspaceTypeId(
+    env.BORING_MANAGED_AGENT_MCP_WORKSPACE_TYPE_ID,
+  )
   if (enabled) {
+    // The credential value required depends on the deployment auth mode:
+    // hosted needs a bearer, local-trusted needs a loopback local token.
+    const credentialRequirement: [string, string | undefined] = authMode === 'local-trusted'
+      ? ['BORING_MANAGED_AGENT_MCP_LOCAL_TOKEN', localToken]
+      : ['BORING_MANAGED_AGENT_MCP_BEARER_TOKEN', bearerToken]
     const missing = [
-      ['BORING_MANAGED_AGENT_MCP_BEARER_TOKEN', bearerToken],
+      credentialRequirement,
       ['BORING_MANAGED_AGENT_MCP_WORKSPACE_ID', workspaceId],
       ['BORING_MANAGED_AGENT_MCP_USER_ID', userId],
     ].filter(([, value]) => !value).map(([name]) => name)
@@ -54,16 +73,44 @@ export function readFullAppManagedAgentMcpConfig(
   }
   return {
     enabled,
+    authMode,
     ...(bearerToken ? { bearerToken } : {}),
+    ...(localToken ? { localToken } : {}),
     ...(workspaceId ? { workspaceId } : {}),
     ...(userId ? { userId } : {}),
+    workspaceTypeId,
     redactionCanaries: [
       bearerToken,
+      localToken,
       trimOptional(env.BORING_AGENT_WORKSPACE_ROOT),
       trimOptional(env.BORING_AGENT_SESSION_ROOT),
       process.cwd(),
     ].filter((value): value is string => Boolean(value)),
   }
+}
+
+function resolveAuthMode(raw: string | undefined): McpIngressAuthMode {
+  const value = trimOptional(raw)
+  if (value === undefined) return 'hosted'
+  if (!isMcpIngressAuthMode(value)) {
+    throw new ManagedAgentMcpError(
+      ErrorCode.enum.CONFIG_INVALID,
+      'BORING_MANAGED_AGENT_MCP_AUTH_MODE must be "hosted" or "local-trusted"',
+    )
+  }
+  return value
+}
+
+function resolveExpectedWorkspaceTypeId(raw: string | undefined): string {
+  const value = trimOptional(raw)
+  if (value === undefined) return DEFAULT_WORKSPACE_TYPE_ID
+  if (!isWorkspaceTypeId(value)) {
+    throw new ManagedAgentMcpError(
+      ErrorCode.enum.CONFIG_INVALID,
+      'BORING_MANAGED_AGENT_MCP_WORKSPACE_TYPE_ID is not a valid workspace type id',
+    )
+  }
+  return value
 }
 
 export function registerFullAppManagedAgentMcpRoutes(
@@ -79,9 +126,10 @@ export function registerFullAppManagedAgentMcpRoutes(
       'managed-agent MCP requires a workspace agent dispatcher binding resolver',
     )
   }
-  const bearerToken = config.bearerToken!
   const workspaceId = config.workspaceId!
   const userId = config.userId!
+  const expectedWorkspaceTypeId = config.workspaceTypeId
+  const authenticator = createConfiguredAuthenticator(config)
   const requestStorage = new AsyncLocalStorage<FastifyRequest>()
 
   const controller = createManagedAgentMcpDelegateController({
@@ -91,7 +139,7 @@ export function registerFullAppManagedAgentMcpRoutes(
       if (ctx.workspaceId !== workspaceId || ctx.userId !== userId) {
         throw new ManagedAgentMcpError(ErrorCode.enum.UNAUTHORIZED, 'managed-agent MCP target is not authorized')
       }
-      await authorizeConfiguredTarget(app, workspaceId, userId)
+      await authorizeConfiguredTarget(app, workspaceId, userId, expectedWorkspaceTypeId)
       const request = requestStorage.getStore()
       const binding = await dispatcherResolver.resolveWithWorkspace!(
         { workspaceId, userId },
@@ -113,7 +161,8 @@ export function registerFullAppManagedAgentMcpRoutes(
     method: ['GET', 'POST', 'DELETE'],
     url: FULL_APP_MANAGED_AGENT_MCP_PATH,
     handler: async (request, reply) => {
-      if (!constantTimeBearerMatches(request, bearerToken)) {
+      const outcome = authenticator.authenticate(request)
+      if (!outcome.ok) {
         return reply.code(401).send({
           error: {
             code: ErrorCode.enum.UNAUTHORIZED,
@@ -128,13 +177,38 @@ export function registerFullAppManagedAgentMcpRoutes(
   })
 }
 
+/**
+ * Builds the two-tier {@link McpIngressAuthenticator} for the configured
+ * deployment mode. The bound principal/workspace is the SAME configured target
+ * the route revalidates on every request; authentication proves the caller, not
+ * membership.
+ */
+function createConfiguredAuthenticator(
+  config: FullAppManagedAgentMcpConfig,
+): McpIngressAuthenticator {
+  const binding = { principalUserId: config.userId!, workspaceId: config.workspaceId! }
+  if (config.authMode === 'local-trusted') {
+    return createLocalTrustedAuthenticator({ localToken: config.localToken!, binding })
+  }
+  return createHostedBearerAuthenticator({ bearerToken: config.bearerToken!, binding })
+}
+
 async function authorizeConfiguredTarget(
   app: CoreWorkspaceAgentServer,
   workspaceId: string,
   userId: string,
+  expectedWorkspaceTypeId: string,
 ): Promise<void> {
   const workspace = await app.workspaceStore.get(workspaceId)
   if (!workspace || workspace.appId !== app.config.appId || workspace.deletedAt) {
+    throw new ManagedAgentMcpError(ErrorCode.enum.UNAUTHORIZED, 'managed-agent MCP target is not authorized')
+  }
+  // Persisted workspace type is a trusted, server-derived identity (Step 1A).
+  // Revalidate it on every request so a retyped or wrong-type workspace is
+  // denied before any dispatcher/model work. Legacy rows without a persisted
+  // type fall back to the default type, matching Core's own default.
+  const persistedWorkspaceTypeId = workspace.workspaceTypeId ?? DEFAULT_WORKSPACE_TYPE_ID
+  if (persistedWorkspaceTypeId !== expectedWorkspaceTypeId) {
     throw new ManagedAgentMcpError(ErrorCode.enum.UNAUTHORIZED, 'managed-agent MCP target is not authorized')
   }
   if (!await app.workspaceStore.isMember(workspaceId, userId)) {
@@ -183,26 +257,6 @@ async function handleStreamableHttpRequest(
       reply.raw.end()
     }
   }
-}
-
-function constantTimeBearerMatches(request: FastifyRequest, expectedToken: string): boolean {
-  const provided = bearerTokenFromRequest(request.raw)
-  if (!provided) return false
-  const expected = Buffer.from(expectedToken)
-  const actual = Buffer.from(provided)
-  if (expected.byteLength !== actual.byteLength) {
-    timingSafeEqual(expected, expected)
-    return false
-  }
-  return timingSafeEqual(expected, actual)
-}
-
-function bearerTokenFromRequest(request: IncomingMessage): string | undefined {
-  const authorization = request.headers.authorization
-  if (typeof authorization !== 'string') return undefined
-  if (!authorization.startsWith(BEARER_PREFIX)) return undefined
-  const token = authorization.slice(BEARER_PREFIX.length).trim()
-  return token || undefined
 }
 
 function trimOptional(value: string | undefined): string | undefined {

--- a/apps/full-app/src/server/mcpIngressAuth.ts
+++ b/apps/full-app/src/server/mcpIngressAuth.ts
@@ -135,12 +135,12 @@ export function createLocalTrustedAuthenticator(
 }
 
 function isLoopbackRequest(request: FastifyRequest, loopback: ReadonlySet<string>): boolean {
+  // Only the raw socket peer address is trusted. `request.ip` must NOT be used:
+  // under Fastify `trustProxy` it derives from `X-Forwarded-For`, which a remote
+  // caller can spoof to impersonate a loopback peer. Fail closed when the raw
+  // peer address is unavailable.
   const socketAddress = request.raw.socket?.remoteAddress
-  if (socketAddress && loopback.has(socketAddress)) return true
-  // Fastify normalizes the peer address onto `request.ip`; fall back to it when
-  // the raw socket address is unavailable (e.g. light-my-request injection).
-  const requestIp = request.ip
-  return Boolean(requestIp && loopback.has(requestIp))
+  return Boolean(socketAddress && loopback.has(socketAddress))
 }
 
 function bearerTokenFromRequest(request: IncomingMessage): string | undefined {

--- a/apps/full-app/src/server/mcpIngressAuth.ts
+++ b/apps/full-app/src/server/mcpIngressAuth.ts
@@ -1,0 +1,166 @@
+import { timingSafeEqual } from 'node:crypto'
+import type { IncomingMessage } from 'node:http'
+
+import type { FastifyRequest } from 'fastify'
+import { ManagedAgentMcpError } from '@hachej/boring-agent/server'
+import { ErrorCode } from '@hachej/boring-agent/shared'
+
+/**
+ * Step 1B MCP ingress (#806) two-tier authentication seam.
+ *
+ * The same managed-agent MCP ingress path serves two deployment shapes, with
+ * the mode chosen by deployment/runtime config (mirrors `BORING_AGENT_MODE`):
+ *
+ * - `hosted` (SaaS / full-app on a server): external MCP clients are UNTRUSTED
+ *   and must AUTHENTICATE. This slice ships a static, secret-backed bearer
+ *   binding. Full OAuth (the MCP-spec authorization server / per-user issued
+ *   bearers) is the NEXT slice — it drops in as another {@link
+ *   McpIngressAuthenticator} without touching the route.
+ * - `local-trusted` (CLI / a locally-running agent): the peer is a TRUSTED
+ *   co-located process. Authentication is a lightweight loopback + local-token
+ *   check, NOT the full OAuth dance.
+ *
+ * Authentication only proves *who is calling* and *which bound principal /
+ * workspace* the credential maps to. It never grants membership: the route
+ * still revalidates app + membership + persisted workspace type before any
+ * dispatcher or model work. See {@link AGENT-CONSUMPTION-MODES.md} Mode 0.
+ */
+export const MCP_INGRESS_AUTH_MODES = ['hosted', 'local-trusted'] as const
+
+export type McpIngressAuthMode = (typeof MCP_INGRESS_AUTH_MODES)[number]
+
+export function isMcpIngressAuthMode(value: unknown): value is McpIngressAuthMode {
+  return typeof value === 'string' && (MCP_INGRESS_AUTH_MODES as readonly string[]).includes(value)
+}
+
+/**
+ * The bound principal/workspace a successful authentication resolves to. This
+ * is the credential binding only; membership and workspace type are revalidated
+ * by the route on every request against live Core authority.
+ */
+export interface McpIngressPrincipalBinding {
+  readonly principalUserId: string
+  readonly workspaceId: string
+}
+
+export type McpIngressAuthOutcome =
+  | { readonly ok: true; readonly binding: McpIngressPrincipalBinding }
+  | { readonly ok: false }
+
+export interface McpIngressAuthenticator {
+  readonly mode: McpIngressAuthMode
+  /**
+   * Decide whether the request is authenticated. Must run BEFORE any workspace
+   * load, dispatcher resolution, or model work, and must never disclose which
+   * check failed.
+   */
+  authenticate(request: FastifyRequest): McpIngressAuthOutcome
+}
+
+const BEARER_PREFIX = 'Bearer '
+
+/** Loopback peers accepted by the `local-trusted` authenticator. */
+const LOOPBACK_ADDRESSES = new Set<string>([
+  '127.0.0.1',
+  '::1',
+  '::ffff:127.0.0.1',
+])
+
+export interface HostedBearerAuthenticatorOptions {
+  readonly bearerToken: string
+  readonly binding: McpIngressPrincipalBinding
+}
+
+/**
+ * HOSTED path. Untrusted external clients present a static, secret-backed
+ * bearer (constant-time compare). Slice-1 authenticated-bearer cut; OAuth is
+ * the next slice.
+ */
+export function createHostedBearerAuthenticator(
+  options: HostedBearerAuthenticatorOptions,
+): McpIngressAuthenticator {
+  const { bearerToken, binding } = options
+  if (!bearerToken) {
+    throw new ManagedAgentMcpError(
+      ErrorCode.enum.CONFIG_INVALID,
+      'managed-agent MCP hosted auth requires a bearer token',
+    )
+  }
+  return {
+    mode: 'hosted',
+    authenticate(request) {
+      const provided = bearerTokenFromRequest(request.raw)
+      if (!provided) return { ok: false }
+      if (!constantTimeEquals(bearerToken, provided)) return { ok: false }
+      return { ok: true, binding }
+    },
+  }
+}
+
+export interface LocalTrustedAuthenticatorOptions {
+  readonly localToken: string
+  readonly binding: McpIngressPrincipalBinding
+  /** Override for tests; defaults to {@link LOOPBACK_ADDRESSES}. */
+  readonly loopbackAddresses?: Iterable<string>
+}
+
+/**
+ * LOCAL / CLI path. A co-located trusted agent authenticates via loopback +
+ * local token. A non-loopback peer is denied even with the correct token; a
+ * missing/wrong token is denied. No OAuth.
+ */
+export function createLocalTrustedAuthenticator(
+  options: LocalTrustedAuthenticatorOptions,
+): McpIngressAuthenticator {
+  const { localToken, binding } = options
+  if (!localToken) {
+    throw new ManagedAgentMcpError(
+      ErrorCode.enum.CONFIG_INVALID,
+      'managed-agent MCP local-trusted auth requires a local token',
+    )
+  }
+  const loopback = new Set<string>(options.loopbackAddresses ?? LOOPBACK_ADDRESSES)
+  return {
+    mode: 'local-trusted',
+    authenticate(request) {
+      // Loopback is required and checked first: a non-loopback peer must be
+      // denied even if it somehow presents the correct local token.
+      if (!isLoopbackRequest(request, loopback)) return { ok: false }
+      const provided = bearerTokenFromRequest(request.raw)
+      if (!provided) return { ok: false }
+      if (!constantTimeEquals(localToken, provided)) return { ok: false }
+      return { ok: true, binding }
+    },
+  }
+}
+
+function isLoopbackRequest(request: FastifyRequest, loopback: ReadonlySet<string>): boolean {
+  const socketAddress = request.raw.socket?.remoteAddress
+  if (socketAddress && loopback.has(socketAddress)) return true
+  // Fastify normalizes the peer address onto `request.ip`; fall back to it when
+  // the raw socket address is unavailable (e.g. light-my-request injection).
+  const requestIp = request.ip
+  return Boolean(requestIp && loopback.has(requestIp))
+}
+
+function bearerTokenFromRequest(request: IncomingMessage): string | undefined {
+  const authorization = request.headers.authorization
+  if (typeof authorization !== 'string') return undefined
+  if (!authorization.startsWith(BEARER_PREFIX)) return undefined
+  const token = authorization.slice(BEARER_PREFIX.length).trim()
+  return token || undefined
+}
+
+/**
+ * Constant-time string comparison that does not early-return on length
+ * mismatch length disclosure.
+ */
+function constantTimeEquals(expected: string, actual: string): boolean {
+  const expectedBytes = Buffer.from(expected)
+  const actualBytes = Buffer.from(actual)
+  if (expectedBytes.byteLength !== actualBytes.byteLength) {
+    timingSafeEqual(expectedBytes, expectedBytes)
+    return false
+  }
+  return timingSafeEqual(expectedBytes, actualBytes)
+}


### PR DESCRIPTION
## Summary

Step 1B first slice for **#806 MCP ingress** — an authenticated external MCP
client reaching a **typed workspace's sole agent** through the *existing*
managed-agent MCP server and dispatcher. This slice introduces the **two-tier
auth-mode abstraction** the owner requires (`hosted` vs `local-trusted`) so one
ingress path serves both the SaaS/hosted deployment and the CLI/local-agent
deployment, with the mode selected at runtime (mirrors `BORING_AGENT_MODE`).

It reuses `managedAgentMcpServer` / `managedAgentDelegate` and consumes
`WorkspaceAgentDispatcherResolver.resolveWithWorkspace` **as-is** — **zero
changes to resolution/dispatch internals**. It adds per-request revalidation of
workspace app, membership, and **persisted `workspaceTypeId`** before dispatch.
The route stays **dark by default**.

## Issue / Slice

Issue #806, Decision 26 Step 1B. Slice = "1B.1 (auth-mode + type revalidation)",
the honest first cut of `docs/issues/806/plan.md` §Remaining-work slices,
building only against seams already on `origin/main`.

## What Changed

New module `apps/full-app/src/server/mcpIngressAuth.ts`:

- `McpIngressAuthMode = 'hosted' | 'local-trusted'` — the two-tier seam.
- `McpIngressAuthenticator` interface: `authenticate(request) -> AuthOutcome`
  (authorized principal **or** a non-disclosing denial), run **before** any
  workspace load or dispatcher/model work.
- `createHostedBearerAuthenticator` — the HOSTED path. Untrusted external
  clients authenticate with a static, secret-backed bearer (constant-time
  compare) that binds to one configured principal + workspace. This is the
  **basic authenticated-bearer** cut; **full OAuth (the MCP-spec authorization
  server) is deferred to the NEXT slice** — the seam is shaped so an
  OAuth authenticator drops in without touching the route.
- `createLocalTrustedAuthenticator` — the CLI/LOCAL path, **fully implemented**.
  A trusted co-located agent authenticates via **loopback + a local token**:
  the request peer address must be loopback (`127.0.0.1` / `::1`) **and** a
  local token must match (constant-time). A non-loopback peer is denied **even
  with the correct token**; a wrong/missing token is denied. No OAuth dance.

`apps/full-app/src/server/managedAgentMcp.ts`:

- Config gains `BORING_MANAGED_AGENT_MCP_AUTH_MODE` (`hosted` default) and
  `BORING_MANAGED_AGENT_MCP_LOCAL_TOKEN` (required + validated only in
  `local-trusted`), plus `BORING_MANAGED_AGENT_MCP_WORKSPACE_TYPE_ID`
  (expected persisted type, defaults to `DEFAULT_WORKSPACE_TYPE_ID`).
- The route delegates authentication to the selected `McpIngressAuthenticator`,
  then revalidates app + non-deleted workspace + membership + **persisted
  `workspaceTypeId` == expected type** in `authorizeConfiguredTarget` before
  calling `resolveWithWorkspace`. The dispatcher continues to select the sole
  workspace agent internally (no agent selection is re-derived in the host).
- Dark-by-default unchanged: no route mounts unless
  `BORING_MANAGED_AGENT_MCP_ENABLED=1` and all mode-required config validates at
  startup (missing values throw `CONFIG_INVALID`).

## Proof
- Exact command: `pnpm --filter full-app test src/server/__tests__/managedAgentMcp.test.ts`
  and `pnpm --filter full-app run typecheck`; `pnpm --filter @hachej/boring-agent run typecheck`;
  `pnpm lint:invariants`. (Results in PR comment.)
- Tests added: hosted-bearer accepted; local-trusted loopback+token accepted;
  local-trusted **non-loopback denied even with correct token**; local-trusted
  wrong token denied; wrong workspace type denied (`UNAUTHORIZED`, no dispatch);
  non-member / app-mismatch denied (retained); dark-by-default 404; config
  validation per mode. All denials assert **no `resolveWithWorkspace` call** and
  no token/root/path leakage in the response.

## Review
- Standards / Spec: consumes existing resolver+controller; only host binding +
  auth-mode added. No resolution internals touched.
- Reviewed SHA: <filled in PR comment>

## Risk / Rollback

Auth surface → labeled `security-review-required`. Rollback = unset
`BORING_MANAGED_AGENT_MCP_ENABLED` and restart; web routing and persisted data
untouched. No new persistence, no migration.

## Deferred to the NEXT slice(s)

- **Full hosted OAuth** — the MCP-spec authorization server / per-user issued
  bearers. Slice 1 ships the authenticated-bearer seam only.
- **Typed-domain resolution** — effective-hostname → workspace-type resolver and
  exact-audience matching land with #845 (1A.2a). This slice binds
  credential→workspace and revalidates persisted `workspaceTypeId` (already on
  main); the domain resolver slots into `authorizeConfiguredTarget` when #845
  merges.
- **Retry-safe bounded admission (1B.2)** — `idempotencyKey`, per-credential
  rate/concurrency, progress/status byte caps.
- **Sole-`agentTypeId` derivation from type** — arrives with 1A sole-agent
  selection; today the dispatcher supplies the workspace's sole/default agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uy8snWzDKyjZBhsFco4Du5
