### PR TITLE
#909 fix(agent): make CSS builds CWD-independent

### DIFF
--- a/packages/agent/scripts/assert-build-artifacts.mjs
+++ b/packages/agent/scripts/assert-build-artifacts.mjs
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { access } from 'node:fs/promises'
+import { access, stat } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -25,6 +25,7 @@ const requiredFiles = [
   'dist/eval/index.js',
   'dist/eval/index.d.ts',
 ]
+const minimumFrontCssBytes = 100_000
 
 function resolveFromPackage(relPath) {
   return path.resolve(packageRoot, relPath)
@@ -52,6 +53,15 @@ function resolvePublishedJsExport(packageJson, exportName) {
 
 async function assertExists(relPath) {
   await access(resolveFromPackage(relPath), constants.F_OK)
+}
+
+async function assertMinimumSize(relPath, minimumBytes) {
+  const { size } = await stat(resolveFromPackage(relPath))
+  if (size < minimumBytes) {
+    throw new Error(
+      `${relPath} must be at least ${minimumBytes} bytes; got ${size} bytes`,
+    )
+  }
 }
 
 function assertNodeParsable(relPath) {
@@ -195,6 +205,7 @@ async function main() {
   for (const relPath of requiredFiles) {
     await assertExists(relPath)
   }
+  await assertMinimumSize('dist/front/styles.css', minimumFrontCssBytes)
   await assertExists(coreEntry.displayPath)
   await assertExists(serverEntry.displayPath)
 

--- a/packages/agent/scripts/build-front-css.mjs
+++ b/packages/agent/scripts/build-front-css.mjs
@@ -1,10 +1,12 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import postcss from "postcss"
 import tailwindcss from "@tailwindcss/postcss"
 
-const input = resolve("src/front/styles/globals.css")
-const output = resolve("dist/front/styles.css")
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const input = resolve(packageRoot, "src/front/styles/globals.css")
+const output = resolve(packageRoot, "dist/front/styles.css")
 
 const css = await readFile(input, "utf8")
 const result = await postcss([tailwindcss()]).process(css, {

--- a/packages/agent/src/front/styles/__tests__/build-front-css.test.ts
+++ b/packages/agent/src/front/styles/__tests__/build-front-css.test.ts
@@ -1,0 +1,25 @@
+import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const packageRoot = fileURLToPath(new URL("../../../../", import.meta.url))
+const repoRoot = path.resolve(packageRoot, "../..")
+const buildScript = path.resolve(packageRoot, "scripts/build-front-css.mjs")
+const output = path.resolve(packageRoot, "dist/front/styles.css")
+
+function buildFrom(cwd: string) {
+  execFileSync(process.execPath, [buildScript], { cwd })
+  return readFileSync(output)
+}
+
+describe("build-front-css", () => {
+  it("produces the same complete stylesheet from the repo root and package directory", () => {
+    const fromRepoRoot = buildFrom(repoRoot)
+    const fromPackageRoot = buildFrom(packageRoot)
+
+    expect(fromRepoRoot.byteLength).toBeGreaterThanOrEqual(100_000)
+    expect(fromPackageRoot).toEqual(fromRepoRoot)
+  })
+})

--- a/packages/workspace/scripts/build-workspace-css.mjs
+++ b/packages/workspace/scripts/build-workspace-css.mjs
@@ -1,16 +1,18 @@
 import { createRequire } from "node:module"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 import postcss from "postcss"
 import tailwindcss from "@tailwindcss/postcss"
 
 const require = createRequire(import.meta.url)
 
-const globalsInput = resolve("src/globals.css")
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const globalsInput = resolve(packageRoot, "src/globals.css")
 const dockviewCssPath = require.resolve("dockview-react/dist/styles/dockview.css")
-const dockviewOverridesPath = resolve("src/front/dock/dockview-overrides.css")
-const chatPaneStagePath = resolve("src/front/layout/chat-pane-stage.css")
-const output = resolve("dist/workspace.css")
+const dockviewOverridesPath = resolve(packageRoot, "src/front/dock/dockview-overrides.css")
+const chatPaneStagePath = resolve(packageRoot, "src/front/layout/chat-pane-stage.css")
+const output = resolve(packageRoot, "dist/workspace.css")
 
 const [dockviewCss, dockviewOverridesCss, chatPaneStageCss, globalsCss] = await Promise.all([
   readFile(dockviewCssPath, "utf8"),

--- a/packages/workspace/src/__tests__/build-workspace-css.test.ts
+++ b/packages/workspace/src/__tests__/build-workspace-css.test.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+const packageRoot = process.cwd()
+const repoRoot = path.resolve(packageRoot, "../..")
+const buildScript = path.resolve(packageRoot, "scripts/build-workspace-css.mjs")
+const output = path.resolve(packageRoot, "dist/workspace.css")
+
+function buildFrom(cwd: string) {
+  execFileSync(process.execPath, [buildScript], { cwd })
+  return readFileSync(output)
+}
+
+describe("build-workspace-css", () => {
+  it("produces the same complete stylesheet from the repo root and package directory", () => {
+    const fromRepoRoot = buildFrom(repoRoot)
+    const fromPackageRoot = buildFrom(packageRoot)
+
+    expect(fromRepoRoot.byteLength).toBeGreaterThanOrEqual(100_000)
+    expect(fromPackageRoot).toEqual(fromRepoRoot)
+  })
+})


### PR DESCRIPTION
## Summary

- resolve Agent front CSS input/output from the package root derived from `import.meta.url`
- reject empty or truncated `dist/front/styles.css` artifacts below 100,000 bytes
- fix the same CWD-sensitive path pattern found in the Workspace CSS builder
- add byte-for-byte CWD regression tests for both CSS builders

Bead: `wt-391-forward-0jpy.29`

## Pre-fix reproduction

From the repository root, the precise failing command in this checkout was:

```bash
node packages/agent/scripts/build-front-css.mjs
```

It exited 1 with:

```text
ENOENT: no such file or directory, open '<repo>/src/front/styles/globals.css'
```

The bead described a possible ~163-byte stylesheet; this revision failed earlier at the same CWD-dependent input resolution seam.

## Proof of work

### CSS output equivalence

All three paths produced the same artifact:

| Invocation | bytes | SHA-256 |
| --- | ---: | --- |
| repo root: `node packages/agent/scripts/build-front-css.mjs` | 166,525 | `15b7f1baea0deb2acb06185b9a86910b74fdb8770bb1c406a92c21077fed5d4b` |
| package dir: `(cd packages/agent && node scripts/build-front-css.mjs)` | 166,525 | `15b7f1baea0deb2acb06185b9a86910b74fdb8770bb1c406a92c21077fed5d4b` |
| playground chain: `pnpm --filter workspace-playground build:deps` | 166,525 | `15b7f1baea0deb2acb06185b9a86910b74fdb8770bb1c406a92c21077fed5d4b` |

### Negative proof

After deliberately truncating `packages/agent/dist/front/styles.css` to zero bytes:

```text
build-artifacts: FAIL
Error: dist/front/styles.css must be at least 100000 bytes; got 0 bytes
Exit status 1
```

The original 166,525-byte file was restored and its SHA-256 rechecked.

### Automated verification

- `pnpm --filter @hachej/boring-agent exec vitest run src/front/styles/__tests__/build-front-css.test.ts` ✅ (1 test)
- `pnpm --filter @hachej/boring-workspace exec vitest run src/__tests__/build-workspace-css.test.ts` ✅ (1 test)
- `pnpm typecheck` ✅
- root `lint` package script via Corepack's pnpm entrypoint ✅ (`generated-artifacts`, `agent-resources`, and import audit passed)
- `pnpm lint:invariants` ✅
- `git diff --check` ✅

Note: two direct `pnpm lint` attempts were terminated by the host command wrapper with `Linter process terminated abnormally`; invoking the same root package script through Corepack's pnpm entrypoint passed all three constituent checks.

### Sibling audit

- `packages/core/scripts/assert-build-artifacts.mjs`: already package-root-relative; no analogous CSS build script
- `packages/workspace/scripts/assert-build-artifacts.mjs`: already package-root-relative
- `packages/workspace/scripts/build-workspace-css.mjs`: had the same bare `resolve("src...")` pattern and is fixed/tested here

### Review

- final independent thermonuclear maintainability review: **CLEAN**

## Known gaps

- None.
