### PR TITLE
[gh-1106 slice 2] CI: run digest-verifying suites on .agents/** changes

### DIFF
--- a/scripts/test-changed-workspaces.mjs
+++ b/scripts/test-changed-workspaces.mjs
@@ -49,6 +49,9 @@ const globalTestFiles = new Set([
 const globalTestPrefixes = [
   '.github/workflows/',
   'scripts/',
+  '.agents/skills/',
+  '.agents/factory/',
+  '.agents/personas/',
 ]
 
 const changedNames = new Set()


### PR DESCRIPTION
## Finding: bug is in test-changed-workspaces.mjs, not ci.yml's path filter

The bead's premise was that `.github/workflows/ci.yml`'s "Detect changed
areas" step (`changes` job, lines ~53-80) gates the unit test jobs. It does
not: `unit-changed` and `unit-full` have no `needs: changes` and their `if:`
conditions only branch on `push` vs `pull_request` and PR labels
(`ci:full`, `release-candidate`, `release/*`). The `changes` job's outputs
(`workspace_bundle`, `core_bundle`, `e2e`, `ui_review`, `worker_smoke`) only
gate bundle-budget/e2e/ui-review/worker-smoke jobs — never unit tests.

The actual routing for unit tests is `pnpm test:changed` →
`scripts/test-changed-workspaces.mjs`, which maps each changed file to its
*owning workspace package* (by path prefix) to decide which package test
scripts to run, with a `globalTestPrefixes` escape hatch
(`.github/workflows/`, `scripts/`) that forces the full `pnpm test` suite.

`.agents/**` files belong to no workspace package (no `package.json`
underneath), so a PR touching only `.agents/skills/**` produced an empty
`changedNames` set and `unit-changed` printed "no workspace package changes
... skipping" — silently never running
`apps/workspace-playground/src/server/factoryAgents.test.ts`, which verifies
trusted-composition digests. That is exactly how #1089/#1097/#1098 landed
while breaking main's `factoryAgents.test.ts` (fixed in #1101).

## Fix

Add `.agents/skills/`, `.agents/factory/`, `.agents/personas/` to
`globalTestPrefixes` in `scripts/test-changed-workspaces.mjs` (same idiom as
the existing `scripts/` and `.github/workflows/` prefixes). A change under
any of these now sets `globalChange = true` and runs the full `pnpm test`
suite, which includes `apps/workspace-playground`'s vitest run
(`factoryAgents.test.ts`).

`.agents/factory/` and `.agents/personas/` are included because persona and
factory content are composed the same way skill content is and feed the
same digest-verification tests.

`.github/workflows/ci.yml` is unchanged — editing its `changes`-job case
statements would have had zero effect on unit test routing, so I did not
touch it despite the bead's file assumption. Flagging this for owner review
since it diverges from the bead's stated file target.

## Proof

- `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml'))"` → OK (file untouched, still valid, included for completeness)
- `node -c scripts/test-changed-workspaces.mjs` → syntax OK
- `actionlint`/`yamllint` not installed on this VM (checked with `which`); no CI workflow file was edited so this is moot for the actual diff
- Manual trace of `test-changed-workspaces.mjs` logic confirms: files under `.agents/skills/`, `.agents/factory/`, `.agents/personas/` now hit `globalTestPrefixes.some(...)` → `globalChange = true` → `pnpm test` (full suite, includes workspace-playground's `factoryAgents.test.ts`)

class B — owner merge required

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1HtxZAQUmLXhaZmL3sEH4