### PR TITLE
docs(direction): record verified lane reality for waves 2-4

### DIFF
--- a/docs/DIRECTION.md
+++ b/docs/DIRECTION.md
@@ -54,9 +54,13 @@ slice absorbed by .27), `.28` (re-land native sessions + rename menu, after
 
 ## Wave 2 — trigger: Wave 1 demo works
 
-- **Chat streaming durability** (`0jpy.8` + `26v`, ONE lane): activate the
-  dormant SqliteEventStreamStore. Trigger is explicit: `.31`'s concurrent
-  streams + Seneca production chat. This is where Seneca hardening lives.
+- **Chat streaming durability** (`0jpy.8` + `26v`, ONE lane; issue #1009):
+  activate the dormant SqliteEventStreamStore. Trigger is explicit: `.31`'s
+  concurrent streams + Seneca production chat. This is where Seneca hardening
+  lives. Verified 2026-07-31: this is **wiring plus a read path**, not a build
+  — the store and its consumer are both written, and no production caller
+  passes `eventStore`. Resolve the agent-keying question (§Lane reality)
+  BEFORE any durable schema is written.
 - **F-graph execution begins** (Decision 28 detail: `docs/issues/391/plan.md`):
   F0b inventory → F1/F2 Environment contracts + boring-bash service → onward.
   F0a paperwork (the rebased #904 with its three shipped-reality amendments)
@@ -65,19 +69,28 @@ slice absorbed by .27), `.28` (re-land native sessions + rename menu, after
 
 ## Wave 3 — trigger: named consumers, not calendar
 
-- **BYOK** (KEY0 + parked PR #917): becomes load-bearing when multi-agent
-  model costs are real. First step is ratifying the de-facto policy the
-  shipped code implements.
+**BYOK and External MCP share one prerequisite** — a per-workspace credential
+and registration substrate (§Lane reality). Whichever fires first builds it;
+it is a named deliverable of this wave, not an implementation detail of
+either lane. Sequence them adjacently.
+
+- **BYOK** (KEY0 + parked PR #917; issue #1010): becomes load-bearing when
+  multi-agent model costs are real. First step is ratifying the de-facto
+  policy the shipped code implements. The `.30` model-cap revisit is
+  MANDATORY here — it has no bead and nothing else forces it.
 - **External MCP** (#900, re-land per #946: small reviewed slices,
-  application-owned atomic backend): waits for its consumer — mail/tools for
-  the CoS persona, or a client need. Do not re-land #937 wholesale.
+  application-owned atomic backend; issue #1011): waits for its consumer —
+  mail/tools for the CoS persona, or a client need. Do not re-land #937
+  wholesale.
 - **Authored catalog** (`0jpy.9`, includes fleet-time model-ID validation and
   maxTokensPerTurn enforcement): when personas become data.
 
 ## Wave 4 — v2 era
 
-- **Sandbox/SBX1** (own-cloud runsc fleet; parked PR #916): infrastructure
-  for remote/third-party agents. Trigger restated: after F7 conformance.
+- **Sandbox/SBX1** (own-cloud runsc fleet; parked PR #916; issue #1012):
+  infrastructure for remote/third-party agents. Trigger restated: after F7
+  conformance. NOTE: two sandbox facts are true TODAY and are not Wave-4
+  problems — see §Lane reality. Decide whether they wait for this wave.
 - **#905 v2 remote Host** (`0jpy.11`/`.16`): behind three gates — plugin
   trust cleanup (`.13`), the model-cap revisit (below), and an owner-recorded
   additive-v2 amendment.
@@ -105,6 +118,59 @@ slice absorbed by .27), `.28` (re-land native sessions + rename menu, after
 - One heavy executor at a time; independent review before merge; verify
   agent claims against `gh`/git ground truth, never against reports.
 
+## Lane reality (verified against `origin/main`, 2026-07-31)
+
+Read this before dispatching any Wave 2–4 work. It is what the CODE does, not
+what the plan folders say; where they disagree, this wins. Full evidence with
+file paths lives in the lane issues (#1009 streaming, #1010 BYOK, #1011 MCP,
+#1012 sandbox), each with a draft seed PR.
+
+**The pattern: every lane is further built than its plan claims, and three of
+four stop at the same missing layer — any way for a user to supply something**
+(a key, a server URL, a trust decision). Infrastructure without an on-ramp.
+
+| Lane | Today | The real delta |
+|---|---|---|
+| Streaming | In-memory ring buffer, NDJSON, correct reconnect. Level B holds — never a silent gap | Wiring + a durable read path. Store and consumer both written; nothing feeds them |
+| BYOK | Encrypted `workspace_settings`; model keys come from process env **via Pi**, not from Boring | UI, store backend, authority verifier, and an **injection seam in the harness** — the hard one |
+| MCP | Genuinely works: real SDK client, 7 tools live in the toolset, read-only by construction | Only 2 hardcoded providers. No user-supplied URL, no stdio/SSE, no per-server credentials |
+| Sandbox | bwrap is real and used by full-app; Vercel Sandbox real; packages published | gVisor does not execute on main; `RemoteWorkerTransportV1` has no implementation |
+
+**The shared substrate.** BYOK, MCP and sandbox converge on one missing
+component: per-workspace credentials and registration. Evidence, not
+architecture-astronomy: the encrypted settings table's only observed content
+is MCP registration data (`__serverBoringMcpSourcesV1`); bead
+`wt-391-forward-16f.7` wants BYOK migrated OFF that same table; and the frozen
+credential contract's `sandbox-pipe`/`sandbox-tmpfs` delivery modes are stubs
+on both ends. Streaming is the genuine exception — independent, and nearly
+done.
+
+**Parked PRs do not close their lanes.** #917 is storage+crypto only and
+defers UI, lifecycle and resolver wiring by its own body. #916's body says do
+not merge and its runsc isolation evidence is self-described as
+non-admitting. Neither is a shortcut.
+
+**Two sandbox facts true today, owned by no wave:** the CLI defaults to
+`direct` — raw spawn, zero isolation — on every platform, with bwrap opt-in
+behind `--mode local-sandbox`; and neither real backend isolates network
+egress (bwrap defaults to `--share-net`). Defensible for a local dev tool the
+user controls; wrong the moment anything less-trusted runs.
+
+**Inert surfaces that read as working support** — fix or remove, do not build
+on: `mcpServerRefs` on agent definitions is validated, frozen and
+inventory-checked but never resolved into a connection; managed-agent MCP
+ingress is hardcoded off in every released host.
+
+**Streaming keying, decide before durable schema:** the buffer key is
+`[sessionId, workspaceId, userId]` and the stream path is
+`sessions/<sessionId>` — `agentTypeId` is in the URL but in neither. Not a
+live defect (ids are minted unique; cross-agent addressing is rejected), but
+durable rows would bake the omission in.
+
+**Bookkeeping correction:** bead `0jpy.15` ("duplicate AgentLiveEventBuffer")
+has a false premise — there is one such class with no external consumers. The
+real duplication is two replay sources. Rewrite the bead before working it.
+
 ## Plan-folder map (what still binds)
 
 | Folder | Status |
@@ -112,7 +178,11 @@ slice absorbed by .27), `.28` (re-land native sessions + rename menu, after
 | `docs/issues/909/` | Frozen record of what shipped + follow-up beads. Binding for the Gateway contract (§6) |
 | `docs/issues/391/` | Decision-28 detail for Waves 2+. Binding once its wave opens |
 | `docs/issues/805/` | A1 shipped; remainder absorbed into 391's F-graph. Reference only |
-| `docs/issues/808/`, `820/`, `806/`, `900/` | Lane detail for Waves 3–4. Reference until their trigger fires |
+| `docs/issues/808/`, `820/`, `806/`, `900/` | Lane detail for Waves 3–4. Reference until their trigger fires — but §Lane reality outranks them on what exists |
+
+Lane tracking issues (each with a draft seed PR): #1009 streaming, #1010 BYOK,
+#1011 external MCP, #1012 sandbox. Issues #820 and #808 are CLOSED; #1010 and
+#1012 replace them as the tracking issues for their parked PRs.
 
 Bead graph: epic `wt-391-forward-0jpy` follow-ups (Wave 1–2) + F-graph under
 `wt-391-forward-step1a-current-xn9` (Wave 2+). Anything not reachable from


### PR DESCRIPTION
Stacked on #1008 — `docs/DIRECTION.md` does not exist on `main` yet (it arrived via #974 into the integration branch), so this targets `integration/wave-1-final` and lands with the wave. **Retarget to `main` if #1008 merges first.**

Records what the code actually does for the four remaining lanes, verified against `origin/main` on 2026-07-31 by four independent explorations, so the next orchestrator dispatches from verified state rather than from four separate plan folders.

## What it adds

A **Lane reality** section: a today/delta table per lane, plus the findings that change sequencing —

- **The shared substrate.** BYOK, MCP and sandbox converge on one missing component (per-workspace credentials + registration). Wave 3 now names it as a deliverable instead of letting whichever lane fires first improvise one.
- **Streaming is wiring, not a build** — but the agent-keying omission must be settled before durable rows bake it in.
- **Parked PRs #916/#917 do not close their lanes** — both defer the load-bearing parts by their own bodies.
- **Two sandbox defaults are true today** and belong to no wave: CLI defaults to zero isolation; neither real backend isolates network egress.
- **Two inert surfaces that read as working support**: `mcpServerRefs` is never resolved; MCP ingress is hardcoded off in every host.
- **Bead `0jpy.15` has a false premise** and should be rewritten before anyone works it.

## Also

Threads lane issues #1009/#1010/#1011/#1012 into the wave sections, and records that #820 and #808 are closed — their parked PRs were pointing at closed issues.

Docs only. No code changes.

Refs #1009, #1010, #1011, #1012