### PR TITLE
feat(full-app): config-driven bounded hostname landings (presentation-only)

### DIFF
--- a/apps/full-app/src/server/__tests__/hostnameLandings.test.ts
+++ b/apps/full-app/src/server/__tests__/hostnameLandings.test.ts
@@ -1,0 +1,187 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import Fastify, { type FastifyInstance } from 'fastify'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  HOSTNAME_LANDING_ENV,
+  createHostnameLandingRootHandler,
+  parseHostnameLandings,
+  type HostnameLandingMap,
+} from '../hostnameLandings.js'
+
+const SPA_SHELL = '<!doctype html><p>spa shell</p>'
+
+const twoAgentDemo: HostnameLandingMap = parseHostnameLandings(JSON.stringify({
+  'insurance.example.test': { title: 'Insurance Agent', summary: 'Compare policies.', ctaLabel: 'Start' },
+  'travel.example.test': { title: 'Travel Agent', summary: 'Plan trips.' },
+}))
+
+let app: FastifyInstance | undefined
+afterEach(async () => {
+  await app?.close()
+  app = undefined
+})
+
+async function build(landings: HostnameLandingMap = twoAgentDemo): Promise<FastifyInstance> {
+  const instance = Fastify()
+  instance.decorateRequest('user')
+  instance.addHook('onRequest', async (request) => {
+    ;(request as { user?: unknown }).user = request.headers.authorization
+      ? { id: 'user', email: 'user@example.test' }
+      : null
+  })
+  const root = createHostnameLandingRootHandler(landings)
+  instance.get('/', async (request, reply) => {
+    if (await root(request, reply)) return reply
+    return reply.type('text/html; charset=utf-8').send(SPA_SHELL)
+  })
+  await instance.ready()
+  return instance
+}
+
+describe('parseHostnameLandings', () => {
+  it('returns an empty map for missing or blank config', () => {
+    expect(parseHostnameLandings(undefined).size).toBe(0)
+    expect(parseHostnameLandings('  ').size).toBe(0)
+  })
+
+  it('accepts multiple exact hostnames served from one process', () => {
+    expect([...twoAgentDemo.keys()].sort()).toEqual(['insurance.example.test', 'travel.example.test'])
+  })
+
+  it.each([
+    ['invalid JSON', 'not json'],
+    ['non-object root', '["x"]'],
+    ['wildcard hostname', JSON.stringify({ '*.example.test': { title: 'T', summary: 'S' } })],
+    ['hostname with port', JSON.stringify({ 'a.example.test:443': { title: 'T', summary: 'S' } })],
+    ['uppercase hostname', JSON.stringify({ 'A.example.test': { title: 'T', summary: 'S' } })],
+    ['title over 120', JSON.stringify({ 'a.example.test': { title: 'T'.repeat(121), summary: 'S' } })],
+    ['summary over 500', JSON.stringify({ 'a.example.test': { title: 'T', summary: 'S'.repeat(501) } })],
+    ['cta over 80', JSON.stringify({ 'a.example.test': { title: 'T', summary: 'S', ctaLabel: 'C'.repeat(81) } })],
+    ['empty title', JSON.stringify({ 'a.example.test': { title: '', summary: 'S' } })],
+    ['control character', JSON.stringify({ 'a.example.test': { title: 'Bad\nTitle', summary: 'S' } })],
+    ['unknown key', JSON.stringify({ 'a.example.test': { title: 'T', summary: 'S', workspaceId: 'w' } })],
+  ])('fails fast on %s', (_name, raw) => {
+    expect(() => parseHostnameLandings(raw)).toThrow(HOSTNAME_LANDING_ENV)
+  })
+
+  it('accepts the exact text bounds', () => {
+    const map = parseHostnameLandings(JSON.stringify({
+      'a.example.test': { title: 'T'.repeat(120), summary: 'S'.repeat(500), ctaLabel: 'C'.repeat(80) },
+    }))
+    expect(map.size).toBe(1)
+  })
+})
+
+describe('hostname landing root handler', () => {
+  it('renders escaped bounded landing text with the fixed same-origin sign-in target', async () => {
+    app = await build(parseHostnameLandings(JSON.stringify({
+      'insurance.example.test': {
+        title: `Policies & <quotes> " ' é`,
+        summary: '<script>safe Unicode ø</script>',
+        ctaLabel: 'Compare & go',
+      },
+    })))
+    const response = await app.inject({
+      method: 'GET',
+      url: '/?redirect=https://evil.example',
+      headers: { host: 'insurance.example.test' },
+    })
+    expect(response.statusCode).toBe(200)
+    expect(response.headers['cache-control']).toBe('no-store')
+    expect(response.headers['content-type']).toBe('text/html; charset=utf-8')
+    expect(response.body).toContain('Policies &amp; &lt;quotes&gt; &quot; &#39; é')
+    expect(response.body).toContain('&lt;script&gt;safe Unicode ø&lt;/script&gt;')
+    expect(response.body).toContain('<a href="/auth/signin?redirect=%2F">Compare &amp; go</a>')
+    expect(response.body).not.toContain('evil.example')
+    expect(response.body).not.toMatch(/<script|style=/)
+  })
+
+  it('serves distinct landings for two hostnames from one process', async () => {
+    app = await build()
+    const insurance = await app.inject({ method: 'GET', url: '/', headers: { host: 'insurance.example.test' } })
+    const travel = await app.inject({ method: 'GET', url: '/', headers: { host: 'travel.example.test:8443' } })
+    expect(insurance.body).toContain('<h1>Insurance Agent</h1>')
+    expect(insurance.body).toContain('>Start</a>')
+    expect(travel.body).toContain('<h1>Travel Agent</h1>')
+    expect(travel.body).toContain('>Sign in</a>')
+  })
+
+  it('matches hosts exactly, never by wildcard/suffix/prefix', async () => {
+    app = await build()
+    for (const host of [
+      'sub.insurance.example.test',
+      'insurance.example.test.evil.example',
+      'xinsurance.example.test',
+      'other.example.test',
+    ]) {
+      const response = await app.inject({ method: 'GET', url: '/', headers: { host } })
+      expect(response.body, host).toBe(SPA_SHELL)
+    }
+  })
+
+  it('leaves unknown hosts untouched', async () => {
+    app = await build()
+    const response = await app.inject({ method: 'GET', url: '/', headers: { host: 'app.example.test' } })
+    expect(response.statusCode).toBe(200)
+    expect(response.body).toBe(SPA_SHELL)
+  })
+
+  it('leaves authenticated requests untouched even on a landing host', async () => {
+    app = await build()
+    const response = await app.inject({
+      method: 'GET',
+      url: '/',
+      headers: { host: 'insurance.example.test', authorization: 'session' },
+    })
+    expect(response.body).toBe(SPA_SHELL)
+  })
+
+  it('falls through untouched when no landings are configured', async () => {
+    app = await build(parseHostnameLandings(undefined))
+    const response = await app.inject({ method: 'GET', url: '/', headers: { host: 'insurance.example.test' } })
+    expect(response.body).toBe(SPA_SHELL)
+  })
+})
+
+describe('presentation-only invariant (Decision 28: zero authority)', () => {
+  it('reads nothing from the request beyond user and headers.host', async () => {
+    const handler = createHostnameLandingRootHandler(twoAgentDemo)
+    const touched: string[] = []
+    const request = new Proxy({} as Record<string, unknown>, {
+      get(_target, property) {
+        touched.push(String(property))
+        if (property === 'user') return null
+        if (property === 'headers') return { host: 'insurance.example.test' }
+        throw new Error(`landing handler must not read request.${String(property)}`)
+      },
+    })
+    const sent: string[] = []
+    const reply = {
+      status: () => reply,
+      header: () => reply,
+      type: () => reply,
+      send: (html: string) => {
+        sent.push(html)
+        return reply
+      },
+    }
+    const handled = await handler(request as never, reply as never)
+    expect(handled).toBe(true)
+    expect(sent).toHaveLength(1)
+    expect(touched.sort()).toEqual(['headers', 'user'])
+  })
+
+  it('performs no workspace/membership/session/db reads or writes (module has no such imports)', async () => {
+    const here = path.dirname(fileURLToPath(import.meta.url))
+    const source = await readFile(path.resolve(here, '../hostnameLandings.ts'), 'utf8')
+    const imports = [...source.matchAll(/^import[^\n]*from\s+'([^']+)'/gm)].map((match) => match[1])
+    // Type-only import of the core seam signature is the sole allowed import.
+    expect(imports).toEqual(['@hachej/boring-core/app/server'])
+    expect(source).toMatch(/^import type \{ CoreFrontendRootHandler \}/m)
+    expect(imports.join('\n')).not.toMatch(/workspace|membership|session|deployment|db|drizzle|node:/i)
+  })
+})

