### PR TITLE
feat(bi-dashboard): add adapter-driven catalog pane

### DIFF
--- a/plugins/bi-dashboard/README.md
+++ b/plugins/bi-dashboard/README.md
@@ -18,6 +18,25 @@ The plugin registers:
 - panel: `bi-dashboard.panel`
 - command: `bi-dashboard.open`
 
+## Custom dashboard catalogs
+
+`DashboardCatalogPane` lets hosts reuse the dashboard browser for server-backed or virtual dashboards instead of
+materializing every dashboard as a workspace file. Provide a stable adapter and map each row to either file-path or
+in-memory-spec panel parameters:
+
+```tsx
+const adapter = useMemo(() => ({
+  search: ({query, limit, offset, signal}) =>
+    fetchDashboardCatalog({query, limit, offset, signal}),
+}), [])
+
+return <DashboardCatalogPane {...sourceProps} adapter={adapter} />
+```
+
+The pane owns loading, cancellation, grouping, badges, refresh, pagination, and panel opening. The built-in
+`DashboardFilesPane` uses the same component with its filesystem-backed adapter, so existing plugin behavior is
+unchanged.
+
 ## Dashboard contract
 
 Agents should generate specs shaped like:

--- a/plugins/bi-dashboard/src/front/DashboardCatalogPane.test.tsx
+++ b/plugins/bi-dashboard/src/front/DashboardCatalogPane.test.tsx
@@ -4,22 +4,31 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { DashboardCatalogPane, type DashboardCatalogAdapter } from "./DashboardCatalogPane"
 
 class IntersectionObserverStub {
-  static callback: IntersectionObserverCallback | undefined
-  constructor(callback: IntersectionObserverCallback) {
-    IntersectionObserverStub.callback = callback
+  static instances: IntersectionObserverStub[] = []
+  active = false
+  constructor(private readonly callback: IntersectionObserverCallback) {
+    IntersectionObserverStub.instances.push(this)
   }
-  observe() {}
-  disconnect() {}
+  observe() { this.active = true }
+  disconnect() { this.active = false }
   unobserve() {}
   takeRecords(): IntersectionObserverEntry[] { return [] }
   readonly root = null
   readonly rootMargin = "0px"
   readonly thresholds = [0]
+
+  static async trigger() {
+    const observer = [...this.instances].reverse().find((instance) => instance.active)
+    await observer?.callback([{ isIntersecting: true } as IntersectionObserverEntry], observer as unknown as IntersectionObserver)
+  }
 }
 
 vi.stubGlobal("IntersectionObserver", IntersectionObserverStub)
 
-afterEach(() => vi.restoreAllMocks())
+afterEach(() => {
+  IntersectionObserverStub.instances = []
+  vi.restoreAllMocks()
+})
 
 describe("DashboardCatalogPane", () => {
   it("forwards search, groups rows, and resolves selected panels", async () => {
@@ -61,14 +70,14 @@ describe("DashboardCatalogPane", () => {
     render(<DashboardCatalogPane adapter={adapter} params={{}} pageSize={1} />)
     await screen.findByText("One")
 
-    await act(async () => IntersectionObserverStub.callback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver))
-    await screen.findByText("Loading more…")
+    await act(async () => IntersectionObserverStub.trigger())
+    await waitFor(() => expect(adapter.search).toHaveBeenCalledTimes(2))
     expect(adapter.search).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1, offset: 1 }))
     expect((adapter.search as ReturnType<typeof vi.fn>).mock.calls[1][0].signal.aborted).toBe(false)
     await act(async () => resolvePage?.({ items: [{ id: "one", title: "One updated", params: { path: "one" } }], total: 3, hasMore: true }))
     expect(await screen.findByText("One updated")).toBeTruthy()
 
-    await act(async () => IntersectionObserverStub.callback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver))
+    await act(async () => IntersectionObserverStub.trigger())
     expect(await screen.findByText("Three")).toBeTruthy()
     expect(adapter.search).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1, offset: 2 }))
   })
