### PR TITLE
#900 spike: prove full-catalog Composio capabilities

### DIFF
--- a/docs/issues/900/composio-capability-spike.md
+++ b/docs/issues/900/composio-capability-spike.md
@@ -1,0 +1,165 @@
+# Composio full-catalog capability spike
+
+Date: 2026-07-22  
+Issue: #900  
+Scope: live provider capability proof only; no customer tool/account execution and no product implementation
+
+## Result
+
+**Partial pass. Implementation remains stopped.**
+
+A synthetic Composio user and disposable Sessions proved the full-catalog,
+context-efficient wrapper shape. The available Vault key was sufficient for a
+session-only catalog probe, but this run did **not** prove that the Composio
+project is isolated. No customer account was selected, connected, or executed.
+
+Every created Session was registered for cleanup before its MCP URL was trusted,
+deleted in `finally`, and then verified absent with `GET ... -> 404`. The actual
+sanitized run recorded `cleanupComplete: true`. No Session ID, MCP URL path,
+header, API key, account row, schema body, search body, or tool output appears in
+this document or the script output.
+
+## Proved live
+
+1. `POST /api/v3.1/tool_router/session` succeeds with:
+   - `mcp: true`;
+   - no `toolkits` field;
+   - managed connection support; and
+   - `workbench: { enable: false }`.
+2. The returned config reported zero enabled-toolkit filters, and an unfiltered
+   query returned GitHub app-native tools.
+3. The Session reports workbench disabled and lists all four required
+   non-sandbox meta-tools:
+   - `COMPOSIO_SEARCH_TOOLS`;
+   - `COMPOSIO_GET_TOOL_SCHEMAS`;
+   - `COMPOSIO_MANAGE_CONNECTIONS`; and
+   - `COMPOSIO_MULTI_EXECUTE_TOOL`.
+4. `COMPOSIO_REMOTE_WORKBENCH` and `COMPOSIO_REMOTE_BASH_TOOL` are absent, and a
+   direct call to the disabled bash name returns an MCP error.
+5. Query-driven search returned one bounded GitHub result; exact schema retrieval
+   returned both requested schemas.
+6. A no-auth Hacker News toolkit correctly rejects connection-link creation as
+   unnecessary (`400`, provider code `4326`) rather than creating a credential.
+7. A Session pin to an intentionally invalid connected-account ID is rejected
+   with a provider 4xx.
+8. The live MCP origin was `https://backend.composio.dev`. The script rejects URL
+   credentials, redirects, and every origin outside that exact allowlist before
+   forwarding secrets.
+9. Returned Session headers alone received `401`; MCP currently requires the
+   operator API key. The successful retry forwarded it only to the exact reviewed
+   Composio origin and recorded booleans, never the key or provider body.
+10. API and MCP requests used a 15-second timeout, redirect rejection, and a
+    512-KiB response cap. Search additionally rejects more than 10 result groups,
+    and schema retrieval requests and requires exactly two schemas.
+
+## Provider behavior that changes implementation
+
+### Use the raw wire key `workbench`, not `sandbox`
+
+The raw v3.1 API accepted and reported:
+
+```json
+{ "workbench": { "enable": false } }
+```
+
+The same automated run created a paired Session using the SDK-documented
+`sandbox` alias; its returned raw config did not report workbench disabled
+(`sandboxAliasIgnoredByRawApi: true`). The thin adapter must send the wire-schema
+key and verify returned config plus tool list. Do not assume SDK aliases are
+normalized by the raw endpoint.
+
+### The operator key currently crosses the Session MCP boundary
+
+The returned Session headers were insufficient; the live MCP endpoint required
+`x-api-key`. Product code may send that key only after exact HTTPS origin
+validation. A provider-returned arbitrary HTTPS URL is not enough.
+
+### Raw execution must remain hidden
+
+The full-catalog Session necessarily exposes `COMPOSIO_MULTI_EXECUTE_TOOL`.
+Boring must keep the raw name unreachable and expose execution only through the
+approval-gated host call. Search/schema may be used internally, but model input
+cannot invoke raw execution around approval.
+
+## Actual sanitized run record
+
+Command exit: `0`  
+Observed at: `2026-07-22T20:50:37.665Z`
+
+```json
+{
+  "observedAt": "2026-07-22T20:50:37.665Z",
+  "projectIsolationProved": false,
+  "sessionCreated": true,
+  "fullCatalogUnfiltered": true,
+  "reportedToolkitFilterCount": 0,
+  "sandboxDisabled": true,
+  "metaToolControlRequired": true,
+  "sessionHeadersSufficient": false,
+  "sessionHeadersFailureStatus": 401,
+  "rawApiKeyForwardedToMcp": true,
+  "observedMcpOrigin": "https://backend.composio.dev",
+  "searchWorked": true,
+  "searchWasGitHubScoped": true,
+  "searchResultCount": 1,
+  "schemaWorked": true,
+  "requestedSchemaCount": 2,
+  "schemaCount": 2,
+  "noAuthConnectionCorrectlySkipped": true,
+  "invalidAccountPinRejected": true,
+  "exactValidAccountPinProved": false,
+  "listedMetaTools": [
+    "COMPOSIO_GET_TOOL_SCHEMAS",
+    "COMPOSIO_MANAGE_CONNECTIONS",
+    "COMPOSIO_MULTI_EXECUTE_TOOL",
+    "COMPOSIO_SEARCH_TOOLS"
+  ],
+  "reportedWorkbenchEnabled": false,
+  "sandboxAliasIgnoredByRawApi": true,
+  "cleanupComplete": true,
+  "stopReason": "A dedicated Composio project and exact valid-account execution pinning with a disposable owned account are still required."
+}
+```
+
+Meta-tool names and counts are capability metadata, not account/provider values.
+Counts can evolve and are not acceptance constants.
+
+## Remaining stop conditions
+
+Implementation cannot start until both are true:
+
+1. The owner creates or identifies a dedicated non-customer Composio project and
+   stores its project key separately from the current generic key.
+2. In that project, one disposable owned account proves exact execution pinning:
+   - connect through a one-time hosted link;
+   - create a Session with exact
+     `connected_accounts: { github: [<owned-account-id>] }`;
+   - verify the returned config pins that ID;
+   - execute one harmless identity/read tool through Session MCP;
+   - verify the selected account without logging its value;
+   - prove a different-user/invalid pin fails; and
+   - revoke the connection and delete/verify the Session.
+
+## Reproduction
+
+From a trusted operator shell, using a project key and synthetic Session only:
+
+```bash
+cd plugins/boring-mcp
+COMPOSIO_SPIKE_ACKNOWLEDGE_SYNTHETIC_USER_ONLY=1 \
+COMPOSIO_API_KEY="$(env -u VAULT_TOKEN vault kv get \
+  -field=api_key secret/agent/composio)" \
+pnpm spike:composio
+unset COMPOSIO_API_KEY COMPOSIO_SPIKE_ACKNOWLEDGE_SYNTHETIC_USER_ONLY
+```
+
+The acknowledgement does not prove project isolation. It only confirms that the
+operator intends this bounded Session/search/schema probe and will not connect
+or execute an existing account.
+
+## Sources
+
+- <https://docs.composio.dev/docs/configuring-sessions>
+- <https://docs.composio.dev/docs/managing-multiple-connected-accounts>
+- <https://docs.composio.dev/reference/api-reference/tool-router/postToolRouterSession>
+- <https://docs.composio.dev/reference/api-reference/tool-router/deleteToolRouterSessionBySessionId>

