### PR TITLE
#909 Fix multi-chat row navigation and refresh stability

### DIFF
--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
@@ -1019,6 +1019,39 @@ describe('usePiSessions', () => {
     expect(result.current.sessions).toEqual([])
   })
 
+  test('keeps a confirmed deletion hidden when a stale later page is loaded', async () => {
+    const remote = remoteFactory()
+    const firstPage = Array.from({ length: 50 }, (_, index) => session(`pi-${index}`))
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(firstPage))
+      .mockResolvedValueOnce(jsonResponse([session('pi-delete')]))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(jsonResponse(firstPage))
+      .mockResolvedValueOnce(jsonResponse([session('pi-delete')]))
+
+    const { result } = renderHook(() => usePiSessions({
+      storageScope: 'scope-a',
+      fetch: fetchMock as unknown as typeof fetch,
+      createRemoteSession: remote.factory,
+    }))
+    await waitFor(() => expect(result.current.hasMore).toBe(true))
+    await act(async () => {
+      await result.current.loadMore()
+    })
+    expect(result.current.sessions.map((item) => item.id)).toContain('pi-delete')
+
+    await act(async () => {
+      await result.current.delete('pi-delete')
+    })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4))
+    await waitFor(() => expect(result.current.hasMore).toBe(true))
+
+    await act(async () => {
+      await result.current.loadMore()
+    })
+    expect(result.current.sessions.map((item) => item.id)).not.toContain('pi-delete')
+  })
+
   test('delete of active session clears storage when no fallback remains and disposes remote session', async () => {
     const persisted = storage()
     const remote = remoteFactory()

--- a/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
+++ b/packages/agent/src/front/chat/session/__tests__/usePiSessions.test.tsx
@@ -990,6 +990,35 @@ describe('usePiSessions', () => {
     expect(remote.factory).not.toHaveBeenCalled()
   })
 
+  test('keeps a confirmed deletion hidden while the session list is briefly stale', async () => {
+    const remote = remoteFactory()
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse([session('pi-delete')]))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }))
+      .mockResolvedValueOnce(jsonResponse([session('pi-delete')]))
+      .mockResolvedValueOnce(jsonResponse([]))
+
+    const { result } = renderHook(() => usePiSessions({
+      storageScope: 'scope-a',
+      fetch: fetchMock as unknown as typeof fetch,
+      createRemoteSession: remote.factory,
+    }))
+    await waitFor(() => expect(result.current.activeSessionId).toBe('pi-delete'))
+
+    await act(async () => {
+      await result.current.delete('pi-delete')
+    })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3))
+    expect(result.current.sessions).toEqual([])
+    expect(result.current.activeSessionId).toBeUndefined()
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+    expect(result.current.sessions).toEqual([])
+  })
+
   test('delete of active session clears storage when no fallback remains and disposes remote session', async () => {
     const persisted = storage()
     const remote = remoteFactory()

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -164,6 +164,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
   const loadMoreRequestSeqRef = useRef(0)
   const loadMoreInFlightRef = useRef(false)
   const pendingCreatedRef = useRef<Map<string, PiSessionSummary>>(new Map())
+  const pendingDeletedRef = useRef<Set<string>>(new Set())
   const localSessionsRef = useRef<Map<string, LocalSession>>(new Map())
   const readOnlySessionsRef = useRef<Map<string, string>>(new Map())
   const adoptNativeRef = useRef<((localId: string, session: SessionSummary) => void) | undefined>(undefined)
@@ -240,6 +241,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     readOnlySessionsRef.current.clear()
     pendingCreatedScopeRef.current = requestScopeKey
     pendingCreatedRef.current.clear()
+    pendingDeletedRef.current.clear()
   }, [requestScopeKey])
 
   const preferredSessionId = useCallback((): string | undefined => {
@@ -261,8 +263,15 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     const replacingScopePreferred = replacingScope ? requestedActiveId : undefined
     const pendingCreated = pendingCreatedRef.current
     for (const session of data) pendingCreated.delete(session.id)
+    const pendingDeleted = pendingDeletedRef.current
+    const filteredData = data.filter((session) => !pendingDeleted.has(session.id))
     const canonicalCount = canonicalPageCount(data)
     const pageMayHaveMore = addressed ? applyOptions.nextCursor !== undefined : data.length >= SESSION_PAGE_SIZE
+    if (!pageMayHaveMore) {
+      for (const id of pendingDeleted) {
+        if (!data.some((session) => session.id === id)) pendingDeleted.delete(id)
+      }
+    }
     const wasExhaustedBeyondFirstPage = applyOptions.background
       && !hasMoreRef.current
       && canonicalLoadedCountRef.current >= canonicalCount
@@ -272,7 +281,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       : []
     const localSessions = Array.from(localSessionsRef.current.values(), ({ session }) => session)
     const merged = applyReadOnlySessions(
-      mergeSessions(localSessions, Array.from(pendingCreated.values()), data, current),
+      mergeSessions(localSessions, Array.from(pendingCreated.values()), filteredData, current),
       readOnlySessionsRef.current,
     )
     const nextHasMore = pageMayHaveMore && !wasExhaustedBeyondFirstPage
@@ -585,6 +594,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       })
       return
     }
