### PR TITLE
docs(1210): WhatsApp-native signup/identity + progressive email [owner gate]

### DIFF
--- a/docs/issues/1210/plan.md
+++ b/docs/issues/1210/plan.md
@@ -2,8 +2,8 @@
 github: https://github.com/hachej/boring-ui/issues/1210
 issue: 1210
 state: needs-owner-approval
-updated: 2026-08-10
-revision: r3
+updated: 2026-08-11
+revision: r3 (+ 2026-08-11 WhatsApp-native signup/identity ruling)
 flag: BORING_AGENT_CHANNELS (reused, from gh-1127); new tenant app repo
 ---
 
@@ -663,14 +663,20 @@ every morning" is done; the web-touching half is entirely absent.**
 
 **Today:** ratified design (#1140), zero code, deprioritized. Substrate on main.
 
-**Delta:** build #1127 slices 1a and 2 — but this product needs materially
-less of them, because **the identity model inverts**. In #1127 the external
-sender is a client's team member: many unknown senders, per-agent grants,
-rejection UX, session rotation. Here the sender is **the business owner,
-approving their own drafts** — one number, one workspace, one agent,
-provisioned at onboarding. That deletes unknown-sender UX (any unbound number
-is dropped silently at the webhook), per-agent grants (the binding *is* the
-grant), and multi-agent routing.
+**Delta:** build #1127 slices 1a, **1c** and 2 — but this product needs
+materially less of the conversational surface, because **the identity model
+inverts**. In #1127's client-channel framing the external sender is a client's
+team member: many unknown senders, per-agent grants, rejection UX, session
+rotation. Here the sender is **the business owner**, and under the 2026-08-11
+WhatsApp-native identity ruling (§ Onboarding, and #1127 §6.6) **the owner's
+phone number IS their account** — a first inbound from a new number is
+**SIGNUP** (creates account + workspace + agent), not a silent drop. So this
+product **needs #1127 slice 1c** (phone-identity provider + magic-link
+web-auth) as a first-class dependency, not just the outbound notification path.
+What still deletes: per-agent grants (the binding *is* the grant) and
+multi-agent routing (one owner, one workspace, one agent). The
+"drop unbound numbers silently" posture applies only *after* signup — i.e. to
+numbers we choose not to onboard, not to first-contact.
 
 Adopted verbatim because it is right and hard-won: signature verify
 (`X-Hub-Signature-256`) plus handshake before any parsing; **durable dedupe
@@ -777,19 +783,78 @@ endpoint 400s on the `developer` role.
 It does not execute code. Ship without agent sandboxing; revisit only if a
 vertical needs it.
 
-## Onboarding — under 30 minutes, nothing installed
+## Onboarding — WhatsApp-native, under 30 minutes, nothing installed
 
 A product requirement, and the onboarding slice is designed to this number.
 
+**Signup is WhatsApp-native (owner ruling, 2026-08-11).** The funnel is: the
+vertical landing page → a **`wa.me/<seneca-number>` click-to-chat button** →
+**conversational signup inside WhatsApp**. The customer's **phone number is
+their account identity**: their first message from a new number creates the
+account + workspace + agent, keyed to that number, and the bot onboards
+conversationally. **No email, no password, no web form.** Auth factor = control
+of the WhatsApp number (proven by messaging from it). When the full web
+workspace is needed, the bot sends a **magic link over WhatsApp** (one-time,
+short-TTL, signed, bound to the phone-account) that establishes a web session;
+phone OTP is the documented fallback. This reuses the #1211 WhatsApp-native
+identity model verbatim (see `docs/issues/1127/plan-whatsapp.md` §6.6) —
+**one Seneca number, multi-tenant by sender, no Embedded Signup, no
+per-customer OAuth**.
+
+**This is a small extension of existing better-auth, not new auth code
+(verified 2026-08-11).** boring-ui core already runs better-auth with Google +
+GitHub OAuth + email/password and the **magic-link plugin already wired**
+(`packages/core/src/server/auth/createAuth.ts:127` mounts
+`magicLink({ sendMagicLink })`; `src/front/auth/authClient.ts:2,17` registers
+`magicLinkClient()`; `src/server/app/capabilities.ts:74` exposes the
+`magicLink` capability). So: (1) WhatsApp/phone is **identity provider #4** on
+the existing provider-agnostic user model — not a new system; (2) "magic link
+over WhatsApp" = wiring the existing `sendMagicLink` (today it renders to email
+via `transport.send`) to a **WhatsApp delivery adapter** that sends the *same*
+better-auth token URL over WhatsApp — no new token/redeem/session code; (3)
+phone verification comes free from the channel itself (an inbound proves number
+control), with better-auth's `phoneNumber` OTP plugin as the alternative.
+(External validation: getnao/nao runs the same better-auth linked-identity model
+with `accountLinking` — `scratchpad/getnao-auth-study.md`.)
+
+**Progressive email — do not require email at signup (owner ruling).** Phone is
+the only identity at signup; email is collected **progressively
+in-conversation** at natural value moments (first quote, first web access) and
+is **effectively required at first payment** (invoices, receipts, Swiss
+business records). Email + phone become **linked identities on one better-auth
+account** — `accountLinking` makes "add email later" native, no migration.
+Email's roles: recovery (number-recycling risk), billing, cross-channel
+notices. This is an identity trust-ladder, parallel to the email-*access*
+trust-ladder in §(a).
+
+**Two doors, one account.** Support both **Flow B** (WhatsApp-first signup →
+magic-link web, the trades default) and **Flow A** (web-first → link WhatsApp
+via a regenerable linking code, nao's pattern). Convergence rule: always link
+into the current session; a simple **v1 claim/merge** flow (detect + verify-to-
+link, no fuzzy matching) handles the case where the same person independently
+created a phone account and an email account. Invariant: one better-auth user,
+N linked identities, reachable via either door. Web-session magic links use
+better-auth's single-use `verification` token, never the reusable linking code.
+Full model in #1211 §6.6.
+
 ```txt
- 1. sign up                                    ~2 min
- 2. connect WhatsApp (verify their number)     ~3 min
- 3. add ONE forwarding rule                   ~10 min   guided, per-provider,
-                                                        with screenshots
- 4. paste price list / last 3 quotes           ~8 min   becomes the price book
- 5. confirm trade, region, capacity            ~2 min   the signal filter
+ 1. tap wa.me link, send first message         ~1 min   phone = account identity
+                                                         (creates account+workspace)
+ 2. conversational signup in WhatsApp           ~3 min   no email, no password, no form
+ 3. add ONE forwarding rule                    ~10 min   guided, per-provider,
+                                                         with screenshots
+ 4. paste price list / last 3 quotes            ~8 min   becomes the price book
+ 5. confirm trade, region, capacity             ~2 min   the signal filter
  6. live — first draft on the next lead
 ```
+
+**This REPLACES the email-forward-rule as the OWNER onboarding path.** The
+owner no longer signs up via email; they sign up by texting our number. Email
+forwarding (step 3, rung 1) is **not** how the owner establishes identity — it
+stays relevant only for **ingesting the owner's own inbound LEADS** later (the
+RESPOND/FIND pipe, §(a)). Keep that distinction explicit: *owner identity =
+WhatsApp; lead ingestion = forwarding.* Two different concerns that happen to
+both touch email/WhatsApp.
 
 Everything else is progressive and post-value: OAuth (rung 2), send-as
 (rung 3), marketplace accounts for BID, the customer landing page (delivered
@@ -867,6 +932,11 @@ critical path is a component #1127 flagged as its risk centre.
 5. **WhatsApp outbound notification**, batched — #1127 slice 1a narrowed to a
    single provisioned binding, plus the send half of slice 2, plus the
    notification abstraction.
+5b. **WhatsApp-native signup** — #1127 slice 1c: the owner's first inbound to
+   the Seneca number creates their account + workspace + agent (phone = account
+   identity), conversational onboarding in the thread, and a magic link over
+   WhatsApp for web workspace access. This REPLACES email-based owner signup;
+   there is no email-forward fallback for establishing identity.
 6. **FOLLOW UP v1**: a cadence on unanswered quotes and a post-job review
    request. Cheap, and it carries the best-evidenced lever we have.
 7. **CH deployment**: Exoscale CH zone, CH Postgres, Infomaniak models,
@@ -1024,13 +1094,24 @@ share of leads arriving outside business hours.
    VM; all three are a cliff at the third or fourth customer, including for
    backup, which #853 left provider-independent and unbuilt (#877). Do not let
    "it worked for the pilot" become the multi-tenant architecture by default.
-8. **Meta Business API timeline — correcting a common assumption.** Standard
-   onboarding is roughly **3-10 business days**: 2-4 days for Business
-   Verification, hours for WABA and number setup, 24-48 hours for first
-   template approval. The 2-8 week figure is the **green-tick Official Business
-   Account badge, which we do not need** for a bot the customer expects to hear
-   from. Start verification on day one — it is free and parallel — but do not
-   sequence engineering behind it or tell the customer it is the blocker.
+8. **Meta Business API timeline — and it is now the true single technical
+   critical path (2026-08-11 identity ruling).** Standard onboarding is roughly
+   **3-10 business days**: 2-4 days for Business Verification, hours for WABA
+   and number setup, 24-48 hours for first template approval. The 2-8 week
+   figure is the **green-tick Official Business Account badge, which we do not
+   need** for a bot the customer expects to hear from. Start verification on
+   day one — it is free and parallel.
+   **What changed:** because signup is now WhatsApp-native (§ Onboarding), the
+   verified Seneca WABA is the gate through which every customer enters —
+   **there is no email-forward fallback for establishing identity**. So Meta
+   WABA verification, previously "do not sequence engineering behind it", is now
+   the **single technical critical path for onboarding at all**. It is still
+   only ~3-10 days and still parallelisable with engineering — but it can no
+   longer be treated as optional or deferrable. **Note the scope stays small:**
+   one Seneca WABA + business verification, **no Embedded Signup, no
+   per-customer OAuth** (users text OUR number; their number is just their
+   identity). The genuine *business* critical path remains the named pilot
+   customer (risk 9); these are two different gates.
 9. **The real critical path is the pilot customer.** Engineering is bounded and
    parallelisable; a firm's decision to route its leads through us is not.
    Secure a named design partner, in the recommended vertical, with written
@@ -1067,6 +1148,16 @@ share of leads arriving outside business hours.
    pieces land upstream: #1127 slices, the share capability-token layer, and
    the notification abstraction.
 9. **One paying customer before the second vertical is built.**
+10. **Owner onboarding is WhatsApp-native (2026-08-11 ruling):** phone number =
+    account identity, conversational signup via a `wa.me` click-to-chat link, no
+    email/password/web form; web access by magic link over WhatsApp. Reuses
+    #1211 §6.6 verbatim (one Seneca number, multi-tenant by sender, no Embedded
+    Signup, no per-customer OAuth). This REPLACES email-based owner signup;
+    email forwarding stays only for lead ingestion. Consequence: the verified
+    Seneca WABA becomes the single technical onboarding gate (risk 8).
+    **Implementation is a small extension of existing better-auth** — phone as
+    identity provider #4 + a WhatsApp delivery adapter for the already-wired
+    magic-link plugin — not a new auth system.
 
 ## Test seams
 
@@ -1103,14 +1194,23 @@ reject → send on tap.
 **Blocked by:** slice 1.
 **Proof:** expiry/revocation uniformity; approve-sends and no-tap-never-sends.
 
-### Slice 3: WhatsApp outbound notification
+### Slice 3: WhatsApp-native signup + outbound notification
 **Delivers:** #1127 slice 1a narrowed to one provisioned binding (webhook core,
 binding store with the single-transaction dedupe insert, credentials, flag,
-trusted-caller seam with guardrails), the send half of slice 2, and the
-notification delivery abstraction off `AskUserStore.subscribe()` with batching.
-**Explicitly not** slice 1b turn assembly or channel-side answering.
-**Blocked by:** slice 2; Meta verification (owner-side, parallel).
-**Proof:** fake-channel loop in CI; live demo to a test number.
+trusted-caller seam with guardrails); **#1127 slice 1c** — WhatsApp/phone as
+better-auth identity provider #4 (first inbound = account+workspace creation
+keyed on the sender number, channel-as-verifier, conversational onboarding) and
+the **magic-link WhatsApp delivery adapter** wiring the existing better-auth
+`sendMagicLink` to WhatsApp (no new token/session code; phone OTP fallback);
+the send half of slice 2;
+and the notification delivery abstraction off `AskUserStore.subscribe()` with
+batching. **Explicitly not** slice 1b turn assembly or in-channel answering.
+**Blocked by:** slice 2; Meta WABA verification (owner-side, now the single
+technical onboarding gate — risk 8).
+**Proof:** fake-channel loop in CI; a first inbound from a new number
+provisions exactly one account+workspace (idempotent on repeat); a magic link
+establishes a web session on first tap and fails closed on second tap; live
+demo to a test number.
 
 ### Slice 4: FOLLOW UP + customer landing page
 **Delivers:** follow-up cadence on unanswered quotes, post-job review request,
