### PR TITLE
test(core): wire native session capability

### DIFF
--- a/packages/cli/src/__tests__/nativePiFirstSend.integration.test.ts
+++ b/packages/cli/src/__tests__/nativePiFirstSend.integration.test.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, test } from 'vitest'
+import { createFolderModeApp } from '../server/cli.js'
+
+const tempDirs: string[] = []
+const originalSessionRoot = process.env.BORING_AGENT_SESSION_ROOT
+
+afterEach(async () => {
+  if (originalSessionRoot === undefined) delete process.env.BORING_AGENT_SESSION_ROOT
+  else process.env.BORING_AGENT_SESSION_ROOT = originalSessionRoot
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })))
+})
+
+async function makeTempDir(prefix: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), prefix))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function filesUnder(root: string): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true })
+  const files = await Promise.all(entries.map(async (entry) => {
+    const path = join(root, entry.name)
+    return entry.isDirectory() ? filesUnder(path) : [path]
+  }))
+  return files.flat()
+}
+
+test('CLI direct folder composition creates, binds, and lists a bare native Pi first-send transcript', async () => {
+  const workspaceRoot = await makeTempDir('boring-cli-native-first-send-workspace-')
+  const sessionRoot = await makeTempDir('boring-cli-native-first-send-sessions-')
+  process.env.BORING_AGENT_SESSION_ROOT = sessionRoot
+
+  const app = await createFolderModeApp({
+    workspaceRoot,
+    mode: 'direct',
+    provisionWorkspace: false,
+  })
+
+  try {
+    const catalog = await app.inject({ method: 'GET', url: '/api/v1/agent/catalog' })
+    expect(catalog.statusCode, catalog.body).toBe(200)
+    expect((catalog.json() as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).toContain('manage_tasks')
+
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/pi-chat/sessions/native-prompt',
+      payload: {
+        message: 'first native prompt',
+        clientNonce: 'native-first-send',
+        nativeSessionStart: { idempotencyKey: 'cli-direct-local-first-send', retry: false },
+      },
+    })
+
+    expect(response.statusCode).toBe(202)
+    const receipt = response.json() as {
+      nativeSessionId: string
+      firstSendState: 'native_persisted' | 'prompt_failed'
+      session: { id: string; nativeSessionId?: string }
+    }
+    expect(receipt).toMatchObject({
+      nativeSessionId: expect.any(String),
+      firstSendState: expect.stringMatching(/^(native_persisted|prompt_failed)$/),
+    })
+    expect(receipt.session).toMatchObject({
+      id: receipt.nativeSessionId,
+      nativeSessionId: receipt.nativeSessionId,
+    })
+
+    const linkPayload = {
+      adapterId: 'smoke-adapter',
+      taskId: 'smoke-task-776',
+      sessionId: receipt.nativeSessionId,
+    }
+    const linked = await app.inject({ method: 'POST', url: '/api/boring-tasks/sessions/link', payload: linkPayload })
+    expect(linked.statusCode).toBe(200)
+    const duplicate = await app.inject({ method: 'POST', url: '/api/boring-tasks/sessions/link', payload: linkPayload })
+    expect(duplicate.statusCode).toBe(200)
+    expect(duplicate.json().link.id).toBe(linked.json().link.id)
+
+    const listedLinks = await app.inject({
+      method: 'POST',
+      url: '/api/boring-tasks/sessions/list',
+      payload: { adapterId: linkPayload.adapterId, taskId: linkPayload.taskId },
+    })
+    expect(listedLinks.statusCode).toBe(200)
+    expect(listedLinks.json().links).toEqual([
+      expect.objectContaining(linkPayload),
+    ])
+    const persistedLinks = JSON.parse(await readFile(join(workspaceRoot, '.pi/tasks/session-links.json'), 'utf8'))
+    expect(persistedLinks.links).toEqual([
+      expect.objectContaining(linkPayload),
+    ])
+
+    const sessions = await app.inject({ method: 'GET', url: '/api/v1/agent/pi-chat/sessions' })
+    expect(sessions.statusCode).toBe(200)
+    expect(sessions.json()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: receipt.nativeSessionId, nativeSessionId: receipt.nativeSessionId }),
+    ]))
+
+    const transcriptFiles = await filesUnder(sessionRoot)
+    expect(transcriptFiles).toHaveLength(1)
+    const transcript = await readFile(transcriptFiles[0]!, 'utf8')
+    expect(transcriptFiles[0]).toContain('.jsonl')
+    expect(transcript).not.toContain('pi_session_file')
+  } finally {
+    await app.close()
+  }
+}, 30_000)