@@ -81,7 +90,8 @@ describe("DashboardCatalogPane", () => {
     }
     render(<DashboardCatalogPane adapter={adapter} params={{}} />)
     await screen.findByText("One")
-    await act(async () => IntersectionObserverStub.callback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver))
+    await waitFor(() => expect(IntersectionObserverStub.instances.some((instance) => instance.active)).toBe(true))
+    await act(async () => IntersectionObserverStub.trigger())
     expect(await screen.findByText("Could not list dashboards")).toBeTruthy()
     expect(adapter.search).toHaveBeenCalledTimes(2)
   })

--- a/plugins/bi-dashboard/src/front/DashboardCatalogPane.test.tsx
+++ b/plugins/bi-dashboard/src/front/DashboardCatalogPane.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { DashboardCatalogPane, type DashboardCatalogAdapter } from "./DashboardCatalogPane"
+
+class IntersectionObserverStub {
+  static callback: IntersectionObserverCallback | undefined
+  constructor(callback: IntersectionObserverCallback) {
+    IntersectionObserverStub.callback = callback
+  }
+  observe() {}
+  disconnect() {}
+  unobserve() {}
+  takeRecords(): IntersectionObserverEntry[] { return [] }
+  readonly root = null
+  readonly rootMargin = "0px"
+  readonly thresholds = [0]
+}
+
+vi.stubGlobal("IntersectionObserver", IntersectionObserverStub)
+
+afterEach(() => vi.restoreAllMocks())
+
+describe("DashboardCatalogPane", () => {
+  it("forwards search, groups rows, and resolves selected panels", async () => {
+    const adapter: DashboardCatalogAdapter = {
+      search: vi.fn().mockResolvedValue({
+        items: [
+          { id: "shared", title: "Overview", group: "Shared", badges: [{ label: "Shared" }], params: { path: "dashboards/overview.dashboard.json" } },
+          { id: "tenant", title: "Workforce", group: "Acme", params: { spec: { title: "Acme" } } },
+        ],
+        total: 2,
+        hasMore: false,
+      }),
+    }
+    const openPanel = vi.fn()
+    render(<DashboardCatalogPane adapter={adapter} openPanel={openPanel} params={{ searchQuery: "work" }} />)
+
+    expect((await screen.findAllByText("Shared")).length).toBe(2)
+    expect(screen.getByText("Acme")).toBeTruthy()
+    expect(adapter.search).toHaveBeenCalledWith(expect.objectContaining({ query: "work", limit: 50, offset: 0 }))
+
+    fireEvent.click(screen.getByRole("button", { name: /Workforce/ }))
+    await waitFor(() => expect(openPanel).toHaveBeenCalledWith(expect.objectContaining({
+      id: "bi-dashboard.panel:tenant",
+      params: { spec: { title: "Acme" } },
+    })))
+  })
+
+  it("keeps asynchronous pagination alive and advances by consumed rows", async () => {
+    let resolvePage: ((value: { items: Array<{ id: string; title: string; params: { path: string } }>; total: number; hasMore: boolean }) => void) | undefined
+    const adapter: DashboardCatalogAdapter = {
+      search: vi.fn()
+        .mockResolvedValueOnce({ items: [{ id: "one", title: "One", params: { path: "one" } }], total: 3, hasMore: true })
+        .mockImplementationOnce(({ signal }) => new Promise((resolve, reject) => {
+          resolvePage = resolve
+          signal?.addEventListener("abort", () => reject(signal.reason), { once: true })
+        }))
+        .mockResolvedValueOnce({ items: [{ id: "three", title: "Three", params: { path: "three" } }], total: 3, hasMore: false }),
+    }
+    render(<DashboardCatalogPane adapter={adapter} params={{}} pageSize={1} />)
+    await screen.findByText("One")
+
+    await act(async () => IntersectionObserverStub.callback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver))
+    await screen.findByText("Loading more…")
+    expect(adapter.search).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1, offset: 1 }))
+    expect((adapter.search as ReturnType<typeof vi.fn>).mock.calls[1][0].signal.aborted).toBe(false)
+    await act(async () => resolvePage?.({ items: [{ id: "one", title: "One updated", params: { path: "one" } }], total: 3, hasMore: true }))
+    expect(await screen.findByText("One updated")).toBeTruthy()
+
+    await act(async () => IntersectionObserverStub.callback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver))
+    expect(await screen.findByText("Three")).toBeTruthy()
+    expect(adapter.search).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1, offset: 2 }))
+  })
+
+  it("stops automatic pagination after an error", async () => {
+    const adapter: DashboardCatalogAdapter = {
+      search: vi.fn()
+        .mockResolvedValueOnce({ items: [{ id: "one", title: "One", params: {} }], total: 2, hasMore: true })
+        .mockRejectedValueOnce(new Error("offline")),
+    }
+    render(<DashboardCatalogPane adapter={adapter} params={{}} />)
+    await screen.findByText("One")
+    await act(async () => IntersectionObserverStub.callback?.([{ isIntersecting: true } as IntersectionObserverEntry], {} as IntersectionObserver))
+    expect(await screen.findByText("Could not list dashboards")).toBeTruthy()
+    expect(adapter.search).toHaveBeenCalledTimes(2)
+  })
+})

