### PR TITLE
#1040 fix(agent): refresh idle CLI session history

### DIFF
--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -1082,6 +1082,112 @@ describe('HarnessPiChatService', () => {
     })
   })
 
+  it('keeps live state when a cold persisted read gains a channel during loading', async () => {
+    const adapter = createAdapter()
+    adapter.readSnapshot().messages = [
+      { id: 'live-user', message: { role: 'user', content: [{ type: 'text', text: 'live prompt' }] } },
+    ]
+    const persisted = deferred<{ id: string; messages: unknown[] }>()
+    const persistedStore: PersistedSessionStore = {
+      ...sessionStore,
+      loadEntries: vi.fn(() => persisted.promise),
+    }
+    const service = new HarnessPiChatService({
+      harness: createHarness(adapter),
+      sessionStore: persistedStore,
+      workdir: '/workspace',
+    })
+
+    const statePromise = service.readState(ctx, 's1')
+    await vi.waitFor(() => expect(persistedStore.loadEntries).toHaveBeenCalled())
+    const subscription = await service.subscribe(ctx, 's1', 0, () => {})
+    expect(subscription.type).toBe('ok')
+    persisted.resolve({
+      id: 's1',
+      messages: [{ id: 'stale-user', role: 'user', content: [{ type: 'text', text: 'stale prompt' }] }],
+    })
+
+    await expect(statePromise).resolves.toMatchObject({
+      status: 'streaming',
+      messages: [expect.objectContaining({ id: 'live-user' })],
+    })
+    if (subscription.type === 'ok') subscription.unsubscribe()
+  })
+
+  it('refreshes an idle previously-opened session from persisted history', async () => {
+    const adapter = createAdapter()
+    adapter.readSnapshot().isStreaming = false
+    adapter.readSnapshot().messages = [
+      { id: 'old-user', message: { role: 'user', content: [{ type: 'text', text: 'old prompt' }] } },
+    ]
+    let persistedMessages: unknown[] = [
+      { id: 'old-user', role: 'user', content: [{ type: 'text', text: 'old prompt' }] },
+    ]
+    const persistedStore: PersistedSessionStore = {
+      ...sessionStore,
+      loadEntries: vi.fn(async () => ({ id: 's1', messages: persistedMessages })),
+    }
+    const service = new HarnessPiChatService({
+      harness: createHarness(adapter),
+      sessionStore: persistedStore,
+      workdir: '/workspace',
+    })
+
+    await service.readState(ctx, 's1')
+    const subscription = await service.subscribe(ctx, 's1', 0, () => {})
+    expect(subscription.type).toBe('ok')
+    if (subscription.type === 'ok') subscription.unsubscribe()
+
+    persistedMessages = [
+      ...persistedMessages,
+      { id: 'cli-user', role: 'user', content: [{ type: 'text', text: 'added from pi CLI' }] },
+    ]
+
+    const state = await service.readState(ctx, 's1')
+
+    expect(state.status).toBe('idle')
+    expect(state.messages).toEqual([
+      expect.objectContaining({ id: 'old-user' }),
+      expect.objectContaining({
+        id: 'cli-user',
+        parts: [expect.objectContaining({ type: 'text', text: 'added from pi CLI' })],
+      }),
+    ])
+  })
+
+  it('keeps live state when an idle session becomes active during persisted refresh', async () => {
+    const adapter = createAdapter()
+    adapter.readSnapshot().isStreaming = false
+    const persisted = deferred<{ id: string; messages: unknown[] }>()
+    const persistedStore: PersistedSessionStore = {
+      ...sessionStore,
+      loadEntries: vi.fn(() => persisted.promise),
+    }
+    const harness = createHarness(adapter)
+    vi.mocked(harness.hasPiSession).mockReturnValue(true)
+    const service = new HarnessPiChatService({
+      harness,
+      sessionStore: persistedStore,
+      workdir: '/workspace',
+    })
+
+    const statePromise = service.readState(ctx, 's1')
+    await vi.waitFor(() => expect(persistedStore.loadEntries).toHaveBeenCalled())
+    adapter.readSnapshot().isStreaming = true
+    adapter.readSnapshot().messages = [
+      { id: 'live-user', message: { role: 'user', content: [{ type: 'text', text: 'live prompt' }] } },
+    ]
+    persisted.resolve({
+      id: 's1',
+      messages: [{ id: 'stale-user', role: 'user', content: [{ type: 'text', text: 'stale prompt' }] }],
+    })
+
+    await expect(statePromise).resolves.toMatchObject({
+      status: 'streaming',
+      messages: [expect.objectContaining({ id: 'live-user' })],
+    })
+  })
+
   it('uses the live adapter instead of persisted state when the harness has a Pi session', async () => {
     const adapter = createAdapter()
     adapter.readSnapshot().messages = [

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -233,13 +233,24 @@ export class HarnessPiChatService implements PiChatSessionService {
 
   private async readStateBeforeDispose(ctx: PiSessionRequestContext, sessionId: string): Promise<PiChatSnapshot> {
     const sessionKey = this.sessionKey(ctx, sessionId)
-    const channel = this.channels.get(sessionKey)
+    let channel = this.channels.get(sessionKey)
     if (!channel && !this.harnessMayHaveLiveSession(ctx, sessionId)) {
       const persisted = await this.readPersistedState(ctx, sessionId)
-      if (persisted) return persisted
+      channel = this.channels.get(sessionKey)
+      if (persisted && !channel && !this.harnessMayHaveLiveSession(ctx, sessionId)) return persisted
     }
 
     const adapter = await this.getAdapter(ctx, sessionId, '')
+    if (this.canRefreshFromPersistedState(sessionKey, adapter)) {
+      const persisted = await this.readPersistedState(ctx, sessionId)
+      if (persisted && this.canRefreshFromPersistedState(sessionKey, adapter)) {
+        return this.enrichSyntheticPromptFailures(
+          sessionKey,
+          this.messageMetadata.enrichSnapshot(sessionKey, persisted),
+        )
+      }
+    }
+
     const snapshot = this.messageMetadata.enrichSnapshot(sessionKey, buildPiChatSnapshot(adapter, {
       seq: channel?.buffer.latestSeq ?? 0,
       sessionId,
@@ -247,6 +258,16 @@ export class HarnessPiChatService implements PiChatSessionService {
       messageTurnIds: channel?.messageTurnIds,
     }))
     return this.enrichSyntheticPromptFailures(sessionKey, snapshot)
+  }
+
+  private canRefreshFromPersistedState(sessionKey: string, adapter: PiAgentSessionAdapter): boolean {
+    if (this.activePromptRuns.has(sessionKey)) return false
+    const snapshot = adapter.readSnapshot()
+    return !snapshot.isStreaming
+      && !snapshot.isRetrying
+      && snapshot.pendingMessageCount === 0
+      && snapshot.steeringMessages.length === 0
+      && snapshot.followUpMessages.length === 0
   }
 
   private harnessMayHaveLiveSession(ctx: PiSessionRequestContext, sessionId: string): boolean {


### PR DESCRIPTION
## Summary

Refresh an idle, previously opened Pi session from persisted history so messages added through the standalone Pi CLI appear when the session is reopened in Boring UI.

## Issue / Slice

Closes #1040.

## What Changed

- Prefer freshly loaded persisted history when the cached Pi adapter is idle and has no pending, steering, or follow-up work.
- Keep active streaming/retrying/prompt/queue state sourced from the live adapter.
- Revalidate live state after async persisted reads to avoid returning stale idle state when work starts concurrently.
- Add regressions for external history updates and both persisted-load races.

## Proof

- `pnpm --filter @hachej/boring-agent exec vitest run src/server/pi-chat/__tests__/harnessPiChatService.test.ts` — PASS, 49/49 tests, no type errors.
- `pnpm --filter @hachej/boring-agent run typecheck` — PASS.
- `pnpm --filter @hachej/boring-agent run lint:invariants` — PASS.
- `git diff --check` — PASS.

Manual verification path:
1. Open a shared Pi session in Boring UI CLI mode, then switch away.
2. Resume the same session in standalone `pi` and add a turn.
3. Reopen the session in Boring UI; the added turn should be present.

## Review

- Standards: initial review found persisted-load races; both were fixed with post-load revalidation and regression tests. Final review clean.
- Spec: clean; idle refresh and live streaming/queue guards verified.
- Thermo: waived — two-file surgical state-selection fix, no new architecture or abstraction.
- Reviewed SHA: `b9b15bf`

## Risk / Rollback

Low. The change only affects `/state` hydration for an idle adapter when durable Pi entries are available. Active or queued sessions retain the previous live-adapter path. Roll back this commit to restore prior behavior.

## Next

- Owner review / manual CLI-mode validation.
