### PR TITLE
[gh-1036] chat: terminal error presentation and recovery (UI loop, epic #1110)

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -52,6 +52,7 @@ import {
   type PanelNotice,
 } from './components/ChatNotices'
 import { PiConversationSurface } from './components/PiConversationSurface'
+import { hasTerminalChatError, isTerminalChatErrorId } from './components/terminalChatErrors'
 import type {
   ActionableSlashCommand,
   MessageMention,
@@ -494,7 +495,17 @@ export function PiChatPanel<
           dismissible: true,
         }]
       : []
-    return [...fromState, ...sessionNotice, ...largeStateNotice, ...localNotices].filter((notice) => !dismissedNoticeIds.has(notice.id))
+    const combined = [...fromState, ...sessionNotice, ...largeStateNotice, ...localNotices]
+      .filter((notice) => !dismissedNoticeIds.has(notice.id))
+    // A terminal chat error (history failed to load) already explains why the
+    // agent looks unreachable. Showing reconnect/warmup/retry chatter next to
+    // it reads as contradictory ("reconnecting..." beside "history
+    // unavailable"), so drop that noise once a terminal error is present.
+    if (!hasTerminalChatError(combined)) return combined
+    return combined.filter((notice) =>
+      isTerminalChatErrorId(notice.id) ||
+      (notice.id !== 'connection-reconnecting' && notice.id !== 'auto-retry' && !notice.id.includes('warmup')),
+    )
   }, [debug, debugState?.largeStateWarning, dismissedNoticeIds, localNotices, selectedChatState, sessionsError])
 
   const addLocalNotice = useCallback((notice: PanelNotice) => {

--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -52,7 +52,7 @@ import {
   type PanelNotice,
 } from './components/ChatNotices'
 import { PiConversationSurface } from './components/PiConversationSurface'
-import { hasTerminalChatError, isTerminalChatErrorId } from './components/terminalChatErrors'
+import { filterCompetingNoiseNotices } from './components/terminalChatErrors'
 import type {
   ActionableSlashCommand,
   MessageMention,
@@ -497,16 +497,14 @@ export function PiChatPanel<
       : []
     const combined = [...fromState, ...sessionNotice, ...largeStateNotice, ...localNotices]
       .filter((notice) => !dismissedNoticeIds.has(notice.id))
-    // A terminal chat error (history failed to load) already explains why the
-    // agent looks unreachable. Showing reconnect/warmup/retry chatter next to
-    // it reads as contradictory ("reconnecting..." beside "history
-    // unavailable"), so drop that noise once a terminal error is present.
-    if (!hasTerminalChatError(combined)) return combined
-    return combined.filter((notice) =>
-      isTerminalChatErrorId(notice.id) ||
-      (notice.id !== 'connection-reconnecting' && notice.id !== 'auto-retry' && !notice.id.includes('warmup')),
-    )
-  }, [debug, debugState?.largeStateWarning, dismissedNoticeIds, localNotices, selectedChatState, sessionsError])
+    // A terminal chat error (history failed to load, no messages present)
+    // already explains why the agent looks unreachable. Showing
+    // reconnect/retry chatter next to it reads as contradictory
+    // ("reconnecting..." beside "history unavailable"), so drop that noise —
+    // but only when there's genuinely no history, matching the gate in
+    // RuntimeNotices/PiConversationSurface (see terminalChatErrors.ts).
+    return filterCompetingNoiseNotices(combined, messages.length === 0)
+  }, [debug, debugState?.largeStateWarning, dismissedNoticeIds, localNotices, messages.length, selectedChatState, sessionsError])
 
   const addLocalNotice = useCallback((notice: PanelNotice) => {
     setLocalNotices((previous) => {

--- a/packages/agent/src/front/chat/components/ChatNotices.tsx
+++ b/packages/agent/src/front/chat/components/ChatNotices.tsx
@@ -38,11 +38,15 @@ export function RuntimeNoticeMessages({
   notices,
   onDismiss,
   renderAction,
+  historyEmpty,
 }: {
   notices: PanelNotice[]
   onDismiss: (id: string) => void
   /** Host-supplied recovery action for a notice, keyed off its error code. */
   renderAction?: (notice: PanelNotice) => ReactNode
+  /** True when the transcript has no messages; gates terminal-error framing
+   * in RuntimeNotices (see terminalChatErrors.ts). */
+  historyEmpty?: boolean
 }) {
   const visible = notices.filter((notice) =>
     notice.level === 'error' ||
@@ -59,6 +63,7 @@ export function RuntimeNoticeMessages({
       notices={visible}
       onDismiss={onDismiss}
       renderAction={renderAction}
+      historyEmpty={historyEmpty}
       className="mx-auto w-full max-w-3xl px-0 py-0"
     />
   )

--- a/packages/agent/src/front/chat/components/PiConversationSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiConversationSurface.tsx
@@ -77,11 +77,12 @@ export function PiConversationSurface({
 }: PiConversationSurfaceProps) {
   const messageItems = buildMessageRenderItems(messages)
   const total = messageItems.length
-  // A terminal error (history failed to load) already explains the empty
-  // transcript below via RuntimeNoticeMessages. Rendering the "What should we
-  // work on?" hero or a loading skeleton next to it reads as contradictory,
-  // so let the error notice stand alone.
-  const terminalError = hasTerminalChatError(runtimeNotices)
+  const historyEmpty = messages.length === 0
+  // A terminal error (history failed to load, no messages present) already
+  // explains the empty transcript below via RuntimeNoticeMessages. Rendering
+  // the "What should we work on?" hero or a loading skeleton next to it reads
+  // as contradictory, so let the error notice stand alone.
+  const terminalError = hasTerminalChatError(runtimeNotices, historyEmpty)
 
   const [visibleCount, setVisibleCount] = useState(TRANSCRIPT_WINDOW)
   // Start each session at the latest window rather than inheriting a large
@@ -146,7 +147,7 @@ export function PiConversationSurface({
             onMentionActivate={onMentionActivate}
           />
         ))}
-        <RuntimeNoticeMessages notices={runtimeNotices} onDismiss={onDismissNotice} renderAction={renderNoticeAction} />
+        <RuntimeNoticeMessages notices={runtimeNotices} onDismiss={onDismissNotice} renderAction={renderNoticeAction} historyEmpty={historyEmpty} />
       </ConversationContent>
       <ConversationScrollButton />
     </Conversation>

--- a/packages/agent/src/front/chat/components/PiConversationSurface.tsx
+++ b/packages/agent/src/front/chat/components/PiConversationSurface.tsx
@@ -17,6 +17,7 @@ import {
 import { RuntimeNoticeMessages, type PanelNotice } from './ChatNotices'
 import { PiTimelineMessage } from './PiTimelineMessage'
 import type { MessageMention, MessageMentionCatalog } from './MessageMentions'
+import { hasTerminalChatError } from './terminalChatErrors'
 
 // Heavy sessions (tool-heavy runs reach thousands of messages) must not mount
 // the whole transcript at once. Render a window anchored to the latest message
@@ -76,6 +77,11 @@ export function PiConversationSurface({
 }: PiConversationSurfaceProps) {
   const messageItems = buildMessageRenderItems(messages)
   const total = messageItems.length
+  // A terminal error (history failed to load) already explains the empty
+  // transcript below via RuntimeNoticeMessages. Rendering the "What should we
+  // work on?" hero or a loading skeleton next to it reads as contradictory,
+  // so let the error notice stand alone.
+  const terminalError = hasTerminalChatError(runtimeNotices)
 
   const [visibleCount, setVisibleCount] = useState(TRANSCRIPT_WINDOW)
   // Start each session at the latest window rather than inheriting a large
@@ -105,10 +111,10 @@ export function PiConversationSurface({
         chrome ? 'max-w-3xl px-6 py-8' : 'max-w-[680px] px-4 py-4',
         emptyHero && 'py-4 text-center',
       )}>
-        {messages.length === 0 && emptyStateHydrating ? (
+        {messages.length === 0 && emptyStateHydrating && !terminalError ? (
           <ConversationHistoryLoadingState />
         ) : null}
-        {messages.length === 0 && !emptyStateHydrating ? (
+        {messages.length === 0 && !emptyStateHydrating && !terminalError ? (
           <ChatEmptyState
             eyebrow={emptyState?.eyebrow}
             title={emptyState?.title}

--- a/packages/agent/src/front/chat/components/RuntimeNotices.tsx
+++ b/packages/agent/src/front/chat/components/RuntimeNotices.tsx
@@ -7,7 +7,7 @@ import { Button } from '@hachej/boring-ui-kit'
 import { cn } from '../../lib'
 import type { PiChatRuntimeNotice } from '../pi/piChatReducer'
 import { noticeIconClass, noticeSurfaceClass, noticeTextClass } from './noticeStyles'
-import { isTerminalChatErrorId } from './terminalChatErrors'
+import { isTerminalChatErrorNotice } from './terminalChatErrors'
 
 export type RuntimeNoticeKind = 'reconnect' | 'protocol' | 'warmup' | 'plugin' | 'retry' | 'generic'
 
@@ -24,9 +24,15 @@ export interface RuntimeNoticesProps extends Omit<HTMLAttributes<HTMLDivElement>
    * onAction button. Lets a host attach a recovery action for a specific error
    * code without this component knowing the code. */
   renderAction?: (notice: RuntimeNotice) => ReactNode
+  /** True when the transcript has no messages. Gates the terminal-error
+   * presentation (plain-language title, collapsible details, reload action):
+   * a terminal-error id like 'chat-error' can also carry a mid-conversation
+   * turn failure that survived a snapshot resync, and that case must keep its
+   * raw headline instead of claiming "history unavailable". */
+  historyEmpty?: boolean
 }
 
-export const RuntimeNotices = memo(({ notices, onDismiss, onAction, renderAction, className, ...props }: RuntimeNoticesProps) => {
+export const RuntimeNotices = memo(({ notices, onDismiss, onAction, renderAction, historyEmpty, className, ...props }: RuntimeNoticesProps) => {
   if (notices.length === 0) return null
 
   return (
@@ -36,7 +42,14 @@ export const RuntimeNotices = memo(({ notices, onDismiss, onAction, renderAction
       {...props}
     >
       {notices.map((notice) => (
-        <RuntimeNoticeRow key={notice.id} notice={notice} onDismiss={onDismiss} onAction={onAction} renderAction={renderAction} />
+        <RuntimeNoticeRow
+          key={notice.id}
+          notice={notice}
+          onDismiss={onDismiss}
+          onAction={onAction}
+          renderAction={renderAction}
+          historyEmpty={historyEmpty ?? false}
+        />
       ))}
     </div>
   )
@@ -49,18 +62,31 @@ interface RuntimeNoticeRowProps {
   onDismiss?: (id: string) => void
   onAction?: (id: string) => void
   renderAction?: (notice: RuntimeNotice) => ReactNode
+  historyEmpty: boolean
 }
 
-function RuntimeNoticeRow({ notice, onDismiss, onAction, renderAction }: RuntimeNoticeRowProps) {
+function RuntimeNoticeRow({ notice, onDismiss, onAction, renderAction, historyEmpty }: RuntimeNoticeRowProps) {
   const kind = inferNoticeKind(notice)
   const Icon = iconForNotice(kind, notice.level)
   const actionLabel = notice.actionLabel ?? defaultActionLabel(kind)
   const hostAction = renderAction?.(notice)
-  // A terminal chat error means the transcript itself failed to load (session
-  // lookup, history hydrate, protocol desync) rather than transient noise.
-  // These get plain-language framing, collapsible technical details, and an
-  // explicit recovery action instead of the raw server error string.
-  const isTerminalError = isTerminalChatErrorId(notice.id)
+  // A terminal chat error means the transcript itself failed to load, with no
+  // message history to show. See terminalChatErrors.ts for why this needs
+  // both the id check and the empty-history gate.
+  const isTerminalError = isTerminalChatErrorNotice(notice.id, historyEmpty)
+  // Never stack a second action next to a host- or notice-supplied one: prefer
+  // whichever the host/notice already set, and only fall back to the built-in
+  // reload action when neither exists.
+  const explicitAction = actionLabel && onAction
+    ? <Button type="button" variant="ghost" size="sm" onClick={() => onAction(notice.id)}>{actionLabel}</Button>
+    : null
+  const primaryAction = hostAction
+    ?? explicitAction
+    ?? (isTerminalError ? (
+      <Button type="button" variant="outline" size="sm" className="shrink-0" onClick={() => window.location.reload()}>
+        Reload workspace
+      </Button>
+    ) : null)
 
   return (
     <div
@@ -92,17 +118,7 @@ function RuntimeNoticeRow({ notice, onDismiss, onAction, renderAction }: Runtime
           <p className={noticeTextClass()}>{notice.text}</p>
         )}
       </div>
-      {hostAction ?? null}
-      {isTerminalError ? (
-        <Button type="button" variant="outline" size="sm" onClick={() => window.location.reload()}>
-          Reload workspace
-        </Button>
-      ) : null}
-      {!isTerminalError && actionLabel && onAction ? (
-        <Button type="button" variant="ghost" size="sm" onClick={() => onAction(notice.id)}>
-          {actionLabel}
-        </Button>
-      ) : null}
+      {primaryAction}
       {notice.dismissible && onDismiss ? (
         <Button
           type="button"

--- a/packages/agent/src/front/chat/components/RuntimeNotices.tsx
+++ b/packages/agent/src/front/chat/components/RuntimeNotices.tsx
@@ -7,6 +7,7 @@ import { Button } from '@hachej/boring-ui-kit'
 import { cn } from '../../lib'
 import type { PiChatRuntimeNotice } from '../pi/piChatReducer'
 import { noticeIconClass, noticeSurfaceClass, noticeTextClass } from './noticeStyles'
+import { isTerminalChatErrorId } from './terminalChatErrors'
 
 export type RuntimeNoticeKind = 'reconnect' | 'protocol' | 'warmup' | 'plugin' | 'retry' | 'generic'
 
@@ -55,6 +56,11 @@ function RuntimeNoticeRow({ notice, onDismiss, onAction, renderAction }: Runtime
   const Icon = iconForNotice(kind, notice.level)
   const actionLabel = notice.actionLabel ?? defaultActionLabel(kind)
   const hostAction = renderAction?.(notice)
+  // A terminal chat error means the transcript itself failed to load (session
+  // lookup, history hydrate, protocol desync) rather than transient noise.
+  // These get plain-language framing, collapsible technical details, and an
+  // explicit recovery action instead of the raw server error string.
+  const isTerminalError = isTerminalChatErrorId(notice.id)
 
   return (
     <div
@@ -71,10 +77,28 @@ function RuntimeNoticeRow({ notice, onDismiss, onAction, renderAction }: Runtime
     >
       <Icon className={cn(noticeIconClass(notice.level), kind === 'retry' && 'animate-spin motion-reduce:animate-none')} aria-hidden="true" />
       <div className="min-w-0 flex-1">
-        <p className={noticeTextClass()}>{notice.text}</p>
+        {isTerminalError ? (
+          <>
+            <p className="text-sm font-semibold text-foreground">Chat history unavailable</p>
+            <p className={noticeTextClass('mt-0.5')}>
+              The saved conversation could not be loaded. Reload the workspace to try again.
+            </p>
+            <details className="mt-2 text-xs text-muted-foreground">
+              <summary className="cursor-pointer select-none">Error details</summary>
+              <p className="mt-1 break-words">{notice.text}</p>
+            </details>
+          </>
+        ) : (
+          <p className={noticeTextClass()}>{notice.text}</p>
+        )}
       </div>
       {hostAction ?? null}
-      {actionLabel && onAction ? (
+      {isTerminalError ? (
+        <Button type="button" variant="outline" size="sm" onClick={() => window.location.reload()}>
+          Reload workspace
+        </Button>
+      ) : null}
+      {!isTerminalError && actionLabel && onAction ? (
         <Button type="button" variant="ghost" size="sm" onClick={() => onAction(notice.id)}>
           {actionLabel}
         </Button>

--- a/packages/agent/src/front/chat/components/__tests__/PiConversationSurface.test.tsx
+++ b/packages/agent/src/front/chat/components/__tests__/PiConversationSurface.test.tsx
@@ -206,4 +206,75 @@ describe('PiConversationSurface', () => {
     rerender(renderSurface(textMessages(100), 'session-b'))
     expect(screen.getAllByTestId('timeline-message')).toHaveLength(60)
   })
+
+  test('a terminal chat error replaces the loading skeleton instead of stacking with it', () => {
+    render(
+      <PiConversationSurface
+        chrome
+        emptyHero={false}
+        messages={[]}
+        emptyStateHydrating
+        suggestions={[]}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+        runtimeNotices={[{ id: 'session-navigation-error', level: 'error', text: 'Could not load session list.' }]}
+        onDismissNotice={() => {}}
+        onScrollToBottomReady={() => {}}
+        onSuggestionSubmit={async () => undefined}
+        onRestoreDraft={() => {}}
+      />,
+    )
+
+    expect(screen.queryByLabelText('Loading chat history')).toBeNull()
+    expect(screen.getByText('Chat history unavailable')).toBeTruthy()
+  })
+
+  test('a terminal chat error replaces the empty-chat hero instead of contradicting it', () => {
+    render(
+      <PiConversationSurface
+        chrome
+        emptyHero={false}
+        messages={[]}
+        emptyStateHydrating={false}
+        emptyState={{ title: 'What should we work on?' }}
+        suggestions={[]}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+        runtimeNotices={[{ id: 'chat-error', level: 'error', text: 'stream closed unexpectedly' }]}
+        onDismissNotice={() => {}}
+        onScrollToBottomReady={() => {}}
+        onSuggestionSubmit={async () => undefined}
+        onRestoreDraft={() => {}}
+      />,
+    )
+
+    expect(screen.queryByText('What should we work on?')).toBeNull()
+    expect(screen.getByText('Chat history unavailable')).toBeTruthy()
+  })
+
+  test('with no terminal error, empty/loading states render as before', () => {
+    render(
+      <PiConversationSurface
+        chrome
+        emptyHero={false}
+        messages={[]}
+        emptyStateHydrating={false}
+        emptyState={{ title: 'What should we work on?' }}
+        suggestions={[]}
+        isStreaming={false}
+        showThoughts={false}
+        toolRenderers={{}}
+        runtimeNotices={[]}
+        onDismissNotice={() => {}}
+        onScrollToBottomReady={() => {}}
+        onSuggestionSubmit={async () => undefined}
+        onRestoreDraft={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('What should we work on?')).toBeTruthy()
+    expect(screen.queryByText('Chat history unavailable')).toBeNull()
+  })
 })

--- a/packages/agent/src/front/chat/components/__tests__/RuntimeNotices.test.tsx
+++ b/packages/agent/src/front/chat/components/__tests__/RuntimeNotices.test.tsx
@@ -48,4 +48,37 @@ describe('RuntimeNotices', () => {
     fireEvent.click(within(protocol).getByRole('button', { name: 'Dismiss notice' }))
     expect(onDismiss).toHaveBeenCalledWith('protocol-error')
   })
+
+  test.each(['chat-error', 'protocol-error', 'session-navigation-error'])(
+    'gives terminal chat error %s plain-language framing, collapsible details, and a reload action',
+    (id) => {
+      const reload = vi.fn()
+      vi.stubGlobal('location', { ...window.location, reload })
+
+      render(<RuntimeNotices notices={[{ id, level: 'error', text: 'ECONNRESET: socket hang up at fetchSession (remotePiSession.ts:42)' }]} />)
+
+      const row = screen.getByText('Chat history unavailable').closest('[data-boring-agent-part="runtime-notice"]') as HTMLElement
+      expect(row).toBeTruthy()
+      expect(within(row).getByText(/saved conversation could not be loaded/i)).toBeTruthy()
+
+      // The raw error is demoted to a collapsed technical-details disclosure,
+      // not shown as the headline message.
+      const details = within(row).getByText('Error details').closest('details') as HTMLDetailsElement
+      expect(details).toBeTruthy()
+      expect(details.open).toBe(false)
+      expect(within(row).getByText(/ECONNRESET/)).toBeTruthy()
+
+      fireEvent.click(within(row).getByRole('button', { name: 'Reload workspace' }))
+      expect(reload).toHaveBeenCalledTimes(1)
+
+      vi.unstubAllGlobals()
+    },
+  )
+
+  test('non-terminal notices keep the raw text as the headline with no reload action', () => {
+    render(<RuntimeNotices notices={[{ id: 'connection-reconnecting', level: 'warning', text: 'Reconnecting to the agent session…' }]} />)
+    expect(screen.queryByText('Chat history unavailable')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Reload workspace' })).toBeNull()
+    expect(screen.getByText('Reconnecting to the agent session…')).toBeTruthy()
+  })
 })

--- a/packages/agent/src/front/chat/components/__tests__/RuntimeNotices.test.tsx
+++ b/packages/agent/src/front/chat/components/__tests__/RuntimeNotices.test.tsx
@@ -49,13 +49,18 @@ describe('RuntimeNotices', () => {
     expect(onDismiss).toHaveBeenCalledWith('protocol-error')
   })
 
-  test.each(['chat-error', 'protocol-error', 'session-navigation-error'])(
-    'gives terminal chat error %s plain-language framing, collapsible details, and a reload action',
+  test.each(['chat-error', 'session-navigation-error'])(
+    'gives terminal chat error %s plain-language framing, collapsible details, and a reload action when history is empty',
     (id) => {
       const reload = vi.fn()
       vi.stubGlobal('location', { ...window.location, reload })
 
-      render(<RuntimeNotices notices={[{ id, level: 'error', text: 'ECONNRESET: socket hang up at fetchSession (remotePiSession.ts:42)' }]} />)
+      render(
+        <RuntimeNotices
+          notices={[{ id, level: 'error', text: 'ECONNRESET: socket hang up at fetchSession (remotePiSession.ts:42)' }]}
+          historyEmpty
+        />,
+      )
 
       const row = screen.getByText('Chat history unavailable').closest('[data-boring-agent-part="runtime-notice"]') as HTMLElement
       expect(row).toBeTruthy()
@@ -75,10 +80,55 @@ describe('RuntimeNotices', () => {
     },
   )
 
+  test('protocol-error never gets terminal treatment: it self-clears on reconnect and is routine noise', () => {
+    render(<RuntimeNotices notices={[{ id: 'protocol-error', level: 'error', text: 'Unsupported protocol version', dismissible: true }]} historyEmpty />)
+    expect(screen.queryByText('Chat history unavailable')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Reload workspace' })).toBeNull()
+    expect(screen.getByText('Unsupported protocol version')).toBeTruthy()
+  })
+
+  test.each(['chat-error', 'session-navigation-error'])(
+    '%s keeps its raw headline (no terminal framing) when the transcript already has messages',
+    (id) => {
+      render(<RuntimeNotices notices={[{ id, level: 'error', text: 'model overloaded, please retry' }]} historyEmpty={false} />)
+      expect(screen.queryByText('Chat history unavailable')).toBeNull()
+      expect(screen.queryByRole('button', { name: 'Reload workspace' })).toBeNull()
+      expect(screen.getByText('model overloaded, please retry')).toBeTruthy()
+    },
+  )
+
   test('non-terminal notices keep the raw text as the headline with no reload action', () => {
-    render(<RuntimeNotices notices={[{ id: 'connection-reconnecting', level: 'warning', text: 'Reconnecting to the agent session…' }]} />)
+    render(<RuntimeNotices notices={[{ id: 'connection-reconnecting', level: 'warning', text: 'Reconnecting to the agent session…' }]} historyEmpty />)
     expect(screen.queryByText('Chat history unavailable')).toBeNull()
     expect(screen.queryByRole('button', { name: 'Reload workspace' })).toBeNull()
     expect(screen.getByText('Reconnecting to the agent session…')).toBeTruthy()
+  })
+
+  test('preserves an existing actionLabel/onAction instead of double-rendering a reload button', () => {
+    const onAction = vi.fn()
+    render(
+      <RuntimeNotices
+        notices={[{ id: 'chat-error', level: 'error', text: 'boom', actionLabel: 'Try again', dismissible: true }]}
+        onAction={onAction}
+        historyEmpty
+      />,
+    )
+    const row = screen.getByText('Chat history unavailable').closest('[data-boring-agent-part="runtime-notice"]') as HTMLElement
+    expect(within(row).queryByRole('button', { name: 'Reload workspace' })).toBeNull()
+    fireEvent.click(within(row).getByRole('button', { name: 'Try again' }))
+    expect(onAction).toHaveBeenCalledWith('chat-error')
+  })
+
+  test('preserves a host renderAction instead of double-rendering a reload button', () => {
+    render(
+      <RuntimeNotices
+        notices={[{ id: 'session-navigation-error', level: 'error', text: 'boom' }]}
+        renderAction={() => <button type="button">Host action</button>}
+        historyEmpty
+      />,
+    )
+    const row = screen.getByText('Chat history unavailable').closest('[data-boring-agent-part="runtime-notice"]') as HTMLElement
+    expect(within(row).queryByRole('button', { name: 'Reload workspace' })).toBeNull()
+    expect(within(row).getByRole('button', { name: 'Host action' })).toBeTruthy()
   })
 })

--- a/packages/agent/src/front/chat/components/__tests__/terminalChatErrors.test.ts
+++ b/packages/agent/src/front/chat/components/__tests__/terminalChatErrors.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'vitest'
+import { hasTerminalChatError, isTerminalChatErrorId } from '../terminalChatErrors'
+
+describe('terminalChatErrors', () => {
+  test.each(['chat-error', 'protocol-error', 'session-navigation-error'])('treats %s as a terminal chat error id', (id) => {
+    expect(isTerminalChatErrorId(id)).toBe(true)
+  })
+
+  test.each(['connection-reconnecting', 'auto-retry', 'large-state-warning', 'command:foo'])(
+    'does not treat %s as a terminal chat error id',
+    (id) => {
+      expect(isTerminalChatErrorId(id)).toBe(false)
+    },
+  )
+
+  test('hasTerminalChatError finds a terminal id anywhere in the list', () => {
+    expect(hasTerminalChatError([{ id: 'connection-reconnecting' }, { id: 'chat-error' }])).toBe(true)
+    expect(hasTerminalChatError([{ id: 'connection-reconnecting' }, { id: 'auto-retry' }])).toBe(false)
+    expect(hasTerminalChatError([])).toBe(false)
+  })
+})

--- a/packages/agent/src/front/chat/components/__tests__/terminalChatErrors.test.ts
+++ b/packages/agent/src/front/chat/components/__tests__/terminalChatErrors.test.ts
@@ -1,21 +1,70 @@
 import { describe, expect, test } from 'vitest'
-import { hasTerminalChatError, isTerminalChatErrorId } from '../terminalChatErrors'
+import {
+  filterCompetingNoiseNotices,
+  hasTerminalChatError,
+  isTerminalChatErrorId,
+  isTerminalChatErrorNotice,
+} from '../terminalChatErrors'
 
 describe('terminalChatErrors', () => {
-  test.each(['chat-error', 'protocol-error', 'session-navigation-error'])('treats %s as a terminal chat error id', (id) => {
+  test.each(['chat-error', 'session-navigation-error'])('treats %s as a terminal chat error id', (id) => {
     expect(isTerminalChatErrorId(id)).toBe(true)
   })
 
-  test.each(['connection-reconnecting', 'auto-retry', 'large-state-warning', 'command:foo'])(
-    'does not treat %s as a terminal chat error id',
+  test.each(['protocol-error', 'connection-reconnecting', 'auto-retry', 'large-state-warning', 'command:foo'])(
+    'does not treat %s as a terminal chat error id (protocol-error self-clears on reconnect)',
     (id) => {
       expect(isTerminalChatErrorId(id)).toBe(false)
     },
   )
 
-  test('hasTerminalChatError finds a terminal id anywhere in the list', () => {
-    expect(hasTerminalChatError([{ id: 'connection-reconnecting' }, { id: 'chat-error' }])).toBe(true)
-    expect(hasTerminalChatError([{ id: 'connection-reconnecting' }, { id: 'auto-retry' }])).toBe(false)
-    expect(hasTerminalChatError([])).toBe(false)
+  test('isTerminalChatErrorNotice requires both a terminal id and an empty transcript', () => {
+    expect(isTerminalChatErrorNotice('chat-error', true)).toBe(true)
+    expect(isTerminalChatErrorNotice('chat-error', false)).toBe(false)
+    expect(isTerminalChatErrorNotice('connection-reconnecting', true)).toBe(false)
+  })
+
+  test('hasTerminalChatError finds a terminal id anywhere in the list, only when history is empty', () => {
+    expect(hasTerminalChatError([{ id: 'connection-reconnecting' }, { id: 'chat-error' }], true)).toBe(true)
+    expect(hasTerminalChatError([{ id: 'connection-reconnecting' }, { id: 'chat-error' }], false)).toBe(false)
+    expect(hasTerminalChatError([{ id: 'connection-reconnecting' }, { id: 'auto-retry' }], true)).toBe(false)
+    expect(hasTerminalChatError([], true)).toBe(false)
+  })
+
+  describe('filterCompetingNoiseNotices', () => {
+    test('drops connection-reconnecting and auto-retry once a terminal notice is present and history is empty', () => {
+      const notices = [
+        { id: 'connection-reconnecting' },
+        { id: 'auto-retry' },
+        { id: 'chat-error' },
+      ]
+      expect(filterCompetingNoiseNotices(notices, true)).toEqual([{ id: 'chat-error' }])
+    })
+
+    test('keeps auto-retry-failed even alongside a terminal notice: it reports a real terminal retry failure', () => {
+      const notices = [
+        { id: 'connection-reconnecting' },
+        { id: 'auto-retry-failed' },
+        { id: 'session-navigation-error' },
+      ]
+      expect(filterCompetingNoiseNotices(notices, true)).toEqual([
+        { id: 'auto-retry-failed' },
+        { id: 'session-navigation-error' },
+      ])
+    })
+
+    test('renders reconnect/retry noise unchanged when no terminal notice is present', () => {
+      const notices = [{ id: 'connection-reconnecting' }, { id: 'auto-retry' }]
+      expect(filterCompetingNoiseNotices(notices, true)).toEqual(notices)
+    })
+
+    test('renders reconnect/retry noise unchanged when history is not empty, even with a chat-error notice', () => {
+      const notices = [
+        { id: 'connection-reconnecting' },
+        { id: 'auto-retry' },
+        { id: 'chat-error' },
+      ]
+      expect(filterCompetingNoiseNotices(notices, false)).toEqual(notices)
+    })
   })
 })

--- a/packages/agent/src/front/chat/components/terminalChatErrors.ts
+++ b/packages/agent/src/front/chat/components/terminalChatErrors.ts
@@ -1,18 +1,49 @@
 /**
- * Notice ids that represent a "terminal" chat error: the transcript itself
- * failed to load (session lookup, history hydrate, protocol desync), as
- * opposed to transient noise (reconnect attempts, warmup, retries) that
- * resolves on its own. These get plain-language presentation with
- * collapsible technical details and an explicit recovery action, and they
- * suppress competing reconnect/warmup notices so the two don't contradict
- * each other in the timeline.
+ * Notice ids that CAN represent a terminal chat error: the transcript failed
+ * to load. `protocol-error` is deliberately excluded — it always pairs with
+ * `connection.state = 'reconnecting'` and self-clears on the next
+ * heartbeat/connect (see `clearProtocolError` in piChatReducer.ts), so it is
+ * routine websocket noise recovering on its own, not a terminal failure.
+ *
+ * An id in this set is only genuinely terminal when the transcript is empty
+ * (`historyEmpty`). The same 'chat-error' id can also carry a turn/send
+ * failure (e.g. "model overloaded") that survives into `state.error` across a
+ * later snapshot resync (piChatReducer.ts hydrateFromSnapshot copies
+ * `snapshot.error` verbatim) even though real message history is present —
+ * that's a normal mid-conversation error, not "history unavailable", so it
+ * keeps its own raw headline instead of the terminal presentation.
  */
-export const TERMINAL_CHAT_ERROR_IDS = new Set(['chat-error', 'protocol-error', 'session-navigation-error'])
+export const TERMINAL_CHAT_ERROR_IDS = new Set(['chat-error', 'session-navigation-error'])
 
 export function isTerminalChatErrorId(id: string): boolean {
   return TERMINAL_CHAT_ERROR_IDS.has(id)
 }
 
-export function hasTerminalChatError(notices: ReadonlyArray<{ id: string }>): boolean {
-  return notices.some((notice) => isTerminalChatErrorId(notice.id))
+/** True only when `id` is a terminal-error id AND the transcript is empty. */
+export function isTerminalChatErrorNotice(id: string, historyEmpty: boolean): boolean {
+  return historyEmpty && isTerminalChatErrorId(id)
+}
+
+export function hasTerminalChatError(notices: ReadonlyArray<{ id: string }>, historyEmpty: boolean): boolean {
+  return historyEmpty && notices.some((notice) => isTerminalChatErrorId(notice.id))
+}
+
+/**
+ * Notice ids that are pure connectivity/retry noise: accurate on their own,
+ * but redundant once a terminal chat error notice already explains why
+ * nothing is happening. Kept as an explicit set (not a substring match) and
+ * deliberately excludes 'auto-retry-failed', which reports a real terminal
+ * retry failure and should keep showing alongside a terminal chat error.
+ */
+const COMPETING_NOISE_NOTICE_IDS = new Set(['connection-reconnecting', 'auto-retry'])
+
+/**
+ * Drops competing reconnect/retry noise once a terminal chat error is
+ * present and the transcript is empty. No-op otherwise (including whenever
+ * `historyEmpty` is false, e.g. a mid-conversation turn error resurfaced via
+ * `chat-error` — see the module doc above).
+ */
+export function filterCompetingNoiseNotices<T extends { id: string }>(notices: T[], historyEmpty: boolean): T[] {
+  if (!hasTerminalChatError(notices, historyEmpty)) return notices
+  return notices.filter((notice) => !COMPETING_NOISE_NOTICE_IDS.has(notice.id))
 }

--- a/packages/agent/src/front/chat/components/terminalChatErrors.ts
+++ b/packages/agent/src/front/chat/components/terminalChatErrors.ts
@@ -1,0 +1,18 @@
+/**
+ * Notice ids that represent a "terminal" chat error: the transcript itself
+ * failed to load (session lookup, history hydrate, protocol desync), as
+ * opposed to transient noise (reconnect attempts, warmup, retries) that
+ * resolves on its own. These get plain-language presentation with
+ * collapsible technical details and an explicit recovery action, and they
+ * suppress competing reconnect/warmup notices so the two don't contradict
+ * each other in the timeline.
+ */
+export const TERMINAL_CHAT_ERROR_IDS = new Set(['chat-error', 'protocol-error', 'session-navigation-error'])
+
+export function isTerminalChatErrorId(id: string): boolean {
+  return TERMINAL_CHAT_ERROR_IDS.has(id)
+}
+
+export function hasTerminalChatError(notices: ReadonlyArray<{ id: string }>): boolean {
+  return notices.some((notice) => isTerminalChatErrorId(notice.id))
+}


### PR DESCRIPTION
## Summary
- New `terminalChatErrors` helper identifies known terminal chat error ids (`chat-error`, `protocol-error`, `session-navigation-error`).
- `RuntimeNotices` gives those ids plain-language "Chat history unavailable" framing, a collapsible `<details>` for the raw technical text, and an explicit "Reload workspace" recovery button — ported from the `ui/aaa-polish` prototype referenced by #1030/#1031.
- `PiConversationSurface` now skips the loading skeleton and the empty-chat hero whenever a terminal error is present, instead of stacking a contradictory "What should we work on?" / loading state next to the error.
- `PiChatPanel`'s combined runtime-notices memo suppresses competing `connection-reconnecting` / `auto-retry` / warmup notices once a terminal error notice is showing, so the timeline doesn't say "reconnecting…" beside "history unavailable".
- Excludes app-wide palette/foundation, composer, top bar, tool-row styling, and workspace-wide loading redesign, per issue scope.

## Proof
- `pnpm vitest run src/front/chat` in `packages/agent`: 265 passed, 0 failed (includes new/updated tests in `RuntimeNotices.test.tsx`, `PiConversationSurface.test.tsx`, new `terminalChatErrors.test.ts`).
- `pnpm typecheck` in `packages/agent`: clean.
- `tools/ui-review/src/registry.ts` has no spec covering this chat pane surface today — registering one is recommended as follow-up, not built in this session.

## Manual verification (no screenshot tooling run this session)
1. Run the workspace app, open a chat pane with `sessionsError` set (e.g. break the sessions fetch) — should see "Chat history unavailable" with a collapsed "Error details" disclosure and a "Reload workspace" button, with no competing empty-state hero or reconnect banner.
2. Confirm normal empty/loading states are unchanged when there is no terminal error.
3. Check both desktop and mobile widths — the notice card uses existing responsive notice-surface styling shared with other runtime notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1HtxZAQUmLXhaZmL3sEH4