### PR TITLE
#1083 feat(url-pane): v0 URL viewer pane plugin

### DIFF
--- a/plugins/url-pane/package.json
+++ b/plugins/url-pane/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@hachej/boring-url-pane",
+  "version": "0.1.95",
+  "type": "module",
+  "private": false,
+  "license": "MIT",
+  "description": "URL viewer pane plugin for Boring workspace.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hachej/boring-ui"
+  },
+  "homepage": "https://github.com/hachej/boring-ui",
+  "boring": {
+    "label": "URL Pane",
+    "front": "dist/front/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/front/index.d.ts",
+      "import": "./dist/front/index.js"
+    },
+    "./front": {
+      "types": "./dist/front/index.d.ts",
+      "import": "./dist/front/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "pnpm run typecheck",
+    "clean": "rm -rf dist .tsbuildinfo"
+  },
+  "dependencies": {
+    "@hachej/boring-ui-kit": "workspace:*"
+  },
+  "peerDependencies": {
+    "@hachej/boring-workspace": "workspace:*",
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@hachej/boring-workspace": "workspace:*",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "jsdom": "^29.1.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "tsup": "^8.4.0",
+    "typescript": "~6.0.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/plugins/url-pane/src/front/UrlPane.tsx
+++ b/plugins/url-pane/src/front/UrlPane.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useState, type FormEvent } from "react"
+import { Input, Toolbar, ToolbarButton, ToolbarGroup } from "@hachej/boring-ui-kit"
+
+const RECENT_URLS_STORAGE_KEY = "boring-url-pane:recent-urls:v1"
+const MAX_RECENT_URLS = 8
+
+type FrameState = "idle" | "loading" | "ready" | "error"
+
+function readRecentUrls(): string[] {
+  try {
+    const parsed: unknown = JSON.parse(globalThis.localStorage?.getItem(RECENT_URLS_STORAGE_KEY) ?? "[]")
+    return Array.isArray(parsed)
+      ? parsed.filter((value): value is string => typeof value === "string").slice(0, MAX_RECENT_URLS)
+      : []
+  } catch {
+    return []
+  }
+}
+
+function writeRecentUrls(urls: string[]): void {
+  try {
+    globalThis.localStorage?.setItem(RECENT_URLS_STORAGE_KEY, JSON.stringify(urls))
+  } catch {
+    // Recent URL persistence is best-effort.
+  }
+}
+
+function normalizeUrl(value: string): string | null {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+  if (/^[a-z][a-z\d+.-]*:/i.test(trimmed) && !/^https?:\/\//i.test(trimmed)) return null
+
+  try {
+    const parsed = new URL(/^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`)
+    return parsed.protocol === "http:" || parsed.protocol === "https:" ? parsed.href : null
+  } catch {
+    return null
+  }
+}
+
+function RefreshIcon() {
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 11a8 8 0 1 0-2.34 5.66" />
+      <path d="M20 4v7h-7" />
+    </svg>
+  )
+}
+
+export function UrlPane() {
+  const [address, setAddress] = useState("")
+  const [url, setUrl] = useState("")
+  const [recentUrls, setRecentUrls] = useState(readRecentUrls)
+  const [frameKey, setFrameKey] = useState(0)
+  const [frameState, setFrameState] = useState<FrameState>("idle")
+  const [addressError, setAddressError] = useState(false)
+
+  const navigate = useCallback((nextAddress: string) => {
+    const normalized = normalizeUrl(nextAddress)
+    if (!normalized) {
+      setAddressError(true)
+      return
+    }
+
+    const nextRecentUrls = [normalized, ...recentUrls.filter((recentUrl) => recentUrl !== normalized)].slice(0, MAX_RECENT_URLS)
+    setAddress(normalized)
+    setAddressError(false)
+    setUrl(normalized)
+    setRecentUrls(nextRecentUrls)
+    setFrameState("loading")
+    setFrameKey((current) => current + 1)
+    writeRecentUrls(nextRecentUrls)
+  }, [recentUrls])
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    navigate(address)
+  }
+
+  function refresh() {
+    if (!url) return
+    setFrameState("loading")
+    setFrameKey((current) => current + 1)
+  }
+
+  return (
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-background text-foreground">
+      <Toolbar className="shrink-0 border-b border-border/70 p-2" aria-label="URL navigation">
+        <form className="flex min-w-48 flex-1 items-center gap-1" onSubmit={handleSubmit}>
+          <Input
+            aria-label="Address"
+            aria-invalid={addressError}
+            className="h-8"
+            inputMode="url"
+            placeholder="Enter a URL"
+            spellCheck={false}
+            value={address}
+            onChange={(event) => {
+              setAddress(event.target.value)
+              setAddressError(false)
+            }}
+          />
+          <button type="submit" className="sr-only">Navigate</button>
+        </form>
+        <ToolbarGroup>
+          <select
+            aria-label="Recent URLs"
+            className="h-8 max-w-40 rounded-md border border-input bg-background px-2 text-xs text-muted-foreground outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50"
+            disabled={recentUrls.length === 0}
+            value=""
+            onChange={(event) => navigate(event.target.value)}
+          >
+            <option value="">Recent URLs</option>
+            {recentUrls.map((recentUrl) => (
+              <option key={recentUrl} value={recentUrl}>{recentUrl}</option>
+            ))}
+          </select>
+          <ToolbarButton type="button" aria-label="Refresh" disabled={!url} onClick={refresh}>
+            <RefreshIcon />
+          </ToolbarButton>
+        </ToolbarGroup>
+      </Toolbar>
+
+      <div className="relative min-h-0 min-w-0 flex-1">
+        {!url ? (
+          <div className="flex h-full items-center justify-center p-6 text-center text-sm text-muted-foreground">
+            Enter a URL above to open it in this pane.
+          </div>
+        ) : (
+          <iframe
+            key={frameKey}
+            className="h-full w-full border-0 bg-background"
+            src={url}
+            title={`URL viewer: ${url}`}
+            onLoad={() => setFrameState("ready")}
+            onErrorCapture={() => setFrameState("error")}
+          />
+        )}
+
+        {frameState === "loading" ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-background/80 text-sm text-muted-foreground" role="status">
+            Loading…
+          </div>
+        ) : null}
+
+        {frameState === "error" ? (
+          <div className="absolute inset-0 flex items-center justify-center bg-background/95 p-6 text-center" role="alert">
+            <div className="max-w-md space-y-2">
+              <p className="text-sm font-medium text-foreground">This page could not be loaded in the pane.</p>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                The site may be unreachable or may block framing with its security headers. Check the address or open a different URL.
+              </p>
+            </div>
+          </div>
+        ) : null}
+
+        {addressError ? (
+          <div className="absolute left-2 top-2 rounded-md border border-destructive/40 bg-background px-3 py-2 text-xs text-destructive" role="alert">
+            Enter a valid HTTP or HTTPS URL.
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/plugins/url-pane/src/front/__tests__/urlPanePlugin.test.tsx
+++ b/plugins/url-pane/src/front/__tests__/urlPanePlugin.test.tsx
@@ -1,0 +1,79 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { captureFrontPlugin } from "@hachej/boring-workspace/plugin"
+import { describe, expect, it } from "vitest"
+import urlPanePlugin, { URL_PANE_PANEL_ID, UrlPane } from "../index"
+
+function navigateTo(value: string) {
+  const address = screen.getByRole("textbox", { name: "Address" })
+  fireEvent.change(address, { target: { value } })
+  fireEvent.submit(address.closest("form")!)
+}
+
+describe("urlPanePlugin", () => {
+  it("registers one shared Dockview pane and its command", () => {
+    const captured = captureFrontPlugin(urlPanePlugin)
+
+    expect(captured.registrations.panels).toEqual([
+      expect.objectContaining({
+        id: URL_PANE_PANEL_ID,
+        label: "URL Pane",
+        placement: "shared-dockview",
+        component: UrlPane,
+      }),
+    ])
+    expect(captured.registrations.panelCommands).toEqual([
+      expect.objectContaining({
+        id: "url-pane.open",
+        title: "Open URL Pane",
+        panelId: URL_PANE_PANEL_ID,
+      }),
+    ])
+  })
+
+  it("navigates, refreshes, and reports iframe load errors", () => {
+    render(<UrlPane />)
+
+    navigateTo("example.com/docs")
+    const frame = screen.getByTitle("URL viewer: https://example.com/docs")
+    expect(frame).toHaveAttribute("src", "https://example.com/docs")
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }))
+    expect(screen.getByTitle("URL viewer: https://example.com/docs")).not.toBe(frame)
+
+    fireEvent.error(screen.getByTitle("URL viewer: https://example.com/docs"))
+    expect(screen.getByRole("alert")).toHaveTextContent("security headers")
+  })
+
+  it("keeps the eight most recent distinct URLs and navigates from the list", () => {
+    const { unmount } = render(<UrlPane />)
+
+    for (let index = 1; index <= 9; index += 1) navigateTo(`example.com/${index}`)
+
+    expect(JSON.parse(localStorage.getItem("boring-url-pane:recent-urls:v1") ?? "[]")).toEqual([
+      "https://example.com/9",
+      "https://example.com/8",
+      "https://example.com/7",
+      "https://example.com/6",
+      "https://example.com/5",
+      "https://example.com/4",
+      "https://example.com/3",
+      "https://example.com/2",
+    ])
+
+    unmount()
+    render(<UrlPane />)
+    fireEvent.change(screen.getByRole("combobox", { name: "Recent URLs" }), {
+      target: { value: "https://example.com/4" },
+    })
+    expect(screen.getByTitle("URL viewer: https://example.com/4")).toBeInTheDocument()
+  })
+
+  it("rejects non-web protocols", () => {
+    render(<UrlPane />)
+
+    navigateTo("javascript:alert(1)")
+
+    expect(screen.getByRole("alert")).toHaveTextContent("valid HTTP or HTTPS URL")
+    expect(screen.queryByTitle(/URL viewer:/)).not.toBeInTheDocument()
+  })
+})

--- a/plugins/url-pane/src/front/index.ts
+++ b/plugins/url-pane/src/front/index.ts
@@ -1,0 +1,28 @@
+import { definePlugin } from "@hachej/boring-workspace/plugin"
+import { UrlPane } from "./UrlPane"
+
+export const URL_PANE_PANEL_ID = "url-pane.panel"
+
+export const urlPanePlugin = definePlugin({
+  id: "url-pane",
+  label: "URL Pane",
+  panels: [
+    {
+      id: URL_PANE_PANEL_ID,
+      label: "URL Pane",
+      component: UrlPane,
+      placement: "shared-dockview",
+    },
+  ],
+  commands: [
+    {
+      id: "url-pane.open",
+      title: "Open URL Pane",
+      panelId: URL_PANE_PANEL_ID,
+      keywords: ["browser", "iframe", "web", "url"],
+    },
+  ],
+})
+
+export default urlPanePlugin
+export { UrlPane } from "./UrlPane"

--- a/plugins/url-pane/src/test-setup.ts
+++ b/plugins/url-pane/src/test-setup.ts
@@ -1,0 +1,10 @@
+import { afterEach, expect } from "vitest"
+import * as matchers from "@testing-library/jest-dom/matchers"
+import { cleanup } from "@testing-library/react"
+
+expect.extend(matchers)
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})

--- a/plugins/url-pane/tsconfig.json
+++ b/plugins/url-pane/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "ignoreDeprecations": "6.0",
+    "paths": {
+      "@hachej/boring-ui-kit": ["../../packages/ui/src/index.ts"],
+      "@hachej/boring-workspace/plugin": ["../../packages/workspace/src/plugin.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/plugins/url-pane/tsup.config.ts
+++ b/plugins/url-pane/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: {
+    "front/index": "src/front/index.ts",
+  },
+  format: ["esm"],
+  dts: true,
+  splitting: false,
+  clean: true,
+  outDir: "dist",
+  target: "es2022",
+  platform: "neutral",
+  external: [
+    /^@hachej\/boring-/,
+    "react",
+    "react-dom",
+    "react/jsx-runtime",
+  ],
+})

--- a/plugins/url-pane/vitest.config.ts
+++ b/plugins/url-pane/vitest.config.ts
@@ -1,0 +1,18 @@
+import { resolve } from "node:path"
+import react from "@vitejs/plugin-react"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@hachej/boring-ui-kit": resolve(import.meta.dirname, "../../packages/ui/src/index.ts"),
+      "@hachej/boring-workspace/plugin": resolve(import.meta.dirname, "../../packages/workspace/src/plugin.ts"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1788,6 +1788,49 @@ importers:
         specifier: ^4.1.9
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
+  plugins/url-pane:
+    dependencies:
+      '@hachej/boring-ui-kit':
+        specifier: workspace:*
+        version: link:../../packages/ui
+    devDependencies:
+      '@hachej/boring-workspace':
+        specifier: workspace:*
+        version: link:../../packages/workspace
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.0.0
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^4.0.0
+        version: 4.7.0(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      tsup:
+        specifier: ^8.4.0
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.23)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ~6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.20.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+
   tools/ui-review:
     devDependencies:
       '@antithesishq/bombadil':


### PR DESCRIPTION
Closes nothing yet — v0 of #1083.

## Summary
- new first-party `plugins/url-pane` plugin: one pane type embedding a user-entered URL in an iframe
- address bar (enter to navigate), refresh, recent-URLs list (localStorage, last 8), load-error hint (frame headers / reachability)
- no process management, no proxying — v1 (worker-reported URLs in review intentions) tracked on #1083

## Proof
- `pnpm -C plugins/url-pane test`: 4 passed (4), typecheck clean

## Provenance
Built by Sol (gpt-5.6-sol via codex exec) as a factory vibe-codeable-plugin test; reviewed and committed by orchestrator. First empirical datapoint for the clean-core plugin thesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eurvfk8oq3stNFsiHqFs7G