--- a/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
+++ b/packages/cli/src/__tests__/workspacesModeRuntimePlugins.test.ts
@@ -191,6 +191,36 @@ describe("workspaces mode runtime plugin wiring", () => {
       .resolves.toBe("Updated prompt")
   })
 
+  test("registers trusted workspace-scoped task session link routes", async () => {
+    const homeRoot = await makeTempDir("boring-cli-task-session-home-")
+    const registryPath = join(await makeTempDir("boring-cli-task-session-registry-"), "workspaces.yaml")
+    const workspaceRoot = await makeTempDir("boring-cli-task-session-workspace-")
+    process.env.HOME = homeRoot
+    const [workspace] = await setupRegistry([workspaceRoot], registryPath)
+    const app = await createWorkspacesModeApp({ mode: "direct", registryPath, provisionWorkspace: false })
+
+    try {
+      const response = await app.inject({
+        method: "POST",
+        url: "/api/boring-tasks/sessions/list",
+        headers: { "x-boring-workspace-id": workspace.id },
+        payload: { adapterId: "github:workspace", taskId: "776" },
+      })
+      expect(response.statusCode, response.body).toBe(200)
+      expect(response.json()).toEqual({ ok: true, links: [] })
+
+      const catalog = await app.inject({
+        method: "GET",
+        url: "/api/v1/agent/catalog",
+        headers: { "x-boring-workspace-id": workspace.id },
+      })
+      expect(catalog.statusCode, catalog.body).toBe(200)
+      expect((catalog.json() as { tools: Array<{ name: string }> }).tools.map((tool) => tool.name)).toContain("manage_tasks")
+    } finally {
+      await app.close()
+    }
+  }, 10000)
+
   test("first SSE connect replays the active workspace scope without a prior GET", async () => {
     const homeRoot = await makeTempDir("boring-cli-workspaces-home-")
     const registryPath = join(await makeTempDir("boring-cli-workspaces-registry-"), "workspaces.yaml")

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -1,4 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from "fastify"
+import type { WorkspaceAgentServerPluginContext } from "@hachej/boring-workspace/app/server"
 import type {
   ProvisionWorkspaceRuntimeOptions,
   RuntimeModeAdapter,
@@ -396,9 +397,9 @@ export async function createFolderModeApp(opts: {
     workspaceRoot,
     mode: opts.mode,
     logger: false,
+    trustedDirectLocalNativeSessions: true,
     provisionWorkspace: false,
     runtimeProvisioning,
-    trustedDirectLocalNativeSessions: true,
     // The standalone CLI runs on the user's own machine, so ambient skill
     // discovery (workspace + user-global ~/.pi skills) is on. The library
     // default is off (withPiHarnessDefaults) to keep hosted agents isolated.
@@ -558,6 +559,7 @@ export async function createWorkspacesModeApp(opts: {
       const pluginCollection = await workspaceAppServer.resolveWorkspaceAgentServerPluginCollection({
         workspaceRoot: workspace.path,
         bridge: getBridge(workspace.id),
+        trustedPluginContext: taskSessionTrustedPluginContext,
         defaultPluginPackages: pluginDiscovery.resolveCliDefaultPluginPackagePaths(),
         installPluginAuthoring: false,
         excludeDefaults: ["boring-ui-plugin-cli-package"],
@@ -751,6 +753,29 @@ export async function createWorkspacesModeApp(opts: {
     return { workspace: toCoreWorkspace(workspace), role: "owner" }
   })
 
+  const taskSessionTrustedPluginContext = {
+    actorResolver: async (request: Parameters<NonNullable<WorkspaceAgentServerPluginContext["trusted"]>["actorResolver"]>[0]) => ({
+      workspaceId: (await workspaceFromRequest(request)).id,
+      userId: "local",
+    }),
+    actorVerifier: async (actor: { workspaceId: string; userId: string }) => (
+      actor.userId === "local" && Boolean(await registry.get(actor.workspaceId))
+    ),
+    workspaceAgentDispatcherResolver: {
+      resolve: async (actor, resolveOptions) => {
+        if (!workspaceAgentDispatcher) throw new Error("workspace agent dispatcher is not ready")
+        return await workspaceAgentDispatcher.resolve(actor, resolveOptions)
+      },
+      resolveWithWorkspace: async (actor, resolveOptions) => {
+        if (!workspaceAgentDispatcher?.resolveWithWorkspace) throw new Error("workspace agent workspace resolver is not ready")
+        return await workspaceAgentDispatcher.resolveWithWorkspace(actor, resolveOptions)
+      },
+      authorizeSession: async (actor, sessionId, resolveOptions) => {
+        if (!workspaceAgentDispatcher?.authorizeSession) throw new Error("workspace agent session authorizer is not ready")
+        await workspaceAgentDispatcher.authorizeSession(actor, sessionId, resolveOptions)
+      },
+    } satisfies WorkspaceAgentDispatcherResolver,
+  } satisfies NonNullable<WorkspaceAgentServerPluginContext["trusted"]>
   await app.register(agentServer.registerAgentRoutes, {
     mode: opts.mode,
     runtimeModeAdapter: sandboxRuntimeAdapter,
@@ -873,6 +898,9 @@ export async function createWorkspacesModeApp(opts: {
       })
     },
   })
+
+  const tasksServer = await import("@hachej/boring-tasks/server")
+  tasksServer.registerTaskSessionLinkRoutes(app, taskSessionTrustedPluginContext)
 
   await app.register(workspaceServer.uiRoutes, {
     getWorkspaceId: async (request) => (await workspaceFromRequest(request)).id,

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   registerAgentRoutes: vi.fn(async () => {}),
   provisionWorkspaceRuntime: vi.fn(async () => ({ changed: false, env: {}, pathEntries: [], skillPaths: [] })),
   collectWorkspaceAgentServerPlugins: vi.fn(),
+  resolveOnePluginEntry: vi.fn(async (entry: unknown, _context?: unknown) => entry),
   createWorkspaceUiTools: vi.fn(() => []),
   runtimeHost: { source: 'custom-adapter-host' },
 }))
@@ -19,6 +20,7 @@ vi.mock('@hachej/boring-agent/server', () => ({
 }))
 
 vi.mock('@hachej/boring-workspace/app/server', () => ({
+  assertWorkspaceBridgeHandlersTrusted: () => undefined,
   collectWorkspaceAgentServerPlugins: mocks.collectWorkspaceAgentServerPlugins,
   createSandboxRuntimeModeAdapter: () => ({ id: 'direct', runtimeHost: mocks.runtimeHost }),
   hasDirServerPlugin: () => false,
@@ -31,7 +33,7 @@ vi.mock('@hachej/boring-workspace/app/server', () => ({
   }),
   readWorkspacePluginPackageRuntimePlugins: () => [],
   resolveDefaultWorkspacePluginPackagePaths: () => [],
-  resolveOnePluginEntry: async (entry: unknown) => entry,
+  resolveOnePluginEntry: mocks.resolveOnePluginEntry,
   sandboxRuntimeHostOperations: {},
 }))
 
@@ -62,6 +64,7 @@ vi.mock('../../../server/auth/index.js', () => ({
 beforeEach(() => {
   vi.clearAllMocks()
   mocks.provisionWorkspaceRuntime.mockResolvedValue({ changed: false, env: {}, pathEntries: [], skillPaths: [] })
+  mocks.resolveOnePluginEntry.mockImplementation(async (entry: unknown, _context?: unknown) => entry)
 })
 
 vi.mock('../../../server/routes/index.js', () => ({
@@ -82,6 +85,50 @@ vi.mock('../../../server/db/index.js', () => ({
 vi.mock('../../../server/runtime/index.js', () => ({
   WorkspaceRuntimeSandboxHandleStore: class {},
 }))
+
+test('core/full-app trusted plugin context forwards redacted session-run detail reads', async () => {
+  mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
+    runtimePlugins: [],
+    provisioningContributions: [],
+    agentOptions: { extraTools: [], pi: { additionalSkillPaths: [], packages: [] } },
+    preservedUiStateKeys: [],
+    routeContributions: [],
+  })
+  let trustedContext: any
+  mocks.resolveOnePluginEntry.mockImplementation(async (_entry: unknown, context: unknown) => {
+    trustedContext = context
+    return { id: 'trusted-test-plugin' }
+  })
+  const { createCoreWorkspaceAgentServer } = await import('../createCoreWorkspaceAgentServer.js')
+  const app = await createCoreWorkspaceAgentServer({
+    config: createTestCoreConfig({ stores: 'postgres', databaseUrl: 'postgres://test' }),
+    workspaceRoot: '/tmp/full-app-workspaces',
+    serveFrontend: false,
+    registerHealthRoute: false,
+    plugins: [{ dir: '/tmp/trusted-test-plugin', trust: 'internal' }],
+  })
+  try {
+    const options = (mocks.registerAgentRoutes as any).mock.calls[0]?.[1] as Record<string, any>
+    const readSessionRunDetails = vi.fn(async () => [{
+      runId: 'run-1', terminalEntryId: 'terminal-1', state: 'success', details: [],
+    }])
+    options.onWorkspaceAgentDispatcher({
+      resolve: vi.fn(),
+      resolveWithWorkspace: vi.fn(),
+      authorizeSession: vi.fn(),
+      readSessionRunDetails,
+    })
+    const actor = { workspaceId: 'workspace-a', userId: 'user-a' }
+    await expect(trustedContext.trusted.workspaceAgentDispatcherResolver.readSessionRunDetails(
+      actor,
+      'native-exact',
+      ['boring.handover.operation'],
+    )).resolves.toEqual([{ runId: 'run-1', terminalEntryId: 'terminal-1', state: 'success', details: [] }])
+    expect(readSessionRunDetails).toHaveBeenCalledWith(actor, 'native-exact', ['boring.handover.operation'], undefined)
+  } finally {
+    await app.close()
+  }
+})
 
 test('core/full-app composition forwards collected runtime provisioning plugins to agent routes', async () => {
   const runtimePlugin = {

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -842,6 +842,18 @@ export async function createCoreWorkspaceAgentServer(
       }
       return await workspaceAgentDispatcherResolver.resolveWithWorkspace(actor, resolveOptions)
     },
+    async authorizeSession(actor, sessionId, resolveOptions) {
+      if (!workspaceAgentDispatcherResolver?.authorizeSession) {
+        throw new Error('workspace agent session authorizer is not ready')
+      }
+      await workspaceAgentDispatcherResolver.authorizeSession(actor, sessionId, resolveOptions)
+    },
+    async readSessionRunDetails(actor, sessionId, detailKinds, resolveOptions) {
+      if (!workspaceAgentDispatcherResolver?.readSessionRunDetails) {
+        throw new Error('workspace agent structured session reader is not ready')
+      }
+      return await workspaceAgentDispatcherResolver.readSessionRunDetails(actor, sessionId, detailKinds, resolveOptions)
+    },
   }
   const basePluginResolveContext: WorkspaceAgentServerPluginContext = {
     workspaceRoot: pluginWorkspaceRoot,

--- a/plugins/deck/src/front/__tests__/deckPluginScaffold.test.tsx
+++ b/plugins/deck/src/front/__tests__/deckPluginScaffold.test.tsx
@@ -30,11 +30,15 @@ vi.mock("../../../../../packages/workspace/src/front/chrome/artifact-surface/Art
 
   function MockArtifactSurfacePane(props: { onReady?: (api: unknown) => void }) {
     React.useEffect(() => {
+      const panels: Array<{ id: string }> = []
       props.onReady?.({
-        panels: [],
+        panels,
         activePanel: null,
-        getPanel: mockGetPanel,
-        addPanel: mockAddPanel,
+        getPanel: (id: string) => mockGetPanel(id) ?? panels.find((panel) => panel.id === id),
+        addPanel: (config: { id: string }) => {
+          mockAddPanel(config)
+          panels.push(config)
+        },
         onDidAddPanel: vi.fn(() => ({ dispose: vi.fn() })),
         onDidRemovePanel: vi.fn(() => ({ dispose: vi.fn() })),
         onDidActivePanelChange: vi.fn(() => ({ dispose: vi.fn() })),


### PR DESCRIPTION
## Summary

Final small wiring/test PR rebuilt on top of #925.

- Core trusted workspace agent server forwards native session capability seams.
- CLI workspace-mode wiring/integration coverage.
- Deck scaffold test compatibility.

## Proof

- `pnpm --filter @hachej/boring-core typecheck` — PASS
- `pnpm --filter @hachej/boring-ui-cli typecheck` — PASS
- `git diff --check` — PASS

## Risk / Rollback

Small final glue/test layer. Roll back independently after #925 if needed.
