### PR TITLE
[gh-1187] fix: hub feeds factory surfaces — addressed sessions in Inbox + beads parent edges

### DIFF
--- a/packages/cli/src/front/App.test.tsx
+++ b/packages/cli/src/front/App.test.tsx
@@ -111,6 +111,9 @@ describe("CliWorkspaceShell", () => {
       workspaceId: "target",
       workspaceLayout: "plugin-tabs",
       workspaceSectionTitle: "Projects",
+      // Fleet-addressed sessions (Inbox opening fleet-seat chats) require the
+      // shipped hub front to opt in — gh-1207.
+      addressedAgentSelection: true,
     })
     expect(window.location.pathname).toBe("/workspace/target")
   })

--- a/packages/cli/src/front/App.tsx
+++ b/packages/cli/src/front/App.tsx
@@ -455,6 +455,7 @@ export function CliWorkspaceShell() {
         workspaceLabel={activeWorkspace.name}
         workspaceSectionTitle="Projects"
         workspaceLayout="plugin-tabs"
+        addressedAgentSelection
         appLeftHeaderMode="workspace"
         appLeftProjects={appLeftProjects}
         appLeftActiveProjectId={activeWorkspace.id}
@@ -511,6 +512,7 @@ export function CliWorkspaceShell() {
       workspaceLabel={projectName}
       workspaceSectionTitle="Project"
       workspaceLayout="plugin-tabs"
+      addressedAgentSelection
       defaultSessionTitle={projectName}
       activeSessionId={initialSessionId ?? undefined}
       chatParams={{ thinkingControl: true }}

--- a/packages/cli/src/server/__tests__/workspacePluginRoutes.test.ts
+++ b/packages/cli/src/server/__tests__/workspacePluginRoutes.test.ts
@@ -36,6 +36,8 @@ const workspace: LocalWorkspace = {
   name: "Workspace",
   path: "/srv/ws-1",
   available: true,
+  createdAt: "2026-08-10T00:00:00.000Z",
+  updatedAt: "2026-08-10T00:00:00.000Z",
   plugins: { tasks: { providers: [{ provider: "beads" }] } },
 } as LocalWorkspace
 

--- a/packages/cli/src/server/__tests__/workspacePluginRoutes.test.ts
+++ b/packages/cli/src/server/__tests__/workspacePluginRoutes.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment node
+
+import fastify from "fastify"
+import { describe, expect, test, vi } from "vitest"
+import { registerWorkspaceTaskRoutes } from "../workspacePluginRoutes.js"
+import type { LocalWorkspace, LocalWorkspaceRegistry } from "../localWorkspaces.js"
+
+const createTaskSourceRegistryFromConfig = vi.fn(() => ({ listSources: () => [] }))
+const disposeBeadsOperations = vi.fn(async () => {})
+const createWorkspaceBeadsOperations = vi.fn(() => ({
+  runRead: vi.fn(async () => ({ stdout: "" })),
+  dispose: disposeBeadsOperations,
+}))
+const createTaskSourceService = vi.fn(() => ({
+  listSources: () => [{ id: "beads:workspace" }],
+  listTasks: async () => ({ tasks: [], errors: {} }),
+}))
+
+vi.mock("@hachej/boring-tasks/server", () => ({
+  createTaskSourceRegistryFromConfig: (...args: unknown[]) => createTaskSourceRegistryFromConfig(...args as []),
+  createWorkspaceBeadsOperations: (...args: unknown[]) => createWorkspaceBeadsOperations(...args as []),
+  createTaskSourceService: (...args: unknown[]) => createTaskSourceService(...args as []),
+}))
+
+const createNodeWorkspace = vi.fn((root: string) => ({ root, runtimeContext: { runtimeCwd: root }, stat: async () => ({ kind: "dir" as const }) }))
+vi.mock("@hachej/boring-sandbox/providers/node-workspace", () => ({
+  createNodeWorkspace: (root: string) => createNodeWorkspace(root),
+}))
+
+function registryWith(workspace: LocalWorkspace): LocalWorkspaceRegistry {
+  return { get: async (id: string) => (id === workspace.id ? workspace : undefined) } as unknown as LocalWorkspaceRegistry
+}
+
+const workspace: LocalWorkspace = {
+  id: "ws-1",
+  name: "Workspace",
+  path: "/srv/ws-1",
+  available: true,
+  plugins: { tasks: { providers: [{ provider: "beads" }] } },
+} as LocalWorkspace
+
+describe("workspace task routes beads wiring", () => {
+  test("passes cached beads operations to the task source registry and disposes on close", async () => {
+    const app = fastify()
+    await registerWorkspaceTaskRoutes(app, registryWith(workspace))
+
+    const first = await app.inject({
+      method: "POST",
+      url: "/api/boring-tasks/sources/tasks/list",
+      headers: { "x-boring-workspace-id": "ws-1" },
+      payload: {},
+    })
+    expect(first.statusCode).toBe(200)
+    expect(createTaskSourceRegistryFromConfig).toHaveBeenLastCalledWith(
+      workspace.plugins?.tasks,
+      expect.objectContaining({
+        workspaceRoot: "/srv/ws-1",
+        beadsOperations: expect.objectContaining({ runRead: expect.any(Function) }),
+      }),
+    )
+    expect(createNodeWorkspace).toHaveBeenCalledWith("/srv/ws-1")
+
+    // A second request reuses the pinned operations instead of re-creating them.
+    await app.inject({ method: "GET", url: "/api/boring-tasks/sources", headers: { "x-boring-workspace-id": "ws-1" } })
+    expect(createWorkspaceBeadsOperations).toHaveBeenCalledTimes(1)
+
+    await app.close()
+    expect(disposeBeadsOperations).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/cli/src/server/workspacePluginRoutes.ts
+++ b/packages/cli/src/server/workspacePluginRoutes.ts
@@ -89,9 +89,38 @@ function isPluginConfig(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value)
 }
 
-async function createWorkspaceTaskService(workspace: LocalWorkspace) {
+type TasksServerModule = typeof import("@hachej/boring-tasks/server")
+type BeadsOperations = import("@hachej/boring-tasks/server").BeadsOperations
+
+/**
+ * Per-workspace-root Beads read operations. Cached because each instance pins
+ * runtime file descriptors; disposed together when the hub shuts down.
+ */
+function createBeadsOperationsCache() {
+  const byRoot = new Map<string, BeadsOperations>()
+  return {
+    async get(tasks: TasksServerModule, workspaceRoot: string): Promise<BeadsOperations> {
+      const cached = byRoot.get(workspaceRoot)
+      if (cached) return cached
+      const { createNodeWorkspace } = await import("@hachej/boring-sandbox/providers/node-workspace")
+      const operations = tasks.createWorkspaceBeadsOperations(createNodeWorkspace(workspaceRoot))
+      byRoot.set(workspaceRoot, operations)
+      return operations
+    },
+    async dispose(): Promise<void> {
+      const operations = [...byRoot.values()]
+      byRoot.clear()
+      await Promise.allSettled(operations.map((entry) => entry.dispose?.()))
+    },
+  }
+}
+
+async function createWorkspaceTaskService(workspace: LocalWorkspace, beadsCache: ReturnType<typeof createBeadsOperationsCache>) {
   const tasks = await import("@hachej/boring-tasks/server")
-  const registry = tasks.createTaskSourceRegistryFromConfig(workspace.plugins?.tasks, { workspaceRoot: workspace.path })
+  const registry = tasks.createTaskSourceRegistryFromConfig(workspace.plugins?.tasks, {
+    workspaceRoot: workspace.path,
+    beadsOperations: await beadsCache.get(tasks, workspace.path),
+  })
   return tasks.createTaskSourceService(registry)
 }
 
@@ -125,11 +154,13 @@ export async function registerWorkspaceTaskRoutes(app: FastifyInstance, registry
   const workspaceFromRequest = async (request: { headers?: Record<string, unknown>; query?: unknown }) => {
     return await requireWorkspace(registry, resolveWorkspaceIdFromRequest(request))
   }
+  const beadsCache = createBeadsOperationsCache()
+  app.addHook("onClose", async () => beadsCache.dispose())
 
   app.get("/api/boring-tasks/sources", async (request, reply) => {
     try {
       const workspace = await workspaceFromRequest(request)
-      const service = await createWorkspaceTaskService(workspace)
+      const service = await createWorkspaceTaskService(workspace, beadsCache)
       return { ok: true, sources: service.listSources() }
     } catch (cause) {
       return reply.status(taskStatusFor(cause)).send(taskResponseError(cause))
@@ -140,7 +171,7 @@ export async function registerWorkspaceTaskRoutes(app: FastifyInstance, registry
     try {
       const workspace = await workspaceFromRequest(request)
       const body = request.body === undefined ? {} : taskBodyObject(request.body)
-      const service = await createWorkspaceTaskService(workspace)
+      const service = await createWorkspaceTaskService(workspace, beadsCache)
       return { ok: true, ...(await service.listTasks({ workspaceId: workspace.id, workspaceRoot: workspace.path }, { sourceIds: taskStringArray(body.sourceIds) })) }
     } catch (cause) {
       return reply.status(taskStatusFor(cause)).send(taskResponseError(cause))
@@ -151,7 +182,7 @@ export async function registerWorkspaceTaskRoutes(app: FastifyInstance, registry
     try {
       const workspace = await workspaceFromRequest(request)
       const body = taskBodyObject(request.body)
-      const service = await createWorkspaceTaskService(workspace)
+      const service = await createWorkspaceTaskService(workspace, beadsCache)
       const task = await service.moveTask({ workspaceId: workspace.id, workspaceRoot: workspace.path }, {
         sourceId: taskRequiredString(body, "sourceId"),
         taskId: taskRequiredString(body, "taskId"),

--- a/plugins/tasks/src/server/beadsOperations.ts
+++ b/plugins/tasks/src/server/beadsOperations.ts
@@ -41,6 +41,8 @@ export interface BeadsWorkspaceAuthority {
 const LIST_ARGS = ["list", "--all", "--json", "--no-auto-flush", "--no-auto-import", "--no-db"] as const
 const SHOW_PREFIX = ["show", "--json", "--no-auto-flush", "--no-auto-import", "--no-db", "--"] as const
 const BEAD_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$/
+/** Maximum bead IDs accepted by one pinned `br show` invocation. */
+export const BEADS_SHOW_BATCH_LIMIT = 100
 const REQUIRED_STORE_FILES = ["issues.jsonl", "metadata.json", "config.yaml"] as const
 
 export function isValidBeadId(value: string): boolean {
@@ -50,10 +52,13 @@ export function isValidBeadId(value: string): boolean {
 export function isAllowedBeadsReadArgs(args: readonly string[]): boolean {
   if (args.length === 1 && args[0] === "--version") return true
   if (args.length === LIST_ARGS.length && LIST_ARGS.every((value, index) => args[index] === value)) return true
-  return args.length === SHOW_PREFIX.length + 1
+  // `show` accepts a bounded batch of IDs so the list view can hydrate
+  // parent/epic edges without one process spawn per bead.
+  const ids = args.slice(SHOW_PREFIX.length)
+  return ids.length >= 1
+    && ids.length <= BEADS_SHOW_BATCH_LIMIT
     && SHOW_PREFIX.every((value, index) => args[index] === value)
-    && typeof args[SHOW_PREFIX.length] === "string"
-    && isValidBeadId(args[SHOW_PREFIX.length]!)
+    && ids.every((id) => typeof id === "string" && isValidBeadId(id))
 }
 
 function isInside(root: string, target: string): boolean {

--- a/plugins/tasks/src/server/beadsSource.test.ts
+++ b/plugins/tasks/src/server/beadsSource.test.ts
@@ -73,6 +73,79 @@ describe("Beads task source", () => {
     expect(ops.runRead).toHaveBeenNthCalledWith(3, listArgs, expect.any(Object))
   })
 
+  test("hydrates parent/epic edges with a batched show call when list carries only dependency_count", async () => {
+    // Recorded br 0.2.16 behavior: `br list --json` ships dependency_count but
+    // never the dependency edges; `br show --json` ships them with
+    // dependency_type. See gh-1208.
+    const ops = withVersion((args) => {
+      if (args[0] === "list") {
+        return JSON.stringify({
+          issues: [
+            { id: "epic-1", title: "Epic bead", status: "open", issue_type: "epic", dependency_count: 0, dependent_count: 2 },
+            { id: "child-1", title: "Child with parent", status: "open", dependency_count: 1, dependent_count: 0 },
+            { id: "child-2", title: "Child with blocker only", status: "open", dependency_count: 1, dependent_count: 0 },
+            { id: "loner", title: "No edges", status: "open", dependency_count: 0, dependent_count: 0 },
+          ],
+        })
+      }
+      expect(args).toEqual([...showArgs("child-1").slice(0, -1), "child-1", "child-2"])
+      return JSON.stringify([
+        {
+          id: "child-1",
+          title: "Child with parent",
+          status: "open",
+          dependencies: [{ id: "epic-1", title: "Epic bead", status: "open", dependency_type: "parent-child" }],
+        },
+        {
+          id: "child-2",
+          title: "Child with blocker only",
+          status: "open",
+          dependencies: [{ id: "loner", title: "No edges", status: "open", dependency_type: "blocks" }],
+        },
+      ])
+    })
+    const source = createBeadsTaskSource({ operations: ops })
+
+    const cards = await source.listTasks({})
+
+    expect(cards.map((card) => [card.id, card.epic])).toEqual([
+      ["epic-1", undefined],
+      ["child-1", { id: "epic-1", title: "Epic bead" }],
+      ["child-2", undefined],
+      ["loner", undefined],
+    ])
+    // One list call plus exactly one batched show call.
+    expect(ops.runRead.mock.calls.filter(([args]) => args[0] === "show")).toHaveLength(1)
+  })
+
+  test("chunks parent-edge hydration and tolerates missing show entries", async () => {
+    const ids = Array.from({ length: 150 }, (_, index) => `bead-${index}`)
+    const showCalls: number[] = []
+    const ops = withVersion((args) => {
+      if (args[0] === "list") {
+        return JSON.stringify({
+          issues: ids.map((id) => ({ id, title: id, status: "open", dependency_count: 1 })),
+        })
+      }
+      const requested = args.slice(showArgs("x").length - 1)
+      showCalls.push(requested.length)
+      // First requested bead of each chunk is missing from the show output.
+      return JSON.stringify(requested.slice(1).map((id) => ({
+        id,
+        title: String(id),
+        status: "open",
+        dependencies: [{ id: "epic-1", title: "Epic bead", dependency_type: "parent-child" }],
+      })))
+    })
+    const source = createBeadsTaskSource({ operations: ops })
+
+    const cards = await source.listTasks({})
+
+    expect(showCalls).toEqual([100, 50])
+    expect(cards.filter((card) => card.epic).length).toBe(148)
+    expect(cards[0]?.epic).toBeUndefined()
+  })
+
   test("maps bounded detail, safe metadata, and native relations", async () => {
     const id = "root.4"
     const ops = withVersion((args) => {
@@ -217,7 +290,11 @@ describe("Beads read authority and config", () => {
     expect(isAllowedBeadsReadArgs(showArgs("root.1"))).toBe(true)
     expect(isAllowedBeadsReadArgs(["close", "root.1"])).toBe(false)
     expect(isAllowedBeadsReadArgs(["show", "--json", "--", "--db=x"])).toBe(false)
-    expect(isAllowedBeadsReadArgs([...showArgs("root.1"), "extra"])).toBe(false)
+    expect(isAllowedBeadsReadArgs([...showArgs("root.1"), "root.2"])).toBe(true)
+    expect(isAllowedBeadsReadArgs([...showArgs("root.1"), ...Array.from({ length: 99 }, (_, index) => `root.${index + 2}`)])).toBe(true)
+    expect(isAllowedBeadsReadArgs([...showArgs("root.1"), ...Array.from({ length: 100 }, (_, index) => `root.${index + 2}`)])).toBe(false)
+    expect(isAllowedBeadsReadArgs([...showArgs("root.1"), "--db=x"])).toBe(false)
+    expect(isAllowedBeadsReadArgs(showArgs("root.1").slice(0, -1))).toBe(false)
   })
 
   test("rejects an uninitialized Workspace without creating store files", async () => {

--- a/plugins/tasks/src/server/beadsSource.ts
+++ b/plugins/tasks/src/server/beadsSource.ts
@@ -7,7 +7,7 @@ import {
   type BoringTaskMetadataItem,
   type BoringTaskRelation,
 } from "../shared"
-import { BeadsOperationError, isValidBeadId, type BeadsOperations } from "./beadsOperations"
+import { BEADS_SHOW_BATCH_LIMIT, BeadsOperationError, isValidBeadId, type BeadsOperations } from "./beadsOperations"
 import type { BoringTaskSourceRuntime } from "./sourceRuntime"
 import { TaskDetailValidationError, validateTaskDetail } from "./taskDtoValidation"
 import { TaskSourceServiceError } from "./taskSourceService"
@@ -260,6 +260,42 @@ function mapDetail(raw: unknown): BoringTaskDetail {
   }
 }
 
+/**
+ * `br list --json` carries only `dependency_count` — never the dependency
+ * edges themselves — so parent/epic assignment (`nativeParent`) would always
+ * be empty from the list call alone. Hydrate the edges with batched pinned
+ * `br show` calls, restricted to issues that report at least one dependency
+ * and that the list call did not already ship edges for.
+ */
+async function fetchDependencyEdges(
+  operations: BeadsOperations | undefined,
+  issues: readonly Record<string, unknown>[],
+): Promise<Map<string, unknown>> {
+  const edges = new Map<string, unknown>()
+  const ids = issues
+    .filter((issue) =>
+      issue.dependencies === undefined
+      && typeof issue.id === "string"
+      && isValidBeadId(issue.id)
+      && Number.isSafeInteger(issue.dependency_count)
+      && (issue.dependency_count as number) > 0)
+    .map((issue) => issue.id as string)
+  for (let start = 0; start < ids.length; start += BEADS_SHOW_BATCH_LIMIT) {
+    const chunk = ids.slice(start, start + BEADS_SHOW_BATCH_LIMIT)
+    const parsed = parseJson(
+      await read(operations, ["show", "--json", "--no-auto-flush", "--no-auto-import", "--no-db", "--", ...chunk], LIST_LIMITS),
+      LIST_LIMITS.maxOutputBytes,
+    )
+    if (!Array.isArray(parsed)) throw serviceError("TASK_BEADS_INVALID_RESPONSE", "Beads returned an invalid show response.")
+    for (const raw of parsed) {
+      const issue = record(raw, "issue")
+      const id = requiredString(issue.id, "issue.id", 256)
+      if (issue.dependencies !== undefined && issue.dependencies !== null) edges.set(id, issue.dependencies)
+    }
+  }
+  return edges
+}
+
 async function read(operations: BeadsOperations | undefined, args: readonly string[], limits: typeof VERSION_LIMITS | typeof LIST_LIMITS | typeof DETAIL_LIMITS): Promise<string> {
   if (!operations) throw serviceError("TASK_BEADS_RUNTIME_UNAVAILABLE", "Beads is unavailable in this Workspace runtime.")
   try {
@@ -300,9 +336,12 @@ export function createBeadsTaskSource(options: { operations?: BeadsOperations; s
       const parsed = parseJson(await read(options.operations, ["list", "--all", "--json", "--no-auto-flush", "--no-auto-import", "--no-db"], LIST_LIMITS), LIST_LIMITS.maxOutputBytes)
       const root = record(parsed, "list response")
       if (!Array.isArray(root.issues)) throw serviceError("TASK_BEADS_INVALID_RESPONSE", "Beads returned an invalid list response.")
+      const issues = root.issues.map((issue) => record(issue, "issue"))
+      const edges = await fetchDependencyEdges(options.operations, issues)
       const seen = new Set<string>()
-      return root.issues.map((issue) => {
-        const card = mapCard(issue)
+      return issues.map((issue) => {
+        const dependencies = typeof issue.id === "string" ? edges.get(issue.id) : undefined
+        const card = mapCard(issue.dependencies === undefined && dependencies !== undefined ? { ...issue, dependencies } : issue)
         if (seen.has(card.id)) throw serviceError("TASK_BEADS_DUPLICATE_ID", "Beads returned duplicate issue IDs.")
         seen.add(card.id)
         return { ...card, adapterId: sourceId }


### PR DESCRIPTION
Fixes #1207, fixes #1208. Both fixes make the shipped CLI hub actually feed the factory surfaces (M1).

## gh-1207 — CLI front never passed `addressedAgentSelection`
The workspace app fronts (full-app, playground) opt into fleet-addressed sessions, but `packages/cli/src/front/App.tsx` never passed the prop, so the shipped hub had no UI path to fleet-seat sessions and the Inbox could not open a seat's `ask_user` gate (attention blockers for unknown sessions are pruned — `WorkspaceAttentionProvider.blockerBelongsToKnownSession`). Both `WorkspaceAgentFront` compositions now pass `addressedAgentSelection`.

## gh-1208 B1 — beads adapter list carries no parent/epic edges
`br list --json` (br 0.2.16) ships only `dependency_count`, never the dependency edges, so `nativeParent()` was always empty and every card fell into one "No epic" bucket. `listTasks` now hydrates edges with batched pinned `br show` calls, restricted to beads that report `dependency_count > 0` and chunked at 100 IDs. The read-argv pin (`isAllowedBeadsReadArgs`) is extended deliberately: `show` accepts 1..100 valid bead IDs (each still `isValidBeadId`-checked; option injection still rejected). Tests use recorded br 0.2.16 output shapes (list without edges, show with `dependency_type: parent-child`).

## gh-1208 B2 — hub route never wired `beadsOperations`
`packages/cli/src/server/workspacePluginRoutes.ts` called `createTaskSourceRegistryFromConfig` without `beadsOperations`, so beads tasks could never load in the shipped hub. The task routes now build pinned workspace Beads operations per workspace root (cached — each instance pins runtime FDs — and disposed on server close).

## Deep test in the running factory hub (127.0.0.1:5210, workspace factory-080c4903)
- Fleet roster (`default`, `boring-triage`, `boring-orchestrator`, `boring-worker`) renders in the left rail with per-seat sessions; a `boring-worker` session was opened from the UI.
- A real `ask_user` gate raised in that worker session appeared in the Inbox (badge + question row), was opened from the Inbox and answered there; the seat resumed ("Answer submitted" → agent continued) and the Inbox drained to zero.
- `POST /api/boring-tasks/sources/tasks/list` against the real graph: 226 tasks, **161 with a populated epic** (matching the 161 parent-child edges in #1208); the Tasks board renders them with 19 real epics in the epic filter.
- Environment note: hub session creation was blocked for *any* build by symlinked global skills (`~/.agents/skills/devops-manage-google-workspace`, `~/.pi/agent/skills/*` → `PATH_SYMLINK_ESCAPE`, surfaced as `AGENT_REQUEST_OUTCOME_UNKNOWN`). Verified pre-existing with the previous hub dist; worked around for evidence by running the hub with a shadow `HOME` containing materialized (symlink-free) copies. Worth a follow-up issue.

Pre-existing/environmental CI-adjacent failures observed locally (untouched areas): `folderModeRuntimePlugins.test.ts` (workspace dist import), `cli.integration` hook timeout, one Playwright browser spec — none touch this diff; CI is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPPbToGDvkARQZuYKFyWN