### PR TITLE
fix(chat): never flash the empty-state hero while a switched session is hydrating

### DIFF
--- a/packages/agent/src/front/chat/PiChatPanel.tsx
+++ b/packages/agent/src/front/chat/PiChatPanel.tsx
@@ -469,7 +469,13 @@ export function PiChatPanel<
   const queuePreview = selectedChatState ? selectQueuePreview(selectedChatState) : []
   const messages = canonicalMessages
   const userHistory = useMemo(() => selectComposerHistoryFromCanonicalUsers(canonicalMessages), [canonicalMessages])
-  const emptyStateHydrating = statusForState(selectedChatState, sessionsLoading || chatStatePending || selectedSessionPending) === 'hydrating'
+  // A session attached with autoStart:false (external sessionId hosts) reports
+  // status 'idle' with hydrated:false until the /state snapshot lands. Treat that
+  // pre-hydration window as hydrating so the empty-state hero never flashes while
+  // an existing transcript is still loading. hydrateMessages:false hosts never
+  // hydrate, so they keep showing the hero as before.
+  const awaitingHydration = Boolean(hydrateMessages && selectedChatState && !selectedChatState.hydrated)
+  const emptyStateHydrating = statusForState(selectedChatState, sessionsLoading || chatStatePending || selectedSessionPending) === 'hydrating' || awaitingHydration
   const emptyHero = emptyPlacement === 'hero' && messages.length === 0 && queuePreview.length === 0 && !emptyStateHydrating
   const debugState = selectedPiSession?.getDebugState()
   const composerBlocked = workspaceWarmupBlocked || activeBlockers.length > 0

--- a/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
+++ b/packages/agent/src/front/chat/__tests__/PiChatPanel.test.tsx
@@ -676,6 +676,35 @@ describe('PiChatPanel sandbox shell', () => {
     expect(screen.queryByText('What should we work on?')).toBeNull()
   })
 
+  test('shows loading, not the empty hero, while an attached session is still unhydrated', async () => {
+    // External-sessionId hosts attach with autoStart:false, so the session
+    // reports status 'idle' with hydrated:false until the /state snapshot
+    // lands. That window must render the history loader, never the hero.
+    const remote = new FakeRemotePiSession(remoteState({
+      committedMessages: [],
+      sessionId: 'pi-1',
+      status: 'idle',
+      hydrated: false,
+      connection: { state: 'disconnected' },
+    }))
+
+    render(
+      <PiChatPanel
+        sessionId="pi-1"
+        serverResourcesEnabled={false}
+        storageScope="scope-a"
+        createRemoteSession={remoteFactory(remote)}
+      />,
+    )
+
+    expect((await screen.findByRole('status', { name: 'Loading chat history' })).getAttribute('aria-busy')).toBe('true')
+    expect(screen.queryByText('What should we work on?')).toBeNull()
+
+    remote.setState(remoteState({ committedMessages: [], sessionId: 'pi-1', hydrated: true }))
+    await screen.findByText('What should we work on?')
+    expect(screen.queryByRole('status', { name: 'Loading chat history' })).toBeNull()
+  })
+
   test('orders the empty hero as title, composer, then quick actions', async () => {
     const remote = new FakeRemotePiSession(remoteState({ committedMessages: [], sessionId: 'pi-empty' }))
 


### PR DESCRIPTION
## Summary
- Switching chats rendered the full "What should we work on?" hero (with suggestion cards) for the ~100–800ms hydration window before the transcript appeared. Follow-up to #1102/#1148; #1152's dock overlay cannot cover this because a session switch swaps content inside the same pane id.
- Root cause: `useExternalRemotePiSession` creates the session with `autoStart: false`, so the store starts at `status: 'idle'` with `hydrated: false` and 0 messages — `emptyStateHydrating` computed false and the hero rendered until the `/state` snapshot landed.
- Fix: treat an attached-but-unhydrated session as hydrating (`hydrateMessages && selectedChatState && !selectedChatState.hydrated`), so the loading surface shows instead of the hero. Hosts with `hydrateMessages: false` are unaffected.

## Proof
- Real-browser probe (playground, fleet mode): before — hero visible at 40/80ms after switch, no loading surface; after — `40ms hero:false loading:true`, messages by 150ms, and a genuinely new chat still shows the hero.
- New unit test: "shows loading, not the empty hero, while an attached session is still unhydrated".
- `PiChatPanel`/`PiConversationSurface`/`piChatPanelHooks` suites: 67 passed; workspace `ChatPaneStageDock.test.tsx`: 13 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qY6FajM6TUYpT8nxwfEXm