### PR TITLE
feat(workspace): surface handover artifacts

### DIFF
--- a/packages/workspace/src/app/front/HandoverTimelineCard.tsx
+++ b/packages/workspace/src/app/front/HandoverTimelineCard.tsx
@@ -1,0 +1,43 @@
+"use client"
+
+import { useState } from "react"
+import { CheckCircle2 } from "lucide-react"
+import { HumanArtifactList } from "../../front/components/HumanArtifactList"
+import { openHumanArtifact } from "../../front/artifacts/openHumanArtifact"
+import { useWorkspaceShellCapabilities } from "../../shared/plugins/workspaceShellCapabilities"
+import type { ProjectedHandover } from "../../shared/artifacts"
+
+export function HandoverTimelineCard({
+  handover,
+  sessionId,
+}: {
+  handover: ProjectedHandover
+  sessionId: string
+}) {
+  const shell = useWorkspaceShellCapabilities()
+  const [unavailableIds, setUnavailableIds] = useState<ReadonlySet<string>>(() => new Set())
+
+  return (
+    <section
+      data-boring-workspace-part="handover-card"
+      data-handover-id={handover.id}
+      className="mt-2 rounded-lg border border-border/50 bg-card/40 p-2.5"
+      aria-label="Run deliverables"
+    >
+      <div className="mb-1.5 flex items-center gap-1.5 px-1 text-muted-foreground">
+        <CheckCircle2 className="size-3.5 text-emerald-600 dark:text-emerald-400" strokeWidth={1.75} aria-hidden="true" />
+        <h3 className="text-xs font-medium">Deliverables</h3>
+        <span className="ml-auto text-xs">{handover.artifacts.length} {handover.artifacts.length === 1 ? "item" : "items"}</span>
+      </div>
+      <HumanArtifactList
+        artifacts={handover.artifacts}
+        unavailableArtifactIds={unavailableIds}
+        onOpen={(artifact) => {
+          const result = openHumanArtifact(shell, artifact, { sessionId })
+          if (result.success) return
+          setUnavailableIds((current) => new Set([...current, artifact.id]))
+        }}
+      />
+    </section>
+  )
+}

--- a/packages/workspace/src/app/front/PluginAppLeftHost.tsx
+++ b/packages/workspace/src/app/front/PluginAppLeftHost.tsx
@@ -69,12 +69,14 @@ export function PluginAppLeftOverlayHost({
   onClose,
   headerInsetStart,
   headerInsetEnd,
+  params,
 }: {
   plugins: readonly CapturedFrontPlugin[]
   activeOverlay: AppLeftOverlayId
   onClose: () => void
   headerInsetStart?: boolean
   headerInsetEnd?: boolean
+  params?: Readonly<Record<string, string>>
 }): ReactNode {
   if (!activeOverlay) return null
   const entry = plugins
@@ -87,7 +89,7 @@ export function PluginAppLeftOverlayHost({
     createElement(
       PluginErrorBoundary,
       { pluginId: entry.plugin.id, contributionKind: "app-left-action", contributionId: entry.action.id },
-      createElement(entry.action.overlay, { onClose }),
+      createElement(entry.action.overlay, { onClose, params }),
     ),
   )
 }

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -2,10 +2,13 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType, 
 import { Plug, Sparkles } from "lucide-react"
 import {
   PiChatPanel as DefaultPiChatPanel,
+  EphemeralSessionCoordinator,
   usePiSessions as useDefaultPiSessions,
   searchPiSessions,
   type SlashCommand,
   type ToolRendererOverrides,
+  type EphemeralSessionCoordinatorApi,
+  type MessageFooterProjectionItem,
 } from "@hachej/boring-agent/front"
 import { WorkspaceProvider, type WorkspaceProviderProps } from "../../front/provider/WorkspaceProvider"
 import { ChatLayout, TopBar, ThemeToggle, type ChatLayoutProps } from "../../front/layout"
@@ -19,6 +22,8 @@ import type {
 } from "../../front/chrome/artifact-surface/SurfaceShell"
 import { SkillsPage } from "../../front/chrome/skills/SkillsPage"
 import { WorkspaceShellCapabilitiesProvider } from "../../front/shell/WorkspaceShellCapabilitiesContext"
+import { HandoverTimelineCard } from "./HandoverTimelineCard"
+import { projectChatHandovers } from "./handoverChatProjection"
 import { useWorkspaceShellCapabilitiesHost } from "./WorkspaceShellCapabilitiesHost"
 import { PluginsOverlay } from "../../front/chrome/plugins/PluginsOverlay"
 import { AppLeftPane } from "../../front/layout/plugin-tabs/AppLeftPane"
@@ -36,6 +41,7 @@ import {
 } from "./localStorageSessions"
 import { WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT } from "../../front/agentPlugins/reloadEvent"
 import { WorkspaceBackgroundBoot } from "./WorkspaceBackgroundBoot"
+import { WORKSPACE_OPEN_APP_LEFT_OVERLAY_EVENT, appLeftOverlayRequestFromEvent } from "../../shared/plugins/appLeftOverlay"
 import { ChatSessionTransitionState, WorkbenchWarmupOverlay } from "./WorkspaceAgentStatusStates"
 import { WorkspaceUiStateSync } from "./WorkspaceUiStateSync"
 import { PluginAppLeftOverlayHost, assertUniqueAppLeftActionIds, pluginAppLeftActionIds, usePluginAppLeftActions, type AppLeftOverlayId } from "./PluginAppLeftHost"
@@ -57,6 +63,7 @@ interface PendingCreatePane {
 export interface WorkspaceAgentSession {
   id: string
   title?: string | null
+  createdAt?: string | number
   updatedAt?: string | number
   turnCount?: number
 }
@@ -75,6 +82,10 @@ export interface WorkspaceAgentSessionsApi<
   switch: (id: string) => void
   create: (input?: { title?: string }) => void | Promise<unknown>
   delete: (id: string) => void | Promise<unknown>
+  materializeLocal?: (localId: string, session: { id: string; title: string; createdAt: string; updatedAt: string; turnCount: number }) => void | Promise<void>
+  /** Explicit browser-local IDs for legacy/injected stores without a coordinator. */
+  ephemeralSessionIds?: readonly string[]
+  ephemeralSessionCoordinator?: EphemeralSessionCoordinatorApi
   loadMore?: () => void | Promise<unknown>
   refresh?: (options?: { background?: boolean }) => void | Promise<unknown>
 }
@@ -88,6 +99,7 @@ export type UseWorkspaceAgentSessions<
   apiBaseUrl?: string
   enabled?: boolean
   refreshKey?: unknown
+  nativeSessionStartEnabled?: boolean
 }) => WorkspaceAgentSessionsApi<TSession>
 
 export type WorkspaceAgentLayout = "classic" | "plugin-tabs"
@@ -240,6 +252,8 @@ export interface WorkspaceAgentFrontProps<
    * should pass `false`. Defaults to `true` (dev/playground default).
    */
   hotReloadEnabled?: boolean
+  /** Explicit direct/local capability for browser-local chats to materialize on first send. */
+  nativeSessionStartEnabled?: boolean
   extraPanels?: string[]
   extraCommands?: SlashCommand[]
   provisionWorkspace?: boolean
@@ -361,7 +375,7 @@ const emptySurfaceSnapshot: SurfaceShellSnapshot = {
   activeTab: null,
 }
 
-function useDefaultWorkspacePiSessions(options: Parameters<UseWorkspaceAgentSessions>[0]): WorkspaceAgentSessionsApi {
+function useDefaultWorkspacePiSessions(options: Parameters<UseWorkspaceAgentSessions>[0] & { nativeSessionStartEnabled?: boolean }): WorkspaceAgentSessionsApi {
   const workspaceId = options.workspaceId ?? workspaceIdFromHeaders(options.requestHeaders) ?? options.storageKey
   const piSessions = useDefaultPiSessions({
     apiBaseUrl: options.apiBaseUrl,
@@ -370,6 +384,7 @@ function useDefaultWorkspacePiSessions(options: Parameters<UseWorkspaceAgentSess
     requestHeaders: options.requestHeaders,
     enabled: options.enabled,
     connectActiveSession: false,
+    localCreateUntilPrompt: options.nativeSessionStartEnabled === true,
     refreshKey: options.refreshKey,
   })
   return { ...piSessions, workspaceId: piSessions.dataStorageScope }
@@ -431,15 +446,20 @@ function readStoredChatPaneState(storageKey: string, workspaceId: string): ChatP
   }
 }
 
-function writeStoredChatPaneState(storageKey: string, state: ChatPaneState): void {
+function writeStoredChatPaneState(
+  storageKey: string,
+  state: ChatPaneState,
+  isEphemeralSession: (id: string) => boolean,
+): void {
   try {
-    if (state.ids.length === 0) {
+    const ids = state.ids.filter((id) => !isEphemeralSession(id))
+    if (ids.length === 0) {
       globalThis.localStorage?.removeItem(storageKey)
       return
     }
     globalThis.localStorage?.setItem(
       storageKey,
-      JSON.stringify({ ids: state.ids, activeId: state.activeId }),
+      JSON.stringify({ ids, activeId: ids.includes(state.activeId ?? '') ? state.activeId : ids[0] }),
     )
   } catch {
     // Best-effort persistence only.
@@ -460,13 +480,27 @@ function readStoredPinnedSessions(storageKey: string, workspaceId: string): { wo
   }
 }
 
-function writeStoredPinnedSessions(storageKey: string, ids: string[]): void {
+function useWorkspaceEphemeralCoordinator(requestScope: string): EphemeralSessionCoordinator {
+  const coordinator = useMemo(() => new EphemeralSessionCoordinator(requestScope), [requestScope])
+  useEffect(() => {
+    coordinator.activate()
+    return () => coordinator.dispose()
+  }, [coordinator])
+  return coordinator
+}
+
+function writeStoredPinnedSessions(
+  storageKey: string,
+  ids: string[],
+  isEphemeralSession: (id: string) => boolean,
+): void {
   try {
-    if (ids.length === 0) {
+    const durableIds = ids.filter((id) => !isEphemeralSession(id))
+    if (durableIds.length === 0) {
       globalThis.localStorage?.removeItem(storageKey)
       return
     }
-    globalThis.localStorage?.setItem(storageKey, JSON.stringify({ ids }))
+    globalThis.localStorage?.setItem(storageKey, JSON.stringify({ ids: durableIds }))
   } catch {
     // Best-effort persistence only.
   }
@@ -539,6 +573,7 @@ export function WorkspaceAgentFront<
   chatParams,
   externalPlugins,
   hotReloadEnabled,
+  nativeSessionStartEnabled = false,
   frontPluginHotReload,
   extraPanels,
   extraCommands,
@@ -608,6 +643,7 @@ export function WorkspaceAgentFront<
     (shellPersistenceEnabled ? readStoredChatPaneState(chatPaneStorageKey, workspaceId) : null)
       ?? { workspaceId, ids: [], activeId: null },
   )
+  const ephemeralSessionCoordinatorRef = useRef<EphemeralSessionCoordinatorApi | undefined>(undefined)
   const [flashChatPane, setFlashChatPane] = useState<{ workspaceId: string; id: string } | null>(null)
   useEffect(() => {
     if (!flashChatPane) return
@@ -634,14 +670,20 @@ export function WorkspaceAgentFront<
       const ids = current.includes(sessionId)
         ? current.filter((id) => id !== sessionId)
         : [sessionId, ...current]
-      if (shellPersistenceEnabled) writeStoredPinnedSessions(pinnedStorageKey, ids)
+      if (shellPersistenceEnabled) {
+        writeStoredPinnedSessions(pinnedStorageKey, ids, (id) => ephemeralSessionCoordinatorRef.current?.isEphemeralSession(id) === true)
+      }
       return { workspaceId, ids }
     })
   }, [pinnedStorageKey, shellPersistenceEnabled, workspaceId])
   useEffect(() => {
     if (!shellPersistenceEnabled) return
     if (chatPaneState.workspaceId !== workspaceId) return
-    writeStoredChatPaneState(chatPaneStorageKey, chatPaneState)
+    writeStoredChatPaneState(
+      chatPaneStorageKey,
+      chatPaneState,
+      (id) => ephemeralSessionCoordinatorRef.current?.isEphemeralSession(id) === true,
+    )
   }, [chatPaneState, chatPaneStorageKey, shellPersistenceEnabled, workspaceId])
   useEffect(() => {
     setChatPaneState((previous) => {
@@ -658,12 +700,16 @@ export function WorkspaceAgentFront<
   const shouldUseRemoteSessions = !chatPanelProp || Boolean(useSessionsProp)
   const remoteSessionHookEnabled = shouldUseRemoteSessions && provisionWorkspace !== false
   const remoteSessionActionsUnavailable = () => undefined
+  const compatibilityEphemeralCoordinator = useWorkspaceEphemeralCoordinator(
+    `${apiBaseUrl ?? ''}\n${workspaceId}\n${JSON.stringify(resolvedRequestHeaders)}`,
+  )
   const remoteSessionApi = useSessions({
     requestHeaders: resolvedRequestHeaders,
     storageKey: resolvedSessionStorageKey,
     workspaceId,
     apiBaseUrl,
     enabled: remoteSessionHookEnabled,
+    nativeSessionStartEnabled,
   })
   const [remoteSessionSnapshot, setRemoteSessionSnapshot] = useState<{
     workspaceId: string
@@ -708,6 +754,44 @@ export function WorkspaceAgentFront<
       ? remoteSessionSnapshot.activeSessionId
       : null
   const sessionApi = shouldUseRemoteSessions && (remoteSessionsAvailable || remoteSessionsHaveStaleData) ? remoteSessionApi : undefined
+  const compatibilityEphemeralIds = nativeSessionStartEnabled ? sessionApi?.ephemeralSessionIds ?? EMPTY_STRING_LIST : EMPTY_STRING_LIST
+  // Registration during render lets child pane effects see explicit local IDs
+  // on their first mount. Repeat it after lifecycle attachment so a request
+  // scope remains synchronized whenever React replays effects.
+  for (const localId of compatibilityEphemeralIds) compatibilityEphemeralCoordinator.register(localId)
+  useEffect(() => {
+    for (const localId of compatibilityEphemeralIds) compatibilityEphemeralCoordinator.register(localId)
+  }, [compatibilityEphemeralCoordinator, compatibilityEphemeralIds])
+  const effectiveEphemeralCoordinator = sessionApi?.ephemeralSessionCoordinator ?? compatibilityEphemeralCoordinator
+  ephemeralSessionCoordinatorRef.current = effectiveEphemeralCoordinator
+  useEffect(() => effectiveEphemeralCoordinator.subscribe(({ localId, session }) => {
+    // Workspace owns pane collection identity. The coordinator is the single
+    // adoption event, so every split is replaced together without a second
+    // materialization callback or an ID-prefix inference branch.
+    setChatPaneState((previous) => {
+      if (previous.workspaceId !== workspaceId || !previous.ids.includes(localId)) return previous
+      const ids = [...new Set(previous.ids.map((id) => id === localId ? session.id : id))]
+      return {
+        workspaceId,
+        ids,
+        activeId: previous.activeId === localId ? session.id : previous.activeId,
+      }
+    })
+    setPinnedState((previous) => {
+      if (previous.workspaceId !== workspaceId || !previous.ids.includes(localId)) return previous
+      const ids = [...new Set(previous.ids.map((id) => id === localId ? session.id : id))]
+      if (shellPersistenceEnabled) {
+        writeStoredPinnedSessions(pinnedStorageKey, ids, (id) => effectiveEphemeralCoordinator.isEphemeralSession(id))
+      }
+      return { workspaceId, ids }
+    })
+    if (sessionApi?.ephemeralSessionCoordinator !== effectiveEphemeralCoordinator) {
+      // Legacy stores use the compatibility coordinator. Materialization may
+      // only replace the collection, so switch after it resolves to retire the
+      // local active ID as well.
+      void Promise.resolve(sessionApi?.materializeLocal?.(localId, session)).then(() => sessionApi?.switch(session.id))
+    }
+  }), [effectiveEphemeralCoordinator, pinnedStorageKey, sessionApi, shellPersistenceEnabled, workspaceId])
   const hasExplicitSessionProps =
     sessions !== undefined ||
     activeSessionId !== undefined ||
@@ -903,7 +987,32 @@ export function WorkspaceAgentFront<
     defaultLeftOverlay,
     shellPersistenceEnabled,
   ) as [AppLeftOverlayId, (next: AppLeftOverlayId | ((previous: AppLeftOverlayId) => AppLeftOverlayId)) => void]
+  const [leftOverlayRequest, setLeftOverlayRequest] = useState<{ id: string; params?: Readonly<Record<string, string>> } | undefined>()
   const pluginOverlayActionIds = useMemo(() => pluginAppLeftActionIds(capturedPlugins), [capturedPlugins])
+  const isAppLeftOverlayAvailable = useCallback((id: string) => (
+    pluginOverlayActionIds.has(id)
+    || (appLeftOverlayActions?.some((action) => action.id === id) ?? false)
+    || (id === "skills" && skillsActionEnabled)
+    || (id === "plugins" && pluginsActionEnabled)
+  ), [appLeftOverlayActions, pluginOverlayActionIds, pluginsActionEnabled, skillsActionEnabled])
+  useEffect(() => {
+    if (leftOverlayRequest && leftOverlay !== leftOverlayRequest.id) setLeftOverlayRequest(undefined)
+  }, [leftOverlay, leftOverlayRequest])
+  useEffect(() => {
+    const onOpenAppLeftOverlay = (event: Event) => {
+      const request = appLeftOverlayRequestFromEvent(event)
+      if (!request) return
+      const { id } = request
+      const customOverlayAvailable = appLeftOverlayActions?.some((action) => action.id === id) ?? false
+      const builtInAvailable = (id === "skills" && skillsActionEnabled) || (id === "plugins" && pluginsActionEnabled)
+      if (pluginOverlayActionIds.has(id) || customOverlayAvailable || builtInAvailable) {
+        setLeftOverlayRequest({ id, params: request.params })
+        setLeftOverlay(id)
+      }
+    }
+    window.addEventListener(WORKSPACE_OPEN_APP_LEFT_OVERLAY_EVENT, onOpenAppLeftOverlay)
+    return () => window.removeEventListener(WORKSPACE_OPEN_APP_LEFT_OVERLAY_EVENT, onOpenAppLeftOverlay)
+  }, [appLeftOverlayActions, pluginOverlayActionIds, pluginsActionEnabled, setLeftOverlay, skillsActionEnabled])
   useEffect(() => {
     const customOverlayActive = Boolean(leftOverlay && appLeftOverlayActions?.some((action) => action.id === leftOverlay))
     if (
@@ -928,6 +1037,7 @@ export function WorkspaceAgentFront<
     shellPersistenceEnabled,
   )
   const [surfaceReady, setSurfaceReady] = useState(false)
+  const [dockviewGeneration, setDockviewGeneration] = useState(0)
   const [workbenchLeftOpen, setWorkbenchLeftOpen] = useStoredBooleanState(
     `${shellStorageKey}:workbenchLeftOpen`,
     defaultWorkbenchLeftOpen ?? false,
@@ -1027,6 +1137,11 @@ export function WorkspaceAgentFront<
     for (const op of ops) op(api)
   }, [resolvedSurfaceStorageKey])
 
+  const handleSurfaceUnavailable = useCallback(() => {
+    surfaceRef.current = null
+    setSurfaceReady(false)
+  }, [])
+
   const enqueueSurfaceOp = useCallback((run: (api: SurfaceShellApi) => void) => {
     pendingSurfaceOpsRef.current.push(run)
   }, [])
@@ -1042,6 +1157,12 @@ export function WorkspaceAgentFront<
     const ready = surfaceRef.current
     return ready?.key === surfaceKeyRef.current ? ready.api : null
   }, [])
+  const recoverSurface = useCallback<NonNullable<DispatchContext["recoverSurface"]>>((unavailable) => {
+    if (getSurface() !== unavailable) return
+    surfaceRef.current = null
+    setSurfaceReady(false)
+    setDockviewGeneration((generation) => generation + 1)
+  }, [getSurface])
   const isWorkbenchOpen = useCallback(() => surfaceOpenRef.current, [])
   const openWorkbench = useCallback(() => {
     surfaceOpenRef.current = true
@@ -1086,8 +1207,9 @@ export function WorkspaceAgentFront<
     openWorkbenchSources,
     closeWorkbench,
     enqueue: enqueueSurfaceOp,
+    recoverSurface,
     shouldOpenSurface,
-  }), [getSurface, isWorkbenchOpen, openWorkbench, openWorkbenchSources, closeWorkbench, enqueueSurfaceOp, shouldOpenSurface])
+  }), [getSurface, isWorkbenchOpen, openWorkbench, openWorkbenchSources, closeWorkbench, enqueueSurfaceOp, recoverSurface, shouldOpenSurface])
 
   const openWorkspacePanel = useCallback((panel?: OpenPanelConfig) => {
     surfaceOpenRef.current = true
@@ -1478,9 +1600,20 @@ export function WorkspaceAgentFront<
       storageScope: workspaceId,
       requestHeaders: resolvedRequestHeaders,
       remoteSessionOptions: chatRemoteSessionOptions,
+      ephemeralSessionCoordinator: effectiveEphemeralCoordinator,
       showSessions: false,
+      nativeSessionStartEnabled,
       onReloadAgentPlugins: chatParams?.onReloadAgentPlugins ?? (() => reloadAgentPluginsForSession(sessionId)),
       toolRenderers: { ...pluginToolRenderers, ...(chatToolRenderers ?? {}) },
+      messageFooterProjection: (items: readonly MessageFooterProjectionItem[]) => {
+        const projected = projectChatHandovers(items.map((item) => item.message))
+        return new Map(items.flatMap((item) => {
+          const handover = projected.get(item.message)
+          return handover
+            ? [[item.key, <HandoverTimelineCard key={handover.id} handover={handover} sessionId={sessionId} />] as const]
+            : []
+        }))
+      },
       bridgeEndpoint: bridgeEnabled ? bridgeEndpoint : null,
       surfaceDispatch,
       extraCommands,
@@ -1514,7 +1647,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [apiBaseUrl, chatParams, chatRemoteSessionOptions, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, sessionApi, workspaceId],
+    [apiBaseUrl, chatParams, chatRemoteSessionOptions, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, nativeSessionStartEnabled, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, effectiveEphemeralCoordinator, sessionApi, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionId),
@@ -1564,21 +1697,25 @@ export function WorkspaceAgentFront<
     storageKey: resolvedSurfaceStorageKey,
     defaultLeftTab: defaultWorkbenchLeftTab,
     initialPanels: surfaceInitialPanels,
+    dockviewGeneration,
     extraPanels: shellExtraPanels,
     onReloadAgentPlugins: () => reloadAgentPluginsMessageForSession(effectiveActiveSessionId ?? chatSessionId),
     onReady: handleSurfaceReady,
+    onUnavailable: handleSurfaceUnavailable,
     onChange: handleSurfaceChange,
     onClose: closeWorkbench,
     showCloseAction: false,
   }), [
     closeWorkbench,
     defaultWorkbenchLeftTab,
+    dockviewGeneration,
     surfaceInitialPanels,
     reloadAgentPluginsMessageForSession,
     effectiveActiveSessionId,
     chatSessionId,
     handleSurfaceChange,
     handleSurfaceReady,
+    handleSurfaceUnavailable,
     resolvedSurfaceStorageKey,
     shellExtraPanels,
     setSurfaceOpen,
@@ -1638,6 +1775,8 @@ export function WorkspaceAgentFront<
     openChatPane,
     surfaceDispatch,
     onDockOverlay: () => setLeftOverlay(null),
+    isAppLeftOverlayAvailable,
+    ephemeralSessionCoordinator: effectiveEphemeralCoordinator,
   })
   const createChatSessionInPopover = useCallback(() => {
     setLeftOverlay(null)
@@ -1731,6 +1870,7 @@ export function WorkspaceAgentFront<
     onClose: () => setLeftOverlay(null),
     headerInsetStart: appLeftPaneCollapsed,
     headerInsetEnd: !surfaceOpen,
+    params: leftOverlayRequest?.id === leftOverlay ? leftOverlayRequest.params : undefined,
   })
   const customLeftOverlayNode = useMemo(() => {
     const overlay = appLeftOverlayActions?.find((action) => action.id === leftOverlay)

--- a/packages/workspace/src/app/front/WorkspaceShellCapabilitiesHost.tsx
+++ b/packages/workspace/src/app/front/WorkspaceShellCapabilitiesHost.tsx
@@ -1,11 +1,18 @@
 "use client"
 
-import { useEffect, useState, type ReactNode } from "react"
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react"
+import type { EphemeralSessionCoordinatorApi } from "@hachej/boring-agent/front"
 import type { DispatchContext } from "../../front/bridge"
 import { DetachedChatPopover } from "../../front/chrome/chat/DetachedChatPopover"
 import type { ChatPanelHostProps } from "../../front/chrome/chat/ChatPanelHost"
 import type { WorkspaceShellCapabilities } from "../../front/shell/WorkspaceShellCapabilitiesContext"
-import { useWorkspaceShellCapabilitiesController } from "./useWorkspaceShellCapabilitiesController"
+import { useWorkspaceShellCapabilitiesController, type FloatingChatSession } from "./useWorkspaceShellCapabilitiesController"
+
+export function fullChatSessionIdFromEvent(event: Event): string | null {
+  const detail = (event as CustomEvent<unknown>).detail as { sessionId?: unknown } | undefined
+  const sessionId = typeof detail?.sessionId === "string" ? detail.sessionId.trim() : ""
+  return sessionId && sessionId.length <= 128 ? sessionId : null
+}
 
 export interface WorkspaceShellCapabilitiesHostResult {
   floatingChatNode: ReactNode
@@ -22,6 +29,8 @@ export function useWorkspaceShellCapabilitiesHost({
   openChatPane,
   surfaceDispatch,
   onDockOverlay,
+  isAppLeftOverlayAvailable,
+  ephemeralSessionCoordinator,
 }: {
   appLeftPaneCollapsed: boolean
   workspaceId: string
@@ -32,12 +41,49 @@ export function useWorkspaceShellCapabilitiesHost({
   openChatPane: (sessionId: string) => void
   surfaceDispatch: DispatchContext
   onDockOverlay?: () => void
+  isAppLeftOverlayAvailable: (id: string) => boolean
+  ephemeralSessionCoordinator: EphemeralSessionCoordinatorApi
 }): WorkspaceShellCapabilitiesHostResult {
-  const [floatingChatSession, setFloatingChatSession] = useState<{ sessionId: string; title?: string; initialDraft?: string; composingEnabled?: boolean } | null>(null)
+  const [floatingChatSession, setFloatingChatSession] = useState<FloatingChatSession | null>(null)
+  const materializationCallbacks = useRef(new Map<string, (sessionId: string) => void | Promise<void>>())
   useEffect(() => {
+    materializationCallbacks.current.clear()
     setFloatingChatSession(null)
   }, [workspaceId])
-  const shellCapabilities = useWorkspaceShellCapabilitiesController({ setFloatingChatSession, openChatPane, surfaceDispatch })
+  const registerBrowserLocalSession = useCallback((localId: string, callback?: (sessionId: string) => void | Promise<void>) => {
+    ephemeralSessionCoordinator.register(localId)
+    if (callback) materializationCallbacks.current.set(localId, callback)
+  }, [ephemeralSessionCoordinator])
+  useEffect(() => ephemeralSessionCoordinator.subscribe(({ localId, session }) => {
+    const callback = materializationCallbacks.current.get(localId)
+    const adoptFloatingSession = () => setFloatingChatSession((current) => current?.browserLocalId === localId
+      ? { ...current, sessionId: session.id, browserLocalId: undefined }
+      : current)
+    if (!callback) {
+      adoptFloatingSession()
+      return
+    }
+    void Promise.resolve(callback(session.id)).then(() => {
+      materializationCallbacks.current.delete(localId)
+      adoptFloatingSession()
+    }).catch(async (error) => {
+      materializationCallbacks.current.delete(localId)
+      setFloatingChatSession((current) => current?.browserLocalId === localId ? null : current)
+      try {
+        await ephemeralSessionCoordinator.discard(localId)
+      } catch {
+        // The binding failed closed; deletion is best-effort and the original error is retained for diagnostics.
+      }
+      console.error("Failed to persist browser-local chat handoff", error)
+    })
+  }), [ephemeralSessionCoordinator])
+  const shellCapabilities = useWorkspaceShellCapabilitiesController({
+    setFloatingChatSession,
+    openChatPane,
+    surfaceDispatch,
+    registerBrowserLocalSession,
+    isAppLeftOverlayAvailable,
+  })
 
   useEffect(() => {
     const onOpenDetachedChat = (event: Event) => {
@@ -49,8 +95,36 @@ export function useWorkspaceShellCapabilitiesHost({
         ...(typeof detail.composingEnabled === "boolean" ? { composingEnabled: detail.composingEnabled } : {}),
       })
     }
+    const onOpenFullChat = (event: Event) => {
+      const sessionId = fullChatSessionIdFromEvent(event)
+      if (!sessionId) return
+      shellCapabilities.openFullChat(sessionId)
+    }
+    const onOpenBrowserLocalDetachedChat = (event: Event) => {
+      const detail = (event as CustomEvent<unknown>).detail as {
+        title?: unknown
+        initialDraft?: unknown
+        composingEnabled?: unknown
+        onNativeSessionPersisted?: unknown
+      } | undefined
+      if (!detail) return
+      shellCapabilities.openBrowserLocalDetachedChat({
+        ...(typeof detail.title === "string" ? { title: detail.title } : {}),
+        ...(typeof detail.initialDraft === "string" ? { initialDraft: detail.initialDraft } : {}),
+        ...(typeof detail.composingEnabled === "boolean" ? { composingEnabled: detail.composingEnabled } : {}),
+        ...(typeof detail.onNativeSessionPersisted === "function"
+          ? { onNativeSessionPersisted: detail.onNativeSessionPersisted as (sessionId: string) => void | Promise<void> }
+          : {}),
+      })
+    }
     window.addEventListener("boring-workspace:open-detached-chat", onOpenDetachedChat)
-    return () => window.removeEventListener("boring-workspace:open-detached-chat", onOpenDetachedChat)
+    window.addEventListener("boring-workspace:open-full-chat", onOpenFullChat)
+    window.addEventListener("boring-workspace:open-browser-local-detached-chat", onOpenBrowserLocalDetachedChat)
+    return () => {
+      window.removeEventListener("boring-workspace:open-detached-chat", onOpenDetachedChat)
+      window.removeEventListener("boring-workspace:open-full-chat", onOpenFullChat)
+      window.removeEventListener("boring-workspace:open-browser-local-detached-chat", onOpenBrowserLocalDetachedChat)
+    }
   }, [shellCapabilities])
 
   const floatingChatSessionId = floatingChatSession?.sessionId ?? null
@@ -71,8 +145,16 @@ export function useWorkspaceShellCapabilitiesHost({
       chatParams={floatingChatParams}
       initialPosition={{ left: appLeftPaneCollapsed ? 24 : effectiveAppLeftPaneWidth + 24, top: 72 }}
       composingEnabled={floatingChatSession?.composingEnabled ?? false}
-      onClose={() => setFloatingChatSession(null)}
+      onClose={() => {
+        const localId = floatingChatSession?.browserLocalId
+        if (localId) {
+          materializationCallbacks.current.delete(localId)
+          void ephemeralSessionCoordinator.discard(localId).catch(() => {})
+        }
+        setFloatingChatSession(null)
+      }}
       onDock={() => {
+        if (floatingChatSession?.browserLocalId) return
         openChatPane(floatingChatSessionId)
         setFloatingChatSession(null)
         onDockOverlay?.()

--- a/packages/workspace/src/app/front/__tests__/HandoverTimelineCard.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/HandoverTimelineCard.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { WorkspaceShellCapabilitiesProvider, type WorkspaceShellCapabilities } from "../../../shared/plugins/workspaceShellCapabilities"
+import { HandoverTimelineCard } from "../HandoverTimelineCard"
+
+const artifact = { id: "plan", surfaceKind: "workspace.open.path", target: "docs/plan.md", title: "Plan" }
+const handover = {
+  id: "handover:native-done",
+  runId: "u",
+  terminalEntryId: "native-done",
+  artifacts: [artifact],
+}
+
+function capabilities(openArtifact: WorkspaceShellCapabilities["openArtifact"]): WorkspaceShellCapabilities {
+  return {
+    openArtifact,
+    openDetachedChat: vi.fn(() => ({ success: false as const, reason: "open-failed" as const, message: "unused" })),
+    openFullChat: vi.fn(() => ({ success: false as const, reason: "open-failed" as const, message: "unused" })),
+    openInboxItem: vi.fn(() => ({ success: false as const, reason: "open-failed" as const, message: "unused" })),
+    openBrowserLocalDetachedChat: vi.fn(() => ({ success: false as const, reason: "open-failed" as const, message: "unused" })),
+  }
+}
+
+describe("HandoverTimelineCard", () => {
+  it("renders a distinct terminal card and routes explicit artifact opening through shell capabilities", async () => {
+    const user = userEvent.setup()
+    const openArtifact = vi.fn(() => ({ success: true as const }))
+    render(
+      <WorkspaceShellCapabilitiesProvider value={capabilities(openArtifact)}>
+        <HandoverTimelineCard handover={handover} sessionId="native-session" />
+      </WorkspaceShellCapabilitiesProvider>,
+    )
+
+    expect(screen.getByRole("region", { name: "Run deliverables" })).toHaveTextContent("1 item")
+    expect(screen.getByRole("heading", { name: "Deliverables" })).toHaveClass("text-xs")
+    expect(screen.getByText("docs/plan.md")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Open Plan" }))
+    expect(openArtifact).toHaveBeenCalledWith({ type: "surface", surfaceKind: "workspace.open.path", target: "docs/plan.md" }, {
+      sessionId: "native-session",
+      title: "Plan",
+      instanceId: "human-artifact:plan",
+    })
+  })
+
+  it("marks an artifact unavailable when its registered surface cannot open", async () => {
+    const user = userEvent.setup()
+    const openArtifact = vi.fn(() => ({ success: false as const, reason: "no-artifact" as const, message: "missing" }))
+    render(
+      <WorkspaceShellCapabilitiesProvider value={capabilities(openArtifact)}>
+        <HandoverTimelineCard handover={handover} sessionId="native-session" />
+      </WorkspaceShellCapabilitiesProvider>,
+    )
+    await user.click(screen.getByRole("button", { name: "Open Plan" }))
+    expect(screen.getByLabelText("Plan unavailable")).toHaveTextContent("Unavailable")
+  })
+})

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -7,7 +7,9 @@ import { UI_COMMAND_EVENT, type UiCommand } from "../../../front/bridge"
 import type { WorkspaceChatPanelProps } from "../../../front/chrome/chat/types"
 import type { PanelConfig } from "../../../front/registry/types"
 import { definePlugin } from "../../../shared/plugins/frontFactory"
+import { requestAppLeftOverlay } from "../../../shared/plugins/appLeftOverlay"
 import type { PluginProviderProps } from "../../../shared/plugins/types"
+import { EphemeralSessionCoordinator } from "@hachej/boring-agent/front"
 import { WorkspaceAgentFront } from "../WorkspaceAgentFront"
 
 type CapturedChatPanelProps = WorkspaceChatPanelProps & {
@@ -171,6 +173,93 @@ describe("WorkspaceAgentFront", () => {
 
     expect(MockEventSource.instances.filter((instance) => instance.url.includes("/api/v1/agent-plugins/events"))).toHaveLength(0)
     expect(captured?.hotReloadEnabled).toBe(false)
+  })
+
+  it("forwards explicit native first-send capability to both session and Pi chat composition", () => {
+    let sessionOptions: { nativeSessionStartEnabled?: boolean } | undefined
+    let panelProps: WorkspaceChatPanelProps | undefined
+    const CapturingChatPanel = (props: WorkspaceChatPanelProps) => {
+      panelProps = props
+      return <div>Chat panel</div>
+    }
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="direct-local-native"
+        nativeSessionStartEnabled
+        chatPanel={CapturingChatPanel}
+        useSessions={(options) => {
+          sessionOptions = options
+          return {
+            sessions: [{ id: "local-native", title: "New chat", createdAt: "", updatedAt: "", turnCount: 0 }],
+            activeSession: null,
+            activeSessionId: "local-native",
+            loading: false,
+            error: undefined,
+            ephemeralSessionIds: ['local-native'],
+            create: vi.fn(),
+            switch: vi.fn(),
+            delete: vi.fn(),
+          }
+        }}
+      />,
+    )
+
+    expect(sessionOptions?.nativeSessionStartEnabled).toBe(true)
+    expect(panelProps?.nativeSessionStartEnabled).toBe(true)
+    expect(panelProps?.remoteSessionOptions).toBeUndefined()
+    expect(panelProps?.ephemeralSessionCoordinator?.isEphemeralSession('local-native')).toBe(true)
+  })
+
+  it("atomically replaces every local pane id when the request-scoped coordinator adopts it", async () => {
+    let adopt: ((value: { localId: string; session: { id: string; title: string; createdAt: string; updatedAt: string; turnCount: number } }) => void) | undefined
+    const coordinator = {
+      register: vi.fn(),
+      discard: vi.fn(async () => {}),
+      discardNativeSession: vi.fn(),
+      isEphemeralSession: (id: string) => id === 'local-first',
+      phase: vi.fn(),
+      failedDraft: vi.fn(),
+      clearFailedDraft: vi.fn(),
+      subscribe: (listener: any) => {
+        adopt = listener
+        return () => { if (adopt === listener) adopt = undefined }
+      },
+      subscribeState: vi.fn(() => () => {}),
+      start: vi.fn(() => Promise.reject(new Error('not used by this pane-only test'))),
+      dispose: vi.fn(),
+    }
+    const sessions = [
+      { id: 'local-first', title: 'New chat' },
+      { id: 'pi-second', title: 'Second chat' },
+    ]
+    render(
+      <WorkspaceAgentFront
+        workspaceId="coordinator-adoption"
+        chatPanel={SessionIdChatPanel}
+        persistenceEnabled={false}
+        useSessions={() => ({
+          sessions,
+          activeSessionId: 'local-first',
+          activeSession: sessions[0],
+          loading: false,
+          create: vi.fn(),
+          switch: vi.fn(),
+          delete: vi.fn(),
+          ephemeralSessionCoordinator: coordinator,
+        })}
+      />,
+    )
+
+    await waitFor(() => expect(adopt).toBeDefined())
+    const native = { id: 'native-first', title: 'First chat', createdAt: '', updatedAt: '', turnCount: 1 }
+    // The source collection updates before notifying its host subscribers.
+    sessions.splice(0, 1, native)
+    await act(async () => {
+      adopt?.({ localId: 'local-first', session: native })
+    })
+
+    expect(visibleChatSessionIds()).toEqual(['native-first'])
   })
 
   it("keeps the chat shell in transition while remote sessions are still loading without an active session", () => {
@@ -394,6 +483,27 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.queryByLabelText("App navigation")).not.toBeInTheDocument()
     expect(document.querySelector('[data-boring-workspace-part="app-left-pane"]')).toBeNull()
     expect(screen.getByRole("button", { name: "Open app navigation" })).toBeInTheDocument()
+  })
+
+  it("opens only a registered app-left overlay requested by a plugin", async () => {
+    const overlayPlugin = definePlugin({
+      id: "event-overlay-plugin",
+      appLeftActions: [{ id: "event-tasks", label: "Event tasks", overlay: () => <div>Event task overlay</div> }],
+    })
+    render(
+      <WorkspaceAgentFront
+        workspaceId="plugin-tabs-event-overlay"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        plugins={[overlayPlugin]}
+        persistenceEnabled={false}
+      />,
+    )
+
+    expect(requestAppLeftOverlay("not-registered")).toBe(true)
+    expect(screen.queryByText("Event task overlay")).not.toBeInTheDocument()
+    expect(requestAppLeftOverlay("event-tasks")).toBe(true)
+    expect(await screen.findByText("Event task overlay")).toBeInTheDocument()
   })
 
   it("rejects plugin app-left actions that collide with built-in overlays", () => {
@@ -846,10 +956,10 @@ describe("WorkspaceAgentFront", () => {
     })
   })
 
-  it("restores the persisted pane layout on reload", async () => {
+  it("does not restore unsent local panes from persisted layout", async () => {
     localStorage.setItem(
       "boring-workspace:chat-panes:restore-panes",
-      JSON.stringify({ ids: ["s1", "s2"], activeId: "s2" }),
+      JSON.stringify({ ids: ["s1", "local-unsent", "s2"], activeId: "s2" }),
     )
     const sessions = [
       { id: "s1", title: "First session", updatedAt: Date.now() - 1_000 },
@@ -870,6 +980,33 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => {
       expect(visibleChatSessionIds()).toEqual(["s1", "s2"])
     })
+  })
+
+  it("does not persist an unsent local chat when it is pinned", async () => {
+    const coordinator = new EphemeralSessionCoordinator('unsent-pin')
+    coordinator.register('local-unsent')
+    render(
+      <WorkspaceAgentFront
+        workspaceId="unsent-pin"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        nativeSessionStartEnabled
+        useSessions={() => ({
+          sessions: [{ id: 'local-unsent', title: 'New chat', updatedAt: Date.now() }],
+          activeSessionId: 'local-unsent',
+          loading: false,
+          error: undefined,
+          ephemeralSessionCoordinator: coordinator,
+          create: vi.fn(),
+          switch: vi.fn(),
+          delete: vi.fn(),
+        })}
+      />,
+    )
+
+    const appNav = screen.getByLabelText('App navigation')
+    await userEvent.click(within(appNav).getByRole('button', { name: 'Pin New chat' }))
+    expect(localStorage.getItem('boring-workspace:pinned-sessions:unsent-pin')).toBeNull()
   })
 
   it("restores the persisted pane layout while remote sessions load", async () => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceShellCapabilitiesHost.test.ts
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceShellCapabilitiesHost.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest"
+import { fullChatSessionIdFromEvent } from "../WorkspaceShellCapabilitiesHost"
+
+describe("fullChatSessionIdFromEvent", () => {
+  it("accepts only bounded non-empty session ids", () => {
+    expect(fullChatSessionIdFromEvent(new CustomEvent("open", { detail: { sessionId: " native-exact " } }))).toBe("native-exact")
+    expect(fullChatSessionIdFromEvent(new CustomEvent("open", { detail: {} }))).toBeNull()
+    expect(fullChatSessionIdFromEvent(new CustomEvent("open", { detail: { sessionId: 42 } }))).toBeNull()
+    expect(fullChatSessionIdFromEvent(new CustomEvent("open", { detail: { sessionId: "x".repeat(129) } }))).toBeNull()
+  })
+
+})

--- a/packages/workspace/src/app/front/__tests__/handoverChatProjection.test.ts
+++ b/packages/workspace/src/app/front/__tests__/handoverChatProjection.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import type { BoringChatMessage } from "@hachej/boring-agent/shared"
+import { projectChatHandovers } from "../handoverChatProjection"
+
+const artifact = { id: "plan", surfaceKind: "workspace.open.path", target: "docs/plan.md", title: "Plan" }
+const operationOutput = {
+  content: [{ type: "text", text: "registered" }],
+  details: { kind: "boring.handover.operation", wireVersion: 1, operation: { action: "upsert", artifact } },
+}
+
+function successfulMessages(): BoringChatMessage[] {
+  return [
+    { id: "user-display", piEntryId: "user-native", role: "user", status: "done", parts: [{ type: "text", text: "Create a plan" }] },
+    {
+      id: "tool-display",
+      piEntryId: "assistant-tool-native",
+      role: "assistant",
+      status: "done",
+      parts: [{ type: "tool-call", id: "call-1", toolName: "manage_handover", input: {}, state: "output-available", output: operationOutput }],
+    },
+    { id: "final-display", piEntryId: "final-native", role: "assistant", status: "done", runTerminalState: "success", createdAt: "2026-01-01T00:00:00.000Z", parts: [{ type: "text", text: "Done." }] },
+  ]
+}
+
+describe("projectChatHandovers", () => {
+  it("attaches one deterministic Handover to the successful terminal assistant message", () => {
+    const messages = successfulMessages()
+    expect(projectChatHandovers(messages).get(messages[2]!)).toEqual({
+      id: "handover:final-native",
+      runId: "user-native",
+      terminalEntryId: "final-native",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      artifacts: [artifact],
+    })
+  })
+
+  it("projects live same-turn assistant merges when the native terminal marker shares tool parts", () => {
+    const messages = successfulMessages()
+    const merged: BoringChatMessage[] = [messages[0]!, {
+      ...messages[1]!,
+      id: "merged-final",
+      piEntryId: "final-native",
+      runTerminalState: "success",
+      parts: [...messages[1]!.parts, { type: "text", text: "Done." }],
+    }]
+    expect(projectChatHandovers(merged).get(merged[1]!)?.artifacts).toEqual([artifact])
+  })
+
+  it("suppresses failed, aborted, empty, and interrupted runs", () => {
+    const failed = successfulMessages().map((message) => message.id === "final-display" ? { ...message, status: "error" as const, runTerminalState: "error" as const } : message)
+    expect(projectChatHandovers(failed).size).toBe(0)
+
+    const aborted = successfulMessages().map((message) => message.id === "final-display" ? { ...message, status: "aborted" as const, runTerminalState: "aborted" as const } : message)
+    expect(projectChatHandovers(aborted).size).toBe(0)
+
+    expect(projectChatHandovers([
+      { id: "u", role: "user", status: "done", parts: [] },
+      { id: "a", role: "assistant", status: "done", runTerminalState: "success", parts: [{ type: "text", text: "No outputs" }] },
+    ]).size).toBe(0)
+
+    expect(projectChatHandovers(successfulMessages().slice(0, 2)).size).toBe(0)
+  })
+
+  it("keeps repeated display message IDs isolated by row identity", () => {
+    const first = successfulMessages()
+    const second = successfulMessages().map((message) => ({
+      ...message,
+      id: message.id === "final-display" ? "final-display" : `${message.id}-second`,
+      piEntryId: message.piEntryId ? `${message.piEntryId}-second` : undefined,
+      parts: message.parts,
+    }))
+    const messages = [...first, ...second]
+    const projected = projectChatHandovers(messages)
+    expect(projected.get(first[2]!)?.id).toBe("handover:final-native")
+    expect(projected.get(second[2]!)?.id).toBe("handover:final-native-second")
+  })
+
+  it("projects nested ask_user artifacts identically to manage_handover details", () => {
+    const messages = successfulMessages()
+    const toolMessage = messages[1]!
+    const toolPart = toolMessage.parts[0]
+    if (toolPart?.type !== "tool-call") throw new Error("expected tool call")
+    toolPart.toolName = "ask_user"
+    toolPart.output = { details: { status: "answered", handover: { kind: "boring.handover.operations", wireVersion: 1, operations: [{ action: "upsert", artifact }] } } }
+    expect(projectChatHandovers(messages).get(messages[2]!)?.artifacts).toEqual([artifact])
+  })
+})

--- a/packages/workspace/src/app/front/__tests__/useWorkspaceShellCapabilitiesController.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/useWorkspaceShellCapabilitiesController.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, renderHook, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 import { describe, expect, it, vi } from 'vitest'
@@ -28,12 +28,12 @@ function Probe({ openChatPane, openSurface }: { openChatPane: (sessionId: string
   })
   return <button type="button" onClick={() => shell.openArtifact(
     { type: 'surface', surfaceKind: 'questions', target: 'q1', params: { sessionId: 's1' } },
-    { sessionId: null, title: 'Need input', instanceId: 'ask-user:s1:q1' },
+    { sessionId: 's1', title: 'Need input', instanceId: 'ask-user:s1:q1' },
   )}>Open question</button>
 }
 
 describe('useWorkspaceShellCapabilitiesController', () => {
-  it('opens surface artifacts with metadata params without opening chat when session option is null', async () => {
+  it('opens surface artifacts with session metadata without switching chat', async () => {
     const user = userEvent.setup()
     const openChatPane = vi.fn()
     const openSurface = vi.fn()
@@ -48,5 +48,114 @@ describe('useWorkspaceShellCapabilitiesController', () => {
       filesystem: 'user',
       meta: { sessionId: 's1' },
     })
+  })
+
+  it('opens workspace document artifacts through the canonical file command', () => {
+    const openFile = vi.fn()
+    const openSurface = vi.fn()
+    const { result } = renderHook(() => useWorkspaceShellCapabilitiesController({
+      setFloatingChatSession: vi.fn(),
+      openChatPane: vi.fn(),
+      surfaceDispatch: {
+        surface: () => ({
+          openSurface,
+          openFile,
+          openPanel: vi.fn(),
+          closePanel: vi.fn(),
+          navigateToLine: vi.fn(),
+          expandToFile: vi.fn(),
+          closeWorkbenchLeftPane: vi.fn(),
+          getSnapshot: () => ({ openTabs: [], activeTab: null }),
+          on: () => () => undefined,
+        }),
+        isWorkbenchOpen: () => true,
+        openWorkbench: vi.fn(),
+      },
+    }))
+
+    act(() => {
+      expect(result.current.openArtifact({
+        type: 'surface',
+        surfaceKind: 'workspace.open.path',
+        target: 'docs/release.md',
+      })).toEqual({ success: true })
+    })
+
+    expect(openFile).toHaveBeenCalledWith('docs/release.md', { filesystem: 'user' })
+    expect(openSurface).not.toHaveBeenCalled()
+  })
+
+  it('opens Inbox items and exact full-chat sessions without creating one', () => {
+    const openChatPane = vi.fn()
+    const inboxRequests: unknown[] = []
+    const onInboxRequest = (event: Event) => inboxRequests.push((event as CustomEvent).detail)
+    window.addEventListener('boring-workspace:open-app-left-overlay', onInboxRequest)
+    const { result } = renderHook(() => useWorkspaceShellCapabilitiesController({
+      setFloatingChatSession: vi.fn(),
+      openChatPane,
+      isAppLeftOverlayAvailable: (id) => id === 'inbox',
+      surfaceDispatch: {
+        surface: () => ({
+          openSurface: vi.fn(),
+          openFile: vi.fn(),
+          openPanel: vi.fn(),
+          closePanel: vi.fn(),
+          navigateToLine: vi.fn(),
+          expandToFile: vi.fn(),
+          closeWorkbenchLeftPane: vi.fn(),
+          getSnapshot: () => ({ openTabs: [], activeTab: null }),
+          on: () => () => undefined,
+        }),
+        isWorkbenchOpen: () => true,
+        openWorkbench: vi.fn(),
+      },
+    }))
+
+    act(() => {
+      expect(result.current.openFullChat('native-exact')).toEqual({ success: true })
+      expect(result.current.openFullChat(' ')).toMatchObject({ success: false, reason: 'invalid-session' })
+      expect(result.current.openInboxItem('ask-user:s1:q1')).toEqual({ success: true })
+      expect(result.current.openInboxItem('bad\nitem')).toMatchObject({ success: false })
+    })
+
+    window.removeEventListener('boring-workspace:open-app-left-overlay', onInboxRequest)
+    expect(inboxRequests).toEqual([{ id: 'inbox', params: { itemId: 'ask-user:s1:q1' } }])
+    expect(openChatPane).toHaveBeenCalledTimes(1)
+    expect(openChatPane).toHaveBeenCalledWith('native-exact')
+  })
+
+  it('registers an opaque browser-local session before opening its detached composer', () => {
+    const setFloatingChatSession = vi.fn()
+    const registerBrowserLocalSession = vi.fn()
+    const onNativeSessionPersisted = vi.fn()
+    const { result } = renderHook(() => useWorkspaceShellCapabilitiesController({
+      setFloatingChatSession,
+      openChatPane: vi.fn(),
+      registerBrowserLocalSession,
+      surfaceDispatch: {
+        surface: () => ({
+          openSurface: vi.fn(),
+          openFile: vi.fn(),
+          openPanel: vi.fn(),
+          closePanel: vi.fn(),
+          navigateToLine: vi.fn(),
+          expandToFile: vi.fn(),
+          closeWorkbenchLeftPane: vi.fn(),
+          getSnapshot: () => ({ openTabs: [], activeTab: null }),
+          on: () => () => undefined,
+        }),
+        isWorkbenchOpen: () => true,
+        openWorkbench: vi.fn(),
+      },
+    }))
+
+    act(() => {
+      expect(result.current.openBrowserLocalDetachedChat({ title: 'Task', onNativeSessionPersisted })).toEqual({ success: true })
+    })
+
+    const localId = registerBrowserLocalSession.mock.calls[0]?.[0]
+    expect(localId).toEqual(expect.any(String))
+    expect(registerBrowserLocalSession).toHaveBeenCalledWith(localId, onNativeSessionPersisted)
+    expect(setFloatingChatSession).toHaveBeenCalledWith(expect.objectContaining({ sessionId: localId, browserLocalId: localId, title: 'Task' }))
   })
 })

--- a/packages/workspace/src/app/front/handoverChatProjection.ts
+++ b/packages/workspace/src/app/front/handoverChatProjection.ts
@@ -1,0 +1,53 @@
+import type { BoringChatMessage } from "@hachej/boring-agent/shared"
+import { projectHandovers, type HandoverProjectionEvent, type ProjectedHandover } from "../../shared/artifacts"
+
+function record(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null
+}
+
+function toolResultDetails(output: unknown): unknown {
+  const value = record(output)
+  return value && "details" in value ? value.details : output
+}
+
+export function projectChatHandovers(messages: readonly BoringChatMessage[]): ReadonlyMap<BoringChatMessage, ProjectedHandover> {
+  const events: HandoverProjectionEvent[] = []
+  const terminalMessages = new Map<string, BoringChatMessage>()
+
+  for (const message of messages) {
+    if (message.role === "user") {
+      events.push({ type: "run-start", runId: message.piEntryId ?? message.id })
+      continue
+    }
+    if (message.role !== "assistant") continue
+
+    const toolParts = message.parts.filter((part) => part.type === "tool-call")
+    for (const part of toolParts) {
+      if (part.type !== "tool-call" || (part.state !== "output-available" && part.state !== "output-error")) continue
+      events.push({
+        type: "tool-result",
+        entryId: part.id,
+        isError: part.state === "output-error",
+        details: toolResultDetails(part.output),
+      })
+    }
+
+    const terminalEntryId = message.piEntryId ?? message.id
+    if (message.runTerminalState) {
+      events.push({
+        type: "run-terminal",
+        entryId: terminalEntryId,
+        state: message.runTerminalState,
+        ...(message.runTerminalState === "success" ? { createdAt: message.createdAt } : {}),
+      })
+      terminalMessages.set(terminalEntryId, message)
+    }
+  }
+
+  const byMessage = new Map<BoringChatMessage, ProjectedHandover>()
+  for (const handover of projectHandovers(events)) {
+    const message = terminalMessages.get(handover.terminalEntryId)
+    if (message) byMessage.set(message, handover)
+  }
+  return byMessage
+}

--- a/packages/workspace/src/app/front/useWorkspaceShellCapabilitiesController.ts
+++ b/packages/workspace/src/app/front/useWorkspaceShellCapabilitiesController.ts
@@ -3,20 +3,39 @@
 import { useMemo, type Dispatch, type SetStateAction } from "react"
 import { dispatchUiCommand, type DispatchContext } from "../../front/bridge"
 import type { WorkspaceShellCapabilities, WorkspaceShellArtifactTarget } from "../../front/shell/WorkspaceShellCapabilitiesContext"
+import { requestAppLeftOverlay } from "../../shared/plugins/appLeftOverlay"
+import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../shared/types/surface"
 
 function panelInstanceId(prefix: string, id: string): string {
   const safe = id.replace(/[^A-Za-z0-9_.:-]/g, "_").slice(0, 96)
   return `${prefix}.${safe || "item"}`
 }
 
+function browserLocalSessionId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") return crypto.randomUUID()
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+export interface FloatingChatSession {
+  sessionId: string
+  title?: string
+  initialDraft?: string
+  composingEnabled?: boolean
+  browserLocalId?: string
+}
+
 export function useWorkspaceShellCapabilitiesController({
   setFloatingChatSession,
   openChatPane,
   surfaceDispatch,
+  registerBrowserLocalSession,
+  isAppLeftOverlayAvailable,
 }: {
-  setFloatingChatSession: Dispatch<SetStateAction<{ sessionId: string; title?: string; initialDraft?: string; composingEnabled?: boolean } | null>>
+  setFloatingChatSession: Dispatch<SetStateAction<FloatingChatSession | null>>
   openChatPane: (sessionId: string) => void
   surfaceDispatch: DispatchContext
+  registerBrowserLocalSession?: (localId: string, onNativeSessionPersisted?: (sessionId: string) => void | Promise<void>) => void
+  isAppLeftOverlayAvailable?: (id: string) => boolean
 }): WorkspaceShellCapabilities {
   return useMemo<WorkspaceShellCapabilities>(() => ({
     openArtifact: (artifact: WorkspaceShellArtifactTarget | null, options) => {
@@ -34,7 +53,16 @@ export function useWorkspaceShellCapabilitiesController({
         return { success: true }
       }
       if (!artifact.target) return { success: false, reason: "open-failed", message: "This item has no surface target." }
-      if (options?.sessionId) openChatPane(options.sessionId)
+      if (artifact.surfaceKind === WORKSPACE_OPEN_PATH_SURFACE_KIND) {
+        dispatchUiCommand({
+          kind: "openFile",
+          params: {
+            path: artifact.target,
+            ...(typeof artifact.params?.filesystem === "string" ? { filesystem: artifact.params.filesystem } : {}),
+          },
+        }, surfaceDispatch)
+        return { success: true }
+      }
       dispatchUiCommand({
         kind: "openSurface",
         params: {
@@ -58,5 +86,36 @@ export function useWorkspaceShellCapabilitiesController({
       })
       return { success: true }
     },
-  }), [openChatPane, setFloatingChatSession, surfaceDispatch])
+    openFullChat: (sessionId: string) => {
+      const normalized = sessionId.trim()
+      if (!normalized) return { success: false, reason: "invalid-session", message: "Missing chat session id." }
+      openChatPane(normalized)
+      return { success: true }
+    },
+    openInboxItem: (itemId: string) => {
+      const normalized = itemId.trim()
+      if (!normalized || normalized.length > 512 || /[\u0000-\u001f\u007f]/.test(normalized)) {
+        return { success: false, reason: "open-failed", message: "Invalid Inbox item id." }
+      }
+      if (!isAppLeftOverlayAvailable?.("inbox")) {
+        return { success: false, reason: "open-failed", message: "Inbox is unavailable." }
+      }
+      return requestAppLeftOverlay("inbox", { itemId: normalized })
+        ? { success: true }
+        : { success: false, reason: "open-failed", message: "Inbox is unavailable." }
+    },
+    openBrowserLocalDetachedChat: (options) => {
+      if (!registerBrowserLocalSession) return { success: false, reason: "open-failed", message: "Browser-local chat sessions are not available." }
+      const localId = browserLocalSessionId()
+      registerBrowserLocalSession(localId, options?.onNativeSessionPersisted)
+      setFloatingChatSession({
+        sessionId: localId,
+        browserLocalId: localId,
+        title: options?.title,
+        initialDraft: options?.initialDraft,
+        composingEnabled: options?.composingEnabled,
+      })
+      return { success: true }
+    },
+  }), [isAppLeftOverlayAvailable, openChatPane, registerBrowserLocalSession, setFloatingChatSession, surfaceDispatch])
 }

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -715,6 +715,18 @@ export async function createWorkspaceAgentServer(
       if (!workspaceAgentDispatcherResolver) throw new Error("workspace agent dispatcher is not ready")
       return await workspaceAgentDispatcherResolver.resolve(actor, options)
     },
+    async resolveWithWorkspace(actor, options) {
+      if (!workspaceAgentDispatcherResolver?.resolveWithWorkspace) throw new Error("workspace agent workspace resolver is not ready")
+      return await workspaceAgentDispatcherResolver.resolveWithWorkspace(actor, options)
+    },
+    async authorizeSession(actor, sessionId, options) {
+      if (!workspaceAgentDispatcherResolver?.authorizeSession) throw new Error("workspace agent session authorizer is not ready")
+      await workspaceAgentDispatcherResolver.authorizeSession(actor, sessionId, options)
+    },
+    async readSessionRunDetails(actor, sessionId, detailKinds, options) {
+      if (!workspaceAgentDispatcherResolver?.readSessionRunDetails) throw new Error("workspace agent structured session reader is not ready")
+      return await workspaceAgentDispatcherResolver.readSessionRunDetails(actor, sessionId, detailKinds, options)
+    },
   }
   const pluginCollection = await resolveWorkspaceAgentServerPluginCollection({
     trustedPluginContext: {

--- a/packages/workspace/src/front/artifacts/openHumanArtifact.test.ts
+++ b/packages/workspace/src/front/artifacts/openHumanArtifact.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest"
+import { openHumanArtifact } from "./openHumanArtifact"
+
+describe("openHumanArtifact", () => {
+  it("routes only the registered surface target through shell capabilities", () => {
+    const openArtifact = vi.fn(() => ({ success: true as const }))
+    expect(openHumanArtifact({ openArtifact }, {
+      id: "plan",
+      surfaceKind: "workspace-file",
+      target: "docs/plan.md",
+      title: "Plan",
+    }, { sessionId: "native-session" })).toEqual({ success: true })
+    expect(openArtifact).toHaveBeenCalledWith({
+      type: "surface",
+      surfaceKind: "workspace-file",
+      target: "docs/plan.md",
+    }, {
+      sessionId: "native-session",
+      title: "Plan",
+      instanceId: "human-artifact:plan",
+    })
+  })
+})

--- a/packages/workspace/src/front/artifacts/openHumanArtifact.ts
+++ b/packages/workspace/src/front/artifacts/openHumanArtifact.ts
@@ -1,0 +1,18 @@
+import type { HumanArtifact } from "../../shared/artifacts"
+import type { WorkspaceShellCapabilities, WorkspaceShellCapabilityResult } from "../../shared/plugins/workspaceShellCapabilities"
+
+export function openHumanArtifact(
+  shell: Pick<WorkspaceShellCapabilities, "openArtifact">,
+  artifact: HumanArtifact,
+  options?: { sessionId?: string | null },
+): WorkspaceShellCapabilityResult {
+  return shell.openArtifact({
+    type: "surface",
+    surfaceKind: artifact.surfaceKind,
+    target: artifact.target,
+  }, {
+    sessionId: options?.sessionId,
+    title: artifact.title,
+    instanceId: `human-artifact:${artifact.id}`,
+  })
+}

--- a/packages/workspace/src/front/attention/WorkspaceAttentionProvider.tsx
+++ b/packages/workspace/src/front/attention/WorkspaceAttentionProvider.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from "react"
+import type { HumanArtifact } from "../../shared/artifacts"
 
 export const WORKSPACE_ATTENTION_ACTION_EVENT = "boring-workspace:attention-action" as const
 
@@ -30,6 +31,7 @@ export type WorkspaceAttentionInboxMetadata = {
   createdAt?: string | number | Date
   updatedAt?: string | number | Date
   priority?: number
+  artifacts?: HumanArtifact[]
 }
 
 export type WorkspaceAttentionFocusMetadata = {

--- a/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
+++ b/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from "vitest"
 import { dispatchUiCommand, WORKSPACE_SURFACE_OPEN_SKIPPED_EVENT, type DispatchContext } from "../uiCommandDispatcher"
-import type { SurfaceShellApi, SurfaceShellSnapshot } from "../../chrome/artifact-surface/SurfaceShell"
+import { SurfaceUnavailableError, type SurfaceShellApi, type SurfaceShellSnapshot } from "../../chrome/artifact-surface/SurfaceShell"
 
 function fakeSurface(): SurfaceShellApi & {
   __opened: string[]
@@ -63,6 +63,41 @@ describe("dispatchUiCommand", () => {
     dispatchUiCommand({ kind: "openFile", params: { path: "greeter.ts" } }, c)
     expect(c.__surface.__opened).toEqual(["greeter.ts"])
     expect(c.__surface.__openFileCalls).toEqual([{ path: "greeter.ts", filesystem: "user" }])
+  })
+
+  it("retires a dead surface and replays the file open after recovery", () => {
+    const stale = fakeSurface()
+    vi.spyOn(stale, "openFile").mockImplementation(() => { throw new SurfaceUnavailableError() })
+    const queued: Array<(surface: SurfaceShellApi) => void> = []
+    const recoverSurface = vi.fn()
+    const c = ctx({ recoverSurface, enqueue: (run) => queued.push(run) }, stale)
+
+    dispatchUiCommand({ kind: "openFile", params: { path: "README.md" } }, c)
+
+    expect(recoverSurface).toHaveBeenCalledWith(stale)
+    expect(queued).toHaveLength(1)
+    const replacement = fakeSurface()
+    queued[0]!(replacement)
+    expect(replacement.__opened).toEqual(["README.md"])
+  })
+
+  it("caps dead-surface recovery at one remount for a persistently failing operation", () => {
+    const dead = () => {
+      const surface = fakeSurface()
+      vi.spyOn(surface, "openSurface").mockImplementation(() => { throw new SurfaceUnavailableError() })
+      return surface
+    }
+    const queued: Array<(surface: SurfaceShellApi) => void> = []
+    const recoverSurface = vi.fn()
+    const first = dead()
+    const c = ctx({ recoverSurface, enqueue: (run) => queued.push(run) }, first)
+
+    dispatchUiCommand({ kind: "openSurface", params: { kind: "questions", target: "q1" } }, c)
+    expect(queued).toHaveLength(1)
+    queued.shift()!(dead())
+
+    expect(recoverSurface).toHaveBeenCalledTimes(1)
+    expect(queued).toHaveLength(0)
   })
 
   it("openFile forwards explicit company_context filesystem", () => {

--- a/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
+++ b/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
@@ -5,7 +5,7 @@
  * be exercised in isolation by tests and re-used by both the SSE and
  * polling transports in `uiCommandStream.ts`.
  */
-import type { SurfaceShellApi, OpenPanelConfig } from "../chrome/artifact-surface/SurfaceShell"
+import { SurfaceUnavailableError, type SurfaceShellApi, type OpenPanelConfig } from "../chrome/artifact-surface/SurfaceShell"
 import type { UiCommand } from "./types"
 import { normalizeUiFilesystem } from "../../shared/types/filesystem"
 import type { SurfaceOpenRequest } from "../../shared/types/surface"
@@ -40,6 +40,8 @@ export interface DispatchContext {
    * silently dropped.
    */
   enqueue?: (run: (surface: SurfaceShellApi) => void) => void
+  /** Retire and remount a surface whose imperative Dockview API stopped accepting operations. */
+  recoverSurface?: (surface: SurfaceShellApi) => void
   /** Optional host policy hook for surface requests that are only relevant in a visible/open context. */
   shouldOpenSurface?: (request: SurfaceOpenRequest) => boolean
 }
@@ -91,6 +93,23 @@ function surfaceRequestParam(params: Record<string, unknown>): SurfaceOpenReques
 
 const SURFACE_READY_RETRY_FRAMES = 60
 
+const surfaceRecoveryAttempts = new WeakMap<(surface: SurfaceShellApi) => void, number>()
+
+function recoverUnavailableSurface(
+  ctx: DispatchContext,
+  surface: SurfaceShellApi,
+  run: (surface: SurfaceShellApi) => void,
+  error: unknown,
+): boolean {
+  if (!(error instanceof SurfaceUnavailableError) || !ctx.recoverSurface || !ctx.enqueue) return false
+  const attempts = surfaceRecoveryAttempts.get(run) ?? 0
+  if (attempts >= 1) return false
+  surfaceRecoveryAttempts.set(run, attempts + 1)
+  ctx.recoverSurface(surface)
+  ctx.enqueue(run)
+  return true
+}
+
 function runWhenSurfaceReady(
   ctx: DispatchContext,
   run: (surface: SurfaceShellApi) => void,
@@ -133,6 +152,7 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
         try {
           surface.openFile(path, { filesystem: normalizeUiFilesystem(strParam(cmd.params, "filesystem")) })
         } catch (err) {
+          if (recoverUnavailableSurface(ctx, surface, run, err)) return
           // eslint-disable-next-line no-console -- intentional dev signal
           console.warn(
             `[uiCommandDispatcher] openFile dispatch failed:`,
@@ -168,6 +188,7 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
         try {
           surface.openSurface(request)
         } catch (err) {
+          if (recoverUnavailableSurface(ctx, surface, run, err)) return
           // eslint-disable-next-line no-console -- intentional dev signal
           console.warn(
             `[uiCommandDispatcher] openSurface dispatch failed:`,
@@ -195,6 +216,7 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
         try {
           surface.openPanel(cfg)
         } catch (err) {
+          if (recoverUnavailableSurface(ctx, surface, run, err)) return
           // eslint-disable-next-line no-console -- intentional dev signal
           console.warn(
             `[uiCommandDispatcher] openPanel dispatch failed:`,

--- a/packages/workspace/src/front/chrome/artifact-surface/ArtifactSurfacePane.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/ArtifactSurfacePane.tsx
@@ -124,10 +124,12 @@ function layoutHasPanels(layout: SerializedLayout): boolean {
 export interface ArtifactSurfacePaneProps {
   visible?: boolean
   storageKey?: string
+  instanceKey?: string | number
   allowedPanels?: string[]
   persistedLayout?: SerializedLayout
   onLayoutChange?: (layout: SerializedLayout) => void
   onReady?: (api: DockviewApi) => void
+  onUnavailable?: (api: DockviewApi) => void
   prefixHeaderActions?: React.FunctionComponent<unknown>
   rightHeaderActions?: React.FunctionComponent<unknown>
   watermarkComponent?: React.FunctionComponent<unknown>
@@ -137,10 +139,12 @@ export interface ArtifactSurfacePaneProps {
 export function ArtifactSurfacePane({
   visible = true,
   storageKey = SURFACE_STORAGE_KEY,
+  instanceKey = 0,
   allowedPanels,
   persistedLayout,
   onLayoutChange,
   onReady,
+  onUnavailable,
   prefixHeaderActions,
   rightHeaderActions,
   watermarkComponent,
@@ -198,11 +202,12 @@ export function ArtifactSurfacePane({
         // dockview only consumes persistedLayout on initial onReady, and
         // writes after a key swap would otherwise land under the new key
         // with the old layout.
-        key={`${storageKey}:${callerControlled ? "ext" : "auto"}:${allowedPanelsKey}`}
+        key={`${storageKey}:${callerControlled ? "ext" : "auto"}:${allowedPanelsKey}:${instanceKey}`}
         layout={SURFACE_LAYOUT}
         persistedLayout={persistedLayout ?? internalPersisted}
         onLayoutChange={handleLayoutChange}
         onReady={onReady}
+        onUnavailable={onUnavailable}
         allowedPanels={allowedPanels}
         prefixHeaderActions={prefixHeaderActions}
         rightHeaderActions={rightHeaderActions}

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -53,6 +53,13 @@ export interface SurfaceShellOpenFileOptions {
   mode?: "view" | "edit" | "diff"
 }
 
+export class SurfaceUnavailableError extends Error {
+  constructor(message = "Surface dockview is unavailable.") {
+    super(message)
+    this.name = "SurfaceUnavailableError"
+  }
+}
+
 export interface SurfaceShellApi {
   /** Open a file in the workbench. Idempotent — re-activates an existing pane for the same filesystem/path. */
   openFile: (path: string, options?: SurfaceShellOpenFileOptions) => void
@@ -79,8 +86,10 @@ export interface SurfaceShellProps {
   sidebarMinWidth?: number
   sidebarMaxWidth?: number
   storageKey?: string
-  /** Called once when the surface dockview becomes ready, with an imperative handle. */
+  /** Called whenever the surface dockview becomes ready, with an imperative handle. */
   onReady?: (api: SurfaceShellApi) => void
+  /** Called before the current dockview instance is disposed or replaced. */
+  onUnavailable?: () => void
   /** Called on every panel add/remove/active-change with the current snapshot. */
   onChange?: (snapshot: SurfaceShellSnapshot) => void
   /** Optional close action for hosts that model the workbench as collapsible. */
@@ -102,6 +111,8 @@ export interface SurfaceShellProps {
   defaultLeftTab?: string
   onReloadAgentPlugins?: () => void | Promise<unknown>
   initialPanels?: Array<{ id: string; component: string; title?: string; params?: Record<string, unknown> }>
+  /** Increment to force a fresh Dockview instance after an imperative API failure. */
+  dockviewGeneration?: number
   className?: string
 }
 
@@ -220,6 +231,7 @@ export function SurfaceShell({
   sidebarMaxWidth = 480,
   storageKey,
   onReady,
+  onUnavailable,
   onChange,
   onClose,
   showCloseAction = true,
@@ -227,6 +239,7 @@ export function SurfaceShell({
   defaultLeftTab,
   onReloadAgentPlugins,
   initialPanels,
+  dockviewGeneration = 0,
   className,
 }: SurfaceShellProps) {
   // Persist and transition the left block as one state object. This avoids
@@ -262,6 +275,8 @@ export function SurfaceShell({
   const [fileTreeRevealRequest, setFileTreeRevealRequest] = useState<{ path: string; seq: number } | null>(null)
   const onReadyRef = useRef(onReady)
   onReadyRef.current = onReady
+  const onUnavailableRef = useRef(onUnavailable)
+  onUnavailableRef.current = onUnavailable
   const onChangeRef = useRef(onChange)
   onChangeRef.current = onChange
   const onCloseRef = useRef(onClose)
@@ -330,19 +345,27 @@ export function SurfaceShell({
     if (!api) return false
     const existing = api.getPanel(config.id)
     if (existing) {
-      if (config.params) existing.api.updateParameters(config.params)
-      existing.api.setActive()
-      applyPanelPlacementTransition(config.component)
-      return true
+      try {
+        if (config.params) existing.api.updateParameters(config.params)
+        existing.api.setActive()
+        applyPanelPlacementTransition(config.component)
+        return true
+      } catch {
+        return false
+      }
     }
     applyPanelPlacementTransition(config.component)
-    api.addPanel({
-      id: config.id,
-      component: config.component,
-      title: config.title,
-      params: config.params,
-    })
-    return true
+    try {
+      api.addPanel({
+        id: config.id,
+        component: config.component,
+        title: config.title,
+        params: config.params,
+      })
+      return Boolean(api.getPanel(config.id))
+    } catch {
+      return false
+    }
   }, [applyPanelPlacementTransition])
 
   const collapseForActiveWorkspacePage = useCallback((dockview: DockviewApi): void => {
@@ -363,18 +386,19 @@ export function SurfaceShell({
     // component. If a newer resolver takes over the path (for example CSV),
     // opening should create the newer panel instead of reactivating stale UI.
     if (dockviewPanelComponent(existing) !== component) return false
-    existing.api.updateParameters(params)
-    existing.api.setActive()
-    applyPanelPlacementTransition(component)
-    return true
+    try {
+      existing.api.updateParameters(params)
+      existing.api.setActive()
+      applyPanelPlacementTransition(component)
+      return true
+    } catch {
+      return false
+    }
   }, [applyPanelPlacementTransition])
 
   const openFileSync = useCallback((path: string, options?: SurfaceShellOpenFileOptions) => {
     const api = apiRef.current
-    if (!api) {
-      console.warn("[SurfaceShell] openFile: surface not ready (dockview not initialized)")
-      return
-    }
+    if (!api) throw new SurfaceUnavailableError()
     const normalizedPath = normalizeWorkbenchPath(path)
     const request: SurfaceOpenRequest = {
       kind: WORKSPACE_OPEN_PATH_SURFACE_KIND,
@@ -391,12 +415,12 @@ export function SurfaceShell({
       const params = fileBackedParams(resolved.params, normalizedPath, { filesystem: request.filesystem, mode: options?.mode })
       fileBackedPanelIdsRef.current.add(panelId)
       if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) return
-      activateDockviewPanel({
+      if (!activateDockviewPanel({
         id: panelId,
         component: resolved.component,
         title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
         params,
-      })
+      })) throw new SurfaceUnavailableError("Surface failed to activate the requested file panel.")
       return
     }
 
@@ -452,24 +476,24 @@ export function SurfaceShell({
       component: resolved.component,
       title: resolved.title ?? normalizedRequest.target,
       params: resolvedParams,
-    })) {
-      console.warn("[SurfaceShell] openSurface: surface not ready (dockview not initialized)")
-    }
+    })) throw new SurfaceUnavailableError("Surface failed to activate the requested panel.")
   }, [activateDockviewPanel, activateExistingFilePanel])
 
   const openPanelSync = useCallback((config: OpenPanelConfig) => {
     const api = apiRef.current
-    if (!api) return
+    if (!api) throw new SurfaceUnavailableError()
     const existing = api.getPanel(config.id)
     if (existing) {
       // Re-activate, and update params if they changed (so callers can drive
       // pane state by re-issuing openPanel with new params — same panel, new
       // input).
-      if (config.params) {
-        existing.api.updateParameters(config.params)
+      try {
+        if (config.params) existing.api.updateParameters(config.params)
+        existing.api.setActive()
+        return
+      } catch {
+        throw new SurfaceUnavailableError("Surface failed to reactivate the requested panel.")
       }
-      existing.api.setActive()
-      return
     }
     // Validate the component is actually registered. Without this check,
     // dockview happily creates an empty tab when handed an unknown
@@ -486,12 +510,12 @@ export function SurfaceShell({
           `Add the component to WorkspaceProvider's "panels" prop, or pick one of the registered ids.`,
       )
     }
-    activateDockviewPanel({
+    if (!activateDockviewPanel({
       id: config.id,
       component: config.component,
       title: config.title ?? config.id,
       params: config.params,
-    })
+    })) throw new SurfaceUnavailableError("Surface failed to activate the requested panel.")
   }, [activateDockviewPanel])
 
   const getSnapshot = useCallback((): SurfaceShellSnapshot => {
@@ -578,6 +602,15 @@ export function SurfaceShell({
   }, [getBridgeState])
 
   const initializedPanelsRef = useRef(false)
+  const handleUnavailable = useCallback((unavailable: DockviewApi) => {
+    if (apiRef.current !== unavailable) return
+    apiRef.current = null
+    initializedPanelsRef.current = false
+    setApi(null)
+    setActiveSurfacePanelId(null)
+    onUnavailableRef.current?.()
+  }, [])
+
   const handleReady = useCallback((ready: DockviewApi) => {
     apiRef.current = ready
     setApi(ready)
@@ -634,26 +667,32 @@ export function SurfaceShell({
           const params = fileBackedParams(resolved.params, normalizedPath, { filesystem: request.filesystem, mode: options?.mode })
           fileBackedPanelIdsRef.current.add(panelId)
           if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) return ok()
-          activateDockviewPanel({
+          if (!activateDockviewPanel({
             id: panelId,
             component: resolved.component,
             title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
             params,
-          })
+          })) return err("SURFACE_UNAVAILABLE", "surface failed to activate the requested file panel")
           return ok()
         }
 
         const existing = findOpenFilePanel(api, normalizedPath, request.filesystem)
         if (existing) {
-          existing.api.setActive()
-          return ok()
+          try {
+            existing.api.setActive()
+            return ok()
+          } catch {
+            return err("SURFACE_UNAVAILABLE", "surface failed to reactivate the requested file panel")
+          }
         }
         return err("NO_SURFACE_RESOLVER", `no registered surface resolver handles ${normalizedPath}`)
       } catch (error) {
-        return err(
-          "INVALID_SURFACE_PATH",
-          error instanceof Error ? error.message : "failed to open file",
-        )
+        return error instanceof SurfaceUnavailableError
+          ? err("SURFACE_UNAVAILABLE", error.message)
+          : err(
+              "INVALID_SURFACE_PATH",
+              error instanceof Error ? error.message : "failed to open file",
+            )
       }
     },
     [activateDockviewPanel, activateExistingFilePanel],
@@ -672,7 +711,9 @@ export function SurfaceShell({
           openPanelSync(config)
           return ok()
         } catch (error) {
-          return err("INVALID_PANEL", error instanceof Error ? error.message : "failed to open panel")
+          return error instanceof SurfaceUnavailableError
+            ? err("SURFACE_UNAVAILABLE", error.message)
+            : err("INVALID_PANEL", error instanceof Error ? error.message : "failed to open panel")
         }
       },
       closePanel: async (id) => {
@@ -857,7 +898,9 @@ export function SurfaceShell({
         >
           <ArtifactSurfacePane
             storageKey={storageKey}
+            instanceKey={dockviewGeneration}
             onReady={handleReady}
+            onUnavailable={handleUnavailable}
             allowedPanels={allowedPanels}
           />
         </div>

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -23,20 +23,32 @@ vi.mock("../../workbench-left/WorkbenchLeftPane", () => ({
 
 vi.mock("../ArtifactSurfacePane", async () => {
   const React = await import("react")
-  function MockArtifactSurfacePane(props: { storageKey?: string; allowedPanels?: string[]; onReady?: (api: unknown) => void }) {
+  function MockArtifactSurfacePane(props: { storageKey?: string; allowedPanels?: string[]; onReady?: (api: unknown) => void; onUnavailable?: (api: unknown) => void }) {
     capturedSurfaceStorageKey = props.storageKey
     capturedAllowedPanels = props.allowedPanels
     React.useEffect(() => {
-      props.onReady?.({
-        panels: mockPanels,
+      const localPanels = [...mockPanels]
+      const api = {
+        panels: localPanels,
         activePanel: null,
-        getPanel: mockGetPanel,
-        addPanel: mockAddPanel,
+        getPanel: (id: string) => mockGetPanel(id) ?? localPanels.find((panel) => panel.id === id),
+        addPanel: (config: { id: string; component: string; title?: string; params?: unknown }) => {
+          mockAddPanel(config)
+          localPanels.push({
+            id: config.id,
+            component: config.component,
+            title: config.title,
+            params: config.params,
+            api: { setActive: vi.fn(), updateParameters: vi.fn() },
+          })
+        },
         onDidAddPanel: vi.fn(() => ({ dispose: vi.fn() })),
         onDidRemovePanel: vi.fn(() => ({ dispose: vi.fn() })),
         onDidActivePanelChange: vi.fn(() => ({ dispose: vi.fn() })),
-      })
-    }, [props.onReady])
+      }
+      props.onReady?.(api)
+      return () => props.onUnavailable?.(api)
+    }, [props.allowedPanels?.join("\0"), props.onReady, props.onUnavailable, props.storageKey])
     return <div data-testid="mock-artifact-surface" />
   }
   MockArtifactSurfacePane.defaultAllowedPanels = [] as string[]
@@ -65,8 +77,8 @@ describe("SurfaceShell", () => {
     capturedSurfaceStorageKey = undefined
     capturedAllowedPanels = undefined
     capturedWorkbenchBridge = undefined
-    mockAddPanel = vi.fn()
     mockPanels = []
+    mockAddPanel = vi.fn()
     mockGetPanel = vi.fn(() => undefined)
     localStorage.clear()
   })
@@ -88,6 +100,27 @@ describe("SurfaceShell", () => {
     )
 
     expect(capturedSurfaceStorageKey).toBe("workspace-b")
+  })
+
+  it("marks the surface unavailable while its Dockview instance is replaced", () => {
+    const onReady = vi.fn()
+    const onUnavailable = vi.fn()
+    const panelRegistry = new PanelRegistry()
+    const commandRegistry = new CommandRegistry()
+    const initialPanels = [{ id: "welcome", component: "welcome-panel", title: "Welcome" }]
+    const { rerender } = renderSurface("workspace-a", { onReady, onUnavailable, initialPanels }, panelRegistry)
+    expect(onReady).toHaveBeenCalledTimes(1)
+    expect(mockAddPanel).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <RegistryProvider panelRegistry={panelRegistry} commandRegistry={commandRegistry}>
+        <SurfaceShell storageKey="workspace-b" onReady={onReady} onUnavailable={onUnavailable} initialPanels={initialPanels} />
+      </RegistryProvider>,
+    )
+
+    expect(onUnavailable).toHaveBeenCalledTimes(1)
+    expect(onReady).toHaveBeenCalledTimes(2)
+    expect(mockAddPanel).toHaveBeenCalledTimes(2)
   })
 
   it("updates allowed surface panels when hot-loaded dockview/plugin-page panels register after mount", async () => {

--- a/packages/workspace/src/front/chrome/chat/types.ts
+++ b/packages/workspace/src/front/chrome/chat/types.ts
@@ -8,6 +8,8 @@ export type OpenArtifactHandler = (path: string, options?: { filesystem?: Filesy
 
 export interface WorkspaceChatPanelProps extends Omit<PiChatPanelProps<WorkspaceAttentionBlocker>, "onOpenArtifact"> {
   sessionId: string
+  /** Explicit direct/local capability for browser-local chats to materialize on first send. */
+  nativeSessionStartEnabled?: boolean
   onOpenArtifact?: OpenArtifactHandler
   /** Endpoint base for agent → visible-workbench UI commands. */
   bridgeEndpoint?: string | null

--- a/packages/workspace/src/front/components/HumanArtifactList.tsx
+++ b/packages/workspace/src/front/components/HumanArtifactList.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useState } from "react"
+import { ExternalLink, FileText } from "lucide-react"
+import type { HumanArtifact } from "../../shared/artifacts"
+
+export interface HumanArtifactListProps {
+  artifacts: readonly HumanArtifact[]
+  onOpen?: (artifact: HumanArtifact) => void
+  unavailableArtifactIds?: ReadonlySet<string>
+  initialVisibleCount?: number
+  typeLabel?: string | ((artifact: HumanArtifact) => string)
+  className?: string
+}
+
+function artifactTypeLabel(artifact: HumanArtifact): string {
+  if (artifact.surfaceKind === "questions") return "Question"
+  if (artifact.surfaceKind === "workspace.open.path" || artifact.surfaceKind === "file") return "Document"
+  return "Artifact"
+}
+
+export function HumanArtifactList({
+  artifacts,
+  onOpen,
+  unavailableArtifactIds,
+  initialVisibleCount = 10,
+  typeLabel,
+  className,
+}: HumanArtifactListProps) {
+  const [expanded, setExpanded] = useState(false)
+  const boundedInitialCount = Math.max(1, initialVisibleCount)
+  const visible = expanded ? artifacts : artifacts.slice(0, boundedInitialCount)
+  const hiddenCount = Math.max(0, artifacts.length - visible.length)
+
+  if (artifacts.length === 0) return null
+
+  return (
+    <div className={className} data-boring-workspace-part="human-artifact-list">
+      <ul className="grid gap-1" aria-label="Artifacts">
+        {visible.map((artifact) => {
+          const unavailable = unavailableArtifactIds?.has(artifact.id) ?? false
+          const canOpen = Boolean(onOpen) && !unavailable
+          const defaultTypeLabel = artifactTypeLabel(artifact)
+          const resolvedTypeLabel = typeof typeLabel === "function" ? typeLabel(artifact) : typeLabel ?? defaultTypeLabel
+          const showDocumentPath = defaultTypeLabel === "Document"
+          const content = (
+            <>
+              <FileText className="size-4 shrink-0 text-[color:var(--accent)]" strokeWidth={1.75} aria-hidden="true" />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-sm font-medium text-foreground">{artifact.title}</span>
+                {showDocumentPath ? (
+                  <span className="block truncate text-xs text-muted-foreground">
+                    <span className="font-mono">{artifact.target}</span>
+                    {artifact.description ? <span> · {artifact.description}</span> : null}
+                  </span>
+                ) : artifact.description ? <span className="block truncate text-xs text-muted-foreground">{artifact.description}</span> : null}
+              </span>
+              <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                {unavailable ? "Unavailable" : resolvedTypeLabel}
+              </span>
+              {canOpen ? <ExternalLink className="size-3.5 shrink-0 text-muted-foreground" aria-hidden="true" /> : null}
+            </>
+          )
+          return (
+            <li key={artifact.id}>
+              {canOpen ? (
+                <button
+                  type="button"
+                  className="flex min-h-11 w-full min-w-0 items-center gap-2 rounded-lg border border-transparent px-2.5 py-2 text-left transition-colors hover:border-border hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                  onClick={() => onOpen?.(artifact)}
+                  aria-label={`Open ${artifact.title}`}
+                >
+                  {content}
+                </button>
+              ) : (
+                <div
+                  className="flex min-h-11 min-w-0 items-center gap-2 rounded-lg px-2.5 py-2 opacity-70"
+                  aria-label={`${artifact.title} unavailable`}
+                >
+                  {content}
+                </div>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+      {hiddenCount > 0 ? (
+        <button
+          type="button"
+          className="mt-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          onClick={() => setExpanded(true)}
+        >
+          Show {hiddenCount} more
+        </button>
+      ) : expanded && artifacts.length > boundedInitialCount ? (
+        <button
+          type="button"
+          className="mt-1 rounded-md px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          onClick={() => setExpanded(false)}
+        >
+          Show less
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/workspace/src/front/components/__tests__/HumanArtifactList.test.tsx
+++ b/packages/workspace/src/front/components/__tests__/HumanArtifactList.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import type { HumanArtifact } from "../../../shared/artifacts"
+import { HumanArtifactList } from "../HumanArtifactList"
+
+function artifacts(count: number): HumanArtifact[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `artifact-${index + 1}`,
+    surfaceKind: "file",
+    target: `docs/artifact-${index + 1}.md`,
+    title: `Artifact ${index + 1}`,
+    description: `Description ${index + 1}`,
+  }))
+}
+
+describe("HumanArtifactList", () => {
+  it("renders nothing for an empty collection", () => {
+    const { container } = render(<HumanArtifactList artifacts={[]} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("opens available artifacts and keeps unavailable artifacts disabled", async () => {
+    const user = userEvent.setup()
+    const items = artifacts(2)
+    const onOpen = vi.fn()
+    render(<HumanArtifactList artifacts={items} onOpen={onOpen} unavailableArtifactIds={new Set(["artifact-2"])} />)
+
+    await user.click(screen.getByRole("button", { name: "Open Artifact 1" }))
+    expect(onOpen).toHaveBeenCalledWith(items[0])
+    expect(screen.getByText("Document", { selector: "span" })).toBeInTheDocument()
+    expect(screen.getByText("docs/artifact-1.md")).toBeInTheDocument()
+    expect(screen.queryByText("file")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Artifact 2/ })).not.toBeInTheDocument()
+    expect(screen.getByLabelText("Artifact 2 unavailable")).toHaveTextContent("Unavailable")
+  })
+
+  it("keeps document paths visible when callers customize the badge label", () => {
+    render(<HumanArtifactList artifacts={artifacts(1)} typeLabel="Attachment" />)
+    expect(screen.getByText("Attachment")).toBeInTheDocument()
+    expect(screen.getByText("docs/artifact-1.md")).toBeInTheDocument()
+  })
+
+  it("shows ten rows initially and expands/collapses the remainder", async () => {
+    const user = userEvent.setup()
+    render(<HumanArtifactList artifacts={artifacts(11)} onOpen={vi.fn()} />)
+
+    expect(screen.getAllByRole("listitem")).toHaveLength(10)
+    await user.click(screen.getByRole("button", { name: "Show 1 more" }))
+    expect(screen.getAllByRole("listitem")).toHaveLength(11)
+    await user.click(screen.getByRole("button", { name: "Show less" }))
+    expect(screen.getAllByRole("listitem")).toHaveLength(10)
+  })
+})

--- a/packages/workspace/src/front/dock/DockviewShell.tsx
+++ b/packages/workspace/src/front/dock/DockviewShell.tsx
@@ -327,6 +327,7 @@ export function DockviewShell({
   layout,
   persistedLayout,
   onReady,
+  onUnavailable,
   onLayoutChange,
   allowedPanels,
   className,
@@ -340,6 +341,8 @@ export function DockviewShell({
   const apiRef = useRef<DockviewApi | null>(null)
   const pendingOnReady = useRef<DockviewReadyEvent | null>(null)
   const disposeRef = useRef<(() => void) | undefined>(undefined)
+  const onUnavailableRef = useRef(onUnavailable)
+  onUnavailableRef.current = onUnavailable
   const componentsCacheRef = useRef<Record<string, React.FunctionComponent<IDockviewPanelProps>> | null>(null)
 
   const components = useMemo(() => {
@@ -381,7 +384,14 @@ export function DockviewShell({
   )
 
   useEffect(() => {
-    return () => disposeRef.current?.()
+    return () => {
+      const current = apiRef.current
+      apiRef.current = null
+      pendingOnReady.current = null
+      if (current) onUnavailableRef.current?.(current)
+      disposeRef.current?.()
+      disposeRef.current = undefined
+    }
   }, [])
 
   useEffect(() => {

--- a/packages/workspace/src/front/dock/__tests__/dock.test.tsx
+++ b/packages/workspace/src/front/dock/__tests__/dock.test.tsx
@@ -95,6 +95,25 @@ describe("DockviewShell", () => {
     }))
   })
 
+  it("reports the exact Dockview API as unavailable before disposal", () => {
+    const { panelRegistry, commandRegistry } = setupStoreAndRegistry()
+    const onReady = vi.fn()
+    const onUnavailable = vi.fn()
+
+    const { unmount } = render(
+      <RegistryProvider panelRegistry={panelRegistry} commandRegistry={commandRegistry}>
+        <DockviewShell layout={simpleLayout} onReady={onReady} onUnavailable={onUnavailable} />
+      </RegistryProvider>,
+    )
+    const readyApi = onReady.mock.calls[0]?.[0]
+    expect(readyApi).toBeDefined()
+
+    unmount()
+
+    expect(onUnavailable).toHaveBeenCalledTimes(1)
+    expect(onUnavailable).toHaveBeenCalledWith(readyApi)
+  })
+
   it("falls back to default panels when a persisted layout is invalid", async () => {
     const { panelRegistry, commandRegistry } = setupStoreAndRegistry()
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})

--- a/packages/workspace/src/front/dock/types.ts
+++ b/packages/workspace/src/front/dock/types.ts
@@ -29,6 +29,8 @@ export interface DockviewShellProps {
   layout: LayoutConfig
   persistedLayout?: SerializedLayout
   onReady?: (api: DockviewApi) => void
+  /** Called before the current Dockview instance is disposed or replaced. */
+  onUnavailable?: (api: DockviewApi) => void
   onLayoutChange?: (layout: SerializedLayout) => void
   storageKey?: string
   allowedPanels?: string[]

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -43,6 +43,8 @@ export type {
   ToolExecContext,
   ToolResult,
 } from "./shared/plugins"
+export * from "./shared/artifacts"
+export { WORKSPACE_TASK_PROVENANCE_CHANGED_EVENT, emitWorkspaceTaskProvenanceChanged } from "./shared/plugins/taskProvenance"
 export { CatalogRegistry } from "./shared/plugins/CatalogRegistry"
 export type { CatalogRegistryOptions } from "./shared/plugins/CatalogRegistry"
 export {
@@ -197,6 +199,9 @@ export { CommandPalette } from "./front/components/CommandPalette"
 export type { CommandPaletteProps } from "./front/components/CommandPalette"
 export { WorkspaceLoadingState } from "./front/components/WorkspaceLoadingState"
 export type { WorkspaceLoadingStateProps } from "./front/components/WorkspaceLoadingState"
+export { HumanArtifactList } from "./front/components/HumanArtifactList"
+export type { HumanArtifactListProps } from "./front/components/HumanArtifactList"
+export { openHumanArtifact } from "./front/artifacts/openHumanArtifact"
 
 // Panes (dockview wrappers — require WorkspaceProvider)
 export { ArtifactSurfacePane } from "./front/chrome/artifact-surface/ArtifactSurfacePane"

--- a/packages/workspace/src/plugin.ts
+++ b/packages/workspace/src/plugin.ts
@@ -37,6 +37,11 @@ export {
 } from "./shared/plugins/manifest"
 export { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "./shared/types/surface"
 export { useAppLeftOverlayChrome } from "./shared/plugins/appLeftOverlayChrome"
+export {
+  WORKSPACE_OPEN_APP_LEFT_OVERLAY_EVENT,
+  appLeftOverlayIdFromEvent,
+  requestAppLeftOverlay,
+} from "./shared/plugins/appLeftOverlay"
 export type { AppLeftOverlayChromeValue } from "./shared/plugins/appLeftOverlayChrome"
 export { useWorkspaceShellCapabilities } from "./shared/plugins/workspaceShellCapabilities"
 export type {

--- a/packages/workspace/src/server/workspaceBridge/__tests__/authPolicy.test.ts
+++ b/packages/workspace/src/server/workspaceBridge/__tests__/authPolicy.test.ts
@@ -142,8 +142,9 @@ describe("BridgeAuthPolicy adapters", () => {
     expect(resolved.context).toMatchObject({
       callerClass: "browser",
       workspaceId: "workspace-local",
-      actor: { actorKind: "human", performedBy: { label: "local-cli:user" } },
+      actor: { actorKind: "human", performedBy: { id: "local", label: "local-cli:user" } },
     })
+    expect(resolved.principal).toEqual({ userId: "local" })
   })
 
   it("can force local CLI browser callers to the single-tenant owner workspace", async () => {

--- a/packages/workspace/src/server/workspaceBridge/authPolicy.ts
+++ b/packages/workspace/src/server/workspaceBridge/authPolicy.ts
@@ -182,12 +182,12 @@ export function createLocalCliBridgeAuthPolicy(
         sessionId: input.sessionId,
         pluginId: input.pluginId,
         capabilities,
-        actor: { actorKind: "human", performedBy: { label: "local-cli:user" } },
+        actor: { actorKind: "human", performedBy: { id: "local", label: "local-cli:user" } },
       })
       return {
         context,
         effectiveCapabilities: capabilities,
-        principal: { userId: "local-cli" },
+        principal: { userId: "local" },
         resourceScope: { workspaceId, sessionId: input.sessionId },
       }
     },

--- a/packages/workspace/src/shared/artifacts/handover.test.ts
+++ b/packages/workspace/src/shared/artifacts/handover.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import {
+  applyHandoverOperations,
+  currentHandoverArtifactsFromStructuredDetails,
+  handoverOperationsFromDetails,
+  projectHandovers,
+  type HandoverOperation,
+  type HandoverProjectionEvent,
+} from "./handover"
+
+const artifact = (id: string, title = id) => ({ id, surfaceKind: "workspace.open.path", target: `docs/${id}.md`, title })
+const operation = (value: HandoverOperation) => ({ kind: "boring.handover.operation", wireVersion: 1, operation: value })
+
+describe("handover registry reducer", () => {
+  it("upserts in registration order, replaces in place, and removes explicitly", () => {
+    const operations: HandoverOperation[] = [
+      { action: "upsert", artifact: artifact("a", "A") },
+      { action: "upsert", artifact: artifact("b", "B") },
+      { action: "upsert", artifact: artifact("a", "A updated") },
+      { action: "remove", artifactId: "b" },
+    ]
+    expect(applyHandoverOperations([], operations)).toEqual([artifact("a", "A updated")])
+  })
+
+  it("extracts direct manage_handover and nested ask_user operations only from structured details", () => {
+    const upsert = { action: "upsert" as const, artifact: artifact("plan") }
+    expect(handoverOperationsFromDetails(operation(upsert))).toEqual([upsert])
+    expect(handoverOperationsFromDetails({ status: "answered", handover: { kind: "boring.handover.operations", wireVersion: 1, operations: [upsert] } })).toEqual([upsert])
+    expect(handoverOperationsFromDetails({ text: "Registered plan in final prose" })).toEqual([])
+  })
+
+  it("projects one deterministic card only at a successful terminal stop", () => {
+    const events: HandoverProjectionEvent[] = [
+      { type: "run-start", runId: "user-1" },
+      { type: "tool-result", entryId: "result-1", isError: false, details: operation({ action: "upsert", artifact: artifact("plan") }) },
+      { type: "tool-result", entryId: "failed", isError: true, details: operation({ action: "upsert", artifact: artifact("ignored") }) },
+      { type: "run-terminal", entryId: "terminal-1", state: "success", createdAt: "2026-01-01T00:00:09.000Z" },
+    ]
+    expect(projectHandovers(events)).toEqual([{
+      id: "handover:terminal-1",
+      runId: "user-1",
+      terminalEntryId: "terminal-1",
+      createdAt: "2026-01-01T00:00:09.000Z",
+      artifacts: [artifact("plan")],
+    }])
+  })
+
+  it("suppresses empty, failed, aborted, interrupted, and superseded runs without leaking state", () => {
+    const events: HandoverProjectionEvent[] = [
+      { type: "run-start", runId: "user-1" },
+      { type: "tool-result", entryId: "one", isError: false, details: operation({ action: "upsert", artifact: artifact("old") }) },
+      { type: "run-terminal", entryId: "failed", state: "error" },
+      { type: "run-start", runId: "user-2" },
+      { type: "tool-result", entryId: "two", isError: false, details: operation({ action: "upsert", artifact: artifact("aborted") }) },
+      { type: "run-terminal", entryId: "aborted", state: "aborted" },
+      { type: "run-start", runId: "user-3" },
+      { type: "tool-result", entryId: "three", isError: false, details: operation({ action: "upsert", artifact: artifact("interrupted") }) },
+      { type: "run-start", runId: "user-4" },
+      { type: "run-terminal", entryId: "empty", state: "success" },
+    ]
+    expect(projectHandovers(events)).toEqual([])
+  })
+
+  it("folds only the already-authorized structured detail projection for current-run list", () => {
+    expect(currentHandoverArtifactsFromStructuredDetails([
+      { detail: operation({ action: "upsert", artifact: artifact("a") }) },
+      { detail: operation({ action: "upsert", artifact: artifact("b") }) },
+      { detail: operation({ action: "remove", artifactId: "a" }) },
+    ])).toEqual([artifact("b")])
+  })
+})

--- a/packages/workspace/src/shared/artifacts/handover.ts
+++ b/packages/workspace/src/shared/artifacts/handover.ts
@@ -1,0 +1,134 @@
+import { z } from "zod"
+import { HUMAN_ARTIFACT_LIMITS, HumanArtifactListSchema, HumanArtifactSchema, type HumanArtifact } from "./humanArtifact"
+
+export const HANDOVER_OPERATION_DETAIL_KINDS = [
+  "boring.handover.operation",
+  "boring.handover.operations",
+] as const
+
+const artifactIdSchema = z.string().trim().min(1).max(HUMAN_ARTIFACT_LIMITS.maxIdLength)
+  .refine((value) => !/[\u0000-\u001f\u007f]/.test(value), "must not contain control characters")
+
+export const HandoverOperationSchema = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("upsert"), artifact: HumanArtifactSchema }).strict(),
+  z.object({ action: z.literal("remove"), artifactId: artifactIdSchema }).strict(),
+])
+
+export type HandoverOperation = z.infer<typeof HandoverOperationSchema>
+
+export const HandoverOperationDetailsSchema = z.object({
+  kind: z.literal("boring.handover.operation"),
+  wireVersion: z.literal(1),
+  operation: HandoverOperationSchema,
+}).strict()
+
+export const HandoverOperationsDetailsSchema = z.object({
+  kind: z.literal("boring.handover.operations"),
+  wireVersion: z.literal(1),
+  operations: z.array(HandoverOperationSchema).max(HUMAN_ARTIFACT_LIMITS.maxArtifactsPerRun),
+}).strict()
+
+export const HandoverSnapshotDetailsSchema = z.object({
+  kind: z.literal("boring.handover.snapshot"),
+  wireVersion: z.literal(1),
+  artifacts: HumanArtifactListSchema,
+}).strict()
+
+export type HandoverOperationDetails = z.infer<typeof HandoverOperationDetailsSchema>
+export type HandoverOperationsDetails = z.infer<typeof HandoverOperationsDetailsSchema>
+export type HandoverSnapshotDetails = z.infer<typeof HandoverSnapshotDetailsSchema>
+
+export interface ProjectedHandover {
+  id: string
+  runId: string
+  terminalEntryId: string
+  createdAt?: string
+  artifacts: HumanArtifact[]
+}
+
+interface ActiveRun {
+  runId: string
+  artifacts: HumanArtifact[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+export function applyHandoverOperations(
+  current: readonly HumanArtifact[],
+  operations: readonly HandoverOperation[],
+): HumanArtifact[] {
+  let artifacts = [...current]
+  for (const operation of operations) {
+    const before = artifacts
+    if (operation.action === "remove") {
+      artifacts = artifacts.filter((artifact) => artifact.id !== operation.artifactId)
+    } else {
+      const index = artifacts.findIndex((artifact) => artifact.id === operation.artifact.id)
+      artifacts = index < 0
+        ? [...artifacts, operation.artifact]
+        : artifacts.map((artifact, artifactIndex) => artifactIndex === index ? operation.artifact : artifact)
+    }
+    if (!HumanArtifactListSchema.safeParse(artifacts).success) artifacts = before
+  }
+  return artifacts
+}
+
+export function handoverOperationsFromDetails(details: unknown): HandoverOperation[] {
+  const single = HandoverOperationDetailsSchema.safeParse(details)
+  if (single.success) return [single.data.operation]
+  const multiple = HandoverOperationsDetailsSchema.safeParse(details)
+  if (multiple.success) return multiple.data.operations
+  return isRecord(details) && "handover" in details
+    ? handoverOperationsFromDetails(details.handover)
+    : []
+}
+
+export type HandoverProjectionEvent =
+  | { type: "run-start"; runId: string }
+  | { type: "tool-result"; entryId: string; isError: boolean; details?: unknown }
+  | { type: "run-terminal"; entryId: string; state: "success" | "error" | "aborted" | "interrupted"; createdAt?: string }
+
+export interface StructuredDetailRecord {
+  detail: unknown
+}
+
+export function projectHandovers(events: readonly HandoverProjectionEvent[]): ProjectedHandover[] {
+  const handovers: ProjectedHandover[] = []
+  let active: ActiveRun | null = null
+
+  for (const event of events) {
+    if (event.type === "run-start") {
+      active = { runId: event.runId, artifacts: [] }
+      continue
+    }
+    if (event.type === "tool-result") {
+      if (active && !event.isError) {
+        active.artifacts = applyHandoverOperations(active.artifacts, handoverOperationsFromDetails(event.details))
+      }
+      continue
+    }
+    if (event.state === "success" && active && active.artifacts.length > 0) {
+      handovers.push({
+        id: `handover:${event.entryId}`,
+        runId: active.runId,
+        terminalEntryId: event.entryId,
+        createdAt: event.createdAt,
+        artifacts: [...active.artifacts],
+      })
+    }
+    active = null
+  }
+
+  return handovers
+}
+
+export function currentHandoverArtifactsFromStructuredDetails(
+  details: readonly StructuredDetailRecord[],
+): HumanArtifact[] {
+  return details.reduce(
+    (artifacts, record) => applyHandoverOperations(artifacts, handoverOperationsFromDetails(record.detail)),
+    [] as HumanArtifact[],
+  )
+}

--- a/packages/workspace/src/shared/artifacts/humanArtifact.test.ts
+++ b/packages/workspace/src/shared/artifacts/humanArtifact.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+import { HUMAN_ARTIFACT_LIMITS, HumanArtifactListSchema, HumanArtifactSchema } from "./humanArtifact"
+
+function artifact(id: string, description?: string) {
+  return { id, surfaceKind: "file", target: `docs/${id}.md`, title: `Artifact ${id}`, ...(description ? { description } : {}) }
+}
+
+describe("HumanArtifact schemas", () => {
+  it("accepts strict registered Workspace surface metadata", () => {
+    expect(HumanArtifactSchema.parse(artifact("plan"))).toEqual(artifact("plan"))
+    expect(() => HumanArtifactSchema.parse({ ...artifact("plan"), url: "https://example.com" })).toThrow()
+    expect(() => HumanArtifactSchema.parse({ ...artifact("plan"), title: "bad\ncontrol" })).toThrow()
+  })
+
+  it("rejects duplicate IDs and more than the hard artifact cap", () => {
+    expect(() => HumanArtifactListSchema.parse([artifact("same"), artifact("same")])).toThrow(/duplicate artifact id/)
+    const tooMany = Array.from({ length: HUMAN_ARTIFACT_LIMITS.maxArtifactsPerRun + 1 }, (_, index) => artifact(String(index)))
+    expect(() => HumanArtifactListSchema.parse(tooMany)).toThrow()
+  })
+
+  it("accepts 100 compact artifacts and rejects metadata above the byte budget", () => {
+    const maximum = Array.from({ length: HUMAN_ARTIFACT_LIMITS.maxArtifactsPerRun }, (_, index) => artifact(String(index)))
+    expect(HumanArtifactListSchema.parse(maximum)).toHaveLength(100)
+
+    const oversized = Array.from({ length: 100 }, (_, index) => ({
+      ...artifact(String(index), "x".repeat(HUMAN_ARTIFACT_LIMITS.maxDescriptionLength)),
+      target: "x".repeat(HUMAN_ARTIFACT_LIMITS.maxTargetLength),
+    }))
+    expect(() => HumanArtifactListSchema.parse(oversized)).toThrow(/artifact metadata exceeds/)
+  })
+})

--- a/packages/workspace/src/shared/artifacts/humanArtifact.ts
+++ b/packages/workspace/src/shared/artifacts/humanArtifact.ts
@@ -1,0 +1,49 @@
+import { z } from "zod"
+
+export const HUMAN_ARTIFACT_LIMITS = {
+  maxArtifactsPerRun: 100,
+  maxSerializedMetadataBytes: 256 * 1024,
+  maxIdLength: 128,
+  maxSurfaceKindLength: 128,
+  maxTargetLength: 2_048,
+  maxTitleLength: 256,
+  maxDescriptionLength: 2_048,
+} as const
+
+const boundedText = (max: number) => z.string().trim().min(1).max(max).refine(
+  (value) => !/[\u0000-\u001f\u007f]/.test(value),
+  "must not contain control characters",
+)
+
+export const HumanArtifactSchema = z.object({
+  id: boundedText(HUMAN_ARTIFACT_LIMITS.maxIdLength),
+  surfaceKind: boundedText(HUMAN_ARTIFACT_LIMITS.maxSurfaceKindLength),
+  target: boundedText(HUMAN_ARTIFACT_LIMITS.maxTargetLength),
+  title: boundedText(HUMAN_ARTIFACT_LIMITS.maxTitleLength),
+  description: boundedText(HUMAN_ARTIFACT_LIMITS.maxDescriptionLength).optional(),
+}).strict()
+
+export type HumanArtifact = z.infer<typeof HumanArtifactSchema>
+
+export const HumanArtifactListSchema = z.array(HumanArtifactSchema)
+  .max(HUMAN_ARTIFACT_LIMITS.maxArtifactsPerRun)
+  .superRefine((artifacts, context) => {
+    const ids = new Set<string>()
+    for (const [index, artifact] of artifacts.entries()) {
+      if (ids.has(artifact.id)) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `duplicate artifact id: ${artifact.id}`,
+          path: [index, "id"],
+        })
+      }
+      ids.add(artifact.id)
+    }
+    const bytes = new TextEncoder().encode(JSON.stringify(artifacts)).byteLength
+    if (bytes > HUMAN_ARTIFACT_LIMITS.maxSerializedMetadataBytes) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `artifact metadata exceeds ${HUMAN_ARTIFACT_LIMITS.maxSerializedMetadataBytes} bytes`,
+      })
+    }
+  })

--- a/packages/workspace/src/shared/artifacts/index.ts
+++ b/packages/workspace/src/shared/artifacts/index.ts
@@ -1,0 +1,24 @@
+export {
+  HANDOVER_OPERATION_DETAIL_KINDS,
+  HandoverOperationDetailsSchema,
+  HandoverOperationsDetailsSchema,
+  HandoverOperationSchema,
+  HandoverSnapshotDetailsSchema,
+  applyHandoverOperations,
+  currentHandoverArtifactsFromStructuredDetails,
+  handoverOperationsFromDetails,
+  projectHandovers,
+  type HandoverOperation,
+  type HandoverProjectionEvent,
+  type HandoverOperationDetails,
+  type HandoverOperationsDetails,
+  type HandoverSnapshotDetails,
+  type ProjectedHandover,
+  type StructuredDetailRecord,
+} from "./handover"
+export {
+  HUMAN_ARTIFACT_LIMITS,
+  HumanArtifactListSchema,
+  HumanArtifactSchema,
+  type HumanArtifact,
+} from "./humanArtifact"

--- a/packages/workspace/src/shared/index.ts
+++ b/packages/workspace/src/shared/index.ts
@@ -12,6 +12,7 @@
  * - `plugins/` — shared plugin internals used by the public `/plugin` subpath and bootstrap
  */
 export type { WorkspaceBridge, UiState, UiCommand, CommandResult } from "./ui-bridge"
+export * from "./artifacts"
 export {
   WorkspaceBridgeErrorCode,
   createWorkspaceBridgeError,

--- a/packages/workspace/src/shared/plugins/appLeftOverlay.ts
+++ b/packages/workspace/src/shared/plugins/appLeftOverlay.ts
@@ -1,0 +1,31 @@
+export const WORKSPACE_OPEN_APP_LEFT_OVERLAY_EVENT = "boring-workspace:open-app-left-overlay"
+
+const SAFE_APP_LEFT_OVERLAY_ID = /^[a-zA-Z0-9][a-zA-Z0-9:_-]{0,127}$/
+
+export interface AppLeftOverlayRequest {
+  id: string
+  params?: Readonly<Record<string, string>>
+}
+
+export function appLeftOverlayRequestFromEvent(event: Event): AppLeftOverlayRequest | null {
+  const detail = (event as CustomEvent<unknown>).detail as { id?: unknown; params?: unknown } | undefined
+  const id = typeof detail?.id === "string" ? detail.id.trim() : ""
+  if (!SAFE_APP_LEFT_OVERLAY_ID.test(id)) return null
+  if (detail?.params === undefined) return { id }
+  if (!detail.params || typeof detail.params !== "object" || Array.isArray(detail.params)) return null
+  const entries = Object.entries(detail.params)
+  if (entries.length > 16 || entries.some(([key, value]) => !key || key.length > 64 || typeof value !== "string" || value.length > 1024)) return null
+  return { id, params: Object.fromEntries(entries) as Record<string, string> }
+}
+
+export function appLeftOverlayIdFromEvent(event: Event): string | null {
+  return appLeftOverlayRequestFromEvent(event)?.id ?? null
+}
+
+export function requestAppLeftOverlay(id: string, params?: Readonly<Record<string, string>>): boolean {
+  const normalized = id.trim()
+  const browserWindow = (globalThis as typeof globalThis & { window?: { dispatchEvent(event: Event): boolean } }).window
+  if (!browserWindow || !SAFE_APP_LEFT_OVERLAY_ID.test(normalized)) return false
+  browserWindow.dispatchEvent(new CustomEvent(WORKSPACE_OPEN_APP_LEFT_OVERLAY_EVENT, { detail: { id: normalized, ...(params ? { params } : {}) } }))
+  return true
+}

--- a/packages/workspace/src/shared/plugins/frontFactory.ts
+++ b/packages/workspace/src/shared/plugins/frontFactory.ts
@@ -56,6 +56,7 @@ export interface BoringFrontBindingRegistration {
 
 export interface BoringFrontAppLeftOverlayProps {
   onClose: () => void
+  params?: Readonly<Record<string, string>>
 }
 
 export interface BoringFrontAppLeftActionRegistration {

--- a/packages/workspace/src/shared/plugins/taskProvenance.ts
+++ b/packages/workspace/src/shared/plugins/taskProvenance.ts
@@ -1,0 +1,7 @@
+export const WORKSPACE_TASK_PROVENANCE_CHANGED_EVENT = "boring-workspace:task-provenance-changed" as const
+
+export function emitWorkspaceTaskProvenanceChanged(browserWindow: Pick<Window, "dispatchEvent"> | undefined = globalThis.window): boolean {
+  if (!browserWindow) return false
+  browserWindow.dispatchEvent(new Event(WORKSPACE_TASK_PROVENANCE_CHANGED_EVENT))
+  return true
+}

--- a/packages/workspace/src/shared/plugins/workspaceShellCapabilities.ts
+++ b/packages/workspace/src/shared/plugins/workspaceShellCapabilities.ts
@@ -22,6 +22,15 @@ export interface WorkspaceShellAnchorRect {
 export interface WorkspaceShellCapabilities {
   openArtifact(target: WorkspaceShellArtifactTarget | null, options?: { sessionId?: string | null; title?: string; instanceId?: string }): WorkspaceShellCapabilityResult
   openDetachedChat(sessionId: string, options?: { anchor?: WorkspaceShellAnchorRect; title?: string; initialDraft?: string; composingEnabled?: boolean }): WorkspaceShellCapabilityResult
+  openFullChat(sessionId: string): WorkspaceShellCapabilityResult
+  openInboxItem(itemId: string): WorkspaceShellCapabilityResult
+  openBrowserLocalDetachedChat(options?: {
+    anchor?: WorkspaceShellAnchorRect
+    title?: string
+    initialDraft?: string
+    composingEnabled?: boolean
+    onNativeSessionPersisted?: (sessionId: string) => void | Promise<void>
+  }): WorkspaceShellCapabilityResult
 }
 
 const failed = (message: string): WorkspaceShellCapabilityResult => ({ success: false, reason: "open-failed", message })
@@ -29,6 +38,9 @@ const failed = (message: string): WorkspaceShellCapabilityResult => ({ success: 
 const noopShellCapabilities: WorkspaceShellCapabilities = {
   openArtifact: () => ({ success: false, reason: "no-artifact", message: "No artifact is available." }),
   openDetachedChat: () => failed("Workspace shell capabilities are not available."),
+  openFullChat: () => failed("Workspace shell capabilities are not available."),
+  openInboxItem: () => failed("Workspace shell capabilities are not available."),
+  openBrowserLocalDetachedChat: () => failed("Workspace shell capabilities are not available."),
 }
 
 const WorkspaceShellCapabilitiesContext = createContext<WorkspaceShellCapabilities>(noopShellCapabilities)

--- a/packages/workspace/src/shared/types/agent-tool.ts
+++ b/packages/workspace/src/shared/types/agent-tool.ts
@@ -7,12 +7,28 @@ export type ToolReadinessRequirement =
   | 'runtime-dependencies'
   | `runtime:${string}`
 
+export interface ToolStructuredDetail {
+  entryId: string
+  toolCallId?: string
+  toolName?: string
+  kind: string
+  detail: unknown
+}
+
 export interface ToolExecContext {
   abortSignal: AbortSignal
   toolCallId: string
   onUpdate?: (partial: string) => void
   /** Agent chat/session id executing this tool, when known. */
   sessionId?: string
+  /** Server-owned authenticated run context. Never sourced from tool parameters. */
+  userId?: string
+  userEmail?: string
+  userEmailVerified?: boolean
+  workspaceId?: string
+  requestId?: string
+  /** Immutable, opt-in structured details from successful tool results in this run. */
+  currentRunStructuredDetails?: readonly ToolStructuredDetail[]
 }
 
 export interface ToolResult {
@@ -31,6 +47,9 @@ export interface AgentTool {
   description: string
   promptSnippet?: string
   readinessRequirements?: ToolReadinessRequirement[]
+  executionMode?: "sequential" | "parallel"
+  /** Structured result detail kinds this tool may inspect from the current run. */
+  currentRunDetailKinds?: readonly string[]
   parameters: JSONSchema
   execute(params: Record<string, unknown>, ctx: ToolExecContext): Promise<ToolResult>
 }


### PR DESCRIPTION
## Summary

Slice 2 of the #796 split stack. Builds on #921 and adds workspace-side Human Handover artifact surfaces.

- Shared typed HumanArtifact/Handover projection model.
- Workspace shell capabilities for exact chat, Inbox item, and browser-local detached chat opens.
- Handover timeline card and human artifact list UI.
- Surface bridge recovery/open-file routing support used by artifacts.

## Stack

- Base: #921 (`stack/796-1-agent-native`)
- Next: ask-user artifact projection, task/session links, final wiring.

## Proof

- `pnpm --filter @hachej/boring-workspace typecheck` — PASS.
- `pnpm --filter @hachej/boring-workspace exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx src/app/front/__tests__/WorkspaceShellCapabilitiesHost.test.ts src/app/front/__tests__/useWorkspaceShellCapabilitiesController.test.tsx src/app/front/__tests__/handoverChatProjection.test.ts src/shared/artifacts/handover.test.ts src/shared/artifacts/humanArtifact.test.ts src/front/components/__tests__/HumanArtifactList.test.tsx` — PASS, 86 tests.

## Risk / Rollback

Workspace-only layer atop agent primitives. Roll back this PR before downstream ask-user/tasks stack PRs land.