--- a/docs/issues/900/composio-capability-spike.md
+++ b/docs/issues/900/composio-capability-spike.md
@@ -1,17 +1,19 @@
 # Composio full-catalog capability spike
 
-Date: 2026-07-22  
-Issue: #900  
+Date: 2026-07-22
+Issue: #900
 Scope: live provider capability proof only; no customer tool/account execution and no product implementation
 
 ## Result
 
-**Partial pass. Implementation remains stopped.**
+**Pass after owner project selection and the valid-account follow-up. Slice
+900.1 implementation may proceed.**
 
-A synthetic Composio user and disposable Sessions proved the full-catalog,
-context-efficient wrapper shape. The available Vault key was sufficient for a
-session-only catalog probe, but this run did **not** prove that the Composio
-project is isolated. No customer account was selected, connected, or executed.
+The initial synthetic-user Session probe proved the full-catalog,
+context-efficient wrapper shape but intentionally stopped before account
+execution. On 2026-07-24 the owner selected the existing Composio project and
+a separate follow-up proved exact, owned, single-account Session pinning with a
+temporary GitHub connection. No customer account was selected or executed.
 
 Every created Session was registered for cleanup before its MCP URL was trusted,
 deleted in `finally`, and then verified absent with `GET ... -> 404`. The actual
@@ -83,7 +85,7 @@ cannot invoke raw execution around approval.
 
 ## Actual sanitized run record
 
