### PR TITLE
#909 fix(core): authorize storage scope against workspace id

### DIFF
--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -410,7 +410,7 @@ test('core/full-app scope authority rejects forged scopes and rechecks membershi
   }
 })
 
-test('core/full-app defaults session namespace to workspace id', async () => {
+test('core/full-app defaults an internal session namespace to workspace id', async () => {
   mocks.collectWorkspaceAgentServerPlugins.mockReturnValue({
     runtimePlugins: [],
     provisioningContributions: [],
@@ -436,15 +436,6 @@ test('core/full-app defaults session namespace to workspace id', async () => {
     expect(options).not.toHaveProperty('sessionNamespace')
     const getSessionNamespace = options.getSessionNamespace as (ctx: { workspaceId: string; workspaceRoot: string; request?: any }) => Promise<string>
     await expect(getSessionNamespace({ workspaceId: 'workspace-a', workspaceRoot: '/tmp/full-app-workspaces/workspace-a' })).resolves.toBe('workspace-a')
-    await expect(getSessionNamespace({
-      workspaceId: 'workspace-a',
-      workspaceRoot: '/tmp/full-app-workspaces/workspace-a',
-      request: {
-        id: 'foreign-storage',
-        headers: { 'x-boring-storage-scope': 'workspace-b' },
-        raw: { rawHeaders: ['x-boring-storage-scope', 'workspace-b'] },
-      },
-    })).rejects.toMatchObject({ status: 421, code: 'AGENT_HOST_SCOPE_VIOLATION' })
   } finally {
     await app.close()
   }

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts
@@ -22,6 +22,26 @@ vi.mock('@hachej/boring-agent/server', () => {
     agentServerMock.registerOpts.push(opts)
     app.post('/api/v1/agent/chat', async () => ({ ok: true }))
     app.get('/api/v1/agent/chat/:sessionId/messages', async () => ({ ok: true }))
+    app.get('/api/v1/agent/pi-chat/sessions', async (request: any, reply: any) => {
+      try {
+        const workspaceId = await (opts.getWorkspaceId as Function)(request)
+        const storageScope = await (opts.getSessionNamespace as Function)({
+          workspaceId,
+          workspaceRoot: '/tmp/workspace',
+          request,
+        })
+        return { storageScope, header: request.headers['x-boring-storage-scope'] }
+      } catch (error) {
+        const statusCode = typeof (error as { statusCode?: unknown })?.statusCode === 'number'
+          ? (error as { statusCode: number }).statusCode
+          : 500
+        const code = typeof (error as { code?: unknown })?.code === 'string'
+          ? (error as { code: string }).code
+          : 'INTERNAL_ERROR'
+        const message = error instanceof Error ? error.message : 'list pi chat sessions failed'
+        return reply.code(statusCode).send({ error: { code, message } })
+      }
+    })
     app.get('/__bridge-owner/:sessionId', async (request: any) => {
       const tools = await (opts.getExtraTools as Function)?.({
         workspaceId: String(request.headers['x-boring-workspace-id'] ?? 'default'),
@@ -209,14 +229,6 @@ vi.mock('../../../server/app/index.js', () => ({
         }
       }
     })
-    app.setErrorHandler((error, request, reply) => {
-      const status = (error as { status?: unknown }).status
-      const code = (error as { code?: unknown }).code
-      if (typeof status === 'number' && typeof code === 'string') {
-        return reply.code(status).send({ code, message: (error as Error).message, requestId: request.id })
-      }
-      return reply.send(error)
-    })
     return app
   },
   registerRoutes: async () => {},
@@ -271,6 +283,62 @@ afterEach(() => {
 })
 
 describe('createCoreWorkspaceAgentServer workspace bridge wiring', () => {
+  it('authorizes browser storage claims and canonicalizes them on the composed HTTP path', async () => {
+    const workspaceId = 'workspace-1'
+    const canonicalNamespace = `${workspaceId}_33982c6908977596_user_cf1025156133f4d4`
+    const app = await createCoreWorkspaceAgentServer({
+      serveFrontend: false,
+      requestScopeResolver: async () => ({
+        bindingId: 'binding-1',
+        workspaceId,
+        defaultDeploymentId: 'deployment-1',
+        activeRevision: 'revision-1',
+        resolvedDigest: `sha256:${'a'.repeat(64)}`,
+      }),
+      getSessionNamespace: async () => canonicalNamespace,
+    })
+    const inject = (storageScope?: string) => app.inject({
+      method: 'GET',
+      url: '/api/v1/agent/pi-chat/sessions',
+      headers: {
+        'x-test-user-id': 'user-1',
+        ...(storageScope === undefined ? {} : { 'x-boring-storage-scope': storageScope }),
+      },
+    })
+
+    const browserClaim = await inject(workspaceId)
+    expect(browserClaim.statusCode).toBe(200)
+    expect(browserClaim.json()).toMatchObject({ storageScope: canonicalNamespace, header: canonicalNamespace })
+
+    const omitted = await inject()
+    expect(omitted.statusCode).toBe(200)
+    expect(omitted.json()).toMatchObject({ storageScope: canonicalNamespace, header: canonicalNamespace })
+
+    const canonical = await inject(canonicalNamespace)
+    expect(canonical.statusCode).toBe(200)
+    expect(canonical.json()).toMatchObject({ storageScope: canonicalNamespace, header: canonicalNamespace })
+
+    const repeatedValidClaims = await inject(`${workspaceId}, ${canonicalNamespace}`)
+    expect(repeatedValidClaims.statusCode).toBe(200)
+    expect(repeatedValidClaims.json()).toMatchObject({ storageScope: canonicalNamespace, header: canonicalNamespace })
+
+    const forged = await inject('workspace-2')
+    expect(forged.statusCode).toBe(421)
+    expect(forged.json()).toMatchObject({
+      error: {
+        code: 'AGENT_HOST_SCOPE_VIOLATION',
+        message: 'AGENT_HOST_SCOPE_VIOLATION',
+      },
+    })
+    expect(forged.statusCode).not.toBe(500)
+
+    const mixedForgery = await inject(`${workspaceId}, workspace-2`)
+    expect(mixedForgery.statusCode).toBe(421)
+    expect(mixedForgery.json()).toMatchObject({ error: { code: 'AGENT_HOST_SCOPE_VIOLATION' } })
+
+    await app.close()
+  })
+
   it('converges every scoped browser selector before membership while preserving generic precedence', async () => {
     const customResolver = vi.fn(async () => 'custom-workspace')
     const actorResolver = vi.fn(async () => ({ workspaceId: 'custom-workspace', userId: 'actor-user' }))

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -567,7 +567,11 @@ function resolveRequestScopedWorkspaceId(
   return scope.workspaceId
 }
 
-function authorizeStorageScope(request: FastifyRequest | undefined, canonicalScope: string): string {
+function authorizeStorageScope(
+  request: FastifyRequest | undefined,
+  authorizedWorkspaceId: string,
+  canonicalScope: string,
+): string {
   if (!request) return canonicalScope
   const presented: unknown[] = []
   const rawHeaders = request.raw?.rawHeaders
@@ -585,7 +589,9 @@ function authorizeStorageScope(request: FastifyRequest | undefined, canonicalSco
     }
   }
   for (const value of presented) {
-    if (typeof value !== 'string' || value.trim() !== canonicalScope) {
+    if (typeof value !== 'string') agentHostScopeViolation(request)
+    const normalized = value.trim()
+    if (normalized !== authorizedWorkspaceId && normalized !== canonicalScope) {
       agentHostScopeViolation(request)
     }
   }
@@ -1144,7 +1150,7 @@ export async function createCoreWorkspaceAgentServer(
     const canonicalScope = options.getSessionNamespace
       ? await options.getSessionNamespace(ctx)
       : options.sessionNamespace ?? ctx.workspaceId
-    return authorizeStorageScope(ctx.request, canonicalScope ?? ctx.workspaceId)
+    return authorizeStorageScope(ctx.request, ctx.workspaceId, canonicalScope ?? ctx.workspaceId)
   }
 
   const agents = options.agents ?? [{ agentTypeId: 'default', legacyDefault: true } as const]

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -52,6 +52,10 @@ export class HttpError extends Error {
   readonly code: ErrorCode
   readonly requestId?: string
 
+  get statusCode(): number {
+    return this.status
+  }
+
   constructor(init: {
     status: number
     code: ErrorCode


### PR DESCRIPTION
## Summary
- Authorize `x-boring-storage-scope` as a client authorization claim against the authorized workspace id, while still accepting canonical server-side namespaces.
- Canonicalize the storage-scope header to the server-derived session namespace after validation.
- Add `HttpError.statusCode` alias so agent HTTP routes return 421 instead of silently degrading scope violations to 500.
- Replace the direct helper-status assertion that masked transport behavior with inject-based HTTP coverage.

## Proof of work
Focused before/after owner repro equivalent (`app.inject` on `/api/v1/agent/pi-chat/sessions`):

Before source fix, with test kept in place and source hunks temporarily reversed:
```text
FAIL  src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts > createCoreWorkspaceAgentServer workspace bridge wiring > authorizes browser storage claims and canonicalizes them on the composed HTTP path
AssertionError: expected 500 to be 200
- Expected
+ Received
- 200
+ 500
```

After fix:
```text
pnpm --filter @hachej/boring-core exec vitest run src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts --no-file-parallelism --testNamePattern 'authorizes browser storage claims'

Test Files  1 passed (1)
Tests       1 passed | 7 skipped (8)
```

Forged case after fix is covered in the same inject test:
- `x-boring-storage-scope: workspace-2` => HTTP `421`
- body includes `error.code: AGENT_HOST_SCOPE_VIOLATION`
- explicit assertion `statusCode` is not `500`

## Gates run
- `pnpm typecheck` ✅
- `pnpm lint` ⚠️ wrapper terminated abnormally with `[warn] Linter process terminated abnormally (possibly out of memory)`; reran its component commands successfully:
  - `pnpm check:generated-artifacts` ✅
  - `pnpm check:agent-resources` ✅
  - `pnpm audit:imports` ✅
- `pnpm lint:invariants` ✅
- `pnpm --filter @hachej/boring-core exec vitest run src/app/server/__tests__/createCoreWorkspaceAgentServer.workspaceBridge.test.ts src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts --no-file-parallelism` ✅
- `pnpm --filter @hachej/boring-core run test -- --no-file-parallelism` ⚠️ unrelated existing DB/concurrency failures in:
  - `src/server/auth/__tests__/deleteUserCompletely.test.ts`
  - `src/server/db/stores/__tests__/PostgresModelBudgetStore.test.ts`
  Reproduced on targeted rerun.
- `pnpm --filter @hachej/boring-agent exec vitest run --no-file-parallelism` ✅
- `pnpm --filter @hachej/boring-workspace exec vitest run --no-file-parallelism` ✅

## Notes
`ctx.workspaceId` is the authorized workspace id: core `resolveWorkspaceId` calls `resolveAuthorizedWorkspaceId()` when `request.requestScope` is present, and that function validates presented selectors against `request.requestScope.workspaceId` then checks `workspaceStore.isMember(normalizedWorkspaceId, user.id)` before returning.
