### PR TITLE
#909 fix(console): agent rows are not hoverable, only their actions

### DIFF
--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -465,7 +465,7 @@ export function AppLeftPane({
         role={announce ? "status" : undefined}
         aria-label={announce ? `${agent.label} ${activity}` : undefined}
         data-boring-agent-activity={activity}
-        className="flex items-center gap-1.5"
+        className="flex min-w-0 items-center gap-1.5"
       >
         <span
           aria-hidden="true"
@@ -473,7 +473,7 @@ export function AppLeftPane({
             ? "size-1.5 rounded-full bg-[color:var(--accent)]"
             : "size-1.5 rounded-full bg-muted-foreground/35"}
         />
-        <span>{agent.label}</span>
+        <span className="min-w-0 truncate">{agent.label}</span>
       </span>
     )
   }

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { Plus, Zap } from "lucide-react"
+import { Bot, Plus, Zap } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { AppLeftPaneSplitAction } from "./AppLeftPaneSplitAction"
+import { PaneRow } from "./AppLeftPaneRow"
 
 export interface AgentNewChatOption {
   agentTypeId: string
@@ -137,48 +138,53 @@ export function AgentNewChatAction({
   onCreatePopoverSession?: () => void
 }) {
   return (
-    <div className="group flex h-11 w-full items-center gap-2 rounded-md px-2.5 text-left text-[13px] font-medium text-foreground/78 transition-colors hover:bg-foreground/[0.055] hover:text-foreground [@media(hover:hover)_and_(min-width:640px)]:h-8 [@media(hover:hover)_and_(min-width:640px)]:py-1">
-      <span className="min-w-0 flex-1 truncate">{label}</span>
-      <span className="flex shrink-0 items-center gap-0.5">
-        <button
-          type="button"
-          aria-label={ariaLabel}
-          title={ariaLabel}
-          onClick={(event) => {
-            onCreateSession()
-            event.currentTarget.blur()
-          }}
-          className="grid size-11 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:size-6"
-        >
-          <Plus className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
-        </button>
-        {onCreateSplitSession ? (
-          <AppLeftPaneSplitAction
-            ariaLabel={splitAriaLabel}
-            title={splitAriaLabel}
-            touchResponsive
-            onClick={(event) => {
-              onCreateSplitSession()
-              event.currentTarget.blur()
-            }}
-          />
-        ) : null}
-        {onCreatePopoverSession ? (
+    <PaneRow
+      data-boring-workspace-part="app-agent-row"
+      leadingIcon={<Bot className="h-4 w-4" strokeWidth={1.75} />}
+      label={label}
+      className="text-foreground/78"
+      trailing={(
+        <>
           <button
             type="button"
-            aria-label={quickChatAriaLabel}
-            title={quickChatAriaLabel}
+            aria-label={ariaLabel}
+            title={ariaLabel}
             onClick={(event) => {
-              onCreatePopoverSession()
+              onCreateSession()
               event.currentTarget.blur()
             }}
-            className="grid size-11 shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:size-6"
+            className="grid size-11 shrink-0 cursor-pointer place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:size-6"
           >
-            <Zap className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
+            <Plus className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
           </button>
-        ) : null}
-      </span>
-    </div>
+          {onCreateSplitSession ? (
+            <AppLeftPaneSplitAction
+              ariaLabel={splitAriaLabel}
+              title={splitAriaLabel}
+              touchResponsive
+              onClick={(event) => {
+                onCreateSplitSession()
+                event.currentTarget.blur()
+              }}
+            />
+          ) : null}
+          {onCreatePopoverSession ? (
+            <button
+              type="button"
+              aria-label={quickChatAriaLabel}
+              title={quickChatAriaLabel}
+              onClick={(event) => {
+                onCreatePopoverSession()
+                event.currentTarget.blur()
+              }}
+              className="grid size-11 shrink-0 cursor-pointer place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 [@media(hover:hover)_and_(min-width:640px)]:size-6"
+            >
+              <Zap className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
+            </button>
+          ) : null}
+        </>
+      )}
+    />
   )
 }
 

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneRow.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import type { ComponentPropsWithoutRef, ReactNode } from "react"
+import { cn } from "../../lib/utils"
+
+export function PaneRow({
+  leadingIcon,
+  label,
+  trailing,
+  interactive = false,
+  className,
+  ...props
+}: Omit<ComponentPropsWithoutRef<"div">, "children"> & {
+  leadingIcon: ReactNode
+  label: ReactNode
+  trailing?: ReactNode
+  interactive?: boolean
+}) {
+  return (
+    <div
+      {...props}
+      className={cn(
+        "flex h-11 w-full items-center gap-2 rounded-md border border-transparent px-2.5 text-left [@media(hover:hover)_and_(min-width:640px)]:h-8 [@media(hover:hover)_and_(min-width:640px)]:py-1",
+        interactive && "group cursor-pointer transition-colors",
+        className,
+      )}
+    >
+      <span
+        data-boring-workspace-part="app-pane-row-type-icon"
+        className="grid size-4 shrink-0 place-items-center text-muted-foreground/65"
+        aria-hidden="true"
+      >
+        {leadingIcon}
+      </span>
+      <div
+        data-boring-workspace-part="app-pane-row-label"
+        className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5"
+      >
+        {label}
+      </div>
+      {trailing ? (
+        <div
+          data-boring-workspace-part="app-pane-row-actions"
+          className="flex shrink-0 items-center gap-0.5"
+        >
+          {trailing}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Clock3, Pin } from "lucide-react"
+import { MessageSquare, Pin } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { CHAT_SESSION_DRAG_TYPE } from "../ChatPaneStage"
 import type { WorkspaceAttentionSessionBadge } from "../../attention/WorkspaceAttentionProvider"
@@ -10,6 +10,7 @@ import { AppSessionActionsMenu } from "./AppSessionActionsMenu"
 import { InlineSessionRename, useInlineSessionRename } from "./InlineSessionRename"
 import { encodeWorkspaceSessionDrag } from "../../sessionIdentity"
 import { AppLeftPaneSplitAction } from "./AppLeftPaneSplitAction"
+import { PaneRow } from "./AppLeftPaneRow"
 
 export type AppSessionRowState = "normal" | "open" | "active"
 
@@ -82,7 +83,7 @@ export function AppSessionRow({
   const activate = () => onSwitch(session.id)
 
   return (
-    <div
+    <PaneRow
       data-boring-workspace-part="app-session-row"
       data-boring-session-id={session.id}
       data-boring-agent-type-id={session.agentTypeId}
@@ -107,25 +108,17 @@ export function AppSessionRow({
       onClick={() => {
         if (!rename.editing) activate()
       }}
+      interactive
+      leadingIcon={<MessageSquare className="h-4 w-4" strokeWidth={1.75} />}
       className={cn(
-        "group flex min-h-8 w-full items-center gap-2 rounded-md border px-2.5 py-1 text-left transition-colors",
         state === "active"
           // Subtle accent-tinted fill, no heavy colored border (Linear/Stripe style).
-          ? "border-transparent bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-foreground"
+          ? "bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-foreground"
           : state === "open"
-            ? "cursor-pointer border-transparent bg-foreground/[0.05] text-foreground/90 hover:bg-foreground/[0.07]"
-            : "cursor-pointer border-transparent text-foreground/78 hover:bg-foreground/[0.055] hover:text-foreground",
+            ? "bg-foreground/[0.05] text-foreground/90 hover:bg-foreground/[0.07]"
+            : "text-foreground/78 hover:bg-foreground/[0.055] hover:text-foreground",
       )}
-    >
-      <Clock3
-        className={cn(
-          "h-3.5 w-3.5 shrink-0",
-          state === "active" ? "text-[color:var(--accent)]" : "text-muted-foreground/65",
-        )}
-        strokeWidth={1.75}
-        aria-hidden="true"
-      />
-      {rename.field ? (
+      label={rename.field ? (
         <InlineSessionRename field={rename.field} onCancel={rename.cancel} />
       ) : (
         <button
@@ -135,96 +128,100 @@ export function AppSessionRow({
             activate()
           }}
           aria-current={state === "active" ? "page" : undefined}
-          className="min-w-0 flex-1 truncate rounded text-left text-[13px] font-medium leading-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          className="w-full min-w-0 truncate rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
           title={title}
         >
           {title}
         </button>
       )}
-      {agentBadge ? (
-        <span
-          data-boring-workspace-part="app-session-agent-badge"
-          data-boring-agent-badge={agentBadge.agentTypeId}
-          className="inline-flex max-w-20 shrink-0 truncate rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
-          title={agentBadge.label}
-        >
-          {agentBadge.label}
-        </span>
-      ) : null}
-      {attentionBadge ? (
-        <span
-          data-boring-workspace-part="app-session-badge"
-          data-boring-badge={attentionBadge.kind}
-          className={cn("pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none", sessionBadgeToneClassName(attentionBadge.tone))}
-        >
-          <span aria-hidden="true" className={cn("h-1.5 w-1.5 animate-pulse rounded-full", sessionBadgeDotClassName(attentionBadge.tone))} />
-          {attentionBadge.label}
-        </span>
-      ) : working ? (
-        <span
-          data-boring-workspace-part="app-session-badge"
-          data-boring-badge="working"
-          className="pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
-        >
-          <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--accent)]" />
-          working
-        </span>
-      ) : null}
-      {canPin ? (
-        <span
-          data-boring-workspace-part="app-session-pin-action"
-          className={cn(
-            "flex w-0 shrink-0 items-center overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100",
-            pinned && "ml-1 w-auto opacity-100",
-          )}
-        >
-          <button
-            type="button"
-            aria-label={pinned ? `Unpin ${title}` : `Pin ${title}`}
-            title={pinned ? "Unpin" : "Pin"}
-            aria-pressed={pinned}
-            onClick={(event) => {
-              event.stopPropagation()
-              onTogglePinned(session.id)
-            }}
-            className={cn(
-              "grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
-              pinned && "text-[color:var(--accent)]",
-            )}
-          >
-            <Pin className={cn("h-3.5 w-3.5", pinned && "fill-current")} strokeWidth={1.75} />
-          </button>
-        </span>
-      ) : null}
-      {/* Keep the split action visible for closed, same-project sessions: it
-          is the first-class path to watching another chat alongside the
-          current one. A cross-project session cannot share this stage. */}
-      {state === "normal" && canSplit && !rename.editing ? (
-        <AppLeftPaneSplitAction
-          ariaLabel={`Open ${title} in split`}
-          title="Open in split"
-          onClick={(event) => {
-            event.stopPropagation()
-            onOpenAsPane(session.id)
-          }}
-        />
-      ) : null}
-      {showMenu ? (
-        <span
-          data-boring-workspace-part="app-session-actions"
-          className="flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100"
-        >
-          <AppSessionActionsMenu
-            sessionId={session.id}
-            title={title}
-            canCopy={canCopy}
-            canRename={renameAvailable && !rename.editing}
-            onRename={rename.begin}
-            onDelete={onDelete}
-            onOpenChange={setMenuOpen}
-          />
-        </span>
-      ) : null}
-    </div>
+      trailing={(
+        <>
+          {agentBadge ? (
+            <span
+              data-boring-workspace-part="app-session-agent-badge"
+              data-boring-agent-badge={agentBadge.agentTypeId}
+              className="inline-flex max-w-20 shrink-0 truncate rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
+              title={agentBadge.label}
+            >
+              {agentBadge.label}
+            </span>
+          ) : null}
+          {attentionBadge ? (
+            <span
+              data-boring-workspace-part="app-session-badge"
+              data-boring-badge={attentionBadge.kind}
+              className={cn("pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none", sessionBadgeToneClassName(attentionBadge.tone))}
+            >
+              <span aria-hidden="true" className={cn("h-1.5 w-1.5 animate-pulse rounded-full", sessionBadgeDotClassName(attentionBadge.tone))} />
+              {attentionBadge.label}
+            </span>
+          ) : working ? (
+            <span
+              data-boring-workspace-part="app-session-badge"
+              data-boring-badge="working"
+              className="pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
+            >
+              <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--accent)]" />
+              working
+            </span>
+          ) : null}
+          {canPin ? (
+            <span
+              data-boring-workspace-part="app-session-pin-action"
+              className={cn(
+                "flex w-0 shrink-0 items-center overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100",
+                pinned && "ml-1 w-auto opacity-100",
+              )}
+            >
+              <button
+                type="button"
+                aria-label={pinned ? `Unpin ${title}` : `Pin ${title}`}
+                title={pinned ? "Unpin" : "Pin"}
+                aria-pressed={pinned}
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onTogglePinned(session.id)
+                }}
+                className={cn(
+                  "grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+                  pinned && "text-[color:var(--accent)]",
+                )}
+              >
+                <Pin className={cn("h-3.5 w-3.5", pinned && "fill-current")} strokeWidth={1.75} />
+              </button>
+            </span>
+          ) : null}
+          {/* Keep the split action visible for closed, same-project sessions: it
+              is the first-class path to watching another chat alongside the
+              current one. A cross-project session cannot share this stage. */}
+          {state === "normal" && canSplit && !rename.editing ? (
+            <AppLeftPaneSplitAction
+              ariaLabel={`Open ${title} in split`}
+              title="Open in split"
+              onClick={(event) => {
+                event.stopPropagation()
+                onOpenAsPane(session.id)
+              }}
+            />
+          ) : null}
+          {showMenu ? (
+            <span
+              data-boring-workspace-part="app-session-actions"
+              className="flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100"
+            >
+              <AppSessionActionsMenu
+                sessionId={session.id}
+                title={title}
+                canCopy={canCopy}
+                canRename={renameAvailable && !rename.editing}
+                onRename={rename.begin}
+                onDelete={onDelete}
+                onOpenChange={setMenuOpen}
+              />
+            </span>
+          ) : null}
+        </>
+      )}
+    />
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSplitAction.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSplitAction.tsx
@@ -24,7 +24,7 @@ export function AppLeftPaneSplitAction({
       title={title}
       onClick={onClick}
       className={cn(
-        "grid shrink-0 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+        "grid shrink-0 cursor-pointer place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
         transitionColors && "transition-colors",
         touchResponsive
           ? "size-11 [@media(hover:hover)_and_(min-width:640px)]:size-6"

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -97,6 +97,30 @@ describe("AppLeftPane", () => {
     expect(within(screen.getByRole("region", { name: "Beta agent" })).queryByText("Beta pinned")).not.toBeInTheDocument()
     expect(screen.queryByRole("combobox", { name: "Agent" })).not.toBeInTheDocument()
 
+    const agentRow = within(screen.getByRole("region", { name: "Alpha agent" }))
+      .getByText("Alpha")
+      .closest('[data-boring-workspace-part="app-agent-row"]')
+    const sessionRow = screen.getByText("Alpha chat").closest('[data-boring-workspace-part="app-session-row"]')
+    const pinnedSessionRow = screen.getByText("Beta pinned").closest('[data-boring-workspace-part="app-session-row"]')
+    const sharedGeometry = [
+      "h-11",
+      "gap-2",
+      "rounded-md",
+      "border",
+      "border-transparent",
+      "px-2.5",
+      "[@media(hover:hover)_and_(min-width:640px)]:h-8",
+      "[@media(hover:hover)_and_(min-width:640px)]:py-1",
+    ]
+    expect(agentRow).toHaveClass(...sharedGeometry)
+    expect(sessionRow).toHaveClass(...sharedGeometry)
+    expect(agentRow?.querySelector(".lucide-bot")).toBeInTheDocument()
+    expect(sessionRow?.querySelector(".lucide-message-square")).toBeInTheDocument()
+    expect(pinnedSessionRow?.querySelector(".lucide-message-square")).toBeInTheDocument()
+    expect(within(pinnedSessionRow as HTMLElement).getByRole("button", { name: "Unpin Beta pinned" })).toHaveAttribute("aria-pressed", "true")
+    expect(agentRow).not.toHaveClass("group", "cursor-pointer")
+    expect(sessionRow).toHaveClass("group", "cursor-pointer")
+
     act(() => {
       window.dispatchEvent(new CustomEvent("boring:chat-session-status", {
         detail: { sessionId: "a1", agentTypeId: "alpha", working: true },
@@ -236,6 +260,7 @@ describe("AppLeftPane", () => {
     expect(document.querySelector('[aria-label$=" chats"]')).not.toBeInTheDocument()
     const betaAgent = screen.getByRole("region", { name: "Beta agent" })
     expect(within(betaAgent).getByText("Beta").closest("button")).toBeNull()
+    expect(within(betaAgent).getByText("Beta")).toHaveClass("min-w-0", "truncate")
     expect(within(betaAgent).getAllByRole("button")).toHaveLength(3)
     expect(within(betaAgent).getAllByRole("button").map((button) => button.getAttribute("aria-label"))).toEqual([
       "New chat with Beta",
@@ -245,17 +270,36 @@ describe("AppLeftPane", () => {
     const betaAction = screen.getByRole("button", { name: "New chat with Beta" })
     const alphaSplitAction = screen.getByRole("button", { name: "New chat with Alpha in split" })
     const betaQuickAction = screen.getByRole("button", { name: "Quick chat with Beta" })
+    const betaAgentRow = betaAction.parentElement?.parentElement
     expect(betaAction).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
-    expect(betaAction.closest(".group")).toHaveClass(
+    expect(betaAgentRow).toHaveClass(
       "h-11",
+      "gap-2",
       "rounded-md",
+      "border",
+      "border-transparent",
       "px-2.5",
       "[@media(hover:hover)_and_(min-width:640px)]:h-8",
       "[@media(hover:hover)_and_(min-width:640px)]:py-1",
     )
+    expect(betaAgentRow).not.toHaveClass(
+      "group",
+      "cursor-pointer",
+      "hover:bg-foreground/[0.055]",
+      "hover:text-foreground",
+    )
+    expect(betaAction).toHaveClass("cursor-pointer", "hover:bg-background", "hover:text-foreground")
     expect(betaAction.querySelector(".lucide-plus")).toBeInTheDocument()
-    expect(alphaSplitAction).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
+    expect(alphaSplitAction).toHaveClass(
+      "cursor-pointer",
+      "hover:bg-background",
+      "hover:text-foreground",
+      "focus-visible:ring-2",
+      "size-11",
+      "[@media(hover:hover)_and_(min-width:640px)]:size-6",
+    )
     expect(alphaSplitAction.querySelector(".lucide-columns-2")).toBeInTheDocument()
+    expect(betaQuickAction).toHaveClass("cursor-pointer", "hover:bg-background", "hover:text-foreground", "focus-visible:ring-2")
     expect(betaQuickAction.querySelector(".lucide-zap")).toBeInTheDocument()
     expect(alphaSplitAction.parentElement).toHaveClass("flex", "shrink-0", "items-center", "gap-0.5")
 
@@ -521,10 +565,21 @@ describe("AppLeftPane", () => {
     expect(screen.getByText("Alpha chat")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Unpin Alpha chat" })).toBeInTheDocument()
     const newChatAction = screen.getByRole("button", { name: "New chat with Alpha" })
-    const agentRow = newChatAction.closest(".group")
+    const agentRow = newChatAction.parentElement?.parentElement
     expect(agentRow).not.toBeNull()
+    expect(agentRow?.querySelector(".lucide-bot")).toBeInTheDocument()
     expect(within(agentRow as HTMLElement).getByText("Alpha").closest("button")).toBeNull()
+    expect(agentRow).not.toHaveClass(
+      "group",
+      "cursor-pointer",
+      "hover:bg-foreground/[0.055]",
+      "hover:text-foreground",
+    )
     expect(newChatAction).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
+    expect(within(agentRow as HTMLElement).getAllByRole("button")).toHaveLength(3)
+    for (const action of within(agentRow as HTMLElement).getAllByRole("button")) {
+      expect(action).toHaveClass("cursor-pointer", "hover:bg-background", "hover:text-foreground", "focus-visible:ring-2")
+    }
 
     fireEvent.click(screen.getByRole("button", { name: "New chat with Alpha" }))
     fireEvent.click(screen.getByRole("button", { name: "New chat with Alpha in split" }))

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -118,7 +118,8 @@ describe("AppLeftPane", () => {
     expect(sessionRow?.querySelector(".lucide-message-square")).toBeInTheDocument()
     expect(pinnedSessionRow?.querySelector(".lucide-message-square")).toBeInTheDocument()
     expect(within(pinnedSessionRow as HTMLElement).getByRole("button", { name: "Unpin Beta pinned" })).toHaveAttribute("aria-pressed", "true")
-    expect(agentRow).not.toHaveClass("group", "cursor-pointer")
+    expect(agentRow).not.toHaveClass("group")
+    expect(agentRow).not.toHaveClass("cursor-pointer")
     expect(sessionRow).toHaveClass("group", "cursor-pointer")
 
     act(() => {
@@ -282,12 +283,14 @@ describe("AppLeftPane", () => {
       "[@media(hover:hover)_and_(min-width:640px)]:h-8",
       "[@media(hover:hover)_and_(min-width:640px)]:py-1",
     )
-    expect(betaAgentRow).not.toHaveClass(
+    for (const className of [
       "group",
       "cursor-pointer",
       "hover:bg-foreground/[0.055]",
       "hover:text-foreground",
-    )
+    ]) {
+      expect(betaAgentRow).not.toHaveClass(className)
+    }
     expect(betaAction).toHaveClass("cursor-pointer", "hover:bg-background", "hover:text-foreground")
     expect(betaAction.querySelector(".lucide-plus")).toBeInTheDocument()
     expect(alphaSplitAction).toHaveClass(
@@ -569,12 +572,14 @@ describe("AppLeftPane", () => {
     expect(agentRow).not.toBeNull()
     expect(agentRow?.querySelector(".lucide-bot")).toBeInTheDocument()
     expect(within(agentRow as HTMLElement).getByText("Alpha").closest("button")).toBeNull()
-    expect(agentRow).not.toHaveClass(
+    for (const className of [
       "group",
       "cursor-pointer",
       "hover:bg-foreground/[0.055]",
       "hover:text-foreground",
-    )
+    ]) {
+      expect(agentRow).not.toHaveClass(className)
+    }
     expect(newChatAction).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")
     expect(within(agentRow as HTMLElement).getAllByRole("button")).toHaveLength(3)
     for (const action of within(agentRow as HTMLElement).getAllByRole("button")) {


### PR DESCRIPTION
## Summary

- extract one `PaneRow` primitive for agent and session rows so height, padding, radius, gaps, label typography/truncation, and trailing-action geometry stay aligned
- render muted `Bot` icons for agent rows and `MessageSquare` icons for session rows while preserving agent presence dots and pinned-session pin state
- keep agent rows non-interactive with no row hover/group/pointer affordance; keep the three agent action buttons visible and independently hoverable/focusable
- preserve clickable session-row hover behavior through the primitive's explicit `interactive` variant

## Root cause

Agent rows still carried the old wide-button `group` and row-hover classes, while agent and session rows separately defined their geometry. That both advertised the agent row as clickable and allowed the two row styles to drift.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint:invariants` ✅
- `pnpm vitest run src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx --no-file-parallelism` from `packages/workspace` ✅ (18/18)
- `packages/agent/dist/front/styles.css` after the typecheck rebuild: 166,664 bytes (>100KB) ✅
- independent tier-1 thermo review: one label-truncation finding integrated; final verdict otherwise clean ✅

Browser tests were not run locally per owner direction; CI owns browser coverage.