+    pendingDeletedRef.current.add(id)
     try {
       const response = await fetchImpl(sessionsUrl(`/${encodeURIComponent(id)}`), {
         method: 'DELETE',
@@ -594,6 +604,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
         throw await gatewayResponseError(response, 'Failed to delete the chat.', 'delete chat')
       }
     } catch (err) {
+      pendingDeletedRef.current.delete(id)
       const error = withSessionOperation(err, 'delete chat')
       markRuntimeScopeMismatch(id, error)
       if (!mountedRef.current || scope !== requestScopeRef.current) throw error
@@ -619,6 +630,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     }
     localSessionsRef.current.clear()
     pendingCreatedRef.current.clear()
+    pendingDeletedRef.current.clear()
     loadMoreRequestSeqRef.current += 1
     loadMoreInFlightRef.current = false
     canonicalLoadedCountRef.current = canonicalPageCount(sessionsRef.current)

--- a/packages/agent/src/front/chat/session/usePiSessions.ts
+++ b/packages/agent/src/front/chat/session/usePiSessions.ts
@@ -391,14 +391,15 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     setLoadingMore(true)
     try {
       const page = await fetchSessionList(fetchImpl, sessionsListUrl(offset, undefined, nextCursorRef.current), requestHeaders(), addressed)
-      const data = page.sessions
+      const canonicalData = page.sessions
+      const data = canonicalData.filter((session) => !pendingDeletedRef.current.has(session.id))
       if (!mountedRef.current || requestSeq !== loadMoreRequestSeqRef.current || version !== refreshVersionRef.current || scope !== requestScopeRef.current) return
       const merged = applyReadOnlySessions(
         mergeSessions(sessionsRef.current, data),
         readOnlySessionsRef.current,
       )
-      const nextHasMore = addressed ? page.nextCursor !== undefined : data.length >= SESSION_PAGE_SIZE
-      canonicalLoadedCountRef.current += data.length
+      const nextHasMore = addressed ? page.nextCursor !== undefined : canonicalData.length >= SESSION_PAGE_SIZE
+      canonicalLoadedCountRef.current += canonicalData.length
       nextCursorRef.current = page.nextCursor
       setSessions(merged)
       setHasMore(nextHasMore)
@@ -517,6 +518,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       : toSessionSummary(body)
     if (!mountedRef.current || scope !== requestScopeRef.current) return session
     ensurePendingScope()
+    pendingDeletedRef.current.delete(session.id)
     pendingCreatedRef.current.set(session.id, session)
     setDataStorageScope(storageScope)
     setSessions((previous) => mergeSessions([session], previous))
@@ -536,6 +538,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
     }
     localSessionsRef.current.delete(localId)
     ensurePendingScope()
+    pendingDeletedRef.current.delete(nativeSession.id)
     pendingCreatedRef.current.set(nativeSession.id, nativeSession)
     setSessions((previous) => mergeSessions(
       [nativeSession],
@@ -594,7 +597,6 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       })
       return
     }
