### PR TITLE
#1064 Update GPT-5.6 worker pricing and routing

### DIFF
--- a/docs/kanzen/MODEL-CARD.md
+++ b/docs/kanzen/MODEL-CARD.md
@@ -5,14 +5,53 @@ taste, and cost. Cost is relative (`low`, `medium`, `high`, `scarce`), not prici
 
 | Level / role | Default | Transport / billing | Cost | Use |
 | --- | --- | --- | --- | --- |
-| L0 worker—easy | GPT-5.5 | Pi / API | low | bounded implementation |
-| L0 worker—medium | Tierra GT | Pi / API | medium | normal implementation |
+| L0 worker—easy | GPT-5.6 Luna | Pi / API | low | bounded implementation, tests, and objective checks |
+| L0 worker—medium | GPT-5.6 Terra | Pi / API | medium | normal implementation and local diagnosis |
 | L0 worker—hard | Sol medium | Pi / API | high | difficult implementation |
 | L0 visual-evidence operator | Qwen 3.6 on `mac` | Pi / local Mac provider | low | deterministic browser execution, asserted screenshots/video, logs, and HTML bundle packaging; never the visual critic or fix planner |
 | L1 orchestrator/integrator | Sol medium | Pi / API | high | readiness, delegation, synthesis, handoff |
 | L1 tier-1 reviewer | Gemini latest Pro, Grok latest, or Sol high | Pi / API | medium–high | fresh correctness, acceptance, proof, thermo |
 | L2 tier-2 reviewer | Sol xHigh | Pi / API | high | plans; medium/hard, structural, risky, uncertain work |
 | L3 tier-3 reviewer | Fable | Claude Code CLI / subscription | scarce | human-gated final falsification |
