### PR TITLE
[epic #1110] fix(workspace): single breakpoint token set across shell and dockview

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -26,6 +26,7 @@ import { AgentDetailsOverlay } from "../../front/chrome/agents/AgentDetailsOverl
 import { AppLeftPane, AppLeftRail } from "../../front/layout/plugin-tabs/AppLeftPane"
 import { PluginTabsWorkspaceShell } from "../../front/layout/plugin-tabs/PluginTabsWorkspaceShell"
 import { useViewportWidth } from "../../front/layout/useViewportWidth"
+import { isCompactViewport } from "../../front/layout/breakpoints"
 import { captureWorkspaceFrontPlugins } from "./workspaceBuiltinPlugins"
 import type { FilesystemId } from "../../shared/types/filesystem"
 import { dispatchUiCommand, registerUiCommandConsumer, startUiCommandStream } from "../../front/bridge"
@@ -763,7 +764,7 @@ export function WorkspaceAgentFront<
   className,
 }: WorkspaceAgentFrontProps<TSession>) {
   const viewport = useViewportWidth()
-  const mobileShellActive = mobileShellEnabled && viewport < 640
+  const mobileShellActive = mobileShellEnabled && isCompactViewport(viewport)
   const externalPluginsEnabled = externalPlugins !== false
   const resolvedFrontPluginHotReload = externalPluginsEnabled ? frontPluginHotReload : false
   const resolvedHotReloadEnabled = externalPluginsEnabled ? hotReloadEnabled : false

--- a/packages/workspace/src/front/hooks/useViewportBreakpoint.ts
+++ b/packages/workspace/src/front/hooks/useViewportBreakpoint.ts
@@ -2,12 +2,14 @@
 
 import { useEffect, useState } from "react"
 
+import { WIDE_MIN_WIDTH } from "../layout/breakpoints"
+
 function readMatches(maxWidth: number): boolean {
   if (typeof window === "undefined") return false
   return window.innerWidth < maxWidth
 }
 
-export function useViewportBreakpoint(maxWidth = 1024): boolean {
+export function useViewportBreakpoint(maxWidth: number = WIDE_MIN_WIDTH): boolean {
   const [matches, setMatches] = useState(() => readMatches(maxWidth))
 
   useEffect(() => {

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -19,6 +19,7 @@ import { CornerChromeButton } from "./cornerChrome"
 import { MobileChatBar, MobileSingleChatPane, MobileWorkspaceBar } from "./mobileShell"
 import { WorkbenchOverlayFrame } from "./WorkbenchOverlayFrame"
 import { useViewportWidth } from "./useViewportWidth"
+import { isCompactViewport } from "./breakpoints"
 import { workspaceSessionRef, workspaceSessionRefFromKey, workspaceSessionRefsEqual } from "../sessionIdentity"
 
 export function buildChatLayout(props: ChatLayoutProps = {}): LayoutConfig {
@@ -82,6 +83,12 @@ export function buildChatLayout(props: ChatLayoutProps = {}): LayoutConfig {
   return { version: "2.0", groups }
 }
 
+/**
+ * Not a shell breakpoint tier (see ./breakpoints.ts): below this width an
+ * open workbench takes over one pane instead of squeezing chat beside it.
+ */
+const CHAT_AUTOCOLLAPSE_MAX_WIDTH = 1180
+
 export function ChatLayout(props: ChatLayoutProps) {
   const navOpen = props.nav !== null
   const surfaceConfigured = props.surface !== undefined
@@ -130,7 +137,7 @@ export function ChatLayout(props: ChatLayoutProps) {
     [blockers],
   )
   const commandRegistry = useCommandRegistry()
-  const mobileShell = props.mobileShellEnabled === true && viewport < 640
+  const mobileShell = props.mobileShellEnabled === true && isCompactViewport(viewport)
   const effectiveNavWidth = mobileShell ? Math.min(Math.max(280, Math.floor(viewport * 0.86)), 360) : clamp(navWidth, 200, 360)
   const effectiveSidebarWidth = mobileShell ? viewport : clamp(sidebarWidth, 200, Math.max(240, Math.floor(viewport * 0.5)))
   const surfaceMax = mobileShell ? viewport : Math.max(480, Math.floor(viewport * 0.72))
@@ -362,7 +369,7 @@ export function ChatLayout(props: ChatLayoutProps) {
   // On compact widths, prefer a one-pane workbench takeover instead of squeezing chat.
   useEffect(() => {
     if (mobileShell || !surfaceOpen || chatCollapsed || props.chatOverlay) return
-    if (viewport < 1180) setChatCollapsed(true)
+    if (viewport < CHAT_AUTOCOLLAPSE_MAX_WIDTH) setChatCollapsed(true)
   }, [chatCollapsed, mobileShell, props.chatOverlay, setChatCollapsed, surfaceOpen, viewport])
 
   // Chat-hosted overlays (Skills/Plugins) must remain visible while workbench

--- a/packages/workspace/src/front/layout/ResponsiveDockviewShell.tsx
+++ b/packages/workspace/src/front/layout/ResponsiveDockviewShell.tsx
@@ -18,8 +18,7 @@ import {
   useViewportBreakpoint,
 } from "../hooks"
 
-const MOBILE_BREAKPOINT = 768
-const TABLET_BREAKPOINT = 1024
+import { COMPACT_MAX_WIDTH, WIDE_MIN_WIDTH } from "./breakpoints"
 
 export interface ResponsiveDockviewShellProps {
   layout: LayoutConfig
@@ -40,8 +39,8 @@ export function ResponsiveDockviewShell({
   const registry = useRegistry()
   const sidebarState = useSidebarState()
   const setSidebar = useSetSidebar()
-  const isMobile = useViewportBreakpoint(MOBILE_BREAKPOINT)
-  const isTablet = useViewportBreakpoint(TABLET_BREAKPOINT)
+  const isMobile = useViewportBreakpoint(COMPACT_MAX_WIDTH)
+  const isTablet = useViewportBreakpoint(WIDE_MIN_WIDTH)
   const isTabletOnly = isTablet && !isMobile
 
   const sidebarGroup = useMemo(

--- a/packages/workspace/src/front/layout/__tests__/breakpoints.test.ts
+++ b/packages/workspace/src/front/layout/__tests__/breakpoints.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import {
+  COMPACT_MAX_WIDTH,
+  WIDE_MIN_WIDTH,
+  WORKSPACE_BREAKPOINTS,
+  isBelowWideViewport,
+  isCompactViewport,
+} from "../breakpoints"
+
+describe("workspace breakpoint tokens", () => {
+  it("pins the token values (aligned with Tailwind sm/lg)", () => {
+    expect(COMPACT_MAX_WIDTH).toBe(640)
+    expect(WIDE_MIN_WIDTH).toBe(1024)
+    expect(WORKSPACE_BREAKPOINTS).toEqual({ compactMax: 640, wideMin: 1024 })
+  })
+
+  it("uses exclusive upper bounds at both boundaries", () => {
+    expect(isCompactViewport(639)).toBe(true)
+    expect(isCompactViewport(640)).toBe(false)
+    expect(isBelowWideViewport(1023)).toBe(true)
+    expect(isBelowWideViewport(1024)).toBe(false)
+  })
+})

--- a/packages/workspace/src/front/layout/__tests__/presets.test.tsx
+++ b/packages/workspace/src/front/layout/__tests__/presets.test.tsx
@@ -281,7 +281,7 @@ describe("IdeLayout responsive behavior", () => {
     setViewport(1280)
   })
 
-  it("shows mobile hamburger under 768px and opens sheet sidebar", async () => {
+  it("shows mobile hamburger in the compact tier and opens sheet sidebar", async () => {
     setViewport(375)
     const user = userEvent.setup()
 
@@ -348,6 +348,39 @@ describe("IdeLayout responsive behavior", () => {
       expect(screen.getAllByTestId("dummy-panel")).toHaveLength(2)
     })
     expect(screen.getByLabelText("Collapse sidebar")).toBeInTheDocument()
+  })
+
+  it("uses the medium (rail) tier, not mobile sheet, between 640 and 1023px", async () => {
+    renderWithRegistry(
+      <IdeLayout />,
+      ["filetree", "empty"],
+    )
+
+    // 700px sat in the old mobile band (<768); it is now medium tier.
+    for (const width of [640, 700, 1023]) {
+      act(() => {
+        setViewport(width)
+      })
+      await waitFor(() => {
+        expect(screen.getByLabelText("Open collapsed sidebar")).toBeInTheDocument()
+        expect(screen.queryByLabelText("Open sidebar menu")).not.toBeInTheDocument()
+      })
+    }
+
+    act(() => {
+      setViewport(639)
+    })
+    await waitFor(() => {
+      expect(screen.getByLabelText("Open sidebar menu")).toBeInTheDocument()
+    })
+
+    act(() => {
+      setViewport(1024)
+    })
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Open sidebar menu")).not.toBeInTheDocument()
+      expect(screen.queryByLabelText("Open collapsed sidebar")).not.toBeInTheDocument()
+    })
   })
 
   it("transitions desktop → tablet → mobile → desktop modes", async () => {

--- a/packages/workspace/src/front/layout/breakpoints.ts
+++ b/packages/workspace/src/front/layout/breakpoints.ts
@@ -1,0 +1,37 @@
+/**
+ * Single source of truth for workspace layout breakpoints.
+ *
+ * Three viewport tiers, aligned with Tailwind's default `sm` (640px) and
+ * `lg` (1024px) screens so JS-driven layout flips and responsive utility
+ * classes (`sm:`, `lg:`) agree:
+ *
+ *   compact  viewport <  640   (mobile shell / sheet chrome)
+ *   medium   640 <= w < 1024   (rail / collapsible sidebar)
+ *   wide     viewport >= 1024  (full inline layout)
+ *
+ * Decision (epic #1110): the shell previously flipped mobile at <640 while
+ * ResponsiveDockviewShell used <768, so 640-767px rendered a mobile dockview
+ * inside a desktop shell. 640 wins because the mobile shell (the outermost
+ * flip) and all Tailwind `sm:` styling already use it.
+ *
+ * Always compare with `width < COMPACT_MAX_WIDTH` / `width < WIDE_MIN_WIDTH`
+ * (exclusive upper bound), matching `min-width`-based CSS at the same value.
+ */
+export const COMPACT_MAX_WIDTH = 640
+
+export const WIDE_MIN_WIDTH = 1024
+
+export const WORKSPACE_BREAKPOINTS = {
+  compactMax: COMPACT_MAX_WIDTH,
+  wideMin: WIDE_MIN_WIDTH,
+} as const
+
+/** True when the viewport is in the compact (mobile-shell) tier. */
+export function isCompactViewport(width: number): boolean {
+  return width < COMPACT_MAX_WIDTH
+}
+
+/** True when the viewport is below the wide tier (compact or medium). */
+export function isBelowWideViewport(width: number): boolean {
+  return width < WIDE_MIN_WIDTH
+}

--- a/packages/workspace/src/front/layout/index.ts
+++ b/packages/workspace/src/front/layout/index.ts
@@ -4,6 +4,13 @@ export { TopBar } from "./TopBar"
 export { ThemeToggle } from "./ThemeToggle"
 /** Tier 2 entry: declarative LayoutConfig with stock responsive chrome. */
 export { ResponsiveDockviewShell } from "./ResponsiveDockviewShell"
+export {
+  COMPACT_MAX_WIDTH,
+  WIDE_MIN_WIDTH,
+  WORKSPACE_BREAKPOINTS,
+  isCompactViewport,
+  isBelowWideViewport,
+} from "./breakpoints"
 export type { TopBarProps } from "./TopBar"
 export type { ResponsiveDockviewShellProps } from "./ResponsiveDockviewShell"
 export type { IdeLayoutProps, ChatLayoutProps } from "./types"

--- a/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/PluginTabsWorkspaceShell.tsx
@@ -6,6 +6,7 @@ import { Sheet, SheetClose, SheetContent, SheetDescription, SheetTitle } from "@
 import { cn } from "../../lib/utils"
 import { PaneCollapseButton } from "../paneCollapseButton"
 import { useViewportWidth } from "../useViewportWidth"
+import { isCompactViewport } from "../breakpoints"
 
 function AppLeftPaneResizeHandle({
   width,
@@ -108,7 +109,7 @@ export function PluginTabsWorkspaceShell({
 }: PluginTabsWorkspaceShellProps) {
   const [mobileOpen, setMobileOpen] = useState(false)
   const viewport = useViewportWidth()
-  const mobileShell = mobileShellEnabled === true && viewport < 640
+  const mobileShell = mobileShellEnabled === true && isCompactViewport(viewport)
   const effectiveCollapsed = mobileShell ? !mobileOpen : collapsed
   useEffect(() => {
     if (!mobileShell) setMobileOpen(false)


### PR DESCRIPTION
## Problem

Three thresholds disagreed on where the workspace flips layout:

| Site | Old threshold | Flips |
| --- | --- | --- |
| `WorkspaceAgentFront.tsx` | `< 640` | mobile shell takeover |
| `ChatLayout.tsx` | `< 640` | mobile shell + full-width panes |
| `PluginTabsWorkspaceShell.tsx` | `< 640` | mobile shell |
| `ResponsiveDockviewShell.tsx` | `< 768` (MOBILE) | sheet sidebar + hamburger |
| `ResponsiveDockviewShell.tsx` | `< 1024` (TABLET) | collapsed rail / pinnable sidebar |
| `useViewportBreakpoint` default | `< 1024` | generic narrow check |
| Tailwind `sm:` classes (left pane etc.) | `>= 640` | compact target sizes |

Between 640-767px, dockview rendered mobile sheet chrome inside a desktop shell.

## Fix

New single source of truth: `packages/workspace/src/front/layout/breakpoints.ts`

- `COMPACT_MAX_WIDTH = 640` — compact tier below (Tailwind `sm`)
- `WIDE_MIN_WIDTH = 1024` — wide tier at/above (Tailwind `lg`)
- medium tier in between; helpers `isCompactViewport` / `isBelowWideViewport`
- exported via the layout barrel; all six JS flip sites migrated

640 wins as the mobile boundary because the outermost flip (mobile shell) and all Tailwind `sm:` styling already used it. `ChatLayout`'s 1180px chat auto-collapse is a distinct concern, kept as a named local constant (unchanged value).

## Visible behavior changes

| Width | Before | After |
| --- | --- | --- |
| 640-767px (e.g. 700px) | Dockview: mobile hamburger + sheet sidebar | Medium tier: collapsed rail with pin-open sidebar |
| < 640px | mobile shell / sheet | unchanged |
| 768-1023px | collapsed rail | unchanged |
| >= 1024px | full inline layout | unchanged |

## Tests

- `breakpoints.test.ts`: token values + boundary semantics (639/640, 1023/1024)
- `presets.test.tsx`: new boundary test asserting rail (not sheet) at 640/700/1023, sheet at 639, inline at 1024
- Full workspace suite: 1996 passed (one pre-existing dist-dependent suite passes after `pnpm -C packages/workspace build`); `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPPbToGDvkARQZuYKFyWN