### PR TITLE
#1049 Add chat session header actions

### DIFF
--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -176,6 +176,11 @@ export function WorkspaceShell() {
     setShowcaseActiveSessionId(session.id)
     return session
   }, [])
+  const renameShowcaseSession = useCallback((sessionId: string, title: string) => {
+    setShowcaseSessions((current) => current.map((session) => (
+      session.id === sessionId ? { ...session, title, updatedAt: Date.now() } : session
+    )))
+  }, [])
   const handleActiveSessionIdChange = useCallback(
     (sessionId: string | null) => {
       if (showcase && sessionId) {
@@ -239,6 +244,7 @@ export function WorkspaceShell() {
       onActiveSessionIdChange={handleActiveSessionIdChange}
       onSwitchSession={showcase ? handleActiveSessionIdChange : undefined}
       onCreateSession={showcase ? createShowcaseSession : undefined}
+      onRenameSession={showcase ? renameShowcaseSession : undefined}
       plugins={activeWorkspacePlugins}
       chatParams={{ thinkingControl: true }}
     />

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -247,6 +247,7 @@ export interface WorkspaceAgentFrontProps<
   onSwitchSession?: (id: string, agentTypeId?: string) => void
   onCreateSession?: () => unknown | Promise<unknown>
   onDeleteSession?: (id: string, agentTypeId?: string) => void
+  onRenameSession?: (id: string, title: string, agentTypeId?: string) => void | Promise<void>
   onActiveSessionIdChange?: (sessionId: string | null) => void
   chatParams?: Record<string, unknown>
   /**
@@ -566,6 +567,7 @@ export function WorkspaceAgentFront<
   onSwitchSession,
   onCreateSession,
   onDeleteSession,
+  onRenameSession,
   onActiveSessionIdChange,
   appTitle = "Boring UI",
   workspaceLabel,
@@ -1648,6 +1650,24 @@ export function WorkspaceAgentFront<
 
   const workbenchBlocked = workspaceWarmupStatus.status !== "ready"
   const workbenchOverlay = workbenchBlocked ? <WorkbenchWarmupOverlay status={workspaceWarmupStatus} /> : undefined
+  const renameChatSession = useCallback(async (sessionKey: string, title: string) => {
+    const ref = workspaceSessionRefFromKey(sessionKey)
+    if (onRenameSession) {
+      await onRenameSession(ref.sessionId, title, ref.agentTypeId)
+      return
+    }
+    const owner = ref.agentTypeId ?? agentTypeId
+    const endpoint = `${apiBaseUrl?.replace(/\/$/, "") ?? ""}/api/v1/agents/${encodeURIComponent(owner)}/sessions/${encodeURIComponent(ref.sessionId)}/rename`
+    const requestId = `session-rename:${globalThis.crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`}`
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { ...resolvedRequestHeaders, "content-type": "application/json" },
+      body: JSON.stringify({ requestId, title }),
+    })
+    if (!response.ok) throw new Error(`rename failed (${response.status})`)
+    await sessionApi?.refresh?.({ background: true })
+  }, [agentTypeId, apiBaseUrl, onRenameSession, resolvedRequestHeaders, sessionApi])
+
   const reloadAgentPluginsForSession = useCallback(async (ref: { agentTypeId: string; sessionId: string }) => {
     const endpoint = `${apiBaseUrl?.replace(/\/$/, "") ?? ""}/api/v1/agents/${encodeURIComponent(ref.agentTypeId)}/reload`
     const requestId = `reload:${globalThis.crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`}`
@@ -1863,6 +1883,21 @@ export function WorkspaceAgentFront<
     onClose: () => setNavOpen(false),
   }
   const canDeleteSessions = Boolean(sessionApi || onDeleteSession || !hasExplicitSessionProps)
+  const canRenameSessions = Boolean(sessionApi || onRenameSession || !hasExplicitSessionProps)
+  const chatPaneSessionActions = useMemo(() => ({
+    isPinned: (sessionKey: string) => pinnedIds.includes(sessionKey),
+    onTogglePin: (sessionKey: string) => {
+      const ref = workspaceSessionRefFromKey(sessionKey)
+      toggleSessionPinned(ref.sessionId, ref.agentTypeId)
+    },
+    ...(canRenameSessions ? { onRename: renameChatSession } : {}),
+    ...(canDeleteSessions ? {
+      onDelete: async (sessionKey: string) => {
+        const ref = workspaceSessionRefFromKey(sessionKey)
+        await deleteSessionAndPane(ref.sessionId, ref.agentTypeId)
+      },
+    } : {}),
+  }), [canDeleteSessions, canRenameSessions, deleteSessionAndPane, pinnedIds, renameChatSession, toggleSessionPinned])
   const commandPaletteSessionSearch = useMemo(() => (
     isPluginTabsLayout
       ? {
@@ -2021,6 +2056,7 @@ export function WorkspaceAgentFront<
       centerParams={centerParams}
       chatPanes={chatPanes}
       chatTopActions={chatTopOverlayActions}
+      chatPaneSessionActions={chatPaneSessionActions}
       activeChatPaneId={activeChatPaneId}
       onActiveChatPaneChange={activateChatPane}
       onCloseChatPane={closeChatPane}

--- a/packages/workspace/src/front/dock/dockview-overrides.css
+++ b/packages/workspace/src/front/dock/dockview-overrides.css
@@ -169,13 +169,35 @@
 
 .dv-chat-stage .dv-tabs-container,
 .dv-chat-stage .tab-container {
+  flex: 0 1 auto !important;
+  width: fit-content !important;
+  min-width: 0;
+  max-width: min(420px, 55vw);
   align-items: stretch;
+}
+
+/* Dockview's scroll wrapper otherwise consumes the whole header and pushes
+   the session menu away from its title. */
+.dv-chat-stage .dv-scrollable {
+  flex: 0 1 auto !important;
+  width: fit-content !important;
+  min-width: 0;
+}
+
+/* Keep session actions adjacent to the readable title while preserving the
+   split/close cluster at the far edge of each pane header. */
+.dv-chat-stage .right-actions-container,
+.dv-chat-stage .dv-right-actions-container {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .dv-chat-stage .dv-tab,
 .dv-chat-stage .tab,
 .dv-chat-stage .dv-tab.dv-active-tab,
 .dv-chat-stage .tab.active-tab {
+  flex: 0 1 auto !important;
+  width: fit-content !important;
   height: 44px;
   min-width: 0;
   max-width: min(420px, 55vw);

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -538,6 +538,7 @@ export function ChatLayout(props: ChatLayoutProps) {
               <ChatPaneStage
                 panes={chatPanes}
                 topActions={props.chatTopActions}
+                sessionActions={props.chatPaneSessionActions}
                 activePaneId={props.activeChatPaneId}
                 onActivePaneChange={props.onActiveChatPaneChange}
                 onClosePane={props.onCloseChatPane}

--- a/packages/workspace/src/front/layout/ChatPaneStage.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStage.tsx
@@ -18,12 +18,20 @@ export interface ChatPanePendingPlacement {
   direction: ChatPaneSplitDirection
 }
 
+export interface ChatPaneSessionActions {
+  isPinned: (id: string) => boolean
+  onTogglePin: (id: string) => void
+  onRename?: (id: string, currentTitle: string) => void | Promise<void>
+  onDelete?: (id: string) => void | Promise<void>
+}
+
 export interface ChatPaneStageProps {
   panes: ChatPaneDescriptor[]
   activePaneId?: string | null
   renderPane: (pane: ChatPaneDescriptor) => ReactNode
   /** Optional host actions rendered in each chat pane header. */
   topActions?: ReactNode
+  sessionActions?: ChatPaneSessionActions
   /** Create a new chat pane split from the requested pane. */
   onSplitPane?: (id: string, direction: ChatPaneSplitDirection) => void
   /** Disable split controls while a previous pane creation is unresolved. */

--- a/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
@@ -18,7 +18,8 @@ import {
 import "dockview-react/dist/styles/dockview.css"
 import "../dock/dockview-overrides.css"
 import "./chat-pane-stage.css"
-import { GripVertical, X } from "lucide-react"
+import { GripVertical, MoreHorizontal, Pencil, Pin, PinOff, Trash2, X } from "lucide-react"
+import { Button, Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger, IconButton, Input } from "@hachej/boring-ui-kit"
 import { cn } from "../lib/utils"
 import { CornerChromeButton } from "./cornerChrome"
 import { CHAT_SESSION_DRAG_TYPE, dispatchChatSessionDragPayload, PaneFocusRing, paneTitle, type ChatPaneDescriptor, type ChatPaneStageProps } from "./ChatPaneStage"
@@ -43,6 +44,7 @@ interface StageContextValue {
   flashPaneId: string | null
   renderPane: ChatPaneStageProps["renderPane"]
   topActions?: ChatPaneStageProps["topActions"]
+  sessionActions?: ChatPaneStageProps["sessionActions"]
   onSplitPane?: ChatPaneStageProps["onSplitPane"]
   splitPending: boolean
   onActivePaneChange?: (id: string) => void
@@ -191,6 +193,7 @@ export function ChatPaneStageDock({
   activePaneId,
   renderPane,
   topActions,
+  sessionActions,
   onSplitPane,
   splitPending = false,
   pendingPanePlacement,
@@ -221,11 +224,12 @@ export function ChatPaneStageDock({
     flashPaneId: flashPaneId ?? null,
     renderPane,
     topActions,
+    sessionActions,
     onSplitPane,
     splitPending,
     onActivePaneChange,
     onClosePane,
-  }), [panes, resolvedActiveId, flashPaneId, renderPane, topActions, onSplitPane, splitPending, onActivePaneChange, onClosePane])
+  }), [panes, resolvedActiveId, flashPaneId, renderPane, topActions, sessionActions, onSplitPane, splitPending, onActivePaneChange, onClosePane])
 
   const handleReady = useCallback((event: DockviewReadyEvent) => {
     const api = event.api
@@ -460,7 +464,7 @@ function ChatPaneHeader(props: IDockviewPanelHeaderProps) {
     <div
       data-boring-workspace-part="chat-pane-title"
       className={cn(
-        "group flex h-full w-full min-w-0 select-none items-center gap-2 px-3 text-[13px] font-medium leading-none tracking-[-0.01em]",
+        "group flex h-full min-w-0 select-none items-center gap-2 px-3 text-[13px] font-medium leading-none tracking-[-0.01em]",
         multiPane && "cursor-grab active:cursor-grabbing",
       )}
       title={title}
@@ -473,10 +477,89 @@ function ChatPaneHeader(props: IDockviewPanelHeaderProps) {
           strokeWidth={1.75}
         />
       ) : null}
-      <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-foreground/90">
+      <span className="min-w-0 max-w-[min(340px,45vw)] overflow-hidden text-ellipsis whitespace-nowrap text-foreground/90">
         {title}
       </span>
     </div>
+  )
+}
+
+function ChatPaneSessionMenu({ paneId, title, actions }: {
+  paneId: string
+  title: string
+  actions: NonNullable<ChatPaneStageProps["sessionActions"]>
+}) {
+  const pinned = actions.isPinned(paneId)
+  const [renameOpen, setRenameOpen] = useState(false)
+  const [renameDraft, setRenameDraft] = useState(title)
+  const rename = () => {
+    const next = renameDraft.trim()
+    if (!actions.onRename || !next || next === title) return setRenameOpen(false)
+    void Promise.resolve(actions.onRename(paneId, next)).then(() => setRenameOpen(false))
+  }
+  const remove = () => {
+    if (!actions.onDelete || typeof window === "undefined") return
+    if (window.confirm(`Delete “${title}”?`)) void actions.onDelete(paneId)
+  }
+
+  return (
+    <>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <IconButton
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          className="border border-transparent bg-transparent text-muted-foreground hover:bg-muted/70 hover:text-foreground"
+          aria-label={`Chat actions for ${title}`}
+          title={`Chat actions for ${title}`}
+        >
+          <MoreHorizontal className="h-3.5 w-3.5" strokeWidth={1.9} />
+        </IconButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" sideOffset={6} className="min-w-48">
+        <DropdownMenuItem onSelect={() => actions.onTogglePin(paneId)}>
+          {pinned ? <PinOff className="mr-2 h-4 w-4" /> : <Pin className="mr-2 h-4 w-4" />}
+          {pinned ? "Unpin chat" : "Pin chat"}
+        </DropdownMenuItem>
+        {actions.onRename ? (
+          <DropdownMenuItem onSelect={() => { setRenameDraft(title); setRenameOpen(true) }}>
+            <Pencil className="mr-2 h-4 w-4" />
+            Rename chat
+          </DropdownMenuItem>
+        ) : null}
+        {actions.onDelete ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onSelect={remove} className="text-destructive focus:text-destructive">
+              <Trash2 className="mr-2 h-4 w-4" />
+              Delete chat
+            </DropdownMenuItem>
+          </>
+        ) : null}
+      </DropdownMenuContent>
+    </DropdownMenu>
+    <Dialog open={renameOpen} onOpenChange={setRenameOpen}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Rename chat</DialogTitle>
+          <DialogDescription>Choose a concise name for this conversation.</DialogDescription>
+        </DialogHeader>
+        <form className="flex flex-col gap-4" onSubmit={(event) => { event.preventDefault(); rename() }}>
+          <Input
+            autoFocus
+            value={renameDraft}
+            onChange={(event) => setRenameDraft(event.target.value)}
+            aria-label="Chat name"
+          />
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={() => setRenameOpen(false)}>Cancel</Button>
+            <Button type="submit" disabled={!renameDraft.trim()}>Rename</Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+    </>
   )
 }
 
@@ -496,9 +579,12 @@ function ChatPaneHeaderActions({ activePanel }: IDockviewHeaderActionsProps) {
 
   if (!api) return null
   return (
-      <div data-boring-workspace-part="chat-pane-actions" className="pointer-events-auto flex h-full shrink-0 items-center gap-1 pr-2">
+      <div data-boring-workspace-part="chat-pane-actions" className="pointer-events-auto flex h-full min-w-0 flex-1 items-center gap-1 pr-2">
+        {stage.sessionActions ? (
+          <ChatPaneSessionMenu paneId={api.id} title={title} actions={stage.sessionActions} />
+        ) : null}
         {stage.onSplitPane ? (
-          <div data-boring-workspace-part="chat-pane-split-controls" className="flex shrink-0 items-center gap-1">
+          <div data-boring-workspace-part="chat-pane-split-controls" className="ml-auto flex shrink-0 items-center gap-1">
             <CornerChromeButton
               label={`Split ${title} chat vertically`}
               appearance="chat"

--- a/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
@@ -224,6 +224,35 @@ describe("ChatPaneStageDock", () => {
     expect(closePane).toHaveBeenNthCalledWith(2, "b")
   })
 
+  it("opens session actions for pin, rename, and delete", () => {
+    const onTogglePin = vi.fn()
+    const onRename = vi.fn()
+    const onDelete = vi.fn()
+    vi.spyOn(window, "confirm").mockReturnValue(true)
+
+    render(
+      <ChatPaneStageDock
+        panes={[{ id: "a", title: "Planning" }]}
+        sessionActions={{ isPinned: () => false, onTogglePin, onRename, onDelete }}
+        renderPane={(pane) => <div>{pane.id}</div>}
+      />,
+    )
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Chat actions for A" }), { button: 0, ctrlKey: false })
+    fireEvent.click(screen.getByRole("menuitem", { name: "Pin chat" }))
+    expect(onTogglePin).toHaveBeenCalledWith("a")
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Chat actions for A" }), { button: 0, ctrlKey: false })
+    fireEvent.click(screen.getByRole("menuitem", { name: "Delete chat" }))
+    expect(onDelete).toHaveBeenCalledWith("a")
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Chat actions for A" }), { button: 0, ctrlKey: false })
+    fireEvent.click(screen.getByRole("menuitem", { name: "Rename chat" }))
+    fireEvent.change(screen.getByRole("textbox", { name: "Chat name" }), { target: { value: "Renamed chat" } })
+    fireEvent.click(screen.getByRole("button", { name: "Rename" }))
+    expect(onRename).toHaveBeenCalledWith("a", "Renamed chat")
+  })
+
   it("replaces machine session identifiers with a readable title", () => {
     const id = "agent::123e4567-e89b-12d3-a456-426614174000"
     expect(readablePaneTitle(id, id)).toBe("New chat")

--- a/packages/workspace/src/front/layout/types.ts
+++ b/packages/workspace/src/front/layout/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react"
-import type { ChatPaneDescriptor, ChatPanePendingPlacement, ChatPaneSplitDirection } from "./ChatPaneStage"
+import type { ChatPaneDescriptor, ChatPanePendingPlacement, ChatPaneSessionActions, ChatPaneSplitDirection } from "./ChatPaneStage"
 
 export interface IdeLayoutProps {
   sidebar?: string
@@ -16,6 +16,7 @@ export interface ChatLayoutProps {
   chatPanes?: ChatPaneDescriptor[]
   /** Optional host actions rendered in each chat pane header. */
   chatTopActions?: ReactNode
+  chatPaneSessionActions?: ChatPaneSessionActions
   activeChatPaneId?: string | null
   onActiveChatPaneChange?: (id: string) => void
   onCloseChatPane?: (id: string) => void


### PR DESCRIPTION
## Summary
Adds a compact session-actions menu beside each readable chat title while preserving split/close controls and the validated Workbench.

Closes #1049

## What changed
- Pin/unpin, rename, and conditional delete actions
- Reusable controlled `onRenameSession` host contract plus default AgentHost rename route
- Accessible dropdown and rename dialog
- Menu remains adjacent to the title; split/close controls remain right-aligned
- Showcase supports real controlled rename behavior

## Proof
- `pnpm --filter @hachej/boring-workspace exec vitest run src/front/layout/__tests__/ChatPaneStageDock.test.tsx src/app/front/__tests__/WorkspaceAgentFront.test.tsx` — 79 passed
- `pnpm --filter @hachej/boring-workspace typecheck` — passed
- `pnpm --filter @hachej/boring-workspace build` — passed (declaration bundling emitted the existing missing optional api-extractor warning)
- Browser proof: `http://100.68.199.114:5208/?showcase=1&reset=1`
- Rename proof: `/tmp/1049v2-renamed.png`

## Review
- Owner visually approved the menu and verified rename behavior.
- Reviewed SHA: `cad9512`

## Risk / rollback
Localized to chat header actions and session rename wiring. Revert the squash commit to roll back.
