### PR TITLE
#909 feat(agent): per-agent model policy

### DIFF
--- a/packages/agent/src/server/agent-host/__tests__/modelPolicy.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/modelPolicy.test.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { createTestRuntimeModeAdapter } from '@agent-test-host'
+import { ErrorCode, type AuthorizedAgentScope } from '../../../shared/index'
+import type { AgentCoreHarness } from '../../../shared/harness'
+import type { PiAgentSessionAdapter } from '../../pi-chat/PiAgentSessionAdapter'
+import {
+  createAgentHost,
+  resolveAgentHostCompatibilityComposition,
+} from '../createAgentHost'
+import type { AgentHostAgentSpec, CreatedAgentHost } from '../types'
+
+const ENV_KEYS = [
+  'BORING_AGENT_DEFAULT_MODEL',
+  'BORING_AGENT_CUSTOM_MODEL_PROVIDER',
+  'BORING_AGENT_CUSTOM_MODEL_ID',
+  'BORING_AGENT_CUSTOM_MODEL_BASE_URL',
+  'BORING_AGENT_CUSTOM_MODEL_API_KEY',
+  'BORING_AGENT_INFOMANIAK_BASE_URL',
+  'BORING_AGENT_INFOMANIAK_MODEL',
+  'BORING_AGENT_INFOMANIAK_API_KEY',
+] as const
+const roots: string[] = []
+const scope = { workspaceScopeId: 'workspace-a', authSubjectId: 'subject-a' } as AuthorizedAgentScope
+let previousEnv: Partial<Record<(typeof ENV_KEYS)[number], string>>
+
+beforeEach(() => {
+  previousEnv = {}
+  for (const key of ENV_KEYS) {
+    previousEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+  process.env.BORING_AGENT_CUSTOM_MODEL_PROVIDER = 'custom'
+  process.env.BORING_AGENT_CUSTOM_MODEL_ID = 'custom-model'
+  process.env.BORING_AGENT_CUSTOM_MODEL_BASE_URL = 'https://custom.example.test/v1'
+  process.env.BORING_AGENT_CUSTOM_MODEL_API_KEY = 'custom-test-key'
+  process.env.BORING_AGENT_INFOMANIAK_BASE_URL = 'https://infomaniak.example.test/v1'
+  process.env.BORING_AGENT_INFOMANIAK_MODEL = 'inf-model'
+  process.env.BORING_AGENT_INFOMANIAK_API_KEY = 'infomaniak-test-key'
+})
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  for (const key of ENV_KEYS) {
+    const previous = previousEnv[key]
+    if (previous === undefined) delete process.env[key]
+    else process.env[key] = previous
+  }
+})
+
+function agent(agentTypeId: string, preferred?: string): AgentHostAgentSpec {
+  return {
+    agentTypeId,
+    definition: { instructions: agentTypeId, label: agentTypeId },
+    ...(preferred === undefined ? {} : { model: { preferred } }),
+  }
+}
+
+async function createHost(agents: readonly AgentHostAgentSpec[]) {
+  const sessionRoot = await mkdtemp(join(tmpdir(), 'agent-model-policy-session-'))
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'agent-model-policy-workspace-'))
+  roots.push(sessionRoot, workspaceRoot)
+  const created = await createAgentHost({
+    agents,
+    fleetCompiler: { compile: async ({ agents: input }) => input },
+    hostId: 'model-policy-host',
+    scopeVerifier: { verify: async (claim) => claim },
+    runtimeModeAdapter: createTestRuntimeModeAdapter('direct'),
+    sessionRoot,
+    resolveRuntimeScope: async ({ agentTypeId }) => ({
+      identity: `runtime-${agentTypeId}`,
+      environment: {
+        placementIdentity: `direct-${agentTypeId}`,
+        workspaceRoot,
+        provisioningFingerprint: `provision-${agentTypeId}`,
+      },
+      sessionNamespace: agentTypeId,
+    }),
+  })
+  return { created, workspaceRoot }
+}
+
+async function resolveModel(
+  created: CreatedAgentHost,
+  workspaceRoot: string,
+  agentTypeId: string,
+  sessionId: string,
+  model?: { provider: string; id: string },
+) {
+  const composition = await resolveAgentHostCompatibilityComposition(created, agentTypeId, scope)
+  const harness = composition.harness as AgentCoreHarness
+  const adapter = await harness.getPiSessionAdapter(
+    { sessionId, message: 'hello', model },
+    { abortSignal: new AbortController().signal, workdir: workspaceRoot },
+  ) as PiAgentSessionAdapter
+  return adapter.currentModel?.()
+}
+
+describe('per-agent model policy', { timeout: 15_000 }, () => {
+  it('uses an agent preferred model when the prompt specifies none', async () => {
+    process.env.BORING_AGENT_DEFAULT_MODEL = 'custom:custom-model'
+    const { created, workspaceRoot } = await createHost([agent('alpha', 'infomaniak:inf-model')])
+    try {
+      await expect(resolveModel(created, workspaceRoot, 'alpha', 'preferred')).resolves.toEqual({
+        provider: 'infomaniak',
+        id: 'inf-model',
+      })
+    } finally {
+      await created.host.close()
+    }
+  })
+
+  it('keeps a per-prompt model ahead of the agent preferred model', async () => {
+    const { created, workspaceRoot } = await createHost([agent('alpha', 'infomaniak:inf-model')])
+    try {
+      await expect(resolveModel(created, workspaceRoot, 'alpha', 'prompt', {
+        provider: 'custom',
+        id: 'custom-model',
+      })).resolves.toEqual({ provider: 'custom', id: 'custom-model' })
+    } finally {
+      await created.host.close()
+    }
+  })
+
+  it('keeps the global env default for an agent without a declared model', async () => {
+    process.env.BORING_AGENT_DEFAULT_MODEL = 'custom:custom-model'
+    const { created, workspaceRoot } = await createHost([agent('alpha')])
+    try {
+      await expect(resolveModel(created, workspaceRoot, 'alpha', 'global')).resolves.toEqual({
+        provider: 'custom',
+        id: 'custom-model',
+      })
+    } finally {
+      await created.host.close()
+    }
+  })
+
+  it('isolates different preferred models across two agents in one fleet', async () => {
+    const { created, workspaceRoot } = await createHost([
+      agent('alpha', 'custom:custom-model'),
+      agent('beta', 'infomaniak:inf-model'),
+    ])
+    try {
+      await expect(Promise.all([
+        resolveModel(created, workspaceRoot, 'alpha', 'alpha-session'),
+        resolveModel(created, workspaceRoot, 'beta', 'beta-session'),
+      ])).resolves.toEqual([
+        { provider: 'custom', id: 'custom-model' },
+        { provider: 'infomaniak', id: 'inf-model' },
+      ])
+    } finally {
+      await created.host.close()
+    }
+  })
+
+  it('fails loudly when an agent preferred model cannot be resolved', async () => {
+    process.env.BORING_AGENT_DEFAULT_MODEL = 'custom:custom-model'
+    const { created, workspaceRoot } = await createHost([agent('alpha', 'missing:missing-model')])
+    try {
+      await expect(resolveModel(created, workspaceRoot, 'alpha', 'missing')).rejects.toMatchObject({
+        statusCode: 400,
+        code: ErrorCode.enum.TOOL_INVALID_INPUT,
+        details: { provider: 'missing', model: 'missing-model' },
+      })
+    } finally {
+      await created.host.close()
+    }
+  })
+})

