### PR TITLE
#1047 Refine persistent Workbench rail and tab workflow

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1163,8 +1163,8 @@ export function WorkspaceAgentFront<
   }, [setSurfaceOpen, setWorkbenchLeftOpen])
   const closeWorkbench = useCallback(() => {
     surfaceOpenRef.current = false
-    surfaceRef.current = null
-    setSurfaceReady(false)
+    // The persistent activity rail keeps SurfaceShell mounted while collapsed,
+    // so its API remains valid and queued surface operations can reopen it.
     setSurfaceOpen(false)
   }, [setSurfaceOpen])
   const openChatSessionIdsRef = useRef<ReadonlySet<string>>(new Set())

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1557,7 +1557,7 @@ describe("WorkspaceAgentFront", () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText("Session browser")).toHaveAttribute("aria-hidden", "true")
-      expect(screen.getByLabelText("Surface")).toHaveAttribute("aria-hidden", "false")
+      expect(screen.getByRole("complementary", { name: "Workbench" })).toHaveAttribute("aria-hidden", "false")
     })
 
     rerender(
@@ -2032,7 +2032,7 @@ describe("WorkspaceAgentFront", () => {
     await user.click(await screen.findByRole("button", { name: "Open artifact" }))
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Surface")).toHaveAttribute("aria-hidden", "false")
+      expect(screen.getByRole("complementary", { name: "Workbench" })).toHaveAttribute("aria-hidden", "false")
     })
   })
 
@@ -2072,7 +2072,7 @@ describe("WorkspaceAgentFront", () => {
     await waitFor(() => {
       expect(visibleChatSessionIds()).toEqual(["s2"])
       expect(onSwitchSession).toHaveBeenCalledWith("s2", "default")
-      expect(screen.getByLabelText("Surface")).toHaveAttribute("aria-hidden", "false")
+      expect(screen.getByRole("complementary", { name: "Workbench" })).toHaveAttribute("aria-hidden", "false")
     })
   })
 
@@ -2100,7 +2100,7 @@ describe("WorkspaceAgentFront", () => {
     window.dispatchEvent(new CustomEvent(UI_COMMAND_EVENT, { detail: command }))
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Surface")).toHaveAttribute("aria-hidden", "false")
+      expect(screen.getByRole("complementary", { name: "Workbench" })).toHaveAttribute("aria-hidden", "false")
     })
     await waitFor(() => {
       expect(screen.getByText("Global command panel body")).toBeInTheDocument()
@@ -2152,7 +2152,7 @@ describe("WorkspaceAgentFront", () => {
     }))
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Surface")).toHaveAttribute("aria-hidden", "false")
+      expect(screen.getByRole("complementary", { name: "Workbench" })).toHaveAttribute("aria-hidden", "false")
     })
     await waitFor(() => {
       expect(screen.getByText("Global command panel body")).toBeInTheDocument()

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -2,17 +2,17 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react"
 import type { DockviewApi } from "dockview-react"
-import { ChevronRight, PanelLeftOpen } from "lucide-react"
-import { ControlTooltip } from "../../components/ControlTooltip"
+import { PanelRightOpen } from "lucide-react"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
-import { PaneCollapseButton } from "../../layout/paneCollapseButton"
 import { ArtifactSurfacePane } from "./ArtifactSurfacePane"
+import { WorkbenchHeaderActions } from "./WorkbenchHeaderActions"
 import type { WorkspaceBridge, CommandResult, BridgeEventMap } from "../../bridge/types"
 import type { WorkspaceState, PanelState } from "../../store/types"
 import { WorkbenchLeftPane } from "../workbench-left/WorkbenchLeftPane"
 import { useRegistry, useSurfaceResolverRegistry } from "../../registry"
 import { normalizeUiFilesystem, type FilesystemId } from "../../../shared/types/filesystem"
+import { closeWorkbenchPreview, workbenchPreviewParams } from "../../dock/workbenchPreview"
 import type { SurfaceOpenRequest } from "../../../shared/types/surface"
 import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../../shared/types/surface"
 import { isSharedDockviewPlacement, isWorkspacePagePlacement } from "../../../shared/types/panel"
@@ -85,6 +85,16 @@ export interface SurfaceShellProps {
   onChange?: (snapshot: SurfaceShellSnapshot) => void
   /** Optional close action for hosts that model the workbench as collapsible. */
   onClose?: () => void
+  /** Host-level collapsed mode: render only the persistent activity rail. */
+  hostRailOnly?: boolean
+  /** Mobile hosts already render their own level-one return bar. */
+  hideLevelOneHeader?: boolean
+  /** Expand the host-level workbench from its persistent activity rail. */
+  onHostExpand?: () => void
+  /** Whether the host has expanded the Workbench to fill the workspace. */
+  hostFullscreen?: boolean
+  /** Toggle between split-view and full-workspace Workbench layouts. */
+  onHostToggleFullscreen?: () => void
   /** Render the built-in top-right close affordance. Hosts can set false when they provide their own chrome. */
   showCloseAction?: boolean
   /**
@@ -147,11 +157,6 @@ function initialWorkbenchLeftState(storageKey: string | undefined, defaultLeftTa
 function hideWorkbenchLeft(state: WorkbenchLeftState): WorkbenchLeftState {
   if (state.mode === "hidden") return state
   return { mode: "hidden", activeTab: state.activeTab, restoreMode: state.mode === "source" ? "source" : "rail" }
-}
-
-function showWorkbenchLeft(state: WorkbenchLeftState): WorkbenchLeftState {
-  if (state.mode !== "hidden") return state
-  return { mode: state.restoreMode, activeTab: state.activeTab }
 }
 
 function openWorkbenchSource(state: WorkbenchLeftState, activeTab = state.activeTab): WorkbenchLeftState {
@@ -222,6 +227,11 @@ export function SurfaceShell({
   onReady,
   onChange,
   onClose,
+  hostRailOnly = false,
+  hideLevelOneHeader = false,
+  onHostExpand,
+  hostFullscreen = false,
+  onHostToggleFullscreen,
   showCloseAction = true,
   extraPanels,
   defaultLeftTab,
@@ -233,8 +243,11 @@ export function SurfaceShell({
   // illegal combinations like "hidden but source-open" and lets full-block
   // collapse restore the same active source (Files, Macro, …) on uncollapse.
   const [leftState, setLeftState] = useState<WorkbenchLeftState>(() => initialWorkbenchLeftState(storageKey, defaultLeftTab))
-  const leftBlockCollapsed = leftState.mode === "hidden"
-  const sourcePaneOpen = leftState.mode === "source"
+  // The far-right activity rail is structural and never disappears on desktop.
+  // Legacy "hidden" state now means rail-only; hostRailOnly additionally hides
+  // the editor and source content while preserving that same rail.
+  const leftBlockCollapsed = false
+  const sourcePaneOpen = !hostRailOnly && leftState.mode === "source"
   const activeLeftTab = leftState.activeTab
   const setActiveLeftTab = useCallback((tab: string) => {
     setLeftState((state) => setWorkbenchActiveTab(state, tab))
@@ -259,6 +272,7 @@ export function SurfaceShell({
   // a workspace-page icon only while its page is the focused surface tab (the rail's
   // own activeTab is set on icon-click and goes stale when you switch surface tabs).
   const [activeSurfacePanelId, setActiveSurfacePanelId] = useState<string | null>(null)
+  const [openSurfacePanels, setOpenSurfacePanels] = useState<Array<{ id: string; title: string }>>([])
   const [fileTreeRevealRequest, setFileTreeRevealRequest] = useState<{ path: string; seq: number } | null>(null)
   const onReadyRef = useRef(onReady)
   onReadyRef.current = onReady
@@ -304,17 +318,22 @@ export function SurfaceShell({
     setLeftState(hideWorkbenchLeft)
   }, [])
 
-  const expandLeftBlock = useCallback((): void => {
-    setLeftState(showWorkbenchLeft)
-  }, [])
-
   const openSourcePane = useCallback((tab?: string): void => {
     setLeftState((state) => openWorkbenchSource(state, tab))
-  }, [])
+    onHostExpand?.()
+  }, [onHostExpand])
 
   const closeSourcePane = useCallback((): void => {
     setLeftState(showWorkbenchRail)
   }, [])
+
+  const toggleHostWorkbench = useCallback((): void => {
+    if (hostRailOnly) {
+      onHostExpand?.()
+      return
+    }
+    onCloseRef.current?.()
+  }, [hostRailOnly, onHostExpand])
 
   const applyPanelPlacementTransition = useCallback((component: string): void => {
     const panel = panelRegistryRef.current.get(component)
@@ -391,11 +410,12 @@ export function SurfaceShell({
       const params = fileBackedParams(resolved.params, normalizedPath, { filesystem: request.filesystem, mode: options?.mode })
       fileBackedPanelIdsRef.current.add(panelId)
       if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) return
+      closeWorkbenchPreview(api)
       activateDockviewPanel({
         id: panelId,
         component: resolved.component,
         title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
-        params,
+        params: workbenchPreviewParams(params),
       })
       return
     }
@@ -447,11 +467,16 @@ export function SurfaceShell({
       apiRef.current &&
       activateExistingFilePanel(apiRef.current, normalizedRequest.target, normalizeUiFilesystem(normalizedRequest.filesystem), resolved.component, resolvedParams ?? {})
     ) return
+    if (normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND && apiRef.current) {
+      closeWorkbenchPreview(apiRef.current)
+    }
     if (!activateDockviewPanel({
       id: panelId,
       component: resolved.component,
       title: resolved.title ?? normalizedRequest.target,
-      params: resolvedParams,
+      params: normalizedRequest.kind === WORKSPACE_OPEN_PATH_SURFACE_KIND
+        ? workbenchPreviewParams(resolvedParams)
+        : resolvedParams,
     })) {
       console.warn("[SurfaceShell] openSurface: surface not ready (dockview not initialized)")
     }
@@ -471,6 +496,10 @@ export function SurfaceShell({
       existing.api.setActive()
       return
     }
+    // File-tree/plugin launches share one reusable preview tab. Pinned tabs
+    // clear this marker from their tab chrome and are never replaced.
+    closeWorkbenchPreview(api)
+
     // Validate the component is actually registered. Without this check,
     // dockview happily creates an empty tab when handed an unknown
     // component name (it falls back to a no-op renderer). That's how the
@@ -490,7 +519,7 @@ export function SurfaceShell({
       id: config.id,
       component: config.component,
       title: config.title ?? config.id,
-      params: config.params,
+      params: workbenchPreviewParams(config.params),
     })
   }, [activateDockviewPanel])
 
@@ -596,6 +625,7 @@ export function SurfaceShell({
     // SurfaceShell unmounts disposes the dockview itself.
     const emit = () => {
       setActiveSurfacePanelId(ready.activePanel?.id ?? null)
+      setOpenSurfacePanels(ready.panels.map((panel) => ({ id: panel.id, title: panel.title ?? panel.id })))
       onChangeRef.current?.(getSnapshot())
       emitBridgeState()
     }
@@ -634,11 +664,12 @@ export function SurfaceShell({
           const params = fileBackedParams(resolved.params, normalizedPath, { filesystem: request.filesystem, mode: options?.mode })
           fileBackedPanelIdsRef.current.add(panelId)
           if (activateExistingFilePanel(api, normalizedPath, normalizeUiFilesystem(request.filesystem), resolved.component, params)) return ok()
+          closeWorkbenchPreview(api)
           activateDockviewPanel({
             id: panelId,
             component: resolved.component,
             title: resolved.title ?? normalizedPath.split("/").pop() ?? normalizedPath,
-            params,
+            params: workbenchPreviewParams(params),
           })
           return ok()
         }
@@ -739,8 +770,10 @@ export function SurfaceShell({
     (e: React.PointerEvent<HTMLDivElement>) => {
       const state = dragStateRef.current
       if (!state) return
+      // The source pane is docked on the right, so dragging its left edge
+      // leftward increases width and dragging rightward decreases it.
       const delta = e.clientX - state.startX
-      const next = Math.max(sidebarMinWidth, Math.min(sidebarMaxWidth, state.startWidth + delta))
+      const next = Math.max(sidebarMinWidth, Math.min(sidebarMaxWidth, state.startWidth - delta))
       setSidebarWidth(next)
     },
     [sidebarMinWidth, sidebarMaxWidth],
@@ -758,10 +791,10 @@ export function SurfaceShell({
       const step = e.shiftKey ? 32 : 16
       if (e.key === "ArrowLeft") {
         e.preventDefault()
-        setSidebarWidth((w) => Math.max(sidebarMinWidth, w - step))
+        setSidebarWidth((w) => Math.min(sidebarMaxWidth, w + step))
       } else if (e.key === "ArrowRight") {
         e.preventDefault()
-        setSidebarWidth((w) => Math.min(sidebarMaxWidth, w + step))
+        setSidebarWidth((w) => Math.max(sidebarMinWidth, w - step))
       } else if (e.key === "Home") {
         e.preventDefault()
         setSidebarWidth(sidebarMinWidth)
@@ -792,23 +825,114 @@ export function SurfaceShell({
   }, [leftState, storageKey])
 
   const workbenchRailWidth = 44
-  const workbenchSidebarWidth = leftBlockCollapsed ? 0 : sourcePaneOpen ? sidebarWidth : workbenchRailWidth
+  const workbenchHeaderHeight = 44
+  const workbenchSidebarWidth = sourcePaneOpen ? sidebarWidth : workbenchRailWidth
 
   return (
     <div
       ref={containerRef}
       data-boring-workspace-part="surface"
-      className={cn("flex h-full min-h-0 w-full bg-background", className)}
+      data-boring-state={hostRailOnly ? "rail" : "expanded"}
+      className={cn("flex h-full min-h-0 w-full flex-col bg-background", className)}
       data-testid="surface-shell"
     >
-      <aside
-        data-boring-workspace-part="surface-sidebar"
-        data-boring-state={leftBlockCollapsed ? "collapsed" : sourcePaneOpen ? "expanded" : "rail"}
-        className="relative z-10 flex h-full min-h-0 flex-col overflow-hidden"
-        style={{ width: workbenchSidebarWidth, minWidth: workbenchSidebarWidth, maxWidth: workbenchSidebarWidth }}
-        aria-label="Workbench left pane"
+      {!hideLevelOneHeader ? <header
+        data-boring-workspace-part="workbench-level-one-header"
+        data-boring-state={hostRailOnly ? "collapsed" : "expanded"}
+        className={cn(
+          "pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center",
+          hostRailOnly ? "justify-center border-b border-border/60 bg-background" : "justify-end px-3",
+        )}
+        style={{ height: workbenchHeaderHeight }}
       >
-        {!leftBlockCollapsed && (
+        {hostRailOnly ? (
+          <IconButton
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            className="pointer-events-auto"
+            onClick={toggleHostWorkbench}
+            aria-label="Open workbench"
+            title="Open workbench (⌘2)"
+          >
+            <PanelRightOpen className="h-4 w-4" strokeWidth={1.75} />
+          </IconButton>
+        ) : (
+          <WorkbenchHeaderActions
+            panels={openSurfacePanels}
+            activePanelId={activeSurfacePanelId}
+            onActivatePanel={(panelId) => apiRef.current?.getPanel(panelId)?.api.setActive()}
+            fullscreen={hostFullscreen}
+            onToggleFullscreen={onHostToggleFullscreen}
+            onClose={showCloseAction ? onClose : undefined}
+          />
+        )}
+      </header> : null}
+
+      <div
+        data-boring-workspace-part="workbench-body"
+        className="flex h-full min-h-0 w-full"
+        style={{ height: "100%" }}
+      >
+        <div
+          data-boring-workspace-part="workbench-content"
+          aria-hidden={hostRailOnly}
+          inert={hostRailOnly ? true : undefined}
+          className={cn("relative min-w-0 flex-1 overflow-hidden", hostRailOnly && "w-0 flex-none")}
+        >
+          <div
+            data-boring-workspace-part="surface-tabs"
+            data-boring-state={sourcePaneOpen ? "expanded" : "rail"}
+            className="workbench-dockview h-full"
+            data-collapsed-sources={!sourcePaneOpen ? "true" : undefined}
+          >
+            <ArtifactSurfacePane
+              storageKey={storageKey}
+              onReady={handleReady}
+              allowedPanels={allowedPanels}
+            />
+          </div>
+          <EmptyWorkbenchOverlay api={api} />
+        </div>
+
+        {sourcePaneOpen ? (
+          <div
+            data-boring-workspace-part="workbench-source-resize"
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize workspace sources"
+            tabIndex={0}
+            onPointerDown={startDrag}
+            onPointerMove={onDrag}
+            onPointerUp={endDrag}
+            onPointerCancel={endDrag}
+            onKeyDown={onHandleKeyDown}
+            className={cn(
+              "relative w-px shrink-0 cursor-col-resize bg-transparent transition-colors hover:bg-primary/40",
+              !hideLevelOneHeader && "mt-11",
+              "focus-visible:outline-none focus-visible:bg-primary/50",
+            )}
+            style={{ height: hideLevelOneHeader ? "100%" : `calc(100% - ${workbenchHeaderHeight}px)` }}
+          >
+            <span aria-hidden="true" className="absolute inset-y-0 -left-1.5 -right-1.5" />
+          </div>
+        ) : null}
+
+        <aside
+          data-boring-workspace-part="surface-sidebar"
+          data-boring-state={hostRailOnly ? "host-collapsed" : sourcePaneOpen ? "expanded" : "rail"}
+          className={cn(
+            "relative z-10 flex min-h-0 shrink-0 flex-col overflow-hidden border-l border-border/60",
+            !hideLevelOneHeader && "mt-11",
+          )}
+          style={{
+            width: workbenchSidebarWidth,
+            minWidth: workbenchSidebarWidth,
+            maxWidth: workbenchSidebarWidth,
+            height: hideLevelOneHeader ? "100%" : `calc(100% - ${workbenchHeaderHeight}px)`,
+          }}
+          aria-label={hostRailOnly ? "Workbench activity rail" : "Workbench sources and activity rail"}
+        >
           <WorkbenchLeftPane
             rootDir={rootDir}
             bridge={bridge}
@@ -819,86 +943,14 @@ export function SurfaceShell({
             revealFileTreeRequest={fileTreeRevealRequest}
             onOpenPanel={openPanelSync}
             onReloadAgentPlugins={onReloadAgentPlugins}
-            onCollapse={collapseLeftBlock}
             onExpand={openSourcePane}
             onCloseSourcePane={closeSourcePane}
             railOnly={!sourcePaneOpen}
+            railSide="right"
           />
-        )}
-      </aside>
-
-      {!leftBlockCollapsed && sourcePaneOpen && (
-        <div
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="Resize sidebar"
-          tabIndex={0}
-          onPointerDown={startDrag}
-          onPointerMove={onDrag}
-          onPointerUp={endDrag}
-          onPointerCancel={endDrag}
-          onKeyDown={onHandleKeyDown}
-          className={cn(
-            "relative w-px shrink-0 cursor-col-resize bg-transparent transition-colors hover:bg-primary/40",
-            "focus-visible:outline-none focus-visible:bg-primary/50",
-          )}
-        >
-          <span aria-hidden="true" className="absolute inset-y-0 -left-1.5 -right-1.5" />
-        </div>
-      )}
-
-      <div className="relative min-w-0 flex-1">
-        <div
-          data-boring-workspace-part="surface-tabs"
-          data-boring-state={leftBlockCollapsed ? "collapsed" : sourcePaneOpen ? "expanded" : "rail"}
-          className="workbench-dockview h-full"
-          data-collapsed-sources={!sourcePaneOpen ? "true" : undefined}
-          data-left-block-collapsed={leftBlockCollapsed ? "true" : undefined}
-        >
-          <ArtifactSurfacePane
-            storageKey={storageKey}
-            onReady={handleReady}
-            allowedPanels={allowedPanels}
-          />
-        </div>
-        {/* Header overlays — always reachable, including existing/single-tab
-            dockview groups where header action slots can be squeezed/hidden.
-            zIndex must beat dockview's "open tabs" overflow popover (built by
-            PopupService at --dv-overlay-z-index 999, sometimes doubled to ~1998)
-            so the close-workspace control on the right edge is never covered by
-            an open dropdown menu. */}
-        <div
-          className="pointer-events-none absolute inset-x-0 top-0 flex items-center justify-between"
-          style={{ height: 44, zIndex: 2000 }}
-        >
-          <div className="self-start pl-1.5 pt-2">
-            {leftBlockCollapsed && (
-              <PaneCollapseButton label="Show workspace menu" side="right" onClick={expandLeftBlock}>
-                <PanelLeftOpen className="h-4 w-4" strokeWidth={1.75} />
-              </PaneCollapseButton>
-            )}
-          </div>
-          {showCloseAction && onClose && <WorkbenchCloseAction onClose={onClose} />}
-        </div>
-        <EmptyWorkbenchOverlay api={api} />
+        </aside>
       </div>
     </div>
-  )
-}
-
-function WorkbenchCloseAction({ onClose }: { onClose: () => void }) {
-  return (
-    <IconButton
-      type="button"
-      variant="ghost"
-      size="icon-xs"
-      onClick={onClose}
-      className="pointer-events-auto mx-1"
-      aria-label="Close workbench"
-      title="Close workbench (⌘2)"
-    >
-      <ChevronRight className="h-4 w-4" strokeWidth={1.75} />
-    </IconButton>
   )
 }
 

