### PR TITLE
[epic #1110] fix(workspace): single-agent left pane renders flat Chats list (no fleet chrome)

### DIFF
--- a/apps/workspace-playground/package.json
+++ b/apps/workspace-playground/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build:deps": "pnpm --filter @hachej/boring-ui-kit build && pnpm --filter @hachej/boring-ui-plugin-cli build && pnpm --filter @hachej/boring-sandbox build && pnpm --filter @hachej/boring-bash build && pnpm --filter @hachej/boring-agent build && pnpm --filter @hachej/boring-workspace build && pnpm --filter @hachej/boring-core build && pnpm --filter @hachej/boring-deck build && pnpm --filter @hachej/boring-ask-user build && pnpm --filter @hachej/boring-tasks build && pnpm --filter @hachej/boring-diagram build && pnpm --filter @hachej/boring-data-explorer build && pnpm --filter @hachej/boring-data-catalog build",
     "dev": "pnpm run build:deps && vite",
+    "dev:multiagent": "VITE_BORING_FACTORY_AGENTS=1 pnpm run dev",
     "build": "pnpm run build:deps && vite build",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -8,6 +8,7 @@ import { diagramPlugin } from "@hachej/boring-diagram/front"
 import { createTasksPlugin } from "@hachej/boring-tasks/front"
 import { SHOWCASE_SESSION_ID, seedShowcase } from "./showcaseMessages"
 import { LoadingStatesShowcase, type LoadingStateMode } from "./LoadingStatesShowcase"
+import { SCRIPTED_DEFAULT_AGENT_TYPE_ID } from "../shared/playgroundAgents"
 
 function isShowcaseRoute(): boolean {
   if (typeof window === "undefined") return false
@@ -151,7 +152,7 @@ function WorkspaceFullPageShell() {
 
   return (
     <WorkspaceProvider
-      agentTypeId="default"
+      agentTypeId={factoryAgentsEnabled() ? "boring-concierge" : SCRIPTED_DEFAULT_AGENT_TYPE_ID}
       apiBaseUrl=""
       plugins={workspacePlugins}
       persistenceEnabled
@@ -171,7 +172,7 @@ export function WorkspaceShell() {
   const fullPage = useMemo(isFullPageRoute, [])
   const multiFilesystem = useMemo(isMultiFilesystemPlaygroundRoute, [])
   const factoryAgents = useMemo(factoryAgentsEnabled, [])
-  const defaultAgentTypeId = factoryAgents ? "boring-concierge" : "default"
+  const defaultAgentTypeId = factoryAgents ? "boring-concierge" : SCRIPTED_DEFAULT_AGENT_TYPE_ID
   const [projectName, setProjectName] = useState("Workspace")
   const [workspaceId, setWorkspaceId] = useState("Workspace")
   const [metaLoaded, setMetaLoaded] = useState(showcase || fullPage)
@@ -180,7 +181,7 @@ export function WorkspaceShell() {
   const sessions = showcase ? showcaseSessions : undefined
   const liveShowcaseSessionIds = useRef(new Set<string>())
   const createShowcaseSession = useCallback(async () => {
-    const response = await fetch("/api/v1/agents/default/sessions", {
+    const response = await fetch(`/api/v1/agents/${encodeURIComponent(defaultAgentTypeId)}/sessions`, {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -193,7 +194,7 @@ export function WorkspaceShell() {
     if (!payload.sessionId) throw new Error("showcase session create returned no session id")
     const session = {
       id: payload.sessionId,
-      agentTypeId: payload.agentTypeId ?? "default",
+      agentTypeId: payload.agentTypeId ?? defaultAgentTypeId,
       title: "New chat",
       updatedAt: Date.now(),
     }
@@ -201,7 +202,7 @@ export function WorkspaceShell() {
     setShowcaseSessions((current) => [...current, session])
     setShowcaseActiveSessionId(session.id)
     return session
-  }, [])
+  }, [defaultAgentTypeId])
   const renameShowcaseSession = useCallback((sessionId: string, title: string) => {
     setShowcaseSessions((current) => current.map((session) => (
       session.id === sessionId ? { ...session, title, updatedAt: Date.now() } : session

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -6,6 +6,8 @@ import { createReadonlyProjectionOperations } from "@hachej/boring-bash/server"
 import { createNodeWorkspace } from "@hachej/boring-sandbox/providers/node-workspace"
 import { createPersistedScriptedPiHarness } from "./testing/scriptedPiHarness"
 import {
+  SCRIPTED_ONE_AGENT,
+  SCRIPTED_ONE_AGENT_CAPABILITY_PLUGINS,
   SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS,
   SCRIPTED_TWO_AGENT_DEFAULT,
   SCRIPTED_TWO_AGENT_FLEET,
@@ -13,6 +15,7 @@ import {
 import { createWorkspaceAgentServer } from "@hachej/boring-workspace/app/server"
 import { createWorkspaceBeadsOperations } from "@hachej/boring-tasks/server"
 import { loadBoringFactoryAgents } from "./factoryAgents"
+import { resolvePlaygroundAgentMode } from "./playgroundAgentMode"
 
 export const AGENT_API_PORT = Number(process.env.AGENT_API_PORT) || 5210
 export const VITE_PORT = Number(process.env.PORT) || 5200
@@ -64,11 +67,16 @@ export async function startPlaygroundServer(): Promise<void> {
       ? undefined
       : createWorkspaceBeadsOperations(createNodeWorkspace(workspaceRoot))
     const localRuntimeMode = process.env.BORING_AGENT_MODE?.trim() === "direct" ? "direct" : "local"
-    const factoryAgentsEnabled = process.env.VITE_BORING_FACTORY_AGENTS === "1"
+    const agentMode = resolvePlaygroundAgentMode(process.env)
     // Same `workspaceRoot` value that is handed to createWorkspaceAgentServer
     // below: the fleet's instruction refs are addressed against the filesystem
     // this server actually serves, so they resolve or are not published.
-    const factoryAgents = factoryAgentsEnabled ? await loadBoringFactoryAgents({ workspaceRoot }) : undefined
+    const factoryAgents = agentMode === "factory" ? await loadBoringFactoryAgents({ workspaceRoot }) : undefined
+    const scriptedAgents = agentMode === "scripted-multi" ? SCRIPTED_TWO_AGENT_FLEET : SCRIPTED_ONE_AGENT
+    const agents = factoryAgents ?? scriptedAgents
+    const scriptedCapabilityPlugins = agentMode === "scripted-multi"
+      ? SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS
+      : agentMode === "scripted-single" ? SCRIPTED_ONE_AGENT_CAPABILITY_PLUGINS : []
     const multiFilesystemPlayground = process.env.BORING_WORKSPACE_PLAYGROUND_MULTI_FS === "1" || process.env.VITE_PLAYGROUND_MULTI_FS === "1"
     const companyContextRoot = resolve(process.env.BORING_WORKSPACE_PLAYGROUND_COMPANY_CONTEXT_ROOT || workspaceRoot)
     if (multiFilesystemPlayground) mkdirSync(companyContextRoot, { recursive: true })
@@ -87,15 +95,10 @@ export async function startPlaygroundServer(): Promise<void> {
       // Explicit so the playground exercises the same `.agents` protection
       // production hosts get, instead of relying on the library default.
       readonlyWorkspacePaths: [".agents"],
-      ...(factoryAgents ? { agents: factoryAgents, defaultAgentTypeId: "boring-concierge" } : {}),
+      agents,
+      defaultAgentTypeId: agentMode === "factory" ? "boring-concierge" : SCRIPTED_TWO_AGENT_DEFAULT,
       externalPlugins: EXTERNAL_PLUGINS_ENABLED,
-      ...(process.env.BORING_AGENT_E2E_SCRIPTED_PI === "1"
-        ? {
-            harnessFactory: createPersistedScriptedPiHarness,
-            agents: SCRIPTED_TWO_AGENT_FLEET,
-            defaultAgentTypeId: SCRIPTED_TWO_AGENT_DEFAULT,
-          }
-        : {}),
+      ...(agentMode === "factory" ? {} : { harnessFactory: createPersistedScriptedPiHarness }),
       plugins: [
         {
           dir: resolve(APP_ROOT, "../../plugins/tasks"),
@@ -105,9 +108,7 @@ export async function startPlaygroundServer(): Promise<void> {
           },
           trust: "internal",
         },
-        ...(process.env.BORING_AGENT_E2E_SCRIPTED_PI === "1"
-          ? SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS
-          : []),
+        ...scriptedCapabilityPlugins,
       ],
       defaultPluginPackages: ["@hachej/boring-ask-user", "@hachej/boring-diagram"],
       getFilesystemBindings: multiFilesystemPlayground

--- a/apps/workspace-playground/src/server/playgroundAgentMode.test.ts
+++ b/apps/workspace-playground/src/server/playgroundAgentMode.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+import { resolvePlaygroundAgentMode } from "./playgroundAgentMode"
+import { SCRIPTED_ONE_AGENT, SCRIPTED_TWO_AGENT_FLEET } from "./testing/twoAgentFleet"
+
+describe("workspace playground agent mode", () => {
+  it("defaults to exactly one scripted agent", () => {
+    expect(resolvePlaygroundAgentMode({})).toBe("scripted-single")
+    expect(SCRIPTED_ONE_AGENT).toEqual([SCRIPTED_TWO_AGENT_FLEET[0]])
+    expect(SCRIPTED_ONE_AGENT).toHaveLength(1)
+  })
+
+  it("keeps the two-agent scripted fleet available for e2e coverage", () => {
+    expect(resolvePlaygroundAgentMode({ BORING_AGENT_E2E_SCRIPTED_PI: "1" })).toBe("scripted-multi")
+    expect(SCRIPTED_TWO_AGENT_FLEET).toHaveLength(2)
+  })
+
+  it("routes the named multi-agent dev script to the factory fleet", () => {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(import.meta.dirname, "../../package.json"), "utf8"),
+    ) as { scripts: Record<string, string> }
+
+    expect(packageJson.scripts.dev).toBe("pnpm run build:deps && vite")
+    expect(packageJson.scripts["dev:multiagent"]).toBe("VITE_BORING_FACTORY_AGENTS=1 pnpm run dev")
+    expect(resolvePlaygroundAgentMode({ VITE_BORING_FACTORY_AGENTS: "1" })).toBe("factory")
+  })
+})

--- a/apps/workspace-playground/src/server/playgroundAgentMode.test.ts
+++ b/apps/workspace-playground/src/server/playgroundAgentMode.test.ts
@@ -2,13 +2,20 @@ import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { describe, expect, it } from "vitest"
 import { resolvePlaygroundAgentMode } from "./playgroundAgentMode"
-import { SCRIPTED_ONE_AGENT, SCRIPTED_TWO_AGENT_FLEET } from "./testing/twoAgentFleet"
+import { SCRIPTED_DEFAULT_AGENT_TYPE_ID } from "../shared/playgroundAgents"
+import {
+  SCRIPTED_ONE_AGENT,
+  SCRIPTED_TWO_AGENT_DEFAULT,
+  SCRIPTED_TWO_AGENT_FLEET,
+} from "./testing/twoAgentFleet"
 
 describe("workspace playground agent mode", () => {
   it("defaults to exactly one scripted agent", () => {
     expect(resolvePlaygroundAgentMode({})).toBe("scripted-single")
     expect(SCRIPTED_ONE_AGENT).toEqual([SCRIPTED_TWO_AGENT_FLEET[0]])
     expect(SCRIPTED_ONE_AGENT).toHaveLength(1)
+    expect(SCRIPTED_ONE_AGENT[0].agentTypeId).toBe(SCRIPTED_DEFAULT_AGENT_TYPE_ID)
+    expect(SCRIPTED_TWO_AGENT_DEFAULT).toBe(SCRIPTED_DEFAULT_AGENT_TYPE_ID)
   })
 
   it("keeps the two-agent scripted fleet available for e2e coverage", () => {

--- a/apps/workspace-playground/src/server/playgroundAgentMode.ts
+++ b/apps/workspace-playground/src/server/playgroundAgentMode.ts
@@ -1,0 +1,9 @@
+export type PlaygroundAgentMode = "scripted-single" | "scripted-multi" | "factory"
+
+export function resolvePlaygroundAgentMode(
+  env: Readonly<Record<string, string | undefined>>,
+): PlaygroundAgentMode {
+  if (env.VITE_BORING_FACTORY_AGENTS === "1") return "factory"
+  if (env.BORING_AGENT_E2E_SCRIPTED_PI === "1") return "scripted-multi"
+  return "scripted-single"
+}

--- a/apps/workspace-playground/src/server/testing/twoAgentFleet.ts
+++ b/apps/workspace-playground/src/server/testing/twoAgentFleet.ts
@@ -1,4 +1,5 @@
 import type { AgentHostAgentSpec } from "@hachej/boring-agent/server"
+import { SCRIPTED_DEFAULT_AGENT_TYPE_ID } from "../../shared/playgroundAgents"
 
 function capabilityTool(name: string) {
   return {
@@ -26,7 +27,7 @@ export const SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS = [
 
 export const SCRIPTED_TWO_AGENT_FLEET = [
   {
-    agentTypeId: "alpha",
+    agentTypeId: SCRIPTED_DEFAULT_AGENT_TYPE_ID,
     definition: {
       label: "Alpha",
       instructions: "You are the Alpha scripted workspace-playground agent.",
@@ -45,7 +46,7 @@ export const SCRIPTED_TWO_AGENT_FLEET = [
   },
 ] as const satisfies readonly AgentHostAgentSpec[]
 
-export const SCRIPTED_TWO_AGENT_DEFAULT = "alpha"
+export const SCRIPTED_TWO_AGENT_DEFAULT = SCRIPTED_DEFAULT_AGENT_TYPE_ID
 
 export const SCRIPTED_ONE_AGENT = [SCRIPTED_TWO_AGENT_FLEET[0]] as const satisfies readonly AgentHostAgentSpec[]
 export const SCRIPTED_ONE_AGENT_CAPABILITY_PLUGINS = [SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS[0]] as const

--- a/apps/workspace-playground/src/server/testing/twoAgentFleet.ts
+++ b/apps/workspace-playground/src/server/testing/twoAgentFleet.ts
@@ -46,3 +46,6 @@ export const SCRIPTED_TWO_AGENT_FLEET = [
 ] as const satisfies readonly AgentHostAgentSpec[]
 
 export const SCRIPTED_TWO_AGENT_DEFAULT = "alpha"
+
+export const SCRIPTED_ONE_AGENT = [SCRIPTED_TWO_AGENT_FLEET[0]] as const satisfies readonly AgentHostAgentSpec[]
+export const SCRIPTED_ONE_AGENT_CAPABILITY_PLUGINS = [SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS[0]] as const

--- a/apps/workspace-playground/src/shared/playgroundAgents.ts
+++ b/apps/workspace-playground/src/shared/playgroundAgents.ts
@@ -1,0 +1,2 @@
+/** Keep the browser's initial provider aligned with the scripted server roster. */
+export const SCRIPTED_DEFAULT_AGENT_TYPE_ID = "alpha"

--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -1132,6 +1132,14 @@ export function WorkspaceAgentFront<
       && !pendingRemoteActiveSessionId,
   )
   const remoteSessionsTransitioning = remoteSessionsInitialLoading || remoteEmptySessionsSettling || remoteInitialSessionCreating || remoteInitialSessionNeeded
+  // A persisted chat pane can render while its list inventory is still
+  // resolving. Keep that shell available, but do not mistake the temporary
+  // empty inventory for an authoritative empty list in app-left navigation.
+  const remoteSessionInventoryLoading = remoteSessionsTransitioning || Boolean(
+    remoteSessionsPending
+      && !remoteSessionsHaveStaleData
+      && !remoteSessionApi.error,
+  )
 
   useEffect(() => {
     if (!remoteEmptySessionsSettling) {
@@ -2681,7 +2689,7 @@ export function WorkspaceAgentFront<
           addressedAgentTypeId={fleetModeEnabled ? effectiveAgentTypeId : undefined}
           onSelectAgent={fleetModeEnabled ? setNewChatAgentTypeIdOverride : undefined}
           onOpenAgentSettings={fleetModeEnabled ? (ownerAgentTypeId) => setLeftOverlay(agentOverlayId(ownerAgentTypeId)) : undefined}
-          sessionsLoading={remoteSessionsTransitioning}
+          sessionsLoading={remoteSessionInventoryLoading}
           activeSessionRef={activeChatPaneRef}
           muteActiveSession={Boolean(leftOverlay)}
           openSessionRefs={openChatPaneRefs}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -1460,14 +1460,19 @@ describe("WorkspaceAgentFront", () => {
       }
     }
     const useFleetSessions: UseWorkspaceAgentSessions = (options) => {
+      const [loading, setLoading] = useState(true)
+      useEffect(() => {
+        const timer = setTimeout(() => setLoading(false), 10)
+        return () => clearTimeout(timer)
+      }, [])
       const session = { id: `${options.agentTypeId}-one`, agentTypeId: options.agentTypeId, title: options.agentTypeId }
       return {
         sourceIdentity: options.sourceIdentity,
-        sessions: [session],
-        loading: false,
-        activeSessionId: session.id,
+        sessions: loading ? [] : [session],
+        loading,
+        activeSessionId: loading ? null : session.id,
         activeSessionAgentTypeId: options.agentTypeId,
-        activeSession: session,
+        activeSession: loading ? null : session,
         switch: vi.fn(),
         create: vi.fn(),
         delete: vi.fn(),
@@ -1479,15 +1484,20 @@ describe("WorkspaceAgentFront", () => {
         workspaceId="async-fleet-restore"
         workspaceLayout="plugin-tabs"
         chatPanel={SessionIdChatPanel}
+        sessions={[]}
         addressedAgentSelection
         useAddressedAgentSelection={useAsyncFleetSelection}
         useSessions={useFleetSessions}
       />,
     )
 
+    expect(screen.getByRole("status", { name: "Loading chats" })).toBeInTheDocument()
+    expect(screen.queryByText("No chats yet.")).not.toBeInTheDocument()
+
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "New chat with Alpha" })).toBeInTheDocument()
       expect(screen.getByRole("button", { name: "New chat with Beta" })).toBeInTheDocument()
+      expect(screen.queryByRole("status", { name: "Loading chats" })).not.toBeInTheDocument()
     })
     expect(visibleChatSessionIds()).toEqual(["alpha-one", "beta-one"])
     expect(JSON.parse(localStorage.getItem("boring-workspace:chat-panes:async-fleet-restore") ?? "null")).toMatchObject({

--- a/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/SurfaceShell.tsx
@@ -938,7 +938,9 @@ export function SurfaceShell({
         data-boring-state={hostRailOnly ? "collapsed" : "expanded"}
         className={cn(
           "pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center",
-          hostRailOnly ? "justify-center border-b border-border/60 bg-background" : "justify-end px-3",
+          hostRailOnly
+            ? "justify-center border-b border-border bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)]"
+            : "justify-end px-3",
         )}
         style={{ height: workbenchHeaderHeight }}
       >
@@ -1019,7 +1021,7 @@ export function SurfaceShell({
           data-boring-workspace-part="surface-sidebar"
           data-boring-state={hostRailOnly ? "host-collapsed" : sourcePaneOpen ? "expanded" : "rail"}
           className={cn(
-            "relative z-10 flex min-h-0 shrink-0 flex-col overflow-hidden border-l border-border/60",
+            "relative z-10 flex min-h-0 shrink-0 flex-col overflow-hidden border-l border-border",
             !hideLevelOneHeader && "mt-11",
           )}
           style={{

--- a/packages/workspace/src/front/chrome/artifact-surface/WorkbenchHeaderActions.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/WorkbenchHeaderActions.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { ChevronDown, ChevronRight, Maximize2, Minimize2 } from "lucide-react"
+import { ChevronDown, Maximize2, Minimize2, PanelRightClose } from "lucide-react"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -88,7 +88,7 @@ export function WorkbenchHeaderActions({
           aria-label="Close workbench"
           title="Close workbench (⌘2)"
         >
-          <ChevronRight className="h-4 w-4" strokeWidth={1.75} />
+          <PanelRightClose className="h-4 w-4" strokeWidth={1.75} />
         </IconButton>
       ) : null}
     </div>

--- a/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
+++ b/packages/workspace/src/front/chrome/artifact-surface/__tests__/SurfaceShell.test.tsx
@@ -153,8 +153,13 @@ describe("SurfaceShell", () => {
     expect(body).toHaveStyle({ height: "100%" })
     expect(rail).toHaveStyle({ height: "calc(100% - 44px)" })
     expect(rail).toHaveAttribute("data-boring-state", "host-collapsed")
+    expect(rail).toHaveClass("border-border")
     expect(rail?.parentElement).toBe(body)
-    fireEvent.click(screen.getByRole("button", { name: "Open workbench" }))
+    expect(header).toHaveClass("border-border")
+    expect(header).toHaveClass("bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)]")
+    const openWorkbench = screen.getByRole("button", { name: "Open workbench" })
+    expect(openWorkbench.querySelector("svg")).toHaveClass("lucide-panel-right-open")
+    fireEvent.click(openWorkbench)
     expect(onHostExpand).toHaveBeenCalledOnce()
   })
 
@@ -547,6 +552,7 @@ describe("SurfaceShell", () => {
 
     const headerActions = screen.getByRole("button", { name: "Fullscreen workbench" }).closest('[data-boring-workspace-part="workbench-header-actions"]')
     expect(headerActions).not.toBeNull()
+    expect(screen.getByRole("button", { name: "Close workbench" }).querySelector("svg")).toHaveClass("lucide-panel-right-close")
     fireEvent.click(screen.getByRole("button", { name: "Fullscreen workbench" }))
     fireEvent.click(screen.getByRole("button", { name: "Close workbench" }))
     expect(onToggleFullscreen).toHaveBeenCalledOnce()

--- a/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/WorkbenchLeftPane.tsx
@@ -143,7 +143,7 @@ export function WorkbenchLeftPane({
     <nav
       data-boring-workspace-part="workbench-activity-rail"
       data-boring-side={railSide}
-      className="flex w-11 shrink-0 flex-col items-center gap-1 bg-muted/35 px-1.5 py-2"
+      className="flex w-11 shrink-0 flex-col items-center gap-1 bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)] px-1.5 py-2"
       aria-label="Workspace categories"
     >
       {railSide === "left" ? (

--- a/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
+++ b/packages/workspace/src/front/chrome/workbench-left/__tests__/WorkbenchLeftPane.test.tsx
@@ -405,6 +405,7 @@ describe("WorkbenchLeftPane", () => {
     })
 
     const rail = screen.getByRole("navigation", { name: "Workspace categories" })
+    expect(rail).toHaveClass("bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)]")
     const filesButton = screen.getByRole("button", { name: "Files" })
     const filesSlot = Array.from(rail.children).findIndex((child) => child.contains(filesButton))
     expect(rail.querySelector('[data-boring-workspace-part="workbench-host-control-slot"]')).not.toBeInTheDocument()

--- a/packages/workspace/src/front/components/SessionList.tsx
+++ b/packages/workspace/src/front/components/SessionList.tsx
@@ -9,7 +9,7 @@ import {
   type KeyboardEvent,
   type MouseEvent,
 } from "react"
-import { IconButton } from "@hachej/boring-ui-kit"
+import { IconButton, Skeleton } from "@hachej/boring-ui-kit"
 import { CheckIcon, CopyIcon } from "lucide-react"
 import { cn } from "../lib/utils"
 import { workspaceSessionKeyFor, workspaceSessionKeyFromBoundaryValue } from "../sessionIdentity"
@@ -25,6 +25,7 @@ export interface SessionItem {
 
 export interface SessionListProps {
   sessions: SessionItem[]
+  loading?: boolean
   activeId?: string | null
   onSwitch?: (id: string, agentTypeId?: string) => void
   onCreate?: () => void
@@ -35,6 +36,7 @@ export interface SessionListProps {
 
 export function SessionList({
   sessions,
+  loading = false,
   activeId,
   onSwitch,
   onCreate,
@@ -133,8 +135,16 @@ export function SessionList({
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto" role="list" aria-label="Session list">
-        {sessions.length === 0 && (
+      <div className="flex-1 overflow-y-auto" role="list" aria-label="Session list" aria-busy={loading || undefined}>
+        {sessions.length === 0 && loading ? (
+          <div className="space-y-2 px-3 py-3" role="status" aria-live="polite" aria-label="Loading sessions">
+            <div className="space-y-2" aria-hidden="true">
+              <Skeleton className="h-9 w-full rounded-md" />
+              <Skeleton className="h-9 w-4/5 rounded-md" />
+            </div>
+          </div>
+        ) : null}
+        {sessions.length === 0 && !loading && (
           <div className="px-3 py-6 text-center text-sm text-muted-foreground">
             No sessions
           </div>

--- a/packages/workspace/src/front/components/__tests__/SessionList.test.tsx
+++ b/packages/workspace/src/front/components/__tests__/SessionList.test.tsx
@@ -126,9 +126,19 @@ describe("SessionList", () => {
     expect(onSwitch).not.toHaveBeenCalled()
   })
 
-  it("shows empty state when no sessions", () => {
-    render(<SessionList sessions={[]} />)
+  it("shows loading, then a resolved empty state, then loaded sessions without flashing empty", () => {
+    const { rerender } = render(<SessionList sessions={[]} loading />)
+
+    expect(screen.getByRole("status", { name: "Loading sessions" })).toBeInTheDocument()
+    expect(screen.queryByText("No sessions")).not.toBeInTheDocument()
+
+    rerender(<SessionList sessions={[]} loading={false} />)
     expect(screen.getByText("No sessions")).toBeInTheDocument()
+    expect(screen.queryByRole("status", { name: "Loading sessions" })).not.toBeInTheDocument()
+
+    rerender(<SessionList sessions={sessions} loading={false} />)
+    expect(screen.queryByText("No sessions")).not.toBeInTheDocument()
+    expect(screen.getByText("First session")).toBeInTheDocument()
   })
 
   it("renders with navigation role and accessible label", () => {

--- a/packages/workspace/src/front/layout/ChatLayout.tsx
+++ b/packages/workspace/src/front/layout/ChatLayout.tsx
@@ -602,7 +602,7 @@ export function ChatLayout(props: ChatLayoutProps) {
               // Collapsed/mobile workbench fills available width; otherwise it is a side panel.
               (chatCollapsed || mobileWorkspaceOpen) && surfaceOpen ? "min-w-0 flex-1" : "shrink-0",
               "transition-[flex-grow,flex-basis,width,min-width,max-width] duration-[280ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none",
-              !mobileShell && "border-l border-[color:oklch(from_var(--border)_l_c_h/0.6)]",
+              !mobileShell && surfaceOpen && "border-l border-border",
             )}
             style={
               (chatCollapsed || mobileWorkspaceOpen) && surfaceOpen

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -368,12 +368,13 @@ export function AppLeftPane({
       return {
         ...project,
         sessions: [...lensed],
+        loadingSessions: project.loadingSessions ?? (project.id === activeProjectId && sessionsLoading),
         // The count stays the true owned total; the lens narrows the rows, not
         // the workspace's real size.
         sessionCount: project.sessionCount ?? (project.id === activeProjectId ? regularSessions.length : injected.length),
       }
     })
-  }, [activeProjectId, chatsAgentLens, layoutMode, projects, regularSessions])
+  }, [activeProjectId, chatsAgentLens, layoutMode, projects, regularSessions, sessionsLoading])
   // Expansion is owned here (lifted from the tree) so pinned-project rows in the
   // Pinned section can expand their project in the tree on click.
   const [expandedProjectIds, setExpandedProjectIds] = useState<ReadonlySet<string>>(() => {
@@ -509,12 +510,7 @@ export function AppLeftPane({
             {agentSessions.length > 0
               ? agentSessions.map((session) => renderSession(session, pinnedSet.has(workspaceSessionKeyFor(session)), activeProjectId ?? undefined, false, true))
               : (agent.sessionsStatus ?? "loading") === "loading"
-                ? (
-                  <div data-boring-workspace-part="app-left-chats-loading-surface" className="space-y-1 px-1 py-1" aria-label="Loading chats">
-                    <Skeleton className="h-6 w-full rounded-md" />
-                    <Skeleton className="h-6 w-3/4 rounded-md" />
-                  </div>
-                )
+                ? renderChatsLoading()
                 : (
                   <div className="flex min-h-[26px] items-center gap-1.5 pl-6 pr-1.5 text-[12px] text-muted-foreground/80">
                     <span>No chats yet.</span>
@@ -536,6 +532,22 @@ export function AppLeftPane({
       </div>
     )
   })
+
+  const renderChatsLoading = () => (
+    <div
+      data-boring-workspace-part="app-left-chats-loading-surface"
+      className="space-y-1 px-1 py-1"
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label="Loading chats"
+    >
+      <div className="space-y-1" aria-hidden="true">
+        <Skeleton className="h-6 w-full rounded-md" />
+        <Skeleton className="h-6 w-3/4 rounded-md" />
+      </div>
+    </div>
+  )
 
   const renderAgentsSection = () => (
     <section data-boring-workspace-part="app-left-pane-agents" aria-label="Agents" className="space-y-1 border-t border-border/50 pt-3">
@@ -725,7 +737,9 @@ export function AppLeftPane({
           className="boring-scrollbar-discreet min-h-0 flex-1 overflow-y-auto px-2 pb-2 [mask-image:linear-gradient(to_bottom,transparent_0,black_8px,black_calc(100%_-_8px),transparent_100%)] motion-reduce:[mask-image:none]"
         >
           {/* Multi-project (PR2): projects remain inside the Chats region. */}
-          {layoutMode === "multi-project" ? (
+          {layoutMode === "multi-project" ? sessionsLoading && !fleetChromeEnabled ? (
+            renderChatsLoading()
+          ) : (
             <div className="space-y-3 py-1">
               {fleetChromeEnabled ? renderFleetNewChat() : null}
               {pinnedSessions.length > 0 || pinnedProjects.length > 0 ? (
@@ -757,28 +771,32 @@ export function AppLeftPane({
           ) : (
             <div className={fleetChromeEnabled ? "space-y-3 py-1" : "space-y-4 py-1"}>
               {fleetChromeEnabled ? renderFleetNewChat() : null}
-              {pinnedSessions.length > 0 ? (
-                fleetChromeEnabled ? (
-                  <section className="mb-3 px-0" aria-label="Pinned chats">
-                    <div className="flex items-center justify-between px-2 pb-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/75">
-                      <span>Pinned chats</span>
-                      <span className="font-normal tabular-nums text-muted-foreground">{pinnedSessions.length}</span>
-                    </div>
-                    <div className="space-y-0.5">{pinnedSessions.map((session) => renderSession(session, true))}</div>
-                  </section>
-                ) : (
-                  <SessionSubSection title="Pinned">
-                    {pinnedSessions.map((session) => renderSession(session, true))}
-                  </SessionSubSection>
-                )
-              ) : null}
-              {/* Nested layout: each Agent's chats live under its card. */}
-              {fleetChromeEnabled ? (
-                renderAgentsSection()
-              ) : (
-                <SessionSubSection title={pinnedSessions.length > 0 ? "Recent" : undefined} empty={sessionsLoading ? "Loading chats…" : "No chats yet."}>
-                  {regularSessions.map((session) => renderSession(session, false))}
-                </SessionSubSection>
+              {sessionsLoading && !fleetChromeEnabled ? renderChatsLoading() : (
+                <>
+                  {pinnedSessions.length > 0 ? (
+                    fleetChromeEnabled ? (
+                      <section className="mb-3 px-0" aria-label="Pinned chats">
+                        <div className="flex items-center justify-between px-2 pb-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/75">
+                          <span>Pinned chats</span>
+                          <span className="font-normal tabular-nums text-muted-foreground">{pinnedSessions.length}</span>
+                        </div>
+                        <div className="space-y-0.5">{pinnedSessions.map((session) => renderSession(session, true))}</div>
+                      </section>
+                    ) : (
+                      <SessionSubSection title="Pinned">
+                        {pinnedSessions.map((session) => renderSession(session, true))}
+                      </SessionSubSection>
+                    )
+                  ) : null}
+                  {/* Nested layout: each Agent's chats live under its card. */}
+                  {fleetChromeEnabled ? (
+                    renderAgentsSection()
+                  ) : (
+                    <SessionSubSection title={pinnedSessions.length > 0 ? "Recent" : undefined} empty="No chats yet.">
+                      {regularSessions.map((session) => renderSession(session, false))}
+                    </SessionSubSection>
+                  )}
+                </>
               )}
             </div>
           )}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPane.tsx
@@ -247,13 +247,18 @@ export function AppLeftPane({
   const openSet = useMemo(() => new Set(normalizedOpenSessionIds), [normalizedOpenSessionIds])
   const pinnedSet = useMemo(() => new Set(normalizedPinnedSessionIds), [normalizedPinnedSessionIds])
   const workingSessionIds = useWorkingSessionIds(sessions)
-  // Any addressed fleet gets cards, including a fleet of one: "one card per
-  // Agent" is what exposes per-Agent settings and scoped chat creation. Hosts
-  // that want the plain single-Agent shell omit `agents` entirely.
-  const agentTreeEnabled = agents.length > 0
+  // Fleet row idiom (accent dot, compact rows, owner labels): any addressed
+  // fleet gets it, including a fleet of one, so chat cards look identical in
+  // both cardinalities. Hosts wanting the plain shell omit `agents` entirely.
+  const agentRowsEnabled = agents.length > 0
+  // Fleet CHROME — per-Agent sections and the New chat Agent picker — only
+  // earns its keep once there is more than one Agent to choose between. With a
+  // single Agent (the default seat) the pane is a flat "Chats" list, owner
+  // spec; the fleet hub (many seats) keeps the full tree.
+  const fleetChromeEnabled = agents.length > 1
   // Ratified layout: each Agent's chats nest under its card in single-project
   // mode; multi-project keeps chats inside the project tree instead.
-  const nestedAgentChats = agentTreeEnabled && layoutMode !== "multi-project"
+  const nestedAgentChats = fleetChromeEnabled && layoutMode !== "multi-project"
   const [agentFilter, setAgentFilter] = useState("")
   // The filter input hides behind its icon until asked for (owner spec); it
   // stays open while it holds a query so active filtering is never invisible.
@@ -419,10 +424,10 @@ export function AppLeftPane({
         canPin={isActiveProjectSession}
         working={working}
         attentionBadge={isActiveProjectSession ? sessionBadges.get(sessionKey) : undefined}
-        activeDot={agentTreeEnabled}
+        activeDot={agentRowsEnabled}
         // The accent dot marks the active chat (spike idiom) and any working one.
         activeDotActive={working || state === "active"}
-        compact={agentTreeEnabled && (nested || !pinned)}
+        compact={agentRowsEnabled && (nested || !pinned)}
         ownerLabel={showOwnerLabel && session.agentTypeId ? agentLabelById.get(session.agentTypeId) : undefined}
         onSwitch={isActiveProjectSession
           ? session.agentTypeId
@@ -660,7 +665,7 @@ export function AppLeftPane({
         agentTypeId: session.agentTypeId,
         title: session.title,
         updatedAt: session.updatedAt,
-      }, pinnedSet.has(workspaceSessionKeyFor(session)), project.id, agentTreeEnabled)}
+      }, pinnedSet.has(workspaceSessionKeyFor(session)), project.id, agentRowsEnabled)}
     />
   )
 
@@ -702,15 +707,15 @@ export function AppLeftPane({
 
       <section
         className="flex min-h-24 flex-1 flex-col border-t border-border/40 pt-3"
-        aria-labelledby={agentTreeEnabled ? undefined : "app-left-chats-heading"}
-        aria-label={agentTreeEnabled ? "Agent navigation" : undefined}
+        aria-labelledby={fleetChromeEnabled ? undefined : "app-left-chats-heading"}
+        aria-label={fleetChromeEnabled ? "Agent navigation" : undefined}
       >
-        {!agentTreeEnabled ? (
+        {!fleetChromeEnabled ? (
           <h2 id="app-left-chats-heading" className="shrink-0 px-4 pb-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/75">
             Chats
           </h2>
         ) : null}
-        {!agentTreeEnabled ? (
+        {!fleetChromeEnabled ? (
           <div data-boring-workspace-part="app-left-new-chat" className="shrink-0 px-2 pb-2">
             <NewChatAction icon={<Plus className="h-4 w-4" strokeWidth={2} />} onCreateSession={onCreateSession} onCreateSplitSession={onCreateSplitSession} onCreatePopoverSession={onCreatePopoverSession} />
           </div>
@@ -722,14 +727,14 @@ export function AppLeftPane({
           {/* Multi-project (PR2): projects remain inside the Chats region. */}
           {layoutMode === "multi-project" ? (
             <div className="space-y-3 py-1">
-              {agentTreeEnabled ? renderFleetNewChat() : null}
+              {fleetChromeEnabled ? renderFleetNewChat() : null}
               {pinnedSessions.length > 0 || pinnedProjects.length > 0 ? (
                 <SessionSubSection title="Pinned">
                   {pinnedSessions.map((session) => renderSession(session, true))}
                   {pinnedProjects.length > 0 ? renderProjectTree(pinnedProjects) : null}
                 </SessionSubSection>
               ) : null}
-              {agentTreeEnabled ? renderAgentsSection() : null}
+              {fleetChromeEnabled ? renderAgentsSection() : null}
               <section data-boring-workspace-part="app-left-pane-section" className="space-y-1">
                 <div className="flex items-center justify-between gap-1 px-2 pb-0.5">
                   <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground/65">{workspaceSectionTitle}</span>
@@ -750,10 +755,10 @@ export function AppLeftPane({
               </section>
             </div>
           ) : (
-            <div className={agentTreeEnabled ? "space-y-3 py-1" : "space-y-4 py-1"}>
-              {agentTreeEnabled ? renderFleetNewChat() : null}
+            <div className={fleetChromeEnabled ? "space-y-3 py-1" : "space-y-4 py-1"}>
+              {fleetChromeEnabled ? renderFleetNewChat() : null}
               {pinnedSessions.length > 0 ? (
-                agentTreeEnabled ? (
+                fleetChromeEnabled ? (
                   <section className="mb-3 px-0" aria-label="Pinned chats">
                     <div className="flex items-center justify-between px-2 pb-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-foreground/75">
                       <span>Pinned chats</span>
@@ -768,7 +773,7 @@ export function AppLeftPane({
                 )
               ) : null}
               {/* Nested layout: each Agent's chats live under its card. */}
-              {agentTreeEnabled ? (
+              {fleetChromeEnabled ? (
                 renderAgentsSection()
               ) : (
                 <SessionSubSection title={pinnedSessions.length > 0 ? "Recent" : undefined} empty={sessionsLoading ? "Loading chats…" : "No chats yet."}>

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneProjects.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneProjects.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Skeleton,
 } from "@hachej/boring-ui-kit"
 import { cn } from "../../lib/utils"
 import { AppSessionRow } from "./AppLeftPaneSessionRow"
@@ -283,7 +284,12 @@ function ProjectRow({
       {expanded ? (
         <div className="space-y-0.5 pl-6">
           {project.loadingSessions && sessions.length === 0 ? (
-            <div className="px-1 py-1.5 text-xs text-muted-foreground">Loading chats…</div>
+            <div className="space-y-1 px-1 py-1.5" role="status" aria-live="polite" aria-label={`Loading chats in ${name}`}>
+              <div className="space-y-1" aria-hidden="true">
+                <Skeleton className="h-6 w-full rounded-md" />
+                <Skeleton className="h-6 w-3/4 rounded-md" />
+              </div>
+            </div>
           ) : sessions.length === 0 ? (
             <div className="px-1 py-1.5 text-xs text-muted-foreground">No chats yet.</div>
           ) : (

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -569,24 +569,80 @@ describe("AppLeftPane", () => {
     Object.defineProperty(window, "innerWidth", { configurable: true, value: originalWidth })
   })
 
-  it("distinguishes a loading chat list from an empty one", () => {
-    render(
+  it("shows loading, then a resolved empty state, then loaded chats without flashing empty", () => {
+    const baseProps = {
+      appTitle: "Test",
+      onCreateSession: vi.fn(),
+      onOpenCommandPalette: vi.fn(),
+      onSwitchSession: vi.fn(),
+      onOpenSessionAsPane: vi.fn(),
+      onToggleSessionPinned: vi.fn(),
+    }
+    const { rerender } = render(
       <WorkspaceAttentionProvider>
         <AppLeftPane
-          appTitle="Test"
+          {...baseProps}
           sessions={[]}
           sessionsLoading
-          onCreateSession={vi.fn()}
-          onOpenCommandPalette={vi.fn()}
-          onSwitchSession={vi.fn()}
-          onOpenSessionAsPane={vi.fn()}
-          onToggleSessionPinned={vi.fn()}
         />
       </WorkspaceAttentionProvider>,
     )
 
-    expect(screen.getByText("Loading chats…")).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: "Loading chats" })).toBeInTheDocument()
     expect(screen.queryByText("No chats yet.")).not.toBeInTheDocument()
+
+    rerender(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane {...baseProps} sessions={[]} sessionsLoading={false} />
+      </WorkspaceAttentionProvider>,
+    )
+    expect(screen.getByText("No chats yet.")).toBeInTheDocument()
+    expect(screen.queryByRole("status", { name: "Loading chats" })).not.toBeInTheDocument()
+
+    rerender(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane {...baseProps} sessions={[{ id: "loaded", title: "Loaded chat" }]} sessionsLoading={false} />
+      </WorkspaceAttentionProvider>,
+    )
+    expect(screen.queryByText("No chats yet.")).not.toBeInTheDocument()
+    expect(screen.getByText("Loaded chat")).toBeInTheDocument()
+  })
+
+  it("keeps multi-project chats loading until the active project inventory resolves", () => {
+    const baseProps = {
+      appTitle: "Test",
+      layoutMode: "multi-project" as const,
+      projects: [{ id: "project", name: "Project" }],
+      activeProjectId: "project",
+      onCreateSession: vi.fn(),
+      onOpenCommandPalette: vi.fn(),
+      onSwitchSession: vi.fn(),
+      onOpenSessionAsPane: vi.fn(),
+      onToggleSessionPinned: vi.fn(),
+    }
+    const { rerender } = render(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane {...baseProps} sessions={[]} sessionsLoading />
+      </WorkspaceAttentionProvider>,
+    )
+
+    expect(screen.getByRole("status", { name: "Loading chats" })).toBeInTheDocument()
+    expect(screen.queryByText("No chats yet.")).not.toBeInTheDocument()
+
+    rerender(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane {...baseProps} sessions={[]} sessionsLoading={false} />
+      </WorkspaceAttentionProvider>,
+    )
+    expect(screen.getByText("No chats yet.")).toBeInTheDocument()
+
+    rerender(
+      <WorkspaceAttentionProvider>
+        <AppLeftPane {...baseProps} sessions={[{ id: "loaded-project", title: "Loaded project chat" }]} sessionsLoading={false} />
+      </WorkspaceAttentionProvider>,
+    )
+    expect(screen.queryByText("No chats yet.")).not.toBeInTheDocument()
+    expect(screen.getByText("Loaded project chat")).toBeInTheDocument()
   })
 
   it("shows working state beside session names", () => {

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -521,6 +521,8 @@ describe("AppLeftPane", () => {
     )
 
     const rail = screen.getByLabelText("Collapsed app navigation")
+    expect(rail).toHaveClass("border-border")
+    expect(rail).toHaveClass("bg-[color:oklch(from_var(--background)_calc(l-0.012)_c_h)]")
     fireEvent.click(within(rail).getByRole("button", { name: "Search" }))
     fireEvent.click(within(rail).getByRole("button", { name: "Tasks" }))
     fireEvent.click(within(rail).getByRole("button", { name: "New chat" }))

--- a/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx
@@ -378,7 +378,13 @@ describe("AppLeftPane", () => {
     expect(screen.getByText("Project")).toBeInTheDocument()
   })
 
-  it("gives a one-Agent addressed fleet its own card", async () => {
+  // Supersedes "gives a one-Agent addressed fleet its own card". Owner ruling:
+  // a fleet of one is not a fleet — the per-Agent section, its card and the New
+  // chat Agent picker all describe a choice that does not exist, so the pane
+  // falls back to the plain "Chats" list. Known consequence, accepted by the
+  // owner: the card was the pane's route to that Agent's settings, so with one
+  // Agent those settings are reached from the Agent surfaces outside the pane.
+  it("renders a flat Chats list with no fleet chrome for a one-Agent fleet", async () => {
     const user = userEvent.setup()
     const onOpenAgentSettings = vi.fn()
     const onCreateSession = vi.fn()
@@ -389,6 +395,7 @@ describe("AppLeftPane", () => {
           agents={[{ agentTypeId: "solo", label: "Boring Solo", sessionsStatus: "loaded" }]}
           selectedAgentTypeId="solo"
           sessions={[{ id: "s1", agentTypeId: "solo", title: "Solo session" }]}
+          activeSessionRef={{ agentTypeId: "solo", sessionId: "s1" }}
           onCreateSession={onCreateSession}
           onOpenAgentSettings={onOpenAgentSettings}
           onOpenCommandPalette={vi.fn()}
@@ -399,13 +406,38 @@ describe("AppLeftPane", () => {
       </WorkspaceAttentionProvider>,
     )
 
-    // A fleet of one still gets a card, which is the only route to per-Agent
-    // settings now that they no longer live on a generic control.
-    expect(screen.getByRole("button", { name: /Boring Solo; 1 chat$/ })).toBeInTheDocument()
-    await user.click(screen.getByRole("button", { name: "New chat with Boring Solo" }))
-    expect(onCreateSession).toHaveBeenCalledWith("solo")
-    await user.click(screen.getByRole("button", { name: "Settings for Boring Solo" }))
-    expect(onOpenAgentSettings).toHaveBeenCalledWith("solo")
+    // Header + flat list, exactly like the no-fleet shell.
+    expect(screen.getByRole("heading", { name: "Chats" })).toBeInTheDocument()
+    expect(screen.getByText("Solo session")).toBeInTheDocument()
+    // No grouping chrome: no Agents section, no Agent card, no seat count.
+    expect(document.querySelector('[data-boring-workspace-part="app-left-pane-agents"]')).toBeNull()
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agent-tree"]')).toBeNull()
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toBeNull()
+    expect(screen.queryByRole("button", { name: /Boring Solo; 1 chat$/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Settings for Boring Solo" })).not.toBeInTheDocument()
+    expect(onOpenAgentSettings).not.toHaveBeenCalled()
+    // New chat is a plain button: no Agent dropdown, no per-Agent variant.
+    expect(document.querySelector('[data-boring-workspace-part="app-left-new-chat"]')).not.toBeNull()
+    expect(screen.queryByRole("button", { name: /^Start new chat with / })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Choose Agent for new chat" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "New chat with Boring Solo" })).not.toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "New chat" }))
+    expect(onCreateSession).toHaveBeenCalled()
+    // Session cards keep the fleet row idiom: the active rail only renders when
+    // the row is in fleet (accent-dot) mode, so its presence proves the cards
+    // are untouched by dropping the surrounding chrome.
+    expect(document.querySelector('[data-boring-workspace-part="app-session-active-rail"]')).not.toBeNull()
+  })
+
+  it("keeps the fleet sections and the New chat Agent picker for two or more Agents", () => {
+    renderFleetPane()
+
+    expect(document.querySelector('[data-boring-workspace-part="app-left-pane-agents"]')).not.toBeNull()
+    expect(document.querySelector('[data-boring-workspace-part="app-left-agents-count"]')).toHaveTextContent("2 seats")
+    expect(screen.getByRole("button", { name: /Boring Alpha;/ })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Boring Beta;/ })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Start new chat with Boring Alpha" })).toBeInTheDocument()
+    expect(screen.queryByRole("heading", { name: "Chats" })).not.toBeInTheDocument()
   })
 
   it("unifies the multi-project fleet: labeled project rows, a lens that filters them, and a global new chat", async () => {

--- a/tools/ui-review/src/__tests__/hardGates.test.ts
+++ b/tools/ui-review/src/__tests__/hardGates.test.ts
@@ -113,12 +113,12 @@ describe("command palette hard gates", () => {
 
   it("allows only origin-bound exact startup aborts", () => {
     const allowed = evaluateCommandPaletteHardGates(snapshot({
-      requestFailures: [{ url: "http://127.0.0.1:5380/api/v1/agents/default/ready-status", errorText: "net::ERR_ABORTED" }],
+      requestFailures: [{ url: "http://127.0.0.1:5380/api/v1/agents/alpha/ready-status", errorText: "net::ERR_ABORTED" }],
     }))
     expect(allowed.results.find((result) => result.id === "request-failures")?.passed).toBe(true)
 
     const external = evaluateCommandPaletteHardGates(snapshot({
-      requestFailures: [{ url: "https://example.com/api/v1/agents/default/ready-status", errorText: "net::ERR_ABORTED" }],
+      requestFailures: [{ url: "https://example.com/api/v1/agents/alpha/ready-status", errorText: "net::ERR_ABORTED" }],
     }))
     expect(external.results.find((result) => result.id === "request-failures")?.passed).toBe(false)
   })

--- a/tools/ui-review/src/review-specs/workspace-command-palette/hardGates.ts
+++ b/tools/ui-review/src/review-specs/workspace-command-palette/hardGates.ts
@@ -25,7 +25,7 @@ export const COMMAND_PALETTE_HARD_GATE_CONTRACT = {
       rationale: "The fixture shell cancels duplicate startup tree refreshes when its fresh-state reset completes.",
     },
     {
-      path: "/api/v1/agents/default/ready-status",
+      path: "/api/v1/agents/alpha/ready-status",
       errorText: "net::ERR_ABORTED",
       rationale: "The fixture shell cancels its readiness poll after the workspace becomes ready.",
     },


### PR DESCRIPTION
## Problem

Owner-reported on the playground (single-agent): the left pane renders the
multi-agent fleet view — per-Agent sections/cards and the New chat Agent
dropdown — even when exactly one Agent exists. A fleet of one is not a fleet;
every one of those controls describes a choice that does not exist.

## Fix

Split the single `agentTreeEnabled` predicate in `AppLeftPane` in two:

| predicate | value | drives |
| --- | --- | --- |
| `agentRowsEnabled` | `agents.length > 0` | session **row idiom** — accent dot, compact density, owner labels |
| `fleetChromeEnabled` | `agents.length > 1` | fleet **chrome** — Agents section, per-Agent cards/nesting, `FleetNewChatAction` picker, pinned-section variant, region aria |

- **1 Agent** → `CHATS` heading → plain `NewChatAction` button → flat session list (`Pinned` / `Recent` sub-sections). No Agents section, no card, no seat count, no Agent dropdown.
- **≥2 Agents** (factory/CLI fleet hub) → unchanged: Agents section, cards, nesting, global fleet New chat.
- **Session cards are byte-identical** in both modes — the card styling stayed on `agentRowsEnabled`, which is exactly the old `agents.length > 0`.

The predicate reads the composed `agents` list the pane already receives (from
`GET /api/v1/agents` via `useAddressedAgentSelection`), so it is host-agnostic:
the playground/full-app single-seat case collapses, the fleet hub does not.
During discovery `agents` is `[]`, which already rendered the plain shell, so
there is no fleet→flat flicker.

### Accepted consequence

The Agent card was the pane's route to per-Agent settings. With one Agent that
route is gone from the pane; those settings are reached from the Agent surfaces
outside it. Noted in the superseded test's comment rather than silently dropped.

## Tests

`packages/workspace/src/front/layout/plugin-tabs/__tests__/AppLeftPane.test.tsx`:

- Rewrote `gives a one-Agent addressed fleet its own card` (it asserted exactly
  the reported bug) into `renders a flat Chats list with no fleet chrome for a
  one-Agent fleet` — asserts the Chats heading, the flat row, absence of every
  chrome part/dropdown, a working plain New chat, and that the active rail
  (fleet-only row affordance) still renders, proving cards are untouched.
- Added `keeps the fleet sections and the New chat Agent picker for two or more
  Agents` as the explicit regression guard for the hub.

31/31 pass in that file. Every other fleet test in the suite already uses ≥2
Agents and is unchanged.

Refs #1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtPPbToGDvkARQZuYKFyWN