### PR TITLE
feat(tasks): epics-first drill-down view (gh-1187 S5)

### DIFF
--- a/plugins/tasks/src/front/TaskEpicsView.test.tsx
+++ b/plugins/tasks/src/front/TaskEpicsView.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, test } from "vitest"
+
+import { WorkspacePluginClientProvider } from "@hachej/boring-workspace"
+import type { BoringTaskAdapter, BoringTaskCard } from "../shared"
+import { TaskKanbanBoard } from "./TaskKanbanBoard"
+
+const COLUMNS = [
+  { id: "open", title: "Open" },
+  { id: "in-progress", title: "In progress" },
+  { id: "closed", title: "Closed" },
+]
+
+function card(id: string, statusId: string, title: string, epic?: { id: string; title: string }, tags?: string[]): BoringTaskCard {
+  return { id, number: id, title, statusId, adapterId: "beads", ...(epic ? { epic } : {}), ...(tags ? { tags } : {}) }
+}
+
+const TASKS: BoringTaskCard[] = [
+  card("bd-1", "open", "Lane worktree pool", { id: "bd-100", title: "Factory migration" }, ["lane"]),
+  card("bd-2", "closed", "Lane registry", { id: "bd-100", title: "Factory migration" }),
+  card("bd-3", "closed", "Retired spike", { id: "bd-200", title: "Old spike" }),
+  card("bd-4", "in-progress", "Unparented chore"),
+]
+
+function beadsAdapter(tasks: BoringTaskCard[] = TASKS): BoringTaskAdapter {
+  return {
+    id: "beads",
+    label: "Beads",
+    capabilities: { move: false },
+    getBoardConfig: async () => ({ adapterId: "beads", columns: COLUMNS }),
+    listTasks: async () => tasks,
+  }
+}
+
+function renderBoard(adapter: BoringTaskAdapter = beadsAdapter(), workspaceId = "epics-test") {
+  return render(
+    <WorkspacePluginClientProvider agentTypeId="default" apiBaseUrl="" workspaceId={workspaceId}>
+      <TaskKanbanBoard adapters={[adapter]} />
+    </WorkspacePluginClientProvider>,
+  )
+}
+
+async function openEpicsView(user: ReturnType<typeof userEvent.setup>) {
+  await screen.findByText("Lane worktree pool")
+  await user.click(screen.getByRole("button", { name: "Show epics view" }))
+}
+
+describe("TaskKanbanBoard epics view", () => {
+  beforeEach(() => localStorage.clear())
+
+  test("switches to an epics-first list with per-epic counts and a status breakdown", async () => {
+    const user = userEvent.setup()
+    renderBoard()
+    await openEpicsView(user)
+
+    const epic = screen.getByRole("button", { name: /Factory migration/ })
+    expect(epic).toHaveAttribute("aria-expanded", "false")
+    expect(epic).toHaveTextContent("bd-100")
+    expect(epic).toHaveTextContent("Open1")
+    expect(epic).toHaveTextContent("Closed1")
+    expect(epic).toHaveTextContent("1/2")
+    expect(screen.getByRole("button", { name: /No epic/ })).toBeInTheDocument()
+    // Collapsed by default: beads are not rendered until the epic is expanded.
+    expect(screen.queryByText("Lane worktree pool")).not.toBeInTheDocument()
+  })
+
+  test("hides fully closed epics by default and restores them through the visible toggle", async () => {
+    const user = userEvent.setup()
+    renderBoard()
+    await openEpicsView(user)
+
+    expect(screen.queryByRole("button", { name: /Old spike/ })).not.toBeInTheDocument()
+    expect(screen.getByText(/1 fully closed epic \(1 task\) hidden/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "All epics" }))
+    expect(screen.getByRole("button", { name: /Old spike/ })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "All epics" })).toHaveAttribute("aria-pressed", "true")
+
+    await user.click(screen.getByRole("button", { name: "Active epics" }))
+    expect(screen.queryByRole("button", { name: /Old spike/ })).not.toBeInTheDocument()
+  })
+
+  test("expands and collapses an epic with disclosure semantics wired to its panel", async () => {
+    const user = userEvent.setup()
+    renderBoard()
+    await openEpicsView(user)
+
+    const epic = screen.getByRole("button", { name: /Factory migration/ })
+    await user.click(epic)
+    expect(epic).toHaveAttribute("aria-expanded", "true")
+    const panelId = epic.getAttribute("aria-controls")
+    expect(panelId).toBeTruthy()
+    expect(document.getElementById(panelId as string)).not.toBeNull()
+    expect(screen.getByText("Lane worktree pool")).toBeInTheDocument()
+    expect(screen.getByText("Lane registry")).toBeInTheDocument()
+
+    await user.click(epic)
+    expect(epic).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByText("Lane worktree pool")).not.toBeInTheDocument()
+  })
+
+  test("is keyboard operable from the view switcher through to a bead", async () => {
+    const user = userEvent.setup()
+    renderBoard()
+    await screen.findByText("Lane worktree pool")
+    screen.getByRole("button", { name: "Show epics view" }).focus()
+    await user.keyboard("{Enter}")
+    const epic = screen.getByRole("button", { name: /Factory migration/ })
+    epic.focus()
+    await user.keyboard(" ")
+    expect(epic).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText("Lane worktree pool")).toBeInTheDocument()
+  })
+
+  test("composes with the epic and tag filters instead of forking the pipeline", async () => {
+    const user = userEvent.setup()
+    renderBoard()
+    await openEpicsView(user)
+
+    await user.selectOptions(screen.getByLabelText("Epic"), "beads:bd-100")
+    expect(screen.queryByRole("button", { name: /No epic/ })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Factory migration/ })).toBeInTheDocument()
+
+    await user.selectOptions(screen.getByLabelText("Epic"), "all")
+    await user.selectOptions(screen.getByLabelText("Tag"), "lane")
+    const epic = screen.getByRole("button", { name: /Factory migration/ })
+    expect(epic).toHaveTextContent("1/1")
+    expect(screen.queryByRole("button", { name: /No epic/ })).not.toBeInTheDocument()
+  })
+
+  test("hides beads whose column is switched off, and drops an epic that empties", async () => {
+    const user = userEvent.setup()
+    renderBoard()
+    await openEpicsView(user)
+
+    await user.click(screen.getByRole("button", { name: /^Columns / }))
+    await user.click(screen.getByRole("checkbox", { name: /Open/ }))
+
+    // Its only open bead is hidden, so the epic is no longer active — but the
+    // toggle label states exactly how much is being withheld.
+    expect(screen.queryByRole("button", { name: /Factory migration/ })).not.toBeInTheDocument()
+    expect(screen.getByText(/fully closed epic/)).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "All epics" }))
+    const epic = screen.getByRole("button", { name: /Factory migration/ })
+    expect(epic).toHaveTextContent("0/1")
+    expect(epic).toHaveTextContent("Closed")
+  })
+
+  test("persists the epics view selection across a remount", async () => {
+    const user = userEvent.setup()
+    const first = renderBoard()
+    await openEpicsView(user)
+    first.unmount()
+
+    renderBoard()
+    expect(await screen.findByRole("button", { name: /Factory migration/ })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Active epics" })).toHaveAttribute("aria-pressed", "true")
+  })
+
+  test("opens the shared task detail dialog from a bead inside an epic", async () => {
+    const user = userEvent.setup()
+    const detailed: BoringTaskAdapter = {
+      ...beadsAdapter(),
+      capabilities: { move: false, detail: true },
+      getTask: async () => ({
+        task: TASKS[0] as BoringTaskCard,
+        body: "Bead body from the epics view.",
+        metadata: [],
+        relations: [],
+      }),
+    }
+    renderBoard(detailed)
+    await openEpicsView(user)
+    await user.click(screen.getByRole("button", { name: /Factory migration/ }))
+    await user.click(screen.getByRole("button", { name: "View details for bd-1" }))
+
+    expect(await screen.findByRole("dialog", { name: "Lane worktree pool" })).toBeInTheDocument()
+    expect(screen.getByText("Bead body from the epics view.")).toBeInTheDocument()
+  })
+})

