### PR TITLE
#1050 Preserve insufficient-credit rejection

### DIFF
--- a/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/createAgentHost.test.ts
@@ -796,6 +796,53 @@ describe('createAgentHost', () => {
     await duplicateApp.close()
   })
 
+  it('durably replays insufficient-credit rejection instead of reporting an unknown outcome', async () => {
+    const workspaceRoot = await root()
+    const reserveRun = vi.fn(async () => {
+      throw Object.assign(new Error('insufficient credits'), {
+        code: ErrorCode.enum.PAYMENT_REQUIRED,
+        statusCode: 402,
+      })
+    })
+    const created = await createAgentHost({
+      ...options(workspaceRoot),
+      metering: {
+        isEnabled: () => true,
+        reserveRun,
+        recordUsage: vi.fn(async () => ({ billedMicros: 0 })),
+        settleRun: vi.fn(async () => {}),
+        releaseRun: vi.fn(async () => {}),
+      },
+    })
+    const app = Fastify({ logger: false })
+    await app.register(created.registerDirectRoutes({ authorizeAgentRequest: async () => scope }))
+    const createdSession = await app.inject({
+      method: 'POST',
+      url: '/api/v1/agents/alpha/sessions',
+      payload: { requestId: 'create-credit-session' },
+    })
+    const sessionId = createdSession.json<{ sessionId: string }>().sessionId
+    const prompt = {
+      method: 'POST' as const,
+      url: `/api/v1/agents/alpha/sessions/${sessionId}/prompt`,
+      payload: {
+        requestId: 'insufficient-credit-prompt',
+        clientNonce: 'insufficient-credit-nonce',
+        content: 'hello',
+      },
+    }
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      const response = await app.inject(prompt)
+      expect(response.statusCode).toBe(402)
+      expect(response.json()).toEqual({
+        error: { code: ErrorCode.enum.PAYMENT_REQUIRED, message: 'insufficient credits' },
+      })
+    }
+    expect(reserveRun).toHaveBeenCalledOnce()
+    await app.close()
+  })
+
   it('preserves safe pre-mutation service errors and canonicalizes post-begin failures on first response and replay', async () => {
     const workspaceRoot = await root()
     const stable = Object.assign(new Error('session catalog is locked'), {

--- a/packages/agent/src/server/agent-host/embeddedGateway.ts
+++ b/packages/agent/src/server/agent-host/embeddedGateway.ts
@@ -16,11 +16,13 @@ import {
   type VerifiedAgentScopeClaim,
 } from '../../shared/index'
 import type { PiChatEvent, PiChatSnapshot } from '../../shared/chat'
+import { ErrorCode } from '../../shared/error-codes'
 import {
   type PiChatSessionService,
   type PiSessionRequestContext,
 } from '../../core/piChatSessionService'
 import { canonicalDigest } from './canonical'
+import { projectStableServiceError } from './stableServiceError'
 import type { AgentHostRuntime } from './createAgentHost'
 import type {
   AgentGatewayEffect,
@@ -778,7 +780,15 @@ export class EmbeddedAgentGateway implements AgentGateway {
           let receipt: JsonValue
           try {
             receipt = await actionResult as JsonValue
-          } catch {
+          } catch (error) {
+            // Metering rejects PAYMENT_REQUIRED before model/session mutation. Keep
+            // that explicitly stable rejection durable and replayable instead of
+            // misclassifying it as an ambiguous post-effect failure.
+            const stable = projectStableServiceError(error)
+            if (stable?.error.code === ErrorCode.enum.PAYMENT_REQUIRED) {
+              await this.runtime.ledger.reject(key, { kind: 'service', error: stable }).catch(() => {})
+              throw error
+            }
             const unknown = new AgentGatewayError(
               AgentGatewayErrorCode.AGENT_REQUEST_OUTCOME_UNKNOWN,
               'effect outcome could not be safely replayed',
@@ -846,7 +856,14 @@ export class EmbeddedAgentGateway implements AgentGateway {
   }
 
   private failure(failure: AgentRequestFailure): Error {
-    return gatewayError(failure.error)
+    if (failure.kind === 'gateway') return gatewayError(failure.error)
+    return Object.assign(new Error(failure.error.error.message), {
+      code: failure.error.error.code,
+      statusCode: failure.error.statusCode,
+      ...(failure.error.error.retryable === undefined
+        ? {}
+        : { retryable: failure.error.error.retryable }),
+    })
   }
 
   private async promptAdmission(

--- a/packages/agent/src/server/agent-host/types.ts
+++ b/packages/agent/src/server/agent-host/types.ts
@@ -55,8 +55,18 @@ export interface AgentRequestKey {
   readonly requestId: string
 }
 
+export interface AgentStableServiceErrorDTO {
+  readonly statusCode: number
+  readonly error: {
+    readonly code: string
+    readonly message: string
+    readonly retryable?: boolean
+  }
+}
+
 export type AgentRequestFailure =
-  { readonly kind: 'gateway'; readonly error: AgentGatewayErrorDTO }
+  | { readonly kind: 'gateway'; readonly error: AgentGatewayErrorDTO }
+  | { readonly kind: 'service'; readonly error: AgentStableServiceErrorDTO }
 
 export interface AgentRequestLedgerRecordBase {
   readonly key: AgentRequestKey


### PR DESCRIPTION
## Summary

Fixes #1050.

An insufficient-credit rejection occurs before model/session mutation inside the metering reservation, but the AgentHost ledger had already entered `in-flight`. The Gateway therefore converted the stable `PAYMENT_REQUIRED` rejection into `AGENT_REQUEST_OUTCOME_UNKNOWN`.

This change adds a durable service-rejection ledger variant and preserves only the explicitly pre-mutation `PAYMENT_REQUIRED` error. Genuine post-effect failures remain fail-closed as outcome unknown. Duplicate request IDs replay the same 402 without reserving twice.

## Proof

- `vitest run src/server/agent-host/__tests__/createAgentHost.test.ts src/server/agent-host/__tests__/requestLedger.test.ts src/server/agent-host/__tests__/httpProjection.test.ts` — 23/23 passed; type errors: none.
- `tsc --noEmit` in `packages/agent` — passed.
- `node scripts/check-alignment-invariants.mjs` — passed.
- `node scripts/check-golden-path-invariants.mjs` — passed.
- `node scripts/run-agenthost-composition-proofs.mjs` — all seven roots passed.
- `node scripts/check-agenthost-cutover-matrix.mjs` — 19 rows, 39 final routes, 23 deleted historical routes, zero forbidden compatibility references.
- `git diff --check` — passed.

## Risk / rollback

Narrow to `PAYMENT_REQUIRED`; all other action failures retain the existing outcome-unknown behavior. Rollback is the single commit if CI finds an integration issue.
