### PR TITLE
#909 feat(console): agent label in top bar + original new-chat control per agent

### DIFF
--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -75,9 +75,17 @@ test.describe("addressed Agent Host browser wire", () => {
     await expect(page.getByRole("listitem", { name: "Alpha" })).toBeVisible()
     await expect(page.getByRole("listitem", { name: "Beta" })).toBeVisible()
 
-    await page.getByRole("button", { name: "New chat with Beta", exact: true }).click()
+    const betaPrimary = page.getByRole("button", { name: "New chat with Beta", exact: true })
+    const betaSplit = page.getByRole("button", { name: "New chat with Beta in split" })
+    const betaQuick = page.getByRole("button", { name: "Quick chat with Beta" })
+    await expect(betaPrimary.locator("svg.lucide-plus")).toBeVisible()
+    await betaPrimary.hover()
+    await expect(betaSplit.locator("svg.lucide-columns-2")).toBeVisible()
+    await expect(betaQuick.locator("svg.lucide-zap")).toBeVisible()
+    await betaPrimary.click()
     const betaChat = page.locator('[data-boring-agent-part="chat"][data-agent-type-id="beta"]').last()
     await expect(betaChat).toHaveAttribute("data-pi-chat-session-id", /^local-/, { timeout: 15_000 })
+    await expect(page.getByLabel(/^Chat session Beta · /)).toBeVisible()
     const betaPrompt = `beta agent row ${Date.now()}`
     await sendFirstAddressedMessage(page, betaChat, "beta", betaPrompt)
     await expect(betaChat.getByText("PI_NATIVE_ASSISTANT_DONE:beta", { exact: true })).toBeVisible({ timeout: 30_000 })
@@ -89,6 +97,7 @@ test.describe("addressed Agent Host browser wire", () => {
     await page.getByRole("button", { name: "New chat with Alpha in split" }).click()
     const alphaChat = page.locator('[data-boring-agent-part="chat"][data-agent-type-id="alpha"]').last()
     await expect(alphaChat).toHaveAttribute("data-pi-chat-session-id", /^local-/, { timeout: 15_000 })
+    await expect(page.getByLabel(/^Chat session Alpha · /)).toBeVisible()
     await expectHorizontalSplit(betaChat, alphaChat)
     const alphaPrompt = `alpha capability ${Date.now()}`
     await sendFirstAddressedMessage(page, alphaChat, "alpha", alphaPrompt)
@@ -375,10 +384,16 @@ test.describe("addressed Agent Host browser wire", () => {
     await expect(page.getByRole("combobox", { name: "Agent" })).toHaveCount(0)
     await page.getByRole("button", { name: "Agents" }).click()
 
-    const ensureAddressedChat = async (agentTypeId: string) => {
+    const ensureAddressedChat = async (agentTypeId: string, split = false) => {
       const chat = page.locator(`[data-boring-agent-part="chat"][data-agent-type-id="${agentTypeId}"]`).last()
       const label = agentTypeId === "alpha" ? "Alpha" : "Beta"
-      await page.getByRole("button", { name: `New chat with ${label}`, exact: true }).click()
+      const primary = page.getByRole("button", { name: `New chat with ${label}`, exact: true })
+      if (split) {
+        await primary.hover()
+        await page.getByRole("button", { name: `New chat with ${label} in split` }).click()
+      } else {
+        await primary.click()
+      }
       await expect(chat).toHaveAttribute("data-pi-chat-session-id", /^local-/, { timeout: 15_000 })
       await expect(chat).toHaveAttribute("data-pi-chat-connection", "disconnected")
       return chat
@@ -390,7 +405,7 @@ test.describe("addressed Agent Host browser wire", () => {
     await expect(alphaChat.getByTestId("chat-working")).toBeVisible({ timeout: 10_000 })
     await expect(page.getByLabel("Alpha streaming")).toBeVisible()
 
-    const betaChat = await ensureAddressedChat("beta")
+    const betaChat = await ensureAddressedChat("beta", true)
     const betaPrompt = `beta concurrent ${Date.now()}`
     const betaSessionId = await sendFirstAddressedMessage(page, betaChat, "beta", betaPrompt)
     await expect(betaChat.getByTestId("chat-working")).toBeVisible({ timeout: 10_000 })
@@ -508,9 +523,12 @@ test.describe("addressed Agent Host browser wire", () => {
     await page.goto("/?fresh=1")
     await expect(page.getByRole("combobox", { name: "Agent" })).toHaveCount(0)
     await expect(page.getByRole("button", { name: "Agents" })).toHaveCount(0)
-    await page.getByRole("button", { name: "New chat with Alpha", exact: true }).click()
+    const alphaPrimary = page.getByRole("button", { name: "New chat with Alpha", exact: true })
+    await expect(alphaPrimary.locator("svg.lucide-plus")).toBeVisible()
+    await alphaPrimary.click()
     const chat = page.locator('[data-boring-agent-part="chat"][data-agent-type-id="alpha"]').last()
     await expect(chat).toHaveAttribute("data-pi-chat-session-id", /^local-/, { timeout: 15_000 })
+    await expect(page.locator('[data-boring-workspace-part="chat-pane"][data-boring-state="active"]')).not.toHaveAttribute("aria-label", /Alpha ·/)
     const completion = chat.getByLabel("Agent conversation")
       .getByText("PI_NATIVE_ASSISTANT_DONE:alpha", { exact: true })
     const completionCountBefore = await completion.count()

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -639,6 +639,7 @@ export function WorkspaceAgentFront<
       flashChatPane,
       pinnedIds,
       sessionTitleById,
+      sessionAgentLabelById,
       emptySessionIds,
       delayAutoSubmitDraft,
       hydrateMessages,
@@ -1066,11 +1067,12 @@ export function WorkspaceAgentFront<
       return {
         id,
         title: sessionTitleById.get(id) ?? (sessionRef.sessionId === "default" ? defaultSessionTitle : sessionRef.sessionId),
+        agentLabel: sessionAgentLabelById.get(id),
         panel: "chat",
         params,
       }
     })
-  }, [chatPaneIds, defaultSessionTitle, displayedActiveChatPaneId, makeCenterParams, sessionTitleById])
+  }, [chatPaneIds, defaultSessionTitle, displayedActiveChatPaneId, makeCenterParams, sessionAgentLabelById, sessionTitleById])
   const providerChatPaneSessionRefs = useMemo(
     () => chatPaneIds.map(workspaceSessionRefFromKey),
     [chatPaneIds],
@@ -1182,26 +1184,39 @@ export function WorkspaceAgentFront<
     surfaceDispatch,
     onDockOverlay: () => setLeftOverlay(null),
   })
-  const createChatSessionInPopover = useCallback(() => {
+  const createChatSessionInPopover = useCallback((targetAgentTypeId?: string) => {
     setLeftOverlay(null)
-    const previousActiveId = effectiveActiveSessionId ?? activeChatPaneId
-    const created = resolvedCreate()
+    const previousActiveRef = displayedActiveChatPaneId
+      ? workspaceSessionRefFromKey(displayedActiveChatPaneId)
+      : effectiveActiveSessionId
+        ? workspaceSessionRef(effectiveActiveSessionId, effectiveActiveSessionAgentTypeId ?? undefined)
+        : null
+    const created = resolvedCreate(targetAgentTypeId)
     void Promise.resolve(created).then((session) => {
       const id = createdSessionId(session)
       if (!id) return
+      const createdAgentTypeId = typeof (session as { agentTypeId?: unknown } | null)?.agentTypeId === "string"
+        ? (session as { agentTypeId: string }).agentTypeId
+        : targetAgentTypeId ?? agentTypeId
       shellCapabilitiesHost.shellCapabilities.openDetachedChat(id, {
+        ...(createdAgentTypeId ? { agentTypeId: createdAgentTypeId } : {}),
         title: defaultSessionTitle,
         composingEnabled: true,
       })
       // Quick chat is an auxiliary popover: creating it must not steal the
       // selected/full chat from the main stage or left session list.
-      if (previousActiveId && previousActiveId !== id) rawSwitch(previousActiveId)
+      if (
+        previousActiveRef
+        && (previousActiveRef.sessionId !== id || previousActiveRef.agentTypeId !== createdAgentTypeId)
+      ) {
+        rawSwitch(previousActiveRef.sessionId, previousActiveRef.agentTypeId)
+      }
     }).catch(() => {
       // Creation errors are surfaced by the session API/chat layer; the menu
       // should not leave a stale detached chat behind.
     })
     return created
-  }, [activeChatPaneId, defaultSessionTitle, effectiveActiveSessionId, rawSwitch, resolvedCreate, shellCapabilitiesHost.shellCapabilities])
+  }, [agentTypeId, defaultSessionTitle, displayedActiveChatPaneId, effectiveActiveSessionAgentTypeId, effectiveActiveSessionId, rawSwitch, resolvedCreate, shellCapabilitiesHost.shellCapabilities])
   const providerPanels = baseProviderPanels
   const pluginAppLeftActions = usePluginAppLeftActions({ plugins: capturedPlugins, activeOverlay: leftOverlay, setActiveOverlay: setLeftOverlay })
   const chatTopOverlayActions = useMemo(() => {

--- a/packages/workspace/src/app/front/WorkspaceShellCapabilitiesHost.tsx
+++ b/packages/workspace/src/app/front/WorkspaceShellCapabilitiesHost.tsx
@@ -5,6 +5,7 @@ import type { DispatchContext } from "../../front/bridge"
 import { DetachedChatPopover } from "../../front/chrome/chat/DetachedChatPopover"
 import type { ChatPanelHostProps } from "../../front/chrome/chat/ChatPanelHost"
 import type { WorkspaceShellCapabilities } from "../../front/shell/WorkspaceShellCapabilitiesContext"
+import { workspaceSessionKey } from "../../front/sessionIdentity"
 import { useWorkspaceShellCapabilitiesController } from "./useWorkspaceShellCapabilitiesController"
 
 export interface WorkspaceShellCapabilitiesHostResult {
@@ -30,12 +31,12 @@ export function useWorkspaceShellCapabilitiesHost({
   sessionTitleById: Map<string, string | null | undefined>
   defaultSessionTitle: string
   makeCenterParams: (sessionId: string, options?: { bridgeEnabled?: boolean }) => unknown
-  openChatPane: (sessionId: string) => void
+  openChatPane: (sessionId: string, agentTypeId?: string) => void
   refreshChatSessions: () => Promise<void>
   surfaceDispatch: DispatchContext
   onDockOverlay?: () => void
 }): WorkspaceShellCapabilitiesHostResult {
-  const [floatingChatSession, setFloatingChatSession] = useState<{ sessionId: string; title?: string; initialDraft?: string; composingEnabled?: boolean } | null>(null)
+  const [floatingChatSession, setFloatingChatSession] = useState<{ sessionId: string; agentTypeId?: string; title?: string; initialDraft?: string; composingEnabled?: boolean } | null>(null)
   useEffect(() => {
     setFloatingChatSession(null)
   }, [workspaceId])
@@ -43,9 +44,10 @@ export function useWorkspaceShellCapabilitiesHost({
 
   useEffect(() => {
     const onOpenDetachedChat = (event: Event) => {
-      const detail = (event as CustomEvent<unknown>).detail as { sessionId?: unknown; title?: unknown; initialDraft?: unknown; composingEnabled?: unknown } | undefined
+      const detail = (event as CustomEvent<unknown>).detail as { sessionId?: unknown; agentTypeId?: unknown; title?: unknown; initialDraft?: unknown; composingEnabled?: unknown } | undefined
       if (!detail || typeof detail.sessionId !== "string") return
       shellCapabilities.openDetachedChat(detail.sessionId, {
+        ...(typeof detail.agentTypeId === "string" ? { agentTypeId: detail.agentTypeId } : {}),
         ...(typeof detail.title === "string" ? { title: detail.title } : {}),
         ...(typeof detail.initialDraft === "string" ? { initialDraft: detail.initialDraft } : {}),
         ...(typeof detail.composingEnabled === "boolean" ? { composingEnabled: detail.composingEnabled } : {}),
@@ -56,18 +58,23 @@ export function useWorkspaceShellCapabilitiesHost({
   }, [shellCapabilities])
 
   const floatingChatSessionId = floatingChatSession?.sessionId ?? null
-  const floatingChatTitle = floatingChatSessionId
-    ? floatingChatSession?.title ?? sessionTitleById.get(floatingChatSessionId) ?? (floatingChatSessionId === "default" ? defaultSessionTitle : floatingChatSessionId)
+  const floatingChatAgentTypeId = floatingChatSession?.agentTypeId
+  const floatingChatSessionKey = floatingChatSessionId
+    ? workspaceSessionKey(floatingChatSessionId, floatingChatAgentTypeId)
     : null
-  const floatingChatParams = floatingChatSessionId
+  const floatingChatTitle = floatingChatSessionId && floatingChatSessionKey
+    ? floatingChatSession?.title ?? sessionTitleById.get(floatingChatSessionKey) ?? (floatingChatSessionId === "default" ? defaultSessionTitle : floatingChatSessionId)
+    : null
+  const floatingChatParams = floatingChatSessionKey
     ? {
-        ...makeCenterParams(floatingChatSessionId, { bridgeEnabled: false }) as ChatPanelHostProps,
+        ...makeCenterParams(floatingChatSessionKey, { bridgeEnabled: false }) as ChatPanelHostProps,
         ...(floatingChatSession?.initialDraft !== undefined ? { initialDraft: floatingChatSession.initialDraft } : {}),
       }
     : null
-  const floatingChatNode = floatingChatSessionId && floatingChatParams ? (
+  const floatingChatNode = floatingChatSessionId && floatingChatSessionKey && floatingChatParams ? (
     <DetachedChatPopover
-      key={floatingChatSessionId}
+      key={floatingChatSessionKey}
+      instanceKey={floatingChatSessionKey}
       sessionId={floatingChatSessionId}
       title={floatingChatTitle ?? floatingChatSessionId}
       chatParams={floatingChatParams}
@@ -75,7 +82,7 @@ export function useWorkspaceShellCapabilitiesHost({
       composingEnabled={floatingChatSession?.composingEnabled ?? false}
       onClose={() => setFloatingChatSession(null)}
       onDock={() => {
-        openChatPane(floatingChatSessionId)
+        openChatPane(floatingChatSessionId, floatingChatAgentTypeId)
         setFloatingChatSession(null)
         onDockOverlay?.()
       }}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -588,11 +588,13 @@ describe("WorkspaceAgentFront", () => {
     )
 
     await waitFor(() => expect(screen.getByTestId("agent-chat-alpha-a1")).toBeInTheDocument())
+    expect(screen.getByLabelText("Chat session Alpha · Alpha one")).toBeInTheDocument()
     await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Alpha two" }))
     await waitFor(() => expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument())
 
     await user.click(screen.getByText("Beta one"))
     await waitFor(() => expect(screen.getByTestId("agent-chat-beta-b1")).toBeInTheDocument())
+    expect(screen.getByLabelText("Chat session Beta · Beta one")).toBeInTheDocument()
     expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument()
     expect(unmounted).not.toContain("alpha/a2")
 
@@ -614,11 +616,11 @@ describe("WorkspaceAgentFront", () => {
     })
 
     await user.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "Alpha two" }))
-    await user.click(screen.getByRole("button", { name: "Split Beta one chat vertically" }))
+    await user.click(screen.getByRole("button", { name: "Split Beta · Beta one chat vertically" }))
     expect(createdForAgents).toEqual(["beta"])
   })
 
-  it("shows an authoritative empty agent without a synthetic wire and inserts its first pane without replacing another owner", async () => {
+  it("shows an authoritative empty agent without a synthetic wire and replaces the active pane from its primary action", async () => {
     const user = userEvent.setup()
     function useTestAgentSelection() {
       const [selectedAgentTypeId, selectAgentTypeId] = useState("alpha")
@@ -695,8 +697,88 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => {
       expect(screen.getByRole("textbox", { name: "Composer beta/beta-first" })).toBeVisible()
     })
-    expect(alphaComposer).toBeInTheDocument()
-    expect(unmountedWires).not.toContain("alpha/alpha-session")
+    await waitFor(() => expect(alphaComposer).not.toBeInTheDocument())
+    expect(unmountedWires).toContain("alpha/alpha-session")
+    expect(screen.getByLabelText("Chat session Beta · Beta first")).toBeInTheDocument()
+  })
+
+  it("creates a quick chat with the selected row's agent without replacing the active pane", async () => {
+    const user = userEvent.setup()
+    const createdForAgents: string[] = []
+    function useTestAgentSelection() {
+      const [selectedAgentTypeId, selectAgentTypeId] = useState("alpha")
+      return {
+        agents: [
+          { agentTypeId: "alpha", label: "Alpha" },
+          { agentTypeId: "beta", label: "Beta" },
+        ],
+        selectedAgentTypeId,
+        loading: false,
+        error: undefined,
+        selectAgentTypeId,
+      }
+    }
+    const useSessions: UseWorkspaceAgentSessions = (options) => {
+      const owner = options.agentTypeId ?? "legacy"
+      const session = { id: "shared", agentTypeId: owner, title: `${owner} session` }
+      return {
+        sessions: [session],
+        sourceAgentTypeId: owner,
+        loading: false,
+        activeSessionId: session.id,
+        activeSessionAgentTypeId: owner,
+        activeSession: session,
+        workspaceId: options.workspaceId,
+        switch: vi.fn(),
+        create: () => {
+          createdForAgents.push(owner)
+          return Promise.resolve({
+            id: "quick-shared",
+            agentTypeId: owner,
+            title: `${owner} quick`,
+          })
+        },
+        delete: vi.fn(),
+      }
+    }
+    function QuickChatPanel(props: WorkspaceChatPanelProps) {
+      const [mountedOwner] = useState(props.agentTypeId)
+      return (
+        <div data-testid={`quick-chat-${props.agentTypeId}-${props.sessionId}`}>
+          mounted:{mountedOwner};current:{props.agentTypeId};session:{props.sessionId}
+        </div>
+      )
+    }
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="addressed-quick-chat"
+        workspaceLayout="plugin-tabs"
+        chatPanel={QuickChatPanel}
+        useSessions={useSessions}
+        addressedAgentSelection
+        useAddressedAgentSelection={useTestAgentSelection}
+        persistenceEnabled={false}
+      />,
+    )
+
+    const alphaPane = await screen.findByTestId("quick-chat-alpha-shared")
+    expect(alphaPane.closest('[data-boring-workspace-part="chat-pane"]')).toHaveAttribute("data-boring-state", "active")
+    await user.click(screen.getByRole("button", { name: "Agents" }))
+    await user.click(screen.getByRole("button", { name: "Quick chat with Alpha" }))
+    expect(await screen.findByTestId("quick-chat-alpha-quick-shared")).toHaveTextContent(
+      "mounted:alpha;current:alpha;session:quick-shared",
+    )
+    await user.click(screen.getByRole("button", { name: "Quick chat with Beta" }))
+
+    expect(await screen.findByTestId("quick-chat-beta-quick-shared")).toHaveTextContent(
+      "mounted:beta;current:beta;session:quick-shared",
+    )
+    expect(screen.queryByText("mounted:alpha;current:beta;session:quick-shared")).not.toBeInTheDocument()
+    expect(alphaPane).toBeInTheDocument()
+    expect(alphaPane.closest('[data-boring-workspace-part="chat-pane"]')).toHaveAttribute("data-boring-state", "active")
+    expect(createdForAgents).toEqual(["alpha", "beta"])
+    expect(screen.getByLabelText("Chat session Alpha · alpha session")).toBeInTheDocument()
   })
 
   it("does not mount a synthetic wire while the initially selected addressed agent resolves empty", async () => {
@@ -1074,7 +1156,7 @@ describe("WorkspaceAgentFront", () => {
     })
     const betaSwitchCount = betaSwitch.mock.calls.length
 
-    await user.click(screen.getByLabelText("Close Beta shared pane"))
+    await user.click(screen.getByLabelText("Close Beta · Beta shared pane"))
 
     await waitFor(() => {
       expect(alphaSwitch).toHaveBeenCalledWith("shared")

--- a/packages/workspace/src/app/front/useWorkspaceAgentChatPanes.ts
+++ b/packages/workspace/src/app/front/useWorkspaceAgentChatPanes.ts
@@ -524,6 +524,17 @@ export function useWorkspaceAgentChatPanes<
   const displayedActiveChatPaneId = selectedAgentIsEmpty || awaitingInitialAddressedSessions
     ? null
     : activeChatPaneId
+  const sessionAgentLabelById = useMemo(() => {
+    const labels = new Map<string, string>()
+    if (!multiAgentConsoleEnabled || agents.length <= 1) return labels
+    const labelByAgentTypeId = new Map(agents.map((agent) => [agent.agentTypeId, agent.label]))
+    for (const id of chatPaneIds) {
+      const owner = workspaceSessionRefFromKey(id).agentTypeId
+      const label = owner ? labelByAgentTypeId.get(owner) : undefined
+      if (label) labels.set(id, label)
+    }
+    return labels
+  }, [agents, chatPaneIds, multiAgentConsoleEnabled])
 
   const switchToChatPane = useCallback((nextSessionId: string, nextAgentTypeId?: string) => {
     onPaneFocus()
@@ -656,10 +667,7 @@ export function useWorkspaceAgentChatPanes<
         const activeId = current.activeId && ids.includes(current.activeId)
           ? current.activeId
           : ids[0] ?? chatSessionKey
-        const activeAgentTypeId = workspaceSessionRefFromKey(activeId).agentTypeId
-        const nextIds = multiAgentConsoleEnabled && activeAgentTypeId !== createdAgentTypeId
-          ? insertPaneAfter(ids, activeId, createdKey)
-          : replaceActivePane(ids, activeId, createdKey)
+        const nextIds = replaceActivePane(ids, activeId, createdKey)
         return { workspaceId, ids: nextIds, activeId: createdKey }
       })
       if (multiAgentConsoleEnabled && createdAgentTypeId) {
@@ -796,6 +804,7 @@ export function useWorkspaceAgentChatPanes<
     flashChatPane,
     pinnedIds,
     sessionTitleById,
+    sessionAgentLabelById,
     emptySessionIds,
     delayAutoSubmitDraft,
     hydrateMessages,

--- a/packages/workspace/src/app/front/useWorkspaceShellCapabilitiesController.ts
+++ b/packages/workspace/src/app/front/useWorkspaceShellCapabilitiesController.ts
@@ -15,8 +15,8 @@ export function useWorkspaceShellCapabilitiesController({
   refreshChatSessions,
   surfaceDispatch,
 }: {
-  setFloatingChatSession: Dispatch<SetStateAction<{ sessionId: string; title?: string; initialDraft?: string; composingEnabled?: boolean } | null>>
-  openChatPane: (sessionId: string) => void
+  setFloatingChatSession: Dispatch<SetStateAction<{ sessionId: string; agentTypeId?: string; title?: string; initialDraft?: string; composingEnabled?: boolean } | null>>
+  openChatPane: (sessionId: string, agentTypeId?: string) => void
   refreshChatSessions: () => Promise<void>
   surfaceDispatch: DispatchContext
 }): WorkspaceShellCapabilities {
@@ -54,6 +54,7 @@ export function useWorkspaceShellCapabilitiesController({
       if (!sessionId) return { success: false, reason: "invalid-session", message: "Missing chat session id." }
       setFloatingChatSession({
         sessionId,
+        agentTypeId: options?.agentTypeId,
         title: options?.title,
         initialDraft: options?.initialDraft,
         composingEnabled: options?.composingEnabled,

--- a/packages/workspace/src/front/chrome/chat/DetachedChatPopover.tsx
+++ b/packages/workspace/src/front/chrome/chat/DetachedChatPopover.tsx
@@ -13,6 +13,7 @@ const READ_ONLY_BLOCKER = {
 }
 
 export function DetachedChatPopover({
+  instanceKey,
   sessionId,
   title,
   chatParams,
@@ -21,6 +22,7 @@ export function DetachedChatPopover({
   onDock,
   composingEnabled = false,
 }: {
+  instanceKey: string
   sessionId: string
   title: string
   chatParams: ChatPanelHostProps
@@ -46,7 +48,7 @@ export function DetachedChatPopover({
       onClose={onClose}
       onDock={onDock}
     >
-      <ChatPanelHost key={sessionId} {...readOnlyParams} sessionId={sessionId} />
+      <ChatPanelHost key={instanceKey} {...readOnlyParams} sessionId={sessionId} />
     </DetachedPanelPopover>
   )
 }

--- a/packages/workspace/src/front/layout/ChatPaneStage.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStage.tsx
@@ -6,6 +6,7 @@ import { ChatPaneStageDock } from "./ChatPaneStageDock"
 export interface ChatPaneDescriptor {
   id: string
   title?: string | null
+  agentLabel?: string
   panel?: string
   params?: Record<string, unknown>
 }
@@ -63,8 +64,9 @@ export function ChatPaneStage(props: ChatPaneStageProps) {
   return <ChatPaneStageDock {...props} />
 }
 
-export function paneTitle(pane: { title?: string | null }): string {
-  return pane.title || "Untitled"
+export function paneTitle(pane: { title?: string | null; agentLabel?: string }): string {
+  const title = pane.title || "Untitled"
+  return pane.agentLabel ? `${pane.agentLabel} · ${title}` : title
 }
 
 /**

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -687,8 +687,8 @@ describe("ChatLayout component", () => {
         center="chat"
         nav={null}
         chatPanes={[
-          { id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } },
-          { id: "s2", title: "Second", panel: "chat", params: { sessionId: "s2" } },
+          { id: "s1", title: "First", agentLabel: "Alpha", panel: "chat", params: { sessionId: "s1" } },
+          { id: "s2", title: "Second", agentLabel: "Beta", panel: "chat", params: { sessionId: "s2" } },
         ]}
         activeChatPaneId="s2"
         onActiveChatPaneChange={setActive}
@@ -698,15 +698,15 @@ describe("ChatLayout component", () => {
       ["chat", "session-list"],
     )
 
-    expect(screen.getByLabelText("Chat session First")).toHaveAttribute("data-boring-state", "inactive")
-    expect(screen.getByLabelText("Chat session Second")).toHaveAttribute("data-boring-state", "active")
+    expect(screen.getByLabelText("Chat session Alpha · First")).toHaveAttribute("data-boring-state", "inactive")
+    expect(screen.getByLabelText("Chat session Beta · Second")).toHaveAttribute("data-boring-state", "active")
     expect(document.querySelector(".dv-chat-stage")).not.toBeNull()
     expect(screen.getByRole("button", { name: "New chat" })).toBeInTheDocument()
 
-    await user.click(screen.getByLabelText("Chat session First"))
+    await user.click(screen.getByLabelText("Chat session Alpha · First"))
     expect(setActive).toHaveBeenCalledWith("s1")
 
-    await user.click(screen.getByLabelText("Close Second pane"))
+    await user.click(screen.getByLabelText("Close Beta · Second pane"))
     expect(closePane).toHaveBeenCalledWith("s2")
 
     // The floating left-edge "+" creates next to the active pane.
@@ -750,7 +750,7 @@ describe("ChatLayout component", () => {
       <ChatLayout
         center="chat"
         chatPanes={[
-          { id: "s1", title: "First", panel: "chat", params: { sessionId: "s1" } },
+          { id: "s1", title: null, agentLabel: "Researcher", panel: "chat", params: { sessionId: "s1" } },
         ]}
         activeChatPaneId="s1"
       />,
@@ -758,6 +758,7 @@ describe("ChatLayout component", () => {
     )
 
     expect(screen.getByRole("button", { name: "Collapse chat" })).toBeInTheDocument()
+    expect(screen.getByLabelText("Chat session Researcher · Untitled")).toBeInTheDocument()
   })
 
   it("keeps the collapse control with multiple chat panes", () => {

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -98,7 +98,7 @@ export interface AppLeftPaneProps {
   pinnedSessionRefs?: readonly WorkspaceSessionRef[]
   onCreateSession: (agentTypeId?: string) => void
   onCreateSplitSession?: (agentTypeId?: string) => void
-  onCreatePopoverSession?: () => void
+  onCreatePopoverSession?: (agentTypeId?: string) => void
   onOpenCommandPalette: () => void
   onSwitchSession: (id: string, agentTypeId?: string) => void
   onOpenSessionAsPane: (id: string, agentTypeId?: string) => void
@@ -474,6 +474,7 @@ export function AppLeftPane({
               agents={agents}
               onCreateSession={onCreateSession}
               onCreateSplitSession={onCreateSplitSession}
+              onCreatePopoverSession={onCreatePopoverSession}
             />
           ) : (
             <NewChatAction icon={<Plus className="h-4 w-4" strokeWidth={2} />} onCreateSession={onCreateSession} onCreateSplitSession={onCreateSplitSession} onCreatePopoverSession={onCreatePopoverSession} />

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -1,8 +1,9 @@
 "use client"
 
 import { useState, type ReactNode } from "react"
-import { ChevronRight, Columns2, Zap } from "lucide-react"
+import { ChevronRight, Plus, Zap } from "lucide-react"
 import { cn } from "../../lib/utils"
+import { AppLeftPaneSplitAction } from "./AppLeftPaneSplitAction"
 
 interface AgentNewChatOption {
   agentTypeId: string
@@ -52,6 +53,7 @@ export function NewChatAction({
   label = "New chat",
   ariaLabel,
   splitAriaLabel = "New chat in split pane",
+  quickChatAriaLabel = "Quick chat",
   onCreateSession,
   onCreateSplitSession,
   onCreatePopoverSession,
@@ -60,6 +62,7 @@ export function NewChatAction({
   label?: string
   ariaLabel?: string
   splitAriaLabel?: string
+  quickChatAriaLabel?: string
   onCreateSession: () => void
   onCreateSplitSession?: () => void
   onCreatePopoverSession?: () => void
@@ -81,25 +84,23 @@ export function NewChatAction({
       </button>
       <span className="flex w-auto shrink-0 items-center gap-0.5 overflow-hidden opacity-100 transition-[width,opacity] [@media(hover:hover)_and_(min-width:640px)]:mr-1 [@media(hover:hover)_and_(min-width:640px)]:w-0 [@media(hover:hover)_and_(min-width:640px)]:opacity-0 [@media(hover:hover)_and_(min-width:640px)]:group-hover:w-auto [@media(hover:hover)_and_(min-width:640px)]:group-hover:opacity-100 [@media(hover:hover)_and_(min-width:640px)]:group-focus-within:w-auto [@media(hover:hover)_and_(min-width:640px)]:group-focus-within:opacity-100">
         {onCreateSplitSession ? (
-          <button
-            type="button"
-            aria-label={splitAriaLabel}
+          <AppLeftPaneSplitAction
+            ariaLabel={splitAriaLabel}
             title={splitAriaLabel}
+            touchResponsive
+            transitionColors
             onClick={(event) => {
               event.stopPropagation()
               onCreateSplitSession()
               event.currentTarget.blur()
             }}
-            className="grid size-11 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:size-6"
-          >
-            <Columns2 className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
-          </button>
+          />
         ) : null}
         {onCreatePopoverSession ? (
           <button
             type="button"
-            aria-label="Quick chat"
-            title="Quick chat"
+            aria-label={quickChatAriaLabel}
+            title={quickChatAriaLabel}
             onClick={(event) => {
               event.stopPropagation()
               onCreatePopoverSession()
@@ -119,21 +120,27 @@ export function AgentNewChatActions({
   agents,
   onCreateSession,
   onCreateSplitSession,
+  onCreatePopoverSession,
 }: {
   agents: readonly AgentNewChatOption[]
   onCreateSession: (agentTypeId: string) => void
   onCreateSplitSession?: (agentTypeId: string) => void
+  onCreatePopoverSession?: (agentTypeId: string) => void
 }) {
   const [expanded, setExpanded] = useState(false)
   const renderAgentAction = (agent: AgentNewChatOption) => (
     <NewChatAction
-      icon={<Zap className="h-3.5 w-3.5" strokeWidth={1.85} />}
+      icon={<Plus className="h-4 w-4" strokeWidth={2} />}
       label={agent.label}
       ariaLabel={`New chat with ${agent.label}`}
       splitAriaLabel={`New chat with ${agent.label} in split`}
+      quickChatAriaLabel={`Quick chat with ${agent.label}`}
       onCreateSession={() => onCreateSession(agent.agentTypeId)}
       onCreateSplitSession={onCreateSplitSession
         ? () => onCreateSplitSession(agent.agentTypeId)
+        : undefined}
+      onCreatePopoverSession={onCreatePopoverSession
+        ? () => onCreatePopoverSession(agent.agentTypeId)
         : undefined}
     />
   )

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Clock3, Columns2, Pin } from "lucide-react"
+import { Clock3, Pin } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { CHAT_SESSION_DRAG_TYPE } from "../ChatPaneStage"
 import type { WorkspaceAttentionSessionBadge } from "../../attention/WorkspaceAttentionProvider"
@@ -9,6 +9,7 @@ import type { AppLeftPaneSession } from "./AppLeftPane"
 import { AppSessionActionsMenu } from "./AppSessionActionsMenu"
 import { InlineSessionRename, useInlineSessionRename } from "./InlineSessionRename"
 import { encodeWorkspaceSessionDrag } from "../../sessionIdentity"
+import { AppLeftPaneSplitAction } from "./AppLeftPaneSplitAction"
 
 export type AppSessionRowState = "normal" | "open" | "active"
 
@@ -184,18 +185,14 @@ export function AppSessionRow({
           is the first-class path to watching another chat alongside the
           current one. A cross-project session cannot share this stage. */}
       {state === "normal" && canSplit && !rename.editing ? (
-        <button
-          type="button"
-          aria-label={`Open ${title} in split`}
+        <AppLeftPaneSplitAction
+          ariaLabel={`Open ${title} in split`}
           title="Open in split"
           onClick={(event) => {
             event.stopPropagation()
             onOpenAsPane(session.id)
           }}
-          className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-        >
-          <Columns2 className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
-        </button>
+        />
       ) : null}
       {showMenu ? (
         <span

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSplitAction.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSplitAction.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import type { MouseEventHandler } from "react"
+import { Columns2 } from "lucide-react"
+import { cn } from "../../lib/utils"
+
+export function AppLeftPaneSplitAction({
+  ariaLabel,
+  title,
+  onClick,
+  touchResponsive = false,
+  transitionColors = false,
+}: {
+  ariaLabel: string
+  title: string
+  onClick: MouseEventHandler<HTMLButtonElement>
+  touchResponsive?: boolean
+  transitionColors?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={ariaLabel}
+      title={title}
+      onClick={onClick}
+      className={cn(
+        "grid shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+        transitionColors && "transition-colors",
+        touchResponsive
+          ? "size-11 [@media(hover:hover)_and_(min-width:640px)]:size-6"
+          : "size-6",
+      )}
+    >
+      <Columns2 className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
+    </button>
+  )
+}

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -89,6 +89,7 @@ describe("AppLeftPane", () => {
   it("creates addressed chats from a collapsible agent list", () => {
     const onCreateSession = vi.fn()
     const onCreateSplitSession = vi.fn()
+    const onCreatePopoverSession = vi.fn()
     render(
       <WorkspaceAttentionProvider>
         <AppLeftPane
@@ -100,6 +101,7 @@ describe("AppLeftPane", () => {
           sessions={[]}
           onCreateSession={onCreateSession}
           onCreateSplitSession={onCreateSplitSession}
+          onCreatePopoverSession={onCreatePopoverSession}
           onOpenCommandPalette={vi.fn()}
           onSwitchSession={vi.fn()}
           onOpenSessionAsPane={vi.fn()}
@@ -120,10 +122,14 @@ describe("AppLeftPane", () => {
     expect(screen.getByRole("listitem", { name: "Beta" })).toBeInTheDocument()
     const betaAction = screen.getByRole("button", { name: "New chat with Beta" })
     const alphaSplitAction = screen.getByRole("button", { name: "New chat with Alpha in split" })
+    const betaQuickAction = screen.getByRole("button", { name: "Quick chat with Beta" })
     expect(agentsToggle).toHaveClass("h-11", "[@media(hover:hover)_and_(min-width:640px)]:h-8")
     expect(betaAction).toHaveClass("h-full")
     expect(betaAction.parentElement).toHaveClass("h-11", "[@media(hover:hover)_and_(min-width:640px)]:h-8")
+    expect(betaAction.querySelector(".lucide-plus")).toBeInTheDocument()
     expect(alphaSplitAction).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
+    expect(alphaSplitAction.querySelector(".lucide-columns-2")).toBeInTheDocument()
+    expect(betaQuickAction.querySelector(".lucide-zap")).toBeInTheDocument()
     expect(alphaSplitAction.parentElement).toHaveClass(
       "w-auto",
       "opacity-100",
@@ -133,9 +139,11 @@ describe("AppLeftPane", () => {
 
     fireEvent.click(betaAction)
     fireEvent.click(alphaSplitAction)
+    fireEvent.click(betaQuickAction)
 
     expect(onCreateSession).toHaveBeenCalledWith("beta")
     expect(onCreateSplitSession).toHaveBeenCalledWith("alpha")
+    expect(onCreatePopoverSession).toHaveBeenCalledWith("beta")
   })
 
   it("shows an empty state only for agents whose session source loaded authoritatively", () => {
@@ -328,6 +336,7 @@ describe("AppLeftPane", () => {
   it("shows one named new-chat row without collapse chrome for one addressed agent", () => {
     const onCreateSession = vi.fn()
     const onCreateSplitSession = vi.fn()
+    const onCreatePopoverSession = vi.fn()
     render(
       <WorkspaceAttentionProvider>
         <AppLeftPane
@@ -339,6 +348,7 @@ describe("AppLeftPane", () => {
           pinnedSessionIds={[]}
           onCreateSession={onCreateSession}
           onCreateSplitSession={onCreateSplitSession}
+          onCreatePopoverSession={onCreatePopoverSession}
           onOpenCommandPalette={vi.fn()}
           onSwitchSession={vi.fn()}
           onOpenSessionAsPane={vi.fn()}
@@ -353,9 +363,11 @@ describe("AppLeftPane", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "New chat with Alpha" }))
     fireEvent.click(screen.getByRole("button", { name: "New chat with Alpha in split" }))
+    fireEvent.click(screen.getByRole("button", { name: "Quick chat with Alpha" }))
 
     expect(onCreateSession).toHaveBeenCalledWith("alpha")
     expect(onCreateSplitSession).toHaveBeenCalledWith("alpha")
+    expect(onCreatePopoverSession).toHaveBeenCalledWith("alpha")
   })
 
   it("shows a hover action for creating a quick popover chat", () => {

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPaneSessionRow.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPaneSessionRow.test.tsx
@@ -28,7 +28,19 @@ describe("AppSessionRow actions", () => {
     row({ onDelete, onRename: vi.fn() })
 
     expect(screen.getByLabelText("Pin Native chat")).toBeInTheDocument()
-    expect(screen.getByLabelText("Open Native chat in split")).toBeInTheDocument()
+    const splitAction = screen.getByLabelText("Open Native chat in split")
+    expect(splitAction).toHaveClass(
+      "grid",
+      "size-6",
+      "shrink-0",
+      "place-items-center",
+      "rounded-md",
+      "text-muted-foreground",
+      "hover:bg-background",
+      "hover:text-foreground",
+    )
+    expect(splitAction).not.toHaveClass("transition-colors")
+    expect(splitAction.querySelector(".lucide-columns-2")).toHaveClass("h-3.5", "w-3.5")
     fireEvent.pointerDown(screen.getByLabelText("More options for Native chat"), { button: 0, ctrlKey: false })
     expect(screen.getByText("Copy session ID")).toBeInTheDocument()
     expect(screen.getByText("Rename")).toBeInTheDocument()

--- a/packages/workspace/src/shared/plugins/workspaceShellCapabilities.ts
+++ b/packages/workspace/src/shared/plugins/workspaceShellCapabilities.ts
@@ -21,7 +21,7 @@ export interface WorkspaceShellAnchorRect {
 
 export interface WorkspaceShellCapabilities {
   openArtifact(target: WorkspaceShellArtifactTarget | null, options?: { sessionId?: string | null; title?: string; instanceId?: string }): WorkspaceShellCapabilityResult
-  openDetachedChat(sessionId: string, options?: { anchor?: WorkspaceShellAnchorRect; title?: string; initialDraft?: string; composingEnabled?: boolean }): WorkspaceShellCapabilityResult
+  openDetachedChat(sessionId: string, options?: { agentTypeId?: string; anchor?: WorkspaceShellAnchorRect; title?: string; initialDraft?: string; composingEnabled?: boolean }): WorkspaceShellCapabilityResult
   refreshChatSessions?(): Promise<void>
 }
 


### PR DESCRIPTION
## Summary

- Prefix multi-agent chat pane titles with the owning catalog label while preserving session-only titles for single-agent deployments.
- Restore the historical wide New chat control shape for every agent row: leading Plus, primary replace-active action, shared Columns2 split action, and Zap quick-chat action.
- Preserve addressed agent identity through detached quick chat, including colliding native session IDs.
- Update affected unit tests and playground E2E specifications; no local browser E2E was run per owner instruction.

## Root cause

The multi-agent pane descriptor carried the addressed session identity but not its catalog label, while the Agents-section action rows had diverged from the pre-existing NewChatAction markup and routing semantics. Detached quick chat also needed owner identity in its composite key.

## Historical control

The row directly reuses NewChatAction, whose control shape comes from commit 2fd696887 (Fix app-left new chat and active states (#834)), with the later touch-safe behavior retained. The split icon/styling is shared with AppLeftPaneSessionRow.

## Proof

- pnpm typecheck — PASS
- pnpm lint:invariants — PASS; 428 plugin sources and 1,274 production sources scanned
- Focused vitest run — PASS, 4 files / 146 tests
- node scripts/build-front-css.mjs from packages/agent — PASS; dist/front/styles.css = 166,664 bytes
- Independent acceptance and thermo reviews completed; owner-aware detached React key and exact session-row split classes were fixed before delivery.

## Manual review

1. In multi-agent mode, open chats for two agents and confirm pane labels read Agent · Session.
2. In single-agent mode, confirm the pane title remains session-only and the lone agent-named control has no Agents collapse chrome.
3. For each agent row, verify primary replaces the active pane, Columns2 opens beside it, and Zap opens quick chat without replacing the active pane.
4. Confirm no agent combobox is present.