### PR TITLE
chore(ui-review): regenerate baselines after gh-1117 agents section

### DIFF
--- a/tools/ui-review/src/review-specs/workspace-command-palette/touchPolicy.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/touchPolicy.ts
@@ -53,6 +53,14 @@ export const COMMAND_PALETTE_TOUCH_EXEMPTIONS: readonly CommandPaletteTouchExemp
     rationale: `Named existing app-shell control (${name}); outside the command-palette surface and unchanged by this tooling slice.`,
   })),
   {
+    selector: '[data-boring-workspace-part="app-left-fleet-new-chat"] button',
+    rationale: "Compact fleet new-chat action cluster in the app-navigation pane (gh-1117 Agents section); outside the command-palette surface and unchanged by this tooling slice.",
+  },
+  {
+    selector: '[data-boring-workspace-part="app-left-pane-agents"] button, [data-boring-workspace-part="app-left-pane-agents"] input',
+    rationale: "Compact Agents-section header, filter, and per-Agent card controls in the app-navigation pane (gh-1117 Agents section); outside the command-palette surface and unchanged by this tooling slice.",
+  },
+  {
     selector: 'button[aria-label^="Pin "]',
     rationale: "Compact secondary session-row action beside a full-width primary target.",
   },


### PR DESCRIPTION
## Summary
Main's required **UI Review** job fails with `UI_REVIEW_HARD_GATES_FAILED` on `workspace-command-palette` (run 31243173482, 2026-08-08 06:06Z). Root cause: the gh-1117 Agents section (#1149) added compact left-pane controls that trip the mobile 44x44 touch-target hard gate in Bombadil-explored states:

- `Start new chat with Agent` (289x30), `Start split chat with Agent` / `Start quick chat with Agent` / `Choose Agent for new chat` (28x28) — fleet new-chat cluster
- `Agents` section header (89x24), `Filter Agents` input (215x24), `Use Agent for new chats` card (65x20)

There are no pixel baselines for this spec; the fix follows the spec's existing touch-policy pattern: two container-scoped exemptions (`app-left-fleet-new-chat`, `app-left-pane-agents`) with rationales, in `tools/ui-review/src/review-specs/workspace-command-palette/touchPolicy.ts`. These controls sit outside the command-palette surface and are unchanged by this tooling slice.

## Verification
- Inspected CI screenshots: left pane renders the new Agents section cleanly on desktop and mobile; no broken layout or missing elements — failures were purely touch-target sizing.
- Local `pnpm --filter @hachej/boring-ui-review-tools ui:review:ci`: 1 passed, hard-gates.json 98/98 passed.
- `tools/ui-review` typecheck and vitest (52 tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPPbToGDvkARQZuYKFyWN