### PR TITLE
[gh-1177 S2] visual docs: gateway + bridge + chat-turn flows

### DIFF
--- a/docs/visual/README.md
+++ b/docs/visual/README.md
@@ -7,6 +7,10 @@ accepted decisions remain normative.
 | --- | --- |
 | [Package map](package-map.md) | Apps, packages, plugins, tooling, and knowledge boundaries |
 | [Runtime stack](runtime-stack.md) | Agent orchestration over boring-bash operations and boring-sandbox providers |
+| [AgentGateway](agent-gateway.md) | Authorized, addressed session operations and their construction funnel |
+| [UiBridge](ui-bridge.md) | Agent-to-browser command dispatch and the display-only chat lane |
+| [Chat turn](chat-turn.md) | Prompt admission, Pi execution, event fan-out, and browser reduction |
+| [Agent-initiated pane](agent-initiated-pane.md) | An `openPanel` tool call reaching Dockview through the bridge |
 
 Further connector and request-flow diagrams are tracked in
 [epic #1177](https://github.com/hachej/boring-ui/issues/1177).

--- a/docs/visual/agent-gateway.md
+++ b/docs/visual/agent-gateway.md
@@ -1,0 +1,49 @@
+# AgentGateway session flow
+
+```mermaid
+flowchart LR
+  subgraph authority[App-owned authority]
+    request[Addressed HTTP request]
+    scope[AuthorizedAgentScope<br/>issuer-owned capability]
+    claim[AgentScopeVerifier.verify<br/>VerifiedAgentScopeClaim]
+    request --> scope
+  end
+
+  subgraph contract[Shared contract]
+    gateway[AgentGateway<br/>7 scoped operations<br/>listAgents · listSessions<br/>create · connect · read · rename · delete]
+    close[AgentGateway.close<br/>lifecycle only · no scope]
+  end
+
+  subgraph server[Agent server]
+    embedded[EmbeddedAgentGateway<br/>re-check · ledger · session pin]
+    inventory[Fleet and inventory reads<br/>listAgents · listSessions]
+    binding[Session runtime binding<br/>create · connect · read · rename · delete]
+    service[PiChatSessionService<br/>session store + Pi harness]
+    shutdown[Close active gateway connections]
+    binding --> service
+    close --> shutdown
+  end
+
+  funnel[createAgentHost<br/>only construction funnel]
+
+  scope -->|nested scope on every operation| gateway
+  gateway --> embedded
+  embedded -->|verify every use| claim
+  claim --> inventory
+  claim -->|session-bearing operation| binding
+  funnel -. constructs .-> embedded
+  funnel -. wires HTTP projection .-> request
+  funnel -. builds compositions .-> binding
+```
+
+The seven addressed operations carry branded scope and re-verify it; fleet and inventory reads stay on host state, while session-bearing calls resolve an Agent runtime binding and Pi service. `AgentGateway.close()` is lifecycle-only, and `createAgentHost()` is the sole construction funnel for the embedded gateway, addressed routes, and Agent-owned composition.
+
+## Depicted files
+
+- `packages/agent/docs/AGENT_GATEWAY_V0.md`
+- `packages/agent/src/shared/gateway/types.ts`
+- `packages/agent/src/server/agent-host/createAgentHost.ts`
+- `packages/agent/src/server/agent-host/embeddedGateway.ts`
+- `packages/agent/src/server/agent-host/httpProjection.ts`
+- `packages/agent/src/server/agent-host/buildAgentComposition.ts`
+- `packages/agent/src/core/piChatSessionService.ts`

--- a/docs/visual/agent-initiated-pane.md
+++ b/docs/visual/agent-initiated-pane.md
@@ -1,0 +1,44 @@
+# Agent-initiated pane
+
+```mermaid
+sequenceDiagram
+  participant A as Model / Pi harness
+  participant T as exec_ui tool
+  participant B as UiBridge
+  participant R as UI command route
+  participant C as Browser command stream
+  participant D as dispatchUiCommand
+  participant W as Workspace surface
+  participant V as Dockview
+
+  C->>R: GET /api/v1/ui/commands/next
+  R->>B: subscribeCommands / drainCommands
+  A->>T: openPanel(id, component, params)
+  T->>B: postCommand(openPanel)
+  B->>B: assign sequence and fan out or queue
+  B-->>R: annotated command
+  B-->>T: CommandResult
+  R-->>C: SSE command event
+  C->>D: dispatchUiCommand(openPanel)
+  D->>W: open workbench and openPanel
+  alt panel already exists
+    W->>V: update parameters and activate
+  else new panel
+    W->>W: require registered panel component
+    W->>V: addPanel
+  end
+```
+
+An agent-created pane has one server dispatch path: `exec_ui` posts a typed command to `UiBridge`, and the browser stream hands it to the shared dispatcher. Dockview focuses an existing panel by ID; for a new panel, the surface first requires its component in the `WorkspaceProvider` registry.
+
+## Depicted files
+
+- `packages/workspace/src/server/ui-control/tools/uiTools.ts`
+- `packages/workspace/src/shared/ui-bridge.ts`
+- `packages/workspace/src/server/bridge/createInMemoryBridge.ts`
+- `packages/workspace/src/server/ui-control/http/uiRoutes.ts`
+- `packages/workspace/src/front/bridge/uiCommandStream.ts`
+- `packages/workspace/src/front/bridge/uiCommandDispatcher.ts`
+- `packages/workspace/src/app/front/WorkspaceAgentFront.tsx`
+- `packages/workspace/src/front/provider/WorkspaceProvider.tsx`
+- `packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx`

--- a/docs/visual/chat-turn.md
+++ b/docs/visual/chat-turn.md
@@ -1,0 +1,57 @@
+# Chat-turn sequence
+
+```mermaid
+sequenceDiagram
+  participant B as Browser / RemotePiSession
+  participant H as Addressed HTTP projection
+  participant G as Embedded AgentGateway
+  participant S as HarnessPiChatService
+  participant P as Pi harness adapter
+  participant N as Native Pi agent
+  participant D as Durable event store
+  participant L as Live replay buffer
+
+  B->>H: GET state, then GET events(cursor)
+  H->>G: readSessionState / connectSession
+  G->>S: readState / subscribe
+  S-->>G: snapshot + live subscription
+  G-->>H: snapshot + addressed event envelopes
+  H-->>B: JSON + NDJSON stream
+
+  B->>H: POST prompt(requestId, clientNonce, content)
+  H->>G: connectSession().send(prompt)
+  G->>S: prompt(context, sessionId, payload)
+  S->>P: adapter.prompt(input)
+  P->>N: start native Pi run
+  S-->>G: accepted cursor
+  G-->>H: AgentSendReceipt
+  H-->>B: HTTP 202 receipt
+
+  N-->>P: native run events
+  P-->>S: subscribed events
+  S->>S: map to sequenced PiChatEvent
+  opt durable stream enabled
+    S->>D: append before live fan-out
+  end
+  S->>L: publish event
+  L-->>G: subscribed event
+  G-->>H: AgentSessionEvent envelope
+  H-->>B: NDJSON frame
+  B->>B: validate sequence and reduce event
+```
+
+The browser hydrates once and keeps an addressed NDJSON subscription while prompt acceptance returns independently of the Pi run. Native Pi events become sequenced `PiChatEvent`s, append durably first when enabled, then fan out through the live buffer to the browser reducer.
+
+## Depicted files
+
+- `packages/agent/src/front/chat/pi/remotePiSession.ts`
+- `packages/agent/src/front/chat/pi/piChatStream.ts`
+- `packages/agent/src/front/chat/pi/piChatReducer.ts`
+- `packages/agent/src/server/agent-host/httpProjection.ts`
+- `packages/agent/src/server/agent-host/embeddedGateway.ts`
+- `packages/agent/src/server/agent-host/buildAgentComposition.ts`
+- `packages/agent/src/core/piChatSessionService.ts`
+- `packages/agent/src/server/pi-chat/harnessPiChatService.ts`
+- `packages/agent/src/server/pi-chat/piChatEvents.ts`
+- `packages/agent/src/server/harness/pi-coding-agent/createHarness.ts`
+- `packages/agent/src/server/events/eventStreamStore.ts`

--- a/docs/visual/ui-bridge.md
+++ b/docs/visual/ui-bridge.md
@@ -1,0 +1,44 @@
+# UiBridge dispatch
+
+```mermaid
+flowchart LR
+  subgraph server[Server and shared]
+    producers[Agent and server producers<br/>exec_ui · plugin helpers · HTTP POST]
+    seam[UiBridge.postCommand<br/>canonical server dispatch seam]
+    bridge[In-memory bridge<br/>sequence · queue · fan-out]
+    routes[UI command route<br/>SSE or polling]
+    producers --> seam --> bridge --> routes
+  end
+
+  subgraph front[Browser front]
+    stream[startUiCommandStream]
+    local[Browser-local UI actions]
+    bus[uiCommandBus]
+    dispatch[dispatchUiCommand]
+    surface[Workspace surface<br/>files · panels · notifications]
+    routes --> stream --> dispatch --> surface
+    local --> bus --> dispatch
+  end
+
+  subgraph chat[Chat presentation only]
+    part[PiChatEvent ui-command<br/>displayOnly: true]
+    reducer[piChatReducer<br/>state unchanged]
+    part -->|display-only; ignored| reducer
+  end
+```
+
+Agent and server producers converge on `UiBridge.postCommand`; the bridge transport and browser-local bus share the final dispatcher. Pi chat `ui-command` events are display-only, so the chat reducer leaves state unchanged and never redispatches them.
+
+## Depicted files
+
+- `docs/procedures/coding-invariants.md`
+- `packages/workspace/src/shared/ui-bridge.ts`
+- `packages/workspace/src/shared/plugins/uiBridgeRegistry.ts`
+- `packages/workspace/src/server/bridge/createInMemoryBridge.ts`
+- `packages/workspace/src/server/ui-control/http/uiRoutes.ts`
+- `packages/workspace/src/server/ui-control/tools/uiTools.ts`
+- `packages/workspace/src/front/bridge/uiCommandStream.ts`
+- `packages/workspace/src/front/bridge/uiCommandBus.ts`
+- `packages/workspace/src/front/bridge/uiCommandDispatcher.ts`
+- `packages/agent/src/server/pi-chat/piChatEvents.ts`
+- `packages/agent/src/front/chat/pi/piChatReducer.ts`


### PR DESCRIPTION
## Summary

- Adds four diagram-first S2 pages for AgentGateway, UiBridge, a chat turn, and an agent-initiated pane.
- Traces every edge to current Agent, Workspace, Pi harness, bridge, browser reducer, and Dockview code.
- Extends the S1 visual-docs hub with the new views.

## Issue / Slice

Refs #1177 — Slice 2 only. Stacked on S1 PR #1179 (`docs/1177-s1`).

## Proof

- `git diff --cached --check`: pass before commit.
- Mermaid 11.16 parse through jsdom: PASS for all four new pages.
- Structural check: exactly one Mermaid fence per page, two-sentence captions, and all 38 depicted-file references exist.
- Manual review: open the four Markdown pages in the GitHub Files tab and verify native Mermaid rendering and source-path traceability.

## Review

- Standards: clean after correcting gateway branching, pane validation placement, and bridge event semantics.
- Spec: clean after the same fixes; S1 stack ancestry confirmed.
- Thermo: waived; documentation-only, no runtime or API change.
- Reviewed SHA: `fb5995d41`.

## Risk / Rollback

Documentation-only. Revert `fb5995d41` to remove S2; no runtime behavior, API, or schema changes.

## Next

Owner review. Do not merge from this worker lane.

🤖 Generated with Codex (gpt-5.6-sol).