### PR TITLE
[gh-1177 S1] visual docs: package map + runtime stack

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ procedures live in [`kanzen/`](kanzen/).
 | Need | Read |
 | --- | --- |
 | Direction & vision (sequencing authority, living vision, completion tracker) | [`direction/`](direction/README.md) — [`DIRECTION.md`](direction/DIRECTION.md) · [`VISION.md`](direction/VISION.md) · [`STATE.md`](direction/STATE.md) |
+| Visual architecture (package map and runtime layers) | [`visual/`](visual/README.md) |
 
 ## What this is
 

--- a/docs/visual/README.md
+++ b/docs/visual/README.md
@@ -1,0 +1,12 @@
+# Visual architecture
+
+Diagram-first orientation to the current system. Package docs, contracts, and
+accepted decisions remain normative.
+
+| View | Shows |
+| --- | --- |
+| [Package map](package-map.md) | Apps, packages, plugins, tooling, and knowledge boundaries |
+| [Runtime stack](runtime-stack.md) | Agent orchestration over boring-bash operations and boring-sandbox providers |
+
+Further connector and request-flow diagrams are tracked in
+[epic #1177](https://github.com/hachej/boring-ui/issues/1177).

--- a/docs/visual/package-map.md
+++ b/docs/visual/package-map.md
@@ -1,0 +1,87 @@
+# Package map
+
+```mermaid
+flowchart TB
+  subgraph hosts[Apps and runnable hosts]
+    apps[full-app and playgrounds]
+    cli[boring-ui CLI]
+  end
+
+  subgraph composition[Composition packages]
+    core[boring-core<br/>identity · persistence · app shell]
+    workspace[boring-workspace<br/>workbench · plugins · UI bridge]
+    agent[boring-agent<br/>gateway · sessions · harness]
+  end
+
+  subgraph runtime[Execution packages]
+    bash[boring-bash<br/>environment operations · Pi tools]
+    sandbox[boring-sandbox<br/>isolation providers]
+  end
+
+  subgraph extensions[Extensions and authoring]
+    plugins[plugins/*<br/>front + trusted server contributions]
+    pluginCli[boring-ui-plugin CLI]
+    pi[boring-pi<br/>Markdown skills + references only]
+  end
+
+  ui[boring-ui-kit<br/>shared UI primitives]
+
+  apps --> core
+  apps --> workspace
+  apps --> agent
+  cli --> workspace
+  cli --> agent
+  cli --> bash
+  cli --> sandbox
+  cli --> ui
+  cli --> plugins
+  cli --> pluginCli
+
+  core --> workspace
+  core --> agent
+  core --> bash
+  workspace -->|app surfaces| agent
+  workspace --> bash
+  workspace --> sandbox
+  workspace --> pluginCli
+  agent --> bash
+  agent --> sandbox
+
+  plugins --> workspace
+  plugins --> ui
+  plugins -. trusted feature seams .-> agent
+  plugins -. trusted feature seams .-> core
+  pluginCli -. scaffolds and resolves .-> plugins
+  pi -. resolved Markdown resources .-> workspace
+
+  core --> ui
+  workspace --> ui
+  agent --> ui
+  bash -. peer type surface .-> agent
+  sandbox -. peer type surface .-> agent
+```
+
+Solid arrows show current host composition or declared package consumption;
+dashed arrows are optional, tooling, knowledge, or peer-type edges.
+`boring-pi` contains no runtime code.
+
+## Depicted files
+
+- `pnpm-workspace.yaml`
+- `packages/core/package.json`
+- `packages/agent/package.json`
+- `packages/workspace/package.json`
+- `packages/cli/package.json`
+- `packages/ui/package.json`
+- `packages/pi/package.json`
+- `packages/plugin-cli/package.json`
+- `packages/boring-bash/package.json`
+- `packages/boring-sandbox/package.json`
+- `packages/core/src/app/server/createCoreWorkspaceAgentServer.ts`
+- `packages/workspace/src/app/server/createWorkspaceAgentServer.ts`
+- `packages/cli/src/server/modeApps.ts`
+- `packages/cli/src/front/App.tsx`
+- `apps/full-app/src/server/main.ts`
+- `plugins/ask-user/src/server/index.ts`
+- `plugins/boring-automation/src/front/AutomationCard.tsx`
+- `plugins/boring-governance/src/server/index.ts`

--- a/docs/visual/runtime-stack.md
+++ b/docs/visual/runtime-stack.md
@@ -1,0 +1,79 @@
+# Three-stack runtime
+
+```mermaid
+flowchart TB
+  host[Workspace, Core, or CLI host]
+
+  subgraph agent[boring-agent — orchestration]
+    gateway[AgentGateway + session service]
+    mode[RuntimeModeAdapter]
+    harness[Pi harness + tool assembly]
+    gateway --> harness
+    mode -->|paired RuntimeBundle| harness
+  end
+
+  subgraph bash[boring-bash — environment operations]
+    factories[Pi shell + file tool factories]
+    fsStrategy{filesystem strategy}
+    shellStrategy{shell strategy}
+    boundFs[boundFs operations]
+    localShell[local BashOperations + spawn hook]
+    remoteWorkspace[remote Workspace operations]
+    remoteSandbox[remote Sandbox operations]
+    factories --> fsStrategy
+    factories --> shellStrategy
+    fsStrategy -->|host| boundFs
+    fsStrategy -->|remote| remoteWorkspace
+    shellStrategy -->|host or local| localShell
+    shellStrategy -->|remote| remoteSandbox
+  end
+
+  subgraph sandbox[boring-sandbox — isolation and providers]
+    provider[SandboxProviderV1]
+    backends[direct · bwrap · Vercel · remote worker]
+    pair[WorkspaceSandboxPairV1]
+    backends -->|implement| provider
+    provider -->|atomic create| pair
+    pair --> workspace[Workspace]
+    pair --> executor[Sandbox]
+  end
+
+  storage[adapter-private host storage root]
+  spawn[host process or bwrap spawn hook]
+
+  host --> gateway
+  host --> mode
+  mode -->|create| provider
+  pair -->|returns one pair| mode
+  mode -. storageRoot .-> storage
+  mode -. runtimeHost .-> spawn
+  harness --> factories
+  boundFs -->|local files · search| storage
+  localShell -->|direct or wrapped exec| spawn
+  remoteWorkspace -->|remote files| workspace
+  remoteSandbox -->|remote exec| executor
+```
+
+Agent owns gateway and harness composition, boring-bash owns consumer-visible
+shell/file operations, and boring-sandbox owns provider confinement. The mode
+adapter wraps one atomic Workspace/Sandbox pair in the runtime bundle.
+
+## Depicted files
+
+- `docs/DECISIONS.md` (Decisions 28 and 29)
+- `docs/procedures/coding-invariants.md`
+- `packages/agent/src/server/runtime/mode.ts`
+- `packages/agent/src/server/runtime/modes/providerAdapter.ts`
+- `packages/agent/src/server/agent-host/buildAgentComposition.ts`
+- `packages/agent/src/server/harness/pi-coding-agent/createHarness.ts`
+- `packages/boring-bash/src/agent/tools/harness/index.ts`
+- `packages/boring-bash/src/agent/tools/harness/bashToolOptions.ts`
+- `packages/boring-bash/src/agent/tools/filesystem/index.ts`
+- `packages/boring-bash/src/agent/tools/operations/bound.ts`
+- `packages/boring-bash/src/agent/tools/operations/remoteWorkspace.ts`
+- `packages/boring-bash/src/agent/tools/operations/remoteSandbox.ts`
+- `packages/boring-sandbox/src/shared/providerV1.ts`
+- `packages/boring-sandbox/src/providers/direct/createDirectProvider.ts`
+- `packages/boring-sandbox/src/providers/bwrap/createBwrapProvider.ts`
+- `packages/boring-sandbox/src/providers/vercel-sandbox/createVercelSandboxProvider.ts`
+- `packages/boring-sandbox/src/providers/remote-worker/createRemoteWorkerProvider.ts`


### PR DESCRIPTION
## Summary

- Adds the docs/visual/ hub and links it from docs/README.md.
- Adds a current-code package map covering apps, packages, plugins, tooling, and Markdown-only Pi knowledge.
- Adds the three-stack runtime view with explicit host/local and remote Operations branches.

## Issue / Slice

Refs #1177 — Slice 1 only.

## Proof

- git diff --cached --check: pass
- Mermaid 11.16 parse through jsdom: PASS docs/visual/package-map.md; PASS docs/visual/runtime-stack.md
- Every path under both Depicted files sections exists at origin/main SHA 27d54226a.
- Independent standards/spec review: clean after correcting runtime strategy and package-boundary ownership.

## Manual review

Open both Markdown files on the GitHub Files tab and verify native Mermaid rendering, captions, and source-path traceability.

## Risk / Rollback

Documentation-only. Revert this commit to remove the visual index and both diagrams; no runtime or API behavior changes.

## Next

Owner review; do not merge from this worker lane.

🤖 Generated with Codex (gpt-5.6-sol).