### PR TITLE
#909 test(core): prove production scope provenance

### DIFF
--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -1,3 +1,4 @@
+import type { AuthorizedAgentScope } from '@hachej/boring-agent/shared'
 import Fastify from 'fastify'
 import { beforeEach, expect, test, vi } from 'vitest'
 import type { CoreConfig } from '../../../shared/types.js'
@@ -233,7 +234,7 @@ test.each([
   expect(mocks.registerAgentRoutes).not.toHaveBeenCalled()
 })
 
-test('core/full-app scope authority binds storage and rechecks membership on every verification', async () => {
+test('core/full-app scope authority rejects forged scopes and rechecks membership on every verification', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
     runtimePlugins: [],
     agentOptions: { extraTools: [], pi: {}, systemPromptAppend: undefined },
@@ -265,16 +266,38 @@ test('core/full-app scope authority binds storage and rechecks membership on eve
       },
     })
     expect(scope.workspaceScopeId).toBe(JSON.stringify(['workspace-a', 'storage-a']))
+    mocks.isMember.mockClear()
     await expect(hostOptions.scopeVerifier.verify(scope)).resolves.toEqual({
       workspaceScopeId: JSON.stringify(['workspace-a', 'storage-a']),
       authSubjectId: 'user-a',
     })
-    await expect(hostOptions.scopeVerifier.verify({
-      workspaceScopeId: scope.workspaceScopeId,
-      authSubjectId: scope.authSubjectId,
-    })).rejects.toThrow(/not issued/)
+
+    const forgedScopes = [
+      { label: 'spread copy', scope: { ...scope } },
+      { label: 'JSON round-trip', scope: JSON.parse(JSON.stringify(scope)) },
+      {
+        label: 'direct structural cast',
+        scope: {
+          workspaceScopeId: scope.workspaceScopeId,
+          authSubjectId: scope.authSubjectId,
+        } as AuthorizedAgentScope,
+      },
+    ]
+    for (const forgery of forgedScopes) {
+      await expect(
+        hostOptions.scopeVerifier.verify(forgery.scope),
+        `${forgery.label} must fail production scope verification`,
+      ).rejects.toThrow(/not issued/)
+      await expect(
+        hostOptions.resolveRuntimeScope({ agentTypeId: 'default', scope: forgery.scope }),
+        `${forgery.label} must not resolve production runtime context`,
+      ).rejects.toThrow(/not issued/)
+    }
+    expect(mocks.isMember).toHaveBeenCalledTimes(1)
+
     mocks.isMember.mockResolvedValue(false)
     await expect(hostOptions.scopeVerifier.verify(scope)).rejects.toThrow(/no longer valid/)
+    expect(mocks.isMember).toHaveBeenCalledTimes(2)
   } finally {
     await app.close()
   }


### PR DESCRIPTION
## Summary
- closes the proof gap for #909 bead `wt-391-forward-0jpy.19`
- confirms the production Core composition already wires its app-owned, membership-backed scope authority into the prebuilt Host verifier and route `issueScope`
- adds separate regression proof that spread copies, JSON round-trips, and direct structurally identical casts are rejected by the production authority
- proves each forgery also cannot resolve production runtime scope, and that membership revocation is rechecked on every verification

No production implementation change was needed: `createCoreAgentScopeAuthority` and its production wiring were already present after #940.

## Exact proof
- `pnpm --filter @hachej/boring-core exec vitest run src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts --no-file-parallelism` — 9/9 passed
- `pnpm --filter @hachej/boring-agent exec vitest run src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts src/server/agent-host/__tests__/createAgentHost.test.ts` — 14/14 passed; type errors 0
- `pnpm --filter @hachej/boring-core run typecheck` — passed
- `pnpm --filter @hachej/boring-agent run typecheck` — passed
- `pnpm lint:invariants` — passed
- `git diff --check` — passed
