### PR TITLE
#942 feat(agent): project readonly capabilities to routes and tools

### DIFF
--- a/packages/agent/src/server/__tests__/createAgentApp.test.ts
+++ b/packages/agent/src/server/__tests__/createAgentApp.test.ts
@@ -583,7 +583,19 @@ test('createAgentApp exposes static filesystem bindings on files and tree routes
 
     const tree = await app.inject({ method: 'GET', url: '/api/v1/tree?filesystem=company_context' })
     expect(tree.statusCode).toBe(200)
-    expect(tree.json().entries).toEqual([{ name: 'company', kind: 'dir', path: 'company' }])
+    expect(tree.json().entries).toEqual([{
+      name: 'company',
+      kind: 'dir',
+      path: 'company',
+      access: 'readonly',
+      capabilities: {
+        read: true,
+        write: false,
+        'create-child': false,
+        delete: false,
+        'move-from': false,
+      },
+    }])
     expect(operations.list).toHaveBeenCalledWith({ filesystem: 'company_context', path: '/' })
     expect(operations.stat).toHaveBeenCalledWith({ filesystem: 'company_context', path: 'company' })
   } finally {

--- a/packages/agent/src/server/index.ts
+++ b/packages/agent/src/server/index.ts
@@ -249,6 +249,7 @@ export {
   resolveRuntimeReadonlyFilesystemAccess,
 } from './runtime/readonlyFilesystemPolicy'
 export type { RuntimeReadonlyFilesystemPolicy } from './runtime/readonlyFilesystemPolicy'
+export { createUserFilesystemBinding } from './runtime/userFilesystemBinding'
 export {
   createFakeAuthorityVerifierV1,
   createHostSideCredentialResolverV1,

--- a/packages/agent/src/server/runtime/__tests__/filesystemBindings.test.ts
+++ b/packages/agent/src/server/runtime/__tests__/filesystemBindings.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import type { RuntimeFilesystemBinding } from '../mode'
 import {
@@ -120,8 +120,10 @@ describe('composeRuntimeFilesystemBindings', () => {
   )
 
   test('consumes exactly one host/governance user pair and intersects every capability', async () => {
+    const writeBinary = vi.fn(async () => ({ mtimeMs: 2 }))
     const hostOperations: RuntimeFilesystemBinding['operations'] = {
       ...operations,
+      writeBinary,
       resolveAccess: async ({ filesystem, path }) => ({
         filesystem,
         normalizedPath: path,
@@ -169,6 +171,12 @@ describe('composeRuntimeFilesystemBindings', () => {
         access: 'readonly',
         capabilities: { write: false, delete: false },
       })
+    await expect(user.operations.writeBinary?.({
+      filesystem: 'user',
+      path: 'upload.bin',
+      content: new Uint8Array([1]),
+    })).resolves.toEqual({ mtimeMs: 2 })
+    expect(writeBinary).toHaveBeenCalledOnce()
   })
 
   test('binding-wide governance readonly cannot be widened by a host readwrite summary', async () => {

--- a/packages/agent/src/server/runtime/__tests__/readonlyFilesystemPolicy.test.ts
+++ b/packages/agent/src/server/runtime/__tests__/readonlyFilesystemPolicy.test.ts
@@ -83,6 +83,17 @@ describe('resolveRuntimeReadonlyFilesystemAccess', () => {
     })
   })
 
+  test('allows scheme-like relative filenames in access queries', () => {
+    expect(resolveRuntimeReadonlyFilesystemAccess(policy, {
+      filesystem: 'user',
+      normalizedPath: 'backup:2026.tar',
+    })).toMatchObject({
+      normalizedPath: 'backup:2026.tar',
+      access: 'readwrite',
+      capabilities: { write: true },
+    })
+  })
+
   test('supports the workspace root as a mixed ancestor', () => {
     expect(resolveRuntimeReadonlyFilesystemAccess(policy, {
       filesystem: 'user',

--- a/packages/agent/src/server/runtime/__tests__/userFilesystemBinding.test.ts
+++ b/packages/agent/src/server/runtime/__tests__/userFilesystemBinding.test.ts
@@ -1,0 +1,30 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, test } from 'vitest'
+import { createNodeWorkspace } from '@agent-test-host'
+
+import { READONLY_FILESYSTEM_MUTATION_CODE } from '../../../shared/workspace'
+import { normalizeRuntimeReadonlyFilesystemPolicy } from '../readonlyFilesystemPolicy'
+import { createUserFilesystemBinding } from '../userFilesystemBinding'
+
+describe('createUserFilesystemBinding', () => {
+  test('projects the real policy and keeps guarded writable siblings functional', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'boring-user-binding-'))
+    await mkdir(join(root, 'mixed/protected'), { recursive: true })
+    await writeFile(join(root, 'mixed/protected/locked.txt'), 'locked')
+    const readonlyWorkspacePolicy = { readonlyPaths: ['mixed/protected'], revision: 'test-v1' }
+    const workspace = createNodeWorkspace(root, { readonlyWorkspacePolicy })
+    const binding = createUserFilesystemBinding(
+      workspace,
+      normalizeRuntimeReadonlyFilesystemPolicy(readonlyWorkspacePolicy.readonlyPaths),
+    )
+
+    await expect(binding.operations.resolveAccess?.({ filesystem: 'user', path: 'mixed/protected/locked.txt' }))
+      .resolves.toMatchObject({ access: 'readonly', capabilities: { write: false, delete: false } })
+    await expect(binding.operations.write?.({ filesystem: 'user', path: 'mixed/sibling.txt', content: 'ok' }))
+      .resolves.toMatchObject({ mtimeMs: expect.any(Number) })
+    await expect(binding.operations.write?.({ filesystem: 'user', path: 'mixed/protected/locked.txt', content: 'no' }))
+      .rejects.toMatchObject({ code: READONLY_FILESYSTEM_MUTATION_CODE, filesystem: 'user', operation: 'write' })
+  })
+})

--- a/packages/agent/src/server/runtime/filesystemBindings.ts
+++ b/packages/agent/src/server/runtime/filesystemBindings.ts
@@ -118,6 +118,7 @@ function mergePrimaryBindings(
     stat: (descriptor) => hostOperations.stat(descriptor),
     rejectMutation: (operation, descriptor) => hostOperations.rejectMutation(operation, descriptor),
     ...(hostOperations.write ? { write: (descriptor) => hostOperations.write!(descriptor) } : {}),
+    ...(hostOperations.writeBinary ? { writeBinary: (descriptor) => hostOperations.writeBinary!(descriptor) } : {}),
     ...(hostOperations.delete ? { delete: (descriptor) => hostOperations.delete!(descriptor) } : {}),
     ...(hostOperations.move ? { move: (descriptor) => hostOperations.move!(descriptor) } : {}),
     ...(hostOperations.mkdir ? { mkdir: (descriptor) => hostOperations.mkdir!(descriptor) } : {}),

--- a/packages/agent/src/server/runtime/mode.ts
+++ b/packages/agent/src/server/runtime/mode.ts
@@ -97,6 +97,7 @@ export interface RuntimeFilesystemBindingOperations {
   grep(descriptor: { filesystem: string; path: string }, pattern: string, options?: { limit?: number; offset?: number }): Promise<{ matches: Array<{ path: string; line: number; text: string }>; metadata?: unknown }>
   stat(descriptor: { filesystem: string; path: string }): Promise<{ isDirectory: boolean; metadata?: unknown }>
   write?(descriptor: { filesystem: string; path: string; content: string; expectedMtimeMs?: number }): Promise<{ mtimeMs?: number; metadata?: unknown }>
+  writeBinary?(descriptor: { filesystem: string; path: string; content: Uint8Array }): Promise<{ mtimeMs?: number; metadata?: unknown }>
   delete?(descriptor: { filesystem: string; path: string }): Promise<{ metadata?: unknown }>
   move?(descriptor: { filesystem: string; from: string; to: string }): Promise<{ metadata?: unknown }>
   mkdir?(descriptor: { filesystem: string; path: string; recursive?: boolean }): Promise<{ metadata?: unknown }>

--- a/packages/agent/src/server/runtime/modes/providerAdapter.ts
+++ b/packages/agent/src/server/runtime/modes/providerAdapter.ts
@@ -14,6 +14,7 @@ import type {
 import type { WorkspaceProvisioningAdapter } from '../../workspace/provisioning'
 import { ErrorCode } from '../../../shared/error-codes'
 import type { AgentRuntimeHostOperations } from '../runtimeHost'
+import { createUserFilesystemBinding } from '../userFilesystemBinding'
 
 interface ProviderRuntimeModeAdapterOptions {
   id: 'direct' | 'local' | 'vercel-sandbox'
@@ -85,6 +86,9 @@ export function createProviderRuntimeModeAdapter(
           runtimeHost: options.runtimeHost,
           bash: options.bash,
           filesystem: options.filesystem,
+          filesystemBindings: pair.readonlyWorkspacePolicy
+            ? [createUserFilesystemBinding(pair.workspace, pair.readonlyWorkspacePolicy)]
+            : undefined,
           readonlyWorkspacePolicy: pair.readonlyWorkspacePolicy,
           provisioningAdapter: options.provisioningAdapter?.(context, pair)
             ?? pair.provisioning,

--- a/packages/agent/src/server/runtime/readonlyFilesystemPolicy.ts
+++ b/packages/agent/src/server/runtime/readonlyFilesystemPolicy.ts
@@ -24,11 +24,11 @@ function stableRevision(values: readonly string[]): string {
   return `readonly-paths-v1-${digestRuntimeIdentityValue([...values])}`
 }
 
-function normalizePolicyPath(input: string, allowRoot = false): string {
+function normalizePolicyPath(input: string, allowRoot = false, rejectSchemeLike = true): string {
   if (typeof input !== 'string' || (!allowRoot && input.length === 0) || input.includes('\0')) {
     throw new RuntimeReadonlyFilesystemPolicyError()
   }
-  if (/^[A-Za-z]:[\\/]/.test(input) || /^[A-Za-z][A-Za-z0-9+.-]*:/.test(input)) {
+  if (/^[A-Za-z]:[\\/]/.test(input) || (rejectSchemeLike && /^[A-Za-z][A-Za-z0-9+.-]*:/.test(input))) {
     throw new RuntimeReadonlyFilesystemPolicyError()
   }
 
@@ -93,7 +93,10 @@ export function resolveRuntimeReadonlyFilesystemAccess(
   policy: RuntimeReadonlyFilesystemPolicy,
   descriptor: { readonly filesystem: string; readonly normalizedPath: string },
 ): RuntimeFilesystemAccessDecision {
-  const path = normalizePolicyPath(descriptor.normalizedPath, true)
+  // A colon is legal in a workspace filename (for example `backup:2026.tar`).
+  // Scheme-like strings are rejected when authoring policy, while access
+  // queries reject only absolute/drive, NUL, and escaping paths.
+  const path = normalizePolicyPath(descriptor.normalizedPath, true, false)
   const insideReadonly = policy.readonlyPaths.some((prefix) => isEqualOrDescendant(path, prefix))
   const containsReadonly = policy.readonlyPaths.some((prefix) => path.length === 0 || isEqualOrDescendant(prefix, path))
   const capabilities = capabilityRecord({

--- a/packages/agent/src/server/runtime/userFilesystemBinding.ts
+++ b/packages/agent/src/server/runtime/userFilesystemBinding.ts
@@ -1,0 +1,127 @@
+import type { Workspace } from '../../shared/workspace'
+import { ReadonlyFilesystemMutationError } from '../../shared/workspace'
+import { ERROR_CODE_CONFLICT } from '../http/middleware'
+import type { RuntimeFilesystemBinding } from './mode'
+import {
+  resolveRuntimeReadonlyFilesystemAccess,
+  type RuntimeReadonlyFilesystemPolicy,
+} from './readonlyFilesystemPolicy'
+
+const USER_FILESYSTEM_ID = 'user'
+
+function workspacePath(workspace: Workspace, input: string): string {
+  const normalized = input.replace(/\\/g, '/')
+  const root = workspace.root.replace(/\\/g, '/').replace(/\/$/, '')
+  if (normalized === root || normalized === '/') return '.'
+  if (root && normalized.startsWith(`${root}/`)) return normalized.slice(root.length + 1)
+  return normalized.replace(/^\.\//, '')
+}
+
+function logicalPath(workspace: Workspace, input: string): string {
+  const value = workspacePath(workspace, input)
+  return value === '.' ? '' : value
+}
+
+function conflict(currentMtimeMs: number | undefined, expectedMtimeMs: number): Error {
+  return Object.assign(new Error('file has been modified since last read'), {
+    code: ERROR_CODE_CONFLICT,
+    statusCode: 409,
+    details: { currentMtimeMs, expectedMtimeMs },
+  })
+}
+
+/** Provider-backed primary binding used by both HTTP routes and real Pi tools. */
+export function createUserFilesystemBinding(
+  workspace: Workspace,
+  policy: RuntimeReadonlyFilesystemPolicy,
+): RuntimeFilesystemBinding {
+  return {
+    filesystem: USER_FILESYSTEM_ID,
+    access: 'readwrite',
+    operations: {
+      async read({ path }) {
+        const target = workspacePath(workspace, path)
+        if (workspace.readFileWithStat) {
+          const result = await workspace.readFileWithStat(target)
+          return { content: result.content, mtimeMs: result.stat.kind === 'file' ? result.stat.mtimeMs : undefined }
+        }
+        const [content, stat] = await Promise.all([workspace.readFile(target), workspace.stat(target)])
+        return { content, mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined }
+      },
+      async list({ path }) {
+        return { entries: (await workspace.readdir(workspacePath(workspace, path))).map((entry) => entry.name) }
+      },
+      async find() {
+        throw new Error('user filesystem discovery uses the canonical Pi tool operations')
+      },
+      async grep() {
+        throw new Error('user filesystem search uses the canonical Pi tool operations')
+      },
+      async stat({ path }) {
+        return { isDirectory: (await workspace.stat(workspacePath(workspace, path))).kind === 'dir' }
+      },
+      async write({ path, content, expectedMtimeMs }) {
+        const target = workspacePath(workspace, path)
+        if (expectedMtimeMs !== undefined) {
+          let currentMtimeMs: number | undefined
+          try {
+            const current = await workspace.stat(target)
+            currentMtimeMs = current.kind === 'file' ? current.mtimeMs : undefined
+          } catch (error: unknown) {
+            if ((error as { code?: string }).code !== 'ENOENT') throw error
+            throw Object.assign(new Error('file no longer exists'), {
+              code: ERROR_CODE_CONFLICT,
+              statusCode: 409,
+              details: { expectedMtimeMs },
+            })
+          }
+          if (currentMtimeMs !== expectedMtimeMs) throw conflict(currentMtimeMs, expectedMtimeMs)
+        }
+        if (workspace.writeFileWithStat) {
+          const stat = await workspace.writeFileWithStat(target, content)
+          return { mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined }
+        }
+        await workspace.writeFile(target, content)
+        const stat = await workspace.stat(target)
+        return { mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined }
+      },
+      async writeBinary({ path, content }) {
+        const target = workspacePath(workspace, path)
+        if (workspace.writeBinaryFileWithStat) {
+          const stat = await workspace.writeBinaryFileWithStat(target, content)
+          return { mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined }
+        }
+        if (!workspace.writeBinaryFile) throw Object.assign(new Error('workspace does not support binary writes'), { statusCode: 501 })
+        await workspace.writeBinaryFile(target, content)
+        const stat = await workspace.stat(target)
+        return { mtimeMs: stat.kind === 'file' ? stat.mtimeMs : undefined }
+      },
+      async delete({ path }) {
+        await workspace.unlink(workspacePath(workspace, path))
+        return {}
+      },
+      async move({ from, to }) {
+        await workspace.rename(workspacePath(workspace, from), workspacePath(workspace, to))
+        return {}
+      },
+      async mkdir({ path, recursive }) {
+        await workspace.mkdir(workspacePath(workspace, path), { recursive })
+        return {}
+      },
+      async resolveAccess({ filesystem, path }) {
+        return resolveRuntimeReadonlyFilesystemAccess(policy, {
+          filesystem,
+          normalizedPath: logicalPath(workspace, path),
+        })
+      },
+      rejectMutation(operation) {
+        throw new ReadonlyFilesystemMutationError(
+          USER_FILESYSTEM_ID,
+          operation === 'delete' || operation === 'move-from' || operation === 'create-child'
+            ? operation
+            : 'write',
+        )
+      },
+    },
+  }
+}

--- a/packages/boring-bash/src/agent/runtime/types.ts
+++ b/packages/boring-bash/src/agent/runtime/types.ts
@@ -77,6 +77,7 @@ export interface RuntimeFilesystemBindingOperations {
   grep(descriptor: { filesystem: string; path: string }, pattern: string, options?: { limit?: number; offset?: number }): Promise<{ matches: Array<{ path: string; line: number; text: string }>; metadata?: unknown }>
   stat(descriptor: { filesystem: string; path: string }): Promise<{ isDirectory: boolean; metadata?: unknown }>
   write?(descriptor: { filesystem: string; path: string; content: string; expectedMtimeMs?: number }): Promise<{ mtimeMs?: number; metadata?: unknown }>
+  writeBinary?(descriptor: { filesystem: string; path: string; content: Uint8Array }): Promise<{ mtimeMs?: number; metadata?: unknown }>
   delete?(descriptor: { filesystem: string; path: string }): Promise<{ metadata?: unknown }>
   move?(descriptor: { filesystem: string; from: string; to: string }): Promise<{ metadata?: unknown }>
   mkdir?(descriptor: { filesystem: string; path: string; recursive?: boolean }): Promise<{ metadata?: unknown }>

--- a/packages/boring-bash/src/agent/tools/filesystem/index.ts
+++ b/packages/boring-bash/src/agent/tools/filesystem/index.ts
@@ -42,7 +42,15 @@ function filesystemBindings(bundle: RuntimeBundle) {
 }
 
 function filesystemIds(bundle: RuntimeBundle): string[] {
-  return filesystemBindings(bundle).map((binding) => binding.filesystem)
+  return filesystemBindings(bundle)
+    .filter((binding) => binding.filesystem !== 'user')
+    .map((binding) => binding.filesystem)
+}
+
+function uniqueFilesystemBinding(bindings: readonly RuntimeFilesystemBinding[], filesystem: string): RuntimeFilesystemBinding | undefined {
+  const matches = bindings.filter((entry) => entry.filesystem === filesystem)
+  if (matches.length > 1) throw new Error(`duplicate filesystem binding: ${filesystem}`)
+  return matches[0]
 }
 
 function withFilesystemParameter(parameters: unknown, filesystemIds: readonly string[], dynamicBindings = false): Record<string, unknown> {
@@ -90,7 +98,7 @@ function assertNotFilesystemPathSpoof(path: string, filesystemIds: readonly stri
 }
 
 function filesystemBinding(bindings: readonly RuntimeFilesystemBinding[], filesystem: string): RuntimeFilesystemBinding {
-  const binding = bindings.find((entry) => entry.filesystem === filesystem)
+  const binding = uniqueFilesystemBinding(bindings, filesystem)
   if (!binding) throw new Error(`No filesystem binding is available for ${filesystem}`)
   return binding
 }
@@ -140,6 +148,18 @@ function applyExactEdits(original: string, edits: readonly ExactEdit[]): string 
   return output
 }
 
+async function requireToolCapability(
+  binding: RuntimeFilesystemBinding,
+  path: string,
+  capability: 'write' | 'create-child' | 'delete' | 'move-from',
+): Promise<void> {
+  const decision = await binding.operations.resolveAccess?.({ filesystem: binding.filesystem, path })
+  const allowed = decision
+    ? decision.capabilities[capability] === true
+    : binding.access === 'readwrite'
+  if (!allowed) binding.operations.rejectMutation(capability, { filesystem: binding.filesystem, path })
+}
+
 async function executeBoundFilesystemTool(
   toolName: string,
   filesystem: string,
@@ -172,17 +192,28 @@ async function executeBoundFilesystemTool(
     return { ...formatBoundGrep(result.matches), details: { metadata: result.metadata } }
   }
   if (toolName === 'write') {
-    if (binding.access !== 'readwrite' || !operations.write) operations.rejectMutation(toolName, { filesystem, path })
+    await requireToolCapability(binding, path, 'write')
+    if (!operations.write) operations.rejectMutation('write', { filesystem, path })
     const write = operations.write
     if (!write) throw new Error(`Tool ${toolName} does not support filesystem ${filesystem}`)
     const content = typeof params.content === 'string' ? params.content : ''
     const parent = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) || '/' : null
-    if (parent && operations.mkdir) await operations.mkdir({ filesystem, path: parent, recursive: true })
+    if (parent && operations.mkdir) {
+      let exists = false
+      try { exists = (await operations.stat({ filesystem, path: parent })).isDirectory } catch (error: unknown) {
+        if ((error as { code?: string }).code !== 'ENOENT') throw error
+      }
+      if (!exists) {
+        await requireToolCapability(binding, parent, 'create-child')
+        await operations.mkdir({ filesystem, path: parent, recursive: true })
+      }
+    }
     const result = await write({ filesystem, path, content })
     return { content: [{ type: 'text', text: `Wrote ${path}` }], details: { metadata: result.metadata, mtimeMs: result.mtimeMs } }
   }
   if (toolName === 'edit') {
-    if (binding.access !== 'readwrite' || !operations.write) operations.rejectMutation(toolName, { filesystem, path })
+    await requireToolCapability(binding, path, 'write')
+    if (!operations.write) operations.rejectMutation('write', { filesystem, path })
     const write = operations.write
     if (!write) throw new Error(`Tool ${toolName} does not support filesystem ${filesystem}`)
     const edits = Array.isArray(params.edits)
@@ -223,7 +254,12 @@ export interface BuildFilesystemAgentToolsOptions {
   getFilesystemBindings?: (ctx: ToolExecContext) => Promise<RuntimeBundle['filesystemBindings'] | undefined> | RuntimeBundle['filesystemBindings'] | undefined
 }
 
-function withFilesystemRouting(tool: AgentTool, bundle: RuntimeBundle, options: BuildFilesystemAgentToolsOptions = {}): AgentTool {
+function withFilesystemRouting(
+  tool: AgentTool,
+  bundle: RuntimeBundle,
+  options: BuildFilesystemAgentToolsOptions = {},
+  createPrimaryTool?: (toolName: string, binding: RuntimeFilesystemBinding | undefined) => AgentTool,
+): AgentTool {
   const ids = filesystemIds(bundle)
   const dynamicBindings = Boolean(options.getFilesystemBindings)
   return {
@@ -232,8 +268,8 @@ function withFilesystemRouting(tool: AgentTool, bundle: RuntimeBundle, options: 
     parameters: withFilesystemParameter(tool.parameters, ids, dynamicBindings),
     async execute(params, ctx) {
       const filesystem = requestedFilesystem(params)
+      const bindings = options.getFilesystemBindings ? await options.getFilesystemBindings(ctx) ?? [] : filesystemBindings(bundle)
       if (filesystem !== 'user') {
-        const bindings = options.getFilesystemBindings ? await options.getFilesystemBindings(ctx) ?? [] : filesystemBindings(bundle)
         const result = await executeBoundFilesystemTool(tool.name, filesystem, params, bindings)
         const textContent = (result.content ?? [])
           .filter(isTextContent)
@@ -242,6 +278,15 @@ function withFilesystemRouting(tool: AgentTool, bundle: RuntimeBundle, options: 
           content: textContent.length > 0 ? textContent : [{ type: 'text', text: '' }],
           isError: false,
           details: result.details,
+        }
+      }
+      if (options.getFilesystemBindings) {
+        const primaryBinding = uniqueFilesystemBinding(bindings, 'user')
+        if (createPrimaryTool) {
+          return await createPrimaryTool(tool.name, primaryBinding).execute(withoutFilesystem(params), ctx)
+        }
+        if (primaryBinding && (tool.name === 'write' || tool.name === 'edit')) {
+          await requireToolCapability(primaryBinding, boundFilesystemPath(params), 'write')
         }
       }
       return await tool.execute(withoutFilesystem(params), ctx)
@@ -292,17 +337,13 @@ function defaultFilesystemStrategyForBundle(bundle: RuntimeBundle): RuntimeFiles
     : { kind: 'host' }
 }
 
-export function buildFilesystemAgentTools(bundle: RuntimeBundle, options: BuildFilesystemAgentToolsOptions = {}): AgentTool[] {
+function buildHostFilesystemTools(
+  bundle: RuntimeBundle,
+  primaryBinding: RuntimeFilesystemBinding | undefined,
+): AgentTool[] {
   const cwd = bundle.workspace.root
-  const strategy = bundle.filesystem ?? defaultFilesystemStrategyForBundle(bundle)
-
-  if (strategy.kind === 'remote-workspace') {
-    return buildRemoteWorkspaceFilesystemAgentTools(bundle, strategy.pathOptions)
-      .map((tool) => withFilesystemRouting(tool, bundle, options))
-  }
-
   const storageRoot = getRuntimeBundleStorageRoot(bundle)
-  const ops = boundFs(storageRoot, { runtimeRoot: cwd })
+  const ops = boundFs(storageRoot, { runtimeRoot: cwd, ...(primaryBinding ? { primaryBinding } : {}) })
   return [
     adaptPiTool(createReadToolDefinition(cwd, { operations: ops.read })),
     adaptPiTool(createWriteToolDefinition(cwd, { operations: ops.write })),
@@ -310,5 +351,23 @@ export function buildFilesystemAgentTools(bundle: RuntimeBundle, options: BuildF
     adaptPiTool(createFindToolDefinition(cwd, { operations: ops.find })),
     adaptPiTool(createGrepToolDefinition(cwd, { operations: ops.grep })),
     adaptPiTool(createLsToolDefinition(cwd, { operations: ops.ls })),
-  ].map((tool) => withFilesystemRouting(tool, bundle, options))
+  ]
+}
+
+export function buildFilesystemAgentTools(bundle: RuntimeBundle, options: BuildFilesystemAgentToolsOptions = {}): AgentTool[] {
+  const strategy = bundle.filesystem ?? defaultFilesystemStrategyForBundle(bundle)
+
+  if (strategy.kind === 'remote-workspace') {
+    return buildRemoteWorkspaceFilesystemAgentTools(bundle, strategy.pathOptions)
+      .map((tool) => withFilesystemRouting(tool, bundle, options))
+  }
+
+  const primaryBinding = uniqueFilesystemBinding(filesystemBindings(bundle), 'user')
+  const tools = buildHostFilesystemTools(bundle, primaryBinding)
+  const createPrimaryTool = (toolName: string, binding: RuntimeFilesystemBinding | undefined): AgentTool => {
+    const rebound = buildHostFilesystemTools(bundle, binding).find((tool) => tool.name === toolName)
+    if (!rebound) throw new Error(`Unknown primary filesystem tool: ${toolName}`)
+    return rebound
+  }
+  return tools.map((tool) => withFilesystemRouting(tool, bundle, options, createPrimaryTool))
 }

--- a/packages/boring-bash/src/agent/tools/operations/bound.ts
+++ b/packages/boring-bash/src/agent/tools/operations/bound.ts
@@ -2,6 +2,7 @@ import { constants } from 'node:fs'
 import { access, lstat, mkdir, readFile, readdir, readlink, realpath, stat, writeFile } from 'node:fs/promises'
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 
+import type { RuntimeFilesystemBinding } from '../../runtime/types'
 import type {
   EditOperations,
   FindOperations,
@@ -23,6 +24,8 @@ export interface BoundFs {
 export interface BoundFsOptions {
   /** Agent-visible root that pi tools may pass back as absolute paths. */
   runtimeRoot?: string
+  /** Optional primary binding used only for mutation authorization/execution. */
+  primaryBinding?: RuntimeFilesystemBinding
 }
 
 function toPosixPath(value: string): string {
@@ -202,6 +205,41 @@ export function boundFs(workspaceRoot: string, opts: BoundFsOptions = {}): Bound
     if (rel.startsWith('..') || isAbsolute(rel)) return absolutePath
     return `${runtimeRoot}/${toPosixPath(rel)}`
   }
+  const binding = opts.primaryBinding
+
+  async function bindingPath(absolutePath: string): Promise<string> {
+    const normalized = toPosixPath(absolutePath)
+    if (runtimeRoot && normalized === runtimeRoot) return '.'
+    if (runtimeRoot && normalized.startsWith(`${runtimeRoot}/`)) return normalized.slice(runtimeRoot.length + 1)
+    const storagePath = toStoragePath(absolutePath)
+    const rel = toPosixPath(relative(workspaceRoot, storagePath))
+    return rel || '.'
+  }
+
+  async function requireCapability(path: string, capability: 'write' | 'create-child'): Promise<void> {
+    if (!binding) return
+    const decision = await binding.operations.resolveAccess?.({ filesystem: binding.filesystem, path })
+    const allowed = decision
+      ? decision.capabilities[capability] === true
+      : binding.access === 'readwrite'
+    if (!allowed) binding.operations.rejectMutation(capability, { filesystem: binding.filesystem, path })
+  }
+
+  async function ensureBindingDirectory(absolutePath: string): Promise<void> {
+    if (!binding) return
+    const path = await bindingPath(absolutePath)
+    try {
+      const statResult = await binding.operations.stat({ filesystem: binding.filesystem, path })
+      if (statResult.isDirectory) return
+      throw Object.assign(new Error('path already exists and is not a directory'), { code: 'EEXIST' })
+    } catch (error: unknown) {
+      if ((error as { code?: string }).code !== 'ENOENT') throw error
+    }
+    await requireCapability(path, 'create-child')
+    if (!binding.operations.mkdir) binding.operations.rejectMutation('create-child', { filesystem: binding.filesystem, path })
+    await binding.operations.mkdir?.({ filesystem: binding.filesystem, path, recursive: true })
+  }
+
   const read: ReadOperations = {
     async readFile(absolutePath: string): Promise<Buffer> {
       const storagePath = toStoragePath(absolutePath)
@@ -219,12 +257,23 @@ export function boundFs(workspaceRoot: string, opts: BoundFsOptions = {}): Bound
     async writeFile(absolutePath: string, content: string): Promise<void> {
       const storagePath = toStoragePath(absolutePath)
       await assertWithinWorkspace(workspaceRoot, storagePath)
+      if (binding) {
+        const path = await bindingPath(absolutePath)
+        await requireCapability(path, 'write')
+        if (!binding.operations.write) binding.operations.rejectMutation('write', { filesystem: binding.filesystem, path })
+        await binding.operations.write?.({ filesystem: binding.filesystem, path, content })
+        return
+      }
       await mkdir(dirname(storagePath), { recursive: true })
       await writeFile(storagePath, content)
     },
     async mkdir(dir: string): Promise<void> {
       const storagePath = toStoragePath(dir)
       await assertWithinWorkspace(workspaceRoot, storagePath)
+      if (binding) {
+        await ensureBindingDirectory(dir)
+        return
+      }
       await mkdir(storagePath, { recursive: true })
     },
   }
@@ -238,6 +287,13 @@ export function boundFs(workspaceRoot: string, opts: BoundFsOptions = {}): Bound
     async writeFile(absolutePath: string, content: string): Promise<void> {
       const storagePath = toStoragePath(absolutePath)
       await assertWithinWorkspace(workspaceRoot, storagePath)
+      if (binding) {
+        const path = await bindingPath(absolutePath)
+        await requireCapability(path, 'write')
+        if (!binding.operations.write) binding.operations.rejectMutation('write', { filesystem: binding.filesystem, path })
+        await binding.operations.write?.({ filesystem: binding.filesystem, path, content })
+        return
+      }
       await writeFile(storagePath, content)
     },
     async access(absolutePath: string): Promise<void> {

--- a/packages/boring-bash/src/server/__tests__/primaryFilesystemAccess.test.ts
+++ b/packages/boring-bash/src/server/__tests__/primaryFilesystemAccess.test.ts
@@ -1,0 +1,292 @@
+import Fastify from 'fastify'
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, test, vi } from 'vitest'
+
+import { buildFilesystemAgentTools } from '../../agent/tools/filesystem'
+import {
+  ReadonlyFilesystemMutationError,
+  type RuntimeBundle,
+  type RuntimeFilesystemBinding,
+  type RuntimeFilesystemCapability,
+} from '../../agent/runtime/types'
+import { fileRoutes } from '../routes/file'
+import { treeRoutes } from '../routes/tree'
+
+function binding(): RuntimeFilesystemBinding {
+  const files = new Map([['protected/a.txt', 'secret'], ['open.txt', 'open'], ['backup:2026.tar', 'backup'], ['records.json', '[{"id":1}]']])
+  const dirs = new Set(['.', 'protected', 'a', '.boring', 'assets/images'])
+  const access = (path: string) => path.startsWith('protected') ? 'readonly' as const : 'readwrite' as const
+  const capabilities = (path: string) => {
+    const writable = access(path) === 'readwrite'
+    return { read: true, write: writable, 'create-child': writable, delete: writable, 'move-from': writable }
+  }
+  return {
+    filesystem: 'user',
+    access: 'readwrite',
+    operations: {
+      async read({ path }) { return { content: files.get(path) ?? '', mtimeMs: 1 } },
+      async list() { return { entries: ['a.txt'] } },
+      async find() { return { paths: [] } },
+      async grep() { return { matches: [] } },
+      async stat({ path }) {
+        if (dirs.has(path)) return { isDirectory: true }
+        if (files.has(path)) return { isDirectory: false }
+        throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      },
+      async write({ path, content }) { files.set(path, content); return { mtimeMs: 2 } },
+      async writeBinary({ path, content }) { files.set(path, new TextDecoder().decode(content)); return { mtimeMs: 2 } },
+      async delete({ path }) { files.delete(path); return {} },
+      async move({ from, to }) { files.set(to, files.get(from) ?? ''); files.delete(from); return {} },
+      async mkdir({ path }) { dirs.add(path); return {} },
+      async resolveAccess({ filesystem, path }) {
+        return { filesystem, normalizedPath: path, access: access(path), capabilities: capabilities(path) }
+      },
+      rejectMutation(operation) { throw new ReadonlyFilesystemMutationError('user', operation as RuntimeFilesystemCapability) },
+    },
+  }
+}
+
+function workspace(root = '/workspace') {
+  return {
+    root,
+    runtimeContext: { runtimeCwd: root },
+    async readFile(path: string) { return path === '.boring/settings' ? JSON.stringify({ markdown: { imageUploadDir: 'assets/images' } }) : 'workspace' },
+    async writeFile() {},
+    async readBinaryFile() { return new TextEncoder().encode('raw') },
+    async writeBinaryFile() {},
+    async unlink() {},
+    async rename() {},
+    async mkdir() {},
+    async readdir(path: string) {
+      if (path === 'missing') throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+      return path === 'protected'
+        ? [{ name: 'a.txt', kind: 'file' as const }]
+        : [
+            { name: 'protected', kind: 'dir' as const },
+            { name: 'open.txt', kind: 'file' as const },
+            { name: 'backup:2026.tar', kind: 'file' as const },
+          ]
+    },
+    async stat(path: string) { return { kind: path === 'protected' ? 'dir' as const : 'file' as const, size: 3, mtimeMs: 1 } },
+  }
+}
+
+async function appWithBinding() {
+  const app = Fastify()
+  const user = binding()
+  const userWorkspace = workspace()
+  await app.register(fileRoutes, { workspace: userWorkspace, filesystemBindings: [user] })
+  await app.register(treeRoutes, { workspace: userWorkspace, filesystemBindings: [user] })
+  return { app, user }
+}
+
+describe('primary filesystem access projection', () => {
+  test('projects readonly decisions on JSON, raw, stat, and tree reads', async () => {
+    const { app } = await appWithBinding()
+    const file = await app.inject({ method: 'GET', url: '/api/v1/files?path=protected/a.txt' })
+    expect(file.json()).toMatchObject({ content: 'secret', access: 'readonly', capabilities: { write: false } })
+    const raw = await app.inject({ method: 'GET', url: '/api/v1/files/raw?path=protected/a.txt' })
+    expect(raw.headers['x-boring-filesystem-access']).toBe('readonly')
+    const stat = await app.inject({ method: 'GET', url: '/api/v1/stat?path=protected/a.txt' })
+    expect(stat.json()).toMatchObject({ size: 3, mtimeMs: 1, access: 'readonly', capabilities: { delete: false } })
+    const tree = await app.inject({ method: 'GET', url: '/api/v1/tree?path=protected' })
+    expect(tree.json()).toMatchObject({
+      access: 'readonly',
+      capabilities: { 'create-child': false },
+      entries: [{ path: 'protected/a.txt', access: 'readonly', capabilities: { write: false } }],
+    })
+    await app.close()
+  })
+
+  test('serializes stable readonly errors and permits writable siblings', async () => {
+    const { app, user } = await appWithBinding()
+    const write = vi.spyOn(user.operations, 'write')
+    const denied = await app.inject({ method: 'POST', url: '/api/v1/files', payload: { path: 'protected/a.txt', content: 'x' } })
+    expect(denied.statusCode).toBe(403)
+    expect(denied.json()).toEqual({ error: { code: 'readonly', message: 'user binding is readonly' } })
+    expect(write).not.toHaveBeenCalled()
+    const allowed = await app.inject({ method: 'POST', url: '/api/v1/files', payload: { path: 'open.txt', content: 'changed' } })
+    expect(allowed.statusCode).toBe(200)
+    expect(write).toHaveBeenCalledOnce()
+    await app.close()
+  })
+
+  test('routes real Pi read/write tools through the user binding capabilities', async () => {
+    const user = binding()
+    const write = vi.spyOn(user.operations, 'write')
+    const root = await mkdtemp(join(tmpdir(), 'boring-pi-access-'))
+    await mkdir(join(root, 'protected'), { recursive: true })
+    await mkdir(join(root, 'a'), { recursive: true })
+    await writeFile(join(root, 'protected/a.txt'), 'secret')
+    await writeFile(join(root, 'open.txt'), 'open')
+    const bundle = {
+      storageRoot: root,
+      workspace: workspace(root),
+      sandbox: { placement: 'local' },
+      fileSearch: {},
+      filesystemBindings: [user],
+    } as unknown as RuntimeBundle
+    const tools = buildFilesystemAgentTools(bundle)
+    const read = tools.find((tool) => tool.name === 'read')!
+    const find = tools.find((tool) => tool.name === 'find')!
+    const grep = tools.find((tool) => tool.name === 'grep')!
+    const writeTool = tools.find((tool) => tool.name === 'write')!
+    const boundFind = vi.spyOn(user.operations, 'find')
+    const boundGrep = vi.spyOn(user.operations, 'grep')
+    const ctx = { abortSignal: new AbortController().signal, toolCallId: 'access-test' }
+    await expect(read.execute({ path: 'protected/a.txt' }, ctx)).resolves.toMatchObject({ content: [{ text: 'secret' }] })
+    await expect(find.execute({ path: '.', pattern: '*.txt' }, ctx)).resolves.toMatchObject({ isError: false })
+    await expect(grep.execute({ path: '.', pattern: 'secret' }, ctx)).resolves.toMatchObject({ isError: false })
+    expect(boundFind).not.toHaveBeenCalled()
+    expect(boundGrep).not.toHaveBeenCalled()
+    await expect(writeTool.execute({ path: 'protected/a.txt', content: 'x' }, ctx)).rejects.toMatchObject({ code: 'readonly', filesystem: 'user', operation: 'write' })
+    await expect(writeTool.execute({ path: 'a/sibling.txt', content: 'changed' }, ctx)).resolves.toMatchObject({ isError: false })
+    expect(write).toHaveBeenCalledOnce()
+    const filesystemSchema = (read.parameters as { properties: { filesystem: { enum: string[] } } }).properties.filesystem
+    expect(filesystemSchema.enum).toEqual(['user'])
+  })
+
+  test('uses the per-request governance-composed user binding for real Pi tools', async () => {
+    const host = binding()
+    const governanceBase = binding()
+    const governance: RuntimeFilesystemBinding = {
+      ...governanceBase,
+      access: 'readonly',
+      operations: {
+        ...governanceBase.operations,
+        resolveAccess: vi.fn(async ({ filesystem, path }) => ({
+          filesystem,
+          normalizedPath: path,
+          access: 'readonly' as const,
+          capabilities: { read: true, write: false, 'create-child': false, delete: false, 'move-from': false },
+        })),
+      },
+    }
+    const hostWrite = vi.spyOn(host.operations, 'write')
+    const governanceWrite = vi.spyOn(governance.operations, 'write')
+    const root = await mkdtemp(join(tmpdir(), 'boring-pi-governance-'))
+    await writeFile(join(root, 'open.txt'), 'open')
+    const bundle = {
+      storageRoot: root,
+      workspace: workspace(root),
+      sandbox: { placement: 'local' },
+      fileSearch: {},
+      filesystemBindings: [host],
+    } as unknown as RuntimeBundle
+    const tools = buildFilesystemAgentTools(bundle, { getFilesystemBindings: async () => [governance] })
+    const writeTool = tools.find((tool) => tool.name === 'write')!
+    const ctx = { abortSignal: new AbortController().signal, toolCallId: 'governance-test' }
+    await expect(writeTool.execute({ path: 'open.txt', content: 'denied' }, ctx)).rejects.toMatchObject({
+      code: 'readonly',
+      filesystem: 'user',
+      operation: 'write',
+    })
+    expect(hostWrite).not.toHaveBeenCalled()
+    expect(governanceWrite).not.toHaveBeenCalled()
+  })
+
+  test('allows legal colon filenames in files and per-entry tree projections', async () => {
+    const { app, user } = await appWithBinding()
+    const write = vi.spyOn(user.operations, 'write')
+    const file = await app.inject({ method: 'GET', url: '/api/v1/files?path=backup%3A2026.tar' })
+    expect(file.statusCode).toBe(200)
+    expect(file.json()).toMatchObject({ content: 'backup', access: 'readwrite' })
+    const tree = await app.inject({ method: 'GET', url: '/api/v1/tree?path=.' })
+    expect(tree.statusCode).toBe(200)
+    expect(tree.json().entries).toContainEqual(expect.objectContaining({ path: 'backup:2026.tar', access: 'readwrite' }))
+    const updated = await app.inject({ method: 'POST', url: '/api/v1/files', payload: { path: 'backup:2026.tar', content: 'next' } })
+    expect(updated.statusCode).toBe(200)
+    expect(write).toHaveBeenCalledWith(expect.objectContaining({ path: 'backup:2026.tar' }))
+    await app.close()
+  })
+
+  test('preserves writable siblings when createDirs sees an existing mixed ancestor', async () => {
+    const { app, user } = await appWithBinding()
+    const mkdirOperation = vi.spyOn(user.operations, 'mkdir')
+    const write = vi.spyOn(user.operations, 'write')
+    const response = await app.inject({
+      method: 'POST',
+      url: '/api/v1/files',
+      payload: { path: 'a/sibling.txt', content: 'ok', createDirs: true },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(mkdirOperation).not.toHaveBeenCalled()
+    expect(write).toHaveBeenCalled()
+    await app.close()
+  })
+
+  test('projects records/settings and executes settings/upload mutations through the binding', async () => {
+    const { app, user } = await appWithBinding()
+    const write = vi.spyOn(user.operations, 'write')
+    const writeBinary = vi.spyOn(user.operations, 'writeBinary')
+    const records = await app.inject({ method: 'GET', url: '/api/v1/files/records?path=records.json' })
+    expect(records.json()).toMatchObject({ access: 'readwrite', capabilities: { write: true }, rows: [{ id: 1 }] })
+    const settings = await app.inject({ method: 'GET', url: '/api/v1/workspace-settings' })
+    expect(settings.json()).toMatchObject({ access: 'readwrite', capabilities: { write: true } })
+    const put = await app.inject({ method: 'PUT', url: '/api/v1/workspace-settings', payload: { settings: { markdown: { imageUploadDir: 'assets/images' } } } })
+    expect(put.statusCode).toBe(200)
+    expect(write).toHaveBeenCalledWith(expect.objectContaining({ path: '.boring/settings' }))
+    const upload = await app.inject({ method: 'POST', url: '/api/v1/files/upload', payload: { filename: 'x.png', contentType: 'image/png', contentBase64: 'eA==' } })
+    expect(upload.statusCode).toBe(200)
+    expect(writeBinary).toHaveBeenCalled()
+    await app.close()
+  })
+
+  test('keeps tree not-found classification with a primary binding', async () => {
+    const { app } = await appWithBinding()
+    const response = await app.inject({ method: 'GET', url: '/api/v1/tree?path=missing' })
+    expect(response.statusCode).toBe(404)
+    expect(response.json()).toEqual({ error: { code: 'not_found', message: 'directory not found: missing' } })
+    await app.close()
+  })
+
+  test('maps invalid access-projection paths to path_rejected', async () => {
+    const { app, user } = await appWithBinding()
+    user.operations.resolveAccess = vi.fn(async () => { throw Object.assign(new Error('invalid'), { code: 'RUNTIME_READONLY_FILESYSTEM_POLICY_INVALID' }) })
+    const response = await app.inject({ method: 'GET', url: '/api/v1/files?path=/etc/passwd' })
+    expect(response.statusCode).toBe(403)
+    expect(response.json()).toEqual({ error: { code: 'path_rejected', message: 'path traversal rejected' } })
+    await app.close()
+  })
+
+  test('preserves readonlySkillFiles compatibility and confines absolute reads', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'boring-skill-root-'))
+    const allowed = join(root, '.pi/agent/skills/demo/SKILL.md')
+    await mkdir(join(root, '.pi/agent/skills/demo'), { recursive: true })
+    await writeFile(allowed, '# allowed')
+    const outsideRoot = await mkdtemp(join(tmpdir(), 'boring-skill-outside-'))
+    const outside = join(outsideRoot, '.pi/agent/skills/demo/SKILL.md')
+    await mkdir(join(outsideRoot, '.pi/agent/skills/demo'), { recursive: true })
+    await writeFile(outside, '# denied')
+    const app = Fastify()
+    await app.register(fileRoutes, { workspace: workspace(root), filesystemBindings: [binding()] })
+    const read = await app.inject({ method: 'GET', url: `/api/v1/files?path=${encodeURIComponent(allowed)}` })
+    expect(read.statusCode).toBe(200)
+    expect(read.json()).toMatchObject({ content: '# allowed', access: 'readonly' })
+    const denied = await app.inject({ method: 'GET', url: `/api/v1/files?path=${encodeURIComponent(outside)}` })
+    expect(denied.statusCode).toBe(403)
+    expect(denied.json()).toMatchObject({ error: { code: 'path_rejected' } })
+    await app.close()
+  })
+
+  test('preserves omission compatibility without filesystem bindings', async () => {
+    const app = Fastify()
+    await app.register(fileRoutes, { workspace: workspace() })
+    const response = await app.inject({ method: 'GET', url: '/api/v1/files?path=open.txt' })
+    expect(response.statusCode).toBe(200)
+    expect(response.json()).toMatchObject({ content: 'workspace', access: 'readwrite' })
+    await app.close()
+  })
+
+  test('checks both move footprints before invoking rename', async () => {
+    const { app, user } = await appWithBinding()
+    const move = vi.spyOn(user.operations, 'move')
+    const response = await app.inject({ method: 'POST', url: '/api/v1/files/move', payload: { from: 'open.txt', to: 'protected/new.txt' } })
+    expect(response.statusCode).toBe(403)
+    expect(response.json()).toEqual({ error: { code: 'readonly', message: 'user binding is readonly' } })
+    expect(move).not.toHaveBeenCalled()
+    await app.close()
+  })
+})

--- a/packages/boring-bash/src/server/routes/bindingAccess.ts
+++ b/packages/boring-bash/src/server/routes/bindingAccess.ts
@@ -1,0 +1,60 @@
+import type {
+  RuntimeFilesystemAccessDecision,
+  RuntimeFilesystemBinding,
+  RuntimeFilesystemCapability,
+} from '../../agent/runtime/types'
+
+function scalarDecision(binding: RuntimeFilesystemBinding, path: string): RuntimeFilesystemAccessDecision {
+  const writable = binding.access === 'readwrite'
+  return {
+    filesystem: binding.filesystem,
+    normalizedPath: path,
+    access: binding.access,
+    capabilities: {
+      read: true,
+      write: writable,
+      'create-child': writable,
+      delete: writable,
+      'move-from': writable,
+    },
+  }
+}
+
+export async function resolveBindingAccess(
+  binding: RuntimeFilesystemBinding,
+  path: string,
+): Promise<RuntimeFilesystemAccessDecision> {
+  try {
+    return await binding.operations.resolveAccess?.({ filesystem: binding.filesystem, path })
+      ?? scalarDecision(binding, path)
+  } catch (error: unknown) {
+    if ((error as { code?: string }).code === 'RUNTIME_READONLY_FILESYSTEM_POLICY_INVALID') {
+      throw Object.assign(new Error('path traversal rejected'), { code: 'EPERM', statusCode: 403 })
+    }
+    throw error
+  }
+}
+
+export async function requireBindingCapability(
+  binding: RuntimeFilesystemBinding,
+  path: string,
+  capability: RuntimeFilesystemCapability,
+): Promise<RuntimeFilesystemAccessDecision> {
+  const decision = await resolveBindingAccess(binding, path)
+  if (!decision.capabilities[capability]) {
+    if (!binding.operations.resolveAccess && binding.access === 'readonly') {
+      throw Object.assign(new Error(`${binding.filesystem} binding is readonly`), {
+        code: 'readonly',
+        statusCode: 403,
+        filesystem: binding.filesystem,
+        operation: capability,
+      })
+    }
+    binding.operations.rejectMutation(capability, { filesystem: binding.filesystem, path })
+  }
+  return decision
+}
+
+export function accessProjection(decision: RuntimeFilesystemAccessDecision) {
+  return { access: decision.access, capabilities: decision.capabilities }
+}

--- a/packages/boring-bash/src/server/routes/file.ts
+++ b/packages/boring-bash/src/server/routes/file.ts
@@ -20,6 +20,7 @@ import {
   parseFileRecordsRequest,
 } from './fileRecords'
 import { isReadonlySkillFilePath, readReadonlySkillFile, statReadonlySkillFile } from './readonlySkillFiles'
+import { accessProjection, requireBindingCapability, resolveBindingAccess } from './bindingAccess'
 
 const log = createLogger('boring/workspace-settings')
 
@@ -111,6 +112,11 @@ function classifyError(
 
   const statusCode = (err as { statusCode?: unknown })?.statusCode
   const stableCode = (err as { code?: unknown })?.code
+  if (statusCode === 403 && stableCode === ERROR_CODE_READONLY) {
+    return reply.code(403).send({
+      error: { code: ERROR_CODE_READONLY, message },
+    })
+  }
   if (typeof statusCode === 'number' && statusCode >= 400 && statusCode < 600) {
     const details = (err as { details?: unknown })?.details
     const conflictDetails = stableCode === ERROR_CODE_CONFLICT && details && typeof details === 'object' && !Array.isArray(details)
@@ -203,14 +209,33 @@ function parseWorkspaceSettings(raw: string): BoringWorkspaceSettings {
   }
 }
 
-async function readWorkspaceSettings(workspace: Workspace): Promise<BoringWorkspaceSettings> {
+async function readWorkspaceSettings(
+  workspace: Workspace,
+  binding?: RuntimeFilesystemBinding,
+): Promise<BoringWorkspaceSettings> {
   try {
-    return parseWorkspaceSettings(await workspace.readFile(BORING_SETTINGS_PATH))
+    const raw = binding
+      ? (await binding.operations.read({ filesystem: binding.filesystem, path: BORING_SETTINGS_PATH })).content
+      : await workspace.readFile(BORING_SETTINGS_PATH)
+    return parseWorkspaceSettings(raw)
   } catch (error) {
     const code = (error as NodeJS.ErrnoException)?.code
     if (code === 'ENOENT') return defaultWorkspaceSettings()
     throw error
   }
+}
+
+async function ensureBindingDirectory(binding: RuntimeFilesystemBinding, path: string): Promise<void> {
+  try {
+    const stat = await binding.operations.stat({ filesystem: binding.filesystem, path })
+    if (stat.isDirectory) return
+    throw Object.assign(new Error('path already exists and is not a directory'), { code: 'EEXIST' })
+  } catch (error: unknown) {
+    if ((error as { code?: string }).code !== 'ENOENT') throw error
+  }
+  await requireBindingCapability(binding, path, 'create-child')
+  if (!binding.operations.mkdir) binding.operations.rejectMutation('create-child', { filesystem: binding.filesystem, path })
+  await binding.operations.mkdir?.({ filesystem: binding.filesystem, path, recursive: true })
 }
 
 function normalizeUploadDir(value: unknown): string | null {
@@ -281,16 +306,6 @@ function sendValidationError(reply: FastifyReply, message: string, field?: strin
   })
 }
 
-function sendFilesystemBindingMutationDenied(
-  reply: FastifyReply,
-  filesystem: string,
-  access: RuntimeFilesystemBinding['access'],
-): FastifyReply {
-  return reply.code(403).send({
-    error: { code: ERROR_CODE_READONLY, message: `${filesystem} binding is ${access}` },
-  })
-}
-
 export function fileRoutes(
   app: FastifyInstance,
   opts: {
@@ -314,7 +329,13 @@ export function fileRoutes(
   }
 
   async function resolveFilesystemBinding(request: FastifyRequest, filesystem: string): Promise<RuntimeFilesystemBinding | undefined> {
-    return (await resolveFilesystemBindings(request)).find((binding) => binding.filesystem === filesystem)
+    const matches = (await resolveFilesystemBindings(request)).filter((binding) => binding.filesystem === filesystem)
+    if (matches.length > 1) throw new Error(`duplicate filesystem binding: ${filesystem}`)
+    return matches[0]
+  }
+
+  async function resolvePrimaryBinding(request: FastifyRequest): Promise<RuntimeFilesystemBinding | undefined> {
+    return resolveFilesystemBinding(request, USER_FILESYSTEM_ID)
   }
 
   app.get('/api/v1/files/raw', async (request, reply) => {
@@ -329,11 +350,13 @@ export function fileRoutes(
         if (!binding) return sendNotFoundOrDenied(reply)
         const result = await binding.operations.read({ filesystem, path })
         const bytes = Buffer.from(result.content, 'utf8')
+        const decision = await resolveBindingAccess(binding, path)
         return reply
           .header('content-type', contentTypeForPath(path))
           .header('content-length', String(bytes.byteLength))
           .header('cache-control', 'no-store')
           .header('x-content-type-options', 'nosniff')
+          .header('X-Boring-Filesystem-Access', decision.access)
           .send(bytes)
       } catch {
         return sendNotFoundOrDenied(reply)
@@ -342,6 +365,8 @@ export function fileRoutes(
 
     try {
       const workspace = await resolveWorkspace(request)
+      const binding = await resolvePrimaryBinding(request)
+      const decision = binding ? await resolveBindingAccess(binding, path) : undefined
       if (!workspace.readBinaryFile) {
         return reply.code(501).send({
           error: { code: ERROR_CODE_INTERNAL, message: 'workspace does not support binary reads' },
@@ -359,6 +384,7 @@ export function fileRoutes(
         .header('content-length', String(bytes.byteLength))
         .header('cache-control', 'no-store')
         .header('x-content-type-options', 'nosniff')
+        .header('X-Boring-Filesystem-Access', decision?.access ?? 'readwrite')
         .send(Buffer.from(bytes))
     } catch (err) {
       return classifyError(err, reply, 'file')
@@ -369,6 +395,7 @@ export function fileRoutes(
     try {
       const parsed = parseFileRecordsRequest(request.query as Record<string, unknown>)
       const workspace = await resolveWorkspace(request)
+      const binding = await resolvePrimaryBinding(request)
       const stat = await workspace.stat(parsed.path)
       if (stat.kind !== 'file') {
         return sendValidationError(reply, 'path is not a file', 'path')
@@ -376,18 +403,23 @@ export function fileRoutes(
       if (stat.size > MAX_RECORD_FILE_BYTES) {
         return sendValidationError(reply, 'records file is too large', 'path')
       }
-      const content = await workspace.readFile(parsed.path)
+      const content = binding
+        ? (await binding.operations.read({ filesystem: binding.filesystem, path: parsed.path })).content
+        : await workspace.readFile(parsed.path)
       if (Buffer.byteLength(content, 'utf8') > MAX_RECORD_FILE_BYTES) {
         return sendValidationError(reply, 'records file is too large', 'path')
       }
-      return buildFileRecordsResult({
-        path: parsed.path,
-        content,
-        mtimeMs: stat.mtimeMs,
-        offset: parsed.offset,
-        limit: parsed.limit,
-        q: parsed.q,
-      })
+      return {
+        ...buildFileRecordsResult({
+          path: parsed.path,
+          content,
+          mtimeMs: stat.mtimeMs,
+          offset: parsed.offset,
+          limit: parsed.limit,
+          q: parsed.q,
+        }),
+        ...(binding ? accessProjection(await resolveBindingAccess(binding, parsed.path)) : { access: 'readwrite' as const }),
+      }
     } catch (err) {
       if (err instanceof FileRecordsValidationError) {
         return sendValidationError(reply, err.message, err.field)
@@ -422,7 +454,12 @@ export function fileRoutes(
             error: { code: ERROR_CODE_VALIDATION_ERROR, message: 'path is not a file', field: 'path' },
           })
         }
-        return { content, mtimeMs: stat.mtimeMs }
+        return { content, mtimeMs: stat.mtimeMs, access: 'readonly' }
+      }
+      const binding = await resolvePrimaryBinding(request)
+      if (binding) {
+        const result = await binding.operations.read({ filesystem, path })
+        return { content: result.content, mtimeMs: result.mtimeMs, ...accessProjection(await resolveBindingAccess(binding, path)) }
       }
       if (workspace.readFileWithStat) {
         const { content, stat } = await workspace.readFileWithStat(path)
@@ -461,7 +498,7 @@ const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
       try {
         const binding = await resolveFilesystemBinding(request, filesystem)
         if (!binding) return sendNotFoundOrDenied(reply)
-        if (binding.access !== 'readwrite') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
+        await requireBindingCapability(binding, path, 'write')
         if (!binding.operations.write) {
           return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} write operation is unavailable` } })
         }
@@ -478,6 +515,17 @@ const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
     }
 
     try {
+      const binding = await resolvePrimaryBinding(request)
+      if (binding) {
+        await requireBindingCapability(binding, path, 'write')
+        if (!binding.operations.write) return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: 'user write operation is unavailable' } })
+        if (body.createDirs) {
+          const dir = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : undefined
+          if (dir) await ensureBindingDirectory(binding, dir)
+        }
+        const result = await binding.operations.write({ filesystem, path, content: body.content, ...(expectedMtimeMs !== null ? { expectedMtimeMs } : {}) })
+        return shouldReturnMtimeMs ? { ok: true, mtimeMs: result.mtimeMs } : { ok: true }
+      }
       const workspace = await resolveWorkspace(request)
       if (expectedMtimeMs !== null) {
         try {
@@ -543,7 +591,8 @@ const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
 
     try {
       const workspace = await resolveWorkspace(request)
-      const settings = await readWorkspaceSettings(workspace)
+      const binding = await resolvePrimaryBinding(request)
+      const settings = await readWorkspaceSettings(workspace, binding)
       const isImage = contentType.startsWith('image/')
       const dir = isImage
         ? normalizeUploadDir(body.directory) ?? normalizeUploadDir(settings.markdown?.imageUploadDir) ?? DEFAULT_MARKDOWN_IMAGE_UPLOAD_DIR
@@ -552,6 +601,7 @@ const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
       const base = basenameForUpload(filename)
       const unique = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
       const path = `${dir}/${base}-${unique}.${ext}`
+      if (binding) await requireBindingCapability(binding, path, 'write')
       // Check base64 length before allocating — base64 is ~4/3 the size of raw bytes.
       const estimatedBytes = Math.ceil(contentBase64.length * 0.75)
       if (estimatedBytes === 0 || estimatedBytes > MAX_UPLOAD_BYTES) {
@@ -561,13 +611,19 @@ const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
       }
       const bytes = Buffer.from(contentBase64, 'base64')
 
-      await workspace.mkdir(dir, { recursive: true })
-      const stat = workspace.writeBinaryFileWithStat
-        ? await workspace.writeBinaryFileWithStat(path, bytes)
-        : await (async () => {
-            if (!workspace.writeBinaryFile) {
-              throw new Error('workspace does not support binary uploads')
+      const stat = binding
+        ? await (async () => {
+            await ensureBindingDirectory(binding, dir)
+            if (!binding.operations.writeBinary) {
+              throw Object.assign(new Error('user binary write operation is unavailable'), { statusCode: 501, code: ERROR_CODE_INTERNAL })
             }
+            const result = await binding.operations.writeBinary({ filesystem: binding.filesystem, path, content: bytes })
+            return { kind: 'file' as const, mtimeMs: result.mtimeMs }
+          })()
+        : await (async () => {
+            await workspace.mkdir(dir, { recursive: true })
+            if (workspace.writeBinaryFileWithStat) return await workspace.writeBinaryFileWithStat(path, bytes)
+            if (!workspace.writeBinaryFile) throw new Error('workspace does not support binary uploads')
             await workspace.writeBinaryFile(path, bytes)
             return await workspace.stat(path)
           })()
@@ -598,7 +654,11 @@ const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
   app.get('/api/v1/workspace-settings', async (request, reply) => {
     try {
       const workspace = await resolveWorkspace(request)
-      return { settings: await readWorkspaceSettings(workspace) }
+      const binding = await resolvePrimaryBinding(request)
+      return {
+        settings: await readWorkspaceSettings(workspace, binding),
+        ...(binding ? accessProjection(await resolveBindingAccess(binding, BORING_SETTINGS_PATH)) : { access: 'readwrite' as const }),
+      }
     } catch (err) {
       return classifyError(err, reply, 'settings')
     }
@@ -617,7 +677,9 @@ const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
 
     try {
       const workspace = await resolveWorkspace(request)
-      const current = await readWorkspaceSettings(workspace)
+      const binding = await resolvePrimaryBinding(request)
+      if (binding) await requireBindingCapability(binding, BORING_SETTINGS_PATH, 'write')
+      const current = await readWorkspaceSettings(workspace, binding)
       const next: BoringWorkspaceSettings = {
         ...current,
         markdown: {
@@ -625,8 +687,15 @@ const expectedMtimeMs = typeof body.expectedMtimeMs === 'number'
           imageUploadDir,
         },
       }
-      await workspace.mkdir('.boring', { recursive: true })
-      await workspace.writeFile(BORING_SETTINGS_PATH, `${JSON.stringify(next, null, 2)}\n`)
+      const content = `${JSON.stringify(next, null, 2)}\n`
+      if (binding) {
+        await ensureBindingDirectory(binding, '.boring')
+        if (!binding.operations.write) binding.operations.rejectMutation('write', { filesystem: binding.filesystem, path: BORING_SETTINGS_PATH })
+        await binding.operations.write?.({ filesystem: binding.filesystem, path: BORING_SETTINGS_PATH, content })
+      } else {
+        await workspace.mkdir('.boring', { recursive: true })
+        await workspace.writeFile(BORING_SETTINGS_PATH, content)
+      }
       return { settings: next }
     } catch (err) {
       return classifyError(err, reply, 'settings')
@@ -642,7 +711,7 @@ if (filesystem !== USER_FILESYSTEM_ID) {
       try {
         const binding = await resolveFilesystemBinding(request, filesystem)
         if (!binding) return sendNotFoundOrDenied(reply)
-        if (binding.access !== 'readwrite') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
+        await requireBindingCapability(binding, path, 'delete')
         if (!binding.operations.delete) {
           return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} delete operation is unavailable` } })
         }
@@ -654,8 +723,14 @@ if (filesystem !== USER_FILESYSTEM_ID) {
     }
 
     try {
-      const workspace = await resolveWorkspace(request)
-      await workspace.unlink(path)
+      const binding = await resolvePrimaryBinding(request)
+      if (binding) {
+        await requireBindingCapability(binding, path, 'delete')
+        if (!binding.operations.delete) return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: 'user delete operation is unavailable' } })
+        await binding.operations.delete({ filesystem, path })
+      } else {
+        await (await resolveWorkspace(request)).unlink(path)
+      }
       return { ok: true }
     } catch (err) {
       return classifyError(err, reply, 'file')
@@ -673,7 +748,8 @@ if (filesystem !== USER_FILESYSTEM_ID) {
       try {
         const binding = await resolveFilesystemBinding(request, filesystem)
         if (!binding) return sendNotFoundOrDenied(reply)
-        if (binding.access !== 'readwrite') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
+        await requireBindingCapability(binding, from, 'move-from')
+        await requireBindingCapability(binding, to, 'create-child')
         if (!binding.operations.move) {
           return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} move operation is unavailable` } })
         }
@@ -685,8 +761,15 @@ if (filesystem !== USER_FILESYSTEM_ID) {
     }
 
     try {
-      const workspace = await resolveWorkspace(request)
-      await workspace.rename(from, to)
+      const binding = await resolvePrimaryBinding(request)
+      if (binding) {
+        await requireBindingCapability(binding, from, 'move-from')
+        await requireBindingCapability(binding, to, 'create-child')
+        if (!binding.operations.move) return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: 'user move operation is unavailable' } })
+        await binding.operations.move({ filesystem, from, to })
+      } else {
+        await (await resolveWorkspace(request)).rename(from, to)
+      }
       return { ok: true }
     } catch (err) {
       return classifyError(err, reply, 'file')
@@ -704,7 +787,7 @@ if (filesystem !== USER_FILESYSTEM_ID) {
       try {
         const binding = await resolveFilesystemBinding(request, filesystem)
         if (!binding) return sendNotFoundOrDenied(reply)
-        if (binding.access !== 'readwrite') return sendFilesystemBindingMutationDenied(reply, filesystem, binding.access)
+        await requireBindingCapability(binding, path, 'create-child')
         if (!binding.operations.mkdir) {
           return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: `${filesystem} mkdir operation is unavailable` } })
         }
@@ -716,8 +799,14 @@ if (filesystem !== USER_FILESYSTEM_ID) {
     }
 
     try {
-      const workspace = await resolveWorkspace(request)
-      await workspace.mkdir(path, { recursive })
+      const binding = await resolvePrimaryBinding(request)
+      if (binding) {
+        await requireBindingCapability(binding, path, 'create-child')
+        if (!binding.operations.mkdir) return reply.code(501).send({ error: { code: ERROR_CODE_INTERNAL, message: 'user mkdir operation is unavailable' } })
+        await binding.operations.mkdir({ filesystem, path, recursive })
+      } else {
+        await (await resolveWorkspace(request)).mkdir(path, { recursive })
+      }
       return { ok: true }
     } catch (err) {
       return classifyError(err, reply, 'directory')
@@ -744,10 +833,15 @@ if (filesystem !== USER_FILESYSTEM_ID) {
     try {
       const workspace = await resolveWorkspace(request)
       if (isReadonlySkillFilePath(path)) {
-        return await statReadonlySkillFile(path, readonlySkillRoots(workspace))
+        return { ...(await statReadonlySkillFile(path, readonlySkillRoots(workspace))), access: 'readonly' }
+      }
+      const binding = await resolvePrimaryBinding(request)
+      if (binding) {
+        const stat = await workspace.stat(path)
+        return { ...stat, ...accessProjection(await resolveBindingAccess(binding, path)) }
       }
       const stat = await workspace.stat(path)
-      return stat
+      return { ...stat, access: 'readwrite' as const }
     } catch (err) {
       return classifyError(err, reply, 'path')
     }

--- a/packages/boring-bash/src/server/routes/tree.ts
+++ b/packages/boring-bash/src/server/routes/tree.ts
@@ -9,6 +9,7 @@ import {
   ERROR_CODE_INTERNAL,
 } from './errorCodes'
 import { ERROR_CODE_NOT_FOUND_OR_DENIED } from './file'
+import { accessProjection, resolveBindingAccess } from './bindingAccess'
 
 const MAX_DEPTH = 10
 const MAX_ENTRIES = 5000
@@ -17,6 +18,8 @@ interface TreeEntry {
   name: string
   kind: 'file' | 'dir'
   path: string
+  access?: 'readonly' | 'readwrite'
+  capabilities?: Awaited<ReturnType<typeof resolveBindingAccess>>['capabilities']
 }
 
 interface TreeQuerystring {
@@ -158,7 +161,40 @@ export function treeRoutes(
     const bindings = opts.getFilesystemBindings
       ? await opts.getFilesystemBindings(request) ?? []
       : opts.filesystemBindings ?? []
-    return bindings.find((binding) => binding.filesystem === filesystem)
+    const matches = bindings.filter((binding) => binding.filesystem === filesystem)
+    if (matches.length > 1) throw new Error(`duplicate filesystem binding: ${filesystem}`)
+    return matches[0]
+  }
+
+  async function projectEntries(binding: RuntimeFilesystemBinding, entries: TreeEntry[]): Promise<TreeEntry[]> {
+    return await Promise.all(entries.map(async (entry) => ({
+      ...entry,
+      ...accessProjection(await resolveBindingAccess(binding, entry.path)),
+    })))
+  }
+
+  function classifyTreeError(err: unknown, reply: FastifyReply, dir: string): FastifyReply {
+    const message = err instanceof Error ? err.message : 'readdir failed'
+    const code = (err as NodeJS.ErrnoException)?.code
+
+    if (code === 'EPERM' || message.includes('traversal') || message.includes('EPERM')) {
+      return reply.code(403).send({ error: { code: ERROR_CODE_PATH_REJECTED, message: 'path traversal rejected' } })
+    }
+    if (code === 'ENOENT' || message.includes('ENOENT')) {
+      return reply.code(404).send({ error: { code: ERROR_CODE_NOT_FOUND, message: `directory not found: ${dir}` } })
+    }
+    const statusCode = (err as { statusCode?: unknown })?.statusCode
+    const stableCode = (err as { code?: unknown })?.code
+    if (typeof statusCode === 'number' && statusCode >= 400 && statusCode < 600) {
+      return reply.code(statusCode).send({
+        error: {
+          code: typeof stableCode === 'string' ? stableCode : ERROR_CODE_INTERNAL,
+          message,
+          details: (err as { details?: unknown })?.details,
+        },
+      })
+    }
+    return reply.code(500).send({ error: { code: ERROR_CODE_INTERNAL, message } })
   }
 
   app.get(
@@ -182,56 +218,29 @@ export function treeRoutes(
       const recursive = request.query.recursive === 'true'
       const filesystem = requestedFilesystem(request.query.filesystem)
 
-      if (filesystem !== 'user') {
+      const binding = await resolveFilesystemBinding(request, filesystem)
+      if (binding && filesystem !== 'user') {
         try {
-          const binding = await resolveFilesystemBinding(request, filesystem)
-          if (!binding) return sendNotFoundOrDenied(reply)
-          return { entries: await listBoundTree(binding, dir, recursive) }
+          const entries = await listBoundTree(binding, dir, recursive)
+          return {
+            entries: await projectEntries(binding, entries),
+            ...accessProjection(await resolveBindingAccess(binding, dir)),
+          }
         } catch {
           return sendNotFoundOrDenied(reply)
         }
       }
+      if (filesystem !== 'user') return sendNotFoundOrDenied(reply)
 
       try {
-
         const workspace = await resolveWorkspace(request)
         const entries = await listTree(workspace, dir, recursive)
-        return { entries }
+        return {
+          entries: binding ? await projectEntries(binding, entries) : entries,
+          ...(binding ? accessProjection(await resolveBindingAccess(binding, dir)) : { access: 'readwrite' as const }),
+        }
       } catch (err) {
-        const message = err instanceof Error ? err.message : 'readdir failed'
-        const code = (err as NodeJS.ErrnoException)?.code
-
-        if (code === 'EPERM' || message.includes('traversal') || message.includes('EPERM')) {
-          return reply.code(403).send({
-            error: { code: ERROR_CODE_PATH_REJECTED, message: 'path traversal rejected' },
-          })
-        }
-
-        if (code === 'ENOENT' || message.includes('ENOENT')) {
-          return reply.code(404).send({
-            error: { code: ERROR_CODE_NOT_FOUND, message: `directory not found: ${dir}` },
-          })
-        }
-
-        const statusCode = (err as { statusCode?: unknown })?.statusCode
-        const stableCode = (err as { code?: unknown })?.code
-        if (
-          typeof statusCode === 'number' &&
-          statusCode >= 400 &&
-          statusCode < 600
-        ) {
-          return reply.code(statusCode).send({
-            error: {
-              code: typeof stableCode === 'string' ? stableCode : ERROR_CODE_INTERNAL,
-              message,
-              details: (err as { details?: unknown })?.details,
-            },
-          })
-        }
-
-        return reply.code(500).send({
-          error: { code: ERROR_CODE_INTERNAL, message },
-        })
+        return classifyTreeError(err, reply, dir)
       }
     },
   )


### PR DESCRIPTION
## Summary

Implements #942 Slice 942.3 / `wt-391-forward-f5p.3`:

- projects the final effective `user` filesystem binding through file/tree/settings/upload/records routes;
- preserves Pi file-tool factories while enforcing request-scoped host∩governance capabilities through Operations;
- adds stable per-path `access` and named capabilities, per-entry tree projection, and exact raw `X-Boring-Filesystem-Access`;
- enforces write/create/delete/move-source/move-destination footprints with writable mixed-ancestor siblings;
- serializes readonly denials as the fixed 403 body and invalid paths as `path_rejected`;
- preserves `readonlySkillFiles` compatibility and proves confined absolute reads;
- preserves omitted-policy behavior;
- forwards binary writes through composed host/governance bindings.

No UI or shell-enforcement claim is included. Legacy bypass retirement remains owned by 938.4.

## Proof

- Agent focused: **3 files / 32 tests passed**.
- Boring Bash focused: **2 files / 17 tests passed**.
- Agent typecheck passed.
- Boring Bash typecheck passed.
- `pnpm audit:imports` passed.
- `pnpm lint:invariants` passed across Agent/Boring Bash/Sandbox/Workspace plugin boundaries.
- `git diff --check` passed.

Coverage includes Fastify route matrix, exact raw header/body, stat metadata, records/settings/upload, move footprints, mixed ancestors, legal colon filenames, omission, confined legacy skill absolute reads, real policy/guard binding, real Pi tools, dynamic governance composition, and binary-write composition.

## Review

Claude Code CLI Opus high-effort security/spec reviews:

1. RED: five blockers/five highs; all fixed.
2. RED: two new highs (colon query paths and request-scoped governance in Pi tools); fixed.
3. GREEN with one latent binary-write composition high; fixed.
4. Final: **GREEN**, no blocker/high remains.

Reviewed SHA: `7e2f6b7`.