--- a/plugins/bi-dashboard/src/front/DashboardCatalogPane.tsx
+++ b/plugins/bi-dashboard/src/front/DashboardCatalogPane.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useRef, useState } from "react"
+import { FileJson2, LayoutDashboard, RefreshCw } from "lucide-react"
+import { Badge, EmptyState, IconButton } from "@hachej/boring-ui-kit"
+import type { WorkspaceSourceOpenPanelConfig, WorkspaceSourceProps } from "@hachej/boring-workspace/plugin"
+import { BI_DASHBOARD_PANEL_ID } from "./constants"
+
+export interface DashboardCatalogSearchArgs {
+  query: string
+  limit: number
+  offset: number
+  signal?: AbortSignal
+}
+
+export interface DashboardCatalogBadge {
+  label: string
+}
+
+export interface DashboardCatalogRow {
+  id: string
+  title: string
+  subtitle?: string
+  group?: string
+  badges?: DashboardCatalogBadge[]
+  params: Record<string, unknown>
+  panelTitle?: string
+}
+
+export interface DashboardCatalogSearchResult {
+  items: DashboardCatalogRow[]
+  total: number
+  hasMore: boolean
+}
+
+export interface DashboardCatalogAdapter {
+  search(args: DashboardCatalogSearchArgs): Promise<DashboardCatalogSearchResult>
+}
+
+export interface DashboardCatalogPaneProps extends WorkspaceSourceProps<{ searchQuery?: string }> {
+  adapter: DashboardCatalogAdapter
+  emptyDescription?: string
+  label?: string
+  pageSize?: number
+  resolvePanel?: (row: DashboardCatalogRow) => WorkspaceSourceOpenPanelConfig | Promise<WorkspaceSourceOpenPanelConfig>
+}
+
+type CatalogState = {
+  loading: boolean
+  loadingMore: boolean
+  rows: DashboardCatalogRow[]
+  total: number
+  hasMore: boolean
+  error?: string
+}
+
+export function dashboardPanelForRow(row: DashboardCatalogRow): WorkspaceSourceOpenPanelConfig {
+  return {
+    id: `${BI_DASHBOARD_PANEL_ID}:${row.id}`,
+    component: BI_DASHBOARD_PANEL_ID,
+    title: row.panelTitle ?? row.title,
+    params: row.params,
+  }
+}
+
+export function DashboardCatalogPane({
+  adapter,
+  className,
+  emptyDescription = "No matching items were found.",
+  label = "Dashboards",
+  openPanel,
+  pageSize = 50,
+  params,
+  resolvePanel = dashboardPanelForRow,
+}: DashboardCatalogPaneProps) {
+  const query = params?.searchQuery?.trim() ?? ""
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [state, setState] = useState<CatalogState>({ loading: true, loadingMore: false, rows: [], total: 0, hasMore: false })
+  const [resultTotal, setResultTotal] = useState(0)
+  const [pageVersion, setPageVersion] = useState(0)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+  const requestVersion = useRef(0)
+  const nextOffset = useRef(0)
+  const paginationInFlight = useRef(false)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    const version = ++requestVersion.current
+    setState({ loading: true, loadingMore: false, rows: [], total: 0, hasMore: false })
+    void adapter.search({ query, limit: pageSize, offset: 0, signal: controller.signal })
+      .then((result) => {
+        if (version !== requestVersion.current) return
+        nextOffset.current = result.items.length
+        setResultTotal(result.total)
+        setState({ loading: false, loadingMore: false, rows: result.items, total: result.total, hasMore: result.hasMore })
+      })
+      .catch((error) => {
+        if (controller.signal.aborted || version !== requestVersion.current) return
+        setState({ loading: false, loadingMore: false, rows: [], total: 0, hasMore: false, error: error instanceof Error ? error.message : String(error) })
+      })
+    return () => controller.abort()
+  }, [adapter, pageSize, query, refreshKey])
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current
+    if (!sentinel || !state.hasMore || state.loading || state.loadingMore) return
+    const controller = new AbortController()
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((entry) => entry.isIntersecting) || paginationInFlight.current) return
+      paginationInFlight.current = true
+      observer.disconnect()
+      const version = requestVersion.current
+      setState((previous) => ({ ...previous, loadingMore: true }))
+      void adapter.search({ query, limit: pageSize, offset: nextOffset.current, signal: controller.signal })
+        .then((result) => {
+          if (version !== requestVersion.current) return
+          nextOffset.current += result.items.length
+          setPageVersion((value) => value + 1)
+          setState((previous) => {
+            const rows = new Map(previous.rows.map((row) => [row.id, row]))
+            for (const row of result.items) rows.set(row.id, row)
+            return { loading: false, loadingMore: false, rows: [...rows.values()], total: result.total, hasMore: result.hasMore }
+          })
+        })
+        .catch((error) => {
+          if (controller.signal.aborted || version !== requestVersion.current) return
+          setState((previous) => ({ ...previous, loadingMore: false, hasMore: false, error: error instanceof Error ? error.message : String(error) }))
+        })
+        .finally(() => {
+          paginationInFlight.current = false
+        })
+    }, { rootMargin: "160px" })
+    observer.observe(sentinel)
+    return () => {
+      controller.abort()
+      observer.disconnect()
+    }
+  }, [adapter, pageSize, pageVersion, query, state.hasMore, state.loading, state.rows.length])
+
+  const groups = groupRows(state.rows)
+  const selectRow = async (row: DashboardCatalogRow) => openPanel?.(await resolvePanel(row))
+
+  return (
+    <div className={`flex h-full min-h-0 flex-col text-sm ${className ?? ""}`}>
+      <div className="flex items-center justify-between border-b border-border/60 px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <LayoutDashboard className="h-4 w-4 text-muted-foreground" />
+          <span className="truncate font-medium">{label}</span>
+          <Badge variant="secondary">{resultTotal}</Badge>
+        </div>
+        <IconButton type="button" aria-label={`Refresh ${label.toLowerCase()}`} variant="ghost" size="icon-xs" onClick={() => setRefreshKey((value) => value + 1)} disabled={state.loading}>
+          <RefreshCw className={`h-3.5 w-3.5 ${state.loading ? "animate-spin" : ""}`} />
+        </IconButton>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto p-2">
+        {state.error ? <EmptyState title={`Could not list ${label.toLowerCase()}`} description={state.error} />
+          : state.loading ? <div className="px-2 py-3 text-xs text-muted-foreground">Scanning {label.toLowerCase()}…</div>
+          : state.rows.length === 0 ? <EmptyState title={`No ${label.toLowerCase()} found`} description={emptyDescription} />
+          : groups.map((group) => (
+            <section key={group.label} className="mb-2">
+              {group.label ? <div className="px-2 py-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{group.label}</div> : null}
+              {group.rows.map((row) => (
+                <button key={row.id} type="button" onClick={() => void selectRow(row)} className="flex w-full min-w-0 items-start gap-2 rounded-lg px-2 py-2 text-left hover:bg-background/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40">
+                  <FileJson2 className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[13px] font-medium text-foreground">{row.title}</span>
+                    {row.subtitle ? <span className="block truncate text-[11px] text-muted-foreground">{row.subtitle}</span> : null}
+                  </span>
+                  {row.badges?.map((badge) => <Badge key={badge.label} variant="secondary">{badge.label}</Badge>)}
+                </button>
+              ))}
+            </section>
+          ))}
+        <div ref={sentinelRef} className="h-px" aria-hidden="true" />
+        {state.loadingMore ? <div className="px-2 py-3 text-center text-xs text-muted-foreground">Loading more…</div> : null}
+      </div>
+    </div>
+  )
+}
+
+function groupRows(rows: DashboardCatalogRow[]) {
+  const groups = new Map<string, DashboardCatalogRow[]>()
+  for (const row of rows) {
+    const group = row.group ?? ""
+    groups.set(group, [...(groups.get(group) ?? []), row])
+  }
+  return [...groups].map(([label, groupedRows]) => ({ label, rows: groupedRows }))
+}

--- a/plugins/bi-dashboard/src/front/DashboardFilesPane.test.ts
+++ b/plugins/bi-dashboard/src/front/DashboardFilesPane.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { createDashboardFilesAdapter } from "./DashboardFilesPane"
+
+describe("createDashboardFilesAdapter", () => {
+  it("maps, filters, deduplicates, and sorts user dashboard files", async () => {
+    const adapter = createDashboardFilesAdapter(async () => ({
+      resources: [
+        { filesystem: "user", path: "dashboards/z-last.dashboard.json" },
+        { filesystem: "system", path: "dashboards/hidden.dashboard.json" },
+        { filesystem: "user", path: "notes/readme.md" },
+        { filesystem: "user", path: "dashboards/a-first.dashboard.json" },
+        { filesystem: "user", path: "dashboards/a-first.dashboard.json" },
+      ],
+    }))
+
+    const result = await adapter.search({ query: "first", limit: 500, offset: 0 })
+    expect(result.total).toBe(2)
+    expect(result.items).toEqual([{
+      id: "dashboards/a-first.dashboard.json",
+      title: "a first",
+      subtitle: "dashboards/a-first.dashboard.json",
+      params: { path: "dashboards/a-first.dashboard.json" },
+    }])
+    expect(result.hasMore).toBe(false)
+  })
+})