--- a/plugins/tasks/src/front/TaskEpicsView.tsx
+++ b/plugins/tasks/src/front/TaskEpicsView.tsx
@@ -1,0 +1,152 @@
+import { useId, type ReactNode } from "react"
+import { ChevronRight } from "lucide-react"
+import type { BoringTaskCard } from "../shared"
+import { NO_EPIC_GROUP_KEY, isTerminalColumnId, type TaskEpicGroup } from "./taskEpicsModel"
+
+interface TaskEpicsViewProps {
+  groups: readonly TaskEpicGroup[]
+  hiddenEpicCount: number
+  hiddenTaskCount: number
+  showClosed: boolean
+  onShowClosedChange: (showClosed: boolean) => void
+  expandedEpicKeys: ReadonlySet<string>
+  onToggleEpic: (key: string) => void
+  renderTask: (task: BoringTaskCard) => ReactNode
+}
+
+function StatusPill({ title, count, color, terminal }: { title: string; count: number; color?: string; terminal: boolean }) {
+  return (
+    <span
+      className={[
+        "inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] leading-4",
+        terminal ? "border-border/60 bg-muted/30 text-muted-foreground" : "border-border bg-background text-foreground",
+      ].join(" ")}
+    >
+      {color ? <span className="h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: color }} aria-hidden="true" /> : null}
+      <span className="truncate">{title}</span>
+      <span className="tabular-nums font-medium">{count}</span>
+    </span>
+  )
+}
+
+export function TaskEpicsView({
+  groups,
+  hiddenEpicCount,
+  hiddenTaskCount,
+  showClosed,
+  onShowClosedChange,
+  expandedEpicKeys,
+  onToggleEpic,
+  renderTask,
+}: TaskEpicsViewProps) {
+  const panelIdPrefix = useId()
+  const activeCount = groups.filter((group) => group.active).length
+
+  return (
+    <div className="boring-scrollbar-discreet flex h-full flex-col gap-3 overflow-y-auto pr-1">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="inline-flex h-8 overflow-hidden rounded-lg border border-border bg-background text-xs shadow-sm" role="group" aria-label="Epic activity filter">
+          <button
+            type="button"
+            className={["px-3 font-medium", !showClosed ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/70 hover:text-foreground"].join(" ")}
+            onClick={() => onShowClosedChange(false)}
+            aria-pressed={!showClosed}
+          >
+            Active epics
+          </button>
+          <button
+            type="button"
+            className={["px-3 font-medium", showClosed ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/70 hover:text-foreground"].join(" ")}
+            onClick={() => onShowClosedChange(true)}
+            aria-pressed={showClosed}
+          >
+            All epics
+          </button>
+        </div>
+        <span className="text-xs text-muted-foreground" aria-live="polite">
+          {showClosed
+            ? `${groups.length} epic${groups.length === 1 ? "" : "s"} · ${activeCount} active`
+            : hiddenEpicCount > 0
+              ? `${groups.length} active · ${hiddenEpicCount} fully closed epic${hiddenEpicCount === 1 ? "" : "s"} (${hiddenTaskCount} task${hiddenTaskCount === 1 ? "" : "s"}) hidden`
+              : `${groups.length} active epic${groups.length === 1 ? "" : "s"} · none hidden`}
+        </span>
+      </div>
+
+      {groups.length === 0 ? (
+        <div className="grid flex-1 place-items-center rounded-2xl border border-dashed border-border p-6 text-center text-sm text-muted-foreground">
+          {hiddenEpicCount > 0
+            ? `No active epics. ${hiddenEpicCount} fully closed epic${hiddenEpicCount === 1 ? " is" : "s are"} hidden — switch to “All epics” to see them.`
+            : "No epics match the current filters."}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {groups.map((group) => {
+            const expanded = expandedEpicKeys.has(group.key)
+            const panelId = `${panelIdPrefix}-${encodeURIComponent(group.key)}`
+            const unassigned = group.key === NO_EPIC_GROUP_KEY
+            return (
+              <section
+                key={group.key}
+                className={[
+                  "rounded-2xl border bg-muted/20",
+                  unassigned ? "border-dashed border-border/70" : group.active ? "border-border/80" : "border-border/50 bg-muted/10",
+                ].join(" ")}
+              >
+                <h3 className="m-0">
+                  <button
+                    type="button"
+                    className="flex w-full items-start gap-3 rounded-2xl p-3 text-left hover:bg-muted/50"
+                    onClick={() => onToggleEpic(group.key)}
+                    aria-expanded={expanded}
+                    aria-controls={panelId}
+                  >
+                    <ChevronRight
+                      className={["mt-0.5 size-4 shrink-0 text-muted-foreground transition-transform", expanded ? "rotate-90" : ""].join(" ")}
+                      strokeWidth={1.75}
+                      aria-hidden="true"
+                    />
+                    <span className="min-w-0 flex-1">
+                      <span className="flex flex-wrap items-center gap-2">
+                        <span className="truncate text-sm font-semibold text-foreground">{group.title}</span>
+                        {group.epicId ? (
+                          <span className="shrink-0 rounded-full border border-border bg-background px-2 py-0.5 text-[11px] tabular-nums text-muted-foreground">
+                            {group.epicId}
+                          </span>
+                        ) : null}
+                        {!group.active && !unassigned ? (
+                          <span className="shrink-0 rounded-full border border-border/60 bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground">Closed</span>
+                        ) : null}
+                      </span>
+                      <span className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                        {group.statuses.map((status) => (
+                          <StatusPill
+                            key={status.columnId}
+                            title={status.title}
+                            count={status.count}
+                            {...(status.color ? { color: status.color } : {})}
+                            terminal={isTerminalColumnId(status.columnId)}
+                          />
+                        ))}
+                      </span>
+                    </span>
+                    <span className="shrink-0 rounded-full border border-border bg-background px-2 py-0.5 text-xs tabular-nums text-muted-foreground">
+                      {group.openCount}/{group.taskCount}
+                      <span className="sr-only"> open of {group.taskCount} tasks</span>
+                    </span>
+                  </button>
+                </h3>
+                <div id={panelId} hidden={!expanded}>
+                  {expanded ? (
+                    <div className="flex flex-col gap-2 border-t border-border/70 p-2">
+                      {group.tasks.map((task) => renderTask(task))}
+                    </div>
+                  ) : null}
+                </div>
+              </section>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/plugins/tasks/src/front/TaskKanbanBoard.tsx
+++ b/plugins/tasks/src/front/TaskKanbanBoard.tsx
@@ -1,10 +1,12 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type DragEvent } from "react"
-import { Columns3, List } from "lucide-react"
+import { Columns3, Layers, List } from "lucide-react"
 import { useWorkspacePluginClient } from "@hachej/boring-workspace"
 import type { BoringTaskAdapter, BoringTaskBoardConfig, BoringTaskCard, BoringTaskColumn, BoringTaskErrorCode, BoringTaskSourceError } from "../shared"
 import { groupTasksByColumn } from "./taskBoardModel"
+import { epicGroupKey, groupTasksByEpic, selectVisibleEpicGroups } from "./taskEpicsModel"
 import { TaskCard } from "./TaskCard"
 import { TaskDetailDialog, type TaskDetailSelection } from "./TaskDetailDialog"
+import { TaskEpicsView } from "./TaskEpicsView"
 import { TaskKanbanColumn } from "./TaskKanbanColumn"
 import { taskAttentionKey, useTaskAttention } from "./useTaskAttention"
 import { taskSessionLinkKey, useTaskSessionLinks } from "./taskSessionLinkStream"
@@ -34,7 +36,8 @@ interface EpicOption {
 
 const TASK_BOARD_CACHE_TTL_MS = 2 * 60 * 1000
 const EMPTY_TASKS: readonly BoringTaskCard[] = []
-type TaskBoardViewMode = "kanban" | "list"
+type TaskBoardViewMode = "kanban" | "list" | "epics"
+const TASK_BOARD_VIEW_MODES: readonly TaskBoardViewMode[] = ["kanban", "list", "epics"]
 
 function adapterSummary(adapters: readonly BoringTaskAdapter[], selectedCount: number): string {
   if (selectedCount === adapters.length) return "All sources"
@@ -49,15 +52,11 @@ function uniqueTags(tasks: readonly BoringTaskCard[]): string[] {
 function uniqueEpics(tasks: readonly BoringTaskCard[]): EpicOption[] {
   const byId = new Map<string, EpicOption>()
   for (const task of tasks) {
-    if (!task.epic) continue
-    const id = `${task.adapterId}:${task.epic.id}`
-    if (!byId.has(id)) byId.set(id, { id, title: task.epic.title })
+    const id = epicGroupKey(task)
+    if (!id || !task.epic || byId.has(id)) continue
+    byId.set(id, { id, title: task.epic.title })
   }
   return [...byId.values()].sort((a, b) => a.title.localeCompare(b.title))
-}
-
-function epicFilterId(task: BoringTaskCard): string | undefined {
-  return task.epic ? `${task.adapterId}:${task.epic.id}` : undefined
 }
 
 function mergeColumns(configs: readonly BoringTaskBoardConfig[], visibleColumnIds: ReadonlySet<string>): BoringTaskColumn[] {
@@ -110,7 +109,8 @@ function writeCachedBoardState(cacheKey: string, state: BoardState): void {
 function readViewMode(cacheKey: string): TaskBoardViewMode {
   if (typeof window === "undefined") return "kanban"
   try {
-    return window.localStorage.getItem(`${cacheKey}:view`) === "list" ? "list" : "kanban"
+    const stored = window.localStorage.getItem(`${cacheKey}:view`)
+    return TASK_BOARD_VIEW_MODES.find((mode) => mode === stored) ?? "kanban"
   } catch {
     return "kanban"
   }
@@ -163,6 +163,8 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
   const [openMenu, setOpenMenu] = useState<"sources" | "columns" | null>(null)
   const [viewMode, setViewModeState] = useState<TaskBoardViewMode>(() => readViewMode(cacheKey))
   const [collapsedSectionIds, setCollapsedSectionIds] = useState<ReadonlySet<string>>(new Set())
+  const [expandedEpicKeys, setExpandedEpicKeys] = useState<ReadonlySet<string>>(new Set())
+  const [showClosedEpics, setShowClosedEpics] = useState(false)
   const [detailSelection, setDetailSelection] = useState<TaskDetailSelection | null>(null)
   const [detailOpen, setDetailOpen] = useState(false)
   const detailTriggerRef = useRef<HTMLButtonElement | null>(null)
@@ -198,6 +200,8 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
     setDeletingTaskId(null)
     setDetailSelection(null)
     setDetailOpen(false)
+    setExpandedEpicKeys(new Set())
+    setShowClosedEpics(false)
   }, [cacheKey, cachedColumnIds, cachedState])
 
   const setViewMode = (mode: TaskBoardViewMode) => {
@@ -337,7 +341,7 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
     const configuredStatusIds = new Set(allColumns.map((column) => column.id))
     return selectedTasks.filter((task) => {
       if (tagFilter !== "all" && !(task.tags ?? []).includes(tagFilter)) return false
-      if (epicFilter !== "all" && epicFilterId(task) !== epicFilter) return false
+      if (epicFilter !== "all" && epicGroupKey(task) !== epicFilter) return false
       if (!configuredStatusIds.has(task.statusId)) return true
       return visibleColumnIds.has(task.statusId)
     })
@@ -355,6 +359,12 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
     () => visibleConfig ? groupTasksByColumn(visibleConfig, filteredTasks) : [],
     [filteredTasks, visibleConfig],
   )
+
+  const epicGroups = useMemo(
+    () => groupTasksByEpic(filteredTasks, visibleConfig?.columns ?? []),
+    [filteredTasks, visibleConfig],
+  )
+  const epicVisibility = useMemo(() => selectVisibleEpicGroups(epicGroups, showClosedEpics), [epicGroups, showClosedEpics])
 
   const handleTaskDragStart = (event: DragEvent<HTMLElement>, task: BoringTaskCard) => {
     setActiveTaskRef({ taskId: task.id, adapterId: task.adapterId })
@@ -545,6 +555,15 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
     setSelectedAdapterIds(new Set(allAdapterIds))
   }
 
+  const toggleEpic = (key: string) => {
+    setExpandedEpicKeys((current) => {
+      const next = new Set(current)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
   const toggleSection = (sectionId: string) => {
     setCollapsedSectionIds((current) => {
       const next = new Set(current)
@@ -553,6 +572,24 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
       return next
     })
   }
+
+  const renderTaskCard = (task: BoringTaskCard, options: { unmapped?: boolean } = {}) => (
+    <TaskCard
+      key={`${task.adapterId}:${task.id}`}
+      task={task}
+      draggable={false}
+      unmapped={options.unmapped ?? false}
+      compact
+      attention={attentionByTask.get(taskAttentionKey(task))}
+      sessionLinks={sessionLinksByTask ? sessionLinksByTask.get(taskSessionLinkKey(task.adapterId, task.id)) ?? [] : undefined}
+      deleteEnabled={deletingTaskId === null && Boolean(adaptersById.get(task.adapterId)?.capabilities.delete && adaptersById.get(task.adapterId)?.deleteTask)}
+      deleteEffect={adaptersById.get(task.adapterId)?.capabilities.deleteEffect ?? "delete"}
+      onDelete={(task) => void deleteTask(task)}
+      onOpenDetail={canOpenTaskDetail(task) ? openTaskDetail : undefined}
+      onDragStart={handleTaskDragStart}
+      onDragEnd={() => setActiveTaskRef(null)}
+    />
+  )
 
   const selectedCount = selectedAdapterIds.size
   const visibleCount = visibleColumnIds.size
@@ -664,6 +701,15 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
           >
             <List className="size-3.5" strokeWidth={1.75} />
           </button>
+          <button
+            type="button"
+            className={["grid w-8 place-items-center", viewMode === "epics" ? "bg-muted text-foreground" : "text-muted-foreground hover:bg-muted/70 hover:text-foreground"].join(" ")}
+            onClick={() => setViewMode("epics")}
+            aria-label="Show epics view"
+            title="Epics view"
+          >
+            <Layers className="size-3.5" strokeWidth={1.75} />
+          </button>
         </div>
         <div className="ml-auto flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
           <span className="rounded-full border border-border bg-muted/40 px-2 py-1">{adapterSummary(adapters, selectedCount)}</span>
@@ -709,6 +755,17 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
           <div className="grid h-full place-items-center rounded-2xl border border-dashed border-border text-sm text-muted-foreground">Loading task board…</div>
         ) : columns.length === 0 ? (
           <div className="grid h-full place-items-center rounded-2xl border border-dashed border-border text-sm text-muted-foreground">No tasks match the current filters.</div>
+        ) : viewMode === "epics" ? (
+          <TaskEpicsView
+            groups={epicVisibility.visible}
+            hiddenEpicCount={epicVisibility.hiddenEpicCount}
+            hiddenTaskCount={epicVisibility.hiddenTaskCount}
+            showClosed={showClosedEpics}
+            onShowClosedChange={setShowClosedEpics}
+            expandedEpicKeys={expandedEpicKeys}
+            onToggleEpic={toggleEpic}
+            renderTask={(task) => renderTaskCard(task)}
+          />
         ) : viewMode === "list" ? (
           <div className="boring-scrollbar-discreet flex h-full flex-col gap-3 overflow-y-auto pr-1">
             {columns.map((column) => {
@@ -741,23 +798,7 @@ export function TaskKanbanBoard({ adapters }: TaskKanbanBoardProps) {
                         <div className="rounded-xl border border-dashed border-border/80 p-3 text-center text-xs text-muted-foreground">
                           No tasks
                         </div>
-                      ) : column.tasks.map((task) => (
-                        <TaskCard
-                          key={`${task.adapterId}:${task.id}`}
-                          task={task}
-                          draggable={false}
-                          unmapped={column.unmapped}
-                          compact
-                          attention={attentionByTask.get(taskAttentionKey(task))}
-                          sessionLinks={sessionLinksByTask ? sessionLinksByTask.get(taskSessionLinkKey(task.adapterId, task.id)) ?? [] : undefined}
-                          deleteEnabled={deletingTaskId === null && Boolean(adaptersById.get(task.adapterId)?.capabilities.delete && adaptersById.get(task.adapterId)?.deleteTask)}
-                          deleteEffect={adaptersById.get(task.adapterId)?.capabilities.deleteEffect ?? "delete"}
-                          onDelete={(task) => void deleteTask(task)}
-                          onOpenDetail={canOpenTaskDetail(task) ? openTaskDetail : undefined}
-                          onDragStart={handleTaskDragStart}
-                          onDragEnd={() => setActiveTaskRef(null)}
-                        />
-                      ))}
+                      ) : column.tasks.map((task) => renderTaskCard(task, { unmapped: column.unmapped ?? false }))}
                     </div>
                   ) : null}
                 </section>

--- a/plugins/tasks/src/front/taskEpicsModel.test.ts
+++ b/plugins/tasks/src/front/taskEpicsModel.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "vitest"
+
+import type { BoringTaskCard, BoringTaskColumn } from "../shared"
+import { NO_EPIC_GROUP_KEY, epicGroupKey, groupTasksByEpic, isTerminalColumnId, selectVisibleEpicGroups } from "./taskEpicsModel"
+
+const columns: BoringTaskColumn[] = [
+  { id: "open", title: "Open" },
+  { id: "in-progress", title: "In progress", color: "#0ea5e9" },
+  { id: "closed", title: "Closed" },
+]
+
+function card(id: string, statusId: string, epic?: { id: string; title: string }, adapterId = "beads"): BoringTaskCard {
+  return { id, number: id, title: `Task ${id}`, statusId, adapterId, ...(epic ? { epic } : {}) }
+}
+
+describe("taskEpicsModel", () => {
+  test("scopes the epic key to its adapter so two sources never collide", () => {
+    expect(epicGroupKey(card("a", "open", { id: "e1", title: "Epic" }))).toBe("beads:e1")
+    expect(epicGroupKey(card("a", "open", { id: "e1", title: "Epic" }, "github"))).toBe("github:e1")
+    expect(epicGroupKey(card("a", "open"))).toBeUndefined()
+  })
+
+  test("recognises terminal columns across adapters, case-insensitively", () => {
+    expect(isTerminalColumnId("closed")).toBe(true)
+    expect(isTerminalColumnId("Done")).toBe(true)
+    expect(isTerminalColumnId("in-progress")).toBe(false)
+  })
+
+  test("groups by epic, orders by title, and puts the unassigned group last", () => {
+    const groups = groupTasksByEpic([
+      card("1", "open", { id: "e2", title: "Zebra" }),
+      card("2", "open"),
+      card("3", "open", { id: "e1", title: "Alpha" }),
+    ], columns)
+    expect(groups.map((group) => group.title)).toEqual(["Alpha", "Zebra", "No epic"])
+    expect(groups.at(-1)?.key).toBe(NO_EPIC_GROUP_KEY)
+  })
+
+  test("counts open versus closed beads and reports activity per epic", () => {
+    const groups = groupTasksByEpic([
+      card("1", "closed", { id: "e1", title: "Alpha" }),
+      card("2", "in-progress", { id: "e1", title: "Alpha" }),
+      card("3", "closed", { id: "e2", title: "Beta" }),
+    ], columns)
+    const [alpha, beta] = groups
+    expect(alpha).toMatchObject({ taskCount: 2, openCount: 1, closedCount: 1, active: true })
+    expect(beta).toMatchObject({ taskCount: 1, openCount: 0, closedCount: 1, active: false })
+  })
+
+  test("orders the status breakdown by board column order and carries column colors", () => {
+    const groups = groupTasksByEpic([
+      card("1", "closed", { id: "e1", title: "Alpha" }),
+      card("2", "in-progress", { id: "e1", title: "Alpha" }),
+      card("3", "open", { id: "e1", title: "Alpha" }),
+    ], columns)
+    expect(groups[0]?.statuses.map((status) => status.columnId)).toEqual(["open", "in-progress", "closed"])
+    expect(groups[0]?.statuses[1]).toMatchObject({ title: "In progress", color: "#0ea5e9", count: 1 })
+  })
+
+  test("still counts beads whose status is absent from the board config", () => {
+    const groups = groupTasksByEpic([card("1", "mystery", { id: "e1", title: "Alpha" })], columns)
+    expect(groups[0]).toMatchObject({ taskCount: 1, openCount: 1 })
+    expect(groups[0]?.statuses[0]).toMatchObject({ columnId: "mystery", title: "mystery", count: 1 })
+  })
+
+  test("falls back to the raw epic id when the parent bead has no resolvable title", () => {
+    const groups = groupTasksByEpic([card("1", "open", { id: "bd-9", title: "bd-9" })], columns)
+    expect(groups[0]?.title).toBe("bd-9")
+    expect(groups[0]?.epicId).toBe("bd-9")
+  })
+
+  test("hides fully closed epics by default and states exactly what is withheld", () => {
+    const groups = groupTasksByEpic([
+      card("1", "open", { id: "e1", title: "Alpha" }),
+      card("2", "closed", { id: "e2", title: "Beta" }),
+      card("3", "closed", { id: "e2", title: "Beta" }),
+    ], columns)
+    expect(selectVisibleEpicGroups(groups, false)).toMatchObject({ hiddenEpicCount: 1, hiddenTaskCount: 2 })
+    expect(selectVisibleEpicGroups(groups, false).visible.map((group) => group.title)).toEqual(["Alpha"])
+    expect(selectVisibleEpicGroups(groups, true)).toMatchObject({ hiddenEpicCount: 0, hiddenTaskCount: 0 })
+    expect(selectVisibleEpicGroups(groups, true).visible).toHaveLength(2)
+  })
+})

--- a/plugins/tasks/src/front/taskEpicsModel.ts
+++ b/plugins/tasks/src/front/taskEpicsModel.ts
@@ -1,0 +1,140 @@
+import type { BoringTaskCard, BoringTaskColumn } from "../shared"
+
+/** Group key used for the epic that a card has no parent for. */
+export const NO_EPIC_GROUP_KEY = "__no_epic__"
+
+/**
+ * Board columns that mean "this work is finished". Kept id-based (not
+ * adapter-specific) so any source whose config uses one of these ids gets the
+ * active/closed split for free: beads uses `closed`, GitHub Issues uses `done`.
+ */
+const TERMINAL_COLUMN_IDS: ReadonlySet<string> = new Set(["closed", "done", "completed", "cancelled", "canceled", "archived"])
+
+export function isTerminalColumnId(columnId: string): boolean {
+  return TERMINAL_COLUMN_IDS.has(columnId.toLowerCase())
+}
+
+/**
+ * Composite key for a card's epic. Adapter-scoped because two sources can hand
+ * back the same native epic id. Shared by the epic filter and the epics view so
+ * a filter selection and a group always agree on identity.
+ */
+export function epicGroupKey(task: BoringTaskCard): string | undefined {
+  return task.epic ? `${task.adapterId}:${task.epic.id}` : undefined
+}
+
+export interface TaskEpicStatusCount {
+  columnId: string
+  title: string
+  color?: string
+  count: number
+}
+
+export interface TaskEpicGroup {
+  /** Stable identity for expansion state and React keys. */
+  key: string
+  /** Native epic id; absent for the "No epic" group. */
+  epicId?: string
+  title: string
+  url?: string
+  adapterId?: string
+  tasks: BoringTaskCard[]
+  taskCount: number
+  /** Cards in a non-terminal column. */
+  openCount: number
+  /** Cards in a terminal column. */
+  closedCount: number
+  /** An epic is active while at least one of its beads is not terminal. */
+  active: boolean
+  /** Per-column counts, in board column order, omitting empty columns. */
+  statuses: TaskEpicStatusCount[]
+}
+
+interface MutableGroup extends Omit<TaskEpicGroup, "statuses" | "taskCount" | "openCount" | "closedCount" | "active"> {
+  countsByColumn: Map<string, number>
+}
+
+/**
+ * Groups cards by their epic. `columns` only orders and titles the status
+ * breakdown; cards in columns absent from the config still count, under their
+ * raw status id, so nothing silently disappears from a total.
+ */
+export function groupTasksByEpic(
+  tasks: readonly BoringTaskCard[],
+  columns: readonly BoringTaskColumn[],
+): TaskEpicGroup[] {
+  const columnOrder = new Map(columns.map((column, index) => [column.id, index]))
+  const columnById = new Map(columns.map((column) => [column.id, column]))
+  const groups = new Map<string, MutableGroup>()
+
+  for (const task of tasks) {
+    const key = epicGroupKey(task) ?? NO_EPIC_GROUP_KEY
+    let group = groups.get(key)
+    if (!group) {
+      group = key === NO_EPIC_GROUP_KEY
+        ? { key, title: "No epic", tasks: [], countsByColumn: new Map() }
+        : {
+          key,
+          epicId: task.epic?.id,
+          title: task.epic?.title ?? task.epic?.id ?? key,
+          adapterId: task.adapterId,
+          ...(task.epic?.url ? { url: task.epic.url } : {}),
+          tasks: [],
+          countsByColumn: new Map(),
+        }
+      groups.set(key, group)
+    }
+    group.tasks.push(task)
+    group.countsByColumn.set(task.statusId, (group.countsByColumn.get(task.statusId) ?? 0) + 1)
+  }
+
+  const resolved = [...groups.values()].map((group): TaskEpicGroup => {
+    const statuses = [...group.countsByColumn.entries()]
+      .map(([columnId, count]): TaskEpicStatusCount => {
+        const column = columnById.get(columnId)
+        return {
+          columnId,
+          title: column?.title ?? columnId,
+          ...(column?.color ? { color: column.color } : {}),
+          count,
+        }
+      })
+      .sort((a, b) => (columnOrder.get(a.columnId) ?? Number.MAX_SAFE_INTEGER) - (columnOrder.get(b.columnId) ?? Number.MAX_SAFE_INTEGER)
+        || a.title.localeCompare(b.title))
+    const closedCount = statuses.reduce((total, status) => isTerminalColumnId(status.columnId) ? total + status.count : total, 0)
+    const { countsByColumn: _counts, ...rest } = group
+    return {
+      ...rest,
+      statuses,
+      taskCount: group.tasks.length,
+      openCount: group.tasks.length - closedCount,
+      closedCount,
+      active: group.tasks.length - closedCount > 0,
+    }
+  })
+
+  return resolved.sort((a, b) => {
+    if (a.key === NO_EPIC_GROUP_KEY) return 1
+    if (b.key === NO_EPIC_GROUP_KEY) return -1
+    return a.title.localeCompare(b.title)
+  })
+}
+
+export interface TaskEpicVisibility {
+  visible: TaskEpicGroup[]
+  /** Epics withheld by the active-only filter. Always surfaced in the UI. */
+  hiddenEpicCount: number
+  hiddenTaskCount: number
+}
+
+/** Splits grouped epics into what the board shows and what the toggle withholds. */
+export function selectVisibleEpicGroups(groups: readonly TaskEpicGroup[], showClosed: boolean): TaskEpicVisibility {
+  if (showClosed) return { visible: [...groups], hiddenEpicCount: 0, hiddenTaskCount: 0 }
+  const visible = groups.filter((group) => group.active)
+  const hidden = groups.filter((group) => !group.active)
+  return {
+    visible,
+    hiddenEpicCount: hidden.length,
+    hiddenTaskCount: hidden.reduce((total, group) => total + group.taskCount, 0),
+  }
+}


### PR DESCRIPTION
Delivers S5 of the Boring Factory migration epic (gh-1187), which pulls gap **G6**: "see all the active epics and drill down into their beads".

## Today / Delta

**Today.** `BoringTaskCard.epic` already exists and the beads adapter already maps a bead's parent onto it (`beadsSource.ts` `nativeParent`). The board exposes that as a single **epic filter dropdown** plus two flat views (kanban, list). To answer "which epics are active", you pick epics from a `<select>` one at a time — the epic level has no surface of its own, and nothing tells you an epic exists until you open the dropdown.

**Delta.** A third view mode, `epics`: an epics-first list, each epic a collapsible row carrying its counts and status breakdown, expanding to its beads. Active-only by default. No adapter, schema, or route work — this is a view over data the board already loads.

## Design rationale

- **The epic level gets its own rows, not a filter.** Epic identity is the adapter-scoped composite key `${adapterId}:${epic.id}` — the same key the existing filter uses, now exported once from `taskEpicsModel.ts` (`epicGroupKey`) and consumed by both, so a filter selection and a group can never disagree.
- **"Active" is legible, and hiding is never silent.** An epic is active while at least one of its beads sits in a non-terminal column. Terminal is id-based (`closed`, `done`, `completed`, `cancelled`, `archived`) so beads (`closed`) and GitHub Issues (`done`) both get the split with no adapter coupling. The default is active-only, but the Active/All segmented control is always visible and the line beside it always states the exact count withheld — `"3 active · 2 fully closed epics (7 tasks) hidden"`. The empty state says the same thing and names the way back.
- **Every row states its shape before you open it.** Per-column pills in board column order (terminal columns rendered muted) plus an `open/total` badge, so scanning epics is a read, not a click-through. Beads whose status is not in the board config still count, under their raw status id — nothing vanishes from a total.
- **One filter pipeline.** The epics view groups `filteredTasks`, so source multiselect, tag, epic, and column visibility compose unchanged. Turning a column off removes its beads from every epic's counts, which can legitimately move an epic out of the active list — the withheld counter reports that.
- **One card, one dialog.** The list view's `TaskCard` wiring was extracted into a single `renderTaskCard`, shared by both views; clicking a bead in an epic opens the same `TaskDetailDialog`.
- **The board did not grow into a monster.** Pure grouping/aggregation lives in `taskEpicsModel.ts` (mirroring `taskBoardModel.ts`), presentation in `TaskEpicsView.tsx`. `TaskKanbanBoard.tsx` gained ~40 net lines, having also shed the duplicated card block.
- **Accessibility.** Each epic header is a `<button>` inside an `<h3>` with `aria-expanded` and `aria-controls` pointing at its panel; the panel is `hidden` when collapsed. The activity toggle is a labelled `role="group"` with `aria-pressed`; the withheld-count line is `aria-live="polite"`. The view switcher keeps its `aria-label="Task view mode"` pattern and gains a labelled "Show epics view" control. Fully keyboard operable.

## Read-only guarantee

Per plan decision 3, the Tasks panel is a read-only mirror for the whole migration and beads stays canonical. **No write path was added or touched.** The diff is four front files; no adapter, no server source, no route, no tool, no shared type. Grouping is derived at render time from `listTasks()` output. `plugins/tasks/scripts/prove-beads-readonly.mjs` remains the standing proof and is unaffected.

## Test evidence

```
pnpm -C plugins/tasks test
  Test Files  20 passed (20)
       Tests  178 passed (178)     # 162 before, +16 new

pnpm -C plugins/tasks typecheck    # clean
pnpm lint:invariants               # plugin-invariants ok (488 files); all alignment checks PASS
```

New coverage — note nothing previously covered the epic filter or the view switcher at all:

- `taskEpicsModel.test.ts` (8): adapter-scoped key collision, terminal-column recognition, grouping + title ordering with "No epic" pinned last, open/closed counts and activity, status breakdown ordering and colors, statuses absent from the board config, raw-id title fallback, and the active/closed split reporting exactly what it withholds.
- `TaskEpicsView.test.tsx` (8): switching to the epics view and reading counts, the active/closed toggle in both directions, expand/collapse with `aria-expanded`/`aria-controls` verified against a real panel node, keyboard operation from switcher to bead, epic-filter and tag-filter composition, column visibility emptying an epic into the closed set, view-mode persistence across a remount, and opening the shared `TaskDetailDialog` from a bead inside an epic.

## Screenshots / evidence

_Placeholder — owner-facing navigation surface; screenshots to be attached from the S5 proof run (owner navigates active epics → beads and finds S1's lane and its lease state without opening a terminal)._

## UI-review spec

Not added in this PR — see the report/thread for the reasoning and the follow-up recommendation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPPbToGDvkARQZuYKFyWN