### PR TITLE
fix(agent): project package skill resource locators

### DIFF
--- a/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/__tests__/createHarness.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { writeFileSync } from "node:fs";
 import { appendFile, mkdir, mkdtemp, readFile, readdir, rm, stat, writeFile, utimes } from "node:fs/promises";
-import { CURRENT_SESSION_VERSION, DefaultResourceLoader, SessionManager } from "@mariozechner/pi-coding-agent";
+import { CURRENT_SESSION_VERSION, DefaultResourceLoader, formatSkillsForPrompt, SessionManager } from "@mariozechner/pi-coding-agent";
 import { basename, join } from "node:path";
 import { homedir, tmpdir } from "node:os";
 import {
   createResourceSettingsManager,
   createPiCodingAgentHarness,
   mergePiPackageSources,
+  projectSkillResourceLocations,
 } from "../createHarness.js";
 import { adaptToolsForPi } from "../tool-adapter.js";
 import {
@@ -338,6 +339,47 @@ describe("pi extension path hot reload", () => {
       await rm(cwd, { recursive: true, force: true });
       await rm(agentDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("projectSkillResourceLocations", () => {
+  it("projects located package skills without changing workspace skills", () => {
+    const packagePath = "/srv/node_modules/@example/plugin/skills/reporting/SKILL.md";
+    const workspacePath = "/workspace/.agents/skills/local/SKILL.md";
+    const prompt = formatSkillsForPrompt([packagePath, workspacePath].map((filePath, index) => ({
+      name: `skill-${index}`,
+      description: `Skill ${index}`,
+      filePath,
+      baseDir: filePath.slice(0, -"/SKILL.md".length),
+      sourceInfo: { path: filePath, source: "test", scope: "project", origin: "top-level" },
+      disableModelInvocation: false,
+    })));
+
+    const projected = projectSkillResourceLocations(prompt, (filePath) =>
+      filePath === packagePath
+        ? { filesystem: "agent_resources", path: "packages/@example/plugin/skills/reporting/SKILL.md" }
+        : undefined,
+    );
+
+    expect(projected).toContain('<location>{"filesystem":"agent_resources","path":"packages/@example/plugin/skills/reporting/SKILL.md"}</location>');
+    expect(projected).toContain(`<location>${workspacePath}</location>`);
+    expect(projected).not.toContain(`<location>${packagePath}</location>`);
+    expect(projected).toContain("pass its filesystem and path fields to the read tool");
+    expect(projected).not.toContain("use that absolute path in tool commands");
+  });
+
+  it("leaves prompts unchanged without a binding-backed locator", () => {
+    const prompt = "<available_skills><location>/workspace/.agents/skills/local/SKILL.md</location></available_skills>";
+    expect(projectSkillResourceLocations(prompt, () => undefined)).toBe(prompt);
+  });
+
+  it("decodes and re-escapes XML entities", () => {
+    const prompt = "<location>/srv/@scope/a&amp;b/SKILL.md</location>";
+    const projected = projectSkillResourceLocations(prompt, (filePath) => {
+      expect(filePath).toBe("/srv/@scope/a&b/SKILL.md");
+      return { filesystem: "agent_resources", path: "packages/@scope/a&b/SKILL.md" };
+    });
+    expect(projected).toContain('{"filesystem":"agent_resources","path":"packages/@scope/a&amp;b/SKILL.md"}');
   });
 });
 

--- a/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
+++ b/packages/agent/src/server/harness/pi-coding-agent/createHarness.ts
@@ -97,6 +97,8 @@ function composeSystemPromptAppend(hostAppend: string | undefined): string {
 
 export interface PiHarnessOptions {
   noContextFiles?: boolean;
+  /** Projects server-internal skill files to model-visible resource locators. */
+  locateSkillResource?: (filePath: string) => { filesystem: string; path: string } | undefined;
   noSkills?: boolean;
   /** Disable ambient Pi extensions (required when tools execute in a remote runtime). */
   noExtensions?: boolean;
@@ -168,6 +170,47 @@ function buildDynamicPromptExtension(
       if (!extra) return
       return { systemPrompt: `${event.systemPrompt}\n\n${extra}` }
     })
+  }
+}
+
+const PI_RELATIVE_SKILL_PATH_GUIDANCE = "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands."
+const RESOURCE_RELATIVE_SKILL_PATH_GUIDANCE = "When a skill location is a JSON resource locator, pass its filesystem and path fields to the read tool. Resolve referenced relative paths against the locator's directory in the same filesystem; never convert a resource locator to a host path."
+
+function unescapeXmlText(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&gt;/g, '>')
+    .replace(/&lt;/g, '<')
+    .replace(/&amp;/g, '&')
+}
+
+function escapeXmlText(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+export function projectSkillResourceLocations(
+  systemPrompt: string,
+  locate: (filePath: string) => { filesystem: string; path: string } | undefined,
+): string {
+  let projected = false
+  const output = systemPrompt.replace(/<location>([^<]*)<\/location>/g, (match, encodedPath: string) => {
+    const resource = locate(unescapeXmlText(encodedPath))
+    if (!resource) return match
+    projected = true
+    return `<location>${escapeXmlText(JSON.stringify(resource))}</location>`
+  })
+  if (!projected) return systemPrompt
+  return output.replace(PI_RELATIVE_SKILL_PATH_GUIDANCE, RESOURCE_RELATIVE_SKILL_PATH_GUIDANCE)
+}
+
+function buildSkillResourceProjectionExtension(
+  locate: (filePath: string) => { filesystem: string; path: string } | undefined,
+): ExtensionFactory {
+  return (pi) => {
+    pi.on("before_agent_start", async (event) => ({
+      systemPrompt: projectSkillResourceLocations(event.systemPrompt, locate),
+    }))
   }
 }
 
@@ -603,10 +646,14 @@ export function createPiCodingAgentHarness(opts: {
       : undefined
     const agentDir = getAgentDir()
     const toolErrorResultExtension = buildToolErrorResultExtension()
+    const skillResourceProjectionExtension = pi.locateSkillResource
+      ? buildSkillResourceProjectionExtension(pi.locateSkillResource)
+      : undefined
     const extensionFactories = [
       toolErrorResultExtension,
       ...(dynamicPromptExtension ? [dynamicPromptExtension] : []),
       ...(pi.extensionFactories ?? []),
+      ...(skillResourceProjectionExtension ? [skillResourceProjectionExtension] : []),
     ]
     const settingsManager = createResourceSettingsManager(
       opts.cwd,

--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -1414,7 +1414,15 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
             packages?: unknown[]
             extensionPaths?: string[]
             getHotReloadableResources?: () => { additionalSkillPaths?: string[] }
+            locateSkillResource?: (filePath: string) => { filesystem: string; path: string } | undefined
           }
+          getFilesystemBindings?: (ctx: { scope: { workspaceScopeId: string; authSubjectId: string }; requestId: string }) => Promise<Array<{
+            filesystem: string
+            operations: { read(input: { filesystem: string; path: string }): Promise<{ content: string }> }
+          }>>
+          getSkillResourceSnapshot?: () => Promise<{
+            managedSkills: Array<{ name: string; resource: { filesystem: string; path: string } }>
+          } | undefined>
         }>
       }]
       const scope = routeOptions.authorizedScope
@@ -1436,6 +1444,24 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
       expect(alpha.pi?.getHotReloadableResources?.().additionalSkillPaths).not.toContain(join(betaPackageRoot, "skills", "beta"))
       expect(await alpha.loadSystemPromptAppend?.()).toContain("ALPHA_MANIFEST_PROMPT")
       expect(await alpha.loadSystemPromptAppend?.()).not.toContain("BETA_MANIFEST_PROMPT")
+      const alphaSkillFile = join(alphaPackageRoot, "skills", "alpha", "SKILL.md")
+      expect(alpha.pi?.locateSkillResource?.(alphaSkillFile)).toEqual({
+        filesystem: "agent_resources",
+        path: "packages/@example/alpha/skills/alpha/SKILL.md",
+      })
+      expect(alpha.pi?.locateSkillResource?.(join(betaPackageRoot, "skills", "beta", "SKILL.md"))).toBeUndefined()
+      expect((await alpha.getSkillResourceSnapshot?.())?.managedSkills.map((skill) => skill.name)).toEqual(["alpha-skill"])
+      const agentCtx = { scope: { workspaceScopeId: "default", authSubjectId: "local" }, requestId: "agent-resource-scope" }
+      const alphaResources = (await alpha.getFilesystemBindings?.(agentCtx))?.find((binding) => binding.filesystem === "agent_resources")
+      expect(alphaResources).toBeDefined()
+      await expect(alphaResources!.operations.read({
+        filesystem: "agent_resources",
+        path: "packages/@example/alpha/skills/alpha/SKILL.md",
+      })).resolves.toMatchObject({ content: expect.stringContaining("alpha-skill") })
+      await expect(alphaResources!.operations.read({
+        filesystem: "agent_resources",
+        path: "packages/@example/beta/skills/beta/SKILL.md",
+      })).rejects.toBeDefined()
       expect(alpha.identity).toMatch(/^[a-f0-9]{64}$/)
 
       expect(beta.extraTools?.map((tool) => tool.name)).toContain("beta_tool")
@@ -1448,6 +1474,12 @@ describe("createWorkspaceAgentServer plugin runtime options", () => {
       expect(beta.pi?.getHotReloadableResources?.().additionalSkillPaths).not.toContain(join(alphaPackageRoot, "skills", "alpha"))
       expect(await beta.loadSystemPromptAppend?.()).toContain("BETA_MANIFEST_PROMPT")
       expect(await beta.loadSystemPromptAppend?.()).not.toContain("ALPHA_MANIFEST_PROMPT")
+      expect(beta.pi?.locateSkillResource?.(join(betaPackageRoot, "skills", "beta", "SKILL.md"))).toEqual({
+        filesystem: "agent_resources",
+        path: "packages/@example/beta/skills/beta/SKILL.md",
+      })
+      expect(beta.pi?.locateSkillResource?.(join(alphaPackageRoot, "skills", "alpha", "SKILL.md"))).toBeUndefined()
+      expect((await beta.getSkillResourceSnapshot?.())?.managedSkills.map((skill) => skill.name)).toEqual(["beta-skill"])
       expect(beta.identity).toMatch(/^[a-f0-9]{64}$/)
       expect(beta.identity).not.toBe(alpha.identity)
 

--- a/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
+++ b/packages/workspace/src/app/server/__tests__/createWorkspaceAgentServer.test.ts
@@ -2544,6 +2544,7 @@ describe("beforeReload triggers directory-source re-resolve", () => {
         } | undefined>
         pi?: {
           getHotReloadableResources?(): { additionalSkillPaths: string[] }
+          locateSkillResource?(filePath: string): { filesystem: string; path: string } | undefined
         }
         systemPromptAppend?: string
         loadSystemPromptAppend?(): string | undefined | Promise<string | undefined>
@@ -2562,6 +2563,10 @@ describe("beforeReload triggers directory-source re-resolve", () => {
       expect((await runtime.getFilesystemBindings?.(ctx))?.map((binding) => binding.filesystem)).toEqual(["agent_resources"])
       expect(runtime.pi?.getHotReloadableResources?.().additionalSkillPaths)
         .toContain(join(packageRoot, "skills", "authoring"))
+      expect(runtime.pi?.locateSkillResource?.(join(packageRoot, "skills", "authoring", "SKILL.md"))).toEqual({
+        filesystem: "agent_resources",
+        path: "packages/@example/direct-resource/skills/authoring/SKILL.md",
+      })
       const prompt = [runtime.systemPromptAppend, await runtime.loadSystemPromptAppend?.()]
         .filter(Boolean)
         .join("\n\n")

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -58,7 +58,7 @@ import {
 import Fastify, { type FastifyInstance, type FastifyRequest } from "fastify"
 import { existsSync, lstatSync, mkdirSync, readFileSync, readdirSync } from "node:fs"
 import { createHash } from "node:crypto"
-import { basename, dirname, isAbsolute, join, resolve } from "node:path"
+import { basename, dirname, isAbsolute, join, posix, resolve } from "node:path"
 import { homedir } from "node:os"
 import { createRequire } from "node:module"
 import { fileURLToPath } from "node:url"
@@ -1782,10 +1782,31 @@ export async function createWorkspaceAgentServer(
       )
       const selectedPluginIds = new Set(contribution.artifacts.map((artifact) => artifact.pluginId))
       const resourceRegistry = currentPackageResourceSnapshot?.registry
-      const selectedPackageSkillPaths = resourceRegistry?.skills
+      const selectedPackageSkills = resourceRegistry?.skills
         .filter((skill) => skill.packageName !== "shared/pi-agent"
-          && skill.pluginIds.some((pluginId) => selectedPluginIds.has(pluginId)))
-        .map((skill) => skill.mountRoot) ?? []
+          && skill.pluginIds.some((pluginId) => selectedPluginIds.has(pluginId))) ?? []
+      const agentPackageSkills = legacyGlobalPluginAgentContributions
+        ? resourceRegistry?.skills ?? []
+        : selectedPackageSkills
+      const selectedPackageSkillPaths = selectedPackageSkills.map((skill) => skill.mountRoot)
+      const agentPackageSkillByFile = new Map(agentPackageSkills.map((skill) => [skill.skillFile, skill.resource]))
+      const agentPackageMounts = [...new Map(agentPackageSkills.map((skill) => [
+        posix.dirname(skill.resource.path),
+        { logicalRoot: posix.dirname(skill.resource.path), sourceRoot: skill.mountRoot },
+      ])).values()]
+      const agentPackageBinding = legacyGlobalPluginAgentContributions
+        ? currentPackageResourceSnapshot?.binding
+        : agentPackageMounts.length > 0
+          ? await runtimeHost.createAgentResourceFilesystemBinding(AGENT_RESOURCES_FILESYSTEM_ID, agentPackageMounts)
+          : undefined
+      const agentManagedPackageSkills = agentPackageSkills.flatMap((skill) => skill.name ? [{
+        name: skill.name,
+        description: skill.description ?? "",
+        resource: skill.resource,
+        invocable: false as const,
+        source: skill.packageName,
+      }] : [])
+      const locateAgentPackageSkill = (filePath: string) => agentPackageSkillByFile.get(resolve(filePath))
       const selectedPackagePrompt = mergePromptContents(resourceRegistry?.systemPrompts
         .filter((prompt) => prompt.pluginIds.some((pluginId) => selectedPluginIds.has(pluginId)))
         .map((prompt) => prompt.content) ?? [])
@@ -1938,12 +1959,7 @@ export async function createWorkspaceAgentServer(
             ...(selectedPi?.extensionPaths ?? []),
           ]),
           ...(getHotReloadableResources ? { getHotReloadableResources } : {}),
-          ...(legacyGlobalPluginAgentContributions
-            ? {
-                locateSkillResource: (filePath: string) =>
-                  currentPackageResourceSnapshot?.registry.locateSkill(filePath),
-              }
-            : {}),
+          ...(agentPackageBinding ? { locateSkillResource: locateAgentPackageSkill } : {}),
         },
         extraTools: [
           ...baseExtraTools,
@@ -1959,26 +1975,20 @@ export async function createWorkspaceAgentServer(
             userId: scope.authSubjectId,
             requestId,
           }) ?? []
-          const packageBinding = currentPackageResourceSnapshot?.binding
           return [
             ...callerBindings,
-            ...(legacyGlobalPluginAgentContributions && packageBinding ? [packageBinding] : []),
+            ...(agentPackageBinding ? [agentPackageBinding] : []),
           ]
         },
         getSkillResourceSnapshot: async () => {
           const skillRegistry = currentPackageResourceSnapshot?.registry
           if (!skillRegistry) return undefined
-          // Package skill locators point at paths served through the
-          // `agent_resources` filesystem binding. That binding is only
-          // granted when `legacyGlobalPluginAgentContributions` is true
-          // (see `packageBinding` gating in getFilesystemBindings above) —
-          // an explicit fleet (`opts.agents` set) never receives it. Advertise
-          // locateSkill only when the binding it points at actually exists,
-          // otherwise callers resolve a locator whose `/files` fetch 404s.
+          // Snapshot and binding are derived from the same selected package
+          // skills, so one Agent can never receive another Agent's locator.
           return {
             generation: skillRegistry.generation,
-            managedSkills: legacyGlobalPluginAgentContributions ? skillRegistry.managedSkills : [],
-            locateSkill: legacyGlobalPluginAgentContributions ? skillRegistry.locateSkill : () => undefined,
+            managedSkills: agentManagedPackageSkills,
+            locateSkill: agentPackageBinding ? locateAgentPackageSkill : () => undefined,
           }
         },
         ...(intent.operation === "reload"

--- a/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
+++ b/packages/workspace/src/app/server/createWorkspaceAgentServer.ts
@@ -1938,6 +1938,12 @@ export async function createWorkspaceAgentServer(
             ...(selectedPi?.extensionPaths ?? []),
           ]),
           ...(getHotReloadableResources ? { getHotReloadableResources } : {}),
+          ...(legacyGlobalPluginAgentContributions
+            ? {
+                locateSkillResource: (filePath: string) =>
+                  currentPackageResourceSnapshot?.registry.locateSkill(filePath),
+              }
+            : {}),
         },
         extraTools: [
           ...baseExtraTools,


### PR DESCRIPTION
Closes #1262.

## Problem

Pi must retain physical `Skill.filePath` values to load package skills and support explicit `/skill` invocation. However, those same paths leaked into the model-visible `<available_skills>` prompt. The guarded filesystem tools correctly rejected them as outside the workspace, even though Boring had already mounted the skills through agent-scoped `agent_resources` bindings.

## Fix

- retain physical skill paths inside Pi;
- project only model-visible `<location>` values through the package resource registry;
- advertise structural JSON `{ filesystem, path }` locators;
- tell the model to preserve the locator filesystem when resolving relative references;
- leave workspace skills and agents without a corresponding resource binding unchanged;
- use a live registry closure so package-resource reloads update the next turn.

The stable `agent_resources` name is session-local. Its binding instance remains scoped by the current workspace/agent composition; package skills do not manufacture agent-specific filesystem IDs.

## Validation

- Agent typecheck
- Agent focused suite: 58 passed
- Workspace typecheck
- Workspace focused suite: 58 passed
- Agent and Workspace production builds
- Real Healio `0.1.97` Infomaniak Kimi smoke:
  1. natural-language prompt: `What was Healio's target coverage in April?`
  2. read `healio-reporting` via `agent_resources`
  3. read its nested semantic model via `agent_resources`
  4. read upstream `bsl-querying` via `agent_resources`
  5. successful BSL `query_data`
  6. answer: 81.7% (98 / 120 cells)

The full Agent package run had two unrelated existing environment-sensitive failures: one timeout in the insufficient-credit replay test and one fleet-repository path expectation caused by the worktree path. 2,039 tests passed; the focused changed suite is green.