@@ -1199,6 +1299,14 @@ people who have not contacted the customer.
     status (§ source conflicts). One email or one call each.
 
 ## Revision note
+
+**2026-08-11 addendum:** owner ratified a WhatsApp-native signup/identity model
+— phone number = account identity, conversational signup via `wa.me`
+click-to-chat, magic-link-over-WhatsApp for web access. This replaces
+email-based owner onboarding (email forwarding is retained only for lead
+ingestion), pulls in #1127 slice 1c, and makes the verified Seneca WABA the
+single technical onboarding gate. Folded into § Onboarding, §(b), MVP, risk 8,
+slice 3, and decision 10.
 
 r3 folds in the platform, tooling, mail-provider and real-estate research.
 Four things changed materially from r2, all of them corrections rather than

--- a/docs/issues/1210/plan.md
+++ b/docs/issues/1210/plan.md
@@ -837,6 +837,96 @@ N linked identities, reachable via either door. Web-session magic links use
 better-auth's single-use `verification` token, never the reusable linking code.
 Full model in #1211 §6.6.
 
+### Signup flows + reconciliation (diagram)
+
+Two entry doors, one better-auth account. The diagram traces both signup paths,
+the link-into-session rule, the collision/merge case, and the point where the
+placeholder email is replaced by the real one at first payment.
+
+```mermaid
+flowchart TD
+    subgraph doors["Two entry doors"]
+        LP["Door A: Landing page (web)"]
+        WA["Door B: wa.me/&lt;seneca-number&gt; (WhatsApp)"]
+    end
+
+    %% ---- Door A: web-first (EXISTING better-auth) ----
+    LP --> A1["Email / password or Google signup<br/>(EXISTING better-auth: emailAndPassword + socialProviders)"]
+    A1 --> A2["better-auth account created<br/>identity: email (+ optional google)"]
+    A2 --> A3{"Link WhatsApp later?"}
+    A3 -->|"yes"| A4["Show regenerable linking code<br/>(nao pattern; reusable, NOT a magic link)"]
+    A4 --> A5["Customer sends linking code from WhatsApp"]
+    A5 --> LINK
+
+    %% ---- Door B: WhatsApp-first ----
+    WA --> B0["Seneca bot: inbound proves number control<br/>(channel = verifier, WhatsApp OTP available)"]
+    B0 --> BQ{"Signup path"}
+
+    %% b1: phone-native
+    BQ -->|"b1: phone-native"| B1a["phoneNumber plugin signup<br/>(NEW plugin) + WhatsApp OTP"]
+    B1a --> B1b["getTempEmail() placeholder fills<br/>required email schema field"]
+    B1b --> B1c["better-auth account created<br/>identity: phone (+ placeholder email)"]
+    B1c --> CONV
+
+    %% b2: round-trip to LP for email signup
+    BQ -->|"b2: redirect to LP"| B2a["Bot sends LP link with SIGNED round-trip token<br/>(binds this WhatsApp identity)"]
+    B2a --> B2b["Email / Google signup on LP (EXISTING better-auth)"]
+    B2b --> B2c["Round-trip token returns to WhatsApp<br/>-> phone linked to the email account"]
+    B2c --> LINK
+
+    %% ---- Reconciliation ----
+    LINK["Link-into-session rule:<br/>authenticated session + 2nd identity presented<br/>=> LINK to current user, NEVER create a new account<br/>(requires account.accountLinking - NEW)"]
+    LINK --> CONV
+
+    CONV(["ONE better-auth account<br/>internal user id + linked identities:<br/>email + phone + google"])
+
+    %% ---- Collision case ----
+    COL["Collision: same person made TWO independent accounts<br/>(phone account AND email account, never in one session)"]
+    COL --> MERGE["v1 claim/verify-to-merge<br/>(detect + verify ownership of both, no fuzzy matching)"]
+    MERGE --> CONV
+
+    %% ---- Placeholder email replacement ----
+    CONV --> PAY{"First payment?<br/>(invoice / receipt / CH records)"}
+    PAY -->|"yes"| REPL["getTempEmail() placeholder REPLACED<br/>by the customer's REAL email<br/>(progressive email becomes effectively required)"]
+    REPL --> CONV
+    PAY -->|"not yet"| CONV
+```
+
+### Auth additions required
+
+**Does the existing default sign-in / sign-up need changes to support WhatsApp
+auth? Yes.** The two web-first paths (door A, and door b2's LP hop) reuse the
+current better-auth stack verbatim. But WhatsApp-native signup (door b1),
+cross-door linking, and merge each require a concrete addition. All four are
+extensions of the existing provider-agnostic user model — no new auth engine.
+
+**What exists today (verified 2026-08-11, `packages/core/src/server/auth/createAuth.ts`):**
+email/password (`emailAndPassword.enabled`, line 257), Google + GitHub OAuth
+(`socialProviders`, line 155), and the magic-link plugin (line 130) whose
+`sendMagicLink` currently **renders an email and sends it over the email
+`transport`** (`renderMagicLink` → `transport.send`, lines 131-139) — it is
+wired to email delivery, not to WhatsApp, and not to phone. There is **no
+`account.accountLinking`** configured (the `account` block, lines 235-248, sets
+field mappings only) and **no `phoneNumber` plugin** in the `plugins` array
+(magic-link is the only plugin, lines 128-142).
+
+| Concern | Exists today | To add for WhatsApp auth |
+| --- | --- | --- |
+| Email/password sign-up | ✅ `emailAndPassword.enabled` (createAuth.ts:257) | — (reused as-is by door A / b2) |
+| Google + GitHub OAuth | ✅ `socialProviders` (createAuth.ts:155) | — (reused as-is) |
+| Magic-link plugin | ✅ mounted (createAuth.ts:130); `sendMagicLink` renders + sends over **email** transport (131-139) | **(3)** add a **WhatsApp delivery adapter** so `sendMagicLink` can emit the *same* token URL over WhatsApp (web-session-over-WhatsApp); no new token/redeem/session code |
+| Cross-door identity linking | ❌ **no** `account.accountLinking` | **(1)** enable `account.accountLinking` so "add email later" and link-into-session are native (no migration) |
+| Phone as an identity | ❌ **no** `phoneNumber` plugin | **(2)** install + configure better-auth `phoneNumber` plugin, with `getTempEmail` to fill the required-email schema field for phone-native (door b1) accounts, and `sendOTP` for WhatsApp OTP |
+| OTP delivery over WhatsApp | ❌ (channel unused for auth) | **(3)** wire the WhatsApp delivery adapter to the `phoneNumber` plugin's `sendOTP` (phone OTP) and/or the magic-link `sendMagicLink` |
+| Web-first → WhatsApp round-trip (door b2) | ❌ | **(4)** a **signed round-trip token** flow: LP-signup link carries a signed token binding the WhatsApp identity, and returns to bind phone ↔ email account |
+| Collision merge | ❌ | v1 claim/verify-to-merge (rides on **(1)** `accountLinking`) |
+
+**Net:** four additions — (1) `accountLinking`, (2) `phoneNumber` plugin +
+`getTempEmail`, (3) a WhatsApp delivery adapter for `sendOTP` / `sendMagicLink`,
+(4) the door-b2 signed round-trip token. Nothing in the existing email/OAuth/
+magic-link paths is removed or rewritten; WhatsApp/phone becomes identity
+provider #4 on the same account model.
+
 ```txt
  1. tap wa.me link, send first message         ~1 min   phone = account identity
                                                          (creates account+workspace)


### PR DESCRIPTION
Follow-up to merged hachej/boring-ui#1212 (the branch had already merged when the 2026-08-11 WhatsApp-native identity ruling landed).

Adds the WhatsApp-native signup/identity model to the CH-trades plan:
- Funnel: landing page -> `wa.me` click-to-chat -> conversational signup, phone number = account identity. No email/password/web form at signup.
- Replaces email-based owner onboarding; email forwarding stays only for lead ingestion.
- Meta WABA verification becomes the single technical onboarding gate (risk 8); no Embedded Signup / per-customer OAuth.
- Implemented as a small extension of existing better-auth (provider hachej/boring-ui#4 + WhatsApp delivery adapter for the already-wired magic-link plugin; single-use `verification` token for web sessions).
- Progressive email as an identity trust-ladder; two-door flows (A web-first link, B WhatsApp-first) converging on one account with a v1 claim/merge rule.

Docs only. Mirrors hachej/boring-ui#1211 §6.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)