### PR TITLE
#1036 Improve terminal chat error recovery

### DIFF
--- a/apps/agent-playground/src/front/App.tsx
+++ b/apps/agent-playground/src/front/App.tsx
@@ -36,7 +36,9 @@ export function App() {
   const [thinkingControl, setThinkingControl] = useState(true)
   const [theme, setTheme] = useState<Theme>(() => readStoredTheme())
   const reloadAgentPlugins = useStandalonePluginReload()
-  const showSessionsParam = typeof window !== 'undefined' ? new URLSearchParams(window.location.search).get('showSessions') : null
+  const searchParams = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null
+  const showSessionsParam = searchParams?.get('showSessions') ?? null
+  const errorShowcase = searchParams?.get('chatError') === '1'
   const [showSessions, setShowSessions] = useState(showSessionsParam === '1')
 
   useEffect(() => {
@@ -89,6 +91,7 @@ export function App() {
         ) : (
           <div className="agent-playground-chat-pane h-full min-w-0 border-r border-border/60 bg-background">
             <PiChatPanel
+              apiBaseUrl={errorShowcase ? '/chat-error-showcase' : undefined}
               chrome={chrome}
               thinkingControl={thinkingControl}
               debug={debug}

--- a/packages/agent/src/front/chat/components/PiConversationSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiConversationSurface.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../primitives/conversation'
 import { RuntimeNoticeMessages, type PanelNotice } from './ChatNotices'
 import { PiTimelineMessage } from './PiTimelineMessage'
+import { isTerminalChatErrorNotice } from './RuntimeNotices'
 import type { MessageMention, MessageMentionCatalog } from './MessageMentions'
 
 // Heavy sessions (tool-heavy runs reach thousands of messages) must not mount
@@ -90,6 +91,10 @@ export function PiConversationSurface({
   const loadOlder = useCallback(() => {
     setVisibleCount((count) => count + TRANSCRIPT_WINDOW_STEP)
   }, [])
+  const terminalEmptyError = messages.length === 0 && runtimeNotices.some(isTerminalChatErrorNotice)
+  const visibleRuntimeNotices = terminalEmptyError
+    ? runtimeNotices.filter((notice) => !isReconnectOrWarmupNotice(notice))
+    : runtimeNotices
 
   return (
     <Conversation
@@ -103,13 +108,13 @@ export function PiConversationSurface({
         chrome ? 'max-w-3xl px-6 py-8' : 'max-w-[680px] px-4 py-4',
         emptyHero && 'py-4 text-center',
       )}>
-        {messages.length === 0 && emptyStateHydrating ? (
+        {messages.length === 0 && emptyStateHydrating && !terminalEmptyError ? (
           <div className="flex items-center gap-2 rounded-xl border border-border bg-card/70 px-4 py-3 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
             Loading chat history…
           </div>
         ) : null}
-        {messages.length === 0 && !emptyStateHydrating ? (
+        {messages.length === 0 && !emptyStateHydrating && !terminalEmptyError ? (
           <ChatEmptyState
             eyebrow={emptyState?.eyebrow}
             title={emptyState?.title}
@@ -141,7 +146,7 @@ export function PiConversationSurface({
             onMentionActivate={onMentionActivate}
           />
         ))}
-        <RuntimeNoticeMessages notices={runtimeNotices} onDismiss={onDismissNotice} renderAction={renderNoticeAction} />
+        <RuntimeNoticeMessages notices={visibleRuntimeNotices} onDismiss={onDismissNotice} renderAction={renderNoticeAction} />
       </ConversationContent>
       <ConversationScrollButton />
     </Conversation>
@@ -199,6 +204,10 @@ function TranscriptHistoryLoader({ olderCount, onLoadOlder }: { olderCount: numb
       </button>
     </div>
   )
+}
+
+function isReconnectOrWarmupNotice(notice: PanelNotice): boolean {
+  return notice.id.includes('reconnect') || notice.id.includes('warmup')
 }
 
 function buildMessageRenderItems(messages: BoringChatMessage[]): Array<{ message: BoringChatMessage; key: string }> {

--- a/packages/agent/src/front/chat/components/RuntimeNotices.tsx
+++ b/packages/agent/src/front/chat/components/RuntimeNotices.tsx
@@ -15,17 +15,36 @@ export interface RuntimeNotice extends PiChatRuntimeNotice {
   actionLabel?: string
 }
 
+const TERMINAL_CHAT_ERROR_IDS = new Set([
+  'chat-error',
+  'protocol-error',
+  'session-navigation-error',
+])
+
+export function isTerminalChatErrorNotice(notice: Pick<RuntimeNotice, 'id' | 'level'>): boolean {
+  return notice.level === 'error' && TERMINAL_CHAT_ERROR_IDS.has(notice.id)
+}
+
 export interface RuntimeNoticesProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   notices: RuntimeNotice[]
   onDismiss?: (id: string) => void
   onAction?: (id: string) => void
+  onReloadWorkspace?: () => void
   /** Host-supplied action node for a notice, rendered before the built-in
    * onAction button. Lets a host attach a recovery action for a specific error
    * code without this component knowing the code. */
   renderAction?: (notice: RuntimeNotice) => ReactNode
 }
 
-export const RuntimeNotices = memo(({ notices, onDismiss, onAction, renderAction, className, ...props }: RuntimeNoticesProps) => {
+export const RuntimeNotices = memo(({
+  notices,
+  onDismiss,
+  onAction,
+  onReloadWorkspace,
+  renderAction,
+  className,
+  ...props
+}: RuntimeNoticesProps) => {
   if (notices.length === 0) return null
 
   return (
@@ -35,7 +54,14 @@ export const RuntimeNotices = memo(({ notices, onDismiss, onAction, renderAction
       {...props}
     >
       {notices.map((notice) => (
-        <RuntimeNoticeRow key={notice.id} notice={notice} onDismiss={onDismiss} onAction={onAction} renderAction={renderAction} />
+        <RuntimeNoticeRow
+          key={notice.id}
+          notice={notice}
+          onDismiss={onDismiss}
+          onAction={onAction}
+          onReloadWorkspace={onReloadWorkspace}
+          renderAction={renderAction}
+        />
       ))}
     </div>
   )
@@ -47,14 +73,16 @@ interface RuntimeNoticeRowProps {
   notice: RuntimeNotice
   onDismiss?: (id: string) => void
   onAction?: (id: string) => void
+  onReloadWorkspace?: () => void
   renderAction?: (notice: RuntimeNotice) => ReactNode
 }
 
-function RuntimeNoticeRow({ notice, onDismiss, onAction, renderAction }: RuntimeNoticeRowProps) {
+function RuntimeNoticeRow({ notice, onDismiss, onAction, onReloadWorkspace, renderAction }: RuntimeNoticeRowProps) {
   const kind = inferNoticeKind(notice)
   const Icon = iconForNotice(kind, notice.level)
   const actionLabel = notice.actionLabel ?? defaultActionLabel(kind)
   const hostAction = renderAction?.(notice)
+  const terminalChatError = isTerminalChatErrorNotice(notice)
 
   return (
     <div
@@ -71,9 +99,33 @@ function RuntimeNoticeRow({ notice, onDismiss, onAction, renderAction }: Runtime
     >
       <Icon className={cn(noticeIconClass(notice.level), kind === 'retry' && 'animate-spin motion-reduce:animate-none')} aria-hidden="true" />
       <div className="min-w-0 flex-1">
-        <p className={noticeTextClass()}>{notice.text}</p>
+        {terminalChatError ? (
+          <>
+            <p className="text-sm font-semibold text-foreground">Chat history unavailable</p>
+            <p className={noticeTextClass('mt-0.5')}>
+              The saved conversation could not be loaded. Reload the workspace to try again.
+            </p>
+            <details className="mt-2 text-xs text-muted-foreground">
+              <summary className="cursor-pointer">Error details</summary>
+              <p className="mt-1 whitespace-pre-wrap break-words">{notice.text}</p>
+            </details>
+          </>
+        ) : (
+          <p className={noticeTextClass()}>{notice.text}</p>
+        )}
       </div>
       {hostAction ?? null}
+      {terminalChatError ? (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="shrink-0 bg-background text-foreground hover:bg-muted hover:text-foreground"
+          onClick={onReloadWorkspace ?? reloadWorkspace}
+        >
+          Reload workspace
+        </Button>
+      ) : null}
       {actionLabel && onAction ? (
         <Button type="button" variant="ghost" size="sm" onClick={() => onAction(notice.id)}>
           {actionLabel}
@@ -93,6 +145,10 @@ function RuntimeNoticeRow({ notice, onDismiss, onAction, renderAction }: Runtime
       ) : null}
     </div>
   )
+}
+
+function reloadWorkspace(): void {
+  window.location.reload()
 }
 
 function inferNoticeKind(notice: RuntimeNotice): RuntimeNoticeKind {

--- a/packages/agent/src/front/chat/components/__tests__/PiConversationSurface.test.tsx
+++ b/packages/agent/src/front/chat/components/__tests__/PiConversationSurface.test.tsx
@@ -64,6 +64,140 @@ afterEach(() => {
 })
 
 describe('PiConversationSurface', () => {
+  test.each([
+    'chat-error',
+    'protocol-error',
+    'session-navigation-error',
+  ])('gives %s precedence over empty-chat hydration', (id) => {
+    render(
+      <PiConversationSurface
+        chrome
+        emptyHero={false}
+        messages={[]}
+        emptyStateHydrating
+        suggestions={[]}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+        runtimeNotices={[{ id, level: 'error', text: 'Request failed with 500' }]}
+        onDismissNotice={() => {}}
+        onScrollToBottomReady={() => {}}
+        onSuggestionSubmit={async () => undefined}
+        onRestoreDraft={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('alert').textContent).toContain('Chat history unavailable')
+    expect(screen.queryByText('Loading chat history…')).toBeNull()
+    expect(document.querySelector('[data-boring-agent-part="empty-state"]')).toBeNull()
+  })
+
+  test('gives a known terminal error precedence over the empty hero', () => {
+    render(
+      <PiConversationSurface
+        chrome
+        emptyHero
+        messages={[]}
+        emptyStateHydrating={false}
+        emptyState={{ title: 'Start a new conversation' }}
+        suggestions={[]}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+        runtimeNotices={[{ id: 'chat-error', level: 'error', text: 'History failed' }]}
+        onDismissNotice={() => {}}
+        onScrollToBottomReady={() => {}}
+        onSuggestionSubmit={async () => undefined}
+        onRestoreDraft={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Chat history unavailable')).toBeTruthy()
+    expect(screen.queryByText('Start a new conversation')).toBeNull()
+    expect(document.querySelector('[data-boring-agent-part="empty-state"]')).toBeNull()
+  })
+
+  test('does not give a generic error terminal empty-chat precedence', () => {
+    render(
+      <PiConversationSurface
+        chrome
+        emptyHero
+        messages={[]}
+        emptyStateHydrating={false}
+        emptyState={{ title: 'Start a new conversation' }}
+        suggestions={[]}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+        runtimeNotices={[{ id: 'generic-error', level: 'error', text: 'Generic failure' }]}
+        onDismissNotice={() => {}}
+        onScrollToBottomReady={() => {}}
+        onSuggestionSubmit={async () => undefined}
+        onRestoreDraft={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Start a new conversation')).toBeTruthy()
+    expect(screen.getByText('Generic failure')).toBeTruthy()
+    expect(screen.queryByText('Chat history unavailable')).toBeNull()
+  })
+
+  test('suppresses only reconnect and warmup notices in a known terminal empty state', () => {
+    render(
+      <PiConversationSurface
+        chrome
+        emptyHero={false}
+        messages={[]}
+        emptyStateHydrating
+        suggestions={[]}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+        runtimeNotices={[
+          { id: 'chat-error', level: 'error', text: 'History failed' },
+          { id: 'connection-reconnecting', level: 'warning', text: 'Reconnecting…' },
+          { id: 'runtime-warmup', level: 'warning', text: 'Starting runtime…' },
+          { id: 'generic-warning', level: 'warning', text: 'Other warning remains' },
+        ]}
+        onDismissNotice={() => {}}
+        onScrollToBottomReady={() => {}}
+        onSuggestionSubmit={async () => undefined}
+        onRestoreDraft={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Chat history unavailable')).toBeTruthy()
+    expect(screen.queryByText('Reconnecting…')).toBeNull()
+    expect(screen.queryByText('Starting runtime…')).toBeNull()
+    expect(screen.getByText('Other warning remains')).toBeTruthy()
+  })
+
+  test('keeps reconnect and warmup notices outside a terminal empty state', () => {
+    render(
+      <PiConversationSurface
+        chrome
+        emptyHero={false}
+        messages={textMessages(1)}
+        emptyStateHydrating={false}
+        suggestions={[]}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+        runtimeNotices={[
+          { id: 'connection-reconnecting', level: 'warning', text: 'Reconnecting…' },
+          { id: 'runtime-warmup', level: 'warning', text: 'Starting runtime…' },
+        ]}
+        onDismissNotice={() => {}}
+        onScrollToBottomReady={() => {}}
+        onSuggestionSubmit={async () => undefined}
+        onRestoreDraft={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('Reconnecting…')).toBeTruthy()
+    expect(screen.getByText('Starting runtime…')).toBeTruthy()
+  })
+
   test('keeps assistant render keys unique when same-turn rows pass through', () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
     const messages: BoringChatMessage[] = [

--- a/packages/agent/src/front/chat/components/__tests__/RuntimeNotices.test.tsx
+++ b/packages/agent/src/front/chat/components/__tests__/RuntimeNotices.test.tsx
@@ -4,6 +4,45 @@ import { describe, expect, test, vi } from 'vitest'
 import { RuntimeNotices, type RuntimeNotice } from '../RuntimeNotices'
 
 describe('RuntimeNotices', () => {
+  test.each([
+    'chat-error',
+    'protocol-error',
+    'session-navigation-error',
+  ])('presents %s as a recoverable chat history error', (id) => {
+    const onReloadWorkspace = vi.fn()
+    const rawDetails = '<img src=x onerror="alert(1)"> Request failed with 500'
+
+    render(
+      <RuntimeNotices
+        notices={[{ id, level: 'error', text: rawDetails }]}
+        onReloadWorkspace={onReloadWorkspace}
+      />,
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(within(alert).getByText('Chat history unavailable')).toBeTruthy()
+    expect(within(alert).getByText(/Reload the workspace to try again/)).toBeTruthy()
+    const details = within(alert).getByText('Error details').closest('details')
+    expect(details?.open).toBe(false)
+    expect(within(details as HTMLElement).getByText(rawDetails)).toBeTruthy()
+    expect(details?.querySelector('img')).toBeNull()
+
+    fireEvent.click(within(alert).getByRole('button', { name: 'Reload workspace' }))
+    expect(onReloadWorkspace).toHaveBeenCalledOnce()
+  })
+
+  test('leaves generic errors in their existing raw notice presentation', () => {
+    render(
+      <RuntimeNotices notices={[{ id: 'generic-error', level: 'error', text: 'A generic failure' }]} />,
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(within(alert).getByText('A generic failure')).toBeTruthy()
+    expect(within(alert).queryByText('Chat history unavailable')).toBeNull()
+    expect(within(alert).queryByText('Error details')).toBeNull()
+    expect(within(alert).queryByRole('button', { name: 'Reload workspace' })).toBeNull()
+  })
+
   test('renders reconnect, protocol, warmup, plugin, and retry notices with stable data attrs', () => {
     const notices: RuntimeNotice[] = [
       { id: 'connection-reconnecting', kind: 'reconnect', level: 'warning', text: 'Reconnecting to the agent session…' },


### PR DESCRIPTION
## Summary

Ports the focused chat-error treatment from the Claude UI prototype without its palette or broad loading-state changes.

## Changed

- known terminal empty-chat failures replace contradictory loading/empty content
- clear “Chat history unavailable” copy
- collapsible technical details
- visible reload recovery action in light and dark themes
- competing reconnect/warmup notices suppressed only for known terminal IDs
- deterministic playground review mode via `?chatError=1`

## Proof

- focused RuntimeNotices/PiConversationSurface tests: 18 passed
- agent typecheck: passed
- agent build: passed
- agent playground typecheck: passed
- visual review: `http://100.68.199.114:5207/?chatError=1`
- owner approved the final treatment

## Review

- Standards/spec review: approved, no blocker/high findings
- Independent verification: SHIP

## Risk / rollback

Presentation and state-precedence change limited to three known terminal notice IDs when the transcript is empty. Revert this PR to restore prior independent loading/notice rendering.

Closes #1036
