### PR TITLE
#909 [wt-391-forward-0jpy.38] boot real two-agent playground fleet

### DIFF
--- a/apps/full-app/README.md
+++ b/apps/full-app/README.md
@@ -134,6 +134,10 @@ Common optional:
 | `COMPOSIO_API_KEY` | — | Optional server-only managed connector credential resolved by the app's boring-mcp managed connector secret resolver. Do not create a `VITE_*` mirror. |
 | `BORING_MCP_MAX_READONLY_INPUT_BYTES` | `65536` | Governed read-only MCP call input limit. |
 
+### Agent fleet composition
+
+Both full-app entrypoints pass `createFullAppAgentFleetComposition()` into `createCoreWorkspaceAgentServer`. That `agents` option uses the same configured-agent shape as workspace-playground: each entry has an `agentTypeId`, distinct `definition.instructions`, and its own encoded `model.preferred`, accompanied by `defaultAgentTypeId` and the app-owned `fleetCompiler`. Full-app currently configures `default` and `dummy`; use `BORING_AGENT_DEFAULT_MODEL` and `BORING_AGENT_DUMMY_MODEL` to override their preferred models. Host compatibility tools remain scoped into every addressed binding, while an app that wants per-agent plugin selection should list the preflighted plugin IDs in each agent's `plugins` bindings.
+
 ### Local dev login
 
 For local development only, the dev server can expose a one-click login helper:

--- a/apps/workspace-playground/README.md
+++ b/apps/workspace-playground/README.md
@@ -47,7 +47,13 @@ Open `http://localhost:5200`. Append `?showcase=1` for the showcase route, or vi
 | `AGENT_API_PORT` | `5210` | In-process agent server port |
 | `BORING_WORKSPACE_PLAYGROUND_SEED_FIXTURES` | `1` | `0` disables seeding `workspace/` from fixtures |
 | `BORING_AGENT_WORKSPACE_ROOT` | `apps/workspace-playground/workspace` | Point the agent at an external workspace root |
+| `BORING_AGENT_SESSION_ROOT` | Pi default | Optional durable root for addressed-agent transcripts |
+| `BORING_WORKSPACE_PLAYGROUND_REAL_FLEET` | `0` | `1` boots the unscripted `default` + `researcher` real-agent fleet |
+| `BORING_WORKSPACE_PLAYGROUND_DEFAULT_MODEL` | `openai-codex:gpt-5.4-mini` | Encoded `provider:model-id` preferred by the real `default` agent |
+| `BORING_WORKSPACE_PLAYGROUND_RESEARCHER_MODEL` | `openai-codex:gpt-5.3-codex-spark` | Encoded `provider:model-id` preferred by the real `researcher` agent |
 | `CHOKIDAR_USEPOLLING` / `BORING_VITE_USEPOLLING` | `0` | `1` for polling file watch (network mounts, some containers); interval via `CHOKIDAR_INTERVAL` / `BORING_VITE_POLL_INTERVAL` |
+
+The real fleet is additive to the single-agent default and the scripted browser-E2E fleet. Both real agents use the normal Pi harness, receive the same bash/filesystem compatibility composition, and explicitly select the playground's `ask-user`, `diagram`, and `tasks` server-plugin contributions. Override both model vars with model encodings reported as available by `GET /api/v1/agent/models` when your Pi credentials do not provide the defaults.
 
 ## Composition
 

