### PR TITLE
fix(agent): update Bombadil browser baseline CLI

### DIFF
--- a/packages/agent/e2e/bombadil/pi-native-chat.spec.ts
+++ b/packages/agent/e2e/bombadil/pi-native-chat.spec.ts
@@ -1,19 +1,21 @@
 import {
-  actions,
   always,
   eventually,
-  extract,
   next,
   now,
+} from '@antithesishq/bombadil'
+import {
+  actions,
+  extract,
   type Action,
   type Point,
-} from '@antithesishq/bombadil'
+} from '@antithesishq/bombadil/browser'
 import {
   noConsoleErrors,
   noHttpErrorCodes,
   noUncaughtExceptions,
   noUnhandledPromiseRejections,
-} from '@antithesishq/bombadil/defaults/properties'
+} from '@antithesishq/bombadil/browser/defaults/properties'
 import { RUNNING_TOOL_GROUP_VISUAL_STATE, TOOL_GROUP_VISUAL_STATES } from '../../src/front/primitives/tool-call-group-state.ts'
 
 const MODEL_LABEL_ORDER = ['Claude Sonnet', 'Claude Opus', 'GPT Main', 'GPT Fast'] as const

--- a/packages/agent/scripts/run-bombadil-chat.mjs
+++ b/packages/agent/scripts/run-bombadil-chat.mjs
@@ -65,6 +65,7 @@ try {
   const result = await runCommand('pnpm', [
     'exec',
     'bombadil',
+    'browser',
     'test',
     targetUrl,
     'e2e/bombadil/pi-native-chat.spec.ts',


### PR DESCRIPTION
## Summary

Restore the nightly Pi-native Bombadil chat baseline after the Bombadil 0.6.1 browser API/CLI split.

## What changed

- Invoke `bombadil browser test` instead of the removed top-level `bombadil test` command.
- Import browser actions/types from `@antithesishq/bombadil/browser`.
- Import browser default properties from the exported `/browser/defaults/properties` subpath.

## Proof

- `pnpm --filter @hachej/boring-agent lint` — passed (typecheck + invariants).
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @hachej/boring-agent... --workspace-concurrency=4 run build` — passed.
- `BOMBADIL_TIME_LIMIT=30s pnpm test:bombadil:chat` — command and specification now resolve successfully; local execution reaches browser launch, then is blocked by the host's snap Chromium cgroup configuration. The branch workflow dispatch is the end-to-end proof using CI's installed Playwright Chromium.

## Review

- Independent fresh-context review: clean; confirmed CLI and package export-map compatibility.
- Reviewed SHA: `8d78a90`

## Risk / rollback

Low-risk test-harness-only change. Revert this commit to roll back.
