### PR TITLE
#996 preserve filesystem root selection when opening files

### DIFF
--- a/apps/workspace-playground/.gitignore
+++ b/apps/workspace-playground/.gitignore
@@ -2,5 +2,7 @@
 # Agent edits land here so they don't dirty committed fixture content.
 # Delete the directory to reset; vite.config.ts will re-seed on next boot.
 workspace/
+# Separate read-only binding used by multi-filesystem playground tests.
+e2e/fixtures/company-context/
 # Playwright/dev Pi session transcripts are mutable host/runtime data.
 sessions/

--- a/apps/workspace-playground/e2e/multi-filesystem-root.spec.ts
+++ b/apps/workspace-playground/e2e/multi-filesystem-root.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test, type Page, type Request } from "@playwright/test"
+import { mkdir, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const APP_DIR = dirname(dirname(fileURLToPath(import.meta.url)))
+const WORKSPACE_ROOT = resolve(process.env.BORING_AGENT_WORKSPACE_ROOT || resolve(APP_DIR, "e2e/fixtures/workspace"))
+const COMPANY_CONTEXT_ROOT = resolve(process.env.BORING_WORKSPACE_PLAYGROUND_COMPANY_CONTEXT_ROOT || resolve(APP_DIR, "e2e/fixtures/company-context"))
+const WORKSPACE_FILE = "workspace-root-test.md"
+const COMPANY_FILE = "company-root-test.md"
+const WORKSPACE_CONTENT = "Workspace source content 996"
+const COMPANY_CONTENT = "Company source content 996"
+
+test.beforeAll(async () => {
+  await mkdir(WORKSPACE_ROOT, { recursive: true })
+  await mkdir(COMPANY_CONTEXT_ROOT, { recursive: true })
+  await writeFile(resolve(WORKSPACE_ROOT, WORKSPACE_FILE), `# ${WORKSPACE_CONTENT}\n`)
+  await writeFile(resolve(COMPANY_CONTEXT_ROOT, COMPANY_FILE), `# ${COMPANY_CONTENT}\n`)
+})
+
+async function selectRoot(page: Page, label: string) {
+  const rootSelector = page.getByRole("combobox", { name: "File root" })
+  await rootSelector.click()
+  await page.getByRole("option", { name: label }).click()
+  await expect(rootSelector).toContainText(label)
+}
+
+function isFileRead(request: Request, path: string, filesystem: string): boolean {
+  const url = new URL(request.url())
+  return request.method() === "GET"
+    && url.pathname === "/api/v1/files"
+    && (url.searchParams.get("path") ?? "").replace(/^\/+/, "") === path
+    && (url.searchParams.get("filesystem") ?? "user") === filesystem
+}
+
+async function openAndAssertFile(
+  page: Page,
+  options: { path: string; filesystem: string; content: string },
+) {
+  const read = page.waitForRequest((request) => isFileRead(request, options.path, options.filesystem))
+  await page.getByText(options.path, { exact: true }).first().click()
+  await read
+  await expect(page.getByRole("tab", { name: new RegExp(options.path) })).toBeVisible()
+  await expect(page.getByText(options.content, { exact: false }).first()).toBeVisible()
+}
+
+test("opening files preserves the selected Workspace and Company roots", async ({ page }) => {
+  await page.goto("/?fresh=1&multiFilesystem=1")
+  await page.getByRole("button", { name: "Open workbench" }).click()
+  await page.getByRole("button", { name: "Files", exact: true }).click()
+
+  const rootSelector = page.getByRole("combobox", { name: "File root" })
+  await expect(rootSelector).toBeVisible({ timeout: 20_000 })
+  await expect(rootSelector).toContainText("Workspace")
+
+  await openAndAssertFile(page, {
+    path: WORKSPACE_FILE,
+    filesystem: "user",
+    content: WORKSPACE_CONTENT,
+  })
+  await expect(rootSelector).toContainText("Workspace")
+
+  await selectRoot(page, "Company")
+  await openAndAssertFile(page, {
+    path: COMPANY_FILE,
+    filesystem: "company_context",
+    content: COMPANY_CONTENT,
+  })
+  await expect(rootSelector).toContainText("Company")
+})

--- a/apps/workspace-playground/playwright.config.ts
+++ b/apps/workspace-playground/playwright.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url"
 
 const APP_DIR = dirname(fileURLToPath(import.meta.url))
 const E2E_WORKSPACE_ROOT = resolve(process.env.BORING_AGENT_WORKSPACE_ROOT || resolve(APP_DIR, "e2e/fixtures/workspace"))
+const E2E_COMPANY_CONTEXT_ROOT = resolve(process.env.BORING_WORKSPACE_PLAYGROUND_COMPANY_CONTEXT_ROOT || resolve(APP_DIR, "e2e/fixtures/company-context"))
 const E2E_SESSION_ROOT = resolve(process.env.BORING_AGENT_SESSION_ROOT || resolve(APP_DIR, "e2e/fixtures/sessions"))
 const VITE_PORT = 5380
 const AGENT_API_PORT = 5390
@@ -53,7 +54,9 @@ export default defineConfig({
       `PORT=${VITE_PORT}`,
       `AGENT_API_PORT=${AGENT_API_PORT}`,
       `BORING_AGENT_WORKSPACE_ROOT=${shell(E2E_WORKSPACE_ROOT)}`,
+      `BORING_WORKSPACE_PLAYGROUND_COMPANY_CONTEXT_ROOT=${shell(E2E_COMPANY_CONTEXT_ROOT)}`,
       `BORING_AGENT_SESSION_ROOT=${shell(E2E_SESSION_ROOT)}`,
+      "BORING_WORKSPACE_PLAYGROUND_MULTI_FS=1",
       "BORING_AGENT_E2E_SCRIPTED_PI=1",
       "BORING_AGENT_E2E_SCRIPTED_PI_TICK_MS=300",
       "BORING_AGENT_E2E_SCRIPTED_PI_TOOL_DELAY_TICKS=20",

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -20,7 +20,9 @@ function isFullPageRoute(): boolean {
 }
 
 function isMultiFilesystemPlaygroundRoute(): boolean {
-  return (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_PLAYGROUND_MULTI_FS === "1"
+  if ((import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_PLAYGROUND_MULTI_FS === "1") return true
+  if (typeof window === "undefined") return false
+  return new URLSearchParams(window.location.search).get("multiFilesystem") === "1"
 }
 
 interface WorkspaceMeta {

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -64,6 +64,8 @@ export async function startPlaygroundServer(): Promise<void> {
       : undefined
     const localRuntimeMode = process.env.BORING_AGENT_MODE?.trim() === "direct" ? "direct" : "local"
     const multiFilesystemPlayground = process.env.BORING_WORKSPACE_PLAYGROUND_MULTI_FS === "1" || process.env.VITE_PLAYGROUND_MULTI_FS === "1"
+    const companyContextRoot = resolve(process.env.BORING_WORKSPACE_PLAYGROUND_COMPANY_CONTEXT_ROOT || workspaceRoot)
+    if (multiFilesystemPlayground) mkdirSync(companyContextRoot, { recursive: true })
     console.log(`[workspace-playground] workspace root: ${workspaceRoot}`)
     console.log(`[workspace-playground] runtime mode: ${remoteWorkerModeAdapter ? "remote-worker" : localRuntimeMode}`)
     if (remoteWorkerWorkspaceId) {
@@ -95,11 +97,11 @@ export async function startPlaygroundServer(): Promise<void> {
                 access: "readonly",
                 operations: {
                   async read({ path }: { path: string }) {
-                    const target = resolvePlaygroundBindingPath(workspaceRoot, path)
+                    const target = resolvePlaygroundBindingPath(companyContextRoot, path)
                     return { content: await readFile(target, "utf8") }
                   },
                   async list({ path }: { path: string }) {
-                    const target = resolvePlaygroundBindingPath(workspaceRoot, path)
+                    const target = resolvePlaygroundBindingPath(companyContextRoot, path)
                     return { entries: await readdir(target) }
                   },
                   async find() {
@@ -109,7 +111,7 @@ export async function startPlaygroundServer(): Promise<void> {
                     return { matches: [] }
                   },
                   async stat({ path }: { path: string }) {
-                    const target = resolvePlaygroundBindingPath(workspaceRoot, path)
+                    const target = resolvePlaygroundBindingPath(companyContextRoot, path)
                     return { isDirectory: (await stat(target)).isDirectory() }
                   },
                   rejectMutation(operation: string) {

--- a/docs/issues/996/plan.md
+++ b/docs/issues/996/plan.md
@@ -1,0 +1,27 @@
+# Issue #996: preserve multi-filesystem file-tree root
+
+## Problem
+
+`FileTreePane` reconciles its local root selection from the default `filesystem` prop whenever the configured `roots` array changes identity. Hosts commonly rebuild an equivalent roots array during file-open rerenders, so a still-valid user selection such as `company_context` is replaced by the default `user` root. Reveal/open synchronization also needs the optional filesystem identity to select the intended root rather than treating a path as globally unique.
+
+## Plan
+
+1. Reconcile root changes with the current selection first, falling back to the configured default and then the first available root only when the current root was removed.
+   - Verify with focused component tests for an equivalent roots-array rerender and deterministic selected-root removal fallback.
+2. Add optional filesystem identity to file-tree reveal requests and use explicit reveal/open events to select a matching configured root.
+   - Keep path-only callers backward compatible as the `user` filesystem where the bridge already applies that default.
+   - Verify explicit company/user synchronization and ensure requests are only delivered to the matching active tree.
+3. Carry optional filesystem through the existing `expandToFile` command/bridge/surface path and ensure successful surface file opens emit the existing identity-bearing `file:opened` event.
+   - Verify bridge/dispatcher forwarding and surface event behavior with targeted unit tests.
+4. Run the focused workspace tests and package typecheck. Add browser coverage only if the playground can enable its multi-filesystem fixture without changing unrelated test-suite behavior.
+
+## Proof status
+
+- Focused FileTreePane, SurfaceShell, mock bridge, bridge/dispatcher/link/client, and agent UI-tool tests pass (246 tests).
+- Workspace and workspace-playground typechecks pass after building playground dependencies.
+- A dedicated Playwright test uses distinct Workspace and Company fixture roots, verifies filesystem-qualified file reads plus visible editor content/tabs, and checks the selector after each open.
+- Reveal requests are one-shot at both the SurfaceShell and FileTreePane boundaries. FileTreePane owns bridge-to-prop conversion for nested trees, while standalone FileTreeView keeps direct bridge expansion support; authoritative prop + event pairs are deduplicated.
+
+## Scope and rollback
+
+This change is limited to file-tree selection and the existing optional filesystem field on open/reveal synchronization. It does not depend on or include #995. Rollback is a direct revert of the issue commit; no persistence or migration changes are involved.

--- a/packages/workspace/src/front/bridge/WorkspaceLink.tsx
+++ b/packages/workspace/src/front/bridge/WorkspaceLink.tsx
@@ -7,7 +7,7 @@ export type WorkspaceLinkTarget =
   | { kind: "openFile"; path: string; mode?: "view" | "edit" | "diff"; filesystem?: FilesystemId }
   | { kind: "openSurface"; surfaceKind: string; target: string; filesystem?: FilesystemId; meta?: Record<string, unknown> }
   | { kind: "openPanel"; id: string; component: string; title?: string; params?: Record<string, unknown> }
-  | { kind: "expandToFile"; path: string }
+  | { kind: "expandToFile"; path: string; filesystem?: FilesystemId }
 
 export interface WorkspaceLinkProps {
   to: WorkspaceLinkTarget
@@ -35,7 +35,7 @@ export function workspaceLinkCommand(to: WorkspaceLinkTarget): UiCommand {
         },
       }
     case "expandToFile":
-      return { kind: "expandToFile", params: { path: to.path } }
+      return { kind: "expandToFile", params: { path: to.path, ...(to.filesystem ? { filesystem: to.filesystem } : {}) } }
   }
 }
 

--- a/packages/workspace/src/front/bridge/__tests__/WorkspaceLink.test.tsx
+++ b/packages/workspace/src/front/bridge/__tests__/WorkspaceLink.test.tsx
@@ -39,6 +39,14 @@ describe("workspaceLinkCommand", () => {
       kind: "expandToFile",
       params: { path: "src/app.ts" },
     })
+    expect(workspaceLinkCommand({
+      kind: "expandToFile",
+      path: "/company/policy.md",
+      filesystem: "company_context",
+    })).toEqual({
+      kind: "expandToFile",
+      params: { path: "/company/policy.md", filesystem: "company_context" },
+    })
   })
 })
 

--- a/packages/workspace/src/front/bridge/__tests__/bridge.test.ts
+++ b/packages/workspace/src/front/bridge/__tests__/bridge.test.ts
@@ -145,6 +145,24 @@ describe("createBridge", () => {
       expect(handler).toHaveBeenCalledWith({ path: "/company/hr/policy.md", mode: "view", filesystem: "company_context" })
     })
 
+    it("emits identity when reactivating an existing file panel", async () => {
+      store.state.panels = [{
+        id: "file:company_context:/company/hr/policy.md",
+        component: "editor",
+      }]
+      const bridge = createBridge(store)
+      const handler = vi.fn()
+      bridge.subscribe("file:opened", handler)
+
+      await bridge.openFile("/company/hr/policy.md", { filesystem: "company_context" })
+
+      expect(handler).toHaveBeenCalledWith({
+        path: "/company/hr/policy.md",
+        mode: "edit",
+        filesystem: "company_context",
+      })
+    })
+
     it("opens same path in user and company_context as distinct panels", async () => {
       const bridge = createBridge(store)
       await bridge.openFile("/same.md")
@@ -273,6 +291,19 @@ describe("createBridge", () => {
       const result = await bridge.expandToFile("/src/foo.ts")
       expect(result.status).toBe("ok")
       expect(handler).toHaveBeenCalledWith({ path: "/src/foo.ts" })
+    })
+
+    it("preserves explicit filesystem identity in tree reveal events", async () => {
+      const bridge = createBridge(store)
+      const handler = vi.fn()
+      bridge.subscribe("tree:expand", handler)
+
+      await bridge.expandToFile("/company/hr/policy.md", { filesystem: "company_context" })
+
+      expect(handler).toHaveBeenCalledWith({
+        path: "/company/hr/policy.md",
+        filesystem: "company_context",
+      })
     })
 
     it("uncollapses sidebar when collapsed", async () => {

--- a/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
+++ b/packages/workspace/src/front/bridge/__tests__/uiCommandDispatcher.test.ts
@@ -7,6 +7,7 @@ function fakeSurface(): SurfaceShellApi & {
   __surfaces: unknown[]
   __panels: unknown[]
   __expanded: string[]
+  __expandCalls: Array<{ path: string; filesystem?: string }>
   __leftClosed: number
   __openFileCalls: Array<{ path: string; filesystem?: string }>
 } {
@@ -15,11 +16,13 @@ function fakeSurface(): SurfaceShellApi & {
   const surfaces: unknown[] = []
   const panels: unknown[] = []
   const expanded: string[] = []
+  const expandCalls: Array<{ path: string; filesystem?: string }> = []
   const surface: SurfaceShellApi & {
     __opened: string[]
     __surfaces: unknown[]
     __panels: unknown[]
     __expanded: string[]
+    __expandCalls: Array<{ path: string; filesystem?: string }>
     __leftClosed: number
     __openFileCalls: Array<{ path: string; filesystem?: string }>
   } = {
@@ -29,7 +32,10 @@ function fakeSurface(): SurfaceShellApi & {
     },
     openSurface: (request: unknown) => surfaces.push(request),
     openPanel: (cfg: unknown) => panels.push(cfg),
-    expandToFile: (path: string) => expanded.push(path),
+    expandToFile: (path: string, options?: { filesystem?: string }) => {
+      expanded.push(path)
+      expandCalls.push({ path, filesystem: options?.filesystem })
+    },
     closeWorkbenchLeftPane: () => {
       surface.__leftClosed += 1
     },
@@ -39,6 +45,7 @@ function fakeSurface(): SurfaceShellApi & {
     __surfaces: surfaces,
     __panels: panels,
     __expanded: expanded,
+    __expandCalls: expandCalls,
     __leftClosed: 0,
   }
   return surface
@@ -261,6 +268,18 @@ describe("dispatchUiCommand", () => {
     expect(openWorkbenchSources).toHaveBeenCalledOnce()
     expect(c.__surface.__expanded).toEqual(["src"])
     expect(c.__surface.__opened).toEqual([])
+  })
+
+  it("expandToFile preserves explicit filesystem identity", () => {
+    const c = ctx()
+    dispatchUiCommand({
+      kind: "expandToFile",
+      params: { path: "/company/policy.md", filesystem: "company_context" },
+    }, c)
+    expect(c.__surface.__expandCalls).toEqual([{
+      path: "/company/policy.md",
+      filesystem: "company_context",
+    }])
   })
 
   it("expandToFile opens the workbench and sources when closed", () => {

--- a/packages/workspace/src/front/bridge/client.ts
+++ b/packages/workspace/src/front/bridge/client.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceBridge, CausedBy } from "./types"
 import type { WorkspaceStore, PanelState } from "../store/types"
+import type { FilesystemId } from "../../shared/types/filesystem"
 
 export interface UIStatePut {
   v: 1
@@ -116,9 +117,12 @@ async function dispatchCommand(
         params.line as number,
       )
       break
-    case "expandToFile":
-      await bridge.expandToFile(params.path as string)
+    case "expandToFile": {
+      const filesystem = params.filesystem as FilesystemId | undefined
+      if (filesystem) await bridge.expandToFile(params.path as string, { filesystem })
+      else await bridge.expandToFile(params.path as string)
       break
+    }
     case "markDirty":
       bridge.markDirty(params.path as string)
       break

--- a/packages/workspace/src/front/bridge/createBridge.ts
+++ b/packages/workspace/src/front/bridge/createBridge.ts
@@ -85,6 +85,7 @@ export function createBridge(store: StoreApi): WorkspaceBridge {
         if (!state.visibleFiles.includes(path)) {
           state.openFile(path, panelId)
         }
+        emit("file:opened", { path, mode, filesystem })
         emit("panel:activated", { panelId, previousPanelId: prev })
         return ok()
       }
@@ -167,8 +168,8 @@ export function createBridge(store: StoreApi): WorkspaceBridge {
       return ok()
     },
 
-    async expandToFile(path) {
-      const parsed = expandToFileSchema.safeParse({ path })
+    async expandToFile(path, opts) {
+      const parsed = expandToFileSchema.safeParse({ path, filesystem: opts?.filesystem })
       if (!parsed.success) return err("VALIDATION", parsed.error.issues[0].message)
 
       const state = store.getState()
@@ -176,7 +177,10 @@ export function createBridge(store: StoreApi): WorkspaceBridge {
         state.setSidebar({ collapsed: false })
         emit("sidebar:toggled", { collapsed: false })
       }
-      emit("tree:expand", { path: parsed.data.path })
+      emit("tree:expand", {
+        path: parsed.data.path,
+        ...(parsed.data.filesystem ? { filesystem: parsed.data.filesystem } : {}),
+      })
       return ok()
     },
 

--- a/packages/workspace/src/front/bridge/types.ts
+++ b/packages/workspace/src/front/bridge/types.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceState, PanelState } from "../store/types"
-import type { FilesystemId } from "../../shared/types/filesystem"
+import type { FilesystemId, UiFileResource } from "../../shared/types/filesystem"
 
 export interface CommandResult {
   seq: number
@@ -22,7 +22,7 @@ export interface BridgeEventMap {
   "file:saved": { path: string }
   "file:dirty": { path: string; dirty: boolean }
   "sidebar:toggled": { collapsed: boolean }
-  "tree:expand": { path: string }
+  "tree:expand": { path: string; filesystem?: FilesystemId }
   "notification:shown": { message: string; level: "info" | "warn" | "error" }
   "pane:error": { panelId: string; error: string; stack?: string }
 }
@@ -39,6 +39,7 @@ export interface DynamicPaneConfig {
 export interface WorkspaceBridge {
   getOpenPanels(): PanelState[]
   getActiveFile(): string | null
+  getActiveFileResource?(): UiFileResource | null
   getDirtyFiles(): string[]
   getVisibleFiles(): string[]
 
@@ -54,7 +55,7 @@ export interface WorkspaceBridge {
     level?: "info" | "warn" | "error",
   ): Promise<CommandResult>
   navigateToLine(file: string, line: number): Promise<CommandResult>
-  expandToFile(path: string): Promise<CommandResult>
+  expandToFile(path: string, opts?: { filesystem?: FilesystemId }): Promise<CommandResult>
   markDirty(path: string): void
   markClean(path: string): void
 
@@ -77,6 +78,8 @@ export interface WorkspaceBridge {
  * surface-backed adapter without importing a plugin module.
  */
 export type FileTreeBridge = Pick<WorkspaceBridge, "openFile" | "getActiveFile" | "select"> &
-  Partial<Pick<WorkspaceBridge, "subscribe">>
+  Partial<Pick<WorkspaceBridge, "subscribe">> & {
+    getActiveFileResource?: () => UiFileResource | null
+  }
 
 export type CausedBy = "user" | "agent" | "restore"

--- a/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
+++ b/packages/workspace/src/front/bridge/uiCommandDispatcher.ts
@@ -208,13 +208,15 @@ export function dispatchUiCommand(cmd: UiCommand, ctx: DispatchContext): void {
     }
     case "expandToFile": {
       const path = strParam(cmd.params, "path")
+      const filesystem = strParam(cmd.params, "filesystem")
       if (!path) return
       const wasClosed = !ctx.isWorkbenchOpen()
       if (wasClosed) ctx.openWorkbench()
       ctx.openWorkbenchSources?.()
       const run = (surface: SurfaceShellApi) => {
         try {
-          surface.expandToFile(path)
+          if (filesystem) surface.expandToFile(path, { filesystem })
+          else surface.expandToFile(path)
         } catch (err) {
           // eslint-disable-next-line no-console -- intentional dev signal
           console.warn(

--- a/packages/workspace/src/front/bridge/validation.ts
+++ b/packages/workspace/src/front/bridge/validation.ts
@@ -57,6 +57,7 @@ export const navigateToLineSchema = z.object({
 
 export const expandToFileSchema = z.object({
   path: safePath,
+  filesystem: z.string().min(1).optional(),
 })
 
 export { MAX_PANELS }

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -12,8 +12,9 @@ import type { WorkspaceBridge, CommandResult, BridgeEventMap } from "../../bridg
 import type { WorkspaceState, PanelState } from "../../store/types"
 import { WorkbenchLeftPane } from "../workbench-left/WorkbenchLeftPane"
 import { useRegistry, useSurfaceResolverRegistry } from "../../registry"
-import { normalizeUiFilesystem, type FilesystemId } from "../../../shared/types/filesystem"
+import { normalizeUiFilesystem, type FilesystemId, type UiFileResource } from "../../../shared/types/filesystem"
 import type { SurfaceOpenRequest } from "../../../shared/types/surface"
+import type { FileTreeRevealRequest } from "../../../shared/plugins/types"
 import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../../shared/types/surface"
 import { isSharedDockviewPlacement, isWorkspacePagePlacement } from "../../../shared/types/panel"
 import {
@@ -67,8 +68,8 @@ export interface SurfaceShellApi {
   openPanel: (config: OpenPanelConfig) => void
   /** Hide the workbench's left sources/files pane while leaving the workbench open. */
   closeWorkbenchLeftPane: () => void
-  /** Reveal/select a file-tree path without opening an editor pane. */
-  expandToFile: (path: string) => void
+  /** Reveal/select a file-tree resource without opening an editor pane. */
+  expandToFile: (path: string, options?: { filesystem?: FilesystemId }) => void
   /** Current snapshot of open tabs + active tab. */
   getSnapshot: () => SurfaceShellSnapshot
 }
@@ -177,7 +178,7 @@ function dockviewPanelComponent(panel: DockviewApi["panels"][number] | null | un
 }
 
 function fileBackedPath(
-  panel: PanelState | null | undefined,
+  panel: Pick<PanelState, "id" | "params"> | null | undefined,
   fileBackedPanelIds: ReadonlySet<string>,
 ): string | null {
   if (!panel) return null
@@ -189,6 +190,19 @@ function fileBackedPath(
   ) return null
   const path = panel.params?.path
   return typeof path === "string" ? path : null
+}
+
+function fileBackedResource(
+  panel: Pick<PanelState, "id" | "params"> | null | undefined,
+  fileBackedPanelIds: ReadonlySet<string>,
+): UiFileResource | null {
+  const path = fileBackedPath(panel, fileBackedPanelIds)
+  if (!path) return null
+  const rawFilesystem = panel?.params?.filesystem
+  return {
+    path,
+    filesystem: normalizeUiFilesystem(typeof rawFilesystem === "string" ? rawFilesystem : undefined),
+  }
 }
 
 let seqCounter = 0
@@ -259,7 +273,12 @@ export function SurfaceShell({
   // a workspace-page icon only while its page is the focused surface tab (the rail's
   // own activeTab is set on icon-click and goes stale when you switch surface tabs).
   const [activeSurfacePanelId, setActiveSurfacePanelId] = useState<string | null>(null)
-  const [fileTreeRevealRequest, setFileTreeRevealRequest] = useState<{ path: string; seq: number } | null>(null)
+  const [fileTreeRevealRequest, setFileTreeRevealRequest] = useState<FileTreeRevealRequest | null>(null)
+  const fileTreeRevealSeqRef = useRef(0)
+  useEffect(() => {
+    if (!fileTreeRevealRequest) return
+    setFileTreeRevealRequest((current) => current?.seq === fileTreeRevealRequest.seq ? null : current)
+  }, [fileTreeRevealRequest])
   const onReadyRef = useRef(onReady)
   onReadyRef.current = onReady
   const onChangeRef = useRef(onChange)
@@ -268,7 +287,7 @@ export function SurfaceShell({
   onCloseRef.current = onClose
   const bridgeSelectorsRef = useRef(new Set<(state: WorkspaceState) => void>())
   const fileBackedPanelIdsRef = useRef(new Set<string>())
-  const pendingTreeExpandRef = useRef<string | null>(null)
+  const pendingTreeExpandRef = useRef<{ path: string; filesystem?: FilesystemId } | null>(null)
   const bridgeEventHandlersRef = useRef(
     new Map<keyof BridgeEventMap, Set<(data: BridgeEventMap[keyof BridgeEventMap]) => void>>(),
   )
@@ -369,6 +388,31 @@ export function SurfaceShell({
     return true
   }, [applyPanelPlacementTransition])
 
+  const emitFileOpened = useCallback((path: string, options?: SurfaceShellOpenFileOptions) => {
+    const handlers = bridgeEventHandlersRef.current.get("file:opened")
+    if (!handlers || handlers.size === 0) return
+    const payload: BridgeEventMap["file:opened"] = {
+      path,
+      mode: options?.mode ?? "edit",
+      filesystem: normalizeUiFilesystem(options?.filesystem),
+    }
+    for (const handler of [...handlers]) handler(payload)
+  }, [])
+
+  const emitActiveFileOpened = useCallback((dockview: DockviewApi) => {
+    const panel = dockview.activePanel
+    const resource = fileBackedResource(
+      panel ? { id: panel.id, params: panel.params as Record<string, unknown> | undefined } : null,
+      fileBackedPanelIdsRef.current,
+    )
+    if (!resource) return
+    const mode = panel?.params?.mode
+    emitFileOpened(resource.path, {
+      filesystem: resource.filesystem,
+      ...(mode === "view" || mode === "edit" || mode === "diff" ? { mode } : {}),
+    })
+  }, [emitFileOpened])
+
   const openFileSync = useCallback((path: string, options?: SurfaceShellOpenFileOptions) => {
     const api = apiRef.current
     if (!api) {
@@ -390,23 +434,29 @@ export function SurfaceShell({
       const panelId = surfacePanelId(request, resolved)
       const params = fileBackedParams(resolved.params, normalizedPath, { filesystem: request.filesystem, mode: options?.mode })
       fileBackedPanelIdsRef.current.add(panelId)
-      if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) return
-      activateDockviewPanel({
+      if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) {
+        emitFileOpened(normalizedPath, { ...options, filesystem: request.filesystem })
+        return
+      }
+      if (activateDockviewPanel({
         id: panelId,
         component: resolved.component,
         title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
         params,
-      })
+      })) {
+        emitFileOpened(normalizedPath, { ...options, filesystem: request.filesystem })
+      }
       return
     }
 
     const existing = findOpenFilePanel(api, normalizedPath, request.filesystem)
     if (existing) {
       existing.api.setActive()
+      emitFileOpened(normalizedPath, { ...options, filesystem: request.filesystem })
       return
     }
     console.warn(`[SurfaceShell] openFile: no surface resolver matched "${normalizedPath}"`)
-  }, [activateDockviewPanel, activateExistingFilePanel])
+  }, [activateDockviewPanel, activateExistingFilePanel, emitFileOpened])
 
   const openSurfaceSync = useCallback((request: SurfaceOpenRequest) => {
     const normalizedRequest = normalizeSurfaceOpenRequest(request)
@@ -442,11 +492,20 @@ export function SurfaceShell({
     const resolvedParams = closeWorkbenchOnDone && onCloseRef.current
       ? { ...(baseParams ?? {}), __closeWorkbenchOnDone: onCloseRef.current }
       : baseParams
+    const fileOptions: SurfaceShellOpenFileOptions | null = normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND
+      ? {
+          filesystem: normalizeUiFilesystem(normalizedRequest.filesystem),
+          ...(surfaceMode === "view" || surfaceMode === "edit" || surfaceMode === "diff" ? { mode: surfaceMode } : {}),
+        }
+      : null
     if (
       normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND &&
       apiRef.current &&
       activateExistingFilePanel(apiRef.current, normalizedRequest.target, normalizeUiFilesystem(normalizedRequest.filesystem), resolved.component, resolvedParams ?? {})
-    ) return
+    ) {
+      emitFileOpened(normalizedRequest.target, fileOptions!)
+      return
+    }
     if (!activateDockviewPanel({
       id: panelId,
       component: resolved.component,
@@ -454,8 +513,10 @@ export function SurfaceShell({
       params: resolvedParams,
     })) {
       console.warn("[SurfaceShell] openSurface: surface not ready (dockview not initialized)")
+    } else if (fileOptions) {
+      emitFileOpened(normalizedRequest.target, fileOptions)
     }
-  }, [activateDockviewPanel, activateExistingFilePanel])
+  }, [activateDockviewPanel, activateExistingFilePanel, emitFileOpened])
 
   const openPanelSync = useCallback((config: OpenPanelConfig) => {
     const api = apiRef.current
@@ -521,12 +582,14 @@ export function SurfaceShell({
     return true
   }, [])
 
-  const expandToFileSync = useCallback((path: string) => {
+  const expandToFileSync = useCallback((path: string, options?: { filesystem?: FilesystemId }) => {
     const normalizedPath = normalizeWorkbenchPath(path)
-    pendingTreeExpandRef.current = normalizedPath
-    setFileTreeRevealRequest((prev) => ({ path: normalizedPath, seq: (prev?.seq ?? 0) + 1 }))
+    const filesystem = options?.filesystem
+    const request = { path: normalizedPath, ...(filesystem ? { filesystem } : {}) }
+    pendingTreeExpandRef.current = request
+    setFileTreeRevealRequest({ ...request, seq: ++fileTreeRevealSeqRef.current })
     openSourcePane(FILES_WORKSPACE_SOURCE_ID)
-    if (emitBridgeEvent("tree:expand", { path: normalizedPath })) {
+    if (emitBridgeEvent("tree:expand", request)) {
       pendingTreeExpandRef.current = null
     }
   }, [emitBridgeEvent, openSourcePane])
@@ -603,12 +666,13 @@ export function SurfaceShell({
     ready.onDidRemovePanel(emit)
     ready.onDidActivePanelChange(() => {
       collapseForActiveWorkspacePage(ready)
+      emitActiveFileOpened(ready)
       emit()
     })
     // Initial snapshot once everyone's wired up.
     collapseForActiveWorkspacePage(ready)
     emit()
-  }, [collapseForActiveWorkspacePage, localSurfaceApi, getSnapshot, emitBridgeState])
+  }, [collapseForActiveWorkspacePage, emitActiveFileOpened, localSurfaceApi, getSnapshot, emitBridgeState])
 
 
   const openFile = useCallback(
@@ -633,19 +697,24 @@ export function SurfaceShell({
           const panelId = surfacePanelId(request, resolved)
           const params = fileBackedParams(resolved.params, normalizedPath, { filesystem: request.filesystem, mode: options?.mode })
           fileBackedPanelIdsRef.current.add(panelId)
-          if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) return ok()
-          activateDockviewPanel({
+          if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) {
+            emitFileOpened(normalizedPath, { ...options, filesystem: request.filesystem })
+            return ok()
+          }
+          if (!activateDockviewPanel({
             id: panelId,
             component: resolved.component,
             title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
             params,
-          })
+          })) return err("not-ready", "surface not ready")
+          emitFileOpened(normalizedPath, { ...options, filesystem: request.filesystem })
           return ok()
         }
 
         const existing = findOpenFilePanel(api, normalizedPath, request.filesystem)
         if (existing) {
           existing.api.setActive()
+          emitFileOpened(normalizedPath, { ...options, filesystem: request.filesystem })
           return ok()
         }
         return err("NO_SURFACE_RESOLVER", `no registered surface resolver handles ${normalizedPath}`)
@@ -656,13 +725,21 @@ export function SurfaceShell({
         )
       }
     },
-    [activateDockviewPanel, activateExistingFilePanel],
+    [activateDockviewPanel, activateExistingFilePanel, emitFileOpened],
   )
 
   const bridge = useMemo<WorkspaceBridge>(() => {
     return {
       getOpenPanels: () => getBridgeState().panels,
       getActiveFile: () => getBridgeState().activeFile,
+      getActiveFileResource: () => {
+        const api = apiRef.current
+        const panel = api?.activePanel
+        return fileBackedResource(
+          panel ? { id: panel.id, params: panel.params as Record<string, unknown> | undefined } : null,
+          fileBackedPanelIdsRef.current,
+        )
+      },
       getDirtyFiles: () => [],
       getVisibleFiles: () => getBridgeState().visibleFiles,
       openFile,
@@ -692,8 +769,8 @@ export function SurfaceShell({
         return ok()
       },
       navigateToLine: async () => err("UNSUPPORTED_BRIDGE_OPERATION", "navigateToLine is not supported by the surface-backed file tree bridge"),
-      expandToFile: async (path) => {
-        expandToFileSync(path)
+      expandToFile: async (path, options) => {
+        expandToFileSync(path, options)
         return ok()
       },
       markDirty: () => { throw new Error("markDirty is not supported by the surface-backed file tree bridge") },
@@ -706,7 +783,7 @@ export function SurfaceShell({
         }
         handlers.add(handler as (data: BridgeEventMap[keyof BridgeEventMap]) => void)
         if (event === "tree:expand" && pendingTreeExpandRef.current) {
-          handler({ path: pendingTreeExpandRef.current } as BridgeEventMap[K])
+          handler(pendingTreeExpandRef.current as BridgeEventMap[K])
           pendingTreeExpandRef.current = null
         }
         return () => {

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -10,13 +10,19 @@ import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../../../shared/types/surfa
 let capturedSurfaceStorageKey: string | undefined
 let capturedAllowedPanels: string[] | undefined
 let capturedWorkbenchBridge: any
+let capturedRevealRequest: any
+let capturedRevealRequests: any[] = []
 let mockAddPanel = vi.fn()
 let mockPanels: any[] = []
+let mockActivePanel: any = null
+let mockActivePanelChange: (() => void) | undefined
 let mockGetPanel: (id: string) => unknown = vi.fn(() => undefined)
 
 vi.mock("../../workbench-left/WorkbenchLeftPane", () => ({
   WorkbenchLeftPane: (props: any) => {
     capturedWorkbenchBridge = props.bridge
+    capturedRevealRequest = props.revealFileTreeRequest
+    if (props.revealFileTreeRequest) capturedRevealRequests.push(props.revealFileTreeRequest)
     return <div data-testid="mock-left-pane" />
   },
 }))
@@ -29,12 +35,15 @@ vi.mock("../ArtifactSurfacePane", async () => {
     React.useEffect(() => {
       props.onReady?.({
         panels: mockPanels,
-        activePanel: null,
+        get activePanel() { return mockActivePanel },
         getPanel: mockGetPanel,
         addPanel: mockAddPanel,
         onDidAddPanel: vi.fn(() => ({ dispose: vi.fn() })),
         onDidRemovePanel: vi.fn(() => ({ dispose: vi.fn() })),
-        onDidActivePanelChange: vi.fn(() => ({ dispose: vi.fn() })),
+        onDidActivePanelChange: vi.fn((callback: () => void) => {
+          mockActivePanelChange = callback
+          return { dispose: vi.fn() }
+        }),
       })
     }, [props.onReady])
     return <div data-testid="mock-artifact-surface" />
@@ -65,8 +74,12 @@ describe("SurfaceShell", () => {
     capturedSurfaceStorageKey = undefined
     capturedAllowedPanels = undefined
     capturedWorkbenchBridge = undefined
+    capturedRevealRequest = undefined
+    capturedRevealRequests = []
     mockAddPanel = vi.fn()
     mockPanels = []
+    mockActivePanel = null
+    mockActivePanelChange = undefined
     mockGetPanel = vi.fn(() => undefined)
     localStorage.clear()
   })
@@ -241,6 +254,8 @@ describe("SurfaceShell", () => {
 
     renderSurface("workspace-a", { onReady: (api) => { surface = api } }, panelRegistry, surfaceResolverRegistry)
     await waitFor(() => expect(surface).toBeDefined())
+    const opened = vi.fn()
+    capturedWorkbenchBridge.subscribe("file:opened", opened)
 
     act(() => {
       surface?.openSurface({ kind: WORKSPACE_OPEN_PATH_SURFACE_KIND, target: "data.csv", filesystem: "company_context" })
@@ -251,6 +266,89 @@ describe("SurfaceShell", () => {
       component: "hot-csv.panel",
       params: expect.objectContaining({ path: "data.csv", filesystem: "company_context" }),
     }))
+    expect(opened).toHaveBeenCalledWith({
+      path: "data.csv",
+      mode: "edit",
+      filesystem: "company_context",
+    })
+  })
+
+  it("synchronizes filesystem identity when an existing file-backed tab becomes active", async () => {
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("editor", { title: "Editor", placement: "center", component: () => null })
+    mockActivePanel = {
+      id: "file:company_context:policy.md",
+      component: "editor",
+      params: { path: "policy.md", filesystem: "company_context", __boringFileBacked: true },
+    }
+    mockPanels = [mockActivePanel]
+    renderSurface("workspace-a", {}, panelRegistry)
+    await waitFor(() => expect(mockActivePanelChange).toBeDefined())
+    const opened = vi.fn()
+    capturedWorkbenchBridge.subscribe("file:opened", opened)
+
+    act(() => mockActivePanelChange?.())
+
+    expect(opened).toHaveBeenCalledWith({
+      path: "policy.md",
+      mode: "edit",
+      filesystem: "company_context",
+    })
+    expect(capturedWorkbenchBridge.getActiveFileResource()).toEqual({
+      path: "policy.md",
+      filesystem: "company_context",
+    })
+  })
+
+  it("carries filesystem identity through file-open and reveal synchronization", async () => {
+    let surface: SurfaceShellApi | undefined
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("editor", { title: "Editor", placement: "center", component: () => null })
+    const surfaceResolverRegistry = new SurfaceResolverRegistry()
+    surfaceResolverRegistry.register("filesystem", {
+      kind: WORKSPACE_OPEN_PATH_SURFACE_KIND,
+      resolve: ({ target }) => ({ component: "editor", title: target, params: { path: target } }),
+    })
+    renderSurface(undefined, { onReady: (api) => { surface = api } }, panelRegistry, surfaceResolverRegistry)
+    await waitFor(() => expect(surface).toBeDefined())
+    const opened = vi.fn()
+    capturedWorkbenchBridge.subscribe("file:opened", opened)
+
+    act(() => {
+      surface?.openFile("/company/policy.md", { filesystem: "company_context" })
+    })
+    expect(opened).toHaveBeenCalledWith({
+      path: "/company/policy.md",
+      mode: "edit",
+      filesystem: "company_context",
+    })
+
+    act(() => {
+      surface?.expandToFile("/company/policy.md", { filesystem: "company_context" })
+    })
+    expect(capturedRevealRequests).toContainEqual({
+      path: "/company/policy.md",
+      seq: 1,
+      filesystem: "company_context",
+    })
+    await waitFor(() => expect(capturedRevealRequest).toBeNull())
+
+    act(() => {
+      surface?.expandToFile("/workspace/README.md", { filesystem: "user" })
+    })
+    expect(capturedRevealRequests).toContainEqual({
+      path: "/workspace/README.md",
+      seq: 2,
+      filesystem: "user",
+    })
+    await waitFor(() => expect(capturedRevealRequest).toBeNull())
+
+    const deliveredRequestCount = capturedRevealRequests.length
+    act(() => surface?.closeWorkbenchLeftPane())
+    fireEvent.click(screen.getAllByRole("button", { name: "Show workspace menu" })[0]!)
+    await waitFor(() => expect(screen.getByTestId("mock-left-pane")).toBeInTheDocument())
+    expect(capturedRevealRequests).toHaveLength(deliveredRequestCount)
+    expect(capturedRevealRequest).toBeNull()
   })
 
   it("auto-collapses the workbench source pane to the rail when opening a workspace-page panel", async () => {

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -17,7 +17,7 @@ import { PaneCollapseButton } from "../../layout/paneCollapseButton"
 import type { FileTreeBridge } from "../../bridge/types"
 import { useWorkspaceSourceRegistry } from "../../registry"
 import type { WorkspaceSourceConfig } from "../../registry/types"
-import type { LeftTabParams } from "../../../shared/plugins/types"
+import type { FileTreeRevealRequest, LeftTabParams } from "../../../shared/plugins/types"
 import { PluginErrorBoundary } from "../../plugin/PluginErrorBoundary"
 
 import {
@@ -40,7 +40,7 @@ export interface WorkbenchLeftPaneProps {
    */
   activePanelId?: string | null
   onActiveTabChange?: (tab: WorkbenchLeftTabId) => void
-  revealFileTreeRequest?: { path: string; seq: number } | null
+  revealFileTreeRequest?: FileTreeRevealRequest | null
   onOpenPanel?: (config: WorkbenchLeftPaneOpenPanelConfig) => void
   onReloadAgentPlugins?: () => void | Promise<unknown>
   onCollapse?: () => void

--- a/packages/workspace/src/front/chrome/workbench-left/useWorkspaceLeftPaneActions.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/useWorkspaceLeftPaneActions.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState, useSyncExternalStore, type R
 import { useRegistry, useWorkspaceSourceRegistry } from "../../registry"
 import type { PanelConfig, WorkspaceSourceConfig } from "../../registry/types"
 import { isWorkspacePagePlacement } from "../../../shared/types/panel"
+import type { FileTreeRevealRequest } from "../../../shared/plugins/types"
 
 export type WorkbenchLeftTabId = string
 
@@ -21,7 +22,7 @@ export interface UseWorkspaceLeftPaneActionsOptions {
   activeTab?: WorkbenchLeftTabId
   activePanelId?: string | null
   onActiveTabChange?: (tab: WorkbenchLeftTabId) => void
-  revealFileTreeRequest?: { path: string; seq: number } | null
+  revealFileTreeRequest?: FileTreeRevealRequest | null
   onOpenPanel?: (config: WorkspaceLeftPaneOpenPanelConfig) => void
   onReloadAgentPlugins?: () => void | Promise<unknown>
   onExpand?: (tab?: WorkbenchLeftTabId) => void

--- a/packages/workspace/src/front/testing/__tests__/testing.test.tsx
+++ b/packages/workspace/src/front/testing/__tests__/testing.test.tsx
@@ -60,9 +60,29 @@ describe("@hachej/boring-workspace/testing", () => {
     expect(selected).toHaveBeenCalledWith("/selected.ts")
     stop()
 
+    const identityOpened = vi.fn()
+    bridge.subscribe("file:opened", identityOpened)
     await bridge.openFile("/mode.ts", { mode: "view" })
-    const modePanel = bridge.getOpenPanels().find((panel) => panel.id === "file:/mode.ts")
-    expect(modePanel?.params?.mode).toBe("view")
+    const modePanel = bridge.getOpenPanels().find((panel) => panel.id === "file:user:/mode.ts")
+    expect(modePanel?.params).toEqual({ path: "/mode.ts", mode: "view", filesystem: "user" })
+    expect(identityOpened).toHaveBeenCalledWith({
+      path: "/mode.ts",
+      mode: "view",
+      filesystem: "user",
+    })
+    expect(bridge.getActiveFileResource?.()).toEqual({ path: "/mode.ts", filesystem: "user" })
+
+    identityOpened.mockClear()
+    await bridge.openFile("/policy.md", { filesystem: "company_context" })
+    expect(identityOpened).toHaveBeenCalledWith({
+      path: "/policy.md",
+      mode: "edit",
+      filesystem: "company_context",
+    })
+    expect(bridge.getActiveFileResource?.()).toEqual({
+      path: "/policy.md",
+      filesystem: "company_context",
+    })
   })
 
   it("renderPane wires provider tree + fixture-backed data without a real server", async () => {

--- a/packages/workspace/src/front/testing/createMockBridge.ts
+++ b/packages/workspace/src/front/testing/createMockBridge.ts
@@ -1,5 +1,6 @@
 import type { BridgeEventMap, CommandResult, WorkspaceBridge } from "../bridge/types"
 import type { WorkspaceState, PanelState } from "../store/types"
+import { normalizeUiFilesystem, uiFileResourceKey, type FilesystemId } from "../../shared/types/filesystem"
 
 type SpyFactory = <T extends (...args: any[]) => any>(implementation?: T) => any
 
@@ -76,6 +77,7 @@ export function createMockBridge(options: CreateMockBridgeOptions = {}): MockWor
     dirtyFiles: options.state?.dirtyFiles ? [...options.state.dirtyFiles] : [],
     visibleFiles: options.state?.visibleFiles ? [...options.state.visibleFiles] : [],
   }
+  let activeFilesystem: FilesystemId | undefined
 
   const listeners = new Map<keyof BridgeEventMap, Set<(payload: any) => void>>()
   const selectors = new Set<SelectorEntry<any>>()
@@ -106,7 +108,10 @@ export function createMockBridge(options: CreateMockBridgeOptions = {}): MockWor
 
   function mergeState(next: Partial<MockBridgeState>): void {
     if (next.openPanels) state.openPanels = [...next.openPanels]
-    if (next.activeFile !== undefined) state.activeFile = next.activeFile
+    if (next.activeFile !== undefined) {
+      state.activeFile = next.activeFile
+      activeFilesystem = undefined
+    }
     if (next.dirtyFiles) state.dirtyFiles = [...next.dirtyFiles]
     if (next.visibleFiles) state.visibleFiles = [...next.visibleFiles]
     notifySelectors()
@@ -115,19 +120,28 @@ export function createMockBridge(options: CreateMockBridgeOptions = {}): MockWor
   const bridge: MockWorkspaceBridge = {
     getOpenPanels: spy(() => [...state.openPanels]),
     getActiveFile: spy(() => state.activeFile),
+    getActiveFileResource: spy(() => state.activeFile
+      ? { path: state.activeFile, filesystem: normalizeUiFilesystem(activeFilesystem) }
+      : null),
     getDirtyFiles: spy(() => [...state.dirtyFiles]),
     getVisibleFiles: spy(() => [...state.visibleFiles]),
 
     openFile: spy(async (path, opts) => {
       if (!state.visibleFiles.includes(path)) state.visibleFiles.push(path)
       state.activeFile = path
-      const panelId = `file:${path}`
+      const filesystem = normalizeUiFilesystem(opts?.filesystem)
+      activeFilesystem = filesystem
+      const panelId = `file:${uiFileResourceKey({ filesystem, path })}`
       const mode = opts?.mode ?? "edit"
       if (!state.openPanels.some((panel) => panel.id === panelId)) {
-        state.openPanels.push({ id: panelId, component: "editor", params: { path, mode } })
+        state.openPanels.push({
+          id: panelId,
+          component: "editor",
+          params: { path, mode, filesystem },
+        })
       }
       notifySelectors()
-      emit("file:opened", { path, mode })
+      emit("file:opened", { path, mode, filesystem })
       return nextResult()
     }),
 
@@ -169,8 +183,8 @@ export function createMockBridge(options: CreateMockBridgeOptions = {}): MockWor
       return nextResult()
     }),
 
-    expandToFile: spy(async (path) => {
-      emit("tree:expand", { path })
+    expandToFile: spy(async (path, opts) => {
+      emit("tree:expand", { path, ...(opts?.filesystem ? { filesystem: opts.filesystem } : {}) })
       return nextResult()
     }),
 

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -34,6 +34,7 @@ export type {
   CatalogRow,
   CatalogSearchArgs,
   CatalogSearchResult,
+  FileTreeRevealRequest,
   LeftTabParams,
   LeftTabComponent,
   PluginProvider,

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/FileTreeView.tsx
@@ -71,7 +71,7 @@ import { events, userMeta } from "../../../../front/events"
 import { filesystemEvents } from "../../shared/events"
 import { normalizeUiFilesystem, type FilesystemId } from "../../../../shared/types/filesystem"
 import type { PaneProps } from "../../../../shared/types/panel"
-import type { LeftTabParams } from "../../../../shared/plugins/types"
+import type { FileTreeRevealRequest, LeftTabParams } from "../../../../shared/plugins/types"
 import { copyToClipboard } from "./clipboard"
 
 export { copyToClipboard } from "./clipboard"
@@ -119,7 +119,9 @@ export interface FileTreeViewProps {
   /** Already-debounced query. Empty/undefined means no filter. */
   searchQuery?: string
   bridge?: FileTreeBridge
-  revealFileTreeRequest?: { path: string; seq: number } | null
+  revealFileTreeRequest?: FileTreeRevealRequest | null
+  /** @internal Pane wrappers disable direct events and translate them into one-shot reveal props. */
+  subscribeToTreeExpand?: boolean
   filesystem?: FilesystemId
   access?: "readonly" | "readwrite"
   /**
@@ -186,6 +188,7 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
   searchQuery,
   bridge,
   revealFileTreeRequest,
+  subscribeToTreeExpand = true,
   filesystem = "user",
   access = "readwrite",
   ignoreNames = DEFAULT_TREE_IGNORE,
@@ -483,37 +486,43 @@ export const FileTreeView = forwardRef<FileTreeViewHandle, FileTreeViewProps>(fu
     [revealTreePath],
   )
 
+  const handledRevealRequestKeyRef = useRef<string | null>(null)
   useEffect(() => {
     if (!revealFileTreeRequest) return
+    const requestKey = `${revealFileTreeRequest.seq}:${revealFileTreeRequest.filesystem ?? ""}:${revealFileTreeRequest.path}`
+    if (handledRevealRequestKeyRef.current === requestKey) return
+    handledRevealRequestKeyRef.current = requestKey
     void revealExplicitTreePath(revealFileTreeRequest.path)
   }, [revealFileTreeRequest, revealExplicitTreePath])
 
   useEffect(() => {
-    const activeFile = bridge?.getActiveFile?.() ?? null
+    const activeFile = revealFileTreeRequest ? null : bridge?.getActiveFile?.() ?? null
     if (activeFile && explicitRevealSeqRef.current === 0) void revealTreePath(activeFile)
     const unsubscribers: Array<() => void> = []
     if (bridge?.select) {
       unsubscribers.push(
         bridge.select((state) => state.activeFile, (path) => {
           if (path) {
-            if (explicitRevealSeqRef.current === 0) void revealTreePath(path)
+            if (!revealFileTreeRequest && explicitRevealSeqRef.current === 0) void revealTreePath(path)
           } else {
             setSelectedPath(null)
           }
         }),
       )
     }
-    if (bridge?.subscribe) {
+    if (subscribeToTreeExpand && bridge?.subscribe) {
       unsubscribers.push(
-        bridge.subscribe("tree:expand", ({ path }) => {
-          void revealExplicitTreePath(path)
+        bridge.subscribe("tree:expand", ({ path, filesystem: requestFilesystem }) => {
+          if (!requestFilesystem || requestFilesystem === activeFilesystem) {
+            void revealExplicitTreePath(path)
+          }
         }),
       )
     }
     return () => {
       for (const unsubscribe of unsubscribers) unsubscribe()
     }
-  }, [bridge, revealExplicitTreePath, revealTreePath])
+  }, [activeFilesystem, bridge, revealExplicitTreePath, revealFileTreeRequest, revealTreePath, subscribeToTreeExpand])
 
   const addOptimisticEntry = useCallback((dir: string, entry: FileEntry) => {
     setOptimisticEntries((prev) => {
@@ -1019,7 +1028,7 @@ export interface FileTreePaneParams extends LeftTabParams {
   filesystem?: FilesystemId
   access?: "readonly" | "readwrite"
   roots?: FileTreeRootConfig[]
-  revealFileTreeRequest?: { path: string; seq: number } | null
+  revealFileTreeRequest?: FileTreeRevealRequest | null
 }
 
 export interface FileTreePaneProps extends Partial<PaneProps<FileTreePaneParams>> {
@@ -1058,7 +1067,17 @@ export function FileTreePane({
   const effectiveFilesystem = params?.filesystem ?? filesystem
   const effectiveAccess = params?.access ?? access
   const effectiveRoots = params?.roots ?? roots
-  const effectiveRevealRequest = params?.revealFileTreeRequest ?? null
+  const authoritativeRevealRequest = params?.revealFileTreeRequest ?? null
+  const [bridgeRevealRequest, setBridgeRevealRequest] = useState<FileTreeRevealRequest | null>(null)
+  const bridgeRevealSeqRef = useRef(0)
+  useEffect(() => {
+    if (!bridgeRevealRequest) return
+    setBridgeRevealRequest((current) => current?.seq === bridgeRevealRequest.seq ? null : current)
+  }, [bridgeRevealRequest])
+  useEffect(() => {
+    if (authoritativeRevealRequest) setBridgeRevealRequest(null)
+  }, [authoritativeRevealRequest])
+  const effectiveRevealRequest = authoritativeRevealRequest ?? bridgeRevealRequest
   const externalSearchQuery =
     params?.searchQuery ?? params?.query ?? controlledSearchQuery
   const effectivePanelApi = panelApi ?? api
@@ -1073,17 +1092,74 @@ export function FileTreePane({
       access: effectiveAccess,
     }]
   }, [effectiveAccess, effectiveFilesystem, effectiveRootDir, effectiveRoots])
-  const [selectedFilesystem, setSelectedFilesystem] = useState<FilesystemId>(rootOptions[0]?.filesystem ?? "user")
-  useEffect(() => {
-    const next = rootOptions.some((root) => root.filesystem === effectiveFilesystem)
+  const [selectedFilesystem, setSelectedFilesystem] = useState<FilesystemId>(() => (
+    rootOptions.some((root) => root.filesystem === effectiveFilesystem)
       ? effectiveFilesystem
       : rootOptions[0]?.filesystem ?? "user"
-    setSelectedFilesystem(next)
+  ))
+  useEffect(() => {
+    setSelectedFilesystem((current) => {
+      if (rootOptions.some((root) => root.filesystem === current)) return current
+      return rootOptions.some((root) => root.filesystem === effectiveFilesystem)
+        ? effectiveFilesystem
+        : rootOptions[0]?.filesystem ?? "user"
+    })
   }, [effectiveFilesystem, rootOptions])
+  const handledRevealRequestRef = useRef<string | null>(null)
+  useEffect(() => {
+    const requestedFilesystem = effectiveRevealRequest?.filesystem
+    if (!requestedFilesystem) return
+    const requestKey = `${effectiveRevealRequest.seq}:${requestedFilesystem}:${effectiveRevealRequest.path}`
+    if (handledRevealRequestRef.current === requestKey) return
+    if (!rootOptions.some((root) => root.filesystem === requestedFilesystem)) return
+    handledRevealRequestRef.current = requestKey
+    setSelectedFilesystem(requestedFilesystem)
+  }, [effectiveRevealRequest, rootOptions])
+  const handledActiveResourceRef = useRef<string | null>(null)
+  useEffect(() => {
+    const activeResource = effectiveBridge?.getActiveFileResource?.()
+    if (!activeResource) return
+    const resourceKey = `${activeResource.filesystem}:${activeResource.path}`
+    if (handledActiveResourceRef.current === resourceKey) return
+    if (!rootOptions.some((root) => root.filesystem === activeResource.filesystem)) return
+    handledActiveResourceRef.current = resourceKey
+    setSelectedFilesystem(activeResource.filesystem)
+  }, [effectiveBridge, rootOptions])
+  useEffect(() => {
+    if (!effectiveBridge?.subscribe) return
+    const selectConfiguredFilesystem = (nextFilesystem: FilesystemId | undefined) => {
+      if (nextFilesystem && rootOptions.some((root) => root.filesystem === nextFilesystem)) {
+        setSelectedFilesystem(nextFilesystem)
+      }
+    }
+    const unsubscribeOpened = effectiveBridge.subscribe("file:opened", ({ filesystem: openedFilesystem }) => {
+      selectConfiguredFilesystem(openedFilesystem)
+    })
+    const unsubscribeExpanded = effectiveBridge.subscribe("tree:expand", ({ path, filesystem: revealedFilesystem }) => {
+      if (revealedFilesystem && !rootOptions.some((root) => root.filesystem === revealedFilesystem)) return
+      selectConfiguredFilesystem(revealedFilesystem)
+      // SurfaceShell sends an authoritative prop request alongside its bridge
+      // event. The pane owns root synchronization, but must not retain a second
+      // reveal. Bridge-only callers get a temporary one-shot prop instead.
+      if (authoritativeRevealRequest) return
+      setBridgeRevealRequest({
+        path,
+        ...(revealedFilesystem ? { filesystem: revealedFilesystem } : {}),
+        seq: ++bridgeRevealSeqRef.current,
+      })
+    })
+    return () => {
+      unsubscribeOpened()
+      unsubscribeExpanded()
+    }
+  }, [authoritativeRevealRequest, effectiveBridge, rootOptions])
   const activeRoot = rootOptions.find((root) => root.filesystem === selectedFilesystem) ?? rootOptions[0]
   const activeFilesystem = activeRoot?.filesystem ?? "user"
   const activeRootDir = activeRoot?.rootDir ?? (activeFilesystem === "user" ? effectiveRootDir : "/")
   const activeAccess = activeRoot?.access ?? effectiveAccess
+  const activeRevealRequest = !effectiveRevealRequest?.filesystem || effectiveRevealRequest.filesystem === activeFilesystem
+    ? effectiveRevealRequest
+    : null
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   // `FileTreeView` remounts (via the `key` below) whenever the active root
@@ -1150,9 +1226,10 @@ export function FileTreePane({
               rootDir={activeRootDir}
               searchQuery={effectiveSearchQuery}
               bridge={effectiveBridge}
+              subscribeToTreeExpand={false}
               filesystem={activeFilesystem}
               access={activeAccess}
-              revealFileTreeRequest={effectiveRevealRequest}
+              revealFileTreeRequest={activeRevealRequest}
               className={cn("px-1 [&_[role=treeitem]]:!indent-0", className)}
             />
           </div>
@@ -1190,9 +1267,10 @@ export function FileTreePane({
             rootDir={activeRootDir}
             searchQuery={effectiveSearchQuery}
             bridge={effectiveBridge}
+            subscribeToTreeExpand={false}
             filesystem={activeFilesystem}
             access={activeAccess}
-            revealFileTreeRequest={effectiveRevealRequest}
+            revealFileTreeRequest={activeRevealRequest}
             className={cn("px-1 pt-1 [&_[role=treeitem]]:!indent-0", className)}
           />
         </div>
@@ -1243,9 +1321,10 @@ export function FileTreePane({
             rootDir={activeRootDir}
             searchQuery={effectiveSearchQuery}
             bridge={effectiveBridge}
+            subscribeToTreeExpand={false}
             filesystem={activeFilesystem}
             access={activeAccess}
-            revealFileTreeRequest={effectiveRevealRequest}
+            revealFileTreeRequest={activeRevealRequest}
             className={className}
           />
         </div>

--- a/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/file-tree/__tests__/FileTreePane.test.tsx
@@ -161,7 +161,7 @@ vi.mock("../FileTree", () => {
   }
 })
 
-import { FileTreePane, clampContextMenuPosition } from "../FileTreeView"
+import { FileTreePane, FileTreeView, clampContextMenuPosition } from "../FileTreeView"
 import { events, remoteMeta, userMeta } from "../../../../../front/events"
 import { filesystemEvents } from "../../../shared/events"
 
@@ -315,6 +315,245 @@ describe("FileTreePane", () => {
     expect(screen.queryByRole("menuitem", { name: "Delete" })).not.toBeInTheDocument()
     // ...but read actions remain available so the menu is still useful.
     expect(screen.getByRole("menuitem", { name: "Copy path" })).toBeInTheDocument()
+  })
+
+  it("honors a configured initial filesystem when it is not the first root", async () => {
+    render(
+      <FileTreePane
+        filesystem="company_context"
+        roots={[
+          { filesystem: "user", label: "Workspace", rootDir: "." },
+          { filesystem: "company_context", label: "Company", rootDir: "/" },
+        ]}
+      />,
+      { wrapper },
+    )
+
+    expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Company")
+  })
+
+  it("preserves a still-configured selected filesystem across equivalent roots-array rerenders", async () => {
+    const bridge = {
+      openFile: vi.fn().mockResolvedValue({ seq: 1, status: "ok" }),
+      select: vi.fn(() => vi.fn()),
+      getActiveFile: vi.fn(() => null),
+    }
+    const roots = () => [
+      { filesystem: "user" as const, label: "Workspace", rootDir: ".", access: "readwrite" as const },
+      { filesystem: "company_context" as const, label: "Company", rootDir: "/", access: "readonly" as const },
+    ]
+    const { rerender } = render(<FileTreePane bridge={bridge} roots={roots()} />, { wrapper })
+
+    await selectRoot("Company")
+    expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Company")
+
+    fireEvent.click(screen.getByText("index.ts"))
+    rerender(<FileTreePane bridge={bridge} roots={roots()} />)
+
+    expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Company")
+    expect(bridge.openFile).toHaveBeenCalledWith("index.ts", {
+      mode: "edit",
+      filesystem: "company_context",
+    })
+  })
+
+  it("falls back to the configured default when the selected filesystem is removed", async () => {
+    const { rerender } = render(
+      <FileTreePane
+        roots={[
+          { filesystem: "user", label: "Workspace", rootDir: "." },
+          { filesystem: "company_context", label: "Company", rootDir: "/" },
+        ]}
+      />,
+      { wrapper },
+    )
+
+    await selectRoot("Company")
+    rerender(
+      <FileTreePane
+        roots={[
+          { filesystem: "user", label: "Workspace", rootDir: "." },
+          { filesystem: "project_alpha", label: "Project", rootDir: "/" },
+        ]}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Workspace")
+    })
+  })
+
+  it("selects the explicit filesystem for reveal requests without sending the request to another root", async () => {
+    const { rerender } = render(
+      <FileTreePane
+        params={{ revealFileTreeRequest: { path: "src", seq: 1, filesystem: "company_context" } }}
+        roots={[
+          { filesystem: "user", label: "Workspace", rootDir: "." },
+          { filesystem: "company_context", label: "Company", rootDir: "/" },
+        ]}
+      />,
+      { wrapper },
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Company")
+      expect(screen.getByTestId("file-tree")).toHaveAttribute("data-reveal", "src")
+    })
+
+    await selectRoot("Workspace")
+    rerender(
+      <FileTreePane
+        params={{ revealFileTreeRequest: { path: "src", seq: 1, filesystem: "company_context" } }}
+        roots={[
+          { filesystem: "user", label: "Workspace", rootDir: "." },
+          { filesystem: "company_context", label: "Company", rootDir: "/" },
+        ]}
+      />,
+    )
+    expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Workspace")
+    expect(screen.getByTestId("file-tree")).toHaveAttribute("data-reveal", "")
+  })
+
+  it("uses an authoritative prop reveal only once when the matching bridge event also arrives", async () => {
+    const expandHandlers: Array<(payload: { filesystem?: string; path: string }) => void> = []
+    const bridge = {
+      openFile: vi.fn(),
+      getActiveFile: vi.fn(() => null),
+      select: vi.fn(() => vi.fn()),
+      subscribe: vi.fn((event: string, handler: (payload: { filesystem?: string; path: string }) => void) => {
+        if (event === "tree:expand") expandHandlers.push(handler)
+        return vi.fn()
+      }),
+    }
+    mockGetTree.mockClear()
+    render(
+      <FileTreePane
+        params={{
+          bridge,
+          revealFileTreeRequest: { path: "src", seq: 1, filesystem: "user" },
+        }}
+        roots={[
+          { filesystem: "user", label: "Workspace", rootDir: "." },
+          { filesystem: "company_context", label: "Company", rootDir: "/" },
+        ]}
+      />,
+      { wrapper },
+    )
+
+    act(() => {
+      for (const handler of expandHandlers) handler({ filesystem: "user", path: "src" })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("file-tree")).toHaveAttribute("data-reveal", "src")
+    })
+    expect(mockGetTree.mock.calls.filter(([path]) => path === "src")).toHaveLength(1)
+  })
+
+  it("keeps standalone FileTreeView bridge expansion behavior", async () => {
+    const expandHandlers: Array<(payload: { filesystem?: string; path: string }) => void> = []
+    const bridge = {
+      openFile: vi.fn(),
+      getActiveFile: vi.fn(() => null),
+      select: vi.fn(() => vi.fn()),
+      subscribe: vi.fn((event: string, handler: (payload: { filesystem?: string; path: string }) => void) => {
+        if (event === "tree:expand") expandHandlers.push(handler)
+        return vi.fn()
+      }),
+    }
+    mockGetTree.mockClear()
+    render(<FileTreeView bridge={bridge as any} filesystem="user" />, { wrapper })
+
+    act(() => {
+      for (const handler of expandHandlers) handler({ filesystem: "user", path: "src" })
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("file-tree")).toHaveAttribute("data-reveal", "src")
+    })
+    expect(mockGetTree.mock.calls.filter(([path]) => path === "src")).toHaveLength(1)
+  })
+
+  it("synchronizes the selected root from identity-bearing open and expand events", async () => {
+    const handlers = new Map<string, Set<(payload: { filesystem?: string; path: string }) => void>>()
+    const bridge = {
+      openFile: vi.fn().mockResolvedValue({ seq: 1, status: "ok" }),
+      getActiveFile: vi.fn(() => null),
+      select: vi.fn(() => vi.fn()),
+      subscribe: vi.fn((event: string, handler: (payload: { filesystem?: string; path: string }) => void) => {
+        const eventHandlers = handlers.get(event) ?? new Set()
+        eventHandlers.add(handler)
+        handlers.set(event, eventHandlers)
+        return () => eventHandlers.delete(handler)
+      }),
+    }
+    render(
+      <FileTreePane
+        bridge={bridge as any}
+        roots={[
+          { filesystem: "user", label: "Workspace", rootDir: "." },
+          { filesystem: "company_context", label: "Company", rootDir: "/" },
+        ]}
+      />,
+      { wrapper },
+    )
+
+    mockGetTree.mockClear()
+    act(() => {
+      for (const handler of handlers.get("tree:expand") ?? []) {
+        handler({ filesystem: "user", path: "src" })
+      }
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("file-tree")).toHaveAttribute("data-reveal", "src")
+    })
+    expect(mockGetTree.mock.calls.filter(([path]) => path === "src")).toHaveLength(1)
+
+    act(() => {
+      for (const handler of handlers.get("file:opened") ?? []) {
+        handler({ filesystem: "company_context", path: "policy.md" })
+      }
+    })
+    expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Company")
+
+    act(() => {
+      for (const handler of handlers.get("file:opened") ?? []) handler({ path: "legacy.md" })
+    })
+    expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Company")
+
+    act(() => {
+      for (const handler of handlers.get("tree:expand") ?? []) {
+        handler({ filesystem: "user", path: "src" })
+      }
+    })
+    await waitFor(() => {
+      expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Workspace")
+      expect(screen.getByTestId("file-tree")).toHaveAttribute("data-reveal", "src")
+    })
+
+    await selectRoot("Company")
+    await selectRoot("Workspace")
+    expect(screen.getByTestId("file-tree")).toHaveAttribute("data-reveal", "")
+  })
+
+  it("restores the active file resource on mount without overriding a later valid selection", async () => {
+    const bridge = {
+      openFile: vi.fn(),
+      getActiveFile: vi.fn(() => "policy.md"),
+      getActiveFileResource: vi.fn(() => ({ filesystem: "company_context", path: "policy.md" })),
+      select: vi.fn(() => vi.fn()),
+    }
+    const roots = () => [
+      { filesystem: "user" as const, label: "Workspace", rootDir: "." },
+      { filesystem: "company_context" as const, label: "Company", rootDir: "/" },
+    ]
+    const { rerender } = render(
+      <FileTreePane bridge={bridge as any} roots={roots()} />,
+      { wrapper },
+    )
+
+    expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Company")
+    await selectRoot("Workspace")
+    rerender(<FileTreePane bridge={bridge as any} roots={roots()} />)
+    expect(screen.getByRole("combobox", { name: "File root" })).toHaveTextContent("Workspace")
   })
 
   it("remounts the tree when switching configured filesystems so expanded path state cannot leak", async () => {
@@ -613,12 +852,12 @@ describe("FileTreePane", () => {
   })
 
   it("tree expand bridge events reveal folders without opening an editor", async () => {
-    let expandHandler: ((payload: { path: string }) => void) | null = null
+    const expandHandlers: Array<(payload: { path: string }) => void> = []
     const bridge = {
       getActiveFile: () => null,
       openFile: vi.fn().mockResolvedValue({ seq: 1, status: "ok" }),
       subscribe: vi.fn((event, handler) => {
-        if (event === "tree:expand") expandHandler = handler
+        if (event === "tree:expand") expandHandlers.push(handler)
         return vi.fn()
       }),
     }
@@ -627,7 +866,9 @@ describe("FileTreePane", () => {
     await waitFor(() => expect(screen.getByTestId("file-tree")).toBeInTheDocument())
     await waitFor(() => expect(bridge.subscribe).toHaveBeenCalled())
 
-    act(() => expandHandler?.({ path: "/src//" }))
+    act(() => {
+      for (const handler of expandHandlers) handler({ path: "/src//" })
+    })
 
     await waitFor(() => {
       expect(screen.getByTestId("file-tree")).toHaveAttribute("data-selected", "src")
@@ -638,12 +879,12 @@ describe("FileTreePane", () => {
 
   it("refreshes an expanded folder when an agent/remote change lands inside it", async () => {
     mockGetTree.mockResolvedValue([{ name: "old.ts", kind: "file", path: "src/old.ts" }])
-    let expandHandler: ((payload: { path: string }) => void) | null = null
+    const expandHandlers: Array<(payload: { path: string }) => void> = []
     const bridge = {
       getActiveFile: () => null,
       openFile: vi.fn().mockResolvedValue({ seq: 1, status: "ok" }),
       subscribe: vi.fn((event, handler) => {
-        if (event === "tree:expand") expandHandler = handler
+        if (event === "tree:expand") expandHandlers.push(handler)
         return vi.fn()
       }),
     }
@@ -655,7 +896,9 @@ describe("FileTreePane", () => {
     // Expand "src" so its children live in local state (not react-query).
     // Wait for the child to actually render — that guarantees expandedChildren
     // committed (getTree is called synchronously, before its promise resolves).
-    act(() => expandHandler?.({ path: "src" }))
+    act(() => {
+      for (const handler of expandHandlers) handler({ path: "src" })
+    })
     await screen.findByText("old.ts")
     mockGetTree.mockClear()
 
@@ -723,9 +966,14 @@ describe("FileTreePane", () => {
   })
 
   it("keeps explicit folder reveal ahead of active-file reveal when sources remount", async () => {
+    let emitActiveFile: ((path: string | null) => void) | undefined
     const bridge = {
       getActiveFile: () => "index.ts",
       openFile: vi.fn().mockResolvedValue({ seq: 1, status: "ok" }),
+      select: vi.fn((_selector, onChange: (path: string | null) => void) => {
+        emitActiveFile = onChange
+        return () => {}
+      }),
     }
 
     render(
@@ -743,6 +991,8 @@ describe("FileTreePane", () => {
       expect(screen.getByTestId("file-tree")).toHaveAttribute("data-reveal", "src")
     })
     expect(screen.getByTestId("file-tree")).not.toHaveAttribute("data-selected", "index.ts")
+    act(() => emitActiveFile?.("index.ts"))
+    expect(screen.getByTestId("file-tree")).toHaveAttribute("data-selected", "src")
     expect(bridge.openFile).not.toHaveBeenCalled()
   })
 

--- a/packages/workspace/src/server/__tests__/uiTools.test.ts
+++ b/packages/workspace/src/server/__tests__/uiTools.test.ts
@@ -191,6 +191,22 @@ describe("createExecUiTool — path validation", () => {
     expect(result.isError).toBe(true)
   })
 
+  test("expandToFile with company_context bypasses user workspace checks and preserves identity", async () => {
+    const tool = createExecUiTool(bridge, { workspaceRoot })
+    const result = await tool.execute(
+      { kind: "expandToFile", params: { path: "/company/hr", filesystem: "company_context" } },
+      FAKE_CTX,
+    )
+
+    expect(result.isError).toBeFalsy()
+    await expect(bridge.drainCommands!()).resolves.toEqual([
+      expect.objectContaining({
+        kind: "expandToFile",
+        params: { path: "/company/hr", filesystem: "company_context" },
+      }),
+    ])
+  })
+
   test("exec_ui advertises openSurface filesystem", () => {
     const tool = createExecUiTool(bridge, { workspaceRoot })
     const parameters = tool.parameters as {
@@ -200,6 +216,7 @@ describe("createExecUiTool — path validation", () => {
     expect(kind?.enum).toContain("openSurface")
     expect(tool.description).toContain("openSurface  params: { kind: string, target: string, filesystem?: 'user'|'company_context', meta?: object }")
     expect(tool.description).toContain("For kind:'workspace.open.path', filesystem follows")
+    expect(tool.description).toContain("expandToFile params: { path: string, filesystem?: 'user'|'company_context' }")
   })
 
   test("non-path kinds (openPanel, openSurface, showNotification, closeWorkbenchLeftPane) do not get path-validated", async () => {

--- a/packages/workspace/src/server/ui-control/tools/uiTools.ts
+++ b/packages/workspace/src/server/ui-control/tools/uiTools.ts
@@ -276,7 +276,7 @@ export function createExecUiTool(
       "               — Hide the workbench's left sources/files pane while",
       "                 keeping the workbench itself open.",
       "  navigateToLine params: { file: string, line: number }",
-      "  expandToFile params: { path: string }",
+      "  expandToFile params: { path: string, filesystem?: 'user'|'company_context' }",
       "  showNotification params: { msg: string, level?: 'info'|'warn'|'error' }",
       "",
       "Returns { seq, status, uiState? }. For openFile / openPanel / openSurface /",
@@ -358,7 +358,7 @@ export function createExecUiTool(
             `${kind}: ${kind === "navigateToLine" ? "file" : "path"} param is required`,
           )
         }
-        const filesystem = kind === "openFile"
+        const filesystem = kind === "openFile" || kind === "expandToFile"
           ? normalizeUiFilesystem(typeof cmdParams.filesystem === "string" ? cmdParams.filesystem : undefined)
           : USER_FILESYSTEM_ID
         const syntax = validatePathSyntax(relPath, workspaceRoot, { allowAbsolute: filesystem !== USER_FILESYSTEM_ID })

--- a/packages/workspace/src/shared/plugins/index.ts
+++ b/packages/workspace/src/shared/plugins/index.ts
@@ -14,6 +14,7 @@ export type {
   CatalogRow,
   CatalogSearchArgs,
   CatalogSearchResult,
+  FileTreeRevealRequest,
   LeftTabParams,
   LeftTabComponent,
   PluginProvider,

--- a/packages/workspace/src/shared/plugins/types.ts
+++ b/packages/workspace/src/shared/plugins/types.ts
@@ -6,6 +6,7 @@ import type {
   ToolResult,
 } from "../types/agent-tool"
 import type { PaneProps, PanelConfig, WorkspaceSourceProps } from "../types/panel"
+import type { FilesystemId } from "../types/filesystem"
 
 export type {
   AgentTool,
@@ -88,6 +89,12 @@ export interface CatalogConfig {
   pluginId?: string
 }
 
+export interface FileTreeRevealRequest {
+  path: string
+  seq: number
+  filesystem?: FilesystemId
+}
+
 export interface LeftTabParams {
   rootDir?: string
   query?: string
@@ -96,7 +103,7 @@ export interface LeftTabParams {
   chromeless?: boolean
   /** Optional DOM target for left-tab toolbar actions owned by the pane. */
   chromeActionsElement?: Element | null
-  revealFileTreeRequest?: { path: string; seq: number } | null
+  revealFileTreeRequest?: FileTreeRevealRequest | null
 }
 
 export type LeftTabComponent = ComponentType<WorkspaceSourceProps<LeftTabParams>>

--- a/packages/workspace/src/shared/ui-bridge.ts
+++ b/packages/workspace/src/shared/ui-bridge.ts
@@ -24,7 +24,7 @@ export type UiCommand =
   | { kind: 'closeWorkbenchLeftPane'; params: Record<string, never> }
   | { kind: 'showNotification'; params: { msg: string; level?: 'info' | 'warn' | 'error' } }
   | { kind: 'navigateToLine'; params: { file: string; line: number } }
-  | { kind: 'expandToFile'; params: { path: string } }
+  | { kind: 'expandToFile'; params: { path: string; filesystem?: FilesystemId } }
   | { kind: string; params: Record<string, unknown> }
 
 export interface CommandResult {


### PR DESCRIPTION
Closes #996.

## Summary

- preserves a valid selected filesystem when hosts recreate equivalent roots arrays
- honors an explicitly configured initial/default filesystem and falls back only when the selected root disappears
- carries optional filesystem identity through open, reveal, bridge, link, mock, and agent UI-tool paths
- synchronizes the Files root for filesystem-aware openSurface, active file tabs, file-open events, and tree expansion
- keeps path-only callers backward-compatible by normalizing them to `user`
- makes reveal delivery one-shot, monotonic, and non-replaying across source/root remounts
- prevents prop/event duplicate reveals while preserving standalone FileTreeView bridge behavior
- adds a distinct-root browser scenario that verifies filesystem-qualified reads, visible tabs/content, and selector stability

## Independence

This PR is independent of #1000/#995. It fixes root selection and reveal/open synchronization only; it does not change search aggregation.

## Validation

- FileTreePane/FileTreeView: 88 focused tests
- Workspace focused suites: 216 + 30 tests in earlier validation
- SurfaceShell/mock focused suites: 19 tests
- Workspace typecheck
- Workspace playground typecheck
- production dependency builds
- multi-filesystem Playwright using distinct Workspace and Company fixture roots
- `git diff --check`
- multiple independent review/fix rounds; final targeted review returned CLEAN

## Compatibility

- path-only public callers remain supported and resolve to `user`
- filesystem-aware callers retain `{ filesystem, path }` identity
- mocks now match production bridge normalization
- generated browser fixtures are ignored/cleaned
