### PR TITLE
feat(transcription): automatically lease Exoscale GPU

### DIFF
--- a/packages/cli/src/server/cli.ts
+++ b/packages/cli/src/server/cli.ts
@@ -459,6 +459,8 @@ async function startFolderMode(opts: {
       diarizerBearerToken: liveTranscriptProvider === "kyutai"
         ? process.env.BORING_LIVE_TRANSCRIPTS_DIARIZER_BEARER_TOKEN
         : undefined,
+      lifecycleUrl: process.env.BORING_LIVE_TRANSCRIPTS_LIFECYCLE_URL,
+      lifecycleBearerToken: process.env.BORING_LIVE_TRANSCRIPTS_LIFECYCLE_BEARER_TOKEN,
     },
   })
 

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -424,6 +424,8 @@ export async function createFolderModeApp(opts: {
     upstreamBearerToken?: string
     diarizerUrl?: string
     diarizerBearerToken?: string
+    lifecycleUrl?: string
+    lifecycleBearerToken?: string
     reviewIntervalMs?: number
   }
 }): Promise<FastifyInstance> {
@@ -464,6 +466,8 @@ export async function createFolderModeApp(opts: {
         upstreamBearerToken: opts.liveTranscripts.upstreamBearerToken,
         diarizerUrl: opts.liveTranscripts.diarizerUrl,
         diarizerBearerToken: opts.liveTranscripts.diarizerBearerToken,
+        lifecycleUrl: opts.liveTranscripts.lifecycleUrl,
+        lifecycleBearerToken: opts.liveTranscripts.lifecycleBearerToken,
         reviewIntervalMs: opts.liveTranscripts.reviewIntervalMs,
       })
     : undefined

--- a/plugins/live-transcription/README.md
+++ b/plugins/live-transcription/README.md
@@ -37,6 +37,9 @@ export BORING_KYUTAI_URL=ws://127.0.0.1:18880/api/asr-streaming
 export BORING_KYUTAI_API_KEY=public_token # omit when the local server needs no key
 # Optional: enrich only /live transcripts with best-effort speaker labels.
 export BORING_LIVE_TRANSCRIPTS_DIARIZER_URL=ws://127.0.0.1:18881/v1/diarize
+# Optional: start/stop on-demand compute through the root-owned lease daemon.
+export BORING_LIVE_TRANSCRIPTS_LIFECYCLE_URL=http://127.0.0.1:18882/v1
+export BORING_LIVE_TRANSCRIPTS_LIFECYCLE_BEARER_TOKEN=<lifecycle token>
 ```
 
 The adapter captures native 24 kHz PCM16 for Kyutai, converts it to float32
@@ -48,7 +51,8 @@ also sends a 16 kHz copy to the raw Streaming Sortformer sidecar and assigns
 Kyutai words by overlap with its anonymous speaker intervals. Kyutai remains the
 text authority; uncovered words render as `Speaker unknown`, and sidecar
 setup/runtime failures do not interrupt capture. See
-`services/sortformer/README.md` for the PoC service contract.
+`services/sortformer/README.md` for the PoC service contract. See
+`services/lifecycle/README.md` for secure on-demand GPU operation.
 With Kyutai selected, the composer microphone streams each `Word` event directly
 into the editable draft without creating a transcript file. `/live start` keeps
 the separate Markdown transcript and agent-review sink.

--- a/plugins/live-transcription/services/lifecycle/.gitignore
+++ b/plugins/live-transcription/services/lifecycle/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/plugins/live-transcription/services/lifecycle/README.md
+++ b/plugins/live-transcription/services/lifecycle/README.md
@@ -1,0 +1,70 @@
+# Transcription compute lifecycle daemon
+
+This root-owned, loopback-only service leases an on-demand GPU to the live-transcription plugin. It is provider-specific at the host boundary; browser and plugin lifecycle code use the provider-neutral lease API.
+
+## Safety model
+
+- Listens only on `127.0.0.1` and requires a bearer token.
+- Rejects requests with a browser `Origin` header.
+- Exoscale credentials remain in root's Exoscale profile; they are never passed to Boring UI.
+- Starts only after `/live start` or composer dictation requests a lease.
+- Requires authenticated WebSocket readiness from **both** Kyutai and Sortformer before granting a lease.
+- Uses 30-second app heartbeats and 90-second lease expiry.
+- Stops after the final lease plus a three-minute idle grace.
+- Reconciles a stranded running instance after daemon/app crashes.
+- Retries stop and verifies provider state is `stopped`.
+- Enforces a hard runtime (default four hours).
+
+## Installation
+
+Install `daemon.py` root-owned (mode `0755`) under `/opt/boring-gpu-lifecycle/`. Put secrets in `/etc/boring-gpu-lifecycle.env` (mode `0600`):
+
+```sh
+BORING_GPU_LIFECYCLE_BEARER_TOKEN=<random 32+ byte token>
+BORING_GPU_READY_WEBSOCKETS=ws://127.0.0.1:18880/api/asr-streaming,ws://127.0.0.1:18881/v1/diarize
+BORING_GPU_READY_BEARER_TOKENS_JSON=["<kyutai token>","<sortformer token>"]
+```
+
+Configure Clinic with the same lifecycle token in its root-owned environment file:
+
+```sh
+BORING_LIVE_TRANSCRIPTS_LIFECYCLE_URL=http://127.0.0.1:18882/v1
+BORING_LIVE_TRANSCRIPTS_LIFECYCLE_BEARER_TOKEN=<same lifecycle token>
+```
+
+Example systemd unit:
+
+```ini
+[Unit]
+Description=Boring transcription GPU lifecycle
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+EnvironmentFile=/etc/boring-gpu-lifecycle.env
+ExecStart=/usr/bin/python3 /opt/boring-gpu-lifecycle/daemon.py \
+  --instance-id 72974288-5e6b-4632-891d-14f60c58e0cb \
+  --zone at-vie-2 \
+  --idle-grace 180 \
+  --max-runtime 15000
+Restart=always
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+
+[Install]
+WantedBy=multi-user.target
+```
+
+`--max-runtime` should be slightly greater than the application's maximum capture duration. Keep the existing manual instance/tunnel controls available as rollback. The SSH tunnel may retry harmlessly while the instance is stopped; the lifecycle service's readiness checks prevent a lease until both forwarded upstreams authenticate successfully.
+
+## Tests
+
+```sh
+python3 -m unittest test_daemon.py
+python3 -m py_compile daemon.py
+```

--- a/plugins/live-transcription/services/lifecycle/README.md
+++ b/plugins/live-transcription/services/lifecycle/README.md
@@ -22,7 +22,7 @@ Install `daemon.py` root-owned (mode `0755`) under `/opt/boring-gpu-lifecycle/`.
 ```sh
 BORING_GPU_LIFECYCLE_BEARER_TOKEN=<random 32+ byte token>
 BORING_GPU_READY_WEBSOCKETS=ws://127.0.0.1:18880/api/asr-streaming,ws://127.0.0.1:18881/v1/diarize
-BORING_GPU_READY_BEARER_TOKENS_JSON=["<kyutai token>","<sortformer token>"]
+BORING_GPU_READY_AUTH_JSON=[{"header":"kyutai-api-key","value":"<kyutai token>"},{"header":"Authorization","value":"Bearer <sortformer token>"}]
 ```
 
 Configure Clinic with the same lifecycle token in its root-owned environment file:

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -36,10 +36,10 @@ class ExoscaleProvider:
         return str(json.loads(result.stdout).get("state", "unknown")).lower()
 
     def start(self) -> None:
-        subprocess.run([self.exo_bin, "compute", "instance", "start", self.instance_id, "--zone", self.zone], check=True, timeout=60)
+        subprocess.run([self.exo_bin, "compute", "instance", "start", self.instance_id, "--zone", self.zone, "--force"], check=True, timeout=60)
 
     def stop(self) -> None:
-        subprocess.run([self.exo_bin, "compute", "instance", "stop", self.instance_id, "--zone", self.zone], check=True, timeout=90)
+        subprocess.run([self.exo_bin, "compute", "instance", "stop", self.instance_id, "--zone", self.zone, "--force"], check=True, timeout=90)
 
 
 class LeaseController:

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Loopback-only renewable lease daemon for on-demand transcription compute."""
+from __future__ import annotations
+
+import argparse
+import hmac
+import json
+import os
+import secrets
+import subprocess
+import threading
+import time
+import urllib.parse
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Callable
+
+
+@dataclass
+class Lease:
+    lease_id: str
+    request_id: str
+    expires_at: float
+    created_at: float
+
+
+class ExoscaleProvider:
+    def __init__(self, exo_bin: str, instance_id: str, zone: str):
+        self.exo_bin, self.instance_id, self.zone = exo_bin, instance_id, zone
+
+    def state(self) -> str:
+        result = subprocess.run(
+            [self.exo_bin, "compute", "instance", "show", self.instance_id, "--zone", self.zone, "-O", "json"],
+            check=True, capture_output=True, text=True, timeout=30,
+        )
+        return str(json.loads(result.stdout).get("state", "unknown")).lower()
+
+    def start(self) -> None:
+        subprocess.run([self.exo_bin, "compute", "instance", "start", self.instance_id, "--zone", self.zone], check=True, timeout=60)
+
+    def stop(self) -> None:
+        subprocess.run([self.exo_bin, "compute", "instance", "stop", self.instance_id, "--zone", self.zone], check=True, timeout=90)
+
+
+class LeaseController:
+    def __init__(self, provider: ExoscaleProvider, ready: Callable[[], bool], *, lease_ttl: float = 90,
+                 idle_grace: float = 180, max_runtime: float = 4 * 3600, ready_timeout: float = 300):
+        self.provider, self.ready = provider, ready
+        self.lease_ttl, self.idle_grace = lease_ttl, idle_grace
+        self.max_runtime, self.ready_timeout = max_runtime, ready_timeout
+        self.lock = threading.RLock()
+        self.condition = threading.Condition(self.lock)
+        self.leases: dict[str, Lease] = {}
+        self.requests: dict[str, str] = {}
+        self.starting = False
+        self.started_at: float | None = None
+        self.stop_after: float | None = None
+        self.closed = False
+        self.worker = threading.Thread(target=self._sweep, daemon=True)
+        self.worker.start()
+
+    def acquire(self, request_id: str) -> Lease:
+        if not request_id or len(request_id) > 200:
+            raise ValueError("invalid requestId")
+        with self.condition:
+            existing_id = self.requests.get(request_id)
+            if existing_id and existing_id in self.leases:
+                lease = self.leases[existing_id]
+                lease.expires_at = time.monotonic() + self.lease_ttl
+                return lease
+            while self.starting:
+                self.condition.wait(timeout=1)
+            if self.provider.state() == "running" and self.ready():
+                return self._new_lease(request_id)
+            self.starting = True
+            self.stop_after = None
+        try:
+            if self.provider.state() == "stopped":
+                self.provider.start()
+            deadline = time.monotonic() + self.ready_timeout
+            while time.monotonic() < deadline:
+                if self.provider.state() == "running" and self.ready():
+                    with self.condition:
+                        self.started_at = self.started_at or time.monotonic()
+                        return self._new_lease(request_id)
+                time.sleep(2)
+            raise RuntimeError("transcription compute readiness timed out")
+        finally:
+            with self.condition:
+                self.starting = False
+                if not self.leases and self.stop_after is None:
+                    self.stop_after = time.monotonic() + self.idle_grace
+                self.condition.notify_all()
+
+    def heartbeat(self, lease_id: str) -> None:
+        with self.lock:
+            lease = self.leases.get(lease_id)
+            if not lease:
+                raise KeyError("lease not found")
+            if self.started_at is not None and time.monotonic() - self.started_at > self.max_runtime:
+                raise RuntimeError("maximum compute runtime exceeded")
+            lease.expires_at = time.monotonic() + self.lease_ttl
+
+    def release(self, lease_id: str) -> None:
+        with self.lock:
+            lease = self.leases.pop(lease_id, None)
+            if lease:
+                self.requests.pop(lease.request_id, None)
+            if not self.leases:
+                self.stop_after = time.monotonic() + self.idle_grace
+
+    def close(self) -> None:
+        self.closed = True
+        self.worker.join(timeout=2)
+
+    def _new_lease(self, request_id: str) -> Lease:
+        now = time.monotonic()
+        lease = Lease(secrets.token_urlsafe(32), request_id, now + self.lease_ttl, now)
+        self.leases[lease.lease_id] = lease
+        self.requests[request_id] = lease.lease_id
+        self.stop_after = None
+        self.started_at = self.started_at or now
+        return lease
+
+    def _sweep(self) -> None:
+        # Crash reconciliation: a running provider with no recovered leases is stopped after grace.
+        with self.lock:
+            self.stop_after = time.monotonic() + self.idle_grace
+        while not self.closed:
+            time.sleep(2)
+            now = time.monotonic()
+            should_stop = False
+            with self.lock:
+                hard_limit_reached = self.started_at is not None and now - self.started_at > self.max_runtime
+                for lease_id, lease in list(self.leases.items()):
+                    if lease.expires_at <= now or hard_limit_reached:
+                        self.leases.pop(lease_id, None)
+                        self.requests.pop(lease.request_id, None)
+                if hard_limit_reached:
+                    self.stop_after = now
+                if not self.leases and self.stop_after is None:
+                    self.stop_after = now + self.idle_grace
+                should_stop = not self.starting and not self.leases and self.stop_after is not None and now >= self.stop_after
+                if should_stop:
+                    self.stop_after = now + 30
+            if should_stop:
+                self._stop_until_verified()
+
+    def _stop_until_verified(self) -> None:
+        delay = 2
+        for _ in range(6):
+            try:
+                if self.provider.state() == "stopped":
+                    with self.lock:
+                        self.started_at = None
+                        self.stop_after = None
+                    return
+                self.provider.stop()
+                if self.provider.state() == "stopped":
+                    with self.lock:
+                        self.started_at = None
+                        self.stop_after = None
+                    return
+            except Exception as error:
+                print(f"lifecycle stop attempt failed: {error}", flush=True)
+            time.sleep(delay)
+            delay = min(delay * 2, 30)
+
+
+class ApiHandler(BaseHTTPRequestHandler):
+    controller: LeaseController
+    bearer_token: str
+
+    def do_POST(self) -> None:
+        if self.headers.get("Origin"):
+            return self._send(403, {"error": "browser origins are forbidden"})
+        supplied = self.headers.get("Authorization", "")
+        if not hmac.compare_digest(supplied, f"Bearer {self.bearer_token}"):
+            return self._send(401, {"error": "unauthorized"})
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            if length > 4096:
+                return self._send(413, {"error": "request too large"})
+            body = json.loads(self.rfile.read(length) or b"{}")
+            if self.path == "/v1/leases/acquire":
+                lease = self.controller.acquire(str(body.get("requestId", "")))
+                return self._send(200, {"id": lease.lease_id})
+            if self.path == "/v1/leases/heartbeat":
+                self.controller.heartbeat(str(body.get("leaseId", "")))
+                return self._send(200, {"ok": True})
+            if self.path == "/v1/leases/release":
+                self.controller.release(str(body.get("leaseId", "")))
+                return self._send(200, {"ok": True})
+            return self._send(404, {"error": "not found"})
+        except KeyError as error:
+            return self._send(404, {"error": str(error)})
+        except ValueError as error:
+            return self._send(400, {"error": str(error)})
+        except Exception as error:
+            print(f"lifecycle request failed: {error}", flush=True)
+            return self._send(503, {"error": "compute lifecycle operation failed"})
+
+    def _send(self, status: int, payload: dict) -> None:
+        encoded = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(encoded)))
+        self.end_headers()
+        self.wfile.write(encoded)
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        print(f"lifecycle api: {fmt % args}", flush=True)
+
+
+def tcp_ready_targets(raw_targets: str, bearer_tokens: list[str]) -> Callable[[], bool]:
+    import base64
+    import socket
+    targets = [urllib.parse.urlparse(item.strip()) for item in raw_targets.split(",") if item.strip()]
+    if len(targets) < 2:
+        raise ValueError("Kyutai and Sortformer authenticated readiness targets are required")
+    if len(targets) != len(bearer_tokens):
+        raise ValueError("readiness target/token count mismatch")
+
+    def ready() -> bool:
+        for target, token in zip(targets, bearer_tokens):
+            if target.scheme != "ws" or target.hostname not in {"127.0.0.1", "localhost", "::1"} or not target.port:
+                return False
+            key = base64.b64encode(os.urandom(16)).decode()
+            path = target.path + (("?" + target.query) if target.query else "")
+            request = (f"GET {path} HTTP/1.1\r\nHost: {target.hostname}:{target.port}\r\nUpgrade: websocket\r\n"
+                       f"Connection: Upgrade\r\nSec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n"
+                       f"Authorization: Bearer {token}\r\n\r\n").encode()
+            try:
+                with socket.create_connection((target.hostname, target.port), timeout=3) as connection:
+                    connection.sendall(request)
+                    response = connection.recv(1024)
+                if not response.startswith(b"HTTP/1.1 101"):
+                    return False
+            except OSError:
+                return False
+        return True
+    return ready
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--listen", default="127.0.0.1:18882")
+    parser.add_argument("--instance-id", required=True)
+    parser.add_argument("--zone", required=True)
+    parser.add_argument("--exo-bin", default="/usr/local/bin/exo")
+    parser.add_argument("--idle-grace", type=float, default=180)
+    parser.add_argument("--max-runtime", type=float, default=4 * 3600)
+    args = parser.parse_args()
+    host, port_text = args.listen.rsplit(":", 1)
+    if host not in {"127.0.0.1", "::1"}:
+        raise SystemExit("lifecycle daemon must bind to loopback")
+    token = os.environ["BORING_GPU_LIFECYCLE_BEARER_TOKEN"]
+    ready_targets = os.environ["BORING_GPU_READY_WEBSOCKETS"]
+    ready_tokens = json.loads(os.environ["BORING_GPU_READY_BEARER_TOKENS_JSON"])
+    controller = LeaseController(
+        ExoscaleProvider(args.exo_bin, args.instance_id, args.zone),
+        tcp_ready_targets(ready_targets, ready_tokens),
+        idle_grace=args.idle_grace,
+        max_runtime=args.max_runtime,
+    )
+    ApiHandler.controller = controller
+    ApiHandler.bearer_token = token
+    server = ThreadingHTTPServer((host, int(port_text)), ApiHandler)
+    try:
+        server.serve_forever()
+    finally:
+        controller.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -64,6 +64,7 @@ class LeaseController:
         self.leases: dict[str, Lease] = {}
         self.requests: dict[str, str] = {}
         self.starting = False
+        self.stopping = False
         self.started_at: float | None = None
         self.stop_after: float | None = None
         self.closed = False
@@ -79,10 +80,8 @@ class LeaseController:
                 lease = self.leases[existing_id]
                 lease.expires_at = time.monotonic() + self.lease_ttl
                 return lease
-            while self.starting:
+            while self.starting or self.stopping:
                 self.condition.wait(timeout=1)
-            if self.provider.state() == "running" and self.ready():
-                return self._new_lease(request_id)
             self.starting = True
             self.stop_after = None
         try:
@@ -154,31 +153,40 @@ class LeaseController:
                     self.stop_after = now
                 if not self.leases and self.stop_after is None:
                     self.stop_after = now + self.idle_grace
-                should_stop = not self.starting and not self.leases and self.stop_after is not None and now >= self.stop_after
+                should_stop = not self.starting and not self.stopping and not self.leases and self.stop_after is not None and now >= self.stop_after
                 if should_stop:
                     self.stop_after = now + 30
             if should_stop:
                 self._stop_until_verified()
 
     def _stop_until_verified(self) -> None:
-        delay = 2
-        for _ in range(6):
-            try:
-                if self.provider.state() == "stopped":
-                    with self.lock:
-                        self.started_at = None
-                        self.stop_after = None
-                    return
-                self.provider.stop()
-                if self.provider.state() == "stopped":
-                    with self.lock:
-                        self.started_at = None
-                        self.stop_after = None
-                    return
-            except Exception as error:
-                print(f"lifecycle stop attempt failed: {error}", flush=True)
-            time.sleep(delay)
-            delay = min(delay * 2, 30)
+        with self.condition:
+            if self.leases or self.starting or self.stopping or self.stop_after is None:
+                return
+            self.stopping = True
+        try:
+            delay = 2
+            for _ in range(6):
+                try:
+                    if self.provider.state() == "stopped":
+                        with self.lock:
+                            self.started_at = None
+                            self.stop_after = None
+                        return
+                    self.provider.stop()
+                    if self.provider.state() == "stopped":
+                        with self.lock:
+                            self.started_at = None
+                            self.stop_after = None
+                        return
+                except Exception as error:
+                    print(f"lifecycle stop attempt failed: {error}", flush=True)
+                time.sleep(delay)
+                delay = min(delay * 2, 30)
+        finally:
+            with self.condition:
+                self.stopping = False
+                self.condition.notify_all()
 
 
 class ApiHandler(BaseHTTPRequestHandler):
@@ -188,12 +196,12 @@ class ApiHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:
         if self.headers.get("Origin"):
             return self._send(403, {"error": "browser origins are forbidden"})
-        supplied = self.headers.get("Authorization", "")
-        if not hmac.compare_digest(supplied, f"Bearer {self.bearer_token}"):
+        supplied = self.headers.get("Authorization", "").encode("utf-8", errors="replace")
+        if not hmac.compare_digest(supplied, f"Bearer {self.bearer_token}".encode()):
             return self._send(401, {"error": "unauthorized"})
         try:
             length = int(self.headers.get("Content-Length", "0"))
-            if length > 4096:
+            if length < 0 or length > 4096:
                 return self._send(413, {"error": "request too large"})
             body = json.loads(self.rfile.read(length) or b"{}")
             if self.path == "/v1/leases/acquire":
@@ -242,7 +250,7 @@ def tcp_ready_targets(raw_targets: str, auth_entries: list[dict[str, str]]) -> C
 
     def ready() -> bool:
         for target, auth in zip(targets, auth_entries):
-            if target.scheme != "ws" or target.hostname not in {"127.0.0.1", "localhost", "::1"} or not target.port:
+            if target.scheme != "ws" or target.hostname not in {"127.0.0.1", "localhost"} or not target.port:
                 return False
             key = base64.b64encode(os.urandom(16)).decode()
             path = target.path + (("?" + target.query) if target.query else "")
@@ -271,9 +279,11 @@ def main() -> None:
     parser.add_argument("--max-runtime", type=float, default=4 * 3600)
     args = parser.parse_args()
     host, port_text = args.listen.rsplit(":", 1)
-    if host not in {"127.0.0.1", "::1"}:
+    if host != "127.0.0.1":
         raise SystemExit("lifecycle daemon must bind to loopback")
     token = os.environ["BORING_GPU_LIFECYCLE_BEARER_TOKEN"]
+    if len(token) < 32:
+        raise SystemExit("BORING_GPU_LIFECYCLE_BEARER_TOKEN must be at least 32 characters")
     ready_targets = os.environ["BORING_GPU_READY_WEBSOCKETS"]
     ready_auth = json.loads(os.environ["BORING_GPU_READY_AUTH_JSON"])
     controller = LeaseController(

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -223,24 +223,29 @@ class ApiHandler(BaseHTTPRequestHandler):
         print(f"lifecycle api: {fmt % args}", flush=True)
 
 
-def tcp_ready_targets(raw_targets: str, bearer_tokens: list[str]) -> Callable[[], bool]:
+def tcp_ready_targets(raw_targets: str, auth_entries: list[dict[str, str]]) -> Callable[[], bool]:
     import base64
     import socket
     targets = [urllib.parse.urlparse(item.strip()) for item in raw_targets.split(",") if item.strip()]
     if len(targets) < 2:
         raise ValueError("Kyutai and Sortformer authenticated readiness targets are required")
-    if len(targets) != len(bearer_tokens):
-        raise ValueError("readiness target/token count mismatch")
+    if len(targets) != len(auth_entries):
+        raise ValueError("readiness target/auth count mismatch")
+    for auth in auth_entries:
+        if auth.get("header", "").lower() not in {"authorization", "kyutai-api-key"} or not auth.get("value"):
+            raise ValueError("invalid readiness authentication entry")
+        if any(character in auth["value"] for character in "\r\n"):
+            raise ValueError("invalid readiness authentication value")
 
     def ready() -> bool:
-        for target, token in zip(targets, bearer_tokens):
+        for target, auth in zip(targets, auth_entries):
             if target.scheme != "ws" or target.hostname not in {"127.0.0.1", "localhost", "::1"} or not target.port:
                 return False
             key = base64.b64encode(os.urandom(16)).decode()
             path = target.path + (("?" + target.query) if target.query else "")
             request = (f"GET {path} HTTP/1.1\r\nHost: {target.hostname}:{target.port}\r\nUpgrade: websocket\r\n"
                        f"Connection: Upgrade\r\nSec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\n"
-                       f"Authorization: Bearer {token}\r\n\r\n").encode()
+                       f"{auth['header']}: {auth['value']}\r\n\r\n").encode()
             try:
                 with socket.create_connection((target.hostname, target.port), timeout=3) as connection:
                     connection.sendall(request)
@@ -267,10 +272,10 @@ def main() -> None:
         raise SystemExit("lifecycle daemon must bind to loopback")
     token = os.environ["BORING_GPU_LIFECYCLE_BEARER_TOKEN"]
     ready_targets = os.environ["BORING_GPU_READY_WEBSOCKETS"]
-    ready_tokens = json.loads(os.environ["BORING_GPU_READY_BEARER_TOKENS_JSON"])
+    ready_auth = json.loads(os.environ["BORING_GPU_READY_AUTH_JSON"])
     controller = LeaseController(
         ExoscaleProvider(args.exo_bin, args.instance_id, args.zone),
-        tcp_ready_targets(ready_targets, ready_tokens),
+        tcp_ready_targets(ready_targets, ready_auth),
         idle_grace=args.idle_grace,
         max_runtime=args.max_runtime,
     )

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -201,7 +201,9 @@ class ApiHandler(BaseHTTPRequestHandler):
             return self._send(401, {"error": "unauthorized"})
         try:
             length = int(self.headers.get("Content-Length", "0"))
-            if length < 0 or length > 4096:
+            if length < 0:
+                return self._send(400, {"error": "invalid content length"})
+            if length > 4096:
                 return self._send(413, {"error": "request too large"})
             body = json.loads(self.rfile.read(length) or b"{}")
             if self.path == "/v1/leases/acquire":
@@ -250,7 +252,7 @@ def tcp_ready_targets(raw_targets: str, auth_entries: list[dict[str, str]]) -> C
 
     def ready() -> bool:
         for target, auth in zip(targets, auth_entries):
-            if target.scheme != "ws" or target.hostname not in {"127.0.0.1", "localhost"} or not target.port:
+            if target.scheme != "ws" or target.hostname != "127.0.0.1" or not target.port:
                 return False
             key = base64.b64encode(os.urandom(16)).decode()
             path = target.path + (("?" + target.query) if target.query else "")

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -36,21 +36,26 @@ class ExoscaleProvider:
         return str(json.loads(result.stdout).get("state", "unknown")).lower()
 
     def start(self) -> None:
-        subprocess.run(
-            [self.exo_bin, "compute", "instance", "start", self.instance_id, "--zone", self.zone, "--force"],
-            check=True, capture_output=True, text=True, timeout=300,
-        )
+        self._request_transition("start")
 
     def stop(self) -> None:
-        subprocess.run(
-            [self.exo_bin, "compute", "instance", "stop", self.instance_id, "--zone", self.zone, "--force"],
-            check=True, capture_output=True, text=True, timeout=300,
-        )
+        self._request_transition("stop")
+
+    def _request_transition(self, action: str) -> None:
+        try:
+            subprocess.run(
+                [self.exo_bin, "compute", "instance", action, self.instance_id, "--zone", self.zone, "--force"],
+                check=True, capture_output=True, text=True, timeout=20,
+            )
+        except subprocess.TimeoutExpired:
+            # exo waits for the asynchronous operation to finish. The request has
+            # already been accepted; state polling below is the source of truth.
+            return
 
 
 class LeaseController:
     def __init__(self, provider: ExoscaleProvider, ready: Callable[[], bool], *, lease_ttl: float = 90,
-                 idle_grace: float = 180, max_runtime: float = 4 * 3600, ready_timeout: float = 300):
+                 idle_grace: float = 180, max_runtime: float = 4 * 3600, ready_timeout: float = 600):
         self.provider, self.ready = provider, ready
         self.lease_ttl, self.idle_grace = lease_ttl, idle_grace
         self.max_runtime, self.ready_timeout = max_runtime, ready_timeout

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -36,10 +36,16 @@ class ExoscaleProvider:
         return str(json.loads(result.stdout).get("state", "unknown")).lower()
 
     def start(self) -> None:
-        subprocess.run([self.exo_bin, "compute", "instance", "start", self.instance_id, "--zone", self.zone, "--force"], check=True, timeout=60)
+        subprocess.run(
+            [self.exo_bin, "compute", "instance", "start", self.instance_id, "--zone", self.zone, "--force"],
+            check=True, capture_output=True, text=True, timeout=300,
+        )
 
     def stop(self) -> None:
-        subprocess.run([self.exo_bin, "compute", "instance", "stop", self.instance_id, "--zone", self.zone, "--force"], check=True, timeout=90)
+        subprocess.run(
+            [self.exo_bin, "compute", "instance", "stop", self.instance_id, "--zone", self.zone, "--force"],
+            check=True, capture_output=True, text=True, timeout=300,
+        )
 
 
 class LeaseController:

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -86,11 +86,14 @@ class LeaseController:
             self.starting = True
             self.stop_after = None
         try:
-            if self.provider.state() == "stopped":
-                self.provider.start()
             deadline = time.monotonic() + self.ready_timeout
+            start_requested = False
             while time.monotonic() < deadline:
-                if self.provider.state() == "running" and self.ready():
+                state = self.provider.state()
+                if state == "stopped" and not start_requested:
+                    self.provider.start()
+                    start_requested = True
+                elif state == "running" and self.ready():
                     with self.condition:
                         self.started_at = self.started_at or time.monotonic()
                         return self._new_lease(request_id)

--- a/plugins/live-transcription/services/lifecycle/test_daemon.py
+++ b/plugins/live-transcription/services/lifecycle/test_daemon.py
@@ -2,6 +2,7 @@ import importlib.util
 import pathlib
 import sys
 import time
+import threading
 import unittest
 from unittest import mock
 
@@ -64,6 +65,37 @@ class LeaseControllerTests(unittest.TestCase):
                 time.sleep(.02)
             self.assertEqual(provider.current, "stopped")
         finally:
+            controller.close()
+
+    def test_acquire_waits_until_in_flight_stop_finishes(self):
+        provider = FakeProvider()
+        provider.current = "running"
+        stop_entered = threading.Event()
+        allow_stop = threading.Event()
+        original_stop = provider.stop
+        def blocked_stop():
+            stop_entered.set()
+            allow_stop.wait(2)
+            original_stop()
+        provider.stop = blocked_stop
+        controller = MODULE.LeaseController(provider, lambda: True, idle_grace=60)
+        acquired = []
+        try:
+            controller.stop_after = time.monotonic()
+            stopping = threading.Thread(target=controller._stop_until_verified)
+            stopping.start()
+            self.assertTrue(stop_entered.wait(1))
+            acquiring = threading.Thread(target=lambda: acquired.append(controller.acquire("request-after-stop")))
+            acquiring.start()
+            time.sleep(.02)
+            self.assertEqual(acquired, [])
+            allow_stop.set()
+            stopping.join(3)
+            acquiring.join(5)
+            self.assertEqual(len(acquired), 1)
+            self.assertEqual(provider.current, "running")
+        finally:
+            allow_stop.set()
             controller.close()
 
     def test_expired_lease_stops_provider(self):

--- a/plugins/live-transcription/services/lifecycle/test_daemon.py
+++ b/plugins/live-transcription/services/lifecycle/test_daemon.py
@@ -81,7 +81,8 @@ class LeaseControllerTests(unittest.TestCase):
         controller = MODULE.LeaseController(provider, lambda: True, idle_grace=60)
         acquired = []
         try:
-            controller.stop_after = time.monotonic()
+            with controller.lock:
+                controller.stop_after = time.monotonic()
             stopping = threading.Thread(target=controller._stop_until_verified)
             stopping.start()
             self.assertTrue(stop_entered.wait(1))

--- a/plugins/live-transcription/services/lifecycle/test_daemon.py
+++ b/plugins/live-transcription/services/lifecycle/test_daemon.py
@@ -1,0 +1,70 @@
+import importlib.util
+import pathlib
+import sys
+import time
+import unittest
+
+SPEC = importlib.util.spec_from_file_location("gpu_lifecycle", pathlib.Path(__file__).with_name("daemon.py"))
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+class FakeProvider:
+    def __init__(self):
+        self.current = "stopped"
+        self.starts = 0
+        self.stops = 0
+    def state(self): return self.current
+    def start(self): self.starts += 1; self.current = "running"
+    def stop(self): self.stops += 1; self.current = "stopped"
+
+
+class LeaseControllerTests(unittest.TestCase):
+    def test_cold_acquire_reuse_heartbeat_and_release(self):
+        provider = FakeProvider()
+        controller = MODULE.LeaseController(provider, lambda: True, lease_ttl=.1, idle_grace=.02)
+        try:
+            first = controller.acquire("request-1")
+            duplicate = controller.acquire("request-1")
+            second = controller.acquire("request-2")
+            self.assertEqual(first.lease_id, duplicate.lease_id)
+            self.assertNotEqual(first.lease_id, second.lease_id)
+            self.assertEqual(provider.starts, 1)
+            controller.heartbeat(first.lease_id)
+            controller.release(first.lease_id)
+            self.assertEqual(provider.stops, 0)
+            controller.release(second.lease_id)
+            deadline = time.time() + 3
+            while provider.stops == 0 and time.time() < deadline:
+                time.sleep(.02)
+            self.assertEqual(provider.current, "stopped")
+        finally:
+            controller.close()
+
+    def test_expired_lease_stops_provider(self):
+        provider = FakeProvider()
+        controller = MODULE.LeaseController(provider, lambda: True, lease_ttl=.01, idle_grace=.01)
+        try:
+            controller.acquire("request-1")
+            deadline = time.time() + 5
+            while provider.current != "stopped" and time.time() < deadline:
+                time.sleep(.02)
+            self.assertEqual(provider.current, "stopped")
+        finally:
+            controller.close()
+
+    def test_readiness_failure_does_not_issue_lease(self):
+        provider = FakeProvider()
+        controller = MODULE.LeaseController(provider, lambda: False, ready_timeout=.02, idle_grace=.01)
+        try:
+            with self.assertRaises(RuntimeError):
+                controller.acquire("request-1")
+            self.assertEqual(controller.leases, {})
+        finally:
+            controller.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/plugins/live-transcription/services/lifecycle/test_daemon.py
+++ b/plugins/live-transcription/services/lifecycle/test_daemon.py
@@ -22,6 +22,20 @@ class FakeProvider:
     def stop(self): self.stops += 1; self.current = "stopped"
 
 
+class ReadinessTests(unittest.TestCase):
+    def test_rejects_unsafe_authentication_headers(self):
+        with self.assertRaises(ValueError):
+            MODULE.tcp_ready_targets(
+                "ws://127.0.0.1:1/a,ws://127.0.0.1:2/b",
+                [{"header": "X-Unsafe", "value": "secret"}, {"header": "Authorization", "value": "Bearer ok"}],
+            )
+        with self.assertRaises(ValueError):
+            MODULE.tcp_ready_targets(
+                "ws://127.0.0.1:1/a,ws://127.0.0.1:2/b",
+                [{"header": "kyutai-api-key", "value": "bad\r\nvalue"}, {"header": "Authorization", "value": "Bearer ok"}],
+            )
+
+
 class ExoscaleProviderTests(unittest.TestCase):
     def test_transition_timeout_means_request_was_accepted(self):
         provider = MODULE.ExoscaleProvider("exo", "instance", "zone")

--- a/plugins/live-transcription/services/lifecycle/test_daemon.py
+++ b/plugins/live-transcription/services/lifecycle/test_daemon.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 import time
 import unittest
+from unittest import mock
 
 SPEC = importlib.util.spec_from_file_location("gpu_lifecycle", pathlib.Path(__file__).with_name("daemon.py"))
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -19,6 +20,14 @@ class FakeProvider:
     def state(self): return self.current
     def start(self): self.starts += 1; self.current = "running"
     def stop(self): self.stops += 1; self.current = "stopped"
+
+
+class ExoscaleProviderTests(unittest.TestCase):
+    def test_transition_timeout_means_request_was_accepted(self):
+        provider = MODULE.ExoscaleProvider("exo", "instance", "zone")
+        with mock.patch.object(MODULE.subprocess, "run", side_effect=MODULE.subprocess.TimeoutExpired("exo", 20)):
+            provider.start()
+            provider.stop()
 
 
 class LeaseControllerTests(unittest.TestCase):

--- a/plugins/live-transcription/services/lifecycle/test_daemon.py
+++ b/plugins/live-transcription/services/lifecycle/test_daemon.py
@@ -78,6 +78,19 @@ class LeaseControllerTests(unittest.TestCase):
         finally:
             controller.close()
 
+    def test_acquire_waits_for_stopping_provider_then_restarts_it(self):
+        provider = FakeProvider()
+        states = iter(["stopping", "stopped", "running"])
+        provider.state = lambda: next(states, "running")
+        controller = MODULE.LeaseController(provider, lambda: True, idle_grace=60)
+        try:
+            with mock.patch.object(MODULE.time, "sleep", return_value=None):
+                lease = controller.acquire("request-during-stop")
+            self.assertTrue(lease.lease_id)
+            self.assertEqual(provider.starts, 1)
+        finally:
+            controller.close()
+
     def test_readiness_failure_does_not_issue_lease(self):
         provider = FakeProvider()
         controller = MODULE.LeaseController(provider, lambda: False, ready_timeout=.02, idle_grace=.01)

--- a/plugins/live-transcription/src/front/__tests__/controller.test.ts
+++ b/plugins/live-transcription/src/front/__tests__/controller.test.ts
@@ -26,6 +26,45 @@ describe("LiveTranscriptBrowserController live attachment", () => {
     })
   })
 
+  it("leaves composer idle when stop cancels GPU preparation", async () => {
+    let resolvePreparation!: (response: Response) => void
+    const preparation = new Promise<Response>((resolve) => { resolvePreparation = resolve })
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => String(input).endsWith("/compute/prepare")
+      ? await preparation
+      : ({ ok: true, json: async () => ({ cancelled: true }) } as Response)))
+    const controller = new LiveTranscriptBrowserController()
+    const starting = controller.startComposer(vi.fn())
+    await vi.waitFor(() => expect(liveTranscriptBrowserState.getSnapshot().phase).toBe("starting"))
+    await controller.stopComposer()
+    resolvePreparation({ ok: true, json: async () => ({ preparationId: "prep-1", state: "ready" }) } as Response)
+    await expect(starting).resolves.toBeUndefined()
+    expect(liveTranscriptBrowserState.getSnapshot().phase).toBe("idle")
+  })
+
+  it("interrupts a live session when stop wins during the start request", async () => {
+    let resolveStart!: (response: Response) => void
+    const startResponse = new Promise<Response>((resolve) => { resolveStart = resolve })
+    const stopTrack = vi.fn()
+    vi.stubGlobal("navigator", { mediaDevices: { getUserMedia: vi.fn(async () => ({ getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream)) } })
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.endsWith("/compute/prepare")) return { ok: true, json: async () => ({ preparationId: "prep-1", state: "ready" }) } as Response
+      if (url.endsWith("/compute/cancel")) return { ok: true, json: async () => ({ cancelled: true }) } as Response
+      if (url.endsWith("/interrupt")) return { ok: true, json: async () => ({ state: "interrupted" }) } as Response
+      return await startResponse
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const controller = new LiveTranscriptBrowserController()
+    const starting = controller.start("chat-1")
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    await expect(controller.stop()).resolves.toContain("stopped during GPU preparation")
+    resolveStart({ ok: true, json: async () => ({ liveSessionId: "live-1", transcriptPath: "live-transcripts/a.md", socketNonce: "nonce", reviewIntervalMs: 60_000, state: "setup" }) } as Response)
+    await expect(starting).resolves.toContain("stopped before microphone attachment")
+    expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith("/interrupt"))).toBe(true)
+    expect(stopTrack).toHaveBeenCalledOnce()
+    expect(liveTranscriptBrowserState.getSnapshot().phase).toBe("idle")
+  })
+
   it("cannot reacquire the microphone after stop wins during attachment", async () => {
     let resolveStream!: (stream: MediaStream) => void
     const streamPromise = new Promise<MediaStream>((resolve) => { resolveStream = resolve })

--- a/plugins/live-transcription/src/front/__tests__/controller.test.ts
+++ b/plugins/live-transcription/src/front/__tests__/controller.test.ts
@@ -46,7 +46,7 @@ describe("LiveTranscriptBrowserController live attachment", () => {
     const startResponse = new Promise<Response>((resolve) => { resolveStart = resolve })
     const stopTrack = vi.fn()
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia: vi.fn(async () => ({ getTracks: () => [{ stop: stopTrack }] } as unknown as MediaStream)) } })
-    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
       const url = String(input)
       if (url.endsWith("/compute/prepare")) return { ok: true, json: async () => ({ preparationId: "prep-1", state: "ready" }) } as Response
       if (url.endsWith("/compute/cancel")) return { ok: true, json: async () => ({ cancelled: true }) } as Response
@@ -60,7 +60,9 @@ describe("LiveTranscriptBrowserController live attachment", () => {
     await expect(controller.stop()).resolves.toContain("stopped during GPU preparation")
     resolveStart({ ok: true, json: async () => ({ liveSessionId: "live-1", transcriptPath: "live-transcripts/a.md", socketNonce: "nonce", reviewIntervalMs: 60_000, state: "setup" }) } as Response)
     await expect(starting).resolves.toContain("stopped before microphone attachment")
-    expect(fetchMock.mock.calls.some(([input]) => String(input).endsWith("/interrupt"))).toBe(true)
+    const interruptCall = fetchMock.mock.calls.find(([input]) => String(input).endsWith("/interrupt"))
+    expect(interruptCall).toBeDefined()
+    expect(JSON.parse(String(interruptCall?.[1]?.body))).toEqual({ reason: "attachment_failed" })
     expect(stopTrack).toHaveBeenCalledOnce()
     expect(liveTranscriptBrowserState.getSnapshot().phase).toBe("idle")
   })

--- a/plugins/live-transcription/src/front/__tests__/controller.test.ts
+++ b/plugins/live-transcription/src/front/__tests__/controller.test.ts
@@ -34,15 +34,17 @@ describe("LiveTranscriptBrowserController live attachment", () => {
     vi.stubGlobal("navigator", { mediaDevices: { getUserMedia: vi.fn(() => streamPromise) } })
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)
-      const payload = url.endsWith("/stop")
-        ? { liveSessionId: "live-1", transcriptPath: "live-transcripts/a.md", state: "complete" }
-        : {
-            liveSessionId: "live-1",
-            transcriptPath: "live-transcripts/a.md",
-            socketNonce: "nonce",
-            reviewIntervalMs: 60_000,
-            state: "setup",
-          }
+      const payload = url.endsWith("/compute/prepare")
+        ? { preparationId: "disabled", state: "ready" }
+        : url.endsWith("/stop")
+          ? { liveSessionId: "live-1", transcriptPath: "live-transcripts/a.md", state: "complete" }
+          : {
+              liveSessionId: "live-1",
+              transcriptPath: "live-transcripts/a.md",
+              socketNonce: "nonce",
+              reviewIntervalMs: 60_000,
+              state: "setup",
+            }
       return { ok: true, json: async () => payload } as Response
     }))
 
@@ -52,9 +54,9 @@ describe("LiveTranscriptBrowserController live attachment", () => {
     const stopping = controller.stop()
     resolveStream(stream)
 
-    await expect(stopping).resolves.toContain("Live transcript complete")
-    await expect(starting).resolves.toContain("stopped before microphone attachment")
-    expect(stopTrack).toHaveBeenCalledOnce()
+    await expect(stopping).resolves.toContain("stopped during GPU preparation")
+    await expect(starting).resolves.toContain("stopped during GPU preparation")
+    expect(stopTrack).not.toHaveBeenCalled()
     expect(liveTranscriptBrowserState.getSnapshot().phase).not.toBe("recording")
   })
 })

--- a/plugins/live-transcription/src/front/controller.ts
+++ b/plugins/live-transcription/src/front/controller.ts
@@ -420,7 +420,7 @@ export class LiveTranscriptBrowserController {
       { kind },
     )
     this.preparationId = prepared.preparationId
-    const deadline = Date.now() + 5 * 60_000
+    const deadline = Date.now() + 12 * 60_000
     let status = prepared
     while (status.state === "warming" && Date.now() < deadline && generation === this.attachGeneration) {
       await new Promise((resolve) => setTimeout(resolve, 2_000))

--- a/plugins/live-transcription/src/front/controller.ts
+++ b/plugins/live-transcription/src/front/controller.ts
@@ -38,6 +38,7 @@ export class LiveTranscriptBrowserController {
   private shortBytes = 0
   private shortLimitReached = false
   private composerStreamId: string | undefined
+  private preparationId: string | undefined
   private streamingSampleRate: number = LIVE_PCM_SAMPLE_RATE
 
   setStreamingSampleRate(sampleRate: number): void {
@@ -173,10 +174,12 @@ export class LiveTranscriptBrowserController {
   async startComposer(onWord: (word: string) => void): Promise<void> {
     if (this.active || this.composerStreamId || this.shortRecorder || this.capture) throw new Error("Another microphone recording is already active.")
     liveTranscriptBrowserState.set({ recordingKind: "composer", phase: "starting" })
+    const generation = ++this.attachGeneration
     try {
-      const started = await postJson<{ composerStreamId: string; socketNonce: string }>(`${LIVE_TRANSCRIPT_BASE_PATH}/composer`, {})
+      const preparationId = await this.prepareCompute("composer", generation)
+      const started = await postJson<{ composerStreamId: string; socketNonce: string }>(`${LIVE_TRANSCRIPT_BASE_PATH}/composer`, { preparationId })
+      this.preparationId = undefined
       this.composerStreamId = started.composerStreamId
-      const generation = ++this.attachGeneration
       await this.attachStream({
         socketNonce: started.socketNonce,
         socketPath: `${LIVE_TRANSCRIPT_BASE_PATH}/composer/${encodeURIComponent(started.composerStreamId)}/audio`,
@@ -186,6 +189,9 @@ export class LiveTranscriptBrowserController {
       })
       liveTranscriptBrowserState.set({ recordingKind: "composer", phase: "recording", startedAt: Date.now() })
     } catch (error) {
+      const preparationId = this.preparationId
+      this.preparationId = undefined
+      if (preparationId) try { await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/cancel`, { preparationId }) } catch {}
       const id = this.composerStreamId
       if (id) {
         try { await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/composer/${encodeURIComponent(id)}/stop`, {}) } catch {}
@@ -198,6 +204,14 @@ export class LiveTranscriptBrowserController {
 
   async stopComposer(): Promise<void> {
     const id = this.composerStreamId
+    if (!id && (this.preparationId || liveTranscriptBrowserState.getSnapshot().phase === "starting")) {
+      this.attachGeneration += 1
+      const preparationId = this.preparationId
+      this.preparationId = undefined
+      if (preparationId) try { await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/cancel`, { preparationId }) } catch {}
+      liveTranscriptBrowserState.set({ phase: "idle" })
+      return
+    }
     if (!id) return
     this.stopping = true
     this.attachGeneration += 1
@@ -224,13 +238,24 @@ export class LiveTranscriptBrowserController {
       return "live_transcript_already_active: A microphone recording is already active."
     }
     let started: LiveTranscriptStartResponse
+    const attachGeneration = ++this.attachGeneration
+    liveTranscriptBrowserState.set({ recordingKind: "live", phase: "starting" })
     try {
+      const preparationId = await this.prepareCompute("live", attachGeneration)
       started = await postJson<LiveTranscriptStartResponse>(LIVE_TRANSCRIPT_BASE_PATH, {
         sessionId,
+        preparationId,
         ...(title?.trim() ? { title: title.trim() } : {}),
       })
+      this.preparationId = undefined
     } catch (error) {
-      return formatError(error)
+      const preparationId = this.preparationId
+      this.preparationId = undefined
+      if (preparationId) try { await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/cancel`, { preparationId }) } catch {}
+      if (error instanceof LiveAttachCancelledError) return "Live transcript stopped during GPU preparation."
+      const message = formatError(error)
+      liveTranscriptBrowserState.set({ recordingKind: "live", phase: "error", error: message })
+      return message
     }
     this.active = started
     liveTranscriptBrowserState.set({
@@ -247,7 +272,6 @@ export class LiveTranscriptBrowserController {
       params: { kind: "workspace.open.path", target: started.transcriptPath },
     })
 
-    const attachGeneration = ++this.attachGeneration
     try {
       await this.attachLive(started, attachGeneration)
       liveTranscriptBrowserState.set({
@@ -281,6 +305,14 @@ export class LiveTranscriptBrowserController {
 
   async stop(): Promise<string> {
     const active = this.active
+    if (!active && (this.preparationId || liveTranscriptBrowserState.getSnapshot().phase === "starting")) {
+      this.attachGeneration += 1
+      const preparationId = this.preparationId
+      this.preparationId = undefined
+      if (preparationId) try { await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/cancel`, { preparationId }) } catch {}
+      liveTranscriptBrowserState.set({ phase: "idle" })
+      return "Live transcript stopped during GPU preparation."
+    }
     if (!active) return "live_transcript_not_active: No live transcript is active."
     this.stopping = true
     this.attachGeneration += 1
@@ -380,6 +412,30 @@ export class LiveTranscriptBrowserController {
     }
     if (subcommand === "status" && !remainder) return await this.status()
     return "Usage: /live start [optional title] | /live stop | /live status"
+  }
+
+  private async prepareCompute(kind: "live" | "composer", generation: number): Promise<string> {
+    const prepared = await postJson<{ preparationId: string; state: "warming" | "ready" | "failed"; error?: string }>(
+      `${LIVE_TRANSCRIPT_BASE_PATH}/compute/prepare`,
+      { kind },
+    )
+    this.preparationId = prepared.preparationId
+    const deadline = Date.now() + 5 * 60_000
+    let status = prepared
+    while (status.state === "warming" && Date.now() < deadline && generation === this.attachGeneration) {
+      await new Promise((resolve) => setTimeout(resolve, 2_000))
+      if (generation !== this.attachGeneration) break
+      status = await postJson<typeof prepared>(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/status`, { preparationId: prepared.preparationId })
+    }
+    if (generation !== this.attachGeneration) {
+      this.preparationId = undefined
+      try { await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/cancel`, { preparationId: prepared.preparationId }) } catch {}
+      throw new LiveAttachCancelledError()
+    }
+    if (status.state === "ready") return prepared.preparationId
+    this.preparationId = undefined
+    try { await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/cancel`, { preparationId: prepared.preparationId }) } catch {}
+    throw new Error(status.error ?? "Transcription GPU did not become ready in time.")
   }
 
   private async attachLive(started: LiveTranscriptStartResponse, generation: number): Promise<void> {

--- a/plugins/live-transcription/src/front/controller.ts
+++ b/plugins/live-transcription/src/front/controller.ts
@@ -291,7 +291,7 @@ export class LiveTranscriptBrowserController {
     } catch (error) {
       if (error instanceof LiveAttachCancelledError) {
         try {
-          await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/${encodeURIComponent(started.liveSessionId)}/interrupt`, { reason: "cancelled_before_attachment" })
+          await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/${encodeURIComponent(started.liveSessionId)}/interrupt`, { reason: "attachment_failed" })
         } catch {}
         await this.cleanup(started.liveSessionId)
         liveTranscriptBrowserState.set({ phase: "idle" })

--- a/plugins/live-transcription/src/front/controller.ts
+++ b/plugins/live-transcription/src/front/controller.ts
@@ -197,6 +197,10 @@ export class LiveTranscriptBrowserController {
         try { await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/composer/${encodeURIComponent(id)}/stop`, {}) } catch {}
       }
       await this.cleanupComposer()
