### PR TITLE
#909 re-land native session adoption and rename menu

### DIFF
--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -11,6 +11,33 @@ async function runCommand(page: Page, command: string): Promise<void> {
   await expect(palette).toBeHidden()
 }
 
+async function sendFirstAddressedMessage(
+  page: Page,
+  chat: ReturnType<Page["locator"]>,
+  agentTypeId: string,
+  prompt: string,
+): Promise<string> {
+  const localSessionId = await chat.getAttribute("data-pi-chat-session-id")
+  expect(localSessionId).toMatch(/^local-/)
+  const created = page.waitForResponse((response) => {
+    const url = new URL(response.url())
+    return response.request().method() === "POST"
+      && url.pathname === `/api/v1/agents/${agentTypeId}/sessions`
+  })
+  await chat.getByRole("textbox", { name: "Agent prompt" }).fill(prompt)
+  await chat.locator('[data-boring-agent-part="composer-submit"]').click()
+  expect((await created).status()).toBe(201)
+
+  let adoptedSessionId = ""
+  await expect.poll(async () => {
+    adoptedSessionId = await chat.getAttribute("data-pi-chat-session-id") ?? ""
+    return adoptedSessionId
+  }, { timeout: 15_000 }).not.toBe(localSessionId)
+  expect(adoptedSessionId).not.toMatch(/^local-/)
+  await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+  return adoptedSessionId
+}
+
 test.describe("addressed Agent Host browser wire", () => {
   test("retains the golden operations across two agents and a mid-stream reload without legacy requests", async ({ page }) => {
     test.setTimeout(180_000)
@@ -66,7 +93,7 @@ test.describe("addressed Agent Host browser wire", () => {
     const activeChatPane = page.locator('[data-boring-workspace-part="chat-pane"][data-boring-state="active"]')
     const chat = activeChatPane.locator('[data-boring-agent-part="chat"]')
     await expect(chat).toHaveAttribute("data-agent-type-id", "alpha")
-    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+    await expect(chat).toHaveAttribute("data-pi-chat-connection", "disconnected")
     const composer = activeChatPane.getByRole("textbox", { name: "Agent prompt" })
     await expect(composer).toBeVisible({ timeout: 15_000 })
     await expect(composer).toBeEnabled({ timeout: 15_000 })
@@ -76,24 +103,17 @@ test.describe("addressed Agent Host browser wire", () => {
     const workspaceMeta = await (await page.request.get("/api/v1/workspace/meta")).json() as { workspaceId: string }
     const workspaceHeaders = { "x-boring-workspace-id": workspaceMeta.workspaceId }
     const initialAlphaSessionId = await chat.getAttribute("data-pi-chat-session-id")
-    const alphaSessionCreated = page.waitForResponse((response) => {
-      const url = new URL(response.url())
-      return response.request().method() === "POST"
-        && url.pathname === "/api/v1/agents/alpha/sessions"
-    })
     await runCommand(page, "New Chat")
-    expect((await alphaSessionCreated).status()).toBe(201)
-    let alphaSessionId: string | null = null
+    let alphaDraftSessionId: string | null = null
     await expect.poll(async () => {
       const nextSessionId = await chat.getAttribute("data-pi-chat-session-id")
-      alphaSessionId = nextSessionId && nextSessionId !== initialAlphaSessionId ? nextSessionId : null
-      return alphaSessionId
+      alphaDraftSessionId = nextSessionId && nextSessionId !== initialAlphaSessionId ? nextSessionId : null
+      return alphaDraftSessionId
     }, { timeout: 10_000 }).not.toBeNull()
-    expect(alphaSessionId).toBeTruthy()
+    expect(alphaDraftSessionId).toMatch(/^local-/)
 
     const goldenPrompt = `golden prompt ${Date.now()}`
-    await composer.fill(goldenPrompt)
-    await page.locator('[data-boring-agent-part="composer-submit"]').click()
+    const alphaSessionId = await sendFirstAddressedMessage(page, chat, "alpha", goldenPrompt)
     await expect(page.getByTestId("chat-working")).toBeVisible({ timeout: 10_000 })
     await expect(page.getByLabel("Agent conversation").getByText(goldenPrompt)).toBeVisible()
 
@@ -198,30 +218,22 @@ test.describe("addressed Agent Host browser wire", () => {
     await expect(startFirstChat).toBeVisible({ timeout: 15_000 })
     await startFirstChat.click()
     await expect(chat).toHaveAttribute("data-agent-type-id", "beta", { timeout: 10_000 })
-    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+    await expect(chat).toHaveAttribute("data-pi-chat-connection", "disconnected")
     await expect(composer).toBeEnabled({ timeout: 15_000 })
 
     const initialBetaSessionId = await chat.getAttribute("data-pi-chat-session-id")
-    const betaSessionCreated = page.waitForResponse((response) => {
-      const url = new URL(response.url())
-      return response.request().method() === "POST"
-        && url.pathname === "/api/v1/agents/beta/sessions"
-    })
     await runCommand(page, "New Chat")
-    expect((await betaSessionCreated).status()).toBe(201)
-    let betaSessionId: string | null = null
+    let betaDraftSessionId: string | null = null
     await expect.poll(async () => {
       const nextSessionId = await chat.getAttribute("data-pi-chat-session-id")
-      betaSessionId = nextSessionId && nextSessionId !== initialBetaSessionId ? nextSessionId : null
-      return betaSessionId
+      betaDraftSessionId = nextSessionId && nextSessionId !== initialBetaSessionId ? nextSessionId : null
+      return betaDraftSessionId
     }, { timeout: 10_000 }).not.toBeNull()
-    expect(betaSessionId).toBeTruthy()
-    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+    expect(betaDraftSessionId).toMatch(/^local-/)
     await expect(composer).toBeEnabled({ timeout: 15_000 })
 
     const betaPrompt = `beta streamed prompt ${Date.now()}`
-    await composer.fill(betaPrompt)
-    await chat.locator('[data-boring-agent-part="composer-submit"]').click()
+    const betaSessionId = await sendFirstAddressedMessage(page, chat, "beta", betaPrompt)
     await expect(chat.getByTestId("chat-working")).toBeVisible({ timeout: 10_000 })
     await expect(chat.getByLabel("Agent conversation").getByText(betaPrompt)).toBeVisible()
     await expect(chat.getByText("PI_NATIVE_ASSISTANT_DONE")).toBeVisible({ timeout: 20_000 })
@@ -238,18 +250,12 @@ test.describe("addressed Agent Host browser wire", () => {
       status: deletion.status(),
     })
 
-    const betaReplacementCreated = page.waitForResponse((response) => {
-      const url = new URL(response.url())
-      return response.request().method() === "POST"
-        && url.pathname === "/api/v1/agents/beta/sessions"
-    })
     await runCommand(page, "New Chat")
-    expect((await betaReplacementCreated).status()).toBe(201)
     await expect.poll(async () => {
       const nextSessionId = await chat.getAttribute("data-pi-chat-session-id")
       return nextSessionId && nextSessionId !== betaSessionId ? nextSessionId : null
     }, { timeout: 10_000 }).not.toBeNull()
-    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+    await expect(chat).toHaveAttribute("data-pi-chat-connection", "disconnected")
 
     await selector.selectOption("alpha")
     await expect(chat).toHaveAttribute("data-agent-type-id", "alpha", { timeout: 10_000 })
@@ -319,36 +325,32 @@ test.describe("addressed Agent Host browser wire", () => {
     const ensureAddressedChat = async (agentTypeId: string) => {
       const chat = page.locator(`[data-boring-agent-part="chat"][data-agent-type-id="${agentTypeId}"]`).last()
       const startFirstChat = page.getByRole("button", { name: "Start new chat" })
-      await expect.poll(async () => {
-        if (await startFirstChat.isVisible()) return "empty"
-        return await chat.getAttribute("data-pi-chat-connection") ?? "pending"
-      }, { timeout: 30_000 }).toMatch(/^(empty|connected)$/)
+      await expect.poll(async () => await startFirstChat.isVisible() || await chat.count() > 0, {
+        timeout: 30_000,
+      }).toBe(true)
       if (await startFirstChat.isVisible()) {
         await expect(page.locator(
           `[data-boring-agent-part="chat"][data-agent-type-id="${agentTypeId}"][data-pi-chat-session-id="default"]`,
         )).toHaveCount(0)
         await startFirstChat.click()
+      } else {
+        await runCommand(page, "New Chat")
       }
-      await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
+      await expect(chat).toHaveAttribute("data-pi-chat-session-id", /^local-/, { timeout: 15_000 })
+      await expect(chat).toHaveAttribute("data-pi-chat-connection", "disconnected")
       return chat
     }
 
     const alphaChat = await ensureAddressedChat("alpha")
-    const alphaSessionId = await alphaChat.getAttribute("data-pi-chat-session-id")
-    expect(alphaSessionId).toBeTruthy()
     const alphaPrompt = `alpha concurrent ${Date.now()}`
-    await alphaChat.getByRole("textbox", { name: "Agent prompt" }).fill(alphaPrompt)
-    await alphaChat.locator('[data-boring-agent-part="composer-submit"]').click()
+    const alphaSessionId = await sendFirstAddressedMessage(page, alphaChat, "alpha", alphaPrompt)
     await expect(alphaChat.getByTestId("chat-working")).toBeVisible({ timeout: 10_000 })
     await expect(page.getByLabel("Alpha streaming")).toBeVisible()
 
     await selector.selectOption("beta")
     const betaChat = await ensureAddressedChat("beta")
-    const betaSessionId = await betaChat.getAttribute("data-pi-chat-session-id")
-    expect(betaSessionId).toBeTruthy()
     const betaPrompt = `beta concurrent ${Date.now()}`
-    await betaChat.getByRole("textbox", { name: "Agent prompt" }).fill(betaPrompt)
-    await betaChat.locator('[data-boring-agent-part="composer-submit"]').click()
+    const betaSessionId = await sendFirstAddressedMessage(page, betaChat, "beta", betaPrompt)
     await expect(betaChat.getByTestId("chat-working")).toBeVisible({ timeout: 10_000 })
     await expect(page.getByLabel("Beta streaming")).toBeVisible()
 
@@ -415,16 +417,19 @@ test.describe("addressed Agent Host browser wire", () => {
 
     await page.goto("/?fresh=1")
     await expect(page.getByRole("combobox", { name: "Agent" })).toHaveCount(0)
+    const startFirstChat = page.getByRole("button", { name: "Start new chat" })
+    await expect.poll(async () => await startFirstChat.isVisible() || await page.locator(
+      '[data-boring-agent-part="chat"][data-agent-type-id="alpha"]',
+    ).count() > 0, { timeout: 15_000 }).toBe(true)
+    if (await startFirstChat.isVisible()) await startFirstChat.click()
+    else await runCommand(page, "New Chat")
     const chat = page.locator('[data-boring-agent-part="chat"][data-agent-type-id="alpha"]').last()
-    await expect(chat).toHaveAttribute("data-pi-chat-connection", "connected", { timeout: 15_000 })
-    const sessionId = await chat.getAttribute("data-pi-chat-session-id")
-    expect(sessionId).toBeTruthy()
+    await expect(chat).toHaveAttribute("data-pi-chat-session-id", /^local-/, { timeout: 15_000 })
     const completion = chat.getByLabel("Agent conversation")
       .getByText("PI_NATIVE_ASSISTANT_DONE:alpha", { exact: true })
     const completionCountBefore = await completion.count()
     const prompt = `single addressed ${Date.now()}`
-    await chat.getByRole("textbox", { name: "Agent prompt" }).fill(prompt)
-    await chat.locator('[data-boring-agent-part="composer-submit"]').click()
+    const sessionId = await sendFirstAddressedMessage(page, chat, "alpha", prompt)
     await expect(chat).toHaveAttribute("data-pi-chat-session-id", sessionId!)
     await expect(chat.getByTestId("chat-working")).toBeVisible({ timeout: 10_000 })
     await expect(chat.getByLabel("Agent conversation").getByText(prompt)).toHaveCount(1)

--- a/apps/workspace-playground/e2e/native-session-regressions.spec.ts
+++ b/apps/workspace-playground/e2e/native-session-regressions.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test, type Page } from "@playwright/test"
+
+async function runCommand(page: Page, command: string): Promise<void> {
+  await page.keyboard.press("ControlOrMeta+KeyK")
+  const palette = page.getByRole("dialog", { name: /command palette/i })
+  await expect(palette).toBeVisible()
+  await page.keyboard.type(`>${command}`)
+  await page.getByRole("option", { name: new RegExp(command, "i") }).first().click()
+  await expect(palette).toBeHidden()
+}
+
+async function openFreshWorkspace(page: Page): Promise<void> {
+  await page.goto("/?fresh=1")
+  await expect(page.locator('aside[aria-label="App navigation"]')).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByRole("combobox", { name: "Agent" })).toHaveValue("alpha", { timeout: 10_000 })
+}
+
+async function createLocalChat(page: Page): Promise<{
+  chat: ReturnType<Page["locator"]>
+  composer: ReturnType<Page["getByRole"]>
+  localSessionId: string
+}> {
+  const createdRequests: string[] = []
+  const recordCreate = (request: import("@playwright/test").Request) => {
+    const url = new URL(request.url())
+    if (request.method() === "POST" && url.pathname === "/api/v1/agents/alpha/sessions") {
+      createdRequests.push(url.pathname)
+    }
+  }
+  page.on("request", recordCreate)
+  await runCommand(page, "New Chat")
+  const activePane = page.locator('[data-boring-workspace-part="chat-pane"][data-boring-state="active"]')
+  const chat = activePane.locator('[data-boring-agent-part="chat"]')
+  await expect(chat).toBeVisible({ timeout: 10_000 })
+  await expect(chat).toHaveAttribute("data-agent-type-id", "alpha")
+  const localSessionId = await chat.getAttribute("data-pi-chat-session-id")
+  expect(localSessionId).toMatch(/^local-/)
+  await page.waitForTimeout(300)
+  expect(createdRequests, "opening a chat must not create a durable server session before first send").toEqual([])
+  page.off("request", recordCreate)
+  return {
+    chat,
+    composer: activePane.getByRole("textbox", { name: "Agent prompt" }),
+    localSessionId: localSessionId!,
+  }
+}
+
+async function sendFirstMessage(
+  page: Page,
+  chat: ReturnType<Page["locator"]>,
+  composer: ReturnType<Page["getByRole"]>,
+  localSessionId: string,
+  prompt: string,
+): Promise<string> {
+  const created = page.waitForResponse((response) => {
+    const url = new URL(response.url())
+    return response.request().method() === "POST"
+      && url.pathname === "/api/v1/agents/alpha/sessions"
+  })
+  await composer.fill(prompt)
+  await chat.locator('[data-boring-agent-part="composer-submit"]').click()
+  expect((await created).status()).toBe(201)
+  await expect(chat.getByLabel("Agent conversation").getByText(prompt)).toBeVisible({ timeout: 10_000 })
+  await expect(chat.getByText("PI_NATIVE_ASSISTANT_DONE:alpha", { exact: true })).toBeVisible({ timeout: 30_000 })
+  await expect(chat.getByTestId("chat-working")).toHaveCount(0, { timeout: 30_000 })
+
+  let adoptedSessionId = ""
+  await expect.poll(async () => {
+    adoptedSessionId = await chat.getAttribute("data-pi-chat-session-id") ?? ""
+    return adoptedSessionId
+  }, { timeout: 10_000 }).not.toBe(localSessionId)
+  expect(adoptedSessionId).not.toMatch(/^local-/)
+  return adoptedSessionId
+}
+
+test.describe("native addressed session regressions", () => {
+  test("first message creates, adopts, streams, and can be renamed from the session menu", async ({ page }) => {
+    test.setTimeout(90_000)
+    await openFreshWorkspace(page)
+    const { chat, composer, localSessionId } = await createLocalChat(page)
+    const prompt = `first native prompt ${Date.now()}`
+    const nativeSessionId = await sendFirstMessage(page, chat, composer, localSessionId, prompt)
+
+    const row = page.locator(
+      `[data-boring-workspace-part="app-session-row"][data-boring-session-id="${nativeSessionId}"]`,
+    )
+    await expect(row).toBeVisible({ timeout: 10_000 })
+    await row.hover()
+    await row.getByRole("button", { name: /More options for/ }).click()
+    await page.getByRole("menuitem", { name: "Rename" }).click()
+    const rename = row.getByRole("textbox", { name: "Rename session" })
+    const renamed = `Renamed native ${Date.now()}`
+    await rename.fill(renamed)
+    await rename.press("Enter")
+    await expect(row).toContainText(renamed, { timeout: 10_000 })
+  })
+
+  test("switching between two adopted sessions renders the matching transcript", async ({ page }) => {
+    test.setTimeout(120_000)
+    await openFreshWorkspace(page)
+
+    const first = await createLocalChat(page)
+    const firstPrompt = `first transcript ${Date.now()}`
+    const firstSessionId = await sendFirstMessage(
+      page,
+      first.chat,
+      first.composer,
+      first.localSessionId,
+      firstPrompt,
+    )
+
+    const second = await createLocalChat(page)
+    const secondPrompt = `second transcript ${Date.now()}`
+    const secondSessionId = await sendFirstMessage(
+      page,
+      second.chat,
+      second.composer,
+      second.localSessionId,
+      secondPrompt,
+    )
+    expect(secondSessionId).not.toBe(firstSessionId)
+    await expect(second.chat.getByLabel("Agent conversation").getByText(secondPrompt)).toBeVisible()
+
+    const firstRow = page.locator(
+      `[data-boring-workspace-part="app-session-row"][data-boring-session-id="${firstSessionId}"]`,
+    )
+    await firstRow.getByRole("button").first().click()
+    const activeChat = page.locator(
+      '[data-boring-workspace-part="chat-pane"][data-boring-state="active"] [data-boring-agent-part="chat"]',
+    )
+    await expect(activeChat).toHaveAttribute("data-pi-chat-session-id", firstSessionId, { timeout: 10_000 })
+    await expect(activeChat.getByLabel("Agent conversation").getByText(firstPrompt)).toBeVisible({ timeout: 15_000 })
+    await expect(activeChat.getByLabel("Agent conversation").getByText(secondPrompt)).toHaveCount(0)
+  })
+
+  test("a newly created local chat renders without a wake-up click", async ({ page }) => {
+    test.setTimeout(60_000)
+    await openFreshWorkspace(page)
+    const { chat, composer, localSessionId } = await createLocalChat(page)
+
+    await expect(chat).toHaveAttribute("data-pi-chat-session-id", localSessionId)
+    await expect(chat.getByLabel("Agent conversation")).toBeVisible()
+    await expect(composer).toBeVisible()
+    await expect(composer).toBeEnabled()
+    await expect(chat.locator('[data-boring-agent-part="composer-submit"]')).toBeVisible()
+  })
+})

--- a/apps/workspace-playground/package.json
+++ b/apps/workspace-playground/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:e2e": "pnpm run build:deps && playwright test",
-    "test:e2e:addressed-agent": "pnpm run build:deps && playwright test apps/workspace-playground/e2e/agent-host-golden-route.spec.ts",
+    "test:e2e:addressed-agent": "pnpm run build:deps && playwright test apps/workspace-playground/e2e/agent-host-golden-route.spec.ts apps/workspace-playground/e2e/native-session-regressions.spec.ts",
     "smoke:bridge": "pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-ask-user build && tsx scripts/bridge-e2e.ts",
     "eval": "AGENT_API_PORT=5350 vite-node src/eval/run.ts",
     "eval:slash-command": "AGENT_API_PORT=5350 vite-node src/eval/run.ts src/eval/plugin-slash-command.yaml",

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -135,6 +135,8 @@ export interface PiChatPanelProps<
 > {
   /** Optional externally selected Pi session id. When provided, session navigation is owned by the host. */
   sessionId?: string
+  /** Explicitly marks an externally selected browser-only session. */
+  sessionEphemeral?: boolean
   /** Selects the additive addressed AgentGateway transport. Omit for legacy wire. */
   agentTypeId?: string
   /** Discovers addressed agents and shows a minimal selector. */
@@ -179,6 +181,9 @@ export interface PiChatPanelProps<
   toolRenderers?: ToolRendererOverrides
   createRemoteSession?: (options: RemotePiSessionOptions) => RemotePiSession
   remoteSessionOptions?: UsePiSessionsOptions['remoteSessionOptions']
+  /** Enables addressed local-session creation and first-send adoption. */
+  nativeSessionStartEnabled?: boolean
+  onNativeSessionAdopt?: (session: import('../../shared/session').SessionSummary) => void
   hydrateMessages?: boolean
   allowPromptDuringInitialHydration?: boolean
   workspaceWarmupStatus?: ChatPanelWorkspaceWarmupStatus
@@ -208,6 +213,7 @@ export function PiChatPanel<
   TComposerBlocker extends ComposerBlocker = ComposerBlocker,
 >({
   sessionId,
+  sessionEphemeral = false,
   agentTypeId,
   addressedAgentSelection = false,
   agentSelection: controlledAgentSelection,
@@ -247,6 +253,8 @@ export function PiChatPanel<
   toolRenderers,
   createRemoteSession,
   remoteSessionOptions,
+  nativeSessionStartEnabled = false,
+  onNativeSessionAdopt,
   hydrateMessages = true,
   allowPromptDuringInitialHydration = false,
   workspaceWarmupStatus,
@@ -321,6 +329,7 @@ export function PiChatPanel<
     createRemoteSession,
     remoteSessionOptions: remoteSessionOptionsWithEvents,
     enabled: externalSessionId === undefined && !agentSelectionBlocked,
+    localCreateUntilPrompt: nativeSessionStartEnabled,
   })
   useEffect(() => {
     if (externalSessionId) {
@@ -345,6 +354,8 @@ export function PiChatPanel<
     fetch,
     createRemoteSession,
     remoteSessionOptions: remoteSessionOptionsWithEvents,
+    nativeSessionStartEnabled: nativeSessionStartEnabled && sessionEphemeral,
+    onNativeSessionAdopt,
   })
   const activePiSession = externalSessionId ? externalPiSession : sessions.activePiSession
   const chatState = useRemotePiSessionState(activePiSession)

--- a/packages/agent/src/front/chat/pi/__tests__/nativeFirstSendTransactions.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/nativeFirstSendTransactions.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ErrorCode } from '../../../../shared/error-codes'
+import {
+  NativeFirstSendErrorKind,
+  clearNativeFirst,
+  completeNativeFirst,
+  sendNativeFirst,
+  tombstoneNativeFirst,
+} from '../nativeFirstSendTransactions'
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve
+    reject = nextReject
+  })
+  return { promise, resolve, reject }
+}
+
+describe('native first-send transactions', () => {
+  it('coalesces identical in-flight first sends and rejects a different prompt', async () => {
+    const pending = deferred<{ accepted: true }>()
+    const request = vi.fn(() => pending.promise)
+    const classify = () => NativeFirstSendErrorKind.Definite
+
+    const first = sendNativeFirst('scope-coalesce', 'local-1', 1_000, 'same-prompt', request, classify)
+    const duplicate = sendNativeFirst('scope-coalesce', 'local-1', 1_000, 'same-prompt', request, classify)
+    const conflict = sendNativeFirst('scope-coalesce', 'local-1', 1_000, 'different-prompt', request, classify)
+
+    await expect(conflict).rejects.toMatchObject({ errorCode: ErrorCode.enum.SESSION_LOCKED })
+    expect(request).toHaveBeenCalledTimes(1)
+
+    pending.resolve({ accepted: true })
+    await expect(Promise.all([first, duplicate])).resolves.toEqual([
+      { accepted: true },
+      { accepted: true },
+    ])
+    expect(completeNativeFirst('scope-coalesce', 'local-1')).toBe(true)
+  })
+
+  it('reconciles one ambiguous result with the same idempotency key', async () => {
+    const keys: string[] = []
+    const retries: boolean[] = []
+    const request = vi.fn(async ({ idempotencyKey, retry }: { idempotencyKey: string; retry: boolean }) => {
+      keys.push(idempotencyKey)
+      retries.push(retry)
+      if (!retry) throw new TypeError('connection closed before receipt')
+      return { accepted: true }
+    })
+
+    await expect(sendNativeFirst(
+      'scope-retry',
+      'local-2',
+      1_000,
+      'prompt',
+      request,
+      () => NativeFirstSendErrorKind.Ambiguous,
+    )).resolves.toEqual({ accepted: true })
+
+    expect(keys).toHaveLength(2)
+    expect(new Set(keys).size).toBe(1)
+    expect(retries).toEqual([false, true])
+    expect(completeNativeFirst('scope-retry', 'local-2')).toBe(true)
+  })
+
+  it('prevents adoption after the browser-local draft is deleted in flight', async () => {
+    const pending = deferred<{ accepted: true }>()
+    const first = sendNativeFirst(
+      'scope-delete',
+      'local-3',
+      1_000,
+      'prompt',
+      () => pending.promise,
+      () => NativeFirstSendErrorKind.Definite,
+    )
+    const deletion = tombstoneNativeFirst<{ accepted: true }>('scope-delete', 'local-3')
+    pending.resolve({ accepted: true })
+
+    await expect(first).resolves.toEqual({ accepted: true })
+    await expect(deletion).resolves.toEqual({ accepted: true })
+    expect(completeNativeFirst('scope-delete', 'local-3')).toBe(false)
+    clearNativeFirst('scope-delete', 'local-3')
+  })
+})

--- a/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
@@ -702,6 +702,134 @@ describe('RemotePiSession', () => {
     session.dispose()
   })
 
+  it('creates, connects, and prompts on the addressed wire before adopting the first native session', async () => {
+    const events = openNdjsonStream()
+    const adopted = vi.fn()
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (url === 'https://agent.test/api/v1/agents/alpha/sessions') {
+        expect(init?.method).toBe('POST')
+        expect(JSON.parse(String(init?.body))).toEqual({ requestId: expect.any(String) })
+        return jsonResponse({ agentTypeId: 'alpha', sessionId: 'native-1' }, 201)
+      }
+      if (url === 'https://agent.test/api/v1/agents/alpha/sessions/native-1/events?cursor=0') {
+        return new Response(events.stream)
+      }
+      if (url === 'https://agent.test/api/v1/agents/alpha/sessions/native-1/prompt') {
+        expect(init?.method).toBe('POST')
+        expect(JSON.parse(String(init?.body))).toMatchObject({
+          clientNonce: 'nonce-first',
+          requestId: 'nonce-first',
+          content: 'first message',
+        })
+        return jsonResponse({ accepted: true, cursor: 0, disposition: 'prompt', clientNonce: 'nonce-first' })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock, {
+      sessionId: 'local-draft',
+      agentTypeId: 'alpha',
+      autoStart: false,
+      nativeFirstPrompt: { onAdopt: adopted },
+    })
+
+    await expect(session.prompt({
+      message: 'first message',
+      clientNonce: 'nonce-first',
+    })).resolves.toEqual({ accepted: true, cursor: 0, clientNonce: 'nonce-first' })
+
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual([
+      'https://agent.test/api/v1/agents/alpha/sessions',
+      'https://agent.test/api/v1/agents/alpha/sessions/native-1/events?cursor=0',
+      'https://agent.test/api/v1/agents/alpha/sessions/native-1/prompt',
+    ])
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/api/v1/agent/pi-chat/'))).toBe(false)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(adopted).toHaveBeenCalledOnce()
+    expect(adopted).toHaveBeenCalledWith(expect.objectContaining({ id: 'native-1' }))
+
+    session.dispose()
+  })
+
+  it('defers native adoption until a rapid follow-up completes on the adopted id', async () => {
+    const events = openNdjsonStream()
+    const promptResponse = deferred<Response>()
+    const followUpResponse = deferred<Response>()
+    const adoptionCallbacks: Array<() => void> = []
+    const adopted = vi.fn()
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === 'https://agent.test/api/v1/agents/alpha/sessions') {
+        return jsonResponse({ agentTypeId: 'alpha', sessionId: 'native-rapid' }, 201)
+      }
+      if (url === 'https://agent.test/api/v1/agents/alpha/sessions/native-rapid/events?cursor=0') {
+        return new Response(events.stream)
+      }
+      if (url.endsWith('/native-rapid/prompt')) return promptResponse.promise
+      if (url.endsWith('/native-rapid/followup')) return followUpResponse.promise
+      throw new Error(`unexpected URL ${url}`)
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock, {
+      sessionId: 'local-rapid',
+      agentTypeId: 'alpha',
+      autoStart: false,
+      nativeFirstPrompt: { onAdopt: adopted },
+      setTimeoutFn: ((callback: TimerHandler) => {
+        adoptionCallbacks.push(callback as () => void)
+        return 1
+      }) as typeof globalThis.setTimeout,
+      clearTimeoutFn: vi.fn() as unknown as typeof globalThis.clearTimeout,
+    })
+
+    const first = session.prompt({ message: 'first', clientNonce: 'nonce-first' })
+    await waitUntil(() => fetchMock.mock.calls.some(([url]) => String(url).endsWith('/native-rapid/prompt')))
+    const followUp = session.followUp({
+      message: 'second',
+      clientNonce: 'nonce-second',
+      clientSeq: 1,
+    })
+    expect(fetchMock.mock.calls.some(([url]) => String(url).endsWith('/native-rapid/followup'))).toBe(false)
+
+    promptResponse.resolve(jsonResponse({
+      accepted: true,
+      cursor: 0,
+      disposition: 'prompt',
+      clientNonce: 'nonce-first',
+    }))
+    await expect(first).resolves.toMatchObject({ accepted: true, clientNonce: 'nonce-first' })
+    await waitUntil(() => fetchMock.mock.calls.some(([url]) => String(url).endsWith('/native-rapid/followup')))
+    for (const callback of adoptionCallbacks.splice(0)) callback()
+    expect(adopted).not.toHaveBeenCalled()
+
+    followUpResponse.resolve(jsonResponse({
+      accepted: true,
+      cursor: 1,
+      disposition: 'followup',
+      clientNonce: 'nonce-second',
+      clientSeq: 1,
+    }))
+    await expect(followUp).resolves.toMatchObject({ accepted: true, clientNonce: 'nonce-second', queued: true })
+    for (const callback of adoptionCallbacks.splice(0)) callback()
+    expect(adopted).toHaveBeenCalledOnce()
+    expect(adopted).toHaveBeenCalledWith(expect.objectContaining({ id: 'native-rapid' }))
+
+    session.dispose()
+  })
+
+  it('does not start native creation after disposal', async () => {
+    const fetchMock = vi.fn() as unknown as MockFetch
+    const session = createSession(fetchMock, {
+      sessionId: 'local-disposed',
+      agentTypeId: 'alpha',
+      autoStart: false,
+      nativeFirstPrompt: { onAdopt: vi.fn() },
+    })
+
+    session.dispose()
+
+    await expect(session.prompt({ message: 'first', clientNonce: 'nonce-first' }))
+      .rejects.toMatchObject({ name: 'AbortError' })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('rolls back optimistic follow-ups when the follow-up command fails', async () => {
     const events = openNdjsonStream()
     const fetchMock = vi.fn(async (url: string) => {

--- a/packages/agent/src/front/chat/pi/addressedNativeFirstPrompt.ts
+++ b/packages/agent/src/front/chat/pi/addressedNativeFirstPrompt.ts
@@ -1,0 +1,127 @@
+import type { SessionSummary } from '../../../shared/session'
+import type { PromptPayload, PromptReceipt } from '../../../shared/chat'
+import { PromptReceiptSchema } from '../../../shared/chat'
+import {
+  type NativeFirstSendErrorKind,
+  sendNativeFirst,
+} from './nativeFirstSendTransactions'
+
+export interface AddressedNativeFirstPromptResult {
+  receipt: PromptReceipt
+  session: SessionSummary
+}
+
+export interface AddressedNativeFirstPromptOptions {
+  dataSource: string
+  localId: string
+  timeoutMs: number
+  apiBaseUrl: string
+  agentTypeId: string
+  payload: PromptPayload
+  requestHeaders: () => Promise<Record<string, string>>
+  connectSession: (sessionId: string) => Promise<void>
+  commandPayload: (payload: PromptPayload) => unknown
+  fetchJson: (url: string, init: RequestInit, signal: AbortSignal) => Promise<unknown>
+  classifyError: (error: unknown) => NativeFirstSendErrorKind
+}
+
+/**
+ * Creates one addressed native session, connects its replayable event stream,
+ * then sends the first prompt. The transaction owns the stable create key so
+ * an ambiguous response can reconcile without producing a second transcript.
+ */
+export async function sendAddressedNativeFirstPrompt(
+  options: AddressedNativeFirstPromptOptions,
+): Promise<AddressedNativeFirstPromptResult> {
+  return sendNativeFirst(
+    options.dataSource,
+    options.localId,
+    options.timeoutMs,
+    addressedNativeFirstPromptIdentity(options.payload),
+    async ({ idempotencyKey, signal }) => {
+      const headers = await raceAbort(signal, options.requestHeaders)
+      const created = await options.fetchJson(
+        `${options.apiBaseUrl}/api/v1/agents/${encodeURIComponent(options.agentTypeId)}/sessions`,
+        {
+          method: 'POST',
+          headers: { ...headers, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ requestId: idempotencyKey }),
+        },
+        signal,
+      )
+      const sessionId = addressedCreatedSessionId(created)
+      await options.connectSession(sessionId)
+      const receipt = await options.fetchJson(
+        `${options.apiBaseUrl}/api/v1/agents/${encodeURIComponent(options.agentTypeId)}/sessions/${encodeURIComponent(sessionId)}/prompt`,
+        {
+          method: 'POST',
+          headers: { ...headers, 'Content-Type': 'application/json' },
+          body: JSON.stringify(options.commandPayload(options.payload)),
+        },
+        signal,
+      )
+      let parsed: PromptReceipt
+      try {
+        parsed = PromptReceiptSchema.parse(receipt)
+      } catch {
+        throw new NativeFirstPromptInvalidReceiptError()
+      }
+      const now = new Date().toISOString()
+      return {
+        receipt: parsed,
+        session: {
+          id: sessionId,
+          title: 'Untitled',
+          createdAt: now,
+          updatedAt: now,
+          turnCount: 0,
+        },
+      }
+    },
+    options.classifyError,
+  )
+}
+
+export class NativeFirstPromptInvalidReceiptError extends Error {
+  constructor() {
+    super('Native session start returned an invalid receipt.')
+    this.name = 'NativeFirstPromptInvalidReceiptError'
+  }
+}
+
+export function addressedNativeFirstPromptIdentity(payload: PromptPayload): string {
+  return JSON.stringify([
+    payload.message,
+    payload.displayMessage ?? null,
+    payload.clientNonce,
+    payload.model?.provider ?? null,
+    payload.model?.id ?? null,
+    payload.thinkingLevel ?? null,
+    (payload.attachments ?? []).map((attachment) => [
+      attachment.filename ?? null,
+      attachment.mediaType ?? null,
+      attachment.url,
+      attachment.path ?? null,
+    ]),
+  ])
+}
+
+function addressedCreatedSessionId(value: unknown): string {
+  if (typeof value !== 'object' || value === null) throw new NativeFirstPromptInvalidReceiptError()
+  const sessionId = (value as { sessionId?: unknown }).sessionId
+  if (typeof sessionId !== 'string' || !sessionId) throw new NativeFirstPromptInvalidReceiptError()
+  return sessionId
+}
+
+function raceAbort<T>(signal: AbortSignal, request: () => Promise<T>): Promise<T> {
+  if (signal.aborted) return Promise.reject(abortError('Request aborted.'))
+  return new Promise((resolve, reject) => {
+    const onAbort = () => reject(abortError('Request aborted.'))
+    signal.addEventListener('abort', onAbort, { once: true })
+    void request().then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort))
+  })
+}
+
+function abortError(message: string): DOMException {
+  return new DOMException(message, 'AbortError')
+}

--- a/packages/agent/src/front/chat/pi/nativeFirstSendTransactions.ts
+++ b/packages/agent/src/front/chat/pi/nativeFirstSendTransactions.ts
@@ -1,0 +1,165 @@
+import { ErrorCode } from '../../../shared/error-codes'
+
+const MAX_TRANSACTIONS = 32
+
+export enum NativeFirstSendErrorKind {
+  Ambiguous,
+  TerminalUnknown,
+  Definite,
+}
+
+interface Transaction<T> {
+  idempotencyKey: string
+  requestIdentity: string
+  tombstoned: boolean
+  ownerReleased: boolean
+  terminalError?: Error
+  inFlight?: Promise<T>
+  settledReceipt?: T
+}
+
+interface NativeFirstSendRequest<T> {
+  (input: { idempotencyKey: string; retry: boolean; signal: AbortSignal }): Promise<T>
+}
+
+const transactions = new Map<string, Transaction<unknown>>()
+
+export function nativeFirstDataSourceIdentity(
+  apiBaseUrl: string,
+  storageScope: string,
+  workspaceId?: string,
+  agentTypeId?: string,
+): string {
+  return `${apiBaseUrl}\n${workspaceId ?? ''}\n${storageScope}\n${agentTypeId ?? ''}`
+}
+
+export async function sendNativeFirst<T>(
+  dataSource: string,
+  localId: string,
+  timeoutMs: number,
+  requestIdentity: string,
+  request: NativeFirstSendRequest<T>,
+  classifyError: (error: unknown) => NativeFirstSendErrorKind,
+): Promise<T> {
+  const key = `${dataSource}\n${localId}`
+  let transaction = transactions.get(key) as Transaction<T> | undefined
+  if (!transaction) {
+    if (transactions.size >= MAX_TRANSACTIONS) throw nativeFirstRequestConflictError()
+    transaction = {
+      idempotencyKey: nativeFirstPromptKey(),
+      requestIdentity,
+      tombstoned: false,
+      ownerReleased: false,
+    }
+    transactions.set(key, transaction)
+  }
+  if (transaction.terminalError) throw transaction.terminalError
+  if (transaction.requestIdentity !== requestIdentity) throw nativeFirstRequestConflictError()
+  if (transaction.inFlight) return transaction.inFlight
+  if (transaction.tombstoned) throw nativeFirstRequestConflictError()
+  if (transaction.settledReceipt !== undefined) return transaction.settledReceipt
+
+  const run = async (): Promise<T> => {
+    try {
+      return await requestWithLifetime(timeoutMs, transaction!, false, request)
+    } catch (error) {
+      const firstErrorKind = classifyError(error)
+      if (firstErrorKind === NativeFirstSendErrorKind.Definite) {
+        transactions.delete(key)
+        throw error
+      }
+      if (firstErrorKind === NativeFirstSendErrorKind.TerminalUnknown) {
+        throw setTerminalError(key, transaction!, toError(error))
+      }
+      try {
+        return await requestWithLifetime(timeoutMs, transaction!, true, request)
+      } catch {
+        throw setTerminalError(key, transaction!, nativeFirstPromptUnknownError())
+      }
+    }
+  }
+  const inFlight = run()
+  transaction.inFlight = inFlight
+  try {
+    const receipt = await inFlight
+    transaction.settledReceipt = receipt
+    return receipt
+  } finally {
+    if (transaction.inFlight === inFlight) transaction.inFlight = undefined
+  }
+}
+
+export function completeNativeFirst(dataSource: string, localId: string, onAdopt?: () => void): boolean {
+  const key = `${dataSource}\n${localId}`
+  const transaction = transactions.get(key)
+  if (!transaction || transaction.tombstoned) return false
+  transactions.delete(key)
+  onAdopt?.()
+  return true
+}
+
+export function tombstoneNativeFirst<T>(dataSource: string, localId: string): Promise<T | undefined> {
+  const transaction = transactions.get(`${dataSource}\n${localId}`) as Transaction<T> | undefined
+  if (!transaction) return Promise.resolve(undefined)
+  transaction.tombstoned = true
+  return transaction.inFlight ?? Promise.resolve(transaction.settledReceipt)
+}
+
+export function clearNativeFirst(dataSource: string, localId: string): void {
+  transactions.delete(`${dataSource}\n${localId}`)
+}
+
+export function releaseNativeFirst(dataSource: string, localId: string): void {
+  const key = `${dataSource}\n${localId}`
+  const transaction = transactions.get(key)
+  if (!transaction) return
+  transaction.ownerReleased = true
+  if (transaction.terminalError) transactions.delete(key)
+}
+
+function setTerminalError<T>(key: string, transaction: Transaction<T>, error: Error): Error {
+  transaction.terminalError = error
+  if (transaction.ownerReleased && transactions.get(key) === transaction) transactions.delete(key)
+  return error
+}
+
+async function requestWithLifetime<T>(
+  timeoutMs: number,
+  transaction: Transaction<T>,
+  retry: boolean,
+  request: NativeFirstSendRequest<T>,
+): Promise<T> {
+  const controller = new AbortController()
+  const timer = globalThis.setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await request({
+      idempotencyKey: transaction.idempotencyKey,
+      retry,
+      signal: controller.signal,
+    })
+  } finally {
+    globalThis.clearTimeout(timer)
+  }
+}
+
+export function nativeFirstRequestConflictError(): Error {
+  return Object.assign(new Error('A different message is already starting this chat.'), {
+    errorCode: ErrorCode.enum.SESSION_LOCKED,
+  })
+}
+
+function nativeFirstPromptUnknownError(): Error {
+  return Object.assign(new Error('Native session start outcome is unknown after its one reconciliation retry.'), {
+    errorCode: ErrorCode.enum.INTERNAL_ERROR,
+  })
+}
+
+function toError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function nativeFirstPromptKey(): string {
+  return typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `native-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}

--- a/packages/agent/src/front/chat/pi/remotePiSession.ts
+++ b/packages/agent/src/front/chat/pi/remotePiSession.ts
@@ -1,4 +1,5 @@
 import { ErrorCode } from '../../../shared/error-codes'
+import type { SessionSummary } from '../../../shared/session'
 import type {
   CommandReceipt,
   FollowUpPayload,
@@ -23,6 +24,17 @@ import {
 import type { ChatError } from '../../../shared/chat'
 import { createInitialPiChatState, type OptimisticUserMessage, type PiChatState } from './piChatReducer'
 import { createPiChatStore, type PiChatStore, type PiChatStoreListener, type PiChatStoreOptions } from './piChatStore'
+import {
+  NativeFirstSendErrorKind,
+  completeNativeFirst,
+  nativeFirstDataSourceIdentity,
+  nativeFirstRequestConflictError,
+} from './nativeFirstSendTransactions'
+import {
+  addressedNativeFirstPromptIdentity,
+  NativeFirstPromptInvalidReceiptError,
+  sendAddressedNativeFirstPrompt,
+} from './addressedNativeFirstPrompt'
 import {
   buildPiChatEventsUrl,
   parsePiChatReplayRangeError,
@@ -82,6 +94,10 @@ export interface RemotePiSessionOptions {
   // Per-attempt timeout for /state and command fetches. Defaults to
   // DEFAULT_REQUEST_TIMEOUT_MS; exposed mainly for tests.
   requestTimeoutMs?: number
+  /** Browser-local addressed session whose first prompt creates and adopts its durable ID. */
+  nativeFirstPrompt?: {
+    onAdopt: (session: SessionSummary) => void
+  }
 }
 
 export interface RemotePiSessionLargeStateWarning {
@@ -143,14 +159,27 @@ export class RemotePiSession {
   private readonly recentEventTypes: string[] = []
   private gapCount = 0
   private largeStateWarning?: RemotePiSessionLargeStateWarning
+  private commandSessionId: string
+  private readonly nativeFirstDataSource: string
+  private nativeFirstPrompt?: { requestIdentity: string; promise: Promise<PromptReceipt> }
+  private nativeFirstAdoption?: { localId: string; session: SessionSummary }
+  private nativeFirstAdoptionTimer?: ReturnType<typeof globalThis.setTimeout>
+  private nativeFirstFollowUps = 0
 
   constructor(private readonly options: RemotePiSessionOptions) {
+    this.commandSessionId = options.sessionId
     ensurePageLifecycleListeners()
     this.apiBaseUrl = options.apiBaseUrl?.replace(/\/$/, '') ?? ''
     this.storageScope = options.storageScope ?? ''
+    this.nativeFirstDataSource = nativeFirstDataSourceIdentity(
+      this.apiBaseUrl,
+      this.storageScope,
+      options.workspaceId,
+      options.agentTypeId,
+    )
     this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis)
-    this.setTimeoutFn = options.setTimeoutFn ?? globalThis.setTimeout
-    this.clearTimeoutFn = options.clearTimeoutFn ?? globalThis.clearTimeout
+    this.setTimeoutFn = options.setTimeoutFn ?? globalThis.setTimeout.bind(globalThis)
+    this.clearTimeoutFn = options.clearTimeoutFn ?? globalThis.clearTimeout.bind(globalThis)
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
     this.store = createPiChatStore(createInitialPiChatState({
       sessionId: options.sessionId,
@@ -215,12 +244,16 @@ export class RemotePiSession {
   }
 
   async prompt(payload: PromptPayload): Promise<PromptReceipt> {
-    if (!this.disposed) {
-      this.store.dispatch({ type: 'optimistic-user-message', message: toOptimisticUserMessage(payload) }, { flush: true })
-    }
-    if (!this.started) await this.start(this.store.getState().lastSeq)
-    else this.ensureReconnectScheduled()
+    const generation = this.generation
+    if (!this.isGenerationActive(generation)) throw abortError('Remote Pi session disposed before command send.')
+    this.store.dispatch({ type: 'optimistic-user-message', message: toOptimisticUserMessage(payload) }, { flush: true })
     try {
+      if (this.options.nativeFirstPrompt && this.commandSessionId === this.options.sessionId) {
+        if (!this.isGenerationActive(generation)) throw abortError('Remote Pi session disposed before native session start.')
+        return await this.postNativeFirstPrompt(payload)
+      }
+      if (!this.started) await this.start(this.store.getState().lastSeq)
+      else this.ensureReconnectScheduled()
       const receipt = await this.postCommand('/prompt', payload, PromptReceiptSchema)
       return receipt
     } catch (error) {
@@ -230,17 +263,29 @@ export class RemotePiSession {
   }
 
   async followUp(payload: FollowUpPayload): Promise<FollowUpReceipt> {
-    if (!this.disposed) {
-      this.store.dispatch({ type: 'optimistic-user-message', message: toOptimisticUserMessage(payload) }, { flush: true })
-    }
-    if (!this.started) await this.start(this.store.getState().lastSeq)
-    else this.ensureReconnectScheduled()
+    if (!this.isGenerationActive(this.generation)) throw abortError('Remote Pi session disposed before command send.')
+    this.store.dispatch({ type: 'optimistic-user-message', message: toOptimisticUserMessage(payload) }, { flush: true })
+    const nativeFirstPrompt = this.nativeFirstPrompt
+    const defersNativeAdoption = nativeFirstPrompt !== undefined
+    if (defersNativeAdoption) this.nativeFirstFollowUps += 1
     try {
+      // A second message can be queued before the first addressed create and
+      // prompt return. Wait for that transaction so this command can only use
+      // the adopted native id, and keep the original remote alive until the
+      // follow-up receipt arrives.
+      if (nativeFirstPrompt) await nativeFirstPrompt.promise
+      if (!this.started) await this.start(this.store.getState().lastSeq)
+      else this.ensureReconnectScheduled()
       const receipt = await this.postCommand('/followup', payload, FollowUpReceiptSchema)
       return receipt
     } catch (error) {
       this.rollbackOptimisticMessage(payload.clientNonce)
       throw error
+    } finally {
+      if (defersNativeAdoption) {
+        this.nativeFirstFollowUps -= 1
+        this.scheduleNativeFirstAdoption()
+      }
     }
   }
 
@@ -499,6 +544,64 @@ export class RemotePiSession {
     return schema.parse(this.addressedCommandReceipt(path, raw))
   }
 
+  private async postNativeFirstPrompt(payload: PromptPayload): Promise<PromptReceipt> {
+    const agentTypeId = this.options.agentTypeId
+    if (!agentTypeId) {
+      throw new Error('Native first send requires an addressed agent.')
+    }
+    const requestIdentity = addressedNativeFirstPromptIdentity(payload)
+    if (this.nativeFirstPrompt) {
+      if (this.nativeFirstPrompt.requestIdentity !== requestIdentity) throw nativeFirstRequestConflictError()
+      return this.nativeFirstPrompt.promise
+    }
+    const localId = this.options.sessionId
+    const promise = (async () => {
+      const result = await sendAddressedNativeFirstPrompt({
+        dataSource: this.nativeFirstDataSource,
+        localId,
+        timeoutMs: this.requestTimeoutMs,
+        apiBaseUrl: this.apiBaseUrl,
+        agentTypeId,
+        payload,
+        requestHeaders: () => this.requestHeaders(),
+        connectSession: (sessionId) => this.connectNativeSession(sessionId),
+        commandPayload: (firstPayload) => this.addressedCommandPayload('/prompt', firstPayload),
+        fetchJson: (url, init, signal) => this.fetchJsonWithSignal(url, init, signal),
+        classifyError: classifyNativeFirstPromptError,
+      })
+      await this.connectNativeSession(result.session.id)
+      this.nativeFirstAdoption = { localId, session: result.session }
+      this.scheduleNativeFirstAdoption()
+      return result.receipt
+    })()
+    this.nativeFirstPrompt = { requestIdentity, promise }
+    try {
+      return await promise
+    } catch (error) {
+      if (this.nativeFirstPrompt?.promise === promise) this.nativeFirstPrompt = undefined
+      throw error
+    }
+  }
+
+  private async connectNativeSession(sessionId: string): Promise<void> {
+    this.commandSessionId = sessionId
+    if (!this.started) await this.start(0)
+  }
+
+  private scheduleNativeFirstAdoption(): void {
+    if (!this.nativeFirstAdoption || this.nativeFirstFollowUps > 0 || this.nativeFirstAdoptionTimer !== undefined) return
+    this.nativeFirstAdoptionTimer = this.setTimeoutFn(() => {
+      this.nativeFirstAdoptionTimer = undefined
+      if (!this.nativeFirstAdoption || this.nativeFirstFollowUps > 0) return
+      const adoption = this.nativeFirstAdoption
+      this.nativeFirstAdoption = undefined
+      this.nativeFirstPrompt = undefined
+      completeNativeFirst(this.nativeFirstDataSource, adoption.localId, () => {
+        this.options.nativeFirstPrompt?.onAdopt(adoption.session)
+      })
+    }, 0)
+  }
+
   private addressedCommandReceipt(path: string, receipt: unknown): unknown {
     if (!this.options.agentTypeId || path !== '/followup' || typeof receipt !== 'object' || receipt === null) {
       return receipt
@@ -541,6 +644,26 @@ export class RemotePiSession {
     }
   }
 
+  private async fetchJsonWithSignal(url: string, init: RequestInit, signal: AbortSignal): Promise<unknown> {
+    let response: Response
+    try {
+      response = await this.fetchImpl(url, { ...init, signal })
+    } catch (error) {
+      if (signal.aborted) throw new RemotePiSessionRequestTimeoutError(url, this.requestTimeoutMs)
+      throw error
+    }
+    const body = await safeReadJson(response)
+    if (!response.ok) {
+      throw new RemotePiSessionHttpError(
+        response.status,
+        routeErrorMessage(body, `HTTP ${response.status}`),
+        body,
+        routeErrorCode(body),
+      )
+    }
+    return body
+  }
+
   private async requestHeaders(): Promise<Record<string, string>> {
     const raw = typeof this.options.headers === 'function' ? await this.options.headers() : this.options.headers
     const headers: Record<string, string> = {}
@@ -561,16 +684,16 @@ export class RemotePiSession {
     return buildPiChatEventsUrl({
       apiBaseUrl: this.apiBaseUrl,
       agentTypeId: this.options.agentTypeId,
-      sessionId: this.options.sessionId,
+      sessionId: this.commandSessionId,
       cursor,
     })
   }
 
   private sessionUrl(path: string): string {
     if (this.options.agentTypeId) {
-      return `${this.apiBaseUrl}/api/v1/agents/${encodeURIComponent(this.options.agentTypeId)}/sessions/${encodeURIComponent(this.options.sessionId)}${path}`
+      return `${this.apiBaseUrl}/api/v1/agents/${encodeURIComponent(this.options.agentTypeId)}/sessions/${encodeURIComponent(this.commandSessionId)}${path}`
     }
-    return `${this.apiBaseUrl}/api/v1/agent/pi-chat/${encodeURIComponent(this.options.sessionId)}${path}`
+    return `${this.apiBaseUrl}/api/v1/agent/pi-chat/${encodeURIComponent(this.commandSessionId)}${path}`
   }
 
   private addressedCommandPayload(path: string, payload: unknown): unknown {
@@ -673,6 +796,13 @@ class RemotePiSessionHttpError extends Error {
   }
 }
 
+class RemotePiSessionRequestTimeoutError extends Error {
+  constructor(url: string, timeoutMs: number) {
+    super(`Request to ${url} timed out after ${timeoutMs}ms.`)
+    this.name = 'RemotePiSessionRequestTimeoutError'
+  }
+}
+
 /**
  * Extract the stable, CANONICAL server error code (a member of the shared ErrorCode
  * enum, e.g. `SESSION_LOCKED`) from an error thrown by a command call (prompt/follow-up/
@@ -687,6 +817,16 @@ export function piChatErrorCode(error: unknown): string | undefined {
   // when it's a canonical ErrorCode, never an arbitrary string.
   const parsed = ErrorCode.safeParse((error as { errorCode?: unknown } | null)?.errorCode)
   return parsed.success ? parsed.data : undefined
+}
+
+function classifyNativeFirstPromptError(error: unknown): NativeFirstSendErrorKind {
+  if (error instanceof TypeError
+    || error instanceof RemotePiSessionRequestTimeoutError
+    || error instanceof NativeFirstPromptInvalidReceiptError
+    || (error instanceof RemotePiSessionHttpError && error.status >= 500)) {
+    return NativeFirstSendErrorKind.Ambiguous
+  }
+  return NativeFirstSendErrorKind.Definite
 }
 
 function toOptimisticUserMessage(payload: PromptPayload | FollowUpPayload): OptimisticUserMessage {

--- a/packages/agent/src/front/chat/piChatPanelHooks.ts
+++ b/packages/agent/src/front/chat/piChatPanelHooks.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import type { PiChatState } from './pi/piChatReducer'
+import type { SessionSummary } from '../../shared/session'
 import { createRemotePiSession, type RemotePiSession, type RemotePiSessionOptions } from './pi/remotePiSession'
 import type { UsePiSessionsOptions } from './session'
 
@@ -15,6 +16,8 @@ export function useExternalRemotePiSession({
   fetch,
   createRemoteSession,
   remoteSessionOptions,
+  nativeSessionStartEnabled = false,
+  onNativeSessionAdopt,
 }: {
   sessionId?: string
   agentTypeId?: string
@@ -25,13 +28,17 @@ export function useExternalRemotePiSession({
   fetch?: typeof globalThis.fetch
   createRemoteSession?: (options: RemotePiSessionOptions) => RemotePiSession
   remoteSessionOptions?: UsePiSessionsOptions['remoteSessionOptions']
+  nativeSessionStartEnabled?: boolean
+  onNativeSessionAdopt?: (session: SessionSummary) => void
 }): RemotePiSession | undefined {
   const [sessionState, setSessionState] = useState<{
     identity: string
     session: RemotePiSession
   } | undefined>()
   const remoteSessionOptionsRef = useRef(remoteSessionOptions)
+  const onNativeSessionAdoptRef = useRef(onNativeSessionAdopt)
   remoteSessionOptionsRef.current = remoteSessionOptions
+  onNativeSessionAdoptRef.current = onNativeSessionAdopt
   const remoteSessionOptionsKey = useMemo(
     () => remoteSessionOptionsIdentity(remoteSessionOptions),
     [remoteSessionOptions],
@@ -46,7 +53,8 @@ export function useExternalRemotePiSession({
     fetch: remoteSessionOptionObjectIdentity(fetch),
     createRemoteSession: remoteSessionOptionObjectIdentity(createRemoteSession),
     remoteSessionOptions: remoteSessionOptionsKey,
-  }), [agentTypeId, apiBaseUrl, createRemoteSession, fetch, remoteSessionOptionsKey, requestHeaders, sessionId, storageScope, workspaceId])
+    nativeSessionStartEnabled,
+  }), [agentTypeId, apiBaseUrl, createRemoteSession, fetch, nativeSessionStartEnabled, remoteSessionOptionsKey, requestHeaders, sessionId, storageScope, workspaceId])
   useEffect(() => {
     if (!sessionId) {
       setSessionState(undefined)
@@ -54,6 +62,14 @@ export function useExternalRemotePiSession({
     }
     const next = (createRemoteSession ?? createRemotePiSession)({
       ...remoteSessionOptionsRef.current,
+      ...(nativeSessionStartEnabled
+        ? {
+            autoStart: false,
+            nativeFirstPrompt: {
+              onAdopt: (nativeSession: SessionSummary) => onNativeSessionAdoptRef.current?.(nativeSession),
+            },
+          }
+        : {}),
       sessionId,
       agentTypeId,
       workspaceId,
@@ -64,7 +80,7 @@ export function useExternalRemotePiSession({
     })
     setSessionState({ identity, session: next })
     return () => next.dispose()
-  }, [agentTypeId, apiBaseUrl, createRemoteSession, fetch, identity, remoteSessionOptionsKey, requestHeaders, sessionId, storageScope, workspaceId])
+  }, [agentTypeId, apiBaseUrl, createRemoteSession, fetch, identity, nativeSessionStartEnabled, remoteSessionOptionsKey, requestHeaders, sessionId, storageScope, workspaceId])
   return sessionState?.identity === identity ? sessionState.session : undefined
 }
 

--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.addressed.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.addressed.test.tsx
@@ -79,6 +79,82 @@ describe('usePiSessions addressed Agent transport', () => {
     expect(deletion?.url).toContain('/api/v1/agents/alpha/sessions/created')
   })
 
+  test('keeps a new addressed chat local until the remote first-send adopts its native id', async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = []
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      calls.push({ url, init })
+      if (url.endsWith('/native-1/rename')) {
+        return new Response(JSON.stringify({
+          ref: { agentTypeId: 'alpha', sessionId: 'native-1' },
+          title: 'Renamed',
+          status: 'idle',
+          createdAt: 1,
+          updatedAt: 2,
+        }), { status: 200 })
+      }
+      return new Response(JSON.stringify({ sessions: [] }), { status: 200 })
+    })
+    const created: RemotePiSessionOptions[] = []
+    const createRemoteSession = vi.fn((options: RemotePiSessionOptions) => {
+      created.push(options)
+      return { dispose: vi.fn() } as unknown as RemotePiSession
+    })
+    const { result } = renderHook(() => usePiSessions({
+      agentTypeId: 'alpha',
+      workspaceId: 'workspace-a',
+      storageScope: 'workspace-a',
+      fetch: fetchMock as unknown as typeof fetch,
+      createRemoteSession,
+      localCreateUntilPrompt: true,
+      retry: { maxRetries: 0 },
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    let draft!: Awaited<ReturnType<typeof result.current.create>>
+    await act(async () => {
+      draft = await result.current.create()
+    })
+
+    expect(draft).toMatchObject({ id: expect.stringMatching(/^local-/), ephemeral: true })
+    expect(result.current.activeSessionId).toBe(draft.id)
+    expect(calls.filter((call) => call.init?.method === 'POST')).toHaveLength(0)
+    await waitFor(() => expect(created).toHaveLength(1))
+    expect(created[0]).toMatchObject({
+      sessionId: draft.id,
+      agentTypeId: 'alpha',
+      workspaceId: 'workspace-a',
+      autoStart: false,
+      nativeFirstPrompt: { onAdopt: expect.any(Function) },
+    })
+
+    act(() => {
+      created[0].nativeFirstPrompt?.onAdopt({
+        id: 'native-1',
+        title: 'Untitled',
+        createdAt: new Date(1).toISOString(),
+        updatedAt: new Date(2).toISOString(),
+        turnCount: 0,
+      })
+    })
+    await waitFor(() => expect(result.current.activeSessionId).toBe('native-1'))
+    expect(result.current.sessions).toEqual([
+      expect.objectContaining({ id: 'native-1', ephemeral: false }),
+    ])
+    expect(localStorage.getItem(activeSessionStorageKey('workspace-a', 'alpha'))).toBe('native-1')
+
+    await act(async () => {
+      await result.current.rename('native-1', 'Renamed')
+    })
+    expect(result.current.sessions[0]).toMatchObject({ id: 'native-1', title: 'Renamed' })
+    const renameCall = calls.find((call) => call.url.endsWith('/native-1/rename'))
+    expect(renameCall?.init?.method).toBe('POST')
+    expect(JSON.parse(String(renameCall?.init?.body))).toEqual({
+      requestId: expect.stringMatching(/^rename-/),
+      title: 'Renamed',
+    })
+  })
+
   test('switches the addressed collection and remote wire without connecting a stale session id', async () => {
     const calls: string[] = []
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {

--- a/packages/agent/src/front/chat/session/index.ts
+++ b/packages/agent/src/front/chat/session/index.ts
@@ -6,7 +6,14 @@ export {
   type ActiveSessionStorageLike,
   type ActiveSessionStorageOptions,
 } from './activeSessionStorage'
-export { usePiSessions, type UsePiSessionsOptions, type UsePiSessionsResult, type PiSessionCreateInit, type PiSessionRefreshOptions } from './usePiSessions'
+export {
+  usePiSessions,
+  type UsePiSessionsOptions,
+  type UsePiSessionsResult,
+  type PiSessionCreateInit,
+  type PiSessionRefreshOptions,
+  type PiSessionSummary,
+} from './usePiSessions'
 export { SessionList, SessionBrowser, type SessionListProps } from './SessionList'
 export {
   searchPiSessions,

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { SessionSummary } from '../../../shared/session'
+import {
+  clearNativeFirst,
+  nativeFirstDataSourceIdentity,
+  releaseNativeFirst,
+  tombstoneNativeFirst,
+} from '../pi/nativeFirstSendTransactions'
 import { createRemotePiSession, type RemotePiSession, type RemotePiSessionOptions } from '../pi/remotePiSession'
 import {
   activeSessionStorageKey,
@@ -43,6 +49,8 @@ export interface UsePiSessionsOptions {
   createRemoteSession?: (options: RemotePiSessionOptions) => RemotePiSession
   remoteSessionOptions?: Omit<Partial<RemotePiSessionOptions>, 'sessionId' | 'agentTypeId' | 'workspaceId' | 'storageScope' | 'apiBaseUrl' | 'headers' | 'fetch'>
   connectActiveSession?: boolean
+  /** Keep newly opened addressed chats in browser memory until their first prompt. */
+  localCreateUntilPrompt?: boolean
   retry?: {
     maxRetries?: number
     baseMs?: number
@@ -50,9 +58,13 @@ export interface UsePiSessionsOptions {
   }
 }
 
+export interface PiSessionSummary extends SessionSummary {
+  ephemeral?: boolean
+}
+
 export interface UsePiSessionsResult {
-  sessions: SessionSummary[]
-  activeSession: SessionSummary | undefined
+  sessions: PiSessionSummary[]
+  activeSession: PiSessionSummary | undefined
   activeSessionId: string | undefined
   activePiSession: RemotePiSession | undefined
   dataStorageScope: string
@@ -63,7 +75,9 @@ export interface UsePiSessionsResult {
   hasMore: boolean
   error: Error | undefined
   refresh: (options?: PiSessionRefreshOptions) => Promise<void>
-  create: (init?: PiSessionCreateInit) => Promise<SessionSummary>
+  create: (init?: PiSessionCreateInit) => Promise<PiSessionSummary>
+  adoptNative: (localId: string, session: SessionSummary) => void
+  rename: (id: string, title: string) => Promise<PiSessionSummary>
   switch: (id: string) => void
   delete: (id: string) => Promise<void>
   loadMore: () => Promise<void>
@@ -75,6 +89,12 @@ class SessionsPreparingError extends Error {
     super('Agent runtime is still preparing')
     this.name = 'SessionsPreparingError'
   }
+}
+
+interface LocalSession {
+  session: PiSessionSummary
+  requestScopeKey: string
+  nativeFirstDataSourceKey: string
 }
 
 // Network-level failure (server restarting, connection refused). fetch()
@@ -96,15 +116,20 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
   const fetchImpl = useMemo(() => options.fetch ?? globalThis.fetch.bind(globalThis), [options.fetch])
   const createRemoteSession = options.createRemoteSession ?? createRemotePiSession
   const connectActiveSession = options.connectActiveSession ?? true
+  const localCreateUntilPrompt = options.localCreateUntilPrompt === true && addressed
   const retryMaxRetries = options.retry?.maxRetries ?? DEFAULT_MAX_RETRIES
   const retryBaseMs = options.retry?.baseMs ?? DEFAULT_RETRY_BASE_MS
   const retryMaxMs = options.retry?.maxMs ?? DEFAULT_RETRY_MAX_MS
   const headersKey = useMemo(() => headersScopeKey(options.requestHeaders, storageScope), [options.requestHeaders, storageScope])
   const normalizedHeaders = useMemo(() => buildRequestHeaders(options.requestHeaders, storageScope), [headersKey, storageScope])
   const requestScopeKey = useMemo(() => requestScopeIdentity(apiBaseUrl, sessionsApiPath, storageScope, headersKey), [apiBaseUrl, headersKey, sessionsApiPath, storageScope])
+  const nativeFirstDataSourceKey = useMemo(
+    () => nativeFirstDataSourceIdentity(apiBaseUrl, storageScope, options.workspaceId, options.agentTypeId),
+    [apiBaseUrl, options.agentTypeId, options.workspaceId, storageScope],
+  )
   const dataSourceKey = useMemo(() => dataSourceIdentity(apiBaseUrl, sessionsApiPath, storageScope), [apiBaseUrl, sessionsApiPath, storageScope])
   const activeSessionPersistenceKey = activeSessionStorageKey(storageScope, options.agentTypeId)
-  const [sessions, setSessions] = useState<SessionSummary[]>([])
+  const [sessions, setSessions] = useState<PiSessionSummary[]>([])
   const [dataStorageScope, setDataStorageScope] = useState(storageScope)
   const [dataAgentTypeId, setDataAgentTypeId] = useState(options.agentTypeId)
   const [activeSessionId, setActiveSessionId] = useState<string | undefined>(() => (
@@ -122,14 +147,16 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
   const mountedRef = useRef(false)
   const refreshVersionRef = useRef(0)
   const retryTimerRef = useRef<RetryDelayHandle | undefined>(undefined)
-  const sessionsRef = useRef<SessionSummary[]>([])
+  const sessionsRef = useRef<PiSessionSummary[]>([])
   const activeSessionIdRef = useRef<string | undefined>(activeSessionId)
   const hasMoreRef = useRef(hasMore)
   const canonicalLoadedCountRef = useRef(0)
   const nextCursorRef = useRef<string | undefined>(undefined)
   const loadMoreRequestSeqRef = useRef(0)
   const loadMoreInFlightRef = useRef(false)
-  const pendingCreatedRef = useRef<Map<string, SessionSummary>>(new Map())
+  const pendingCreatedRef = useRef<Map<string, PiSessionSummary>>(new Map())
+  const localSessionsRef = useRef<Map<string, LocalSession>>(new Map())
+  const adoptNativeRef = useRef<((localId: string, session: SessionSummary) => void) | undefined>(undefined)
   const pendingCreatedScopeRef = useRef(requestScopeKey)
   const dataStorageScopeRef = useRef(storageScope)
   const loadedDataSourceRef = useRef(dataSourceKey)
@@ -147,6 +174,12 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     sessionsRef.current = sessions
   }, [sessions])
 
+  useEffect(() => () => {
+    for (const [id, local] of localSessionsRef.current) {
+      releaseNativeFirst(local.nativeFirstDataSourceKey, id)
+    }
+  }, [])
+
   useEffect(() => {
     activeSessionIdRef.current = activeSessionId
   }, [activeSessionId])
@@ -156,7 +189,10 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
   }, [hasMore])
 
   const dataSourceCurrent = loadedDataSourceRef.current === dataSourceKey
-  const activeSessionKnown = Boolean(dataSourceCurrent && activeSessionId && sessions.some((session) => session.id === activeSessionId))
+  const activeSessionKnown = Boolean(dataSourceCurrent && activeSessionId && sessions.some((session) => (
+    session.id === activeSessionId
+    && (session.ephemeral !== true || localSessionsRef.current.get(session.id)?.requestScopeKey === requestScopeKey)
+  )))
 
   const requestHeaders = useCallback((): Record<string, string> => normalizedHeaders, [normalizedHeaders])
   const sessionsUrl = useCallback((suffix = '') => `${apiBaseUrl}${sessionsApiPath}${suffix}`, [apiBaseUrl, sessionsApiPath])
@@ -177,6 +213,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
   }, [addressed, sessionsUrl])
 
   const persistActive = useCallback((id: string | undefined) => {
+    if (id && localSessionsRef.current.has(id)) id = undefined
     writeActiveSessionId(id, {
       storageScope,
       agentTypeId: options.agentTypeId,
@@ -186,6 +223,10 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
 
   const ensurePendingScope = useCallback(() => {
     if (pendingCreatedScopeRef.current === requestScopeKey) return
+    for (const [id, local] of localSessionsRef.current) {
+      releaseNativeFirst(local.nativeFirstDataSourceKey, id)
+    }
+    localSessionsRef.current.clear()
     pendingCreatedScopeRef.current = requestScopeKey
     pendingCreatedRef.current.clear()
   }, [requestScopeKey])
@@ -202,7 +243,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       : persisted
   }, [activeSessionPersistenceKey, dataSourceKey, options.agentTypeId, options.initialActiveSessionId, options.storage, storageScope])
 
-  const applySessions = useCallback((data: SessionSummary[], applyOptions: { background?: boolean; nextCursor?: string } = {}) => {
+  const applySessions = useCallback((data: PiSessionSummary[], applyOptions: { background?: boolean; nextCursor?: string } = {}) => {
     ensurePendingScope()
     const replacingScope = loadedDataSourceRef.current !== dataSourceKey
     const requestedActiveId = preferredSessionId()
@@ -218,7 +259,8 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     const current = applyOptions.background && pageMayHaveMore
       ? sessionsRef.current.filter((session) => !requestedActiveId || requestedActiveReturned || session.id !== requestedActiveId)
       : []
-    const merged = mergeSessions(Array.from(pendingCreated.values()), data, current)
+    const localSessions = Array.from(localSessionsRef.current.values(), ({ session }) => session)
+    const merged = mergeSessions(localSessions, Array.from(pendingCreated.values()), data, current)
     const nextHasMore = pageMayHaveMore && !wasExhaustedBeyondFirstPage
     canonicalLoadedCountRef.current = applyOptions.background
       ? Math.max(canonicalLoadedCountRef.current, canonicalCount)
@@ -359,8 +401,17 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       return
     }
 
+    const local = localSessionsRef.current.get(activeSessionId)
     const session = createRemoteSession({
       ...remoteSessionOptionsRef.current,
+      ...(local
+        ? {
+            autoStart: false,
+            nativeFirstPrompt: {
+              onAdopt: (nativeSession: SessionSummary) => adoptNativeRef.current?.(activeSessionId, nativeSession),
+            },
+          }
+        : {}),
       sessionId: activeSessionId,
       agentTypeId: options.agentTypeId,
       workspaceId: options.workspaceId,
@@ -375,8 +426,31 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     }
   }, [activeSessionId, activeSessionKnown, apiBaseUrl, connectActiveSession, createRemoteSession, enabled, fetchImpl, remoteSessionOptionsKey, options.agentTypeId, options.workspaceId, requestHeaders, storageScope])
 
-  const create = useCallback(async (init?: PiSessionCreateInit): Promise<SessionSummary> => {
+  const create = useCallback(async (init?: PiSessionCreateInit): Promise<PiSessionSummary> => {
     if (!enabled) throw new Error('Pi sessions are disabled')
+    if (localCreateUntilPrompt) {
+      ensurePendingScope()
+      const now = new Date().toISOString()
+      const session: PiSessionSummary = {
+        id: localSessionId(),
+        title: init?.title ?? 'Untitled',
+        createdAt: now,
+        updatedAt: now,
+        turnCount: 0,
+        ephemeral: true,
+      }
+      localSessionsRef.current.set(session.id, {
+        session,
+        requestScopeKey,
+        nativeFirstDataSourceKey,
+      })
+      setDataStorageScope(storageScope)
+      setDataAgentTypeId(options.agentTypeId)
+      setSessions((previous) => mergeSessions([session], previous))
+      setActiveSessionId(session.id)
+      persistActive(undefined)
+      return session
+    }
     const scope = requestScopeKey
     const response = await fetchImpl(sessionsUrl(), {
       method: 'POST',
@@ -401,7 +475,46 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     persistActive(session.id)
     void refresh()
     return session
-  }, [addressed, enabled, ensurePendingScope, fetchImpl, persistActive, refresh, requestHeaders, requestScopeKey, sessionsUrl, storageScope])
+  }, [addressed, enabled, ensurePendingScope, fetchImpl, localCreateUntilPrompt, nativeFirstDataSourceKey, options.agentTypeId, persistActive, refresh, requestHeaders, requestScopeKey, sessionsUrl, storageScope])
+
+  const adoptNative = useCallback((localId: string, session: SessionSummary) => {
+    const local = localSessionsRef.current.get(localId)
+    if (!local || local.requestScopeKey !== requestScopeRef.current) return
+    const nativeSession: PiSessionSummary = {
+      ...session,
+      title: local.session.title,
+      ephemeral: false,
+    }
+    localSessionsRef.current.delete(localId)
+    ensurePendingScope()
+    pendingCreatedRef.current.set(nativeSession.id, nativeSession)
+    setSessions((previous) => mergeSessions(
+      [nativeSession],
+      previous.filter((item) => item.id !== localId && item.id !== nativeSession.id),
+    ))
+    setActiveSessionId((previous) => {
+      const next = previous === localId ? nativeSession.id : previous
+      persistActive(next)
+      return next
+    })
+    void refresh({ background: true })
+  }, [ensurePendingScope, persistActive, refresh])
+  adoptNativeRef.current = adoptNative
+
+  const rename = useCallback(async (id: string, title: string): Promise<PiSessionSummary> => {
+    if (!enabled || !addressed) throw new Error('Session rename requires addressed sessions')
+    if (localSessionsRef.current.has(id)) throw new Error('Send a message before renaming this chat')
+    const response = await fetchImpl(sessionsUrl(`/${encodeURIComponent(id)}/rename`), {
+      method: 'POST',
+      headers: { ...requestHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ requestId: sessionMutationRequestId('rename'), title }),
+    })
+    if (!response.ok) throw new Error(`Failed to rename session: ${response.status}`)
+    const renamed = toAddressedSessionSummary(await response.json())
+    if (pendingCreatedRef.current.has(id)) pendingCreatedRef.current.set(id, renamed)
+    setSessions((previous) => previous.map((item) => item.id === id ? { ...item, ...renamed } : item))
+    return renamed
+  }, [addressed, enabled, fetchImpl, requestHeaders, sessionsUrl])
 
   const switchSession = useCallback((id: string) => {
     const known = sessionsRef.current.some((session) => session.id === id)
@@ -414,6 +527,20 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     if (!enabled) throw new Error('Pi sessions are disabled')
     const scope = requestScopeKey
     ensurePendingScope()
+    const local = localSessionsRef.current.get(id)
+    if (local) {
+      await tombstoneNativeFirst(local.nativeFirstDataSourceKey, id).catch(() => undefined)
+      clearNativeFirst(local.nativeFirstDataSourceKey, id)
+      localSessionsRef.current.delete(id)
+      setSessions((previous) => previous.filter((session) => session.id !== id))
+      setActiveSessionId((previous) => {
+        if (previous !== id) return previous
+        const next = sessionsRef.current.find((session) => session.id !== id)?.id
+        persistActive(next)
+        return next
+      })
+      return
+    }
     pendingCreatedRef.current.delete(id)
     setDataStorageScope(storageScope)
     setSessions((previous) => previous.filter((session) => session.id !== id))
@@ -442,6 +569,10 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
   }, [enabled, ensurePendingScope, fetchImpl, persistActive, refresh, requestHeaders, requestScopeKey, sessionsUrl, storageScope])
 
   const reset = useCallback(() => {
+    for (const [id, local] of localSessionsRef.current) {
+      releaseNativeFirst(local.nativeFirstDataSourceKey, id)
+    }
+    localSessionsRef.current.clear()
     pendingCreatedRef.current.clear()
     loadMoreRequestSeqRef.current += 1
     loadMoreInFlightRef.current = false
@@ -474,6 +605,8 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     error: enabled && dataSourceCurrent ? error : undefined,
     refresh,
     create,
+    adoptNative,
+    rename,
     switch: switchSession,
     delete: deleteSession,
     loadMore,
@@ -482,7 +615,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
 }
 
 interface SessionPage {
-  sessions: SessionSummary[]
+  sessions: PiSessionSummary[]
   nextCursor?: string
 }
 
@@ -510,7 +643,7 @@ async function fetchSessionList(
   }
 }
 
-function toSessionSummary(value: unknown): SessionSummary {
+function toSessionSummary(value: unknown): PiSessionSummary {
   if (typeof value !== 'object' || value === null) throw new Error('invalid session summary')
   const record = value as Record<string, unknown>
   if (typeof record.id !== 'string' || !record.id) throw new Error('invalid session id')
@@ -524,7 +657,7 @@ function toSessionSummary(value: unknown): SessionSummary {
   }
 }
 
-function toAddressedSessionSummary(value: unknown): SessionSummary {
+function toAddressedSessionSummary(value: unknown): PiSessionSummary {
   if (typeof value !== 'object' || value === null) throw new Error('invalid addressed session summary')
   const record = value as Record<string, unknown>
   const ref = record.ref
@@ -542,7 +675,7 @@ function toAddressedSessionSummary(value: unknown): SessionSummary {
   }
 }
 
-function addressedCreatedSession(value: unknown, title?: string): SessionSummary {
+function addressedCreatedSession(value: unknown, title?: string): PiSessionSummary {
   if (typeof value !== 'object' || value === null || typeof (value as { sessionId?: unknown }).sessionId !== 'string') {
     throw new Error('invalid addressed session ref')
   }
@@ -556,7 +689,19 @@ function addressedCreatedSession(value: unknown, title?: string): SessionSummary
   }
 }
 
-function canonicalPageCount(data: SessionSummary[]): number {
+function localSessionId(): string {
+  return typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? `local-${crypto.randomUUID()}`
+    : `local-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function sessionMutationRequestId(operation: string): string {
+  return typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? `${operation}-${crypto.randomUUID()}`
+    : `${operation}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function canonicalPageCount(data: PiSessionSummary[]): number {
   return Math.min(data.length, SESSION_PAGE_SIZE)
 }
 
@@ -596,9 +741,9 @@ function remoteSessionOptionsIdentity(options: UsePiSessionsOptions['remoteSessi
   })
 }
 
-function mergeSessions(...lists: SessionSummary[][]): SessionSummary[] {
+function mergeSessions(...lists: PiSessionSummary[][]): PiSessionSummary[] {
   const seen = new Set<string>()
-  const merged: SessionSummary[] = []
+  const merged: PiSessionSummary[] = []
   for (const list of lists) {
     for (const session of list) {
       if (seen.has(session.id)) continue

--- a/packages/agent/src/front/index.ts
+++ b/packages/agent/src/front/index.ts
@@ -50,6 +50,7 @@ export type {
   UsePiSessionsOptions,
   UsePiSessionsResult,
   PiSessionCreateInit,
+  PiSessionSummary,
   SessionListProps,
   PiSessionSearchItem,
   PiSessionSearchOptions,

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -266,10 +266,16 @@ export class EmbeddedAgentGateway implements AgentGateway {
       { agentTypeId: input.agentTypeId, title: input.title ?? null },
       async () => {
         const binding = await this.runtime.resolveBinding(input.agentTypeId, input.scope, claim)
-        const created = await binding.composition.service.createSession!(
-          context(claim, input.requestId, binding.scope.identity),
-          { title: input.title },
-        )
+        const sessionCtx = context(claim, input.requestId, binding.scope.identity)
+        const repository = binding.composition.sessionStore as typeof binding.composition.sessionStore & {
+          createNative?: (
+            ctx: { workspaceId?: string; userId?: string },
+            init?: { title?: string },
+          ) => Promise<{ id: string }>
+        }
+        const created = repository.createNative
+          ? await repository.createNative(sessionCtx, { title: input.title })
+          : await binding.composition.service.createSession!(sessionCtx, { title: input.title })
         const ref = { agentTypeId: input.agentTypeId, sessionId: created.id }
         this.pins.set(sessionKey(claim.workspaceScopeId, ref), binding.scope.identity)
         this.runtime.activity.set(claim.workspaceScopeId, ref, 'idle')

--- a/packages/agent/src/server/harness/pi-coding-agent/nativeSessionPersistence.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/nativeSessionPersistence.ts
@@ -1,0 +1,92 @@
+import { mkdir, rename, unlink, writeFile } from "node:fs/promises"
+import { basename, join } from "node:path"
+import { SessionManager } from "@mariozechner/pi-coding-agent"
+import { ErrorCode } from "../../../shared/error-codes.js"
+
+export const NATIVE_SESSION_PRE_PERSISTENCE_FAILURE = Symbol("native-session-pre-persistence-failure")
+
+/**
+ * Pi chooses its session id and timestamped filename. Materialize and reopen
+ * the transcript before exposing that id so an addressed create never returns
+ * a session that cannot be loaded immediately.
+ */
+export async function createPersistedNativeSessionManager(
+  runtimeCwd: string,
+  nativeSessionDir: string,
+): Promise<SessionManager> {
+  await mkdir(nativeSessionDir, { recursive: true })
+  let sessionManager = SessionManager.create(runtimeCwd, nativeSessionDir)
+  const nativeFile = sessionManager.getSessionFile()
+  const initialId = sessionManager.getSessionId()
+  const header = sessionManager.getHeader()
+  let nativeSessionId: string | undefined
+
+  if (nativeFile && header) {
+    let createdPlaceholder = false
+    try {
+      try {
+        await writeFile(nativeFile, "", { flag: "wx" })
+        createdPlaceholder = true
+      } catch (error) {
+        if ((error as { code?: string }).code !== "EEXIST") throw error
+      }
+      sessionManager = SessionManager.open(nativeFile, nativeSessionDir, runtimeCwd)
+      const openedId = sessionManager.getSessionId()
+      nativeSessionId = openedId
+      if (openedId !== initialId) {
+        const reconciledFile = join(nativeSessionDir, basename(nativeFile).replace(initialId, openedId))
+        let renamed = false
+        try {
+          await rename(nativeFile, reconciledFile)
+          renamed = true
+        } catch {
+          try {
+            await writeFile(nativeFile, `${JSON.stringify({ ...header, id: initialId })}\n`)
+            nativeSessionId = initialId
+            sessionManager = SessionManager.open(nativeFile, nativeSessionDir, runtimeCwd)
+          } catch {
+            const cleanupFailed = createdPlaceholder && await unlink(nativeFile).then(
+              () => false,
+              () => true,
+            )
+            nativeSessionId = undefined
+            throw Object.assign(new Error(
+              cleanupFailed
+                ? "Native Pi session setup failed before persistence; cleanup of the unusable transcript also failed."
+                : "Native Pi session setup failed before persistence.",
+            ), {
+              code: ErrorCode.enum.TOOL_EXECUTION_ERROR,
+              statusCode: 500,
+              ...(cleanupFailed ? { cleanupError: "Could not remove the unusable native session file." } : {}),
+              [NATIVE_SESSION_PRE_PERSISTENCE_FAILURE]: true,
+            })
+          }
+        }
+        if (renamed) sessionManager = SessionManager.open(reconciledFile, nativeSessionDir, runtimeCwd)
+      }
+      nativeSessionId = sessionManager.getSessionId()
+    } catch (error) {
+      if (!nativeSessionId && createdPlaceholder) await unlink(nativeFile).catch(() => {})
+      throw Object.assign(error instanceof Error ? error : new Error(String(error)), {
+        ...(nativeSessionId ? { nativeSessionId } : {}),
+      })
+    }
+  }
+
+  nativeSessionId ??= sessionManager.getSessionId()
+  const persistedFile = sessionManager.getSessionFile()
+  const persistedHeader = sessionManager.getHeader()
+  if (
+    !nativeSessionId
+    || !persistedFile
+    || persistedHeader?.id !== nativeSessionId
+    || !basename(persistedFile).endsWith(`_${nativeSessionId}.jsonl`)
+  ) {
+    throw Object.assign(new Error("Native Pi session setup did not produce a durable transcript."), {
+      code: ErrorCode.enum.TOOL_EXECUTION_ERROR,
+      statusCode: 500,
+      [NATIVE_SESSION_PRE_PERSISTENCE_FAILURE]: true,
+    })
+  }
+  return sessionManager
+}

--- a/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/sessions.ts
@@ -29,6 +29,7 @@ import type {
   SessionDetail,
   SessionListOptions,
 } from "../../../shared/session.js";
+import { createPersistedNativeSessionManager } from "./nativeSessionPersistence.js";
 
 /** Raw pi message objects (role/content/timestamp on the object), in file
  * order, ready to feed straight into buildPiChatHistory — the same shape the
@@ -234,6 +235,37 @@ export class PiSessionStore implements SessionStore {
       updatedAt: now,
       turnCount: 0,
     };
+  }
+
+  /**
+   * Addressed-gateway creation path. The public id is Pi's native id while the
+   * small Boring wrapper retains the verified storage/runtime scope.
+   */
+  async createNative(
+    ctx: SessionCtx,
+    init?: { title?: string },
+  ): Promise<SessionSummary> {
+    const manager = await createPersistedNativeSessionManager(this.cwd, this.sessionDir);
+    const id = manager.getSessionId();
+    const nativePath = manager.getSessionFile();
+    if (!id || !nativePath) throw new Error("Native Pi session did not persist");
+    const entries = safeParseEntries(await readFile(nativePath, "utf-8"));
+    const wrapperPath = join(this.sessionDir, `${id}.jsonl`);
+    let wrapper = buildNativePiSessionWrapper(id, this.cwd, nativePath, entries, ctx);
+    if (init?.title) {
+      const now = new Date().toISOString();
+      const info: SessionInfoEntry = {
+        type: "session_info",
+        id: randomUUID(),
+        parentId: null,
+        timestamp: now,
+        name: init.title,
+      };
+      wrapper += `${JSON.stringify(info)}\n`;
+    }
+    await writeFile(wrapperPath, wrapper, { encoding: "utf-8", flag: "wx" });
+    this.prefixCache.delete(wrapperPath);
+    return await this.load(ctx, id);
   }
 
   async load(ctx: SessionCtx, sessionId: string): Promise<SessionDetail> {

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -54,6 +54,15 @@ export interface WorkspaceAgentSession {
   title?: string | null
   updatedAt?: string | number
   turnCount?: number
+  /** Browser-only draft that has not completed its first addressed send. */
+  ephemeral?: boolean
+}
+
+export interface WorkspaceNativeSession extends WorkspaceAgentSession {
+  title: string
+  createdAt: string
+  updatedAt: string
+  turnCount: number
 }
 
 export interface WorkspaceAgentSessionsApi<
@@ -76,6 +85,8 @@ export interface WorkspaceAgentSessionsApi<
   workspaceId?: string | null
   switch: (id: string, agentTypeId?: string) => void
   create: (input?: { title?: string }) => void | Promise<unknown>
+  adoptNative?: (localId: string, session: WorkspaceNativeSession) => void
+  rename?: (id: string, title: string) => void | Promise<unknown>
   delete: (id: string, agentTypeId?: string) => void | Promise<unknown>
   loadMore?: () => void | Promise<unknown>
   refresh?: (options?: { background?: boolean; throwOnError?: boolean }) => void | Promise<unknown>
@@ -424,6 +435,7 @@ function useDefaultWorkspacePiSessions(options: Parameters<UseWorkspaceAgentSess
     requestHeaders: options.requestHeaders,
     enabled: options.enabled,
     connectActiveSession: false,
+    localCreateUntilPrompt: Boolean(options.agentTypeId),
     refreshKey: options.refreshKey,
   })
   return {
@@ -609,6 +621,8 @@ export function WorkspaceAgentFront<
       resolvedSessionTitle,
       rawSwitch,
       resolvedCreate,
+      resolvedRename,
+      adoptAddressedSession,
     },
     panes: {
       chatSessionId,
@@ -933,6 +947,9 @@ export function WorkspaceAgentFront<
       const bridgeEnabled = options.bridgeEnabled ?? true
       const sessionRef = workspaceSessionRefFromKey(sessionKey)
       const sessionId = sessionRef.sessionId
+      const paneSession = resolvedSessions.find((session) => workspaceSessionKeyFor(session) === sessionKey)
+      const paneEphemeral = (paneSession as WorkspaceAgentSession | undefined)?.ephemeral === true
+        || sessionId.startsWith("local-")
       const paneHydrateMessages = hydrateMessages || Boolean(
         multiAgentConsoleEnabled
         && sessionRef.agentTypeId
@@ -945,7 +962,25 @@ export function WorkspaceAgentFront<
       ...chatParams,
       ...(delayAutoSubmitDraft ? { autoSubmitInitialDraft: false, initialDraft: undefined } : {}),
       sessionId,
+      sessionEphemeral: paneEphemeral,
       agentTypeId: sessionRef.agentTypeId ?? agentTypeId,
+      nativeSessionStartEnabled: Boolean(
+        (sessionRef.agentTypeId ?? agentTypeId)
+        && paneEphemeral,
+      ),
+      onNativeSessionAdopt: (nativeSession: {
+        id: string
+        title: string
+        createdAt: string
+        updatedAt: string
+        turnCount: number
+      }) => {
+        if (multiAgentConsoleEnabled && sessionRef.agentTypeId) {
+          adoptAddressedSession(sessionRef, nativeSession)
+          return
+        }
+        sessionApi?.adoptNative?.(sessionId, nativeSession)
+      },
       agentSelection: isPluginTabsLayout ? undefined : controlledAgentSelection,
       apiBaseUrl,
       workspaceId,
@@ -984,7 +1019,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [agentTypeId, apiBaseUrl, chatParams, chatRemoteSessionOptions, controlledAgentSelection, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, isPluginTabsLayout, markInitialHydrationPromptStarted, multiAgentConsoleEnabled, refreshAddressedSession, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, sessionApi, settleAutoSubmitHydration, workspaceId],
+    [adoptAddressedSession, agentTypeId, apiBaseUrl, chatParams, chatRemoteSessionOptions, controlledAgentSelection, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, isPluginTabsLayout, markInitialHydrationPromptStarted, multiAgentConsoleEnabled, refreshAddressedSession, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, resolvedSessions, sessionApi, settleAutoSubmitHydration, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionKey),
@@ -1388,6 +1423,7 @@ export function WorkspaceAgentFront<
           onOpenSessionAsPane={openChatPane}
           onToggleSessionPinned={toggleSessionPinned}
           onDeleteSession={canDeleteSessions ? deleteSessionAndPane : undefined}
+          onRenameSession={agentTypeId && sessionApi?.rename ? resolvedRename : undefined}
           actions={managementActions}
         />
       )}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -981,7 +981,8 @@ describe("WorkspaceAgentFront", () => {
 
     await screen.findByText("Beta shared")
     expect(screen.getByRole("combobox", { name: "Agent" })).toHaveValue("alpha")
-    await user.click(screen.getByLabelText("Delete Beta shared"))
+    await user.click(screen.getByLabelText("More options for Beta shared"))
+    await user.click(screen.getByRole("menuitem", { name: "Delete" }))
 
     await waitFor(() => {
       expect(betaDelete).toHaveBeenCalledWith("shared")

--- a/packages/workspace/src/app/front/addressedConsoleSessions.tsx
+++ b/packages/workspace/src/app/front/addressedConsoleSessions.tsx
@@ -4,6 +4,7 @@ import type {
   UseWorkspaceAgentSessions,
   WorkspaceAddressedAgentOption,
   WorkspaceAgentSession,
+  WorkspaceNativeSession,
   WorkspaceAgentSessionsApi,
 } from "./WorkspaceAgentFront"
 
@@ -69,12 +70,28 @@ export function useAddressedConsoleController<
     return controllers.current.get(session.agentTypeId)?.delete(session.sessionId)
   }, [controllers, enabled])
 
+  const adoptNativeSession = useCallback((
+    session: WorkspaceSessionRef,
+    nativeSession: WorkspaceNativeSession,
+  ) => {
+    if (!enabled || !session.agentTypeId) return
+    controllers.current.get(session.agentTypeId)?.adoptNative?.(session.sessionId, nativeSession)
+  }, [controllers, enabled])
+
+  const renameSession = useCallback((
+    session: WorkspaceSessionRef,
+    title: string,
+  ) => {
+    if (!enabled || !session.agentTypeId) return undefined
+    return controllers.current.get(session.agentTypeId)?.rename?.(session.sessionId, title)
+  }, [controllers, enabled])
+
   const refreshSession = useCallback((session: WorkspaceSessionRef) => {
     if (!enabled || !session.agentTypeId) return undefined
     return controllers.current.get(session.agentTypeId)?.refresh?.({ background: true })
   }, [controllers, enabled])
 
-  return { activate, deleteSession, refreshSession }
+  return { activate, adoptNativeSession, renameSession, deleteSession, refreshSession }
 }
 
 function AddressedConsoleSessionSource<

--- a/packages/workspace/src/app/front/index.ts
+++ b/packages/workspace/src/app/front/index.ts
@@ -3,6 +3,7 @@ export {
   type UseWorkspaceAddressedAgentSelection,
   type WorkspaceAgentFrontProps,
   type WorkspaceAgentLayout,
+  type WorkspaceNativeSession,
   type WorkspaceAddressedAgentOption,
   type WorkspaceAddressedAgentSelection,
   type WorkspaceAgentSession,

--- a/packages/workspace/src/app/front/useWorkspaceAgentSessionCoordinator.ts
+++ b/packages/workspace/src/app/front/useWorkspaceAgentSessionCoordinator.ts
@@ -232,6 +232,8 @@ export function useWorkspaceAgentSessionCoordinator<
       workspaceId,
       switch: (id) => controller()?.switch(id),
       create: (input) => controller()?.create(input),
+      adoptNative: (localId, session) => controller()?.adoptNative?.(localId, session),
+      rename: (id, title) => controller()?.rename?.(id, title),
       delete: (id) => controller()?.delete(id),
       loadMore: () => controller()?.loadMore?.(),
       refresh: (options) => controller()?.refresh?.(options),
@@ -239,6 +241,8 @@ export function useWorkspaceAgentSessionCoordinator<
   }, [agentSessionScopeKey, agentTypeId, multiAgentConsoleEnabled, primaryRemoteSessionApi, remoteSessionSnapshots, workspaceId])
   const {
     activate: activateAddressedSession,
+    adoptNativeSession: adoptAddressedSession,
+    renameSession: renameAddressedSession,
     deleteSession: deleteAddressedSession,
     refreshSession: refreshAddressedSession,
   } = useAddressedConsoleController({
@@ -535,6 +539,12 @@ export function useWorkspaceAgentSessionCoordinator<
       : onCreateSession
         ? () => onCreateSession()
         : () => localSessionStore.create()
+  const resolvedRename = useCallback((id: string, title: string, sessionAgentTypeId?: string) => {
+    if (multiAgentConsoleEnabled && sessionAgentTypeId) {
+      return renameAddressedSession(workspaceSessionRef(id, sessionAgentTypeId), title)
+    }
+    return sessionApi?.rename?.(id, title)
+  }, [multiAgentConsoleEnabled, renameAddressedSession, sessionApi])
   const rawDelete: (id: string, agentTypeId?: string) => unknown = remoteSessionsPending
     ? remoteSessionActionsUnavailable
     : sessionApi?.delete ?? onDeleteSession ?? localSessionStore.remove
@@ -709,6 +719,8 @@ export function useWorkspaceAgentSessionCoordinator<
       resolvedSessionTitle,
       rawSwitch,
       resolvedCreate,
+      resolvedRename,
+      adoptAddressedSession,
     },
     panes,
   }

--- a/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
@@ -169,7 +169,29 @@ function syncPanesToDock(
   }
   if (activePaneId) {
     const panel = api.getPanel(activePaneId)
-    if (panel && api.activePanel?.id !== activePaneId) panel.api.setActive()
+    // A replacement can inherit the active panel's group while the removed
+    // panel is still Dockview's visible renderer. Reassert activation even
+    // when `api.activePanel` already reports the replacement; otherwise the
+    // authoritative pane is marked active while its `.dv-react-part` remains
+    // visibility:hidden until a user click. Dockview can still retain a stale
+    // visibility bit after that activation; fall back to its direct renderer
+    // for that panel so the active transcript is never left blank.
+    panel?.api.setActive()
+    if (panel && panel.api.renderer === "always") {
+      const panelWindow = panel.api.getWindow()
+      panelWindow.requestAnimationFrame(() => {
+        panelWindow.requestAnimationFrame(() => {
+          const current = api.getPanel(activePaneId)
+          if (!current || current.api.renderer !== "always") return
+          const pane = Array.from(panelWindow.document.querySelectorAll<HTMLElement>(
+            '[data-boring-workspace-part="chat-pane"][data-boring-state="active"]',
+          )).find((candidate) => candidate.dataset.boringPaneId === activePaneId)
+          if (pane && panelWindow.getComputedStyle(pane).visibility === "hidden") {
+            current.api.setRenderer("onlyWhenVisible")
+          }
+        })
+      })
+    }
   }
 }
 
@@ -351,6 +373,7 @@ function ChatPanePanel(props: IDockviewPanelProps) {
   return (
     <div
       data-boring-workspace-part="chat-pane"
+      data-boring-pane-id={paneId}
       data-boring-state={active ? "active" : "inactive"}
       aria-label={`Chat session ${paneTitle(pane)}`}
       className="relative flex h-full min-h-0 w-full flex-col overflow-hidden bg-background"

--- a/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import { render } from "@testing-library/react"
+import { act, render } from "@testing-library/react"
 
 // Capture the props handed to DockviewReact so we can assert the rendering
 // contract that keeps chat panes mounted across activation. The real dockview
@@ -47,5 +47,60 @@ describe("ChatPaneStageDock", () => {
     // container's scrollTop to 0. "always" keeps it mounted in place.
     expect(dockviewProps).toHaveBeenCalled()
     expect(dockviewProps.mock.calls[0][0]).toMatchObject({ defaultRenderer: "always" })
+  })
+
+  it("repairs a Dockview active pane that remains hidden after a session replacement", () => {
+    dockviewProps.mockClear()
+    render(
+      <ChatPaneStageDock
+        panes={[{ id: "native-1", title: "Native" }]}
+        activePaneId="native-1"
+        renderPane={(pane) => <div>{pane.id}</div>}
+      />,
+    )
+
+    const setActive = vi.fn()
+    const setRenderer = vi.fn()
+    const activePaneElement = {
+      dataset: { boringPaneId: "native-1" },
+    } as unknown as HTMLElement
+    const panelWindow = {
+      requestAnimationFrame: (callback: FrameRequestCallback) => {
+        callback(0)
+        return 1
+      },
+      document: {
+        querySelectorAll: () => [activePaneElement],
+      },
+      getComputedStyle: () => ({ visibility: "hidden" }),
+    }
+    const panel = {
+      id: "native-1",
+      title: "Native",
+      api: {
+        renderer: "always",
+        setActive,
+        setRenderer,
+        setTitle: vi.fn(),
+        getWindow: () => panelWindow,
+      },
+    }
+    const disposable = () => ({ dispose: vi.fn() })
+    const api = {
+      panels: [panel],
+      getPanel: (id: string) => id === panel.id ? panel : undefined,
+      removePanel: vi.fn(),
+      onDidActivePanelChange: disposable,
+      onWillShowOverlay: disposable,
+      onUnhandledDragOver: disposable,
+      onDidDrop: disposable,
+      onDidLayoutChange: disposable,
+    }
+
+    const onReady = dockviewProps.mock.calls[0][0].onReady as (event: { api: unknown }) => void
+    act(() => onReady({ api }))
+
+    expect(setActive).toHaveBeenCalledOnce()
+    expect(setRenderer).toHaveBeenCalledWith("onlyWhenVisible")
   })
 })

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -16,6 +16,7 @@ export interface AppLeftPaneSession {
   title?: string | null
   updatedAt?: string | number
   turnCount?: number
+  ephemeral?: boolean
 }
 
 export interface AppLeftPaneAgent {
@@ -105,6 +106,7 @@ export interface AppLeftPaneProps {
   onOpenSessionAsPane: (id: string, agentTypeId?: string) => void
   onToggleSessionPinned: (id: string, agentTypeId?: string) => void
   onDeleteSession?: (id: string, agentTypeId?: string) => void
+  onRenameSession?: (id: string, title: string, agentTypeId?: string) => void | Promise<unknown>
   /** Primary app-left actions supplied by the host/app/plugin shell after New chat/Search. */
   actions?: readonly AppLeftPaneAction[]
   /**
@@ -230,6 +232,7 @@ export function AppLeftPane({
   onOpenSessionAsPane,
   onToggleSessionPinned,
   onDeleteSession,
+  onRenameSession,
   actions = [],
   layoutMode = "single-project",
 }: AppLeftPaneProps) {
@@ -355,6 +358,9 @@ export function AppLeftPane({
         onTogglePinned={session.agentTypeId
           ? () => onToggleSessionPinned(session.id, session.agentTypeId)
           : () => onToggleSessionPinned(session.id)}
+        onRename={isActiveProjectSession && onRenameSession
+          ? (id, title) => onRenameSession(id, title, session.agentTypeId)
+          : undefined}
         onDelete={isActiveProjectSession && onDeleteSession
           ? session.agentTypeId
             ? () => onDeleteSession(session.id, session.agentTypeId)

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -1,10 +1,13 @@
 "use client"
 
-import { Clock3, MessageSquarePlus, Pin, X } from "lucide-react"
+import { useState } from "react"
+import { Clock3, MessageSquarePlus, Pin } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { CHAT_SESSION_DRAG_TYPE } from "../ChatPaneStage"
 import type { WorkspaceAttentionSessionBadge } from "../../attention/WorkspaceAttentionProvider"
 import type { AppLeftPaneSession } from "./AppLeftPane"
+import { AppSessionActionsMenu } from "./AppSessionActionsMenu"
+import { InlineSessionRename, useInlineSessionRename } from "./InlineSessionRename"
 import { encodeWorkspaceSessionDrag } from "../../sessionIdentity"
 
 export type AppSessionRowState = "normal" | "open" | "active"
@@ -38,6 +41,7 @@ export function AppSessionRow({
   onSwitch,
   onOpenAsPane,
   onTogglePinned,
+  onRename,
   onDelete,
 }: {
   session: AppLeftPaneSession
@@ -52,9 +56,20 @@ export function AppSessionRow({
   onSwitch: (id: string) => void
   onOpenAsPane: (id: string) => void
   onTogglePinned: (id: string) => void
-  onDelete?: (id: string) => void
+  onRename?: (id: string, title: string) => void | Promise<unknown>
+  onDelete?: (id: string) => void | Promise<unknown>
 }) {
   const title = session.title || "Untitled"
+  const [menuOpen, setMenuOpen] = useState(false)
+  const renameAvailable = Boolean(onRename) && session.ephemeral !== true
+  const canCopy = session.ephemeral !== true
+  const showMenu = canCopy || renameAvailable || Boolean(onDelete)
+  const rename = useInlineSessionRename({
+    sessionId: session.id,
+    title,
+    available: renameAvailable,
+    onRename,
+  })
   // Re-selecting the active chat is intentional: the shell uses this callback
   // to dismiss transient app-left overlays (Tasks, Skills, Plugins) even when
   // no session switch is needed.
@@ -63,13 +78,19 @@ export function AppSessionRow({
   return (
     <div
       data-boring-workspace-part="app-session-row"
+      data-boring-session-id={session.id}
+      data-boring-agent-type-id={session.agentTypeId}
       data-boring-session-state={state}
       // Drag a session onto the chat stage to open it as a split pane (the
       // stage accepts CHAT_SESSION_DRAG_TYPE; see ChatPaneStageDock). Only
       // same-project sessions are draggable — a split pane lives in the loaded
       // workspace's stage, so cross-project sessions can't join it.
-      draggable={canSplit}
+      draggable={canSplit && !rename.editing && !menuOpen}
       onDragStart={canSplit ? (event) => {
+        if (rename.editing || menuOpen) {
+          event.preventDefault()
+          return
+        }
         event.dataTransfer.setData(CHAT_SESSION_DRAG_TYPE, encodeWorkspaceSessionDrag({
           sessionId: session.id,
           ...(session.agentTypeId ? { agentTypeId: session.agentTypeId } : {}),
@@ -77,7 +98,9 @@ export function AppSessionRow({
         event.dataTransfer.setData("text/plain", title)
         event.dataTransfer.effectAllowed = "copyMove"
       } : undefined}
-      onClick={activate}
+      onClick={() => {
+        if (!rename.editing) activate()
+      }}
       className={cn(
         "group flex min-h-8 w-full items-center gap-2 rounded-md border px-2.5 py-1 text-left transition-colors",
         state === "active"
@@ -96,18 +119,22 @@ export function AppSessionRow({
         strokeWidth={1.75}
         aria-hidden="true"
       />
-      <button
-        type="button"
-        onClick={(event) => {
-          event.stopPropagation()
-          activate()
-        }}
-        aria-current={state === "active" ? "page" : undefined}
-        className="min-w-0 flex-1 truncate rounded text-left text-[13px] font-medium leading-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-        title={title}
-      >
-        {title}
-      </button>
+      {rename.field ? (
+        <InlineSessionRename field={rename.field} onCancel={rename.cancel} />
+      ) : (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation()
+            activate()
+          }}
+          aria-current={state === "active" ? "page" : undefined}
+          className="min-w-0 flex-1 truncate rounded text-left text-[13px] font-medium leading-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          title={title}
+        >
+          {title}
+        </button>
+      )}
       {attentionBadge ? (
         <span
           data-boring-workspace-part="app-session-badge"
@@ -156,12 +183,12 @@ export function AppSessionRow({
       {/* "Open in new chat pane" only for closed, same-project sessions —
           it's pointless once open, and a cross-project session can't share
           this workspace's split stage. */}
-      {(state === "normal" && canSplit) || onDelete ? (
+      {(state === "normal" && canSplit) || showMenu ? (
         <span
           data-boring-workspace-part="app-session-actions"
           className="flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100"
         >
-          {state === "normal" && canSplit ? (
+          {state === "normal" && canSplit && !rename.editing ? (
             <button
               type="button"
               aria-label={`Open ${title} in new chat pane`}
@@ -175,19 +202,16 @@ export function AppSessionRow({
               <MessageSquarePlus className="h-3.5 w-3.5" strokeWidth={1.75} />
             </button>
           ) : null}
-          {onDelete ? (
-            <button
-              type="button"
-              aria-label={`Delete ${title}`}
-              title="Delete"
-              onClick={(event) => {
-                event.stopPropagation()
-                onDelete(session.id)
-              }}
-              className="grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-            >
-              <X className="h-3.5 w-3.5" strokeWidth={1.75} />
-            </button>
+          {showMenu ? (
+            <AppSessionActionsMenu
+              sessionId={session.id}
+              title={title}
+              canCopy={canCopy}
+              canRename={renameAvailable && !rename.editing}
+              onRename={rename.begin}
+              onDelete={onDelete}
+              onOpenChange={setMenuOpen}
+            />
           ) : null}
         </span>
       ) : null}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppSessionActionsMenu.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppSessionActionsMenu.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { Copy, MoreHorizontal, Pencil, Trash2 } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@hachej/boring-ui-kit"
+import { toast } from "../../toast"
+
+export function AppSessionActionsMenu({
+  sessionId,
+  title,
+  canCopy,
+  canRename,
+  onRename,
+  onDelete,
+  onOpenChange,
+}: {
+  sessionId: string
+  title: string
+  canCopy: boolean
+  canRename: boolean
+  onRename: () => void
+  onDelete?: (id: string) => void | Promise<unknown>
+  onOpenChange: (open: boolean) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const suppressCloseAutoFocus = useRef(false)
+  const setMenuOpen = (next: boolean) => {
+    setOpen(next)
+    onOpenChange(next)
+  }
+  const copy = async () => {
+    if (await copyText(sessionId)) {
+      toast.success({ title: "Session ID copied", description: sessionId })
+      return
+    }
+    toast.error({ title: "Could not copy session ID", description: "Allow clipboard access and try again." })
+  }
+  return (
+    <DropdownMenu open={open} onOpenChange={setMenuOpen}>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          draggable={false}
+          aria-label={`More options for ${title}`}
+          title="More"
+          onPointerDown={() => { suppressCloseAutoFocus.current = false }}
+          onKeyDown={() => { suppressCloseAutoFocus.current = false }}
+          onClick={(event) => event.stopPropagation()}
+          onDragStart={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          className="grid size-11 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 sm:size-6"
+        >
+          <MoreHorizontal className="h-3.5 w-3.5" strokeWidth={1.75} />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={6}
+        onPointerDownCapture={() => { suppressCloseAutoFocus.current = true }}
+        onPointerDownOutside={() => { suppressCloseAutoFocus.current = true }}
+        onEscapeKeyDown={() => { suppressCloseAutoFocus.current = false }}
+        onCloseAutoFocus={(event) => {
+          if (suppressCloseAutoFocus.current) event.preventDefault()
+        }}
+        onClick={(event) => event.stopPropagation()}
+        className="w-48 border-border/50"
+      >
+        {canCopy ? (
+          <DropdownMenuItem onSelect={() => void copy()} className="gap-2 text-[13px]">
+            <Copy className="h-3.5 w-3.5" /> Copy session ID
+          </DropdownMenuItem>
+        ) : null}
+        {canCopy && (canRename || onDelete) ? <DropdownMenuSeparator /> : null}
+        {canRename ? (
+          <DropdownMenuItem
+            onSelect={() => {
+              setMenuOpen(false)
+              onRename()
+            }}
+            className="gap-2 text-[13px]"
+          >
+            <Pencil className="h-3.5 w-3.5" /> Rename
+          </DropdownMenuItem>
+        ) : null}
+        {canRename && onDelete ? <DropdownMenuSeparator /> : null}
+        {onDelete ? (
+          <DropdownMenuItem
+            onSelect={() => void onDelete(sessionId)}
+            variant="destructive"
+            className="gap-2 text-[13px]"
+          >
+            <Trash2 className="h-3.5 w-3.5" /> Delete
+          </DropdownMenuItem>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+async function copyText(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    } catch {
+      // Fall through for HTTP dev URLs and browsers that deny Clipboard API access.
+    }
+  }
+
+  if (typeof document === "undefined") return false
+  const textarea = document.createElement("textarea")
+  textarea.value = text
+  textarea.setAttribute("readonly", "")
+  textarea.style.position = "fixed"
+  textarea.style.top = "-9999px"
+  textarea.style.opacity = "0"
+  document.body.appendChild(textarea)
+  const writeCopyData = (event: ClipboardEvent) => {
+    if (!event.clipboardData) return
+    event.clipboardData.setData("text/plain", text)
+    event.preventDefault()
+  }
+  document.addEventListener("copy", writeCopyData, { once: true })
+  try {
+    textarea.focus()
+    textarea.select()
+    textarea.setSelectionRange(0, text.length)
+    return document.execCommand?.("copy") ?? false
+  } catch {
+    return false
+  } finally {
+    document.removeEventListener("copy", writeCopyData)
+    document.body.removeChild(textarea)
+  }
+}

--- a/packages/workspace/src/front/layout/plugin-tabs/InlineSessionRename.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/InlineSessionRename.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+const MAX_TITLE_LENGTH = 200
+
+export function useInlineSessionRename({
+  sessionId,
+  title,
+  available,
+  onRename,
+}: {
+  sessionId: string
+  title: string
+  available: boolean
+  onRename?: (id: string, title: string) => void | Promise<unknown>
+}) {
+  const [value, setValue] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    if (value !== null) inputRef.current?.focus()
+  }, [value])
+  useEffect(() => {
+    if (!available) setValue(null)
+  }, [available])
+
+  const cancel = () => {
+    setValue(null)
+    setError(null)
+  }
+  const save = () => {
+    const next = value?.trim() ?? ""
+    if (!next) {
+      setError("Session title is required")
+      return
+    }
+    if (next.length > MAX_TITLE_LENGTH) {
+      setError(`Session title must be ${MAX_TITLE_LENGTH} characters or fewer`)
+      return
+    }
+    if (next === title) {
+      cancel()
+      return
+    }
+    if (!onRename || saving) return
+    setSaving(true)
+    void Promise.resolve(onRename(sessionId, next))
+      .then(cancel)
+      .catch((reason) => setError(reason instanceof Error ? reason.message : "Rename failed"))
+      .finally(() => setSaving(false))
+  }
+
+  return {
+    editing: value !== null,
+    begin: () => {
+      if (!available) return
+      setValue(title)
+      setError(null)
+    },
+    cancel,
+    field: value === null ? null : { inputRef, value, error, saving, setValue, save },
+  }
+}
+
+export function InlineSessionRename({
+  field,
+  onCancel,
+}: {
+  field: NonNullable<ReturnType<typeof useInlineSessionRename>["field"]>
+  onCancel: () => void
+}) {
+  return (
+    <span className="min-w-0 flex-1">
+      <input
+        ref={field.inputRef}
+        value={field.value}
+        disabled={field.saving}
+        onClick={(event) => event.stopPropagation()}
+        onChange={(event) => field.setValue(event.currentTarget.value)}
+        onBlur={field.save}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault()
+            field.save()
+          }
+          if (event.key === "Escape") {
+            event.preventDefault()
+            onCancel()
+          }
+        }}
+        aria-label="Rename session"
+        aria-invalid={field.error ? true : undefined}
+        className="h-6 w-full rounded border border-border bg-background px-1.5 text-[13px] text-foreground outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+      />
+      {field.error ? <p role="alert" className="mt-1 text-xs text-destructive">{field.error}</p> : null}
+    </span>
+  )
+}

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPaneSessionRow.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPaneSessionRow.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("../../../lib/utils", () => ({
+  cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(" "),
+}))
+
+import { AppSessionRow } from "../AppLeftPaneSessionRow"
+
+function row(overrides: Partial<Parameters<typeof AppSessionRow>[0]> = {}) {
+  return render(
+    <AppSessionRow
+      session={{ id: "native-1", title: "Native chat" }}
+      state="normal"
+      pinned={false}
+      onSwitch={vi.fn()}
+      onOpenAsPane={vi.fn()}
+      onTogglePinned={vi.fn()}
+      {...overrides}
+    />,
+  )
+}
+
+describe("AppSessionRow actions", () => {
+  it("keeps pane actions direct and routes durable rename/delete through the menu", () => {
+    const onDelete = vi.fn()
+    row({ onDelete, onRename: vi.fn() })
+
+    expect(screen.getByLabelText("Pin Native chat")).toBeInTheDocument()
+    expect(screen.getByLabelText("Open Native chat in new chat pane")).toBeInTheDocument()
+    fireEvent.pointerDown(screen.getByLabelText("More options for Native chat"), { button: 0, ctrlKey: false })
+    expect(screen.getByText("Copy session ID")).toBeInTheDocument()
+    expect(screen.getByText("Rename")).toBeInTheDocument()
+    fireEvent.click(screen.getByText("Delete"))
+    expect(onDelete).toHaveBeenCalledWith("native-1")
+  })
+
+  it("does not expose copy or rename for an ephemeral draft", () => {
+    row({
+      session: { id: "local-1", title: "Local draft", ephemeral: true },
+      canSplit: false,
+    })
+
+    expect(screen.queryByLabelText("More options for Local draft")).not.toBeInTheDocument()
+  })
+})

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/InlineSessionRename.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/InlineSessionRename.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { InlineSessionRename, useInlineSessionRename } from "../InlineSessionRename"
+
+function RenameHarness({ onRename }: { onRename: (id: string, title: string) => void | Promise<unknown> }) {
+  const rename = useInlineSessionRename({
+    sessionId: "session-1",
+    title: "Original",
+    available: true,
+    onRename,
+  })
+  return rename.field
+    ? <InlineSessionRename field={rename.field} onCancel={rename.cancel} />
+    : <button type="button" onClick={rename.begin}>Rename</button>
+}
+
+describe("InlineSessionRename", () => {
+  it("trims and saves a changed title on Enter", async () => {
+    const onRename = vi.fn(async () => undefined)
+    render(<RenameHarness onRename={onRename} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }))
+    const input = screen.getByRole("textbox", { name: "Rename session" })
+    fireEvent.change(input, { target: { value: "  Better title  " } })
+    fireEvent.keyDown(input, { key: "Enter" })
+
+    await waitFor(() => expect(onRename).toHaveBeenCalledWith("session-1", "Better title"))
+    await waitFor(() => expect(screen.getByRole("button", { name: "Rename" })).toBeTruthy())
+  })
+
+  it("keeps the editor open and explains an empty title", async () => {
+    render(<RenameHarness onRename={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }))
+    const input = screen.getByRole("textbox", { name: "Rename session" })
+    fireEvent.change(input, { target: { value: "   " } })
+    fireEvent.keyDown(input, { key: "Enter" })
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Session title is required")
+    expect(screen.getByRole("textbox", { name: "Rename session" })).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## Summary

- keep new addressed chats browser-local until the first prompt, then create one durable native Pi session and adopt its returned ID
- connect the addressed event stream before sending the first prompt; coalesce/reconcile ambiguous sends with one stable create request ID
- defer adoption while a rapid follow-up is in flight and prevent native creation after disposal
- restore the session actions/inline rename menu in the current per-agent AppLeftPane groups
- repair Dockview hidden active renderer after a session-ID replacement
- add CI-wired workspace-playground regressions for first response, two-session switching, and no-click rendering

## Root cause

The reverted implementation sent the first prompt through the legacy native-prompt route, then subscribed on the addressed route. Those two contexts could resolve different live-channel keys, so the first turn ran on a channel the browser was not observing. This re-land stays entirely on the existing addressed wire: create -> subscribe -> prompt -> adopt.

## #968 overlap

PR #968 carries some of the same session-identity intent, but it targets the legacy/pre-addressing shape and changes frozen gateway contract types. This branch uses it only as diagnosis/reference, does not copy its wire changes, and is rebuilt on `integration/wave-1` with #976/#981.

## Proof

- `pnpm typecheck` — TypeScript: no errors
- `pnpm lint` — generated artifacts/resources/import audit pass
- `pnpm lint:invariants` — agent, boring-bash, boring-sandbox, workspace plugin, and alignment invariants pass
- `pnpm --filter @hachej/boring-agent run test` — 198 files passed; 1,818 tests passed; 18 skipped
- `pnpm --filter @hachej/boring-workspace run test` — 134 files passed; 1,804 tests passed; 10 skipped
- `pnpm --filter workspace-playground run test:e2e:addressed-agent` — 6 passed, including all three required regressions
- `packages/agent/dist/front/styles.css` — 166,664 bytes

No frozen gateway wire/contract files are changed. This PR should not be merged automatically.