--- a/plugins/bi-dashboard/src/front/DashboardFilesPane.tsx
+++ b/plugins/bi-dashboard/src/front/DashboardFilesPane.tsx
@@ -1,18 +1,15 @@
-import { useEffect, useMemo, useState } from "react"
-import { FileJson2, LayoutDashboard, RefreshCw } from "lucide-react"
-import { Badge, EmptyState, IconButton } from "@hachej/boring-ui-kit"
+import { useMemo } from "react"
 import { useApiBaseUrl, useWorkspaceRequestId } from "@hachej/boring-workspace"
 import type { WorkspaceSourceProps } from "@hachej/boring-workspace/plugin"
-import { BI_DASHBOARD_PANEL_ID } from "./constants"
-
-interface DashboardSearchState {
-  loading: boolean
-  error?: string
-  paths: string[]
-}
+import {
+  DashboardCatalogPane,
+  type DashboardCatalogAdapter,
+  type DashboardCatalogSearchResult,
+} from "./DashboardCatalogPane"
 
 interface DashboardSearchResponse {
   resources?: Array<{ filesystem: string; path: string }>
+  results?: string[]
 }
 
 function titleFromPath(path: string): string {
@@ -24,114 +21,43 @@ function isWorkspaceDashboardPath(path: string): boolean {
   return path.startsWith("dashboards/") && path.endsWith(".dashboard.json")
 }
 
-function matchesQuery(path: string, query: string | undefined): boolean {
-  if (!isWorkspaceDashboardPath(path)) return false
-  const value = query?.trim().toLowerCase()
-  if (!value) return true
-  return path.toLowerCase().includes(value) || titleFromPath(path).toLowerCase().includes(value)
-}
-
 type DashboardFilesPaneProps = WorkspaceSourceProps<{ searchQuery?: string }>
 
-export function DashboardFilesPane({ params, openPanel }: DashboardFilesPaneProps) {
+type DashboardSearchClient = (limit: number, signal?: AbortSignal) => Promise<DashboardSearchResponse>
+
+export function createDashboardFilesAdapter(searchFiles: DashboardSearchClient): DashboardCatalogAdapter {
+  return {
+    async search({ query, limit, signal }): Promise<DashboardCatalogSearchResult> {
+      const body = await searchFiles(limit, signal)
+      const resources = body.resources?.filter((resource) => resource.filesystem === "user").map((resource) => resource.path)
+        ?? body.results
+        ?? []
+      const normalizedQuery = query.toLowerCase()
+      const dashboardPaths = [...new Set(resources)].filter(isWorkspaceDashboardPath)
+      const paths = dashboardPaths
+        .filter((path) => !normalizedQuery || path.toLowerCase().includes(normalizedQuery) || titleFromPath(path).toLowerCase().includes(normalizedQuery))
+        .sort((left, right) => left.localeCompare(right))
+      return {
+        items: paths.map((path) => ({ id: path, title: titleFromPath(path), subtitle: path, params: { path } })),
+        total: dashboardPaths.length,
+        hasMore: false,
+      }
+    },
+  }
+}
+
+export function DashboardFilesPane(props: DashboardFilesPaneProps) {
   const apiBaseUrl = useApiBaseUrl()
   const workspaceId = useWorkspaceRequestId()
-  const [state, setState] = useState<DashboardSearchState>({ loading: true, paths: [] })
-  const [refreshKey, setRefreshKey] = useState(0)
-
-  useEffect(() => {
-    const controller = new AbortController()
-    setState((prev) => ({ ...prev, loading: true, error: undefined }))
-    void fetch(`${apiBaseUrl}/api/v1/files/search?q=**%2F*.dashboard.json&limit=500`, {
-      signal: controller.signal,
+  const adapter = useMemo(() => createDashboardFilesAdapter(async (limit, signal) => {
+    const response = await fetch(`${apiBaseUrl}/api/v1/files/search?q=**%2F*.dashboard.json&limit=${limit}`, {
+      signal,
       credentials: "include",
       headers: workspaceId ? { "x-boring-workspace-id": workspaceId } : {},
     })
-      .then(async (response) => {
-        if (!response.ok) throw new Error(`Dashboard search failed with HTTP ${response.status}`)
-        return await response.json() as DashboardSearchResponse
-      })
-      .then((body) => {
-        setState({
-          loading: false,
-          paths: [...new Set((body.resources ?? [])
-            .filter((resource) => resource.filesystem === "user")
-            .map((resource) => resource.path))]
-            .filter(isWorkspaceDashboardPath)
-            .sort((a, b) => a.localeCompare(b)),
-        })
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) return
-        setState({ loading: false, paths: [], error: error instanceof Error ? error.message : String(error) })
-      })
-    return () => controller.abort()
-  }, [apiBaseUrl, refreshKey, workspaceId])
+    if (!response.ok) throw new Error(`Dashboard search failed with HTTP ${response.status}`)
+    return await response.json() as DashboardSearchResponse
+  }), [apiBaseUrl, workspaceId])
 
-  const paths = useMemo(
-    () => state.paths.filter((path) => matchesQuery(path, params?.searchQuery)),
-    [params?.searchQuery, state.paths],
-  )
-
-  const openDashboard = (path: string) => {
-    const panel = {
-      id: `${BI_DASHBOARD_PANEL_ID}:${path}`,
-      component: BI_DASHBOARD_PANEL_ID,
-      title: titleFromPath(path),
-      params: { path },
-    }
-    openPanel?.(panel)
-  }
-
-  return (
-    <div className="flex h-full min-h-0 flex-col text-sm">
-      <div className="flex items-center justify-between border-b border-border/60 px-3 py-2">
-        <div className="flex min-w-0 items-center gap-2">
-          <LayoutDashboard className="h-4 w-4 text-muted-foreground" />
-          <span className="truncate font-medium">Dashboards</span>
-          <Badge variant="secondary">{state.paths.length}</Badge>
-        </div>
-        <IconButton
-          type="button"
-          aria-label="Refresh dashboards"
-          variant="ghost"
-          size="icon-xs"
-          onClick={() => setRefreshKey((value) => value + 1)}
-          disabled={state.loading}
-        >
-          <RefreshCw className={`h-3.5 w-3.5 ${state.loading ? "animate-spin" : ""}`} />
-        </IconButton>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-auto p-2">
-        {state.error ? (
-          <EmptyState title="Could not list dashboards" description={state.error} />
-        ) : state.loading ? (
-          <div className="px-2 py-3 text-xs text-muted-foreground">Scanning dashboards…</div>
-        ) : paths.length === 0 ? (
-          <EmptyState
-            title="No dashboards found"
-            description="Create files under dashboards/*.dashboard.json to list them here."
-          />
-        ) : (
-          <div className="space-y-1">
-            {paths.map((path) => (
-              <button
-                key={path}
-                type="button"
-                onClick={() => openDashboard(path)}
-                className="flex w-full min-w-0 items-start gap-2 rounded-lg px-2 py-2 text-left hover:bg-background/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-              >
-                <FileJson2 className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-                <span className="min-w-0 flex-1">
-                  <span className="block truncate text-[13px] font-medium text-foreground">{titleFromPath(path)}</span>
-                  <span className="block truncate text-[11px] text-muted-foreground">{path}</span>
-                </span>
-              </button>
-            ))}
-          </div>
-        )}
-      </div>
-    </div>
-  )
+  return <DashboardCatalogPane {...props} adapter={adapter} pageSize={500} emptyDescription="Create files under dashboards/*.dashboard.json to list them here." />
 }

--- a/plugins/bi-dashboard/src/front/index.ts
+++ b/plugins/bi-dashboard/src/front/index.ts
@@ -13,7 +13,16 @@ export { BiDashboardRenderProvider, useBiDashboardRenderContext } from "./render
 export type { BiDashboardRenderState } from "./renderContext"
 export { sampleBiDashboardSpec } from "./sampleSpec"
 export { BI_DASHBOARD_LEFT_TAB_ID, BI_DASHBOARD_PANEL_ID } from "./constants"
-export { DashboardFilesPane } from "./DashboardFilesPane"
+export { DashboardFilesPane, createDashboardFilesAdapter } from "./DashboardFilesPane"
+export { DashboardCatalogPane, dashboardPanelForRow } from "./DashboardCatalogPane"
+export type {
+  DashboardCatalogAdapter,
+  DashboardCatalogBadge,
+  DashboardCatalogPaneProps,
+  DashboardCatalogRow,
+  DashboardCatalogSearchArgs,
+  DashboardCatalogSearchResult,
+} from "./DashboardCatalogPane"
 export { biDashboardSurfaceResolver } from "./surfaceResolver"
 export type {
   BslDashboardSpec,


### PR DESCRIPTION
Closes #1243.

## Summary

- add an exported `DashboardCatalogPane` for server-backed and virtual dashboards
- support query forwarding, cancellation, grouped rows, badges, refresh, offset pagination, and custom async row-to-panel resolution
- rebuild the existing `DashboardFilesPane` on that reusable pane while preserving its filesystem behavior
- export the adapter and row contracts for host applications

## Why

Hosts such as Healio expose both committed dashboard files and dynamically rendered tenant templates. Those virtual dashboards should not be materialized into the workspace merely to appear in the dashboard browser.

## Validation

- `pnpm --filter @hachej/boring-bi-dashboard typecheck`
- `pnpm --filter @hachej/boring-bi-dashboard test` — 18 tests passed
- `pnpm --filter @hachej/boring-bi-dashboard build`
- `pnpm audit:publish-manifests`
- `pnpm audit:release-staging`

The pagination tests cover delayed requests, cancellation safety, duplicate-only pages, offset advancement, grouping, selection, and failure behavior.
