### PR TITLE
fix(workspace): stabilize active-reload timeline hydration (#1159)

### DIFF
--- a/packages/agent/e2e/pi-native-harness-baseline-message-flow.spec.ts
+++ b/packages/agent/e2e/pi-native-harness-baseline-message-flow.spec.ts
@@ -236,12 +236,18 @@ test.describe('Pi-native harness-backed baseline message flow', () => {
       await page.reload({ waitUntil: 'domcontentloaded' })
       await expect(chat).toHaveAttribute('data-pi-chat-connection', 'connected', { timeout: 10_000 })
 
+      // The second turn may legitimately settle while the page is reloading
+      // (the scripted run keeps streaming server-side), so this frame asserts
+      // the hydration ORDERING guarantee — the completed first turn precedes
+      // the second turn with stable ids — and accepts the second assistant in
+      // either its streaming or its already-settled shape. Requiring the
+      // working indicator here made the wait unsatisfiable whenever the run
+      // settled during the reload window (the original flake).
       const secondRunningAfterReload = await waitForTimelineFrame(page, 'active reload keeps previous completed turn before the running turn', (state) => {
         const assistants = assistantMessages(state)
         const firstAssistant = assistants[0]
         const secondAssistant = assistants[1]
-        return state.workingVisible
-          && state.messages.map((message) => message.role).join(',') === 'user,assistant,user,assistant'
+        return state.messages.map((message) => message.role).join(',') === 'user,assistant,user,assistant'
           && state.messages.slice(0, 2).map((message) => message.id).join(',') === firstTurnIds.join(',')
           && state.messages.map((message) => message.id).join(',') === 'u1,a1,u2,a2'
           && firstAssistant?.status === 'done'

--- a/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
+++ b/packages/agent/src/server/pi-chat/__tests__/harnessPiChatService.test.ts
@@ -1220,6 +1220,37 @@ describe('HarnessPiChatService', () => {
     ])
   })
 
+  it('keeps live state when the persisted transcript lags behind the live adapter', async () => {
+    // An active-reload hydration race (gh-1159): the run settles, the adapter
+    // holds the full transcript, but the persisted store has not caught up
+    // (or, like the scripted e2e harness, never persists transcripts). The
+    // lagging persisted snapshot would fence the durable seq while dropping
+    // the rendered turns, permanently hiding them from a hydrating client.
+    const adapter = createAdapter()
+    adapter.readSnapshot().isStreaming = false
+    adapter.readSnapshot().messages = [
+      { id: 'live-user', message: { role: 'user', content: [{ type: 'text', text: 'live prompt' }] } },
+    ]
+    const persistedStore: PersistedSessionStore = {
+      ...sessionStore,
+      loadEntries: vi.fn(async () => ({ id: 's1', messages: [] })),
+    }
+    const service = new HarnessPiChatService({
+      harness: createHarness(adapter),
+      sessionStore: persistedStore,
+      workdir: '/workspace',
+    })
+    // Open the channel first so readState takes the previously-opened path.
+    const subscription = await service.subscribe(ctx, 's1', 0, () => {})
+    expect(subscription.type).toBe('ok')
+    if (subscription.type === 'ok') subscription.unsubscribe()
+
+    const state = await service.readState(ctx, 's1')
+
+    expect(state.status).toBe('idle')
+    expect(state.messages).toEqual([expect.objectContaining({ id: 'live-user' })])
+  })
+
   it('fences in-memory event replay behind an idle persisted snapshot cursor', async () => {
     const adapter = createAdapter()
     adapter.readSnapshot().isStreaming = false

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -273,7 +273,11 @@ export class HarnessPiChatService implements PiChatSessionService {
     const adapter = await this.getAdapter(ctx, sessionId, '')
     if (this.canRefreshFromPersistedState(sessionKey, adapter)) {
       const persisted = await this.readPersistedState(ctx, sessionId)
-      if (persisted && this.canRefreshFromPersistedState(sessionKey, adapter)) {
+      if (
+        persisted
+        && this.canRefreshFromPersistedState(sessionKey, adapter)
+        && !this.persistedStateDropsLiveMessages(persisted, adapter, sessionId)
+      ) {
         const liveSeq = this.channels.get(sessionKey)?.buffer.latestSeq ?? 0
         return this.enrichSyntheticPromptFailures(
           sessionKey,
@@ -296,6 +300,24 @@ export class HarnessPiChatService implements PiChatSessionService {
       attachmentUrl: this.attachmentUrlFor(sessionId),
     }))
     return this.enrichSyntheticPromptFailures(sessionKey, snapshot)
+  }
+
+  /**
+   * The persisted transcript can lag the live adapter: transcript writes are
+   * asynchronous, and some harnesses never persist transcripts at all. A
+   * persisted refresh whose seq fences the live replay buffer while its
+   * messages are missing would permanently hide those turns from a hydrating
+   * client (it starts "caught up" at that seq with an empty timeline), so
+   * refresh from persisted state only when it carries at least as much
+   * rendered history as the live adapter.
+   */
+  private persistedStateDropsLiveMessages(
+    persisted: PiChatSnapshot,
+    adapter: PiAgentSessionAdapter,
+    sessionId: string,
+  ): boolean {
+    const liveCount = buildPiChatHistory(adapter.readSnapshot().messages, { sessionId }).length
+    return persisted.messages.length < liveCount
   }
 
   private canRefreshFromPersistedState(sessionKey: string, adapter: PiAgentSessionAdapter): boolean {


### PR DESCRIPTION
Fixes #1159.

## The actual race

The flaky frame is the post-reload hydration wait in
`packages/agent/e2e/pi-native-harness-baseline-message-flow.spec.ts`
("keeps completed previous turns ordered while the next assistant streams").
Reproduced locally at 5/10 failures with `--repeat-each=10 --workers=4` plus 6
CPU-hog processes. Playwright traces showed the reloaded page hydrating
`GET /state` as `{seq: 22, status: "idle", messages: []}` — a snapshot that
claims to be fully caught up while carrying no transcript.

Two defects, one product and one test:

1. **Product (root cause)** — `HarnessPiChatService.readState` refreshes an
   idle previously-opened session from the *persisted* transcript and fences
   the snapshot `seq` at the durable replay buffer's latest seq. The persisted
   transcript can lag the live adapter (transcript writes are asynchronous;
   the scripted e2e harness never persists them at all). Under load the
   scripted second turn settles during the reload window, `readState` takes
   the persisted path, and the client hydrates an empty timeline "caught up"
   at seq 22 — the dropped turns are never replayed. Permanently blank chat.

   Fix: guard the persisted-refresh path with
   `persistedStateDropsLiveMessages` — fall back to the live adapter snapshot
   whenever the persisted history carries fewer rendered messages than the
   live adapter holds. New unit test covers the lagging-transcript case.

2. **Test synchronization (honest disclosure)** — the post-reload predicate
   also required `workingVisible` (second turn still streaming). When the run
   settles server-side during the reload — legitimate behavior — that wait was
   unsatisfiable. The frame now asserts the actual ordering guarantee
   (completed first turn precedes the second, stable ids `u1,a1,u2,a2`) and
   accepts the second assistant in streaming *or* settled shape; the later
   frame still asserts the full settle. Event-based waits only, no sleeps.

Note: the bisect in #1159 attributed the flake to 6b451336f (workspace left
pane). That commit does not touch this surface — the e2e front is the bare
agent-playground `PiChatPanel` — and the race reproduces on current main under
CPU load; the attribution appears to be load-timing noise.

## Proof

- Before fix: 5/10 failures (`--repeat-each=10 --workers=4` + 6 CPU hogs), all
  with the same empty-timeline signature.
- After fix: 10/10 under those same conditions, plus 20/20 across two
  `--repeat-each=10 --workers=2` runs.
- Full `packages/agent` e2e suite green locally.
- `pnpm typecheck`, harnessPiChatService unit suite (53/53), invariants check
  all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPPbToGDvkARQZuYKFyWN