### PR TITLE
#938 feat(workspace): open skill resources by filesystem

### DIFF
--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -916,10 +916,10 @@ describe("WorkspaceAgentFront", () => {
       await waitFor(() => expect(screen.getByText("/review")).toBeInTheDocument())
       expect(screen.getByText("Review the current diff")).toBeInTheDocument()
 
-      await user.click(screen.getByRole("button", { name: "Open skill review in workspace" }))
+      await user.click(screen.getByRole("button", { name: "Open skill review from project" }))
       expect(commands).toContainEqual({
         kind: "openFile",
-        params: { path: ".agents/skills/review/SKILL.md", mode: "view" },
+        params: { path: ".agents/skills/review/SKILL.md", filesystem: "user", mode: "view" },
       })
       expect(screen.getByText("/review")).toBeInTheDocument()
 

--- a/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
+++ b/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
@@ -8,13 +8,17 @@ import { postUiCommand } from "../../bridge"
 import { ManagementOverlaySurface } from "../management/ManagementOverlaySurface"
 import { useWorkspacePluginClient } from "../../plugin/useWorkspacePluginClient"
 import type { PaneProps } from "../../registry/types"
+import { uiFileResourceKey, type UiFileResource } from "../../../shared/types/filesystem"
 
 interface SkillSummary {
   name: string
   description?: string
   source?: string
-  /** Absolute path to the skill's SKILL.md. Used to open the skill through
-   *  the workspace UI bridge, not by mutating chat/composer DOM. */
+  /** False when the row exists for source management but Pi did not retain it as invocable. */
+  invocable?: boolean
+  /** Preferred browser-safe resource identity. */
+  resource?: UiFileResource
+  /** Transitional workspace-relative user locator. */
   filePath?: string
 }
 
@@ -26,6 +30,48 @@ type LoadState =
   | { status: "loading"; skills: SkillSummary[]; error?: undefined }
   | { status: "ready"; skills: SkillSummary[]; error?: undefined }
   | { status: "error"; skills: SkillSummary[]; error: string }
+
+type IndexedSkill = { skill: SkillSummary; sourceIndex: number }
+
+function isSafeRelativeSkillPath(value: unknown): value is string {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\0") || value.includes("\\")) return false
+  if (value.startsWith("/") || /^[A-Za-z]:/.test(value) || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(value)) return false
+  if (/%(?:2e|2f|5c)/i.test(value)) return false
+  const segments = value.split("/")
+  return !segments.some((segment) => segment === "" || segment === "." || segment === "..")
+}
+
+function openableResource(skill: SkillSummary): UiFileResource | undefined {
+  const resource = skill.resource
+  if (resource) {
+    return typeof resource.filesystem === "string"
+      && resource.filesystem.length > 0
+      && isSafeRelativeSkillPath(resource.path)
+      ? resource
+      : undefined
+  }
+  return isSafeRelativeSkillPath(skill.filePath)
+    ? { filesystem: "user", path: skill.filePath }
+    : undefined
+}
+
+function compareSkills(left: IndexedSkill, right: IndexedSkill): number {
+  const a = left.skill
+  const b = right.skill
+  return a.name.localeCompare(b.name)
+    || Number(a.invocable === false) - Number(b.invocable === false)
+    || (a.source ?? "").localeCompare(b.source ?? "")
+    || (a.resource?.filesystem ?? "").localeCompare(b.resource?.filesystem ?? "")
+    || (a.resource?.path ?? a.filePath ?? "").localeCompare(b.resource?.path ?? b.filePath ?? "")
+    || (a.description ?? "").localeCompare(b.description ?? "")
+    || left.sourceIndex - right.sourceIndex
+}
+
+function skillRowKey({ skill, sourceIndex }: IndexedSkill): string {
+  const resource = openableResource(skill)
+  if (resource) return `resource:${uiFileResourceKey(resource)}`
+  return `management:${skill.name}\0${skill.source ?? ""}\0${skill.description ?? ""}\0${sourceIndex}`
+}
 
 export type SkillsPageProps = Partial<PaneProps> & {
   /** When provided, renders a close control in the header — used when Skills
@@ -42,8 +88,16 @@ export function SkillsPage({ onClose, headerInsetStart = false, headerInsetEnd =
   const [state, setState] = useState<LoadState>({ status: "loading", skills: [] })
 
   const openSkillInWorkspace = useCallback((skill: SkillSummary) => {
-    if (!skill.filePath) return
-    postUiCommand({ kind: "openFile", params: { path: skill.filePath, mode: "view" } })
+    const resource = openableResource(skill)
+    if (!resource) return
+    postUiCommand({
+      kind: "openFile",
+      params: {
+        path: resource.path,
+        filesystem: resource.filesystem,
+        mode: "view",
+      },
+    })
   }, [])
 
   const loadSkills = useCallback(async (refresh = false) => {
@@ -70,7 +124,7 @@ export function SkillsPage({ onClose, headerInsetStart = false, headerInsetEnd =
   }, [loadSkills])
 
   const sortedSkills = useMemo(
-    () => [...state.skills].sort((a, b) => a.name.localeCompare(b.name)),
+    () => state.skills.map((skill, sourceIndex) => ({ skill, sourceIndex })).sort(compareSkills),
     [state.skills],
   )
 
@@ -78,7 +132,7 @@ export function SkillsPage({ onClose, headerInsetStart = false, headerInsetEnd =
     <ManagementOverlaySurface
       part="skills-page"
       title="Skills"
-      description="Workspace skills available to slash commands"
+      description="Invocable skills and their registered source resources"
       headerInsetStart={headerInsetStart}
       headerInsetEnd={headerInsetEnd}
       icon={(
@@ -134,29 +188,57 @@ export function SkillsPage({ onClose, headerInsetStart = false, headerInsetEnd =
           </div>
         ) : (
           <ul role="list" className="grid gap-2">
-            {sortedSkills.map((skill) => {
+            {sortedSkills.map((entry) => {
+              const { skill } = entry
+              const resource = openableResource(skill)
+              const managementOnly = skill.invocable === false
+              const content = (
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                      <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                        {managementOnly ? skill.name : `/${skill.name}`}
+                      </span>
+                      {managementOnly ? (
+                        <span className="rounded-full border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          Management source
+                        </span>
+                      ) : null}
+                    </div>
+                    {skill.source ? (
+                      <p className="mt-1 truncate text-[11px] text-muted-foreground" title={skill.source}>
+                        Source: {skill.source}
+                      </p>
+                    ) : null}
+                    {skill.description ? (
+                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">{skill.description}</p>
+                    ) : null}
+                  </div>
+                  {resource ? <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" /> : null}
+                </div>
+              )
               return (
                 <li
-                  key={skill.name}
-                  className="rounded-xl border border-border/60 bg-card/70 px-3 py-2.5 cursor-pointer transition-colors hover:border-border hover:bg-muted/60"
+                  key={skillRowKey(entry)}
+                  className={cn(
+                    "rounded-xl border border-border/60 bg-card/70 px-3 py-2.5",
+                    resource && "transition-colors hover:border-border hover:bg-muted/60",
+                    managementOnly && "border-dashed bg-muted/25",
+                  )}
                 >
-                  <button
-                    type="button"
-                    onClick={() => openSkillInWorkspace(skill)}
-                    title="Open skill"
-                    aria-label={`Open skill ${skill.name} in workspace`}
-                    className="block w-full text-left"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-medium text-foreground">/{skill.name}</div>
-                        {skill.description ? (
-                          <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">{skill.description}</p>
-                        ) : null}
-                      </div>
-                      <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
-                    </div>
-                  </button>
+                  {resource ? (
+                    <button
+                      type="button"
+                      onClick={() => openSkillInWorkspace(skill)}
+                      title="Open skill source"
+                      aria-label={`Open ${managementOnly ? "management source" : "skill"} ${skill.name} from ${skill.source ?? resource.filesystem}`}
+                      className="block w-full cursor-pointer text-left"
+                    >
+                      {content}
+                    </button>
+                  ) : (
+                    <div>{content}</div>
+                  )}
                 </li>
               )
             })}

--- a/packages/workspace/src/front/chrome/skills/__tests__/SkillsPage.test.tsx
+++ b/packages/workspace/src/front/chrome/skills/__tests__/SkillsPage.test.tsx
@@ -1,0 +1,158 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SkillsPage } from "../SkillsPage"
+
+const mocks = vi.hoisted(() => {
+  const getJson = vi.fn()
+  return {
+    getJson,
+    client: { getJson },
+    postUiCommand: vi.fn(),
+  }
+})
+
+vi.mock("../../../plugin/useWorkspacePluginClient", () => ({
+  useWorkspacePluginClient: () => mocks.client,
+}))
+
+vi.mock("../../../bridge", () => ({
+  postUiCommand: mocks.postUiCommand,
+}))
+
+const skills = [
+  {
+    name: "workspace-skill",
+    description: "Workspace source.",
+    source: "project",
+    resource: { filesystem: "user", path: ".agents/skills/workspace-skill/SKILL.md" },
+  },
+  {
+    name: "duplicate",
+    description: "Package management source.",
+    source: "@example/package",
+    invocable: false,
+    resource: { filesystem: "agent_resources", path: "packages/@example/package/skills/duplicate/SKILL.md" },
+  },
+  {
+    name: "duplicate",
+    description: "Shared management source.",
+    source: "shared/pi-agent",
+    invocable: false,
+    resource: { filesystem: "agent_resources", path: "shared/pi-agent/duplicate/SKILL.md" },
+  },
+  {
+    name: "legacy-safe",
+    description: "Legacy workspace locator.",
+    filePath: ".pi/skills/legacy-safe/SKILL.md",
+  },
+  {
+    name: "legacy-host-path",
+    description: "Must not become openable.",
+    filePath: "/home/operator/.pi/agent/skills/private/SKILL.md",
+  },
+]
+
+describe("SkillsPage resource rows", () => {
+  beforeEach(() => {
+    mocks.getJson.mockReset()
+    mocks.postUiCommand.mockReset()
+    mocks.getJson.mockResolvedValue({ skills })
+  })
+
+  it("preserves filesystem identity when opening workspace, package, shared, and safe legacy sources", async () => {
+    render(<SkillsPage />)
+
+    await screen.findByText("/workspace-skill")
+    fireEvent.click(screen.getByRole("button", { name: "Open skill workspace-skill from project" }))
+    fireEvent.click(screen.getByRole("button", { name: "Open management source duplicate from @example/package" }))
+    fireEvent.click(screen.getByRole("button", { name: "Open management source duplicate from shared/pi-agent" }))
+    fireEvent.click(screen.getByRole("button", { name: "Open skill legacy-safe from user" }))
+
+    expect(mocks.postUiCommand.mock.calls.map(([command]) => command)).toEqual([
+      {
+        kind: "openFile",
+        params: { path: ".agents/skills/workspace-skill/SKILL.md", filesystem: "user", mode: "view" },
+      },
+      {
+        kind: "openFile",
+        params: { path: "packages/@example/package/skills/duplicate/SKILL.md", filesystem: "agent_resources", mode: "view" },
+      },
+      {
+        kind: "openFile",
+        params: { path: "shared/pi-agent/duplicate/SKILL.md", filesystem: "agent_resources", mode: "view" },
+      },
+      {
+        kind: "openFile",
+        params: { path: ".pi/skills/legacy-safe/SKILL.md", filesystem: "user", mode: "view" },
+      },
+    ])
+  })
+
+  it("keeps same-name management identities distinct without presenting slash commands", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    render(<SkillsPage />)
+
+    const badges = await screen.findAllByText("Management source")
+    expect(badges).toHaveLength(2)
+    expect(screen.getAllByText("duplicate")).toHaveLength(2)
+    expect(screen.queryByText("/duplicate")).not.toBeInTheDocument()
+    expect(screen.getByText("Source: @example/package")).toBeInTheDocument()
+    expect(screen.getByText("Source: shared/pi-agent")).toBeInTheDocument()
+
+    const rows = screen.getAllByRole("listitem")
+    const duplicateRows = rows.filter((row) => within(row).queryByText("duplicate"))
+    expect(duplicateRows).toHaveLength(2)
+    expect(duplicateRows[0]).toHaveTextContent("Package management source.")
+    expect(duplicateRows[1]).toHaveTextContent("Shared management source.")
+    expect(consoleError.mock.calls.flat().join(" ")).not.toMatch(/same key/i)
+    consoleError.mockRestore()
+  })
+
+  it("rejects absolute and traversal legacy locators without leaking them into the DOM", async () => {
+    mocks.getJson.mockResolvedValue({
+      skills: [
+        skills[4],
+        { name: "traversal", filePath: "../secret/SKILL.md" },
+        { name: "encoded", filePath: "skills/%2e%2e/secret/SKILL.md" },
+        { name: "backslash", filePath: "skills\\evil\\SKILL.md" },
+        { name: "drive", filePath: "C:/skills/SKILL.md" },
+        { name: "scheme", filePath: "file:///etc/passwd" },
+        {
+          name: "invalid-resource",
+          resource: { filesystem: "agent_resources", path: "../secret/SKILL.md" },
+          filePath: ".pi/skills/must-not-fallback/SKILL.md",
+        },
+      ],
+    })
+    const { container } = render(<SkillsPage />)
+
+    await screen.findByText("/legacy-host-path")
+    expect(screen.queryByRole("button", { name: /legacy-host-path/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /traversal/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /encoded/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /backslash/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /drive/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /scheme/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /invalid-resource/ })).not.toBeInTheDocument()
+    expect(container.textContent).not.toContain("/home/operator")
+    expect(container.textContent).not.toContain("../secret")
+    expect(mocks.postUiCommand).not.toHaveBeenCalled()
+  })
+
+  it("exposes clear accessible labels and refreshes through the guarded endpoint", async () => {
+    render(<SkillsPage onClose={vi.fn()} />)
+    await screen.findByText("/workspace-skill")
+
+    expect(screen.getByRole("button", { name: "Open skill workspace-skill from project" })).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Open management source duplicate from @example/package" })).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Refresh skills" })).toBeEnabled()
+    expect(screen.getByRole("button", { name: "Close skills" })).toBeEnabled()
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh skills" }))
+    await waitFor(() => expect(mocks.getJson).toHaveBeenCalledWith(
+      "/api/v1/agent/skills?refresh=1",
+      expect.objectContaining({ missingMessage: expect.any(String) }),
+    ))
+  })
+})


### PR DESCRIPTION
## Summary

Implements #938 Slice 938.3 / `wt-391-forward-ehl.3`:

- consumes structural `{ filesystem, path }` skill resources;
- preserves filesystem identity in `openFile` and opens in view mode;
- uses `uiFileResourceKey` for identity-safe same-name rows;
- keeps strict relative-only legacy `filePath` fallback;
- fails closed when a supplied resource is malformed rather than switching filesystems;
- distinguishes `invocable: false` management sources without rendering slash commands;
- keeps same-name package/shared identities distinct;
- disables opening for absolute, URL/drive, backslash, dot-segment and encoded-traversal legacy paths;
- adds accessible open/refresh/close semantics and openability affordances.

No 938.4 server bypass removal is included.

## Proof

- Skills UI component: **1 file / 4 tests passed**.
- Workspace typecheck passed.
- Agent/Sandbox/UI prerequisite builds and Agent artifact assertion passed.
- `pnpm audit:imports` passed.
- `pnpm lint:invariants` passed.
- `git diff --check` passed.

Tests cover workspace/package/shared opens, exact filesystem dispatch, same-name stable keys with no React warning, management-only semantics, safe legacy fallback, full unsafe path matrix, invalid-resource no-fallback, host-path DOM redaction, and accessible labels.

## Review

Claude Code CLI Opus high-effort frontend/Standards/Spec review:

1. GREEN with seven localized highs: missing key mutation proof, invalid resource fail-open, ARIA, pointer/truncation, generic key helper, incomplete unsafe matrix.
2. All fixed and proof rerun.
3. Final Opus review: **GREEN**, no blockers/high findings.

Reviewed SHA: `7e4b262ce`.

Artifacts:
- `/tmp/review-938-942/ehl3-opus-review.md`
- `/tmp/review-938-942/ehl3-opus-final.md`
