### PR TITLE
#1051 Hide close action on the final chat pane

### DIFF
--- a/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
@@ -224,7 +224,7 @@ export function ChatPaneStageDock({
     onSplitPane,
     splitPending,
     onActivePaneChange,
-    onClosePane,
+    onClosePane: panes.length > 1 ? onClosePane : undefined,
   }), [panes, resolvedActiveId, flashPaneId, renderPane, topActions, onSplitPane, splitPending, onActivePaneChange, onClosePane])
 
   const handleReady = useCallback((event: DockviewReadyEvent) => {

--- a/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
@@ -189,6 +189,7 @@ describe("ChatPaneStageDock", () => {
 
     expect(screen.getByRole("button", { name: "Split A chat vertically" })).toBeDisabled()
     expect(screen.getByRole("button", { name: "Split A chat horizontally" })).toBeDisabled()
+    expect(screen.queryByRole("button", { name: "Close A pane" })).toBeNull()
     fireEvent.click(screen.getByRole("button", { name: "Split A chat horizontally" }))
     expect(splitPane).not.toHaveBeenCalled()
   })

--- a/packages/workspace/src/front/layout/__tests__/mobileShell.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/mobileShell.test.tsx
@@ -18,9 +18,9 @@ describe("mobile chat chrome", () => {
     expect(screen.queryByText("One active thread on mobile")).toBeNull()
   })
 
-  it("uses an accessible touch target for the close action even for the sole pane", () => {
+  it("omits close for the sole pane and keeps a touch target when multiple panes exist", () => {
     const onClosePane = vi.fn()
-    render(
+    const { rerender } = render(
       <MobileSingleChatPane
         pane={{ id: "pane-a", title: "Planning" }}
         totalPanes={1}
@@ -29,6 +29,15 @@ describe("mobile chat chrome", () => {
       />,
     )
 
+    expect(screen.queryByRole("button", { name: "Close Planning pane" })).toBeNull()
+    rerender(
+      <MobileSingleChatPane
+        pane={{ id: "pane-a", title: "Planning" }}
+        totalPanes={2}
+        onClosePane={onClosePane}
+        renderPane={() => <div>Transcript</div>}
+      />,
+    )
     const close = screen.getByRole("button", { name: "Close Planning pane" })
     expect(close.className).toContain("size-11")
     fireEvent.click(close)
@@ -47,7 +56,7 @@ describe("mobile chat chrome", () => {
     )
 
     expect(screen.getByText("New chat")).toBeTruthy()
-    expect(screen.getByRole("button", { name: "Close New chat pane" })).toBeTruthy()
+    expect(screen.queryByRole("button", { name: "Close New chat pane" })).toBeNull()
   })
 
   it("keeps the workspace return bar concise", () => {

--- a/packages/workspace/src/front/layout/mobileShell.tsx
+++ b/packages/workspace/src/front/layout/mobileShell.tsx
@@ -27,7 +27,7 @@ export function MobileSingleChatPane({
           ) : null}
         </div>
         {topActions ? <div className="flex shrink-0 items-center gap-1">{topActions}</div> : null}
-        {onClosePane ? (
+        {totalPanes > 1 && onClosePane ? (
           <button
             type="button"
             className="inline-flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"


### PR DESCRIPTION
## Summary
- omit close on the final desktop and mobile chat pane
- retain close controls when multiple panes exist
- preserve both split actions

## Proof
- focused layout tests: 13 passed
- workspace typecheck: passed

Closes #1051
