### PR TITLE
#909 test(agent): prove per-agent capability isolation

### DIFF
--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -65,7 +65,7 @@ test.describe("addressed Agent Host browser wire", () => {
     test.setTimeout(90_000)
 
     await page.goto("/?fresh=1")
-    await expect(page.locator('aside[aria-label="App navigation"]')).toBeVisible({ timeout: 10_000 })
+    await expect(page.locator('aside[aria-label="App navigation"]')).toBeVisible({ timeout: 20_000 })
     await expect(page.getByRole("combobox", { name: "Agent" })).toHaveCount(0)
 
     const agentsToggle = page.getByRole("button", { name: "Agents" })
@@ -145,9 +145,7 @@ test.describe("addressed Agent Host browser wire", () => {
     await expect(page.getByRole("button", { name: "New chat with Alpha", exact: true })).toBeVisible()
     await expect(page.getByRole("button", { name: "New chat with Beta", exact: true })).toBeVisible()
 
-    const startFirstChat = page.getByRole("button", { name: "Start new chat" })
-    await expect(startFirstChat).toBeVisible({ timeout: 15_000 })
-    await startFirstChat.click()
+    await page.getByRole("button", { name: "New chat with Alpha", exact: true }).click()
 
     const activeChatPane = page.locator('[data-boring-workspace-part="chat-pane"][data-boring-state="active"]')
     const chat = activeChatPane.locator('[data-boring-agent-part="chat"]')

--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -81,6 +81,8 @@ test.describe("addressed Agent Host browser wire", () => {
     const betaPrompt = `beta agent row ${Date.now()}`
     await sendFirstAddressedMessage(page, betaChat, "beta", betaPrompt)
     await expect(betaChat.getByText("PI_NATIVE_ASSISTANT_DONE:beta", { exact: true })).toBeVisible({ timeout: 30_000 })
+    await expect(betaChat.getByRole("button", { name: /beta_capability/ })).toBeVisible()
+    await expect(betaChat.getByRole("button", { name: /alpha_capability/ })).toHaveCount(0)
 
     const alphaPrimary = page.getByRole("button", { name: "New chat with Alpha", exact: true })
     await alphaPrimary.hover()
@@ -88,6 +90,11 @@ test.describe("addressed Agent Host browser wire", () => {
     const alphaChat = page.locator('[data-boring-agent-part="chat"][data-agent-type-id="alpha"]').last()
     await expect(alphaChat).toHaveAttribute("data-pi-chat-session-id", /^local-/, { timeout: 15_000 })
     await expectHorizontalSplit(betaChat, alphaChat)
+    const alphaPrompt = `alpha capability ${Date.now()}`
+    await sendFirstAddressedMessage(page, alphaChat, "alpha", alphaPrompt)
+    await expect(alphaChat.getByText("PI_NATIVE_ASSISTANT_DONE:alpha", { exact: true })).toBeVisible({ timeout: 30_000 })
+    await expect(alphaChat.getByRole("button", { name: /alpha_capability/ })).toBeVisible()
+    await expect(alphaChat.getByRole("button", { name: /beta_capability/ })).toHaveCount(0)
   })
 
   test("retains the golden operations across two agents and a mid-stream reload without legacy requests", async ({ page }) => {

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -4,7 +4,11 @@ import { readFile, readdir, stat } from "node:fs/promises"
 import { basename, dirname, isAbsolute, relative, resolve } from "node:path"
 import { createRemoteWorkerModeAdapter } from "@hachej/boring-agent/server"
 import { createPersistedScriptedPiHarness } from "./testing/scriptedPiHarness"
-import { SCRIPTED_TWO_AGENT_DEFAULT, SCRIPTED_TWO_AGENT_FLEET } from "./testing/twoAgentFleet"
+import {
+  SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS,
+  SCRIPTED_TWO_AGENT_DEFAULT,
+  SCRIPTED_TWO_AGENT_FLEET,
+} from "./testing/twoAgentFleet"
 import { createWorkspaceAgentServer } from "@hachej/boring-workspace/app/server"
 import { createTasksServerPlugin } from "@hachej/boring-tasks/server"
 
@@ -85,10 +89,15 @@ export async function startPlaygroundServer(): Promise<void> {
             defaultAgentTypeId: SCRIPTED_TWO_AGENT_DEFAULT,
           }
         : {}),
-      plugins: [createTasksServerPlugin({
-        workspaceRoot,
-        config: { providers: [{ provider: "github", repo: "auto" }] },
-      })],
+      plugins: [
+        createTasksServerPlugin({
+          workspaceRoot,
+          config: { providers: [{ provider: "github", repo: "auto" }] },
+        }),
+        ...(process.env.BORING_AGENT_E2E_SCRIPTED_PI === "1"
+          ? SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS
+          : []),
+      ],
       defaultPluginPackages: ["@hachej/boring-ask-user", "@hachej/boring-diagram"],
       runtimeProvisioner: multiFilesystemPlayground
         ? async ({ runtimeBundle }) => {

--- a/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
+++ b/apps/workspace-playground/src/server/testing/scriptedPiHarness.ts
@@ -5,19 +5,10 @@ import { homedir } from 'node:os'
 import { setTimeout as sleep } from 'node:timers/promises'
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent'
 import { CURRENT_SESSION_VERSION } from '@mariozechner/pi-coding-agent'
-import type { AgentHarness, RunContext, AgentSendInput } from '@hachej/boring-agent/shared'
+import type { AgentCoreHarnessFactory, AgentHarness, RunContext, AgentSendInput } from '@hachej/boring-agent/shared'
 import type { SessionCtx, SessionDetail, SessionStore, SessionSummary } from '@hachej/boring-agent/shared'
 
-interface AgentHarnessFactoryInput {
-  cwd: string
-  runtimeCwd?: string
-  systemPromptAppend?: string
-  sessionNamespace?: string
-  sessionRoot?: string
-  sessionDir?: string
-}
-
-
+type AgentHarnessFactoryInput = Parameters<AgentCoreHarnessFactory>[0]
 
 type ScriptedMessage = Record<string, unknown>
 
@@ -98,6 +89,7 @@ export function createScriptedPiHarness(input: AgentHarnessFactoryInput): Script
   const toolDelayTicks = readToolDelayTicks()
   const reasoningPartCount = readReasoningPartCount()
   const responseMarker = scriptedResponseMarker(input.sessionNamespace)
+  const capabilityToolName = input.tools.find((tool) => tool.name.endsWith('_capability'))?.name
 
   const getAdapter = (sessionId: string): ScriptedPiSessionAdapter => {
     let adapter = adapters.get(sessionId)
@@ -108,6 +100,7 @@ export function createScriptedPiHarness(input: AgentHarnessFactoryInput): Script
         toolDelayTicks,
         reasoningPartCount,
         responseMarker,
+        capabilityToolName,
         (message) => sessions.appendMessage(sessionId, message),
       )
       adapters.set(sessionId, adapter)
@@ -261,6 +254,7 @@ class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {
     private readonly toolDelayTicks: number,
     private readonly reasoningPartCount: number,
     private readonly responseMarker: string,
+    private readonly capabilityToolName: string | undefined,
     private readonly appendMessage: (message: ScriptedMessage) => void,
   ) {}
 
@@ -405,7 +399,7 @@ class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {
     const toolPart = {
       type: 'toolCall',
       id: toolCallId,
-      name: 'grep',
+      name: this.capabilityToolName ?? 'grep',
       arguments: { pattern: 'baseline' },
       state: 'input-available',
     }
@@ -419,7 +413,7 @@ class ScriptedPiSessionAdapter implements PiAgentSessionAdapter {
         partial: { id: assistantId },
         toolCall: {
           id: toolCallId,
-          name: 'grep',
+          name: this.capabilityToolName ?? 'grep',
           arguments: { pattern: 'baseline' },
         },
       },

--- a/apps/workspace-playground/src/server/testing/twoAgentFleet.test.ts
+++ b/apps/workspace-playground/src/server/testing/twoAgentFleet.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import {
+  SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS,
+  SCRIPTED_TWO_AGENT_FLEET,
+} from "./twoAgentFleet"
+
+describe("SCRIPTED_TWO_AGENT_FLEET", () => {
+  it("gives Alpha and Beta divergent models and capability plugins", () => {
+    const [alpha, beta] = SCRIPTED_TWO_AGENT_FLEET
+    expect(alpha.model.preferred).not.toBe(beta.model.preferred)
+    expect(alpha.plugins).toEqual([{ name: "scripted-alpha-capability" }])
+    expect(beta.plugins).toEqual([{ name: "scripted-beta-capability" }])
+
+    const toolNamesByPlugin = Object.fromEntries(
+      SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS.map((plugin) => [
+        plugin.id,
+        plugin.agentTools.map((tool) => tool.name),
+      ]),
+    )
+    expect(toolNamesByPlugin["scripted-alpha-capability"]).toEqual(["alpha_capability"])
+    expect(toolNamesByPlugin["scripted-beta-capability"]).toEqual(["beta_capability"])
+  })
+})

--- a/apps/workspace-playground/src/server/testing/twoAgentFleet.ts
+++ b/apps/workspace-playground/src/server/testing/twoAgentFleet.ts
@@ -1,5 +1,29 @@
 import type { AgentHostAgentSpec } from "@hachej/boring-agent/server"
 
+function capabilityTool(name: string) {
+  return {
+    name,
+    description: `${name} is available only to its scripted playground agent.`,
+    parameters: { type: "object", properties: {} },
+    async execute() {
+      return { content: [{ type: "text" as const, text: name }] }
+    },
+  }
+}
+
+export const SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS = [
+  {
+    id: "scripted-alpha-capability",
+    contentDigest: "scripted-alpha-capability-v1",
+    agentTools: [capabilityTool("alpha_capability")],
+  },
+  {
+    id: "scripted-beta-capability",
+    contentDigest: "scripted-beta-capability-v1",
+    agentTools: [capabilityTool("beta_capability")],
+  },
+]
+
 export const SCRIPTED_TWO_AGENT_FLEET = [
   {
     agentTypeId: "alpha",
@@ -7,6 +31,8 @@ export const SCRIPTED_TWO_AGENT_FLEET = [
       label: "Alpha",
       instructions: "You are the Alpha scripted workspace-playground agent.",
     },
+    model: { preferred: "scripted:alpha-model" },
+    plugins: [{ name: "scripted-alpha-capability" }],
   },
   {
     agentTypeId: "beta",
@@ -14,6 +40,8 @@ export const SCRIPTED_TWO_AGENT_FLEET = [
       label: "Beta",
       instructions: "You are the Beta scripted workspace-playground agent.",
     },
+    model: { preferred: "scripted:beta-model" },
+    plugins: [{ name: "scripted-beta-capability" }],
   },
 ] as const satisfies readonly AgentHostAgentSpec[]
 

--- a/packages/agent/src/server/agent-host/__tests__/acceptanceIntegration.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/acceptanceIntegration.test.ts
@@ -53,6 +53,17 @@ function actorTool(subject: string, root: string): AgentTool {
   }
 }
 
+function capabilityTool(name: string): AgentTool {
+  return {
+    name,
+    description: `${name} capability probe`,
+    parameters: { type: 'object', properties: {} },
+    async execute() {
+      return { content: [{ type: 'text', text: name }] }
+    },
+  }
+}
+
 describe('createAgentHost AH0 acceptance integration', () => {
   it('partitions the full workspace/agent/storage/subject matrix while sharing compatible Environments', async () => {
     const sessionRoot = await temporaryRoot('agent-host-acceptance-sessions-')
@@ -175,6 +186,102 @@ describe('createAgentHost AH0 acceptance integration', () => {
     expect(create).toHaveBeenCalledTimes(4)
     await host.host.close()
   }, 30_000)
+
+  it('composes each agent session with only its resolved capability tools', async () => {
+    const sessionRoot = await temporaryRoot('agent-host-tool-isolation-sessions-')
+    const workspaceRoot = await temporaryRoot('agent-host-tool-isolation-workspace-')
+    const scope = { workspaceScopeId: 'workspace', authSubjectId: 'subject' } as AuthorizedAgentScope
+    const captures: CapturedHarness[] = []
+    const host = await createAgentHost({
+      agents: [
+        { agentTypeId: 'alpha', definition: { label: 'Alpha', instructions: 'alpha' } },
+        { agentTypeId: 'beta', definition: { label: 'Beta', instructions: 'beta' } },
+      ],
+      fleetCompiler: { async compile({ agents }) { return agents } },
+      hostId: 'tool-isolation-host',
+      scopeVerifier: { async verify() { return { workspaceScopeId: 'workspace', authSubjectId: 'subject' } } },
+      runtimeModeAdapter: createTestRuntimeModeAdapter('direct'),
+      sessionRoot,
+      harnessFactory: persistedScriptedHarness(captures),
+      async resolveRuntimeScope({ agentTypeId }) {
+        return {
+          identity: agentTypeId,
+          environment: {
+            placementIdentity: 'shared-placement',
+            workspaceRoot,
+            provisioningFingerprint: 'generation-one',
+          },
+          sessionNamespace: 'acceptance',
+          extraTools: [capabilityTool(`${agentTypeId}_capability`)],
+        }
+      },
+    })
+
+    await host.gateway.createSession({ scope, agentTypeId: 'alpha', requestId: 'alpha' })
+    await host.gateway.createSession({ scope, agentTypeId: 'beta', requestId: 'beta' })
+
+    const capabilityNames = (capture: CapturedHarness) => capture.input.tools
+      .map((tool) => tool.name)
+      .filter((name) => name.endsWith('_capability'))
+    const alpha = captures.find((capture) => capture.input.systemPromptAppend === 'alpha')
+    const beta = captures.find((capture) => capture.input.systemPromptAppend === 'beta')
+    expect(alpha && capabilityNames(alpha)).toEqual(['alpha_capability'])
+    expect(beta && capabilityNames(beta)).toEqual(['beta_capability'])
+    expect(alpha && capabilityNames(alpha)).not.toContain('beta_capability')
+    expect(beta && capabilityNames(beta)).not.toContain('alpha_capability')
+    await host.host.close()
+  })
+
+  it('runs two agents in one workspace on distinct placement Environment bundles', async () => {
+    const sessionRoot = await temporaryRoot('agent-host-placement-isolation-sessions-')
+    const workspaceRoots = {
+      alpha: await temporaryRoot('agent-host-placement-alpha-'),
+      beta: await temporaryRoot('agent-host-placement-beta-'),
+    }
+    const scope = { workspaceScopeId: 'workspace', authSubjectId: 'subject' } as AuthorizedAgentScope
+    const captures: CapturedHarness[] = []
+    const bundles: object[] = []
+    const baseAdapter = createTestRuntimeModeAdapter('direct')
+    const create = vi.fn(async (input: Parameters<typeof baseAdapter.create>[0]) => {
+      const bundle = await baseAdapter.create(input)
+      bundles.push(bundle)
+      return bundle
+    })
+    const host = await createAgentHost({
+      agents: [
+        { agentTypeId: 'alpha', definition: { label: 'Alpha', instructions: 'alpha' } },
+        { agentTypeId: 'beta', definition: { label: 'Beta', instructions: 'beta' } },
+      ],
+      fleetCompiler: { async compile({ agents }) { return agents } },
+      hostId: 'placement-isolation-host',
+      scopeVerifier: { async verify() { return { workspaceScopeId: 'workspace', authSubjectId: 'subject' } } },
+      runtimeModeAdapter: { ...baseAdapter, create },
+      sessionRoot,
+      harnessFactory: persistedScriptedHarness(captures),
+      async resolveRuntimeScope({ agentTypeId }) {
+        const placement = agentTypeId as keyof typeof workspaceRoots
+        return {
+          identity: agentTypeId,
+          environment: {
+            placementIdentity: `${placement}-placement`,
+            workspaceRoot: workspaceRoots[placement],
+            provisioningFingerprint: 'generation-one',
+          },
+          sessionNamespace: 'acceptance',
+        }
+      },
+    })
+
+    await expect(host.gateway.createSession({ scope, agentTypeId: 'alpha', requestId: 'alpha' }))
+      .resolves.toMatchObject({ agentTypeId: 'alpha' })
+    await expect(host.gateway.createSession({ scope, agentTypeId: 'beta', requestId: 'beta' }))
+      .resolves.toMatchObject({ agentTypeId: 'beta' })
+    expect(create).toHaveBeenCalledTimes(2)
+    expect(bundles).toHaveLength(2)
+    expect(bundles[0]).not.toBe(bundles[1])
+    expect(captures.map((capture) => capture.input.cwd).sort()).toEqual(Object.values(workspaceRoots).sort())
+    await host.host.close()
+  })
 
   it('rejects an incompatible shared identity before provider/provisioning/transcript mutation', async () => {
     const sessionRoot = await temporaryRoot('agent-host-incompatible-sessions-')


### PR DESCRIPTION
## What changed

- prove Alpha and Beta compose only their own runtime-scope `extraTools`
- prove two agents in one workspace can resolve distinct placement identities and receive distinct Environment bundles
- make the scripted playground fleet capability-divergent with different preferred models and per-agent capability plugins
- make the scripted harness surface the composed capability tool and assert Alpha/Beta isolation in the addressed-agent browser spec

## Why

The per-agent tool, environment, and model machinery existed, but the positive isolation paths were not exercised. The scripted two-agent demo also presented capability-identical agents.

## Proof of work

Automated verification:

- `pnpm typecheck` ✅ (31 workspace projects)
- `pnpm lint:invariants` ✅
- `pnpm --filter @hachej/boring-agent exec vitest run src/server/agent-host/__tests__/acceptanceIntegration.test.ts --no-file-parallelism` ✅ (5 tests)
- `pnpm --filter workspace-playground exec vitest run src/server/testing/twoAgentFleet.test.ts --no-file-parallelism` ✅ (1 test)

Falsification proof:

- scratch-leaked `beta_capability` into Alpha's resolved `extraTools`
- the focused isolation test failed with received `['alpha_capability', 'beta_capability']` vs expected `['alpha_capability']`
- restored the source and reran the same focused test: ✅ 1 passed, 4 skipped

Browser E2E:

- spec updated in `apps/workspace-playground/e2e/agent-host-golden-route.spec.ts`
- intentionally not executed locally per bead instructions; CI owns Playwright execution

## Risk / rollback

Test/fixture-only change. Revert commit `04870acbe` to roll back. No production fleet behavior changes outside the scripted playground mode.
