### PR TITLE
fix(cli): stop pooling workspace-local agent packages into the global fleet (#1202 P0 isolation)

### DIFF
--- a/packages/agent/docs/AGENT_PACKAGES.md
+++ b/packages/agent/docs/AGENT_PACKAGES.md
@@ -1,21 +1,22 @@
 # Workspace agent packages
 
-With `BORING_AGENT_FLEET=1`, an agent definition may come from either the
-repository's `.agents/personas/` packages or a local package path registered in
-the workspace's `.pi/settings.json#packages`. Registration makes an agent
-package discoverable. It does not activate the agent: the class-B
-`.agents/factory/fleet.yaml` roster must also seat the package's
-`boring.agent.definitionId`.
+With `BORING_AGENT_FLEET=1`, a single-workspace host may discover an agent
+definition from either the trusted repository's `.agents/personas/` packages
+or a local package path registered in that workspace's
+`.pi/settings.json#packages`. Registration makes an agent package discoverable.
+It does not activate the agent: the class-B `.agents/factory/fleet.yaml` roster
+must also seat the package's `boring.agent.definitionId`.
 
 Agent fleet changes are boot-time changes. `/reload` can refresh ordinary
 plugin resources, but installing, updating, seating, unseating, or removing an
 agent requires restarting the workspace/CLI host.
 
-The CLI workspaces hub collects local agent packages from every available
-registered workspace when the process starts. Its Agent Host is shared, so two
-workspaces claiming the same `definitionId` conflict host-wide and both claims
-fail closed. Adding a workspace or changing its package registrations requires
-restarting the hub.
+The CLI workspaces hub has one Agent Host shared by every registered workspace.
+Its global fleet therefore admits only personas from the trusted repository's
+`.agents/personas/`; it does not admit agent definitions from any workspace's
+local package registrations. Local packages keep their ordinary plugin
+surfaces in their owning workspace. Seating workspace-local agent definitions
+in workspaces mode requires a future workspace-scoped fleet boundary.
 
 ## Install and seat
 
@@ -35,9 +36,11 @@ seats:
     skills: []
 ```
 
-Restart with `BORING_AGENT_FLEET=1`. A valid seated package appears in the
-agent catalog. An installed package without a matching seat remains inert and
-reports `AGENT_DEFINITION_UNSEATED` during fleet composition.
+Restart a single-workspace host with `BORING_AGENT_FLEET=1`. A valid seated
+package appears in the agent catalog. An installed package without a matching
+seat remains inert and reports `AGENT_DEFINITION_UNSEATED` during fleet
+composition. The shared CLI workspaces hub never admits the local agent
+contribution, even when the global roster names its definition id.
 
 ## Update
 
@@ -68,8 +71,10 @@ excluded with `AGENT_FLEET_SEAT_PERSONA_INVALID` while other agents boot.
 
 ## v1 distribution boundary
 
-Only repository personas and workspace-registered local package paths may
-contribute agents in v1. Git/npm package sources — including their materialized
-`.pi/git/` and `.pi/npm/` directories — cannot contribute an agent until the
-remote-distribution trust gate ships. Their non-agent plugin surfaces continue
-through the normal plugin pipeline unchanged.
+Repository personas may contribute agents to any fleet in v1. A
+workspace-registered local package path may contribute an agent only to a
+single-workspace host; it never enters the CLI workspaces hub's global fleet.
+Git/npm package sources — including their materialized `.pi/git/` and
+`.pi/npm/` directories — cannot contribute an agent until the
+remote-distribution trust gate ships. All excluded packages' non-agent plugin
+surfaces continue through the normal plugin pipeline unchanged.

--- a/packages/cli/src/__tests__/pluginDiscovery.test.ts
+++ b/packages/cli/src/__tests__/pluginDiscovery.test.ts
@@ -5,9 +5,8 @@ import {
   getGlobalPiExtensionsRoot,
   readCliPluginPiSnapshot,
   resolveCliBoringPluginDirs,
-  resolveCliLocalAgentPackageDirs,
 } from "../server/pluginDiscovery.js"
-import { mkdir, mkdtemp, writeFile, rm, symlink } from "node:fs/promises"
+import { mkdir, mkdtemp, writeFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 
 async function makeTempDir(prefix: string): Promise<string> {
@@ -180,45 +179,6 @@ describe("plugin discovery helpers", () => {
     try {
       const snapshot = readCliPluginPiSnapshot(workspaceRoot, { globalRoot: join(root, "global-extensions"), includeDefaultPackages: false })
       expect(snapshot.systemPromptAppend).toContain("File prompt")
-    } finally {
-      await rm(root, { recursive: true, force: true })
-    }
-  })
-
-  test("agent fleet sources include workspace-local paths but exclude remote package specs", async () => {
-    const root = await makeTempDir("boring-cli-agent-package-sources-")
-    const workspaceRoot = join(root, "host-workspace")
-    const localAgent = join(workspaceRoot, "agents", "local-agent")
-    await mkdir(join(workspaceRoot, ".pi"), { recursive: true })
-    const remoteAgent = join(workspaceRoot, ".pi", "npm", "materialized-remote-agent")
-    await mkdir(remoteAgent, { recursive: true })
-    await mkdir(join(workspaceRoot, "agents"), { recursive: true })
-    await symlink(remoteAgent, join(workspaceRoot, "agents", "remote-alias"))
-    await writePiSettings(join(workspaceRoot, ".pi", "settings.json"), [
-      "../agents/local-agent",
-      "file:../agents/file-agent",
-      "../agents/remote-alias",
-      "npm:@fixture/remote-agent",
-      "git:https://example.test/remote-agent.git",
-      "./npm/materialized-remote-agent",
-      "./git/materialized-remote-agent",
-    ])
-
-    try {
-      expect(resolveCliLocalAgentPackageDirs(workspaceRoot)).toEqual([
-        {
-          rootDir: resolve(localAgent),
-          kind: "external",
-          registered: true,
-          workspaceId: resolve(workspaceRoot),
-        },
-        {
-          rootDir: resolve(workspaceRoot, "agents", "file-agent"),
-          kind: "external",
-          registered: true,
-          workspaceId: resolve(workspaceRoot),
-        },
-      ])
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/packages/cli/src/server/__tests__/modeApps.agentHost.test.ts
+++ b/packages/cli/src/server/__tests__/modeApps.agentHost.test.ts
@@ -143,18 +143,25 @@ async function fixtureApp(useConfiguredSessionRoot: boolean) {
 }
 
 describe.sequential("CLI Agent Host composition", () => {
-  it("workspaces hub boots a seated agent from a registered workspace-local package", async () => {
+  it("workspaces hub excludes workspace-local packages from its global fleet", async () => {
     const fleetRoot = await temporaryRoot("boring-cli-local-agent-fleet-")
-    const workspaceRoot = await temporaryRoot("boring-cli-local-agent-workspace-")
+    const workspaceARoot = await temporaryRoot("boring-cli-local-agent-workspace-a-")
+    const workspaceBRoot = await temporaryRoot("boring-cli-local-agent-workspace-b-")
     const registryRoot = await temporaryRoot("boring-cli-local-agent-registry-")
-    const packageRoot = join(workspaceRoot, "agents", "local-worker")
+    const localPackageRoot = join(workspaceARoot, "agents", "local-worker")
+    const duplicatePackageRoot = join(workspaceARoot, "agents", "duplicate-repository-worker")
+    const repositoryPackageRoot = join(fleetRoot, ".agents", "personas", "repository-worker")
     const registryPath = join(registryRoot, "workspaces.yaml")
-    await createLocalWorkspaceRegistry(registryPath).add(workspaceRoot)
-    await mkdir(packageRoot, { recursive: true })
-    await mkdir(join(workspaceRoot, ".pi"), { recursive: true })
+    const registry = createLocalWorkspaceRegistry(registryPath)
+    await registry.add(workspaceARoot)
+    const workspaceB = await registry.add(workspaceBRoot)
+    await mkdir(localPackageRoot, { recursive: true })
+    await mkdir(join(duplicatePackageRoot, "knowledge"), { recursive: true })
+    await mkdir(join(repositoryPackageRoot, "knowledge"), { recursive: true })
+    await mkdir(join(workspaceARoot, ".pi"), { recursive: true })
     await mkdir(join(fleetRoot, ".agents", "factory"), { recursive: true })
-    await writeFile(join(packageRoot, "instructions.md"), "CLI local worker.\n", "utf8")
-    await writeFile(join(packageRoot, "package.json"), JSON.stringify({
+    await writeFile(join(localPackageRoot, "instructions.md"), "CLI local worker.\n", "utf8")
+    await writeFile(join(localPackageRoot, "package.json"), JSON.stringify({
       name: "@fixture/cli-local-worker",
       version: "1.0.0",
       boring: {
@@ -167,14 +174,53 @@ describe.sequential("CLI Agent Host composition", () => {
       },
       pi: { skills: [] },
     }), "utf8")
+    await writeFile(join(duplicatePackageRoot, "instructions.md"), "Workspace A duplicate worker.\n", "utf8")
+    await writeFile(join(duplicatePackageRoot, "knowledge", "scope.md"), "Workspace A only.\n", "utf8")
+    await writeFile(join(duplicatePackageRoot, "package.json"), JSON.stringify({
+      name: "@fixture/cli-duplicate-repository-worker",
+      version: "1.0.0",
+      boring: {
+        agent: {
+          definitionId: "fixture-cli-repository-worker",
+          version: "1.0.0",
+          label: "Workspace A Duplicate Worker",
+          instructionsRef: "instructions.md",
+        },
+      },
+      pi: { skills: [] },
+    }), "utf8")
+    await writeFile(join(repositoryPackageRoot, "instructions.md"), "CLI repository worker.\n", "utf8")
+    await writeFile(join(repositoryPackageRoot, "knowledge", "scope.md"), "Repository owned.\n", "utf8")
+    await writeFile(join(repositoryPackageRoot, "package.json"), JSON.stringify({
+      name: "@fixture/cli-repository-worker",
+      version: "1.0.0",
+      boring: {
+        agent: {
+          definitionId: "fixture-cli-repository-worker",
+          version: "1.0.0",
+          label: "CLI Repository Worker",
+          instructionsRef: "instructions.md",
+        },
+      },
+      pi: { skills: [] },
+    }), "utf8")
     await writeFile(
-      join(workspaceRoot, ".pi", "settings.json"),
-      JSON.stringify({ packages: ["../agents/local-worker"] }),
+      join(workspaceARoot, ".pi", "settings.json"),
+      JSON.stringify({ packages: ["../agents/local-worker", "../agents/duplicate-repository-worker"] }),
       "utf8",
     )
     await writeFile(
       join(fleetRoot, ".agents", "factory", "fleet.yaml"),
-      "seats:\n  - seat: local-worker\n    agentTypeId: fixture-cli-local-worker\n    skills: []\n",
+      [
+        "seats:",
+        "  - seat: repository-worker",
+        "    agentTypeId: fixture-cli-repository-worker",
+        "    skills: []",
+        "  - seat: local-worker",
+        "    agentTypeId: fixture-cli-local-worker",
+        "    skills: []",
+        "",
+      ].join("\n"),
       "utf8",
     )
 
@@ -193,16 +239,47 @@ describe.sequential("CLI Agent Host composition", () => {
       expect(createAgentHost).toHaveBeenCalledWith(expect.objectContaining({
         agents: expect.arrayContaining([
           expect.objectContaining({ agentTypeId: "default" }),
-          expect.objectContaining({ agentTypeId: "fixture-cli-local-worker" }),
+          expect.objectContaining({ agentTypeId: "fixture-cli-repository-worker" }),
         ]),
       }))
+      const agents = createAgentHost.mock.calls[0]?.[0].agents ?? []
+      expect(agents).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ agentTypeId: "fixture-cli-local-worker" }),
+      ]))
+      expect(agents).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          agentTypeId: "fixture-cli-repository-worker",
+          definition: expect.objectContaining({
+            instructions: "CLI repository worker.\n",
+            digest: expect.stringMatching(/^sha256:/),
+          }),
+          knowledge: { rootDir: join(repositoryPackageRoot, "knowledge") },
+        }),
+      ]))
+
+      const workspaceBAgents = await app.inject({
+        method: "GET",
+        url: "/api/v1/agents",
+        headers: { "x-boring-workspace-id": workspaceB.id },
+      })
+      expect(workspaceBAgents.statusCode, workspaceBAgents.body).toBe(200)
+      expect(workspaceBAgents.json()).toEqual(expect.arrayContaining([
+        expect.objectContaining({ agentTypeId: "default" }),
+        expect.objectContaining({
+          agentTypeId: "fixture-cli-repository-worker",
+          label: "CLI Repository Worker",
+        }),
+      ]))
+      expect(workspaceBAgents.json()).not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ agentTypeId: "fixture-cli-local-worker" }),
+      ]))
     } finally {
       if (app) await app.close()
       process.chdir(previousCwd)
       if (previousFlag === undefined) delete process.env.BORING_AGENT_FLEET
       else process.env.BORING_AGENT_FLEET = previousFlag
     }
-  })
+  }, 30_000)
 
   it("closes folder-mode Host and front runtime when post-mount runtime route init fails", async () => {
     const workspaceRoot = await temporaryRoot("boring-cli-folder-post-mount-cleanup-")

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -960,15 +960,11 @@ export async function createWorkspacesModeApp(opts: {
   const fleetRepositoryRoot = process.cwd()
   let discoveredAgentPackages: Awaited<ReturnType<typeof workspaceServer.discoverRepositoryAgentPackages>> | undefined
   if (process.env.BORING_AGENT_FLEET === "1") {
-    const registeredWorkspaceRoots = (await registry.list())
-      .filter((workspace) => workspace.available)
-      .map((workspace) => workspace.path)
-    const packageWorkspaceRoots = [...new Set([fleetRepositoryRoot, ...registeredWorkspaceRoots])]
-    discoveredAgentPackages = await workspaceServer.discoverRepositoryAgentPackages(fleetRepositoryRoot, {
-      localPackageSources: packageWorkspaceRoots.flatMap((root) => (
-        pluginDiscovery.resolveCliLocalAgentPackageDirs(root)
-      )),
-    })
+    // This Host is shared by every registered workspace, so only repository-
+    // owned personas may enter its fleet. Workspace-local package descriptors
+    // carry no scope once handed to the Agent fleet loader; admitting them here
+    // would let one workspace seat an agent (and its knowledge) for all others.
+    discoveredAgentPackages = await workspaceServer.discoverRepositoryAgentPackages(fleetRepositoryRoot)
   }
   const agentHost = await agentServer.createAgentHost({
     // The hub serves a DIFFERENT root per registered workspace, so there is no

--- a/packages/cli/src/server/pluginDiscovery.ts
+++ b/packages/cli/src/server/pluginDiscovery.ts
@@ -3,7 +3,6 @@ import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import {
   BoringPluginAssetManager,
-  isRemoteMaterializedPiPackageRoot,
   type BoringPluginFrontTargetResolver,
   type BoringPluginSourceInput,
 } from "@hachej/boring-workspace/server"
@@ -126,27 +125,6 @@ export function resolveCliBoringPluginDirs(
     seen.add(key)
     return true
   })
-}
-
-/**
- * Workspace-local package roots eligible to contribute `boring.agent` at
- * fleet boot. `resolveRegisteredPluginSourceDirs` returns local path entries
- * only, so installed git/npm copies remain ordinary plugins until the remote
- * agent-distribution gate is implemented.
- */
-export function resolveCliLocalAgentPackageDirs(
-  workspaceRoot: string,
-): BoringPluginSourceInput[] {
-  const resolvedWorkspaceRoot = resolve(workspaceRoot)
-  const localScope = resolvePluginSourceScopePaths("local", { workspaceRoot: resolvedWorkspaceRoot })
-  return resolveRegisteredPluginSourceDirs(localScope)
-    .filter((record) => !isRemoteMaterializedPiPackageRoot(record.rootDir, localScope))
-    .map((record) => ({
-      rootDir: record.rootDir,
-      kind: "external" as const,
-      registered: true,
-      workspaceId: resolvedWorkspaceRoot,
-    }))
 }
 
 export function readCliPluginPiSnapshot(


### PR DESCRIPTION
## Summary

Stops the CLI workspaces hub from pooling workspace-local agent packages into its shared global AgentHost fleet. Repository-owned personas remain globally seated.

## Issue / Slice

P0 isolation follow-up to #1202.

## What Changed

- Global workspaces-mode discovery now scans only the trusted repository `.agents/personas` root.
- Removed the now-dead CLI helper that collected `.pi/settings.json` local package roots for global fleet composition.
- Updated agent-package docs to distinguish single-workspace local-package admission from the shared workspaces hub boundary.
- Replaced the old one-workspace happy-path test with a two-workspace isolation regression.

## Leak Path Closed

Previously, workspaces mode enumerated every available registered workspace, resolved each workspace local agent-package roots, flattened all descriptors into one unscoped discovery result, and composed one global AgentHost. Because fleet descriptors carry no workspace scope, workspace A could seat an agent and mount its package knowledge while serving workspace B; a duplicate definition claim could also suppress a repository seat globally.

## Proof

- `pnpm --filter @hachej/boring-ui-cli exec vitest run src/server/__tests__/modeApps.agentHost.test.ts -t "excludes workspace-local packages"` — passed, 1 selected.
- `pnpm --filter @hachej/boring-ui-cli run typecheck` — passed.
- CLI suite — 121 passed, 2 skipped; one pre-existing folder-mode browser integration fails locally after repeated 403 responses. The isolation test and all other CLI tests pass.
- `pnpm --filter @hachej/boring-agent run typecheck` — passed.
- Agent suite — 2033 passed, 17 skipped; three load-sensitive SQLite/timing tests failed under full parallel load and all passed in isolation (1 insufficient-credit replay + 4 event-stream concurrency tests).
- `git diff --check` — passed.
- No dev server started. Screenshot/demo waived: server-side composition boundary with automated regression coverage.

## Isolation Test

The regression registers two workspaces. Workspace A registers a local-only seated package plus a duplicate claimant for the repository persona, each with workspace-local content. It proves the local-only seat is absent, the duplicate cannot suppress the repository seat, the repository digest/knowledge root survives, and workspace B sees only the repository-backed persona.

## Review

- Standards/spec review: clean after docs and dead-helper cleanup.
- Adversarial isolation/thermo review: accepted duplicate-claim, knowledge-provenance, and timeout hardening.
- Final fresh-context review: clean, no P0-P3 findings.
- Reviewed SHA: `599d0c69f8159bc1788b2bfe0b26a104ce349561`.

## Risk / Rollback

Low and intentionally restrictive: workspace-local agent contributions no longer enter the shared workspaces-mode fleet, while ordinary workspace-local plugin surfaces and single-workspace host behavior remain unchanged. Roll back by reverting `599d0c69f8159bc1788b2bfe0b26a104ce349561`.

## Next

Ready for owner review after CI. Do not merge automatically.