### PR TITLE
#909 feat(playground): align onto AgentGateway

### DIFF
--- a/apps/agent-playground/README.md
+++ b/apps/agent-playground/README.md
@@ -6,7 +6,7 @@ For panels/file-tree/plugins use [`workspace-playground`](../workspace-playgroun
 
 ## What it is
 
-`pnpm --filter agent-playground dev` boots an in-process Fastify agent app (`createAgentApp({ mode: 'direct' })`) on an ephemeral port, then starts a Vite dev server on **`http://localhost:5183`** that proxies `/api`, `/health`, and `/ready` to it. The frontend renders `ChatPanel` from `@hachej/boring-agent/front`. The agent's workspace root is the **current working directory** — it reads and writes the real filesystem.
+`pnpm --filter agent-playground dev` boots one in-process Agent Host (`createAgentHost()` with the direct runtime adapter) on an ephemeral Fastify port, then starts a Vite dev server on **`http://localhost:5183`** that proxies `/api`, `/health`, and `/ready` to it. A fixed trusted-local capability is the only scope the app can issue; all session work flows through its `AgentGateway`. The frontend renders `ChatPanel` from `@hachej/boring-agent/front`. The agent's workspace root is the **current working directory** — it reads and writes the real filesystem.
 
 The Vite config aliases `@hachej/boring-agent/front` and `/shared` directly to `packages/agent/src`, so editing agent **frontend/shared** source hot-reloads without a rebuild. The `dev` script first runs `build:dev` on `@hachej/boring-agent` to compile the **server** half; restart after changing agent server code.
 
@@ -26,7 +26,8 @@ The agent is not Anthropic-only: it also supports Infomaniak (OpenAI-compatible)
 
 | Script | What it does |
 |--------|--------------|
-| `dev` | `build:dev` the agent package, then `tsx src/server/index.ts` (Fastify + Vite on :5183) |
+| `dev` | `build:dev` the agent package, then `tsx src/server/index.ts` (one Agent Host + Fastify + Vite on :5183) |
+| `test` | Run the bounded AgentGateway lifecycle smoke |
 | `typecheck` | `tsc --noEmit` |
 
 ## Env vars
@@ -39,11 +40,11 @@ The agent is not Anthropic-only: it also supports Infomaniak (OpenAI-compatible)
 | `HOST` | `0.0.0.0` | Vite host |
 | `BORING_AGENT_DEFAULT_MODEL`, `BORING_AGENT_CUSTOM_MODEL_*`, `BORING_AGENT_INFOMANIAK_*`, `INFOMANIAK_API_TOKEN` | — | Model/provider selection (read by `@hachej/boring-agent`) |
 
-Note: the agent's workspace root on the `createAgentApp` path is the process cwd. `BORING_AGENT_WORKSPACE_ROOT` is **not** read here.
+Note: the Agent Host workspace root is the process cwd. Sessions use `BORING_AGENT_SESSION_ROOT` when set and otherwise stay under the playground's `.boring-agent/sessions` directory. `BORING_AGENT_WORKSPACE_ROOT` is **not** read here.
 
 ## Composition
 
-Depends only on `@hachej/boring-agent` (workspace dependency). It does not pull in `@hachej/boring-core` or `@hachej/boring-workspace` — it is the isolated agent surface.
+Depends on `@hachej/boring-agent` plus Fastify/React development surface dependencies. It does not pull in `@hachej/boring-core` or `@hachej/boring-workspace` — it is the isolated Agent Host reference composition.
 
 ## License
 

--- a/apps/agent-playground/package.json
+++ b/apps/agent-playground/package.json
@@ -5,12 +5,13 @@
   "type": "module",
   "description": "Rich standalone playground for @hachej/boring-agent.",
   "scripts": {
-    "dev": "pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build:dev && pnpm --filter @hachej/boring-workspace build && tsx --env-file=.env.local src/server/index.ts",
+    "dev": "pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build:dev && tsx --env-file=.env.local src/server/index.ts",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hachej/boring-agent": "workspace:*",
-    "@hachej/boring-workspace": "workspace:*",
+    "fastify": "^5.9.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },
@@ -24,6 +25,7 @@
     "tailwindcss": "^4.3.1",
     "tsx": "^4.23.1",
     "typescript": "^6.0.3",
-    "vite": "^8.1.2"
+    "vite": "^8.1.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/agent-playground/src/server/__tests__/agentGateway.smoke.test.ts
+++ b/apps/agent-playground/src/server/__tests__/agentGateway.smoke.test.ts
@@ -140,6 +140,10 @@ describe('agent-playground AgentGateway reference composition', () => {
       logger: false,
     })
 
+    const modelsResponse = await runtime.app.inject({ method: 'GET', url: '/api/v1/agent/models' })
+    expect(modelsResponse.statusCode).toBe(200)
+    expect(modelsResponse.json()).toMatchObject({ models: expect.any(Array) })
+
     const agents = await runtime.gateway.listAgents({ scope: runtime.scope })
     expect(agents).toEqual([expect.objectContaining({ agentTypeId: PLAYGROUND_AGENT_TYPE_ID })])
 

--- a/apps/agent-playground/src/server/__tests__/agentGateway.smoke.test.ts
+++ b/apps/agent-playground/src/server/__tests__/agentGateway.smoke.test.ts
@@ -1,0 +1,184 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import { createSandboxRuntimeModeAdapter } from '@hachej/boring-agent/server'
+import type {
+  AgentCoreHarness,
+  AgentCoreHarnessFactory,
+  AgentCoreSessionAdapter,
+  SessionDetail,
+  SessionStore,
+  SessionSummary,
+} from '@hachej/boring-agent/shared'
+
+import {
+  createAgentPlaygroundRuntime,
+  PLAYGROUND_AGENT_TYPE_ID,
+} from '../agentHost.js'
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+class SmokeSessionStore implements SessionStore {
+  private readonly sessions = new Map<string, SessionSummary>()
+  private nextId = 0
+
+  async list(): Promise<SessionSummary[]> {
+    return [...this.sessions.values()]
+  }
+
+  async create(_ctx: unknown, init?: { title?: string }): Promise<SessionSummary> {
+    const id = `playground-smoke-${++this.nextId}`
+    const now = new Date(1_000 + this.nextId).toISOString()
+    const summary = { id, title: init?.title ?? 'New session', createdAt: now, updatedAt: now, turnCount: 0 }
+    this.sessions.set(id, summary)
+    return summary
+  }
+
+  async load(_ctx: unknown, sessionId: string): Promise<SessionDetail> {
+    const summary = this.sessions.get(sessionId)
+    if (!summary) throw new Error(`Session not found: ${sessionId}`)
+    return summary
+  }
+
+  async delete(_ctx: unknown, sessionId: string): Promise<void> {
+    this.sessions.delete(sessionId)
+  }
+}
+
+class SmokeSessionAdapter implements AgentCoreSessionAdapter {
+  private readonly listeners = new Set<Parameters<AgentCoreSessionAdapter['subscribe']>[0]>()
+  private streaming = false
+  private finishPrompt: (() => void) | undefined
+
+  readSnapshot() {
+    return {
+      state: {},
+      messages: [],
+      isStreaming: this.streaming,
+      isRetrying: false,
+      retryAttempt: 0,
+      pendingMessageCount: 0,
+      steeringMessages: [],
+      followUpMessages: [],
+      followUpMode: 'one-at-a-time' as const,
+      sessionId: 'playground-smoke-1',
+    }
+  }
+
+  subscribe(listener: Parameters<AgentCoreSessionAdapter['subscribe']>[0]): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  async prompt(): Promise<void> {
+    this.streaming = true
+    this.emit({ type: 'agent_start', turnId: 'smoke-turn' })
+    await new Promise<void>((resolve) => { this.finishPrompt = resolve })
+  }
+
+  async followUp(): Promise<void> {}
+  clearFollowUp(): void {}
+
+  async abort(): Promise<void> {
+    if (!this.streaming) return
+    this.streaming = false
+    this.emit({
+      type: 'agent_end',
+      status: 'aborted',
+      messages: [{ role: 'assistant', stopReason: 'aborted' }],
+      willRetry: false,
+    })
+    this.finishPrompt?.()
+    this.finishPrompt = undefined
+  }
+
+  private emit(event: unknown): void {
+    for (const listener of this.listeners) {
+      listener(event as Parameters<Parameters<AgentCoreSessionAdapter['subscribe']>[0]>[0])
+    }
+  }
+}
+
+function createSmokeHarnessFactory(): AgentCoreHarnessFactory {
+  return async (): Promise<AgentCoreHarness> => {
+    const sessions = new SmokeSessionStore()
+    const adapters = new Map<string, SmokeSessionAdapter>()
+    return {
+      id: 'agent-playground-smoke',
+      placement: 'server',
+      sessions,
+      async getPiSessionAdapter({ sessionId }) {
+        if (!sessionId) throw new Error('sessionId is required')
+        let adapter = adapters.get(sessionId)
+        if (!adapter) {
+          adapter = new SmokeSessionAdapter()
+          adapters.set(sessionId, adapter)
+        }
+        return adapter
+      },
+    }
+  }
+}
+
+describe('agent-playground AgentGateway reference composition', () => {
+  test('runs create, connect, prompt, event, stop, unsubscribe, and bounded shutdown through one Host', async () => {
+    const sessionRoot = await mkdtemp(join(tmpdir(), 'agent-playground-gateway-'))
+    tempDirs.push(sessionRoot)
+    const directMode = createSandboxRuntimeModeAdapter('direct')
+    const disposeRuntime = vi.fn(async () => await directMode.dispose?.())
+    const runtime = await createAgentPlaygroundRuntime({
+      workspaceRoot: sessionRoot,
+      sessionRoot,
+      runtimeModeAdapter: { ...directMode, dispose: disposeRuntime },
+      harnessFactory: createSmokeHarnessFactory(),
+      logger: false,
+    })
+
+    const agents = await runtime.gateway.listAgents({ scope: runtime.scope })
+    expect(agents).toEqual([expect.objectContaining({ agentTypeId: PLAYGROUND_AGENT_TYPE_ID })])
+
+    const ref = await runtime.gateway.createSession({
+      scope: runtime.scope,
+      agentTypeId: PLAYGROUND_AGENT_TYPE_ID,
+      requestId: 'smoke-create',
+      title: 'Gateway smoke',
+    })
+    const connection = await runtime.gateway.connectSession({ scope: runtime.scope, ref })
+    const iterator = connection.events[Symbol.asyncIterator]()
+    const nextEvent = iterator.next()
+
+    await expect(connection.send({
+      kind: 'prompt',
+      requestId: 'smoke-prompt',
+      clientNonce: 'smoke-nonce',
+      content: 'exercise the reference composition',
+    })).resolves.toMatchObject({ accepted: true, disposition: 'prompt' })
+    await expect(nextEvent).resolves.toMatchObject({
+      done: false,
+      value: expect.objectContaining({
+        ref,
+        event: expect.objectContaining({ type: 'agent-start' }),
+      }),
+    })
+    await expect(connection.stop({ requestId: 'smoke-stop' })).resolves.toMatchObject({
+      accepted: true,
+      stopped: true,
+    })
+
+    await connection.close()
+    await runtime.gateway.close()
+    await runtime.created.host.drain()
+    await runtime.created.host.close()
+    await runtime.close()
+    await runtime.close()
+
+    await expect(runtime.created.host.describe()).resolves.toMatchObject({ draining: true })
+    expect(disposeRuntime).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/agent-playground/src/server/agentHost.ts
+++ b/apps/agent-playground/src/server/agentHost.ts
@@ -1,0 +1,132 @@
+import Fastify, { type FastifyInstance } from 'fastify'
+
+import {
+  createAgentHost,
+  createSandboxRuntimeModeAdapter,
+  type AgentHarnessFactory,
+  type CreatedAgentHost,
+  type RuntimeModeAdapter,
+} from '@hachej/boring-agent/server'
+import type {
+  AgentGateway,
+  AgentScopeVerifier,
+  AuthorizedAgentScope,
+} from '@hachej/boring-agent/shared'
+
+export const PLAYGROUND_AGENT_TYPE_ID = 'default'
+export const PLAYGROUND_WORKSPACE_SCOPE_ID = 'agent-playground'
+export const PLAYGROUND_AUTH_SUBJECT_ID = 'trusted-local'
+
+export interface AgentPlaygroundRuntimeOptions {
+  readonly workspaceRoot?: string
+  readonly sessionRoot?: string
+  readonly runtimeModeAdapter?: RuntimeModeAdapter
+  readonly harnessFactory?: AgentHarnessFactory
+  readonly logger?: boolean
+}
+
+export interface AgentPlaygroundRuntime {
+  readonly app: FastifyInstance
+  readonly created: CreatedAgentHost
+  readonly gateway: AgentGateway
+  readonly scope: AuthorizedAgentScope
+  close(): Promise<void>
+}
+
+function createTrustedLocalScope(): {
+  readonly scope: AuthorizedAgentScope
+  readonly verifier: AgentScopeVerifier
+} {
+  const scope = Object.freeze({
+    workspaceScopeId: PLAYGROUND_WORKSPACE_SCOPE_ID,
+    authSubjectId: PLAYGROUND_AUTH_SUBJECT_ID,
+  }) as AuthorizedAgentScope
+
+  return {
+    scope,
+    verifier: {
+      async verify(candidate) {
+        if (candidate !== scope) throw new Error('agent-playground scope denied')
+        return {
+          workspaceScopeId: PLAYGROUND_WORKSPACE_SCOPE_ID,
+          authSubjectId: PLAYGROUND_AUTH_SUBJECT_ID,
+        }
+      },
+    },
+  }
+}
+
+async function closeRuntime(created: CreatedAgentHost, app: FastifyInstance): Promise<void> {
+  let firstError: unknown
+  for (const operation of [
+    () => created.gateway.close(),
+    () => created.host.drain(),
+    () => created.host.close(),
+    () => app.close(),
+  ]) {
+    try {
+      await operation()
+    } catch (error) {
+      firstError ??= error
+    }
+  }
+  if (firstError !== undefined) throw firstError
+}
+
+/** Small reference composition: one Host, one fixed local capability, one Gateway. */
+export async function createAgentPlaygroundRuntime(
+  options: AgentPlaygroundRuntimeOptions = {},
+): Promise<AgentPlaygroundRuntime> {
+  const workspaceRoot = options.workspaceRoot ?? process.cwd()
+  const modeAdapter = options.runtimeModeAdapter ?? createSandboxRuntimeModeAdapter('direct')
+  const { scope, verifier } = createTrustedLocalScope()
+  const app = Fastify({ logger: options.logger ?? true, bodyLimit: 16 * 1024 * 1024 })
+  const created = await createAgentHost({
+    agents: [{ agentTypeId: PLAYGROUND_AGENT_TYPE_ID, legacyDefault: true }],
+    fleetCompiler: { async compile({ agents }) { return agents } },
+    hostId: 'agent-playground',
+    scopeVerifier: verifier,
+    runtimeModeAdapter: modeAdapter,
+    runtimeHost: modeAdapter.runtimeHost,
+    sessionRoot: options.sessionRoot,
+    harnessFactory: options.harnessFactory,
+    async resolveRuntimeScope() {
+      return {
+        identity: JSON.stringify(['agent-playground', modeAdapter.id, workspaceRoot]),
+        environment: {
+          placementIdentity: JSON.stringify([modeAdapter.id, workspaceRoot]),
+          workspaceRoot,
+          provisioningFingerprint: JSON.stringify([modeAdapter.id, workspaceRoot]),
+        },
+        sessionNamespace: 'agent-playground',
+      }
+    },
+  })
+
+  try {
+    await app.register(created.registerRoutes({
+      defaultAgentTypeId: PLAYGROUND_AGENT_TYPE_ID,
+      legacyPiChatAliases: true,
+      async authorizeRequest() {
+        return scope
+      },
+    }))
+    app.get('/health', async () => ({ ok: true }))
+    app.get('/ready', async () => ({ ready: !(await created.host.describe()).draining }))
+  } catch (error) {
+    await closeRuntime(created, app).catch(() => {})
+    throw error
+  }
+
+  let closePromise: Promise<void> | undefined
+  return {
+    app,
+    created,
+    gateway: created.gateway,
+    scope,
+    close() {
+      closePromise ??= closeRuntime(created, app)
+      return closePromise
+    },
+  }
+}

--- a/apps/agent-playground/src/server/agentHost.ts
+++ b/apps/agent-playground/src/server/agentHost.ts
@@ -3,6 +3,7 @@ import Fastify, { type FastifyInstance } from 'fastify'
 import {
   createAgentHost,
   createSandboxRuntimeModeAdapter,
+  registerAgentRoutes,
   type AgentHarnessFactory,
   type CreatedAgentHost,
   type RuntimeModeAdapter,
@@ -104,15 +105,19 @@ export async function createAgentPlaygroundRuntime(
   })
 
   try {
-    await app.register(created.registerRoutes({
-      defaultAgentTypeId: PLAYGROUND_AGENT_TYPE_ID,
-      legacyPiChatAliases: true,
-      async authorizeRequest() {
-        return scope
+    await app.register(registerAgentRoutes, {
+      agentHost: {
+        created,
+        defaultAgentTypeId: PLAYGROUND_AGENT_TYPE_ID,
+        issueScope: () => scope,
       },
-    }))
-    app.get('/health', async () => ({ ok: true }))
-    app.get('/ready', async () => ({ ready: !(await created.host.describe()).draining }))
+      workspaceRoot,
+      sessionRoot: options.sessionRoot,
+      sessionId: PLAYGROUND_WORKSPACE_SCOPE_ID,
+      runtimeModeAdapter: modeAdapter,
+      runtimeHost: modeAdapter.runtimeHost,
+      getSessionNamespace: () => 'agent-playground',
+    })
   } catch (error) {
     await closeRuntime(created, app).catch(() => {})
     throw error

--- a/apps/agent-playground/src/server/index.ts
+++ b/apps/agent-playground/src/server/index.ts
@@ -2,29 +2,25 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import tailwindcss from '@tailwindcss/vite'
+import { applyCspHeaders } from '@hachej/boring-agent/server'
 import { createServer as createViteServer } from 'vite'
 
-import {
-  applyCspHeaders,
-  createAgentApp,
-  createSandboxRuntimeModeAdapter,
-  sandboxRuntimeHostOperations,
-} from '@hachej/boring-agent/server'
-
-const app = await createAgentApp({
-  mode: 'direct',
-  runtimeModeAdapter: createSandboxRuntimeModeAdapter('direct'),
-  runtimeHost: sandboxRuntimeHostOperations,
-  sessionId: 'playground',
-})
-
-const apiAddress = await app.listen({ port: 0, host: '127.0.0.1' })
-const apiPort = Number(new URL(apiAddress).port)
-const apiTarget = `http://127.0.0.1:${apiPort}`
+import { createAgentPlaygroundRuntime } from './agentHost.js'
 
 const playgroundRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
 const repoRoot = path.resolve(playgroundRoot, '../..')
 const agentSourceRoot = path.resolve(repoRoot, 'packages/agent/src')
+const sessionRoot = path.resolve(
+  process.env.BORING_AGENT_SESSION_ROOT ?? path.join(playgroundRoot, '.boring-agent', 'sessions'),
+)
+const runtime = await createAgentPlaygroundRuntime({
+  workspaceRoot: process.cwd(),
+  sessionRoot,
+})
+
+const apiAddress = await runtime.app.listen({ port: 0, host: '127.0.0.1' })
+const apiPort = Number(new URL(apiAddress).port)
+const apiTarget = `http://127.0.0.1:${apiPort}`
 const configuredFrontendPort = process.env.FRONTEND_PORT
 const frontendPort = configuredFrontendPort ? Number(configuredFrontendPort) : 5183
 const frontendStrictPort = process.env.FRONTEND_STRICT_PORT === '1'
@@ -97,4 +93,22 @@ const vite = await createViteServer({
 
 await vite.listen()
 vite.printUrls()
-app.log.info(`playground API listening at ${apiAddress}`)
+runtime.app.log.info(`playground API listening at ${apiAddress}`)
+runtime.app.log.info(`playground Agent Host ready: ${runtime.created.host.hostId}`)
+
+let shutdownPromise: Promise<void> | undefined
+function shutdown(signal: NodeJS.Signals): Promise<void> {
+  shutdownPromise ??= (async () => {
+    runtime.app.log.info({ signal }, 'agent-playground shutting down')
+    await runtime.close()
+    await vite.close()
+  })()
+  return shutdownPromise
+}
+
+process.once('SIGINT', () => {
+  void shutdown('SIGINT').catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,9 +28,9 @@ importers:
       '@hachej/boring-agent':
         specifier: workspace:*
         version: link:../../packages/agent
-      '@hachej/boring-workspace':
-        specifier: workspace:*
-        version: link:../../packages/workspace
+      fastify:
+        specifier: ^5.9.0
+        version: 5.10.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -68,6 +68,9 @@ importers:
       vite:
         specifier: ^8.1.2
         version: 8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.3(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   apps/full-app:
     dependencies:


### PR DESCRIPTION
## Summary

Migrates `agent-playground` to the smallest direct Agent Host reference composition.

- removes the Workspace package dependency and build reach-through
- creates exactly one Agent Host with an identity-bound trusted-local scope
- projects legacy chat aliases from the same Gateway for the existing front
- adds a bounded Gateway lifecycle smoke and idempotent shutdown
- stores standalone sessions under `BORING_AGENT_SESSION_ROOT` or the app-local durable fallback

## Slice

`wt-391-forward-0jpy.6` — MIG-PG

## Proof

A current-head proof comment follows with exact commands, SIGINT evidence, rollback, and risks.

## Rollback

Revert this PR. It has no production data migration.
