### PR TITLE
[factory] Beadle = supervisor (pull-based dispatch) + lease heartbeat + session-bead binding

### DIFF
--- a/.agents/factory/README.md
+++ b/.agents/factory/README.md
@@ -31,7 +31,7 @@ One line per stage. The gate column is what must be true before work leaves it.
 | refine | concierge | `ask-boring` routing | boring-loop | idea/issue → agreed epic scope | owner says go (conversational) |
 | triage | triage | `triage` | boring-loop | GH issue → category, state, first blocker, route | exactly one state, one next action |
 | plan | steward | `plan` | `issue-plans.md` | epic → bead graph + proof path | **human gate 1**: plan-approval intention |
-| dispatch | beadle (automation) | — | `worktree-agent.md` | ready beads → claimed bead + worker session | worker cap and lease rules in policy.yaml |
+| dispatch | beadle (automation) | — | `worktree-agent.md` | ready beads → claimed bead + worker session | worker cap and lease rules in policy.yaml; Beadle stamps the session id on the bead and injects the bead id into the session at spawn |
 | exec | worker | `exec` | `worktree-agent.md`, `proof-of-work.md` | one bead → commits + proof + handoff | focused proof green; handoff written |
 | review | reviewer | `fresh-eyes`, code review | `owner-review-card.md` | exact SHA → dispositions | no blocker/major open at that SHA |
 | merge | owner, or automatic for class A | — | `rolling-small-fixes.md` (bug lane) | reviewed PR → main | **human gate 2**: trust ladder in policy.yaml |
@@ -90,6 +90,11 @@ These rules apply to every seat including the Concierge — its durable state
 lives in beads/notes, never in accumulated session context.
 
 - One bead = one durable session. Identity lives in the seat, not the session.
