### PR TITLE
[gh-781/gh-778] session list: live status sync (UI loop, epic #1110)

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -903,18 +903,41 @@ export function WorkspaceAgentFront<
     && !remoteSessionApi.error
     && !remoteSessionsArePreviousWorkspace
   const remoteSessionsPending = remoteSessionHookEnabled && !remoteSessionsAvailable
+  // Latest sessions/refresh read inside the activity stream's onActivity
+  // closure without resubscribing the SSE connection on every list change.
+  const remoteSessionsActivityRef = useRef({
+    sessions: remoteSessionApi.sessions,
+    refresh: remoteSessionApi.refresh,
+    selectedAgentTypeId,
+  })
+  remoteSessionsActivityRef.current = {
+    sessions: remoteSessionApi.sessions,
+    refresh: remoteSessionApi.refresh,
+    selectedAgentTypeId,
+  }
   useEffect(() => {
     if (!remoteSessionsAvailable) return
     return startSessionActivityStream({
       endpoint: apiBaseUrl,
       workspaceId,
-      onActivity: ({ ref, status }) => window.dispatchEvent(new CustomEvent("boring:chat-session-status", {
-        detail: {
-          sessionId: ref.sessionId,
-          agentTypeId: ref.agentTypeId,
-          working: status === "running" || status === "aborting",
-        },
-      })),
+      onActivity: ({ ref, status }) => {
+        window.dispatchEvent(new CustomEvent("boring:chat-session-status", {
+          detail: {
+            sessionId: ref.sessionId,
+            agentTypeId: ref.agentTypeId,
+            working: status === "running" || status === "aborting",
+          },
+        }))
+        // A session created out-of-band (e.g. an external chat entrypoint)
+        // surfaces here as activity before this hook's own list has ever
+        // fetched it. Reconcile the list immediately instead of waiting on
+        // a manual refresh or remount (gh-778).
+        if (status !== "running" && status !== "aborting") return
+        const current = remoteSessionsActivityRef.current
+        if (ref.agentTypeId !== current.selectedAgentTypeId) return
+        const known = current.sessions.some((session) => session.id === ref.sessionId)
+        if (!known) void current.refresh?.({ background: true })
+      },
     })
   }, [apiBaseUrl, remoteSessionsAvailable, sessionSourceIdentity, workspaceId])
   useEffect(() => {

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -291,6 +291,54 @@ describe("WorkspaceAgentFront", () => {
     window.removeEventListener("boring:chat-session-status", onStatus)
   })
 
+  it("reconciles the session list when activity reports a session created out-of-band (gh-778)", () => {
+    MockEventSource.instances = []
+    vi.stubGlobal("EventSource", MockEventSource)
+    const refresh = vi.fn()
+
+    render(
+      <WorkspaceAgentFront
+        workspaceId="external-session-stream"
+        chatPanel={SessionIdChatPanel}
+        useSessions={() => ({
+          sessions: [{ id: "session-1", title: "Session one", status: "idle" }],
+          activeSession: { id: "session-1", title: "Session one", status: "idle" },
+          activeSessionId: "session-1",
+          loading: false,
+          error: undefined,
+          create: vi.fn(),
+          switch: vi.fn(),
+          delete: vi.fn(),
+          refresh,
+        })}
+      />,
+    )
+    const stream = MockEventSource.instances.find((instance) => instance.url.includes("/api/v1/agents/session-activity/events"))
+
+    // Activity for a session already known to the list must not trigger an
+    // extra refresh.
+    act(() => {
+      stream?.emit("activity", { ref: { agentTypeId: "default", sessionId: "session-1" }, status: "running" })
+    })
+    expect(refresh).not.toHaveBeenCalled()
+
+    // Activity for a session the list has never fetched (created via an
+    // external entrypoint) must trigger a background refresh so it appears
+    // without a manual refresh or remount.
+    act(() => {
+      stream?.emit("activity", { ref: { agentTypeId: "default", sessionId: "external-session" }, status: "running" })
+    })
+    expect(refresh).toHaveBeenCalledWith({ background: true })
+
+    refresh.mockClear()
+    // Activity for a different agent type's session must not leak into this
+    // agent-scoped session list's refresh.
+    act(() => {
+      stream?.emit("activity", { ref: { agentTypeId: "other-agent", sessionId: "other-agent-session" }, status: "running" })
+    })
+    expect(refresh).not.toHaveBeenCalled()
+  })
+
   it("renders a known active session while remote sessions are still loading", () => {
     const PendingChatPanel = (props: WorkspaceChatPanelProps) => (
       <div data-testid="chat-panel">Chat {props.sessionId} hydrate={String(props.hydrateMessages)}</div>


### PR DESCRIPTION
## Summary

- **gh-781** (session status stays stale until manual refresh): already largely fixed on `main` via the existing per-workspace `session-activity` SSE stream (`packages/workspace/src/front/sessionActivity.ts`, `startSessionActivityStream`/`useWorkingSessionIds`) added in prior commits (`700e2cb99`, `e4469fdb6`). No further change needed for the working badge.
- **gh-778** (session created via an external entrypoint doesn't appear in the list until manual refresh): root cause was that `WorkspaceAgentFront`'s activity-stream `onActivity` handler only dispatched a `boring:chat-session-status` CustomEvent for badge state — it never checked whether the referenced session id was already known to the workspace's session list. A session created out-of-band therefore stayed invisible until a manual refresh or remount.

## Fix

`packages/workspace/src/app/front/WorkspaceAgentFront.tsx`: when the activity stream reports `running`/`aborting` status for a session id not present in the current agent-scoped session list, trigger a background `refresh()` of that list. This reuses the existing SSE infrastructure — no new backend endpoint, no session-model change — and keeps `#1102`'s pending rebase cheap since the session-source architecture is untouched.

`AppLeftPane` and `SessionBrowser` both render from this single `sessions` source (passed down from `WorkspaceAgentFront`), so one fix covers both list surfaces.

## Proof

- New regression test in `packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx`: `reconciles the session list when activity reports a session created out-of-band (gh-778)` — asserts no extra refresh for an already-known session, a background refresh for an unknown session id, and no cross-agent-type leakage.
- `pnpm --filter @hachej/boring-workspace exec vitest run src/app/front/__tests__/WorkspaceAgentFront.test.tsx` → 80/80 passed.
- `pnpm --filter @hachej/boring-workspace exec vitest run src/front/chrome/session-list/__tests__/SessionBrowser.test.tsx src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx` → 37/37 passed.
- `pnpm --filter @hachej/boring-workspace typecheck` → clean.

## Manual verification steps

1. Open the workspace app with the session list visible.
2. Trigger a chat run from an entrypoint that creates a session out-of-band (not via the sidebar "New chat" button).
3. Observe the new session appear in the sidebar/left-pane list within the activity-stream's push interval, without a manual refresh or remount.
4. Start a run on an existing session, switch away, and confirm the working badge clears when the run completes without revisiting that pane (gh-781, pre-existing behavior — verifies no regression).

## Friction

- Issue #781's writeup described a large backend "activity read model" slice (new endpoint, DTO, etc.) that already exists on `main` from unrelated prior commits — the issue body was stale relative to `main`. Confirmed via code inspection and the existing `useWorkingSessionIds`/SSE test coverage rather than reimplementing it.
- `pnpm --filter @hachej/boring-agent build`'s CSS asset step (`build-front-css.mjs` / tailwindcss) failed in this environment, unrelated to this change — the JS/DTS build completed fine and was sufficient for tests/typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1HtxZAQUmLXhaZmL3sEH4