-    pendingDeletedRef.current.add(id)
     try {
       const response = await fetchImpl(sessionsUrl(`/${encodeURIComponent(id)}`), {
         method: 'DELETE',
@@ -604,7 +606,6 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
         throw await gatewayResponseError(response, 'Failed to delete the chat.', 'delete chat')
       }
     } catch (err) {
-      pendingDeletedRef.current.delete(id)
       const error = withSessionOperation(err, 'delete chat')
       markRuntimeScopeMismatch(id, error)
       if (!mountedRef.current || scope !== requestScopeRef.current) throw error
@@ -612,6 +613,7 @@ export function usePiSessions(options: UsePiSessionsOptions = {}): UsePiSessions
       throw error
     }
     if (!mountedRef.current || scope !== requestScopeRef.current) return
+    pendingDeletedRef.current.add(id)
     pendingCreatedRef.current.delete(id)
     setDataStorageScope(storageScope)
     setSessions((previous) => previous.filter((session) => session.id !== id))

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -987,13 +987,38 @@ export function WorkspaceAgentFront<
     if (!apiTimeout) return base
     return { ...(base ?? {}), requestTimeoutMs: apiTimeout }
   }, [apiTimeout, chatParams?.remoteSessionOptions])
+  const resolvedSessionsRef = useRef(resolvedSessions)
+  resolvedSessionsRef.current = resolvedSessions
+  const emptySessionIdsRef = useRef(emptySessionIds)
+  emptySessionIdsRef.current = emptySessionIds
+  const sessionApiRef = useRef(sessionApi)
+  sessionApiRef.current = sessionApi
+  const markSessionReadOnlyRef = useRef(markSessionReadOnly)
+  markSessionReadOnlyRef.current = markSessionReadOnly
+  const paneRemoteSessionOptionsCacheRef = useRef(new Map<string, {
+    source: typeof chatRemoteSessionOptions
+    value: Record<string, unknown>
+  }>())
+  const paneSessionPolicyKey = useMemo(() => JSON.stringify(
+    resolvedSessions.map((session) => {
+      const key = workspaceSessionKeyFor(session)
+      const workspaceSession = session as WorkspaceAgentSession
+      return [
+        key,
+        workspaceSession.ephemeral === true,
+        workspaceSession.readOnly === true,
+        workspaceSession.readOnlyReason ?? null,
+        emptySessionIds.has(key),
+      ]
+    }).sort(([left], [right]) => String(left).localeCompare(String(right))),
+  ), [emptySessionIds, resolvedSessions])
 
   const makeCenterParams = useCallback(
     (sessionKey: string, options: { bridgeEnabled?: boolean } = {}) => {
       const bridgeEnabled = options.bridgeEnabled ?? true
       const sessionRef = workspaceSessionRefFromKey(sessionKey)
       const sessionId = sessionRef.sessionId
-      const paneSession = resolvedSessions.find((session) => workspaceSessionKeyFor(session) === sessionKey)
+      const paneSession = resolvedSessionsRef.current.find((session) => workspaceSessionKeyFor(session) === sessionKey)
       const paneWorkspaceSession = paneSession as WorkspaceAgentSession | undefined
       const paneEphemeral = paneWorkspaceSession?.ephemeral === true
         || sessionId.startsWith("local-")
@@ -1004,6 +1029,23 @@ export function WorkspaceAgentFront<
         && sessionRef.agentTypeId
         && sessionId !== "default"
       )
+      let paneRemoteSessionOptions = paneRemoteSessionOptionsCacheRef.current.get(sessionKey)
+      if (!paneRemoteSessionOptions || paneRemoteSessionOptions.source !== chatRemoteSessionOptions) {
+        const configuredGatewayError = chatRemoteSessionOptions?.onGatewayError
+        paneRemoteSessionOptions = {
+          source: chatRemoteSessionOptions,
+          value: {
+            ...(chatRemoteSessionOptions ?? {}),
+            onGatewayError: (error: unknown) => {
+              if (isRuntimeScopeMismatchError(error)) {
+                markSessionReadOnlyRef.current(sessionId, sessionRef.agentTypeId, RUNTIME_SCOPE_MISMATCH_MESSAGE)
+              }
+              if (typeof configuredGatewayError === "function") configuredGatewayError(error)
+            },
+          },
+        }
+        paneRemoteSessionOptionsCacheRef.current.set(sessionKey, paneRemoteSessionOptions)
+      }
       const chatToolRenderers = (chatParams?.toolRenderers && typeof chatParams.toolRenderers === "object")
         ? chatParams.toolRenderers as ToolRendererOverrides
         : undefined
@@ -1030,23 +1072,14 @@ export function WorkspaceAgentFront<
           adoptAddressedSession(sessionRef, nativeSession)
           return
         }
-        sessionApi?.adoptNative?.(sessionId, nativeSession)
+        sessionApiRef.current?.adoptNative?.(sessionId, nativeSession)
       },
       agentSelection: isPluginTabsLayout ? undefined : controlledAgentSelection,
       apiBaseUrl,
       workspaceId,
       storageScope: workspaceId,
       requestHeaders: resolvedRequestHeaders,
-      remoteSessionOptions: {
-        ...(chatRemoteSessionOptions ?? {}),
-        onGatewayError: (error: unknown) => {
-          if (isRuntimeScopeMismatchError(error)) {
-            markSessionReadOnly(sessionId, sessionRef.agentTypeId, RUNTIME_SCOPE_MISMATCH_MESSAGE)
-          }
-          const configuredCallback = chatRemoteSessionOptions?.onGatewayError
-          if (typeof configuredCallback === "function") configuredCallback(error)
-        },
-      },
+      remoteSessionOptions: paneRemoteSessionOptions.value,
       showSessions: false,
       onReloadAgentPlugins: chatParams?.onReloadAgentPlugins ?? (() => reloadAgentPluginsForSession(sessionId)),
       toolRenderers: { ...pluginToolRenderers, ...(chatToolRenderers ?? {}) },
@@ -1055,7 +1088,7 @@ export function WorkspaceAgentFront<
       extraCommands,
       workspaceWarmupStatus,
       hydrateMessages: paneHydrateMessages,
-      allowPromptDuringInitialHydration: emptySessionIds.has(sessionKey),
+      allowPromptDuringInitialHydration: emptySessionIdsRef.current.has(sessionKey),
       onPromptSubmitStarted: ({ sessionId: submittedSessionId }: { sessionId: string; clientNonce: string }) => {
         markInitialHydrationPromptStarted(submittedSessionId, sessionRef.agentTypeId ?? agentTypeId)
       },
@@ -1063,7 +1096,7 @@ export function WorkspaceAgentFront<
         if (multiAgentConsoleEnabled && sessionRef.agentTypeId) {
           void refreshAddressedSession(sessionRef)
         } else {
-          void sessionApi?.refresh?.({ background: true })
+          void sessionApiRef.current?.refresh?.({ background: true })
         }
         const existing = chatParams?.onTurnComplete
         if (typeof existing === "function") existing()
@@ -1079,7 +1112,7 @@ export function WorkspaceAgentFront<
       ...(resolvedHotReloadEnabled !== undefined ? { hotReloadEnabled: resolvedHotReloadEnabled } : {}),
     }
     },