+- The **Beadle writes the binding** at dispatch (session id on the bead, bead
+  id in the session's opening context); the **worker maintains it** — first
+  action is verifying the lease and bound bead, and a session that wakes
+  without a bead id stops rather than improvises. Planners never touch
+  sessions; their contract ends at ready beads.
 - The handoff ritual (`.agents/skills/handoff/`, procedure
   `docs/procedures/session-handoff.md`) runs **before** compaction at
   the policy threshold. Convention: commit work in progress, persist the full

--- a/.agents/factory/README.md
+++ b/.agents/factory/README.md
@@ -31,7 +31,7 @@ One line per stage. The gate column is what must be true before work leaves it.
 | refine | concierge | `ask-boring` routing | boring-loop | idea/issue → agreed epic scope | owner says go (conversational) |
 | triage | triage | `triage` | boring-loop | GH issue → category, state, first blocker, route | exactly one state, one next action |
 | plan | steward | `plan` | `issue-plans.md` | epic → bead graph + proof path | **human gate 1**: plan-approval intention |
-| dispatch | beadle (automation) | — | `worktree-agent.md` | ready beads → claimed bead + worker session | worker cap and lease rules in policy.yaml; Beadle stamps the session id on the bead and injects the bead id into the session at spawn |
+| dispatch | worker (pull) + beadle (supervisor) | — | `worktree-agent.md` | ready beads → claimed bead + worker session | pull-based: worker runs `br ready`, leases one bead, stamps its session id on the bead at claim; Beadle only spawns workers while ready > active (cap and lease rules in policy.yaml) — it never picks beads |
 | exec | worker | `exec` | `worktree-agent.md`, `proof-of-work.md` | one bead → commits + proof + handoff | focused proof green; handoff written |
 | review | reviewer | `fresh-eyes`, code review | `owner-review-card.md` | exact SHA → dispositions | no blocker/major open at that SHA |
 | merge | owner, or automatic for class A | — | `rolling-small-fixes.md` (bug lane) | reviewed PR → main | **human gate 2**: trust ladder in policy.yaml |
@@ -90,11 +90,20 @@ These rules apply to every seat including the Concierge — its durable state
 lives in beads/notes, never in accumulated session context.
 
 - One bead = one durable session. Identity lives in the seat, not the session.
-- The **Beadle writes the binding** at dispatch (session id on the bead, bead
-  id in the session's opening context); the **worker maintains it** — first
-  action is verifying the lease and bound bead, and a session that wakes
-  without a bead id stops rather than improvises. Planners never touch
-  sessions; their contract ends at ready beads.
+- The **worker writes the binding at claim**: leasing a bead and stamping the
+  session id on it are one atomic act (`br` lease + note). A session that
+  cannot verify its lease and bound bead stops rather than improvises.
+  Planners never touch sessions; their contract ends at ready beads.
+- **Liveness**: the lease is the heartbeat. A working session refreshes its
+  lease at least every `beadle.lease_heartbeat_minutes` (any `br` touch of the
+  bead counts). Idle for any reason — compaction, crash, a wait that never
+  wakes — looks identical from outside: no heartbeat. After
+  `beadle.stale_lease_minutes` the Beadle breaks the lease and the bead
+  returns to ready; the next worker re-primes from the bead + handoff
+  artifact. Handoff-before-compaction makes this loss-free for the planned
+  case; for crashes, the last commit + bead notes are the floor. Never wait on
+  a fire-and-forget monitor to wake you — poll synchronously so the heartbeat
+  keeps beating.
 - The handoff ritual (`.agents/skills/handoff/`, procedure
   `docs/procedures/session-handoff.md`) runs **before** compaction at
   the policy threshold. Convention: commit work in progress, persist the full

--- a/.agents/factory/policy.yaml
+++ b/.agents/factory/policy.yaml
@@ -6,6 +6,7 @@ beadle:
   tick_minutes: 10
   worker_cap: 2 # concurrent /exec workers, fleet-wide
   stale_lease_minutes: 90
+  lease_heartbeat_minutes: 15 # a working session must touch its bead at least this often
   bugfix_reserved_slots: 0 # worker slots held for the bugfix lane
 
 bounce:

--- a/.agents/factory/tools.md
+++ b/.agents/factory/tools.md
@@ -9,7 +9,7 @@ fact has exactly one authority, and no stage invents a second path to it.
 | human intake, epics, PRs, labels | GitHub | `gh` CLI | triage, steward, reviewer |
 | code and history | git worktrees | `git` | worker (write), reviewer (read) |
 | human decisions | inbox Human Intentions | `ask_user` | every seat |
-| dispatch and sweeps | `plugins/boring-automation` | scheduled automation | beadle only |
+| supervisor spawns and sweeps | `plugins/boring-automation` | scheduled automation | beadle only |
 | task board rendering | `plugins/tasks` sources | GitHub + Beads adapters | UI, read-only |
 | seat runtime | AgentHost fleet | authored persona + trusted policy | host |
 | parallel fan-out | `pi-subagents` (runtime plugin skill) | ephemeral subagents | steward, reviewer, worker |

--- a/.agents/skills/exec/SKILL.md
+++ b/.agents/skills/exec/SKILL.md
@@ -21,6 +21,8 @@ Read the artifact, `docs/procedures/boring-loop.md`, and
 Require clear scope, acceptance, proof, dependencies, and risk; repair planning
 gaps through `/skill:plan` and stop on unresolved human intent. For Beads work,
 lease exactly one ready bead with `br` before working; never work unclaimed.
+If dispatched by the Beadle, verify the bound bead id and lease first; if the
+session has no bound bead id, stop and flag it — do not pick one yourself.
 
 Implement the smallest bounded slice with behavior tests, record current proof,
 apply the Model Card review ladder and mandatory code-thermo gate, and integrate

--- a/.agents/skills/exec/SKILL.md
+++ b/.agents/skills/exec/SKILL.md
@@ -20,9 +20,10 @@ Read the artifact, `docs/procedures/boring-loop.md`, and
 
 Require clear scope, acceptance, proof, dependencies, and risk; repair planning
 gaps through `/skill:plan` and stop on unresolved human intent. For Beads work,
-lease exactly one ready bead with `br` before working; never work unclaimed.
-If dispatched by the Beadle, verify the bound bead id and lease first; if the
-session has no bound bead id, stop and flag it — do not pick one yourself.
+pull your work: `br ready --json`, lease exactly one bead, and stamp your
+session id on it in the same act — never work unclaimed. Refresh the lease as
+you work (any `br` touch counts; cadence key `beadle.lease_heartbeat_minutes`);
+poll long waits synchronously so the heartbeat keeps beating.
 
 Implement the smallest bounded slice with behavior tests, record current proof,
 apply the Model Card review ladder and mandatory code-thermo gate, and integrate

--- a/docs/factory/TODO.md
+++ b/docs/factory/TODO.md
@@ -34,11 +34,14 @@ only (do not duplicate in VISION).
 
 ## 4. Beadle automation + policy parser
 
-- **Today**: no dispatcher; task→chat only on human click;
-  `plugins/boring-automation` exists as the scheduling host.
+- **Today**: no supervisor; task→chat only on human click;
+  `plugins/boring-automation` exists as the scheduling host. Workers pull
+  their own beads (`br ready` → lease + session-id stamp); the Beadle never
+  picks beads.
 - **Delta**: a `boring-automation` scheduled automation on the tick cadence in
   `.agents/factory/policy.yaml`: spawn workers while ready > active (cap), break
-  stale leases (require handoff notes), flag beads closed without proof,
+  stale leases (no heartbeat past `stale_lease_minutes`; require handoff notes
+  or a provably dead session), flag beads closed without proof,
   rebase epic branches past thresholds, file conflict beads.
 
 ## 5. Trust ladder + bugfix lane

--- a/docs/factory/VISION.md
+++ b/docs/factory/VISION.md
@@ -25,7 +25,7 @@ Agent Mail — adopted selectively; deviations are deliberate and listed below.
 | L0 Chassis | AgentHost fleet spec, identity/authority split, plugin system, sandboxed tool admission | exists (#1075) |
 | L1 Work graph | Beads via plain `br` CLI; GH issues = human intake, 1 epic = 1 GH issue | br live; UI read-only provider in #1075 |
 | L2 Seats | concierge / triage / steward / worker / reviewer under `.agents/personas/` | authored in #1075; no production loader |
-| L3 Loops | /triage /plan /exec skills + Beadle dispatcher automation | skills exist; Beadle missing |
+| L3 Loops | /triage /plan /exec skills + Beadle supervisor automation (workers pull) | skills exist; Beadle missing |
 | L4 Human plane | Concierge front door, inbox intentions, (later) Swarm Console | intentions exist; edges landing (session↔task, artifact handover) |
 | L5 Comms | thread=bead convention only; Agent Mail/Buzz deferred | convention adoptable now |
 
@@ -37,9 +37,14 @@ Agent Mail — adopted selectively; deviations are deliberate and listed below.
 2. **Beads**: plain `br` for all agents. Git history of `.beads/issues.jsonl`
    is the audit trail. Beadle flags beads closed without linked proof/handoff.
    No verb ACLs.
-3. **Beadle**: a boring-ui automation. Tick cadence and worker cap live in
-   policy.yaml; workers self-claim via `br` lease; breaks stale leases; spawns
-   workers while ready > active; sweeps epic-branch drift.
+3. **Beadle** (amended 2026-08-06): a supervisor, never a dispatcher. Dispatch
+   is pull-based, flywheel-style: a worker session starts with `br ready
+   --json`, leases exactly one bead, and stamps its own session id on the bead
+   at claim — claim and binding are one atomic act by the worker. The Beadle
+   only guarantees pullers exist and janitors the graph: spawns workers while
+   ready > active (up to the cap), breaks stale leases, flags proof-less
+   closures, sweeps epic-branch drift. It never chooses which bead. Tick
+   cadence and worker cap live in policy.yaml.
 4. **Trust ladder**: class A = path-allowlist AND reviewer-pass AND size-cap.
    Ladder/config/workflow/fleet-policy files are permanently class B (no agent
    can widen its own permissions). Config: `.agents/factory/policy.yaml`,
@@ -76,7 +81,7 @@ The factory adds no new runtime. Every moving part is an existing primitive:
 
 | Factory part | Primitive |
 | --- | --- |
-| Beadle dispatcher | `plugins/boring-automation` scheduled automation |
+| Beadle supervisor | `plugins/boring-automation` scheduled automation |
 | Task board (GH + Beads) | `plugins/tasks` sources — `githubSource` (main) + Beads adapter (read-only, on PR #1075; merge + registry seam = TODO 3) |
 | Seats | AgentHost fleet spec + `.agents/personas/*` identities |
 | Worker execution | pi sessions (1 bead = 1 session) + pi-subagents for ephemeral roles |


### PR DESCRIPTION
Re-lands two commits stranded on the #1089 branch after its auto-merge fired:

- Worker claims-and-binds: `br ready` → lease one bead + stamp session id, one atomic act. Planners never touch sessions.
- Beadle amended to supervisor (VISION decision 3): spawns workers while ready > active, breaks stale leases, sweeps — never picks beads (flywheel pull model).
- Liveness: lease = heartbeat (`beadle.lease_heartbeat_minutes: 15`); idle-for-any-reason (compaction/crash/dead wait) is uniformly a missed heartbeat → lease break → re-prime from bead + handoff artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1HtxZAQUmLXhaZmL3sEH4