### PR TITLE
#909 Preserve legacy admission for non-Gateway agent routes

### DIFF
--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -537,7 +537,7 @@ test('request-scoped ready-status resolves the requested workspace', async () =>
   }
 })
 
-test('registerAgentRoutes reload reruns provisioning and refreshes skills scope', async () => {
+test('registerAgentRoutes non-Gateway admission covers reload and command execution', async () => {
   const workspaceRoot = await makeTempDir('boring-agent-embed-reload-provision-')
   const skillRoot = join(workspaceRoot, 'generated-skills', 'reload-skill')
   async function writeReloadSkill(description: string): Promise<void> {
@@ -548,6 +548,7 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
   let blockAdmission = false
   const events: string[] = []
   const reloadSession = vi.fn(async () => { events.push('reloadSession'); return true })
+  const executeSlashCommand = vi.fn(async () => { events.push('executeSlashCommand') })
   const app = Fastify({ logger: false })
 
   await app.register(registerAgentRoutes, {
@@ -564,7 +565,7 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
         skillPaths: [dirname(skillRoot)],
       }
     },
-    admitEffect: async () => {
+    admitNonGatewayEffect: async () => {
       events.push('admit')
       if (blockAdmission) {
         throw new AgentEffectAdmissionError(ADMISSION_ERROR_CODE)
@@ -587,6 +588,7 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
         async delete() {},
       },
       reloadSession,
+      executeSlashCommand,
       }),
   })
   await app.ready()
@@ -606,6 +608,15 @@ test('registerAgentRoutes reload reruns provisioning and refreshes skills scope'
     expect(reloadSession).toHaveBeenCalledWith('default')
     expect(provisionCalls).toBe(2)
     expect(events).toEqual(['admit', 'reprovision', 'beforeReload', 'reloadSession'])
+
+    events.length = 0
+    const command = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/commands/execute',
+      payload: { name: 'plan', args: '' },
+    })
+    expect(command.statusCode).toBe(200)
+    expect(events).toEqual(['admit', 'executeSlashCommand'])
 
     events.length = 0
     blockAdmission = true

--- a/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
+++ b/packages/agent/src/server/__tests__/registerAgentRoutes.test.ts
@@ -95,6 +95,12 @@ test('registerAgentRoutes reuses one prebuilt Host while retaining addressed and
   const runtimeModeAdapter = createTestRuntimeModeAdapter('direct')
   const contexts = new WeakMap<object, ResolvedAgentRuntimeScope>()
   const claims = new WeakMap<object, { workspaceScopeId: string; authSubjectId: string }>()
+  const harness = createDispatcherTestHarness()
+  const strongAdmission = vi.fn(async () => ({
+    type: 'accepted' as const,
+    admissionReceipt: 'prebuilt-strong-admission',
+  }))
+  const admitEffect = vi.fn(async () => {})
   const created = await createAgentHost({
     agents: [{ agentTypeId: 'default', legacyDefault: true }],
     fleetCompiler: { async compile({ agents }) { return agents } },
@@ -108,6 +114,8 @@ test('registerAgentRoutes reuses one prebuilt Host while retaining addressed and
     },
     runtimeModeAdapter,
     sessionRoot,
+    harnessFactory: harness.factory,
+    effectAdmission: { admit: strongAdmission },
     async resolveRuntimeScope({ scope }) {
       const context = contexts.get(scope as object)
       if (!context) throw new Error('missing runtime context')
@@ -120,6 +128,8 @@ test('registerAgentRoutes reuses one prebuilt Host while retaining addressed and
     sessionRoot,
     runtimeModeAdapter,
     externalPlugins: false,
+    harnessFactory: harness.factory,
+    admitEffect,
     agentHost: {
       created,
       defaultAgentTypeId: 'default',
@@ -138,6 +148,15 @@ test('registerAgentRoutes reuses one prebuilt Host while retaining addressed and
     expect(agents.json()).toEqual([{ agentTypeId: 'default', label: 'Agent' }])
     expect((await app.inject({ method: 'GET', url: '/api/v1/agent/models' })).statusCode).toBe(200)
     expect((await app.inject({ method: 'GET', url: '/api/v1/agent/pi-chat/sessions' })).statusCode).toBe(200)
+
+    const session = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/default/sessions',
+      payload: { requestId: 'prebuilt-session-create', title: 'Prebuilt admission' },
+    })
+    expect(session.statusCode).toBe(201)
+    expect(strongAdmission).toHaveBeenCalledOnce()
+    expect(admitEffect).not.toHaveBeenCalled()
     await expect(created.host.describe()).resolves.toMatchObject({ hostId: 'prebuilt-route-test' })
   } finally {
     await app.close()
@@ -537,7 +556,7 @@ test('request-scoped ready-status resolves the requested workspace', async () =>
   }
 })
 
-test('registerAgentRoutes non-Gateway admission covers reload and command execution', async () => {
+test('registerAgentRoutes legacy admission covers reload and command execution', async () => {
   const workspaceRoot = await makeTempDir('boring-agent-embed-reload-provision-')
   const skillRoot = join(workspaceRoot, 'generated-skills', 'reload-skill')
   async function writeReloadSkill(description: string): Promise<void> {
@@ -565,7 +584,7 @@ test('registerAgentRoutes non-Gateway admission covers reload and command execut
         skillPaths: [dirname(skillRoot)],
       }
     },
-    admitNonGatewayEffect: async () => {
+    admitEffect: async () => {
       events.push('admit')
       if (blockAdmission) {
         throw new AgentEffectAdmissionError(ADMISSION_ERROR_CODE)

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -396,6 +396,11 @@ export interface RegisterAgentRoutesOptions {
   telemetry?: TelemetrySink
   /** Optional host admission called immediately before each agent effect. */
   admitEffect?: AgentEffectAdmission
+  /**
+   * Optional admission for legacy effects outside AgentGateway: `/reload` and
+   * `/commands/execute`. Falls back to admitEffect for legacy-only callers.
+   */
+  admitNonGatewayEffect?: AgentEffectAdmission
   /** Generic request-aware model filtering seam. Hosts may filter per user/workspace. */
   filterModels?: ModelsRoutesOptions['filterModels']
   /** Generic per-request/per-run filesystem binding seam. Hosts may return user/session-filtered bindings. */
@@ -1487,6 +1492,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       : async (request) => (await getSkillsScopeForRequest(request)).pi.noSkills,
   })
   await app.register(sessionChangesRoutes, { tracker: sessionChangesTracker })
+  const admitNonGatewayEffect = opts.admitNonGatewayEffect ?? opts.admitEffect
   app.post<{ Body: { sessionId?: string } }>('/api/v1/agent/reload', async (request, reply) => {
     const workspaceId = getRequestWorkspaceId(request)
     const binding = await getBindingForRequest(request)
@@ -1495,7 +1501,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     }
 
     try {
-      await opts.admitEffect?.({ workspaceId, requestId: request.id })
+      await admitNonGatewayEffect?.({ workspaceId, requestId: request.id })
       await binding.reprovision(request)
       binding.assertActive()
       const hookResult = await opts.beforeReload?.({
@@ -1552,14 +1558,14 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
         defaultSessionId: sessionId,
         workdir: staticBinding.runtimeBundle.workspace.root,
         metering: opts.metering,
-        admitEffect: opts.admitEffect,
+        admitEffect: admitNonGatewayEffect,
       }
     : {
         defaultSessionId: sessionId,
         getHarness: async (request) => (await getBindingForRequest(request)).harness,
         getWorkdir: async (request) => (await getBindingForRequest(request)).runtimeBundle.workspace.root,
         metering: opts.metering,
-        admitEffect: opts.admitEffect,
+        admitEffect: admitNonGatewayEffect,
       },
   )
   await app.register(readyStatusRoutes, staticBinding

--- a/packages/agent/src/server/registerAgentRoutes.ts
+++ b/packages/agent/src/server/registerAgentRoutes.ts
@@ -396,11 +396,6 @@ export interface RegisterAgentRoutesOptions {
   telemetry?: TelemetrySink
   /** Optional host admission called immediately before each agent effect. */
   admitEffect?: AgentEffectAdmission
-  /**
-   * Optional admission for legacy effects outside AgentGateway: `/reload` and
-   * `/commands/execute`. Falls back to admitEffect for legacy-only callers.
-   */
-  admitNonGatewayEffect?: AgentEffectAdmission
   /** Generic request-aware model filtering seam. Hosts may filter per user/workspace. */
   filterModels?: ModelsRoutesOptions['filterModels']
   /** Generic per-request/per-run filesystem binding seam. Hosts may return user/session-filtered bindings. */
@@ -881,7 +876,10 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
         readyTracker,
         checkReadiness,
         harnessFactory: opts.harnessFactory,
-        admitEffect: opts.admitEffect,
+        // A prebuilt Host owns admission for AgentGateway effects. Keep the
+        // legacy callback only on this plugin's non-Gateway reload/command
+        // routes; compatibility Hosts still use it for their Gateway aliases.
+        admitEffect: opts.agentHost ? undefined : opts.admitEffect,
         harnessRuntime: {
           getCurrent: () => runtimeProvisioning ? {
             env: runtimeProvisioning.env,
@@ -1492,7 +1490,6 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
       : async (request) => (await getSkillsScopeForRequest(request)).pi.noSkills,
   })
   await app.register(sessionChangesRoutes, { tracker: sessionChangesTracker })
-  const admitNonGatewayEffect = opts.admitNonGatewayEffect ?? opts.admitEffect
   app.post<{ Body: { sessionId?: string } }>('/api/v1/agent/reload', async (request, reply) => {
     const workspaceId = getRequestWorkspaceId(request)
     const binding = await getBindingForRequest(request)
@@ -1501,7 +1498,7 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
     }
 
     try {
-      await admitNonGatewayEffect?.({ workspaceId, requestId: request.id })
+      await opts.admitEffect?.({ workspaceId, requestId: request.id })
       await binding.reprovision(request)
       binding.assertActive()
       const hookResult = await opts.beforeReload?.({
@@ -1558,14 +1555,14 @@ export const registerAgentRoutes: FastifyPluginAsync<RegisterAgentRoutesOptions>
         defaultSessionId: sessionId,
         workdir: staticBinding.runtimeBundle.workspace.root,
         metering: opts.metering,
-        admitEffect: admitNonGatewayEffect,
+        admitEffect: opts.admitEffect,
       }
     : {
         defaultSessionId: sessionId,
         getHarness: async (request) => (await getBindingForRequest(request)).harness,
         getWorkdir: async (request) => (await getBindingForRequest(request)).runtimeBundle.workspace.root,
         metering: opts.metering,
-        admitEffect: admitNonGatewayEffect,
+        admitEffect: opts.admitEffect,
       },
   )
   await app.register(readyStatusRoutes, staticBinding

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -8,7 +8,17 @@ const mocks = vi.hoisted(() => ({
     await options.fleetCompiler.compile({ agents: options.agents })
     return { marker: 'prebuilt-agent-host' }
   }),
-  registerAgentRoutes: vi.fn(async () => {}),
+  registerAgentRoutes: vi.fn(async (app: any, options: any) => {
+    const admitNonGatewayEffect = options.admitNonGatewayEffect ?? options.admitEffect
+    app.post('/api/v1/agent/reload', async (request: any) => {
+      await admitNonGatewayEffect?.({ workspaceId: 'default', requestId: request.id })
+      return { ok: true }
+    })
+    app.post('/api/v1/agent/commands/execute', async (request: any) => {
+      await admitNonGatewayEffect?.({ workspaceId: 'default', requestId: request.id })
+      return { ok: true }
+    })
+  }),
   provisionWorkspaceRuntime: vi.fn(async () => ({ changed: false, env: {}, pathEntries: [], skillPaths: [] })),
   collectWorkspaceAgentServerPlugins: vi.fn(),
   createWorkspaceUiTools: vi.fn(() => []),
@@ -151,7 +161,7 @@ test('core/full-app composition forwards collected runtime provisioning plugins 
   }
 })
 
-test('core/full-app supplies strong Gateway admission and keeps legacy admission wrapper-only', async () => {
+test('core/full-app partitions Gateway admission from legacy reload and command admission', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
     runtimePlugins: [],
     agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
@@ -170,8 +180,24 @@ test('core/full-app supplies strong Gateway admission and keeps legacy admission
   })
 
   try {
-    expect((mocks.createAgentHost as any).mock.calls[0]?.[0].effectAdmission).toBe(effectAdmission)
-    expect((mocks.registerAgentRoutes as any).mock.calls[0]?.[1].admitEffect).toBeUndefined()
+    const hostOptions = (mocks.createAgentHost as any).mock.calls[0]?.[0]
+    const routeOptions = (mocks.registerAgentRoutes as any).mock.calls[0]?.[1]
+    expect(hostOptions.effectAdmission).toBe(effectAdmission)
+    expect(routeOptions.admitEffect).toBeUndefined()
+    expect(routeOptions.admitNonGatewayEffect).toBe(admitEffect)
+
+    expect((await app.inject({ method: 'POST', url: '/api/v1/agent/reload' })).statusCode).toBe(200)
+    expect((await app.inject({
+      method: 'POST',
+      url: '/api/v1/agent/commands/execute',
+      payload: { name: 'plan' },
+    })).statusCode).toBe(200)
+    expect(admitEffect).toHaveBeenCalledTimes(2)
+    expect(effectAdmission.admit).not.toHaveBeenCalled()
+
+    await hostOptions.effectAdmission.admit({ key: { requestId: 'gateway-session-create' } })
+    expect(effectAdmission.admit).toHaveBeenCalledOnce()
+    expect(admitEffect).toHaveBeenCalledTimes(2)
   } finally {
     await app.close()
   }

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -9,13 +9,12 @@ const mocks = vi.hoisted(() => ({
     return { marker: 'prebuilt-agent-host' }
   }),
   registerAgentRoutes: vi.fn(async (app: any, options: any) => {
-    const admitNonGatewayEffect = options.admitNonGatewayEffect ?? options.admitEffect
     app.post('/api/v1/agent/reload', async (request: any) => {
-      await admitNonGatewayEffect?.({ workspaceId: 'default', requestId: request.id })
+      await options.admitEffect?.({ workspaceId: 'default', requestId: request.id })
       return { ok: true }
     })
     app.post('/api/v1/agent/commands/execute', async (request: any) => {
-      await admitNonGatewayEffect?.({ workspaceId: 'default', requestId: request.id })
+      await options.admitEffect?.({ workspaceId: 'default', requestId: request.id })
       return { ok: true }
     })
   }),
@@ -183,8 +182,7 @@ test('core/full-app partitions Gateway admission from legacy reload and command 
     const hostOptions = (mocks.createAgentHost as any).mock.calls[0]?.[0]
     const routeOptions = (mocks.registerAgentRoutes as any).mock.calls[0]?.[1]
     expect(hostOptions.effectAdmission).toBe(effectAdmission)
-    expect(routeOptions.admitEffect).toBeUndefined()
-    expect(routeOptions.admitNonGatewayEffect).toBe(admitEffect)
+    expect(routeOptions.admitEffect).toBe(admitEffect)
 
     expect((await app.inject({ method: 'POST', url: '/api/v1/agent/reload' })).statusCode).toBe(200)
     expect((await app.inject({
@@ -194,10 +192,6 @@ test('core/full-app partitions Gateway admission from legacy reload and command 
     })).statusCode).toBe(200)
     expect(admitEffect).toHaveBeenCalledTimes(2)
     expect(effectAdmission.admit).not.toHaveBeenCalled()
-
-    await hostOptions.effectAdmission.admit({ key: { requestId: 'gateway-session-create' } })
-    expect(effectAdmission.admit).toHaveBeenCalledOnce()
-    expect(admitEffect).toHaveBeenCalledTimes(2)
   } finally {
     await app.close()
   }

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -160,7 +160,7 @@ export interface CoreWorkspaceBridgeExtraToolsContext {
 export type CoreWorkspaceBridgePiContext = CoreWorkspaceBridgeExtraToolsContext
 
 export interface CreateCoreWorkspaceAgentServerOptions
-  extends Omit<RegisterAgentRoutesOptions, 'agentHost' | 'extraTools' | 'admitNonGatewayEffect'> {
+  extends Omit<RegisterAgentRoutesOptions, 'agentHost' | 'extraTools'> {
   appRoot?: string
   config?: CoreConfig
   loadConfigOptions?: LoadConfigOptions
@@ -1228,11 +1228,9 @@ export async function createCoreWorkspaceAgentServer(
     runtimeModeAdapter,
     runtimeHost,
     version: options.version,
-    // effectAdmission covers the eight AgentGateway effect keys. Keep legacy
-    // admitEffect on non-Gateway reload and slash-command execution without
-    // also running it inside Gateway compatibility effects (double admission).
-    admitEffect: options.effectAdmission ? undefined : options.admitEffect,
-    admitNonGatewayEffect: options.effectAdmission ? options.admitEffect : undefined,
+    // The prebuilt Host applies effectAdmission to AgentGateway effects;
+    // registerAgentRoutes keeps admitEffect on reload and command routes only.
+    admitEffect: options.admitEffect,
     extraTools: [
       ...(options.extraTools ?? []),
       ...(pluginCollection.agentOptions.extraTools ?? []),

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -160,7 +160,7 @@ export interface CoreWorkspaceBridgeExtraToolsContext {
 export type CoreWorkspaceBridgePiContext = CoreWorkspaceBridgeExtraToolsContext
 
 export interface CreateCoreWorkspaceAgentServerOptions
-  extends Omit<RegisterAgentRoutesOptions, 'agentHost' | 'extraTools'> {
+  extends Omit<RegisterAgentRoutesOptions, 'agentHost' | 'extraTools' | 'admitNonGatewayEffect'> {
   appRoot?: string
   config?: CoreConfig
   loadConfigOptions?: LoadConfigOptions
@@ -1228,7 +1228,11 @@ export async function createCoreWorkspaceAgentServer(
     runtimeModeAdapter,
     runtimeHost,
     version: options.version,
+    // effectAdmission covers the eight AgentGateway effect keys. Keep legacy
+    // admitEffect on non-Gateway reload and slash-command execution without
+    // also running it inside Gateway compatibility effects (double admission).
     admitEffect: options.effectAdmission ? undefined : options.admitEffect,
+    admitNonGatewayEffect: options.effectAdmission ? options.admitEffect : undefined,
     extraTools: [
       ...(options.extraTools ?? []),
       ...(pluginCollection.agentOptions.extraTools ?? []),


### PR DESCRIPTION
## Summary
- preserve legacy `admitEffect` for Agent `/reload` and `/commands/execute` when strong `effectAdmission` is configured
- keep legacy admission out of AgentGateway compatibility effects so Gateway mutations receive only strong admission
- add Core public-composition and Agent route-seam coverage

## Context
- Bead: `wt-391-forward-0jpy.18`
- Related: #909

## Risk / rollback
Low, localized admission wiring change. Legacy `admitEffect`-only composition retains its existing fallback behavior. Roll back by reverting this commit.

## Validation
- `pnpm --filter @hachej/boring-agent exec vitest run src/server/__tests__/registerAgentRoutes.test.ts` — 48 passed
- `pnpm --filter @hachej/boring-core exec vitest run src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts` — 9 passed
- `pnpm --filter @hachej/boring-agent run typecheck` — passed
- `pnpm --filter @hachej/boring-core run typecheck` — passed after building workspace dependency artifacts
- `pnpm lint:invariants` — passed
- `git diff --check` — passed