--- a/apps/full-app/src/server/hostnameLandings.ts
+++ b/apps/full-app/src/server/hostnameLandings.ts
@@ -1,0 +1,144 @@
+import type { CoreFrontendRootHandler } from '@hachej/boring-core/app/server'
+
+/**
+ * Presentation-only hostname landings (Decision 28).
+ *
+ * A landing grants ZERO authority: the request Host header selects nothing but
+ * static, trusted landing *content* configured at boot. It never routes,
+ * authorizes, or touches membership/workspace/session/default-agent state.
+ * Unauthenticated `GET /` on an exactly-matching Host gets a bounded static
+ * HTML page whose only link is the fixed same-origin sign-in path; every other
+ * request falls through untouched to the normal frontend.
+ */
+
+const SIGN_IN_PATH = '/auth/signin?redirect=%2F'
+
+export const HOSTNAME_LANDING_ENV = 'BORING_HOSTNAME_LANDINGS'
+
+export const HOSTNAME_LANDING_BOUNDS = Object.freeze({
+  title: 120,
+  summary: 500,
+  ctaLabel: 80,
+})
+
+export interface HostnameLandingContent {
+  readonly title: string
+  readonly summary: string
+  readonly ctaLabel?: string
+}
+
+/** Exact lowercase hostname (no port, no wildcard) → bounded landing content. */
+export type HostnameLandingMap = ReadonlyMap<string, HostnameLandingContent>
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  })[character]!)
+}
+
+function validText(value: unknown, max: number): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= max &&
+    !/[\0-\x1f\x7f]/.test(value)
+  )
+}
+
+// Exact lowercase DNS-style hostname; explicitly no wildcards, ports, or paths.
+const HOSTNAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,62}[a-z0-9])?)*$/
+
+function renderLanding(content: HostnameLandingContent): string | null {
+  const { title, summary, ctaLabel } = content
+  if (
+    !validText(title, HOSTNAME_LANDING_BOUNDS.title) ||
+    !validText(summary, HOSTNAME_LANDING_BOUNDS.summary) ||
+    (ctaLabel !== undefined && !validText(ctaLabel, HOSTNAME_LANDING_BOUNDS.ctaLabel))
+  ) {
+    return null
+  }
+  const cta = escapeHtml(ctaLabel ?? 'Sign in')
+  return (
+    '<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>' +
+    `${escapeHtml(title)}</title></head><body><main><h1>${escapeHtml(title)}</h1><p>${escapeHtml(summary)}</p>` +
+    `<a href="${SIGN_IN_PATH}">${cta}</a></main></body></html>`
+  )
+}
+
+/**
+ * Parse the static trusted landing config. Fails fast on any malformed entry
+ * so a bad deploy config never half-serves. Input shape:
+ * `{"agent-a.example.com":{"title":"…","summary":"…","ctaLabel":"…"}}`.
+ */
+export function parseHostnameLandings(raw: string | undefined): HostnameLandingMap {
+  const trimmed = raw?.trim()
+  if (!trimmed) return new Map()
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    throw new Error(`${HOSTNAME_LANDING_ENV}: invalid JSON`)
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${HOSTNAME_LANDING_ENV}: expected an object mapping hostname to landing content`)
+  }
+  const landings = new Map<string, HostnameLandingContent>()
+  for (const [hostname, value] of Object.entries(parsed)) {
+    if (!HOSTNAME_PATTERN.test(hostname)) {
+      throw new Error(`${HOSTNAME_LANDING_ENV}: invalid hostname ${JSON.stringify(hostname)} (exact lowercase hostname required, no wildcards or ports)`)
+    }
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      throw new Error(`${HOSTNAME_LANDING_ENV}: landing for ${hostname} must be an object`)
+    }
+    const { title, summary, ctaLabel, ...rest } = value as Record<string, unknown>
+    if (Object.keys(rest).length > 0) {
+      throw new Error(`${HOSTNAME_LANDING_ENV}: unknown keys for ${hostname}: ${Object.keys(rest).join(', ')}`)
+    }
+    if (
+      !validText(title, HOSTNAME_LANDING_BOUNDS.title) ||
+      !validText(summary, HOSTNAME_LANDING_BOUNDS.summary) ||
+      (ctaLabel !== undefined && !validText(ctaLabel, HOSTNAME_LANDING_BOUNDS.ctaLabel))
+    ) {
+      throw new Error(`${HOSTNAME_LANDING_ENV}: landing for ${hostname} is out of bounds (title<=120, summary<=500, ctaLabel<=80, no control characters)`)
+    }
+    landings.set(hostname, ctaLabel === undefined ? { title, summary } : { title, summary, ctaLabel })
+  }
+  return landings
+}
+
+function exactHost(hostHeader: unknown): string | null {
+  if (typeof hostHeader !== 'string') return null
+  // Strip a plain port suffix only; anything else must match exactly.
+  const withoutPort = hostHeader.replace(/:\d{1,5}$/, '')
+  const lowered = withoutPort.toLowerCase()
+  return HOSTNAME_PATTERN.test(lowered) ? lowered : null
+}
+
+/**
+ * Root handler for the core `frontendRootHandler` seam. Returns true (handled)
+ * only for unauthenticated `GET /` on an exact configured host; returns false
+ * (fall through, untouched) otherwise. Reads nothing beyond `request.user`
+ * and `request.headers.host`.
+ */
+export function createHostnameLandingRootHandler(landings: HostnameLandingMap): CoreFrontendRootHandler {
+  return (request, reply) => {
+    if (landings.size === 0) return false
+    if ((request as { user?: unknown }).user) return false
+    const host = exactHost(request.headers.host)
+    if (host === null) return false
+    const content = landings.get(host)
+    if (content === undefined) return false
+    const html = renderLanding(content)
+    if (html === null) return false
+    reply
+      .status(200)
+      .header('cache-control', 'no-store')
+      .type('text/html; charset=utf-8')
+      .send(html)
+    return true
+  }
+}

--- a/apps/full-app/src/server/main.ts
+++ b/apps/full-app/src/server/main.ts
@@ -17,6 +17,11 @@ import {
   registerFullAppManagedAgentMcpRoutes,
 } from './managedAgentMcp.js'
 import { assertProductionAgentModeIsSafe } from './productionSafety.js'
+import {
+  HOSTNAME_LANDING_ENV,
+  createHostnameLandingRootHandler,
+  parseHostnameLandings,
+} from './hostnameLandings.js'
 import type { WorkspaceAgentDispatcherResolver } from '@hachej/boring-agent/server'
 
 function pluginAuthoringEnabledFromEnv(): boolean {
@@ -42,6 +47,11 @@ async function main() {
     config,
     defaultAgentTypeId: 'default',
     serveFrontend: true,
+    // Presentation-only bounded landings keyed by exact Host (Decision 28);
+    // grants zero authority and never touches workspace/membership state.
+    frontendRootHandler: createHostnameLandingRootHandler(
+      parseHostnameLandings(process.env[HOSTNAME_LANDING_ENV]),
+    ),
     plugins: [...pluginComposition.plugins],
     defaultPluginPackages: [...pluginComposition.defaultPluginPackages],
     externalPlugins: false,


### PR DESCRIPTION
## Summary
- Recovers the bounded landing renderer (escaped HTML; 120/500/80-char bounds for title/summary/CTA; fixed same-origin CTA `/auth/signin?redirect=%2F`) from the deleted `agentHostLanding.ts`, re-sourced from static trusted config instead of the deployment collection.
- Config: `BORING_HOSTNAME_LANDINGS` env JSON mapping exact lowercase hostname -> `{title, summary, ctaLabel?}`; parse fails fast on malformed/out-of-bounds entries, wildcards, or ports. Multiple hostnames serve from one process (two-agent demo covered by tests).
- Integration: the existing core `frontendRootHandler` seam of `createCoreWorkspaceAgentServer` (registered at `GET /` in `registerFrontendFallback`). Unauthenticated `GET /` on an exactly-matching Host gets the bounded landing; everything else (unknown hosts, authenticated users, all other routes/assets) is untouched.

## Decision 28: zero authority
The hostname selects landing *content* only. It never routes, selects, authorizes, or touches workspace/membership/session/default-agent state. Enforced by invariant tests: a Proxy request asserts the handler reads only `user` and `headers.host`, and a module-import scan asserts the sole import is the type-only core seam signature.

## Tests
- `apps/full-app` vitest: 53 passing (22 new: escaping, exact bounds, exact-host matching incl. suffix/prefix/subdomain non-matches, unknown host untouched, authenticated untouched, empty config untouched, fail-fast config parsing, zero-authority invariants).
- `apps/full-app` `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPPbToGDvkARQZuYKFyWN