### PR TITLE
[epic #1081] SBX1.3 salvage slice 2: runsc session-lifetime runtime (TS)

### DIFF
--- a/packages/boring-sandbox/src/providers/runsc/index.ts
+++ b/packages/boring-sandbox/src/providers/runsc/index.ts
@@ -80,3 +80,64 @@ export {
   verifyQualificationBundle,
 } from "./qualificationBundle";
 export { verifyFleetAdmission } from "./fleetAdmission";
+export {
+  RUNSC_RUNTIME_DOCKER_LABELS_V1,
+  RUNSC_RUNTIME_HELPER_PATH,
+  buildDockerExecArgv,
+  buildDockerInspectArgv,
+  buildDockerOwnedContainerListArgv,
+  buildDockerRemoveArgv,
+  buildDockerRemoveOwnedIdArgv,
+  buildDockerRunArgv,
+  dockerContainerNameV1,
+  trustedWorkspaceMountSource,
+  type DockerExecHelperModeV1,
+  type DockerRunProfileV1,
+  type TrustedWorkspaceMountSource,
+} from "./runtime/dockerArgv";
+export {
+  DOCKER_BINARY_PATH,
+  DockerCliCommandRunner,
+  runDockerChecked,
+  type DockerCommandInput,
+  type DockerCommandResult,
+  type DockerCommandRunner,
+} from "./runtime/dockerRunner";
+export {
+  RUNSC_RUNTIME_LIMITS_V1,
+  boundedPositiveInteger,
+  boundedUtf8Bytes,
+} from "./runtime/limits";
+export {
+  RUNSC_RUNTIME_RESERVED_ENV_NAMES_V1,
+  prepareInvocationEnvelopeV1,
+  type PreparedInvocationEnvelopeV1,
+} from "./runtime/invocationEnvelope";
+export {
+  createRunscInvocationCredentialResolverV1,
+  type ResolvedRunscInvocationCredentialsV1,
+  type RunscInvocationCredentialResolutionInputV1,
+  type RunscInvocationCredentialResolverOptionsV1,
+  type RunscInvocationCredentialResolverV1,
+} from "./runtime/invocationCredentials";
+export {
+  RUNSC_QUOTA_HELPER_EXCEEDED_EXIT,
+  RUNSC_QUOTA_HELPER_PATH,
+  RUNSC_WORKSPACE_QUOTA_PROFILE_V1,
+  FixedProjectQuotaManagerV1,
+  FixedQuotaHelperCommandRunnerV1,
+  assertHostReserveWritable,
+  requiredHostReserveBytes,
+  validateQuotaWorkspaceId,
+  type QuotaHelperCommandResultV1,
+  type QuotaHelperCommandRunnerV1,
+  type QuotaHelperOperationV1,
+} from "./runtime/quota";
+export {
+  RunscSessionRuntimeV1,
+  type CreateRunscSessionInputV1,
+  type RunscSessionLeaseV1,
+  type RunscSessionRetirementV1,
+  type RunscSessionRuntimeOptionsV1,
+} from "./runtime/sessionRuntime";
+export { RunscWorkspaceHelperClientV1 } from "./runtime/workspaceHelperClient";

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/dockerArgv.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/dockerArgv.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  RUNSC_RUNTIME_HELPER_PATH,
+  buildDockerExecArgv,
+  buildDockerRunArgv,
+  trustedWorkspaceMountSource,
+} from "../dockerArgv";
+
+const runtimeId = "a".repeat(32);
+const image = `registry.example/boring-workload@sha256:${"b".repeat(64)}`;
+
+describe("typed Docker argv construction", () => {
+  test("emits the exact fixed V3 run profile without a shell fragment", () => {
+    expect(
+      buildDockerRunArgv({
+        runtimeId,
+        workspaceMountSource: trustedWorkspaceMountSource(
+          "/srv/boring/workspaces",
+          "00000000-0000-4000-8000-000000000001",
+        ),
+        image,
+      }),
+    ).toEqual([
+      "run",
+      "-d",
+      "--name",
+      `boring-sbx-${runtimeId}`,
+      "--runtime=runsc",
+      "--user",
+      "0:0",
+      "--read-only",
+      "--cap-drop",
+      "ALL",
+      "--cap-add",
+      "SETUID",
+      "--cap-add",
+      "SETGID",
+      "--cap-add",
+      "KILL",
+      "--security-opt",
+      "no-new-privileges",
+      "--cpus",
+      "0.5",
+      "--memory",
+      "128m",
+      "--pids-limit",
+      "64",
+      "--network",
+      "none",
+      "--tmpfs",
+      "/tmp:rw,nosuid,nodev,size=16m",
+      "--ulimit",
+      "nofile=1024:1024",
+      "--ulimit",
+      "fsize=1073741824:1073741824",
+      "--mount",
+      "type=bind,src=/srv/boring/workspaces/00000000-0000-4000-8000-000000000001,dst=/workspace,readonly=false",
+      "--label",
+      "com.hachej.boring.runsc-runtime=true",
+      "--label",
+      "com.hachej.boring.runsc-profile=v1",
+      image,
+      RUNSC_RUNTIME_HELPER_PATH,
+      "supervise",
+    ]);
+  });
+
+  test.each([
+    "a;--privileged",
+    "$(touch-pwned)",
+    "A".repeat(32),
+    "../tenant",
+  ])("rejects a tenant-shaped runtime id: %s", (untrusted) => {
+    expect(() =>
+      buildDockerRunArgv({
+        runtimeId: untrusted,
+        workspaceMountSource: trustedWorkspaceMountSource(
+          "/srv/boring/workspaces",
+          "00000000-0000-4000-8000-000000000001",
+        ),
+        image,
+      }),
+    ).toThrow();
+  });
+
+  test.each([
+    "/srv/workspaces,readonly",
+    "relative/workspaces",
+    "/srv/workspaces\n--privileged",
+    "/srv/../private",
+  ])("rejects an unsafe configured workspace root: %s", (root) => {
+    expect(() =>
+      trustedWorkspaceMountSource(
+        root,
+        "00000000-0000-4000-8000-000000000001",
+      ),
+    ).toThrow();
+  });
+
+  test("rejects a tenant-shaped workspace id before building a mount source", () => {
+    expect(() =>
+      trustedWorkspaceMountSource(
+        "/srv/boring/workspaces",
+        "../../private,readonly",
+      ),
+    ).toThrow();
+  });
+
+  test("runs control helpers as supervisor and workspace helpers as tenant", () => {
+    const argv = buildDockerExecArgv(runtimeId, "invoke");
+    expect(argv).toEqual([
+      "exec",
+      "--interactive",
+      "--user",
+      "0:0",
+      `boring-sbx-${runtimeId}`,
+      RUNSC_RUNTIME_HELPER_PATH,
+      "invoke",
+    ]);
+    expect(argv).not.toContain("--env");
+    expect(buildDockerExecArgv(runtimeId, "baseline")[3]).toBe("0:0");
+    expect(buildDockerExecArgv(runtimeId, "workspace")[3]).toBe("65532:65532");
+  });
+});

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/dockerRunner.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/dockerRunner.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../../shared/remoteWorkerProtocolV1";
+import { DockerCliCommandRunner, runDockerChecked } from "../dockerRunner";
+
+describe("Docker command runner", () => {
+  test("rejects malformed argv before spawning", async () => {
+    const runner = new DockerCliCommandRunner();
+    await expect(
+      runner.run({ argv: ["run", "bad\0arg"], timeoutMs: 1_000 }),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+    });
+  });
+
+  test("maps runner failures without reflecting infrastructure stderr", async () => {
+    const runner = {
+      run: vi.fn(async () => ({
+        exitCode: 1,
+        stdout: new Uint8Array(),
+        stderr: new TextEncoder().encode("SECRET=/host/root/docker.sock"),
+        timedOut: false,
+        truncated: false,
+      })),
+    };
+    const failure = await runDockerChecked(runner, {
+      argv: ["inspect", "missing"],
+      timeoutMs: 1_000,
+    }).catch((error: unknown) => error);
+    expect(failure).toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.dockerCommandFailed,
+    });
+    expect(String((failure as Error).message)).not.toMatch(
+      /SECRET|\/host|docker\.sock/,
+    );
+  });
+
+  test("sanitizes spawn causes before they leave the runtime", async () => {
+    const failure = await runDockerChecked(
+      {
+        run: vi.fn(async () => {
+          const error = Object.assign(new Error("spawn failed"), {
+            code: "ENOENT",
+            errno: -2,
+            syscall: "spawn /usr/bin/docker",
+            path: "/usr/bin/docker",
+            spawnargs: ["--mount", "src=/host/private/workspace"],
+          });
+          throw error;
+        }),
+      },
+      { argv: ["inspect", "missing"], timeoutMs: 1_000 },
+    ).catch((error: unknown) => error);
+    expect(failure).toMatchObject({ cause: { code: "ENOENT", errno: -2 } });
+    const serialized = JSON.stringify((failure as Error).cause);
+    expect(serialized).toContain("ENOENT");
+    expect(serialized).not.toMatch(/\/usr\/bin|\/host|--mount|spawnargs/);
+  });
+});

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/invocationEnvelope.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/invocationEnvelope.test.ts
@@ -1,0 +1,280 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, test } from "vitest";
+
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../../shared/remoteWorkerProtocolV1";
+import { prepareInvocationEnvelopeV1 } from "../invocationEnvelope";
+
+const base = {
+  invocationId: "invocation-a",
+  command: "printf ok",
+  timeoutMs: 30_000,
+  maxOutputBytes: 1024,
+};
+
+const credential = {
+  deliveryAttemptId: "delivery-a",
+  ref: {
+    contractVersion: "boring.provider-credential-ref.v1" as const,
+    providerId: "search-provider",
+    executionId: "invocation-a",
+    bindingId: "search-tool",
+  },
+  fields: [{ name: "TOOL_CREDENTIAL", fieldId: "api-key" }],
+};
+
+interface CredentialFrameGoldenV1 {
+  readonly version: number;
+  readonly maxNameBytes: number;
+  readonly vectors: readonly {
+    readonly name: string;
+    readonly valueHex: string;
+    readonly frameHex: string;
+  }[];
+}
+
+const credentialFrameGolden = JSON.parse(
+  readFileSync(
+    new URL(
+      "../workload/cmd/boring-runtime/testdata/credential-frame-v1.json",
+      import.meta.url,
+    ),
+    "utf8",
+  ),
+) as CredentialFrameGoldenV1;
+
+function resolvedCredential(
+  value: string | Uint8Array = "canary-value",
+  name = "TOOL_CREDENTIAL",
+) {
+  return {
+    bindingId: "search-tool",
+    fieldId: "api-key",
+    name,
+    value: typeof value === "string" ? new TextEncoder().encode(value) : value,
+  };
+}
+
+function credentialFrame(prepared: { bytes: Uint8Array }): Uint8Array {
+  const view = new DataView(
+    prepared.bytes.buffer,
+    prepared.bytes.byteOffset,
+    prepared.bytes.byteLength,
+  );
+  const metadataLength = view.getUint32(4, false);
+  return prepared.bytes.subarray(12 + metadataLength);
+}
+
+function bytesToHex(value: Uint8Array): string {
+  return [...value].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+describe("bounded invocation stdin envelope", () => {
+  test("keeps trusted credential bytes out of JSON and frames them for fd3", () => {
+    const prepared = prepareInvocationEnvelopeV1({
+      workspaceId: "workspace-a",
+      request: { ...base, credentialRefs: [credential] },
+      resolvedCredentialFields: [resolvedCredential()],
+    });
+    expect(prepared.secretBearing).toBe(true);
+    expect(new TextDecoder().decode(prepared.bytes.subarray(0, 4))).toBe(
+      "BRI1",
+    );
+    const view = new DataView(
+      prepared.bytes.buffer,
+      prepared.bytes.byteOffset,
+      prepared.bytes.byteLength,
+    );
+    const metadataLength = view.getUint32(4, false);
+    const credentialLength = view.getUint32(8, false);
+    const metadataBytes = prepared.bytes.subarray(12, 12 + metadataLength);
+    const metadataText = new TextDecoder().decode(metadataBytes);
+    const metadata = JSON.parse(metadataText);
+    expect(Object.keys(metadata)).not.toContain("credentialRefs");
+    expect(Object.keys(metadata)).not.toContain("env");
+    expect(metadataText).not.toContain("canary-value");
+
+    const credentialBytes = prepared.bytes.subarray(12 + metadataLength);
+    expect(credentialBytes).toHaveLength(credentialLength);
+    expect(new TextDecoder().decode(credentialBytes.subarray(0, 4))).toBe(
+      "BRC1",
+    );
+    const credentialView = new DataView(
+      credentialBytes.buffer,
+      credentialBytes.byteOffset,
+      credentialBytes.byteLength,
+    );
+    expect(credentialView.getUint16(4, false)).toBe(1);
+    const nameLength = credentialView.getUint16(6, false);
+    const valueLength = credentialView.getUint32(8, false);
+    expect(
+      new TextDecoder().decode(credentialBytes.subarray(12, 12 + nameLength)),
+    ).toBe("TOOL_CREDENTIAL");
+    expect(
+      new TextDecoder().decode(
+        credentialBytes.subarray(
+          12 + nameLength,
+          12 + nameLength + valueLength,
+        ),
+      ),
+    ).toBe("canary-value");
+  });
+
+  test("matches the shared credential-frame golden vector and name limits", () => {
+    expect(credentialFrameGolden.version).toBe(1);
+    const [vector] = credentialFrameGolden.vectors;
+    expect(vector).toBeDefined();
+    const value = Uint8Array.from(
+      vector!.valueHex.match(/.{2}/g)!.map((byte) => Number.parseInt(byte, 16)),
+    );
+    const prepared = prepareInvocationEnvelopeV1({
+      workspaceId: "workspace-a",
+      request: {
+        ...base,
+        credentialRefs: [
+          {
+            ...credential,
+            fields: [{ name: vector!.name, fieldId: "api-key" }],
+          },
+        ],
+      },
+      resolvedCredentialFields: [resolvedCredential(value, vector!.name)],
+    });
+    expect(bytesToHex(credentialFrame(prepared))).toBe(vector!.frameHex);
+
+    const acceptedName = "A".repeat(credentialFrameGolden.maxNameBytes);
+    expect(() =>
+      prepareInvocationEnvelopeV1({
+        workspaceId: "workspace-a",
+        request: {
+          ...base,
+          credentialRefs: [
+            {
+              ...credential,
+              fields: [{ name: acceptedName, fieldId: "api-key" }],
+            },
+          ],
+        },
+        resolvedCredentialFields: [resolvedCredential("ok", acceptedName)],
+      }),
+    ).not.toThrow();
+
+    const rejectedName = `${acceptedName}A`;
+    expect(() =>
+      prepareInvocationEnvelopeV1({
+        workspaceId: "workspace-a",
+        request: {
+          ...base,
+          credentialRefs: [
+            {
+              ...credential,
+              fields: [{ name: rejectedName, fieldId: "api-key" }],
+            },
+          ],
+        },
+        resolvedCredentialFields: [resolvedCredential("blocked", rejectedName)],
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      }),
+    );
+  });
+
+  test("rejects forged raw-value classification and execution mismatch", () => {
+    expect(() =>
+      prepareInvocationEnvelopeV1({
+        workspaceId: "workspace-a",
+        request: {
+          ...base,
+          secretEnv: [
+            {
+              name: "TOOL_CREDENTIAL",
+              value: "forged-model-key",
+              reference: { kind: "sandbox-invocation-secret" },
+            },
+          ],
+        } as never,
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      }),
+    );
+    expect(() =>
+      prepareInvocationEnvelopeV1({
+        workspaceId: "workspace-a",
+        request: {
+          ...base,
+          credentialRefs: [
+            {
+              ...credential,
+              ref: { ...credential.ref, executionId: "another-invocation" },
+            },
+          ],
+        },
+        resolvedCredentialFields: [resolvedCredential()],
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+      }),
+    );
+  });
+
+  test.each(["PATH", "LD_PRELOAD", "BORING_WORKER_TOKEN", "bad-name"])(
+    "rejects reserved or malformed credential env name %s",
+    (name) => {
+      expect(() =>
+        prepareInvocationEnvelopeV1({
+          workspaceId: "workspace-a",
+          request: {
+            ...base,
+            credentialRefs: [
+              {
+                ...credential,
+                fields: [{ name, fieldId: "api-key" }],
+              },
+            ],
+          },
+          resolvedCredentialFields: [{ ...resolvedCredential(), name }],
+        }),
+      ).toThrow();
+    },
+  );
+
+  test("rejects ordinary raw env, including a model key", () => {
+    expect(() =>
+      prepareInvocationEnvelopeV1({
+        workspaceId: "workspace-a",
+        request: {
+          ...base,
+          env: { OPENAI_API_KEY: "sk-model-key" },
+        } as never,
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      }),
+    );
+  });
+
+  test("rejects cwd escape and oversized output policy", () => {
+    expect(() =>
+      prepareInvocationEnvelopeV1({
+        workspaceId: "workspace-a",
+        request: { ...base, cwd: "/workspace/../etc" },
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+      }),
+    );
+    expect(() =>
+      prepareInvocationEnvelopeV1({
+        workspaceId: "workspace-a",
+        request: { ...base, maxOutputBytes: 4 * 1024 * 1024 + 1 },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/quota.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/quota.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../../shared/remoteWorkerProtocolV1";
+import {
+  RUNSC_QUOTA_HELPER_EXCEEDED_EXIT,
+  RUNSC_WORKSPACE_QUOTA_PROFILE_V1,
+  FixedProjectQuotaManagerV1,
+  assertHostReserveWritable,
+  requiredHostReserveBytes,
+} from "../quota";
+
+const workspaceId = "00000000-0000-4000-8000-000000000001";
+
+describe("fixed project quota contract", () => {
+  test("passes only validated workspace id and the fixed profile to the helper", async () => {
+    const run = vi.fn(async () => ({ exitCode: 0, timedOut: false }));
+    await new FixedProjectQuotaManagerV1({ run }).apply(workspaceId.toUpperCase());
+    expect(run).toHaveBeenCalledWith({
+      argv: ["apply", workspaceId, RUNSC_WORKSPACE_QUOTA_PROFILE_V1.profileId],
+      timeoutMs: 120_000,
+    });
+  });
+
+  test.each(["../workspace", "/srv/workspace", "$(id)", "workspace-a"])(
+    "rejects arbitrary path/shell input: %s",
+    async (untrusted) => {
+      const run = vi.fn();
+      await expect(
+        new FixedProjectQuotaManagerV1({ run }).apply(untrusted),
+      ).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      });
+      expect(run).not.toHaveBeenCalled();
+    },
+  );
+
+  test("maps all quota exhaustion to one stable failure", async () => {
+    await expect(
+      new FixedProjectQuotaManagerV1({
+        run: async () => ({
+          exitCode: RUNSC_QUOTA_HELPER_EXCEEDED_EXIT,
+          timedOut: false,
+        }),
+      }).check(workspaceId),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.quotaExceeded,
+    });
+  });
+
+  test("reserves the larger of ten percent and ten GiB", () => {
+    expect(requiredHostReserveBytes(50 * 1024 ** 3)).toBe(10 * 1024 ** 3);
+    expect(requiredHostReserveBytes(200 * 1024 ** 3)).toBe(20 * 1024 ** 3);
+    expect(() =>
+      assertHostReserveWritable({
+        totalVolumeBytes: 50 * 1024 ** 3,
+        freeVolumeBytes: 10 * 1024 ** 3,
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: REMOTE_WORKER_ERROR_CODES_V1.quotaExceeded,
+      }),
+    );
+  });
+});

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRuntime.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/sessionRuntime.test.ts
@@ -1,0 +1,992 @@
+import { describe, expect, test, vi } from "vitest";
+
+import type {
+  AuthorizedWorkspaceCredentialScopeV1,
+  CredentialConsumerBindingId,
+  CredentialConsumerBindingRegistryV1,
+  CredentialFieldId,
+  ProviderId,
+  ProviderRegistryV1,
+  SandboxCredentialPayloadResolverV1,
+  SandboxCredentialSecretPayloadV1,
+} from "@hachej/boring-agent/shared";
+
+import {
+  REMOTE_WORKER_ERROR_CODES_V1,
+  type RemoteWorkerExecRequestV1,
+} from "../../../../shared/remoteWorkerProtocolV1";
+import { trustedWorkspaceMountSource } from "../dockerArgv";
+import type {
+  DockerCommandInput,
+  DockerCommandResult,
+  DockerCommandRunner,
+} from "../dockerRunner";
+import {
+  RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1,
+  createRunscInvocationCredentialResolverV1,
+  runscCredentialPayloadMetadataBytesV1,
+} from "../invocationCredentials";
+import { RunscSessionRuntimeV1 } from "../sessionRuntime";
+
+const image = `registry.example/boring-workload@sha256:${"b".repeat(64)}`;
+const workspaceId = "00000000-0000-4000-8000-000000000001";
+const credentialScope = {} as AuthorizedWorkspaceCredentialScopeV1;
+const searchProviderId = "search-provider" as ProviderId;
+const searchBindingId = "search-tool" as CredentialConsumerBindingId;
+const apiKeyFieldId = "api-key" as CredentialFieldId;
+
+function success(stdout: unknown = ""): DockerCommandResult {
+  return {
+    exitCode: 0,
+    stdout:
+      typeof stdout === "string"
+        ? new TextEncoder().encode(stdout)
+        : new TextEncoder().encode(JSON.stringify(stdout)),
+    stderr: new Uint8Array(),
+    timedOut: false,
+    truncated: false,
+  };
+}
+
+function helperResult(overrides: Record<string, unknown> = {}) {
+  return {
+    ok: true,
+    stdoutBase64: Buffer.from("ok").toString("base64"),
+    stderrBase64: "",
+    exitCode: 0,
+    durationMs: 5,
+    truncated: false,
+    timedOut: false,
+    cleanupProven: true,
+    ...overrides,
+  };
+}
+
+function fakeRunner(
+  invokeResponse: () => unknown = () => helperResult(),
+): DockerCommandRunner & { run: ReturnType<typeof vi.fn> } {
+  return {
+    run: vi.fn(async (input: DockerCommandInput) => {
+      if (input.argv[0] === "ps") return success("");
+      if (input.argv[0] !== "exec") return success("container-id\n");
+      const mode = input.argv.at(-1);
+      if (mode === "workspace") {
+        const request = JSON.parse(new TextDecoder().decode(input.stdin));
+        return request.op === "probe"
+          ? success({ openat2: true })
+          : success({ ok: true });
+      }
+      return success(invokeResponse());
+    }),
+  };
+}
+
+function runtime(
+  runner: DockerCommandRunner,
+  options: {
+    now?: () => number;
+    onRetire?: (value: {
+      sandboxId: string;
+      reason: string;
+    }) => void | Promise<void>;
+    credentialKind?: "first-party-tool" | "model-provider";
+    providerCategory?: "search" | "llm";
+    resolveCredential?: SandboxCredentialPayloadResolverV1["resolveForDelivery"];
+    quota?: {
+      apply(workspaceId: string): Promise<void>;
+      check(workspaceId: string): Promise<void>;
+    };
+  } = {},
+) {
+  let id = 0;
+  const providerId = searchProviderId;
+  const bindingId = searchBindingId;
+  const fieldId = apiKeyFieldId;
+  const resolveCredential: SandboxCredentialPayloadResolverV1["resolveForDelivery"] =
+    options.resolveCredential ??
+    vi.fn<SandboxCredentialPayloadResolverV1["resolveForDelivery"]>(
+      async (_scope, request) => ({
+        payload: {
+          contractVersion: "boring.sandbox-credential-secret-payload.v1",
+          workspaceId: request.workspaceId,
+          sandboxId: request.sandboxId,
+          executionId: request.executionId,
+          deliveryAttemptId: request.deliveryAttemptId,
+          bindingId,
+          credentialVersion: 1,
+          expiresAt: new Date(Date.now() + 60_000).toISOString(),
+          fields: [
+            {
+              fieldId,
+              value: new TextEncoder().encode("planted-secret-canary"),
+            },
+          ],
+        },
+        dispose: vi.fn(),
+      }),
+    );
+  const provider = Object.freeze({
+    contractVersion: "boring.provider.v1" as const,
+    id: providerId,
+    displayName: "Search provider",
+    category: options.providerCategory ?? "search",
+    credential: {
+      type: "api-key" as const,
+      fields: [
+        {
+          id: fieldId,
+          label: "API key",
+          required: true,
+          sensitivity: "secret" as const,
+          maxBytes: 65_536,
+        },
+      ],
+    },
+    consumerBindingIds: [bindingId],
+    sandboxEgressOrigins: [],
+  });
+  const providers: ProviderRegistryV1 = {
+    contractVersion: "boring.provider-registry.v1",
+    list: () => [provider],
+    require: (id) => {
+      if (id !== providerId) {
+        throw new Error("unknown test provider");
+      }
+      return provider;
+    },
+  };
+  const binding = Object.freeze({
+    contractVersion: "boring.credential-consumer-binding.v1" as const,
+    id: bindingId,
+    providerId,
+    consumer: {
+      id: bindingId,
+      kind: options.credentialKind ?? "first-party-tool",
+      trust: "untrusted" as const,
+    },
+    purpose: "search request",
+    allowedFieldIds: [fieldId],
+    delivery: "sandbox-pipe" as const,
+    sandbox: {
+      credentialChannel: "fd-3" as const,
+      egressOrigins: [],
+    },
+  });
+  const bindings: CredentialConsumerBindingRegistryV1 = {
+    contractVersion: "boring.credential-consumer-bindings.v1",
+    require: (id) => {
+      if (id !== bindingId) {
+        throw new Error("unknown test binding");
+      }
+      return binding;
+    },
+  };
+  return new RunscSessionRuntimeV1({
+    runner,
+    quota: options.quota ?? { apply: vi.fn(), check: vi.fn() },
+    runtimeIdFactory: () => (++id).toString(16).padStart(32, "0"),
+    now: options.now,
+    onRetire: options.onRetire,
+    invocationCredentials: createRunscInvocationCredentialResolverV1({
+      bindings,
+      providers,
+      payloadResolver: {
+        contractVersion: "boring.sandbox-credential-payload-resolver.v1",
+        resolveForDelivery: resolveCredential,
+      },
+    }),
+  });
+}
+
+const createInput = {
+  sandboxId: "sandbox-a",
+  clientLeaseId: "lease-a",
+  workspaceId,
+  workspaceMountSource: trustedWorkspaceMountSource(
+    "/srv/boring/workspaces",
+    workspaceId,
+  ),
+  image,
+};
+
+const execRequest = {
+  invocationId: "invocation-a",
+  command: "printf ok",
+  timeoutMs: 30_000,
+  maxOutputBytes: 1024,
+};
+
+describe("warm runsc session runtime", () => {
+  test("creates once, reuses one container, and replays only non-secret output", async () => {
+    const runner = fakeRunner();
+    const sessions = runtime(runner);
+    const first = await sessions.create(createInput);
+    const second = await sessions.create(createInput);
+    expect(second).toEqual(first);
+    const one = await sessions.exec("sandbox-a", workspaceId, execRequest);
+    const replay = await sessions.exec("sandbox-a", workspaceId, execRequest);
+    expect(replay).toEqual(one);
+    expect(
+      runner.run.mock.calls.filter(([input]) => input.argv[0] === "run"),
+    ).toHaveLength(1);
+    expect(
+      runner.run.mock.calls.filter(
+        ([input]) => input.argv[0] === "exec" && input.argv.at(-1) === "invoke",
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("uses clean containers around a secret and stores only a terminal marker", async () => {
+    const runner = fakeRunner();
+    const sessions = runtime(runner);
+    await sessions.create(createInput);
+    const request = {
+      ...execRequest,
+      credentialRefs: [
+        {
+          deliveryAttemptId: "delivery-a",
+          ref: {
+            contractVersion: "boring.provider-credential-ref.v1" as const,
+            providerId: "search-provider",
+            executionId: "invocation-a",
+            bindingId: "search-tool",
+          },
+          fields: [{ name: "TOOL_CREDENTIAL", fieldId: "api-key" }],
+        },
+      ],
+    };
+    await sessions.exec(
+      "sandbox-a",
+      workspaceId,
+      request,
+      undefined,
+      credentialScope,
+    );
+    await expect(
+      sessions.exec(
+        "sandbox-a",
+        workspaceId,
+        request,
+        undefined,
+        credentialScope,
+      ),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.secretInvocationNotReplayable,
+    });
+    const calls = runner.run.mock.calls.map(
+      ([input]) => input as DockerCommandInput,
+    );
+    expect(calls.filter((input) => input.argv[0] === "run")).toHaveLength(3);
+    expect(calls.filter((input) => input.argv[0] === "rm")).toHaveLength(2);
+    expect(
+      calls
+        .filter((input) => input.argv[0] === "run")
+        .map((input) =>
+          input.argv.find((value) => value.includes("dst=/workspace")),
+        ),
+    ).toEqual([
+      expect.stringContaining("readonly=false"),
+      expect.stringContaining("readonly=true"),
+      expect.stringContaining("readonly=false"),
+    ]);
+    expect(calls.flatMap((input) => input.argv).join(" ")).not.toContain(
+      "planted-secret-canary",
+    );
+  });
+
+  test("retires and retries when a secret-bearing container cannot be replaced", async () => {
+    vi.useFakeTimers();
+    try {
+      const runner = fakeRunner();
+      const run = runner.run.getMockImplementation() as (
+        input: DockerCommandInput,
+      ) => Promise<DockerCommandResult>;
+      let removeAttempts = 0;
+      runner.run.mockImplementation(async (input) => {
+        if (input.argv[0] === "rm") {
+          removeAttempts += 1;
+          if (removeAttempts >= 2 && removeAttempts <= 4) {
+            return {
+              ...success(),
+              exitCode: 1,
+              stderr: new TextEncoder().encode("transient removal failure"),
+            };
+          }
+        }
+        return await run(input);
+      });
+      const sessions = runtime(runner);
+      await sessions.create(createInput);
+      const request = {
+        ...execRequest,
+        credentialRefs: [
+          {
+            deliveryAttemptId: "delivery-a",
+            ref: {
+              contractVersion: "boring.provider-credential-ref.v1" as const,
+              providerId: "search-provider",
+              executionId: "invocation-a",
+              bindingId: "search-tool",
+            },
+            fields: [{ name: "TOOL_CREDENTIAL", fieldId: "api-key" }],
+          },
+        ],
+      };
+
+      await expect(
+        sessions.exec(
+          "sandbox-a",
+          workspaceId,
+          request,
+          undefined,
+          credentialScope,
+        ),
+      ).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+      });
+      await expect(
+        sessions.exec("sandbox-a", workspaceId, {
+          ...execRequest,
+          invocationId: "later-invocation",
+          command: "cat /tmp/planted-secret",
+        }),
+      ).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.sandboxDisposed,
+      });
+      expect(
+        runner.run.mock.calls.filter(
+          ([input]) =>
+            input.argv[0] === "exec" && input.argv.at(-1) === "invoke",
+        ),
+      ).toHaveLength(1);
+      expect(removeAttempts).toBe(4);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(removeAttempts).toBe(5);
+      await expect(sessions.renew("sandbox-a", 100)).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.sandboxNotFound,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("rejects a forged non-model reference using trusted model classification", async () => {
+    const resolveCredential =
+      vi.fn<SandboxCredentialPayloadResolverV1["resolveForDelivery"]>();
+    const runner = fakeRunner();
+    const sessions = runtime(runner, {
+      credentialKind: "model-provider",
+      providerCategory: "llm",
+      resolveCredential,
+    });
+    await sessions.create(createInput);
+    await expect(
+      sessions.exec(
+        "sandbox-a",
+        workspaceId,
+        {
+          ...execRequest,
+          credentialRefs: [
+            {
+              deliveryAttemptId: "delivery-a",
+              ref: {
+                contractVersion: "boring.provider-credential-ref.v1",
+                providerId: "search-provider",
+                executionId: "invocation-a",
+                bindingId: "search-tool",
+              },
+              fields: [{ name: "OPENAI_API_KEY", fieldId: "api-key" }],
+            },
+          ],
+        },
+        undefined,
+        credentialScope,
+      ),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+    });
+    expect(resolveCredential).not.toHaveBeenCalled();
+    expect(
+      runner.run.mock.calls.filter(
+        ([input]) => input.argv[0] === "exec" && input.argv.at(-1) === "invoke",
+      ),
+    ).toHaveLength(0);
+  });
+
+  test("rejects more than the credential contract aggregate field limit", async () => {
+    const resolveCredential =
+      vi.fn<SandboxCredentialPayloadResolverV1["resolveForDelivery"]>();
+    const runner = fakeRunner();
+    const sessions = runtime(runner, { resolveCredential });
+    await sessions.create(createInput);
+    const references = ["a", "b"].map((suffix) => ({
+      deliveryAttemptId: `delivery-${suffix}`,
+      ref: {
+        contractVersion: "boring.provider-credential-ref.v1" as const,
+        providerId: "search-provider",
+        executionId: "invocation-a",
+        bindingId: searchBindingId,
+      },
+      fields: Array.from({ length: 9 }, (_, index) => ({
+        name: `TOOL_CREDENTIAL_${suffix.toUpperCase()}_${index}`,
+        fieldId: "api-key",
+      })),
+    }));
+
+    await expect(
+      sessions.exec(
+        "sandbox-a",
+        workspaceId,
+        { ...execRequest, credentialRefs: references },
+        undefined,
+        credentialScope,
+      ),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+    });
+    expect(resolveCredential).not.toHaveBeenCalled();
+  });
+
+  test("disposes and rejects a payload over the aggregate secret byte limit", async () => {
+    const dispose = vi.fn();
+    const resolveCredential = vi.fn<
+      SandboxCredentialPayloadResolverV1["resolveForDelivery"]
+    >(async (_scope, request) => ({
+      payload: {
+        contractVersion: "boring.sandbox-credential-secret-payload.v1",
+        workspaceId: request.workspaceId,
+        sandboxId: request.sandboxId,
+        executionId: request.executionId,
+        deliveryAttemptId: request.deliveryAttemptId,
+        bindingId: searchBindingId,
+        credentialVersion: 1,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        fields: [
+          {
+            fieldId: apiKeyFieldId,
+            value: new Uint8Array(65_537),
+          },
+        ],
+      },
+      dispose,
+    }));
+    const runner = fakeRunner();
+    const sessions = runtime(runner, { resolveCredential });
+    await sessions.create(createInput);
+
+    await expect(
+      sessions.exec(
+        "sandbox-a",
+        workspaceId,
+        {
+          ...execRequest,
+          credentialRefs: [
+            {
+              deliveryAttemptId: "delivery-a",
+              ref: {
+                contractVersion: "boring.provider-credential-ref.v1",
+                providerId: "search-provider",
+                executionId: "invocation-a",
+                bindingId: "search-tool",
+              },
+              fields: [{ name: "TOOL_CREDENTIAL", fieldId: "api-key" }],
+            },
+          ],
+        },
+        undefined,
+        credentialScope,
+      ),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+    });
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(
+      runner.run.mock.calls.filter(
+        ([input]) => input.argv[0] === "exec" && input.argv.at(-1) === "invoke",
+      ),
+    ).toHaveLength(0);
+  });
+
+  test("disposes and rejects oversized resolved payload metadata", async () => {
+    const dispose = vi.fn();
+    const basePayload: SandboxCredentialSecretPayloadV1 = {
+      contractVersion: "boring.sandbox-credential-secret-payload.v1",
+      workspaceId,
+      sandboxId: "sandbox-a",
+      executionId: "invocation-a",
+      deliveryAttemptId: "delivery-a",
+      bindingId: searchBindingId,
+      credentialVersion: 1,
+      expiresAt: "Jan 1 2030",
+      fields: [
+        {
+          fieldId: apiKeyFieldId,
+          value: new TextEncoder().encode("bounded-secret"),
+        },
+      ],
+    };
+    expect(runscCredentialPayloadMetadataBytesV1(basePayload)).toBe(326);
+    const padding =
+      RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1.maxMetadataBytes -
+      runscCredentialPayloadMetadataBytesV1(basePayload) +
+      1;
+    const payload = {
+      ...basePayload,
+      expiresAt: `${basePayload.expiresAt}${" ".repeat(padding)}`,
+    };
+    expect(Date.parse(payload.expiresAt)).toBeGreaterThan(Date.now());
+    expect(runscCredentialPayloadMetadataBytesV1(payload)).toBe(
+      RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1.maxMetadataBytes + 1,
+    );
+    const resolveCredential = vi.fn<
+      SandboxCredentialPayloadResolverV1["resolveForDelivery"]
+    >(async () => ({
+      payload,
+      dispose,
+    }));
+    const runner = fakeRunner();
+    const sessions = runtime(runner, { resolveCredential });
+    await sessions.create(createInput);
+
+    await expect(
+      sessions.exec(
+        "sandbox-a",
+        workspaceId,
+        {
+          ...execRequest,
+          credentialRefs: [
+            {
+              deliveryAttemptId: "delivery-a",
+              ref: {
+                contractVersion: "boring.provider-credential-ref.v1",
+                providerId: "search-provider",
+                executionId: "invocation-a",
+                bindingId: "search-tool",
+              },
+              fields: [{ name: "TOOL_CREDENTIAL", fieldId: "api-key" }],
+            },
+          ],
+        },
+        undefined,
+        credentialScope,
+      ),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+    });
+    expect(dispose).toHaveBeenCalledOnce();
+    expect(
+      runner.run.mock.calls.filter(
+        ([input]) => input.argv[0] === "exec" && input.argv.at(-1) === "invoke",
+      ),
+    ).toHaveLength(0);
+  });
+
+  test.each([
+    {
+      label: "ordinary env model key",
+      request: {
+        ...execRequest,
+        env: { OPENAI_API_KEY: "sk-model-key" },
+      },
+    },
+    {
+      label: "forged-kind raw model key",
+      request: {
+        ...execRequest,
+        secretEnv: [
+          {
+            name: "OPENAI_API_KEY",
+            value: "sk-model-key",
+            reference: { kind: "sandbox-invocation-secret" },
+          },
+        ],
+      },
+    },
+  ])("rejects $label before Docker exec", async ({ request }) => {
+    const runner = fakeRunner();
+    const sessions = runtime(runner);
+    await sessions.create(createInput);
+    await expect(
+      sessions.exec(
+        "sandbox-a",
+        workspaceId,
+        request as unknown as RemoteWorkerExecRequestV1,
+      ),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+    });
+    expect(
+      runner.run.mock.calls.filter(
+        ([input]) => input.argv[0] === "exec" && input.argv.at(-1) === "invoke",
+      ),
+    ).toHaveLength(0);
+  });
+
+  test("returns timeout only when the wrapper proves process-group cleanup", async () => {
+    const runner = fakeRunner(() =>
+      helperResult({ timedOut: true, exitCode: 124 }),
+    );
+    const sessions = runtime(runner);
+    await sessions.create(createInput);
+    await expect(
+      sessions.exec("sandbox-a", workspaceId, execRequest),
+    ).rejects.toMatchObject({ code: REMOTE_WORKER_ERROR_CODES_V1.timeout });
+    expect(
+      runner.run.mock.calls.filter(([input]) => input.argv[0] === "run"),
+    ).toHaveLength(1);
+  });
+
+  test("destroys and replaces the container when cleanup is uncertain", async () => {
+    const runner = fakeRunner(() => helperResult({ cleanupProven: false }));
+    const sessions = runtime(runner);
+    await sessions.create(createInput);
+    await expect(
+      sessions.exec("sandbox-a", workspaceId, execRequest),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+    });
+    expect(
+      runner.run.mock.calls.filter(([input]) => input.argv[0] === "rm"),
+    ).toHaveLength(1);
+    expect(
+      runner.run.mock.calls.filter(([input]) => input.argv[0] === "run"),
+    ).toHaveLength(2);
+  });
+
+  test("retires expiry single-flight and never side-door recreates", async () => {
+    vi.useFakeTimers();
+    let clock = 1_000;
+    const retire = vi.fn();
+    try {
+      const runner = fakeRunner();
+      const sessions = runtime(runner, { now: () => clock, onRetire: retire });
+      await sessions.create({ ...createInput, idleTtlMs: 100 });
+      clock = 1_100;
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(sessions.renew("sandbox-a", 100)).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.sandboxNotFound,
+      });
+      expect(retire).toHaveBeenCalledWith({
+        sandboxId: "sandbox-a",
+        reason: "idle",
+      });
+      expect(
+        runner.run.mock.calls.filter(([input]) => input.argv[0] === "run"),
+      ).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("retains ownership and retries expiry removal after a transient failure", async () => {
+    vi.useFakeTimers();
+    let clock = 1_000;
+    const retire = vi.fn();
+    try {
+      const runner = fakeRunner();
+      const run = runner.run.getMockImplementation() as (
+        input: DockerCommandInput,
+      ) => Promise<DockerCommandResult>;
+      let removeAttempts = 0;
+      runner.run.mockImplementation(async (input) => {
+        if (input.argv[0] === "rm" && removeAttempts++ === 0) {
+          throw Object.assign(new Error("transient docker outage"), {
+            code: "ECONNREFUSED",
+          });
+        }
+        return await run(input);
+      });
+      const sessions = runtime(runner, {
+        now: () => clock,
+        onRetire: retire,
+      });
+      await sessions.create({ ...createInput, idleTtlMs: 100 });
+      clock = 1_100;
+      await vi.advanceTimersByTimeAsync(100);
+
+      await expect(sessions.renew("sandbox-a", 100)).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.sandboxDisposed,
+      });
+      expect(() =>
+        sessions.create({ ...createInput, idleTtlMs: 100 }),
+      ).toThrowError(
+        expect.objectContaining({
+          code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        }),
+      );
+      expect(removeAttempts).toBe(1);
+      expect(retire).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(removeAttempts).toBe(2);
+      expect(retire).toHaveBeenCalledTimes(1);
+      expect(retire).toHaveBeenCalledWith({
+        sandboxId: "sandbox-a",
+        reason: "idle",
+      });
+      await expect(sessions.renew("sandbox-a", 100)).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.sandboxNotFound,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test.each(["nonzero", "throw"] as const)(
+    "retains failed-create ownership when docker rm returns %s",
+    async (failureMode) => {
+      vi.useFakeTimers();
+      try {
+        const runner = fakeRunner();
+        const run = runner.run.getMockImplementation() as (
+          input: DockerCommandInput,
+        ) => Promise<DockerCommandResult>;
+        let removeAttempts = 0;
+        runner.run.mockImplementation(async (input) => {
+          if (input.argv[0] === "exec" && input.argv.at(-1) === "workspace") {
+            const request = JSON.parse(new TextDecoder().decode(input.stdin));
+            if (request.op === "probe") {
+              return {
+                ...success(),
+                exitCode: 1,
+                stderr: new TextEncoder().encode("probe failed"),
+              };
+            }
+          }
+          if (input.argv[0] === "rm") {
+            removeAttempts += 1;
+            if (removeAttempts === 1) {
+              if (failureMode === "throw") {
+                throw new Error("docker transport unavailable");
+              }
+              return {
+                ...success(),
+                exitCode: 1,
+                stderr: new TextEncoder().encode("remove failed"),
+              };
+            }
+          }
+          return await run(input);
+        });
+        const sessions = runtime(runner);
+
+        await expect(sessions.create(createInput)).rejects.toMatchObject({
+          code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        });
+        expect(() => sessions.create(createInput)).toThrowError(
+          expect.objectContaining({
+            code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+          }),
+        );
+        expect(removeAttempts).toBe(1);
+
+        await vi.advanceTimersByTimeAsync(100);
+        expect(removeAttempts).toBe(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  test("shutdown schedules every retirement before surfacing a removal failure", async () => {
+    vi.useFakeTimers();
+    try {
+      const onRetire = vi.fn();
+      const runner = fakeRunner();
+      const run = runner.run.getMockImplementation() as (
+        input: DockerCommandInput,
+      ) => Promise<DockerCommandResult>;
+      let removeAttempts = 0;
+      runner.run.mockImplementation(async (input) => {
+        if (input.argv[0] === "rm") {
+          removeAttempts += 1;
+          if (removeAttempts === 1) {
+            throw new Error("transient docker outage");
+          }
+        }
+        return await run(input);
+      });
+      const sessions = runtime(runner, { onRetire });
+      await sessions.create(createInput);
+      const secondWorkspaceId = "00000000-0000-4000-8000-000000000002";
+      await sessions.create({
+        ...createInput,
+        sandboxId: "sandbox-b",
+        clientLeaseId: "lease-b",
+        workspaceId: secondWorkspaceId,
+        workspaceMountSource: trustedWorkspaceMountSource(
+          "/srv/boring/workspaces",
+          secondWorkspaceId,
+        ),
+      });
+
+      await expect(sessions.shutdown()).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+      });
+      expect(removeAttempts).toBe(2);
+      expect(onRetire).toHaveBeenCalledTimes(1);
+      expect(onRetire).toHaveBeenCalledWith({
+        sandboxId: "sandbox-b",
+        reason: "shutdown",
+      });
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(removeAttempts).toBe(3);
+      expect(onRetire).toHaveBeenCalledTimes(2);
+      expect(onRetire).toHaveBeenCalledWith({
+        sandboxId: "sandbox-a",
+        reason: "shutdown",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test.each(["expired", "missing"] as const)(
+    "sanitizes a throwing retirement callback for a %s sandbox",
+    async (scenario) => {
+      let clock = 1_000;
+      const raw =
+        "unlink /srv/private/workspace: TOKEN=super-secret-host-value";
+      const sessions = runtime(fakeRunner(), {
+        now: () => clock,
+        onRetire: async () => {
+          throw new Error(raw);
+        },
+      });
+      if (scenario === "expired") {
+        await sessions.create({ ...createInput, idleTtlMs: 100 });
+        clock = 1_100;
+      }
+      let failure: unknown;
+      try {
+        await sessions.renew(
+          scenario === "expired" ? "sandbox-a" : "sandbox-missing",
+          100,
+        );
+      } catch (error) {
+        failure = error;
+      }
+      expect(failure).toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        message: "remote-worker retirement notification failed",
+      });
+      expect(JSON.stringify(failure)).not.toContain(raw);
+      expect(JSON.stringify(failure)).not.toContain("super-secret-host-value");
+    },
+  );
+
+  test("does not let a missing notification suppress cleanup of a reused sandbox id", async () => {
+    let releaseMissing: (() => void) | undefined;
+    const missingPending = new Promise<void>((resolve) => {
+      releaseMissing = resolve;
+    });
+    const onRetire = vi.fn(
+      async (retirement: { sandboxId: string; reason: string }) => {
+        if (retirement.reason === "missing") await missingPending;
+      },
+    );
+    const runner = fakeRunner();
+    const sessions = runtime(runner, { onRetire });
+
+    const missing = sessions.renew("sandbox-a", 100);
+    await vi.waitFor(() =>
+      expect(onRetire).toHaveBeenCalledWith({
+        sandboxId: "sandbox-a",
+        reason: "missing",
+      }),
+    );
+    await sessions.create(createInput);
+    await sessions.dispose("sandbox-a");
+
+    expect(
+      runner.run.mock.calls.filter(([input]) => input.argv[0] === "rm"),
+    ).toHaveLength(1);
+    expect(onRetire).toHaveBeenCalledTimes(1);
+
+    releaseMissing?.();
+    await expect(missing).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.sandboxNotFound,
+    });
+  });
+
+  test("bounded startup sweep removes only owned container ids", async () => {
+    const runner = fakeRunner();
+    runner.run.mockImplementationOnce(async () =>
+      success("a".repeat(64) + "\n"),
+    );
+    await runtime(runner).startupSweep();
+    expect(runner.run.mock.calls[1]?.[0].argv).toEqual([
+      "rm",
+      "--force",
+      "a".repeat(64),
+    ]);
+  });
+
+  test("serializes quota application against every session for one workspace", async () => {
+    let releaseApply: (() => void) | undefined;
+    const apply = vi.fn(
+      async () =>
+        await new Promise<void>((resolve) => {
+          releaseApply = resolve;
+        }),
+    );
+    const runner = fakeRunner();
+    const sessions = runtime(runner, {
+      quota: { apply, check: vi.fn(async () => undefined) },
+    });
+    const first = sessions.create(createInput);
+    await vi.waitFor(() => expect(apply).toHaveBeenCalledOnce());
+    expect(() =>
+      sessions.create({
+        ...createInput,
+        sandboxId: "sandbox-b",
+        clientLeaseId: "lease-b",
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: REMOTE_WORKER_ERROR_CODES_V1.idempotencyConflict,
+      }),
+    );
+    releaseApply?.();
+    await first;
+    expect(() =>
+      sessions.create({
+        ...createInput,
+        sandboxId: "sandbox-c",
+        clientLeaseId: "lease-c",
+      }),
+    ).toThrowError(
+      expect.objectContaining({
+        code: REMOTE_WORKER_ERROR_CODES_V1.idempotencyConflict,
+      }),
+    );
+    expect(apply).toHaveBeenCalledOnce();
+  });
+
+  test("retires instead of dropping invocation replay markers at its bound", async () => {
+    const retire = vi.fn();
+    const runner = fakeRunner();
+    const sessions = runtime(runner, { onRetire: retire });
+    await sessions.create(createInput);
+    for (let index = 0; index < 256; index += 1) {
+      await sessions.exec("sandbox-a", workspaceId, {
+        ...execRequest,
+        invocationId: `invocation-${index}`,
+      });
+    }
+    await expect(
+      sessions.exec("sandbox-a", workspaceId, {
+        ...execRequest,
+        invocationId: "invocation-overflow",
+      }),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.sandboxExpired,
+    });
+    expect(retire).toHaveBeenCalledWith({
+      sandboxId: "sandbox-a",
+      reason: "history",
+    });
+  });
+});

--- a/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/workspaceHelperClient.test.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/__tests__/workspaceHelperClient.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../../shared/remoteWorkerProtocolV1";
+import type { DockerCommandRunner } from "../dockerRunner";
+import { RunscWorkspaceHelperClientV1 } from "../workspaceHelperClient";
+
+function runner(response: unknown): DockerCommandRunner {
+  return {
+    run: vi.fn(async () => ({
+      exitCode: 0,
+      stdout: new TextEncoder().encode(JSON.stringify(response)),
+      stderr: new Uint8Array(),
+      timedOut: false,
+      truncated: false,
+    })),
+  };
+}
+
+describe("dirfd workspace helper client", () => {
+  test.each(["../sibling", "/etc/passwd", "dir/../../escape"])(
+    "rejects traversal before Docker: %s",
+    async (path) => {
+      const commandRunner = runner({ content: "not reached" });
+      await expect(
+        new RunscWorkspaceHelperClientV1(commandRunner).execute("a".repeat(32), {
+          op: "readFile",
+          path,
+        }),
+      ).rejects.toMatchObject({
+        code: REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+      });
+      expect(commandRunner.run).not.toHaveBeenCalled();
+    },
+  );
+
+  test("fails closed when openat2 is unavailable", async () => {
+    await expect(
+      new RunscWorkspaceHelperClientV1(runner({
+        ok: false,
+        code: REMOTE_WORKER_ERROR_CODES_V1.pathPrimitiveUnavailable,
+      })).probe("a".repeat(32)),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.pathPrimitiveUnavailable,
+    });
+  });
+
+  test("maps quota failure without helper detail", async () => {
+    await expect(
+      new RunscWorkspaceHelperClientV1(
+        runner({
+          ok: false,
+          code: REMOTE_WORKER_ERROR_CODES_V1.quotaExceeded,
+          detail: "/host/private/canary",
+        }),
+      ).execute("a".repeat(32), {
+        op: "writeFile",
+        path: "file.txt",
+        data: "x",
+      }),
+    ).rejects.toMatchObject({
+      code: REMOTE_WORKER_ERROR_CODES_V1.quotaExceeded,
+      message: "remote-worker workspace operation failed",
+    });
+  });
+
+  test("accepts a filesystem write larger than the invocation envelope", async () => {
+    const commandRunner = runner({ ok: true });
+    await new RunscWorkspaceHelperClientV1(commandRunner).execute(
+      "a".repeat(32),
+      {
+        op: "writeFile",
+        path: "large.txt",
+        data: "x".repeat(1024 * 1024),
+      },
+    );
+    expect(commandRunner.run).toHaveBeenCalledOnce();
+    const input = vi.mocked(commandRunner.run).mock.calls[0]?.[0];
+    expect(input?.stdin?.byteLength).toBeGreaterThan(1024 * 1024);
+  });
+});

--- a/packages/boring-sandbox/src/providers/runsc/runtime/dockerArgv.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/dockerArgv.ts
@@ -1,0 +1,163 @@
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
+
+import { runscRuntimeError } from "./errors";
+
+export const RUNSC_RUNTIME_DOCKER_LABELS_V1 = Object.freeze({
+  owner: "com.hachej.boring.runsc-runtime",
+  profile: "com.hachej.boring.runsc-profile",
+} as const);
+
+export const RUNSC_RUNTIME_HELPER_PATH =
+  "/opt/boring/bin/boring-runtime" as const;
+
+declare const trustedWorkspaceMountSourceBrand: unique symbol;
+export type TrustedWorkspaceMountSource = string & {
+  readonly [trustedWorkspaceMountSourceBrand]: true;
+};
+
+const runtimeIdPattern = /^[a-f0-9]{32}$/;
+const workspaceIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const imageDigestPattern =
+  /^(?:[a-z0-9.-]+(?::[0-9]{1,5})?\/)?[a-z0-9]+(?:[._-][a-z0-9]+)*(?:\/[a-z0-9]+(?:[._-][a-z0-9]+)*)*@sha256:[a-f0-9]{64}$/;
+
+function invalidDockerInput(label: string): never {
+  throw runscRuntimeError(
+    REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+    `remote-worker ${label} is invalid`,
+  );
+}
+
+export function trustedWorkspaceMountSource(
+  workspaceRoot: string,
+  workspaceId: string,
+): TrustedWorkspaceMountSource {
+  if (
+    !workspaceRoot.startsWith("/") ||
+    workspaceRoot === "/" ||
+    workspaceRoot.endsWith("/") ||
+    workspaceRoot.length > 4000 ||
+    workspaceRoot.includes("\0") ||
+    workspaceRoot.includes(",") ||
+    /[\r\n]/.test(workspaceRoot) ||
+    workspaceRoot.split("/").some((component) => component === ".." || component === ".")
+  ) {
+    invalidDockerInput("workspace root");
+  }
+  if (!workspaceIdPattern.test(workspaceId)) invalidDockerInput("workspace id");
+  const source = `${workspaceRoot}/${workspaceId.toLowerCase()}`;
+  if (source.length > 4096) invalidDockerInput("workspace mount source");
+  return source as TrustedWorkspaceMountSource;
+}
+
+export interface DockerRunProfileV1 {
+  readonly runtimeId: string;
+  readonly workspaceMountSource: TrustedWorkspaceMountSource;
+  readonly workspaceReadOnly?: boolean;
+  readonly image: string;
+}
+
+export function dockerContainerNameV1(runtimeId: string): string {
+  if (!runtimeIdPattern.test(runtimeId)) invalidDockerInput("runtime id");
+  return `boring-sbx-${runtimeId}`;
+}
+
+export function buildDockerRunArgv(
+  profile: DockerRunProfileV1,
+): readonly string[] {
+  const containerName = dockerContainerNameV1(profile.runtimeId);
+  if (!imageDigestPattern.test(profile.image)) invalidDockerInput("image digest");
+  return Object.freeze([
+    "run",
+    "-d",
+    "--name",
+    containerName,
+    "--runtime=runsc",
+    "--user",
+    "0:0",
+    "--read-only",
+    "--cap-drop",
+    "ALL",
+    "--cap-add",
+    "SETUID",
+    "--cap-add",
+    "SETGID",
+    "--cap-add",
+    "KILL",
+    "--security-opt",
+    "no-new-privileges",
+    "--cpus",
+    "0.5",
+    "--memory",
+    "128m",
+    "--pids-limit",
+    "64",
+    "--network",
+    "none",
+    "--tmpfs",
+    "/tmp:rw,nosuid,nodev,size=16m",
+    "--ulimit",
+    "nofile=1024:1024",
+    "--ulimit",
+    "fsize=1073741824:1073741824",
+    "--mount",
+    `type=bind,src=${profile.workspaceMountSource},dst=/workspace,readonly=${profile.workspaceReadOnly === true}`,
+    "--label",
+    `${RUNSC_RUNTIME_DOCKER_LABELS_V1.owner}=true`,
+    "--label",
+    `${RUNSC_RUNTIME_DOCKER_LABELS_V1.profile}=v1`,
+    profile.image,
+    RUNSC_RUNTIME_HELPER_PATH,
+    "supervise",
+  ]);
+}
+
+export type DockerExecHelperModeV1 = "invoke" | "workspace" | "baseline";
+
+export function buildDockerExecArgv(
+  runtimeId: string,
+  mode: DockerExecHelperModeV1,
+): readonly string[] {
+  const user = mode === "workspace" ? "65532:65532" : "0:0";
+  return Object.freeze([
+    "exec",
+    "--interactive",
+    "--user",
+    user,
+    dockerContainerNameV1(runtimeId),
+    RUNSC_RUNTIME_HELPER_PATH,
+    mode,
+  ]);
+}
+
+export function buildDockerRemoveArgv(runtimeId: string): readonly string[] {
+  return Object.freeze(["rm", "--force", dockerContainerNameV1(runtimeId)]);
+}
+
+export function buildDockerRemoveOwnedIdArgv(
+  containerId: string,
+): readonly string[] {
+  if (!/^[a-f0-9]{12,64}$/.test(containerId)) {
+    invalidDockerInput("owned container id");
+  }
+  return Object.freeze(["rm", "--force", containerId]);
+}
+
+export function buildDockerInspectArgv(runtimeId: string): readonly string[] {
+  return Object.freeze([
+    "inspect",
+    "--format",
+    "{{.State.Running}}",
+    dockerContainerNameV1(runtimeId),
+  ]);
+}
+
+export function buildDockerOwnedContainerListArgv(): readonly string[] {
+  return Object.freeze([
+    "ps",
+    "--all",
+    "--quiet",
+    "--filter",
+    `label=${RUNSC_RUNTIME_DOCKER_LABELS_V1.owner}=true`,
+  ]);
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/dockerRunner.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/dockerRunner.ts
@@ -1,0 +1,178 @@
+import { spawn } from "node:child_process";
+
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
+import { SandboxProviderError } from "../../../shared/providerV1";
+
+import { runscRuntimeError } from "./errors";
+import { RUNSC_RUNTIME_LIMITS_V1, boundedPositiveInteger } from "./limits";
+
+export const DOCKER_BINARY_PATH = "/usr/bin/docker" as const;
+
+export interface DockerCommandInput {
+  readonly argv: readonly string[];
+  readonly timeoutMs: number;
+  readonly maxOutputBytes?: number;
+  /** Owned by the runner and zeroed after it is written. */
+  readonly stdin?: Uint8Array;
+  readonly signal?: AbortSignal;
+}
+
+export interface DockerCommandResult {
+  readonly exitCode: number;
+  readonly stdout: Uint8Array;
+  readonly stderr: Uint8Array;
+  readonly timedOut: boolean;
+  readonly truncated: boolean;
+  readonly aborted?: boolean;
+}
+
+export interface DockerCommandRunner {
+  run(input: DockerCommandInput): Promise<DockerCommandResult>;
+}
+
+function appendBounded(
+  chunks: Uint8Array[],
+  chunk: Uint8Array,
+  state: { bytes: number; truncated: boolean },
+  maximum: number,
+): void {
+  const remaining = maximum - state.bytes;
+  if (remaining <= 0) {
+    state.truncated = true;
+    return;
+  }
+  const accepted = chunk.byteLength > remaining ? chunk.subarray(0, remaining) : chunk;
+  chunks.push(accepted);
+  state.bytes += accepted.byteLength;
+  if (accepted.byteLength !== chunk.byteLength) state.truncated = true;
+}
+
+function concatChunks(chunks: readonly Uint8Array[], size: number): Uint8Array {
+  const output = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    output.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return output;
+}
+
+export class DockerCliCommandRunner implements DockerCommandRunner {
+  async run(input: DockerCommandInput): Promise<DockerCommandResult> {
+    const timeoutMs = boundedPositiveInteger(
+      input.timeoutMs,
+      RUNSC_RUNTIME_LIMITS_V1.maxInvocationTimeoutMs +
+        RUNSC_RUNTIME_LIMITS_V1.dockerCommandTimeoutMs,
+      "Docker command timeout",
+    );
+    const maximum = boundedPositiveInteger(
+      input.maxOutputBytes ?? RUNSC_RUNTIME_LIMITS_V1.maxCombinedOutputBytes,
+      16 * 1024 * 1024,
+      "Docker command output limit",
+    );
+    if (
+      input.argv.length === 0 ||
+      input.argv.length > 128 ||
+      input.argv.some(
+        (arg) =>
+          typeof arg !== "string" ||
+          arg.length === 0 ||
+          arg.length > 8192 ||
+          arg.includes("\0"),
+      )
+    ) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+        "remote-worker Docker argv is invalid",
+      );
+    }
+
+    return await new Promise<DockerCommandResult>((resolve, reject) => {
+      const child = spawn(DOCKER_BINARY_PATH, [...input.argv], {
+        shell: false,
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
+      const stdout: Uint8Array[] = [];
+      const stderr: Uint8Array[] = [];
+      const outputState = { bytes: 0, truncated: false };
+      let timedOut = false;
+      let aborted = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, timeoutMs);
+      const abort = (): void => {
+        aborted = true;
+        child.kill("SIGKILL");
+      };
+      if (input.signal?.aborted) abort();
+      else input.signal?.addEventListener("abort", abort, { once: true });
+      child.stdout.on("data", (chunk: Uint8Array) =>
+        appendBounded(stdout, chunk, outputState, maximum),
+      );
+      child.stderr.on("data", (chunk: Uint8Array) =>
+        appendBounded(stderr, chunk, outputState, maximum),
+      );
+      child.once("error", (error) => {
+        clearTimeout(timer);
+        input.signal?.removeEventListener("abort", abort);
+        input.stdin?.fill(0);
+        reject(
+          runscRuntimeError(
+            REMOTE_WORKER_ERROR_CODES_V1.dockerCommandFailed,
+            "remote-worker Docker command could not start",
+            error,
+          ),
+        );
+      });
+      child.once("close", (code) => {
+        clearTimeout(timer);
+        input.signal?.removeEventListener("abort", abort);
+        input.stdin?.fill(0);
+        resolve({
+          exitCode: code ?? -1,
+          stdout: concatChunks(stdout, stdout.reduce((n, c) => n + c.byteLength, 0)),
+          stderr: concatChunks(stderr, stderr.reduce((n, c) => n + c.byteLength, 0)),
+          timedOut,
+          truncated: outputState.truncated,
+          aborted,
+        });
+      });
+      if (input.stdin) child.stdin.end(input.stdin);
+      else child.stdin.end();
+    });
+  }
+}
+
+export async function runDockerChecked(
+  runner: DockerCommandRunner,
+  input: DockerCommandInput,
+): Promise<DockerCommandResult> {
+  let result: DockerCommandResult;
+  try {
+    result = await runner.run(input);
+  } catch (error) {
+    if (error instanceof SandboxProviderError) {
+      throw error;
+    }
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.dockerCommandFailed,
+      "remote-worker Docker command failed",
+      error,
+    );
+  }
+  if (result.timedOut) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.timeout,
+      "remote-worker Docker command timed out",
+    );
+  }
+  if (result.exitCode !== 0) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.dockerCommandFailed,
+      "remote-worker Docker command failed",
+    );
+  }
+  return result;
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/errors.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/errors.ts
@@ -1,0 +1,54 @@
+import type { ErrorCode } from "@hachej/boring-agent/shared";
+
+import { SandboxProviderError } from "../../../shared/providerV1";
+
+interface SanitizedRuntimeCause {
+  readonly name?: string;
+  readonly code?: string;
+  readonly errno?: number | string;
+  readonly syscall?: string;
+}
+
+const SAFE_CAUSE_TOKEN = /^[A-Za-z0-9_.:-]{1,128}$/;
+
+function safeCauseToken(value: unknown): string | undefined {
+  return typeof value === "string" && SAFE_CAUSE_TOKEN.test(value)
+    ? value
+    : undefined;
+}
+
+function sanitizedCause(cause: unknown): SanitizedRuntimeCause | undefined {
+  if (!cause || typeof cause !== "object") return undefined;
+  const candidate = cause as {
+    name?: unknown;
+    code?: unknown;
+    errno?: unknown;
+    syscall?: unknown;
+  };
+  const errno =
+    typeof candidate.errno === "number" && Number.isSafeInteger(candidate.errno)
+      ? candidate.errno
+      : safeCauseToken(candidate.errno);
+  const result: SanitizedRuntimeCause = {
+    name: safeCauseToken(candidate.name),
+    code: safeCauseToken(candidate.code),
+    errno,
+    syscall: safeCauseToken(candidate.syscall),
+  };
+  return Object.values(result).some((value) => value !== undefined)
+    ? result
+    : undefined;
+}
+
+export function runscRuntimeError(
+  code: ErrorCode,
+  message: string,
+  cause?: unknown,
+): SandboxProviderError {
+  const safeCause = sanitizedCause(cause);
+  return new SandboxProviderError(
+    code,
+    message,
+    safeCause === undefined ? {} : { cause: safeCause },
+  );
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/invocationCredentials.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/invocationCredentials.ts
@@ -1,0 +1,297 @@
+import type {
+  AuthorizedWorkspaceCredentialScopeV1,
+  CredentialConsumerBindingId,
+  CredentialConsumerBindingRegistryV1,
+  CredentialFieldDefinitionV1,
+  ProviderDefinitionV1,
+  ProviderId,
+  ProviderRegistryV1,
+  SandboxCredentialPayloadResolverV1,
+  SandboxCredentialSecretPayloadLeaseV1,
+  SandboxCredentialSecretPayloadV1,
+} from "@hachej/boring-agent/shared";
+
+import {
+  REMOTE_WORKER_ERROR_CODES_V1,
+  type RemoteWorkerCredentialReferenceV1,
+} from "../../../shared/remoteWorkerProtocolV1";
+
+import { runscRuntimeError } from "./errors";
+import type { ResolvedInvocationCredentialFieldV1 } from "./invocationEnvelope";
+
+const ALLOWED_SANDBOX_CREDENTIAL_CONSUMERS = new Set([
+  "first-party-tool",
+  "plugin-server",
+  "mcp-server",
+  "tenant-custom-tool",
+]);
+
+// Runtime mirror of the 16f.1 credential contract. Sandbox may depend on its
+// types, but the package invariant forbids an agent value dependency.
+export const RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1 = Object.freeze({
+  maxExecutionIdLength: 256,
+  maxFields: 16,
+  maxMetadataBytes: 16_384,
+  maxTotalBytes: 65_536,
+});
+
+export interface ResolvedRunscInvocationCredentialsV1 {
+  readonly fields: readonly ResolvedInvocationCredentialFieldV1[];
+  readonly leases: readonly SandboxCredentialSecretPayloadLeaseV1[];
+}
+
+export interface RunscInvocationCredentialResolverV1 {
+  readonly contractVersion: "boring.runsc-invocation-credential-resolver.v1";
+  resolve(
+    input: RunscInvocationCredentialResolutionInputV1,
+  ): Promise<ResolvedRunscInvocationCredentialsV1>;
+}
+
+export interface RunscInvocationCredentialResolutionInputV1 {
+  readonly workspaceId: string;
+  readonly sandboxId: string;
+  readonly invocationId: string;
+  readonly references: readonly RemoteWorkerCredentialReferenceV1[];
+  readonly credentialScope: AuthorizedWorkspaceCredentialScopeV1;
+  readonly nowMs: number;
+}
+
+export interface RunscInvocationCredentialResolverOptionsV1 {
+  readonly bindings: CredentialConsumerBindingRegistryV1;
+  readonly providers: ProviderRegistryV1;
+  readonly payloadResolver: SandboxCredentialPayloadResolverV1;
+}
+
+function trustedBindingId(value: string): CredentialConsumerBindingId {
+  return value as CredentialConsumerBindingId;
+}
+
+function trustedProviderId(value: string): ProviderId {
+  return value as ProviderId;
+}
+
+function providerCredentialFields(
+  provider: ProviderDefinitionV1,
+): readonly CredentialFieldDefinitionV1[] {
+  if (provider.credential.type === "api-key") {
+    return provider.credential.fields;
+  }
+  if (
+    provider.credential.type === "oauth2-authorization-code" &&
+    provider.credential.tokenCustody === "local-vault"
+  ) {
+    return [
+      provider.credential.refreshTokenField,
+      provider.credential.resolvedAccessTokenField,
+    ];
+  }
+  return [];
+}
+
+function metadataBytes(input: {
+  workspaceId: string;
+  sandboxId: string;
+  invocationId: string;
+  references: readonly RemoteWorkerCredentialReferenceV1[];
+}): number {
+  return new TextEncoder().encode(
+    JSON.stringify({
+      workspaceId: input.workspaceId,
+      sandboxId: input.sandboxId,
+      invocationId: input.invocationId,
+      references: input.references,
+    }),
+  ).byteLength;
+}
+
+export function runscCredentialPayloadMetadataBytesV1(
+  payload: SandboxCredentialSecretPayloadV1,
+): number {
+  return new TextEncoder().encode(
+    JSON.stringify({
+      contractVersion: payload.contractVersion,
+      workspaceId: payload.workspaceId,
+      sandboxId: payload.sandboxId,
+      executionId: payload.executionId,
+      deliveryAttemptId: payload.deliveryAttemptId,
+      bindingId: payload.bindingId,
+      credentialVersion: payload.credentialVersion,
+      expiresAt: payload.expiresAt,
+      fields: payload.fields.map((field) => ({
+        fieldId: field.fieldId,
+        byteLength: field.value.byteLength,
+      })),
+    }),
+  ).byteLength;
+}
+
+export function createRunscInvocationCredentialResolverV1(
+  options: RunscInvocationCredentialResolverOptionsV1,
+): RunscInvocationCredentialResolverV1 {
+  return Object.freeze({
+    contractVersion: "boring.runsc-invocation-credential-resolver.v1" as const,
+    async resolve(
+      input: RunscInvocationCredentialResolutionInputV1,
+    ): Promise<ResolvedRunscInvocationCredentialsV1> {
+      const fieldCount = input.references.reduce(
+        (count, reference) => count + reference.fields.length,
+        0,
+      );
+      if (
+        input.invocationId.trim().length === 0 ||
+        input.invocationId.length >
+          RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1.maxExecutionIdLength ||
+        fieldCount > RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1.maxFields ||
+        metadataBytes(input) >
+          RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1.maxMetadataBytes
+      ) {
+        throw runscRuntimeError(
+          REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+          "remote-worker credential reference was rejected",
+        );
+      }
+
+      const leases: SandboxCredentialSecretPayloadLeaseV1[] = [];
+      const fields: ResolvedInvocationCredentialFieldV1[] = [];
+      let totalSecretBytes = 0;
+      try {
+        for (const reference of input.references) {
+          if (reference.ref.executionId !== input.invocationId) {
+            throw new Error("credential execution mismatch");
+          }
+          const binding = options.bindings.require(
+            trustedBindingId(reference.ref.bindingId),
+          );
+          const provider = options.providers.require(
+            trustedProviderId(reference.ref.providerId),
+          );
+          if (
+            binding.id !== reference.ref.bindingId ||
+            binding.providerId !== reference.ref.providerId ||
+            provider.id !== reference.ref.providerId ||
+            provider.category === "llm" ||
+            binding.consumer.trust !== "untrusted" ||
+            !ALLOWED_SANDBOX_CREDENTIAL_CONSUMERS.has(binding.consumer.kind) ||
+            binding.delivery !== "sandbox-pipe" ||
+            binding.sandbox?.credentialChannel !== "fd-3"
+          ) {
+            throw new Error("credential binding rejected");
+          }
+          const requestedFieldIds = new Set(
+            reference.fields.map((field) => field.fieldId),
+          );
+          const allowedFieldIds = new Set<string>(binding.allowedFieldIds);
+          if (
+            requestedFieldIds.size !== reference.fields.length ||
+            [...requestedFieldIds].some(
+              (fieldId) => !allowedFieldIds.has(fieldId),
+            )
+          ) {
+            throw new Error("credential field rejected");
+          }
+
+          const trustedRef = Object.freeze({
+            contractVersion: "boring.provider-credential-ref.v1" as const,
+            providerId: binding.providerId,
+            executionId: input.invocationId,
+            bindingId: binding.id,
+          });
+          const lease = await options.payloadResolver.resolveForDelivery(
+            input.credentialScope,
+            {
+              contractVersion: "boring.sandbox-credential-delivery.v1",
+              workspaceId: input.workspaceId,
+              sandboxId: input.sandboxId,
+              executionId: input.invocationId,
+              deliveryAttemptId: reference.deliveryAttemptId,
+              ref: trustedRef,
+            },
+          );
+          leases.push(lease);
+          const payload = lease.payload;
+          if (
+            payload.contractVersion !==
+              "boring.sandbox-credential-secret-payload.v1" ||
+            runscCredentialPayloadMetadataBytesV1(payload) >
+              RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1.maxMetadataBytes ||
+            payload.workspaceId !== input.workspaceId ||
+            payload.sandboxId !== input.sandboxId ||
+            payload.executionId !== input.invocationId ||
+            payload.deliveryAttemptId !== reference.deliveryAttemptId ||
+            payload.bindingId !== binding.id ||
+            !Number.isSafeInteger(payload.credentialVersion) ||
+            payload.credentialVersion <= 0 ||
+            !Number.isFinite(Date.parse(payload.expiresAt)) ||
+            Date.parse(payload.expiresAt) <= input.nowMs
+          ) {
+            throw new Error("credential payload scope rejected");
+          }
+          if (
+            payload.fields.length >
+              RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1.maxFields ||
+            payload.fields.length !== requestedFieldIds.size
+          ) {
+            throw new Error("credential payload fields rejected");
+          }
+          const providerFields = new Map(
+            providerCredentialFields(provider).map((field) => [
+              field.id,
+              field,
+            ]),
+          );
+          const payloadFields = new Map<string, Uint8Array>(
+            payload.fields.map((field) => [field.fieldId, field.value]),
+          );
+          if (payloadFields.size !== payload.fields.length) {
+            throw new Error("credential payload fields rejected");
+          }
+          for (const payloadField of payload.fields) {
+            const definition = providerFields.get(payloadField.fieldId);
+            if (
+              !requestedFieldIds.has(payloadField.fieldId) ||
+              !(payloadField.value instanceof Uint8Array) ||
+              !definition ||
+              payloadField.value.byteLength > definition.maxBytes ||
+              payloadField.value.byteLength < (definition.minBytes ?? 0)
+            ) {
+              throw new Error("credential payload field rejected");
+            }
+            totalSecretBytes += payloadField.value.byteLength;
+            if (
+              totalSecretBytes >
+              RUNSC_SANDBOX_CREDENTIAL_LIMITS_V1.maxTotalBytes
+            ) {
+              throw new Error("credential payload exceeds aggregate bound");
+            }
+          }
+          for (const requested of reference.fields) {
+            const value = payloadFields.get(requested.fieldId);
+            if (!(value instanceof Uint8Array)) {
+              throw new Error("credential payload field missing");
+            }
+            fields.push({
+              bindingId: binding.id,
+              fieldId: requested.fieldId,
+              name: requested.name,
+              value,
+            });
+          }
+        }
+        return { fields, leases };
+      } catch (error) {
+        for (const lease of leases) {
+          try {
+            lease.dispose();
+          } catch {
+            // Resolver errors stay on the trusted side of the boundary.
+          }
+        }
+        throw runscRuntimeError(
+          REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+          "remote-worker credential reference was rejected",
+          error,
+        );
+      }
+    },
+  });
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/invocationEnvelope.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/invocationEnvelope.ts
@@ -1,0 +1,254 @@
+import {
+  REMOTE_WORKER_CREDENTIAL_NAME_MAX_BYTES_V1,
+  REMOTE_WORKER_ERROR_CODES_V1,
+  RemoteWorkerExecRequestSchemaV1,
+  type RemoteWorkerExecRequestV1,
+} from "../../../shared/remoteWorkerProtocolV1";
+
+import { runscRuntimeError } from "./errors";
+import { encodeBoundedJson } from "./jsonEnvelope";
+import {
+  RUNSC_RUNTIME_LIMITS_V1,
+  boundedPositiveInteger,
+  boundedUtf8Bytes,
+} from "./limits";
+
+const envNamePattern = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const utf8Encoder = new TextEncoder();
+const invocationFrameMagic = new Uint8Array([0x42, 0x52, 0x49, 0x31]);
+const credentialFrameMagic = new Uint8Array([0x42, 0x52, 0x43, 0x31]);
+const reservedNames = new Set([
+  "BASH_ENV",
+  "DOCKER_CONFIG",
+  "DOCKER_HOST",
+  "ENV",
+  "HOME",
+  "IFS",
+  "LD_LIBRARY_PATH",
+  "LD_PRELOAD",
+  "NODE_OPTIONS",
+  "PATH",
+  "PWD",
+  "PYTHONHOME",
+  "PYTHONPATH",
+  "SHELL",
+  "_",
+]);
+
+export const RUNSC_RUNTIME_RESERVED_ENV_NAMES_V1 = Object.freeze([
+  ...reservedNames,
+]);
+
+function validateEnvName(name: string): void {
+  if (
+    !envNamePattern.test(name) ||
+    reservedNames.has(name) ||
+    name.startsWith("BORING_")
+  ) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+      "remote-worker invocation env name is not allowed",
+    );
+  }
+}
+
+function encodeCredentialFrame(
+  fields: readonly ResolvedInvocationCredentialFieldV1[],
+): Uint8Array {
+  if (fields.length === 0) return new Uint8Array();
+  if (fields.length > 16) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+      "remote-worker credential field count exceeds its bound",
+    );
+  }
+  const encodedNames = fields.map((field) => utf8Encoder.encode(field.name));
+  let size = 6;
+  for (let index = 0; index < fields.length; index += 1) {
+    const name = encodedNames[index]!;
+    const value = fields[index]!.value;
+    if (
+      name.byteLength === 0 ||
+      name.byteLength > REMOTE_WORKER_CREDENTIAL_NAME_MAX_BYTES_V1 ||
+      value.byteLength > RUNSC_RUNTIME_LIMITS_V1.maxEnvValueBytes
+    ) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+        "remote-worker credential field exceeds its bound",
+      );
+    }
+    size += 6 + name.byteLength + value.byteLength;
+  }
+  if (size > RUNSC_RUNTIME_LIMITS_V1.maxEnvelopeBytes) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+      "remote-worker credential frame exceeds its bound",
+    );
+  }
+  const frame = new Uint8Array(size);
+  frame.set(credentialFrameMagic, 0);
+  const view = new DataView(frame.buffer);
+  view.setUint16(4, fields.length, false);
+  let offset = 6;
+  for (let index = 0; index < fields.length; index += 1) {
+    const name = encodedNames[index]!;
+    const value = fields[index]!.value;
+    view.setUint16(offset, name.byteLength, false);
+    view.setUint32(offset + 2, value.byteLength, false);
+    offset += 6;
+    frame.set(name, offset);
+    offset += name.byteLength;
+    frame.set(value, offset);
+    offset += value.byteLength;
+  }
+  return frame;
+}
+
+function encodeInvocationFrame(
+  metadata: Uint8Array,
+  credentials: Uint8Array,
+): Uint8Array {
+  const size = 12 + metadata.byteLength + credentials.byteLength;
+  if (size > RUNSC_RUNTIME_LIMITS_V1.maxEnvelopeBytes) {
+    credentials.fill(0);
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      "remote-worker invocation frame exceeds its bound",
+    );
+  }
+  const frame = new Uint8Array(size);
+  frame.set(invocationFrameMagic, 0);
+  const view = new DataView(frame.buffer);
+  view.setUint32(4, metadata.byteLength, false);
+  view.setUint32(8, credentials.byteLength, false);
+  frame.set(metadata, 12);
+  frame.set(credentials, 12 + metadata.byteLength);
+  credentials.fill(0);
+  return frame;
+}
+
+export interface PreparedInvocationEnvelopeV1 {
+  readonly bytes: Uint8Array;
+  readonly secretBearing: boolean;
+  readonly timeoutMs: number;
+  readonly maxOutputBytes: number;
+}
+
+export interface ResolvedInvocationCredentialFieldV1 {
+  readonly bindingId: string;
+  readonly fieldId: string;
+  readonly name: string;
+  readonly value: Uint8Array;
+}
+
+export function prepareInvocationEnvelopeV1(input: {
+  workspaceId: string;
+  request: RemoteWorkerExecRequestV1;
+  resolvedCredentialFields?: readonly ResolvedInvocationCredentialFieldV1[];
+}): PreparedInvocationEnvelopeV1 {
+  let request: RemoteWorkerExecRequestV1;
+  try {
+    request = RemoteWorkerExecRequestSchemaV1.parse(input.request);
+  } catch (error) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      "remote-worker invocation failed strict validation",
+      error,
+    );
+  }
+  boundedUtf8Bytes(
+    request.command,
+    RUNSC_RUNTIME_LIMITS_V1.maxCommandBytes,
+    "command",
+  );
+  const timeoutMs = boundedPositiveInteger(
+    request.timeoutMs ?? RUNSC_RUNTIME_LIMITS_V1.defaultInvocationTimeoutMs,
+    RUNSC_RUNTIME_LIMITS_V1.maxInvocationTimeoutMs,
+    "invocation timeout",
+  );
+  const maxOutputBytes = boundedPositiveInteger(
+    request.maxOutputBytes,
+    RUNSC_RUNTIME_LIMITS_V1.maxCombinedOutputBytes,
+    "invocation output limit",
+  );
+  const cwd = request.cwd ?? "/workspace";
+  boundedUtf8Bytes(cwd, RUNSC_RUNTIME_LIMITS_V1.maxPathBytes, "cwd");
+  if (
+    (cwd !== "/workspace" && !cwd.startsWith("/workspace/")) ||
+    cwd.includes("\0") ||
+    cwd.split("/").includes("..")
+  ) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+      "remote-worker invocation cwd is outside the workspace",
+    );
+  }
+
+  const secretNames = new Set<string>();
+  const expectedFields = new Map<string, string>();
+  for (const credential of request.credentialRefs ?? []) {
+    if (credential.ref.executionId !== request.invocationId) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+        "remote-worker credential execution scope is invalid",
+      );
+    }
+    for (const field of credential.fields) {
+      validateEnvName(field.name);
+      const key = `${credential.ref.bindingId}\0${field.fieldId}`;
+      if (expectedFields.has(key) || secretNames.has(field.name)) {
+        throw runscRuntimeError(
+          REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+          "remote-worker credential fields must be unique",
+        );
+      }
+      expectedFields.set(key, field.name);
+      secretNames.add(field.name);
+    }
+  }
+  const resolvedFields = input.resolvedCredentialFields ?? [];
+  if (resolvedFields.length !== expectedFields.size) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+      "remote-worker credential resolution is incomplete",
+    );
+  }
+  const delivered = new Set<string>();
+  for (const field of resolvedFields) {
+    const key = `${field.bindingId}\0${field.fieldId}`;
+    const expectedName = expectedFields.get(key);
+    if (
+      expectedName === undefined ||
+      expectedName !== field.name ||
+      delivered.has(key)
+    ) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+        "remote-worker credential resolution does not match the request",
+      );
+    }
+    delivered.add(key);
+  }
+
+  const metadata = encodeBoundedJson(
+    {
+      version: 1,
+      command: request.command,
+      cwd,
+      timeoutMs,
+      maxOutputBytes,
+      graceMs: RUNSC_RUNTIME_LIMITS_V1.processGroupGraceMs,
+    },
+    RUNSC_RUNTIME_LIMITS_V1.maxEnvelopeBytes,
+  );
+  const bytes = encodeInvocationFrame(
+    metadata,
+    encodeCredentialFrame(resolvedFields),
+  );
+  return {
+    bytes,
+    secretBearing: expectedFields.size > 0,
+    timeoutMs,
+    maxOutputBytes,
+  };
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/jsonEnvelope.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/jsonEnvelope.ts
@@ -1,0 +1,48 @@
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
+
+import { runscRuntimeError } from "./errors";
+
+export function encodeBoundedJson(
+  value: unknown,
+  maximumBytes: number,
+): Uint8Array {
+  let encoded: Uint8Array;
+  try {
+    encoded = new TextEncoder().encode(JSON.stringify(value));
+  } catch (error) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      "remote-worker envelope cannot be encoded",
+      error,
+    );
+  }
+  if (encoded.byteLength === 0 || encoded.byteLength > maximumBytes) {
+    encoded.fill(0);
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      "remote-worker envelope exceeds its byte bound",
+    );
+  }
+  return encoded;
+}
+
+export function decodeBoundedJson(
+  value: Uint8Array,
+  maximumBytes: number,
+): unknown {
+  if (value.byteLength === 0 || value.byteLength > maximumBytes) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.responseInvalid,
+      "remote-worker helper response exceeds its byte bound",
+    );
+  }
+  try {
+    return JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(value));
+  } catch (error) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.responseInvalid,
+      "remote-worker helper returned an invalid response",
+      error,
+    );
+  }
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/limits.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/limits.ts
@@ -1,0 +1,55 @@
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
+
+import { runscRuntimeError } from "./errors";
+
+export const RUNSC_RUNTIME_LIMITS_V1 = Object.freeze({
+  defaultInvocationTimeoutMs: 30_000,
+  maxInvocationTimeoutMs: 15 * 60 * 1000,
+  maxCombinedOutputBytes: 4 * 1024 * 1024,
+  maxEnvelopeBytes: 512 * 1024,
+  maxWorkspaceEnvelopeBytes: 8 * 1024 * 1024,
+  maxCommandBytes: 64 * 1024,
+  maxPathBytes: 4 * 1024,
+  maxEnvEntries: 128,
+  maxSecretEntries: 32,
+  maxEnvValueBytes: 64 * 1024,
+  processGroupGraceMs: 2_000,
+  dockerCommandTimeoutMs: 120_000,
+  createTimeoutMs: 120_000,
+  fsTimeoutMs: 30_000,
+  renewTimeoutMs: 15_000,
+  disposeTimeoutMs: 30_000,
+  idleTtlMs: 30 * 60 * 1000,
+  hardLifetimeMs: 24 * 60 * 60 * 1000,
+  shutdownDrainMs: 30_000,
+  maxStartupSweepContainers: 1_000,
+} as const);
+
+export function boundedPositiveInteger(
+  value: number,
+  maximum: number,
+  label: string,
+): number {
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      `remote-worker ${label} is outside its bound`,
+    );
+  }
+  return value;
+}
+
+export function boundedUtf8Bytes(
+  value: string,
+  maximum: number,
+  label: string,
+): number {
+  const bytes = new TextEncoder().encode(value).byteLength;
+  if (bytes > maximum) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      `remote-worker ${label} exceeds its byte bound`,
+    );
+  }
+  return bytes;
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/quota.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/quota.ts
@@ -1,0 +1,147 @@
+import { spawn } from "node:child_process";
+
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
+
+import { runscRuntimeError } from "./errors";
+import { RUNSC_RUNTIME_LIMITS_V1 } from "./limits";
+
+export const RUNSC_WORKSPACE_QUOTA_PROFILE_V1 = Object.freeze({
+  profileId: "fixed-1gib-100k-v1",
+  bytes: 1024 * 1024 * 1024,
+  inodes: 100_000,
+} as const);
+
+export const RUNSC_QUOTA_HELPER_PATH =
+  "/usr/local/libexec/boring-workspace-quota" as const;
+export const RUNSC_QUOTA_HELPER_EXCEEDED_EXIT = 73;
+
+const workspaceIdPattern =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function validateQuotaWorkspaceId(workspaceId: string): string {
+  const normalized = workspaceId.trim().toLowerCase();
+  if (!workspaceIdPattern.test(normalized)) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      "remote-worker workspace id is invalid",
+    );
+  }
+  return normalized;
+}
+
+export type QuotaHelperOperationV1 = "apply" | "check";
+
+export interface QuotaHelperCommandResultV1 {
+  readonly exitCode: number;
+  readonly timedOut: boolean;
+}
+
+export interface QuotaHelperCommandRunnerV1 {
+  run(input: {
+    readonly argv: readonly [QuotaHelperOperationV1, string, string];
+    readonly timeoutMs: number;
+  }): Promise<QuotaHelperCommandResultV1>;
+}
+
+export class FixedQuotaHelperCommandRunnerV1
+  implements QuotaHelperCommandRunnerV1
+{
+  async run(input: {
+    readonly argv: readonly [QuotaHelperOperationV1, string, string];
+    readonly timeoutMs: number;
+  }): Promise<QuotaHelperCommandResultV1> {
+    return await new Promise((resolve, reject) => {
+      const child = spawn(RUNSC_QUOTA_HELPER_PATH, [...input.argv], {
+        shell: false,
+        stdio: "ignore",
+        windowsHide: true,
+      });
+      let timedOut = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        child.kill("SIGKILL");
+      }, input.timeoutMs);
+      child.once("error", (error) => {
+        clearTimeout(timer);
+        reject(
+          runscRuntimeError(
+            REMOTE_WORKER_ERROR_CODES_V1.unqualified,
+            "remote-worker quota helper is unavailable",
+            error,
+          ),
+        );
+      });
+      child.once("close", (exitCode) => {
+        clearTimeout(timer);
+        resolve({ exitCode: exitCode ?? -1, timedOut });
+      });
+    });
+  }
+}
+
+export class FixedProjectQuotaManagerV1 {
+  constructor(private readonly runner: QuotaHelperCommandRunnerV1) {}
+
+  async apply(workspaceId: string): Promise<void> {
+    await this.invoke("apply", workspaceId);
+  }
+
+  async check(workspaceId: string): Promise<void> {
+    await this.invoke("check", workspaceId);
+  }
+
+  private async invoke(
+    operation: QuotaHelperOperationV1,
+    workspaceId: string,
+  ): Promise<void> {
+    const normalized = validateQuotaWorkspaceId(workspaceId);
+    const result = await this.runner.run({
+      argv: [operation, normalized, RUNSC_WORKSPACE_QUOTA_PROFILE_V1.profileId],
+      timeoutMs: RUNSC_RUNTIME_LIMITS_V1.createTimeoutMs,
+    });
+    if (result.timedOut) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.timeout,
+        "remote-worker quota operation timed out",
+      );
+    }
+    if (result.exitCode === RUNSC_QUOTA_HELPER_EXCEEDED_EXIT) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.quotaExceeded,
+        "remote-worker workspace quota exceeded",
+      );
+    }
+    if (result.exitCode !== 0) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.unqualified,
+        "remote-worker quota operation failed",
+      );
+    }
+  }
+}
+
+export function requiredHostReserveBytes(totalVolumeBytes: number): number {
+  if (!Number.isSafeInteger(totalVolumeBytes) || totalVolumeBytes <= 0) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      "remote-worker volume capacity is invalid",
+    );
+  }
+  return Math.max(Math.ceil(totalVolumeBytes * 0.1), 10 * 1024 ** 3);
+}
+
+export function assertHostReserveWritable(input: {
+  readonly totalVolumeBytes: number;
+  readonly freeVolumeBytes: number;
+}): void {
+  const reserve = requiredHostReserveBytes(input.totalVolumeBytes);
+  if (
+    !Number.isSafeInteger(input.freeVolumeBytes) ||
+    input.freeVolumeBytes < reserve + RUNSC_WORKSPACE_QUOTA_PROFILE_V1.bytes
+  ) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.quotaExceeded,
+      "remote-worker host reserve prevents workspace allocation",
+    );
+  }
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/sessionRetirement.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/sessionRetirement.ts
@@ -1,0 +1,135 @@
+import { REMOTE_WORKER_ERROR_CODES_V1 } from "../../../shared/remoteWorkerProtocolV1";
+
+import { buildDockerRemoveArgv } from "./dockerArgv";
+import type { DockerCommandRunner } from "./dockerRunner";
+import { runDockerChecked } from "./dockerRunner";
+import { runscRuntimeError } from "./errors";
+import { RUNSC_RUNTIME_LIMITS_V1 } from "./limits";
+
+const RETIREMENT_RETRY_BASE_MS = 100;
+const RETIREMENT_RETRY_MAX_MS = 5_000;
+
+export type RunscSessionRetirementReasonV1 =
+  "idle" | "hard-expiry" | "missing" | "cleanup" | "history" | "shutdown";
+
+export interface RunscSessionRetirementV1 {
+  readonly sandboxId: string;
+  readonly reason: RunscSessionRetirementReasonV1;
+}
+
+export interface RetirableRunscSessionRecordV1 {
+  readonly sandboxId: string;
+  readonly runtimeId: string;
+  timer: ReturnType<typeof setTimeout>;
+  retirement?: {
+    readonly reason: RunscSessionRetirementReasonV1;
+    readonly notify: boolean;
+    attempts: number;
+  };
+}
+
+export interface RunscSessionRetirementManagerOptionsV1<
+  RecordV1 extends RetirableRunscSessionRecordV1,
+> {
+  readonly runner: DockerCommandRunner;
+  readonly detach: (record: RecordV1) => void;
+  readonly onRetire?: (
+    retirement: RunscSessionRetirementV1,
+  ) => void | Promise<void>;
+}
+
+export class RunscSessionRetirementManagerV1<
+  RecordV1 extends RetirableRunscSessionRecordV1,
+> {
+  private readonly cleanupInflight = new Map<RecordV1, Promise<void>>();
+  private readonly notificationInflight = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly options: RunscSessionRetirementManagerOptionsV1<RecordV1>,
+  ) {}
+
+  async retire(
+    record: RecordV1,
+    reason: RunscSessionRetirementReasonV1,
+    notify = true,
+  ): Promise<void> {
+    const existing = this.cleanupInflight.get(record);
+    if (existing) return await existing;
+    clearTimeout(record.timer);
+    record.retirement ??= { reason, notify, attempts: 0 };
+    const retirement = this.removeAndDetach(record);
+    this.cleanupInflight.set(record, retirement);
+    try {
+      await retirement;
+    } finally {
+      this.cleanupInflight.delete(record);
+    }
+  }
+
+  async notifyMissing(sandboxId: string): Promise<void> {
+    const existing = this.notificationInflight.get(sandboxId);
+    if (existing) return await existing;
+    const retirement = this.notify({ sandboxId, reason: "missing" });
+    this.notificationInflight.set(sandboxId, retirement);
+    try {
+      await retirement;
+    } finally {
+      this.notificationInflight.delete(sandboxId);
+    }
+  }
+
+  private async removeAndDetach(record: RecordV1): Promise<void> {
+    try {
+      await runDockerChecked(this.options.runner, {
+        argv: buildDockerRemoveArgv(record.runtimeId),
+        timeoutMs: RUNSC_RUNTIME_LIMITS_V1.disposeTimeoutMs,
+        maxOutputBytes: 64 * 1024,
+      });
+    } catch (error) {
+      record.retirement!.attempts += 1;
+      this.scheduleRetry(record);
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        "remote-worker sandbox cleanup is incomplete",
+        error,
+      );
+    }
+    const retirement = record.retirement;
+    this.options.detach(record);
+    if (retirement?.notify) {
+      await this.notify({
+        sandboxId: record.sandboxId,
+        reason: retirement.reason,
+      });
+    }
+  }
+
+  private scheduleRetry(record: RecordV1): void {
+    if (!record.retirement) return;
+    const exponent = Math.max(0, record.retirement.attempts - 1);
+    const delayMs = Math.min(
+      RETIREMENT_RETRY_BASE_MS * 2 ** exponent,
+      RETIREMENT_RETRY_MAX_MS,
+    );
+    clearTimeout(record.timer);
+    record.timer = setTimeout(() => {
+      void this.retire(
+        record,
+        record.retirement!.reason,
+        record.retirement!.notify,
+      ).catch(() => undefined);
+    }, delayMs);
+  }
+
+  private async notify(retirement: RunscSessionRetirementV1): Promise<void> {
+    try {
+      await this.options.onRetire?.(retirement);
+    } catch (error) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        "remote-worker retirement notification failed",
+        error,
+      );
+    }
+  }
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/sessionRuntime.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/sessionRuntime.ts
@@ -1,0 +1,860 @@
+import { randomBytes } from "node:crypto";
+
+import type {
+  AuthorizedWorkspaceCredentialScopeV1,
+  SandboxCredentialSecretPayloadLeaseV1,
+} from "@hachej/boring-agent/shared";
+
+import {
+  REMOTE_WORKER_ERROR_CODES_V1,
+  RemoteWorkerExecRequestSchemaV1,
+  RemoteWorkerExecResponseSchemaV1,
+  type RemoteWorkerExecRequestV1,
+  type RemoteWorkerExecResponseV1,
+  type RemoteWorkerWorkspaceOperationV1,
+  type RemoteWorkerWorkspaceResultV1,
+} from "../../../shared/remoteWorkerProtocolV1";
+import { remoteWorkerRequestDigestV1 } from "../../remote-worker/requestDigest";
+
+import {
+  buildDockerOwnedContainerListArgv,
+  buildDockerRemoveArgv,
+  buildDockerRemoveOwnedIdArgv,
+  buildDockerRunArgv,
+  buildDockerExecArgv,
+  type TrustedWorkspaceMountSource,
+} from "./dockerArgv";
+import type { DockerCommandResult, DockerCommandRunner } from "./dockerRunner";
+import { runDockerChecked } from "./dockerRunner";
+import { runscRuntimeError } from "./errors";
+import { prepareInvocationEnvelopeV1 } from "./invocationEnvelope";
+import type {
+  ResolvedRunscInvocationCredentialsV1,
+  RunscInvocationCredentialResolverV1,
+} from "./invocationCredentials";
+import { decodeBoundedJson } from "./jsonEnvelope";
+import { RUNSC_RUNTIME_LIMITS_V1, boundedPositiveInteger } from "./limits";
+import type { FixedProjectQuotaManagerV1 } from "./quota";
+import {
+  RunscSessionRetirementManagerV1,
+  type RunscSessionRetirementReasonV1,
+  type RunscSessionRetirementV1,
+} from "./sessionRetirement";
+import { RunscWorkspaceHelperClientV1 } from "./workspaceHelperClient";
+
+const MAX_INVOCATION_RECORDS = 256;
+export type { RunscSessionRetirementV1 } from "./sessionRetirement";
+
+export interface RunscSessionRuntimeOptionsV1 {
+  readonly runner: DockerCommandRunner;
+  readonly quota: Pick<FixedProjectQuotaManagerV1, "apply" | "check">;
+  readonly maxConcurrentCreates?: number;
+  readonly maxConcurrentExecs?: number;
+  readonly now?: () => number;
+  readonly runtimeIdFactory?: () => string;
+  readonly invocationCredentials?: RunscInvocationCredentialResolverV1;
+  readonly onRetire?: (
+    retirement: RunscSessionRetirementV1,
+  ) => void | Promise<void>;
+}
+
+export interface CreateRunscSessionInputV1 {
+  readonly sandboxId: string;
+  readonly clientLeaseId: string;
+  readonly workspaceId: string;
+  readonly workspaceMountSource: TrustedWorkspaceMountSource;
+  readonly image: string;
+  readonly idleTtlMs?: number;
+  readonly hardLifetimeMs?: number;
+}
+
+export interface RunscSessionLeaseV1 {
+  readonly sandboxId: string;
+  readonly leaseExpiresAtMs: number;
+  readonly hardExpiresAtMs: number;
+}
+
+interface InvocationRecordV1 {
+  readonly digest: `sha256:${string}`;
+  state: "running" | "complete" | "secret-terminal";
+  result?: RemoteWorkerExecResponseV1;
+}
+
+interface SessionRecordV1 {
+  readonly sandboxId: string;
+  readonly clientLeaseId: string;
+  readonly createDigest: `sha256:${string}`;
+  readonly workspaceId: string;
+  readonly workspaceMountSource: TrustedWorkspaceMountSource;
+  readonly image: string;
+  readonly createdAtMs: number;
+  readonly hardExpiresAtMs: number;
+  readonly idleTtlMs: number;
+  runtimeId: string;
+  leaseExpiresAtMs: number;
+  timer: ReturnType<typeof setTimeout>;
+  activeExec: boolean;
+  activeFs: boolean;
+  invocations: Map<string, InvocationRecordV1>;
+  retirement?: {
+    readonly reason: RunscSessionRetirementReasonV1;
+    readonly notify: boolean;
+    attempts: number;
+  };
+}
+
+interface InvocationHelperResponseV1 {
+  readonly ok: true;
+  readonly stdoutBase64: string;
+  readonly stderrBase64: string;
+  readonly exitCode: number;
+  readonly durationMs: number;
+  readonly truncated: boolean;
+  readonly timedOut: boolean;
+  readonly cleanupProven: boolean;
+}
+
+function isHelperResponse(value: unknown): value is InvocationHelperResponseV1 {
+  if (!value || typeof value !== "object") return false;
+  const result = value as Partial<InvocationHelperResponseV1>;
+  return (
+    result.ok === true &&
+    typeof result.stdoutBase64 === "string" &&
+    typeof result.stderrBase64 === "string" &&
+    Number.isInteger(result.exitCode) &&
+    typeof result.durationMs === "number" &&
+    typeof result.truncated === "boolean" &&
+    typeof result.timedOut === "boolean" &&
+    typeof result.cleanupProven === "boolean"
+  );
+}
+
+function runtimeId(): string {
+  return randomBytes(16).toString("hex");
+}
+
+function safeOpaqueId(value: string, label: string): string {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/.test(value)) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+      `remote-worker ${label} is invalid`,
+    );
+  }
+  return value;
+}
+
+export class RunscSessionRuntimeV1 {
+  private readonly sessions = new Map<string, SessionRecordV1>();
+  private readonly leaseBindings = new Map<string, SessionRecordV1>();
+  private readonly workspaceBindings = new Map<string, SessionRecordV1>();
+  private readonly pendingWorkspaceCreates = new Set<string>();
+  private readonly pendingCreates = new Map<
+    string,
+    { digest: `sha256:${string}`; promise: Promise<RunscSessionLeaseV1> }
+  >();
+  private readonly pendingOperations = new Set<Promise<unknown>>();
+  private readonly workspace: RunscWorkspaceHelperClientV1;
+  private readonly retirement: RunscSessionRetirementManagerV1<SessionRecordV1>;
+  private readonly now: () => number;
+  private readonly runtimeIdFactory: () => string;
+  private readonly maxConcurrentCreates: number;
+  private readonly maxConcurrentExecs: number;
+  private activeCreates = 0;
+  private activeExecs = 0;
+  private closed = false;
+
+  constructor(private readonly options: RunscSessionRuntimeOptionsV1) {
+    this.workspace = new RunscWorkspaceHelperClientV1(options.runner);
+    this.retirement = new RunscSessionRetirementManagerV1({
+      runner: options.runner,
+      detach: (record) => this.detach(record),
+      onRetire: options.onRetire,
+    });
+    this.now = options.now ?? Date.now;
+    this.runtimeIdFactory = options.runtimeIdFactory ?? runtimeId;
+    this.maxConcurrentCreates = boundedPositiveInteger(
+      options.maxConcurrentCreates ?? 4,
+      1_000,
+      "create concurrency",
+    );
+    this.maxConcurrentExecs = boundedPositiveInteger(
+      options.maxConcurrentExecs ?? 16,
+      10_000,
+      "exec concurrency",
+    );
+  }
+
+  async startupSweep(): Promise<void> {
+    if (this.closed) this.unavailable();
+    const listed = await runDockerChecked(this.options.runner, {
+      argv: buildDockerOwnedContainerListArgv(),
+      timeoutMs: RUNSC_RUNTIME_LIMITS_V1.disposeTimeoutMs,
+      maxOutputBytes: 128 * 1024,
+    });
+    const containerIds = new TextDecoder()
+      .decode(listed.stdout)
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+    if (
+      containerIds.length > RUNSC_RUNTIME_LIMITS_V1.maxStartupSweepContainers
+    ) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        "remote-worker startup cleanup exceeds its bound",
+      );
+    }
+    for (const containerId of containerIds) {
+      await runDockerChecked(this.options.runner, {
+        argv: buildDockerRemoveOwnedIdArgv(containerId),
+        timeoutMs: RUNSC_RUNTIME_LIMITS_V1.disposeTimeoutMs,
+        maxOutputBytes: 64 * 1024,
+      });
+    }
+  }
+
+  create(input: CreateRunscSessionInputV1): Promise<RunscSessionLeaseV1> {
+    if (this.closed) this.unavailable();
+    safeOpaqueId(input.sandboxId, "sandbox id");
+    safeOpaqueId(input.clientLeaseId, "client lease id");
+    const digest = remoteWorkerRequestDigestV1({
+      sandboxId: input.sandboxId,
+      clientLeaseId: input.clientLeaseId,
+      workspaceId: input.workspaceId,
+      workspaceMountSource: input.workspaceMountSource,
+      image: input.image,
+      idleTtlMs: input.idleTtlMs,
+      hardLifetimeMs: input.hardLifetimeMs,
+    });
+    const existing = this.leaseBindings.get(input.clientLeaseId);
+    if (existing) {
+      if (existing.createDigest !== digest) this.idempotencyConflict();
+      if (existing.retirement) this.incompleteCleanup();
+      return Promise.resolve(this.lease(existing));
+    }
+    const pending = this.pendingCreates.get(input.clientLeaseId);
+    if (pending) {
+      if (pending.digest !== digest) this.idempotencyConflict();
+      return pending.promise;
+    }
+    if (
+      this.workspaceBindings.has(input.workspaceId) ||
+      this.pendingWorkspaceCreates.has(input.workspaceId)
+    ) {
+      this.idempotencyConflict();
+    }
+    if (this.activeCreates >= this.maxConcurrentCreates) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.createConcurrencyExhausted,
+        "remote-worker create concurrency is exhausted",
+      );
+    }
+    this.activeCreates += 1;
+    this.pendingWorkspaceCreates.add(input.workspaceId);
+    const operation = this.track(this.createNew(input, digest));
+    this.pendingCreates.set(input.clientLeaseId, {
+      digest,
+      promise: operation,
+    });
+    const finishCreate = (): void => {
+      this.activeCreates -= 1;
+      this.pendingCreates.delete(input.clientLeaseId);
+      this.pendingWorkspaceCreates.delete(input.workspaceId);
+    };
+    void operation.then(finishCreate, finishCreate);
+    return operation;
+  }
+
+  private async createNew(
+    input: CreateRunscSessionInputV1,
+    digest: `sha256:${string}`,
+  ): Promise<RunscSessionLeaseV1> {
+    if (this.sessions.has(input.sandboxId)) this.idempotencyConflict();
+    const idleTtlMs = boundedPositiveInteger(
+      input.idleTtlMs ?? RUNSC_RUNTIME_LIMITS_V1.idleTtlMs,
+      RUNSC_RUNTIME_LIMITS_V1.idleTtlMs,
+      "idle TTL",
+    );
+    const hardLifetimeMs = boundedPositiveInteger(
+      input.hardLifetimeMs ?? RUNSC_RUNTIME_LIMITS_V1.hardLifetimeMs,
+      RUNSC_RUNTIME_LIMITS_V1.hardLifetimeMs,
+      "hard lifetime",
+    );
+    await this.options.quota.apply(input.workspaceId);
+    await this.options.quota.check(input.workspaceId);
+    const createdAtMs = this.now();
+    const record: SessionRecordV1 = {
+      sandboxId: input.sandboxId,
+      clientLeaseId: input.clientLeaseId,
+      createDigest: digest,
+      workspaceId: input.workspaceId,
+      workspaceMountSource: input.workspaceMountSource,
+      image: input.image,
+      createdAtMs,
+      hardExpiresAtMs: createdAtMs + hardLifetimeMs,
+      idleTtlMs,
+      runtimeId: this.nextRuntimeId(),
+      leaseExpiresAtMs: Math.min(
+        createdAtMs + idleTtlMs,
+        createdAtMs + hardLifetimeMs,
+      ),
+      timer: setTimeout(() => undefined, 1),
+      activeExec: false,
+      activeFs: false,
+      invocations: new Map(),
+    };
+    clearTimeout(record.timer);
+    try {
+      await this.startContainer(record);
+    } catch (error) {
+      await this.retireFailedCreate(record);
+      throw error;
+    }
+    if (this.closed) {
+      await this.retireFailedCreate(record);
+      this.unavailable();
+    }
+    this.bind(record);
+    this.armTimer(record);
+    return this.lease(record);
+  }
+
+  async exec(
+    sandboxId: string,
+    workspaceId: string,
+    requestInput: RemoteWorkerExecRequestV1,
+    signal?: AbortSignal,
+    credentialScope?: AuthorizedWorkspaceCredentialScopeV1,
+  ): Promise<RemoteWorkerExecResponseV1> {
+    const record = await this.activeSession(sandboxId);
+    if (record.workspaceId !== workspaceId) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.sandboxWorkspaceMismatch,
+        "remote-worker sandbox binding does not match the authorized workspace",
+      );
+    }
+    const parsedRequest =
+      RemoteWorkerExecRequestSchemaV1.safeParse(requestInput);
+    if (!parsedRequest.success) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+        "remote-worker invocation failed strict validation",
+      );
+    }
+    const request = parsedRequest.data;
+    const digest = remoteWorkerRequestDigestV1(request);
+    const prior = record.invocations.get(request.invocationId);
+    if (prior) {
+      if (prior.digest !== digest) this.idempotencyConflict();
+      if (prior.state === "running") {
+        throw runscRuntimeError(
+          REMOTE_WORKER_ERROR_CODES_V1.execInProgress,
+          "remote-worker invocation is already running",
+        );
+      }
+      if (prior.state === "secret-terminal") {
+        throw runscRuntimeError(
+          REMOTE_WORKER_ERROR_CODES_V1.secretInvocationNotReplayable,
+          "remote-worker secret-bearing invocation is not replayable",
+        );
+      }
+      return prior.result as RemoteWorkerExecResponseV1;
+    }
+    if (
+      record.activeExec ||
+      record.activeFs ||
+      this.activeExecs >= this.maxConcurrentExecs
+    ) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.execConcurrencyExhausted,
+        "remote-worker exec concurrency is exhausted",
+      );
+    }
+    await this.requireInvocationCapacity(record);
+    const invocation: InvocationRecordV1 = { digest, state: "running" };
+    record.invocations.set(request.invocationId, invocation);
+    record.activeExec = true;
+    this.activeExecs += 1;
+    this.touch(record);
+
+    const operation = this.track(
+      this.executeInvocation(
+        record,
+        request.invocationId,
+        invocation,
+        request,
+        signal,
+        credentialScope,
+      ),
+    );
+    return await operation;
+  }
+
+  private async executeInvocation(
+    record: SessionRecordV1,
+    invocationId: string,
+    invocation: InvocationRecordV1,
+    request: RemoteWorkerExecRequestV1,
+    signal?: AbortSignal,
+    credentialScope?: AuthorizedWorkspaceCredentialScopeV1,
+  ): Promise<RemoteWorkerExecResponseV1> {
+    let secretExecutionStarted = false;
+    let envelope: ReturnType<typeof prepareInvocationEnvelopeV1> | undefined;
+    let credentialLeases: readonly SandboxCredentialSecretPayloadLeaseV1[] = [];
+    try {
+      const resolved =
+        request.credentialRefs && request.credentialRefs.length > 0
+          ? await this.resolveInvocationCredentials(
+              record,
+              request,
+              credentialScope,
+            )
+          : { fields: [], leases: [] };
+      credentialLeases = resolved.leases;
+      secretExecutionStarted = resolved.leases.length > 0;
+      envelope = prepareInvocationEnvelopeV1({
+        workspaceId: record.workspaceId,
+        request,
+        resolvedCredentialFields: resolved.fields,
+      });
+      if (envelope.secretBearing) await this.replaceContainer(record, true);
+      const result = await this.runInvocation(record, envelope, signal);
+      if (envelope.secretBearing) {
+        await this.replaceContainer(record, false);
+        invocation.state = "secret-terminal";
+      } else {
+        invocation.state = "complete";
+        invocation.result = result;
+      }
+      return result;
+    } catch (error) {
+      await this.recoverInvocationFailure(
+        record,
+        invocationId,
+        invocation,
+        secretExecutionStarted,
+        signal?.aborted === true,
+      );
+      if (signal?.aborted) {
+        throw runscRuntimeError(
+          REMOTE_WORKER_ERROR_CODES_V1.execAborted,
+          "remote-worker invocation was aborted",
+        );
+      }
+      throw error;
+    } finally {
+      envelope?.bytes.fill(0);
+      for (const lease of credentialLeases) {
+        try {
+          lease.dispose();
+        } catch {
+          // Lease disposal is best effort and must never expose credential data.
+        }
+      }
+      record.activeExec = false;
+      this.activeExecs -= 1;
+      if (this.sessions.get(record.sandboxId) === record) this.touch(record);
+    }
+  }
+
+  private async resolveInvocationCredentials(
+    record: SessionRecordV1,
+    request: RemoteWorkerExecRequestV1,
+    credentialScope?: AuthorizedWorkspaceCredentialScopeV1,
+  ): Promise<ResolvedRunscInvocationCredentialsV1> {
+    const references = request.credentialRefs ?? [];
+    if (references.length === 0) return { fields: [], leases: [] };
+    const resolver = this.options.invocationCredentials;
+    if (!credentialScope || !resolver) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.secretReferenceRejected,
+        "remote-worker credential delivery is unavailable",
+      );
+    }
+    return await resolver.resolve({
+      workspaceId: record.workspaceId,
+      sandboxId: record.sandboxId,
+      invocationId: request.invocationId,
+      references,
+      credentialScope,
+      nowMs: this.now(),
+    });
+  }
+
+  private async recoverInvocationFailure(
+    record: SessionRecordV1,
+    invocationId: string,
+    invocation: InvocationRecordV1,
+    secretExecutionStarted: boolean,
+    aborted: boolean,
+  ): Promise<void> {
+    if (secretExecutionStarted) {
+      invocation.state = "secret-terminal";
+      if (this.sessions.get(record.sandboxId) === record) {
+        const cleaned = await this.replaceAfterUnprovenExecution(record);
+        if (!cleaned) {
+          try {
+            await this.retire(record, "cleanup");
+          } catch {
+            // retire() retains ownership and schedules a bounded retry.
+          }
+          this.incompleteCleanup();
+        }
+      }
+      return;
+    }
+    if (invocation.state === "running") {
+      record.invocations.delete(invocationId);
+    }
+    if (aborted) {
+      const cleaned = await this.replaceAfterUnprovenExecution(record);
+      if (!cleaned) this.incompleteCleanup();
+    }
+  }
+
+  async fs(
+    sandboxId: string,
+    operation: RemoteWorkerWorkspaceOperationV1,
+  ): Promise<RemoteWorkerWorkspaceResultV1> {
+    const record = await this.activeSession(sandboxId);
+    if (record.activeExec || record.activeFs) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.execInProgress,
+        "remote-worker session operation is already running",
+      );
+    }
+    record.activeFs = true;
+    try {
+      const result = await this.workspace.execute(record.runtimeId, operation);
+      this.touch(record);
+      return result;
+    } finally {
+      record.activeFs = false;
+    }
+  }
+
+  async renew(
+    sandboxId: string,
+    idleTtlMs: number,
+  ): Promise<RunscSessionLeaseV1> {
+    const record = await this.activeSession(sandboxId);
+    const bounded = boundedPositiveInteger(
+      idleTtlMs,
+      RUNSC_RUNTIME_LIMITS_V1.idleTtlMs,
+      "idle TTL",
+    );
+    record.leaseExpiresAtMs = Math.min(
+      this.now() + bounded,
+      record.hardExpiresAtMs,
+    );
+    this.armTimer(record);
+    return this.lease(record);
+  }
+
+  async dispose(sandboxId: string): Promise<void> {
+    const record = this.sessions.get(sandboxId);
+    if (!record) return;
+    await this.retire(record, "cleanup", false);
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    for (const record of this.sessions.values()) clearTimeout(record.timer);
+    const drain = Promise.allSettled([...this.pendingOperations]);
+    await Promise.race([
+      drain,
+      new Promise<void>((resolve) =>
+        setTimeout(resolve, RUNSC_RUNTIME_LIMITS_V1.shutdownDrainMs),
+      ),
+    ]);
+    const records = [...this.sessions.values()];
+    const retirements = await Promise.allSettled(
+      records.map(async (record) => await this.retire(record, "shutdown")),
+    );
+    const failure = retirements.find(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (failure) {
+      throw failure.reason;
+    }
+  }
+
+  private async runInvocation(
+    record: SessionRecordV1,
+    envelope: ReturnType<typeof prepareInvocationEnvelopeV1>,
+    signal?: AbortSignal,
+  ): Promise<RemoteWorkerExecResponseV1> {
+    let dockerResult: DockerCommandResult;
+    try {
+      dockerResult = await this.options.runner.run({
+        argv: buildDockerExecArgv(record.runtimeId, "invoke"),
+        stdin: envelope.bytes,
+        timeoutMs:
+          envelope.timeoutMs +
+          RUNSC_RUNTIME_LIMITS_V1.processGroupGraceMs +
+          30_000,
+        maxOutputBytes:
+          Math.ceil((envelope.maxOutputBytes * 4) / 3) + 128 * 1024,
+        signal,
+      });
+    } catch (error) {
+      await this.resetOrRetireAfterUnknown(record);
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        "remote-worker invocation cleanup could not be proven",
+        error,
+      );
+    }
+    if (
+      dockerResult.timedOut ||
+      dockerResult.aborted ||
+      dockerResult.exitCode !== 0 ||
+      dockerResult.truncated
+    ) {
+      await this.resetOrRetireAfterUnknown(record);
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        "remote-worker invocation cleanup could not be proven",
+      );
+    }
+    const parsed = decodeBoundedJson(dockerResult.stdout, 8 * 1024 * 1024);
+    if (!isHelperResponse(parsed) || !parsed.cleanupProven) {
+      await this.resetOrRetireAfterUnknown(record);
+      this.incompleteCleanup();
+    }
+    let response: RemoteWorkerExecResponseV1;
+    try {
+      response = RemoteWorkerExecResponseSchemaV1.parse({
+        stdoutBase64: parsed.stdoutBase64,
+        stderrBase64: parsed.stderrBase64,
+        exitCode: parsed.exitCode,
+        durationMs: parsed.durationMs,
+        truncated: parsed.truncated,
+      });
+      const outputBytes =
+        Buffer.from(response.stdoutBase64, "base64").byteLength +
+        Buffer.from(response.stderrBase64, "base64").byteLength;
+      if (outputBytes > envelope.maxOutputBytes)
+        throw new Error("output bound");
+    } catch (error) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.responseInvalid,
+        "remote-worker invocation wrapper returned an invalid result",
+        error,
+      );
+    }
+    if (parsed.timedOut) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.timeout,
+        "remote-worker invocation timed out",
+      );
+    }
+    return response;
+  }
+
+  private async startContainer(
+    record: SessionRecordV1,
+    workspaceReadOnly = false,
+  ): Promise<void> {
+    await runDockerChecked(this.options.runner, {
+      argv: buildDockerRunArgv({
+        runtimeId: record.runtimeId,
+        workspaceMountSource: record.workspaceMountSource,
+        workspaceReadOnly,
+        image: record.image,
+      }),
+      timeoutMs: RUNSC_RUNTIME_LIMITS_V1.createTimeoutMs,
+      maxOutputBytes: 64 * 1024,
+    });
+    await this.workspace.probe(record.runtimeId);
+  }
+
+  private async replaceContainer(
+    record: SessionRecordV1,
+    workspaceReadOnly = false,
+  ): Promise<void> {
+    await runDockerChecked(this.options.runner, {
+      argv: buildDockerRemoveArgv(record.runtimeId),
+      timeoutMs: RUNSC_RUNTIME_LIMITS_V1.disposeTimeoutMs,
+      maxOutputBytes: 64 * 1024,
+    });
+    record.runtimeId = this.nextRuntimeId();
+    try {
+      await this.startContainer(record, workspaceReadOnly);
+    } catch (error) {
+      await this.retire(record, "cleanup");
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+        "remote-worker clean container replacement failed",
+        error,
+      );
+    }
+  }
+
+  private async replaceAfterUnprovenExecution(
+    record: SessionRecordV1,
+  ): Promise<boolean> {
+    try {
+      await this.replaceContainer(record);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async resetOrRetireAfterUnknown(
+    record: SessionRecordV1,
+  ): Promise<void> {
+    if (!(await this.replaceAfterUnprovenExecution(record))) {
+      await this.retire(record, "cleanup");
+    }
+  }
+
+  private async activeSession(sandboxId: string): Promise<SessionRecordV1> {
+    if (this.closed) this.unavailable();
+    const record = this.sessions.get(sandboxId);
+    if (!record) {
+      await this.notifyMissing(sandboxId);
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.sandboxNotFound,
+        "remote-worker sandbox was not found",
+      );
+    }
+    if (record.retirement) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.sandboxDisposed,
+        "remote-worker sandbox retirement is in progress",
+      );
+    }
+    const nowMs = this.now();
+    if (record.hardExpiresAtMs <= nowMs || record.leaseExpiresAtMs <= nowMs) {
+      const hard = record.hardExpiresAtMs <= nowMs;
+      await this.retire(record, hard ? "hard-expiry" : "idle");
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.sandboxExpired,
+        "remote-worker sandbox expired",
+      );
+    }
+    return record;
+  }
+
+  private armTimer(record: SessionRecordV1): void {
+    clearTimeout(record.timer);
+    if (record.retirement) return;
+    const deadline = Math.min(record.leaseExpiresAtMs, record.hardExpiresAtMs);
+    record.timer = setTimeout(
+      () => {
+        const reason: RunscSessionRetirementReasonV1 =
+          record.hardExpiresAtMs <= this.now() ? "hard-expiry" : "idle";
+        void this.retire(record, reason).catch(() => undefined);
+      },
+      Math.max(0, deadline - this.now()),
+    );
+  }
+
+  private touch(record: SessionRecordV1): void {
+    if (record.retirement) return;
+    record.leaseExpiresAtMs = Math.min(
+      this.now() + record.idleTtlMs,
+      record.hardExpiresAtMs,
+    );
+    this.armTimer(record);
+  }
+
+  private lease(record: SessionRecordV1): RunscSessionLeaseV1 {
+    return Object.freeze({
+      sandboxId: record.sandboxId,
+      leaseExpiresAtMs: record.leaseExpiresAtMs,
+      hardExpiresAtMs: record.hardExpiresAtMs,
+    });
+  }
+
+  private nextRuntimeId(): string {
+    const value = this.runtimeIdFactory();
+    if (!/^[a-f0-9]{32}$/.test(value)) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.configInvalid,
+        "remote-worker runtime id factory is invalid",
+      );
+    }
+    return value;
+  }
+
+  private async requireInvocationCapacity(
+    record: SessionRecordV1,
+  ): Promise<void> {
+    if (record.invocations.size < MAX_INVOCATION_RECORDS) return;
+    await this.retire(record, "history");
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.sandboxExpired,
+      "remote-worker sandbox invocation history is exhausted",
+    );
+  }
+
+  private detach(record: SessionRecordV1): void {
+    clearTimeout(record.timer);
+    this.sessions.delete(record.sandboxId);
+    if (this.leaseBindings.get(record.clientLeaseId) === record) {
+      this.leaseBindings.delete(record.clientLeaseId);
+    }
+    if (this.workspaceBindings.get(record.workspaceId) === record) {
+      this.workspaceBindings.delete(record.workspaceId);
+    }
+    record.invocations.clear();
+  }
+
+  private bind(record: SessionRecordV1): void {
+    this.sessions.set(record.sandboxId, record);
+    this.leaseBindings.set(record.clientLeaseId, record);
+    this.workspaceBindings.set(record.workspaceId, record);
+  }
+
+  private async retireFailedCreate(record: SessionRecordV1): Promise<void> {
+    this.bind(record);
+    await this.retire(record, "cleanup", false);
+  }
+
+  private async retire(
+    record: SessionRecordV1,
+    reason: RunscSessionRetirementReasonV1,
+    notify = true,
+  ): Promise<void> {
+    await this.retirement.retire(record, reason, notify);
+  }
+
+  private async notifyMissing(sandboxId: string): Promise<void> {
+    safeOpaqueId(sandboxId, "sandbox id");
+    await this.retirement.notifyMissing(sandboxId);
+  }
+
+  private track<T>(operation: Promise<T>): Promise<T> {
+    this.pendingOperations.add(operation);
+    const cleanup = (): void => {
+      this.pendingOperations.delete(operation);
+    };
+    void operation.then(cleanup, cleanup);
+    return operation;
+  }
+
+  private unavailable(): never {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.unavailable,
+      "remote-worker runtime is unavailable",
+    );
+  }
+
+  private idempotencyConflict(): never {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.idempotencyConflict,
+      "remote-worker idempotency key conflicts with an existing request",
+    );
+  }
+
+  private incompleteCleanup(): never {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.incompleteCleanup,
+      "remote-worker invocation cleanup could not be proven",
+    );
+  }
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/workload/cmd/boring-runtime/testdata/credential-frame-v1.json
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/workload/cmd/boring-runtime/testdata/credential-frame-v1.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "maxNameBytes": 256,
+  "vectors": [
+    {
+      "name": "TOOL_CREDENTIAL",
+      "valueHex": "000102ff",
+      "frameHex": "425243310001000f00000004544f4f4c5f43524544454e5449414c000102ff"
+    }
+  ]
+}

--- a/packages/boring-sandbox/src/providers/runsc/runtime/workspaceHelperClient.ts
+++ b/packages/boring-sandbox/src/providers/runsc/runtime/workspaceHelperClient.ts
@@ -1,0 +1,121 @@
+import {
+  REMOTE_WORKER_ERROR_CODES_V1,
+  RemoteWorkerWorkspaceOperationSchemaV1,
+  RemoteWorkerWorkspaceResultSchemaV1,
+  type RemoteWorkerWorkspaceOperationV1,
+  type RemoteWorkerWorkspaceResultV1,
+} from "../../../shared/remoteWorkerProtocolV1";
+
+import { buildDockerExecArgv } from "./dockerArgv";
+import type { DockerCommandRunner } from "./dockerRunner";
+import { runDockerChecked } from "./dockerRunner";
+import { runscRuntimeError } from "./errors";
+import { decodeBoundedJson, encodeBoundedJson } from "./jsonEnvelope";
+import { RUNSC_RUNTIME_LIMITS_V1 } from "./limits";
+
+interface HelperFailure {
+  readonly ok: false;
+  readonly code: string;
+}
+
+function validateWorkspacePath(path: string): void {
+  if (
+    path.length === 0 ||
+    path.length > RUNSC_RUNTIME_LIMITS_V1.maxPathBytes ||
+    path.startsWith("/") ||
+    path.includes("\0") ||
+    path.split("/").some((component) => component === "..")
+  ) {
+    throw runscRuntimeError(
+      REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe,
+      "remote-worker workspace path is unsafe",
+    );
+  }
+}
+
+function validateOperationPaths(operation: RemoteWorkerWorkspaceOperationV1): void {
+  if ("path" in operation) validateWorkspacePath(operation.path);
+  if (operation.op === "rename") {
+    validateWorkspacePath(operation.from);
+    validateWorkspacePath(operation.to);
+  }
+}
+
+function helperFailure(value: unknown): value is HelperFailure {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    (value as { ok?: unknown }).ok === false &&
+    typeof (value as { code?: unknown }).code === "string"
+  );
+}
+
+export class RunscWorkspaceHelperClientV1 {
+  constructor(private readonly runner: DockerCommandRunner) {}
+
+  async probe(runtimeId: string): Promise<void> {
+    const response = await this.call(runtimeId, { op: "probe" });
+    if (
+      !response ||
+      typeof response !== "object" ||
+      (response as { openat2?: unknown }).openat2 !== true
+    ) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.pathPrimitiveUnavailable,
+        "remote-worker workspace containment primitive is unavailable",
+      );
+    }
+  }
+
+  async execute(
+    runtimeId: string,
+    input: RemoteWorkerWorkspaceOperationV1,
+  ): Promise<RemoteWorkerWorkspaceResultV1> {
+    let operation: RemoteWorkerWorkspaceOperationV1;
+    try {
+      operation = RemoteWorkerWorkspaceOperationSchemaV1.parse(input);
+    } catch (error) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.requestInvalid,
+        "remote-worker workspace operation failed strict validation",
+        error,
+      );
+    }
+    validateOperationPaths(operation);
+    const response = await this.call(runtimeId, operation);
+    if (helperFailure(response)) {
+      const code =
+        response.code === REMOTE_WORKER_ERROR_CODES_V1.quotaExceeded
+          ? REMOTE_WORKER_ERROR_CODES_V1.quotaExceeded
+          : response.code === REMOTE_WORKER_ERROR_CODES_V1.pathPrimitiveUnavailable
+            ? REMOTE_WORKER_ERROR_CODES_V1.pathPrimitiveUnavailable
+            : REMOTE_WORKER_ERROR_CODES_V1.pathUnsafe;
+      throw runscRuntimeError(code, "remote-worker workspace operation failed");
+    }
+    try {
+      return RemoteWorkerWorkspaceResultSchemaV1.parse(response);
+    } catch (error) {
+      throw runscRuntimeError(
+        REMOTE_WORKER_ERROR_CODES_V1.responseInvalid,
+        "remote-worker workspace helper returned an invalid result",
+        error,
+      );
+    }
+  }
+
+  private async call(runtimeId: string, body: unknown): Promise<unknown> {
+    const result = await runDockerChecked(this.runner, {
+      argv: buildDockerExecArgv(runtimeId, "workspace"),
+      stdin: encodeBoundedJson(
+        body,
+        RUNSC_RUNTIME_LIMITS_V1.maxWorkspaceEnvelopeBytes,
+      ),
+      timeoutMs: RUNSC_RUNTIME_LIMITS_V1.fsTimeoutMs,
+      maxOutputBytes: RUNSC_RUNTIME_LIMITS_V1.maxWorkspaceEnvelopeBytes,
+    });
+    return decodeBoundedJson(
+      result.stdout,
+      RUNSC_RUNTIME_LIMITS_V1.maxWorkspaceEnvelopeBytes,
+    );
+  }
+}


### PR DESCRIPTION
Part of epic #1081. This PR is stacked on #1163 and uses `feat/1081-sbx13-slice1` as its base.

## What this slice ports

- The session-lifetime Docker+runsc TypeScript runtime: typed Docker argv construction/runner, bounded JSON and process I/O, runtime limits/errors, session creation/reuse/renewal/expiry/disposal, orphan cleanup, and retryable retirement ownership.
- Purpose-typed, non-model per-invocation credential resolution and fd3 binary envelope wiring with exact workspace/sandbox/execution/binding scope checks and secret-byte zeroing.
- Fixed project-quota management, host-reserve checks, and serialized quota application before session container creation.
- Workspace helper client wiring.
- The donor conformance coverage: six runtime test files / 58 tests, including the 992-line sessionRuntime suite and its 16 session/race/cleanup scenarios.
- The credential-frame JSON golden vector required by the TypeScript envelope suite.

## Faithful port vs adaptation

All 18 runtime implementation/test/fixture files are byte-identical to donor head `12939f363` from `origin/feat/808-sbx1-3-runtime`. The only adaptation is appending the donor runtime exports to the current slice-1 shape of `providers/runsc/index.ts`.

## Explicit exclusions and gates

- Excludes the Go workload supervisor, Go quota helper, Dockerfile, `test:runsc:integration` script, and evidence documentation; those remain slices 3-4.
- SBX1.4 gate (`d3a1bd393`): no legacy V0 remote-worker path is touched or un-retired.
- SBX1.4/1.5 gates (`bb6e328d3`): no image/cohort qualification, fleet admission, or real-runsc admitting evidence is claimed here.
- #1167: this slice does not attempt the per-tenant nonce sub-budget, alter nonce persistence, or add workspaceId to the credential-ref wire shape. Credential resolution binds the authenticated workspace at runtime.

## Verification

- `pnpm -C packages/boring-sandbox exec vitest run src/providers/runsc/runtime/__tests__` — 6 files, 58 tests passed.
- `pnpm -C packages/boring-sandbox build` — passed.
- `pnpm -C packages/boring-sandbox typecheck` — passed.
- `pnpm -C packages/boring-sandbox test` — 51 files, 493 tests passed after the package build.
- `pnpm lint:invariants` — passed.
- Donor integrity check — all 18 restored files match donor Git blob hashes.

## Review

Independent thermo/security review of `f9095e29a1591cad00a28f49c04b245da008a582`: clean, no blockers.

🤖 Generated with Codex (gpt-5.6-sol)