### PR TITLE
#1032 Refine per-chat pane headers

### DIFF
--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createDeckPlugin } from "@hachej/boring-deck/front"
 import type { DeckWidgetDefinition } from "@hachej/boring-deck/shared"
 import { FileTreePane, WorkspaceProvider } from "@hachej/boring-workspace"
@@ -153,23 +153,34 @@ export function WorkspaceShell() {
   const [projectName, setProjectName] = useState("Workspace")
   const [workspaceId, setWorkspaceId] = useState("Workspace")
   const [metaLoaded, setMetaLoaded] = useState(showcase || fullPage)
-
-  const sessions = useMemo(
-    () =>
-      showcase
-        ? [
-            {
-              id: SHOWCASE_SESSION_ID,
-              title: "Showcase conversation",
-              updatedAt: Date.now(),
-            },
-          ]
-        : undefined,
-    [showcase],
-  )
+  const [showcaseActiveSessionId, setShowcaseActiveSessionId] = useState(SHOWCASE_SESSION_ID)
+  const [showcaseSessions, setShowcaseSessions] = useState(() => [
+    {
+      id: SHOWCASE_SESSION_ID,
+      title: "Showcase conversation",
+      updatedAt: Date.now(),
+    },
+  ])
+  const sessions = showcase ? showcaseSessions : undefined
+  const showcaseSessionSequence = useRef(0)
+  const createShowcaseSession = useCallback(() => {
+    showcaseSessionSequence.current += 1
+    const session = {
+      id: `showcase-${Date.now()}-${showcaseSessionSequence.current}`,
+      title: "New chat",
+      updatedAt: Date.now(),
+    }
+    seedShowcase(session.id)
+    setShowcaseSessions((current) => [...current, session])
+    setShowcaseActiveSessionId(session.id)
+    return session
+  }, [])
   const handleActiveSessionIdChange = useCallback(
     (sessionId: string | null) => {
-      if (showcase && sessionId) seedShowcase(sessionId)
+      if (showcase && sessionId) {
+        seedShowcase(sessionId)
+        setShowcaseActiveSessionId(sessionId)
+      }
     },
     [showcase],
   )
@@ -223,8 +234,10 @@ export function WorkspaceShell() {
       fullPageBasePath="/full-page"
       provisionWorkspace={!showcase}
       sessions={sessions}
-      activeSessionId={showcase ? SHOWCASE_SESSION_ID : undefined}
+      activeSessionId={showcase ? showcaseActiveSessionId : undefined}
       onActiveSessionIdChange={handleActiveSessionIdChange}
+      onSwitchSession={showcase ? handleActiveSessionIdChange : undefined}
+      onCreateSession={showcase ? createShowcaseSession : undefined}
       plugins={activeWorkspacePlugins}
       chatParams={{ thinkingControl: true }}
     />

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -60,8 +60,10 @@ import {
 interface PendingCreatePane {
   afterId: string
   knownIds: Set<string>
+  workspaceId: string
   placementDirection?: ChatPaneSplitDirection
   createdId?: string
+  mode: "insert" | "replace"
 }
 
 export interface WorkspaceAgentSession {
@@ -644,6 +646,8 @@ export function WorkspaceAgentFront<
     (shellPersistenceEnabled ? readStoredChatPaneState(chatPaneStorageKey, workspaceId) : null)
       ?? { workspaceId, ids: [], activeId: null },
   )
+  const chatPaneStateRef = useRef(chatPaneState)
+  chatPaneStateRef.current = chatPaneState
   const [pendingChatPanePlacement, setPendingChatPanePlacement] = useState<ChatPanePendingPlacement | null>(null)
   const [chatPaneSplitPending, setChatPaneSplitPending] = useState(false)
   const consumePendingChatPanePlacement = useCallback((paneId: string) => {
@@ -1235,7 +1239,20 @@ export function WorkspaceAgentFront<
   const sessionListAuthoritative = !sessionApi?.hasMore && !remoteSessionsPending
   useEffect(() => {
     if (remoteSessionsTransitioning) return
-    const pendingCreatePane = pendingCreatePaneRef.current
+    const ownedPendingCreatePane = pendingCreatePaneRef.current?.workspaceId === workspaceId
+      ? pendingCreatePaneRef.current
+      : null
+    const pendingPaneState = chatPaneStateRef.current
+    const pendingPaneIds = pendingPaneState.workspaceId === workspaceId && pendingPaneState.ids.length > 0
+      ? pendingPaneState.ids
+      : [chatSessionKey]
+    const pendingCreatePane = ownedPendingCreatePane && pendingPaneIds.includes(ownedPendingCreatePane.afterId)
+      ? ownedPendingCreatePane
+      : null
+    if (ownedPendingCreatePane && !pendingCreatePane && pendingCreatePaneRef.current === ownedPendingCreatePane) {
+      pendingCreatePaneRef.current = null
+      if (ownedPendingCreatePane.placementDirection) setChatPaneSplitPending(false)
+    }
     const sessionKeys = new Set(resolvedSessions.map(workspaceSessionKeyFor))
     for (const key of optimisticCreatedPaneKeysRef.current) {
       if (sessionKeys.has(key)) optimisticCreatedPaneKeysRef.current.delete(key)
@@ -1293,13 +1310,17 @@ export function WorkspaceAgentFront<
       const ids = prunedIds.length > 0 ? prunedIds : [resolvedDesiredSessionId]
       const activeId = current.activeId && ids.includes(current.activeId) ? current.activeId : ids[0] ?? resolvedDesiredSessionId
       const nextIds = pendingCreatedId
-        ? insertPaneAfter(ids, pendingCreatePane?.afterId, pendingCreatedId)
+        ? pendingCreatePane?.mode === "replace"
+          ? replaceActivePane(ids, pendingCreatePane.afterId, pendingCreatedId)
+          : insertPaneAfter(ids, pendingCreatePane?.afterId, pendingCreatedId)
         : resolvedDesiredSessionId === activeId || ids.includes(resolvedDesiredSessionId)
           ? ids
           : replaceActivePane(ids, activeId, resolvedDesiredSessionId)
-      const nextActiveId = nextIds.includes(resolvedDesiredSessionId)
-        ? resolvedDesiredSessionId
-        : nextIds[0] ?? resolvedDesiredSessionId
+      const nextActiveId = pendingCreatedId && nextIds.includes(pendingCreatedId)
+        ? pendingCreatedId
+        : nextIds.includes(resolvedDesiredSessionId)
+          ? resolvedDesiredSessionId
+          : nextIds[0] ?? resolvedDesiredSessionId
       if (
         previous.workspaceId === workspaceId
         && previous.activeId === nextActiveId
@@ -1411,53 +1432,64 @@ export function WorkspaceAgentFront<
     return nextAgentTypeId ? rawSwitch(nextSessionId, nextAgentTypeId) : rawSwitch(nextSessionId)
   }, [chatPaneState, chatSessionKey, rawSwitch, workspaceId])
 
-  const closeChatPane = useCallback((sessionKey: string) => {
-    const current = chatPaneState.workspaceId === workspaceId
-      ? chatPaneState
-      : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
-    if (current.ids.length <= 1) return
-    const closingIndex = current.ids.indexOf(sessionKey)
-    if (closingIndex < 0) return
-    const nextIds = current.ids.filter((id) => id !== sessionKey)
-    const nextActiveId = current.activeId === sessionKey
-      ? nextIds[Math.max(0, closingIndex - 1)] ?? nextIds[0] ?? null
-      : current.activeId
-    setChatPaneState({ workspaceId, ids: nextIds, activeId: nextActiveId })
-    if (nextActiveId && current.activeId === sessionKey) {
-      const next = workspaceSessionRefFromKey(nextActiveId)
-      if (next.agentTypeId) rawSwitch(next.sessionId, next.agentTypeId)
-      else rawSwitch(next.sessionId)
-    }
-  }, [chatPaneState, chatSessionKey, rawSwitch, workspaceId])
-
-  const createChatSession = useCallback(() => {
-    const pendingCreatePane = {
-      afterId: activeChatPaneId,
+  const createChatPaneTransaction = useCallback((
+    afterId: string,
+    mode: "insert" | "replace",
+    placementDirection?: ChatPaneSplitDirection,
+  ) => {
+    if (pendingCreatePaneRef.current) return
+    const pendingCreatePane: PendingCreatePane = {
+      afterId,
       knownIds: new Set(resolvedSessions.map(workspaceSessionKeyFor)),
+      workspaceId,
+      mode,
+      placementDirection,
     }
     pendingCreatePaneRef.current = pendingCreatePane
+    if (placementDirection) setChatPaneSplitPending(true)
+
+    const settleIfOwner = () => {
+      if (pendingCreatePaneRef.current !== pendingCreatePane) return false
+      pendingCreatePaneRef.current = null
+      if (placementDirection) setChatPaneSplitPending(false)
+      return true
+    }
+
     const created = resolvedCreate()
     void Promise.resolve(created).then((session) => {
       const id = createdSessionId(session)
+      // Some session providers signal creation through a later sessions update.
+      // Keep the transaction owned until the reconciliation effect observes it.
       if (!id) return
+      if (pendingCreatePaneRef.current !== pendingCreatePane) return
+
+      if (chatPaneStateRef.current.workspaceId !== pendingCreatePane.workspaceId) {
+        settleIfOwner()
+        return
+      }
+      const current = chatPaneStateRef.current
+      const ids = current.ids.length > 0 ? current.ids : [chatSessionKey]
+      if (!ids.includes(afterId)) {
+        settleIfOwner()
+        return
+      }
+
       const createdAgentTypeId = typeof (session as { agentTypeId?: unknown } | null)?.agentTypeId === "string"
         ? (session as { agentTypeId: string }).agentTypeId
         : agentTypeId
       const createdKey = workspaceSessionKey(id, createdAgentTypeId)
+      const nextIds = mode === "replace"
+        ? replaceActivePane(ids, afterId, createdKey)
+        : insertPaneAfter(ids, afterId, createdKey)
+      const nextState = { workspaceId, ids: nextIds, activeId: createdKey }
+
+      if (!settleIfOwner()) return
       optimisticCreatedPaneKeysRef.current.add(createdKey)
-      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
-      setChatPaneState((previous) => {
-        const current = previous.workspaceId === workspaceId
-          ? previous
-          : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
-        const ids = current.ids.length > 0 ? current.ids : [chatSessionKey]
-        const activeId = current.activeId ?? ids[0] ?? chatSessionKey
-        return {
-          workspaceId,
-          ids: replaceActivePane(ids, activeId, createdKey),
-          activeId: createdKey,
-        }
-      })
+      chatPaneStateRef.current = nextState
+      setChatPaneState(nextState)
+      if (placementDirection) {
+        setPendingChatPanePlacement({ paneId: createdKey, referencePaneId: afterId, direction: placementDirection })
+      }
       // The remote session API's create() already selects/persists the new
       // session. Calling switch() immediately after create races against its
       // stale sessionsRef and can snap back to the previous session.
@@ -1467,59 +1499,53 @@ export function WorkspaceAgentFront<
       }
       scheduleActiveAgentComposerFocus()
     }).catch(() => {
-      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
-      // Creation errors are surfaced by the session API/chat layer; the left
-      // action should not leave stale optimistic panes behind.
-    })
-    return created
-  }, [activeChatPaneId, agentTypeId, chatSessionKey, rawSwitch, resolvedCreate, resolvedSessions, sessionApi, workspaceId])
-
-  const createChatPaneAfter = useCallback((afterId: string, placementDirection?: ChatPaneSplitDirection) => {
-    if (pendingCreatePaneRef.current) return
-    setChatPaneSplitPending(true)
-    const pendingCreatePane = {
-      afterId,
-      placementDirection,
-      knownIds: new Set(resolvedSessions.map(workspaceSessionKeyFor)),
-    }
-    pendingCreatePaneRef.current = pendingCreatePane
-    const created = resolvedCreate()
-    void Promise.resolve(created).then((session) => {
-      const id = createdSessionId(session)
-      if (!id) return
-      const createdAgentTypeId = typeof (session as { agentTypeId?: unknown } | null)?.agentTypeId === "string"
-        ? (session as { agentTypeId: string }).agentTypeId
-        : agentTypeId
-      const createdKey = workspaceSessionKey(id, createdAgentTypeId)
-      optimisticCreatedPaneKeysRef.current.add(createdKey)
-      if (pendingCreatePaneRef.current === pendingCreatePane) {
-        pendingCreatePaneRef.current = null
-        if (placementDirection) {
-          setPendingChatPanePlacement({ paneId: createdKey, referencePaneId: afterId, direction: placementDirection })
-        }
-        setChatPaneSplitPending(false)
-      }
-      setChatPaneState((previous) => {
-        const current = previous.workspaceId === workspaceId
-          ? previous
-          : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
-        return {
-          workspaceId,
-          ids: insertPaneAfter(current.ids, afterId, createdKey),
-          activeId: createdKey,
-        }
-      })
-      if (!sessionApi) {
-        if (createdAgentTypeId) rawSwitch(id, createdAgentTypeId)
-        else rawSwitch(id)
-      }
-      scheduleActiveAgentComposerFocus()
-    }).catch(() => {
-      if (pendingCreatePaneRef.current === pendingCreatePane) pendingCreatePaneRef.current = null
-      setChatPaneSplitPending(false)
+      settleIfOwner()
+      // Creation errors are surfaced by the session API/chat layer; the pane
+      // transaction only owns clearing its pending state.
     })
     return created
   }, [agentTypeId, chatSessionKey, rawSwitch, resolvedCreate, resolvedSessions, sessionApi, workspaceId])
+
+  useEffect(() => {
+    const pending = pendingCreatePaneRef.current
+    if (!pending || pending.workspaceId === workspaceId) return
+    pendingCreatePaneRef.current = null
+    if (pending.placementDirection) setChatPaneSplitPending(false)
+  }, [workspaceId])
+
+  const createChatSession = useCallback(() => (
+    createChatPaneTransaction(activeChatPaneId, "replace")
+  ), [activeChatPaneId, createChatPaneTransaction])
+
+  const closeChatPane = useCallback((sessionKey: string) => {
+    if (pendingCreatePaneRef.current) return
+    const current = chatPaneStateRef.current.workspaceId === workspaceId
+      ? chatPaneStateRef.current
+      : { workspaceId, ids: [chatSessionKey], activeId: chatSessionKey }
+    const ids = current.ids.length > 0 ? current.ids : [chatSessionKey]
+    const closingIndex = ids.indexOf(sessionKey)
+    if (closingIndex < 0) return
+    if (ids.length === 1) {
+      createChatPaneTransaction(sessionKey, "replace")
+      return
+    }
+    const nextIds = ids.filter((id) => id !== sessionKey)
+    const nextActiveId = current.activeId === sessionKey
+      ? nextIds[Math.max(0, closingIndex - 1)] ?? nextIds[0] ?? null
+      : current.activeId
+    const nextState = { workspaceId, ids: nextIds, activeId: nextActiveId }
+    chatPaneStateRef.current = nextState
+    setChatPaneState(nextState)
+    if (nextActiveId && current.activeId === sessionKey) {
+      const next = workspaceSessionRefFromKey(nextActiveId)
+      if (next.agentTypeId) rawSwitch(next.sessionId, next.agentTypeId)
+      else rawSwitch(next.sessionId)
+    }
+  }, [chatSessionKey, createChatPaneTransaction, rawSwitch, workspaceId])
+
+  const createChatPaneAfter = useCallback((afterId: string, placementDirection?: ChatPaneSplitDirection) => (
+    createChatPaneTransaction(afterId, "insert", placementDirection)
+  ), [createChatPaneTransaction])
 
   const deleteSessionAndPane = useCallback((sessionId: string, sessionAgentTypeId?: string) => {
     const sessionKey = workspaceSessionKey(sessionId, sessionAgentTypeId)

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -325,6 +325,44 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.getByText("First session")).toBeInTheDocument()
   })
 
+  it("replaces the sole closed chat pane with a fresh New chat pane", async () => {
+    const user = userEvent.setup()
+    const createSession = vi.fn()
+
+    function Harness() {
+      const [sessions, setSessions] = useState([
+        { id: "s1", title: "First session", updatedAt: Date.now() },
+      ])
+      const [activeSessionId, setActiveSessionId] = useState("s1")
+      return (
+        <WorkspaceAgentFront
+          workspaceId="singleton-close"
+          chatPanel={SessionIdChatPanel}
+          sessions={sessions}
+          activeSessionId={activeSessionId}
+          onSwitchSession={setActiveSessionId}
+          onCreateSession={() => {
+            createSession()
+            const session = { id: "fresh", title: "New chat", updatedAt: Date.now() }
+            setSessions((current) => [...current, session])
+            setActiveSessionId(session.id)
+            return session
+          }}
+          persistenceEnabled={false}
+        />
+      )
+    }
+
+    render(<Harness />)
+    expect(visibleChatSessionIds()).toEqual(["s1"])
+
+    await user.click(screen.getByLabelText("Close First session pane"))
+
+    await waitFor(() => expect(visibleChatSessionIds()).toEqual(["fresh"]))
+    expect(createSession).toHaveBeenCalledOnce()
+    expect(screen.getByLabelText("Close New chat pane")).toBeInTheDocument()
+  })
+
   it("keeps colliding addressed sessions distinct through pane activation and deletion", async () => {
     const user = userEvent.setup()
     const switched: Array<[string, string | undefined]> = []

--- a/packages/workspace/src/front/dock/dockview-overrides.css
+++ b/packages/workspace/src/front/dock/dockview-overrides.css
@@ -152,6 +152,46 @@
   opacity: 0.7;
 }
 
+/* Chat headers are a single, calm session strip rather than workbench tabs. */
+.dv-chat-stage {
+  --dv-tabs-and-actions-container-height: 44px;
+}
+
+.dv-chat-stage .dv-tabs-and-actions-container,
+.dv-chat-stage .tabs-and-actions-container {
+  height: 44px !important;
+  padding: 0 8px 0 0;
+  align-items: center;
+  gap: 8px;
+  background: oklch(from var(--muted) l c h / 0.22) !important;
+  border-bottom: 1px solid oklch(from var(--border) l c h / 0.55);
+}
+
+.dv-chat-stage .dv-tabs-container,
+.dv-chat-stage .tab-container {
+  align-items: stretch;
+}
+
+.dv-chat-stage .dv-tab,
+.dv-chat-stage .tab,
+.dv-chat-stage .dv-tab.dv-active-tab,
+.dv-chat-stage .tab.active-tab {
+  height: 44px;
+  min-width: 0;
+  max-width: min(420px, 55vw);
+  margin: 0;
+  align-self: stretch;
+  color: var(--foreground) !important;
+  background: transparent !important;
+  border: 0;
+  border-radius: 0;
+}
+
+.dv-chat-stage .dv-tab::before,
+.dv-chat-stage .tab::before {
+  display: none;
+}
+
 /* Sash (resize handle)
    Dockview's default 4px grab zone is easy to miss. Keep the visible divider
    subtle, but expand the pointer target to 12px so pane resizing is forgiving. */

--- a/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
@@ -19,9 +19,8 @@ import "dockview-react/dist/styles/dockview.css"
 import "../dock/dockview-overrides.css"
 import "./chat-pane-stage.css"
 import { GripVertical, X } from "lucide-react"
-import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../lib/utils"
-import { ControlTooltip } from "../components/ControlTooltip"
+import { CornerChromeButton } from "./cornerChrome"
 import { CHAT_SESSION_DRAG_TYPE, dispatchChatSessionDragPayload, PaneFocusRing, paneTitle, type ChatPaneDescriptor, type ChatPaneStageProps } from "./ChatPaneStage"
 import { workspaceSessionKey } from "../sessionIdentity"
 
@@ -30,6 +29,13 @@ type ChatPaneStageDockProps = ChatPaneStageProps
 const CHAT_PANE_COMPONENT = "chat-pane"
 const PANE_MIN_WIDTH = 280
 const PERSIST_DEBOUNCE_MS = 300
+
+export function readablePaneTitle(title: string | undefined, id: string | undefined): string {
+  const trimmed = title?.trim()
+  const isMachineId = trimmed === id
+    || Boolean(trimmed && /(?:^|::)[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}$/i.test(trimmed))
+  return trimmed && !isMachineId ? trimmed : "New chat"
+}
 
 interface StageContextValue {
   panes: ChatPaneDescriptor[]
@@ -218,7 +224,7 @@ export function ChatPaneStageDock({
     onSplitPane,
     splitPending,
     onActivePaneChange,
-    onClosePane: panes.length > 1 ? onClosePane : undefined,
+    onClosePane,
   }), [panes, resolvedActiveId, flashPaneId, renderPane, topActions, onSplitPane, splitPending, onActivePaneChange, onClosePane])
 
   const handleReady = useCallback((event: DockviewReadyEvent) => {
@@ -439,10 +445,10 @@ function SplitHorizontalIcon() {
 function ChatPaneHeader(props: IDockviewPanelHeaderProps) {
   const stage = useStage()
   const { api } = props
-  const [title, setTitle] = useState(api.title ?? api.id)
+  const [title, setTitle] = useState(() => readablePaneTitle(api.title, api.id))
 
   useEffect(() => {
-    const sync = () => setTitle(api.title ?? api.id)
+    const sync = () => setTitle(readablePaneTitle(api.title, api.id))
     sync()
     const sub = api.onDidTitleChange?.(sync)
     return () => sub?.dispose?.()
@@ -452,8 +458,9 @@ function ChatPaneHeader(props: IDockviewPanelHeaderProps) {
   const multiPane = stage.panes.length > 1
   return (
     <div
+      data-boring-workspace-part="chat-pane-title"
       className={cn(
-        "group flex h-full w-full min-w-0 select-none items-center gap-1.5 px-2 text-[12px] font-medium leading-none tracking-tight",
+        "group flex h-full w-full min-w-0 select-none items-center gap-2 px-3 text-[13px] font-medium leading-none tracking-[-0.01em]",
         multiPane && "cursor-grab active:cursor-grabbing",
       )}
       title={title}
@@ -462,11 +469,11 @@ function ChatPaneHeader(props: IDockviewPanelHeaderProps) {
         <GripVertical
           aria-hidden="true"
           data-boring-workspace-part="chat-pane-grip"
-          className="h-3.5 w-3.5 shrink-0 text-muted-foreground/45 transition-colors group-hover:text-muted-foreground"
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-colors group-hover:text-muted-foreground"
           strokeWidth={1.75}
         />
       ) : null}
-      <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-foreground/70">
+      <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-foreground/90">
         {title}
       </span>
     </div>
@@ -477,11 +484,11 @@ function ChatPaneHeader(props: IDockviewPanelHeaderProps) {
 function ChatPaneHeaderActions({ activePanel }: IDockviewHeaderActionsProps) {
   const stage = useStage()
   const api = activePanel?.api
-  const [title, setTitle] = useState(api?.title ?? api?.id ?? "Chat")
+  const [title, setTitle] = useState(() => readablePaneTitle(api?.title, api?.id))
 
   useEffect(() => {
     if (!api) return
-    const sync = () => setTitle(api.title ?? api.id)
+    const sync = () => setTitle(readablePaneTitle(api.title, api.id))
     sync()
     const sub = api.onDidTitleChange?.(sync)
     return () => sub?.dispose?.()
@@ -489,59 +496,42 @@ function ChatPaneHeaderActions({ activePanel }: IDockviewHeaderActionsProps) {
 
   if (!api) return null
   return (
-    <div className="flex h-full shrink-0 items-center gap-1 pr-1">
-      {stage.onSplitPane ? (
-        <div data-boring-workspace-part="chat-pane-split-controls" className="flex shrink-0 items-center gap-0.5">
-          <ControlTooltip label="Split chat vertically" side="bottom">
-            <IconButton
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              data-boring-workspace-part="chat-pane-control"
-              className="h-5 w-5 shrink-0 text-muted-foreground/80 opacity-55 hover:opacity-100 focus-visible:opacity-100"
-              disabled={stage.splitPending}
+      <div data-boring-workspace-part="chat-pane-actions" className="pointer-events-auto flex h-full shrink-0 items-center gap-1 pr-2">
+        {stage.onSplitPane ? (
+          <div data-boring-workspace-part="chat-pane-split-controls" className="flex shrink-0 items-center gap-1">
+            <CornerChromeButton
+              label={`Split ${title} chat vertically`}
+              appearance="chat"
               onClick={() => stage.onSplitPane?.(api.id, "right")}
-              aria-label={`Split ${title} chat vertically`}
+              disabled={stage.splitPending}
             >
               <SplitVerticalIcon />
-            </IconButton>
-          </ControlTooltip>
-          <ControlTooltip label="Split chat horizontally" side="bottom">
-            <IconButton
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              data-boring-workspace-part="chat-pane-control"
-              className="h-5 w-5 shrink-0 text-muted-foreground/80 opacity-55 hover:opacity-100 focus-visible:opacity-100"
-              disabled={stage.splitPending}
+            </CornerChromeButton>
+            <CornerChromeButton
+              label={`Split ${title} chat horizontally`}
+              appearance="chat"
               onClick={() => stage.onSplitPane?.(api.id, "below")}
-              aria-label={`Split ${title} chat horizontally`}
+              disabled={stage.splitPending}
             >
               <SplitHorizontalIcon />
-            </IconButton>
-          </ControlTooltip>
-        </div>
-      ) : null}
-      {stage.topActions ? (
-        <div data-boring-workspace-part="chat-pane-top-actions" className="flex shrink-0 items-center gap-1">
-          {stage.topActions}
-        </div>
-      ) : null}
-      {stage.onClosePane ? (
-        <ControlTooltip label="Close pane" side="bottom">
-          <IconButton
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            data-boring-workspace-part="chat-pane-control"
-            className="h-5 w-5 shrink-0 text-muted-foreground/80 opacity-55 hover:opacity-100 focus-visible:opacity-100"
+            </CornerChromeButton>
+          </div>
+        ) : null}
+        {stage.topActions && api.id === stage.activePaneId ? (
+          <div data-boring-workspace-part="chat-pane-top-actions" className="flex shrink-0 items-center gap-1">
+            {stage.topActions}
+          </div>
+        ) : null}
+        {stage.onClosePane ? (
+          <CornerChromeButton
+            label={`Close ${title} pane`}
+            appearance="chat"
+            disabled={stage.splitPending}
             onClick={() => stage.onClosePane?.(api.id)}
-            aria-label={`Close ${title} pane`}
           >
             <X className="h-3 w-3" strokeWidth={2.25} />
-          </IconButton>
-        </ControlTooltip>
-      ) : null}
-    </div>
+          </CornerChromeButton>
+        ) : null}
+      </div>
   )
 }

--- a/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
@@ -37,7 +37,7 @@ vi.mock("dockview-react/dist/styles/dockview.css", () => ({}))
 vi.mock("../dock/dockview-overrides.css", () => ({}))
 vi.mock("../chat-pane-stage.css", () => ({}))
 
-import { ChatPaneStageDock } from "../ChatPaneStageDock"
+import { ChatPaneStageDock, readablePaneTitle } from "../ChatPaneStageDock"
 import { dispatchChatSessionDragPayload } from "../ChatPaneStage"
 
 function mockPanel(id: string) {
@@ -102,7 +102,7 @@ describe("ChatPaneStageDock", () => {
     expect(dockviewProps.mock.calls[0][0]).toMatchObject({ defaultRenderer: "always" })
   })
 
-  it("renders chat top actions in every pane header, not only the active pane", () => {
+  it("renders chat top actions only in the active pane header", () => {
     dockviewProps.mockClear()
     render(
       <ChatPaneStageDock
@@ -116,7 +116,7 @@ describe("ChatPaneStageDock", () => {
       />,
     )
 
-    expect(screen.getAllByRole("button", { name: "Pane menu" })).toHaveLength(2)
+    expect(screen.getAllByRole("button", { name: "Pane menu" })).toHaveLength(1)
   })
   it.each(["right", "below"] as const)(
     "consumes a compound-key pending %s placement beside its reference pane",
@@ -193,8 +193,9 @@ describe("ChatPaneStageDock", () => {
     expect(splitPane).not.toHaveBeenCalled()
   })
 
-  it("wires vertical and horizontal split controls to the pane they belong to", () => {
+  it("gives every pane its own split and close controls", () => {
     const splitPane = vi.fn()
+    const closePane = vi.fn()
     render(
       <ChatPaneStageDock
         panes={[
@@ -203,14 +204,30 @@ describe("ChatPaneStageDock", () => {
         ]}
         activePaneId="a"
         onSplitPane={splitPane}
+        onClosePane={closePane}
         renderPane={(pane) => <div>{pane.id}</div>}
       />,
     )
 
     fireEvent.click(screen.getByRole("button", { name: "Split A chat vertically" }))
+    fireEvent.click(screen.getByRole("button", { name: "Split A chat horizontally" }))
+    fireEvent.click(screen.getByRole("button", { name: "Split B chat vertically" }))
     fireEvent.click(screen.getByRole("button", { name: "Split B chat horizontally" }))
+    fireEvent.click(screen.getByRole("button", { name: "Close A pane" }))
+    fireEvent.click(screen.getByRole("button", { name: "Close B pane" }))
 
     expect(splitPane).toHaveBeenNthCalledWith(1, "a", "right")
-    expect(splitPane).toHaveBeenNthCalledWith(2, "b", "below")
+    expect(splitPane).toHaveBeenNthCalledWith(2, "a", "below")
+    expect(splitPane).toHaveBeenNthCalledWith(3, "b", "right")
+    expect(splitPane).toHaveBeenNthCalledWith(4, "b", "below")
+    expect(closePane).toHaveBeenNthCalledWith(1, "a")
+    expect(closePane).toHaveBeenNthCalledWith(2, "b")
+  })
+
+  it("replaces machine session identifiers with a readable title", () => {
+    const id = "agent::123e4567-e89b-12d3-a456-426614174000"
+    expect(readablePaneTitle(id, id)).toBe("New chat")
+    expect(readablePaneTitle("123e4567-e89b-12d3-a456-426614174000", id)).toBe("New chat")
+    expect(readablePaneTitle("Quarterly planning", id)).toBe("Quarterly planning")
   })
 })

--- a/packages/workspace/src/front/layout/__tests__/mobileShell.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/mobileShell.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { MobileChatBar, MobileSingleChatPane, MobileWorkspaceBar } from "../mobileShell"
+
+describe("mobile chat chrome", () => {
+  it("keeps the top bar concise and safe-area aware", () => {
+    render(
+      <MobileChatBar
+        canOpenNav
+        canOpenWorkspace
+        onOpenNav={() => {}}
+        onOpenWorkspace={() => {}}
+      />,
+    )
+
+    const bar = screen.getByText("Chat").closest('[data-boring-workspace-part="mobile-chat-bar"]')
+    expect(bar?.className).toContain("env(safe-area-inset-top)")
+    expect(screen.queryByText("One active thread on mobile")).toBeNull()
+  })
+
+  it("uses a compact accessible close action even for the sole pane", () => {
+    const onClosePane = vi.fn()
+    render(
+      <MobileSingleChatPane
+        pane={{ id: "pane-a", title: "Planning" }}
+        totalPanes={1}
+        onClosePane={onClosePane}
+        renderPane={() => <div>Transcript</div>}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Close Planning pane" }))
+    expect(onClosePane).toHaveBeenCalledWith("pane-a")
+  })
+
+  it("normalizes machine UUID titles to New chat", () => {
+    const id = "123e4567-e89b-12d3-a456-426614174000"
+    render(
+      <MobileSingleChatPane
+        pane={{ id, title: id }}
+        totalPanes={1}
+        onClosePane={() => {}}
+        renderPane={() => <div>Transcript</div>}
+      />,
+    )
+
+    expect(screen.getByText("New chat")).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Close New chat pane" })).toBeTruthy()
+  })
+
+  it("keeps the workspace return bar concise", () => {
+    render(<MobileWorkspaceBar onBack={() => {}} />)
+    expect(screen.getByText("Workspace")).toBeTruthy()
+    expect(screen.queryByText("One active panel on mobile")).toBeNull()
+  })
+})

--- a/packages/workspace/src/front/layout/cornerChrome.tsx
+++ b/packages/workspace/src/front/layout/cornerChrome.tsx
@@ -5,37 +5,14 @@ import { IconButton } from "@hachej/boring-ui-kit"
 import { ControlTooltip } from "../components/ControlTooltip"
 import { cn } from "../lib/utils"
 
-/**
- * Shared fixed-position corner chrome control.
- *
- * Design-system contract (see `.impeccable.md`):
- * - Sized to the in-header chrome family: `IconButton size="icon-xs"` → 24px
- *   button, `rounded-md` (8px, ramp step), 12px icon at stroke 1.75. This
- *   matches WorkbenchCloseAction / session-list header buttons so the corner
- *   controls read as part of the same family, not a larger foreign element.
- * - Opaque `bg-muted` (one lightness step above `--background`) + 1px `border`
- *   for separation. No glassmorphism blur, no soft drop shadows (design
- *   system: "separation via borders and opacity, not big elevation jumps";
- *   "no glassmorphism blur for chrome"). The muted fill lifts the control off
- *   same-background content without an elevation jump.
- * - Resting `text-muted-foreground` so chrome recedes; hover/pressed lift to
- *   `text-foreground` on a darker fill (`bg-foreground/[0.06]` →
- *   `bg-foreground/[0.09]`) — a monotonic step, no shadow.
- * - Vertical position is set at the call site so the top-right controls
- *   center in the 44px workbench/header strip.
- * - Visible focus ring is provided by the `IconButton` base
- *   (`focus-visible:ring-[3px] ring-ring/50`) — keyboard-accessible by default.
- *
- * Used by the top-right workbench/chat toggles (`ChatLayout`). Left-pane
- * collapse controls use `PaneCollapseButton` because they belong to the
- * workspace-left rail family (32px button / 16px icon).
- */
-
 const CORNER_CHROME_CLASS =
   "pointer-events-auto relative border border-border/70 bg-muted text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
 
 const CORNER_CHROME_PRESSED_CLASS =
   "border-border bg-foreground/[0.09] text-foreground"
+
+const CHAT_CHROME_CLASS =
+  "border-transparent bg-transparent hover:bg-muted/70"
 
 export function CornerChromeButton({
   label,
@@ -43,6 +20,8 @@ export function CornerChromeButton({
   side = "bottom",
   onClick,
   pressed,
+  disabled = false,
+  appearance = "default",
   pulse = false,
   children,
 }: {
@@ -50,7 +29,9 @@ export function CornerChromeButton({
   hint?: string
   side?: "top" | "bottom" | "left" | "right"
   onClick: () => void
-  pressed: boolean
+  pressed?: boolean
+  disabled?: boolean
+  appearance?: "default" | "chat"
   pulse?: boolean
   children: ReactNode
 }) {
@@ -61,12 +42,15 @@ export function CornerChromeButton({
         variant="ghost"
         size="icon-xs"
         onClick={onClick}
+        disabled={disabled}
         aria-label={label}
-        aria-pressed={pressed}
+        aria-pressed={pressed === undefined ? undefined : pressed}
         title={label}
         className={cn(
           CORNER_CHROME_CLASS,
+          appearance === "chat" && CHAT_CHROME_CLASS,
           pressed && CORNER_CHROME_PRESSED_CLASS,
+          disabled && "cursor-not-allowed opacity-50 hover:bg-muted hover:text-muted-foreground",
         )}
       >
         {children}

--- a/packages/workspace/src/front/layout/mobileShell.tsx
+++ b/packages/workspace/src/front/layout/mobileShell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react"
-import { ArrowLeft } from "lucide-react"
+import { ArrowLeft, X } from "lucide-react"
 import { paneTitle, type ChatPaneDescriptor } from "./ChatPaneStage"
+import { readablePaneTitle } from "./ChatPaneStageDock"
 
 export function MobileSingleChatPane({
   pane,
@@ -15,23 +16,25 @@ export function MobileSingleChatPane({
   onClosePane?: (id: string) => void
   renderPane: (pane: ChatPaneDescriptor) => ReactNode
 }) {
+  const title = readablePaneTitle(paneTitle(pane), pane.id)
   return (
     <div data-boring-workspace-part="mobile-chat-pane" className="flex h-full min-h-0 flex-col bg-background">
-      <div className="flex min-h-11 items-center gap-2 border-b border-border px-3 py-2">
+      <div className="flex min-h-11 items-center gap-2 border-b border-border pb-2 pl-[calc(0.75rem+env(safe-area-inset-left))] pr-[calc(0.75rem+env(safe-area-inset-right))] pt-2">
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-semibold">{paneTitle(pane)}</div>
+          <div className="truncate text-sm font-semibold">{title}</div>
           {totalPanes > 1 ? (
             <div className="text-[11px] font-medium text-muted-foreground">Showing 1 of {totalPanes} chats — split panes are disabled on mobile.</div>
           ) : null}
         </div>
         {topActions ? <div className="flex shrink-0 items-center gap-1">{topActions}</div> : null}
-        {totalPanes > 1 && onClosePane ? (
+        {onClosePane ? (
           <button
             type="button"
-            className="min-h-9 rounded-full border border-border px-3 text-xs font-semibold text-muted-foreground"
+            className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"
             onClick={() => onClosePane(pane.id)}
+            aria-label={`Close ${title} pane`}
           >
-            Close
+            <X className="size-4" aria-hidden="true" />
           </button>
         ) : null}
       </div>
@@ -54,7 +57,10 @@ export function MobileChatBar({
   onOpenWorkspace: () => void
 }) {
   return (
-    <div data-boring-workspace-part="mobile-chat-bar" className="flex min-h-12 items-center gap-2 border-b border-border bg-background px-2 py-2" style={{ paddingLeft: "4rem" }}>
+    <div
+      data-boring-workspace-part="mobile-chat-bar"
+      className="flex min-h-12 items-center gap-2 border-b border-border bg-background pb-2 pl-[calc(4rem+env(safe-area-inset-left))] pr-[calc(0.5rem+env(safe-area-inset-right))] pt-[calc(0.5rem+env(safe-area-inset-top))]"
+    >
       {canOpenNav ? (
         <button
           type="button"
@@ -66,7 +72,6 @@ export function MobileChatBar({
       ) : null}
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-semibold">Chat</div>
-        <div className="truncate text-[11px] font-medium text-muted-foreground">One active thread on mobile</div>
       </div>
       {canOpenWorkspace ? (
         <button
@@ -83,7 +88,10 @@ export function MobileChatBar({
 
 export function MobileWorkspaceBar({ onBack }: { onBack: () => void }) {
   return (
-    <div data-boring-workspace-part="mobile-workspace-bar" className="flex min-h-12 items-center gap-2 border-b border-border bg-background px-2 py-2" style={{ paddingLeft: "4rem" }}>
+    <div
+      data-boring-workspace-part="mobile-workspace-bar"
+      className="flex min-h-12 items-center gap-2 border-b border-border bg-background pb-2 pl-[calc(4rem+env(safe-area-inset-left))] pr-[calc(0.5rem+env(safe-area-inset-right))] pt-[calc(0.5rem+env(safe-area-inset-top))]"
+    >
       <button
         type="button"
         className="inline-flex min-h-10 items-center gap-1 rounded-full border border-border px-3 text-sm font-semibold text-foreground"
@@ -94,7 +102,6 @@ export function MobileWorkspaceBar({ onBack }: { onBack: () => void }) {
       </button>
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm font-semibold">Workspace</div>
-        <div className="truncate text-[11px] font-medium text-muted-foreground">One active panel on mobile</div>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

Gives every chat pane a compact, consistent local header while preserving the existing palette and separating the upcoming Workbench redesign into #1047.

## What changed

- readable per-pane session title with machine-ID fallback
- vertical split, horizontal split, and close on every desktop pane
- functional singleton close replaces the closed pane with a fresh New chat
- guarded single-flight pane creation and stale async completion handling
- compact mobile title/close treatment with safe-area spacing
- functional showcase session creation/switching for visual review

## Excluded

- Workbench layout/activity rail redesign (#1047)
- transcript, composer, navigation, and palette changes

## Proof

- `pnpm --filter @hachej/boring-workspace exec vitest run src/front/layout/__tests__/ChatPaneStageDock.test.tsx src/front/layout/__tests__/mobileShell.test.tsx src/app/front/__tests__/WorkspaceAgentFront.test.tsx` — 81 passed
- `pnpm --filter @hachej/boring-workspace typecheck` — passed
- `pnpm --filter @hachej/boring-workspace build` — passed
- demo: http://100.68.199.114:5205/?showcase=1
- owner approved the chat top-bar direction

## Review

- standards/spec review completed; all blocker/high findings fixed
- independent race/scope re-review: ship

Closes #1032
