### PR TITLE
chore(boring-bash): remove tenant fs names from generic shared types

### DIFF
--- a/packages/boring-bash/src/server/__tests__/companyContextFixture.ts
+++ b/packages/boring-bash/src/server/__tests__/companyContextFixture.ts
@@ -1,0 +1,32 @@
+import type { FilesystemId } from "../../shared/index";
+import {
+  FixtureExternalContextBindingProvider,
+  seedExternalContextFixture,
+  type ExternalContextFixtureFile,
+  type ExternalContextFixturePreparedHandle,
+  type ExternalContextFixtureProviderOptions,
+} from "../testing/externalContextFixtureProvider";
+
+export const COMPANY_CONTEXT_FILESYSTEM_ID = "company_context" satisfies FilesystemId;
+export const COMPANY_CONTEXT_SENTINEL = "FORBIDDEN_FINANCE_SECRET_123";
+
+export const DEFAULT_COMPANY_CONTEXT_FIXTURE_FILES: readonly ExternalContextFixtureFile[] = [
+  { path: "/company/hr/policy.md", content: "# HR policy\nVacation and onboarding policies.\n" },
+  { path: "/company/hr/onboarding.md", content: "# Onboarding\nWelcome to the company.\n" },
+  { path: "/company/finance/budget.md", content: `# Finance budget\n${COMPANY_CONTEXT_SENTINEL}\n` },
+  { path: "/company/legal/contract.md", content: "# Legal contract\nStandard terms.\n" },
+];
+
+export type CompanyContextFixturePreparedHandle = ExternalContextFixturePreparedHandle;
+
+export class FixtureCompanyContextBindingProvider extends FixtureExternalContextBindingProvider {
+  constructor(options: Omit<ExternalContextFixtureProviderOptions, "filesystemId"> & { filesystemId?: FilesystemId }) {
+    super({ ...options, filesystemId: options.filesystemId ?? COMPANY_CONTEXT_FILESYSTEM_ID });
+  }
+}
+
+export async function seedCompanyContextFixture(root: string): Promise<void> {
+  await seedExternalContextFixture(root, DEFAULT_COMPANY_CONTEXT_FIXTURE_FILES);
+}
+
+export { listFixtureProjectionFiles, readFixtureProjectionFile } from "../testing/externalContextFixtureProvider";

--- a/packages/boring-bash/src/server/__tests__/fixtureCompanyContextProvider.test.ts
+++ b/packages/boring-bash/src/server/__tests__/fixtureCompanyContextProvider.test.ts
@@ -12,7 +12,7 @@ import {
   listFixtureProjectionFiles,
   readFixtureProjectionFile,
   seedCompanyContextFixture,
-} from "../testing/companyContextFixtureProvider";
+} from "./companyContextFixture";
 
 const ctx: BoundFilesystemContext = {
   humanUserId: "human-1",
@@ -129,6 +129,6 @@ describe("FixtureCompanyContextBindingProvider", () => {
       resolvePolicy: () => ({ allowedPathPrefixes: ["/company/hr"] }),
     });
 
-    await expect(provider.prepareBinding(ctx, readonlyBinding)).rejects.toThrow("escapes company context root");
+    await expect(provider.prepareBinding(ctx, readonlyBinding)).rejects.toThrow("escapes external context root");
   });
 });

--- a/packages/boring-bash/src/server/__tests__/managementCompanyContextOperations.test.ts
+++ b/packages/boring-bash/src/server/__tests__/managementCompanyContextOperations.test.ts
@@ -5,16 +5,19 @@ import { tmpdir } from "node:os";
 import { describe, expect, test } from "vitest";
 
 import type { BoundFilesystemContext, FilesystemBinding, FilesystemBindingResolver } from "../../shared/index";