--- a/packages/workspace/src/front/chrome/artifact-surface/WorkbenchHeaderActions.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/WorkbenchHeaderActions.tsx
@@ -1,0 +1,96 @@
+"use client"
+
+import { ChevronDown, ChevronRight, Maximize2, Minimize2 } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  IconButton,
+} from "@hachej/boring-ui-kit"
+
+export interface WorkbenchHeaderPanel {
+  id: string
+  title: string
+}
+
+export function WorkbenchHeaderActions({
+  panels,
+  activePanelId,
+  onActivatePanel,
+  fullscreen,
+  onToggleFullscreen,
+  onClose,
+}: {
+  panels: WorkbenchHeaderPanel[]
+  activePanelId: string | null
+  onActivatePanel: (panelId: string) => void
+  fullscreen: boolean
+  onToggleFullscreen?: () => void
+  onClose?: () => void
+}) {
+  return (
+    <div
+      data-boring-workspace-part="workbench-header-actions"
+      className="pointer-events-auto flex items-center gap-1"
+    >
+      {panels.length > 0 ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              type="button"
+              className="inline-flex h-7 items-center gap-1 rounded-md px-2 text-[11px] text-muted-foreground hover:bg-muted/60 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              aria-label={`Open tabs (${panels.length})`}
+              title="Open tabs"
+            >
+              <ChevronDown className="h-3.5 w-3.5" strokeWidth={1.75} />
+              <span>{panels.length}</span>
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" sideOffset={6} className="min-w-52">
+            {panels.map((panel) => (
+              <DropdownMenuItem
+                key={panel.id}
+                onSelect={() => onActivatePanel(panel.id)}
+                className="flex items-center justify-between gap-4"
+              >
+                <span className="min-w-0 truncate">{panel.title}</span>
+                {panel.id === activePanelId ? (
+                  <span className="text-[10px] text-muted-foreground">Current</span>
+                ) : null}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+      {onToggleFullscreen ? (
+        <IconButton
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          onClick={onToggleFullscreen}
+          aria-label={fullscreen ? "Restore split view" : "Fullscreen workbench"}
+          title={fullscreen ? "Restore split view" : "Fullscreen workbench"}
+        >
+          {fullscreen ? (
+            <Minimize2 className="h-3.5 w-3.5" strokeWidth={1.75} />
+          ) : (
+            <Maximize2 className="h-3.5 w-3.5" strokeWidth={1.75} />
+          )}
+        </IconButton>
+      ) : null}
+      {onClose ? (
+        <IconButton
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          onClick={onClose}
+          aria-label="Close workbench"
+          title="Close workbench (⌘2)"
+        >
+          <ChevronRight className="h-4 w-4" strokeWidth={1.75} />
+        </IconButton>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -1,3 +1,4 @@
+import type { FunctionComponent } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { SurfaceShell, type SurfaceShellApi, type SurfaceShellProps } from "../SurfaceShell"
@@ -10,6 +11,8 @@ import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../../../shared/types/surfa
 let capturedSurfaceStorageKey: string | undefined
 let capturedAllowedPanels: string[] | undefined
 let capturedWorkbenchBridge: any
+let capturedWorkbenchProps: any
+let capturedRightHeaderActions: FunctionComponent<unknown> | undefined
 let mockAddPanel = vi.fn()
 let mockPanels: any[] = []
 let mockGetPanel: (id: string) => unknown = vi.fn(() => undefined)
@@ -17,15 +20,24 @@ let mockGetPanel: (id: string) => unknown = vi.fn(() => undefined)
 vi.mock("../../workbench-left/WorkbenchLeftPane", () => ({
   WorkbenchLeftPane: (props: any) => {
     capturedWorkbenchBridge = props.bridge
-    return <div data-testid="mock-left-pane" />
+    capturedWorkbenchProps = props
+    return (
+      <div data-testid="mock-left-pane">
+        {props.workbenchCollapsed && props.onToggleWorkbench ? (
+          <button type="button" onClick={props.onToggleWorkbench}>Open workbench</button>
+        ) : null}
+      </div>
+    )
   },
 }))
 
 vi.mock("../ArtifactSurfacePane", async () => {
   const React = await import("react")
-  function MockArtifactSurfacePane(props: { storageKey?: string; allowedPanels?: string[]; onReady?: (api: unknown) => void }) {
+  function MockArtifactSurfacePane(props: { storageKey?: string; allowedPanels?: string[]; onReady?: (api: unknown) => void; rightHeaderActions?: FunctionComponent<unknown> }) {
     capturedSurfaceStorageKey = props.storageKey
     capturedAllowedPanels = props.allowedPanels
+    capturedRightHeaderActions = props.rightHeaderActions
+    const RightHeaderActions = props.rightHeaderActions
     React.useEffect(() => {
       props.onReady?.({
         panels: mockPanels,
@@ -37,7 +49,7 @@ vi.mock("../ArtifactSurfacePane", async () => {
         onDidActivePanelChange: vi.fn(() => ({ dispose: vi.fn() })),
       })
     }, [props.onReady])
-    return <div data-testid="mock-artifact-surface" />
+    return <div data-testid="mock-artifact-surface">{RightHeaderActions ? <RightHeaderActions /> : null}</div>
   }
   MockArtifactSurfacePane.defaultAllowedPanels = [] as string[]
   return { ArtifactSurfacePane: MockArtifactSurfacePane }
@@ -65,6 +77,8 @@ describe("SurfaceShell", () => {
     capturedSurfaceStorageKey = undefined
     capturedAllowedPanels = undefined
     capturedWorkbenchBridge = undefined
+    capturedWorkbenchProps = undefined
+    capturedRightHeaderActions = undefined
     mockAddPanel = vi.fn()
     mockPanels = []
     mockGetPanel = vi.fn(() => undefined)
@@ -88,6 +102,47 @@ describe("SurfaceShell", () => {
     )
 
     expect(capturedSurfaceStorageKey).toBe("workspace-b")
+  })
+
+  it("reserves the level-one tab row above the full expanded Workbench body", () => {
+    const onHostToggleFullscreen = vi.fn()
+    const onClose = vi.fn()
+    renderSurface("workspace-a", { hostFullscreen: true, onHostToggleFullscreen, onClose })
+
+    const shell = screen.getByTestId("surface-shell")
+    const header = shell.querySelector<HTMLElement>('[data-boring-workspace-part="workbench-level-one-header"]')
+    const body = shell.querySelector<HTMLElement>('[data-boring-workspace-part="workbench-body"]')
+    const rail = shell.querySelector<HTMLElement>('[data-boring-workspace-part="surface-sidebar"]')
+
+    expect(capturedRightHeaderActions).toBeUndefined()
+    expect(header).not.toBeNull()
+    expect(header).toHaveStyle({ height: "44px" })
+    expect(header?.parentElement).toBe(shell)
+    expect(body?.previousElementSibling).toBe(header)
+    expect(body).toHaveStyle({ height: "100%" })
+    expect(rail).toHaveStyle({ height: "calc(100% - 44px)" })
+    expect(rail?.parentElement).toBe(body)
+    expect(header).toHaveTextContent("")
+    expect(screen.getByRole("button", { name: "Restore split view" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Close workbench" })).toBeInTheDocument()
+  })
+
+  it("lets the collapsed activity rail fill the host and reopen the Workbench", () => {
+    const onHostExpand = vi.fn()
+    renderSurface("workspace-a", { hostRailOnly: true, onHostExpand })
+
+    const shell = screen.getByTestId("surface-shell")
+    const body = shell.querySelector<HTMLElement>('[data-boring-workspace-part="workbench-body"]')
+    const rail = shell.querySelector<HTMLElement>('[data-boring-workspace-part="surface-sidebar"]')
+
+    const header = shell.querySelector('[data-boring-workspace-part="workbench-level-one-header"]')
+    expect(header).toHaveAttribute("data-boring-state", "collapsed")
+    expect(body).toHaveStyle({ height: "100%" })
+    expect(rail).toHaveStyle({ height: "calc(100% - 44px)" })
+    expect(rail).toHaveAttribute("data-boring-state", "host-collapsed")
+    expect(rail?.parentElement).toBe(body)
+    fireEvent.click(screen.getByRole("button", { name: "Open workbench" }))
+    expect(onHostExpand).toHaveBeenCalledOnce()
   })
 
   it("updates allowed surface panels when hot-loaded dockview/plugin-page panels register after mount", async () => {
@@ -259,7 +314,7 @@ describe("SurfaceShell", () => {
     panelRegistry.register("plugin.page", { title: "Plugin Page", placement: "workspace-page", component: () => null })
 
     renderSurface("workspace-a", { onReady: (api) => { surface = api } }, panelRegistry)
-    expect(screen.getByLabelText("Workbench left pane")).toBeInTheDocument()
+    expect(screen.getByLabelText("Workbench sources and activity rail")).toBeInTheDocument()
     await waitFor(() => expect(surface).toBeDefined())
 
     act(() => {
@@ -267,7 +322,7 @@ describe("SurfaceShell", () => {
     })
 
     expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({ id: "plugin.page", component: "plugin.page" }))
-    expect(screen.getByLabelText("Workbench left pane")).toHaveAttribute("data-boring-state", "rail")
+    expect(screen.getByLabelText("Workbench sources and activity rail")).toHaveAttribute("data-boring-state", "rail")
   })
 
   it("keeps the workbench left pane open when opening a shared-dockview panel", async () => {
@@ -276,7 +331,7 @@ describe("SurfaceShell", () => {
     panelRegistry.register("plugin.chart", { title: "Plugin Chart", placement: "shared-dockview", component: () => null })
 
     renderSurface("workspace-a", { onReady: (api) => { surface = api } }, panelRegistry)
-    expect(screen.getByLabelText("Workbench left pane")).toBeInTheDocument()
+    expect(screen.getByLabelText("Workbench sources and activity rail")).toBeInTheDocument()
     await waitFor(() => expect(surface).toBeDefined())
 
     act(() => {
@@ -284,7 +339,7 @@ describe("SurfaceShell", () => {
     })
 
     expect(mockAddPanel).toHaveBeenCalledWith(expect.objectContaining({ id: "plugin.chart", component: "plugin.chart" }))
-    expect(screen.getByLabelText("Workbench left pane")).toBeInTheDocument()
+    expect(screen.getByLabelText("Workbench sources and activity rail")).toBeInTheDocument()
   })
 
   it("renders a reachable close-workbench button as an overlay regardless of tab state", async () => {
@@ -300,6 +355,53 @@ describe("SurfaceShell", () => {
     renderSurface("workspace-a")
 
     expect(screen.queryByRole("button", { name: "Close workbench" })).not.toBeInTheDocument()
+  })
+
+  it("owns fullscreen and close controls in the expanded Workbench header", () => {
+    const onClose = vi.fn()
+    const onToggleFullscreen = vi.fn()
+    const { rerender } = renderSurface("workspace-a", {
+      onClose,
+      onHostToggleFullscreen: onToggleFullscreen,
+    })
+
+    const headerActions = screen.getByRole("button", { name: "Fullscreen workbench" }).closest('[data-boring-workspace-part="workbench-header-actions"]')
+    expect(headerActions).not.toBeNull()
+    fireEvent.click(screen.getByRole("button", { name: "Fullscreen workbench" }))
+    fireEvent.click(screen.getByRole("button", { name: "Close workbench" }))
+    expect(onToggleFullscreen).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledOnce()
+
+    rerender(
+      <RegistryProvider
+        panelRegistry={new PanelRegistry()}
+        commandRegistry={new CommandRegistry()}
+        surfaceResolverRegistry={new SurfaceResolverRegistry()}
+      >
+        <SurfaceShell
+          storageKey="workspace-a"
+          hostFullscreen
+          onClose={onClose}
+          onHostToggleFullscreen={onToggleFullscreen}
+        />
+      </RegistryProvider>,
+    )
+    expect(screen.getByRole("button", { name: "Restore split view" })).toBeInTheDocument()
+  })
+
+  it("hides expanded-header actions in rail-only mode and delegates reopen to the rail", () => {
+    const onHostExpand = vi.fn()
+    renderSurface("workspace-a", {
+      hostRailOnly: true,
+      onClose: vi.fn(),
+      onHostExpand,
+      onHostToggleFullscreen: vi.fn(),
+    })
+
+    expect(screen.queryByRole("button", { name: "Close workbench" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Fullscreen workbench" })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Open workbench" }))
+    expect(onHostExpand).toHaveBeenCalledOnce()
   })
 
   it("surface-backed source bridge opens panels and reports unsupported requests as errors", async () => {
@@ -332,7 +434,7 @@ describe("SurfaceShell", () => {
       },
     })
 
-    const sidebar = screen.getByLabelText("Workbench left pane")
+    const sidebar = screen.getByLabelText("Workbench sources and activity rail")
     expect(sidebar).toBeInTheDocument()
     expect(sidebar).toHaveAttribute("data-boring-state", "expanded")
     await waitFor(() => expect(surface).toBeDefined())
@@ -341,10 +443,10 @@ describe("SurfaceShell", () => {
       surface?.closeWorkbenchLeftPane()
     })
 
-    expect(screen.getByLabelText("Workbench left pane")).toHaveAttribute("data-boring-state", "collapsed")
+    expect(screen.getByLabelText("Workbench sources and activity rail")).toHaveAttribute("data-boring-state", "rail")
 
-    fireEvent.click(screen.getAllByRole("button", { name: "Show workspace menu" })[0]!)
+    act(() => capturedWorkbenchProps.onExpand("files"))
 
-    expect(screen.getByLabelText("Workbench left pane")).toHaveAttribute("data-boring-state", "expanded")
+    expect(screen.getByLabelText("Workbench sources and activity rail")).toHaveAttribute("data-boring-state", "expanded")
   })
 })

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -47,6 +47,8 @@ export interface WorkbenchLeftPaneProps {
   onExpand?: (tab?: WorkbenchLeftTabId) => void
   onCloseSourcePane?: () => void
   railOnly?: boolean
+  /** Mirrors the activity rail to the far-right edge of its source pane. */
+  railSide?: "left" | "right"
   className?: string
 }
 
@@ -64,6 +66,7 @@ export function WorkbenchLeftPane({
   onExpand,
   onCloseSourcePane,
   railOnly = false,
+  railSide = "left",
   className,
 }: WorkbenchLeftPaneProps) {
   const { actions: tabs, activeTab, activeAction, activeSource } = useWorkbenchLeftPaneModel({
@@ -134,23 +137,34 @@ export function WorkbenchLeftPane({
   // background on the icon and the pane, bridged across the rail gutter,
   // with no accent marker or side stripe (see WORKSPACE_LEFT_NAV_UX_SPEC).
   // Instant tooltips (no OS hover delay) name the icon-only categories.
+  const tooltipSide = railSide === "right" ? "left" : "right"
   const rail = (
     <nav
+      data-boring-workspace-part="workbench-activity-rail"
+      data-boring-side={railSide}
       className="flex w-11 shrink-0 flex-col items-center gap-1 bg-muted/35 px-1.5 py-2"
       aria-label="Workspace categories"
     >
-      {onCollapse && (
-        <PaneCollapseButton label="Hide workspace menu" side="right" onClick={onCollapse} className="mb-1">
-          <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
-        </PaneCollapseButton>
-      )}
+      {railSide === "left" ? (
+        <>
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center" data-boring-workspace-part="workbench-host-control-slot">
+            {onCollapse ? (
+              <PaneCollapseButton label="Hide workspace menu" side={tooltipSide} onClick={onCollapse}>
+                <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
+              </PaneCollapseButton>
+            ) : null}
+          </div>
+          <span aria-hidden="true" className="my-1 h-px w-6 shrink-0 bg-border/70" />
+        </>
+      ) : null}
       {tabs.map((entry) => {
         return (
-          <ControlTooltip key={entry.id} label={entry.title} side="right">
+          <ControlTooltip key={entry.id} label={entry.title} side={tooltipSide}>
             <button
               type="button"
               aria-label={entry.title}
               aria-pressed={entry.active}
+              data-boring-workspace-rail-id={entry.id}
               onClick={entry.select}
               onContextMenu={(event) => {
                 if (!entry.reloadAgentPlugins) return
@@ -187,9 +201,9 @@ export function WorkbenchLeftPane({
 
   return (
     <div data-boring-workspace-part="workbench-left" className={cn("workbench-left-root flex h-full min-h-0", className)}>
-      {rail}
+      {railSide === "left" ? rail : null}
 
-      <div className="flex h-full min-w-0 flex-1 flex-col bg-muted/35">
+      <div data-boring-workspace-part="workbench-source-pane" className="flex h-full min-w-0 flex-1 flex-col bg-muted/35">
         {!activeOwnsSearch && (
           <div className="flex h-11 items-center gap-1 border-b border-border/60 bg-muted/35 px-2.5">
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
@@ -252,6 +266,8 @@ export function WorkbenchLeftPane({
           )}
         </div>
       </div>
+
+      {railSide === "right" ? rail : null}
     </div>
   )
 }

--- a/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
@@ -364,6 +364,63 @@ describe("WorkbenchLeftPane", () => {
     expect(onExpand).toHaveBeenCalledTimes(1)
   })
 
+  test("puts Files at the top of the right activity rail", () => {
+    const sources = new WorkspaceSourceRegistry()
+    sources.register("files", { title: "Files", component: () => <div>files body</div> })
+
+    renderLeftPane({
+      sources,
+      children: <WorkbenchLeftPane railOnly railSide="right" />,
+    })
+
+    const rail = screen.getByRole("navigation", { name: "Workspace categories" })
+    const filesButton = screen.getByRole("button", { name: "Files" })
+    const filesSlot = Array.from(rail.children).findIndex((child) => child.contains(filesButton))
+    expect(rail.querySelector('[data-boring-workspace-part="workbench-host-control-slot"]')).not.toBeInTheDocument()
+    expect(filesSlot).toBe(0)
+  })
+
+  test("toggles the source menu from the fixed Files rail slot", () => {
+    const sources = new WorkspaceSourceRegistry()
+    sources.register("files", { title: "Files", component: () => <div>files body</div> })
+    const onCloseSourcePane = vi.fn()
+
+    const { rerender } = renderLeftPane({
+      sources,
+      children: (
+        <WorkbenchLeftPane
+          railSide="right"
+          onCloseSourcePane={onCloseSourcePane}
+        />
+      ),
+    })
+
+    const rail = screen.getByRole("navigation", { name: "Workspace categories" })
+    const filesButton = screen.getByRole("button", { name: "Files" })
+    const expandedSlot = Array.from(rail.children).findIndex((child) => child.contains(filesButton))
+    expect(expandedSlot).toBe(0)
+    expect(screen.queryByRole("button", { name: "Collapse Files" })).not.toBeInTheDocument()
+
+    fireEvent.click(filesButton)
+    expect(onCloseSourcePane).toHaveBeenCalledOnce()
+
+    rerender(
+      <RegistryProvider
+        panelRegistry={new PanelRegistry()}
+        workspaceSourceRegistry={sources}
+        commandRegistry={new CommandRegistry()}
+        surfaceResolverRegistry={new SurfaceResolverRegistry()}
+      >
+        <WorkbenchLeftPane railOnly railSide="right" />
+      </RegistryProvider>,
+    )
+    const collapsedRail = screen.getByRole("navigation", { name: "Workspace categories" })
+    const collapsedFiles = screen.getByRole("button", { name: "Files" })
+    const collapsedSlot = Array.from(collapsedRail.children).findIndex((child) => child.contains(collapsedFiles))
+    expect(collapsedSlot).toBe(expandedSlot)
+    expect(screen.queryByRole("button", { name: "Collapse Files" })).not.toBeInTheDocument()
+  })
+
   test("icon-less categories fall back to an initial-letter glyph", () => {
     const sources = new WorkspaceSourceRegistry()
     sources.register("files", {

--- a/packages/workspace/src/front/chrome/workbench-left/useWorkspaceLeftPaneActions.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/useWorkspaceLeftPaneActions.tsx
@@ -96,7 +96,12 @@ export function useWorkbenchLeftPaneModel({
   )
   const entries = useMemo<WorkbenchLeftPaneEntry[]>(() => {
     const next: WorkbenchLeftPaneEntry[] = []
-    for (const source of workspaceSources) {
+    const orderedSources = [...workspaceSources].sort((left, right) => {
+      if (left.id === "files") return -1
+      if (right.id === "files") return 1
+      return 0
+    })
+    for (const source of orderedSources) {
       const Icon = source.icon
       next.push({
         id: source.id,

--- a/packages/workspace/src/front/dock/ShadcnTab.tsx
+++ b/packages/workspace/src/front/dock/ShadcnTab.tsx
@@ -5,6 +5,7 @@ import { X } from "lucide-react"
 import { getFileIcon } from "../registry/getFileIcon"
 import { IconButton } from "@hachej/boring-ui-kit"
 import { cn } from "../lib/utils"
+import { isWorkbenchPreviewParams, pinnedWorkbenchParams } from "./workbenchPreview"
 import { useEvent, workspaceEvents } from "../events"
 import { WORKSPACE_OPEN_PATH_SURFACE_KIND } from "../../shared/types/surface"
 
@@ -135,6 +136,7 @@ export function ShadcnTab(props: IDockviewPanelHeaderProps) {
   const displayTitle = isDirty ? title.slice(0, -2) : title
   const Icon = getFileIcon(displayTitle)
   const filePath = readStringParam(props.params, "path") ?? readPathFromPanelId(api.id)
+  const isPreview = isWorkbenchPreviewParams(props.params)
   const groupTabs = siblingPanels(props)
     .map(panelSnapshot)
     .filter((panel) => panel.close)
@@ -150,6 +152,15 @@ export function ShadcnTab(props: IDockviewPanelHeaderProps) {
   useEvent(workspaceEvents.editorSaveEnd, (p) => {
     if (p.panelId === api.id) setIsSaving(false)
   })
+
+  const pinPreview = () => {
+    if (!isPreview) return
+    api.updateParameters(pinnedWorkbenchParams(props.params))
+  }
+
+  useEffect(() => {
+    if (isDirty && isPreview) pinPreview()
+  }, [isDirty, isPreview])
 
   const handleClose = (e: React.MouseEvent) => {
     e.preventDefault()
@@ -264,6 +275,11 @@ export function ShadcnTab(props: IDockviewPanelHeaderProps) {
           if (e.button === 2) openContextMenu(e)
         }}
         onContextMenu={openContextMenu}
+        onDoubleClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          pinPreview()
+        }}
       >
         <Icon
           className={cn(
@@ -272,7 +288,10 @@ export function ShadcnTab(props: IDockviewPanelHeaderProps) {
           )}
           strokeWidth={1.5}
         />
-        <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">{displayTitle}</span>
+        <span className={cn(
+          "min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap",
+          isPreview && "italic",
+        )}>{displayTitle}</span>
         <div className="flex shrink-0 items-center gap-1">
           {isDirty || isSaving ? (
             <span

--- a/packages/workspace/src/front/dock/dockview-overrides.css
+++ b/packages/workspace/src/front/dock/dockview-overrides.css
@@ -283,6 +283,12 @@
   color: var(--foreground);
 }
 
+/* SurfaceShell owns a stable, Workbench-wide open-tabs menu beside the
+   fullscreen/collapse controls. Hide Dockview's editor-width overflow trigger. */
+.workbench-dockview .dv-tabs-overflow-dropdown-root {
+  display: none;
+}
+
 /* Drag ghost */
 .dv-shell .dv-drag-image {
   opacity: 0.85;

--- a/packages/workspace/src/front/dock/workbenchPreview.ts
+++ b/packages/workspace/src/front/dock/workbenchPreview.ts
@@ -1,0 +1,23 @@
+import type { DockviewApi } from "dockview-react"
+
+export const WORKBENCH_PREVIEW_PARAM = "__workbenchPreview" as const
+
+export function isWorkbenchPreviewParams(params: unknown): boolean {
+  return Boolean(
+    params &&
+    typeof params === "object" &&
+    (params as Record<string, unknown>)[WORKBENCH_PREVIEW_PARAM] === true,
+  )
+}
+
+export function workbenchPreviewParams(params?: Record<string, unknown>): Record<string, unknown> {
+  return { ...(params ?? {}), [WORKBENCH_PREVIEW_PARAM]: true }
+}
+
+export function pinnedWorkbenchParams(params?: Record<string, unknown>): Record<string, unknown> {
+  return { ...(params ?? {}), [WORKBENCH_PREVIEW_PARAM]: false }
+}
+
+export function closeWorkbenchPreview(api: DockviewApi): void {
+  api.panels.find((panel) => isWorkbenchPreviewParams(panel.params))?.api.close()
+}

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType, type ReactNode } from "react"
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
 import { Maximize2, MessageSquare, Minimize2, PanelRightClose, PanelRightOpen } from "lucide-react"
 import { cn } from "../lib/utils"
@@ -16,6 +16,7 @@ import { useWorkspaceAttention, useWorkspaceContext, workspaceAttentionSessionBa
 import { ChatPaneStage } from "./ChatPaneStage"
 import { CornerChromeButton } from "./cornerChrome"
 import { MobileChatBar, MobileSingleChatPane, MobileWorkspaceBar } from "./mobileShell"
+import { WorkbenchOverlayFrame } from "./WorkbenchOverlayFrame"
 import { useViewportWidth } from "./useViewportWidth"
 import { workspaceSessionRef, workspaceSessionRefFromKey, workspaceSessionRefsEqual } from "../sessionIdentity"
 
@@ -893,59 +894,6 @@ function createPanelApi(id: string): Partial<PaneProps["api"]> {
     onDidVisibilityChange: () => ({ dispose() {} }),
     onDidConstraintsChange: () => ({ dispose() {} }),
   } as Partial<PaneProps["api"]>
-}
-
-function WorkbenchOverlayFrame({
-  open,
-  fullscreen,
-  onOpen,
-  onClose,
-  onToggleFullscreen,
-  children,
-}: {
-  open: boolean
-  fullscreen: boolean
-  onOpen: () => void
-  onClose: () => void
-  onToggleFullscreen: () => void
-  children: ReactNode
-}) {
-  return (
-    <div className="flex h-full min-h-0 flex-col">
-      <header className="flex h-11 shrink-0 items-center justify-between border-b border-border/60 bg-background px-2">
-        {open ? <span className="truncate text-[13px] font-medium">Workbench</span> : <span />}
-        <div className="flex items-center gap-1">
-          {open ? (
-            <>
-              <IconButton
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                onClick={onToggleFullscreen}
-                aria-label={fullscreen ? "Restore split view" : "Fullscreen workbench"}
-              >
-                {fullscreen ? <Minimize2 /> : <Maximize2 />}
-              </IconButton>
-              <IconButton type="button" variant="ghost" size="icon-xs" onClick={onClose} aria-label="Close workbench">
-                <PanelRightClose />
-              </IconButton>
-            </>
-          ) : (
-            <IconButton type="button" variant="ghost" size="icon-xs" onClick={onOpen} aria-label="Open workbench">
-              <PanelRightOpen />
-            </IconButton>
-          )}
-        </div>
-      </header>
-      <div
-        className={cn("min-h-0 flex-1 overflow-hidden", !open && "pointer-events-none opacity-0")}
-        aria-hidden={!open}
-        inert={!open ? true : undefined}
-      >
-        {children}
-      </div>
-    </div>
-  )
 }
 
 function TopRightWorkspaceControls({

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType } from "react"
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore, type ComponentType, type ReactNode } from "react"
 import { IconButton, LoadingState, ResizeHandle as UiResizeHandle } from "@hachej/boring-ui-kit"
 import { Maximize2, MessageSquare, Minimize2, PanelRightClose, PanelRightOpen } from "lucide-react"
 import { cn } from "../lib/utils"
@@ -159,13 +159,21 @@ export function ChatLayout(props: ChatLayoutProps) {
     }
     props.onOpenNav?.()
   }, [closeNav, navOpen, props.onOpenNav])
+  const openWorkbenchSplit = useCallback(() => {
+    if (chatCollapsed) setChatCollapsed(false)
+    props.onOpenSurface?.()
+  }, [chatCollapsed, props.onOpenSurface, setChatCollapsed])
+  const collapseWorkbench = useCallback(() => {
+    if (chatCollapsed) setChatCollapsed(false)
+    closeSurface?.()
+  }, [chatCollapsed, closeSurface, setChatCollapsed])
   const toggleSurface = useCallback(() => {
     if (surfaceOpen) {
-      closeSurface?.()
+      collapseWorkbench()
       return
     }
-    props.onOpenSurface?.()
-  }, [closeSurface, props.onOpenSurface, surfaceOpen])
+    openWorkbenchSplit()
+  }, [collapseWorkbench, openWorkbenchSplit, surfaceOpen])
   const toggleSidebar = useCallback(() => {
     if (sidebarOpen) {
       closeSidebar?.()
@@ -567,23 +575,23 @@ export function ChatLayout(props: ChatLayoutProps) {
           <aside
             data-boring-workspace-part="workbench"
             data-boring-state={surfaceOpen ? "expanded" : "collapsed"}
-            aria-label={surfaceOpen ? "Surface" : undefined}
-            aria-hidden={!surfaceOpen}
+            aria-label={surfaceOpen ? "Workbench" : "Workbench activity rail"}
+            aria-hidden={mobileShell && !surfaceOpen}
             className={cn(
               mobileShell ? "absolute inset-0 z-40" : "relative",
               "h-full min-h-0 overflow-hidden bg-background",
               // Collapsed/mobile workbench fills available width; otherwise it is a side panel.
               (chatCollapsed || mobileWorkspaceOpen) && surfaceOpen ? "min-w-0 flex-1" : "shrink-0",
               "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
-              surfaceOpen && !mobileShell && "border-l border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
+              !mobileShell && "border-l border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
             )}
             style={
               (chatCollapsed || mobileWorkspaceOpen) && surfaceOpen
-                ? { width: surfaceOpen ? effectiveSurfaceWidth : 0, minWidth: surfaceOpen ? effectiveSurfaceWidth : 0, maxWidth: surfaceOpen ? effectiveSurfaceWidth : 0, willChange: "width" }
+                ? { width: "auto", minWidth: 0, maxWidth: "none", flex: "1 1 0%", willChange: "width" }
                 : {
-                    width: surfaceOpen ? effectiveSurfaceWidth : 0,
-                    minWidth: surfaceOpen ? effectiveSurfaceWidth : 0,
-                    maxWidth: surfaceOpen ? effectiveSurfaceWidth : 0,
+                    width: surfaceOpen ? effectiveSurfaceWidth : mobileShell ? 0 : 44,
+                    minWidth: surfaceOpen ? effectiveSurfaceWidth : mobileShell ? 0 : 44,
+                    maxWidth: surfaceOpen ? effectiveSurfaceWidth : mobileShell ? 0 : 44,
                     willChange: "width",
                   }
             }
@@ -592,7 +600,7 @@ export function ChatLayout(props: ChatLayoutProps) {
               className={cn(
                 "h-full min-h-0 overflow-hidden",
                 "transition-[opacity,padding] duration-[200ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
-                surfaceOpen ? "opacity-100" : "opacity-0",
+                surfaceOpen || !mobileShell ? "opacity-100" : "opacity-0",
               )}
             >
               {mobileWorkspaceOpen ? (
@@ -603,14 +611,34 @@ export function ChatLayout(props: ChatLayoutProps) {
                       <div className="relative h-full min-h-0">
                         {props.surfaceOverlay}
                       </div>
-                    ) : <PanelSlot id={surfaceId} params={props.surfaceParams} />}
+                    ) : <PanelSlot
+                      id={surfaceId}
+                      params={{ ...props.surfaceParams, hideLevelOneHeader: true }}
+                    />}
                   </div>
                 </div>
               ) : props.surfaceOverlay ? (
-                <div className="relative h-full min-h-0">
+                <WorkbenchOverlayFrame
+                  open={surfaceOpen}
+                  fullscreen={chatCollapsed}
+                  onOpen={openWorkbenchSplit}
+                  onClose={collapseWorkbench}
+                  onToggleFullscreen={toggleChatCollapsed}
+                >
                   {props.surfaceOverlay}
-                </div>
-              ) : <PanelSlot id={surfaceId} params={props.surfaceParams} />}
+                </WorkbenchOverlayFrame>
+              ) : <PanelSlot
+                id={surfaceId}
+                params={{
+                  ...props.surfaceParams,
+                  hostRailOnly: !surfaceOpen,
+                  showCloseAction: true,
+                  onClose: collapseWorkbench,
+                  onHostExpand: openWorkbenchSplit,
+                  hostFullscreen: chatCollapsed,
+                  onHostToggleFullscreen: toggleChatCollapsed,
+                }}
+              />}
             </div>
             {surfaceOpen && !chatCollapsed && !mobileShell ? (
               <ResizeHandle
@@ -624,13 +652,13 @@ export function ChatLayout(props: ChatLayoutProps) {
 
       </div>
 
-      {!mobileShell ? (
+      {!mobileShell && !surfaceConfigured ? (
         <TopRightWorkspaceControls
           surfaceOpen={surfaceOpen}
-          canToggleSurface={canControlSurface}
+          canToggleSurface={false}
           onToggleSurface={toggleSurface}
           chatCollapsed={chatCollapsed}
-          canToggleChat={centerId === "chat" && (!surfaceConfigured || (surfaceOpen && !chatCollapsed))}
+          canToggleChat={centerId === "chat"}
           onToggleChat={toggleChatCollapsed}
           chatPulse={chatRailPulse || blockers.length > 0}
           surfaceConfigured={surfaceConfigured}
@@ -867,6 +895,59 @@ function createPanelApi(id: string): Partial<PaneProps["api"]> {
   } as Partial<PaneProps["api"]>
 }
 
+function WorkbenchOverlayFrame({
+  open,
+  fullscreen,
+  onOpen,
+  onClose,
+  onToggleFullscreen,
+  children,
+}: {
+  open: boolean
+  fullscreen: boolean
+  onOpen: () => void
+  onClose: () => void
+  onToggleFullscreen: () => void
+  children: ReactNode
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex h-11 shrink-0 items-center justify-between border-b border-border/60 bg-background px-2">
+        {open ? <span className="truncate text-[13px] font-medium">Workbench</span> : <span />}
+        <div className="flex items-center gap-1">
+          {open ? (
+            <>
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={onToggleFullscreen}
+                aria-label={fullscreen ? "Restore split view" : "Fullscreen workbench"}
+              >
+                {fullscreen ? <Minimize2 /> : <Maximize2 />}
+              </IconButton>
+              <IconButton type="button" variant="ghost" size="icon-xs" onClick={onClose} aria-label="Close workbench">
+                <PanelRightClose />
+              </IconButton>
+            </>
+          ) : (
+            <IconButton type="button" variant="ghost" size="icon-xs" onClick={onOpen} aria-label="Open workbench">
+              <PanelRightOpen />
+            </IconButton>
+          )}
+        </div>
+      </header>
+      <div
+        className={cn("min-h-0 flex-1 overflow-hidden", !open && "pointer-events-none opacity-0")}
+        aria-hidden={!open}
+        inert={!open ? true : undefined}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}
+
 function TopRightWorkspaceControls({
   surfaceOpen,
   canToggleSurface,
@@ -895,7 +976,10 @@ function TopRightWorkspaceControls({
     : surfaceConfigured ? "Expand workbench" : "Collapse chat"
 
   return (
-    <div className="pointer-events-none absolute right-3 top-2.5 z-[70] flex items-center gap-1">
+    <div className={cn(
+      "pointer-events-none absolute top-2.5 z-[70] flex items-center gap-1",
+      surfaceConfigured ? "right-14" : "right-3",
+    )}>
       {showChatToggle ? (
         <CornerChromeButton
           label={chatLabel}

--- a/packages/workspace/src/front/layout/WorkbenchOverlayFrame.tsx
+++ b/packages/workspace/src/front/layout/WorkbenchOverlayFrame.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react"
+import { Maximize2, Minimize2, PanelRightClose, PanelRightOpen } from "lucide-react"
+import { IconButton } from "@hachej/boring-ui-kit"
+import { cn } from "../lib/utils"
+
+/** Keeps Workbench-owned controls available while warmup blocks panel mounting. */
+export function WorkbenchOverlayFrame({
+  open,
+  fullscreen,
+  onOpen,
+  onClose,
+  onToggleFullscreen,
+  children,
+}: {
+  open: boolean
+  fullscreen: boolean
+  onOpen: () => void
+  onClose: () => void
+  onToggleFullscreen: () => void
+  children: ReactNode
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex h-11 shrink-0 items-center justify-between border-b border-border/60 bg-background px-2">
+        {open ? <span className="truncate text-[13px] font-medium">Workbench</span> : <span />}
+        <div className="flex items-center gap-1">
+          {open ? (
+            <>
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                onClick={onToggleFullscreen}
+                aria-label={fullscreen ? "Restore split view" : "Fullscreen workbench"}
+              >
+                {fullscreen ? <Minimize2 /> : <Maximize2 />}
+              </IconButton>
+              <IconButton type="button" variant="ghost" size="icon-xs" onClick={onClose} aria-label="Close workbench">
+                <PanelRightClose />
+              </IconButton>
+            </>
+          ) : (
+            <IconButton type="button" variant="ghost" size="icon-xs" onClick={onOpen} aria-label="Open workbench">
+              <PanelRightOpen />
+            </IconButton>
+          )}
+        </div>
+      </header>
+      <div
+        className={cn("min-h-0 flex-1 overflow-hidden", !open && "pointer-events-none opacity-0")}
+        aria-hidden={!open}
+        inert={!open ? true : undefined}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -797,7 +797,7 @@ describe("ChatLayout component", () => {
 
     const user = userEvent.setup()
     render(
-      <WorkspaceProvider persistenceEnabled={false}>
+      <WorkspaceProvider agentTypeId="default" persistenceEnabled={false}>
         <RegistryProvider panelRegistry={panelRegistry} commandRegistry={commandRegistry}>
           <Host />
         </RegistryProvider>

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import userEvent from "@testing-library/user-event"
 import { buildIdeLayout } from "../IdeLayout"
 import { buildChatLayout } from "../ChatLayout"
@@ -28,6 +28,19 @@ import {
 
 function DummyPanel() {
   return <div data-testid="dummy-panel">panel</div>
+}
+
+function WorkbenchHostControlProbe({ params }: { params?: Record<string, unknown> }) {
+  const expand = params?.onHostExpand as (() => void) | undefined
+  const collapse = params?.onClose as (() => void) | undefined
+  const toggleFullscreen = params?.onHostToggleFullscreen as (() => void) | undefined
+  return (
+    <div data-testid="workbench-host-probe" data-fullscreen={String(params?.hostFullscreen)} data-rail-only={String(params?.hostRailOnly)}>
+      <button type="button" onClick={expand}>Probe open workbench</button>
+      <button type="button" onClick={collapse}>Probe collapse workbench</button>
+      <button type="button" onClick={toggleFullscreen}>Probe toggle fullscreen</button>
+    </div>
+  )
 }
 
 function StreamingChatPanel() {
@@ -748,7 +761,7 @@ describe("ChatLayout component", () => {
     expect(chatButton.closest(".right-3")).not.toBeNull()
   })
 
-  it("keeps workbench close and expand controls visible over chat overlays", () => {
+  it("keeps Workbench controls out of chat-global chrome above overlays", () => {
     renderWithRegistry(
       <ChatLayout
         center="chat"
@@ -759,8 +772,66 @@ describe("ChatLayout component", () => {
       ["chat", "artifact-surface"],
     )
 
-    expect(screen.getByRole("button", { name: "Close workbench" })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Expand workbench" })).toBeInTheDocument()
+    expect(screen.getByRole("complementary", { name: "Workbench" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Expand workbench" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Close workbench" })).not.toBeInTheDocument()
+  })
+
+  it("owns collapsed, split, fullscreen, restore, and collapse transitions at the ChatLayout host", async () => {
+    const panelRegistry = new PanelRegistry()
+    panelRegistry.register("chat", { title: "Chat", lazy: false, component: DummyPanel })
+    panelRegistry.register("artifact-surface", { title: "Workbench", lazy: false, component: WorkbenchHostControlProbe })
+    const commandRegistry = new CommandRegistry()
+
+    function Host() {
+      const [open, setOpen] = useState(false)
+      return (
+        <ChatLayout
+          center="chat"
+          surface={open ? "artifact-surface" : null}
+          onOpenSurface={() => setOpen(true)}
+          surfaceParams={{ onClose: () => setOpen(false) }}
+        />
+      )
+    }
+
+    const user = userEvent.setup()
+    render(
+      <WorkspaceProvider persistenceEnabled={false}>
+        <RegistryProvider panelRegistry={panelRegistry} commandRegistry={commandRegistry}>
+          <Host />
+        </RegistryProvider>
+      </WorkspaceProvider>,
+    )
+
+    const workbench = () => screen.getByRole("complementary", { name: /Workbench/ })
+    const probe = () => screen.getByTestId("workbench-host-probe")
+    expect(workbench()).toHaveAttribute("data-boring-state", "collapsed")
+    expect(probe()).toHaveAttribute("data-rail-only", "true")
+    expect(screen.queryByRole("button", { name: "Expand workbench" })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Probe open workbench" }))
+    expect(workbench()).toHaveAttribute("data-boring-state", "expanded")
+    expect(probe()).toHaveAttribute("data-fullscreen", "false")
+    expect(screen.getByRole("main", { name: "Chat" })).toHaveAttribute("data-boring-state", "expanded")
+
+    await user.click(screen.getByRole("button", { name: "Probe toggle fullscreen" }))
+    expect(probe()).toHaveAttribute("data-fullscreen", "true")
+    expect(screen.getByLabelText("Collapsed chat")).toHaveAttribute("data-boring-state", "collapsed")
+    expect(workbench().getAttribute("style")).toContain("flex: 1 1 0%")
+
+    await user.click(screen.getByRole("button", { name: "Probe toggle fullscreen" }))
+    expect(probe()).toHaveAttribute("data-fullscreen", "false")
+    expect(screen.getByRole("main", { name: "Chat" })).toHaveAttribute("data-boring-state", "expanded")
+
+    await user.click(screen.getByRole("button", { name: "Probe toggle fullscreen" }))
+    await user.click(screen.getByRole("button", { name: "Probe collapse workbench" }))
+    expect(workbench()).toHaveAttribute("data-boring-state", "collapsed")
+    expect(screen.getByRole("main", { name: "Chat" })).toHaveAttribute("data-boring-state", "expanded")
+
+    await user.click(screen.getByRole("button", { name: "Probe open workbench" }))
+    expect(probe()).toHaveAttribute("data-fullscreen", "false")
+    expect(screen.getByRole("main", { name: "Chat" })).toHaveAttribute("data-boring-state", "expanded")
   })
 
   it("auto-expands the chat panel when a blocker appears while collapsed", async () => {

--- a/packages/workspace/src/front/layout/paneCollapseButton.tsx
+++ b/packages/workspace/src/front/layout/paneCollapseButton.tsx
@@ -10,6 +10,7 @@ export interface PaneCollapseButtonProps {
   children: ReactNode
   side?: "top" | "right" | "bottom" | "left"
   className?: string
+  dataPart?: string
 }
 
 /**
@@ -24,12 +25,14 @@ export function PaneCollapseButton({
   children,
   side = "right",
   className,
+  dataPart,
 }: PaneCollapseButtonProps) {
   return (
     <ControlTooltip label={label} side={side}>
       <button
         type="button"
         aria-label={label}
+        data-boring-workspace-part={dataPart}
         onClick={onClick}
         className={cn(
           "pointer-events-auto flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors",

--- a/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/FilePaneShell.tsx
@@ -3,9 +3,21 @@
 import { lazy, Suspense } from "react"
 import type { ReactNode } from "react"
 import { EmptyState, ErrorState, Spinner } from "@hachej/boring-ui-kit"
+import { ChevronRight } from "lucide-react"
 import { ConflictBanner } from "./ConflictBanner"
 import { FetchError, type FileConflictError } from "./data/fetchClient"
 import { redactedFilesystemErrorMessage } from "./data/filesystemErrorRedaction"
+
+function governedPathSegments(path: string): string[] {
+  const normalized = path.replaceAll("\\", "/").replace(/^\.\//, "")
+  const segments = normalized.split("/").filter((segment) => segment && segment !== "." && segment !== "..")
+  // Governed workspace paths are relative. If a host accidentally supplies an
+  // absolute path, disclose only the filename instead of leaking host roots.
+  if (normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized)) {
+    return segments.slice(-1)
+  }
+  return segments.length > 0 ? segments : [path]
+}
 
 export interface FilePaneShellProps {
   /** The file path being edited (for "no file selected" check). */
@@ -123,8 +135,31 @@ export function FilePaneShell({
     </div>
   )
 
+  const relativeSegments = governedPathSegments(path)
+  const displayPath = relativeSegments.join("/")
+
   return (
     <div className={`flex h-full min-h-0 flex-col ${className ?? ""}`}>
+      <nav
+        aria-label={`File path: ${displayPath}`}
+        title={displayPath}
+        data-boring-workspace-part="file-path-header"
+        className="flex h-9 shrink-0 items-center gap-1 overflow-hidden border-b border-border/60 bg-background px-3 text-[12px] leading-none"
+      >
+        <span className="shrink-0 text-muted-foreground/70">Workspace</span>
+        {relativeSegments.map((segment, index) => (
+          <span key={`${segment}-${index}`} className="contents">
+            <ChevronRight aria-hidden="true" className="size-3 shrink-0 text-muted-foreground/45" strokeWidth={1.75} />
+            <span
+              className={index === relativeSegments.length - 1
+                ? "min-w-0 truncate font-medium text-foreground"
+                : "shrink-0 text-muted-foreground"}
+            >
+              {segment}
+            </span>
+          </span>
+        ))}
+      </nav>
       {readOnly && (
         <div className="flex items-center gap-2 border-b border-border bg-muted/40 px-3 py-1.5 text-xs text-muted-foreground" role="status">
           <span className="rounded-sm border border-border bg-background px-1.5 py-0.5 font-medium text-foreground">Readonly</span>

--- a/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/FilePaneShell.test.tsx
+++ b/packages/workspace/src/plugins/filesystemPlugin/front/__tests__/FilePaneShell.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { FilePaneShell } from "../FilePaneShell"
+
+function Editor() {
+  return <div>editor</div>
+}
+
+function renderShell(path: string) {
+  return render(
+    <FilePaneShell
+      path={path}
+      content="content"
+      isLoading={false}
+      error={null}
+      conflict={null}
+      onChange={vi.fn()}
+      onReload={vi.fn()}
+      onOverwrite={vi.fn()}
+      editorComponent={Editor}
+    />,
+  )
+}
+
+describe("FilePaneShell path header", () => {
+  it("renders a governed relative breadcrumb with the filename emphasized", () => {
+    renderShell("src/features/editor.tsx")
+
+    const breadcrumb = screen.getByRole("navigation", { name: "File path: src/features/editor.tsx" })
+    expect(breadcrumb).toHaveAttribute("data-boring-workspace-part", "file-path-header")
+    expect(breadcrumb).toHaveTextContent("Workspace")
+    expect(breadcrumb).toHaveTextContent("src")
+    expect(breadcrumb).toHaveTextContent("features")
+    expect(breadcrumb).toHaveTextContent("editor.tsx")
+    expect(screen.getByText("editor.tsx")).toHaveClass("font-medium")
+  })
+
+  it("does not disclose host directory segments from an accidental absolute path", () => {
+    renderShell("/home/runner/private/project/secret.ts")
+
+    expect(screen.getByRole("navigation", { name: "File path: secret.ts" })).toBeInTheDocument()
+    expect(screen.queryByText("home")).not.toBeInTheDocument()
+    expect(screen.queryByText("private")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Refines the Workbench into a persistent right-edge workspace with inward-opening content, stable activity rail, consolidated tab chrome, and preview-tab behavior.

## What changed

- persistent 44px far-right activity rail
- level-one Workbench row uses file tabs with open-tabs menu and fixed fullscreen/collapse controls
- Workbench grows inward: content → source menu → activity rail
- Files icon remains fixed and toggles the file tree
- file breadcrumbs for filesystem-backed panels
- reusable italic preview tab for single-click file opens
- double-click pins preview; dirty preview auto-pins
- open-tabs menu lists every open panel and activates selections
- collapsed content is inert while the live Surface API remains available
- warmup and mobile host chrome preserve lifecycle controls

## Proof

- focused frontend suites: 184 passed
- workspace typecheck: passed
- workspace build: passed
- browser interaction proof: preview replacement, pinning, rail stability, split/fullscreen/restore
- owner visually approved the Workbench v0

## Review

- adversarial UX/engineering review completed
- thermonuclear maintainability review completed
- extracted Workbench header, preview policy, and warmup chrome
- `SurfaceShell.tsx` reduced below 1,000 lines
- rebased onto current `origin/main`

## Risk / rollback

Frontend Workbench layout/state behavior. Revert this PR to restore the prior right-side surface and tab behavior.

Closes #1047
