### PR TITLE
chore(release): bump packages to 0.1.95

### DIFF
--- a/docs/issues/391/runtime-refactor/golden-path.json
+++ b/docs/issues/391/runtime-refactor/golden-path.json
@@ -1,10 +1,10 @@
 {
-  "version": "0.1.94",
-  "date": "2026-08-01T07:39:39.529Z",
+  "version": "0.1.95",
+  "date": "2026-08-03T14:41:03.421Z",
   "seconds": {
-    "compileAgentDirectory": 0.015844,
-    "resolveAgentDeployment": 0.002842,
-    "total": 0.018702
+    "compileAgentDirectory": 0.014508,
+    "resolveAgentDeployment": 0.002608,
+    "total": 0.01713
   },
   "stagesCovered": [
     "A1 compileAgentDirectory (#624)",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "boring-ui-v2",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "scripts": {
     "build": "pnpm -r --workspace-concurrency=4 run build",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-agent",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "license": "MIT",
   "description": "Pane-embeddable coding agent. Ships direct/local/vercel-sandbox execution modes behind one interface.",

--- a/packages/boring-bash/package.json
+++ b/packages/boring-bash/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-bash",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "license": "MIT",
   "description": "Filesystem and shell binding contracts for Boring runtimes.",

--- a/packages/boring-sandbox/package.json
+++ b/packages/boring-sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-sandbox",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "license": "MIT",
   "description": "Sandbox provider contracts and implementations for Boring runtimes.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-ui-cli",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "description": "Turn an agent into an app",
   "license": "MIT",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-core",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "license": "MIT",
   "description": "Foundation package for boring-ui-v2 apps: DB, auth, config, HTTP app factory, and frontend app shell.",

--- a/packages/plugin-cli/package.json
+++ b/packages/plugin-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-ui-plugin-cli",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "description": "Slim boring-ui plugin authoring CLI for workspace runtimes.",
   "license": "MIT",
   "type": "module",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-ui-kit",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "license": "MIT",
   "description": "Shared shadcn-style UI primitives for Boring packages and app-generated panes.",

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-workspace",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "license": "MIT",
   "description": "Workspace UI, plugin, and bridge package for composing chat, files, catalogs, editors, and app-specific panes.",

--- a/plugins/ask-user/package.json
+++ b/plugins/ask-user/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-ask-user",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/bi-dashboard/package.json
+++ b/plugins/bi-dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-bi-dashboard",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/boring-automation/package.json
+++ b/plugins/boring-automation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-automation",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/boring-governance/package.json
+++ b/plugins/boring-governance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-governance",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/boring-mcp/package.json
+++ b/plugins/boring-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-mcp",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/data-bridge/package.json
+++ b/plugins/data-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-data-bridge",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/data-catalog/package.json
+++ b/plugins/data-catalog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-data-catalog",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/data-explorer/package.json
+++ b/plugins/data-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-data-explorer",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/deck/package.json
+++ b/plugins/deck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-deck",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "license": "MIT",
   "description": "Front-only markdown deck plugin scaffold for Boring workspace.",

--- a/plugins/diagram/package.json
+++ b/plugins/diagram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-diagram",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/generated-pane/package.json
+++ b/plugins/generated-pane/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-generated-pane",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/live-transcription/package.json
+++ b/plugins/live-transcription/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-transcription",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",

--- a/plugins/tasks/package.json
+++ b/plugins/tasks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hachej/boring-tasks",
-  "version": "0.1.94",
+  "version": "0.1.95",
   "type": "module",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump all publishable packages to `0.1.95`
- include `@hachej/boring-transcription` in the aligned release cohort
- refresh golden-path timing evidence

## Validation
- `node scripts/version.mjs --check`
- `pnpm golden-path:timing`
- `pnpm check:golden-path`
- `pnpm audit:publish-manifests`
- `node scripts/check-release-staging.mjs`
- `git diff --cached --check`