+      if (error instanceof LiveAttachCancelledError) {
+        liveTranscriptBrowserState.set({ phase: "idle" })
+        return
+      }
       liveTranscriptBrowserState.set({ recordingKind: "composer", phase: "error", error: formatError(error, "Streaming dictation failed to start.") })
       throw error
     }
@@ -285,7 +289,14 @@ export class LiveTranscriptBrowserController {
       })
       return `Live transcript started: ${started.transcriptPath}`
     } catch (error) {
-      if (error instanceof LiveAttachCancelledError) return "Live transcript stopped before microphone attachment completed."
+      if (error instanceof LiveAttachCancelledError) {
+        try {
+          await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/${encodeURIComponent(started.liveSessionId)}/interrupt`, { reason: "cancelled_before_attachment" })
+        } catch {}
+        await this.cleanup(started.liveSessionId)
+        liveTranscriptBrowserState.set({ phase: "idle" })
+        return "Live transcript stopped before microphone attachment completed."
+      }
       const permissionDenied = error instanceof DOMException && error.name === "NotAllowedError"
       try {
         await postJson(`${LIVE_TRANSCRIPT_BASE_PATH}/${encodeURIComponent(started.liveSessionId)}/interrupt`, {
@@ -422,10 +433,17 @@ export class LiveTranscriptBrowserController {
     this.preparationId = prepared.preparationId
     const deadline = Date.now() + 12 * 60_000
     let status = prepared
+    let consecutivePollFailures = 0
     while (status.state === "warming" && Date.now() < deadline && generation === this.attachGeneration) {
       await new Promise((resolve) => setTimeout(resolve, 2_000))
       if (generation !== this.attachGeneration) break
-      status = await postJson<typeof prepared>(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/status`, { preparationId: prepared.preparationId })
+      try {
+        status = await postJson<typeof prepared>(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/status`, { preparationId: prepared.preparationId })
+        consecutivePollFailures = 0
+      } catch (error) {
+        consecutivePollFailures += 1
+        if (consecutivePollFailures >= 3) throw error
+      }
     }
     if (generation !== this.attachGeneration) {
       this.preparationId = undefined

--- a/plugins/live-transcription/src/server/__tests__/computeLifecycle.test.ts
+++ b/plugins/live-transcription/src/server/__tests__/computeLifecycle.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { ComputeLifecycleCoordinator, validateLifecycleUrl, type LifecycleClient } from "../computeLifecycle"
+
+afterEach(() => vi.useRealTimers())
+
+describe("ComputeLifecycleCoordinator", () => {
+  it("warms once, adopts, heartbeats, and releases after capture ends", async () => {
+    vi.useFakeTimers()
+    const client = fakeClient()
+    const coordinator = new ComputeLifecycleCoordinator(client)
+    let active = true
+    coordinator.setActiveChecker(() => active)
+    const preparation = coordinator.prepare("live")
+    expect(preparation.state).toBe("warming")
+    await vi.waitFor(() => expect(coordinator.status(preparation.preparationId).state).toBe("ready"))
+    const lease = coordinator.take(preparation.preparationId, "live")
+    coordinator.adopt(lease)
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(client.heartbeat).toHaveBeenCalled()
+    active = false
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(client.release).toHaveBeenCalledWith("lease-1")
+    await coordinator.close()
+  })
+
+  it("releases a ready preparation that is cancelled", async () => {
+    const client = fakeClient()
+    const coordinator = new ComputeLifecycleCoordinator(client)
+    const preparation = coordinator.prepare("composer")
+    await vi.waitFor(() => expect(coordinator.status(preparation.preparationId).state).toBe("ready"))
+    await coordinator.cancel(preparation.preparationId)
+    expect(client.release).toHaveBeenCalledWith("lease-1")
+  })
+
+  it("rejects wrong kinds and unsafe lifecycle authorities", async () => {
+    const coordinator = new ComputeLifecycleCoordinator(fakeClient())
+    const preparation = coordinator.prepare("live")
+    await vi.waitFor(() => expect(coordinator.status(preparation.preparationId).state).toBe("ready"))
+    expect(() => coordinator.take(preparation.preparationId, "composer")).toThrow(expect.objectContaining({ code: "live_transcript_upstream_failed" }))
+    expect(validateLifecycleUrl("http://127.0.0.1:18882/v1")).toBe("http://127.0.0.1:18882/v1")
+    expect(() => validateLifecycleUrl("https://remote.example/v1")).toThrow(expect.objectContaining({ code: "live_transcript_local_only" }))
+  })
+})
+
+function fakeClient(): LifecycleClient & { acquire: ReturnType<typeof vi.fn>; heartbeat: ReturnType<typeof vi.fn>; release: ReturnType<typeof vi.fn> } {
+  return {
+    acquire: vi.fn(async () => ({ id: "lease-1" })),
+    heartbeat: vi.fn(async () => undefined),
+    release: vi.fn(async () => undefined),
+  }
+}

--- a/plugins/live-transcription/src/server/computeLifecycle.ts
+++ b/plugins/live-transcription/src/server/computeLifecycle.ts
@@ -64,15 +64,19 @@ export class ComputeLifecycleCoordinator {
   prepare(kind: CaptureKind): PreparationStatus {
     if (!this.client) return { preparationId: "disabled", state: "ready" }
     const preparation: Preparation = { id: randomUUID(), kind, state: "warming" }
+    preparation.expiry = setTimeout(() => { void this.cancel(preparation.id) }, 15 * 60_000)
     this.preparations.set(preparation.id, preparation)
     void this.client.acquire(preparation.id).then((lease) => {
       if (!this.preparations.has(preparation.id)) return void this.client?.release(lease.id).catch(() => undefined)
       preparation.lease = lease
       preparation.state = "ready"
+      if (preparation.expiry) clearTimeout(preparation.expiry)
       preparation.expiry = setTimeout(() => { void this.cancel(preparation.id) }, 2 * 60_000)
     }).catch((error) => {
       preparation.state = "failed"
       preparation.error = error instanceof Error ? error.message : "Transcription GPU failed to start."
+      if (preparation.expiry) clearTimeout(preparation.expiry)
+      preparation.expiry = setTimeout(() => { this.preparations.delete(preparation.id) }, 2 * 60_000)
     })
     return this.publicStatus(preparation)
   }
@@ -142,7 +146,7 @@ export class ComputeLifecycleCoordinator {
 export function validateLifecycleUrl(raw: string): string {
   let url: URL
   try { url = new URL(raw) } catch { throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle URL is invalid.", 500) }
-  if (url.protocol !== "http:" || !["127.0.0.1", "localhost", "::1"].includes(url.hostname) || url.pathname !== "/v1" || url.search || url.username || url.password) {
+  if (url.protocol !== "http:" || !["127.0.0.1", "localhost"].includes(url.hostname) || url.pathname !== "/v1" || url.search || url.username || url.password) {
     throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle service must use the exact loopback /v1 authority.", 500)
   }
   return url.toString().replace(/\/$/, "")

--- a/plugins/live-transcription/src/server/computeLifecycle.ts
+++ b/plugins/live-transcription/src/server/computeLifecycle.ts
@@ -1,0 +1,149 @@
+import { randomUUID } from "node:crypto"
+import { LiveTranscriptError } from "./errors"
+
+export type CaptureKind = "live" | "composer"
+export type PreparationStatus =
+  | { preparationId: string; state: "warming" }
+  | { preparationId: string; state: "ready" }
+  | { preparationId: string; state: "failed"; error: string }
+
+export interface Lease { id: string }
+export interface LifecycleClient {
+  acquire(requestId: string): Promise<Lease>
+  heartbeat(id: string): Promise<void>
+  release(id: string): Promise<void>
+}
+interface Preparation {
+  id: string
+  kind: CaptureKind
+  state: "warming" | "ready" | "failed"
+  lease?: Lease
+  error?: string
+  expiry?: ReturnType<typeof setTimeout>
+}
+
+export class ComputeLifecycleClient implements LifecycleClient {
+  constructor(private readonly baseUrl: string, private readonly token: string) {}
+
+  async acquire(requestId: string): Promise<Lease> {
+    return await this.post<Lease>("/leases/acquire", { requestId }, 5 * 60_000)
+  }
+  async heartbeat(id: string): Promise<void> { await this.post("/leases/heartbeat", { leaseId: id }, 15_000) }
+  async release(id: string): Promise<void> { await this.post("/leases/release", { leaseId: id }, 60_000) }
+
+  private async post<T = unknown>(path: string, body: unknown, timeoutMs: number): Promise<T> {
+    let response: Response
+    try {
+      response = await fetch(`${this.baseUrl}${path}`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${this.token}`, "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+    } catch {
+      throw new LiveTranscriptError("live_transcript_upstream_failed", "Transcription GPU lifecycle service is unavailable.", 503)
+    }
+    if (!response.ok) throw new LiveTranscriptError("live_transcript_upstream_failed", "Transcription GPU could not become ready.", 503)
+    return await response.json() as T
+  }
+}
+
+/** Coordinates browser warming preparations with one active capture lease. */
+export class ComputeLifecycleCoordinator {
+  private readonly preparations = new Map<string, Preparation>()
+  private active: Lease | undefined
+  private activeChecker: (() => boolean) | undefined
+  private heartbeatTimer: ReturnType<typeof setInterval> | undefined
+  private monitorTimer: ReturnType<typeof setInterval> | undefined
+
+  constructor(private readonly client?: LifecycleClient) {}
+
+  setActiveChecker(checker: () => boolean): void { this.activeChecker = checker }
+  get enabled(): boolean { return Boolean(this.client) }
+
+  prepare(kind: CaptureKind): PreparationStatus {
+    if (!this.client) return { preparationId: "disabled", state: "ready" }
+    const preparation: Preparation = { id: randomUUID(), kind, state: "warming" }
+    this.preparations.set(preparation.id, preparation)
+    void this.client.acquire(preparation.id).then((lease) => {
+      if (!this.preparations.has(preparation.id)) return void this.client?.release(lease.id).catch(() => undefined)
+      preparation.lease = lease
+      preparation.state = "ready"
+      preparation.expiry = setTimeout(() => { void this.cancel(preparation.id) }, 2 * 60_000)
+    }).catch((error) => {
+      preparation.state = "failed"
+      preparation.error = error instanceof Error ? error.message : "Transcription GPU failed to start."
+    })
+    return this.publicStatus(preparation)
+  }
+
+  status(id: string): PreparationStatus {
+    if (!this.client && id === "disabled") return { preparationId: id, state: "ready" }
+    const preparation = this.preparations.get(id)
+    if (!preparation) throw new LiveTranscriptError("live_transcript_not_active", "GPU preparation was not found.", 404)
+    return this.publicStatus(preparation)
+  }
+
+  take(id: string, kind: CaptureKind): Lease | undefined {
+    if (!this.client && id === "disabled") return undefined
+    const preparation = this.preparations.get(id)
+    if (!preparation || preparation.kind !== kind || preparation.state !== "ready" || !preparation.lease) {
+      throw new LiveTranscriptError("live_transcript_upstream_failed", "Transcription GPU is not ready.", 409)
+    }
+    this.preparations.delete(id)
+    if (preparation.expiry) clearTimeout(preparation.expiry)
+    return preparation.lease
+  }
+
+  adopt(lease: Lease | undefined): void {
+    if (!lease || !this.client) return
+    if (this.active) throw new LiveTranscriptError("live_transcript_already_active", "Transcription compute is already leased.", 409)
+    this.active = lease
+    this.heartbeatTimer = setInterval(() => { void this.client?.heartbeat(lease.id).catch(() => undefined) }, 30_000)
+    this.monitorTimer = setInterval(() => {
+      if (!this.activeChecker?.()) void this.releaseActive()
+    }, 2_000)
+  }
+
+  async release(lease: Lease | undefined): Promise<void> {
+    if (lease) await this.client?.release(lease.id).catch(() => undefined)
+  }
+
+  async cancel(id: string): Promise<void> {
+    const preparation = this.preparations.get(id)
+    if (!preparation) return
+    this.preparations.delete(id)
+    if (preparation.expiry) clearTimeout(preparation.expiry)
+    if (preparation.lease) await this.client?.release(preparation.lease.id).catch(() => undefined)
+  }
+
+  async close(): Promise<void> {
+    await Promise.all([...this.preparations.keys()].map(async (id) => this.cancel(id)))
+    await this.releaseActive()
+  }
+
+  private async releaseActive(): Promise<void> {
+    const lease = this.active
+    if (!lease) return
+    this.active = undefined
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer)
+    if (this.monitorTimer) clearInterval(this.monitorTimer)
+    this.heartbeatTimer = undefined
+    this.monitorTimer = undefined
+    await this.client?.release(lease.id).catch(() => undefined)
+  }
+
+  private publicStatus(preparation: Preparation): PreparationStatus {
+    if (preparation.state === "failed") return { preparationId: preparation.id, state: "failed", error: preparation.error ?? "Transcription GPU failed to start." }
+    return { preparationId: preparation.id, state: preparation.state }
+  }
+}
+
+export function validateLifecycleUrl(raw: string): string {
+  let url: URL
+  try { url = new URL(raw) } catch { throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle URL is invalid.", 500) }
+  if (url.protocol !== "http:" || !["127.0.0.1", "localhost", "::1"].includes(url.hostname) || url.pathname !== "/v1" || url.search || url.username || url.password) {
+    throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle service must use the exact loopback /v1 authority.", 500)
+  }
+  return url.toString().replace(/\/$/, "")
+}

--- a/plugins/live-transcription/src/server/computeLifecycle.ts
+++ b/plugins/live-transcription/src/server/computeLifecycle.ts
@@ -26,7 +26,7 @@ export class ComputeLifecycleClient implements LifecycleClient {
   constructor(private readonly baseUrl: string, private readonly token: string) {}
 
   async acquire(requestId: string): Promise<Lease> {
-    return await this.post<Lease>("/leases/acquire", { requestId }, 5 * 60_000)
+    return await this.post<Lease>("/leases/acquire", { requestId }, 12 * 60_000)
   }
   async heartbeat(id: string): Promise<void> { await this.post("/leases/heartbeat", { leaseId: id }, 15_000) }
   async release(id: string): Promise<void> { await this.post("/leases/release", { leaseId: id }, 60_000) }

--- a/plugins/live-transcription/src/server/computeLifecycle.ts
+++ b/plugins/live-transcription/src/server/computeLifecycle.ts
@@ -146,7 +146,7 @@ export class ComputeLifecycleCoordinator {
 export function validateLifecycleUrl(raw: string): string {
   let url: URL
   try { url = new URL(raw) } catch { throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle URL is invalid.", 500) }
-  if (url.protocol !== "http:" || !["127.0.0.1", "localhost"].includes(url.hostname) || url.pathname !== "/v1" || url.search || url.username || url.password) {
+  if (url.protocol !== "http:" || url.hostname !== "127.0.0.1" || url.pathname !== "/v1" || url.search || url.username || url.password) {
     throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle service must use the exact loopback /v1 authority.", 500)
   }
   return url.toString().replace(/\/$/, "")

--- a/plugins/live-transcription/src/server/index.ts
+++ b/plugins/live-transcription/src/server/index.ts
@@ -8,6 +8,7 @@ import { LiveTranscriptError, liveTranscriptErrorPayload } from "./errors"
 import { LiveTranscriptManager, type LiveTranscriptManagerOptions } from "./manager"
 import { KyutaiComposerManager } from "./kyutaiComposer"
 import { transcribeShortDictation } from "./dictation"
+import { ComputeLifecycleClient, ComputeLifecycleCoordinator, validateLifecycleUrl } from "./computeLifecycle"
 
 export interface LiveTranscriptServerPluginOptions {
   dispatcherResolver: WorkspaceAgentDispatcherResolver
@@ -21,6 +22,9 @@ export interface LiveTranscriptServerPluginOptions {
   /** Optional raw Sortformer `/v1/diarize` endpoint used only to label `/live` Kyutai words. */
   diarizerUrl?: string
   diarizerBearerToken?: string
+  /** Optional authenticated loopback service that leases on-demand transcription compute. */
+  lifecycleUrl?: string
+  lifecycleBearerToken?: string
   setupTimeoutMs?: number
   drainTimeoutMs?: number
   maxDurationMs?: number
@@ -35,6 +39,10 @@ export interface LiveTranscriptServerPluginOptions {
 export function createLiveTranscriptServerPlugin(options: LiveTranscriptServerPluginOptions): WorkspaceServerPlugin {
   validateLocalAuthority(options.authority, options.upstreamUrl, options.upstreamProvider)
   if (options.diarizerUrl) validateLocalAuthority(options.authority, options.diarizerUrl, "sortformer")
+  if (options.lifecycleUrl && !options.lifecycleBearerToken) throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle bearer token is required.", 500)
+  const lifecycle = new ComputeLifecycleCoordinator(options.lifecycleUrl
+    ? new ComputeLifecycleClient(validateLifecycleUrl(options.lifecycleUrl), options.lifecycleBearerToken!)
+    : undefined)
   const manager = new LiveTranscriptManager({
     dispatcherResolver: options.dispatcherResolver,
     agentTypeId: options.agentTypeId,
@@ -62,6 +70,7 @@ export function createLiveTranscriptServerPlugin(options: LiveTranscriptServerPl
         maxDurationMs: options.maxDurationMs,
       })
     : undefined
+  lifecycle.setActiveChecker(() => Boolean(manager.getAgentReloadBlock()) || Boolean(composerManager?.isActive))
 
   return defineServerPlugin({
     id: "live-transcription",
@@ -70,13 +79,38 @@ export function createLiveTranscriptServerPlugin(options: LiveTranscriptServerPl
     routes: async (app) => {
       await app.register(fastifyWebsocket)
 
+      app.post(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/prepare`, async (request, reply) => withControl(request, reply, options.authority, async () => {
+        const body = strictRecord(request.body, ["kind"])
+        if (body.kind !== "live" && body.kind !== "composer") throw new LiveTranscriptError("live_transcript_disabled", "Capture kind was invalid.", 400)
+        return lifecycle.prepare(body.kind)
+      }))
+      app.post(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/status`, async (request, reply) => withControl(request, reply, options.authority, async () => {
+        const body = strictRecord(request.body, ["preparationId"])
+        if (typeof body.preparationId !== "string") throw new LiveTranscriptError("live_transcript_disabled", "GPU preparation id was invalid.", 400)
+        return lifecycle.status(body.preparationId)
+      }))
+      app.post(`${LIVE_TRANSCRIPT_BASE_PATH}/compute/cancel`, async (request, reply) => withControl(request, reply, options.authority, async () => {
+        const body = strictRecord(request.body, ["preparationId"])
+        if (typeof body.preparationId !== "string") throw new LiveTranscriptError("live_transcript_disabled", "GPU preparation id was invalid.", 400)
+        await lifecycle.cancel(body.preparationId)
+        return { cancelled: true }
+      }))
+
       app.post(LIVE_TRANSCRIPT_BASE_PATH, async (request, reply) => withControl(request, reply, options.authority, async () => {
-        const body = strictRecord(request.body, ["sessionId", "title"])
+        const body = strictRecord(request.body, ["sessionId", "title", "preparationId"])
         if (typeof body.sessionId !== "string" || (body.title !== undefined && typeof body.title !== "string")) {
           throw new LiveTranscriptError("live_transcript_session_not_found", "A valid originating Pi session is required.", 400)
         }
         if (composerManager?.isActive) throw new LiveTranscriptError("live_transcript_already_active", "A composer microphone stream is already active.", 409)
-        return await manager.start(request, { sessionId: body.sessionId, title: body.title as string | undefined })
+        const lease = lifecycle.take(requirePreparationId(body.preparationId, lifecycle.enabled), "live")
+        try {
+          const result = await manager.start(request, { sessionId: body.sessionId, title: body.title as string | undefined })
+          lifecycle.adopt(lease)
+          return result
+        } catch (error) {
+          await lifecycle.release(lease)
+          throw error
+        }
       }))
 
       app.post(`${LIVE_TRANSCRIPT_BASE_PATH}/dictate`, async (request, reply) => withControl(request, reply, options.authority, async () => {
@@ -97,10 +131,18 @@ export function createLiveTranscriptServerPlugin(options: LiveTranscriptServerPl
       }))
 
       app.post(`${LIVE_TRANSCRIPT_BASE_PATH}/composer`, async (request, reply) => withControl(request, reply, options.authority, async () => {
-        strictEmptyBody(request.body)
+        const body = strictRecord(request.body, ["preparationId"])
         if (!composerManager) throw new LiveTranscriptError("live_transcript_disabled", "Streaming composer dictation requires Kyutai.", 409)
         if (manager.getAgentReloadBlock()) throw new LiveTranscriptError("live_transcript_already_active", "A live transcript is already active.", 409)
-        return composerManager.start()
+        const lease = lifecycle.take(requirePreparationId(body.preparationId, lifecycle.enabled), "composer")
+        try {
+          const result = composerManager.start()
+          lifecycle.adopt(lease)
+          return result
+        } catch (error) {
+          await lifecycle.release(lease)
+          throw error
+        }
       }))
 
       app.post(`${LIVE_TRANSCRIPT_BASE_PATH}/composer/:id/stop`, async (request, reply) => withControl(request, reply, options.authority, async () => {
@@ -171,6 +213,7 @@ export function createLiveTranscriptServerPlugin(options: LiveTranscriptServerPl
       app.addHook("onClose", async () => {
         composerManager?.close()
         await manager.close()
+        await lifecycle.close()
       })
     },
   })
@@ -200,6 +243,12 @@ function strictRecord(value: unknown, allowedKeys: string[]): Record<string, unk
     throw new LiveTranscriptError("live_transcript_disabled", "Live transcript request body contained unsupported fields.", 400)
   }
   return record
+}
+
+function requirePreparationId(value: unknown, required: boolean): string {
+  if (!required && value === undefined) return "disabled"
+  if (typeof value !== "string") throw new LiveTranscriptError("live_transcript_upstream_failed", "Transcription GPU preparation is required.", 409)
+  return value
 }
 
 function strictEmptyBody(value: unknown): void {

--- a/plugins/live-transcription/src/server/index.ts
+++ b/plugins/live-transcription/src/server/index.ts
@@ -39,7 +39,7 @@ export interface LiveTranscriptServerPluginOptions {
 export function createLiveTranscriptServerPlugin(options: LiveTranscriptServerPluginOptions): WorkspaceServerPlugin {
   validateLocalAuthority(options.authority, options.upstreamUrl, options.upstreamProvider)
   if (options.diarizerUrl) validateLocalAuthority(options.authority, options.diarizerUrl, "sortformer")
-  if (options.lifecycleUrl && !options.lifecycleBearerToken) throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle bearer token is required.", 500)
+  if (options.lifecycleUrl && (!options.lifecycleBearerToken || options.lifecycleBearerToken.length < 32)) throw new LiveTranscriptError("live_transcript_local_only", "Lifecycle bearer token must contain at least 32 characters.", 500)
   const lifecycle = new ComputeLifecycleCoordinator(options.lifecycleUrl
     ? new ComputeLifecycleClient(validateLifecycleUrl(options.lifecycleUrl), options.lifecycleBearerToken!)
     : undefined)


### PR DESCRIPTION
Closes #1124

## Summary
- add provider-neutral asynchronous compute preparation and renewable lease coordination
- add root-owned loopback Exoscale lifecycle daemon with authenticated readiness, expiry, idle grace, hard runtime, reconciliation, and verified stop retries
- wire cold `/live` and composer starts through warming/cancellation while preserving disabled/manual mode

## Verification
- `pnpm --filter @hachej/boring-transcription typecheck`
- `pnpm --filter @hachej/boring-transcription test:system` (18 files, 102 tests)
- `pnpm --filter @hachej/boring-ui-cli typecheck`
- `pnpm --filter @hachej/boring-ui-cli build:full`
- `python3 -m py_compile daemon.py`
- `python3 -m unittest test_daemon.py` (3 tests)
- `git diff --check`