### PR TITLE
#900 plan: thin full-catalog Composio wrapper

### DIFF
--- a/docs/issues/900/plan.md
+++ b/docs/issues/900/plan.md
@@ -1,0 +1,1078 @@
+---
+github: https://github.com/hachej/boring-ui/issues/900
+issue: 900
+state: ready-for-human
+updated: 2026-07-22
+flag: flag:boring-mcp-catalog-v1
+track: owner
+---
+
+# gh-900 Full MCP catalogs, remote servers, and approved execution
+
+## Authority and named consumer
+
+This is the canonical reusable-package plan for issue #900. The named product
+consumer is generic Seneca issue
+[`hachej/seneca#35`](https://github.com/hachej/seneca/issues/35).
+
+This plan is about **agents consuming external MCP tools**. It is not:
+
+- issue #806's opposite-direction ingress, where an external MCP client invokes
+  a Boring agent;
+- the curated Constellation tenant policy, which may remain a static restricted
+  Notion/Airtable deployment; or
+- arbitrary local `stdio` process installation on a shared host.
+
+The plan is ready for owner/security review, not implementation dispatch. It
+changes public package contracts, workspace authority, OAuth, credential
+identity, outbound networking, execution permissions, and the meaning of
+“enabled MCP tool.” No Beads are created by this plan.
+
+## Problem
+
+### User problem
+
+Generic Seneca is intended to be a general agent application, but its current
+MCP surface exposes only two statically configured Composio toolkits: Notion and
+Airtable. A user cannot browse the complete Composio catalog, discover remote
+servers from the official MCP Registry, or connect a remote MCP endpoint by
+URL. The agent can execute only a small exact read-only allowlist.
+
+The desired product is:
+
+1. every valid Composio app-native tool can be discovered and described;
+2. active remote servers in the official MCP Registry can be browsed and
+   connected when they offer a compatible endpoint;
+3. a workspace owner can add a custom remote HTTPS MCP endpoint;
+4. all valid discovered tools remain available through the governed proxy
+   surface rather than being silently hidden because they are not on a static
+   provider list;
+5. only host-classified safe reads execute without interruption; and
+6. write, destructive, administrative, open-world, or unknown operations cannot
+   reach a provider until the current human explicitly approves that exact
+   invocation through Ask User.
+
+### Current implementation
+
+`@hachej/boring-mcp` already supplies valuable foundations:
+
+- an app-left MCP source overlay;
+- actor-owned source access and secret-free DTOs;
+- a real MCP SDK Streamable HTTP client;
+- Composio v3.1 Session creation and hosted connection links;
+- source status, discovery, normalized schema hashes, redaction, rate limits,
+  timeout wrappers, and stable MCP errors;
+- seven context-efficient bridge tools, including search/describe and governed
+  read-only execution; and
+- app-injected persistence and credential resolution.
+
+The current restrictions are structural, not only configuration:
+
+- `DEFAULT_MCP_PROVIDER_TEMPLATES` contains only Notion and Airtable.
+- Seneca's front and server compositions list only those providers.
+- every Composio Session sends `toolkits.enable: [toolkitId]` and therefore
+  enables exactly one toolkit;
+- Composio meta-tools are hidden, while internal discovery searches only the
+  configured toolkit and caps the result set;
+- `McpDiscoveredTool` drops protocol annotations and output schemas;
+- catalog normalization denies any tool not on an exact static read allowlist;
+- the only execution bridge is `mcp_readonly_call`;
+- `createMcpSdkStreamableHttpTransport` accepts an endpoint but has no hosted
+  source lifecycle, OAuth provider, SSRF-safe fetch boundary, redirect policy,
+  or credential profile;
+- source metadata lives under a per-user server-owned settings key in consuming
+  apps; and
+- Ask User and MCP are composed as independent runtimes, with no enforcement
+  seam connecting approval to provider execution.
+
+### Existing owner-ratified dependency
+
+Issue #820's owner-ratified credential-vault plan already decides that provider
+credentials become workspace-scoped, owner-managed, host-resolved credentials;
+`@hachej/boring-mcp` must migrate onto that common mechanism instead of creating
+another secret store or onboarding surface. Its sequence is:
+
+```text
+16f.1 credential/provider contract
+-> 16f.2 encrypted vault storage
+-> 16f.3 owner-only API-key/OAuth onboarding
+-> 16f.4 boring-mcp migration onto the common mechanism
+```
+
+Open PR #893 is the current `16f.1` contract candidate. This plan neither copies
+nor bypasses it. MCP source/account secrets, OAuth refresh tokens, bearer/API
+keys, and session headers must use the landed #820 authority and custody path.
+The operator-owned Composio project key remains an operator secret.
+
+This feature also triggers a deliberately deferred #820 decision: custom MCP
+servers are a named consumer that needs more than one credential profile for the
+same provider kind. The required identity is one profile per remote source,
+semantically keyed by `(workspaceId, providerId, profileId)`, where `profileId`
+is a host-generated opaque source identity and never caller authority. The
+implementation must amend Decision 27/#820 before changing the v1 credential
+contract or schema. It must not simulate profiles with tenant-authored dynamic
+provider registrations. If approved, slice 900.0 inserts after `16f.1` and before
+`16f.2`, because vault schema and onboarding must not first ship a one-profile
+identity that this named consumer immediately replaces.
+
+## Solution
+
+### Product surface
+
+The MCP overlay becomes one management surface with four views:
+
+1. **Connected** — workspace MCP sources/accounts, health, provenance, tools,
+   authorization state, and disconnect/revoke controls.
+2. **Composio apps** — server-side search/pagination over the complete Composio
+   toolkit catalog, connection readiness, and on-demand hosted connection.
+3. **MCP Registry** — search over a validated last-known-good mirror of active
+   official Registry metadata, showing only compatible remote transports as
+   connectable.
+4. **Custom server** — owner enters a display name and HTTPS Streamable HTTP URL,
+   chooses automatic OAuth, no auth, bearer, or an approved API-key mode, and
+   reviews the server identity/capabilities discovered by a guarded probe.
+
+Members may list/use workspace-connected sources. Only current workspace owners
+may create, connect, replace, disable, revoke, or delete a source or credential.
+A source identifier, provider identifier, Registry name, endpoint, or Agent tool
+argument never grants workspace authority.
+
+### Meaning of “all tools”
+
+“All tools available” has a precise v1 meaning:
+
+- every protocol-valid **app-native** tool discovered through an enabled source
+  can be searched, described, and submitted to the governed `mcp_tool_call`
+  boundary;
+- tools are not loaded en masse into the model context; the stable
+  search/describe/call proxy pattern remains;
+- unsupported names, malformed/oversized schemas, secret-bearing metadata, or
+  protocol-invalid results fail closed with stable errors rather than entering
+  the catalog;
+- Composio catalog/auth/schema/execute meta-tools remain server implementation
+  details, not agent-callable tools; and
+- Composio remote workbench/bash meta-tools are disabled for this release. They
+  are a separate remote-code product, not an app-native toolkit action.
+
+Availability is distinct from automatic execution. A catalog entry reports one
+of:
+
+- `direct` — host policy has classified the exact current tool as a safe read;
+- `approval-required` — the tool is available but needs one exact human
+  approval;
+- `blocked` — only for invalid protocol data, an unsafe/unavailable source,
+  missing authority/credentials, or an explicit deployment deny policy.
+
+The system no longer uses `enabled: false` as a synonym for “not on the old
+read-only list.”
+
+### Architecture
+
+```text
+MCP overlay / agent bridge
+        |
+        v
+workspace-authorized MCP application service
+        |
+        +-- catalog adapters
+        |     +-- Composio full-catalog Session adapter
+        |     +-- official Registry mirror/search adapter
+        |
+        +-- workspace source/account registry
+        |     +-- Composio catalog source + connected toolkit accounts
+        |     +-- Registry-derived remote source
+        |     +-- custom remote source
+        |
+        +-- #820 workspace credential resolver
+        |     +-- external-managed Composio account reference
+        |     +-- standard MCP OAuth refresh/access lifecycle
+        |     +-- bearer/API-key profile per remote source
+        |
+        +-- guarded remote transport
+        |     +-- URL/redirect/DNS policy
+        |     +-- egress proxy
+        |     +-- MCP SDK Streamable HTTP + OAuth provider
+        |
+        +-- catalog + host risk policy
+        |
+        +-- governed execution boundary
+              +-- direct safe read
+              +-- exact Ask User approval -> revalidate -> one provider call
+```
+
+`@hachej/boring-mcp` remains the external-MCP consumption owner. Core owns
+workspace authorization and the #820 credential store. Ask User owns questions
+and human answers. The host app composes these capabilities; no package gains a
+second workspace/runtime authority.
+
+## Decisions
+
+### 1. Workspace authority replaces personal source authority
+
+New sources and credentials are workspace-scoped. `createdByUserId` is audit
+metadata only. Current membership is checked for every source read and tool
+call; current owner role is checked for every lifecycle mutation.
+
+Existing personal `__serverBoringMcpSourcesV1` records stay personal until the
+#820 migration performs inventory and consent quarantine. No connection is
+automatically promoted, even if only one exists. Promotion requires the
+connected member's consent and current owner approval/reconnection. Departed
+users and collisions cannot be promoted automatically.
+
+### 2. Credential profiles are source-scoped without dynamic providers
+
+The host registers stable provider kinds such as `composio` and `mcp-remote`.
+A custom/Registry remote source receives an opaque host-generated `profileId`
+equal to or derived from its opaque source identity. The common credential
+resolver accepts that trusted profile identity only through a host-owned MCP
+consumer binding.
+
+The browser, model, and endpoint never construct or widen credential references.
+A source in workspace A cannot select workspace B's profile, and deleting one
+remote source does not revoke another remote source of the same provider kind.
+This is the named-consumer amendment required by #820's one-profile decision.
+
+### 3. One Composio catalog source per workspace
+
+Composio uses one virtual catalog source per workspace rather than one static
+provider template per app. A random opaque custodian subject identifies the
+workspace to Composio; raw Boring workspace/user identifiers are not sent as
+Composio `user_id` values. Multiple toolkit accounts live under that custodian
+subject and appear as child connection records in the UI. A current workspace
+owner must select the active account for a toolkit; execution never inherits
+Composio's “most recently connected” fallback. Account selection is a
+source-revisioned, auditable metadata change and a tool call rechecks it.
+
+Full-catalog Sessions omit `toolkits.enable`. Search/schema/execute meta-tools
+are called only inside the adapter. Toolkit linking remains an authenticated
+server route and validates toolkit slugs against live Composio catalog results.
+Session sandbox/workbench support is disabled.
+
+Composio managed auth works without app credentials for supported toolkits.
+Toolkits requiring custom developer credentials or unsupported auth remain
+visible with an actionable “provider setup required” state; “full catalog” does
+not claim that every external vendor can authenticate without configuration.
+
+### 4. Registry metadata is discovery, not trust
+
+The official MCP Registry is preview infrastructure and explicitly provides no
+uptime or durability guarantee. Seneca does not query it on every user search.
+A host adapter refreshes a bounded last-known-good snapshot no more than hourly,
+using cursor pagination, schema/size validation, active/latest status filtering,
+and atomic replacement only after a complete successful refresh. Search is
+local. A cold cache may report Registry unavailable without affecting existing
+connections.
+
+At connect time, the source stores the selected Registry name, version, remote
+transport, canonical endpoint fingerprint, record hash, publication status,
+and retrieval time as provenance. This metadata does not make the server or its
+tool annotations trusted. Registry-derived and custom sources deduplicate on the
+canonical endpoint fingerprint within one workspace: connecting the same remote
+cannot silently create a second credential/profile or bypass a quarantine; the
+owner is directed to the existing source or performs an explicit provenance
+conversion. A later `deleted` moderation state quarantines new calls
+from a Registry-derived source until an owner explicitly reconnects it as a
+custom source after seeing the warning; `deprecated` produces a warning.
+
+Only exact HTTPS `streamable-http` remotes are connectable in v1. SSE-only,
+package/`stdio`, and unresolved template-variable records remain discoverable
+but are marked unsupported. Registry cache loss never deletes a connected
+source.
+
+### 5. Custom remote MCP is HTTPS Streamable HTTP only
+
+A custom source accepts a bounded display name and canonical HTTPS URL. URLs
+with userinfo, fragments, credential-like query parameters, unsafe schemes, or
+excessive length are rejected. Secrets are never placed in the URL.
+
+Supported initial auth modes are:
+
+- standard MCP OAuth 2.1 discovery/authorization;
+- no authentication;
+- bearer token; and
+- a bounded approved API-key header mode.
+
+Arbitrary request headers are not accepted. Hop-by-hop, routing, cookie,
+forwarding, host, proxy, and browser security headers cannot be user-defined.
+`stdio` commands, npm/package installation, local filesystem server configs,
+and legacy SSE fallback are out of scope.
+
+### 6. One outbound network policy covers MCP and OAuth
+
+Every server-side request influenced by a remote source uses one guarded fetch
+and egress path, including:
+
+- initial endpoint probe and MCP initialize;
+- Streamable HTTP GET/POST;
+- OAuth protected-resource metadata;
+- authorization-server/OIDC metadata;
+- dynamic registration or Client ID metadata fetches when supported;
+- token and revocation endpoints; and
+- every redirect hop.
+
+The policy:
+
+1. requires HTTPS in production;
+2. canonicalizes scheme/host/port/path and rejects userinfo/fragments;
+3. rejects ambiguous URL normalization, encoded/alternate IP forms, IPv6 zone
+   IDs, unsafe IDNA/punycode transformations, and unapproved ports before DNS;
+4. resolves all A/AAAA results and rejects the destination if any address is
+   loopback, unspecified, private, link-local, multicast, documentation-only,
+   carrier-grade NAT/Tailscale (`100.64.0.0/10`), metadata, or otherwise
+   non-global unicast, including IPv4-mapped IPv6 forms;
+5. pins an approved resolution for the connection while preserving TLS SNI,
+   certificate/SAN hostname verification, and origin isolation, then
+   re-resolves/revalidates on a new connection, session, redirect, or token
+   refresh; no per-workspace custom CA, TLS bypass, trust-on-first-use,
+   cross-authority pool reuse, HTTP/2 origin coalescing, or Alt-Svc escape is
+   allowed;
+6. disables automatic redirects, validates each hop, caps the chain, forbids
+   HTTPS downgrade, and never forwards authorization material across origin;
+7. applies connect, headers, body, stream-idle, and total-operation limits;
+8. sends only redacted stable errors to browser/agent; and
+9. runs behind a production egress proxy/network policy that independently
+   blocks private and metadata networks. The proxy is mandatory for every MCP,
+   OAuth discovery/authorization-metadata, JWKS/introspection (if used), token,
+   refresh, registration, revocation, redirect, and alternate network path;
+   environment `NO_PROXY` and direct-socket bypasses are disabled/proven absent.
+
+Application checks without connection pinning are insufficient because of DNS
+rebinding/TOCTOU. An egress proxy alone is insufficient because the application
+must also bind credentials and OAuth resources to the intended canonical
+origin. Both are production gates.
+
+### 7. OAuth follows the standard and the #820 custody boundary
+
+The remote transport uses the current MCP TypeScript SDK OAuth client contract
+where it passes conformance; Boring owns multi-tenant state, storage, callback
+routing, and network policy.
+
+Each authorization attempt is bound server-side to the current actor,
+workspace, source/profile, canonical MCP resource URI, selected authorization
+server/issuer, client registration identity, exact callback URI, PKCE verifier,
+requested scopes, nonce/state, and short expiry. State is random, one-use, and
+consumed atomically. Callback processing rechecks current owner role and
+source/profile state before storing anything. Registration metadata, refresh
+tokens, and issuer state cannot be reused across source profiles merely because
+two endpoints share a host.
+
+Required behavior includes RFC 9728 protected-resource discovery, both required
+authorization-server metadata discovery forms, PKCE S256, exact redirect
+matching, RFC 8707 `resource` on authorization and token requests, audience/
+resource separation, issuer consistency, authorization-response `iss`
+validation when supplied (RFC 9207), bounded step-up scope retries, refresh
+rotation, and no token passthrough. Missing or inconsistent discovery fails
+closed; the client never guesses `/authorize` or `/token` fallback endpoints.
+Access tokens are memory-only per call where
+the #820 contract requires; refresh tokens use the workspace vault. OAuth URLs
+are validated before being returned to the browser and are opened without shell
+execution.
+
+A protocol conformance spike against the pinned MCP SDK is a prerequisite. If
+the SDK does not satisfy the required discovery/challenge behavior, the slice
+must either upgrade to a proven version or add a narrowly tested adapter around
+public SDK seams; it must not fork OAuth ad hoc.
+
+### 8. Tool annotations are hints; policy is host-owned
+
+`McpDiscoveredTool` preserves bounded title, input/output schema, and MCP
+annotations, but an untrusted server cannot authorize itself by claiming
+`readOnlyHint` or omitting `destructiveHint`.
+
+The host-owned policy computes an effective decision from:
+
+- source provenance and host trust tier;
+- deployment deny rules;
+- provider/tool-specific reviewed policy;
+- protocol annotations as non-authoritative evidence;
+- schema hash and source revision; and
+- effects such as mutation, destruction, administration, credential handling,
+  open-world communication, and unknown behavior.
+
+For v1:
+
+- a Composio app-native tool may execute directly only when host policy accepts
+  Composio as the metadata authority and current metadata explicitly marks it
+  read-only, non-destructive, and not open-world;
+- Registry and custom-server annotations are untrusted, so their tools default
+  to `approval-required`, including apparent reads;
+- a deployment may add an exact reviewed direct-read rule bound to source
+  origin, tool name, and schema hash; and
+- there is no “trust this whole server forever” browser shortcut.
+
+This preserves direct safe reads without allowing a malicious custom server to
+label a destructive action as read-only.
+
+### 9. Risky execution is enforced inside the provider-call boundary
+
+Add a general `mcp_tool_call` bridge. Keep `mcp_readonly_call` as a compatibility
+wrapper for curated/read-only deployments during migration. Provider-native
+tools remain behind search/describe/call proxy tools to avoid catalog context
+bloat.
+
+The general execution state machine is:
+
+```text
+validate bounded JSON input
+-> authorize current workspace/source/profile
+-> fresh describe + source/policy/schema revisions
+-> classify through host policy
+-> direct safe read OR create exact approval request
+-> await Ask User answer
+-> on approval, re-authorize and re-describe
+-> require identical source revision, policy revision, schema hash,
+   tool identity, and canonical-arguments digest
+-> consume one approval receipt
+-> call provider once (no automatic tool-call retry)
+-> redact/validate result
+-> append value-free audit outcome
+```
+
+Approval is `approve once` or deny/cancel only. It binds actor, workspace,
+agent session, source/profile, endpoint fingerprint, active provider account,
+tool/version, source/policy/schema revisions, canonical normalized argument
+digest, question/approval nonce, and expiration. Changed arguments, schema,
+source, policy, account, auth state, membership, or ownership produce a
+stale/denied result before provider execution. The exact normalized object shown
+to the human is the object sent; Boring adds no post-approval defaults or
+rewrites. Provider-side defaults and mutable target state remain an honest
+residual risk and are called out in the approval UI. Where a tool/schema exposes
+an ETag, revision, precondition, dry-run, operation ID, or idempotency field,
+host policy may require and bind it.
+
+The process-local approval ledger performs one atomic
+`approved -> dispatching` transition before network dispatch. The nonce is
+single-use even for identical arguments; restart discards it and never resumes
+dispatch.
+Provider-supported idempotency/operation IDs are created before dispatch and
+bound to the receipt, but unsupported tools never receive a fake exactly-once
+claim. Timeout, abort, missing UI, Ask User rate limit, existing pending
+question, process restart, or answer-owner mismatch all fail closed. Network
+ambiguity after provider dispatch becomes a first-class `outcome-unknown` state,
+is never automatically retried under the old approval, and offers a
+provider-specific reconciliation/status action only when one exists.
+
+### 10. Ask User is one explicit shared runtime
+
+The host constructs one Ask User store/runtime and passes that same runtime to:
+
+- `createAskUserServerPlugin`, so browser bridge handlers and the normal
+  `ask_user` tool share it; and
+- the MCP approval adapter, which calls the runtime directly with the current
+  session, abort signal, and `ownerPrincipalId`.
+
+The approval adapter is an injected `McpExecutionApprover` contract. The
+`boring-mcp` core execution policy does not rely on the model voluntarily
+calling `ask_user`, and provider execution is unreachable before the approver
+returns an exact approval.
+
+The question uses server-authored, structured, escaped labels for
+source/provenance, tool identity, host risk reasons, mutable-state/unknown-outcome
+warnings, and a lossless canonical rendering of every argument after the
+existing secret-input guard. Model text, provider descriptions, tool output,
+and Markdown/HTML never become trusted approval copy. Secret-like input is
+rejected rather than redacted and then sent. If the canonical arguments cannot
+fit the approval display bound, execution fails closed instead of presenting a
+truncated approval. The workspace-scoped Ask
+User store may persist that displayed business input under its existing durable
+file protections, but it stores no provider credential, session header,
+access/refresh token, endpoint secret, or raw approval capability. Only a
+digest/receipt is used for execution enforcement and value-free MCP audit.
+
+The current in-process waiter model is acceptable for Seneca's one app replica.
+A multi-replica deployment is a stop condition until Ask User has a distributed
+coordinator or sticky single-owner execution proof.
+
+### 11. App configuration is server-authoritative and reversible
+
+The existing master `BORING_MCP_PROD_ENABLED` gate remains. New capabilities are
+independently deployment-gated and reported to the front through an
+authenticated server capability DTO rather than relying only on compile-time
+`VITE_*` values:
+
+- full Composio catalog;
+- official Registry browsing;
+- custom remote sources;
+- general approval-gated execution; and
+- direct-read policy.
+
+All new gates default off in production. Static provider-template/read-only mode
+remains supported so Constellation does not broaden when Seneca opts into the
+generic mode.
+
+## Stable source and catalog contract
+
+The implementation may refine names, but the semantic contract must preserve:
+
+### Source
+
+- opaque source ID;
+- workspace authority and audit creator;
+- source kind: Composio catalog, Registry remote, or custom remote;
+- display name and secret-free endpoint summary/fingerprint;
+- Registry/Composio provenance and version where applicable;
+- credential profile reference, never credential material;
+- connected/needs-auth/expired/revoked/quarantined/error state;
+- source revision and timestamps; and
+- trust tier assigned by the host, never the server.
+
+### Tool catalog entry
+
+- source and provider/toolkit/account identity plus exact toolkit/tool version;
+- provider-native tool name and bounded descriptions marked as untrusted data;
+- input/output schemas and schema hash;
+- bounded protocol annotations as evidence;
+- host effects/risk classification and reasons;
+- execution mode: direct, approval-required, or blocked;
+- source and policy revisions; and
+- secret-free native references.
+
+### Approval/audit receipt
+
+- request/approval ID, actor, workspace, source, and tool;
+- source/policy/schema revisions and canonical argument digest;
+- decision, timestamps, outcome, stable code, and provider-dispatch state;
+- no raw arguments, answers, endpoint credentials, headers, or token material.
+
+## Stable errors
+
+Extend the canonical MCP error registry rather than returning ad hoc strings.
+The final names are frozen with implementation tests, covering at least:
+
+- unsafe/unsupported endpoint;
+- remote/Registry unavailable;
+- source quarantined;
+- authentication required, invalid/expired OAuth state, callback subject/source
+  mismatch, refresh failure, and insufficient scope;
+- tool metadata invalid and source/schema/policy drift;
+- approval denied, stale, unavailable, pending conflict, or expired;
+- credential absent, revoked, or unreadable (mapped from canonical #820 errors
+  without leaking profile existence);
+- rate/concurrency/body/result limits; and
+- provider outcome unknown after dispatch.
+
+Cross-workspace/source/profile lookup uses non-disclosing not-found behavior.
+Errors returned to UI/agent contain stable code, safe message, and request ID,
+not raw provider stack traces or URLs.
+
+## Threat model and required controls
+
+| Threat | Required control |
+| --- | --- |
+| Custom URL reaches App/DB/Tailscale/metadata services | guarded DNS-pinned fetch plus network egress proxy; block all non-global destinations and every redirect/metadata URL |
+| DNS rebinding between validation and request | resolve all records, reject any unsafe answer, pin approved connection, revalidate new connections |
+| OAuth metadata points to internal or attacker endpoints | run every discovered URL through the same egress/resource/issuer policy |
+| OAuth mix-up/code interception | source-bound one-use state, PKCE S256, exact callback, issuer/resource/audience binding, current owner recheck |
+| Token or session-header leakage | #820 vault, memory-bounded access token, no URL/query token, redaction/canaries across browser, logs, sessions, approvals, errors |
+| Registry entry is malicious or later deleted | Registry is provenance only; untrusted policy; status refresh; quarantine deleted entries |
+| Server lies in tool annotations | annotations never authorize untrusted sources; custom/Registry tools require approval unless exact host policy says otherwise |
+| Prompt injection asks agent to skip confirmation | approval is in the server call boundary, not prompt convention |
+| Approval reused for changed tool/input | bind session, account/tool versions, revisions + canonical argument digest; atomic single-use receipt |
+| Mutable provider target changes after approval | show residual warning; bind provider preconditions/ETag/dry-run when available; never claim semantic snapshot without provider support |
+| Provider executes twice after timeout | no automatic execution retry; explicit unknown-outcome state; provider idempotency/reconciliation only when supported |
+| Tool description/output poisons model or approval | mark as untrusted data; render approval from escaped server-owned fields; later risky calls still require exact approval |
+| Another user/workspace uses a source | fresh membership and source/profile scope checks; opaque IDs; not-found semantics |
+| Owner adds many endpoints/tools to exhaust host | per-workspace/source limits, body/schema/result caps, bounded Registry mirror, connection/concurrency/rate budgets |
+| Remote content injects secrets or malicious UI | text-only escaped rendering, CSP, no HTML execution, redaction/leak guard, no raw auth URL schemes |
+| Process restart leaves approval reusable | in-process receipt dies; pending question is abandoned; provider call never resumes automatically |
+
+## Test seams
+
+### Highest public seams
+
+Prefer complete public behavior over private helper tests:
+
+1. a fake Streamable HTTP MCP server behind a controllable DNS/redirect/OAuth
+   harness;
+2. the `@hachej/boring-mcp` source/catalog/execution facade with real MCP SDK
+   client transport;
+3. Fastify source/credential/OAuth routes with real Core workspace membership
+   and #820 fake/real credential backends;
+4. one explicitly shared Ask User runtime: agent MCP call blocks, browser answers,
+   revisions are rechecked, and exactly one fake provider call occurs;
+5. MCP overlay tests through its HTTP client contract; and
+6. clean packed-package installation into Seneca followed by deterministic
+   browser + agent E2E.
+
+### Required deterministic matrices
+
+#### Network and OAuth
+
+- public IPv4/IPv6 success;
+- loopback, private, link-local, multicast, CGNAT/Tailscale, metadata,
+  IPv4-mapped IPv6, mixed safe/unsafe DNS answers, and IP-literal negatives;
+- safe DNS first then rebind negative;
+- redirect to private/cross-origin/downgrade/too-many hops;
+- OAuth metadata/token/revocation URL SSRF;
+- missing/malformed resource metadata, guessed-fallback rejection, issuer or
+  authorization-response `iss` mismatch, cross-profile client-registration
+  reuse, missing PKCE S256, state replay/expiry, callback wrong
+  actor/workspace/source/profile, exact redirect mismatch, scope step-up bounds,
+  refresh race/rotation, and revocation;
+- no auth, OAuth, bearer, and approved API-key modes; forbidden headers fail;
+- timeout, body/header/schema/result, concurrent connection, and rate bounds.
+
+#### Authority and credential isolation
+
+- owner can mutate; editor/viewer/nonmember cannot;
+- members can use an enabled workspace source under registered policy;
+- two workspaces × two remote profiles × concurrent calls observe only matching
+  fake-provider canaries;
+- same provider kind with two sources resolves two distinct profiles;
+- caller-supplied profile/workspace/provider mismatch fails before decrypt/fetch;
+- revoke/tombstone blocks the next call and never falls back;
+- existing personal MCP records are inventoried/quarantined and never
+  auto-promoted.
+
+#### Catalog and policy
+
+- Composio Session omits toolkit restriction and disables sandbox/workbench;
+- two accounts for one toolkit require an explicit active-account selection;
+  removing/changing that selection invalidates source revision and no call uses
+  Composio's most-recent fallback;
+- toolkit/tool version and schema drift invalidate cached execution metadata;
+- query-driven internal meta-tool discovery is paginated/bounded and raw
+  `COMPOSIO_*` tools never enter the agent catalog;
+- managed-auth and provider-setup-required states are distinct;
+- Registry complete-snapshot replacement, cursor pagination, cache fallback,
+  active/latest filtering, record hashes, invalid record bounds, duplicate
+  Registry/custom endpoint handling, and deleted quarantine;
+- all valid app-native tools are searchable/describable;
+- malformed tool/schema/secret metadata fails closed;
+- untrusted `readOnlyHint` cannot obtain direct execution;
+- exact host read policy requires matching origin/tool/schema;
+- source, policy, and schema revisions invalidate cached decisions.
+
+#### Approval and execution
+
+- direct host-classified read invokes once without a question;
+- every other risk class blocks before provider call and creates one question;
+- approve once invokes exactly once; deny/cancel/timeout/abort/no UI does not
+  invoke;
+- question answer from another principal/session is denied;
+- argument, schema, policy, source, endpoint, active account/tool version,
+  credential, or membership change while waiting produces stale/denied with zero
+  calls;
+- duplicate answer/replay cannot invoke twice and the ledger transition to
+  dispatch is atomic;
+- provider timeout after dispatch records unknown outcome and does not retry;
+  supported operation/idempotency IDs permit bounded reconciliation without a
+  second side effect;
+- secret/canary corpus is absent from question, transcript, DTO, tool output,
+  audit, errors, and captured logs.
+
+### Avoid testing
+
+- MCP SDK private implementation details when stock-client/server behavior proves
+  the contract;
+- Composio's own OAuth implementation beyond the app's request/response boundary;
+- generated direct provider tools or thousands of tool definitions in prompt;
+- local `stdio` execution;
+- a second credential store, Workspace authority, runtime composer, or approval
+  UI; and
+- live destructive actions against real customer/provider data.
+
+## Flag, rollout, and rollback
+
+### Flags
+
+- Existing master MCP production gate remains the outer switch.
+- New catalog, Registry, custom remote, general execution, and direct-read
+  features are separate server-authoritative gates.
+- Static curated/read-only mode is the compatibility default.
+
+### Rollout
+
+1. Land #820 `16f.1`, then owner-ratify 900.0's source-scoped profile
+   amendment before `16f.2` schema/storage and `16f.3` onboarding. Re-read the
+   landed contract and record the amended Bead edges.
+2. Land #820 `16f.2`–`16f.3`, then `16f.4`'s personal-to-workspace MCP migration
+   with existing curated behavior unchanged.
+3. Land remote egress/OAuth and new data contracts dark; qualify with fake
+   endpoints and no production routes.
+4. Enable full Composio catalog in development with an isolated Composio
+   project, server-side operator key, no sandbox/workbench, and test accounts.
+5. Enable the Registry mirror, then custom URL onboarding, while execution
+   remains approval-required.
+6. Enable direct reads only for exact host-reviewed policy (initially eligible
+   Composio read-only/non-open-world tools).
+7. Pack the affected package cohort and install into a clean Seneca checkout.
+8. Publish through the normal release process with owner approval; Seneca pins
+   exact versions/integrity.
+9. Deploy Seneca with all new flags off, then enable one capability at a time.
+10. Run controlled production proof using disposable accounts and a Boring-owned
+    remote MCP test server; no customer data or irreversible tool is used.
+11. Observe provider errors, approval rate/latency, blocked SSRF attempts,
+    Registry freshness, token refresh failures, and unknown outcomes before
+    widening availability.
+
+### Rollback
+
+Disable, in order: direct-read policy, general execution, custom remote,
+Registry, and full-catalog Composio. Existing curated Notion/Airtable read-only
+mode and web/agent operation remain available if their retained path is healthy.
+
+Rollback never:
+
+- decrypts new credentials back into generic settings;
+- clears revocation tombstones;
+- promotes personal sources;
+- changes workspace membership;
+- retries an approval/provider call; or
+- downgrades below the #820 schema/package floor after migration.
+
+Registry cache and custom-source metadata may remain inert. Credential records
+remain encrypted for forward recovery or explicit owner deletion.
+
+## Acceptance
+
+The reusable feature is complete only when:
+
+1. Composio app/toolkit discovery has no static toolkit allowlist and all valid
+   app-native tools are searchable/describable through bounded proxy tools.
+2. An owner can browse a validated official Registry snapshot and connect a
+   compatible active remote without Registry metadata granting trust.
+3. An owner can add a custom HTTPS Streamable HTTP URL and complete supported
+   auth without exposing credentials to browser state, URLs, workspace files,
+   prompts, sessions, approvals, logs, or errors.
+4. Multiple remote sources of the same provider kind have isolated
+   source-scoped credential profiles under the owner-ratified #820 extension.
+5. Current membership precedes every use; current owner role precedes every
+   lifecycle mutation; cross-workspace/profile attempts do not reveal existence.
+6. All remote/OAuth server-side requests pass DNS-pinned application validation
+   and an independent production egress policy.
+7. Tool annotations from untrusted servers never authorize direct execution.
+8. Every valid tool is direct, approval-required, or blocked for a stable
+   security/configuration reason; absence from an old static list is not a block.
+9. A risky/unknown call cannot reach the provider before the same human answers
+   an exact Ask User question, and post-answer drift/replay cannot reuse approval.
+10. A direct read, approved call, denial, timeout, stale approval, and ambiguous
+    provider outcome each produce a value-free auditable result with a stable
+    code.
+11. Curated static/read-only consumers remain unchanged unless they explicitly
+    select generic mode.
+12. The package cohort is tested from tarballs, released normally, pinned in
+    Seneca, deployed behind flags, live-smoked non-destructively, observed, and
+    rollback-proven.
+
+## Proof
+
+Expected upstream gates, refined to exact filenames in each slice:
+
+```bash
+pnpm --filter @hachej/boring-core typecheck
+pnpm --filter @hachej/boring-core test
+pnpm --filter @hachej/boring-agent typecheck
+pnpm --filter @hachej/boring-agent test
+pnpm --filter @hachej/boring-mcp typecheck
+pnpm --filter @hachej/boring-mcp test
+pnpm --filter @hachej/boring-ask-user typecheck
+pnpm --filter @hachej/boring-ask-user test
+pnpm lint:invariants
+pnpm audit:imports
+```
+
+Expected clean Seneca consumer gates:
+
+```bash
+pnpm agents:compile
+pnpm typecheck
+pnpm test
+pnpm build
+pnpm e2e
+```
+
+Additional proof artifacts:
+
+- SSRF/DNS/redirect/OAuth conformance matrix output;
+- egress-proxy negative probe showing App/DB/Tailscale/metadata targets received
+  no request;
+- raw Postgres and artifact/log canary scans from #820 plus MCP-specific values;
+- real shared Ask User runtime trace: pending -> exact answer -> one provider
+  call, plus stale/deny zero-call traces;
+- exact Registry snapshot timestamp/status and degraded-cache proof;
+- package tarball contents, registry versions, and lockfile integrity;
+- production image digest, flags, controlled source/tool identities, health,
+  audit outcomes, executed rollback, and restored state; and
+- independent standards, security, UI/UX, and operations reviews.
+
+## Slices
+
+### Slice 900.0 — Ratify profile identity and freeze dependencies
+
+**Delivers:** An amendment to Decision 27/#820 defining source-scoped MCP
+credential profiles, authority/selection semantics, and the relationship to the
+landed `16f.1` contract. Re-inventory current #820/#805 PRs and `boring-mcp`
+after merge; record exact symbols and no-overlap sequencing.
+
+**Blocked by:** Owner/security approval of this plan; resolution of open PR
+#893 as the candidate `16f.1` base. Do not overwrite another writer's contract.
+This slice blocks #820 `16f.2`/`16f.3` if the profile amendment is accepted,
+because their schema and APIs must use the final identity.
+
+**Proof:** Decision diff; two-source/two-workspace semantic fixture; dependency
+DAG with the new `16f.1 -> 900.0 -> 16f.2` edge; docs-only checks; adversarial
+security review.
+
+**Review budget:** Inside one plan/contract PR. No runtime behavior.
+
+### Slice 900.1 — Guarded remote transport and OAuth conformance
+
+**Delivers:** One reusable remote endpoint policy, DNS-pinned/manual-redirect
+fetch, egress-proxy contract, bounded Streamable HTTP transport, OAuth client
+provider/state adapter, stable errors, and fake DNS/redirect/OAuth harness.
+
+**Blocked by:** 900.0; exact #820 credential resolver/OAuth seams available for
+integration or represented by fakes without a second store.
+
+**Proof:** Full network/OAuth deterministic matrix; MCP SDK stock-server/client
+smoke; typecheck/test/invariants; security re-review.
+
+**Review budget:** One focused security PR. No UI and no production enablement.
+
+### Slice 900.2 — Dynamic catalogs and source model
+
+**Delivers:** Workspace source/provenance contracts, Composio virtual catalog
+source, unrestricted toolkit Session configuration with internal query-driven
+meta-tools, connected toolkit account model, official Registry LKG mirror,
+Registry/custom source creation contracts, and migration compatibility types.
+
+**Blocked by:** 900.1; serialize with #820 `16f.4` if it touches the same MCP
+source/onboarding files.
+
+**Proof:** Composio/Registry/source matrices; secret-free DTO scans; existing
+curated tests unchanged; package test/typecheck/build.
+
+**Review budget:** Likely two PRs if Composio and Registry/source persistence
+cannot remain independently reviewable; one writer owns overlapping contracts.
+
+### Slice 900.3 — General tool policy and exact approval execution
+
+**Delivers:** Preserved annotations/output schema, host risk/effects policy,
+`direct|approval-required|blocked`, general `mcp_tool_call`, compatibility
+`mcp_readonly_call`, source/policy/schema revisions, canonical argument digest,
+value-free audit receipts, and injected approver contract.
+
+**Blocked by:** 900.2; host trust policy reviewed.
+
+**Proof:** catalog/policy/approval matrices with provider-call spies; drift and
+replay negatives; no automatic retry; stable errors; thermo/security review.
+
+**Review budget:** One focused execution-boundary PR.
+
+### Slice 900.4 — Ask User and provider-credential composition
+
+**Delivers:** One explicit shared Ask User store/runtime, MCP Ask User approval
+adapter, owner-bound questions, source-scoped credential resolution, Composio
+external-managed custody, remote OAuth/bearer/API-key lifecycle, personal-source
+quarantine migration, and current-authority checks.
+
+**Blocked by:** 900.3 and #820 `16f.2`–`16f.4`; any multi-replica deployment is
+blocked pending a coordinator decision.
+
+**Proof:** real blocking Ask User -> browser bridge answer -> exact one-call
+integration; two-workspace/two-profile credential matrix; raw DB/log/transcript
+canary scans; revoke/tombstone proof.
+
+**Review budget:** Exceeds one PR. Split reusable credential/source migration
+from Ask User execution composition, with one writer at a time for shared files.
+
+### Slice 900.5 — MCP overlay and server-authoritative capabilities
+
+**Delivers:** Connected/Composio/Registry/Custom views, owner/member affordances,
+source/tool/risk/provenance detail, OAuth/connect handoff, capability DTO,
+loading/error/empty/quarantine states, and accessible approval copy.
+
+**Blocked by:** Stable server contracts from 900.2–900.4.
+
+**Proof:** front contract tests, keyboard/accessibility checks, screenshots for
+all four views and approval states, responsive proof, high-taste UI review.
+
+**Review budget:** One UI PR after contracts stabilize.
+
+### Slice 900.6 — Compatibility, release, and clean Seneca qualification
+
+**Delivers:** App-binding factory supports explicit curated and generic modes;
+existing full-app/Constellation behavior remains curated; affected packages are
+packed, installed in a clean Seneca checkout, tested, released, and pinned.
+
+**Blocked by:** 900.1–900.5; normal release approval.
+
+**Proof:** package gates, curated compatibility suite, tarball export/content
+check, clean Seneca gates, exact registry versions/integrity.
+
+**Review budget:** Upstream compatibility/release PR plus separate Seneca
+integration PR.
+
+### Slice 900.7 — Seneca deployment and controlled production proof
+
+**Delivers:** Seneca #35 generic-mode composition, persistent Registry cache,
+egress proxy/network policy, operator Composio secret, server flags, monitoring,
+controlled live Composio/Registry/custom sources, approval E2E, observation, and
+executed rollback/restore.
+
+**Blocked by:** 900.6; owner access/secret/vendor-risk/deployment approval; an
+isolated Composio project and Boring-owned public MCP test server.
+
+**Proof:** exact image/package versions; browser and agent E2E; non-destructive
+live calls; SSRF canary negative; redacted logs/audit; rollback/restore; security
+and operations review.
+
+**Review budget:** One Seneca code PR and one explicit production proof record.
+
+## Dependency graph
+
+```text
+#820 16f.1
+    |
+    v
+900.0 owner profile amendment + contract freeze
+    |
+    v
+#820 16f.2 -> 16f.3 -> 16f.4 curated workspace migration
+                                  |
+                                  v
+                                900.1 guarded transport/OAuth
+                                  |
+                                  v
+                                900.2 catalogs/sources
+                    |
+                    v
+                                900.3 policy/approval boundary
+                                  |
+                                  v
+                                900.4 credentials + shared Ask User runtime
+                                  |
+                                  v
+                                900.5 UI
+                                  |
+                                  v
+                                900.6 compatibility/release
+                                  |
+                                  v
+                                900.7 Seneca production proof
+```
+
+The runtime path is intentionally mostly linear because the same MCP contracts
+and files are affected and credential/auth/source decisions must settle before
+UI and release. Beads are appropriate after owner approval, but they must be
+created from then-current #820 IDs, checked with `br dep cycles`, and inspected
+with `bv --robot-insights`; no Beads are created by this plan PR.
+
+## Stop conditions
+
+Stop and amend/route instead of improvising if:
+
+1. Decision 27/#820 does not approve multiple source-scoped profiles for custom
+   MCP servers.
+2. The landed #820 resolver cannot bind a profile without accepting authority
+   from browser/model input.
+3. A proposed implementation stores any custom credential/token in user
+   settings, source metadata, URL, browser, workspace file, transcript, or log.
+4. Safe remote fetch cannot pin validated DNS connections or production cannot
+   enforce independent private-network egress denial.
+5. MCP OAuth conformance requires copying/forking the protocol instead of using
+   a reviewed public SDK seam.
+6. Provider execution can occur before approval or approval cannot be bound to
+   exact revisions and arguments.
+7. The host would trust arbitrary server annotations or a Registry listing for
+   direct execution.
+8. Ask User would be reconstructed separately for bridge and execution, or a
+   multi-replica deployment cannot guarantee the answering runtime owns the
+   waiter.
+9. Full Composio discovery requires exposing raw management/remote-bash
+   meta-tools to the agent.
+10. Constellation/static consumers broaden without explicit configuration.
+11. A release or production proof requires real destructive actions, customer
+   credentials/data, raw secrets in commands, or unpublished workspace links.
+
+## Out of scope
+
+- Hosted user-supplied `stdio`, package commands, or local MCP binaries.
+- Legacy SSE remote transport in v1.
+- Trusting an entire custom server permanently from one browser click.
+- Automatic retry of provider tool execution.
+- Durable or cross-replica approval resumption.
+- Direct generation of every provider tool into model context.
+- Composio remote workbench/bash, local code execution, or arbitrary sandbox
+  credential delivery.
+- Tenant-authored general provider definitions outside the guarded MCP remote
+  source kind.
+- Billing, marketplace ratings, malware scanning claims, or Registry trust
+  scores.
+- Cross-workspace credentials, public credential sharing, or plaintext export.
+- Changes to #806 MCP ingress or agent-fleet/runtime authority.
+
+## Open owner decisions
+
+These decisions require explicit owner/security ratification before `/exec`:
+
+1. **Credential profile amendment:** adopt one profile per remote MCP source,
+   semantically `(workspaceId, providerId, profileId)`, while keeping Composio
+   one workspace profile with multiple custodian-managed toolkit accounts.
+2. **Trust default:** custom and Registry tools, including apparent reads,
+   require approval unless an exact host policy recognizes source origin, tool,
+   and schema; Composio-only safe read metadata may be trusted by deployment
+   policy.
+3. **Meta-tool boundary:** “all tools” means all valid app-native tools; raw
+   Composio management/schema/execute and remote workbench/bash meta-tools stay
+   internal/disabled.
+4. **Production network gate:** custom remote support does not launch until both
+   DNS-pinned app validation and an independent egress proxy/network policy are
+   proven.
+
+## Grounding sources
+
+- Composio Sessions: sessions expose every toolkit by default when no toolkit
+  filter is supplied; meta-tools are the recommended broad-agent discovery
+  shape; tag filters exist; sandbox/workbench can be disabled:
+  <https://docs.composio.dev/docs/configuring-sessions>.
+- Composio Connect/auth: dynamic meta-tools and managed versus custom auth:
+  <https://docs.composio.dev/docs/composio-connect>,
+  <https://docs.composio.dev/docs/authentication>, and
+  <https://docs.composio.dev/docs/custom-app-vs-managed-app>.
+- Official MCP Registry: remote records and Registry aggregator API/cache/status
+  expectations; the service has no uptime or durability guarantee:
+  <https://modelcontextprotocol.io/registry/remote-servers> and
+  <https://modelcontextprotocol.io/registry/registry-aggregators>.
+- MCP authorization: RFC 9728 discovery, OAuth 2.1, PKCE, RFC 8707 resources,
+  token handling, and redirect requirements:
+  <https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization>.
+- MCP tools: human-in-the-loop guidance and annotations as untrusted hints:
+  <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>.
+- MCP security best practices: SSRF, DNS rebinding, redirects, OAuth URL safety,
+  token passthrough, scope minimization, and local `stdio` risk:
+  <https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices>.
+
+## Planning proof and review record
+
+Plan-only proof:
+
+```bash
+git diff --check
+test -z "$(git diff --name-only origin/main...HEAD | grep -v '^docs/')"
+rg -n 'hachej/seneca/issues/35|#820|Ask User|SSRF|approval|required|rollback' \
+  docs/issues/900/plan.md
+```
+
+Review status:
+
+- Direct code and contract reconnaissance completed against Boring
+  `origin/main` at `86d38893a`, Seneca `origin/main` at `e5e82c8`, current
+  `@hachej/boring-mcp`/Ask User sources, owner-ratified #820 plan, and open PRs
+  #887/#893.
+- Official Composio, MCP Registry, MCP authorization/tools, and MCP security
+  documents were re-fetched on 2026-07-22; a live Registry v0.1 response was
+  schema-checked for remote records and status metadata.
+- Three web-assisted adversarial passes were run after the first complete
+  draft. Integrated findings: OAuth issuer/registration binding and `iss`, no
+  guessed discovery fallbacks, URL/TLS/pool/proxy bypass cases, explicit
+  account/version identity, Registry/custom dedupe, atomic single-use approval,
+  structured injection-resistant consent, mutable-resource TOCTOU honesty,
+  provider idempotency/reconciliation, and first-class unknown outcome.
+- APR and a fresh repository subagent review were unavailable in this
+  long-running session (`apr`/Oracle absent; session subagent cap exhausted).
+  This is not a review waiver. Before merge, run fresh independent
+  architecture/security and UI/test-seam reviews, integrate accepted findings,
+  and record convergence here. The plan remains `ready-for-human` until those
+  reviews and the four owner decisions above are resolved.

--- a/docs/issues/900/plan.md
+++ b/docs/issues/900/plan.md
@@ -1,778 +1,471 @@
 ---
 github: https://github.com/hachej/boring-ui/issues/900
 issue: 900
-state: ready-for-human
+state: ready-for-agent
 updated: 2026-07-22
-flag: flag:boring-mcp-catalog-v1
-track: owner
+flag: flag:boring-mcp-composio-catalog
+track: fast
 ---
 
-# gh-900 Full MCP catalogs, remote servers, and approved execution
+# gh-900 Ship one full-catalog Composio integration for Seneca
 
-## Authority and named consumer
+## Scope decision
 
-This is the canonical reusable-package plan for issue #900. The named product
-consumer is generic Seneca issue
-[`hachej/seneca#35`](https://github.com/hachej/seneca/issues/35).
+The owner narrowed the product on 2026-07-22 to the fastest sellable path:
 
-This plan is about **agents consuming external MCP tools**. It is not:
+- **one Composio integration** in generic Seneca;
+- the complete Composio app/toolkit catalog;
+- all valid Composio app-native tools discoverable and callable;
+- the fastest launch requires one exact Ask User approval for **every** call;
+- optional verified direct reads are a post-launch optimization, not a sale
+  blocker; and
+- no official MCP Registry, custom MCP URLs, user-supplied servers, `stdio`,
+  remote workbench, or remote bash.
 
-- issue #806's opposite-direction ingress, where an external MCP client invokes
-  a Boring agent;
-- the curated Constellation tenant policy, which may remain a static restricted
-  Notion/Airtable deployment; or
-- arbitrary local `stdio` process installation on a shared host.
-
-The plan is ready for owner/security review, not implementation dispatch. It
-changes public package contracts, workspace authority, OAuth, credential
-identity, outbound networking, execution permissions, and the meaning of
-“enabled MCP tool.” No Beads are created by this plan.
+The named consumer is
+[`hachej/seneca#35`](https://github.com/hachej/seneca/issues/35). The owner
+further clarified that Seneca must be a **thin wrapper around Composio**, not an
+independent integration marketplace: Composio remains the source of truth for
+apps, tools, schemas, managed auth, connections, and execution. Boring adds only
+product identity/isolation, secret-safe transport, bounded output, and the
+server-side approval guard. This plan is about an Agent consuming Composio
+tools. It does not change #806's opposite-direction Agent MCP ingress or
+Constellation's curated connector mode.
 
 ## Problem
 
-### User problem
+Seneca already integrates `@hachej/boring-mcp` and Composio, but the product is
+hard-coded to Notion and Airtable:
 
-Generic Seneca is intended to be a general agent application, but its current
-MCP surface exposes only two statically configured Composio toolkits: Notion and
-Airtable. A user cannot browse the complete Composio catalog, discover remote
-servers from the official MCP Registry, or connect a remote MCP endpoint by
-URL. The agent can execute only a small exact read-only allowlist.
+- Seneca front options enable only `notion` and `airtable`;
+- Seneca server connector configs list only those two toolkit IDs;
+- `@hachej/boring-mcp` exports only two default provider templates;
+- each Composio Session sends `toolkits.enable: [toolkitId]`, so it sees one
+  toolkit rather than the full catalog;
+- internal discovery searches only that configured toolkit;
+- raw Composio meta-tools are hidden; and
+- execution is limited to exact static read-only allowlists through
+  `mcp_readonly_call`.
 
-The desired product is:
+The transport, source ownership, redaction, rate limits, schema hashing,
+provider calls, Composio hosted links, and Ask User UI already exist. The fast
+path is to generalize those seams for one Composio catalog, not build another
+MCP marketplace or secret system.
 
-1. every valid Composio app-native tool can be discovered and described;
-2. active remote servers in the official MCP Registry can be browsed and
-   connected when they offer a compatible endpoint;
-3. a workspace owner can add a custom remote HTTPS MCP endpoint;
-4. all valid discovered tools remain available through the governed proxy
-   surface rather than being silently hidden because they are not on a static
-   provider list;
-5. only host-classified safe reads execute without interruption; and
-6. write, destructive, administrative, open-world, or unknown operations cannot
-   reach a provider until the current human explicitly approves that exact
-   invocation through Ask User.
+## Sellable user journey
 
-### Current implementation
+1. User opens **MCP → Composio**.
+2. User searches the full Composio app catalog.
+3. User selects an app and completes Composio's hosted connection flow.
+4. The connected app appears under the single Composio integration.
+5. The Agent searches relevant tools without loading the whole catalog into its
+   context.
+6. The Agent describes the selected tool and receives its current schema.
+7. Every launch-version call opens one exact Ask User approval form.
+8. Approval invokes the exact reviewed call once; denial/cancel/stale approval
+   invokes nothing.
+9. User can inspect connections and revoke an app account.
 
-`@hachej/boring-mcp` already supplies valuable foundations:
-
-- an app-left MCP source overlay;
-- actor-owned source access and secret-free DTOs;
-- a real MCP SDK Streamable HTTP client;
-- Composio v3.1 Session creation and hosted connection links;
-- source status, discovery, normalized schema hashes, redaction, rate limits,
-  timeout wrappers, and stable MCP errors;
-- seven context-efficient bridge tools, including search/describe and governed
-  read-only execution; and
-- app-injected persistence and credential resolution.
-
-The current restrictions are structural, not only configuration:
-
-- `DEFAULT_MCP_PROVIDER_TEMPLATES` contains only Notion and Airtable.
-- Seneca's front and server compositions list only those providers.
-- every Composio Session sends `toolkits.enable: [toolkitId]` and therefore
-  enables exactly one toolkit;
-- Composio meta-tools are hidden, while internal discovery searches only the
-  configured toolkit and caps the result set;
-- `McpDiscoveredTool` drops protocol annotations and output schemas;
-- catalog normalization denies any tool not on an exact static read allowlist;
-- the only execution bridge is `mcp_readonly_call`;
-- `createMcpSdkStreamableHttpTransport` accepts an endpoint but has no hosted
-  source lifecycle, OAuth provider, SSRF-safe fetch boundary, redirect policy,
-  or credential profile;
-- source metadata lives under a per-user server-owned settings key in consuming
-  apps; and
-- Ask User and MCP are composed as independent runtimes, with no enforcement
-  seam connecting approval to provider execution.
-
-### Existing owner-ratified dependency
-
-Issue #820's owner-ratified credential-vault plan already decides that provider
-credentials become workspace-scoped, owner-managed, host-resolved credentials;
-`@hachej/boring-mcp` must migrate onto that common mechanism instead of creating
-another secret store or onboarding surface. Its sequence is:
-
-```text
-16f.1 credential/provider contract
--> 16f.2 encrypted vault storage
--> 16f.3 owner-only API-key/OAuth onboarding
--> 16f.4 boring-mcp migration onto the common mechanism
-```
-
-Open PR #893 is the current `16f.1` contract candidate. This plan neither copies
-nor bypasses it. MCP source/account secrets, OAuth refresh tokens, bearer/API
-keys, and session headers must use the landed #820 authority and custody path.
-The operator-owned Composio project key remains an operator secret.
-
-This feature also triggers a deliberately deferred #820 decision: custom MCP
-servers are a named consumer that needs more than one credential profile for the
-same provider kind. The required identity is one profile per remote source,
-semantically keyed by `(workspaceId, providerId, profileId)`, where `profileId`
-is a host-generated opaque source identity and never caller authority. The
-implementation must amend Decision 27/#820 before changing the v1 credential
-contract or schema. It must not simulate profiles with tenant-authored dynamic
-provider registrations. If approved, slice 900.0 inserts after `16f.1` and before
-`16f.2`, because vault schema and onboarding must not first ship a one-profile
-identity that this named consumer immediately replaces.
+The product promises access to the Composio catalog. It does not promise that
+every vendor works without setup: many apps use Composio managed auth, while
+others require a custom auth configuration in the isolated Composio project.
+The UI reports `Connect`, `Connected`, `Needs provider setup`, `Expired`, or
+`Revoked` honestly.
 
 ## Solution
 
-### Product surface
+### Thin wrapper boundary
 
-The MCP overlay becomes one management surface with four views:
+Replace the app-level Notion/Airtable toolkit array with one `composio` adapter
+identity per current Seneca user/workspace scope. This is not a second catalog
+or provider model. Do not mirror Composio's app registry, generate one Boring
+template per provider, normalize provider-specific auth, or persist tool copies
+as authoritative records.
 
-1. **Connected** — workspace MCP sources/accounts, health, provenance, tools,
-   authorization state, and disconnect/revoke controls.
-2. **Composio apps** — server-side search/pagination over the complete Composio
-   toolkit catalog, connection readiness, and on-demand hosted connection.
-3. **MCP Registry** — search over a validated last-known-good mirror of active
-   official Registry metadata, showing only compatible remote transports as
-   connectable.
-4. **Custom server** — owner enters a display name and HTTPS Streamable HTTP URL,
-   chooses automatic OAuth, no auth, bearer, or an approved API-key mode, and
-   reviews the server identity/capabilities discovered by a guarded probe.
+The adapter keeps only what the host boundary requires:
 
-Members may list/use workspace-connected sources. Only current workspace owners
-may create, connect, replace, disable, revoke, or delete a source or credential.
-A source identifier, provider identifier, Registry name, endpoint, or Agent tool
-argument never grants workspace authority.
+- opaque Boring source identity and current actor/workspace ownership;
+- a stable opaque Composio subject;
+- secret-free connection/account references needed for selection and revocation;
+- source revision plus short-lived schema/policy cache keys; and
+- no API key, OAuth token, MCP Session headers, or auth URL secrets.
 
-### Meaning of “all tools”
+Every app/tool/schema/connection response is fetched from current Composio APIs
+or its Session MCP surface and returned through bounded/redacted DTOs. For the
+initial sale, retain the current personal authority: each Seneca user gets
+isolated Composio connections under their workspace. Do not block this launch on
+#820's future workspace-shared credential-vault migration. The operator
+Composio API key stays server-only. When #820 `16f.4` later migrates MCP
+onboarding, it must inventory and quarantine personal sources rather than
+automatically promoting them to workspace-wide authority.
 
-“All tools available” has a precise v1 meaning:
+### Full-catalog Composio Session
 
-- every protocol-valid **app-native** tool discovered through an enabled source
-  can be searched, described, and submitted to the governed `mcp_tool_call`
-  boundary;
-- tools are not loaded en masse into the model context; the stable
-  search/describe/call proxy pattern remains;
-- unsupported names, malformed/oversized schemas, secret-bearing metadata, or
-  protocol-invalid results fail closed with stable errors rather than entering
-  the catalog;
-- Composio catalog/auth/schema/execute meta-tools remain server implementation
-  details, not agent-callable tools; and
-- Composio remote workbench/bash meta-tools are disabled for this release. They
-  are a separate remote-code product, not an app-native toolkit action.
+Create Composio v3 Sessions with:
 
-Availability is distinct from automatic execution. A catalog entry reports one
-of:
+- `mcp: true`;
+- no `toolkits.enable` filter, which leaves the full catalog discoverable;
+- connection management enabled;
+- Composio sandbox/workbench disabled; and
+- one stable opaque Composio subject per Boring source.
 
-- `direct` — host policy has classified the exact current tool as a safe read;
-- `approval-required` — the tool is available but needs one exact human
-  approval;
-- `blocked` — only for invalid protocol data, an unsafe/unavailable source,
-  missing authority/credentials, or an explicit deployment deny policy.
+The adapter is a shallow mapping over Composio Connect's own meta-tool flow:
 
-The system no longer uses `enabled: false` as a synonym for “not on the old
-read-only list.”
+- Composio search answers the Agent's tool query;
+- Composio schema retrieval describes selected tool slugs;
+- Composio connection management supplies hosted auth/link state; and
+- Composio execution invokes the selected app-native tool after the host guard.
 
-### Architecture
+Do not reimplement those capabilities. Raw execution/control-plane meta-tools
+remain unreachable so they cannot bypass Boring's one approval interception;
+`COMPOSIO_REMOTE_BASH_TOOL` and `COMPOSIO_REMOTE_WORKBENCH` stay disabled.
+“All tools” means every valid app-native tool exposed by Composio MCP for every
+provider, not Composio infrastructure controls.
 
-```text
-MCP overlay / agent bridge
-        |
-        v
-workspace-authorized MCP application service
-        |
-        +-- catalog adapters
-        |     +-- Composio full-catalog Session adapter
-        |     +-- official Registry mirror/search adapter
-        |
-        +-- workspace source/account registry
-        |     +-- Composio catalog source + connected toolkit accounts
-        |     +-- Registry-derived remote source
-        |     +-- custom remote source
-        |
-        +-- #820 workspace credential resolver
-        |     +-- external-managed Composio account reference
-        |     +-- standard MCP OAuth refresh/access lifecycle
-        |     +-- bearer/API-key profile per remote source
-        |
-        +-- guarded remote transport
-        |     +-- URL/redirect/DNS policy
-        |     +-- egress proxy
-        |     +-- MCP SDK Streamable HTTP + OAuth provider
-        |
-        +-- catalog + host risk policy
-        |
-        +-- governed execution boundary
-              +-- direct safe read
-              +-- exact Ask User approval -> revalidate -> one provider call
-```
+### Query-driven tool catalog
 
-`@hachej/boring-mcp` remains the external-MCP consumption owner. Core owns
-workspace authorization and the #820 credential store. Ask User owns questions
-and human answers. The host app composes these capabilities; no package gains a
-second workspace/runtime authority.
+Keep the context-efficient Boring bridge instead of generating thousands of
+Agent tools:
 
-## Decisions
+- `mcp_servers_list` reports the Composio source;
+- `mcp_tools_search` sends the actual query through internal Composio search;
+- `mcp_tool_describe` retrieves the current complete schema;
+- `mcp_readonly_call` remains only as a compatibility alias during rollout; and
+- new `mcp_tool_call` is the one general execution boundary.
 
-### 1. Workspace authority replaces personal source authority
+Current `McpTransportClient` supports only `listTools` and `callTool`, while the
+catalog locally filters a full list. Slice 900.1 must add an optional bounded
+provider search/describe seam at the managed-catalog adapter level. The Composio
+adapter maps it to Composio search/schema meta-tools; curated transports retain
+the current bounded list/filter fallback. Do not push Composio-specific methods
+into generic MCP transport or silently list the full catalog.
 
-New sources and credentials are workspace-scoped. `createdByUserId` is audit
-metadata only. Current membership is checked for every source read and tool
-call; current owner role is checked for every lifecycle mutation.
+Search is paginated and bounded, but Boring does not build an independent
+catalog index. Each transient tool result preserves:
 
-Existing personal `__serverBoringMcpSourcesV1` records stay personal until the
-#820 migration performs inventory and consent quarantine. No connection is
-automatically promoted, even if only one exists. Promotion requires the
-connected member's consent and current owner approval/reconnection. Departed
-users and collisions cannot be promoted automatically.
+- toolkit, tool slug, and current Composio version/account selection;
+- title and description marked as provider-supplied untrusted text;
+- input/output schemas and canonical schema hash;
+- Composio behavior tags/annotations;
+- source and policy revisions;
+- host risk reasons; and
+- execution mode: `direct`, `approval-required`, or `blocked`.
 
-### 2. Credential profiles are source-scoped without dynamic providers
+Catalog and schema caches are bounded and short-lived. Before execution, the
+server refreshes the exact selected tool when an expected schema hash is
+supplied. Account, source, tool version, or schema drift invalidates the cached
+decision.
 
-The host registers stable provider kinds such as `composio` and `mcp-remote`.
-A custom/Registry remote source receives an opaque host-generated `profileId`
-equal to or derived from its opaque source identity. The common credential
-resolver accepts that trusted profile identity only through a host-owned MCP
-consumer binding.
+### Connection management
 
-The browser, model, and endpoint never construct or widen credential references.
-A source in workspace A cannot select workspace B's profile, and deleting one
-remote source does not revoke another remote source of the same provider kind.
-This is the named-consumer amendment required by #820's one-profile decision.
+The MCP overlay searches Composio toolkits server-side and requests a hosted
+connection link for a selected toolkit. Only toolkit slugs returned by the live
+Composio catalog are accepted. Connect URLs remain HTTPS and match reviewed
+Composio origins.
 
-### 3. One Composio catalog source per workspace
+If multiple connected accounts exist for one toolkit, the current user must
+select the active account. The adapter pins the exact account in the Composio
+Session `connectedAccounts`/`connected_accounts` mapping (or the documented
+Session execute `account` field) and enables Composio's explicit-selection mode
+when multiple accounts are allowed. It never silently adopts Composio's
+most-recent-account fallback. Changing the active account patches/recreates the
+Session, increments source revision, and invalidates pending approval. The early
+real-Composio spike must prove the MCP execution uses the pinned account; if it
+cannot, stop rather than claim account-safe execution.
 
-Composio uses one virtual catalog source per workspace rather than one static
-provider template per app. A random opaque custodian subject identifies the
-workspace to Composio; raw Boring workspace/user identifiers are not sent as
-Composio `user_id` values. Multiple toolkit accounts live under that custodian
-subject and appear as child connection records in the UI. A current workspace
-owner must select the active account for a toolkit; execution never inherits
-Composio's “most recently connected” fallback. Account selection is a
-source-revisioned, auditable metadata change and a tool call rechecks it.
+Disconnect/revoke calls the current Composio connected-account endpoint,
+verifies the result, marks local metadata revoked, and prevents subsequent
+calls. A provider failure returns a stable error and never reports a false local
+success.
 
-Full-catalog Sessions omit `toolkits.enable`. Search/schema/execute meta-tools
-are called only inside the adapter. Toolkit linking remains an authenticated
-server route and validates toolkit slugs against live Composio catalog results.
-Session sandbox/workbench support is disabled.
+## Tool policy
 
-Composio managed auth works without app credentials for supported toolkits.
-Toolkits requiring custom developer credentials or unsupported auth remain
-visible with an actionable “provider setup required” state; “full catalog” does
-not claim that every external vendor can authenticate without configuration.
+### Availability versus automatic execution
 
-### 4. Registry metadata is discovery, not trust
+All protocol-valid app-native tools are available through search/describe/call.
+A tool is blocked only when:
 
-The official MCP Registry is preview infrastructure and explicitly provides no
-uptime or durability guarantee. Seneca does not query it on every user search.
-A host adapter refreshes a bounded last-known-good snapshot no more than hourly,
-using cursor pagination, schema/size validation, active/latest status filtering,
-and atomic replacement only after a complete successful refresh. Search is
-local. A cold cache may report Registry unavailable without affecting existing
-connections.
+- metadata/schema is invalid, oversized, or secret-bearing;
+- no usable connection/account exists;
+- the source is expired/revoked/unavailable;
+- deployment policy explicitly denies that class; or
+- current actor/source ownership fails.
 
-At connect time, the source stores the selected Registry name, version, remote
-transport, canonical endpoint fingerprint, record hash, publication status,
-and retrieval time as provenance. This metadata does not make the server or its
-tool annotations trusted. Registry-derived and custom sources deduplicate on the
-canonical endpoint fingerprint within one workspace: connecting the same remote
-cannot silently create a second credential/profile or bypass a quarantine; the
-owner is directed to the existing source or performs an explicit provenance
-conversion. A later `deleted` moderation state quarantines new calls
-from a Registry-derived source until an owner explicitly reconnects it as a
-custom source after seeing the warning; `deprecated` produces a warning.
+Absence from the old Notion/Airtable allowlist is no longer a block.
 
-Only exact HTTPS `streamable-http` remotes are connectable in v1. SSE-only,
-package/`stdio`, and unresolved template-variable records remain discoverable
-but are marked unsupported. Registry cache loss never deletes a connected
-source.
+### Direct reads are post-launch
 
-### 5. Custom remote MCP is HTTPS Streamable HTTP only
+The sellable launch does not build a risk-classification engine: every otherwise
+allowed tool call is approval-required. This is simpler and strictly safer.
 
-A custom source accepts a bounded display name and canonical HTTPS URL. URLs
-with userinfo, fragments, credential-like query parameters, unsafe schemes, or
-excessive length are rejected. Secrets are never placed in the URL.
+A later optional slice may add direct reads behind a separate server flag after
+sampling real Composio metadata. It may execute directly only when trusted
+current metadata explicitly says read-only, non-destructive,
+non-administrative, and not open-world; unknown or contradictory metadata stays
+approval-required. Disabling that future flag returns calls to approval-required
+and never disables the catalog.
 
-Supported initial auth modes are:
+### Approval-required calls
 
-- standard MCP OAuth 2.1 discovery/authorization;
-- no authentication;
-- bearer token; and
-- a bounded approved API-key header mode.
-
-Arbitrary request headers are not accepted. Hop-by-hop, routing, cookie,
-forwarding, host, proxy, and browser security headers cannot be user-defined.
-`stdio` commands, npm/package installation, local filesystem server configs,
-and legacy SSE fallback are out of scope.
-
-### 6. One outbound network policy covers MCP and OAuth
-
-Every server-side request influenced by a remote source uses one guarded fetch
-and egress path, including:
-
-- initial endpoint probe and MCP initialize;
-- Streamable HTTP GET/POST;
-- OAuth protected-resource metadata;
-- authorization-server/OIDC metadata;
-- dynamic registration or Client ID metadata fetches when supported;
-- token and revocation endpoints; and
-- every redirect hop.
-
-The policy:
-
-1. requires HTTPS in production;
-2. canonicalizes scheme/host/port/path and rejects userinfo/fragments;
-3. rejects ambiguous URL normalization, encoded/alternate IP forms, IPv6 zone
-   IDs, unsafe IDNA/punycode transformations, and unapproved ports before DNS;
-4. resolves all A/AAAA results and rejects the destination if any address is
-   loopback, unspecified, private, link-local, multicast, documentation-only,
-   carrier-grade NAT/Tailscale (`100.64.0.0/10`), metadata, or otherwise
-   non-global unicast, including IPv4-mapped IPv6 forms;
-5. pins an approved resolution for the connection while preserving TLS SNI,
-   certificate/SAN hostname verification, and origin isolation, then
-   re-resolves/revalidates on a new connection, session, redirect, or token
-   refresh; no per-workspace custom CA, TLS bypass, trust-on-first-use,
-   cross-authority pool reuse, HTTP/2 origin coalescing, or Alt-Svc escape is
-   allowed;
-6. disables automatic redirects, validates each hop, caps the chain, forbids
-   HTTPS downgrade, and never forwards authorization material across origin;
-7. applies connect, headers, body, stream-idle, and total-operation limits;
-8. sends only redacted stable errors to browser/agent; and
-9. runs behind a production egress proxy/network policy that independently
-   blocks private and metadata networks. The proxy is mandatory for every MCP,
-   OAuth discovery/authorization-metadata, JWKS/introspection (if used), token,
-   refresh, registration, revocation, redirect, and alternate network path;
-   environment `NO_PROXY` and direct-socket bypasses are disabled/proven absent.
-
-Application checks without connection pinning are insufficient because of DNS
-rebinding/TOCTOU. An egress proxy alone is insufficient because the application
-must also bind credentials and OAuth resources to the intended canonical
-origin. Both are production gates.
-
-### 7. OAuth follows the standard and the #820 custody boundary
-
-The remote transport uses the current MCP TypeScript SDK OAuth client contract
-where it passes conformance; Boring owns multi-tenant state, storage, callback
-routing, and network policy.
-
-Each authorization attempt is bound server-side to the current actor,
-workspace, source/profile, canonical MCP resource URI, selected authorization
-server/issuer, client registration identity, exact callback URI, PKCE verifier,
-requested scopes, nonce/state, and short expiry. State is random, one-use, and
-consumed atomically. Callback processing rechecks current owner role and
-source/profile state before storing anything. Registration metadata, refresh
-tokens, and issuer state cannot be reused across source profiles merely because
-two endpoints share a host.
-
-Required behavior includes RFC 9728 protected-resource discovery, both required
-authorization-server metadata discovery forms, PKCE S256, exact redirect
-matching, RFC 8707 `resource` on authorization and token requests, audience/
-resource separation, issuer consistency, authorization-response `iss`
-validation when supplied (RFC 9207), bounded step-up scope retries, refresh
-rotation, and no token passthrough. Missing or inconsistent discovery fails
-closed; the client never guesses `/authorize` or `/token` fallback endpoints.
-Access tokens are memory-only per call where
-the #820 contract requires; refresh tokens use the workspace vault. OAuth URLs
-are validated before being returned to the browser and are opened without shell
-execution.
-
-A protocol conformance spike against the pinned MCP SDK is a prerequisite. If
-the SDK does not satisfy the required discovery/challenge behavior, the slice
-must either upgrade to a proven version or add a narrowly tested adapter around
-public SDK seams; it must not fork OAuth ad hoc.
-
-### 8. Tool annotations are hints; policy is host-owned
-
-`McpDiscoveredTool` preserves bounded title, input/output schema, and MCP
-annotations, but an untrusted server cannot authorize itself by claiming
-`readOnlyHint` or omitting `destructiveHint`.
-
-The host-owned policy computes an effective decision from:
-
-- source provenance and host trust tier;
-- deployment deny rules;
-- provider/tool-specific reviewed policy;
-- protocol annotations as non-authoritative evidence;
-- schema hash and source revision; and
-- effects such as mutation, destruction, administration, credential handling,
-  open-world communication, and unknown behavior.
-
-For v1:
-
-- a Composio app-native tool may execute directly only when host policy accepts
-  Composio as the metadata authority and current metadata explicitly marks it
-  read-only, non-destructive, and not open-world;
-- Registry and custom-server annotations are untrusted, so their tools default
-  to `approval-required`, including apparent reads;
-- a deployment may add an exact reviewed direct-read rule bound to source
-  origin, tool name, and schema hash; and
-- there is no “trust this whole server forever” browser shortcut.
-
-This preserves direct safe reads without allowing a malicious custom server to
-label a destructive action as read-only.
-
-### 9. Risky execution is enforced inside the provider-call boundary
-
-Add a general `mcp_tool_call` bridge. Keep `mcp_readonly_call` as a compatibility
-wrapper for curated/read-only deployments during migration. Provider-native
-tools remain behind search/describe/call proxy tools to avoid catalog context
-bloat.
-
-The general execution state machine is:
+Write, destructive, admin, open-world, and unknown tools use one server-enforced
+state machine:
 
 ```text
 validate bounded JSON input
--> authorize current workspace/source/profile
--> fresh describe + source/policy/schema revisions
--> classify through host policy
--> direct safe read OR create exact approval request
--> await Ask User answer
+-> authorize current actor/source/account
+-> refresh exact schema and host policy
+-> canonicalize exact input
+-> ask current user through the shared Ask User runtime
 -> on approval, re-authorize and re-describe
--> require identical source revision, policy revision, schema hash,
-   tool identity, and canonical-arguments digest
--> consume one approval receipt
--> call provider once (no automatic tool-call retry)
--> redact/validate result
--> append value-free audit outcome
+-> require identical actor/session/source/account/tool/version/schema/policy
+   and canonical-argument digest
+-> atomically consume one approval nonce
+-> dispatch exactly once without automatic retry
+-> redact and validate provider result
+-> record value-free outcome
 ```
 
-Approval is `approve once` or deny/cancel only. It binds actor, workspace,
-agent session, source/profile, endpoint fingerprint, active provider account,
-tool/version, source/policy/schema revisions, canonical normalized argument
-digest, question/approval nonce, and expiration. Changed arguments, schema,
-source, policy, account, auth state, membership, or ownership produce a
-stale/denied result before provider execution. The exact normalized object shown
-to the human is the object sent; Boring adds no post-approval defaults or
-rewrites. Provider-side defaults and mutable target state remain an honest
-residual risk and are called out in the approval UI. Where a tool/schema exposes
-an ETag, revision, precondition, dry-run, operation ID, or idempotency field,
-host policy may require and bind it.
+The Agent cannot skip approval by calling a raw Composio meta-tool because raw
+meta-tools are unreachable. Prompt instructions are usability guidance only;
+security lives at provider dispatch.
 
-The process-local approval ledger performs one atomic
-`approved -> dispatching` transition before network dispatch. The nonce is
-single-use even for identical arguments; restart discards it and never resumes
-dispatch.
-Provider-supported idempotency/operation IDs are created before dispatch and
-bound to the receipt, but unsupported tools never receive a fake exactly-once
-claim. Timeout, abort, missing UI, Ask User rate limit, existing pending
-question, process restart, or answer-owner mismatch all fail closed. Network
-ambiguity after provider dispatch becomes a first-class `outcome-unknown` state,
-is never automatically retried under the old approval, and offers a
-provider-specific reconciliation/status action only when one exists.
+Approval is **Approve once** or deny/cancel. The form uses escaped,
+server-authored labels and shows:
 
-### 10. Ask User is one explicit shared runtime
+- app/account;
+- tool name;
+- host risk reasons;
+- mutable-state and unknown-outcome warnings; and
+- a lossless canonical rendering of every argument.
 
-The host constructs one Ask User store/runtime and passes that same runtime to:
+Provider descriptions, model prose, tool output, Markdown, and HTML never become
+trusted approval copy. Tool arguments may contain sensitive business data and are shown losslessly to
+the approving current user under the existing protected Ask User store; they
+are never copied into value-bearing audit/log records. Composio/API/session/OAuth
+credentials are never accepted as tool arguments. Oversized arguments fail
+closed rather than receiving a truncated approval.
 
-- `createAskUserServerPlugin`, so browser bridge handlers and the normal
-  `ask_user` tool share it; and
-- the MCP approval adapter, which calls the runtime directly with the current
-  session, abort signal, and `ownerPrincipalId`.
+Approval binds a process-local one-use nonce, current session, source/account,
+tool/version, schema/policy/source revisions, and argument digest. The exact
+normalized object shown is the object sent; Boring does not add defaults after
+approval. Any drift while waiting produces `approval-stale` with zero provider
+calls.
 
-The approval adapter is an injected `McpExecutionApprover` contract. The
-`boring-mcp` core execution policy does not rely on the model voluntarily
-calling `ask_user`, and provider execution is unreachable before the approver
-returns an exact approval.
+No tool execution is automatically retried. If the provider may have committed
+before a timeout, return `outcome-unknown`; do not invite an automatic duplicate.
+Use a provider-supported operation/idempotency identifier or status check only
+when that exact tool supports one.
 
-The question uses server-authored, structured, escaped labels for
-source/provenance, tool identity, host risk reasons, mutable-state/unknown-outcome
-warnings, and a lossless canonical rendering of every argument after the
-existing secret-input guard. Model text, provider descriptions, tool output,
-and Markdown/HTML never become trusted approval copy. Secret-like input is
-rejected rather than redacted and then sent. If the canonical arguments cannot
-fit the approval display bound, execution fails closed instead of presenting a
-truncated approval. The workspace-scoped Ask
-User store may persist that displayed business input under its existing durable
-file protections, but it stores no provider credential, session header,
-access/refresh token, endpoint secret, or raw approval capability. Only a
-digest/receipt is used for execution enforcement and value-free MCP audit.
+## One shared Ask User runtime
 
-The current in-process waiter model is acceptable for Seneca's one app replica.
-A multi-replica deployment is a stop condition until Ask User has a distributed
-coordinator or sticky single-owner execution proof.
+Seneca currently proves that one stable `createAskUserServerPlugin` object must
+own both the blocking tool waiter and browser bridge handlers. Preserve that
+invariant explicitly:
 
-### 11. App configuration is server-authoritative and reversible
+1. construct one Ask User store/runtime;
+2. pass it to the Ask User server plugin;
+3. pass the same runtime to the MCP execution approver; and
+4. pass current Agent session ID, abort signal, and user principal into every
+   approval request.
 
-The existing master `BORING_MCP_PROD_ENABLED` gate remains. New capabilities are
-independently deployment-gated and reported to the front through an
-authenticated server capability DTO rather than relying only on compile-time
-`VITE_*` values:
+This is grounded in Seneca's deployed `@hachej/boring-ask-user@0.1.89`
+composition: `src/server/plugins.ts` creates one explicit server plugin/runtime,
+and production commit `e5e82c86253774079035de57f32588c289008de7` proved its
+blocking tool → browser answer → resumed Agent path. The upstream full-app does
+not need to adopt Ask User for this consumer slice; Seneca #35 owns that exact
+front/server dependency and composition.
 
-- full Composio catalog;
-- official Registry browsing;
-- custom remote sources;
-- general approval-gated execution; and
-- direct-read policy.
+Timeout, abort, cancellation, missing UI, rate limit, another pending question,
+answer from another principal/session, or process restart all deny execution.
+The current in-process coordinator is acceptable for Seneca's one app replica.
+A multi-replica launch requires sticky ownership or a distributed coordinator
+and is out of this fast path.
 
-All new gates default off in production. Static provider-template/read-only mode
-remains supported so Constellation does not broaden when Seneca opts into the
-generic mode.
+The Ask User durable store may contain the exact displayed business arguments
+under its current mode-`0600` workspace-root protection. It must never contain
+the Composio API key, provider OAuth tokens, MCP Session headers, raw approval
+capability, or account secret.
 
-## Stable source and catalog contract
+## Security boundary
 
-The implementation may refine names, but the semantic contract must preserve:
+The narrowed Composio-only scope removes arbitrary endpoint SSRF and arbitrary
+OAuth issuer handling from this launch. Outbound destinations are deployment
+configuration plus URLs returned by authenticated Composio APIs, not browser or
+model input.
 
-### Source
+Required controls remain:
 
-- opaque source ID;
-- workspace authority and audit creator;
-- source kind: Composio catalog, Registry remote, or custom remote;
-- display name and secret-free endpoint summary/fingerprint;
-- Registry/Composio provenance and version where applicable;
-- credential profile reference, never credential material;
-- connected/needs-auth/expired/revoked/quarantined/error state;
-- source revision and timestamps; and
-- trust tier assigned by the host, never the server.
+- isolated Composio production project/account;
+- operator API key resolved server-side from approved secret storage;
+- reviewed HTTPS Composio API, connection-link, and MCP endpoint origin policy;
+- no browser/workspace/prompt/session/log exposure of API key, OAuth tokens, or
+  Session headers;
+- response/error redaction and seeded canary tests;
+- bounded timeouts, bodies, schemas, results, connections, search, and calls;
+- no automatic provider-call retry;
+- current actor/workspace/source checks before every catalog/account/tool call;
+- toolkit/account IDs accepted only from validated Composio responses;
+- tool descriptions/results treated as untrusted data, never policy; and
+- vendor DPA, subprocessors, data residency, incident history, billing, and
+  managed-auth limitations accepted before production sale.
 
-### Tool catalog entry
+The session MCP URL must be HTTPS, contain no credentials, and match the
+reviewed Composio endpoint policy. If Composio changes its endpoint domains, the
+operator updates reviewed configuration; the app does not accept a user URL.
 
-- source and provider/toolkit/account identity plus exact toolkit/tool version;
-- provider-native tool name and bounded descriptions marked as untrusted data;
-- input/output schemas and schema hash;
-- bounded protocol annotations as evidence;
-- host effects/risk classification and reasons;
-- execution mode: direct, approval-required, or blocked;
-- source and policy revisions; and
-- secret-free native references.
+## UI
 
-### Approval/audit receipt
+The existing MCP overlay becomes a single **Composio** experience:
 
-- request/approval ID, actor, workspace, source, and tool;
-- source/policy/schema revisions and canonical argument digest;
-- decision, timestamps, outcome, stable code, and provider-dispatch state;
-- no raw arguments, answers, endpoint credentials, headers, or token material.
+### Catalog
+
+- searchable/paginated app cards;
+- app logo/name and secret-free auth readiness;
+- Connect, Connected, Needs setup, Expired, or Revoked state;
+- no provider-template dropdown; and
+- no Registry or custom-server tab.
+
+### Connections
+
+- connected app/account label;
+- active account selection when multiple accounts exist;
+- refresh and revoke;
+- last verified time and safe errors; and
+- tool browser with Direct / Approval required / Blocked badges.
+
+### Approval
+
+Reuse the Questions/Inbox surface. Do not build a second modal or approval
+store. Copy is server-authored and action-specific.
+
+The front reads enabled capabilities from an authenticated server DTO. It does
+not infer production authority from `VITE_*` flags alone.
 
 ## Stable errors
 
 Extend the canonical MCP error registry rather than returning ad hoc strings.
-The final names are frozen with implementation tests, covering at least:
+Implementation tests freeze names for at least:
 
-- unsafe/unsupported endpoint;
-- remote/Registry unavailable;
-- source quarantined;
-- authentication required, invalid/expired OAuth state, callback subject/source
-  mismatch, refresh failure, and insufficient scope;
-- tool metadata invalid and source/schema/policy drift;
-- approval denied, stale, unavailable, pending conflict, or expired;
-- credential absent, revoked, or unreadable (mapped from canonical #820 errors
-  without leaking profile existence);
-- rate/concurrency/body/result limits; and
-- provider outcome unknown after dispatch.
+- Composio catalog/session/account unavailable;
+- connection/auth required or expired;
+- toolkit/account not found without cross-user existence leakage;
+- invalid/oversized tool metadata or schema drift;
+- tool direct-execution not allowed;
+- approval denied, stale, unavailable, conflicting, expired, or rate-limited;
+- provider timeout, error, and outcome unknown;
+- body/result/rate/concurrency limits; and
+- secret leak guard.
 
-Cross-workspace/source/profile lookup uses non-disclosing not-found behavior.
-Errors returned to UI/agent contain stable code, safe message, and request ID,
-not raw provider stack traces or URLs.
+Browser and Agent responses contain stable code, safe message, and request ID,
+not raw Composio responses, URLs with sensitive parameters, or stack traces.
 
-## Threat model and required controls
+## Flags and rollback
 
-| Threat | Required control |
-| --- | --- |
-| Custom URL reaches App/DB/Tailscale/metadata services | guarded DNS-pinned fetch plus network egress proxy; block all non-global destinations and every redirect/metadata URL |
-| DNS rebinding between validation and request | resolve all records, reject any unsafe answer, pin approved connection, revalidate new connections |
-| OAuth metadata points to internal or attacker endpoints | run every discovered URL through the same egress/resource/issuer policy |
-| OAuth mix-up/code interception | source-bound one-use state, PKCE S256, exact callback, issuer/resource/audience binding, current owner recheck |
-| Token or session-header leakage | #820 vault, memory-bounded access token, no URL/query token, redaction/canaries across browser, logs, sessions, approvals, errors |
-| Registry entry is malicious or later deleted | Registry is provenance only; untrusted policy; status refresh; quarantine deleted entries |
-| Server lies in tool annotations | annotations never authorize untrusted sources; custom/Registry tools require approval unless exact host policy says otherwise |
-| Prompt injection asks agent to skip confirmation | approval is in the server call boundary, not prompt convention |
-| Approval reused for changed tool/input | bind session, account/tool versions, revisions + canonical argument digest; atomic single-use receipt |
-| Mutable provider target changes after approval | show residual warning; bind provider preconditions/ETag/dry-run when available; never claim semantic snapshot without provider support |
-| Provider executes twice after timeout | no automatic execution retry; explicit unknown-outcome state; provider idempotency/reconciliation only when supported |
-| Tool description/output poisons model or approval | mark as untrusted data; render approval from escaped server-owned fields; later risky calls still require exact approval |
-| Another user/workspace uses a source | fresh membership and source/profile scope checks; opaque IDs; not-found semantics |
-| Owner adds many endpoints/tools to exhaust host | per-workspace/source limits, body/schema/result caps, bounded Registry mirror, connection/concurrency/rate budgets |
-| Remote content injects secrets or malicious UI | text-only escaped rendering, CSP, no HTML execution, redaction/leak guard, no raw auth URL schemes |
-| Process restart leaves approval reusable | in-process receipt dies; pending question is abandoned; provider call never resumes automatically |
+### Flags
+
+- Existing `BORING_MCP_PROD_ENABLED` remains the outer production switch.
+- Add one full-catalog Composio mode flag.
+- Add one general approval-gated execution flag.
+- Reserve one future direct-read flag; it is absent/off for the sellable launch.
+- The server exposes effective capabilities to the front.
+
+Static Notion/Airtable read-only mode remains the default compatibility path for
+Constellation or other curated apps. Seneca explicitly selects Composio catalog
+mode.
+
+### Rollout
+
+1. Before changing contracts, run one isolated real-Composio capability spike:
+   prove an unfiltered full-catalog Session, disabled sandbox/workbench,
+   controlled meta-tool reachability, bounded search/schema, and exact pinned
+   account execution with a disposable account. Record sanitized request/response
+   shapes; stop if any assumption fails.
+2. Land full-catalog session/search/account behavior behind flags with existing
+   curated consumers unchanged.
+3. Land exact Ask User approval for every execution and keep execution disabled.
+4. Land the one-Composio UI and server capability DTO.
+5. Pack the affected package cohort and install tarballs in a clean Seneca
+   checkout.
+6. Publish through the normal release process and pin exact versions in Seneca.
+7. Create an isolated production Composio project, configure the operator key,
+   and accept the vendor/security/billing review.
+8. Deploy Seneca with catalog and execution flags off; verify current web and
+   Ask User health.
+9. Enable catalog plus approval-required execution.
+10. Prove one managed-auth app and one provider-setup-required state.
+11. Prove an approved read, approved disposable write, denial, stale approval,
+    revoke, and unknown-outcome behavior against test accounts only.
+12. Observe error/approval/latency/rate/billing signals on the current
+    `prod.senecaapp.ai` deployment.
+13. Execute Seneca issue #36's reviewed, reversible cutover so
+    `app.senecaapp.ai` reaches this deployment and `prod.senecaapp.ai` remains a
+    rollback alias. Its Cloudflare, TLS, auth, Stripe-accounting, and live proof
+    gates are mandatory.
+14. Keep the legacy Fly/Neon environment recoverable until boring-ui #877
+    completes archive, observation, two-person deletion, and billing proof.
+
+### Rollback
+
+1. Disable general execution: catalog/search/describe remain; calls return stable
+   unavailable/not-allowed.
+2. Disable full-catalog mode: while the old Seneca UI is retained during
+   observation it may return to curated mode; after that UI is removed, MCP is
+   hidden/unavailable rather than promising a missing screen.
+3. Disable outer MCP production gate: core Seneca web/Agent and Ask User remain.
+4. Any future direct-read flag disables back to approval-required.
+
+Rollback never retries an ambiguous call, clears revocation, promotes a personal
+connection, exposes a secret, or rewrites stored data. No new credential schema
+is required for this fast path.
 
 ## Test seams
 
 ### Highest public seams
 
-Prefer complete public behavior over private helper tests:
+1. fake Composio HTTP API plus fake Session MCP server;
+2. real MCP SDK client transport through the Boring adapter;
+3. full source/catalog/describe/call facade;
+4. one real Ask User runtime: call blocks, browser answers, exact one dispatch;
+5. Fastify source/catalog/account routes with actor/workspace checks; and
+6. MCP overlay contract tests plus Seneca production E2E.
 
-1. a fake Streamable HTTP MCP server behind a controllable DNS/redirect/OAuth
-   harness;
-2. the `@hachej/boring-mcp` source/catalog/execution facade with real MCP SDK
-   client transport;
-3. Fastify source/credential/OAuth routes with real Core workspace membership
-   and #820 fake/real credential backends;
-4. one explicitly shared Ask User runtime: agent MCP call blocks, browser answers,
-   revisions are rechecked, and exactly one fake provider call occurs;
-5. MCP overlay tests through its HTTP client contract; and
-6. clean packed-package installation into Seneca followed by deterministic
-   browser + agent E2E.
+### Required upstream tests
 
-### Required deterministic matrices
+#### Full catalog
 
-#### Network and OAuth
+- Session request omits toolkit enable filter;
+- sandbox/workbench disabled;
+- internal meta-tools only, never listed/callable by Agent;
+- search uses actual query, pagination, limits, and schema retrieval;
+- all valid app-native search results become catalog entries;
+- malformed/oversized/secret metadata fails closed;
+- account/tool/version/schema changes invalidate cache;
+- managed-auth versus provider-setup-required state; and
+- multiple accounts require explicit active selection.
 
-- public IPv4/IPv6 success;
-- loopback, private, link-local, multicast, CGNAT/Tailscale, metadata,
-  IPv4-mapped IPv6, mixed safe/unsafe DNS answers, and IP-literal negatives;
-- safe DNS first then rebind negative;
-- redirect to private/cross-origin/downgrade/too-many hops;
-- OAuth metadata/token/revocation URL SSRF;
-- missing/malformed resource metadata, guessed-fallback rejection, issuer or
-  authorization-response `iss` mismatch, cross-profile client-registration
-  reuse, missing PKCE S256, state replay/expiry, callback wrong
-  actor/workspace/source/profile, exact redirect mismatch, scope step-up bounds,
-  refresh race/rotation, and revocation;
-- no auth, OAuth, bearer, and approved API-key modes; forbidden headers fail;
-- timeout, body/header/schema/result, concurrent connection, and rate bounds.
+#### Policy and execution
 
-#### Authority and credential isolation
+- every launch-version call requires approval;
+- no pre-approval path exists for read/write/destructive/admin/unknown calls;
+- raw `COMPOSIO_MULTI_EXECUTE_TOOL` cannot bypass policy;
+- approval, denial, cancel, timeout, abort, owner mismatch, replay, and stale
+  revisions all assert exact provider-call count;
+- duplicate answer/nonces never dispatch twice;
+- provider timeout after dispatch reports unknown and does not retry;
+- input/output/schema/rate/concurrency bounds; and
+- provider descriptions/results cannot inject approval UI markup or policy.
 
-- owner can mutate; editor/viewer/nonmember cannot;
-- members can use an enabled workspace source under registered policy;
-- two workspaces × two remote profiles × concurrent calls observe only matching
-  fake-provider canaries;
-- same provider kind with two sources resolves two distinct profiles;
-- caller-supplied profile/workspace/provider mismatch fails before decrypt/fetch;
-- revoke/tombstone blocks the next call and never falls back;
-- existing personal MCP records are inventoried/quarantined and never
-  auto-promoted.
+#### Identity and secrets
 
-#### Catalog and policy
+- user/workspace A cannot list/use B's source/account;
+- fake IDs fail before Composio calls;
+- revoke prevents later use;
+- API key, Session headers, OAuth/token/cookie/auth-code canaries are absent from
+  browser DTOs, Agent output, Ask User files/transcripts, sessions, errors, and
+  captured logs; and
+- personal-source migration compatibility remains unchanged pending #820.
 
-- Composio Session omits toolkit restriction and disables sandbox/workbench;
-- two accounts for one toolkit require an explicit active-account selection;
-  removing/changing that selection invalidates source revision and no call uses
-  Composio's most-recent fallback;
-- toolkit/tool version and schema drift invalidate cached execution metadata;
-- query-driven internal meta-tool discovery is paginated/bounded and raw
-  `COMPOSIO_*` tools never enter the agent catalog;
-- managed-auth and provider-setup-required states are distinct;
-- Registry complete-snapshot replacement, cursor pagination, cache fallback,
-  active/latest filtering, record hashes, invalid record bounds, duplicate
-  Registry/custom endpoint handling, and deleted quarantine;
-- all valid app-native tools are searchable/describable;
-- malformed tool/schema/secret metadata fails closed;
-- untrusted `readOnlyHint` cannot obtain direct execution;
-- exact host read policy requires matching origin/tool/schema;
-- source, policy, and schema revisions invalidate cached decisions.
-
-#### Approval and execution
-
-- direct host-classified read invokes once without a question;
-- every other risk class blocks before provider call and creates one question;
-- approve once invokes exactly once; deny/cancel/timeout/abort/no UI does not
-  invoke;
-- question answer from another principal/session is denied;
-- argument, schema, policy, source, endpoint, active account/tool version,
-  credential, or membership change while waiting produces stale/denied with zero
-  calls;
-- duplicate answer/replay cannot invoke twice and the ledger transition to
-  dispatch is atomic;
-- provider timeout after dispatch records unknown outcome and does not retry;
-  supported operation/idempotency IDs permit bounded reconciliation without a
-  second side effect;
-- secret/canary corpus is absent from question, transcript, DTO, tool output,
-  audit, errors, and captured logs.
-
-### Avoid testing
-
-- MCP SDK private implementation details when stock-client/server behavior proves
-  the contract;
-- Composio's own OAuth implementation beyond the app's request/response boundary;
-- generated direct provider tools or thousands of tool definitions in prompt;
-- local `stdio` execution;
-- a second credential store, Workspace authority, runtime composer, or approval
-  UI; and
-- live destructive actions against real customer/provider data.
-
-## Flag, rollout, and rollback
-
-### Flags
-
-- Existing master MCP production gate remains the outer switch.
-- New catalog, Registry, custom remote, general execution, and direct-read
-  features are separate server-authoritative gates.
-- Static curated/read-only mode is the compatibility default.
-
-### Rollout
-
-1. Land #820 `16f.1`, then owner-ratify 900.0's source-scoped profile
-   amendment before `16f.2` schema/storage and `16f.3` onboarding. Re-read the
-   landed contract and record the amended Bead edges.
-2. Land #820 `16f.2`–`16f.3`, then `16f.4`'s personal-to-workspace MCP migration
-   with existing curated behavior unchanged.
-3. Land remote egress/OAuth and new data contracts dark; qualify with fake
-   endpoints and no production routes.
-4. Enable full Composio catalog in development with an isolated Composio
-   project, server-side operator key, no sandbox/workbench, and test accounts.
-5. Enable the Registry mirror, then custom URL onboarding, while execution
-   remains approval-required.
-6. Enable direct reads only for exact host-reviewed policy (initially eligible
-   Composio read-only/non-open-world tools).
-7. Pack the affected package cohort and install into a clean Seneca checkout.
-8. Publish through the normal release process with owner approval; Seneca pins
-   exact versions/integrity.
-9. Deploy Seneca with all new flags off, then enable one capability at a time.
-10. Run controlled production proof using disposable accounts and a Boring-owned
-    remote MCP test server; no customer data or irreversible tool is used.
-11. Observe provider errors, approval rate/latency, blocked SSRF attempts,
-    Registry freshness, token refresh failures, and unknown outcomes before
-    widening availability.
-
-### Rollback
-
-Disable, in order: direct-read policy, general execution, custom remote,
-Registry, and full-catalog Composio. Existing curated Notion/Airtable read-only
-mode and web/agent operation remain available if their retained path is healthy.
-
-Rollback never:
-
-- decrypts new credentials back into generic settings;
-- clears revocation tombstones;
-- promotes personal sources;
-- changes workspace membership;
-- retries an approval/provider call; or
-- downgrades below the #820 schema/package floor after migration.
-
-Registry cache and custom-source metadata may remain inert. Credential records
-remain encrypted for forward recovery or explicit owner deletion.
-
-## Acceptance
-
-The reusable feature is complete only when:
-
-1. Composio app/toolkit discovery has no static toolkit allowlist and all valid
-   app-native tools are searchable/describable through bounded proxy tools.
-2. An owner can browse a validated official Registry snapshot and connect a
-   compatible active remote without Registry metadata granting trust.
-3. An owner can add a custom HTTPS Streamable HTTP URL and complete supported
-   auth without exposing credentials to browser state, URLs, workspace files,
-   prompts, sessions, approvals, logs, or errors.
-4. Multiple remote sources of the same provider kind have isolated
-   source-scoped credential profiles under the owner-ratified #820 extension.
-5. Current membership precedes every use; current owner role precedes every
-   lifecycle mutation; cross-workspace/profile attempts do not reveal existence.
-6. All remote/OAuth server-side requests pass DNS-pinned application validation
-   and an independent production egress policy.
-7. Tool annotations from untrusted servers never authorize direct execution.
-8. Every valid tool is direct, approval-required, or blocked for a stable
-   security/configuration reason; absence from an old static list is not a block.
-9. A risky/unknown call cannot reach the provider before the same human answers
-   an exact Ask User question, and post-answer drift/replay cannot reuse approval.
-10. A direct read, approved call, denial, timeout, stale approval, and ambiguous
-    provider outcome each produce a value-free auditable result with a stable
-    code.
-11. Curated static/read-only consumers remain unchanged unless they explicitly
-    select generic mode.
-12. The package cohort is tested from tarballs, released normally, pinned in
-    Seneca, deployed behind flags, live-smoked non-destructively, observed, and
-    rollback-proven.
-
-## Proof
-
-Expected upstream gates, refined to exact filenames in each slice:
-
-```bash
-pnpm --filter @hachej/boring-core typecheck
-pnpm --filter @hachej/boring-core test
-pnpm --filter @hachej/boring-agent typecheck
-pnpm --filter @hachej/boring-agent test
-pnpm --filter @hachej/boring-mcp typecheck
-pnpm --filter @hachej/boring-mcp test
-pnpm --filter @hachej/boring-ask-user typecheck
-pnpm --filter @hachej/boring-ask-user test
-pnpm lint:invariants
-pnpm audit:imports
-```
-
-Expected clean Seneca consumer gates:
+### Required Seneca proof
 
 ```bash
 pnpm agents:compile
@@ -782,297 +475,201 @@ pnpm build
 pnpm e2e
 ```
 
-Additional proof artifacts:
+Production proof records:
 
-- SSRF/DNS/redirect/OAuth conformance matrix output;
-- egress-proxy negative probe showing App/DB/Tailscale/metadata targets received
-  no request;
-- raw Postgres and artifact/log canary scans from #820 plus MCP-specific values;
-- real shared Ask User runtime trace: pending -> exact answer -> one provider
-  call, plus stale/deny zero-call traces;
-- exact Registry snapshot timestamp/status and degraded-cache proof;
-- package tarball contents, registry versions, and lockfile integrity;
-- production image digest, flags, controlled source/tool identities, health,
-  audit outcomes, executed rollback, and restored state; and
-- independent standards, security, UI/UX, and operations reviews.
+- exact image digest and package pins;
+- public and direct-origin health;
+- one full-catalog search;
+- managed connection and revoke using a disposable account;
+- approved read;
+- approved disposable write, denial, and stale zero-call result;
+- no raw Composio secret in logs/files/transcripts;
+- flags-off rollback and restore; and
+- vendor/security and operations acceptance.
+
+## Acceptance
+
+The fast sellable release is complete when:
+
+1. Seneca displays one Composio integration, not Notion/Airtable provider cards.
+2. Catalog search is not restricted by a static toolkit allowlist.
+3. A user can connect any toolkit supported by the configured Composio project
+   and its managed/custom auth readiness is represented honestly.
+4. All valid app-native tools are searchable/describable/callable through the
+   bounded proxy surface.
+5. Raw Composio control-plane/workbench/bash tools are unreachable.
+6. Every launch-version call requires one exact current-user approval and
+   cannot reach Composio before approval.
+7. Drift, denial, cancel, timeout, replay, or wrong user/session produces zero
+   provider calls.
+8. Ambiguous provider outcomes are not retried automatically.
+9. User/workspace/account isolation, revocation, stable errors, rate limits,
+   and secret redaction pass deterministic tests.
+10. Curated static consumers do not broaden unless they select catalog mode.
+11. Exact packages are released/pinned in Seneca and production rollback is
+    executed successfully.
 
 ## Slices
 
-### Slice 900.0 — Ratify profile identity and freeze dependencies
+### Slice 900.1 — Full-catalog Composio backend
 
-**Delivers:** An amendment to Decision 27/#820 defining source-scoped MCP
-credential profiles, authority/selection semantics, and the relationship to the
-landed `16f.1` contract. Re-inventory current #820/#805 PRs and `boring-mcp`
-after merge; record exact symbols and no-overlap sequencing.
+**Delivers:** First, a no-contract real-Composio capability spike proving
+unfiltered Session behavior, sandbox/workbench disablement, meta-tool control,
+query/schema bounds, and exact pinned-account execution. Then a thin Composio
+adapter identity, optional managed search/describe seam, shallow
+query/schema/connection mapping, bounded transient caches, source/tool
+revisions, and curated compatibility. No provider templates or mirrored catalog.
 
-**Blocked by:** Owner/security approval of this plan; resolution of open PR
-#893 as the candidate `16f.1` base. Do not overwrite another writer's contract.
-This slice blocks #820 `16f.2`/`16f.3` if the profile amendment is accepted,
-because their schema and APIs must use the final identity.
+**Blocked by:** Isolated Composio development project/key and disposable test
+account for the spike. No production/customer secret.
 
-**Proof:** Decision diff; two-source/two-workspace semantic fixture; dependency
-DAG with the new `16f.1 -> 900.0 -> 16f.2` edge; docs-only checks; adversarial
-security review.
+**Proof:** Sanitized live capability record plus fake deterministic fixtures;
+`@hachej/boring-mcp` typecheck/test/build, real fake MCP transport, secret
+canaries, full-app compatibility, standards/security review.
 
-**Review budget:** Inside one plan/contract PR. No runtime behavior.
+**Review budget:** One focused upstream PR.
 
-### Slice 900.1 — Guarded remote transport and OAuth conformance
+### Slice 900.2 — General calls with exact Ask User approval
 
-**Delivers:** One reusable remote endpoint policy, DNS-pinned/manual-redirect
-fetch, egress-proxy contract, bounded Streamable HTTP transport, OAuth client
-provider/state adapter, stable errors, and fake DNS/redirect/OAuth harness.
+**Delivers:** Launch policy `approval-required|blocked`, `mcp_tool_call`,
+`mcp_readonly_call` compatibility alias, injected approver, one shared Ask User
+runtime composition, one-use revision/digest-bound approval, value-free audit,
+and outcome-unknown handling. No direct-read classifier on the sale path.
 
-**Blocked by:** 900.0; exact #820 credential resolver/OAuth seams available for
-integration or represented by fakes without a second store.
+**Blocked by:** 900.1.
 
-**Proof:** Full network/OAuth deterministic matrix; MCP SDK stock-server/client
-smoke; typecheck/test/invariants; security re-review.
-
-**Review budget:** One focused security PR. No UI and no production enablement.
-
-### Slice 900.2 — Dynamic catalogs and source model
-
-**Delivers:** Workspace source/provenance contracts, Composio virtual catalog
-source, unrestricted toolkit Session configuration with internal query-driven
-meta-tools, connected toolkit account model, official Registry LKG mirror,
-Registry/custom source creation contracts, and migration compatibility types.
-
-**Blocked by:** 900.1; serialize with #820 `16f.4` if it touches the same MCP
-source/onboarding files.
-
-**Proof:** Composio/Registry/source matrices; secret-free DTO scans; existing
-curated tests unchanged; package test/typecheck/build.
-
-**Review budget:** Likely two PRs if Composio and Registry/source persistence
-cannot remain independently reviewable; one writer owns overlapping contracts.
-
-### Slice 900.3 — General tool policy and exact approval execution
-
-**Delivers:** Preserved annotations/output schema, host risk/effects policy,
-`direct|approval-required|blocked`, general `mcp_tool_call`, compatibility
-`mcp_readonly_call`, source/policy/schema revisions, canonical argument digest,
-value-free audit receipts, and injected approver contract.
-
-**Blocked by:** 900.2; host trust policy reviewed.
-
-**Proof:** catalog/policy/approval matrices with provider-call spies; drift and
-replay negatives; no automatic retry; stable errors; thermo/security review.
+**Proof:** real blocking Ask User -> browser answer -> one fake Composio call;
+approve/deny/cancel/stale/replay/timeout matrices; secret scan; thermo/security
+review.
 
 **Review budget:** One focused execution-boundary PR.
 
-### Slice 900.4 — Ask User and provider-credential composition
+### Slice 900.3 — One-Composio UI and capabilities
 
-**Delivers:** One explicit shared Ask User store/runtime, MCP Ask User approval
-adapter, owner-bound questions, source-scoped credential resolution, Composio
-external-managed custody, remote OAuth/bearer/API-key lifecycle, personal-source
-quarantine migration, and current-authority checks.
+**Delivers:** Live Composio-backed catalog, connections, active-account
+selection, tool detail, server-authoritative capabilities, and approval copy in
+the existing Questions/Inbox surface. Seneca keeps the old UI behind capability
+selection through the observation window; if it is removed later, catalog-mode
+rollback disables MCP rather than promising a missing curated screen.
 
-**Blocked by:** 900.3 and #820 `16f.2`–`16f.4`; any multi-replica deployment is
-blocked pending a coordinator decision.
+**Blocked by:** Stable 900.1–900.2 contracts.
 
-**Proof:** real blocking Ask User -> browser bridge answer -> exact one-call
-integration; two-workspace/two-profile credential matrix; raw DB/log/transcript
-canary scans; revoke/tombstone proof.
+**Proof:** front tests, accessibility/keyboard checks, screenshots, responsive
+proof, high-taste UI review.
 
-**Review budget:** Exceeds one PR. Split reusable credential/source migration
-from Ask User execution composition, with one writer at a time for shared files.
+**Review budget:** One UI PR.
 
-### Slice 900.5 — MCP overlay and server-authoritative capabilities
+### Slice 900.4 — Release and Seneca production proof
 
-**Delivers:** Connected/Composio/Registry/Custom views, owner/member affordances,
-source/tool/risk/provenance detail, OAuth/connect handoff, capability DTO,
-loading/error/empty/quarantine states, and accessible approval copy.
+**Delivers:** Pack/install qualification, normal package release, exact Seneca
+pins/composition, isolated Composio project/secret, deployment flags,
+non-destructive production E2E on `prod.senecaapp.ai`, then issue #36's exact-SHA
+Cloudflare cutover making `app.senecaapp.ai` canonical while retaining `prod` as
+a rollback alias. The legacy environment remains recoverable under #877.
 
-**Blocked by:** Stable server contracts from 900.2–900.4.
+**Blocked by:** 900.1–900.3; release/deployment/vendor/security approval;
+Seneca #36 Cloudflare DNS API access and approved Stripe accounting transition.
 
-**Proof:** front contract tests, keyboard/accessibility checks, screenshots for
-all four views and approval states, responsive proof, high-taste UI review.
+**Proof:** upstream package gates, clean Seneca gates, tarball/lock integrity,
+image digest, live Composio test-account evidence, secret scans,
+`app.senecaapp.ai` self-hosted origin marker/health/auth/payment proof,
+DNS/config rollback and restore, operations review, and #877 retention proof.
 
-**Review budget:** One UI PR after contracts stabilize.
+**Review budget:** One release qualification, one Seneca PR, one production
+proof record.
 
-### Slice 900.6 — Compatibility, release, and clean Seneca qualification
+### Optional post-launch slice 900.5 — Verified direct reads
 
-**Delivers:** App-binding factory supports explicit curated and generic modes;
-existing full-app/Constellation behavior remains curated; affected packages are
-packed, installed in a clean Seneca checkout, tested, released, and pinned.
+**Delivers:** Sampled/accepted Composio risk metadata authority, conservative
+`direct|approval-required|blocked` classification, a direct-read server flag,
+and deterministic contradiction/unknown tests.
 
-**Blocked by:** 900.1–900.5; normal release approval.
-
-**Proof:** package gates, curated compatibility suite, tarball export/content
-check, clean Seneca gates, exact registry versions/integrity.
-
-**Review budget:** Upstream compatibility/release PR plus separate Seneca
-integration PR.
-
-### Slice 900.7 — Seneca deployment and controlled production proof
-
-**Delivers:** Seneca #35 generic-mode composition, persistent Registry cache,
-egress proxy/network policy, operator Composio secret, server flags, monitoring,
-controlled live Composio/Registry/custom sources, approval E2E, observation, and
-executed rollback/restore.
-
-**Blocked by:** 900.6; owner access/secret/vendor-risk/deployment approval; an
-isolated Composio project and Boring-owned public MCP test server.
-
-**Proof:** exact image/package versions; browser and agent E2E; non-destructive
-live calls; SSRF canary negative; redacted logs/audit; rollback/restore; security
-and operations review.
-
-**Review budget:** One Seneca code PR and one explicit production proof record.
+**Blocked by:** Successful sellable launch plus a recorded sample of live
+Composio metadata. It is not part of 900.1–900.4 or the domain cutover.
 
 ## Dependency graph
 
 ```text
-#820 16f.1
-    |
-    v
-900.0 owner profile amendment + contract freeze
-    |
-    v
-#820 16f.2 -> 16f.3 -> 16f.4 curated workspace migration
-                                  |
-                                  v
-                                900.1 guarded transport/OAuth
-                                  |
-                                  v
-                                900.2 catalogs/sources
-                    |
-                    v
-                                900.3 policy/approval boundary
-                                  |
-                                  v
-                                900.4 credentials + shared Ask User runtime
-                                  |
-                                  v
-                                900.5 UI
-                                  |
-                                  v
-                                900.6 compatibility/release
-                                  |
-                                  v
-                                900.7 Seneca production proof
+900.1 live spike + full-catalog backend
+  -> 900.2 approval for every call
+    -> 900.3 one-Composio UI
+      -> 900.4 release + Seneca proof
+        -> optional 900.5 verified direct reads
 ```
 
-The runtime path is intentionally mostly linear because the same MCP contracts
-and files are affected and credential/auth/source decisions must settle before
-UI and release. Beads are appropriate after owner approval, but they must be
-created from then-current #820 IDs, checked with `br dep cycles`, and inspected
-with `bv --robot-insights`; no Beads are created by this plan PR.
-
-## Stop conditions
-
-Stop and amend/route instead of improvising if:
-
-1. Decision 27/#820 does not approve multiple source-scoped profiles for custom
-   MCP servers.
-2. The landed #820 resolver cannot bind a profile without accepting authority
-   from browser/model input.
-3. A proposed implementation stores any custom credential/token in user
-   settings, source metadata, URL, browser, workspace file, transcript, or log.
-4. Safe remote fetch cannot pin validated DNS connections or production cannot
-   enforce independent private-network egress denial.
-5. MCP OAuth conformance requires copying/forking the protocol instead of using
-   a reviewed public SDK seam.
-6. Provider execution can occur before approval or approval cannot be bound to
-   exact revisions and arguments.
-7. The host would trust arbitrary server annotations or a Registry listing for
-   direct execution.
-8. Ask User would be reconstructed separately for bridge and execution, or a
-   multi-replica deployment cannot guarantee the answering runtime owns the
-   waiter.
-9. Full Composio discovery requires exposing raw management/remote-bash
-   meta-tools to the agent.
-10. Constellation/static consumers broaden without explicit configuration.
-11. A release or production proof requires real destructive actions, customer
-   credentials/data, raw secrets in commands, or unpublished workspace links.
+This is intentionally linear and small. Do not create a large Bead graph. Each
+slice can be one tracked PR/slice under issue #900 and Seneca #35.
 
 ## Out of scope
 
-- Hosted user-supplied `stdio`, package commands, or local MCP binaries.
-- Legacy SSE remote transport in v1.
-- Trusting an entire custom server permanently from one browser click.
-- Automatic retry of provider tool execution.
-- Durable or cross-replica approval resumption.
-- Direct generation of every provider tool into model context.
-- Composio remote workbench/bash, local code execution, or arbitrary sandbox
-  credential delivery.
-- Tenant-authored general provider definitions outside the guarded MCP remote
-  source kind.
-- Billing, marketplace ratings, malware scanning claims, or Registry trust
-  scores.
-- Cross-workspace credentials, public credential sharing, or plaintext export.
-- Changes to #806 MCP ingress or agent-fleet/runtime authority.
+- MCP Registry or marketplace.
+- User-supplied/custom MCP URLs.
+- `stdio`, SSE fallback, local MCP processes, or package installation.
+- Multiple MCP providers in the Seneca UI.
+- Composio workbench, remote bash, or raw meta-tools.
+- General provider credential vault or multiple same-provider credential
+  profiles; #820 owns future workspace-shared custody.
+- Multi-replica Ask User coordination.
+- Generated direct app tools loaded into model context.
+- Automatic tool-call retry or false exactly-once guarantees.
+- Constellation policy broadening.
 
-## Open owner decisions
+## Stop conditions
 
-These decisions require explicit owner/security ratification before `/exec`:
+Stop and amend instead of improvising if:
 
-1. **Credential profile amendment:** adopt one profile per remote MCP source,
-   semantically `(workspaceId, providerId, profileId)`, while keeping Composio
-   one workspace profile with multiple custodian-managed toolkit accounts.
-2. **Trust default:** custom and Registry tools, including apparent reads,
-   require approval unless an exact host policy recognizes source origin, tool,
-   and schema; Composio-only safe read metadata may be trusted by deployment
-   policy.
-3. **Meta-tool boundary:** “all tools” means all valid app-native tools; raw
-   Composio management/schema/execute and remote workbench/bash meta-tools stay
-   internal/disabled.
-4. **Production network gate:** custom remote support does not launch until both
-   DNS-pinned app validation and an independent egress proxy/network policy are
-   proven.
-
-## Grounding sources
-
-- Composio Sessions: sessions expose every toolkit by default when no toolkit
-  filter is supplied; meta-tools are the recommended broad-agent discovery
-  shape; tag filters exist; sandbox/workbench can be disabled:
-  <https://docs.composio.dev/docs/configuring-sessions>.
-- Composio Connect/auth: dynamic meta-tools and managed versus custom auth:
-  <https://docs.composio.dev/docs/composio-connect>,
-  <https://docs.composio.dev/docs/authentication>, and
-  <https://docs.composio.dev/docs/custom-app-vs-managed-app>.
-- Official MCP Registry: remote records and Registry aggregator API/cache/status
-  expectations; the service has no uptime or durability guarantee:
-  <https://modelcontextprotocol.io/registry/remote-servers> and
-  <https://modelcontextprotocol.io/registry/registry-aggregators>.
-- MCP authorization: RFC 9728 discovery, OAuth 2.1, PKCE, RFC 8707 resources,
-  token handling, and redirect requirements:
-  <https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization>.
-- MCP tools: human-in-the-loop guidance and annotations as untrusted hints:
-  <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>.
-- MCP security best practices: SSRF, DNS rebinding, redirects, OAuth URL safety,
-  token passthrough, scope minimization, and local `stdio` risk:
-  <https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices>.
+1. full-catalog Sessions cannot disable remote sandbox/workbench;
+2. Composio Session MCP cannot prove the selected/pinned account is the account
+   used for execution;
+3. raw execution meta-tools can bypass Boring policy;
+4. approval cannot bind exact arguments/revisions and revalidate before call;
+5. Ask User would be reconstructed separately for waiter and browser handlers;
+6. Composio Session/account secrets would enter browser, workspace, prompt,
+   transcript, session, log, or error;
+7. Seneca would require arbitrary endpoint/OAuth handling to call this release
+   complete; or
+8. a production proof requires customer data or irreversible actions.
 
 ## Planning proof and review record
-
-Plan-only proof:
 
 ```bash
 git diff --check
 test -z "$(git diff --name-only origin/main...HEAD | grep -v '^docs/')"
-rg -n 'hachej/seneca/issues/35|#820|Ask User|SSRF|approval|required|rollback' \
+rg -n 'Composio|Ask User|approval|required|rollback|Out of scope' \
   docs/issues/900/plan.md
 ```
 
-Review status:
+Grounding:
 
-- Direct code and contract reconnaissance completed against Boring
-  `origin/main` at `86d38893a`, Seneca `origin/main` at `e5e82c8`, current
-  `@hachej/boring-mcp`/Ask User sources, owner-ratified #820 plan, and open PRs
-  #887/#893.
-- Official Composio, MCP Registry, MCP authorization/tools, and MCP security
-  documents were re-fetched on 2026-07-22; a live Registry v0.1 response was
-  schema-checked for remote records and status metadata.
-- Three web-assisted adversarial passes were run after the first complete
-  draft. Integrated findings: OAuth issuer/registration binding and `iss`, no
-  guessed discovery fallbacks, URL/TLS/pool/proxy bypass cases, explicit
-  account/version identity, Registry/custom dedupe, atomic single-use approval,
-  structured injection-resistant consent, mutable-resource TOCTOU honesty,
-  provider idempotency/reconciliation, and first-class unknown outcome.
-- APR and a fresh repository subagent review were unavailable in this
-  long-running session (`apr`/Oracle absent; session subagent cap exhausted).
-  This is not a review waiver. Before merge, run fresh independent
-  architecture/security and UI/test-seam reviews, integrate accepted findings,
-  and record convergence here. The plan remains `ready-for-human` until those
-  reviews and the four owner decisions above are resolved.
+- Composio Sessions expose the full toolkit catalog by default when no toolkit
+  filter is supplied, recommend meta-tool discovery for broad Agents, support
+  toolkit pagination plus exact `connectedAccounts` account pinning, behavior
+  tags, and sandbox disablement:
+  <https://docs.composio.dev/docs/configuring-sessions> and
+  <https://docs.composio.dev/docs/managing-multiple-connected-accounts>.
+- Composio Connect uses seven meta-tools for discovery, auth, schema, and
+  execution without loading the full catalog:
+  <https://docs.composio.dev/docs/composio-connect>.
+- Managed versus custom auth limitations:
+  <https://docs.composio.dev/docs/custom-app-vs-managed-app>.
+- MCP tool annotations are hints and human denial must remain possible:
+  <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>.
+
+Review record:
+
+- Code reconnaissance covered current Boring MCP/Ask User and Seneca production
+  composition.
+- The first broad plan received three web-assisted adversarial security passes.
+  Their approval TOCTOU, replay, prompt-injection, version/account identity, and
+  ambiguous-outcome findings remain integrated in this narrowed plan.
+- The owner explicitly removed Registry/custom-server scope and required a thin
+  Composio wrapper to optimize time to sale. That removes arbitrary endpoint
+  SSRF, dynamic OAuth issuer, custom credential-profile, egress-proxy, mirrored
+  provider catalog, and provider-template work from the critical path.
+- A fresh adversarial thin-wrapper review removed the launch-time direct-read
+  classifier (all launch calls require approval), added the early live Composio
+  spike, grounded exact account pinning, named the managed search/describe seam,
+  grounded Seneca's deployed shared Ask User runtime, and made UI rollback
+  honest.
+- CI on plan PR #901 was green before this scope reduction. Re-run after this
+  revision.


### PR DESCRIPTION
## Summary

Rewrite #900's canonical plan around the owner-confirmed fastest path: **one thin full-catalog Composio wrapper for generic Seneca**.

This revision supersedes the original Registry/custom-server scope.

## Scope

- Composio is authoritative for providers, app-native tools, schemas, auth, connections, and execution.
- One unfiltered Composio Session exposes every valid app-native provider tool through bounded search/describe/call proxy tools.
- No mirrored provider catalog or static template per app.
- Every launch-version call requires exact Ask User approval; direct reads move to optional post-launch work.
- Exact Composio account pinning, raw meta-tool non-bypass, no retry, and unknown-outcome handling are explicit.
- Registry, custom MCP URLs, `stdio`, workbench, bash, per-server credentials, and arbitrary egress are excluded.
- Seneca #36 owns the later reversible `app.senecaapp.ai` cutover; boring-ui #877 continues to own legacy deletion gates.

## Planning proof

- Current Boring MCP and Ask User code plus deployed Seneca composition were inspected.
- Official Composio Sessions/Connect/account-selection behavior grounds the design.
- Fresh adversarial thin-wrapper review is clean after:
  - removing launch-time direct-read classification;
  - adding an early real-Composio capability spike;
  - grounding exact `connectedAccounts`/execute-account pinning;
  - naming the managed search/describe contract seam;
  - grounding Seneca's deployed shared Ask User runtime;
  - making catalog/UI rollback honest; and
  - adding Seneca #36 domain/Stripe/decommission dependencies.
- `git diff --check` passes.
- Diff remains docs-only.

## Slices

1. Live capability spike + thin full-catalog backend.
2. Exact Ask User approval for every call.
3. One-Composio UI.
4. Release, `prod` proof, then #36 domain cutover.
5. Optional post-launch verified direct reads.

## Status

Plan only. No implementation or Beads were created. Keep draft for owner review before execution.
