### PR TITLE
#1030 Refine chat transcript and tool transparency

### DIFF
--- a/apps/agent-playground/src/Showcase.tsx
+++ b/apps/agent-playground/src/Showcase.tsx
@@ -38,20 +38,6 @@ function mockTool(opts: {
 
 const settledGroup = [
   mockTool({
-    toolName: 'bash',
-    state: 'output-available',
-    id: 'mock-bash-list',
-    input: { command: 'ls -la packages/', description: '' },
-    output: { stdout: 'drwxr-xr-x  agent\ndrwxr-xr-x  ui\ndrwxr-xr-x  workspace\n' },
-  }),
-  mockTool({
-    toolName: 'bash',
-    state: 'output-available',
-    id: 'mock-bash-version',
-    input: { command: 'cat packages/agent/package.json | grep version', description: '' },
-    output: { stdout: '  "version": "0.1.0"' },
-  }),
-  mockTool({
     toolName: 'read',
     state: 'output-available',
     id: 'mock-read-chat-panel',
@@ -59,15 +45,18 @@ const settledGroup = [
     output: { text: '"use client"\n\nimport { useCallback } from "react"\n// ... 1493 lines' },
   }),
   mockTool({
-    toolName: 'edit',
+    toolName: 'grep',
     state: 'output-available',
-    id: 'mock-edit-renderers',
-    input: {
-      path: 'packages/agent/src/front/toolRenderers.tsx',
-      oldString: "  <h4 className=\"font-medium text-muted-foreground text-xs uppercase tracking-wide\">\n    Parameters\n  </h4>",
-      newString: '',
-    },
-    output: { text: 'OK' },
+    id: 'mock-grep-tool-groups',
+    input: { pattern: 'ToolCallGroup', path: 'packages/agent/src/front' },
+    output: { text: 'chat/components/PiTimelineMessage.tsx: ToolCallGroup\nprimitives/tool-call-group.tsx: ToolCallGroup' },
+  }),
+  mockTool({
+    toolName: 'find',
+    state: 'output-available',
+    id: 'mock-find-tests',
+    input: { pattern: '*.test.tsx', path: 'packages/agent/src/front' },
+    output: { text: 'primitives/__tests__/message.test.tsx\nchat/components/__tests__/PiTimelineMessage.test.tsx' },
   }),
 ]
 
@@ -195,13 +184,13 @@ function ShowcaseMessageSession() {
           <div className="mx-auto flex max-w-3xl flex-col gap-6">
             <Message from="system" data-boring-agent-message-id="showcase-system" data-boring-agent-message-status="done">
               <MessageContent className="rounded-lg border border-border/60 bg-background/60 px-3 py-2 text-muted-foreground">
-                <MessageResponse>Session loaded from the static playground fixture.</MessageResponse>
+                <MessageResponse className="boring-agent-markdown">Session loaded from the static playground fixture.</MessageResponse>
               </MessageContent>
             </Message>
 
             <Message from="user" data-boring-agent-message-id="showcase-user" data-boring-agent-message-status="done">
               <MessageContent>
-                <MessageResponse>Can you inspect `README.md`, explain the issue, and update the fixture?</MessageResponse>
+                <MessageResponse className="boring-agent-markdown">Can you inspect `README.md`, explain the issue, and update the fixture?</MessageResponse>
               </MessageContent>
             </Message>
 
@@ -232,7 +221,7 @@ function ShowcaseMessageSession() {
                   tools={settledGroup.slice(0, 2).map((part, index) => ({ part, key: `settled-${index}` }))}
                   mergedToolRenderers={renderers}
                 />
-                <MessageResponse>
+                <MessageResponse className="boring-agent-markdown">
                   Done. Inline filenames like `README.md` now render as quiet chips, and fenced blocks still use the code block primitive.
 
                   ```ts
@@ -264,7 +253,7 @@ function ShowcaseMessageSession() {
                   tools={abortedGroup.map((part, index) => ({ part, key: `aborted-${index}` }))}
                   mergedToolRenderers={renderers}
                 />
-                <MessageResponse>
+                <MessageResponse className="boring-agent-markdown">
                   The active turn was stopped. The tool state stays stopped instead of being reported as a used command.
                 </MessageResponse>
               </MessageContent>
@@ -290,7 +279,7 @@ function ShowcaseMessageSession() {
 
 export function Showcase() {
   return (
-    <div style={{ minHeight: '100vh' }}>
+    <div data-boring-agent style={{ minHeight: '100vh' }}>
       <div className="mx-auto max-w-5xl px-6 py-10 text-foreground">
         {/* header */}
         <div className="mb-8">
@@ -310,7 +299,7 @@ export function Showcase() {
             />
 
             <GroupDemo
-              label="Running — auto-expanded + shimmer title"
+              label="Running — collapsed live status"
               parts={runningGroup}
             />
 

--- a/packages/agent/e2e/pi-native-baseline-message-flow.spec.ts
+++ b/packages/agent/e2e/pi-native-baseline-message-flow.spec.ts
@@ -599,7 +599,7 @@ test.describe("Pi-native baseline message flow", () => {
     });
     await expect(failedToolTrigger).toBeVisible();
     const failedToolTriggerClass = await failedToolTrigger.getAttribute("class");
-    expect(failedToolTriggerClass).toContain("text-muted-foreground/70");
+    expect(failedToolTriggerClass).toContain("text-muted-foreground");
     expect(failedToolTriggerClass).not.toContain("border-destructive");
     expect(failedToolTriggerClass).not.toContain("text-destructive");
     const failedToolDot = page.locator('[data-boring-agent-tool-state="failed"] [data-boring-agent-part="tool-group-state-dot"]');

--- a/packages/agent/src/front/__tests__/toolRenderers.test.tsx
+++ b/packages/agent/src/front/__tests__/toolRenderers.test.tsx
@@ -299,6 +299,23 @@ describe("shadcn exec_ui renderer", () => {
   })
 })
 
+describe("edit tool transparency", () => {
+  test("opens completed edits by default and renders the shared diff view", () => {
+    const part = makePart({
+      toolName: "edit",
+      input: { path: "README.md", edits: [{ oldText: "before", newText: "after" }] },
+      output: { text: "Successfully replaced 1 block" },
+    })
+
+    render(<>{shadcnDefaultToolRenderers.edit!(part)}</>)
+
+    expect(screen.getByText("before")).toBeTruthy()
+    expect(screen.getByText("after")).toBeTruthy()
+    expect(screen.queryByText("Successfully replaced 1 block")).toBeNull()
+    expect(screen.getByRole("button", { name: /edit.*README\.md.*Completed/ }).getAttribute("data-state")).toBe("open")
+  })
+})
+
 describe("write tool renderer copy action", () => {
   const originalExecCommand = document.execCommand
 
@@ -320,7 +337,7 @@ describe("write tool renderer copy action", () => {
 
     render(<>{shadcnDefaultToolRenderers.write!(part)}</>)
 
-    fireEvent.click(screen.getByRole("button", { name: /writesrc\/example\.tsCompleted/ }))
+    expect(screen.getByRole("button", { name: /writesrc\/example\.tsCompleted/ }).getAttribute("data-state")).toBe("open")
     fireEvent.click(screen.getByRole("button", { name: "Copy" }))
 
     await waitFor(() => {

--- a/packages/agent/src/front/bareToolRenderers/DiffView.tsx
+++ b/packages/agent/src/front/bareToolRenderers/DiffView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import { createPatch } from 'diff'
 import { Button } from '@hachej/boring-ui-kit'
 import { cn } from '../lib'
@@ -10,6 +10,7 @@ export interface DiffViewProps {
   newString: string
   path: string
   replaceAll?: boolean
+  actions?: ReactNode
 }
 
 interface DiffLine {
@@ -40,7 +41,7 @@ const lineClass: Record<DiffLine['type'], string> = {
 
 const prefixMap: Record<DiffLine['type'], string> = { '+': '+', '-': '-', ' ': ' ' }
 
-export function DiffView({ oldString, newString, path, replaceAll }: DiffViewProps) {
+export function DiffView({ oldString, newString, path, replaceAll, actions }: DiffViewProps) {
   const [expanded, setExpanded] = useState(false)
 
   if (oldString === newString) {
@@ -58,8 +59,9 @@ export function DiffView({ oldString, newString, path, replaceAll }: DiffViewPro
 
   return (
     <div data-testid="diff-view">
-      <div className="px-3 py-1.5 font-[family-name:var(--boring-agent-font-mono,monospace)] text-xs opacity-70">
-        {path}{replaceAll ? ' (replace all)' : ''}
+      <div className="flex min-h-7 items-center justify-between gap-2 px-2 py-0.5 font-[family-name:var(--boring-agent-font-mono,monospace)] text-xs opacity-70">
+        <span className="min-w-0 truncate">{path}{replaceAll ? ' (replace all)' : ''}</span>
+        {actions ? <span className="flex shrink-0 items-center gap-0.5">{actions}</span> : null}
       </div>
       <pre className="m-0 overflow-auto py-2 font-[family-name:var(--boring-agent-font-mono,monospace)] text-[0.8125rem] leading-relaxed">
         {visible.map((line, i) => (

--- a/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
+++ b/packages/agent/src/front/chat/components/PiTimelineMessage.tsx
@@ -96,20 +96,8 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
       data-boring-agent-message-id={message.id}
       data-boring-agent-message-role={role}
       data-boring-agent-message-status={message.status}
-      className="!max-w-full !gap-1.5"
     >
-      <MessageContent
-        className={cn(
-          '!overflow-visible text-[13px] leading-relaxed text-foreground',
-          role === 'user'
-            ? cn(
-                '!ml-auto !max-w-[80%] !rounded-[var(--radius-lg)]',
-                '!px-4 !py-2.5',
-                '!bg-secondary !text-secondary-foreground',
-              )
-            : '!w-full !bg-transparent !p-0',
-        )}
-      >
+      <MessageContent>
         {fileParts.length > 0 ? (
           <Attachments
             variant={role === 'user' ? 'inline' : 'list'}
@@ -193,20 +181,7 @@ export function PiTimelineMessage({ message, isLast, isStreaming, showThoughts, 
                 <MessageResponse
                   key={`${mentionSignature || 'no-message-mentions'}:${mentionsEnabled ? 'enabled' : 'static'}`}
                   components={mentionMarkdownComponents}
-                  className={cn(
-                    'max-w-none',
-                    'prose prose-invert prose-neutral',
-                    'prose-p:my-3 prose-p:leading-[1.7] prose-p:text-[13px]',
-                    'prose-headings:mt-5 prose-headings:mb-2 prose-headings:font-semibold prose-headings:tracking-[-0.01em]',
-                    'prose-ul:my-3 prose-ul:pl-6 prose-ol:my-3 prose-ol:pl-6',
-                    'prose-li:my-1.5 prose-li:leading-[1.7] prose-li:pl-1 prose-li:marker:text-muted-foreground/70',
-                    'prose-strong:font-semibold prose-strong:text-foreground',
-                    'prose-em:text-foreground/90',
-                    'prose-a:text-[color:var(--accent)] prose-a:underline-offset-4 hover:prose-a:underline',
-                    'prose-code:before:content-none prose-code:after:content-none',
-                    'prose-pre:my-0 prose-pre:rounded-none prose-pre:border-0',
-                    'prose-pre:bg-transparent prose-pre:p-0',
-                  )}
+                  className="boring-agent-markdown max-w-none"
                 >
                   {text}
                 </MessageResponse>

--- a/packages/agent/src/front/chat/components/chat-transcript.css
+++ b/packages/agent/src/front/chat/components/chat-transcript.css
@@ -1,0 +1,134 @@
+[data-boring-agent] .boring-agent-markdown {
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
+}
+
+[data-boring-agent] .boring-agent-markdown p,
+[data-boring-agent] .boring-agent-markdown ol,
+[data-boring-agent] .boring-agent-markdown ul {
+  margin-block: 0.75rem;
+}
+
+[data-boring-agent] .boring-agent-markdown h1,
+[data-boring-agent] .boring-agent-markdown h2,
+[data-boring-agent] .boring-agent-markdown h3 {
+  color: var(--foreground);
+  font-weight: 600;
+  letter-spacing: -0.015em;
+}
+
+[data-boring-agent] .boring-agent-markdown h1 {
+  margin-block: 1.5rem 0.5rem;
+  font-size: 1.25rem;
+  line-height: 1.5rem;
+}
+
+[data-boring-agent] .boring-agent-markdown h2 {
+  margin-block: 1.5rem 0.5rem;
+  font-size: 1rem;
+  line-height: 1.5rem;
+}
+
+[data-boring-agent] .boring-agent-markdown h3 {
+  margin-block: 1rem 0.5rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+}
+
+[data-boring-agent] .boring-agent-markdown ol,
+[data-boring-agent] .boring-agent-markdown ul {
+  padding-inline-start: 1.5rem;
+  list-style-position: outside;
+}
+
+[data-boring-agent] .boring-agent-markdown ol {
+  list-style-type: decimal;
+}
+
+[data-boring-agent] .boring-agent-markdown ul {
+  list-style-type: disc;
+}
+
+[data-boring-agent] .boring-agent-markdown li {
+  padding-inline-start: 0.25rem;
+  font: inherit;
+}
+
+[data-boring-agent] .boring-agent-markdown li + li {
+  margin-top: 0.25rem;
+}
+
+[data-boring-agent] .boring-agent-markdown li::marker {
+  color: var(--muted-foreground);
+}
+
+[data-boring-agent] .boring-agent-markdown strong {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+[data-boring-agent] .boring-agent-markdown a {
+  color: var(--accent);
+  text-underline-offset: 0.25rem;
+}
+
+[data-boring-agent] .boring-agent-markdown a:hover {
+  text-decoration-line: underline;
+}
+
+[data-boring-agent] .boring-agent-markdown blockquote {
+  margin-block: 1rem;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklab, var(--muted) 45%, transparent);
+  color: var(--muted-foreground);
+  font-style: normal;
+}
+
+[data-boring-agent] .boring-agent-markdown blockquote p {
+  margin-block: 0;
+}
+
+[data-boring-agent] .boring-agent-markdown table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: inherit;
+  font-variant-numeric: tabular-nums;
+  text-align: left;
+}
+
+[data-boring-agent] .boring-agent-markdown thead {
+  background: color-mix(in oklab, var(--muted) 45%, transparent);
+}
+
+[data-boring-agent] .boring-agent-markdown th,
+[data-boring-agent] .boring-agent-markdown td {
+  padding: 0.5rem 1rem;
+  border-bottom: 1px solid var(--border);
+}
+
+[data-boring-agent] .boring-agent-markdown th {
+  font-weight: 600;
+}
+
+[data-boring-agent] .boring-agent-markdown tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+[data-boring-agent] .boring-agent-markdown pre {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+}
+
+[data-boring-agent] .boring-agent-markdown > *:first-child {
+  margin-top: 0;
+}
+
+[data-boring-agent] .boring-agent-markdown > *:last-child {
+  margin-bottom: 0;
+}

--- a/packages/agent/src/front/primitives/message.tsx
+++ b/packages/agent/src/front/primitives/message.tsx
@@ -42,7 +42,7 @@ export const Message = ({ className, from, ...props }: MessageProps) => (
   <div
     data-boring-agent-message-role={from}
     className={cn(
-      "group flex w-full max-w-[95%] flex-col gap-2",
+      "group flex w-full max-w-full flex-col gap-1.5",
       from === "user" ? "is-user ml-auto justify-end" : "is-assistant",
       className
     )}
@@ -59,9 +59,9 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-hidden text-sm",
-      "group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground",
-      "group-[.is-assistant]:text-foreground",
+      "is-user:dark flex w-fit min-w-0 max-w-full flex-col gap-2 overflow-visible text-[13px] leading-5",
+      "group-[.is-user]:ml-auto group-[.is-user]:max-w-[80%] group-[.is-user]:rounded-[var(--radius-lg)] group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-2.5 group-[.is-user]:text-foreground",
+      "group-[.is-assistant]:w-full group-[.is-assistant]:max-w-[40.5rem] group-[.is-assistant]:bg-transparent group-[.is-assistant]:p-0 group-[.is-assistant]:text-foreground",
       className
     )}
     {...props}

--- a/packages/agent/src/front/primitives/tool-call-group.tsx
+++ b/packages/agent/src/front/primitives/tool-call-group.tsx
@@ -11,7 +11,6 @@ import {
   type ToolRendererOverrides,
 } from '../bareToolRenderers'
 import { cn } from '../lib'
-import { Shimmer } from './shimmer'
 import { getWorkspaceNotReadyStatus } from '../workspaceReadinessStatus'
 import {
   RUNNING_TOOL_GROUP_VISUAL_STATE,
@@ -21,16 +20,6 @@ import {
 export { RUNNING_TOOL_GROUP_VISUAL_STATE, TOOL_GROUP_VISUAL_STATES, type ToolGroupVisualState } from './tool-call-group-state'
 
 export type GroupedToolEntry = { part: ToolRenderablePart; key: string }
-
-function isSettledState(state: ToolPart['state']): boolean {
-  return (
-    state === 'output-available' ||
-    state === 'output-error' ||
-    state === 'output-denied' ||
-    state === 'approval-responded' ||
-    state === 'aborted'
-  )
-}
 
 function isInputRunningState(state: ToolPart['state']): boolean {
   return state === 'input-streaming' || state === 'input-available'
@@ -108,8 +97,6 @@ export const ToolCallGroup = memo(({ tools, mergedToolRenderers }: ToolCallGroup
     })
     .filter((entry): entry is { part: ToolPart; key: string } => Boolean(entry)), [tools])
 
-  const isSettled = toolParts.every(({ part }) => isSettledState(part.state))
-
   const workspaceNotReady = toolParts.map(({ part }) => getWorkspaceNotReadyStatus(part.output)).find(Boolean)
 
   const hasError = toolParts.some(({ part }) => part.state === 'output-error') && !workspaceNotReady
@@ -161,48 +148,40 @@ export const ToolCallGroup = memo(({ tools, mergedToolRenderers }: ToolCallGroup
       <CollapsibleTrigger
         aria-label={`Tool calls: ${title}`}
         className={cn(
-          'group/trigger flex w-fit items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] font-medium transition-colors motion-reduce:transition-none',
-          'border border-border/40 bg-card/40 text-muted-foreground/70',
-          'hover:border-border/70 hover:bg-card/70 hover:text-muted-foreground',
+          'group/trigger flex min-h-10 w-full items-center gap-2 rounded-[var(--radius-md)] px-2 py-1 text-[13px] font-normal',
+          'border border-border/60 bg-muted/45 text-muted-foreground',
+          'transition-colors hover:bg-muted/70 hover:text-foreground motion-reduce:transition-none',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
           TOOL_GROUP_VISUAL_PRESENTATION[visualState].triggerClassName,
         )}
       >
         {/* State-coded dot: green settled, amber pending, red failed. */}
-        <span
-          data-boring-agent-part="tool-group-state-dot"
-          className={cn(
-            'size-1.5 shrink-0 rounded-full',
-            TOOL_GROUP_VISUAL_PRESENTATION[visualState].dotClassName,
-          )}
-        />
-        <ChevronDownIcon
-          className={cn(
-            'size-3 shrink-0 transition-transform duration-150',
-            isOpen && 'rotate-180',
-          )}
-        />
-        {workspaceNotReady ? (
-          <span data-boring-agent-part="tool-group-title">{workspaceNotReady.message}</span>
-        ) : !isSettled ? (
-          <span data-boring-agent-part="tool-group-title">
-            <Shimmer as="span" duration={1.5}>
-              {title}
-            </Shimmer>
-          </span>
-        ) : (
-          <span data-boring-agent-part="tool-group-title">{title}</span>
-        )}
+        <span className="flex size-4 shrink-0 items-center justify-center" aria-hidden="true">
+          <span
+            data-boring-agent-part="tool-group-state-dot"
+            className={cn(
+              'size-1.5 rounded-full',
+              TOOL_GROUP_VISUAL_PRESENTATION[visualState].dotClassName,
+            )}
+          />
+        </span>
+        <span data-boring-agent-part="tool-group-title">
+          {workspaceNotReady ? workspaceNotReady.message : title}
+        </span>
         {elapsedLabel ? (
-          <span className="ml-1 shrink-0 tabular-nums text-[10px] text-muted-foreground/50">
+          <span className="ml-1 shrink-0 tabular-nums text-[12px] text-muted-foreground/70">
             {elapsedLabel}
           </span>
         ) : null}
-        <span className={cn(
-          'ml-1 shrink-0 rounded-sm border border-border/40 px-1 tabular-nums',
-          'text-[10px] text-muted-foreground/50',
-        )}>
+        <span className="ml-1 shrink-0 tabular-nums text-[12px] text-muted-foreground/70">
           {toolParts.length}
         </span>
+        <ChevronDownIcon
+          className={cn(
+            'ml-auto size-4 shrink-0 transition-transform duration-150 motion-reduce:transition-none',
+            isOpen && 'rotate-180',
+          )}
+        />
       </CollapsibleTrigger>
 
       <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-[boring-collapse-close_200ms_ease] data-[state=open]:animate-[boring-collapse-open_200ms_ease]">

--- a/packages/agent/src/front/styles/globals.css
+++ b/packages/agent/src/front/styles/globals.css
@@ -19,6 +19,7 @@
 
 /* @hachej/boring-ui-kit styles imported as a regular package. */
 @import "@hachej/boring-ui-kit/styles.css";
+@import "../chat/components/chat-transcript.css";
 
 @source "../**/*.{ts,tsx}";
 

--- a/packages/agent/src/front/toolRenderers.tsx
+++ b/packages/agent/src/front/toolRenderers.tsx
@@ -9,6 +9,7 @@
  */
 import type { KeyboardEvent as ReactKeyboardEvent, MouseEvent as ReactMouseEvent, ReactNode } from 'react'
 import {
+  DiffView,
   langFromPath,
   resolveToolRendererForPart,
   type ToolPart,
@@ -17,20 +18,11 @@ import {
 } from './bareToolRenderers'
 import { Tool, ToolContent, ToolHeader, ToolInput, ToolOutput, getStatusBadge } from './primitives/tool'
 import { CollapsibleTrigger } from '@hachej/boring-ui-kit'
-import { ChevronDownIcon, ExternalLinkIcon, FileDiffIcon, FilePlus2Icon, FileTextIcon, SearchIcon, SquareTerminalIcon, ZapIcon } from 'lucide-react'
+import { ChevronDownIcon, CopyIcon, DownloadIcon, ExternalLinkIcon, FileDiffIcon, FilePlus2Icon, FileTextIcon, SearchIcon, SquareTerminalIcon, ZapIcon } from 'lucide-react'
 import { CodeBlock } from './primitives/code-block'
-import { useOpenArtifact } from './ArtifactOpenContext'
-import {
-  Artifact,
-  ArtifactAction,
-  ArtifactActions,
-  ArtifactContent,
-  ArtifactDescription,
-  ArtifactHeader,
-  ArtifactTitle,
-} from './primitives/artifact'
-import { CopyIcon, DownloadIcon } from 'lucide-react'
+import { ArtifactAction } from './primitives/artifact'
 import { copyTextToClipboard } from './clipboard'
+import { useOpenArtifact } from './ArtifactOpenContext'
 import { cn } from './lib'
 import { ErrorCode } from '../shared/error-codes'
 import { getRuntimeReadinessStatus } from './runtimeReadinessStatus'
@@ -243,10 +235,6 @@ function renderRead(part: ToolPart): ReactNode {
 }
 
 // ---- write ----
-//
-// Uses the canonical <Artifact> primitive to present the written file as a
-// workspace artifact. Saved content is shown in a titled card with download
-// + copy actions, matching the Vercel artifact pattern.
 
 function renderWrite(part: ToolPart): ReactNode {
   const readiness = renderReadinessBlock(part)
@@ -255,60 +243,47 @@ function renderWrite(part: ToolPart): ReactNode {
   const path = typeof input.path === 'string' ? input.path : ''
   const filesystem = typeof input.filesystem === 'string' ? input.filesystem : undefined
   const content = typeof input.content === 'string' ? input.content : ''
-  const bytes = content.length
-  const lang = langFromPath(path)
 
   return (
-    <Tool>
-      <ToolHeader icon={<FilePlus2Icon className="size-4 text-muted-foreground" />} title={pathTitle('write', path, filesystem)} {...toHeaderProps(part)} />
-      <ToolContent>
-        {/* Flat surface: the outer <Tool> already owns a bordered card, so
-         * the nested <Artifact> drops its own border/shadow to keep stacked
-         * depth at 1 — no "box-in-a-box" feel. */}
-        <Artifact className="rounded-none border-0 bg-transparent shadow-none">
-          <ArtifactHeader className="border-0 px-0 pt-0 pb-2">
-            <div>
-              <ArtifactTitle>{path || 'untitled'}</ArtifactTitle>
-              <ArtifactDescription>
-                {bytes.toLocaleString()} {bytes === 1 ? 'byte' : 'bytes'}
-                {lang ? ` · ${lang}` : ''}
-              </ArtifactDescription>
-            </div>
-            <ArtifactActions>
-              <ArtifactAction
-                icon={CopyIcon}
-                tooltip="Copy contents"
-                label="Copy"
-                onClick={() => {
-                  void copyTextToClipboard(content)
-                }}
-              />
-              <ArtifactAction
-                icon={DownloadIcon}
-                tooltip="Download file"
-                label="Download"
-                onClick={() => {
-                  try {
-                    const blob = new Blob([content], { type: 'text/plain' })
-                    const url = URL.createObjectURL(blob)
-                    const a = document.createElement('a')
-                    a.href = url
-                    a.download = path.split('/').pop() || 'artifact.txt'
-                    document.body.appendChild(a)
-                    a.click()
-                    a.remove()
-                    URL.revokeObjectURL(url)
-                  } catch { /* noop */ }
-                }}
-              />
-            </ArtifactActions>
-          </ArtifactHeader>
-          {content && (
-            <ArtifactContent className="p-0">
-              <CodeBlock code={content} language={lang ?? 'text'} showLineNumbers />
-            </ArtifactContent>
+    <Tool defaultOpen={part.state === 'output-available'}>
+      <ToolHeader className="p-2" icon={<FilePlus2Icon className="size-4 shrink-0 text-muted-foreground" />} title={pathTitle('write', path, filesystem)} {...toHeaderProps(part)} />
+      <ToolContent className="p-1.5">
+        <div className="max-h-80 overflow-auto overscroll-contain rounded-sm">
+          {content ? (
+            <DiffView
+              oldString=""
+              newString={content}
+              path={path}
+              actions={(
+                <>
+                  <ArtifactAction className="size-6" icon={CopyIcon} tooltip="Copy contents" label="Copy" onClick={() => { void copyTextToClipboard(content) }} />
+                  <ArtifactAction
+                    className="size-6"
+                    icon={DownloadIcon}
+                    tooltip="Download file"
+                    label="Download"
+                    onClick={() => {
+                      const blob = new Blob([content], { type: 'text/plain' })
+                      const url = URL.createObjectURL(blob)
+                      const anchor = document.createElement('a')
+                      anchor.href = url
+                      anchor.download = path.split('/').pop() || 'artifact.txt'
+                      document.body.appendChild(anchor)
+                      anchor.click()
+                      anchor.remove()
+                      URL.revokeObjectURL(url)
+                    }}
+                  />
+                </>
+              )}
+            />
+          ) : (
+            <p className="px-2 py-1 text-[12px] text-muted-foreground">No file content was included with this tool call.</p>
           )}
-        </Artifact>
+        </div>
+        {part.errorText || part.state === 'output-error' || part.state === 'output-denied' ? (
+          <ToolOutput output={part.output} errorText={part.errorText} />
+        ) : null}
       </ToolContent>
     </Tool>
   )
@@ -322,33 +297,47 @@ function renderEdit(part: ToolPart): ReactNode {
   const input = asRecord(part.input)
   const path = typeof input.path === 'string' ? input.path : ''
   const filesystem = typeof input.filesystem === 'string' ? input.filesystem : undefined
-  const oldString = typeof input.oldString === 'string' ? input.oldString : ''
-  const newString = typeof input.newString === 'string' ? input.newString : ''
+  const edits = Array.isArray(input.edits)
+    ? input.edits.flatMap((value) => {
+        const edit = asRecord(value)
+        const oldText = typeof edit.oldText === 'string' ? edit.oldText : ''
+        const newText = typeof edit.newText === 'string' ? edit.newText : ''
+        return oldText || newText ? [{ oldText, newText }] : []
+      })
+    : []
+  const legacyOldText = typeof input.oldString === 'string'
+    ? input.oldString
+    : typeof input.oldText === 'string' ? input.oldText : ''
+  const legacyNewText = typeof input.newString === 'string'
+    ? input.newString
+    : typeof input.newText === 'string' ? input.newText : ''
+  const visibleEdits = edits.length > 0
+    ? edits
+    : legacyOldText || legacyNewText
+      ? [{ oldText: legacyOldText, newText: legacyNewText }]
+      : []
 
   return (
-    <Tool>
-      <ToolHeader icon={<FileDiffIcon className="size-4 text-muted-foreground" />} title={pathTitle('edit', path, filesystem)} {...toHeaderProps(part)} />
-      <ToolContent>
-        <section className="space-y-2">
-          <h4 className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
-            Diff
-          </h4>
-          <div className="overflow-hidden rounded-sm border border-input/60 bg-muted/30 font-mono text-[13px] leading-relaxed">
-            {oldString && (
-              <div className="grid grid-cols-[auto_1fr] gap-2 border-b border-input/40 bg-destructive/5 px-3 py-2">
-                <span className="select-none text-destructive/70">-</span>
-                <span className={cn('whitespace-pre-wrap break-all text-destructive/90')}>{oldString}</span>
-              </div>
-            )}
-            {newString && (
-              <div className="grid grid-cols-[auto_1fr] gap-2 bg-accent/5 px-3 py-2">
-                <span className="select-none text-accent/80">+</span>
-                <span className="whitespace-pre-wrap break-all text-accent">{newString}</span>
-              </div>
-            )}
-          </div>
-        </section>
-        <ToolOutput output={part.output} errorText={part.errorText} />
+    <Tool defaultOpen={part.state === 'output-available'}>
+      <ToolHeader className="p-2" icon={<FileDiffIcon className="size-4 shrink-0 text-muted-foreground" />} title={pathTitle('edit', path, filesystem)} {...toHeaderProps(part)} />
+      <ToolContent className="space-y-2 p-2">
+        <div className="max-h-80 space-y-2 overflow-auto overscroll-contain rounded-sm">
+          {visibleEdits.length > 0 ? visibleEdits.map((edit, index) => (
+            <div key={`${index}:${edit.oldText.length}:${edit.newText.length}`}>
+              {visibleEdits.length > 1 ? (
+                <div className="mb-1 px-1 text-[11px] text-muted-foreground">Change {index + 1}</div>
+              ) : null}
+              <DiffView oldString={edit.oldText} newString={edit.newText} path={path} />
+            </div>
+          )) : (
+            <p className="px-2 py-1 text-[12px] text-muted-foreground">
+              Diff details were not included with this tool call.
+            </p>
+          )}
+        </div>
+        {part.errorText || part.state === 'output-error' || part.state === 'output-denied' ? (
+          <ToolOutput output={part.output} errorText={part.errorText} />
+        ) : null}
       </ToolContent>
     </Tool>
   )


### PR DESCRIPTION
## Summary

Isolates the approved chat-surface work from the broad Claude prototype while preserving the existing application palette.

## What changed

- tighter transcript reading measure and markdown hierarchy
- discreet original reasoning treatment retained
- grouping limited to repetitive read/search tools
- bash/write/edit remain standalone and transparent
- completed edits and writes open their diffs by default
- successful result JSON hidden when status + diff already communicate success
- compact copy/download actions in the write diff header
- representative playground showcase updated

## Explicit exclusions

- no app-wide palette/foundation changes
- no composer, navigation, session-list, or data-plugin redesign

## Proof

- `pnpm --filter @hachej/boring-agent exec vitest run src/front/__tests__/toolRenderers.test.tsx src/front/chat/components/__tests__/PiTimelineMessage.test.tsx src/front/primitives/__tests__/tool-call-group.test.tsx src/front/primitives/__tests__/message.test.tsx src/front/__tests__/agentPlaygroundShowcase.test.tsx` — 43 passed
- `pnpm --filter @hachej/boring-agent typecheck` — passed
- `pnpm --filter agent-playground typecheck` — passed
- `pnpm --filter @hachej/boring-agent build:dev` — passed
- owner visually iterated and explicitly approved merge through the live playground at `http://100.68.199.114:5203/`

## Review

Independent review found and we fixed two playground honesty issues: transcript scoping and stale running-group copy. The dedicated registered UI-review spec and HTML comparison bundle were not completed before the owner's explicit merge instruction; residual risk is limited to missing automated screenshot baselines for this new surface.

## Risk / rollback

Presentation-only agent frontend changes. Revert this PR to restore prior transcript and tool rendering.

Closes #1030
