### PR TITLE
refactor(agent): drop forgeable filesystem provenance tag; isolation is structural (#1202 P2)

### DIFF
--- a/packages/agent/src/server/agent-host/__tests__/environmentHttpProjection.test.ts
+++ b/packages/agent/src/server/agent-host/__tests__/environmentHttpProjection.test.ts
@@ -72,7 +72,6 @@ describe('direct Agent Host Environment HTTP projection', () => {
     const binding: RuntimeFilesystemBinding = {
       filesystem: 'company_context',
       access: 'readonly',
-      provenance: 'agent-definition',
       operations: {
         async read() { return { content: 'company' } },
         async list() { return { entries: ['duplicate.md'] } },
@@ -105,7 +104,6 @@ describe('direct Agent Host Environment HTTP projection', () => {
         label: 'company_context',
         rootDir: '/',
         access: 'readonly',
-        provenance: 'agent-definition',
         capabilities: expect.objectContaining({ read: true, list: true, search: true, write: false }),
       }),
     ])

--- a/packages/agent/src/server/agent-host/buildAgentComposition.ts
+++ b/packages/agent/src/server/agent-host/buildAgentComposition.ts
@@ -154,11 +154,11 @@ export async function buildAgentComposition(
     storageRoot: getOptionalRuntimeBundleStorageRoot(runtimeBundle),
   }
   // Agent-carried knowledge (`knowledge/` inside the definition package)
-  // becomes a readonly, agent-scoped filesystem binding with provenance
-  // `agent-definition`. Built here — the one Agent-owned assembly funnel —
-  // so every host (workspace, core, CLI hub) gets it without per-host
-  // wiring, and sibling agents never see it. A declared-but-unmountable
-  // knowledge folder fails this agent's composition closed.
+  // becomes a readonly, agent-scoped filesystem binding. Built here — the
+  // one Agent-owned assembly funnel — so every host (workspace, core, CLI hub)
+  // gets it without per-host wiring, and sibling agents never see it. A
+  // declared-but-unmountable knowledge folder fails this agent's composition
+  // closed.
   const knowledgeRootDir = 'legacyDefault' in input.agent
     ? undefined
     : input.agent.knowledge?.rootDir
@@ -176,7 +176,6 @@ export async function buildAgentComposition(
         AGENT_KNOWLEDGE_FILESYSTEM_ID,
         [{ logicalRoot: '/', sourceRoot: knowledgeRootDir }],
       ),
-      provenance: 'agent-definition' as const,
     })
   }
   const scopedKnowledgeBinding = knowledgeBinding

--- a/packages/agent/src/server/agent-host/types.ts
+++ b/packages/agent/src/server/agent-host/types.ts
@@ -169,8 +169,8 @@ export interface ConfiguredAgentHostAgentSpec {
   }
   /**
    * Optional agent-carried knowledge shipped inside the definition package.
-   * Composition mounts it as a readonly, agent-scoped filesystem binding
-   * with provenance `agent-definition`; absent = no binding.
+   * Composition mounts it as a readonly, agent-scoped filesystem binding;
+   * absent = no binding.
    */
   readonly knowledge?: {
     /** Host path of the package's `knowledge/` folder. */

--- a/packages/agent/src/server/runtime/mode.ts
+++ b/packages/agent/src/server/runtime/mode.ts
@@ -99,8 +99,6 @@ export interface RuntimeFilesystemBindingOperations {
 export interface RuntimeFilesystemBinding {
   readonly filesystem: string
   readonly access: 'readonly' | 'readwrite'
-  /** Origin of the binding when it was contributed by a definition-shaped source (e.g. an agent package's knowledge/). */
-  readonly provenance?: 'agent-definition'
   readonly operations: RuntimeFilesystemBindingOperations
 }
 

--- a/packages/boring-bash/src/agent/runtime/types.ts
+++ b/packages/boring-bash/src/agent/runtime/types.ts
@@ -60,8 +60,6 @@ export interface RuntimeFilesystemBindingOperations {
 export interface RuntimeFilesystemBinding {
   readonly filesystem: string
   readonly access: 'readonly' | 'readwrite'
-  /** Origin of the binding when it was contributed by a definition-shaped source (e.g. an agent package's knowledge/). */
-  readonly provenance?: 'agent-definition'
   readonly operations: RuntimeFilesystemBindingOperations
 }
 

--- a/packages/boring-bash/src/server/routes/filesystems.ts
+++ b/packages/boring-bash/src/server/routes/filesystems.ts
@@ -66,7 +66,6 @@ function catalogEntry(binding: RuntimeFilesystemBinding): FilesystemCatalogEntry
     label: binding.filesystem,
     rootDir: '/',
     access: binding.access === 'readwrite' ? 'readwrite' : 'readonly',
-    ...(binding.provenance === 'agent-definition' ? { provenance: binding.provenance } : {}),
     capabilities: capabilitiesFor(binding),
   }
 }

--- a/packages/boring-bash/src/shared/catalog.ts
+++ b/packages/boring-bash/src/shared/catalog.ts
@@ -41,8 +41,6 @@ export interface FilesystemCatalogEntry {
   label: string;
   rootDir: LogicalFilesystemRoot;
   access: "readonly" | "readwrite";
-  /** Present when the binding was contributed by a definition-shaped source (e.g. an agent package's knowledge/). */
-  provenance?: "agent-definition";
   capabilities: FilesystemCatalogCapabilities;
 }
 
@@ -80,7 +78,6 @@ export function parseFilesystemCatalog(value: unknown): FilesystemCatalogEntry[]
       label: entry.label,
       rootDir: entry.rootDir as LogicalFilesystemRoot,
       access: entry.access,
-      ...(entry.provenance === "agent-definition" ? { provenance: entry.provenance } : {}),
       capabilities: Object.fromEntries(
         FILESYSTEM_CATALOG_CAPABILITIES.map((capability) => [capability, capabilities[capability]]),
       ) as unknown as FilesystemCatalogCapabilities,


### PR DESCRIPTION
## Summary

Remove the forgeable `RuntimeFilesystemBinding.provenance?: 'agent-definition'` tag and its catalog plumbing. Agent knowledge isolation continues to come from per-agent composition and scoped filesystem operations.

## Issue / Slice

Follow-up P2 cleanup from merged #1202.

## What Changed

- Removed the field from the agent and boring-bash runtime binding contracts.
- Stopped setting, serializing, parsing, and documenting the tag.
- Removed the catalog projection assertion that promised the tag.
- Left knowledge binding composition and sibling isolation behavior intact.

## Proof

- `pnpm exec vitest run src/server/agent-host/__tests__/createAgentHost.test.ts -t 'mounts an agent definition knowledge/ folder as a readonly agent-scoped agent_knowledge binding invisible to sibling agents'` — 1 passed; unchanged sibling-isolation test remains green.
- `pnpm exec vitest run --maxWorkers=4` in `packages/agent` — 221 files passed, 2 skipped; 2,036 tests passed, 17 skipped; no type errors.
- `pnpm test` in `packages/boring-bash` — 16 files, 62 tests passed.
- `pnpm typecheck` in `packages/agent` — green.
- `pnpm typecheck` in `packages/boring-bash` — green.
- `git diff --check` — green.

## Review

- Standards/spec review: complete after restoring the prior shallow-wrapper/freeze semantics around the knowledge binding.
- Isolation path: no changes found.
- Reviewed SHA: `b83f59fe2`.

## Risk / Rollback

Low-risk contract cleanup. Revert `b83f59fe2` to restore the decorative field and catalog projection.

## Next

- [ ] Owner review.
- [ ] Merge only after approval; this PR must not be auto-merged.
