### PR TITLE
#935 Return actionable BSL query errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ apps/boring-macro-v2/src/plugins/macro/sdk/build/
 apps/boring-macro-v2/src/plugins/macro/transforms/**/__pycache__/
 apps/boring-macro-v2/src/plugins/macro/transforms/**/*.py[cod]
 packages/agent/fixtures/provisioning/test-sdk/**/__pycache__/
+plugins/data-bridge/python/__pycache__/
+plugins/data-bridge/src/server/bsl/fixtures/__pycache__/
 packages/agent/fixtures/provisioning/test-sdk/**/*.py[cod]
 packages/agent/fixtures/provisioning/test-sdk/*.egg-info/
 packages/agent/fixtures/provisioning/test-sdk/build/

--- a/plugins/data-bridge/python/bsl_worker.py
+++ b/plugins/data-bridge/python/bsl_worker.py
@@ -1,16 +1,31 @@
 import ast
 import json
+import sys
+import traceback
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import ibis
 from ibis import _
+from ibis.common.deferred import Deferred
+from ibis.expr.types import Table
 from returns.result import Failure, Success
 from boring_semantic_layer import from_yaml
 from boring_semantic_layer.utils import safe_eval
 
 
 MODEL_CACHE: Dict[str, Any] = {}
+
+BSL_INVALID_SYNTAX = "DATA_BRIDGE_BSL_INVALID_SYNTAX"
+BSL_DEFERRED_RESULT = "DATA_BRIDGE_BSL_DEFERRED_RESULT"
+BSL_NON_TABULAR_RESULT = "DATA_BRIDGE_BSL_NON_TABULAR_RESULT"
+BSL_EXECUTION_FAILED = "DATA_BRIDGE_BSL_EXECUTION_FAILED"
+
+
+class BslQueryError(Exception):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code
 
 
 def _model_key(payload: Dict[str, Any]) -> str:
@@ -35,11 +50,18 @@ def _resolve_models(payload: Dict[str, Any]) -> Dict[str, Any]:
 def _guard_query(query: str) -> None:
     try:
         tree = ast.parse(query, mode="eval")
-    except SyntaxError:
-        # Preserve BSL/safe_eval's existing syntax diagnostics.
-        return
+    except SyntaxError as exc:
+        raise BslQueryError(
+            BSL_INVALID_SYNTAX,
+            "BSL expression is incomplete or has invalid syntax; replace placeholders such as ... with a complete expression",
+        ) from exc
 
     for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and node.value is Ellipsis:
+            raise BslQueryError(
+                BSL_INVALID_SYNTAX,
+                "BSL expression is incomplete or has invalid syntax; replace placeholders such as ... with a complete expression",
+            )
         if isinstance(node, ast.Attribute) and node.attr.startswith("_"):
             raise ValueError("private/dunder attribute access is not allowed")
         if isinstance(node, ast.Name) and node.id != "_" and node.id.startswith("_"):
@@ -59,6 +81,20 @@ def _dtype_for_value(value):
     return "string"
 
 
+def _concrete_table(result: Any) -> Any:
+    if isinstance(result, Deferred):
+        raise BslQueryError(
+            BSL_DEFERRED_RESULT,
+            "BSL expression must return a concrete executable table; use _ only inside operations on a selected model such as sm.filter(...)",
+        )
+    if not isinstance(result, Table):
+        raise BslQueryError(
+            BSL_NON_TABULAR_RESULT,
+            "BSL expression must return a concrete executable table, not a scalar, column, or Python value",
+        )
+    return result
+
+
 def _query_to_table(payload: Dict[str, Any]) -> Dict[str, Any]:
     _guard_query(payload["query"])
     models = _resolve_models(payload)
@@ -68,8 +104,11 @@ def _query_to_table(payload: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(evaluated, Failure):
         raise evaluated.failure()
 
-    result = evaluated.unwrap() if isinstance(evaluated, Success) else evaluated
-    df = result.execute()
+    if not isinstance(evaluated, Success):
+        failure = evaluated.failure()
+        raise failure if isinstance(failure, BaseException) else RuntimeError(str(failure))
+    result = evaluated.unwrap()
+    df = _concrete_table(result).execute()
 
     limit = int(payload.get("limit") or 5000)
     rows = json.loads(df.head(limit).to_json(orient="records", date_format="iso"))
@@ -97,22 +136,35 @@ def _emit(payload: Dict[str, Any]) -> None:
     print(json.dumps(payload), flush=True)
 
 
-def _emit_error(id: str, message: str) -> None:
-    _emit({"id": id, "ok": False, "error": {"message": message}})
+def _emit_error(id: str, code: str, message: str) -> None:
+    _emit({"id": id, "ok": False, "error": {"code": code, "message": message}})
 
 
-def _handle_query_batch(message_id: str, payload: Dict[str, Any]) -> None:
+def _query_batch(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
     results = []
     for query in payload["queries"]:
         try:
             if not isinstance(query.get("query"), str):
-                results.append({"ok": False, "error": {"message": "invalid query payload"}})
+                results.append({"ok": False, "error": {
+                    "code": BSL_INVALID_SYNTAX,
+                    "message": "BSL query payload must include an expression string",
+                }})
                 continue
             results.append(_query_to_table(query))
-        except Exception as exc:
-            results.append({"ok": False, "error": {"message": str(exc) or exc.__class__.__name__}})
+        except BslQueryError as exc:
+            results.append({"ok": False, "error": {"code": exc.code, "message": str(exc)}})
+        except Exception:
+            traceback.print_exc(file=sys.stderr)
+            results.append({"ok": False, "error": {
+                "code": BSL_EXECUTION_FAILED,
+                "message": "BSL expression could not be evaluated; check the selected model and expression",
+            }})
 
-    _emit({"id": message_id, "ok": True, "payload": results})
+    return results
+
+
+def _handle_query_batch(message_id: str, payload: Dict[str, Any]) -> None:
+    _emit({"id": message_id, "ok": True, "payload": _query_batch(payload)})
 
 
 def _handle_ready(message_id: str) -> None:
@@ -120,7 +172,6 @@ def _handle_ready(message_id: str) -> None:
 
 
 def main() -> None:
-    import sys
     for raw_line in sys.stdin:
         if not raw_line.strip():
             continue
@@ -143,10 +194,11 @@ def main() -> None:
                 raise ValueError(f"unknown method: {method}")
         except SystemExit:
             raise
-        except json.JSONDecodeError as exc:
-            _emit_error(message_id, str(exc) or exc.__class__.__name__)
-        except Exception as exc:
-            _emit_error(message_id, str(exc) or exc.__class__.__name__)
+        except json.JSONDecodeError:
+            _emit_error(message_id, BSL_EXECUTION_FAILED, "Invalid BSL worker request")
+        except Exception:
+            traceback.print_exc(file=sys.stderr)
+            _emit_error(message_id, BSL_EXECUTION_FAILED, "BSL worker request failed")
 
 
 if __name__ == "__main__":

--- a/plugins/data-bridge/src/server/bsl/fixtures/bsl_worker_validation.py
+++ b/plugins/data-bridge/src/server/bsl/fixtures/bsl_worker_validation.py
@@ -1,0 +1,161 @@
+"""Dependency-free protocol validation for the real Data Bridge Python worker."""
+
+import contextlib
+import importlib.util
+import io
+import sys
+import types
+from pathlib import Path
+
+
+class Deferred:
+    pass
+
+
+class Table:
+    def execute(self):
+        return Frame()
+
+
+class Column:
+    pass
+
+
+class Success:
+    def __init__(self, value):
+        self.value = value
+
+    def unwrap(self):
+        return self.value
+
+
+class Failure:
+    def __init__(self, value):
+        self.value = value
+
+    def failure(self):
+        return self.value
+
+
+class Dtype:
+    def __str__(self):
+        return "int64"
+
+
+class Series:
+    dtype = Dtype()
+
+
+class Frame:
+    columns = ["value"]
+
+    def head(self, _limit):
+        return self
+
+    def to_json(self, orient, date_format):
+        assert orient == "records"
+        assert date_format == "iso"
+        return '[{"value": 1}]'
+
+    def __getitem__(self, _name):
+        return Series()
+
+    def __len__(self):
+        return 1
+
+
+class Model:
+    name = "semanticModel"
+    model = {"table": Table()}
+
+
+def install_stubs():
+    ibis = types.ModuleType("ibis")
+    ibis._ = Deferred()
+    ibis.interval = object()
+    ibis.literal = object()
+    ibis_common = types.ModuleType("ibis.common")
+    ibis_deferred = types.ModuleType("ibis.common.deferred")
+    ibis_deferred.Deferred = Deferred
+    ibis_expr = types.ModuleType("ibis.expr")
+    ibis_types = types.ModuleType("ibis.expr.types")
+    ibis_types.Table = Table
+
+    returns = types.ModuleType("returns")
+    returns_result = types.ModuleType("returns.result")
+    returns_result.Failure = Failure
+    returns_result.Success = Success
+
+    bsl = types.ModuleType("boring_semantic_layer")
+    bsl.from_yaml = lambda *_args, **_kwargs: {"semanticModel": Model()}
+    bsl_utils = types.ModuleType("boring_semantic_layer.utils")
+    bsl_utils.safe_eval = lambda *_args, **_kwargs: Success(Table())
+
+    sys.modules.update({
+        "ibis": ibis,
+        "ibis.common": ibis_common,
+        "ibis.common.deferred": ibis_deferred,
+        "ibis.expr": ibis_expr,
+        "ibis.expr.types": ibis_types,
+        "returns": returns,
+        "returns.result": returns_result,
+        "boring_semantic_layer": bsl,
+        "boring_semantic_layer.utils": bsl_utils,
+    })
+
+
+def load_worker():
+    install_stubs()
+    worker_path = Path(__file__).parents[4] / "python" / "bsl_worker.py"
+    spec = importlib.util.spec_from_file_location("data_bridge_bsl_worker", worker_path)
+    worker = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(worker)
+    return worker
+
+
+def main():
+    worker = load_worker()
+
+    def safe_eval(query, context):
+        assert "sm" in context
+        if query == "_":
+            return Success(Deferred())
+        if query == "scalar":
+            return Success(42)
+        if query == "column":
+            return Success(Column())
+        if query == "failure":
+            return Failure(ValueError("private diagnostic: /secret/model.yml"))
+        return Success(Table())
+
+    worker.safe_eval = safe_eval
+    queries = [
+        {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "sm.filter(...)", "limit": 10},
+        {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "_", "limit": 10},
+        {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "scalar", "limit": 10},
+        {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "column", "limit": 10},
+        {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "table", "limit": 10},
+        {"modelPath": "/tmp/model.yml", "model": "semanticModel", "query": "failure", "limit": 10},
+    ]
+    diagnostics = io.StringIO()
+    with contextlib.redirect_stderr(diagnostics):
+        results = worker._query_batch({"queries": queries})
+
+    assert [result["ok"] for result in results] == [False, False, False, False, True, False]
+    assert [results[index]["error"]["code"] for index in range(4)] == [
+        worker.BSL_INVALID_SYNTAX,
+        worker.BSL_DEFERRED_RESULT,
+        worker.BSL_NON_TABULAR_RESULT,
+        worker.BSL_NON_TABULAR_RESULT,
+    ]
+    assert results[4]["output"]["rows"] == [{"value": 1}]
+    assert results[5]["error"] == {
+        "code": worker.BSL_EXECUTION_FAILED,
+        "message": "BSL expression could not be evaluated; check the selected model and expression",
+    }
+    assert "/secret/model.yml" not in str(results)
+    assert "/secret/model.yml" in diagnostics.getvalue()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/data-bridge/src/server/bsl/pythonBslRuntime.test.ts
+++ b/plugins/data-bridge/src/server/bsl/pythonBslRuntime.test.ts
@@ -14,7 +14,10 @@ function bslQuery(overrides: Partial<PythonBslQuery> = {}): PythonBslQuery {
   }
 }
 
-function createFakeWorker(options: { hangQuery?: boolean } = {}) {
+function createFakeWorker(options: {
+  hangQuery?: boolean
+  queryError?: { code: string; message: string }
+} = {}) {
   const writes: unknown[] = []
   const stdout = new PassThrough()
   const stderr = new PassThrough()
@@ -44,17 +47,19 @@ function createFakeWorker(options: { hangQuery?: boolean } = {}) {
           emitMessage({
             id: message.id,
             ok: true,
-            payload: (message.payload?.queries ?? []).map((query) => ({
-              ok: true,
-              output: {
-                kind: "data-bridge.table",
-                version: 1,
-                columns: [{ name: "query", type: "string" }],
-                rows: [{ query: query.query }],
-                rowCount: 1,
-                source: "bsl",
-              },
-            })),
+            payload: (message.payload?.queries ?? []).map((query) => options.queryError
+              ? { ok: false, error: options.queryError }
+              : {
+                  ok: true,
+                  output: {
+                    kind: "data-bridge.table",
+                    version: 1,
+                    columns: [{ name: "query", type: "string" }],
+                    rows: [{ query: query.query }],
+                    rowCount: 1,
+                    source: "bsl",
+                  },
+                }),
           })
         }
       })
@@ -99,6 +104,43 @@ describe("PythonBslRuntime", () => {
 
     await runtime.close()
     expect(worker.child.kill).not.toHaveBeenCalled()
+  })
+
+  it("preserves stable per-query worker error codes", async () => {
+    const worker = createFakeWorker({
+      queryError: {
+        code: "DATA_BRIDGE_BSL_DEFERRED_RESULT",
+        message: "BSL expression must return a concrete executable table",
+      },
+    })
+    const runtime = new PythonBslRuntime({ spawn: vi.fn(() => worker.child as never), workerPath: "/worker.py" })
+
+    await expect(runtime.queryBatch([bslQuery({ query: "_" })])).resolves.toEqual([{
+      ok: false,
+      error: {
+        code: "DATA_BRIDGE_BSL_DEFERRED_RESULT",
+        message: "BSL expression must return a concrete executable table",
+      },
+    }])
+    await runtime.close()
+  })
+
+  it("keeps worker tracebacks in server diagnostics without returning them to callers", async () => {
+    const worker = createFakeWorker({ hangQuery: true })
+    const runtime = new PythonBslRuntime({ spawn: vi.fn(() => worker.child as never), workerPath: "/worker.py" })
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true)
+    const pending = runtime.queryBatch([bslQuery()])
+    await vi.waitFor(() => expect(worker.writes).toHaveLength(2))
+
+    worker.child.stderr.write("Traceback: /private/model.yml\n")
+    worker.child.emit("exit", 1, null)
+
+    await expect(pending).rejects.toMatchObject({
+      code: "BSL_WORKER_EXITED",
+      message: "BSL worker exited (code 1)",
+    })
+    expect(stderr).toHaveBeenCalledWith("Traceback: /private/model.yml\n")
+    stderr.mockRestore()
   })
 
   it("rejects aborted requests without killing the warm worker", async () => {

--- a/plugins/data-bridge/src/server/bsl/pythonBslRuntime.ts
+++ b/plugins/data-bridge/src/server/bsl/pythonBslRuntime.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs"
 import { setTimeout } from "node:timers/promises"
 import { fileURLToPath } from "node:url"
 
-import { type DataBridgeBslQuery, type DataBridgeTableResult } from "../../shared"
+import { type DataBridgeBslError, type DataBridgeBslQuery, type DataBridgeTableResult } from "../../shared"
 
 const MAX_STDERR_BYTES = 4_096
 const MAX_QUEUED_OPERATIONS = 100
@@ -21,6 +21,7 @@ type WorkerMessageError = {
   id: string
   ok: false
   error: {
+    code: string
     message: string
   }
 }
@@ -33,7 +34,7 @@ export type PythonBslQuery = DataBridgeBslQuery & {
 
 export type PythonBslRuntimeRequestResult =
   | { ok: true; output: DataBridgeTableResult }
-  | { ok: false; error: { message: string } }
+  | { ok: false; error: DataBridgeBslError }
 
 export interface PythonBslRuntimeOptions {
   pythonExecutable?: string
@@ -129,15 +130,16 @@ export class PythonBslRuntime {
     }
 
     const onStderr = (chunk: Buffer | string) => {
-      this.stderrBuffer = `${this.stderrBuffer}${String(chunk)}`.slice(-MAX_STDERR_BYTES)
+      const diagnostics = String(chunk)
+      this.stderrBuffer = `${this.stderrBuffer}${diagnostics}`.slice(-MAX_STDERR_BYTES)
+      process.stderr.write(diagnostics)
     }
 
     const onExit = (code: number | null, codeSignal: NodeJS.Signals | null) => {
       child.stdout.off("data", onStdout)
       child.stderr.off("data", onStderr)
       const details = code === null ? `signal ${String(codeSignal)}` : `code ${code}`
-      const stderr = this.stderrBuffer.trim()
-      this.handleWorkerFailure(bslRuntimeError(`BSL worker exited (${details})${stderr ? `: ${stderr}` : ""}`, "BSL_WORKER_EXITED"))
+      this.handleWorkerFailure(bslRuntimeError(`BSL worker exited (${details})`, "BSL_WORKER_EXITED"))
     }
 
     child.stdout.on("data", onStdout)

--- a/plugins/data-bridge/src/server/bsl/pythonBslWorker.test.ts
+++ b/plugins/data-bridge/src/server/bsl/pythonBslWorker.test.ts
@@ -1,0 +1,13 @@
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const validationScript = fileURLToPath(new URL("./fixtures/bsl_worker_validation.py", import.meta.url))
+
+describe("bsl_worker validation", () => {
+  it("classifies invalid and non-tabular results while isolating ordered batch failures", () => {
+    const result = spawnSync("python3", [validationScript], { encoding: "utf8" })
+
+    expect(result.status, result.stderr || result.stdout).toBe(0)
+  })
+})

--- a/plugins/data-bridge/src/server/index.test.ts
+++ b/plugins/data-bridge/src/server/index.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { describe, expect, it, vi } from "vitest"
 
 import { createWorkspaceBridgeRegistry, type WorkspaceBridgeCallResponse } from "@hachej/boring-workspace/server"
-import { DATA_BRIDGE_QUERY_BATCH_OP, DATA_BRIDGE_QUERY_RUN_OP, type DataBridgeQueryBatchOutput, type DataBridgeTableResult } from "../shared"
+import { DATA_BRIDGE_BSL_ERROR_CODES, DATA_BRIDGE_QUERY_BATCH_OP, DATA_BRIDGE_QUERY_RUN_OP, type DataBridgeQueryBatchOutput, type DataBridgeTableResult } from "../shared"
 import { createClickHouseDataBridgeAdapter, createDataBridgeQueryAgentTool, createDataBridgeServerPlugin, type DataBridgeSqlAdapter } from "./index"
 
 const { clickHouseQuery, clickHouseExec } = vi.hoisted(() => ({ clickHouseQuery: vi.fn(), clickHouseExec: vi.fn() }))
@@ -345,9 +345,12 @@ describe("data bridge BSL runtime integration", () => {
     })], expect.any(AbortSignal))
   })
 
-  it("routes all BSL batch items through one runtime call and preserves item errors", async () => {
+  it("routes mixed batches through shared BSL validation and preserves ordered item errors", async () => {
     const queryBatch = vi.fn(async () => [
-      { ok: false as const, error: { message: "bad model" } },
+      { ok: false as const, error: {
+        code: DATA_BRIDGE_BSL_ERROR_CODES.deferredResult,
+        message: "BSL expression must return a concrete executable table",
+      } },
       {
         ok: true as const,
         output: {
@@ -360,10 +363,18 @@ describe("data bridge BSL runtime integration", () => {
         },
       },
     ])
+    const sqlExecute = vi.fn(async () => ({
+      kind: "data-bridge.table" as const,
+      version: 1 as const,
+      columns: [{ name: "sql", type: "integer" as const }],
+      rows: [{ sql: 1 }],
+      rowCount: 1,
+    }))
     const plugin = createDataBridgeServerPlugin({
       workspaceRoot: createWorkspaceFixture(),
       bslModelPath: "/tmp/model.yml",
       bslRuntime: { queryBatch, close: vi.fn() } as unknown as Parameters<typeof createDataBridgeServerPlugin>[0]["bslRuntime"],
+      sqlAdapters: { test: { execute: sqlExecute } },
       agentTool: false,
     })
     const registry = createWorkspaceBridgeRegistry()
@@ -376,9 +387,57 @@ describe("data bridge BSL runtime integration", () => {
       input: {
         queries: [
           { id: "bad", input: { query: { language: "bsl", model: "semanticModel", query: "bad" } } },
+          { id: "sql", input: { query: { language: "sql", source: "test", sql: "SELECT 1" } } },
           { id: "good", input: { query: { language: "bsl", model: "semanticModel", query: "good" } } },
         ],
       },
+    }, {
+      callerClass: "runtime",
+      workspaceId: "workspace-test",
+      capabilities: ["data:read", "data:sql-query"],
+      actor: { actorKind: "agent", performedBy: { label: "test" } },
+    })
+
+    expect(res.ok).toBe(true)
+    const output = res.ok ? res.output as DataBridgeQueryBatchOutput : undefined
+    expect(output?.results).toMatchObject([
+      {
+        id: "bad",
+        ok: false,
+        error: {
+          code: DATA_BRIDGE_BSL_ERROR_CODES.deferredResult,
+          message: "BSL expression must return a concrete executable table",
+        },
+      },
+      { id: "sql", ok: true, output: { rows: [{ sql: 1 }] } },
+      { id: "good", ok: true, output: { rows: [{ value: 2 }] } },
+    ])
+    expect(queryBatch).toHaveBeenCalledTimes(1)
+    expect(sqlExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns a canonical bridge error with the actionable BSL code and message", async () => {
+    const queryBatch = vi.fn(async () => [{
+      ok: false as const,
+      error: {
+        code: DATA_BRIDGE_BSL_ERROR_CODES.invalidSyntax,
+        message: "BSL expression is incomplete or has invalid syntax",
+      },
+    }])
+    const plugin = createDataBridgeServerPlugin({
+      workspaceRoot: createWorkspaceFixture(),
+      bslModelPath: "/tmp/model.yml",
+      bslRuntime: { queryBatch, close: vi.fn() } as unknown as Parameters<typeof createDataBridgeServerPlugin>[0]["bslRuntime"],
+      agentTool: false,
+    })
+    const registry = createWorkspaceBridgeRegistry()
+    for (const contribution of plugin.workspaceBridgeHandlers ?? []) {
+      registry.registerHandler(contribution.definition, contribution.handler)
+    }
+
+    const res = await registry.call({
+      op: DATA_BRIDGE_QUERY_RUN_OP,
+      input: { query: { language: "bsl", model: "semanticModel", query: "sm.filter(...)" } },
     }, {
       callerClass: "runtime",
       workspaceId: "workspace-test",
@@ -386,13 +445,13 @@ describe("data bridge BSL runtime integration", () => {
       actor: { actorKind: "agent", performedBy: { label: "test" } },
     })
 
-    expect(res.ok).toBe(true)
-    const output = res.ok ? res.output as DataBridgeQueryBatchOutput : undefined
-    expect(output?.results).toMatchObject([
-      { id: "bad", ok: false, error: { message: "bad model" } },
-      { id: "good", ok: true, output: { rows: [{ value: 2 }] } },
-    ])
-    expect(queryBatch).toHaveBeenCalledTimes(1)
+    expect(res).toMatchObject({
+      ok: false,
+      error: {
+        code: "BRIDGE_INVALID_REQUEST",
+        message: `${DATA_BRIDGE_BSL_ERROR_CODES.invalidSyntax}: BSL expression is incomplete or has invalid syntax`,
+      },
+    })
   })
 })
 
@@ -452,6 +511,34 @@ describe("data bridge agent tool", () => {
       params: { frequency: "monthly" },
       limit: 2,
     }))
+  })
+
+  it("returns the same actionable BSL error through query_data", async () => {
+    const queryBatch = vi.fn(async () => [{
+      ok: false as const,
+      error: {
+        code: DATA_BRIDGE_BSL_ERROR_CODES.deferredResult,
+        message: "BSL expression must return a concrete executable table",
+      },
+    }])
+    const tool = createDataBridgeQueryAgentTool({
+      workspaceRoot: createWorkspaceFixture(),
+      bslModelPath: "/tmp/model.yml",
+      bslRuntime: { queryBatch, close: vi.fn() } as unknown as Parameters<typeof createDataBridgeQueryAgentTool>[0]["bslRuntime"],
+    })
+
+    const result = await tool.execute({
+      language: "bsl",
+      model: "semanticModel",
+      query: "_.filter(...) ",
+    }, toolContext())
+
+    expect(result).toMatchObject({
+      isError: true,
+      content: [{
+        text: `${DATA_BRIDGE_BSL_ERROR_CODES.deferredResult}: BSL expression must return a concrete executable table`,
+      }],
+    })
   })
 
   it("rejects invalid tool inputs before execution", async () => {

--- a/plugins/data-bridge/src/server/index.ts
+++ b/plugins/data-bridge/src/server/index.ts
@@ -2,13 +2,16 @@ import type { FastifyPluginAsync } from "fastify"
 import type { NodeClickHouseClientConfigOptions } from "@clickhouse/client/dist/config"
 import type { AgentTool, ToolResult } from "@hachej/boring-workspace"
 import {
+  createWorkspaceBridgeError,
   defineServerPlugin,
   defineTrustedDomainBridgeHandler,
+  WorkspaceBridgeErrorCode,
   type WorkspaceServerPlugin,
   type WorkspaceBridgeHandlerContribution,
 } from "@hachej/boring-workspace/server"
 import type {
   DataBridgeArrowResult,
+  DataBridgeBslError,
   DataBridgeBslQuery,
   DataBridgeQueryBatchInput,
   DataBridgeQueryBatchItemResult,
@@ -119,6 +122,10 @@ function bslPayload(options: CreateDataBridgeServerPluginOptions, input: DataBri
   }
 }
 
+function formatBslError(error: DataBridgeBslError): string {
+  return `${error.code}: ${error.message}`
+}
+
 async function runBslQuery(
   runtime: PythonBslRuntime,
   options: CreateDataBridgeServerPluginOptions,
@@ -127,8 +134,11 @@ async function runBslQuery(
 ): Promise<DataBridgeTableResult> {
   const results = await runtime.queryBatch([bslPayload(options, input)], signal)
   const first = results.at(0)
-  if (!first || !first.ok) {
-    throw new Error(first?.error.message ?? "BSL query failed")
+  if (!first) {
+    throw createWorkspaceBridgeError(WorkspaceBridgeErrorCode.HandlerFailed, "BSL query failed")
+  }
+  if (!first.ok) {
+    throw createWorkspaceBridgeError(WorkspaceBridgeErrorCode.InvalidRequest, formatBslError(first.error))
   }
   return first.output
 }
@@ -367,14 +377,16 @@ export function createDataBridgeQueryAgentTool(options: CreateDataBridgeServerPl
         const result = await executeQuery(runtime, options, input, capabilities, "json", ctx.abortSignal)
         return textResult(JSON.stringify(result, null, 2), result)
       } catch (error) {
-        return errorResult(error instanceof Error ? error.message : String(error))
+        return errorResult(errorMessage(error))
       }
     },
   }
 }
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
+  if (error instanceof Error) return error.message
+  if (isRecord(error) && typeof error.message === "string") return error.message
+  return String(error)
 }
 
 async function executeBatch(

--- a/plugins/data-bridge/src/shared/index.ts
+++ b/plugins/data-bridge/src/shared/index.ts
@@ -1,6 +1,25 @@
 export const DATA_BRIDGE_QUERY_RUN_OP = "data.v1.query.run" as const
 export const DATA_BRIDGE_QUERY_BATCH_OP = "data.v1.query.batch" as const
 
+export const DATA_BRIDGE_BSL_ERROR_CODES = {
+  invalidSyntax: "DATA_BRIDGE_BSL_INVALID_SYNTAX",
+  deferredResult: "DATA_BRIDGE_BSL_DEFERRED_RESULT",
+  nonTabularResult: "DATA_BRIDGE_BSL_NON_TABULAR_RESULT",
+  executionFailed: "DATA_BRIDGE_BSL_EXECUTION_FAILED",
+} as const
+
+export type DataBridgeBslErrorCode = typeof DATA_BRIDGE_BSL_ERROR_CODES[keyof typeof DATA_BRIDGE_BSL_ERROR_CODES]
+
+export interface DataBridgeBslError {
+  code: DataBridgeBslErrorCode
+  message: string
+}
+
+export interface DataBridgeQueryError {
+  code?: DataBridgeBslErrorCode
+  message: string
+}
+
 export type DataBridgeScalarType = "string" | "integer" | "float" | "boolean" | "date" | "datetime" | "json"
 export type DataBridgeRole = "dimension" | "measure" | "time" | "unknown"
 export type DataBridgeQueryFormat = "json" | "arrow"
@@ -76,7 +95,7 @@ export type DataBridgeQueryBatchItemResult =
   | {
     id: string
     ok: false
-    error: { message: string }
+    error: DataBridgeQueryError
   }
 
 export interface DataBridgeQueryBatchOutput {


### PR DESCRIPTION
Closes #935

## Summary
- reject malformed and placeholder BSL expressions with stable, actionable error codes
- require `safe_eval` to produce a concrete executable Ibis table, with specific Deferred/non-tabular guidance
- preserve per-item ordering and failure isolation in mixed SQL/BSL batches
- keep Python tracebacks in server diagnostics while returning sanitized client errors
- propagate consistent BSL code/message text through `query_data` and `data.v1.query.run`

## Proof
- `pnpm --filter @hachej/boring-data-bridge test` — 25 passed
- `pnpm --filter @hachej/boring-data-bridge typecheck` — passed
- direct dependency-free worker fixture covers malformed/Ellipsis syntax, Deferred, scalar/column, valid table, isolated batch failure, and traceback redaction
- `git diff --check` — passed

## Review
- Fresh review identified missing direct Python-worker coverage; addressed with `pythonBslWorker.test.ts` and `bsl_worker_validation.py`.
- Final reviewer path concern was disproven by executing the fixture and full package suite successfully.
