### PR TITLE
docs(1082): BYOK plan r3 + key-scope decision memo [owner gate]

### DIFF
--- a/docs/issues/1082/key-scope-decision.md
+++ b/docs/issues/1082/key-scope-decision.md
@@ -1,0 +1,72 @@
+# Decision memo — DEK scope: per-workspace vs per-seat
+
+**Issue:** gh-1082 · **Date:** 2026-08-07 · **Decide before:** rotation slice (S2)
+**Context:** #1132 ships one DEK per workspace, keyed `(workspaceId, dekGeneration)`,
+shared across all providers/credentials in that workspace. Fleets (#1114) give each
+workspace five tier-differentiated seats. Question: should the DEK instead be scoped
+per seat?
+
+## Recommendation: keep the per-workspace DEK. Do not introduce per-seat DEKs.
+
+The DEK is a **storage-encryption** key; it is not, and should not become, an
+**authorization** boundary. Everything a per-seat DEK appears to buy is already
+provided — or better provided — elsewhere in the ratified design.
+
+### Threat model, option by option
+
+**Cross-seat credential reuse.** Not a threat — it is the product. Decision 27 and
+16f.3 define one active credential per `(workspaceId, providerId)`; all five seats of
+a workspace are *supposed* to spend the same workspace key. Per-seat DEKs cannot
+prevent misuse of a credential that is deliberately shared; the control point for
+"which consumer may use which field over which channel" is the consumer-binding
+registry and lease resolver (16f.1), which already enforces this per binding, with
+`CREDENTIAL_CONSUMER_MISMATCH` / `CREDENTIAL_DELIVERY_FORBIDDEN` on violation.
+
+**Blast radius on seat compromise.** Seats run in sandboxes and — under the
+ratified Tier-1 model (host-side resolution, planned in S6; the shipped 16f.1
+host resolver already enforces host-only delivery) — **never hold the DEK, the
+KEK, or even the credential plaintext**; the secret never enters the sandbox. A compromised seat
+gets exactly the leases the host resolver grants that seat's bindings, and that is
+identical under either key scope. Per-seat DEKs shrink nothing here; they only add
+key-management surface. The keys' real blast-radius boundary is the host process,
+and that is governed by KEK custody (local file vs remote KMS — a separate, already
+ratified axis), not by DEK fan-out.
+
+**Crypto-shred granularity vs operational complexity.** The shred unit should match
+the data unit. Credential rows are per `(workspaceId, providerId)`; per-workspace
+DEK rotation-then-destroy (S2) shreds a tenant cleanly in one operation. A per-seat
+DEK gives a shred granularity — "seat 3's view" — that corresponds to no stored
+object, while multiplying wrapped-DEK rows ×5, giving rotation five independent
+generation counters per workspace, five rewrap paths on KEK rotation, and five ways
+for the "record exists but key generation missing" fail-closed state to occur.
+That is pure operational cost with no matching data boundary.
+
+### Interaction with AAD and dekGeneration
+
+The AAD (`workspaceId:credentialId:providerId:fieldId:credentialVersion:dekGeneration`)
+contains **no seat identity**, and the wrapped-DEK AAD binds `(workspaceId,
+dekGeneration)`. Per-workspace scoping is therefore what the ciphertext already
+cryptographically asserts. Per-seat DEKs would require a seat component in both AAD
+contexts — a new AAD encoding version, a new wrapped-DEK context, and re-encryption
+of every existing envelope — and S2's rotation design would need per-seat generation
+tracking before it is even built. Deciding per-workspace *now* lets S2 proceed on the
+shipped AAD unchanged.
+
+### If a real seat-scoped need appears later
+
+The plausible future ask (r1 Q2: a Seneca-style tenant wanting a cheap key for
+T4/Haiku and a premium key for T1/Fable) is a **different credential**, not a
+different encryption key. Model it as seat/tier-qualified credential *profiles*:
+`credentialId` (already AAD-bound) or a tier-qualified provider profile row under
+the same workspace DEK. That is an additive schema + resolver-selection change —
+no AAD version bump, no re-encryption, no rotation redesign. Migration cost of that
+path later: **low** (new rows, new selection rule). Migration cost of switching to
+per-seat DEKs later: **moderate but bounded** — a full decrypt/re-encrypt per
+workspace, which is exactly the machinery S2 builds anyway, so we are not painting
+ourselves into a corner by deciding per-workspace today.
+
+### Decision asked of the owner
+
+Ratify: **per-workspace DEK stands; seat/tier key differentiation, if ever needed,
+ships as credential profiles under the same DEK.** Rejecting this means pausing S2
+and re-opening the AAD contract before any rotation work.

--- a/docs/issues/1082/plan.md
+++ b/docs/issues/1082/plan.md
@@ -1,0 +1,219 @@
+---
+github: https://github.com/hachej/boring-ui/issues/1082
+issue: 1082
+state: ready-for-human
+updated: 2026-08-07
+revision: r3
+flag: not-needed
+track: owner
+---
+
+# gh-1082 BYOK tenant keys — plan r3 (post-#1132)
+
+Revision of the r1 draft (branch `docs/1082-byok-plan`, commit `5ebcd2422`)
+now that **PR #1132 ([16f.2] KmsBackend + local-KEK envelope crypto) is open
+and implements the crypto core**. This revision replans only what remains.
+r3 folds the adversarial review of r2: external rollback anchor (S1),
+envelope deletion port ops (S1), authenticated store pointer + dual-read
+write rules (S8), S3 shipping dependency.
+Companion decision memo: [`key-scope-decision.md`](key-scope-decision.md)
+(per-workspace vs per-seat DEK scoping — owner decision required before the
+rotation slice).
+
+## What #1132 already delivers (verified against the PR diff)
+
+`packages/agent/src/server/credentials/vault/`:
+
+- `envelopeCrypto.ts` — AES-256-GCM field envelopes, 12-byte random nonce,
+  16-byte tag, canonical **length-prefixed** AAD
+  (`workspaceId:credentialId:providerId:fieldId:credentialVersion:dekGeneration`,
+  versioned prefix, no boundary ambiguity), constant-time AAD compare,
+  code-only errors (`CREDENTIAL_UNREADABLE`, never "absent").
+- `kmsBackend.ts` — `WorkspaceKekProviderV1` local-KEK implementation:
+  sealed 32-byte KEK file (explicit env selection, no plaintext-env default,
+  never `WORKSPACE_SETTINGS_ENCRYPTION_KEY`), wrap/unwrap/rewrap of the
+  per-workspace DEK with workspace+generation-bound AAD, readiness reporting,
+  best-effort buffer zeroing.
+- `vaultStoreBackend.ts` — composes KmsBackend + envelope crypto + an
+  **injectable persistence port** into the `CredentialStoreBackendV1` the
+  existing host resolver consumes. Every `writeCredentialFields` mints a fresh
+  `credentialVersion`; `rewrapWorkspaceDek` rotates KEK wrapping in place.
+- `persistence.ts` / `inMemoryPersistence.ts` — port + in-memory impl.
+  **Postgres persistence is explicitly out of scope of #1132.**
+- 700+ lines of conformance tests: tamper/swap/cross-workspace/cross-backend
+  fail-closed proofs, no-secret-in-errors proofs, end-to-end through the
+  frozen 16f.1 contract (`createHostSideCredentialResolverV1`,
+  `withResolvedCredential`).
+
+Known, filed gaps from the #1132 crypto review (beads):
+
+- `wt-391-forward-byok-version-rollback-0th` (gh-1082-f1): AAD binds *which
+  version a row is*, not *which version is current* — a DB-write attacker can
+  point `record.credentialVersion` back at a rotated-away (leaked) version and
+  it decrypts cleanly. Rotate-after-leak is not cryptographically durable.
+- `wt-391-forward-byok-dek-rotation-fil` (gh-1082-f2): `dekGeneration` is
+  always `existing ?? 1`; nothing increments it. The per-workspace crypto-shred
+  lever currently depends entirely on destroying the KMS key; nonce-space never
+  resets (safe at realistic volume, but unbounded DEK lifetime).
+
+## Today vs delta
+
+| | Today (with #1132 merged) | Delta to v1 BYOK |
+|---|---|---|
+| Envelope crypto + local-KEK backend | Done (#1132) | — |
+| Persistence | In-memory port impl only | Postgres schema/store behind the same port (S1) |
+| Rollback prevention | AAD version binding only; current-version pointer unauthenticated | Monotonic authenticated current-version marker (S1, gh-1082-f1) |
+| DEK rotation | KEK rewrap only; `dekGeneration` frozen at 1 | Generation bump + field re-encrypt + old-generation destruction (S2, gh-1082-f2) |
+| Provider registry wiring | Test-only registries constructed in tests | Startup registry (Anthropic + Tavily/Firecrawl/Deepgram), backend selector, server wiring (S3) |
+| Credential UI | None | Owner-only "Providers & credentials" surface, API-key write-only forms (S4, 16f.3 subset) |
+| Fleet/seat interaction | `resolveSeatModel()` reads instance `process.env` only | Workspace-scoped key presence in tier resolution (S5, 16f.8 / wt-391-forward-703w) |
+| First-party proxy tools | Operator keys only | Tier-1 host-side per-workspace resolution (S6, 16f.5) |
+| MCP credentials | Separate `__serverBoringMcpSourcesV1` | Migrate onto shared mechanism (S7, 16f.4) |
+| Legacy key migration | N/A | Off `WORKSPACE_SETTINGS_ENCRYPTION_KEY` for credential rows (S8, 16f.7) |
+
+## Remaining slices (ordered)
+
+### S1 — Postgres persistence + external rollback anchor + envelope deletion
+**Beads:** new (Postgres pass) + `wt-391-forward-byok-version-rollback-0th`
+**Blocked by:** #1132 merge.
+Implement `CredentialVaultPersistenceV1` on Postgres (3 tables matching the
+ratified model: credential record, wrapped DEK, field envelopes), plus two
+gaps the r2 review surfaced:
+
+**Rollback prevention (gh-1082-f1).** A MAC-under-DEK current-version marker
+is *not* sufficient: an attacker with DB write access replays a full snapshot
+(old row + its validly-MACed marker together), and store-level monotonic
+checks are bypassed by direct DB writes. The anchor must live **outside
+attacker-writable storage**: a monotonic current-version counter per
+workspace held in the KEK-provider/KMS context (one integer per workspace —
+for local-KEK, in the operator-owned sealed mount beside the KEK; for a
+remote KMS backend, in KMS-side context/metadata). Reads verify the record's
+`credentialVersion` against the external counter; a snapshot replay then
+presents a stale counter value and fails as `CREDENTIAL_UNREADABLE`. No
+per-record MAC mini-envelope — with the external counter it is pure surface.
+**Honest framing:** the counter *narrows* the window (the current version is
+authenticated), but old ciphertext an attacker exfiltrated before rotation is
+only made cryptographically dead by S2's generation-destroy. S1 narrows;
+S2 closes.
+
+**Envelope deletion (r2 finding 2).** The #1132 port has no delete
+operations, so superseded field envelopes and old wrapped DEKs live forever —
+retained replay material, and S2's generation-destroy is impossible. Extend
+`CredentialVaultPersistenceV1` in this pass: delete/tombstone superseded
+credential-version field envelopes on successful rotation to a new version,
+and `deleteWrappedDek(workspaceId, dekGeneration)` for S2. Tombstones record
+metadata (version, deleted-at, reason) — never ciphertext.
+
+**Proof:** #1132's conformance suite re-run against Postgres persistence;
+snapshot-replay test (old row + old marker restored wholesale → fail closed);
+superseded-version envelopes verified absent from the store after a
+successful new-version write.
+
+### S2 — DEK-generation rotation (crypto-shred lever)
+**Bead:** `wt-391-forward-byok-dek-rotation-fil`
+**Blocked by:** S1 (needs durable persistence + the authenticated marker so
+rotation state itself cannot be rolled back) **and the key-scope decision**
+(rotation machinery is per-key-scope; don't build it twice).
+Owner-triggered + operator-triggered `rotateWorkspaceDek(workspaceId)`:
+mint generation N+1, re-encrypt all live field envelopes under the new DEK
+(new AAD `dekGeneration`), atomically bump record `dekGeneration`, then
+destroy generation-N wrapped-DEK rows after verification. Crypto-shred =
+rotate-then-destroy without re-encrypting (deliberate data loss path, owner
+confirmation required).
+**Proof:** post-rotation reads succeed; generation-N ciphertext no longer
+decryptable via the store; interrupted-rotation recovery (idempotent resume);
+shred leaves `CREDENTIAL_UNREADABLE`, never a plaintext residue or fallback.
+
+### S3 — Provider registry + backend selector wiring
+**Bead:** part of 16f.3 scope, server side.
+Startup provider registry (Anthropic model key first; Tavily/Firecrawl/
+Deepgram definitions), consumer bindings, KMS backend selection from env
+(local-KEK now; OVH-KMS provider is a follow-up implementation of the same
+`WorkspaceKekProviderV1` port — owner Q1 from r1 stands), owner-only CRUD
+routes (create/replace/disable/revoke/delete; masked last-4 metadata reads
+only, no plaintext read API). Instance-fallback tombstone semantics per
+Decision 27.
+**Dependency note:** S3 builds against the `CredentialVaultPersistenceV1`
+port (in-memory impl) now and can proceed in parallel, but ships to
+production only after S1's schema lands — the disable/revoke tombstone state
+S3 depends on is defined by S1's schema work.
+**Proof:** route tests — role gating, no secret in any GET/list/status
+response, disable/revoke tombstone suppresses instance fallback.
+
+### S4 — Front-end credential UI
+**Bead:** 16f.3 (UI subset; API-key only, **OAuth deferred** — owner Q3
+from r1: v1 providers are all API-key, OAuth is 16f.3's highest-complexity
+part and not needed for the motivating model-key case).
+Owner-only "Providers & credentials" workspace settings surface: provider
+list from registry, write-only key form, last-4 + status + version +
+connected-at display, disable/revoke/replace actions, fallback-state
+indicator.
+**Proof:** SettingsSurface tests; no credential value ever present in any
+front-end store, prop, or network response.
+
+### S5 — Fleet-seat integration (workspace-key tier resolution)
+**Bead:** `wt-391-forward-703w` (16f.8).
+Extend `resolveSeatModel()` / `MODEL_TIER_CANDIDATES` in
+`loadConfiguredAgentFleet.ts` to consult workspace-scoped credential presence
+(via the resolver) alongside instance env. Precedence: explicit workspace key
+> instance-fallback-enabled state > unavailable. Per the key-scope memo's
+recommendation, seat/tier key differentiation (if ever wanted) arrives as
+distinct credential profiles, not as a resolver fork.
+**Proof:** fleet-compile tests — workspace key unlocks a tier the instance
+lacks; keyless workspace behaves exactly as today; revoked key never silently
+falls back.
+
+### S6 — First-party proxy tools, Tier-1 host-side (16f.5)
+Unchanged from r1. **Blocked by:** S3.
+
+### S7 — MCP generalization onto shared mechanism (16f.4)
+Unchanged from r1 (consent-quarantine, amendment E, no auto-promotion).
+**Blocked by:** S3/S4.
+
+### S8 — Migration off `WORKSPACE_SETTINGS_ENCRYPTION_KEY` (16f.7)
+Core mechanics unchanged from r1 (decrypt-once/re-encrypt/verify/
+switch-pointer per (workspace, provider), rollback restores the previous safe
+path only, retirement gated on backup retention + owner approval), with two
+r3 specifications:
+
+- **Authenticated store pointer.** The which-store-is-authoritative pointer
+  is itself a downgrade lever: a DB-write attacker who flips it back to
+  "legacy" re-routes reads through `WORKSPACE_SETTINGS_ENCRYPTION_KEY`
+  ciphertext. The pointer must be covered by S1's external rollback anchor
+  (fold pointer state into the per-workspace counter context), so a flipped
+  pointer fails `CREDENTIAL_UNREADABLE` rather than silently downgrading.
+  Legitimate rollback goes through the anchored path, not a raw DB write.
+- **Dual-read-window write rules.** Between re-encrypt and pointer switch,
+  writes are forbidden on the legacy path: the migration marks the
+  (workspace, provider) entry migration-locked before re-encrypting; a
+  legacy-path write attempt during the window fails visibly (retryable
+  error), never lands silently in a store about to stop being read. After
+  the pointer switch, all writes go to the vault store only — no dual-write,
+  ever.
+
+**Blocked by:** S1 (schema, anchor, deletion port).
+
+## Non-goals
+
+- Reopening Decision 27 (BYOK-per-workspace policy) or platform-billed pooled
+  keys (#809/BL1, pending #819 metering).
+- Tier-2 in-sandbox credential delivery (16f.6) — still deferred behind the
+  hostile-test harness + red-team pass.
+- OAuth provider flows (PKCE, refresh rotation) — deferred out of v1 with the
+  error codes already reserved (`CREDENTIAL_OAUTH_*`).
+- Multi-profile-per-provider — one active credential per
+  `(workspaceId, providerId)` stands; the key-scope memo shows how seat-tier
+  profiles would extend this *without* a crypto change if ever ratified.
+- Self-run Vault/OpenBao Transit as a shipped backend (optional alternative
+  only; the `vault-transit-ciphertext.v1` wrapped-DEK format is reserved).
+- OVH-KMS backend implementation is **scheduled but not specced here** — it is
+  a second `WorkspaceKekProviderV1` implementation, gated on owner Q1 (r1).
+
+## Owner decisions needed
+
+1. **Key scope** — decide from [`key-scope-decision.md`](key-scope-decision.md)
+   (blocks S2).
+2. r1's Q1 (local-KEK-first vs OVH-KMS-first for production) and Q4
+   (instance-fallback default for existing workspaces at S8 migration time)
+   remain open; Q3 (OAuth) and Q5 (separate fleet bead) are resolved in this
+   revision (deferred; separate bead `wt-391-forward-703w`).


### PR DESCRIPTION
Two documents for one gate:

1. **key-scope-decision.md** (1 page) — decide per-workspace vs per-seat DEK. Recommendation: **keep per-workspace** (DEK is storage encryption, not an authorization boundary; seats spend credentials via leases, never read them; no lock-in — switching later reuses S2's rotation machinery). Survived adversarial review.
2. **plan.md r3** — 8 slices post-#1132 (rotation, rollback with external monotonic anchor, provider registry, credential UI, fleet integration, legacy migration).

Related: PR #1132 (implementation this plan builds on) has a passed crypto audit and can merge with this gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F15mxaqthycNkk8o9FDLfC