### PR TITLE
#942 feat(sandbox): enforce readonly workspace paths

### DIFF
--- a/packages/agent/src/server/agent-host/__tests__/environmentLease.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/environmentLease.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AgentGatewayErrorCode } from '../../../shared/index'
+import { ErrorCode } from '../../../shared/error-codes'
 import { createTestRuntimeModeAdapter } from '@agent-test-host'
 import { EnvironmentLeaseManager } from '../environmentLease'
 
@@ -76,6 +77,33 @@ describe('EnvironmentLeaseManager', () => {
       await manager.close()
     },
   )
+
+  it('fails closed and disposes when a custom adapter drops host readonly policy', async () => {
+    const workspaceRoot = await makeRoot()
+    const baseAdapter = createTestRuntimeModeAdapter('direct')
+    const disposeRuntime = vi.fn(async () => {})
+    const manager = new EnvironmentLeaseManager({
+      ...baseAdapter,
+      async create(ctx) {
+        const bundle = await baseAdapter.create(ctx)
+        return { ...bundle, readonlyWorkspacePolicy: undefined, disposeRuntime }
+      },
+    })
+    const environment = {
+      placementIdentity: 'direct:workspace',
+      workspaceRoot,
+      provisioningFingerprint: 'policy-v1',
+      compatibilityModeContext: {
+        readonlyWorkspacePolicy: { readonlyPaths: ['locked'], revision: 'policy-v1' },
+      },
+    }
+
+    await expect(manager.acquire('workspace-a', environment)).rejects.toMatchObject({
+      code: ErrorCode.enum.CONFIG_INVALID,
+    })
+    expect(disposeRuntime).toHaveBeenCalledOnce()
+    await manager.close()
+  })
 
   it('reloads only after the final old-generation lease retires', async () => {
     const workspaceRoot = await makeRoot()

--- a/packages/agent/src/server/agent-host/environmentLease.ts
+++ b/packages/agent/src/server/agent-host/environmentLease.ts
@@ -1,5 +1,6 @@
 import type { RuntimeBundle, RuntimeModeAdapter } from '../runtime/mode'
 import { AgentGatewayError, AgentGatewayErrorCode } from '../../shared/index'
+import { ErrorCode } from '../../shared/error-codes'
 import type { WorkspaceProvisioningResult } from '../workspace/provisioning'
 import type { ResolvedEnvironmentScope } from './types'
 
@@ -140,6 +141,16 @@ export class EnvironmentLeaseManager {
       ...compatibilityModeContext,
     })
     try {
+      const expectedPolicy = compatibilityModeContext?.readonlyWorkspacePolicy
+      const effectivePolicy = bundle.readonlyWorkspacePolicy
+      if (expectedPolicy && (!effectivePolicy
+        || effectivePolicy.revision !== expectedPolicy.revision
+        || JSON.stringify(effectivePolicy.readonlyPaths) !== JSON.stringify(expectedPolicy.readonlyPaths))) {
+        throw Object.assign(
+          new Error('runtime mode adapter dropped readonly workspace path policy'),
+          { code: ErrorCode.enum.CONFIG_INVALID },
+        )
+      }
       if (signal.aborted) throw closedError()
       const provisioning = freezeProvisioningSnapshot(
         await environment.provisionRuntime?.({ runtimeBundle: bundle, signal }),

--- a/packages/agent/src/server/agentHostLegacyRouteOptions.ts
+++ b/packages/agent/src/server/agentHostLegacyRouteOptions.ts
@@ -19,6 +19,7 @@ import type { PiHarnessOptions } from './harness/pi-coding-agent/createHarness'
 import type { ModelsRoutesOptions } from './http/routes/models'
 import type { ReloadHookResult } from './http/routes/reload'
 import type { RuntimeEnvContribution } from './runtimeEnvContributions'
+import type { RuntimeReadonlyFilesystemPolicy } from './runtime/readonlyFilesystemPolicy'
 import type { AgentMeteringSink } from './pi-chat/metering'
 import type { WorkspaceAgentDispatcherResolver } from './workspaceAgentDispatcher'
 import type { WorkspaceAgentDispatcherContext } from '../shared/workspaceAgentDispatcher'
@@ -59,6 +60,8 @@ export interface RegisterAgentRoutesOptions {
   runtimeModeAdapter?: RuntimeModeAdapter
   /** Provider/runtime values supplied by the embedding host. */
   runtimeHost?: AgentRuntimeHostOperations
+  /** Host-normalized server-private policy enforced by supported Workspace providers. */
+  readonlyWorkspacePolicy?: RuntimeReadonlyFilesystemPolicy
   version?: string
   extraTools?: AgentTool[]
   /** When true, omit the six filesystem tools (read/write/edit/find/grep/ls). */

--- a/packages/agent/src/server/agentHostLegacyRouteRuntime.ts
+++ b/packages/agent/src/server/agentHostLegacyRouteRuntime.ts
@@ -592,11 +592,13 @@ export async function mountAgentHostLegacyRouteRuntime(
           workspaceId,
           requestId: request?.id,
           telemetry: opts.telemetry,
+          readonlyWorkspacePolicy: opts.readonlyWorkspacePolicy,
         },
         provisioningFingerprint: JSON.stringify([
           resolvedMode,
           root,
           scope.templatePath ?? null,
+          opts.readonlyWorkspacePolicy?.revision ?? null,
           opts.runtimeEnvContributions?.map((contribution) => contribution.id) ?? [],
         ]),
       },

--- a/packages/agent/src/server/runtime/mode.ts
+++ b/packages/agent/src/server/runtime/mode.ts
@@ -2,7 +2,17 @@ import type { FileSearch } from '../../shared/file-search'
 import type { WorkspaceRuntimeContext } from '../../shared/runtime'
 import type { Sandbox } from '../../shared/sandbox'
 import type { TelemetrySink } from '../../shared/telemetry'
-import type { Workspace } from '../../shared/workspace'
+import type {
+  RuntimeFilesystemCapability,
+  Workspace,
+} from '../../shared/workspace'
+export {
+  READONLY_FILESYSTEM_MUTATION_CODE,
+  RUNTIME_FILESYSTEM_CAPABILITIES,
+  ReadonlyFilesystemMutationError,
+  isReadonlyFilesystemMutationError,
+} from '../../shared/workspace'
+export type { RuntimeFilesystemCapability } from '../../shared/workspace'
 import type { CapabilityReadinessDetail, ReadyStatusTracker } from './readyStatus'
 import type { AgentRuntimeHostOperations } from './runtimeHost'
 import type { WorkspaceProvisioningAdapter } from '../workspace/provisioning'
@@ -65,14 +75,12 @@ export interface ModeContext {
   templatePath?: string
   requestId?: string
   telemetry?: TelemetrySink
+  /** Host-normalized path policy passed through to the authoritative provider. */
+  readonlyWorkspacePolicy?: {
+    readonly readonlyPaths: readonly string[]
+    readonly revision: string
+  }
 }
-
-export type RuntimeFilesystemCapability =
-  | 'read'
-  | 'write'
-  | 'create-child'
-  | 'delete'
-  | 'move-from'
 
 export interface RuntimeFilesystemAccessDecision {
   readonly filesystem: string
@@ -81,41 +89,6 @@ export interface RuntimeFilesystemAccessDecision {
   readonly access: 'readonly' | 'readwrite'
   readonly capabilities: Readonly<Record<RuntimeFilesystemCapability, boolean>>
 }
-
-export const READONLY_FILESYSTEM_MUTATION_CODE = 'readonly' as const
-
-export class ReadonlyFilesystemMutationError extends Error {
-  readonly code = READONLY_FILESYSTEM_MUTATION_CODE
-  readonly statusCode = 403 as const
-  readonly filesystem: string
-  readonly operation: RuntimeFilesystemCapability
-
-  constructor(filesystem: string, operation: RuntimeFilesystemCapability) {
-    super(`${filesystem} binding is readonly`)
-    this.name = 'ReadonlyFilesystemMutationError'
-    this.filesystem = filesystem
-    this.operation = operation
-  }
-}
-
-export function isReadonlyFilesystemMutationError(
-  value: unknown,
-): value is ReadonlyFilesystemMutationError {
-  if (!value || typeof value !== 'object') return false
-  const candidate = value as Record<string, unknown>
-  return candidate.code === READONLY_FILESYSTEM_MUTATION_CODE
-    && candidate.statusCode === 403
-    && typeof candidate.filesystem === 'string'
-    && RUNTIME_FILESYSTEM_CAPABILITIES.includes(candidate.operation as RuntimeFilesystemCapability)
-}
-
-export const RUNTIME_FILESYSTEM_CAPABILITIES = Object.freeze([
-  'read',
-  'write',
-  'create-child',
-  'delete',
-  'move-from',
-] as const satisfies readonly RuntimeFilesystemCapability[])
 
 export interface RuntimeFilesystemBindingOperations {
   read(descriptor: { filesystem: string; path: string }): Promise<{ content: string; mtimeMs?: number; metadata?: unknown }>
@@ -159,6 +132,11 @@ export interface RuntimeBundle {
   filesystem?: RuntimeFilesystemStrategy
   /** Optional filesystem bindings prepared for this runtime/session. */
   filesystemBindings?: RuntimeFilesystemBinding[]
+  /** Provider-confirmed frozen policy for binding/projection composition. */
+  readonlyWorkspacePolicy?: {
+    readonly readonlyPaths: readonly string[]
+    readonly revision: string
+  }
   /** Provisioning operations derived from this bundle's acquired Workspace + Sandbox pair. */
   provisioningAdapter?: WorkspaceProvisioningAdapter
   /** Idempotently releases the acquired Workspace + Sandbox pair. */

--- a/packages/agent/src/server/runtime/modes/__tests__/providerAdapter.test.ts
+++ b/packages/agent/src/server/runtime/modes/__tests__/providerAdapter.test.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 
 import type { SandboxProviderV1 } from '@hachej/boring-sandbox/shared'
 import type { Sandbox, Workspace } from '../../../../shared'
+import { ErrorCode } from '../../../../shared/error-codes'
 import type { RuntimeBundle } from '../../mode'
 import { createProviderRuntimeModeAdapter } from '../providerAdapter'
 import {
@@ -14,6 +15,7 @@ function createPairProvider(options: {
   checkHealth?: () => Promise<{ state: 'ok' } | { state: 'recreate'; message?: string }>
   dispose: () => Promise<void>
   invalidate?: (ctx: { workspaceId: string }) => Promise<void>
+  echoReadonlyPolicy?: boolean
 }): SandboxProviderV1 {
   const runtimeContext = { runtimeCwd: '/workspace' }
   const workspace: Workspace = {
@@ -65,11 +67,12 @@ function createPairProvider(options: {
     },
     resolveRuntimeRoot: () => '/workspace',
     ...(options.invalidate ? { invalidate: options.invalidate } : {}),
-    async create() {
+    async create(context) {
       return {
         workspace,
         sandbox,
         checkHealth: options.checkHealth,
+        ...(options.echoReadonlyPolicy ? { readonlyWorkspacePolicy: context.readonlyWorkspacePolicy } : {}),
         dispose: options.dispose,
       }
     },
@@ -98,6 +101,25 @@ test('health and disposal stay bound to the pair after RuntimeBundle decoration'
   expect(checkHealth).toHaveBeenCalledOnce()
 
   await decoratedBundle.disposeRuntime?.()
+  expect(dispose).toHaveBeenCalledOnce()
+})
+
+test('fails closed and disposes when a provider drops readonly policy', async () => {
+  const dispose = vi.fn(async () => {})
+  const adapter = createProviderRuntimeModeAdapter({
+    id: 'direct',
+    provider: createPairProvider({ dispose }),
+    runtimeHost: testRuntimeHostOperations,
+    workspaceFsCapability: 'strong',
+    bash: { kind: 'host' },
+    filesystem: { kind: 'host' },
+  })
+
+  await expect(adapter.create({
+    workspaceRoot: '/tmp/workspace',
+    sessionId: 'session',
+    readonlyWorkspacePolicy: { readonlyPaths: ['locked'], revision: 'policy-v1' },
+  })).rejects.toMatchObject({ code: ErrorCode.enum.CONFIG_INVALID })
   expect(dispose).toHaveBeenCalledOnce()
 })
 

--- a/packages/agent/src/server/runtime/modes/direct.ts
+++ b/packages/agent/src/server/runtime/modes/direct.ts
@@ -23,9 +23,11 @@ export function createDirectModeAdapter(options: {
       await mkdir(context.workspaceRoot, { recursive: true })
       await copyTemplate(context.templatePath, context.workspaceRoot)
     },
-    provisioningAdapter: (context) => createDirectProvisioningAdapter(
+    provisioningAdapter: (context, pair) => createDirectProvisioningAdapter(
       options.runtimeHost.getBoringAgentRuntimePaths(context.workspaceRoot),
       options.runtimeHost,
+      undefined,
+      pair.workspace,
     ),
   })
 }

--- a/packages/agent/src/server/runtime/modes/local.ts
+++ b/packages/agent/src/server/runtime/modes/local.ts
@@ -28,9 +28,11 @@ export function createLocalModeAdapter(options: {
       await mkdir(context.workspaceRoot, { recursive: true })
       await copyTemplate(context.templatePath, context.workspaceRoot)
     },
-    provisioningAdapter: (context) => createLocalProvisioningAdapter(
+    provisioningAdapter: (context, pair) => createLocalProvisioningAdapter(
       options.runtimeHost.getBoringAgentRuntimePaths(context.workspaceRoot),
       options.runtimeHost,
+      undefined,
+      pair.workspace,
     ),
   })
 }

--- a/packages/agent/src/server/runtime/modes/providerAdapter.ts
+++ b/packages/agent/src/server/runtime/modes/providerAdapter.ts
@@ -12,6 +12,7 @@ import type {
   RuntimeModeAdapter,
 } from '../mode'
 import type { WorkspaceProvisioningAdapter } from '../../workspace/provisioning'
+import { ErrorCode } from '../../../shared/error-codes'
 import type { AgentRuntimeHostOperations } from '../runtimeHost'
 
 interface ProviderRuntimeModeAdapterOptions {
@@ -68,6 +69,12 @@ export function createProviderRuntimeModeAdapter(
       await options.prepare?.(context)
       const pair = await options.provider.create(context)
       try {
+        if (context.readonlyWorkspacePolicy && !pair.readonlyWorkspacePolicy) {
+          throw Object.assign(
+            new Error(`${options.provider.providerId} dropped readonly workspace path policy`),
+            { code: ErrorCode.enum.CONFIG_INVALID },
+          )
+        }
         const runtimeBundle: ProviderRuntimeBundle = {
           [runtimePair]: pair,
           runtimeContext: pair.workspace.runtimeContext,
@@ -78,6 +85,7 @@ export function createProviderRuntimeModeAdapter(
           runtimeHost: options.runtimeHost,
           bash: options.bash,
           filesystem: options.filesystem,
+          readonlyWorkspacePolicy: pair.readonlyWorkspacePolicy,
           provisioningAdapter: options.provisioningAdapter?.(context, pair)
             ?? pair.provisioning,
           disposeRuntime: () => pair.dispose(),

--- a/packages/agent/src/server/runtime/modes/provisioningAdapter.ts
+++ b/packages/agent/src/server/runtime/modes/provisioningAdapter.ts
@@ -1,9 +1,10 @@
 import { spawn } from 'node:child_process'
-import { cp, lstat, mkdir, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
+import { chmod, cp, lstat, mkdir, readFile, readdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import type { BoringAgentRuntimePaths } from '@hachej/boring-sandbox/providers/node-workspace'
+import type { Workspace } from '../../../shared/workspace'
 import type { WorkspaceProvisioningAdapter, WorkspaceProvisioningExecResult } from '../../workspace/provisioning'
 import type { AgentRuntimeHostOperations } from '../runtimeHost'
 import {
@@ -150,37 +151,111 @@ function mapEnvToLocalSandbox(paths: BoringAgentRuntimePaths, env: Record<string
   )
 }
 
+async function ensureWorkspaceParent(workspace: Workspace, workspaceRelativePath: string): Promise<void> {
+  const parent = dirname(workspaceRelativePath).split(sep).join('/')
+  if (parent === '.' || parent === '') return
+  try {
+    await workspace.stat(parent)
+  } catch (error: unknown) {
+    if ((error as { code?: string }).code !== 'ENOENT') throw error
+    await workspace.mkdir(parent, { recursive: true })
+  }
+}
+
+async function copyHostIntoWorkspace(
+  sourcePath: string,
+  workspaceRelativeTarget: string,
+  workspace: Workspace,
+  workspaceHostRoot: string | undefined,
+): Promise<void> {
+  let targetExists = true
+  try {
+    await workspace.stat(workspaceRelativeTarget)
+  } catch (error: unknown) {
+    if ((error as { code?: string }).code !== 'ENOENT') throw error
+    targetExists = false
+  }
+  if (targetExists) throw new Error('provisioning copy target already exists')
+  const sourceStat = await stat(sourcePath)
+  if (sourceStat.isDirectory()) {
+    await workspace.mkdir(workspaceRelativeTarget, { recursive: true })
+    for (const entry of await readdir(sourcePath, { withFileTypes: true })) {
+      await copyHostIntoWorkspace(
+        resolve(sourcePath, entry.name),
+        `${workspaceRelativeTarget.replace(/\/$/, '')}/${entry.name}`,
+        workspace,
+        workspaceHostRoot,
+      )
+    }
+    return
+  }
+  await ensureWorkspaceParent(workspace, workspaceRelativeTarget)
+  if (!sourceStat.isFile()) return
+  if (!workspace.writeBinaryFile) throw new Error('Workspace binary writes are required for provisioning copy')
+  await workspace.writeBinaryFile(workspaceRelativeTarget, new Uint8Array(await readFile(sourcePath)))
+  if (workspaceHostRoot) {
+    await chmod(resolve(workspaceHostRoot, workspaceRelativeTarget), sourceStat.mode)
+  }
+}
+
 function createWorkspaceFs(
   workspaceRoot: string,
-  opts: { enforceSymlinkBoundary: boolean; runtimeHost: AgentRuntimeHostOperations },
+  opts: {
+    enforceSymlinkBoundary: boolean
+    runtimeHost: AgentRuntimeHostOperations
+    workspace?: Workspace
+  },
 ): WorkspaceProvisioningAdapter['workspaceFs'] {
-  const { enforceSymlinkBoundary, runtimeHost } = opts
+  const { enforceSymlinkBoundary, runtimeHost, workspace } = opts
+  const exists = async (workspaceRelativePath: string): Promise<boolean> => {
+    // Reachability probe intentionally follows an in-workspace shim to an
+    // external runtime install; it reads no content and remains lexically confined.
+    const absPath = runtimeHost.validatePath(workspaceRoot, workspaceRelativePath)
+    try {
+      await stat(absPath)
+      return true
+    } catch (error: unknown) {
+      if ((error as { code?: string }).code === 'ENOENT') return false
+      throw error
+    }
+  }
+  if (workspace) {
+    return {
+      exists,
+      async rm(workspaceRelativePath) {
+        try {
+          await workspace.unlink(workspaceRelativePath)
+        } catch (error: unknown) {
+          if ((error as { code?: string }).code !== 'ENOENT') throw error
+        }
+      },
+      async mkdir(workspaceRelativePath) {
+        await workspace.mkdir(workspaceRelativePath, { recursive: true })
+      },
+      async writeText(workspaceRelativePath, content) {
+        await ensureWorkspaceParent(workspace, workspaceRelativePath)
+        await workspace.writeFile(workspaceRelativePath, content)
+      },
+      async readText(workspaceRelativePath) {
+        try {
+          return await workspace.readFile(workspaceRelativePath)
+        } catch (error: unknown) {
+          if ((error as { code?: string }).code === 'ENOENT') return null
+          throw error
+        }
+      },
+      async copyFromHost(hostSourcePath, workspaceRelativeTarget) {
+        await copyHostIntoWorkspace(
+          sourceToPath(hostSourcePath),
+          workspaceRelativeTarget,
+          workspace,
+          runtimeHost.getNodeWorkspaceHostRoot(workspace),
+        )
+      },
+    }
+  }
   return {
-    async exists(workspaceRelativePath) {
-      // Existence is a target-reachability check used by provisioning's
-      // skip-vs-reinstall probe, not a content read — so it does NOT enforce
-      // the realpath boundary. That lets an in-workspace bin shim pointing at
-      // the host's npm-global install (e.g.
-      // .boring-agent/node/node_modules/.bin/boring-ui) report as present
-      // instead of tripping the sandbox guard and aborting provisioning. The
-      // lexical validatePath() still rejects ../ escapes, and a boolean
-      // reachability check leaks no out-of-sandbox content, so this stays safe
-      // in sandbox modes (local/bwrap, vercel-sandbox) too. Content ops below
-      // keep the strict realpath boundary via enforceSymlinkBoundary.
-      //
-      // Use stat() (follows symlinks), not lstat(): a dangling shim — e.g. the
-      // global CLI was moved/uninstalled — must report missing so the probe
-      // reinstalls and self-heals, rather than skipping forever and bricking
-      // the workspace on a broken link.
-      const absPath = runtimeHost.validatePath(workspaceRoot, workspaceRelativePath)
-      try {
-        await stat(absPath)
-        return true
-      } catch (error: unknown) {
-        if ((error as { code?: string }).code === 'ENOENT') return false
-        throw error
-      }
-    },
+    exists,
     async rm(workspaceRelativePath) {
       const absPath = await assertExistingInsideWorkspace(workspaceRoot, workspaceRelativePath, enforceSymlinkBoundary, runtimeHost)
       if (!absPath) return
@@ -219,6 +294,7 @@ export function createDirectProvisioningAdapter(
   paths: BoringAgentRuntimePaths,
   runtimeHost: AgentRuntimeHostOperations,
   runner: CommandRunner = spawnCommand,
+  workspace?: Workspace,
 ): WorkspaceProvisioningAdapter {
   return {
     mode: 'direct',
@@ -228,7 +304,11 @@ export function createDirectProvisioningAdapter(
     async resolveInstallSource(source) {
       return sourceToPath(source)
     },
-    workspaceFs: createWorkspaceFs(paths.workspaceRoot, { enforceSymlinkBoundary: false, runtimeHost }),
+    workspaceFs: createWorkspaceFs(paths.workspaceRoot, {
+      enforceSymlinkBoundary: false,
+      runtimeHost,
+      workspace,
+    }),
     getRuntimeCacheRoot() {
       return paths.cache
     },
@@ -239,9 +319,14 @@ export function createLocalProvisioningAdapter(
   paths: BoringAgentRuntimePaths,
   runtimeHost: AgentRuntimeHostOperations,
   runner: CommandRunner = spawnCommand,
+  workspace?: Workspace,
 ): WorkspaceProvisioningAdapter {
   const sourceMounts = new Map<string, string>()
-  const workspaceFs = createWorkspaceFs(paths.workspaceRoot, { enforceSymlinkBoundary: true, runtimeHost })
+  const workspaceFs = createWorkspaceFs(paths.workspaceRoot, {
+    enforceSymlinkBoundary: true,
+    runtimeHost,
+    workspace,
+  })
 
   return {
     mode: 'local',

--- a/packages/agent/src/shared/index.ts
+++ b/packages/agent/src/shared/index.ts
@@ -44,7 +44,19 @@ export {
   AGENT_RESOURCES_FILESYSTEM_ID,
 } from './skill-resource'
 export type { AgentSkillResource } from './skill-resource'
-export type { Workspace, Entry, Stat, WorkspaceWatchControlEvent } from './workspace'
+export {
+  READONLY_FILESYSTEM_MUTATION_CODE,
+  RUNTIME_FILESYSTEM_CAPABILITIES,
+  ReadonlyFilesystemMutationError,
+  isReadonlyFilesystemMutationError,
+} from './workspace'
+export type {
+  Workspace,
+  Entry,
+  Stat,
+  WorkspaceWatchControlEvent,
+  RuntimeFilesystemCapability,
+} from './workspace'
 export type {
   Sandbox,
   SandboxCapability,

--- a/packages/agent/src/shared/workspace.ts
+++ b/packages/agent/src/shared/workspace.ts
@@ -1,5 +1,46 @@
 import type { WorkspaceRuntimeContext } from './runtime'
 
+export type RuntimeFilesystemCapability =
+  | 'read'
+  | 'write'
+  | 'create-child'
+  | 'delete'
+  | 'move-from'
+
+export const READONLY_FILESYSTEM_MUTATION_CODE = 'readonly' as const
+export const RUNTIME_FILESYSTEM_CAPABILITIES = Object.freeze([
+  'read',
+  'write',
+  'create-child',
+  'delete',
+  'move-from',
+] as const satisfies readonly RuntimeFilesystemCapability[])
+
+export class ReadonlyFilesystemMutationError extends Error {
+  readonly code = READONLY_FILESYSTEM_MUTATION_CODE
+  readonly statusCode = 403 as const
+  readonly filesystem: string
+  readonly operation: RuntimeFilesystemCapability
+
+  constructor(filesystem: string, operation: RuntimeFilesystemCapability) {
+    super(`${filesystem} binding is readonly`)
+    this.name = 'ReadonlyFilesystemMutationError'
+    this.filesystem = filesystem
+    this.operation = operation
+  }
+}
+
+export function isReadonlyFilesystemMutationError(
+  value: unknown,
+): value is ReadonlyFilesystemMutationError {
+  if (!value || typeof value !== 'object') return false
+  const candidate = value as Record<string, unknown>
+  return candidate.code === READONLY_FILESYSTEM_MUTATION_CODE
+    && candidate.statusCode === 403
+    && typeof candidate.filesystem === 'string'
+    && RUNTIME_FILESYSTEM_CAPABILITIES.includes(candidate.operation as RuntimeFilesystemCapability)
+}
+
 export interface Workspace {
   /** Agent-visible workspace root; must match runtimeContext.runtimeCwd. */
   readonly root: string

--- a/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
+++ b/packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts
@@ -6,7 +6,12 @@ import {
   type SandboxProviderV1,
   type WorkspaceSandboxPairV1,
 } from '../../shared/providerV1'
-import { createNodeWorkspace, disposeNodeWorkspace } from '../node-workspace/createNodeWorkspace'
+import {
+  createNodeWorkspace,
+  disposeNodeWorkspace,
+  getNodeWorkspaceReadonlyPolicy,
+  whenNodeWorkspaceReady,
+} from '../node-workspace/createNodeWorkspace'
 import {
   createBwrapSandbox,
   type CreateBwrapSandboxOptions,
@@ -36,7 +41,12 @@ export function createBwrapSandboxProvider(
 
       await mkdir(context.workspaceRoot, { recursive: true })
       const runtimeContext = { runtimeCwd: '/workspace' }
-      const workspace = createNodeWorkspace(context.workspaceRoot, { runtimeContext })
+      const workspace = createNodeWorkspace(context.workspaceRoot, {
+        runtimeContext,
+        readonlyWorkspacePolicy: context.readonlyWorkspacePolicy,
+      })
+      await whenNodeWorkspaceReady(workspace)
+      const readonlyWorkspacePolicy = await getNodeWorkspaceReadonlyPolicy(workspace)
       const sandbox = createBwrapSandbox({
         ...options.sandbox,
         hostWorkspaceRoot: context.workspaceRoot,
@@ -61,6 +71,7 @@ export function createBwrapSandboxProvider(
       return {
         workspace,
         sandbox,
+        readonlyWorkspacePolicy,
         async dispose() {
           if (disposed) return
           disposed = true

--- a/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
+++ b/packages/boring-sandbox/src/providers/direct/createDirectProvider.ts
@@ -2,7 +2,12 @@ import { mkdir } from 'node:fs/promises'
 
 import { PROVIDER_CAPABILITIES, PROVIDER_CONTRACT_VERSION } from '../../shared/providerMatrix'
 import type { SandboxProviderV1, WorkspaceSandboxPairV1 } from '../../shared/providerV1'
-import { createNodeWorkspace, disposeNodeWorkspace } from '../node-workspace/createNodeWorkspace'
+import {
+  createNodeWorkspace,
+  disposeNodeWorkspace,
+  getNodeWorkspaceReadonlyPolicy,
+  whenNodeWorkspaceReady,
+} from '../node-workspace/createNodeWorkspace'
 import { createDirectSandbox, type CreateDirectSandboxOptions } from './createDirectSandbox'
 
 export interface DirectSandboxProviderOptions {
@@ -22,7 +27,12 @@ export function createDirectSandboxProvider(
     async create(context): Promise<WorkspaceSandboxPairV1> {
       await mkdir(context.workspaceRoot, { recursive: true })
       const runtimeContext = { runtimeCwd: context.workspaceRoot }
-      const workspace = createNodeWorkspace(context.workspaceRoot, { runtimeContext })
+      const workspace = createNodeWorkspace(context.workspaceRoot, {
+        runtimeContext,
+        readonlyWorkspacePolicy: context.readonlyWorkspacePolicy,
+      })
+      await whenNodeWorkspaceReady(workspace)
+      const readonlyWorkspacePolicy = await getNodeWorkspaceReadonlyPolicy(workspace)
       const sandbox = createDirectSandbox({ ...options.sandbox, runtimeContext })
 
       try {
@@ -37,6 +47,7 @@ export function createDirectSandboxProvider(
       return {
         workspace,
         sandbox,
+        readonlyWorkspacePolicy,
         async dispose() {
           if (disposed) return
           disposed = true

--- a/packages/boring-sandbox/src/providers/node-workspace/__tests__/readonlyPolicy.test.ts
+++ b/packages/boring-sandbox/src/providers/node-workspace/__tests__/readonlyPolicy.test.ts
@@ -1,0 +1,208 @@
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import type { Workspace } from '@hachej/boring-agent/shared'
+
+import {
+  createNodeWorkspace,
+  disposeNodeWorkspace,
+  whenNodeWorkspaceReady,
+} from '../createNodeWorkspace'
+
+const roots: string[] = []
+const workspaces: Workspace[] = []
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), 'boring-readonly-workspace-'))
+  roots.push(root)
+  await mkdir(join(root, 'mixed', 'protected', 'nested'), { recursive: true })
+  await mkdir(join(root, 'mixed', 'writable'), { recursive: true })
+  await mkdir(join(root, 'safe'), { recursive: true })
+  await writeFile(join(root, 'mixed', 'protected', 'locked.txt'), 'LOCKED', 'utf8')
+  await writeFile(join(root, 'mixed', 'protected', 'nested', 'deep.txt'), 'DEEP', 'utf8')
+  await writeFile(join(root, 'mixed', 'writable', 'open.txt'), 'OPEN', 'utf8')
+  await writeFile(join(root, 'safe', 'open.txt'), 'SAFE', 'utf8')
+  const workspace = createNodeWorkspace(root, {
+    readonlyWorkspacePolicy: {
+      readonlyPaths: ['mixed/protected', 'future/locked'],
+      revision: 'policy-v1',
+    },
+  })
+  workspaces.push(workspace)
+  await whenNodeWorkspaceReady(workspace)
+  return { root, workspace }
+}
+
+function isReadonlyFilesystemMutationError(value: unknown): boolean {
+  return Boolean(value && typeof value === 'object' && (value as { code?: unknown }).code === 'readonly')
+}
+
+function expectReadonly(operation: string) {
+  return expect.objectContaining({
+    code: 'readonly',
+    statusCode: 403,
+    filesystem: 'user',
+    operation,
+  })
+}
+
+afterEach(async () => {
+  for (const workspace of workspaces.splice(0)) disposeNodeWorkspace(workspace)
+  const { rm } = await import('node:fs/promises')
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('Node Workspace readonly policy', () => {
+  test('keeps reads available and denies every protected write shape without partial effects', async () => {
+    const { root, workspace } = await fixture()
+
+    await expect(workspace.readFile('mixed/protected/locked.txt')).resolves.toBe('LOCKED')
+    await expect(workspace.readdir('mixed/protected')).resolves.toContainEqual({ name: 'locked.txt', kind: 'file' })
+    await expect(workspace.stat('mixed/protected/locked.txt')).resolves.toMatchObject({ kind: 'file' })
+
+    await expect(workspace.writeFile('mixed/protected/locked.txt', 'changed')).rejects.toMatchObject(expectReadonly('write'))
+    await expect(workspace.writeBinaryFile?.('mixed/protected/new.bin', new Uint8Array([1]))).rejects.toMatchObject(expectReadonly('write'))
+    await expect(workspace.writeFileWithStat?.('mixed/protected/new.txt', 'new')).rejects.toMatchObject(expectReadonly('write'))
+    await expect(workspace.writeBinaryFileWithStat?.('mixed/protected/new.bin', new Uint8Array([1]))).rejects.toMatchObject(expectReadonly('write'))
+    await expect(workspace.mkdir('mixed/protected/new-dir', { recursive: true })).rejects.toMatchObject(expectReadonly('create-child'))
+    await expect(workspace.mkdir('future', { recursive: true })).rejects.toMatchObject(expectReadonly('create-child'))
+    await expect(workspace.unlink('mixed/protected/locked.txt')).rejects.toMatchObject(expectReadonly('delete'))
+    await expect(workspace.unlink('mixed')).rejects.toMatchObject(expectReadonly('delete'))
+    await expect(workspace.rename('mixed/protected/locked.txt', 'safe/moved.txt')).rejects.toMatchObject(expectReadonly('move-from'))
+    await expect(workspace.rename('safe/open.txt', 'mixed/protected/replaced.txt')).rejects.toMatchObject(expectReadonly('create-child'))
+
+    await expect(readFile(join(root, 'mixed', 'protected', 'locked.txt'), 'utf8')).resolves.toBe('LOCKED')
+    await expect(readFile(join(root, 'mixed', 'protected', 'nested', 'deep.txt'), 'utf8')).resolves.toBe('DEEP')
+    await expect(readFile(join(root, 'safe', 'open.txt'), 'utf8')).resolves.toBe('SAFE')
+  })
+
+  test('permits writable siblings under a mixed ancestor', async () => {
+    const { workspace } = await fixture()
+
+    await workspace.writeFile('mixed/writable/open.txt', 'UPDATED')
+    await workspace.mkdir('mixed/writable/new/deep', { recursive: true })
+    await workspace.writeFile('mixed/writable/new/deep/file.txt', 'NEW')
+    await workspace.rename('mixed/writable/new/deep/file.txt', 'mixed/writable/new/deep/renamed.txt')
+    await workspace.unlink('mixed/writable/new')
+
+    await expect(workspace.readFile('mixed/writable/open.txt')).resolves.toBe('UPDATED')
+    await expect(workspace.stat('mixed/writable/new')).rejects.toThrow()
+  })
+
+  test('protects canonical targets reached through safe in-workspace symlink aliases', async () => {
+    const { root, workspace } = await fixture()
+    await symlink(join(root, 'mixed', 'protected'), join(root, 'protected-alias'), 'dir')
+
+    await expect(workspace.readFile('protected-alias/locked.txt')).resolves.toBe('LOCKED')
+    const denial = await workspace.writeFile('protected-alias/locked.txt', 'BYPASS').catch((error) => error)
+    expect(isReadonlyFilesystemMutationError(denial)).toBe(true)
+    expect(denial).toMatchObject(expectReadonly('write'))
+    expect(JSON.stringify(denial)).not.toContain(root)
+    await expect(readFile(join(root, 'mixed', 'protected', 'locked.txt'), 'utf8')).resolves.toBe('LOCKED')
+  })
+
+  test('inherits the guarded root across every Node Workspace re-projection', async () => {
+    const { root } = await fixture()
+    const reprojected = createNodeWorkspace(root)
+    workspaces.push(reprojected)
+    await whenNodeWorkspaceReady(reprojected)
+
+    await expect(reprojected.writeFile('mixed/protected/locked.txt', 'BYPASS'))
+      .rejects.toMatchObject(expectReadonly('write'))
+    await reprojected.writeFile('mixed/writable/open.txt', 'REPROJECTED')
+    await expect(reprojected.readFile('mixed/writable/open.txt')).resolves.toBe('REPROJECTED')
+  })
+
+  test('keys nonexistent roots through a symlinked ancestor before and after creation', async () => {
+    const parent = await mkdtemp(join(tmpdir(), 'boring-readonly-planned-root-'))
+    roots.push(parent)
+    const actualParent = join(parent, 'actual')
+    const aliasParent = join(parent, 'alias')
+    await mkdir(actualParent)
+    await symlink(actualParent, aliasParent, 'dir')
+    const aliasRoot = join(aliasParent, 'workspace')
+    const actualRoot = join(actualParent, 'workspace')
+
+    const first = createNodeWorkspace(aliasRoot)
+    workspaces.push(first)
+    await whenNodeWorkspaceReady(first)
+    await mkdir(join(actualRoot, 'locked'), { recursive: true })
+    await writeFile(join(actualRoot, 'locked', 'file.txt'), 'LOCKED', 'utf8')
+    const guarded = createNodeWorkspace(actualRoot, {
+      readonlyWorkspacePolicy: { readonlyPaths: ['locked'], revision: 'planned-v1' },
+    })
+    workspaces.push(guarded)
+    await whenNodeWorkspaceReady(guarded)
+
+    await expect(first.writeFile('locked/file.txt', 'BYPASS')).rejects.toMatchObject(expectReadonly('write'))
+    await expect(guarded.writeFile('locked/file.txt', 'BYPASS')).rejects.toMatchObject(expectReadonly('write'))
+  })
+
+  test('upgrades an earlier policy-less projection in place without opening a bypass', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'boring-readonly-upgrade-'))
+    roots.push(root)
+    await mkdir(join(root, 'locked'), { recursive: true })
+    await writeFile(join(root, 'locked', 'file.txt'), 'LOCKED', 'utf8')
+    const first = createNodeWorkspace(root)
+    workspaces.push(first)
+    await whenNodeWorkspaceReady(first)
+
+    const guarded = createNodeWorkspace(root, {
+      readonlyWorkspacePolicy: { readonlyPaths: ['locked'], revision: 'upgrade-v1' },
+    })
+    workspaces.push(guarded)
+    await whenNodeWorkspaceReady(guarded)
+
+    await expect(guarded.writeFile('locked/file.txt', 'BYPASS')).rejects.toMatchObject(expectReadonly('write'))
+    await expect(first.writeFile('locked/file.txt', 'BYPASS')).rejects.toMatchObject(expectReadonly('write'))
+  })
+
+  test('keeps root policy durable after the originating runtime is disposed', async () => {
+    const { workspace, root } = await fixture()
+    disposeNodeWorkspace(workspace)
+    workspaces.splice(workspaces.indexOf(workspace), 1)
+
+    const reprojected = createNodeWorkspace(root)
+    workspaces.push(reprojected)
+    await whenNodeWorkspaceReady(reprojected)
+    await expect(reprojected.writeFile('mixed/protected/locked.txt', 'BYPASS'))
+      .rejects.toMatchObject(expectReadonly('write'))
+  })
+
+  test('rejects reuse of a revision with a different normalized policy', async () => {
+    const { root } = await fixture()
+    const conflicting = createNodeWorkspace(root, {
+      readonlyWorkspacePolicy: { readonlyPaths: ['safe'], revision: 'policy-v1' },
+    })
+    workspaces.push(conflicting)
+    await expect(whenNodeWorkspaceReady(conflicting)).rejects.toMatchObject({
+      code: 'RUNTIME_READONLY_FILESYSTEM_POLICY_INVALID',
+    })
+  })
+
+  test('serializes substitution attempts and never changes protected content', async () => {
+    const { root, workspace } = await fixture()
+    await symlink(join(root, 'safe'), join(root, 'safe-link'), 'dir')
+    await symlink(join(root, 'mixed', 'protected'), join(root, 'protected-link'), 'dir')
+
+    const attacker = createNodeWorkspace(root)
+    workspaces.push(attacker)
+    await whenNodeWorkspaceReady(attacker)
+
+    const results = await Promise.allSettled([
+      attacker.rename('protected-link', 'candidate-link'),
+      workspace.writeFile('candidate-link/locked.txt', 'BYPASS'),
+      workspace.writeFile('safe-link/open.txt', 'PERMITTED'),
+      attacker.unlink('mixed'),
+    ])
+
+    expect(results[0]?.status).toBe('rejected')
+    expect(results[1]?.status).toBe('rejected')
+    expect(results[2]?.status).toBe('fulfilled')
+    expect(results[3]?.status).toBe('rejected')
+    await expect(readFile(join(root, 'mixed', 'protected', 'locked.txt'), 'utf8')).resolves.toBe('LOCKED')
+    await expect(readFile(join(root, 'safe', 'open.txt'), 'utf8')).resolves.toBe('PERMITTED')
+  })
+})

--- a/packages/boring-sandbox/src/providers/node-workspace/createNodeWorkspace.ts
+++ b/packages/boring-sandbox/src/providers/node-workspace/createNodeWorkspace.ts
@@ -1,7 +1,12 @@
 import { lstat, mkdir, readdir, readFile, rename, rm, stat, unlink, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
-import type { Workspace, WorkspaceRuntimeContext } from '@hachej/boring-agent/shared'
+import type {
+  RuntimeFilesystemCapability,
+  Workspace,
+  WorkspaceRuntimeContext,
+} from '@hachej/boring-agent/shared'
+import type { ReadonlyWorkspacePolicyV1 } from '../../shared/providerV1'
 import {
   assertRealPathWithinWorkspace,
   ensureExistingWorkspacePath,
@@ -9,15 +14,21 @@ import {
   validatePath,
 } from './paths'
 import { createNodeWatcher, toPosixRel, type NodeWorkspaceWatcher } from './nodeWatcher'
+import {
+  acquireNodeWorkspaceMutationGuard,
+  type NodeWorkspaceMutationGuard,
+} from './readonlyMutationGuard'
 
 const EPERM_CODE = 'EPERM'
 
 export interface CreateNodeWorkspaceOptions {
   runtimeContext?: WorkspaceRuntimeContext
+  readonlyWorkspacePolicy?: ReadonlyWorkspacePolicyV1
 }
 
 const nodeWorkspaceHostRoots = new WeakMap<Workspace, string>()
 const nodeWorkspaceDisposers = new WeakMap<Workspace, () => void>()
+const nodeWorkspaceReady = new WeakMap<Workspace, Promise<NodeWorkspaceMutationGuard>>()
 
 export function getNodeWorkspaceHostRoot(workspace: Workspace): string | undefined {
   return nodeWorkspaceHostRoots.get(workspace)
@@ -27,8 +38,34 @@ export function disposeNodeWorkspace(workspace: Workspace): void {
   nodeWorkspaceDisposers.get(workspace)?.()
 }
 
+export async function whenNodeWorkspaceReady(workspace: Workspace): Promise<void> {
+  await nodeWorkspaceReady.get(workspace)
+}
+
+export async function getNodeWorkspaceReadonlyPolicy(
+  workspace: Workspace,
+): Promise<ReadonlyWorkspacePolicyV1 | undefined> {
+  return (await nodeWorkspaceReady.get(workspace))?.policy
+}
+
 export function createNodeWorkspace(root: string, opts: CreateNodeWorkspaceOptions = {}): Workspace {
   const runtimeContext = opts.runtimeContext ?? { runtimeCwd: root }
+
+  const mutationGuard = acquireNodeWorkspaceMutationGuard(root, opts.readonlyWorkspacePolicy)
+  // Read-only use or an abandoned invalid workspace must not create an
+  // unhandled rejected promise; mutators/whenReady still observe the error.
+  void mutationGuard.catch(() => {})
+  const mutate = async <T>(
+    operation: RuntimeFilesystemCapability,
+    paths: readonly string[],
+    effect: () => Promise<T>,
+  ): Promise<T> => {
+    const guard = await mutationGuard
+    return await guard.runExclusive(async () => {
+      await guard.assertAllowed(operation, paths)
+      return await effect()
+    })
+  }
 
   // Lazy singleton: a single chokidar instance shared by every caller
   // of `watch()` on this workspace. Codex flagged "one watcher per
@@ -52,12 +89,16 @@ export function createNodeWorkspace(root: string, opts: CreateNodeWorkspaceOptio
       return new Uint8Array(await readFile(absPath))
     },
     async writeFile(relPath, data) {
-      const absPath = await ensureWritableWorkspacePath(root, relPath)
-      await writeFile(absPath, data, 'utf-8')
+      await mutate('write', [relPath], async () => {
+        const absPath = await ensureWritableWorkspacePath(root, relPath)
+        await writeFile(absPath, data, 'utf-8')
+      })
     },
     async writeBinaryFile(relPath, data) {
-      const absPath = await ensureWritableWorkspacePath(root, relPath)
-      await writeFile(absPath, data)
+      await mutate('write', [relPath], async () => {
+        const absPath = await ensureWritableWorkspacePath(root, relPath)
+        await writeFile(absPath, data)
+      })
     },
     async readFileWithStat(relPath) {
       const absPath = await ensureExistingWorkspacePath(root, relPath)
@@ -75,36 +116,42 @@ export function createNodeWorkspace(root: string, opts: CreateNodeWorkspaceOptio
       }
     },
     async writeFileWithStat(relPath, data) {
-      const absPath = await ensureWritableWorkspacePath(root, relPath)
-      await writeFile(absPath, data, 'utf-8')
-      const fileStat = await stat(absPath)
-      return {
-        size: fileStat.size,
-        mtimeMs: fileStat.mtimeMs,
-        kind: fileStat.isDirectory() ? 'dir' : 'file',
-      }
+      return await mutate('write', [relPath], async () => {
+        const absPath = await ensureWritableWorkspacePath(root, relPath)
+        await writeFile(absPath, data, 'utf-8')
+        const fileStat = await stat(absPath)
+        return {
+          size: fileStat.size,
+          mtimeMs: fileStat.mtimeMs,
+          kind: fileStat.isDirectory() ? 'dir' as const : 'file' as const,
+        }
+      })
     },
     async writeBinaryFileWithStat(relPath, data) {
-      const absPath = await ensureWritableWorkspacePath(root, relPath)
-      await writeFile(absPath, data)
-      const fileStat = await stat(absPath)
-      return {
-        size: fileStat.size,
-        mtimeMs: fileStat.mtimeMs,
-        kind: fileStat.isDirectory() ? 'dir' : 'file',
-      }
+      return await mutate('write', [relPath], async () => {
+        const absPath = await ensureWritableWorkspacePath(root, relPath)
+        await writeFile(absPath, data)
+        const fileStat = await stat(absPath)
+        return {
+          size: fileStat.size,
+          mtimeMs: fileStat.mtimeMs,
+          kind: fileStat.isDirectory() ? 'dir' as const : 'file' as const,
+        }
+      })
     },
     async unlink(relPath) {
-      const absPath = await ensureExistingWorkspacePath(root, relPath)
-      if (absPath === resolve(root)) {
-        throw Object.assign(new Error('cannot remove workspace root'), { code: EPERM_CODE })
-      }
-      const pathStat = await lstat(absPath)
-      if (pathStat.isDirectory()) {
-        await rm(absPath, { recursive: true, force: false })
-        return
-      }
-      await unlink(absPath)
+      await mutate('delete', [relPath], async () => {
+        const absPath = await ensureExistingWorkspacePath(root, relPath)
+        if (absPath === resolve(root)) {
+          throw Object.assign(new Error('cannot remove workspace root'), { code: EPERM_CODE })
+        }
+        const pathStat = await lstat(absPath)
+        if (pathStat.isDirectory()) {
+          await rm(absPath, { recursive: true, force: false })
+          return
+        }
+        await unlink(absPath)
+      })
     },
     async readdir(relPath) {
       const absPath = await ensureExistingWorkspacePath(root, relPath)
@@ -124,39 +171,48 @@ export function createNodeWorkspace(root: string, opts: CreateNodeWorkspaceOptio
       }
     },
     async mkdir(relPath, opts) {
-      const absPath = validatePath(root, relPath)
-      let existingAncestor = absPath
-      while (true) {
-        try {
-          await stat(existingAncestor)
-          break
-        } catch (error: unknown) {
-          const code = (error as { code?: string }).code
-          if (code !== 'ENOENT') throw error
-          const parent = dirname(existingAncestor)
-          if (parent === existingAncestor) throw error
-          existingAncestor = parent
+      await mutate('create-child', [relPath], async () => {
+        const absPath = validatePath(root, relPath)
+        let existingAncestor = absPath
+        while (true) {
+          try {
+            await stat(existingAncestor)
+            break
+          } catch (error: unknown) {
+            const code = (error as { code?: string }).code
+            if (code !== 'ENOENT') throw error
+            const parent = dirname(existingAncestor)
+            if (parent === existingAncestor) throw error
+            existingAncestor = parent
+          }
         }
-      }
-      await assertRealPathWithinWorkspace(root, existingAncestor)
-      await mkdir(absPath, { recursive: opts?.recursive ?? false })
+        await assertRealPathWithinWorkspace(root, existingAncestor)
+        await mkdir(absPath, { recursive: opts?.recursive ?? false })
+      })
     },
     async rename(fromRelPath, toRelPath) {
-      validatePath(root, toRelPath)
-      const fromAbsPath = await ensureExistingWorkspacePath(root, fromRelPath)
-      const toAbsPath = await ensureWritableWorkspacePath(root, toRelPath)
-      await rename(fromAbsPath, toAbsPath)
-      // One synthetic rename instead of the unlink/add event storm
-      // chokidar would stream for every file under a moved directory.
-      // No watcher yet → no subscribers → nothing to announce.
-      cachedWatcher?.emitRename(toPosixRel(root, fromAbsPath), toPosixRel(root, toAbsPath))
+      const guard = await mutationGuard
+      await guard.runExclusive(async () => {
+        await guard.assertAllowed('move-from', [fromRelPath])
+        await guard.assertAllowed('create-child', [toRelPath])
+        validatePath(root, toRelPath)
+        const fromAbsPath = await ensureExistingWorkspacePath(root, fromRelPath)
+        const toAbsPath = await ensureWritableWorkspacePath(root, toRelPath)
+        await rename(fromAbsPath, toAbsPath)
+        // One synthetic rename instead of the unlink/add event storm
+        // chokidar would stream for every file under a moved directory.
+        // No watcher yet → no subscribers → nothing to announce.
+        cachedWatcher?.emitRename(toPosixRel(root, fromAbsPath), toPosixRel(root, toAbsPath))
+      })
     },
   }
 
   nodeWorkspaceHostRoots.set(workspace, root)
+  nodeWorkspaceReady.set(workspace, mutationGuard)
   nodeWorkspaceDisposers.set(workspace, () => {
     cachedWatcher?.close()
     cachedWatcher = null
+    void mutationGuard.then((guard) => guard.release(), () => undefined)
   })
   return workspace
 }

--- a/packages/boring-sandbox/src/providers/node-workspace/index.ts
+++ b/packages/boring-sandbox/src/providers/node-workspace/index.ts
@@ -2,6 +2,8 @@ export {
   createNodeWorkspace,
   disposeNodeWorkspace,
   getNodeWorkspaceHostRoot,
+  getNodeWorkspaceReadonlyPolicy,
+  whenNodeWorkspaceReady,
 } from './createNodeWorkspace'
 export type { CreateNodeWorkspaceOptions } from './createNodeWorkspace'
 export { DEFAULT_IGNORED_DIR_NAMES, isIgnoredDirName } from './ignore'

--- a/packages/boring-sandbox/src/providers/node-workspace/readonlyMutationGuard.ts
+++ b/packages/boring-sandbox/src/providers/node-workspace/readonlyMutationGuard.ts
@@ -1,0 +1,234 @@
+import { lstat, realpath } from 'node:fs/promises'
+import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
+
+import type { RuntimeFilesystemCapability } from '@hachej/boring-agent/shared'
+
+import type { ReadonlyWorkspacePolicyV1 } from '../../shared/providerV1'
+import { validatePath } from './paths'
+
+class ProviderReadonlyFilesystemMutationError extends Error {
+  readonly code = 'readonly' as const
+  readonly statusCode = 403 as const
+  readonly filesystem = 'user' as const
+
+  constructor(readonly operation: RuntimeFilesystemCapability) {
+    super('user binding is readonly')
+    this.name = 'ReadonlyFilesystemMutationError'
+  }
+}
+
+interface RootMutationState {
+  readonly canonicalRoot: string
+  policy?: ReadonlyWorkspacePolicyV1
+  protectedPrefixes: readonly string[]
+  policyUpgrade?: Promise<void>
+  references: number
+  tail: Promise<void>
+}
+
+export interface NodeWorkspaceMutationGuard {
+  readonly policy?: ReadonlyWorkspacePolicyV1
+  runExclusive<T>(operation: () => Promise<T>): Promise<T>
+  assertAllowed(
+    operation: RuntimeFilesystemCapability,
+    workspaceRelativePaths: readonly string[],
+  ): Promise<void>
+  release(): void
+}
+
+const statesByRoot = new Map<string, Promise<RootMutationState>>()
+
+function invalidPolicy(): Error {
+  return Object.assign(new Error('readonly workspace policy is invalid'), {
+    code: 'RUNTIME_READONLY_FILESYSTEM_POLICY_INVALID',
+  })
+}
+
+function normalizePolicyPath(path: string): string {
+  if (!path || path.includes('\0') || path.includes('\\') || path.startsWith('/') || isAbsolute(path)) {
+    throw invalidPolicy()
+  }
+  const segments = path.split('/')
+  if (segments.some((segment) => !segment || segment === '.' || segment === '..')) throw invalidPolicy()
+  return segments.join('/')
+}
+
+function normalizeRelativePath(root: string, path: string): string {
+  const absolute = validatePath(root, path)
+  const normalized = relative(resolve(root), absolute).split(sep).join('/')
+  return normalized === '.' ? '' : normalized
+}
+
+function isEqualOrDescendant(path: string, ancestor: string): boolean {
+  return path === ancestor || path.startsWith(`${ancestor}/`)
+}
+
+function pathsIntersect(left: string, right: string): boolean {
+  return isEqualOrDescendant(left, right) || isEqualOrDescendant(right, left)
+}
+
+function collapsePrefixes(prefixes: readonly string[]): readonly string[] {
+  const sorted = [...new Set(prefixes)].sort()
+  return Object.freeze(sorted.filter((path) => !sorted.some((candidate) => (
+    candidate !== path && candidate.length < path.length && isEqualOrDescendant(path, candidate)
+  ))))
+}
+
+async function canonicalRelativePath(state: RootMutationState, workspaceRelativePath: string): Promise<string> {
+  const absolute = validatePath(state.canonicalRoot, workspaceRelativePath)
+  const suffix: string[] = []
+  let existing = absolute
+  while (true) {
+    try {
+      await lstat(existing)
+      break
+    } catch (error: unknown) {
+      if ((error as { code?: string }).code !== 'ENOENT') throw error
+      const parent = dirname(existing)
+      if (parent === existing) throw error
+      suffix.unshift(relative(parent, existing))
+      existing = parent
+    }
+  }
+  const realExisting = await realpath(existing)
+  const projected = resolve(realExisting, ...suffix)
+  const canonicalRelative = relative(state.canonicalRoot, projected)
+  if (canonicalRelative === '..' || canonicalRelative.startsWith(`..${sep}`) || isAbsolute(canonicalRelative)) {
+    throw Object.assign(new Error('Resolved path escapes workspace root'), {
+      statusCode: 400,
+      reason: 'symlink-escape',
+      requestedPath: workspaceRelativePath,
+    })
+  }
+  return canonicalRelative.split(sep).join('/')
+}
+
+async function buildProtectedPrefixes(
+  canonicalRoot: string,
+  policy: ReadonlyWorkspacePolicyV1 | undefined,
+): Promise<readonly string[]> {
+  if (!policy) return Object.freeze([])
+  if (!policy.revision.trim()) throw invalidPolicy()
+  const provisional: RootMutationState = {
+    canonicalRoot,
+    policy,
+    protectedPrefixes: [],
+    references: 0,
+    tail: Promise.resolve(),
+  }
+  const prefixes: string[] = []
+  for (const input of policy.readonlyPaths) {
+    const lexical = normalizePolicyPath(input)
+    prefixes.push(lexical)
+    prefixes.push(await canonicalRelativePath(provisional, lexical))
+  }
+  return collapsePrefixes(prefixes)
+}
+
+async function canonicalPlannedRoot(root: string): Promise<string> {
+  const resolvedRoot = resolve(root)
+  const suffix: string[] = []
+  let existing = resolvedRoot
+  while (true) {
+    try {
+      const canonicalExisting = await realpath(existing)
+      return resolve(canonicalExisting, ...suffix)
+    } catch (error: unknown) {
+      if ((error as { code?: string }).code !== 'ENOENT') throw error
+      const parent = dirname(existing)
+      if (parent === existing) throw error
+      suffix.unshift(relative(parent, existing))
+      existing = parent
+    }
+  }
+}
+
+export async function acquireNodeWorkspaceMutationGuard(
+  root: string,
+  policy: ReadonlyWorkspacePolicyV1 | undefined,
+): Promise<NodeWorkspaceMutationGuard> {
+  const canonicalRoot = await canonicalPlannedRoot(root)
+  const frozenPolicy = policy
+    ? Object.freeze({
+        readonlyPaths: Object.freeze(policy.readonlyPaths.map(normalizePolicyPath)),
+        revision: policy.revision,
+      })
+    : undefined
+  let statePromise = statesByRoot.get(canonicalRoot)
+  if (!statePromise) {
+    statePromise = buildProtectedPrefixes(canonicalRoot, frozenPolicy).then((protectedPrefixes) => ({
+      canonicalRoot,
+      policy: frozenPolicy,
+      protectedPrefixes,
+      references: 0,
+      tail: Promise.resolve(),
+    }))
+    statesByRoot.set(canonicalRoot, statePromise)
+  }
+  let state: RootMutationState
+  try {
+    state = await statePromise
+  } catch (error) {
+    if (statesByRoot.get(canonicalRoot) === statePromise) statesByRoot.delete(canonicalRoot)
+    throw error
+  }
+  if (frozenPolicy && !state.policy) {
+    if (!state.policyUpgrade) {
+      const upgrade = buildProtectedPrefixes(canonicalRoot, frozenPolicy)
+        .then((protectedPrefixes) => {
+          state!.policy = frozenPolicy
+          state!.protectedPrefixes = protectedPrefixes
+        })
+      state.policyUpgrade = upgrade
+      void upgrade.catch(() => {
+        if (state!.policyUpgrade === upgrade) state!.policyUpgrade = undefined
+      })
+    }
+    try {
+      await state.policyUpgrade
+    } catch {
+      throw invalidPolicy()
+    }
+  }
+  if (frozenPolicy && (!state.policy
+    || state.policy.revision !== frozenPolicy.revision
+    || JSON.stringify(state.policy.readonlyPaths) !== JSON.stringify(frozenPolicy.readonlyPaths))) {
+    throw invalidPolicy()
+  }
+  state.references += 1
+  let released = false
+
+  return {
+    policy: state.policy,
+    async runExclusive<T>(operation: () => Promise<T>): Promise<T> {
+      let release!: () => void
+      const predecessor = state!.tail
+      state!.tail = new Promise<void>((resolveTail) => { release = resolveTail })
+      await predecessor
+      try {
+        return await operation()
+      } finally {
+        release()
+      }
+    },
+    async assertAllowed(operation, workspaceRelativePaths) {
+      if (!state!.policy) return
+      for (const requestedPath of workspaceRelativePaths) {
+        const lexical = normalizeRelativePath(state!.canonicalRoot, requestedPath)
+        const canonical = await canonicalRelativePath(state!, requestedPath)
+        if (state!.protectedPrefixes.some((prefix) => (
+          pathsIntersect(lexical, prefix) || pathsIntersect(canonical, prefix)
+        ))) {
+          throw new ProviderReadonlyFilesystemMutationError(operation)
+        }
+      }
+    },
+    release() {
+      if (released) return
+      released = true
+      state!.references -= 1
+      // Policy and FIFO lock identity are process-lifetime root state. Runtime
+      // disposal must never create an unguarded re-projection or a second lock.
+    },
+  }
+}

--- a/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
+++ b/packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts
@@ -215,6 +215,12 @@ export function createRemoteWorkerSandboxProviderV1(
       return REMOTE_WORKER_RUNTIME_CWD;
     },
     async create(context): Promise<WorkspaceSandboxPairV1> {
+      if (context.readonlyWorkspacePolicy) {
+        throw new SandboxProviderError(
+          "CONFIG_INVALID",
+          "remote-worker does not implement readonly workspace path policy",
+        );
+      }
       let finishCreate = (): void => {};
       const pendingCreate = new Promise<void>((resolve) => {
         finishCreate = resolve;

--- a/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
+++ b/packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts
@@ -512,6 +512,12 @@ export function createVercelSandboxProvider(
       await snapshotScheduler?.shutdown()
     },
     async create(ctx): Promise<WorkspaceSandboxPairV1> {
+      if (ctx.readonlyWorkspacePolicy) {
+        throw new SandboxProviderError(
+          'CONFIG_INVALID',
+          'vercel-sandbox does not implement readonly workspace path policy',
+        )
+      }
       const telemetry = ctx.telemetry
       const totalStartedAt = Date.now()
       captureSandboxSetupEvent(telemetry, ctx, 'agent.runtime.sandbox.setup.started', {

--- a/packages/boring-sandbox/src/shared/providerV1.ts
+++ b/packages/boring-sandbox/src/shared/providerV1.ts
@@ -25,6 +25,11 @@ export type SandboxProvisioningRuntimeModeIdV1 = Exclude<
   "remote-worker"
 >;
 
+export interface ReadonlyWorkspacePolicyV1 {
+  readonly readonlyPaths: readonly string[];
+  readonly revision: string;
+}
+
 export interface SandboxProviderCreateContextV1 {
   workspaceRoot: string;
   sessionId: string;
@@ -32,6 +37,8 @@ export interface SandboxProviderCreateContextV1 {
   templatePath?: string;
   requestId?: string;
   telemetry?: TelemetrySink;
+  /** Host-normalized, server-private path policy enforced by the Workspace provider. */
+  readonlyWorkspacePolicy?: ReadonlyWorkspacePolicyV1;
 }
 
 export interface SandboxProviderInvalidateContextV1 {
@@ -86,6 +93,8 @@ export interface SandboxProvisioningOperationsV1 {
 
 export type WorkspaceSandboxPairV1 = Readonly<{
   workspace: Workspace;
+  /** Frozen effective provider policy; omitted when legacy behavior is active. */
+  readonlyWorkspacePolicy?: ReadonlyWorkspacePolicyV1;
   sandbox: Sandbox;
   provisioning?: SandboxProvisioningOperationsV1;
   checkHealth?(): Promise<SandboxPairHealthV1>;

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -10,6 +10,7 @@ import {
   createAgentHost,
   createResolvedRuntimeScopeIdentity,
   createSandboxRuntimeModeAdapter,
+  normalizeRuntimeReadonlyFilesystemPolicy,
   provisionRuntimeWorkspace,
   provisionWorkspaceRuntime,
   registerAgentRoutes,
@@ -138,6 +139,8 @@ export interface CreateWorkspaceAgentServerOptions
    */
   plugins?: WorkspacePluginEntry[]
   provisionWorkspace?: boolean
+  /** Host-owned workspace-relative readonly path ceiling. */
+  readonlyWorkspacePaths?: readonly string[]
   workspaceProvisioning?: { force?: boolean }
   validateUiPaths?: boolean
   /**
@@ -1040,6 +1043,9 @@ export async function createWorkspaceAgentServer(
   opts: CreateWorkspaceAgentServerOptions = {},
 ): Promise<FastifyInstance> {
   const workspaceRoot = opts.workspaceRoot ?? process.cwd()
+  const readonlyWorkspacePolicy = opts.readonlyWorkspacePaths
+    ? normalizeRuntimeReadonlyFilesystemPolicy(opts.readonlyWorkspacePaths)
+    : undefined
   const bridge = createInMemoryBridge()
   const unregisterUiBridge = registerWorkspaceUiBridge(bridge)
   const resolvedMode = opts.runtimeModeAdapter?.id ?? opts.mode ?? autoDetectMode()
@@ -1394,6 +1400,7 @@ export async function createWorkspaceAgentServer(
             baseRuntimeScopeIdentity: base.identity,
             environmentProvisioningFingerprint: base.environment.provisioningFingerprint,
             sessionNamespace: base.sessionNamespace,
+            readonlyWorkspacePolicyRevision: readonlyWorkspacePolicy?.revision ?? null,
             base: baseBindingInputs,
             contribution: contribution.bindingInputs,
           },
@@ -1460,6 +1467,7 @@ export async function createWorkspaceAgentServer(
     mode: resolvedMode,
     runtimeModeAdapter: modeAdapter,
     runtimeHost,
+    readonlyWorkspacePolicy,
     getWorkspaceId: async (request) => trustedWorkspaceScopeId(
       request,
       workspaceScopeId,


### PR DESCRIPTION
## Summary

Implements #942 Slice 942.2 / `wt-391-forward-f5p.2`:

- adds host `readonlyWorkspacePaths` normalization/revision and post-#939 runtime identity wiring;
- threads the private policy through ModeContext and provider contracts;
- enforces write/create/delete/move footprints inside provider-owned Node Workspace mutation critical sections;
- denies ancestor deletion/move, destination replacement and canonical symlink aliases;
- projects nonexistent paths through the deepest existing canonical ancestor;
- shares one durable per-canonical-root FIFO/policy across every Node Workspace re-projection;
- supports policy-less-first projections by atomic in-place upgrade, without downgrade or second lock;
- fails closed when custom, Vercel, or remote providers drop/ignore policy;
- routes direct/local provisioning mutations through guarded Workspace operations while preserving reachability probes, overwrite protection and executable modes.

No HTTP/tree/UI capability projection or shell enforcement claim lands here; those remain 942.3+.

## Proof

- Boring Sandbox full suite: **43 files / 433 tests passed**.
- Focused readonly provider suite: **9/9 passed**.
- Focused Agent provider/policy/provisioning/lease suites: **4 files / 43 tests passed**.
- Agent, Sandbox, Workspace typechecks passed.
- Agent and Sandbox builds passed (including Agent artifact assertion).
- `pnpm audit:imports` passed.
- `pnpm lint:invariants` passed.
- `git diff --check` passed.

The readonly cohort covers every Workspace mutation, mixed writable siblings, ancestor footprints, source/destination rename, missing targets, safe aliases, durable post-dispose projection, policy-less-first upgrade, conflicting identity, symlinked nonexistent-root keying, substitution serialization, custom-provider fail-closed/disposal, and omitted-policy compatibility.

## Review

Claude Code CLI Opus high-effort Standards + Spec + thermonuclear review:

1. RED: root policy eviction/second-lock bypass, weak identity compare, unsupported provider fail-open, provisioning regressions, sync/unhandled construction.
2. RED: policy-less-first production ordering, nonexistent symlink-root key split, missing outer custom-adapter boundary.
3. GREEN with one availability high: failed upgrade poisoning and missing tests.
4. Fixed retryable stable upgrade errors; added canonical-planned-root and EnvironmentLease fail-closed tests.
5. Final Opus review: **GREEN**, no blockers/high findings.

Reviewed implementation SHA: `4458e859c`.

Artifacts:
- `/tmp/review-938-942/f5p2-opus-review.md`
- `/tmp/review-938-942/f5p2-opus-rereview.md`
- `/tmp/review-938-942/f5p2-opus-final.md`
- `/tmp/review-938-942/f5p2-opus-green.md`

## Forward obligations

942.3 consumes `RuntimeBundle.readonlyWorkspacePolicy`/`resolveAccess` for routes, tree and real Pi tools with stable serialization. 942.5 separately qualifies provider shell enforcement; this PR makes no shell claim.
