### PR TITLE
fix(core): make Blaxel usable through full-app (#1248)

### DIFF
--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -98,6 +98,8 @@ function composeSystemPromptAppend(hostAppend: string | undefined): string {
 export interface PiHarnessOptions {
   noContextFiles?: boolean;
   noSkills?: boolean;
+  /** Disable ambient Pi extensions (required when tools execute in a remote runtime). */
+  noExtensions?: boolean;
   additionalSkillPaths?: string[];
   defaultModel?: { provider: string; id: string };
   /**
@@ -620,6 +622,7 @@ export function createPiCodingAgentHarness(opts: {
       ...(extensionFactories.length ? { extensionFactories } : {}),
       ...(pi.noContextFiles ? { noContextFiles: true } : {}),
       ...(pi.noSkills ? { noSkills: true } : {}),
+      ...(pi.noExtensions ? { noExtensions: true } : {}),
       ...(effectiveSkillPaths.length ? { additionalSkillPaths: effectiveSkillPaths } : {}),
       // skillsOverride REPLACES Pi's resolved skill set, which includes
       // skills contributed by host-declared pi packages (e.g.

--- a/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelProvider.conformance.test.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/__tests__/blaxelProvider.conformance.test.ts
@@ -70,7 +70,7 @@ describe('Blaxel adapter policies', () => {
     expect(result.truncated).toBe(true)
   })
 
-  test('preserves terminal output exactly and applies one stdout-first byte budget without lossy callbacks', async () => {
+  test('preserves terminal output and replays capped buffers through callbacks', async () => {
     const value = await harness()
     const stdoutChunks: Uint8Array[] = []
     const stderrChunks: Uint8Array[] = []
@@ -82,8 +82,8 @@ describe('Blaxel adapter policies', () => {
     expect(new TextDecoder().decode(exact.stdout)).toBe('a\n\nb')
     expect(exact.stderr.byteLength).toBe(2)
     expect(exact.truncated).toBe(true)
-    expect(stdoutChunks).toEqual([])
-    expect(stderrChunks).toEqual([])
+    expect(stdoutChunks).toEqual([exact.stdout])
+    expect(stderrChunks).toEqual([exact.stderr])
     expect(value.client.kills).toEqual([])
     await value.pair.dispose()
   })

--- a/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxExec.ts
+++ b/packages/boring-sandbox/src/providers/blaxel/createBlaxelSandboxExec.ts
@@ -199,6 +199,11 @@ export function createBlaxelSandboxExec(
         }
         if (signal?.aborted) throw abortReason(signal)
         const capped = capUtf8Outputs(terminal.stdout ?? '', terminal.stderr ?? '', maxOutputBytes)
+        // Blaxel 0.3.11 returns terminal buffers but does not stream process
+        // output. Preserve Sandbox's callback contract so consumers such as the
+        // pi bash tool receive command output.
+        if (capped.stdout.length > 0) opts?.onStdout?.(capped.stdout)
+        if (capped.stderr.length > 0) opts?.onStderr?.(capped.stderr)
         return {
           ...capped,
           exitCode: terminal.exitCode ?? 1,

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -451,7 +451,6 @@ test('core/full-app scope authority rejects forgeries and cross-workspace route 
     })
     await expect(hostOptions.resolveAuthorizedEnvironmentScope({ authorizedScope: scope }))
       .resolves.toMatchObject({ runtimeWorkspaceId: 'workspace-a' })
-
     const forgedScopes = [
       { label: 'spread copy', scope: { ...scope } },
       { label: 'JSON round-trip', scope: JSON.parse(JSON.stringify(scope)) },

--- a/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
+++ b/packages/core/src/app/server/__tests__/createCoreWorkspaceAgentServer.provisioning.test.ts
@@ -449,6 +449,8 @@ test('core/full-app scope authority rejects forgeries and cross-workspace route 
       workspaceScopeId: JSON.stringify(['workspace-a', 'workspace-a']),
       authSubjectId: 'user-a',
     })
+    await expect(hostOptions.resolveAuthorizedEnvironmentScope({ authorizedScope: scope }))
+      .resolves.toMatchObject({ runtimeWorkspaceId: 'workspace-a' })
 
     const forgedScopes = [
       { label: 'spread copy', scope: { ...scope } },

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1373,7 +1373,10 @@ export async function createCoreWorkspaceAgentServer(
     const templatePath = options.getTemplatePath
       ? await options.getTemplatePath({ workspaceId, workspaceRoot: root, request })
       : options.templatePath ?? normalizeOptionalPath(process.env.BORING_AGENT_TEMPLATE_PATH)
-    const pi = await resolvePiOptions({ workspaceId, workspaceRoot: root, request }) ?? {}
+    const resolvedPi = await resolvePiOptions({ workspaceId, workspaceRoot: root, request }) ?? {}
+    const pi: PiHarnessOptions = runtimeModeAdapter.id === 'blaxel' || runtimeModeAdapter.id === 'vercel-sandbox'
+      ? { ...resolvedPi, noExtensions: true }
+      : resolvedPi
     const sessionNamespace = await resolveSessionNamespace({
       workspaceId,
       workspaceRoot: root,

--- a/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
+++ b/packages/core/src/app/server/createCoreWorkspaceAgentServer.ts
@@ -1500,6 +1500,7 @@ export async function createCoreWorkspaceAgentServer(
     const environment: AgentHostEnvironmentScope = {
       placementIdentity,
       provisioningFingerprint,
+      runtimeWorkspaceId: workspaceId,
       workspaceRoot: root,
       templatePath,
       resolveFilesystemBindings: resolveFilesystemBindings


### PR DESCRIPTION
## Summary
- keep Core sandbox-handle persistence keyed by the canonical workspace UUID while retaining the composite Agent scope identity
- replay Blaxel terminal buffers through Sandbox callbacks so the pi bash tool receives stdout/stderr
- disable ambient host Pi extensions in remote builtin modes so host-only command rewrites cannot leak into remote sandboxes

## Live proof
Authenticated full-app running locally against Blaxel `eu-fra-1` and Infomaniak model:
- file tree and filesystem catalog loaded from `/workspace`
- HTTP create/read/move/search/tree passed
- agent write/read/edit tools passed
- agent bash returned `BASH_CALLBACK_OK/workspace`
- exact `cat exact.txt && printf _OK` returned `EXACT_OK` without host RTK rewriting
- direct Blaxel provider lifecycle/Volume smoke had already passed; smoke sandboxes and Volumes cleaned up

## Tests
- Core provisioning regression: 15/15
- Blaxel provider conformance: 22/22

Closes #1248