### PR TITLE
#942 feat(workspace): honor filesystem path capabilities

### DIFF
--- a/packages/core/src/front/__tests__/WorkspaceSettingsPage.test.tsx
+++ b/packages/core/src/front/__tests__/WorkspaceSettingsPage.test.tsx
@@ -180,6 +180,46 @@ describe('WorkspaceSettingsPage', () => {
   )
 
   it(
+    'disables file settings mutation when the settings target lacks write capability',
+    withTaskId(TASK_ID, async ({ assertionPassed }) => {
+      const qc = createQueryClient()
+      let putCalled = false
+      setupRuntimeHandler(null)
+      useMswHandler(async (input, init) => {
+        const url = extractUrl(input)
+        if (!url.endsWith('/api/v1/workspace-settings')) return undefined
+        if (init?.method === 'PUT') {
+          putCalled = true
+          return new Response(JSON.stringify({ ok: true }), { status: 200 })
+        }
+        return new Response(JSON.stringify({
+          settings: { markdown: { imageUploadDir: 'assets/images' } },
+          access: 'readwrite',
+          capabilities: { write: false },
+        }), { status: 200, headers: { 'content-type': 'application/json' } })
+      })
+
+      render(
+        <Wrapper qc={qc}>
+          <WorkspaceSettingsPage />
+        </Wrapper>,
+      )
+
+      const input = await waitFor(() => screen.getByTestId('markdown-image-upload-dir-input'))
+      expect(input).toBeDisabled()
+      expect(input).toHaveAttribute('aria-describedby', 'file-settings-readonly-note')
+      expect(screen.getByTestId('file-settings-readonly')).toHaveAttribute('role', 'status')
+      const save = screen.getByTestId('save-file-settings')
+      expect(save).toBeDisabled()
+      fireEvent.click(save)
+      expect(putCalled).toBe(false)
+
+      assertionPassed('readonly-file-settings-disabled')
+      qc.clear()
+    }),
+  )
+
+  it(
     'encodes workspace id in settings API URLs',
     withTaskId(TASK_ID, async ({ assertionPassed }) => {
       const qc = createQueryClient()

--- a/packages/core/src/front/workspace/WorkspaceSettingsPage.tsx
+++ b/packages/core/src/front/workspace/WorkspaceSettingsPage.tsx
@@ -144,6 +144,12 @@ type WorkspaceFileSettings = {
   markdown?: { imageUploadDir?: string }
 }
 
+type WorkspaceFileSettingsResponse = {
+  settings: WorkspaceFileSettings
+  access?: 'readonly' | 'readwrite'
+  capabilities?: { write?: boolean }
+}
+
 export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {}) {
   const workspace = useCurrentWorkspace()
   const role = useWorkspaceRole()
@@ -187,11 +193,10 @@ export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {
     queryKey: ['workspace-file-settings', workspaceId],
     queryFn: async () => {
       try {
-        const data = await apiFetchJson<{ settings: WorkspaceFileSettings }>(
+        return await apiFetchJson<WorkspaceFileSettingsResponse>(
           '/api/v1/workspace-settings',
           { headers: requestHeaders },
         )
-        return data.settings
       } catch (err: unknown) {
         const detail = getHttpErrorDetail(err)
         if (detail.status === 404) return null
@@ -203,9 +208,9 @@ export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {
   })
 
   useEffect(() => {
-    const next = fileSettingsQuery.data?.markdown?.imageUploadDir
+    const next = fileSettingsQuery.data?.settings.markdown?.imageUploadDir
     if (typeof next === 'string') setImageUploadDirValue(next)
-  }, [fileSettingsQuery.data?.markdown?.imageUploadDir])
+  }, [fileSettingsQuery.data?.settings.markdown?.imageUploadDir])
 
   const fileSettingsMutation = useMutation({
     mutationFn: async (imageUploadDir: string) => {
@@ -301,15 +306,19 @@ export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {
     deleteMutation.mutate()
   }, [deleteMutation])
 
+  const fileSettingsWritable = fileSettingsQuery.data?.capabilities
+    ? fileSettingsQuery.data.capabilities.write === true
+    : fileSettingsQuery.data?.access !== 'readonly'
+
   const handleSaveFileSettings = useCallback(() => {
     const trimmed = (imageUploadDirValue ?? '').trim()
-    if (!trimmed) return
+    if (!trimmed || !fileSettingsWritable) return
     fileSettingsMutation.mutate(trimmed)
-  }, [fileSettingsMutation, imageUploadDirValue])
+  }, [fileSettingsMutation, fileSettingsWritable, imageUploadDirValue])
 
   const runtime = runtimeQuery.data ?? null
   const hasRuntime = runtime !== null && runtimeQuery.isSuccess
-  const fileSettings = fileSettingsQuery.data ?? null
+  const fileSettings = fileSettingsQuery.data?.settings ?? null
   const hasFileSettings = fileSettings !== null && fileSettingsQuery.isSuccess
   const currentImageUploadDir = fileSettings?.markdown?.imageUploadDir ?? 'assets/images'
   const fileSettingsChanged = imageUploadDirValue !== null && imageUploadDirValue.trim() !== currentImageUploadDir
@@ -469,7 +478,9 @@ export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {
                 <Button
                   data-testid="save-file-settings"
                   size="sm"
-                  disabled={!fileSettingsChanged || fileSettingsMutation.isPending || !canEditName}
+                  disabled={!fileSettingsChanged || fileSettingsMutation.isPending || !canEditName || !fileSettingsWritable}
+                  aria-disabled={!fileSettingsWritable}
+                  title={fileSettingsWritable ? 'Save file settings' : 'File settings are readonly'}
                   onClick={handleSaveFileSettings}
                 >
                   {fileSettingsMutation.isPending ? 'Saving...' : 'Save file settings'}
@@ -478,6 +489,14 @@ export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {
             >
               <div className="space-y-4">
                 {fileSettingsError && <Notice data-testid="file-settings-error" role="alert" tone="error" description={fileSettingsError} />}
+                {!fileSettingsWritable ? (
+                  <Notice
+                    data-testid="file-settings-readonly"
+                    role="status"
+                    tone="info"
+                    description="File settings are readonly for this workspace path."
+                  />
+                ) : null}
                 <div className="space-y-2">
                   <Label htmlFor="markdown-image-upload-dir" className="text-[12px]">Markdown image upload path</Label>
                   <Input
@@ -486,8 +505,14 @@ export function WorkspaceSettingsPage({ topBar }: WorkspaceSettingsPageProps = {
                     className="h-8 font-mono text-[13px]"
                     value={imageUploadDirValue ?? currentImageUploadDir}
                     onChange={(e) => setImageUploadDirValue(e.target.value)}
-                    disabled={!canEditName}
+                    disabled={!canEditName || !fileSettingsWritable}
+                    aria-describedby={!fileSettingsWritable ? 'file-settings-readonly-note' : undefined}
                   />
+                  {!fileSettingsWritable ? (
+                    <p id="file-settings-readonly-note" className="text-[12px] text-muted-foreground">
+                      This value cannot be changed because <code>.boring/settings</code> is readonly.
+                    </p>
+                  ) : null}
                   <FieldNote>
                     Relative workspace path used by markdown image uploads. Stored in <code>.boring/settings</code>.
                   </FieldNote>

--- a/packages/workspace/src/front/testing/__tests__/testing.test.tsx
+++ b/packages/workspace/src/front/testing/__tests__/testing.test.tsx
@@ -9,12 +9,12 @@ import { renderPane } from "../renderPane"
 
 function FixtureProbe({ bridge }: { bridge?: WorkspaceBridge }) {
   const { data: file } = useFileContent("src/main.ts")
-  const { data: tree = [] } = useFileList(".")
+  const { data: tree } = useFileList(".")
 
   return (
     <div>
       <div data-testid="fixture-content">{file?.content ?? "loading"}</div>
-      <div data-testid="fixture-tree">{tree.map((entry) => entry.path).join(",")}</div>
+      <div data-testid="fixture-tree">{tree?.entries.map((entry) => entry.path).join(",") ?? ""}</div>
       <button type="button" onClick={() => bridge?.openFile("src/main.ts")}>
         open fixture
       </button>

--- a/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/useFilePane.test.tsx
@@ -317,12 +317,13 @@ describe("useFilePane", () => {
       expect(result.current.isDirty).toBe(true)
     })
 
-    it("blocks edits when server marks any named filesystem readonly", async () => {
+    it("blocks edits and autosave when write capability is false even if access summary is readwrite", async () => {
+      const capabilities = { read: true, write: false, "create-child": true, delete: false, "move-from": false }
       mockFileContent.mockReturnValue({
-        data: { content: "initial", mtimeMs: 1000, access: "readonly" },
+        data: { content: "initial", mtimeMs: 1000, access: "readwrite", capabilities },
         isLoading: false,
         error: undefined,
-        refetch: vi.fn(async () => ({ data: { content: "initial", mtimeMs: 1000, access: "readonly" } })),
+        refetch: vi.fn(async () => ({ data: { content: "initial", mtimeMs: 1000, access: "readwrite", capabilities } })),
       })
       const { result } = renderHook(
         () => useFilePane({ path: "same.md", filesystem: "project_alpha", createIfMissing: "new" }),

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/hooks.test.tsx
@@ -27,7 +27,7 @@ vi.mock("../DataProvider", () => ({
 
 let mockClient: {
   getFile: ReturnType<typeof vi.fn>
-  getTree: ReturnType<typeof vi.fn>
+  getTreeListing: ReturnType<typeof vi.fn>
   stat: ReturnType<typeof vi.fn>
   search: ReturnType<typeof vi.fn>
   writeFile: ReturnType<typeof vi.fn>
@@ -49,7 +49,7 @@ beforeEach(() => {
   events._reset()
   mockClient = {
     getFile: vi.fn(),
-    getTree: vi.fn(),
+    getTreeListing: vi.fn(),
     stat: vi.fn(),
     search: vi.fn(),
     writeFile: vi.fn(),
@@ -150,11 +150,15 @@ describe("useFileContent", () => {
 describe("useFileList", () => {
   it("returns directory listing", async () => {
     const entries = [{ name: "a.ts", kind: "file" as const, path: "a.ts" }]
-    mockClient.getTree.mockResolvedValue(entries)
+    mockClient.getTreeListing.mockResolvedValue({
+      entries,
+      access: "readwrite",
+      capabilities: { read: true, write: true, "create-child": true, delete: true, "move-from": true },
+    })
     const { result } = renderHook(() => useFileList("/"), { wrapper })
     await waitFor(() => expect(result.current.isSuccess).toBe(true))
-    expect(result.current.data).toEqual(entries)
-    expect(mockClient.getTree).toHaveBeenCalledWith("/", expect.any(AbortSignal))
+    expect(result.current.data).toEqual(expect.objectContaining({ entries, access: "readwrite" }))
+    expect(mockClient.getTreeListing).toHaveBeenCalledWith("/", expect.any(AbortSignal))
   })
 })
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/__tests__/useFileEventInvalidation.test.tsx
@@ -87,17 +87,21 @@ describe("useFileEventInvalidation", () => {
   })
 
   it("updates cached parent tree entries for remote creates before refetch completes", async () => {
-    qc.setQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src"], [
-      { name: "old.ts", kind: "file", path: "src/old.ts" },
-    ])
+    qc.setQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src"], {
+      entries: [{ name: "old.ts", kind: "file", path: "src/old.ts" }],
+      access: "readwrite",
+    })
     renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
 
     events.emit(filesystemEvents.created, { ...remoteMeta(), path: "src/new.ts", kind: "file" })
 
-    await waitFor(() => expect(qc.getQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src"])).toEqual([
-      { name: "old.ts", kind: "file", path: "src/old.ts" },
-      { name: "new.ts", kind: "file", path: "src/new.ts" },
-    ]))
+    await waitFor(() => expect(qc.getQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "src"])).toEqual({
+      entries: [
+        { name: "old.ts", kind: "file", path: "src/old.ts" },
+        { name: "new.ts", kind: "file", path: "src/new.ts" },
+      ],
+      access: "readwrite",
+    }))
   })
 
   it("keeps tree invalidation scoped by filesystem", async () => {
@@ -142,6 +146,30 @@ describe("useFileEventInvalidation", () => {
     expect(invalidate).toHaveBeenCalledWith({
       queryKey: [TEST_BASE, TEST_WORKSPACE_ID, "search"],
     })
+  })
+
+  it("drops stale capabilities when moving a cached entry to a new destination", async () => {
+    qc.setQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "."], {
+      entries: [{
+        name: "old.ts",
+        kind: "file",
+        path: "old.ts",
+        access: "readwrite",
+        capabilities: { read: true, write: true, "create-child": true, delete: true, "move-from": true },
+      }],
+      capabilities: { read: true, write: true, "create-child": true, delete: false, "move-from": false },
+    })
+    qc.setQueryData([TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "protected"], {
+      entries: [],
+      capabilities: { read: true, write: true, "create-child": true, delete: false, "move-from": false },
+    })
+    renderHook(() => useFileEventInvalidation(), { wrapper: makeWrapper(qc) })
+
+    events.emit(filesystemEvents.moved, { ...userMeta(), from: "old.ts", to: "protected/new.ts" })
+
+    await waitFor(() => expect(qc.getQueryData<{ entries: Array<Record<string, unknown>> }>(
+      [TEST_BASE, TEST_WORKSPACE_ID, "tree", "user", "protected"],
+    )?.entries).toContainEqual({ name: "new.ts", kind: "file", path: "protected/new.ts" }))
   })
 
   it("directory move invalidates descendant file/stat/tree caches under the old prefix", async () => {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/fetchClient.ts
@@ -1,4 +1,4 @@
-import type { FetchClientOptions, FileContent, FileEntry, FileStat, GitUrlMetadata } from "./types"
+import type { FetchClientOptions, FileContent, FileEntry, FileStat, FileTreeListing, GitUrlMetadata } from "./types"
 
 const DEFAULT_TIMEOUT = 10_000
 const DEFAULT_MAX_RETRIES = 3
@@ -129,17 +129,20 @@ export class FetchClient {
     throw lastError ?? new FetchError(0, "Request failed after retries")
   }
 
-  async getTree(path: string, signal?: AbortSignal, filesystem?: string): Promise<FileEntry[]> {
+  async getTreeListing(path: string, signal?: AbortSignal, filesystem?: string): Promise<FileTreeListing> {
     const params = new URLSearchParams({ path })
     if (filesystem) params.set("filesystem", filesystem)
-    const res = await this.request<{ entries: FileEntry[] }>(
+    return this.request<FileTreeListing>(
       "GET",
       `/api/v1/tree?${params}`,
       undefined,
       undefined,
       signal,
     )
-    return res.entries
+  }
+
+  async getTree(path: string, signal?: AbortSignal, filesystem?: string): Promise<FileEntry[]> {
+    return (await this.getTreeListing(path, signal, filesystem)).entries
   }
 
   async getFile(path: string, signal?: AbortSignal, filesystem?: string): Promise<FileContent> {

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/hooks.ts
@@ -14,7 +14,7 @@ import { events, userMeta } from "../../../../front/events"
 import { filesystemEvents } from "../../shared/events"
 import { FILES_QUERY_KEY_SEGMENT } from "../../shared/constants"
 import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
-import type { FileContent, FileEntry, FileStat, GitUrlMetadata } from "./types"
+import type { FileContent, FileStat, FileTreeListing, GitUrlMetadata } from "./types"
 
 function noRetryOn404(count: number, error: Error): boolean {
   if (error instanceof FetchError && error.status === 404) return false
@@ -57,17 +57,25 @@ export function useFileContent(
   })
 }
 
-export function useFileList(dir: string | null, filesystem?: FilesystemId): UseQueryResult<FileEntry[]> {
+export function useFileList(dir: string | null, filesystem?: FilesystemId): UseQueryResult<FileTreeListing> {
   const client = useDataClient()
   const base = useApiBaseUrl()
   const workspaceId = useWorkspaceRequestId()
   const fs = normalizeUiFilesystem(filesystem)
   return useQuery({
     queryKey: [base, workspaceId, "tree", fs, dir],
-    queryFn: async ({ signal }) => (await (fs === "user" ? client.getTree(dir!, signal) : client.getTree(dir!, signal, fs))) ?? [],
+    queryFn: ({ signal }) => fs === "user"
+      ? client.getTreeListing(dir!, signal)
+      : client.getTreeListing(dir!, signal, fs),
     enabled: dir != null,
     staleTime: 3_000,
-    initialData: () => fs === "user" ? getPreloadedTreeEntries(base, workspaceId, dir) : undefined,
+    initialData: () => {
+      const entries = fs === "user" ? getPreloadedTreeEntries(base, workspaceId, dir) : undefined
+      return entries ? { entries } : undefined
+    },
+    // Preload carries identity only. Refetch immediately before exposing
+    // mutation affordances that require server-projected capabilities.
+    initialDataUpdatedAt: 0,
     // File-event SSE invalidates this query when files change. Polling every
     // 3s made slow/dev backends self-abort before the first tree response,
     // leaving the workbench tree stuck on its skeleton.

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/index.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/index.ts
@@ -23,7 +23,18 @@ export {
   getPreloadedTreeEntries,
   setPreloadedTreeEntries,
 } from "./treePreloadCache"
-export type { FileEntry, FileContent, FileStat, FetchClientOptions, GitUrlMetadata } from "./types"
+export { allowsFilesystemCapability } from "./types"
+export type {
+  FileEntry,
+  FileContent,
+  FileStat,
+  FileTreeListing,
+  FilesystemAccessProjection,
+  FilesystemCapabilities,
+  FilesystemCapability,
+  FetchClientOptions,
+  GitUrlMetadata,
+} from "./types"
 export type { FileRecordsFormat, FileRecordsResult, FileRecordsSource, ReadFileRecordsOptions } from "./fileRecords"
 export { useFileUpload } from "./useFileUpload"
 export type { UseFileUploadOptions, UseFileUploadResult } from "./useFileUpload"

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/types.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/types.ts
@@ -1,13 +1,35 @@
-export interface FileEntry {
+export type FilesystemCapability = "read" | "write" | "create-child" | "delete" | "move-from"
+
+export type FilesystemCapabilities = Readonly<Record<FilesystemCapability, boolean>>
+
+export interface FilesystemAccessProjection {
+  /** Compatibility summary only; operation controls consume `capabilities`. */
+  access?: "readonly" | "readwrite"
+  capabilities?: FilesystemCapabilities
+}
+
+export interface FileEntry extends FilesystemAccessProjection {
   name: string
   kind: "file" | "dir"
   path: string
 }
 
-export interface FileContent {
+export interface FileTreeListing extends FilesystemAccessProjection {
+  entries: FileEntry[]
+}
+
+/** Browser presentation helper only; the server remains the mutation authority. */
+export function allowsFilesystemCapability(
+  projection: FilesystemAccessProjection | undefined,
+  capability: FilesystemCapability,
+  fallbackAccess: "readonly" | "readwrite" = "readwrite",
+): boolean {
+  if (projection?.capabilities) return projection.capabilities[capability] === true
+  return (projection?.access ?? fallbackAccess) !== "readonly"
+}
+
+export interface FileContent extends FilesystemAccessProjection {
   content: string
-  /** Access granted by the resolved filesystem binding, when the server exposes it. */
-  access?: "readonly" | "readwrite"
   /**
    * Server-stat'd modification time. Used as the OCC baseline for the
    * next write — the client sends it back as `expectedMtimeMs` so the
@@ -18,7 +40,7 @@ export interface FileContent {
   mtimeMs?: number
 }
 
-export interface FileStat {
+export interface FileStat extends FilesystemAccessProjection {
   size: number
   mtimeMs: number
   kind: "file" | "dir"

--- a/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventInvalidation.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/data/useFileEventInvalidation.ts
@@ -8,7 +8,7 @@ import { filesystemEvents } from "../../shared/events"
 import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import { FILES_QUERY_KEY_SEGMENT } from "../../shared/constants"
 import { parentDir } from "../file-tree/treeModel"
-import type { FileEntry } from "./types"
+import type { FileEntry, FileTreeListing } from "./types"
 
 /**
  * Single source of truth for translating workspace bus `filesystem:file.*` events
@@ -75,8 +75,9 @@ export function useFileEventInvalidation(): void {
       const movedEntry = getTreeCacheEntry(queryClient, base, workspaceId, e.from, e.filesystem)
       removeTreeCacheEntry(queryClient, base, workspaceId, e.from, e.filesystem)
       if (movedEntry) {
+        const { access: _access, capabilities: _capabilities, ...identity } = movedEntry
         upsertTreeCache(queryClient, base, workspaceId, e.filesystem, {
-          ...movedEntry,
+          ...identity,
           name: basename(e.to),
           path: e.to,
         })
@@ -175,8 +176,8 @@ function getTreeCacheEntry(
   path: string,
   filesystem?: FilesystemId,
 ): FileEntry | undefined {
-  const entries = qc.getQueryData<FileEntry[]>(treeKey(base, workspaceId, filesystem, parentDir(path)))
-  return entries?.find((entry) => entry.path === path)
+  const listing = qc.getQueryData<FileTreeListing>(treeKey(base, workspaceId, filesystem, parentDir(path)))
+  return listing?.entries.find((entry) => entry.path === path)
 }
 
 function upsertTreeCache(
@@ -186,10 +187,10 @@ function upsertTreeCache(
   filesystem: FilesystemId | undefined,
   entry: FileEntry,
 ): void {
-  qc.setQueryData<FileEntry[]>(treeKey(base, workspaceId, filesystem, parentDir(entry.path)), (entries) => {
-    if (!entries) return entries
-    const withoutEntry = entries.filter((candidate) => candidate.path !== entry.path)
-    return [...withoutEntry, entry]
+  qc.setQueryData<FileTreeListing>(treeKey(base, workspaceId, filesystem, parentDir(entry.path)), (listing) => {
+    if (!listing) return listing
+    const withoutEntry = listing.entries.filter((candidate) => candidate.path !== entry.path)
+    return { ...listing, entries: [...withoutEntry, entry] }
   })
 }
 
@@ -200,9 +201,9 @@ function removeTreeCacheEntry(
   path: string,
   filesystem?: FilesystemId,
 ): void {
-  qc.setQueryData<FileEntry[]>(treeKey(base, workspaceId, filesystem, parentDir(path)), (entries) => {
-    if (!entries) return entries
-    return entries.filter((entry) => entry.path !== path)
+  qc.setQueryData<FileTreeListing>(treeKey(base, workspaceId, filesystem, parentDir(path)), (listing) => {
+    if (!listing) return listing
+    return { ...listing, entries: listing.entries.filter((entry) => entry.path !== path) }
   })
 }
 

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTree.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTree.tsx
@@ -19,8 +19,9 @@ import { getFileIcon } from "../../../../front/registry/getFileIcon"
 import { EmptyState, Input } from "@hachej/boring-ui-kit"
 import { cn } from "../../../../front/lib/utils"
 import { getFileTreeDndManager } from "./dndManager"
+import type { FilesystemAccessProjection } from "../data/types"
 
-export interface FileTreeNode {
+export interface FileTreeNode extends FilesystemAccessProjection {
   name: string
   kind: "file" | "dir"
   path: string
@@ -58,6 +59,12 @@ export interface FileTreeProps {
   onCollapse?: (path: string) => void
   onContextMenu?: (event: React.MouseEvent, node: FileTreeNode) => void
   onDragDrop?: (sourcePath: string, targetDirPath: string) => void
+  onRename?: (path: string, value: string) => void
+  onDelete?: (node: FileTreeNode) => void
+  canRename?: (node: FileTreeNode) => boolean
+  canDelete?: (node: FileTreeNode) => boolean
+  canDrag?: (node: FileTreeNode) => boolean
+  canDragDrop?: (source: FileTreeNode, targetDirPath: string) => boolean
   /** Called after a reveal request has opened parents and scheduled scrolling. */
   onRevealHandled?: (path: string) => void
   /** Called when the user presses Enter on an inline-edit input. */
@@ -214,7 +221,7 @@ function Node({ node, style, dragHandle }: NodeRendererProps<FileTreeNode>) {
     useContext(TreeHandlersCtx)
   const data = node.data
   const isDir = data.kind === "dir"
-  const isEditingHere = editing?.path === data.path
+  const isEditingHere = editing?.path === data.path || node.isEditing
   const isPending = pendingPaths.has(data.path)
   const Icon = isDir
     ? node.isOpen
@@ -275,10 +282,16 @@ function Node({ node, style, dragHandle }: NodeRendererProps<FileTreeNode>) {
       />
       {isEditingHere ? (
         <InlineEditInput
-          initialValue={editing?.initialValue ?? data.name ?? ""}
-          isDraft={!!editing?.isDraft}
-          onSubmit={(value) => onSubmitEdit?.(data.path, value)}
-          onCancel={() => onCancelEdit?.()}
+          initialValue={editing?.path === data.path ? editing.initialValue ?? data.name ?? "" : data.name ?? ""}
+          isDraft={editing?.path === data.path ? !!editing.isDraft : false}
+          onSubmit={(value) => {
+            if (editing?.path === data.path) onSubmitEdit?.(data.path, value)
+            else node.submit(value)
+          }}
+          onCancel={() => {
+            if (editing?.path === data.path) onCancelEdit?.()
+            else node.reset()
+          }}
         />
       ) : (
         <span
@@ -314,6 +327,12 @@ export function FileTree({
   onExpand,
   onCollapse,
   onContextMenu,
+  onRename,
+  onDelete,
+  canRename,
+  canDelete,
+  canDrag,
+  canDragDrop,
   onSubmitEdit,
   onCancelEdit,
   onRevealHandled,
@@ -411,12 +430,13 @@ export function FileTree({
 
       for (const dragNode of args.dragNodes) {
         const sourcePath = dragNode.data.path
-        if (targetPath === sourcePath) return
-        if (targetPath !== "." && targetPath.startsWith(sourcePath + "/")) return
+        if (targetPath === sourcePath) continue
+        if (targetPath !== "." && targetPath.startsWith(sourcePath + "/")) continue
+        if (canDragDrop && !canDragDrop(dragNode.data, targetPath)) continue
         onDragDrop(sourcePath, targetPath)
       }
     },
-    [onDragDrop],
+    [canDragDrop, onDragDrop],
   )
 
   const disableDrop = useCallback(
@@ -424,15 +444,19 @@ export function FileTree({
       parentNode: { data: FileTreeNode; isRoot?: boolean } | null
       dragNodes: { data: FileTreeNode }[]
     }) => {
-      if (!args.parentNode || args.parentNode.isRoot) return false
+      if (!args.parentNode || args.parentNode.isRoot) {
+        return args.dragNodes.some((node) => canDragDrop ? !canDragDrop(node.data, ".") : false)
+      }
       if (args.parentNode.data.kind !== "dir") return true
+      const targetPath = args.parentNode.data.path
       for (const dn of args.dragNodes) {
-        if (args.parentNode.data.path === dn.data.path) return true
-        if (args.parentNode.data.path.startsWith(dn.data.path + "/")) return true
+        if (targetPath === dn.data.path) return true
+        if (targetPath.startsWith(dn.data.path + "/")) return true
+        if (canDragDrop && !canDragDrop(dn.data, targetPath)) return true
       }
       return false
     },
-    [],
+    [canDragDrop],
   )
 
   const searchMatch = useCallback(
@@ -506,8 +530,14 @@ export function FileTree({
           onActivate={handleActivate}
           onToggle={handleToggle}
           onMove={handleMove}
+          onRename={onRename ? ({ node, name }) => onRename(node.data.path, name) : undefined}
+          onDelete={onDelete ? ({ nodes }) => {
+            const node = nodes[0]?.data
+            if (node && (canDelete?.(node) ?? true)) onDelete(node)
+          } : undefined}
           disableDrop={disableDrop}
-          disableEdit={true}
+          disableDrag={(node) => !(canDrag?.(node) ?? Boolean(onDragDrop))}
+          disableEdit={(node) => !(onRename && (canRename?.(node) ?? true))}
           dndManager={getFileTreeDndManager()}
         >
           {Node}

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -24,7 +24,12 @@ import {
   useDataClient,
   useGitUrlMetadata,
 } from "../data"
-import type { FileEntry } from "../data/types"
+import {
+  allowsFilesystemCapability,
+  type FileEntry,
+  type FilesystemAccessProjection,
+  type FilesystemCapability,
+} from "../data/types"
 import type { FileTreeNode, FileTreeEditState } from "./FileTree"
 import {
   buildTree,
@@ -192,14 +197,15 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
   className,
 }, ref) {
   const dataClient = useDataClient()
-  const canMutate = access !== "readonly"
   const activeFilesystem = normalizeUiFilesystem(filesystem)
   const requestFilesystem = activeFilesystem === "user" ? undefined : activeFilesystem
   const getTreeEntries = useCallback(
     (path: string) => requestFilesystem ? dataClient.getTree(path, undefined, requestFilesystem) : dataClient.getTree(path),
     [dataClient, requestFilesystem],
   )
-  const { data: rawFileList, error, isLoading, refetch: refetchFileList } = useFileList(rootDir, requestFilesystem)
+  const { data: rawFileListing, error, isLoading, refetch: refetchFileList } = useFileList(rootDir, requestFilesystem)
+  const rawFileList = rawFileListing?.entries
+  const rootProjection: FilesystemAccessProjection | undefined = rawFileListing
   const [optimisticEntries, setOptimisticEntries] = useState<
     Map<string, FileEntry[]>
   >(new Map())
@@ -323,12 +329,49 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
   // appear in the regular browse view.
   const treeData = injectDraftIntoTree(baseTreeData, editing, rootDir)
 
+  const nodesByPath = useMemo(() => {
+    const index = new Map<string, FileTreeNode>()
+    const visit = (nodes: FileTreeNode[]) => {
+      for (const node of nodes) {
+        index.set(node.path, node)
+        if (node.children?.length) visit(node.children)
+      }
+    }
+    visit(treeData)
+    return index
+  }, [treeData])
+
+  const capabilityAware = rootProjection?.capabilities !== undefined
+  const allows = useCallback(
+    (projection: FilesystemAccessProjection | undefined, capability: FilesystemCapability) =>
+      allowsFilesystemCapability(projection, capability, capabilityAware ? "readonly" : access),
+    [access, capabilityAware],
+  )
+  const directoryProjection = useCallback(
+    (path: string): FilesystemAccessProjection | undefined => {
+      const normalized = path === "." ? rootDir : path
+      return normalized === rootDir ? rootProjection : nodesByPath.get(normalized)
+    },
+    [nodesByPath, rootDir, rootProjection],
+  )
+  const canCreateIn = useCallback(
+    (path: string) => allows(directoryProjection(path), "create-child"),
+    [allows, directoryProjection],
+  )
+  const canRenameNode = useCallback((node: FileTreeNode) => allows(node, "move-from"), [allows])
+  const canDeleteNode = useCallback((node: FileTreeNode) => allows(node, "delete"), [allows])
+  const canDragDrop = useCallback(
+    (source: FileTreeNode, targetDirPath: string) => canRenameNode(source) && canCreateIn(targetDirPath),
+    [canCreateIn, canRenameNode],
+  )
+
   const handleSelect = useCallback(
     (path: string) => {
       setSelectedPath(path)
-      bridge?.openFile(path, { mode: "edit", ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
+      const mode = allows(nodesByPath.get(path), "write") ? "edit" : "view"
+      bridge?.openFile(path, { mode, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
     },
-    [bridge, requestFilesystem],
+    [allows, bridge, nodesByPath, requestFilesystem],
   )
 
   const handleExpand = useCallback(
@@ -622,10 +665,9 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
         return
       event.preventDefault()
       // The background menu only ever offers New file / New folder, both
-      // mutating actions gated by canMutate. On a read-only root there is
-      // nothing to show — opening it would render an empty menu shell.
-      // Suppress the trigger entirely rather than pop an empty box.
-      if (!canMutate) return
+      // mutating actions gated by the listed directory's create-child
+      // capability. Suppress an otherwise-empty background menu.
+      if (!canCreateIn(rootDir)) return
       setCtxMenu({
         node: { name: rootDir, kind: "dir", path: rootDir },
         x: event.clientX,
@@ -633,7 +675,7 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
         isBackground: true,
       })
     },
-    [rootDir, canMutate],
+    [canCreateIn, rootDir],
   )
 
   const handleDragDrop = useCallback(
@@ -643,9 +685,10 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
       const newPath =
         effectiveDir === "." ? fileName : `${effectiveDir}/${fileName}`
       if (newPath === sourcePath) return
+      const source = nodesByPath.get(sourcePath)
+      if (!source || !canDragDrop(source, targetDirPath)) return
       markPending(sourcePath)
       try {
-        if (!canMutate) return
         await moveFile({ from: sourcePath, to: newPath, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
         await refreshDirs([parentDir(sourcePath), parentDir(newPath)])
         toast.success({ title: "Moved", description: `${sourcePath} → ${newPath}` })
@@ -658,7 +701,36 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
         clearPending(sourcePath)
       }
     },
-    [canMutate, requestFilesystem, moveFile, refreshDirs, rootDir, markPending, clearPending],
+    [canDragDrop, clearPending, markPending, moveFile, nodesByPath, refreshDirs, requestFilesystem, rootDir],
+  )
+
+  const handleKeyboardRename = useCallback(
+    async (path: string, value: string) => {
+      const node = nodesByPath.get(path)
+      const trimmed = value.trim()
+      if (!node || !canRenameNode(node) || !trimmed || trimmed === node.name) return
+      const parts = path.split("/")
+      parts[parts.length - 1] = trimmed
+      const to = parts.join("/")
+      markPending(path)
+      try {
+        await moveFile({ from: path, to, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
+        await refreshDirs([parentDir(path)])
+        toast.success({ title: "Renamed", description: `${path} → ${to}` })
+      } catch (err) {
+        toast.error({ title: "Rename failed", description: err instanceof Error ? err.message : String(err) })
+      } finally {
+        clearPending(path)
+      }
+    },
+    [canRenameNode, clearPending, markPending, moveFile, nodesByPath, refreshDirs, requestFilesystem],
+  )
+
+  const handleKeyboardDelete = useCallback(
+    (node: FileTreeNode) => {
+      if (canDeleteNode(node)) setDeleteTarget(node)
+    },
+    [canDeleteNode],
   )
 
   function ctxAction(fn: () => void | Promise<void>) {
@@ -682,6 +754,7 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
     setCtxMenu(null)
     const dir =
       node?.kind === "dir" ? node.path : node ? parentDir(node.path) : rootDir
+    if (!canCreateIn(dir)) return
     const draftPath = `__draft__:${++draftSeqRef.current}`
     setEditing({ kind, parentDir: dir, path: draftPath })
   }
@@ -692,7 +765,7 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
   const handleRename = () => {
     const node = ctxMenu?.node
     setCtxMenu(null)
-    if (!node) return
+    if (!node || !canRenameNode(node)) return
     setEditing({ kind: "rename", path: node.path, initialValue: node.name })
   }
 
@@ -702,8 +775,10 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
       setEditing(null)
       if (!current) return
       const trimmed = value.trim()
-      if (!trimmed || !canMutate) return
+      if (!trimmed) return
       const dir = current.kind === "rename" ? parentDir(current.path) : current.parentDir
+      const currentNode = current.kind === "rename" ? nodesByPath.get(current.path) : undefined
+      if (current.kind === "rename" ? !currentNode || !canRenameNode(currentNode) : !canCreateIn(dir)) return
       const newPath = current.kind === "rename" ? current.path : joinPath(dir, trimmed)
       const trackPath = current.kind === "rename" ? current.path : newPath
       markPending(trackPath)
@@ -737,7 +812,11 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
               filesystem: requestFilesystem,
               kind: "file",
             })
-            handleSelect(newPath)
+            // The exact destination has just been authorized and created by
+            // the server, so it is safe to open this new file for editing even
+            // before the refreshed listing carries its projection.
+            setSelectedPath(newPath)
+            bridge?.openFile(newPath, { mode: "edit", ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
             toast.success({ title: "File created", description: newPath })
           } else {
             await createDir({ path: newPath, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
@@ -764,7 +843,9 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
     },
     [
       editing,
-      canMutate,
+      canCreateIn,
+      canRenameNode,
+      nodesByPath,
       requestFilesystem,
       moveFile,
       writeFile,
@@ -774,7 +855,7 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
       clearPending,
       addOptimisticEntry,
       removeOptimisticEntry,
-      handleSelect,
+      bridge,
     ],
   )
 
@@ -797,12 +878,11 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
   })
 
   const handleDeleteConfirm = useCallback(async () => {
-    if (!deleteTarget) return
+    if (!deleteTarget || !canDeleteNode(deleteTarget)) return
     const target = deleteTarget
     setDeleteTarget(null)
     markPending(target.path)
     try {
-      if (!canMutate) return
       await deleteFile({ path: target.path, ...(requestFilesystem ? { filesystem: requestFilesystem } : {}) })
       removeOptimisticEntry(parentDir(target.path), target.path)
       if (target.kind === "dir") {
@@ -833,7 +913,7 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
     markPending,
     clearPending,
     removeOptimisticEntry,
-    canMutate,
+    canDeleteNode,
     requestFilesystem,
   ])
 
@@ -845,7 +925,13 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
   // has at least "Copy path". Used as a belt-and-suspenders guard so an
   // empty item set never renders as a blank menu shell, even if a future
   // change to the rules above misses a trigger-side check.
-  const ctxMenuHasItems = ctxMenu ? canMutate || !ctxMenu.isBackground : false
+  const contextDirectory = ctxMenu
+    ? ctxMenu.node.kind === "dir" ? ctxMenu.node.path : parentDir(ctxMenu.node.path)
+    : rootDir
+  const canContextCreate = ctxMenu ? canCreateIn(contextDirectory) : false
+  const canContextRename = ctxMenu ? !ctxMenu.isBackground && canRenameNode(ctxMenu.node) : false
+  const canContextDelete = ctxMenu ? !ctxMenu.isBackground && canDeleteNode(ctxMenu.node) : false
+  const ctxMenuHasItems = ctxMenu ? canContextCreate || !ctxMenu.isBackground : false
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -905,7 +991,13 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
               onContextMenu={handleContextMenu}
               onSubmitEdit={handleSubmitEdit}
               onCancelEdit={handleCancelEdit}
-              onDragDrop={canMutate ? handleDragDrop : undefined}
+              onDragDrop={handleDragDrop}
+              onRename={(path, value) => void handleKeyboardRename(path, value)}
+              onDelete={handleKeyboardDelete}
+              canRename={canRenameNode}
+              canDelete={canDeleteNode}
+              canDrag={canRenameNode}
+              canDragDrop={canDragDrop}
               height={treeHeight}
               className={cn(className)}
             />
@@ -920,7 +1012,7 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
           className="fixed z-50 min-w-[10rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md"
           style={{ left: ctxMenu.x, top: ctxMenu.y }}
         >
-          {canMutate && (
+          {canContextCreate ? (
             <>
               <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleNewFile}>
                 New file
@@ -929,29 +1021,38 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
                 New folder
               </Button>
             </>
-          )}
+          ) : null}
           {!ctxMenu.isBackground && (
             <>
-              {canMutate && (
-                <>
-                  <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleRename}>
-                    Rename
-                  </Button>
-                  <Button
-                    type="button"
-                    role="menuitem"
-                    variant="ghost"
-                    size="sm"
-                    className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
-                    onClick={() => {
-                      setDeleteTarget(ctxMenu.node)
-                      setCtxMenu(null)
-                    }}
-                  >
-                    Delete
-                  </Button>
-                </>
-              )}
+              <Button
+                type="button"
+                role="menuitem"
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start"
+                disabled={!canContextRename}
+                aria-disabled={!canContextRename}
+                title={canContextRename ? "Rename" : "Rename unavailable for this path"}
+                onClick={handleRename}
+              >
+                Rename
+              </Button>
+              <Button
+                type="button"
+                role="menuitem"
+                variant="ghost"
+                size="sm"
+                className="w-full justify-start text-destructive hover:bg-destructive/10 hover:text-destructive"
+                disabled={!canContextDelete}
+                aria-disabled={!canContextDelete}
+                title={canContextDelete ? "Delete" : "Delete unavailable for this path"}
+                onClick={() => {
+                  setDeleteTarget(ctxMenu.node)
+                  setCtxMenu(null)
+                }}
+              >
+                Delete
+              </Button>
               <Button type="button" role="menuitem" variant="ghost" size="sm" className="w-full justify-start" onClick={handleCopyPath}>
                 Copy path
               </Button>

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import type React from "react"
 import { Toaster, clearToasts } from "../../../../../front/toast"
+import type { FileEntry, FilesystemCapabilities } from "../../data/types"
 
 const mockFileList = vi.fn()
 const mockFileListRefetch = vi.fn()
@@ -43,7 +44,16 @@ vi.mock("../../../../../front/dock", () => ({
 }))
 
 vi.mock("../FileTree", () => {
-  type Node = { name: string; path: string; kind: string; isDraft?: boolean; children?: Node[] }
+  type Capabilities = { read: boolean; write: boolean; "create-child": boolean; delete: boolean; "move-from": boolean }
+  type Node = {
+    name: string
+    path: string
+    kind: string
+    isDraft?: boolean
+    access?: "readonly" | "readwrite"
+    capabilities?: Capabilities
+    children?: Node[]
+  }
   type EditingArg = { path: string; isDraft: boolean; initialValue?: string } | null
   type PendingArg = ReadonlySet<string> | undefined
 
@@ -109,6 +119,12 @@ vi.mock("../FileTree", () => {
       onSubmitEdit,
       onCancelEdit,
       onDragDrop,
+      onRename,
+      onDelete,
+      canRename,
+      canDelete,
+      canDrag,
+      canDragDrop,
       onExpand,
     }: {
       files: Node[]
@@ -122,6 +138,12 @@ vi.mock("../FileTree", () => {
       onSubmitEdit?: (p: string, v: string) => void
       onCancelEdit?: () => void
       onDragDrop?: (src: string, dst: string) => void
+      onRename?: (path: string, value: string) => void
+      onDelete?: (node: Node) => void
+      canRename?: (node: Node) => boolean
+      canDelete?: (node: Node) => boolean
+      canDrag?: (node: Node) => boolean
+      canDragDrop?: (source: Node, target: string) => boolean
       onExpand?: (path: string) => void
     }) => (
       <div
@@ -145,9 +167,33 @@ vi.mock("../FileTree", () => {
         <button
           type="button"
           data-testid="trigger-drag"
-          onClick={() => onDragDrop?.("a.ts", "src")}
+          disabled={!files.find((node) => node.path === "a.ts") || !canDrag?.(files.find((node) => node.path === "a.ts")!)}
+          onClick={() => {
+            const source = files.find((node) => node.path === "a.ts")
+            if (source && (canDragDrop?.(source, "src") ?? true)) onDragDrop?.("a.ts", "src")
+          }}
         >
           drag
+        </button>
+        <button
+          type="button"
+          data-testid="trigger-keyboard-rename"
+          onClick={() => {
+            const source = files.find((node) => node.path === "a.ts")
+            if (source && (canRename?.(source) ?? true)) onRename?.(source.path, "renamed.ts")
+          }}
+        >
+          keyboard rename
+        </button>
+        <button
+          type="button"
+          data-testid="trigger-keyboard-delete"
+          onClick={() => {
+            const source = files.find((node) => node.path === "a.ts")
+            if (source && (canDelete?.(source) ?? true)) onDelete?.(source)
+          }}
+        >
+          keyboard delete
         </button>
         <button
           type="button"
@@ -165,11 +211,40 @@ import { FileTreePane, clampContextMenuPosition } from "../FileTreeView"
 import { events, remoteMeta, userMeta } from "../../../../../front/events"
 import { filesystemEvents } from "../../../shared/events"
 
-const sampleFiles = [
-  { name: "src", kind: "dir" as const, path: "src" },
-  { name: "index.ts", kind: "file" as const, path: "index.ts" },
-  { name: "README.md", kind: "file" as const, path: "README.md" },
+const writableCapabilities = {
+  read: true,
+  write: true,
+  "create-child": true,
+  delete: true,
+  "move-from": true,
+} as const
+
+const readonlyCapabilities = {
+  read: true,
+  write: false,
+  "create-child": false,
+  delete: false,
+  "move-from": false,
+} as const
+
+const mixedAncestorCapabilities = {
+  read: true,
+  write: true,
+  "create-child": true,
+  delete: false,
+  "move-from": false,
+} as const
+
+const sampleFiles: FileEntry[] = [
+  { name: "src", kind: "dir" as const, path: "src", access: "readwrite" as const, capabilities: writableCapabilities },
+  { name: "a.ts", kind: "file" as const, path: "a.ts", access: "readwrite" as const, capabilities: writableCapabilities },
+  { name: "index.ts", kind: "file" as const, path: "index.ts", access: "readwrite" as const, capabilities: writableCapabilities },
+  { name: "README.md", kind: "file" as const, path: "README.md", access: "readwrite" as const, capabilities: writableCapabilities },
 ]
+
+function fileListing(entries: FileEntry[] = sampleFiles, capabilities: FilesystemCapabilities = writableCapabilities) {
+  return { entries, access: capabilities.write ? "readwrite" as const : "readonly" as const, capabilities }
+}
 
 function wrapper({ children }: { children: React.ReactNode }) {
   const qc = new QueryClient({
@@ -233,7 +308,7 @@ beforeEach(() => {
   mockFileListRefetch.mockResolvedValue(undefined)
   mockFileSearch.mockReturnValue({ data: undefined })
   mockFileList.mockReturnValue({
-    data: sampleFiles,
+    data: fileListing(),
     isLoading: false,
     error: undefined,
     refetch: mockFileListRefetch,
@@ -277,8 +352,8 @@ describe("FileTreePane", () => {
   it("shows configured filesystem roots without probing hardcoded bindings", async () => {
     mockFileList.mockImplementation((dir: string, filesystem?: string) => ({
       data: filesystem === "project_alpha"
-        ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
-        : sampleFiles,
+        ? fileListing([{ name: "handbook.md", kind: "file" as const, path: "handbook.md", capabilities: readonlyCapabilities }], readonlyCapabilities)
+        : fileListing(),
       isLoading: false,
       isSuccess: true,
       error: undefined,
@@ -303,7 +378,7 @@ describe("FileTreePane", () => {
     await waitFor(() => expect(screen.getByText("handbook.md")).toBeInTheDocument())
     fireEvent.click(screen.getByText("handbook.md"))
     expect(bridge.openFile).toHaveBeenCalledWith("handbook.md", {
-      mode: "edit",
+      mode: "view",
       filesystem: "project_alpha",
     })
 
@@ -311,15 +386,75 @@ describe("FileTreePane", () => {
     // Mutating actions are gated by read-only access...
     expect(screen.queryByRole("menuitem", { name: "New file" })).not.toBeInTheDocument()
     expect(screen.queryByRole("menuitem", { name: "New folder" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("menuitem", { name: "Rename" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("menuitem", { name: "Delete" })).not.toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Rename" })).toBeDisabled()
+    expect(screen.getByRole("menuitem", { name: "Rename" })).toHaveAttribute("aria-disabled", "true")
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toBeDisabled()
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toHaveAttribute("aria-disabled", "true")
     // ...but read actions remain available so the menu is still useful.
     expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeInTheDocument()
   })
 
+  it("uses per-path capabilities for readonly leaves, mixed ancestors, writable siblings, and unknown rows", async () => {
+    mockFileList.mockReturnValue({
+      data: fileListing([
+        { name: "mixed", kind: "dir", path: "mixed", access: "readwrite", capabilities: mixedAncestorCapabilities },
+        { name: "locked.ts", kind: "file", path: "locked.ts", access: "readonly", capabilities: readonlyCapabilities },
+        { name: "sibling.ts", kind: "file", path: "sibling.ts", access: "readwrite", capabilities: writableCapabilities },
+        { name: "unknown.ts", kind: "file", path: "unknown.ts" },
+      ]),
+      isLoading: false,
+      isSuccess: true,
+      error: undefined,
+    })
+    const bridge = { openFile: vi.fn(), select: vi.fn(() => vi.fn()), getActiveFile: vi.fn() }
+    render(<FileTreePane bridge={bridge} />, { wrapper })
+
+    fireEvent.click(await screen.findByText("locked.ts"))
+    fireEvent.click(screen.getByText("sibling.ts"))
+    fireEvent.click(screen.getByText("unknown.ts"))
+    expect(bridge.openFile).toHaveBeenNthCalledWith(1, "locked.ts", { mode: "view" })
+    expect(bridge.openFile).toHaveBeenNthCalledWith(2, "sibling.ts", { mode: "edit" })
+    expect(bridge.openFile).toHaveBeenNthCalledWith(3, "unknown.ts", { mode: "view" })
+
+    fireEvent.contextMenu(screen.getByText("mixed"))
+    expect(screen.getByRole("menuitem", { name: "New file" })).toBeEnabled()
+    expect(screen.getByRole("menuitem", { name: "New folder" })).toBeEnabled()
+    expect(screen.getByRole("menuitem", { name: "Rename" })).toBeDisabled()
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toBeDisabled()
+  })
+
+  it("withholds keyboard and drag mutations when move-from/delete are denied", async () => {
+    mockFileList.mockReturnValue({
+      data: fileListing([
+        { name: "src", kind: "dir", path: "src", capabilities: writableCapabilities },
+        { name: "a.ts", kind: "file", path: "a.ts", capabilities: mixedAncestorCapabilities },
+      ]),
+      isLoading: false,
+      isSuccess: true,
+      error: undefined,
+    })
+    render(<FileTreePane />, { wrapper })
+    await screen.findByText("a.ts")
+    expect(screen.getByTestId("trigger-drag")).toBeDisabled()
+    fireEvent.click(screen.getByTestId("trigger-keyboard-rename"))
+    fireEvent.click(screen.getByTestId("trigger-keyboard-delete"))
+    expect(mockMoveFile).not.toHaveBeenCalled()
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+  })
+
+  it("still submits a drag destination and surfaces a stale server readonly denial", async () => {
+    mockMoveFile.mockRejectedValueOnce(new Error("user binding is readonly"))
+    render(<><FileTreePane /><Toaster /></>, { wrapper })
+    await screen.findByText("a.ts")
+    fireEvent.click(screen.getByTestId("trigger-drag"))
+    await waitFor(() => expect(mockMoveFile).toHaveBeenCalledWith({ from: "a.ts", to: "src/a.ts" }))
+    expect(await screen.findByText("Move failed")).toBeInTheDocument()
+    expect(screen.getByText("user binding is readonly")).toBeInTheDocument()
+  })
+
   it("remounts the tree when switching configured filesystems so expanded path state cannot leak", async () => {
     mockFileList.mockImplementation((dir: string, filesystem?: string) => ({
-      data: [{ name: "src", kind: "dir" as const, path: "src" }],
+      data: fileListing([{ name: "src", kind: "dir" as const, path: "src", capabilities: writableCapabilities }]),
       isLoading: false,
       isSuccess: true,
       error: undefined,
@@ -350,7 +485,7 @@ describe("FileTreePane", () => {
 
   it("does not show extra filesystem roots unless configured", async () => {
     mockFileList.mockReturnValue({
-      data: sampleFiles,
+      data: fileListing(),
       isLoading: false,
       isSuccess: true,
       error: undefined,
@@ -366,7 +501,7 @@ describe("FileTreePane", () => {
     mockFileList.mockImplementation((_dir: string, filesystem?: string) => (
       filesystem === "project_alpha"
         ? { data: undefined, isLoading: false, error: new Error("Forbidden") }
-        : { data: sampleFiles, isLoading: false, error: undefined }
+        : { data: fileListing(), isLoading: false, error: undefined }
     ))
 
     render(<FileTreePane
@@ -404,8 +539,8 @@ describe("FileTreePane", () => {
     it("multi-root chromeless renders the fs root dropdown without a duplicate title or per-root filter input", async () => {
       mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
         data: filesystem === "project_alpha"
-          ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
-          : sampleFiles,
+          ? fileListing([{ name: "handbook.md", kind: "file" as const, path: "handbook.md", capabilities: readonlyCapabilities }], readonlyCapabilities)
+          : fileListing(),
         isLoading: false,
         isSuccess: true,
         error: undefined,
@@ -434,8 +569,8 @@ describe("FileTreePane", () => {
     it("forwards the chrome search query to whichever root is active, including after switching roots", async () => {
       mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
         data: filesystem === "project_alpha"
-          ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
-          : sampleFiles,
+          ? fileListing([{ name: "handbook.md", kind: "file" as const, path: "handbook.md", capabilities: readonlyCapabilities }], readonlyCapabilities)
+          : fileListing(),
         isLoading: false,
         isSuccess: true,
         error: undefined,
@@ -473,10 +608,10 @@ describe("FileTreePane", () => {
 
   it("hides .boring-agent from the default tree view", async () => {
     mockFileList.mockReturnValue({
-      data: [
+      data: fileListing([
         ...sampleFiles,
-        { name: ".boring-agent", kind: "dir" as const, path: ".boring-agent" },
-      ],
+        { name: ".boring-agent", kind: "dir" as const, path: ".boring-agent", capabilities: writableCapabilities },
+      ]),
       isLoading: false,
       error: undefined,
     })
@@ -962,6 +1097,12 @@ describe("FileTreePane", () => {
 
   describe("Read-only root context menu", () => {
     it("background right-click on a read-only root does not open an empty menu", async () => {
+      mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
+        data: filesystem === "project_alpha" ? fileListing([], readonlyCapabilities) : fileListing(),
+        isLoading: false,
+        isSuccess: true,
+        error: undefined,
+      }))
       render(
         <FileTreePane
           roots={[
@@ -990,8 +1131,8 @@ describe("FileTreePane", () => {
     it("right-click on a read-only root's file still opens a menu with read actions", async () => {
       mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
         data: filesystem === "project_alpha"
-          ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
-          : sampleFiles,
+          ? fileListing([{ name: "handbook.md", kind: "file" as const, path: "handbook.md", capabilities: readonlyCapabilities }], readonlyCapabilities)
+          : fileListing(),
         isLoading: false,
         isSuccess: true,
         error: undefined,
@@ -1016,8 +1157,10 @@ describe("FileTreePane", () => {
       expect(screen.getByRole("menu")).toBeInTheDocument()
       expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeInTheDocument()
       expect(screen.queryByRole("menuitem", { name: "New file" })).not.toBeInTheDocument()
-      expect(screen.queryByRole("menuitem", { name: "Rename" })).not.toBeInTheDocument()
-      expect(screen.queryByRole("menuitem", { name: "Delete" })).not.toBeInTheDocument()
+      expect(screen.getByRole("menuitem", { name: "Rename" })).toBeDisabled()
+      expect(screen.getByRole("menuitem", { name: "Rename" })).toHaveAttribute("aria-disabled", "true")
+      expect(screen.getByRole("menuitem", { name: "Delete" })).toBeDisabled()
+      expect(screen.getByRole("menuitem", { name: "Delete" })).toHaveAttribute("aria-disabled", "true")
     })
 
     it("leaves the default read-write root's background menu unchanged", async () => {
@@ -1704,10 +1847,10 @@ describe("FileTreePane", () => {
       mockDeleteFile.mockResolvedValue(undefined)
       mockGetTree.mockResolvedValue([])
       mockFileList.mockReturnValue({
-        data: [
-          { name: "src", kind: "dir" as const, path: "src" },
-          { name: "deep.ts", kind: "file" as const, path: "src/deep.ts" },
-        ],
+        data: fileListing([
+          { name: "src", kind: "dir" as const, path: "src", capabilities: writableCapabilities },
+          { name: "deep.ts", kind: "file" as const, path: "src/deep.ts", capabilities: writableCapabilities },
+        ]),
         isLoading: false,
         error: undefined,
       })
@@ -1761,7 +1904,7 @@ describe("FileTreePane", () => {
       // deduped by path and the row rendered twice.
       mockFileWrite.mockResolvedValue(undefined)
       mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
-        data: filesystem === "project_alpha" ? sampleFiles : [],
+        data: filesystem === "project_alpha" ? fileListing() : fileListing([]),
         isLoading: false,
         isSuccess: true,
         error: undefined,
@@ -1856,8 +1999,8 @@ describe("FileTreePane", () => {
     it("shows the Refresh button in multi-root chromeless mode and refetches whichever root is active", async () => {
       mockFileList.mockImplementation((_dir: string, filesystem?: string) => ({
         data: filesystem === "project_alpha"
-          ? [{ name: "handbook.md", kind: "file" as const, path: "handbook.md" }]
-          : sampleFiles,
+          ? fileListing([{ name: "handbook.md", kind: "file" as const, path: "handbook.md", capabilities: readonlyCapabilities }], readonlyCapabilities)
+          : fileListing(),
         isLoading: false,
         isSuccess: true,
         error: undefined,

--- a/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/useFilePane.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { normalizeUiFilesystem, uiFileResourceKey, type FilesystemId } from "../../../shared/types/filesystem"
 import { useFileContent, useFileWrite } from "./data"
+import { allowsFilesystemCapability } from "./data/types"
 import { FileConflictError } from "./data/fetchClient"
 import { useEditorLifecycle, type EditorLifecycleAdapter } from "../../../front/hooks"
 
@@ -90,7 +91,7 @@ export function useFilePane(options: UseFilePaneOptions): UseFilePaneReturn {
   // may be readonly or readwrite.
   const fileContentOptions = createIfMissing === undefined ? { filesystem } : { filesystem, createIfMissing }
   const { data: fileData, isLoading, error, refetch: refetchFileData } = useFileContent(activePath, fileContentOptions)
-  const isReadonly = fileData?.access === "readonly"
+  const isReadonly = fileData != null && !allowsFilesystemCapability(fileData, "write")
   const { mutateAsync: writeFile } = useFileWrite()
 
   // Local content state


### PR DESCRIPTION
## Summary

Implements #942 Slice 942.4 / `wt-391-forward-f5p.4`:

- consumes server-returned path capabilities in tree, editor lifecycle, and workspace settings;
- opens paths without `write` in view mode and suppresses edits/autosave;
- gates rename, delete, keyboard actions, drag/drop, and create affordances by named capabilities;
- keeps mixed ancestors creatable while disabling rename/delete with accessible disabled states;
- treats missing per-node projection as unknown/fail-closed once a listing is capability-aware;
- keeps legacy no-binding hosts compatible;
- preserves exact destination submission so stale/crafted moves remain server-authorized;
- normalizes tree cache data to one `FileTreeListing` shape and drops stale projection after moves;
- disables `.boring/settings` controls when its write capability is false.

No browser policy list or shell/provider claim is added.

## Proof

- Workspace focused UI/data suites: **6 files / 157 tests passed**.
- Core settings component: **1 file / 11 tests passed**.
- Workspace and Core typechecks passed.
- Workspace production build and 19-artifact assertion passed.
- Workspace full suite reached **131 files / 1791 tests passed** with one unrelated default-plugin `jiti` environment failure; focused reproduction remained environmental (`require3 is not a function`), outside this diff.
- Core full suite reached **104 files / 1256 tests passed** with unrelated stale dependency-artifact and shared Postgres-state failures; focused settings suite is green.
- `pnpm audit:imports`, `pnpm lint:invariants`, and `git diff --check` passed.

Capability tests cover readonly leaf, mixed ancestor, writable sibling, unknown/search/event rows, keyboard/context/drag denial, stale destination server rejection, settings no-PUT, accessibility, and readonly no-autosave.

## Review

Claude Code CLI Opus high-effort reviews:

1. RED: cache-shape break, missing tests, fail-open unknown rows, missing settings consumer, dead keyboard scaffold.
2. All fixed; re-review GREEN.
3. Added direct capability/settings/stale tests and created-file exact-authorization handling; final review **GREEN**, no blocker/high.

Reviewed SHA: `dd42f38`.
