### PR TITLE
[gh-1011 slice 1] typed user-registered MCP source with SSRF-safe endpoint validation

### DIFF
--- a/plugins/boring-mcp/src/__tests__/mcpSdkTransport.test.ts
+++ b/plugins/boring-mcp/src/__tests__/mcpSdkTransport.test.ts
@@ -116,4 +116,22 @@ describe("MCP SDK Streamable HTTP transport", () => {
 
     expect(fake.seenHeaders).toContain("server-only-session-header")
   })
+
+  it("refuses to follow a redirect for a 'user-registered' source (redirect could otherwise carry auth headers to a private address)", async () => {
+    const redirectServer = createServer((req, res) => {
+      res.statusCode = 307
+      res.setHeader("location", "http://169.254.169.254/latest/meta-data")
+      res.end()
+    })
+    await new Promise<void>((resolve) => redirectServer.listen(0, "127.0.0.1", resolve))
+    const { port } = redirectServer.address() as AddressInfo
+    servers.push({ close: () => new Promise<void>((resolve, reject) => redirectServer.close((error) => error ? reject(error) : resolve())) })
+
+    const transport = createMcpSdkStreamableHttpTransport({
+      endpoint: { url: `http://127.0.0.1:${port}/mcp` },
+    })
+    const userRegisteredSource: McpSource = { ...source, provider: "user-registered" }
+
+    await expect(transport.listTools(userRegisteredSource)).rejects.toMatchObject({ code: "MCP_PROVIDER_ERROR" })
+  })
 })

--- a/plugins/boring-mcp/src/__tests__/shared.test.ts
+++ b/plugins/boring-mcp/src/__tests__/shared.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 import {
   AIRTABLE_MCP_TEMPLATE,
+  DEFAULT_MCP_PROVIDER_TEMPLATES,
   MCP_ERROR_CODES,
   McpAccessFacade,
   McpError,
@@ -9,13 +10,17 @@ import {
   classifyMcpTool,
   containsMcpSecret,
   containsMcpSecretOrCanary,
+  createUserRegisteredMcpProviderTemplate,
   doctorMcpSource,
+  getMcpProviderTemplate,
   redactMcpSecrets,
   toMcpSourceDto,
+  validateUserRegisteredMcpEndpoint,
   type McpActor,
   type McpSource,
   type McpSourceStore,
   type McpTransportClient,
+  type McpUserRegisteredSourceConfig,
 } from "../shared"
 
 const actor: McpActor = { userId: "user-1", workspaceId: "workspace-1" }
@@ -155,4 +160,81 @@ describe("McpAccessFacade", () => {
     await expect(policyFacade.probeSource(actor, teamSource.id)).resolves.toMatchObject({ sourceId: teamSource.id })
   })
 
+})
+
+describe("user-registered MCP source type", () => {
+  const baseConfig: McpUserRegisteredSourceConfig = {
+    enabled: true,
+    endpoint: "https://mcp.example.com/stream",
+    displayName: "Example MCP",
+  }
+
+  it("does not add entries to the default provider template list", () => {
+    expect(DEFAULT_MCP_PROVIDER_TEMPLATES).toEqual([NOTION_MCP_TEMPLATE, AIRTABLE_MCP_TEMPLATE])
+    expect(getMcpProviderTemplate("user-registered")).toBeUndefined()
+  })
+
+  it("leaves the two existing hardcoded providers unchanged", () => {
+    expect(getMcpProviderTemplate("notion")).toBe(NOTION_MCP_TEMPLATE)
+    expect(getMcpProviderTemplate("airtable")).toBe(AIRTABLE_MCP_TEMPLATE)
+  })
+
+  it("builds a valid template for an enabled, well-formed endpoint", () => {
+    const template = createUserRegisteredMcpProviderTemplate(baseConfig)
+    expect(template.id).toBe("user-registered")
+    expect(template.transport).toBe("streamable-http")
+    expect(template.endpoint).toBe("https://mcp.example.com/stream")
+  })
+
+  it("default-denies when not explicitly enabled", () => {
+    expect(() => createUserRegisteredMcpProviderTemplate({ ...baseConfig, enabled: false })).toThrow(McpError)
+    try {
+      createUserRegisteredMcpProviderTemplate({ ...baseConfig, enabled: false })
+    } catch (error) {
+      expect((error as McpError).code).toBe(MCP_ERROR_CODES.USER_REGISTERED_SOURCE_DISABLED)
+    }
+  })
+
+  it("accepts a valid https endpoint", () => {
+    expect(validateUserRegisteredMcpEndpoint("https://mcp.example.com/stream").hostname).toBe("mcp.example.com")
+  })
+
+  it.each([
+    ["http (non-https)", "http://mcp.example.com/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_SCHEME_INVALID],
+    ["unparseable URL", "not-a-url", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_SCHEME_INVALID],
+    ["non-streamable-http scheme", "wss://mcp.example.com/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_SCHEME_INVALID],
+    ["loopback hostname", "https://localhost/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["loopback IPv4", "https://127.0.0.1/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["loopback IPv6", "https://[::1]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["link-local", "https://169.254.1.5/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["cloud metadata service", "https://169.254.169.254/latest/meta-data", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["private 10.x", "https://10.0.0.5/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["private 192.168.x", "https://192.168.1.1/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    [".internal suffix", "https://svc.internal/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["credentials in URL", "https://user:pass@mcp.example.com/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_CREDENTIALS_INVALID],
+  ])("rejects %s", (_label, endpoint, expectedCode) => {
+    expect(() => validateUserRegisteredMcpEndpoint(endpoint)).toThrow(McpError)
+    try {
+      validateUserRegisteredMcpEndpoint(endpoint)
+    } catch (error) {
+      expect((error as McpError).code).toBe(expectedCode)
+    }
+  })
+
+  it("rejects a non-streamable-http transport even with a valid https endpoint", () => {
+    expect(() =>
+      validateUserRegisteredMcpEndpoint("https://mcp.example.com/stream", "sse" as never),
+    ).toThrowError(expect.objectContaining({ code: MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_TRANSPORT_INVALID }))
+  })
+
+  it("propagates endpoint validation failures through the template builder", () => {
+    expect(() =>
+      createUserRegisteredMcpProviderTemplate({ ...baseConfig, endpoint: "https://localhost/stream" }),
+    ).toThrowError(expect.objectContaining({ code: MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED }))
+  })
+
+  it("defaults denied tools to the same write/admin patterns as curated templates when unspecified", () => {
+    const template = createUserRegisteredMcpProviderTemplate(baseConfig)
+    expect(template.deniedTools).toEqual(["create_*", "update_*", "delete_*", "publish_*", "admin_*"])
+  })
 })

--- a/plugins/boring-mcp/src/__tests__/shared.test.ts
+++ b/plugins/boring-mcp/src/__tests__/shared.test.ts
@@ -212,6 +212,16 @@ describe("user-registered MCP source type", () => {
     ["private 192.168.x", "https://192.168.1.1/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
     [".internal suffix", "https://svc.internal/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
     ["credentials in URL", "https://user:pass@mcp.example.com/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_CREDENTIALS_INVALID],
+    ["IPv4-mapped IPv6 loopback (dotted-quad spelling)", "https://[::ffff:127.0.0.1]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["IPv4-mapped IPv6 loopback (hex-word spelling, as WHATWG URL normalizes it)", "https://[::ffff:7f00:1]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["IPv4-mapped IPv6 cloud metadata (hex-word spelling)", "https://[::ffff:a9fe:a9fe]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["IPv4-mapped IPv6 private 10.x (dotted-quad spelling)", "https://[::ffff:10.0.0.1]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["IPv4-mapped IPv6 private 192.168.x (hex-word spelling)", "https://[::ffff:c0a8:1]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["trailing-root-dot localhost", "https://localhost./stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["IPv6 link-local upper end of /10 (febf)", "https://[febf::1]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["deprecated IPv6 site-local (fec0::/10)", "https://[fec0::1]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["NAT64 well-known prefix", "https://[64:ff9b::a9fe:a9fe]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
+    ["6to4-encoded loopback", "https://[2002:7f00:1::]/stream", MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED],
   ])("rejects %s", (_label, endpoint, expectedCode) => {
     expect(() => validateUserRegisteredMcpEndpoint(endpoint)).toThrow(McpError)
     try {
@@ -231,6 +241,24 @@ describe("user-registered MCP source type", () => {
     expect(() =>
       createUserRegisteredMcpProviderTemplate({ ...baseConfig, endpoint: "https://localhost/stream" }),
     ).toThrowError(expect.objectContaining({ code: MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED }))
+  })
+
+  it("getMcpProviderTemplate rejects a hand-constructed 'user-registered' template that bypasses the factory's endpoint validation", () => {
+    const bypassTemplate = {
+      id: "user-registered" as const,
+      displayName: "Malicious",
+      endpoint: "https://127.0.0.1/x",
+      transport: "streamable-http" as const,
+      readOnlyDefault: true,
+      allowedTools: ["*"],
+      deniedTools: [],
+    }
+    expect(getMcpProviderTemplate("user-registered", [bypassTemplate])).toBeUndefined()
+  })
+
+  it("getMcpProviderTemplate accepts a 'user-registered' template whose endpoint passes validation", () => {
+    const template = createUserRegisteredMcpProviderTemplate(baseConfig)
+    expect(getMcpProviderTemplate("user-registered", [template])).toBe(template)
   })
 
   it("defaults denied tools to the same write/admin patterns as curated templates when unspecified", () => {

--- a/plugins/boring-mcp/src/server/mcpSdkTransport.ts
+++ b/plugins/boring-mcp/src/server/mcpSdkTransport.ts
@@ -53,8 +53,20 @@ async function withClient<T>(options: McpSdkTransportOptions, source: McpSource,
   const client = new Client({ name: options.clientName ?? "boring-mcp", version: options.clientVersion ?? "0.0.0" })
   try {
     const endpoint = await resolveEndpoint(options, source)
+    // validateUserRegisteredMcpEndpoint (shared/index.ts) is only a syntactic
+    // pre-filter on the literal endpoint string — it cannot stop a validated
+    // https:// host from 302-redirecting to a private/metadata address at
+    // connect time, and fetch's default `redirect: "follow"` would carry
+    // this transport's auth headers straight to wherever that redirect
+    // points. Until real connect-time enforcement lands (resolve-then-pin or
+    // an egress allowlist/proxy — see gh-1011-ssrf (bead wt-391-forward-1011-connect-time-ssrf-x35)), refuse to follow any
+    // redirect for user-registered sources rather than silently following it.
+    const requestInit: RequestInit = { headers: normalizeHeaders(endpoint.headers) }
+    if (source.provider === "user-registered") {
+      requestInit.redirect = "error"
+    }
     const transport = new StreamableHTTPClientTransport(normalizeUrl(endpoint.url), {
-      requestInit: { headers: normalizeHeaders(endpoint.headers) },
+      requestInit,
     })
     await client.connect(transport)
     return await run(client)

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -314,21 +314,56 @@ function isBlockedIpv4(octets: number[]): boolean {
   return false
 }
 
+/** Converts two IPv6 hex words (e.g. "7f00", "1") into the 4 embedded IPv4 octets. */
+function hexWordsToIpv4Octets(high: string, low: string): number[] {
+  const hi = Number.parseInt(high, 16)
+  const lo = Number.parseInt(low, 16)
+  return [(hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff, lo & 0xff]
+}
+
+/**
+ * Extracts the embedded IPv4 address from an IPv4-mapped IPv6 literal
+ * (`::ffff:a.b.c.d` or the WHATWG-URL-normalized hex-word form
+ * `::ffff:7f00:1`). The URL parser rewrites the former to the latter, so both
+ * spellings must be recognized or the mapped-address block below is a no-op
+ * for anything that has gone through `new URL(...)`.
+ */
+function ipv4MappedTail(normalizedHostname: string): number[] | undefined {
+  if (!normalizedHostname.startsWith("::ffff:")) return undefined
+  const tail = normalizedHostname.slice("::ffff:".length)
+  const dotted = ipv4OctetsFromHostname(tail)
+  if (dotted) return dotted
+  const hexWords = /^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(tail)
+  if (hexWords) return hexWordsToIpv4Octets(hexWords[1], hexWords[2])
+  return undefined
+}
+
+/** True if the hostname's first hextet falls in [lo, hi] (inclusive), covering a CIDR-style /N range. */
+function firstHextetInRange(normalizedHostname: string, lo: number, hi: number): boolean {
+  const first = normalizedHostname.split(":")[0]
+  if (!/^[0-9a-f]{1,4}$/.test(first)) return false
+  const value = Number.parseInt(first, 16)
+  return value >= lo && value <= hi
+}
+
 function isBlockedIpv6(hostname: string): boolean {
   const normalized = hostname.replace(/^\[|\]$/g, "").toLowerCase()
   if (normalized === "::1") return true // loopback
   if (normalized === "::") return true
-  if (normalized.startsWith("fe80:")) return true // link-local
+  if (firstHextetInRange(normalized, 0xfe80, 0xfebf)) return true // link-local fe80::/10
+  if (firstHextetInRange(normalized, 0xfec0, 0xfeff)) return true // deprecated site-local fec0::/10
   if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true // unique local
-  if (normalized.startsWith("::ffff:")) {
-    const embedded = ipv4OctetsFromHostname(normalized.slice("::ffff:".length))
-    if (embedded && isBlockedIpv4(embedded)) return true
-  }
+  if (normalized.startsWith("64:ff9b::")) return true // NAT64 well-known prefix (embeds an IPv4 address)
+  if (normalized.startsWith("2002:7f00:1:") || normalized === "2002:7f00:1::") return true // 6to4-encoded loopback
+  const mappedTail = ipv4MappedTail(normalized)
+  if (mappedTail && isBlockedIpv4(mappedTail)) return true
   return false
 }
 
 function isBlockedHostname(hostname: string): boolean {
-  const lower = hostname.toLowerCase()
+  // Resolvers treat a single trailing root dot as equivalent to no dot
+  // ("localhost." === "localhost"); strip it before every other check.
+  const lower = hostname.toLowerCase().replace(/\.$/, "")
   if (BLOCKED_HOSTNAME_EXACT.has(lower)) return true
   if (BLOCKED_HOSTNAME_SUFFIXES.some((suffix) => lower.endsWith(suffix))) return true
   const ipv4 = ipv4OctetsFromHostname(lower)
@@ -338,9 +373,22 @@ function isBlockedHostname(hostname: string): boolean {
 }
 
 /**
- * SSRF-safe validation for a user-registered MCP endpoint. Enforces:
- * https-only, no credentials embedded in the URL, and a blocklist covering
- * loopback / link-local / private-network / cloud-metadata-service hosts.
+ * SYNTACTIC PRE-FILTER, NOT AN SSRF CONTROL. This function inspects the
+ * literal endpoint string only: https-only, no credentials embedded in the
+ * URL, and a hostname/IP-literal blocklist covering loopback / link-local /
+ * private-network / cloud-metadata-service addresses. It never resolves DNS,
+ * so an attacker-controlled A record (e.g. `evil.example` -> 169.254.169.254,
+ * or a wildcard DNS rebinding host such as `127.0.0.1.nip.io`) sails through
+ * unchanged, and nothing here prevents a validated `https://` endpoint from
+ * later issuing an HTTP redirect to a private address at connect time.
+ *
+ * Real SSRF protection for this feature requires connect-time enforcement
+ * (resolve-then-pin the IP before connecting, or route through an egress
+ * allowlist/proxy) plus redirect handling at the transport layer — see
+ * gh-1011-ssrf (bead wt-391-forward-1011-connect-time-ssrf-x35). This validator MUST NOT be treated as sufficient to admit a
+ * user-registered source into any environment that can reach production
+ * networks or a cloud metadata service.
+ *
  * Throws {@link McpError} with a stable code per rejection reason.
  */
 export function validateUserRegisteredMcpEndpoint(endpoint: string, transport?: McpTransport): URL {
@@ -379,11 +427,25 @@ export function validateUserRegisteredMcpEndpoint(endpoint: string, transport?: 
 
 /**
  * Builds a {@link McpProviderTemplate} for a user-registered source. This is
- * the plugin's single admission point for the escape hatch: it is
+ * the plugin's intended admission point for the escape hatch: it is
  * default-deny (throws `USER_REGISTERED_SOURCE_DISABLED` unless
- * `config.enabled === true`) and always runs the endpoint through
- * {@link validateUserRegisteredMcpEndpoint} before returning a template,
- * regardless of caller. It never mutates {@link DEFAULT_MCP_PROVIDER_TEMPLATES}.
+ * `config.enabled === true`) and always runs the endpoint through the
+ * syntactic pre-filter {@link validateUserRegisteredMcpEndpoint} before
+ * returning a template, regardless of caller. It never mutates
+ * {@link DEFAULT_MCP_PROVIDER_TEMPLATES}.
+ *
+ * `McpProviderTemplate` is a plain structural type, so nothing stops a caller
+ * from hand-constructing a `{ id: "user-registered", endpoint: ... }` object
+ * and bypassing this factory entirely. {@link getMcpProviderTemplate} — the
+ * shared lookup used by every consumption point — re-runs the same
+ * validation on any template whose id is `"user-registered"` and silently
+ * drops it (returns `undefined`) if the endpoint doesn't pass, so a
+ * hand-crafted bypass template is rejected as "unknown provider" rather than
+ * being trusted. This is a runtime guard, not type-level branding: it was
+ * chosen over branding the interface because branding `McpProviderTemplate`
+ * would ripple across every call site that constructs or clones a template.
+ * It does not close the connect-time SSRF gap described above — see
+ * gh-1011-ssrf (bead wt-391-forward-1011-connect-time-ssrf-x35).
  */
 export function createUserRegisteredMcpProviderTemplate(config: McpUserRegisteredSourceConfig): McpProviderTemplate {
   if (!config.enabled) {
@@ -405,11 +467,24 @@ export function createUserRegisteredMcpProviderTemplate(config: McpUserRegistere
   }
 }
 
+/** Re-validates a "user-registered" template's endpoint at lookup time, guarding against hand-constructed bypass templates (see doc comment on {@link createUserRegisteredMcpProviderTemplate}). */
+function isValidUserRegisteredTemplate(template: McpProviderTemplate): boolean {
+  if (!template.endpoint) return false
+  try {
+    validateUserRegisteredMcpEndpoint(template.endpoint, template.transport)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export function getMcpProviderTemplate(
   provider: string,
   templates: readonly McpProviderTemplate[] = DEFAULT_MCP_PROVIDER_TEMPLATES,
 ): McpProviderTemplate | undefined {
-  return templates.find((template) => template.id === provider)
+  const template = templates.find((template) => template.id === provider)
+  if (template && template.id === "user-registered" && !isValidUserRegisteredTemplate(template)) return undefined
+  return template
 }
 
 export const MCP_TOOL_NAME_PATTERN = /^[A-Za-z0-9_.:-]{1,128}$/

--- a/plugins/boring-mcp/src/shared/index.ts
+++ b/plugins/boring-mcp/src/shared/index.ts
@@ -16,10 +16,21 @@ export const MCP_ERROR_CODES = {
   SECRET_LEAK_GUARD: "MCP_SECRET_LEAK_GUARD",
   INPUT_INVALID: "MCP_INPUT_INVALID",
   RESOURCE_URI_INVALID: "MCP_RESOURCE_URI_INVALID",
+  USER_REGISTERED_SOURCE_DISABLED: "MCP_USER_REGISTERED_SOURCE_DISABLED",
+  USER_REGISTERED_ENDPOINT_SCHEME_INVALID: "MCP_USER_REGISTERED_ENDPOINT_SCHEME_INVALID",
+  USER_REGISTERED_ENDPOINT_HOST_BLOCKED: "MCP_USER_REGISTERED_ENDPOINT_HOST_BLOCKED",
+  USER_REGISTERED_ENDPOINT_CREDENTIALS_INVALID: "MCP_USER_REGISTERED_ENDPOINT_CREDENTIALS_INVALID",
+  USER_REGISTERED_ENDPOINT_TRANSPORT_INVALID: "MCP_USER_REGISTERED_ENDPOINT_TRANSPORT_INVALID",
 } as const
 
 export type McpErrorCode = (typeof MCP_ERROR_CODES)[keyof typeof MCP_ERROR_CODES]
-export type McpProviderId = "notion" | "airtable" | (string & {})
+/**
+ * "user-registered" is an explicit discriminator for caller-supplied MCP
+ * endpoints (see {@link McpUserRegisteredSourceConfig}), distinct from the
+ * untyped `(string & {})` escape hatch used for forward-compatible provider
+ * ids. It never appears in {@link DEFAULT_MCP_PROVIDER_TEMPLATES}.
+ */
+export type McpProviderId = "notion" | "airtable" | "user-registered" | (string & {})
 export type McpTransport = "streamable-http"
 export type McpSourceStatus = "connected" | "expired" | "revoked" | "error" | "unconfigured"
 export type McpToolRisk = "read" | "write" | "admin" | "unknown"
@@ -257,6 +268,142 @@ export const AIRTABLE_MCP_TEMPLATE: McpProviderTemplate = {
 }
 
 export const DEFAULT_MCP_PROVIDER_TEMPLATES = [NOTION_MCP_TEMPLATE, AIRTABLE_MCP_TEMPLATE] as const
+
+/**
+ * A user-supplied MCP server registration. This is the escape hatch for
+ * endpoints outside {@link DEFAULT_MCP_PROVIDER_TEMPLATES} — no credential
+ * value ever lives here (see plan #1011: credential custody is a separate,
+ * currently-blocked slice). `headerNames` only records which header keys the
+ * transport should attach at call time from wherever credentials eventually
+ * come from.
+ *
+ * `enabled` is a required, explicit opt-in: {@link createUserRegisteredMcpProviderTemplate}
+ * default-denies (`USER_REGISTERED_SOURCE_DISABLED`) unless it is `true`. A
+ * user-registered source is never admitted implicitly.
+ */
+export interface McpUserRegisteredSourceConfig {
+  enabled: boolean
+  endpoint: string
+  displayName: string
+  transport?: McpTransport
+  headerNames?: string[]
+  allowedTools?: string[]
+  deniedTools?: string[]
+  allowedResourceUriPrefixes?: string[]
+}
+
+const BLOCKED_HOSTNAME_SUFFIXES = [".local", ".internal", ".localhost"]
+const BLOCKED_HOSTNAME_EXACT = new Set(["localhost", "metadata.google.internal"])
+
+function ipv4OctetsFromHostname(hostname: string): number[] | undefined {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname)
+  if (!match) return undefined
+  const octets = match.slice(1, 5).map(Number)
+  return octets.every((octet) => octet >= 0 && octet <= 255) ? octets : undefined
+}
+
+function isBlockedIpv4(octets: number[]): boolean {
+  const [a, b] = octets
+  if (a === 127) return true // loopback
+  if (a === 10) return true // private
+  if (a === 0) return true // "this network"
+  if (a === 169 && b === 254) return true // link-local + cloud metadata service (169.254.169.254)
+  if (a === 172 && b >= 16 && b <= 31) return true // private
+  if (a === 192 && b === 168) return true // private
+  if (a === 100 && b >= 64 && b <= 127) return true // carrier-grade NAT
+  return false
+}
+
+function isBlockedIpv6(hostname: string): boolean {
+  const normalized = hostname.replace(/^\[|\]$/g, "").toLowerCase()
+  if (normalized === "::1") return true // loopback
+  if (normalized === "::") return true
+  if (normalized.startsWith("fe80:")) return true // link-local
+  if (normalized.startsWith("fc") || normalized.startsWith("fd")) return true // unique local
+  if (normalized.startsWith("::ffff:")) {
+    const embedded = ipv4OctetsFromHostname(normalized.slice("::ffff:".length))
+    if (embedded && isBlockedIpv4(embedded)) return true
+  }
+  return false
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase()
+  if (BLOCKED_HOSTNAME_EXACT.has(lower)) return true
+  if (BLOCKED_HOSTNAME_SUFFIXES.some((suffix) => lower.endsWith(suffix))) return true
+  const ipv4 = ipv4OctetsFromHostname(lower)
+  if (ipv4) return isBlockedIpv4(ipv4)
+  if (lower.includes(":")) return isBlockedIpv6(lower)
+  return false
+}
+
+/**
+ * SSRF-safe validation for a user-registered MCP endpoint. Enforces:
+ * https-only, no credentials embedded in the URL, and a blocklist covering
+ * loopback / link-local / private-network / cloud-metadata-service hosts.
+ * Throws {@link McpError} with a stable code per rejection reason.
+ */
+export function validateUserRegisteredMcpEndpoint(endpoint: string, transport?: McpTransport): URL {
+  if (transport && transport !== "streamable-http") {
+    throw new McpError(
+      MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_TRANSPORT_INVALID,
+      "User-registered MCP sources only support the streamable-http transport",
+    )
+  }
+  let url: URL
+  try {
+    url = new URL(endpoint)
+  } catch {
+    throw new McpError(MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_SCHEME_INVALID, "Invalid MCP endpoint URL")
+  }
+  if (url.protocol !== "https:") {
+    throw new McpError(
+      MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_SCHEME_INVALID,
+      "User-registered MCP endpoints must use https",
+    )
+  }
+  if (url.username || url.password) {
+    throw new McpError(
+      MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_CREDENTIALS_INVALID,
+      "User-registered MCP endpoints must not embed credentials in the URL",
+    )
+  }
+  if (isBlockedHostname(url.hostname)) {
+    throw new McpError(
+      MCP_ERROR_CODES.USER_REGISTERED_ENDPOINT_HOST_BLOCKED,
+      "User-registered MCP endpoint host is not allowed (loopback, link-local, private, or metadata-service address)",
+    )
+  }
+  return url
+}
+
+/**
+ * Builds a {@link McpProviderTemplate} for a user-registered source. This is
+ * the plugin's single admission point for the escape hatch: it is
+ * default-deny (throws `USER_REGISTERED_SOURCE_DISABLED` unless
+ * `config.enabled === true`) and always runs the endpoint through
+ * {@link validateUserRegisteredMcpEndpoint} before returning a template,
+ * regardless of caller. It never mutates {@link DEFAULT_MCP_PROVIDER_TEMPLATES}.
+ */
+export function createUserRegisteredMcpProviderTemplate(config: McpUserRegisteredSourceConfig): McpProviderTemplate {
+  if (!config.enabled) {
+    throw new McpError(
+      MCP_ERROR_CODES.USER_REGISTERED_SOURCE_DISABLED,
+      "User-registered MCP sources must be explicitly enabled",
+    )
+  }
+  const url = validateUserRegisteredMcpEndpoint(config.endpoint, config.transport)
+  return {
+    id: "user-registered",
+    displayName: config.displayName,
+    endpoint: url.toString(),
+    transport: "streamable-http",
+    readOnlyDefault: true,
+    allowedTools: config.allowedTools ?? [],
+    deniedTools: config.deniedTools ?? ["create_*", "update_*", "delete_*", "publish_*", "admin_*"],
+    allowedResourceUriPrefixes: config.allowedResourceUriPrefixes,
+  }
+}
 
 export function getMcpProviderTemplate(
   provider: string,


### PR DESCRIPTION
## Summary

- Adds `"user-registered"` as an explicit `McpProviderId` discriminator in `plugins/boring-mcp/src/shared/index.ts`, distinct from the untyped `(string & {})` escape hatch. `DEFAULT_MCP_PROVIDER_TEMPLATES` is untouched — still only Notion + Airtable.
- `createUserRegisteredMcpProviderTemplate(config)` is the plugin's intended admission point for the escape hatch. It is **default-deny**: throws `MCP_USER_REGISTERED_SOURCE_DISABLED` unless `config.enabled === true` — a user-registered source is never admitted implicitly.
- `validateUserRegisteredMcpEndpoint(endpoint, transport)` is a **syntactic pre-filter, NOT an SSRF control** (downgraded language, see security fix round below):
  - https-only (`MCP_USER_REGISTERED_ENDPOINT_SCHEME_INVALID`)
  - rejects credentials embedded in the URL (`MCP_USER_REGISTERED_ENDPOINT_CREDENTIALS_INVALID`)
  - rejects non-streamable-http transport (`MCP_USER_REGISTERED_ENDPOINT_TRANSPORT_INVALID`)
  - blocks loopback / link-local / private-network (10.x, 172.16-31.x, 192.168.x, CGNAT 100.64/10) / cloud-metadata-service (169.254.169.254) / `.local`/`.internal`/`.localhost` hostnames, IPv4 and IPv6, including IPv4-mapped IPv6 in both dotted-quad and WHATWG-URL-normalized hex-word spellings, the full fe80::/10 and fec0::/10 ranges, NAT64, and 6to4-encoded loopback (`MCP_USER_REGISTERED_ENDPOINT_HOST_BLOCKED`)
  - it never resolves DNS and cannot see redirects — see the security fix round below for what this does and does not cover.

## Security fix round (adversarial review, addressed on this branch)

**Fixed:**
- **S1 (critical):** `::ffff:7f00:1` and other IPv4-mapped IPv6 hex-word literals (the form the WHATWG URL parser normalizes dotted-quad mapped addresses to) bypassed the blocklist entirely, making every private/metadata IPv4 address reachable via its IPv6-mapped spelling. Fixed by recovering the embedded IPv4 address from both dotted-quad and hex-word forms and running it through the same `isBlockedIpv4` check.
- **S4:** `localhost.` (trailing root dot) bypassed the exact/suffix hostname blocklist. Fixed by stripping a single trailing root dot before all hostname checks.
- **S5:** IPv6 link-local matching only caught the literal `fe80:` prefix, missing the rest of the `fe80::/10` range (e.g. `febf::1`) and the deprecated `fec0::/10` site-local range. Fixed with proper first-hextet range checks; also added NAT64 (`64:ff9b::/96`) and 6to4-encoded-loopback (`2002:7f00:1::`) detection.
- **Admission bypass:** `McpProviderTemplate` is a plain structural type, so a caller could hand-construct `{ id: "user-registered", endpoint: "https://127.0.0.1/x" }` and skip `createUserRegisteredMcpProviderTemplate` (and its validation) entirely at every consumption point (`getMcpProviderTemplate`, `readonlyCall.ts`, `toolCatalog.ts`, `managedConnectorAdapter.ts`). Fixed with a runtime guard in `getMcpProviderTemplate` (the shared lookup all consumption points already call): any template with id `"user-registered"` is re-validated against the endpoint blocklist and silently dropped (`undefined`) if it doesn't pass. Chose the runtime-guard approach over branding the `McpProviderTemplate` interface because branding would ripple across every template construction/clone site; documented on `createUserRegisteredMcpProviderTemplate`.
- **Redirect SSRF (partial):** `mcpSdkTransport.ts`'s `StreamableHTTPClientTransport` used fetch's default `redirect: "follow"`, so a validated `https://` endpoint could 302 to a private/metadata address and the transport would follow it with auth headers attached. Fixed by setting `requestInit.redirect = "error"` for sources whose provider is `"user-registered"`, so a redirect now fails the request instead of being silently followed.

**Downgraded claims (honesty pass), not fixed on this branch:**
- The validator's doc comment, and this PR description, no longer call `validateUserRegisteredMcpEndpoint` "SSRF-safe." It is a syntactic pre-filter on the literal endpoint string only. It never resolves DNS, so an attacker-controlled DNS record (e.g. `127.0.0.1.nip.io`, or a DNS-rebinding host) passes the filter unchanged and reaches a private address at connect time.
- The `redirect: "error"` fix stops a *redirect* from reaching a private address, but does **not** stop a first-hop connection to an attacker-controlled hostname that resolves (via DNS, not URL text) to a private/metadata IP. Real connect-time enforcement — resolve-then-pin the IP before connecting, or route through an egress allowlist/proxy — is tracked as a follow-up and **must land before any user-registered MCP source is admitted in an environment that can reach production networks or a cloud metadata service**: see bead `wt-391-forward-1011-connect-time-ssrf-x35` (external ref `gh-1011-ssrf`), referenced in code comments in `shared/index.ts` and `mcpSdkTransport.ts`.

## Deferred (per plan #1011, not this slice)

- Per-server credential storage — blocked on BYOK lane #1010; `McpUserRegisteredSourceConfig` only records `headerNames` (which headers to attach), never values.
- Wiring `mcpServerRefs` / per-agent grants through the #1087 grant seam (in flight) — this slice doesn't resolve a user-registered source into any live connection yet, only the type + validation.
- Workspace MCP pane UI.
- Composio-style catalogs (#900's territory; #937 stays reverted per #946).
- Connect-time SSRF enforcement (resolve-then-pin or egress allowlist/proxy) — see bead `wt-391-forward-1011-connect-time-ssrf-x35` above.

## Test plan

- [x] `pnpm --filter @hachej/boring-mcp test` — `src/__tests__/shared.test.ts` and `src/__tests__/mcpSdkTransport.test.ts` cover: default-deny when not enabled, valid https endpoint accepted, all prior rejections, plus new coverage for the security fix round: IPv4-mapped IPv6 in both dotted-quad and hex-word spellings (loopback, cloud metadata, private 10.x/192.168.x), trailing-root-dot `localhost.`, `fe80::/10` upper range, `fec0::/10`, NAT64, 6to4-encoded loopback, the `getMcpProviderTemplate` admission-bypass guard (both a rejected hand-crafted template and an accepted validated one), and a redirect-to-metadata-service transport test asserting the request fails rather than following.
- [x] Verified each new bypass test fails against the pre-fix code and passes after, via `git stash` isolating the source fix from the new tests.
- [x] 121/121 tests pass in the touched plugin (108 pre-existing/prior-round + 13 new). Two unrelated suites (`agentTools.test.ts`, `appServerBinding.test.ts`) fail both before and after this change due to pre-existing missing built workspace/core dist artifacts and a fastify version mismatch in this environment — confirmed via `git stash` diff, unrelated to this change.
- [x] `tsc --noEmit` — confirmed the same 25 pre-existing fastify version-duplication errors (all in `appServerBinding.ts`) exist before and after this change (via `git stash`); none reference the touched files (`shared/index.ts`, `mcpSdkTransport.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1HtxZAQUmLXhaZmL3sEH4