+
+## GPT-5.6 worker routing
+
+Route each stage separately:
+
+- **Sol** resolves uncertainty, plans, adjudicates tradeoffs, and handles hard or
+  consequential implementation.
+- **Terra** handles normal implementation that still needs diagnosis or local
+  design judgment.
+- **Luna** implements bounded, reversible work packets, writes/runs tests, and
+  checks objective acceptance criteria.
+
+A Luna packet names one outcome, relevant context, invariants, forbidden changes,
+proof commands, and stop conditions for unapproved product, API, architecture,
+security, or scope choices. Escalate when requirements are ambiguous, tests do
+not localize failure, cross-layer tradeoffs appear, or one focused retry fails.
+Worker self-check is not independent review; consequential work still follows the
+review ladder.
+
+### Price snapshot
+
+Verified 2026-08-04. Prices are base API rates per million text tokens.
+
+| Model | Input | Cached input | Output | Announced reduction |
+| --- | ---: | ---: | ---: | ---: |
+| GPT-5.6 Luna | $0.20 | $0.02 | $1.20 | 80% |
+| GPT-5.6 Terra | $2.00 | $0.20 | $12.00 | 20% |
+
+Prompts over 272K input tokens are billed at 2× input and 1.5× output for the
+full request; cache writes are billed at 1.25× uncached input. API pricing is not
+subscription quota accounting. Treat price as a routing input, not evidence of a
+capability change. Track first-pass success, review findings, retries, elapsed
+time, and total cost per accepted change before changing roles.
+
+Refresh this snapshot through the
+[documentation refresh task list](documentation-refresh-tasks.md). Official
+sources: [price-performance announcement](https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/),
+[Luna model documentation](https://developers.openai.com/api/docs/models/gpt-5.6-luna),
+and [Terra model documentation](https://developers.openai.com/api/docs/models/gpt-5.6-terra).
 
 ## Visual evidence operator
 

--- a/docs/kanzen/README.md
+++ b/docs/kanzen/README.md
@@ -11,6 +11,7 @@ Active explicit-only skills live in `.agents/skills/`. Invoke with
 | --- | --- |
 | workflow, states, quality bars | [`boring-loop.md`](boring-loop.md) |
 | models and review tiers | [`MODEL-CARD.md`](MODEL-CARD.md) |
+| nightly documentation refresh | [`procedures/documentation-refresh.md`](procedures/documentation-refresh.md), [`documentation-refresh-tasks.md`](documentation-refresh-tasks.md) |
 | coding/invariants/commands | [`procedures/`](procedures/) |
 | proof | [`procedures/proof-of-work.md`](procedures/proof-of-work.md) |
 | human handoff | [`procedures/owner-review-card.md`](procedures/owner-review-card.md) |

--- a/docs/kanzen/documentation-refresh-tasks.md
+++ b/docs/kanzen/documentation-refresh-tasks.md
@@ -1,0 +1,31 @@
+# Documentation Refresh Tasks
+
+The nightly [documentation refresh procedure](procedures/documentation-refresh.md)
+runs only tasks whose cadence is due. A task remains here only while it gates a
+named capability.
+
+| ID | Cadence | Gate | Targets | Primary sources | Validation |
+| --- | --- | --- | --- | --- | --- |
+| `internal-links` | nightly | navigable canonical docs | changed canonical Markdown | repository paths | resolve relative links |
+| `model-pricing` | weekly | cost-aware model routing | [`MODEL-CARD.md`](MODEL-CARD.md) price snapshot | official model and pricing pages linked from the card | verify base/cached/output units, qualifiers, links, and `git diff --check` |
+| `model-capabilities` | weekly | valid worker/reviewer routing | [`MODEL-CARD.md`](MODEL-CARD.md) defaults and roles | official model pages plus repository eval evidence | factual update or `policy-review-needed` |
+| `repo-commands` | weekly | executable contributor guidance | command-bearing Kanzen/package docs | workspace scripts and CI workflows | run or resolve each changed command |
+| `version-references` | monthly | accurate release/install guidance | version-bearing canonical docs | manifests and release metadata | compare exact versions and links |
+
+## Model-pricing task
+
+For every explicitly priced model:
+
+1. Record the UTC check date and official URLs.
+2. Compare base input, cached input, and output prices per million tokens.
+3. Record long-context multipliers, cache-write premiums, batch discounts, tool
+   fees, and fast/priority premiums when they qualify a quoted price.
+4. Keep API pricing separate from subscription quotas or credit accounting.
+5. Update the snapshot only when a quoted value or qualifier changed.
+6. Do not promote or demote a model on price alone. Routing changes require
+   repository evidence such as first-pass success, review findings, retries,
+   elapsed time, and total cost per accepted change.
+7. Treat model renames, retirements, context changes, and tool-support changes as
+   `model-capabilities`, not silent pricing edits.
+
+A successful no-change result is a run report, not a repository commit.

--- a/docs/kanzen/procedures/documentation-refresh.md
+++ b/docs/kanzen/procedures/documentation-refresh.md
@@ -1,0 +1,50 @@
+# Documentation Refresh
+
+Run this procedure nightly. It executes only due tasks from
+[`../documentation-refresh-tasks.md`](../documentation-refresh-tasks.md) and
+keeps source-backed operational documentation aligned with the capabilities it
+gates.
+
+## Rules
+
+- Use primary sources: repository files for repository facts and official vendor
+  pages for external facts.
+- No change means no file edit and no commit.
+- Update facts automatically only when the source is unambiguous.
+- Return `policy-review-needed` for routing, architecture, safety, or product
+  decisions. A price change alone does not prove a capability change.
+- Do not create freshness dashboards, ledgers, or reports in the repository.
+  Keep the run report in the automation log or PR proof.
+
+## Nightly procedure
+
+1. Read the task list and select tasks whose cadence is due.
+2. For each task, read its targets and primary sources before comparing values.
+3. Record the same units and qualifiers. Do not compare base API price with
+   cached, batch, long-context, subscription, tool, or priority pricing.
+4. Apply the smallest factual correction. If evidence conflicts or policy must
+   change, do not guess; report `policy-review-needed`.
+5. If files changed, run each task's validation plus `git diff --check`, inspect
+   the complete diff, and obtain independent documentation review.
+6. Open a targeted PR containing only related documentation changes. If no files
+   changed, report `checked—no change` and stop.
+
+## Nightly invocation
+
+```text
+Run docs/kanzen/procedures/documentation-refresh.md. Execute only due tasks from
+docs/kanzen/documentation-refresh-tasks.md. Use primary sources, make no edit
+when facts are unchanged, and return policy-review-needed instead of silently
+changing policy.
+```
+
+## Run report
+
+```text
+checked_at_utc: <date>
+due_tasks: <task ids>
+result: no-change | updated | policy-review-needed
+sources: <primary URLs or repository paths>
+changes: <none or concise summary>
+validation: <commands and review result>
+```


### PR DESCRIPTION
## Summary

- update easy/medium worker defaults to GPT-5.6 Luna and Terra
- document Sol → Terra/Luna stage routing and escalation boundaries
- record official Luna and Terra base API prices, reductions, and billing qualifiers
- add one nightly documentation-refresh procedure with a due-task registry; model pricing runs weekly as one task
- prevent no-change commits and price-only capability-policy changes

Closes #1064

## Proof of work

Automated verification:
- `git diff --check` ✅
- 18 relative Markdown links resolved ✅
- Markdown whitespace/final-newline checks ✅

Source verification:
- OpenAI Luna documentation: `$0.20` input, `$0.02` cached input, `$1.20` output ✅
- OpenAI Terra documentation: `$2.00` input, `$0.20` cached input, `$12.00` output ✅
- OpenAI announcement: Luna 80% reduction, Terra 20% reduction ✅
- Official model pages: >272K and cache-write qualifiers confirmed ✅

Review:
- independent documentation review: `SHIP`, no blockers

Waiver / known gaps:
- Code tests are not applicable to this documentation-only change.
