### PR TITLE
#909 Prove legacy runtime fallback selection

### DIFF
--- a/packages/agent/src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts
@@ -7,6 +7,7 @@ import { AgentGatewayErrorCode, type AuthorizedAgentScope } from '../../../share
 import { PiSessionStore } from '../../harness/pi-coding-agent/sessions'
 import type { RuntimeModeAdapter } from '../../runtime/mode'
 import { createAgentHost } from '../createAgentHost'
+import { EmbeddedAgentGateway } from '../embeddedGateway'
 import { sessionNamespaceForAgent } from '../sessionInventory'
 import type { AgentEffectAdmission, AgentHostAgentSpec, CreateAgentHostOptions } from '../types'
 import {
@@ -173,9 +174,10 @@ describe('runtime scope identity', () => {
     await restarted.host.close()
   })
 
-  it('opens a pre-AH0 unpinned transcript with the current runtime without rewriting history', async () => {
+  it('uses the first Host-lifetime compatibility runtime for a pre-AH0 unpinned transcript', async () => {
     const sessionRoot = await temporaryRoot()
-    const scope = { workspaceScopeId: 'workspace-a', authSubjectId: 'legacy-reader' } as AuthorizedAgentScope
+    const firstReader = { workspaceScopeId: 'workspace-a', authSubjectId: 'legacy-reader-a' } as AuthorizedAgentScope
+    const laterReader = { workspaceScopeId: 'workspace-a', authSubjectId: 'legacy-reader-b' } as AuthorizedAgentScope
     const namespace = sessionNamespaceForAgent(agent, 'workspace-a', 'sessions')!
     const store = new PiSessionStore(sessionRoot, { sessionRoot, sessionNamespace: namespace })
     const legacy = await store.create({ workspaceId: 'workspace-a' }, { title: 'Legacy' })
@@ -183,10 +185,80 @@ describe('runtime scope identity', () => {
     const before = await readFile(transcriptPath, 'utf8')
     expect(before).not.toContain('runtimeScopeIdentity')
 
-    const restarted = await createAgentHost(hostOptions({ sessionRoot, runtimeIdentity: () => 'runtime-current' }))
+    const runtimeIdentity = vi.fn((scope: AuthorizedAgentScope) => (
+      scope.authSubjectId === firstReader.authSubjectId ? 'runtime-first' : 'runtime-later'
+    ))
+    const restarted = await createAgentHost(hostOptions({ sessionRoot, runtimeIdentity }))
+    const resolution = vi.fn()
+    ;(restarted.gateway as EmbeddedAgentGateway).setSessionRuntimeResolutionObserverForTesting(resolution)
     const ref = { agentTypeId: 'alpha', sessionId: legacy.id }
-    await expect(restarted.gateway.readSessionState({ scope, ref })).resolves.toMatchObject({ ref })
+
+    await expect(restarted.gateway.readSessionState({ scope: firstReader, ref })).resolves.toMatchObject({ ref })
+    await expect(restarted.gateway.readSessionState({ scope: firstReader, ref })).resolves.toMatchObject({ ref })
+    expect(resolution).toHaveBeenCalledTimes(2)
+    expect(resolution).toHaveBeenNthCalledWith(1, {
+      source: 'pre-ah0-compatibility-fallback',
+      runtimeScopeIdentity: 'runtime-first',
+    })
+    expect(resolution).toHaveBeenNthCalledWith(2, {
+      source: 'pre-ah0-compatibility-fallback',
+      runtimeScopeIdentity: 'runtime-first',
+    })
+
+    await expect(restarted.gateway.readSessionState({ scope: laterReader, ref }))
+      .rejects.toMatchObject({ code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH })
+    expect(resolution).toHaveBeenCalledTimes(2)
+    expect(runtimeIdentity).toHaveBeenCalledTimes(3)
     expect(await readFile(transcriptPath, 'utf8')).toBe(before)
+    await restarted.host.close()
+  })
+
+  it('uses a persisted post-AH0 runtime pin without the compatibility fallback when another runtime exists', async () => {
+    const sessionRoot = await temporaryRoot()
+    const creator = { workspaceScopeId: 'workspace-a', authSubjectId: 'creator' } as AuthorizedAgentScope
+    const pinnedReader = { workspaceScopeId: 'workspace-a', authSubjectId: 'pinned-reader' } as AuthorizedAgentScope
+    const currentReader = { workspaceScopeId: 'workspace-a', authSubjectId: 'current-reader' } as AuthorizedAgentScope
+    const first = await createAgentHost(hostOptions({ sessionRoot, runtimeIdentity: () => 'runtime-pinned' }))
+    const pinnedRef = await first.gateway.createSession({
+      scope: creator,
+      agentTypeId: 'alpha',
+      requestId: 'create-persisted-pin',
+      title: 'Persisted pin',
+    })
+    await first.host.close()
+
+    const runtimeIdentity = vi.fn((scope: AuthorizedAgentScope) => (
+      scope.authSubjectId === currentReader.authSubjectId ? 'runtime-current' : 'runtime-pinned'
+    ))
+    const restarted = await createAgentHost(hostOptions({ sessionRoot, runtimeIdentity }))
+    const resolution = vi.fn()
+    ;(restarted.gateway as EmbeddedAgentGateway).setSessionRuntimeResolutionObserverForTesting(resolution)
+
+    const currentRef = await restarted.gateway.createSession({
+      scope: currentReader,
+      agentTypeId: 'alpha',
+      requestId: 'create-current-runtime',
+      title: 'Current runtime',
+    })
+    expect(currentRef).not.toEqual(pinnedRef)
+    await expect(restarted.gateway.readSessionState({ scope: pinnedReader, ref: pinnedRef }))
+      .resolves.toMatchObject({ ref: pinnedRef })
+    await expect(restarted.gateway.readSessionState({ scope: pinnedReader, ref: pinnedRef }))
+      .resolves.toMatchObject({ ref: pinnedRef })
+
+    expect(resolution).toHaveBeenCalledTimes(2)
+    expect(resolution).toHaveBeenNthCalledWith(1, {
+      source: 'persisted-runtime-pin',
+      runtimeScopeIdentity: 'runtime-pinned',
+    })
+    expect(resolution).toHaveBeenNthCalledWith(2, {
+      source: 'persisted-runtime-pin',
+      runtimeScopeIdentity: 'runtime-pinned',
+    })
+    expect(resolution.mock.calls).not.toContainEqual([expect.objectContaining({
+      source: 'pre-ah0-compatibility-fallback',
+    })])
+    expect(runtimeIdentity.mock.results.map(({ value }) => value)).toContain('runtime-current')
     await restarted.host.close()
   })
 

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -175,9 +175,23 @@ export class EmbeddedAgentGateway implements AgentGateway {
   private readonly effects = new Map<string, Promise<JsonValue>>()
   private readonly pins = new Map<string, string>()
   private readonly writerTails = new Map<string, Promise<void>>()
+  private sessionRuntimeResolutionObserver?: (input: {
+    readonly source: 'pre-ah0-compatibility-fallback' | 'persisted-runtime-pin'
+    readonly runtimeScopeIdentity: string
+  }) => void
   private closed = false
 
   constructor(private readonly runtime: AgentHostRuntime) {}
+
+  /** Server-only test observer for distinguishing runtime pin resolution paths. */
+  setSessionRuntimeResolutionObserverForTesting(
+    observer: (input: {
+      readonly source: 'pre-ah0-compatibility-fallback' | 'persisted-runtime-pin'
+      readonly runtimeScopeIdentity: string
+    }) => void,
+  ): void {
+    this.sessionRuntimeResolutionObserver = observer
+  }
 
   /** Test-only activity seam used by the shared implementation conformance. */
   setActivityForTesting(
@@ -465,7 +479,8 @@ export class EmbeddedAgentGateway implements AgentGateway {
     }
     const resolved = authority?.runtimeScope
       ?? await this.runtime.options.resolveRuntimeScope({ agentTypeId: ref.agentTypeId, scope })
-    const pinned = authority?.runtimeScopeIdentity ?? cached
+    const persistedPin = authority?.runtimeScopeIdentity
+    const pinned = persistedPin ?? cached
     if (pinned && pinned !== resolved.identity) {
       throw new AgentGatewayError(
         AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
@@ -474,7 +489,12 @@ export class EmbeddedAgentGateway implements AgentGateway {
     }
     // Missing pins are pre-AH0 compatibility transcripts. They use the first
     // current runtime for this Host lifetime without mutating historical JSONL.
-    this.pins.set(key, pinned ?? resolved.identity)
+    const runtimeScopeIdentity = pinned ?? resolved.identity
+    this.sessionRuntimeResolutionObserver?.({
+      source: persistedPin ? 'persisted-runtime-pin' : 'pre-ah0-compatibility-fallback',
+      runtimeScopeIdentity,
+    })
+    this.pins.set(key, runtimeScopeIdentity)
     return await this.runtime.resolveBinding(ref.agentTypeId, scope, claim, resolved)
   }
 


### PR DESCRIPTION
## Summary
- adds a server-only, behavior-neutral runtime-resolution observer to distinguish persisted pins from the pre-AH0 compatibility fallback
- proves an unpinned legacy transcript repeatedly uses the first current runtime selected for the Host lifetime and rejects a later actor/runtime switch without rewriting history
- proves a post-AH0 persisted pin is selected repeatedly without entering the compatibility fallback while another current runtime is active

## Context
- Related: #909
- Bead: `wt-391-forward-0jpy.21`
- Base: current `origin/main` after #947

## Proof
- Focused fallback/transcript/session-inventory matrix:
  `pnpm --filter @hachej/boring-agent exec vitest run src/server/agent-host/__tests__/runtimeScopeIdentity.test.ts src/server/agent-host/__tests__/legacyTranscriptCompatibility.test.ts src/server/agent-host/__tests__/noBootSessionListing.test.ts src/server/agent-host/__tests__/sessionIsolation.test.ts`
  — **4 files / 22 tests passed**, no type errors
- Agent typecheck:
  `pnpm --filter @hachej/boring-agent typecheck`
  — **passed**
- Architecture invariants:
  `pnpm lint:invariants`
  — **passed**
- Import audit:
  `pnpm audit:imports`
  — **passed**
- Diff hygiene:
  `git diff --check`
  — **passed**

## Risk / rollback
Low risk: production resolution and mismatch behavior are unchanged; the only production addition is an unset server-only test observer. Revert this PR to roll back.

## Review
No merge requested. Please review the observer seam and the exact branch assertions before merge.