--- a/packages/agent/src/server/agent-host/buildAgentComposition.ts
+++ b/packages/agent/src/server/agent-host/buildAgentComposition.ts
@@ -15,6 +15,7 @@ import {
   type CreateAgentRuntimeBridgeOptions,
 } from '../createAgent'
 import { withPiHarnessDefaults } from '../harness/pi-coding-agent/createHarness'
+import { parseEncodedModelSelection } from '../models/modelConfig'
 import type { HarnessPiChatService } from '../pi-chat/harnessPiChatService'
 import type { ReadyStatusTracker } from '../runtime/readyStatus'
 import { createRuntimeReadyStatusTracker } from '../runtime/modeReadiness'
@@ -154,8 +155,15 @@ export async function buildAgentComposition(
 
   const readyTracker = compatibility?.readyTracker
     ?? createRuntimeReadyStatusTracker(options.runtimeModeAdapter, { harnessReady: true })
+  const encodedPreferredModel = 'legacyDefault' in input.agent
+    ? undefined
+    : input.agent.model?.preferred
   const pi = withPiHarnessDefaults({
     ...runtimeScope.pi,
+    defaultModel: parseEncodedModelSelection(encodedPreferredModel) ?? runtimeScope.pi?.defaultModel,
+    strictModelResolution: encodedPreferredModel === undefined
+      ? runtimeScope.pi?.strictModelResolution
+      : true,
     additionalSkillPaths: [
       ...(input.environmentProvisioning?.skillPaths ?? []),
       ...(runtimeScope.pi?.additionalSkillPaths ?? []),

--- a/packages/agent/src/server/agent-host/types.ts
+++ b/packages/agent/src/server/agent-host/types.ts
@@ -133,6 +133,7 @@ export interface ConfiguredAgentHostAgentSpec {
   }[]
   readonly model?: {
     readonly preferred?: string
+    /** RESERVED / NOT ENFORCED. Per-turn token-limit enforcement is future work. */
     readonly maxTokensPerTurn?: number
   }
 }

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -98,6 +98,7 @@ export interface PiHarnessOptions {
   noContextFiles?: boolean;
   noSkills?: boolean;
   additionalSkillPaths?: string[];
+  defaultModel?: { provider: string; id: string };
   /**
    * Additional native Pi package sources to enable for this agent runtime.
    * These are applied as in-memory SettingsManager overrides, so host/plugin
@@ -227,7 +228,14 @@ function resolveRequestedModel(
   return model;
 }
 
-function resolveDefaultModel(modelRegistry: ModelRegistry) {
+function resolveDefaultModel(
+  modelRegistry: ModelRegistry,
+  override?: { provider: string; id: string },
+  strict?: boolean,
+) {
+  if (override) {
+    return resolveRequestedModel(modelRegistry, { model: override }, { strict });
+  }
   const configured = readConfiguredDefaultModel();
   if (configured) {
     const model = modelRegistry.find(configured.provider, configured.id);
@@ -605,7 +613,7 @@ export function createPiCodingAgentHarness(opts: {
     // Prefer an explicit available UI selection; otherwise use configured
     // Boring/Pi default if present. Undefined is intentional: Pi/session owns
     // the final fallback model selection.
-    const model = resolvedModel ?? resolveDefaultModel(modelRegistry);
+    const model = resolvedModel ?? resolveDefaultModel(modelRegistry, pi.defaultModel, pi.strictModelResolution);
 
     // Hosts may extend pi's base prompt and/or isolate resource discovery.
     // We keep pi's default system prompt but always tack on a workspace-paths

--- a/packages/agent/src/server/models/modelConfig.ts
+++ b/packages/agent/src/server/models/modelConfig.ts
@@ -31,6 +31,15 @@ function clean(value: string | undefined): string | undefined {
   return trimmed && trimmed.length > 0 ? trimmed : undefined
 }
 
+export function parseEncodedModelSelection(value: string | undefined): AgentModelSelection | undefined {
+  const encoded = clean(value)
+  if (!encoded) return undefined
+  const idx = encoded.indexOf(':')
+  return idx > 0 && idx < encoded.length - 1
+    ? { provider: encoded.slice(0, idx), id: encoded.slice(idx + 1) }
+    : undefined
+}
+
 function readPositiveInt(name: string, fallback: number): number {
   const raw = clean(getEnv(name))
   if (!raw) return fallback
@@ -246,13 +255,8 @@ function readPiSettingsDefaultModel(): AgentModelSelection | undefined {
 }
 
 export function readConfiguredDefaultModel(): AgentModelSelection | undefined {
-  const encoded = clean(getEnv('BORING_AGENT_DEFAULT_MODEL'))
-  if (encoded) {
-    const idx = encoded.indexOf(':')
-    if (idx > 0 && idx < encoded.length - 1) {
-      return { provider: encoded.slice(0, idx), id: encoded.slice(idx + 1) }
-    }
-  }
+  const encoded = parseEncodedModelSelection(getEnv('BORING_AGENT_DEFAULT_MODEL'))
+  if (encoded) return encoded
 
   const explicitProvider = clean(getEnv('BORING_AGENT_DEFAULT_MODEL_PROVIDER'))
   const explicitId = clean(getEnv('BORING_AGENT_DEFAULT_MODEL_ID'))


### PR DESCRIPTION
## Summary
- make `ConfiguredAgentHostAgentSpec.model.preferred` load-bearing as each agent's Pi harness default model
- keep precedence as `command.model > agent model.preferred > global env/pi default`
- enable strict model resolution only for agents declaring `model.preferred`
- mark `maxTokensPerTurn` as reserved / not enforced

## Proof of work
- Per-agent default model: `buildAgentComposition.ts` parses `input.agent.model?.preferred` with shared `parseEncodedModelSelection` and passes it as `pi.defaultModel`; `createHarness.ts` resolves `pi.defaultModel` before global defaults.
- Shared parser: `modelConfig.ts` exports `parseEncodedModelSelection`; `readConfiguredDefaultModel()` reuses it for `BORING_AGENT_DEFAULT_MODEL`.
- Strict declared model: `buildAgentComposition.ts` sets `strictModelResolution: true` only when `model.preferred` is declared.
- `maxTokensPerTurn`: `agent-host/types.ts` TSDoc marks it RESERVED / NOT ENFORCED.
- No cost ceilings or non-overridable model policy added; per-prompt model still wins.

## Required tests
`pnpm --filter @hachej/boring-agent exec vitest run src/server/agent-host/__tests__/modelPolicy.test.ts --no-file-parallelism --reporter=verbose`
- preferred model default: passed
- per-prompt override wins: passed
- no declared model uses global env default: passed
- two agents with different preferred models resolve independently: passed
- unresolvable preferred model fails loudly: passed

## Gates
- `pnpm typecheck`: passed
- `pnpm lint:invariants`: passed
- `pnpm --filter @hachej/boring-agent exec vitest run --no-file-parallelism`: passed
- `pnpm --filter @hachej/boring-workspace exec vitest run --no-file-parallelism`: passed

## Known local gate issue
- `pnpm lint` exited from the harness with `[warn] Linter process terminated abnormally (possibly out of memory)` before script output. The equivalent subcommands passed:
  - `pnpm check:generated-artifacts`: passed
  - `pnpm check:agent-resources`: passed
  - `NODE_OPTIONS=--max-old-space-size=8192 pnpm audit:imports`: passed
- `pnpm --filter @hachej/boring-core exec vitest run --no-file-parallelism` failed in pre-existing core DB tests unrelated to this agent-only diff; targeted rerun reproduced the same 3 failures in `deleteUserCompletely.test.ts` and `PostgresModelBudgetStore.test.ts`.
