### PR TITLE
#1054 Add tangible progress rules to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,40 @@ Detailed coding practices, workflow, architecture, and package docs live under `
    requests for `stop caveman`, `normal mode`, or any other explicit tone
    change.
 
+## Tangible Progress, Anti-Ceremony, and Honest Credit
+
+The purpose of this project is working, deployable software delivered
+accretively in the shortest time compatible with correctness, performance,
+reliability, and innovation. Process exists to serve that outcome; it must
+never become the product.
+
+- **No process porn.** Certificates, ledgers, dashboards, meta-reports,
+  and process documents are not progress. A process artifact may exist
+  only when it is a hard gate for a named feature or capability — the
+  conformance validator and required release evidence qualify;
+  self-referential paperwork does not. Choosing process artifacts because
+  they are easy and low-risk is reward hacking, and it is treated as such.
+- **Feature-first ratio.** The overwhelming majority of open work items
+  must deliver runnable behavior — code, schemas, and contracts that an
+  end user or consuming agent can actually exercise. Process/ops items are
+  capped (guideline: at most ~5% of open beads), and each must name the
+  feature work it gates; a process item that gates nothing does not get
+  created.
+- **Honesty is absolute.** Never fake a test, present a fixture or mock as
+  live proof, weaken an assertion to make it pass, hard-code a success
+  path, or close work that is not done. A false close is reopened with an
+  incident comment on the record.
+- **Refusal is not delivery.** A correctly typed refusal is far better
+  than a fabricated result — and far less valuable than the real
+  capability. Implementing only the refusal path earns partial credit at
+  most; it never closes a feature work item. Full credit requires the
+  positive capability implemented for real, tested, and verified. Mark
+  refusal-only states explicitly (e.g., a `refusal-only` label plus a
+  follow-up item) so they read as unfinished, never as shipped.
+
+These rules bind human-directed sessions and NTM swarms alike, and they
+must be encoded into the acceptance criteria of the work items themselves.
+
 ## Start here
 
 | Need | Read |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,37 @@ Detailed coding practices, workflow, architecture, and package docs live under `
    isolated branch worktrees (which must always be created inside the `.worktrees/`
    directory) and leave the anchor clean/current for handoffs.
 7. **Do not overwrite other agents' work.** Investigate unexpected changes before editing.
-8. **Run relevant quality gates** before calling work done.
+8. **Tangible progress, anti-ceremony, and honest credit.** The purpose of this
+   project is working, deployable software delivered accretively in the shortest
+   time compatible with correctness, performance, reliability, and innovation.
+   Process exists to serve that outcome; it must never become the product.
+   - **No process porn.** Certificates, ledgers, dashboards, meta-reports,
+     and process documents are not progress. A process artifact may exist
+     only when it is a hard gate for a named feature or capability — the
+     conformance validator and required release evidence qualify;
+     self-referential paperwork does not. Choosing process artifacts because
+     they are easy and low-risk is reward hacking, and it is treated as such.
+   - **Feature-first ratio.** The overwhelming majority of open work items
+     must deliver runnable behavior — code, schemas, and contracts that an
+     end user or consuming agent can actually exercise. Process/ops items are
+     capped (guideline: at most ~5% of open beads), and each must name the
+     feature work it gates; a process item that gates nothing does not get
+     created.
+   - **Honesty is absolute.** Never fake a test, present a fixture or mock as
+     live proof, weaken an assertion to make it pass, hard-code a success
+     path, or close work that is not done. A false close is reopened with an
+     incident comment on the record. Run relevant quality gates before calling
+     work done.
+   - **Refusal is not delivery.** A correctly typed refusal is far better
+     than a fabricated result — and far less valuable than the real
+     capability. Implementing only the refusal path earns partial credit at
+     most; it never closes a feature work item. Full credit requires the
+     positive capability implemented for real, tested, and verified. Mark
+     refusal-only states explicitly (e.g., a `refusal-only` label plus a
+     follow-up item) so they read as unfinished, never as shipped.
+
+   These rules bind human-directed sessions and NTM swarms alike, and they
+   must be encoded into the acceptance criteria of the work items themselves.
 9. **Session history is host app user data:** Pi chat transcripts/session lists
    are owned by the deployed core app host, not by the sandbox/workspace
    runtime. Store them on the host app's durable volume via
@@ -31,40 +61,6 @@ Detailed coding practices, workflow, architecture, and package docs live under `
 10. **Default communication style:** concise, direct, high-signal. Honor user
    requests for `stop caveman`, `normal mode`, or any other explicit tone
    change.
-
-## Tangible Progress, Anti-Ceremony, and Honest Credit
-
-The purpose of this project is working, deployable software delivered
-accretively in the shortest time compatible with correctness, performance,
-reliability, and innovation. Process exists to serve that outcome; it must
-never become the product.
-
-- **No process porn.** Certificates, ledgers, dashboards, meta-reports,
-  and process documents are not progress. A process artifact may exist
-  only when it is a hard gate for a named feature or capability — the
-  conformance validator and required release evidence qualify;
-  self-referential paperwork does not. Choosing process artifacts because
-  they are easy and low-risk is reward hacking, and it is treated as such.
-- **Feature-first ratio.** The overwhelming majority of open work items
-  must deliver runnable behavior — code, schemas, and contracts that an
-  end user or consuming agent can actually exercise. Process/ops items are
-  capped (guideline: at most ~5% of open beads), and each must name the
-  feature work it gates; a process item that gates nothing does not get
-  created.
-- **Honesty is absolute.** Never fake a test, present a fixture or mock as
-  live proof, weaken an assertion to make it pass, hard-code a success
-  path, or close work that is not done. A false close is reopened with an
-  incident comment on the record.
-- **Refusal is not delivery.** A correctly typed refusal is far better
-  than a fabricated result — and far less valuable than the real
-  capability. Implementing only the refusal path earns partial credit at
-  most; it never closes a feature work item. Full credit requires the
-  positive capability implemented for real, tested, and verified. Mark
-  refusal-only states explicitly (e.g., a `refusal-only` label plus a
-  follow-up item) so they read as unfinished, never as shipped.
-
-These rules bind human-directed sessions and NTM swarms alike, and they
-must be encoded into the acceptance criteria of the work items themselves.
 
 ## Start here
 


### PR DESCRIPTION
## Summary

- transcribe the complete owner-supplied “Tangible Progress, Anti-Ceremony, and Honest Credit” policy into `AGENTS.md`
- group the four supplied points under the existing single `## Hard rules` section
- merge the existing quality-gate instruction into **Honesty is absolute** so it appears once
- keep the policy machine-readable instead of relying on an external image

Closes #1054

## Proof of work

What changed:
- `AGENTS.md` only
- one existing hard rule replaced by the grouped policy; no second hard-rules section or duplicate quality-gate instruction

Automated verification:
- `git diff --check` ✅
- hard-rule uniqueness checks for the section, four policy points, and quality-gate sentence ✅
- Markdown whitespace checks ✅

Manual validation:
1. Compared the transcription against the supplied source image.
2. Confirmed the purpose, all four rules, examples, limits, and closing acceptance statement remain present.
3. Independent final documentation review returned `SHIP`.

Waiver / known gaps:
- Code tests are not applicable to this documentation-only transcription and organization change.
