### PR TITLE
fix(workspace): clear stale app-left selection

### DIFF
--- a/packages/workspace/src/app/front/PluginAppLeftHost.tsx
+++ b/packages/workspace/src/app/front/PluginAppLeftHost.tsx
@@ -60,7 +60,7 @@ export function usePluginAppLeftActions({
           setActiveOverlay((current) => current === action.id ? null : action.id)
         },
       }
-    }), [plugins, setActiveOverlay])
+    }), [activeOverlay, plugins, setActiveOverlay])
 }
 
 export function PluginAppLeftOverlayHost({

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -396,6 +396,44 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.getByRole("button", { name: "Open app navigation" })).toBeInTheDocument()
   })
 
+  it("keeps only the current app-left overlay action selected", async () => {
+    const user = userEvent.setup()
+    const automationPlugin = definePlugin({
+      id: "automation-action",
+      appLeftActions: [{ id: "automations", label: "Automations", overlay: () => <div>Automation overlay</div> }],
+    })
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="plugin-tabs-active-overlay"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        plugins={[automationPlugin]}
+        persistenceEnabled={false}
+      />,
+    )
+
+    const appNav = screen.getByLabelText("App navigation")
+    const automations = within(appNav).getByRole("button", { name: "Automations" })
+    const plugins = within(appNav).getByRole("button", { name: "Plugins" })
+
+    await user.click(automations)
+    expect(automations).toHaveAttribute("data-active", "true")
+    expect(plugins).not.toHaveAttribute("data-active")
+
+    await user.click(plugins)
+    expect(automations).not.toHaveAttribute("data-active")
+    expect(plugins).toHaveAttribute("data-active", "true")
+
+    await user.click(automations)
+    expect(automations).toHaveAttribute("data-active", "true")
+    expect(plugins).not.toHaveAttribute("data-active")
+
+    await user.click(automations)
+    expect(automations).not.toHaveAttribute("data-active")
+    expect(plugins).not.toHaveAttribute("data-active")
+  })
+
   it("rejects plugin app-left actions that collide with built-in overlays", () => {
     const collidingPlugin = definePlugin({
       id: "colliding-action",


### PR DESCRIPTION
Closes #883

## Summary

Fixes the stale amber selection background/dot reported while testing Automations. Plugin-contributed app-left actions memoized their `active` value without depending on the current overlay, so switching from Automations to Plugins updated the built-in row but left Automations visually selected.

## What changed

- Added `activeOverlay` to `usePluginAppLeftActions` memo dependencies.
- Added a public `WorkspaceAgentFront` regression covering:
  - plugin → built-in;
  - built-in → plugin;
  - closing the selected plugin overlay;
  - exactly one `data-active="true"` row at a time.

## Proof

- `pnpm --filter @hachej/boring-workspace... --workspace-concurrency=4 run build` ✅
- `pnpm --filter @hachej/boring-workspace exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx` ✅ — 61 tests
- `pnpm --filter @hachej/boring-workspace typecheck` ✅
- `pnpm check:generated-artifacts` ✅
- `git diff --check` ✅

## Review

- Tier-1 Sol high standards/spec/thermo review: **CLEAN**
- Reviewed implementation: one dependency correction plus one shell-level regression test.

## Risk / rollback

Very low. This only makes the memo recompute when its captured `active` input changes. Revert commit `3284147` to roll back.

## Manual verification

1. Open Automations from app navigation.
2. Switch to Plugins or Skills.
3. Confirm only the newly selected row has the amber background/dot.
4. Select Automations again, then close it; confirm no stale selected row remains.
