### PR TITLE
feat(boring-mcp): add full-catalog Composio backend

### DIFF
--- a/plugins/boring-mcp/src/__tests__/composioManagedConnector.test.ts
+++ b/plugins/boring-mcp/src/__tests__/composioManagedConnector.test.ts
@@ -4,8 +4,14 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js"
 import { createBoringMcpAgentBridgeRegistry } from "../server/agentBridge"
-import { createComposioManagedConnectorProvider, createComposioMcpTransport } from "../server/composioManagedConnector"
-import { createManagedConnectorAdapter, type ManagedConnectorConfig, type ManagedConnectorSecretResolver, type ManagedConnectorSourceRegistry } from "../server/managedConnectorAdapter"
+import {
+  createComposioManagedConnectorProvider,
+  createComposioMcpAdapter,
+  createComposioMcpTransport,
+  requireExactlyOneComposioConnectedAccount,
+  resolveComposioMcpSession,
+} from "../server/composioManagedConnector"
+import { createManagedConnectorAdapter, type ManagedConnectorConfig, type ManagedConnectorDefinition, type ManagedConnectorSecretResolver, type ManagedConnectorSourceRegistry } from "../server/managedConnectorAdapter"
 import type { ManagedConnectorPreflightEvidence } from "../server/managedConnectorPreflight"
 import { createBoringMcpSourceHandlers } from "../server/sourceHandlers"
 import { MCP_ERROR_CODES, type McpActor, type McpSource } from "../shared"
@@ -17,8 +23,22 @@ const config: ManagedConnectorConfig = {
   toolkitId: "notion",
   connectUrlOrigins: ["https://app.composio.dev"],
 }
