### PR TITLE
#1033 Refine composer and empty chat state

### DIFF
--- a/packages/agent/e2e/pi-native-baseline-composer-controls.spec.ts
+++ b/packages/agent/e2e/pi-native-baseline-composer-controls.spec.ts
@@ -19,8 +19,8 @@ test.describe('Pi-native baseline composer controls', () => {
     const thinkingSelect = page.locator('[data-boring-agent-part="thinking-select"]')
 
     await expect(chat).toHaveAttribute('data-pi-chat-connection', 'connected', { timeout: 10_000 })
-    await expect(modelSelect).toContainText('/model:', { timeout: 10_000 })
-    await expect(thinkingSelect).toContainText('/thinking:')
+    await expect(modelSelect).toContainText('Model ·', { timeout: 10_000 })
+    await expect(thinkingSelect).toContainText('Thinking ·')
     await expect(page.getByRole('option', { name: /Claude Sonnet/ })).toHaveCount(0)
     await expect(page.getByRole('option', { name: /Deep reasoning/ })).toHaveCount(0)
 
@@ -31,7 +31,7 @@ test.describe('Pi-native baseline composer controls', () => {
     expect(chrome.rail.backgroundColor).toBe('rgba(0, 0, 0, 0)')
     expect(chrome.rail.boxShadow).toContain('inset')
     expect(chrome.rail.borderWidth).toBe('0px')
-    expect(chrome.rail.borderRadius).toBeGreaterThan(20)
+    expect(chrome.rail.borderRadius).toBe(14)
     expect(Math.round(chrome.inputGroup.height)).toBe(56)
     // The composer input-group is a column shell (textarea row stacked over the
     // controls row); the visible horizontal bar is the inner items-center row.
@@ -40,7 +40,7 @@ test.describe('Pi-native baseline composer controls', () => {
     expect(chrome.inputGroup.backgroundColor).toBe('rgba(0, 0, 0, 0)')
     expect(chrome.inputGroup.boxShadow).not.toContain('inset')
     expect(chrome.inputGroup.borderWidth).toBe('0px')
-    expect(chrome.inputGroup.borderRadius).toBeGreaterThan(20)
+    expect(chrome.inputGroup.borderRadius).toBe(14)
     expect(chrome.formClass).not.toContain('!bg-[color:var(--background)]')
     expect(chrome.formClass).not.toContain('shadow-[inset')
     expect(chrome.viewport.height - chrome.chat.bottom).toBeLessThanOrEqual(1)
@@ -52,16 +52,15 @@ test.describe('Pi-native baseline composer controls', () => {
     expect(chrome.submit.status).toBe('ready')
     expect(chrome.submit.className).toContain('text-background')
     expect(chrome.submit.className).not.toContain('!text-background')
-    expect(Math.round(chrome.settings.top - chrome.rail.bottom)).toBe(6)
+    expect(Math.round(chrome.settings.top - chrome.rail.bottom)).toBe(8)
     expect(Math.round(chrome.settings.width)).toBe(Math.round(chrome.rail.width))
-    expect(chrome.settings.justifyContent).toBe('center')
-    expect(chrome.settings.gap).toBe('6px')
-    expect(chrome.settings.fontSize).toBe('10.5px')
-    expect(chrome.settings.color).toContain('/ 0.45')
+    expect(chrome.settings.justifyContent).toBe('normal')
+    expect(chrome.settings.gap).toBe('normal')
+    expect(chrome.settings.fontSize).toBe('12px')
     expect(chrome.modelSelect.borderRadius).toBeGreaterThan(0)
-    expect(Math.round(chrome.modelSelect.height)).toBe(20)
+    expect(Math.round(chrome.modelSelect.height)).toBe(32)
     expect(chrome.thinkingSelect.borderRadius).toBeGreaterThan(0)
-    expect(Math.round(chrome.thinkingSelect.height)).toBe(20)
+    expect(Math.round(chrome.thinkingSelect.height)).toBe(32)
 
     await testInfo.attach('pi-native-baseline-composer-rail.json', {
       body: Buffer.from(JSON.stringify({

--- a/packages/agent/src/front/ChatEmptyState.tsx
+++ b/packages/agent/src/front/ChatEmptyState.tsx
@@ -84,13 +84,72 @@ export interface ChatEmptyStateProps {
    * resolves this to `sendMessage` with the suggestion's prompt.
    */
   onSelect?: (suggestion: ChatSuggestion) => void
-  /** Optional content rendered between the title and suggestions. */
-  composer?: ReactNode
-  /** Uses the concise empty-chat hierarchy: title, composer, suggestions. */
+  /** Uses the concise empty-chat hierarchy. */
   hero?: boolean
   /** Optional content rendered below the suggestion grid. */
   footer?: ReactNode
   className?: string
+}
+
+interface ChatSuggestionGridProps {
+  suggestions: ChatSuggestion[]
+  onSelect?: (suggestion: ChatSuggestion) => void
+  className?: string
+}
+
+export function ChatSuggestionGrid({ suggestions, onSelect, className }: ChatSuggestionGridProps) {
+  if (suggestions.length === 0) return null
+  return (
+    <div
+      data-boring-agent-part="suggestion-grid"
+      style={{
+        ["--chat-empty-card-hover" as string]: "var(--accent-soft)",
+        ["--chat-empty-accent" as string]: "var(--accent)",
+      }}
+      className={cn(
+        "grid w-full grid-cols-1 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70 @[480px]:grid-cols-2",
+        className,
+      )}
+    >
+      {suggestions.map((suggestion) => {
+        const Icon = suggestion.icon
+        return (
+          <Button
+            key={suggestion.label}
+            type="button"
+            variant="ghost"
+            data-boring-agent-part="suggestion-card"
+            onClick={() => {
+              if (suggestion.onSelect) {
+                suggestion.onSelect()
+                return
+              }
+              onSelect?.(suggestion)
+            }}
+            className="group h-auto justify-start gap-3 rounded-none bg-background px-4 py-3.5 text-left hover:bg-[color:var(--chat-empty-card-hover)] focus-visible:bg-[color:var(--chat-empty-card-hover)]"
+          >
+            {Icon && (
+              <Icon
+                className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-[color:var(--chat-empty-accent)]"
+                strokeWidth={1.75}
+              />
+            )}
+            <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span className="text-[13px] font-medium text-foreground">{suggestion.label}</span>
+              {suggestion.hint && <span className="text-[12px] text-muted-foreground">{suggestion.hint}</span>}
+            </span>
+            <ArrowUpRight
+              className={cn(
+                "mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-all duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
+                "group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:opacity-100 group-hover:text-[color:var(--chat-empty-accent)]",
+              )}
+              strokeWidth={2}
+            />
+          </Button>
+        )
+      })}
+    </div>
+  )
 }
 
 export function ChatEmptyState({
@@ -99,7 +158,6 @@ export function ChatEmptyState({
   description = "Ask a question, open a file from the workbench, or start from a template.",
   suggestions = defaultChatSuggestions,
   onSelect,
-  composer,
   hero = false,
   footer,
   className,
@@ -136,65 +194,12 @@ export function ChatEmptyState({
           {title}
         </h3>
       )}
-      {composer ? <div className={cn("w-full", hero && "mt-6")}>{composer}</div> : null}
       {!hero && description && (
         <p className="mt-3 hidden max-w-[440px] text-[14px] leading-relaxed text-[color:var(--chat-empty-description-color)] @[420px]:block">
           {description}
         </p>
       )}
-      {suggestions.length > 0 && (
-        <div
-          data-boring-agent-part="suggestion-grid"
-          className={cn(
-            "grid w-full grid-cols-1 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70 @[480px]:grid-cols-2",
-            hero ? "mt-4" : "mt-8",
-          )}
-        >
-          {suggestions.map((suggestion) => {
-            const Icon = suggestion.icon
-            return (
-              <Button
-                key={suggestion.label}
-                type="button"
-                variant="ghost"
-                data-boring-agent-part="suggestion-card"
-                onClick={() => {
-                  if (suggestion.onSelect) {
-                    suggestion.onSelect()
-                    return
-                  }
-                  onSelect?.(suggestion)
-                }}
-                className="group h-auto justify-start gap-3 rounded-none bg-background px-4 py-3.5 text-left hover:bg-[color:var(--chat-empty-card-hover)] focus-visible:bg-[color:var(--chat-empty-card-hover)]"
-              >
-                {Icon && (
-                  <Icon
-                    className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-colors group-hover:text-[color:var(--chat-empty-accent)]"
-                    strokeWidth={1.75}
-                  />
-                )}
-                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-                  <span className="text-[13px] font-medium text-foreground">
-                    {suggestion.label}
-                  </span>
-                  {suggestion.hint && (
-                    <span className="text-[12px] text-muted-foreground">
-                      {suggestion.hint}
-                    </span>
-                  )}
-                </span>
-                <ArrowUpRight
-                  className={cn(
-                    "mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition-all duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]",
-                    "group-hover:translate-x-0.5 group-hover:-translate-y-0.5 group-hover:opacity-100 group-hover:text-[color:var(--chat-empty-accent)]",
-                  )}
-                  strokeWidth={2}
-                />
-              </Button>
-            )
-          })}
-        </div>
-      )}
+      <ChatSuggestionGrid suggestions={suggestions} onSelect={onSelect} className={hero ? "mt-4" : "mt-8"} />
       {footer}
     </div>
   )

--- a/packages/agent/src/front/ChatEmptyState.tsx
+++ b/packages/agent/src/front/ChatEmptyState.tsx
@@ -84,6 +84,10 @@ export interface ChatEmptyStateProps {
    * resolves this to `sendMessage` with the suggestion's prompt.
    */
   onSelect?: (suggestion: ChatSuggestion) => void
+  /** Optional content rendered between the title and suggestions. */
+  composer?: ReactNode
+  /** Uses the concise empty-chat hierarchy: title, composer, suggestions. */
+  hero?: boolean
   /** Optional content rendered below the suggestion grid. */
   footer?: ReactNode
   className?: string
@@ -91,10 +95,12 @@ export interface ChatEmptyStateProps {
 
 export function ChatEmptyState({
   eyebrow = "New session",
-  title = "What are we building?",
+  title = "What should we work on?",
   description = "Ask a question, open a file from the workbench, or start from a template.",
   suggestions = defaultChatSuggestions,
   onSelect,
+  composer,
+  hero = false,
   footer,
   className,
 }: ChatEmptyStateProps) {
@@ -112,21 +118,26 @@ export function ChatEmptyState({
         // @container lets the hero scale to the pane it lives in, not the
         // viewport — split chat panes get the compact variant.
         "@container mx-auto flex w-full max-w-[640px] flex-col px-2 pt-12 pb-4",
+        hero && "items-center py-0 text-center",
         className,
       )}
     >
-      {eyebrow && (
+      {!hero && eyebrow && (
         <div className="flex items-center gap-2 text-[10.5px] font-medium uppercase tracking-[0.16em] text-[color:var(--chat-empty-eyebrow-color)]">
           <span className="inline-block h-px w-4 bg-[color:var(--chat-empty-accent)]" aria-hidden="true" />
           {eyebrow}
         </div>
       )}
       {title && (
-        <h3 className="mt-3 text-[24px] font-medium leading-[1.05] tracking-[-0.02em] text-[color:var(--chat-empty-title-color)] @[480px]:text-[34px]">
+        <h3 className={cn(
+          "text-[24px] font-medium leading-[1.05] tracking-[-0.02em] text-[color:var(--chat-empty-title-color)] @[480px]:text-[34px]",
+          hero ? "m-0" : "mt-3",
+        )}>
           {title}
         </h3>
       )}
-      {description && (
+      {composer ? <div className={cn("w-full", hero && "mt-6")}>{composer}</div> : null}
+      {!hero && description && (
         <p className="mt-3 hidden max-w-[440px] text-[14px] leading-relaxed text-[color:var(--chat-empty-description-color)] @[420px]:block">
           {description}
         </p>
@@ -134,7 +145,10 @@ export function ChatEmptyState({
       {suggestions.length > 0 && (
         <div
           data-boring-agent-part="suggestion-grid"
-          className="mt-8 grid w-full grid-cols-1 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70 @[480px]:grid-cols-2"
+          className={cn(
+            "grid w-full grid-cols-1 gap-px overflow-hidden rounded-xl bg-border/70 ring-1 ring-border/70 @[480px]:grid-cols-2",
+            hero ? "mt-4" : "mt-8",
+          )}
         >
           {suggestions.map((suggestion) => {
             const Icon = suggestion.icon

--- a/packages/agent/src/front/__tests__/ModelSelect.test.tsx
+++ b/packages/agent/src/front/__tests__/ModelSelect.test.tsx
@@ -196,7 +196,7 @@ describe('ModelSelect', () => {
     )
 
     fireEvent.click(screen.getByRole('button', { name: 'Model' }))
-    fireEvent.click(screen.getByText('auto'))
+    fireEvent.click(screen.getByText('Auto'))
 
     expect(onChange).toHaveBeenCalledWith(null)
   })
@@ -256,7 +256,7 @@ describe('ModelSelect', () => {
     )
 
     const trigger = screen.getByRole('button', { name: /Current model: Default model/ })
-    expect(trigger.textContent).toContain('/model: Default model')
+    expect(trigger.textContent).toContain('Model · Default model')
     expect(trigger.className).toContain('whitespace-nowrap')
     expect(trigger.className).toContain('overflow-hidden')
     expect(trigger.className).toContain('text-ellipsis')
@@ -332,7 +332,7 @@ describe('ThinkingSelect', () => {
     const { rerender } = render(<ThinkingSelect value="medium" onChange={() => {}} trigger="slash" openSignal={0} />)
 
     const trigger = screen.getByRole('button', { name: 'Thinking level: Med' })
-    expect(trigger.textContent).toContain('/thinking: medium')
+    expect(trigger.textContent).toContain('Thinking · Medium')
     expect(screen.queryByText('Deep reasoning')).toBeNull()
 
     rerender(<ThinkingSelect value="medium" onChange={() => {}} trigger="slash" openSignal={1} />)

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -215,7 +215,7 @@ export function PiChatPanel<
   hotReloadEnabled = true,
   suggestions = defaultChatSuggestions,
   emptyState,
-  emptyPlacement = 'default',
+  emptyPlacement = 'hero',
   composerPlaceholder,
   initialDraft,
   autoSubmitInitialDraft = false,
@@ -1091,72 +1091,10 @@ export function PiChatPanel<
     handleComposerKeyDown(event)
   }, [handleComposerKeyDown, interrupt, isStreaming, mentionState, slashQuery])
 
-  return (
-    <ArtifactOpenProvider onOpenArtifact={onOpenArtifact}>
-      <div
-        data-boring-agent=""
-        data-boring-agent-part="chat"
-        data-pi-chat-session-id={activeSessionId}
-        data-pi-chat-connection={debugState?.connection ?? 'disconnected'}
-        data-pi-chat-last-seq={debugState?.lastSeq ?? 0}
-        className={cn(
-          'flex h-full min-h-0 overflow-hidden text-foreground antialiased',
-          debug ? 'flex-row' : showSessionSidebar ? 'flex-row' : 'flex-col',
-          chrome ? 'bg-[color:var(--canvas)] text-[13px]' : 'bg-transparent text-[13px]',
-          className,
-        )}
-        role="region"
-        aria-label="Agent assistant"
-      >
-        {showSessionSidebar ? (
-          <aside data-boring-agent-part="pi-chat-session-sidebar" className="min-h-0 w-64 shrink-0 border-r border-border/60">
-            <SessionList
-              sessions={sessionList}
-              activeId={activeSessionId}
-              loading={sessionsLoading}
-              onCreate={createSession}
-              onSwitch={sessions.switch}
-              onDelete={deleteSession}
-              onLoadMore={sessions.loadMore}
-              hasMore={sessions.hasMore}
-              loadingMore={sessions.loadingMore}
-            />
-          </aside>
-        ) : null}
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-          <div
-            className={cn(
-              'flex h-full min-h-0 flex-col overflow-hidden',
-              emptyHero && 'justify-center',
-              chrome &&
-                'mx-3 my-3 rounded-xl bg-[color:var(--surface-chat)] shadow-[0_1px_0_oklch(0_0_0/0.02),0_1px_2px_-1px_oklch(0_0_0/0.04),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.6)]',
-            )}
-          >
-            <PiConversationSurface
+  const composerSurface = (
+    <PiChatComposerSurface
               chrome={chrome}
-              emptyHero={emptyHero}
-              messages={messages}
-              emptyStateHydrating={emptyStateHydrating}
-              emptyState={emptyState}
-              suggestions={suggestions}
-              isStreaming={isStreaming}
-              showThoughts={showThoughts}
-              toolRenderers={mergedToolRenderers}
-              mentionCatalog={assistantMentionCatalog}
-              onMentionActivate={activateAssistantMention}
-              runtimeNotices={runtimeNotices}
-              onDismissNotice={clearLocalNotice}
-              renderNoticeAction={renderNoticeAction}
-              onScrollToBottomReady={(scrollToBottom) => {
-                scrollToBottomRef.current = scrollToBottom
-              }}
-              onSuggestionSubmit={({ text, files, source }) => sendComposerMessage({ text, files, source })}
-              onRestoreDraft={setComposerDraft}
-              windowResetKey={activeSessionId}
-            />
-
-            <PiChatComposerSurface
-              chrome={chrome}
+              pickerPlacement={emptyHero ? 'above-compact' : 'above'}
               isStreaming={isStreaming}
               status={status}
               disabled={disabled}
@@ -1215,7 +1153,75 @@ export function PiChatPanel<
               }}
               onSubmitMessage={({ text, files }) => sendComposerMessage({ text, files })}
               onStop={stop}
+    />
+  )
+
+  return (
+    <ArtifactOpenProvider onOpenArtifact={onOpenArtifact}>
+      <div
+        data-boring-agent=""
+        data-boring-agent-part="chat"
+        data-pi-chat-session-id={activeSessionId}
+        data-pi-chat-connection={debugState?.connection ?? 'disconnected'}
+        data-pi-chat-last-seq={debugState?.lastSeq ?? 0}
+        className={cn(
+          'flex h-full min-h-0 overflow-hidden text-foreground antialiased',
+          debug ? 'flex-row' : showSessionSidebar ? 'flex-row' : 'flex-col',
+          chrome ? 'bg-[color:var(--canvas)] text-[13px]' : 'bg-transparent text-[13px]',
+          className,
+        )}
+        role="region"
+        aria-label="Agent assistant"
+      >
+        {showSessionSidebar ? (
+          <aside data-boring-agent-part="pi-chat-session-sidebar" className="min-h-0 w-64 shrink-0 border-r border-border/60">
+            <SessionList
+              sessions={sessionList}
+              activeId={activeSessionId}
+              loading={sessionsLoading}
+              onCreate={createSession}
+              onSwitch={sessions.switch}
+              onDelete={deleteSession}
+              onLoadMore={sessions.loadMore}
+              hasMore={sessions.hasMore}
+              loadingMore={sessions.loadingMore}
             />
+          </aside>
+        ) : null}
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <div
+            className={cn(
+              'flex h-full min-h-0 flex-col overflow-hidden',
+              emptyHero && 'justify-center',
+              chrome &&
+                'mx-3 my-3 rounded-xl bg-[color:var(--surface-chat)] shadow-[0_1px_0_oklch(0_0_0/0.02),0_1px_2px_-1px_oklch(0_0_0/0.04),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.6)]',
+            )}
+          >
+            <PiConversationSurface
+              chrome={chrome}
+              emptyHero={emptyHero}
+              emptyHeroComposer={emptyHero ? composerSurface : undefined}
+              messages={messages}
+              emptyStateHydrating={emptyStateHydrating}
+              emptyState={emptyState}
+              suggestions={suggestions}
+              isStreaming={isStreaming}
+              showThoughts={showThoughts}
+              toolRenderers={mergedToolRenderers}
+              mentionCatalog={assistantMentionCatalog}
+              onMentionActivate={activateAssistantMention}
+              runtimeNotices={runtimeNotices}
+              onDismissNotice={clearLocalNotice}
+              renderNoticeAction={renderNoticeAction}
+              onScrollToBottomReady={(scrollToBottom) => {
+                scrollToBottomRef.current = scrollToBottom
+              }}
+              onSuggestionSubmit={({ text, files, source }) => sendComposerMessage({ text, files, source })}
+              onRestoreDraft={setComposerDraft}
+              windowResetKey={activeSessionId}
+            />
+
+            {emptyHero ? null : composerSurface}
           </div>
         </div>
         {debug ? (

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -13,7 +13,7 @@ import type { PiChatEvent, PiChatStatus } from '../../shared/chat'
 import type { AvailableModel, ModelSelection, ThinkingLevel } from '../chatPanelSettings'
 import { DEFAULT_THINKING } from '../chatPanelSettings'
 import { cn } from '../lib'
-import { defaultChatSuggestions, type ChatSuggestion } from '../ChatEmptyState'
+import { ChatSuggestionGrid, defaultChatSuggestions, type ChatSuggestion } from '../ChatEmptyState'
 import type { SlashCommand } from '../slashCommands'
 import { builtinCommands, createCommandRegistry } from '../slashCommands'
 import type { ToolRendererOverrides } from '../bareToolRenderers'
@@ -1091,6 +1091,14 @@ export function PiChatPanel<
     handleComposerKeyDown(event)
   }, [handleComposerKeyDown, interrupt, isStreaming, mentionState, slashQuery])
 
+  const selectEmptySuggestion = useCallback((suggestion: ChatSuggestion) => {
+    const text = suggestion.prompt ?? suggestion.label
+    if (!text.trim()) return
+    void sendComposerMessage({ text, files: [], source: 'suggestion' }).then((result) => {
+      if (result === false) setComposerDraft(text)
+    })
+  }, [sendComposerMessage, setComposerDraft])
+
   const composerSurface = (
     <PiChatComposerSurface
               chrome={chrome}
@@ -1191,8 +1199,8 @@ export function PiChatPanel<
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           <div
             className={cn(
-              'flex h-full min-h-0 flex-col overflow-hidden',
-              emptyHero && 'justify-center',
+              'flex h-full min-h-0 flex-col',
+              emptyHero ? 'justify-center overflow-y-auto py-6' : 'overflow-hidden',
               chrome &&
                 'mx-3 my-3 rounded-xl bg-[color:var(--surface-chat)] shadow-[0_1px_0_oklch(0_0_0/0.02),0_1px_2px_-1px_oklch(0_0_0/0.04),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.6)]',
             )}
@@ -1200,7 +1208,6 @@ export function PiChatPanel<
             <PiConversationSurface
               chrome={chrome}
               emptyHero={emptyHero}
-              emptyHeroComposer={emptyHero ? composerSurface : undefined}
               messages={messages}
               emptyStateHydrating={emptyStateHydrating}
               emptyState={emptyState}
@@ -1221,7 +1228,16 @@ export function PiChatPanel<
               windowResetKey={activeSessionId}
             />
 
-            {emptyHero ? null : composerSurface}
+            {composerSurface}
+            {emptyHero ? (
+              <div
+                data-boring-agent-part="empty-hero-suggestions"
+                className="@container mx-auto w-full max-w-[640px] px-2 pb-4"
+              >
+                <ChatSuggestionGrid suggestions={suggestions} onSelect={selectEmptySuggestion} className="mt-4" />
+                {emptyState?.footer}
+              </div>
+            ) : null}
           </div>
         </div>
         {debug ? (

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -638,9 +638,9 @@ describe('PiChatPanel sandbox shell', () => {
     )
 
     const title = await screen.findByText('What should we work on?')
-    const emptyState = title.closest('[data-boring-agent-part="empty-state"]')
-    const composer = emptyState?.querySelector('[data-boring-agent-part="composer-rail"]')
-    const suggestions = emptyState?.querySelector('[data-boring-agent-part="suggestion-grid"]')
+    const composer = document.querySelector('[data-boring-agent-part="composer-rail"]')
+    const suggestions = document.querySelector('[data-boring-agent-part="suggestion-grid"]')
+    const textarea = screen.getByLabelText('Agent prompt') as HTMLTextAreaElement
 
     expect(composer).toBeTruthy()
     expect(suggestions).toBeTruthy()
@@ -648,6 +648,24 @@ describe('PiChatPanel sandbox shell', () => {
     expect(composer!.compareDocumentPosition(suggestions!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(screen.queryByText('Ask a question, open a file from the workbench, or start from a template.')).toBeNull()
     expect(document.querySelectorAll('[data-boring-agent-part="composer-rail"]')).toHaveLength(1)
+
+    fireEvent.change(textarea, { target: { value: 'preserve this draft' } })
+    textarea.focus()
+    remote.setState(remoteState({
+      sessionId: 'pi-empty',
+      committedMessages: [{
+        id: 'user-1',
+        role: 'user',
+        status: 'done',
+        parts: [{ type: 'text', id: 'user-1:text', text: 'First message' }],
+      }],
+    }))
+
+    await screen.findByText('First message')
+    expect(document.querySelector('[data-boring-agent-part="composer-rail"]')).toBe(composer)
+    expect(screen.getByLabelText('Agent prompt')).toBe(textarea)
+    expect(textarea.value).toBe('preserve this draft')
+    expect(document.activeElement).toBe(textarea)
   })
 
   test('shows loading instead of empty suggestions before selected session state is available', async () => {

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -609,7 +609,7 @@ describe('PiChatPanel sandbox shell', () => {
       />,
     )
 
-    await screen.findByText('What are we building?')
+    await screen.findByText('What should we work on?')
 
     rerender(
       <PiChatPanel
@@ -621,7 +621,33 @@ describe('PiChatPanel sandbox shell', () => {
     )
 
     expect(screen.getByText(/Loading chat history/)).toBeTruthy()
-    expect(screen.queryByText('What are we building?')).toBeNull()
+    expect(screen.queryByText('What should we work on?')).toBeNull()
+  })
+
+  test('orders the empty hero as title, composer, then quick actions', async () => {
+    const remote = new FakeRemotePiSession(remoteState({ committedMessages: [], sessionId: 'pi-empty' }))
+
+    render(
+      <PiChatPanel
+        sessionId="pi-empty"
+        emptyPlacement="hero"
+        serverResourcesEnabled={false}
+        storageScope="scope-a"
+        createRemoteSession={remoteFactory(remote)}
+      />,
+    )
+
+    const title = await screen.findByText('What should we work on?')
+    const emptyState = title.closest('[data-boring-agent-part="empty-state"]')
+    const composer = emptyState?.querySelector('[data-boring-agent-part="composer-rail"]')
+    const suggestions = emptyState?.querySelector('[data-boring-agent-part="suggestion-grid"]')
+
+    expect(composer).toBeTruthy()
+    expect(suggestions).toBeTruthy()
+    expect(title.compareDocumentPosition(composer!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(composer!.compareDocumentPosition(suggestions!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(screen.queryByText('Ask a question, open a file from the workbench, or start from a template.')).toBeNull()
+    expect(document.querySelectorAll('[data-boring-agent-part="composer-rail"]')).toHaveLength(1)
   })
 
   test('shows loading instead of empty suggestions before selected session state is available', async () => {
@@ -642,7 +668,7 @@ describe('PiChatPanel sandbox shell', () => {
     )
 
     expect(await screen.findByText(/Loading chat history/)).toBeTruthy()
-    expect(screen.queryByText('What are we building?')).toBeNull()
+    expect(screen.queryByText('What should we work on?')).toBeNull()
   })
 
   test('keeps an external Pi session stable when equal request headers are recreated', async () => {
@@ -1024,8 +1050,10 @@ describe('PiChatPanel sandbox shell', () => {
     )
 
     const textarea = await screen.findByLabelText('Agent prompt')
-    expect(screen.getByRole('button', { name: /Current model:/ }).textContent).toContain('/model:')
-    expect(screen.getByRole('button', { name: 'Thinking level: Med' }).textContent).toContain('/thinking:')
+    expect(screen.getByRole('button', { name: /Current model:/ }).textContent).toContain('Model ·')
+    expect(screen.getByRole('button', { name: 'Thinking level: Med' }).textContent).toContain('Thinking ·')
+    expect(screen.getByRole('button', { name: 'Attach files' }).className).toContain('!h-10')
+    expect(document.querySelector('[data-boring-agent-part="composer-submit"]')?.className).toContain('h-8')
 
     fireEvent.change(textarea, { target: { value: '/mod' } })
     let commands = await screen.findByRole('listbox', { name: 'Commands' })

--- a/packages/agent/src/front/chat/components/ComposerAttachments.tsx
+++ b/packages/agent/src/front/chat/components/ComposerAttachments.tsx
@@ -24,11 +24,11 @@ export function AttachmentButton({ disabled, className }: { disabled?: boolean; 
       onClick={() => {
         if (!disabled) attachments.openFileDialog()
       }}
-      className={cn(composerActionClass, 'w-8', className)}
+      className={cn(composerActionClass, '!h-10 !w-10', className)}
       aria-label="Attach files"
       title={disabled ? 'Attachments are available when the composer is ready.' : 'Attach files'}
     >
-      <PaperclipIcon className="h-3.5 w-3.5" strokeWidth={1.75} />
+      <PaperclipIcon className="h-4 w-4" strokeWidth={1.75} />
     </IconButton>
   )
 }

--- a/packages/agent/src/front/chat/components/MessageTimeline.tsx
+++ b/packages/agent/src/front/chat/components/MessageTimeline.tsx
@@ -61,7 +61,7 @@ export const MessageTimeline = memo(({
         {isEmpty ? (
           <ConversationEmptyState
             data-boring-agent-part="chat-empty-state"
-            title={emptyState?.title ?? 'What are we building?'}
+            title={emptyState?.title ?? 'What should we work on?'}
             description={emptyState?.description ?? 'Send a prompt to start an assistant session.'}
             icon={emptyState?.icon}
           />

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -318,22 +318,26 @@ export function PiChatComposerSurface<
           </div>
         ) : null}
         {mentionState === null && slashQuery === null && modelPickerOpen ? (
-          <ModelPickerMenu
-            value={selectedModel}
-            onChange={onModelChange}
-            options={modelOptions}
-            disabled={isStreaming || modelControlled}
-            hideDefaultOption={hideDefaultModelOption}
-            onClose={() => onSetModelPickerOpen(false)}
-          />
+          <div className="mr-px mb-1 ml-[43px]">
+            <ModelPickerMenu
+              value={selectedModel}
+              onChange={onModelChange}
+              options={modelOptions}
+              disabled={isStreaming || modelControlled}
+              hideDefaultOption={hideDefaultModelOption}
+              onClose={() => onSetModelPickerOpen(false)}
+            />
+          </div>
         ) : null}
         {mentionState === null && slashQuery === null && thinkingPickerOpen ? (
-          <ThinkingPickerMenu
-            value={selectedThinking}
-            onChange={onThinkingChange}
-            disabled={isStreaming || thinkingControlled}
-            onClose={() => onSetThinkingPickerOpen(false)}
-          />
+          <div className="mr-px mb-1 ml-[43px]">
+            <ThinkingPickerMenu
+              value={selectedThinking}
+              onChange={onThinkingChange}
+              disabled={isStreaming || thinkingControlled}
+              onClose={() => onSetThinkingPickerOpen(false)}
+            />
+          </div>
         ) : null}
       </div>
       {composerContributions.map(({ id, Top }) => Top ? (

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -67,6 +67,7 @@ export interface PiChatComposerSurfaceProps<
   TComposerBlocker extends ComposerBlocker = ComposerBlocker,
 > {
   chrome: boolean
+  pickerPlacement?: 'above' | 'above-compact'
   isStreaming: boolean
   status: string
   disabled: boolean
@@ -129,6 +130,7 @@ export function PiChatComposerSurface<
   TComposerBlocker extends ComposerBlocker = ComposerBlocker,
 >({
   chrome,
+  pickerPlacement = 'above',
   isStreaming,
   status,
   disabled,
@@ -224,7 +226,12 @@ export function PiChatComposerSurface<
   }, [draft, resizeTextarea, textareaRef])
 
   return (
-    <div className={cn('relative z-20', chrome ? 'px-4 pb-4 pt-2 sm:px-6 sm:pb-5' : 'px-3 pb-2 pt-1')}>
+    <div className={cn(
+      'relative z-20',
+      chrome
+        ? 'pb-[calc(1rem+env(safe-area-inset-bottom))] pl-[calc(1rem+env(safe-area-inset-left))] pr-[calc(1rem+env(safe-area-inset-right))] pt-2 sm:pb-[calc(1.25rem+env(safe-area-inset-bottom))] sm:pl-[calc(1.5rem+env(safe-area-inset-left))] sm:pr-[calc(1.5rem+env(safe-area-inset-right))]'
+        : 'pb-[calc(0.5rem+env(safe-area-inset-bottom))] pl-[calc(0.75rem+env(safe-area-inset-left))] pr-[calc(0.75rem+env(safe-area-inset-right))] pt-1',
+    )}>
       <div
         data-boring-agent-part="chat-working-slot"
         className={cn(
@@ -280,8 +287,15 @@ export function PiChatComposerSurface<
           {attachmentNotice}
         </div>
       ) : null}
-      <div className={cn('mx-auto w-full', chrome ? 'max-w-3xl' : 'max-w-[680px]')}>
+      <div className={cn('@container group/composer relative mx-auto w-full', chrome ? 'max-w-3xl' : 'max-w-[680px]')}>
+        <div className={cn(
+          'absolute inset-x-0 z-30',
+          pickerPlacement === 'above-compact'
+            ? 'bottom-[calc(100%+4px)] [&_[cmdk-list]]:!max-h-[200px]'
+            : 'bottom-[calc(100%+4px)]',
+        )}>
         {mentionState ? (
+          <div className="mr-px ml-[43px]">
           <MentionPicker
             mention={mentionState}
             apiBaseUrl={apiBaseUrl}
@@ -291,14 +305,17 @@ export function PiChatComposerSurface<
             onSelect={onSelectMention}
             onDismiss={onDismissMention}
           />
+          </div>
         ) : null}
         {slashQuery !== null ? (
+          <div className="mr-px ml-[43px]">
           <SlashCommandPicker
             query={slashQuery}
             commands={commands}
             onSelect={onSelectSlashCommand}
             onDismiss={onDismissSlash}
           />
+          </div>
         ) : null}
         {mentionState === null && slashQuery === null && modelPickerOpen ? (
           <ModelPickerMenu
@@ -334,12 +351,12 @@ export function PiChatComposerSurface<
         data-composer-multiline="false"
         style={{ '--composer-input-group-height': `${COMPOSER_INPUT_GROUP_MIN_HEIGHT}px` } as CSSProperties}
         className={cn(
-          'relative mx-auto w-full overflow-visible rounded-[28px]',
+          'relative mx-auto w-full overflow-visible rounded-xl',
           chrome ? 'max-w-3xl bg-transparent shadow-[0_1px_2px_-1px_oklch(0_0_0/0.06),0_6px_18px_-12px_oklch(0_0_0/0.12),inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.7)] focus-within:shadow-[0_1px_3px_-1px_oklch(0_0_0/0.08),0_10px_28px_-14px_oklch(0_0_0/0.16),inset_0_0_0_1px_oklch(from_var(--accent)_l_c_h/0.45)]' : 'max-w-[680px] bg-transparent shadow-[inset_0_0_0_1px_oklch(from_var(--border)_l_c_h/0.7)] focus-within:shadow-[inset_0_0_0_1px_oklch(from_var(--accent)_l_c_h/0.45)]',
           'transition-shadow duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]',
           '[&_[data-slot=input-group]]:!h-auto [&_[data-slot=input-group]]:!min-h-[var(--composer-input-group-height)]',
           '[&_[data-slot=input-group]]:!flex-col [&_[data-slot=input-group]]:!items-stretch [&_[data-slot=input-group]]:!overflow-hidden',
-          '[&_[data-slot=input-group]]:!border-0 [&_[data-slot=input-group]]:!rounded-[28px]',
+          '[&_[data-slot=input-group]]:!border-0 [&_[data-slot=input-group]]:!rounded-xl',
           '[&_[data-slot=input-group]]:!bg-transparent [&_[data-slot=input-group]]:!shadow-none',
           '[&_[data-slot=input-group]]:dark:!bg-transparent [&_[data-slot=input-group]]:!ring-0',
           '[&_[data-slot=input-group]]:has-[:focus]:!ring-0',
@@ -392,8 +409,8 @@ export function PiChatComposerSurface<
               className={cn(
                 'min-w-0 flex-1 !min-h-10 !max-h-40 resize-none overflow-hidden border-0 bg-transparent shadow-none',
                 '[field-sizing:fixed]',
-                'px-2 py-2 text-[13px] leading-6',
-                'placeholder:text-muted-foreground/45',
+                'px-2 py-2 text-sm leading-6 text-foreground',
+                'placeholder:text-muted-foreground/60',
                 'focus-visible:ring-0 focus-visible:ring-offset-0',
               )}
             />
@@ -420,8 +437,7 @@ export function PiChatComposerSurface<
                   disabled={submitDisabled}
                   className={cn(
                     'h-8 w-8 shrink-0 rounded-full',
-                    'bg-foreground',
-                    'text-background',
+                    'bg-foreground text-background',
                     'transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
                     'hover:bg-foreground/90 hover:shadow-[0_0_0_3px_oklch(from_var(--foreground)_l_c_h/0.12)] hover:scale-[1.04]',
                     'active:scale-[0.93] active:brightness-95',
@@ -439,10 +455,11 @@ export function PiChatComposerSurface<
       <div
         data-boring-agent-part="composer-settings-row"
         className={cn(
-          'mx-auto mt-1.5 flex w-full items-center justify-center gap-1.5 text-[10.5px] text-muted-foreground/45',
+          'mx-auto mt-2 grid min-h-8 w-full grid-cols-[minmax(0,1fr)_auto] items-center text-xs text-muted-foreground',
           chrome ? 'max-w-3xl' : 'max-w-[680px]',
         )}
       >
+        <div className="flex min-w-0 items-center justify-center gap-1">
         <ModelSelectTrigger
           value={selectedModel}
           options={modelOptions}
@@ -472,8 +489,10 @@ export function PiChatComposerSurface<
             }}
           />
         ) : null}
+        </div>
       </div>
       )}
+      </div>
     </div>
   )
 }

--- a/packages/agent/src/front/chat/components/PiConversationSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiConversationSurface.tsx
@@ -28,7 +28,6 @@ const LOAD_OLDER_THRESHOLD_PX = 320
 export interface PiConversationSurfaceProps {
   chrome: boolean
   emptyHero: boolean
-  emptyHeroComposer?: ReactNode
   messages: BoringChatMessage[]
   emptyStateHydrating: boolean
   emptyState?: {
@@ -58,7 +57,6 @@ export interface PiConversationSurfaceProps {
 export function PiConversationSurface({
   chrome,
   emptyHero,
-  emptyHeroComposer,
   messages,
   emptyStateHydrating,
   emptyState,
@@ -96,7 +94,7 @@ export function PiConversationSurface({
   return (
     <Conversation
       className={emptyHero
-        ? 'max-h-[45vh] flex-none !overflow-visible [&>div]:!overflow-visible [&>div>div]:!overflow-visible'
+        ? cn('flex-none', runtimeNotices.length > 0 ? 'max-h-[45vh]' : 'max-h-[20vh]')
         : 'flex-1'}
       aria-label="Agent conversation"
       aria-live="polite"
@@ -118,9 +116,8 @@ export function PiConversationSurface({
             eyebrow={emptyState?.eyebrow}
             title={emptyState?.title}
             description={emptyState?.description}
-            footer={emptyState?.footer}
-            suggestions={suggestions}
-            composer={emptyHeroComposer}
+            footer={emptyHero ? undefined : emptyState?.footer}
+            suggestions={emptyHero ? [] : suggestions}
             hero={emptyHero}
             onSelect={(suggestion) => {
               const text = suggestion.prompt ?? suggestion.label

--- a/packages/agent/src/front/chat/components/PiConversationSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiConversationSurface.tsx
@@ -28,6 +28,7 @@ const LOAD_OLDER_THRESHOLD_PX = 320
 export interface PiConversationSurfaceProps {
   chrome: boolean
   emptyHero: boolean
+  emptyHeroComposer?: ReactNode
   messages: BoringChatMessage[]
   emptyStateHydrating: boolean
   emptyState?: {
@@ -57,6 +58,7 @@ export interface PiConversationSurfaceProps {
 export function PiConversationSurface({
   chrome,
   emptyHero,
+  emptyHeroComposer,
   messages,
   emptyStateHydrating,
   emptyState,
@@ -93,7 +95,9 @@ export function PiConversationSurface({
 
   return (
     <Conversation
-      className={emptyHero ? 'max-h-[45vh] flex-none' : 'flex-1'}
+      className={emptyHero
+        ? 'max-h-[45vh] flex-none !overflow-visible [&>div]:!overflow-visible [&>div>div]:!overflow-visible'
+        : 'flex-1'}
       aria-label="Agent conversation"
       aria-live="polite"
       onScrollToBottomReady={onScrollToBottomReady}
@@ -116,7 +120,8 @@ export function PiConversationSurface({
             description={emptyState?.description}
             footer={emptyState?.footer}
             suggestions={suggestions}
-            className={emptyHero ? 'items-center text-center [&>p]:mx-auto' : undefined}
+            composer={emptyHeroComposer}
+            hero={emptyHero}
             onSelect={(suggestion) => {
               const text = suggestion.prompt ?? suggestion.label
               if (!text.trim()) return

--- a/packages/agent/src/front/chatPanelComposerControls.tsx
+++ b/packages/agent/src/front/chatPanelComposerControls.tsx
@@ -27,9 +27,9 @@ import {
 // wraps this so we never drift.
 export const composerActionClass = cn(
   "inline-flex h-8 items-center justify-center gap-1.5 rounded-[var(--radius-md)] border-0 bg-transparent",
-  "text-muted-foreground shadow-none transition",
+  "text-muted-foreground shadow-none transition-colors motion-reduce:transition-none",
   "hover:bg-muted/60 hover:text-foreground",
-  "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+  "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-popover",
   "disabled:pointer-events-none disabled:opacity-50",
 )
 
@@ -41,10 +41,10 @@ const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string> = {
 }
 
 const THINKING_LEVEL_STATUS_LABELS: Record<ThinkingLevel, string> = {
-  off: 'off',
-  low: 'low',
-  medium: 'medium',
-  high: 'high',
+  off: 'Off',
+  low: 'Low',
+  medium: 'Medium',
+  high: 'High',
 }
 
 const THINKING_LEVEL_DETAILS: Record<ThinkingLevel, string> = {
@@ -56,7 +56,7 @@ const THINKING_LEVEL_DETAILS: Record<ThinkingLevel, string> = {
 
 const selectorTriggerClass = cn(
   composerActionClass,
-  'h-7 rounded-lg border border-border/60 bg-transparent px-2 text-[12px] font-medium text-muted-foreground',
+  'h-8 rounded-lg border border-border/60 bg-transparent px-2 text-xs font-medium text-muted-foreground',
   'hover:border-border/80 hover:bg-muted/55 hover:text-foreground',
 )
 
@@ -66,13 +66,13 @@ const selectorContentClass = cn(
 )
 
 const composerPickerMenuClass = cn(
-  'mb-1 w-full overflow-hidden rounded-lg border border-border/60',
-  'bg-[color:var(--popover)] text-[color:var(--popover-foreground)] shadow-lg',
+  'w-full overflow-hidden rounded-xl border border-border',
+  'bg-[color:var(--popover)] text-[color:var(--popover-foreground)] shadow-xl',
 )
 
 function selectorItemClass(selected: boolean) {
   return cn(
-    'flex items-center gap-2 rounded-md px-2 py-1.5 text-[13px]',
+    'flex min-h-10 items-center gap-2 rounded-md px-2.5 py-2 text-sm text-muted-foreground',
     'data-[selected=true]:bg-[color:oklch(from_var(--accent)_l_c_h/0.15)] data-[selected=true]:text-foreground',
     selected && 'bg-foreground/[0.06] text-foreground',
   )
@@ -139,11 +139,12 @@ function modelTriggerLabel(value: ModelSelection | null, options: AvailableModel
     ? options.find((m) => m.provider === value.provider && m.id === value.id)
     : undefined
   const rawTriggerLabel = current?.label ?? value?.id
-  return value
+  const label = value
     ? rawTriggerLabel && current?.label && current.label !== value.id && /[A-Z]/.test(current.label)
       ? current.label
       : displayModelLabel(rawTriggerLabel ?? value.id)
     : emptyLabel
+  return value ? label.replace(/\s+\([^)]*\)\s*$/, '') : label
 }
 
 function modelMenuOptions(_value: ModelSelection | null, options: AvailableModel[]): AvailableModel[] {
@@ -197,7 +198,7 @@ export const ModelSelectTrigger = forwardRef<HTMLButtonElement, ModelSelectTrigg
       onClick={onClick}
       className={cn(
         trigger === 'slash'
-          ? 'max-w-[min(52vw,260px)] cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap rounded-[var(--radius-md)] px-1.5 py-0.5 transition-colors hover:bg-foreground/[0.045] hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/20 disabled:pointer-events-none disabled:opacity-50'
+          ? 'h-8 max-w-[min(68vw,420px)] cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap rounded-[var(--radius-md)] px-2 text-xs transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-popover disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none'
           : selectorTriggerClass,
         trigger === 'slash' ? 'w-auto' : 'w-auto max-w-[min(52vw,260px)] gap-1',
         open && (trigger === 'slash' ? 'bg-muted/45' : 'border-border/80 bg-muted/55 text-foreground'),
@@ -207,8 +208,9 @@ export const ModelSelectTrigger = forwardRef<HTMLButtonElement, ModelSelectTrigg
     >
       {trigger === 'slash' ? (
         <>
-          <span className="text-muted-foreground">/model: </span>
-          <span className="text-foreground">{triggerDisplay}</span>
+          <span className="text-muted-foreground">Model · </span>
+          <span className="min-w-0 truncate text-foreground">{triggerLabel}</span>
+          {value ? <span className="shrink-0 text-muted-foreground"> · {displayProviderLabel(value.provider)}</span> : null}
         </>
       ) : (
         <>
@@ -290,12 +292,12 @@ export function ModelPickerMenu({
             <CommandInput
               placeholder="Search models…"
               autoFocus
-              className="h-8 w-full border-0 bg-transparent text-[13px] outline-none focus:ring-0"
+              className="h-8 w-full border-0 bg-transparent text-sm outline-none focus:ring-0"
             />
           </div>
         )}
         <CommandList className="max-h-[300px] p-0.5">
-          <CommandEmpty className="py-4 text-center text-[13px] text-muted-foreground">
+          <CommandEmpty className="py-4 text-center text-sm text-muted-foreground">
             No models found
           </CommandEmpty>
           {!hideDefaultOption ? (
@@ -316,7 +318,7 @@ export function ModelPickerMenu({
                   )}
                 />
                 <span className="truncate">Default model</span>
-                <span className="ml-auto shrink-0 text-[10px] text-muted-foreground/60">auto</span>
+                <span className="ml-auto shrink-0 text-xs text-muted-foreground">Auto</span>
               </CommandItem>
             </CommandGroup>
           ) : null}
@@ -324,7 +326,7 @@ export function ModelPickerMenu({
             <CommandGroup
               key={provider}
               heading={displayProviderLabel(provider)}
-              className="[&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-[10px] [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.08em] [&_[cmdk-group-heading]]:text-muted-foreground/60"
+              className="[&_[cmdk-group-heading]]:px-2.5 [&_[cmdk-group-heading]]:py-2 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-semibold [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-[0.08em] [&_[cmdk-group-heading]]:text-muted-foreground"
             >
               {list.map((m) => {
                 const key = encodeModelKey(m)
@@ -348,7 +350,7 @@ export function ModelPickerMenu({
                       )}
                     />
                     <span className="min-w-0 flex-1 truncate whitespace-nowrap">{label}</span>
-                    <span className="ml-auto max-w-[45%] shrink-0 truncate whitespace-nowrap text-right text-[10px] text-muted-foreground/60">{m.id}</span>
+                    <span className="ml-auto max-w-[45%] shrink-0 truncate whitespace-nowrap text-right text-xs text-muted-foreground">{m.id}</span>
                   </CommandItem>
                 )
               })}
@@ -527,7 +529,7 @@ export const ThinkingSelectTrigger = forwardRef<HTMLButtonElement, ThinkingSelec
       disabled={disabled}
       className={cn(
         trigger === 'slash'
-          ? 'cursor-pointer rounded-[var(--radius-md)] px-1.5 py-0.5 transition-colors hover:bg-foreground/[0.045] hover:text-foreground/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-foreground/20 disabled:pointer-events-none disabled:opacity-50'
+          ? 'h-8 cursor-pointer rounded-[var(--radius-md)] px-2 text-xs transition-colors hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-popover disabled:pointer-events-none disabled:opacity-50 motion-reduce:transition-none'
           : selectorTriggerClass,
         trigger === 'button' && 'gap-1.5',
         trigger === 'button' && value !== 'off' && !open && 'border-[color:oklch(from_var(--accent)_l_c_h/0.35)] bg-[color:oklch(from_var(--accent)_l_c_h/0.08)] text-foreground',
@@ -543,7 +545,7 @@ export const ThinkingSelectTrigger = forwardRef<HTMLButtonElement, ThinkingSelec
       {trigger === 'button' ? <ThinkingLevelGlyph level={value} /> : null}
       {trigger === 'slash' ? (
         <>
-          <span className="text-muted-foreground">/thinking: </span>
+          <span className="text-muted-foreground">Thinking · </span>
           <span className="text-foreground">{THINKING_LEVEL_STATUS_LABELS[value]}</span>
         </>
       ) : (
@@ -628,7 +630,7 @@ export function ThinkingPickerMenu({
               />
               <ThinkingLevelGlyph level={level} />
               <span className="font-medium">{THINKING_LEVEL_LABELS[level]}</span>
-              <span className="ml-auto text-[11px] text-muted-foreground/65">
+              <span className="ml-auto text-xs text-muted-foreground">
                 {THINKING_LEVEL_DETAILS[level]}
               </span>
             </CommandItem>


### PR DESCRIPTION
## Summary

Ports the approved composer direction from the Claude prototype while preserving the original palette and current runtime/contribution contracts.

## Changed

- empty chat hierarchy: “What should we work on?” → composer → quick actions
- stable composer mount preserves focus, attachments, draft, and contribution slots across first send
- compact original-style send button
- clearer model/thinking labels and picker density
- aligned slash/mention/model/thinking picker slot
- upward empty-state picker with bounded scrolling so it remains visible
- mobile safe-area-aware composer spacing
- removed the focus-triggered keyboard hint

## Explicit exclusions

- no palette/foundation changes
- no runtime-notice relocation
- no submit/hydrating semantic changes
- no transcript/top-bar/navigation changes

## Proof

- focused unit tests: 89 passed
- composer Playwright spec: 7 passed
- agent typecheck: passed
- agent build: passed
- agent playground: `http://100.68.199.114:5204/`
- workspace playground: `http://100.68.199.114:5206/`
- owner approved final visual behavior and interactive send flow

## Review

- Final standards/spec review: approved, no blocker/high findings after fixes
- Composer contribution APIs preserved
- Stable composer identity verified
- Runtime notices retain scrollable room in empty hero

## Risk / rollback

Frontend layout/presentation change. Revert this PR to restore the prior docked empty composer and legacy labels.

Closes #1033
