### PR TITLE
[epic #1081] SBX1.3 slice 4: evidence docs + 2026-08-10 local proof

### DIFF
--- a/docs/issues/808/sbx1.3/evidence/proof.md
+++ b/docs/issues/808/sbx1.3/evidence/proof.md
@@ -1,0 +1,135 @@
+# SBX1.3 proof ledger — 2026-07-22
+
+This is non-admitting implementation evidence. It does not claim fleet
+admission, an exact production cohort freeze, or escape resistance.
+
+## Automated gates
+
+| Exact command | Result |
+| --- | --- |
+| `rtk pnpm -C packages/boring-sandbox build` | PASS; ESM and declaration builds completed for all nine package entrypoints. |
+| `rtk pnpm -C packages/boring-sandbox test` | PASS; 51 files, 475 tests. |
+| `rtk pnpm -C packages/boring-sandbox lint` | PASS; TypeScript plus all Sandbox package invariants. |
+| `rtk pnpm --filter @hachej/boring-agent exec vitest run src/shared/__tests__/error-codes.test.ts` | PASS; 1 file, 6 tests, no type errors. |
+| `rtk go test ./... && rtk go vet ./...` from `packages/boring-sandbox/src/providers/runsc/runtime/workload` | PASS; 17 tests, no vet findings. |
+| `rtk go test ./... && rtk go vet ./...` from `packages/boring-sandbox/src/providers/runsc/runtime/quota-helper` | PASS; 3 tests, no vet findings. |
+| `rtk pnpm lint` | PASS; generated artifacts, Agent resources, and import audit. |
+| `rtk pnpm lint:invariants` | PASS; Agent, boring-bash, Sandbox, and Workspace plugin invariants. |
+| `rtk pnpm run typecheck` | PASS; full package build followed by all 31 workspace-project typechecks. |
+| `rtk git diff --check` | PASS. The repository exposes no top-level format script. |
+
+## Real Docker+runsc integration
+
+Exact command:
+
+```text
+rtk env RUN_RUNSC_INTEGRATION=1 pnpm --filter @hachej/boring-sandbox run test:runsc:integration
+```
+
+Result: PASS as non-admitting evidence; 11 passed, 3 operator follow-ups,
+0 failed. The raw machine-readable result is
+[`runsc-runtime-integration-2026-07-22.json`](./runsc-runtime-integration-2026-07-22.json).
+
+Passed probes:
+
+- runsc guest sentinel (`4.19.0-gvisor`) and digest-pinned workload image;
+- fail-closed session creation when the required path primitive is absent,
+  including removal of the rejected container;
+- exact `65532:65532`, `--runtime=runsc`, `--network none` workload creation
+  on the explicitly non-admitting helper-bypass path;
+- durable workspace write, background and double-fork reaping, non-model
+  secret delivery and post-secret container replacement;
+- planted secret absence from container env/argv, Docker inspect, labels, image
+  inspect, and image history;
+- model-provider-credential rejection before Docker exec;
+- timeout process-group cleanup with a clean subsequent baseline;
+- external IPv4/IPv6, metadata IPv4/IPv6, sibling, worker bridge, DNS, and
+  Docker-socket denial, with loopback as a positive control;
+- teardown of every session container.
+
+Operator follow-ups:
+
+1. `workspace-openat2-fs`: this runsc release returns `ENOSYS` for Linux
+   `openat2` syscall 437. Product session creation correctly fails closed and
+   removes the container; there is no realpath fallback.
+2. `symlink-swap-race`: because the mandatory primitive is unavailable, the
+   mutating helper and its race probe cannot be admitted or truthfully run on
+   this profile.
+3. `project-quota-fill`: the host ext4 mount lacks `prjquota`/project-quota
+   mount support. Enabling it would mutate host filesystem policy, so the real
+   fill/sibling/reserve probe was not run here.
+
+After the fail-closed `openat2` result, the harness runs process, secret,
+timeout, egress, and teardown probes through an explicit workload-only
+`nonAdmittingPathHelperBypass`; this is proof of those mechanisms, not proof of
+the rejected workspace helper or a production-ready session.
+
+## Independent review
+
+Claude Opus performed the required different-model read-only security and
+thermonuclear maintainability review. The first pass reported no P0/P1 and
+identified eight P2/P3 correctness/hardening/maintainability findings. All were
+fixed: workspace envelope symmetry, Go module decomposition, heap-based nonce
+expiry, locked quota collision probing, sanitized causes, extracted exec
+failure recovery, retention of replay markers through terminal retirement, and
+workspace-root/control-socket hardening. The post-fix pass returned PASS with
+no P0/P1/P2; its remaining base64 boundary P3 was then fixed and covered by a
+Go boundary test. A final executor contract audit additionally moved host
+reserve enforcement into the root quota helper and made the Docker mount source
+derivable only from a configured root plus validated workspace UUID.
+
+## Documented deviation
+
+Docker 28.2.2 rejects the plan's literal `--mount ... ,rw` token for the
+key/value `--mount` grammar. The argv builder emits the equivalent explicit
+`readonly=false`; every other V3 Docker control is emitted as specified. This
+syntax was exercised by the real runsc harness.
+
+## Local proof refresh — 2026-08-10
+
+The freshly landed slices 1–3 at `origin/main` `637999391` were exercised on
+this OVH VM with Docker 28.2.2 and the real gVisor runtime
+`runsc version release-20260706.0` (`4.19.0-gvisor` guest sentinel). The exact
+integration command above reported **12 passed / 3 operator follow-ups / 0
+failed**. The raw result is
+[`runsc-runtime-integration-2026-08-10.json`](./runsc-runtime-integration-2026-08-10.json).
+The accompanying local gates also passed the package build, 19 workload
+supervisor Go tests plus `go vet`, and 8 quota-helper Go tests plus `go vet`.
+
+The run proved the fd-3 credential canary was delivered without leaking: it
+was absent from the container environment, argv, inspect data, labels, image
+inspection/history, and the replacement container, while the workspace was
+read-only during delivery. It also proved the complete default-deny egress
+matrix: external IPv4 and IPv6, metadata IPv4 and IPv6 link-local, a sibling
+container, the worker bridge (`172.17.0.1`), DNS, and Docker socket access were
+all denied; loopback succeeded as the positive control.
+
+The three environment follow-ups remain explicit and non-admitting:
+
+1. `workspace-openat2-fs`: runsc release-20260706.0 returns `ENOSYS` for
+   `openat2` syscall 437; product session creation fails closed and removes the
+   rejected container, with no realpath fallback.
+2. `project-quota-fill`: the host ext4 workspace volume is mounted without
+   `prjquota`, so the harness does not mutate host filesystem policy to run the
+   real fill/sibling/reserve probe.
+3. `symlink-swap-race`: blocked by follow-up 1 because the mandatory `openat2`
+   helper cannot be admitted, so the mutating race probe cannot be truthfully
+   exercised on this profile.
+
+Everything after the admission refusal ran through the labeled workload-only
+`nonAdmittingPathHelperBypass`. This demonstrates those mechanisms and the
+fail-closed gate; it does not claim a production-ready session or fleet
+admission.
+
+Production still requires:
+
+1. a pinned, qualified runsc build whose profile implements `openat2` and
+   admits the real workspace helper and symlink-race probe;
+2. ext4/XFS worker data volumes provisioned with `prjquota`, followed by the
+   real quota fill, sibling, and reserve probe;
+3. the quota helper installed as a preconfigured root-owned binary rather than
+   run from a source checkout;
+4. fleet admission evidence for the actual worker cohort, including the
+   qualification bundle (`fleetAdmissionClaimed` remains `false` here); and
+5. production operational plumbing: a real registry and image pipeline,
+   worker provisioning, and deployed V1 remote-worker credential-ref wiring.

--- a/docs/issues/808/sbx1.3/evidence/runsc-runtime-integration-2026-07-22.json
+++ b/docs/issues/808/sbx1.3/evidence/runsc-runtime-integration-2026-07-22.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": 1,
+  "domain": "boring-sbx1.3-runsc-runtime-integration:non-admitting",
+  "nonAdmitting": true,
+  "exactProductionCohortClaimed": false,
+  "fleetAdmissionClaimed": false,
+  "runId": "ba897f6816dc5fcb",
+  "timestamp": "2026-07-22T12:00:08.787Z",
+  "safeFacts": {
+    "dockerServerVersion": "28.2.2",
+    "runscVersion": "runsc version release-20260706.0",
+    "guestKernel": "4.19.0-gvisor",
+    "workloadImageDigest": "127.0.0.1:32808/boring-sbx13-runtime@sha256:4b45bd3746adb9db0a23d887559a49bbd4c25eecba64b19ba0605093b2d1d9d4"
+  },
+  "results": [
+    {
+      "probe": "runsc-sentinel",
+      "status": "passed",
+      "guestKernel": "4.19.0-gvisor"
+    },
+    {
+      "probe": "workload-image",
+      "status": "passed",
+      "pinnedByDigest": true,
+      "workloadUid": 65532
+    },
+    {
+      "probe": "project-quota-fill",
+      "status": "operator-follow-up",
+      "reason": "host ext4 lacks project-quota mount support; enabling it would mutate host filesystem policy"
+    },
+    {
+      "probe": "session-create-fail-closed",
+      "status": "passed",
+      "unsupportedPrimitive": "openat2",
+      "containerRemoved": true
+    },
+    {
+      "probe": "workspace-openat2-fs",
+      "status": "operator-follow-up",
+      "reason": "runsc returns ENOSYS for openat2 syscall 437; the runtime correctly rejects creation without a fallback"
+    },
+    {
+      "probe": "symlink-swap-race",
+      "status": "operator-follow-up",
+      "reason": "the required openat2 primitive is unavailable in this runsc profile, so a mutating helper race cannot be admitted or side-door tested"
+    },
+    {
+      "probe": "workload-container-create",
+      "status": "passed",
+      "network": "none",
+      "runtime": "runsc",
+      "nonAdmittingPathHelperBypass": true
+    },
+    {
+      "probe": "workload-workspace-write",
+      "status": "passed",
+      "helperPathAdmitted": false
+    },
+    {
+      "probe": "background-double-fork-reaping",
+      "status": "passed",
+      "cleanBaseline": true
+    },
+    {
+      "probe": "non-model-secret",
+      "status": "passed",
+      "delivered": true,
+      "workspacePersistedAcrossRecreate": true,
+      "absentFromContainerEnvArgvInspectLabelsAndImage": true
+    },
+    {
+      "probe": "model-provider-credential-negative",
+      "status": "passed",
+      "rejectedBeforeDockerExec": true
+    },
+    {
+      "probe": "timeout-process-group-kill",
+      "status": "passed",
+      "cleanBaseline": true
+    },
+    {
+      "probe": "egress-default-deny",
+      "status": "passed",
+      "externalDenied": true,
+      "externalIpv6Denied": true,
+      "metadataDenied": true,
+      "metadataIpv6Denied": true,
+      "siblingDenied": true,
+      "workerPrivateInterfaceDenied": true,
+      "dnsDenied": true,
+      "dockerSocketAbsent": true,
+      "loopbackPositiveControl": true
+    },
+    {
+      "probe": "teardown",
+      "status": "passed",
+      "allSessionContainersRemoved": true
+    }
+  ],
+  "summary": {
+    "passed": 11,
+    "operatorFollowup": 3,
+    "failed": 0
+  }
+}

