### PR TITLE
#1062 Polish navigation and session rail

### DIFF
--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -14,6 +14,55 @@ function isShowcaseRoute(): boolean {
   return new URLSearchParams(window.location.search).get("showcase") === "1"
 }
 
+const showcaseSessionTitles = [
+  "Navigation polish review",
+  "Fix mobile drawer focus",
+  "Investigate session persistence",
+  "Prepare release checklist",
+  "Review workspace permissions",
+  "Refactor command routing",
+  "Debug background task status",
+  "Plan analytics dashboard",
+  "Improve empty states",
+  "Audit keyboard navigation",
+  "Update onboarding copy",
+  "Long-running migration follow-up and rollback planning",
+  "Trace file synchronization",
+  "Review pull request feedback",
+  "Prototype data explorer",
+  "Resolve flaky integration test",
+  "Document runtime architecture",
+  "Optimize initial workspace load",
+  "Design notification preferences",
+  "Test narrow viewport behavior",
+  "Review dependency updates",
+  "Investigate API timeout",
+  "Draft customer handoff",
+  "Polish dark mode contrast",
+  "Verify deployment health",
+  "Explore plugin permissions",
+  "Triage accessibility findings",
+  "Plan session search",
+  "Compare model responses",
+  "Archive completed experiments",
+]
+
+function showcaseSessionCount(): number {
+  if (typeof window === "undefined") return 1
+  const requested = Number(new URLSearchParams(window.location.search).get("sessions") ?? 1)
+  return Number.isFinite(requested) ? Math.min(100, Math.max(1, Math.floor(requested))) : 1
+}
+
+function createInitialShowcaseSessions() {
+  const count = showcaseSessionCount()
+  const now = Date.now()
+  return Array.from({ length: count }, (_, index) => ({
+    id: index === 0 ? SHOWCASE_SESSION_ID : `${SHOWCASE_SESSION_ID}-${index + 1}`,
+    title: showcaseSessionTitles[index % showcaseSessionTitles.length] ?? `Session ${index + 1}`,
+    updatedAt: now - index * 60_000,
+  }))
+}
+
 function isFullPageRoute(): boolean {
   if (typeof window === "undefined") return false
   return window.location.pathname === "/full-page" || window.location.pathname === "/full-page/"
@@ -155,13 +204,7 @@ export function WorkspaceShell() {
   const [workspaceId, setWorkspaceId] = useState("Workspace")
   const [metaLoaded, setMetaLoaded] = useState(showcase || fullPage)
   const [showcaseActiveSessionId, setShowcaseActiveSessionId] = useState(SHOWCASE_SESSION_ID)
-  const [showcaseSessions, setShowcaseSessions] = useState(() => [
-    {
-      id: SHOWCASE_SESSION_ID,
-      title: "Showcase conversation",
-      updatedAt: Date.now(),
-    },
-  ])
+  const [showcaseSessions, setShowcaseSessions] = useState(createInitialShowcaseSessions)
   const sessions = showcase ? showcaseSessions : undefined
   const showcaseSessionSequence = useRef(0)
   const createShowcaseSession = useCallback(() => {
@@ -226,7 +269,7 @@ export function WorkspaceShell() {
 
   return (
     <WorkspaceAgentFront
-      workspaceId={showcase ? "playground" : workspaceId}
+      workspaceId={showcase ? "default" : workspaceId}
       agentTypeId="default"
       apiBaseUrl=""
       persistenceEnabled

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -21,7 +21,7 @@ import { SkillsPage } from "../../front/chrome/skills/SkillsPage"
 import { WorkspaceShellCapabilitiesProvider } from "../../front/shell/WorkspaceShellCapabilitiesContext"
 import { useWorkspaceShellCapabilitiesHost } from "./WorkspaceShellCapabilitiesHost"
 import { PluginsOverlay } from "../../front/chrome/plugins/PluginsOverlay"
-import { AppLeftPane } from "../../front/layout/plugin-tabs/AppLeftPane"
+import { AppLeftPane, AppLeftRail } from "../../front/layout/plugin-tabs/AppLeftPane"
 import { PluginTabsWorkspaceShell } from "../../front/layout/plugin-tabs/PluginTabsWorkspaceShell"
 import { useViewportWidth } from "../../front/layout/useViewportWidth"
 import { captureWorkspaceFrontPlugins } from "./workspaceBuiltinPlugins"
@@ -2014,7 +2014,7 @@ export function WorkspaceAgentFront<
     plugins: capturedPlugins,
     activeOverlay: leftOverlay,
     onClose: () => setLeftOverlay(null),
-    headerInsetStart: appLeftPaneCollapsed,
+    headerInsetStart: mobileShellActive,
     headerInsetEnd: !surfaceOpen,
   })
   const customLeftOverlayNode = useMemo(() => {
@@ -2022,16 +2022,16 @@ export function WorkspaceAgentFront<
     if (!overlay) return null
     return overlay.render({
       onClose: () => setLeftOverlay(null),
-      headerInsetStart: appLeftPaneCollapsed,
+      headerInsetStart: mobileShellActive,
       headerInsetEnd: !surfaceOpen,
       workspaceId,
     })
-  }, [appLeftOverlayActions, appLeftPaneCollapsed, leftOverlay, surfaceOpen, workspaceId])
+  }, [appLeftOverlayActions, leftOverlay, mobileShellActive, surfaceOpen, workspaceId])
 
   const leftOverlayNode = pluginLeftOverlayNode ?? customLeftOverlayNode ?? (leftOverlay === "skills" && skillsActionEnabled ? (
     <SkillsPage
       onClose={() => setLeftOverlay(null)}
-      headerInsetStart={appLeftPaneCollapsed}
+      headerInsetStart={mobileShellActive}
       headerInsetEnd={!surfaceOpen}
     />
   ) : leftOverlay === "plugins" && pluginsActionEnabled ? (
@@ -2041,7 +2041,7 @@ export function WorkspaceAgentFront<
         agentTypeId: effectiveActiveSessionAgentTypeId ?? agentTypeId,
         sessionId: effectiveActiveSessionId ?? chatSessionId,
       })}
-      headerInsetStart={appLeftPaneCollapsed}
+      headerInsetStart={mobileShellActive}
       headerInsetEnd={!surfaceOpen}
     />
   ) : null)
@@ -2115,6 +2115,17 @@ export function WorkspaceAgentFront<
       minLeftPaneWidth={220}
       maxLeftPaneWidth={420}
       mobileShellEnabled={mobileShellEnabled}
+      collapsedRail={(
+        <AppLeftRail
+          actions={managementActions}
+          footerSlot={showThemeToggle ? <ThemeToggle /> : undefined}
+          onOpenCommandPalette={openCommandPalette}
+          onCreateSession={() => {
+            setLeftOverlay(null)
+            void createChatSession()
+          }}
+        />
+      )}
       leftPane={(
         <AppLeftPane
           width={effectiveAppLeftPaneWidth}
@@ -2145,6 +2156,7 @@ export function WorkspaceAgentFront<
           topSlot={topBarLeft}
           bottomSlot={showThemeToggle || topBarRight != null ? <div className="flex w-full min-w-0 items-center gap-2">{topBarRightContent}</div> : undefined}
           sessions={resolvedSessions}
+          sessionsLoading={remoteSessionsTransitioning}
           activeSessionRef={activeChatPaneRef}
           muteActiveSession={Boolean(leftOverlay)}
           openSessionRefs={openChatPaneRefs}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -574,12 +574,14 @@ describe("WorkspaceAgentFront", () => {
     expect(onSwitchSession).toHaveBeenCalledWith("s2", "default")
 
     const switchCallsAfterRowClick = onSwitchSession.mock.calls.length
-    await user.click(within(appNav).getByRole("button", { name: "Pin Second session" }))
+    await user.click(within(appNav).getByRole("button", { name: "Chat actions for Second session" }))
+    await user.click(screen.getByRole("menuitem", { name: "Pin chat" }))
     expect(onSwitchSession).toHaveBeenCalledTimes(switchCallsAfterRowClick)
     expect(within(appNav).getByText("Pinned")).toBeInTheDocument()
     expect(within(appNav).getByText("Chats")).toBeInTheDocument()
 
-    await user.click(within(appNav).getByRole("button", { name: "Open Third session in new chat pane" }))
+    await user.click(within(appNav).getByRole("button", { name: "Chat actions for Third session" }))
+    await user.click(screen.getByRole("menuitem", { name: "Open in new chat pane" }))
     expect(onSwitchSession).toHaveBeenCalledWith("s3", "default")
 
     await user.click(screen.getByRole("button", { name: "Hide app navigation" }))
@@ -726,7 +728,8 @@ describe("WorkspaceAgentFront", () => {
     expect(within(appNav).getByText("Chats")).toBeInTheDocument()
   })
 
-  it("renders multi-project app navigation with pinned sessions above the inline projects tree", () => {
+  it("renders multi-project app navigation with pinned sessions above the inline projects tree", async () => {
+    const user = userEvent.setup()
     const sessions = [
       { id: "s1", title: "Active project session", updatedAt: Date.now() - 1_000 },
       { id: "s2", title: "Pinned session", updatedAt: Date.now() - 2_000 },
@@ -769,18 +772,23 @@ describe("WorkspaceAgentFront", () => {
     expect(within(appNav).getByText("Beta kickoff")).toBeInTheDocument()
     expect(within(appNav).queryByRole("button", { name: "Pin Beta kickoff" })).not.toBeInTheDocument()
     expect(within(appNav).getByText("Active project session")).toBeInTheDocument()
-    // The active session is already open, so it offers no "open in a new pane".
-    expect(within(appNav).queryByRole("button", { name: "Open Active project session in new chat pane" })).not.toBeInTheDocument()
-    // A session that isn't open still does.
-    expect(within(appNav).getByRole("button", { name: "Open Pinned session in new chat pane" })).toBeInTheDocument()
-    expect(within(appNav).getByRole("button", { name: "Pin Active project session" })).toBeInTheDocument()
+    // The active session is already open, so its menu offers pinning but no split action.
+    await user.click(within(appNav).getByRole("button", { name: "Chat actions for Active project session" }))
+    expect(screen.queryByRole("menuitem", { name: "Open in new chat pane" })).not.toBeInTheDocument()
+    await user.click(screen.getByRole("menuitem", { name: "Pin chat" }))
+    // A session that isn't open still offers the split action.
+    await user.click(within(appNav).getByRole("button", { name: "Chat actions for Pinned session" }))
+    await user.click(screen.getByRole("menuitem", { name: "Open in new chat pane" }))
+    // Restore the active project session to its project tree before collapsing it.
+    await user.click(within(appNav).getByRole("button", { name: "Chat actions for Active project session" }))
+    await user.click(screen.getByRole("menuitem", { name: "Unpin chat" }))
     expect(within(appNav).getByText("Pinned session")).toBeInTheDocument()
     expect(within(appNav).getByText("Chats")).toBeInTheDocument()
     // Per-project action: start a new chat inside a specific project.
     expect(within(appNav).getByRole("button", { name: "New chat in Project Alpha" })).toBeInTheDocument()
 
     // The chevron (not the row) toggles expansion.
-    fireEvent.click(collapseAlpha)
+    fireEvent.click(within(appNav).getByRole("button", { name: "Collapse Project Alpha" }))
     expect(within(appNav).getByRole("button", { name: "Expand Project Alpha" })).toHaveAttribute("aria-expanded", "false")
     expect(within(appNav).queryByText("Active project session")).not.toBeInTheDocument()
   })

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -585,6 +585,12 @@ describe("WorkspaceAgentFront", () => {
     await user.click(screen.getByRole("button", { name: "Hide app navigation" }))
     expect(screen.queryByLabelText("App navigation")).not.toBeInTheDocument()
     expect(document.querySelector('[data-boring-workspace-part="app-left-pane"]')).toBeNull()
+    const collapsedRail = screen.getByLabelText("Collapsed app navigation")
+    expect(collapsedRail).toHaveClass("w-11")
+    expect(within(collapsedRail).getByRole("button", { name: "Search" })).toBeInTheDocument()
+    expect(within(collapsedRail).getByRole("button", { name: "Plugins" })).toBeInTheDocument()
+    expect(within(collapsedRail).getByRole("button", { name: "Skills" })).toBeInTheDocument()
+    expect(within(collapsedRail).getByRole("button", { name: "New chat" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Open app navigation" })).toBeInTheDocument()
   })
 
@@ -611,6 +617,7 @@ describe("WorkspaceAgentFront", () => {
 
     await user.click(automations)
     expect(automations).toHaveAttribute("data-active", "true")
+    expect(automations).toHaveAttribute("aria-current", "page")
     expect(plugins).not.toHaveAttribute("data-active")
 
     await user.click(plugins)
@@ -768,7 +775,7 @@ describe("WorkspaceAgentFront", () => {
     expect(within(appNav).getByRole("button", { name: "Open Pinned session in new chat pane" })).toBeInTheDocument()
     expect(within(appNav).getByRole("button", { name: "Pin Active project session" })).toBeInTheDocument()
     expect(within(appNav).getByText("Pinned session")).toBeInTheDocument()
-    expect(within(appNav).queryByText("Chats")).not.toBeInTheDocument()
+    expect(within(appNav).getByText("Chats")).toBeInTheDocument()
     // Per-project action: start a new chat inside a specific project.
     expect(within(appNav).getByRole("button", { name: "New chat in Project Alpha" })).toBeInTheDocument()
 
@@ -1031,7 +1038,7 @@ describe("WorkspaceAgentFront", () => {
       expect(screen.getByText("/review")).toBeInTheDocument()
 
       await user.click(screen.getByRole("button", { name: "Hide app navigation" }))
-      expect(screen.getByText("Skills").closest("header")?.className).toContain("pl-12")
+      expect(screen.getByText("Skills").closest("header")?.className).not.toContain("pl-12")
 
       await user.click(screen.getByRole("button", { name: "Close skills" }))
       expect(screen.queryByText("/review")).not.toBeInTheDocument()

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -850,7 +850,7 @@ export function SurfaceShell({
             type="button"
             variant="ghost"
             size="icon-xs"
-            className="pointer-events-auto"
+            className="workbench-open-button pointer-events-auto"
             onClick={toggleHostWorkbench}
             aria-label="Open workbench"
             title="Open workbench (⌘2)"

--- a/packages/workspace/src/front/dock/dockview-overrides.css
+++ b/packages/workspace/src/front/dock/dockview-overrides.css
@@ -64,18 +64,6 @@
   padding-left: 44px !important;
 }
 
-/* Plugin-tabs shell: when the app-navigation left pane is collapsed, the
-   fixed top-left "Open app navigation" corner control (24px at left-3,
-   right edge x=36) overlays the chat stage. Reserve header-only space on the
-   chat stage's flat pane header so the session title clears that control
-   instead of sitting underneath it. Only applies in the collapsed state; when
-   the left pane is open the control sits over the app-nav header, not the
-   chat. 48px = control right edge (36) + 12px gap. */
-[data-boring-workspace-part="plugin-tabs-shell"][data-boring-state="collapsed"] .dv-chat-stage .dv-tabs-and-actions-container,
-[data-boring-workspace-part="plugin-tabs-shell"][data-boring-state="collapsed"] .dv-chat-stage .tabs-and-actions-container {
-  padding-left: 48px !important;
-}
-
 /* The app shell renders fixed top-right workbench/full-workspace controls
    over this 44px tab strip. Reserve enough room so dockview's built-in open-tabs
    overflow trigger sits left of that chrome instead of underneath it.

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -387,7 +387,7 @@ export function AppLeftPane({
       )}
 
       <section className="boring-scrollbar-discreet min-h-0 max-h-[45%] shrink overflow-y-auto px-2 pb-3" aria-labelledby="app-left-workspace-heading">
-        <h2 id="app-left-workspace-heading" className="px-2 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">
+        <h2 id="app-left-workspace-heading" className="px-2 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/75">
           Workspace
         </h2>
         <nav className="space-y-0.5" aria-label="Workspace actions">
@@ -407,7 +407,7 @@ export function AppLeftPane({
       </section>
 
       <section className="flex min-h-24 flex-1 flex-col border-t border-border/40 pt-3" aria-labelledby="app-left-chats-heading">
-        <h2 id="app-left-chats-heading" className="shrink-0 px-4 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">
+        <h2 id="app-left-chats-heading" className="shrink-0 px-4 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/75">
           Chats
         </h2>
         <div data-boring-workspace-part="app-left-new-chat" className="shrink-0 px-2 pb-2">
@@ -451,7 +451,7 @@ export function AppLeftPane({
                   {pinnedSessions.map((session) => renderSession(session, true))}
                 </SessionSubSection>
               ) : null}
-              <SessionSubSection title="Recent" empty={sessionsLoading ? "Loading chats…" : "No chats yet."}>
+              <SessionSubSection title={pinnedSessions.length > 0 ? "Recent" : undefined} empty={sessionsLoading ? "Loading chats…" : "No chats yet."}>
                 {regularSessions.map((session) => renderSession(session, false))}
               </SessionSubSection>
             </div>
@@ -459,7 +459,7 @@ export function AppLeftPane({
         </div>
       </section>
 
-      {bottomSlot ? <footer className="shrink-0 border-t border-border/40 p-2">{bottomSlot}</footer> : null}
+      {bottomSlot ? <footer data-boring-workspace-part="app-left-footer" className="shrink-0 border-t border-border/40 p-2">{bottomSlot}</footer> : null}
     </aside>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react"
 import { Plus, Search } from "lucide-react"
 import { AppLeftPaneHeader } from "./AppLeftPaneHeader"
-import { PrimaryAction, NewChatAction, KbdHint } from "./AppLeftPaneActions"
+import { PrimaryAction, NewChatAction, KbdHint, RailAction } from "./AppLeftPaneActions"
 import { ProjectOverview, usePinnedProjectIds } from "./AppLeftPaneProjects"
 import { AppSessionRow, type AppSessionRowState } from "./AppLeftPaneSessionRow"
 import { SessionSubSection } from "./AppLeftPaneSections"
@@ -72,6 +72,7 @@ export interface AppLeftPaneProps {
   /** full: brand + workspace, workspace: workspace picker only, hidden: reserve collapse clearance only. */
   headerMode?: AppLeftPaneHeaderMode
   sessions: AppLeftPaneSession[]
+  sessionsLoading?: boolean
   /** Raw legacy native session id. */
   activeSessionId?: string | null
   /** Structured Workspace-internal active session ref. */
@@ -130,6 +131,51 @@ function useWorkingSessionIds(): ReadonlySet<string> {
   return working
 }
 
+export function AppLeftRail({
+  actions = [],
+  footerSlot,
+  onCreateSession,
+  onOpenCommandPalette,
+}: Pick<AppLeftPaneProps, "actions" | "onCreateSession" | "onOpenCommandPalette"> & { footerSlot?: ReactNode }) {
+  return (
+    <aside
+      data-boring-workspace-part="app-left-rail"
+      className="flex h-full w-11 shrink-0 flex-col items-center border-r border-border bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)] px-1 pb-1 pt-12"
+      aria-label="Collapsed app navigation"
+    >
+      <nav className="boring-scrollbar-discreet flex min-h-0 w-full flex-1 flex-col items-center gap-1 overflow-y-auto overflow-x-hidden" aria-label="Workspace shortcuts">
+        <RailAction
+          icon={<Search className="h-4 w-4" strokeWidth={1.75} />}
+          label="Search"
+          onClick={onOpenCommandPalette}
+        />
+        {actions.map((action) => (
+          <RailAction
+            key={action.id}
+            icon={action.icon}
+            label={action.label}
+            onClick={action.onClick}
+            active={action.active}
+            trailing={action.trailing}
+          />
+        ))}
+      </nav>
+      <div className="flex w-full shrink-0 flex-col items-center gap-1 border-t border-border/50 pt-1">
+        <RailAction
+          icon={<Plus className="h-4 w-4" strokeWidth={2} />}
+          label="New chat"
+          onClick={onCreateSession}
+        />
+        {footerSlot ? (
+          <div className="flex w-9 justify-center" data-boring-workspace-part="app-left-rail-footer">
+            {footerSlot}
+          </div>
+        ) : null}
+      </div>
+    </aside>
+  )
+}
+
 export function AppLeftPane({
   width = 268,
   appTitle,
@@ -147,6 +193,7 @@ export function AppLeftPane({
   bottomSlot,
   headerMode = "full",
   sessions,
+  sessionsLoading = false,
   activeSessionId,
   activeSessionRef,
   muteActiveSession = false,
@@ -339,75 +386,78 @@ export function AppLeftPane({
         <div className="h-12 shrink-0" aria-hidden="true" />
       )}
 
-      <nav className="shrink-0 space-y-0.5 px-2 pb-1 pt-1" aria-label="Primary workspace actions">
-        <PrimaryAction icon={<Search className="h-4 w-4" strokeWidth={1.75} />} label="Search" onClick={onOpenCommandPalette} trailing={<KbdHint keys="⌘K" />} />
-        {actions.map((action) => (
-          <PrimaryAction
-            key={action.id}
-            icon={action.icon}
-            label={action.label}
-            onClick={action.onClick}
-            trailing={action.trailing}
-            emphasis={action.emphasis}
-            active={action.active}
-          />
-        ))}
-      </nav>
+      <section className="boring-scrollbar-discreet min-h-0 max-h-[45%] shrink overflow-y-auto px-2 pb-3" aria-labelledby="app-left-workspace-heading">
+        <h2 id="app-left-workspace-heading" className="px-2 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">
+          Workspace
+        </h2>
+        <nav className="space-y-0.5" aria-label="Workspace actions">
+          <PrimaryAction icon={<Search className="h-4 w-4" strokeWidth={1.75} />} label="Search" onClick={onOpenCommandPalette} trailing={<KbdHint keys="⌘K" />} />
+          {actions.map((action) => (
+            <PrimaryAction
+              key={action.id}
+              icon={action.icon}
+              label={action.label}
+              onClick={action.onClick}
+              trailing={action.trailing}
+              emphasis={action.emphasis}
+              active={action.active}
+            />
+          ))}
+        </nav>
+      </section>
 
-      <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 py-2">
-        <div className="pb-2">
+      <section className="flex min-h-24 flex-1 flex-col border-t border-border/40 pt-3" aria-labelledby="app-left-chats-heading">
+        <h2 id="app-left-chats-heading" className="shrink-0 px-4 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">
+          Chats
+        </h2>
+        <div
+          data-boring-workspace-part="app-left-session-scroll"
+          className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 pb-2 [mask-image:linear-gradient(to_bottom,transparent_0,black_8px,black_calc(100%_-_8px),transparent_100%)] motion-reduce:[mask-image:none]"
+        >
+          {/* Multi-project (PR2): projects remain inside the Chats region. */}
+          {layoutMode === "multi-project" ? (
+            <div className="space-y-3 py-1">
+              {pinnedSessions.length > 0 || pinnedProjects.length > 0 ? (
+                <SessionSubSection title="Pinned">
+                  {pinnedSessions.map((session) => renderSession(session, true))}
+                  {pinnedProjects.length > 0 ? renderProjectTree(pinnedProjects) : null}
+                </SessionSubSection>
+              ) : null}
+              <section data-boring-workspace-part="app-left-pane-section" className="space-y-1">
+                <div className="flex items-center justify-between gap-1 px-2 pb-0.5">
+                  <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/65">{workspaceSectionTitle}</span>
+                  {onCreateProject ? (
+                    <button
+                      type="button"
+                      aria-label="New project"
+                      title="New project"
+                      onClick={onCreateProject}
+                      className="grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors motion-reduce:transition-none hover:bg-foreground/[0.055] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                    >
+                      <Plus className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
+                    </button>
+                  ) : null}
+                </div>
+                {renderProjectTree(unpinnedProjectItems)}
+              </section>
+            </div>
+          ) : (
+            <div className="space-y-4 py-1">
+              {pinnedSessions.length > 0 ? (
+                <SessionSubSection title="Pinned">
+                  {pinnedSessions.map((session) => renderSession(session, true))}
+                </SessionSubSection>
+              ) : null}
+              <SessionSubSection title="Recent" empty={sessionsLoading ? "Loading chats…" : "No chats yet."}>
+                {regularSessions.map((session) => renderSession(session, false))}
+              </SessionSubSection>
+            </div>
+          )}
+        </div>
+        <div data-boring-workspace-part="app-left-new-chat" className="shrink-0 border-t border-border/40 px-2 py-2">
           <NewChatAction icon={<Plus className="h-4 w-4" strokeWidth={2} />} onCreateSession={onCreateSession} onCreateSplitSession={onCreateSplitSession} onCreatePopoverSession={onCreatePopoverSession} />
         </div>
-        {/* Multi-project (PR2): the Workspaces/projects tree. Single-project
-            shows no projects section — the workspace lives in the header above
-            and the body is just the session list. */}
-        {layoutMode === "multi-project" ? (
-          <div className="space-y-3 py-1">
-            {/* Pinned: pinned sessions + pinned projects (as full, expandable
-                rows). Pinned projects are removed from the Projects list below so
-                they're never shown twice. Hidden entirely when empty. */}
-            {pinnedSessions.length > 0 || pinnedProjects.length > 0 ? (
-              <SessionSubSection title="Pinned">
-                {pinnedSessions.map((session) => renderSession(session, true))}
-                {pinnedProjects.length > 0 ? renderProjectTree(pinnedProjects) : null}
-              </SessionSubSection>
-            ) : null}
-            <section data-boring-workspace-part="app-left-pane-section" className="space-y-1">
-              {/* Plain label header (matches "Pinned") — projects collapse
-                  individually via their own chevrons, so a section-level chevron
-                  here would just stutter against the first project's. */}
-              <div className="flex items-center justify-between gap-1 px-2 pb-0.5">
-                <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/65">{workspaceSectionTitle}</span>
-                {onCreateProject ? (
-                  <button
-                    type="button"
-                    aria-label="New project"
-                    title="New project"
-                    onClick={onCreateProject}
-                    className="grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-foreground/[0.055] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-                  >
-                    <Plus className="h-3.5 w-3.5" strokeWidth={2} aria-hidden="true" />
-                  </button>
-                ) : null}
-              </div>
-              {renderProjectTree(unpinnedProjectItems)}
-            </section>
-          </div>
-        ) : (
-          /* Single-project: no "Chats" wrapper — the session list is the whole
-             point of the body, so show Pinned + Sessions directly. */
-          <div className="space-y-4 py-1">
-            {pinnedSessions.length > 0 ? (
-              <SessionSubSection title="Pinned">
-                {pinnedSessions.map((session) => renderSession(session, true))}
-              </SessionSubSection>
-            ) : null}
-            <SessionSubSection title="Chats" empty="No chats yet.">
-              {regularSessions.map((session) => renderSession(session, false))}
-            </SessionSubSection>
-          </div>
-        )}
-      </div>
+      </section>
 
       {bottomSlot ? <footer className="shrink-0 border-t border-border/40 p-2">{bottomSlot}</footer> : null}
     </aside>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -410,6 +410,9 @@ export function AppLeftPane({
         <h2 id="app-left-chats-heading" className="shrink-0 px-4 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/70">
           Chats
         </h2>
+        <div data-boring-workspace-part="app-left-new-chat" className="shrink-0 px-2 pb-2">
+          <NewChatAction icon={<Plus className="h-4 w-4" strokeWidth={2} />} onCreateSession={onCreateSession} onCreateSplitSession={onCreateSplitSession} onCreatePopoverSession={onCreatePopoverSession} />
+        </div>
         <div
           data-boring-workspace-part="app-left-session-scroll"
           className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 pb-2 [mask-image:linear-gradient(to_bottom,transparent_0,black_8px,black_calc(100%_-_8px),transparent_100%)] motion-reduce:[mask-image:none]"
@@ -453,9 +456,6 @@ export function AppLeftPane({
               </SessionSubSection>
             </div>
           )}
-        </div>
-        <div data-boring-workspace-part="app-left-new-chat" className="shrink-0 border-t border-border/40 px-2 py-2">
-          <NewChatAction icon={<Plus className="h-4 w-4" strokeWidth={2} />} onCreateSession={onCreateSession} onCreateSplitSession={onCreateSplitSession} onCreatePopoverSession={onCreatePopoverSession} />
         </div>
       </section>
 

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -38,7 +38,6 @@ export function PrimaryAction({
     >
       <span className={cn("grid size-5 shrink-0 place-items-center", active ? "text-[color:var(--accent)]" : emphasis ? "text-foreground/90" : "text-muted-foreground")} aria-hidden="true">{icon}</span>
       <span className="min-w-0 flex-1 truncate">{label}</span>
-      {active ? <span aria-hidden="true" className="size-1.5 shrink-0 rounded-full bg-[color:var(--accent)]" /> : null}
       {trailing ? <span className="shrink-0">{trailing}</span> : null}
     </button>
   )

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import type { ReactNode } from "react"
-import { Columns2, Zap } from "lucide-react"
+import { Columns2, MoreHorizontal, Zap } from "lucide-react"
 import { cn } from "../../lib/utils"
 
 export function PrimaryAction({
@@ -23,7 +23,9 @@ export function PrimaryAction({
     <button
       type="button"
       onClick={onClick}
+      data-boring-mobile-dismiss="true"
       data-active={active ? "true" : undefined}
+      aria-current={active ? "page" : undefined}
       className={cn(
         "relative flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
         active
@@ -42,6 +44,45 @@ export function PrimaryAction({
   )
 }
 
+export function RailAction({
+  icon,
+  label,
+  onClick,
+  active = false,
+  trailing,
+}: {
+  icon: ReactNode
+  label: string
+  onClick: () => void
+  active?: boolean
+  trailing?: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      data-active={active ? "true" : undefined}
+      aria-current={active ? "page" : undefined}
+      onClick={onClick}
+      className={cn(
+        "relative grid size-9 place-items-center rounded-lg text-muted-foreground transition-colors motion-reduce:transition-none",
+        "hover:bg-foreground/[0.055] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50",
+        active && "bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-[color:var(--accent)]",
+      )}
+    >
+      <span className="grid size-5 place-items-center" aria-hidden="true">
+        {icon ?? <MoreHorizontal className="h-4 w-4" strokeWidth={1.75} />}
+      </span>
+      {trailing ? (
+        <span className="pointer-events-none absolute right-0 top-0 max-w-5 truncate rounded-full bg-background px-1 text-[9px] font-semibold leading-4 text-foreground shadow-sm" aria-hidden="true">
+          {trailing}
+        </span>
+      ) : null}
+    </button>
+  )
+}
+
 export function NewChatAction({
   icon,
   onCreateSession,
@@ -54,9 +95,10 @@ export function NewChatAction({
   onCreatePopoverSession?: () => void
 }) {
   return (
-    <div className="group flex h-8 w-full items-center rounded-md text-[13px] font-medium text-foreground transition-colors hover:bg-foreground/[0.045] focus-within:ring-2 focus-within:ring-ring/40">
+    <div className="group flex h-8 w-full items-center rounded-md text-[13px] font-medium text-foreground transition-colors motion-reduce:transition-none hover:bg-foreground/[0.045] focus-within:ring-2 focus-within:ring-ring/40">
       <button
         type="button"
+        data-boring-mobile-dismiss="true"
         onClick={(event) => {
           onCreateSession()
           event.currentTarget.blur()
@@ -66,12 +108,13 @@ export function NewChatAction({
         <span className="grid size-5 shrink-0 place-items-center text-foreground/90" aria-hidden="true">{icon}</span>
         <span className="min-w-0 flex-1 truncate">New chat</span>
       </button>
-      <span className="mr-1 flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity] group-hover:w-auto group-hover:opacity-100 group-focus-within:w-auto group-focus-within:opacity-100">
+      <span className="mr-1 flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity] motion-reduce:transition-none group-hover:w-auto group-hover:opacity-100 group-focus-within:w-auto group-focus-within:opacity-100">
         {onCreateSplitSession ? (
           <button
             type="button"
             aria-label="New chat in split pane"
             title="New chat in split pane"
+            data-boring-mobile-dismiss="true"
             onClick={(event) => {
               event.stopPropagation()
               onCreateSplitSession()
@@ -87,6 +130,7 @@ export function NewChatAction({
             type="button"
             aria-label="Quick chat"
             title="Quick chat"
+            data-boring-mobile-dismiss="true"
             onClick={(event) => {
               event.stopPropagation()
               onCreatePopoverSession()

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneActions.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react"
 import { Columns2, MoreHorizontal, Zap } from "lucide-react"
 import { cn } from "../../lib/utils"
+import { ControlTooltip } from "../../components/ControlTooltip"
 
 export function PrimaryAction({
   icon,
@@ -27,10 +28,10 @@ export function PrimaryAction({
       data-active={active ? "true" : undefined}
       aria-current={active ? "page" : undefined}
       className={cn(
-        "relative flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+        "app-left-primary-action relative flex h-8 w-full items-center gap-2 rounded-md px-2 text-left text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         active
           // When an overlay is open, it owns the selected nav state.
-          ? "bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-foreground hover:bg-[color:oklch(from_var(--accent)_l_c_h/0.18)]"
+          ? "bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] font-semibold text-foreground hover:bg-[color:oklch(from_var(--accent)_l_c_h/0.18)]"
           : emphasis
             ? "text-foreground hover:bg-foreground/[0.045]"
             : "text-foreground/82 hover:bg-foreground/[0.055] hover:text-foreground",
@@ -57,28 +58,29 @@ export function RailAction({
   trailing?: ReactNode
 }) {
   return (
-    <button
-      type="button"
-      aria-label={label}
-      title={label}
-      data-active={active ? "true" : undefined}
-      aria-current={active ? "page" : undefined}
-      onClick={onClick}
-      className={cn(
-        "relative grid size-9 place-items-center rounded-lg text-muted-foreground transition-colors motion-reduce:transition-none",
-        "hover:bg-foreground/[0.055] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring/50",
-        active && "bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-[color:var(--accent)]",
-      )}
-    >
-      <span className="grid size-5 place-items-center" aria-hidden="true">
-        {icon ?? <MoreHorizontal className="h-4 w-4" strokeWidth={1.75} />}
-      </span>
-      {trailing ? (
-        <span className="pointer-events-none absolute right-0 top-0 max-w-5 truncate rounded-full bg-background px-1 text-[9px] font-semibold leading-4 text-foreground shadow-sm" aria-hidden="true">
-          {trailing}
+    <ControlTooltip label={label} side="right">
+      <button
+        type="button"
+        aria-label={label}
+        data-active={active ? "true" : undefined}
+        aria-current={active ? "page" : undefined}
+        onClick={onClick}
+        className={cn(
+          "app-left-rail-action relative grid size-9 place-items-center rounded-lg text-muted-foreground transition-colors motion-reduce:transition-none",
+          "hover:bg-foreground/[0.055] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+          active && "bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-[color:var(--accent)]",
+        )}
+      >
+        <span className="grid size-5 place-items-center" aria-hidden="true">
+          {icon ?? <MoreHorizontal className="h-4 w-4" strokeWidth={1.75} />}
         </span>
-      ) : null}
-    </button>
+        {trailing ? (
+          <span className="pointer-events-none absolute right-0 top-0 max-w-5 truncate rounded-full bg-background px-1 text-[9px] font-semibold leading-4 text-foreground shadow-sm" aria-hidden="true">
+            {trailing}
+          </span>
+        ) : null}
+      </button>
+    </ControlTooltip>
   )
 }
 
@@ -94,7 +96,7 @@ export function NewChatAction({
   onCreatePopoverSession?: () => void
 }) {
   return (
-    <div className="group flex h-8 w-full items-center rounded-md text-[13px] font-medium text-foreground transition-colors motion-reduce:transition-none hover:bg-foreground/[0.045] focus-within:ring-2 focus-within:ring-ring/40">
+    <div className="app-left-new-chat-action group flex h-8 w-full items-center rounded-md text-[13px] font-medium text-foreground transition-colors motion-reduce:transition-none hover:bg-foreground/[0.045] focus-within:ring-2 focus-within:ring-ring">
       <button
         type="button"
         data-boring-mobile-dismiss="true"
@@ -102,12 +104,12 @@ export function NewChatAction({
           onCreateSession()
           event.currentTarget.blur()
         }}
-        className="flex min-w-0 flex-1 items-center gap-2 px-2 text-left focus-visible:outline-none"
+        className="flex h-full min-w-0 flex-1 items-center gap-2 px-2 text-left focus-visible:outline-none"
       >
         <span className="grid size-5 shrink-0 place-items-center text-foreground/90" aria-hidden="true">{icon}</span>
         <span className="min-w-0 flex-1 truncate">New chat</span>
       </button>
-      <span className="mr-1 flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity] motion-reduce:transition-none group-hover:w-auto group-hover:opacity-100 group-focus-within:w-auto group-focus-within:opacity-100">
+      <span className="app-left-new-chat-secondary mr-1 flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-opacity motion-reduce:transition-none group-hover:w-auto group-hover:opacity-100 group-focus-within:w-auto group-focus-within:opacity-100">
         {onCreateSplitSession ? (
           <button
             type="button"
@@ -119,7 +121,7 @@ export function NewChatAction({
               onCreateSplitSession()
               event.currentTarget.blur()
             }}
-            className="grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            className="app-left-secondary-action grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <Columns2 className="h-3.5 w-3.5" strokeWidth={1.75} aria-hidden="true" />
           </button>
@@ -135,7 +137,7 @@ export function NewChatAction({
               onCreatePopoverSession()
               event.currentTarget.blur()
             }}
-            className="grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            className="app-left-secondary-action grid size-6 place-items-center rounded-md text-muted-foreground transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <Zap className="h-3.5 w-3.5" strokeWidth={1.85} aria-hidden="true" />
           </button>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneProjects.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneProjects.tsx
@@ -183,6 +183,7 @@ function ProjectRow({
         <button
           type="button"
           aria-current={active ? "page" : undefined}
+          data-boring-mobile-dismiss="true"
           disabled={unavailable}
           onClick={() => { if (!unavailable) onActivate() }}
           className="min-w-0 flex-1 truncate rounded text-left text-[13px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 disabled:cursor-default"
@@ -217,6 +218,7 @@ function ProjectRow({
                   type="button"
                   aria-label={`New chat in ${name}`}
                   title="New chat"
+                  data-boring-mobile-dismiss="true"
                   onClick={(event) => { event.stopPropagation(); onCreateSession(project.id) }}
                   className="grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
                 >

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSections.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSections.tsx
@@ -2,14 +2,16 @@
 
 import type { ReactNode } from "react"
 
-export function SessionSubSection({ title, empty, children }: { title: string; empty?: string; children: ReactNode }) {
+export function SessionSubSection({ title, empty, children }: { title?: string; empty?: string; children: ReactNode }) {
   const hasChildren = Array.isArray(children) ? children.length > 0 : Boolean(children)
   if (!hasChildren && !empty) return null
   return (
     <div className="space-y-1">
-      <div className="px-2 pb-0.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
-        {title}
-      </div>
+      {title ? (
+        <div className="px-2 pb-0.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/75">
+          {title}
+        </div>
+      ) : null}
       <div className="space-y-0.5">
         {hasChildren ? children : <div className="px-2 py-1.5 text-xs text-muted-foreground/60">{empty}</div>}
       </div>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -18,15 +18,6 @@ function sessionBadgeToneClassName(tone: WorkspaceAttentionSessionBadge["tone"])
   }
 }
 
-function sessionBadgeDotClassName(tone: WorkspaceAttentionSessionBadge["tone"]): string {
-  switch (tone) {
-    case "danger": return "bg-destructive"
-    case "warning": return "bg-amber-500"
-    case "neutral": return "bg-muted-foreground/70"
-    default: return "bg-[color:var(--accent)]"
-  }
-}
-
 export function AppSessionRow({
   session,
   state,
@@ -54,6 +45,15 @@ export function AppSessionRow({
 }) {
   const title = session.title || "Untitled"
   const activate = () => onSwitch(session.id)
+  const actionCount = Number(state === "normal" && canSplit) + Number(canPin) + Number(Boolean(onDelete))
+  const actionWidthClassName = actionCount >= 3
+    ? "w-[88px]"
+    : actionCount === 2
+      ? "w-[58px]"
+      : actionCount === 1
+        ? "w-7"
+        : "w-0"
+  const statusWidthClassName = attentionBadge || working ? "w-[88px]" : actionWidthClassName
 
   return (
     <div
@@ -68,7 +68,7 @@ export function AppSessionRow({
         event.dataTransfer.setData("text/plain", title)
         event.dataTransfer.effectAllowed = "copyMove"
       } : undefined}
-      className="group relative h-9 w-full"
+      className="app-left-session-row group relative h-9 w-full"
     >
       <button
         type="button"
@@ -91,28 +91,25 @@ export function AppSessionRow({
             className={cn("h-4 w-4", state === "active" ? "text-[color:var(--accent)]" : "text-muted-foreground/65")}
             strokeWidth={1.75}
           />
-          {state === "active" ? <span className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-[color:var(--accent)] ring-2 ring-background" /> : null}
         </span>
-        <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5">
+        <span className={cn("min-w-0 flex-1 truncate text-[13px] leading-5", state === "active" ? "font-semibold" : "font-medium")}>
           {title}
         </span>
-        <span className="flex w-[88px] shrink-0 justify-end overflow-hidden group-hover:opacity-0 group-focus-within:opacity-0">
+        <span data-action-count={actionCount} data-has-status={attentionBadge || working ? "true" : "false"} className={cn("app-left-session-trailing flex shrink-0 justify-end overflow-hidden group-hover:opacity-0 group-focus-within:opacity-0", statusWidthClassName)}>
           {attentionBadge ? (
             <span
               data-boring-workspace-part="app-session-badge"
               data-boring-badge={attentionBadge.kind}
-              className={cn("pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none", sessionBadgeToneClassName(attentionBadge.tone))}
+              className={cn("pointer-events-none inline-flex max-w-full shrink-0 truncate rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none", sessionBadgeToneClassName(attentionBadge.tone))}
             >
-              <span aria-hidden="true" className={cn("h-1.5 w-1.5 animate-pulse rounded-full motion-reduce:animate-none", sessionBadgeDotClassName(attentionBadge.tone))} />
               {attentionBadge.label}
             </span>
           ) : working ? (
             <span
               data-boring-workspace-part="app-session-badge"
               data-boring-badge="working"
-              className="pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
+              className="pointer-events-none inline-flex shrink-0 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
             >
-              <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--accent)] motion-reduce:animate-none" />
               working
             </span>
           ) : pinned ? (
@@ -123,8 +120,10 @@ export function AppSessionRow({
 
       <span
         data-boring-workspace-part="app-session-actions"
+        data-action-count={actionCount}
         className={cn(
-          "pointer-events-none absolute inset-y-0 right-1 z-10 flex w-[88px] items-center justify-end gap-0.5 opacity-0 transition-opacity motion-reduce:transition-none",
+          "app-left-session-actions pointer-events-none absolute inset-y-0 right-1 z-10 flex items-center justify-end gap-0.5 opacity-0 transition-opacity motion-reduce:transition-none",
+          actionWidthClassName,
           "group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
         )}
       >
@@ -135,7 +134,7 @@ export function AppSessionRow({
             title="Open in new chat pane"
             data-boring-mobile-dismiss="true"
             onClick={() => onOpenAsPane(session.id)}
-            className="grid size-7 place-items-center rounded-md bg-background/90 text-muted-foreground shadow-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            className="app-left-session-secondary-action grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <MessageSquarePlus className="h-4 w-4" strokeWidth={1.75} />
           </button>
@@ -148,7 +147,7 @@ export function AppSessionRow({
             aria-pressed={pinned}
             onClick={() => onTogglePinned(session.id)}
             className={cn(
-              "grid size-7 place-items-center rounded-md bg-background/90 text-muted-foreground shadow-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+              "app-left-session-secondary-action grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
               pinned && "text-[color:var(--accent)]",
             )}
           >
@@ -163,7 +162,7 @@ export function AppSessionRow({
             onClick={() => {
               if (typeof window !== "undefined" && window.confirm(`Delete “${title}”?`)) onDelete(session.id)
             }}
-            className="grid size-7 place-items-center rounded-md bg-background/90 text-muted-foreground shadow-sm hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            className="app-left-session-secondary-action grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-foreground/[0.08] hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
             <X className="h-4 w-4" strokeWidth={1.75} />
           </button>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -1,6 +1,13 @@
 "use client"
 
-import { MessageSquare, MessageSquarePlus, Pin, X } from "lucide-react"
+import { MessageSquare, MessageSquarePlus, MoreHorizontal, Pin, PinOff, Trash2 } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import { CHAT_SESSION_DRAG_TYPE } from "../ChatPaneStage"
 import type { WorkspaceAttentionSessionBadge } from "../../attention/WorkspaceAttentionProvider"
@@ -45,14 +52,9 @@ export function AppSessionRow({
 }) {
   const title = session.title || "Untitled"
   const activate = () => onSwitch(session.id)
-  const actionCount = Number(state === "normal" && canSplit) + Number(canPin) + Number(Boolean(onDelete))
-  const actionWidthClassName = actionCount >= 3
-    ? "w-[88px]"
-    : actionCount === 2
-      ? "w-[58px]"
-      : actionCount === 1
-        ? "w-7"
-        : "w-0"
+  const hasActions = (state === "normal" && canSplit) || canPin || Boolean(onDelete)
+  const actionCount = hasActions ? 1 : 0
+  const actionWidthClassName = hasActions ? "w-7" : "w-0"
   const statusWidthClassName = attentionBadge || working ? "w-[88px]" : actionWidthClassName
 
   return (
@@ -127,45 +129,49 @@ export function AppSessionRow({
           "group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
         )}
       >
-        {state === "normal" && canSplit ? (
-          <button
-            type="button"
-            aria-label={`Open ${title} in new chat pane`}
-            title="Open in new chat pane"
-            data-boring-mobile-dismiss="true"
-            onClick={() => onOpenAsPane(session.id)}
-            className="app-left-session-secondary-action grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <MessageSquarePlus className="h-4 w-4" strokeWidth={1.75} />
-          </button>
-        ) : null}
-        {canPin ? (
-          <button
-            type="button"
-            aria-label={pinned ? `Unpin ${title}` : `Pin ${title}`}
-            title={pinned ? "Unpin" : "Pin"}
-            aria-pressed={pinned}
-            onClick={() => onTogglePinned(session.id)}
-            className={cn(
-              "app-left-session-secondary-action grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              pinned && "text-[color:var(--accent)]",
-            )}
-          >
-            <Pin className={cn("h-4 w-4", pinned && "fill-current")} strokeWidth={1.75} />
-          </button>
-        ) : null}
-        {onDelete ? (
-          <button
-            type="button"
-            aria-label={`Delete ${title}`}
-            title="Delete"
-            onClick={() => {
-              if (typeof window !== "undefined" && window.confirm(`Delete “${title}”?`)) onDelete(session.id)
-            }}
-            className="app-left-session-secondary-action grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-foreground/[0.08] hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <X className="h-4 w-4" strokeWidth={1.75} />
-          </button>
+        {hasActions ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                aria-label={`Chat actions for ${title}`}
+                title="Chat actions"
+                onClick={(event) => event.stopPropagation()}
+                className="app-left-session-secondary-action grid size-7 place-items-center rounded-md text-muted-foreground hover:bg-foreground/[0.08] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <MoreHorizontal className="h-4 w-4" strokeWidth={1.75} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" sideOffset={6} className="min-w-48">
+              {state === "normal" && canSplit ? (
+                <DropdownMenuItem data-boring-mobile-dismiss="true" onSelect={() => onOpenAsPane(session.id)}>
+                  <MessageSquarePlus className="mr-2 h-4 w-4" />
+                  Open in new chat pane
+                </DropdownMenuItem>
+              ) : null}
+              {canPin ? (
+                <DropdownMenuItem onSelect={() => onTogglePinned(session.id)}>
+                  {pinned ? <PinOff className="mr-2 h-4 w-4" /> : <Pin className="mr-2 h-4 w-4" />}
+                  {pinned ? "Unpin chat" : "Pin chat"}
+                </DropdownMenuItem>
+              ) : null}
+              {onDelete ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    variant="destructive"
+                    data-boring-mobile-dismiss="true"
+                    onSelect={() => {
+                      if (typeof window !== "undefined" && window.confirm(`Delete “${title}”?`)) onDelete(session.id)
+                    }}
+                  >
+                    <Trash2 className="mr-2 h-4 w-4" />
+                    Delete chat
+                  </DropdownMenuItem>
+                </>
+              ) : null}
+            </DropdownMenuContent>
+          </DropdownMenu>
         ) : null}
       </span>
     </div>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Clock3, MessageSquarePlus, Pin, X } from "lucide-react"
+import { MessageSquare, MessageSquarePlus, Pin, X } from "lucide-react"
 import { cn } from "../../lib/utils"
 import { CHAT_SESSION_DRAG_TYPE } from "../ChatPaneStage"
 import type { WorkspaceAttentionSessionBadge } from "../../attention/WorkspaceAttentionProvider"
@@ -43,9 +43,7 @@ export function AppSessionRow({
   session: AppLeftPaneSession
   state: AppSessionRowState
   pinned: boolean
-  /** Whether this session can be split-paned/dragged (same-project only). */
   canSplit?: boolean
-  /** Whether this session belongs to the active project's pinned-session scope. */
   canPin?: boolean
   working?: boolean
   attentionBadge?: WorkspaceAttentionSessionBadge
@@ -55,19 +53,12 @@ export function AppSessionRow({
   onDelete?: (id: string) => void
 }) {
   const title = session.title || "Untitled"
-  // Re-selecting the active chat is intentional: the shell uses this callback
-  // to dismiss transient app-left overlays (Tasks, Skills, Plugins) even when
-  // no session switch is needed.
   const activate = () => onSwitch(session.id)
 
   return (
     <div
       data-boring-workspace-part="app-session-row"
       data-boring-session-state={state}
-      // Drag a session onto the chat stage to open it as a split pane (the
-      // stage accepts CHAT_SESSION_DRAG_TYPE; see ChatPaneStageDock). Only
-      // same-project sessions are draggable — a split pane lives in the loaded
-      // workspace's stage, so cross-project sessions can't join it.
       draggable={canSplit}
       onDragStart={canSplit ? (event) => {
         event.dataTransfer.setData(CHAT_SESSION_DRAG_TYPE, encodeWorkspaceSessionDrag({
@@ -77,120 +68,107 @@ export function AppSessionRow({
         event.dataTransfer.setData("text/plain", title)
         event.dataTransfer.effectAllowed = "copyMove"
       } : undefined}
-      onClick={activate}
-      className={cn(
-        "group flex min-h-8 w-full items-center gap-2 rounded-md border px-2.5 py-1 text-left transition-colors",
-        state === "active"
-          // Subtle accent-tinted fill, no heavy colored border (Linear/Stripe style).
-          ? "border-transparent bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-foreground"
-          : state === "open"
-            ? "cursor-pointer border-transparent bg-foreground/[0.05] text-foreground/90 hover:bg-foreground/[0.07]"
-            : "cursor-pointer border-transparent text-foreground/78 hover:bg-foreground/[0.055] hover:text-foreground",
-      )}
+      className="group relative h-9 w-full"
     >
-      <Clock3
-        className={cn(
-          "h-3.5 w-3.5 shrink-0",
-          state === "active" ? "text-[color:var(--accent)]" : "text-muted-foreground/65",
-        )}
-        strokeWidth={1.75}
-        aria-hidden="true"
-      />
       <button
         type="button"
-        onClick={(event) => {
-          event.stopPropagation()
-          activate()
-        }}
+        data-boring-mobile-dismiss="true"
+        onClick={activate}
         aria-current={state === "active" ? "page" : undefined}
-        className="min-w-0 flex-1 truncate rounded text-left text-[13px] font-medium leading-5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+        className={cn(
+          "flex h-full w-full items-center gap-2 rounded-md px-2 text-left transition-colors motion-reduce:transition-none",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+          state === "active"
+            ? "bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-foreground"
+            : state === "open"
+              ? "bg-foreground/[0.05] text-foreground/90 hover:bg-foreground/[0.08]"
+              : "text-foreground/78 hover:bg-foreground/[0.055] hover:text-foreground",
+        )}
         title={title}
       >
-        {title}
+        <span className="relative grid size-5 shrink-0 place-items-center" aria-hidden="true">
+          <MessageSquare
+            className={cn("h-4 w-4", state === "active" ? "text-[color:var(--accent)]" : "text-muted-foreground/65")}
+            strokeWidth={1.75}
+          />
+          {state === "active" ? <span className="absolute -right-0.5 -top-0.5 size-1.5 rounded-full bg-[color:var(--accent)] ring-2 ring-background" /> : null}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-[13px] font-medium leading-5">
+          {title}
+        </span>
+        <span className="flex w-[88px] shrink-0 justify-end overflow-hidden group-hover:opacity-0 group-focus-within:opacity-0">
+          {attentionBadge ? (
+            <span
+              data-boring-workspace-part="app-session-badge"
+              data-boring-badge={attentionBadge.kind}
+              className={cn("pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none", sessionBadgeToneClassName(attentionBadge.tone))}
+            >
+              <span aria-hidden="true" className={cn("h-1.5 w-1.5 animate-pulse rounded-full motion-reduce:animate-none", sessionBadgeDotClassName(attentionBadge.tone))} />
+              {attentionBadge.label}
+            </span>
+          ) : working ? (
+            <span
+              data-boring-workspace-part="app-session-badge"
+              data-boring-badge="working"
+              className="pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
+            >
+              <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--accent)] motion-reduce:animate-none" />
+              working
+            </span>
+          ) : pinned ? (
+            <Pin className="h-3.5 w-3.5 shrink-0 fill-current text-[color:var(--accent)]" strokeWidth={1.75} aria-hidden="true" />
+          ) : null}
+        </span>
       </button>
-      {attentionBadge ? (
-        <span
-          data-boring-workspace-part="app-session-badge"
-          data-boring-badge={attentionBadge.kind}
-          className={cn("pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none", sessionBadgeToneClassName(attentionBadge.tone))}
-        >
-          <span aria-hidden="true" className={cn("h-1.5 w-1.5 animate-pulse rounded-full", sessionBadgeDotClassName(attentionBadge.tone))} />
-          {attentionBadge.label}
-        </span>
-      ) : working ? (
-        <span
-          data-boring-workspace-part="app-session-badge"
-          data-boring-badge="working"
-          className="pointer-events-none inline-flex shrink-0 items-center gap-1 rounded-full bg-foreground/[0.07] px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground"
-        >
-          <span aria-hidden="true" className="h-1.5 w-1.5 animate-pulse rounded-full bg-[color:var(--accent)]" />
-          working
-        </span>
-      ) : null}
-      {canPin ? (
-        <span
-          data-boring-workspace-part="app-session-pin-action"
-          className={cn(
-            "flex w-0 shrink-0 items-center overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100",
-            pinned && "ml-1 w-auto opacity-100",
-          )}
-        >
+
+      <span
+        data-boring-workspace-part="app-session-actions"
+        className={cn(
+          "pointer-events-none absolute inset-y-0 right-1 z-10 flex w-[88px] items-center justify-end gap-0.5 opacity-0 transition-opacity motion-reduce:transition-none",
+          "group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100",
+        )}
+      >
+        {state === "normal" && canSplit ? (
+          <button
+            type="button"
+            aria-label={`Open ${title} in new chat pane`}
+            title="Open in new chat pane"
+            data-boring-mobile-dismiss="true"
+            onClick={() => onOpenAsPane(session.id)}
+            className="grid size-7 place-items-center rounded-md bg-background/90 text-muted-foreground shadow-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          >
+            <MessageSquarePlus className="h-4 w-4" strokeWidth={1.75} />
+          </button>
+        ) : null}
+        {canPin ? (
           <button
             type="button"
             aria-label={pinned ? `Unpin ${title}` : `Pin ${title}`}
             title={pinned ? "Unpin" : "Pin"}
             aria-pressed={pinned}
-            onClick={(event) => {
-              event.stopPropagation()
-              onTogglePinned(session.id)
-            }}
+            onClick={() => onTogglePinned(session.id)}
             className={cn(
-              "grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40",
+              "grid size-7 place-items-center rounded-md bg-background/90 text-muted-foreground shadow-sm hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
               pinned && "text-[color:var(--accent)]",
             )}
           >
-            <Pin className={cn("h-3.5 w-3.5", pinned && "fill-current")} strokeWidth={1.75} />
+            <Pin className={cn("h-4 w-4", pinned && "fill-current")} strokeWidth={1.75} />
           </button>
-        </span>
-      ) : null}
-      {/* "Open in new chat pane" only for closed, same-project sessions —
-          it's pointless once open, and a cross-project session can't share
-          this workspace's split stage. */}
-      {(state === "normal" && canSplit) || onDelete ? (
-        <span
-          data-boring-workspace-part="app-session-actions"
-          className="flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity,margin] group-hover:ml-1 group-hover:w-auto group-hover:opacity-100 group-focus-within:ml-1 group-focus-within:w-auto group-focus-within:opacity-100"
-        >
-          {state === "normal" && canSplit ? (
-            <button
-              type="button"
-              aria-label={`Open ${title} in new chat pane`}
-              title="Open in new chat pane"
-              onClick={(event) => {
-                event.stopPropagation()
-                onOpenAsPane(session.id)
-              }}
-              className="grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-            >
-              <MessageSquarePlus className="h-3.5 w-3.5" strokeWidth={1.75} />
-            </button>
-          ) : null}
-          {onDelete ? (
-            <button
-              type="button"
-              aria-label={`Delete ${title}`}
-              title="Delete"
-              onClick={(event) => {
-                event.stopPropagation()
-                onDelete(session.id)
-              }}
-              className="grid size-6 place-items-center rounded-md text-muted-foreground hover:bg-background hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-            >
-              <X className="h-3.5 w-3.5" strokeWidth={1.75} />
-            </button>
-          ) : null}
-        </span>
-      ) : null}
+        ) : null}
+        {onDelete ? (
+          <button
+            type="button"
+            aria-label={`Delete ${title}`}
+            title="Delete"
+            onClick={() => {
+              if (typeof window !== "undefined" && window.confirm(`Delete “${title}”?`)) onDelete(session.id)
+            }}
+            className="grid size-7 place-items-center rounded-md bg-background/90 text-muted-foreground shadow-sm hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          >
+            <X className="h-4 w-4" strokeWidth={1.75} />
+          </button>
+        ) : null}
+      </span>
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -79,6 +79,7 @@ function AppLeftPaneResizeHandle({
 export interface PluginTabsWorkspaceShellProps {
   collapsed: boolean
   leftPane: ReactNode
+  collapsedRail: ReactNode
   children: ReactNode
   onExpand: () => void
   onCollapse: () => void
@@ -93,6 +94,7 @@ export interface PluginTabsWorkspaceShellProps {
 export function PluginTabsWorkspaceShell({
   collapsed,
   leftPane,
+  collapsedRail,
   children,
   onExpand,
   onCollapse,
@@ -103,10 +105,6 @@ export function PluginTabsWorkspaceShell({
   className,
   mobileShellEnabled,
 }: PluginTabsWorkspaceShellProps) {
-  // Ephemeral peek: when the pane is collapsed, hovering the left edge slides
-  // the pane in as an overlay (it does not push the content or pin open). It
-  // retracts when the pointer leaves the overlay.
-  const [peek, setPeek] = useState(false)
   const [mobileOpen, setMobileOpen] = useState(false)
   const viewport = useViewportWidth()
   const mobileShell = mobileShellEnabled === true && viewport < 640
@@ -118,7 +116,7 @@ export function PluginTabsWorkspaceShell({
       data-mobile-shell={mobileShell ? "true" : "false"}
       className={cn("relative flex h-full min-h-0 w-full overflow-hidden bg-background", className)}
     >
-      {mobileShell ? null : collapsed ? null : leftPane}
+      {mobileShell ? null : collapsed ? collapsedRail : leftPane}
       {!mobileShell && !collapsed && onResizeLeftPane && leftPaneWidth != null ? (
         <AppLeftPaneResizeHandle
           width={leftPaneWidth}
@@ -131,57 +129,30 @@ export function PluginTabsWorkspaceShell({
         {children}
       </div>
 
-      {/* Ephemeral peek (collapsed only): hover the left edge to reveal the
-          pane as an overlay. The overlay is mounted ONLY while peeking, so the
-          collapsed state is genuinely empty otherwise (an always-mounted,
-          transform-hidden overlay left the pane visible). */}
-      {mobileShell ? (
-        mobileOpen ? (
-          <>
-            <div
-              aria-hidden="true"
-              data-boring-workspace-part="app-left-mobile-scrim"
-              className="absolute inset-0 z-[64] bg-foreground/30"
-              onClick={() => setMobileOpen(false)}
-            />
-            <div
-              data-boring-workspace-part="app-left-mobile-overlay"
-              data-boring-state="open"
-              onClick={(event) => {
-                const target = event.target as HTMLElement | null
-                if (target?.closest("button")) setMobileOpen(false)
-              }}
-              className="absolute inset-y-0 left-0 z-[65] flex w-[min(86vw,360px)] max-w-[360px] shadow-2xl"
-            >
-              {leftPane}
-            </div>
-          </>
-        ) : null
-      ) : collapsed ? (
+      {mobileShell && mobileOpen ? (
         <>
           <div
-            data-boring-workspace-part="app-left-peek-trigger"
-            className="absolute inset-y-0 left-0 z-[60] w-3"
-            onMouseEnter={() => setPeek(true)}
             aria-hidden="true"
+            data-boring-workspace-part="app-left-mobile-scrim"
+            className="absolute inset-0 z-[64] bg-foreground/30"
+            onClick={() => setMobileOpen(false)}
           />
-          {peek ? (
-            <div
-              data-boring-workspace-part="app-left-peek"
-              data-boring-state="open"
-              onMouseLeave={() => setPeek(false)}
-              className="absolute inset-y-0 left-0 z-[65] flex shadow-2xl"
-            >
-              {leftPane}
-            </div>
-          ) : null}
+          <div
+            data-boring-workspace-part="app-left-mobile-overlay"
+            data-boring-state="open"
+            onClick={(event) => {
+              const target = event.target as HTMLElement | null
+              if (target?.closest('[data-boring-mobile-dismiss="true"]')) setMobileOpen(false)
+            }}
+            className="absolute inset-y-0 left-0 z-[65] flex w-[min(86vw,360px)] max-w-[360px] shadow-2xl [&>[data-boring-workspace-part=app-left-pane]]:!w-full [&>[data-boring-workspace-part=app-left-pane]]:!min-w-0 [&>[data-boring-workspace-part=app-left-pane]]:!max-w-none"
+          >
+            {leftPane}
+          </div>
         </>
       ) : null}
 
-      {/* One collapse rule: same place and style in both states; only the
-          quiet panel glyph changes to show open vs close mode. The app pane
-          reserves matching header padding while expanded, and the collapsed
-          chat tab strip keeps 48px leading clearance via dockview-overrides.css. */}
+      {/* The same control owns both states. Expanded chrome reserves matching
+          header space; collapsed chrome occupies the rail's fixed top slot. */}
       <div className="pointer-events-none absolute left-1.5 top-2 z-[70]">
         <PaneCollapseButton
           label={effectiveCollapsed ? "Open app navigation" : "Hide app navigation"}

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -1,7 +1,8 @@
 "use client"
 
-import { useCallback, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from "react"
+import { useCallback, useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from "react"
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
+import { Sheet, SheetClose, SheetContent, SheetDescription, SheetTitle } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import { PaneCollapseButton } from "../paneCollapseButton"
 import { useViewportWidth } from "../useViewportWidth"
@@ -109,6 +110,9 @@ export function PluginTabsWorkspaceShell({
   const viewport = useViewportWidth()
   const mobileShell = mobileShellEnabled === true && viewport < 640
   const effectiveCollapsed = mobileShell ? !mobileOpen : collapsed
+  useEffect(() => {
+    if (!mobileShell) setMobileOpen(false)
+  }, [mobileShell])
   return (
     <div
       data-boring-workspace-part="plugin-tabs-shell"
@@ -129,34 +133,43 @@ export function PluginTabsWorkspaceShell({
         {children}
       </div>
 
-      {mobileShell && mobileOpen ? (
-        <>
-          <div
-            aria-hidden="true"
-            data-boring-workspace-part="app-left-mobile-scrim"
-            className="absolute inset-0 z-[64] bg-foreground/30"
-            onClick={() => setMobileOpen(false)}
-          />
-          <div
+      {mobileShell ? (
+        <Sheet open={mobileOpen} onOpenChange={setMobileOpen}>
+          <SheetContent
+            side="left"
+            showCloseButton={false}
             data-boring-workspace-part="app-left-mobile-overlay"
             data-boring-state="open"
             onClick={(event) => {
               const target = event.target as HTMLElement | null
               if (target?.closest('[data-boring-mobile-dismiss="true"]')) setMobileOpen(false)
             }}
-            className="absolute inset-y-0 left-0 z-[65] flex w-[min(86vw,360px)] max-w-[360px] shadow-2xl [&>[data-boring-workspace-part=app-left-pane]]:!w-full [&>[data-boring-workspace-part=app-left-pane]]:!min-w-0 [&>[data-boring-workspace-part=app-left-pane]]:!max-w-none"
+            className="w-[min(86vw,360px)] max-w-[360px] gap-0 p-0 shadow-2xl [&>[data-boring-workspace-part=app-left-pane]]:!w-full [&>[data-boring-workspace-part=app-left-pane]]:!min-w-0 [&>[data-boring-workspace-part=app-left-pane]]:!max-w-none"
           >
+            <SheetTitle className="sr-only">App navigation</SheetTitle>
+            <SheetDescription className="sr-only">Workspace actions and chats</SheetDescription>
+            <SheetClose asChild>
+              <button
+                type="button"
+                aria-label="Close app navigation"
+                className="absolute left-1.5 top-1.5 z-10 grid size-11 place-items-center rounded-lg text-muted-foreground transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <PanelLeftClose className="h-4 w-4" strokeWidth={1.75} />
+              </button>
+            </SheetClose>
             {leftPane}
-          </div>
-        </>
+          </SheetContent>
+        </Sheet>
       ) : null}
 
       {/* The same control owns both states. Expanded chrome reserves matching
           header space; collapsed chrome occupies the rail's fixed top slot. */}
+      {!mobileShell || !mobileOpen ? (
       <div className="pointer-events-none absolute left-1.5 top-2 z-[70]">
         <PaneCollapseButton
           label={effectiveCollapsed ? "Open app navigation" : "Hide app navigation"}
           side="right"
+          className="app-left-pane-toggle"
           onClick={mobileShell ? () => setMobileOpen((open) => !open) : collapsed ? onExpand : onCollapse}
         >
           {effectiveCollapsed ? (
@@ -166,6 +179,7 @@ export function PluginTabsWorkspaceShell({
           )}
         </PaneCollapseButton>
       </div>
+      ) : null}
     </div>
   )
 }

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -31,7 +31,7 @@ function renderPane() {
 }
 
 describe("AppLeftPane", () => {
-  it("separates fixed workspace actions from the scrolling chat list and bottom New chat action", () => {
+  it("places New chat at the top of Chats before the scrolling session list", () => {
     renderPane()
 
     const appNav = screen.getByLabelText("App navigation")
@@ -41,6 +41,8 @@ describe("AppLeftPane", () => {
     const newChat = appNav.querySelector('[data-boring-workspace-part="app-left-new-chat"]')
 
     expect(workspaceHeading.compareDocumentPosition(chatsHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(chatsHeading.compareDocumentPosition(newChat as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect((newChat as Node).compareDocumentPosition(sessionScroll as Node) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(sessionScroll).toContainElement(screen.getByText("First session"))
     expect(sessionScroll).not.toContainElement(screen.getByRole("button", { name: "New chat" }))
     expect(newChat).toContainElement(screen.getByRole("button", { name: "New chat" }))

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -1,9 +1,10 @@
 import { useEffect } from "react"
-import { act, fireEvent, render, screen } from "@testing-library/react"
+import { act, fireEvent, render, screen, within } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { WorkspaceAttentionProvider, useWorkspaceAttention } from "../../../attention/WorkspaceAttentionProvider"
 import { workspaceSessionKey } from "../../../sessionIdentity"
-import { AppLeftPane } from "../AppLeftPane"
+import { AppLeftPane, AppLeftRail } from "../AppLeftPane"
+import { PluginTabsWorkspaceShell } from "../PluginTabsWorkspaceShell"
 
 const sessions = [
   { id: "s1", title: "First session" },
@@ -30,6 +31,105 @@ function renderPane() {
 }
 
 describe("AppLeftPane", () => {
+  it("separates fixed workspace actions from the scrolling chat list and bottom New chat action", () => {
+    renderPane()
+
+    const appNav = screen.getByLabelText("App navigation")
+    const workspaceHeading = within(appNav).getByRole("heading", { name: "Workspace" })
+    const chatsHeading = within(appNav).getByRole("heading", { name: "Chats" })
+    const sessionScroll = appNav.querySelector('[data-boring-workspace-part="app-left-session-scroll"]')
+    const newChat = appNav.querySelector('[data-boring-workspace-part="app-left-new-chat"]')
+
+    expect(workspaceHeading.compareDocumentPosition(chatsHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(sessionScroll).toContainElement(screen.getByText("First session"))
+    expect(sessionScroll).not.toContainElement(screen.getByRole("button", { name: "New chat" }))
+    expect(newChat).toContainElement(screen.getByRole("button", { name: "New chat" }))
+  })
+
+  it("renders icon-only collapsed shortcuts with accessible labels", () => {
+    const onCreateSession = vi.fn()
+    const onOpenCommandPalette = vi.fn()
+    const onOpenTasks = vi.fn()
+    render(
+      <AppLeftRail
+        actions={[
+          { id: "tasks", label: "Tasks", icon: <span>T</span>, onClick: onOpenTasks, active: true },
+          { id: "inbox", label: "Inbox", icon: null, trailing: "3", onClick: vi.fn() },
+        ]}
+        onCreateSession={onCreateSession}
+        onOpenCommandPalette={onOpenCommandPalette}
+      />,
+    )
+
+    const rail = screen.getByLabelText("Collapsed app navigation")
+    fireEvent.click(within(rail).getByRole("button", { name: "Search" }))
+    fireEvent.click(within(rail).getByRole("button", { name: "Tasks" }))
+    fireEvent.click(within(rail).getByRole("button", { name: "New chat" }))
+
+    expect(onOpenCommandPalette).toHaveBeenCalledOnce()
+    expect(onOpenTasks).toHaveBeenCalledOnce()
+    expect(onCreateSession).toHaveBeenCalledOnce()
+    expect(within(rail).getByRole("button", { name: "Tasks" })).toHaveAttribute("aria-current", "page")
+    expect(within(rail).getByRole("button", { name: "Inbox" }).querySelector("svg")).toBeInTheDocument()
+    expect(within(rail).getByText("3")).toBeInTheDocument()
+    expect(within(rail).queryByText("Search")).not.toBeInTheDocument()
+    expect(within(rail).queryByText("New chat")).not.toBeInTheDocument()
+  })
+
+  it("keeps mobile drawer controls open for multi-step interactions", () => {
+    const originalWidth = window.innerWidth
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 500 })
+    const onProjectExpand = vi.fn()
+    render(
+      <PluginTabsWorkspaceShell
+        collapsed={false}
+        mobileShellEnabled
+        leftPane={(
+          <aside data-boring-workspace-part="app-left-pane" style={{ width: 420, minWidth: 420, maxWidth: 420 }}>
+            <button type="button" onClick={onProjectExpand}>Expand project</button>
+            <button type="button" data-boring-mobile-dismiss="true">Open chat</button>
+          </aside>
+        )}
+        collapsedRail={<div>Rail</div>}
+        onExpand={vi.fn()}
+        onCollapse={vi.fn()}
+      >
+        <div>Content</div>
+      </PluginTabsWorkspaceShell>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Open app navigation" }))
+    const overlay = document.querySelector('[data-boring-workspace-part="app-left-mobile-overlay"]')
+    expect(overlay).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Expand project" }))
+    expect(onProjectExpand).toHaveBeenCalledOnce()
+    expect(overlay).toBeInTheDocument()
+    expect(overlay).toHaveClass("[&>[data-boring-workspace-part=app-left-pane]]:!w-full")
+    fireEvent.click(screen.getByRole("button", { name: "Open chat" }))
+    expect(document.querySelector('[data-boring-workspace-part="app-left-mobile-overlay"]')).not.toBeInTheDocument()
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: originalWidth })
+  })
+
+  it("distinguishes a loading chat list from an empty one", () => {
+    render(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane
+          appTitle="Test"
+          sessions={[]}
+          sessionsLoading
+          onCreateSession={vi.fn()}
+          onOpenCommandPalette={vi.fn()}
+          onSwitchSession={vi.fn()}
+          onOpenSessionAsPane={vi.fn()}
+          onToggleSessionPinned={vi.fn()}
+        />
+      </WorkspaceAttentionProvider>,
+    )
+
+    expect(screen.getByText("Loading chats…")).toBeInTheDocument()
+    expect(screen.queryByText("No chats yet.")).not.toBeInTheDocument()
+  })
+
   it("shows working state beside session names", () => {
     renderPane()
 
@@ -169,7 +269,7 @@ describe("AppLeftPane", () => {
 
     const badge = document.querySelector('[data-boring-badge="working"]')
     expect(badge).toBeInTheDocument()
-    fireEvent.click(badge?.closest('[data-boring-workspace-part="app-session-row"]') as Element)
+    fireEvent.click(badge as Element)
     expect(onSwitchSession).toHaveBeenCalledWith("s2")
   })
 

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react"
 import { act, fireEvent, render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 import { WorkspaceAttentionProvider, useWorkspaceAttention } from "../../../attention/WorkspaceAttentionProvider"
 import { workspaceSessionKey } from "../../../sessionIdentity"
@@ -275,7 +276,8 @@ describe("AppLeftPane", () => {
     expect(onSwitchSession).toHaveBeenCalledWith("s2")
   })
 
-  it("keeps structured addressed refs distinct from a colliding raw legacy id", () => {
+  it("keeps structured addressed refs distinct from a colliding raw legacy id", async () => {
+    const user = userEvent.setup()
     const addressedKey = workspaceSessionKey("shared", "alpha")
     const onSwitchSession = vi.fn()
     const onToggleSessionPinned = vi.fn()
@@ -303,7 +305,8 @@ describe("AppLeftPane", () => {
     expect(screen.getByText("Legacy collision").closest('[data-boring-workspace-part="app-session-row"]')).toHaveAttribute("data-boring-session-state", "open")
     fireEvent.click(screen.getByText("Addressed session"))
     fireEvent.click(screen.getByText("Legacy collision"))
-    fireEvent.click(screen.getByRole("button", { name: "Unpin Addressed session" }))
+    await user.click(screen.getByRole("button", { name: "Chat actions for Addressed session" }))
+    await user.click(screen.getByRole("menuitem", { name: "Unpin chat" }))
     expect(onSwitchSession).toHaveBeenNthCalledWith(1, "shared", "alpha")
     expect(onSwitchSession).toHaveBeenNthCalledWith(2, addressedKey)
     expect(onToggleSessionPinned).toHaveBeenCalledWith("shared", "alpha")

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -382,3 +382,54 @@
 [data-boring-workspace] ::-webkit-scrollbar-thumb:hover {
   background-color: oklch(from var(--foreground) l c h / 0.3);
 }
+
+/* App-left chrome stays compact for fine pointers while meeting 44px touch
+   targets and keeping secondary actions discoverable on touch-only devices. */
+@media (pointer: coarse) {
+  [data-boring-workspace-part="app-left-rail"] {
+    padding-inline: 0;
+  }
+
+  .app-left-primary-action,
+  .app-left-new-chat-action,
+  .app-left-session-row {
+    height: 44px;
+  }
+
+  .app-left-secondary-action,
+  .app-left-session-secondary-action,
+  .app-left-rail-action,
+  .app-left-pane-toggle,
+  [data-boring-workspace-part="app-left-footer"] button,
+  [data-boring-workspace-part="app-left-rail-footer"] button {
+    width: 44px;
+    height: 44px;
+  }
+
+  .app-left-session-trailing[data-action-count="1"][data-has-status="false"],
+  .app-left-session-actions[data-action-count="1"] {
+    width: 44px;
+  }
+
+  .app-left-session-trailing[data-action-count="2"][data-has-status="false"],
+  .app-left-session-actions[data-action-count="2"] {
+    width: 90px;
+  }
+
+  .app-left-session-trailing[data-action-count="3"][data-has-status="false"],
+  .app-left-session-actions[data-action-count="3"] {
+    width: 136px;
+  }
+}
+
+@media (hover: none) {
+  .app-left-new-chat-secondary {
+    width: auto;
+    opacity: 1;
+  }
+
+  .app-left-session-actions {
+    pointer-events: auto;
+    opacity: 1;
+  }
+}

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -422,6 +422,13 @@
   }
 }
 
+@media (pointer: coarse) {
+  .workbench-open-button {
+    min-height: 44px;
+    min-width: 44px;
+  }
+}
+
 @media (hover: none) {
   .app-left-new-chat-secondary {
     width: auto;


### PR DESCRIPTION
## Summary

- adds a persistent 44px icon-only desktop rail when app navigation is collapsed
- gives the expanded pane two clear top-level regions: Workspace and Chats
- keeps Workspace actions and New chat fixed while the session list scrolls
- stabilizes session-row title/action geometry and clarifies active/open/working/pinned states
- preserves multi-step mobile drawer interactions while dismissing terminal navigation actions
- keeps the existing palette and limits changes to the navigation/session surface

Closes #1062

## Proof

- `pnpm --filter @hachej/boring-workspace exec vitest run src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx src/app/front/__tests__/WorkspaceAgentFront.test.tsx` — **81 passed**
- `pnpm --filter @hachej/boring-workspace typecheck` — **passed**
- `pnpm --filter @hachej/boring-workspace build` — **passed**; all 19 build artifacts present (existing optional `@microsoft/api-extractor` warning remains non-fatal)
- `git diff --check` — **passed**
- browser geometry at 1440×900 — collapsed rail width **44px**, chat header begins at **x=44**, seven accessible rail controls

## Visual review

- Demo: http://100.68.199.114:5390/?showcase=1
- Expanded screenshot: `/tmp/issue-1062-expanded-final.png`
- Collapsed screenshot: `/tmp/issue-1062-collapsed-final.png`

Inspect:
1. Workspace and Chats hierarchy.
2. New chat anchored above the footer.
3. Session title truncation and hover/focus actions.
4. Persistent collapsed rail and bottom-anchored New chat/theme controls.

## Review

- Standards/spec review: clean after fixes.
- Thermonuclear UI review: findings addressed (desktop inset, compact footer, stable row geometry, mobile width/dismissal, short-height overflow).
- Final focused review: clean.

## Risk / rollback

- Risk is limited to app-left navigation layout and interaction behavior.
- Revert commit `9d4cc7c6b` to restore the prior disappearing collapsed pane and scroll layout.