-Command exit: `0`  
+Command exit: `0`
 Observed at: `2026-07-22T20:50:37.665Z`
 
 ```json
@@ -124,21 +126,69 @@ Observed at: `2026-07-22T20:50:37.665Z`
 Meta-tool names and counts are capability metadata, not account/provider values.
 Counts can evolve and are not acceptance constants.
 
-## Remaining stop conditions
+## Owner project decision
 
-Implementation cannot start until both are true:
+On 2026-07-24 the owner confirmed that the existing key at
+`secret/agent/composio` is the Composio project intended for this Seneca work.
+This resolves the product/project selection gate. It is an owner attestation,
+not a claim that the API can prove organizational isolation.
 
-1. The owner creates or identifies a dedicated non-customer Composio project and
-   stores its project key separately from the current generic key.
-2. In that project, one disposable owned account proves exact execution pinning:
-   - connect through a one-time hosted link;
-   - create a Session with exact
-     `connected_accounts: { github: [<owned-account-id>] }`;
-   - verify the returned config pins that ID;
-   - execute one harmless identity/read tool through Session MCP;
-   - verify the selected account without logging its value;
-   - prove a different-user/invalid pin fails; and
-   - revoke the connection and delete/verify the Session.
+## Exact valid-account pin proof
+
+After the owner authorized a temporary GitHub connection for the synthetic
+spike user, the server-side proof ran one harmless authenticated-profile read.
+It never printed the account ID, profile value, MCP URL/header, OAuth material,
+or tool output.
+
+Observed at: `2026-07-24T18:42Z`
+Command exit: `0`
+
+```json
+{
+  "connectedAccountFound": true,
+  "connectedAccountUnique": true,
+  "pinnedSessionCreated": true,
+  "returnedConfigPinnedExactAccount": true,
+  "crossUserInvalidPinRejected": true,
+  "githubIdentityToolSelected": true,
+  "githubIdentityReadSucceeded": true,
+  "explicitAccountArgumentSupported": false,
+  "executionResponseReferencedPinnedAccount": false,
+  "accountRevokedAndVerified": true,
+  "sessionsDeletedAndVerified": true,
+  "cleanupComplete": true,
+  "exactValidAccountPinProved": true
+}
+```
+
+The MCP execution meta-tool did not accept an explicit per-call account field and
+did not echo the account ID. Account identity was instead bound and verified at
+the Session boundary:
+
+1. the Session request pinned exactly one owned account with
+   `connected_accounts`;
+2. returned Session config preserved that exact ID;
+3. the same account ID under a different Composio user was rejected;
+4. the pinned Session completed the harmless GitHub identity read; and
+5. Composio's documented precedence selects `connectedAccounts` before every
+   other account source.
+
+Cleanup revoked the temporary connected account, verified it absent, deleted
+both original and pinned Sessions, and verified both returned `404`. The Vault
+link is overwritten with `REVOKED` and status `completed-revoked`.
+
+## Gate outcome
+
+The two pre-implementation stop conditions are resolved by owner project
+selection plus the exact valid-account proof above. Slice 900.1 may proceed with
+these mandatory implementation requirements:
+
+- raw wire `workbench: { enable: false }`;
+- exact MCP origin allowlist before forwarding the project key;
+- exact user/toolkit filtering of any connected-account result;
+- Session-level `connected_accounts` pinning and drift invalidation;
+- no raw multi-execute exposure; and
+- bounded, redacted, cleanup-verified provider calls.
 
 ## Reproduction
 

--- a/docs/issues/900/plan.md
+++ b/docs/issues/900/plan.md
@@ -68,7 +68,7 @@ MCP marketplace or secret system.
 
 The product promises access to the Composio catalog. It does not promise that
 every vendor works without setup: many apps use Composio managed auth, while
-others require a custom auth configuration in the isolated Composio project.
+others require a custom auth configuration in the owner-selected Composio project.
 The UI reports `Connect`, `Connected`, `Needs provider setup`, `Expired`, or
 `Revoked` honestly.
 
@@ -163,15 +163,15 @@ connection link for a selected toolkit. Only toolkit slugs returned by the live
 Composio catalog are accepted. Connect URLs remain HTTPS and match reviewed
 Composio origins.
 
-If multiple connected accounts exist for one toolkit, the current user must
-select the active account. The adapter pins the exact account in the Composio
-Session `connectedAccounts`/`connected_accounts` mapping (or the documented
-Session execute `account` field) and enables Composio's explicit-selection mode
-when multiple accounts are allowed. It never silently adopts Composio's
-most-recent-account fallback. Changing the active account patches/recreates the
-Session, increments source revision, and invalidates pending approval. The early
-real-Composio spike must prove the MCP execution uses the pinned account; if it
-cannot, stop rather than claim account-safe execution.
+The fastest launch supports exactly one active connected account per toolkit
+for each synthetic Composio user. The adapter filters by exact Boring-derived
+`user_id` plus toolkit, requires exactly one active result, and pins that ID in
+the Session `connectedAccounts`/`connected_accounts` mapping. Zero accounts
+returns auth-required; more than one fails closed before Session creation or
+execution and asks the user to revoke one. It never adopts Composio's
+most-recent-account fallback. Replacing an account requires revoke-then-connect,
+increments source revision, and invalidates pending approval. Multi-account
+selection is post-launch work, not part of the sale path.
 
 Disconnect/revoke calls the current Composio connected-account endpoint,
 verifies the result, marks local metadata revoked, and prevents subsequent
@@ -295,7 +295,8 @@ model input.
 
 Required controls remain:
 
-- isolated Composio production project/account;
+- owner-selected Composio project key, with Boring user/workspace isolation and
+  exactly-one-account-per-toolkit enforcement;
 - operator API key resolved server-side from approved secret storage;
 - reviewed HTTPS Composio API, connection-link, and MCP endpoint origin policy;
 - no browser/workspace/prompt/session/log exposure of API key, OAuth tokens, or
@@ -328,7 +329,7 @@ The existing MCP overlay becomes a single **Composio** experience:
 ### Connections
 
 - connected app/account label;
-- active account selection when multiple accounts exist;
+- exactly one connected account per toolkit, with revoke-before-replace copy;
 - refresh and revoke;
 - last verified time and safe errors; and
 - tool browser with Direct / Approval required / Blocked badges.
@@ -387,8 +388,8 @@ mode.
 5. Pack the affected package cohort and install tarballs in a clean Seneca
    checkout.
 6. Publish through the normal release process and pin exact versions in Seneca.
-7. Create an isolated production Composio project, configure the operator key,
-   and accept the vendor/security/billing review.
+7. Configure the owner-selected Composio project key and accept the
+   vendor/security/billing review.
 8. Deploy Seneca with catalog and execution flags off; verify current web and
    Ask User health.
 9. Enable catalog plus approval-required execution.
@@ -441,7 +442,8 @@ is required for this fast path.
 - malformed/oversized/secret metadata fails closed;
 - account/tool/version/schema changes invalidate cache;
 - managed-auth versus provider-setup-required state; and
-- multiple accounts require explicit active selection.
+- zero accounts requires auth and multiple same-toolkit accounts fail closed
+  before Session creation/execution;
 
 #### Policy and execution
 
@@ -520,8 +522,9 @@ adapter identity, optional managed search/describe seam, shallow
 query/schema/connection mapping, bounded transient caches, source/tool
 revisions, and curated compatibility. No provider templates or mirrored catalog.
 
-**Blocked by:** Isolated Composio development project/key and disposable test
-account for the spike. No production/customer secret.
+**Blocked by:** Owner-selected Composio project key and one owner-authorized
+temporary account for the spike. No customer account. The 2026-07-24 capability
+record resolves this gate and verifies cleanup/revocation.
 
 **Proof:** Sanitized live capability record plus fake deterministic fixtures;
 `@hachej/boring-mcp` typecheck/test/build, real fake MCP transport, secret
@@ -546,8 +549,9 @@ review.
 
 ### Slice 900.3 — One-Composio UI and capabilities
 
-**Delivers:** Live Composio-backed catalog, connections, active-account
-selection, tool detail, server-authoritative capabilities, and approval copy in
+**Delivers:** Live Composio-backed catalog, connections,
+revoke-before-replace single-account status, tool detail, server-authoritative
+capabilities, and approval copy in
 the existing Questions/Inbox surface. Seneca keeps the old UI behind capability
 selection through the observation window; if it is removed later, catalog-mode
 rollback disables MCP rather than promising a missing curated screen.
@@ -562,7 +566,7 @@ proof, high-taste UI review.
 ### Slice 900.4 — Release and Seneca production proof
 
 **Delivers:** Pack/install qualification, normal package release, exact Seneca
-pins/composition, isolated Composio project/secret, deployment flags,
+pins/composition, owner-selected Composio project/secret, deployment flags,
 non-destructive production E2E on `prod.senecaapp.ai`, then issue #36's exact-SHA
 Cloudflare cutover making `app.senecaapp.ai` canonical while retaining `prod` as
 a rollback alias. The legacy environment remains recoverable under #877.
@@ -619,8 +623,8 @@ slice can be one tracked PR/slice under issue #900 and Seneca #35.
 Stop and amend instead of improvising if:
 
 1. full-catalog Sessions cannot disable remote sandbox/workbench;
-2. Composio Session MCP cannot prove the selected/pinned account is the account
-   used for execution;
+2. Composio does not preserve the exact owned account pin, or the adapter cannot
+   block zero/multiple same-toolkit accounts before execution;
 3. raw execution meta-tools can bypass Boring policy;
 4. approval cannot bind exact arguments/revisions and revalidate before call;
 5. Ask User would be reconstructed separately for waiter and browser handlers;

--- a/plugins/boring-mcp/package.json
+++ b/plugins/boring-mcp/package.json
@@ -49,6 +49,7 @@
     "build": "tsup",
     "typecheck": "tsc --noEmit",
     "test": "vitest run --no-file-parallelism",
+    "spike:composio": "node scripts/composio-capability-spike.mjs",
     "lint": "pnpm run typecheck",
     "clean": "rm -rf dist .tsbuildinfo"
   },

--- a/plugins/boring-mcp/scripts/composio-capability-spike.mjs
+++ b/plugins/boring-mcp/scripts/composio-capability-spike.mjs
@@ -1,0 +1,305 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+
+const apiKey = process.env.COMPOSIO_API_KEY
+if (!apiKey) throw new Error("COMPOSIO_API_KEY is required")
+if (process.env.COMPOSIO_SPIKE_ACKNOWLEDGE_SYNTHETIC_USER_ONLY !== "1") {
+  throw new Error("Set COMPOSIO_SPIKE_ACKNOWLEDGE_SYNTHETIC_USER_ONLY=1 only for this session-only synthetic-user probe")
+}
+
+const apiBase = "https://backend.composio.dev"
+const apiOrigin = new URL(apiBase).origin
+const allowedMcpOrigins = new Set(["https://backend.composio.dev"])
+const userId = `boring-catalog-spike-${Date.now()}`
+const sessionIds = []
+const maxResponseBytes = 512 * 1024
+const requestTimeoutMs = 15_000
+
+function record(value) { return value && typeof value === "object" && !Array.isArray(value) ? value : {} }
+function array(value) { return Array.isArray(value) ? value : [] }
+function textJson(content) {
+  for (const item of array(content)) {
+    if (typeof item?.text !== "string") continue
+    try { return JSON.parse(item.text) } catch {}
+  }
+  return undefined
+}
+
+function combinedSignal(signal) {
+  const timeout = AbortSignal.timeout(requestTimeoutMs)
+  return signal ? AbortSignal.any([signal, timeout]) : timeout
+}
+
+async function boundedFetch(input, init = {}, allowedOrigins = new Set([apiOrigin])) {
+  const requestedUrl = new URL(input instanceof Request ? input.url : String(input))
+  if (!allowedOrigins.has(requestedUrl.origin)) throw new Error("Provider URL origin is not allowlisted")
+  const response = await fetch(input, {
+    ...init,
+    redirect: "error",
+    signal: combinedSignal(init.signal),
+  })
+  if (response.url && !allowedOrigins.has(new URL(response.url).origin)) throw new Error("Provider response origin changed")
+  const declaredLength = Number(response.headers.get("content-length") ?? "0")
+  if (Number.isFinite(declaredLength) && declaredLength > maxResponseBytes) throw new Error("Provider response exceeded byte limit")
+  if (!response.body) return new Response(undefined, { status: response.status, statusText: response.statusText, headers: response.headers })
+
+  const chunks = []
+  let total = 0
+  const reader = response.body.getReader()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      total += value.byteLength
+      if (total > maxResponseBytes) throw new Error("Provider response exceeded byte limit")
+      chunks.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  const body = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    body.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new Response(body, { status: response.status, statusText: response.statusText, headers: response.headers })
+}
+
+async function api(path, init = {}) {
+  const response = await boundedFetch(`${apiBase}${path}`, {
+    ...init,
+    headers: { "content-type": "application/json", "x-api-key": apiKey, ...(init.headers ?? {}) },
+  })
+  const text = await response.text()
+  let payload
+  try { payload = text ? JSON.parse(text) : undefined } catch { payload = undefined }
+  if (!response.ok) {
+    const error = new Error(`Composio API ${init.method ?? "GET"} ${path.split("?")[0]} failed with ${response.status}`)
+    error.status = response.status
+    error.payloadCode = payload?.error?.code ?? payload?.code
+    throw error
+  }
+  return payload
+}
+
+async function createSession(body) {
+  const payload = await api("/api/v3.1/tool_router/session", { method: "POST", body: JSON.stringify(body) })
+  const root = record(payload)
+  const session = record(root.session ?? root.data ?? root)
+  const id = session.id ?? session.session_id ?? root.id ?? root.session_id
+  if (typeof id !== "string") throw new Error("Session response omitted id")
+  sessionIds.push(id)
+  const mcp = record(session.mcp)
+  if (typeof mcp.url !== "string") throw new Error("Session response omitted MCP URL")
+  return { id, url: mcp.url, headers: record(mcp.headers), config: record(session.config ?? root.config) }
+}
+
+async function deleteAndVerifySession(id) {
+  const deleted = await boundedFetch(`${apiBase}/api/v3.1/tool_router/session/${encodeURIComponent(id)}`, {
+    method: "DELETE", headers: { "x-api-key": apiKey },
+  })
+  if (!deleted.ok && deleted.status !== 404) throw new Error(`Session cleanup failed with ${deleted.status}`)
+  const verified = await boundedFetch(`${apiBase}/api/v3.1/tool_router/session/${encodeURIComponent(id)}`, {
+    headers: { "x-api-key": apiKey },
+  })
+  if (verified.status !== 404) throw new Error(`Deleted Session remained readable with ${verified.status}`)
+}
+
+const report = {
+  observedAt: new Date().toISOString(),
+  projectIsolationProved: false,
+  sessionCreated: false,
+  fullCatalogUnfiltered: false,
+  reportedToolkitFilterCount: null,
+  sandboxDisabled: false,
+  metaToolControlRequired: false,
+  sessionHeadersSufficient: false,
+  sessionHeadersFailureStatus: null,
+  rawApiKeyForwardedToMcp: false,
+  observedMcpOrigin: null,
+  searchWorked: false,
+  searchWasGitHubScoped: false,
+  searchResultCount: 0,
+  schemaWorked: false,
+  requestedSchemaCount: 0,
+  schemaCount: 0,
+  noAuthConnectionCorrectlySkipped: false,
+  invalidAccountPinRejected: false,
+  exactValidAccountPinProved: false,
+  listedMetaTools: [],
+  reportedWorkbenchEnabled: null,
+  sandboxAliasIgnoredByRawApi: false,
+  cleanupComplete: false,
+  stopReason: null,
+}
+
+let client
+let phase = "initialization"
+let primaryError
+const cleanupErrors = []
+try {
+  phase = "sandbox alias probe"
+  const aliasSession = await createSession({
+    user_id: userId,
+    mcp: true,
+    sandbox: { enable: false },
+  })
+  report.sandboxAliasIgnoredByRawApi = record(aliasSession.config.workbench).enable !== false
+  if (!report.sandboxAliasIgnoredByRawApi) throw new Error("Raw API unexpectedly normalized the sandbox alias")
+
+  phase = "full-catalog Session creation"
+  const session = await createSession({
+    user_id: userId,
+    mcp: true,
+    manage_connections: { enable: true, enable_wait_for_connections: false },
+    workbench: { enable: false },
+  })
+  report.sessionCreated = true
+  const toolkitConfig = record(session.config.toolkits)
+  const enabledToolkits = array(toolkitConfig.enabled ?? toolkitConfig.enable)
+  report.reportedToolkitFilterCount = enabledToolkits.length
+  report.fullCatalogUnfiltered = report.reportedToolkitFilterCount === 0
+  if (!report.fullCatalogUnfiltered) throw new Error("Session unexpectedly reported a toolkit filter")
+  report.reportedWorkbenchEnabled = record(session.config.workbench).enable ?? null
+  if (report.reportedWorkbenchEnabled !== false) throw new Error("Session did not report workbench disabled")
+
+  const parsedUrl = new URL(session.url)
+  report.observedMcpOrigin = parsedUrl.origin
+  if (parsedUrl.protocol !== "https:" || parsedUrl.username || parsedUrl.password || !allowedMcpOrigins.has(parsedUrl.origin)) {
+    throw new Error("Composio MCP URL failed the reviewed origin policy")
+  }
+
+  client = new Client({ name: "boring-composio-capability-spike", version: "0.0.0" })
+  phase = "Session-header-only MCP authentication probe"
+  try {
+    const headersOnlyTransport = new StreamableHTTPClientTransport(parsedUrl, {
+      requestInit: { headers: session.headers },
+      fetch: (input, init) => boundedFetch(input, init, allowedMcpOrigins),
+    })
+    await client.connect(headersOnlyTransport)
+    report.sessionHeadersSufficient = true
+  } catch (error) {
+    report.sessionHeadersFailureStatus = Number.isInteger(error?.code) ? error.code : null
+    if (report.sessionHeadersFailureStatus !== 401) throw new Error("Session-header-only MCP probe failed without the expected 401")
+    await client.close().catch(() => undefined)
+    client = new Client({ name: "boring-composio-capability-spike", version: "0.0.0" })
+    const apiKeyTransport = new StreamableHTTPClientTransport(parsedUrl, {
+      requestInit: { headers: { ...session.headers, "x-api-key": apiKey } },
+      fetch: (input, init) => boundedFetch(input, init, allowedMcpOrigins),
+    })
+    await client.connect(apiKeyTransport)
+    report.rawApiKeyForwardedToMcp = true
+  }
+  phase = "MCP tool-list probe"
+  const listed = await client.listTools()
+  if (listed.tools.length > 16) throw new Error("MCP meta-tool list exceeded the spike bound")
+  const names = listed.tools.map((tool) => tool.name)
+  report.listedMetaTools = names.filter((name) => name.startsWith("COMPOSIO_")).sort()
+  const required = [
+    "COMPOSIO_SEARCH_TOOLS",
+    "COMPOSIO_GET_TOOL_SCHEMAS",
+    "COMPOSIO_MANAGE_CONNECTIONS",
+    "COMPOSIO_MULTI_EXECUTE_TOOL",
+  ]
+  if (!required.every((name) => names.includes(name))) throw new Error("Required Composio meta tools were absent")
+  report.sandboxDisabled = !names.includes("COMPOSIO_REMOTE_WORKBENCH") && !names.includes("COMPOSIO_REMOTE_BASH_TOOL")
+  if (!report.sandboxDisabled) throw new Error("Sandbox tools remained enabled")
+  report.metaToolControlRequired = names.includes("COMPOSIO_MULTI_EXECUTE_TOOL")
+
+  let disabledSandboxRejected = false
+  try {
+    const disabledResult = await client.callTool({ name: "COMPOSIO_REMOTE_BASH_TOOL", arguments: { command: "true" } })
+    disabledSandboxRejected = disabledResult?.isError === true
+  } catch { disabledSandboxRejected = true }
+  if (!disabledSandboxRejected) throw new Error("Disabled sandbox call did not reject")
+
+  phase = "full-catalog search probe"
+  const search = await client.callTool({
+    name: "COMPOSIO_SEARCH_TOOLS",
+    arguments: { queries: ["Find tools for reading GitHub issues"], session: session.id },
+  })
+  if (search?.isError) throw new Error("Full-catalog search returned an MCP error")
+  const searchPayload = record(textJson(search.content))
+  const searchData = record(searchPayload.data ?? searchPayload)
+  const results = array(searchData.results)
+  if (results.length === 0 || results.length > 10) throw new Error("Search result count was outside the spike bound")
+  const slugs = []
+  const toolkits = new Set()
+  for (const item of results) {
+    for (const toolkit of array(item?.toolkits)) if (typeof toolkit === "string") toolkits.add(toolkit.toLowerCase())
+    for (const slug of [...array(item?.primary_tool_slugs), ...array(item?.related_tool_slugs)]) {
+      if (typeof slug === "string" && !slug.startsWith("COMPOSIO_") && !slugs.includes(slug)) slugs.push(slug)
+    }
+  }
+  if (slugs.length > 50) throw new Error("Search tool-slug count exceeded the spike bound")
+  report.searchResultCount = results.length
+  report.searchWasGitHubScoped = toolkits.has("github") && slugs.some((slug) => slug.startsWith("GITHUB_"))
+  report.searchWorked = slugs.length > 0 && report.searchWasGitHubScoped
+  if (!report.searchWorked) throw new Error("Search did not return GitHub app-native tools")
+
+  const requestedSlugs = slugs.slice(0, 2)
+  report.requestedSchemaCount = requestedSlugs.length
+  if (requestedSlugs.length !== 2) throw new Error("Search did not provide two bounded schema candidates")
+  phase = "schema probe"
+  const schema = await client.callTool({
+    name: "COMPOSIO_GET_TOOL_SCHEMAS",
+    arguments: { tool_slugs: requestedSlugs, session_id: session.id },
+  })
+  if (schema?.isError) throw new Error("Schema retrieval returned an MCP error")
+  const schemaPayload = record(textJson(schema.content))
+  const schemaData = record(schemaPayload.data ?? schemaPayload)
+  const schemas = record(schemaData.tool_schemas ?? schemaPayload.tool_schemas)
+  report.schemaCount = Object.keys(schemas).length
+  report.schemaWorked = requestedSlugs.every((slug) => record(schemas)[slug] && typeof record(schemas)[slug] === "object")
+  if (!report.schemaWorked || report.schemaCount !== requestedSlugs.length) throw new Error("Schema retrieval did not return every requested schema")
+
+  phase = "no-auth connection probe"
+  let noAuthLinkUnexpectedlyCreated = false
+  try {
+    await api(`/api/v3.1/tool_router/session/${encodeURIComponent(session.id)}/link`, {
+      method: "POST", body: JSON.stringify({ toolkit: "hackernews" }),
+    })
+    noAuthLinkUnexpectedlyCreated = true
+  } catch (error) {
+    report.noAuthConnectionCorrectlySkipped = error?.status === 400 && error?.payloadCode === 4326
+    if (!report.noAuthConnectionCorrectlySkipped) throw error
+  }
+  if (noAuthLinkUnexpectedlyCreated || !report.noAuthConnectionCorrectlySkipped) {
+    throw new Error("No-auth toolkit unexpectedly created a connection link")
+  }
+
+  phase = "invalid account-pin probe"
+  try {
+    await createSession({
+      user_id: userId,
+      mcp: true,
+      connected_accounts: { github: ["ca_intentionally_invalid_boring_spike"] },
+      workbench: { enable: false },
+    })
+  } catch (error) {
+    report.invalidAccountPinRejected = error?.status >= 400 && error?.status < 500
+  }
+  if (!report.invalidAccountPinRejected) throw new Error("Invalid connected account pin was not rejected")
+
+  report.stopReason = "A dedicated Composio project and exact valid-account execution pinning with a disposable owned account are still required."
+} catch (error) {
+  const status = Number.isInteger(error?.status) ? ` status=${error.status}` : ""
+  const code = Number.isInteger(error?.code) ? ` code=${error.code}` : ""
+  const providerCode = Number.isInteger(error?.payloadCode) ? ` providerCode=${error.payloadCode}` : ""
+  primaryError = new Error(`Composio capability spike failed during ${phase}.${status}${code}${providerCode}`)
+} finally {
+  if (client) await client.close().catch(() => undefined)
+  for (const id of sessionIds.reverse()) {
+    try {
+      await deleteAndVerifySession(id)
+    } catch {
+      cleanupErrors.push(true)
+    }
+  }
+  report.cleanupComplete = cleanupErrors.length === 0
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+}
+
+if (cleanupErrors.length > 0) throw new Error(`Composio capability spike cleanup failed for ${cleanupErrors.length} Session(s)`)
+if (primaryError) throw primaryError


### PR DESCRIPTION
## Summary

Complete issue #900's live Composio capability gate before changing product contracts.

**Result: pass. Slice 900.1 implementation may proceed.**

## Issue / Slice

#900, slice 900.1 preflight.

## What Changed

- Adds a repeatable, bounded full-catalog Session capability command.
- Records actual sanitized full-catalog and exact account-pin proof.
- Narrows the fastest launch to exactly one active account per toolkit; zero/multiple accounts fail closed and replacing requires revoke-then-connect.
- Adds no runtime `src/` implementation.

Live findings:

- Omitting `toolkits` exposes full-catalog GitHub search/schema.
- Raw v3.1 requires `workbench: { enable: false }`; the SDK `sandbox` alias is not normalized by this endpoint.
- Session exposes search/schema/manage-connections/multi-execute; workbench/bash are absent.
- Session headers alone return 401; project API key is required at exact allowlisted `https://backend.composio.dev`.
- Owner selected the existing Composio project.
- An owner-authorized temporary GitHub account proved unique ownership, exact returned Session pin, cross-user rejection, and a harmless authenticated identity read.
- The account was revoked and both Sessions were deleted and verified absent.

