### PR TITLE
#1265 fix(ask-user): unblock browser question bridge

### DIFF
--- a/packages/core/src/app/front/credits/CreditBalanceBadge.tsx
+++ b/packages/core/src/app/front/credits/CreditBalanceBadge.tsx
@@ -16,7 +16,7 @@ export interface CreditBalanceBadgeProps {
 }
 
 /**
- * Top-bar credit balance: a DISCRETE remaining-balance figure plus a small "+" button.
+ * Top-bar credit balance: a DISCRETE available-balance figure plus a small "+" button.
  * Clicking "+" opens a popover of fixed top-up amounts (Anthropic-style); picking one starts
  * the server-created checkout and opens it. Polls `/api/credits/balance`; hides itself when
  * credits are disabled or the user is unauthenticated.
@@ -33,7 +33,9 @@ export function CreditBalanceBadge({
   if (hidden || !balance) return null
 
   const inDebt = (balance.debtMicros ?? 0) > 0
-  const low = inDebt || isLowBalance(balance.remainingMicros)
+  const availableMicros = balance.availableMicros
+  const reservedMicros = balance.activeReservedMicros
+  const low = inDebt || isLowBalance(availableMicros)
   // Prefer server truth over the build-time flag so the action can't drift.
   const showBuy = balance.checkoutEnabled ?? buyEnabled
   // Fixed packs only (custom pay-what-you-want is not offered).
@@ -42,6 +44,11 @@ export function CreditBalanceBadge({
   // not a hard-coded EUR — packs carry the configured currency; fall back to EUR when no
   // purchase provider is wired (consumption-only).
   const currency = balance.packs?.[0]?.currency ?? 'EUR'
+  const title = inDebt
+    ? 'Amount owed — top up to resume'
+    : reservedMicros > 0
+      ? `${formatCreditMicros(availableMicros, currency, locale)} available (${formatCreditMicros(balance.remainingMicros, currency, locale)} remaining, ${formatCreditMicros(reservedMicros, currency, locale)} reserved by active runs)`
+      : 'Available credits'
 
   const pick = async (packId?: string) => {
     setOpen(false)
@@ -52,10 +59,10 @@ export function CreditBalanceBadge({
     <div className="inline-flex items-center gap-1.5" data-low={low ? 'true' : 'false'} data-debt={inDebt ? 'true' : 'false'}>
       {/* Discrete: small, muted, tabular; only colors up when low / in debt. */}
       <span
-        title={inDebt ? 'Amount owed — top up to resume' : 'Remaining credits'}
+        title={title}
         className={`text-[11px] tabular-nums ${low ? 'text-destructive' : 'text-muted-foreground'}`}
       >
-        {inDebt ? `−${formatCreditMicros(balance.debtMicros, currency, locale)}` : formatCreditMicros(balance.remainingMicros, currency, locale)}
+        {inDebt ? `−${formatCreditMicros(balance.debtMicros, currency, locale)}` : formatCreditMicros(availableMicros, currency, locale)}
       </span>
       {showBuy ? (
         <Popover open={open} onOpenChange={setOpen}>

--- a/packages/core/src/app/front/credits/__tests__/CreditBalanceBadge.test.tsx
+++ b/packages/core/src/app/front/credits/__tests__/CreditBalanceBadge.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CreditBalanceBadge } from '../CreditBalanceBadge.js'
+import { useCreditBalance } from '../useCreditBalance.js'
+
+vi.mock('../useCreditBalance.js', () => ({ useCreditBalance: vi.fn() }))
+
+const useCreditBalanceMock = vi.mocked(useCreditBalance)
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('CreditBalanceBadge', () => {
+  it('shows spendable credits instead of balance reserved by active runs', () => {
+    useCreditBalanceMock.mockReturnValue({
+      balance: {
+        enabled: true,
+        userId: 'user-1',
+        grantedMicros: 3_000_000,
+        usedMicros: 750_000,
+        remainingMicros: 2_250_000,
+        activeReservedMicros: 2_200_000,
+        availableMicros: 50_000,
+        debtMicros: 0,
+        checkoutEnabled: false,
+        currency: 'credits',
+      },
+      hidden: false,
+      error: null,
+      refresh: vi.fn(),
+      refreshWithRetry: vi.fn(),
+      buy: vi.fn(),
+      buying: false,
+      lastUpdatedAt: Date.now(),
+      updating: false,
+    })
+
+    render(<CreditBalanceBadge locale="en-US" />)
+
+    const balance = screen.getByTitle(/€0\.05 available/)
+    expect(balance).toHaveTextContent('€0.05')
+    expect(balance).toHaveAttribute('title', expect.stringContaining('€2.25 remaining'))
+    expect(balance).toHaveAttribute('title', expect.stringContaining('€2.20 reserved by active runs'))
+    expect(balance.parentElement).toHaveAttribute('data-low', 'true')
+  })
+})

--- a/plugins/ask-user/src/front/__tests__/client.test.ts
+++ b/plugins/ask-user/src/front/__tests__/client.test.ts
@@ -60,7 +60,7 @@ describe("ask-user front client", () => {
   })
 
   it("allows hosts to override the stock browser CSRF proof", async () => {
-    const fetchMock = vi.fn(async () => Response.json({ ok: true, output: { pending: null } }))
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => Response.json({ ok: true, output: { pending: null } }))
     vi.stubGlobal("fetch", fetchMock)
 
     await createQuestionsClient({ headers: { "x-csrf-token": "signed-proof" } }).pending("default")

--- a/plugins/ask-user/src/front/__tests__/client.test.ts
+++ b/plugins/ask-user/src/front/__tests__/client.test.ts
@@ -59,6 +59,18 @@ describe("ask-user front client", () => {
     expect(normalizeQuestion({ ...question, artifact })?.artifacts).toEqual([])
   })
 
+  it("allows hosts to override the stock browser CSRF proof", async () => {
+    const fetchMock = vi.fn(async () => Response.json({ ok: true, output: { pending: null } }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await createQuestionsClient({ headers: { "x-csrf-token": "signed-proof" } }).pending("default")
+
+    expect(fetchMock.mock.calls[0]![1]!.headers).toMatchObject({
+      "x-csrf-token": "signed-proof",
+      "x-boring-session-id": "default",
+    })
+  })
+
   it("cancels through the bridge when crypto.subtle is unavailable", async () => {
     vi.stubGlobal("crypto", {})
     const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => Response.json({ ok: true, output: { ok: true, status: "cancelled" } }))
@@ -66,7 +78,12 @@ describe("ask-user front client", () => {
 
     await expect(createQuestionsClient().cancel(question)).resolves.toEqual({ ok: true, status: "cancelled" })
 
-    const body = JSON.parse(String(fetchMock.mock.calls[0]![1]!.body))
+    const request = fetchMock.mock.calls[0]![1]!
+    expect(request.headers).toMatchObject({
+      "x-csrf-token": "browser",
+      "x-boring-session-id": "default",
+    })
+    const body = JSON.parse(String(request.body))
     expect(body).toMatchObject({
       op: "ask-user.v1.cancel",
       input: { questionId: "q1", sessionId: "default", answerToken: "secret" },

--- a/plugins/ask-user/src/front/client.ts
+++ b/plugins/ask-user/src/front/client.ts
@@ -62,6 +62,10 @@ export function createQuestionsClient(options: QuestionsClientOptions = {}) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
+        // Core's browser bridge policy requires a non-empty non-simple header as
+        // CSRF proof. Its stock policy checks presence, not a secret value; hosts
+        // that validate signed values can override this default in options.headers.
+        "x-csrf-token": "browser",
         ...(options.headers ?? {}),
         ...(sessionId ? { "x-boring-session-id": sessionId } : {}),
       },


### PR DESCRIPTION
Closes #1265.

## What changed

- send the browser bridge's required non-empty CSRF proof on every ask-user pending/answer/cancel call, while preserving signed-token overrides
- show spendable `availableMicros` in the top credit badge instead of ledger remainder hidden behind active run reservations
- explain remaining and reserved credit in the badge title

## Production evidence

Seneca diagnostics run `31741410327` showed authenticated workspace and balance requests returning 200 while every ask-user `POST /api/v1/workspace-bridge/call` returned 401. The blocked question run retained a reservation, and another prompt returned 402.

## Validation

- `plugins/ask-user: vitest run --no-file-parallelism src/front/__tests__/client.test.ts` — 5 passed
- `packages/core: vitest run --no-file-parallelism src/app/front/credits/__tests__/CreditBalanceBadge.test.tsx` — 1 passed
- `git diff --check` — passed
- thermo review — pass; no blockers
- independent review — static proof confirmed contract-correct; signed-token override finding fixed before commit

Package-level typecheck was attempted but this linked worktree resolves stale built exports from the coordination checkout; unrelated missing-export errors prevent a meaningful package result. CI installs/builds the branch normally.
