### PR TITLE
fix(workspace): factory-mode default seat + drop dead agent-tab exports/dup (#1202 P1/P2)

### DIFF
--- a/apps/workspace-playground/src/front/App.tsx
+++ b/apps/workspace-playground/src/front/App.tsx
@@ -8,7 +8,6 @@ import { diagramPlugin } from "@hachej/boring-diagram/front"
 import { createTasksPlugin } from "@hachej/boring-tasks/front"
 import { SHOWCASE_SESSION_ID, seedShowcase } from "./showcaseMessages"
 import { LoadingStatesShowcase, type LoadingStateMode } from "./LoadingStatesShowcase"
-import { SCRIPTED_DEFAULT_AGENT_TYPE_ID } from "../shared/playgroundAgents"
 
 function isShowcaseRoute(): boolean {
   if (typeof window === "undefined") return false
@@ -81,13 +80,10 @@ function isMultiFilesystemPlaygroundRoute(): boolean {
   return new URLSearchParams(window.location.search).get("multiFilesystem") === "1"
 }
 
-function factoryAgentsEnabled(): boolean {
-  return (import.meta as ImportMeta & { env?: Record<string, string> }).env?.VITE_BORING_FACTORY_AGENTS === "1"
-}
-
 interface WorkspaceMeta {
   projectName?: string
   workspaceId?: string
+  defaultAgentTypeId?: string
 }
 
 const playgroundDeckWidgets: DeckWidgetDefinition[] = [
@@ -134,7 +130,7 @@ function resetPlaygroundStorageIfRequested(): void {
   window.history.replaceState(null, "", `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}${window.location.hash}`)
 }
 
-function WorkspaceFullPageShell() {
+function WorkspaceFullPageShell({ agentTypeId }: { agentTypeId: string }) {
   const parsed = parseFullPagePanelLocation(window.location.search)
 
   if (!parsed.componentId || parsed.error) {
@@ -152,7 +148,7 @@ function WorkspaceFullPageShell() {
 
   return (
     <WorkspaceProvider
-      agentTypeId={factoryAgentsEnabled() ? "boring-concierge" : SCRIPTED_DEFAULT_AGENT_TYPE_ID}
+      agentTypeId={agentTypeId}
       apiBaseUrl=""
       plugins={workspacePlugins}
       persistenceEnabled
@@ -171,11 +167,11 @@ export function WorkspaceShell() {
   const loadingShowcase = useMemo(loadingStateMode, [])
   const fullPage = useMemo(isFullPageRoute, [])
   const multiFilesystem = useMemo(isMultiFilesystemPlaygroundRoute, [])
-  const factoryAgents = useMemo(factoryAgentsEnabled, [])
-  const defaultAgentTypeId = factoryAgents ? "boring-concierge" : SCRIPTED_DEFAULT_AGENT_TYPE_ID
+  const [defaultAgentTypeId, setDefaultAgentTypeId] = useState("")
   const [projectName, setProjectName] = useState("Workspace")
   const [workspaceId, setWorkspaceId] = useState("Workspace")
-  const [metaLoaded, setMetaLoaded] = useState(showcase || fullPage)
+  const [metaLoaded, setMetaLoaded] = useState(Boolean(loadingShowcase))
+  const [metaError, setMetaError] = useState<string | null>(null)
   const [showcaseActiveSessionId, setShowcaseActiveSessionId] = useState(SHOWCASE_SESSION_ID)
   const [showcaseSessions, setShowcaseSessions] = useState(createInitialShowcaseSessions)
   const sessions = showcase ? showcaseSessions : undefined
@@ -219,27 +215,33 @@ export function WorkspaceShell() {
   )
 
   useEffect(() => {
-    if (showcase || loadingShowcase || fullPage) return
+    if (loadingShowcase) return
     let cancelled = false
     void fetch("/api/v1/workspace/meta")
-      .then(async (res) => res.ok ? await res.json() as WorkspaceMeta : null)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`workspace metadata request failed (${res.status})`)
+        return await res.json() as WorkspaceMeta
+      })
       .then((meta) => {
         if (cancelled) return
         const next = meta?.projectName?.trim()
         const nextWorkspaceId = meta?.workspaceId?.trim() || next
-        if (next) {
+        const nextDefaultAgentTypeId = meta?.defaultAgentTypeId?.trim()
+        if (!nextDefaultAgentTypeId) throw new Error("workspace metadata did not include a default agent")
+        if (next && !showcase) {
           setProjectName(next)
         }
-        if (nextWorkspaceId) {
+        if (nextWorkspaceId && !showcase) {
           setWorkspaceId(nextWorkspaceId)
         }
+        if (nextDefaultAgentTypeId) setDefaultAgentTypeId(nextDefaultAgentTypeId)
         setMetaLoaded(true)
       })
       .catch(() => {
-        if (!cancelled) setMetaLoaded(true)
+        if (!cancelled) setMetaError("The playground could not load its agent roster. Reload to try again.")
       })
     return () => { cancelled = true }
-  }, [showcase, loadingShowcase, fullPage])
+  }, [showcase, loadingShowcase])
 
   if (showcase) seedShowcase(SHOWCASE_SESSION_ID)
 
@@ -247,12 +249,19 @@ export function WorkspaceShell() {
     return <LoadingStatesShowcase mode={loadingShowcase} />
   }
 
-  if (fullPage) {
-    return <WorkspaceFullPageShell />
+  if (!metaLoaded || !defaultAgentTypeId) {
+    if (metaError) {
+      return (
+        <div className="flex h-screen w-screen items-center justify-center bg-background p-6">
+          <p role="alert" className="max-w-md text-center text-sm text-destructive">{metaError}</p>
+        </div>
+      )
+    }
+    return <div className="h-screen w-screen bg-background" />
   }
 
-  if (!metaLoaded) {
-    return <div className="h-screen w-screen bg-background" />
+  if (fullPage) {
+    return <WorkspaceFullPageShell agentTypeId={defaultAgentTypeId} />
   }
 
   return (

--- a/apps/workspace-playground/src/server/dev.ts
+++ b/apps/workspace-playground/src/server/dev.ts
@@ -9,13 +9,13 @@ import {
   SCRIPTED_ONE_AGENT,
   SCRIPTED_ONE_AGENT_CAPABILITY_PLUGINS,
   SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS,
-  SCRIPTED_TWO_AGENT_DEFAULT,
   SCRIPTED_TWO_AGENT_FLEET,
 } from "./testing/twoAgentFleet"
 import { createWorkspaceAgentServer } from "@hachej/boring-workspace/app/server"
 import { createWorkspaceBeadsOperations } from "@hachej/boring-tasks/server"
 import { loadBoringFactoryAgents } from "./factoryAgents"
 import { resolvePlaygroundAgentMode } from "./playgroundAgentMode"
+import { resolvePlaygroundDefaultAgentTypeId } from "../shared/playgroundAgents"
 
 export const AGENT_API_PORT = Number(process.env.AGENT_API_PORT) || 5210
 export const VITE_PORT = Number(process.env.PORT) || 5200
@@ -74,6 +74,7 @@ export async function startPlaygroundServer(): Promise<void> {
     const factoryAgents = agentMode === "factory" ? await loadBoringFactoryAgents({ workspaceRoot }) : undefined
     const scriptedAgents = agentMode === "scripted-multi" ? SCRIPTED_TWO_AGENT_FLEET : SCRIPTED_ONE_AGENT
     const agents = factoryAgents ?? scriptedAgents
+    const defaultAgentTypeId = resolvePlaygroundDefaultAgentTypeId(agents)
     const scriptedCapabilityPlugins = agentMode === "scripted-multi"
       ? SCRIPTED_TWO_AGENT_CAPABILITY_PLUGINS
       : agentMode === "scripted-single" ? SCRIPTED_ONE_AGENT_CAPABILITY_PLUGINS : []
@@ -96,7 +97,7 @@ export async function startPlaygroundServer(): Promise<void> {
       // production hosts get, instead of relying on the library default.
       readonlyWorkspacePaths: [".agents"],
       agents,
-      defaultAgentTypeId: agentMode === "factory" ? "boring-concierge" : SCRIPTED_TWO_AGENT_DEFAULT,
+      defaultAgentTypeId,
       externalPlugins: EXTERNAL_PLUGINS_ENABLED,
       ...(agentMode === "factory" ? {} : { harnessFactory: createPersistedScriptedPiHarness }),
       plugins: [
@@ -129,6 +130,7 @@ export async function startPlaygroundServer(): Promise<void> {
         projectName: remoteWorkerWorkspaceId ? "Remote worker playground" : localName,
         workspaceId: remoteWorkerWorkspaceId ?? localName,
         workspaceRoot,
+        defaultAgentTypeId,
       }
     })
     await app.listen({ port: AGENT_API_PORT, host: "127.0.0.1" })

--- a/apps/workspace-playground/src/server/factoryAgents.test.ts
+++ b/apps/workspace-playground/src/server/factoryAgents.test.ts
@@ -20,6 +20,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 import { ErrorCode } from '@hachej/boring-agent/shared'
 
 import { loadBoringFactoryAgents, type BoringFactoryRole } from './factoryAgents'
+import { resolvePlaygroundDefaultAgentTypeId } from '../shared/playgroundAgents'
 
 const REPOSITORY_ROOT = resolve(import.meta.dirname, '../../../..')
 // The ratified 3-seat roster (gh-1187 S0), in fleet.yaml order.
@@ -52,8 +53,11 @@ async function expectedInstructions(role: string, skills: readonly string[]): Pr
 describe('loadBoringFactoryAgents (loader against the real .agents/ tree)', () => {
   test('composes exactly the independently expected canonical skills in deterministic order', async () => {
     const agents = await loadBoringFactoryAgents({ workspaceRoot: REPOSITORY_ROOT })
+    const defaultAgentTypeId = resolvePlaygroundDefaultAgentTypeId(agents)
 
     expect(agents.map((agent) => agent.agentTypeId)).toEqual(EXPECTED.map(({ id }) => id))
+    expect(defaultAgentTypeId).toBe(EXPECTED[0].id)
+    expect(agents.some((agent) => agent.agentTypeId === defaultAgentTypeId)).toBe(true)
     for (const [index, expected] of EXPECTED.entries()) {
       const agent = agents[index]
       if (!agent || 'legacyDefault' in agent) throw new Error('factory agent must be configured')

--- a/apps/workspace-playground/src/shared/playgroundAgents.ts
+++ b/apps/workspace-playground/src/shared/playgroundAgents.ts
@@ -1,2 +1,17 @@
-/** Keep the browser's initial provider aligned with the scripted server roster. */
+/** Keep the scripted server roster and its tests aligned on one default id. */
 export const SCRIPTED_DEFAULT_AGENT_TYPE_ID = "alpha"
+
+interface PlaygroundAgentSeat {
+  readonly agentTypeId: string
+}
+
+/** Resolve the playground default from the roster that was actually loaded. */
+export function resolvePlaygroundDefaultAgentTypeId(
+  agents: readonly PlaygroundAgentSeat[],
+): string {
+  const agentTypeId = agents[0]?.agentTypeId.trim()
+  if (agentTypeId) return agentTypeId
+  throw Object.assign(new Error("playground agent roster must include at least one seat"), {
+    code: "PLAYGROUND_AGENT_ROSTER_EMPTY",
+  })
+}

--- a/packages/workspace/src/front/chrome/agents/agentCapabilities.test.ts
+++ b/packages/workspace/src/front/chrome/agents/agentCapabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import {
   fileResourceExists,
+  loadAgentCapabilitySections,
   loadAgentCapabilities,
   parseDescription,
   parseSkills,
@@ -169,7 +170,7 @@ describe("loadAgentCapabilities", () => {
     const client = okClient({ "/skills": new Error("boom") })
     const result = await loadAgentCapabilities(client, "a")
     expect(result.status).toBe("ready")
-    expect(result.skills).toEqual({ status: "error" })
+    expect(result.skills).toEqual({ status: "error", error: "boom" })
     expect(result.tools).toEqual({ status: "loaded", value: [{ name: "t" }] })
     expect(result.description.status).toBe("loaded")
   })
@@ -200,5 +201,27 @@ describe("loadAgentCapabilities", () => {
     expect(client.getJson.mock.calls).toHaveLength(4)
     expect(client.getJson.mock.calls.filter(([p]) => (p as string).startsWith("/api/v1/filesystems"))).toHaveLength(0)
     expect(client.getJson.mock.calls.filter(([p]) => (p as string).startsWith("/api/v1/tree"))).toHaveLength(0)
+  })
+
+  it("loads the Agent management sections without waiting on unused sources", async () => {
+    const client = okClient({
+      "/skills": { skills: [{ name: "visible" }, { name: "management", invocable: false }] },
+      "/tools": new Error("tools down"),
+    })
+    const result = await loadAgentCapabilitySections(client, "a", {
+      refresh: true,
+      includeNonInvocableSkills: true,
+    })
+
+    expect(result.skills).toEqual({
+      status: "loaded",
+      value: [{ name: "management", invocable: false }, { name: "visible" }],
+    })
+    expect(result.tools).toEqual({ status: "error", error: "tools down" })
+    expect(client.getJson).toHaveBeenCalledTimes(2)
+    for (const call of client.getJson.mock.calls) {
+      expect(call[0]).toMatch(/\?refresh=1$/)
+      expect(call[0]).toMatch(/\/(skills|tools)\?refresh=1$/)
+    }
   })
 })

--- a/packages/workspace/src/front/chrome/agents/agentCapabilities.ts
+++ b/packages/workspace/src/front/chrome/agents/agentCapabilities.ts
@@ -41,7 +41,7 @@ export interface AgentDescription {
  */
 export type SourceResult<T> =
   | { status: "loaded"; value: T }
-  | { status: "error" }
+  | { status: "error"; error: string }
 
 export interface AgentCapabilities {
   status: "loading" | "ready"
@@ -64,10 +64,10 @@ export const INITIAL_CAPABILITIES: AgentCapabilities = {
 
 export const UNAVAILABLE_CAPABILITIES: AgentCapabilities = {
   status: "ready",
-  description: { status: "error" },
-  skills: { status: "error" },
-  tools: { status: "error" },
-  modelLabel: { status: "error" },
+  description: { status: "error", error: "This agent's details are unavailable." },
+  skills: { status: "error", error: "Failed to load this agent's skills." },
+  tools: { status: "error", error: "Failed to load this agent's tools." },
+  modelLabel: { status: "error", error: "Models are unavailable." },
 }
 
 export function parseSkills(payload: unknown): AgentSkillSummary[] {
@@ -188,6 +188,47 @@ export interface AgentCapabilitiesClient {
   getJson(path: string, options?: { missingMessage?: string }): Promise<unknown>
 }
 
+export interface LoadAgentCapabilitySectionsOptions {
+  refresh?: boolean
+  includeNonInvocableSkills?: boolean
+}
+
+function sourceError(reason: unknown, fallback: string): SourceResult<never> {
+  return {
+    status: "error",
+    error: reason instanceof Error ? reason.message : fallback,
+  }
+}
+
+/** Load only the two capability sections shared by both Agent surfaces. */
+export async function loadAgentCapabilitySections(
+  client: AgentCapabilitiesClient,
+  agentTypeId: string,
+  options: LoadAgentCapabilitySectionsOptions = {},
+): Promise<Pick<AgentCapabilities, "skills" | "tools">> {
+  const id = encodeURIComponent(agentTypeId)
+  const query = options.refresh ? "?refresh=1" : ""
+  const [skills, tools] = await Promise.allSettled([
+    client.getJson(`/api/v1/agents/${id}/skills${query}`, {
+      missingMessage: "Failed to load this agent's skills.",
+    }),
+    client.getJson(`/api/v1/agents/${id}/tools${query}`, {
+      missingMessage: "Failed to load this agent's tools.",
+    }),
+  ])
+  return {
+    skills: skills.status === "fulfilled"
+      ? {
+        status: "loaded",
+        value: parseSkills(skills.value).filter((skill) => options.includeNonInvocableSkills || skill.invocable !== false),
+      }
+      : sourceError(skills.reason, "Failed to load this agent's skills."),
+    tools: tools.status === "fulfilled"
+      ? { status: "loaded", value: parseTools(tools.value) }
+      : sourceError(tools.reason, "Failed to load this agent's tools."),
+  }
+}
+
 /**
  * Reads everything the panel shows in ONE fan-out. Per-agent instruction
  * sources come from `/describe` — the Host owns that mapping — and only the
@@ -200,34 +241,27 @@ export async function loadAgentCapabilities(
   // Each route is spelled in full: the #1029 matrix checker classifies literal
   // Agent routes, and a shared base prefix would hide them from it.
   const id = encodeURIComponent(agentTypeId)
-  const [describe, skills, tools, models] = await Promise.allSettled([
-    client.getJson(`/api/v1/agents/${id}/describe`, { missingMessage: "This agent's details are unavailable." }),
-    client.getJson(`/api/v1/agents/${id}/skills`, { missingMessage: "This agent's skills are unavailable." }),
-    client.getJson(`/api/v1/agents/${id}/tools`, { missingMessage: "This agent's tools are unavailable." }),
-    client.getJson(`/api/v1/agents/${id}/models`, { missingMessage: "Models are unavailable." }),
+  const [[describe, models], sections] = await Promise.all([
+    Promise.allSettled([
+      client.getJson(`/api/v1/agents/${id}/describe`, { missingMessage: "This agent's details are unavailable." }),
+      client.getJson(`/api/v1/agents/${id}/models`, { missingMessage: "Models are unavailable." }),
+    ]),
+    loadAgentCapabilitySections(client, agentTypeId),
   ])
   const description = describe.status === "fulfilled" ? parseDescription(describe.value) : undefined
   return {
     status: "ready",
     description: description
       ? { status: "loaded", value: description }
-      : { status: "error" },
-    skills: skills.status === "fulfilled"
-      ? {
-        status: "loaded",
-      // The panel lists what the agent can be ASKED to do, so policy-hidden
-      // (non-invocable) skills are excluded here — the Skills page keeps them.
-        value: parseSkills(skills.value).filter((skill) => skill.invocable !== false),
-      }
-      : { status: "error" },
-    tools: tools.status === "fulfilled"
-      ? { status: "loaded", value: parseTools(tools.value) }
-      : { status: "error" },
+      : sourceError(describe.status === "rejected" ? describe.reason : undefined, "This agent's details are unavailable."),
+    // The details panel lists what the agent can be ASKED to do, so the shared
+    // section loader's default excludes policy-hidden (non-invocable) skills.
+    ...sections,
     modelLabel: models.status === "fulfilled"
       ? { status: "loaded", value: resolveModelLabel(models.value, description?.model ?? null) }
       : description?.model
         ? { status: "loaded", value: description.model }
-        : { status: "error" },
+        : sourceError(models.status === "rejected" ? models.reason : undefined, "Models are unavailable."),
   }
 }
 

--- a/packages/workspace/src/front/chrome/skills/AgentPage.tsx
+++ b/packages/workspace/src/front/chrome/skills/AgentPage.tsx
@@ -11,32 +11,12 @@ import type { PaneProps } from "../../registry/types"
 import { uiFileResourceKey } from "../../../shared/types/filesystem"
 import { openableFileResource } from "../../../shared/skills/openableFileResource"
 import {
-  parseSkills,
-  parseTools,
+  INITIAL_CAPABILITIES,
+  loadAgentCapabilitySections,
+  type AgentCapabilities,
   type AgentSkillSummary,
   type AgentToolSummary,
 } from "../agents/agentCapabilities"
-
-/**
- * One request per section, committed together but failing apart: a slow or
- * broken tools route must not blank the skills the user came to see, and vice
- * versa. `status` is the whole-page phase; each section keeps its own outcome.
- */
-type SectionResult<T> =
-  | { status: "loaded"; value: T[] }
-  | { status: "error"; error: string }
-
-interface AgentPageState {
-  status: "loading" | "ready"
-  skills: SectionResult<AgentSkillSummary>
-  tools: SectionResult<AgentToolSummary>
-}
-
-const INITIAL_STATE: AgentPageState = {
-  status: "loading",
-  skills: { status: "loaded", value: [] },
-  tools: { status: "loaded", value: [] },
-}
 
 /**
  * `parseSkills` already orders by name; this only breaks the ties it leaves —
@@ -50,7 +30,7 @@ function compareSkills(left: AgentSkillSummary, right: AgentSkillSummary): numbe
       .localeCompare(right.resource ? uiFileResourceKey(right.resource) : "")
 }
 
-export type AgentPageProps = Partial<PaneProps> & {
+type AgentPageProps = Partial<PaneProps> & {
   /** When provided, renders a close control in the header — used when the Agent
    *  page is hosted as a chat left overlay rather than a workspace panel. */
   onClose?: () => void
@@ -72,7 +52,7 @@ export type AgentPageProps = Partial<PaneProps> & {
  */
 export function AgentPage({ onClose, headerInsetStart = false, headerInsetEnd = false }: AgentPageProps) {
   const client = useWorkspacePluginClient()
-  const [state, setState] = useState<AgentPageState>(INITIAL_STATE)
+  const [state, setState] = useState<AgentCapabilities>(INITIAL_CAPABILITIES)
   const [expandedTool, setExpandedTool] = useState<string | null>(null)
 
   // Reload and Retry can be triggered from the same error state, and `client`
@@ -85,31 +65,13 @@ export function AgentPage({ onClose, headerInsetStart = false, headerInsetEnd = 
   const load = useCallback(async (refresh = false) => {
     const generation = ++generationRef.current
     const isStale = () => generationRef.current !== generation
-    const id = encodeURIComponent(client.agentTypeId)
-    const query = refresh ? "?refresh=1" : ""
     setState((current) => ({ ...current, status: "loading" }))
-    // Each route is spelled in full — a shared base prefix would hide these
-    // literal Agent routes from the route-matrix checker.
-    const [skills, tools] = await Promise.allSettled([
-      client.getJson<unknown>(`/api/v1/agents/${id}/skills${query}`, {
-        missingMessage: "Failed to load this agent's skills.",
-      }),
-      client.getJson<unknown>(`/api/v1/agents/${id}/tools${query}`, {
-        missingMessage: "Failed to load this agent's tools.",
-      }),
-    ])
-    if (isStale()) return
-    setState({
-      status: "ready",
-      // Parse-then-rebuild (see agentCapabilities): a hostile `description`
-      // reaching React as a child blanks the whole pane with no boundary above.
-      skills: skills.status === "fulfilled"
-        ? { status: "loaded", value: parseSkills(skills.value) }
-        : { status: "error", error: errorMessage(skills.reason, "Failed to load this agent's skills.") },
-      tools: tools.status === "fulfilled"
-        ? { status: "loaded", value: parseTools(tools.value) }
-        : { status: "error", error: errorMessage(tools.reason, "Failed to load this agent's tools.") },
+    const sections = await loadAgentCapabilitySections(client, client.agentTypeId, {
+      refresh,
+      includeNonInvocableSkills: true,
     })
+    if (isStale()) return
+    setState((current) => ({ ...current, ...sections, status: "ready" }))
   }, [client])
 
   useEffect(() => {
@@ -184,10 +146,6 @@ export function AgentPage({ onClose, headerInsetStart = false, headerInsetEnd = 
       </div>
     </ManagementOverlaySurface>
   )
-}
-
-function errorMessage(reason: unknown, fallback: string): string {
-  return reason instanceof Error ? reason.message : fallback
 }
 
 function SectionHeading({ id, title, count }: { id: string; title: string; count?: number }) {

--- a/packages/workspace/src/front/chrome/skills/__tests__/AgentPage.test.tsx
+++ b/packages/workspace/src/front/chrome/skills/__tests__/AgentPage.test.tsx
@@ -43,7 +43,7 @@ const skills = [
   },
 ]
 
-/** Route the two fan-out requests to their own payloads. */
+/** Route the shared skills/tools fan-out to its own payloads. */
 function respondWith({ skills: skillsPayload, tools: toolsPayload }: {
   skills?: unknown
   tools?: unknown
@@ -139,6 +139,7 @@ describe("AgentPage skills section", () => {
       "/api/v1/agents/default/tools?refresh=1",
       expect.objectContaining({ missingMessage: expect.any(String) }),
     )
+    expect(mocks.getJson.mock.calls.every(([path]) => /\/(skills|tools)(\?refresh=1)?$/.test(path))).toBe(true)
   })
 
   it("describes the surface as skills and tools in the header", async () => {

--- a/packages/workspace/src/front/chrome/skills/definition.ts
+++ b/packages/workspace/src/front/chrome/skills/definition.ts
@@ -1,2 +1,0 @@
-// AgentPage is mounted directly by WorkspaceAgentFront; no registry definition
-// is exported for this overlay-only surface.

--- a/packages/workspace/src/front/chrome/skills/definition.ts
+++ b/packages/workspace/src/front/chrome/skills/definition.ts
@@ -1,14 +1,2 @@
-import { Bot } from "lucide-react"
-import type { PanelConfig } from "../../registry/types"
-import { AgentPage } from "./AgentPage"
-
-export const WORKSPACE_AGENT_PANEL_ID = "workspace:agent"
-
-export const workspaceAgentPanel: PanelConfig = {
-  id: WORKSPACE_AGENT_PANEL_ID,
-  title: "Agent",
-  icon: Bot,
-  placement: "workspace-page",
-  source: "core",
-  component: AgentPage,
-}
+// AgentPage is mounted directly by WorkspaceAgentFront; no registry definition
+// is exported for this overlay-only surface.

--- a/packages/workspace/src/front/components/SessionList.tsx
+++ b/packages/workspace/src/front/components/SessionList.tsx
@@ -9,7 +9,7 @@ import {
   type KeyboardEvent,
   type MouseEvent,
 } from "react"
-import { IconButton, Skeleton } from "@hachej/boring-ui-kit"
+import { IconButton } from "@hachej/boring-ui-kit"
 import { CheckIcon, CopyIcon } from "lucide-react"
 import { cn } from "../lib/utils"
 import { workspaceSessionKeyFor, workspaceSessionKeyFromBoundaryValue } from "../sessionIdentity"
@@ -25,7 +25,6 @@ export interface SessionItem {
 
 export interface SessionListProps {
   sessions: SessionItem[]
-  loading?: boolean
   activeId?: string | null
   onSwitch?: (id: string, agentTypeId?: string) => void
   onCreate?: () => void
@@ -36,7 +35,6 @@ export interface SessionListProps {
 
 export function SessionList({
   sessions,
-  loading = false,
   activeId,
   onSwitch,
   onCreate,
@@ -135,16 +133,8 @@ export function SessionList({
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto" role="list" aria-label="Session list" aria-busy={loading || undefined}>
-        {sessions.length === 0 && loading ? (
-          <div className="space-y-2 px-3 py-3" role="status" aria-live="polite" aria-label="Loading sessions">
-            <div className="space-y-2" aria-hidden="true">
-              <Skeleton className="h-9 w-full rounded-md" />
-              <Skeleton className="h-9 w-4/5 rounded-md" />
-            </div>
-          </div>
-        ) : null}
-        {sessions.length === 0 && !loading && (
+      <div className="flex-1 overflow-y-auto" role="list" aria-label="Session list">
+        {sessions.length === 0 && (
           <div className="px-3 py-6 text-center text-sm text-muted-foreground">
             No sessions
           </div>

--- a/packages/workspace/src/front/components/__tests__/SessionList.test.tsx
+++ b/packages/workspace/src/front/components/__tests__/SessionList.test.tsx
@@ -126,21 +126,6 @@ describe("SessionList", () => {
     expect(onSwitch).not.toHaveBeenCalled()
   })
 
-  it("shows loading, then a resolved empty state, then loaded sessions without flashing empty", () => {
-    const { rerender } = render(<SessionList sessions={[]} loading />)
-
-    expect(screen.getByRole("status", { name: "Loading sessions" })).toBeInTheDocument()
-    expect(screen.queryByText("No sessions")).not.toBeInTheDocument()
-
-    rerender(<SessionList sessions={[]} loading={false} />)
-    expect(screen.getByText("No sessions")).toBeInTheDocument()
-    expect(screen.queryByRole("status", { name: "Loading sessions" })).not.toBeInTheDocument()
-
-    rerender(<SessionList sessions={sessions} loading={false} />)
-    expect(screen.queryByText("No sessions")).not.toBeInTheDocument()
-    expect(screen.getByText("First session")).toBeInTheDocument()
-  })
-
   it("renders with navigation role and accessible label", () => {
     render(<SessionList sessions={sessions} />)
     expect(screen.getByRole("navigation", { name: "Sessions" })).toBeInTheDocument()


### PR DESCRIPTION
## Summary

Fixes the #1202 P1 factory-mode default-seat regression and the reviewed P2 workspace UI dead code/duplication.

## Issue / Slice

Follow-up to #1202: factory default seat and agent-tab UI cleanup.

## What Changed

- Resolves the playground default agent from the first seat of the roster actually loaded by the server, publishes that resolved id through workspace metadata, and makes browser bootstrap fail closed if the roster default is unavailable.
- Adds factory coverage proving the resolved default is the first ratified seat and belongs to the loaded fleet.
- Removes unused `WORKSPACE_AGENT_PANEL_ID`, `workspaceAgentPanel`, exported `AgentPageProps`, and the unconsumed workspace `SessionList.loading` path.
- Refactors `AgentPage` to reuse the shared skills/tools capability loader while preserving management-only skills, refresh behavior, per-section errors, stale-response protection, sorting, and rendered output.
- Leaves the public `showSkills` / `skills` naming unchanged; that lying-name cleanup remains deferred.

## Proof

- `pnpm --dir packages/workspace exec vitest run --maxWorkers=4` — 164 files passed, 3 skipped; 2103 tests passed, 10 skipped.
- `pnpm --dir apps/workspace-playground test` — 8 files / 26 tests passed.
- `pnpm --dir packages/workspace typecheck` — passed.
- `pnpm --dir apps/workspace-playground typecheck` — passed.
- `pnpm --dir packages/workspace build` — passed; all 19 build artifacts present.
- `pnpm check:agenthost-cutover-matrix` — passed.
- `pnpm lint:workspace-plugin-invariants` — passed (500 source files scanned).
- No dev server was started.

## Review

- Standards: clean.
- Spec: clean against the requested P1/P2 scope.
- Thermo: clean after fixing fail-open metadata fallback, unused endpoint blocking, error-state/API growth, and final orchestration readability findings.
- Reviewed SHA: `4993242eb`.

## Risk / Rollback

Low, localized playground bootstrap and workspace UI data-loading changes. Roll back this single commit if needed.

## Next

Owner review / CI. Do not merge from this handoff.