### PR TITLE
[epic #1110] Skills page polish (UI loop)

### DIFF
--- a/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
+++ b/packages/workspace/src/front/chrome/skills/SkillsPage.tsx
@@ -74,11 +74,17 @@ export function SkillsPage({ onClose, headerInsetStart = false, headerInsetEnd =
     [state.skills],
   )
 
+  // Header subtitle doubles as the count readout so the list size is legible
+  // without scrolling the pane.
+  const skillsDescription = sortedSkills.length > 0
+    ? `${sortedSkills.length} skill${sortedSkills.length === 1 ? "" : "s"} available to slash commands`
+    : "Workspace skills available to slash commands"
+
   return (
     <ManagementOverlaySurface
       part="skills-page"
       title="Skills"
-      description="Workspace skills available to slash commands"
+      description={skillsDescription}
       headerInsetStart={headerInsetStart}
       headerInsetEnd={headerInsetEnd}
       icon={(
@@ -114,49 +120,92 @@ export function SkillsPage({ onClose, headerInsetStart = false, headerInsetEnd =
         ) : null}
       </>)}
     >
-      <div className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto p-4" aria-live="polite">
+      <div
+        className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto p-4"
+        aria-busy={state.status === "loading"}
+      >
         {state.status === "error" ? (
-          <div className="mb-4 rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-sm text-destructive">
-            {state.error}
+          <div
+            role="alert"
+            className="mb-4 flex items-start justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/8 px-3 py-2 text-sm text-destructive"
+          >
+            <span className="min-w-0">{state.error}</span>
+            <button
+              type="button"
+              onClick={() => void loadSkills(true)}
+              className="shrink-0 rounded-md border border-destructive/40 px-2 py-0.5 text-xs font-medium transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+            >
+              Retry
+            </button>
           </div>
         ) : null}
 
         {state.status === "loading" && sortedSkills.length === 0 ? (
-          <div className="flex h-full min-h-[180px] items-center justify-center text-sm text-muted-foreground">
-            Loading skills…
-          </div>
+          <ul role="list" aria-label="Loading skills" className="grid gap-2">
+            {[0, 1, 2, 3].map((row) => (
+              <li
+                key={row}
+                aria-hidden="true"
+                className="animate-pulse rounded-xl border border-border/60 bg-card/70 px-3 py-2.5"
+              >
+                <div className="h-3.5 w-1/3 rounded bg-foreground/[0.08]" />
+                <div className="mt-2 h-3 w-4/5 rounded bg-foreground/[0.06]" />
+              </li>
+            ))}
+            <li className="sr-only">Loading skills…</li>
+          </ul>
         ) : sortedSkills.length === 0 ? (
-          <div className="flex h-full min-h-[180px] items-center justify-center text-center text-sm text-muted-foreground">
-            <div>
-              <div className="font-medium text-foreground/80">No skills found</div>
-              <p className="mt-1 max-w-xs">Reload plugins or add workspace skills to make them available in chat.</p>
+          state.status === "error" ? null : (
+            <div className="flex h-full min-h-[180px] items-center justify-center text-center text-sm text-muted-foreground">
+              <div>
+                <div className="font-medium text-foreground/80">No skills found</div>
+                <p className="mt-1 max-w-xs">Reload plugins or add workspace skills to make them available in chat.</p>
+              </div>
             </div>
-          </div>
+          )
         ) : (
           <ul role="list" className="grid gap-2">
             {sortedSkills.map((skill) => {
-              return (
-                <li
-                  key={skill.name}
-                  className="rounded-xl border border-border/60 bg-card/70 px-3 py-2.5 cursor-pointer transition-colors hover:border-border hover:bg-muted/60"
-                >
-                  <button
-                    type="button"
-                    onClick={() => openSkillInWorkspace(skill)}
-                    title="Open skill"
-                    aria-label={`Open skill ${skill.name} in workspace`}
-                    className="block w-full text-left"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="truncate text-sm font-medium text-foreground">/{skill.name}</div>
-                        {skill.description ? (
-                          <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">{skill.description}</p>
-                        ) : null}
-                      </div>
-                      <FileText className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" strokeWidth={1.75} aria-hidden="true" />
+              const openable = Boolean(skill.filePath)
+              const body = (
+                <div className="flex min-h-11 w-full items-center justify-between gap-3 px-3 py-2.5">
+                  <div className="min-w-0">
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="truncate text-sm font-medium leading-5 text-foreground">/{skill.name}</span>
+                      {skill.source ? (
+                        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+                          {skill.source}
+                        </span>
+                      ) : null}
                     </div>
-                  </button>
+                    {skill.description ? (
+                      <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">{skill.description}</p>
+                    ) : null}
+                  </div>
+                  {openable ? (
+                    <FileText
+                      className="h-4 w-4 shrink-0 text-muted-foreground/70 transition-colors group-hover:text-foreground"
+                      strokeWidth={1.75}
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                </div>
+              )
+              return (
+                <li key={skill.name} className="min-w-0">
+                  {openable ? (
+                    <button
+                      type="button"
+                      onClick={() => openSkillInWorkspace(skill)}
+                      title="Open skill"
+                      aria-label={`Open skill ${skill.name} in workspace`}
+                      className="group block w-full rounded-xl border border-border/60 bg-card/70 text-left transition-colors hover:border-border hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                    >
+                      {body}
+                    </button>
+                  ) : (
+                    <div className="rounded-xl border border-border/60 bg-card/70">{body}</div>
+                  )}
                 </li>
               )
             })}

--- a/packages/workspace/src/front/chrome/skills/__tests__/SkillsPage.test.tsx
+++ b/packages/workspace/src/front/chrome/skills/__tests__/SkillsPage.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { SkillsPage } from "../SkillsPage"
+
+const getJson = vi.fn()
+
+// Stable identity: SkillsPage keys its load effect off the client object, and
+// the real provider memoises it.
+const client = { agentTypeId: "agent", getJson }
+
+vi.mock("../../../plugin/useWorkspacePluginClient", () => ({
+  useWorkspacePluginClient: () => client,
+}))
+
+vi.mock("../../../bridge", () => ({ postUiCommand: vi.fn() }))
+
+describe("SkillsPage", () => {
+  beforeEach(() => {
+    getJson.mockReset()
+  })
+
+  it("renders openable skills as buttons and non-openable skills as static rows", async () => {
+    getJson.mockResolvedValue({
+      skills: [
+        { name: "alpha", description: "Alpha skill", source: "workspace", filePath: "/skills/alpha/SKILL.md" },
+        { name: "beta", description: "Beta skill" },
+      ],
+    })
+
+    render(<SkillsPage />)
+
+    await screen.findByRole("button", { name: "Open skill alpha in workspace" })
+    expect(screen.queryByRole("button", { name: /beta/ })).toBeNull()
+    expect(screen.getByText("/beta")).toBeTruthy()
+    expect(screen.getByText("workspace")).toBeTruthy()
+  })
+
+  it("summarises the skill count in the header description", async () => {
+    getJson.mockResolvedValue({ skills: [{ name: "alpha" }] })
+    render(<SkillsPage />)
+    await screen.findByText("1 skill available to slash commands")
+  })
+
+  it("shows an alert with a retry action and no empty state when loading fails", async () => {
+    getJson.mockRejectedValue(new Error("boom"))
+    render(<SkillsPage />)
+
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toContain("boom")
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy()
+    expect(screen.queryByText("No skills found")).toBeNull()
+
+    getJson.mockResolvedValue({ skills: [{ name: "alpha", filePath: "/a/SKILL.md" }] })
+    screen.getByRole("button", { name: "Retry" }).click()
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull())
+  })
+
+  it("shows the empty state when there are no skills", async () => {
+    getJson.mockResolvedValue({ skills: [] })
+    render(<SkillsPage />)
+    await screen.findByText("No skills found")
+  })
+})


### PR DESCRIPTION
Bead: `wt-391-forward-ui-skills-page-ki7` (epic #1110, UI loop). Bounded, **presentation-only** polish of `SkillsPage.tsx`. No new features, no data-model or API changes — deliberately kept away from the skill projection shape so #970 (package-resource projections) stays cheap to merge.

## Inventory (one bullet per visual change)

- **Row hit area = row.** Padding moved from the `<li>` onto the button, so the outer ~10px/12px gutter of every card is now actually clickable. Measured: interactive element went from 20–64px tall (inset inside a 46–86px card) to 46–86px, matching the card exactly. The shortest hit target was 20px; it is now 46px, clearing the 44px gate.
- **Focus-visible ring on rows** (`focus-visible:ring-2 ring-ring/40`), reusing the `WorkbenchLeftPane`/`WorkbenchHeaderActions` idiom. Keyboard users previously had no visible focus on the list.
- **Non-openable skills are no longer fake buttons.** A skill without a resolvable `filePath` rendered as a button labelled "Open skill … in workspace" whose click was a silent no-op; it now renders as a static row with no `FileText` affordance.
- **Source chip.** `skill.source` was fetched but never rendered; shown as a muted chip using the exact chip idiom from `PluginsOverlay` (`rounded bg-muted px-1.5 py-0.5 text-[10px]`).
- **Loading = skeleton rows.** Replaced the centred "Loading skills…" text with four pulsing skeleton cards at the real row geometry, so the pane doesn't jump on resolve. Screen readers get an `sr-only` "Loading skills…".
- **Error state is actionable.** The error box gains `role="alert"` and an inline **Retry** button; previously the only recovery was the header refresh icon.
- **Error no longer stacks with the empty state.** A failed load with zero skills showed both the error *and* "No skills found"; the empty state is now suppressed while errored.
- **Header subtitle carries the count** — "5 skills available to slash commands" instead of a static string.
- **`aria-live` scoping.** The whole scroll container was `aria-live="polite"`, so every refresh re-announced the entire list; replaced with `aria-busy` on the container plus the scoped alert.
- **Icon alignment.** The trailing `FileText` is vertically centred in the row and dims to `muted-foreground/70`, brightening on row hover.

## Proof

- Before/after Playwright screenshots at 460x760 @2x for **list / loading / empty / error / keyboard-focus**, driven against the real component (workspace `src` via a Vite harness, `getJson` responses stubbed per state).
- Row geometry measured in-browser: interactive-element heights `[20,64,64,44,64]` → `[46,86,86,66,86]`.
- `vitest run src/front/chrome/skills` — **4/4 pass** (new focused tests: openable vs static rows, source chip, count subtitle, error alert + Retry recovery, empty state).
- `tsc --noEmit -p tsconfig.front.source.json` — output identical to the `origin/main` baseline in this worktree (5 pre-existing errors from unbuilt sibling package dists; zero added).

## Friction

The workspace `tsc` and the `WorkspaceAgentFront` suite fail identically on unmodified `origin/main` in a fresh worktree until sibling packages are built — baseline diffed rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1HtxZAQUmLXhaZmL3sEH4