## Proof

- Full-catalog sanitized spike: exit 0 at `2026-07-22T20:50:37.665Z`.
- Exact account-pin proof: exit 0 at `2026-07-24T18:42Z`.
- `node --check plugins/boring-mcp/scripts/composio-capability-spike.mjs` — passed.
- `pnpm build:packages` — passed.
- `pnpm --filter @hachej/boring-mcp test` — 13 files / 99 tests passed.
- `pnpm --filter @hachej/boring-mcp typecheck` — passed.
- `pnpm --filter @hachej/boring-mcp build` — passed.
- `git diff --check` — passed.

## Review

- Initial security/spec review found origin, error-redaction, cleanup, bounds, and overclaim gaps; all were fixed.
- Final capability review: clean.
- Final narrowed single-account invariant/proof review: clean.
- Reviewed SHA: `c859ada38`.

## Security

- Exact MCP origin allowlist before forwarding the operator key.
- Redirect rejection, 15-second timeout, 512-KiB body cap, result/schema caps.
- Raw provider errors replaced with phase plus numeric codes.
- No existing/customer connected-account list or app-native customer tool was called.
- Every Session cleanup attempt is aggregated and requires subsequent 404.
- Temporary GitHub connection was revoked and verified absent.
- Output contains no API key, URL path, header, Session/account ID, profile value, schema/search body, or tool output.

## Next

Merge this capability record, then implement the thin full-catalog backend with mandatory:

- raw `workbench: { enable: false }`;
- exact Composio MCP origin policy;
- exactly-one owned account per toolkit;
- Session-level account pin plus drift invalidation;
- hidden raw multi-execute;
- bounded query/schema; and
- curated consumer compatibility.