+const fullCatalogConfig: ManagedConnectorDefinition = {
+  mode: "catalog",
+  provider: "composio",
+  displayName: "Composio",
+  connectUrlOrigins: ["https://app.composio.dev"],
+}
 const secretResolver: ManagedConnectorSecretResolver = {
   resolveSecret: vi.fn(async () => ({ storage: "server-env" as const, value: "cmp_test_key" })),
+}
+const activeNotionAccount = {
+  id: "account-1",
+  user_id: "workspace-1:user-1",
+  status: "ACTIVE",
+  is_disabled: false,
+  toolkit: { slug: "notion" },
+  alias: "Demo Notion",
 }
 const preflightEvidence: ManagedConnectorPreflightEvidence = {
   connectorName: "Composio managed MCP",
@@ -67,8 +87,9 @@ function jsonResponse(payload: unknown, status = 200): Response {
   return new Response(JSON.stringify(payload), { status, headers: { "content-type": "application/json" } })
 }
 
-function createComposioFetch(mcpUrl = "https://mcp.example/session", accounts: unknown[] = [], deleteStatus = 200) {
+function createComposioFetch(mcpUrl = "https://backend.composio.dev/mcp/session", accounts: unknown[] = [], deleteStatus = 200) {
   let sessionCount = 0
+  let currentAccounts = [...accounts]
   const fakeFetch = vi.fn(async (input: string | URL, init?: RequestInit) => {
     expect(init?.headers).toMatchObject({ "x-api-key": "cmp_test_key" })
     const url = String(input)
@@ -76,20 +97,36 @@ function createComposioFetch(mcpUrl = "https://mcp.example/session", accounts: u
       expect(init?.method).toBe("GET")
       expect(url).toContain("user_id=workspace-1%3Auser-1")
       expect(url).toContain("toolkit_slug=notion")
-      return jsonResponse({ items: accounts })
+      return jsonResponse({ items: currentAccounts })
     }
     if (url.includes("/api/v3.1/connected_accounts/") && init?.method === "DELETE") {
+      const accountId = decodeURIComponent(url.split("/").at(-1) ?? "")
+      if (deleteStatus < 400 || deleteStatus === 404) {
+        currentAccounts = currentAccounts.filter((account) => {
+          const value = account as { id?: unknown }
+          return value.id !== accountId
+        })
+      }
       return jsonResponse({ deleted: deleteStatus < 400 }, deleteStatus)
     }
     if (url.endsWith("/api/v3.1/tool_router/session")) {
-      expect(JSON.parse(String(init?.body))).toMatchObject({
+      const body = JSON.parse(String(init?.body)) as Record<string, unknown>
+      expect(body).toMatchObject({
         user_id: "workspace-1:user-1",
         mcp: true,
-        toolkits: { enable: ["notion"] },
         manage_connections: { enable: true, enable_wait_for_connections: false },
+        workbench: { enable: false },
       })
       sessionCount += 1
-      return jsonResponse({ id: `session-${sessionCount}`, mcp: { url: mcpUrl, headers: { "x-composio-mcp-session": `server-only-session-${sessionCount}` } } })
+      return jsonResponse({
+        id: `session-${sessionCount}`,
+        mcp: { url: mcpUrl, headers: { "x-composio-mcp-session": `server-only-session-${sessionCount}` } },
+        config: {
+          toolkits: body.toolkits,
+          connected_accounts: body.connected_accounts,
+          workbench: body.workbench,
+        },
+      })
     }
     if (/\/api\/v3\/tool_router\/session\/session-\d+\/link$/.test(url)) {
       expect(JSON.parse(String(init?.body))).toMatchObject({ toolkit: "notion" })
@@ -106,9 +143,9 @@ async function readJson(req: IncomingMessage): Promise<unknown> {
   return chunks.length ? JSON.parse(Buffer.concat(chunks).toString("utf8")) : undefined
 }
 
-function createFakeMcpServer(seenHeaders: string[]) {
+function createFakeMcpServer(seenHeaders: string[], description = "Search pages", toolText = "composio mcp ok") {
   const server = new McpServer({ name: "composio-fake-mcp", version: "1.0.0" })
-  server.registerTool("NOTION_SEARCH_NOTION_PAGE", { description: "Search pages" }, async () => ({ content: [{ type: "text", text: "composio mcp ok" }] }))
+  server.registerTool("NOTION_SEARCH_NOTION_PAGE", { description }, async () => ({ content: [{ type: "text", text: toolText }] }))
   server.registerTool("COMPOSIO_MANAGE_CONNECTIONS", { description: "Raw meta tool must stay hidden" }, async () => ({ content: [{ type: "text", text: "hidden" }] }))
   return createServer(async (req: IncomingMessage, res: ServerResponse) => {
     if (req.url !== "/mcp" || req.method !== "POST") {
@@ -126,9 +163,9 @@ function createFakeMcpServer(seenHeaders: string[]) {
   })
 }
 
-async function listenFakeMcpServer() {
+async function listenFakeMcpServer(description?: string, toolText?: string) {
   const seenHeaders: string[] = []
-  const httpServer = createFakeMcpServer(seenHeaders)
+  const httpServer = createFakeMcpServer(seenHeaders, description, toolText)
   await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve))
   const { port } = httpServer.address() as AddressInfo
   const close = () => new Promise<void>((resolve, reject) => httpServer.close((error) => error ? reject(error) : resolve()))
@@ -136,15 +173,16 @@ async function listenFakeMcpServer() {
   return { url: `http://127.0.0.1:${port}/mcp`, seenHeaders }
 }
 
-function createFakeComposioMetaMcpServer(seenHeaders: string[], seenToolCalls: string[]) {
+function createFakeComposioMetaMcpServer(seenHeaders: string[], seenToolCalls: string[], seenToolArguments: unknown[], schemaToolkit?: string) {
   const server = new McpServer({ name: "composio-meta-fake-mcp", version: "1.0.0" })
   server.registerTool("COMPOSIO_SEARCH_TOOLS", { description: "Search provider tools" }, async () => ({
     content: [{ type: "text", text: JSON.stringify({ data: { results: [{ toolkits: ["notion"], primary_tool_slugs: ["NOTION_SEARCH_NOTION_PAGE"], related_tool_slugs: ["NOTION_GET_PAGE_MARKDOWN", "COMPOSIO_MANAGE_CONNECTIONS"] }] } }) }],
   }))
   server.registerTool("COMPOSIO_GET_TOOL_SCHEMAS", { description: "Get provider tool schemas" }, async () => ({
     content: [{ type: "text", text: JSON.stringify({ data: { success: true, tool_schemas: {
-      NOTION_SEARCH_NOTION_PAGE: { tool_slug: "NOTION_SEARCH_NOTION_PAGE", description: "Search pages", input_schema: { type: "object", properties: { query: { type: "string" } } } },
+      NOTION_SEARCH_NOTION_PAGE: { tool_slug: "NOTION_SEARCH_NOTION_PAGE", toolkit_slug: schemaToolkit, description: "Search pages", input_schema: { type: "object", properties: { query: { type: "string" } } } },
       NOTION_GET_PAGE_MARKDOWN: { tool_slug: "NOTION_GET_PAGE_MARKDOWN", description: "Read page markdown", input_schema: { type: "object", properties: { page_id: { type: "string" } } } },
+      NOTION_RETRIEVE_PAGE: { tool_slug: "NOTION_RETRIEVE_PAGE", description: "Retrieve page", input_schema: { type: "object", properties: { page_id: { type: "string" } } } },
     } } }) }],
   }))
   server.registerTool("COMPOSIO_MULTI_EXECUTE_TOOL", { description: "Execute provider tools" }, async () => ({ content: [{ type: "text", text: "meta execute ok" }] }))
@@ -159,8 +197,11 @@ function createFakeComposioMetaMcpServer(seenHeaders: string[], seenToolCalls: s
     const body = await readJson(req)
     for (const message of Array.isArray(body) ? body : [body]) {
       if (message && typeof message === "object" && (message as { method?: unknown }).method === "tools/call") {
-        const params = (message as { params?: { name?: unknown } }).params
-        if (typeof params?.name === "string") seenToolCalls.push(params.name)
+        const params = (message as { params?: { name?: unknown; arguments?: unknown } }).params
+        if (typeof params?.name === "string") {
+          seenToolCalls.push(params.name)
+          seenToolArguments.push(params.arguments)
+        }
       }
     }
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined, enableJsonResponse: true })
@@ -170,15 +211,48 @@ function createFakeComposioMetaMcpServer(seenHeaders: string[], seenToolCalls: s
   })
 }
 
-async function listenFakeComposioMetaMcpServer() {
+async function listenFakeComposioMetaMcpServer(schemaToolkit?: string) {
   const seenHeaders: string[] = []
   const seenToolCalls: string[] = []
-  const httpServer = createFakeComposioMetaMcpServer(seenHeaders, seenToolCalls)
+  const seenToolArguments: unknown[] = []
+  const httpServer = createFakeComposioMetaMcpServer(seenHeaders, seenToolCalls, seenToolArguments, schemaToolkit)
   await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve))
   const { port } = httpServer.address() as AddressInfo
   const close = () => new Promise<void>((resolve, reject) => httpServer.close((error) => error ? reject(error) : resolve()))
   servers.push({ close })
-  return { url: `http://127.0.0.1:${port}/mcp`, seenHeaders, seenToolCalls }
+  return { url: `http://127.0.0.1:${port}/mcp`, seenHeaders, seenToolCalls, seenToolArguments }
+}
+
+async function listenRedirectingMcpServer() {
+  let redirectedRequests = 0
+  let leakedApiKey: string | undefined
+  const destination = createServer((req, res) => {
+    redirectedRequests += 1
+    leakedApiKey = typeof req.headers["x-api-key"] === "string" ? req.headers["x-api-key"] : undefined
+    res.statusCode = 200
+    res.end("{}")
+  })
+  await new Promise<void>((resolve) => destination.listen(0, "127.0.0.1", resolve))
+  const destinationPort = (destination.address() as AddressInfo).port
+  const redirect = createServer((_req, res) => {
+    res.statusCode = 307
+    res.setHeader("location", `http://127.0.0.1:${destinationPort}/capture`)
+    res.end()
+  })
+  await new Promise<void>((resolve) => redirect.listen(0, "127.0.0.1", resolve))
+  const redirectPort = (redirect.address() as AddressInfo).port
+  const close = async () => {
+    await Promise.all([
+      new Promise<void>((resolve, reject) => redirect.close((error) => error ? reject(error) : resolve())),
+      new Promise<void>((resolve, reject) => destination.close((error) => error ? reject(error) : resolve())),
+    ])
+  }
+  servers.push({ close })
+  return {
+    url: `http://127.0.0.1:${redirectPort}/mcp`,
+    redirectedRequests: () => redirectedRequests,
+    leakedApiKey: () => leakedApiKey,
+  }
 }
 
 afterEach(async () => {
@@ -211,8 +285,24 @@ describe("Composio managed connector provider", () => {
     expect(fetch).toHaveBeenCalledTimes(3)
   })
 
+  it("verified-cleans a created Session when adapter persistence validation fails", async () => {
+    const fetch = createComposioFetch()
+    const registry = createRegistry()
+    const adapter = createManagedConnectorAdapter({
+      registry,
+      provider: createComposioManagedConnectorProvider({ fetch }),
+      secretResolver,
+      configs: [{ ...config, connectUrlOrigins: ["https://approved.example"] }],
+      preflightEvidence,
+    })
+
+    await expect(adapter.startConnect(actor, { provider: "notion" })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
+    expect(fetch).toHaveBeenCalledWith(expect.stringMatching(/session\/session-1$/), expect.objectContaining({ method: "DELETE" }))
+    expect(fetch).toHaveBeenCalledWith(expect.stringMatching(/session\/session-1$/), expect.objectContaining({ method: "GET" }))
+  })
+
   it("promotes an unconfigured source to connected only after Composio reports an active connected account", async () => {
-    const fetch = createComposioFetch("https://mcp.example/session", [{
+    const fetch = createComposioFetch("https://backend.composio.dev/mcp/session", [{
       id: "account-1",
       user_id: "workspace-1:user-1",
       status: "ACTIVE",
@@ -240,7 +330,7 @@ describe("Composio managed connector provider", () => {
   })
 
   it("treats an already-missing Composio connected account as a successful local disconnect", async () => {
-    const fetch = createComposioFetch("https://mcp.example/session", [{
+    const fetch = createComposioFetch("https://backend.composio.dev/mcp/session", [{
       id: "account-gone",
       user_id: "workspace-1:user-1",
       status: "ACTIVE",
@@ -263,16 +353,196 @@ describe("Composio managed connector provider", () => {
     expect(fetch).toHaveBeenCalledWith("https://backend.composio.dev/api/v3.1/connected_accounts/account-gone", expect.objectContaining({ method: "DELETE" }))
   })
 
+  it("revokes and verifies an owned inactive account instead of dropping its identity", async () => {
+    const inactiveAccount = { ...activeNotionAccount, id: "account-inactive", status: "DISABLED" }
+    const fetch = createComposioFetch(undefined, [inactiveAccount])
+    const registry = createRegistry()
+    const adapter = createManagedConnectorAdapter({
+      registry,
+      provider: createComposioManagedConnectorProvider({ fetch }),
+      secretResolver,
+      configs: [config],
+      preflightEvidence,
+    })
+
+    const started = await adapter.startConnect(actor, { provider: "notion" })
+    await expect(adapter.refreshStatus(actor, started.source.id)).resolves.toMatchObject({ source: { status: "unconfigured" } })
+    await expect(adapter.disconnectSource(actor, started.source.id)).resolves.toMatchObject({ source: { status: "revoked" } })
+    expect(fetch).toHaveBeenCalledWith("https://backend.composio.dev/api/v3.1/connected_accounts/account-inactive", expect.objectContaining({ method: "DELETE" }))
+  })
+
   it("rejects non-HTTPS Composio MCP session URLs unless using the loopback-only test override", async () => {
     const fetch = createComposioFetch("http://evil.example/mcp")
     const provider = createComposioManagedConnectorProvider({ fetch })
 
     await expect(provider.probe({
       actor,
-      config,
+      config: fullCatalogConfig,
       secret: { storage: "server-env", value: "cmp_test_key" },
       source: {} as McpSource,
     })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
+  })
+
+  it("rejects unapproved Composio API and MCP origins before secret egress", async () => {
+    const apiFetch = vi.fn(async () => jsonResponse({})) as typeof fetch & ReturnType<typeof vi.fn>
+    await expect(resolveComposioMcpSession({ fetch: apiFetch, apiBaseUrl: "https://unapproved.example" }, {
+      actor,
+      config: fullCatalogConfig,
+      secret: { storage: "server-env", value: "cmp_test_key" },
+    })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
+    expect(apiFetch).not.toHaveBeenCalled()
+
+    const mcpFetch = createComposioFetch("https://unapproved.example/mcp")
+    await expect(resolveComposioMcpSession({ fetch: mcpFetch }, {
+      actor,
+      config: fullCatalogConfig,
+      secret: { storage: "server-env", value: "cmp_test_key" },
+    })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
+
+    await expect(resolveComposioMcpSession({ fetch: createComposioFetch("https://tenant-composio.example/mcp") }, {
+      actor,
+      config: { ...fullCatalogConfig, mcpUrlOrigins: ["https://tenant-composio.example"] },
+      secret: { storage: "server-env", value: "cmp_test_key" },
+    })).resolves.toMatchObject({ mcp: { url: "https://tenant-composio.example/mcp" } })
+  })
+
+  it("rejects MCP redirects before the operator key can cross to another destination", async () => {
+    const redirect = await listenRedirectingMcpServer()
+    const source: McpSource = {
+      id: "managed:workspace-1:user-1:composio",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      provider: "composio",
+      displayName: "Composio",
+      status: "connected",
+      ownerKind: "user",
+      credentialProvider: "composio-managed",
+    }
+    const composio = createComposioMcpAdapter({
+      fetch: createComposioFetch(redirect.url),
+      secretResolver,
+      configs: [fullCatalogConfig],
+      allowInsecureMcpUrlsForTests: true,
+    })
+
+    await expect(composio.transport.listTools(source)).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+    expect(redirect.redirectedRequests()).toBe(0)
+    expect(redirect.leakedApiKey()).toBeUndefined()
+  })
+
+  it("redacts exact operator-key echoes from MCP transport failures", async () => {
+    const source: McpSource = {
+      id: "managed:workspace-1:user-1:composio",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      provider: "composio",
+      displayName: "Composio",
+      status: "connected",
+      ownerKind: "user",
+      credentialProvider: "composio-managed",
+    }
+    const mcpFetch = vi.fn(async () => { throw new Error("cmp_test_key") }) as typeof globalThis.fetch & ReturnType<typeof vi.fn>
+    const composio = createComposioMcpAdapter({ fetch: createComposioFetch(), mcpFetch, secretResolver, configs: [fullCatalogConfig] })
+
+    const error = await composio.transport.listTools(source).catch((caught: unknown) => caught)
+    expect(error).toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+    expect(JSON.stringify(error)).not.toContain("cmp_test_key")
+  })
+
+  it("rejects incomplete connected-account pages and malformed Session security echoes", async () => {
+    const secret = { storage: "server-env" as const, value: "cmp_test_key" }
+    const fullPage = Array.from({ length: 100 }, (_, index) => ({
+      ...activeNotionAccount,
+      id: `account-${index}`,
+      status: index === 0 ? "ACTIVE" : "DISABLED",
+    }))
+    await expect(requireExactlyOneComposioConnectedAccount({ fetch: createComposioFetch(undefined, fullPage) }, { actor, secret, toolkitId: "notion" }))
+      .rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+    await expect(requireExactlyOneComposioConnectedAccount({ fetch: createComposioFetch(undefined, [{ ...activeNotionAccount, id: undefined }]) }, { actor, secret, toolkitId: "notion" }))
+      .rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+    await expect(requireExactlyOneComposioConnectedAccount({ fetch: createComposioFetch(undefined, [null]) }, { actor, secret, toolkitId: "notion" }))
+      .rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+    const malformedPageFetch = vi.fn(async () => jsonResponse({ items: [], has_more: "false" })) as typeof globalThis.fetch & ReturnType<typeof vi.fn>
+    await expect(requireExactlyOneComposioConnectedAccount({ fetch: malformedPageFetch }, { actor, secret, toolkitId: "notion" }))
+      .rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith("/api/v3.1/tool_router/session")) {
+        return jsonResponse({
+          id: "session-drifted",
+          mcp: { url: "https://backend.composio.dev/mcp" },
+          config: { workbench: { enable: true } },
+        })
+      }
+      if (url.endsWith("/api/v3.1/tool_router/session/session-drifted") && init?.method === "DELETE") return new Response(undefined, { status: 204 })
+      return jsonResponse({ error: "not found" }, 404)
+    }) as typeof globalThis.fetch & ReturnType<typeof vi.fn>
+    await expect(resolveComposioMcpSession({ fetch }, { actor, config: fullCatalogConfig, secret }))
+      .rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+    expect(fetch).toHaveBeenCalledWith(expect.stringMatching(/session\/session-drifted$/), expect.objectContaining({ method: "DELETE" }))
+    expect(fetch).toHaveBeenCalledWith(expect.stringMatching(/session\/session-drifted$/), expect.objectContaining({ method: "GET" }))
+  })
+
+  it("redacts an exact operator-key echo from Composio error details", async () => {
+    const fetch = vi.fn(async () => jsonResponse({ echo: "cmp_test_key" }, 400)) as typeof globalThis.fetch & ReturnType<typeof vi.fn>
+    const error = await resolveComposioMcpSession({ fetch }, {
+      actor,
+      config: fullCatalogConfig,
+      secret: { storage: "server-env", value: "cmp_test_key" },
+    }).catch((caught: unknown) => caught)
+
+    expect(error).toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR, details: { status: 400 } })
+    expect(JSON.stringify(error)).not.toContain("cmp_test_key")
+
+    const thrownFetch = vi.fn(async () => { throw new Error("cmp_test_key") }) as typeof globalThis.fetch & ReturnType<typeof vi.fn>
+    const thrown = await resolveComposioMcpSession({ fetch: thrownFetch }, {
+      actor,
+      config: fullCatalogConfig,
+      secret: { storage: "server-env", value: "cmp_test_key" },
+    }).catch((caught: unknown) => caught)
+    expect(JSON.stringify(thrown)).not.toContain("cmp_test_key")
+  })
+
+  it("bounds streamed Composio API responses before buffering them", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("{\"padding\":\""))
+        controller.enqueue(new Uint8Array(64))
+        controller.close()
+      },
+    })
+    const fetch = vi.fn(async () => new Response(body, { status: 200 })) as typeof globalThis.fetch & ReturnType<typeof vi.fn>
+    await expect(resolveComposioMcpSession({ fetch, maxResponseBytes: 32 }, {
+      actor,
+      config: fullCatalogConfig,
+      secret: { storage: "server-env", value: "cmp_test_key" },
+    })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+  })
+
+  it("keeps the Composio API timeout active while reading the response body", async () => {
+    const fetch = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      const signal = init?.signal
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          const timer = setTimeout(() => {
+            controller.enqueue(new TextEncoder().encode("{}"))
+            controller.close()
+          }, 100)
+          signal?.addEventListener("abort", () => {
+            clearTimeout(timer)
+            controller.error(new DOMException("aborted", "AbortError"))
+          }, { once: true })
+        },
+      })
+      return new Response(body, { status: 200 })
+    }) as typeof globalThis.fetch & ReturnType<typeof vi.fn>
+
+    await expect(resolveComposioMcpSession({ fetch, requestTimeoutMs: 5 }, {
+      actor,
+      config: fullCatalogConfig,
+      secret: { storage: "server-env", value: "cmp_test_key" },
+    })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_TIMEOUT })
   })
 
   it("rejects non-server Composio transport secrets before any provider request", async () => {
@@ -296,9 +566,27 @@ describe("Composio managed connector provider", () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
+  it("rejects oversized direct MCP tool metadata before catalog normalization", async () => {
+    const fakeMcp = await listenFakeMcpServer("x".repeat(4_001))
+    const fetch = createComposioFetch(fakeMcp.url)
+    const transport = createComposioMcpTransport({ fetch, secretResolver, configs: [config], allowInsecureMcpUrlsForTests: true })
+    const source: McpSource = {
+      id: "managed:workspace-1:user-1:notion",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      provider: "notion",
+      displayName: "Notion",
+      status: "connected",
+      ownerKind: "user",
+      credentialProvider: "composio-managed",
+    }
+
+    await expect(transport.listTools(source)).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+  })
+
   it("uses Composio session MCP headers with the real MCP SDK transport and hides raw Composio meta tools", async () => {
     const fakeMcp = await listenFakeMcpServer()
-    const fetch = createComposioFetch(fakeMcp.url)
+    const fetch = createComposioFetch(fakeMcp.url, [activeNotionAccount])
     const registry = createRegistry()
     const source = await registry.upsertSource(actor, {
       id: "managed:workspace-1:user-1:notion",
@@ -326,9 +614,181 @@ describe("Composio managed connector provider", () => {
     expect(fakeMcp.seenHeaders).toContain("cmp_test_key")
   })
 
-  it("discovers live-style Composio provider tools through server-side meta tools", async () => {
+  it("blocks exact execution-Session capabilities echoed in successful tool output", async () => {
+    const fakeMcp = await listenFakeMcpServer(undefined, "server-only-session-2")
+    const fetch = createComposioFetch(fakeMcp.url, [activeNotionAccount])
+    const source: McpSource = {
+      id: "managed:workspace-1:user-1:notion",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      provider: "notion",
+      displayName: "Notion",
+      status: "connected",
+      ownerKind: "user",
+      credentialProvider: "composio-managed",
+      connectorRef: { provider: "notion", toolkitId: "notion" },
+    }
+    const transport = createComposioMcpTransport({ fetch, secretResolver, configs: [config], allowInsecureMcpUrlsForTests: true })
+
+    await expect(transport.callTool(source, "NOTION_SEARCH_NOTION_PAGE", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.SECRET_LEAK_GUARD })
+  })
+
+  it("attempts verified cleanup for every cached Session when one deletion fails", async () => {
+    const fakeMcp = await listenFakeMcpServer()
+    const baseFetch = createComposioFetch(fakeMcp.url, [activeNotionAccount])
+    const deletedSessionIds: string[] = []
+    const fetch = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      const sessionMatch = url.match(/\/api\/v3\.1\/tool_router\/session\/(session-\d+)$/)
+      if (sessionMatch && init?.method === "DELETE") {
+        deletedSessionIds.push(sessionMatch[1]!)
+        return sessionMatch[1] === "session-1" ? jsonResponse({ error: "cleanup failed" }, 500) : new Response(undefined, { status: 204 })
+      }
+      if (sessionMatch && init?.method === "GET") return jsonResponse({ error: "not found" }, 404)
+      return baseFetch(input as string | URL, init)
+    }) as typeof globalThis.fetch & ReturnType<typeof vi.fn>
+    const source: McpSource = {
+      id: "managed:workspace-1:user-1:notion",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      provider: "notion",
+      displayName: "Notion",
+      status: "connected",
+      ownerKind: "user",
+      credentialProvider: "composio-managed",
+      connectorRef: { provider: "notion", toolkitId: "notion" },
+    }
+    const composio = createComposioMcpAdapter({ fetch, secretResolver, configs: [config], allowInsecureMcpUrlsForTests: true })
+
+    await expect(composio.transport.callTool(source, "NOTION_SEARCH_NOTION_PAGE", {})).resolves.toMatchObject({ content: expect.any(Array) })
+    await expect(composio.catalog.disposeSource?.(source)).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+    expect(deletedSessionIds).toEqual(expect.arrayContaining(["session-1", "session-2"]))
+  })
+
+  it("supports one template-free full-catalog source and omits toolkit filters from its Session", async () => {
     const fakeMcp = await listenFakeComposioMetaMcpServer()
     const fetch = createComposioFetch(fakeMcp.url)
+    const registry = createRegistry()
+    const adapter = createManagedConnectorAdapter({
+      registry,
+      provider: createComposioManagedConnectorProvider({ fetch, allowInsecureMcpUrlsForTests: true }),
+      secretResolver,
+      configs: [fullCatalogConfig],
+      preflightEvidence,
+    })
+
+    const started = await adapter.startConnect(actor, { provider: "composio" })
+    expect(started).toMatchObject({ source: { provider: "composio", status: "connected" } })
+    expect(started.connectUrl).toBeUndefined()
+    await expect(adapter.refreshStatus(actor, started.source.id)).resolves.toMatchObject({ source: { status: "connected" } })
+    await expect(adapter.probeSource(actor, started.source.id)).resolves.toMatchObject({ provider: "composio", tools: [] })
+    const sessionCall = fetch.mock.calls.find(([url]) => String(url).endsWith("/api/v3.1/tool_router/session"))
+    const body = JSON.parse(String(sessionCall?.[1]?.body)) as Record<string, unknown>
+    expect(body).toMatchObject({ workbench: { enable: false }, mcp: true })
+    expect(body).not.toHaveProperty("toolkits")
+  })
+
+  it("requires exactly one active owned account and preserves its exact Session pin", async () => {
+    const secret = { storage: "server-env" as const, value: "cmp_test_key" }
+    const twoAccounts = [activeNotionAccount, { ...activeNotionAccount, id: "account-2" }]
+    await expect(requireExactlyOneComposioConnectedAccount({ fetch: createComposioFetch() }, { actor, secret, toolkitId: "notion" }))
+      .rejects.toMatchObject({ code: MCP_ERROR_CODES.CONNECTED_ACCOUNT_REQUIRED })
+    await expect(requireExactlyOneComposioConnectedAccount({ fetch: createComposioFetch(undefined, twoAccounts) }, { actor, secret, toolkitId: "notion" }))
+      .rejects.toMatchObject({ code: MCP_ERROR_CODES.CONNECTED_ACCOUNT_CONFLICT })
+
+    const fetch = createComposioFetch(undefined, [
+      { ...activeNotionAccount, id: "other-user", user_id: "workspace-1:user-2" },
+      activeNotionAccount,
+    ])
+    const account = await requireExactlyOneComposioConnectedAccount({ fetch }, { actor, secret, toolkitId: "notion" })
+    expect(account.id).toBe("account-1")
+
+    await resolveComposioMcpSession({ fetch }, {
+      actor,
+      config: fullCatalogConfig,
+      secret,
+      accountPin: { toolkitId: "notion", connectedAccountId: account.id },
+    })
+    const sessionCalls = fetch.mock.calls.filter(([url]) => String(url).endsWith("/api/v3.1/tool_router/session"))
+    const body = JSON.parse(String(sessionCalls.at(-1)?.[1]?.body)) as Record<string, unknown>
+    expect(body).toMatchObject({
+      workbench: { enable: false },
+      connected_accounts: { notion: ["account-1"] },
+    })
+    expect(body).not.toHaveProperty("toolkits")
+  })
+
+  it("forwards the exact query through the managed catalog seam and keeps raw meta-tools hidden", async () => {
+    const fakeMcp = await listenFakeComposioMetaMcpServer()
+    const fetch = createComposioFetch(fakeMcp.url)
+    const registry = createRegistry()
+    const source = await registry.upsertSource(actor, {
+      id: "managed:workspace-1:user-1:composio",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      provider: "composio",
+      displayName: "Composio",
+      status: "connected",
+      ownerKind: "user",
+      credentialProvider: "composio-managed",
+    })
+    const composio = createComposioMcpAdapter({
+      fetch,
+      secretResolver,
+      configs: [fullCatalogConfig],
+      allowInsecureMcpUrlsForTests: true,
+    })
+    const handlers = createBoringMcpSourceHandlers({
+      registry,
+      transport: composio.transport,
+      managedCatalog: composio.catalog,
+    })
+
+    await expect(handlers.doctorSource(actor, source.id)).resolves.toMatchObject({ ok: true, issues: [] })
+    const probe = await handlers.probeSource(actor, source.id)
+    expect(probe.provider).toBe("composio")
+    expect(probe.resources).toEqual([])
+    expect(probe.tools[0]).toMatchObject({ name: "NOTION_SEARCH_NOTION_PAGE", decision: { allowed: false, risk: "unknown" } })
+    const searched = await handlers.searchTools(actor, { sourceId: source.id, query: "github current user", limit: 1 })
+    expect(searched).toMatchObject({
+      tools: [expect.objectContaining({ toolName: "NOTION_SEARCH_NOTION_PAGE", enabled: false, nativeRef: { provider: "composio", toolkit: "notion", action: "NOTION_SEARCH_NOTION_PAGE" } })],
+    })
+    expect(fakeMcp.seenToolArguments).toContainEqual(expect.objectContaining({ queries: ["github current user"] }))
+
+    const described = await handlers.describeTool(actor, { sourceId: source.id, toolName: "NOTION_SEARCH_NOTION_PAGE" })
+    expect(described.tool.toolName).toBe("NOTION_SEARCH_NOTION_PAGE")
+    expect(described.tool.nativeRef.toolkit).toBe("notion")
+    expect(described.tool.descriptorHash).toBe(searched.tools[0]?.descriptorHash)
+    await expect(composio.catalog.describeTool(source, "COMPOSIO_MULTI_EXECUTE_TOOL")).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
+    await expect(composio.transport.callTool(source, "COMPOSIO_REMOTE_BASH_TOOL", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
+    await expect(composio.transport.callTool(source, "NOTION_SEARCH_NOTION_PAGE", {})).rejects.toMatchObject({ code: MCP_ERROR_CODES.TOOL_NOT_ALLOWED })
+    await expect(composio.transport.listTools(source)).resolves.toEqual([])
+    await composio.catalog.disposeSource?.(source)
+    expect(fetch).toHaveBeenCalledWith(expect.stringMatching(/\/api\/v3\.1\/tool_router\/session\/session-\d+$/), expect.objectContaining({ method: "DELETE" }))
+    expect(fetch).toHaveBeenCalledWith(expect.stringMatching(/\/api\/v3\.1\/tool_router\/session\/session-\d+$/), expect.objectContaining({ method: "GET" }))
+  })
+
+  it("rejects schema toolkit identity that contradicts provider search provenance", async () => {
+    const fakeMcp = await listenFakeComposioMetaMcpServer("github")
+    const fetch = createComposioFetch(fakeMcp.url)
+    const source: McpSource = {
+      id: "managed:workspace-1:user-1:composio",
+      workspaceId: actor.workspaceId,
+      userId: actor.userId,
+      provider: "composio",
+      displayName: "Composio",
+      status: "connected",
+      ownerKind: "user",
+      credentialProvider: "composio-managed",
+    }
+    const composio = createComposioMcpAdapter({ fetch, secretResolver, configs: [fullCatalogConfig], allowInsecureMcpUrlsForTests: true })
+
+    await expect(composio.catalog.searchTools(source, { query: "notion", limit: 1 })).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_ERROR })
+  })
+
+  it("discovers live-style Composio provider tools through server-side meta tools", async () => {
+    const fakeMcp = await listenFakeComposioMetaMcpServer()
+    const fetch = createComposioFetch(fakeMcp.url, [activeNotionAccount])
     const registry = createRegistry()
     const source = await registry.upsertSource(actor, {
       id: "managed:workspace-1:user-1:notion",
@@ -349,6 +809,7 @@ describe("Composio managed connector provider", () => {
       tools: [
         expect.objectContaining({ toolName: "NOTION_SEARCH_NOTION_PAGE", enabled: true }),
         expect.objectContaining({ toolName: "NOTION_GET_PAGE_MARKDOWN", enabled: true }),
+        expect.objectContaining({ toolName: "NOTION_RETRIEVE_PAGE", enabled: true }),
       ],
     })
     const searchCallsAfterFirstLoad = fakeMcp.seenToolCalls.filter((name) => name === "COMPOSIO_SEARCH_TOOLS").length

--- a/plugins/boring-mcp/src/__tests__/managedConnectorAdapter.test.ts
+++ b/plugins/boring-mcp/src/__tests__/managedConnectorAdapter.test.ts
@@ -238,7 +238,7 @@ describe("managed connector adapter", () => {
     expect(secretResolver.resolveSecret).not.toHaveBeenCalled()
   })
 
-  it("disconnects stale sources locally when remote revoke cannot be configured", async () => {
+  it("fails closed when remote revoke cannot be configured", async () => {
     const provider = createProvider()
     provider.revoke = vi.fn()
     const registry = createRegistry()
@@ -262,9 +262,9 @@ describe("managed connector adapter", () => {
     }
     await registry.upsertSource(actor, source)
 
-    const result = await adapter.disconnectSource(actor, source.id)
+    await expect(adapter.disconnectSource(actor, source.id)).rejects.toMatchObject({ code: MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID })
 
-    expect(result.source.status).toBe("revoked")
+    expect((await registry.getSource(source.id))?.status).toBe("connected")
     expect(secretResolver.resolveSecret).toHaveBeenCalledWith("notion")
     expect(provider.revoke).not.toHaveBeenCalled()
   })

--- a/plugins/boring-mcp/src/__tests__/toolCatalog.test.ts
+++ b/plugins/boring-mcp/src/__tests__/toolCatalog.test.ts
@@ -64,6 +64,10 @@ describe("boring-mcp tool catalog", () => {
         risk: "read",
         blockedReasons: [],
         schemaHash: createMcpSchemaHash(readonlySearch.inputSchema),
+        descriptorHash: expect.stringMatching(/^sha256:/),
+        sourceRevision: expect.any(String),
+        policyRevision: expect.stringMatching(/^sha256:/),
+        accountRequired: true,
       }),
     ])
     expect(tx.callTool).not.toHaveBeenCalled()

--- a/plugins/boring-mcp/src/server/agentBridge.ts
+++ b/plugins/boring-mcp/src/server/agentBridge.ts
@@ -66,6 +66,7 @@ const TOOL_SEARCH_INPUT_SCHEMA = {
   properties: {
     sourceId: { type: "string", description: "Optional source id to search within." },
     query: { type: "string", description: "Optional text query for tool name, summary, provider, or description." },
+    limit: { type: "integer", minimum: 1, maximum: 20, description: "Maximum number of matching tools (1-20)." },
     refresh: { type: "boolean", description: "Refresh provider tool metadata before searching." },
   },
   additionalProperties: false,
@@ -138,6 +139,13 @@ function optionalStringField(record: Record<string, unknown>, key: string): stri
   return value
 }
 
+function optionalIntegerField(record: Record<string, unknown>, key: string): number | undefined {
+  const value = record[key]
+  if (value === undefined) return undefined
+  if (!Number.isInteger(value)) throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, `MCP bridge ${key} must be an integer`)
+  return value as number
+}
+
 function optionalBooleanField(record: Record<string, unknown>, key: string): boolean | undefined {
   const value = record[key]
   if (value === undefined) return undefined
@@ -169,6 +177,7 @@ function parseSearchInput(input: unknown): McpToolsSearchInput {
   return {
     sourceId: sourceId === undefined ? undefined : parseBridgeSourceId(sourceId),
     query: optionalStringField(record, "query"),
+    limit: optionalIntegerField(record, "limit"),
     refresh: optionalBooleanField(record, "refresh"),
   }
 }

--- a/plugins/boring-mcp/src/server/agentTools.ts
+++ b/plugins/boring-mcp/src/server/agentTools.ts
@@ -3,6 +3,7 @@ import type { McpActor, McpProviderTemplate, McpSourceRegistry, McpTransportClie
 import { createBoringMcpAgentBridgeRegistry, listBoringMcpAgentBridgeTools } from "./agentBridge"
 import type { McpProviderHardeningOptions } from "./hardening"
 import type { McpReadonlyCallAuditSink } from "./readonlyCall"
+import type { McpManagedCatalogAdapter } from "./toolCatalog"
 import { createBoringMcpSourceHandlers } from "./sourceHandlers"
 
 export type BoringMcpAgentToolActorResolver = (
@@ -13,6 +14,7 @@ export type BoringMcpAgentToolActorResolver = (
 export interface CreateBoringMcpAgentToolsOptions {
   registry: McpSourceRegistry
   transport: McpTransportClient
+  managedCatalog?: McpManagedCatalogAdapter
   resolveActor: BoringMcpAgentToolActorResolver
   templates?: readonly McpProviderTemplate[]
   maxReadonlyInputBytes?: number

--- a/plugins/boring-mcp/src/server/appServerBinding.ts
+++ b/plugins/boring-mcp/src/server/appServerBinding.ts
@@ -29,13 +29,14 @@ import {
   createManagedConnectorAdapter,
   createManagedConnectorSourceId,
   type ManagedConnectorAdapter,
-  type ManagedConnectorConfig,
+  type ManagedConnectorDefinition,
   type ManagedConnectorProvider,
   type ManagedConnectorSecret,
   type ManagedConnectorSecretResolver,
   type ManagedConnectorSourceRegistry,
 } from './managedConnectorAdapter'
-import { createComposioManagedConnectorProvider, createComposioMcpTransport } from './composioManagedConnector'
+import { createComposioManagedConnectorProvider, createComposioMcpAdapter, type ComposioMcpAdapter } from './composioManagedConnector'
+import type { McpManagedCatalogAdapter } from './toolCatalog'
 import { createMcpSourceStatusPayload } from './sourceAccess'
 import { createBoringMcpSourceHandlers } from './sourceHandlers'
 import { createBoringMcpAgentTools } from './agentTools'
@@ -56,7 +57,7 @@ export type BoringMcpAppServer = CoreWorkspaceAgentServer
  */
 export interface BoringMcpBindingConfig {
   /** Managed connector providers this deployment exposes. */
-  connectorConfigs: readonly ManagedConnectorConfig[]
+  connectorConfigs: readonly ManagedConnectorDefinition[]
   /**
    * Env var names checked (in order) for the Composio managed-connector API
    * key. Defaults to `['COMPOSIO_API_KEY']`.
@@ -110,7 +111,7 @@ export function readBoringMcpServerConfig(
 
 export interface CreateManagedConnectorSecretResolverOptions {
   env?: NodeJS.ProcessEnv
-  configs: readonly ManagedConnectorConfig[]
+  configs: readonly ManagedConnectorDefinition[]
   secretEnvVars?: readonly string[]
 }
 
@@ -215,6 +216,8 @@ function mcpHttpStatus(error: McpError): { status: number; code: ErrorCode } {
         ? { status: 400, code: ERROR_CODES.VALIDATION_FAILED }
         : { status: 503, code: ERROR_CODES.CONFIG_VALIDATION_FAILED }
     case MCP_ERROR_CODES.SOURCE_UNAVAILABLE:
+    case MCP_ERROR_CODES.CONNECTED_ACCOUNT_REQUIRED:
+    case MCP_ERROR_CODES.CONNECTED_ACCOUNT_CONFLICT:
       return { status: 409, code: ERROR_CODES.VALIDATION_FAILED }
     case MCP_ERROR_CODES.RESOURCE_LIMIT_EXCEEDED:
       return { status: 413, code: ERROR_CODES.VALIDATION_FAILED }
@@ -404,10 +407,11 @@ export interface CreateBoringMcpAppAgentToolsOptions {
   config: BoringMcpBindingConfig
   env?: NodeJS.ProcessEnv
   transport?: McpTransportClient
+  managedCatalog?: McpManagedCatalogAdapter
 }
 
-function createComposioMcpTransportFor(config: BoringMcpBindingConfig, env?: NodeJS.ProcessEnv): McpTransportClient {
-  return createComposioMcpTransport({
+function createComposioMcpAdapterFor(config: BoringMcpBindingConfig, env?: NodeJS.ProcessEnv): ComposioMcpAdapter {
+  return createComposioMcpAdapter({
     secretResolver: createManagedConnectorSecretResolver({ env, configs: config.connectorConfigs, secretEnvVars: config.secretEnvVars }),
     configs: config.connectorConfigs,
     clientName: config.clientName ?? 'boring-mcp',
@@ -423,10 +427,12 @@ export function createBoringMcpAppAgentTools(
   const runtimeConfig = readBoringMcpServerConfig(options.env, { secretEnvVars: options.config.secretEnvVars })
   if (!runtimeConfig.enabled) return []
   const registry = createUserSettingsMcpSourceRegistry(app, actor)
-  const transport = options.transport ?? createComposioMcpTransportFor(options.config, options.env)
+  const composio = options.transport ? undefined : createComposioMcpAdapterFor(options.config, options.env)
+  const transport = options.transport ?? composio!.transport
   return createBoringMcpAgentTools({
     registry,
     transport,
+    managedCatalog: options.managedCatalog ?? composio?.catalog,
     resolveActor: () => actor,
     templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
     hardening: { gate: new InMemoryMcpRateBudgetGate({ maxCalls: 100, maxToolCalls: 10, windowMs: 60_000 }), timeoutMs: 30_000 },
@@ -519,6 +525,7 @@ export interface RegisterBoringMcpRoutesOptions {
   provider?: ManagedConnectorProvider
   env?: NodeJS.ProcessEnv
   transport?: McpTransportClient
+  managedCatalog?: McpManagedCatalogAdapter
   resolveTrustedWorkspaceId?: (request: FastifyRequest) => string | undefined
   /**
    * Behavior when boring-mcp is disabled for this deployment.
@@ -537,7 +544,17 @@ export function registerBoringMcpRoutes(app: BoringMcpAppServer, options: Regist
     if (!enabled) throw routeError(503, ERROR_CODES.INTERNAL_ERROR, 'MCP source routes are disabled for this deployment', requestId)
   }
 
-  const routeTransport = options.transport ?? createComposioMcpTransportFor(options.config, options.env)
+  const composio = options.transport ? undefined : createComposioMcpAdapterFor(options.config, options.env)
+  const routeTransport = options.transport ?? composio!.transport
+  const routeCatalog = options.managedCatalog ?? composio?.catalog
+  const connectorProvider: ManagedConnectorProvider<ManagedConnectorDefinition> = options.provider ?? createComposioManagedConnectorProvider()
+  const cleanupAwareProvider: ManagedConnectorProvider<ManagedConnectorDefinition> = {
+    ...connectorProvider,
+    async revoke(args) {
+      await connectorProvider.revoke?.(args)
+      await routeCatalog?.disposeSource?.(args.source)
+    },
+  }
   const routeGate = new InMemoryMcpRateBudgetGate({ maxCalls: 100, maxToolCalls: 10, windowMs: 60_000 })
   const admittedWorkspaceIds = new WeakMap<FastifyRequest, string>()
   const trustedWorkspaceId = (request: FastifyRequest) => options.resolveTrustedWorkspaceId?.(request)
@@ -567,7 +584,7 @@ export function registerBoringMcpRoutes(app: BoringMcpAppServer, options: Regist
     const registry = createUserSettingsMcpSourceRegistry(app, actor)
     return {
       registry,
-      adapter: createBoringMcpManagedConnectorAdapter({ config: options.config, registry, provider: options.provider, env: options.env }),
+      adapter: createBoringMcpManagedConnectorAdapter({ config: options.config, registry, provider: cleanupAwareProvider, env: options.env }),
     }
   }
 
@@ -575,6 +592,7 @@ export function registerBoringMcpRoutes(app: BoringMcpAppServer, options: Regist
     return createBoringMcpSourceHandlers({
       registry: createUserSettingsMcpSourceRegistry(app, actor),
       transport: routeTransport,
+      managedCatalog: routeCatalog,
       templates: DEFAULT_MCP_PROVIDER_TEMPLATES,
       hardening: { gate: routeGate, timeoutMs: 30_000 },
     })
@@ -635,6 +653,8 @@ export function registerBoringMcpRoutes(app: BoringMcpAppServer, options: Regist
     const body = asRecord(request.body)
     const result = await withMcpHttpErrors(request.id, () => handlersFor(actor).searchTools(actor, {
       sourceId: sourceIdFromBody(request.body, request.id),
+      query: parseString(body.query),
+      limit: typeof body.limit === 'number' ? body.limit : undefined,
       refresh: body.refresh === true,
     }))
     return { tools: result.tools }
@@ -665,12 +685,14 @@ export interface BoringMcpAppBindingsConfig extends BoringMcpBindingConfig {
 export interface BoringMcpAppBindingsAgentToolsOptions {
   env?: NodeJS.ProcessEnv
   transport?: McpTransportClient
+  managedCatalog?: McpManagedCatalogAdapter
 }
 
 export interface BoringMcpAppBindingsRoutesOptions {
   provider?: ManagedConnectorProvider
   env?: NodeJS.ProcessEnv
   transport?: McpTransportClient
+  managedCatalog?: McpManagedCatalogAdapter
   resolveTrustedWorkspaceId?: (request: FastifyRequest) => string | undefined
 }
 
@@ -721,9 +743,9 @@ export function createBoringMcpAppBindings(config: BoringMcpAppBindingsConfig): 
     agentSessionNamespace: boringMcpAgentSessionNamespace,
     createMcpSourceRegistry: createUserSettingsMcpSourceRegistry,
     createAgentTools: (app, actor, options = {}) =>
-      createBoringMcpAppAgentTools(app, actor, { config, env: options.env, transport: options.transport }),
+      createBoringMcpAppAgentTools(app, actor, { config, env: options.env, transport: options.transport, managedCatalog: options.managedCatalog }),
     createAgentToolsForRequest: (app, ctx, options = {}) =>
-      createBoringMcpAppAgentToolsForRequest(app, ctx, { config, env: options.env, transport: options.transport }),
+      createBoringMcpAppAgentToolsForRequest(app, ctx, { config, env: options.env, transport: options.transport, managedCatalog: options.managedCatalog }),
     registerRoutes: (app, options = {}) =>
       registerBoringMcpRoutes(app, {
         config,
@@ -731,6 +753,7 @@ export function createBoringMcpAppBindings(config: BoringMcpAppBindingsConfig): 
         provider: options.provider,
         env: options.env,
         transport: options.transport,
+        managedCatalog: options.managedCatalog,
         resolveTrustedWorkspaceId: options.resolveTrustedWorkspaceId ?? config.resolveTrustedWorkspaceId,
       }),
     createServerPlugins: (env = process.env) => {

--- a/plugins/boring-mcp/src/server/composioManagedConnector.ts
+++ b/plugins/boring-mcp/src/server/composioManagedConnector.ts
@@ -1,8 +1,10 @@
 import {
   MCP_ERROR_CODES,
   McpError,
+  containsMcpSecretOrCanary,
   getMcpProviderTemplate,
   redactMcpSecrets,
+  validateMcpToolName,
   type McpActor,
   type McpDiscoveredResource,
   type McpDiscoveredTool,
@@ -10,10 +12,12 @@ import {
   type McpTransportClient,
 } from "../shared"
 import {
-  type ManagedConnectorConfig,
+  isFullCatalogManagedConnectorConfig,
+  type ManagedConnectorDefinition,
   type ManagedConnectorProvider,
   type ManagedConnectorSecret,
 } from "./managedConnectorAdapter"
+import type { McpManagedCatalogAdapter } from "./toolCatalog"
 import { createMcpSdkStreamableHttpTransport } from "./mcpSdkTransport"
 
 export interface ComposioMcpSession {
@@ -22,33 +26,53 @@ export interface ComposioMcpSession {
     url: string
     headers?: Record<string, string>
   }
+  config?: Record<string, unknown>
 }
 
 export interface ComposioManagedConnectorProviderOptions {
   /** Defaults to Composio production API. Override in tests or private deployments. */
   apiBaseUrl?: string
-  /** Defaults to global fetch. */
+  /** Defaults to global fetch and is used for Composio REST API calls. */
   fetch?: typeof fetch
+  /** Defaults to global fetch and is used for guarded MCP transport calls. */
+  mcpFetch?: typeof fetch
   /** Optional redirect URL Composio should use after hosted auth completes. */
   callbackUrl?: string
   /** Optional client metadata for the MCP SDK client used during probe/transport calls. */
   clientName?: string
   clientVersion?: string
+  /** Exact approved Composio API origins that may receive the operator key. */
+  apiUrlOrigins?: readonly string[]
+  /** Exact approved MCP origins that may receive the Composio operator key. */
+  mcpUrlOrigins?: readonly string[]
+  requestTimeoutMs?: number
+  maxResponseBytes?: number
   /** Test-only escape hatch for loopback fake MCP servers. Production Composio MCP URLs must be https. */
   allowInsecureMcpUrlsForTests?: boolean
 }
 
-export interface ResolveComposioMcpSessionInput {
-  actor: McpActor
-  config: ManagedConnectorConfig
-  secret: ManagedConnectorSecret
+export interface ComposioAccountPin {
+  toolkitId: string
+  connectedAccountId: string
 }
 
-interface ComposioConnectedAccountSummary {
-  id?: string
+export interface ResolveComposioMcpSessionInput {
+  actor: McpActor
+  config: ManagedConnectorDefinition
+  secret: ManagedConnectorSecret
+  accountPin?: ComposioAccountPin
+}
+
+export interface ComposioConnectedAccountSummary {
+  id: string
   label?: string
   active: boolean
 }
+
+const DEFAULT_COMPOSIO_MCP_ORIGINS = ["https://backend.composio.dev"] as const
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000
+const DEFAULT_MAX_RESPONSE_BYTES = 512 * 1024
+const MAX_CONNECTED_ACCOUNT_RESULTS = 100
 
 function trimTrailingSlash(value: string): string {
   return value.endsWith("/") ? value.slice(0, -1) : value
@@ -62,8 +86,33 @@ function actorForSource(source: McpSource): McpActor {
   return { userId: source.userId, workspaceId: source.workspaceId }
 }
 
-function providerError(message: string, details?: unknown): McpError {
-  return new McpError(MCP_ERROR_CODES.PROVIDER_ERROR, message, redactMcpSecrets(details))
+function redactExactCanaries(value: unknown, canaries: readonly string[]): unknown {
+  const exact = canaries.filter(Boolean)
+  if (typeof value === "string") {
+    return exact.reduce((result, canary) => result.split(canary).join("[REDACTED_MCP_SECRET]"), value)
+  }
+  if (Array.isArray(value)) return value.map((entry) => redactExactCanaries(entry, exact))
+  if (!value || typeof value !== "object") return value
+  return Object.fromEntries(Object.entries(value).map(([key, nested]) => [
+    redactExactCanaries(key, exact) as string,
+    redactExactCanaries(nested, exact),
+  ]))
+}
+
+function providerError(message: string, details?: unknown, canaries: readonly string[] = []): McpError {
+  const exactRedacted = containsMcpSecretOrCanary(details, canaries) ? redactExactCanaries(details, canaries) : details
+  return new McpError(MCP_ERROR_CODES.PROVIDER_ERROR, message, redactMcpSecrets(exactRedacted))
+}
+
+function sanitizeMcpErrorWithCanaries(error: unknown, canaries: readonly string[], fallbackMessage: string): McpError {
+  if (error instanceof McpError) {
+    return new McpError(
+      error.code,
+      redactExactCanaries(error.message, canaries) as string,
+      redactMcpSecrets(redactExactCanaries(error.details, canaries)),
+    )
+  }
+  return providerError(fallbackMessage, error, canaries)
 }
 
 function providerErrorStatus(error: unknown): number | undefined {
@@ -78,14 +127,78 @@ function requireServerSecret(secret: ManagedConnectorSecret): void {
   }
 }
 
-async function readJsonResponse(response: Response): Promise<unknown> {
-  const text = await response.text()
-  if (!text) return undefined
+async function readJsonResponse(response: Response, maxBytes: number, controller: AbortController): Promise<unknown> {
+  const declaredLength = Number(response.headers.get("content-length"))
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    controller.abort()
+    throw providerError("Composio response exceeded the configured size limit", { status: response.status })
+  }
+  const reader = response.body?.getReader()
+  if (!reader) return undefined
+  const chunks: Uint8Array[] = []
+  let length = 0
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    length += value.byteLength
+    if (length > maxBytes) {
+      await reader.cancel().catch(() => undefined)
+      controller.abort()
+      throw providerError("Composio response exceeded the configured size limit", { status: response.status })
+    }
+    chunks.push(value)
+  }
+  if (length === 0) return undefined
+  const bytes = new Uint8Array(length)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
   try {
-    return JSON.parse(text)
+    return JSON.parse(new TextDecoder().decode(bytes))
   } catch {
     throw providerError("Composio returned non-JSON response", { status: response.status })
   }
+}
+
+function boundedResponseBody(response: Response, maxBytes: number, controller: AbortController): Response {
+  const declaredLength = Number(response.headers.get("content-length"))
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    controller.abort()
+    throw providerError("Composio MCP response exceeded the configured size limit", { status: response.status })
+  }
+  if (!response.body) return response
+  const reader = response.body.getReader()
+  let length = 0
+  const body = new ReadableStream<Uint8Array>({
+    async pull(streamController) {
+      try {
+        const { done, value } = await reader.read()
+        if (done) {
+          streamController.close()
+          return
+        }
+        length += value.byteLength
+        if (length > maxBytes) {
+          await reader.cancel().catch(() => undefined)
+          controller.abort()
+          streamController.error(providerError("Composio MCP response exceeded the configured size limit", { status: response.status }))
+          return
+        }
+        streamController.enqueue(value)
+      } catch (error) {
+        streamController.error(controller.signal.aborted
+          ? new McpError(MCP_ERROR_CODES.PROVIDER_TIMEOUT, "Composio MCP request timed out")
+          : error)
+      }
+    },
+    async cancel(reason) {
+      controller.abort(reason)
+      await reader.cancel(reason).catch(() => undefined)
+    },
+  })
+  return new Response(body, { status: response.status, statusText: response.statusText, headers: response.headers })
 }
 
 function record(value: unknown): Record<string, unknown> {
@@ -117,17 +230,35 @@ function normalizeComposioMcpUrl(rawUrl: string, options: ComposioManagedConnect
   if ((parsed.protocol !== "https:" && !allowedInsecureLoopback) || parsed.username || parsed.password) {
     throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Composio MCP URL must be https and must not include credentials")
   }
+  const approvedOrigins = options.mcpUrlOrigins ?? DEFAULT_COMPOSIO_MCP_ORIGINS
+  if (!allowedInsecureLoopback && !approvedOrigins.includes(parsed.origin)) {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Composio MCP URL origin is not approved")
+  }
   return parsed.toString()
 }
 
-function extractSession(payload: unknown, options: ComposioManagedConnectorProviderOptions): ComposioMcpSession {
+function rawSessionIdentity(payload: unknown): { id?: string; canaries: string[] } {
+  const root = record(payload)
+  const session = record(root.session ?? root.data ?? root)
+  const mcp = record(session.mcp)
+  const id = optionalString(session.id) ?? optionalString(session.session_id) ?? optionalString(root.id) ?? optionalString(root.session_id)
+  const canaries = [id, optionalString(mcp.url), ...Object.values(optionalHeaders(mcp.headers) ?? {})]
+    .filter((value): value is string => Boolean(value))
+  return { id, canaries }
+}
+
+function extractSession(payload: unknown, options: ComposioManagedConnectorProviderOptions, canaries: readonly string[] = []): ComposioMcpSession {
   const root = record(payload)
   const session = record(root.session ?? root.data ?? root)
   const mcp = record(session.mcp)
   const id = optionalString(session.id) ?? optionalString(session.session_id) ?? optionalString(root.id) ?? optionalString(root.session_id)
   const url = optionalString(mcp.url)
-  if (!id || !url) throw providerError("Composio session response did not include an MCP session", payload)
-  return { id, mcp: { url: normalizeComposioMcpUrl(url, options), headers: optionalHeaders(mcp.headers) } }
+  if (!id || !url) throw providerError("Composio session response did not include an MCP session", payload, canaries)
+  return {
+    id,
+    mcp: { url: normalizeComposioMcpUrl(url, options), headers: optionalHeaders(mcp.headers) },
+    config: record(session.config ?? root.config),
+  }
 }
 
 function extractConnectUrl(payload: unknown): string | undefined {
@@ -143,6 +274,23 @@ function extractConnectUrl(payload: unknown): string | undefined {
     ?? optionalString(nested.connect_url)
     ?? optionalString(nested.connectUrl)
     ?? optionalString(nested.url)
+}
+
+function normalizeComposioApiBaseUrl(options: ComposioManagedConnectorProviderOptions): string {
+  let parsed: URL
+  try {
+    parsed = new URL(options.apiBaseUrl ?? "https://backend.composio.dev")
+  } catch {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Composio API base URL is invalid")
+  }
+  if (parsed.protocol !== "https:" || parsed.username || parsed.password) {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Composio API base URL must be credential-free https")
+  }
+  const approvedOrigins = options.apiUrlOrigins ?? ["https://backend.composio.dev"]
+  if (!approvedOrigins.includes(parsed.origin)) {
+    throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Composio API origin is not approved")
+  }
+  return trimTrailingSlash(parsed.toString())
 }
 
 function extractProviderAccountLabel(payload: unknown): string | undefined {
@@ -166,17 +314,31 @@ async function composioRequest(
   requireServerSecret(secret)
   const fetchImpl = options.fetch ?? globalThis.fetch
   if (!fetchImpl) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "fetch is not available for Composio connector")
-  const response = await fetchImpl(`${trimTrailingSlash(options.apiBaseUrl ?? "https://backend.composio.dev")}${path}`, {
-    method,
-    headers: {
-      "content-type": "application/json",
-      "x-api-key": secret.value,
-    },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  })
-  const payload = await readJsonResponse(response)
-  if (!response.ok) throw providerError("Composio request failed", { status: response.status, payload })
-  return payload
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS)
+  try {
+    const response = await fetchImpl(`${normalizeComposioApiBaseUrl(options)}${path}`, {
+      method,
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": secret.value,
+      },
+      body: body === undefined ? undefined : JSON.stringify(body),
+      redirect: "error",
+      signal: controller.signal,
+    })
+    const payload = await readJsonResponse(response, options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES, controller)
+    if (!response.ok) throw providerError("Composio request failed", { status: response.status, payload }, [secret.value])
+    return payload
+  } catch (error) {
+    if (controller.signal.aborted && !(error instanceof McpError && error.code === MCP_ERROR_CODES.PROVIDER_ERROR)) {
+      throw new McpError(MCP_ERROR_CODES.PROVIDER_TIMEOUT, "Composio request timed out")
+    }
+    if (error instanceof McpError) throw error
+    throw providerError("Composio request failed", error, [secret.value])
+  } finally {
+    clearTimeout(timeout)
+  }
 }
 
 function composioPost(options: ComposioManagedConnectorProviderOptions, secret: ManagedConnectorSecret, path: string, body: unknown): Promise<unknown> {
@@ -191,50 +353,199 @@ function composioDelete(options: ComposioManagedConnectorProviderOptions, secret
   return composioRequest(options, secret, "DELETE", path)
 }
 
+async function deleteComposioSessionVerified(
+  options: ComposioManagedConnectorProviderOptions,
+  secret: ManagedConnectorSecret,
+  sessionId: string,
+): Promise<void> {
+  const path = `/api/v3.1/tool_router/session/${encodeURIComponent(sessionId)}`
+  const canaries = [secret.value, sessionId]
+  try {
+    try {
+      await composioDelete(options, secret, path)
+    } catch (error) {
+      if (providerErrorStatus(error) !== 404) throw error
+    }
+    try {
+      await composioGet(options, secret, path)
+    } catch (error) {
+      if (providerErrorStatus(error) === 404) return
+      throw error
+    }
+    throw providerError("Composio Session deletion could not be verified")
+  } catch (error) {
+    throw sanitizeMcpErrorWithCanaries(error, canaries, "Composio Session cleanup failed")
+  }
+}
+
+async function deleteResolvedComposioSessionVerified(
+  options: ComposioManagedConnectorProviderOptions,
+  secret: ManagedConnectorSecret,
+  session: ComposioMcpSession,
+): Promise<void> {
+  try {
+    await deleteComposioSessionVerified(options, secret, session.id)
+  } catch (error) {
+    const canaries = [secret.value, session.id, session.mcp.url, ...Object.values(session.mcp.headers ?? {})]
+    throw sanitizeMcpErrorWithCanaries(error, canaries, "Composio Session cleanup failed")
+  }
+}
+
+function curatedToolkitId(config: ManagedConnectorDefinition): string | undefined {
+  return isFullCatalogManagedConnectorConfig(config) ? undefined : config.toolkitId
+}
+
+function optionsForConnector(
+  options: ComposioManagedConnectorProviderOptions,
+  config: ManagedConnectorDefinition,
+): ComposioManagedConnectorProviderOptions {
+  return config.mcpUrlOrigins?.length ? { ...options, mcpUrlOrigins: config.mcpUrlOrigins } : options
+}
+
+function verifySessionConfig(session: ComposioMcpSession, input: ResolveComposioMcpSessionInput): void {
+  const sessionConfig = record(session.config)
+  const workbench = record(sessionConfig.workbench)
+  if (workbench.enable !== false) throw providerError("Composio Session did not preserve disabled workbench configuration")
+  if (Object.prototype.hasOwnProperty.call(sessionConfig, "toolkits") && (typeof sessionConfig.toolkits !== "object" || sessionConfig.toolkits === null || Array.isArray(sessionConfig.toolkits))) {
+    throw providerError("Composio Session returned malformed toolkit configuration")
+  }
+  const toolkits = record(sessionConfig.toolkits)
+  if (Object.prototype.hasOwnProperty.call(toolkits, "enable") && !Array.isArray(toolkits.enable)) {
+    throw providerError("Composio Session returned malformed toolkit configuration")
+  }
+  if (Object.keys(toolkits).some((key) => key !== "enable")) {
+    throw providerError("Composio Session returned unexpected toolkit configuration")
+  }
+  const rawEnabledToolkits = array(toolkits.enable)
+  if (rawEnabledToolkits.some((value) => typeof value !== "string" || !value.trim())) {
+    throw providerError("Composio Session returned malformed toolkit configuration")
+  }
+  const enabledToolkits = rawEnabledToolkits as string[]
+  const expectedToolkit = curatedToolkitId(input.config)
+  if (expectedToolkit) {
+    if (enabledToolkits.length !== 1 || enabledToolkits[0] !== expectedToolkit) throw providerError("Composio Session did not preserve toolkit restriction")
+  } else if (enabledToolkits.length > 0) {
+    throw providerError("Composio Session unexpectedly restricted the full catalog")
+  }
+  if (!input.accountPin && Object.prototype.hasOwnProperty.call(sessionConfig, "connected_accounts")) {
+    if (typeof sessionConfig.connected_accounts !== "object" || sessionConfig.connected_accounts === null || Array.isArray(sessionConfig.connected_accounts) || Object.keys(record(sessionConfig.connected_accounts)).length > 0) {
+      throw providerError("Composio Session unexpectedly selected connected accounts")
+    }
+  }
+  if (input.accountPin) {
+    const connectedAccounts = record(sessionConfig.connected_accounts)
+    const rawIds = connectedAccounts[input.accountPin.toolkitId]
+    if (!Array.isArray(rawIds) || rawIds.some((value) => typeof value !== "string" || !value.trim())) {
+      throw providerError("Composio Session returned malformed connected-account configuration")
+    }
+    const ids = rawIds as string[]
+    if (ids.length !== 1 || ids[0] !== input.accountPin.connectedAccountId || Object.keys(connectedAccounts).length !== 1) {
+      throw providerError("Composio Session did not preserve the exact connected-account pin")
+    }
+  }
+}
+
 export async function resolveComposioMcpSession(options: ComposioManagedConnectorProviderOptions, input: ResolveComposioMcpSessionInput): Promise<ComposioMcpSession> {
-  const payload = await composioPost(options, input.secret, "/api/v3.1/tool_router/session", {
+  const toolkitId = curatedToolkitId(input.config)
+  const body: Record<string, unknown> = {
     user_id: composioUserId(input.actor),
     mcp: true,
-    toolkits: { enable: [input.config.toolkitId] },
     manage_connections: {
       enable: true,
       enable_wait_for_connections: false,
       callback_url: options.callbackUrl,
     },
-  })
-  return extractSession(payload, options)
+    workbench: { enable: false },
+  }
+  if (toolkitId) body.toolkits = { enable: [toolkitId] }
+  if (input.accountPin) body.connected_accounts = { [input.accountPin.toolkitId]: [input.accountPin.connectedAccountId] }
+  const payload = await composioPost(options, input.secret, "/api/v3.1/tool_router/session", body)
+  const rawIdentity = rawSessionIdentity(payload)
+  const canaries = [input.secret.value, ...rawIdentity.canaries]
+  try {
+    const session = extractSession(payload, optionsForConnector(options, input.config), canaries)
+    verifySessionConfig(session, input)
+    return session
+  } catch (error) {
+    if (rawIdentity.id) {
+      try {
+        await deleteComposioSessionVerified(options, input.secret, rawIdentity.id)
+      } catch (cleanupError) {
+        throw sanitizeMcpErrorWithCanaries(cleanupError, canaries, "Composio Session cleanup failed")
+      }
+    }
+    throw sanitizeMcpErrorWithCanaries(error, canaries, "Composio Session validation failed")
+  }
 }
 
-async function createLink(options: ComposioManagedConnectorProviderOptions, secret: ManagedConnectorSecret, sessionId: string, config: ManagedConnectorConfig): Promise<unknown> {
+async function createLink(options: ComposioManagedConnectorProviderOptions, secret: ManagedConnectorSecret, sessionId: string, toolkitId: string): Promise<unknown> {
   return composioPost(options, secret, `/api/v3/tool_router/session/${encodeURIComponent(sessionId)}/link`, {
-    toolkit: config.toolkitId,
+    toolkit: toolkitId,
     callback_url: options.callbackUrl,
   })
 }
 
-function accountIsForConfig(account: Record<string, unknown>, actor: McpActor, config: ManagedConnectorConfig): boolean {
+function accountIsForToolkit(account: Record<string, unknown>, actor: McpActor, toolkitId: string): boolean {
   const toolkit = record(account.toolkit)
-  return optionalString(toolkit.slug) === config.toolkitId && optionalString(account.user_id) === composioUserId(actor)
+  return optionalString(toolkit.slug) === toolkitId && optionalString(account.user_id) === composioUserId(actor)
 }
 
-function summarizeAccount(account: Record<string, unknown>): ComposioConnectedAccountSummary {
+function summarizeAccount(account: Record<string, unknown>): ComposioConnectedAccountSummary | undefined {
+  const id = optionalString(account.id) ?? optionalString(account.nanoid) ?? optionalString(account.word_id)
+  if (!id) return undefined
   const status = optionalString(account.status)?.toUpperCase()
   const disabled = account.is_disabled === true || record(account.auth_config).is_disabled === true
   return {
-    id: optionalString(account.id) ?? optionalString(account.nanoid) ?? optionalString(account.word_id),
+    id,
     label: extractProviderAccountLabel(account),
     active: !disabled && (status === "ACTIVE" || status === "CONNECTED" || status === "ENABLED"),
   }
 }
 
-async function findConnectedAccount(options: ComposioManagedConnectorProviderOptions, input: ResolveComposioMcpSessionInput): Promise<ComposioConnectedAccountSummary | undefined> {
-  const params = new URLSearchParams({ user_id: composioUserId(input.actor), toolkit_slug: input.config.toolkitId })
+async function listOwnedConnectedAccounts(
+  options: ComposioManagedConnectorProviderOptions,
+  input: Pick<ResolveComposioMcpSessionInput, "actor" | "secret"> & { toolkitId: string },
+): Promise<ComposioConnectedAccountSummary[]> {
+  const params = new URLSearchParams({ user_id: composioUserId(input.actor), toolkit_slug: input.toolkitId, limit: String(MAX_CONNECTED_ACCOUNT_RESULTS) })
   const payload = await composioGet(options, input.secret, `/api/v3.1/connected_accounts?${params}`)
-  const items = array(record(payload).items)
-    .map(record)
-    .filter((account) => accountIsForConfig(account, input.actor, input.config))
-    .map(summarizeAccount)
-  return items.find((account) => account.active) ?? items[0]
+  const page = record(payload)
+  if (!Array.isArray(page.items)) throw providerError("Composio connected-account response did not include an item list")
+  if (Object.prototype.hasOwnProperty.call(page, "has_more") && typeof page.has_more !== "boolean") {
+    throw providerError("Composio connected-account pagination was malformed")
+  }
+  for (const key of ["next_cursor", "nextCursor"] as const) {
+    const value = page[key]
+    if (value !== undefined && value !== null && typeof value !== "string") throw providerError("Composio connected-account pagination was malformed")
+  }
+  const rawItems = page.items
+  if (rawItems.length >= MAX_CONNECTED_ACCOUNT_RESULTS || page.has_more === true || optionalString(page.next_cursor) || optionalString(page.nextCursor)) {
+    throw providerError("Composio connected-account result was not provably complete")
+  }
+  const accounts = rawItems.map((value) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) throw providerError("Composio connected-account row was malformed")
+    const account = value as Record<string, unknown>
+    const userId = optionalString(account.user_id)
+    const toolkitSlug = optionalString(record(account.toolkit).slug)
+    if (!userId || !toolkitSlug) throw providerError("Composio connected-account ownership fields were malformed")
+    return account
+  })
+  const matching = accounts.filter((account) => accountIsForToolkit(account, input.actor, input.toolkitId))
+  return matching.map((account) => {
+    const summary = summarizeAccount(account)
+    if (!summary) throw providerError("Composio returned a matching connected account without a stable ID")
+    return summary
+  })
+}
+
+export async function requireExactlyOneComposioConnectedAccount(
+  options: ComposioManagedConnectorProviderOptions,
+  input: Pick<ResolveComposioMcpSessionInput, "actor" | "secret"> & { toolkitId: string },
+): Promise<ComposioConnectedAccountSummary> {
+  const accounts = await listOwnedConnectedAccounts(options, input)
+  if (accounts.length > 1) throw new McpError(MCP_ERROR_CODES.CONNECTED_ACCOUNT_CONFLICT, "Multiple connected accounts require revoke-then-connect replacement")
+  const account = accounts[0]
+  if (!account?.active) throw new McpError(MCP_ERROR_CODES.CONNECTED_ACCOUNT_REQUIRED, "Exactly one active connected account is required")
+  return account
 }
 
 function composioMcpHeaders(session: ComposioMcpSession, secret: ManagedConnectorSecret): Record<string, string> {
@@ -242,17 +553,48 @@ function composioMcpHeaders(session: ComposioMcpSession, secret: ManagedConnecto
   return { ...(session.mcp.headers ?? {}), "x-api-key": secret.value }
 }
 
-function transportForSession(options: ComposioManagedConnectorProviderOptions, session: ComposioMcpSession, secret: ManagedConnectorSecret): McpTransportClient {
+function createGuardedComposioMcpFetch(options: ComposioManagedConnectorProviderOptions): typeof fetch {
+  const fetchImpl = options.mcpFetch ?? globalThis.fetch
+  if (!fetchImpl) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "fetch is not available for Composio MCP transport")
+  return async (input, init) => {
+    const request = new Request(input, init)
+    normalizeComposioMcpUrl(request.url, options)
+    const controller = new AbortController()
+    const timeoutSignal = AbortSignal.timeout(options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS)
+    timeoutSignal.addEventListener("abort", () => controller.abort(), { once: true })
+    const signal = AbortSignal.any([request.signal, controller.signal, timeoutSignal])
+    try {
+      const response = await fetchImpl(request, { redirect: "error", signal })
+      return boundedResponseBody(response, options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES, controller)
+    } catch (error) {
+      if (timeoutSignal.aborted) throw new McpError(MCP_ERROR_CODES.PROVIDER_TIMEOUT, "Composio MCP request timed out")
+      throw error
+    }
+  }
+}
+
+function transportForSession(
+  options: ComposioManagedConnectorProviderOptions,
+  session: ComposioMcpSession,
+  secret: ManagedConnectorSecret,
+  config: ManagedConnectorDefinition,
+): McpTransportClient {
+  const connectorOptions = optionsForConnector(options, config)
   return createMcpSdkStreamableHttpTransport({
     endpoint: { url: session.mcp.url, headers: composioMcpHeaders(session, secret) },
-    clientName: options.clientName ?? "boring-mcp-composio",
-    clientVersion: options.clientVersion ?? "0.0.0",
+    clientName: connectorOptions.clientName ?? "boring-mcp-composio",
+    clientVersion: connectorOptions.clientVersion ?? "0.0.0",
+    fetch: createGuardedComposioMcpFetch(connectorOptions),
   })
 }
 
 const COMPOSIO_SEARCH_TOOLS = "COMPOSIO_SEARCH_TOOLS"
 const COMPOSIO_GET_TOOL_SCHEMAS = "COMPOSIO_GET_TOOL_SCHEMAS"
 const COMPOSIO_MULTI_EXECUTE_TOOL = "COMPOSIO_MULTI_EXECUTE_TOOL"
+const COMPOSIO_TOOL_NAME_MAX_LENGTH = 256
+const COMPOSIO_TOOL_DESCRIPTION_MAX_LENGTH = 4_000
+const COMPOSIO_TOOL_SCHEMA_MAX_BYTES = 128 * 1024
+const COMPOSIO_TOOL_SCHEMA_MAX_DEPTH = 20
 
 function isComposioMetaTool(toolName: string): boolean {
   return toolName.startsWith("COMPOSIO_")
@@ -260,6 +602,31 @@ function isComposioMetaTool(toolName: string): boolean {
 
 function safeTools(tools: McpDiscoveredTool[]): McpDiscoveredTool[] {
   return tools.filter((tool) => !isComposioMetaTool(tool.name))
+}
+
+function jsonDepth(value: unknown, depth = 0): number {
+  if (!value || typeof value !== "object") return depth
+  const children = Array.isArray(value) ? value : Object.values(value as Record<string, unknown>)
+  return children.reduce((max, child) => Math.max(max, jsonDepth(child, depth + 1)), depth)
+}
+
+function assertBoundedToolMetadata(tool: McpDiscoveredTool): void {
+  validateMcpToolName(tool.name)
+  if (
+    tool.name.length > COMPOSIO_TOOL_NAME_MAX_LENGTH
+    || (tool.description?.length ?? 0) > COMPOSIO_TOOL_DESCRIPTION_MAX_LENGTH
+    || (tool.toolkit?.length ?? 0) > 128
+    || (tool.version?.length ?? 0) > 128
+  ) {
+    throw providerError("Composio tool metadata exceeded configured length limits")
+  }
+  for (const value of [tool.inputSchema, tool.outputSchema, tool.annotations]) {
+    if (value === undefined) continue
+    const encoded = new TextEncoder().encode(JSON.stringify(value))
+    if (encoded.byteLength > COMPOSIO_TOOL_SCHEMA_MAX_BYTES || jsonDepth(value) > COMPOSIO_TOOL_SCHEMA_MAX_DEPTH) {
+      throw providerError("Composio tool schema exceeded configured complexity limits")
+    }
+  }
 }
 
 function jsonFromTextContent(value: unknown): unknown {
@@ -277,77 +644,165 @@ function jsonFromTextContent(value: unknown): unknown {
   return undefined
 }
 
-function concreteAllowedToolSlugs(provider: string): string[] {
-  return getMcpProviderTemplate(provider)?.allowedTools.filter((toolName) => !toolName.includes("*")) ?? []
+interface ComposioToolSlug {
+  slug: string
+  toolkit?: string
 }
 
-function collectComposioToolSlugs(payload: unknown, toolkitId: string): string[] {
+function collectComposioToolSlugs(payload: unknown, limit: number, toolkitId?: string): ComposioToolSlug[] {
   const root = record(jsonFromTextContent(payload) ?? payload)
   const data = record(root.data ?? root)
-  const seen = new Set<string>()
-  for (const item of array(data.results)) {
+  const seen = new Map<string, ComposioToolSlug>()
+  const results = array(data.results)
+  if (results.length > 100) throw providerError("Composio tool search returned too many result groups")
+  for (const item of results) {
     const result = record(item)
-    const toolkits = array(result.toolkits).filter((toolkit): toolkit is string => typeof toolkit === "string")
-    if (toolkits.length > 0 && !toolkits.some((toolkit) => toolkit.toLowerCase() === toolkitId.toLowerCase())) continue
-    for (const slug of [...array(result.primary_tool_slugs), ...array(result.related_tool_slugs)]) {
-      if (typeof slug === "string" && slug.trim() && !isComposioMetaTool(slug)) seen.add(slug)
+    const toolkits = array(result.toolkits).filter((toolkit): toolkit is string => typeof toolkit === "string" && Boolean(toolkit.trim()))
+    if (toolkitId && toolkits.length > 0 && !toolkits.some((toolkit) => toolkit.toLowerCase() === toolkitId.toLowerCase())) continue
+    const candidateSlugs = [...array(result.primary_tool_slugs), ...array(result.related_tool_slugs)]
+    if (candidateSlugs.length > 0 && toolkits.length !== 1) throw providerError("Composio tool search did not return exact toolkit provenance")
+    for (const slug of candidateSlugs) {
+      if (typeof slug !== "string" || !slug.trim() || isComposioMetaTool(slug)) continue
+      try {
+        validateMcpToolName(slug)
+      } catch {
+        throw providerError("Composio tool search returned an invalid tool slug")
+      }
+      if (slug.length > COMPOSIO_TOOL_NAME_MAX_LENGTH || toolkits.some((toolkit) => toolkit.length > 128)) {
+        throw providerError("Composio tool search returned oversized identifiers")
+      }
+      const existing = seen.get(slug)
+      if (existing?.toolkit && toolkits[0] && existing.toolkit !== toolkits[0]) {
+        throw providerError("Composio tool search returned ambiguous toolkit provenance")
+      }
+      if (!existing) seen.set(slug, { slug, toolkit: toolkits[0] })
+      if (seen.size >= limit) return [...seen.values()]
     }
   }
-  return [...seen].slice(0, 50)
+  return [...seen.values()]
 }
 
-function toolsFromComposioSchemas(payload: unknown, slugs: readonly string[]): McpDiscoveredTool[] {
+function toolsFromComposioSchemas(payload: unknown, slugs: readonly ComposioToolSlug[]): McpDiscoveredTool[] {
   const root = record(jsonFromTextContent(payload) ?? payload)
   const data = record(root.data ?? root)
   const schemas = record(data.tool_schemas ?? root.tool_schemas)
   const tools: McpDiscoveredTool[] = []
-  for (const slug of slugs) {
-    const rawSchema = schemas[slug]
+  for (const item of slugs) {
+    const rawSchema = schemas[item.slug]
     if (!rawSchema || typeof rawSchema !== "object" || Array.isArray(rawSchema)) continue
     const schema = rawSchema as Record<string, unknown>
-    tools.push({
-      name: optionalString(schema.tool_slug) ?? slug,
+    const name = optionalString(schema.tool_slug) ?? item.slug
+    const schemaToolkit = optionalString(schema.toolkit_slug)
+    if (name !== item.slug || (schemaToolkit && item.toolkit && schemaToolkit !== item.toolkit)) {
+      throw providerError("Composio tool schema contradicted searched tool identity")
+    }
+    if (isComposioMetaTool(name)) continue
+    const tool: McpDiscoveredTool = {
+      name,
       description: optionalString(schema.description),
       inputSchema: schema.input_schema ?? {},
-    })
+      outputSchema: schema.output_schema,
+      toolkit: schemaToolkit ?? item.toolkit,
+      version: optionalString(schema.version),
+      annotations: Object.keys(record(schema.annotations)).length ? record(schema.annotations) : undefined,
+    }
+    assertBoundedToolMetadata(tool)
+    tools.push(tool)
   }
   return tools
 }
 
-async function discoverComposioToolkitTools(input: {
+function concreteAllowedToolSlugs(provider: string): string[] {
+  return getMcpProviderTemplate(provider)?.allowedTools.filter((toolName) => !toolName.includes("*")) ?? []
+}
+
+async function searchComposioTools(input: {
   transport: McpTransportClient
   source: McpSource
-  config: ManagedConnectorConfig
   session: ComposioMcpSession
+  query: string
+  limit: number
+  toolkitId?: string
+  additionalToolSlugs?: readonly string[]
 }): Promise<McpDiscoveredTool[]> {
-  // Composio's MCP meta tools intentionally use `session` for search and
-  // `session_id` for schema/execute; keep these argument names pinned by tests.
   const searchResult = await input.transport.callTool(input.source, COMPOSIO_SEARCH_TOOLS, {
-    queries: [input.config.toolkitId],
+    queries: [input.query],
     session: input.session.id,
   })
-  const slugs = [...new Set([
-    ...collectComposioToolSlugs(searchResult, input.config.toolkitId),
-    ...concreteAllowedToolSlugs(input.source.provider),
-  ].filter((toolName) => !isComposioMetaTool(toolName)))]
+  const searchedSlugs = collectComposioToolSlugs(searchResult, input.limit, input.toolkitId)
+  const slugs: ComposioToolSlug[] = []
+  const known = new Set<string>()
+  for (const slug of input.additionalToolSlugs ?? []) {
+    if (known.has(slug) || isComposioMetaTool(slug) || slugs.length >= input.limit) continue
+    slugs.push({ slug, toolkit: input.toolkitId })
+    known.add(slug)
+  }
+  for (const item of searchedSlugs) {
+    if (known.has(item.slug) || slugs.length >= input.limit) continue
+    slugs.push(item)
+    known.add(item.slug)
+  }
   if (slugs.length === 0) return []
   const schemaResult = await input.transport.callTool(input.source, COMPOSIO_GET_TOOL_SCHEMAS, {
-    tool_slugs: slugs,
+    tool_slugs: slugs.map(({ slug }) => slug),
     session_id: input.session.id,
   })
   return toolsFromComposioSchemas(schemaResult, slugs)
 }
 
-export function createComposioManagedConnectorProvider(options: ComposioManagedConnectorProviderOptions = {}): ManagedConnectorProvider {
+async function describeComposioTool(input: {
+  transport: McpTransportClient
+  source: McpSource
+  session: ComposioMcpSession
+  toolName: string
+}): Promise<McpDiscoveredTool> {
+  if (isComposioMetaTool(input.toolName)) throw new McpError(MCP_ERROR_CODES.TOOL_NOT_ALLOWED, "Composio MCP management tools are not exposed")
+  const searchResult = await input.transport.callTool(input.source, COMPOSIO_SEARCH_TOOLS, {
+    queries: [input.toolName],
+    session: input.session.id,
+  })
+  const matches = collectComposioToolSlugs(searchResult, COMPOSIO_SEARCH_MAX_TOOLS).filter(({ slug }) => slug === input.toolName)
+  if (matches.length !== 1 || !matches[0]?.toolkit) throw providerError("Composio could not prove exact toolkit provenance for the requested tool")
+  const schemaResult = await input.transport.callTool(input.source, COMPOSIO_GET_TOOL_SCHEMAS, {
+    tool_slugs: [input.toolName],
+    session_id: input.session.id,
+  })
+  const [tool] = toolsFromComposioSchemas(schemaResult, matches)
+  if (!tool || tool.name !== input.toolName || !tool.toolkit) throw new McpError(MCP_ERROR_CODES.TOOL_NOT_FOUND, "MCP tool was not found")
+  return tool
+}
+
+function connectorToolkitId(config: ManagedConnectorDefinition, source?: McpSource): string | undefined {
+  return curatedToolkitId(config) || source?.connectorRef?.toolkitId
+}
+
+export function createComposioManagedConnectorProvider(options: ComposioManagedConnectorProviderOptions = {}): ManagedConnectorProvider<ManagedConnectorDefinition> {
   return {
     async startConnect({ actor, config, secret }) {
+      const toolkitId = connectorToolkitId(config)
+      if (!toolkitId) {
+        requireServerSecret(secret)
+        return { connectorRef: { provider: config.provider }, status: "connected" }
+      }
       const session = await resolveComposioMcpSession(options, { actor, config, secret })
-      const link = await createLink(options, secret, session.id, config)
+      let link: unknown
+      try {
+        link = await createLink(options, secret, session.id, toolkitId)
+      } catch (error) {
+        await deleteResolvedComposioSessionVerified(options, secret, session)
+        throw error
+      }
       return {
-        connectorRef: { provider: config.provider, toolkitId: config.toolkitId, sessionId: session.id },
+        connectorRef: { provider: config.provider, toolkitId, sessionId: session.id },
         status: "unconfigured",
         connectUrl: extractConnectUrl(link),
         providerAccountLabel: extractProviderAccountLabel(link),
+      }
+    },
+
+    async abortConnect({ secret, response }) {
+      if (response.connectorRef.sessionId) {
+        await deleteComposioSessionVerified(options, secret, response.connectorRef.sessionId)
       }
     },
 
@@ -355,28 +810,56 @@ export function createComposioManagedConnectorProvider(options: ComposioManagedC
       if (source.status === "revoked") {
         return { status: "revoked", providerAccountLabel: source.providerAccountLabel, lastVerifiedAt: source.lastVerifiedAt, connectorRef: source.connectorRef }
       }
-      const account = await findConnectedAccount(options, { actor, config, secret })
+      const toolkitId = connectorToolkitId(config, source)
+      if (!toolkitId && isFullCatalogManagedConnectorConfig(config)) {
+        return {
+          status: "connected",
+          providerAccountLabel: source.providerAccountLabel,
+          lastVerifiedAt: new Date().toISOString(),
+          connectorRef: { ...source.connectorRef, provider: config.provider },
+        }
+      }
+      if (!toolkitId) throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "Connected source does not identify a toolkit")
+      const accounts = await listOwnedConnectedAccounts(options, { actor, secret, toolkitId })
+      if (accounts.length > 1) throw new McpError(MCP_ERROR_CODES.CONNECTED_ACCOUNT_CONFLICT, "Multiple connected accounts require revoke-then-connect replacement")
+      const account = accounts[0]
       if (!account?.active) {
         return {
           status: source.status === "connected" ? "expired" : source.status,
           providerAccountLabel: account?.label ?? source.providerAccountLabel,
           lastVerifiedAt: new Date().toISOString(),
-          connectorRef: { ...source.connectorRef, provider: config.provider, toolkitId: config.toolkitId, connectedAccountId: account?.id },
+          connectorRef: { ...source.connectorRef, provider: config.provider, toolkitId, connectedAccountId: account?.id },
         }
       }
-      const session = await resolveComposioMcpSession(options, { actor, config, secret })
+      const session = await resolveComposioMcpSession(options, {
+        actor,
+        config,
+        secret,
+        accountPin: { toolkitId, connectedAccountId: account.id },
+      })
+      await deleteResolvedComposioSessionVerified(options, secret, session)
+      if (source.connectorRef?.sessionId && source.connectorRef.sessionId !== session.id) {
+        await deleteComposioSessionVerified(options, secret, source.connectorRef.sessionId)
+      }
       return {
         status: "connected",
         providerAccountLabel: account.label ?? source.providerAccountLabel,
         lastVerifiedAt: new Date().toISOString(),
-        connectorRef: { ...source.connectorRef, provider: config.provider, toolkitId: config.toolkitId, sessionId: session.id, connectedAccountId: account.id },
+        connectorRef: { ...source.connectorRef, provider: config.provider, toolkitId, sessionId: undefined, connectedAccountId: account.id },
       }
     },
 
-    async probe({ actor, config, secret }) {
-      const session = await resolveComposioMcpSession(options, { actor, config, secret })
-      const transport = transportForSession(options, session, secret)
-      const source: McpSource = {
+    async probe({ actor, source, config, secret }) {
+      const toolkitId = connectorToolkitId(config, source)
+      const account = toolkitId ? await requireExactlyOneComposioConnectedAccount(options, { actor, secret, toolkitId }) : undefined
+      const session = await resolveComposioMcpSession(options, {
+        actor,
+        config,
+        secret,
+        accountPin: account && toolkitId ? { toolkitId, connectedAccountId: account.id } : undefined,
+      })
+      const transport = transportForSession(options, session, secret, config)
+      const probeSource: McpSource = {
         id: `composio-probe:${actor.workspaceId}:${actor.userId}:${config.provider}`,
         workspaceId: actor.workspaceId,
         userId: actor.userId,
@@ -385,37 +868,90 @@ export function createComposioManagedConnectorProvider(options: ComposioManagedC
         status: "connected",
         ownerKind: "user",
         credentialProvider: "composio-managed",
-        connectorRef: { provider: config.provider, toolkitId: config.toolkitId, sessionId: session.id },
+        connectorRef: { provider: config.provider, toolkitId, sessionId: session.id, connectedAccountId: account?.id },
       }
-      const [tools, resources] = await Promise.all([
-        transport.listTools(source).then(safeTools),
-        transport.listResources(source).catch((): McpDiscoveredResource[] => []),
-      ])
-      return { tools, resources }
+      try {
+        const [tools, resources] = await Promise.all([
+          transport.listTools(probeSource).then(safeTools),
+          transport.listResources(probeSource).catch((): McpDiscoveredResource[] => []),
+        ])
+        return { tools, resources }
+      } catch (error) {
+        throw sanitizeComposioTransportError(error, { secret, session })
+      } finally {
+        await deleteResolvedComposioSessionVerified(options, secret, session)
+      }
     },
 
     async revoke({ actor, source, config, secret }) {
-      const connectedAccountId = source.connectorRef?.connectedAccountId ?? (await findConnectedAccount(options, { actor, config, secret }))?.id
-      if (!connectedAccountId) return
+      const toolkitId = connectorToolkitId(config, source)
       try {
-        await composioDelete(options, secret, `/api/v3.1/connected_accounts/${encodeURIComponent(connectedAccountId)}`)
-      } catch (error) {
-        if (providerErrorStatus(error) === 404) return
-        throw error
+        if (!toolkitId) return
+        const accounts = await listOwnedConnectedAccounts(options, { actor, secret, toolkitId })
+        if (accounts.length === 0) return
+        if (accounts.length > 1) throw new McpError(MCP_ERROR_CODES.CONNECTED_ACCOUNT_CONFLICT, "Multiple connected accounts require revoke-then-connect replacement")
+        const account = accounts[0]!
+        try {
+          await composioDelete(options, secret, `/api/v3.1/connected_accounts/${encodeURIComponent(account.id)}`)
+        } catch (error) {
+          if (providerErrorStatus(error) !== 404) throw error
+        }
+        const remaining = await listOwnedConnectedAccounts(options, { actor, secret, toolkitId })
+        if (remaining.some((candidate) => candidate.id === account.id)) {
+          throw providerError("Composio connected-account revocation could not be verified")
+        }
+      } finally {
+        if (source.connectorRef?.sessionId) await deleteComposioSessionVerified(options, secret, source.connectorRef.sessionId)
       }
     },
   }
 }
 
 const COMPOSIO_TRANSPORT_SESSION_TTL_MS = 5 * 60_000
+const COMPOSIO_TRANSPORT_CLEANUP_RETRY_MS = 60_000
+const COMPOSIO_TRANSPORT_MAX_SESSIONS = 128
+const COMPOSIO_SEARCH_QUERY_MAX_LENGTH = 256
+const COMPOSIO_SEARCH_MAX_TOOLS = 20
 
 interface ComposioTransportCacheEntry {
   expiresAt: number
-  config: ManagedConnectorConfig
+  config: ManagedConnectorDefinition
   secret: ManagedConnectorSecret
   session: ComposioMcpSession
   rawTools?: McpDiscoveredTool[]
   toolkitTools?: McpDiscoveredTool[]
+  executionAccountId?: string
+  executionSession?: ComposioMcpSession
+  cleanupTimer?: ReturnType<typeof setTimeout>
+}
+
+function composioSessionCanaries(entry: Pick<ComposioTransportCacheEntry, "secret" | "session"> & { executionSession?: ComposioMcpSession }): string[] {
+  const sessions = [entry.session, entry.executionSession].filter((value): value is ComposioMcpSession => Boolean(value))
+  return [
+    entry.secret.value,
+    ...sessions.flatMap((session) => [session.id, session.mcp.url, ...Object.values(session.mcp.headers ?? {})]),
+  ]
+}
+
+function assertComposioToolMetadataSecretFree(entry: ComposioTransportCacheEntry, tools: readonly McpDiscoveredTool[]): void {
+  if (containsMcpSecretOrCanary(tools, composioSessionCanaries(entry))) {
+    throw new McpError(MCP_ERROR_CODES.SECRET_LEAK_GUARD, "Composio tool metadata contained server-only material")
+  }
+}
+
+function assertComposioToolResultSecretFree(entry: ComposioTransportCacheEntry, result: unknown): void {
+  if (containsMcpSecretOrCanary(result, composioSessionCanaries(entry))) {
+    throw new McpError(MCP_ERROR_CODES.SECRET_LEAK_GUARD, "Composio tool result contained server-only material")
+  }
+}
+
+function sanitizeComposioTransportError(error: unknown, entry: Pick<ComposioTransportCacheEntry, "secret" | "session"> & { executionSession?: ComposioMcpSession }): McpError {
+  return sanitizeMcpErrorWithCanaries(error, composioSessionCanaries(entry), "Composio MCP request failed")
+}
+
+export interface ComposioMcpAdapter {
+  transport: McpTransportClient
+  catalog: McpManagedCatalogAdapter
 }
 
 function providerErrorText(error: unknown): string {
@@ -435,12 +971,15 @@ function isUnsupportedResourcesError(error: unknown): boolean {
   )
 }
 
-export function createComposioMcpTransport(options: ComposioManagedConnectorProviderOptions & {
+export interface CreateComposioMcpAdapterOptions extends ComposioManagedConnectorProviderOptions {
   secretResolver: { resolveSecret(provider: string): Promise<ManagedConnectorSecret> }
-  configs: readonly ManagedConnectorConfig[]
-}): McpTransportClient {
+  configs: readonly ManagedConnectorDefinition[]
+}
+
+export function createComposioMcpAdapter(options: CreateComposioMcpAdapterOptions): ComposioMcpAdapter {
   const cache = new Map<string, ComposioTransportCacheEntry>()
   const pendingSessions = new Map<string, Promise<ComposioTransportCacheEntry>>()
+  const pendingCleanup = new Map<string, Promise<void>>()
 
   function keyForSource(source: McpSource): string {
     const connector = source.connectorRef
@@ -456,104 +995,245 @@ export function createComposioMcpTransport(options: ComposioManagedConnectorProv
     ].join(":")
   }
 
+  async function cleanupEntry(entry: ComposioTransportCacheEntry): Promise<void> {
+    const sessions = [entry.session, entry.executionSession].filter((value): value is ComposioMcpSession => Boolean(value))
+    const unique = sessions.filter((session, index) => sessions.findIndex((candidate) => candidate.id === session.id) === index)
+    let failures = 0
+    for (const session of unique) {
+      try {
+        await deleteResolvedComposioSessionVerified(options, entry.secret, session)
+      } catch {
+        failures += 1
+      }
+    }
+    if (failures > 0) throw providerError("One or more Composio Sessions could not be cleaned up", { failures })
+  }
+
+  function scheduleCleanup(key: string, entry: ComposioTransportCacheEntry, delayMs: number): void {
+    if (entry.cleanupTimer) clearTimeout(entry.cleanupTimer)
+    entry.cleanupTimer = setTimeout(() => void evictCacheEntry(key).catch(() => undefined), delayMs)
+    entry.cleanupTimer.unref?.()
+  }
+
+  async function evictCacheEntry(key: string): Promise<void> {
+    const entry = cache.get(key)
+    if (!entry) return
+    const cleanup = pendingCleanup.get(key) ?? cleanupEntry(entry).catch((error) => {
+      scheduleCleanup(key, entry, COMPOSIO_TRANSPORT_CLEANUP_RETRY_MS)
+      throw sanitizeComposioTransportError(error, entry)
+    }).then(() => {
+      if (entry.cleanupTimer) clearTimeout(entry.cleanupTimer)
+      cache.delete(key)
+    }).finally(() => pendingCleanup.delete(key))
+    pendingCleanup.set(key, cleanup)
+    await cleanup
+  }
+
   async function createCacheEntry(source: McpSource): Promise<ComposioTransportCacheEntry> {
     const config = options.configs.find((entry) => entry.provider === source.provider)
     if (!config) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown Composio MCP provider", { reason: "unsupported_provider" })
     const secret = await options.secretResolver.resolveSecret(source.provider)
     const session = await resolveComposioMcpSession(options, { actor: actorForSource(source), config, secret })
-    const entry = { config, secret, session, expiresAt: Date.now() + COMPOSIO_TRANSPORT_SESSION_TTL_MS }
-    cache.set(keyForSource(source), entry)
+    const key = keyForSource(source)
+    const entry: ComposioTransportCacheEntry = { config, secret, session, expiresAt: Date.now() + COMPOSIO_TRANSPORT_SESSION_TTL_MS }
+    scheduleCleanup(key, entry, COMPOSIO_TRANSPORT_SESSION_TTL_MS)
+    cache.set(key, entry)
     return entry
   }
 
-  function pruneExpiredEntries(now = Date.now()): void {
+  async function pruneExpiredEntries(now = Date.now()): Promise<void> {
     for (const [key, entry] of cache) {
-      if (entry.expiresAt <= now) cache.delete(key)
+      if (entry.expiresAt <= now) await evictCacheEntry(key)
+    }
+    while (cache.size >= COMPOSIO_TRANSPORT_MAX_SESSIONS) {
+      const oldestKey = cache.keys().next().value as string | undefined
+      if (!oldestKey) break
+      await evictCacheEntry(oldestKey)
     }
   }
 
   async function cachedContext(source: McpSource): Promise<{ key: string; entry: ComposioTransportCacheEntry; transport: McpTransportClient }> {
     const key = keyForSource(source)
     const now = Date.now()
-    pruneExpiredEntries(now)
+    await pruneExpiredEntries(now)
     const cached = cache.get(key)
     if (cached && cached.expiresAt > now) {
-      return { key, entry: cached, transport: transportForSession(options, cached.session, cached.secret) }
+      return { key, entry: cached, transport: transportForSession(options, cached.session, cached.secret, cached.config) }
     }
     const pending = pendingSessions.get(key) ?? createCacheEntry(source).finally(() => pendingSessions.delete(key))
     pendingSessions.set(key, pending)
     const entry = await pending
-    return { key, entry, transport: transportForSession(options, entry.session, entry.secret) }
+    return { key, entry, transport: transportForSession(options, entry.session, entry.secret, entry.config) }
   }
 
   async function rawToolsFor(source: McpSource, entry: ComposioTransportCacheEntry, transport: McpTransportClient): Promise<McpDiscoveredTool[]> {
     if (entry.rawTools) return entry.rawTools
     const tools = await transport.listTools(source)
+    tools.forEach(assertBoundedToolMetadata)
+    assertComposioToolMetadataSecretFree(entry, tools)
     entry.rawTools = tools
     return tools
   }
 
-  return {
+  async function executionTransportFor(source: McpSource, entry: ComposioTransportCacheEntry): Promise<McpTransportClient> {
+    const toolkitId = connectorToolkitId(entry.config, source)
+    if (!toolkitId) throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "Tool execution requires an exact toolkit")
+    const account = await requireExactlyOneComposioConnectedAccount(options, {
+      actor: actorForSource(source),
+      secret: entry.secret,
+      toolkitId,
+    })
+    if (!entry.executionSession || entry.executionAccountId !== account.id) {
+      if (entry.executionSession) await deleteResolvedComposioSessionVerified(options, entry.secret, entry.executionSession)
+      entry.executionSession = await resolveComposioMcpSession(options, {
+        actor: actorForSource(source),
+        config: entry.config,
+        secret: entry.secret,
+        accountPin: { toolkitId, connectedAccountId: account.id },
+      })
+      entry.executionAccountId = account.id
+    }
+    return transportForSession(options, entry.executionSession, entry.secret, entry.config)
+  }
+
+  const transport: McpTransportClient = {
     async listTools(source, input) {
+      if (input?.forceProviderRefresh) await evictCacheEntry(keyForSource(source))
       const { key, entry, transport } = await cachedContext(source)
-      if (input?.forceProviderRefresh) {
-        entry.rawTools = undefined
-        entry.toolkitTools = undefined
-      }
       try {
         const rawTools = await rawToolsFor(source, entry, transport)
         const directTools = safeTools(rawTools)
         if (directTools.length > 0 || !rawTools.some((tool) => tool.name === COMPOSIO_SEARCH_TOOLS) || !rawTools.some((tool) => tool.name === COMPOSIO_GET_TOOL_SCHEMAS)) {
           return directTools
         }
-        entry.toolkitTools ??= await discoverComposioToolkitTools({ transport, source, config: entry.config, session: entry.session })
+        const toolkitId = curatedToolkitId(entry.config)
+        if (!toolkitId) return directTools
+        entry.toolkitTools ??= await searchComposioTools({
+          transport,
+          source,
+          session: entry.session,
+          query: toolkitId,
+          limit: COMPOSIO_SEARCH_MAX_TOOLS,
+          toolkitId,
+          additionalToolSlugs: concreteAllowedToolSlugs(source.provider),
+        })
+        assertComposioToolMetadataSecretFree(entry, entry.toolkitTools)
         return entry.toolkitTools
       } catch (error) {
-        cache.delete(key)
-        throw error
+        await evictCacheEntry(key)
+        throw sanitizeComposioTransportError(error, entry)
       }
     },
 
     async listResources(source) {
-      const { key, transport } = await cachedContext(source)
+      const { key, entry, transport } = await cachedContext(source)
       try {
         return await transport.listResources(source)
       } catch (error) {
         if (isUnsupportedResourcesError(error)) return []
-        cache.delete(key)
-        throw error
+        await evictCacheEntry(key)
+        throw sanitizeComposioTransportError(error, entry)
       }
     },
 
     async readResource(source, uri) {
-      const { key, transport } = await cachedContext(source)
+      const { key, entry, transport } = await cachedContext(source)
       try {
         return await transport.readResource(source, uri)
       } catch (error) {
-        cache.delete(key)
-        throw error
+        await evictCacheEntry(key)
+        throw sanitizeComposioTransportError(error, entry)
       }
     },
 
     async callTool(source, toolName, input) {
       if (isComposioMetaTool(toolName)) throw new McpError(MCP_ERROR_CODES.TOOL_NOT_ALLOWED, "Composio MCP management tools are not exposed")
-      const { key, entry, transport } = await cachedContext(source)
+      const config = options.configs.find((entry) => entry.provider === source.provider)
+      if (config && isFullCatalogManagedConnectorConfig(config)) {
+        throw new McpError(MCP_ERROR_CODES.TOOL_NOT_ALLOWED, "Full-catalog execution requires the approval-gated provider dispatch")
+      }
+      const { key, entry, transport: metadataTransport } = await cachedContext(source)
       try {
-        const rawTools = await rawToolsFor(source, entry, transport)
-        if (rawTools.some((tool) => tool.name === toolName)) return await transport.callTool(source, toolName, input)
-        if (!rawTools.some((tool) => tool.name === COMPOSIO_MULTI_EXECUTE_TOOL)) return await transport.callTool(source, toolName, input)
-        return await transport.callTool(source, COMPOSIO_MULTI_EXECUTE_TOOL, {
-          tools: [{ tool_slug: toolName, arguments: input && typeof input === "object" ? input : {} }],
-          sync_response_to_workbench: false,
-          thought: `Execute ${toolName} through governed boring-mcp`,
-          current_step: "MCP_READONLY_CALL",
-          current_step_metric: "1/1 tools",
-          session_id: entry.session.id,
-        })
+        const rawTools = await rawToolsFor(source, entry, metadataTransport)
+        const transport = await executionTransportFor(source, entry)
+        let result
+        if (rawTools.some((tool) => tool.name === toolName) || !rawTools.some((tool) => tool.name === COMPOSIO_MULTI_EXECUTE_TOOL)) {
+          result = await transport.callTool(source, toolName, input)
+        } else {
+          result = await transport.callTool(source, COMPOSIO_MULTI_EXECUTE_TOOL, {
+            tools: [{ tool_slug: toolName, arguments: input && typeof input === "object" ? input : {} }],
+            sync_response_to_workbench: false,
+            thought: `Execute ${toolName} through governed boring-mcp`,
+            current_step: "MCP_READONLY_CALL",
+            current_step_metric: "1/1 tools",
+            session_id: entry.executionSession!.id,
+          })
+        }
+        assertComposioToolResultSecretFree(entry, result)
+        return result
       } catch (error) {
-        cache.delete(key)
-        throw error
+        await evictCacheEntry(key)
+        throw sanitizeComposioTransportError(error, entry)
       }
     },
   }
+
+  const catalog: McpManagedCatalogAdapter = {
+    supports(source) {
+      const config = options.configs.find((entry) => entry.provider === source.provider)
+      return Boolean(config && isFullCatalogManagedConnectorConfig(config))
+    },
+
+    async searchTools(source, input) {
+      const query = input.query.trim()
+      if (!query || query.length > COMPOSIO_SEARCH_QUERY_MAX_LENGTH) {
+        throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "Composio tool search query must be between 1 and 256 characters")
+      }
+      const limit = Math.min(Math.max(input.limit, 1), COMPOSIO_SEARCH_MAX_TOOLS)
+      if (input.forceProviderRefresh) await evictCacheEntry(keyForSource(source))
+      const { key, entry, transport } = await cachedContext(source)
+      try {
+        const rawTools = await rawToolsFor(source, entry, transport)
+        if (!rawTools.some((tool) => tool.name === COMPOSIO_SEARCH_TOOLS) || !rawTools.some((tool) => tool.name === COMPOSIO_GET_TOOL_SCHEMAS)) {
+          throw providerError("Composio Session did not expose the required managed catalog tools")
+        }
+        const tools = await searchComposioTools({ transport, source, session: entry.session, query, limit })
+        assertComposioToolMetadataSecretFree(entry, tools)
+        return tools
+      } catch (error) {
+        await evictCacheEntry(key)
+        throw sanitizeComposioTransportError(error, entry)
+      }
+    },
+
+    async describeTool(source, toolName, input) {
+      if (!toolName.trim() || toolName.length > 256 || isComposioMetaTool(toolName)) {
+        throw new McpError(MCP_ERROR_CODES.TOOL_NOT_ALLOWED, "Composio MCP management tools are not exposed")
+      }
+      if (input?.forceProviderRefresh) await evictCacheEntry(keyForSource(source))
+      const { key, entry, transport } = await cachedContext(source)
+      try {
+        const rawTools = await rawToolsFor(source, entry, transport)
+        if (!rawTools.some((tool) => tool.name === COMPOSIO_SEARCH_TOOLS) || !rawTools.some((tool) => tool.name === COMPOSIO_GET_TOOL_SCHEMAS)) {
+          throw providerError("Composio Session did not expose the required managed catalog tools")
+        }
+        const tool = await describeComposioTool({ transport, source, session: entry.session, toolName })
+        assertComposioToolMetadataSecretFree(entry, [tool])
+        return tool
+      } catch (error) {
+        await evictCacheEntry(key)
+        throw sanitizeComposioTransportError(error, entry)
+      }
+    },
+
+    async disposeSource(source) {
+      await evictCacheEntry(keyForSource(source))
+    },
+  }
+
+  return { transport, catalog }
+}
+
+export function createComposioMcpTransport(options: CreateComposioMcpAdapterOptions): McpTransportClient {
+  return createComposioMcpAdapter(options).transport
 }

--- a/plugins/boring-mcp/src/server/hardening.ts
+++ b/plugins/boring-mcp/src/server/hardening.ts
@@ -11,9 +11,10 @@ import {
   type McpTransportClient,
 } from "../shared"
 import { BORING_MCP_AGENT_BRIDGE_TOOL_NAMES, type BoringMcpAgentBridgeRegistry } from "./agentBridge"
+import type { McpManagedCatalogAdapter } from "./toolCatalog"
 import { assertMcpPublicPayloadSecretFree, createMcpSourceStatusPayload, isActorOwnedMcpSource } from "./sourceAccess"
 
-export type McpProviderOperation = "listTools" | "listResources" | "readResource" | "callTool"
+export type McpProviderOperation = "listTools" | "listResources" | "readResource" | "callTool" | "searchTools" | "describeTool"
 
 export interface McpProviderCallContext {
   actor?: McpActor
@@ -106,6 +107,30 @@ function normalizeProviderError(error: unknown): never {
   }
   const details = redactMcpSecrets(error instanceof Error ? { name: error.name, message: error.message } : error)
   throw new McpError(MCP_ERROR_CODES.PROVIDER_ERROR, "MCP provider operation failed", details)
+}
+
+export function createHardenedMcpManagedCatalog(
+  catalog: McpManagedCatalogAdapter,
+  options: McpProviderHardeningOptions = {},
+  actor?: McpActor,
+): McpManagedCatalogAdapter {
+  async function guard<T>(sourceId: string, operation: "searchTools" | "describeTool", run: () => Promise<T>): Promise<T> {
+    try {
+      const attempt = async () => {
+        await options.gate?.check({ actor, sourceId, operation })
+        return withProviderTimeout(run, options.timeoutMs)
+      }
+      return await withMetadataRetry(attempt, options.metadataRetries ?? 0)
+    } catch (error) {
+      normalizeProviderError(error)
+    }
+  }
+  return {
+    supports: (source) => catalog.supports(source),
+    searchTools: (source, input) => guard(source.id, "searchTools", () => catalog.searchTools(source, input)),
+    describeTool: (source, toolName, input) => guard(source.id, "describeTool", () => catalog.describeTool(source, toolName, input)),
+    disposeSource: catalog.disposeSource ? (source) => catalog.disposeSource!(source) : undefined,
+  }
 }
 
 export function createHardenedMcpTransport(

--- a/plugins/boring-mcp/src/server/managedConnectorAdapter.ts
+++ b/plugins/boring-mcp/src/server/managedConnectorAdapter.ts
@@ -34,12 +34,31 @@ export interface ManagedConnectorSecretResolver {
   resolveSecret(provider: McpProviderId): Promise<ManagedConnectorSecret>
 }
 
-export interface ManagedConnectorConfig {
+interface ManagedConnectorConfigBase {
   provider: McpProviderId
   displayName: string
-  toolkitId: string
   scopes?: readonly string[]
   connectUrlOrigins?: readonly string[]
+  mcpUrlOrigins?: readonly string[]
+}
+
+/** Backward-compatible curated connector configuration. */
+export interface ManagedConnectorConfig extends ManagedConnectorConfigBase {
+  mode?: "curated"
+  toolkitId: string
+}
+
+export type CuratedManagedConnectorConfig = ManagedConnectorConfig
+
+export interface FullCatalogManagedConnectorConfig extends ManagedConnectorConfigBase {
+  mode: "catalog"
+  provider: "composio"
+}
+
+export type ManagedConnectorDefinition = ManagedConnectorConfig | FullCatalogManagedConnectorConfig
+
+export function isFullCatalogManagedConnectorConfig(config: ManagedConnectorDefinition): config is FullCatalogManagedConnectorConfig {
+  return config.mode === "catalog"
 }
 
 export interface ManagedConnectorSourceRegistry extends McpSourceRegistry {
@@ -53,7 +72,7 @@ export interface ManagedConnectorStartInput {
 
 export interface ManagedConnectorStartResponse {
   connectorRef: McpConnectorRef
-  status?: Exclude<McpSourceStatus, "connected">
+  status?: McpSourceStatus
   connectUrl?: string
   providerAccountLabel?: string
 }
@@ -70,22 +89,23 @@ export interface ManagedConnectorProbeResponse {
   resources: McpDiscoveredResource[]
 }
 
-export interface ManagedConnectorProvider {
-  startConnect(args: { actor: McpActor; config: ManagedConnectorConfig; secret: ManagedConnectorSecret; sourceId: string }): Promise<ManagedConnectorStartResponse>
-  refreshStatus(args: { actor: McpActor; source: McpSource; config: ManagedConnectorConfig; secret: ManagedConnectorSecret }): Promise<ManagedConnectorStatusResponse>
-  probe(args: { actor: McpActor; source: McpSource; config: ManagedConnectorConfig; secret: ManagedConnectorSecret }): Promise<ManagedConnectorProbeResponse>
-  revoke?(args: { actor: McpActor; source: McpSource; config: ManagedConnectorConfig; secret: ManagedConnectorSecret }): Promise<void>
+export interface ManagedConnectorProvider<Config extends ManagedConnectorDefinition = ManagedConnectorConfig> {
+  startConnect(args: { actor: McpActor; config: Config; secret: ManagedConnectorSecret; sourceId: string }): Promise<ManagedConnectorStartResponse>
+  abortConnect?(args: { actor: McpActor; config: Config; secret: ManagedConnectorSecret; response: ManagedConnectorStartResponse }): Promise<void>
+  refreshStatus(args: { actor: McpActor; source: McpSource; config: Config; secret: ManagedConnectorSecret }): Promise<ManagedConnectorStatusResponse>
+  probe(args: { actor: McpActor; source: McpSource; config: Config; secret: ManagedConnectorSecret }): Promise<ManagedConnectorProbeResponse>
+  revoke?(args: { actor: McpActor; source: McpSource; config: Config; secret: ManagedConnectorSecret }): Promise<void>
 }
 
 export interface ManagedConnectorAdapterOptions {
   registry: ManagedConnectorSourceRegistry
-  provider: ManagedConnectorProvider
+  provider: ManagedConnectorProvider<ManagedConnectorDefinition>
   secretResolver: ManagedConnectorSecretResolver
-  configs: readonly ManagedConnectorConfig[]
+  configs: readonly ManagedConnectorDefinition[]
   preflightEvidence?: ManagedConnectorPreflightEvidence
   templates?: readonly McpProviderTemplate[]
   redactionCanaries?: readonly string[]
-  sourceIdFactory?: (actor: McpActor, config: ManagedConnectorConfig) => string
+  sourceIdFactory?: (actor: McpActor, config: ManagedConnectorDefinition) => string
 }
 
 export interface ManagedConnectorAdapter {
@@ -99,7 +119,7 @@ export interface ManagedConnectorStartResult extends McpSourceStatusPayload {
   connectUrl?: string
 }
 
-function findConfig(configs: readonly ManagedConnectorConfig[], provider: McpProviderId): ManagedConnectorConfig | undefined {
+function findConfig(configs: readonly ManagedConnectorDefinition[], provider: McpProviderId): ManagedConnectorDefinition | undefined {
   return configs.find((config) => config.provider === provider)
 }
 
@@ -112,7 +132,7 @@ export function createLegacyManagedConnectorSourceId(actor: McpActor, provider: 
   return validateMcpSourceId(`managed:${actor.workspaceId}:${actor.userId}:${provider}`)
 }
 
-function defaultSourceId(actor: McpActor, config: ManagedConnectorConfig): string {
+function defaultSourceId(actor: McpActor, config: ManagedConnectorDefinition): string {
   return createManagedConnectorSourceId(actor, config.provider)
 }
 
@@ -122,7 +142,7 @@ function assertSecretFree(value: unknown, canaries: readonly string[], code: Mcp
   }
 }
 
-function safeConnectUrl(rawUrl: string | undefined, config: ManagedConnectorConfig): string | undefined {
+function safeConnectUrl(rawUrl: string | undefined, config: ManagedConnectorDefinition): string | undefined {
   if (!rawUrl) return undefined
   let parsed: URL
   try {
@@ -151,45 +171,58 @@ export function createManagedConnectorAdapter(options: ManagedConnectorAdapterOp
     return secret
   }
 
-  function requireConfig(provider: McpProviderId): { config: ManagedConnectorConfig; template: McpProviderTemplate } {
+  function requireConfig(provider: McpProviderId): ManagedConnectorDefinition {
     const config = findConfig(options.configs, provider)
-    const template = getMcpProviderTemplate(provider, templates)
-    if (!config || !template) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown managed connector provider", { reason: "unsupported_provider" })
-    return { config, template }
+    if (!config) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown managed connector provider", { reason: "unsupported_provider" })
+    if (!isFullCatalogManagedConnectorConfig(config) && !getMcpProviderTemplate(provider, templates)) {
+      throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Unknown managed connector provider", { reason: "unsupported_provider" })
+    }
+    return config
+  }
+
+  function requireTemplate(config: ManagedConnectorDefinition): McpProviderTemplate {
+    const template = getMcpProviderTemplate(config.provider, templates)
+    if (!template) throw new McpError(MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID, "Managed connector has no curated policy template")
+    return template
   }
 
   return {
     async startConnect(actor, input) {
-      const { config } = requireConfig(input.provider)
+      const config = requireConfig(input.provider)
       const sourceId = validateMcpSourceId((options.sourceIdFactory ?? defaultSourceId)(actor, config))
       const secret = await getSecret(config.provider)
       const secretCanaries = [...canaries, secret.value]
       const response = await options.provider.startConnect({ actor, config, secret, sourceId })
-      const connectUrl = safeConnectUrl(response.connectUrl, config)
-      assertSecretFree({ ...response, connectUrl }, secretCanaries)
-      const source: McpSource = {
-        id: sourceId,
-        workspaceId: actor.workspaceId,
-        userId: actor.userId,
-        provider: config.provider,
-        displayName: input.displayName ?? config.displayName,
-        status: response.status ?? "unconfigured",
-        ownerKind: "user",
-        credentialProvider: "composio-managed",
-        scopes: config.scopes ? [...config.scopes] : undefined,
-        providerAccountLabel: response.providerAccountLabel,
-        connectorRef: response.connectorRef,
+      try {
+        const connectUrl = safeConnectUrl(response.connectUrl, config)
+        assertSecretFree({ ...response, connectUrl }, secretCanaries)
+        const source: McpSource = {
+          id: sourceId,
+          workspaceId: actor.workspaceId,
+          userId: actor.userId,
+          provider: config.provider,
+          displayName: input.displayName ?? config.displayName,
+          status: response.status ?? "unconfigured",
+          ownerKind: "user",
+          credentialProvider: "composio-managed",
+          scopes: config.scopes ? [...config.scopes] : undefined,
+          providerAccountLabel: response.providerAccountLabel,
+          connectorRef: response.connectorRef,
+        }
+        assertSecretFree(source, secretCanaries)
+        const saved = await options.registry.upsertSource(actor, source)
+        const result = { ...createMcpSourceStatusPayload(saved), connectUrl }
+        assertSecretFree(result, secretCanaries)
+        return result
+      } catch (error) {
+        await options.provider.abortConnect?.({ actor, config, secret, response })
+        throw error
       }
-      assertSecretFree(source, secretCanaries)
-      const saved = await options.registry.upsertSource(actor, source)
-      const result = { ...createMcpSourceStatusPayload(saved), connectUrl }
-      assertSecretFree(result, secretCanaries)
-      return result
     },
 
     async refreshStatus(actor, sourceId) {
       const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
-      const { config } = requireConfig(source.provider)
+      const config = requireConfig(source.provider)
       const secret = await getSecret(config.provider)
       const secretCanaries = [...canaries, secret.value]
       const response = await options.provider.refreshStatus({ actor, source, config, secret })
@@ -211,14 +244,17 @@ export function createManagedConnectorAdapter(options: ManagedConnectorAdapterOp
     async probeSource(actor, sourceId) {
       const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
       if (source.status !== "connected") throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source is not connected")
-      const { config, template } = requireConfig(source.provider)
+      const config = requireConfig(source.provider)
       const secret = await getSecret(config.provider)
       const response = await options.provider.probe({ actor, source, config, secret })
       assertSecretFree(response, [...canaries, secret.value])
+      const tools = isFullCatalogManagedConnectorConfig(config)
+        ? response.tools.map((tool) => ({ ...tool, decision: { allowed: false, risk: "unknown" as const, reason: "Full-catalog execution requires approval" } }))
+        : classifyMcpTools(requireTemplate(config), response.tools)
       const result = {
         sourceId: source.id,
         provider: source.provider,
-        tools: classifyMcpTools(template, response.tools),
+        tools,
         resources: response.resources,
       }
       assertSecretFree(result, [...canaries, secret.value])
@@ -230,14 +266,10 @@ export function createManagedConnectorAdapter(options: ManagedConnectorAdapterOp
       const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
       let secretCanaries: readonly string[] = canaries
       if (options.provider.revoke) {
-        try {
-          const { config } = requireConfig(source.provider)
-          const secret = await getSecret(config.provider)
-          await options.provider.revoke({ actor, source, config, secret })
-          secretCanaries = [...canaries, secret.value]
-        } catch (error) {
-          if (!(error instanceof McpError && error.code === MCP_ERROR_CODES.PROVIDER_CONFIG_INVALID)) throw error
-        }
+        const config = requireConfig(source.provider)
+        const secret = await getSecret(config.provider)
+        await options.provider.revoke({ actor, source, config, secret })
+        secretCanaries = [...canaries, secret.value]
       }
       const disconnected = await options.registry.disconnectSource(actor, source.id)
       const result = await verifyMcpDisconnectResult(options.registry, actor, source.id, disconnected)

--- a/plugins/boring-mcp/src/server/mcpSdkTransport.ts
+++ b/plugins/boring-mcp/src/server/mcpSdkTransport.ts
@@ -24,6 +24,7 @@ export interface McpSdkTransportOptions {
   endpoint: McpSdkEndpoint | ((input: McpSdkEndpointResolverInput) => McpSdkEndpoint | Promise<McpSdkEndpoint>)
   clientName?: string
   clientVersion?: string
+  fetch?: typeof fetch
 }
 
 async function resolveEndpoint(options: McpSdkTransportOptions, source: McpSource): Promise<McpSdkEndpoint> {
@@ -54,7 +55,8 @@ async function withClient<T>(options: McpSdkTransportOptions, source: McpSource,
   try {
     const endpoint = await resolveEndpoint(options, source)
     const transport = new StreamableHTTPClientTransport(normalizeUrl(endpoint.url), {
-      requestInit: { headers: normalizeHeaders(endpoint.headers) },
+      requestInit: { headers: normalizeHeaders(endpoint.headers), redirect: "error" },
+      fetch: options.fetch,
     })
     await client.connect(transport)
     return await run(client)

--- a/plugins/boring-mcp/src/server/sourceHandlers.ts
+++ b/plugins/boring-mcp/src/server/sourceHandlers.ts
@@ -17,14 +17,15 @@ import {
   type McpToolSearchResult,
   type McpTransportClient,
 } from "../shared"
-import { createHardenedMcpTransport, verifyMcpDisconnectResult, type McpProviderHardeningOptions } from "./hardening"
+import { createHardenedMcpManagedCatalog, createHardenedMcpTransport, verifyMcpDisconnectResult, type McpProviderHardeningOptions } from "./hardening"
 import { assertMcpPublicPayloadSecretFree, createMcpSourceStatusPayload, requireActorOwnedMcpSource, validateMcpSourceId } from "./sourceAccess"
 import { createBoringMcpReadonlyCaller, type McpReadonlyCallAuditSink } from "./readonlyCall"
-import { InMemoryMcpToolCatalogCache, createBoringMcpToolCatalog, type McpToolDescribeInput, type McpToolsSearchInput } from "./toolCatalog"
+import { InMemoryMcpToolCatalogCache, createBoringMcpToolCatalog, type McpManagedCatalogAdapter, type McpToolDescribeInput, type McpToolsSearchInput } from "./toolCatalog"
 
 export interface BoringMcpSourceHandlersOptions {
   registry: McpSourceRegistry
   transport: McpTransportClient
+  managedCatalog?: McpManagedCatalogAdapter
   templates?: readonly McpProviderTemplate[]
   maxReadonlyInputBytes?: number
   audit?: McpReadonlyCallAuditSink
@@ -57,7 +58,12 @@ export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOp
   }
 
   function catalogFor(actor: McpActor) {
-    return createBoringMcpToolCatalog({ ...options, transport: transportFor(actor), cache: catalogCache })
+    return createBoringMcpToolCatalog({
+      ...options,
+      transport: transportFor(actor),
+      managedCatalog: options.managedCatalog ? createHardenedMcpManagedCatalog(options.managedCatalog, options.hardening, actor) : undefined,
+      cache: catalogCache,
+    })
   }
 
   function readonlyCallerFor(actor: McpActor) {
@@ -85,14 +91,38 @@ export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOp
 
     async doctorSource(actor, sourceId) {
       const source = await requireActorOwnedMcpSource(options.registry, actor, sourceId)
-      const result = doctorMcpSource(source, options.templates)
+      const result = options.managedCatalog?.supports(source)
+        ? {
+            ok: source.status === "connected",
+            sourceId: source.id,
+            issues: source.status === "connected"
+              ? []
+              : [{ level: "warning" as const, code: MCP_ERROR_CODES.SOURCE_UNAVAILABLE, message: "MCP source is not connected" }],
+          }
+        : doctorMcpSource(source, options.templates)
       assertMcpPublicPayloadSecretFree(result)
       return result
     },
 
     async probeSource(actor, sourceId) {
       const normalizedSourceId = validateMcpSourceId(sourceId)
-      const result = await facadeFor(actor).probeSource(actor, normalizedSourceId)
+      const source = await requireActorOwnedMcpSource(options.registry, actor, normalizedSourceId)
+      if (source.status !== "connected") throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source is not connected")
+      const result = options.managedCatalog?.supports(source)
+        ? {
+            sourceId: source.id,
+            provider: source.provider,
+            tools: (await createHardenedMcpManagedCatalog(options.managedCatalog, options.hardening, actor).searchTools(source, {
+              query: "connection identity profile",
+              limit: 1,
+              forceProviderRefresh: true,
+            })).map((tool) => ({
+              ...tool,
+              decision: { allowed: false, risk: "unknown" as const, reason: "Full-catalog execution requires approval" },
+            })),
+            resources: [],
+          }
+        : await facadeFor(actor).probeSource(actor, normalizedSourceId)
       assertMcpPublicPayloadSecretFree(result)
       return result
     },
@@ -123,7 +153,8 @@ export function createBoringMcpSourceHandlers(options: BoringMcpSourceHandlersOp
 
     async disconnectSource(actor, sourceId) {
       const normalizedSourceId = validateMcpSourceId(sourceId)
-      await requireActorOwnedMcpSource(options.registry, actor, normalizedSourceId)
+      const ownedSource = await requireActorOwnedMcpSource(options.registry, actor, normalizedSourceId)
+      await options.managedCatalog?.disposeSource?.(ownedSource)
       if (!options.registry.disconnectSource) {
         throw new McpError(MCP_ERROR_CODES.SOURCE_UNAVAILABLE, "MCP source disconnect is not configured")
       }

--- a/plugins/boring-mcp/src/server/toolCatalog.ts
+++ b/plugins/boring-mcp/src/server/toolCatalog.ts
@@ -9,6 +9,7 @@ import {
   type McpDiscoveredTool,
   type McpProviderId,
   type McpProviderTemplate,
+  type McpSource,
   type McpSourceRegistry,
   type McpToolCatalogEntry,
   type McpToolDescribeResult,
@@ -29,9 +30,23 @@ export interface McpToolCatalogCache {
   set(actor: McpActor, sourceId: string, result: McpToolCatalogSnapshot): Promise<void>
 }
 
+export interface McpManagedToolSearchInput {
+  query: string
+  limit: number
+  forceProviderRefresh?: boolean
+}
+
+export interface McpManagedCatalogAdapter {
+  supports(source: McpSource): boolean
+  searchTools(source: McpSource, input: McpManagedToolSearchInput): Promise<McpDiscoveredTool[]>
+  describeTool(source: McpSource, toolName: string, input?: { forceProviderRefresh?: boolean }): Promise<McpDiscoveredTool>
+  disposeSource?(source: McpSource): Promise<void>
+}
+
 export interface BoringMcpToolCatalogOptions {
   registry: McpSourceRegistry
   transport: McpTransportClient
+  managedCatalog?: McpManagedCatalogAdapter
   templates?: readonly McpProviderTemplate[]
   cache?: McpToolCatalogCache
 }
@@ -39,6 +54,7 @@ export interface BoringMcpToolCatalogOptions {
 export interface McpToolsSearchInput {
   sourceId?: string
   query?: string
+  limit?: number
   refresh?: boolean
   providerRefresh?: boolean
 }
@@ -92,17 +108,36 @@ function sourceCatalogRevision(source: { status: string; updatedAt?: string; con
   })).digest("hex")
 }
 
+export interface NormalizeMcpCatalogToolContext {
+  sourceRevision?: string
+  accountRequired?: boolean
+}
+
 export function normalizeMcpCatalogTool(
   sourceId: string,
   provider: McpProviderId,
   tool: McpDiscoveredTool,
   templates?: readonly McpProviderTemplate[],
+  context: NormalizeMcpCatalogToolContext = {},
 ): McpToolCatalogEntry {
   const template = getMcpProviderTemplate(provider, templates)
   const decision = template
     ? classifyMcpTool(template, tool.name)
     : { allowed: false, risk: "unknown" as const, reason: "Tool provider has no read-only allowlist" }
   const inputSchema = tool.inputSchema ?? {}
+  const policyRevision = createMcpSchemaHash({ template, decision })
+  const descriptorHash = createMcpSchemaHash({
+    provider,
+    toolkit: tool.toolkit,
+    toolName: tool.name,
+    version: tool.version,
+    inputSchema,
+    outputSchema: tool.outputSchema,
+    annotations: tool.annotations,
+    sourceRevision: context.sourceRevision,
+    policyRevision,
+    accountRequired: context.accountRequired,
+  })
   return {
     sourceId,
     provider,
@@ -111,11 +146,18 @@ export function normalizeMcpCatalogTool(
     summary: tool.description ?? displayName(tool.name),
     description: tool.description,
     inputSchema,
+    outputSchema: tool.outputSchema,
+    providerVersion: tool.version,
+    annotations: tool.annotations,
+    descriptorHash,
+    sourceRevision: context.sourceRevision,
+    policyRevision,
+    accountRequired: context.accountRequired,
     risk: decision.risk,
     enabled: decision.allowed,
     blockedReasons: decision.allowed ? [] : [decision.reason],
     schemaHash: createMcpSchemaHash(inputSchema),
-    nativeRef: { provider, action: tool.name },
+    nativeRef: { provider, toolkit: tool.toolkit, action: tool.name },
   }
 }
 
@@ -136,6 +178,13 @@ function assertConnectedSource(sourceId: string, status: string): void {
 export function createBoringMcpToolCatalog(options: BoringMcpToolCatalogOptions): BoringMcpToolCatalog {
   const cache = options.cache ?? new InMemoryMcpToolCatalogCache()
 
+  async function requireConnectedSource(actor: McpActor, sourceId: string): Promise<McpSource> {
+    const requestedSourceId = validateMcpSourceId(sourceId)
+    const source = await requireActorOwnedMcpSource(options.registry, actor, requestedSourceId)
+    assertConnectedSource(source.id, source.status)
+    return source
+  }
+
   async function loadSourceCatalog(actor: McpActor, sourceId: string, refresh?: boolean, providerRefresh?: boolean): Promise<McpToolCatalogSnapshot> {
     const requestedSourceId = validateMcpSourceId(sourceId)
     const source = await requireActorOwnedMcpSource(options.registry, actor, requestedSourceId)
@@ -149,7 +198,11 @@ export function createBoringMcpToolCatalog(options: BoringMcpToolCatalogOptions)
     }
 
     const discoveredTools = await options.transport.listTools(source, { forceProviderRefresh: providerRefresh ?? refresh })
-    const tools = discoveredTools.map((tool) => normalizeMcpCatalogTool(resolvedSourceId, source.provider, tool, options.templates))
+    const normalizationContext = {
+      sourceRevision,
+      accountRequired: source.credentialProvider === "composio-managed",
+    }
+    const tools = discoveredTools.map((tool) => normalizeMcpCatalogTool(resolvedSourceId, source.provider, tool, options.templates, normalizationContext))
     const snapshot = { sourceId: resolvedSourceId, provider: source.provider, sourceRevision, tools }
     assertMcpPublicPayloadSecretFree(snapshot)
     await cache.set(actor, resolvedSourceId, snapshot)
@@ -159,21 +212,49 @@ export function createBoringMcpToolCatalog(options: BoringMcpToolCatalogOptions)
   return {
     async searchTools(actor, input = {}) {
       const sources = input.sourceId
-        ? [{ id: validateMcpSourceId(input.sourceId) }]
+        ? [await requireConnectedSource(actor, input.sourceId)]
         : (await options.registry.listSources(actor)).filter((source) => source.status === "connected")
       const catalog: McpToolCatalogEntry[] = []
+      const query = input.query?.trim() ?? ""
+      const limit = Math.min(Math.max(input.limit ?? 20, 1), 20)
       for (const source of sources) {
+        if (options.managedCatalog?.supports(source)) {
+          if (!query) throw new McpError(MCP_ERROR_CODES.INPUT_INVALID, "A non-empty query is required for managed full-catalog search")
+          const discovered = await options.managedCatalog.searchTools(source, {
+            query,
+            limit,
+            forceProviderRefresh: input.providerRefresh ?? input.refresh,
+          })
+          const sourceRevision = sourceCatalogRevision(source)
+          catalog.push(...discovered.map((tool) => normalizeMcpCatalogTool(source.id, source.provider, tool, options.templates, {
+            sourceRevision,
+            accountRequired: source.credentialProvider === "composio-managed",
+          })))
+          continue
+        }
         const result = await loadSourceCatalog(actor, source.id, input.refresh, input.providerRefresh)
-        catalog.push(...result.tools)
+        catalog.push(...result.tools.filter((entry) => matchesQuery(entry, query)))
       }
-      const response = { tools: catalog.filter((entry) => matchesQuery(entry, input.query ?? "")) }
+      const response = { tools: input.limit === undefined ? catalog : catalog.slice(0, limit) }
       assertMcpPublicPayloadSecretFree(response)
       return response
     },
 
     async describeTool(actor, input) {
-      const result = await loadSourceCatalog(actor, input.sourceId, input.refresh, input.providerRefresh)
-      const tool = result.tools.find((candidate) => candidate.toolName === input.toolName)
+      const source = await requireConnectedSource(actor, input.sourceId)
+      let tool: McpToolCatalogEntry | undefined
+      if (options.managedCatalog?.supports(source)) {
+        const discovered = await options.managedCatalog.describeTool(source, input.toolName, {
+          forceProviderRefresh: input.providerRefresh ?? input.refresh,
+        })
+        tool = normalizeMcpCatalogTool(source.id, source.provider, discovered, options.templates, {
+          sourceRevision: sourceCatalogRevision(source),
+          accountRequired: source.credentialProvider === "composio-managed",
+        })
+      } else {
+        const result = await loadSourceCatalog(actor, input.sourceId, input.refresh, input.providerRefresh)
+        tool = result.tools.find((candidate) => candidate.toolName === input.toolName)
+      }
       if (!tool) throw new McpError(MCP_ERROR_CODES.TOOL_NOT_FOUND, "MCP tool not found")
       const schemaDrifted = Boolean(input.expectedSchemaHash && input.expectedSchemaHash !== tool.schemaHash)
       if (containsMcpSecret(tool)) throw new McpError(MCP_ERROR_CODES.SECRET_LEAK_GUARD, "MCP tool metadata looked like it contained a secret")

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -15,11 +15,13 @@ export const MCP_ERROR_CODES = {
   RESOURCE_LIMIT_EXCEEDED: "MCP_RESOURCE_LIMIT_EXCEEDED",
   SECRET_LEAK_GUARD: "MCP_SECRET_LEAK_GUARD",
   INPUT_INVALID: "MCP_INPUT_INVALID",
+  CONNECTED_ACCOUNT_REQUIRED: "MCP_CONNECTED_ACCOUNT_REQUIRED",
+  CONNECTED_ACCOUNT_CONFLICT: "MCP_CONNECTED_ACCOUNT_CONFLICT",
   RESOURCE_URI_INVALID: "MCP_RESOURCE_URI_INVALID",
 } as const
 
 export type McpErrorCode = (typeof MCP_ERROR_CODES)[keyof typeof MCP_ERROR_CODES]
-export type McpProviderId = "notion" | "airtable" | (string & {})
+export type McpProviderId = "notion" | "airtable" | "composio" | (string & {})
 export type McpTransport = "streamable-http"
 export type McpSourceStatus = "connected" | "expired" | "revoked" | "error" | "unconfigured"
 export type McpToolRisk = "read" | "write" | "admin" | "unknown"
@@ -87,6 +89,10 @@ export interface McpDiscoveredTool {
   name: string
   description?: string
   inputSchema?: unknown
+  outputSchema?: unknown
+  toolkit?: string
+  version?: string
+  annotations?: Readonly<Record<string, unknown>>
 }
 
 export interface McpDiscoveredResource {
@@ -130,6 +136,12 @@ export interface McpToolCatalogEntry {
   description?: string
   inputSchema: unknown
   outputSchema?: unknown
+  providerVersion?: string
+  annotations?: Readonly<Record<string, unknown>>
+  descriptorHash?: string
+  sourceRevision?: string
+  policyRevision?: string
+  accountRequired?: boolean
   risk: McpToolRisk
   enabled: boolean
   blockedReasons: string[]


### PR DESCRIPTION
## Summary

Implements issue #900 slice 900.1: the thin full-catalog Composio backend for `boring-mcp`.

- adds one template-free `composio` catalog/source mode while preserving curated Notion/Airtable configurations
- creates unfiltered Composio MCP Sessions with raw `workbench: { enable: false }`
- adds a query-driven managed search/describe seam without broadening generic `McpTransportClient`
- requires exactly one complete, actor-owned connected account and verifies exact Session account pins
- keeps every raw `COMPOSIO_*` control/execution tool hidden
- deliberately blocks all full-catalog execution until the approval-gated slice 900.2
- enforces exact API/MCP origins, redirect rejection, time/stream/schema bounds, exact canary redaction, and hardened provider budgets
- verifies remote Session/account cleanup and retries failed Session cleanup
- carries toolkit/version/schema/annotation/source/policy revisions in normalized descriptors

## Security boundaries

- the operator key remains server-only
- the MCP key crosses only a reviewed exact origin
- Session workbench stays disabled and echoed config is verified fail-closed
- zero, multiple, malformed, or incomplete account results fail closed
- toolkit provenance is proved through provider search and checked against schema metadata
- raw multi-execute, workbench, bash, and all other `COMPOSIO_*` names remain unreachable
- successful results and errors are checked against metadata and execution Session capabilities

## Compatibility

- `ManagedConnectorConfig` retains its existing curated interface and required `toolkitId`
- catalog mode uses an additive `ManagedConnectorDefinition` union
- existing Notion/Airtable discovery keeps static allowlist priority and existing default result cardinality
- full-catalog execution stays blocked rather than weakening `mcp_readonly_call`

## Proof

- `pnpm --filter @hachej/boring-mcp test` — 115 passed
- `pnpm --filter @hachej/boring-mcp typecheck` — passed
- `pnpm --filter @hachej/boring-mcp build` — passed
- `pnpm --filter full-app typecheck` — passed
- `git diff --check` — passed
- independent final review — CLEAN

## Remaining slices

- 900.2: exact Ask User approval at provider dispatch for every call
- 900.3: one-Composio connection/account UI
- 900.4: release and Seneca production proof

Closes no parent issue; this completes only slice 900.1.
