### PR TITLE
fix(release): align golden-path stagesPending between generator and checker

### DIFF
--- a/scripts/check-golden-path-invariants.mjs
+++ b/scripts/check-golden-path-invariants.mjs
@@ -5,6 +5,7 @@ import { spawnSync } from "node:child_process"
 
 const repoRoot = resolve(import.meta.dirname, "..")
 const goldenPath = resolve(repoRoot, "docs/issues/391/runtime-refactor/golden-path.json")
+// Must stay in sync with `stagesPending` in scripts/golden-path-timing.mjs.
 const expectedPending = [
   "Decision 28 fleet and Environment service implementation through F7 conformance",
   "H2c/F2c contraction plus F8a/H8/F8b packed publication proof",

--- a/scripts/golden-path-timing.mjs
+++ b/scripts/golden-path-timing.mjs
@@ -13,9 +13,13 @@ const stagesCovered = [
   "A1 compileAgentDirectory (#624)",
   "P6-R resolveAgentDeployment (#647)",
 ]
+// Must stay in sync with `expectedPending` in scripts/check-golden-path-invariants.mjs.
+// These two lists drifted between #885 (generator) and #889 (checker), which left
+// `pnpm release:*` broken: the release regenerates this file, and the checker then
+// rejects the regenerated values. Change both lists together.
 const stagesPending = [
-  "persisted workspace-type package tracer",
-  "Seneca two-domain agent-product deployment proof",
+  "Decision 28 fleet and Environment service implementation through F7 conformance",
+  "H2c/F2c contraction plus F8a/H8/F8b packed publication proof",
 ]
 
 function seconds(startMs, endMs) {


### PR DESCRIPTION
## Problem

`pnpm release:patch|minor|major` fails at the P8 gate:

```
[p8] FAIL stagesPending must be exactly ["Decision 28 fleet and Environment service implementation through F7 conformance","H2c/F2c contraction plus F8a/H8/F8b packed publication proof"]
```

`scripts/golden-path-timing.mjs` (writes the file) and `scripts/check-golden-path-invariants.mjs` (verifies it) each hardcode their own `stagesPending`, and they drifted:

| | value | last changed |
|---|---|---|
| generator | `persisted workspace-type package tracer`, `Seneca two-domain agent-product deployment proof` | #885, 2026-07-21 |
| checker | `Decision 28 fleet…F7 conformance`, `H2c/F2c contraction…` | #889, 2026-07-22 |

The committed JSON carries the checker's values, so normal CI is green — the mismatch only appears when something **regenerates** the file, which is exactly what a release does. v0.1.90 was cut 2026-07-20, before the drift, so this is the first release attempt to hit it.

## Fix

Align the generator to the checker (the newer values, from the #391 realignment) and add a cross-reference comment to both files so they get changed together.

## Proof

```
pnpm golden-path:timing
  wrote docs/issues/391/runtime-refactor/golden-path.json
node scripts/check-golden-path-invariants.mjs
  [p8] PASS golden-path version matches root package.json (0.1.90)
  [p8] PASS stagesPending records the current Decision 28 delivery gates
  [p8] PASS golden-path seconds include compile, resolve, and total
  [p8] PASS no public runtime none residue outside historical docs
  [p8] PASS no node:* imports in src/shared/**
  [p8] PASS no Buffer references in src/shared/**
  [p8] PASS no raw-path HTTP route module signatures
```

Only the two scripts change; the committed JSON is left untouched (the release regenerates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NxQWirpWsYV5Y6Tz8Txy5i