### PR TITLE
fix(workspace): clean up left header and chat chrome (#1251)

### DIFF
--- a/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
+++ b/packages/workspace/src/app/front/WorkspaceAgentFront.tsx
@@ -2464,35 +2464,6 @@ export function WorkspaceAgentFront<
   }, [createAddressedSessionWithoutActivating, defaultSessionTitle, newChatAgentTypeId, fleetModeEnabled, shellCapabilitiesHost.shellCapabilities])
   const providerPanels = baseProviderPanels
   const pluginAppLeftActions = usePluginAppLeftActions({ plugins: capturedPlugins, activeOverlay: leftOverlay, setActiveOverlay: setLeftOverlay })
-  const chatTopOverlayActions = useMemo(() => {
-    if (!isPluginTabsLayout || !appLeftOverlayActions?.length) return null
-    return (
-      <div className="flex items-center gap-1">
-        {appLeftOverlayActions.map((action) => (
-          <button
-            key={action.id}
-            type="button"
-            data-boring-workspace-part="chat-pane-control"
-            className="inline-flex h-5 items-center gap-1 rounded-md px-1.5 text-[11px] font-medium text-muted-foreground/80 transition-colors hover:bg-muted/70 hover:text-foreground aria-pressed:bg-muted aria-pressed:text-foreground"
-            aria-label={action.label}
-            aria-pressed={leftOverlay === action.id}
-            title={action.label}
-            onPointerDownCapture={(event) => event.nativeEvent.stopPropagation()}
-            onMouseDownCapture={(event) => event.nativeEvent.stopPropagation()}
-            onClick={(event) => {
-              event.preventDefault()
-              event.stopPropagation()
-              setLeftOverlay((cur) => cur === action.id ? null : action.id)
-            }}
-          >
-            {action.icon ? <span className="grid size-3.5 place-items-center">{action.icon}</span> : null}
-            <span>{action.label}</span>
-          </button>
-        ))}
-      </div>
-    )
-  }, [appLeftOverlayActions, isPluginTabsLayout, leftOverlay])
-
   const managementActions = useMemo<WorkspaceAgentAppLeftAction[]>(() => {
     const actions: WorkspaceAgentAppLeftAction[] = [...pluginAppLeftActions, ...(appLeftActions ?? [])]
     for (const action of appLeftOverlayActions ?? []) {
@@ -2584,8 +2555,7 @@ export function WorkspaceAgentFront<
       center="chat"
       centerParams={centerParams}
       chatPanes={chatPanes}
-      chatTopActions={chatTopOverlayActions}
-      chatPaneSessionActions={chatPaneSessionActions}
+        chatPaneSessionActions={chatPaneSessionActions}
       activeChatPaneId={activeChatPaneId}
       onActiveChatPaneChange={activateChatPane}
       onCloseChatPane={closeChatPane}

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -884,6 +884,27 @@ describe("WorkspaceAgentFront", () => {
     expect(screen.getByTestId("chat-pane")).toHaveAttribute("data-session-id", "s1")
   })
 
+  it("keeps app-left overlay actions out of chat pane headers", () => {
+    render(
+      <WorkspaceAgentFront
+        workspaceId="plugin-tabs-overlay-header"
+        workspaceLayout="plugin-tabs"
+        chatPanel={SessionIdChatPanel}
+        sessions={[{ id: "s1", title: "First session" }]}
+        activeSessionId="s1"
+        appLeftOverlayActions={[{
+          id: "mcp",
+          label: "MCP",
+          render: () => <div>MCP overlay</div>,
+        }]}
+        persistenceEnabled={false}
+      />,
+    )
+
+    expect(within(screen.getByLabelText("App navigation")).getByRole("button", { name: "MCP" })).toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: "MCP" })).toHaveLength(1)
+  })
+
   it("keeps only the current app-left overlay action selected and returns to Chats from the rail", async () => {
     const user = userEvent.setup()
     const automationPlugin = definePlugin({

--- a/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
+++ b/packages/workspace/src/app/front/__tests__/WorkspaceAgentFront.test.tsx
@@ -895,6 +895,7 @@ describe("WorkspaceAgentFront", () => {
         appLeftOverlayActions={[{
           id: "mcp",
           label: "MCP",
+          icon: <span aria-hidden="true">M</span>,
           render: () => <div>MCP overlay</div>,
         }]}
         persistenceEnabled={false}

--- a/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneHeader.tsx
+++ b/packages/workspace/src/front/layout/plugin-tabs/AppLeftPaneHeader.tsx
@@ -18,7 +18,7 @@ export function AppLeftPaneHeader({
 
   return (
     <div className="flex h-[50px] shrink-0 items-center border-b border-border/50 px-2 pr-3" data-boring-workspace-part="app-left-header">
-      <div className="flex min-w-0 flex-1 items-center gap-2" style={{ paddingLeft: "2.5rem" }}>
+      <div className="flex min-w-0 flex-1 items-center gap-2 pl-10">
         {showBrand ? (
           <>
             <span
@@ -34,7 +34,9 @@ export function AppLeftPaneHeader({
         ) : null}
         {workspace ? (
           <div
-            className="ml-auto min-w-0 max-w-[45%] truncate text-right text-[11px] font-normal text-muted-foreground"
+            className={showBrand
+              ? "ml-auto min-w-0 max-w-[45%] truncate text-right text-[11px] font-normal text-muted-foreground"
+              : "min-w-0 flex-1 text-left text-[11px] font-normal text-muted-foreground"}
             data-boring-workspace-part="app-left-pane-workspace"
           >
             {workspace}


### PR DESCRIPTION
## Summary
- let the workspace switcher use the full left-header width after the sidebar toggle
- remove app-left overlay actions from chat pane headers; MCP remains available in app navigation
- cover the single MCP navigation affordance

## Validation
- WorkspaceAgentFront: 91/91 tests passed

Closes #1251