### PR TITLE
fix(release): stage live transcription manifest

### DIFF
--- a/scripts/check-release-staging.mjs
+++ b/scripts/check-release-staging.mjs
@@ -19,6 +19,7 @@ const allowed = new Set([
   "plugins/diagram/package.json",
   "plugins/tasks/package.json",
   "plugins/boring-automation/package.json",
+  "plugins/live-transcription/package.json",
   "plugins/data-explorer/package.json",
   "plugins/data-catalog/package.json",
   "plugins/generated-pane/package.json",

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -64,6 +64,7 @@ release_files=(
   plugins/diagram/package.json
   plugins/tasks/package.json
   plugins/boring-automation/package.json
+  plugins/live-transcription/package.json
   plugins/data-explorer/package.json
   plugins/data-catalog/package.json
   plugins/generated-pane/package.json


### PR DESCRIPTION
Adds the newly publishable live-transcription package manifest to both release staging allowlists. Without this, `scripts/version.mjs` modifies the manifest but `cut-release.sh` leaves it unstaged and aborts on the unexpected dirty file.\n\nProof: `bash -n scripts/cut-release.sh`; `node scripts/check-release-staging.mjs`; diff check. The publish-manifest audit requires built package artifacts and will run in CI.