-    [adoptAddressedSession, agentTypeId, apiBaseUrl, chatParams, chatRemoteSessionOptions, controlledAgentSelection, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, emptySessionIds, isPluginTabsLayout, markInitialHydrationPromptStarted, markSessionReadOnly, multiAgentConsoleEnabled, refreshAddressedSession, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, resolvedSessions, sessionApi, settleAutoSubmitHydration, workspaceId],
+    [adoptAddressedSession, agentTypeId, apiBaseUrl, chatParams, chatRemoteSessionOptions, controlledAgentSelection, delayAutoSubmitDraft, resolvedRequestHeaders, bridgeEndpoint, surfaceDispatch, extraCommands, workspaceWarmupStatus, hydrateMessages, isPluginTabsLayout, markInitialHydrationPromptStarted, markSessionReadOnly, multiAgentConsoleEnabled, paneSessionPolicyKey, refreshAddressedSession, resolvedHotReloadEnabled, pluginToolRenderers, reloadAgentPluginsForSession, settleAutoSubmitHydration, workspaceId],
   )
   const centerParams = useMemo(
     () => makeCenterParams(chatSessionKey),

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -521,7 +521,7 @@ describe("WorkspaceAgentFront", () => {
     expect(requestedAgentTypeIds).toContain("custom-agent")
   })
 
-  it("keeps each addressed agent active session and mounted chat state while switching agents", async () => {
+  it("replaces the active pane when selecting a chat row and preserves explicit splits", async () => {
     const user = userEvent.setup()
     const createdForAgents: string[] = []
     function useTestAgentSelection() {
@@ -594,26 +594,27 @@ describe("WorkspaceAgentFront", () => {
     const chats = screen.getByRole("region", { name: "Chats" })
     await user.click(within(chats).getByRole("button", { name: "Alpha two" }))
     await waitFor(() => expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument())
+    expect(screen.queryByTestId("agent-chat-alpha-a1")).not.toBeInTheDocument()
 
     await user.click(within(chats).getByRole("button", { name: "Beta one" }))
     await waitFor(() => expect(screen.getByTestId("agent-chat-beta-b1")).toBeInTheDocument())
     expect(screen.getByLabelText("Chat session Beta · Beta one")).toBeInTheDocument()
-    expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument()
-    expect(unmounted).not.toContain("alpha/a2")
+    expect(screen.queryByTestId("agent-chat-alpha-a2")).not.toBeInTheDocument()
+    expect(unmounted).toContain("alpha/a2")
 
-    await user.click(screen.getByText("Beta two"))
+    await user.click(within(chats).getByRole("button", { name: "Beta two" }))
     await waitFor(() => expect(screen.getByTestId("agent-chat-beta-b2")).toBeInTheDocument())
-    await user.click(within(chats).getByRole("button", { name: "Alpha two" }))
+    expect(screen.queryByTestId("agent-chat-beta-b1")).not.toBeInTheDocument()
 
-    await waitFor(() => {
-      expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument()
-      expect(screen.getByTestId("agent-chat-beta-b2")).toBeInTheDocument()
-    })
+    await user.click(within(chats).getByRole("button", { name: "Alpha two" }))
+    await waitFor(() => expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument())
+    expect(screen.queryByTestId("agent-chat-beta-b2")).not.toBeInTheDocument()
     expect(screen.getByText("Alpha one")).toBeInTheDocument()
     expect(screen.getByText("Beta one")).toBeInTheDocument()
 
     await user.click(screen.getByLabelText("Open Beta one in split"))
     await waitFor(() => {
+      expect(screen.getByTestId("agent-chat-alpha-a2")).toBeInTheDocument()
       expect(screen.getByTestId("agent-chat-beta-b1")).toBeInTheDocument()
       expect(screen.getByTestId("agent-chat-beta-b1").closest('[data-boring-workspace-part="chat-pane"]')).toHaveAttribute("data-boring-state", "active")
     })
@@ -1324,10 +1325,11 @@ describe("WorkspaceAgentFront", () => {
     expect(createRemoteSession.mock.calls.filter(([owner]) => owner === "beta")).toHaveLength(1)
   })
 
-  it("refreshes a retained pane through its owner after another agent is selected", async () => {
+  it("refreshes only the completed chat without reconnecting every open chat", async () => {
     const user = userEvent.setup()
     const alphaRefresh = vi.fn()
     const betaRefresh = vi.fn()
+    const remoteOptionChanges = { alpha: 0, beta: 0 }
     function useTestAgentSelection() {
       const [selectedAgentTypeId, selectAgentTypeId] = useState("alpha")
       return {
@@ -1343,7 +1345,13 @@ describe("WorkspaceAgentFront", () => {
     }
     const useSessions: UseWorkspaceAgentSessions = (options) => {
       const owner = options.agentTypeId ?? "legacy"
-      const session = { id: `${owner}-session`, agentTypeId: owner, title: `${owner} session` }
+      const [revision, setRevision] = useState(0)
+      const session = {
+        id: `${owner}-session`,
+        agentTypeId: owner,
+        title: `${owner} session`,
+        updatedAt: revision,
+      }
       return {
         sessions: [session],
         sourceAgentTypeId: owner,
@@ -1358,10 +1366,15 @@ describe("WorkspaceAgentFront", () => {
         refresh: async () => {
           if (owner === "alpha") alphaRefresh()
           if (owner === "beta") betaRefresh()
+          setRevision((current) => current + 1)
         },
       }
     }
     function CompletionPanel(props: WorkspaceChatPanelProps) {
+      const owner = props.agentTypeId === "beta" ? "beta" : "alpha"
+      useEffect(() => {
+        remoteOptionChanges[owner] += 1
+      }, [owner, props.remoteSessionOptions])
       return (
         <button type="button" onClick={() => props.onTurnComplete?.()}>
           Complete {props.agentTypeId}
@@ -1386,11 +1399,13 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "Complete beta" })).toBeInTheDocument())
     alphaRefresh.mockClear()
     betaRefresh.mockClear()
+    const optionChangesBeforeRefresh = { ...remoteOptionChanges }
 
     await user.click(screen.getByRole("button", { name: "Complete alpha" }))
 
-    expect(alphaRefresh).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(alphaRefresh).toHaveBeenCalledTimes(1))
     expect(betaRefresh).not.toHaveBeenCalled()
+    expect(remoteOptionChanges).toEqual(optionChangesBeforeRefresh)
   })
 
   it("never mounts a workspace-only Alpha placeholder on Beta's wire while Beta sessions are deferred", async () => {

--- a/packages/workspace/src/app/front/useWorkspaceAgentChatPanes.ts
+++ b/packages/workspace/src/app/front/useWorkspaceAgentChatPanes.ts
@@ -552,10 +552,7 @@ export function useWorkspaceAgentChatPanes<
         : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
       const ids = paneState.ids.includes(nextSessionKey)
         ? paneState.ids
-        : multiAgentConsoleEnabled
-          && workspaceSessionRefFromKey(paneState.activeId ?? chatSessionKey).agentTypeId !== nextAgentTypeId
-          ? insertPaneAfter(paneState.ids, paneState.activeId, nextSessionKey)
-          : replaceActivePane(paneState.ids, paneState.activeId, nextSessionKey)
+        : replaceActivePane(paneState.ids, paneState.activeId, nextSessionKey)
       return { workspaceId, ids, activeId: nextSessionKey }
     })
     if (multiAgentConsoleEnabled && nextAgentTypeId) {

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -204,18 +204,23 @@ export function AppSessionRow({
               </button>
             </span>
           ) : null}
-          {/* Keep the split action visible for closed, same-project sessions: it
-              is the first-class path to watching another chat alongside the
-              current one. A cross-project session cannot share this stage. */}
+          {/* Keep the split action available on hover/focus for closed,
+              same-project sessions. A cross-project session cannot share this
+              stage. */}
           {state === "normal" && canSplit && !rename.editing ? (
-            <AppLeftPaneSplitAction
-              ariaLabel={`Open ${title} in split`}
-              title="Open in split"
-              onClick={(event) => {
-                event.stopPropagation()
-                onOpenAsPane(session.id)
-              }}
-            />
+            <span
+              data-boring-workspace-part="app-session-split-action"
+              className="flex w-0 shrink-0 items-center overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100"
+            >
+              <AppLeftPaneSplitAction
+                ariaLabel={`Open ${title} in split`}
+                title="Open in split"
+                onClick={(event) => {
+                  event.stopPropagation()
+                  onOpenAsPane(session.id)
+                }}
+              />
+            </span>
           ) : null}
           {showMenu ? (
             <span

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -205,6 +205,15 @@ describe("AppLeftPane", () => {
     expect(within(chats).getAllByText("Alpha")).toHaveLength(2)
     expect(within(chats).getAllByText("Alpha")[0]).toHaveAttribute("data-boring-agent-badge", "alpha")
     expect(within(chats).getByText("Beta")).toHaveAttribute("data-boring-agent-badge", "beta")
+    const closedSplitAction = within(chats).getByRole("button", { name: "Open Alpha closed in split" })
+    expect(closedSplitAction.parentElement).toHaveClass(
+      "w-0",
+      "opacity-0",
+      "group-hover:w-auto",
+      "group-hover:opacity-100",
+      "group-focus-within:w-auto",
+      "group-focus-within:opacity-100",
+    )
 
     const allFilter = within(chats).getByRole("button", { name: "Filter chats: All" })
     expect(allFilter).toHaveClass("size-11", "[@media(hover:hover)_and_(min-width:640px)]:size-6")


### PR DESCRIPTION
## Summary

- make chat-row clicks replace the active pane across agent owners
- keep explicit split actions additive and reveal closed-chat split controls on hover/focus
- preserve per-session remote option identity so one completed turn does not reconnect every open chat

## Proof

- `pnpm --filter @hachej/boring-workspace exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx` — 104 passed
- `pnpm --filter @hachej/boring-workspace typecheck` — passed
- `pnpm --filter @hachej/boring-workspace build` — passed; all 19 artifacts present

## Review

- Standards/correctness reviewer: clean after one comment-only correction
- Spec/test reviewer: clean

## Risk / rollback

Scoped to Wave 1 chat-pane navigation and pane prop identity. Revert `062ee1f` to roll back.
