### PR TITLE
fix(agent): prevent first prompt timeout during Pi cold start

### DIFF
--- a/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
+++ b/packages/agent/src/front/chat/pi/__tests__/remotePiSession.test.ts
@@ -212,6 +212,32 @@ describe('RemotePiSession', () => {
     session.dispose()
   })
 
+  it('allows command admission more time than state hydration', async () => {
+    vi.useFakeTimers()
+    const events = openNdjsonStream()
+    const promptResponse = deferred<Response>()
+    const fetchMock = vi.fn((url: string) => {
+      if (url.endsWith('/events?cursor=0')) return Promise.resolve(new Response(events.stream))
+      if (url.endsWith('/prompt')) return promptResponse.promise
+      throw new Error(`unexpected URL ${url}`)
+    }) as unknown as MockFetch
+    const session = createSession(fetchMock, {
+      autoStart: false,
+      requestTimeoutMs: 20,
+      commandTimeoutMs: 40,
+    })
+
+    const prompt = session.prompt({ message: 'hello', clientNonce: 'nonce-1' })
+    await flushPromises()
+    vi.advanceTimersByTime(25)
+    await flushPromises()
+    expect(fetchMock.mock.calls.some(([url]) => url.endsWith('/prompt'))).toBe(true)
+
+    promptResponse.resolve(jsonResponse({ accepted: true, cursor: 1, clientNonce: 'nonce-1' }))
+    await expect(prompt).resolves.toMatchObject({ accepted: true, clientNonce: 'nonce-1' })
+    session.dispose()
+  })
+
   it('recovers a hung /state hydration via the request timeout instead of stalling forever', async () => {
     // First /state never settles (saturated/restarting server). Without a
     // per-attempt timeout the chat stays stuck "Loading chat history…"; the

--- a/packages/agent/src/front/chat/pi/remotePiSession.ts
+++ b/packages/agent/src/front/chat/pi/remotePiSession.ts
@@ -43,6 +43,11 @@ const DEFAULT_RECONNECT_MAX_MS = 30_000
 // a slow/hung attempt surfaces as a (retryable) error and the reconnect loop
 // re-issues a fresh request against the recovered server.
 const DEFAULT_REQUEST_TIMEOUT_MS = 15_000
+// Prompt admission may cold-start the agent runtime and load plugins before it
+// can return its 202 receipt. Keep state/stream recovery bounded tightly, but
+// give commands enough time to finish admission instead of rolling back an
+// accepted prompt after the client-side deadline.
+const DEFAULT_COMMAND_TIMEOUT_MS = 60_000
 const DEFAULT_LARGE_STATE_WARNING_BYTES = 5 * 1024 * 1024
 const DEFAULT_LARGE_STATE_WARNING_MESSAGES = 300
 const EVENT_TYPE_RING_LIMIT = 20
@@ -79,9 +84,12 @@ export interface RemotePiSessionOptions {
   }
   setTimeoutFn?: typeof globalThis.setTimeout
   clearTimeoutFn?: typeof globalThis.clearTimeout
-  // Per-attempt timeout for /state and command fetches. Defaults to
-  // DEFAULT_REQUEST_TIMEOUT_MS; exposed mainly for tests.
+  // Per-attempt timeout for /state and event-stream connection fetches.
+  // Defaults to DEFAULT_REQUEST_TIMEOUT_MS; exposed mainly for tests.
   requestTimeoutMs?: number
+  // Per-attempt timeout for command fetches. Defaults to
+  // DEFAULT_COMMAND_TIMEOUT_MS; exposed mainly for tests.
+  commandTimeoutMs?: number
 }
 
 export interface RemotePiSessionLargeStateWarning {
@@ -133,6 +141,7 @@ export class RemotePiSession {
   private readonly setTimeoutFn: typeof globalThis.setTimeout
   private readonly clearTimeoutFn: typeof globalThis.clearTimeout
   private readonly requestTimeoutMs: number
+  private readonly commandTimeoutMs: number
   private generation = 0
   private streamRunId = 0
   private reconnectAttempt = 0
@@ -154,6 +163,7 @@ export class RemotePiSession {
     this.setTimeoutFn = options.setTimeoutFn ?? globalThis.setTimeout
     this.clearTimeoutFn = options.clearTimeoutFn ?? globalThis.clearTimeout
     this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
+    this.commandTimeoutMs = options.commandTimeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS
     this.store = createPiChatStore(createInitialPiChatState({
       sessionId: options.sessionId,
       workspaceId: options.workspaceId,
@@ -520,7 +530,7 @@ export class RemotePiSession {
       method: 'POST',
       headers: { ...headers, 'Content-Type': 'application/json' },
       body: JSON.stringify(this.addressedCommandPayload(path, payload)),
-    })
+    }, this.commandTimeoutMs)
     if (!this.isGenerationActive(generation)) {
       throw abortError('Remote Pi session disposed before command receipt.')
     }
@@ -540,7 +550,7 @@ export class RemotePiSession {
     this.store.dispatch({ type: 'remove-optimistic-user-message', clientNonce }, { flush: true })
   }
 
-  private async fetchJson(url: string, init: RequestInit): Promise<unknown> {
+  private async fetchJson(url: string, init: RequestInit, timeoutMs = this.requestTimeoutMs): Promise<unknown> {
     const controller = new AbortController()
     this.fetchControllers.add(controller)
     // Bound the attempt: a hung request (saturated server right after a
@@ -551,7 +561,7 @@ export class RemotePiSession {
     const timer = globalThis.setTimeout(() => {
       timedOut = true
       controller.abort()
-    }, this.requestTimeoutMs)
+    }, timeoutMs)
     try {
       const response = await this.fetchImpl(url, { ...init, signal: controller.signal })
       const body = await safeReadJson(response)
@@ -561,7 +571,7 @@ export class RemotePiSession {
       // Distinguish our own timeout abort from a dispose-driven abort: a
       // dispose abort must stay an (ignored) AbortError, but a timeout should
       // throw a real error so the caller's catch reaches scheduleReconnect.
-      if (timedOut) throw new Error(`Request to ${url} timed out after ${this.requestTimeoutMs}ms.`)
+      if (timedOut) throw new Error(`Request to ${url} timed out after ${timeoutMs}ms.`)
       throw error
     } finally {
       globalThis.clearTimeout(timer)

--- a/packages/agent/src/server/pi-chat/harnessPiChatService.ts
+++ b/packages/agent/src/server/pi-chat/harnessPiChatService.ts
@@ -271,6 +271,11 @@ export class HarnessPiChatService implements PiChatSessionService {
     }
 
     const adapter = await this.getAdapter(ctx, sessionId, '')
+    // State hydration is the normal first request for a newly opened chat.
+    // Finish the channel's cold setup here so the first prompt only has to
+    // reserve and enqueue work; otherwise /prompt races this lazy setup and
+    // can spend the entire client request budget booting Pi/plugins.
+    await this.ensureChannel(ctx, sessionId, adapter)
     if (this.canRefreshFromPersistedState(sessionKey, adapter)) {
       const persisted = await this.readPersistedState(ctx, sessionId)
       if (


### PR DESCRIPTION
## Problem
The first prompt could time out after 15 seconds while the server lazily booted the Pi session, loaded skills/plugins, opened the transcript, and created the live event channel. The browser then reported the request timeout and rolled back the optimistic message, even though startup was still in progress.

## Fix
- Prewarm the Pi adapter and event channel during `/state` hydration.
- Keep the existing 15-second timeout for state hydration and event-stream connection recovery.
- Give command requests a separate 60-second admission timeout for unavoidable cold-start work.
- Add regression coverage for command-vs-hydration timeout behavior.

## Validation
- `pnpm exec vitest run src/front/chat/pi/__tests__/remotePiSession.test.ts` — 24 passed
- `pnpm exec vitest run src/server/pi-chat/__tests__/harnessPiChatService.test.ts src/front/chat/pi/__tests__/remotePiSession.test.ts` — 77 passed
- `pnpm exec playwright test e2e/pi-native-standalone-playground-smoke.spec.ts --config=e2e/playwright.config.ts` — 1 passed
- `pnpm exec playwright test e2e/pi-native-harness-baseline-message-flow.spec.ts --config=e2e/playwright.config.ts` — 2 passed
- Agent build passed.

## Review note
The full package test command has unrelated environment/package-build failures in existing UI suites and one unrelated timeout; the focused unit and playground-backed tests pass.
