### PR TITLE
#909 test(ci): seed workspace playground E2E fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,11 @@ jobs:
 
       - name: Run e2e
         run: pnpm e2e
+        env:
+          # The workspace-playground config seeds this clean override from its
+          # committed fixtures, matching a fresh checkout instead of relying on
+          # mutable local playground state.
+          BORING_AGENT_WORKSPACE_ROOT: ${{ runner.temp }}/workspace-playground-e2e
 
   full-app-e2e:
     name: Full App E2E

--- a/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
+++ b/apps/workspace-playground/e2e/agent-host-golden-route.spec.ts
@@ -61,10 +61,25 @@ async function expectHorizontalSplit(
 }
 
 test.describe("addressed Agent Host browser wire", () => {
+  test("seeds committed fixtures into the configured workspace root", async ({ request }) => {
+    const metaResponse = await request.get("/api/v1/workspace/meta")
+    expect(metaResponse.status()).toBe(200)
+    const { workspaceId } = await metaResponse.json() as { workspaceId: string }
+
+    const fixtureResponse = await request.get("/api/v1/files?path=README.md", {
+      headers: { "x-boring-workspace-id": workspaceId },
+    })
+    expect(fixtureResponse.status(), await fixtureResponse.text()).toBe(200)
+    await expect(fixtureResponse.json()).resolves.toMatchObject({
+      content: expect.stringContaining("# Workspace Playground"),
+    })
+  })
+
   test("marks a chat read-only after a structured runtime-scope mutation failure", async ({ page }) => {
-    test.setTimeout(90_000)
+    test.setTimeout(180_000)
 
     await page.goto("/?fresh=1")
+    await expect(page.locator('aside[aria-label="App navigation"]')).toBeVisible({ timeout: 120_000 })
     await page.getByRole("button", { name: "New chat with Alpha", exact: true }).click()
     const chat = page.locator('[data-boring-agent-part="chat"][data-agent-type-id="alpha"]').last()
     await expect(chat).toHaveAttribute("data-pi-chat-session-id", /^local-/, { timeout: 15_000 })


### PR DESCRIPTION
## Summary

Runs the Wave 1 workspace-playground acceptance suite against a genuinely empty CI workspace root and verifies that committed fixtures are seeded before the golden route continues.

## Issue / Slice

- Bead `wt-391-forward-0jpy.26`
- Stacked on PR #1008 until `integration/wave-1-final` reaches `main`

## What Changed

- CI supplies a clean runner-temp `BORING_AGENT_WORKSPACE_ROOT` to the existing root `pnpm e2e` gate.
- Golden-route E2E verifies committed `README.md` fixture content through the workspace API.
- Cold Vite readiness receives an evidenced 120-second visibility bound inside a 180-second test budget.

## Proof

- `pnpm install --frozen-lockfile` — passed.
- `pnpm --filter workspace-playground run build:deps` — passed.
- Baseline empty-root run before timeout adjustment: **7 passed, 1 failed** when the first cold-start test exhausted 90 seconds waiting for the Agent navigation.
- Final empty-root command:
  `BORING_AGENT_WORKSPACE_ROOT=<fresh mktemp dir> CI=true pnpm --filter workspace-playground exec playwright test --config playwright.config.ts apps/workspace-playground/e2e/agent-host-golden-route.spec.ts apps/workspace-playground/e2e/native-session-regressions.spec.ts`
  — **9/9 passed in 3.1 minutes**.
- Seeded fixture SHA-256 exactly matched committed fixture: `d64fb96b28907d8a7c6096ef4f2c4f13d9a374f2f9593f2974d7d36bea1456f2`.
- `pnpm --filter workspace-playground run typecheck` — passed.
- `pnpm --filter workspace-playground run test` — 4 files / 8 tests passed.
- `pnpm check:action-pins` — passed.

## Review

- Standards/spec static review: clean on env propagation, fixture proof, intended suite wiring, and scope.
- One reviewer questioned the timeout without seeing runtime evidence; the exact pre-fix 90-second failure and post-fix empty-root 9/9 pass are recorded above.
- Reviewed SHA: `5600946708dc6e2bfa02a793430197ea654dc381`

## Risk / Rollback

Low-risk CI/test-only change. Revert this commit to restore the prior mutable-root behavior and timeout.

## Next

CI, then merge into `integration/wave-1-final`; retarget to `main` after PR #1008 if needed.
