### PR TITLE
fix(transcription): support least-privilege Exoscale key

### DIFF
--- a/plugins/live-transcription/services/lifecycle/README.md
+++ b/plugins/live-transcription/services/lifecycle/README.md
@@ -6,7 +6,7 @@ This root-owned, loopback-only service leases an on-demand GPU to the live-trans
 
 - Listens only on `127.0.0.1` and requires a bearer token.
 - Rejects requests with a browser `Origin` header.
-- Exoscale credentials remain in root's Exoscale profile; they are never passed to Boring UI.
+- A dedicated Exoscale key remains in root's Exoscale profile; it is limited to `get-instance`, `start-instance`, and `stop-instance` for the configured instance and is never passed to Boring UI.
 - Starts only after `/live start` or composer dictation requests a lease.
 - Requires authenticated WebSocket readiness from **both** Kyutai and Sortformer before granting a lease.
 - Uses 30-second app heartbeats and 90-second lease expiry.
@@ -17,7 +17,9 @@ This root-owned, loopback-only service leases an on-demand GPU to the live-trans
 
 ## Installation
 
-Install `daemon.py` root-owned (mode `0755`) under `/opt/boring-gpu-lifecycle/`. Put secrets in `/etc/boring-gpu-lifecycle.env` (mode `0600`):
+Install `daemon.py` root-owned (mode `0755`) under `/opt/boring-gpu-lifecycle/`. Create a non-editable IAM role with default deny and allow only `list-zones`, `get-operation`, plus `get-instance`, `start-instance`, and `stop-instance` when `parameters.id` equals the transcription instance UUID. Bind a dedicated API key to that role and store it in root's Exoscale CLI profile.
+
+Put lifecycle secrets in `/etc/boring-gpu-lifecycle.env` (mode `0600`):
 
 ```sh
 BORING_GPU_LIFECYCLE_BEARER_TOKEN=<random 32+ byte token>

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -30,7 +30,7 @@ class ExoscaleProvider:
 
     def state(self) -> str:
         result = subprocess.run(
-            [self.exo_bin, "compute", "instance", "show", self.instance_id, "--zone", self.zone, "-O", "json"],
+            [self.exo_bin, "x", "get-instance", self.instance_id, "--zone", self.zone, "-o", "json"],
             check=True, capture_output=True, text=True, timeout=30,
         )
         return str(json.loads(result.stdout).get("state", "unknown")).lower()
@@ -44,7 +44,7 @@ class ExoscaleProvider:
     def _request_transition(self, action: str) -> None:
         try:
             subprocess.run(
-                [self.exo_bin, "compute", "instance", action, self.instance_id, "--zone", self.zone, "--force"],
+                [self.exo_bin, "x", f"{action}-instance", self.instance_id, "--zone", self.zone, "-o", "json"],
                 check=True, capture_output=True, text=True, timeout=20,
             )
         except subprocess.TimeoutExpired:

--- a/plugins/live-transcription/services/lifecycle/daemon.py
+++ b/plugins/live-transcription/services/lifecycle/daemon.py
@@ -43,10 +43,13 @@ class ExoscaleProvider:
 
     def _request_transition(self, action: str) -> None:
         try:
-            subprocess.run(
+            result = subprocess.run(
                 [self.exo_bin, "x", f"{action}-instance", self.instance_id, "--zone", self.zone, "-o", "json"],
                 check=True, capture_output=True, text=True, timeout=20,
             )
+            operation = json.loads(result.stdout)
+            if operation.get("state") == "failure":
+                raise RuntimeError(f"Exoscale {action} operation failed")
         except subprocess.TimeoutExpired:
             # exo waits for the asynchronous operation to finish. The request has
             # already been accepted; state polling below is the source of truth.

--- a/plugins/live-transcription/services/lifecycle/test_daemon.py
+++ b/plugins/live-transcription/services/lifecycle/test_daemon.py
@@ -46,9 +46,16 @@ class ExoscaleProviderTests(unittest.TestCase):
             provider.start()
             provider.stop()
         commands = [call.args[0] for call in run.call_args_list]
-        self.assertEqual(commands[0][:3], ["exo", "x", "get-instance"])
-        self.assertEqual(commands[1][:3], ["exo", "x", "start-instance"])
-        self.assertEqual(commands[2][:3], ["exo", "x", "stop-instance"])
+        self.assertEqual(commands[0], ["exo", "x", "get-instance", "instance", "--zone", "zone", "-o", "json"])
+        self.assertEqual(commands[1], ["exo", "x", "start-instance", "instance", "--zone", "zone", "-o", "json"])
+        self.assertEqual(commands[2], ["exo", "x", "stop-instance", "instance", "--zone", "zone", "-o", "json"])
+
+    def test_rejects_failed_transition_operation(self):
+        provider = MODULE.ExoscaleProvider("exo", "instance", "zone")
+        completed = MODULE.subprocess.CompletedProcess([], 0, stdout='{"state":"failure"}', stderr="")
+        with mock.patch.object(MODULE.subprocess, "run", return_value=completed):
+            with self.assertRaises(RuntimeError):
+                provider.start()
 
     def test_transition_timeout_means_request_was_accepted(self):
         provider = MODULE.ExoscaleProvider("exo", "instance", "zone")

--- a/plugins/live-transcription/services/lifecycle/test_daemon.py
+++ b/plugins/live-transcription/services/lifecycle/test_daemon.py
@@ -38,6 +38,18 @@ class ReadinessTests(unittest.TestCase):
 
 
 class ExoscaleProviderTests(unittest.TestCase):
+    def test_uses_raw_least_privilege_operations(self):
+        provider = MODULE.ExoscaleProvider("exo", "instance", "zone")
+        completed = MODULE.subprocess.CompletedProcess([], 0, stdout='{"state":"stopped"}', stderr="")
+        with mock.patch.object(MODULE.subprocess, "run", return_value=completed) as run:
+            self.assertEqual(provider.state(), "stopped")
+            provider.start()
+            provider.stop()
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertEqual(commands[0][:3], ["exo", "x", "get-instance"])
+        self.assertEqual(commands[1][:3], ["exo", "x", "start-instance"])
+        self.assertEqual(commands[2][:3], ["exo", "x", "stop-instance"])
+
     def test_transition_timeout_means_request_was_accepted(self):
         provider = MODULE.ExoscaleProvider("exo", "instance", "zone")
         with mock.patch.object(MODULE.subprocess, "run", side_effect=MODULE.subprocess.TimeoutExpired("exo", 20)):


### PR DESCRIPTION
## Summary
- use raw Exoscale `x` operations so the lifecycle daemon needs only get/start/stop permissions for one instance
- document the dedicated non-editable IAM role
- cover exact CLI operation selection

## Proof
- `python3 -m py_compile daemon.py`
- `python3 -m unittest -v test_daemon.py` (8 passed)
- `git diff --check`