### PR TITLE
[gh-1009] durable store: unblock event loop (async driver)

### DIFF
--- a/packages/agent/src/server/events/__tests__/eventStreamStore.concurrentAppend.test.ts
+++ b/packages/agent/src/server/events/__tests__/eventStreamStore.concurrentAppend.test.ts
@@ -4,8 +4,15 @@ import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { Worker } from 'node:worker_threads'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { openDatabase, type SqlTransactionMode } from '../sqlStorage'
-import { SqliteEventStreamStore } from '../eventStreamStore'
+import {
+  openDatabase,
+  SQLITE_BUSY_TIMEOUT_MS,
+  type SqlTransactionMode,
+} from '../sqlStorage'
+import {
+  SQLITE_BUSY_RETRY_WINDOW_MS,
+  SqliteEventStreamStore,
+} from '../eventStreamStore'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const WORKER_PATH = join(__dirname, 'fixtures', 'concurrentAppendWorker.ts')
@@ -36,6 +43,48 @@ function runWorker(input: {
     })
     worker.once('error', reject)
   })
+}
+
+async function startHoldingWriteLock(dbPath: string, holdMs: number): Promise<{ done: Promise<void> }> {
+  let resolveLocked!: () => void
+  let rejectLocked!: (error: Error) => void
+  let resolveDone!: () => void
+  let rejectDone!: (error: Error) => void
+  const locked = new Promise<void>((resolve, reject) => {
+    resolveLocked = resolve
+    rejectLocked = reject
+  })
+  const done = new Promise<void>((resolve, reject) => {
+    resolveDone = resolve
+    rejectDone = reject
+  })
+  const worker = new Worker(`
+    const { parentPort, workerData } = require('node:worker_threads')
+    const { DatabaseSync } = require('node:sqlite')
+    const db = new DatabaseSync(workerData.dbPath)
+    db.exec('PRAGMA busy_timeout=1000; BEGIN IMMEDIATE')
+    parentPort.postMessage('locked')
+    Atomics.wait(new Int32Array(workerData.sleep), 0, 0, workerData.holdMs)
+    db.exec('COMMIT')
+    db.close()
+    parentPort.postMessage('done')
+  `, {
+    eval: true,
+    workerData: { dbPath, holdMs, sleep: new SharedArrayBuffer(4) },
+  })
+  worker.on('message', (message: string) => {
+    if (message === 'locked') resolveLocked()
+    if (message === 'done') {
+      resolveDone()
+      void worker.terminate()
+    }
+  })
+  worker.once('error', (error) => {
+    rejectLocked(error)
+    rejectDone(error)
+  })
+  await locked
+  return { done }
 }
 
 async function setupStreamFile(dir: string): Promise<{ dbPath: string; path: string }> {
@@ -126,6 +175,56 @@ describe('runTransaction concurrent-write contention (real sqlStorage.ts primiti
     // wording SQLite uses for this condition.
     expect(allErrors.some((error) => error.code === 'ERR_SQLITE_ERROR' && /lock|busy/i.test(error.message))).toBe(true)
   }, 20_000)
+})
+
+describe('SqliteEventStreamStore event-loop contention bound', () => {
+  let dir: string
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('does not let a concurrent writer stall reads or the event loop beyond the configured bounds', async () => {
+    dir = mkdtempSync(join(tmpdir(), 'boring-event-stream-write-bound-'))
+    const { dbPath, path } = await setupStreamFile(dir)
+    const opened = openDatabase(dbPath)
+    const store = new SqliteEventStreamStore(opened.sql, opened.runTransaction)
+
+    try {
+      const lock = await startHoldingWriteLock(dbPath, 1_000)
+      const startedAt = performance.now()
+      let timerElapsed = Number.POSITIVE_INFINITY
+      const timer = new Promise<void>((resolve) => setTimeout(() => {
+        timerElapsed = performance.now() - startedAt
+        resolve()
+      }, 50))
+      const appendResult = store.appendEvent(path, { waitsForLock: true }).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error }),
+      )
+      const readStartedAt = performance.now()
+      await expect(store.readEvents(path, { offset: '-1' })).resolves.toMatchObject({ events: [] })
+      expect(performance.now() - readStartedAt).toBeLessThan(SQLITE_BUSY_TIMEOUT_MS + 150)
+
+      await timer
+      const result = await appendResult
+      const operationElapsed = performance.now() - startedAt
+
+      // busy_timeout=5000 held this timer until the worker released its lock.
+      // The short native wait lets it run near schedule; timer-based retries
+      // then give up inside a bounded window under sustained contention.
+      expect(timerElapsed).toBeLessThan(SQLITE_BUSY_TIMEOUT_MS + 150)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(String(result.error)).toMatch(/lock|busy/i)
+      expect(operationElapsed).toBeLessThan(
+        SQLITE_BUSY_RETRY_WINDOW_MS + SQLITE_BUSY_TIMEOUT_MS + 250,
+      )
+
+      await lock.done
+    } finally {
+      opened.db.close()
+    }
+  }, 5_000)
 })
 
 describe('SqliteEventStreamStore write-path transaction mode wiring', () => {

--- a/packages/agent/src/server/events/__tests__/fixtures/concurrentAppendWorker.ts
+++ b/packages/agent/src/server/events/__tests__/fixtures/concurrentAppendWorker.ts
@@ -38,6 +38,11 @@ const { dbPath, path, mode, iterations, sharedBuf, sleepMs } = workerData as Wor
 const sync = new Int32Array(sharedBuf)
 
 const { db, sql } = openDatabase(dbPath)
+// This fixture isolates BEGIN IMMEDIATE semantics from the durable store's
+// production event-loop bound. Its long worker-local timeout lets the test
+// prove lock acquisition happens up front without transient errors; the
+// parent suite separately proves production uses short, yielding retries.
+db.exec('PRAGMA busy_timeout=5000')
 
 // Start barrier: block until the main thread flips sync[0] to 1, so both
 // workers begin their hammering loop at effectively the same instant.

--- a/packages/agent/src/server/events/eventStreamStore.ts
+++ b/packages/agent/src/server/events/eventStreamStore.ts
@@ -10,6 +10,12 @@ const ZERO_COMPONENT = '0'.repeat(COMPONENT_PAD)
 export const DEFAULT_READ_LIMIT = 100
 export const MAX_READ_LIMIT = 1000
 
+// Total timer-based retry window for a continuously contended write. A final
+// attempt can add at most sqlStorage's short per-call busy timeout.
+export const SQLITE_BUSY_RETRY_WINDOW_MS = 250
+const SQLITE_BUSY_BACKOFF_START_MS = 5
+const SQLITE_BUSY_BACKOFF_MAX_MS = 50
+
 export interface EventStreamReadResult {
   events: Array<{ data: unknown; offset: string }>
   nextOffset: string
@@ -100,14 +106,18 @@ export class SqliteEventStreamStore implements EventStreamStore {
   }
 
   async createStream(path: string): Promise<void> {
-    this.sql.exec(`INSERT OR IGNORE INTO boring_event_streams (path) VALUES (?)`, path)
+    await this.retryBusy(() => {
+      this.sql.exec(`INSERT OR IGNORE INTO boring_event_streams (path) VALUES (?)`, path)
+    })
   }
 
   async appendEvent(path: string, event: unknown): Promise<string> {
     const data = JSON.stringify(event)
     // allocateSeq() reads next_offset then writes it (UPDATE ... RETURNING) —
     // a read-then-write transaction needs BEGIN IMMEDIATE, see SqlTransactionMode.
-    const offset = this.runTransaction(() => this.appendSerializedEvent(path, data), 'immediate')
+    const offset = await this.retryBusy(() => (
+      this.runTransaction(() => this.appendSerializedEvent(path, data), 'immediate')
+    ))
     this.notifyListeners(path)
     return offset
   }
@@ -122,32 +132,35 @@ export class SqliteEventStreamStore implements EventStreamStore {
       // upgrade to a write lock with SQLITE_BUSY immediately, WITHOUT
       // honoring busy_timeout, whenever another connection holds the write
       // lock. See SqlTransactionMode in sqlStorage.ts.
-      const offset = this.runTransaction(() => {
-        const existing = this.readIdempotencyKey(path, key)
-        if (existing) {
-          if (existing.data !== data) {
-            throw new EventStreamStoreError(`Event key "${key}" already has a conflicting payload.`)
+      const offset = await this.retryBusy(() => {
+        inserted = false
+        return this.runTransaction(() => {
+          const existing = this.readIdempotencyKey(path, key)
+          if (existing) {
+            if (existing.data !== data) {
+              throw new EventStreamStoreError(`Event key "${key}" already has a conflicting payload.`)
+            }
+            return formatOffset(existing.seq)
           }
-          return formatOffset(existing.seq)
-        }
 
-        const seq = this.allocateSeq(path)
-        this.sql.exec(
-          `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
-          path,
-          seq,
-          data,
-        )
-        this.sql.exec(
-          `INSERT INTO boring_event_stream_keys (path, idempotency_key, seq, data) VALUES (?, ?, ?, ?)`,
-          path,
-          key,
-          seq,
-          data,
-        )
-        inserted = true
-        return formatOffset(seq)
-      }, 'immediate')
+          const seq = this.allocateSeq(path)
+          this.sql.exec(
+            `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
+            path,
+            seq,
+            data,
+          )
+          this.sql.exec(
+            `INSERT INTO boring_event_stream_keys (path, idempotency_key, seq, data) VALUES (?, ?, ?, ?)`,
+            path,
+            key,
+            seq,
+            data,
+          )
+          inserted = true
+          return formatOffset(seq)
+        }, 'immediate')
+      })
       if (inserted) this.notifyListeners(path)
       return offset
     } catch (error) {
@@ -167,43 +180,46 @@ export class SqliteEventStreamStore implements EventStreamStore {
     let inserted = false
     try {
       // Same read-then-write shape as appendEventOnce — BEGIN IMMEDIATE required.
-      const offset = this.runTransaction(() => {
-        if (opts.idempotencyKey !== undefined) {
-          const existing = this.readIdempotencyKey(path, opts.idempotencyKey)
-          if (existing) {
-            this.assertSameAgentIdempotencyPayload(opts.idempotencyKey, existing.data, chunk)
-            return formatOffset(existing.seq)
+      const offset = await this.retryBusy(() => {
+        inserted = false
+        return this.runTransaction(() => {
+          if (opts.idempotencyKey !== undefined) {
+            const existing = this.readIdempotencyKey(path, opts.idempotencyKey)
+            if (existing) {
+              this.assertSameAgentIdempotencyPayload(opts.idempotencyKey, existing.data, chunk)
+              return formatOffset(existing.seq)
+            }
           }
-        }
 
-        const seq = this.allocateSeq(path)
-        const envelope: AgentEvent = {
-          v: 1,
-          eventIndex: seq,
-          timestamp: Date.now(),
-          sessionId,
-          chunk,
-        }
-        const data = JSON.stringify(envelope)
-        const keyData = opts.idempotencyKey === undefined ? undefined : JSON.stringify(chunk)
-        this.sql.exec(
-          `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
-          path,
-          seq,
-          data,
-        )
-        if (opts.idempotencyKey !== undefined) {
+          const seq = this.allocateSeq(path)
+          const envelope: AgentEvent = {
+            v: 1,
+            eventIndex: seq,
+            timestamp: Date.now(),
+            sessionId,
+            chunk,
+          }
+          const data = JSON.stringify(envelope)
+          const keyData = opts.idempotencyKey === undefined ? undefined : JSON.stringify(chunk)
           this.sql.exec(
-            `INSERT INTO boring_event_stream_keys (path, idempotency_key, seq, data) VALUES (?, ?, ?, ?)`,
+            `INSERT INTO boring_event_stream_entries (path, seq, data) VALUES (?, ?, ?)`,
             path,
-            opts.idempotencyKey,
             seq,
-            keyData,
+            data,
           )
-        }
-        inserted = true
-        return formatOffset(seq)
-      }, 'immediate')
+          if (opts.idempotencyKey !== undefined) {
+            this.sql.exec(
+              `INSERT INTO boring_event_stream_keys (path, idempotency_key, seq, data) VALUES (?, ?, ?, ?)`,
+              path,
+              opts.idempotencyKey,
+              seq,
+              keyData,
+            )
+          }
+          inserted = true
+          return formatOffset(seq)
+        }, 'immediate')
+      })
       if (inserted) this.notifyListeners(path)
       return offset
     } catch (error) {
@@ -265,7 +281,9 @@ export class SqliteEventStreamStore implements EventStreamStore {
   }
 
   async closeStream(path: string): Promise<void> {
-    this.sql.exec(`UPDATE boring_event_streams SET closed = 1 WHERE path = ?`, path)
+    await this.retryBusy(() => {
+      this.sql.exec(`UPDATE boring_event_streams SET closed = 1 WHERE path = ?`, path)
+    })
     this.notifyListeners(path)
   }
 
@@ -284,6 +302,23 @@ export class SqliteEventStreamStore implements EventStreamStore {
     return () => {
       bucket.delete(listener)
       if (bucket.size === 0) this.listeners.delete(path)
+    }
+  }
+
+  private async retryBusy<T>(operation: () => T): Promise<T> {
+    const deadline = Date.now() + SQLITE_BUSY_RETRY_WINDOW_MS
+    let backoffMs = SQLITE_BUSY_BACKOFF_START_MS
+
+    while (true) {
+      try {
+        return operation()
+      } catch (error) {
+        if (!isSqliteBusy(error)) throw error
+        const remainingMs = deadline - Date.now()
+        if (remainingMs <= 0) throw error
+        await delay(Math.min(backoffMs, remainingMs))
+        backoffMs = Math.min(backoffMs * 2, SQLITE_BUSY_BACKOFF_MAX_MS)
+      }
     }
   }
 
@@ -357,6 +392,16 @@ export class SqliteEventStreamStore implements EventStreamStore {
       }
     }
   }
+}
+
+function isSqliteBusy(error: unknown): boolean {
+  if (!(error instanceof Error)) return false
+  const code = (error as Error & { code?: unknown }).code
+  return (code === 'SQLITE_BUSY' || code === 'ERR_SQLITE_ERROR') && /busy|lock/i.test(error.message)
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 function clampLimit(value: number | undefined, defaultValue: number, maxValue: number): number {

--- a/packages/agent/src/server/events/sqlStorage.ts
+++ b/packages/agent/src/server/events/sqlStorage.ts
@@ -5,6 +5,11 @@ import type { DatabaseSync } from 'node:sqlite'
 
 const require = createRequire(import.meta.url)
 
+// DatabaseSync cannot yield while SQLite's busy handler waits. Keep each
+// synchronous lock wait short; write callers retry asynchronously so the
+// event loop can serve reads and unrelated work between attempts.
+export const SQLITE_BUSY_TIMEOUT_MS = 25
+
 export interface SqlResult {
   toArray(): Array<Record<string, unknown>>
 }
@@ -81,19 +86,12 @@ export function openDatabase(path: string): OpenDatabaseResult {
   const { DatabaseSync: SqliteDatabaseSync } = require('node:sqlite') as typeof import('node:sqlite')
   const db = new SqliteDatabaseSync(path)
   if (path !== ':memory:') {
-    // Matches SqliteAgentRequestLedger's pragmas (the sibling durable sqlite
-    // store): WAL lets readers and the writer proceed concurrently, and
-    // busy_timeout makes a writer wait out another connection's write lock
-    // instead of throwing SQLITE_BUSY immediately. This matters here because
-    // multiple runtime bindings for the SAME workspace scope (different
-    // agentTypeId/identity/fingerprint keys — see createAgentHost.ts's
-    // composition cache) can concurrently open the same on-disk event-stream
-    // file; each is a distinct DatabaseSync connection but they are all
-    // single in-process writers serialized by SQLite's file lock, not a
-    // multi-replica/multi-process writer setup. busy_timeout absorbs that
-    // in-process lock contention window instead of poisoning a live channel
-    // on a transient SQLITE_BUSY.
-    db.exec('PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;')
+    // WAL lets readers and the writer proceed concurrently. Keep the native
+    // busy handler short because DatabaseSync occupies the event loop while
+    // waiting; EventStreamStore retries transient writer contention
+    // asynchronously instead of allowing one call to block for seconds.
+    // Set the timeout before journal_mode so initialization is bounded too.
+    db.exec(`PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}; PRAGMA journal_mode=WAL;`)
   }
 
   return {


### PR DESCRIPTION
## Summary
- cap synchronous `node:sqlite` lock waits at 25ms instead of 5s
- retry transient SQLite writer contention asynchronously with bounded exponential backoff (250ms window)
- preserve `BEGIN IMMEDIATE` for all read-then-write transactions
- add a real worker-thread contention proof for event-loop and caller bounds

## Tests
- `pnpm --filter @hachej/boring-agent exec vitest run src/server/events/__tests__/eventStreamStore.concurrentAppend.test.ts src/server/events/__tests__/eventStreamStore.conformance.test.ts`
- `pnpm --filter @hachej/boring-agent run typecheck`
- concurrent contention suite repeated 3 additional times
