### PR TITLE
#1076 Polish new-chat composer touch and motion

### DIFF
--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -851,6 +851,8 @@ describe('PiChatPanel sandbox shell', () => {
     expect(attachmentRow).toBeTruthy()
     expect(inputRow).toBeTruthy()
     expect(inputRow?.contains(attachmentRow)).toBe(false)
+    expect(within(attachmentRow as HTMLElement).getByRole('button', { name: 'Remove' }).className)
+      .toContain('composer-attachment-remove')
   })
 
   test('renders server queued follow-ups only in the composer banner', async () => {
@@ -1092,10 +1094,16 @@ describe('PiChatPanel sandbox shell', () => {
     )
 
     const textarea = await screen.findByLabelText('Agent prompt')
-    expect(screen.getByRole('button', { name: /Current model:/ }).textContent).toContain('Model ·')
-    expect(screen.getByRole('button', { name: 'Thinking level: Med' }).textContent).toContain('Thinking ·')
-    expect(screen.getByRole('button', { name: 'Attach files' }).className).toContain('!h-10')
-    expect(document.querySelector('[data-boring-agent-part="composer-submit"]')?.className).toContain('h-8')
+    const modelControl = screen.getByRole('button', { name: /Current model:/ })
+    const thinkingControl = screen.getByRole('button', { name: 'Thinking level: Med' })
+    const attachControl = screen.getByRole('button', { name: 'Attach files' })
+    const submitControl = document.querySelector('[data-boring-agent-part="composer-submit"]')
+    expect(modelControl.textContent).toContain('Model ·')
+    expect(modelControl.className).toContain('composer-settings-trigger')
+    expect(thinkingControl.textContent).toContain('Thinking ·')
+    expect(thinkingControl.className).toContain('composer-settings-trigger')
+    expect(attachControl.className).toContain('composer-attachment-button')
+    expect(submitControl?.className).toContain('composer-submit-control')
 
     fireEvent.change(textarea, { target: { value: '/mod' } })
     let commands = await screen.findByRole('listbox', { name: 'Commands' })

--- a/packages/agent/src/front/chat/components/ComposerAttachments.tsx
+++ b/packages/agent/src/front/chat/components/ComposerAttachments.tsx
@@ -24,7 +24,7 @@ export function AttachmentButton({ disabled, className }: { disabled?: boolean; 
       onClick={() => {
         if (!disabled) attachments.openFileDialog()
       }}
-      className={cn(composerActionClass, '!h-10 !w-10', className)}
+      className={cn(composerActionClass, 'composer-attachment-button !h-10 !w-10', className)}
       aria-label="Attach files"
       title={disabled ? 'Attachments are available when the composer is ready.' : 'Attach files'}
     >
@@ -49,7 +49,7 @@ export function AttachmentsList() {
           data={file}
           onRemove={() => attachments.remove(file.id)}
           className={cn(
-            '!h-9 !gap-2 !rounded-full !border-input/80 !bg-muted/40 !pl-1 !pr-2',
+            'composer-attachment-chip !h-9 !gap-2 !rounded-full !border-input/80 !bg-muted/40 !pl-1 !pr-2',
             'transition-colors hover:!bg-muted/70 hover:!text-foreground',
             file.status === 'error' && '!border-destructive/50 !bg-destructive/10',
           )}
@@ -68,7 +68,7 @@ export function AttachmentsList() {
             ) : null}
           </div>
           <AttachmentInfo className="min-w-0 !max-w-[180px] truncate text-[13px] font-medium" />
-          <AttachmentRemove className="!size-5 !rounded-full !opacity-100 text-muted-foreground/80 hover:text-foreground" />
+          <AttachmentRemove className="composer-attachment-remove !size-5 !rounded-full !opacity-100 text-muted-foreground/80 hover:text-foreground" />
         </Attachment>
       ))}
     </Attachments>

--- a/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiChatComposerSurface.tsx
@@ -2,7 +2,7 @@
 
 import type { CSSProperties, ChangeEvent, KeyboardEvent as ReactKeyboardEvent, RefObject } from 'react'
 import { useCallback, useLayoutEffect } from 'react'
-import { motion } from 'motion/react'
+import { motion, useReducedMotion } from 'motion/react'
 import type { QueuedUserMessage } from '../../../shared/chat'
 import type { AvailableModel, ModelSelection, ThinkingLevel } from '../../chatPanelSettings'
 import type { PluginUpdateState } from '../../composer/PluginUpdateStatus'
@@ -188,6 +188,7 @@ export function PiChatComposerSurface<
   onSubmitMessage,
   onStop,
 }: PiChatComposerSurfaceProps<TComposerBlocker>) {
+  const prefersReducedMotion = useReducedMotion()
   const workspaceRequestId = getHeaderValue(requestHeaders, 'x-boring-workspace-id')
   const composerContributions = useComposerContributions()
   const uploadAttachment = useCallback((file: File) => uploadFile(file, {
@@ -250,8 +251,8 @@ export function PiChatComposerSurface<
           <motion.span
             aria-hidden="true"
             className="inline-block size-1.5 rounded-full bg-[color:var(--accent)]"
-            animate={{ opacity: [0.35, 1, 0.35] }}
-            transition={{ duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
+            animate={prefersReducedMotion ? { opacity: 1 } : { opacity: [0.35, 1, 0.35] }}
+            transition={prefersReducedMotion ? { duration: 0 } : { duration: 1.2, repeat: Infinity, ease: 'easeInOut' }}
           />
           <span>Working…</span>
         </div>
@@ -440,7 +441,7 @@ export function PiChatComposerSurface<
                   onStop={onStop}
                   disabled={submitDisabled}
                   className={cn(
-                    'h-8 w-8 shrink-0 rounded-full',
+                    'composer-submit-control h-8 w-8 shrink-0 rounded-full',
                     'bg-foreground text-background',
                     'transition-all duration-150 ease-[cubic-bezier(0.22,1,0.36,1)]',
                     'hover:bg-foreground/90 hover:shadow-[0_0_0_3px_oklch(from_var(--foreground)_l_c_h/0.12)] hover:scale-[1.04]',
@@ -470,6 +471,7 @@ export function PiChatComposerSurface<
           disabled={isStreaming || modelControlled}
           trigger="slash"
           open={modelPickerOpen}
+          className="composer-settings-trigger"
           onClick={() => {
             if (modelPickerOpen) {
               onSetModelPickerOpen(false)
@@ -484,6 +486,7 @@ export function PiChatComposerSurface<
             disabled={isStreaming || thinkingControlled}
             trigger="slash"
             open={thinkingPickerOpen}
+            className="composer-settings-trigger"
             onClick={() => {
               if (thinkingPickerOpen) {
                 onSetThinkingPickerOpen(false)

--- a/packages/agent/src/front/styles/globals.css
+++ b/packages/agent/src/front/styles/globals.css
@@ -237,6 +237,20 @@
   background-color: color-mix(in oklab, var(--foreground) 90%, transparent);
 }
 
+@media (pointer: coarse) {
+  [data-boring-agent] .composer-attachment-button,
+  [data-boring-agent] .composer-attachment-remove,
+  [data-boring-agent] .composer-submit-control,
+  [data-boring-agent] .composer-settings-trigger {
+    min-height: 44px !important;
+    min-width: 44px !important;
+  }
+
+  [data-boring-agent] .composer-attachment-chip {
+    min-height: 44px !important;
+  }
+}
+
 /*
  * Streamdown's Shiki highlighting sets per-token CSS custom properties
  * (--sdm-c, --sdm-bg, --shiki-dark, --shiki-dark-bg) and relies on


### PR DESCRIPTION
## Summary
- raises attachment, submit/stop, model, thinking, attachment-chip, and remove controls to 44px minimum on coarse pointers
- keeps desktop density unchanged
- disables the pulsing working indicator under reduced motion while preserving visible and announced status
- adds focused assertions for stable composer control classes and attachment removal

The empty-state/composer visual implementation already matched the Claude AAA reference, so this intentionally fixes the remaining runtime quality gaps rather than redesigning it.

Closes #1076

## Proof
- `PiChatPanel.test.tsx`: 65 passed
- Agent typecheck: passed
- Agent/workspace playground dependency build: passed
- Browser measurements at 390×844 with touch:
  - attachment: 44×44
  - submit/stop: 44×44
  - model/thinking: 44px high
  - attachment chip: 282×44
  - attachment remove: 44×44
- Reduced motion: working dot computed `opacity: 1`, `animation: none`
- Independent review: `CLEAN`

## Visual proof
`/tmp/1076-composer-review/`

## Demo
http://100.68.199.114:5420/?showcase=1&sessions=30&fresh=1
