### PR TITLE
#909 feat(agent): freeze AgentGateway v0 contract

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -32,6 +32,11 @@
       "import": "./dist/server/pi-session-readability.js",
       "default": "./dist/server/pi-session-readability.js"
     },
+    "./server/agent-host/testing/gatewayConformance": {
+      "types": "./dist/server/agent-host/testing/gatewayConformance.d.ts",
+      "import": "./dist/server/agent-host/testing/gatewayConformance.js",
+      "default": "./dist/server/agent-host/testing/gatewayConformance.js"
+    },
     "./server/worker": {
       "types": "./dist/server/worker/index.d.ts",
       "import": "./dist/server/worker/index.js",
@@ -139,7 +144,8 @@
   "peerDependencies": {
     "react": "^18.0.0 || ^19.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
-    "tailwindcss": ">=3.4.0 || >=4.0.0"
+    "tailwindcss": ">=3.4.0 || >=4.0.0",
+    "vitest": "^4.1.9"
   },
   "peerDependenciesMeta": {
     "react": {
@@ -149,6 +155,9 @@
       "optional": true
     },
     "tailwindcss": {
+      "optional": true
+    },
+    "vitest": {
       "optional": true
     }
   }

--- a/packages/agent/src/front/__tests__/publicExports.test.ts
+++ b/packages/agent/src/front/__tests__/publicExports.test.ts
@@ -30,6 +30,7 @@ describe('@hachej/boring-agent/front public exports', () => {
       './front',
       './front/styles.css',
       './server',
+      './server/agent-host/testing/gatewayConformance',
       './server/pi-session-readability',
       './server/worker',
       './shared',

--- a/packages/agent/src/server/agent-host/testing/__tests__/gatewayConformance.test.ts
+++ b/packages/agent/src/server/agent-host/testing/__tests__/gatewayConformance.test.ts
@@ -355,6 +355,11 @@ class FakeGatewayFixture implements GatewayConformanceFixture {
   private readonly revokedScopes = new WeakSet<object>()
   private readonly sessions = new Map<string, FakeSession>()
   private readonly requests = new Map<string, RecordedRequest>()
+  private readonly requestFailures = new Map<string, {
+    readonly digest: string
+    readonly error: AgentGatewayError
+  }>()
+  private readonly admissionQueue = new Map<AgentRequestKey['operation'], Array<'strong-reject' | 'retryable'>>()
   private readonly connections = new Set<{
     closed: boolean
     resolveClose?: () => void
@@ -385,6 +390,7 @@ class FakeGatewayFixture implements GatewayConformanceFixture {
         const digest = JSON.stringify({ agentTypeId: input.agentTypeId, title: input.title })
         const replay = this.replayRequest<AgentSessionRef>(requestKey, digest)
         if (replay !== undefined) return replay
+        this.applyAdmission('session.create', requestKey, digest)
         this.nextSessionId += 1
         const ref = { agentTypeId: input.agentTypeId, sessionId: `session-${this.nextSessionId}` }
         const timestamp = this.tick()
@@ -430,6 +436,7 @@ class FakeGatewayFixture implements GatewayConformanceFixture {
         const replay = this.replayRequest<AgentSessionSummary>(key, digest)
         if (replay !== undefined) return replay
         const session = this.requireSession(claim, input.ref)
+        this.applyAdmission('session.rename', key, digest)
         session.title = input.title
         session.updatedAt = this.tick()
         const summary = this.summary(session)
@@ -447,6 +454,7 @@ class FakeGatewayFixture implements GatewayConformanceFixture {
           return
         }
         this.requireSession(claim, input.ref)
+        this.applyAdmission('session.delete', key, digest)
         this.sessions.delete(this.sessionIdentity(claim.workspaceScopeId, input.ref))
         this.requests.set(key, { digest, receipt: undefined })
       },
@@ -475,6 +483,15 @@ class FakeGatewayFixture implements GatewayConformanceFixture {
 
   revoke(scope: AuthorizedAgentScope): void {
     this.revokedScopes.add(scope)
+  }
+
+  queueAdmission(
+    operation: AgentRequestKey['operation'],
+    disposition: 'strong-reject' | 'retryable',
+  ): void {
+    const queue = this.admissionQueue.get(operation) ?? []
+    queue.push(disposition)
+    this.admissionQueue.set(operation, queue)
   }
 
   setActivity(ref: AgentSessionRef, activity: AgentSessionActivity): void {
@@ -562,6 +579,7 @@ class FakeGatewayFixture implements GatewayConformanceFixture {
         if (input.kind === 'prompt' && session.activity !== 'idle' && session.activity !== 'error') {
           throw this.error(AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE, 'prompt is invalid in current state')
         }
+        this.applyAdmission(operation, key, digest)
         if (input.kind === 'prompt') {
           session.activity = 'running'
         } else {
@@ -617,6 +635,7 @@ class FakeGatewayFixture implements GatewayConformanceFixture {
             throw this.error(AgentGatewayErrorCode.AGENT_REQUEST_CONFLICT, 'queue selectors disagree')
           }
         }
+        this.applyAdmission('session.queue.clear', key, digest)
         const before = session.queue.length
         const retained = session.queue.filter((queued) => {
           if (input.clientNonce !== undefined && queued.clientNonce !== input.clientNonce) return true
@@ -646,6 +665,7 @@ class FakeGatewayFixture implements GatewayConformanceFixture {
     const key = this.requestIdentity(claim, operation, this.targetIdentity(session.ref), requestId)
     const replay = this.replayRequest<T>(key, '{}')
     if (replay !== undefined) return replay
+    this.applyAdmission(operation, key, '{}')
     const receipt = effect()
     this.requests.set(key, { digest: '{}', receipt })
     return receipt
@@ -700,12 +720,36 @@ class FakeGatewayFixture implements GatewayConformanceFixture {
   }
 
   private replayRequest<T>(key: string, digest: string): T | undefined {
+    const failure = this.requestFailures.get(key)
+    if (failure !== undefined) {
+      if (failure.digest !== digest) {
+        throw this.error(AgentGatewayErrorCode.AGENT_REQUEST_CONFLICT, 'request id reused with different payload')
+      }
+      throw failure.error
+    }
     const recorded = this.requests.get(key)
     if (recorded === undefined) return undefined
     if (recorded.digest !== digest) {
       throw this.error(AgentGatewayErrorCode.AGENT_REQUEST_CONFLICT, 'request id reused with different payload')
     }
     return recorded.receipt as T
+  }
+
+  private applyAdmission(
+    operation: AgentRequestKey['operation'],
+    key: string,
+    digest: string,
+  ): void {
+    const queue = this.admissionQueue.get(operation)
+    const disposition = queue?.shift()
+    if (disposition === 'strong-reject') {
+      const error = this.error(AgentGatewayErrorCode.AGENT_SCOPE_DENIED, 'effect denied by admission')
+      this.requestFailures.set(key, { digest, error })
+      throw error
+    }
+    if (disposition === 'retryable') {
+      throw this.error(AgentGatewayErrorCode.AGENT_GATEWAY_CLOSED, 'admission temporarily unavailable')
+    }
   }
 
   private verify(scope: AuthorizedAgentScope): VerifiedAgentScopeClaim {

--- a/packages/agent/src/server/agent-host/testing/__tests__/gatewayConformance.test.ts
+++ b/packages/agent/src/server/agent-host/testing/__tests__/gatewayConformance.test.ts
@@ -1,0 +1,843 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AgentGatewayError,
+  AgentGatewayErrorCode,
+  type AgentGateway,
+  type AgentGatewayErrorDTO,
+  type AgentSessionActivity,
+  type AgentSessionConnection,
+  type AgentSessionEvent,
+  type AgentSessionRef,
+  type AgentSessionStateSnapshot,
+  type AgentSessionSummary,
+  type AuthorizedAgentScope,
+  type IdempotentAgentSend,
+  type JsonValue,
+  type QueuedUserMessage,
+  type VerifiedAgentScopeClaim,
+} from '../../../../shared/index'
+import {
+  gatewayConformance,
+  type GatewayConformanceFixture,
+} from '../gatewayConformance'
+import type {
+  AgentRequestFailure,
+  AgentRequestKey,
+  AgentRequestLedger,
+  AgentRequestLedgerRecord,
+} from '../../types'
+
+function keyIdentity(key: AgentRequestKey): string {
+  const target = key.target.kind === 'agent'
+    ? `agent:${key.target.agentTypeId}`
+    : `session:${key.target.ref.agentTypeId}:${key.target.ref.sessionId}`
+  return [key.workspaceScopeId, key.authSubjectId, key.operation, target, key.requestId].join('|')
+}
+
+class InMemoryAgentRequestLedger implements AgentRequestLedger {
+  private readonly records = new Map<string, AgentRequestLedgerRecord>()
+  private clock = 0
+
+  async prepare(key: AgentRequestKey, digest: string): Promise<AgentRequestLedgerRecord> {
+    this.validateTarget(key)
+    const identity = keyIdentity(key)
+    const current = this.records.get(identity)
+    if (current !== undefined) {
+      if (current.digest !== digest) {
+        throw new AgentGatewayError('AGENT_REQUEST_CONFLICT', 'request id reused with a different payload')
+      }
+      return current
+    }
+    const record: AgentRequestLedgerRecord = {
+      state: 'pending-admission',
+      key,
+      digest,
+      updatedAt: this.tick(),
+    }
+    this.records.set(identity, record)
+    return record
+  }
+
+  async acceptAdmission(key: AgentRequestKey, admissionReceipt: string): Promise<void> {
+    const current = this.requireState(key, 'pending-admission')
+    this.write(key, { ...current, state: 'admission-accepted', admissionReceipt, updatedAt: this.tick() })
+  }
+
+  async beginEffect(key: AgentRequestKey): Promise<void> {
+    const current = this.requireState(key, 'admission-accepted')
+    this.write(key, { ...current, state: 'in-flight', updatedAt: this.tick() })
+  }
+
+  async reject(key: AgentRequestKey, failure: AgentRequestFailure): Promise<void> {
+    const expected = failure.kind === 'gateway' ? 'pending-admission' : 'in-flight'
+    const current = this.requireState(key, expected)
+    this.write(key, { ...current, state: 'rejected', failure, updatedAt: this.tick() })
+  }
+
+  async complete(key: AgentRequestKey, receipt: JsonValue): Promise<void> {
+    const current = this.requireState(key, 'in-flight')
+    this.write(key, { ...current, state: 'completed', receipt, updatedAt: this.tick() })
+  }
+
+  async markOutcomeUnknown(key: AgentRequestKey, error: AgentGatewayErrorDTO): Promise<void> {
+    const current = this.requireState(key, 'in-flight')
+    this.write(key, { ...current, state: 'outcome-unknown', error, updatedAt: this.tick() })
+  }
+
+  async read(key: AgentRequestKey): Promise<AgentRequestLedgerRecord | undefined> {
+    return this.records.get(keyIdentity(key))
+  }
+
+  private validateTarget(key: AgentRequestKey): void {
+    const valid = key.operation === 'session.create'
+      ? key.target.kind === 'agent'
+      : key.target.kind === 'session'
+    if (!valid) throw new Error('ledger effect/target mismatch')
+  }
+
+  private requireState<S extends AgentRequestLedgerRecord['state']>(
+    key: AgentRequestKey,
+    expected: S,
+  ): Extract<AgentRequestLedgerRecord, { state: S }> {
+    const current = this.records.get(keyIdentity(key))
+    if (current?.state !== expected) {
+      throw new Error(`invalid ledger transition: ${current?.state ?? 'missing'} -> expected ${expected}`)
+    }
+    return current as Extract<AgentRequestLedgerRecord, { state: S }>
+  }
+
+  private write(key: AgentRequestKey, record: AgentRequestLedgerRecord): void {
+    this.records.set(keyIdentity(key), record)
+  }
+
+  private tick(): number {
+    this.clock += 1
+    return this.clock
+  }
+}
+
+const agentTarget = { kind: 'agent', agentTypeId: 'alpha' } as const
+const sessionTarget = {
+  kind: 'session',
+  ref: { agentTypeId: 'alpha', sessionId: 'session-1' },
+} as const
+
+function requestKey(
+  operation: AgentRequestKey['operation'] = 'session.create',
+  target: AgentRequestKey['target'] = agentTarget,
+  overrides: Partial<AgentRequestKey> = {},
+): AgentRequestKey {
+  return {
+    workspaceScopeId: 'workspace-a',
+    authSubjectId: 'subject-a',
+    operation,
+    target,
+    requestId: 'request-1',
+    ...overrides,
+  }
+}
+
+const LEGACY_ADMISSION_CODE = 'CUSTOM_DENIAL'
+
+const gatewayFailure: AgentRequestFailure = {
+  kind: 'gateway',
+  error: { code: AgentGatewayErrorCode.AGENT_SCOPE_DENIED, message: 'denied' },
+}
+const legacyFailure: AgentRequestFailure = {
+  kind: 'legacy-admission',
+  code: LEGACY_ADMISSION_CODE,
+  statusCode: 500,
+  message: 'legacy denied',
+  details: { reason: 'policy' },
+}
+const outcomeUnknown: AgentGatewayErrorDTO = {
+  code: AgentGatewayErrorCode.AGENT_REQUEST_OUTCOME_UNKNOWN,
+  message: 'outcome unknown',
+}
+
+async function advanceToInFlight(ledger: AgentRequestLedger, key: AgentRequestKey): Promise<void> {
+  await ledger.prepare(key, 'digest-a')
+  await ledger.acceptAdmission(key, 'admission-a')
+  await ledger.beginEffect(key)
+}
+
+async function ledgerAt(
+  state: AgentRequestLedgerRecord['state'],
+): Promise<{ ledger: InMemoryAgentRequestLedger; key: AgentRequestKey }> {
+  const ledger = new InMemoryAgentRequestLedger()
+  const key = requestKey()
+  await ledger.prepare(key, 'digest-a')
+  if (state === 'pending-admission') return { ledger, key }
+  if (state === 'rejected') {
+    await ledger.reject(key, gatewayFailure)
+    return { ledger, key }
+  }
+  await ledger.acceptAdmission(key, 'admission-a')
+  if (state === 'admission-accepted') return { ledger, key }
+  await ledger.beginEffect(key)
+  if (state === 'in-flight') return { ledger, key }
+  if (state === 'completed') await ledger.complete(key, { accepted: true })
+  if (state === 'outcome-unknown') await ledger.markOutcomeUnknown(key, outcomeUnknown)
+  return { ledger, key }
+}
+
+describe('AgentRequestLedger exact state machine (process-lifetime Level B fake)', () => {
+  it('prepares missing records and returns the current record on same-digest retry', async () => {
+    const ledger = new InMemoryAgentRequestLedger()
+    const key = requestKey()
+    const prepared = await ledger.prepare(key, 'digest-a')
+    expect(prepared).toMatchObject({ state: 'pending-admission', key, digest: 'digest-a' })
+    expect(await ledger.prepare(key, 'digest-a')).toBe(prepared)
+    await expect(ledger.prepare(key, 'digest-b')).rejects.toMatchObject({
+      code: AgentGatewayErrorCode.AGENT_REQUEST_CONFLICT,
+    })
+  })
+
+  it('coalesces concurrent same-digest preparation', async () => {
+    const ledger = new InMemoryAgentRequestLedger()
+    const key = requestKey()
+    const records = await Promise.all([
+      ledger.prepare(key, 'digest-a'),
+      ledger.prepare(key, 'digest-a'),
+      ledger.prepare(key, 'digest-a'),
+    ])
+    expect(records.every((record) => record === records[0])).toBe(true)
+  })
+
+  it('replays every current state for the same digest and conflicts every state for a different digest', async () => {
+    for (const state of [
+      'pending-admission',
+      'admission-accepted',
+      'in-flight',
+      'rejected',
+      'completed',
+      'outcome-unknown',
+    ] as const) {
+      const { ledger, key } = await ledgerAt(state)
+      await expect(ledger.prepare(key, 'digest-a')).resolves.toMatchObject({ state })
+      await expect(ledger.prepare(key, 'digest-b')).rejects.toMatchObject({
+        code: AgentGatewayErrorCode.AGENT_REQUEST_CONFLICT,
+      })
+    }
+  })
+
+  it('accepts admission only from pending-admission', async () => {
+    const { ledger, key } = await ledgerAt('pending-admission')
+    await ledger.acceptAdmission(key, 'receipt')
+    await expect(ledger.read(key)).resolves.toMatchObject({ state: 'admission-accepted', admissionReceipt: 'receipt' })
+  })
+
+  it('strongly rejects only from pending-admission and preserves the closed Gateway error', async () => {
+    const { ledger, key } = await ledgerAt('pending-admission')
+    await ledger.reject(key, gatewayFailure)
+    await expect(ledger.read(key)).resolves.toMatchObject({ state: 'rejected', failure: gatewayFailure })
+    expect(await ledger.prepare(key, 'digest-a')).toMatchObject({ state: 'rejected', failure: gatewayFailure })
+  })
+
+  it('begins an effect only after accepted admission', async () => {
+    const { ledger, key } = await ledgerAt('admission-accepted')
+    await ledger.beginEffect(key)
+    await expect(ledger.read(key)).resolves.toMatchObject({ state: 'in-flight' })
+  })
+
+  it('records a legacy observed rejection only from in-flight without widening public errors', async () => {
+    const { ledger, key } = await ledgerAt('in-flight')
+    await ledger.reject(key, legacyFailure)
+    await expect(ledger.read(key)).resolves.toMatchObject({ state: 'rejected', failure: legacyFailure })
+  })
+
+  it('completes only from in-flight and replays the typed JSON receipt', async () => {
+    const { ledger, key } = await ledgerAt('in-flight')
+    const receipt = { accepted: true, cursor: 7 }
+    await ledger.complete(key, receipt)
+    await expect(ledger.read(key)).resolves.toMatchObject({ state: 'completed', receipt })
+    expect(await ledger.prepare(key, 'digest-a')).toMatchObject({ state: 'completed', receipt })
+  })
+
+  it('marks outcome unknown only from in-flight', async () => {
+    const { ledger, key } = await ledgerAt('in-flight')
+    await ledger.markOutcomeUnknown(key, outcomeUnknown)
+    await expect(ledger.read(key)).resolves.toMatchObject({ state: 'outcome-unknown', error: outcomeUnknown })
+  })
+
+  it('rejects every invalid CAS predecessor', async () => {
+    const states: AgentRequestLedgerRecord['state'][] = [
+      'pending-admission',
+      'admission-accepted',
+      'in-flight',
+      'rejected',
+      'completed',
+      'outcome-unknown',
+    ]
+    const operations = [
+      ['acceptAdmission', (ledger: AgentRequestLedger, key: AgentRequestKey) => ledger.acceptAdmission(key, 'receipt'), 'pending-admission'],
+      ['beginEffect', (ledger: AgentRequestLedger, key: AgentRequestKey) => ledger.beginEffect(key), 'admission-accepted'],
+      ['strong reject', (ledger: AgentRequestLedger, key: AgentRequestKey) => ledger.reject(key, gatewayFailure), 'pending-admission'],
+      ['legacy reject', (ledger: AgentRequestLedger, key: AgentRequestKey) => ledger.reject(key, legacyFailure), 'in-flight'],
+      ['complete', (ledger: AgentRequestLedger, key: AgentRequestKey) => ledger.complete(key, { ok: true }), 'in-flight'],
+      ['markOutcomeUnknown', (ledger: AgentRequestLedger, key: AgentRequestKey) => ledger.markOutcomeUnknown(key, outcomeUnknown), 'in-flight'],
+    ] as const
+
+    for (const [name, operation, validState] of operations) {
+      for (const state of states) {
+        if (state === validState) continue
+        const { ledger, key } = await ledgerAt(state)
+        await expect(operation(ledger, key), `${name} from ${state}`).rejects.toThrow('invalid ledger transition')
+      }
+      const ledger = new InMemoryAgentRequestLedger()
+      await expect(operation(ledger, requestKey()), `${name} from missing`).rejects.toThrow('invalid ledger transition')
+    }
+  })
+
+  it('validates create Agent targets and full session targets for all other effects', async () => {
+    const ledger = new InMemoryAgentRequestLedger()
+    await expect(ledger.prepare(requestKey('session.create', sessionTarget), 'digest')).rejects.toThrow('effect/target mismatch')
+    for (const effect of [
+      'session.rename',
+      'session.delete',
+      'session.prompt',
+      'session.followup',
+      'session.interrupt',
+      'session.stop',
+      'session.queue.clear',
+    ] as const) {
+      await expect(ledger.prepare(requestKey(effect, agentTarget, { requestId: effect }), 'digest')).rejects.toThrow('effect/target mismatch')
+      await expect(ledger.prepare(requestKey(effect, sessionTarget, { requestId: effect }), 'digest')).resolves.toMatchObject({ state: 'pending-admission' })
+    }
+  })
+
+  it('isolates equal request IDs across scope, subject, effect, Agent, and session targets', async () => {
+    const ledger = new InMemoryAgentRequestLedger()
+    const keys = [
+      requestKey(),
+      requestKey('session.create', { kind: 'agent', agentTypeId: 'beta' }),
+      requestKey('session.create', agentTarget, { workspaceScopeId: 'workspace-b' }),
+      requestKey('session.create', agentTarget, { authSubjectId: 'subject-b' }),
+      requestKey('session.rename', sessionTarget),
+      requestKey('session.rename', { kind: 'session', ref: { agentTypeId: 'alpha', sessionId: 'session-2' } }),
+    ]
+    for (const [index, key] of keys.entries()) {
+      await expect(ledger.prepare(key, `digest-${index}`)).resolves.toMatchObject({ state: 'pending-admission' })
+    }
+  })
+
+  it('leaves retryable strong admission pending and process lifetime does not imply durability', async () => {
+    const ledger = new InMemoryAgentRequestLedger()
+    const key = requestKey()
+    await ledger.prepare(key, 'digest-a')
+    // A retryable admission result performs no ledger transition.
+    expect(await ledger.read(key)).toMatchObject({ state: 'pending-admission' })
+    expect(await new InMemoryAgentRequestLedger().read(key)).toBeUndefined()
+  })
+})
+
+interface FakeSession {
+  readonly workspaceScopeId: string
+  readonly ref: AgentSessionRef
+  title: string
+  activity: AgentSessionActivity
+  readonly createdAt: number
+  updatedAt: number
+  seq: number
+  readonly events: AgentSessionEvent[]
+  readonly queue: QueuedUserMessage[]
+}
+
+interface RecordedRequest {
+  readonly digest: string
+  readonly receipt: unknown
+}
+
+class FakeGatewayFixture implements GatewayConformanceFixture {
+  readonly gateway: AgentGateway
+  private readonly primaryScopes = new WeakSet<object>()
+  private readonly foreignScopes = new WeakSet<object>()
+  private readonly revokedScopes = new WeakSet<object>()
+  private readonly sessions = new Map<string, FakeSession>()
+  private readonly requests = new Map<string, RecordedRequest>()
+  private readonly connections = new Set<{
+    closed: boolean
+    resolveClose?: () => void
+  }>()
+  private now = 1_000
+  private nextSessionId = 0
+  private closed = false
+
+  constructor() {
+    this.gateway = {
+      listAgents: async ({ scope }) => {
+        this.assertOpen()
+        this.verify(scope)
+        return [
+          { agentTypeId: 'alpha', label: 'Alpha' },
+          { agentTypeId: 'beta', label: 'Beta' },
+        ]
+      },
+      listSessions: async (input) => this.listSessions(input),
+      createSession: async (input) => {
+        this.assertOpen()
+        const claim = this.verify(input.scope)
+        if (input.agentTypeId !== 'alpha' && input.agentTypeId !== 'beta') {
+          throw this.error(AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN, 'unknown Agent type')
+        }
+        const target = `agent:${input.agentTypeId}`
+        const requestKey = this.requestIdentity(claim, 'session.create', target, input.requestId)
+        const digest = JSON.stringify({ agentTypeId: input.agentTypeId, title: input.title })
+        const replay = this.replayRequest<AgentSessionRef>(requestKey, digest)
+        if (replay !== undefined) return replay
+        this.nextSessionId += 1
+        const ref = { agentTypeId: input.agentTypeId, sessionId: `session-${this.nextSessionId}` }
+        const timestamp = this.tick()
+        this.sessions.set(this.sessionIdentity(claim.workspaceScopeId, ref), {
+          workspaceScopeId: claim.workspaceScopeId,
+          ref,
+          title: input.title ?? 'Untitled',
+          activity: 'idle',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+          seq: 0,
+          events: [],
+          queue: [],
+        })
+        this.requests.set(requestKey, { digest, receipt: ref })
+        return ref
+      },
+      connectSession: async (input) => {
+        this.assertOpen()
+        const claim = this.verify(input.scope)
+        const session = this.requireSession(claim, input.ref)
+        const cursor = input.cursor ?? session.seq
+        const firstReplaySeq = session.events[0]?.seq
+        if (cursor > session.seq) {
+          throw this.error(AgentGatewayErrorCode.AGENT_SESSION_CURSOR_AHEAD, 'cursor is ahead')
+        }
+        if (firstReplaySeq !== undefined && cursor < firstReplaySeq - 1) {
+          throw this.error(AgentGatewayErrorCode.AGENT_SESSION_REPLAY_GAP, 'cursor was evicted')
+        }
+        return this.connection(input.scope, session, cursor)
+      },
+      readSessionState: async (input) => {
+        this.assertOpen()
+        const claim = this.verify(input.scope)
+        return this.snapshot(this.requireSession(claim, input.ref))
+      },
+      renameSession: async (input) => {
+        this.assertOpen()
+        const claim = this.verify(input.scope)
+        const target = this.targetIdentity(input.ref)
+        const key = this.requestIdentity(claim, 'session.rename', target, input.requestId)
+        const digest = JSON.stringify({ title: input.title })
+        const replay = this.replayRequest<AgentSessionSummary>(key, digest)
+        if (replay !== undefined) return replay
+        const session = this.requireSession(claim, input.ref)
+        session.title = input.title
+        session.updatedAt = this.tick()
+        const summary = this.summary(session)
+        this.requests.set(key, { digest, receipt: summary })
+        return summary
+      },
+      deleteSession: async (input) => {
+        this.assertOpen()
+        const claim = this.verify(input.scope)
+        const target = this.targetIdentity(input.ref)
+        const key = this.requestIdentity(claim, 'session.delete', target, input.requestId)
+        const digest = '{}'
+        if (this.requests.has(key)) {
+          this.replayRequest<void>(key, digest)
+          return
+        }
+        this.requireSession(claim, input.ref)
+        this.sessions.delete(this.sessionIdentity(claim.workspaceScopeId, input.ref))
+        this.requests.set(key, { digest, receipt: undefined })
+      },
+      close: async () => {
+        this.closed = true
+        for (const connection of this.connections) {
+          connection.closed = true
+          connection.resolveClose?.()
+        }
+      },
+    }
+  }
+
+  issueScope(input: {
+    readonly workspaceScopeId?: string
+    readonly authSubjectId?: string
+    readonly issuer?: 'primary' | 'foreign'
+  } = {}): AuthorizedAgentScope {
+    const scope = Object.freeze({
+      workspaceScopeId: input.workspaceScopeId ?? 'workspace-a',
+      authSubjectId: input.authSubjectId ?? 'subject-a',
+    }) as AuthorizedAgentScope
+    ;(input.issuer === 'foreign' ? this.foreignScopes : this.primaryScopes).add(scope)
+    return scope
+  }
+
+  revoke(scope: AuthorizedAgentScope): void {
+    this.revokedScopes.add(scope)
+  }
+
+  setActivity(ref: AgentSessionRef, activity: AgentSessionActivity): void {
+    this.findSession(ref).activity = activity
+  }
+
+  moveSession(ref: AgentSessionRef, updatedAt: number): void {
+    this.findSession(ref).updatedAt = updatedAt
+  }
+
+  private async listSessions(input: Parameters<AgentGateway['listSessions']>[0]) {
+    this.assertOpen()
+    const claim = this.verify(input.scope)
+    const limit = input.limit ?? 50
+    const filter = input.agentTypeId ?? ''
+    let after: readonly [number, string, string] | undefined
+    if (input.cursor !== undefined) {
+      const parsed = this.parseCursor(input.cursor)
+      if (
+        parsed.workspaceScopeId !== claim.workspaceScopeId
+        || parsed.filter !== filter
+        || parsed.limit !== limit
+      ) {
+        throw this.error(AgentGatewayErrorCode.AGENT_SESSION_CURSOR_INVALID, 'cursor binding is invalid')
+      }
+      after = parsed.after
+    }
+    const ordered = [...this.sessions.values()]
+      .filter((session) => session.workspaceScopeId === claim.workspaceScopeId)
+      .filter((session) => filter === '' || session.ref.agentTypeId === filter)
+      .sort((left, right) => this.compareSessions(left, right))
+      .filter((session) => after === undefined || this.compareTuple(session, after) > 0)
+    const sessions = ordered.slice(0, limit).map((session) => this.summary(session))
+    if (ordered.length <= limit || sessions.length === 0) return { sessions }
+    const last = sessions[sessions.length - 1]
+    return {
+      sessions,
+      nextCursor: this.createCursor({
+        workspaceScopeId: claim.workspaceScopeId,
+        filter,
+        limit,
+        after: [last.updatedAt, last.ref.agentTypeId, last.ref.sessionId],
+      }),
+    }
+  }
+
+  private connection(
+    scope: AuthorizedAgentScope,
+    session: FakeSession,
+    cursor: number,
+  ): AgentSessionConnection {
+    const state: {
+      closed: boolean
+      resolveClose?: () => void
+    } = { closed: false }
+    this.connections.add(state)
+    let eventIndex = session.events.findIndex((event) => event.seq > cursor)
+    if (eventIndex < 0) eventIndex = session.events.length
+    const events: AsyncIterable<AgentSessionEvent> = {
+      [Symbol.asyncIterator]: () => ({
+        next: async () => {
+          if (state.closed) return { done: true, value: undefined }
+          const event = session.events[eventIndex]
+          if (event === undefined) {
+            return new Promise((resolve) => {
+              state.resolveClose = () => resolve({ done: true, value: undefined })
+            })
+          }
+          eventIndex += 1
+          return { done: false, value: event }
+        },
+      }),
+    }
+    return {
+      ref: session.ref,
+      events,
+      send: async (input) => {
+        this.assertConnection(scope, state)
+        const claim = this.verify(scope)
+        const operation = input.kind === 'prompt' ? 'session.prompt' : 'session.followup'
+        const key = this.requestIdentity(claim, operation, this.targetIdentity(session.ref), input.requestId)
+        const digest = JSON.stringify(input)
+        const replay = this.replayRequest<Awaited<ReturnType<AgentSessionConnection['send']>>>(key, digest)
+        if (replay !== undefined) return { ...replay, duplicate: true }
+        if (input.kind === 'prompt' && session.activity !== 'idle' && session.activity !== 'error') {
+          throw this.error(AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE, 'prompt is invalid in current state')
+        }
+        if (input.kind === 'prompt') {
+          session.activity = 'running'
+        } else {
+          session.queue.push({
+            id: `queue-${session.queue.length + 1}`,
+            kind: 'followup',
+            clientNonce: input.clientNonce,
+            clientSeq: input.clientSeq,
+            displayText: input.displayContent ?? input.content,
+          })
+        }
+        const event = this.appendEvent(session)
+        const receipt = {
+          accepted: true as const,
+          cursor: event.seq,
+          disposition: input.kind,
+          clientNonce: input.clientNonce,
+          ...(input.kind === 'followup' ? { clientSeq: input.clientSeq } : {}),
+        }
+        this.requests.set(key, { digest, receipt })
+        return receipt
+      },
+      interrupt: async (input) => {
+        this.assertConnection(scope, state)
+        const claim = this.verify(scope)
+        return this.control(claim, session, 'session.interrupt', input.requestId, () => {
+          if (session.activity === 'running') session.activity = 'aborting'
+          return { accepted: true as const, cursor: this.appendEvent(session).seq }
+        })
+      },
+      stop: async (input) => {
+        this.assertConnection(scope, state)
+        const claim = this.verify(scope)
+        return this.control(claim, session, 'session.stop', input.requestId, () => {
+          const clearedQueue = session.queue.splice(0)
+          const stopped = session.activity === 'running' || session.activity === 'aborting'
+          session.activity = 'idle'
+          return { accepted: true as const, cursor: this.appendEvent(session).seq, stopped, clearedQueue }
+        })
+      },
+      clearQueue: async (input) => {
+        this.assertConnection(scope, state)
+        const claim = this.verify(scope)
+        const key = this.requestIdentity(claim, 'session.queue.clear', this.targetIdentity(session.ref), input.requestId)
+        const digest = JSON.stringify({ clientNonce: input.clientNonce, clientSeq: input.clientSeq })
+        const replay = this.replayRequest<Awaited<ReturnType<AgentSessionConnection['clearQueue']>>>(key, digest)
+        if (replay !== undefined) return replay
+        if (input.clientNonce !== undefined && input.clientSeq !== undefined) {
+          const selected = session.queue.find((queued) =>
+            queued.clientNonce === input.clientNonce || queued.clientSeq === input.clientSeq,
+          )
+          if (selected !== undefined && (selected.clientNonce !== input.clientNonce || selected.clientSeq !== input.clientSeq)) {
+            throw this.error(AgentGatewayErrorCode.AGENT_REQUEST_CONFLICT, 'queue selectors disagree')
+          }
+        }
+        const before = session.queue.length
+        const retained = session.queue.filter((queued) => {
+          if (input.clientNonce !== undefined && queued.clientNonce !== input.clientNonce) return true
+          if (input.clientSeq !== undefined && queued.clientSeq !== input.clientSeq) return true
+          return input.clientNonce === undefined && input.clientSeq === undefined ? false : false
+        })
+        session.queue.splice(0, session.queue.length, ...retained)
+        const receipt = { accepted: true as const, cursor: this.appendEvent(session).seq, cleared: before - retained.length }
+        this.requests.set(key, { digest, receipt })
+        return receipt
+      },
+      close: async () => {
+        state.closed = true
+        state.resolveClose?.()
+        this.connections.delete(state)
+      },
+    }
+  }
+
+  private control<T>(
+    claim: VerifiedAgentScopeClaim,
+    session: FakeSession,
+    operation: AgentRequestKey['operation'],
+    requestId: string,
+    effect: () => T,
+  ): T {
+    const key = this.requestIdentity(claim, operation, this.targetIdentity(session.ref), requestId)
+    const replay = this.replayRequest<T>(key, '{}')
+    if (replay !== undefined) return replay
+    const receipt = effect()
+    this.requests.set(key, { digest: '{}', receipt })
+    return receipt
+  }
+
+  private appendEvent(session: FakeSession): AgentSessionEvent {
+    session.seq += 1
+    session.updatedAt = this.tick()
+    const event: AgentSessionEvent = {
+      ref: session.ref,
+      seq: session.seq,
+      event: {
+        type: 'queue-updated',
+        seq: session.seq,
+        queue: { followUps: session.queue.map((queued) => ({ ...queued })) },
+      },
+    }
+    session.events.push(event)
+    if (session.events.length > 4) session.events.shift()
+    return event
+  }
+
+  private snapshot(session: FakeSession): AgentSessionStateSnapshot {
+    return {
+      ref: session.ref,
+      seq: session.seq,
+      summary: this.summary(session),
+      state: {
+        protocolVersion: 1,
+        sessionId: session.ref.sessionId,
+        seq: session.seq,
+        status: session.activity === 'running'
+          ? 'streaming'
+          : session.activity === 'aborting'
+            ? 'aborting'
+            : session.activity,
+        messages: [],
+        queue: { followUps: session.queue.map((queued) => ({ ...queued })) },
+        followUpMode: 'one-at-a-time',
+      },
+    }
+  }
+
+  private summary(session: FakeSession): AgentSessionSummary {
+    return {
+      ref: session.ref,
+      title: session.title,
+      status: session.activity,
+      createdAt: session.createdAt,
+      updatedAt: session.updatedAt,
+    }
+  }
+
+  private replayRequest<T>(key: string, digest: string): T | undefined {
+    const recorded = this.requests.get(key)
+    if (recorded === undefined) return undefined
+    if (recorded.digest !== digest) {
+      throw this.error(AgentGatewayErrorCode.AGENT_REQUEST_CONFLICT, 'request id reused with different payload')
+    }
+    return recorded.receipt as T
+  }
+
+  private verify(scope: AuthorizedAgentScope): VerifiedAgentScopeClaim {
+    if (!this.primaryScopes.has(scope) || this.foreignScopes.has(scope) || this.revokedScopes.has(scope)) {
+      throw this.error(AgentGatewayErrorCode.AGENT_SCOPE_DENIED, 'scope denied')
+    }
+    return { workspaceScopeId: scope.workspaceScopeId, authSubjectId: scope.authSubjectId }
+  }
+
+  private requireSession(claim: VerifiedAgentScopeClaim, ref: AgentSessionRef): FakeSession {
+    const session = this.sessions.get(this.sessionIdentity(claim.workspaceScopeId, ref))
+    if (session === undefined) {
+      throw this.error(AgentGatewayErrorCode.AGENT_SESSION_NOT_FOUND, 'session not found')
+    }
+    return session
+  }
+
+  private findSession(ref: AgentSessionRef): FakeSession {
+    const session = [...this.sessions.values()].find((candidate) =>
+      candidate.ref.agentTypeId === ref.agentTypeId && candidate.ref.sessionId === ref.sessionId,
+    )
+    if (session === undefined) throw new Error('test session not found')
+    return session
+  }
+
+  private assertConnection(scope: AuthorizedAgentScope, state: { closed: boolean }): void {
+    this.assertOpen()
+    if (state.closed) throw this.error(AgentGatewayErrorCode.AGENT_GATEWAY_CLOSED, 'connection closed')
+    this.verify(scope)
+  }
+
+  private assertOpen(): void {
+    if (this.closed) throw this.error(AgentGatewayErrorCode.AGENT_GATEWAY_CLOSED, 'gateway closed')
+  }
+
+  private error(code: AgentGatewayErrorDTO['code'], message: string): AgentGatewayError {
+    return new AgentGatewayError(code, message)
+  }
+
+  private requestIdentity(
+    claim: VerifiedAgentScopeClaim,
+    operation: AgentRequestKey['operation'],
+    target: string,
+    requestId: string,
+  ): string {
+    return [claim.workspaceScopeId, claim.authSubjectId, operation, target, requestId].join('|')
+  }
+
+  private targetIdentity(ref: AgentSessionRef): string {
+    return `session:${ref.agentTypeId}:${ref.sessionId}`
+  }
+
+  private sessionIdentity(workspaceScopeId: string, ref: AgentSessionRef): string {
+    return `${workspaceScopeId}|${ref.agentTypeId}|${ref.sessionId}`
+  }
+
+  private compareSessions(left: FakeSession, right: FakeSession): number {
+    return right.updatedAt - left.updatedAt
+      || left.ref.agentTypeId.localeCompare(right.ref.agentTypeId)
+      || left.ref.sessionId.localeCompare(right.ref.sessionId)
+  }
+
+  private compareTuple(session: FakeSession, tuple: readonly [number, string, string]): number {
+    return tuple[0] - session.updatedAt
+      || session.ref.agentTypeId.localeCompare(tuple[1])
+      || session.ref.sessionId.localeCompare(tuple[2])
+  }
+
+  private createCursor(payload: {
+    readonly workspaceScopeId: string
+    readonly filter: string
+    readonly limit: number
+    readonly after: readonly [number, string, string]
+  }): string {
+    const body = encodeURIComponent(JSON.stringify(payload))
+    return `${body}.${this.cursorChecksum(body)}`
+  }
+
+  private parseCursor(cursor: string): {
+    readonly workspaceScopeId: string
+    readonly filter: string
+    readonly limit: number
+    readonly after: readonly [number, string, string]
+  } {
+    const separator = cursor.lastIndexOf('.')
+    const body = cursor.slice(0, separator)
+    const checksum = cursor.slice(separator + 1)
+    if (separator < 0 || checksum !== this.cursorChecksum(body)) {
+      throw this.error(AgentGatewayErrorCode.AGENT_SESSION_CURSOR_INVALID, 'cursor is invalid')
+    }
+    try {
+      const parsed = JSON.parse(decodeURIComponent(body)) as {
+        workspaceScopeId?: unknown
+        filter?: unknown
+        limit?: unknown
+        after?: unknown
+      }
+      if (
+        typeof parsed.workspaceScopeId !== 'string'
+        || typeof parsed.filter !== 'string'
+        || typeof parsed.limit !== 'number'
+        || !Array.isArray(parsed.after)
+        || parsed.after.length !== 3
+        || typeof parsed.after[0] !== 'number'
+        || typeof parsed.after[1] !== 'string'
+        || typeof parsed.after[2] !== 'string'
+      ) throw new Error('invalid shape')
+      return parsed as {
+        workspaceScopeId: string
+        filter: string
+        limit: number
+        after: [number, string, string]
+      }
+    } catch {
+      throw this.error(AgentGatewayErrorCode.AGENT_SESSION_CURSOR_INVALID, 'cursor is invalid')
+    }
+  }
+
+  private cursorChecksum(value: string): string {
+    let checksum = 17
+    for (const character of value) checksum = (checksum * 31 + character.charCodeAt(0)) >>> 0
+    return checksum.toString(36)
+  }
+
+  private tick(): number {
+    this.now += 1
+    return this.now
+  }
+}
+
+gatewayConformance({
+  createFixture: async () => new FakeGatewayFixture(),
+  replayLevel: 'B',
+  paginationLevel: 'keyset',
+})

--- a/packages/agent/src/server/agent-host/testing/gatewayConformance.ts
+++ b/packages/agent/src/server/agent-host/testing/gatewayConformance.ts
@@ -9,9 +9,12 @@ import {
   type AgentSessionSummary,
   type AuthorizedAgentScope,
 } from '../../../shared/index'
+import type { AgentGatewayEffect } from '../types'
 
-export type GatewayReplayConformanceLevel = 'B' | 'D'
-export type GatewayPaginationConformanceLevel = 'keyset' | 'immutable-snapshot'
+/** G1 ships only the embedded bounded-replay contract. */
+export type GatewayReplayConformanceLevel = 'B'
+/** G1 ships only mutation-best-effort keyset pagination. */
+export type GatewayPaginationConformanceLevel = 'keyset'
 
 export interface GatewayConformanceFixture {
   readonly gateway: AgentGateway
@@ -23,6 +26,10 @@ export interface GatewayConformanceFixture {
   revoke(scope: AuthorizedAgentScope): void
   setActivity(ref: AgentSessionRef, activity: AgentSessionActivity): void
   moveSession(ref: AgentSessionRef, updatedAt: number): void
+  queueAdmission(
+    operation: AgentGatewayEffect,
+    disposition: 'strong-reject' | 'retryable',
+  ): void
 }
 
 export interface GatewayConformanceOptions {
@@ -119,6 +126,46 @@ export function gatewayConformance(options: GatewayConformanceOptions): void {
       })
     })
 
+    it('applies admission before mutation with strong denial, retryable retry, and digest conflict', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+
+      fixture.queueAdmission('session.create', 'strong-reject')
+      const rejected = fixture.gateway.createSession({
+        scope,
+        agentTypeId: 'alpha',
+        requestId: 'strong-reject',
+        title: 'denied',
+      })
+      await expectCode(rejected, 'AGENT_SCOPE_DENIED')
+      await expect(fixture.gateway.listSessions({ scope })).resolves.toEqual({ sessions: [] })
+      await expectCode(fixture.gateway.createSession({
+        scope,
+        agentTypeId: 'alpha',
+        requestId: 'strong-reject',
+        title: 'denied',
+      }), 'AGENT_SCOPE_DENIED')
+      await expectCode(fixture.gateway.createSession({
+        scope,
+        agentTypeId: 'alpha',
+        requestId: 'strong-reject',
+        title: 'conflicting digest',
+      }), 'AGENT_REQUEST_CONFLICT')
+
+      fixture.queueAdmission('session.create', 'retryable')
+      await expectCode(fixture.gateway.createSession({
+        scope,
+        agentTypeId: 'alpha',
+        requestId: 'retryable',
+      }), 'AGENT_GATEWAY_CLOSED')
+      await expect(fixture.gateway.listSessions({ scope })).resolves.toEqual({ sessions: [] })
+      await expect(fixture.gateway.createSession({
+        scope,
+        agentTypeId: 'alpha',
+        requestId: 'retryable',
+      })).resolves.toMatchObject({ agentTypeId: 'alpha' })
+    })
+
     it('fails unknown agents and hidden cross-scope sessions with stable errors', async () => {
       const fixture = await options.createFixture()
       const scopeA = fixture.issueScope({ workspaceScopeId: 'workspace-a' })
@@ -202,6 +249,63 @@ export function gatewayConformance(options: GatewayConformanceOptions): void {
       expect(stop).toMatchObject({ accepted: true, stopped: true, clearedQueue: [] })
       expect(await connection.stop({ requestId: 'stop' })).toEqual(stop)
       await connection.close()
+    })
+
+    it('covers the complete command-state table and queue selector semantics', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      const states: readonly AgentSessionActivity[] = ['idle', 'running', 'aborting', 'error']
+
+      for (const [index, state] of states.entries()) {
+        const ref = await createSession(fixture, scope, `state-${state}`)
+        const connection = await fixture.gateway.connectSession({ scope, ref })
+        fixture.setActivity(ref, state)
+        const prompt = connection.send({
+          kind: 'prompt',
+          requestId: `state-prompt-${index}`,
+          clientNonce: `state-prompt-${index}`,
+          content: 'prompt',
+        })
+        if (state === 'idle' || state === 'error') {
+          await expect(prompt).resolves.toMatchObject({ disposition: 'prompt' })
+        } else {
+          await expectCode(prompt, 'AGENT_COMMAND_INVALID_STATE')
+        }
+
+        fixture.setActivity(ref, state)
+        const followupInput = {
+          kind: 'followup' as const,
+          requestId: `state-followup-${index}`,
+          clientNonce: `state-followup-${index}`,
+          clientSeq: index,
+          content: 'follow-up',
+        }
+        await expect(connection.send(followupInput)).resolves.toMatchObject({ disposition: 'followup' })
+        await expect(connection.send(followupInput)).resolves.toMatchObject({ duplicate: true })
+        await expectCode(connection.send({ ...followupInput, content: 'conflict' }), 'AGENT_REQUEST_CONFLICT')
+        await expectCode(connection.clearQueue({
+          requestId: `selector-mismatch-${index}`,
+          clientNonce: followupInput.clientNonce,
+          clientSeq: index + 100,
+        }), 'AGENT_REQUEST_CONFLICT')
+
+        const beforeClear = (await fixture.gateway.readSessionState({ scope, ref })).summary.status
+        await expect(connection.clearQueue({ requestId: `state-clear-${index}` })).resolves.toMatchObject({ accepted: true })
+        expect((await fixture.gateway.readSessionState({ scope, ref })).summary.status).toBe(beforeClear)
+
+        fixture.setActivity(ref, state)
+        await expect(connection.interrupt({ requestId: `state-interrupt-${index}` })).resolves.toMatchObject({ accepted: true })
+        const afterInterrupt = (await fixture.gateway.readSessionState({ scope, ref })).summary.status
+        expect(afterInterrupt).toBe(state === 'running' ? 'aborting' : state)
+
+        fixture.setActivity(ref, state)
+        await expect(connection.stop({ requestId: `state-stop-${index}` })).resolves.toMatchObject({
+          accepted: true,
+          stopped: state === 'running' || state === 'aborting',
+        })
+        expect((await fixture.gateway.readSessionState({ scope, ref })).summary.status).toBe('idle')
+        await connection.close()
+      }
     })
 
     it('treats close as unsubscribe and keeps the session turn alive', async () => {

--- a/packages/agent/src/server/agent-host/testing/gatewayConformance.ts
+++ b/packages/agent/src/server/agent-host/testing/gatewayConformance.ts
@@ -126,19 +126,120 @@ export function gatewayConformance(options: GatewayConformanceOptions): void {
       })
     })
 
-    it('applies admission before mutation with strong denial, retryable retry, and digest conflict', async () => {
+    it('applies admission before mutation with strong denial for every effect', async () => {
+      const cases: readonly {
+        readonly effect: AgentGatewayEffect
+        readonly run: (fixture: GatewayConformanceFixture, scope: AuthorizedAgentScope, requestId: string) => Promise<void>
+      }[] = [
+        {
+          effect: 'session.create',
+          run: async (fixture, scope, requestId) => {
+            await expectCode(fixture.gateway.createSession({ scope, agentTypeId: 'alpha', requestId, title: 'denied' }), 'AGENT_SCOPE_DENIED')
+            expect(await fixture.gateway.listSessions({ scope })).toEqual({ sessions: [] })
+          },
+        },
+        {
+          effect: 'session.rename',
+          run: async (fixture, scope, requestId) => {
+            const ref = await createSession(fixture, scope, `${requestId}-session`)
+            await expectCode(fixture.gateway.renameSession({ scope, ref, requestId, title: 'mutated' }), 'AGENT_SCOPE_DENIED')
+            expect((await fixture.gateway.readSessionState({ scope, ref })).summary.title).toBe(`${requestId}-session`)
+          },
+        },
+        {
+          effect: 'session.delete',
+          run: async (fixture, scope, requestId) => {
+            const ref = await createSession(fixture, scope, `${requestId}-session`)
+            await expectCode(fixture.gateway.deleteSession({ scope, ref, requestId }), 'AGENT_SCOPE_DENIED')
+            await expect(fixture.gateway.readSessionState({ scope, ref })).resolves.toMatchObject({ ref })
+          },
+        },
+        {
+          effect: 'session.prompt',
+          run: async (fixture, scope, requestId) => {
+            const ref = await createSession(fixture, scope, `${requestId}-session`)
+            const connection = await fixture.gateway.connectSession({ scope, ref })
+            await expectCode(connection.send({ kind: 'prompt', requestId, clientNonce: requestId, content: 'prompt' }), 'AGENT_SCOPE_DENIED')
+            const state = await fixture.gateway.readSessionState({ scope, ref })
+            expect(state.summary.status).toBe('idle')
+            expect(state.state.messages).toEqual([])
+            await connection.close()
+          },
+        },
+        {
+          effect: 'session.followup',
+          run: async (fixture, scope, requestId) => {
+            const ref = await createSession(fixture, scope, `${requestId}-session`)
+            const connection = await fixture.gateway.connectSession({ scope, ref })
+            fixture.setActivity(ref, 'running')
+            await expectCode(connection.send({ kind: 'followup', requestId, clientNonce: requestId, clientSeq: 1, content: 'followup' }), 'AGENT_SCOPE_DENIED')
+            const state = await fixture.gateway.readSessionState({ scope, ref })
+            expect(state.summary.status).toBe('running')
+            expect(state.state.queue.followUps).toEqual([])
+            await connection.close()
+          },
+        },
+        {
+          effect: 'session.interrupt',
+          run: async (fixture, scope, requestId) => {
+            const ref = await createSession(fixture, scope, `${requestId}-session`)
+            const connection = await fixture.gateway.connectSession({ scope, ref })
+            fixture.setActivity(ref, 'running')
+            await expectCode(connection.interrupt({ requestId }), 'AGENT_SCOPE_DENIED')
+            expect((await fixture.gateway.readSessionState({ scope, ref })).summary.status).toBe('running')
+            await connection.close()
+          },
+        },
+        {
+          effect: 'session.stop',
+          run: async (fixture, scope, requestId) => {
+            const ref = await createSession(fixture, scope, `${requestId}-session`)
+            const connection = await fixture.gateway.connectSession({ scope, ref })
+            fixture.setActivity(ref, 'running')
+            await connection.send({ kind: 'followup', requestId: `${requestId}-queued`, clientNonce: `${requestId}-queued`, clientSeq: 1, content: 'queued' })
+            await expectCode(connection.stop({ requestId }), 'AGENT_SCOPE_DENIED')
+            const state = await fixture.gateway.readSessionState({ scope, ref })
+            expect(state.summary.status).toBe('running')
+            expect(state.state.queue.followUps).toHaveLength(1)
+            await connection.close()
+          },
+        },
+        {
+          effect: 'session.queue.clear',
+          run: async (fixture, scope, requestId) => {
+            const ref = await createSession(fixture, scope, `${requestId}-session`)
+            const connection = await fixture.gateway.connectSession({ scope, ref })
+            fixture.setActivity(ref, 'running')
+            await connection.send({ kind: 'followup', requestId: `${requestId}-queued`, clientNonce: `${requestId}-queued`, clientSeq: 1, content: 'queued' })
+            await expectCode(connection.clearQueue({ requestId }), 'AGENT_SCOPE_DENIED')
+            const state = await fixture.gateway.readSessionState({ scope, ref })
+            expect(state.summary.status).toBe('running')
+            expect(state.state.queue.followUps).toHaveLength(1)
+            await connection.close()
+          },
+        },
+      ]
+
+      for (const [index, testCase] of cases.entries()) {
+        const fixture = await options.createFixture()
+        const scope = fixture.issueScope()
+        const requestId = `strong-reject-${index}`
+        fixture.queueAdmission(testCase.effect, 'strong-reject')
+        await testCase.run(fixture, scope, requestId)
+      }
+    })
+
+    it('applies admission before mutation with retryable retry and digest conflict', async () => {
       const fixture = await options.createFixture()
       const scope = fixture.issueScope()
 
       fixture.queueAdmission('session.create', 'strong-reject')
-      const rejected = fixture.gateway.createSession({
+      await expectCode(fixture.gateway.createSession({
         scope,
         agentTypeId: 'alpha',
         requestId: 'strong-reject',
         title: 'denied',
-      })
-      await expectCode(rejected, 'AGENT_SCOPE_DENIED')
-      await expect(fixture.gateway.listSessions({ scope })).resolves.toEqual({ sessions: [] })
+      }), 'AGENT_SCOPE_DENIED')
       await expectCode(fixture.gateway.createSession({
         scope,
         agentTypeId: 'alpha',

--- a/packages/agent/src/server/agent-host/testing/gatewayConformance.ts
+++ b/packages/agent/src/server/agent-host/testing/gatewayConformance.ts
@@ -1,0 +1,337 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_GATEWAY_ERROR_CODES,
+  AgentGatewayError,
+  AgentGatewayErrorCode,
+  type AgentGateway,
+  type AgentSessionActivity,
+  type AgentSessionRef,
+  type AgentSessionSummary,
+  type AuthorizedAgentScope,
+} from '../../../shared/index'
+
+export type GatewayReplayConformanceLevel = 'B' | 'D'
+export type GatewayPaginationConformanceLevel = 'keyset' | 'immutable-snapshot'
+
+export interface GatewayConformanceFixture {
+  readonly gateway: AgentGateway
+  issueScope(input?: {
+    readonly workspaceScopeId?: string
+    readonly authSubjectId?: string
+    readonly issuer?: 'primary' | 'foreign'
+  }): AuthorizedAgentScope
+  revoke(scope: AuthorizedAgentScope): void
+  setActivity(ref: AgentSessionRef, activity: AgentSessionActivity): void
+  moveSession(ref: AgentSessionRef, updatedAt: number): void
+}
+
+export interface GatewayConformanceOptions {
+  readonly createFixture: () => Promise<GatewayConformanceFixture>
+  readonly replayLevel: GatewayReplayConformanceLevel
+  readonly paginationLevel: GatewayPaginationConformanceLevel
+}
+
+async function expectCode(
+  operation: Promise<unknown>,
+  code: AgentGatewayErrorCode,
+): Promise<void> {
+  await expect(operation).rejects.toMatchObject({ code })
+}
+
+async function createSession(
+  fixture: GatewayConformanceFixture,
+  scope: AuthorizedAgentScope,
+  requestId: string,
+  agentTypeId = 'alpha',
+) {
+  return fixture.gateway.createSession({
+    scope,
+    agentTypeId,
+    requestId,
+    title: requestId,
+  })
+}
+
+/**
+ * Registers the placement-independent Gateway semantic contract against any
+ * implementation. Pagination capability is intentionally independent of the
+ * replay durability level.
+ */
+export function gatewayConformance(options: GatewayConformanceOptions): void {
+  describe(`AgentGateway conformance (replay ${options.replayLevel}, pagination ${options.paginationLevel})`, () => {
+    it('requires issuer provenance and current membership on every operation', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      const ref = await createSession(fixture, scope, 'create-valid')
+      const foreign = fixture.issueScope({ issuer: 'foreign' })
+      const spread = { ...scope }
+      const jsonCopy = JSON.parse(JSON.stringify(scope)) as AuthorizedAgentScope
+      const forged = {
+        workspaceScopeId: scope.workspaceScopeId,
+        authSubjectId: scope.authSubjectId,
+      } as AuthorizedAgentScope
+
+      fixture.revoke(scope)
+      for (const [index, denied] of [foreign, spread, jsonCopy, forged, scope].entries()) {
+        await expectCode(fixture.gateway.listAgents({ scope: denied }), 'AGENT_SCOPE_DENIED')
+        await expectCode(fixture.gateway.listSessions({ scope: denied }), 'AGENT_SCOPE_DENIED')
+        await expectCode(fixture.gateway.createSession({ scope: denied, agentTypeId: 'alpha', requestId: `denied-create-${index}` }), 'AGENT_SCOPE_DENIED')
+        await expectCode(fixture.gateway.connectSession({ scope: denied, ref }), 'AGENT_SCOPE_DENIED')
+        await expectCode(fixture.gateway.readSessionState({ scope: denied, ref }), 'AGENT_SCOPE_DENIED')
+        await expectCode(fixture.gateway.renameSession({ scope: denied, ref, requestId: `denied-rename-${index}`, title: 'x' }), 'AGENT_SCOPE_DENIED')
+        await expectCode(fixture.gateway.deleteSession({ scope: denied, ref, requestId: `denied-delete-${index}` }), 'AGENT_SCOPE_DENIED')
+      }
+    })
+
+    it('re-verifies membership for every command on an open connection', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      const ref = await createSession(fixture, scope, 'open-command-session')
+      const connection = await fixture.gateway.connectSession({ scope, ref })
+      fixture.revoke(scope)
+
+      await expectCode(connection.send({ kind: 'prompt', requestId: 'p', clientNonce: 'n', content: 'hello' }), 'AGENT_SCOPE_DENIED')
+      await expectCode(connection.interrupt({ requestId: 'i' }), 'AGENT_SCOPE_DENIED')
+      await expectCode(connection.stop({ requestId: 's' }), 'AGENT_SCOPE_DENIED')
+      await expectCode(connection.clearQueue({ requestId: 'q' }), 'AGENT_SCOPE_DENIED')
+      await connection.close()
+    })
+
+    it('exposes the complete closed v0 stable error mapping', () => {
+      expect(AGENT_GATEWAY_ERROR_CODES).toEqual([
+        'AGENT_TYPE_UNKNOWN',
+        'AGENT_SESSION_NOT_FOUND',
+        'AGENT_SCOPE_DENIED',
+        'AGENT_SESSION_REPLAY_GAP',
+        'AGENT_SESSION_CURSOR_AHEAD',
+        'AGENT_SESSION_CURSOR_EXPIRED',
+        'AGENT_SESSION_CURSOR_INVALID',
+        'AGENT_REQUEST_CONFLICT',
+        'AGENT_REQUEST_OUTCOME_UNKNOWN',
+        'AGENT_COMMAND_INVALID_STATE',
+        'AGENT_SESSION_RUNTIME_SCOPE_MISMATCH',
+        'AGENT_SHARED_ENVIRONMENT_UNAVAILABLE',
+        'AGENT_GATEWAY_CLOSED',
+      ])
+      expect(new AgentGatewayError(AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN, 'unknown').toJSON()).toEqual({
+        code: AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN,
+        message: 'unknown',
+      })
+    })
+
+    it('fails unknown agents and hidden cross-scope sessions with stable errors', async () => {
+      const fixture = await options.createFixture()
+      const scopeA = fixture.issueScope({ workspaceScopeId: 'workspace-a' })
+      const scopeB = fixture.issueScope({ workspaceScopeId: 'workspace-b' })
+      const ref = await createSession(fixture, scopeA, 'scope-a-session')
+
+      await expectCode(createSession(fixture, scopeA, 'unknown-agent', 'missing'), 'AGENT_TYPE_UNKNOWN')
+      await expectCode(fixture.gateway.readSessionState({ scope: scopeB, ref }), 'AGENT_SESSION_NOT_FOUND')
+      await expectCode(fixture.gateway.readSessionState({ scope: scopeA, ref: { agentTypeId: ref.agentTypeId, sessionId: 'missing' } }), 'AGENT_SESSION_NOT_FOUND')
+    })
+
+    it('keys idempotency by scope, effect, full target, request id, and digest', async () => {
+      const fixture = await options.createFixture()
+      const scopeA = fixture.issueScope({ workspaceScopeId: 'workspace-a' })
+      const scopeB = fixture.issueScope({ workspaceScopeId: 'workspace-b' })
+      const [first, concurrentRetry] = await Promise.all([
+        createSession(fixture, scopeA, 'same-id'),
+        createSession(fixture, scopeA, 'same-id'),
+      ])
+      expect(concurrentRetry).toEqual(first)
+      expect(await createSession(fixture, scopeA, 'same-id')).toEqual(first)
+      await expectCode(
+        fixture.gateway.createSession({ scope: scopeA, agentTypeId: 'alpha', requestId: 'same-id', title: 'different' }),
+        'AGENT_REQUEST_CONFLICT',
+      )
+
+      const otherScope = await createSession(fixture, scopeB, 'same-id')
+      const otherAgent = await createSession(fixture, scopeA, 'same-id', 'beta')
+      expect(otherScope).not.toEqual(first)
+      expect(otherAgent.agentTypeId).toBe('beta')
+
+      const second = await createSession(fixture, scopeA, 'second-target')
+      const renamedFirst = await fixture.gateway.renameSession({ scope: scopeA, ref: first, requestId: 'shared-target-id', title: 'one' })
+      expect(await fixture.gateway.renameSession({ scope: scopeA, ref: first, requestId: 'shared-target-id', title: 'one' })).toEqual(renamedFirst)
+      await expectCode(
+        fixture.gateway.renameSession({ scope: scopeA, ref: first, requestId: 'shared-target-id', title: 'changed' }),
+        'AGENT_REQUEST_CONFLICT',
+      )
+      await expect(fixture.gateway.renameSession({ scope: scopeA, ref: second, requestId: 'shared-target-id', title: 'two' })).resolves.toMatchObject({ title: 'two' })
+
+      await fixture.gateway.deleteSession({ scope: scopeA, ref: second, requestId: 'delete-id' })
+      await expect(fixture.gateway.deleteSession({ scope: scopeA, ref: second, requestId: 'delete-id' })).resolves.toBeUndefined()
+    })
+
+    it('enforces command states, queue controls, typed receipts, and command idempotency', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      const ref = await createSession(fixture, scope, 'commands')
+      const connection = await fixture.gateway.connectSession({ scope, ref })
+
+      expect(await connection.interrupt({ requestId: 'idle-interrupt' })).toMatchObject({ accepted: true })
+      expect((await fixture.gateway.readSessionState({ scope, ref })).summary.status).toBe('idle')
+      const prompt = await connection.send({ kind: 'prompt', requestId: 'prompt', clientNonce: 'nonce-p', content: 'start' })
+      expect(prompt).toMatchObject({ accepted: true, disposition: 'prompt', clientNonce: 'nonce-p' })
+      expect(await connection.send({ kind: 'prompt', requestId: 'prompt', clientNonce: 'nonce-p', content: 'start' })).toMatchObject({ duplicate: true })
+      await expectCode(
+        connection.send({ kind: 'prompt', requestId: 'prompt', clientNonce: 'nonce-p', content: 'different' }),
+        'AGENT_REQUEST_CONFLICT',
+      )
+      await expectCode(
+        connection.send({ kind: 'prompt', requestId: 'second-prompt', clientNonce: 'nonce-p2', content: 'invalid while running' }),
+        'AGENT_COMMAND_INVALID_STATE',
+      )
+
+      const followup = await connection.send({ kind: 'followup', requestId: 'followup', clientNonce: 'nonce-f', clientSeq: 4, content: 'next' })
+      expect(followup).toMatchObject({ accepted: true, disposition: 'followup', clientNonce: 'nonce-f', clientSeq: 4 })
+      expect(await connection.interrupt({ requestId: 'interrupt' })).toMatchObject({ accepted: true })
+      expect(await connection.interrupt({ requestId: 'interrupt' })).toMatchObject({ accepted: true })
+      expect(await connection.interrupt({ requestId: 'interrupt-aborting' })).toMatchObject({ accepted: true })
+      await expectCode(
+        connection.send({ kind: 'prompt', requestId: 'aborting-prompt', clientNonce: 'nonce-a', content: 'invalid while aborting' }),
+        'AGENT_COMMAND_INVALID_STATE',
+      )
+      await expect(connection.send({ kind: 'followup', requestId: 'aborting-followup', clientNonce: 'nonce-af', clientSeq: 5, content: 'queued while aborting' })).resolves.toMatchObject({ disposition: 'followup' })
+      expect(await connection.clearQueue({ requestId: 'clear' })).toMatchObject({ accepted: true, cleared: 2 })
+      expect(await connection.clearQueue({ requestId: 'clear' })).toMatchObject({ accepted: true, cleared: 2 })
+
+      fixture.setActivity(ref, 'error')
+      await expect(connection.send({ kind: 'prompt', requestId: 'error-recovery', clientNonce: 'nonce-e', content: 'retry' })).resolves.toMatchObject({ disposition: 'prompt' })
+      const stop = await connection.stop({ requestId: 'stop' })
+      expect(stop).toMatchObject({ accepted: true, stopped: true, clearedQueue: [] })
+      expect(await connection.stop({ requestId: 'stop' })).toEqual(stop)
+      await connection.close()
+    })
+
+    it('treats close as unsubscribe and keeps the session turn alive', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      const ref = await createSession(fixture, scope, 'close-unsubscribe')
+      const first = await fixture.gateway.connectSession({ scope, ref })
+      const pendingEvent = first.events[Symbol.asyncIterator]().next()
+      await first.close()
+      await expect(pendingEvent).resolves.toMatchObject({ done: true })
+
+      const second = await fixture.gateway.connectSession({ scope, ref })
+      await second.send({ kind: 'prompt', requestId: 'run', clientNonce: 'run', content: 'continue' })
+      await second.close()
+      const snapshot = await fixture.gateway.readSessionState({ scope, ref })
+      expect(snapshot.summary.status).toBe('running')
+      const third = await fixture.gateway.connectSession({ scope, ref })
+      await expect(third.interrupt({ requestId: 'interrupt-after-close' })).resolves.toMatchObject({ accepted: true })
+      await third.close()
+    })
+
+    it('provides monotonic single-sequence envelopes and consistent snapshots', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      const ref = await createSession(fixture, scope, 'sequence')
+      const connection = await fixture.gateway.connectSession({ scope, ref, cursor: 0 })
+      await connection.send({ kind: 'prompt', requestId: 'event-1', clientNonce: 'event-1', content: 'one' })
+      await connection.send({ kind: 'followup', requestId: 'event-2', clientNonce: 'event-2', clientSeq: 1, content: 'two' })
+      const iterator = connection.events[Symbol.asyncIterator]()
+      const first = await iterator.next()
+      const second = await iterator.next()
+      expect(first.done).toBe(false)
+      expect(second.done).toBe(false)
+      if (!first.done && !second.done) {
+        expect(first.value.seq).toBe(first.value.event.seq)
+        expect(second.value.seq).toBe(second.value.event.seq)
+        expect(second.value.seq).toBeGreaterThan(first.value.seq)
+      }
+      const snapshot = await fixture.gateway.readSessionState({ scope, ref })
+      expect(snapshot.seq).toBe(snapshot.state.seq)
+      expect(snapshot.ref).toEqual(ref)
+      await connection.close()
+    })
+
+    it('recovers a bounded replay gap through snapshot then reconnect', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      const ref = await createSession(fixture, scope, 'replay')
+      const connection = await fixture.gateway.connectSession({ scope, ref })
+      for (let index = 0; index < 6; index += 1) {
+        await connection.send({ kind: 'followup', requestId: `replay-${index}`, clientNonce: `replay-${index}`, clientSeq: index, content: 'event' })
+      }
+      await connection.close()
+
+      await expectCode(fixture.gateway.connectSession({ scope, ref, cursor: 0 }), 'AGENT_SESSION_REPLAY_GAP')
+      const snapshot = await fixture.gateway.readSessionState({ scope, ref })
+      await expect(fixture.gateway.connectSession({ scope, ref, cursor: snapshot.seq })).resolves.toMatchObject({ ref })
+      await expectCode(fixture.gateway.connectSession({ scope, ref, cursor: snapshot.seq + 1 }), 'AGENT_SESSION_CURSOR_AHEAD')
+    })
+
+    it('orders keyset pages and denies tampered or rebound cursors', async () => {
+      const fixture = await options.createFixture()
+      const scopeA = fixture.issueScope({ workspaceScopeId: 'workspace-a' })
+      const scopeB = fixture.issueScope({ workspaceScopeId: 'workspace-b' })
+      const alphaA = await createSession(fixture, scopeA, 'a', 'alpha')
+      const beta = await createSession(fixture, scopeA, 'b', 'beta')
+      const alphaC = await createSession(fixture, scopeA, 'c', 'alpha')
+      fixture.moveSession(alphaA, 5_000)
+      fixture.moveSession(beta, 5_000)
+      fixture.moveSession(alphaC, 5_000)
+      const page = await fixture.gateway.listSessions({ scope: scopeA, limit: 1 })
+      expect(page.sessions).toHaveLength(1)
+      expect(page.nextCursor).toBeDefined()
+      const cursor = page.nextCursor!
+
+      await expectCode(fixture.gateway.listSessions({ scope: scopeA, cursor: `${cursor}tampered`, limit: 1 }), 'AGENT_SESSION_CURSOR_INVALID')
+      await expectCode(fixture.gateway.listSessions({ scope: scopeB, cursor, limit: 1 }), 'AGENT_SESSION_CURSOR_INVALID')
+      await expectCode(fixture.gateway.listSessions({ scope: scopeA, cursor, limit: 2 }), 'AGENT_SESSION_CURSOR_INVALID')
+      await expectCode(fixture.gateway.listSessions({ scope: scopeA, cursor, agentTypeId: 'alpha', limit: 1 }), 'AGENT_SESSION_CURSOR_INVALID')
+
+      const all = await fixture.gateway.listSessions({ scope: scopeA, limit: 20 })
+      expect(all.sessions).toEqual([...all.sessions].sort((left, right) =>
+        right.updatedAt - left.updatedAt
+        || left.ref.agentTypeId.localeCompare(right.ref.agentTypeId)
+        || left.ref.sessionId.localeCompare(right.ref.sessionId),
+      ))
+      expect(all.sessions.map((session) => session.ref)).toEqual([alphaA, alphaC, beta])
+    })
+
+    it('documents keyset mutation behavior: moved rows may shift and deleted rows disappear', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      const first = await createSession(fixture, scope, 'mutation-a')
+      const moved = await createSession(fixture, scope, 'mutation-b')
+      const deleted = await createSession(fixture, scope, 'mutation-c')
+      const page = await fixture.gateway.listSessions({ scope, limit: 1 })
+      expect(page.nextCursor).toBeDefined()
+
+      fixture.moveSession(moved, Date.now() + 100_000)
+      await fixture.gateway.deleteSession({ scope, ref: deleted, requestId: 'mutation-delete' })
+      const continuation = await fixture.gateway.listSessions({ scope, limit: 1, cursor: page.nextCursor })
+      expect(continuation.sessions).not.toContainEqual(expect.objectContaining({ ref: deleted }))
+      expect(continuation.sessions).not.toContainEqual(expect.objectContaining({ ref: moved }))
+      expect([first, moved, deleted]).toHaveLength(3)
+    })
+
+    it('allows a still-valid cursor to yield an empty page after mutation', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      const tail = await createSession(fixture, scope, 'empty-a')
+      await createSession(fixture, scope, 'empty-b')
+      const page = await fixture.gateway.listSessions({ scope, limit: 1 })
+      expect(page.nextCursor).toBeDefined()
+      await fixture.gateway.deleteSession({ scope, ref: tail, requestId: 'empty-delete' })
+      await expect(fixture.gateway.listSessions({ scope, limit: 1, cursor: page.nextCursor })).resolves.toEqual({ sessions: [] })
+    })
+
+    it('closes the facade idempotently and rejects subsequent operations', async () => {
+      const fixture = await options.createFixture()
+      const scope = fixture.issueScope()
+      await fixture.gateway.close()
+      await fixture.gateway.close()
+      await expectCode(fixture.gateway.listAgents({ scope }), 'AGENT_GATEWAY_CLOSED')
+    })
+
+    it.skip('Level D restart preserves sequence continuity [owner: streaming lane]', () => {})
+    it.skip('Level D durable request ledger replays receipts and create tombstones across restart [owner: streaming lane]', () => {})
+    it.skip('Level D durable admission/effect crash matrix resolves acknowledged and outcome-unknown work [owner: streaming lane]', () => {})
+    it.skip('Level D durable activity index reconciles non-quiescent states at startup [owner: streaming lane]', () => {})
+    it.skip('Level D/v2 immutable snapshot pagination is mutation-stable and expires [owner: #905 pool cursor]', () => {})
+    it.skip('v2 remote wire validates JSON event leaves, paths, depth, and size [owner: #905 remote wire]', () => {})
+  })
+}

--- a/packages/agent/src/server/agent-host/types.ts
+++ b/packages/agent/src/server/agent-host/types.ts
@@ -1,0 +1,93 @@
+import type {
+  AgentGatewayErrorDTO,
+  AgentSessionRef,
+  AuthSubjectId,
+  JsonValue,
+  VerifiedAgentScopeClaim,
+  WorkspaceScopeId,
+} from '../../shared/index'
+
+export type AgentGatewayEffect =
+  | 'session.create'
+  | 'session.rename'
+  | 'session.delete'
+  | 'session.prompt'
+  | 'session.followup'
+  | 'session.interrupt'
+  | 'session.stop'
+  | 'session.queue.clear'
+
+export type AgentRequestTarget =
+  | { readonly kind: 'agent'; readonly agentTypeId: string }
+  | { readonly kind: 'session'; readonly ref: AgentSessionRef }
+
+export interface AgentRequestKey {
+  readonly workspaceScopeId: WorkspaceScopeId
+  readonly authSubjectId: AuthSubjectId
+  readonly operation: AgentGatewayEffect
+  readonly target: AgentRequestTarget
+  readonly requestId: string
+}
+
+export type AgentRequestFailure =
+  | { readonly kind: 'gateway'; readonly error: AgentGatewayErrorDTO }
+  | {
+      /** Server-only compatibility envelope; never returned by AgentGateway. */
+      readonly kind: 'legacy-admission'
+      readonly code: string
+      readonly statusCode: 500
+      readonly message: string
+      readonly details?: JsonValue
+    }
+
+export interface AgentRequestLedgerRecordBase {
+  readonly key: AgentRequestKey
+  readonly digest: string
+  readonly updatedAt: number
+}
+
+export type AgentRequestLedgerRecord =
+  | (AgentRequestLedgerRecordBase & { readonly state: 'pending-admission' })
+  | (AgentRequestLedgerRecordBase & {
+      readonly state: 'admission-accepted'
+      readonly admissionReceipt: string
+    })
+  | (AgentRequestLedgerRecordBase & { readonly state: 'in-flight' })
+  | (AgentRequestLedgerRecordBase & {
+      readonly state: 'rejected'
+      readonly failure: AgentRequestFailure
+    })
+  | (AgentRequestLedgerRecordBase & {
+      readonly state: 'completed'
+      readonly receipt: JsonValue
+    })
+  | (AgentRequestLedgerRecordBase & {
+      readonly state: 'outcome-unknown'
+      readonly error: AgentGatewayErrorDTO
+    })
+
+export interface AgentRequestLedger {
+  prepare(key: AgentRequestKey, digest: string): Promise<AgentRequestLedgerRecord>
+  acceptAdmission(key: AgentRequestKey, admissionReceipt: string): Promise<void>
+  beginEffect(key: AgentRequestKey): Promise<void>
+  reject(key: AgentRequestKey, failure: AgentRequestFailure): Promise<void>
+  complete(key: AgentRequestKey, receipt: JsonValue): Promise<void>
+  markOutcomeUnknown(key: AgentRequestKey, error: AgentGatewayErrorDTO): Promise<void>
+  read(key: AgentRequestKey): Promise<AgentRequestLedgerRecord | undefined>
+}
+
+export type AgentEffectAdmissionResult =
+  | { readonly type: 'accepted'; readonly admissionReceipt: string }
+  | { readonly type: 'rejected'; readonly error: AgentGatewayErrorDTO }
+  | { readonly type: 'retryable'; readonly error: AgentGatewayErrorDTO }
+
+export interface AgentEffectAdmission {
+  /** Must be idempotent and reconcilable on the complete ledger key. */
+  admit(input: {
+    readonly key: AgentRequestKey
+    readonly digest: string
+    readonly scope: VerifiedAgentScopeClaim
+    readonly operation: AgentGatewayEffect
+    readonly target: AgentRequestTarget
+  }): Promise<AgentEffectAdmissionResult>
+}

--- a/packages/agent/src/shared/chat/piChatCommand.ts
+++ b/packages/agent/src/shared/chat/piChatCommand.ts
@@ -18,21 +18,21 @@ export type InterruptPayload = Record<string, never>
 export type StopPayload = Record<string, never>
 
 export interface CommandReceipt {
-  accepted: true
-  cursor: number
+  readonly accepted: true
+  readonly cursor: number
 }
 
-export type PromptReceipt = CommandReceipt & { clientNonce: string; duplicate?: boolean }
+export type PromptReceipt = CommandReceipt & { readonly clientNonce: string; readonly duplicate?: boolean }
 
 export type FollowUpReceipt = CommandReceipt & {
-  clientNonce: string
-  clientSeq: number
-  queued: true
-  duplicate?: boolean
+  readonly clientNonce: string
+  readonly clientSeq: number
+  readonly queued: true
+  readonly duplicate?: boolean
 }
 
-export type QueueClearReceipt = CommandReceipt & { cleared: number }
+export type QueueClearReceipt = CommandReceipt & { readonly cleared: number }
 
 export type InterruptReceipt = CommandReceipt
 
-export type StopReceipt = CommandReceipt & { stopped: boolean; clearedQueue: QueuedUserMessage[] }
+export type StopReceipt = CommandReceipt & { readonly stopped: boolean; readonly clearedQueue: readonly QueuedUserMessage[] }

--- a/packages/agent/src/shared/gateway/__tests__/dtoDiscipline.test.ts
+++ b/packages/agent/src/shared/gateway/__tests__/dtoDiscipline.test.ts
@@ -11,18 +11,16 @@ import type {
   AgentSessionStateSnapshot,
   AgentSummary,
   AuthorizedAgentScope,
+  CommandReceipt,
   CreateAgentSessionInput,
   JsonPrimitive,
   JsonSafe,
   JsonValue,
   PiChatEvent,
   PiChatSnapshot,
-} from '../../index'
-import type {
-  CommandReceipt,
   QueueClearReceipt,
   StopReceipt,
-} from '../types'
+} from '../../index'
 
 type IsJsonDto<T> = unknown extends T
   ? false

--- a/packages/agent/src/shared/gateway/__tests__/dtoDiscipline.test.ts
+++ b/packages/agent/src/shared/gateway/__tests__/dtoDiscipline.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, expectTypeOf, it } from 'vitest'
+import type {
+  AgentFollowUpCommand,
+  AgentGatewayErrorDTO,
+  AgentPromptCommand,
+  AgentSendReceipt,
+  AgentSessionEvent,
+  AgentSessionPage,
+  AgentSessionRef,
+  AgentSessionStateSnapshot,
+  AgentSummary,
+  AuthorizedAgentScope,
+  CommandReceipt,
+  CreateAgentSessionInput,
+  JsonPrimitive,
+  JsonSafe,
+  JsonValue,
+  QueueClearReceipt,
+  StopReceipt,
+} from '../../index'
+
+type IsJsonDto<T> = unknown extends T
+  ? false
+  : IsJsonDtoValue<Exclude<T, undefined>>
+
+type IsJsonDtoValue<T> = [T] extends [JsonPrimitive]
+  ? true
+  : T extends (...args: readonly never[]) => unknown
+    ? false
+    : T extends Date
+      ? false
+      : T extends readonly (infer U)[]
+        ? IsJsonDto<U>
+        : T extends object
+          ? Exclude<keyof T, string> extends never
+            ? false extends { [K in keyof T]-?: IsJsonDto<T[K]> }[keyof T]
+              ? false
+              : true
+            : false
+          : false
+
+type AssertJsonDto<T extends true> = T
+
+type TransportDtoAssertions = [
+  AssertJsonDto<IsJsonDto<AgentSessionRef>>,
+  AssertJsonDto<IsJsonDto<AgentSummary>>,
+  AssertJsonDto<IsJsonDto<AgentSessionPage>>,
+  AssertJsonDto<IsJsonDto<AgentPromptCommand>>,
+  AssertJsonDto<IsJsonDto<AgentFollowUpCommand>>,
+  AssertJsonDto<IsJsonDto<CommandReceipt>>,
+  AssertJsonDto<IsJsonDto<AgentSendReceipt>>,
+  AssertJsonDto<IsJsonDto<QueueClearReceipt>>,
+  AssertJsonDto<IsJsonDto<StopReceipt>>,
+  AssertJsonDto<IsJsonDto<Omit<AgentSessionStateSnapshot, 'state'>>>,
+  AssertJsonDto<IsJsonDto<Omit<AgentSessionEvent, 'event'>>>,
+  AssertJsonDto<IsJsonDto<Omit<AgentGatewayErrorDTO, 'details'>>>,
+]
+
+interface InvalidFunctionDto {
+  readonly callback: () => void
+}
+interface InvalidDateDto {
+  readonly createdAt: Date
+}
+
+function requireAuthorizedScope(_scope: AuthorizedAgentScope): void {}
+
+describe('gateway DTO discipline', () => {
+  it('keeps every transport projection structurally JSON-safe', () => {
+    expectTypeOf<TransportDtoAssertions[number]>().toEqualTypeOf<true>()
+    expectTypeOf<JsonSafe<unknown>>().toEqualTypeOf<JsonValue>()
+    expectTypeOf<IsJsonDto<InvalidFunctionDto>>().toEqualTypeOf<false>()
+    expectTypeOf<IsJsonDto<InvalidDateDto>>().toEqualTypeOf<false>()
+  })
+
+  it('does not permit structural construction of an AuthorizedAgentScope', () => {
+    const plain = { workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' }
+    // @ts-expect-error The issuer-owned symbol brand is absent.
+    requireAuthorizedScope(plain)
+
+    const issued = plain as AuthorizedAgentScope
+    // A spread retains the compile-time brand; provenance checking by the
+    // issuer is what rejects the new object at runtime (covered by conformance).
+    const spread = { ...issued }
+    requireAuthorizedScope(spread)
+
+    const input: CreateAgentSessionInput = {
+      scope: issued,
+      agentTypeId: 'alpha',
+      requestId: 'request-1',
+    }
+    expect(input.scope).toBe(issued)
+    expect({ ...input }.scope).toBe(issued)
+
+    const roundTrip: unknown = JSON.parse(JSON.stringify(issued))
+    // @ts-expect-error JSON data is not an issuer-owned capability.
+    requireAuthorizedScope(roundTrip)
+
+    expect(JSON.parse(JSON.stringify(issued))).toEqual(plain)
+    expectTypeOf<IsJsonDto<AuthorizedAgentScope>>().toEqualTypeOf<false>()
+  })
+})

--- a/packages/agent/src/shared/gateway/__tests__/dtoDiscipline.test.ts
+++ b/packages/agent/src/shared/gateway/__tests__/dtoDiscipline.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
+import { AgentGatewayErrorCode } from '../../index'
 import type {
   AgentFollowUpCommand,
   AgentGatewayErrorDTO,
@@ -10,14 +11,18 @@ import type {
   AgentSessionStateSnapshot,
   AgentSummary,
   AuthorizedAgentScope,
-  CommandReceipt,
   CreateAgentSessionInput,
   JsonPrimitive,
   JsonSafe,
   JsonValue,
+  PiChatEvent,
+  PiChatSnapshot,
+} from '../../index'
+import type {
+  CommandReceipt,
   QueueClearReceipt,
   StopReceipt,
-} from '../../index'
+} from '../types'
 
 type IsJsonDto<T> = unknown extends T
   ? false
@@ -65,12 +70,66 @@ interface InvalidDateDto {
 
 function requireAuthorizedScope(_scope: AuthorizedAgentScope): void {}
 
+function assertReadonlyReceipts(
+  command: CommandReceipt,
+  queueClear: QueueClearReceipt,
+  stop: StopReceipt,
+): void {
+  // @ts-expect-error Gateway receipts are immutable DTOs.
+  command.cursor = 2
+  // @ts-expect-error Gateway receipts are immutable DTOs.
+  queueClear.cleared = 2
+  // @ts-expect-error Cleared queue snapshots are readonly.
+  stop.clearedQueue.push({ id: 'x', kind: 'followup', displayText: 'x' })
+}
+
+void assertReadonlyReceipts
+
 describe('gateway DTO discipline', () => {
   it('keeps every transport projection structurally JSON-safe', () => {
     expectTypeOf<TransportDtoAssertions[number]>().toEqualTypeOf<true>()
     expectTypeOf<JsonSafe<unknown>>().toEqualTypeOf<JsonValue>()
+    expectTypeOf<AgentSessionStateSnapshot['state']>().toEqualTypeOf<JsonSafe<PiChatSnapshot>>()
+    expectTypeOf<AgentSessionEvent['event']>().toEqualTypeOf<JsonSafe<PiChatEvent>>()
+    expectTypeOf<AgentGatewayErrorDTO['details']>().toEqualTypeOf<JsonValue | undefined>()
     expectTypeOf<IsJsonDto<InvalidFunctionDto>>().toEqualTypeOf<false>()
     expectTypeOf<IsJsonDto<InvalidDateDto>>().toEqualTypeOf<false>()
+  })
+
+  it('serializes complete snapshot, event, and error DTOs at the existing JSON boundary', () => {
+    const ref = { agentTypeId: 'alpha', sessionId: 'session-1' }
+    const snapshot = {
+      ref,
+      seq: 1,
+      summary: {
+        ref,
+        title: 'Session',
+        status: 'idle',
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      state: {
+        protocolVersion: 1,
+        sessionId: ref.sessionId,
+        seq: 1,
+        status: 'idle',
+        messages: [],
+        queue: { followUps: [] },
+        followUpMode: 'one-at-a-time',
+      },
+    } satisfies AgentSessionStateSnapshot
+    const event = {
+      ref,
+      seq: 1,
+      event: { type: 'usage', seq: 1, usage: { inputTokens: 2 } },
+    } satisfies AgentSessionEvent
+    const error = {
+      code: AgentGatewayErrorCode.AGENT_SESSION_REPLAY_GAP,
+      message: 'rehydrate',
+      details: { latestSeq: 1 },
+    } satisfies AgentGatewayErrorDTO
+
+    expect(() => JSON.stringify({ snapshot, event, error })).not.toThrow()
   })
 
   it('does not permit structural construction of an AuthorizedAgentScope', () => {

--- a/packages/agent/src/shared/gateway/errors.ts
+++ b/packages/agent/src/shared/gateway/errors.ts
@@ -1,0 +1,62 @@
+import type { JsonValue } from './types'
+
+export const AgentGatewayErrorCode = {
+  AGENT_TYPE_UNKNOWN: 'AGENT_TYPE_UNKNOWN',
+  AGENT_SESSION_NOT_FOUND: 'AGENT_SESSION_NOT_FOUND',
+  AGENT_SCOPE_DENIED: 'AGENT_SCOPE_DENIED',
+  AGENT_SESSION_REPLAY_GAP: 'AGENT_SESSION_REPLAY_GAP',
+  AGENT_SESSION_CURSOR_AHEAD: 'AGENT_SESSION_CURSOR_AHEAD',
+  AGENT_SESSION_CURSOR_EXPIRED: 'AGENT_SESSION_CURSOR_EXPIRED',
+  AGENT_SESSION_CURSOR_INVALID: 'AGENT_SESSION_CURSOR_INVALID',
+  AGENT_REQUEST_CONFLICT: 'AGENT_REQUEST_CONFLICT',
+  AGENT_REQUEST_OUTCOME_UNKNOWN: 'AGENT_REQUEST_OUTCOME_UNKNOWN',
+  AGENT_COMMAND_INVALID_STATE: 'AGENT_COMMAND_INVALID_STATE',
+  AGENT_SESSION_RUNTIME_SCOPE_MISMATCH: 'AGENT_SESSION_RUNTIME_SCOPE_MISMATCH',
+  AGENT_SHARED_ENVIRONMENT_UNAVAILABLE: 'AGENT_SHARED_ENVIRONMENT_UNAVAILABLE',
+  AGENT_GATEWAY_CLOSED: 'AGENT_GATEWAY_CLOSED',
+} as const
+
+export type AgentGatewayErrorCode =
+  (typeof AgentGatewayErrorCode)[keyof typeof AgentGatewayErrorCode]
+
+export const AGENT_GATEWAY_ERROR_CODES = [
+  AgentGatewayErrorCode.AGENT_TYPE_UNKNOWN,
+  AgentGatewayErrorCode.AGENT_SESSION_NOT_FOUND,
+  AgentGatewayErrorCode.AGENT_SCOPE_DENIED,
+  AgentGatewayErrorCode.AGENT_SESSION_REPLAY_GAP,
+  AgentGatewayErrorCode.AGENT_SESSION_CURSOR_AHEAD,
+  AgentGatewayErrorCode.AGENT_SESSION_CURSOR_EXPIRED,
+  AgentGatewayErrorCode.AGENT_SESSION_CURSOR_INVALID,
+  AgentGatewayErrorCode.AGENT_REQUEST_CONFLICT,
+  AgentGatewayErrorCode.AGENT_REQUEST_OUTCOME_UNKNOWN,
+  AgentGatewayErrorCode.AGENT_COMMAND_INVALID_STATE,
+  AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+  AgentGatewayErrorCode.AGENT_SHARED_ENVIRONMENT_UNAVAILABLE,
+  AgentGatewayErrorCode.AGENT_GATEWAY_CLOSED,
+] as const
+
+export interface AgentGatewayErrorDTO {
+  readonly code: AgentGatewayErrorCode
+  readonly message: string
+  readonly details?: JsonValue
+}
+
+export class AgentGatewayError extends Error {
+  readonly code: AgentGatewayErrorCode
+  readonly details?: JsonValue
+
+  constructor(code: AgentGatewayErrorCode, message: string, details?: JsonValue) {
+    super(message)
+    this.name = 'AgentGatewayError'
+    this.code = code
+    this.details = details
+  }
+
+  toJSON(): AgentGatewayErrorDTO {
+    return {
+      code: this.code,
+      message: this.message,
+      ...(this.details === undefined ? {} : { details: this.details }),
+    }
+  }
+}

--- a/packages/agent/src/shared/gateway/events.ts
+++ b/packages/agent/src/shared/gateway/events.ts
@@ -1,0 +1,9 @@
+import type { PiChatEvent } from '../chat'
+import type { AgentSessionRef, JsonSafe } from './types'
+
+/** Placement-independent event envelope. `seq` is the only replay cursor. */
+export interface AgentSessionEvent {
+  readonly ref: AgentSessionRef
+  readonly seq: number
+  readonly event: JsonSafe<PiChatEvent>
+}

--- a/packages/agent/src/shared/gateway/types.ts
+++ b/packages/agent/src/shared/gateway/types.ts
@@ -1,11 +1,8 @@
 import type {
   ChatAttachmentPayload,
   ChatModelSelection,
-  CommandReceipt as PiCommandReceipt,
   PiChatSnapshot,
-  QueueClearReceipt as PiQueueClearReceipt,
   QueuedUserMessage,
-  StopReceipt as PiStopReceipt,
   ThinkingLevel,
 } from '../chat'
 import type { AgentSessionEvent } from './events'
@@ -157,7 +154,10 @@ export interface IdempotentQueueClear extends IdempotentAgentControl {
   readonly clientSeq?: number
 }
 
-export type CommandReceipt = PiCommandReceipt
+export interface CommandReceipt {
+  readonly accepted: true
+  readonly cursor: number
+}
 
 export interface AgentSendReceipt extends CommandReceipt {
   readonly disposition: 'prompt' | 'followup'
@@ -166,14 +166,20 @@ export interface AgentSendReceipt extends CommandReceipt {
   readonly clientSeq?: number
 }
 
-export type QueueClearReceipt = PiQueueClearReceipt
-export type StopReceipt = PiStopReceipt
+export interface QueueClearReceipt extends CommandReceipt {
+  readonly cleared: number
+}
+
+export interface StopReceipt extends CommandReceipt {
+  readonly stopped: boolean
+  readonly clearedQueue: readonly QueuedUserMessage[]
+}
 
 export interface AgentSessionStateSnapshot {
   readonly ref: AgentSessionRef
   readonly seq: number
   readonly summary: AgentSessionSummary
-  readonly state: PiChatSnapshot
+  readonly state: JsonSafe<PiChatSnapshot>
 }
 
 export interface AgentSessionConnection {

--- a/packages/agent/src/shared/gateway/types.ts
+++ b/packages/agent/src/shared/gateway/types.ts
@@ -1,0 +1,200 @@
+import type {
+  ChatAttachmentPayload,
+  ChatModelSelection,
+  CommandReceipt as PiCommandReceipt,
+  PiChatSnapshot,
+  QueueClearReceipt as PiQueueClearReceipt,
+  QueuedUserMessage,
+  StopReceipt as PiStopReceipt,
+  ThinkingLevel,
+} from '../chat'
+import type { AgentSessionEvent } from './events'
+
+export type WorkspaceScopeId = string
+export type AuthSubjectId = string
+
+export type JsonPrimitive = string | number | boolean | null
+export type JsonValue =
+  | JsonPrimitive
+  | readonly JsonValue[]
+  | { readonly [key: string]: JsonValue }
+
+/** Maps unknown event leaves onto the JSON transport boundary. */
+export type JsonSafe<T> = unknown extends T
+  ? JsonValue
+  : T extends JsonPrimitive
+    ? T
+    : T extends (...args: readonly never[]) => unknown
+      ? never
+      : T extends readonly (infer U)[]
+        ? readonly JsonSafe<U>[]
+        : T extends object
+          ? { readonly [K in keyof T]: JsonSafe<T[K]> }
+          : never
+
+/** Verified identity facts returned only by the app-owned verifier. */
+export interface VerifiedAgentScopeClaim {
+  readonly workspaceScopeId: WorkspaceScopeId
+  readonly authSubjectId: AuthSubjectId
+}
+
+declare const authorizedAgentScope: unique symbol
+
+/**
+ * Issuer-owned runtime capability. It is deliberately not a transport DTO and
+ * must be checked by issuer identity and current membership on every use.
+ */
+export interface AuthorizedAgentScope {
+  readonly workspaceScopeId: WorkspaceScopeId
+  readonly authSubjectId: AuthSubjectId
+  readonly [authorizedAgentScope]: true
+}
+
+export interface AgentScopeVerifier {
+  verify(scope: AuthorizedAgentScope): Promise<VerifiedAgentScopeClaim>
+}
+
+export interface AgentSessionRef {
+  readonly agentTypeId: string
+  readonly sessionId: string
+}
+
+export interface AgentSummary {
+  readonly agentTypeId: string
+  readonly label: string
+  readonly description?: string
+  readonly definition?: {
+    readonly version: string
+    readonly digest: string
+  }
+}
+
+export interface ListAgentsInput {
+  readonly scope: AuthorizedAgentScope
+}
+
+export interface AuthorizedAgentSessionQuery {
+  readonly scope: AuthorizedAgentScope
+  readonly agentTypeId?: string
+  readonly cursor?: string
+  readonly limit?: number
+}
+
+export type AgentSessionActivity = 'idle' | 'running' | 'aborting' | 'error'
+
+export interface AgentSessionSummary {
+  readonly ref: AgentSessionRef
+  readonly title: string
+  readonly status: AgentSessionActivity
+  readonly createdAt: number
+  readonly updatedAt: number
+}
+
+export interface AgentSessionPage {
+  readonly sessions: readonly AgentSessionSummary[]
+  readonly nextCursor?: string
+}
+
+export interface CreateAgentSessionInput {
+  readonly scope: AuthorizedAgentScope
+  readonly agentTypeId: string
+  readonly requestId: string
+  readonly title?: string
+}
+
+export interface ConnectAgentSessionInput {
+  readonly scope: AuthorizedAgentScope
+  readonly ref: AgentSessionRef
+  readonly cursor?: number
+}
+
+export interface ReadAgentSessionStateInput {
+  readonly scope: AuthorizedAgentScope
+  readonly ref: AgentSessionRef
+}
+
+export interface RenameAgentSessionInput {
+  readonly scope: AuthorizedAgentScope
+  readonly ref: AgentSessionRef
+  readonly requestId: string
+  readonly title: string
+}
+
+export interface DeleteAgentSessionInput {
+  readonly scope: AuthorizedAgentScope
+  readonly ref: AgentSessionRef
+  readonly requestId: string
+}
+
+export interface AgentPromptCommand {
+  readonly kind: 'prompt'
+  readonly requestId: string
+  readonly clientNonce: string
+  readonly content: string
+  readonly displayContent?: string
+  readonly model?: ChatModelSelection
+  readonly thinkingLevel?: ThinkingLevel
+  readonly attachments?: readonly ChatAttachmentPayload[]
+}
+
+export interface AgentFollowUpCommand {
+  readonly kind: 'followup'
+  readonly requestId: string
+  readonly clientNonce: string
+  readonly content: string
+  readonly displayContent?: string
+  readonly clientSeq: number
+}
+
+export type IdempotentAgentSend = AgentPromptCommand | AgentFollowUpCommand
+
+export interface IdempotentAgentControl {
+  readonly requestId: string
+}
+
+export interface IdempotentQueueClear extends IdempotentAgentControl {
+  readonly clientNonce?: string
+  readonly clientSeq?: number
+}
+
+export type CommandReceipt = PiCommandReceipt
+
+export interface AgentSendReceipt extends CommandReceipt {
+  readonly disposition: 'prompt' | 'followup'
+  readonly clientNonce: string
+  readonly duplicate?: boolean
+  readonly clientSeq?: number
+}
+
+export type QueueClearReceipt = PiQueueClearReceipt
+export type StopReceipt = PiStopReceipt
+
+export interface AgentSessionStateSnapshot {
+  readonly ref: AgentSessionRef
+  readonly seq: number
+  readonly summary: AgentSessionSummary
+  readonly state: PiChatSnapshot
+}
+
+export interface AgentSessionConnection {
+  readonly ref: AgentSessionRef
+  readonly events: AsyncIterable<AgentSessionEvent>
+  send(input: IdempotentAgentSend): Promise<AgentSendReceipt>
+  interrupt(input: IdempotentAgentControl): Promise<CommandReceipt>
+  stop(input: IdempotentAgentControl): Promise<StopReceipt>
+  clearQueue(input: IdempotentQueueClear): Promise<QueueClearReceipt>
+  close(): Promise<void>
+}
+
+export interface AgentGateway {
+  listAgents(input: ListAgentsInput): Promise<readonly AgentSummary[]>
+  listSessions(input: AuthorizedAgentSessionQuery): Promise<AgentSessionPage>
+  createSession(input: CreateAgentSessionInput): Promise<AgentSessionRef>
+  connectSession(input: ConnectAgentSessionInput): Promise<AgentSessionConnection>
+  readSessionState(input: ReadAgentSessionStateInput): Promise<AgentSessionStateSnapshot>
+  renameSession(input: RenameAgentSessionInput): Promise<AgentSessionSummary>
+  deleteSession(input: DeleteAgentSessionInput): Promise<void>
+  close(): Promise<void>
+}
+
+export type { QueuedUserMessage }

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -162,6 +162,44 @@ export {
 } from './agentPluginEvents'
 export type { CommandNotifyPayload } from './agentPluginEvents'
 export {
+  AGENT_GATEWAY_ERROR_CODES,
+  AgentGatewayError,
+  AgentGatewayErrorCode,
+} from './gateway/errors'
+export type { AgentGatewayErrorDTO } from './gateway/errors'
+export type {
+  AgentFollowUpCommand,
+  AgentGateway,
+  AgentPromptCommand,
+  AgentScopeVerifier,
+  AgentSendReceipt,
+  AgentSessionActivity,
+  AgentSessionConnection,
+  AgentSessionPage,
+  AgentSessionRef,
+  AgentSessionStateSnapshot,
+  AgentSessionSummary,
+  AgentSummary,
+  AuthSubjectId,
+  AuthorizedAgentScope,
+  AuthorizedAgentSessionQuery,
+  ConnectAgentSessionInput,
+  CreateAgentSessionInput,
+  DeleteAgentSessionInput,
+  IdempotentAgentControl,
+  IdempotentAgentSend,
+  IdempotentQueueClear,
+  JsonPrimitive,
+  JsonSafe,
+  JsonValue,
+  ListAgentsInput,
+  ReadAgentSessionStateInput,
+  RenameAgentSessionInput,
+  VerifiedAgentScopeClaim,
+  WorkspaceScopeId,
+} from './gateway/types'
+export type { AgentSessionEvent } from './gateway/events'
+export {
   OpaqueShareLocatorIdSchema,
   ShareEntryProvenanceSchema,
   ShareEntryV1Schema,

--- a/packages/agent/tsup.config.ts
+++ b/packages/agent/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 const EXTERNALS = ["react", "react-dom"];
-const DEV_BUNDLE_EXTERNALS = ["@vitejs/plugin-react", "@babel/core"];
+const DEV_BUNDLE_EXTERNALS = ["@vitejs/plugin-react", "@babel/core", "vitest"];
 
 export default defineConfig({
   entry: {
@@ -9,6 +9,7 @@ export default defineConfig({
     "core/index": "src/core/index.ts",
     "server/index": "src/server/index.ts",
     "server/pi-session-readability": "src/server/harness/pi-coding-agent/sessionReadability.ts",
+    "server/agent-host/testing/gatewayConformance": "src/server/agent-host/testing/gatewayConformance.ts",
     "server/worker/index": "src/server/worker/index.ts",
     "front/index": "src/front/index.ts",
     "eval/index": "src/eval/index.ts",


### PR DESCRIPTION
## Summary
- freeze the placement-independent AgentGateway v0 shared contract and stable errors
- add server-only admission/request-ledger contracts and reusable Level-B conformance
- publish the conformance helper and enforce DTO/public-export discipline

## Scope
G1 contract/conformance only. No production runtime behavior changes and no Level-D durability, immutable snapshot registry, or recursive remote-wire validator.

## Stack
Targets `issue-909/agent-gateway-v0`; this bead does not merge directly to `main`.

## Validation
See the current-head proof-of-work comment for exact commands, results, named skips, review dispositions, and rollback.
