### PR TITLE
fix(workspace): eliminate dnd-core post-teardown flake in ChatPanelHost test

### DIFF
--- a/packages/workspace/vitest.setup.ts
+++ b/packages/workspace/vitest.setup.ts
@@ -10,6 +10,20 @@
 import { expect, afterEach } from "vitest"
 import * as matchers from "@testing-library/jest-dom/matchers"
 import { cleanup } from "@testing-library/react"
+// Eagerly warm the lazily-loaded file-tree module graph (react-arborist +
+// dnd-core + react-dnd-html5-backend) into the module cache before any test
+// runs. The filesystem plugin's `FilesystemTreePreloadBinding` — mounted by
+// every `WorkspaceProvider` render — fires a fire-and-forget
+// `import("./FileTree")` from a mount effect. That dynamic import cannot be
+// cancelled on unmount, so under CI timing it can resolve *after* Vitest tears
+// the environment down, and its transitive `dnd-core` fetch then throws
+// `EnvironmentTeardownError: Cannot load dnd-core ... after the environment was
+// torn down` — false-failing unrelated PRs. Vitest only throws on a real module
+// *fetch*; a module already evaluated in the cache resolves synchronously with
+// no server round-trip. Warming the graph here means the preload's dynamic
+// import always hits the cache and never races teardown. Keep this import bare
+// (no side effects at module top; the HTML5 backend is only built at render).
+import "@/plugins/filesystemPlugin/front/file-tree/FileTree"
 
 expect.extend(matchers)
 


### PR DESCRIPTION
## Root cause

`ChatPanelHost.test.tsx` renders `WorkspaceProvider`, which bootstraps the filesystem plugin. That plugin registers `FilesystemTreePreloadBinding` — a binding whose mount effect fires a fire-and-forget `import("./FileTree")` to warm the lazily-loaded file tree.

`FileTree.tsx` statically imports `dnd-core` (via `dndManager.ts`), `react-dnd-html5-backend`, and `react-arborist`. That dynamic import **cannot be cancelled on unmount**, so under CI timing it resolves *after* Vitest tears the test environment down. Its transitive `dnd-core` fetch then throws:

```
EnvironmentTeardownError: Cannot load dnd-core .../index.js after the environment was torn down
```

This false-failed unrelated PRs (#831, #892, others) on `Unit Tests` / `Unit Tests Changed`.

## Fix

Eagerly warm the FileTree module graph in `packages/workspace/vitest.setup.ts`.

Vitest only throws `EnvironmentTeardownError` on a real module **fetch** (server round-trip in `VitestTransport.fetchModule`). A module already evaluated in the module cache resolves synchronously via `cachedRequest` with no fetch. Pre-loading the graph in the shared setup — which runs before any test in every file — means the preload binding's dynamic `import("./FileTree")` always hits the cache and can never race teardown.

- Fixes it for **every** `WorkspaceProvider`-rendering test, not just `ChatPanelHost`.
- The import is bare and side-effect-free (the HTML5 backend is only constructed at render, not at module eval), so it adds nothing to test behavior.
- No product code changed; one test-setup line + explanatory comment.

## Evidence

- `ChatPanelHost.test.tsx`: **8/8 consecutive passes**, zero teardown errors.
- Full `packages/workspace` suite: **1727 passed / 10 skipped**, no `dnd-core`/teardown errors. (One `createWorkspaceAgentServer` failure was a local worktree missing-`dist` artifact — went green after building the workspace dist; not a regression.)
- Typecheck (`tsc` front + server projects): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uy8snWzDKyjZBhsFco4Du5