### PR TITLE
feat(data-bridge): ship generic BSL querying skill

### DIFF
--- a/plugins/data-bridge/package.json
+++ b/plugins/data-bridge/package.json
@@ -16,9 +16,14 @@
     "front": "dist/front/index.js",
     "server": "dist/server/index.js"
   },
+  "pi": {
+    "skills": ["skills/bsl-querying"],
+    "systemPrompt": "Use the bsl-querying skill for semantic queries. Validate models and fields against the configured semantic model before querying, and use query_data for data retrieval."
+  },
   "files": [
     "dist",
     "python",
+    "skills",
     "README.md"
   ],
   "exports": {

--- a/plugins/data-bridge/skills/bsl-querying/SKILL.md
+++ b/plugins/data-bridge/skills/bsl-querying/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: bsl-querying
+description: Construct and debug Boring Semantic Layer queries through Data Bridge. Use for semantic model discovery, dimensions, measures, filters, grouping, ordering, dates, limits, and BSL query errors.
+---
+
+# BSL Querying
+
+Use Data Bridge's `query_data` tool with `language: "bsl"` for semantic queries. The host configures the semantic model and profile; always inspect the configured model rather than inventing model or field names.
+
+## Query contract
+
+Every BSL query string must be one complete expression that returns an executable table:
+
+- root the expression at `sm`, the model selected by the request's `model` field;
+- use `_` only as a deferred column reference inside operations on `sm`;
+- never submit pseudocode, a bare `_`, or a literal `...` placeholder;
+- do not append `.execute()` because Data Bridge executes the expression;
+- use only dimensions and measures defined verbatim by the configured model;
+- prefer explicit date ranges and bounded results.
+
+Example:
+
+```python
+sm.filter(
+    (_.date >= ibis.date("2026-01-01"))
+    & (_.date < ibis.date("2027-01-01"))
+).group_by("month").aggregate(
+    "record_count"
+).order_by("month")
+```
+
+## Workflow
+
+1. Identify the requested semantic model.
+2. Verify every selected, filtered, grouped, and ordered field exists in that model.
+3. Apply filters before aggregation, especially tenant/security filters supplied by host policy.
+4. Request only the dimensions and measures needed for the answer.
+5. Keep limits small and report truncation.
+6. If a metric or field is absent, say it is unavailable instead of querying a guess.
+
+Use SQL only when the host explicitly allows it and BSL cannot express the required validation or shape. Do not expose connection credentials or physical database details.

--- a/plugins/data-bridge/src/server/index.ts
+++ b/plugins/data-bridge/src/server/index.ts
@@ -512,6 +512,10 @@ export function createDataBridgeServerPlugin(options: CreateDataBridgeServerPlug
     agentTools: options.agentTool === false ? [] : [createDataBridgeQueryAgentTool(pluginOptions)],
     workspaceBridgeHandlers: [queryRun as unknown as WorkspaceBridgeHandlerContribution, queryBatch as unknown as WorkspaceBridgeHandlerContribution],
     routes,
+    packageResources: [{
+      packageName: "@hachej/boring-data-bridge",
+      packageRoot: new URL("../../", import.meta.url),
+    }],
     systemPrompt: "Use query_data for dashboard/reporting data. Supported query languages are bsl and sql. Use data.v1.query.run for individual requests and data.v1.query.batch when loading multiple queries; set format=arrow for BI/Perspective snapshot viewers.",
   })
 }

--- a/plugins/data-bridge/src/server/package-resources.test.ts
+++ b/plugins/data-bridge/src/server/package-resources.test.ts
@@ -1,0 +1,22 @@
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+import { createDataBridgeServerPlugin } from "./index"
+
+const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))))
+
+describe("data bridge package resources", () => {
+  it("declares and publishes its generic BSL skill", () => {
+    const manifest = JSON.parse(readFileSync(join(packageRoot, "package.json"), "utf8"))
+    expect(manifest.files).toContain("skills")
+    expect(manifest.pi.skills).toEqual(["skills/bsl-querying"])
+    expect(manifest.pi.systemPrompt).not.toMatch(/Healio|tenant_id/)
+    expect(existsSync(join(packageRoot, "skills/bsl-querying/SKILL.md"))).toBe(true)
+
+    const plugin = createDataBridgeServerPlugin({ workspaceRoot: "/workspace", agentTool: false })
+    expect(plugin.packageResources).toHaveLength(1)
+    expect(plugin.packageResources?.[0]?.packageName).toBe("@hachej/boring-data-bridge")
+    expect(fileURLToPath(plugin.packageResources?.[0]?.packageRoot as URL)).toBe(`${packageRoot}/`)
+  })
+})


### PR DESCRIPTION
Closes #1257.

## Summary

- add a generic `bsl-querying` skill owned by Data Bridge
- register the Data Bridge package as a package-resource contribution
- publish the skill and declare it through `package.json#pi`
- keep all host/domain-specific models, paths, tenant rules, and reporting policy out of the generic skill

## Validation

- `pnpm --filter @hachej/boring-data-bridge typecheck`
- `pnpm --filter @hachej/boring-data-bridge test` — 26 passed
- `pnpm --filter @hachej/boring-data-bridge build`
- `pnpm pack`; tarball contains `skills/bsl-querying/SKILL.md`