--- a/docs/issues/808/sbx1.3/evidence/runsc-runtime-integration-2026-08-10.json
+++ b/docs/issues/808/sbx1.3/evidence/runsc-runtime-integration-2026-08-10.json
@@ -1,0 +1,116 @@
+{
+  "schemaVersion": 1,
+  "domain": "boring-sbx1.3-runsc-runtime-integration:non-admitting",
+  "nonAdmitting": true,
+  "exactProductionCohortClaimed": false,
+  "fleetAdmissionClaimed": false,
+  "runId": "201728b12d0e1b62",
+  "timestamp": "2026-08-10T13:35:18.903Z",
+  "safeFacts": {
+    "dockerServerVersion": "28.2.2",
+    "runscVersion": "runsc version release-20260706.0",
+    "guestKernel": "4.19.0-gvisor",
+    "workloadImageDigest": "127.0.0.1:32812/boring-sbx13-runtime@sha256:5d3b9912487661e1816e6ada9c11581e6cfc8497cff82ad80e325c8301222d6e"
+  },
+  "results": [
+    {
+      "probe": "runsc-sentinel",
+      "status": "passed",
+      "guestKernel": "4.19.0-gvisor"
+    },
+    {
+      "probe": "workload-image",
+      "status": "passed",
+      "pinnedByDigest": true,
+      "supervisorUid": 0,
+      "tenantUid": 65532
+    },
+    {
+      "probe": "project-quota-fill",
+      "status": "operator-follow-up",
+      "reason": "host ext4 lacks project-quota mount support; enabling it would mutate host filesystem policy"
+    },
+    {
+      "probe": "session-create-fail-closed",
+      "status": "passed",
+      "unsupportedPrimitive": "openat2",
+      "containerRemoved": true
+    },
+    {
+      "probe": "workspace-openat2-fs",
+      "status": "operator-follow-up",
+      "reason": "runsc returns ENOSYS for openat2 syscall 437; the runtime correctly rejects creation without a fallback"
+    },
+    {
+      "probe": "symlink-swap-race",
+      "status": "operator-follow-up",
+      "reason": "the required openat2 primitive is unavailable in this runsc profile, so a mutating helper race cannot be admitted or side-door tested"
+    },
+    {
+      "probe": "workload-container-create",
+      "status": "passed",
+      "network": "none",
+      "runtime": "runsc",
+      "nonAdmittingPathHelperBypass": true
+    },
+    {
+      "probe": "workload-workspace-write",
+      "status": "passed",
+      "helperPathAdmitted": false
+    },
+    {
+      "probe": "background-double-fork-reaping",
+      "status": "passed",
+      "cleanBaseline": true
+    },
+    {
+      "probe": "tenant-control-socket-negative",
+      "status": "passed",
+      "tenantConnectRejected": true,
+      "queuedDeadPeerRejected": true
+    },
+    {
+      "probe": "non-model-secret",
+      "status": "passed",
+      "delivered": true,
+      "inheritedCredentialChannel": "fd-3",
+      "commonJsonAndEnvironmentDelivery": false,
+      "workspaceReadOnlyDuringDelivery": true,
+      "absentAfterContainerReplacement": true,
+      "absentFromContainerEnvArgvInspectLabelsAndImage": true
+    },
+    {
+      "probe": "model-provider-credential-negative",
+      "status": "passed",
+      "rejectedBeforeDockerExec": true
+    },
+    {
+      "probe": "timeout-process-group-kill",
+      "status": "passed",
+      "cleanBaseline": true
+    },
+    {
+      "probe": "egress-default-deny",
+      "status": "passed",
+      "externalDenied": true,
+      "externalIpv6Denied": true,
+      "metadataDenied": true,
+      "metadataIpv6Denied": true,
+      "siblingDenied": true,
+      "workerPrivateInterfaceDenied": true,
+      "dnsDenied": true,
+      "dockerSocketAbsent": true,
+      "loopbackPositiveControl": true
+    },
+    {
+      "probe": "teardown",
+      "status": "passed",
+      "allSessionContainersRemoved": true
+    }
+  ],
+  "summary": {
+    "passed": 12,
+    "operatorFollowup": 3,
+    "failed": 0
+  }
+}

