### PR TITLE
docs(1127): external channels (WhatsApp & co) plan r2 [owner gate]

### DIFF
--- a/docs/issues/1127/cloudflare-channels-assessment.md
+++ b/docs/issues/1127/cloudflare-channels-assessment.md
@@ -1,0 +1,192 @@
+---
+issue: 1127
+kind: decision-memo
+updated: 2026-08-07
+question: Reuse the Cloudflare Agents framework's channel integrations for external
+  channels instead of building plan r2's adapter ourselves — including the owner's
+  reframed variant, vendoring the OSS channel-adapter code self-hosted on our VPS?
+---
+
+# gh-1127 — Cloudflare channels reuse assessment
+
+Research date 2026-08-07 (web research + repo grounding against plan r2).
+
+## TL;DR
+
+**The channel adapters the owner remembers are not Cloudflare's — they are
+Vercel's.** cloudflare/agents delegates all messenger I/O to Vercel's Chat SDK
+(`vercel/chat`, MIT). Cloudflare's own channel catalog has **no WhatsApp and no
+SMS**. Cloudflare's `Agent` runtime is hard-coupled to Durable Objects/workerd
+and is not sanely self-hostable on a Node VPS. But **`@chat-adapter/whatsapp`
+(Vercel, MIT, Node >= 20, plain-Node)** is a real, substantive Meta Cloud API
+adapter that covers most of plan r2's Slice 2.
+
+**Recommendation: no to Cloudflare (cloud or vendored); yes-partially to
+Vercel's adapter layer** — keep plan r2's backend core (slices 1a/1b)
+unchanged, and evaluate `@chat-adapter/whatsapp` as the provider-edge
+implementation inside Slice 2 behind our own `ChannelAdapter` contract.
+
+## 1. What Cloudflare actually offers today (Aug 2026)
+
+Docs "Communication channels" catalog is exactly five entries: **Chat, Voice,
+Email, Slack, Webhooks**
+([overview](https://developers.cloudflare.com/agents/communication-channels/)).
+
+- **Email** — real: inbound Email Routing rule → Worker `onEmail()`; outbound
+  `sendEmail()`/`replyToEmail()` via Cloudflare Email Service, **public beta**
+  since 2026-04-16
+  ([docs](https://developers.cloudflare.com/agents/communication-channels/email/),
+  [blog](https://blog.cloudflare.com/email-service/)). Inbound routing GA/free.
+- **Slack** — a documented recipe (Slack Events API → Worker → DO-per-workspace
+  agent), not a managed connector
+  ([docs](https://developers.cloudflare.com/agents/communication-channels/slack/)).
+- **Voice** — `@cloudflare/voice`, browser-audio-to-DO, **Beta**; telephony
+  only via a Twilio adapter
+  ([docs](https://developers.cloudflare.com/agents/communication-channels/voice/)).
+- **WhatsApp: not in the catalog. SMS: not in the catalog.** Bluntly: on
+  Cloudflare you would build the Meta Cloud API webhook/send path yourself,
+  exactly as on any VPS.
+- Telegram/Discord/Teams/GChat appear only via the **Chat SDK integration**
+  ([docs](https://developers.cloudflare.com/agents/runtime/communication/chat-sdk/)),
+  i.e. Vercel's `chat` + `@chat-adapter/*` hosted inside an Agent DO.
+- The [cloudflare-os blog](https://blog.cloudflare.com/cloudflare-os/) ships no
+  messaging integrations; Slack-workspace talk there is roadmap language. The
+  catalog is thinner than the marketing.
+
+Programming model: `Agent` = Durable Object subclass — SQL-in-DO state
+(`this.sql`), DO alarms, WebSocket hibernation, `cloudflare:workers` imports,
+partyserver, wrangler bindings ([repo](https://github.com/cloudflare/agents),
+MIT, very active, core `agents` pkg still 0.x).
+
+## 2. The reframed option: vendor the OSS channel adapters self-hosted
+
+**Finding: the adapter layer is `vercel/chat`, not Cloudflare code.**
+Verified on npm 2026-08-07:
+
+- Publisher Vercel, repo [vercel/chat](https://github.com/vercel/chat), MIT,
+  `engines: node >= 20` — **plain-Node fetch-based libraries, no Workers
+  dependency**. State backends pluggable (e.g. `@chat-adapter/state-redis`).
+- Adapters at v4.37.0, lockstep active releases: slack (728k dl/wk), telegram
+  (174k), whatsapp (73k), discord (78k), teams, gchat, twilio-SMS. Core `chat`
+  pkg 2.08M dl/wk. Multi-maintainer, healthy — not an experiment.
+- **`@chat-adapter/whatsapp`** ([README](https://github.com/vercel/chat/tree/main/packages/adapter-whatsapp),
+  [changelog](https://vercel.com/changelog/chat-sdk-adds-whatsapp-adapter-support)):
+  Meta WhatsApp Business Cloud API (Graph v25.0), `X-Hub-Signature-256` HMAC
+  verify + `hub.verify_token` handshake, inbound parse (text/media/location/
+  interactive), outbound send with **4,096-char auto-chunking**, **template
+  sends** for outside-24h-window, buttons/lists, typing indicators. That is
+  most of plan r2 Slice 2's checklist. Still ours: Meta business verification,
+  number setup, template approval, and markdown→WhatsApp dialect rendering of
+  *agent* output.
+
+**Vendoring cloudflare/agents itself is a non-starter**: the runtime is
+workerd-shaped (DO storage, alarms, hibernation); self-hosting means
+workerd/miniflare with no durable-storage ops story off Cloudflare, plus 0.x
+churn risk (docs rewritten June 2026, high commit velocity). The Cloudflare
+value-add (durable agent identity, DO SQLite, hibernating sockets, scheduling)
+is precisely the proprietary-runtime part — and we already have our own durable
+substrate (`SqliteEventStreamStore` + `HarnessPiChatService`).
+
+## 3. Architecture comparison
+
+**(a) Plan r2 self-built (baseline).** Meta webhook → our host endpoint →
+durable dedupe+queue (single sqlite txn) → per-binding drain → prompt/followUp
+→ durable-store tail with CAS cursor → turn assembler → dialect render → Meta
+send API. Everything in-process with `HarnessPiChatService`.
+
+**(b) Vendored Vercel adapter at the edge (recommended variant).** Identical to
+(a) except `ChannelAdapter.parseInbound` / `renderOutbound`-send are
+implemented on top of `@chat-adapter/whatsapp` (verify, parse, chunked send,
+template fallback) instead of hand-rolled Meta API code. Integration caveat to
+spike in Slice 2: the adapters are designed for use inside the `chat`
+framework's bot loop; we want the adapter package standalone behind our
+contract, **not** their Redis-state bot framework (their state/dedupe model
+would duplicate and fight our binding store and cursor semantics).
+
+**(c) On-Cloudflare hybrid (comparison row only).** Worker terminates webhooks
+at edge → HTTPS forward to VPS. Technically clean: CPU-time (not wall-clock)
+billing makes proxying cheap (paid $5/mo; DO pricing
+[here](https://developers.cloudflare.com/durable-objects/platform/pricing/));
+Meta/Slack ack deadlines easily met. But since Cloudflare has no
+WhatsApp-specific anything, the Worker contributes only edge presence — we'd
+still write the same adapter code, plus a second deploy surface, plus US-entity
+exposure (below). Only genuinely differentiated piece: free inbound Email
+Routing → code, relevant to a later email channel at most.
+
+## 4. What of plan r2 survives in every variant — claim verified
+
+Verified against plan r2 (`docs/issues/1127/plan.md`) and the repo: streams are
+keyed by composite sessionKey on our pi-chat service; the durable store,
+replay-window limits, and the trusted-caller seam are all internal to our
+backend. Therefore, **regardless of who terminates the webhook**:
+
+- `ChannelBindingStore` (bindings, durable inbound dedupe + queue, park
+  policies) — ours; no external framework knows our scopes/sessions.
+- Trusted-caller seam minting `AuthorizedAgentScope` — ours by definition.
+- Durable-store tail worker, CAS cursor, terminal-event turn assembly
+  (agent-end/error/stall) — ours; it consumes our `SqliteEventStreamStore`
+  and pi event semantics. No third party can supply this.
+- Markdown→dialect shaping of agent turns and the ask_user deferral — ours
+  (the Vercel adapter chunks and sends; it does not understand pi turns).
+
+So slices 1a and 1b are invariant. Only Slice 2's provider-transport edge is
+substitutable. The claim in the task framing holds.
+
+## 5. Sovereignty, lock-in, cost
+
+- **Self-hosted Vercel adapters**: MIT code from npm running on our EU VPS —
+  no US infrastructure operator in the data path besides Meta itself (which
+  WhatsApp implies in every variant). Sovereignty concern dissolved. Lock-in:
+  a library dependency behind our own `ChannelAdapter` contract — flip-cost
+  is Slice-2-sized. Churn risk: v4.x lockstep releases are frequent; pin +
+  renovate.
+- **On-Cloudflare**: Cloudflare Inc is US (CLOUD Act exposure regardless of
+  data location). DO `jurisdiction("eu")` exists
+  ([docs](https://developers.cloudflare.com/durable-objects/reference/data-location/))
+  but Workers still execute globally, and the full Data Localization Suite is
+  Enterprise-only ([DLS](https://www.cloudflare.com/data-localization/)).
+  Incompatible with Seneca's "no US data path" positioning for message
+  content. Cost is trivial ($5/mo class) — cost is not the discriminator.
+- **Effort**: variant (b) saves the Meta-API plumbing of Slice 2 (verify,
+  parse, chunked send, template call) — real but modest, since Slice 2 was
+  the smallest slice; slices 1a/1b dominate effort in every variant.
+
+## 6. Recommendation
+
+1. **Do not adopt Cloudflare** — cloud or vendored. Its catalog has no
+   WhatsApp/SMS; its runtime is not Node-portable; its jurisdiction conflicts
+   with our positioning; its one unique asset (Email Routing) is out of scope
+   for this epic.
+2. **Keep plan r2 as written for slices 1a/1b** — the binding store, trusted
+   seam, durable tail, and turn assembly are backend-invariant and have no
+   OSS substitute.
+3. **Amend Slice 2 with a bounded spike (half-day)**: attempt
+   `@chat-adapter/whatsapp` standalone (no `chat` framework, no Redis) behind
+   our `ChannelAdapter` contract for verify/parse/send/template. If it
+   composes cleanly standalone, use it; if it drags in the framework's bot
+   loop or state model, fall back to plan r2's hand-rolled Meta client. Either
+   outcome keeps the conformance suite and acceptance criteria unchanged.
+4. Answer to the owner's question — "reuse the OSS channels layer self-hosted,
+   yes or no": **yes for the provider edge, via Vercel's `@chat-adapter/*`
+   (which is what actually ships WhatsApp/Telegram); no for anything from
+   Cloudflare's own code.**
+
+## Sources
+
+[CF communication channels](https://developers.cloudflare.com/agents/communication-channels/) ·
+[email](https://developers.cloudflare.com/agents/communication-channels/email/) ·
+[voice](https://developers.cloudflare.com/agents/communication-channels/voice/) ·
+[slack](https://developers.cloudflare.com/agents/communication-channels/slack/) ·
+[chat-sdk integration](https://developers.cloudflare.com/agents/runtime/communication/chat-sdk/) ·
+[cloudflare/agents](https://github.com/cloudflare/agents) ·
+[cloudflare-os blog](https://blog.cloudflare.com/cloudflare-os/) ·
+[Email Service beta](https://blog.cloudflare.com/email-service/) ·
+[Email pricing](https://developers.cloudflare.com/email-service/platform/pricing/) ·
+[DO pricing](https://developers.cloudflare.com/durable-objects/platform/pricing/) ·
+[DO data location / eu](https://developers.cloudflare.com/durable-objects/reference/data-location/) ·
+[Data Localization Suite](https://www.cloudflare.com/data-localization/) ·
+[vercel/chat](https://github.com/vercel/chat) ·
+[WhatsApp adapter](https://github.com/vercel/chat/tree/main/packages/adapter-whatsapp) ·
+[WhatsApp adapter changelog](https://vercel.com/changelog/chat-sdk-adds-whatsapp-adapter-support) ·
+[Telegram adapter changelog](https://vercel.com/changelog/chat-sdk-adds-telegram-adapter-support) ·
+npm registry metadata (versions/downloads/engines) queried 2026-08-07.

--- a/docs/issues/1127/plan.md
+++ b/docs/issues/1127/plan.md
@@ -10,6 +10,11 @@ flag: BORING_AGENT_CHANNELS (new; adapter host is dead code when off)
 
 Adversarially reviewed 2026-08-07 (3 blockers, 6 majors folded in — r1);
 independent fresh-eyes review folded in — r2 (3 majors, 3 mediums, minors).
+Reuse research folded in — r2.1: Cloudflare Agents (cloud or vendored) was
+assessed and **rejected** (no WhatsApp/SMS in its channel catalog; runtime
+hard-coupled to Durable Objects) — see
+[`cloudflare-channels-assessment.md`](cloudflare-channels-assessment.md);
+Vercel's `@chat-adapter/whatsapp` adopted as the Slice 2 provider-edge spike.
 
 ## Problem
 
@@ -264,8 +269,15 @@ policy, gone-session recovery, full conformance suite.
 
 ### Slice 2: WhatsApp adapter (Meta Cloud API)
 **Bead:** on approval
-**Delivers:** signature verify + handshake, payload parse, dialect rendering +
+**Delivers:** the provider edge behind our `ChannelAdapter` contract —
+webhook signature verify + handshake, payload parse, dialect rendering +
 chunking, send with retry, 24h template fallback, host wiring + credentials.
+**Approach (per the reuse assessment):** start with a **half-day spike using
+Vercel's `@chat-adapter/whatsapp`** (MIT, plain Node >= 20) standalone as the
+provider edge — verify/parse, chunked send, template fallback — wrapped
+behind our contract. Fall back to the hand-rolled Meta client only if the
+package drags in the rest of Vercel's bot framework instead of standing
+alone.
 **Blocked by:** 1b; Meta business account + test number (owner-side).
 **Proof:** acceptance 7; manual demo recording.
 **Review budget:** inside

--- a/docs/issues/1127/plan.md
+++ b/docs/issues/1127/plan.md
@@ -1,0 +1,303 @@
+---
+github: https://github.com/hachej/boring-ui/issues/1127
+issue: 1127
+state: needs-owner-approval
+updated: 2026-08-07
+flag: BORING_AGENT_CHANNELS (new; adapter host is dead code when off)
+---
+
+# gh-1127 — external channels: consume agents from WhatsApp and co
+
+Adversarially reviewed 2026-08-07 (3 blockers, 6 majors folded in — r1);
+independent fresh-eyes review folded in — r2 (3 majors, 3 mediums, minors).
+
+## Problem
+
+Agents are only reachable through the workspace UI over a held ndjson stream.
+Owner direction: a client's team should talk to a deployed agent from WhatsApp
+(email/SMS class later) with zero workspace onboarding. External channels are
+disconnected and asynchronous — no socket between messages, replies minutes
+later, process restarts in between — so they need durable, unbounded-horizon
+session state, not the UI's retention-window replay.
+
+## Today / Delta
+
+**Today (origin/main, post PR #1128 + hydration follow-up):**
+- `SqliteEventStreamStore` (`packages/agent/src/server/events/eventStreamStore.ts`):
+  durable idempotent append, opaque offsets, `readEvents(path, {offset,
+  limit})` → `{events, nextOffset, upToDate}`, in-process `subscribe`.
+- Every pi-chat event is durably appended before live fan-out
+  (`harnessPiChatService.publishChannelEvents`); a failed append poisons the
+  channel — the store is authoritative.
+- Cold channel open rehydrates the in-memory `PiChatReplayBuffer` from the
+  store (`hydrateDurableReplayBuffer`, harnessPiChatService.ts:996) — but only
+  up to the buffer's retention window (~1000 events). UI reconnects survive
+  restarts; a consumer absent for longer than the window still gaps.
+- Streams are keyed by **composite session key** — `sessionStreamPath(
+  sessionKey)` where sessionKey encodes sessionId + workspace/storage scope
+  (harnessPiChatService.ts:922) — not by bare sessionId.
+- HTTP surface (`agent-host/httpProjection.ts`): create session,
+  `POST .../prompt|followup`, `GET .../events` (ndjson, numeric cursor into
+  the in-memory buffer). Prompt `requestId` dedupe is gateway/metering-layer
+  and in-memory — not durable. Auth = host-injected `authorizeAgentRequest →
+  AuthorizedAgentScope`. `trustedPiSessionBinding.ts` validates a requested
+  scope against an already-authorized ctx; nothing mints scopes from storage.
+- No webhooks (billing aside), no outbound messaging, no external identity
+  mapping anywhere.
+
+**Delta:** a channel adapter host that (a) accepts provider webhooks with fast
+ack + durable inbound dedupe, (b) maps external identity → scope + session,
+(c) drives the agent via a new trusted-caller seam, (d) tails the durable
+store with a persisted, leased cursor, assembles completed turns, and delivers
+rendered replies out-channel — including when the store's retention window has
+long passed.
+
+## Solution
+
+### 1. Channel adapter contract (channel-agnostic core)
+
+New module `packages/agent/src/server/channels/` (placement = open question 1);
+host wiring in the deployed app. Pipeline, not two halves:
+
+**Inbound** — webhook handler does signature verification + payload parse
+(`ChannelAdapter.parseInbound(request) → InboundChannelMessage { channelId,
+externalId, providerMessageId, text, attachments? }`) then **acks 200
+immediately** after durably enqueueing the message keyed by
+`(channel, providerMessageId)` in the `ChannelBindingStore`. Providers retry
+aggressively on slow responses (Meta retries for hours); prompt-path dedupe is
+in-memory/metering-dependent, so **inbound dedupe is durable and ours** — a
+replayed `providerMessageId` is dropped at the store, never reaching the
+agent. **The dedupe-row insert and the queue insert are one sqlite
+transaction** — a crash between separate writes would eat the message forever
+(the dedupe row makes Meta's redelivery a no-op); the conformance suite
+crash-tests this. Note: dedupe rows must outlive the provider's redelivery
+horizon — retention is by age, independent of event-stream retention — and
+provider timestamp freshness checks are a spam guard only, never a dedupe
+substitute (retries arrive with old timestamps). A per-binding serialized
+worker drains the queue in enqueue order (providers do not guarantee webhook
+ordering; we impose per-sender ordering).
+
+**Agent invocation** — the drain worker resolves the binding, ensures the
+session, and calls `prompt`; if the session is busy it uses `followUp` (never
+`requireIdle`-and-drop — a channel message must not be silently discarded).
+**Inbound park policy, symmetric to outbound**: a permanently failing prompt
+(revoked scope, deleted workspace) gets bounded retry → park with a stable
+code → failure notice out-channel; a wedged per-binding queue is
+unacceptable.
+
+**Outbound** — a per-binding delivery worker tails
+`eventStore.readEvents(streamPath, { offset: binding.cursor })`.
+`streamPath` is resolved via a **new exported resolver on the pi-chat service**
+(streams are keyed by composite sessionKey — a bare-sessionId tail reads an
+empty stream forever). The worker:
+- assembles turns at the **chunk level** against an explicit terminal-event
+  contract: `agent-end` → render reply; synthetic `error` / aborted turn →
+  render a short failure notice (silence is not acceptable on a chat channel);
+  stall timeout (no terminal event within N minutes, e.g. poisoned channel) →
+  failure notice + park;
+- renders via `ChannelAdapter.renderOutbound(turn) → ProviderMessage[]`;
+- sends, then advances `binding.cursor` (a store offset) with **compare-and-
+  set**. Honesty about semantics: send precedes the CAS, so outbound is
+  **at-least-once** — a crash between send and CAS resends on recovery, and
+  two accidental workers can both send before one CAS wins; CAS prevents
+  cursor divergence, **not** duplicate sends (WhatsApp offers no send
+  idempotency key). v1 runs **in the same process as
+  `HarnessPiChatService`** (store `subscribe` is an in-process listener;
+  pattern: subscribe first, then `readEvents` loop until `upToDate` to close
+  the wake/read race).
+- **Send-failure policy**: bounded retry; permanent failure (expired 24h
+  window, unrenderable content) → park that message with a stable code and
+  advance — one bad message must not wedge the binding forever.
+
+**Why the durable store, not the ndjson `/events` route:** the numeric cursor
+replays from the retention-window-bounded in-memory buffer; a channel silent
+for days needs resumption from an arbitrary offset. The store gives exactly
+that; the adapter is its first non-UI consumer.
+
+### 2. Identity mapping and session binding
+
+`ChannelBindingStore` (sqlite, same `SqlStorage` seam as the event store):
+
+```
+binding: (channel, externalId) → { workspaceScopeId, authSubjectId,
+          agentTypeId, sessionId, cursor, status, askUserPending? }
+inbound_dedupe: (channel, providerMessageId) → seenAt
+```
+
+- One durable session per (channel, externalId, agentTypeId); created lazily
+  on first inbound, reused thereafter.
+- **Gone-session policy**: if the bound session was deleted/retired, the
+  worker auto-creates a fresh session, resets `cursor` to the new stream's
+  tail, and notes the reset in the outbound greeting. The cursor is scoped to
+  the composite stream key: it resets whenever **any** sessionKey component
+  changes (workspaceScopeId/authSubjectId rebinding, not just sessionId).
+  Long-conversation rotation policy = open question 5.
+- Fail-closed: unknown sender → polite rejection template **rate-limited to
+  once per sender** (no reply-loop or spam amplification), no session, no
+  agent invocation, stable error code. Bindings provisioned explicitly
+  (CLI/admin op in v1; #1087 per-agent grants is the eventual policy seam).
+- **Trust model — named honestly as a new seam**: the adapter is a host-side
+  trusted caller that mints `AuthorizedAgentScope` from a binding row. This
+  has no precedent (`trustedPiSessionBinding` only *validates* against an
+  already-authorized ctx). Guardrails: mint only after verifying the
+  workspace scope still resolves and `binding.status === active`; bindings
+  are revocable; the seam lives behind the flag and is unreachable when off.
+
+### 3. Message shaping
+
+- Assistant markdown → channel dialect (WhatsApp: `*bold*`, `_italic_`; no
+  headings/tables — degrade to plain text), split at provider limits
+  (WhatsApp 4096 chars) on paragraph boundaries. Fenced code blocks convert
+  to the dialect's monospace form and, when a hard split lands inside one,
+  the fence is closed and re-opened in the next chunk.
+- Channels receive completed turns only — tool calls, thinking, and streaming
+  deltas are suppressed by the turn assembler.
+- `ask_user`: **demoted out of v1 acceptance.** The answer-delivery seam is in
+  churn on fix/786 (inbox human-intention rework), and there is a design
+  tension to resolve first: the turn assembler suppresses tool-call events
+  yet would have to special-case ask_user detection and answer routing. v1
+  behavior: an ask_user turn renders as a deferral message ("open the
+  workspace to answer"). The sketched design (askUserPending consumed by
+  exactly one inbound, rich intentions → numbered choices) moves to slice 3
+  against whatever seam fix/786 lands.
+- **24h window**: replies delivered after the customer's window lapses are
+  rejected by Meta for free-form sends. In scope: a single pre-approved
+  "your agent has an update — reply to continue" template as fallback.
+  Proactive agent-initiated outreach stays out of scope.
+
+### 4. Auth / tenancy boundaries
+
+- Webhook endpoint in the deployed host app: per-channel secret + provider
+  signature check (WhatsApp Cloud API `X-Hub-Signature-256` HMAC + verify
+  handshake) before any parsing.
+- Provider credentials via the existing credentials seam
+  (`server/credentials/`), never in git.
+- Tenancy: the binding carries the workspace scope; one endpoint serves many
+  tenants since routing is (channel, externalId) → binding. Genericity: no
+  provider names in core contracts — `channelId` is opaque.
+
+## Decisions (proposed, not yet ratified)
+
+1. Adapter consumes the durable store directly with its own persisted cursor —
+   not the HTTP events route, not the in-memory buffer.
+2. Contract-first with a **fake channel** conformance harness; WhatsApp the
+   only concrete channel in this epic. The fake channel makes the loop
+   CI-provable without Meta credentials; WhatsApp (not email) because it is
+   the owner's named demo and boring-mail already covers the email surface.
+3. WhatsApp via **Meta Cloud API direct** (no Twilio) — one fewer vendor,
+   native template access for the 24h fallback. Cheap to flip later behind
+   the adapter contract.
+4. Inbound dedupe + ordering are owned durably by the channel core (not the
+   prompt path); webhook ack is asynchronous.
+5. v1 runs **in the same process as `HarnessPiChatService`** — the store
+   `subscribe` seam and direct service invocation require it. A separate
+   adapter process is not "add workers later": it is a redesign that goes
+   through the HTTP surface with minted auth tokens. Cursor CAS limits the
+   blast radius of an accidental second process (cursor divergence prevented;
+   duplicate sends still possible).
+
+## Test Seams
+
+- Highest public seam: fake-channel conformance suite — inject inbound
+  webhook payload → durable enqueue + ack → real `HarnessPiChatService` with
+  sqlite store completes a turn → rendered outbound + cursor CAS persisted →
+  restart adapter → next inbound resumes, zero dupes, zero loss.
+- Prior art: `eventStreamStore.conformance.test.ts`,
+  `harnessPiChatService.eventStore.test.ts`, billing webhook signature tests
+  (`packages/core/src/server/credits/`).
+- Avoid testing: Meta API behavior (mock at the adapter transport edge), pi
+  runtime internals, replay-buffer internals.
+
+## Acceptance
+
+1. Fake-channel loop green in CI, surviving **graceful** adapter restart
+   mid-conversation with cursor resume and zero duplicate sends. On hard
+   crash between send and cursor CAS, a duplicate outbound send is possible
+   and accepted (at-least-once); the suite asserts no message *loss* in that
+   case.
+2. Replayed webhook with the same `providerMessageId` — including after a
+   process restart — produces exactly one agent turn (durable dedupe), and a
+   crash between dedupe insert and queue insert cannot lose the message
+   (single transaction, crash-tested).
+3. Unknown sender rejected fail-closed with a stable code; no session.
+4. Error/aborted/stalled turns produce a failure notice out-channel, never
+   silence; a permanently unsendable message parks without wedging the
+   binding.
+5. An `ask_user` turn produces the deferral message (round-trip answering is
+   slice 3, post fix/786); inbound park policy proven: revoked binding →
+   bounded retry → park + failure notice, queue not wedged.
+6. Gone-session auto-recreate works; greeting notes the reset.
+7. WhatsApp adapter: signature verify, handshake, dialect rendering + 4096
+   chunking, template fallback — unit-tested on recorded fixtures; live
+   demo against a Meta test number.
+8. Flag off → no routes, no workers, byte-identical host.
+
+## Proof
+
+- Exact command: channels suites in `packages/agent`; full
+  `pnpm -C packages/agent test` green.
+- Manual/demo: WhatsApp test number ↔ deployed factory agent; recording of a
+  multi-message conversation spanning a server restart.
+- Owner demo: "message the Engagement Analyst on WhatsApp" (GTM framing).
+
+## Slices
+
+### Slice 1a: contract + bindings + inbound path
+**Bead:** on approval
+**Delivers:** `ChannelAdapter` contract, `ChannelBindingStore` (bindings,
+durable dedupe + inbound queue with **atomic single-transaction insert**,
+crash-tested), inbound park policy, async-ack webhook core, trusted-caller
+seam with guardrails, provisioning op, flag plumbing, fake-channel inbound
+tests.
+**Blocked by:** None (substrate on main).
+**Proof:** acceptance 2, 3, 8.
+**Review budget:** inside
+
+### Slice 1b: durable tail + turn assembly + outbound
+**Bead:** on approval
+**Delivers:** stream-path resolver export, tail worker (subscribe+read loop,
+cursor CAS), terminal-event turn assembler, shaping core, send-failure/park
+policy, gone-session recovery, full conformance suite.
+**Blocked by:** 1a.
+**Proof:** acceptance 1, 4, 5, 6.
+**Review budget:** inside — turn assembly is the risk center, kept alone here
+
+### Slice 2: WhatsApp adapter (Meta Cloud API)
+**Bead:** on approval
+**Delivers:** signature verify + handshake, payload parse, dialect rendering +
+chunking, send with retry, 24h template fallback, host wiring + credentials.
+**Blocked by:** 1b; Meta business account + test number (owner-side).
+**Proof:** acceptance 7; manual demo recording.
+**Review budget:** inside
+
+### Slice 3 (stretch, separate gate): ask_user channel answering (against the
+post-fix/786 intention seam) + boring-mail reuse assessment for the email
+channel — written up, not built, in this epic.
+
+## Out of Scope
+
+Email/SMS channels (assessment only), group chats, inbound media→agent
+attachments (v1: acknowledge + defer), per-agent grant policy (#1087),
+workspace Inbox interplay beyond text `ask_user`, proactive agent-initiated
+outreach beyond the single reply-fallback template, multi-agent routing per
+sender, horizontal adapter scale-out, billing/metering of channel traffic.
+
+## Open Questions — owner decisions required
+
+Fresh-eyes review positions recorded per item.
+
+1. **Placement**: `packages/agent/src/server/channels/`. *Review-endorsed.*
+2. **boring-mail**: assessment-only in this epic (slice 3 write-up).
+   *Review-endorsed.*
+3. **Unknown-sender UX**: polite rejection, rate-limited once per sender.
+   *Review-endorsed with that condition — folded into §2.*
+4. **Meta account** — still open, reframed per review: **start Meta Business
+   verification now** (owner-side, days); if it stalls past slice 1, demo on
+   the Twilio sandbox. On the reviewer's walking-skeleton suggestion (Twilio
+   spike parallel to 1a): **not taken as default** — a parallel spike builds
+   against a provider we intend to discard (decision 3) and splits the one
+   review lane; the fake-channel harness already proves the loop end-to-end
+   in CI. Taken **conditionally**: if Meta verification has not cleared by
+   1a's gate, spin the Twilio sandbox spike then, as a demo vehicle only.
+5. **Session rotation**: accept unbounded per-contact sessions for v1, with a
+   turn-count/age alert so rotation lands before it hurts. *Review-endorsed.*


### PR DESCRIPTION
Channel adapter on the durable event store — r2 after fresh-eyes review (inbound-loss transaction fix, inbound park policy, honest at-least-once semantics). One open owner question: start Meta Business verification now vs demo on Twilio sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F15mxaqthycNkk8o9FDLfC