### PR TITLE
#909 refactor(console): agent rows as label + icon actions

### DIFF
--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -116,7 +116,7 @@ test.describe("addressed Agent Host browser wire", () => {
     await expect(alphaChatRow.locator('[data-boring-agent-badge="alpha"]')).toBeVisible()
     await expect(alphaChatRow).toHaveAttribute("data-boring-session-state", "active")
 
-    const filter = chats.getByRole("button", { name: /Filter chats:/ })
+    const filter = chats.getByRole("button", { name: "Filter chats by agent" })
     await filter.click()
     await page.getByRole("menuitemradio", { name: "Alpha" }).click()
     await expect(alphaChatRow).toBeVisible()

--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -116,7 +116,7 @@ test.describe("addressed Agent Host browser wire", () => {
     await expect(alphaChatRow.locator('[data-boring-agent-badge="alpha"]')).toBeVisible()
     await expect(alphaChatRow).toHaveAttribute("data-boring-session-state", "active")
 
-    const filter = chats.getByRole("button", { name: "Filter chats by agent" })
+    const filter = chats.getByRole("button", { name: /Filter chats:/ })
     await filter.click()
     await page.getByRole("menuitemradio", { name: "Alpha" }).click()
     await expect(alphaChatRow).toBeVisible()

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
-import { Filter, Plus, Search } from "lucide-react"
+import { ChevronDown, Plus, Search } from "lucide-react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -500,24 +500,20 @@ export function AppLeftPane({
         : undefined}
     />
   ))
-  const filteredAgentLabel = effectiveChatAgentFilter
-    ? agentLabelByTypeId.get(effectiveChatAgentFilter)
-    : null
   const chatAgentFilterControl = multiAgent ? (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          aria-label={`Filter chats: ${filteredAgentLabel ?? "All"}`}
-          data-active={filteredAgentLabel ? "true" : undefined}
-          className={filteredAgentLabel
-            ? "mr-1 flex h-11 shrink-0 items-center gap-1 rounded-md bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] px-1.5 text-[11px] font-medium text-[color:var(--accent)] transition-colors hover:bg-[color:oklch(from_var(--accent)_l_c_h/0.18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:h-6"
-            : "mr-1 grid size-11 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:size-6"}
+          aria-label="Filter chats by agent"
+          className="mr-1 flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.045] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
         >
-          <Filter className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
-          {filteredAgentLabel ? (
-            <span className="max-w-20 truncate text-foreground">{filteredAgentLabel}</span>
-          ) : null}
+          <span className="max-w-20 truncate">
+            {effectiveChatAgentFilter
+              ? agentLabelByTypeId.get(effectiveChatAgentFilter)
+              : "All"}
+          </span>
+          <ChevronDown className="size-3" strokeWidth={1.75} aria-hidden="true" />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" sideOffset={4} className="w-44 border-border/50">

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -458,12 +458,12 @@ export function AppLeftPane({
       ? { agent, sessions: sessions.filter((session) => session.agentTypeId === agent.agentTypeId) }
       : null
   }, [agents, sessions])
-  const renderAgentActivity = (agent: AppLeftPaneAgent) => {
+  const renderAgentActivity = (agent: AppLeftPaneAgent, announce = true) => {
     const activity = working.agentTypeIds.has(agent.agentTypeId) ? "streaming" : "idle"
     return (
       <span
-        role="status"
-        aria-label={`${agent.label} ${activity}`}
+        role={announce ? "status" : undefined}
+        aria-label={announce ? `${agent.label} ${activity}` : undefined}
         data-boring-agent-activity={activity}
         className="flex items-center gap-1.5"
       >
@@ -581,6 +581,7 @@ export function AppLeftPane({
             {agents.length === 1 ? (
               <SingleAgentNewChatAction
                 agent={agents[0]}
+                label={renderAgentActivity(agents[0], false)}
                 onCreateSession={onCreateSession}
                 onCreateSplitSession={onCreateSplitSession}
                 onCreatePopoverSession={onCreatePopoverSession}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
-import { ChevronDown, Plus, Search } from "lucide-react"
+import { Filter, Plus, Search } from "lucide-react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -500,20 +500,24 @@ export function AppLeftPane({
         : undefined}
     />
   ))
+  const filteredAgentLabel = effectiveChatAgentFilter
+    ? agentLabelByTypeId.get(effectiveChatAgentFilter)
+    : null
   const chatAgentFilterControl = multiAgent ? (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          aria-label="Filter chats by agent"
-          className="mr-1 flex h-7 shrink-0 items-center gap-1 rounded-md px-1.5 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-foreground/[0.045] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          aria-label={`Filter chats: ${filteredAgentLabel ?? "All"}`}
+          data-active={filteredAgentLabel ? "true" : undefined}
+          className={filteredAgentLabel
+            ? "mr-1 flex h-11 shrink-0 items-center gap-1 rounded-md bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] px-1.5 text-[11px] font-medium text-[color:var(--accent)] transition-colors hover:bg-[color:oklch(from_var(--accent)_l_c_h/0.18)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:h-6"
+            : "mr-1 grid size-11 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:size-6"}
         >
-          <span className="max-w-20 truncate">
-            {effectiveChatAgentFilter
-              ? agentLabelByTypeId.get(effectiveChatAgentFilter)
-              : "All"}
-          </span>
-          <ChevronDown className="size-3" strokeWidth={1.75} aria-hidden="true" />
+          <Filter className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
+          {filteredAgentLabel ? (
+            <span className="max-w-20 truncate text-foreground">{filteredAgentLabel}</span>
+          ) : null}
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" sideOffset={4} className="w-44 border-border/50">

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -560,38 +560,39 @@ export function AppLeftPane({
         <div className="h-12 shrink-0" aria-hidden="true" />
       )}
 
-      <nav className="shrink-0 space-y-0.5 border-b border-border/60 px-2 pb-2 pt-1" aria-label="Primary workspace actions">
-        <PrimaryAction icon={<Search className="h-4 w-4" strokeWidth={1.75} />} label="Search" onClick={onOpenCommandPalette} trailing={<KbdHint keys="⌘K" />} />
-        {actions.map((action) => (
-          <PrimaryAction
-            key={action.id}
-            icon={action.icon}
-            label={action.label}
-            onClick={action.onClick}
-            trailing={action.trailing}
-            emphasis={action.emphasis}
-            active={action.active}
-          />
-        ))}
-      </nav>
-
       <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
-        {!multiAgent ? (
-          <div className="pb-2">
-            {agents.length === 1 ? (
-              <SingleAgentNewChatAction
-                agent={agents[0]}
-                label={renderAgentActivity(agents[0], false)}
-                onCreateSession={onCreateSession}
-                onCreateSplitSession={onCreateSplitSession}
-                onCreatePopoverSession={onCreatePopoverSession}
-              />
-            ) : (
-              <NewChatAction icon={<Plus className="h-4 w-4" strokeWidth={2} />} onCreateSession={onCreateSession} onCreateSplitSession={onCreateSplitSession} onCreatePopoverSession={onCreatePopoverSession} />
-            )}
-          </div>
-        ) : null}
         <div className="space-y-3 py-1">
+          <AppLeftPaneSection title="Workspace">
+            <nav className="space-y-0.5" aria-label="Primary workspace actions">
+              <PrimaryAction icon={<Search className="h-4 w-4" strokeWidth={1.75} />} label="Search" onClick={onOpenCommandPalette} trailing={<KbdHint keys="⌘K" />} />
+              {actions.map((action) => (
+                <PrimaryAction
+                  key={action.id}
+                  icon={action.icon}
+                  label={action.label}
+                  onClick={action.onClick}
+                  trailing={action.trailing}
+                  emphasis={action.emphasis}
+                  active={action.active}
+                />
+              ))}
+            </nav>
+          </AppLeftPaneSection>
+          {!multiAgent ? (
+            <div>
+              {agents.length === 1 ? (
+                <SingleAgentNewChatAction
+                  agent={agents[0]}
+                  label={renderAgentActivity(agents[0], false)}
+                  onCreateSession={onCreateSession}
+                  onCreateSplitSession={onCreateSplitSession}
+                  onCreatePopoverSession={onCreatePopoverSession}
+                />
+              ) : (
+                <NewChatAction icon={<Plus className="h-4 w-4" strokeWidth={2} />} onCreateSession={onCreateSession} onCreateSplitSession={onCreateSplitSession} onCreatePopoverSession={onCreatePopoverSession} />
+              )}
+            </div>
+          ) : null}
           {multiAgent ? (
             <AppLeftPaneSection title="Agents">
               <div className="space-y-0.5">

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -119,21 +119,84 @@ export function NewChatAction({
   )
 }
 
+export function AgentNewChatAction({
+  label,
+  ariaLabel,
+  splitAriaLabel,
+  quickChatAriaLabel,
+  onCreateSession,
+  onCreateSplitSession,
+  onCreatePopoverSession,
+}: {
+  label: ReactNode
+  ariaLabel: string
+  splitAriaLabel: string
+  quickChatAriaLabel: string
+  onCreateSession: () => void
+  onCreateSplitSession?: () => void
+  onCreatePopoverSession?: () => void
+}) {
+  return (
+    <div className="group flex min-h-8 w-full items-center gap-2 rounded-md border border-transparent px-2.5 py-1 text-left text-[13px] font-medium text-foreground/78 transition-colors hover:bg-foreground/[0.055] hover:text-foreground">
+      <span className="min-w-0 flex-1 truncate">{label}</span>
+      <span className="flex shrink-0 items-center gap-0.5">
+        <button
+          type="button"
+          aria-label={ariaLabel}
+          title={ariaLabel}
+          onClick={(event) => {
+            onCreateSession()
+            event.currentTarget.blur()
+          }}
+          className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+        >
+          <Plus className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
+        </button>
+        {onCreateSplitSession ? (
+          <AppLeftPaneSplitAction
+            ariaLabel={splitAriaLabel}
+            title={splitAriaLabel}
+            onClick={(event) => {
+              onCreateSplitSession()
+              event.currentTarget.blur()
+            }}
+          />
+        ) : null}
+        {onCreatePopoverSession ? (
+          <button
+            type="button"
+            aria-label={quickChatAriaLabel}
+            title={quickChatAriaLabel}
+            onClick={(event) => {
+              onCreatePopoverSession()
+              event.currentTarget.blur()
+            }}
+            className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          >
+            <Zap className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
+          </button>
+        ) : null}
+      </span>
+    </div>
+  )
+}
+
 export function SingleAgentNewChatAction({
   agent,
+  label,
   onCreateSession,
   onCreateSplitSession,
   onCreatePopoverSession,
 }: {
   agent: AgentNewChatOption
+  label: ReactNode
   onCreateSession: (agentTypeId: string) => void
   onCreateSplitSession?: (agentTypeId: string) => void
   onCreatePopoverSession?: (agentTypeId: string) => void
 }) {
   return (
-    <NewChatAction
-      icon={<Plus className="h-4 w-4" strokeWidth={2} />}
-      label={agent.label}
+    <AgentNewChatAction
+      label={label}
       ariaLabel={`New chat with ${agent.label}`}
       splitAriaLabel={`New chat with ${agent.label} in split`}
       quickChatAriaLabel={`Quick chat with ${agent.label}`}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -137,7 +137,7 @@ export function AgentNewChatAction({
   onCreatePopoverSession?: () => void
 }) {
   return (
-    <div className="group flex min-h-8 w-full items-center gap-2 rounded-md border border-transparent px-2.5 py-1 text-left text-[13px] font-medium text-foreground/78 transition-colors hover:bg-foreground/[0.055] hover:text-foreground">
+    <div className="group flex h-11 w-full items-center gap-2 rounded-md px-2.5 text-left text-[13px] font-medium text-foreground/78 transition-colors hover:bg-foreground/[0.055] hover:text-foreground [@media(hover:hover)_and_(min-width:640px)]:h-8 [@media(hover:hover)_and_(min-width:640px)]:py-1">
       <span className="min-w-0 flex-1 truncate">{label}</span>
       <span className="flex shrink-0 items-center gap-0.5">
         <button
@@ -148,7 +148,7 @@ export function AgentNewChatAction({
             onCreateSession()
             event.currentTarget.blur()
           }}
-          className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          className="grid size-11 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:size-6"
         >
           <Plus className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
         </button>
@@ -156,6 +156,7 @@ export function AgentNewChatAction({
           <AppLeftPaneSplitAction
             ariaLabel={splitAriaLabel}
             title={splitAriaLabel}
+            touchResponsive
             onClick={(event) => {
               onCreateSplitSession()
               event.currentTarget.blur()
@@ -171,7 +172,7 @@ export function AgentNewChatAction({
               onCreatePopoverSession()
               event.currentTarget.blur()
             }}
-            className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            className="grid size-11 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:size-6"
           >
             <Zap className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
           </button>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentGroup.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentGroup.tsx
@@ -1,8 +1,7 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { Plus } from "lucide-react"
-import { NewChatAction } from "./AppLeftPaneActions"
+import { AgentNewChatAction } from "./AppLeftPaneActions"
 import type { AppLeftPaneAgent } from "./AppLeftPane"
 
 export function AgentSessionEmptyState({
@@ -40,8 +39,7 @@ export function AppLeftPaneAgentGroup({
       data-boring-workspace-part="app-left-agent-group"
       data-boring-agent-type-id={agent.agentTypeId}
     >
-      <NewChatAction
-        icon={<Plus className="h-4 w-4" strokeWidth={2} />}
+      <AgentNewChatAction
         label={activity}
         ariaLabel={`New chat with ${agent.label}`}
         splitAriaLabel={`New chat with ${agent.label} in split`}

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -229,13 +229,24 @@ describe("AppLeftPane", () => {
     const betaAgent = screen.getByRole("region", { name: "Beta agent" })
     expect(within(betaAgent).getByText("Beta").closest("button")).toBeNull()
     expect(within(betaAgent).getAllByRole("button")).toHaveLength(3)
+    expect(within(betaAgent).getAllByRole("button").map((button) => button.getAttribute("aria-label"))).toEqual([
+      "New chat with Beta",
+      "New chat with Beta in split",
+      "Quick chat with Beta",
+    ])
     const betaAction = screen.getByRole("button", { name: "New chat with Beta" })
     const alphaSplitAction = screen.getByRole("button", { name: "New chat with Alpha in split" })
     const betaQuickAction = screen.getByRole("button", { name: "Quick chat with Beta" })
-    expect(betaAction).toHaveClass("size-6")
-    expect(betaAction.closest(".group")).toHaveClass("min-h-8", "rounded-md", "px-2.5", "py-1")
+    expect(betaAction).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
+    expect(betaAction.closest(".group")).toHaveClass(
+      "h-11",
+      "rounded-md",
+      "px-2.5",
+      "[@media(hover:hover)_and_(min-width:640px)]:h-8",
+      "[@media(hover:hover)_and_(min-width:640px)]:py-1",
+    )
     expect(betaAction.querySelector(".lucide-plus")).toBeInTheDocument()
-    expect(alphaSplitAction).toHaveClass("size-6")
+    expect(alphaSplitAction).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
     expect(alphaSplitAction.querySelector(".lucide-columns-2")).toBeInTheDocument()
     expect(betaQuickAction.querySelector(".lucide-zap")).toBeInTheDocument()
     expect(alphaSplitAction.parentElement).toHaveClass("flex", "shrink-0", "items-center", "gap-0.5")
@@ -505,7 +516,7 @@ describe("AppLeftPane", () => {
     const agentRow = newChatAction.closest(".group")
     expect(agentRow).not.toBeNull()
     expect(within(agentRow as HTMLElement).getByText("Alpha").closest("button")).toBeNull()
-    expect(newChatAction).toHaveClass("size-6")
+    expect(newChatAction).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
 
     fireEvent.click(screen.getByRole("button", { name: "New chat with Alpha" }))
     fireEvent.click(screen.getByRole("button", { name: "New chat with Alpha in split" }))

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -48,7 +48,7 @@ describe("AppLeftPane", () => {
     expect(badge?.closest('[data-boring-workspace-part="app-session-row"]')).toHaveTextContent("Second session")
   })
 
-  it("renders Agents, Pinned, and Chats without workspace or nested agent sessions", () => {
+  it("renders collapsible Workspace, Agents, Pinned, and Chats sections in order", () => {
     render(
       <WorkspaceAttentionProvider>
         <AppLeftPane
@@ -66,6 +66,7 @@ describe("AppLeftPane", () => {
           pinnedSessionRefs={[{ sessionId: "b1", agentTypeId: "beta" }]}
           onCreateSession={vi.fn()}
           onOpenCommandPalette={vi.fn()}
+          actions={[{ id: "inbox", label: "Inbox", icon: null, onClick: vi.fn() }]}
           onSwitchSession={vi.fn()}
           onOpenSessionAsPane={vi.fn()}
           onToggleSessionPinned={vi.fn()}
@@ -75,12 +76,20 @@ describe("AppLeftPane", () => {
 
     expect([...document.querySelectorAll('[data-boring-workspace-part="app-left-pane-section"]')]
       .map((section) => section.getAttribute("data-boring-section"))).toEqual([
+      "workspace",
       "agents",
       "pinned",
       "chats",
     ])
-    expect(screen.queryByRole("region", { name: "Workspace" })).not.toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "Workspace" })).not.toBeInTheDocument()
+    const workspace = screen.getByRole("region", { name: "Workspace" })
+    const workspaceToggle = screen.getByRole("button", { name: "Workspace" })
+    expect(workspaceToggle).toHaveAttribute("aria-expanded", "true")
+    expect(within(workspace).getByRole("button", { name: "Search" })).toBeInTheDocument()
+    expect(within(workspace).getByRole("button", { name: "Inbox" })).toBeInTheDocument()
+    fireEvent.click(workspaceToggle)
+    expect(workspaceToggle).toHaveAttribute("aria-expanded", "false")
+    expect(within(workspace).queryByRole("button", { name: "Search" })).not.toBeInTheDocument()
+    expect(within(workspace).queryByRole("button", { name: "Inbox" })).not.toBeInTheDocument()
     expect(document.querySelector('[data-boring-workspace-part="app-left-agent-sessions"]')).not.toBeInTheDocument()
     expect(within(screen.getByRole("region", { name: "Chats" })).getByText("Alpha chat")).toBeInTheDocument()
     expect(within(screen.getByRole("region", { name: "Pinned" })).getByText("Beta pinned")).toBeInTheDocument()
@@ -481,6 +490,7 @@ describe("AppLeftPane", () => {
     )
 
     expect(screen.queryByRole("combobox", { name: "Agent" })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Workspace" })).toHaveAttribute("aria-expanded", "true")
     expect(screen.queryByRole("button", { name: "Filter chats by agent" })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Agents" })).not.toBeInTheDocument()
     expect(screen.queryByRole("region", { name: "Agents" })).not.toBeInTheDocument()

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -150,18 +150,26 @@ describe("AppLeftPane", () => {
     expect(within(chats).getAllByText("Alpha")[0]).toHaveAttribute("data-boring-agent-badge", "alpha")
     expect(within(chats).getByText("Beta")).toHaveAttribute("data-boring-agent-badge", "beta")
 
-    await user.click(within(chats).getByRole("button", { name: "Filter chats by agent" }))
+    const allFilter = within(chats).getByRole("button", { name: "Filter chats: All" })
+    expect(allFilter).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
+    expect(allFilter.querySelector(".lucide-funnel")).toBeInTheDocument()
+    expect(allFilter).not.toHaveTextContent("All")
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
+    await user.click(allFilter)
     await user.click(screen.getByRole("menuitemradio", { name: "Beta" }))
     expect(within(chats).queryByText("Alpha closed")).not.toBeInTheDocument()
     expect(within(chats).queryByText("Alpha open")).not.toBeInTheDocument()
     expect(within(chats).getByText("Beta open")).toBeInTheDocument()
-    expect(within(chats).getByRole("button", { name: "Filter chats by agent" })).toHaveTextContent("Beta")
+    const betaFilter = within(chats).getByRole("button", { name: "Filter chats: Beta" })
+    expect(betaFilter).toHaveAttribute("data-active", "true")
+    expect(betaFilter).toHaveTextContent("Beta")
 
-    await user.click(within(chats).getByRole("button", { name: "Filter chats by agent" }))
+    await user.click(betaFilter)
     await user.click(screen.getByRole("menuitemradio", { name: "All agents" }))
     expect(within(chats).getByText("Alpha closed")).toBeInTheDocument()
     expect(within(chats).getByText("Alpha open")).toBeInTheDocument()
     expect(within(chats).getByText("Beta open")).toBeInTheDocument()
+    expect(within(chats).getByRole("button", { name: "Filter chats: All" })).not.toHaveTextContent("Beta")
   })
 
   it("can filter an agent whose id is all without colliding with the All option", async () => {
@@ -188,7 +196,7 @@ describe("AppLeftPane", () => {
     )
 
     const chats = screen.getByRole("region", { name: "Chats" })
-    await user.click(within(chats).getByRole("button", { name: "Filter chats by agent" }))
+    await user.click(within(chats).getByRole("button", { name: "Filter chats: All" }))
     await user.click(screen.getByRole("menuitemradio", { name: "All-purpose" }))
     expect(within(chats).getByText("All-purpose chat")).toBeInTheDocument()
     expect(within(chats).queryByText("Beta chat")).not.toBeInTheDocument()
@@ -502,7 +510,7 @@ describe("AppLeftPane", () => {
 
     expect(screen.queryByRole("combobox", { name: "Agent" })).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Workspace" })).toHaveAttribute("aria-expanded", "true")
-    expect(screen.queryByRole("button", { name: "Filter chats by agent" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Filter chats:/ })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Agents" })).not.toBeInTheDocument()
     expect(screen.queryByRole("region", { name: "Agents" })).not.toBeInTheDocument()
     expect(document.querySelector('[data-boring-workspace-part="app-left-agent-group"]')).not.toBeInTheDocument()

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -217,21 +217,19 @@ describe("AppLeftPane", () => {
     expect(screen.queryByRole("button", { name: /Expand .* agent/ })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: /Collapse .* agent/ })).not.toBeInTheDocument()
     expect(document.querySelector('[aria-label$=" chats"]')).not.toBeInTheDocument()
+    const betaAgent = screen.getByRole("region", { name: "Beta agent" })
+    expect(within(betaAgent).getByText("Beta").closest("button")).toBeNull()
+    expect(within(betaAgent).getAllByRole("button")).toHaveLength(3)
     const betaAction = screen.getByRole("button", { name: "New chat with Beta" })
     const alphaSplitAction = screen.getByRole("button", { name: "New chat with Alpha in split" })
     const betaQuickAction = screen.getByRole("button", { name: "Quick chat with Beta" })
-    expect(betaAction).toHaveClass("h-full")
-    expect(betaAction.parentElement).toHaveClass("h-11", "[@media(hover:hover)_and_(min-width:640px)]:h-8")
+    expect(betaAction).toHaveClass("size-6")
+    expect(betaAction.closest(".group")).toHaveClass("min-h-8", "rounded-md", "px-2.5", "py-1")
     expect(betaAction.querySelector(".lucide-plus")).toBeInTheDocument()
-    expect(alphaSplitAction).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
+    expect(alphaSplitAction).toHaveClass("size-6")
     expect(alphaSplitAction.querySelector(".lucide-columns-2")).toBeInTheDocument()
     expect(betaQuickAction.querySelector(".lucide-zap")).toBeInTheDocument()
-    expect(alphaSplitAction.parentElement).toHaveClass(
-      "w-auto",
-      "opacity-100",
-      "[@media(hover:hover)_and_(min-width:640px)]:w-0",
-      "[@media(hover:hover)_and_(min-width:640px)]:opacity-0",
-    )
+    expect(alphaSplitAction.parentElement).toHaveClass("flex", "shrink-0", "items-center", "gap-0.5")
 
     fireEvent.click(betaAction)
     fireEvent.click(alphaSplitAction)
@@ -493,6 +491,11 @@ describe("AppLeftPane", () => {
     expect(document.querySelector("[data-boring-agent-badge]")).not.toBeInTheDocument()
     expect(screen.getByText("Alpha chat")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Unpin Alpha chat" })).toBeInTheDocument()
+    const newChatAction = screen.getByRole("button", { name: "New chat with Alpha" })
+    const agentRow = newChatAction.closest(".group")
+    expect(agentRow).not.toBeNull()
+    expect(within(agentRow as HTMLElement).getByText("Alpha").closest("button")).toBeNull()
+    expect(newChatAction).toHaveClass("size-6")
 
     fireEvent.click(screen.getByRole("button", { name: "New chat with Alpha" }))
     fireEvent.click(screen.getByRole("button", { name: "New chat with Alpha in split" }))

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -150,26 +150,18 @@ describe("AppLeftPane", () => {
     expect(within(chats).getAllByText("Alpha")[0]).toHaveAttribute("data-boring-agent-badge", "alpha")
     expect(within(chats).getByText("Beta")).toHaveAttribute("data-boring-agent-badge", "beta")
 
-    const allFilter = within(chats).getByRole("button", { name: "Filter chats: All" })
-    expect(allFilter).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
-    expect(allFilter.querySelector(".lucide-funnel")).toBeInTheDocument()
-    expect(allFilter).not.toHaveTextContent("All")
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
-    await user.click(allFilter)
+    await user.click(within(chats).getByRole("button", { name: "Filter chats by agent" }))
     await user.click(screen.getByRole("menuitemradio", { name: "Beta" }))
     expect(within(chats).queryByText("Alpha closed")).not.toBeInTheDocument()
     expect(within(chats).queryByText("Alpha open")).not.toBeInTheDocument()
     expect(within(chats).getByText("Beta open")).toBeInTheDocument()
-    const betaFilter = within(chats).getByRole("button", { name: "Filter chats: Beta" })
-    expect(betaFilter).toHaveAttribute("data-active", "true")
-    expect(betaFilter).toHaveTextContent("Beta")
+    expect(within(chats).getByRole("button", { name: "Filter chats by agent" })).toHaveTextContent("Beta")
 
-    await user.click(betaFilter)
+    await user.click(within(chats).getByRole("button", { name: "Filter chats by agent" }))
     await user.click(screen.getByRole("menuitemradio", { name: "All agents" }))
     expect(within(chats).getByText("Alpha closed")).toBeInTheDocument()
     expect(within(chats).getByText("Alpha open")).toBeInTheDocument()
     expect(within(chats).getByText("Beta open")).toBeInTheDocument()
-    expect(within(chats).getByRole("button", { name: "Filter chats: All" })).not.toHaveTextContent("Beta")
   })
 
   it("can filter an agent whose id is all without colliding with the All option", async () => {
@@ -196,7 +188,7 @@ describe("AppLeftPane", () => {
     )
 
     const chats = screen.getByRole("region", { name: "Chats" })
-    await user.click(within(chats).getByRole("button", { name: "Filter chats: All" }))
+    await user.click(within(chats).getByRole("button", { name: "Filter chats by agent" }))
     await user.click(screen.getByRole("menuitemradio", { name: "All-purpose" }))
     expect(within(chats).getByText("All-purpose chat")).toBeInTheDocument()
     expect(within(chats).queryByText("Beta chat")).not.toBeInTheDocument()
@@ -510,7 +502,7 @@ describe("AppLeftPane", () => {
 
     expect(screen.queryByRole("combobox", { name: "Agent" })).not.toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Workspace" })).toHaveAttribute("aria-expanded", "true")
-    expect(screen.queryByRole("button", { name: /Filter chats:/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Filter chats by agent" })).not.toBeInTheDocument()
     expect(screen.queryByRole("button", { name: "Agents" })).not.toBeInTheDocument()
     expect(screen.queryByRole("region", { name: "Agents" })).not.toBeInTheDocument()
     expect(document.querySelector('[data-boring-workspace-part="app-left-agent-group"]')).not.toBeInTheDocument()


### PR DESCRIPTION
## What changed

- Render addressed agent names as non-interactive labels with their presence dot.
- Move create-on-active-pane behavior to a dedicated Lucide plus icon button.
- Keep split and quick-chat as always-visible icon actions in `+`, columns, zap order.
- Preserve 44×44 mobile touch targets and compact 24×24 desktop icon sizing.
- Apply the same row treatment to single-agent deployments without adding AGENTS section chrome.
- Restore `WORKSPACE` as an expanded-by-default Disclosure section above Agents/Pinned/Chats.
- Keep Search and host-supplied workspace actions unchanged inside the disclosure and remove the replacement hairline divider.

## Why

The previous wide bordered primary control made the agent name itself look and behave like a button. The simplified pane also removed the Workspace section header, leaving its actions inconsistent with the other collapsible sections. This restores a consistent section hierarchy while keeping all agent actions discoverable.

## Proof of work

Automated verification:
- `pnpm exec vitest run src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx --no-file-parallelism` from `packages/workspace` ✅ (18 tests on final head)
- `pnpm typecheck` ✅
- `pnpm lint:invariants` ✅
- Root typecheck rebuilt `packages/agent`; `packages/agent/dist/front/styles.css` verified at 166,664 bytes (>100 KB) ✅

Acceptance proof:
- Agent labels have no button role/click handler; each addressed row exposes three separate action buttons when the three callbacks are supplied.
- Unit coverage locks action order as `New chat`, split, quick and verifies the `+` callback retains create-on-active-pane behavior.
- Split/quick labels and `lucide-columns-2` / `lucide-zap` classes are unchanged.
- Unit coverage asserts Workspace → Agents → Pinned → Chats order, expanded-by-default state, and collapse hiding both Search and a host-supplied Inbox action.

CI repair:
- Initial UI Review correctly caught 24×24 mobile action targets.
- Fixed with responsive `size-11` mobile / `size-6` desktop controls and a 44px mobile / 32px desktop row.

Review:
- Fresh-eyes review found one proof gap (host-supplied Workspace action was not covered); fixed in the unit test.
- Tier-1 thermo/maintainability review of the requested diff ✅; no structural findings.

E2E:
- Browser suite intentionally not run locally per owner direction; CI owns it.
- No E2E selectors moved or changed in the final diff.

Waiver / known gaps:
- No local browser run, by explicit request.