### PR TITLE
feat(workspace): nest chat sessions under compact flat agent rows

### DIFF
--- a/apps/workspace-playground/e2e/multi-agent-addressed-ui.spec.ts
+++ b/apps/workspace-playground/e2e/multi-agent-addressed-ui.spec.ts
@@ -65,7 +65,9 @@ test("discovers two Agents and keeps colliding sessions, capabilities, replaceme
   await expect(alphaNew).toBeVisible({ timeout: 120_000 })
   await expect(betaNew).toBeVisible()
   await expect(page.getByRole("combobox", { name: "Filter chats by Agent" })).toHaveCount(0)
-  await page.getByRole("button", { name: "Expand Beta sessions" }).click()
+  // The disclosure toggle's accessible name is stable ("Beta; 1 chat");
+  // expanded state is exposed via aria-expanded, not the label.
+  await page.getByRole("button", { name: /^Expand Beta;/ }).click()
 
   const betaRow = page.locator(
     `[data-boring-workspace-part="app-session-row"][data-boring-agent-type-id="beta"][data-boring-session-id="${betaSessionId}"]`,
@@ -130,10 +132,13 @@ test("discovers two Agents and keeps colliding sessions, capabilities, replaceme
   await expect(page.locator('[data-boring-agent-part="chat"][data-agent-type-id="alpha"]')).toHaveAttribute("data-pi-chat-session-id", alphaSessionId!)
   await expect(page.locator('[data-boring-agent-part="chat"][data-agent-type-id="beta"]')).toHaveAttribute("data-pi-chat-session-id", betaSessionId!)
 
-  await page.getByRole("button", { name: /Collapse Alpha;/ }).click()
+  const alphaToggle = page.getByRole("button", { name: /(Expand|Collapse) Alpha;/ })
+  await expect(alphaToggle).toHaveAttribute("aria-expanded", "true")
+  await alphaToggle.click()
   await expect(betaRow).toBeVisible()
   await expect(alphaRow).toHaveCount(0)
-  await page.getByRole("button", { name: /Expand Alpha;/ }).click()
+  await expect(alphaToggle).toHaveAttribute("aria-expanded", "false")
+  await alphaToggle.click()
   await expect(alphaRow).toBeVisible()
 
   expect(addressedPaths.some((path) => path.startsWith(`${addressedPrefix}alpha/`))).toBe(true)

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -680,12 +680,13 @@ describe("WorkspaceAgentFront", () => {
       expect(screen.getByRole("button", { name: "New chat with Beta" })).toBeInTheDocument()
       expect(screen.getAllByText("Alpha one").length).toBeGreaterThan(0)
     })
-    // The Chats list is unified across the fleet: every owner's chats are
-    // listed together, labeled, with no per-Agent disclosure to open first.
-    const chats = screen.getByRole("region", { name: "Chats" })
-    expect(within(chats).getByText("Beta one")).toBeInTheDocument()
-    expect(within(chats).getByText("Beta one").closest('[data-boring-workspace-part="app-session-row"]')).toHaveTextContent("Beta")
-    expect(within(chats).getByText("Alpha one").closest('[data-boring-workspace-part="app-session-row"]')).toHaveTextContent("Alpha")
+    // Chats nest under their Agent: the addressed Agent (Alpha) starts
+    // disclosed, other owners' chats appear only after expanding their row.
+    expect(screen.getAllByText("Alpha one").length).toBeGreaterThan(0)
+    expect(screen.queryByText("Beta one")).not.toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Expand Beta; 1 chat" }))
+    const betaBlock = screen.getAllByText("Beta one")[0]!.closest('[data-boring-workspace-part="app-left-agent-sessions"]')
+    expect(betaBlock).not.toBeNull()
     expect(sessionScopes).toEqual(new Map([
       ["alpha", "fleet-ui:alpha"],
       ["beta", "fleet-ui:beta"],

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -483,7 +483,7 @@ export function AppLeftPane({
                   </div>
                 )
                 : (
-                  <div className="flex h-[26px] items-center gap-1.5 pl-6 pr-1.5 text-[12px] text-muted-foreground/80">
+                  <div className="flex min-h-[26px] items-center gap-1.5 pl-6 pr-1.5 text-[12px] text-muted-foreground/80">
                     <span>No chats yet.</span>
                     <button
                       type="button"
@@ -492,7 +492,7 @@ export function AppLeftPane({
                         onSelectAgent?.(agent.agentTypeId)
                         onCreateSession(agent.agentTypeId)
                       }}
-                      className="rounded-sm text-[12px] font-medium text-[color:var(--accent)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                      className="app-left-empty-start rounded-sm text-[12px] font-medium text-[color:var(--accent)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
                     >
                       Start one
                     </button>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -238,12 +238,26 @@ export function AppLeftPane({
   // Agent" is what exposes per-Agent settings and scoped chat creation. Hosts
   // that want the plain single-Agent shell omit `agents` entirely.
   const agentTreeEnabled = agents.length > 0
+  // Ratified layout: each Agent's chats nest under its card in single-project
+  // mode; multi-project keeps chats inside the project tree instead.
+  const nestedAgentChats = agentTreeEnabled && layoutMode !== "multi-project"
   const [agentFilter, setAgentFilter] = useState("")
   const filteredAgents = useMemo(() => {
     const query = agentFilter.trim().toLocaleLowerCase()
     return query ? agents.filter((agent) => agent.label.toLocaleLowerCase().includes(query)) : agents
   }, [agentFilter, agents])
   const [agentsSectionOpen, setAgentsSectionOpen] = useState(true)
+  // Per-Agent disclosure of the nested chat list; the addressed Agent starts
+  // open so the pane never boots to an all-collapsed, chat-less wall.
+  const [expandedAgentIds, setExpandedAgentIds] = useState<ReadonlySet<string>>(
+    () => new Set(selectedAgentTypeId ? [selectedAgentTypeId] : []),
+  )
+  const toggleAgentExpanded = (agentTypeId: string) => setExpandedAgentIds((current) => {
+    const next = new Set(current)
+    if (next.has(agentTypeId)) next.delete(agentTypeId)
+    else next.add(agentTypeId)
+    return next
+  })
   // The Chats lens is deliberately independent from the selected Agent: picking
   // a different Agent (or starting a chat with it) must never silently rewrite
   // or clear what the operator chose to look at.
@@ -291,17 +305,6 @@ export function AppLeftPane({
     () => new Map(agents.map((agent) => [agent.agentTypeId, shortAgentLabel(agent.label)])),
     [agents],
   )
-  // One unified Chats list across the fleet; the lens only narrows what it shows.
-  const lensedSessions = useMemo(
-    () => (chatsAgentLens ? regularSessions.filter((session) => session.agentTypeId === chatsAgentLens) : regularSessions),
-    [chatsAgentLens, regularSessions],
-  )
-  // Under a lens only the lensed Agent's inventory matters; reporting "no chats"
-  // while that Agent is still loading would be a false empty state.
-  const fleetSessionsPending = (chatsAgentLens
-    ? agents.filter((agent) => agent.agentTypeId === chatsAgentLens)
-    : agents
-  ).some((agent) => (agent.sessionsStatus ?? "loading") === "loading")
   const projectItems = useMemo(() => {
     const source = projects ?? []
     if (layoutMode !== "multi-project") return source
@@ -358,7 +361,7 @@ export function AppLeftPane({
   )
   const headerVisible = headerMode !== "hidden" && (layoutMode !== "multi-project" || headerMode === "workspace")
   const headerShowsBrand = headerMode === "full" && layoutMode !== "multi-project"
-  const renderSession = (session: AppLeftPaneSession, pinned: boolean, projectId = activeProjectId ?? undefined, showOwnerLabel = pinned) => {
+  const renderSession = (session: AppLeftPaneSession, pinned: boolean, projectId = activeProjectId ?? undefined, showOwnerLabel = pinned, nested = false) => {
     const isActiveProjectSession = !projectId || projectId === activeProjectId
     const sessionKey = workspaceSessionKeyFor(session)
     const state: SessionRowState = isActiveProjectSession && sessionKey === normalizedActiveSessionId && !muteActiveSession
@@ -381,8 +384,9 @@ export function AppLeftPane({
         working={working}
         attentionBadge={isActiveProjectSession ? sessionBadges.get(sessionKey) : undefined}
         activeDot={agentTreeEnabled}
-        activeDotActive={working}
-        compact={agentTreeEnabled && !pinned}
+        // The accent dot marks the active chat (spike idiom) and any working one.
+        activeDotActive={working || state === "active"}
+        compact={agentTreeEnabled && (nested || !pinned)}
         ownerLabel={showOwnerLabel && session.agentTypeId ? agentLabelById.get(session.agentTypeId) : undefined}
         onSwitch={isActiveProjectSession
           ? session.agentTypeId
@@ -413,23 +417,72 @@ export function AppLeftPane({
       onSelectAgent?.(agent.agentTypeId)
       create?.(agent.agentTypeId)
     }
-    return (
+    const expanded = nestedAgentChats && expandedAgentIds.has(agent.agentTypeId)
+    // Pinning is a shortcut, not a move: the Agent's nested list keeps every
+    // chat it owns (pinned ones carry the pin glyph), matching the count.
+    const agentSessions = nestedAgentChats && expanded
+      ? sessions.filter((session) => session.agentTypeId === agent.agentTypeId)
+      : []
+    const card = (
       <AppLeftPaneAgentCard
-        key={agent.agentTypeId}
+        key={nestedAgentChats ? undefined : agent.agentTypeId}
         agentTypeId={agent.agentTypeId}
         label={agent.label}
         description={agent.description}
         sessionCount={sessionCountByAgent.get(agent.agentTypeId) ?? 0}
         sessionsStatus={agent.sessionsStatus}
-        selected={selectedAgentTypeId === agent.agentTypeId}
         filtered={chatsAgentLens === agent.agentTypeId}
-        onSelect={onSelectAgent ? () => onSelectAgent(agent.agentTypeId) : undefined}
-        onToggleFilter={() => toggleChatsAgentLens(agent.agentTypeId)}
+        expandable={nestedAgentChats}
+        expanded={expanded}
+        // Owner-ratified: card click means exactly one thing — disclose the
+        // Agent's chats. New-chat targeting lives on the picker and the "+".
+        onToggle={nestedAgentChats ? () => toggleAgentExpanded(agent.agentTypeId) : undefined}
+        // The per-Agent lens only exists where a shared list remains to
+        // filter (the multi-project tree); nesting replaces it elsewhere.
+        onToggleFilter={nestedAgentChats ? undefined : () => toggleChatsAgentLens(agent.agentTypeId)}
         onCreateSession={createForAgent(onCreateSession)}
         onCreateSplitSession={onCreateSplitSession ? createForAgent(onCreateSplitSession) : undefined}
         onCreatePopoverSession={onCreatePopoverSession ? createForAgent(onCreatePopoverSession) : undefined}
         onOpenSettings={onOpenAgentSettings ? () => onOpenAgentSettings(agent.agentTypeId) : undefined}
       />
+    )
+    if (!nestedAgentChats) return card
+    return (
+      <div key={agent.agentTypeId} className="space-y-0.5">
+        {card}
+        {expanded ? (
+          <div
+            data-boring-workspace-part="app-left-agent-sessions"
+            className="ml-3 space-y-px border-l border-border pl-0.5"
+          >
+            {agentSessions.length > 0
+              ? agentSessions.map((session) => renderSession(session, pinnedSet.has(workspaceSessionKeyFor(session)), activeProjectId ?? undefined, false, true))
+              : (agent.sessionsStatus ?? "loading") === "loading"
+                ? (
+                  <div data-boring-workspace-part="app-left-chats-loading-surface" className="space-y-1 px-1 py-1" aria-label="Loading chats">
+                    <Skeleton className="h-6 w-full rounded-md" />
+                    <Skeleton className="h-6 w-3/4 rounded-md" />
+                  </div>
+                )
+                : (
+                  <div className="flex h-[26px] items-center gap-1.5 pl-6 pr-1.5 text-[12px] text-muted-foreground/80">
+                    <span>No chats yet.</span>
+                    <button
+                      type="button"
+                      data-boring-mobile-dismiss="true"
+                      onClick={() => {
+                        onSelectAgent?.(agent.agentTypeId)
+                        onCreateSession(agent.agentTypeId)
+                      }}
+                      className="rounded-sm text-[12px] font-medium text-[color:var(--accent)] hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+                    >
+                      Start one
+                    </button>
+                  </div>
+                )}
+          </div>
+        ) : null}
+      </div>
     )
   })
 
@@ -515,27 +568,6 @@ export function AppLeftPane({
       <X className="size-3 shrink-0" strokeWidth={2} aria-hidden="true" />
     </button>
   ) : null
-  const renderFleetChatsSection = () => (
-    <section data-boring-workspace-part="app-left-pane-chats" aria-label="Chats" className="space-y-1">
-      <div className="flex items-center gap-1.5 px-2 pb-0.5">
-        <span className="shrink-0 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/75">Chats</span>
-        {renderLensChip()}
-        <span className="ml-auto shrink-0 text-[10px] font-normal tabular-nums text-muted-foreground/75">{lensedSessions.length}</span>
-      </div>
-      {lensedSessions.length === 0 && fleetSessionsPending ? (
-        <div data-boring-workspace-part="app-left-chats-loading-surface" className="space-y-1 px-2 py-1" aria-label="Loading chats">
-          <Skeleton className="h-[30px] w-full rounded-md" />
-          <Skeleton className="h-[30px] w-4/5 rounded-md" />
-          <Skeleton className="h-[30px] w-3/5 rounded-md" />
-        </div>
-      ) : (
-        <SessionSubSection empty={chatsAgentLens ? `No chats with ${lensAgentLabel} yet.` : "No chats yet."}>
-          {lensedSessions.map((session) => renderSession(session, false, activeProjectId ?? undefined, true))}
-        </SessionSubSection>
-      )}
-    </section>
-  )
-
   // Shared renderer for both the pinned project rows (in Pinned) and the rest
   // (in Projects), so they share one expand/pin state and identical behavior.
   const renderProjectTree = (items: AppLeftPaneProject[]) => (
@@ -668,11 +700,9 @@ export function AppLeftPane({
                   </SessionSubSection>
                 )
               ) : null}
+              {/* Nested layout: each Agent's chats live under its card. */}
               {agentTreeEnabled ? (
-                <>
-                  {renderAgentsSection()}
-                  {renderFleetChatsSection()}
-                </>
+                renderAgentsSection()
               ) : (
                 <SessionSubSection title={pinnedSessions.length > 0 ? "Recent" : undefined} empty={sessionsLoading ? "Loading chats…" : "No chats yet."}>
                   {regularSessions.map((session) => renderSession(session, false))}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useMemo, useState, type ReactNode } from "react"
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { ChevronRight, Plus, Search, X } from "lucide-react"
 import { Skeleton } from "@hachej/boring-ui-kit"
 import { AppLeftPaneHeader } from "./AppLeftPaneHeader"
@@ -252,6 +252,17 @@ export function AppLeftPane({
   const [expandedAgentIds, setExpandedAgentIds] = useState<ReadonlySet<string>>(
     () => new Set(selectedAgentTypeId ? [selectedAgentTypeId] : []),
   )
+  // Selection often resolves after the first render (async Agent discovery).
+  // Disclose the addressed Agent whenever selection lands on a new one, but
+  // never fight an explicit collapse of the currently selected Agent.
+  const lastAutoExpandedAgentIdRef = useRef<string | undefined>(selectedAgentTypeId ?? undefined)
+  useEffect(() => {
+    if (!selectedAgentTypeId || lastAutoExpandedAgentIdRef.current === selectedAgentTypeId) return
+    lastAutoExpandedAgentIdRef.current = selectedAgentTypeId
+    setExpandedAgentIds((current) => (
+      current.has(selectedAgentTypeId) ? current : new Set([...current, selectedAgentTypeId])
+    ))
+  }, [selectedAgentTypeId])
   const toggleAgentExpanded = (agentTypeId: string) => setExpandedAgentIds((current) => {
     const next = new Set(current)
     if (next.has(agentTypeId)) next.delete(agentTypeId)
@@ -448,11 +459,18 @@ export function AppLeftPane({
     )
     if (!nestedAgentChats) return card
     return (
-      <div key={agent.agentTypeId} className="space-y-0.5">
+      <div
+        key={agent.agentTypeId}
+        data-boring-workspace-part="app-left-agent-tree"
+        data-boring-agent-type-id={agent.agentTypeId}
+        className="space-y-0.5"
+      >
         {card}
         {expanded ? (
           <div
             data-boring-workspace-part="app-left-agent-sessions"
+            role="region"
+            aria-label={`${agent.label} sessions`}
             className="ml-3 space-y-px border-l border-border pl-0.5"
           >
             {agentSessions.length > 0

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentCards.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentCards.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Columns2, ListFilter, Plus, Settings, Zap } from "lucide-react"
+import { ChevronRight, Columns2, ListFilter, Plus, Settings, Zap } from "lucide-react"
 import { cn } from "../../lib/utils"
 
 /** Agent labels are workspace-branded upstream; the pane shows the short form. */
@@ -14,18 +14,25 @@ export interface AppLeftPaneAgentCardProps {
   description?: string
   sessionCount: number
   sessionsStatus?: "loading" | "loaded" | "error"
-  selected: boolean
-  /** The Chats lens is an optional filter, independent from the selected Agent. */
+  /** The Chats lens is an optional filter (multi-project tree only). */
   filtered: boolean
-  onSelect?: () => void
-  onToggleFilter: () => void
+  /**
+   * When the pane nests each Agent's chats under its card, the card is a
+   * disclosure row: default click means exactly one thing — toggle its nested
+   * chat list. New-chat targeting lives on the New chat picker and the "+".
+   */
+  expandable?: boolean
+  expanded?: boolean
+  onToggle?: () => void
+  /** Omitted in nested mode: the disclosure replaces the per-Agent lens. */
+  onToggleFilter?: () => void
   onCreateSession: () => void
   onCreateSplitSession?: () => void
   onCreatePopoverSession?: () => void
   onOpenSettings?: () => void
 }
 
-const cardActionClassName = "app-left-secondary-action grid size-7 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors motion-reduce:transition-none hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+const cardActionClassName = "app-left-secondary-action grid size-6 shrink-0 place-items-center rounded-md text-muted-foreground transition-colors motion-reduce:transition-none hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 
 export function AppLeftPaneAgentCard({
   agentTypeId,
@@ -33,9 +40,10 @@ export function AppLeftPaneAgentCard({
   description,
   sessionCount,
   sessionsStatus,
-  selected,
   filtered,
-  onSelect,
+  expandable = false,
+  expanded = false,
+  onToggle,
   onToggleFilter,
   onCreateSession,
   onCreateSplitSession,
@@ -43,8 +51,8 @@ export function AppLeftPaneAgentCard({
   onOpenSettings,
 }: AppLeftPaneAgentCardProps) {
   const short = shortAgentLabel(label)
-  // Only fleets that publish a description get a second line; repeating the
-  // Agent type id under its own label would be noise, not identity.
+  // The description no longer earns a second line: compact rows show it only
+  // as the row tooltip so Agent rows match session-row density.
   const subtitle = description?.trim() || undefined
   const countLabel = sessionsStatus === "error"
     ? "chats unavailable"
@@ -54,46 +62,51 @@ export function AppLeftPaneAgentCard({
     <div
       data-boring-workspace-part="app-left-agent-card"
       data-boring-agent-type-id={agentTypeId}
-      data-selected={selected ? "true" : "false"}
       data-filtered={filtered ? "true" : "false"}
+      data-expanded={expandable ? (expanded ? "true" : "false") : undefined}
       className={cn(
-        "app-left-agent-card group relative flex w-full items-center gap-1 rounded-lg border px-1.5 py-1.5 transition-colors motion-reduce:transition-none",
-        "focus-within:ring-2 focus-within:ring-ring/40",
-        selected
-          ? "border-[color:oklch(from_var(--accent)_l_c_h/0.35)] bg-[color:oklch(from_var(--accent)_l_c_h/0.09)]"
-          : "border-border/45 bg-foreground/[0.015] hover:border-border/70 hover:bg-foreground/[0.045]",
+        // Owner-ratified look: flat compact rows (no card borders/boxes),
+        // session-row density; hover reveals the secondary actions.
+        "app-left-agent-card group relative flex min-h-7 w-full items-center gap-0.5 rounded-md px-1 py-0.5 transition-colors motion-reduce:transition-none",
+        // Tint on hover only — a mouse click must not leave a lingering ring
+        // that reads as "selected"; keyboard focus still gets its ring.
+        "hover:bg-foreground/[0.05] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/40",
       )}
     >
       <button
         type="button"
-        data-boring-mobile-dismiss="true"
-        aria-pressed={selected}
-        aria-label={`Use ${label} for new chats; ${countLabel}`}
-        title={subtitle}
-        onClick={onSelect}
-        disabled={!onSelect}
-        className="flex min-w-0 flex-1 flex-col items-start gap-0.5 rounded-md px-1 py-0.5 text-left focus-visible:outline-none disabled:cursor-default"
+        aria-expanded={expandable ? expanded : undefined}
+        aria-label={`${label}; ${countLabel}`}
+        title={subtitle ? `${label} — ${subtitle}` : label}
+        onClick={onToggle}
+        disabled={!onToggle}
+        className="flex h-6 min-w-0 flex-1 items-center gap-1 rounded-md px-0.5 text-left focus-visible:outline-none disabled:cursor-default"
       >
-        <span className="flex w-full min-w-0 items-center gap-1.5">
-          <span className={cn("min-w-0 flex-1 truncate text-[13px] leading-4", selected ? "font-semibold text-foreground" : "font-medium text-foreground/85")}>
-            {short}
-          </span>
-          <span
-            data-boring-agent-session-count="true"
-            className="shrink-0 rounded-full bg-foreground/[0.07] px-1.5 text-[10px] font-medium leading-4 tabular-nums text-muted-foreground"
-          >
-            {sessionsStatus === "error" ? "!" : sessionCount}
-          </span>
-        </span>
-        {subtitle ? (
-          <span className="w-full min-w-0 truncate text-[11px] leading-4 text-muted-foreground/85">{subtitle}</span>
+        {expandable ? (
+          <ChevronRight
+            className={cn("size-3 shrink-0 text-muted-foreground/70 transition-transform motion-reduce:transition-none", expanded && "rotate-90")}
+            strokeWidth={1.75}
+            aria-hidden="true"
+          />
         ) : null}
+        <span className={cn("min-w-0 truncate text-[13px] font-semibold leading-4", expandable && expanded ? "text-foreground" : "text-foreground/85")}>
+          {short}
+        </span>
+        <span
+          data-boring-agent-session-count="true"
+          className="min-w-0 flex-1 shrink-0 pl-0.5 text-[11px] font-normal leading-4 tabular-nums text-muted-foreground/80"
+        >
+          {sessionsStatus === "error" ? "!" : sessionCount}
+        </span>
       </button>
       {/*
         Secondary actions collapse to zero width off-hover so the Agent label
         gets the whole card, matching the session-row / new-chat idiom.
       */}
-      <span className="app-left-agent-card-actions flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity] motion-reduce:transition-none group-hover:w-auto group-hover:opacity-100 group-focus-within:w-auto group-focus-within:opacity-100 data-[filtered=true]:w-auto data-[filtered=true]:opacity-100" data-filtered={filtered ? "true" : "false"}>
+      {/* Reveal on hover or keyboard focus; a mouse click on the row must not
+          leave the icons pinned open (plain focus-within would). */}
+      <span className="app-left-agent-card-actions flex w-0 shrink-0 items-center gap-0.5 overflow-hidden opacity-0 transition-[width,opacity] motion-reduce:transition-none group-hover:w-auto group-hover:opacity-100 group-has-[:focus-visible]:w-auto group-has-[:focus-visible]:opacity-100 data-[filtered=true]:w-auto data-[filtered=true]:opacity-100" data-filtered={filtered ? "true" : "false"}>
+        {onToggleFilter ? (
         <button
           type="button"
           aria-label={`${filtered ? "Clear" : "Show only"} ${label} chats`}
@@ -107,6 +120,7 @@ export function AppLeftPaneAgentCard({
         >
           <ListFilter className="size-3.5" strokeWidth={1.75} aria-hidden="true" />
         </button>
+        ) : null}
         {onCreateSplitSession ? (
           <button
             type="button"
@@ -144,7 +158,7 @@ export function AppLeftPaneAgentCard({
           </button>
         ) : null}
       </span>
-      {/* Item 3: the "+" is the card's primary affordance, so it never hides. */}
+      {/* The "+" is the card's primary affordance, so it never hides. */}
       <button
         type="button"
         aria-label={`New chat with ${label}`}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentCards.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneAgentCards.tsx
@@ -69,7 +69,7 @@ export function AppLeftPaneAgentCard({
       className={cn(
         // Owner-ratified look: flat compact rows (no card borders/boxes),
         // session-row density; hover reveals the secondary actions.
-        "app-left-agent-card group relative flex min-h-7 w-full items-center gap-0.5 rounded-md px-1 py-0.5 transition-colors motion-reduce:transition-none",
+        "app-left-agent-card app-left-agent-row group relative flex min-h-7 w-full items-center gap-0.5 rounded-md px-1 py-0.5 transition-colors motion-reduce:transition-none",
         // Tint on hover only — a mouse click must not leave a lingering ring
         // that reads as "selected"; keyboard focus still gets its ring.
         "hover:bg-foreground/[0.05] has-[:focus-visible]:ring-2 has-[:focus-visible]:ring-ring/40",
@@ -78,7 +78,7 @@ export function AppLeftPaneAgentCard({
       <button
         type="button"
         aria-expanded={expandable ? expanded : undefined}
-        aria-label={`${label}; ${countLabel}`}
+        aria-label={`${expandable ? `${expanded ? "Collapse" : "Expand"} ` : ""}${label}; ${countLabel}`}
         title={subtitle ? `${label} — ${subtitle}` : label}
         onClick={onToggle}
         disabled={!onToggle}
@@ -130,7 +130,7 @@ export function AppLeftPaneAgentCard({
             title="New chat in split pane"
             data-boring-mobile-dismiss="true"
             onClick={onCreateSplitSession}
-            className={cardActionClassName}
+            className={cn(cardActionClassName, "app-left-agent-card-optional")}
           >
             <Columns2 className="size-3.5" strokeWidth={1.75} aria-hidden="true" />
           </button>
@@ -142,7 +142,7 @@ export function AppLeftPaneAgentCard({
             title="Quick chat"
             data-boring-mobile-dismiss="true"
             onClick={onCreatePopoverSession}
-            className={cardActionClassName}
+            className={cn(cardActionClassName, "app-left-agent-card-optional")}
           >
             <Zap className="size-3.5" strokeWidth={1.85} aria-hidden="true" />
           </button>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneSessionRow.tsx
@@ -75,15 +75,19 @@ export function AppSessionRow({
   })
   const activate = () => onSwitch?.(session.id)
   const rowClassName = cn(
-    "flex h-full w-full items-center gap-2 rounded-md px-2 text-left transition-colors motion-reduce:transition-none",
+    "flex h-full w-full items-center rounded-md text-left transition-colors motion-reduce:transition-none",
+    compact ? "gap-1.5 px-1.5" : "gap-2 px-2",
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
     !actionsAvailable && "opacity-60",
+    // Active stays quiet: one step past the hover tint plus the accent dot,
+    // so the guide line and the rest of the pane keep their weight.
     state === "active"
-      ? "bg-[color:oklch(from_var(--accent)_l_c_h/0.14)] text-foreground"
+      ? "bg-foreground/[0.07] text-foreground"
       : state === "open"
         ? "bg-foreground/[0.05] text-foreground/90 hover:bg-foreground/[0.08]"
         : "text-foreground/78 hover:bg-foreground/[0.055] hover:text-foreground",
   )
+  const leadingSlotClassName = compact ? "relative grid h-5 w-3 shrink-0 place-items-center" : "relative grid size-5 shrink-0 place-items-center"
 
   return (
     <div
@@ -105,7 +109,7 @@ export function AppSessionRow({
     >
       {rename.field ? (
         <div className={rowClassName}>
-          <span className="relative grid size-5 shrink-0 place-items-center" aria-hidden="true">
+          <span className={leadingSlotClassName} aria-hidden="true">
             <MessageSquare className="h-4 w-4 text-[color:var(--accent)]" strokeWidth={1.75} />
           </span>
           <InlineSessionRename field={rename.field} onCancel={rename.cancel} />
@@ -120,11 +124,25 @@ export function AppSessionRow({
           className={rowClassName}
           title={title}
         >
-          <span className="relative grid size-5 shrink-0 place-items-center" aria-hidden={activeDot ? undefined : "true"}>
+          {activeDot && state === "active" ? (
+            // The open chat announces itself with a discreet accent rail at
+            // the row edge; the dot is reserved for a chat that is working.
+            <span
+              aria-hidden="true"
+              data-boring-workspace-part="app-session-active-rail"
+              className="absolute left-0 top-1/2 h-4 w-[2px] -translate-y-1/2 rounded-full bg-[color:var(--accent)]"
+            />
+          ) : null}
+          <span className={leadingSlotClassName} aria-hidden={activeDot ? undefined : "true"}>
             {activeDot ? (
-              activeDotActive ? (
-                <span title="Active session" className="size-2 rounded-full bg-[color:var(--accent)]">
-                  <span className="sr-only">Active session</span>
+              activeDotActive && working ? (
+                // Pulsing accent dot = working. Under reduced motion the
+                // pulse stops and the dot dims instead.
+                <span
+                  title="Working"
+                  className="size-2 animate-pulse rounded-full bg-[color:var(--accent)] motion-reduce:animate-none motion-reduce:opacity-60"
+                >
+                  <span className="sr-only">Working</span>
                 </span>
               ) : null
             ) : (

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -89,10 +89,10 @@ describe("AppLeftPane", () => {
     const user = userEvent.setup()
     const handlers = renderFleetPane()
 
-    const cards = screen.getAllByRole("button", { name: /^Boring .*chats?$/ })
+    const cards = screen.getAllByRole("button", { name: /Boring .*chats?$/ })
     expect(cards.map((card) => card.getAttribute("aria-label"))).toEqual([
-      "Boring Alpha; 2 chats",
-      "Boring Beta; 1 chat",
+      "Collapse Boring Alpha; 2 chats",
+      "Expand Boring Beta; 1 chat",
     ])
     // Compact rows: the description survives only as the row tooltip; the row
     // itself stays a single line at session-row density.
@@ -128,14 +128,14 @@ describe("AppLeftPane", () => {
     expect(toggle).toHaveAttribute("aria-expanded", "true")
     await user.click(toggle)
     expect(toggle).toHaveAttribute("aria-expanded", "false")
-    expect(screen.queryByRole("button", { name: /^Boring Alpha;/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Boring Alpha;/ })).not.toBeInTheDocument()
     expect(screen.queryByRole("searchbox", { name: "Filter Agents" })).not.toBeInTheDocument()
     // Nested chats collapse with their Agents; pinned chats stay top-level.
     expect(screen.queryByText("Alpha follow-up")).not.toBeInTheDocument()
     expect(screen.getByText("Alpha session")).toBeInTheDocument()
 
     await user.click(toggle)
-    expect(screen.getByRole("button", { name: /^Boring Alpha;/ })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Boring Alpha;/ })).toBeInTheDocument()
   })
 
   it("nests each Agent's chats under its card behind a disclosure", async () => {
@@ -153,11 +153,11 @@ describe("AppLeftPane", () => {
     // Beta is collapsed: its chats are hidden until disclosed.
     expect(screen.queryByText("Beta session")).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: "Boring Beta; 1 chat" }))
+    await user.click(screen.getByRole("button", { name: /Boring Beta; 1 chat$/ }))
     expect(screen.getByText("Beta session").closest('[data-boring-workspace-part="app-left-agent-sessions"]')).toBeInTheDocument()
 
     // Collapse alpha again: its nested chats disappear, beta's stay.
-    await user.click(screen.getByRole("button", { name: "Boring Alpha; 2 chats" }))
+    await user.click(screen.getByRole("button", { name: /Boring Alpha; 2 chats$/ }))
     expect(screen.queryByText("Alpha follow-up")).not.toBeInTheDocument()
     expect(screen.getByText("Beta session")).toBeInTheDocument()
   })
@@ -193,8 +193,8 @@ describe("AppLeftPane", () => {
     await waitFor(() => expect(screen.getAllByTitle("Working")).toHaveLength(2))
 
     await user.type(screen.getByRole("searchbox", { name: "Filter Agents" }), "beta")
-    expect(screen.queryByRole("button", { name: /^Boring Alpha;/ })).not.toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /^Boring Beta;/ })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /Boring Alpha;/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Boring Beta;/ })).toBeInTheDocument()
   })
 
   it("defaults the plain fleet new chat to the selected Agent", async () => {
@@ -257,7 +257,7 @@ describe("AppLeftPane", () => {
 
     // A fleet of one still gets a card, which is the only route to per-Agent
     // settings now that they no longer live on a generic control.
-    expect(screen.getByRole("button", { name: "Boring Solo; 1 chat" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Boring Solo; 1 chat$/ })).toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: "New chat with Boring Solo" }))
     expect(onCreateSession).toHaveBeenCalledWith("solo")
     await user.click(screen.getByRole("button", { name: "Settings for Boring Solo" }))
@@ -324,7 +324,7 @@ describe("AppLeftPane", () => {
       pinnedSessionRefs: [],
     })
 
-    await user.click(screen.getByRole("button", { name: "Boring Beta; 0 chats" }))
+    await user.click(screen.getByRole("button", { name: /Boring Beta; 0 chats$/ }))
     expect(screen.queryByText("No chats yet.")).not.toBeInTheDocument()
     expect(screen.getByLabelText("Loading chats")).toBeInTheDocument()
   })

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -89,20 +89,25 @@ describe("AppLeftPane", () => {
     const user = userEvent.setup()
     const handlers = renderFleetPane()
 
-    const cards = screen.getAllByRole("button", { name: /^Use Boring .* for new chats/ })
+    const cards = screen.getAllByRole("button", { name: /^Boring .*chats?$/ })
     expect(cards.map((card) => card.getAttribute("aria-label"))).toEqual([
-      "Use Boring Alpha for new chats; 2 chats",
-      "Use Boring Beta for new chats; 1 chat",
+      "Boring Alpha; 2 chats",
+      "Boring Beta; 1 chat",
     ])
-    // Item 2: the card carries the Agent's description when the fleet publishes
-    // one, and stays a single clean line when it does not.
-    expect(screen.getByText("Ships code")).toBeInTheDocument()
+    // Compact rows: the description survives only as the row tooltip; the row
+    // itself stays a single line at session-row density.
+    expect(screen.queryByText("Ships code")).not.toBeInTheDocument()
+    expect(cards[0]).toHaveAttribute("title", "Boring Alpha — Ships code")
     expect(cards[1]).toHaveTextContent(/^Beta1$/)
-    expect(cards[0]).toHaveAttribute("aria-pressed", "true")
-    expect(cards[1]).toHaveAttribute("aria-pressed", "false")
+    // The addressed Agent starts disclosed; the other starts collapsed.
+    expect(cards[0]).toHaveAttribute("aria-expanded", "true")
+    expect(cards[1]).toHaveAttribute("aria-expanded", "false")
 
+    // Owner-ratified: default click means exactly one thing — disclosure. It
+    // never silently retargets new chats.
     await user.click(cards[1]!)
-    expect(handlers.onSelectAgent).toHaveBeenCalledWith("beta")
+    expect(cards[1]).toHaveAttribute("aria-expanded", "true")
+    expect(handlers.onSelectAgent).not.toHaveBeenCalled()
 
     await user.click(screen.getByRole("button", { name: "New chat with Boring Beta" }))
     expect(handlers.onCreateSession).toHaveBeenCalledWith("beta")
@@ -115,7 +120,7 @@ describe("AppLeftPane", () => {
     expect(handlers.onOpenAgentDetails).not.toHaveBeenCalled()
   })
 
-  it("collapses the Agents section without touching the Chats list", async () => {
+  it("collapses the Agents section including the nested chats", async () => {
     const user = userEvent.setup()
     renderFleetPane()
 
@@ -123,54 +128,73 @@ describe("AppLeftPane", () => {
     expect(toggle).toHaveAttribute("aria-expanded", "true")
     await user.click(toggle)
     expect(toggle).toHaveAttribute("aria-expanded", "false")
-    expect(screen.queryByRole("button", { name: /^Use Boring Alpha/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /^Boring Alpha;/ })).not.toBeInTheDocument()
     expect(screen.queryByRole("searchbox", { name: "Filter Agents" })).not.toBeInTheDocument()
-    // The unified Chats list is independent of the Agents disclosure.
-    expect(screen.getByText("Beta session")).toBeInTheDocument()
-    expect(screen.getByText("Alpha follow-up")).toBeInTheDocument()
+    // Nested chats collapse with their Agents; pinned chats stay top-level.
+    expect(screen.queryByText("Alpha follow-up")).not.toBeInTheDocument()
+    expect(screen.getByText("Alpha session")).toBeInTheDocument()
 
     await user.click(toggle)
-    expect(screen.getByRole("button", { name: /^Use Boring Alpha/ })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^Boring Alpha;/ })).toBeInTheDocument()
   })
 
-  it("keeps one labeled Chats list across Agents and filters it through an independent lens", async () => {
+  it("nests each Agent's chats under its card behind a disclosure", async () => {
     const user = userEvent.setup()
-    const handlers = renderFleetPane()
+    renderFleetPane()
 
-    const chats = screen.getByRole("region", { name: "Chats" })
-    // Item 4: every unpinned row names its owning Agent in one shared list.
-    expect(within(chats).getByText("Alpha follow-up").closest('[data-boring-workspace-part="app-session-row"]')).toHaveTextContent("Alpha")
-    expect(within(chats).getByText("Beta session").closest('[data-boring-workspace-part="app-session-row"]')).toHaveTextContent("Beta")
+    // The addressed Agent (alpha) starts expanded; its unpinned chats render
+    // in the guided sub-list under the card. Pinned chats stay top-level.
+    const alphaSessions = screen.getByText("Alpha follow-up").closest('[data-boring-workspace-part="app-left-agent-sessions"]')
+    expect(alphaSessions).toBeInTheDocument()
     expect(screen.getByText("Pinned chats")).toBeInTheDocument()
+    // Pinning is a shortcut, not a move: the pinned chat shows in Pinned AND
+    // stays inside its Agent's nested list, keeping the count honest.
+    expect(screen.getAllByText("Alpha session")).toHaveLength(2)
+    // Beta is collapsed: its chats are hidden until disclosed.
+    expect(screen.queryByText("Beta session")).not.toBeInTheDocument()
 
-    // Item 5: the lens narrows the shared list, it does not restructure it.
-    await user.click(screen.getByRole("button", { name: "Show only Boring Beta chats" }))
-    expect(within(chats).queryByText("Alpha follow-up")).not.toBeInTheDocument()
-    expect(within(chats).getByText("Beta session")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Boring Beta; 1 chat" }))
+    expect(screen.getByText("Beta session").closest('[data-boring-workspace-part="app-left-agent-sessions"]')).toBeInTheDocument()
 
-    // Ratified: switching or creating for another Agent must never reset the lens.
-    await user.click(screen.getByRole("button", { name: /^Use Boring Alpha/ }))
-    await user.click(screen.getByRole("button", { name: "New chat with Boring Alpha" }))
-    expect(handlers.onCreateSession).toHaveBeenCalledWith("alpha")
-    expect(within(chats).queryByText("Alpha follow-up")).not.toBeInTheDocument()
+    // Collapse alpha again: its nested chats disappear, beta's stay.
+    await user.click(screen.getByRole("button", { name: "Boring Alpha; 2 chats" }))
+    expect(screen.queryByText("Alpha follow-up")).not.toBeInTheDocument()
+    expect(screen.getByText("Beta session")).toBeInTheDocument()
+  })
 
-    await user.click(screen.getByRole("button", { name: "Clear Beta chat filter" }))
-    expect(within(chats).getByText("Alpha follow-up")).toBeInTheDocument()
+  it("drops the per-Agent lens in nested mode: disclosure is the only scoping", () => {
+    renderFleetPane()
+
+    // With chats nested under their Agents there is no shared list left to
+    // filter, so the confusing per-card filter state is gone entirely.
+    expect(screen.queryByRole("button", { name: /^Show only .* chats$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("region", { name: "Chats" })).not.toBeInTheDocument()
+  })
+
+  it("marks the active chat with a quiet rail, not a dot", () => {
+    renderFleetPane({ activeSessionRef: { agentTypeId: "alpha", sessionId: "alpha-one" } })
+
+    // The static dot is reserved for working chats; the open chat gets the
+    // discreet accent rail at the row edge instead.
+    const activeRow = document.querySelector('[data-boring-session-state="active"]')
+    expect(activeRow?.querySelector('[data-boring-workspace-part="app-session-active-rail"]')).toBeTruthy()
+    expect(screen.queryByTitle("Active session")).not.toBeInTheDocument()
   })
 
   it("shows working state on fleet rows and filters cards by name", async () => {
     const user = userEvent.setup()
     renderFleetPane()
 
-    expect(screen.queryByTitle("Active session")).not.toBeInTheDocument()
+    expect(screen.queryByTitle("Working")).not.toBeInTheDocument()
     act(() => window.dispatchEvent(new CustomEvent("boring:chat-session-status", {
       detail: { sessionId: "alpha-one", agentTypeId: "alpha", working: true },
     })))
-    await waitFor(() => expect(screen.getAllByTitle("Active session")).toHaveLength(1))
+    // The working (pulsing) dot appears on the pinned row and its nested twin.
+    await waitFor(() => expect(screen.getAllByTitle("Working")).toHaveLength(2))
 
     await user.type(screen.getByRole("searchbox", { name: "Filter Agents" }), "beta")
-    expect(screen.queryByRole("button", { name: /^Use Boring Alpha/ })).not.toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /^Use Boring Beta/ })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /^Boring Alpha;/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /^Boring Beta;/ })).toBeInTheDocument()
   })
 
   it("defaults the plain fleet new chat to the selected Agent", async () => {
@@ -233,7 +257,7 @@ describe("AppLeftPane", () => {
 
     // A fleet of one still gets a card, which is the only route to per-Agent
     // settings now that they no longer live on a generic control.
-    expect(screen.getByRole("button", { name: "Use Boring Solo for new chats; 1 chat" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Boring Solo; 1 chat" })).toBeInTheDocument()
     await user.click(screen.getByRole("button", { name: "New chat with Boring Solo" }))
     expect(onCreateSession).toHaveBeenCalledWith("solo")
     await user.click(screen.getByRole("button", { name: "Settings for Boring Solo" }))
@@ -300,8 +324,8 @@ describe("AppLeftPane", () => {
       pinnedSessionRefs: [],
     })
 
-    await user.click(screen.getByRole("button", { name: "Show only Boring Beta chats" }))
-    expect(screen.queryByText("No chats with Beta yet.")).not.toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Boring Beta; 0 chats" }))
+    expect(screen.queryByText("No chats yet.")).not.toBeInTheDocument()
     expect(screen.getByLabelText("Loading chats")).toBeInTheDocument()
   })
 

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -564,12 +564,17 @@
     display: none;
   }
 
-  /* "Start one" is the primary action of an empty Agent — it must be a real
-     touch target, not a 17px text link. */
+}
+
+/* "Start one" is the primary action of an empty Agent — it must be a real
+   touch target, not a 17px text link. Width-gated as well as pointer-gated so
+   narrow fine-pointer emulation gets it too; 48px keeps the measured rect
+   above the 44px gate even when an in-flight transform scales it slightly. */
+@media (pointer: coarse), (max-width: 500px) {
   .app-left-empty-start {
     display: inline-flex;
-    min-height: 44px;
-    min-width: 44px;
+    min-height: 48px;
+    min-width: 48px;
     align-items: center;
     justify-content: center;
     padding-inline: 8px;

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -563,4 +563,15 @@
   .app-left-agent-card-optional {
     display: none;
   }
+
+  /* "Start one" is the primary action of an empty Agent — it must be a real
+     touch target, not a 17px text link. */
+  .app-left-empty-start {
+    display: inline-flex;
+    min-height: 44px;
+    min-width: 44px;
+    align-items: center;
+    justify-content: center;
+    padding-inline: 8px;
+  }
 }

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -552,9 +552,15 @@
 
 /* Touch devices have no hover to gate the per-Agent secondary actions; showing
    all of them permanently reads as clutter. Only the "+" stays per row; the
-   remaining actions are a coarse-pointer follow-up (overflow menu). */
+   split/quick chat move behind a coarse-pointer follow-up (overflow menu),
+   but "+" and Settings stay: Agent details must remain reachable on touch. */
 @media (pointer: coarse) {
   .app-left-agent-card-actions {
+    width: auto;
+    opacity: 1;
+  }
+
+  .app-left-agent-card-optional {
     display: none;
   }
 }

--- a/packages/workspace/src/globals.css
+++ b/packages/workspace/src/globals.css
@@ -528,3 +528,33 @@
     opacity: 1;
   }
 }
+
+/* Nested per-Agent chat disclosure: a brief settle so expand/collapse gives an
+   unmistakable response without a heavyweight height animation. */
+@keyframes boring-app-left-disclose {
+  from {
+    opacity: 0;
+    transform: translateY(-3px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+[data-boring-workspace-part="app-left-agent-sessions"] {
+  animation: boring-app-left-disclose 140ms ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-boring-workspace-part="app-left-agent-sessions"] {
+    animation: none;
+  }
+}
+
+/* Touch devices have no hover to gate the per-Agent secondary actions; showing
+   all of them permanently reads as clutter. Only the "+" stays per row; the
+   remaining actions are a coarse-pointer follow-up (overflow menu). */
+@media (pointer: coarse) {
+  .app-left-agent-card-actions {
+    display: none;
+  }
+}

--- a/tools/ui-review/src/review-specs/workspace-agent-sidebar/hardGates.ts
+++ b/tools/ui-review/src/review-specs/workspace-agent-sidebar/hardGates.ts
@@ -6,7 +6,7 @@ import {
 } from "../../core/contracts"
 import type { UiReviewBrowserErrors } from "../../core/reviewSpec"
 
-export const AGENT_SIDEBAR_HARD_GATE_CONTRACT = "workspace-agent-sidebar-v2"
+export const AGENT_SIDEBAR_HARD_GATE_CONTRACT = "workspace-agent-sidebar-v3"
 
 const KNOWN_ABORTED_REQUESTS: Array<{
   rationale: string
@@ -88,7 +88,10 @@ export function evaluateAgentSidebarHardGates(snapshot: AgentSidebarHardGateSnap
     && (snapshot.checkpoint !== "expanded-sessions" || (state.expandedRegionCount >= 2 && state.guideCount >= 2))
     && (snapshot.checkpoint !== "pinned-chat" || (state.pinnedHeading === "Pinned chats" && state.pinnedCount === 1 && state.pinnedProvenance === "Alpha" && state.pinnedAgentSessionCount >= 1 && state.nestedPinnedHasPin))
     && (snapshot.checkpoint !== "agent-details" || (state.detailOverlayCount === 1 && state.detailTabCount === 0 && state.configurationHeadingCount === 1))
-    && (!snapshot.viewport.mobile || snapshot.checkpoint !== "agent-list" || (state.visibleActionCount >= 8 && state.visibleAgentCountLabels === 2))
+    // v3 (owner-ratified nested design): coarse pointers keep only "New chat"
+    // and "Settings" per Agent directly visible (2 agents × 2 = 4); split and
+    // quick chat move behind the touch overflow follow-up.
+    && (!snapshot.viewport.mobile || snapshot.checkpoint !== "agent-list" || (state.visibleActionCount >= 4 && state.visibleAgentCountLabels === 2))
 
   add("fixture-ready", surfaceReady, `agentCount=${state.agentCount};detailOverlayCount=${state.detailOverlayCount}`)
   add("console-errors", snapshot.consoleErrors.length === 0, snapshot.consoleErrors.join("\n") || "none")

--- a/tools/ui-review/src/review-specs/workspace-agent-sidebar/spec.ts
+++ b/tools/ui-review/src/review-specs/workspace-agent-sidebar/spec.ts
@@ -62,9 +62,9 @@ export const workspaceAgentSidebarSpec: UiReviewSpec = {
       await expect(page.getByRole("button", { name: "New chat with Beta", exact: true })).toBeVisible()
     } },
     { id: "expanded-sessions", colorScheme: "dark", reach: async (page) => {
-      const expandBeta = page.getByRole("button", { name: "Expand Beta sessions" })
+      const expandBeta = page.getByRole("button", { name: /^Expand Beta;/ })
       if (await expandBeta.isVisible().catch(() => false)) await expandBeta.click()
-      await expect(page.getByRole("button", { name: "Collapse Beta sessions" })).toBeVisible()
+      await expect(page.getByRole("button", { name: /^Collapse Beta;/ })).toBeVisible()
       await page.mouse.move(1_000, 500)
     } },
     { id: "pinned-chat", colorScheme: "dark", reach: async (page) => {


### PR DESCRIPTION
## Summary
Owner-directed left-pane redesign, iterated to approval on the live playground against the reference frontend spike:

- AGENTS become flat borderless rows — chevron, semibold name, bare muted count, always-visible "+", hover-only split/quick/settings.
- Each agent's chats disclose inline beneath it with a 1px vertical guide line; session text aligns to the agent name at every width.
- Row click = disclosure only. The selected-agent highlight and the per-agent filter lens are removed in nested mode (they made highlight states illegible).
- Pinning is a shortcut, not a move: pinned chats stay in their agent's nested list with a pin glyph; counts stay consistent.
- Open chat = discreet accent rail at the row edge; pulsing accent dot reserved for a working chat (motion-reduce: static, dimmed).
- Empty agents disclose a quiet "No chats yet · Start one" row; coarse pointers show only "+" per row; single-agent workspaces keep the flat CHATS list.

Follow-ups (non-blocking): keyboard left/right disclosure nav; touch overflow menu for split/quick/settings.

## Proof
- 3 review rounds with screenshots (light/dark/360px/mobile): collapsed, expanded ± active, hovers, pinned populated, empty agent, working-vs-open indicators; owner validated the result live on the playground and approved ("I like the UX, ship").
- Unit tests 33/33 (includes new pin-duplication, working-title, and active-rail tests), workspace typecheck clean, package build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016qY6FajM6TUYpT8nxwfEXm