### PR TITLE
#909 refactor(console): simplify left pane to Agents / Pinned / Chats

### DIFF
--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -112,7 +112,18 @@ test.describe("addressed Agent Host browser wire", () => {
     )
     await expect(betaChatRow).toBeVisible()
     await expect(alphaChatRow).toBeVisible()
+    await expect(betaChatRow.locator('[data-boring-agent-badge="beta"]')).toBeVisible()
+    await expect(alphaChatRow.locator('[data-boring-agent-badge="alpha"]')).toBeVisible()
     await expect(alphaChatRow).toHaveAttribute("data-boring-session-state", "active")
+
+    const filter = chats.getByRole("button", { name: "Filter chats by agent" })
+    await filter.click()
+    await page.getByRole("menuitemradio", { name: "Alpha" }).click()
+    await expect(alphaChatRow).toBeVisible()
+    await expect(betaChatRow).toHaveCount(0)
+    await filter.click()
+    await page.getByRole("menuitemradio", { name: "All agents" }).click()
+    await expect(betaChatRow).toBeVisible()
 
     await betaChatRow.hover()
     await betaChatRow.getByRole("button", { name: /^Pin / }).click()
@@ -122,12 +133,7 @@ test.describe("addressed Agent Host browser wire", () => {
     )
     await expect(pinnedBetaRow).toBeVisible()
     await expect(pinnedBetaRow.locator('[data-boring-agent-badge="beta"]')).toBeVisible()
-
-    const betaAgent = page.getByRole("region", { name: "Beta agent" })
-    await betaAgent.getByRole("button", { name: "Collapse Beta agent" }).click()
-    await expect(betaAgent.locator(
-      `[data-boring-workspace-part="app-left-agent-sessions"] [data-boring-session-id="${betaSessionId}"]`,
-    )).toHaveCount(0)
+    await expect(betaChatRow).toHaveCount(0)
     await expect(pinnedBetaRow).toBeVisible()
   })
 
@@ -300,7 +306,7 @@ test.describe("addressed Agent Host browser wire", () => {
     await page.reload({ waitUntil: "domcontentloaded" })
     await expect(
       page
-        .getByRole("region", { name: "Alpha agent" })
+        .getByRole("region", { name: "Chats" })
         .locator(
           `[data-boring-workspace-part="app-session-row"][data-boring-session-id="${alphaSessionId}"][data-boring-agent-type-id="alpha"]`,
         ),

--- a/apps/workspace-playground/e2e/native-session-regressions.spec.ts
+++ b/apps/workspace-playground/e2e/native-session-regressions.spec.ts
@@ -83,7 +83,7 @@ test.describe("native addressed session regressions", () => {
     const nativeSessionId = await sendFirstMessage(page, chat, composer, localSessionId, prompt)
 
     const row = page
-      .getByRole("region", { name: "Alpha agent" })
+      .getByRole("region", { name: "Chats" })
       .locator(
         `[data-boring-workspace-part="app-session-row"][data-boring-session-id="${nativeSessionId}"][data-boring-agent-type-id="alpha"]`,
       )

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1435,7 +1435,6 @@ export function WorkspaceAgentFront<
           bottomSlot={showThemeToggle || topBarRight != null ? <div className="flex w-full min-w-0 items-center gap-2">{topBarRightContent}</div> : undefined}
           sessions={appLeftSessions}
           agents={multiAgentConsoleEnabled ? appLeftAgents : undefined}
-          activeAgentTypeId={multiAgentConsoleEnabled ? agentTypeId : undefined}
           activeSessionRef={activeChatPaneRef}
           muteActiveSession={Boolean(leftOverlay)}
           openSessionRefs={openChatPaneRefs}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -589,12 +589,11 @@ describe("WorkspaceAgentFront", () => {
 
     await waitFor(() => expect(screen.getByTestId("agent-chat-alpha-a1")).toBeInTheDocument())
     expect(screen.getByLabelText("Chat session Alpha · Alpha one")).toBeInTheDocument()
-    const alphaAgent = screen.getByRole("region", { name: "Alpha agent" })
-    await user.click(within(alphaAgent).getByRole("button", { name: "Alpha two" }))
+    const chats = screen.getByRole("region", { name: "Chats" })
+    await user.click(within(chats).getByRole("button", { name: "Alpha two" }))
     await waitFor(() => expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument())
 
-    await user.click(screen.getByRole("button", { name: "Expand Beta agent" }))
-    await user.click(screen.getByText("Beta one"))
+    await user.click(within(chats).getByRole("button", { name: "Beta one" }))
     await waitFor(() => expect(screen.getByTestId("agent-chat-beta-b1")).toBeInTheDocument())
     expect(screen.getByLabelText("Chat session Beta · Beta one")).toBeInTheDocument()
     expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument()
@@ -602,7 +601,7 @@ describe("WorkspaceAgentFront", () => {
 
     await user.click(screen.getByText("Beta two"))
     await waitFor(() => expect(screen.getByTestId("agent-chat-beta-b2")).toBeInTheDocument())
-    await user.click(within(alphaAgent).getByRole("button", { name: "Alpha two" }))
+    await user.click(within(chats).getByRole("button", { name: "Alpha two" }))
 
     await waitFor(() => {
       expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument()
@@ -617,7 +616,7 @@ describe("WorkspaceAgentFront", () => {
       expect(screen.getByTestId("agent-chat-beta-b1").closest('[data-boring-workspace-part="chat-pane"]')).toHaveAttribute("data-boring-state", "active")
     })
 
-    await user.click(within(alphaAgent).getByRole("button", { name: "Alpha two" }))
+    await user.click(within(chats).getByRole("button", { name: "Alpha two" }))
     await user.click(screen.getByRole("button", { name: "Split Beta · Beta one chat vertically" }))
     expect(createdForAgents).toEqual(["beta"])
   })
@@ -692,7 +691,7 @@ describe("WorkspaceAgentFront", () => {
     const alphaComposer = await screen.findByRole("textbox", { name: "Composer alpha/alpha-session" })
     expect(screen.getByRole("button", { name: "Agents" })).toHaveAttribute("aria-expanded", "true")
     const betaAgent = screen.getByRole("region", { name: "Beta agent" })
-    expect(within(betaAgent).getByRole("button", { name: "Expand Beta agent" })).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByRole("button", { name: "Expand Beta agent" })).not.toBeInTheDocument()
     await user.click(within(betaAgent).getByRole("button", { name: "New chat with Beta" }))
 
     expect(screen.queryByRole("textbox", { name: /Composer beta\/default/ })).not.toBeInTheDocument()
@@ -701,8 +700,8 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => {
       expect(screen.getByRole("textbox", { name: "Composer beta/beta-first" })).toBeVisible()
     })
-    expect(within(betaAgent).getByRole("button", { name: "Collapse Beta agent" })).toHaveAttribute("aria-expanded", "true")
-    const betaFirstRow = within(betaAgent).getByText("Beta first").closest('[data-boring-workspace-part="app-session-row"]')
+    const chats = screen.getByRole("region", { name: "Chats" })
+    const betaFirstRow = within(chats).getByText("Beta first").closest('[data-boring-workspace-part="app-session-row"]')
     expect(betaFirstRow).toHaveAttribute("data-boring-session-state", "active")
     expect(within(betaFirstRow as HTMLElement).getByRole("button", { name: "Beta first" })).toHaveAttribute("aria-current", "page")
     await waitFor(() => expect(alphaComposer).not.toBeInTheDocument())
@@ -995,14 +994,13 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
-    await user.click(screen.getByRole("button", { name: "Expand Beta agent" }))
     await screen.findByText("beta session")
     await user.click(screen.getByLabelText("Open beta session in split"))
     await waitFor(() => expect(screen.getByTestId("catalog-pane-beta")).toBeInTheDocument())
     await user.click(screen.getByRole("button", { name: "New chat with Beta" }))
     expect(betaCreateStarted).toHaveBeenCalledOnce()
 
-    await user.click(within(screen.getByRole("region", { name: "Alpha agent" })).getByRole("button", { name: "alpha session" }))
+    await user.click(within(screen.getByRole("region", { name: "Chats" })).getByRole("button", { name: "alpha session" }))
     act(() => failAlphaSource())
     act(() => removeBeta())
 
@@ -1071,7 +1069,6 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
-    await user.click(screen.getByRole("button", { name: "Expand Beta agent" }))
     await screen.findByText("Beta shared")
     expect(screen.queryByRole("combobox", { name: "Agent" })).not.toBeInTheDocument()
     await user.click(screen.getByLabelText("More options for Beta shared"))
@@ -1080,8 +1077,9 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => {
       expect(betaDelete).toHaveBeenCalledWith("shared")
       expect(alphaDelete).not.toHaveBeenCalled()
-      expect(within(screen.getByRole("region", { name: "Alpha agent" })).getByText("Alpha shared")).toBeInTheDocument()
-      expect(within(screen.getByRole("region", { name: "Beta agent" })).queryByText("Beta shared")).not.toBeInTheDocument()
+      const chats = screen.getByRole("region", { name: "Chats" })
+      expect(within(chats).getByText("Alpha shared")).toBeInTheDocument()
+      expect(within(chats).queryByText("Beta shared")).not.toBeInTheDocument()
     })
   })
 
@@ -1154,7 +1152,6 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
-    await user.click(screen.getByRole("button", { name: "Expand Beta agent" }))
     await screen.findByText("Beta shared")
     await user.click(screen.getByLabelText("Open Beta shared in split"))
     await waitFor(() => {
@@ -1223,7 +1220,10 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => expect(screen.getByTestId("canonical-wire")).toHaveTextContent("alpha/alpha-second"))
     act(() => selectAgent("beta"))
     await waitFor(() => {
-      expect(screen.getByText("No chats yet.")).toBeInTheDocument()
+      const chats = screen.getByRole("region", { name: "Chats" })
+      expect(within(chats).getByText("alpha first")).toBeInTheDocument()
+      expect(within(chats).getByText("alpha second")).toBeInTheDocument()
+      expect(within(chats).queryByText("beta first")).not.toBeInTheDocument()
     })
     act(() => selectAgent("alpha"))
     await waitFor(() => expect(screen.getByTestId("canonical-wire")).toHaveTextContent("alpha/alpha-second"))
@@ -1379,7 +1379,6 @@ describe("WorkspaceAgentFront", () => {
       />,
     )
 
-    await user.click(screen.getByRole("button", { name: "Expand Beta agent" }))
     await screen.findByText("beta session")
     await user.click(screen.getByLabelText("Open beta session in split"))
     await waitFor(() => expect(screen.getByRole("button", { name: "Complete beta" })).toBeInTheDocument())

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,7 +1,14 @@
 "use client"
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
-import { Plus, Search } from "lucide-react"
+import { ChevronDown, Plus, Search } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@hachej/boring-ui-kit"
 import { AppLeftPaneHeader } from "./AppLeftPaneHeader"
 import { SingleAgentNewChatAction, PrimaryAction, NewChatAction, KbdHint } from "./AppLeftPaneActions"
 import { AgentSessionEmptyState, AppLeftPaneAgentGroup } from "./AppLeftPaneAgentGroup"
@@ -87,8 +94,6 @@ export interface AppLeftPaneProps {
   activeSessionId?: string | null
   /** Structured Workspace-internal active session ref. */
   activeSessionRef?: WorkspaceSessionRef | null
-  /** Selected addressed agent, including when it has no active session yet. */
-  activeAgentTypeId?: string
   /** When an app-left overlay is active, the overlay owns the selected nav state. */
   muteActiveSession?: boolean
   /** Raw legacy native session ids. */
@@ -121,6 +126,19 @@ export interface AppLeftPaneProps {
 type SessionRowState = AppSessionRowState
 
 const CHAT_SESSION_STATUS_EVENT = "boring:chat-session-status"
+const ALL_AGENTS_FILTER_VALUE = "all"
+const AGENT_FILTER_VALUE_PREFIX = "agent:"
+
+function agentFilterValue(agentTypeId: string): string {
+  return `${AGENT_FILTER_VALUE_PREFIX}${agentTypeId}`
+}
+
+function sessionUpdatedAt(session: AppLeftPaneSession): number {
+  if (typeof session.updatedAt === "number") return session.updatedAt
+  if (typeof session.updatedAt !== "string") return 0
+  const timestamp = Date.parse(session.updatedAt)
+  return Number.isNaN(timestamp) ? 0 : timestamp
+}
 
 function useWorkingSessions(
   sessions: readonly AppLeftPaneSession[],
@@ -218,7 +236,6 @@ export function AppLeftPane({
   agents = [],
   activeSessionId,
   activeSessionRef,
-  activeAgentTypeId: selectedAgentTypeId,
   muteActiveSession = false,
   openSessionIds = [],
   openSessionRefs,
@@ -275,12 +292,6 @@ export function AppLeftPane({
     [normalizedPinnedSessionIds, sessions],
   )
   const showSharedPinnedSessions = agents.length === 0 || multiAgent
-  const openSessions = useMemo(
-    () => normalizedOpenSessionIds
-      .map((id) => sessions.find((session) => workspaceSessionKeyFor(session) === id))
-      .filter((session): session is AppLeftPaneSession => Boolean(session)),
-    [normalizedOpenSessionIds, sessions],
-  )
   const agentLabelByTypeId = useMemo(
     () => new Map(agents.map((agent) => [agent.agentTypeId, agent.label])),
     [agents],
@@ -334,35 +345,20 @@ export function AppLeftPane({
     () => projectItems.filter((project) => !pinnedProjectSet.has(project.id)),
     [projectItems, pinnedProjectSet],
   )
-  const activeAgentTypeId = selectedAgentTypeId
-    ?? activeSessionRef?.agentTypeId
-    ?? sessions.find((session) => workspaceSessionKeyFor(session) === normalizedActiveSessionId)?.agentTypeId
-  const [expandedAgentTypeIds, setExpandedAgentTypeIds] = useState<ReadonlySet<string>>(() => {
-    const seed = activeAgentTypeId ?? agents[0]?.agentTypeId
-    return new Set(seed ? [seed] : [])
-  })
-  useEffect(() => {
-    const available = new Set(agents.map((agent) => agent.agentTypeId))
-    setExpandedAgentTypeIds((current) => {
-      const next = new Set([...current].filter((agentTypeId) => available.has(agentTypeId)))
-      if (activeAgentTypeId) next.add(activeAgentTypeId)
-      if (
-        next.size === current.size
-        && [...next].every((agentTypeId) => current.has(agentTypeId))
-      ) return current
-      return next
-    })
-  }, [activeAgentTypeId, agents])
-  const setAgentExpanded = (agentTypeId: string, expanded: boolean) => {
-    setExpandedAgentTypeIds((current) => {
-      if (current.has(agentTypeId) === expanded) return current
-      const next = new Set(current)
-      if (expanded) next.add(agentTypeId)
-      else next.delete(agentTypeId)
-      return next
-    })
-  }
-  const expandAgent = (agentTypeId: string) => setAgentExpanded(agentTypeId, true)
+  const [chatAgentFilter, setChatAgentFilter] = useState<string | null>(null)
+  const effectiveChatAgentFilter = chatAgentFilter && agentLabelByTypeId.has(chatAgentFilter)
+    ? chatAgentFilter
+    : null
+  const recencyOrderedRegularSessions = useMemo(
+    () => [...regularSessions].sort((left, right) => sessionUpdatedAt(right) - sessionUpdatedAt(left)),
+    [regularSessions],
+  )
+  const filteredRegularSessions = useMemo(
+    () => effectiveChatAgentFilter
+      ? recencyOrderedRegularSessions.filter((session) => session.agentTypeId === effectiveChatAgentFilter)
+      : recencyOrderedRegularSessions,
+    [effectiveChatAgentFilter, recencyOrderedRegularSessions],
+  )
   const headerVisible = headerMode !== "hidden" && (layoutMode !== "multi-project" || headerMode === "workspace")
   const headerShowsBrand = headerMode === "full" && layoutMode !== "multi-project"
   const renderSession = (
@@ -456,17 +452,12 @@ export function AppLeftPane({
       }, pinnedSet.has(workspaceSessionKeyFor(session)), { projectId: project.id })}
     />
   )
-  const addressedSessionGroups = useMemo(() => agents.map((agent) => ({
-    agent,
-    sessions: sessions
-      .filter((session) => session.agentTypeId === agent.agentTypeId)
-      .sort((left, right) => (
-        multiAgent
-          ? Number(pinnedSet.has(workspaceSessionKeyFor(right)))
-            - Number(pinnedSet.has(workspaceSessionKeyFor(left)))
-          : 0
-      )),
-  })), [agents, multiAgent, pinnedSet, sessions])
+  const addressedSessionGroup = useMemo(() => {
+    const agent = agents.length === 1 ? agents[0] : undefined
+    return agent
+      ? { agent, sessions: sessions.filter((session) => session.agentTypeId === agent.agentTypeId) }
+      : null
+  }, [agents, sessions])
   const renderAgentActivity = (agent: AppLeftPaneAgent) => {
     const activity = working.agentTypeIds.has(agent.agentTypeId) ? "streaming" : "idle"
     return (
@@ -486,47 +477,70 @@ export function AppLeftPane({
       </span>
     )
   }
-  const renderAddressedSessionGroups = () => addressedSessionGroups.map(({ agent, sessions: agentSessions }) => (
+  const renderAddressedSessionGroup = () => addressedSessionGroup ? (
     <SessionSubSection
-      key={agent.agentTypeId}
-      title={renderAgentActivity(agent)}
+      title={renderAgentActivity(addressedSessionGroup.agent)}
     >
-      {agentSessions.length > 0
-        ? agentSessions.map((session) => renderSession(session, pinnedSet.has(workspaceSessionKeyFor(session))))
-        : <AgentSessionEmptyState status={agent.sessionsStatus} />}
+      {addressedSessionGroup.sessions.length > 0
+        ? addressedSessionGroup.sessions.map((session) => renderSession(session, pinnedSet.has(workspaceSessionKeyFor(session))))
+        : <AgentSessionEmptyState status={addressedSessionGroup.agent.sessionsStatus} />}
     </SessionSubSection>
+  ) : null
+  const renderAgentGroups = () => agents.map((agent) => (
+    <AppLeftPaneAgentGroup
+      key={agent.agentTypeId}
+      agent={agent}
+      activity={renderAgentActivity(agent)}
+      onCreateSession={() => onCreateSession(agent.agentTypeId)}
+      onCreateSplitSession={onCreateSplitSession
+        ? () => onCreateSplitSession(agent.agentTypeId)
+        : undefined}
+      onCreatePopoverSession={onCreatePopoverSession
+        ? () => onCreatePopoverSession(agent.agentTypeId)
+        : undefined}
+    />
   ))
-  const renderAgentGroups = () => addressedSessionGroups.map(({ agent, sessions: agentSessions }) => {
-    const expanded = expandedAgentTypeIds.has(agent.agentTypeId)
-    return (
-      <AppLeftPaneAgentGroup
-        key={agent.agentTypeId}
-        agent={agent}
-        sessions={agentSessions}
-        expanded={expanded}
-        activity={renderAgentActivity(agent)}
-        onExpandedChange={(open) => setAgentExpanded(agent.agentTypeId, open)}
-        onCreateSession={() => {
-          expandAgent(agent.agentTypeId)
-          onCreateSession(agent.agentTypeId)
-        }}
-        onCreateSplitSession={onCreateSplitSession
-          ? () => {
-              expandAgent(agent.agentTypeId)
-              onCreateSplitSession(agent.agentTypeId)
-            }
-          : undefined}
-        onCreatePopoverSession={onCreatePopoverSession
-          ? () => onCreatePopoverSession(agent.agentTypeId)
-          : undefined}
-        renderSession={(session) => renderSession(
-          session,
-          pinnedSet.has(workspaceSessionKeyFor(session)),
-          { showWorking: false },
-        )}
-      />
-    )
-  })
+  const chatAgentFilterControl = multiAgent ? (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Filter chats by agent"
+          className="mr-1 flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.045] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+        >
+          <span className="max-w-20 truncate">
+            {effectiveChatAgentFilter
+              ? agentLabelByTypeId.get(effectiveChatAgentFilter)
+              : "All"}
+          </span>
+          <ChevronDown className="size-3" strokeWidth={1.75} aria-hidden="true" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={4} className="w-44 border-border/50">
+        <DropdownMenuRadioGroup
+          value={effectiveChatAgentFilter ? agentFilterValue(effectiveChatAgentFilter) : ALL_AGENTS_FILTER_VALUE}
+          onValueChange={(value) => setChatAgentFilter(
+            value === ALL_AGENTS_FILTER_VALUE
+              ? null
+              : value.slice(AGENT_FILTER_VALUE_PREFIX.length),
+          )}
+        >
+          <DropdownMenuRadioItem value={ALL_AGENTS_FILTER_VALUE} className="gap-2 text-[13px]">
+            All agents
+          </DropdownMenuRadioItem>
+          {agents.map((agent) => (
+            <DropdownMenuRadioItem
+              key={agent.agentTypeId}
+              value={agentFilterValue(agent.agentTypeId)}
+              className="gap-2 text-[13px]"
+            >
+              {agent.label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ) : null
 
   return (
     <aside
@@ -546,24 +560,20 @@ export function AppLeftPane({
         <div className="h-12 shrink-0" aria-hidden="true" />
       )}
 
-      <div className="shrink-0 px-2 pb-1 pt-1">
-        <AppLeftPaneSection title="Workspace">
-          <nav className="space-y-0.5" aria-label="Primary workspace actions">
-            <PrimaryAction icon={<Search className="h-4 w-4" strokeWidth={1.75} />} label="Search" onClick={onOpenCommandPalette} trailing={<KbdHint keys="⌘K" />} />
-            {actions.map((action) => (
-              <PrimaryAction
-                key={action.id}
-                icon={action.icon}
-                label={action.label}
-                onClick={action.onClick}
-                trailing={action.trailing}
-                emphasis={action.emphasis}
-                active={action.active}
-              />
-            ))}
-          </nav>
-        </AppLeftPaneSection>
-      </div>
+      <nav className="shrink-0 space-y-0.5 border-b border-border/60 px-2 pb-2 pt-1" aria-label="Primary workspace actions">
+        <PrimaryAction icon={<Search className="h-4 w-4" strokeWidth={1.75} />} label="Search" onClick={onOpenCommandPalette} trailing={<KbdHint keys="⌘K" />} />
+        {actions.map((action) => (
+          <PrimaryAction
+            key={action.id}
+            icon={action.icon}
+            label={action.label}
+            onClick={action.onClick}
+            trailing={action.trailing}
+            emphasis={action.emphasis}
+            active={action.active}
+          />
+        ))}
+      </nav>
 
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
         {!multiAgent ? (
@@ -581,6 +591,13 @@ export function AppLeftPane({
           </div>
         ) : null}
         <div className="space-y-3 py-1">
+          {multiAgent ? (
+            <AppLeftPaneSection title="Agents">
+              <div className="space-y-0.5">
+                {renderAgentGroups()}
+              </div>
+            </AppLeftPaneSection>
+          ) : null}
           {(showSharedPinnedSessions && pinnedSessions.length > 0) || pinnedProjects.length > 0 ? (
             <AppLeftPaneSection title="Pinned">
               {showSharedPinnedSessions
@@ -594,19 +611,16 @@ export function AppLeftPane({
             </AppLeftPaneSection>
           ) : null}
           {multiAgent ? (
-            <AppLeftPaneSection title="Chats" empty="No open chats.">
-              {openSessions.map((session) => renderSession(
+            <AppLeftPaneSection
+              title="Chats"
+              empty="No chats yet."
+              headerAction={chatAgentFilterControl}
+            >
+              {filteredRegularSessions.map((session) => renderSession(
                 session,
-                pinnedSet.has(workspaceSessionKeyFor(session)),
+                false,
                 { showAgentBadge: true, showWorking: false },
               ))}
-            </AppLeftPaneSection>
-          ) : null}
-          {multiAgent ? (
-            <AppLeftPaneSection title="Agents">
-              <div className="space-y-0.5">
-                {renderAgentGroups()}
-              </div>
             </AppLeftPaneSection>
           ) : null}
         {/* Multi-project (PR2): the Workspaces/projects tree. Single-project
@@ -614,7 +628,7 @@ export function AppLeftPane({
             and the body is just the session list. */}
         {layoutMode === "multi-project" ? (
           <>
-            {!multiAgent && addressedSessionGroups.length > 0 ? renderAddressedSessionGroups() : null}
+            {!multiAgent ? renderAddressedSessionGroup() : null}
             <section data-boring-workspace-part="app-left-pane-section" className="space-y-1">
               <div className="flex items-center justify-between gap-1 px-2 pb-0.5">
                 <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/65">{workspaceSectionTitle}</span>
@@ -635,7 +649,7 @@ export function AppLeftPane({
           </>
         ) : (
           !multiAgent ? (
-            addressedSessionGroups.length > 0 ? renderAddressedSessionGroups() : (
+            addressedSessionGroup ? renderAddressedSessionGroup() : (
               <AppLeftPaneSection title="Chats" empty="No chats yet.">
                 {regularSessions.map((session) => renderSession(session, false))}
               </AppLeftPaneSection>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentGroup.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentGroup.tsx
@@ -2,13 +2,8 @@
 
 import type { ReactNode } from "react"
 import { Plus } from "lucide-react"
-import {
-  Disclosure,
-  DisclosureContent,
-  DisclosureTrigger,
-} from "@hachej/boring-ui-kit"
 import { NewChatAction } from "./AppLeftPaneActions"
-import type { AppLeftPaneAgent, AppLeftPaneSession } from "./AppLeftPane"
+import type { AppLeftPaneAgent } from "./AppLeftPane"
 
 export function AgentSessionEmptyState({
   status,
@@ -28,68 +23,33 @@ export function AgentSessionEmptyState({
 
 export function AppLeftPaneAgentGroup({
   agent,
-  sessions,
-  expanded,
   activity,
-  onExpandedChange,
   onCreateSession,
   onCreateSplitSession,
   onCreatePopoverSession,
-  renderSession,
 }: {
   agent: AppLeftPaneAgent
-  sessions: readonly AppLeftPaneSession[]
-  expanded: boolean
   activity: ReactNode
-  onExpandedChange: (expanded: boolean) => void
   onCreateSession: () => void
   onCreateSplitSession?: () => void
   onCreatePopoverSession?: () => void
-  renderSession: (session: AppLeftPaneSession) => ReactNode
 }) {
   return (
-    <Disclosure open={expanded} onOpenChange={onExpandedChange}>
-      <section
-        aria-label={`${agent.label} agent`}
-        data-boring-workspace-part="app-left-agent-group"
-        data-boring-agent-type-id={agent.agentTypeId}
-        className="space-y-0.5"
-      >
-        <div className="flex min-w-0 items-center">
-          <DisclosureTrigger
-            aria-label={`${expanded ? "Collapse" : "Expand"} ${agent.label} agent`}
-            className="h-8 w-6 shrink-0 px-0 hover:bg-foreground/[0.045]"
-          />
-          <div className="min-w-0 flex-1">
-            <NewChatAction
-              icon={<Plus className="h-4 w-4" strokeWidth={2} />}
-              label={activity}
-              meta={!expanded && sessions.length > 0 ? (
-                <span
-                  aria-label={`${sessions.length} chats`}
-                  className="text-[10px] font-medium text-muted-foreground/75"
-                >
-                  ·{sessions.length}
-                </span>
-              ) : undefined}
-              ariaLabel={`New chat with ${agent.label}`}
-              splitAriaLabel={`New chat with ${agent.label} in split`}
-              quickChatAriaLabel={`Quick chat with ${agent.label}`}
-              onCreateSession={onCreateSession}
-              onCreateSplitSession={onCreateSplitSession}
-              onCreatePopoverSession={onCreatePopoverSession}
-            />
-          </div>
-        </div>
-        <DisclosureContent
-          data-boring-workspace-part="app-left-agent-sessions"
-          className="ml-3 space-y-0.5 border-l border-border/55 pl-2"
-        >
-          {sessions.length > 0
-            ? sessions.map(renderSession)
-            : <AgentSessionEmptyState status={agent.sessionsStatus} />}
-        </DisclosureContent>
-      </section>
-    </Disclosure>
+    <section
+      aria-label={`${agent.label} agent`}
+      data-boring-workspace-part="app-left-agent-group"
+      data-boring-agent-type-id={agent.agentTypeId}
+    >
+      <NewChatAction
+        icon={<Plus className="h-4 w-4" strokeWidth={2} />}
+        label={activity}
+        ariaLabel={`New chat with ${agent.label}`}
+        splitAriaLabel={`New chat with ${agent.label} in split`}
+        quickChatAriaLabel={`Quick chat with ${agent.label}`}
+        onCreateSession={onCreateSession}
+        onCreateSplitSession={onCreateSplitSession}
+        onCreatePopoverSession={onCreatePopoverSession}
+      />
+    </section>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSections.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSections.tsx
@@ -12,6 +12,7 @@ export function AppLeftPaneSection({
   title,
   children,
   empty,
+  headerAction,
   defaultOpen = true,
   className,
   contentClassName,
@@ -19,6 +20,7 @@ export function AppLeftPaneSection({
   title: string
   children: ReactNode
   empty?: string
+  headerAction?: ReactNode
   defaultOpen?: boolean
   className?: string
   contentClassName?: string
@@ -34,9 +36,12 @@ export function AppLeftPaneSection({
         data-boring-section={title.toLowerCase()}
         className={cn("space-y-0.5", className)}
       >
-        <DisclosureTrigger className="h-11 w-full px-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/75 hover:bg-foreground/[0.045] hover:text-foreground [@media(hover:hover)_and_(min-width:640px)]:h-7">
-          {title}
-        </DisclosureTrigger>
+        <div className="flex items-center">
+          <DisclosureTrigger className="h-11 min-w-0 flex-1 px-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/75 hover:bg-foreground/[0.045] hover:text-foreground [@media(hover:hover)_and_(min-width:640px)]:h-7">
+            {title}
+          </DisclosureTrigger>
+          {headerAction}
+        </div>
         <DisclosureContent className={cn("space-y-0.5", contentClassName)}>
           {hasChildren ? children : <div className="px-2 py-1.5 text-xs text-muted-foreground/60">{empty}</div>}
         </DisclosureContent>

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { act, fireEvent, render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 import { WorkspaceAttentionProvider, useWorkspaceAttention } from "../../../attention/WorkspaceAttentionProvider"
 import { workspaceSessionKey } from "../../../sessionIdentity"
@@ -47,7 +48,7 @@ describe("AppLeftPane", () => {
     expect(badge?.closest('[data-boring-workspace-part="app-session-row"]')).toHaveTextContent("Second session")
   })
 
-  it("groups addressed sessions by agent without redundant selector chrome and reports per-agent activity", () => {
+  it("renders Agents, Pinned, and Chats without workspace or nested agent sessions", () => {
     render(
       <WorkspaceAttentionProvider>
         <AppLeftPane
@@ -58,10 +59,11 @@ describe("AppLeftPane", () => {
           ]}
           sessions={[
             { id: "a1", agentTypeId: "alpha", title: "Alpha chat" },
+            { id: "b1", agentTypeId: "beta", title: "Beta pinned" },
           ]}
           activeSessionRef={{ sessionId: "a1", agentTypeId: "alpha" }}
           openSessionRefs={[{ sessionId: "a1", agentTypeId: "alpha" }]}
-          pinnedSessionIds={[]}
+          pinnedSessionRefs={[{ sessionId: "b1", agentTypeId: "beta" }]}
           onCreateSession={vi.fn()}
           onOpenCommandPalette={vi.fn()}
           onSwitchSession={vi.fn()}
@@ -71,11 +73,19 @@ describe("AppLeftPane", () => {
       </WorkspaceAttentionProvider>,
     )
 
+    expect([...document.querySelectorAll('[data-boring-workspace-part="app-left-pane-section"]')]
+      .map((section) => section.getAttribute("data-boring-section"))).toEqual([
+      "agents",
+      "pinned",
+      "chats",
+    ])
+    expect(screen.queryByRole("region", { name: "Workspace" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Workspace" })).not.toBeInTheDocument()
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agent-sessions"]')).not.toBeInTheDocument()
     expect(within(screen.getByRole("region", { name: "Chats" })).getByText("Alpha chat")).toBeInTheDocument()
-    expect(within(screen.getByRole("region", { name: "Alpha agent" })).getByText("Alpha chat")).toBeInTheDocument()
-    fireEvent.click(screen.getByRole("button", { name: "Expand Beta agent" }))
-    expect(within(screen.getByRole("region", { name: "Beta agent" })).getByText("Loading chats…")).toBeInTheDocument()
-    expect(screen.queryByText("No chats yet.")).not.toBeInTheDocument()
+    expect(within(screen.getByRole("region", { name: "Pinned" })).getByText("Beta pinned")).toBeInTheDocument()
+    expect(within(screen.getByRole("region", { name: "Alpha agent" })).queryByText("Alpha chat")).not.toBeInTheDocument()
+    expect(within(screen.getByRole("region", { name: "Beta agent" })).queryByText("Beta pinned")).not.toBeInTheDocument()
     expect(screen.queryByRole("combobox", { name: "Agent" })).not.toBeInTheDocument()
 
     act(() => {
@@ -89,7 +99,8 @@ describe("AppLeftPane", () => {
     expect(document.querySelector('[data-boring-badge="working"]')).not.toBeInTheDocument()
   })
 
-  it("shows only currently open addressed sessions in Chats while agent history remains complete", () => {
+  it("shows every unpinned session in recency order and filters Chats by agent", async () => {
+    const user = userEvent.setup()
     render(
       <WorkspaceAttentionProvider>
         <AppLeftPane
@@ -99,9 +110,9 @@ describe("AppLeftPane", () => {
             { agentTypeId: "beta", label: "Beta", sessionsStatus: "loaded" },
           ]}
           sessions={[
-            { id: "a1", agentTypeId: "alpha", title: "Alpha closed" },
-            { id: "a2", agentTypeId: "alpha", title: "Alpha open" },
-            { id: "b1", agentTypeId: "beta", title: "Beta open" },
+            { id: "a1", agentTypeId: "alpha", title: "Alpha closed", updatedAt: 100 },
+            { id: "a2", agentTypeId: "alpha", title: "Alpha open", updatedAt: 300 },
+            { id: "b1", agentTypeId: "beta", title: "Beta open", updatedAt: 200 },
           ]}
           activeSessionRef={{ sessionId: "b1", agentTypeId: "beta" }}
           openSessionRefs={[
@@ -118,16 +129,60 @@ describe("AppLeftPane", () => {
     )
 
     const chats = screen.getByRole("region", { name: "Chats" })
-    expect(within(chats).queryByText("Alpha closed")).not.toBeInTheDocument()
+    expect(within(chats).getByText("Alpha closed")).toBeInTheDocument()
     expect(within(chats).getByText("Alpha open")).toBeInTheDocument()
     expect(within(chats).getByText("Beta open")).toBeInTheDocument()
-    expect(within(chats).getByText("Alpha")).toHaveAttribute("data-boring-agent-badge", "alpha")
+    expect(within(chats).getAllByText(/Alpha (closed|open)|Beta open/).map((node) => node.textContent)).toEqual([
+      "Alpha open",
+      "Beta open",
+      "Alpha closed",
+    ])
+    expect(within(chats).getAllByText("Alpha")).toHaveLength(2)
+    expect(within(chats).getAllByText("Alpha")[0]).toHaveAttribute("data-boring-agent-badge", "alpha")
     expect(within(chats).getByText("Beta")).toHaveAttribute("data-boring-agent-badge", "beta")
 
-    fireEvent.click(screen.getByRole("button", { name: "Expand Alpha agent" }))
-    const alphaAgent = screen.getByRole("region", { name: "Alpha agent" })
-    expect(within(alphaAgent).getByText("Alpha closed")).toBeInTheDocument()
-    expect(within(alphaAgent).getByText("Alpha open")).toBeInTheDocument()
+    await user.click(within(chats).getByRole("button", { name: "Filter chats by agent" }))
+    await user.click(screen.getByRole("menuitemradio", { name: "Beta" }))
+    expect(within(chats).queryByText("Alpha closed")).not.toBeInTheDocument()
+    expect(within(chats).queryByText("Alpha open")).not.toBeInTheDocument()
+    expect(within(chats).getByText("Beta open")).toBeInTheDocument()
+    expect(within(chats).getByRole("button", { name: "Filter chats by agent" })).toHaveTextContent("Beta")
+
+    await user.click(within(chats).getByRole("button", { name: "Filter chats by agent" }))
+    await user.click(screen.getByRole("menuitemradio", { name: "All agents" }))
+    expect(within(chats).getByText("Alpha closed")).toBeInTheDocument()
+    expect(within(chats).getByText("Alpha open")).toBeInTheDocument()
+    expect(within(chats).getByText("Beta open")).toBeInTheDocument()
+  })
+
+  it("can filter an agent whose id is all without colliding with the All option", async () => {
+    const user = userEvent.setup()
+    render(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane
+          appTitle="Test"
+          agents={[
+            { agentTypeId: "all", label: "All-purpose" },
+            { agentTypeId: "beta", label: "Beta" },
+          ]}
+          sessions={[
+            { id: "all-1", agentTypeId: "all", title: "All-purpose chat" },
+            { id: "beta-1", agentTypeId: "beta", title: "Beta chat" },
+          ]}
+          onCreateSession={vi.fn()}
+          onOpenCommandPalette={vi.fn()}
+          onSwitchSession={vi.fn()}
+          onOpenSessionAsPane={vi.fn()}
+          onToggleSessionPinned={vi.fn()}
+        />
+      </WorkspaceAttentionProvider>,
+    )
+
+    const chats = screen.getByRole("region", { name: "Chats" })
+    await user.click(within(chats).getByRole("button", { name: "Filter chats by agent" }))
+    await user.click(screen.getByRole("menuitemradio", { name: "All-purpose" }))
+    expect(within(chats).getByText("All-purpose chat")).toBeInTheDocument()
+    expect(within(chats).queryByText("Beta chat")).not.toBeInTheDocument()
   })
 
   it("creates addressed chats from a collapsible agent list", () => {
@@ -159,6 +214,9 @@ describe("AppLeftPane", () => {
     expect(screen.queryByRole("list", { name: "Agents available for new chat" })).not.toBeInTheDocument()
     expect(screen.getByRole("region", { name: "Alpha agent" })).toBeInTheDocument()
     expect(screen.getByRole("region", { name: "Beta agent" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Expand .* agent/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Collapse .* agent/ })).not.toBeInTheDocument()
+    expect(document.querySelector('[aria-label$=" chats"]')).not.toBeInTheDocument()
     const betaAction = screen.getByRole("button", { name: "New chat with Beta" })
     const alphaSplitAction = screen.getByRole("button", { name: "New chat with Alpha in split" })
     const betaQuickAction = screen.getByRole("button", { name: "Quick chat with Beta" })
@@ -184,7 +242,7 @@ describe("AppLeftPane", () => {
     expect(onCreatePopoverSession).toHaveBeenCalledWith("beta")
   })
 
-  it("shows an empty state only for agents whose session source loaded authoritatively", () => {
+  it("does not render per-agent session empty states", () => {
     render(
       <WorkspaceAttentionProvider>
         <AppLeftPane
@@ -207,8 +265,8 @@ describe("AppLeftPane", () => {
     expect(screen.getByLabelText("Alpha idle")).toBeInTheDocument()
     expect(screen.getByLabelText("Beta idle")).toBeInTheDocument()
     expect(screen.getAllByText("No chats yet.")).toHaveLength(1)
-    fireEvent.click(screen.getByRole("button", { name: "Expand Beta agent" }))
-    expect(within(screen.getByRole("region", { name: "Beta agent" })).getByText("Loading chats…")).toBeInTheDocument()
+    expect(screen.queryByText("Loading chats…")).not.toBeInTheDocument()
+    expect(screen.queryByText("Chats unavailable.")).not.toBeInTheDocument()
   })
 
   it("clears stale presence after definitive session deletion and agent removal", () => {
@@ -311,7 +369,7 @@ describe("AppLeftPane", () => {
     expect(document.querySelector('[data-boring-badge="working"]')).not.toBeInTheDocument()
   })
 
-  it("surfaces pinned addressed sessions across agents and sorts them pin-first within an expanded owner", () => {
+  it("moves pinned addressed sessions from Chats to the shared Pinned section", () => {
     function MultiAgentPinHarness() {
       const [pinnedSessionRefs, setPinnedSessionRefs] = useState<Array<{ sessionId: string; agentTypeId: string }>>([])
       return (
@@ -354,22 +412,16 @@ describe("AppLeftPane", () => {
     fireEvent.click(screen.getByRole("button", { name: "Pin Beta pinned" }))
 
     const pinned = screen.getByRole("region", { name: "Pinned" })
+    const chats = screen.getByRole("region", { name: "Chats" })
     expect(within(pinned).getByText("Beta pinned")).toBeInTheDocument()
     expect(within(pinned).getByText("Beta")).toHaveAttribute("data-boring-agent-badge", "beta")
-    const betaAgent = screen.getByRole("region", { name: "Beta agent" })
-    expect(within(betaAgent).getAllByText(/Beta/).map((node) => node.textContent)).toEqual([
-      "Beta",
-      "Beta pinned",
-      "Beta newer",
-    ])
+    expect(within(chats).queryByText("Beta pinned")).not.toBeInTheDocument()
+    expect(screen.getAllByText("Beta pinned")).toHaveLength(1)
 
     fireEvent.click(within(pinned).getByRole("button", { name: "Unpin Beta pinned" }))
     expect(screen.queryByRole("region", { name: "Pinned" })).not.toBeInTheDocument()
-    expect(within(betaAgent).getAllByText(/Beta/).map((node) => node.textContent)).toEqual([
-      "Beta",
-      "Beta newer",
-      "Beta pinned",
-    ])
+    expect(within(chats).getByText("Beta pinned")).toBeInTheDocument()
+    expect(screen.getAllByText("Beta pinned")).toHaveLength(1)
   })
 
   it("preserves addressed grouping in multi-project mode", () => {
@@ -397,9 +449,10 @@ describe("AppLeftPane", () => {
       </WorkspaceAttentionProvider>,
     )
 
-    expect(within(screen.getByRole("region", { name: "Alpha agent" })).getByText("Alpha chat")).toBeInTheDocument()
-    fireEvent.click(screen.getByRole("button", { name: "Expand Beta agent" }))
-    expect(within(screen.getByRole("region", { name: "Beta agent" })).getByText("Beta chat")).toBeInTheDocument()
+    expect(within(screen.getByRole("region", { name: "Chats" })).getByText("Alpha chat")).toBeInTheDocument()
+    expect(within(screen.getByRole("region", { name: "Chats" })).getByText("Beta chat")).toBeInTheDocument()
+    expect(within(screen.getByRole("region", { name: "Alpha agent" })).queryByText("Alpha chat")).not.toBeInTheDocument()
+    expect(within(screen.getByRole("region", { name: "Beta agent" })).queryByText("Beta chat")).not.toBeInTheDocument()
     expect(screen.getByLabelText("Alpha idle")).toBeInTheDocument()
     expect(screen.getByLabelText("Beta idle")).toBeInTheDocument()
     expect(screen.getByText("Project A")).toBeInTheDocument()
@@ -430,12 +483,14 @@ describe("AppLeftPane", () => {
     )
 
     expect(screen.queryByRole("combobox", { name: "Agent" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Filter chats by agent" })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Agents" })).not.toBeInTheDocument()
     expect(screen.queryByRole("region", { name: "Agents" })).not.toBeInTheDocument()
     expect(document.querySelector('[data-boring-workspace-part="app-left-agent-group"]')).not.toBeInTheDocument()
     expect(document.querySelector('[data-boring-workspace-part="app-left-agent-sessions"]')).not.toBeInTheDocument()
     expect(screen.queryByRole("list", { name: "Agents available for new chat" })).not.toBeInTheDocument()
     expect(screen.queryByRole("region", { name: "Pinned" })).not.toBeInTheDocument()
+    expect(document.querySelector("[data-boring-agent-badge]")).not.toBeInTheDocument()
     expect(screen.getByText("Alpha chat")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Unpin Alpha chat" })).toBeInTheDocument()
 


### PR DESCRIPTION
## Summary

- remove the Workspace disclosure and leave primary navigation bare above a hairline
- simplify multi-agent navigation to collapsible Agents, shared Pinned, and one flat recency-ordered Chats list
- replace nested agent histories/counts/disclosures with launcher-only agent rows and a dropdown-radio agent filter (no combobox)
- preserve single-agent chrome and pin de-duplication behavior
- update unit and playground E2E coverage for create, badge, pin-move, filter, and single-agent behavior

## Validation

- `pnpm typecheck` ✅
- `pnpm lint:invariants` ✅
- `pnpm --filter @hachej/boring-workspace exec vitest run src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx src/app/front/__tests__/WorkspaceAgentFront.test.tsx --no-file-parallelism` ✅ (101 tests)
- `node scripts/build-front-css.mjs` from `packages/agent` + `wc -c dist/front/styles.css` ✅ (166,664 bytes)
- independent acceptance review ✅
- independent tier-2 thermonuclear maintainability review ✅

## E2E

Playwright specs were updated but intentionally not run locally per the task instructions; CI owns the browser run.

## Manual validation

In the two-agent playground fixture:
1. Confirm navigation is followed by Agents → Pinned (when non-empty) → Chats, with no Workspace heading.
2. Create an Alpha and Beta chat; both should appear once in Chats with the right badge.
3. Filter Chats to Alpha, then restore All.
4. Pin the Beta chat; it should move to Pinned and disappear from Chats.
5. In a single-agent fixture, confirm there is no Agents chrome, agent badge, or filter.