--- a/docs/issues/808/sbx1.3/plan.md
+++ b/docs/issues/808/sbx1.3/plan.md
@@ -1,0 +1,47 @@
+# SBX1.3 — Session-lifetime Docker+runsc worker runtime
+
+Bead: `wt-391-forward-6gd.3`. Branch: `feat/808-sbx1-3-runtime`. Depends on SBX1.1 (#855, V1 protocol/provider) + SBX1.2 (#892, V3 qualification), both on `main`.
+
+## Scope framing (Today → Delta)
+
+**Today (landed on main).**
+- `packages/boring-sandbox/src/shared/remoteWorkerProtocolV1.ts` — V1 wire schemas (health/create/exec/fs/renew/delete, capability claims *including a `nonce` field*, binding receipt). Exec request has **no** secret channel yet.
+- `providers/remote-worker/*` — client-side provider, binding registry, `requestDigest.ts` (already uses a `canonicalJson` — sorted-keys, drops `undefined`).
+- `providers/runsc/*` — structural `preflightRunsc()` (`productionReady:false`), V2/V3 isolation evidence + qualification bundle + fleet-admission validators (SBX1.2). No live container runtime.
+- `qualify-docker-runsc-isolation.mjs` — adversarial qualification harness (passed 11/11 on this VPS, runsc `4.19.0-gvisor` confirmed runnable for the current user).
+
+**Delta (SBX1.3 delivers — the worker-side RUNTIME the SBX1.4 daemon will host).** Server-side composable modules under `packages/boring-sandbox/src/providers/runsc/runtime/**` (node:* allowed here; **never** in `src/shared/**`). No HTTP daemon (SBX1.4), no fleet admission (SBX1.5).
+
+## Slices
+
+1. **Typed Docker argv runner.** Pure `buildDockerRunArgv(profile)` / `buildDockerExecArgv` producing an argv array for `/usr/bin/docker`, plus an injected `DockerCommandRunner` that spawns `/usr/bin/docker` with `shell:false`. Tenant values never become flag names, volume sources, labels, names, or shell fragments. Emits the exact V3 launch profile (`--runtime=runsc --user 65532:65532 --read-only --cap-drop ALL --security-opt no-new-privileges --cpus 0.5 --memory 128m --pids-limit 64 --network none --tmpfs /tmp:rw,nosuid,nodev,size=16m --mount type=bind,...rw --label ... <image@sha256> <PID1>`). Finite per-command Docker timeouts.
+
+2. **Workspace path-safety helper (dirfd/openat2, RESOLVE_BENEATH+RESOLVE_NO_MAGICLINKS).** In-container trusted helper holding a dirfd for `/workspace`, doing dirfd-relative `openat2` for every component/rename endpoint; host-side client speaks to it (not host check-then-open). If the qualified kernel/runsc profile cannot provide `openat2`+RESOLVE flags, **admission fails** — no realpath-then-open fallback. Host root/path never serialized in responses/errors. Sibling-traversal + concurrent symlink-swap/rename-race negatives.
+
+3. **Fixed project quota + host reserve.** Root-owned quota helper takes only a validated workspace ID + fixed profile; assigns/checks ext4/XFS project quota (1 GiB + 100k inodes) outside the tenant mount; exposes no arbitrary path/shell. Host emergency reserve = max(10% volume, 10 GiB) tenant cannot consume. One stable quota-exceeded failure to both fs ops and in-container commands; siblings + reserve stay writable.
+
+4. **Workload image + trusted PID1/subreaper + invocation wrapper.** Dockerfile (minimal tool runtime, pinned by digest, non-root 65532). Trusted PID1 supervisor reaps all descendants (incl. double-fork/background) after success/error/abort/timeout; proves clean tenant-process baseline before each invocation; uncertain cleanup ⇒ destroy+recreate container. In-container invocation wrapper receives one bounded JSON stdin envelope, populates child env in memory, runs the command, clears refs on exit.
+
+5. **Warm no-network session container lifecycle.** One `create()` → one `--network none` container reused across invocations for the runtime-binding lease. Idle 30-min TTL timer (not a reconcile loop), 24-h hard lifetime → single-flight retirement through the landed binding owner. Startup bounded sweep of own labeled containers; shutdown drains then removes. Missing/expired ⇒ stable retryable error + retirement, never a side-door recreate.
+
+6. **Purpose-typed NON-MODEL per-invocation secrets (stdin envelope) + model-key negative.** Add a typed secret-reference contract (`sandbox-invocation-secret` vs `model-provider-credential`) in `src/shared` (types/zod only, no node). Extend `RemoteWorkerExecRequestSchemaV1` with a `secretEnv` envelope separate from ordinary `env`. Worker: strict env-name grammar + reserved-name denylist; classification comes **only** from trusted sensitivity metadata (never inferred from `_TOKEN`/`_SECRET`); **rejects** `model-provider-credential` refs (`REMOTE_WORKER_*`); pipes one bounded JSON envelope over stdin to the wrapper; never puts secrets in argv/`docker exec --env`/labels/layers/files/logs; secret-bearing invocation uses a clean container and destroys+recreates it after completion (preserving `/workspace`); never caches a secret-bearing invocation's output for replay (`REMOTE_WORKER_SECRET_INVOCATION_NOT_REPLAYABLE`). This is the host-controlled Tier-1-adjacent path; the deferred Tier-2 in-sandbox tenant-tool injection (`16f.6`) is **out of scope**.
+
+7. **Time/resource/output bounds + dispose/expiry/orphan cleanup.** 30-s default / 15-min max invocation timeout; 4 MiB combined stdout+stderr with truncation facts; one active exec/session + finite daemon-wide concurrency; finite create/fs/exec-grace/renew/dispose/Docker timeouts; body/command/path/env/secret count+value + SSE caps. Timeout: wrapper kills the process **group**, grace, then kill; killing only host-side `docker exec` is insufficient; unproven group death ⇒ destroy container + stable cleanup error.
+
+8. **#855-review GATES (security-critical, must implement).**
+   - **Single-use nonce:** a worker-side nonce store records every accepted capability `nonce` and **rejects replays** (`REMOTE_WORKER_*` replay code), bounded by capability lifetime with expiry eviction. Concurrent-replay race is single-flight/atomic.
+   - **Request-digest canonicalization:** idempotency/binding digests use `canonicalJson` (sorted keys, stable), **never** `JSON.stringify`, for any Date-bearing / key-order-sensitive body. Add a negative test proving `JSON.stringify` key-order or Date drift would break idempotency but `canonicalJson` does not.
+
+## Invariants
+Stable error codes (extend `REMOTE_WORKER_ERROR_CODES_V1` as needed, mapped in the agent `ErrorCode` union); no `node:*`/`Buffer` in `src/shared/**` (use `Uint8Array`); messages never reflect token/secret values, host roots, or the Docker socket.
+
+## Proof / exit
+- **Unit fault matrix** for every module (argv builder rejects injection; path helper rejects traversal/race; quota helper; secret envelope grammar/denylist + model-key reject; nonce replay; canonicalization; timeout/output bounds; lifecycle/retirement).
+- **Non-admitting real-runsc integration** (runsc IS installed, qualification passed 2026-07-19) for: create, fs, symlink-race, quota-fill, background/double-fork process reaping, non-model-secret delivery + non-leak, model-key negative, timeout group-kill, egress default-deny, teardown. Gated behind a `RUN_RUNSC_INTEGRATION` env so CI without runsc still passes; harness present regardless.
+- Explicitly **NOT** claimed: fleet admission, "exact production" cohort freeze (SBX1.4/1.5).
+
+## Deferred (out of scope)
+SBX1.4 minimal VPS daemon + V0 retirement; SBX1.5 fleet admission; `16f.6` Tier-2 in-sandbox injection; deep host-side `withRuntimeEnvContributions` migration across agent/core/workspace (SBX1.4 wiring — SBX1.3 lands only the worker-side secret-reference contract + rejection).
+
+## Reviewer
+Independent adversarial security review by a **different model** than the executor (delegation-model requirement for security surfaces), attacking isolation/secret/nonce/egress/path/quota properties before done.


### PR DESCRIPTION
## Summary

- recover the original SBX1.3 plan, proof ledger, and 2026-07-22 runsc integration result from `origin/feat/808-sbx1-3-runtime` at `12939f363`
- add the 2026-08-10 VM proof and its machine-readable integration result
- document the 12/3/0 outcome, fd-3 canary non-leak, full egress-deny matrix, three environment follow-ups, and remaining production gap

## Why

Slices 1–3 landed the SBX1.3 implementation, but its durable evidence directory was not recovered. This slice restores that review context and records the latest real-runsc proof without claiming fleet admission or production readiness.

## Validation

- donor plan and 2026-07-22 JSON match `12939f363` byte-for-byte
- donor proof ledger matches byte-for-byte through its original final byte; the new dated section is appended
- 2026-08-10 JSON matches the supplied integration output object byte-for-byte and passes `jq` validation
- machine-checked 12 passed / 3 operator follow-ups / 0 failed, runsc release, fd-3 channel, and every egress-deny predicate
- `git diff --check`

Part of #1081.

🤖 Generated with Codex (gpt-5.6-sol).