### PR TITLE
feat(factory): wire loop conventions into exec/plan/triage/handoff skills

### DIFF
--- a/.agents/skills/exec/SKILL.md
+++ b/.agents/skills/exec/SKILL.md
@@ -19,17 +19,23 @@ Read the artifact, `docs/procedures/boring-loop.md`, and
 - provider method: `../../skill-references/exec/index.md`
 
 Require clear scope, acceptance, proof, dependencies, and risk; repair planning
-gaps through `/skill:plan` and stop on unresolved human intent.
+gaps through `/skill:plan` and stop on unresolved human intent. For Beads work,
+lease exactly one ready bead with `br` before working; never work unclaimed.
 
 Implement the smallest bounded slice with behavior tests, record current proof,
 apply the Model Card review ladder and mandatory code-thermo gate, and integrate
 or disposition every material finding. Re-prove and re-review non-trivial fixes.
 Then open/update the PR and send the owner card through `ask_user` (PR comment
-fallback), attaching the best runnable UI or file/proof artifact.
+fallback), attaching the best runnable UI or file/proof artifact. Use commit
+subjects `[br-###] description` and push after every commit.
 
 For a UI packet, validate it first and follow the complete round, stop, baseline,
 and Inbox rules in `visual-review.md`; the packet grants no edit or merge
 authority.
+
+Before compaction, perform the handoff ritual in `.agents/factory/README.md`
+Session rules and link the artifact from the bead. At handoff/closure, write a
+one-line `friction` note on the bead. Never close your own bead.
 
 Exit only with green proof or an explicit waiver/residual risk, current required
 reviews, a human-runnable validation path, and a clear next action.

--- a/.agents/skills/handoff/SKILL.md
+++ b/.agents/skills/handoff/SKILL.md
@@ -26,7 +26,8 @@ An empty, incomplete, or unknown branch returns this usage and stops:
 ```
 
 If a human owes the next decision, use
-`docs/procedures/owner-review-card.md` instead.
+`docs/procedures/owner-review-card.md` instead. For bead work, put the handoff
+artifact pointer and a one-line `friction` note on the bead.
 
 Return branch-specific evidence:
 

--- a/.agents/skills/plan/SKILL.md
+++ b/.agents/skills/plan/SKILL.md
@@ -28,10 +28,13 @@ canonical contracts: `docs/procedures/{boring-loop.md,MODEL-CARD.md}` and
   artifacts, Inbox projections, and provenance only.
 - Keep one slice when possible. APR is advisory; accepted revisions enter the
   canonical plan.
+- Materialize slices as beads meeting `docs/procedures/bead-ready.md` (WHAT,
+  proof path, file scope, fits one session), and set bead priority at plan time.
 - Before Beads handoff run `br dep cycles` and `bv --robot-insights`; never bare
   `bv`.
 - Use `/skill:fresh-eyes` as tier 1, then continue the required Model Card ladder.
-  Use `ask_user` for unresolved intent, risk, or approval.
+  Use `ask_user` for unresolved intent, risk, or approval. A plan-approval
+  intention links the visual plan doc from `docs/procedures/visual-review-doc.md`.
 - Provider command names are advisory; translate legacy `/implement` to `/exec`.
 
 Return the canonical artifact/URL, method, slices/Beads, blockers, proof path, and

--- a/.agents/skills/triage/SKILL.md
+++ b/.agents/skills/triage/SKILL.md
@@ -7,7 +7,8 @@ disable-model-invocation: true
 # Triage
 
 Classify; do not implement. Use the labels, blocker vocabulary, and transitions in
-`docs/procedures/boring-loop.md`.
+`docs/procedures/boring-loop.md`. Thread equals bead: include the bead ID in
+session titles, intention subjects, and artifact names.
 
 1. Read the item, comments, links, and relevant code/docs.
 2. Verify cheaply when safe; bugs need a red-capable repro or concrete manual path.


### PR DESCRIPTION
Follow-up to #1075. Wires the ratified factory loop into the executing skills so agents actually follow it:

- **exec**: claim exactly one ready bead via `br` lease before working; `[br-###]` commit subjects, push every commit; handoff ritual before compaction (artifact linked from the bead); one-line `friction` note at handoff/closure; never close your own bead
- **plan**: slices materialize as beads meeting `docs/procedures/bead-ready.md`; priority set at plan time; plan-approval intention links the visual plan doc
- **triage**: thread=bead correlation (bead ID in session titles, intention subjects, artifact names)
- **handoff**: bead carries the artifact pointer + friction note

16 insertions across 4 skills; references procedures instead of restating them. Built by the pi worker track of the factory orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Eurvfk8oq3stNFsiHqFs7G