### PR TITLE
[wt-391-forward-1051-final-pane-close-y8u] fix(workspace): hide close action on final chat pane (#1051)

### DIFF
--- a/docs/issues/1051/plan.md
+++ b/docs/issues/1051/plan.md
@@ -1,0 +1,66 @@
+---
+github: https://github.com/hachej/boring-ui/issues/1051
+issue: 1051
+state: ready-for-agent
+updated: 2026-08-06
+flag: not-needed
+---
+
+# gh-1051 Chat pane: hide close action on the final session
+
+## Problem
+
+The workspace center requires at least one chat pane. Today the final
+remaining chat pane still renders a close action; using it leaves an invalid
+center state. Follow-up to #1032.
+
+## Solution
+
+In the chat pane header, render the close action only when more than one chat
+pane exists. Split actions remain on the final pane. Multi-pane chats keep
+close. Pure front-end conditional; no server involvement.
+
+## Decisions
+
+- Derive "is final pane" from the existing pane/layout model the header
+  already receives — no new state, no new props threading beyond what the
+  layout already knows.
+
+## Flag / Abstraction
+- Needed?: no — tiny, reversible UI conditional.
+- Rollback: revert the PR.
+
+## Test Seams
+- Highest public seam: the chat pane header component with 1 vs 2+ panes.
+- Existing prior art: pane header tests near the touched component.
+- Avoid testing: layout engine internals.
+
+## Acceptance
+
+1. Final remaining chat pane: no close action; split actions present.
+2. Two or more chat panes: every pane shows close.
+3. Closing down to one pane removes the last close button reactively.
+4. Desktop and mobile variants both covered.
+
+## Proof
+- Exact command: focused vitest run on the touched component's test file(s)
+  in `packages/workspace`.
+- Manual steps: workspace playground — open two chats, close one, observe the
+  survivor loses its close button.
+
+## Slices
+
+### Slice: hide-close-on-final-pane
+**Bead:** wt-391-forward-1051-final-pane-close-y8u
+**Delivers:** conditional close action + regression tests (desktop/mobile)
+**Blocked by:** None
+**Proof:** focused vitest green + playground manual check
+**Review budget:** inside
+
+## Out of Scope
+
+- Any change to split behavior, pane persistence, or session deletion.
+
+## Open Questions
+
+None.

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -417,12 +417,9 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.getByText("First session")).toBeInTheDocument()
   })
 
-  it("replaces the sole closed chat pane with a fresh New chat pane", async () => {
-    const user = userEvent.setup()
-    const createSession = vi.fn()
-
+  it("hides the close action on the sole chat pane (#1051: the center always needs one chat)", () => {
     function Harness() {
-      const [sessions, setSessions] = useState([
+      const [sessions] = useState([
         { id: "s1", title: "First session", updatedAt: Date.now() },
       ])
       const [activeSessionId, setActiveSessionId] = useState("s1")
@@ -434,10 +431,7 @@ describe("WorkspaceAgentFront", () => {
           activeSessionId={activeSessionId}
           onSwitchSession={setActiveSessionId}
           onCreateSession={() => {
-            createSession()
             const session = { id: "fresh", title: "New chat", updatedAt: Date.now() }
-            setSessions((current) => [...current, session])
-            setActiveSessionId(session.id)
             return session
           }}
           persistenceEnabled={false}
@@ -447,12 +441,7 @@ describe("WorkspaceAgentFront", () => {
 
     render(<Harness />)
     expect(visibleChatSessionIds()).toEqual(["s1"])
-
-    await user.click(screen.getByLabelText("Close First session pane"))
-
-    await waitFor(() => expect(visibleChatSessionIds()).toEqual(["fresh"]))
-    expect(createSession).toHaveBeenCalledOnce()
-    expect(screen.getByLabelText("Close New chat pane")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Close First session pane")).not.toBeInTheDocument()
   })
 
   it("keeps colliding addressed sessions distinct through pane activation and deletion", async () => {

--- a/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
+++ b/packages/workspace/src/front/layout/ChatPaneStageDock.tsx
@@ -608,7 +608,7 @@ function ChatPaneHeaderActions({ activePanel }: IDockviewHeaderActionsProps) {
             {stage.topActions}
           </div>
         ) : null}
-        {stage.onClosePane ? (
+        {stage.onClosePane && stage.panes.length > 1 ? (
           <CornerChromeButton
             label={`Close ${title} pane`}
             appearance="chat"

--- a/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/ChatPaneStageDock.test.tsx
@@ -224,6 +224,50 @@ describe("ChatPaneStageDock", () => {
     expect(closePane).toHaveBeenNthCalledWith(2, "b")
   })
 
+  it("hides the close control on the final remaining pane but keeps split", () => {
+    const closePane = vi.fn()
+    render(
+      <ChatPaneStageDock
+        panes={[{ id: "a", title: "A" }]}
+        onSplitPane={vi.fn()}
+        onClosePane={closePane}
+        renderPane={(pane) => <div>{pane.id}</div>}
+      />,
+    )
+
+    expect(screen.queryByRole("button", { name: /Close .* pane/ })).toBeNull()
+    expect(screen.getByRole("button", { name: "Split A chat vertically" })).toBeTruthy()
+  })
+
+  it("restores the close control reactively once a second pane exists", () => {
+    const closePane = vi.fn()
+    const { rerender } = render(
+      <ChatPaneStageDock
+        panes={[{ id: "a", title: "A" }]}
+        onSplitPane={vi.fn()}
+        onClosePane={closePane}
+        renderPane={(pane) => <div>{pane.id}</div>}
+      />,
+    )
+
+    expect(screen.queryByRole("button", { name: /Close .* pane/ })).toBeNull()
+
+    rerender(
+      <ChatPaneStageDock
+        panes={[
+          { id: "a", title: "A" },
+          { id: "b", title: "B" },
+        ]}
+        onSplitPane={vi.fn()}
+        onClosePane={closePane}
+        renderPane={(pane) => <div>{pane.id}</div>}
+      />,
+    )
+
+    expect(screen.getByRole("button", { name: "Close A pane" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Close B pane" })).toBeTruthy()
+  })
+
   it("opens session actions for pin, rename, and delete", () => {
     const onTogglePin = vi.fn()
     const onRename = vi.fn()

--- a/packages/workspace/src/front/layout/__tests__/mobileShell.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/mobileShell.test.tsx
@@ -18,12 +18,26 @@ describe("mobile chat chrome", () => {
     expect(screen.queryByText("One active thread on mobile")).toBeNull()
   })
 
-  it("uses an accessible touch target for the close action even for the sole pane", () => {
+  it("hides the close action when this is the sole remaining pane", () => {
     const onClosePane = vi.fn()
     render(
       <MobileSingleChatPane
         pane={{ id: "pane-a", title: "Planning" }}
         totalPanes={1}
+        onClosePane={onClosePane}
+        renderPane={() => <div>Transcript</div>}
+      />,
+    )
+
+    expect(screen.queryByRole("button", { name: "Close Planning pane" })).toBeNull()
+  })
+
+  it("uses an accessible touch target for the close action when more than one pane exists", () => {
+    const onClosePane = vi.fn()
+    render(
+      <MobileSingleChatPane
+        pane={{ id: "pane-a", title: "Planning" }}
+        totalPanes={2}
         onClosePane={onClosePane}
         renderPane={() => <div>Transcript</div>}
       />,
@@ -40,7 +54,7 @@ describe("mobile chat chrome", () => {
     render(
       <MobileSingleChatPane
         pane={{ id, title: id }}
-        totalPanes={1}
+        totalPanes={2}
         onClosePane={() => {}}
         renderPane={() => <div>Transcript</div>}
       />,

--- a/packages/workspace/src/front/layout/mobileShell.tsx
+++ b/packages/workspace/src/front/layout/mobileShell.tsx
@@ -27,7 +27,7 @@ export function MobileSingleChatPane({
           ) : null}
         </div>
         {topActions ? <div className="flex shrink-0 items-center gap-1">{topActions}</div> : null}
-        {onClosePane ? (
+        {onClosePane && totalPanes > 1 ? (
           <button
             type="button"
             className="inline-flex size-11 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground"


### PR DESCRIPTION
Closes #1051. First Boring Factory loop run (bead wt-391-forward-1051-final-pane-close-y8u).

- Desktop: `ChatPaneStageDock.tsx` close button gated on `stage.panes.length > 1`; split actions untouched.
- Mobile: `mobileShell.tsx` gated on `totalPanes > 1`.
- Regression tests desktop+mobile (17 green), reviewer mutation-verified: reverting the guards fails 3 tests.
- Reviewer verdict: pass at c5bbc5487 (2 source lines changed; typecheck failures pre-existing on base in WorkspaceAgentFront.tsx).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1HtxZAQUmLXhaZmL3sEH4