-import type { CompanyContextFixturePreparedHandle, FilesystemRuntimeLifecycleEvent } from "../index";
+import type { FilesystemRuntimeLifecycleEvent } from "../index";
+import {
+  ScopedFilesystemRuntimeBindingManager,
+  createManagementProjectionOperations,
+  createReadonlyProjectionOperations,
+} from "../index";
 import {
   COMPANY_CONTEXT_FILESYSTEM_ID,
   COMPANY_CONTEXT_SENTINEL,
   FixtureCompanyContextBindingProvider,
-  ScopedFilesystemRuntimeBindingManager,
-  createManagementProjectionOperations,
-  createReadonlyProjectionOperations,
   seedCompanyContextFixture,
-} from "../index";
+  type CompanyContextFixturePreparedHandle,
+} from "./companyContextFixture";
 
 const readonlyBinding: FilesystemBinding = {
   filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,

--- a/packages/boring-bash/src/server/__tests__/readonlyCompanyContextE2e.test.ts
+++ b/packages/boring-bash/src/server/__tests__/readonlyCompanyContextE2e.test.ts
@@ -11,7 +11,7 @@ import {
   FixtureCompanyContextBindingProvider,
   listFixtureProjectionFiles,
   seedCompanyContextFixture,
-} from "../testing/companyContextFixtureProvider";
+} from "./companyContextFixture";
 import {
   READONLY_PROJECTION_INVALID_PATH_CODE,
   READONLY_PROJECTION_MUTATION_CODE,
@@ -112,12 +112,12 @@ describe("readonly company_context e2e harness", () => {
   test("unsafe projection fails reusable conformance in the e2e harness", async () => {
     const sourceRoot = await createSourceRoot();
     const unsafeHandle = {
-      kind: "company-context-fixture-projection" as const,
+      kind: "external-context-fixture-projection" as const,
       filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
       sourceRoot,
       projectionRoot: sourceRoot,
       visiblePaths: await listFixtureProjectionFiles({
-        kind: "company-context-fixture-projection",
+        kind: "external-context-fixture-projection",
         filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
         sourceRoot,
         projectionRoot: sourceRoot,

--- a/packages/boring-bash/src/server/__tests__/readonlyCompanyContextLeakage.test.ts
+++ b/packages/boring-bash/src/server/__tests__/readonlyCompanyContextLeakage.test.ts
@@ -13,7 +13,7 @@ import {
   FixtureCompanyContextBindingProvider,
   listFixtureProjectionFiles,
   seedCompanyContextFixture,
-} from "../testing/companyContextFixtureProvider";
+} from "./companyContextFixture";
 import { ReadonlyProjectionOperationError, createReadonlyProjectionOperations } from "../readonlyProjectionOperations";
 
 const execFileAsync = promisify(execFile);

--- a/packages/boring-bash/src/server/__tests__/readonlyCompanyContextOperations.test.ts
+++ b/packages/boring-bash/src/server/__tests__/readonlyCompanyContextOperations.test.ts
@@ -10,7 +10,7 @@ import {
   COMPANY_CONTEXT_SENTINEL,
   FixtureCompanyContextBindingProvider,
   seedCompanyContextFixture,
-} from "../testing/companyContextFixtureProvider";
+} from "./companyContextFixture";
 import {
   READONLY_PROJECTION_INVALID_PATH_CODE,
   READONLY_PROJECTION_MUTATION_CODE,

--- a/packages/boring-bash/src/server/__tests__/readonlyProjectionConformance.test.ts
+++ b/packages/boring-bash/src/server/__tests__/readonlyProjectionConformance.test.ts
@@ -12,7 +12,7 @@ import {
   listFixtureProjectionFiles,
   seedCompanyContextFixture,
   type CompanyContextFixturePreparedHandle,
-} from "../testing/companyContextFixtureProvider";
+} from "./companyContextFixture";
 import { createReadonlyProjectionOperations } from "../readonlyProjectionOperations";
 import { checkReadonlyProjectionConformance, type ReadonlyProjectionConformanceSubject } from "../testing/readonlyProjectionConformance";
 
@@ -90,12 +90,12 @@ describe("readonly projection conformance", () => {
     const sourceRoot = await mkdtemp(join(tmpdir(), "boring-company-unsafe-source-"));
     await seedCompanyContextFixture(sourceRoot);
     const unsafeHandle: CompanyContextFixturePreparedHandle = {
-      kind: "company-context-fixture-projection",
+      kind: "external-context-fixture-projection",
       filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
       sourceRoot,
       projectionRoot: sourceRoot,
       visiblePaths: await listFixtureProjectionFiles({
-        kind: "company-context-fixture-projection",
+        kind: "external-context-fixture-projection",
         filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,
         sourceRoot,
         projectionRoot: sourceRoot,

--- a/packages/boring-bash/src/server/__tests__/runtimeBindingManager.test.ts
+++ b/packages/boring-bash/src/server/__tests__/runtimeBindingManager.test.ts
@@ -12,12 +12,14 @@ import type {
   PreparedFilesystemBinding,
 } from "../../shared/index";
 import {
-  COMPANY_CONTEXT_FILESYSTEM_ID,
-  FixtureCompanyContextBindingProvider,
   ScopedFilesystemRuntimeBindingManager,
   filesystemRuntimeScopeKey,
-  seedCompanyContextFixture,
 } from "../index";
+import {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
+  FixtureCompanyContextBindingProvider,
+  seedCompanyContextFixture,
+} from "./companyContextFixture";
 
 const readonlyBinding: FilesystemBinding = {
   filesystem: COMPANY_CONTEXT_FILESYSTEM_ID,

--- a/packages/boring-bash/src/server/index.ts
+++ b/packages/boring-bash/src/server/index.ts
@@ -1,12 +1,9 @@
 export {
-  COMPANY_CONTEXT_FILESYSTEM_ID,
-  COMPANY_CONTEXT_SENTINEL,
-  DEFAULT_COMPANY_CONTEXT_FIXTURE_FILES,
-  FixtureCompanyContextBindingProvider,
+  FixtureExternalContextBindingProvider,
   listFixtureProjectionFiles,
   readFixtureProjectionFile,
-  seedCompanyContextFixture,
-} from "./testing/companyContextFixtureProvider";
+  seedExternalContextFixture,
+} from "./testing/externalContextFixtureProvider";
 
 export {
   MANAGEMENT_PROJECTION_BINDING_REQUIRED_CODE,
@@ -38,13 +35,13 @@ export type {
 } from "./readonlyProjectionOperations";
 
 export type {
-  CompanyContextFixtureFile,
-  CompanyContextFixturePreparedBinding,
-  CompanyContextFixturePreparedHandle,
-  CompanyContextFixturePreparedLifecycle,
-  CompanyContextFixtureProjectionPolicy,
-  CompanyContextFixtureProviderOptions,
-} from "./testing/companyContextFixtureProvider";
+  ExternalContextFixtureFile,
+  ExternalContextFixturePreparedBinding,
+  ExternalContextFixturePreparedHandle,
+  ExternalContextFixturePreparedLifecycle,
+  ExternalContextFixtureProjectionPolicy,
+  ExternalContextFixtureProviderOptions,
+} from "./testing/externalContextFixtureProvider";
 
 export {
   ScopedFilesystemRuntimeBindingManager,

--- a/packages/boring-bash/src/server/testing/externalContextFixtureProvider.ts
+++ b/packages/boring-bash/src/server/testing/externalContextFixtureProvider.ts
@@ -1,7 +1,7 @@
 import { constants } from "node:fs";
-import { access, chmod, copyFile, lstat, mkdir, mkdtemp, readFile, readdir, realpath } from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { access, chmod, copyFile, lstat, mkdir, mkdtemp, readFile, readdir, realpath, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 
 import type {
   BoundFilesystemContext,
@@ -12,38 +12,29 @@ import type {
   PreparedFilesystemBinding,
 } from "../../shared/index";
 
-export const COMPANY_CONTEXT_FILESYSTEM_ID = "company_context" satisfies FilesystemId;
-export const COMPANY_CONTEXT_SENTINEL = "FORBIDDEN_FINANCE_SECRET_123";
-
-export interface CompanyContextFixtureFile {
+export interface ExternalContextFixtureFile {
   path: string;
   content: string;
 }
 
-export const DEFAULT_COMPANY_CONTEXT_FIXTURE_FILES: readonly CompanyContextFixtureFile[] = [
-  { path: "/company/hr/policy.md", content: "# HR policy\nVacation and onboarding policies.\n" },
-  { path: "/company/hr/onboarding.md", content: "# Onboarding\nWelcome to the company.\n" },
-  { path: "/company/finance/budget.md", content: `# Finance budget\n${COMPANY_CONTEXT_SENTINEL}\n` },
-  { path: "/company/legal/contract.md", content: "# Legal contract\nStandard terms.\n" },
-];
-
-export interface CompanyContextFixtureProjectionPolicy {
+export interface ExternalContextFixtureProjectionPolicy {
   readonly allowedPathPrefixes: readonly string[];
   readonly grantManagementBinding?: boolean;
 }
 
-export interface CompanyContextFixtureProviderOptions {
+export interface ExternalContextFixtureProviderOptions {
+  readonly filesystemId: FilesystemId;
   readonly sourceRoot: string;
   readonly projectionRootParent?: string;
-  readonly resolvePolicy: (ctx: BoundFilesystemContext) => CompanyContextFixtureProjectionPolicy | Promise<CompanyContextFixtureProjectionPolicy>;
+  readonly resolvePolicy: (ctx: BoundFilesystemContext) => ExternalContextFixtureProjectionPolicy | Promise<ExternalContextFixtureProjectionPolicy>;
 }
 
-export interface CompanyContextFixturePreparedLifecycle {
+export interface ExternalContextFixturePreparedLifecycle {
   active: boolean;
 }
 
-export interface CompanyContextFixturePreparedHandle {
-  readonly kind: "company-context-fixture-projection";
+export interface ExternalContextFixturePreparedHandle {
+  readonly kind: "external-context-fixture-projection";
   /** Logical filesystem identity for this prepared binding; paths are scoped by this id. */
   readonly filesystem: FilesystemId;
   readonly sourceRoot: string;
@@ -51,32 +42,32 @@ export interface CompanyContextFixturePreparedHandle {
   readonly visiblePaths: readonly string[];
   readonly access?: "readonly" | "readwrite";
   readonly projection?: FilesystemProjection;
-  readonly lifecycle?: CompanyContextFixturePreparedLifecycle;
+  readonly lifecycle?: ExternalContextFixturePreparedLifecycle;
 }
 
-export type CompanyContextFixturePreparedBinding = PreparedFilesystemBinding & {
-  handle: CompanyContextFixturePreparedHandle;
+export type ExternalContextFixturePreparedBinding = PreparedFilesystemBinding & {
+  handle: ExternalContextFixturePreparedHandle;
 };
 
-function normalizeCompanyPath(path: string): string {
+function normalizeExternalPath(path: string): string {
   const normalized = path.replace(/\\/g, "/");
   if (!normalized.startsWith("/")) return `/${normalized}`;
   return normalized;
 }
 
-function assertSafeCompanyPath(path: string): string {
-  const normalized = normalizeCompanyPath(path);
-  if (normalized.includes("\0")) throw new Error(`invalid company path: ${path}`);
+function assertSafeExternalPath(path: string): string {
+  const normalized = normalizeExternalPath(path);
+  if (normalized.includes("\0")) throw new Error(`invalid external context path: ${path}`);
   for (const part of normalized.split("/")) {
-    if (part === "..") throw new Error(`invalid company path traversal: ${path}`);
+    if (part === "..") throw new Error(`invalid external context path traversal: ${path}`);
   }
   return normalized.replace(/\/+/g, "/");
 }
 
 function isAllowed(path: string, prefixes: readonly string[]): boolean {
-  const normalized = assertSafeCompanyPath(path);
+  const normalized = assertSafeExternalPath(path);
   return prefixes.some((prefix) => {
-    const normalizedPrefix = assertSafeCompanyPath(prefix).replace(/\/+$/, "");
+    const normalizedPrefix = assertSafeExternalPath(prefix).replace(/\/+$/, "");
     return normalized === normalizedPrefix || normalized.startsWith(`${normalizedPrefix}/`);
   });
 }
@@ -86,7 +77,7 @@ async function assertInsideRoot(root: string, candidate: string): Promise<void> 
   const existing = await realpath(candidate);
   const rel = relative(realRoot, existing);
   if (rel.startsWith("..") || isAbsolute(rel)) {
-    throw new Error(`path escapes company context root: ${candidate}`);
+    throw new Error(`path escapes external context root: ${candidate}`);
   }
 }
 
@@ -116,22 +107,27 @@ async function makeProjectionReadonly(root: string, current = root): Promise<voi
   await chmod(current, 0o555);
 }
 
-export async function seedCompanyContextFixture(root: string): Promise<void> {
-  for (const file of DEFAULT_COMPANY_CONTEXT_FIXTURE_FILES) {
-    const safePath = assertSafeCompanyPath(file.path);
+export async function seedExternalContextFixture(
+  root: string,
+  files: readonly ExternalContextFixtureFile[],
+): Promise<void> {
+  for (const file of files) {
+    const safePath = assertSafeExternalPath(file.path);
     const target = join(root, ...safePath.slice(1).split("/"));
     await mkdir(dirname(target), { recursive: true });
     await access(dirname(target), constants.W_OK);
-    await import("node:fs/promises").then(({ writeFile }) => writeFile(target, file.content));
+    await writeFile(target, file.content);
   }
 }
 
-export class FixtureCompanyContextBindingProvider implements FilesystemBindingProvider {
+export class FixtureExternalContextBindingProvider implements FilesystemBindingProvider {
+  readonly #filesystem: FilesystemId;
   readonly #sourceRoot: string;
   readonly #projectionRootParent: string;
-  readonly #resolvePolicy: CompanyContextFixtureProviderOptions["resolvePolicy"];
+  readonly #resolvePolicy: ExternalContextFixtureProviderOptions["resolvePolicy"];
 
-  constructor(options: CompanyContextFixtureProviderOptions) {
+  constructor(options: ExternalContextFixtureProviderOptions) {
+    this.#filesystem = options.filesystemId;
     this.#sourceRoot = resolve(options.sourceRoot);
     this.#projectionRootParent = resolve(options.projectionRootParent ?? tmpdir());
     this.#resolvePolicy = options.resolvePolicy;
@@ -142,29 +138,29 @@ export class FixtureCompanyContextBindingProvider implements FilesystemBindingPr
   }
 
   async disposeBinding(prepared: PreparedFilesystemBinding): Promise<void> {
-    const handle = prepared.handle as Partial<CompanyContextFixturePreparedHandle>;
+    const handle = prepared.handle as Partial<ExternalContextFixturePreparedHandle>;
     if (handle.lifecycle) handle.lifecycle.active = false;
   }
 
-  async prepareBinding(ctx: BoundFilesystemContext, binding: FilesystemBinding): Promise<CompanyContextFixturePreparedBinding> {
-    if (binding.filesystem !== COMPANY_CONTEXT_FILESYSTEM_ID) {
-      throw new Error(`fixture company provider cannot prepare filesystem ${binding.filesystem}`);
+  async prepareBinding(ctx: BoundFilesystemContext, binding: FilesystemBinding): Promise<ExternalContextFixturePreparedBinding> {
+    if (binding.filesystem !== this.#filesystem) {
+      throw new Error(`fixture external context provider cannot prepare filesystem ${binding.filesystem}`);
     }
     if (binding.access === "readwrite" && binding.projection === "management") {
       const policy = await this.#resolvePolicy(ctx);
       if (!policy.grantManagementBinding) {
-        throw new Error("fixture company provider policy did not grant readwrite management binding");
+        throw new Error("fixture external context provider policy did not grant readwrite management binding");
       }
       const lifecycle = { active: true };
       return {
         binding,
         handle: {
-          kind: "company-context-fixture-projection",
+          kind: "external-context-fixture-projection",
           filesystem: binding.filesystem,
           sourceRoot: this.#sourceRoot,
           projectionRoot: this.#sourceRoot,
           visiblePaths: await listFixtureProjectionFiles({
-            kind: "company-context-fixture-projection",
+            kind: "external-context-fixture-projection",
             filesystem: binding.filesystem,
             sourceRoot: this.#sourceRoot,
             projectionRoot: this.#sourceRoot,
@@ -179,24 +175,24 @@ export class FixtureCompanyContextBindingProvider implements FilesystemBindingPr
       };
     }
     if (binding.access !== "readonly" || binding.projection !== "policy-filtered") {
-      throw new Error("fixture company provider only prepares readonly policy-filtered or readwrite management bindings");
+      throw new Error("fixture external context provider only prepares readonly policy-filtered or readwrite management bindings");
     }
 
     const policy = await this.#resolvePolicy(ctx);
-    const projectionRoot = await mkdtemp(join(this.#projectionRootParent, "boring-company-context-"));
+    const projectionRoot = await mkdtemp(join(this.#projectionRootParent, "boring-external-context-"));
     const visiblePaths: string[] = [];
     const files = await walkFiles(this.#sourceRoot);
 
     for (const sourceFile of files) {
       await assertInsideRoot(this.#sourceRoot, sourceFile);
       const rel = relative(this.#sourceRoot, sourceFile).split(sep).join("/");
-      const companyPath = assertSafeCompanyPath(`/${rel}`);
-      if (!isAllowed(companyPath, policy.allowedPathPrefixes)) continue;
+      const externalPath = assertSafeExternalPath(`/${rel}`);
+      if (!isAllowed(externalPath, policy.allowedPathPrefixes)) continue;
 
-      const destination = join(projectionRoot, ...companyPath.slice(1).split("/"));
+      const destination = join(projectionRoot, ...externalPath.slice(1).split("/"));
       await mkdir(dirname(destination), { recursive: true });
       await copyFile(sourceFile, destination);
-      visiblePaths.push(companyPath);
+      visiblePaths.push(externalPath);
     }
 
     visiblePaths.sort();
@@ -205,7 +201,7 @@ export class FixtureCompanyContextBindingProvider implements FilesystemBindingPr
     return {
       binding,
       handle: {
-        kind: "company-context-fixture-projection",
+        kind: "external-context-fixture-projection",
         filesystem: binding.filesystem,
         sourceRoot: this.#sourceRoot,
         projectionRoot,
@@ -218,14 +214,17 @@ export class FixtureCompanyContextBindingProvider implements FilesystemBindingPr
   }
 }
 
-export async function readFixtureProjectionFile(handle: CompanyContextFixturePreparedHandle, companyPath: string): Promise<string> {
-  const safePath = assertSafeCompanyPath(companyPath);
+export async function readFixtureProjectionFile(
+  handle: ExternalContextFixturePreparedHandle,
+  externalPath: string,
+): Promise<string> {
+  const safePath = assertSafeExternalPath(externalPath);
   const target = join(handle.projectionRoot, ...safePath.slice(1).split("/"));
   await assertInsideRoot(handle.projectionRoot, target);
   return await readFile(target, "utf8");
 }
 
-export async function listFixtureProjectionFiles(handle: CompanyContextFixturePreparedHandle): Promise<string[]> {
+export async function listFixtureProjectionFiles(handle: ExternalContextFixturePreparedHandle): Promise<string[]> {
   const files = await walkFiles(handle.projectionRoot);
   return files
     .map((file) => `/${relative(handle.projectionRoot, file).split(sep).join("/")}`)

--- a/packages/boring-bash/src/shared/index.ts
+++ b/packages/boring-bash/src/shared/index.ts
@@ -1,5 +1,5 @@
 /** Logical filesystem identity used by tools, UI, and runtime bindings. */
-export type FilesystemId = "user" | "company_context" | (string & {});
+export type FilesystemId = "user" | (string & {});
 
 /** Access granted for a prepared runtime filesystem binding. */
 export type FilesystemAccess = "readonly" | "readwrite";

--- a/plugins/boring-governance/src/server/filesystemBindings.ts
+++ b/plugins/boring-governance/src/server/filesystemBindings.ts
@@ -7,7 +7,6 @@ import type { RuntimeFilesystemBinding, RuntimeFilesystemBindingOperations } fro
 import { ErrorCode } from '@hachej/boring-agent/shared'
 import type { CreateCoreWorkspaceAgentServerOptions } from '@hachej/boring-core/app/server'
 import {
-  COMPANY_CONTEXT_FILESYSTEM_ID,
   ScopedFilesystemRuntimeBindingManager,
   createLogger,
   createReadonlyProjectionOperations,
@@ -22,6 +21,8 @@ import { COMPANY_CONTEXT_STATE_DIR, CompanyContextStore } from './companyContext
 import type { GovernanceService } from './governanceService.js'
 import type { GovernanceUserLike } from './policyTypes.js'
 import { normalizePolicyEmail } from './validatePolicy.js'
+
+export const COMPANY_CONTEXT_FILESYSTEM_ID = 'company_context'
 
 const COMPANY_CONTEXT_MOUNT_PATH = '/company_context'
 const AGENT_MODE_ENV = 'BORING_AGENT_MODE'

--- a/plugins/boring-governance/src/server/index.ts
+++ b/plugins/boring-governance/src/server/index.ts
@@ -39,6 +39,7 @@ export {
 export { normalizePolicyEmail, validateGovernancePolicy } from './validatePolicy.js'
 export { createGovernanceMeteringSink } from './metering.js'
 export {
+  COMPANY_CONTEXT_FILESYSTEM_ID,
   createDefaultCompanyContextRootResolver,
   createGovernanceFilesystemBindings,
   type CompanyContextRootResolver,


### PR DESCRIPTION
## Summary
- remove the tenant-specific `company_context` literal from the generic boring-bash `FilesystemId` type
- replace the tenant-specific public fixture provider with a generic external-context provider parameterized by filesystem ID
- keep company-context fixture constants and sample data in test-only support
- move the tenant filesystem constant into boring-governance and export it from that tenant-owning package

## Validation
- `pnpm --filter @hachej/boring-bash exec vitest run src/server/__tests__/fixtureCompanyContextProvider.test.ts src/server/__tests__/managementCompanyContextOperations.test.ts src/server/__tests__/readonlyCompanyContextE2e.test.ts src/server/__tests__/readonlyCompanyContextLeakage.test.ts src/server/__tests__/readonlyCompanyContextOperations.test.ts src/server/__tests__/readonlyProjectionConformance.test.ts src/server/__tests__/runtimeBindingManager.test.ts --no-file-parallelism`
- `pnpm --filter @hachej/boring-bash run typecheck`
- `pnpm --filter @hachej/boring-bash run build`
- `pnpm --filter @hachej/boring-governance exec vitest run src/server/__tests__/filesystemBindings.test.ts --no-file-parallelism`
- dependent typecheck sweep attempted with `pnpm --filter '...@hachej/boring-bash' --no-bail run typecheck`; blocked by existing workspace build/type skew, including Fastify 5.10/5.11 duplicate types and missing generated package exports
- `pnpm --filter @hachej/boring-governance run typecheck` remains blocked by the same pre-existing Fastify/declaration skew
