### PR TITLE
feat(core): persist per-workspace default_agent_type_id (D28 requirement)

### DIFF
--- a/packages/core/drizzle/0024_workspace_default_agent_type_id.sql
+++ b/packages/core/drizzle/0024_workspace_default_agent_type_id.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "workspaces"
+  ADD COLUMN "default_agent_type_id" text;
+--> statement-breakpoint
+ALTER TABLE "workspaces"
+  ADD CONSTRAINT "workspaces_default_agent_type_id_check"
+  CHECK ("default_agent_type_id" IS NULL OR "default_agent_type_id" ~ '^[a-z][a-z0-9-]{0,62}$');

--- a/packages/core/drizzle/meta/_journal.json
+++ b/packages/core/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1784419200000,
       "tag": "0023_workspace_type_id",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1786147200000,
+      "tag": "0024_workspace_default_agent_type_id",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -101,6 +101,7 @@ import {
   type Database,
 } from '../../server/db/index.js'
 import { loadConfig, type LoadConfigOptions } from '../../server/config/index.js'
+import { resolveWorkspaceDefaultAgentTypeId } from '../../server/defaultAgentType.js'
 import { WorkspaceRuntimeSandboxHandleStore } from '../../server/runtime/index.js'
 import { createDatabaseTelemetryFromEnv } from '../../server/telemetry/db.js'
 
@@ -1550,6 +1551,20 @@ export async function createCoreWorkspaceAgentServer(
           workspaceId,
           workspaceRoot: workspaceRootForRequest,
           projectName: workspace?.name ?? 'Workspace',
+          // Decision 28: prefer the workspace's persisted default seat when it
+          // names a validated fleet member; fail closed to the boot option,
+          // then the legacy default, with a stable diagnostic code.
+          defaultAgentTypeId: resolveWorkspaceDefaultAgentTypeId({
+            persistedDefaultAgentTypeId: workspace?.defaultAgentTypeId,
+            bootDefaultAgentTypeId: options.defaultAgentTypeId,
+            availableAgentTypeIds: agents.map((agent) => agent.agentTypeId),
+            onUnknownPersistedSeat: (diagnostic) => {
+              request.log.warn(
+                { workspaceId, ...diagnostic },
+                'workspace default agent seat is not in the validated fleet; falling back',
+              )
+            },
+          }),
         }
       } catch (error) {
         if (

--- a/packages/core/src/server/__tests__/defaultAgentType.test.ts
+++ b/packages/core/src/server/__tests__/defaultAgentType.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest'
+import { ERROR_CODES } from '../../shared/errors.js'
+import {
+  LEGACY_DEFAULT_AGENT_TYPE_ID,
+  isAgentTypeId,
+  parseTrustedDefaultAgentTypeId,
+  resolveWorkspaceDefaultAgentTypeId,
+} from '../defaultAgentType.js'
+
+describe('parseTrustedDefaultAgentTypeId', () => {
+  it('maps absent values to null (no persisted default)', () => {
+    expect(parseTrustedDefaultAgentTypeId(undefined)).toBeNull()
+    expect(parseTrustedDefaultAgentTypeId(null)).toBeNull()
+  })
+
+  it('accepts the slug grammar and rejects everything else with a stable code', () => {
+    expect(parseTrustedDefaultAgentTypeId('boring-v2')).toBe('boring-v2')
+    expect(parseTrustedDefaultAgentTypeId('a')).toBe('a')
+    for (const invalid of ['', 'Default', '-seat', '0seat', 'seat_a', `a${'0'.repeat(63)}`, 42]) {
+      expect(() => parseTrustedDefaultAgentTypeId(invalid)).toThrowError(
+        expect.objectContaining({ code: ERROR_CODES.INVALID_DEFAULT_AGENT_TYPE_ID }),
+      )
+    }
+  })
+
+  it('exposes the grammar predicate', () => {
+    expect(isAgentTypeId('boring-v2')).toBe(true)
+    expect(isAgentTypeId('Boring')).toBe(false)
+  })
+})
+
+describe('resolveWorkspaceDefaultAgentTypeId', () => {
+  const fleet = ['default', 'boring-v2', 'reviewer']
+
+  it('prefers the persisted seat when it names a validated fleet member', () => {
+    expect(resolveWorkspaceDefaultAgentTypeId({
+      persistedDefaultAgentTypeId: 'reviewer',
+      bootDefaultAgentTypeId: 'boring-v2',
+      availableAgentTypeIds: fleet,
+    })).toBe('reviewer')
+  })
+
+  it('falls back to the boot option when nothing is persisted', () => {
+    expect(resolveWorkspaceDefaultAgentTypeId({
+      persistedDefaultAgentTypeId: null,
+      bootDefaultAgentTypeId: 'boring-v2',
+      availableAgentTypeIds: fleet,
+    })).toBe('boring-v2')
+    expect(resolveWorkspaceDefaultAgentTypeId({
+      persistedDefaultAgentTypeId: undefined,
+      bootDefaultAgentTypeId: 'boring-v2',
+      availableAgentTypeIds: fleet,
+    })).toBe('boring-v2')
+  })
+
+  it('falls back to the first fleet seat, then the legacy default', () => {
+    expect(resolveWorkspaceDefaultAgentTypeId({
+      persistedDefaultAgentTypeId: null,
+      bootDefaultAgentTypeId: undefined,
+      availableAgentTypeIds: fleet,
+    })).toBe('default')
+    expect(resolveWorkspaceDefaultAgentTypeId({
+      persistedDefaultAgentTypeId: null,
+      bootDefaultAgentTypeId: undefined,
+      availableAgentTypeIds: [],
+    })).toBe(LEGACY_DEFAULT_AGENT_TYPE_ID)
+  })
+
+  it('fails closed to the fallback with a stable diagnostic when the persisted seat is unknown', () => {
+    const onUnknownPersistedSeat = vi.fn()
+    expect(resolveWorkspaceDefaultAgentTypeId({
+      persistedDefaultAgentTypeId: 'retired-seat',
+      bootDefaultAgentTypeId: 'boring-v2',
+      availableAgentTypeIds: fleet,
+      onUnknownPersistedSeat,
+    })).toBe('boring-v2')
+    expect(onUnknownPersistedSeat).toHaveBeenCalledTimes(1)
+    expect(onUnknownPersistedSeat).toHaveBeenCalledWith({
+      code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
+      persistedDefaultAgentTypeId: 'retired-seat',
+      fallbackAgentTypeId: 'boring-v2',
+    })
+  })
+
+  it('never throws on an unknown persisted seat even without a diagnostic sink', () => {
+    expect(resolveWorkspaceDefaultAgentTypeId({
+      persistedDefaultAgentTypeId: 'retired-seat',
+      bootDefaultAgentTypeId: undefined,
+      availableAgentTypeIds: [],
+    })).toBe(LEGACY_DEFAULT_AGENT_TYPE_ID)
+  })
+})

--- a/packages/core/src/server/app/types.ts
+++ b/packages/core/src/server/app/types.ts
@@ -43,6 +43,11 @@ export interface WorkspaceStoreCreateOptions {
   isDefault?: boolean
   id?: string
   managedBy?: string
+  /**
+   * Persisted default Agent seat (Decision 28). Applied only at workspace
+   * initialization; an existing workspace's value is never rewritten.
+   */
+  readonly defaultAgentTypeId?: string
 }
 
 export interface WorkspaceStore {

--- a/packages/core/src/server/auth/postSignupHook.ts
+++ b/packages/core/src/server/auth/postSignupHook.ts
@@ -96,7 +96,11 @@ export function createPostSignupHook(deps: PostSignupHookDeps) {
     }
 
     if (!inviteAccepted && !disableDefaultWorkspaceCreation) {
-      await workspaceStore.create(user.id, 'Default workspace', config.appId, { isDefault: true })
+      await workspaceStore.create(user.id, 'Default workspace', config.appId, {
+        isDefault: true,
+        // Decision 28: stamp the host default seat at initialization only.
+        ...(config.defaultAgentTypeId ? { defaultAgentTypeId: config.defaultAgentTypeId } : {}),
+      })
     }
 
     if (

--- a/packages/core/src/server/config/loadConfig.ts
+++ b/packages/core/src/server/config/loadConfig.ts
@@ -268,6 +268,10 @@ export async function loadConfig(
     databaseUrl,
     stores,
 
+    ...(env.BORING_DEFAULT_AGENT_TYPE_ID
+      ? { defaultAgentTypeId: env.BORING_DEFAULT_AGENT_TYPE_ID }
+      : {}),
+
     cors: {
       origins: securityConfig.corsOrigins,
       credentials: true as const,

--- a/packages/core/src/server/config/schema.ts
+++ b/packages/core/src/server/config/schema.ts
@@ -50,6 +50,10 @@ export const coreConfigSchema = z.object({
   databaseUrl: z.string().nullable(),
   stores: z.enum(['postgres', 'local']),
 
+  // Decision 28: boot-time host default Agent seat, stamped onto workspaces
+  // at initialization. Same slug grammar as workspace type ids.
+  defaultAgentTypeId: z.string().regex(/^[a-z][a-z0-9-]{0,62}$/).optional(),
+
   cors: z.object({
     origins: z.array(z.string()),
     credentials: z.literal(true),

--- a/packages/core/src/server/db/__tests__/defaultAgentTypeId.migration.test.ts
+++ b/packages/core/src/server/db/__tests__/defaultAgentTypeId.migration.test.ts
@@ -1,0 +1,79 @@
+import { fileURLToPath } from 'node:url'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { readMigrationFiles, type MigrationMeta } from 'drizzle-orm/migrator'
+import postgres from 'postgres'
+
+const TEST_DB_URL = process.env.DATABASE_URL ?? 'postgres://ubuntu:test@localhost/boring_ui_test'
+const MIGRATIONS_FOLDER = fileURLToPath(new URL('../../../../drizzle', import.meta.url))
+const DEFAULT_AGENT_TYPE_MIGRATION_MILLIS = 1786147200000
+
+let client: postgres.Sql
+let migration: MigrationMeta
+
+async function applyMigration(sql: postgres.TransactionSql): Promise<void> {
+  for (const statement of migration.sql) {
+    if (statement.trim()) await sql.unsafe(statement)
+  }
+}
+
+beforeAll(() => {
+  client = postgres(TEST_DB_URL, { max: 1 })
+  const found = readMigrationFiles({ migrationsFolder: MIGRATIONS_FOLDER })
+    .find(({ folderMillis }) => folderMillis === DEFAULT_AGENT_TYPE_MIGRATION_MILLIS)
+  if (!found) throw new Error('0024_workspace_default_agent_type_id migration not found')
+  migration = found
+})
+
+afterAll(async () => {
+  await client.end()
+})
+
+describe('0024 workspace default agent type migration', () => {
+  it('adds a nullable column and leaves existing rows NULL (no implicit rewrite)', async () => {
+    await client.begin(async (sql) => {
+      await sql`CREATE TEMP TABLE workspaces (id integer PRIMARY KEY, name text NOT NULL) ON COMMIT DROP`
+      await sql`INSERT INTO workspaces (id, name) VALUES (1, 'Existing A'), (2, 'Existing B')`
+
+      await applyMigration(sql)
+
+      const rows = await sql`SELECT id, default_agent_type_id FROM workspaces ORDER BY id`
+      expect(rows).toEqual([
+        { id: 1, default_agent_type_id: null },
+        { id: 2, default_agent_type_id: null },
+      ])
+
+      const [column] = await sql`
+        SELECT attnotnull AS not_null
+        FROM pg_attribute
+        WHERE attrelid = 'workspaces'::regclass
+          AND attname = 'default_agent_type_id'
+      `
+      expect(column).toMatchObject({ not_null: false })
+    })
+  })
+
+  it('installs the NULL-permitting grammar constraint', async () => {
+    await client.begin(async (sql) => {
+      await sql`CREATE TEMP TABLE workspaces (id integer PRIMARY KEY, name text NOT NULL) ON COMMIT DROP`
+      await applyMigration(sql)
+
+      const [constraint] = await sql`
+        SELECT pg_get_constraintdef(oid) AS definition
+        FROM pg_constraint
+        WHERE conrelid = 'workspaces'::regclass
+          AND conname = 'workspaces_default_agent_type_id_check'
+      `
+      expect(constraint.definition).toContain("default_agent_type_id ~ '^[a-z][a-z0-9-]{0,62}$'::text")
+
+      await sql`INSERT INTO workspaces (id, name, default_agent_type_id) VALUES (1, 'Seated', 'boring-v2'), (2, 'Unseated', NULL)`
+    })
+  })
+
+  it('rejects non-slug seats via the check constraint', async () => {
+    await expect(client.begin(async (sql) => {
+      await sql`CREATE TEMP TABLE workspaces (id integer PRIMARY KEY, name text NOT NULL) ON COMMIT DROP`
+      await applyMigration(sql)
+      await sql`INSERT INTO workspaces (id, name, default_agent_type_id) VALUES (1, 'Bad seat', 'Not-A-Slug')`
+    })).rejects.toMatchObject({ code: '23514' })
+  })
+})

--- a/packages/core/src/server/db/__tests__/storeConformance.ts
+++ b/packages/core/src/server/db/__tests__/storeConformance.ts
@@ -336,6 +336,65 @@ export function describeWorkspaceStoreConformance(
     )
 
     it(
+      'persists defaultAgentTypeId at initialization and defaults to null (D28)',
+      withTaskId(TASK_ID, async ({ assertionPassed }) => {
+        const { workspaceStore, appId, users } = await setup()
+        const seated = await workspaceStore.create(users.owner.id, 'Seated WS', appId, {
+          defaultAgentTypeId: 'boring-v2',
+        })
+        expect(seated.defaultAgentTypeId).toBe('boring-v2')
+        expect((await workspaceStore.get(seated.id))?.defaultAgentTypeId).toBe('boring-v2')
+        expect((await workspaceStore.list(users.owner.id, appId))[0]?.defaultAgentTypeId).toBe('boring-v2')
+
+        const unseated = await workspaceStore.create(users.owner.id, 'Unseated WS', appId)
+        expect(unseated.defaultAgentTypeId ?? null).toBeNull()
+        expect((await workspaceStore.get(unseated.id))?.defaultAgentTypeId ?? null).toBeNull()
+        assertionPassed('default-agent-type-persisted-at-init')
+      }),
+    )
+
+    it(
+      'never rewrites an existing workspace defaultAgentTypeId implicitly (D28 write-once)',
+      withTaskId(TASK_ID, async ({ assertionPassed }) => {
+        const { workspaceStore, appId, users } = await setup()
+        const id = randomUUID()
+        await workspaceStore.create(users.owner.id, 'Write once', appId, {
+          id,
+          defaultAgentTypeId: 'boring-v2',
+        })
+        const recreated = await workspaceStore.create(users.owner.id, 'Write once', appId, {
+          id,
+          defaultAgentTypeId: 'other-seat',
+        })
+        expect(recreated.defaultAgentTypeId).toBe('boring-v2')
+
+        const updated = await workspaceStore.update(id, { name: 'Renamed' })
+        expect(updated).toMatchObject({ name: 'Renamed', defaultAgentTypeId: 'boring-v2' })
+        expect((await workspaceStore.get(id))?.defaultAgentTypeId).toBe('boring-v2')
+        assertionPassed('default-agent-type-write-once')
+      }),
+    )
+
+    it(
+      'rejects invalid defaultAgentTypeId at the trusted create seam with a stable code',
+      withTaskId(TASK_ID, async ({ assertionPassed }) => {
+        const { workspaceStore, appId, users } = await setup()
+        const invalidIds: unknown[] = ['', 'Default', '-seat', '0seat', 'seat_a', `a${'0'.repeat(63)}`]
+        for (const [index, defaultAgentTypeId] of invalidIds.entries()) {
+          await expect(workspaceStore.create(
+            users.owner.id,
+            `Invalid seat ${index}`,
+            appId,
+            { defaultAgentTypeId: defaultAgentTypeId as string },
+          )).rejects.toMatchObject({
+            code: ERROR_CODES.INVALID_DEFAULT_AGENT_TYPE_ID,
+          })
+        }
+        assertionPassed('default-agent-type-invalid-stable-code')
+      }),
+    )
+
+    it(
       'does not create workspaces as a side effect of store list or get',
       withTaskId(TASK_ID, async ({ assertionPassed }) => {
         const { workspaceStore, appId, users } = await setup()

--- a/packages/core/src/server/db/schema.ts
+++ b/packages/core/src/server/db/schema.ts
@@ -53,6 +53,7 @@ export const workspaces = pgTable(
     deletedAt: timestamp('deleted_at'),
     isDefault: boolean('is_default').notNull().default(false),
     managedBy: text('managed_by'),
+    defaultAgentTypeId: text('default_agent_type_id'),
   },
   (table) => [
     index('workspaces_created_by_idx').on(table.createdBy),
@@ -62,6 +63,10 @@ export const workspaces = pgTable(
     check(
       'workspaces_workspace_type_id_check',
       sql`${table.workspaceTypeId} ~ '^[a-z][a-z0-9-]{0,62}$'`,
+    ),
+    check(
+      'workspaces_default_agent_type_id_check',
+      sql`${table.defaultAgentTypeId} IS NULL OR ${table.defaultAgentTypeId} ~ '^[a-z][a-z0-9-]{0,62}$'`,
     ),
   ],
 )

--- a/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/LocalWorkspaceStore.ts
@@ -17,6 +17,7 @@ import {
   assertWorkspaceTypeIdNotMutable,
   parseTrustedWorkspaceTypeId,
 } from '../../workspaceType.js'
+import { parseTrustedDefaultAgentTypeId } from '../../defaultAgentType.js'
 import type { LocalUserStore } from './LocalUserStore.js'
 
 function toWorkspace(workspace: Workspace): Workspace {
@@ -36,6 +37,7 @@ export class LocalWorkspaceStore implements WorkspaceStore {
 
   async create(userId: string, name: string, appId: string, opts?: WorkspaceStoreCreateOptions): Promise<Workspace> {
     const workspaceTypeId = parseTrustedWorkspaceTypeId(opts?.workspaceTypeId)
+    const defaultAgentTypeId = parseTrustedDefaultAgentTypeId(opts?.defaultAgentTypeId)
     const id = opts?.id ?? randomUUID()
     const existing = opts?.id ? this.workspaces.get(id) : undefined
     if (existing) {
@@ -54,6 +56,7 @@ export class LocalWorkspaceStore implements WorkspaceStore {
       deletedAt: null,
       isDefault: opts?.isDefault ?? false,
       managedBy: opts?.managedBy ?? null,
+      defaultAgentTypeId,
     }
     this.workspaces.set(ws.id, ws)
     const memberKey = `${ws.id}:${userId}`

--- a/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
+++ b/packages/core/src/server/db/stores/PostgresWorkspaceStore.ts
@@ -20,6 +20,7 @@ import {
   assertWorkspaceTypeIdNotMutable,
   parseTrustedWorkspaceTypeId,
 } from '../../workspaceType.js'
+import { parseTrustedDefaultAgentTypeId } from '../../defaultAgentType.js'
 import {
   userSettings,
   users,
@@ -142,6 +143,7 @@ function toWorkspace(row: typeof workspaces.$inferSelect): Workspace {
     deletedAt: row.deletedAt?.toISOString() ?? null,
     isDefault: row.isDefault,
     managedBy: row.managedBy,
+    defaultAgentTypeId: row.defaultAgentTypeId,
   }
 }
 
@@ -171,6 +173,7 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
 
   async create(userId: string, name: string, appId: string, opts?: WorkspaceStoreCreateOptions): Promise<Workspace> {
     const workspaceTypeId = parseTrustedWorkspaceTypeId(opts?.workspaceTypeId)
+    const defaultAgentTypeId = parseTrustedDefaultAgentTypeId(opts?.defaultAgentTypeId)
     return this.db.transaction(async (tx) => {
       const insert = tx
         .insert(workspaces)
@@ -182,6 +185,7 @@ export class PostgresWorkspaceStore implements WorkspaceStore {
           createdBy: userId,
           isDefault: opts?.isDefault ?? false,
           managedBy: opts?.managedBy ?? null,
+          defaultAgentTypeId,
         })
 
       const insertedRows = opts?.id

--- a/packages/core/src/server/defaultAgentType.ts
+++ b/packages/core/src/server/defaultAgentType.ts
@@ -1,0 +1,78 @@
+import { ERROR_CODES, HttpError } from '../shared/errors.js'
+
+/**
+ * Decision 28: every initialized Workspace durably persists its
+ * `defaultAgentTypeId`. This module owns the trusted write-path validation and
+ * the read-path resolution preference order.
+ *
+ * Agent type ids share the workspace-type slug grammar (lowercase slug,
+ * <= 63 chars), matching the `workspaces_default_agent_type_id_check`
+ * constraint installed by migration 0024.
+ */
+export const AGENT_TYPE_ID_PATTERN = /^[a-z][a-z0-9-]{0,62}$/
+
+export function isAgentTypeId(value: unknown): value is string {
+  return typeof value === 'string' && AGENT_TYPE_ID_PATTERN.test(value)
+}
+
+/**
+ * Validates a server-controlled default agent type id at workspace
+ * initialization. `undefined` means "no persisted default" and maps to NULL.
+ */
+export function parseTrustedDefaultAgentTypeId(value: unknown): string | null {
+  if (value === undefined || value === null) return null
+  if (!isAgentTypeId(value)) {
+    throw new HttpError({
+      status: 400,
+      code: ERROR_CODES.INVALID_DEFAULT_AGENT_TYPE_ID,
+      message: 'Invalid default agent type ID',
+    })
+  }
+  return value
+}
+
+export interface ResolveWorkspaceDefaultAgentTypeIdInput {
+  /** Persisted per-workspace value (`workspaces.default_agent_type_id`). */
+  readonly persistedDefaultAgentTypeId: string | null | undefined
+  /** Boot-time host option (`defaultAgentTypeId`). */
+  readonly bootDefaultAgentTypeId: string | undefined
+  /** Validated fleet seats compiled at boot. */
+  readonly availableAgentTypeIds: readonly string[]
+  /** Diagnostic sink for the fail-closed fallback; stable error code attached. */
+  readonly onUnknownPersistedSeat?: (diagnostic: {
+    readonly code: typeof ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT
+    readonly persistedDefaultAgentTypeId: string
+    readonly fallbackAgentTypeId: string
+  }) => void
+}
+
+export const LEGACY_DEFAULT_AGENT_TYPE_ID = 'default'
+
+/**
+ * Read-path preference order (Decision 28):
+ *   1. the workspace's persisted `defaultAgentTypeId`, iff it names a
+ *      validated fleet seat;
+ *   2. the boot-time host `defaultAgentTypeId` option;
+ *   3. the first validated fleet seat;
+ *   4. the legacy `'default'` agent.
+ *
+ * Fails closed to the fallback chain — never throws — when the persisted
+ * value names an unknown seat; the caller receives a
+ * `default_agent_type_unknown_seat` diagnostic instead.
+ */
+export function resolveWorkspaceDefaultAgentTypeId(
+  input: ResolveWorkspaceDefaultAgentTypeIdInput,
+): string {
+  const fallback = input.bootDefaultAgentTypeId
+    ?? input.availableAgentTypeIds[0]
+    ?? LEGACY_DEFAULT_AGENT_TYPE_ID
+  const persisted = input.persistedDefaultAgentTypeId ?? null
+  if (persisted === null) return fallback
+  if (input.availableAgentTypeIds.includes(persisted)) return persisted
+  input.onUnknownPersistedSeat?.({
+    code: ERROR_CODES.DEFAULT_AGENT_TYPE_UNKNOWN_SEAT,
+    persistedDefaultAgentTypeId: persisted,
+    fallbackAgentTypeId: fallback,
+  })
+  return fallback
+}

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -11,6 +11,15 @@ export type {
   LoadConfigOptions,
 } from './config/index.js'
 
+export {
+  AGENT_TYPE_ID_PATTERN,
+  LEGACY_DEFAULT_AGENT_TYPE_ID,
+  isAgentTypeId,
+  parseTrustedDefaultAgentTypeId,
+  resolveWorkspaceDefaultAgentTypeId,
+} from './defaultAgentType.js'
+export type { ResolveWorkspaceDefaultAgentTypeIdInput } from './defaultAgentType.js'
+
 export { safeRedirect } from './security/index.js'
 
 export { createCoreApp, registerRoutes, withUserSettingsWriteLock } from './app/index.js'

--- a/packages/core/src/server/routes/workspaces.ts
+++ b/packages/core/src/server/routes/workspaces.ts
@@ -46,7 +46,12 @@ const workspaceRoutesPlugin: FastifyPluginAsync = async (app) => {
   }
 
   async function createWorkspaceForUser(userId: string, name: string, isDefault: boolean, request: FastifyRequest) {
-    const workspace = await store.create(userId, name, app.config.appId, { isDefault })
+    const workspace = await store.create(userId, name, app.config.appId, {
+      isDefault,
+      // Decision 28: stamp the host default seat at initialization only;
+      // existing workspaces are never rewritten.
+      ...(app.config.defaultAgentTypeId ? { defaultAgentTypeId: app.config.defaultAgentTypeId } : {}),
+    })
     await provisionWorkspace(workspace, userId, request)
     return workspace
   }

--- a/packages/core/src/shared/errors.ts
+++ b/packages/core/src/shared/errors.ts
@@ -11,6 +11,8 @@ export const ERROR_CODES = {
   LAST_OWNER: 'last_owner',
   INVALID_WORKSPACE_TYPE_ID: 'invalid_workspace_type_id',
   WORKSPACE_TYPE_IMMUTABLE: 'workspace_type_immutable',
+  INVALID_DEFAULT_AGENT_TYPE_ID: 'invalid_default_agent_type_id',
+  DEFAULT_AGENT_TYPE_UNKNOWN_SEAT: 'default_agent_type_unknown_seat',
 
   // Invites
   INVITE_NOT_FOUND: 'invite_not_found',

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -22,6 +22,11 @@ export type Workspace = {
   deletedAt: string | null
   isDefault: boolean
   managedBy?: string | null
+  /**
+   * Durably persisted default Agent seat for this workspace (Decision 28).
+   * Written once at workspace initialization; never rewritten implicitly.
+   */
+  readonly defaultAgentTypeId?: string | null
 }
 
 export type WorkspaceMember = {
@@ -148,6 +153,13 @@ export interface CoreConfig {
 
   databaseUrl: string | null
   stores: 'postgres' | 'local'
+
+  /**
+   * Boot-time host default Agent seat. Stamped onto workspaces at
+   * initialization (Decision 28) and used as the resolution fallback when a
+   * workspace has no persisted `defaultAgentTypeId`.
+   */
+  defaultAgentTypeId?: string
 
   cors: {
     origins: string[]


### PR DESCRIPTION
## Summary

Decision 28 requires every initialized Workspace to durably persist its `defaultAgentTypeId`; until now the default agent was only a boot-time host option. Slice 1 of the landing lane implements the persisted column, write-once initialization, and fail-closed resolution.

- **Migration 0024 + drizzle schema**: nullable `workspaces.default_agent_type_id` with a NULL-permitting slug check constraint (same grammar as `workspace_type_id`), following the hand-written SQL + journal convention.
- **Write path**: `WorkspaceStoreCreateOptions.defaultAgentTypeId` validated at the trusted create seam (stable code `invalid_default_agent_type_id`) in both Postgres and Local stores; stamped only at workspace initialization from `CoreConfig.defaultAgentTypeId` (env `BORING_DEFAULT_AGENT_TYPE_ID`) via the workspaces route and post-signup default-workspace creation. An existing workspace's value is never rewritten (create-conflict returns the existing row unchanged; `update()` cannot touch it).
- **Read path**: `resolveWorkspaceDefaultAgentTypeId` prefers the persisted seat iff it names a validated fleet member, then the boot option, then the first fleet seat, then legacy `'default'`. Unknown persisted seats fail closed to the fallback and emit stable diagnostic `default_agent_type_unknown_seat` (never throws). Wired into `GET /api/v1/workspace/meta`.

## Tests

- `defaultAgentTypeId.migration.test.ts`: column nullability, no implicit backfill, exact constraint, 23514 rejection.
- Store conformance (runs against both Local and Postgres stores): persistence at init, NULL default, write-once semantics, invalid-seat stable code.
- `defaultAgentType.test.ts`: parse grammar, resolution preference order, unknown-seat fail-closed fallback.

`pnpm -C packages/core typecheck` clean; core test suite green except pre-existing `PostgresModelBudgetStore` failures reproduced on clean origin/main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPPbToGDvkARQZuYKFyWN