### PR TITLE
fix(cli): allow authorized repository skill symlinks

### DIFF
--- a/packages/agent/src/server/piResourceDigest.ts
+++ b/packages/agent/src/server/piResourceDigest.ts
@@ -39,6 +39,8 @@ export interface PiResourceDigestInput {
   readonly extensionPaths?: readonly string[]
   /** Lexical roots explicitly authorized by the embedding Workspace/CLI. */
   readonly authorizedRoots: readonly string[]
+  /** CLI workspaces may contain repo-managed symlinks (e.g. .pi/skills/*). */
+  readonly allowInternalSymlinks?: boolean
   readonly limits?: Partial<PiResourceDigestLimits>
 }
 
@@ -57,6 +59,7 @@ export function createPiResourceDigestInput(input: {
   readonly noSkills?: boolean
   readonly resourceSets: readonly PiResourceSet[]
   readonly authorizedRoots: readonly string[]
+  readonly allowInternalSymlinks?: boolean
   readonly limits?: Partial<PiResourceDigestLimits>
 }): PiResourceDigestInput {
   const piCwd = resolvePiPath(input.piCwd, process.cwd())
@@ -72,6 +75,7 @@ export function createPiResourceDigestInput(input: {
     additionalSkillPaths: uniqueStrings(input.resourceSets.flatMap((set) => set.additionalSkillPaths ?? [])),
     packages: compactPiPackages(input.resourceSets.flatMap((set) => set.packages ?? [])),
     extensionPaths: uniqueStrings(input.resourceSets.flatMap((set) => set.extensionPaths ?? [])),
+    allowInternalSymlinks: input.allowInternalSymlinks,
     authorizedRoots: uniqueStrings([
       piCwd,
       piAgentDir,
@@ -88,6 +92,7 @@ interface WalkState {
   readonly hash: Hash
   readonly limits: PiResourceDigestLimits
   readonly authorizedRoots: readonly string[]
+  readonly allowInternalSymlinks: boolean
   nodes: number
   bytes: number
 }
@@ -110,7 +115,14 @@ export async function digestPiResourceInputs(input: PiResourceDigestInput): Prom
     throw stableError(ErrorCode.enum.CONFIG_INVALID, 400, 'Pi resource digest requires at least one independently authorized root')
   }
   const limits = normalizeLimits(input.limits)
-  const state: WalkState = { hash, limits, authorizedRoots, nodes: 0, bytes: 0 }
+  const state: WalkState = {
+    hash,
+    limits,
+    authorizedRoots,
+    allowInternalSymlinks: input.allowInternalSymlinks ?? false,
+    nodes: 0,
+    bytes: 0,
+  }
   frameString(hash, 'format', FORMAT_VERSION)
   frameString(hash, 'pi-cwd', piCwd)
   frameString(hash, 'project-settings-dir', projectSettingsDir)
@@ -209,7 +221,7 @@ async function hashResourceCollection(
 ): Promise<void> {
   for (const path of [...new Set(paths)].sort()) {
     const absolutePath = resolvePiPath(path, baseDir)
-    await assertContainedWithoutSymlinks(absolutePath, state.authorizedRoots)
+    await assertContainedWithoutSymlinks(absolutePath, state.authorizedRoots, state.allowInternalSymlinks)
     try {
       await lstat(absolutePath)
     } catch (error) {
@@ -311,7 +323,7 @@ async function hashLocalResource(
   depth: number,
 ): Promise<void> {
   const absolutePath = resolve(path)
-  await assertContainedWithoutSymlinks(absolutePath, state.authorizedRoots)
+  await assertContainedWithoutSymlinks(absolutePath, state.authorizedRoots, state.allowInternalSymlinks)
   if (depth > state.limits.maxDepth) {
     throw limitError(`Pi resource tree exceeds maximum depth ${state.limits.maxDepth}`)
   }
@@ -330,7 +342,16 @@ async function hashLocalResource(
     throw limitError(`Pi resource tree exceeds maximum node count ${state.limits.maxFiles}`)
   }
   if (stat.isSymbolicLink()) {
-    throw stableError(ErrorCode.enum.PATH_SYMLINK_ESCAPE, 403, `Pi resource symlinks are not allowed: ${absolutePath}`)
+    if (!state.allowInternalSymlinks) {
+      throw stableError(ErrorCode.enum.PATH_SYMLINK_ESCAPE, 403, `Pi resource symlinks are not allowed: ${absolutePath}`)
+    }
+    const target = await realpath(absolutePath)
+    if (!mostSpecificContainingRoot(target, state.authorizedRoots)) {
+      throw stableError(ErrorCode.enum.PATH_SYMLINK_ESCAPE, 403, `Pi resource symlink resolves outside authorized roots: ${absolutePath}`)
+    }
+    frameString(state.hash, 'symlink-target', target)
+    await hashLocalResource(state, target, logicalPath, depth)
+    return
   }
   if (stat.isDirectory()) {
     frameString(state.hash, 'directory', logicalPath)
@@ -416,7 +437,7 @@ function assertSameFile(
   ) throw changedError(path)
 }
 
-async function assertContainedWithoutSymlinks(path: string, roots: readonly string[]): Promise<void> {
+async function assertContainedWithoutSymlinks(path: string, roots: readonly string[], allowInternalSymlinks = false): Promise<void> {
   const root = mostSpecificContainingRoot(path, roots)
   if (!root) {
     throw stableError(ErrorCode.enum.PATH_ESCAPE, 403, `Pi resource path is outside authorized roots: ${path}`)
@@ -429,7 +450,13 @@ async function assertContainedWithoutSymlinks(path: string, roots: readonly stri
     current = resolve(current, segment)
     try {
       if ((await lstat(current)).isSymbolicLink()) {
-        throw stableError(ErrorCode.enum.PATH_SYMLINK_ESCAPE, 403, `Pi resource symlinks are not allowed: ${current}`)
+        if (!allowInternalSymlinks) {
+          throw stableError(ErrorCode.enum.PATH_SYMLINK_ESCAPE, 403, `Pi resource symlinks are not allowed: ${current}`)
+        }
+        const target = await realpath(current)
+        if (!mostSpecificContainingRoot(target, roots)) {
+          throw stableError(ErrorCode.enum.PATH_SYMLINK_ESCAPE, 403, `Pi resource symlink resolves outside authorized roots: ${current}`)
+        }
       }
     } catch (error) {
       if (isMissing(error)) return

--- a/packages/cli/src/server/modeApps.ts
+++ b/packages/cli/src/server/modeApps.ts
@@ -1039,6 +1039,7 @@ export async function createWorkspacesModeApp(opts: {
               extensionPaths: hotResources.extensionPaths,
             }],
             authorizedRoots: piResourceAuthorizedRoots(workspace),
+            allowInternalSymlinks: true,
           })
         }
         const { resourceInputDigest, revalidateResourceInputs } = await agentServer.createPiResourceDigestFence(buildResourceDigestInput)
@@ -1130,6 +1131,7 @@ export async function createWorkspacesModeApp(opts: {
               extensionPaths: hotResources.extensionPaths,
             }],
             authorizedRoots: piResourceAuthorizedRoots(workspace),
+            allowInternalSymlinks: true,
           }),
         ),
         sessionNamespace: "",

--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -660,6 +660,16 @@ describe("workspace app-server plugin package helpers", () => {
       code: "PATH_SYMLINK_ESCAPE",
       statusCode: 403,
     })
+    const internalRoot = join(root, "internal")
+    const internalTarget = join(internalRoot, "internal.js")
+    await mkdir(internalRoot)
+    await writeFile(internalTarget, "export default 'internal'\n", "utf8")
+    await symlink(internalTarget, join(internalRoot, "internal-link.js"))
+    await expect(digestWorkspacePiResourceInputs({
+      ...input,
+      extensionPaths: [join(internalRoot, "internal-link.js")],
+      allowInternalSymlinks: true,
+    })).resolves.toMatch(/^sha256:/)
 
     const collisionRoot = await makeTempDir("boring-resource-digest-framing-")
     const directoryShape = join(collisionRoot, "a")


### PR DESCRIPTION
## Problem
CLI workspace startup failed when a repository-managed Pi skill symlink such as `.pi/skills/exec -> ../../.agents/skills/exec` was encountered:

```text
Pi resource symlinks are not allowed: .../.pi/skills/exec
```

The runtime-scope error was a secondary setup failure caused by this rejected resource digest.

## Fix
- Allow symlinks in CLI mode only when their resolved target remains inside authorized roots.
- Continue rejecting symlinks by default in workspace/remote modes.
- Include the symlink target in the resource digest.
- Add regression coverage for authorized internal symlinks.

## Validation
- Workspace resource tests: 58 passed.
- CLI resource digest measured on `boring-ui-v2`: 393ms.
- Agent typecheck passed.
- CLI bundle build passed.

Full CLI browser startup timing could not be completed because this checkout lacks a built CLI frontend and has unrelated stale workspace/plugin build artifacts; `pnpm build:full` is required for that environment-level check.
