### PR TITLE
#909 fix(console): surface gateway errors and mark orphaned sessions read-only

### DIFF
--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -61,6 +61,52 @@ async function expectHorizontalSplit(
 }
 
 test.describe("addressed Agent Host browser wire", () => {
+  test("marks a chat read-only after a structured runtime-scope mutation failure", async ({ page }) => {
+    test.setTimeout(90_000)
+
+    await page.goto("/?fresh=1")
+    await page.getByRole("button", { name: "New chat with Alpha", exact: true }).click()
+    const chat = page.locator('[data-boring-agent-part="chat"][data-agent-type-id="alpha"]').last()
+    await expect(chat).toHaveAttribute("data-pi-chat-session-id", /^local-/, { timeout: 15_000 })
+    const sessionId = await sendFirstAddressedMessage(page, chat, "alpha", `orphan fixture ${Date.now()}`)
+    await expect(chat.getByTestId("chat-working")).toHaveCount(0, { timeout: 30_000 })
+
+    await page.route(`**/api/v1/agents/alpha/sessions/${sessionId}/rename`, async (route) => {
+      await route.fulfill({
+        status: 409,
+        contentType: "application/json",
+        body: JSON.stringify({
+          error: {
+            code: "AGENT_SESSION_RUNTIME_SCOPE_MISMATCH",
+            message: "session is pinned to a different runtime scope",
+          },
+        }),
+      })
+    })
+
+    const row = page.getByRole("region", { name: "Chats" }).locator(
+      `[data-boring-workspace-part="app-session-row"][data-boring-session-id="${sessionId}"][data-boring-agent-type-id="alpha"]`,
+    )
+    await row.hover()
+    await row.getByRole("button", { name: /More options/ }).click()
+    await page.getByRole("menuitem", { name: "Rename" }).click()
+    const rename = row.getByRole("textbox", { name: "Rename session" })
+    await rename.fill("Should not save")
+    await rename.press("Enter")
+
+    const explanation = "This chat belongs to a previous runtime configuration and can no longer be changed."
+    await expect(row).toHaveAttribute("data-boring-session-read-only", "true")
+    await expect(row.getByLabel(`Read-only chat. ${explanation}`)).toBeVisible()
+    await expect(page.getByText(/previous runtime configuration.*AGENT_SESSION_RUNTIME_SCOPE_MISMATCH/i)).toBeVisible()
+    await expect(chat.getByRole("textbox", { name: "Agent prompt" })).toBeDisabled()
+    await expect(chat.getByRole("status").filter({ hasText: explanation })).toBeVisible()
+
+    await row.hover()
+    await row.getByRole("button", { name: /More options/ }).click()
+    await expect(page.getByRole("menuitem", { name: "Rename" })).toBeDisabled()
+    await expect(page.getByRole("menuitem", { name: "Delete" })).toBeDisabled()
+  })
+
   test("creates addressed chats from named agent rows and opens them in split", async ({ page }) => {
     test.setTimeout(90_000)
 

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -137,6 +137,10 @@ export interface PiChatPanelProps<
   sessionId?: string
   /** Explicitly marks an externally selected browser-only session. */
   sessionEphemeral?: boolean
+  /** Marks an externally selected session as readable but not mutable. */
+  sessionReadOnly?: boolean
+  /** Human explanation shown above a disabled composer for a read-only session. */
+  sessionReadOnlyReason?: string
   /** Selects the additive addressed AgentGateway transport. Omit for legacy wire. */
   agentTypeId?: string
   /** Discovers addressed agents and shows a minimal selector. */
@@ -214,6 +218,8 @@ export function PiChatPanel<
 >({
   sessionId,
   sessionEphemeral = false,
+  sessionReadOnly = false,
+  sessionReadOnlyReason,
   agentTypeId,
   addressedAgentSelection = false,
   agentSelection: controlledAgentSelection,
@@ -496,11 +502,17 @@ export function PiChatPanel<
   const emptyStateHydrating = statusForState(selectedChatState, sessionsLoading || chatStatePending || selectedSessionPending) === 'hydrating'
   const emptyHero = emptyPlacement === 'hero' && messages.length === 0 && queuePreview.length === 0 && !emptyStateHydrating
   const debugState = selectedPiSession?.getDebugState()
-  const composerBlocked = workspaceWarmupBlocked || activeBlockers.length > 0
+  const activeSessionReadOnly = sessionReadOnly || sessions.activeSession?.readOnly === true
+  const activeSessionReadOnlyReason = sessionReadOnlyReason
+    ?? sessions.activeSession?.readOnlyReason
+    ?? 'This chat is read-only.'
+  const composerBlocked = workspaceWarmupBlocked || activeSessionReadOnly || activeBlockers.length > 0
   const primaryComposerBlocker = activeBlockers[0]
   const composerBlockerLabel = workspaceWarmupBlocked
     ? (warmupNotice?.title ?? 'Preparing workspace...')
-    : primaryComposerBlocker?.label ?? primaryComposerBlocker?.reason ?? 'Complete the pending workspace action to continue.'
+    : activeSessionReadOnly
+      ? activeSessionReadOnlyReason
+      : primaryComposerBlocker?.label ?? primaryComposerBlocker?.reason ?? 'Complete the pending workspace action to continue.'
   const composerStatusNotice = warmupNotice ?? runtimeDependenciesNotice
   const runtimeNotices = useMemo(() => {
     const fromState = selectedChatState ? selectRuntimeNotices(selectedChatState) : []

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -725,6 +725,26 @@ describe('PiChatPanel sandbox shell', () => {
     expect(onTurnComplete).not.toHaveBeenCalled()
   })
 
+  test('disables the composer with the read-only runtime explanation for an orphaned session', async () => {
+    const remote = new FakeRemotePiSession(remoteState({ status: 'idle' }))
+    render(
+      <PiChatPanel
+        sessionId="pi-1"
+        sessionReadOnly
+        sessionReadOnlyReason="This chat belongs to a previous runtime configuration and can no longer be changed."
+        serverResourcesEnabled={false}
+        storageScope="scope-a"
+        createRemoteSession={remoteFactory(remote)}
+      />,
+    )
+
+    const textarea = await screen.findByLabelText('Agent prompt') as HTMLTextAreaElement
+    expect(textarea.disabled).toBe(true)
+    expect(textarea.readOnly).toBe(true)
+    expect(screen.getByRole('status').textContent).toContain('This chat belongs to a previous runtime configuration and can no longer be changed.')
+    expect(remote.prompt).not.toHaveBeenCalled()
+  })
+
   test('fires onTurnComplete per turn-settle event, including back-to-back queued turns', async () => {
     const remote = new FakeRemotePiSession(remoteState({ status: 'idle' }))
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse([session('pi-1')]))

--- a/packages/agent/src/front/chat/__tests__/useAddressedAgentSelection.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/useAddressedAgentSelection.test.tsx
@@ -2,6 +2,7 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { StrictMode, type ReactNode } from 'react'
 import { describe, expect, test, vi } from 'vitest'
+import { AgentGatewayErrorCode } from '../../../shared/gateway/errors'
 import { useAddressedAgentSelection } from '../useAddressedAgentSelection'
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -57,6 +58,23 @@ describe('useAddressedAgentSelection', () => {
     expect(result.current.loading).toBe(false)
     expect(result.current.selectedAgentTypeId).toBeUndefined()
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test('surfaces the structured server message when agent discovery fails', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      error: { code: AgentGatewayErrorCode.AGENT_GATEWAY_CLOSED, message: 'Agent catalog is restarting.' },
+    }, 503))
+    const { result } = renderHook(() => useAddressedAgentSelection({
+      fetch: fetchMock as unknown as typeof fetch,
+      enabled: true,
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toMatchObject({
+      code: AgentGatewayErrorCode.AGENT_GATEWAY_CLOSED,
+      message: 'Agent catalog is restarting.',
+    })
+    expect(result.current.error?.message).not.toContain('503')
   })
 
   test('keeps a selected agent across refresh and falls back when it disappears', async () => {

--- a/packages/agent/src/front/chat/gatewayResponseError.ts
+++ b/packages/agent/src/front/chat/gatewayResponseError.ts
@@ -1,0 +1,101 @@
+import { ErrorCode } from '../../shared/error-codes'
+import {
+  AGENT_GATEWAY_ERROR_CODES,
+  AgentGatewayErrorCode,
+  type AgentGatewayErrorCode as AgentGatewayErrorCodeValue,
+} from '../../shared/gateway/errors'
+import type { JsonValue } from '../../shared/gateway/types'
+
+export const RUNTIME_SCOPE_MISMATCH_MESSAGE = 'This chat belongs to a previous runtime configuration and can no longer be changed.'
+
+export type GatewayResponseErrorCode = AgentGatewayErrorCodeValue | ErrorCode
+
+export class GatewayResponseError extends Error {
+  readonly errorCode?: GatewayResponseErrorCode
+
+  constructor(
+    readonly status: number,
+    message: string,
+    readonly code?: GatewayResponseErrorCode,
+    readonly details?: JsonValue,
+    readonly body?: unknown,
+    readonly operation?: string,
+  ) {
+    super(message)
+    this.name = 'GatewayResponseError'
+    this.errorCode = code
+  }
+}
+
+export async function gatewayResponseError(
+  response: Response,
+  fallbackMessage: string,
+  operation?: string,
+): Promise<GatewayResponseError> {
+  const body = await safeReadJson(response)
+  return gatewayResponseErrorFromBody(response.status, body, fallbackMessage, operation)
+}
+
+export function gatewayResponseErrorFromBody(
+  status: number,
+  body: unknown,
+  fallbackMessage: string,
+  operation?: string,
+): GatewayResponseError {
+  const payload = errorPayload(body)
+  const code = gatewayResponseErrorCode(payload?.code)
+  const serverMessage = typeof payload?.message === 'string' && payload.message.trim().length > 0
+    ? payload.message
+    : fallbackMessage
+  const message = code === AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH
+    ? RUNTIME_SCOPE_MISMATCH_MESSAGE
+    : serverMessage
+  const details = isJsonValue(payload?.details) ? payload.details : undefined
+  return new GatewayResponseError(status, message, code, details, body, operation)
+}
+
+export function gatewayResponseErrorCode(value: unknown): GatewayResponseErrorCode | undefined {
+  const sharedCode = ErrorCode.safeParse(value)
+  if (sharedCode.success) return sharedCode.data
+  return typeof value === 'string' && (AGENT_GATEWAY_ERROR_CODES as readonly string[]).includes(value)
+    ? value as AgentGatewayErrorCodeValue
+    : undefined
+}
+
+export function errorResponseCode(error: unknown): GatewayResponseErrorCode | undefined {
+  if (error instanceof GatewayResponseError) return error.code
+  const record = typeof error === 'object' && error !== null
+    ? error as { code?: unknown; errorCode?: unknown }
+    : undefined
+  return gatewayResponseErrorCode(record?.code ?? record?.errorCode)
+}
+
+export function isRuntimeScopeMismatchError(error: unknown): boolean {
+  return errorResponseCode(error) === AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH
+}
+
+async function safeReadJson(response: Response): Promise<unknown> {
+  const text = await response.text()
+  if (!text) return undefined
+  try {
+    return JSON.parse(text)
+  } catch {
+    return undefined
+  }
+}
+
+function errorPayload(body: unknown): Record<string, unknown> | undefined {
+  if (typeof body !== 'object' || body === null) return undefined
+  const record = body as Record<string, unknown>
+  return typeof record.error === 'object' && record.error !== null
+    ? record.error as Record<string, unknown>
+    : record
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (value === null || ['string', 'number', 'boolean'].includes(typeof value)) return true
+  if (Array.isArray(value)) return value.every(isJsonValue)
+  return typeof value === 'object'
+    && value !== null
+    && Object.values(value as Record<string, unknown>).every(isJsonValue)
+}

--- a/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ErrorCode } from '../../../../shared/error-codes'
+import { AgentGatewayErrorCode } from '../../../../shared/gateway/errors'
+import { RUNTIME_SCOPE_MISMATCH_MESSAGE } from '../../gatewayResponseError'
 import type { PiChatEvent, PiChatSnapshot } from '../../../../shared/chat'
 import { PI_CHAT_CURSOR_AHEAD_CODE, PI_CHAT_REPLAY_GAP_CODE } from '../piChatStream'
 import { RemotePiSession, piChatErrorCode } from '../remotePiSession'
@@ -180,6 +182,31 @@ describe('RemotePiSession', () => {
     ])
     expect(fetchMock.mock.calls.some(([url]) => String(url).includes('/api/v1/agent/pi-chat/'))).toBe(false)
 
+    session.dispose()
+  })
+
+  it('reports a runtime-scope mismatch from the event stream before reconnecting', async () => {
+    const onGatewayError = vi.fn()
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/state')) return jsonResponse(snapshot({ seq: 42 }))
+      if (url.endsWith('/events?cursor=42')) {
+        return jsonResponse({
+          error: {
+            code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+            message: 'session is pinned to a different runtime scope',
+          },
+        }, 409)
+      }
+      throw new Error(`unexpected URL ${url}`)
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock, { onGatewayError })
+
+    await waitUntil(() => expect(onGatewayError).toHaveBeenCalled())
+
+    expect(onGatewayError.mock.calls[0]?.[0]).toMatchObject({
+      code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+      message: RUNTIME_SCOPE_MISMATCH_MESSAGE,
+    })
     session.dispose()
   })
 
@@ -863,6 +890,36 @@ describe('RemotePiSession', () => {
     )
     expect(piChatErrorCode(error)).toBe(ErrorCode.enum.SESSION_LOCKED)
     // The rejection also rolls back the optimistic message so the composer recovers.
+    expect(session.getState().optimisticOutbox).toEqual({})
+
+    session.dispose()
+  })
+
+  it('surfaces a gateway runtime-scope code and human message for prompt failures', async () => {
+    const events = openNdjsonStream()
+    const onGatewayError = vi.fn()
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith('/events?cursor=0')) return new Response(events.stream)
+      if (url.endsWith('/prompt')) {
+        return jsonResponse({
+          error: {
+            code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+            message: 'session is pinned to a different runtime scope',
+          },
+        }, 409)
+      }
+      throw new Error(`unexpected URL ${url}`)
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock, { autoStart: false, onGatewayError })
+
+    const error = await session.prompt({ message: 'hello', clientNonce: 'nonce-scope' }).catch((reason) => reason)
+
+    expect(error).toMatchObject({
+      code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+      message: RUNTIME_SCOPE_MISMATCH_MESSAGE,
+    })
+    expect(piChatErrorCode(error)).toBe(AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH)
+    expect(onGatewayError).toHaveBeenCalledWith(error)
     expect(session.getState().optimisticOutbox).toEqual({})
 
     session.dispose()

--- a/packages/agent/src/front/chat/pi/remotePiSession.ts
+++ b/packages/agent/src/front/chat/pi/remotePiSession.ts
@@ -42,6 +42,11 @@ import {
   readPiChatNdjsonStream,
   schedulePiChatReconnect,
 } from './piChatStream'
+import {
+  errorResponseCode,
+  gatewayResponseErrorFromBody,
+  GatewayResponseError,
+} from '../gatewayResponseError'
 
 const SUPPORTED_PROTOCOL_VERSION = 1
 const DEFAULT_RECONNECT_BASE_MS = 1_000
@@ -94,6 +99,8 @@ export interface RemotePiSessionOptions {
   // Per-attempt timeout for /state and command fetches. Defaults to
   // DEFAULT_REQUEST_TIMEOUT_MS; exposed mainly for tests.
   requestTimeoutMs?: number
+  /** Reports structured gateway failures so session-list owners can mark incompatible sessions read-only. */
+  onGatewayError?: (error: GatewayResponseError) => void
   /** Browser-local addressed session whose first prompt creates and adopts its durable ID. */
   nativeFirstPrompt?: {
     onAdopt: (session: SessionSummary) => void
@@ -428,7 +435,12 @@ export class RemotePiSession {
           markOpen()
           return
         }
-        this.dispatchProtocolError(routeErrorMessage(body, `Pi chat event stream failed with HTTP ${response.status}.`))
+        const error = this.reportGatewayError(gatewayResponseErrorFromBody(
+          response.status,
+          body,
+          'Pi chat event stream failed.',
+        ))
+        this.dispatchProtocolError(error.message)
         this.scheduleReconnect(generation)
         markOpen()
         return
@@ -630,7 +642,11 @@ export class RemotePiSession {
     try {
       const response = await this.fetchImpl(url, { ...init, signal: controller.signal })
       const body = await safeReadJson(response)
-      if (!response.ok) throw new RemotePiSessionHttpError(response.status, routeErrorMessage(body, `HTTP ${response.status}`), body, routeErrorCode(body))
+      if (!response.ok) throw this.reportGatewayError(gatewayResponseErrorFromBody(
+        response.status,
+        body,
+        'The chat request failed.',
+      ))
       return body
     } catch (error) {
       // Distinguish our own timeout abort from a dispose-driven abort: a
@@ -654,14 +670,22 @@ export class RemotePiSession {
     }
     const body = await safeReadJson(response)
     if (!response.ok) {
-      throw new RemotePiSessionHttpError(
+      throw this.reportGatewayError(gatewayResponseErrorFromBody(
         response.status,
-        routeErrorMessage(body, `HTTP ${response.status}`),
         body,
-        routeErrorCode(body),
-      )
+        'The chat request failed.',
+      ))
     }
     return body
+  }
+
+  private reportGatewayError(error: GatewayResponseError): GatewayResponseError {
+    try {
+      this.options.onGatewayError?.(error)
+    } catch {
+      // An observer must not replace the structured request failure.
+    }
+    return error
   }
 
   private async requestHeaders(): Promise<Record<string, string>> {
@@ -789,13 +813,6 @@ export function createRemotePiSession(options: RemotePiSessionOptions): RemotePi
   return new RemotePiSession(options)
 }
 
-class RemotePiSessionHttpError extends Error {
-  constructor(readonly status: number, message: string, readonly body: unknown, readonly errorCode?: string) {
-    super(message)
-    this.name = 'RemotePiSessionHttpError'
-  }
-}
-
 class RemotePiSessionRequestTimeoutError extends Error {
   constructor(url: string, timeoutMs: number) {
     super(`Request to ${url} timed out after ${timeoutMs}ms.`)
@@ -804,26 +821,18 @@ class RemotePiSessionRequestTimeoutError extends Error {
 }
 
 /**
- * Extract the stable, CANONICAL server error code (a member of the shared ErrorCode
- * enum, e.g. `SESSION_LOCKED`) from an error thrown by a command call (prompt/follow-up/
- * etc). Returns undefined for non-HTTP errors, bodies without a code, or non-canonical
- * codes. This is the agent's generic seam: callers map a code to UI (a notice action)
- * WITHOUT the agent knowing what the code means.
+ * Extract a stable server error code from a command failure. This accepts both
+ * the legacy shared ErrorCode enum and AgentGateway error codes.
  */
 export function piChatErrorCode(error: unknown): string | undefined {
-  if (error instanceof RemotePiSessionHttpError) return error.errorCode
-  // Also accept a plain `errorCode` carried on any thrown value, so callers that
-  // re-wrap or synthesize a command error can still surface a stable code — but only
-  // when it's a canonical ErrorCode, never an arbitrary string.
-  const parsed = ErrorCode.safeParse((error as { errorCode?: unknown } | null)?.errorCode)
-  return parsed.success ? parsed.data : undefined
+  return errorResponseCode(error)
 }
 
 function classifyNativeFirstPromptError(error: unknown): NativeFirstSendErrorKind {
   if (error instanceof TypeError
     || error instanceof RemotePiSessionRequestTimeoutError
     || error instanceof NativeFirstPromptInvalidReceiptError
-    || (error instanceof RemotePiSessionHttpError && error.status >= 500)) {
+    || (error instanceof GatewayResponseError && error.status >= 500)) {
     return NativeFirstSendErrorKind.Ambiguous
   }
   return NativeFirstSendErrorKind.Definite
@@ -860,23 +869,6 @@ async function safeReadJson(response: Response): Promise<unknown> {
   } catch {
     return undefined
   }
-}
-
-function routeErrorMessage(body: unknown, fallback: string): string {
-  if (typeof body !== 'object' || body === null) return fallback
-  const error = (body as Record<string, unknown>).error
-  const payload = typeof error === 'object' && error !== null ? error as Record<string, unknown> : body as Record<string, unknown>
-  return typeof payload.message === 'string' && payload.message ? payload.message : fallback
-}
-
-function routeErrorCode(body: unknown): string | undefined {
-  if (typeof body !== 'object' || body === null) return undefined
-  const error = (body as Record<string, unknown>).error
-  const payload = typeof error === 'object' && error !== null ? error as Record<string, unknown> : body as Record<string, unknown>
-  // Only surface a CANONICAL code: hosts treat notice.errorCode as a stable action
-  // key, so a malformed/legacy body must not leak an arbitrary string.
-  const parsed = ErrorCode.safeParse(payload.code)
-  return parsed.success ? parsed.data : undefined
 }
 
 function errorMessage(error: unknown, fallback: string): string {

--- a/packages/agent/src/front/chat/piChatPanelHooks.ts
+++ b/packages/agent/src/front/chat/piChatPanelHooks.ts
@@ -103,6 +103,7 @@ function remoteSessionOptionsIdentity(options: UsePiSessionsOptions['remoteSessi
     autoStart: options.autoStart,
     requestTimeoutMs: options.requestTimeoutMs,
     onEvent: remoteSessionOptionObjectIdentity(options.onEvent),
+    onGatewayError: remoteSessionOptionObjectIdentity(options.onGatewayError),
     storeOptions: remoteSessionOptionObjectIdentity(options.storeOptions),
     setTimeoutFn: remoteSessionOptionObjectIdentity(options.setTimeoutFn),
     clearTimeoutFn: remoteSessionOptionObjectIdentity(options.clearTimeoutFn),

--- a/packages/agent/src/front/chat/session/SessionList.tsx
+++ b/packages/agent/src/front/chat/session/SessionList.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import { useMemo } from 'react'
-import { ChevronLeftIcon, PlusIcon, Trash2Icon } from 'lucide-react'
+import { ChevronLeftIcon, LockKeyholeIcon, PlusIcon, Trash2Icon } from 'lucide-react'
 import { IconButton } from '@hachej/boring-ui-kit'
-import type { SessionSummary } from '../../../shared/session'
 import { cn } from '../../lib'
+import type { PiSessionSummary } from './usePiSessions'
 
 export interface SessionListProps {
-  sessions: SessionSummary[]
+  sessions: PiSessionSummary[]
   activeId?: string
   loading?: boolean
   onSwitch?: (id: string) => void
@@ -20,7 +20,7 @@ export interface SessionListProps {
   className?: string
 }
 
-type Group = { key: string; label: string; items: SessionSummary[] }
+type Group = { key: string; label: string; items: PiSessionSummary[] }
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -110,8 +110,9 @@ export function SessionList({
 
 export const SessionBrowser = SessionList
 
-function SessionRow({ session, active, onSwitch, onDelete }: { session: SessionSummary; active: boolean; onSwitch?: (id: string) => void; onDelete?: (id: string) => void }) {
+function SessionRow({ session, active, onSwitch, onDelete }: { session: PiSessionSummary; active: boolean; onSwitch?: (id: string) => void; onDelete?: (id: string) => void }) {
   const time = relativeTime(session.updatedAt)
+  const readOnlyReason = session.readOnlyReason ?? 'This chat is read-only.'
   return (
     <li
       role="listitem"
@@ -128,11 +129,23 @@ function SessionRow({ session, active, onSwitch, onDelete }: { session: SessionS
         <span className={cn(active ? 'font-medium text-foreground' : 'text-foreground/90')}>{session.title || 'Untitled'}</span>
         {time ? <span className={cn('ml-1.5 tabular-nums text-[11px]', active ? 'text-[color:var(--accent)]' : 'text-muted-foreground/60')}>{time}</span> : null}
       </span>
+      {session.readOnly ? (
+        <span
+          aria-label={`Read-only chat. ${readOnlyReason}`}
+          title={readOnlyReason}
+          className="inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
+        >
+          <LockKeyholeIcon aria-hidden="true" className="size-3" />
+          read-only
+        </span>
+      ) : null}
       {onDelete ? (
         <IconButton
           type="button"
           variant="ghost"
           size="icon-xs"
+          disabled={session.readOnly}
+          title={session.readOnly ? readOnlyReason : 'Delete chat'}
           className="shrink-0 text-muted-foreground opacity-0 hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
           onClick={(event) => {
             event.stopPropagation()
@@ -147,11 +160,11 @@ function SessionRow({ session, active, onSwitch, onDelete }: { session: SessionS
   )
 }
 
-function groupSessions(sessions: SessionSummary[]): Group[] {
+function groupSessions(sessions: PiSessionSummary[]): Group[] {
   const today = startOfDay(new Date())
   const yesterday = today - DAY_MS
   const lastWeek = today - 7 * DAY_MS
-  const groups: Array<[string, string, SessionSummary[]]> = [
+  const groups: Array<[string, string, PiSessionSummary[]]> = [
     ['today', 'Today', []],
     ['yesterday', 'Yesterday', []],
     ['week', 'This week', []],
@@ -199,7 +212,7 @@ function startOfDay(date: Date): number {
   return copy.getTime()
 }
 
-function sortByUpdatedDesc(a: SessionSummary, b: SessionSummary): number {
+function sortByUpdatedDesc(a: PiSessionSummary, b: PiSessionSummary): number {
   const updatedDelta = (toDate(b.updatedAt)?.getTime() ?? 0) - (toDate(a.updatedAt)?.getTime() ?? 0)
   if (updatedDelta !== 0) return updatedDelta
   const createdDelta = (toDate(b.createdAt)?.getTime() ?? 0) - (toDate(a.createdAt)?.getTime() ?? 0)

--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.addressed.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.addressed.test.tsx
@@ -2,6 +2,8 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 import type { RemotePiSession, RemotePiSessionOptions } from '../../pi/remotePiSession'
+import { AgentGatewayErrorCode } from '../../../../shared/gateway/errors'
+import { GatewayResponseError, RUNTIME_SCOPE_MISMATCH_MESSAGE } from '../../gatewayResponseError'
 import { activeSessionStorageKey } from '../activeSessionStorage'
 import { usePiSessions } from '../usePiSessions'
 
@@ -153,6 +155,179 @@ describe('usePiSessions addressed Agent transport', () => {
       requestId: expect.stringMatching(/^rename-/),
       title: 'Renamed',
     })
+  })
+
+  test('parses a runtime-scope rename failure and lazily marks the listed chat read-only', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return new Response(JSON.stringify({
+          error: {
+            code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+            message: 'session is pinned to a different runtime scope',
+          },
+        }), { status: 409, headers: { 'content-type': 'application/json' } })
+      }
+      return new Response(JSON.stringify({
+        sessions: [{
+          ref: { agentTypeId: 'alpha', sessionId: 'orphaned' },
+          title: 'Previous runtime chat',
+          status: 'idle',
+          createdAt: 1,
+          updatedAt: 2,
+        }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    })
+    const { result } = renderHook(() => usePiSessions({
+      agentTypeId: 'alpha',
+      fetch: fetchMock as unknown as typeof fetch,
+      connectActiveSession: false,
+      retry: { maxRetries: 0 },
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    let error: unknown
+    await act(async () => {
+      error = await result.current.rename('orphaned', 'New title').catch((reason) => reason)
+    })
+
+    expect(error).toMatchObject({
+      code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+      message: RUNTIME_SCOPE_MISMATCH_MESSAGE,
+    })
+    expect((error as Error).message).not.toContain('409')
+    expect(result.current.sessions).toEqual([
+      expect.objectContaining({
+        id: 'orphaned',
+        readOnly: true,
+        readOnlyReason: RUNTIME_SCOPE_MISMATCH_MESSAGE,
+      }),
+    ])
+  })
+
+  test('keeps a chat listed when delete is rejected and marks a scope mismatch read-only', async () => {
+    const deleteResponse = deferred<Response>()
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'DELETE') return deleteResponse.promise
+      return new Response(JSON.stringify({
+        sessions: [{
+          ref: { agentTypeId: 'alpha', sessionId: 'orphaned' },
+          title: 'Previous runtime chat',
+          status: 'idle',
+          createdAt: 1,
+          updatedAt: 2,
+        }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    })
+    const { result } = renderHook(() => usePiSessions({
+      agentTypeId: 'alpha',
+      fetch: fetchMock as unknown as typeof fetch,
+      connectActiveSession: false,
+      retry: { maxRetries: 0 },
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    let deletion!: Promise<void>
+    act(() => {
+      deletion = result.current.delete('orphaned')
+    })
+    expect(result.current.sessions.map((session) => session.id)).toEqual(['orphaned'])
+
+    await act(async () => {
+      deleteResponse.resolve(new Response(JSON.stringify({
+        error: {
+          code: AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+          message: 'session is pinned to a different runtime scope',
+        },
+      }), { status: 409, headers: { 'content-type': 'application/json' } }))
+      await deletion.catch(() => undefined)
+    })
+
+    expect(result.current.sessions).toEqual([
+      expect.objectContaining({ id: 'orphaned', readOnly: true }),
+    ])
+    expect(result.current.error?.message).toBe(RUNTIME_SCOPE_MISMATCH_MESSAGE)
+  })
+
+  test('marks a mismatch before notifying a consumer callback that throws', async () => {
+    const created: RemotePiSessionOptions[] = []
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      sessions: [{
+        ref: { agentTypeId: 'alpha', sessionId: 'orphaned' },
+        title: 'Previous runtime chat',
+        status: 'idle',
+        createdAt: 1,
+        updatedAt: 2,
+      }],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }))
+    const createRemoteSession = vi.fn((options: RemotePiSessionOptions) => {
+      created.push(options)
+      return { dispose: vi.fn() } as unknown as RemotePiSession
+    })
+    const consumerError = new Error('consumer observer failed')
+    const remoteSessionOptions = {
+      onGatewayError: () => {
+        throw consumerError
+      },
+    }
+    const { result } = renderHook(() => usePiSessions({
+      agentTypeId: 'alpha',
+      fetch: fetchMock as unknown as typeof fetch,
+      createRemoteSession,
+      remoteSessionOptions,
+      retry: { maxRetries: 0 },
+    }))
+
+    await waitFor(() => expect(created).toHaveLength(1))
+    const mismatch = new GatewayResponseError(
+      409,
+      RUNTIME_SCOPE_MISMATCH_MESSAGE,
+      AgentGatewayErrorCode.AGENT_SESSION_RUNTIME_SCOPE_MISMATCH,
+    )
+    let observedError: unknown
+    act(() => {
+      try {
+        created[0]?.onGatewayError?.(mismatch)
+      } catch (error) {
+        observedError = error
+      }
+    })
+
+    expect(observedError).toBe(consumerError)
+    expect(result.current.sessions).toEqual([
+      expect.objectContaining({ id: 'orphaned', readOnly: true }),
+    ])
+  })
+
+  test('tags a network delete failure with its action so load-error observers can ignore it', async () => {
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      if (init?.method === 'DELETE') throw new TypeError('network unavailable')
+      return new Response(JSON.stringify({
+        sessions: [{
+          ref: { agentTypeId: 'alpha', sessionId: 'healthy' },
+          title: 'Healthy chat',
+          status: 'idle',
+          createdAt: 1,
+          updatedAt: 2,
+        }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } })
+    })
+    const { result } = renderHook(() => usePiSessions({
+      agentTypeId: 'alpha',
+      fetch: fetchMock as unknown as typeof fetch,
+      connectActiveSession: false,
+      retry: { maxRetries: 0 },
+    }))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const error = await result.current.delete('healthy').catch((reason) => reason)
+
+    expect(error).toMatchObject({
+      message: 'network unavailable',
+      operation: 'delete chat',
+    })
+    expect(result.current.sessions).toEqual([
+      expect.objectContaining({ id: 'healthy' }),
+    ])
   })
 
   test('switches the addressed collection and remote wire without connecting a stale session id', async () => {

--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
@@ -670,7 +670,7 @@ describe('usePiSessions', () => {
     await act(async () => {
       await result.current.loadMore()
     })
-    expect(result.current.error?.message).toBe('Failed to load sessions: 500')
+    expect(result.current.error?.message).toBe('older page failed')
 
     await act(async () => {
       await result.current.loadMore()
@@ -966,7 +966,7 @@ describe('usePiSessions', () => {
 
     await expect(act(async () => {
       await result.current.refresh({ background: true, throwOnError: true })
-    })).rejects.toThrow('Failed to load sessions: 500')
+    })).rejects.toThrow('metadata refresh failed')
     expect(result.current.sessions.map((item) => item.id)).toEqual(['pi-existing'])
   })
 

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -8,6 +8,12 @@ import {
 } from '../pi/nativeFirstSendTransactions'
 import { createRemotePiSession, type RemotePiSession, type RemotePiSessionOptions } from '../pi/remotePiSession'
 import {
+  gatewayResponseError,
+  isRuntimeScopeMismatchError,
+  RUNTIME_SCOPE_MISMATCH_MESSAGE,
+  type GatewayResponseError,
+} from '../gatewayResponseError'
+import {
   activeSessionStorageKey,
   readActiveSessionId,
   writeActiveSessionId,
@@ -60,6 +66,8 @@ export interface UsePiSessionsOptions {
 
 export interface PiSessionSummary extends SessionSummary {
   ephemeral?: boolean
+  readOnly?: boolean
+  readOnlyReason?: string
 }
 
 export interface UsePiSessionsResult {
@@ -80,6 +88,7 @@ export interface UsePiSessionsResult {
   rename: (id: string, title: string) => Promise<PiSessionSummary>
   switch: (id: string) => void
   delete: (id: string) => Promise<void>
+  markReadOnly: (id: string, reason?: string) => void
   loadMore: () => Promise<void>
   reset: () => void
 }
@@ -156,6 +165,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
   const loadMoreInFlightRef = useRef(false)
   const pendingCreatedRef = useRef<Map<string, PiSessionSummary>>(new Map())
   const localSessionsRef = useRef<Map<string, LocalSession>>(new Map())
+  const readOnlySessionsRef = useRef<Map<string, string>>(new Map())
   const adoptNativeRef = useRef<((localId: string, session: SessionSummary) => void) | undefined>(undefined)
   const pendingCreatedScopeRef = useRef(requestScopeKey)
   const dataStorageScopeRef = useRef(storageScope)
@@ -227,6 +237,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       releaseNativeFirst(local.nativeFirstDataSourceKey, id)
     }
     localSessionsRef.current.clear()
+    readOnlySessionsRef.current.clear()
     pendingCreatedScopeRef.current = requestScopeKey
     pendingCreatedRef.current.clear()
   }, [requestScopeKey])
@@ -260,7 +271,10 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       ? sessionsRef.current.filter((session) => !requestedActiveId || requestedActiveReturned || session.id !== requestedActiveId)
       : []
     const localSessions = Array.from(localSessionsRef.current.values(), ({ session }) => session)
-    const merged = mergeSessions(localSessions, Array.from(pendingCreated.values()), data, current)
+    const merged = applyReadOnlySessions(
+      mergeSessions(localSessions, Array.from(pendingCreated.values()), data, current),
+      readOnlySessionsRef.current,
+    )
     const nextHasMore = pageMayHaveMore && !wasExhaustedBeyondFirstPage
     canonicalLoadedCountRef.current = applyOptions.background
       ? Math.max(canonicalLoadedCountRef.current, canonicalCount)
@@ -370,7 +384,10 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       const page = await fetchSessionList(fetchImpl, sessionsListUrl(offset, undefined, nextCursorRef.current), requestHeaders(), addressed)
       const data = page.sessions
       if (!mountedRef.current || requestSeq !== loadMoreRequestSeqRef.current || version !== refreshVersionRef.current || scope !== requestScopeRef.current) return
-      const merged = mergeSessions(sessionsRef.current, data)
+      const merged = applyReadOnlySessions(
+        mergeSessions(sessionsRef.current, data),
+        readOnlySessionsRef.current,
+      )
       const nextHasMore = addressed ? page.nextCursor !== undefined : data.length >= SESSION_PAGE_SIZE
       canonicalLoadedCountRef.current += data.length
       nextCursorRef.current = page.nextCursor
@@ -395,6 +412,24 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     }
   }, [addressed, enabled, fetchImpl, hasMore, loading, loadingMore, persistActive, requestHeaders, requestScopeKey, sessionsListUrl])
 
+  const markReadOnly = useCallback((id: string, reason = RUNTIME_SCOPE_MISMATCH_MESSAGE) => {
+    if (requestScopeKey !== requestScopeRef.current) return
+    readOnlySessionsRef.current.set(id, reason)
+    setSessions((previous) => {
+      let changed = false
+      const next = previous.map((session) => {
+        if (session.id !== id || (session.readOnly && session.readOnlyReason === reason)) return session
+        changed = true
+        return { ...session, readOnly: true, readOnlyReason: reason }
+      })
+      return changed ? next : previous
+    })
+  }, [requestScopeKey])
+
+  const markRuntimeScopeMismatch = useCallback((id: string, error: unknown) => {
+    if (isRuntimeScopeMismatchError(error)) markReadOnly(id)
+  }, [markReadOnly])
+
   useEffect(() => {
     if (!enabled || !connectActiveSession || !activeSessionId || !activeSessionKnown) {
       setActivePiSession(undefined)
@@ -402,8 +437,9 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     }
 
     const local = localSessionsRef.current.get(activeSessionId)
+    const configuredRemoteOptions = remoteSessionOptionsRef.current
     const session = createRemoteSession({
-      ...remoteSessionOptionsRef.current,
+      ...configuredRemoteOptions,
       ...(local
         ? {
             autoStart: false,
@@ -419,12 +455,16 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       apiBaseUrl,
       headers: requestHeaders,
       fetch: fetchImpl,
+      onGatewayError: (error: GatewayResponseError) => {
+        markRuntimeScopeMismatch(activeSessionId, error)
+        configuredRemoteOptions?.onGatewayError?.(error)
+      },
     })
     setActivePiSession(session)
     return () => {
       session.dispose()
     }
-  }, [activeSessionId, activeSessionKnown, apiBaseUrl, connectActiveSession, createRemoteSession, enabled, fetchImpl, remoteSessionOptionsKey, options.agentTypeId, options.workspaceId, requestHeaders, storageScope])
+  }, [activeSessionId, activeSessionKnown, apiBaseUrl, connectActiveSession, createRemoteSession, enabled, fetchImpl, markRuntimeScopeMismatch, remoteSessionOptionsKey, options.agentTypeId, options.workspaceId, requestHeaders, storageScope])
 
   const create = useCallback(async (init?: PiSessionCreateInit): Promise<PiSessionSummary> => {
     if (!enabled) throw new Error('Pi sessions are disabled')
@@ -458,7 +498,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       body: JSON.stringify(init ?? {}),
     })
     if (!response.ok) {
-      const err = new Error(`Failed to create session: ${response.status}`)
+      const err = await gatewayResponseError(response, 'Failed to create the chat.', 'create chat')
       if (mountedRef.current && scope === requestScopeRef.current) setError(err)
       throw err
     }
@@ -509,12 +549,16 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       headers: { ...requestHeaders(), 'Content-Type': 'application/json' },
       body: JSON.stringify({ requestId: sessionMutationRequestId('rename'), title }),
     })
-    if (!response.ok) throw new Error(`Failed to rename session: ${response.status}`)
+    if (!response.ok) {
+      const error = await gatewayResponseError(response, 'Failed to rename the chat.', 'rename chat')
+      markRuntimeScopeMismatch(id, error)
+      throw error
+    }
     const renamed = toAddressedSessionSummary(await response.json())
     if (pendingCreatedRef.current.has(id)) pendingCreatedRef.current.set(id, renamed)
     setSessions((previous) => previous.map((item) => item.id === id ? { ...item, ...renamed } : item))
     return renamed
-  }, [addressed, enabled, fetchImpl, requestHeaders, sessionsUrl])
+  }, [addressed, enabled, fetchImpl, markRuntimeScopeMismatch, requestHeaders, sessionsUrl])
 
   const switchSession = useCallback((id: string) => {
     const known = sessionsRef.current.some((session) => session.id === id)
@@ -541,6 +585,22 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       })
       return
     }
+    try {
+      const response = await fetchImpl(sessionsUrl(`/${encodeURIComponent(id)}`), {
+        method: 'DELETE',
+        headers: requestHeaders(),
+      })
+      if (!response.ok && response.status !== 404) {
+        throw await gatewayResponseError(response, 'Failed to delete the chat.', 'delete chat')
+      }
+    } catch (err) {
+      const error = withSessionOperation(err, 'delete chat')
+      markRuntimeScopeMismatch(id, error)
+      if (!mountedRef.current || scope !== requestScopeRef.current) throw error
+      setError(error)
+      throw error
+    }
+    if (!mountedRef.current || scope !== requestScopeRef.current) return
     pendingCreatedRef.current.delete(id)
     setDataStorageScope(storageScope)
     setSessions((previous) => previous.filter((session) => session.id !== id))
@@ -550,23 +610,8 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       persistActive(next)
       return next
     })
-
-    try {
-      const response = await fetchImpl(sessionsUrl(`/${encodeURIComponent(id)}`), {
-        method: 'DELETE',
-        headers: requestHeaders(),
-      })
-      if (!response.ok && response.status !== 404) throw new Error(`Failed to delete session: ${response.status}`)
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err))
-      if (!mountedRef.current || scope !== requestScopeRef.current) throw error
-      setError(error)
-      void refresh()
-      throw error
-    }
-    if (!mountedRef.current || scope !== requestScopeRef.current) return
     void refresh()
-  }, [enabled, ensurePendingScope, fetchImpl, persistActive, refresh, requestHeaders, requestScopeKey, sessionsUrl, storageScope])
+  }, [enabled, ensurePendingScope, fetchImpl, markRuntimeScopeMismatch, persistActive, refresh, requestHeaders, requestScopeKey, sessionsUrl, storageScope])
 
   const reset = useCallback(() => {
     for (const [id, local] of localSessionsRef.current) {
@@ -609,6 +654,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     rename,
     switch: switchSession,
     delete: deleteSession,
+    markReadOnly,
     loadMore,
     reset,
   }
@@ -627,7 +673,7 @@ async function fetchSessionList(
 ): Promise<SessionPage> {
   const response = await fetchImpl(url, Object.keys(headers).length > 0 ? { headers } : undefined)
   if (response.status === 503) throw new SessionsPreparingError()
-  if (!response.ok) throw new Error(`Failed to load sessions: ${response.status}`)
+  if (!response.ok) throw await gatewayResponseError(response, 'Failed to load chats.', 'load chats')
   const body = await response.json()
   if (!addressed) {
     if (!Array.isArray(body)) throw new Error('Failed to load sessions: invalid response')
@@ -654,6 +700,31 @@ function toSessionSummary(value: unknown): PiSessionSummary {
     createdAt: typeof record.createdAt === 'string' ? record.createdAt : now,
     updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : now,
     turnCount: typeof record.turnCount === 'number' ? record.turnCount : 0,
+  }
+}
+
+function applyReadOnlySessions(
+  sessions: PiSessionSummary[],
+  readOnlySessions: ReadonlyMap<string, string>,
+): PiSessionSummary[] {
+  return sessions.map((session) => {
+    const reason = readOnlySessions.get(session.id)
+    return reason ? { ...session, readOnly: true, readOnlyReason: reason } : session
+  })
+}
+
+function withSessionOperation(error: unknown, operation: string): Error {
+  const resolved = error instanceof Error ? error : new Error(String(error))
+  if (typeof (resolved as { operation?: unknown }).operation === 'string') return resolved
+  try {
+    Object.defineProperty(resolved, 'operation', {
+      configurable: true,
+      enumerable: false,
+      value: operation,
+    })
+    return resolved
+  } catch {
+    return Object.assign(new Error(resolved.message, { cause: resolved }), { operation })
   }
 }
 
@@ -724,6 +795,7 @@ function remoteSessionOptionsIdentity(options: UsePiSessionsOptions['remoteSessi
     autoStart: options.autoStart,
     requestTimeoutMs: options.requestTimeoutMs,
     onEvent: remoteSessionOptionObjectIdentity(options.onEvent),
+    onGatewayError: remoteSessionOptionObjectIdentity(options.onGatewayError),
     storeOptions: remoteSessionOptionObjectIdentity(options.storeOptions),
     setTimeoutFn: remoteSessionOptionObjectIdentity(options.setTimeoutFn),
     clearTimeoutFn: remoteSessionOptionObjectIdentity(options.clearTimeoutFn),

--- a/packages/agent/src/front/chat/useAddressedAgentSelection.ts
+++ b/packages/agent/src/front/chat/useAddressedAgentSelection.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { AgentSummary } from '../../shared/gateway/types'
+import { gatewayResponseError } from './gatewayResponseError'
 
 export type AddressedAgentOption = Pick<AgentSummary, 'agentTypeId' | 'label' | 'description'>
 
@@ -141,7 +142,7 @@ function discoverAgents(
   if (existing) return existing
 
   const request = fetchImpl(url, init).then(async (response) => {
-    if (!response.ok) throw new Error(`Failed to load agents: ${response.status}`)
+    if (!response.ok) throw await gatewayResponseError(response, 'Failed to load agents.', 'load agents')
     return parseAgentOptions(await response.json())
   })
   requests.set(discoveryKey, request)

--- a/packages/agent/src/front/index.ts
+++ b/packages/agent/src/front/index.ts
@@ -20,6 +20,15 @@ export type {
   UseAddressedAgentSelectionOptions,
   UseAddressedAgentSelectionResult,
 } from './chat/useAddressedAgentSelection'
+export {
+  GatewayResponseError,
+  errorResponseCode,
+  gatewayResponseError,
+  gatewayResponseErrorFromBody,
+  isRuntimeScopeMismatchError,
+  RUNTIME_SCOPE_MISMATCH_MESSAGE,
+} from './chat/gatewayResponseError'
+export type { GatewayResponseErrorCode } from './chat/gatewayResponseError'
 export { DebugDrawer } from './DebugDrawer'
 export {
   ArtifactOpenProvider,

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -3,6 +3,8 @@ import { Plug, Sparkles } from "lucide-react"
 import {
   PiChatPanel as DefaultPiChatPanel,
   usePiSessions as useDefaultPiSessions,
+  isRuntimeScopeMismatchError,
+  RUNTIME_SCOPE_MISMATCH_MESSAGE,
   searchPiSessions,
   type SlashCommand,
   type ToolRendererOverrides,
@@ -45,6 +47,7 @@ import { PluginAppLeftOverlayHost, assertUniqueAppLeftActionIds, pluginAppLeftAc
 import { CloseLeftPaneOnAttention } from "./CloseLeftPaneOnAttention"
 import { workspaceRequestHeaders, type WorkspaceWarmupStatus } from "./workspacePreload"
 import { createdSessionId } from "./chatPaneState"
+import { surfaceSessionActionError } from "../../front/sessionActionErrors"
 import {
   workspaceSessionKey,
   workspaceSessionKeyFor,
@@ -62,6 +65,9 @@ export interface WorkspaceAgentSession {
   turnCount?: number
   /** Browser-only draft that has not completed its first addressed send. */
   ephemeral?: boolean
+  /** Front-only marker learned from a runtime-scope mismatch response. */
+  readOnly?: boolean
+  readOnlyReason?: string
 }
 
 export interface WorkspaceNativeSession extends WorkspaceAgentSession {
@@ -94,6 +100,7 @@ export interface WorkspaceAgentSessionsApi<
   adoptNative?: (localId: string, session: WorkspaceNativeSession) => void
   rename?: (id: string, title: string) => void | Promise<unknown>
   delete: (id: string, agentTypeId?: string) => void | Promise<unknown>
+  markReadOnly?: (id: string, reason?: string) => void
   loadMore?: () => void | Promise<unknown>
   refresh?: (options?: { background?: boolean; throwOnError?: boolean }) => void | Promise<unknown>
 }
@@ -628,6 +635,7 @@ export function WorkspaceAgentFront<
       rawSwitch,
       resolvedCreate,
       resolvedRename,
+      markSessionReadOnly,
       adoptAddressedSession,
     },
     panes: {
@@ -683,6 +691,30 @@ export function WorkspaceAgentFront<
     persistenceEnabled: shellPersistenceEnabled,
     onPaneFocus: handlePaneFocus,
   })
+  const surfacedSessionLoadErrorRef = useRef<Error | null>(null)
+  const surfacedAgentLoadErrorRef = useRef<Error | null>(null)
+  useEffect(() => {
+    const error = remoteSessionApi.error
+    if (!error) {
+      surfacedSessionLoadErrorRef.current = null
+      return
+    }
+    const operation = (error as { operation?: unknown }).operation
+    if (operation && operation !== "load chats") return
+    if (surfacedSessionLoadErrorRef.current === error) return
+    surfacedSessionLoadErrorRef.current = error
+    surfaceSessionActionError("load chats", error)
+  }, [remoteSessionApi.error])
+  useEffect(() => {
+    const error = addressedAgentSelectionState.error
+    if (!error) {
+      surfacedAgentLoadErrorRef.current = null
+      return
+    }
+    if (surfacedAgentLoadErrorRef.current === error) return
+    surfacedAgentLoadErrorRef.current = error
+    surfaceSessionActionError("load agents", error)
+  }, [addressedAgentSelectionState.error])
   const splitChatPane = useCallback((paneId: string, direction: ChatPaneSplitDirection) => {
     const targetAgentTypeId = workspaceSessionRefFromKey(paneId).agentTypeId
     void createChatPaneAfter(paneId, { targetAgentTypeId, placementDirection: direction })
@@ -962,8 +994,11 @@ export function WorkspaceAgentFront<
       const sessionRef = workspaceSessionRefFromKey(sessionKey)
       const sessionId = sessionRef.sessionId
       const paneSession = resolvedSessions.find((session) => workspaceSessionKeyFor(session) === sessionKey)
-      const paneEphemeral = (paneSession as WorkspaceAgentSession | undefined)?.ephemeral === true
+      const paneWorkspaceSession = paneSession as WorkspaceAgentSession | undefined
+      const paneEphemeral = paneWorkspaceSession?.ephemeral === true
         || sessionId.startsWith("local-")
+      const paneReadOnly = paneWorkspaceSession?.readOnly === true
+      const paneReadOnlyReason = paneWorkspaceSession?.readOnlyReason ?? RUNTIME_SCOPE_MISMATCH_MESSAGE
       const paneHydrateMessages = hydrateMessages || Boolean(
         multiAgentConsoleEnabled
         && sessionRef.agentTypeId
@@ -977,6 +1012,8 @@ export function WorkspaceAgentFront<
       ...(delayAutoSubmitDraft ? { autoSubmitInitialDraft: false, initialDraft: undefined } : {}),
       sessionId,
       sessionEphemeral: paneEphemeral,
+      sessionReadOnly: paneReadOnly,
+      sessionReadOnlyReason: paneReadOnly ? paneReadOnlyReason : undefined,
       agentTypeId: sessionRef.agentTypeId ?? agentTypeId,
       nativeSessionStartEnabled: Boolean(
         (sessionRef.agentTypeId ?? agentTypeId)
@@ -1000,7 +1037,16 @@ export function WorkspaceAgentFront<
       workspaceId,
       storageScope: workspaceId,
       requestHeaders: resolvedRequestHeaders,
-      remoteSessionOptions: chatRemoteSessionOptions,
+      remoteSessionOptions: {
+        ...(chatRemoteSessionOptions ?? {}),
+        onGatewayError: (error: unknown) => {
+          if (isRuntimeScopeMismatchError(error)) {
+            markSessionReadOnly(sessionId, sessionRef.agentTypeId, RUNTIME_SCOPE_MISMATCH_MESSAGE)
+          }
+          const configuredCallback = chatRemoteSessionOptions?.onGatewayError
+          if (typeof configuredCallback === "function") configuredCallback(error)
+        },
+      },
       showSessions: false,
       onReloadAgentPlugins: chatParams?.onReloadAgentPlugins ?? (() => reloadAgentPluginsForSession(sessionId)),
       toolRenderers: { ...pluginToolRenderers, ...(chatToolRenderers ?? {}) },
@@ -1033,7 +1079,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [adoptAddressedSession, agentTypeId, apiBaseUrl, chatParams, chatRemoteSessionOptions, controlledAgentSelection, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, isPluginTabsLayout, markInitialHydrationPromptStarted, multiAgentConsoleEnabled, refreshAddressedSession, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, resolvedSessions, sessionApi, settleAutoSubmitHydration, workspaceId],
+    [adoptAddressedSession, agentTypeId, apiBaseUrl, chatParams, chatRemoteSessionOptions, controlledAgentSelection, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, isPluginTabsLayout, markInitialHydrationPromptStarted, markSessionReadOnly, multiAgentConsoleEnabled, refreshAddressedSession, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, resolvedSessions, sessionApi, settleAutoSubmitHydration, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionKey),
@@ -1150,7 +1196,15 @@ export function WorkspaceAgentFront<
     onTogglePin: toggleSessionPinned,
     onSwitch: switchToChatPane,
     onOpenAsTab: openChatPane,
-    onCreate: resolvedCreate,
+    onCreate: () => {
+      try {
+        void Promise.resolve(resolvedCreate()).catch((error) => {
+          surfaceSessionActionError("create chat", error)
+        })
+      } catch (error) {
+        surfaceSessionActionError("create chat", error)
+      }
+    },
     onDelete: deleteSessionAndPane,
     onLoadMore: sessionApi?.loadMore,
     hasMore: sessionApi?.hasMore,
@@ -1191,7 +1245,13 @@ export function WorkspaceAgentFront<
       : effectiveActiveSessionId
         ? workspaceSessionRef(effectiveActiveSessionId, effectiveActiveSessionAgentTypeId ?? undefined)
         : null
-    const created = resolvedCreate(targetAgentTypeId)
+    let created: unknown
+    try {
+      created = resolvedCreate(targetAgentTypeId)
+    } catch (error) {
+      surfaceSessionActionError("create chat", error)
+      return
+    }
     void Promise.resolve(created).then((session) => {
       const id = createdSessionId(session)
       if (!id) return
@@ -1211,9 +1271,8 @@ export function WorkspaceAgentFront<
       ) {
         rawSwitch(previousActiveRef.sessionId, previousActiveRef.agentTypeId)
       }
-    }).catch(() => {
-      // Creation errors are surfaced by the session API/chat layer; the menu
-      // should not leave a stale detached chat behind.
+    }).catch((error) => {
+      surfaceSessionActionError("create chat", error)
     })
     return created
   }, [agentTypeId, defaultSessionTitle, displayedActiveChatPaneId, effectiveActiveSessionAgentTypeId, effectiveActiveSessionId, rawSwitch, resolvedCreate, shellCapabilitiesHost.shellCapabilities])

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { WORKSPACE_AGENT_PLUGINS_RELOADED_EVENT } from "../../../front/agentPlugins/reloadEvent"
 import { UI_COMMAND_EVENT, type UiCommand } from "../../../front/bridge"
 import type { WorkspaceChatPanelProps } from "../../../front/chrome/chat/types"
+import { clearToasts, getActiveToasts } from "../../../front/toast"
 import type { PanelConfig } from "../../../front/registry/types"
 import { definePlugin } from "../../../shared/plugins/frontFactory"
 import type { PluginProviderProps } from "../../../shared/plugins/types"
@@ -87,6 +88,7 @@ describe("WorkspaceAgentFront", () => {
 
   beforeEach(() => {
     localStorage.clear()
+    clearToasts()
     sessionsFailuresRemaining = 0
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
@@ -3421,6 +3423,104 @@ describe("WorkspaceAgentFront", () => {
 
     expect(create).toHaveBeenCalledOnce()
     expect(create.mock.calls[0]).toEqual([])
+  })
+
+  it("shows the structured server message when New chat creation is rejected", async () => {
+    const createError = Object.assign(new Error("Agent gateway is restarting."), {
+      code: "AGENT_GATEWAY_CLOSED",
+    })
+    render(
+      <WorkspaceAgentFront
+        workspaceId="create-error-surface"
+        workspaceLayout="plugin-tabs"
+        chatPanel={ChatPanel}
+        sessions={[{ id: "existing", title: "Existing chat", updatedAt: Date.now() }]}
+        activeSessionId="existing"
+        onCreateSession={() => Promise.reject(createError)}
+        persistenceEnabled={false}
+      />,
+    )
+
+    fireEvent.click(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "New chat" }))
+
+    expect(await screen.findByText(/Agent gateway is restarting.*AGENT_GATEWAY_CLOSED/)).toBeInTheDocument()
+    expect(screen.getAllByText("Existing chat").length).toBeGreaterThan(0)
+    expect(screen.queryByText(/Failed to create.*503/)).not.toBeInTheDocument()
+  })
+
+  it("keeps a rejected delete row visible and explains the failure", async () => {
+    const user = userEvent.setup()
+    const deleteError = Object.assign(
+      new Error("This chat belongs to a previous runtime configuration and can no longer be changed."),
+      { code: "AGENT_SESSION_RUNTIME_SCOPE_MISMATCH", operation: "delete chat" },
+    )
+    const deleteSession = vi.fn((_id: string) => Promise.reject(deleteError))
+    const sessions = [
+      { id: "first", title: "First chat", updatedAt: Date.now() },
+      { id: "orphaned", title: "Previous runtime chat", updatedAt: Date.now() - 1 },
+    ]
+    function useFailingDeleteSessions() {
+      const [error, setError] = useState<Error>()
+      return {
+        sessions,
+        activeSessionId: "first",
+        activeSession: sessions[0],
+        loading: false,
+        error,
+        create: vi.fn(),
+        switch: vi.fn(),
+        delete: (id: string) => {
+          setError(deleteError)
+          return deleteSession(id)
+        },
+      }
+    }
+    render(
+      <WorkspaceAgentFront
+        workspaceId="delete-error-surface"
+        workspaceLayout="plugin-tabs"
+        chatPanel={ChatPanel}
+        useSessions={useFailingDeleteSessions}
+        persistenceEnabled={false}
+      />,
+    )
+
+    await user.click(screen.getByLabelText("More options for Previous runtime chat"))
+    await user.click(screen.getByRole("menuitem", { name: "Delete" }))
+
+    await waitFor(() => expect(deleteSession).toHaveBeenCalledWith("orphaned"))
+    expect(screen.getByText("Previous runtime chat")).toBeInTheDocument()
+    expect(await screen.findByText(/previous runtime configuration.*AGENT_SESSION_RUNTIME_SCOPE_MISMATCH/i)).toBeInTheDocument()
+    expect(getActiveToasts()).toEqual([
+      expect.objectContaining({ title: "Could not delete chat" }),
+    ])
+  })
+
+  it("shows a structured session-list load error", async () => {
+    const loadError = Object.assign(new Error("Session catalog is unavailable."), {
+      code: "AGENT_GATEWAY_CLOSED",
+    })
+    render(
+      <WorkspaceAgentFront
+        workspaceId="load-error-surface"
+        workspaceLayout="plugin-tabs"
+        chatPanel={ChatPanel}
+        useSessions={() => ({
+          sessions: [],
+          activeSessionId: null,
+          activeSession: null,
+          loading: false,
+          error: loadError,
+          create: vi.fn(),
+          switch: vi.fn(),
+          delete: vi.fn(),
+        })}
+        persistenceEnabled={false}
+      />,
+    )
+
+    expect(await screen.findByText(/Session catalog is unavailable.*AGENT_GATEWAY_CLOSED/)).toBeInTheDocument()
+    expect(screen.queryByText(/Failed to load sessions: 500/)).not.toBeInTheDocument()
   })
 
   it("creates a replacement before deleting the last authoritative remote session", async () => {

--- a/packages/workspace/src/app/front/addressedConsoleSessions.tsx
+++ b/packages/workspace/src/app/front/addressedConsoleSessions.tsx
@@ -91,12 +91,20 @@ export function useAddressedConsoleController<
     return controllers.current.get(session.agentTypeId)?.rename?.(session.sessionId, title)
   }, [controllers, enabled])
 
+  const markSessionReadOnly = useCallback((
+    session: WorkspaceSessionRef,
+    reason?: string,
+  ) => {
+    if (!enabled || !session.agentTypeId) return
+    controllers.current.get(session.agentTypeId)?.markReadOnly?.(session.sessionId, reason)
+  }, [controllers, enabled])
+
   const refreshSession = useCallback((session: WorkspaceSessionRef) => {
     if (!enabled || !session.agentTypeId) return undefined
     return controllers.current.get(session.agentTypeId)?.refresh?.({ background: true })
   }, [controllers, enabled])
 
-  return { activate, createSession, adoptNativeSession, renameSession, deleteSession, refreshSession }
+  return { activate, createSession, adoptNativeSession, renameSession, deleteSession, markSessionReadOnly, refreshSession }
 }
 
 function AddressedConsoleSessionSource<

--- a/packages/workspace/src/app/front/useWorkspaceAgentChatPanes.ts
+++ b/packages/workspace/src/app/front/useWorkspaceAgentChatPanes.ts
@@ -9,6 +9,7 @@ import {
   type WorkspaceSessionRef,
 } from "../../front/sessionIdentity"
 import type { ChatPanePendingPlacement, ChatPaneSplitDirection } from "../../front/layout"
+import { surfaceSessionActionError } from "../../front/sessionActionErrors"
 import {
   createdSessionId,
   insertPaneAfter,
@@ -241,6 +242,8 @@ export function useWorkspaceAgentChatPanes<
     (persistenceEnabled ? readStoredChatPaneState(chatPaneStorageKey, workspaceId) : null)
       ?? { workspaceId, ids: [], activeId: null },
   )
+  const chatPaneStateRef = useRef(chatPaneState)
+  chatPaneStateRef.current = chatPaneState
   const [pendingChatPanePlacement, setPendingChatPanePlacement] = useState<ChatPanePendingPlacement | null>(null)
   const [chatPaneSplitPending, setChatPaneSplitPending] = useState(false)
   const consumePendingChatPanePlacement = useCallback((paneId: string) => {
@@ -642,7 +645,14 @@ export function useWorkspaceAgentChatPanes<
       knownIds: new Set(resolvedSessions.map(workspaceSessionKeyFor)),
     }
     pendingCreatePaneRef.current = pendingCreatePane
-    const created = resolvedCreate(targetAgentTypeId)
+    let created: unknown
+    try {
+      created = resolvedCreate(targetAgentTypeId)
+    } catch (error) {
+      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
+      surfaceSessionActionError("create chat", error)
+      return
+    }
     void Promise.resolve(created).then((session) => {
       const id = createdSessionId(session)
       if (!id) return
@@ -677,8 +687,9 @@ export function useWorkspaceAgentChatPanes<
         else rawSwitch(id)
       }
       scheduleActiveAgentComposerFocus()
-    }).catch(() => {
+    }).catch((error) => {
       if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
+      surfaceSessionActionError("create chat", error)
     })
     return created
   }, [activateAddressedSession, activeChatPaneId, addressedAgentTypeIds, agentTypeId, canMountCreatedAgentPane, chatSessionKey, multiAgentConsoleEnabled, rawSwitch, resolvedCreate, resolvedSessions, selectedAgentIsEmpty, sessionApi, workspaceId])
@@ -696,7 +707,15 @@ export function useWorkspaceAgentChatPanes<
       knownIds: new Set(resolvedSessions.map(workspaceSessionKeyFor)),
     }
     pendingCreatePaneRef.current = pendingCreatePane
-    const created = resolvedCreate(targetAgentTypeId)
+    let created: unknown
+    try {
+      created = resolvedCreate(targetAgentTypeId)
+    } catch (error) {
+      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
+      setChatPaneSplitPending(false)
+      surfaceSessionActionError("create chat", error)
+      return
+    }
     void Promise.resolve(created).then((session) => {
       const id = createdSessionId(session)
       if (!id) return
@@ -740,34 +759,46 @@ export function useWorkspaceAgentChatPanes<
         else rawSwitch(id)
       }
       scheduleActiveAgentComposerFocus()
-    }).catch(() => {
+    }).catch((error) => {
       if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
       setChatPaneSplitPending(false)
+      surfaceSessionActionError("create chat", error)
     })
     return created
   }, [activateAddressedSession, agentTypeId, canMountCreatedAgentPane, chatSessionKey, multiAgentConsoleEnabled, rawSwitch, resolvedCreate, resolvedSessions, sessionApi, workspaceId])
 
   const deleteSessionAndPane = useCallback((sessionId: string, sessionAgentTypeId?: string) => {
-    const sessionKey = workspaceSessionKey(sessionId, sessionAgentTypeId)
-    const current = chatPaneState.workspaceId === workspaceId
-      ? chatPaneState
-      : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
-    const deletingIndex = current.ids.indexOf(sessionKey)
-    if (deletingIndex >= 0) {
-      const nextIds = current.ids.filter((id) => id !== sessionKey)
-      const nextActiveId = current.activeId === sessionKey
-        ? nextIds[Math.max(0, deletingIndex - 1)] ?? nextIds[0] ?? null
-        : current.activeId
-      setChatPaneState({ workspaceId, ids: nextIds, activeId: nextActiveId })
-      if (nextActiveId && current.activeId === sessionKey) {
-        const next = workspaceSessionRefFromKey(nextActiveId)
-        if (multiAgentConsoleEnabled && next.agentTypeId) activateAddressedSession(next)
-        else if (next.agentTypeId) resolvedSwitch(next.sessionId, next.agentTypeId)
-        else resolvedSwitch(next.sessionId)
-      }
+    let deletion: unknown
+    try {
+      deletion = resolvedDelete(sessionId, sessionAgentTypeId)
+    } catch (error) {
+      surfaceSessionActionError("delete chat", error)
+      return
     }
-    return resolvedDelete(sessionId, sessionAgentTypeId)
-  }, [activateAddressedSession, chatPaneState, chatSessionKey, multiAgentConsoleEnabled, resolvedDelete, resolvedSwitch, workspaceId])
+    const sessionKey = workspaceSessionKey(sessionId, sessionAgentTypeId)
+    return Promise.resolve(deletion).then(() => {
+      const latest = chatPaneStateRef.current
+      const current = latest.workspaceId === workspaceId
+        ? latest
+        : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
+      const deletingIndex = current.ids.indexOf(sessionKey)
+      if (deletingIndex >= 0) {
+        const nextIds = current.ids.filter((id) => id !== sessionKey)
+        const nextActiveId = current.activeId === sessionKey
+          ? nextIds[Math.max(0, deletingIndex - 1)] ?? nextIds[0] ?? null
+          : current.activeId
+        setChatPaneState({ workspaceId, ids: nextIds, activeId: nextActiveId })
+        if (nextActiveId && current.activeId === sessionKey) {
+          const next = workspaceSessionRefFromKey(nextActiveId)
+          if (multiAgentConsoleEnabled && next.agentTypeId) activateAddressedSession(next)
+          else if (next.agentTypeId) resolvedSwitch(next.sessionId, next.agentTypeId)
+          else resolvedSwitch(next.sessionId)
+        }
+      }
+    }).catch((error) => {
+      surfaceSessionActionError("delete chat", error)
+    })
+  }, [activateAddressedSession, chatSessionKey, multiAgentConsoleEnabled, resolvedDelete, resolvedSwitch, workspaceId])
 
   const createChatSessionPreferNewPane = useCallback((targetAgentTypeId?: string) => {
     if (chatPaneIds.length >= 2) return createChatPaneAfter(activeChatPaneId, { targetAgentTypeId })

--- a/packages/workspace/src/app/front/useWorkspaceAgentSessionCoordinator.ts
+++ b/packages/workspace/src/app/front/useWorkspaceAgentSessionCoordinator.ts
@@ -175,6 +175,8 @@ export function useWorkspaceAgentSessionCoordinator<
             && session.agentTypeId === next.agentTypeId
             && session.title === next.title
             && session.turnCount === next.turnCount
+            && session.readOnly === next.readOnly
+            && session.readOnlyReason === next.readOnlyReason
         })
       if (
         current?.workspaceId === workspaceId
@@ -235,6 +237,7 @@ export function useWorkspaceAgentSessionCoordinator<
       adoptNative: (localId, session) => controller()?.adoptNative?.(localId, session),
       rename: (id, title) => controller()?.rename?.(id, title),
       delete: (id) => controller()?.delete(id),
+      markReadOnly: (id, reason) => controller()?.markReadOnly?.(id, reason),
       loadMore: () => controller()?.loadMore?.(),
       refresh: (options) => controller()?.refresh?.(options),
     }
@@ -245,6 +248,7 @@ export function useWorkspaceAgentSessionCoordinator<
     adoptNativeSession: adoptAddressedSession,
     renameSession: renameAddressedSession,
     deleteSession: deleteAddressedSession,
+    markSessionReadOnly: markAddressedSessionReadOnly,
     refreshSession: refreshAddressedSession,
   } = useAddressedConsoleController({
     enabled: multiAgentConsoleEnabled,
@@ -286,6 +290,8 @@ export function useWorkspaceAgentSessionCoordinator<
           && session.agentTypeId === remoteSessionApi.sessions[index]?.agentTypeId
           && session.title === remoteSessionApi.sessions[index]?.title
           && session.turnCount === remoteSessionApi.sessions[index]?.turnCount
+          && session.readOnly === remoteSessionApi.sessions[index]?.readOnly
+          && session.readOnlyReason === remoteSessionApi.sessions[index]?.readOnlyReason
         ))
       if (sameScope && sameActive && sameSessions) return previous
       const next = new Map(previous)
@@ -548,6 +554,13 @@ export function useWorkspaceAgentSessionCoordinator<
     }
     return sessionApi?.rename?.(id, title)
   }, [multiAgentConsoleEnabled, renameAddressedSession, sessionApi])
+  const markSessionReadOnly = useCallback((id: string, sessionAgentTypeId?: string, reason?: string) => {
+    if (multiAgentConsoleEnabled && sessionAgentTypeId) {
+      markAddressedSessionReadOnly(workspaceSessionRef(id, sessionAgentTypeId), reason)
+      return
+    }
+    sessionApi?.markReadOnly?.(id, reason)
+  }, [markAddressedSessionReadOnly, multiAgentConsoleEnabled, sessionApi])
   const rawDelete: (id: string, agentTypeId?: string) => unknown = remoteSessionsPending
     ? remoteSessionActionsUnavailable
     : sessionApi?.delete ?? onDeleteSession ?? localSessionStore.remove
@@ -723,6 +736,7 @@ export function useWorkspaceAgentSessionCoordinator<
       rawSwitch,
       resolvedCreate,
       resolvedRename,
+      markSessionReadOnly,
       adoptAddressedSession,
     },
     panes,

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -25,6 +25,8 @@ export interface AppLeftPaneSession {
   updatedAt?: string | number
   turnCount?: number
   ephemeral?: boolean
+  readOnly?: boolean
+  readOnlyReason?: string
 }
 
 export interface AppLeftPaneAgent {

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { Clock3, Pin } from "lucide-react"
+import { Clock3, LockKeyhole, Pin } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { CHAT_SESSION_DRAG_TYPE } from "../ChatPaneStage"
 import type { WorkspaceAttentionSessionBadge } from "../../attention/WorkspaceAttentionProvider"
@@ -66,6 +66,7 @@ export function AppSessionRow({
   onDelete?: (id: string) => void | Promise<unknown>
 }) {
   const title = session.title || "Untitled"
+  const readOnlyReason = session.readOnlyReason ?? "This chat is read-only."
   const [menuOpen, setMenuOpen] = useState(false)
   const renameAvailable = Boolean(onRename) && session.ephemeral !== true
   const canCopy = session.ephemeral !== true
@@ -73,7 +74,7 @@ export function AppSessionRow({
   const rename = useInlineSessionRename({
     sessionId: session.id,
     title,
-    available: renameAvailable,
+    available: renameAvailable && session.readOnly !== true,
     onRename,
   })
   // Re-selecting the active chat is intentional: the shell uses this callback
@@ -87,6 +88,7 @@ export function AppSessionRow({
       data-boring-session-id={session.id}
       data-boring-agent-type-id={session.agentTypeId}
       data-boring-session-state={state}
+      data-boring-session-read-only={session.readOnly ? "true" : undefined}
       // Drag a session onto the chat stage to open it as a split pane (the
       // stage accepts CHAT_SESSION_DRAG_TYPE; see ChatPaneStageDock). Only
       // same-project sessions are draggable — a split pane lives in the loaded
@@ -149,6 +151,17 @@ export function AppSessionRow({
           title={agentBadge.label}
         >
           {agentBadge.label}
+        </span>
+      ) : null}
+      {session.readOnly ? (
+        <span
+          data-boring-workspace-part="app-session-read-only-badge"
+          aria-label={`Read-only chat. ${readOnlyReason}`}
+          title={readOnlyReason}
+          className="inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
+        >
+          <LockKeyhole aria-hidden="true" className="size-3" strokeWidth={1.75} />
+          read-only
         </span>
       ) : null}
       {attentionBadge ? (
@@ -219,6 +232,8 @@ export function AppSessionRow({
             title={title}
             canCopy={canCopy}
             canRename={renameAvailable && !rename.editing}
+            mutationsDisabled={session.readOnly === true}
+            disabledReason={readOnlyReason}
             onRename={rename.begin}
             onDelete={onDelete}
             onOpenChange={setMenuOpen}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppSessionActionsMenu.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppSessionActionsMenu.tsx
@@ -16,6 +16,8 @@ export function AppSessionActionsMenu({
   title,
   canCopy,
   canRename,
+  mutationsDisabled = false,
+  disabledReason,
   onRename,
   onDelete,
   onOpenChange,
@@ -24,6 +26,8 @@ export function AppSessionActionsMenu({
   title: string
   canCopy: boolean
   canRename: boolean
+  mutationsDisabled?: boolean
+  disabledReason?: string
   onRename: () => void
   onDelete?: (id: string) => void | Promise<unknown>
   onOpenChange: (open: boolean) => void
@@ -81,7 +85,10 @@ export function AppSessionActionsMenu({
         {canCopy && (canRename || onDelete) ? <DropdownMenuSeparator /> : null}
         {canRename ? (
           <DropdownMenuItem
+            disabled={mutationsDisabled}
+            title={mutationsDisabled ? disabledReason : undefined}
             onSelect={() => {
+              if (mutationsDisabled) return
               setMenuOpen(false)
               onRename()
             }}
@@ -93,7 +100,11 @@ export function AppSessionActionsMenu({
         {canRename && onDelete ? <DropdownMenuSeparator /> : null}
         {onDelete ? (
           <DropdownMenuItem
-            onSelect={() => void onDelete(sessionId)}
+            disabled={mutationsDisabled}
+            title={mutationsDisabled ? disabledReason : undefined}
+            onSelect={() => {
+              if (!mutationsDisabled) void onDelete(sessionId)
+            }}
             variant="destructive"
             className="gap-2 text-[13px]"
           >

--- a/packages/workspace/src/front/layout/plugin-tabs/InlineSessionRename.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/InlineSessionRename.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useEffect, useRef, useState } from "react"
+import { surfaceSessionActionError } from "../../sessionActionErrors"
 
 const MAX_TITLE_LENGTH = 200
 
@@ -49,7 +50,10 @@ export function useInlineSessionRename({
     setSaving(true)
     void Promise.resolve(onRename(sessionId, next))
       .then(cancel)
-      .catch((reason) => setError(reason instanceof Error ? reason.message : "Rename failed"))
+      .catch((reason) => {
+        surfaceSessionActionError("rename chat", reason)
+        setError(reason instanceof Error ? reason.message : "Rename failed")
+      })
       .finally(() => setSaving(false))
   }
 

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPaneSessionRow.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPaneSessionRow.test.tsx
@@ -43,7 +43,9 @@ describe("AppSessionRow actions", () => {
     expect(splitAction.querySelector(".lucide-columns-2")).toHaveClass("h-3.5", "w-3.5")
     fireEvent.pointerDown(screen.getByLabelText("More options for Native chat"), { button: 0, ctrlKey: false })
     expect(screen.getByText("Copy session ID")).toBeInTheDocument()
-    expect(screen.getByText("Rename")).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Read-only chat/i)).not.toBeInTheDocument()
+    expect(screen.getByRole("menuitem", { name: "Rename" })).not.toHaveAttribute("aria-disabled", "true")
+    expect(screen.getByRole("menuitem", { name: "Delete" })).not.toHaveAttribute("aria-disabled", "true")
     fireEvent.click(screen.getByText("Delete"))
     expect(onDelete).toHaveBeenCalledWith("native-1")
   })
@@ -55,5 +57,33 @@ describe("AppSessionRow actions", () => {
     })
 
     expect(screen.queryByLabelText("More options for Local draft")).not.toBeInTheDocument()
+  })
+
+  it("keeps a read-only chat visible and openable while disabling server mutations", () => {
+    const onSwitch = vi.fn()
+    const onDelete = vi.fn()
+    const onRename = vi.fn()
+    row({
+      session: {
+        id: "orphaned",
+        title: "Previous runtime chat",
+        readOnly: true,
+        readOnlyReason: "This chat belongs to a previous runtime configuration and can no longer be changed.",
+      },
+      onSwitch,
+      onDelete,
+      onRename,
+    })
+
+    expect(screen.getByText("Previous runtime chat")).toBeInTheDocument()
+    expect(screen.getByLabelText(/Read-only chat.*previous runtime configuration/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByText("Previous runtime chat"))
+    expect(onSwitch).toHaveBeenCalledWith("orphaned")
+
+    fireEvent.pointerDown(screen.getByLabelText("More options for Previous runtime chat"), { button: 0, ctrlKey: false })
+    expect(screen.getByRole("menuitem", { name: "Rename" })).toHaveAttribute("aria-disabled", "true")
+    expect(screen.getByRole("menuitem", { name: "Delete" })).toHaveAttribute("aria-disabled", "true")
+    expect(onRename).not.toHaveBeenCalled()
+    expect(onDelete).not.toHaveBeenCalled()
   })
 })

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/InlineSessionRename.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/InlineSessionRename.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { clearToasts, getActiveToasts } from "../../../toast"
 import { InlineSessionRename, useInlineSessionRename } from "../InlineSessionRename"
 
 function RenameHarness({ onRename }: { onRename: (id: string, title: string) => void | Promise<unknown> }) {
@@ -15,6 +16,8 @@ function RenameHarness({ onRename }: { onRename: (id: string, title: string) => 
 }
 
 describe("InlineSessionRename", () => {
+  afterEach(() => clearToasts())
+
   it("trims and saves a changed title on Enter", async () => {
     const onRename = vi.fn(async () => undefined)
     render(<RenameHarness onRename={onRename} />)
@@ -38,5 +41,28 @@ describe("InlineSessionRename", () => {
 
     expect(await screen.findByRole("alert")).toHaveTextContent("Session title is required")
     expect(screen.getByRole("textbox", { name: "Rename session" })).toBeTruthy()
+  })
+
+  it("keeps the editor open and surfaces a structured rename failure", async () => {
+    const onRename = vi.fn(async () => {
+      throw Object.assign(new Error("This chat belongs to a previous runtime configuration and can no longer be changed."), {
+        code: "AGENT_SESSION_RUNTIME_SCOPE_MISMATCH",
+      })
+    })
+    render(<RenameHarness onRename={onRename} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }))
+    const input = screen.getByRole("textbox", { name: "Rename session" })
+    fireEvent.change(input, { target: { value: "Changed title" } })
+    fireEvent.keyDown(input, { key: "Enter" })
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("previous runtime configuration")
+    await waitFor(() => expect(getActiveToasts()).toEqual([
+      expect.objectContaining({
+        title: "Could not rename chat",
+        description: expect.stringMatching(/previous runtime configuration.*AGENT_SESSION_RUNTIME_SCOPE_MISMATCH/i),
+      }),
+    ]))
+    expect(screen.getByRole("textbox", { name: "Rename session" })).toBeInTheDocument()
   })
 })

--- a/packages/workspace/src/front/sessionActionErrors.ts
+++ b/packages/workspace/src/front/sessionActionErrors.ts
@@ -1,0 +1,16 @@
+import { toast } from "./toast"
+
+export function surfaceSessionActionError(action: string, error: unknown): void {
+  const message = error instanceof Error && error.message
+    ? error.message
+    : `The ${action.toLowerCase()} request failed.`
+  const record = typeof error === "object" && error !== null
+    ? error as { code?: unknown; errorCode?: unknown }
+    : undefined
+  const rawCode = record?.code ?? record?.errorCode
+  const code = typeof rawCode === "string" && rawCode.length > 0 ? rawCode : undefined
+  toast.error({
+    title: `Could not ${action.toLowerCase()}`,
+    description: code ? `${message} (${code})` : message,
+  })
+}


### PR DESCRIPTION
## Summary

- parse gateway `{ error: { code, message, details } }` envelopes into a shared typed `GatewayResponseError` across create, rename, delete, load, prompt/follow-up, interrupt/stop, queue clear, state, and event-stream paths
- translate `AGENT_SESSION_RUNTIME_SCOPE_MISMATCH` to: “This chat belongs to a previous runtime configuration and can no longer be changed.” while retaining the stable code
- lazily mark mismatched sessions read-only for the current front-session lifetime; keep rows/open actions visible while disabling rename, delete, and composer send
- route create/delete/rename/load failures through the existing workspace toast surface; deletion is server-confirmed before session/pane removal
- add unit coverage plus a CI-run playground E2E spec (browser suite intentionally not run locally)

## Detection strategy

The frozen session-summary DTO has no runtime-scope identity/pin signal, so proactive detection is not possible without widening the gateway contract. This PR uses the bead-authorized fallback: mark the session lazily on the first structured `AGENT_SESSION_RUNTIME_SCOPE_MISMATCH` response, remember it in front state for the request scope, and reapply it across list refreshes. The runtime-scope pin is unchanged; no migration or pin relaxation is included.

## Error surface

The workspace already has a globally mounted toast primitive, so this reuses it rather than introducing a notification system. Rename also retains its inline editor error. Delete now waits for server success, so a rejected row/pane never disappears. No confirmation primitive was added; consistent delete confirmation remains a follow-up.

## Proof

- `pnpm typecheck`
- `pnpm lint:invariants`
- agent: `pnpm vitest run src/front/chat/session/__tests__/usePiSessions.addressed.test.tsx src/front/chat/session/__tests__/usePiSessions.test.tsx src/front/chat/pi/__tests__/remotePiSession.test.ts src/front/chat/__tests__/useAddressedAgentSelection.test.tsx src/front/chat/__tests__/PiChatPanel.test.tsx --no-file-parallelism` — 5 files / 143 tests
- workspace: `pnpm vitest run src/front/layout/plugin-tabs/__tests__/AppLeftPaneSessionRow.test.tsx src/front/layout/plugin-tabs/__tests__/InlineSessionRename.test.tsx src/app/front/__tests__/WorkspaceAgentFront.test.tsx --no-file-parallelism` — 3 files / 92 tests
- `node scripts/build-front-css.mjs` from `packages/agent`; `dist/front/styles.css` = 166,894 bytes
- independent acceptance and maintainability re-reviews: clean after fixes

## Contract escalation

A fresh client cannot currently guarantee the owner-requested readable transcript for an orphaned session: both `readSessionState` and `connectSession` pass through the gateway runtime binding check, while the front starts without a transcript cache. Solving cold-open transcript readability appears to require a gateway/read-contract decision that this bead explicitly forbids widening. This PR therefore preserves already-hydrated transcript readability and marks on the first mismatch, but does not claim cold-open transcript acceptance. Owner direction is required for that separate contract change.

## CI

E2E coverage was added to `apps/workspace-playground/e2e/agent-host-golden-route.spec.ts`; per bead mechanics, the browser suite was not run locally and is left to CI.