--- a/apps/workspace-playground/src/server/__tests__/realAgentFleet.test.ts
+++ b/apps/workspace-playground/src/server/__tests__/realAgentFleet.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { createWorkspacePlaygroundRealAgentFleet } from "../realAgentFleet"
+
+describe("workspace-playground real agent fleet", () => {
+  it("stays disabled unless the real fleet flag is set", () => {
+    expect(createWorkspacePlaygroundRealAgentFleet({})).toBeUndefined()
+  })
+
+  it("configures two real agents with isolated identity, model, and full app plugin bindings", () => {
+    const composition = createWorkspacePlaygroundRealAgentFleet({
+      BORING_WORKSPACE_PLAYGROUND_REAL_FLEET: "1",
+      BORING_WORKSPACE_PLAYGROUND_DEFAULT_MODEL: "test:default-model",
+      BORING_WORKSPACE_PLAYGROUND_RESEARCHER_MODEL: "test:researcher-model",
+    })
+
+    expect(composition).toEqual({
+      defaultAgentTypeId: "default",
+      agents: [
+        expect.objectContaining({
+          agentTypeId: "default",
+          definition: expect.objectContaining({
+            instructions: expect.stringContaining("DEFAULT_AGENT:"),
+          }),
+          plugins: [{ name: "ask-user" }, { name: "diagram" }, { name: "tasks" }],
+          model: { preferred: "test:default-model" },
+        }),
+        expect.objectContaining({
+          agentTypeId: "researcher",
+          definition: expect.objectContaining({
+            instructions: expect.stringContaining("RESEARCHER_AGENT:"),
+          }),
+          plugins: [{ name: "ask-user" }, { name: "diagram" }, { name: "tasks" }],
+          model: { preferred: "test:researcher-model" },
+        }),
+      ],
+    })
+  })
+})

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readdirSync, copyFileSync, statSync } from "node
 import { readFile, readdir, stat } from "node:fs/promises"
 import { basename, dirname, isAbsolute, relative, resolve } from "node:path"
 import { createRemoteWorkerModeAdapter } from "@hachej/boring-agent/server"
+import { createWorkspacePlaygroundRealAgentFleet } from "./realAgentFleet"
 import { createPersistedScriptedPiHarness } from "./testing/scriptedPiHarness"
 import { SCRIPTED_TWO_AGENT_DEFAULT, SCRIPTED_TWO_AGENT_FLEET } from "./testing/twoAgentFleet"
 import { createWorkspaceAgentServer } from "@hachej/boring-workspace/app/server"
@@ -72,6 +73,7 @@ export async function startPlaygroundServer(): Promise<void> {
     }
     const app = await createWorkspaceAgentServer({
       workspaceRoot,
+      sessionRoot: process.env.BORING_AGENT_SESSION_ROOT,
       appRoot: APP_ROOT,
       sessionId: remoteWorkerWorkspaceId,
       mode: remoteWorkerModeAdapter ? undefined : localRuntimeMode,
@@ -84,7 +86,7 @@ export async function startPlaygroundServer(): Promise<void> {
             agents: SCRIPTED_TWO_AGENT_FLEET,
             defaultAgentTypeId: SCRIPTED_TWO_AGENT_DEFAULT,
           }
-        : {}),
+        : createWorkspacePlaygroundRealAgentFleet() ?? {}),
       plugins: [createTasksServerPlugin({
         workspaceRoot,
         config: { providers: [{ provider: "github", repo: "auto" }] },

--- a/apps/workspace-playground/src/server/realAgentFleet.ts
+++ b/apps/workspace-playground/src/server/realAgentFleet.ts
@@ -1,0 +1,57 @@
+import type { AgentHostAgentSpec } from "@hachej/boring-agent/server"
+
+const DEFAULT_AGENT_MODEL = "openai-codex:gpt-5.4-mini"
+const RESEARCHER_AGENT_MODEL = "openai-codex:gpt-5.3-codex-spark"
+
+const PLAYGROUND_AGENT_PLUGINS = [
+  { name: "ask-user" },
+  { name: "diagram" },
+  { name: "tasks" },
+] as const
+
+function configuredModel(env: NodeJS.ProcessEnv, name: string, fallback: string): string {
+  return env[name]?.trim() || fallback
+}
+
+export function createWorkspacePlaygroundRealAgentFleet(env: NodeJS.ProcessEnv = process.env): {
+  readonly agents: readonly AgentHostAgentSpec[]
+  readonly defaultAgentTypeId: string
+} | undefined {
+  if (env.BORING_WORKSPACE_PLAYGROUND_REAL_FLEET !== "1") return undefined
+
+  return {
+    agents: [
+      {
+        agentTypeId: "default",
+        definition: {
+          label: "Default",
+          instructions: 'You are the Default real workspace-playground agent. Start every final response with "DEFAULT_AGENT:".',
+        },
+        plugins: PLAYGROUND_AGENT_PLUGINS,
+        model: {
+          preferred: configuredModel(
+            env,
+            "BORING_WORKSPACE_PLAYGROUND_DEFAULT_MODEL",
+            DEFAULT_AGENT_MODEL,
+          ),
+        },
+      },
+      {
+        agentTypeId: "researcher",
+        definition: {
+          label: "Researcher",
+          instructions: 'You are the Researcher real workspace-playground agent. Start every final response with "RESEARCHER_AGENT:".',
+        },
+        plugins: PLAYGROUND_AGENT_PLUGINS,
+        model: {
+          preferred: configuredModel(
+            env,
+            "BORING_WORKSPACE_PLAYGROUND_RESEARCHER_MODEL",
+            RESEARCHER_AGENT_MODEL,
+          ),
+        },
+      },
+    ],
+    defaultAgentTypeId: "default",
+  }
+}

--- a/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AuthorizedAgentScope } from '../../../shared/index'
+import type { AgentTool } from '../../../shared/tool'
 import type { AgentHarnessFactory } from '../../../shared/harness'
 import { createTestRuntimeModeAdapter } from '@agent-test-host'
 import { createScriptedPiHarness } from '../../testing/scriptedPiHarness'
@@ -42,6 +43,63 @@ function options(sessionRoot: string) {
 }
 
 describe('createAgentHost', () => {
+  it('gives a configured non-default agent the legacy default compatibility tool groups', async () => {
+    const sessionRoot = await root()
+    const compatibilityTool = (name: string): AgentTool => ({
+      name,
+      description: `${name} compatibility probe`,
+      parameters: { type: 'object', properties: {} },
+      async execute() {
+        return { content: [{ type: 'text', text: name }] }
+      },
+    })
+    const additionalStandardTool = compatibilityTool('compatibility_standard')
+    const extraTool = compatibilityTool('compatibility_extra')
+    const pluginTool = compatibilityTool('compatibility_plugin')
+    const parityOptions = {
+      ...options(sessionRoot),
+      agents: [
+        { agentTypeId: 'default', legacyDefault: true },
+        { agentTypeId: 'researcher', definition: { instructions: 'researcher', label: 'Researcher' } },
+      ] as const,
+      harnessFactory: (async (input) => createScriptedPiHarness(input)) satisfies AgentHarnessFactory,
+      resolveRuntimeScope: vi.fn(async () => ({
+        identity: 'runtime-parity',
+        environment: {
+          placementIdentity: 'direct-parity',
+          workspaceRoot: sessionRoot,
+          provisioningFingerprint: 'provision-parity',
+        },
+        sessionNamespace: 'parity',
+        extraTools: [extraTool],
+        compatibility: {
+          additionalStandardTools: [additionalStandardTool],
+          pluginTools: [{ pluginName: 'parity-plugin', tools: [pluginTool] }],
+        },
+      })),
+    }
+    const host = await createAgentHost(parityOptions)
+
+    try {
+      const legacy = await resolveAgentHostCompatibilityComposition(host, 'default', scope)
+      const configured = await resolveAgentHostCompatibilityComposition(host, 'researcher', scope)
+      const legacyToolNames = legacy.tools.map((tool) => tool.name)
+      const configuredToolNames = configured.tools.map((tool) => tool.name)
+
+      expect(configuredToolNames).toEqual(legacyToolNames)
+      expect(configuredToolNames).toEqual(expect.arrayContaining([
+        'bash',
+        'read',
+        'ls',
+        'compatibility_standard',
+        'compatibility_extra',
+        'compatibility_plugin',
+      ]))
+    } finally {
+      await host.host.close()
+    }
+  })
+
   it('awaits compilation, freezes the fleet, and publishes a stable durable identity', async () => {
     const sessionRoot = await root()
     const firstOptions = options(sessionRoot)


### PR DESCRIPTION
## DO NOT MERGE

Orchestrator review/merge is required.

## Summary

- Adds `BORING_WORKSPACE_PLAYGROUND_REAL_FLEET=1` as an additive, unscripted two-agent playground boot path.
- Configures `default` and `researcher` as real `ConfiguredAgentHostAgentSpec` entries with distinct instructions, plugin selections, and per-agent `model.preferred`.
- Leaves `BORING_AGENT_E2E_SCRIPTED_PI=1` and the scripted fleet untouched.
- Documents the equivalent `agents` / `defaultAgentTypeId` shape for full-app.

## Live boot configuration

Preflight confirmed ports 5290-5299 were free and no `workspace-playground` process was running. The successful boot used:

```sh
AGENT_API_PORT=5291
PORT=5292
BORING_AGENT_SESSION_ROOT=/data/pi-sessions/bead38-fixround1
BORING_WORKSPACE_PLAYGROUND_REAL_FLEET=1
BORING_WORKSPACE_PLAYGROUND_DEFAULT_MODEL=openai-codex:gpt-5.4-mini
BORING_WORKSPACE_PLAYGROUND_RESEARCHER_MODEL=openai-codex:gpt-5.3-codex-spark
unset BORING_AGENT_E2E_SCRIPTED_PI
pnpm --filter workspace-playground exec vite --host 127.0.0.1
```

The first attempted boot loaded Vault's `secret/agent/anthropic` `api_key` into `ANTHROPIC_API_KEY` (value never printed) and selected `anthropic:claude-haiku-4-5`, which `GET /api/v1/agent/models` reported available. The real provider call failed with an Anthropic quota error ("out of extra usage") before any tool execution, so it is not claimed as proof. I stopped that server, confirmed ports 5291/5292 were free, and rebooted with the two distinct, already-authenticated `openai-codex` defaults above. Both then completed real turns. No scripted harness flag was set in either boot.

Two distinct models were used because both configured defaults were available and callable: `default` used `openai-codex:gpt-5.4-mini`; `researcher` used `openai-codex:gpt-5.3-codex-spark`.

## Tool-composition finding

No composition gap was found. `resolveRuntimeScope` supplies the same compatibility inputs to each binding, and `buildAgentComposition` applies standard bash/filesystem tools, extra tools, and compatibility plugin tools independently of `legacyDefault`. This is verified by:

```sh
pnpm --filter @hachej/boring-agent exec vitest run src/server/agent-host/__tests__/createAgentHost.test.ts --no-file-parallelism
# 1 file passed; 4 tests passed; Type Errors: no errors
```

The added test `gives a configured non-default agent the legacy default compatibility tool groups` compares the configured `researcher` tool list to the legacy default under identical runtime compatibility and asserts `bash`, `read`, `ls`, additional-standard, extra, and plugin tools.

## Real unscripted transcript: `default`

Addressed session:

```json
{"agentTypeId":"default","sessionId":"019fad88-dcc5-720b-8ebe-c3ec160e536f"}
```

Prompt:

```text
Use the ls tool to list the workspace root. Then use the read tool to read README.md. Then use the bash tool to run exactly: pwd && printf "BASH_PROBE_DEFAULT\n". After all three tool results, give a short final summary and include the README heading and bash marker. Do not skip any tool call.
```

Persisted Pi transcript metadata and messages:

```jsonl
{"type":"model_change","provider":"openai-codex","modelId":"gpt-5.4-mini"}
{"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.4-mini","stopReason":"toolUse","content":[{"type":"toolCall","name":"ls","arguments":{"path":".","limit":200}},{"type":"toolCall","name":"read","arguments":{"path":"README.md"}},{"type":"toolCall","name":"bash","arguments":{"command":"pwd && printf \"BASH_PROBE_DEFAULT\\n\""}}]}}
{"type":"message","message":{"role":"toolResult","content":[{"type":"text","text":".boring-agent/\n.pi/\nanalysis.py\nconfig.json\ndata.csv\ndeck/\ngreeter.ts\npipeline.yaml\nREADME.md\nschema.sql\nstatus.csv\nutils.ts"}]}}
{"type":"message","message":{"role":"toolResult","content":[{"type":"text","text":"# Workspace Playground\n\nA minimal reference app that wires `@boring/workspace` end-to-end.\n\n## Features\n\n- File tree with fixture files\n- Code editor (CodeMirror 6) for `.ts`, `.json`, `.py`, `.sql`, `.yaml`\n- Markdown editor (TipTap) for `.md` files\n- Theme toggle (light / dark)\n- In-memory file system — edits are not persisted across reloads\n\n## Running\n\n```bash\npnpm --filter workspace-playground dev\n```\n"}]}}
{"type":"message","message":{"role":"toolResult","content":[{"type":"text","text":"/workspace\nBASH_PROBE_DEFAULT\n"}]}}
{"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.4-mini","stopReason":"stop","content":[{"type":"text","text":"DEFAULT_AGENT: Workspace root listed, README read, and bash probe ran successfully.\n\nREADME heading: `# Workspace Playground`\nbash marker: `BASH_PROBE_DEFAULT`"}]}}
```

The addressed state endpoint finished with `status: "idle"`, `seq: 49`, and no error.

## Real unscripted transcript: `researcher`

Addressed session:

```json
{"agentTypeId":"researcher","sessionId":"019fad89-8f68-749c-b042-405fd6dc74ed"}
```

Prompt:

```text
Use the ls tool to list the workspace root. Then use the read tool to read README.md. Then use the bash tool to run exactly: pwd && printf "BASH_PROBE_RESEARCHER\n". After all three tool results, give a short final summary and include the README heading and bash marker. Do not skip any tool call.
```

Persisted Pi transcript metadata and messages:

```jsonl
{"type":"model_change","provider":"openai-codex","modelId":"gpt-5.3-codex-spark"}
{"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.3-codex-spark","stopReason":"toolUse","content":[{"type":"toolCall","name":"ls","arguments":{"path":".","limit":500}}]}}
{"type":"message","message":{"role":"toolResult","content":[{"type":"text","text":".boring-agent/\n.pi/\nanalysis.py\nconfig.json\ndata.csv\ndeck/\ngreeter.ts\npipeline.yaml\nREADME.md\nschema.sql\nstatus.csv\nutils.ts"}]}}
{"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.3-codex-spark","stopReason":"toolUse","content":[{"type":"toolCall","name":"read","arguments":{"path":"README.md"}}]}}
{"type":"message","message":{"role":"toolResult","content":[{"type":"text","text":"# Workspace Playground\n\nA minimal reference app that wires `@boring/workspace` end-to-end.\n\n## Features\n\n- File tree with fixture files\n- Code editor (CodeMirror 6) for `.ts`, `.json`, `.py`, `.sql`, `.yaml`\n- Markdown editor (TipTap) for `.md` files\n- Theme toggle (light / dark)\n- In-memory file system — edits are not persisted across reloads\n\n## Running\n\n```bash\npnpm --filter workspace-playground dev\n```\n"}]}}
{"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.3-codex-spark","stopReason":"toolUse","content":[{"type":"toolCall","name":"bash","arguments":{"command":"pwd && printf \"BASH_PROBE_RESEARCHER\\n\""}}]}}
{"type":"message","message":{"role":"toolResult","content":[{"type":"text","text":"/workspace\nBASH_PROBE_RESEARCHER\n"}]}}
{"type":"message","message":{"role":"assistant","provider":"openai-codex","model":"gpt-5.3-codex-spark","stopReason":"stop","content":[{"type":"text","text":"RESEARCHER_AGENT: Completed all three steps.\n\n- `ls` result (workspace root): `.boring-agent/`, `.pi/`, `analysis.py`, `config.json`, `data.csv`, `deck/`, `greeter.ts`, `pipeline.yaml`, `README.md`, `schema.sql`, `status.csv`, `utils.ts`\n- `README.md` heading: `# Workspace Playground`\n- Bash output: `/workspace` and marker `BASH_PROBE_RESEARCHER`"}]}}
```

The addressed state endpoint finished with `status: "idle"`, `seq: 26`, and no error.

## Manual checks for dependent beads

- Bead .35 (Agents section): in this real-fleet boot, `GET /api/v1/agents` returned `[{"agentTypeId":"default","label":"Default"},{"agentTypeId":"researcher","label":"Researcher"}]`; the live left-navigation `Agents` section rendered visible `Default` and `Researcher` rows and their real session titles.
- Bead .34 (splits): from the live left-navigation action `Open Bead 38 OpenAI live parity researcher in split`, the UI rendered two connected chat panes side by side: default session `019fad88-dcc5-720b-8ebe-c3ec160e536f` at `{x:271,y:32,width:584,height:968}` and researcher session `019fad89-8f68-749c-b042-405fd6dc74ed` at `{x:855,y:32,width:584,height:968}`; both panes showed their own `DEFAULT_AGENT:` / `RESEARCHER_AGENT:` final response.

## Verification

```sh
pnpm --filter @hachej/boring-agent typecheck
# exit 0

pnpm --filter workspace-playground typecheck
# exit 0

pnpm lint:invariants
# exit 0; all agent, boring-bash, boring-sandbox, workspace-plugin, and alignment invariants passed

pnpm --filter @hachej/boring-agent exec vitest run src/server/agent-host/__tests__/createAgentHost.test.ts --no-file-parallelism
# 1 file passed; 4 tests passed; Type Errors: no errors

pnpm --filter workspace-playground exec vitest run src/server/__tests__/realAgentFleet.test.ts --no-file-parallelism
# 1 file passed; 2 tests passed
```

The full browser E2E suite was not run, per task instruction. After live verification, the Vite/API process was interrupted and both ports 5291 and 5292 were confirmed free; `ps` showed no remaining `workspace-playground`/Vite process for this boot.
